### PR TITLE
Add AGENTS guide for GPT workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md – GPT Workflow Guide
+
+## Overview
+- This repository contains the Exocortex Obsidian plugin. Treat it as a production-grade TypeScript/React codebase with strict quality expectations.
+- Claude-specific slash-command automation described in `CLAUDE.md` is **not** available here. Instead, run the underlying npm scripts yourself while preserving the intent of those guardrails (structured planning, parallel quality checks, and gated releases).
+- Consult architectural background in `ARCHITECTURE.md`, domain references in `docs/`, task history in `.claude/`, and existing specs/tests before making changes.
+
+## Setup Commands
+- Install dependencies: `npm install`
+- Start the development build (esbuild bundler): `npm run dev`
+- Create a production build: `npm run build`
+
+## Development Workflow
+1. **Plan deliberately** – outline requirements, risks, and design before coding (mirrors the orchestrated agent flow in `CLAUDE.md`).
+2. **Work incrementally** – keep changes focused and align with existing architecture and result-pattern usage.
+3. **Document decisions** – update relevant markdown docs when behavior or conventions change.
+
+## Code Style & Quality
+- Use TypeScript with existing lint/format rules (`npm run lint`, `npm run format:check`).
+- Follow the established project conventions (e.g., double quotes, semicolons, React functional components).
+- Prefer explicit error handling and graceful fallbacks consistent with the patterns documented in `CLAUDE.md` (result objects, safe degradation).
+
+## Testing Requirements
+- Run targeted checks that mirror the `/test` command pipeline:
+  - Unit tests: `npm run test:unit`
+  - UI tests: `npm run test:ui`
+  - Component tests: `npm run test:component`
+- When time permits or before significant merges, execute the full suite: `npm run test`.
+- Validate behavior-driven coverage as expected by the CLAUDE workflow: `npm run bdd:check` (or `npm run bdd:coverage` / `npm run bdd:report` for diagnostics).
+- Investigate and resolve all failures; prevent Playwright hangs by keeping runs scoped when possible.
+
+## Release Guidance
+- Do **not** bump versions or craft releases manually. Coordinate with maintainers for release automation that mirrors the `/release` command.
+- Ensure changelog updates and release activities happen through the sanctioned process once available.
+
+## Additional Resources
+- Specialized agent guides in `.claude/agents/` explain domain patterns (QA, architecture, security, performance, etc.). Use them for context even without direct agent orchestration.
+- Review `tests/`, `specs/`, and existing components for examples before introducing new patterns.
+- Record troubleshooting insights and follow-up tasks so they can inform future automation improvements.


### PR DESCRIPTION
## Summary
- add a repository-level AGENTS.md describing how GPT-based agents should work with the project
- translate the Claude slash-command expectations into actionable npm scripts for setup, testing, and release coordination

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ee7ed30298832e94a95f25ebe859eb