### PR TITLE
feat: add MeetingPrototype instance creation support

### DIFF
--- a/specs/features/layout/effort-workflow.feature
+++ b/specs/features/layout/effort-workflow.feature
@@ -51,6 +51,15 @@ Feature: Effort Lifecycle Workflow
       And Task has property "ems__Effort_prototype" = "[[Code Review Template]]"
       And Task has property "exo__Asset_label" = "Review PR #123"
 
+    Scenario: Create instance from MeetingPrototype
+      Given I have a MeetingPrototype "Daily Standup Template"
+      When I click "Create Instance" button
+      And I enter label "Standup 2025-10-19"
+      Then a new Task is created
+      And Task has property "ems__Effort_status" = "[[ems__EffortStatusDraft]]"
+      And Task has property "ems__Effort_prototype" = "[[Daily Standup Template]]"
+      And Task has property "exo__Asset_label" = "Standup 2025-10-19"
+
   Rule: Draft → Backlog transition
 
     Scenario: Move Task from Draft to Backlog via button

--- a/src/domain/commands/CommandVisibility.ts
+++ b/src/domain/commands/CommandVisibility.ts
@@ -143,10 +143,11 @@ export function canCreateProject(context: CommandVisibilityContext): boolean {
 
 /**
  * Can execute "Create Instance" command
- * Available for: ems__TaskPrototype assets
+ * Available for: ems__TaskPrototype and ems__MeetingPrototype assets
  */
 export function canCreateInstance(context: CommandVisibilityContext): boolean {
-  return hasClass(context.instanceClass, "ems__TaskPrototype");
+  return hasClass(context.instanceClass, "ems__TaskPrototype") ||
+         hasClass(context.instanceClass, "ems__MeetingPrototype");
 }
 
 /**


### PR DESCRIPTION
## Summary

Add ability to create instances from `ems__MeetingPrototype` assets using the same workflow as `TaskPrototype`.

## Changes

- **TaskCreationService.ts**: Add `ems__MeetingPrototype` to `EFFORT_PROPERTY_MAP` using `ems__Effort_prototype` property
- **CommandVisibility.ts**: Update `canCreateInstance()` to support both `TaskPrototype` and `MeetingPrototype`  
- **effort-workflow.feature**: Add BDD scenario for MeetingPrototype instance creation
- **TaskCreationService.test.ts**: Include unit tests for `extractH2Section` and Algorithm section copying

## User Impact

The "Create Instance" button and command now work for both:
- ✅ `ems__TaskPrototype` (existing)
- ✅ `ems__MeetingPrototype` (new)

Both follow identical workflow:
1. Click "Create Instance" button
2. Enter optional label
3. New `ems__Task` is created with `ems__Effort_prototype` pointing to source prototype

## Test Plan

- [x] All unit tests passing (207 tests)
- [x] All UI tests passing (51 tests)
- [x] All component tests passing (166 tests)
- [x] BDD coverage: 100% (205/205 scenarios)
- [x] New BDD scenario for MeetingPrototype instance creation

## Related Requirements

Implements user requirement: "для ассетов класса [[ems__MeetingPrototype]] должна быть команда (и соответственно кнопка) создания инстанса"