### PR TITLE
fix: disable Playwright HTML reporter auto-open to prevent hang

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:ui": "jest --config jest.ui.config.js",
     "test:component": "playwright test -c playwright-ct.config.ts",
     "test:component:ui": "playwright test -c playwright-ct.config.ts --ui",
+    "test:component:report": "playwright show-report playwright-report-ct",
     "test:e2e": "playwright test -c playwright-e2e.config.ts",
     "test:e2e:local": "./scripts/test-e2e-local.sh",
     "test:e2e:docker": "docker build --platform linux/amd64 -f Dockerfile.e2e -t exocortex-e2e . && docker run --rm exocortex-e2e",

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
 
   // Reporter configuration
   reporter: [
-    ['html', { outputFolder: 'playwright-report-ct' }],
+    ['html', { outputFolder: 'playwright-report-ct', open: 'never' }],
     ['list'],
     ...(process.env.CI ? [['github'] as ['github']] : []),
   ],


### PR DESCRIPTION
## Summary

Fixes the issue where component tests hang indefinitely after completion, requiring manual Ctrl+C to exit. This was caused by Playwright's HTML reporter automatically starting an HTTP server that waits for user interaction.

## Problem

**Before this fix:**
```bash
npm run test:component
# ... tests complete ...
166 passed (25.1s)

Serving HTML report at http://localhost:9323. Press Ctrl+C to quit.
← HANGS HERE FOREVER ⏸️
```

**Impact:**
- `/test` command requires workaround with `timeout 120 ... | head -200`
- CI/CD pipelines waste time waiting for timeout
- Automated testing workflows get stuck
- User has to manually interrupt process

## Root Cause

**playwright-ct.config.ts:24-28:**
```typescript
reporter: [
  ['html', { outputFolder: 'playwright-report-ct' }],  // ← Auto-starts HTTP server!
  ['list'],
],
```

By default, Playwright's HTML reporter:
1. Generates HTML report after tests ✅
2. Automatically starts HTTP server on localhost:9323 ✅
3. Waits indefinitely for user to press Ctrl+C ❌

## Solution

### 1. Disable Auto-Open (playwright-ct.config.ts)
```typescript
reporter: [
  ['html', { outputFolder: 'playwright-report-ct', open: 'never' }],  // ← Add this!
  ['list'],
],
```

**Behavior change:**
- HTML report still generated ✅
- Tests exit cleanly after completion ✅
- No more "Press Ctrl+C" message ✅

### 2. Add Manual Report Command (package.json)
```json
"test:component:report": "playwright show-report playwright-report-ct"
```

**Usage:**
```bash
npm run test:component          # Run tests, auto-exit
npm run test:component:report   # View HTML report manually
npm run test:component:ui       # Interactive debugging (already existed)
```

## Testing

**Verified:**
- ✅ 166 component tests pass and exit cleanly (25.1s)
- ✅ No "Press Ctrl+C to quit" message in output
- ✅ HTML report still generated in `playwright-report-ct/`
- ✅ Manual report viewing works: `npm run test:component:report`
- ✅ All tests pass in pre-commit hook

**Output after fix:**
```bash
npm run test:component
# ... tests run ...
166 passed (25.1s)

To open last HTML report run:
  npx playwright show-report playwright-report-ct

← EXITS IMMEDIATELY ✅
```

## Benefits

1. **CI/CD Performance**: No more 120s timeout waste
2. **Developer Experience**: Tests exit cleanly, no manual interruption
3. **Automation**: `/test` command can remove timeout workaround
4. **Flexibility**: HTML report still available via dedicated command

## Files Changed

- `playwright-ct.config.ts` - Added `open: 'never'` to HTML reporter
- `package.json` - Added `test:component:report` command

## Breaking Changes

None - HTML report generation still works, only auto-open behavior changed.

## Related Issues

This fixes the issue described in user question: "Ты часто зависаешь на прогоне тестов и в консоли висит Press Ctrl + C - почему так?"