### PR TITLE
perf: optimize e2e-tests job execution time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,25 +81,29 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Upload built plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-build
+          path: |
+            main.js
+            manifest.json
+          retention-days: 1
+
   e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: build-and-test
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download built plugin
+        uses: actions/download-artifact@v4
         with:
-          node-version: "18"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build plugin
-        run: npm run build
+          name: plugin-build
+          path: .
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -56,13 +56,12 @@ FROM dependencies AS app
 COPY docker-entrypoint-e2e.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
-# Copy source code
-COPY . .
+# Copy only necessary files (built plugin passed from CI, not built inside Docker)
+COPY main.js manifest.json ./
+COPY tests/e2e/ ./tests/e2e/
+COPY playwright-e2e.config.ts ./
 
-# Build plugin
-RUN npm run build
-
-# Create test vault and install plugin
+# Create test vault and install pre-built plugin
 RUN mkdir -p tests/e2e/test-vault/.obsidian/plugins/exocortex \
     && cp main.js manifest.json tests/e2e/test-vault/.obsidian/plugins/exocortex/ \
     && echo "=== Verifying .obsidian config files ===" \


### PR DESCRIPTION
## Summary

Optimizes the GitHub Actions e2e-tests job to reduce execution time by 50-100 seconds through artifact reuse and Docker build optimization.

## Problem

The current CI pipeline has significant redundancy:
1. `build-and-test` job: npm ci → build → test
2. `e2e-tests` job: npm ci (again) → build (again) → Docker build (with another build inside)

This redundancy adds 1-2 minutes of wasted time on every CI run.

## Solution

### 1. Artifact Sharing Between Jobs
- `build-and-test` now uploads `main.js` and `manifest.json` as artifacts
- `e2e-tests` downloads these artifacts instead of rebuilding
- **Time saved**: ~40-80 seconds (npm ci + build)

### 2. Job Dependency
- Added `needs: build-and-test` to e2e-tests
- Prevents wasted e2e runs when build fails
- Ensures artifacts are available

### 3. Optimized Docker Build
- Removed `npm run build` from Dockerfile (redundant)
- Copy only necessary files: tests/e2e/, playwright-e2e.config.ts, pre-built plugin
- Reduced Docker context size
- **Time saved**: ~10-20 seconds

## Changes

### `.github/workflows/ci.yml`
- Added `Upload built plugin` step to build-and-test job
- Added `needs: build-and-test` dependency to e2e-tests job
- Replaced npm setup/install/build steps with artifact download
- Removed redundant Node.js setup from e2e-tests

### `Dockerfile.e2e`
- Changed from `COPY . .` to selective copying
- Removed `RUN npm run build` step
- Updated comments to reflect artifact-based approach
- Plugin now expected as pre-built input

## Expected Impact

**Before**: 
- build-and-test: ~2-3 min
- e2e-tests: ~5-7 min
- **Total**: ~7-10 min

**After**:
- build-and-test: ~2-3 min
- e2e-tests: ~3-5 min (50-100s faster)
- **Total**: ~5-8 min

## Testing

CI pipeline will validate:
- ✅ Build artifacts upload/download correctly
- ✅ Docker build succeeds with pre-built plugin
- ✅ E2E tests pass with artifact-based workflow
- ✅ All quality gates maintained

## Checklist

- [x] Changes follow CLAUDE.md guidelines (RULE 0: worktree isolation)
- [x] Commit message follows conventional commits (perf:)
- [x] No breaking changes to CI/CD behavior
- [x] Optimization maintains test quality
- [x] Both jobs still enforce quality gates