### PR TITLE
docs: add explicit task completion criteria after PR creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,18 @@ git pull origin main
 
 **NEVER push directly to main.** All changes MUST go through Pull Requests.
 
+**🚨 CRITICAL: Task is NOT complete after creating PR!**
+
+**Task is COMPLETE ONLY when:**
+1. ✅ CI pipeline passes (both checks GREEN)
+2. ✅ PR merged to main
+3. ✅ Auto-release workflow completes successfully
+
+**DO NOT stop after `gh pr create`** - you MUST monitor and wait for:
+- CI checks to pass (watch with `gh pr checks --watch`)
+- PR to be merged (use `gh pr merge --auto --rebase`)
+- Release to be created (verify with `gh release list --limit 1`)
+
 **Complete workflow (11 steps):**
 
 ```bash


### PR DESCRIPTION
## Summary

Added explicit warning in CLAUDE.md that task completion doesn't end at PR creation.

## Problem

Claude instances were stopping work after creating PR, not monitoring CI pipeline, merge, and release completion.

## Solution

Added prominent 🚨 warning in RULE 1 stating:

**Task is COMPLETE ONLY when:**
1. ✅ CI pipeline passes (both checks GREEN)
2. ✅ PR merged to main
3. ✅ Auto-release workflow completes successfully

Includes specific commands for monitoring:
- `gh pr checks --watch` - Monitor CI
- `gh pr merge --auto --rebase` - Wait for merge
- `gh release list --limit 1` - Verify release

## Impact

- Prevents premature task abandonment
- Ensures full workflow completion
- Improves reliability of development process