### PR TITLE
feat: auto-generate meeting labels with source name and date

### DIFF
--- a/src/infrastructure/services/TaskCreationService.ts
+++ b/src/infrastructure/services/TaskCreationService.ts
@@ -137,6 +137,18 @@ export class TaskCreationService {
   }
 
   /**
+   * Format date as human-readable format (YYYY-MM-DD)
+   * @param date Date object
+   * @returns Formatted date string
+   */
+  private formatDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  /**
    * Generate frontmatter for new Task
    * Inherits exo__Asset_isDefinedBy from source
    * Uses provided UUID and generates timestamp
@@ -187,9 +199,18 @@ export class TaskCreationService {
     frontmatter["ems__Effort_status"] = '"[[ems__EffortStatusDraft]]"';
     frontmatter[effortProperty] = `"[[${sourceName}]]"`;
 
-    // Add label if provided and non-empty
-    if (label && label.trim() !== "") {
-      frontmatter["exo__Asset_label"] = label.trim();
+    // Auto-generate label for ems__Meeting instances if not provided
+    let finalLabel = label;
+    if (instanceClass === "ems__Meeting" && (!label || label.trim() === "")) {
+      // Use exo__Asset_label from source metadata if available, otherwise use sourceName
+      const baseLabel = sourceMetadata.exo__Asset_label || sourceName;
+      const dateStr = this.formatDate(now);
+      finalLabel = `${baseLabel} ${dateStr}`;
+    }
+
+    // Add label if provided or auto-generated
+    if (finalLabel && finalLabel.trim() !== "") {
+      frontmatter["exo__Asset_label"] = finalLabel.trim();
     }
 
     return frontmatter;

--- a/tests/unit/TaskCreationService.test.ts
+++ b/tests/unit/TaskCreationService.test.ts
@@ -328,6 +328,70 @@ describe("TaskCreationService", () => {
       expect(frontmatter.exo__Asset_label).toBe("Standup 2025-10-19");
       expect(frontmatter.ems__Effort_status).toBe('"[[ems__EffortStatusDraft]]"');
     });
+
+    it("should auto-generate label from exo__Asset_label + date for ems__Meeting when no label provided", () => {
+      const sourceMetadata = {
+        exo__Asset_isDefinedBy: '"[[!toos]]"',
+        exo__Asset_label: "Weekly Team Sync",
+      };
+
+      const frontmatter = service.generateTaskFrontmatter(
+        sourceMetadata,
+        "Team Meeting Template",
+        "ems__MeetingPrototype",
+      );
+
+      expect(frontmatter.exo__Instance_class).toEqual(['"[[ems__Meeting]]"']);
+      expect(frontmatter.exo__Asset_label).toMatch(/^Weekly Team Sync \d{4}-\d{2}-\d{2}$/);
+    });
+
+    it("should auto-generate label from sourceName + date for ems__Meeting when no label and no exo__Asset_label", () => {
+      const sourceMetadata = {
+        exo__Asset_isDefinedBy: '"[[!toos]]"',
+      };
+
+      const frontmatter = service.generateTaskFrontmatter(
+        sourceMetadata,
+        "Sprint Planning Template",
+        "ems__MeetingPrototype",
+      );
+
+      expect(frontmatter.exo__Instance_class).toEqual(['"[[ems__Meeting]]"']);
+      expect(frontmatter.exo__Asset_label).toMatch(/^Sprint Planning Template \d{4}-\d{2}-\d{2}$/);
+    });
+
+    it("should prefer explicit label over auto-generated one for ems__Meeting", () => {
+      const sourceMetadata = {
+        exo__Asset_isDefinedBy: '"[[!toos]]"',
+        exo__Asset_label: "Weekly Team Sync",
+      };
+
+      const frontmatter = service.generateTaskFrontmatter(
+        sourceMetadata,
+        "Team Meeting Template",
+        "ems__MeetingPrototype",
+        "Custom Meeting Label",
+      );
+
+      expect(frontmatter.exo__Instance_class).toEqual(['"[[ems__Meeting]]"']);
+      expect(frontmatter.exo__Asset_label).toBe("Custom Meeting Label");
+    });
+
+    it("should not auto-generate label for ems__Task instances", () => {
+      const sourceMetadata = {
+        exo__Asset_isDefinedBy: '"[[!toos]]"',
+        exo__Asset_label: "Sales Area",
+      };
+
+      const frontmatter = service.generateTaskFrontmatter(
+        sourceMetadata,
+        "Sales Offering",
+        "ems__Area",
+      );
+
+      expect(frontmatter.exo__Instance_class).toEqual(['"[[ems__Task]]"']);
+      expect(frontmatter.exo__Asset_label).toBeUndefined();
+    });
   });
 
   describe("buildFileContent", () => {


### PR DESCRIPTION
## Summary

Auto-populate `exo__Asset_label` for `ems__Meeting` instances when creating from `ems__MeetingPrototype`:
- Uses `exo__Asset_label` from source metadata if available
- Falls back to source filename if no label exists
- Appends current date in YYYY-MM-DD format
- Respects explicit labels when provided

## Example

When creating a meeting from a prototype with label "Weekly Standup":
```yaml
exo__Asset_label: Weekly Standup 2025-10-21
```

When creating from a prototype without label (filename: "Team Meeting Template"):
```yaml
exo__Asset_label: Team Meeting Template 2025-10-21
```

## Test Plan

Added 4 comprehensive unit tests:
- ✅ Auto-generation from source label + date
- ✅ Auto-generation from filename + date  
- ✅ Explicit label override behavior
- ✅ No auto-generation for non-Meeting instances

All 220 unit + 52 UI + 167 component tests pass.

## Implementation Details

- Added `formatDate()` helper method in `TaskCreationService.ts:144-149`
- Modified `generateTaskFrontmatter()` to auto-generate labels for `ems__Meeting` instances (lines 202-209)
- Maintains backward compatibility - explicit labels still override auto-generation