### PR TITLE
feat: enable child project creation from parent projects

### DIFF
--- a/src/domain/commands/CommandVisibility.ts
+++ b/src/domain/commands/CommandVisibility.ts
@@ -135,10 +135,12 @@ export function canCreateTask(context: CommandVisibilityContext): boolean {
 
 /**
  * Can execute "Create Project" command
- * Available for: ems__Area and ems__Initiative assets
+ * Available for: ems__Area, ems__Initiative, and ems__Project assets
  */
 export function canCreateProject(context: CommandVisibilityContext): boolean {
-  return hasClass(context.instanceClass, "ems__Area") || hasClass(context.instanceClass, "ems__Initiative");
+  return hasClass(context.instanceClass, "ems__Area") ||
+         hasClass(context.instanceClass, "ems__Initiative") ||
+         hasClass(context.instanceClass, "ems__Project");
 }
 
 /**

--- a/src/infrastructure/services/ProjectCreationService.ts
+++ b/src/infrastructure/services/ProjectCreationService.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 const EFFORT_PROPERTY_MAP: Record<string, string> = {
   ems__Area: "ems__Effort_area",
   ems__Initiative: "ems__Effort_parent",
+  ems__Project: "ems__Effort_parent",
 };
 
 export class ProjectCreationService {

--- a/tests/unit/CommandVisibility.test.ts
+++ b/tests/unit/CommandVisibility.test.ts
@@ -152,7 +152,7 @@ describe("CommandVisibility", () => {
       expect(canCreateProject(context)).toBe(false);
     });
 
-    it("should return false for ems__Project", () => {
+    it("should return true for ems__Project", () => {
       const context: CommandVisibilityContext = {
         instanceClass: "[[ems__Project]]",
         currentStatus: null,
@@ -161,7 +161,19 @@ describe("CommandVisibility", () => {
         currentFolder: "",
         expectedFolder: null,
       };
-      expect(canCreateProject(context)).toBe(false);
+      expect(canCreateProject(context)).toBe(true);
+    });
+
+    it("should return true for Project without brackets", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "ems__Project",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateProject(context)).toBe(true);
     });
 
     it("should return false when instanceClass is null", () => {

--- a/tests/unit/ProjectCreationService.test.ts
+++ b/tests/unit/ProjectCreationService.test.ts
@@ -48,6 +48,24 @@ describe("ProjectCreationService", () => {
       expect(frontmatter.exo__Asset_createdAt).toBeDefined();
     });
 
+    it("should generate frontmatter with ems__Effort_parent for Project", () => {
+      const sourceMetadata = {
+        exo__Asset_isDefinedBy: '"[[Ontology/EMS]]"',
+      };
+
+      const frontmatter = service.generateProjectFrontmatter(
+        sourceMetadata,
+        "Parent Project",
+        "ems__Project",
+      );
+
+      expect(frontmatter.exo__Instance_class).toEqual(['"[[ems__Project]]"']);
+      expect(frontmatter.exo__Asset_isDefinedBy).toBe('"[[Ontology/EMS]]"');
+      expect(frontmatter.ems__Effort_parent).toBe('"[[Parent Project]]"');
+      expect(frontmatter.exo__Asset_uid).toBeDefined();
+      expect(frontmatter.exo__Asset_createdAt).toBeDefined();
+    });
+
     it("should use provided UUID for exo__Asset_uid", () => {
       const testUid = "12345678-1234-4123-8123-123456789abc";
       const frontmatter = service.generateProjectFrontmatter(


### PR DESCRIPTION
## Summary

Enable creating child projects from existing ems__Project instances. Child projects are linked to parent through the `ems__Effort_parent` property.

## Changes

1. **CommandVisibility.ts**
   - Updated `canCreateProject()` to include `ems__Project` (in addition to `ems__Area` and `ems__Initiative`)
   - This makes the "Create Project" button visible in the Layout when viewing a Project

2. **ProjectCreationService.ts**
   - Added `ems__Project` → `ems__Effort_parent` mapping in `EFFORT_PROPERTY_MAP`
   - When creating a child project from a parent project, the parent reference is stored in `ems__Effort_parent`

3. **Tests**
   - Updated `CommandVisibility.test.ts`: Changed test to expect TRUE for `ems__Project` and added test for Project without brackets
   - Added new test in `ProjectCreationService.test.ts` to verify `ems__Effort_parent` property is correctly set

## Test Results

✅ All unit tests pass (269 tests)
✅ All UI tests pass (52 tests)
✅ All component tests pass (183 tests)
✅ BDD coverage: 100%

## Use Case

This enables hierarchical project structures:

```
Initiative
├── Project A (parent)
│   ├── Project A.1 (child) → ems__Effort_parent: "Project A"
│   └── Project A.2 (child) → ems__Effort_parent: "Project A"
└── Project B (parent)
    └── Project B.1 (child) → ems__Effort_parent: "Project B"
```

Users can now:
- Open any Project asset
- See the "Create Project" button in the Layout
- Create a child project that references the parent via `ems__Effort_parent`