### PR TITLE
feat: auto-fill meeting label with prototype name and current date

### DIFF
--- a/src/presentation/modals/LabelInputModal.ts
+++ b/src/presentation/modals/LabelInputModal.ts
@@ -9,9 +9,10 @@ export class LabelInputModal extends Modal {
   private onSubmit: (label: string | null) => void;
   private inputEl: HTMLInputElement | null = null;
 
-  constructor(app: App, onSubmit: (label: string | null) => void) {
+  constructor(app: App, onSubmit: (label: string | null) => void, defaultValue: string = "") {
     super(app);
     this.onSubmit = onSubmit;
+    this.label = defaultValue;
   }
 
   onOpen(): void {


### PR DESCRIPTION
## Summary

Implements auto-filling of meeting instance labels when creating instances from `ems__MeetingPrototype`.

**User Experience:**
- When clicking "Create Instance" on a meeting prototype, the label input modal now pre-fills with: `{prototype label or filename} {YYYY-MM-DD}`
- User can edit or clear the suggested value before creating the instance
- Example: Creating instance from "Weekly Standup" prototype on 2025-10-22 shows "Weekly Standup 2025-10-22"

## Changes

### Core Implementation
- **LabelInputModal**: Added optional `defaultValue` parameter to constructor
- **UniversalLayoutRenderer**: 
  - Added `formatDate()` helper (YYYY-MM-DD format)
  - Added `generateDefaultMeetingLabel()` to combine prototype label + date
  - Updated Create Instance button to check for `ems__MeetingPrototype` and pass default value

### Behavior
- Only applies to `ems__MeetingPrototype` instances
- Falls back to filename if `exo__Asset_label` is missing from prototype
- Other prototype types (Task, Project) remain unchanged (empty input field)

## Test Plan

- [x] Build successful
- [x] All unit tests passing (260 passed)
- [x] All UI tests passing (52 passed)
- [x] All component tests passing (183 passed)
- [ ] Manual test: Create meeting instance from prototype with label
- [ ] Manual test: Create meeting instance from prototype without label (uses filename)
- [ ] Manual test: Verify other prototype types unaffected

## Related

Addresses user requirement for better UX when creating meeting instances - eliminates manual date entry and ensures consistent naming format.