### PR TITLE
revert: restore Properties section visibility by default

### DIFF
--- a/src/domain/settings/ExocortexSettings.ts
+++ b/src/domain/settings/ExocortexSettings.ts
@@ -5,7 +5,7 @@ export interface ExocortexSettings {
 }
 
 export const DEFAULT_SETTINGS: ExocortexSettings = {
-  showPropertiesSection: false,
+  showPropertiesSection: true,
   layoutVisible: true,
   showArchivedAssets: false,
 };


### PR DESCRIPTION
## Summary

Restores `showPropertiesSection: true` as default setting based on user feedback.

## Rationale

Both Properties sections serve different purposes:
1. **Native Obsidian Properties** (top) - Can be collapsed by user
2. **Plugin Properties section** (bottom) - Can be hidden via layout toggle command

Having both visible by default gives users maximum control:
- Users can collapse native Obsidian properties if desired
- Users can hide plugin layout (including Properties) with toggle command
- No duplication issue - both have distinct UX affordances

## Changes

- `ExocortexSettings.ts`: Changed `showPropertiesSection: true` (line 8)

## Breaking Changes

None - This reverts to the previous default behavior before v12.30.2