### PR TITLE
feat: duplicate exo__Asset_label to aliases field

### DIFF
--- a/src/infrastructure/services/AreaCreationService.ts
+++ b/src/infrastructure/services/AreaCreationService.ts
@@ -66,7 +66,9 @@ export class AreaCreationService {
     frontmatter["ems__Area_parent"] = `"[[${sourceName}]]"`;
 
     if (label && label.trim() !== "") {
-      frontmatter["exo__Asset_label"] = label.trim();
+      const trimmedLabel = label.trim();
+      frontmatter["exo__Asset_label"] = trimmedLabel;
+      frontmatter["aliases"] = [trimmedLabel];
     }
 
     return frontmatter;

--- a/src/infrastructure/services/ProjectCreationService.ts
+++ b/src/infrastructure/services/ProjectCreationService.ts
@@ -85,7 +85,9 @@ export class ProjectCreationService {
     frontmatter[effortProperty] = `"[[${sourceName}]]"`;
 
     if (label && label.trim() !== "") {
-      frontmatter["exo__Asset_label"] = label.trim();
+      const trimmedLabel = label.trim();
+      frontmatter["exo__Asset_label"] = trimmedLabel;
+      frontmatter["aliases"] = [trimmedLabel];
     }
 
     return frontmatter;

--- a/src/infrastructure/services/RenameToUidService.ts
+++ b/src/infrastructure/services/RenameToUidService.ts
@@ -40,7 +40,7 @@ export class RenameToUidService {
       }
 
       const frontmatterContent = match[1];
-      const newFrontmatter = `${frontmatterContent}\nexo__Asset_label: ${label}`;
+      const newFrontmatter = `${frontmatterContent}\nexo__Asset_label: ${label}\naliases:\n  - ${label}`;
 
       return content.replace(frontmatterRegex, `---\n${newFrontmatter}\n---`);
     });

--- a/src/infrastructure/services/TaskCreationService.ts
+++ b/src/infrastructure/services/TaskCreationService.ts
@@ -210,7 +210,9 @@ export class TaskCreationService {
 
     // Add label if provided or auto-generated
     if (finalLabel && finalLabel.trim() !== "") {
-      frontmatter["exo__Asset_label"] = finalLabel.trim();
+      const trimmedLabel = finalLabel.trim();
+      frontmatter["exo__Asset_label"] = trimmedLabel;
+      frontmatter["aliases"] = [trimmedLabel];
     }
 
     return frontmatter;


### PR DESCRIPTION
## Summary

Автоматически дублирует значение `exo__Asset_label` в поле `aliases` (массив) при создании ассетов и выполнении команды "Rename to UID".

## Changes

- **TaskCreationService**: Добавляет label в aliases при создании задач
- **ProjectCreationService**: Добавляет label в aliases при создании проектов  
- **AreaCreationService**: Добавляет label в aliases при создании областей
- **RenameToUidService**: Добавляет label в aliases при переименовании в UID

## Benefits

- Интеграция с встроенной функциональностью aliases в Obsidian
- Улучшенный поиск и навигация по ассетам через алиасы
- Консистентность между label и aliases

## Test Plan

- ✅ All unit tests pass (290 tests)
- ✅ All UI tests pass (55 tests)
- ✅ All component tests pass (183 tests)
- ✅ Total: 528 tests passing

CI will run E2E tests in Docker.