### PR TITLE
fix: add styles.css to GitHub Release files list

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -209,6 +209,7 @@ jobs:
           files: |
             main.js
             manifest.json
+            styles.css
             ${{ github.event.repository.name }}.zip
           body_path: release_notes.md
           draft: false


### PR DESCRIPTION
## Summary

Fixed missing styles.css file in GitHub Releases by adding it to the files list in auto-release.yml workflow.

## Changes

- Added styles.css to the files list in `.github/workflows/auto-release.yml` (line 212)
- Now GitHub Releases will include all three required files: main.js, manifest.json, and styles.css

## Issue

Previously, styles.css was being included in the .zip archive but was not being uploaded as a separate file in GitHub Releases, which is required for proper Obsidian plugin installation.

## Testing

This change only affects the GitHub Actions workflow configuration. No functional code changes, so no additional tests required. The workflow will be validated when CI runs.