### PR TITLE
feat: separate daily tasks and projects into two tables

### DIFF
--- a/src/presentation/components/DailyProjectsTable.tsx
+++ b/src/presentation/components/DailyProjectsTable.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+
+export interface DailyProject {
+  file: {
+    path: string;
+    basename: string;
+  };
+  path: string;
+  title: string;
+  label: string;
+  startTime: string;
+  endTime: string;
+  status: string;
+  metadata: Record<string, unknown>;
+  isDone: boolean;
+  isTrashed: boolean;
+}
+
+export interface DailyProjectsTableProps {
+  projects: DailyProject[];
+  onProjectClick?: (path: string, event: React.MouseEvent) => void;
+  getAssetLabel?: (path: string) => string | null;
+}
+
+export const DailyProjectsTable: React.FC<DailyProjectsTableProps> = ({
+  projects,
+  onProjectClick,
+  getAssetLabel,
+}) => {
+  interface WikiLink {
+    target: string;
+    alias?: string;
+  }
+
+  const parseWikiLink = (value: string): WikiLink => {
+    const content = value.replace(/^\[\[|\]\]$/g, "");
+
+    const pipeIndex = content.indexOf("|");
+
+    if (pipeIndex !== -1) {
+      return {
+        target: content.substring(0, pipeIndex).trim(),
+        alias: content.substring(pipeIndex + 1).trim()
+      };
+    }
+
+    return {
+      target: content.trim()
+    };
+  };
+
+  const getDisplayName = (project: DailyProject): string => {
+    const icon = project.isDone ? "✅ " : project.isTrashed ? "❌ " : "📦 ";
+
+    let displayText = project.label || project.title;
+
+    if (typeof getAssetLabel === 'function') {
+      const customLabel = getAssetLabel(project.path);
+      if (customLabel !== null && customLabel !== undefined && customLabel !== '') {
+        displayText = customLabel;
+      }
+    }
+
+    return icon + displayText;
+  };
+
+  return (
+    <div className="exocortex-daily-projects">
+      <table className="exocortex-projects-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Start</th>
+            <th>End</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {projects.map((project, index) => (
+            <tr key={`${project.path}-${index}`} data-path={project.path}>
+              <td className="project-name">
+                <a
+                  data-href={project.path}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onProjectClick?.(project.path, e);
+                  }}
+                  className="internal-link"
+                  style={{ cursor: "pointer" }}
+                >
+                  {getDisplayName(project)}
+                </a>
+              </td>
+              <td className="project-start">{project.startTime || "-"}</td>
+              <td className="project-end">{project.endTime || "-"}</td>
+              <td className="project-status">
+                {project.status ? (() => {
+                  const isWikiLink = typeof project.status === "string" && /\[\[.*?\]\]/.test(project.status);
+                  const parsed = isWikiLink ? parseWikiLink(project.status) : { target: project.status };
+                  const displayText = parsed.alias || parsed.target;
+
+                  return (
+                    <a
+                      data-href={parsed.target}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onProjectClick?.(parsed.target, e);
+                      }}
+                      className="internal-link"
+                      style={{ cursor: "pointer" }}
+                    >
+                      {displayText}
+                    </a>
+                  );
+                })() : "-"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Разделил таблицу задач и проектов в Layout для класса `pn__DailyNote` на две отдельные таблицы:

- **Таблица задач (Tasks)** - отображает только ассеты класса `ems__Task`
- **Таблица проектов (Projects)** - отображает только ассеты класса `ems__Project`

Обе таблицы фильтруются по значению `ems__Effort_day`, равному `pn__DailyNote_day`.

## Changes

### New Component
- **DailyProjectsTable.tsx** - React компонент для отображения проектов
  - Аналогичен DailyTasksTable, но без поля `isMeeting`
  - Иконка 📦 для активных проектов (вместо стандартной иконки)
  - Те же колонки: Name, Start, End, Status

### Updated Files
- **UniversalLayoutRenderer.ts**
  - Добавлен импорт `DailyProjectsTable` и `DailyProject`
  - Обновлен `getDailyTasks()` - теперь фильтрует только задачи (исключает `ems__Project`)
  - Добавлен `getDailyProjects()` - фильтрует только проекты (включает только `ems__Project`)
  - Добавлен `renderDailyProjects()` - рендерит таблицу проектов
  - Обновлен `render()` - вызывает оба метода: `renderDailyTasks()` → `renderDailyProjects()`

### Layout Order
1. Action Buttons
2. Properties Table (если включено)
3. **Tasks Table** (новое: только задачи)
4. **Projects Table** (новое: только проекты)
5. Relations Table

## Benefits

✅ Улучшена читаемость - задачи и проекты больше не смешаны  
✅ Визуальное разделение - отдельные заголовки "Tasks" и "Projects"  
✅ Удобная навигация - пользователь сразу видит, где задачи, а где проекты  
✅ Консистентность - обе таблицы используют одинаковую логику сортировки и отображения

## Test Plan

- [x] Unit tests pass (290/290)
- [x] UI tests pass (55/55)  
- [x] Component tests pass (183/183)
- [ ] E2E tests pass (will run in CI)
- [x] Build succeeds
- [x] TypeScript compilation clean

## Screenshots

Будут добавлены после ручного тестирования в Obsidian.