### PR TITLE
test: add validation for styles.css in release workflow

### DIFF
--- a/tests/unit/release-workflow.test.ts
+++ b/tests/unit/release-workflow.test.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Release Workflow Validation', () => {
+  const projectRoot = path.join(__dirname, '../..');
+  const workflowPath = path.join(projectRoot, '.github/workflows/auto-release.yml');
+  const stylesPath = path.join(projectRoot, 'styles.css');
+
+  describe('styles.css in GitHub Releases', () => {
+    it('should include styles.css in auto-release.yml files list', () => {
+      expect(fs.existsSync(workflowPath)).toBe(true);
+
+      const workflowContent = fs.readFileSync(workflowPath, 'utf-8');
+
+      const releaseStepMatch = workflowContent.match(
+        /- name: Create GitHub Release[\s\S]*?files:\s*\|[\s\S]*?(?=\n      -|\n  [a-z]|\Z)/m
+      );
+
+      expect(releaseStepMatch).toBeTruthy();
+      expect(releaseStepMatch![0]).toContain('styles.css');
+    });
+
+    it('should have styles.css file in project root', () => {
+      expect(fs.existsSync(stylesPath)).toBe(true);
+
+      const stats = fs.statSync(stylesPath);
+      expect(stats.size).toBeGreaterThan(0);
+    });
+
+    it('should reference all required plugin files in release workflow', () => {
+      const workflowContent = fs.readFileSync(workflowPath, 'utf-8');
+
+      const requiredFiles = ['main.js', 'manifest.json', 'styles.css'];
+
+      requiredFiles.forEach(file => {
+        expect(workflowContent).toContain(file);
+      });
+    });
+  });
+
+  describe('Release package contents', () => {
+    it('should copy styles.css to release-files directory in workflow', () => {
+      const workflowContent = fs.readFileSync(workflowPath, 'utf-8');
+
+      const createPackageStepMatch = workflowContent.match(
+        /- name: Create release package[\s\S]*?run:\s*\|[\s\S]*?(?=\n      -|\Z)/m
+      );
+
+      expect(createPackageStepMatch).toBeTruthy();
+      expect(createPackageStepMatch![0]).toContain('cp styles.css release-files/');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Added automated test to prevent regression of styles.css being missing from GitHub Releases (as fixed in PR #50).

## Changes

- Created `tests/unit/release-workflow.test.ts` with 4 tests:
  1. ✅ Validates `styles.css` is listed in `auto-release.yml` files section
  2. ✅ Validates `styles.css` exists in project root  
  3. ✅ Validates all required files (main.js, manifest.json, styles.css) are referenced
  4. ✅ Validates `styles.css` is copied to release-files directory in workflow

## Testing

All tests passed (294 unit tests):
- ✅ Unit tests: 294 passed
- ✅ UI tests: 55 passed
- ✅ Component tests: 184 passed

## Prevents Regression

This test ensures BRAT installations will always receive styles.css in future releases. If anyone removes styles.css from the workflow, CI will fail immediately.