### PR TITLE
test: add E2E tests for daily tasks and projects separation

### DIFF
--- a/tests/e2e/specs/daily-tasks-and-projects-separation.spec.ts
+++ b/tests/e2e/specs/daily-tasks-and-projects-separation.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test';
+import { ObsidianLauncher } from '../utils/obsidian-launcher';
+import * as path from 'path';
+
+test.describe('DailyNote Tasks and Projects Separation', () => {
+  let launcher: ObsidianLauncher;
+
+  test.beforeEach(async () => {
+    const vaultPath = path.join(__dirname, '../test-vault');
+    launcher = new ObsidianLauncher(vaultPath);
+    await launcher.launch();
+  });
+
+  test.afterEach(async () => {
+    await launcher.close();
+  });
+
+  test('should display separate tables for tasks and projects', async () => {
+    await launcher.openFile('Daily Notes/2025-10-16.md');
+
+    const window = await launcher.getWindow();
+
+    await launcher.waitForModalsToClose(10000);
+
+    await launcher.waitForElement('.exocortex-daily-tasks-section', 60000);
+    await launcher.waitForElement('.exocortex-daily-projects-section', 60000);
+
+    const tasksSection = window.locator('.exocortex-daily-tasks-section').first();
+    const projectsSection = window.locator('.exocortex-daily-projects-section').first();
+
+    await expect(tasksSection).toBeVisible({ timeout: 10000 });
+    await expect(projectsSection).toBeVisible({ timeout: 10000 });
+
+    const tasksSectionText = await tasksSection.textContent();
+    const projectsSectionText = await projectsSection.textContent();
+
+    expect(tasksSectionText).toContain('Tasks');
+    expect(projectsSectionText).toContain('Projects');
+  });
+
+  test('should display only tasks in tasks table', async () => {
+    await launcher.openFile('Daily Notes/2025-10-16.md');
+
+    const window = await launcher.getWindow();
+
+    await launcher.waitForModalsToClose(10000);
+
+    await launcher.waitForElement('.exocortex-daily-tasks-section', 60000);
+
+    const tasksTable = window.locator('.exocortex-daily-tasks-section table').first();
+    await expect(tasksTable).toBeVisible({ timeout: 10000 });
+
+    const tasksTableContent = await tasksTable.textContent();
+
+    expect(tasksTableContent).toContain('Morning standup');
+    expect(tasksTableContent).toContain('Code review');
+
+    expect(tasksTableContent).not.toContain('Website Redesign');
+    expect(tasksTableContent).not.toContain('Mobile App Development');
+  });
+
+  test('should display only projects in projects table', async () => {
+    await launcher.openFile('Daily Notes/2025-10-16.md');
+
+    const window = await launcher.getWindow();
+
+    await launcher.waitForModalsToClose(10000);
+
+    await launcher.waitForElement('.exocortex-daily-projects-section', 60000);
+
+    const projectsTable = window.locator('.exocortex-daily-projects-section table').first();
+    await expect(projectsTable).toBeVisible({ timeout: 10000 });
+
+    const projectsTableContent = await projectsTable.textContent();
+
+    expect(projectsTableContent).toContain('Website Redesign');
+    expect(projectsTableContent).toContain('Mobile App Development');
+
+    expect(projectsTableContent).not.toContain('Morning standup');
+    expect(projectsTableContent).not.toContain('Code review');
+  });
+
+  test('should display projects with correct status and timestamps', async () => {
+    await launcher.openFile('Daily Notes/2025-10-16.md');
+
+    const window = await launcher.getWindow();
+
+    await launcher.waitForModalsToClose(10000);
+
+    await launcher.waitForElement('.exocortex-daily-projects-section', 60000);
+
+    const projectsTable = window.locator('.exocortex-daily-projects-section table').first();
+    await expect(projectsTable).toBeVisible({ timeout: 10000 });
+
+    const projectsTableContent = await projectsTable.textContent();
+
+    expect(projectsTableContent).toContain('Doing');
+    expect(projectsTableContent).toContain('ToDo');
+
+    expect(projectsTableContent).toMatch(/10:00/);
+    expect(projectsTableContent).toMatch(/14:00/);
+  });
+
+  test('should display correct row counts in both tables', async () => {
+    await launcher.openFile('Daily Notes/2025-10-16.md');
+
+    const window = await launcher.getWindow();
+
+    await launcher.waitForModalsToClose(10000);
+
+    await launcher.waitForElement('.exocortex-daily-tasks-section', 60000);
+    await launcher.waitForElement('.exocortex-daily-projects-section', 60000);
+
+    const tasksTable = window.locator('.exocortex-daily-tasks-section table').first();
+    const projectsTable = window.locator('.exocortex-daily-projects-section table').first();
+
+    await expect(tasksTable).toBeVisible({ timeout: 10000 });
+    await expect(projectsTable).toBeVisible({ timeout: 10000 });
+
+    const taskRows = tasksTable.locator('tbody tr');
+    const projectRows = projectsTable.locator('tbody tr');
+
+    await expect(taskRows.first()).toBeVisible({ timeout: 5000 });
+    await expect(projectRows.first()).toBeVisible({ timeout: 5000 });
+
+    const taskRowCount = await taskRows.count();
+    const projectRowCount = await projectRows.count();
+
+    expect(taskRowCount).toBe(2);
+    expect(projectRowCount).toBe(2);
+  });
+
+  test('should display projects table after tasks table', async () => {
+    await launcher.openFile('Daily Notes/2025-10-16.md');
+
+    const window = await launcher.getWindow();
+
+    await launcher.waitForModalsToClose(10000);
+
+    await launcher.waitForElement('.exocortex-daily-tasks-section', 60000);
+    await launcher.waitForElement('.exocortex-daily-projects-section', 60000);
+
+    const tasksSection = window.locator('.exocortex-daily-tasks-section').first();
+    const projectsSection = window.locator('.exocortex-daily-projects-section').first();
+
+    const tasksSectionBox = await tasksSection.boundingBox();
+    const projectsSectionBox = await projectsSection.boundingBox();
+
+    expect(tasksSectionBox).not.toBeNull();
+    expect(projectsSectionBox).not.toBeNull();
+
+    if (tasksSectionBox && projectsSectionBox) {
+      expect(projectsSectionBox.y).toBeGreaterThan(tasksSectionBox.y);
+    }
+  });
+});

--- a/tests/e2e/test-vault/Projects/mobile-app-development.md
+++ b/tests/e2e/test-vault/Projects/mobile-app-development.md
@@ -1,0 +1,11 @@
+---
+exo__Instance_class: "[[ems__Project]]"
+exo__Asset_label: "Mobile App Development"
+exo__Asset_uid: test-project-002
+ems__Effort_status: "[[ems__EffortStatusToDo]]"
+ems__Effort_day: "[[2025-10-16]]"
+ems__Effort_plannedStartTimestamp: "2025-10-16T14:00:00"
+---
+# Mobile App Development
+
+Build mobile app for iOS and Android.

--- a/tests/e2e/test-vault/Projects/website-redesign.md
+++ b/tests/e2e/test-vault/Projects/website-redesign.md
@@ -1,0 +1,12 @@
+---
+exo__Instance_class: "[[ems__Project]]"
+exo__Asset_label: "Website Redesign"
+exo__Asset_uid: test-project-001
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_day: "[[2025-10-16]]"
+ems__Effort_startTimestamp: "2025-10-16T10:00:00"
+ems__Effort_plannedStartTimestamp: "2025-10-16T10:00:00"
+---
+# Website Redesign
+
+Complete redesign of company website.


### PR DESCRIPTION
## Summary

Добавлены E2E тесты для проверки разделения таблиц задач и проектов в DailyNote Layout.

## Root Cause Analysis

**Почему пользователь видел одну таблицу:**
- ❌ В test-vault не было проектов с `ems__Effort_day`
- ❌ В реальном vault пользователя, вероятно, нет проектов с этим свойством
- ✅ Код работает корректно - таблица Projects отображается только если есть данные

## Changes

### Test Data
- **test-vault/Projects/website-redesign.md** - тестовый проект с Doing статусом
- **test-vault/Projects/mobile-app-development.md** - тестовый проект с ToDo статусом
- Оба проекта имеют `ems__Effort_day: "[[2025-10-16]]"`

### E2E Tests (6 новых тестов)
1. ✅ `should display separate tables for tasks and projects`
2. ✅ `should display only tasks in tasks table`
3. ✅ `should display only projects in projects table`
4. ✅ `should display projects with correct status and timestamps`
5. ✅ `should display correct row counts in both tables`
6. ✅ `should display projects table after tasks table`

## Test Results

Все тесты прошли в Docker окружении:
```
✓  8 should display separate tables for tasks and projects (5.0s)
✓ 10 should display only tasks in tasks table (retry #1) (12.4s)
✓ 11 should display only projects in projects table (5.4s)
✓ 13 should display projects with correct status and timestamps (retry #1) (4.6s)
✓ 14 should display correct row counts in both tables (4.3s)
✓ 15 should display projects table after tasks table (4.2s)
```

## For User

Чтобы увидеть таблицу Projects в вашем vault:
1. Создайте проект (ассет класса `ems__Project`)
2. Установите `ems__Effort_day` равным текущему дню (например, `[[2025-10-22]]`)
3. Откройте DailyNote для этого дня
4. Таблица Projects появится автоматически

## Follow-up

Это PR добавляет только тесты. Функциональность уже работает с v12.32.2.