### PR TITLE
feat: add votes sorting for efforts in DailyNote Layout

### DIFF
--- a/specs/features/layout/daily-projects.feature
+++ b/specs/features/layout/daily-projects.feature
@@ -1,0 +1,73 @@
+Feature: Daily Projects Table in Layout
+  As a user viewing a pn__DailyNote
+  I want to see all projects scheduled for that day
+  So that I can manage my daily projects efficiently
+
+  Background:
+    Given I am viewing a note with UniversalLayout
+    And I have a pn__DailyNote for "2025-10-16"
+
+  Scenario: Display projects for DailyNote with projects
+    Given the note has "pn__DailyNote_day" property set to "[[2025-10-16]]"
+    And there are 3 projects with "ems__Effort_day" property set to "[[2025-10-16]]"
+    When I view the daily note
+    Then I should see a "Projects" section
+    And the Projects table should appear after Tasks table
+    And I should see 3 projects in the table
+    And each project should display Name, Start, End, and Status columns
+
+  Scenario: Projects display with icons based on status
+    Given project "Active Project" has status "[[ems__EffortStatusDoing]]" and class "[[ems__Project]]"
+    And project "Completed Project" has status "[[ems__EffortStatusDone]]"
+    And project "Cancelled Project" has status "[[ems__EffortStatusTrashed]]"
+    When I view the daily note
+    Then project "Active Project" should display with 📦 icon
+    And project "Completed Project" should display with ✅ icon
+    And project "Cancelled Project" should display with ❌ icon
+
+  Scenario: Projects sorted by priority
+    Given project "Active Project" has status "[[ems__EffortStatusDoing]]" and start time "09:00"
+    And project "Done Project" has status "[[ems__EffortStatusDone]]" and start time "08:00"
+    And project "Trashed Project" has status "[[ems__EffortStatusTrashed]]"
+    When I view the daily note
+    Then projects should be sorted with Trashed at bottom
+    And Done projects should appear before Trashed
+    And Active projects should appear first, sorted by votes then by start time
+
+  Scenario: Projects sorted by votes within same status
+    Given project "High Priority" has status "[[ems__EffortStatusDoing]]" and "ems__Effort_votes" set to 5
+    And project "Medium Priority" has status "[[ems__EffortStatusDoing]]" and "ems__Effort_votes" set to 3
+    And project "Low Priority" has status "[[ems__EffortStatusDoing]]" and "ems__Effort_votes" set to 1
+    And project "No Votes" has status "[[ems__EffortStatusDoing]]" and no "ems__Effort_votes" property
+    When I view the daily note
+    Then projects should be sorted in order: "High Priority", "Medium Priority", "Low Priority", "No Votes"
+    And projects with missing votes should be treated as having 0 votes
+
+  Scenario: Click on project opens project file
+    Given I have a pn__DailyNote with projects
+    When I click on a project name
+    Then the project file should open in current tab
+    When I Cmd+Click on a project name
+    Then the project file should open in new tab
+
+  Scenario: Projects limit to 50 items
+    Given there are 75 projects with "ems__Effort_day" property set to "[[2025-10-16]]"
+    When I view the daily note
+    Then I should see exactly 50 projects in the table
+    And projects should be sorted by priority (Active > Done > Trashed, then by votes, then by start time)
+
+  Scenario: No Projects table when no projects for the day
+    Given there are NO projects with "ems__Effort_day" property set to "[[2025-10-16]]"
+    When I view the daily note
+    Then I should NOT see a Projects section
+    And Tasks table should render normally
+    And Relations table should render normally
+
+  Scenario: Projects and Tasks tables are independent
+    Given there are 2 tasks with "ems__Effort_votes" set to 5 and 3
+    And there are 2 projects with "ems__Effort_votes" set to 10 and 1
+    When I view the daily note
+    Then Tasks table should sort tasks by their own votes independently
+    And Projects table should sort projects by their own votes independently
+    And project votes should NOT affect task sorting
+    And task votes should NOT affect project sorting

--- a/specs/features/layout/daily-tasks.feature
+++ b/specs/features/layout/daily-tasks.feature
@@ -36,7 +36,17 @@ Feature: Daily Tasks Table in Layout
     When I view the daily note
     Then tasks should be sorted with Trashed at bottom
     And Done tasks should appear before Trashed
-    And Active tasks should appear first, sorted by start time
+    And Active tasks should appear first, sorted by votes then by start time
+
+  Scenario: Tasks sorted by votes within same status
+    Given I have a pn__DailyNote for "2025-10-16"
+    And task "High Priority" has status "[[ems__EffortStatusDoing]]" and "ems__Effort_votes" set to 5
+    And task "Medium Priority" has status "[[ems__EffortStatusDoing]]" and "ems__Effort_votes" set to 3
+    And task "Low Priority" has status "[[ems__EffortStatusDoing]]" and "ems__Effort_votes" set to 1
+    And task "No Votes" has status "[[ems__EffortStatusDoing]]" and no "ems__Effort_votes" property
+    When I view the daily note
+    Then tasks should be sorted in order: "High Priority", "Medium Priority", "Low Priority", "No Votes"
+    And tasks with missing votes should be treated as having 0 votes
 
   Scenario: Click on task opens task file
     Given I have a pn__DailyNote with tasks

--- a/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -1864,6 +1864,19 @@ export class UniversalLayoutRenderer {
           return a.isDone ? 1 : -1;
         }
 
+        const aVotes =
+          typeof a.metadata.ems__Effort_votes === "number"
+            ? a.metadata.ems__Effort_votes
+            : 0;
+        const bVotes =
+          typeof b.metadata.ems__Effort_votes === "number"
+            ? b.metadata.ems__Effort_votes
+            : 0;
+
+        if (aVotes !== bVotes) {
+          return bVotes - aVotes;
+        }
+
         if (a.startTime && b.startTime) {
           return a.startTime.localeCompare(b.startTime);
         }
@@ -1968,6 +1981,19 @@ export class UniversalLayoutRenderer {
 
         if (a.isDone !== b.isDone) {
           return a.isDone ? 1 : -1;
+        }
+
+        const aVotes =
+          typeof a.metadata.ems__Effort_votes === "number"
+            ? a.metadata.ems__Effort_votes
+            : 0;
+        const bVotes =
+          typeof b.metadata.ems__Effort_votes === "number"
+            ? b.metadata.ems__Effort_votes
+            : 0;
+
+        if (aVotes !== bVotes) {
+          return bVotes - aVotes;
         }
 
         if (a.startTime && b.startTime) {


### PR DESCRIPTION
## Summary
Implements sorting by `ems__Effort_votes` for both Tasks and Projects tables in `pn__DailyNote` Layout.

- Tasks table (ems__Task + ems__Meeting): Sorted by status > votes (desc) > start time
- Projects table (ems__Project): Sorted by status > votes (desc) > start time
- Missing votes treated as 0
- Both tables have independent sorting logic

## Changes
- Modified `UniversalLayoutRenderer.ts`: Added vote sorting logic between status and time sorting for both `getDailyTasks()` and `getDailyProjects()` methods
- Created `specs/features/layout/daily-projects.feature`: Comprehensive BDD scenarios for Projects table sorting
- Updated `specs/features/layout/daily-tasks.feature`: Added vote sorting scenarios

## Test Coverage
- ✅ Unit tests: All passed (290 tests)
- ✅ UI tests: All passed (55 tests)
- ✅ Component tests: All passed (183 tests)
- E2E tests will run in CI

## Technical Details
Sorting priority order:
1. Status (Trashed at bottom, Done before Trashed, Active first)
2. Votes (descending, missing = 0)
3. Start time (ascending)

Both tables sort independently as specified in requirements.