### PR TITLE
feat: add meeting icon to completed meetings in DailyNote tasks

### DIFF
--- a/src/presentation/components/DailyTasksTable.tsx
+++ b/src/presentation/components/DailyTasksTable.tsx
@@ -53,7 +53,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   };
 
   const getDisplayName = (task: DailyTask): string => {
-    const icon = task.isDone ? "✅ " : task.isTrashed ? "❌ " : task.isMeeting ? "👥 " : "";
+    const icon = (task.isDone && task.isMeeting) ? "✅ 👥 " : task.isDone ? "✅ " : task.isTrashed ? "❌ " : task.isMeeting ? "👥 " : "";
 
     let displayText = task.label || task.title;
 

--- a/tests/component/DailyTasksTable.spec.tsx
+++ b/tests/component/DailyTasksTable.spec.tsx
@@ -56,6 +56,19 @@ test.describe("DailyTasksTable", () => {
       isTrashed: true,
       isMeeting: false,
     },
+    {
+      file: { path: "meeting2.md", basename: "meeting2" },
+      path: "meeting2.md",
+      title: "Meeting 2",
+      label: "Completed Meeting",
+      startTime: "16:00",
+      endTime: "17:00",
+      status: "ems__EffortStatusDone",
+      metadata: {},
+      isDone: true,
+      isTrashed: false,
+      isMeeting: true,
+    },
   ];
 
   test("should render tasks table with all columns", async ({ mount }) => {
@@ -72,7 +85,7 @@ test.describe("DailyTasksTable", () => {
     const component = await mount(<DailyTasksTable tasks={mockTasks} />);
 
     const rows = component.locator("tbody tr");
-    await expect(rows).toHaveCount(4);
+    await expect(rows).toHaveCount(5);
   });
 
   test("should display task with done icon", async ({ mount }) => {
@@ -97,6 +110,14 @@ test.describe("DailyTasksTable", () => {
     const meetingTask = component.locator('tr[data-path="meeting1.md"] .task-name a');
     await expect(meetingTask).toContainText("👥");
     await expect(meetingTask).toContainText("Team Sync");
+  });
+
+  test("should display completed meeting with both done and meeting icons", async ({ mount }) => {
+    const component = await mount(<DailyTasksTable tasks={mockTasks} />);
+
+    const completedMeeting = component.locator('tr[data-path="meeting2.md"] .task-name a');
+    await expect(completedMeeting).toContainText("✅ 👥");
+    await expect(completedMeeting).toContainText("Completed Meeting");
   });
 
   test("should display start and end times", async ({ mount }) => {
@@ -214,6 +235,6 @@ test.describe("DailyTasksTable", () => {
     const component = await mount(<DailyTasksTable tasks={mockTasks} />);
 
     const taskLinks = component.locator(".task-name a.internal-link");
-    await expect(taskLinks).toHaveCount(4);
+    await expect(taskLinks).toHaveCount(5);
   });
 });


### PR DESCRIPTION
## Summary

For completed meetings (Meeting assets with Done status), the DailyNote Tasks table now displays both ✅ and 👥 icons before the meeting title, making it visually clear that the item is both a meeting and completed.

## Changes

- **Updated icon logic** in `DailyTasksTable.tsx` (line 56) to check for `isDone && isMeeting` combination first
- **Added test case** for completed meeting icon display in `DailyTasksTable.spec.tsx`
- **Added mock data** for completed meeting scenario (meeting2.md)
- **Updated test counts** to reflect new test data (4 → 5 tasks)

## Behavior

| Scenario | Icon Display |
|----------|--------------|
| Completed Meeting (`isDone` + `isMeeting`) | ✅ 👥 Title |
| Completed Task (`isDone` only) | ✅ Title |
| Active Meeting (`isMeeting` only) | 👥 Title |
| Trashed (`isTrashed`) | ❌ Title |
| Regular Task | Title (no icon) |

## Test Coverage

- ✅ All unit tests pass (294 tests)
- ✅ All UI tests pass (55 tests)  
- ✅ All component tests pass (185 tests)
- ✅ New test case: "should display completed meeting with both done and meeting icons"

## Files Modified

1. `src/presentation/components/DailyTasksTable.tsx` - Icon logic update
2. `tests/component/DailyTasksTable.spec.tsx` - New test case and mock data

Total: 2 files, 24 insertions(+), 3 deletions(-)