### PR TITLE
feat: extend label prefill with date to TaskPrototype

### DIFF
--- a/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -293,7 +293,7 @@ export class UniversalLayoutRenderer {
             ? (instanceClass[0] || "").replace(/\[\[|\]\]/g, "").trim()
             : (instanceClass || "").replace(/\[\[|\]\]/g, "").trim();
 
-          const defaultValue = sourceClass === "ems__MeetingPrototype"
+          const defaultValue = sourceClass === "ems__MeetingPrototype" || sourceClass === "ems__TaskPrototype"
             ? this.generateDefaultMeetingLabel(metadata, file.basename)
             : "";
 


### PR DESCRIPTION
## Summary

Extended the modal pre-fill logic to include `ems__TaskPrototype` in addition to `ems__MeetingPrototype`. Now when creating an instance from TaskPrototype, the label input field is automatically filled with:

**Format**: `[prototype label] [YYYY-MM-DD]`

Example: If prototype has label "Weekly Review", the modal will show: "Weekly Review 2025-10-23"

## Changes

- Modified `UniversalLayoutRenderer.ts:296-298` to check for both `ems__MeetingPrototype` and `ems__TaskPrototype`
- Reused existing `generateDefaultMeetingLabel()` method for both prototype types

## Test Coverage

All tests passing:
- ✅ Unit tests: 294 passed
- ✅ UI tests: 55 passed
- ✅ Component tests: 183 passed
- ✅ Pre-commit hooks: passed

## Related

Implements user requirement to extend date prefill functionality from MeetingPrototype to TaskPrototype for consistent UX across all prototype types.