### PR TITLE
refactor: reorder layout blocks - Properties first, then Buttons

### DIFF
--- a/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -576,6 +576,11 @@ export class UniversalLayoutRenderer {
         return;
       }
 
+      // Render asset properties (if enabled in settings)
+      if (this.settings.showPropertiesSection) {
+        await this.renderAssetProperties(el, currentFile);
+      }
+
       // Render action buttons with semantic grouping
       const buttonGroups = await this.buildActionButtonGroups(currentFile);
       if (buttonGroups.length > 0) {
@@ -584,11 +589,6 @@ export class UniversalLayoutRenderer {
           buttonsContainer,
           React.createElement(ActionButtonsGroup, { groups: buttonGroups }),
         );
-      }
-
-      // Render asset properties (if enabled in settings)
-      if (this.settings.showPropertiesSection) {
-        await this.renderAssetProperties(el, currentFile);
       }
 
       // Render daily tasks for pn__DailyNote assets

--- a/tests/ui/ActionButtonsLayout.ui.test.ts
+++ b/tests/ui/ActionButtonsLayout.ui.test.ts
@@ -108,7 +108,7 @@ describe("Layout Settings and Structure", () => {
   });
 
   describe("Layout Sections Order", () => {
-    it("should render sections in correct order: Buttons -> Properties -> Relations", async () => {
+    it("should render sections in correct order: Properties -> Buttons -> Relations", async () => {
       const settings: ExocortexSettings = {
         ...DEFAULT_SETTINGS,
         showPropertiesSection: true,
@@ -141,7 +141,7 @@ describe("Layout Settings and Structure", () => {
       const propertiesIndex = sectionClasses.findIndex((c) => c === "exocortex-properties-section");
 
       if (buttonsIndex !== -1 && propertiesIndex !== -1) {
-        expect(buttonsIndex).toBeLessThan(propertiesIndex);
+        expect(propertiesIndex).toBeLessThan(buttonsIndex);
       }
     });
   });

--- a/tests/ui/UniversalLayoutRenderer.ui.test.ts
+++ b/tests/ui/UniversalLayoutRenderer.ui.test.ts
@@ -396,7 +396,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
       expect(button).toBeFalsy();
     });
 
-    it("should position Create Task button above properties table", async () => {
+    it("should position Create Task button below properties table", async () => {
       const currentFile = {
         basename: "Area",
         path: "area.md",
@@ -416,7 +416,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
 
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      // Verify order: buttons section (containing action buttons) -> properties section -> relations
+      // Verify order: properties section -> buttons section (containing action buttons) -> relations
       const children = Array.from(container.children);
       const buttonsContainerIndex = children.findIndex((el) =>
         el.classList.contains("exocortex-buttons-section"),
@@ -427,7 +427,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
 
       expect(buttonsContainerIndex).toBeGreaterThanOrEqual(0);
       expect(propertiesIndex).toBeGreaterThanOrEqual(0);
-      expect(buttonsContainerIndex).toBeLessThan(propertiesIndex);
+      expect(propertiesIndex).toBeLessThan(buttonsContainerIndex);
 
       // Verify Create Task button is inside the action buttons container (inside buttons section)
       const buttonsSection = children[buttonsContainerIndex];
@@ -1059,7 +1059,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
       expect(button).toBeFalsy();
     });
 
-    it("should position Repair Folder button after Clean button and before properties", async () => {
+    it("should position Repair Folder button after Clean button and after properties", async () => {
       const currentFile = {
         basename: "Misplaced",
         path: "wrong/asset.md",
@@ -1091,7 +1091,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
 
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      // Verify buttons section is before properties
+      // Verify properties section is before buttons section
       const children = Array.from(container.children);
       const buttonsContainerIndex = children.findIndex((el) =>
         el.classList.contains("exocortex-buttons-section"),
@@ -1102,7 +1102,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
 
       expect(buttonsContainerIndex).toBeGreaterThanOrEqual(0);
       expect(propertiesIndex).toBeGreaterThanOrEqual(0);
-      expect(buttonsContainerIndex).toBeLessThan(propertiesIndex);
+      expect(propertiesIndex).toBeLessThan(buttonsContainerIndex);
 
       // Verify both buttons exist inside the buttons section (via action buttons container)
       const buttonsSection = children[buttonsContainerIndex];


### PR DESCRIPTION
## Summary

Changed the rendering order in UniversalLayoutRenderer to match new UX requirement:

**New order:**
1. **Properties** block (first)
2. **Buttons** block (second)
3. Rest of the content (Daily Tasks, Daily Projects, Asset Relations)

**Previously:** Buttons → Properties → Rest
**Now:** Properties → Buttons → Rest

## Changes

### Source Code
- **src/presentation/renderers/UniversalLayoutRenderer.ts**: Swapped Properties and Buttons rendering order (lines 579-592)

### Tests Updated
- **tests/ui/ActionButtonsLayout.ui.test.ts**: Updated test expectations for new order
  - Test title: "Properties -> Buttons -> Relations"
  - Assertion: `expect(propertiesIndex).toBeLessThan(buttonsIndex)`
  
- **tests/ui/UniversalLayoutRenderer.ui.test.ts**: Updated 2 tests for button positioning
  - "should position Create Task button below properties table"
  - "should position Repair Folder button after Clean button and after properties"

## Test Results

All tests passing locally:
- ✅ Unit tests: 294 passed
- ✅ UI tests: 55 passed (including updated order tests)
- ✅ Component tests: 183 passed

E2E tests will run in CI pipeline.

## Checklist

- [x] Code changes implemented
- [x] Tests updated to reflect new behavior
- [x] All local tests passing
- [x] Commit message follows conventional commits
- [ ] CI checks passing (waiting for pipeline)