### PR TITLE
feat: add ems__Effort_status column to ems__Effort_area relations

### DIFF
--- a/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -1564,6 +1564,7 @@ export class UniversalLayoutRenderer {
         showProperties: config.showProperties || [],
         groupSpecificProperties: {
           "ems__Effort_parent": ["ems__Effort_status"],
+          "ems__Effort_area": ["ems__Effort_status"],
         },
         onAssetClick: async (path: string, event: React.MouseEvent) => {
           // Use Obsidian's Keymap.isModEvent to detect Cmd/Ctrl properly


### PR DESCRIPTION
## Summary

Adds `ems__Effort_status` column display for `ems__Effort_area` relation type in Area asset layout.

## Changes

- Updated `UniversalLayoutRenderer.ts` to include `ems__Effort_status` in `groupSpecificProperties` for `ems__Effort_area`
- Users can now see effort status directly in the relations table when viewing Area assets
- Consistent with existing behavior for `ems__Effort_parent` relations

## Technical Details

Modified `renderAssetRelations()` method in `UniversalLayoutRenderer.ts` (line 1566):
- Added `"ems__Effort_area": ["ems__Effort_status"]` to `groupSpecificProperties` configuration
- This enables the AssetRelationsTable component to display the status column for efforts linked via `ems__Effort_area` property

## Test Plan

- ✅ All unit tests passed (329 tests)
- ✅ All UI tests passed
- ✅ All component tests passed (188 tests)
- ✅ Build successful
- ⏳ E2E tests will run in CI

## Impact

- No breaking changes
- Pure configuration change (one line added)
- Improves UX by showing effort status in Area layout