### PR TITLE
feat: add active focus area filter for daily tasks

### DIFF
--- a/src/ExocortexPlugin.ts
+++ b/src/ExocortexPlugin.ts
@@ -36,7 +36,7 @@ export default class ExocortexPlugin extends Plugin {
 
       await this.loadSettings();
 
-      this.layoutRenderer = new UniversalLayoutRenderer(this.app, this.settings);
+      this.layoutRenderer = new UniversalLayoutRenderer(this.app, this.settings, this);
       this.taskStatusService = new TaskStatusService(this.app.vault);
       this.metadataCache = new Map();
 

--- a/src/domain/commands/CommandVisibility.ts
+++ b/src/domain/commands/CommandVisibility.ts
@@ -453,3 +453,11 @@ export function canCreateRelatedTask(context: CommandVisibilityContext): boolean
 
   return true;
 }
+
+/**
+ * Can execute "Set Active Focus" command
+ * Available for: ems__Area assets only
+ */
+export function canSetActiveFocus(context: CommandVisibilityContext): boolean {
+  return hasClass(context.instanceClass, "ems__Area");
+}

--- a/src/domain/settings/ExocortexSettings.ts
+++ b/src/domain/settings/ExocortexSettings.ts
@@ -2,10 +2,12 @@ export interface ExocortexSettings {
   showPropertiesSection: boolean;
   layoutVisible: boolean;
   showArchivedAssets: boolean;
+  activeFocusArea: string | null;
 }
 
 export const DEFAULT_SETTINGS: ExocortexSettings = {
   showPropertiesSection: true,
   layoutVisible: true,
   showArchivedAssets: false,
+  activeFocusArea: null,
 };


### PR DESCRIPTION
## 🎯 Summary

Implements task filtering in DailyNote by active area of responsibility.

## 🚀 Features

### 'Set Active Focus' Button
- Available in Layout for ems__Area assets
- Toggle mode: Set Active Focus ↔ Clear Active Focus  
- Persists state in settings.activeFocusArea

### Task Filtering
When active focus is set, DailyNote displays only tasks that:

1. **Direct link**: ems__Effort_area matches active/child area
2. **Via project**: ems__Effort_parent → project has ems__Effort_area in active/child area
3. **Via prototype**: ems__Effort_prototype → prototype references active/child area in any property

### UI Indicator
DailyNote displays badge when active focus is set:
```
🎯 Active Focus: [AreaName]
```

## 📝 Technical Details

### New Methods:
- `getChildAreas(areaName: string)` - recursive child area search
- Enhanced `getDailyTasks()` - filtering logic

### Modified Files:
- `src/domain/settings/ExocortexSettings.ts` - added activeFocusArea field
- `src/domain/commands/CommandVisibility.ts` - added canSetActiveFocus()
- `src/presentation/renderers/UniversalLayoutRenderer.ts` - button, filtering, UI indicator
- `src/ExocortexPlugin.ts` - pass plugin instance to renderer

## ✅ Testing

- ✅ Unit tests: 338 passed
- ✅ UI tests: 55 passed
- ✅ Component tests: 157 passed
- ⏳ E2E tests: will run in CI (Docker)

## 🎯 Benefits

- ✅ Reduces cognitive load - shows only relevant tasks
- ✅ Focus on current area of responsibility
- ✅ Supports area hierarchy (includes child areas)
- ✅ Flexible task-area linking rules