### PR TITLE
feat: add blocked tasks indicator with 🚩 emoji

### DIFF
--- a/src/presentation/components/DailyTasksTable.tsx
+++ b/src/presentation/components/DailyTasksTable.tsx
@@ -16,6 +16,7 @@ export interface DailyTask {
   isTrashed: boolean;
   isDoing: boolean;
   isMeeting: boolean;
+  isBlocked: boolean;
 }
 
 export interface DailyTasksTableProps {
@@ -58,6 +59,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   };
 
   const getDisplayName = (task: DailyTask): string => {
+    const blockerIcon = task.isBlocked ? "🚩 " : "";
     const icon = (task.isDone && task.isMeeting) ? "✅ 👥 " : task.isDone ? "✅ " : task.isTrashed ? "❌ " : task.isDoing ? "🔄 " : task.isMeeting ? "👥 " : "";
 
     let displayText = task.label || task.title;
@@ -71,7 +73,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
       }
     }
 
-    return icon + displayText;
+    return blockerIcon + icon + displayText;
   };
 
   return (

--- a/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -2083,6 +2083,20 @@ export class UniversalLayoutRenderer {
 
         const label = metadata.exo__Asset_label || file.basename;
 
+        let isBlocked = false;
+        const effortBlocker = metadata.ems__Effort_blocker;
+        if (effortBlocker) {
+          const blockerPath = String(effortBlocker).replace(/^\[\[|\]\]$/g, "");
+          const blockerFile = this.app.metadataCache.getFirstLinkpathDest(blockerPath, "");
+          if (blockerFile) {
+            const blockerCache = this.app.metadataCache.getFileCache(blockerFile);
+            const blockerMetadata = blockerCache?.frontmatter || {};
+            const blockerStatus = blockerMetadata.ems__Effort_status || "";
+            const blockerStatusStr = String(blockerStatus).replace(/^\[\[|\]\]$/g, "");
+            isBlocked = blockerStatusStr !== "ems__EffortStatusDone" && blockerStatusStr !== "ems__EffortStatusTrashed";
+          }
+        }
+
         tasks.push({
           file: {
             path: file.path,
@@ -2099,6 +2113,7 @@ export class UniversalLayoutRenderer {
           isTrashed,
           isDoing,
           isMeeting,
+          isBlocked,
         });
       }
 


### PR DESCRIPTION
## Summary

Добавлен индикатор 🚩 для заблокированных задач в таблице Tasks на DailyNote.

### Changes

- Добавлено свойство `isBlocked` в интерфейс `DailyTask`
- Реализована логика определения блокировки в методе `getDailyTasks()`
- Проверка свойства `ems__Effort_blocker` и статуса блокера
- Эмодзи 🚩 отображается для задач с незавершённым блокером (статусы != Done/Trashed)
- Иконка блокера появляется перед другими статусными иконками

### Implementation Details

**File**: `src/presentation/components/DailyTasksTable.tsx`
- Added `isBlocked: boolean` property to `DailyTask` interface (line 19)
- Modified `getDisplayName()` to prepend 🚩 emoji for blocked tasks (lines 62-63, 76)

**File**: `src/presentation/renderers/UniversalLayoutRenderer.ts`
- Added blocker detection logic in `getDailyTasks()` method (lines 2086-2098)
- Checks `ems__Effort_blocker` property
- Resolves blocker file and validates status
- Sets `isBlocked = true` if blocker status is not Done or Trashed

### Test Plan

- [x] Unit tests pass (338 passed)
- [x] UI tests pass (55 passed)  
- [x] Component tests pass (200 passed)
- [x] Build successful
- [x] TypeScript compilation clean
- [ ] E2E tests (will run in CI)

### Visual Result

Tasks with incomplete blockers will now display as: `🚩 <other-icons> <task-name>`

Example:
- `🚩 ✅ Completed but blocked task`
- `🚩 🔄 In progress but blocked task`
- `🚩 Meeting about blocked topic`