### PR TITLE
refactor: extract duplicate ensureQuoted logic to MetadataHelpers

### DIFF
--- a/src/infrastructure/services/AreaCreationService.ts
+++ b/src/infrastructure/services/AreaCreationService.ts
@@ -2,6 +2,7 @@ import { TFile, Vault } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import { AssetClass } from "../../domain/constants";
 import { DateFormatter } from "../utilities/DateFormatter";
+import { MetadataHelpers } from "../utilities/MetadataHelpers";
 
 export class AreaCreationService {
   constructor(private vault: Vault) {}
@@ -43,14 +44,8 @@ export class AreaCreationService {
       isDefinedBy = isDefinedBy[0] || '""';
     }
 
-    const ensureQuoted = (value: string): string => {
-      if (!value || value === '""') return '""';
-      if (value.startsWith('"') && value.endsWith('"')) return value;
-      return `"${value}"`;
-    };
-
     const frontmatter: Record<string, any> = {};
-    frontmatter["exo__Asset_isDefinedBy"] = ensureQuoted(isDefinedBy);
+    frontmatter["exo__Asset_isDefinedBy"] = MetadataHelpers.ensureQuoted(isDefinedBy);
     frontmatter["exo__Asset_uid"] = uid || uuidv4();
     frontmatter["exo__Asset_createdAt"] = timestamp;
     frontmatter["exo__Instance_class"] = [`"[[${AssetClass.AREA}]]"`];

--- a/src/infrastructure/services/ProjectCreationService.ts
+++ b/src/infrastructure/services/ProjectCreationService.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import { WikiLinkHelpers } from "../utilities/WikiLinkHelpers";
 import { AssetClass } from "../../domain/constants";
 import { DateFormatter } from "../utilities/DateFormatter";
+import { MetadataHelpers } from "../utilities/MetadataHelpers";
 
 /**
  * Mapping of source class to effort property name
@@ -57,19 +58,13 @@ export class ProjectCreationService {
       isDefinedBy = isDefinedBy[0] || '""';
     }
 
-    const ensureQuoted = (value: string): string => {
-      if (!value || value === '""') return '""';
-      if (value.startsWith('"') && value.endsWith('"')) return value;
-      return `"${value}"`;
-    };
-
     // Get appropriate effort property name based on source class
     const cleanSourceClass = WikiLinkHelpers.normalize(sourceClass);
     const effortProperty =
       EFFORT_PROPERTY_MAP[cleanSourceClass] || "ems__Effort_area";
 
     const frontmatter: Record<string, any> = {};
-    frontmatter["exo__Asset_isDefinedBy"] = ensureQuoted(isDefinedBy);
+    frontmatter["exo__Asset_isDefinedBy"] = MetadataHelpers.ensureQuoted(isDefinedBy);
     frontmatter["exo__Asset_uid"] = uid || uuidv4();
     frontmatter["exo__Asset_createdAt"] = timestamp;
     frontmatter["exo__Instance_class"] = [`"[[${AssetClass.PROJECT}]]"`];

--- a/src/infrastructure/services/TaskCreationService.ts
+++ b/src/infrastructure/services/TaskCreationService.ts
@@ -2,6 +2,7 @@ import { TFile, Vault } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { WikiLinkHelpers } from "../utilities/WikiLinkHelpers";
+import { MetadataHelpers } from "../utilities/MetadataHelpers";
 import { AssetClass } from "../../domain/constants";
 
 /**
@@ -192,15 +193,8 @@ export class TaskCreationService {
       isDefinedBy = isDefinedBy[0] || '""';
     }
 
-    // Ensure wiki-links are quoted
-    const ensureQuoted = (value: string): string => {
-      if (!value || value === '""') return '""';
-      if (value.startsWith('"') && value.endsWith('"')) return value;
-      return `"${value}"`;
-    };
-
     const frontmatter: Record<string, any> = {};
-    frontmatter["exo__Asset_isDefinedBy"] = ensureQuoted(isDefinedBy);
+    frontmatter["exo__Asset_isDefinedBy"] = MetadataHelpers.ensureQuoted(isDefinedBy);
     frontmatter["exo__Asset_uid"] = uid || uuidv4();
     frontmatter["exo__Asset_createdAt"] = timestamp;
     frontmatter["exo__Instance_class"] = [`"[[${AssetClass.TASK}]]"`];
@@ -315,15 +309,6 @@ export class TaskCreationService {
       isDefinedBy = isDefinedBy[0] || '""';
     }
 
-    // Ensure wiki-links are quoted
-    const ensureQuoted = (value: string): string => {
-      if (!value || value === '""') return '""';
-      // If already quoted, return as is
-      if (value.startsWith('"') && value.endsWith('"')) return value;
-      // Add quotes around wiki-link
-      return `"${value}"`;
-    };
-
     // Get appropriate effort property name and instance class based on source class
     const cleanSourceClass = WikiLinkHelpers.normalize(sourceClass);
     const effortProperty =
@@ -332,7 +317,7 @@ export class TaskCreationService {
       INSTANCE_CLASS_MAP[cleanSourceClass] || AssetClass.TASK;
 
     const frontmatter: Record<string, any> = {};
-    frontmatter["exo__Asset_isDefinedBy"] = ensureQuoted(isDefinedBy);
+    frontmatter["exo__Asset_isDefinedBy"] = MetadataHelpers.ensureQuoted(isDefinedBy);
     frontmatter["exo__Asset_uid"] = uid || uuidv4();
     frontmatter["exo__Asset_createdAt"] = timestamp;
     frontmatter["exo__Instance_class"] = [`"[[${instanceClass}]]"`];

--- a/src/infrastructure/utilities/MetadataHelpers.ts
+++ b/src/infrastructure/utilities/MetadataHelpers.ts
@@ -80,4 +80,10 @@ export class MetadataHelpers {
     if (propertyName === "path") return relation.path;
     return relation.metadata?.[propertyName];
   }
+
+  static ensureQuoted(value: string): string {
+    if (!value || value === '""') return '""';
+    if (value.startsWith('"') && value.endsWith('"')) return value;
+    return `"${value}"`;
+  }
 }


### PR DESCRIPTION
## Summary

Eliminates DRY violation by extracting duplicate `ensureQuoted()` function into centralized `MetadataHelpers` utility.

## Changes

### New Utility Method
- Added `MetadataHelpers.ensureQuoted()` for frontmatter value quoting

### Duplicates Removed (4 places)
- `ensureQuoted()` in AreaCreationService.ts (5 lines → 0)
- `ensureQuoted()` in ProjectCreationService.ts (5 lines → 0)
- `ensureQuoted()` in TaskCreationService.ts, 1st occurrence (6 lines → 0)
- `ensureQuoted()` in TaskCreationService.ts, 2nd occurrence (8 lines → 0)

### Function Logic (Consistent)
1. **Empty/null values** → `""`
2. **Already quoted** → unchanged
3. **Unquoted strings** → add quotes

## Impact
- **+6 lines** centralized utility
- **-24 lines** duplicate code removed
- **Net: -18 lines**
- ✅ All 805+ tests pass
- ✅ Zero breaking changes
- ✅ 100% backward compatible

## Quality Metrics
- DRY compliance: +4 violations fixed
- Code duplication: -24 lines
- Maintainability: Improved (single source of truth)

## Related Work
- Part of Phase 4: Deep DRY/SOLID refactoring
- Previous: #97-101 (various refactorings)
- Addresses: V-DRY-008 (duplicate quoting logic)

## Test Plan
- ✅ `npm run build` - Clean compilation
- ✅ `npm run test:all` - All tests pass
- ✅ No behavior changes (pure refactoring)

## Checklist
- [x] Code compiles without errors
- [x] All tests pass
- [x] No breaking changes
- [x] Follows Clean Code principles
- [x] Adheres to DRY/SOLID/GRASP