### PR TITLE
refactor: extract duplicate buildFileContent logic to MetadataHelpers

### DIFF
--- a/src/infrastructure/services/AreaCreationService.ts
+++ b/src/infrastructure/services/AreaCreationService.ts
@@ -20,7 +20,7 @@ export class AreaCreationService {
       label,
       uid,
     );
-    const fileContent = this.buildFileContent(frontmatter);
+    const fileContent = MetadataHelpers.buildFileContent(frontmatter);
 
     const folderPath = sourceFile.parent?.path || "";
     const filePath = folderPath ? `${folderPath}/${fileName}` : fileName;
@@ -58,19 +58,5 @@ export class AreaCreationService {
     }
 
     return frontmatter;
-  }
-
-  private buildFileContent(frontmatter: Record<string, any>): string {
-    const frontmatterLines = Object.entries(frontmatter)
-      .map(([key, value]) => {
-        if (Array.isArray(value)) {
-          const arrayItems = value.map((item) => `  - ${item}`).join("\n");
-          return `${key}:\n${arrayItems}`;
-        }
-        return `${key}: ${value}`;
-      })
-      .join("\n");
-
-    return `---\n${frontmatterLines}\n---\n\n`;
   }
 }

--- a/src/infrastructure/services/ProjectCreationService.ts
+++ b/src/infrastructure/services/ProjectCreationService.ts
@@ -33,7 +33,7 @@ export class ProjectCreationService {
       label,
       uid,
     );
-    const fileContent = this.buildFileContent(frontmatter);
+    const fileContent = MetadataHelpers.buildFileContent(frontmatter);
 
     const folderPath = sourceFile.parent?.path || "";
     const filePath = folderPath ? `${folderPath}/${fileName}` : fileName;
@@ -78,19 +78,5 @@ export class ProjectCreationService {
     }
 
     return frontmatter;
-  }
-
-  private buildFileContent(frontmatter: Record<string, any>): string {
-    const frontmatterLines = Object.entries(frontmatter)
-      .map(([key, value]) => {
-        if (Array.isArray(value)) {
-          const arrayItems = value.map((item) => `  - ${item}`).join("\n");
-          return `${key}:\n${arrayItems}`;
-        }
-        return `${key}: ${value}`;
-      })
-      .join("\n");
-
-    return `---\n${frontmatterLines}\n---\n\n`;
   }
 }

--- a/src/infrastructure/services/TaskCreationService.ts
+++ b/src/infrastructure/services/TaskCreationService.ts
@@ -106,7 +106,7 @@ export class TaskCreationService {
       }
     }
 
-    const fileContent = this.buildFileContent(frontmatter, bodyContent);
+    const fileContent = MetadataHelpers.buildFileContent(frontmatter, bodyContent);
 
     // Create file in same folder as source
     const folderPath = sourceFile.parent?.path || "";
@@ -154,7 +154,7 @@ export class TaskCreationService {
       taskSize,
     );
 
-    const fileContent = this.buildFileContent(frontmatter);
+    const fileContent = MetadataHelpers.buildFileContent(frontmatter);
 
     // Create file in same folder as source
     const folderPath = sourceFile.parent?.path || "";
@@ -357,27 +357,5 @@ export class TaskCreationService {
     const timestamp = DateFormatter.toLocalTimestamp(now).replace(/:/g, "-"); // Replace colons for filesystem compatibility
 
     return `Task-${timestamp}.md`;
-  }
-
-  /**
-   * Build complete file content with frontmatter
-   * Handles arrays in YAML format with proper indentation
-   * @param frontmatter Frontmatter properties
-   * @param bodyContent Optional body content to append after frontmatter
-   */
-  private buildFileContent(frontmatter: Record<string, any>, bodyContent?: string): string {
-    const frontmatterLines = Object.entries(frontmatter)
-      .map(([key, value]) => {
-        if (Array.isArray(value)) {
-          // YAML array format with indentation
-          const arrayItems = value.map((item) => `  - ${item}`).join("\n");
-          return `${key}:\n${arrayItems}`;
-        }
-        return `${key}: ${value}`;
-      })
-      .join("\n");
-
-    const body = bodyContent ? `\n${bodyContent}\n` : "\n";
-    return `---\n${frontmatterLines}\n---\n${body}`;
   }
 }

--- a/src/infrastructure/utilities/MetadataHelpers.ts
+++ b/src/infrastructure/utilities/MetadataHelpers.ts
@@ -86,4 +86,19 @@ export class MetadataHelpers {
     if (value.startsWith('"') && value.endsWith('"')) return value;
     return `"${value}"`;
   }
+
+  static buildFileContent(frontmatter: Record<string, any>, bodyContent?: string): string {
+    const frontmatterLines = Object.entries(frontmatter)
+      .map(([key, value]) => {
+        if (Array.isArray(value)) {
+          const arrayItems = value.map((item) => `  - ${item}`).join("\n");
+          return `${key}:\n${arrayItems}`;
+        }
+        return `${key}: ${value}`;
+      })
+      .join("\n");
+
+    const body = bodyContent ? `\n${bodyContent}\n` : "\n";
+    return `---\n${frontmatterLines}\n---\n${body}`;
+  }
 }

--- a/tests/unit/TaskCreationService.test.ts
+++ b/tests/unit/TaskCreationService.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { TaskCreationService } from "../../src/infrastructure/services/TaskCreationService";
+import { MetadataHelpers } from "../../src/infrastructure/utilities/MetadataHelpers";
 
 describe("TaskCreationService", () => {
   let service: TaskCreationService;
@@ -406,8 +407,8 @@ describe("TaskCreationService", () => {
         "ems__Area",
       );
 
-      // Access private method through TypeScript any
-      const content = (service as any).buildFileContent(frontmatter);
+      // Use MetadataHelpers utility
+      const content = MetadataHelpers.buildFileContent(frontmatter);
 
       // Should contain YAML array format with bullet
       expect(content).toContain('exo__Instance_class:\n  - "[[ems__Task]]"');
@@ -431,7 +432,7 @@ describe("TaskCreationService", () => {
         "ems__Project",
       );
 
-      const content = (service as any).buildFileContent(frontmatter);
+      const content = MetadataHelpers.buildFileContent(frontmatter);
 
       expect(content).toContain('exo__Instance_class:\n  - "[[ems__Task]]"');
       expect(content).toContain('exo__Asset_isDefinedBy: "[[!toos]]"');
@@ -445,7 +446,7 @@ describe("TaskCreationService", () => {
         exo__Asset_uid: "test-uuid",
       };
 
-      const content = (service as any).buildFileContent(frontmatter);
+      const content = MetadataHelpers.buildFileContent(frontmatter);
 
       expect(content).toContain('exo__Instance_class:\n  - "[[ems__Task]]"\n  - "[[ems__Effort]]"');
     });


### PR DESCRIPTION
## Summary

Extracted duplicate `buildFileContent()` implementations from 3 creation services into a shared utility method in MetadataHelpers.

## Changes

### Extraction
- **MetadataHelpers.buildFileContent()**: New static method with optional `bodyContent` parameter
  - Handles frontmatter formatting
  - Supports YAML array format with indentation
  - Optional body content for task creation

### Removed Duplicates
- **AreaCreationService**: Removed 13 lines (private method)
- **ProjectCreationService**: Removed 13 lines (private method)
- **TaskCreationService**: Removed 16 lines (private method + JSDoc)

### Test Updates
- **TaskCreationService.test.ts**: 
  - Import MetadataHelpers
  - Update 3 tests to use static method instead of private method

## Impact

- **Code reduction**: -28 lines duplication (42 lines → 14 lines shared utility)
- **DRY principle**: Eliminated 3 identical implementations
- **Maintainability**: Single source of truth for frontmatter formatting

## Testing

- ✅ Unit tests: 538 passed
- ✅ UI tests: 55 passed
- ✅ Component tests: 212 passed
- ⚠️ E2E tests: 21 passed, 2 flaky (pre-existing timing issues unrelated to this change)

## Notes

**Flaky E2E tests (pre-existing, unrelated to frontmatter refactoring)**:
- Algorithm block extraction (timeout waiting for `.exocortex-buttons-section`)
- DailyNote projects table (timing issue with table rendering)

These are known Docker environment timing issues, not caused by the buildFileContent extraction which only affects frontmatter generation logic.