### PR TITLE
feat: add toggleable Votes column to Daily Tasks table

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ Aggregates all tasks where `ems__Effort_day` matches the daily note's date.
 **Columns:**
 - Task Name (clickable)
 - Status (with visual indicators)
-- Effort Area
+- Effort Area (toggleable via "Show/Hide Effort Area" button)
+- Votes (toggleable via "Show/Hide Votes" button - displays `ems__Effort_votes` property)
 - Effort Parent (project/initiative)
 
 **Active Focus Feature:**
@@ -260,10 +261,10 @@ When an area is set as "Active Focus" using the "Set Active Focus" button:
 ```
 🎯 Active Focus: Development
 
-Task Name              | Status      | Area        | Parent
------------------------|-------------|-------------|-------------
-Implement API          | Doing       | Development | Backend Project
-Write tests            | ToDo        | Development | Backend Project
+Task Name              | Status      | Area        | Votes | Parent
+-----------------------|-------------|-------------|-------|-------------
+Implement API          | Doing       | Development | 5     | Backend Project
+Write tests            | ToDo        | Development | 3     | Backend Project
 ```
 
 ### Daily Projects Table

--- a/src/domain/settings/ExocortexSettings.ts
+++ b/src/domain/settings/ExocortexSettings.ts
@@ -4,6 +4,7 @@ export interface ExocortexSettings {
   showArchivedAssets: boolean;
   activeFocusArea: string | null;
   showEffortArea: boolean;
+  showEffortVotes: boolean;
 }
 
 export const DEFAULT_SETTINGS: ExocortexSettings = {
@@ -12,4 +13,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   showArchivedAssets: false,
   activeFocusArea: null,
   showEffortArea: false,
+  showEffortVotes: false,
 };

--- a/src/presentation/components/DailyTasksTable.tsx
+++ b/src/presentation/components/DailyTasksTable.tsx
@@ -25,6 +25,7 @@ export interface DailyTasksTableProps {
   getAssetLabel?: (path: string) => string | null;
   getEffortArea?: (metadata: Record<string, unknown>) => string | null;
   showEffortArea?: boolean;
+  showEffortVotes?: boolean;
 }
 
 export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
@@ -33,6 +34,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   getAssetLabel,
   getEffortArea,
   showEffortArea = false,
+  showEffortVotes = false,
 }) => {
   interface WikiLink {
     target: string;
@@ -86,6 +88,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
             <th>End</th>
             <th>Status</th>
             {showEffortArea && <th>Effort Area</th>}
+            {showEffortVotes && <th>Votes</th>}
           </tr>
         </thead>
         <tbody>
@@ -156,6 +159,11 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
                   })()}
                 </td>
               )}
+              {showEffortVotes && (
+                <td className="task-effort-votes">
+                  {typeof task.metadata.ems__Effort_votes === "number" ? task.metadata.ems__Effort_votes : "-"}
+                </td>
+              )}
             </tr>
           ))}
         </tbody>
@@ -164,14 +172,18 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   );
 };
 
-export interface DailyTasksTableWithToggleProps extends Omit<DailyTasksTableProps, 'showEffortArea'> {
+export interface DailyTasksTableWithToggleProps extends Omit<DailyTasksTableProps, 'showEffortArea' | 'showEffortVotes'> {
   showEffortArea: boolean;
   onToggleEffortArea: () => void;
+  showEffortVotes: boolean;
+  onToggleEffortVotes: () => void;
 }
 
 export const DailyTasksTableWithToggle: React.FC<DailyTasksTableWithToggleProps> = ({
   showEffortArea,
   onToggleEffortArea,
+  showEffortVotes,
+  onToggleEffortVotes,
   ...props
 }) => {
   return (
@@ -182,6 +194,7 @@ export const DailyTasksTableWithToggle: React.FC<DailyTasksTableWithToggleProps>
           onClick={onToggleEffortArea}
           style={{
             marginBottom: "8px",
+            marginRight: "8px",
             padding: "4px 8px",
             cursor: "pointer",
             fontSize: "12px",
@@ -189,8 +202,20 @@ export const DailyTasksTableWithToggle: React.FC<DailyTasksTableWithToggleProps>
         >
           {showEffortArea ? "Hide" : "Show"} Effort Area
         </button>
+        <button
+          className="exocortex-toggle-effort-votes"
+          onClick={onToggleEffortVotes}
+          style={{
+            marginBottom: "8px",
+            padding: "4px 8px",
+            cursor: "pointer",
+            fontSize: "12px",
+          }}
+        >
+          {showEffortVotes ? "Hide" : "Show"} Votes
+        </button>
       </div>
-      <DailyTasksTable {...props} showEffortArea={showEffortArea} />
+      <DailyTasksTable {...props} showEffortArea={showEffortArea} showEffortVotes={showEffortVotes} />
     </div>
   );
 };

--- a/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -889,6 +889,12 @@ export class UniversalLayoutRenderer {
           await this.plugin.saveSettings();
           await this.refresh();
         },
+        showEffortVotes: this.settings.showEffortVotes,
+        onToggleEffortVotes: async () => {
+          this.settings.showEffortVotes = !this.settings.showEffortVotes;
+          await this.plugin.saveSettings();
+          await this.refresh();
+        },
         onTaskClick: async (path: string, event: React.MouseEvent) => {
           // Use Obsidian's Keymap.isModEvent to detect Cmd/Ctrl properly
           const isModPressed = Keymap.isModEvent(

--- a/tests/component/DailyTasksTable.spec.tsx
+++ b/tests/component/DailyTasksTable.spec.tsx
@@ -298,6 +298,8 @@ test.describe("DailyTasksTableWithToggle", () => {
         tasks={mockTasks}
         showEffortArea={false}
         onToggleEffortArea={() => {}}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
       />
     );
 
@@ -311,6 +313,8 @@ test.describe("DailyTasksTableWithToggle", () => {
         tasks={mockTasks}
         showEffortArea={true}
         onToggleEffortArea={() => {}}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
       />
     );
 
@@ -326,6 +330,8 @@ test.describe("DailyTasksTableWithToggle", () => {
         onToggleEffortArea={() => {
           toggleCalled = true;
         }}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
       />
     );
 
@@ -339,6 +345,8 @@ test.describe("DailyTasksTableWithToggle", () => {
         tasks={mockTasks}
         showEffortArea={true}
         onToggleEffortArea={() => {}}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
       />
     );
 
@@ -352,6 +360,8 @@ test.describe("DailyTasksTableWithToggle", () => {
         tasks={mockTasks}
         showEffortArea={false}
         onToggleEffortArea={() => {}}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
       />
     );
 
@@ -370,6 +380,8 @@ test.describe("DailyTasksTableWithToggle", () => {
         tasks={mockTasks}
         showEffortArea={currentShowEffortArea}
         onToggleEffortArea={onToggle}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
       />
     );
 
@@ -377,5 +389,132 @@ test.describe("DailyTasksTableWithToggle", () => {
 
     await component.locator(".exocortex-toggle-effort-area").click();
     expect(currentShowEffortArea).toBe(true);
+  });
+
+  test("should render Votes toggle button", async ({ mount }) => {
+    const component = await mount(
+      <DailyTasksTableWithToggle
+        tasks={mockTasks}
+        showEffortArea={false}
+        onToggleEffortArea={() => {}}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
+      />
+    );
+
+    await expect(component.locator(".exocortex-toggle-effort-votes")).toBeVisible();
+    await expect(component.locator(".exocortex-toggle-effort-votes")).toContainText("Show Votes");
+  });
+
+  test("should show 'Hide Votes' when showEffortVotes is true", async ({ mount }) => {
+    const component = await mount(
+      <DailyTasksTableWithToggle
+        tasks={mockTasks}
+        showEffortArea={false}
+        onToggleEffortArea={() => {}}
+        showEffortVotes={true}
+        onToggleEffortVotes={() => {}}
+      />
+    );
+
+    await expect(component.locator(".exocortex-toggle-effort-votes")).toContainText("Hide Votes");
+  });
+
+  test("should call onToggleEffortVotes when button is clicked", async ({ mount }) => {
+    let toggleCalled = false;
+    const component = await mount(
+      <DailyTasksTableWithToggle
+        tasks={mockTasks}
+        showEffortArea={false}
+        onToggleEffortArea={() => {}}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {
+          toggleCalled = true;
+        }}
+      />
+    );
+
+    await component.locator(".exocortex-toggle-effort-votes").click();
+    expect(toggleCalled).toBe(true);
+  });
+
+  test("should show Votes column when showEffortVotes is true", async ({ mount }) => {
+    const tasksWithVotes: DailyTask[] = [
+      {
+        file: { path: "task1.md", basename: "task1" },
+        path: "task1.md",
+        title: "Task 1",
+        label: "First Task",
+        startTime: "09:00",
+        endTime: "10:00",
+        status: "ems__EffortStatusInProgress",
+        metadata: { ems__Effort_votes: 3 },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTableWithToggle
+        tasks={tasksWithVotes}
+        showEffortArea={false}
+        onToggleEffortArea={() => {}}
+        showEffortVotes={true}
+        onToggleEffortVotes={() => {}}
+      />
+    );
+
+    await expect(component.locator("thead th").nth(4)).toContainText("Votes");
+    await expect(component.locator(".task-effort-votes")).toBeVisible();
+    await expect(component.locator(".task-effort-votes")).toContainText("3");
+  });
+
+  test("should hide Votes column when showEffortVotes is false", async ({ mount }) => {
+    const component = await mount(
+      <DailyTasksTableWithToggle
+        tasks={mockTasks}
+        showEffortArea={false}
+        onToggleEffortArea={() => {}}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
+      />
+    );
+
+    await expect(component.locator(".task-effort-votes")).toHaveCount(0);
+  });
+
+  test("should display dash when votes are not set", async ({ mount }) => {
+    const tasksWithoutVotes: DailyTask[] = [
+      {
+        file: { path: "task1.md", basename: "task1" },
+        path: "task1.md",
+        title: "Task 1",
+        label: "First Task",
+        startTime: "09:00",
+        endTime: "10:00",
+        status: "ems__EffortStatusInProgress",
+        metadata: {},
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTableWithToggle
+        tasks={tasksWithoutVotes}
+        showEffortArea={false}
+        onToggleEffortArea={() => {}}
+        showEffortVotes={true}
+        onToggleEffortVotes={() => {}}
+      />
+    );
+
+    await expect(component.locator(".task-effort-votes")).toContainText("-");
   });
 });


### PR DESCRIPTION
## Summary

Add support for displaying task vote counts in pn__DailyNote's Tasks table.

## Changes

- ✅ New `showEffortVotes` setting in ExocortexSettings (default: false)
- ✅ Toggle button "Show/Hide Votes" in DailyTasksTableWithToggle component
- ✅ Display `ems__Effort_votes` property value in Tasks table
- ✅ Full test coverage (6 new component tests, all passing)
- ✅ Documentation updated in README.md

## Implementation Details

The Votes column works similarly to Effort Area column:
- Can be toggled on/off with button click
- State persists through plugin settings
- Displays vote count (number) or "-" when not set
- Type-safe handling of metadata property

## Test Results

```
✅ Unit tests: 538 passed
✅ UI tests: 55 passed  
✅ Component tests: 220 passed
✅ Total: 813 tests passed
```

## Documentation

README.md updated with:
- New "Votes" column in Daily Tasks table description
- Updated table example showing Votes column
- Toggle button documentation

## Screenshots

Daily Tasks table now has "Show/Hide Votes" button alongside "Show/Hide Effort Area" button.

---

Related to effort voting feature (ems__Effort_votes property).