### PR TITLE
fix: change let to const in ConceptCreationService and GraphCanvas

### DIFF
--- a/src/infrastructure/services/ConceptCreationService.ts
+++ b/src/infrastructure/services/ConceptCreationService.ts
@@ -28,7 +28,7 @@ export class ConceptCreationService {
     const folderPath = "concepts";
     const filePath = `${folderPath}/${fullFileName}`;
 
-    let folder = this.vault.getAbstractFileByPath(folderPath);
+    const folder = this.vault.getAbstractFileByPath(folderPath);
     if (!folder) {
       await this.vault.createFolder(folderPath);
     }

--- a/src/presentation/components/GraphCanvas.tsx
+++ b/src/presentation/components/GraphCanvas.tsx
@@ -117,7 +117,7 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ app, plugin }) => {
   }, [settings.groups, matchesGroup]);
 
   const filteredData = useMemo(() => {
-    let filteredNodes = graphData.nodes.filter((node) => {
+    const filteredNodes = graphData.nodes.filter((node) => {
       if (!settings.filters.existingFilesOnly) {
         return true;
       }


### PR DESCRIPTION
## Summary

Fix ESLint prefer-const errors introduced in #112:

- Change `let folder` to `const folder` in ConceptCreationService.ts:31
- Change `let filteredNodes` to `const filteredNodes` in GraphCanvas.tsx:120

## Why

These variables are never reassigned and should be const per ESLint rules.

## Test Plan

- [x] Lint passes (0 errors)
- [x] All tests pass (812 tests)