### PR TITLE
fix: support array format and project membership for Area inheritance

### DIFF
--- a/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/src/presentation/renderers/DailyTasksRenderer.ts
@@ -262,54 +262,83 @@ export class DailyTasksRenderer {
     }
   }
 
+  private extractFirstValue(value: unknown): string | null {
+    if (!value) {
+      return null;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+      return value.replace(/^\[\[|\]\]$/g, "").trim();
+    }
+
+    if (Array.isArray(value) && value.length > 0) {
+      const firstValue = value[0];
+      if (typeof firstValue === "string" && firstValue.trim() !== "") {
+        return firstValue.replace(/^\[\[|\]\]$/g, "").trim();
+      }
+    }
+
+    return null;
+  }
+
   private getEffortArea(metadata: Record<string, unknown>, visited: Set<string> = new Set()): string | null {
     if (!metadata || typeof metadata !== "object") {
       return null;
     }
 
     const area = metadata.ems__Effort_area;
-    if (area && typeof area === "string" && area.trim() !== "") {
-      return area;
+    const directArea = this.extractFirstValue(area);
+    if (directArea) {
+      return directArea;
     }
 
     const prototypeRef = metadata.ems__Effort_prototype;
-    if (prototypeRef) {
-      const prototypePath = typeof prototypeRef === "string"
-        ? prototypeRef.replace(/^\[\[|\]\]$/g, "").trim()
-        : null;
+    const prototypePath = this.extractFirstValue(prototypeRef);
 
-      if (prototypePath && !visited.has(prototypePath)) {
-        visited.add(prototypePath);
-        const prototypeFile = this.app.metadataCache.getFirstLinkpathDest(prototypePath, "");
-        if (prototypeFile && typeof prototypeFile === "object" && "path" in prototypeFile) {
-          const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile as TFile);
-          const prototypeMetadata = prototypeCache?.frontmatter || {};
+    if (prototypePath && !visited.has(prototypePath)) {
+      visited.add(prototypePath);
+      const prototypeFile = this.app.metadataCache.getFirstLinkpathDest(prototypePath, "");
+      if (prototypeFile && typeof prototypeFile === "object" && "path" in prototypeFile) {
+        const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile as TFile);
+        const prototypeMetadata = prototypeCache?.frontmatter || {};
 
-          const resolvedArea = this.getEffortArea(prototypeMetadata, visited);
-          if (resolvedArea) {
-            return resolvedArea;
-          }
+        const resolvedArea = this.getEffortArea(prototypeMetadata, visited);
+        if (resolvedArea) {
+          return resolvedArea;
+        }
+      }
+    }
+
+    const memberOfRef = metadata.exo__Asset_memberOf;
+    const memberOfPath = this.extractFirstValue(memberOfRef);
+
+    if (memberOfPath && !visited.has(memberOfPath)) {
+      visited.add(memberOfPath);
+      const memberOfFile = this.app.metadataCache.getFirstLinkpathDest(memberOfPath, "");
+      if (memberOfFile && typeof memberOfFile === "object" && "path" in memberOfFile) {
+        const memberOfCache = this.app.metadataCache.getFileCache(memberOfFile as TFile);
+        const memberOfMetadata = memberOfCache?.frontmatter || {};
+
+        const resolvedArea = this.getEffortArea(memberOfMetadata, visited);
+        if (resolvedArea) {
+          return resolvedArea;
         }
       }
     }
 
     const parentRef = metadata.ems__Effort_parent;
-    if (parentRef) {
-      const parentPath = typeof parentRef === "string"
-        ? parentRef.replace(/^\[\[|\]\]$/g, "").trim()
-        : null;
+    const parentPath = this.extractFirstValue(parentRef);
 
-      if (parentPath && !visited.has(parentPath)) {
-        visited.add(parentPath);
-        const parentFile = this.app.metadataCache.getFirstLinkpathDest(parentPath, "");
-        if (parentFile && typeof parentFile === "object" && "path" in parentFile) {
-          const parentCache = this.app.metadataCache.getFileCache(parentFile as TFile);
-          const parentMetadata = parentCache?.frontmatter || {};
+    if (parentPath && !visited.has(parentPath)) {
+      visited.add(parentPath);
+      const parentFile = this.app.metadataCache.getFirstLinkpathDest(parentPath, "");
+      if (parentFile && typeof parentFile === "object" && "path" in parentFile) {
+        const parentCache = this.app.metadataCache.getFileCache(parentFile as TFile);
+        const parentMetadata = parentCache?.frontmatter || {};
 
-          const resolvedArea = this.getEffortArea(parentMetadata, visited);
-          if (resolvedArea) {
-            return resolvedArea;
-          }
+        const resolvedArea = this.getEffortArea(parentMetadata, visited);
+        if (resolvedArea) {
+          return resolvedArea;
         }
       }
     }

--- a/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -595,54 +595,83 @@ export class UniversalLayoutRenderer {
     return null;
   }
 
+  private extractFirstValue(value: unknown): string | null {
+    if (!value) {
+      return null;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+      return value.replace(/^\[\[|\]\]$/g, "").trim();
+    }
+
+    if (Array.isArray(value) && value.length > 0) {
+      const firstValue = value[0];
+      if (typeof firstValue === "string" && firstValue.trim() !== "") {
+        return firstValue.replace(/^\[\[|\]\]$/g, "").trim();
+      }
+    }
+
+    return null;
+  }
+
   private getEffortArea(metadata: Record<string, unknown>, visited: Set<string> = new Set()): string | null {
     if (!metadata || typeof metadata !== "object") {
       return null;
     }
 
     const area = metadata.ems__Effort_area;
-    if (area && typeof area === "string" && area.trim() !== "") {
-      return area;
+    const directArea = this.extractFirstValue(area);
+    if (directArea) {
+      return directArea;
     }
 
     const prototypeRef = metadata.ems__Effort_prototype;
-    if (prototypeRef) {
-      const prototypePath = typeof prototypeRef === "string"
-        ? prototypeRef.replace(/^\[\[|\]\]$/g, "").trim()
-        : null;
+    const prototypePath = this.extractFirstValue(prototypeRef);
 
-      if (prototypePath && !visited.has(prototypePath)) {
-        visited.add(prototypePath);
-        const prototypeFile = this.app.metadataCache.getFirstLinkpathDest(prototypePath, "");
-        if (prototypeFile && typeof prototypeFile === "object" && "path" in prototypeFile) {
-          const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile as TFile);
-          const prototypeMetadata = prototypeCache?.frontmatter || {};
+    if (prototypePath && !visited.has(prototypePath)) {
+      visited.add(prototypePath);
+      const prototypeFile = this.app.metadataCache.getFirstLinkpathDest(prototypePath, "");
+      if (prototypeFile && typeof prototypeFile === "object" && "path" in prototypeFile) {
+        const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile as TFile);
+        const prototypeMetadata = prototypeCache?.frontmatter || {};
 
-          const resolvedArea = this.getEffortArea(prototypeMetadata, visited);
-          if (resolvedArea) {
-            return resolvedArea;
-          }
+        const resolvedArea = this.getEffortArea(prototypeMetadata, visited);
+        if (resolvedArea) {
+          return resolvedArea;
+        }
+      }
+    }
+
+    const memberOfRef = metadata.exo__Asset_memberOf;
+    const memberOfPath = this.extractFirstValue(memberOfRef);
+
+    if (memberOfPath && !visited.has(memberOfPath)) {
+      visited.add(memberOfPath);
+      const memberOfFile = this.app.metadataCache.getFirstLinkpathDest(memberOfPath, "");
+      if (memberOfFile && typeof memberOfFile === "object" && "path" in memberOfFile) {
+        const memberOfCache = this.app.metadataCache.getFileCache(memberOfFile as TFile);
+        const memberOfMetadata = memberOfCache?.frontmatter || {};
+
+        const resolvedArea = this.getEffortArea(memberOfMetadata, visited);
+        if (resolvedArea) {
+          return resolvedArea;
         }
       }
     }
 
     const parentRef = metadata.ems__Effort_parent;
-    if (parentRef) {
-      const parentPath = typeof parentRef === "string"
-        ? parentRef.replace(/^\[\[|\]\]$/g, "").trim()
-        : null;
+    const parentPath = this.extractFirstValue(parentRef);
 
-      if (parentPath && !visited.has(parentPath)) {
-        visited.add(parentPath);
-        const parentFile = this.app.metadataCache.getFirstLinkpathDest(parentPath, "");
-        if (parentFile && typeof parentFile === "object" && "path" in parentFile) {
-          const parentCache = this.app.metadataCache.getFileCache(parentFile as TFile);
-          const parentMetadata = parentCache?.frontmatter || {};
+    if (parentPath && !visited.has(parentPath)) {
+      visited.add(parentPath);
+      const parentFile = this.app.metadataCache.getFirstLinkpathDest(parentPath, "");
+      if (parentFile && typeof parentFile === "object" && "path" in parentFile) {
+        const parentCache = this.app.metadataCache.getFileCache(parentFile as TFile);
+        const parentMetadata = parentCache?.frontmatter || {};
 
-          const resolvedArea = this.getEffortArea(parentMetadata, visited);
-          if (resolvedArea) {
-            return resolvedArea;
-          }
+        const resolvedArea = this.getEffortArea(parentMetadata, visited);
+        if (resolvedArea) {
+          return resolvedArea;
         }
       }
     }

--- a/tests/ui/UniversalLayoutRenderer.ui.test.ts
+++ b/tests/ui/UniversalLayoutRenderer.ui.test.ts
@@ -86,7 +86,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
       await renderer.render("", container, ctx);
 
       // Wait for React to render
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 200));
 
       // Verify DOM structure - should have both properties and relations sections
       expect(container.querySelector(".exocortex-properties-section")).toBeTruthy();
@@ -364,7 +364,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
       await renderer.render("", container, {} as MarkdownPostProcessorContext);
 
       // Wait for React to render
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 200));
 
       // Verify button is present - find by text content
       const buttons = container.querySelectorAll(".exocortex-action-button");


### PR DESCRIPTION
## Summary

Fixes Area column display in Tasks table for daily notes by adding support for array format in frontmatter fields and project membership inheritance.

## Changes

### 1. Array Support for Prototype/Parent Fields
- Handle `ems__Effort_prototype` and `ems__Effort_parent` when they are arrays
- Extract first value from array format: `ems__Effort_prototype: ["[[TaskName]]"]`
- Maintain backward compatibility with string format

### 2. Project Membership Inheritance
- Add Area inheritance through `exo__Asset_memberOf`
- Tasks now inherit Area from projects they belong to
- Inheritance order: direct value → prototype → project membership → parent

### 3. Helper Method
- Add `extractFirstValue()` to normalize string/array values
- Handles both formats consistently across all inheritance paths
- Properly strips wiki-link brackets for path resolution

### 4. Test Improvements
- Increase React render timeout in UI tests from 50ms to 200ms
- Fixes flaky tests in `UniversalLayoutRenderer.ui.test.ts`

## Example

Task `c27a08cf-af44-41e0-b123-5f882be3aaac` now correctly displays:
- **Area** = "Кухня" 
- Inherited from its prototype "Сделать уборку на кухне" (`5093ae88-d429-4864-ac21-1ef0842c5643`)

## Files Changed

- `src/presentation/renderers/DailyTasksRenderer.ts` - Added `extractFirstValue()` and enhanced `getEffortArea()` 
- `src/presentation/renderers/UniversalLayoutRenderer.ts` - Same changes for consistency
- `tests/ui/UniversalLayoutRenderer.ui.test.ts` - Increased timeout for flaky tests

## Testing

- ✅ All unit tests passed (538/538)
- ✅ All UI tests passed (55/55)
- ✅ All component tests passed (220/220)
- E2E tests will run in CI

## Related Issue

Resolves user-reported issue with Area column not displaying inherited values in pn__DailyNote Layout.