### PR TITLE
fix: remove incorrect exo__Asset_memberOf from Area inheritance

### DIFF
--- a/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/src/presentation/renderers/DailyTasksRenderer.ts
@@ -309,23 +309,6 @@ export class DailyTasksRenderer {
       }
     }
 
-    const memberOfRef = metadata.exo__Asset_memberOf;
-    const memberOfPath = this.extractFirstValue(memberOfRef);
-
-    if (memberOfPath && !visited.has(memberOfPath)) {
-      visited.add(memberOfPath);
-      const memberOfFile = this.app.metadataCache.getFirstLinkpathDest(memberOfPath, "");
-      if (memberOfFile && typeof memberOfFile === "object" && "path" in memberOfFile) {
-        const memberOfCache = this.app.metadataCache.getFileCache(memberOfFile as TFile);
-        const memberOfMetadata = memberOfCache?.frontmatter || {};
-
-        const resolvedArea = this.getEffortArea(memberOfMetadata, visited);
-        if (resolvedArea) {
-          return resolvedArea;
-        }
-      }
-    }
-
     const parentRef = metadata.ems__Effort_parent;
     const parentPath = this.extractFirstValue(parentRef);
 

--- a/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -642,23 +642,6 @@ export class UniversalLayoutRenderer {
       }
     }
 
-    const memberOfRef = metadata.exo__Asset_memberOf;
-    const memberOfPath = this.extractFirstValue(memberOfRef);
-
-    if (memberOfPath && !visited.has(memberOfPath)) {
-      visited.add(memberOfPath);
-      const memberOfFile = this.app.metadataCache.getFirstLinkpathDest(memberOfPath, "");
-      if (memberOfFile && typeof memberOfFile === "object" && "path" in memberOfFile) {
-        const memberOfCache = this.app.metadataCache.getFileCache(memberOfFile as TFile);
-        const memberOfMetadata = memberOfCache?.frontmatter || {};
-
-        const resolvedArea = this.getEffortArea(memberOfMetadata, visited);
-        if (resolvedArea) {
-          return resolvedArea;
-        }
-      }
-    }
-
     const parentRef = metadata.ems__Effort_parent;
     const parentPath = this.extractFirstValue(parentRef);
 


### PR DESCRIPTION
## Summary

Removed non-existent property `exo__Asset_memberOf` from Area inheritance logic in both renderers:
- `src/presentation/renderers/DailyTasksRenderer.ts` (lines 312-327 removed)
- `src/presentation/renderers/UniversalLayoutRenderer.ts` (lines 645-660 removed)

## Problem

In PR #115 (v13.2.2), while fixing Area inheritance for `pn__DailyNote`, I incorrectly added logic to inherit Area from `exo__Asset_memberOf`. This property doesn't exist in the ontology.

## Solution

Preserved correct inheritance order:
1. ✅ `ems__Effort_area` - direct value
2. ✅ `ems__Effort_prototype` - prototype inheritance  
3. ✅ `ems__Effort_parent` - parent inheritance

Removed incorrect step between prototype and parent inheritance.

## Test Plan

- [x] All unit tests pass (538 tests)
- [x] All UI tests pass (36 tests)
- [x] All component tests pass (218 tests)
- [x] All E2E tests pass (Docker)
- [x] No functionality change - just removed dead code

## Related

- Introduced in: PR #115 (v13.2.2)
- Property doesn't exist in ontology
- No impact on production (code was never executed)