### PR TITLE
fix: parse EffortArea display for both wikilink formats

### DIFF
--- a/src/presentation/components/DailyTasksTable.tsx
+++ b/src/presentation/components/DailyTasksTable.tsx
@@ -138,8 +138,25 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
                     const effortArea = getEffortArea?.(task.metadata) || task.metadata.ems__Effort_area;
                     if (!effortArea) return "-";
 
-                    const isWikiLink = typeof effortArea === "string" && /\[\[.*?\]\]/.test(effortArea);
-                    const parsed = isWikiLink ? parseWikiLink(effortArea as string) : { target: effortArea as string };
+                    // Parse both formats: [[UID|Alias]] and UID|Alias
+                    let parsed: WikiLink;
+                    const effortAreaStr = String(effortArea);
+
+                    if (/\[\[.*?\]\]/.test(effortAreaStr)) {
+                      // Format: [[UID|Alias]]
+                      parsed = parseWikiLink(effortAreaStr);
+                    } else if (effortAreaStr.includes("|")) {
+                      // Format: UID|Alias (already extracted from wikilink)
+                      const parts = effortAreaStr.split("|");
+                      parsed = {
+                        target: parts[0].trim(),
+                        alias: parts[1]?.trim()
+                      };
+                    } else {
+                      // Plain value
+                      parsed = { target: effortAreaStr.trim() };
+                    }
+
                     const displayText = parsed.alias || parsed.target;
 
                     return (


### PR DESCRIPTION
## Summary

Fixes EffortArea column display in Daily Tasks table.

## Problem

When `ems__Effort_area` value comes from prototype inheritance, it may be in format:
- With wikilink brackets: `[[5093ae88-d429-4864-ac21-1ef0842c5643|Кухня]]`
- Without brackets (Obsidian-processed): `5093ae88-d429-4864-ac21-1ef0842c5643|Кухня`

Current code only handles first format, showing raw UID|Alias string for second.

## Solution

Enhanced parsing logic to handle both formats:
1. Check for `[[]]` → use existing parseWikiLink()
2. Check for `|` separator → parse UID|Alias directly
3. Fallback → use as-is

Now displays "Кухня" instead of "5093ae88-d429-4864-ac21-1ef0842c5643|Кухня".

## Test Plan

- [x] Manual test with task c27a08cf-af44-41e0-b123-5f882be3aaac
- [x] Verify alias displayed correctly
- [x] All unit tests pass (538 passed)
- [x] All UI tests pass (55 passed)
- [x] All component tests pass (218 passed)
- [ ] E2E tests pass (will run in CI)

## Related

Affects Daily Tasks table rendering in pn__DailyNote layout.