### PR TITLE
fix: remove unused chalk import breaking CI and blocking releases

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
-import chalk from 'chalk';
 import { createTaskCommand } from './commands/create-task.js';
 import { createInstanceCommand } from './commands/create-instance.js';
 import { statusCommand } from './commands/status.js';


### PR DESCRIPTION
EMERGENCY HOTFIX

**Problem**: 6 commits in main (870bcba through b5effd7) have NO releases because CI fails with:
```
packages/cli/src/index.ts(4,1): error TS6133: 'chalk' is declared but its value is never read.
```

**Impact**: Auto-release workflow skipped when CI fails, leaving 6 commits untagged

**Fix**: Remove unused chalk import from CLI

**After merge**: Auto-release will create releases for all 6 commits