### PR TITLE
chore: add eslint-disable comment for console usage in Logger.ts

### DIFF
--- a/packages/obsidian-plugin/src/adapters/logging/Logger.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/Logger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ILogger } from "./ILogger";
 
 export class Logger implements ILogger {
@@ -8,7 +9,6 @@ export class Logger implements ILogger {
   }
 
   info(message: string, ...args: unknown[]): void {
-    // eslint-disable-next-line no-console
     console.info(`[${this.context}] ${message}`, ...args);
   }
 


### PR DESCRIPTION
## Summary
Added file-level `/* eslint-disable no-console */` comment to Logger.ts to properly document that console usage is intentional in this logging utility implementation.

## Changes
- ✅ Added `/* eslint-disable no-console */` at file top
- ✅ Removed redundant line-level disable comment
- ✅ Cleaner than individual `// eslint-disable-next-line` comments

## Rationale
Logger.ts is a logging utility implementation where console.* methods are intentionally used. File-level disable is more appropriate than line-by-line suppression.

## Verification
```bash
npm run lint  # ✅ No console-related warnings
```

Fixes #166