### PR TITLE
fix: use FileManager.trashFile() to respect user deletion preferences

### DIFF
--- a/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
+++ b/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
@@ -27,7 +27,7 @@ export class ObsidianVaultAdapter implements IVaultAdapter {
 
   async delete(file: IFile): Promise<void> {
     const obsidianFile = this.toObsidianFile(file);
-    await this.vault.delete(obsidianFile);
+    await this.app.fileManager.trashFile(obsidianFile);
   }
 
   async exists(path: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
Replaced `Vault.delete()` with `FileManager.trashFile()` in `ObsidianVaultAdapter` to respect the user's file deletion preference.

## Problem
ESLint warning `obsidianmd/prefer-file-manager-trash-file` indicated that using `Vault.delete()` bypasses the user's configured file deletion preference (trash vs permanent delete).

## Solution
Changed `ObsidianVaultAdapter.delete()` to use `this.app.fileManager.trashFile()` instead of `this.vault.delete()`.

## Benefits
- ✅ Respects user's file deletion settings in Obsidian
- ✅ Files go to trash by default (safer for users)
- ✅ Eliminates ESLint warning
- ✅ Follows Obsidian plugin best practices

## Changes
**File**: `packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts:30`

```diff
async delete(file: IFile): Promise<void> {
  const obsidianFile = this.toObsidianFile(file);
-  await this.vault.delete(obsidianFile);
+  await this.app.fileManager.trashFile(obsidianFile);
}
```

## Verification
```bash
npm run lint  # ✅ No obsidianmd/prefer-file-manager-trash-file warnings
```

Fixes #163