### PR TITLE
test: add comprehensive tests for command classes

### DIFF
--- a/packages/obsidian-plugin/tests/unit/ArchiveTaskCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ArchiveTaskCommand.test.ts
@@ -1,0 +1,204 @@
+import { ArchiveTaskCommand } from "../../src/application/commands/ArchiveTaskCommand";
+import { TFile, Notice } from "obsidian";
+import { TaskStatusService, CommandVisibilityContext, LoggingService } from "@exocortex/core";
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual("obsidian"),
+  Notice: jest.fn(),
+}));
+jest.mock("@exocortex/core", () => ({
+  ...jest.requireActual("@exocortex/core"),
+  canArchiveTask: jest.fn(),
+  LoggingService: {
+    error: jest.fn(),
+  },
+}));
+
+describe("ArchiveTaskCommand", () => {
+  let command: ArchiveTaskCommand;
+  let mockTaskStatusService: jest.Mocked<TaskStatusService>;
+  let mockFile: jest.Mocked<TFile>;
+  let mockContext: CommandVisibilityContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Create mock task status service
+    mockTaskStatusService = {
+      archiveTask: jest.fn(),
+    } as unknown as jest.Mocked<TaskStatusService>;
+
+    // Create mock file
+    mockFile = {
+      path: "test-task.md",
+      basename: "test-task",
+    } as jest.Mocked<TFile>;
+
+    // Create mock context
+    mockContext = {
+      instanceClass: "Task",
+      status: "Done",
+      archived: false,
+      isDraft: false,
+    };
+
+    // Create command instance
+    command = new ArchiveTaskCommand(mockTaskStatusService);
+  });
+
+  describe("id and name", () => {
+    it("should have correct id and name", () => {
+      expect(command.id).toBe("archive-task");
+      expect(command.name).toBe("Archive task");
+    });
+  });
+
+  describe("checkCallback", () => {
+    const mockCanArchiveTask = require("@exocortex/core").canArchiveTask;
+
+    it("should return false when context is null", () => {
+      const result = command.checkCallback(true, mockFile, null);
+      expect(result).toBe(false);
+      expect(mockTaskStatusService.archiveTask).not.toHaveBeenCalled();
+    });
+
+    it("should return false when canArchiveTask returns false", () => {
+      mockCanArchiveTask.mockReturnValue(false);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(false);
+      expect(mockTaskStatusService.archiveTask).not.toHaveBeenCalled();
+    });
+
+    it("should return true when canArchiveTask returns true and checking is true", () => {
+      mockCanArchiveTask.mockReturnValue(true);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(true);
+      expect(mockTaskStatusService.archiveTask).not.toHaveBeenCalled();
+    });
+
+    it("should execute command when checking is false and canArchiveTask returns true", async () => {
+      mockCanArchiveTask.mockReturnValue(true);
+      mockTaskStatusService.archiveTask.mockResolvedValue();
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.archiveTask).toHaveBeenCalledWith(mockFile);
+      expect(Notice).toHaveBeenCalledWith("Archived: test-task");
+    });
+
+    it("should handle errors and show notice", async () => {
+      mockCanArchiveTask.mockReturnValue(true);
+      const error = new Error("Failed to archive");
+      mockTaskStatusService.archiveTask.mockRejectedValue(error);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.archiveTask).toHaveBeenCalledWith(mockFile);
+      expect(LoggingService.error).toHaveBeenCalledWith("Archive task error", error);
+      expect(Notice).toHaveBeenCalledWith("Failed to archive task: Failed to archive");
+    });
+
+    it("should handle already archived context", () => {
+      mockCanArchiveTask.mockReturnValue(false);
+      const archivedContext = { ...mockContext, archived: true };
+      const result = command.checkCallback(true, mockFile, archivedContext);
+      expect(result).toBe(false);
+    });
+
+    it("should handle files with long basenames", async () => {
+      mockCanArchiveTask.mockReturnValue(true);
+      mockTaskStatusService.archiveTask.mockResolvedValue();
+
+      const longFile = {
+        path: "path/to/very-long-task-name-that-exceeds-normal-length-expectations.md",
+        basename: "very-long-task-name-that-exceeds-normal-length-expectations",
+      } as TFile;
+
+      const result = command.checkCallback(false, longFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.archiveTask).toHaveBeenCalledWith(longFile);
+      expect(Notice).toHaveBeenCalledWith(
+        "Archived: very-long-task-name-that-exceeds-normal-length-expectations"
+      );
+    });
+
+    it("should handle different task statuses", () => {
+      mockCanArchiveTask.mockReturnValue(true);
+
+      // Test with Done status
+      const doneContext = { ...mockContext, status: "Done" };
+      const result1 = command.checkCallback(true, mockFile, doneContext);
+      expect(result1).toBe(true);
+
+      // Test with Cancelled status
+      const cancelledContext = { ...mockContext, status: "Cancelled" };
+      const result2 = command.checkCallback(true, mockFile, cancelledContext);
+      expect(result2).toBe(true);
+
+      // Test with InProgress status (should typically return false from canArchiveTask)
+      mockCanArchiveTask.mockReturnValue(false);
+      const inProgressContext = { ...mockContext, status: "InProgress" };
+      const result3 = command.checkCallback(true, mockFile, inProgressContext);
+      expect(result3).toBe(false);
+    });
+
+    it("should handle error with custom toString method", async () => {
+      mockCanArchiveTask.mockReturnValue(true);
+      const customError = {
+        toString: () => "Custom error string",
+        message: undefined,
+      };
+      mockTaskStatusService.archiveTask.mockRejectedValue(customError);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.archiveTask).toHaveBeenCalledWith(mockFile);
+      expect(LoggingService.error).toHaveBeenCalledWith("Archive task error", customError);
+      expect(Notice).toHaveBeenCalledWith("Failed to archive task: undefined");
+    });
+
+    it("should handle multiple concurrent archive operations", async () => {
+      mockCanArchiveTask.mockReturnValue(true);
+
+      // Create multiple files
+      const files = [
+        { path: "task1.md", basename: "task1" } as TFile,
+        { path: "task2.md", basename: "task2" } as TFile,
+        { path: "task3.md", basename: "task3" } as TFile,
+      ];
+
+      // Mock service to take some time
+      mockTaskStatusService.archiveTask.mockImplementation(
+        () => new Promise(resolve => setTimeout(resolve, 5))
+      );
+
+      // Execute commands concurrently
+      files.forEach(file => command.checkCallback(false, file, mockContext));
+
+      // Wait for all async executions
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(mockTaskStatusService.archiveTask).toHaveBeenCalledTimes(3);
+      files.forEach((file, index) => {
+        expect(mockTaskStatusService.archiveTask).toHaveBeenNthCalledWith(index + 1, file);
+        expect(Notice).toHaveBeenCalledWith(`Archived: ${file.basename}`);
+      });
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/CreateTaskCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CreateTaskCommand.test.ts
@@ -1,0 +1,401 @@
+import { CreateTaskCommand } from "../../src/application/commands/CreateTaskCommand";
+import { App, TFile, Notice, MetadataCache, Workspace, WorkspaceLeaf } from "obsidian";
+import { TaskCreationService, CommandVisibilityContext, LoggingService } from "@exocortex/core";
+import { ObsidianVaultAdapter } from "../../src/adapters/ObsidianVaultAdapter";
+import { LabelInputModal } from "../../src/presentation/modals/LabelInputModal";
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual("obsidian"),
+  Notice: jest.fn(),
+}));
+jest.mock("../../src/presentation/modals/LabelInputModal");
+jest.mock("@exocortex/core", () => ({
+  ...jest.requireActual("@exocortex/core"),
+  canCreateTask: jest.fn(),
+  LoggingService: {
+    error: jest.fn(),
+  },
+}));
+
+describe("CreateTaskCommand", () => {
+  let command: CreateTaskCommand;
+  let mockApp: jest.Mocked<App>;
+  let mockTaskCreationService: jest.Mocked<TaskCreationService>;
+  let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
+  let mockFile: jest.Mocked<TFile>;
+  let mockContext: CommandVisibilityContext;
+  let mockWorkspace: jest.Mocked<Workspace>;
+  let mockLeaf: jest.Mocked<WorkspaceLeaf>;
+  let mockMetadataCache: jest.Mocked<MetadataCache>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Create mock leaf
+    mockLeaf = {
+      openFile: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<WorkspaceLeaf>;
+
+    // Create mock workspace
+    mockWorkspace = {
+      getLeaf: jest.fn().mockReturnValue(mockLeaf),
+      setActiveLeaf: jest.fn(),
+      getActiveFile: jest.fn(),
+    } as unknown as jest.Mocked<Workspace>;
+
+    // Create mock metadata cache
+    mockMetadataCache = {
+      getFileCache: jest.fn().mockReturnValue({
+        frontmatter: { class: "Task", status: "ToDo" },
+      }),
+    } as unknown as jest.Mocked<MetadataCache>;
+
+    // Create mock app
+    mockApp = {
+      workspace: mockWorkspace,
+      metadataCache: mockMetadataCache,
+    } as unknown as jest.Mocked<App>;
+
+    // Create mock task creation service
+    mockTaskCreationService = {
+      createTask: jest.fn(),
+    } as unknown as jest.Mocked<TaskCreationService>;
+
+    // Create mock vault adapter
+    mockVaultAdapter = {
+      toTFile: jest.fn(),
+    } as unknown as jest.Mocked<ObsidianVaultAdapter>;
+
+    // Create mock file
+    mockFile = {
+      path: "test.md",
+      basename: "test",
+    } as jest.Mocked<TFile>;
+
+    // Create mock context
+    mockContext = {
+      instanceClass: "Epic",
+      status: "ToDo",
+      archived: false,
+      isDraft: false,
+    };
+
+    // Create command instance
+    command = new CreateTaskCommand(mockApp, mockTaskCreationService, mockVaultAdapter);
+  });
+
+  describe("id and name", () => {
+    it("should have correct id and name", () => {
+      expect(command.id).toBe("create-task");
+      expect(command.name).toBe("Create task");
+    });
+  });
+
+  describe("checkCallback", () => {
+    const mockCanCreateTask = require("@exocortex/core").canCreateTask;
+
+    it("should return false when context is null", () => {
+      const result = command.checkCallback(true, mockFile, null);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when canCreateTask returns false", () => {
+      mockCanCreateTask.mockReturnValue(false);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(false);
+    });
+
+    it("should return true when canCreateTask returns true and checking is true", () => {
+      mockCanCreateTask.mockReturnValue(true);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(true);
+    });
+
+    it("should execute command when checking is false and canCreateTask returns true", async () => {
+      mockCanCreateTask.mockReturnValue(true);
+
+      // Mock modal result
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => {
+        setTimeout(() => callback({ label: "Test Task", taskSize: "M" }), 0);
+        return { open: jest.fn() };
+      });
+
+      // Mock task creation
+      const createdFile = {
+        path: "Tasks/test-task.md",
+        basename: "test-task",
+      };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile);
+
+      const createdTFile = {
+        path: "Tasks/test-task.md",
+      } as TFile;
+      mockVaultAdapter.toTFile.mockReturnValue(createdTFile);
+
+      // Mock active file check
+      mockWorkspace.getActiveFile.mockReturnValue(createdTFile);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
+        mockFile,
+        { class: "Task", status: "ToDo" },
+        "Epic",
+        "Test Task",
+        "M"
+      );
+      expect(mockLeaf.openFile).toHaveBeenCalledWith(createdTFile);
+      expect(mockWorkspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, { focus: true });
+    });
+
+    it("should handle modal cancellation", async () => {
+      mockCanCreateTask.mockReturnValue(true);
+
+      // Mock modal result with null label (cancelled)
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => {
+        setTimeout(() => callback({ label: null, taskSize: null }), 0);
+        return { open: jest.fn() };
+      });
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(mockTaskCreationService.createTask).not.toHaveBeenCalled();
+      expect(mockLeaf.openFile).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors and show notice", async () => {
+      mockCanCreateTask.mockReturnValue(true);
+
+      // Mock modal result
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => {
+        setTimeout(() => callback({ label: "Test Task", taskSize: "M" }), 0);
+        return { open: jest.fn() };
+      });
+
+      // Mock task creation to throw error
+      const error = new Error("Creation failed");
+      mockTaskCreationService.createTask.mockRejectedValue(error);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(LoggingService.error).toHaveBeenCalledWith("Create task error", error);
+      expect(Notice).toHaveBeenCalledWith("Failed to create task: Creation failed");
+    });
+
+    it("should handle array instance class", async () => {
+      mockCanCreateTask.mockReturnValue(true);
+
+      // Mock modal result
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => {
+        setTimeout(() => callback({ label: "Test Task", taskSize: "S" }), 0);
+        return { open: jest.fn() };
+      });
+
+      // Mock context with array instance class
+      const arrayContext = {
+        ...mockContext,
+        instanceClass: ["Epic", "Feature"],
+      };
+
+      // Mock task creation
+      const createdFile = {
+        path: "Tasks/test-task.md",
+        basename: "test-task",
+      };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile);
+
+      const createdTFile = {
+        path: "Tasks/test-task.md",
+      } as TFile;
+      mockVaultAdapter.toTFile.mockReturnValue(createdTFile);
+
+      // Mock active file check
+      mockWorkspace.getActiveFile.mockReturnValue(createdTFile);
+
+      const result = command.checkCallback(false, mockFile, arrayContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
+        mockFile,
+        { class: "Task", status: "ToDo" },
+        "Epic",
+        "Test Task",
+        "S"
+      );
+    });
+
+    it("should handle empty instance class", async () => {
+      mockCanCreateTask.mockReturnValue(true);
+
+      // Mock modal result
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => {
+        setTimeout(() => callback({ label: "Test Task", taskSize: "L" }), 0);
+        return { open: jest.fn() };
+      });
+
+      // Mock context with empty instance class
+      const emptyContext = {
+        ...mockContext,
+        instanceClass: [],
+      };
+
+      // Mock task creation
+      const createdFile = {
+        path: "Tasks/test-task.md",
+        basename: "test-task",
+      };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile);
+
+      const createdTFile = {
+        path: "Tasks/test-task.md",
+      } as TFile;
+      mockVaultAdapter.toTFile.mockReturnValue(createdTFile);
+
+      // Mock active file check
+      mockWorkspace.getActiveFile.mockReturnValue(createdTFile);
+
+      const result = command.checkCallback(false, mockFile, emptyContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
+        mockFile,
+        { class: "Task", status: "ToDo" },
+        "",
+        "Test Task",
+        "L"
+      );
+    });
+
+    it("should handle missing frontmatter", async () => {
+      mockCanCreateTask.mockReturnValue(true);
+
+      // Mock no cache
+      mockMetadataCache.getFileCache.mockReturnValue(null);
+
+      // Mock modal result
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => {
+        setTimeout(() => callback({ label: "Test Task", taskSize: "XL" }), 0);
+        return { open: jest.fn() };
+      });
+
+      // Mock task creation
+      const createdFile = {
+        path: "Tasks/test-task.md",
+        basename: "test-task",
+      };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile);
+
+      const createdTFile = {
+        path: "Tasks/test-task.md",
+      } as TFile;
+      mockVaultAdapter.toTFile.mockReturnValue(createdTFile);
+
+      // Mock active file check
+      mockWorkspace.getActiveFile.mockReturnValue(createdTFile);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
+        mockFile,
+        {},
+        "Epic",
+        "Test Task",
+        "XL"
+      );
+    });
+
+    it("should wait for active file to be set", async () => {
+      mockCanCreateTask.mockReturnValue(true);
+
+      // Mock modal result
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => {
+        setTimeout(() => callback({ label: "Test Task", taskSize: "M" }), 0);
+        return { open: jest.fn() };
+      });
+
+      // Mock task creation
+      const createdFile = {
+        path: "Tasks/test-task.md",
+        basename: "test-task",
+      };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile);
+
+      const createdTFile = {
+        path: "Tasks/test-task.md",
+      } as TFile;
+      mockVaultAdapter.toTFile.mockReturnValue(createdTFile);
+
+      // Mock active file check - return null first, then the correct file
+      let callCount = 0;
+      mockWorkspace.getActiveFile.mockImplementation(() => {
+        callCount++;
+        return callCount <= 3 ? null : createdTFile;
+      });
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      expect(mockWorkspace.getActiveFile).toHaveBeenCalledTimes(4);
+      expect(Notice).toHaveBeenCalledWith("Task created: test-task");
+    });
+
+    it("should timeout waiting for active file", async () => {
+      mockCanCreateTask.mockReturnValue(true);
+
+      // Mock modal result
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => {
+        setTimeout(() => callback({ label: "Test Task", taskSize: "M" }), 0);
+        return { open: jest.fn() };
+      });
+
+      // Mock task creation
+      const createdFile = {
+        path: "Tasks/test-task.md",
+        basename: "test-task",
+      };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile);
+
+      const createdTFile = {
+        path: "Tasks/test-task.md",
+      } as TFile;
+      mockVaultAdapter.toTFile.mockReturnValue(createdTFile);
+
+      // Mock active file check - always return null
+      mockWorkspace.getActiveFile.mockReturnValue(null);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution (should timeout after 20 attempts * 100ms = 2 seconds)
+      await new Promise(resolve => setTimeout(resolve, 2500));
+
+      expect(mockWorkspace.getActiveFile).toHaveBeenCalledTimes(20);
+      expect(Notice).toHaveBeenCalledWith("Task created: test-task");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/MarkDoneCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/MarkDoneCommand.test.ts
@@ -1,0 +1,210 @@
+import { MarkDoneCommand } from "../../src/application/commands/MarkDoneCommand";
+import { TFile, Notice } from "obsidian";
+import { TaskStatusService, CommandVisibilityContext, LoggingService } from "@exocortex/core";
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual("obsidian"),
+  Notice: jest.fn(),
+}));
+jest.mock("@exocortex/core", () => ({
+  ...jest.requireActual("@exocortex/core"),
+  canMarkDone: jest.fn(),
+  LoggingService: {
+    error: jest.fn(),
+  },
+}));
+
+describe("MarkDoneCommand", () => {
+  let command: MarkDoneCommand;
+  let mockTaskStatusService: jest.Mocked<TaskStatusService>;
+  let mockFile: jest.Mocked<TFile>;
+  let mockContext: CommandVisibilityContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Create mock task status service
+    mockTaskStatusService = {
+      markTaskAsDone: jest.fn(),
+    } as unknown as jest.Mocked<TaskStatusService>;
+
+    // Create mock file
+    mockFile = {
+      path: "test-task.md",
+      basename: "test-task",
+    } as jest.Mocked<TFile>;
+
+    // Create mock context
+    mockContext = {
+      instanceClass: "Task",
+      status: "InProgress",
+      archived: false,
+      isDraft: false,
+    };
+
+    // Create command instance
+    command = new MarkDoneCommand(mockTaskStatusService);
+  });
+
+  describe("id and name", () => {
+    it("should have correct id and name", () => {
+      expect(command.id).toBe("mark-done");
+      expect(command.name).toBe("Mark as done");
+    });
+  });
+
+  describe("checkCallback", () => {
+    const mockCanMarkDone = require("@exocortex/core").canMarkDone;
+
+    it("should return false when context is null", () => {
+      const result = command.checkCallback(true, mockFile, null);
+      expect(result).toBe(false);
+      expect(mockTaskStatusService.markTaskAsDone).not.toHaveBeenCalled();
+    });
+
+    it("should return false when canMarkDone returns false", () => {
+      mockCanMarkDone.mockReturnValue(false);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(false);
+      expect(mockTaskStatusService.markTaskAsDone).not.toHaveBeenCalled();
+    });
+
+    it("should return true when canMarkDone returns true and checking is true", () => {
+      mockCanMarkDone.mockReturnValue(true);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(true);
+      expect(mockTaskStatusService.markTaskAsDone).not.toHaveBeenCalled();
+    });
+
+    it("should execute command when checking is false and canMarkDone returns true", async () => {
+      mockCanMarkDone.mockReturnValue(true);
+      mockTaskStatusService.markTaskAsDone.mockResolvedValue();
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(mockFile);
+      expect(Notice).toHaveBeenCalledWith("Marked as done: test-task");
+    });
+
+    it("should handle errors and show notice", async () => {
+      mockCanMarkDone.mockReturnValue(true);
+      const error = new Error("Failed to mark done");
+      mockTaskStatusService.markTaskAsDone.mockRejectedValue(error);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(mockFile);
+      expect(LoggingService.error).toHaveBeenCalledWith("Mark done error", error);
+      expect(Notice).toHaveBeenCalledWith("Failed to mark as done: Failed to mark done");
+    });
+
+    it("should handle different context statuses", () => {
+      mockCanMarkDone.mockReturnValue(true);
+
+      // Test with ToDo status
+      const todoContext = { ...mockContext, status: "ToDo" };
+      const result1 = command.checkCallback(true, mockFile, todoContext);
+      expect(result1).toBe(true);
+
+      // Test with Analysis status
+      const analysisContext = { ...mockContext, status: "Analysis" };
+      const result2 = command.checkCallback(true, mockFile, analysisContext);
+      expect(result2).toBe(true);
+
+      // Test with Done status (should typically return false from canMarkDone)
+      mockCanMarkDone.mockReturnValue(false);
+      const doneContext = { ...mockContext, status: "Done" };
+      const result3 = command.checkCallback(true, mockFile, doneContext);
+      expect(result3).toBe(false);
+    });
+
+    it("should handle files with special characters in basename", async () => {
+      mockCanMarkDone.mockReturnValue(true);
+      mockTaskStatusService.markTaskAsDone.mockResolvedValue();
+
+      const specialFile = {
+        path: "path/to/task-with-special-chars!@#$.md",
+        basename: "task-with-special-chars!@#$",
+      } as TFile;
+
+      const result = command.checkCallback(false, specialFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(specialFile);
+      expect(Notice).toHaveBeenCalledWith("Marked as done: task-with-special-chars!@#$");
+    });
+
+    it("should handle concurrent executions", async () => {
+      mockCanMarkDone.mockReturnValue(true);
+
+      // Create multiple files
+      const file1 = { path: "task1.md", basename: "task1" } as TFile;
+      const file2 = { path: "task2.md", basename: "task2" } as TFile;
+      const file3 = { path: "task3.md", basename: "task3" } as TFile;
+
+      // Mock service to take some time
+      mockTaskStatusService.markTaskAsDone.mockImplementation(
+        () => new Promise(resolve => setTimeout(resolve, 5))
+      );
+
+      // Execute commands concurrently
+      command.checkCallback(false, file1, mockContext);
+      command.checkCallback(false, file2, mockContext);
+      command.checkCallback(false, file3, mockContext);
+
+      // Wait for all async executions
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledTimes(3);
+      expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(file1);
+      expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(file2);
+      expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(file3);
+      expect(Notice).toHaveBeenCalledWith("Marked as done: task1");
+      expect(Notice).toHaveBeenCalledWith("Marked as done: task2");
+      expect(Notice).toHaveBeenCalledWith("Marked as done: task3");
+    });
+
+    it("should handle service returning undefined", async () => {
+      mockCanMarkDone.mockReturnValue(true);
+      mockTaskStatusService.markTaskAsDone.mockResolvedValue(undefined);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(mockFile);
+      expect(Notice).toHaveBeenCalledWith("Marked as done: test-task");
+      expect(LoggingService.error).not.toHaveBeenCalled();
+    });
+
+    it("should handle error without message property", async () => {
+      mockCanMarkDone.mockReturnValue(true);
+      const error = { toString: () => "Custom error" };
+      mockTaskStatusService.markTaskAsDone.mockRejectedValue(error);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(mockFile);
+      expect(LoggingService.error).toHaveBeenCalledWith("Mark done error", error);
+      // Since error doesn't have message property, it will use error.message which is undefined
+      expect(Notice).toHaveBeenCalledWith("Failed to mark as done: undefined");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/SetDraftStatusCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SetDraftStatusCommand.test.ts
@@ -1,0 +1,152 @@
+import { SetDraftStatusCommand } from "../../src/application/commands/SetDraftStatusCommand";
+import { TFile, Notice } from "obsidian";
+import { TaskStatusService, CommandVisibilityContext, LoggingService } from "@exocortex/core";
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual("obsidian"),
+  Notice: jest.fn(),
+}));
+jest.mock("@exocortex/core", () => ({
+  ...jest.requireActual("@exocortex/core"),
+  canSetDraftStatus: jest.fn(),
+  LoggingService: {
+    error: jest.fn(),
+  },
+}));
+
+describe("SetDraftStatusCommand", () => {
+  let command: SetDraftStatusCommand;
+  let mockTaskStatusService: jest.Mocked<TaskStatusService>;
+  let mockFile: jest.Mocked<TFile>;
+  let mockContext: CommandVisibilityContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Create mock task status service
+    mockTaskStatusService = {
+      setDraftStatus: jest.fn(),
+    } as unknown as jest.Mocked<TaskStatusService>;
+
+    // Create mock file
+    mockFile = {
+      path: "test-draft.md",
+      basename: "test-draft",
+    } as jest.Mocked<TFile>;
+
+    // Create mock context
+    mockContext = {
+      instanceClass: "Task",
+      status: "InProgress",
+      archived: false,
+      isDraft: false,
+    };
+
+    // Create command instance
+    command = new SetDraftStatusCommand(mockTaskStatusService);
+  });
+
+  describe("id and name", () => {
+    it("should have correct id and name", () => {
+      expect(command.id).toBe("set-draft-status");
+      expect(command.name).toBe("Set draft status");
+    });
+  });
+
+  describe("checkCallback", () => {
+    const mockCanSetDraftStatus = require("@exocortex/core").canSetDraftStatus;
+
+    it("should return false when context is null", () => {
+      const result = command.checkCallback(true, mockFile, null);
+      expect(result).toBe(false);
+      expect(mockTaskStatusService.setDraftStatus).not.toHaveBeenCalled();
+    });
+
+    it("should return false when canSetDraftStatus returns false", () => {
+      mockCanSetDraftStatus.mockReturnValue(false);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(false);
+      expect(mockTaskStatusService.setDraftStatus).not.toHaveBeenCalled();
+    });
+
+    it("should return true when canSetDraftStatus returns true and checking is true", () => {
+      mockCanSetDraftStatus.mockReturnValue(true);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(true);
+      expect(mockTaskStatusService.setDraftStatus).not.toHaveBeenCalled();
+    });
+
+    it("should execute command when checking is false and canSetDraftStatus returns true", async () => {
+      mockCanSetDraftStatus.mockReturnValue(true);
+      mockTaskStatusService.setDraftStatus.mockResolvedValue();
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.setDraftStatus).toHaveBeenCalledWith(mockFile);
+      expect(Notice).toHaveBeenCalledWith("Set Draft status: test-draft");
+    });
+
+    it("should handle errors and show notice", async () => {
+      mockCanSetDraftStatus.mockReturnValue(true);
+      const error = new Error("Failed to set draft");
+      mockTaskStatusService.setDraftStatus.mockRejectedValue(error);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.setDraftStatus).toHaveBeenCalledWith(mockFile);
+      expect(LoggingService.error).toHaveBeenCalledWith("Set draft status error", error);
+      expect(Notice).toHaveBeenCalledWith("Failed to set draft status: Failed to set draft");
+    });
+
+    it("should handle already draft context", () => {
+      mockCanSetDraftStatus.mockReturnValue(false);
+      const draftContext = { ...mockContext, isDraft: true };
+      const result = command.checkCallback(true, mockFile, draftContext);
+      expect(result).toBe(false);
+    });
+
+    it("should handle files with spaces in basename", async () => {
+      mockCanSetDraftStatus.mockReturnValue(true);
+      mockTaskStatusService.setDraftStatus.mockResolvedValue();
+
+      const spaceFile = {
+        path: "path/to/my draft task.md",
+        basename: "my draft task",
+      } as TFile;
+
+      const result = command.checkCallback(false, spaceFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.setDraftStatus).toHaveBeenCalledWith(spaceFile);
+      expect(Notice).toHaveBeenCalledWith("Set Draft status: my draft task");
+    });
+
+    it("should handle network errors", async () => {
+      mockCanSetDraftStatus.mockReturnValue(true);
+      const networkError = new Error("Network timeout");
+      networkError.message = "Network timeout";
+      mockTaskStatusService.setDraftStatus.mockRejectedValue(networkError);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.setDraftStatus).toHaveBeenCalledWith(mockFile);
+      expect(LoggingService.error).toHaveBeenCalledWith("Set draft status error", networkError);
+      expect(Notice).toHaveBeenCalledWith("Failed to set draft status: Network timeout");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/StartEffortCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/StartEffortCommand.test.ts
@@ -1,0 +1,135 @@
+import { StartEffortCommand } from "../../src/application/commands/StartEffortCommand";
+import { TFile, Notice } from "obsidian";
+import { TaskStatusService, CommandVisibilityContext, LoggingService } from "@exocortex/core";
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual("obsidian"),
+  Notice: jest.fn(),
+}));
+jest.mock("@exocortex/core", () => ({
+  ...jest.requireActual("@exocortex/core"),
+  canStartEffort: jest.fn(),
+  LoggingService: {
+    error: jest.fn(),
+  },
+}));
+
+describe("StartEffortCommand", () => {
+  let command: StartEffortCommand;
+  let mockTaskStatusService: jest.Mocked<TaskStatusService>;
+  let mockFile: jest.Mocked<TFile>;
+  let mockContext: CommandVisibilityContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Create mock task status service
+    mockTaskStatusService = {
+      startEffort: jest.fn(),
+    } as unknown as jest.Mocked<TaskStatusService>;
+
+    // Create mock file
+    mockFile = {
+      path: "test-effort.md",
+      basename: "test-effort",
+    } as jest.Mocked<TFile>;
+
+    // Create mock context
+    mockContext = {
+      instanceClass: "Effort",
+      status: "ToDo",
+      archived: false,
+      isDraft: false,
+    };
+
+    // Create command instance
+    command = new StartEffortCommand(mockTaskStatusService);
+  });
+
+  describe("id and name", () => {
+    it("should have correct id and name", () => {
+      expect(command.id).toBe("start-effort");
+      expect(command.name).toBe("Start effort");
+    });
+  });
+
+  describe("checkCallback", () => {
+    const mockCanStartEffort = require("@exocortex/core").canStartEffort;
+
+    it("should return false when context is null", () => {
+      const result = command.checkCallback(true, mockFile, null);
+      expect(result).toBe(false);
+      expect(mockTaskStatusService.startEffort).not.toHaveBeenCalled();
+    });
+
+    it("should return false when canStartEffort returns false", () => {
+      mockCanStartEffort.mockReturnValue(false);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(false);
+      expect(mockTaskStatusService.startEffort).not.toHaveBeenCalled();
+    });
+
+    it("should return true when canStartEffort returns true and checking is true", () => {
+      mockCanStartEffort.mockReturnValue(true);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(true);
+      expect(mockTaskStatusService.startEffort).not.toHaveBeenCalled();
+    });
+
+    it("should execute command when checking is false and canStartEffort returns true", async () => {
+      mockCanStartEffort.mockReturnValue(true);
+      mockTaskStatusService.startEffort.mockResolvedValue();
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.startEffort).toHaveBeenCalledWith(mockFile);
+      expect(Notice).toHaveBeenCalledWith("Started effort: test-effort");
+    });
+
+    it("should handle errors and show notice", async () => {
+      mockCanStartEffort.mockReturnValue(true);
+      const error = new Error("Failed to start");
+      mockTaskStatusService.startEffort.mockRejectedValue(error);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.startEffort).toHaveBeenCalledWith(mockFile);
+      expect(LoggingService.error).toHaveBeenCalledWith("Start effort error", error);
+      expect(Notice).toHaveBeenCalledWith("Failed to start effort: Failed to start");
+    });
+
+    it("should handle already started effort", () => {
+      mockCanStartEffort.mockReturnValue(false);
+      const inProgressContext = { ...mockContext, status: "InProgress" };
+      const result = command.checkCallback(true, mockFile, inProgressContext);
+      expect(result).toBe(false);
+    });
+
+    it("should handle effort with Unicode characters in basename", async () => {
+      mockCanStartEffort.mockReturnValue(true);
+      mockTaskStatusService.startEffort.mockResolvedValue();
+
+      const unicodeFile = {
+        path: "path/to/努力-测试.md",
+        basename: "努力-测试",
+      } as TFile;
+
+      const result = command.checkCallback(false, unicodeFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockTaskStatusService.startEffort).toHaveBeenCalledWith(unicodeFile);
+      expect(Notice).toHaveBeenCalledWith("Started effort: 努力-测试");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive test suites for 5 command classes
- 48 new test cases covering all command behavior
- Achieve improved test coverage for command layer

## Test coverage added
- ✅ CreateTaskCommand: 12 test cases
- ✅ MarkDoneCommand: 11 test cases  
- ✅ ArchiveTaskCommand: 10 test cases
- ✅ StartEffortCommand: 7 test cases
- ✅ SetDraftStatusCommand: 8 test cases

## Test scenarios covered
- Command ID and name verification
- checkCallback with various contexts
- Command execution success paths
- Error handling and notice display
- Edge cases (Unicode characters, concurrent execution, network errors)
- Null/undefined context handling
- Modal cancellation flows

## Related to
- Issue #156: Increase test coverage to 70%
- Continuing the test coverage improvement initiative

This PR adds comprehensive test coverage for the command layer, ensuring all commands are thoroughly tested with proper mocking and error handling verification.