### PR TITLE
fix: include core package tests in CI coverage

### DIFF
--- a/packages/obsidian-plugin/jest.config.js
+++ b/packages/obsidian-plugin/jest.config.js
@@ -1,7 +1,10 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
-  testMatch: ["<rootDir>/tests/unit/**/*.test.ts"],
+  testMatch: [
+    "<rootDir>/tests/unit/**/*.test.ts",
+    "<rootDir>/../core/tests/**/*.test.ts",
+  ],
   testPathIgnorePatterns: [
     "/node_modules/",
     "/tests/ui/",


### PR DESCRIPTION
## Problem

CI was only running tests from `packages/obsidian-plugin/tests/unit/`, missing tests in `packages/core/tests/services/`.

**Root cause**: `testMatch` in `jest.config.js` only included obsidian-plugin tests:
```js
testMatch: ["<rootDir>/tests/unit/**/*.test.ts"],
```

While `collectCoverageFrom` included core source files, the tests for those files weren't being executed!

## Solution

Updated `testMatch` to include both test locations:
```js
testMatch: [
    "<rootDir>/tests/unit/**/*.test.ts",
    "<rootDir>/../core/tests/**/*.test.ts",  // ← Added
],
```

## Impact

Now runs 3 additional unique test suites that weren't executed before:
- `LoggingService.test.ts` (from PR #194)
- `PlanningService.test.ts` (from PR #194)
- `StatusTimestampService.test.ts` (pre-existing)

This should improve global coverage toward the 70% target (Issue #156).

## Test Plan

- ✅ All tests pass locally with new config
- ✅ Pre-commit hooks pass
- ⏳ Monitoring CI for coverage improvement

Fixes #156