### PR TITLE
fix: enforce code coverage thresholds in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,6 @@ jobs:
           export NODE_OPTIONS="--max-old-space-size=4096"
           export COVERAGE=true
           ./scripts/test-ci-batched.sh || exit 1
-        continue-on-error: true
 
       - name: Generate coverage summary
         if: always()


### PR DESCRIPTION
## Problem

Currently, the CI pipeline has `continue-on-error: true` in the `test-coverage` job, which allows PRs to be merged even when code coverage falls below minimum thresholds.

**Risk**: Technical debt accumulates as new code can be merged without adequate test coverage.

## Solution

Remove `continue-on-error: true` from the `test-coverage` job in `.github/workflows/ci.yml`.

Now CI will **fail** if code coverage is below thresholds, preventing PRs with insufficient coverage from being merged.

## Changes

- Removed `continue-on-error: true` from line 133 in `.github/workflows/ci.yml`
- No other changes needed - coverage thresholds already configured in jest.config.js

## Coverage Thresholds Enforced

- **packages/core**: 95% (all metrics)
- **packages/obsidian-plugin**: 
  - Global: 70-73% (branches, functions, lines, statements)
  - Domain layer: 78-80%

## Testing

✅ Tested locally with `npm run test:all` - all tests pass
✅ Coverage script properly exits with error code when thresholds not met
✅ Pre-commit hooks pass

## Related

Closes #197

---

**Impact**: Enforces quality standards and prevents regression in test coverage.