### PR TITLE
fix: convert IFile to TFile before opening in workspace (Issue #161)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -129,8 +129,12 @@ export class ButtonGroupsBuilder {
             result.label,
             result.taskSize,
           );
+          const tFile = this.app.vault.getAbstractFileByPath(createdFile.path);
+          if (!tFile || !(tFile instanceof TFile)) {
+            throw new Error(`Created file not found: ${createdFile.path}`);
+          }
           const leaf = this.app.workspace.getLeaf("tab");
-          await leaf.openFile(createdFile);
+          await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(
             `Created Task from ${sourceClass}: ${createdFile.path}`,
@@ -158,8 +162,12 @@ export class ButtonGroupsBuilder {
             sourceClass,
             result.label,
           );
+          const tFile = this.app.vault.getAbstractFileByPath(createdFile.path);
+          if (!tFile || !(tFile instanceof TFile)) {
+            throw new Error(`Created file not found: ${createdFile.path}`);
+          }
           const leaf = this.app.workspace.getLeaf("tab");
-          await leaf.openFile(createdFile);
+          await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(
             `Created Project from ${sourceClass}: ${createdFile.path}`,
@@ -182,8 +190,12 @@ export class ButtonGroupsBuilder {
             metadata,
             result.label,
           );
+          const tFile = this.app.vault.getAbstractFileByPath(createdFile.path);
+          if (!tFile || !(tFile instanceof TFile)) {
+            throw new Error(`Created file not found: ${createdFile.path}`);
+          }
           const leaf = this.app.workspace.getLeaf("tab");
-          await leaf.openFile(createdFile);
+          await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(`Created child Area: ${createdFile.path}`);
         },
@@ -223,8 +235,12 @@ export class ButtonGroupsBuilder {
             result.label,
             result.taskSize,
           );
+          const tFile = this.app.vault.getAbstractFileByPath(createdFile.path);
+          if (!tFile || !(tFile instanceof TFile)) {
+            throw new Error(`Created file not found: ${createdFile.path}`);
+          }
           const leaf = this.app.workspace.getLeaf("tab");
-          await leaf.openFile(createdFile);
+          await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(
             `Created Instance from TaskPrototype: ${createdFile.path}`,
@@ -248,8 +264,12 @@ export class ButtonGroupsBuilder {
             result.label,
             result.taskSize,
           );
+          const tFile = this.app.vault.getAbstractFileByPath(createdFile.path);
+          if (!tFile || !(tFile instanceof TFile)) {
+            throw new Error(`Created file not found: ${createdFile.path}`);
+          }
           const leaf = this.app.workspace.getLeaf("tab");
-          await leaf.openFile(createdFile);
+          await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(`Created Related Task: ${createdFile.path}`);
         },
@@ -274,8 +294,12 @@ export class ButtonGroupsBuilder {
               result.definition,
               result.aliases,
             );
+          const tFile = this.app.vault.getAbstractFileByPath(createdFile.path);
+          if (!tFile || !(tFile instanceof TFile)) {
+            throw new Error(`Created file not found: ${createdFile.path}`);
+          }
           const leaf = this.app.workspace.getLeaf("tab");
-          await leaf.openFile(createdFile);
+          await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(`Created Narrower Concept: ${createdFile.path}`);
         },

--- a/packages/obsidian-plugin/tests/e2e/specs/algorithm-block-extraction.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/algorithm-block-extraction.spec.ts
@@ -17,13 +17,7 @@ test.describe("Algorithm Block Extraction from TaskPrototype", () => {
     await launcher.close();
   });
 
-  // SKIPPED: These tests are flaky in headless Docker environments.
-  // The Create Instance command executes successfully (files are created),
-  // but workspace.getActiveFile() is unreliable in headless Electron.
-  // This is a known limitation of E2E testing with Obsidian in Docker.
-  // Core functionality verified by 930+ passing unit/component/integration tests.
-  // TODO: Re-enable when Obsidian provides better E2E workspace state support.
-  test.skip("should copy Algorithm section when creating instance from TaskPrototype", async () => {
+  test("should copy Algorithm section when creating instance from TaskPrototype", async () => {
     // Open the TaskPrototype file
     await launcher.openFile("Tasks/bug-fix-prototype.md");
 
@@ -101,7 +95,7 @@ test.describe("Algorithm Block Extraction from TaskPrototype", () => {
     );
   });
 
-  test.skip("should create empty body when TaskPrototype has no Algorithm section", async () => {
+  test("should create empty body when TaskPrototype has no Algorithm section", async () => {
     // Open the pre-existing TaskPrototype file without Algorithm section
     await launcher.openFile("Tasks/simple-prototype.md");
 


### PR DESCRIPTION
## Summary

Fixes #161 - E2E tests for "Create Instance" command were failing after IVaultAdapter refactoring (PR #160).

## Root Cause

After the IVaultAdapter refactoring, creation services now return IFile (abstract interface) instead of TFile (Obsidian concrete type). The UI layer was trying to pass IFile directly to leaf.openFile(), which expects TFile, causing workspace activation to fail.

This caused workspace.getActiveFile() to return null in E2E tests because the newly created file wasn't being opened/activated properly.

## Changes

- Convert IFile to TFile using vault.getAbstractFileByPath() with proper instanceof TFile check (ESLint obsidianmd/no-tfile-tfolder-cast compliant) before calling leaf.openFile() in 6 creation buttons:
  * Create Task
  * Create Project
  * Create Area
  * Create Instance (primary fix for E2E test failure)
  * Create Related Task
  * Create Narrower Concept

- Re-enable 2 E2E tests that were skipped (test.skip → test):
  * "should copy Algorithm section when creating instance from TaskPrototype"
  * "should create empty body when TaskPrototype has no Algorithm section"

## Design Pattern

The adapter provides IFile for storage-agnostic design (core package doesn't know about Obsidian), but the UI layer needs concrete TFile for workspace operations. The fix properly bridges this abstraction gap with type-safe conversion.

## Test Plan

- All unit tests pass (1428 tests)
- All component tests pass (218 tests)  
- BDD coverage: 100%
- ESLint: No errors
- Build succeeds
- E2E tests will be verified in CI

## Files Changed

- packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts - Add IFile→TFile conversion with instanceof check
- packages/obsidian-plugin/tests/e2e/specs/algorithm-block-extraction.spec.ts - Re-enable skipped tests

Fixes #161