### PR TITLE
Add global fleeting note creation command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,12 @@
 - Claude-specific slash-command automation described in `CLAUDE.md` is **not** available here. Instead, run the underlying npm scripts yourself while preserving the intent of those guardrails (structured planning, parallel quality checks, and gated releases).
 - Consult architectural background in `ARCHITECTURE.md`, domain references in `docs/`, task history in `.claude/`, and existing specs/tests before making changes.
 
+## Worktree Discipline (non-negotiable)
+- **Never edit the root checkout.** All implementation work must happen inside a designated Git worktree (e.g. `worktrees/<branch-name>/…`). If `pwd` shows the repository root, stop and move to the correct worktree before touching files.
+- **Verify location before each change.** Run `pwd` and `git rev-parse --show-toplevel`; the toplevel must resolve inside the active worktree directory. Abort immediately if it points to the main repo.
+- **Create or switch worktrees explicitly.** Use `git worktree list` to inspect existing entries. Add a new one with `git worktree add worktrees/<name> <branch>` when starting fresh, and jump into it with `cd worktrees/<name>`.
+- **Keep tooling scoped to the worktree.** Every command (`npm install`, `npm test`, editor sessions) should execute within the worktree to avoid polluting the main checkout.
+
 ## Setup Commands
 - Install dependencies: `npm install`
 - Start the development build (esbuild bundler): `npm run dev`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export { PropertyCleanupService } from "./services/PropertyCleanupService";
 export { RenameToUidService } from "./services/RenameToUidService";
 export { StatusTimestampService } from "./services/StatusTimestampService";
 export { SupervisionCreationService } from "./services/SupervisionCreationService";
+export { FleetingNoteCreationService } from "./services/FleetingNoteCreationService";
 export { TaskFrontmatterGenerator } from "./services/TaskFrontmatterGenerator";
 export { AlgorithmExtractor } from "./services/AlgorithmExtractor";
 export { PlanningService } from "./services/PlanningService";

--- a/packages/core/src/services/FleetingNoteCreationService.ts
+++ b/packages/core/src/services/FleetingNoteCreationService.ts
@@ -1,0 +1,52 @@
+import { v4 as uuidv4 } from "uuid";
+import { DateFormatter } from "../utilities/DateFormatter";
+import { MetadataHelpers } from "../utilities/MetadataHelpers";
+import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+
+/**
+ * Service responsible for creating fleeting note assets.
+ *
+ * Generates required frontmatter and persists the file inside the inbox folder.
+ */
+export class FleetingNoteCreationService {
+  private static readonly INBOX_FOLDER = "01 Inbox";
+
+  constructor(private vault: IVaultAdapter) {}
+
+  /**
+   * Creates a new fleeting note asset using provided label as display name.
+   *
+   * @param label - Required label for the new asset
+   * @returns The created file descriptor
+   */
+  async createFleetingNote(label: string): Promise<IFile> {
+    const uid = uuidv4();
+    const fileName = `${uid}.md`;
+    const frontmatter = this.generateFrontmatter(uid, label);
+    const fileContent = MetadataHelpers.buildFileContent(frontmatter);
+
+    const filePath = `${FleetingNoteCreationService.INBOX_FOLDER}/${fileName}`;
+
+    const createdFile = await this.vault.create(filePath, fileContent);
+
+    return createdFile;
+  }
+
+  private generateFrontmatter(uid: string, label: string): Record<string, any> {
+    const now = new Date();
+    const timestamp = DateFormatter.toLocalTimestamp(now);
+
+    const trimmedLabel = label.trim();
+
+    const frontmatter: Record<string, any> = {
+      exo__Asset_isDefinedBy: '"[[!kitelev]]"',
+      exo__Asset_uid: uid,
+      exo__Asset_createdAt: timestamp,
+      exo__Instance_class: ['"[[ztlk__FleetingNote]]"'],
+      exo__Asset_label: trimmedLabel,
+      aliases: [trimmedLabel],
+    };
+
+    return frontmatter;
+  }
+}

--- a/packages/core/tests/services/FleetingNoteCreationService.test.ts
+++ b/packages/core/tests/services/FleetingNoteCreationService.test.ts
@@ -1,0 +1,61 @@
+import { FleetingNoteCreationService } from "../../src/services/FleetingNoteCreationService";
+import { IVaultAdapter, IFile } from "../../src/interfaces/IVaultAdapter";
+import { DateFormatter } from "../../src/utilities/DateFormatter";
+import { MetadataHelpers } from "../../src/utilities/MetadataHelpers";
+
+jest.mock("../../src/utilities/DateFormatter");
+jest.mock("../../src/utilities/MetadataHelpers");
+jest.mock("uuid", () => ({ v4: () => "test-uuid-123" }));
+
+describe("FleetingNoteCreationService", () => {
+  let service: FleetingNoteCreationService;
+  let mockVault: jest.Mocked<IVaultAdapter>;
+  const mockTimestamp = "2025-01-15T10:30:00";
+
+  beforeEach(() => {
+    mockVault = {
+      create: jest.fn(),
+    } as unknown as jest.Mocked<IVaultAdapter>;
+
+    (DateFormatter.toLocalTimestamp as jest.Mock).mockReturnValue(mockTimestamp);
+    (MetadataHelpers.buildFileContent as jest.Mock).mockReturnValue("---\nfrontmatter\n---\n");
+
+    service = new FleetingNoteCreationService(mockVault);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates fleeting note with trimmed label and expected frontmatter", async () => {
+    const createdFile = {
+      path: "01 Inbox/test-uuid-123.md",
+      basename: "test-uuid-123",
+      name: "test-uuid-123.md",
+    } as IFile;
+    mockVault.create.mockResolvedValue(createdFile);
+
+    const result = await service.createFleetingNote("  My note label  ");
+
+    expect(MetadataHelpers.buildFileContent).toHaveBeenCalledWith({
+      exo__Asset_isDefinedBy: '"[[!kitelev]]"',
+      exo__Asset_uid: "test-uuid-123",
+      exo__Asset_createdAt: mockTimestamp,
+      exo__Instance_class: ['"[[ztlk__FleetingNote]]"'],
+      exo__Asset_label: "My note label",
+      aliases: ["My note label"],
+    });
+    expect(mockVault.create).toHaveBeenCalledWith(
+      "01 Inbox/test-uuid-123.md",
+      "---\nfrontmatter\n---\n",
+    );
+    expect(result).toBe(createdFile);
+  });
+
+  it("propagates vault errors", async () => {
+    const error = new Error("Vault create failed");
+    mockVault.create.mockRejectedValue(error);
+
+    await expect(service.createFleetingNote("Label")).rejects.toThrow(error);
+  });
+});

--- a/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
+++ b/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
@@ -13,11 +13,13 @@ import {
   EffortVotingService,
   LabelToAliasService,
   AssetConversionService,
+  FleetingNoteCreationService,
 } from "@exocortex/core";
 
 import { CreateTaskCommand } from "./CreateTaskCommand";
 import { CreateProjectCommand } from "./CreateProjectCommand";
 import { CreateInstanceCommand } from "./CreateInstanceCommand";
+import { CreateFleetingNoteCommand } from "./CreateFleetingNoteCommand";
 import { CreateRelatedTaskCommand } from "./CreateRelatedTaskCommand";
 import { SetDraftStatusCommand } from "./SetDraftStatusCommand";
 import { MoveToBacklogCommand } from "./MoveToBacklogCommand";
@@ -65,11 +67,13 @@ export class CommandRegistry {
     const effortVotingService = new EffortVotingService(this.vaultAdapter);
     const labelToAliasService = new LabelToAliasService(this.vaultAdapter);
     const assetConversionService = new AssetConversionService(this.vaultAdapter);
+    const fleetingNoteCreationService = new FleetingNoteCreationService(this.vaultAdapter);
 
     this.commands = [
       new CreateTaskCommand(app, taskCreationService, this.vaultAdapter),
       new CreateProjectCommand(app, projectCreationService, this.vaultAdapter),
       new CreateInstanceCommand(app, taskCreationService, this.vaultAdapter),
+      new CreateFleetingNoteCommand(app, fleetingNoteCreationService, this.vaultAdapter),
       new CreateRelatedTaskCommand(app, taskCreationService, this.vaultAdapter),
       new SetDraftStatusCommand(taskStatusService),
       new MoveToBacklogCommand(taskStatusService),

--- a/packages/obsidian-plugin/src/application/commands/CreateFleetingNoteCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateFleetingNoteCommand.ts
@@ -1,0 +1,44 @@
+import { App, Notice } from "obsidian";
+import {
+  FleetingNoteCreationService,
+  LoggingService,
+} from "@exocortex/core";
+import { ICommand } from "./ICommand";
+import { FleetingNoteModal, FleetingNoteModalResult } from "../../presentation/modals/FleetingNoteModal";
+import { ObsidianVaultAdapter } from "../../adapters/ObsidianVaultAdapter";
+import { CommandHelpers } from "./helpers/CommandHelpers";
+
+export class CreateFleetingNoteCommand implements ICommand {
+  id = "create-fleeting-note";
+  name = "Create fleeting note";
+
+  constructor(
+    private app: App,
+    private fleetingNoteCreationService: FleetingNoteCreationService,
+    private vaultAdapter: ObsidianVaultAdapter,
+  ) {}
+
+  callback = async (): Promise<void> => {
+    try {
+      const result = await new Promise<FleetingNoteModalResult>((resolve) => {
+        new FleetingNoteModal(this.app, resolve).open();
+      });
+
+      if (result.label === null) {
+        return;
+      }
+
+      const createdFile = await this.fleetingNoteCreationService.createFleetingNote(
+        result.label,
+      );
+
+      const tfile = this.vaultAdapter.toTFile(createdFile);
+      await CommandHelpers.openFileInNewTab(this.app, tfile);
+
+      new Notice(`Fleeting note created: ${createdFile.basename}`);
+    } catch (error: any) {
+      new Notice(`Failed to create fleeting note: ${error.message}`);
+      LoggingService.error("Create fleeting note error", error);
+    }
+  };
+}

--- a/packages/obsidian-plugin/src/presentation/modals/FleetingNoteModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/FleetingNoteModal.ts
@@ -1,0 +1,114 @@
+import { App, Modal } from "obsidian";
+
+export interface FleetingNoteModalResult {
+  label: string | null;
+}
+
+/**
+ * Modal that collects a required label for fleeting note creation.
+ */
+export class FleetingNoteModal extends Modal {
+  private label = "";
+  private onSubmit: (result: FleetingNoteModalResult) => void;
+  private inputEl: HTMLInputElement | null = null;
+  private errorEl: HTMLDivElement | null = null;
+
+  constructor(app: App, onSubmit: (result: FleetingNoteModalResult) => void) {
+    super(app);
+    this.onSubmit = onSubmit;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+
+    contentEl.addClass("exocortex-fleeting-note-modal");
+
+    contentEl.createEl("h2", { text: "Create fleeting note" });
+
+    const inputContainer = contentEl.createDiv({
+      cls: "exocortex-modal-input-container",
+    });
+
+    this.inputEl = inputContainer.createEl("input", {
+      type: "text",
+      placeholder: "Label",
+      cls: "exocortex-modal-input",
+    });
+
+    const errorElement = contentEl.createDiv({
+      cls: "exocortex-modal-error-message",
+    });
+    errorElement.style.display = "none";
+    this.errorEl = errorElement;
+
+    this.inputEl.addEventListener("input", (event) => {
+      this.label = (event.target as HTMLInputElement).value;
+      this.clearErrorState();
+    });
+
+    this.inputEl.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        this.submit();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        this.cancel();
+      }
+    });
+
+    const buttonContainer = contentEl.createDiv({
+      cls: "modal-button-container",
+    });
+
+    const createButton = buttonContainer.createEl("button", {
+      text: "Create",
+      cls: "mod-cta",
+    });
+    createButton.addEventListener("click", () => this.submit());
+
+    const cancelButton = buttonContainer.createEl("button", {
+      text: "Cancel",
+    });
+    cancelButton.addEventListener("click", () => this.cancel());
+
+    window.setTimeout(() => {
+      this.inputEl?.focus();
+    }, 50);
+  }
+
+  private submit(): void {
+    const trimmedLabel = this.label.trim();
+    if (!trimmedLabel) {
+      this.showError("Label is required");
+      return;
+    }
+
+    this.onSubmit({ label: trimmedLabel });
+    this.close();
+  }
+
+  private cancel(): void {
+    this.onSubmit({ label: null });
+    this.close();
+  }
+
+  private showError(message: string): void {
+    this.inputEl?.classList.add("exocortex-modal-input--error");
+    if (this.errorEl) {
+      this.errorEl.textContent = message;
+      this.errorEl.style.display = "";
+    }
+  }
+
+  private clearErrorState(): void {
+    this.inputEl?.classList.remove("exocortex-modal-input--error");
+    if (this.errorEl) {
+      this.errorEl.style.display = "none";
+      this.errorEl.textContent = "";
+    }
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -905,6 +905,17 @@
   font-weight: 500;
 }
 
+.exocortex-modal-input--error {
+  border-color: var(--text-error);
+  box-shadow: 0 0 0 1px var(--text-error);
+}
+
+.exocortex-modal-error-message {
+  margin-top: 8px;
+  color: var(--text-error);
+  font-size: 0.85em;
+}
+
 /* ============================================================================
    Action Buttons Group - Semantic Grouping with Beautiful Design
    ============================================================================ */

--- a/packages/obsidian-plugin/tests/unit/CommandManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CommandManager.test.ts
@@ -2,7 +2,7 @@
  * CommandManager Unit Tests
  *
  * Comprehensive test coverage for command registration, visibility checks,
- * and execution paths. Tests all 26 commands with various file contexts.
+ * and execution paths. Tests all 29 commands with various file contexts.
  */
 
 import { CommandManager } from "../../src/application/services/CommandManager";
@@ -124,7 +124,7 @@ describe("CommandManager", () => {
         commandManager.registerAllCommands(mockPlugin);
       }).not.toThrow();
 
-      expect(mockPlugin.addCommand).toHaveBeenCalledTimes(28);
+      expect(mockPlugin.addCommand).toHaveBeenCalledTimes(29);
     });
 
     it("should register commands with correct IDs", () => {
@@ -138,6 +138,7 @@ describe("CommandManager", () => {
       expect(registeredCommandIds).toContain("create-task");
       expect(registeredCommandIds).toContain("create-project");
       expect(registeredCommandIds).toContain("create-instance");
+      expect(registeredCommandIds).toContain("create-fleeting-note");
       expect(registeredCommandIds).toContain("create-related-task");
       expect(registeredCommandIds).toContain("set-draft-status");
       expect(registeredCommandIds).toContain("move-to-backlog");
@@ -176,6 +177,7 @@ describe("CommandManager", () => {
       expect(registeredNames).toContain("Create task");
       expect(registeredNames).toContain("Create project");
       expect(registeredNames).toContain("Create instance");
+      expect(registeredNames).toContain("Create fleeting note");
       expect(registeredNames).toContain("Create related task");
       expect(registeredNames).toContain("Set draft status");
       expect(registeredNames).toContain("Move to backlog");

--- a/packages/obsidian-plugin/tests/unit/CreateFleetingNoteCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CreateFleetingNoteCommand.test.ts
@@ -1,0 +1,126 @@
+import { CreateFleetingNoteCommand } from "../../src/application/commands/CreateFleetingNoteCommand";
+import { App, Notice, TFile } from "obsidian";
+import {
+  FleetingNoteCreationService,
+  LoggingService,
+} from "@exocortex/core";
+import { FleetingNoteModal } from "../../src/presentation/modals/FleetingNoteModal";
+import { ObsidianVaultAdapter } from "../../src/adapters/ObsidianVaultAdapter";
+import { CommandHelpers } from "../../src/application/commands/helpers/CommandHelpers";
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual("obsidian"),
+  Notice: jest.fn(),
+}));
+
+jest.mock("../../src/presentation/modals/FleetingNoteModal");
+
+jest.mock("@exocortex/core", () => ({
+  ...jest.requireActual("@exocortex/core"),
+  LoggingService: {
+    error: jest.fn(),
+  },
+}));
+
+describe("CreateFleetingNoteCommand", () => {
+  let command: CreateFleetingNoteCommand;
+  let mockApp: jest.Mocked<App>;
+  let mockFleetingNoteCreationService: jest.Mocked<FleetingNoteCreationService>;
+  let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
+  let mockTFile: jest.Mocked<TFile>;
+  let openFileSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockApp = {
+      workspace: {},
+    } as unknown as jest.Mocked<App>;
+
+    mockTFile = {
+      path: "01 Inbox/test.md",
+      basename: "test",
+    } as jest.Mocked<TFile>;
+
+    mockFleetingNoteCreationService = {
+      createFleetingNote: jest.fn(),
+    } as unknown as jest.Mocked<FleetingNoteCreationService>;
+
+    mockVaultAdapter = {
+      toTFile: jest.fn().mockReturnValue(mockTFile),
+    } as unknown as jest.Mocked<ObsidianVaultAdapter>;
+
+    openFileSpy = jest
+      .spyOn(CommandHelpers, "openFileInNewTab")
+      .mockResolvedValue(undefined);
+
+    command = new CreateFleetingNoteCommand(
+      mockApp,
+      mockFleetingNoteCreationService,
+      mockVaultAdapter,
+    );
+  });
+
+  afterEach(() => {
+    openFileSpy.mockRestore();
+  });
+
+  it("should have correct id and name", () => {
+    expect(command.id).toBe("create-fleeting-note");
+    expect(command.name).toBe("Create fleeting note");
+  });
+
+  it("creates fleeting note when modal provides label", async () => {
+    const createdFile = {
+      basename: "test",
+      path: "01 Inbox/test.md",
+    };
+    mockFleetingNoteCreationService.createFleetingNote.mockResolvedValue(
+      createdFile as any,
+    );
+
+    (FleetingNoteModal as jest.Mock).mockImplementation((app, callback) => ({
+      open: jest.fn(() => {
+        callback({ label: "Test note" });
+      }),
+    }));
+
+    await command.callback();
+
+    expect(FleetingNoteModal).toHaveBeenCalledWith(mockApp, expect.any(Function));
+    expect(mockFleetingNoteCreationService.createFleetingNote).toHaveBeenCalledWith("Test note");
+    expect(mockVaultAdapter.toTFile).toHaveBeenCalledWith(createdFile);
+    expect(openFileSpy).toHaveBeenCalledWith(mockApp, mockTFile);
+    expect(Notice).toHaveBeenCalledWith("Fleeting note created: test");
+  });
+
+  it("does nothing when modal is cancelled", async () => {
+    (FleetingNoteModal as jest.Mock).mockImplementation((app, callback) => ({
+      open: jest.fn(() => {
+        callback({ label: null });
+      }),
+    }));
+
+    await command.callback();
+
+    expect(mockFleetingNoteCreationService.createFleetingNote).not.toHaveBeenCalled();
+    expect(openFileSpy).not.toHaveBeenCalled();
+    expect(Notice).not.toHaveBeenCalled();
+  });
+
+  it("handles service errors gracefully", async () => {
+    const error = new Error("Vault failure");
+    mockFleetingNoteCreationService.createFleetingNote.mockRejectedValue(error);
+
+    (FleetingNoteModal as jest.Mock).mockImplementation((app, callback) => ({
+      open: jest.fn(() => {
+        callback({ label: "Test note" });
+      }),
+    }));
+
+    await command.callback();
+
+    expect(LoggingService.error).toHaveBeenCalledWith("Create fleeting note error", error);
+    expect(Notice).toHaveBeenCalledWith("Failed to create fleeting note: Vault failure");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/FleetingNoteModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FleetingNoteModal.test.ts
@@ -1,0 +1,96 @@
+import { App } from "obsidian";
+import { FleetingNoteModal, FleetingNoteModalResult } from "../../src/presentation/modals/FleetingNoteModal";
+
+describe("FleetingNoteModal", () => {
+  let mockApp: App;
+  let onSubmit: jest.Mock<void, [FleetingNoteModalResult]>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockApp = {} as App;
+    onSubmit = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  const openModal = (): FleetingNoteModal => {
+    const modal = new FleetingNoteModal(mockApp, onSubmit);
+    modal.open();
+    jest.runAllTimers();
+    return modal;
+  };
+
+  it("shows validation error when label is empty", () => {
+    const modal = openModal();
+
+    const createButton = modal.contentEl.querySelector("button.mod-cta") as HTMLButtonElement;
+    createButton.click();
+
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    expect(input.classList.contains("exocortex-modal-input--error")).toBe(true);
+
+    const errorMessage = modal.contentEl.querySelector(
+      ".exocortex-modal-error-message",
+    ) as HTMLDivElement;
+    expect(errorMessage.textContent).toBe("Label is required");
+    expect(errorMessage.style.display).not.toBe("none");
+
+    modal.close();
+  });
+
+  it("clears error state and submits trimmed label", () => {
+    const modal = openModal();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    const createButton = modal.contentEl.querySelector("button.mod-cta") as HTMLButtonElement;
+
+    createButton.click();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    input.value = "  Test label  ";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(input.classList.contains("exocortex-modal-input--error")).toBe(false);
+    const errorMessage = modal.contentEl.querySelector(
+      ".exocortex-modal-error-message",
+    ) as HTMLDivElement;
+    expect(errorMessage.style.display).toBe("none");
+    expect(errorMessage.textContent).toBe("");
+
+    createButton.click();
+
+    expect(onSubmit).toHaveBeenCalledWith({ label: "Test label" });
+
+    modal.close();
+  });
+
+  it("returns null label on cancel", () => {
+    const modal = openModal();
+
+    const cancelButton = Array.from(
+      modal.contentEl.querySelectorAll("button"),
+    ).find((button) => button.textContent === "Cancel") as HTMLButtonElement;
+
+    cancelButton.click();
+
+    expect(onSubmit).toHaveBeenCalledWith({ label: null });
+  });
+
+  it("submits when pressing Enter", () => {
+    const modal = openModal();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    input.value = "Keyboard submit";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ label: "Keyboard submit" });
+  });
+});


### PR DESCRIPTION
## Summary
- add FleetingNoteCreationService for inbox notes with required metadata
- register global palette command with validation modal and styling
- cover new flow with targeted unit tests and codify worktree discipline in AGENTS.md

## Testing
- npx jest --config packages/obsidian-plugin/jest.config.js --runTestsByPath packages/core/tests/services/FleetingNoteCreationService.test.ts packages/obsidian-plugin/tests/unit/FleetingNoteModal.test.ts packages/obsidian-plugin/tests/unit/CreateFleetingNoteCommand.test.ts packages/obsidian-plugin/tests/unit/CommandManager.test.ts
