### PR TITLE
feat: auto-sync plannedEndTimestamp when plannedStartTimestamp changes

### DIFF
--- a/packages/core/src/services/StatusTimestampService.ts
+++ b/packages/core/src/services/StatusTimestampService.ts
@@ -110,4 +110,21 @@ export class StatusTimestampService {
     );
     await this.vault.modify(taskFile, updated);
   }
+
+  async syncPlannedEndTimestamp(
+    taskFile: IFile,
+    date?: Date,
+  ): Promise<void> {
+    const content = await this.vault.read(taskFile);
+    const targetDate = date || new Date();
+    const timestamp = DateFormatter.toLocalTimestamp(targetDate);
+
+    const updated = this.frontmatterService.updateProperty(
+      content,
+      "ems__Effort_plannedEndTimestamp",
+      timestamp,
+    );
+
+    await this.vault.modify(taskFile, updated);
+  }
 }

--- a/packages/core/src/services/TaskStatusService.ts
+++ b/packages/core/src/services/TaskStatusService.ts
@@ -76,6 +76,10 @@ export class TaskStatusService {
     await this.timestampService.addEndAndResolutionTimestamps(taskFile, date);
   }
 
+  async syncPlannedEndTimestamp(taskFile: IFile, date?: Date): Promise<void> {
+    await this.timestampService.syncPlannedEndTimestamp(taskFile, date);
+  }
+
   async trashEffort(taskFile: IFile): Promise<void> {
     const content = await this.vault.read(taskFile);
     const timestamp = DateFormatter.toLocalTimestamp(new Date());

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -185,6 +185,8 @@ export default class ExocortexPlugin extends Plugin {
       }
 
       const currentEndTimestamp = metadata.ems__Effort_endTimestamp;
+      const currentPlannedStartTimestamp =
+        metadata.ems__Effort_plannedStartTimestamp;
       const cachedMetadata = this.metadataCache.get(file.path);
 
       if (!cachedMetadata) {
@@ -193,6 +195,8 @@ export default class ExocortexPlugin extends Plugin {
       }
 
       const previousEndTimestamp = cachedMetadata.ems__Effort_endTimestamp;
+      const previousPlannedStartTimestamp =
+        cachedMetadata.ems__Effort_plannedStartTimestamp;
 
       if (currentEndTimestamp && currentEndTimestamp !== previousEndTimestamp) {
         this.logger.info(
@@ -204,6 +208,26 @@ export default class ExocortexPlugin extends Plugin {
           await this.taskStatusService.syncEffortEndTimestamp(file, parsedDate);
           this.logger.info(
             `Auto-synced ems__Effort_resolutionTimestamp to ${currentEndTimestamp}`,
+          );
+        }
+      }
+
+      if (
+        currentPlannedStartTimestamp &&
+        currentPlannedStartTimestamp !== previousPlannedStartTimestamp
+      ) {
+        this.logger.info(
+          `Detected ems__Effort_plannedStartTimestamp change in ${file.path}: ${String(previousPlannedStartTimestamp)} → ${String(currentPlannedStartTimestamp)}`,
+        );
+
+        const parsedDate = new Date(currentPlannedStartTimestamp);
+        if (!isNaN(parsedDate.getTime())) {
+          await this.taskStatusService.syncPlannedEndTimestamp(
+            file,
+            parsedDate,
+          );
+          this.logger.info(
+            `Auto-synced ems__Effort_plannedEndTimestamp to ${currentPlannedStartTimestamp}`,
           );
         }
       }


### PR DESCRIPTION
## Summary

Implements automatic updating of `ems__Effort_plannedEndTimestamp` when `ems__Effort_plannedStartTimestamp` is modified, matching the existing behavior for `ems__Effort_resolutionTimestamp` auto-sync.

## Changes

- Added `syncPlannedEndTimestamp` method to `StatusTimestampService`
- Exposed `syncPlannedEndTimestamp` in `TaskStatusService`  
- Updated `ExocortexPlugin.handleMetadataChange` to watch for `plannedStartTimestamp` changes and trigger auto-sync

## Testing

All unit tests pass (1217 tests across 59 suites)