### PR TITLE
feat: add tab preference when creating assets

### DIFF
--- a/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
@@ -61,7 +61,9 @@ export class CreateInstanceCommand implements ICommand {
       result.taskSize,
     );
 
-    const leaf = this.app.workspace.getLeaf("tab");
+    const leaf = result.openInNewTab
+      ? this.app.workspace.getLeaf("tab")
+      : this.app.workspace.getLeaf(false);
     const tfile = this.vaultAdapter.toTFile(createdFile);
     await leaf.openFile(tfile);
 

--- a/packages/obsidian-plugin/src/application/commands/CreateProjectCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateProjectCommand.ts
@@ -54,7 +54,9 @@ export class CreateProjectCommand implements ICommand {
       result.label,
     );
 
-    const leaf = this.app.workspace.getLeaf("tab");
+    const leaf = result.openInNewTab
+      ? this.app.workspace.getLeaf("tab")
+      : this.app.workspace.getLeaf(false);
     const tfile = this.vaultAdapter.toTFile(createdFile);
     await leaf.openFile(tfile);
 

--- a/packages/obsidian-plugin/src/application/commands/CreateRelatedTaskCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateRelatedTaskCommand.ts
@@ -51,7 +51,9 @@ export class CreateRelatedTaskCommand implements ICommand {
       result.taskSize,
     );
 
-    const leaf = this.app.workspace.getLeaf("tab");
+    const leaf = result.openInNewTab
+      ? this.app.workspace.getLeaf("tab")
+      : this.app.workspace.getLeaf(false);
     const tfile = this.vaultAdapter.toTFile(createdFile);
     await leaf.openFile(tfile);
 

--- a/packages/obsidian-plugin/src/application/commands/CreateTaskCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateTaskCommand.ts
@@ -58,7 +58,9 @@ export class CreateTaskCommand implements ICommand {
       result.taskSize,
     );
 
-    const leaf = this.app.workspace.getLeaf("tab");
+    const leaf = result.openInNewTab
+      ? this.app.workspace.getLeaf("tab")
+      : this.app.workspace.getLeaf(false);
     const tfile = this.vaultAdapter.toTFile(createdFile);
     await leaf.openFile(tfile);
 

--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -137,7 +137,9 @@ export class ButtonGroupsBuilder {
           if (!tFile || !(tFile instanceof TFile)) {
             throw new Error(`Created file not found: ${createdFile.path}`);
           }
-          const leaf = this.app.workspace.getLeaf("tab");
+          const leaf = result.openInNewTab
+            ? this.app.workspace.getLeaf("tab")
+            : this.app.workspace.getLeaf(false);
           await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(
@@ -170,7 +172,9 @@ export class ButtonGroupsBuilder {
           if (!tFile || !(tFile instanceof TFile)) {
             throw new Error(`Created file not found: ${createdFile.path}`);
           }
-          const leaf = this.app.workspace.getLeaf("tab");
+          const leaf = result.openInNewTab
+            ? this.app.workspace.getLeaf("tab")
+            : this.app.workspace.getLeaf(false);
           await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(
@@ -198,7 +202,9 @@ export class ButtonGroupsBuilder {
           if (!tFile || !(tFile instanceof TFile)) {
             throw new Error(`Created file not found: ${createdFile.path}`);
           }
-          const leaf = this.app.workspace.getLeaf("tab");
+          const leaf = result.openInNewTab
+            ? this.app.workspace.getLeaf("tab")
+            : this.app.workspace.getLeaf(false);
           await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(`Created child Area: ${createdFile.path}`);
@@ -243,7 +249,9 @@ export class ButtonGroupsBuilder {
           if (!tFile || !(tFile instanceof TFile)) {
             throw new Error(`Created file not found: ${createdFile.path}`);
           }
-          const leaf = this.app.workspace.getLeaf("tab");
+          const leaf = result.openInNewTab
+            ? this.app.workspace.getLeaf("tab")
+            : this.app.workspace.getLeaf(false);
           await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(
@@ -272,7 +280,9 @@ export class ButtonGroupsBuilder {
           if (!tFile || !(tFile instanceof TFile)) {
             throw new Error(`Created file not found: ${createdFile.path}`);
           }
-          const leaf = this.app.workspace.getLeaf("tab");
+          const leaf = result.openInNewTab
+            ? this.app.workspace.getLeaf("tab")
+            : this.app.workspace.getLeaf(false);
           await leaf.openFile(tFile);
           this.app.workspace.setActiveLeaf(leaf, { focus: true });
           this.logger.info(`Created Related Task: ${createdFile.path}`);

--- a/packages/obsidian-plugin/src/presentation/modals/FleetingNoteModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/FleetingNoteModal.ts
@@ -38,7 +38,7 @@ export class FleetingNoteModal extends Modal {
     const errorElement = contentEl.createDiv({
       cls: "exocortex-modal-error-message",
     });
-    errorElement.style.display = "none";
+    errorElement.addClass("exocortex-modal-error-message--hidden");
     this.errorEl = errorElement;
 
     this.inputEl.addEventListener("input", (event) => {
@@ -96,14 +96,14 @@ export class FleetingNoteModal extends Modal {
     this.inputEl?.classList.add("exocortex-modal-input--error");
     if (this.errorEl) {
       this.errorEl.textContent = message;
-      this.errorEl.style.display = "";
+      this.errorEl.removeClass("exocortex-modal-error-message--hidden");
     }
   }
 
   private clearErrorState(): void {
     this.inputEl?.classList.remove("exocortex-modal-input--error");
     if (this.errorEl) {
-      this.errorEl.style.display = "none";
+      this.errorEl.addClass("exocortex-modal-error-message--hidden");
       this.errorEl.textContent = "";
     }
   }

--- a/packages/obsidian-plugin/src/presentation/modals/LabelInputModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/LabelInputModal.ts
@@ -3,6 +3,7 @@ import { App, Modal } from "obsidian";
 export interface LabelInputModalResult {
   label: string | null;
   taskSize: string | null;
+  openInNewTab: boolean;
 }
 
 /**
@@ -12,6 +13,7 @@ export interface LabelInputModalResult {
 export class LabelInputModal extends Modal {
   private label = "";
   private taskSize: string | null = null;
+  private openInNewTab = true;
   private onSubmit: (result: LabelInputModalResult) => void;
   private inputEl: HTMLInputElement | null = null;
   private taskSizeSelectEl: HTMLSelectElement | null = null;
@@ -104,6 +106,34 @@ export class LabelInputModal extends Modal {
       });
     }
 
+    const tabPreferenceContainer = contentEl.createDiv({
+      cls: "exocortex-modal-input-container",
+    });
+
+    const checkboxWrapper = tabPreferenceContainer.createDiv({
+      cls: "exocortex-modal-checkbox-wrapper",
+    });
+
+    const checkboxId = `exocortex-open-in-new-tab-${Date.now()}`;
+    const checkboxEl = checkboxWrapper.createEl("input", {
+      type: "checkbox",
+    });
+    checkboxEl.id = checkboxId;
+    checkboxEl.checked = this.openInNewTab;
+    checkboxEl.addEventListener("change", (e) => {
+      this.openInNewTab = (e.target as HTMLInputElement).checked;
+    });
+
+    checkboxWrapper.createEl("label", {
+      text: "Open created asset in a new tab",
+      attr: { for: checkboxId },
+    });
+
+    tabPreferenceContainer.createEl("p", {
+      text: "Uncheck to use the current tab instead.",
+      cls: "exocortex-modal-description",
+    });
+
     const buttonContainer = contentEl.createDiv({
       cls: "modal-button-container",
     });
@@ -129,12 +159,17 @@ export class LabelInputModal extends Modal {
     this.onSubmit({
       label: trimmedLabel || null,
       taskSize: this.taskSize,
+      openInNewTab: this.openInNewTab,
     });
     this.close();
   }
 
   private cancel(): void {
-    this.onSubmit({ label: null, taskSize: null });
+    this.onSubmit({
+      label: null,
+      taskSize: null,
+      openInNewTab: this.openInNewTab,
+    });
     this.close();
   }
 

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -926,6 +926,10 @@
   font-size: 0.85em;
 }
 
+.exocortex-modal-error-message--hidden {
+  display: none;
+}
+
 /* ============================================================================
    Action Buttons Group - Semantic Grouping with Beautiful Design
    ============================================================================ */

--- a/packages/obsidian-plugin/tests/unit/FleetingNoteModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FleetingNoteModal.test.ts
@@ -39,7 +39,7 @@ describe("FleetingNoteModal", () => {
       ".exocortex-modal-error-message",
     ) as HTMLDivElement;
     expect(errorMessage.textContent).toBe("Label is required");
-    expect(errorMessage.style.display).not.toBe("none");
+    expect(errorMessage.classList.contains("exocortex-modal-error-message--hidden")).toBe(false);
 
     modal.close();
   });
@@ -60,7 +60,7 @@ describe("FleetingNoteModal", () => {
     const errorMessage = modal.contentEl.querySelector(
       ".exocortex-modal-error-message",
     ) as HTMLDivElement;
-    expect(errorMessage.style.display).toBe("none");
+    expect(errorMessage.classList.contains("exocortex-modal-error-message--hidden")).toBe(true);
     expect(errorMessage.textContent).toBe("");
 
     createButton.click();

--- a/packages/obsidian-plugin/tests/unit/LabelInputModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/LabelInputModal.test.ts
@@ -7,6 +7,7 @@ describe("LabelInputModal", () => {
   let onSubmitSpy: jest.Mock<void, [LabelInputModalResult]>;
   let mockContentEl: any;
   let mockInputEl: HTMLInputElement;
+  let mockCheckboxEl: HTMLInputElement;
   let mockSelectEl: HTMLSelectElement;
 
   beforeEach(() => {
@@ -15,6 +16,7 @@ describe("LabelInputModal", () => {
 
     // Mock content element and its methods
     mockInputEl = document.createElement("input");
+    mockCheckboxEl = document.createElement("input");
     mockSelectEl = document.createElement("select");
 
     mockContentEl = {
@@ -27,6 +29,12 @@ describe("LabelInputModal", () => {
     // Setup createEl mock to return appropriate elements
     mockContentEl.createEl.mockImplementation((tag: string, options?: any) => {
       if (tag === "input") {
+        if (options?.type === "checkbox") {
+          mockCheckboxEl = document.createElement("input");
+          mockCheckboxEl.type = "checkbox";
+          mockCheckboxEl.checked = Boolean(options?.checked);
+          return mockCheckboxEl;
+        }
         if (options?.value !== undefined) mockInputEl.value = options.value;
         return mockInputEl;
       }
@@ -50,6 +58,7 @@ describe("LabelInputModal", () => {
     // Setup createDiv mock
     mockContentEl.createDiv.mockImplementation(() => ({
       createEl: mockContentEl.createEl,
+      createDiv: mockContentEl.createDiv,
     }));
 
     onSubmitSpy = jest.fn();
@@ -151,6 +160,18 @@ describe("LabelInputModal", () => {
       expect(mockContentEl.createEl).toHaveBeenCalledWith("button", {
         text: "Cancel",
       });
+    });
+
+    it("should create open-in-new-tab checkbox checked by default", () => {
+      modal.onOpen();
+
+      expect(mockContentEl.createEl).toHaveBeenCalledWith(
+        "input",
+        expect.objectContaining({
+          type: "checkbox",
+        }),
+      );
+      expect(mockCheckboxEl.checked).toBe(true);
     });
   });
 
@@ -293,6 +314,7 @@ describe("LabelInputModal", () => {
       expect(onSubmitSpy).toHaveBeenCalledWith({
         label: "Test Label",
         taskSize: null,
+        openInNewTab: true,
       });
       expect(modal.close).toHaveBeenCalled();
     });
@@ -306,6 +328,7 @@ describe("LabelInputModal", () => {
       expect(onSubmitSpy).toHaveBeenCalledWith({
         label: null,
         taskSize: null,
+        openInNewTab: true,
       });
       expect(modal.close).toHaveBeenCalled();
     });
@@ -319,6 +342,25 @@ describe("LabelInputModal", () => {
       expect(onSubmitSpy).toHaveBeenCalledWith({
         label: "Task Name",
         taskSize: '"[[ems__TaskSize_M]]"',
+        openInNewTab: true,
+      });
+      expect(modal.close).toHaveBeenCalled();
+    });
+
+    it("should submit with openInNewTab false when checkbox unchecked", () => {
+      modal.contentEl = mockContentEl;
+      modal.close = jest.fn();
+      modal.onOpen();
+
+      mockCheckboxEl.checked = false;
+      mockCheckboxEl.dispatchEvent(new Event("change"));
+
+      modal["submit"]();
+
+      expect(onSubmitSpy).toHaveBeenCalledWith({
+        label: null,
+        taskSize: null,
+        openInNewTab: false,
       });
       expect(modal.close).toHaveBeenCalled();
     });
@@ -339,6 +381,7 @@ describe("LabelInputModal", () => {
       expect(onSubmitSpy).toHaveBeenCalledWith({
         label: null,
         taskSize: null,
+        openInNewTab: true,
       });
       expect(modal.close).toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- add default-on checkbox to asset creation modal so users can choose new tab behavior
- plumb selection through all creation commands and button builder
- tidy FleetingNote modal styles to satisfy lint

## Testing
- npm test
- npm run bdd:check
- npm run lint