### PR TITLE
fix: ensure effort area prefers parent inheritance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,18 @@
 - Validate behavior-driven coverage as expected by the CLAUDE workflow: `npm run bdd:check` (or `npm run bdd:coverage` / `npm run bdd:report` for diagnostics).
 - Investigate and resolve all failures; prevent Playwright hangs by keeping runs scoped when possible.
 
+### Troubleshooting: Missing ts-jest preset
+
+**Symptom**: Running Jest yields `Preset ts-jest not found relative to rootDir ...`.
+
+**Root Cause**: Dependencies have not been installed inside the current worktree (common immediately after `git worktree add`).
+
+**Solution**:
+1. From the worktree root, run `npm install`.
+2. Re-run the Jest command.
+
+**Prevention**: Always execute `npm install` right after creating a new worktree.
+
 ## Release Guidance
 - Do **not** bump versions or craft releases manually. Coordinate with maintainers for release automation that mirrors the `/release` command.
 - Ensure changelog updates and release activities happen through the sanctioned process once available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,6 +461,14 @@ Testing:
   - Total execution: ~15s (unit) + ~3min (E2E)
   - Coverage: 49% global, 78-80% domain layer
 
+#### Testing shortcut
+
+Run a single TypeScript Jest suite with the shared config to avoid parsing errors:
+
+```bash
+npx jest --config packages/obsidian-plugin/jest.config.js path/to/test.ts --runInBand
+```
+
 CI/CD:
   - GitHub Actions
   - Automated releases

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
@@ -90,6 +90,26 @@ export class AssetMetadataService {
       return directArea;
     }
 
+    const parentRef = metadata.ems__Effort_parent;
+    const parentPath = this.extractFirstValue(parentRef);
+
+    if (parentPath && !visited.has(parentPath)) {
+      visited.add(parentPath);
+      const parentFile = this.app.metadataCache.getFirstLinkpathDest(
+        parentPath,
+        "",
+      );
+      if (parentFile instanceof TFile) {
+        const parentCache = this.app.metadataCache.getFileCache(parentFile);
+        const parentMetadata = parentCache?.frontmatter || {};
+
+        const resolvedArea = this.getEffortArea(parentMetadata, visited);
+        if (resolvedArea) {
+          return resolvedArea;
+        }
+      }
+    }
+
     const prototypeRef = metadata.ems__Effort_prototype;
     const prototypePath = this.extractFirstValue(prototypeRef);
 
@@ -105,26 +125,6 @@ export class AssetMetadataService {
         const prototypeMetadata = prototypeCache?.frontmatter || {};
 
         const resolvedArea = this.getEffortArea(prototypeMetadata, visited);
-        if (resolvedArea) {
-          return resolvedArea;
-        }
-      }
-    }
-
-    const parentRef = metadata.ems__Effort_parent;
-    const parentPath = this.extractFirstValue(parentRef);
-
-    if (parentPath && !visited.has(parentPath)) {
-      visited.add(parentPath);
-      const parentFile = this.app.metadataCache.getFirstLinkpathDest(
-        parentPath,
-        "",
-      );
-      if (parentFile instanceof TFile) {
-        const parentCache = this.app.metadataCache.getFileCache(parentFile);
-        const parentMetadata = parentCache?.frontmatter || {};
-
-        const resolvedArea = this.getEffortArea(parentMetadata, visited);
         if (resolvedArea) {
           return resolvedArea;
         }

--- a/packages/obsidian-plugin/tests/unit/AssetMetadataService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AssetMetadataService.test.ts
@@ -146,19 +146,77 @@ describe("AssetMetadataService", () => {
       const mockPrototypeFile = new TFile();
       const mockParentFile = new TFile();
 
-      mockApp.metadataCache.getFirstLinkpathDest
-        .mockReturnValueOnce(mockPrototypeFile)
-        .mockReturnValueOnce(mockParentFile);
+      mockApp.metadataCache.getFirstLinkpathDest.mockImplementation(
+        (linkpath: string) => {
+          if (linkpath === "parent-effort") {
+            return mockParentFile;
+          }
+          if (linkpath === "prototype-path") {
+            return mockPrototypeFile;
+          }
+          return null;
+        },
+      );
 
-      mockApp.metadataCache.getFileCache
-        .mockReturnValueOnce({
-          frontmatter: {},
-        })
-        .mockReturnValueOnce({
-          frontmatter: {
-            ems__Effort_area: "parent-area",
-          },
-        });
+      mockApp.metadataCache.getFileCache.mockImplementation((file: TFile) => {
+        if (file === mockParentFile) {
+          return {
+            frontmatter: {
+              ems__Effort_area: "parent-area",
+            },
+          };
+        }
+        if (file === mockPrototypeFile) {
+          return {
+            frontmatter: {},
+          };
+        }
+        return null;
+      });
+
+      const metadata = {
+        ems__Effort_prototype: "[[prototype-path]]",
+        ems__Effort_parent: "[[parent-effort]]",
+      };
+
+      const result = service.getEffortArea(metadata);
+
+      expect(result).toBe("parent-area");
+    });
+
+    it("should prefer parent area over prototype area when both are present", () => {
+      const mockPrototypeFile = new TFile();
+      const mockParentFile = new TFile();
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockImplementation(
+        (linkpath: string) => {
+          if (linkpath === "parent-effort") {
+            return mockParentFile;
+          }
+          if (linkpath === "prototype-path") {
+            return mockPrototypeFile;
+          }
+          return null;
+        },
+      );
+
+      mockApp.metadataCache.getFileCache.mockImplementation((file: TFile) => {
+        if (file === mockParentFile) {
+          return {
+            frontmatter: {
+              ems__Effort_area: "parent-area",
+            },
+          };
+        }
+        if (file === mockPrototypeFile) {
+          return {
+            frontmatter: {
+              ems__Effort_area: "prototype-area",
+            },
+          };
+        }
+        return null;
+      });
 
       const metadata = {
         ems__Effort_prototype: "[[prototype-path]]",


### PR DESCRIPTION
## Summary
- ensure effort area inheritance prioritizes direct area, then parent, then prototype
- add coverage confirming parent wins when both parent and prototype provide areas
- document worktree ts-jest fix and jest shortcut for future agents

## Testing
- npm run test:all
