### PR TITLE
docs: capture ts-jest streaming gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@
 
 **Prevention**: Always execute `npm install` right after creating a new worktree.
 
+### Jest async generators
+
+The shared ts-jest configuration does not handle class-level `async *` methods. When you need an async stream, expose a helper that returns an `AsyncIterableIterator` instead of adding `async *` directly on a class.
+
 ## Release Guidance
 - Do **not** bump versions or craft releases manually. Coordinate with maintainers for release automation that mirrors the `/release` command.
 - Ensure changelog updates and release activities happen through the sanctioned process once available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@
 git worktree add ../exocortex-[task-name] -b feature/[description]
 cd ../exocortex-[task-name]
 git fetch origin main && git rebase origin/main
+
+# Immediately hydrate dependencies in the new worktree (prevents ts-jest preset errors)
+npm install
 ```
 
 **ALWAYS use slash commands for these operations:**
@@ -468,6 +471,8 @@ Run a single TypeScript Jest suite with the shared config to avoid parsing error
 ```bash
 npx jest --config packages/obsidian-plugin/jest.config.js path/to/test.ts --runInBand
 ```
+
+> **ts-jest quirk**: class-level `async *` methods are not transpiled by the current Jest configuration. When you need an async stream, return an `AsyncIterableIterator` from a helper or closure instead of declaring `async *` directly on a class.
 
 CI/CD:
   - GitHub Actions


### PR DESCRIPTION
## Summary

Capture the worktree dependency bootstrap requirement and the ts-jest async generator limitation so future agents avoid the same pitfalls.

## Changes

- ✅ Remind agents to run `npm install` immediately after creating a new worktree
- ✅ Document the ts-jest failure mode for class-level `async *` methods and the supported workaround
- ✅ Surface the async generator guidance in both AGENTS.md and CLAUDE.md without duplicating unrelated info

## Test Plan

Documentation-only change — no automated tests executed.
