### PR TITLE
feat(ios): add status detection service for Live Activities (#276)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -15,6 +15,7 @@ import {
 import { ExocortexSettingTab } from "./presentation/settings/ExocortexSettingTab";
 import { TaskStatusService } from "@exocortex/core";
 import { ObsidianVaultAdapter } from "./adapters/ObsidianVaultAdapter";
+import { TaskTrackingService } from "./application/services/TaskTrackingService";
 
 /**
  * Exocortex Plugin - Automatic layout rendering
@@ -26,6 +27,7 @@ export default class ExocortexPlugin extends Plugin {
   private layoutRenderer!: UniversalLayoutRenderer;
   private commandManager!: CommandManager;
   private taskStatusService!: TaskStatusService;
+  private taskTrackingService!: TaskTrackingService;
   private metadataCache!: Map<string, Record<string, unknown>>;
   private vaultAdapter!: ObsidianVaultAdapter;
   settings!: ExocortexSettings;
@@ -48,6 +50,11 @@ export default class ExocortexPlugin extends Plugin {
         this,
       );
       this.taskStatusService = new TaskStatusService(this.vaultAdapter);
+      this.taskTrackingService = new TaskTrackingService(
+        this.app,
+        this.app.vault,
+        this.app.metadataCache
+      );
       this.metadataCache = new Map();
 
       // Initialize CommandManager and register all commands
@@ -183,6 +190,9 @@ export default class ExocortexPlugin extends Plugin {
       if (!metadata) {
         return;
       }
+
+      // iOS Live Activities: Track status changes to DOING
+      await this.taskTrackingService.handleFileChange(file);
 
       const currentEndTimestamp = metadata.ems__Effort_endTimestamp;
       const currentPlannedStartTimestamp =

--- a/packages/obsidian-plugin/src/application/services/TaskTrackingService.ts
+++ b/packages/obsidian-plugin/src/application/services/TaskTrackingService.ts
@@ -1,0 +1,258 @@
+import { App, MetadataCache, TFile, Vault, Platform } from "obsidian";
+import { v4 as uuidv4 } from "uuid";
+import { ILogger } from "../../adapters/logging/ILogger";
+import { LoggerFactory } from "../../adapters/logging/LoggerFactory";
+
+/**
+ * Task data for iOS Live Activities integration
+ */
+export interface TaskData {
+  taskId: string;
+  title: string;
+  startTime: string; // ISO8601
+  filePath: string;
+  callbackURL: string;
+}
+
+/**
+ * Service for detecting task status changes and launching iOS app
+ * 
+ * This service listens for metadata changes in Obsidian notes and detects
+ * when a task's status changes to "DOING". When detected, it:
+ * 1. Generates or retrieves a unique TaskId
+ * 2. Builds an exocortex:// URL with task details
+ * 3. Launches the iOS companion app via URL scheme
+ * 4. The iOS app then displays a Live Activity on the lock screen
+ * 
+ * Architecture:
+ * - Domain Layer: TaskData interface (pure data)
+ * - Application Layer: TaskTrackingService (business logic)
+ * - Infrastructure Layer: Obsidian API integration (vault, metadata cache)
+ */
+export class TaskTrackingService {
+  private logger: ILogger;
+  private currentTask: TaskData | null = null;
+
+  constructor(
+    private app: App,
+    private vault: Vault,
+    private metadataCache: MetadataCache
+  ) {
+    this.logger = LoggerFactory.create("TaskTrackingService");
+  }
+
+  /**
+   * Register event listener for metadata changes
+   * Call this during plugin initialization
+   */
+  public registerListener(): void {
+    this.logger.debug("Registering status change listener");
+    // Listener is registered in ExocortexPlugin.ts via metadataCache.on('changed')
+    // This method documents the integration point
+  }
+
+  /**
+   * Handle file metadata change event
+   * Called by ExocortexPlugin when metadataCache emits 'changed' event
+   */
+  public async handleFileChange(file: TFile): Promise<void> {
+    try {
+      const cache = this.metadataCache.getFileCache(file);
+      if (!cache?.frontmatter) {
+        return; // No frontmatter, nothing to track
+      }
+
+      const status = cache.frontmatter.Status;
+
+      // Check if status changed to DOING
+      if (this.isDoingStatus(status)) {
+        this.logger.info(`Detected DOING status for: ${file.basename}`);
+        await this.startTracking(file, cache.frontmatter);
+      }
+    } catch (error) {
+      this.logger.error("Error handling file change", error);
+    }
+  }
+
+  /**
+   * Check if status is "DOING"
+   * Handles both formats: [[ems__EffortStatusDoing]] and ems__EffortStatusDoing
+   */
+  private isDoingStatus(status: unknown): boolean {
+    if (!status || typeof status !== "string") {
+      return false;
+    }
+
+    // Remove wiki link brackets if present
+    const normalized = status.replace(/\[\[|\]\]/g, "").trim();
+    return normalized === "ems__EffortStatusDoing";
+  }
+
+  /**
+   * Start tracking a task - launch iOS app with task details
+   */
+  private async startTracking(
+    file: TFile,
+    frontmatter: Record<string, unknown>
+  ): Promise<void> {
+    try {
+      // Extract or generate task ID
+      let taskId = frontmatter.TaskId as string | undefined;
+      if (!taskId) {
+        taskId = uuidv4();
+        this.logger.info(`Generated new TaskId: ${taskId}`);
+        await this.addTaskIdToFrontmatter(file, taskId);
+      }
+
+      // Extract task title
+      const title = (frontmatter.Title as string) || file.basename;
+
+      // Current time as ISO8601
+      const startTime = new Date().toISOString();
+
+      // Build callback URL for task completion
+      const callbackURL = this.buildCallbackURL(file.path);
+
+      // Create task data
+      const taskData: TaskData = {
+        taskId,
+        title,
+        startTime,
+        filePath: file.path,
+        callbackURL,
+      };
+
+      // Save current task
+      this.currentTask = taskData;
+
+      // Launch iOS app
+      await this.launchIOSApp(taskData);
+    } catch (error) {
+      this.logger.error("Error starting task tracking", error);
+    }
+  }
+
+  /**
+   * Add TaskId to frontmatter if not present
+   */
+  private async addTaskIdToFrontmatter(
+    file: TFile,
+    taskId: string
+  ): Promise<void> {
+    try {
+      const content = await this.vault.read(file);
+
+      // Check if frontmatter exists
+      if (!content.startsWith("---")) {
+        this.logger.warn(
+          `Cannot add TaskId: no frontmatter in ${file.basename}`
+        );
+        return;
+      }
+
+      // Find end of frontmatter
+      const lines = content.split("\n");
+      let endIndex = -1;
+      for (let i = 1; i < lines.length; i++) {
+        if (lines[i].trim() === "---") {
+          endIndex = i;
+          break;
+        }
+      }
+
+      if (endIndex === -1) {
+        this.logger.warn(
+          `Cannot add TaskId: malformed frontmatter in ${file.basename}`
+        );
+        return;
+      }
+
+      // Insert TaskId before closing ---
+      lines.splice(endIndex, 0, `TaskId: ${taskId}`);
+      const updatedContent = lines.join("\n");
+
+      await this.vault.modify(file, updatedContent);
+      this.logger.info(`Added TaskId to ${file.basename}`);
+    } catch (error) {
+      this.logger.error("Error adding TaskId to frontmatter", error);
+    }
+  }
+
+  /**
+   * Build callback URL for Advanced URI plugin
+   * This URL will be called by iOS app when user completes the task
+   */
+  private buildCallbackURL(filePath: string): string {
+    const vaultName = this.app.vault.getName();
+    const encodedPath = encodeURIComponent(filePath);
+    const encodedVault = encodeURIComponent(vaultName);
+
+    // Advanced URI format for updating frontmatter
+    // Requires "Advanced URI" community plugin to be installed
+    const callbackURL =
+      `obsidian://advanced-uri?` +
+      `vault=${encodedVault}&` +
+      `filepath=${encodedPath}&` +
+      `updatefrontmatter=true&` +
+      `frontmatterkey=Status&` +
+      `frontmattervalue=[[ems__EffortStatusDone]]`;
+
+    return callbackURL;
+  }
+
+  /**
+   * Launch iOS app with task data
+   * Uses exocortex:// URL scheme to communicate with iOS companion app
+   */
+  private async launchIOSApp(taskData: TaskData): Promise<void> {
+    // Check if running on iOS
+    // @ts-ignore - Platform is available in Obsidian mobile
+    if (typeof Platform !== "undefined" && !Platform.isIOS) {
+      this.logger.warn(
+        "iOS Live Activities only available on iOS. " +
+          "This feature will not work on desktop or Android."
+      );
+      return;
+    }
+
+    // Build URL parameters
+    const params = new URLSearchParams({
+      taskId: taskData.taskId,
+      title: taskData.title,
+      startTime: taskData.startTime,
+      "x-success": taskData.callbackURL,
+    });
+
+    const url = `exocortex://task/start?${params.toString()}`;
+
+    this.logger.info("Launching iOS app with URL:", url);
+    this.logger.debug("Task data:", taskData);
+
+    try {
+      // Open URL - this will launch the iOS app
+      // On iOS, this triggers the registered URL scheme handler
+      // On desktop, this will do nothing (already warned above)
+      window.open(url, "_blank");
+
+      this.logger.info("iOS app launch initiated successfully");
+    } catch (error) {
+      this.logger.error("Failed to launch iOS app", error);
+    }
+  }
+
+  /**
+   * Get current tracked task
+   */
+  public getCurrentTask(): TaskData | null {
+    return this.currentTask;
+  }
+
+  /**
+   * Clear current task
+   * Call this when task is completed or cancelled
+   */
+  public clearCurrentTask(): void {
+    this.currentTask = null;
+    this.logger.debug("Cleared current task");
+  }
+}


### PR DESCRIPTION
## Summary

Implements iOS Live Activities integration for Obsidian plugin (issue #276).

**New files:**
- `TaskTrackingService.ts`: Detects status changes to DOING and launches iOS app

**Changes:**
- `ExocortexPlugin.ts`: Integrated TaskTrackingService with metadata change listener

## Features

- ✅ Listens to metadataCache 'changed' events
- ✅ Detects `[[ems__EffortStatusDoing]]` status changes
- ✅ Auto-generates UUID TaskId if missing
- ✅ Builds `exocortex://` URL with task parameters
- ✅ Includes x-success callback URL (Advanced URI format)
- ✅ Platform check: iOS only, desktop shows warning
- ✅ Comprehensive error handling and logging

## Architecture

- Clean separation: Domain (TaskData) / Application (Service) / Infrastructure (Obsidian API)
- Follows existing plugin patterns (LoggerFactory, service injection)
- Non-intrusive: Only activates on status change to DOING

## Integration flow

1. User changes task status to `[[ems__EffortStatusDoing]]`
2. Plugin detects metadata change
3. TaskTrackingService validates platform (iOS)
4. Service extracts task data (title, TaskId, etc.)
5. Generates UUID TaskId if missing
6. Builds URL: `exocortex://start?taskId=...&title=...&x-success=obsidian://...`
7. Opens URL → iOS app launches Live Activity

## Test plan

- [ ] Verify TypeScript compiles without errors
- [ ] Check that TaskTrackingService is properly integrated
- [ ] Validate URL format matches iOS app expectations
- [ ] Test metadata change listener activation

## Related issues

Closes #276