### PR TITLE
fix: safely handle error message in AddSupervisionCommand

### DIFF
--- a/packages/obsidian-plugin/src/application/commands/AddSupervisionCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/AddSupervisionCommand.ts
@@ -41,9 +41,14 @@ export class AddSupervisionCommand implements ICommand {
       }
 
       new Notice(`Supervision created: ${createdFile.basename}`);
-    } catch (error: any) {
-      new Notice(`Failed to create supervision: ${error.message}`);
-      LoggingService.error("Add supervision error", error);
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      new Notice(`Failed to create supervision: ${errorMessage}`);
+      LoggingService.error(
+        "Add supervision error",
+        error instanceof Error ? error : undefined,
+      );
     }
   };
 }


### PR DESCRIPTION
## Description

Fixes a bug where `error.message` was accessed without type checking in the `AddSupervisionCommand` catch block.

## Problem

Previously, if an error was thrown that was not an `Error` instance (e.g., a string or number), accessing `error.message` would cause a runtime error or return `undefined`.

## Solution

- Changed `error: any` to `error: unknown` for better type safety
- Safely extract error message: `error instanceof Error ? error.message : String(error)`
- Pass error correctly to `LoggingService.error()` (expects `Error | undefined`)

## Changes

- `packages/obsidian-plugin/src/application/commands/AddSupervisionCommand.ts`

## Testing

- Type checking passes: `npm run check:types`
- All tests pass (existing tests continue to work with improved error handling)