### PR TITLE
docs: add SPARQL Query Blocks to Key Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Exocortex is a powerful Obsidian plugin that transforms your notes into an inter
 - 📱 **Mobile Compatible**: Full touch-optimized UI for desktop and mobile
 - ⌨️ **23 Commands**: Comprehensive command palette integration for all operations
 - 🎨 **Action Buttons**: Context-aware UI buttons for quick access to relevant commands
+- 🔍 **SPARQL Query Blocks**: Execute semantic queries directly in markdown with `sparql` code blocks
 
 ## 📦 Monorepo Structure
 


### PR DESCRIPTION
## Summary

Updates README.md to document the SPARQL Query Blocks feature delivered in v13.31.0.

## Changes

- ✅ Added "SPARQL Query Blocks" to Key Features section
- ✅ Documents user-facing capability to execute semantic queries in markdown

## Context

Following RULE 8 (Documentation Updates - MANDATORY) from CLAUDE.md:
> "New Features → Add to Key Features section"

The SPARQL Code Block Processor (#241, #316, v13.31.0) enables users to execute SPARQL queries directly in markdown using `sparql` code blocks. This user-facing feature must be documented in README.md.

## Test Plan

- Verify README.md renders correctly on GitHub
- No functional changes - documentation only