### PR TITLE
feat: change 'Plan on Today' to set plannedStartTimestamp instead of Effort_day

### DIFF
--- a/packages/core/src/services/PlanningService.ts
+++ b/packages/core/src/services/PlanningService.ts
@@ -17,11 +17,11 @@ export class PlanningService {
     }
 
     const content = await this.vault.read(file);
-    const todayWikilink = DateFormatter.getTodayWikilink();
+    const todayStartTimestamp = DateFormatter.getTodayStartTimestamp();
     const updated = this.frontmatterService.updateProperty(
       content,
-      "ems__Effort_day",
-      todayWikilink,
+      "ems__Effort_plannedStartTimestamp",
+      todayStartTimestamp,
     );
     await this.vault.modify(file, updated);
   }

--- a/packages/core/src/utilities/DateFormatter.ts
+++ b/packages/core/src/utilities/DateFormatter.ts
@@ -206,4 +206,25 @@ export class DateFormatter {
       date1.getDate() === date2.getDate()
     );
   }
+
+  /**
+   * Get start of day timestamp for today (00:00:00).
+   *
+   * Format: `YYYY-MM-DDT00:00:00`
+   *
+   * Used for setting planned start timestamp to beginning of current day.
+   *
+   * @returns Today's date at midnight as ISO timestamp string
+   *
+   * @example
+   * ```typescript
+   * const startOfToday = DateFormatter.getTodayStartTimestamp();
+   * // "2025-11-03T00:00:00"
+   * ```
+   */
+  static getTodayStartTimestamp(): string {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return DateFormatter.toLocalTimestamp(today);
+  }
 }

--- a/packages/core/tests/services/PlanningService.test.ts
+++ b/packages/core/tests/services/PlanningService.test.ts
@@ -9,7 +9,7 @@ describe("PlanningService", () => {
   let mockVault: jest.Mocked<IVaultAdapter>;
   let mockFile: IFile;
 
-  const mockTodayWikilink = "[[2025-01-15]]";
+  const mockTodayTimestamp = "2025-01-15T00:00:00";
 
   beforeEach(() => {
     mockVault = {
@@ -24,7 +24,7 @@ describe("PlanningService", () => {
       basename: "task",
     } as IFile;
 
-    (DateFormatter.getTodayWikilink as jest.Mock).mockReturnValue(mockTodayWikilink);
+    (DateFormatter.getTodayStartTimestamp as jest.Mock).mockReturnValue(mockTodayTimestamp);
 
     service = new PlanningService(mockVault);
   });
@@ -44,7 +44,7 @@ Task content.`;
 
       const expectedContent = `---
 title: My Task
-ems__Effort_day: ${mockTodayWikilink}
+ems__Effort_plannedStartTimestamp: ${mockTodayTimestamp}
 ---
 
 Task content.`;
@@ -57,7 +57,7 @@ Task content.`;
       expect(mockVault.getAbstractFileByPath).toHaveBeenCalledWith(taskPath);
       expect(mockVault.read).toHaveBeenCalledWith(mockFile);
       expect(mockVault.modify).toHaveBeenCalledWith(mockFile, expectedContent);
-      expect(DateFormatter.getTodayWikilink).toHaveBeenCalled();
+      expect(DateFormatter.getTodayStartTimestamp).toHaveBeenCalled();
     });
 
     it("should throw error when file not found", async () => {
@@ -90,18 +90,18 @@ Task content.`;
       expect(mockVault.modify).not.toHaveBeenCalled();
     });
 
-    it("should update existing ems__Effort_day property", async () => {
+    it("should update existing ems__Effort_plannedStartTimestamp property", async () => {
       const taskPath = "/path/to/task.md";
       const originalContent = `---
 title: My Task
-ems__Effort_day: "[[2025-01-10]]"
+ems__Effort_plannedStartTimestamp: 2025-01-10T00:00:00
 ---
 
 Task content.`;
 
       const expectedContent = `---
 title: My Task
-ems__Effort_day: ${mockTodayWikilink}
+ems__Effort_plannedStartTimestamp: ${mockTodayTimestamp}
 ---
 
 Task content.`;
@@ -119,7 +119,7 @@ Task content.`;
       const originalContent = "Task content without frontmatter.";
 
       const expectedContent = `---
-ems__Effort_day: ${mockTodayWikilink}
+ems__Effort_plannedStartTimestamp: ${mockTodayTimestamp}
 ---
 Task content without frontmatter.`;
 
@@ -149,7 +149,7 @@ Task content.`;
 
       expect(mockVault.modify).toHaveBeenCalled();
       const modifiedContent = mockVault.modify.mock.calls[0][1];
-      expect(modifiedContent).toContain(`ems__Effort_day: ${mockTodayWikilink}`);
+      expect(modifiedContent).toContain(`ems__Effort_plannedStartTimestamp: ${mockTodayTimestamp}`);
       expect(modifiedContent).toContain("title: My Task");
       expect(modifiedContent).toContain("exo__Asset_uid: task-123");
     });


### PR DESCRIPTION
## Summary
Changes the 'Plan on Today' command behavior to set `ems__Effort_plannedStartTimestamp` instead of `ems__Effort_day`.

## Changes
- ✅ Modified `PlanningService.planOnToday()` to set `ems__Effort_plannedStartTimestamp`
- ✅ Timestamp set to start of current day (00:00:00)
- ✅ Added `DateFormatter.getTodayStartTimestamp()` helper method
- ✅ Updated all PlanningService tests to reflect new behavior

## Test Plan
- [x] Run `npm run test:all`
- [x] All PlanningService tests pass
- [x] No regressions in other tests (1 pre-existing failure unrelated to changes)

## Related
Closes #319