### PR TITLE
fix: correct timezone handling in DailyNote task filtering

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
@@ -74,23 +74,28 @@ export class DailyNoteHelpers {
    *
    * @param metadata - Effort frontmatter metadata
    * @param dayStr - Day string in format "YYYY-MM-DD" (e.g., "2025-11-02")
-   * @returns true if ANY timestamp falls within day's 00:00:00 - 23:59:59 interval
+   * @returns true if ANY timestamp falls within day's 00:00:00 - 23:59:59 interval (local timezone)
    */
   static isEffortInDay(
     metadata: Record<string, unknown>,
     dayStr: string,
   ): boolean {
-    // Parse day string to Date (local midnight)
-    const dayDate = new Date(dayStr);
-    if (isNaN(dayDate.getTime())) {
+    // Parse day string to Date in local timezone
+    // Split "YYYY-MM-DD" and use Date constructor with year, month, day
+    const parts = dayStr.split("-").map(Number);
+    if (parts.length !== 3 || parts.some(isNaN)) {
       return false; // Invalid day format
     }
+    
+    const [year, month, day] = parts;
+    
+    // Create date in local timezone (month is 0-indexed)
+    const dayStart = new Date(year, month - 1, day, 0, 0, 0, 0);
+    if (isNaN(dayStart.getTime())) {
+      return false; // Invalid date
+    }
 
-    // Define day interval (local timezone)
-    const dayStart = new Date(dayDate); // Already at 00:00:00.000
-
-    const dayEnd = new Date(dayDate);
-    dayEnd.setHours(23, 59, 59, 999);
+    const dayEnd = new Date(year, month - 1, day, 23, 59, 59, 999);
 
     // Collect all timestamp fields
     const timestampFields = [

--- a/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.test.ts
+++ b/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.test.ts
@@ -327,5 +327,22 @@ describe("DailyNoteHelpers", () => {
       const metadata = { ems__Effort_startTimestamp: "2025-11-03T00:00:00" };
       expect(DailyNoteHelpers.isEffortInDay(metadata, day)).toBe(false);
     });
+
+    it("returns true for early morning timestamps (before 05:00) in local timezone", () => {
+      // Bug fix test: tasks with plannedStartTimestamp < 05:00 should show in correct day
+      // regardless of timezone (e.g., UTC+5)
+      const metadata = {
+        ems__Effort_plannedStartTimestamp: "2025-11-02T02:30:00",
+      };
+      expect(DailyNoteHelpers.isEffortInDay(metadata, day)).toBe(true);
+    });
+
+    it("returns true for midnight timestamp in local timezone", () => {
+      // Verify that 00:00:00 local time is correctly handled
+      const metadata = {
+        ems__Effort_plannedStartTimestamp: "2025-11-02T00:00:00",
+      };
+      expect(DailyNoteHelpers.isEffortInDay(metadata, day)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Problem

Tasks with `ems__Effort_plannedStartTimestamp < 05:00` were not showing in DailyNote layouts for users in UTC+5 timezone.

## Root Cause

The `isEffortInDay` method used `new Date('YYYY-MM-DD')` which parses the string as **UTC midnight**, not local midnight. For UTC+5 users:
- `'2025-11-02'` → `2025-11-02T00:00:00Z` (UTC)
- In local time: `2025-11-02T05:00:00+05:00`
- Tasks before 05:00 local time fell into the **previous day** by UTC

## Solution

Changed date parsing to use `new Date(year, month-1, day, 0, 0, 0, 0)` constructor, which creates dates in **local timezone**.

## Changes
- Modified `DailyNoteHelpers.isEffortInDay()` to parse day string in local timezone
- Added tests for early morning timestamps (< 05:00) and midnight edge cases
- All existing tests continue to pass

## Testing
- Added specific test for timestamps before 05:00
- Added test for midnight (00:00:00) edge case
- Verified existing timezone-agnostic tests still pass