### PR TITLE
fix: use Obsidian default folder for session events

### DIFF
--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -140,6 +140,13 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
     return newContent;
   }
 
+  getDefaultNewFileParent(): IFolder | null {
+    return {
+      path: "",
+      name: "",
+    };
+  }
+
   private resolvePath(filePath: string): string {
     if (path.isAbsolute(filePath)) {
       return filePath;

--- a/packages/core/src/interfaces/IVaultAdapter.ts
+++ b/packages/core/src/interfaces/IVaultAdapter.ts
@@ -33,4 +33,5 @@ export interface IVaultAdapter {
   createFolder(path: string): Promise<void>;
   getFirstLinkpathDest(linkpath: string, sourcePath: string): IFile | null;
   process(file: IFile, fn: (content: string) => string): Promise<string>;
+  getDefaultNewFileParent(): IFolder | null;
 }

--- a/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
+++ b/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
@@ -99,6 +99,12 @@ export class ObsidianVaultAdapter implements IVaultAdapter {
     return await this.vault.process(obsidianFile, fn);
   }
 
+  getDefaultNewFileParent(): IFolder | null {
+    const folder = this.app.fileManager.getNewFileParent("");
+    if (!folder) return null;
+    return this.fromObsidianFolder(folder);
+  }
+
   private fromObsidianFile(file: TFile): IFile {
     const iFile: IFile = {
       path: file.path,

--- a/packages/obsidian-plugin/tests/unit/SetFocusAreaCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SetFocusAreaCommand.test.ts
@@ -29,13 +29,19 @@ describe("SetFocusAreaCommand", () => {
       refreshLayout: jest.fn(),
       vaultAdapter: {
         create: jest.fn().mockResolvedValue({
-          path: "Events/test-uid.md",
+          path: "test-uid.md",
           basename: "test-uid",
           name: "test-uid.md",
           parent: null,
         }),
         getAllFiles: jest.fn().mockReturnValue([]),
         getFrontmatter: jest.fn().mockReturnValue(null),
+        getDefaultNewFileParent: jest.fn().mockReturnValue({
+          path: "",
+          name: "",
+        }),
+        exists: jest.fn().mockResolvedValue(true),
+        createFolder: jest.fn().mockResolvedValue(undefined),
       },
     } as unknown as jest.Mocked<ExocortexPluginInterface>;
 


### PR DESCRIPTION
## Summary

Fixes issue where Set Focus Area command failed with `ENOENT: no such file or directory` error when the hardcoded `Events` folder didn't exist.

## Changes

- Added `getDefaultNewFileParent()` method to `IVaultAdapter` interface
- Implemented `getDefaultNewFileParent()` in `ObsidianVaultAdapter` using Obsidian's `fileManager.getNewFileParent()`
- Updated `SessionEventService` to use vault's default new file location as fallback instead of hardcoded `"Events"`
- Added folder existence check before creating session event files
- Auto-create folder if it doesn't exist (prevents ENOENT errors)
- Updated all unit tests to reflect new default folder behavior
- Fixed `SetFocusAreaCommand` tests to include new vault adapter methods

## Behavior

**Before:**
- Session events always created in `Events/` folder
- Command failed with ENOENT error if `Events/` didn't exist
- No respect for user's Obsidian default new file location setting

**After:**
- Session events created in Obsidian's default new file location (vault root by default)
- Folder auto-created if it doesn't exist (no more ENOENT errors)
- When ontology is selected in settings, session events still created in ontology's folder ✅

## Test Plan

- ✅ All unit tests pass (1283 tests)
- ✅ Folder creation logic tested with new test cases
- ✅ SetFocusAreaCommand tests updated and passing