### PR TITLE
fix: use display label for Name column sorting

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -192,8 +192,8 @@ const SingleTable: React.FC<SingleTableProps> = ({
       let bVal: string | number;
 
       if (sortState.column === "title") {
-        aVal = a.title.toLowerCase();
-        bVal = b.title.toLowerCase();
+        aVal = getDisplayLabel(a).toLowerCase();
+        bVal = getDisplayLabel(b).toLowerCase();
       } else if (sortState.column === "exo__Instance_class") {
         const aClass = getInstanceClass(a.metadata);
         const bClass = getInstanceClass(b.metadata);

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -65,10 +65,11 @@ export class RelationsRenderer {
 
         if (referencingProperties.length > 0) {
           for (const propertyName of referencingProperties) {
+            const displayLabel = enrichedMetadata.exo__Asset_label || sourceFile.basename;
             const relation: AssetRelation = {
               file: sourceFile,
               path: sourcePath,
-              title: sourceFile.basename,
+              title: displayLabel,
               metadata: enrichedMetadata,
               propertyName: propertyName,
               isBodyLink: false,
@@ -80,10 +81,11 @@ export class RelationsRenderer {
             relations.push(relation);
           }
         } else {
+          const displayLabel = enrichedMetadata.exo__Asset_label || sourceFile.basename;
           const relation: AssetRelation = {
             file: sourceFile,
             path: sourcePath,
-            title: sourceFile.basename,
+            title: displayLabel,
             metadata: enrichedMetadata,
             propertyName: undefined,
             isBodyLink: true,

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -191,7 +191,7 @@ describe("RelationsRenderer", () => {
         expect(result[0]).toMatchObject({
           file: sourceFile,
           path: sourceFile.path,
-          title: sourceFile.basename,
+          title: "Resolved Label",
           propertyName: undefined,
           isBodyLink: true,
           isArchived: false,
@@ -459,7 +459,7 @@ describe("RelationsRenderer", () => {
 
         mockApp.vault.getAbstractFileByPath.mockImplementation((path) => fileMap.get(path));
         mockApp.metadataCache.getFileCache.mockReturnValue({
-          frontmatter: createMockMetadata(),
+          frontmatter: createMockMetadata({ exo__Asset_label: null }),
         });
         MetadataHelpers.isAssetArchived.mockReturnValue(false);
         MetadataHelpers.findAllReferencingProperties.mockReturnValue([]);
@@ -602,7 +602,7 @@ describe("RelationsRenderer", () => {
         mockBacklinksCacheManager.getBacklinks.mockReturnValue([sourceFile.path]);
         mockApp.vault.getAbstractFileByPath.mockReturnValue(sourceFile);
         mockApp.metadataCache.getFileCache.mockReturnValue({
-          frontmatter: createMockMetadata(),
+          frontmatter: createMockMetadata({ exo__Asset_label: null }),
         });
         MetadataHelpers.isAssetArchived.mockReturnValue(false);
         MetadataHelpers.findAllReferencingProperties.mockReturnValue([]);


### PR DESCRIPTION
## Problem
Tables in Layout sorted by file basename instead of displayed name (exo__Asset_label).

## Solution
- **AssetRelationsTable.tsx**: Use `getDisplayLabel()` for sorting instead of `a.title`
- **RelationsRenderer.ts**: Set `title` to `exo__Asset_label || basename`
- **Tests**: Updated expectations to match new behavior

## Testing
- ✅ 1480 unit tests passed
- ✅ 55 UI tests passed  
- ✅ 285 component tests passed
- CI will run E2E tests in Docker

## Impact
Users will see proper sorting by displayed names in all relation tables.