### PR TITLE
docs: add sorting post-mortem learnings from PR #337

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -927,6 +927,47 @@ exocortex-assets-relations         // line 1196
 // NOTE: .exocortex-layout-container does NOT exist!
 ```
 
+### Test Mock Default Values Can Mask Bugs
+
+**Problem:** Test passes when it should fail because mock helper provides default value that hides "missing data" scenario.
+
+**Example from PR #337 (Name Sorting Fix):**
+
+After fixing code to use `exo__Asset_label || basename`, tests failed with:
+```
+Expected: "a-file" (basename)
+Received: "Test Asset" (mock default)
+```
+
+**Root Cause:** Test helper `createMockMetadata()` provides default values:
+```typescript
+// In tests/unit/helpers/testHelpers.ts
+export function createMockMetadata(overrides?: Record<string, any>) {
+  return {
+    exo__Asset_label: "Test Asset",  // ⚠️ Default value masks "missing label" tests
+    exo__Instance_class: "ems__Task",
+    // ...
+    ...overrides,
+  };
+}
+```
+
+**Solution:** Explicitly override with `null` to test fallback behavior:
+```typescript
+// ✅ CORRECT - Tests basename fallback when label missing
+frontmatter: createMockMetadata({ exo__Asset_label: null }),
+```
+
+**Prevention:**
+1. Review default values in test helpers before writing tests
+2. Explicitly test missing data scenarios with `null` overrides
+3. Don't assume defaults match your test intention
+4. Read test helper source when tests pass but logic seems wrong
+
+**Test Helper Location:** `packages/obsidian-plugin/tests/unit/helpers/testHelpers.ts`
+
+**Example:** See PR #337 for display label resolution fix and test updates.
+
 ## 📚 Key Resources
 
 **Internal:**


### PR DESCRIPTION
## Summary

Document three key learnings from PR #337 (Name sorting fix) to prevent similar issues in future development.

### Changes

1. **AGENTS.md** - Display Name Resolution Pattern
   - Resolve display labels once at source (Renderer) → single source of truth
   - Sort by display value, not internal identifier
   - Prevents sorting/display inconsistencies

2. **CLAUDE.md** - Test Mock Default Values Troubleshooting
   - `createMockMetadata()` defaults can mask "missing data" tests
   - Explicitly override with `null` to test fallback behavior
   - Review test helper defaults before writing tests

3. **packages/obsidian-plugin/CLAUDE.md** - Table Sorting Best Practices
   - Sort by what user sees (display value)
   - Comprehensive examples of correct vs wrong patterns
   - Testing patterns for sort + display behavior

### Impact

- **Prevents similar bugs**: Future developers will know to resolve display names at source
- **Better tests**: Guidance on test mocks prevents hidden test bugs
- **Clear patterns**: Sorting best practices documented with examples

### Test Plan

- [x] Documentation-only changes
- [x] No code modifications
- [x] CI will verify markdown formatting

### Related

- Based on learnings from PR #337
- Implements RULE #2 (Mandatory Self-Improvement)