### PR TITLE
fix: add Show Archived toggle to AssetRelationsTable for pn__DailyNote layout

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -381,14 +381,20 @@ export interface AssetRelationsTableWithToggleProps
   extends AssetRelationsTableProps {
   showEffortVotes: boolean;
   onToggleEffortVotes: () => void;
+  showArchived: boolean;
+  onToggleArchived: () => void;
 }
 
 export const AssetRelationsTableWithToggle: React.FC<
   AssetRelationsTableWithToggleProps
-> = ({ showEffortVotes, onToggleEffortVotes, showProperties = [], ...props }) => {
+> = ({ showEffortVotes, onToggleEffortVotes, showArchived, onToggleArchived, showProperties = [], ...props }) => {
   const enhancedShowProperties = showEffortVotes
     ? [...showProperties, "ems__Effort_votes"]
     : showProperties;
+
+  const filteredRelations = showArchived
+    ? props.relations
+    : props.relations.filter(r => !r.isArchived);
 
   return (
     <div className="exocortex-relations-wrapper">
@@ -398,6 +404,7 @@ export const AssetRelationsTableWithToggle: React.FC<
           onClick={onToggleEffortVotes}
           style={{
             marginBottom: "8px",
+            marginRight: "8px",
             padding: "4px 8px",
             cursor: "pointer",
             fontSize: "12px",
@@ -405,9 +412,22 @@ export const AssetRelationsTableWithToggle: React.FC<
         >
           {showEffortVotes ? "Hide" : "Show"} Votes
         </button>
+        <button
+          className="exocortex-toggle-archived"
+          onClick={onToggleArchived}
+          style={{
+            marginBottom: "8px",
+            padding: "4px 8px",
+            cursor: "pointer",
+            fontSize: "12px",
+          }}
+        >
+          {showArchived ? "Hide" : "Show"} Archived
+        </button>
       </div>
       <AssetRelationsTable
         {...props}
+        relations={filteredRelations}
         showProperties={enhancedShowProperties}
       />
     </div>

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -48,10 +48,6 @@ export class RelationsRenderer {
 
         const isArchived = MetadataHelpers.isAssetArchived(metadata);
 
-        if (isArchived && !this.settings.showArchivedAssets) {
-          continue;
-        }
-
         const referencingProperties =
           MetadataHelpers.findAllReferencingProperties(metadata, file.basename);
 
@@ -138,6 +134,12 @@ export class RelationsRenderer {
         showEffortVotes: this.settings.showEffortVotes,
         onToggleEffortVotes: async () => {
           this.settings.showEffortVotes = !this.settings.showEffortVotes;
+          await this.plugin.saveSettings();
+          await this.refresh();
+        },
+        showArchived: this.settings.showArchivedAssets,
+        onToggleArchived: async () => {
+          this.settings.showArchivedAssets = !this.settings.showArchivedAssets;
           await this.plugin.saveSettings();
           await this.refresh();
         },

--- a/packages/obsidian-plugin/tests/component/AssetRelationsTable.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/AssetRelationsTable.spec.tsx
@@ -513,6 +513,8 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
         relations={mockRelationsWithVotes}
         showEffortVotes={false}
         onToggleEffortVotes={() => {}}
+        showArchived={false}
+        onToggleArchived={() => {}}
       />,
     );
 
@@ -532,6 +534,8 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
         relations={mockRelationsWithVotes}
         showEffortVotes={true}
         onToggleEffortVotes={() => {}}
+        showArchived={false}
+        onToggleArchived={() => {}}
       />,
     );
 
@@ -551,6 +555,8 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
         relations={mockRelationsWithVotes}
         showEffortVotes={false}
         onToggleEffortVotes={() => {}}
+        showArchived={false}
+        onToggleArchived={() => {}}
       />,
     );
 
@@ -574,6 +580,8 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
         onToggleEffortVotes={() => {
           toggleCalled = true;
         }}
+        showArchived={false}
+        onToggleArchived={() => {}}
       />,
     );
 
@@ -589,6 +597,8 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
         relations={mockRelationsWithVotes}
         showEffortVotes={false}
         onToggleEffortVotes={() => {}}
+        showArchived={false}
+        onToggleArchived={() => {}}
         groupByProperty={true}
         showProperties={["ems__Effort_status"]}
       />,
@@ -598,6 +608,131 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
     await expect(
       component.locator('th:has-text("ems__Effort_status")'),
     ).toBeVisible();
+  });
+
+  test("should render Show Archived toggle button", async ({ mount }) => {
+    const component = await mount(
+      <AssetRelationsTableWithToggle
+        relations={mockRelationsWithVotes}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
+        showArchived={false}
+        onToggleArchived={() => {}}
+      />,
+    );
+
+    await expect(
+      component.locator("button.exocortex-toggle-archived"),
+    ).toBeVisible();
+    await expect(
+      component.locator("button.exocortex-toggle-archived"),
+    ).toHaveText("Show Archived");
+  });
+
+  test("should filter archived relations when showArchived is false", async ({
+    mount,
+  }) => {
+    const relationsWithArchived: AssetRelation[] = [
+      {
+        path: "tasks/active-task.md",
+        title: "Active Task",
+        propertyName: "ems__Effort_parent",
+        isBodyLink: false,
+        created: Date.now(),
+        modified: Date.now(),
+        isArchived: false,
+        metadata: { exo__Instance_class: "ems__Task" },
+      },
+      {
+        path: "tasks/archived-task.md",
+        title: "Archived Task",
+        propertyName: "ems__Effort_parent",
+        isBodyLink: false,
+        created: Date.now(),
+        modified: Date.now(),
+        isArchived: true,
+        metadata: { exo__Instance_class: "ems__Task", exo__Asset_isArchived: true },
+      },
+    ];
+
+    const component = await mount(
+      <AssetRelationsTableWithToggle
+        relations={relationsWithArchived}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
+        showArchived={false}
+        onToggleArchived={() => {}}
+      />,
+    );
+
+    await expect(component.locator("text=Active Task")).toBeVisible();
+    await expect(component.locator("text=Archived Task")).not.toBeVisible();
+    await expect(component.locator("tbody tr")).toHaveCount(1);
+  });
+
+  test("should show archived relations when showArchived is true", async ({
+    mount,
+  }) => {
+    const relationsWithArchived: AssetRelation[] = [
+      {
+        path: "tasks/active-task.md",
+        title: "Active Task",
+        propertyName: "ems__Effort_parent",
+        isBodyLink: false,
+        created: Date.now(),
+        modified: Date.now(),
+        isArchived: false,
+        metadata: { exo__Instance_class: "ems__Task" },
+      },
+      {
+        path: "tasks/archived-task.md",
+        title: "Archived Task",
+        propertyName: "ems__Effort_parent",
+        isBodyLink: false,
+        created: Date.now(),
+        modified: Date.now(),
+        isArchived: true,
+        metadata: { exo__Instance_class: "ems__Task", exo__Asset_isArchived: true },
+      },
+    ];
+
+    const component = await mount(
+      <AssetRelationsTableWithToggle
+        relations={relationsWithArchived}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
+        showArchived={true}
+        onToggleArchived={() => {}}
+      />,
+    );
+
+    await expect(component.locator("text=Active Task")).toBeVisible();
+    await expect(component.locator("text=Archived Task")).toBeVisible();
+    await expect(component.locator("tbody tr")).toHaveCount(2);
+    await expect(
+      component.locator("button.exocortex-toggle-archived"),
+    ).toHaveText("Hide Archived");
+  });
+
+  test("should call onToggleArchived when button clicked", async ({
+    mount,
+  }) => {
+    let toggleCalled = false;
+
+    const component = await mount(
+      <AssetRelationsTableWithToggle
+        relations={mockRelationsWithVotes}
+        showEffortVotes={false}
+        onToggleEffortVotes={() => {}}
+        showArchived={false}
+        onToggleArchived={() => {
+          toggleCalled = true;
+        }}
+      />,
+    );
+
+    await component.locator("button.exocortex-toggle-archived").click();
+    expect(toggleCalled).toBe(true);
   });
 
   test("should have sortable dynamic property headers", async ({ mount }) => {


### PR DESCRIPTION
## Summary

Fixes bug where "Show Archived" button had no effect in pn__DailyNote layout.

## Root Cause

-  was filtering archived relations server-side before passing to component
-  component had no UI button to toggle archived visibility
- Users saw filtered results but couldn't toggle the filter

## Solution

- **Moved filtering** from server-side (RelationsRenderer) to client-side (React component)
- **Added toggle button** alongside existing "Show Votes" button
- **Client-side filtering**: `const filteredRelations = showArchived ? props.relations : props.relations.filter(r => !r.isArchived)`

## Changes

**Component (AssetRelationsTableWithToggle):**
- Added `showArchived` and `onToggleArchived` props
- Implemented client-side filtering logic
- Added "Show Archived" / "Hide Archived" button

**Renderer (RelationsRenderer):**
- Removed server-side filtering (`if (isArchived && !this.settings.showArchivedAssets) continue;`)
- Added `showArchived` and `onToggleArchived` prop passing

**Tests:**
- Updated all component tests to include new required props
- Added 3 new tests for archived filtering behavior:
  - "should render Show Archived toggle button"
  - "should filter archived relations when showArchived is false"
  - "should show archived relations when showArchived is true"
- Fixed 2 unit tests in RelationsRenderer to expect all relations with isArchived flags

## Test plan

- [x] Unit tests pass (803 tests)
- [x] Component tests pass (289 tests, 3 skipped)
- [x] UI tests pass
- [x] Manual testing: Show Archived button now works in pn__DailyNote layout