### PR TITLE
test: add comprehensive E2E test for Show Archived button in pn__DailyNote

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/archived-button.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/archived-button.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Show Archived Button in pn__DailyNote", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("http://localhost:8080");
+
+    await page.waitForSelector(".exocortex-action-buttons-container", {
+      timeout: 10000,
+    });
+
+    const dailyNoteLink = page.locator('a[href*="2025-10-18"]').first();
+    if (await dailyNoteLink.isVisible()) {
+      await dailyNoteLink.click();
+      await page.waitForTimeout(1000);
+    }
+  });
+
+  test("should display Show Archived toggle button in relations section", async ({ page }) => {
+    const relationsSection = page.locator(".exocortex-assets-relations");
+    await expect(relationsSection).toBeVisible({ timeout: 10000 });
+
+    const showArchivedButton = page.locator("button.exocortex-toggle-archived");
+    await expect(showArchivedButton).toBeVisible();
+
+    const buttonText = await showArchivedButton.textContent();
+    expect(buttonText).toContain("Show Archived");
+  });
+
+  test("should hide archived assets by default", async ({ page }) => {
+    const relationsSection = page.locator(".exocortex-assets-relations");
+    await expect(relationsSection).toBeVisible({ timeout: 10000 });
+
+    await page.waitForTimeout(1000);
+
+    const archivedTaskRow = page.locator('text="Archived Task"');
+    const isVisible = await archivedTaskRow.isVisible().catch(() => false);
+
+    expect(isVisible).toBe(false);
+  });
+
+  test("should show archived assets when Show Archived button is clicked", async ({ page }) => {
+    const relationsSection = page.locator(".exocortex-assets-relations");
+    await expect(relationsSection).toBeVisible({ timeout: 10000 });
+
+    const showArchivedButton = page.locator("button.exocortex-toggle-archived");
+    await expect(showArchivedButton).toBeVisible();
+
+    const rowsBeforeClick = await page.locator(".exocortex-relation-table tbody tr").count();
+
+    await showArchivedButton.click();
+    await page.waitForTimeout(500);
+
+    const buttonTextAfter = await showArchivedButton.textContent();
+    expect(buttonTextAfter).toContain("Hide Archived");
+
+    const archivedTaskRow = page.locator('text="Archived Task"');
+    await expect(archivedTaskRow).toBeVisible({ timeout: 5000 });
+
+    const rowsAfterClick = await page.locator(".exocortex-relation-table tbody tr").count();
+    expect(rowsAfterClick).toBeGreaterThan(rowsBeforeClick);
+  });
+
+  test("should hide archived assets again when Hide Archived button is clicked", async ({ page }) => {
+    const relationsSection = page.locator(".exocortex-assets-relations");
+    await expect(relationsSection).toBeVisible({ timeout: 10000 });
+
+    const showArchivedButton = page.locator("button.exocortex-toggle-archived");
+    await expect(showArchivedButton).toBeVisible();
+
+    await showArchivedButton.click();
+    await page.waitForTimeout(500);
+
+    const archivedTaskRow = page.locator('text="Archived Task"');
+    await expect(archivedTaskRow).toBeVisible({ timeout: 5000 });
+
+    const rowsWithArchived = await page.locator(".exocortex-relation-table tbody tr").count();
+
+    await showArchivedButton.click();
+    await page.waitForTimeout(500);
+
+    const buttonText = await showArchivedButton.textContent();
+    expect(buttonText).toContain("Show Archived");
+
+    const isVisible = await archivedTaskRow.isVisible().catch(() => false);
+    expect(isVisible).toBe(false);
+
+    const rowsWithoutArchived = await page.locator(".exocortex-relation-table tbody tr").count();
+    expect(rowsWithoutArchived).toBeLessThan(rowsWithArchived);
+  });
+
+  test("should persist archived visibility state across page reloads", async ({ page }) => {
+    const relationsSection = page.locator(".exocortex-assets-relations");
+    await expect(relationsSection).toBeVisible({ timeout: 10000 });
+
+    const showArchivedButton = page.locator("button.exocortex-toggle-archived");
+    await expect(showArchivedButton).toBeVisible();
+
+    await showArchivedButton.click();
+    await page.waitForTimeout(500);
+
+    const archivedTaskRow = page.locator('text="Archived Task"');
+    await expect(archivedTaskRow).toBeVisible({ timeout: 5000 });
+
+    await page.reload();
+    await page.waitForSelector(".exocortex-assets-relations", { timeout: 10000 });
+    await page.waitForTimeout(1000);
+
+    const archivedTaskAfterReload = page.locator('text="Archived Task"');
+    const isVisibleAfterReload = await archivedTaskAfterReload.isVisible({ timeout: 5000 }).catch(() => false);
+
+    expect(isVisibleAfterReload).toBe(true);
+
+    const buttonTextAfterReload = await page.locator("button.exocortex-toggle-archived").textContent();
+    expect(buttonTextAfterReload).toContain("Hide Archived");
+  });
+
+  test("should only filter archived assets, not other assets", async ({ page }) => {
+    const relationsSection = page.locator(".exocortex-assets-relations");
+    await expect(relationsSection).toBeVisible({ timeout: 10000 });
+
+    const showArchivedButton = page.locator("button.exocortex-toggle-archived");
+    await expect(showArchivedButton).toBeVisible();
+
+    const nonArchivedRowsInitial = await page.locator(".exocortex-relation-table tbody tr").count();
+
+    await showArchivedButton.click();
+    await page.waitForTimeout(500);
+
+    const allRowsAfterShow = await page.locator(".exocortex-relation-table tbody tr").count();
+
+    const archivedCount = allRowsAfterShow - nonArchivedRowsInitial;
+    expect(archivedCount).toBeGreaterThan(0);
+
+    const regularTaskRows = page.locator('tbody tr').filter({ hasNotText: "Archived Task" });
+    const regularCount = await regularTaskRows.count();
+    expect(regularCount).toBe(nonArchivedRowsInitial);
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive E2E test to verify the "Show Archived" button functionality in pn__DailyNote layout.

## Test Coverage

The E2E test validates:
1. ✅ Button visibility - Show Archived toggle button is rendered
2. ✅ Default behavior - Archived assets are hidden by default  
3. ✅ Show functionality - Clicking button reveals archived assets
4. ✅ Hide functionality - Clicking again hides archived assets
5. ✅ State persistence - Settings are saved and restored across page reloads
6. ✅ Selective filtering - Only archived assets are filtered, not regular ones

## Test Data

Uses existing test vault data:
- Daily note: `2025-10-18.md` with `pn__DailyNote` layout
- Archived task: `archived-task.md` with `exo__Asset_isArchived: true`
- Task references daily note via `ems__Effort_day: "[[2025-10-18]]"`

## Why This Test?

User reported the Show Archived button is not working. This E2E test will run in Docker CI environment to verify the functionality works correctly end-to-end, not just in unit/component tests.

## Next Steps

CI will run this E2E test in Docker. If it:
- ✅ **Passes** → Functionality works correctly (user may need to update plugin version)
- ❌ **Fails** → Will identify exact issue and create fix PR

Related to PR #343 which added the Show Archived button feature.