### PR TITLE
test: add E2E test coverage for legacy archived field format

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/archived-button.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/archived-button.spec.ts
@@ -135,4 +135,26 @@ test.describe("Show Archived Button in pn__DailyNote", () => {
     const regularCount = await regularTaskRows.count();
     expect(regularCount).toBe(nonArchivedRowsInitial);
   });
+
+  test("should support both archived field formats (archived and exo__Asset_isArchived)", async ({ page }) => {
+    const relationsSection = page.locator(".exocortex-assets-relations");
+    await expect(relationsSection).toBeVisible({ timeout: 10000 });
+
+    const showArchivedButton = page.locator("button.exocortex-toggle-archived");
+    await expect(showArchivedButton).toBeVisible();
+
+    const rowsBeforeClick = await page.locator(".exocortex-relation-table tbody tr").count();
+
+    await showArchivedButton.click();
+    await page.waitForTimeout(500);
+
+    const newFormatTask = page.locator('text="Archived Task"').first();
+    await expect(newFormatTask).toBeVisible({ timeout: 5000 });
+
+    const legacyFormatTask = page.locator('text="Archived Task (Legacy Format)"');
+    await expect(legacyFormatTask).toBeVisible({ timeout: 5000 });
+
+    const rowsAfterClick = await page.locator(".exocortex-relation-table tbody tr").count();
+    expect(rowsAfterClick).toBeGreaterThanOrEqual(rowsBeforeClick + 2);
+  });
 });

--- a/packages/obsidian-plugin/tests/e2e/test-vault/Tasks/archived-task-legacy.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/Tasks/archived-task-legacy.md
@@ -1,0 +1,15 @@
+---
+exo__Instance_class: "[[ems__Task]]"
+exo__Asset_label: "Archived Task (Legacy Format)"
+exo__Asset_uid: test-task-archived-legacy-001
+archived: true
+ems__Effort_status: "[[ems__EffortStatusDone]]"
+ems__Effort_day: "[[2025-10-18]]"
+ems__Effort_area: "[[development]]"
+ems__Effort_startTimestamp: "2025-10-18T13:00:00"
+ems__Effort_endTimestamp: "2025-10-18T14:00:00"
+---
+# Archived Task (Legacy Format)
+
+This task uses the legacy `archived: true` field instead of `exo__Asset_isArchived: true`.
+It should also be hidden by default when Show Archived is off.


### PR DESCRIPTION
## Summary
Extends E2E test coverage to verify backward compatibility with legacy `archived: true` field (in addition to `exo__Asset_isArchived: true`).

## Changes
- Added test file with `archived: true` field (legacy format)
- Added E2E test case to verify both archived field formats work correctly
- Ensures Show Archived button filters assets with either field format

## Testing
- New E2E test verifies both `archived` and `exo__Asset_isArchived` fields
- All existing tests pass

## Related
- Followup to #345
- Addresses user feedback about `archived` field support