### PR TITLE
feat: user-friendly SPARQL error and empty state UI (#248)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,7 +54,7 @@ export { InMemoryTripleStore } from "./infrastructure/rdf/InMemoryTripleStore";
 export { NoteToRDFConverter } from "./services/NoteToRDFConverter";
 
 // SPARQL Engine exports
-export { SPARQLParser, type SPARQLQuery, type SelectQuery, type ConstructQuery } from "./infrastructure/sparql/SPARQLParser";
+export { SPARQLParser, SPARQLParseError, type SPARQLQuery, type SelectQuery, type ConstructQuery } from "./infrastructure/sparql/SPARQLParser";
 export { AlgebraTranslator } from "./infrastructure/sparql/algebra/AlgebraTranslator";
 export { AlgebraOptimizer } from "./infrastructure/sparql/algebra/AlgebraOptimizer";
 export { AlgebraSerializer } from "./infrastructure/sparql/algebra/AlgebraSerializer";

--- a/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLEmptyState.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLEmptyState.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+export interface SPARQLEmptyStateProps {
+  queryString?: string;
+}
+
+const getQueryType = (query: string): string => {
+  const upperQuery = query.toUpperCase().trim();
+  if (upperQuery.startsWith("SELECT")) return "SELECT";
+  if (upperQuery.startsWith("CONSTRUCT")) return "CONSTRUCT";
+  if (upperQuery.startsWith("ASK")) return "ASK";
+  if (upperQuery.startsWith("DESCRIBE")) return "DESCRIBE";
+  return "query";
+};
+
+export const SPARQLEmptyState: React.FC<SPARQLEmptyStateProps> = ({ queryString }) => {
+  const queryType = queryString ? getQueryType(queryString) : "query";
+
+  return (
+    <div className="sparql-empty-state">
+      <div className="sparql-empty-icon">📭</div>
+      <h3 className="sparql-empty-title">no results found</h3>
+      <p className="sparql-empty-message">
+        your {queryType} query returned no matching data
+      </p>
+
+      <div className="sparql-empty-hints">
+        <h4>suggestions:</h4>
+        <ul>
+          <li>verify that your vault contains notes with matching properties</li>
+          <li>check your WHERE clause conditions</li>
+          <li>try broadening your filter criteria</li>
+          <li>ensure property names match your note frontmatter (e.g., exo__Asset_label, ems__Task)</li>
+        </ul>
+      </div>
+
+      <div className="sparql-empty-example">
+        <strong>example query:</strong>
+        <pre>
+SELECT ?task ?label{"\n"}
+WHERE {"{"}
+{"\n"}  ?task &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;ems__Task&gt; .{"\n"}
+  ?task &lt;exo__Asset_label&gt; ?label .{"\n"}
+{"}"}
+        </pre>
+      </div>
+    </div>
+  );
+};

--- a/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLErrorView.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLErrorView.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+
+export interface SPARQLError {
+  message: string;
+  line?: number;
+  column?: number;
+  queryString?: string;
+}
+
+export interface SPARQLErrorViewProps {
+  error: SPARQLError;
+}
+
+const highlightErrorPosition = (
+  queryString: string,
+  line?: number,
+  column?: number,
+): { beforeError: string; errorChar: string; afterError: string } => {
+  if (!line || !column) {
+    return { beforeError: queryString, errorChar: "", afterError: "" };
+  }
+
+  const lines = queryString.split("\n");
+  const errorLineIndex = line - 1;
+
+  if (errorLineIndex < 0 || errorLineIndex >= lines.length) {
+    return { beforeError: queryString, errorChar: "", afterError: "" };
+  }
+
+  const errorLine = lines[errorLineIndex];
+  const errorColIndex = column - 1;
+
+  if (errorColIndex < 0 || errorColIndex >= errorLine.length) {
+    return { beforeError: queryString, errorChar: "", afterError: "" };
+  }
+
+  const beforeLines = lines.slice(0, errorLineIndex).join("\n");
+  const beforeError = beforeLines + (beforeLines ? "\n" : "") + errorLine.slice(0, errorColIndex);
+  const errorChar = errorLine[errorColIndex];
+  const afterError = errorLine.slice(errorColIndex + 1) + "\n" + lines.slice(errorLineIndex + 1).join("\n");
+
+  return { beforeError, errorChar, afterError };
+};
+
+export const SPARQLErrorView: React.FC<SPARQLErrorViewProps> = ({ error }) => {
+  const isParseError = error.line !== undefined && error.column !== undefined;
+  const highlighted = error.queryString
+    ? highlightErrorPosition(error.queryString, error.line, error.column)
+    : null;
+
+  return (
+    <div className="sparql-error-view">
+      <div className="sparql-error-header">
+        <span className="sparql-error-icon">⚠️</span>
+        <h3 className="sparql-error-title">
+          {isParseError ? "syntax error" : "query execution error"}
+        </h3>
+      </div>
+
+      <div className="sparql-error-message">
+        <strong>error:</strong> {error.message}
+      </div>
+
+      {isParseError && (
+        <div className="sparql-error-position">
+          at line {error.line}, column {error.column}
+        </div>
+      )}
+
+      {highlighted && isParseError && (
+        <div className="sparql-error-code">
+          <pre className="sparql-error-query">
+            {highlighted.beforeError}
+            <span className="sparql-error-highlight">{highlighted.errorChar}</span>
+            {highlighted.afterError}
+          </pre>
+        </div>
+      )}
+
+      <div className="sparql-error-hint">
+        <strong>hint:</strong>{" "}
+        {isParseError
+          ? "check your SPARQL syntax. common issues: missing brackets, unclosed quotes, invalid keywords"
+          : "verify your query logic, check triple store data, ensure proper variable bindings"}
+      </div>
+    </div>
+  );
+};

--- a/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLResultViewer.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLResultViewer.tsx
@@ -5,6 +5,7 @@ import { SPARQLTableView } from "./SPARQLTableView";
 import { SPARQLListView } from "./SPARQLListView";
 import { SPARQLGraphView } from "./SPARQLGraphView";
 import { ViewModeSelector, type ViewMode } from "./ViewModeSelector";
+import { SPARQLEmptyState } from "./SPARQLEmptyState";
 
 export interface SPARQLResultViewerProps {
   results: SolutionMapping[] | Triple[];
@@ -205,11 +206,7 @@ export const SPARQLResultViewer: React.FC<SPARQLResultViewerProps> = ({
   };
 
   if (results.length === 0) {
-    return (
-      <div className="sparql-no-results">
-        no results found
-      </div>
-    );
+    return <SPARQLEmptyState queryString={queryString} />;
   }
 
   return (

--- a/packages/obsidian-plugin/tests/component/sparql/SPARQLErrorView.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/sparql/SPARQLErrorView.spec.tsx
@@ -1,0 +1,142 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import React from "react";
+import { SPARQLErrorView, type SPARQLError } from "../../../src/presentation/components/sparql/SPARQLErrorView";
+
+test.describe("SPARQLErrorView", () => {
+  test("should render parser error with line and column", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Expected WHERE clause",
+      line: 3,
+      column: 15,
+      queryString: "SELECT ?task\nWHERE {\n  ?task <status> ?status\n}",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    await expect(component.getByText(/syntax error/i)).toBeVisible();
+    await expect(component.getByText(/Expected WHERE clause/)).toBeVisible();
+    await expect(component.getByText(/at line 3, column 15/)).toBeVisible();
+  });
+
+  test("should render execution error without line/column", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Triple store not initialized",
+      queryString: "SELECT ?task WHERE { ?task <status> ?status }",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    await expect(component.getByText(/query execution error/i)).toBeVisible();
+    await expect(component.getByText(/Triple store not initialized/)).toBeVisible();
+    await expect(component.getByText(/at line/)).not.toBeVisible();
+  });
+
+  test("should highlight error position in query string", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Unexpected token",
+      line: 1,
+      column: 8,
+      queryString: "SELECT ?",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    const highlightedChar = component.locator(".sparql-error-highlight");
+    await expect(highlightedChar).toBeVisible();
+    await expect(highlightedChar).toHaveText("?");
+  });
+
+  test("should display error hint for parser errors", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Syntax error",
+      line: 2,
+      column: 10,
+      queryString: "SELECT ?task\nWHERE { }",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    await expect(
+      component.getByText(/check your SPARQL syntax/i)
+    ).toBeVisible();
+  });
+
+  test("should display error hint for execution errors", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Query execution failed",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    await expect(
+      component.getByText(/verify your query logic/i)
+    ).toBeVisible();
+  });
+
+  test("should render without query string", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Unknown error occurred",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    await expect(component.getByText(/Unknown error occurred/)).toBeVisible();
+    const codeBlock = component.locator(".sparql-error-code");
+    await expect(codeBlock).not.toBeVisible();
+  });
+
+  test("should render error icon", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Test error",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    const icon = component.locator(".sparql-error-icon");
+    await expect(icon).toBeVisible();
+    await expect(icon).toHaveText("⚠️");
+  });
+
+  test("should handle multiline query with error on second line", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Invalid property",
+      line: 2,
+      column: 3,
+      queryString: "SELECT ?task ?status\nWHERE {\n  ?task <invalid> ?status\n}",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    await expect(component.getByText(/at line 2, column 3/)).toBeVisible();
+    const highlightedChar = component.locator(".sparql-error-highlight");
+    await expect(highlightedChar).toBeVisible();
+  });
+
+  test("should handle error at end of query", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Unexpected end of input",
+      line: 1,
+      column: 13,
+      queryString: "SELECT ?task",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    await expect(component.getByText(/at line 1, column 13/)).toBeVisible();
+    const codeBlock = component.locator(".sparql-error-query");
+    await expect(codeBlock).toBeVisible();
+  });
+
+  test("should handle invalid line number gracefully", async ({ mount }) => {
+    const error: SPARQLError = {
+      message: "Test error",
+      line: 999,
+      column: 1,
+      queryString: "SELECT ?task",
+    };
+
+    const component = await mount(<SPARQLErrorView error={error} />);
+
+    await expect(component.getByText(/at line 999, column 1/)).toBeVisible();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/application/processors/SPARQLCodeBlockProcessor.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/processors/SPARQLCodeBlockProcessor.test.ts
@@ -239,7 +239,7 @@ describe("SPARQLCodeBlockProcessor", () => {
 
       await (processor as any).refreshQuery(el, container, source);
 
-      expect((processor as any).renderError).toHaveBeenCalledWith(error, container);
+      expect((processor as any).renderError).toHaveBeenCalledWith(error, container, source);
       expect(container.innerHTML).toBe("");
     });
   });


### PR DESCRIPTION
## Summary

Implements user-friendly error and empty state UI for SPARQL queries as specified in #248 (Epic 4: Visualization).

### Components Implemented

1. **SPARQLErrorView.tsx** - React component for displaying SPARQL errors with:
   - Syntax error highlighting (shows exact position of parser errors)
   - Line/column display for parse errors
   - Helpful hints based on error type
   - Visual error icon and styling

2. **SPARQLEmptyState.tsx** - React component for empty query results with:
   - Query-type-aware messaging (SELECT, CONSTRUCT, etc.)
   - Helpful suggestions for users
   - Example query snippet
   - Clean, friendly visual design

### Integration

- **SPARQLCodeBlockProcessor.ts**: Modified renderError() to use SPARQLErrorView component
- **SPARQLResultViewer.tsx**: Replaced simple "no results" message with SPARQLEmptyState component
- **@exocortex/core**: Exported SPARQLParseError for use in plugin package

### Tests

- **Component tests**: 10 comprehensive test cases in SPARQLErrorView.spec.tsx covering:
  - Parser errors with line/column display
  - Execution errors without position
  - Syntax highlighting of error position
  - Error hints for both error types
  - Edge cases (invalid line numbers, missing query, etc.)

- **Unit tests**: Updated SPARQLCodeBlockProcessor.test.ts to match new renderError signature

### Test Results

- ✅ Unit tests: 1546 passed
- ✅ UI tests: 55 passed
- ✅ Component tests: 299 passed (including 10 new SPARQLErrorView tests)
- E2E tests will run in CI

### Acceptance Criteria Met

- [x] SPARQLErrorView component created with syntax highlighting
- [x] SPARQLEmptyState component created with query-aware messaging
- [x] Both components integrated into existing SPARQL UI
- [x] Comprehensive component tests written
- [x] All existing tests still pass
- [x] Error view shows line/column for parser errors
- [x] Empty state provides helpful user guidance

### Screenshots

(Will be visible in Obsidian when SPARQL queries fail or return empty results)

Closes #248