### PR TITLE
docs: add learnings from SPARQL API implementation (#249)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1020,6 +1020,35 @@ git push --force-with-lease origin <branch-name>
 
 **Remember**: This is coordinated parallel development working as designed (see RULE 5).
 
+### Verifying Package Exports Before Re-exporting
+
+**Problem**: TypeScript compilation fails with "Module has no exported member 'X'" when re-exporting types from dependencies.
+
+**Root Cause**: Types exist in source files but aren't in package's public API (`index.ts`).
+
+**Solution**:
+1. Verify what's actually exported:
+   ```bash
+   grep -r "export.*TypeName" packages/*/src/index.ts
+   ```
+
+2. If type not found in index.ts, either:
+   - Add it to the package's exports (if it should be public)
+   - Remove it from your re-export list (if it's internal)
+
+3. Verify locally before pushing:
+   ```bash
+   npm run check:types
+   ```
+
+**Example from PR #352**:
+- Tried to export `TriplePattern` from `@exocortex/core`
+- Exists in `packages/core/src/domain/TriplePattern.ts`
+- NOT in `packages/core/src/index.ts` → not public API
+- Solution: Removed from re-export list
+
+**Prevention**: Always check package index.ts before assuming type availability.
+
 ## 📚 Key Resources
 
 **Internal:**

--- a/packages/obsidian-plugin/CLAUDE.md
+++ b/packages/obsidian-plugin/CLAUDE.md
@@ -1034,6 +1034,35 @@ exocortex-assets-relations         // line 1196
 // NOTE: .exocortex-layout-container does NOT exist!
 ```
 
+### Verifying Package Exports Before Re-exporting
+
+**Problem**: TypeScript compilation fails with "Module has no exported member 'X'" when re-exporting types from dependencies.
+
+**Root Cause**: Types exist in source files but aren't in package's public API (`index.ts`).
+
+**Solution**:
+1. Verify what's actually exported:
+   ```bash
+   grep -r "export.*TypeName" packages/*/src/index.ts
+   ```
+
+2. If type not found in index.ts, either:
+   - Add it to the package's exports (if it should be public)
+   - Remove it from your re-export list (if it's internal)
+
+3. Verify locally before pushing:
+   ```bash
+   npm run check:types
+   ```
+
+**Example from PR #352**:
+- Tried to export `TriplePattern` from `@exocortex/core`
+- Exists in `packages/core/src/domain/TriplePattern.ts`
+- NOT in `packages/core/src/index.ts` → not public API
+- Solution: Removed from re-export list
+
+**Prevention**: Always check package index.ts before assuming type availability.
+
 ## 📚 Key Resources
 
 **Internal:**


### PR DESCRIPTION
## Post-Mortem Documentation from PR #352

This PR captures learnings from implementing the SPARQL Public API (issue #249).

### Documentation Updates

**1. Added "Verifying Package Exports" troubleshooting section** (CLAUDE.md, packages/obsidian-plugin/CLAUDE.md)
- Covers TypeScript "Module has no exported member 'X'" errors
- Solution: `grep -r "export.*TypeName" packages/*/src/index.ts`
- Real-world example from `TriplePattern`/`ITripleStore` export issue in PR #352

**2. Added "Testing Public API Wrappers" pattern** (AGENTS.md)
- Test strategy: mock → delegate → transform → propagate
- Example implementation from `SPARQLApi.test.ts`
- Emphasizes testing API layer, not underlying service logic

### Why These Docs Matter

These patterns will help future AI agent instances avoid:
- ❌ TypeScript compilation errors from missing package exports
- ❌ Incorrect assumptions about what's public API vs internal
- ❌ Testing wrong layers (testing service logic in API wrapper tests)

### Related

- Issue: #249 (Public API for SPARQL Execution)
- Implementation PR: #352 (merged as v13.47.0)
- Follows RULE 2 (Mandatory Self-Improvement) from CLAUDE.md