### PR TITLE
fix: add .md extension fallback for parent/prototype area inheritance lookups

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
@@ -95,10 +95,18 @@ export class AssetMetadataService {
 
     if (parentPath && !visited.has(parentPath)) {
       visited.add(parentPath);
-      const parentFile = this.app.metadataCache.getFirstLinkpathDest(
+      let parentFile = this.app.metadataCache.getFirstLinkpathDest(
         parentPath,
         "",
       );
+
+      if (!parentFile && !parentPath.endsWith(".md")) {
+        parentFile = this.app.metadataCache.getFirstLinkpathDest(
+          parentPath + ".md",
+          "",
+        );
+      }
+
       if (parentFile instanceof TFile) {
         const parentCache = this.app.metadataCache.getFileCache(parentFile);
         const parentMetadata = parentCache?.frontmatter || {};
@@ -115,10 +123,18 @@ export class AssetMetadataService {
 
     if (prototypePath && !visited.has(prototypePath)) {
       visited.add(prototypePath);
-      const prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+      let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
         prototypePath,
         "",
       );
+
+      if (!prototypeFile && !prototypePath.endsWith(".md")) {
+        prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+          prototypePath + ".md",
+          "",
+        );
+      }
+
       if (prototypeFile instanceof TFile) {
         const prototypeCache =
           this.app.metadataCache.getFileCache(prototypeFile);

--- a/packages/obsidian-plugin/tests/unit/AssetMetadataService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AssetMetadataService.test.ts
@@ -227,6 +227,100 @@ describe("AssetMetadataService", () => {
 
       expect(result).toBe("parent-area");
     });
+
+    it("should resolve parent area with .md extension fallback", () => {
+      const mockParentFile = new TFile();
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockImplementation(
+        (linkpath: string) => {
+          if (linkpath === "parent-effort") {
+            return null;
+          }
+          if (linkpath === "parent-effort.md") {
+            return mockParentFile;
+          }
+          return null;
+        },
+      );
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          ems__Effort_area: "parent-area",
+        },
+      });
+
+      const metadata = {
+        ems__Effort_parent: "[[parent-effort]]",
+      };
+
+      const result = service.getEffortArea(metadata);
+
+      expect(result).toBe("parent-area");
+    });
+
+    it("should resolve prototype area with .md extension fallback", () => {
+      const mockPrototypeFile = new TFile();
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockImplementation(
+        (linkpath: string) => {
+          if (linkpath === "prototype-effort") {
+            return null;
+          }
+          if (linkpath === "prototype-effort.md") {
+            return mockPrototypeFile;
+          }
+          return null;
+        },
+      );
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          ems__Effort_area: "prototype-area",
+        },
+      });
+
+      const metadata = {
+        ems__Effort_prototype: "[[prototype-effort]]",
+      };
+
+      const result = service.getEffortArea(metadata);
+
+      expect(result).toBe("prototype-area");
+    });
+
+    it("should not add .md extension if path already ends with .md", () => {
+      const mockParentFile = new TFile();
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockImplementation(
+        (linkpath: string) => {
+          if (linkpath === "parent-effort.md") {
+            return mockParentFile;
+          }
+          return null;
+        },
+      );
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          ems__Effort_area: "parent-area",
+        },
+      });
+
+      const metadata = {
+        ems__Effort_parent: "[[parent-effort.md]]",
+      };
+
+      const result = service.getEffortArea(metadata);
+
+      expect(result).toBe("parent-area");
+      expect(mockApp.metadataCache.getFirstLinkpathDest).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockApp.metadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+        "parent-effort.md",
+        "",
+      );
+    });
   });
 
   describe("extractInstanceClass", () => {


### PR DESCRIPTION
## Summary

Fixes #355 - Tasks were showing `-` in the Effort Area column even though they had parent/prototype relationships that should provide the area through inheritance.

### Root Cause

The `getEffortArea()` method was failing to resolve parent/prototype files when the file path didn't include the `.md` extension. The method calls `getFirstLinkpathDest(path, "")` which can fail if the path doesn't end with `.md`.

The existing `getAssetLabel()` method already had this fallback pattern, but it wasn't applied to area inheritance lookups.

### Changes Made

- **AssetMetadataService.ts**: Added `.md` extension fallback for parent effort lookups (lines 103-108)
- **AssetMetadataService.ts**: Added `.md` extension fallback for prototype effort lookups (lines 131-136)
- **AssetMetadataService.test.ts**: Added 3 new test cases covering:
  - Parent area resolution with `.md` fallback
  - Prototype area resolution with `.md` fallback
  - No duplicate `.md` extension when path already ends with `.md`

### Test Coverage

- All existing tests pass ✅
- 3 new unit tests added for `.md` extension fallback scenarios
- Total test suite: 820 tests (unit + ui + component + e2e)

### Before/After

**Before**: Tasks with `ems__Effort_parent` or `ems__Effort_prototype` showed `-` in Effort Area column

**After**: Tasks correctly inherit areas from their parent/prototype relationships

## Test Plan

- [x] Unit tests pass
- [x] UI tests pass
- [x] Component tests pass
- [x] E2E tests will run in CI