### PR TITLE
fix: unify RDF namespace URIs between CLI and Obsidian plugin

### DIFF
--- a/packages/core/src/domain/models/rdf/Namespace.ts
+++ b/packages/core/src/domain/models/rdf/Namespace.ts
@@ -56,7 +56,7 @@ export class Namespace {
     "http://www.w3.org/2001/XMLSchema#"
   );
 
-  static readonly EXO = new Namespace("exo", "http://exocortex.org/ontology/");
+  static readonly EXO = new Namespace("exo", "https://exocortex.my/ontology/exo#");
 
-  static readonly EMS = new Namespace("ems", "http://exocortex.org/ems/");
+  static readonly EMS = new Namespace("ems", "https://exocortex.my/ontology/ems#");
 }

--- a/packages/core/tests/unit/domain/rdf/Namespace.test.ts
+++ b/packages/core/tests/unit/domain/rdf/Namespace.test.ts
@@ -85,13 +85,13 @@ describe("Namespace", () => {
     it("should provide EXO namespace", () => {
       const exo = Namespace.EXO;
       expect(exo.prefix).toBe("exo");
-      expect(exo.iri.value).toBe("http://exocortex.org/ontology/");
+      expect(exo.iri.value).toBe("https://exocortex.my/ontology/exo#");
     });
 
     it("should provide EMS namespace", () => {
       const ems = Namespace.EMS;
       expect(ems.prefix).toBe("ems");
-      expect(ems.iri.value).toBe("http://exocortex.org/ems/");
+      expect(ems.iri.value).toBe("https://exocortex.my/ontology/ems#");
     });
   });
 

--- a/packages/core/tests/unit/infrastructure/sparql/AlgebraOptimizer.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/AlgebraOptimizer.test.ts
@@ -186,7 +186,7 @@ describe("AlgebraOptimizer", () => {
 
     it("optimizes complex query with OPTIONAL and FILTER", () => {
       const query = `
-        PREFIX ems: <http://exocortex.org/ems#>
+        PREFIX ems: <https://exocortex.my/ontology/ems#>
         SELECT ?task ?label ?priority
         WHERE {
           ?task ems:label ?label .

--- a/packages/core/tests/unit/infrastructure/sparql/AlgebraSerializer.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/AlgebraSerializer.test.ts
@@ -66,7 +66,7 @@ describe("AlgebraSerializer", () => {
 
     it("serializes OPTIONAL (LeftJoin) operation", () => {
       const query = `
-        PREFIX ems: <http://exocortex.org/ems#>
+        PREFIX ems: <https://exocortex.my/ontology/ems#>
         SELECT ?task ?label ?priority
         WHERE {
           ?task ems:label ?label .

--- a/packages/core/tests/unit/infrastructure/sparql/AlgebraTranslator.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/AlgebraTranslator.test.ts
@@ -60,7 +60,7 @@ describe("AlgebraTranslator", () => {
 
     it("translates SELECT with PREFIX declarations", () => {
       const query = `
-        PREFIX ems: <http://exocortex.org/ems#>
+        PREFIX ems: <https://exocortex.my/ontology/ems#>
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         SELECT ?task ?label
         WHERE {
@@ -150,7 +150,7 @@ describe("AlgebraTranslator", () => {
   describe("OPTIONAL Translation", () => {
     it("translates SELECT with OPTIONAL", () => {
       const query = `
-        PREFIX ems: <http://exocortex.org/ems#>
+        PREFIX ems: <https://exocortex.my/ontology/ems#>
         SELECT ?task ?label ?priority
         WHERE {
           ?task ems:label ?label .
@@ -172,7 +172,7 @@ describe("AlgebraTranslator", () => {
   describe("UNION Translation", () => {
     it("translates SELECT with UNION", () => {
       const query = `
-        PREFIX ems: <http://exocortex.org/ems#>
+        PREFIX ems: <https://exocortex.my/ontology/ems#>
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         SELECT ?asset
         WHERE {

--- a/packages/core/tests/unit/infrastructure/sparql/SPARQLParser.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/SPARQLParser.test.ts
@@ -20,7 +20,7 @@ describe("SPARQLParser", () => {
       {
         name: "SELECT with PREFIX declarations",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           SELECT ?task ?label
           WHERE {
@@ -32,7 +32,7 @@ describe("SPARQLParser", () => {
       {
         name: "SELECT with FILTER regex",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           SELECT ?task ?label
           WHERE {
@@ -66,7 +66,7 @@ describe("SPARQLParser", () => {
       {
         name: "SELECT with OPTIONAL",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           SELECT ?task ?label ?priority
           WHERE {
@@ -79,7 +79,7 @@ describe("SPARQLParser", () => {
       {
         name: "SELECT with UNION",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           SELECT ?asset
           WHERE {
@@ -112,7 +112,7 @@ describe("SPARQLParser", () => {
       {
         name: "SELECT with LIMIT",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           SELECT ?task WHERE { ?task rdf:type ems:Task } LIMIT 10
         `,
@@ -120,7 +120,7 @@ describe("SPARQLParser", () => {
       {
         name: "SELECT with LIMIT and OFFSET",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           SELECT ?task WHERE { ?task rdf:type ems:Task } LIMIT 10 OFFSET 20
         `,
@@ -136,7 +136,7 @@ describe("SPARQLParser", () => {
       {
         name: "SELECT with nested graph patterns",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           SELECT ?task ?label
           WHERE {
@@ -160,7 +160,7 @@ describe("SPARQLParser", () => {
       {
         name: "SELECT with VALUES",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           SELECT ?task
           WHERE {
@@ -238,7 +238,7 @@ describe("SPARQLParser", () => {
       {
         name: "CONSTRUCT with complex template",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX ex: <http://example.org/>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           CONSTRUCT {
@@ -282,7 +282,7 @@ describe("SPARQLParser", () => {
       {
         name: "simple ASK query",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           ASK {
             ?task rdf:type ems:Task .
@@ -314,7 +314,7 @@ describe("SPARQLParser", () => {
       {
         name: "simple DESCRIBE query",
         query: `
-          PREFIX ems: <http://exocortex.org/ems#>
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           DESCRIBE ?task
           WHERE {
@@ -389,7 +389,7 @@ describe("SPARQLParser", () => {
   describe("Round-trip serialization", () => {
     it("serializes and re-parses SELECT query", () => {
       const original = `
-        PREFIX ems: <http://exocortex.org/ems#>
+        PREFIX ems: <https://exocortex.my/ontology/ems#>
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         SELECT ?task ?label
         WHERE {
@@ -427,7 +427,7 @@ describe("SPARQLParser", () => {
 
     it("serializes and re-parses complex query", () => {
       const original = `
-        PREFIX ems: <http://exocortex.org/ems#>
+        PREFIX ems: <https://exocortex.my/ontology/ems#>
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         SELECT DISTINCT ?task ?effort
         WHERE {
@@ -465,7 +465,7 @@ describe("SPARQLParser", () => {
 
     it("parses medium complexity query in <10ms", () => {
       const query = `
-        PREFIX ems: <http://exocortex.org/ems#>
+        PREFIX ems: <https://exocortex.my/ontology/ems#>
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         SELECT ?task ?label ?effort
         WHERE {


### PR DESCRIPTION
Fixes namespace inconsistency between CLI and Obsidian plugin that prevented SPARQL queries from working identically in both environments.

## Problem

SPARQL queries in vault README used `http://exocortex.org/ontology/` namespace but this was outdated. The code used different namespaces than what was defined in vault ontology files (`exo__Ontology_url` property).

## Changes

**Updated Namespace.ts constants**:
- EXO namespace: `http://exocortex.org/ontology/` → `https://exocortex.my/ontology/exo#`
- EMS namespace: `http://exocortex.org/ems/` → `https://exocortex.my/ontology/ems#`

**Updated all SPARQL test files** (4 files):
- SPARQLParser.test.ts
- AlgebraTranslator.test.ts
- AlgebraSerializer.test.ts
- AlgebraOptimizer.test.ts

**Updated vault ontology definitions** (separate commit):
- `/Users/kitelev/vault-2025/03 Knowledge/exo/!exo.md` - Added # suffix to ontology URL
- `/Users/kitelev/vault-2025/03 Knowledge/ems/!ems.md` - Added # suffix to ontology URL
- `/Users/kitelev/vault-2025/README.md` - Updated all SPARQL examples with correct namespaces

## Benefits

✅ SPARQL queries now work identically in CLI and Obsidian plugin
✅ Namespace URIs match canonical definitions in vault (`exo__Ontology_url` property)
✅ Follows RDF/OWL best practices (hash-style URIs for ontology terms)
✅ README examples are now copy-paste ready and actually work

## Testing

- All 1555 unit tests pass
- CLI query execution verified:
  ```bash
  node packages/cli/dist/index.js sparql query /tmp/test-new-namespace.sparql \
    --vault /Users/kitelev/vault-2025
  # Result: ✅ Found 10 result(s) in 3ms
  ```
- Query used correct namespace:
  ```sparql
  PREFIX exo: <https://exocortex.my/ontology/exo#>
  
  SELECT ?asset ?label
  WHERE {
    ?asset exo:Asset_label ?label .
  }
  LIMIT 10
  ```

## Technical Details

Hash-style URIs (`https://example.com/ontology#`) are standard for RDF/RDFS/OWL ontologies when ontology terms are fragments. This matches the pattern used by W3C standards (rdf:type, rdfs:subClassOf, etc.).