### PR TITLE
docs: add RDF namespace URI standards and troubleshooting

### DIFF
--- a/docs/sparql/User-Guide.md
+++ b/docs/sparql/User-Guide.md
@@ -705,6 +705,41 @@ WHERE {
    ```
    Verify tasks exist in your vault with correct frontmatter.
 
+### Pitfall 7: Namespace URI Mismatch
+
+**Problem**: Query executes without errors but returns 0 results.
+
+**Root Cause**: Namespace URIs in query don't match actual URIs used in triple store.
+
+**Diagnostic Query**:
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?predicate
+WHERE {
+  ?subject ?predicate ?object .
+}
+LIMIT 20
+```
+
+If you see predicates like `http://exocortex.org/ontology/Asset_label` but your query uses:
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+```
+
+That's a mismatch!
+
+**Solution**:
+1. Check vault ontology files (`!exo.md`, `!ems.md`) for canonical URIs in `exo__Ontology_url` property
+2. Update PREFIX declarations to match:
+   ```sparql
+   PREFIX exo: <https://exocortex.my/ontology/exo#>
+   PREFIX ems: <https://exocortex.my/ontology/ems#>
+   ```
+3. Use hash-style URIs (`#` at end), not slash-style (`/` at end)
+
+**Reference**: See PR #363 for namespace unification example.
+
 ---
 
 ## Next Steps


### PR DESCRIPTION
## Summary

Added comprehensive documentation on RDF namespace URIs based on learnings from PR #363 (namespace unification task).

## Context

During PR #363, I discovered that SPARQL queries returned empty results due to namespace URI mismatch between:
- Code definitions (`Namespace.ts`)
- Vault ontology files (`exo__Ontology_url` property)

This documentation prevents future AI agents from encountering the same issue.

## Changes

### 1. AGENTS.md (Universal AI Agent Instructions)
- **New section**: "RDF Namespace URI Standards" under "SPARQL & RDF Development"
- **Content**:
  - Explains hash-style URIs (`#`) vs slash-style (`/`) - RDF standard
  - Source of truth: vault ontology files
  - Step-by-step guide for implementing SPARQL features
  - Troubleshooting empty results with diagnostic queries
  - Verification commands

### 2. CLAUDE.md (Claude Code Specific)
- **New section**: "SPARQL queries return empty results..." under "Troubleshooting"
- **Content**:
  - Problem description and root cause
  - Quick detection commands
  - 5-step solution guide
  - Diagnostic query example
  - Reference to PR #363

### 3. docs/sparql/User-Guide.md
- **New section**: "Pitfall 7: Namespace URI Mismatch" under "Common Pitfalls and Solutions"
- **Content**:
  - Concrete example of mismatch detection
  - Diagnostic SPARQL query
  - Solution with correct PREFIX declarations
  - Reference to PR #363

## Files Modified

- `AGENTS.md` (+61 lines)
- `CLAUDE.md` (+41 lines)
- `docs/sparql/User-Guide.md` (+35 lines)

**Total**: 3 files, 137 lines added

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Documentation is clear and accurate
- [x] Examples are copy-paste ready
- [x] Cross-references (PR #363) are correct
- [x] No code changes (documentation-only PR)

## Related Issues/PRs

- Relates to PR #363 - unify RDF namespace URIs between CLI and Obsidian plugin
- Based on post-mortem findings from namespace unification task
- Implements RULE #2 (Mandatory Self-Improvement) from AGENTS.md

## Post-Mortem

This PR is the result of the mandatory post-mortem report after completing PR #363. The documentation improvements were proposed, approved by user, and now implemented.

**Learnings documented**:
- RDF namespace URI standards (hash-style required)
- Vault ontology files as source of truth
- Troubleshooting steps for empty SPARQL results
- Diagnostic queries for namespace mismatch detection