### PR TITLE
feat: add EventPrototype and Event asset classes with Create Instance button support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ All commands accessible via Command Palette (Cmd/Ctrl+P → "Exocortex:"). Comma
 |---------|---------------|---------|---------------------|
 | **Create Task** | ems__Area, ems__Project | ems__Task | Parent reference, area, prototype |
 | **Create Project** | ems__Area, ems__Initiative, ems__Project | ems__Project | Area, initiative reference |
-| **Create Instance** | ems__TaskPrototype, ems__MeetingPrototype | ems__Task or ems__Meeting | Prototype template content |
+| **Create Instance** | ems__TaskPrototype, ems__MeetingPrototype, exo__EventPrototype | ems__Task, ems__Meeting, or exo__Event | Prototype template content |
 | **Create Related Task** | ems__Project | ems__Task with project parent | Parent project, area |
 | **Create Area** | ems__Area | Child ems__Area | Parent area reference |
 
@@ -502,6 +502,8 @@ Understanding the class hierarchy:
 | **ems__Initiative** | High-level initiative | Similar to Project |
 | **ems__TaskPrototype** | Task template | Used for instance creation |
 | **ems__MeetingPrototype** | Meeting template | Used for instance creation |
+| **exo__EventPrototype** | Event template | Used for instance creation |
+| **exo__Event** | Event instance | ems__Effort_status, ems__Effort_prototype |
 | **pn__DailyNote** | Daily planning note | pn__DailyNote_day |
 | **ztlk__FleetingNote** | Supervision/fleeting note | Created in 01 Inbox |
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -245,6 +245,8 @@ enum AssetClass {
   INITIATIVE = "ems__Initiative",
   TASK_PROTOTYPE = "ems__TaskPrototype",
   MEETING_PROTOTYPE = "ems__MeetingPrototype",
+  EVENT_PROTOTYPE = "exo__EventPrototype",
+  EVENT = "exo__Event",
   DAILY_NOTE = "pn__DailyNote",
   CONCEPT = "ims__Concept"
 }

--- a/packages/core/src/domain/commands/CommandVisibility.ts
+++ b/packages/core/src/domain/commands/CommandVisibility.ts
@@ -149,6 +149,14 @@ export function canCreateProject(context: CommandVisibilityContext): boolean {
 }
 
 /**
+ * Can execute "Create Event" command
+ * Available for: ems__Area and ems__Project assets
+ */
+export function canCreateEvent(context: CommandVisibilityContext): boolean {
+  return isAreaOrProject(context.instanceClass);
+}
+
+/**
  * Can execute "Create Child Area" command
  * Available for: ems__Area assets only
  */
@@ -158,12 +166,13 @@ export function canCreateChildArea(context: CommandVisibilityContext): boolean {
 
 /**
  * Can execute "Create Instance" command
- * Available for: ems__TaskPrototype and ems__MeetingPrototype assets
+ * Available for: ems__TaskPrototype, ems__MeetingPrototype, and exo__EventPrototype assets
  */
 export function canCreateInstance(context: CommandVisibilityContext): boolean {
   return (
     hasClass(context.instanceClass, AssetClass.TASK_PROTOTYPE) ||
-    hasClass(context.instanceClass, AssetClass.MEETING_PROTOTYPE)
+    hasClass(context.instanceClass, AssetClass.MEETING_PROTOTYPE) ||
+    hasClass(context.instanceClass, AssetClass.EVENT_PROTOTYPE)
   );
 }
 

--- a/packages/core/src/domain/constants/AssetClass.ts
+++ b/packages/core/src/domain/constants/AssetClass.ts
@@ -6,6 +6,8 @@ export enum AssetClass {
   INITIATIVE = "ems__Initiative",
   TASK_PROTOTYPE = "ems__TaskPrototype",
   MEETING_PROTOTYPE = "ems__MeetingPrototype",
+  EVENT_PROTOTYPE = "exo__EventPrototype",
+  EVENT = "exo__Event",
   DAILY_NOTE = "pn__DailyNote",
   CONCEPT = "ims__Concept",
   SESSION_START_EVENT = "ems__SessionStartEvent",

--- a/packages/core/src/services/TaskFrontmatterGenerator.ts
+++ b/packages/core/src/services/TaskFrontmatterGenerator.ts
@@ -10,6 +10,7 @@ const EFFORT_PROPERTY_MAP: Record<string, string> = {
   [AssetClass.PROJECT]: "ems__Effort_parent",
   [AssetClass.TASK_PROTOTYPE]: "ems__Effort_prototype",
   [AssetClass.MEETING_PROTOTYPE]: "ems__Effort_prototype",
+  [AssetClass.EVENT_PROTOTYPE]: "ems__Effort_prototype",
 };
 
 const INSTANCE_CLASS_MAP: Record<string, string> = {
@@ -17,6 +18,7 @@ const INSTANCE_CLASS_MAP: Record<string, string> = {
   [AssetClass.PROJECT]: AssetClass.TASK,
   [AssetClass.TASK_PROTOTYPE]: AssetClass.TASK,
   [AssetClass.MEETING_PROTOTYPE]: AssetClass.MEETING,
+  [AssetClass.EVENT_PROTOTYPE]: AssetClass.EVENT,
 };
 
 export class TaskFrontmatterGenerator {

--- a/packages/obsidian-plugin/tests/unit/CommandVisibility.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CommandVisibility.test.ts
@@ -2,6 +2,7 @@ import type { CommandVisibilityContext } from "@exocortex/core";
 import {
   canCreateTask,
   canCreateProject,
+  canCreateEvent,
   canCreateChildArea,
   canCreateInstance,
   canMoveToBacklog,
@@ -294,6 +295,80 @@ describe("CommandVisibility", () => {
     });
   });
 
+  describe("canCreateEvent", () => {
+    it("should return true for ems__Area", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__Area]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateEvent(context)).toBe(true);
+    });
+
+    it("should return true for ems__Project", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__Project]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateEvent(context)).toBe(true);
+    });
+
+    it("should return true for Area without brackets", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "ems__Area",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateEvent(context)).toBe(true);
+    });
+
+    it("should return false for ems__Task", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__Task]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateEvent(context)).toBe(false);
+    });
+
+    it("should return false when instanceClass is null", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: null,
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateEvent(context)).toBe(false);
+    });
+
+    it("should return true for array with ems__Area", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: ["[[ems__Area]]", "[[SomeOtherClass]]"],
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateEvent(context)).toBe(true);
+    });
+  });
+
   describe("canCreateInstance", () => {
     it("should return true for ems__TaskPrototype", () => {
       const context: CommandVisibilityContext = {
@@ -358,6 +433,54 @@ describe("CommandVisibility", () => {
     it("should return true for array with ems__TaskPrototype", () => {
       const context: CommandVisibilityContext = {
         instanceClass: ["[[ems__TaskPrototype]]", "[[SomeOtherClass]]"],
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateInstance(context)).toBe(true);
+    });
+
+    it("should return true for ems__MeetingPrototype", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__MeetingPrototype]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateInstance(context)).toBe(true);
+    });
+
+    it("should return true for exo__EventPrototype", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[exo__EventPrototype]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateInstance(context)).toBe(true);
+    });
+
+    it("should return true for EventPrototype without brackets", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "exo__EventPrototype",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateInstance(context)).toBe(true);
+    });
+
+    it("should return true for array with exo__EventPrototype", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: ["[[exo__EventPrototype]]", "[[SomeOtherClass]]"],
         currentStatus: null,
         metadata: {},
         isArchived: false,


### PR DESCRIPTION
## Summary

Add support for event prototype-instance pattern, allowing users to create Event instances from EventPrototype assets using the existing "Create Instance" button.

This implements issue #362 by extending the prototype-instance pattern that already exists for Tasks and Meetings to support Events.

## Changes

### Domain Layer
- ✅ Add `exo__EventPrototype` and `exo__Event` to AssetClass enum
- ✅ Add EVENT_PROTOTYPE → ems__Effort_prototype mapping in EFFORT_PROPERTY_MAP
- ✅ Add EVENT_PROTOTYPE → exo__Event mapping in INSTANCE_CLASS_MAP
- ✅ Add canCreateEvent() visibility function for creating events from Area/Project
- ✅ Update canCreateInstance() to support EventPrototype assets

### Tests
- ✅ Add 6 unit tests for canCreateEvent() visibility logic
- ✅ Add 4 unit tests for EventPrototype support in canCreateInstance()
- ✅ All existing tests pass

### Documentation
- ✅ Update README.md with EventPrototype and Event classes
- ✅ Update core/README.md AssetClass enum documentation

## Implementation

The implementation follows the established pattern for TaskPrototype and MeetingPrototype:
- EventPrototype assets display "Create Instance" button (via existing canCreateInstance())
- Clicking button creates new Event with proper property inheritance
- Auto-generates UUID for filename and exo__Asset_uid
- Copies Algorithm section from prototype if present
- Opens new asset automatically

## Behavior

When users click "Create Instance" on an EventPrototype asset:
1. Modal opens for label input
2. New note created with:
   - `exo__Instance_class: [[exo__Event]]`
   - Auto-generated UUID for filename and `exo__Asset_uid`
   - `ems__Effort_prototype: [[PrototypeName]]` reference
   - Algorithm section copied from prototype (if present)
3. New asset opens automatically

## Testing

✅ Build succeeds
✅ Linter passes
✅ All unit tests pass (803 tests total)

Closes #362