### PR TITLE
fix: use exo__Asset_prototype for EventPrototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ Understanding the class hierarchy:
 | **ems__TaskPrototype** | Task template | Used for instance creation |
 | **ems__MeetingPrototype** | Meeting template | Used for instance creation |
 | **exo__EventPrototype** | Event template | Used for instance creation |
-| **exo__Event** | Event instance | ems__Effort_status, ems__Effort_prototype |
+| **exo__Event** | Event instance | ems__Effort_status, exo__Asset_prototype |
 | **pn__DailyNote** | Daily planning note | pn__DailyNote_day |
 | **ztlk__FleetingNote** | Supervision/fleeting note | Created in 01 Inbox |
 

--- a/packages/core/src/services/TaskFrontmatterGenerator.ts
+++ b/packages/core/src/services/TaskFrontmatterGenerator.ts
@@ -10,7 +10,7 @@ const EFFORT_PROPERTY_MAP: Record<string, string> = {
   [AssetClass.PROJECT]: "ems__Effort_parent",
   [AssetClass.TASK_PROTOTYPE]: "ems__Effort_prototype",
   [AssetClass.MEETING_PROTOTYPE]: "ems__Effort_prototype",
-  [AssetClass.EVENT_PROTOTYPE]: "ems__Effort_prototype",
+  [AssetClass.EVENT_PROTOTYPE]: "exo__Asset_prototype",
 };
 
 const INSTANCE_CLASS_MAP: Record<string, string> = {


### PR DESCRIPTION
## Summary

Change EventPrototype to use `exo__Asset_prototype` instead of `ems__Effort_prototype` to maintain namespace consistency.

## Changes

- ✅ Update `EFFORT_PROPERTY_MAP`: `EVENT_PROTOTYPE` now maps to `exo__Asset_prototype`
- ✅ Update `README.md`: `exo__Event` properties now list `exo__Asset_prototype`

## Rationale

EventPrototype uses the `exo__` prefix (universal Exocortex namespace) rather than `ems__` prefix (Effort Management System namespace). The prototype property should match this namespace convention:

- TaskPrototype (`ems__`) → `ems__Effort_prototype` ✓
- MeetingPrototype (`ems__`) → `ems__Effort_prototype` ✓  
- EventPrototype (`exo__`) → `exo__Asset_prototype` ✓

This maintains semantic consistency and ensures Event instances reference their prototypes using the correct universal property.

## Testing

✅ All 803 tests pass
✅ Build succeeds
✅ Linter passes

Refs #362