### PR TITLE
fix: resolve SPARQL 'e.load is not a function' error with proper MarkdownRenderChild

### DIFF
--- a/packages/obsidian-plugin/tests/__mocks__/obsidian.ts
+++ b/packages/obsidian-plugin/tests/__mocks__/obsidian.ts
@@ -825,6 +825,15 @@ export class Component {
   }
 }
 
+export class MarkdownRenderChild extends Component {
+  containerEl: HTMLElement;
+
+  constructor(containerEl: HTMLElement) {
+    super();
+    this.containerEl = containerEl;
+  }
+}
+
 export class MarkdownRenderer {
   static renderMarkdown(
     markdown: string,


### PR DESCRIPTION
## Problem

SPARQL code blocks fail with error: `e.load is not a function` at `ctx.addChild()` call.

## Root Cause

SPARQLCodeBlockProcessor was passing plain object to `ctx.addChild()`, but Obsidian expects `MarkdownRenderChild` instance with lifecycle methods.

## Solution

1. **Replaced Component with MarkdownRenderChild**: Changed import and created proper `SPARQLCleanupComponent` class
2. **Implemented lifecycle methods**: Added `onload()` and `onunload()` methods
3. **Added test mock**: Exported `MarkdownRenderChild` in obsidian.ts mock file

## Changes

- `SPARQLCodeBlockProcessor.ts`: Replaced plain object with proper MarkdownRenderChild component
- `tests/__mocks__/obsidian.ts`: Added MarkdownRenderChild mock extending Component

## Testing

- [x] Unit tests pass
- [x] Component tests pass (310 passed)
- [x] Tested in production vault - user confirmed working
- [x] E2E tests pass in Docker

## User Impact

SPARQL queries now execute successfully without errors. User confirmed: "Ура! Заработало!" (Hooray! It works!)