### PR TITLE
feat: add editable properties to Layout Properties block

### DIFF
--- a/packages/obsidian-plugin/src/application/services/PropertyUpdateService.ts
+++ b/packages/obsidian-plugin/src/application/services/PropertyUpdateService.ts
@@ -1,0 +1,74 @@
+import { App, TFile } from "obsidian";
+import { ILogger } from "../../adapters/logging/ILogger";
+import { LoggerFactory } from "../../adapters/logging/LoggerFactory";
+
+export class PropertyUpdateService {
+  private logger: ILogger;
+
+  constructor(private app: App) {
+    this.logger = LoggerFactory.create("PropertyUpdateService");
+  }
+
+  async updateProperty(
+    file: TFile,
+    propertyKey: string,
+    newValue: any,
+  ): Promise<void> {
+    try {
+      this.logger.debug(
+        `Updating property "${propertyKey}" in file: ${file.path}`,
+      );
+
+      await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+        if (newValue === null || newValue === undefined || newValue === "") {
+          delete frontmatter[propertyKey];
+        } else {
+          frontmatter[propertyKey] = newValue;
+        }
+      });
+
+      this.logger.debug(
+        `Successfully updated property "${propertyKey}" in file: ${file.path}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to update property "${propertyKey}" in file: ${file.path}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  async updateTextProperty(
+    file: TFile,
+    propertyKey: string,
+    newValue: string,
+  ): Promise<void> {
+    const trimmedValue = newValue.trim();
+    await this.updateProperty(file, propertyKey, trimmedValue || null);
+  }
+
+  async updateDateTimeProperty(
+    file: TFile,
+    propertyKey: string,
+    newValue: string | null,
+  ): Promise<void> {
+    await this.updateProperty(file, propertyKey, newValue);
+  }
+
+  async updateNumberProperty(
+    file: TFile,
+    propertyKey: string,
+    newValue: number | null,
+  ): Promise<void> {
+    await this.updateProperty(file, propertyKey, newValue);
+  }
+
+  async updateBooleanProperty(
+    file: TFile,
+    propertyKey: string,
+    newValue: boolean,
+  ): Promise<void> {
+    await this.updateProperty(file, propertyKey, newValue);
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
@@ -1,0 +1,206 @@
+import React, { useState, useRef, useEffect } from "react";
+
+export interface DateTimePropertyFieldProps {
+  value: string | null;
+  onChange: (newValue: string | null) => void;
+  onBlur?: () => void;
+}
+
+export const DateTimePropertyField: React.FC<DateTimePropertyFieldProps> = ({
+  value,
+  onChange,
+  onBlur,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [localValue, setLocalValue] = useState(value || "");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setLocalValue(value || "");
+  }, [value]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+        onBlur?.();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen, onBlur]);
+
+  const formatDisplayValue = (isoString: string | null): string => {
+    if (!isoString) return "Empty";
+
+    try {
+      const date = new Date(isoString);
+      if (isNaN(date.getTime())) return isoString;
+
+      const hasTime =
+        isoString.includes("T") ||
+        date.getHours() !== 0 ||
+        date.getMinutes() !== 0;
+
+      if (hasTime) {
+        return date.toLocaleString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+      } else {
+        return date.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        });
+      }
+    } catch {
+      return isoString;
+    }
+  };
+
+  const convertToDateTimeLocalFormat = (isoString: string | null): string => {
+    if (!isoString) return "";
+
+    try {
+      const date = new Date(isoString);
+      if (isNaN(date.getTime())) return "";
+
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      const hours = String(date.getHours()).padStart(2, "0");
+      const minutes = String(date.getMinutes()).padStart(2, "0");
+
+      return `${year}-${month}-${day}T${hours}:${minutes}`;
+    } catch {
+      return "";
+    }
+  };
+
+  const convertToISOFormat = (localDateTimeString: string): string | null => {
+    if (!localDateTimeString) return null;
+
+    try {
+      const date = new Date(localDateTimeString);
+      if (isNaN(date.getTime())) return null;
+
+      return date.toISOString();
+    } catch {
+      return null;
+    }
+  };
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsOpen(!isOpen);
+  };
+
+  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newLocalValue = e.target.value;
+    setLocalValue(newLocalValue);
+
+    const isoValue = convertToISOFormat(newLocalValue);
+    onChange(isoValue);
+  };
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setLocalValue("");
+    onChange(null);
+    setIsOpen(false);
+    onBlur?.();
+  };
+
+  return (
+    <div className="exocortex-property-datetime-container">
+      <div
+        ref={buttonRef}
+        className="exocortex-property-datetime-display"
+        onClick={handleToggle}
+        style={{ cursor: "pointer", display: "flex", alignItems: "center" }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ marginRight: "6px" }}
+        >
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        <span>{formatDisplayValue(value)}</span>
+      </div>
+
+      {isOpen && (
+        <div
+          ref={dropdownRef}
+          className="exocortex-property-datetime-dropdown"
+          style={{
+            position: "absolute",
+            zIndex: 1000,
+            background: "var(--background-primary)",
+            border: "1px solid var(--background-modifier-border)",
+            borderRadius: "4px",
+            padding: "12px",
+            boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+            marginTop: "4px",
+          }}
+        >
+          <input
+            type="datetime-local"
+            value={convertToDateTimeLocalFormat(localValue)}
+            onChange={handleDateChange}
+            className="exocortex-property-datetime-input"
+            style={{
+              width: "100%",
+              padding: "6px",
+              border: "1px solid var(--background-modifier-border)",
+              borderRadius: "3px",
+              marginBottom: "8px",
+            }}
+          />
+          <button
+            onClick={handleClear}
+            className="exocortex-property-datetime-clear"
+            style={{
+              width: "100%",
+              padding: "6px",
+              border: "1px solid var(--background-modifier-border)",
+              borderRadius: "3px",
+              background: "var(--background-secondary)",
+              cursor: "pointer",
+            }}
+          >
+            Clear
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/obsidian-plugin/src/presentation/components/properties/TextPropertyField.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/properties/TextPropertyField.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect, useRef } from "react";
+
+export interface TextPropertyFieldProps {
+  value: string;
+  onChange: (newValue: string) => void;
+  onBlur?: () => void;
+}
+
+export const TextPropertyField: React.FC<TextPropertyFieldProps> = ({
+  value,
+  onChange,
+  onBlur,
+}) => {
+  const [localValue, setLocalValue] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLocalValue(e.target.value);
+  };
+
+  const handleBlur = () => {
+    if (localValue !== value) {
+      onChange(localValue);
+    }
+    onBlur?.();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      inputRef.current?.blur();
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setLocalValue(value);
+      inputRef.current?.blur();
+    }
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      className="exocortex-property-text-input"
+      value={localValue}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+      placeholder="Enter value..."
+    />
+  );
+};

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/PropertiesRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/PropertiesRenderer.ts
@@ -4,6 +4,7 @@ import { ReactRenderer } from "../../utils/ReactRenderer";
 import { MetadataExtractor } from "@exocortex/core";
 import { AssetPropertiesTable } from "../../components/AssetPropertiesTable";
 import { AssetMetadataService } from "./helpers/AssetMetadataService";
+import { PropertyUpdateService } from "../../../application/services/PropertyUpdateService";
 
 type ObsidianApp = any;
 
@@ -13,15 +14,23 @@ export interface PropertiesRendererOptions {
    * Useful when Relations block is present to avoid redundant information.
    */
   hideAliases?: boolean;
+  /**
+   * If true, properties will be editable inline.
+   */
+  editable?: boolean;
 }
 
 export class PropertiesRenderer {
+  private propertyUpdateService: PropertyUpdateService;
+
   constructor(
     private app: ObsidianApp,
     private reactRenderer: ReactRenderer,
     private metadataExtractor: MetadataExtractor,
     private metadataService: AssetMetadataService,
-  ) {}
+  ) {
+    this.propertyUpdateService = new PropertyUpdateService(app);
+  }
 
   async render(
     el: HTMLElement,
@@ -78,6 +87,9 @@ export class PropertiesRenderer {
           },
           getAssetLabel: (path: string) =>
             this.metadataService.getAssetLabel(path),
+          file: file,
+          propertyUpdateService: this.propertyUpdateService,
+          editable: options?.editable ?? true,
         }),
       );
     }

--- a/packages/obsidian-plugin/tests/unit/services/PropertyUpdateService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/services/PropertyUpdateService.test.ts
@@ -1,0 +1,240 @@
+import { PropertyUpdateService } from "../../../src/application/services/PropertyUpdateService";
+import type { App, TFile } from "obsidian";
+
+describe("PropertyUpdateService", () => {
+  let service: PropertyUpdateService;
+  let mockApp: App;
+  let mockFile: TFile;
+  let mockProcessFrontMatter: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockProcessFrontMatter = jest.fn(
+      async (file: TFile, callback: (frontmatter: any) => void) => {
+        const frontmatter = {};
+        callback(frontmatter);
+      },
+    );
+
+    mockApp = {
+      fileManager: {
+        processFrontMatter: mockProcessFrontMatter,
+      },
+    } as unknown as App;
+
+    mockFile = {
+      path: "test/file.md",
+      basename: "file",
+    } as TFile;
+
+    service = new PropertyUpdateService(mockApp);
+  });
+
+  describe("initialization", () => {
+    it("should create PropertyUpdateService instance", () => {
+      expect(service).toBeDefined();
+    });
+
+    it("should be an instance of PropertyUpdateService", () => {
+      expect(service).toBeInstanceOf(PropertyUpdateService);
+    });
+  });
+
+  describe("public API", () => {
+    it("should have updateProperty method", () => {
+      expect(typeof service.updateProperty).toBe("function");
+    });
+
+    it("should have updateTextProperty method", () => {
+      expect(typeof service.updateTextProperty).toBe("function");
+    });
+
+    it("should have updateDateTimeProperty method", () => {
+      expect(typeof service.updateDateTimeProperty).toBe("function");
+    });
+
+    it("should have updateNumberProperty method", () => {
+      expect(typeof service.updateNumberProperty).toBe("function");
+    });
+
+    it("should have updateBooleanProperty method", () => {
+      expect(typeof service.updateBooleanProperty).toBe("function");
+    });
+  });
+
+  describe("updateProperty", () => {
+    it("should update property with new value", async () => {
+      await service.updateProperty(mockFile, "testKey", "testValue");
+
+      expect(mockProcessFrontMatter).toHaveBeenCalledWith(
+        mockFile,
+        expect.any(Function),
+      );
+    });
+
+    it("should delete property when value is null", async () => {
+      await service.updateProperty(mockFile, "testKey", null);
+
+      expect(mockProcessFrontMatter).toHaveBeenCalledWith(
+        mockFile,
+        expect.any(Function),
+      );
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = { testKey: "oldValue" };
+      callback(frontmatter);
+
+      expect(frontmatter.testKey).toBeUndefined();
+    });
+
+    it("should delete property when value is undefined", async () => {
+      await service.updateProperty(mockFile, "testKey", undefined);
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = { testKey: "oldValue" };
+      callback(frontmatter);
+
+      expect(frontmatter.testKey).toBeUndefined();
+    });
+
+    it("should delete property when value is empty string", async () => {
+      await service.updateProperty(mockFile, "testKey", "");
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = { testKey: "oldValue" };
+      callback(frontmatter);
+
+      expect(frontmatter.testKey).toBeUndefined();
+    });
+
+    it("should set property when value is provided", async () => {
+      await service.updateProperty(mockFile, "testKey", "newValue");
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = {};
+      callback(frontmatter);
+
+      expect(frontmatter.testKey).toBe("newValue");
+    });
+
+    it("should handle processFrontMatter errors", async () => {
+      mockProcessFrontMatter.mockRejectedValueOnce(
+        new Error("File processing failed"),
+      );
+
+      await expect(
+        service.updateProperty(mockFile, "testKey", "testValue"),
+      ).rejects.toThrow("File processing failed");
+    });
+  });
+
+  describe("updateTextProperty", () => {
+    it("should trim and update text property", async () => {
+      await service.updateTextProperty(mockFile, "textKey", "  text value  ");
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = {};
+      callback(frontmatter);
+
+      expect(frontmatter.textKey).toBe("text value");
+    });
+
+    it("should delete property when text is empty after trim", async () => {
+      await service.updateTextProperty(mockFile, "textKey", "   ");
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = { textKey: "oldValue" };
+      callback(frontmatter);
+
+      expect(frontmatter.textKey).toBeUndefined();
+    });
+
+    it("should handle empty string", async () => {
+      await service.updateTextProperty(mockFile, "textKey", "");
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = { textKey: "oldValue" };
+      callback(frontmatter);
+
+      expect(frontmatter.textKey).toBeUndefined();
+    });
+  });
+
+  describe("updateDateTimeProperty", () => {
+    it("should update datetime property with ISO string", async () => {
+      const isoDate = "2025-01-15T10:30:00.000Z";
+      await service.updateDateTimeProperty(mockFile, "dateKey", isoDate);
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = {};
+      callback(frontmatter);
+
+      expect(frontmatter.dateKey).toBe(isoDate);
+    });
+
+    it("should delete property when value is null", async () => {
+      await service.updateDateTimeProperty(mockFile, "dateKey", null);
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = { dateKey: "2025-01-15T10:30:00.000Z" };
+      callback(frontmatter);
+
+      expect(frontmatter.dateKey).toBeUndefined();
+    });
+  });
+
+  describe("updateNumberProperty", () => {
+    it("should update number property", async () => {
+      await service.updateNumberProperty(mockFile, "numberKey", 42);
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = {};
+      callback(frontmatter);
+
+      expect(frontmatter.numberKey).toBe(42);
+    });
+
+    it("should handle zero value", async () => {
+      await service.updateNumberProperty(mockFile, "numberKey", 0);
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = {};
+      callback(frontmatter);
+
+      expect(frontmatter.numberKey).toBe(0);
+    });
+
+    it("should delete property when value is null", async () => {
+      await service.updateNumberProperty(mockFile, "numberKey", null);
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = { numberKey: 42 };
+      callback(frontmatter);
+
+      expect(frontmatter.numberKey).toBeUndefined();
+    });
+  });
+
+  describe("updateBooleanProperty", () => {
+    it("should update boolean property to true", async () => {
+      await service.updateBooleanProperty(mockFile, "boolKey", true);
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = {};
+      callback(frontmatter);
+
+      expect(frontmatter.boolKey).toBe(true);
+    });
+
+    it("should update boolean property to false", async () => {
+      await service.updateBooleanProperty(mockFile, "boolKey", false);
+
+      const callback = mockProcessFrontMatter.mock.calls[0][1];
+      const frontmatter: any = {};
+      callback(frontmatter);
+
+      expect(frontmatter.boolKey).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements editable property fields for the Properties block in UniversalLayout, allowing users to edit DateTime and Text properties inline with a native Obsidian-like UX.

## Changes

### New Components
- PropertyUpdateService - Handles frontmatter updates via app.fileManager.processFrontMatter
- DateTimePropertyField - Calendar icon with dropdown datetime picker
- TextPropertyField - Inline text input field with keyboard shortcuts

### Modified Components
- AssetPropertiesTable - Added editable mode support with property type detection
- PropertiesRenderer - Integrated editable properties (enabled by default)

### Tests
- 23 unit test cases for PropertyUpdateService
- Full coverage of all property update scenarios
- All existing tests passing (unit + ui + component)

## Features

- DateTime properties: Icon + dropdown picker (matches Obsidian native UX)
- Text properties: Inline editing with keyboard shortcuts
- Property type auto-detection (datetime regex, wikilink, plain text)
- Empty value handling (deletes property from frontmatter)
- Enabled by default in all Properties blocks

## Testing

- Unit tests: All 23 PropertyUpdateService tests passing
- Component tests: All 347 existing tests passing
- UI tests: All existing tests passing

## Resolves

Closes #387