### PR TITLE
docs: add troubleshooting for TypeScript unused parameter and auto-merge BEHIND status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1474,6 +1474,42 @@ it("should resolve file with .md extension fallback", () => {
 
 **Related Issues**: #355 (Area inheritance fix)
 
+### TypeScript Error: Parameter Declared But Never Used
+
+**Problem**: TypeScript compilation fails with `error TS6138: Property 'X' is declared but its value is never read`.
+
+**Root Cause**: Parameter declared in constructor or function but not referenced in the implementation body.
+
+**Solution**:
+```typescript
+// ❌ WRONG - 'vault' declared but never used
+constructor(
+  private vault: Vault,
+  private metadataCache: MetadataCache,
+  private app: App,
+) {
+  // Only uses metadataCache and app, not vault
+}
+
+// ✅ CORRECT - Remove unused parameter
+constructor(
+  private metadataCache: MetadataCache,
+  private app: App,
+) {
+  // Uses only what's needed
+}
+
+// Alternative: Use underscore prefix for intentionally unused
+constructor(
+  private _vault: Vault,  // Signals "intentionally unused"
+  private app: App,
+) {}
+```
+
+**Prevention**: Run `npm run check:types` locally before pushing to catch unused parameter errors early.
+
+**Related Issues**: PR #391 (AliasSyncService unused vault parameter)
+
 ---
 
 ## 📚 Additional Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1114,11 +1114,16 @@ git commit -am "your message"
    ```
 
    If `mergeStateStatus: BEHIND`:
+   - **Cause**: Another PR merged to main while your PR was in CI pipeline
+   - **Solution**: Branch must be up-to-date before auto-merge activates
    ```bash
    git fetch origin main
    git rebase origin/main
    git push --force-with-lease origin <branch-name>
+   # CI will rerun automatically, auto-merge activates when checks GREEN
    ```
+
+   **Prevention**: Monitor `mergeStateStatus` regularly when using auto-merge. If you see another PR merged to main while yours is running, rebase proactively to avoid delays.
 
 2. **Auto-merge workflow timing**:
    - PR merge → CI on main starts (~3s delay)


### PR DESCRIPTION
## Summary

Added two troubleshooting entries to AGENTS.md and CLAUDE.md based on learnings from PR #391 (alias sync feature implementation).

## Changes

### AGENTS.md - TypeScript Error Troubleshooting

Added entry for `error TS6138: Property 'X' is declared but its value is never read`

- **Problem**: Constructor/function parameter declared but never used
- **Example**: AliasSyncService initially had unused `vault` parameter
- **Solution**: Remove unused parameter or use underscore prefix
- **Prevention**: Run `npm run check:types` before pushing

### CLAUDE.md - Auto-Merge Troubleshooting Enhancement

Enhanced existing auto-merge section with details about `mergeStateStatus: BEHIND`

- **Cause**: Another PR merged to main while your PR was in CI pipeline
- **Solution**: Rebase branch with main and force-push
- **Prevention**: Monitor `mergeStateStatus` regularly when using auto-merge
- **Context**: PR #391 encountered this - another PR merged during CI run

## Motivation

These errors were encountered during PR #391 development:
1. TypeScript error blocked CI (unused `vault` parameter)
2. Auto-merge stuck because branch fell behind main

By documenting these patterns, future AI agents can:
- Recognize these errors faster
- Apply proven solutions immediately  
- Avoid making the same mistakes

## Related

- PR #391: Alias sync feature (where these errors occurred)
- Post-mortem report: Documented all learnings from #391

## Checklist

- [x] Documentation follows existing format and style
- [x] Examples are clear and actionable
- [x] Prevention guidance included
- [x] Real-world context provided (PR #391)