### PR TITLE
fix: property field UX improvements

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
@@ -147,7 +147,7 @@ export const DateTimePropertyField: React.FC<DateTimePropertyFieldProps> = ({
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
-          style={{ marginRight: "6px" }}
+          style={{ marginRight: "6px", pointerEvents: "none" }}
         >
           <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
           <line x1="16" y1="2" x2="16" y2="6"></line>

--- a/packages/obsidian-plugin/src/presentation/components/properties/TextPropertyField.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/properties/TextPropertyField.tsx
@@ -13,6 +13,7 @@ export const TextPropertyField: React.FC<TextPropertyFieldProps> = ({
 }) => {
   const [localValue, setLocalValue] = useState(value);
   const inputRef = useRef<HTMLInputElement>(null);
+  const cancelledRef = useRef(false);
 
   useEffect(() => {
     setLocalValue(value);
@@ -23,6 +24,12 @@ export const TextPropertyField: React.FC<TextPropertyFieldProps> = ({
   };
 
   const handleBlur = () => {
+    if (cancelledRef.current) {
+      cancelledRef.current = false;
+      onBlur?.();
+      return;
+    }
+
     if (localValue !== value) {
       onChange(localValue);
     }
@@ -36,6 +43,7 @@ export const TextPropertyField: React.FC<TextPropertyFieldProps> = ({
     }
     if (e.key === "Escape") {
       e.preventDefault();
+      cancelledRef.current = true;
       setLocalValue(value);
       inputRef.current?.blur();
     }
@@ -51,6 +59,7 @@ export const TextPropertyField: React.FC<TextPropertyFieldProps> = ({
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
       placeholder="Enter value..."
+      style={{ width: "100%" }}
     />
   );
 };

--- a/packages/obsidian-plugin/tests/component/properties/DateTimePropertyField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/properties/DateTimePropertyField.spec.tsx
@@ -1,0 +1,245 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { DateTimePropertyField } from "../../../src/presentation/components/properties/DateTimePropertyField";
+
+test.describe("DateTimePropertyField Component", () => {
+  test("should render with calendar icon and display value", async ({ mount }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value="2024-11-11T10:30:00.000Z"
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toBeVisible();
+
+    // Check for calendar icon (SVG element)
+    const svg = component.locator("svg");
+    await expect(svg).toBeVisible();
+
+    // Check for formatted display value
+    const displayText = component.locator("span");
+    await expect(displayText).toBeVisible();
+  });
+
+  test("should display Empty when value is null", async ({ mount }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+
+    const displayText = component.locator("span");
+    await expect(displayText).toHaveText("Empty");
+  });
+
+  test("should open dropdown on single click", async ({ mount }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+
+    // Dropdown should not be visible initially
+    const dropdown = component.locator(".exocortex-property-datetime-dropdown");
+    await expect(dropdown).not.toBeVisible();
+
+    // Single click on display area
+    await component.click();
+
+    // Dropdown should now be visible
+    await expect(dropdown).toBeVisible();
+  });
+
+  test("should have pointer-events: none on SVG icon", async ({ mount }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+
+    const svg = component.locator("svg");
+    await expect(svg).toHaveCSS("pointer-events", "none");
+  });
+
+  test("should close dropdown on outside click", async ({ mount, page }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+
+    // Open dropdown
+    await component.click();
+
+    const dropdown = component.locator(".exocortex-property-datetime-dropdown");
+    await expect(dropdown).toBeVisible();
+
+    // Click outside (on page body)
+    await page.locator("body").click({ position: { x: 0, y: 0 } });
+
+    // Dropdown should close
+    await expect(dropdown).not.toBeVisible();
+  });
+
+  test("should call onChange when date is selected", async ({ mount }) => {
+    let changedValue: string | null | undefined = undefined;
+    const onChange = (value: string | null) => {
+      changedValue = value;
+    };
+
+    const component = await mount(
+      <DateTimePropertyField
+        value={null}
+        onChange={onChange}
+      />,
+    );
+
+    // Open dropdown
+    await component.click();
+
+    // Select date in datetime-local input
+    const dateInput = component.locator("input[type='datetime-local']");
+    await dateInput.fill("2024-11-11T15:30");
+
+    // onChange should be called with ISO string
+    await expect.poll(() => changedValue).toBeTruthy();
+    await expect.poll(() => typeof changedValue).toBe("string");
+  });
+
+  test("should call onChange with null when Clear button clicked", async ({ mount }) => {
+    let changedValue: string | null | undefined = undefined;
+    const onChange = (value: string | null) => {
+      changedValue = value;
+    };
+
+    const component = await mount(
+      <DateTimePropertyField
+        value="2024-11-11T10:30:00.000Z"
+        onChange={onChange}
+      />,
+    );
+
+    // Open dropdown
+    await component.click();
+
+    // Click Clear button
+    const clearButton = component.locator("button:has-text('Clear')");
+    await clearButton.click();
+
+    // onChange should be called with null
+    await expect.poll(() => changedValue).toBeNull();
+  });
+
+  test("should close dropdown after Clear button clicked", async ({ mount }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value="2024-11-11T10:30:00.000Z"
+        onChange={() => {}}
+      />,
+    );
+
+    // Open dropdown
+    await component.click();
+
+    const dropdown = component.locator(".exocortex-property-datetime-dropdown");
+    await expect(dropdown).toBeVisible();
+
+    // Click Clear button
+    const clearButton = component.locator("button:has-text('Clear')");
+    await clearButton.click();
+
+    // Dropdown should close
+    await expect(dropdown).not.toBeVisible();
+  });
+
+  test("should call onBlur callback when provided", async ({ mount, page }) => {
+    let onBlurCalled = false;
+    const onBlur = () => {
+      onBlurCalled = true;
+    };
+
+    const component = await mount(
+      <DateTimePropertyField
+        value={null}
+        onChange={() => {}}
+        onBlur={onBlur}
+      />,
+    );
+
+    // Open dropdown
+    await component.click();
+
+    // Click outside to close
+    await page.locator("body").click({ position: { x: 0, y: 0 } });
+
+    // onBlur should be called
+    await expect.poll(() => onBlurCalled).toBe(true);
+  });
+
+  test("should format date without time correctly", async ({ mount }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value="2024-11-11T00:00:00.000Z"
+        onChange={() => {}}
+      />,
+    );
+
+    const displayText = component.locator("span");
+    const text = await displayText.textContent();
+
+    // Should display date in localized format
+    // Format depends on locale, but should contain date components
+    expect(text).toBeTruthy();
+    expect(text).not.toBe("Empty");
+
+    // Date should be displayed (exact format varies by locale)
+    // Just verify it's not empty and is a valid date representation
+    expect(text?.length).toBeGreaterThan(0);
+  });
+
+  test("should format date with time correctly", async ({ mount }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value="2024-11-11T15:30:00.000Z"
+        onChange={() => {}}
+      />,
+    );
+
+    const displayText = component.locator("span");
+    const text = await displayText.textContent();
+
+    // Should display date with time (e.g., "Nov 11, 2024, 15:30")
+    expect(text).toContain("Nov");
+    expect(text).toContain("11");
+    expect(text).toContain("2024");
+    expect(text).toContain(":");
+  });
+
+  test("should update display when prop value changes", async ({ mount }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+
+    let displayText = component.locator("span");
+    await expect(displayText).toHaveText("Empty");
+
+    // Update prop value (simulating external update)
+    await component.update(
+      <DateTimePropertyField
+        value="2024-11-11T10:30:00.000Z"
+        onChange={() => {}}
+      />,
+    );
+
+    displayText = component.locator("span");
+    const text = await displayText.textContent();
+    expect(text).toContain("Nov");
+  });
+});

--- a/packages/obsidian-plugin/tests/component/properties/TextPropertyField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/properties/TextPropertyField.spec.tsx
@@ -1,0 +1,178 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { TextPropertyField } from "../../../src/presentation/components/properties/TextPropertyField";
+
+test.describe("TextPropertyField Component", () => {
+  test("should render input with full width style", async ({ mount }) => {
+    const component = await mount(
+      <TextPropertyField
+        value="test value"
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toBeVisible();
+
+    // Check that width: 100% is in the inline style attribute
+    const styleAttr = await component.getAttribute("style");
+    expect(styleAttr).toContain("width: 100%");
+  });
+
+  test("should render with initial value", async ({ mount }) => {
+    const component = await mount(
+      <TextPropertyField
+        value="initial value"
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toHaveValue("initial value");
+  });
+
+  test("should update local value on input change", async ({ mount }) => {
+    const component = await mount(
+      <TextPropertyField
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    await component.fill("new value");
+    await expect(component).toHaveValue("new value");
+  });
+
+  test("should call onChange on blur when value changed", async ({ mount }) => {
+    let changedValue: string | null = null;
+    const onChange = (value: string) => {
+      changedValue = value;
+    };
+
+    const component = await mount(
+      <TextPropertyField
+        value="original"
+        onChange={onChange}
+      />,
+    );
+
+    await component.fill("modified");
+    await component.blur();
+
+    await expect.poll(() => changedValue).toBe("modified");
+  });
+
+  test("should NOT call onChange on blur when value unchanged", async ({ mount }) => {
+    let onChangeCalled = false;
+    const onChange = () => {
+      onChangeCalled = true;
+    };
+
+    const component = await mount(
+      <TextPropertyField
+        value="unchanged"
+        onChange={onChange}
+      />,
+    );
+
+    await component.blur();
+
+    await expect.poll(() => onChangeCalled).toBe(false);
+  });
+
+  test("should call onBlur callback when provided", async ({ mount, page }) => {
+    let onBlurCalled = false;
+    const onBlur = () => {
+      onBlurCalled = true;
+    };
+
+    const component = await mount(
+      <TextPropertyField
+        value="test"
+        onChange={() => {}}
+        onBlur={onBlur}
+      />,
+    );
+
+    // Focus the input first
+    await component.focus();
+
+    // Click outside to trigger blur
+    await page.locator("body").click({ position: { x: 0, y: 0 } });
+
+    await expect.poll(() => onBlurCalled).toBe(true);
+  });
+
+  test("should save on Enter key press", async ({ mount }) => {
+    let savedValue: string | null = null;
+    const onChange = (value: string) => {
+      savedValue = value;
+    };
+
+    const component = await mount(
+      <TextPropertyField
+        value="original"
+        onChange={onChange}
+      />,
+    );
+
+    await component.fill("new value");
+    await component.press("Enter");
+
+    await expect.poll(() => savedValue).toBe("new value");
+  });
+
+  test("should revert changes on Escape key press", async ({ mount }) => {
+    let changeCount = 0;
+    const onChange = () => {
+      changeCount++;
+    };
+
+    const component = await mount(
+      <TextPropertyField
+        value="original"
+        onChange={onChange}
+      />,
+    );
+
+    await component.fill("modified");
+    await component.press("Escape");
+
+    // Value should revert to original
+    await expect(component).toHaveValue("original");
+
+    // onChange should NOT have been called (changeCount should remain 0)
+    // Note: The blur that happens after Escape will check if value changed,
+    // but since it's reverted to original, onChange won't be called
+    expect(changeCount).toBe(0);
+  });
+
+  test("should update local value when prop value changes", async ({ mount }) => {
+    const component = await mount(
+      <TextPropertyField
+        value="initial"
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toHaveValue("initial");
+
+    // Update prop value (simulating external update)
+    await component.update(
+      <TextPropertyField
+        value="updated"
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toHaveValue("updated");
+  });
+
+  test("should render placeholder text", async ({ mount }) => {
+    const component = await mount(
+      <TextPropertyField
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toHaveAttribute("placeholder", "Enter value...");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two UX issues with editable property fields:

1. **Text field width** - Input now fills available space with `width: 100%`
2. **DateTime picker single-click** - SVG icon no longer blocks clicks with `pointer-events: none`
3. **Escape key behavior** - Properly cancels editing without calling onChange

## Changes

- `TextPropertyField.tsx`: Added width: 100% inline style, fixed Escape key handling with cancelledRef
- `DateTimePropertyField.tsx`: Added pointer-events: none to SVG icon
- Added 22 comprehensive component tests for both fields

## Test Coverage

- All existing tests pass (803 unit + 55 UI + 332 component)
- New tests: 10 for TextPropertyField, 12 for DateTimePropertyField
- Tests verify: width styling, single-click opening, onChange/onBlur callbacks, keyboard shortcuts

## Testing

Tested both fixes work correctly in component tests with Playwright CT.