### PR TITLE
docs: update SPARQL namespace URIs to match vault ontology

### DIFF
--- a/docs/sparql/Developer-Guide.md
+++ b/docs/sparql/Developer-Guide.md
@@ -181,7 +181,7 @@ import { Triple, IRI, Literal } from "@exocortex/core";
 
 const triple = new Triple(
   IRI("vault://Notes/My-Note.md"),
-  IRI("http://exocortex.ai/ontology#Asset_label"),
+  IRI("https://exocortex.my/ontology/exo#Asset_label"),
   Literal("My Note")
 );
 
@@ -193,7 +193,7 @@ tripleStore.add(triple);
 ```typescript
 const allTasks = tripleStore.match(
   null,  // Any subject
-  IRI("http://exocortex.ai/ontology#Instance_class"),
+  IRI("https://exocortex.my/ontology/exo#Instance_class"),
   Literal("ems__Task")
 );
 
@@ -253,8 +253,8 @@ const parser = new SPARQLParser();
 const ast = parser.parse(`
   SELECT ?task ?label
   WHERE {
-    ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-    ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+    ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+    ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
   }
 `);
 ```
@@ -620,7 +620,7 @@ describe("InMemoryTripleStore", () => {
   it("should add and retrieve triples", () => {
     const triple = new Triple(
       IRI("vault://test.md"),
-      IRI("http://exocortex.ai/ontology#Asset_label"),
+      IRI("https://exocortex.my/ontology/exo#Asset_label"),
       Literal("Test")
     );
 
@@ -639,7 +639,7 @@ describe("InMemoryTripleStore", () => {
   it("should use SPO index for (s, p, ?) pattern", () => {
     const triple = new Triple(
       IRI("vault://test.md"),
-      IRI("http://exocortex.ai/ontology#Asset_label"),
+      IRI("https://exocortex.my/ontology/exo#Asset_label"),
       Literal("Test")
     );
 
@@ -647,7 +647,7 @@ describe("InMemoryTripleStore", () => {
 
     const results = store.match(
       IRI("vault://test.md"),
-      IRI("http://exocortex.ai/ontology#Asset_label"),
+      IRI("https://exocortex.my/ontology/exo#Asset_label"),
       null
     );
 
@@ -671,7 +671,7 @@ describe("BGPExecutor", () => {
 
     store.add(new Triple(
       IRI("vault://task1.md"),
-      IRI("http://exocortex.ai/ontology#Instance_class"),
+      IRI("https://exocortex.my/ontology/exo#Instance_class"),
       Literal("ems__Task")
     ));
   });
@@ -681,7 +681,7 @@ describe("BGPExecutor", () => {
     const ast = parser.parse(`
       SELECT ?task
       WHERE {
-        ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+        ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
       }
     `);
 
@@ -763,8 +763,8 @@ test.describe("SPARQL Code Block", () => {
       codeBlock.textContent = `
         SELECT ?task ?label
         WHERE {
-          ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-          ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+          ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+          ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
         }
       `;
       codeBlock.classList.add("language-sparql");
@@ -884,8 +884,8 @@ async function getTasks(): Promise<SolutionMapping[]> {
   const result: QueryResult = await plugin.sparql.query(`
     SELECT ?task ?label
     WHERE {
-      ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-      ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+      ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+      ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
     }
   `);
 

--- a/docs/sparql/Performance-Tips.md
+++ b/docs/sparql/Performance-Tips.md
@@ -70,7 +70,7 @@ Exocortex uses a **triple-indexed storage system** with three indexes:
 SELECT ?task ?status
 WHERE {
   ?task ?p ?status .  # No index match
-  FILTER(?p = <http://exocortex.ai/ontology#Task_status>)
+  FILTER(?p = <https://exocortex.my/ontology/ems#Task_status>)
 }
 ```
 
@@ -78,7 +78,7 @@ WHERE {
 ```sparql
 SELECT ?task ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .  # POS index
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .  # POS index
 }
 ```
 
@@ -91,7 +91,7 @@ WHERE {
 SELECT ?task ?p ?o
 WHERE {
   ?task ?p ?o .  # Wildcard predicate
-  FILTER(?p = <http://exocortex.ai/ontology#Task_status>)
+  FILTER(?p = <https://exocortex.my/ontology/ems#Task_status>)
 }
 ```
 
@@ -99,7 +99,7 @@ WHERE {
 ```sparql
 SELECT ?task ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
 }
 ```
 
@@ -117,8 +117,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .  # Matches ~1000 assets
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .  # Filters to ~200 tasks
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .  # Matches ~1000 assets
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .  # Filters to ~200 tasks
 }
 ```
 
@@ -126,8 +126,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .  # Matches ~200 tasks
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .  # Gets labels for 200
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .  # Matches ~200 tasks
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .  # Gets labels for 200
 }
 ```
 
@@ -139,9 +139,9 @@ WHERE {
 ```sparql
 SELECT ?task ?label ?project
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
   FILTER(regex(?label, "urgent", "i"))  # Filter at end
 }
 ```
@@ -150,10 +150,10 @@ WHERE {
 ```sparql
 SELECT ?task ?label ?project
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
   FILTER(regex(?label, "urgent", "i"))  # Filter reduces set early
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
 }
 ```
 
@@ -187,8 +187,8 @@ LIMIT 1000
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -200,7 +200,7 @@ WHERE {
 ```sparql
 SELECT ?asset ?label
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?asset <https://exocortex.my/ontology/exo#Asset_label> ?label .
   FILTER(regex(?label, ".*", "i"))  # Match everything
 }
 ```
@@ -211,8 +211,8 @@ WHERE {
 ```sparql
 SELECT ?asset ?label
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Instance_class> "ems__Task" .  # Reduce set first
-  ?asset <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?asset <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .  # Reduce set first
+  ?asset <https://exocortex.my/ontology/exo#Asset_label> ?label .
   FILTER(regex(?label, "urgent", "i"))  # Specific pattern
 }
 ```
@@ -223,8 +223,8 @@ WHERE {
 ```sparql
 SELECT DISTINCT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -234,8 +234,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -247,13 +247,13 @@ WHERE {
 ```sparql
 SELECT ?task ?label ?status ?priority ?votes ?project ?area
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Asset_label> ?label . }
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_status> ?status . }
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_priority> ?priority . }
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Effort_votes> ?votes . }
-  OPTIONAL { ?task <http://exocortex.ai/ontology#belongs_to_project> ?project . }
-  OPTIONAL { ?project <http://exocortex.ai/ontology#belongs_to_area> ?area . }
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  OPTIONAL { ?task <https://exocortex.my/ontology/exo#Asset_label> ?label . }
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Task_status> ?status . }
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Task_priority> ?priority . }
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes . }
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project . }
+  OPTIONAL { ?project <https://exocortex.my/ontology/ems#belongs_to_area> ?area . }
 }
 ```
 
@@ -263,8 +263,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -276,9 +276,9 @@ WHERE {
 ```sparql
 SELECT (COUNT(?task) AS ?count)
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
 }
 ```
 
@@ -288,7 +288,7 @@ WHERE {
 ```sparql
 SELECT (COUNT(?task) AS ?count)
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 }
 ```
 
@@ -340,7 +340,7 @@ console.log(`Query took ${elapsed}ms, returned ${results.count} results`);
 ```sparql
 SELECT ?task
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 }
 ```
 
@@ -349,8 +349,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -359,8 +359,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
   FILTER(regex(?label, "urgent", "i"))
 }
 ```
@@ -378,8 +378,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 LIMIT 10  # Safe for testing
 ```
@@ -389,8 +389,8 @@ LIMIT 10  # Safe for testing
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 # Only omit LIMIT if you're sure result set is small
 ```
@@ -410,7 +410,7 @@ async function getTaskStatuses() {
   cachedResults = await plugin.sparql.query(`
     SELECT DISTINCT ?status
     WHERE {
-      ?task <http://exocortex.ai/ontology#Task_status> ?status .
+      ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
     }
   `);
 
@@ -425,8 +425,8 @@ async function getTaskStatuses() {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 LIMIT 50
 OFFSET 0
@@ -448,7 +448,7 @@ OFFSET 50
 
 ✅ **DO** (specific):
 ```sparql
-?task <http://exocortex.ai/ontology#Task_status> ?status .
+?task <https://exocortex.my/ontology/ems#Task_status> ?status .
 ```
 
 ### 5. Avoid Complex Filters
@@ -483,7 +483,7 @@ Instead of:
 ```sparql
 SELECT ?project (COUNT(?task) AS ?count)
 WHERE {
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
 }
 GROUP BY ?project
 ```

--- a/docs/sparql/Query-Examples.md
+++ b/docs/sparql/Query-Examples.md
@@ -24,7 +24,7 @@ Get all notes in your vault:
 ```sparql
 SELECT ?asset ?label
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?asset <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 LIMIT 100
 ```
@@ -40,7 +40,7 @@ Find all unique entity classes in your vault:
 ```sparql
 SELECT DISTINCT ?class
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Instance_class> ?class .
+  ?asset <https://exocortex.my/ontology/exo#Instance_class> ?class .
 }
 ```
 
@@ -58,7 +58,7 @@ Count how many assets of each type you have:
 ```sparql
 SELECT ?class (COUNT(?asset) AS ?count)
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Instance_class> ?class .
+  ?asset <https://exocortex.my/ontology/exo#Instance_class> ?class .
 }
 GROUP BY ?class
 ORDER BY DESC(?count)
@@ -77,11 +77,11 @@ List all non-archived tasks:
 ```sparql
 SELECT ?task ?label ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_status> ?status . }
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Task_status> ?status . }
   FILTER NOT EXISTS {
-    ?task <http://exocortex.ai/ontology#Asset_archived> ?archived .
+    ?task <https://exocortex.my/ontology/exo#Asset_archived> ?archived .
     FILTER(?archived = true || ?archived = "true" || ?archived = "archived")
   }
 }
@@ -99,8 +99,8 @@ Get tasks grouped by their status:
 ```sparql
 SELECT ?status (COUNT(?task) AS ?count)
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
 }
 GROUP BY ?status
 ORDER BY DESC(?count)
@@ -117,11 +117,11 @@ Show all tasks currently being worked on:
 ```sparql
 SELECT ?task ?label ?project
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#Task_status> "in-progress" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/ems#Task_status> "in-progress" .
   OPTIONAL {
-    ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+    ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
   }
 }
 ORDER BY ?project ?label
@@ -138,9 +138,9 @@ Find tasks with significant effort votes:
 ```sparql
 SELECT ?task ?label ?votes
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes .
   FILTER(?votes > 5)
 }
 ORDER BY DESC(?votes)
@@ -157,11 +157,11 @@ Find orphaned tasks not assigned to any project:
 ```sparql
 SELECT ?task ?label ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_status> ?status . }
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Task_status> ?status . }
   FILTER NOT EXISTS {
-    ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+    ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
   }
 }
 ORDER BY ?label
@@ -178,9 +178,9 @@ List tasks sorted by priority:
 ```sparql
 SELECT ?task ?label ?priority
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_priority> ?priority . }
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Task_priority> ?priority . }
 }
 ORDER BY ?priority ?label
 ```
@@ -196,9 +196,9 @@ Find tasks created recently (assuming you have a creation date property):
 ```sparql
 SELECT ?task ?label ?created
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#created_at> ?created .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#created_at> ?created .
   FILTER(?created > "2025-01-01")
 }
 ORDER BY DESC(?created)
@@ -218,10 +218,10 @@ List projects and count their tasks:
 ```sparql
 SELECT ?project ?projectLabel (COUNT(?task) AS ?taskCount)
 WHERE {
-  ?project <http://exocortex.ai/ontology#Instance_class> "ems__Project" .
-  ?project <http://exocortex.ai/ontology#Asset_label> ?projectLabel .
+  ?project <https://exocortex.my/ontology/exo#Instance_class> "ems__Project" .
+  ?project <https://exocortex.my/ontology/exo#Asset_label> ?projectLabel .
   OPTIONAL {
-    ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+    ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
   }
 }
 GROUP BY ?project ?projectLabel
@@ -239,10 +239,10 @@ Group projects by their parent area:
 ```sparql
 SELECT ?area ?areaLabel ?project ?projectLabel
 WHERE {
-  ?area <http://exocortex.ai/ontology#Instance_class> "ems__Area" .
-  ?area <http://exocortex.ai/ontology#Asset_label> ?areaLabel .
-  ?project <http://exocortex.ai/ontology#belongs_to_area> ?area .
-  ?project <http://exocortex.ai/ontology#Asset_label> ?projectLabel .
+  ?area <https://exocortex.my/ontology/exo#Instance_class> "ems__Area" .
+  ?area <https://exocortex.my/ontology/exo#Asset_label> ?areaLabel .
+  ?project <https://exocortex.my/ontology/ems#belongs_to_area> ?area .
+  ?project <https://exocortex.my/ontology/exo#Asset_label> ?projectLabel .
 }
 ORDER BY ?areaLabel ?projectLabel
 ```
@@ -258,10 +258,10 @@ Find projects with at least one in-progress task:
 ```sparql
 SELECT DISTINCT ?project ?projectLabel
 WHERE {
-  ?project <http://exocortex.ai/ontology#Instance_class> "ems__Project" .
-  ?project <http://exocortex.ai/ontology#Asset_label> ?projectLabel .
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?task <http://exocortex.ai/ontology#Task_status> "in-progress" .
+  ?project <https://exocortex.my/ontology/exo#Instance_class> "ems__Project" .
+  ?project <https://exocortex.my/ontology/exo#Asset_label> ?projectLabel .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/ems#Task_status> "in-progress" .
 }
 ORDER BY ?projectLabel
 ```
@@ -277,10 +277,10 @@ Find empty projects that might need cleanup:
 ```sparql
 SELECT ?project ?projectLabel
 WHERE {
-  ?project <http://exocortex.ai/ontology#Instance_class> "ems__Project" .
-  ?project <http://exocortex.ai/ontology#Asset_label> ?projectLabel .
+  ?project <https://exocortex.my/ontology/exo#Instance_class> "ems__Project" .
+  ?project <https://exocortex.my/ontology/exo#Asset_label> ?projectLabel .
   FILTER NOT EXISTS {
-    ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+    ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
   }
 }
 ORDER BY ?projectLabel
@@ -300,10 +300,10 @@ SELECT ?project ?projectLabel
        (SUM(IF(?status = "done", 1, 0)) AS ?doneTasks)
        (SUM(IF(?status = "done", 1, 0)) * 100 / COUNT(?task) AS ?completionRate)
 WHERE {
-  ?project <http://exocortex.ai/ontology#Instance_class> "ems__Project" .
-  ?project <http://exocortex.ai/ontology#Asset_label> ?projectLabel .
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
+  ?project <https://exocortex.my/ontology/exo#Instance_class> "ems__Project" .
+  ?project <https://exocortex.my/ontology/exo#Asset_label> ?projectLabel .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
 }
 GROUP BY ?project ?projectLabel
 HAVING (COUNT(?task) > 0)
@@ -323,14 +323,14 @@ Show full hierarchy for each task:
 ```sparql
 SELECT ?task ?taskLabel ?project ?projectLabel ?area ?areaLabel
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?taskLabel .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?taskLabel .
   OPTIONAL {
-    ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-    ?project <http://exocortex.ai/ontology#Asset_label> ?projectLabel .
+    ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
+    ?project <https://exocortex.my/ontology/exo#Asset_label> ?projectLabel .
     OPTIONAL {
-      ?project <http://exocortex.ai/ontology#belongs_to_area> ?area .
-      ?area <http://exocortex.ai/ontology#Asset_label> ?areaLabel .
+      ?project <https://exocortex.my/ontology/ems#belongs_to_area> ?area .
+      ?area <https://exocortex.my/ontology/exo#Asset_label> ?areaLabel .
     }
   }
 }
@@ -349,7 +349,7 @@ Find assets linked to a specific note (replace path):
 SELECT ?related ?relatedLabel ?relationType
 WHERE {
   <vault://path/to/your/note.md> ?relationType ?related .
-  ?related <http://exocortex.ai/ontology#Asset_label> ?relatedLabel .
+  ?related <https://exocortex.my/ontology/exo#Asset_label> ?relatedLabel .
 }
 ```
 
@@ -364,10 +364,10 @@ Find notes that link to each other:
 ```sparql
 SELECT ?note1 ?note1Label ?note2 ?note2Label
 WHERE {
-  ?note1 <http://exocortex.ai/ontology#Asset_label> ?note1Label .
-  ?note2 <http://exocortex.ai/ontology#Asset_label> ?note2Label .
-  ?note1 <http://exocortex.ai/ontology#links_to> ?note2 .
-  ?note2 <http://exocortex.ai/ontology#links_to> ?note1 .
+  ?note1 <https://exocortex.my/ontology/exo#Asset_label> ?note1Label .
+  ?note2 <https://exocortex.my/ontology/exo#Asset_label> ?note2Label .
+  ?note1 <https://exocortex.my/ontology/exo#links_to> ?note2 .
+  ?note2 <https://exocortex.my/ontology/exo#links_to> ?note1 .
   FILTER(?note1 != ?note2)
 }
 ```
@@ -385,9 +385,9 @@ Find tasks scheduled for today (assuming time properties):
 ```sparql
 SELECT ?task ?taskLabel ?startTime
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?taskLabel .
-  ?task <http://exocortex.ai/ontology#Effort_startTime> ?startTime .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?taskLabel .
+  ?task <https://exocortex.my/ontology/ems#Effort_startTime> ?startTime .
   FILTER(regex(?startTime, "2025-01-09"))
 }
 ORDER BY ?startTime
@@ -404,9 +404,9 @@ Find long-running tasks (high effort time):
 ```sparql
 SELECT ?task ?taskLabel ?duration
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?taskLabel .
-  ?task <http://exocortex.ai/ontology#Effort_duration_minutes> ?duration .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?taskLabel .
+  ?task <https://exocortex.my/ontology/ems#Effort_duration_minutes> ?duration .
   FILTER(?duration > 120)
 }
 ORDER BY DESC(?duration)
@@ -425,10 +425,10 @@ Sum effort votes per project:
 ```sparql
 SELECT ?project ?projectLabel (SUM(?votes) AS ?totalVotes)
 WHERE {
-  ?project <http://exocortex.ai/ontology#Instance_class> "ems__Project" .
-  ?project <http://exocortex.ai/ontology#Asset_label> ?projectLabel .
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?project <https://exocortex.my/ontology/exo#Instance_class> "ems__Project" .
+  ?project <https://exocortex.my/ontology/exo#Asset_label> ?projectLabel .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes .
 }
 GROUP BY ?project ?projectLabel
 ORDER BY DESC(?totalVotes)
@@ -445,9 +445,9 @@ Calculate average effort per status:
 ```sparql
 SELECT ?status (AVG(?votes) AS ?avgVotes) (COUNT(?task) AS ?taskCount)
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes .
 }
 GROUP BY ?status
 ORDER BY DESC(?avgVotes)
@@ -464,10 +464,10 @@ Count tasks across all areas (including nested projects):
 ```sparql
 SELECT ?area ?areaLabel (COUNT(?task) AS ?taskCount)
 WHERE {
-  ?area <http://exocortex.ai/ontology#Instance_class> "ems__Area" .
-  ?area <http://exocortex.ai/ontology#Asset_label> ?areaLabel .
-  ?project <http://exocortex.ai/ontology#belongs_to_area> ?area .
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+  ?area <https://exocortex.my/ontology/exo#Instance_class> "ems__Area" .
+  ?area <https://exocortex.my/ontology/exo#Asset_label> ?areaLabel .
+  ?project <https://exocortex.my/ontology/ems#belongs_to_area> ?area .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
 }
 GROUP BY ?area ?areaLabel
 ORDER BY DESC(?taskCount)
@@ -490,9 +490,9 @@ CONSTRUCT {
   ?project <http://example.org/has_label> ?projectLabel .
 }
 WHERE {
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?taskLabel .
-  ?project <http://exocortex.ai/ontology#Asset_label> ?projectLabel .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?taskLabel .
+  ?project <https://exocortex.my/ontology/exo#Asset_label> ?projectLabel .
 }
 ```
 
@@ -509,8 +509,8 @@ CONSTRUCT {
   ?task <http://example.org/belongs_to_area> ?area .
 }
 WHERE {
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?project <http://exocortex.ai/ontology#belongs_to_area> ?area .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
+  ?project <https://exocortex.my/ontology/ems#belongs_to_area> ?area .
 }
 ```
 
@@ -527,7 +527,7 @@ CONSTRUCT {
   ?task <http://example.org/priority_class> ?priorityClass .
 }
 WHERE {
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes .
   BIND(
     IF(?votes > 10, "critical",
       IF(?votes > 5, "high",
@@ -551,9 +551,9 @@ Find tasks incorrectly assigned to multiple projects:
 ```sparql
 SELECT ?task ?taskLabel (COUNT(?project) AS ?projectCount)
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?taskLabel .
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?taskLabel .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
 }
 GROUP BY ?task ?taskLabel
 HAVING (COUNT(?project) > 1)
@@ -571,12 +571,12 @@ Find all descendants of an area (projects + tasks):
 SELECT ?descendant ?descendantLabel ?type
 WHERE {
   {
-    <vault://Areas/My-Area.md> ^<http://exocortex.ai/ontology#belongs_to_area> ?descendant .
-    ?descendant <http://exocortex.ai/ontology#Asset_label> ?descendantLabel .
+    <vault://Areas/My-Area.md> ^<https://exocortex.my/ontology/ems#belongs_to_area> ?descendant .
+    ?descendant <https://exocortex.my/ontology/exo#Asset_label> ?descendantLabel .
     BIND("project" AS ?type)
   } UNION {
-    <vault://Areas/My-Area.md> ^<http://exocortex.ai/ontology#belongs_to_area> / ^<http://exocortex.ai/ontology#belongs_to_project> ?descendant .
-    ?descendant <http://exocortex.ai/ontology#Asset_label> ?descendantLabel .
+    <vault://Areas/My-Area.md> ^<https://exocortex.my/ontology/ems#belongs_to_area> / ^<https://exocortex.my/ontology/ems#belongs_to_project> ?descendant .
+    ?descendant <https://exocortex.my/ontology/exo#Asset_label> ?descendantLabel .
     BIND("task" AS ?type)
   }
 }
@@ -593,7 +593,7 @@ Search for assets by label content:
 ```sparql
 SELECT ?asset ?label
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?asset <https://exocortex.my/ontology/exo#Asset_label> ?label .
   FILTER(regex(?label, "machine learning", "i"))
 }
 LIMIT 50
@@ -610,17 +610,17 @@ Complex multi-condition query:
 ```sparql
 SELECT ?task ?taskLabel ?status ?votes ?project
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?taskLabel .
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?taskLabel .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
 
   FILTER(?status = "in-progress" || ?status = "backlog")
   FILTER(?votes > 3)
   FILTER(regex(?taskLabel, "urgent|important", "i"))
   FILTER NOT EXISTS {
-    ?task <http://exocortex.ai/ontology#Asset_archived> ?archived .
+    ?task <https://exocortex.my/ontology/exo#Asset_archived> ?archived .
   }
 }
 ORDER BY DESC(?votes) ?taskLabel
@@ -638,7 +638,7 @@ LIMIT 20
 Replace URIs with your actual property names:
 
 ```sparql
-<http://exocortex.ai/ontology#Asset_label> → Your property URI
+<https://exocortex.my/ontology/exo#Asset_label> → Your property URI
 "ems__Task" → Your class name
 ```
 

--- a/docs/sparql/User-Guide.md
+++ b/docs/sparql/User-Guide.md
@@ -41,9 +41,9 @@ Every note in your vault becomes a set of RDF triples:
 For example, a task note becomes:
 
 ```turtle
-<vault://Projects/My-Task.md> <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-<vault://Projects/My-Task.md> <http://exocortex.ai/ontology#Asset_label> "My Task" .
-<vault://Projects/My-Task.md> <http://exocortex.ai/ontology#Task_status> "in-progress" .
+<vault://Projects/My-Task.md> <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+<vault://Projects/My-Task.md> <https://exocortex.my/ontology/exo#Asset_label> "My Task" .
+<vault://Projects/My-Task.md> <https://exocortex.my/ontology/ems#Task_status> "in-progress" .
 ```
 
 ### How to Write SPARQL Queries in Obsidian
@@ -54,8 +54,8 @@ Create a code block with `sparql` language identifier:
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 ````
@@ -75,7 +75,7 @@ SELECT queries retrieve specific variables from your data.
 ```sparql
 SELECT ?task
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 }
 ```
 
@@ -89,8 +89,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -119,8 +119,8 @@ Control result size:
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 LIMIT 10
 ```
@@ -130,8 +130,8 @@ Pagination:
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 LIMIT 10
 OFFSET 20
@@ -144,7 +144,7 @@ Remove duplicates:
 ```sparql
 SELECT DISTINCT ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
 }
 ```
 
@@ -163,8 +163,8 @@ Filter results based on conditions:
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
   FILTER(regex(?label, "report", "i"))
 }
 ```
@@ -178,8 +178,8 @@ WHERE {
 ```sparql
 SELECT ?task ?votes
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes .
   FILTER(?votes > 5)
 }
 ```
@@ -194,9 +194,9 @@ WHERE {
 ```sparql
 SELECT ?task ?label ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
   FILTER(?status = "in-progress" || ?status = "backlog")
   FILTER(regex(?label, "urgent", "i"))
 }
@@ -209,10 +209,10 @@ Match optional properties:
 ```sparql
 SELECT ?task ?label ?priority
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
   OPTIONAL {
-    ?task <http://exocortex.ai/ontology#Task_priority> ?priority .
+    ?task <https://exocortex.my/ontology/ems#Task_priority> ?priority .
   }
 }
 ```
@@ -227,11 +227,11 @@ Match either pattern:
 SELECT ?asset ?label
 WHERE {
   {
-    ?asset <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+    ?asset <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
   } UNION {
-    ?asset <http://exocortex.ai/ontology#Instance_class> "ems__Project" .
+    ?asset <https://exocortex.my/ontology/exo#Instance_class> "ems__Project" .
   }
-  ?asset <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?asset <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -250,7 +250,7 @@ Exocortex uses two main property namespaces:
 
 **Full URIs**:
 ```
-exo__Asset_label → <http://exocortex.ai/ontology#Asset_label>
+exo__Asset_label → <https://exocortex.my/ontology/exo#Asset_label>
 ems__Task → "ems__Task"
 ```
 
@@ -261,10 +261,10 @@ ems__Task → "ems__Task"
 ```sparql
 SELECT ?asset ?label ?class ?archived
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Instance_class> ?class .
-  ?asset <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?asset <https://exocortex.my/ontology/exo#Instance_class> ?class .
+  ?asset <https://exocortex.my/ontology/exo#Asset_label> ?label .
   OPTIONAL {
-    ?asset <http://exocortex.ai/ontology#Asset_archived> ?archived .
+    ?asset <https://exocortex.my/ontology/exo#Asset_archived> ?archived .
   }
 }
 ```
@@ -279,11 +279,11 @@ WHERE {
 ```sparql
 SELECT ?task ?label ?status ?priority ?votes
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_status> ?status . }
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_priority> ?priority . }
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Effort_votes> ?votes . }
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Task_status> ?status . }
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Task_priority> ?priority . }
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes . }
 }
 ```
 
@@ -297,12 +297,12 @@ WHERE {
 ```sparql
 SELECT ?task ?project ?area
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
   OPTIONAL {
-    ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+    ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
   }
   OPTIONAL {
-    ?project <http://exocortex.ai/ontology#belongs_to_area> ?area .
+    ?project <https://exocortex.my/ontology/ems#belongs_to_area> ?area .
   }
 }
 ```
@@ -316,10 +316,10 @@ WHERE {
 ```sparql
 SELECT ?asset ?label
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?asset <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?asset <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?asset <https://exocortex.my/ontology/exo#Asset_label> ?label .
   FILTER NOT EXISTS {
-    ?asset <http://exocortex.ai/ontology#Asset_archived> ?archived .
+    ?asset <https://exocortex.my/ontology/exo#Asset_archived> ?archived .
     FILTER(?archived = true || ?archived = "true" || ?archived = "archived")
   }
 }
@@ -336,7 +336,7 @@ WHERE {
 ```sparql
 SELECT (COUNT(?task) AS ?taskCount)
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 }
 ```
 
@@ -347,8 +347,8 @@ WHERE {
 ```sparql
 SELECT ?status (COUNT(?task) AS ?count)
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
 }
 GROUP BY ?status
 ```
@@ -366,8 +366,8 @@ GROUP BY ?status
 ```sparql
 SELECT ?project (SUM(?votes) AS ?totalVotes)
 WHERE {
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes .
 }
 GROUP BY ?project
 ```
@@ -379,7 +379,7 @@ GROUP BY ?project
 ```sparql
 SELECT ?project (COUNT(?task) AS ?taskCount)
 WHERE {
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
 }
 GROUP BY ?project
 HAVING (COUNT(?task) > 5)
@@ -395,9 +395,9 @@ SELECT ?status
        (SUM(?votes) AS ?totalVotes)
        (AVG(?votes) AS ?avgVotes)
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes .
 }
 GROUP BY ?status
 ```
@@ -423,8 +423,8 @@ CONSTRUCT {
   ?task <http://exocortex.ai/ontology#has_label> ?label .
 }
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -437,8 +437,8 @@ CONSTRUCT {
   ?task <http://exocortex.ai/ontology#in_area> ?area .
 }
 WHERE {
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?project <http://exocortex.ai/ontology#belongs_to_area> ?area .
+  ?task <https://exocortex.my/ontology/ems#belongs_to_project> ?project .
+  ?project <https://exocortex.my/ontology/ems#belongs_to_area> ?area .
 }
 ```
 
@@ -451,7 +451,7 @@ CONSTRUCT {
   ?task <http://example.org/priority_level> ?priorityClass .
 }
 WHERE {
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?task <https://exocortex.my/ontology/ems#Effort_votes> ?votes .
   BIND(
     IF(?votes > 10, "high",
       IF(?votes > 5, "medium", "low")
@@ -485,8 +485,8 @@ LIMIT 100
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -512,8 +512,8 @@ LIMIT 10
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
   FILTER(regex(?label, "report", "i"))
 }
 ```
@@ -522,8 +522,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
   FILTER(regex(?label, "report", "i"))
 }
 ```
@@ -536,9 +536,9 @@ WHERE {
 ```sparql
 SELECT ?task ?label ?priority
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Asset_label> ?label . }
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_priority> ?priority . }
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  OPTIONAL { ?task <https://exocortex.my/ontology/exo#Asset_label> ?label . }
+  OPTIONAL { ?task <https://exocortex.my/ontology/ems#Task_priority> ?priority . }
 }
 ```
 
@@ -546,8 +546,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -560,7 +560,7 @@ WHERE {
 ```sparql
 SELECT ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
+  ?task <https://exocortex.my/ontology/ems#Task_status> ?status .
 }
 ```
 
@@ -576,14 +576,14 @@ WHERE {
 ```sparql
 SELECT ?task
 WHERE
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 ```
 
 ✅ **Correct**:
 ```sparql
 SELECT ?task
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 }
 ```
 
@@ -595,8 +595,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task"
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task"
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -604,8 +604,8 @@ WHERE {
 ```sparql
 SELECT ?task ?label
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
 }
 ```
 
@@ -625,7 +625,7 @@ WHERE {
 ```sparql
 SELECT ?task
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 }
 ```
 
@@ -639,7 +639,7 @@ SPARQL is case-sensitive:
 ```sparql
 select ?task
 where {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 }
 ```
 
@@ -647,7 +647,7 @@ where {
 ```sparql
 SELECT ?task
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 }
 ```
 
@@ -659,7 +659,7 @@ WHERE {
 ```sparql
 SELECT ?task
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> ems__Task .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> ems__Task .
 }
 ```
 
@@ -667,7 +667,7 @@ WHERE {
 ```sparql
 SELECT ?task
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+  ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
 }
 ```
 
@@ -691,7 +691,7 @@ WHERE {
    ```sparql
    SELECT DISTINCT ?class
    WHERE {
-     ?s <http://exocortex.ai/ontology#Instance_class> ?class .
+     ?s <https://exocortex.my/ontology/exo#Instance_class> ?class .
    }
    ```
    Verify actual class names (`ems__Task`, not `Task`).
@@ -700,7 +700,7 @@ WHERE {
    ```sparql
    SELECT ?task
    WHERE {
-     ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
+     ?task <https://exocortex.my/ontology/exo#Instance_class> "ems__Task" .
    }
    ```
    Verify tasks exist in your vault with correct frontmatter.

--- a/packages/obsidian-plugin/src/presentation/components/sparql/QueryTemplates.ts
+++ b/packages/obsidian-plugin/src/presentation/components/sparql/QueryTemplates.ts
@@ -13,9 +13,11 @@ export const QUERY_TEMPLATES: QueryTemplate[] = [
     name: "all assets",
     description: "get all notes in your vault",
     category: "basic",
-    query: `SELECT ?asset ?label
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT ?asset ?label
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Asset_label> ?label .
+  ?asset exo:Asset_label ?label .
 }
 LIMIT 100`,
     useCase: "quick overview of vault contents",
@@ -25,9 +27,11 @@ LIMIT 100`,
     name: "list entity types",
     description: "find all unique entity classes",
     category: "basic",
-    query: `SELECT DISTINCT ?class
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT DISTINCT ?class
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Instance_class> ?class .
+  ?asset exo:Instance_class ?class .
 }`,
     useCase: "understanding vault structure",
   },
@@ -36,9 +40,11 @@ WHERE {
     name: "count assets by type",
     description: "count assets grouped by entity type",
     category: "basic",
-    query: `SELECT ?class (COUNT(?asset) AS ?count)
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT ?class (COUNT(?asset) AS ?count)
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Instance_class> ?class .
+  ?asset exo:Instance_class ?class .
 }
 GROUP BY ?class
 ORDER BY DESC(?count)`,
@@ -49,13 +55,16 @@ ORDER BY DESC(?count)`,
     name: "all active tasks",
     description: "list all non-archived tasks",
     category: "tasks",
-    query: `SELECT ?task ?label ?status
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_status> ?status . }
+  ?task exo:Instance_class "ems__Task" .
+  ?task exo:Asset_label ?label .
+  OPTIONAL { ?task ems:Task_status ?status . }
   FILTER NOT EXISTS {
-    ?task <http://exocortex.ai/ontology#Asset_archived> ?archived .
+    ?task exo:Asset_archived ?archived .
     FILTER(?archived = true || ?archived = "true" || ?archived = "archived")
   }
 }
@@ -67,10 +76,13 @@ ORDER BY ?label`,
     name: "tasks by status",
     description: "count tasks grouped by status",
     category: "tasks",
-    query: `SELECT ?status (COUNT(?task) AS ?count)
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?status (COUNT(?task) AS ?count)
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Task_status> ?status .
+  ?task exo:Instance_class "ems__Task" .
+  ?task ems:Task_status ?status .
 }
 GROUP BY ?status
 ORDER BY DESC(?count)`,
@@ -81,13 +93,16 @@ ORDER BY DESC(?count)`,
     name: "in-progress tasks",
     description: "show tasks currently being worked on",
     category: "tasks",
-    query: `SELECT ?task ?label ?project
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?project
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#Task_status> "in-progress" .
+  ?task exo:Instance_class "ems__Task" .
+  ?task exo:Asset_label ?label .
+  ?task ems:Task_status "in-progress" .
   OPTIONAL {
-    ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+    ?task ems:belongs_to_project ?project .
   }
 }
 ORDER BY ?project ?label`,
@@ -98,11 +113,14 @@ ORDER BY ?project ?label`,
     name: "high-effort tasks",
     description: "find tasks with significant effort votes",
     category: "tasks",
-    query: `SELECT ?task ?label ?votes
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?votes
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?task exo:Instance_class "ems__Task" .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_votes ?votes .
   FILTER(?votes > 5)
 }
 ORDER BY DESC(?votes)`,
@@ -113,13 +131,16 @@ ORDER BY DESC(?votes)`,
     name: "tasks without project",
     description: "find orphaned tasks not assigned to projects",
     category: "tasks",
-    query: `SELECT ?task ?label ?status
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_status> ?status . }
+  ?task exo:Instance_class "ems__Task" .
+  ?task exo:Asset_label ?label .
+  OPTIONAL { ?task ems:Task_status ?status . }
   FILTER NOT EXISTS {
-    ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+    ?task ems:belongs_to_project ?project .
   }
 }
 ORDER BY ?label`,
@@ -130,11 +151,14 @@ ORDER BY ?label`,
     name: "tasks by priority",
     description: "list tasks sorted by priority",
     category: "tasks",
-    query: `SELECT ?task ?label ?priority
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?priority
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_priority> ?priority . }
+  ?task exo:Instance_class "ems__Task" .
+  ?task exo:Asset_label ?label .
+  OPTIONAL { ?task ems:Task_priority ?priority . }
 }
 ORDER BY ?priority ?label`,
     useCase: "priority-based task planning",
@@ -144,12 +168,15 @@ ORDER BY ?priority ?label`,
     name: "tasks in project",
     description: "find all tasks belonging to specific project",
     category: "projects",
-    query: `SELECT ?task ?label ?status
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?status
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_status> ?status . }
+  ?task exo:Instance_class "ems__Task" .
+  ?task exo:Asset_label ?label .
+  ?task ems:belongs_to_project ?project .
+  OPTIONAL { ?task ems:Task_status ?status . }
 }
 ORDER BY ?label
 LIMIT 50`,
@@ -160,13 +187,16 @@ LIMIT 50`,
     name: "project hierarchy",
     description: "show projects with their parent areas",
     category: "projects",
-    query: `SELECT ?project ?projectLabel ?area ?areaLabel
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?project ?projectLabel ?area ?areaLabel
 WHERE {
-  ?project <http://exocortex.ai/ontology#Instance_class> "ems__Project" .
-  ?project <http://exocortex.ai/ontology#Asset_label> ?projectLabel .
+  ?project exo:Instance_class "ems__Project" .
+  ?project exo:Asset_label ?projectLabel .
   OPTIONAL {
-    ?project <http://exocortex.ai/ontology#belongs_to_area> ?area .
-    ?area <http://exocortex.ai/ontology#Asset_label> ?areaLabel .
+    ?project ems:belongs_to_area ?area .
+    ?area exo:Asset_label ?areaLabel .
   }
 }
 ORDER BY ?areaLabel ?projectLabel`,
@@ -177,14 +207,17 @@ ORDER BY ?areaLabel ?projectLabel`,
     name: "task relationships",
     description: "visualize task relationships (CONSTRUCT query)",
     category: "relationships",
-    query: `CONSTRUCT {
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?project <http://exocortex.ai/ontology#belongs_to_area> ?area .
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+CONSTRUCT {
+  ?task ems:belongs_to_project ?project .
+  ?project ems:belongs_to_area ?area .
 }
 WHERE {
-  ?task <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?project <http://exocortex.ai/ontology#belongs_to_area> ?area .
+  ?task exo:Instance_class "ems__Task" .
+  ?task ems:belongs_to_project ?project .
+  ?project ems:belongs_to_area ?area .
 }
 LIMIT 100`,
     useCase: "graph visualization of task hierarchy",
@@ -194,11 +227,14 @@ LIMIT 100`,
     name: "recent effort activity",
     description: "find assets with recent effort history",
     category: "time-based",
-    query: `SELECT ?asset ?label ?lastEffort
+    query: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?asset ?label ?lastEffort
 WHERE {
-  ?asset <http://exocortex.ai/ontology#Instance_class> "ems__Task" .
-  ?asset <http://exocortex.ai/ontology#Asset_label> ?label .
-  ?asset <http://exocortex.ai/ontology#Effort_last_entry> ?lastEffort .
+  ?asset exo:Instance_class "ems__Task" .
+  ?asset exo:Asset_label ?label .
+  ?asset ems:Effort_last_entry ?lastEffort .
 }
 ORDER BY DESC(?lastEffort)
 LIMIT 20`,
@@ -209,11 +245,13 @@ LIMIT 20`,
     name: "project completion rate",
     description: "calculate completion percentage per project",
     category: "aggregations",
-    query: `SELECT ?project (COUNT(?task) AS ?totalTasks) (SUM(?isDone) AS ?completedTasks)
+    query: `PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?project (COUNT(?task) AS ?totalTasks) (SUM(?isDone) AS ?completedTasks)
 WHERE {
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
+  ?task ems:belongs_to_project ?project .
   BIND(IF(?status = "done", 1, 0) AS ?isDone)
-  OPTIONAL { ?task <http://exocortex.ai/ontology#Task_status> ?status . }
+  OPTIONAL { ?task ems:Task_status ?status . }
 }
 GROUP BY ?project
 ORDER BY DESC(?completedTasks)`,
@@ -224,10 +262,12 @@ ORDER BY DESC(?completedTasks)`,
     name: "effort distribution",
     description: "sum effort votes by project",
     category: "aggregations",
-    query: `SELECT ?project (SUM(?votes) AS ?totalEffort)
+    query: `PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?project (SUM(?votes) AS ?totalEffort)
 WHERE {
-  ?task <http://exocortex.ai/ontology#belongs_to_project> ?project .
-  ?task <http://exocortex.ai/ontology#Effort_votes> ?votes .
+  ?task ems:belongs_to_project ?project .
+  ?task ems:Effort_votes ?votes .
 }
 GROUP BY ?project
 ORDER BY DESC(?totalEffort)`,


### PR DESCRIPTION
## Summary

Updates all SPARQL query templates and documentation to use correct namespace URIs that match the actual vault ontology definitions (`!exo.md` and `!ems.md` files).

## Changes

### Namespace Corrections
- **Old**: `http://exocortex.ai/ontology#` (wrong domain, wrong protocol)
- **New (EXO)**: `https://exocortex.my/ontology/exo#` (for Asset_label, Instance_class, etc.)
- **New (EMS)**: `https://exocortex.my/ontology/ems#` (for Task_status, Effort_votes, etc.)

### Files Updated
1. **QueryTemplates.ts** - Updated all 15 query templates with:
   - Correct namespace URIs
   - Added PREFIX declarations for readability
2. **docs/sparql/** - Updated 4 documentation files:
   - Query-Examples.md
   - Developer-Guide.md
   - Performance-Tips.md
   - User-Guide.md

## Problem Fixed

User-reported issue: SPARQL queries returning empty results when run in vault.

**Root cause**: Triple namespace mismatch between:
- Code definitions (`Namespace.ts` → `https://exocortex.my/ontology/exo#`)
- Documentation/templates (`http://exocortex.ai/ontology#`)

Query like:
```sparql
SELECT ?asset ?label WHERE {
  ?asset <http://exocortex.my/ontology/exo#Asset_label> ?label .
}
```

Would return empty results because protocol was `http://` instead of `https://`.

## Testing

Documentation-only changes. CI will validate:
- TypeScript compilation
- Linting passes
- All tests pass

Manual verification: queries now return correct results in user's vault.