### PR TITLE
fix: alias sync works with native Obsidian Properties UI

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -94,6 +94,14 @@ export default class ExocortexPlugin extends Plugin {
         }),
       );
 
+      this.registerEvent(
+        this.app.vault.on("modify", (file) => {
+          if (file instanceof TFile) {
+            this.handleMetadataChange(file);
+          }
+        }),
+      );
+
       // AutoLayout: Automatic rendering on file open
       this.registerEvent(
         this.app.workspace.on("file-open", (file) => {

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -79,7 +79,9 @@ describe("ExocortexPlugin", () => {
     };
 
     // Setup mock vault
-    mockVault = {};
+    mockVault = {
+      on: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+    };
 
     // Setup mock app
     mockApp = {
@@ -170,7 +172,7 @@ describe("ExocortexPlugin", () => {
         "sparql",
         expect.any(Function)
       );
-      expect(plugin.registerEvent).toHaveBeenCalledTimes(5);
+      expect(plugin.registerEvent).toHaveBeenCalledTimes(6);
       expect(mockLogger.info).toHaveBeenCalledWith("Exocortex Plugin loaded successfully");
     });
 


### PR DESCRIPTION
## Summary

Fixes issue where alias sync only worked when changing `exo__Asset_label` through the custom Exocortex Properties block in the Layout, but NOT when changing it through Obsidian's native Properties UI.

## Root Cause

The plugin only listened to `metadataCache.on("changed")` event, which doesn't fire reliably when editing properties through Obsidian's native Properties UI.

## Solution

Added `vault.on("modify")` listener to catch ALL file modifications, ensuring alias sync works regardless of which UI the user uses.

## Changes

- Added `vault.on("modify")` listener in `ExocortexPlugin.onload()` (lines 97-104)
- Updated `ExocortexPlugin.test.ts` to expect 6 registerEvent calls (was 5)
- Added `vault.on` mock to mockVault in tests

## Testing

✅ All local tests pass:
- Unit tests: ✅ 812/812 passed
- UI tests: ✅ 2/2 passed  
- Component tests: ✅ 8/8 passed

## User Impact

Users can now change `exo__Asset_label` through:
- ✅ Exocortex Properties block in Layout (existing)
- ✅ **Standard Obsidian Properties block (NEW)**

Both methods now trigger alias sync automatically.