### PR TITLE
fix: only set ems__Effort_area when creating task from ems__Area

### DIFF
--- a/packages/core/src/services/TaskFrontmatterGenerator.ts
+++ b/packages/core/src/services/TaskFrontmatterGenerator.ts
@@ -37,8 +37,7 @@ export class TaskFrontmatterGenerator {
     const isDefinedBy = MetadataExtractor.extractIsDefinedBy(sourceMetadata);
 
     const cleanSourceClass = WikiLinkHelpers.normalize(sourceClass);
-    const effortProperty =
-      EFFORT_PROPERTY_MAP[cleanSourceClass] || "ems__Effort_area";
+    const effortProperty = EFFORT_PROPERTY_MAP[cleanSourceClass];
     const instanceClass =
       INSTANCE_CLASS_MAP[cleanSourceClass] || AssetClass.TASK;
 
@@ -49,7 +48,10 @@ export class TaskFrontmatterGenerator {
     frontmatter["exo__Asset_createdAt"] = timestamp;
     frontmatter["exo__Instance_class"] = [`"[[${instanceClass}]]"`];
     frontmatter["ems__Effort_status"] = '"[[ems__EffortStatusDraft]]"';
-    frontmatter[effortProperty] = `"[[${sourceName}]]"`;
+
+    if (effortProperty) {
+      frontmatter[effortProperty] = `"[[${sourceName}]]"`;
+    }
 
     let finalLabel = label;
     if (

--- a/packages/obsidian-plugin/tests/unit/TaskCreationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/TaskCreationService.test.ts
@@ -421,6 +421,35 @@ describe("TaskCreationService", () => {
       expect(frontmatter.exo__Instance_class).toEqual(['"[[ems__Task]]"']);
       expect(frontmatter.exo__Asset_label).toBeUndefined();
     });
+
+    it("should NOT set ems__Effort_area when creating task from pn__DailyNote", () => {
+      const sourceMetadata = {
+        exo__Asset_isDefinedBy: '"[[!toos]]"',
+        pn__DailyNote_day: "2025-11-12",
+      };
+
+      const frontmatter = service.generateTaskFrontmatter(
+        sourceMetadata,
+        "2025-11-12",
+        "pn__DailyNote",
+        "Morning planning",
+        undefined,
+        null,
+        "1730937600000",
+      );
+
+      expect(frontmatter.exo__Instance_class).toEqual(['"[[ems__Task]]"']);
+      expect(frontmatter.ems__Effort_status).toBe(
+        '"[[ems__EffortStatusDraft]]"',
+      );
+      expect(frontmatter.exo__Asset_label).toBe("Morning planning");
+      expect(frontmatter.ems__Effort_plannedStartTimestamp).toBe(
+        "1730937600000",
+      );
+      expect(frontmatter.ems__Effort_area).toBeUndefined();
+      expect(frontmatter.ems__Effort_parent).toBeUndefined();
+      expect(frontmatter.exo__Asset_prototype).toBeUndefined();
+    });
   });
 
   describe("buildFileContent", () => {


### PR DESCRIPTION
## Problem

When creating a task from `pn__DailyNote`, the system incorrectly adds `ems__Effort_area` property pointing to the date (e.g., `ems__Effort_area: "[[2025-11-12]]"`).

**Root Cause**: `TaskFrontmatterGenerator` had a fallback that set `ems__Effort_area` for ALL unknown source classes:
```typescript
const effortProperty = EFFORT_PROPERTY_MAP[cleanSourceClass] || "ems__Effort_area"; // ❌
frontmatter[effortProperty] = \`"[[${sourceName}]]"\`; // Always set
```

## Solution

1. **Removed fallback**: Changed to `EFFORT_PROPERTY_MAP[cleanSourceClass]` (no `|| "ems__Effort_area"`)
2. **Made conditional**: Only add property if `effortProperty` exists:
   ```typescript
   if (effortProperty) {
     frontmatter[effortProperty] = \`"[[${sourceName}]]"\`;
   }
   ```

## Result

Property mapping now works correctly for all source classes:
- ✅ `ems__Area` → `ems__Effort_area` (Area relationship)
- ✅ `ems__Project` → `ems__Effort_parent` (Parent relationship)
- ✅ `ems__TaskPrototype` → `exo__Asset_prototype` (Prototype relationship)
- ✅ `pn__DailyNote` → no property (FIXED - no longer adds ems__Effort_area)

## Tests

- Added unit test verifying `pn__DailyNote` tasks don't get `ems__Effort_area`
- All 1661 existing tests pass
- Total: 72 tests in TaskCreationService (including new test)

## Files Changed

- `packages/core/src/services/TaskFrontmatterGenerator.ts` (logic fix)
- `packages/obsidian-plugin/tests/unit/TaskCreationService.test.ts` (new test)