### PR TITLE
fix: improve DateTimePropertyField UX (single click + 24h format)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
@@ -61,6 +61,7 @@ export const DateTimePropertyField: React.FC<DateTimePropertyFieldProps> = ({
           day: "numeric",
           hour: "2-digit",
           minute: "2-digit",
+          hour12: false,
         });
       } else {
         return date.toLocaleDateString(undefined, {
@@ -109,7 +110,7 @@ export const DateTimePropertyField: React.FC<DateTimePropertyFieldProps> = ({
   const handleToggle = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    setIsOpen(!isOpen);
+    setIsOpen((prev) => !prev);
   };
 
   const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -134,7 +135,7 @@ export const DateTimePropertyField: React.FC<DateTimePropertyFieldProps> = ({
       <div
         ref={buttonRef}
         className="exocortex-property-datetime-display"
-        onClick={handleToggle}
+        onMouseDown={handleToggle}
         style={{ cursor: "pointer", display: "flex", alignItems: "center" }}
       >
         <svg

--- a/packages/obsidian-plugin/tests/component/properties/DateTimePropertyField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/properties/DateTimePropertyField.spec.tsx
@@ -242,4 +242,24 @@ test.describe("DateTimePropertyField Component", () => {
     const text = await displayText.textContent();
     expect(text).toContain("Nov");
   });
+
+  test("should format time in 24h format (not AM/PM)", async ({ mount }) => {
+    const component = await mount(
+      <DateTimePropertyField
+        value="2024-11-11T15:30:00.000Z"
+        onChange={() => {}}
+      />,
+    );
+
+    const displayText = component.locator("span");
+    const text = await displayText.textContent();
+
+    // Should NOT contain AM/PM indicators
+    expect(text).not.toContain("AM");
+    expect(text).not.toContain("PM");
+    expect(text).not.toContain("am");
+    expect(text).not.toContain("pm");
+    // Should contain time with colon
+    expect(text).toContain(":");
+  });
 });


### PR DESCRIPTION
## Исправления

### 1. Открытие dropdown с первого клика
- **Проблема**: Требовалось 2 клика на иконке календаря для открытия dropdown
- **Причина**: `onClick` срабатывает после `mousedown`, который уже добавил listener для закрытия
- **Решение**: Заменил `onClick` на `onMouseDown` - теперь обработчик срабатывает ДО добавления listener

### 2. Формат времени 24h вместо AM/PM
- **Проблема**: Время отображалось в 12-часовом формате с AM/PM (например, "3:30 PM")
- **Решение**: Добавил `hour12: false` в опции `toLocaleString()` - теперь отображается "15:30"

### 3. Улучшена стабильность React
- Использован functional state update в `handleToggle`: `setIsOpen((prev) => !prev)`

## Тесты

- ✅ Добавлен новый тест для проверки формата 24h (отсутствие AM/PM)
- ✅ Все 370 component тестов прошли успешно

## Связанные issues

Дополняет #396 (первоначальное исправление property fields UX)