### PR TITLE
test: add comprehensive RDF/RDFS mapping tests

### DIFF
--- a/packages/core/tests/performance/RDFMappingPerformance.test.ts
+++ b/packages/core/tests/performance/RDFMappingPerformance.test.ts
@@ -1,0 +1,295 @@
+import { InMemoryTripleStore } from "../../src/infrastructure/rdf/InMemoryTripleStore";
+import { RDFVocabularyMapper } from "../../src/infrastructure/rdf/RDFVocabularyMapper";
+import { Triple } from "../../src/domain/models/rdf/Triple";
+import { IRI } from "../../src/domain/models/rdf/IRI";
+import { Namespace } from "../../src/domain/models/rdf/Namespace";
+
+describe("RDF Mapping Performance", () => {
+  let store: InMemoryTripleStore;
+  let mapper: RDFVocabularyMapper;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    mapper = new RDFVocabularyMapper();
+  });
+
+  describe("Vocabulary Triple Generation Performance", () => {
+    it("should generate class hierarchy triples in <1ms", () => {
+      const iterations = 100;
+      const startTime = performance.now();
+
+      for (let i = 0; i < iterations; i++) {
+        mapper.generateClassHierarchyTriples();
+      }
+
+      const endTime = performance.now();
+      const avgDuration = (endTime - startTime) / iterations;
+
+      expect(avgDuration).toBeLessThan(1); // <1ms average
+    });
+
+    it("should generate property hierarchy triples in <1ms", () => {
+      const iterations = 100;
+      const startTime = performance.now();
+
+      for (let i = 0; i < iterations; i++) {
+        mapper.generatePropertyHierarchyTriples();
+      }
+
+      const endTime = performance.now();
+      const avgDuration = (endTime - startTime) / iterations;
+
+      expect(avgDuration).toBeLessThan(1); // <1ms average
+    });
+  });
+
+  describe("Triple Store Loading Performance", () => {
+    it("should load vocabulary triples in <10ms", async () => {
+      const classTriples = mapper.generateClassHierarchyTriples();
+      const propertyTriples = mapper.generatePropertyHierarchyTriples();
+      const allTriples = [...classTriples, ...propertyTriples];
+
+      const startTime = performance.now();
+
+      for (const triple of allTriples) {
+        await store.add(triple);
+      }
+
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+
+      expect(duration).toBeLessThan(10); // <10ms for 12 triples
+    });
+
+    it("should load 100 asset triples in <50ms", async () => {
+      // Load vocabulary first
+      const classTriples = mapper.generateClassHierarchyTriples();
+      for (const triple of classTriples) {
+        await store.add(triple);
+      }
+
+      // Generate 100 asset triples
+      const assetTriples: Triple[] = [];
+      for (let i = 0; i < 100; i++) {
+        const assetURI = new IRI(
+          `https://exocortex.my/ontology/ems/asset-${i}`,
+        );
+        assetTriples.push(
+          new Triple(assetURI, Namespace.RDF.term("type"), Namespace.EMS.term("Task")),
+        );
+      }
+
+      const startTime = performance.now();
+
+      for (const triple of assetTriples) {
+        await store.add(triple);
+      }
+
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+
+      expect(duration).toBeLessThan(50); // <50ms for 100 triples (<0.5ms per triple)
+    });
+
+    it("should load 1000 asset triples in <500ms", async () => {
+      // Generate 1000 asset triples
+      const assetTriples: Triple[] = [];
+      for (let i = 0; i < 1000; i++) {
+        const assetURI = new IRI(
+          `https://exocortex.my/ontology/ems/asset-${i}`,
+        );
+        assetTriples.push(
+          new Triple(assetURI, Namespace.RDF.term("type"), Namespace.EMS.term("Task")),
+        );
+      }
+
+      const startTime = performance.now();
+
+      for (const triple of assetTriples) {
+        await store.add(triple);
+      }
+
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+
+      expect(duration).toBeLessThan(500); // <500ms for 1000 triples (<0.5ms per triple)
+    });
+  });
+
+  describe("Query Performance with RDF/RDFS Predicates", () => {
+    beforeEach(async () => {
+      // Load vocabulary
+      const classTriples = mapper.generateClassHierarchyTriples();
+      const propertyTriples = mapper.generatePropertyHierarchyTriples();
+      for (const triple of [...classTriples, ...propertyTriples]) {
+        await store.add(triple);
+      }
+
+      // Load 100 mock assets
+      for (let i = 0; i < 100; i++) {
+        const assetURI = new IRI(
+          `https://exocortex.my/ontology/ems/asset-${i}`,
+        );
+        await store.add(
+          new Triple(assetURI, Namespace.RDF.term("type"), Namespace.EMS.term("Task")),
+        );
+      }
+    });
+
+    it("should query using rdf:type in <10ms", async () => {
+      const startTime = performance.now();
+
+      const results = await store.match(
+        undefined,
+        Namespace.RDF.term("type"),
+        Namespace.EMS.term("Task"),
+      );
+
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+
+      expect(results.length).toBe(100);
+      expect(duration).toBeLessThan(10); // <10ms for query
+    });
+
+    it("should query class hierarchy using rdfs:subClassOf in <5ms", async () => {
+      const startTime = performance.now();
+
+      const results = await store.match(
+        undefined,
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      );
+
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+
+      expect(results.length).toBeGreaterThanOrEqual(3); // Task, Project, Area
+      expect(duration).toBeLessThan(5); // <5ms for hierarchy query
+    });
+
+    it("should query property hierarchy using rdfs:subPropertyOf in <5ms", async () => {
+      const startTime = performance.now();
+
+      const results = await store.match(
+        undefined,
+        Namespace.RDFS.term("subPropertyOf"),
+        undefined,
+      );
+
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+
+      expect(results.length).toBeGreaterThanOrEqual(6); // 6 property mappings
+      expect(duration).toBeLessThan(5); // <5ms for property hierarchy query
+    });
+  });
+
+  describe("Mapped Triple Generation Performance", () => {
+    it("should generate mapped triples in <0.1ms per triple", () => {
+      const assetURI = new IRI(
+        "https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440000",
+      );
+
+      const iterations = 1000;
+      const startTime = performance.now();
+
+      for (let i = 0; i < iterations; i++) {
+        mapper.generateMappedTriple(
+          assetURI,
+          "exo__Instance_class",
+          "ems__Task",
+        );
+      }
+
+      const endTime = performance.now();
+      const avgDuration = (endTime - startTime) / iterations;
+
+      expect(avgDuration).toBeLessThan(0.1); // <0.1ms per triple generation
+    });
+
+    it("should check mapping existence in <0.01ms", () => {
+      const iterations = 10000;
+      const startTime = performance.now();
+
+      for (let i = 0; i < iterations; i++) {
+        mapper.hasMappingFor("exo__Instance_class");
+        mapper.hasMappingFor("ems__Task_size"); // No mapping
+      }
+
+      const endTime = performance.now();
+      const avgDuration = (endTime - startTime) / iterations / 2; // 2 calls per iteration
+
+      expect(avgDuration).toBeLessThan(0.01); // <0.01ms per check
+    });
+  });
+
+  describe("Memory Usage (Conceptual)", () => {
+    it("should not significantly increase memory with RDF/RDFS triples", async () => {
+      // Baseline: store 100 assets with ExoRDF predicates only
+      const baselineAssets = 100;
+      for (let i = 0; i < baselineAssets; i++) {
+        const assetURI = new IRI(
+          `https://exocortex.my/ontology/ems/baseline-${i}`,
+        );
+        await store.add(
+          new Triple(
+            assetURI,
+            Namespace.EXO.term("Instance_class"),
+            Namespace.EMS.term("Task"),
+          ),
+        );
+      }
+
+      const baselineSize = (await store.match(undefined, undefined, undefined))
+        .length;
+
+      // Add RDF/RDFS mapped triples for same assets
+      for (let i = 0; i < baselineAssets; i++) {
+        const assetURI = new IRI(
+          `https://exocortex.my/ontology/ems/baseline-${i}`,
+        );
+        await store.add(
+          new Triple(assetURI, Namespace.RDF.term("type"), Namespace.EMS.term("Task")),
+        );
+      }
+
+      const withMappingSize = (await store.match(undefined, undefined, undefined))
+        .length;
+
+      // Memory increase should be exactly 100 triples (100% increase, but that's expected for dual representation)
+      expect(withMappingSize).toBe(baselineSize + 100);
+      expect(withMappingSize / baselineSize).toBeLessThanOrEqual(2.5); // <2.5x increase
+    });
+  });
+
+  describe("Deduplication Performance", () => {
+    it("should deduplicate triples efficiently", async () => {
+      const triple = new Triple(
+        Namespace.EMS.term("Task"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      );
+
+      // Add same triple 1000 times
+      const startTime = performance.now();
+
+      for (let i = 0; i < 1000; i++) {
+        await store.add(triple);
+      }
+
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+
+      // Should deduplicate and store only once
+      const results = await store.match(
+        Namespace.EMS.term("Task"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      );
+
+      expect(results.length).toBe(1);
+      expect(duration).toBeLessThan(100); // <100ms for 1000 deduplication checks
+    });
+  });
+});

--- a/packages/core/tests/unit/infrastructure/rdf/InMemoryTripleStore.rdf-mapping.test.ts
+++ b/packages/core/tests/unit/infrastructure/rdf/InMemoryTripleStore.rdf-mapping.test.ts
@@ -1,0 +1,437 @@
+import { InMemoryTripleStore } from "../../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { RDFVocabularyMapper } from "../../../../src/infrastructure/rdf/RDFVocabularyMapper";
+import { Triple } from "../../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../../src/domain/models/rdf/IRI";
+import { Namespace } from "../../../../src/domain/models/rdf/Namespace";
+
+describe("InMemoryTripleStore RDF/RDFS Mapping Integration", () => {
+  let store: InMemoryTripleStore;
+  let mapper: RDFVocabularyMapper;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    mapper = new RDFVocabularyMapper();
+  });
+
+  describe("Vocabulary Triple Generation", () => {
+    it("should store class hierarchy triples", async () => {
+      const triples = mapper.generateClassHierarchyTriples();
+
+      for (const triple of triples) {
+        await store.add(triple);
+      }
+
+      // Verify ems:Task rdfs:subClassOf exo:Asset
+      const taskSubclassTriples = await store.match(
+        Namespace.EMS.term("Task"),
+        Namespace.RDFS.term("subClassOf"),
+        undefined,
+      );
+
+      expect(taskSubclassTriples.length).toBeGreaterThan(0);
+      expect((taskSubclassTriples[0].object as IRI).value).toContain("Asset");
+    });
+
+    it("should store property hierarchy triples", async () => {
+      const triples = mapper.generatePropertyHierarchyTriples();
+
+      for (const triple of triples) {
+        await store.add(triple);
+      }
+
+      // Verify exo:Instance_class rdfs:subPropertyOf rdf:type
+      const instanceClassTriples = await store.match(
+        Namespace.EXO.term("Instance_class"),
+        Namespace.RDFS.term("subPropertyOf"),
+        undefined,
+      );
+
+      expect(instanceClassTriples.length).toBeGreaterThan(0);
+      expect((instanceClassTriples[0].object as IRI).value).toBe(
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+      );
+    });
+
+    it("should store all 6 class hierarchy mappings", async () => {
+      const triples = mapper.generateClassHierarchyTriples();
+
+      for (const triple of triples) {
+        await store.add(triple);
+      }
+
+      // Verify all mappings are stored
+      const allClassTriples = await store.match(
+        undefined,
+        Namespace.RDFS.term("subClassOf"),
+        undefined,
+      );
+
+      expect(allClassTriples.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it("should store all 6 property hierarchy mappings", async () => {
+      const triples = mapper.generatePropertyHierarchyTriples();
+
+      for (const triple of triples) {
+        await store.add(triple);
+      }
+
+      // Verify all mappings are stored
+      const allPropertyTriples = await store.match(
+        undefined,
+        Namespace.RDFS.term("subPropertyOf"),
+        undefined,
+      );
+
+      expect(allPropertyTriples.length).toBeGreaterThanOrEqual(6);
+    });
+  });
+
+  describe("Asset Triple Generation with RDF Predicates", () => {
+    beforeEach(async () => {
+      // Load vocabulary triples first
+      const classTriples = mapper.generateClassHierarchyTriples();
+      const propertyTriples = mapper.generatePropertyHierarchyTriples();
+
+      for (const triple of [...classTriples, ...propertyTriples]) {
+        await store.add(triple);
+      }
+    });
+
+    it("should generate rdf:type triple for exo__Instance_class", async () => {
+      const assetURI = new IRI(
+        "https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440000",
+      );
+
+      // Generate mapped triple using RDFVocabularyMapper
+      const mappedTriple = mapper.generateMappedTriple(
+        assetURI,
+        "exo__Instance_class",
+        "ems__Task",
+      );
+
+      expect(mappedTriple).not.toBeNull();
+
+      await store.add(mappedTriple!);
+
+      // Verify rdf:type triple is stored
+      const typeTriples = await store.match(
+        assetURI,
+        Namespace.RDF.term("type"),
+        undefined,
+      );
+
+      expect(typeTriples.length).toBe(1);
+      expect((typeTriples[0].object as IRI).value).toContain("Task");
+    });
+
+    it("should generate rdfs:isDefinedBy triple for exo__Asset_isDefinedBy", async () => {
+      const assetURI = new IRI(
+        "https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440000",
+      );
+      const ontologyURI = new IRI("https://exocortex.my/ontology/ems/");
+
+      const mappedTriple = mapper.generateMappedTriple(
+        assetURI,
+        "exo__Asset_isDefinedBy",
+        ontologyURI,
+      );
+
+      expect(mappedTriple).not.toBeNull();
+
+      await store.add(mappedTriple!);
+
+      // Verify rdfs:isDefinedBy triple is stored
+      const isDefinedByTriples = await store.match(
+        assetURI,
+        Namespace.RDFS.term("isDefinedBy"),
+        undefined,
+      );
+
+      expect(isDefinedByTriples.length).toBe(1);
+      expect((isDefinedByTriples[0].object as IRI).value).toBe(
+        "https://exocortex.my/ontology/ems/",
+      );
+    });
+
+    it("should not generate triple for unmapped ExoRDF property", async () => {
+      const assetURI = new IRI(
+        "https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440000",
+      );
+
+      // ems__Task_size has no RDF/RDFS mapping
+      const mappedTriple = mapper.generateMappedTriple(
+        assetURI,
+        "ems__Task_size",
+        "M",
+      );
+
+      expect(mappedTriple).toBeNull();
+    });
+  });
+
+  describe("RDF/RDFS Query Patterns", () => {
+    beforeEach(async () => {
+      // Load vocabulary triples
+      const classTriples = mapper.generateClassHierarchyTriples();
+      const propertyTriples = mapper.generatePropertyHierarchyTriples();
+
+      for (const triple of [...classTriples, ...propertyTriples]) {
+        await store.add(triple);
+      }
+
+      // Add mock asset triples
+      const task1URI = new IRI(
+        "https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440000",
+      );
+      const task2URI = new IRI(
+        "https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440001",
+      );
+      const projectURI = new IRI(
+        "https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440002",
+      );
+
+      await store.add(
+        new Triple(task1URI, Namespace.RDF.term("type"), Namespace.EMS.term("Task")),
+      );
+      await store.add(
+        new Triple(task2URI, Namespace.RDF.term("type"), Namespace.EMS.term("Task")),
+      );
+      await store.add(
+        new Triple(
+          projectURI,
+          Namespace.RDF.term("type"),
+          Namespace.EMS.term("Project"),
+        ),
+      );
+    });
+
+    it("should query all assets of type ems:Task using rdf:type", async () => {
+      const taskTriples = await store.match(
+        undefined,
+        Namespace.RDF.term("type"),
+        Namespace.EMS.term("Task"),
+      );
+
+      expect(taskTriples.length).toBe(2);
+    });
+
+    it("should query all assets of type ems:Project using rdf:type", async () => {
+      const projectTriples = await store.match(
+        undefined,
+        Namespace.RDF.term("type"),
+        Namespace.EMS.term("Project"),
+      );
+
+      expect(projectTriples.length).toBe(1);
+    });
+
+    it("should query class hierarchy using rdfs:subClassOf", async () => {
+      // Query: What are the subclasses of exo:Asset?
+      const subclassTriples = await store.match(
+        undefined,
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      );
+
+      expect(subclassTriples.length).toBeGreaterThanOrEqual(3); // Task, Project, Area
+      const subclassNames = subclassTriples.map((t) => (t.subject as IRI).value);
+      expect(subclassNames.some((name) => name.includes("Task"))).toBe(true);
+      expect(subclassNames.some((name) => name.includes("Project"))).toBe(true);
+      expect(subclassNames.some((name) => name.includes("Area"))).toBe(true);
+    });
+
+    it("should query property hierarchy using rdfs:subPropertyOf", async () => {
+      // Query: What properties are sub-properties of rdfs:isDefinedBy?
+      const subpropertyTriples = await store.match(
+        undefined,
+        Namespace.RDFS.term("subPropertyOf"),
+        Namespace.RDFS.term("isDefinedBy"),
+      );
+
+      expect(subpropertyTriples.length).toBeGreaterThanOrEqual(1);
+      expect((subpropertyTriples[0].subject as IRI).value).toContain("Asset_isDefinedBy");
+    });
+  });
+
+  describe("Transitive Closure (Conceptual Tests)", () => {
+    beforeEach(async () => {
+      const classTriples = mapper.generateClassHierarchyTriples();
+
+      for (const triple of classTriples) {
+        await store.add(triple);
+      }
+    });
+
+    it("should retrieve all ancestors of ems:Task", async () => {
+      // ems:Task -> exo:Asset -> rdfs:Resource
+      // We can traverse this manually (transitive inference would be in SPARQL engine)
+
+      // Step 1: Get direct superclass of ems:Task
+      const taskSuperclass = await store.match(
+        Namespace.EMS.term("Task"),
+        Namespace.RDFS.term("subClassOf"),
+        undefined,
+      );
+
+      expect(taskSuperclass.length).toBe(1);
+      expect((taskSuperclass[0].object as IRI).value).toContain("Asset");
+
+      // Step 2: Get superclass of exo:Asset
+      const assetSuperclass = await store.match(
+        Namespace.EXO.term("Asset"),
+        Namespace.RDFS.term("subClassOf"),
+        undefined,
+      );
+
+      expect(assetSuperclass.length).toBe(1);
+      expect((assetSuperclass[0].object as IRI).value).toBe(
+        "http://www.w3.org/2000/01/rdf-schema#Resource",
+      );
+    });
+
+    it("should handle circular hierarchy gracefully", async () => {
+      // Test circular reference detection
+      // exo:Asset already has rdfs:Resource as superclass
+      // Attempting to add rdfs:Resource -> exo:Asset would create cycle
+
+      const circularTriple = new Triple(
+        Namespace.RDFS.term("Resource"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      );
+
+      await store.add(circularTriple);
+
+      // Triple is stored (no validation in store layer)
+      const hasCircular = await store.has(circularTriple);
+      expect(hasCircular).toBe(true);
+
+      // Note: Cycle detection should be in SPARQL engine, not triple store
+    });
+  });
+
+  describe("Backward Compatibility", () => {
+    beforeEach(async () => {
+      // Load vocabulary triples
+      const classTriples = mapper.generateClassHierarchyTriples();
+      const propertyTriples = mapper.generatePropertyHierarchyTriples();
+
+      for (const triple of [...classTriples, ...propertyTriples]) {
+        await store.add(triple);
+      }
+
+      // Add both ExoRDF and RDF/RDFS triples for same asset
+      const assetURI = new IRI(
+        "https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440000",
+      );
+
+      // ExoRDF triple
+      await store.add(
+        new Triple(
+          assetURI,
+          Namespace.EXO.term("Instance_class"),
+          Namespace.EMS.term("Task"),
+        ),
+      );
+
+      // RDF/RDFS mapped triple
+      await store.add(
+        new Triple(assetURI, Namespace.RDF.term("type"), Namespace.EMS.term("Task")),
+      );
+    });
+
+    it("should query using ExoRDF predicate (exo:Instance_class)", async () => {
+      const exoTriples = await store.match(
+        undefined,
+        Namespace.EXO.term("Instance_class"),
+        undefined,
+      );
+
+      expect(exoTriples.length).toBe(1);
+    });
+
+    it("should query using RDF/RDFS predicate (rdf:type)", async () => {
+      const rdfTriples = await store.match(
+        undefined,
+        Namespace.RDF.term("type"),
+        undefined,
+      );
+
+      expect(rdfTriples.length).toBe(1);
+    });
+
+    it("should support both query styles simultaneously", async () => {
+      const assetURI = new IRI(
+        "https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440000",
+      );
+
+      // Query with ExoRDF predicate
+      const exoTriples = await store.match(
+        assetURI,
+        Namespace.EXO.term("Instance_class"),
+        undefined,
+      );
+      expect(exoTriples.length).toBe(1);
+
+      // Query with RDF/RDFS predicate
+      const rdfTriples = await store.match(
+        assetURI,
+        Namespace.RDF.term("type"),
+        undefined,
+      );
+      expect(rdfTriples.length).toBe(1);
+
+      // Both should return same object value
+      expect((exoTriples[0].object as IRI).value).toBe((rdfTriples[0].object as IRI).value);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle empty vocabulary gracefully", async () => {
+      // Query with no vocabulary triples loaded
+      const triples = await store.match(
+        undefined,
+        Namespace.RDFS.term("subClassOf"),
+        undefined,
+      );
+
+      expect(triples.length).toBe(0);
+    });
+
+    it("should handle large vocabulary efficiently", async () => {
+      const startTime = performance.now();
+
+      // Generate and store 100 class hierarchy triples
+      for (let i = 0; i < 100; i++) {
+        const triple = new Triple(
+          new IRI(`https://exocortex.my/ontology/class${i}`),
+          Namespace.RDFS.term("subClassOf"),
+          Namespace.EXO.term("Asset"),
+        );
+        await store.add(triple);
+      }
+
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+
+      // Should complete in <50ms for 100 triples
+      expect(duration).toBeLessThan(50);
+    });
+
+    it("should deduplicate identical vocabulary triples", async () => {
+      const triple = mapper.generateClassHierarchyTriples()[0];
+
+      await store.add(triple);
+      await store.add(triple); // Add same triple twice
+
+      const allTriples = await store.match(
+        triple.subject,
+        triple.predicate,
+        triple.object,
+      );
+
+      expect(allTriples.length).toBe(1); // Deduplicated
+    });
+  });
+});

--- a/packages/core/tests/unit/infrastructure/rdf/RDFVocabularyMapper.test.ts
+++ b/packages/core/tests/unit/infrastructure/rdf/RDFVocabularyMapper.test.ts
@@ -17,13 +17,13 @@ describe("RDFVocabularyMapper", () => {
 
       const taskSubclassTriple = triples.find(
         (t) =>
-          t.subject.value.includes("Task") &&
-          t.predicate.value ===
+          (t.subject as IRI).value.includes("Task") &&
+          (t.predicate as IRI).value ===
             "http://www.w3.org/2000/01/rdf-schema#subClassOf",
       );
 
       expect(taskSubclassTriple).toBeDefined();
-      expect(taskSubclassTriple!.object.value).toContain("Asset");
+      expect((taskSubclassTriple!.object as IRI).value).toContain("Asset");
     });
 
     it("should generate triples for all ExoRDF classes", () => {
@@ -33,7 +33,7 @@ describe("RDFVocabularyMapper", () => {
 
       for (const className of classNames) {
         const classTriple = triples.find((t) =>
-          t.subject.value.includes(className),
+          (t.subject as IRI).value.includes(className),
         );
         expect(classTriple).toBeDefined();
       }
@@ -44,8 +44,8 @@ describe("RDFVocabularyMapper", () => {
 
       const assetTriple = triples.find(
         (t) =>
-          t.subject.value.includes("Asset") &&
-          t.object.value ===
+          (t.subject as IRI).value.includes("Asset") &&
+          (t.object as IRI).value ===
             "http://www.w3.org/2000/01/rdf-schema#Resource",
       );
 
@@ -57,8 +57,8 @@ describe("RDFVocabularyMapper", () => {
 
       const classTriple = triples.find(
         (t) =>
-          t.subject.value.includes("/Class") &&
-          t.object.value === "http://www.w3.org/2000/01/rdf-schema#Class",
+          (t.subject as IRI).value.includes("#Class") &&
+          (t.object as IRI).value === "http://www.w3.org/2000/01/rdf-schema#Class",
       );
 
       expect(classTriple).toBeDefined();
@@ -69,8 +69,8 @@ describe("RDFVocabularyMapper", () => {
 
       const propertyTriple = triples.find(
         (t) =>
-          t.subject.value.includes("/Property") &&
-          t.object.value ===
+          (t.subject as IRI).value.includes("#Property") &&
+          (t.object as IRI).value ===
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
       );
 
@@ -90,8 +90,8 @@ describe("RDFVocabularyMapper", () => {
 
       const instanceClassTriple = triples.find(
         (t) =>
-          t.subject.value.includes("Instance_class") &&
-          t.object.value === "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+          (t.subject as IRI).value.includes("Instance_class") &&
+          (t.object as IRI).value === "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
       );
 
       expect(instanceClassTriple).toBeDefined();
@@ -102,8 +102,8 @@ describe("RDFVocabularyMapper", () => {
 
       const isDefinedByTriple = triples.find(
         (t) =>
-          t.subject.value.includes("Asset_isDefinedBy") &&
-          t.object.value ===
+          (t.subject as IRI).value.includes("Asset_isDefinedBy") &&
+          (t.object as IRI).value ===
             "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
       );
 
@@ -115,8 +115,8 @@ describe("RDFVocabularyMapper", () => {
 
       const superClassTriple = triples.find(
         (t) =>
-          t.subject.value.includes("Class_superClass") &&
-          t.object.value ===
+          (t.subject as IRI).value.includes("Class_superClass") &&
+          (t.object as IRI).value ===
             "http://www.w3.org/2000/01/rdf-schema#subClassOf",
       );
 
@@ -128,8 +128,8 @@ describe("RDFVocabularyMapper", () => {
 
       const rangeTriple = triples.find(
         (t) =>
-          t.subject.value.includes("Property_range") &&
-          t.object.value === "http://www.w3.org/2000/01/rdf-schema#range",
+          (t.subject as IRI).value.includes("Property_range") &&
+          (t.object as IRI).value === "http://www.w3.org/2000/01/rdf-schema#range",
       );
 
       expect(rangeTriple).toBeDefined();
@@ -140,8 +140,8 @@ describe("RDFVocabularyMapper", () => {
 
       const domainTriple = triples.find(
         (t) =>
-          t.subject.value.includes("Property_domain") &&
-          t.object.value === "http://www.w3.org/2000/01/rdf-schema#domain",
+          (t.subject as IRI).value.includes("Property_domain") &&
+          (t.object as IRI).value === "http://www.w3.org/2000/01/rdf-schema#domain",
       );
 
       expect(domainTriple).toBeDefined();
@@ -152,8 +152,8 @@ describe("RDFVocabularyMapper", () => {
 
       const superPropertyTriple = triples.find(
         (t) =>
-          t.subject.value.includes("Property_superProperty") &&
-          t.object.value ===
+          (t.subject as IRI).value.includes("Property_superProperty") &&
+          (t.object as IRI).value ===
             "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
       );
 
@@ -174,10 +174,10 @@ describe("RDFVocabularyMapper", () => {
       );
 
       expect(triple).toBeDefined();
-      expect(triple!.predicate.value).toBe(
+      expect((triple!.predicate as IRI).value).toBe(
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
       );
-      expect(triple!.object.value).toContain("Task");
+      expect((triple!.object as IRI).value).toContain("Task");
     });
 
     it("should generate rdfs:isDefinedBy triple for exo__Asset_isDefinedBy", () => {
@@ -224,7 +224,7 @@ describe("RDFVocabularyMapper", () => {
 
       expect(triple).toBeDefined();
       expect(triple!.object).toBeInstanceOf(IRI);
-      expect(triple!.object.value).toContain("Project");
+      expect((triple!.object as IRI).value).toContain("Project");
     });
 
     it("should handle IRI values directly", () => {
@@ -241,7 +241,7 @@ describe("RDFVocabularyMapper", () => {
 
       expect(triple).toBeDefined();
       expect(triple!.object).toBeInstanceOf(IRI);
-      expect(triple!.object.value).toBe(valueIRI.value);
+      expect((triple!.object as IRI).value).toBe(valueIRI.value);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for ExoRDF to RDF/RDFS mapping functionality implemented in PR #406 (Task #367).

## Changes

### New Test Files

1. **InMemoryTripleStore.rdf-mapping.test.ts** (19 tests)
   - Vocabulary triple generation and storage
   - Asset triple generation with RDF predicates
   - RDF/RDFS query patterns (rdf:type, rdfs:subClassOf, rdfs:subPropertyOf)
   - Transitive closure and circular hierarchy handling
   - Backward compatibility (ExoRDF + RDF/RDFS coexistence)
   - Edge cases (empty vocabulary, large datasets, deduplication)

2. **RDFMappingPerformance.test.ts** (12 tests)
   - Vocabulary generation: <1ms average ✅
   - Triple store loading: <0.5ms per triple ✅
   - Query performance: <10ms for type queries, <5ms for hierarchy ✅
   - Mapped triple generation: <0.1ms per triple ✅
   - Memory usage: <2.5x increase ✅
   - Deduplication efficiency ✅

### Bug Fixes

3. **RDFVocabularyMapper.test.ts** (from Task #367)
   - Fixed TypeScript errors: Property 'value' does not exist on type 'Object'
   - Added IRI casting for union type properties
   - Fixed hash-style URI matching (`#Class` not `/Class`)

## Test Summary

- **Total RDF Mapping Tests:** 50 passing
  - RDFVocabularyMapper: 19 tests (fixed)
  - InMemoryTripleStore RDF Integration: 19 tests (new)
  - RDF Mapping Performance: 12 tests (new)

## Definition of Done

- [x] Unit tests for InMemoryTripleStore RDF/RDFS integration (>80% coverage)
- [x] Performance tests for triple generation overhead
- [x] Edge case tests (circular hierarchies, large datasets, deduplication)
- [x] Backward compatibility tests (existing SPARQL queries still work)
- [x] All tests pass

## Future Work (Not in Scope)

- SPARQL query tests using RDF/RDFS predicates (will be in separate task)
- E2E tests demonstrating semantic queries (will be in separate task)

Closes #368