### PR TITLE
fix: prevent alias creation for archived assets in Rename to UID

### DIFF
--- a/docs/Command-Reference.md
+++ b/docs/Command-Reference.md
@@ -443,6 +443,12 @@ aliases:
 
 **Use case**: Standardize filenames for consistency.
 
+**Behavior**:
+- Renames file: `old-name.md` → `{exo__Asset_uid}.md`
+- Updates `exo__Asset_label` if missing (uses old filename)
+- For **non-archived assets**: Adds old filename to `aliases` for searchability
+- For **archived assets** (`exo__Asset_isArchived: true` or `archived: true`): Does NOT add aliases (reduces namespace clutter)
+
 **Visibility**: Available on notes with UID property.
 
 ---

--- a/packages/core/tests/services/RenameToUidService.test.ts
+++ b/packages/core/tests/services/RenameToUidService.test.ts
@@ -199,6 +199,211 @@ describe("RenameToUidService", () => {
     });
   });
 
+  describe("archived asset handling", () => {
+    it("should NOT add alias for archived asset (exo__Asset_isArchived: true)", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        exo__Asset_isArchived: true,
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).toContain("exo__Asset_label: old-name");
+        expect(result).not.toContain("aliases:");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+      expect(mockVault.rename).toHaveBeenCalled();
+    });
+
+    it("should NOT add alias for archived asset (archived: true)", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        archived: true,
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).toContain("exo__Asset_label: old-name");
+        expect(result).not.toContain("aliases:");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+    });
+
+    it("should support multi-format archived values (string 'true')", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        exo__Asset_isArchived: "true",
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).not.toContain("aliases:");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+    });
+
+    it("should support multi-format archived values (string 'yes')", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        archived: "yes",
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).not.toContain("aliases:");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+    });
+
+    it("should support multi-format archived values (number 1)", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        exo__Asset_isArchived: 1,
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).not.toContain("aliases:");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+    });
+
+    it("should NOT add alias when both archived properties are true", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        exo__Asset_isArchived: true,
+        archived: true,
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).toContain("exo__Asset_label: old-name");
+        expect(result).not.toContain("aliases:");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+    });
+
+    it("SHOULD add alias for non-archived asset (backward compatibility)", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        exo__Asset_isArchived: false,
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).toContain("exo__Asset_label: old-name");
+        expect(result).toContain("aliases:");
+        expect(result).toContain("- old-name");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+    });
+
+    it("SHOULD add alias when no archived property (backward compatibility)", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).toContain("exo__Asset_label: old-name");
+        expect(result).toContain("aliases:");
+        expect(result).toContain("- old-name");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+    });
+
+    it("SHOULD add alias when archived: false (backward compatibility)", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        archived: false,
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).toContain("exo__Asset_label: old-name");
+        expect(result).toContain("aliases:");
+        expect(result).toContain("- old-name");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+    });
+
+    it("SHOULD add alias when archived: null (backward compatibility)", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        archived: null,
+      };
+
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\ntitle: Test\n---\nContent";
+        const result = fn(content);
+        expect(result).toContain("aliases:");
+        return result;
+      });
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).toHaveBeenCalled();
+    });
+
+    it("should handle archived asset with existing label (no frontmatter modification)", async () => {
+      const metadata = {
+        exo__Asset_uid: "asset-123",
+        exo__Asset_label: "Existing Label",
+        exo__Asset_isArchived: true,
+      };
+
+      await service.renameToUid(mockFile, metadata);
+
+      expect(mockVault.process).not.toHaveBeenCalled();
+      expect(mockVault.rename).toHaveBeenCalledWith(mockFile, "/folder/asset-123.md");
+    });
+  });
+
   describe("updateLinks integration", () => {
     it("should call updateLinks before rename", async () => {
       const metadata = {


### PR DESCRIPTION
## Summary

Fixes #410

Prevents the "Rename to UID" command from adding old filenames to the `aliases` property for archived assets, reducing namespace clutter while preserving the behavior for active assets.

## Changes

- Added `isAssetArchived()` helper method with multi-format support (boolean, number, string)
- Updated `updateLabel()` to conditionally add aliases based on archived status
- Added 11 comprehensive unit tests covering all scenarios
- Updated `docs/Command-Reference.md` with new behavior documentation

## Behavior

**For non-archived assets** (existing behavior preserved):
- File renamed to UID
- `exo__Asset_label` updated if missing
- Old filename added to `aliases` array

**For archived assets** (new behavior):
- File renamed to UID
- `exo__Asset_label` updated if missing
- **NO** `aliases` added

## Test Coverage

- ✅ 6 tests for archived scenarios (no aliases added)
- ✅ 5 tests for non-archived scenarios (backward compatibility)
- ✅ Multi-format archive detection (true, 1, "true", "yes")
- ✅ Dual property support (`exo__Asset_isArchived` and `archived`)

## Documentation

- Updated `docs/Command-Reference.md` with detailed behavior explanation

## Build & Tests

- ✅ All unit tests pass
- ✅ Build successful
- ✅ Lint clean (2 pre-existing warnings unrelated to changes)