### PR TITLE
refactor: integrate ApplicationErrorHandler in services (Phase 3B)

### DIFF
--- a/packages/obsidian-plugin/tests/unit/services/PropertyUpdateService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/services/PropertyUpdateService.test.ts
@@ -118,14 +118,15 @@ describe("PropertyUpdateService", () => {
       expect(frontmatter.testKey).toBe("newValue");
     });
 
-    it("should handle processFrontMatter errors", async () => {
-      mockProcessFrontMatter.mockRejectedValueOnce(
+    it("should handle processFrontMatter errors after retries", async () => {
+      // Mock must fail on all retry attempts (default maxRetries = 3, so 4 total attempts)
+      mockProcessFrontMatter.mockRejectedValue(
         new Error("File processing failed"),
       );
 
       await expect(
         service.updateProperty(mockFile, "testKey", "testValue"),
-      ).rejects.toThrow("File processing failed");
+      ).rejects.toThrow("Failed to update property");
     });
   });
 


### PR DESCRIPTION
Refactors PropertyUpdateService, AliasSyncService, PropertyValidationService, and TaskTrackingService to use ApplicationErrorHandler for consistent error handling, retry logic, and telemetry.

Part of Issue #438 Phase 3B: Service Error Handler Integration

## Changes

### PropertyUpdateService
- Added ApplicationErrorHandler with retry logic
- Wrapped file operations in `executeWithRetry()` with NetworkError
- Transient file I/O errors now automatically retry with exponential backoff

### AliasSyncService
- Added error handling (previously had **none**)
- Added retry logic for file operations with NetworkError
- Optional logger/notifier parameters for better observability

### PropertyValidationService
- Replaced `console.error` with ApplicationErrorHandler
- Used ValidationError for validation failures
- Preserved fail-open behavior (returns `isValid: true` on errors)

### TaskTrackingService
- Added retry logic for file operations (addTaskIdToFrontmatter)
- Consistent ServiceError handling for event handlers
- Improved error context for debugging

## Benefits

- ✅ **Automatic retry** with exponential backoff for transient failures
- ✅ **Consistent error formatting** and user notifications
- ✅ **Telemetry hooks** for error monitoring and metrics
- ✅ **Structured error context** for debugging
- ✅ **Backward compatible** - optional logger/notifier parameters

## Testing

- Updated PropertyUpdateService test to match retry behavior
- All tests passing (1785 total: 1775 unit + 10 component)
- E2E tests will run in CI (Docker not running locally)

## Related

- Phase 3A: PR #453 (ApplicationErrorHandler implementation) - merged as v13.70.0
- Phase 2: PRs #451, #452 (ErrorBoundary, SPARQLQueryService refactor) - merged as v13.69.0, v13.69.1