### PR TITLE
feat: implement centralized state management with Zustand (#437)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4401,7 +4401,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -6033,7 +6033,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3": {
@@ -14618,6 +14618,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
     "packages/cli": {
       "name": "exocortex-cli",
       "version": "0.1.0",
@@ -14718,7 +14747,8 @@
         "react-dom": "^19.2.0",
         "reflect-metadata": "^0.2.2",
         "tsyringe": "^4.10.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@playwright/experimental-ct-react": "^1.55.1",

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^19.2.0",
     "reflect-metadata": "^0.2.2",
     "tsyringe": "^4.10.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@playwright/experimental-ct-react": "^1.55.1",

--- a/packages/obsidian-plugin/src/presentation/components/DailyProjectsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyProjectsTable.tsx
@@ -1,9 +1,5 @@
-import React, { useState, useMemo } from "react";
-
-interface SortState {
-  column: string;
-  order: "asc" | "desc";
-}
+import React, { useMemo } from "react";
+import { useTableSortStore, useUIStore } from "../stores";
 
 export interface DailyProject {
   file: {
@@ -36,19 +32,22 @@ export const DailyProjectsTable: React.FC<DailyProjectsTableProps> = ({
   projects,
   onProjectClick,
   getAssetLabel,
-  showArchived = false,
-  showFullDateInEffortTimes = false,
+  showArchived: propShowArchived,
+  showFullDateInEffortTimes: propShowFullDate,
 }) => {
-  const [sortState, setSortState] = useState<SortState>({
-    column: "",
-    order: "asc",
-  });
+  const sortState = useTableSortStore((state) => state.dailyProjects);
+  const toggleSort = useTableSortStore((state) => state.toggleSort);
+
+  const storeShowArchived = useUIStore((state) => state.showArchived);
+  const storeShowFullDate = useUIStore(
+    (state) => state.showFullDateInEffortTimes,
+  );
+
+  const showArchived = propShowArchived ?? storeShowArchived;
+  const showFullDateInEffortTimes = propShowFullDate ?? storeShowFullDate;
 
   const handleSort = (column: string) => {
-    setSortState((prev) => ({
-      column,
-      order: prev.column === column && prev.order === "asc" ? "desc" : "asc",
-    }));
+    toggleSort("dailyProjects", column);
   };
 
   interface WikiLink {
@@ -287,27 +286,54 @@ export interface DailyProjectsTableWithToggleProps
     DailyProjectsTableProps,
     "showArchived" | "showFullDateInEffortTimes"
   > {
-  showArchived: boolean;
-  onToggleArchived: () => void;
-  showFullDateInEffortTimes: boolean;
-  onToggleFullDate: () => void;
+  showArchived?: boolean;
+  onToggleArchived?: () => void;
+  showFullDateInEffortTimes?: boolean;
+  onToggleFullDate?: () => void;
 }
 
 export const DailyProjectsTableWithToggle: React.FC<
   DailyProjectsTableWithToggleProps
 > = ({
-  showArchived,
+  showArchived: propShowArchived,
   onToggleArchived,
-  showFullDateInEffortTimes,
+  showFullDateInEffortTimes: propShowFullDate,
   onToggleFullDate,
   ...props
 }) => {
+  const storeShowArchived = useUIStore((state) => state.showArchived);
+  const storeShowFullDate = useUIStore(
+    (state) => state.showFullDateInEffortTimes,
+  );
+
+  const storeToggleArchived = useUIStore((state) => state.toggleArchived);
+  const storeToggleFullDate = useUIStore((state) => state.toggleFullDate);
+
+  const showArchived = propShowArchived ?? storeShowArchived;
+  const showFullDateInEffortTimes = propShowFullDate ?? storeShowFullDate;
+
+  const handleToggleArchived = () => {
+    if (onToggleArchived) {
+      onToggleArchived();
+    } else {
+      storeToggleArchived();
+    }
+  };
+
+  const handleToggleFullDate = () => {
+    if (onToggleFullDate) {
+      onToggleFullDate();
+    } else {
+      storeToggleFullDate();
+    }
+  };
+
   return (
     <div className="exocortex-daily-projects-wrapper">
       <div className="exocortex-daily-projects-controls">
         <button
           className="exocortex-toggle-archived"
-          onClick={onToggleArchived}
+          onClick={handleToggleArchived}
           style={{
             marginBottom: "8px",
             marginRight: "8px",
@@ -320,7 +346,7 @@ export const DailyProjectsTableWithToggle: React.FC<
         </button>
         <button
           className="exocortex-toggle-full-date"
-          onClick={onToggleFullDate}
+          onClick={handleToggleFullDate}
           style={{
             marginBottom: "8px",
             padding: "4px 8px",

--- a/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
@@ -1,10 +1,6 @@
-import React, { useState, useMemo } from "react";
+import React, { useMemo } from "react";
 import { MetadataHelpers } from "@exocortex/core";
-
-interface SortState {
-  column: string;
-  order: "asc" | "desc";
-}
+import { useTableSortStore, useUIStore } from "../stores";
 
 export interface DailyTask {
   file: {
@@ -43,21 +39,28 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   onTaskClick,
   getAssetLabel,
   getEffortArea,
-  showEffortArea = false,
-  showEffortVotes = false,
-  showArchived = false,
-  showFullDateInEffortTimes = false,
+  showEffortArea: propShowEffortArea,
+  showEffortVotes: propShowEffortVotes,
+  showArchived: propShowArchived,
+  showFullDateInEffortTimes: propShowFullDate,
 }) => {
-  const [sortState, setSortState] = useState<SortState>({
-    column: "",
-    order: "asc",
-  });
+  const sortState = useTableSortStore((state) => state.dailyTasks);
+  const toggleSort = useTableSortStore((state) => state.toggleSort);
+
+  const storeShowArchived = useUIStore((state) => state.showArchived);
+  const storeShowEffortArea = useUIStore((state) => state.showEffortArea);
+  const storeShowEffortVotes = useUIStore((state) => state.showEffortVotes);
+  const storeShowFullDate = useUIStore(
+    (state) => state.showFullDateInEffortTimes,
+  );
+
+  const showArchived = propShowArchived ?? storeShowArchived;
+  const showEffortArea = propShowEffortArea ?? storeShowEffortArea;
+  const showEffortVotes = propShowEffortVotes ?? storeShowEffortVotes;
+  const showFullDateInEffortTimes = propShowFullDate ?? storeShowFullDate;
 
   const handleSort = (column: string) => {
-    setSortState((prev) => ({
-      column,
-      order: prev.column === column && prev.order === "asc" ? "desc" : "asc",
-    }));
+    toggleSort("dailyTasks", column);
   };
 
   interface WikiLink {
@@ -434,35 +437,84 @@ export interface DailyTasksTableWithToggleProps
     | "showArchived"
     | "showFullDateInEffortTimes"
   > {
-  showEffortArea: boolean;
-  onToggleEffortArea: () => void;
-  showEffortVotes: boolean;
-  onToggleEffortVotes: () => void;
-  showArchived: boolean;
-  onToggleArchived: () => void;
-  showFullDateInEffortTimes: boolean;
-  onToggleFullDate: () => void;
+  showEffortArea?: boolean;
+  onToggleEffortArea?: () => void;
+  showEffortVotes?: boolean;
+  onToggleEffortVotes?: () => void;
+  showArchived?: boolean;
+  onToggleArchived?: () => void;
+  showFullDateInEffortTimes?: boolean;
+  onToggleFullDate?: () => void;
 }
 
 export const DailyTasksTableWithToggle: React.FC<
   DailyTasksTableWithToggleProps
 > = ({
-  showEffortArea,
+  showEffortArea: propShowEffortArea,
   onToggleEffortArea,
-  showEffortVotes,
+  showEffortVotes: propShowEffortVotes,
   onToggleEffortVotes,
-  showArchived,
+  showArchived: propShowArchived,
   onToggleArchived,
-  showFullDateInEffortTimes,
+  showFullDateInEffortTimes: propShowFullDate,
   onToggleFullDate,
   ...props
 }) => {
+  const storeShowEffortArea = useUIStore((state) => state.showEffortArea);
+  const storeShowEffortVotes = useUIStore((state) => state.showEffortVotes);
+  const storeShowArchived = useUIStore((state) => state.showArchived);
+  const storeShowFullDate = useUIStore(
+    (state) => state.showFullDateInEffortTimes,
+  );
+
+  const storeToggleEffortArea = useUIStore((state) => state.toggleEffortArea);
+  const storeToggleEffortVotes = useUIStore((state) => state.toggleEffortVotes);
+  const storeToggleArchived = useUIStore((state) => state.toggleArchived);
+  const storeToggleFullDate = useUIStore((state) => state.toggleFullDate);
+
+  const showEffortArea = propShowEffortArea ?? storeShowEffortArea;
+  const showEffortVotes = propShowEffortVotes ?? storeShowEffortVotes;
+  const showArchived = propShowArchived ?? storeShowArchived;
+  const showFullDateInEffortTimes = propShowFullDate ?? storeShowFullDate;
+
+  const handleToggleEffortArea = () => {
+    if (onToggleEffortArea) {
+      onToggleEffortArea();
+    } else {
+      storeToggleEffortArea();
+    }
+  };
+
+  const handleToggleEffortVotes = () => {
+    if (onToggleEffortVotes) {
+      onToggleEffortVotes();
+    } else {
+      storeToggleEffortVotes();
+    }
+  };
+
+  const handleToggleArchived = () => {
+    if (onToggleArchived) {
+      onToggleArchived();
+    } else {
+      storeToggleArchived();
+    }
+  };
+
+  const handleToggleFullDate = () => {
+    if (onToggleFullDate) {
+      onToggleFullDate();
+    } else {
+      storeToggleFullDate();
+    }
+  };
+
   return (
     <div className="exocortex-daily-tasks-wrapper">
       <div className="exocortex-daily-tasks-controls">
         <button
           className="exocortex-toggle-effort-area"
-          onClick={onToggleEffortArea}
+          onClick={handleToggleEffortArea}
           style={{
             marginBottom: "8px",
             marginRight: "8px",
@@ -475,7 +527,7 @@ export const DailyTasksTableWithToggle: React.FC<
         </button>
         <button
           className="exocortex-toggle-effort-votes"
-          onClick={onToggleEffortVotes}
+          onClick={handleToggleEffortVotes}
           style={{
             marginBottom: "8px",
             marginRight: "8px",
@@ -488,7 +540,7 @@ export const DailyTasksTableWithToggle: React.FC<
         </button>
         <button
           className="exocortex-toggle-archived"
-          onClick={onToggleArchived}
+          onClick={handleToggleArchived}
           style={{
             marginBottom: "8px",
             marginRight: "8px",
@@ -501,7 +553,7 @@ export const DailyTasksTableWithToggle: React.FC<
         </button>
         <button
           className="exocortex-toggle-full-date"
-          onClick={onToggleFullDate}
+          onClick={handleToggleFullDate}
           style={{
             marginBottom: "8px",
             padding: "4px 8px",

--- a/packages/obsidian-plugin/src/presentation/stores/index.ts
+++ b/packages/obsidian-plugin/src/presentation/stores/index.ts
@@ -1,0 +1,9 @@
+export { useUIStore, getUIDefaults } from "./uiStore";
+export { useTableSortStore, getDefaultSortState } from "./tableSortStore";
+export type {
+  UIStore,
+  UISettings,
+  TableSortStore,
+  TableSortState,
+  SortState,
+} from "./types";

--- a/packages/obsidian-plugin/src/presentation/stores/tableSortStore.ts
+++ b/packages/obsidian-plugin/src/presentation/stores/tableSortStore.ts
@@ -1,0 +1,76 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+import type { TableSortStore, TableSortState, SortState } from "./types";
+
+const DEFAULT_SORT_STATE: SortState = {
+  column: "",
+  order: "asc",
+};
+
+const DEFAULT_TABLE_SORT_STATE: TableSortState = {
+  dailyTasks: { ...DEFAULT_SORT_STATE },
+  dailyProjects: { ...DEFAULT_SORT_STATE },
+  assetRelations: { ...DEFAULT_SORT_STATE },
+  assetProperties: { ...DEFAULT_SORT_STATE },
+};
+
+export const useTableSortStore = create<TableSortStore>()(
+  devtools(
+    persist(
+      (set) => ({
+        ...DEFAULT_TABLE_SORT_STATE,
+
+        setSort: (table, column, order) =>
+          set(
+            () => ({
+              [table]: { column, order },
+            }),
+            false,
+            `setSort:${table}`,
+          ),
+
+        toggleSort: (table, column) =>
+          set(
+            (state) => {
+              const currentSort = state[table];
+              const newOrder =
+                currentSort.column === column && currentSort.order === "asc"
+                  ? "desc"
+                  : "asc";
+              return {
+                [table]: { column, order: newOrder },
+              };
+            },
+            false,
+            `toggleSort:${table}:${column}`,
+          ),
+
+        resetSort: (table) =>
+          set(
+            () => ({
+              [table]: { ...DEFAULT_SORT_STATE },
+            }),
+            false,
+            `resetSort:${table}`,
+          ),
+
+        resetAllSorts: () =>
+          set(DEFAULT_TABLE_SORT_STATE, false, "resetAllSorts"),
+      }),
+      {
+        name: "exocortex-table-sort-v1",
+        partialize: (state) => ({
+          dailyTasks: state.dailyTasks,
+          dailyProjects: state.dailyProjects,
+          assetRelations: state.assetRelations,
+          assetProperties: state.assetProperties,
+        }),
+      },
+    ),
+    {
+      name: "TableSortStore",
+    },
+  ),
+);
+
+export const getDefaultSortState = (): SortState => ({ ...DEFAULT_SORT_STATE });

--- a/packages/obsidian-plugin/src/presentation/stores/types.ts
+++ b/packages/obsidian-plugin/src/presentation/stores/types.ts
@@ -1,0 +1,37 @@
+export interface SortState {
+  column: string;
+  order: "asc" | "desc";
+}
+
+export interface UISettings {
+  showArchived: boolean;
+  showEffortArea: boolean;
+  showEffortVotes: boolean;
+  showFullDateInEffortTimes: boolean;
+}
+
+export interface UIStore extends UISettings {
+  toggleArchived: () => void;
+  toggleEffortArea: () => void;
+  toggleEffortVotes: () => void;
+  toggleFullDate: () => void;
+  resetToDefaults: () => void;
+}
+
+export interface TableSortState {
+  dailyTasks: SortState;
+  dailyProjects: SortState;
+  assetRelations: SortState;
+  assetProperties: SortState;
+}
+
+export interface TableSortStore extends TableSortState {
+  setSort: (
+    table: keyof TableSortState,
+    column: string,
+    order: "asc" | "desc",
+  ) => void;
+  toggleSort: (table: keyof TableSortState, column: string) => void;
+  resetSort: (table: keyof TableSortState) => void;
+  resetAllSorts: () => void;
+}

--- a/packages/obsidian-plugin/src/presentation/stores/uiStore.ts
+++ b/packages/obsidian-plugin/src/presentation/stores/uiStore.ts
@@ -1,0 +1,67 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+import type { UIStore, UISettings } from "./types";
+
+const DEFAULT_UI_SETTINGS: UISettings = {
+  showArchived: false,
+  showEffortArea: false,
+  showEffortVotes: false,
+  showFullDateInEffortTimes: false,
+};
+
+export const useUIStore = create<UIStore>()(
+  devtools(
+    persist(
+      (set) => ({
+        ...DEFAULT_UI_SETTINGS,
+
+        toggleArchived: () =>
+          set(
+            (state) => ({ showArchived: !state.showArchived }),
+            false,
+            "toggleArchived",
+          ),
+
+        toggleEffortArea: () =>
+          set(
+            (state) => ({ showEffortArea: !state.showEffortArea }),
+            false,
+            "toggleEffortArea",
+          ),
+
+        toggleEffortVotes: () =>
+          set(
+            (state) => ({ showEffortVotes: !state.showEffortVotes }),
+            false,
+            "toggleEffortVotes",
+          ),
+
+        toggleFullDate: () =>
+          set(
+            (state) => ({
+              showFullDateInEffortTimes: !state.showFullDateInEffortTimes,
+            }),
+            false,
+            "toggleFullDate",
+          ),
+
+        resetToDefaults: () =>
+          set(DEFAULT_UI_SETTINGS, false, "resetToDefaults"),
+      }),
+      {
+        name: "exocortex-ui-settings-v1",
+        partialize: (state) => ({
+          showArchived: state.showArchived,
+          showEffortArea: state.showEffortArea,
+          showEffortVotes: state.showEffortVotes,
+          showFullDateInEffortTimes: state.showFullDateInEffortTimes,
+        }),
+      },
+    ),
+    {
+      name: "UIStore",
+    },
+  ),
+);
+
+export const getUIDefaults = (): UISettings => ({ ...DEFAULT_UI_SETTINGS });

--- a/packages/obsidian-plugin/tests/unit/stores/tableSortStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/stores/tableSortStore.test.ts
@@ -1,0 +1,297 @@
+import {
+  useTableSortStore,
+  getDefaultSortState,
+} from "../../../src/presentation/stores/tableSortStore";
+import type { SortState } from "../../../src/presentation/stores/types";
+
+const mockStorage: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: jest.fn((key: string) => mockStorage[key] || null),
+  setItem: jest.fn((key: string, value: string) => {
+    mockStorage[key] = value;
+  }),
+  removeItem: jest.fn((key: string) => {
+    delete mockStorage[key];
+  }),
+  clear: jest.fn(() => {
+    Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
+  }),
+  length: 0,
+  key: jest.fn(),
+};
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
+
+describe("TableSortStore", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    useTableSortStore.setState({
+      dailyTasks: { column: "", order: "asc" },
+      dailyProjects: { column: "", order: "asc" },
+      assetRelations: { column: "", order: "asc" },
+      assetProperties: { column: "", order: "asc" },
+    });
+  });
+
+  describe("initial state", () => {
+    it("should have default sort state for all tables", () => {
+      const state = useTableSortStore.getState();
+
+      expect(state.dailyTasks).toEqual({ column: "", order: "asc" });
+      expect(state.dailyProjects).toEqual({ column: "", order: "asc" });
+      expect(state.assetRelations).toEqual({ column: "", order: "asc" });
+      expect(state.assetProperties).toEqual({ column: "", order: "asc" });
+    });
+  });
+
+  describe("setSort", () => {
+    it("should set sort for dailyTasks table", () => {
+      useTableSortStore.getState().setSort("dailyTasks", "name", "asc");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "name",
+        order: "asc",
+      });
+    });
+
+    it("should set sort for dailyProjects table", () => {
+      useTableSortStore.getState().setSort("dailyProjects", "status", "desc");
+
+      expect(useTableSortStore.getState().dailyProjects).toEqual({
+        column: "status",
+        order: "desc",
+      });
+    });
+
+    it("should set sort for assetRelations table", () => {
+      useTableSortStore.getState().setSort("assetRelations", "title", "asc");
+
+      expect(useTableSortStore.getState().assetRelations).toEqual({
+        column: "title",
+        order: "asc",
+      });
+    });
+
+    it("should set sort for assetProperties table", () => {
+      useTableSortStore.getState().setSort("assetProperties", "value", "desc");
+
+      expect(useTableSortStore.getState().assetProperties).toEqual({
+        column: "value",
+        order: "desc",
+      });
+    });
+
+    it("should not affect other tables when setting sort", () => {
+      useTableSortStore.getState().setSort("dailyTasks", "name", "asc");
+      useTableSortStore.getState().setSort("dailyProjects", "start", "desc");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "name",
+        order: "asc",
+      });
+      expect(useTableSortStore.getState().dailyProjects).toEqual({
+        column: "start",
+        order: "desc",
+      });
+    });
+
+    it("should overwrite existing sort state", () => {
+      useTableSortStore.getState().setSort("dailyTasks", "name", "asc");
+      useTableSortStore.getState().setSort("dailyTasks", "status", "desc");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "status",
+        order: "desc",
+      });
+    });
+  });
+
+  describe("toggleSort", () => {
+    it("should set asc order when clicking new column", () => {
+      useTableSortStore.getState().toggleSort("dailyTasks", "name");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "name",
+        order: "asc",
+      });
+    });
+
+    it("should toggle to desc when clicking same column with asc", () => {
+      useTableSortStore.setState({
+        dailyTasks: { column: "name", order: "asc" },
+        dailyProjects: { column: "", order: "asc" },
+        assetRelations: { column: "", order: "asc" },
+        assetProperties: { column: "", order: "asc" },
+      });
+
+      useTableSortStore.getState().toggleSort("dailyTasks", "name");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "name",
+        order: "desc",
+      });
+    });
+
+    it("should toggle to asc when clicking same column with desc", () => {
+      useTableSortStore.setState({
+        dailyTasks: { column: "name", order: "desc" },
+        dailyProjects: { column: "", order: "asc" },
+        assetRelations: { column: "", order: "asc" },
+        assetProperties: { column: "", order: "asc" },
+      });
+
+      useTableSortStore.getState().toggleSort("dailyTasks", "name");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "name",
+        order: "asc",
+      });
+    });
+
+    it("should reset to asc when clicking different column", () => {
+      useTableSortStore.setState({
+        dailyTasks: { column: "name", order: "desc" },
+        dailyProjects: { column: "", order: "asc" },
+        assetRelations: { column: "", order: "asc" },
+        assetProperties: { column: "", order: "asc" },
+      });
+
+      useTableSortStore.getState().toggleSort("dailyTasks", "status");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "status",
+        order: "asc",
+      });
+    });
+
+    it("should work for different tables independently", () => {
+      useTableSortStore.getState().toggleSort("dailyTasks", "name");
+      useTableSortStore.getState().toggleSort("dailyProjects", "start");
+      useTableSortStore.getState().toggleSort("dailyTasks", "name");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "name",
+        order: "desc",
+      });
+      expect(useTableSortStore.getState().dailyProjects).toEqual({
+        column: "start",
+        order: "asc",
+      });
+    });
+  });
+
+  describe("resetSort", () => {
+    it("should reset sort for specific table", () => {
+      useTableSortStore.setState({
+        dailyTasks: { column: "name", order: "desc" },
+        dailyProjects: { column: "start", order: "asc" },
+        assetRelations: { column: "", order: "asc" },
+        assetProperties: { column: "", order: "asc" },
+      });
+
+      useTableSortStore.getState().resetSort("dailyTasks");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "",
+        order: "asc",
+      });
+      expect(useTableSortStore.getState().dailyProjects).toEqual({
+        column: "start",
+        order: "asc",
+      });
+    });
+
+    it("should work when already at default", () => {
+      useTableSortStore.getState().resetSort("dailyTasks");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "",
+        order: "asc",
+      });
+    });
+  });
+
+  describe("resetAllSorts", () => {
+    it("should reset all tables to default sort state", () => {
+      useTableSortStore.setState({
+        dailyTasks: { column: "name", order: "desc" },
+        dailyProjects: { column: "start", order: "asc" },
+        assetRelations: { column: "title", order: "desc" },
+        assetProperties: { column: "value", order: "asc" },
+      });
+
+      useTableSortStore.getState().resetAllSorts();
+
+      const state = useTableSortStore.getState();
+      expect(state.dailyTasks).toEqual({ column: "", order: "asc" });
+      expect(state.dailyProjects).toEqual({ column: "", order: "asc" });
+      expect(state.assetRelations).toEqual({ column: "", order: "asc" });
+      expect(state.assetProperties).toEqual({ column: "", order: "asc" });
+    });
+
+    it("should work when already at defaults", () => {
+      useTableSortStore.getState().resetAllSorts();
+
+      const state = useTableSortStore.getState();
+      expect(state.dailyTasks).toEqual({ column: "", order: "asc" });
+      expect(state.dailyProjects).toEqual({ column: "", order: "asc" });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty column name", () => {
+      useTableSortStore.getState().setSort("dailyTasks", "", "asc");
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "",
+        order: "asc",
+      });
+    });
+
+    it("should handle column names with special characters", () => {
+      useTableSortStore.getState().setSort("dailyTasks", "start-time", "asc");
+
+      expect(useTableSortStore.getState().dailyTasks.column).toBe("start-time");
+    });
+
+    it("should handle rapid sequential operations", () => {
+      for (let i = 0; i < 10; i++) {
+        useTableSortStore.getState().toggleSort("dailyTasks", "name");
+      }
+
+      expect(useTableSortStore.getState().dailyTasks).toEqual({
+        column: "name",
+        order: "desc",
+      });
+    });
+  });
+});
+
+describe("getDefaultSortState", () => {
+  it("should return default sort state", () => {
+    const defaultState = getDefaultSortState();
+
+    expect(defaultState).toEqual({ column: "", order: "asc" });
+  });
+
+  it("should return a new object each time", () => {
+    const state1 = getDefaultSortState();
+    const state2 = getDefaultSortState();
+
+    expect(state1).not.toBe(state2);
+    expect(state1).toEqual(state2);
+  });
+
+  it("should be immutable (modifying returned object does not affect next call)", () => {
+    const state1 = getDefaultSortState();
+    state1.column = "modified";
+    state1.order = "desc";
+
+    const state2 = getDefaultSortState();
+    expect(state2.column).toBe("");
+    expect(state2.order).toBe("asc");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/stores/uiStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/stores/uiStore.test.ts
@@ -1,0 +1,207 @@
+import { useUIStore, getUIDefaults } from "../../../src/presentation/stores/uiStore";
+import type { UISettings } from "../../../src/presentation/stores/types";
+
+const mockStorage: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: jest.fn((key: string) => mockStorage[key] || null),
+  setItem: jest.fn((key: string, value: string) => {
+    mockStorage[key] = value;
+  }),
+  removeItem: jest.fn((key: string) => {
+    delete mockStorage[key];
+  }),
+  clear: jest.fn(() => {
+    Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
+  }),
+  length: 0,
+  key: jest.fn(),
+};
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
+
+describe("UIStore", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    useUIStore.setState({
+      showArchived: false,
+      showEffortArea: false,
+      showEffortVotes: false,
+      showFullDateInEffortTimes: false,
+    });
+  });
+
+  describe("initial state", () => {
+    it("should have default values", () => {
+      const state = useUIStore.getState();
+
+      expect(state.showArchived).toBe(false);
+      expect(state.showEffortArea).toBe(false);
+      expect(state.showEffortVotes).toBe(false);
+      expect(state.showFullDateInEffortTimes).toBe(false);
+    });
+  });
+
+  describe("toggleArchived", () => {
+    it("should toggle showArchived from false to true", () => {
+      expect(useUIStore.getState().showArchived).toBe(false);
+
+      useUIStore.getState().toggleArchived();
+
+      expect(useUIStore.getState().showArchived).toBe(true);
+    });
+
+    it("should toggle showArchived from true to false", () => {
+      useUIStore.setState({ showArchived: true });
+      expect(useUIStore.getState().showArchived).toBe(true);
+
+      useUIStore.getState().toggleArchived();
+
+      expect(useUIStore.getState().showArchived).toBe(false);
+    });
+
+    it("should not affect other settings when toggling", () => {
+      useUIStore.setState({ showEffortArea: true, showEffortVotes: true });
+
+      useUIStore.getState().toggleArchived();
+
+      expect(useUIStore.getState().showEffortArea).toBe(true);
+      expect(useUIStore.getState().showEffortVotes).toBe(true);
+    });
+  });
+
+  describe("toggleEffortArea", () => {
+    it("should toggle showEffortArea from false to true", () => {
+      expect(useUIStore.getState().showEffortArea).toBe(false);
+
+      useUIStore.getState().toggleEffortArea();
+
+      expect(useUIStore.getState().showEffortArea).toBe(true);
+    });
+
+    it("should toggle showEffortArea from true to false", () => {
+      useUIStore.setState({ showEffortArea: true });
+
+      useUIStore.getState().toggleEffortArea();
+
+      expect(useUIStore.getState().showEffortArea).toBe(false);
+    });
+  });
+
+  describe("toggleEffortVotes", () => {
+    it("should toggle showEffortVotes from false to true", () => {
+      expect(useUIStore.getState().showEffortVotes).toBe(false);
+
+      useUIStore.getState().toggleEffortVotes();
+
+      expect(useUIStore.getState().showEffortVotes).toBe(true);
+    });
+
+    it("should toggle showEffortVotes from true to false", () => {
+      useUIStore.setState({ showEffortVotes: true });
+
+      useUIStore.getState().toggleEffortVotes();
+
+      expect(useUIStore.getState().showEffortVotes).toBe(false);
+    });
+  });
+
+  describe("toggleFullDate", () => {
+    it("should toggle showFullDateInEffortTimes from false to true", () => {
+      expect(useUIStore.getState().showFullDateInEffortTimes).toBe(false);
+
+      useUIStore.getState().toggleFullDate();
+
+      expect(useUIStore.getState().showFullDateInEffortTimes).toBe(true);
+    });
+
+    it("should toggle showFullDateInEffortTimes from true to false", () => {
+      useUIStore.setState({ showFullDateInEffortTimes: true });
+
+      useUIStore.getState().toggleFullDate();
+
+      expect(useUIStore.getState().showFullDateInEffortTimes).toBe(false);
+    });
+  });
+
+  describe("resetToDefaults", () => {
+    it("should reset all settings to defaults", () => {
+      useUIStore.setState({
+        showArchived: true,
+        showEffortArea: true,
+        showEffortVotes: true,
+        showFullDateInEffortTimes: true,
+      });
+
+      useUIStore.getState().resetToDefaults();
+
+      const state = useUIStore.getState();
+      expect(state.showArchived).toBe(false);
+      expect(state.showEffortArea).toBe(false);
+      expect(state.showEffortVotes).toBe(false);
+      expect(state.showFullDateInEffortTimes).toBe(false);
+    });
+
+    it("should work when already at defaults", () => {
+      useUIStore.getState().resetToDefaults();
+
+      const state = useUIStore.getState();
+      expect(state.showArchived).toBe(false);
+      expect(state.showEffortArea).toBe(false);
+      expect(state.showEffortVotes).toBe(false);
+      expect(state.showFullDateInEffortTimes).toBe(false);
+    });
+  });
+
+  describe("multiple toggles", () => {
+    it("should handle multiple sequential toggles", () => {
+      useUIStore.getState().toggleArchived();
+      useUIStore.getState().toggleArchived();
+      useUIStore.getState().toggleArchived();
+
+      expect(useUIStore.getState().showArchived).toBe(true);
+    });
+
+    it("should handle toggling multiple settings", () => {
+      useUIStore.getState().toggleArchived();
+      useUIStore.getState().toggleEffortArea();
+      useUIStore.getState().toggleEffortVotes();
+      useUIStore.getState().toggleFullDate();
+
+      const state = useUIStore.getState();
+      expect(state.showArchived).toBe(true);
+      expect(state.showEffortArea).toBe(true);
+      expect(state.showEffortVotes).toBe(true);
+      expect(state.showFullDateInEffortTimes).toBe(true);
+    });
+  });
+});
+
+describe("getUIDefaults", () => {
+  it("should return default UI settings", () => {
+    const defaults = getUIDefaults();
+
+    expect(defaults.showArchived).toBe(false);
+    expect(defaults.showEffortArea).toBe(false);
+    expect(defaults.showEffortVotes).toBe(false);
+    expect(defaults.showFullDateInEffortTimes).toBe(false);
+  });
+
+  it("should return a new object each time", () => {
+    const defaults1 = getUIDefaults();
+    const defaults2 = getUIDefaults();
+
+    expect(defaults1).not.toBe(defaults2);
+    expect(defaults1).toEqual(defaults2);
+  });
+
+  it("should be immutable (modifying returned object does not affect next call)", () => {
+    const defaults1 = getUIDefaults();
+    defaults1.showArchived = true;
+
+    const defaults2 = getUIDefaults();
+    expect(defaults2.showArchived).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Zustand with persist and devtools middleware for centralized React state management
- Create UIStore for shared UI settings (showArchived, showEffortArea, showEffortVotes, showFullDateInEffortTimes)
- Create TableSortStore for per-table sorting state (dailyTasks, dailyProjects, assetRelations, assetProperties)
- Migrate DailyTasksTable and DailyProjectsTable to use stores
- Maintain backward compatibility with optional prop overrides (props take precedence over store values)
- Add 39 unit tests for stores

## Implementation Details

### Store Architecture
- `UIStore` - Shared UI settings with toggle actions and persist middleware
- `TableSortStore` - Per-table sorting state with setSort, toggleSort, resetSort, resetAllSorts actions
- Both stores use Zustand `devtools` middleware for debugging
- Both stores use Zustand `persist` middleware with localStorage

### Backward Compatibility
Components accept optional props that override store values using nullish coalescing:
```typescript
const showArchived = propShowArchived ?? storeShowArchived;
```

### Test Coverage
- 39 new unit tests covering all store actions and edge cases
- Tests for UIStore: toggles, resetToDefaults, multiple toggles
- Tests for TableSortStore: setSort, toggleSort, resetSort, resetAllSorts

## Closes #437

## Test plan
- [x] Unit tests pass (39 new tests for stores)
- [x] TypeScript compiles without errors
- [x] Existing component tests pass
- [x] BDD coverage at 100%