### PR TITLE
refactor: integrate ApplicationErrorHandler in infrastructure services (Phase 3C)

### DIFF
--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.test.ts
@@ -1,6 +1,6 @@
 import { VaultRDFIndexer } from "../../../src/infrastructure/VaultRDFIndexer";
 import type { App, TFile, EventRef } from "obsidian";
-import { InMemoryTripleStore, NoteToRDFConverter } from "@exocortex/core";
+import { InMemoryTripleStore, NoteToRDFConverter, ApplicationErrorHandler } from "@exocortex/core";
 import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
 
 jest.mock("@exocortex/core");
@@ -16,6 +16,14 @@ describe("VaultRDFIndexer", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Set up ApplicationErrorHandler mock to execute operations directly
+    (ApplicationErrorHandler as jest.MockedClass<typeof ApplicationErrorHandler>).mockImplementation(() => ({
+      executeWithRetry: jest.fn().mockImplementation(async (operation: () => Promise<unknown>) => {
+        return await operation();
+      }),
+      handle: jest.fn(),
+    } as any));
 
     mockEventRefs = [];
     mockApp = {


### PR DESCRIPTION
## Summary
- Integrate ApplicationErrorHandler in VaultRDFIndexer with executeWithRetry for vault operations
- Integrate ApplicationErrorHandler in SPARQLQueryService with executeWithRetry for indexer operations
- Update unit tests to mock ApplicationErrorHandler properly

## Changes
- **VaultRDFIndexer**: Added error handling with retry for initialize(), updateFile(), removeFile(), renameFile(), refresh()
- **SPARQLQueryService**: Added error handling with retry for initialize(), refresh(), updateFile()
- **Tests**: Updated mock setup to properly configure ApplicationErrorHandler after jest.clearAllMocks()

## Test plan
- [x] TypeScript compilation passes
- [x] All unit tests pass (1785 tests)
- [x] All component tests pass (354 tests)
- [ ] CI pipeline validates all checks

Part of Issue #438 - Phase 3C: Infrastructure services error handling