### PR TITLE
perf: add list virtualization for large tables (#440)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3945,6 +3945,33 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -14741,6 +14768,7 @@
       "version": "0.0.0-dev",
       "dependencies": {
         "@exocortex/core": "*",
+        "@tanstack/react-virtual": "^3.13.12",
         "d3": "^7.9.0",
         "obsidian": "latest",
         "react": "^19.2.0",

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@exocortex/core": "*",
+    "@tanstack/react-virtual": "^3.13.12",
     "d3": "^7.9.0",
     "obsidian": "latest",
     "react": "^19.2.0",


### PR DESCRIPTION
## Summary
Implements list virtualization for tables with 50+ items using @tanstack/react-virtual.
Only visible rows are rendered, dramatically improving performance for large datasets.

**Issue**: #440

## Changes
- Add `@tanstack/react-virtual` dependency
- Virtualize `DailyTasksTable` component
- Virtualize `DailyProjectsTable` component
- Virtualize `AssetRelationsTable` (SingleTable component)

## Implementation Details
- **Threshold**: Tables with >50 items use virtualization
- **Row height**: 35px estimated
- **Overscan**: 5 rows for smooth scrolling
- **Fixed header**: Header stays visible during scroll
- **Graceful fallback**: Small tables render normally without virtualization overhead

## Test Plan
- [x] TypeScript compilation passes
- [x] All 1815 unit tests pass
- [x] Build succeeds
- [ ] Manual testing with large datasets in Obsidian
- [ ] CI pipeline passes