### PR TITLE
feat: implement query caching infrastructure with React Query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,8 @@
         "@playwright/experimental-ct-react": "^1.56.1",
         "@playwright/test": "^1.56.1",
         "@preact/compat": "^18.3.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^18.19.129",
         "@types/react": "^19.2.2",
@@ -1803,6 +1805,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3945,6 +3957,32 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.11.tgz",
+      "integrity": "sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.11.tgz",
+      "integrity": "sha512-3uyzz01D1fkTLXuxF3JfoJoHQMU2fxsfJwE+6N5hHy0dVNoZOvwKP8Z2k7k1KDeD54N20apcJnG75TBAStIrBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.11"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.13.12",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
@@ -3972,6 +4010,86 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -3992,6 +4110,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5188,6 +5313,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -6653,6 +6788,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -6675,6 +6820,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -11243,6 +11395,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -14768,6 +14930,7 @@
       "version": "0.0.0-dev",
       "dependencies": {
         "@exocortex/core": "*",
+        "@tanstack/react-query": "^5.90.11",
         "@tanstack/react-virtual": "^3.13.12",
         "d3": "^7.9.0",
         "obsidian": "latest",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "@playwright/experimental-ct-react": "^1.56.1",
     "@playwright/test": "^1.56.1",
     "@preact/compat": "^18.3.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^18.19.129",
     "@types/react": "^19.2.2",

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@exocortex/core": "*",
+    "@tanstack/react-query": "^5.90.11",
     "@tanstack/react-virtual": "^3.13.12",
     "d3": "^7.9.0",
     "obsidian": "latest",

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -163,6 +163,10 @@ export default class ExocortexPlugin extends Plugin {
     this.autoRenderLayout();
   }
 
+  getSPARQLApi(): SPARQLApi | null {
+    return this.sparql ?? null;
+  }
+
   private autoRenderLayout(): void {
     // Remove existing auto-rendered layouts
     this.removeAutoRenderedLayouts();

--- a/packages/obsidian-plugin/src/infrastructure/query/QueryClientSetup.ts
+++ b/packages/obsidian-plugin/src/infrastructure/query/QueryClientSetup.ts
@@ -1,0 +1,84 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export interface QueryClientConfig {
+  staleTime?: number;
+  gcTime?: number;
+  retry?: number | boolean;
+  refetchOnWindowFocus?: boolean;
+}
+
+const DEFAULT_STALE_TIME = 5 * 60 * 1000;
+const DEFAULT_GC_TIME = 10 * 60 * 1000;
+
+export function createQueryClient(config: QueryClientConfig = {}): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: config.staleTime ?? DEFAULT_STALE_TIME,
+        gcTime: config.gcTime ?? DEFAULT_GC_TIME,
+        retry: config.retry ?? 1,
+        refetchOnWindowFocus: config.refetchOnWindowFocus ?? false,
+      },
+    },
+  });
+}
+
+let globalQueryClient: QueryClient | null = null;
+
+export function getQueryClient(): QueryClient {
+  if (!globalQueryClient) {
+    globalQueryClient = createQueryClient();
+  }
+  return globalQueryClient;
+}
+
+export function setQueryClient(client: QueryClient): void {
+  globalQueryClient = client;
+}
+
+export function invalidateAllQueries(): Promise<void> {
+  const client = getQueryClient();
+  return client.invalidateQueries();
+}
+
+export function invalidateSPARQLQueries(): Promise<void> {
+  const client = getQueryClient();
+  return client.invalidateQueries({ queryKey: ["sparql"] });
+}
+
+export function clearQueryCache(): void {
+  const client = getQueryClient();
+  client.clear();
+}
+
+export interface CacheStatistics {
+  totalQueries: number;
+  staleQueries: number;
+  fetchingQueries: number;
+  cacheSize: number;
+}
+
+export function getCacheStatistics(): CacheStatistics {
+  const client = getQueryClient();
+  const cache = client.getQueryCache();
+  const queries = cache.getAll();
+
+  let staleQueries = 0;
+  let fetchingQueries = 0;
+
+  queries.forEach((query) => {
+    if (query.isStale()) {
+      staleQueries++;
+    }
+    if (query.state.fetchStatus === "fetching") {
+      fetchingQueries++;
+    }
+  });
+
+  return {
+    totalQueries: queries.length,
+    staleQueries,
+    fetchingQueries,
+    cacheSize: queries.length,
+  };
+}

--- a/packages/obsidian-plugin/src/infrastructure/query/QueryProvider.tsx
+++ b/packages/obsidian-plugin/src/infrastructure/query/QueryProvider.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from "react";
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { App, EventRef } from "obsidian";
+import { getQueryClient, invalidateSPARQLQueries } from "./QueryClientSetup";
+
+export interface QueryProviderProps {
+  children: React.ReactNode;
+  app: App;
+  queryClient?: QueryClient;
+}
+
+export const QueryProvider: React.FC<QueryProviderProps> = ({
+  children,
+  app,
+  queryClient,
+}) => {
+  const client = queryClient ?? getQueryClient();
+
+  useEffect(() => {
+    let eventRef: EventRef | null = null;
+    let debounceTimeout: ReturnType<typeof setTimeout> | null = null;
+    const DEBOUNCE_DELAY = 500;
+
+    const handleFileChange = () => {
+      if (debounceTimeout) {
+        clearTimeout(debounceTimeout);
+      }
+
+      debounceTimeout = setTimeout(() => {
+        invalidateSPARQLQueries();
+      }, DEBOUNCE_DELAY);
+    };
+
+    eventRef = app.metadataCache.on("changed", handleFileChange);
+
+    return () => {
+      if (eventRef) {
+        app.metadataCache.offref(eventRef);
+      }
+      if (debounceTimeout) {
+        clearTimeout(debounceTimeout);
+      }
+    };
+  }, [app, client]);
+
+  return (
+    <QueryClientProvider client={client}>
+      {children}
+    </QueryClientProvider>
+  );
+};

--- a/packages/obsidian-plugin/src/infrastructure/query/WithQueryProvider.tsx
+++ b/packages/obsidian-plugin/src/infrastructure/query/WithQueryProvider.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { App } from "obsidian";
+import { QueryProvider } from "./QueryProvider";
+
+export interface WithQueryProviderProps {
+  app: App;
+  children?: React.ReactNode;
+}
+
+export const WithQueryProvider: React.FC<WithQueryProviderProps> = ({
+  app,
+  children,
+}) => {
+  return (
+    <QueryProvider app={app}>
+      {children}
+    </QueryProvider>
+  );
+};
+
+export function wrapWithQueryProvider(
+  app: App,
+  component: React.ReactElement
+): React.ReactElement {
+  return React.createElement(WithQueryProvider, { app, children: component });
+}

--- a/packages/obsidian-plugin/src/infrastructure/query/index.ts
+++ b/packages/obsidian-plugin/src/infrastructure/query/index.ts
@@ -1,0 +1,28 @@
+export {
+  createQueryClient,
+  getQueryClient,
+  setQueryClient,
+  invalidateAllQueries,
+  invalidateSPARQLQueries,
+  clearQueryCache,
+  getCacheStatistics,
+  type QueryClientConfig,
+  type CacheStatistics,
+} from "./QueryClientSetup";
+
+export { QueryProvider, type QueryProviderProps } from "./QueryProvider";
+
+export {
+  WithQueryProvider,
+  wrapWithQueryProvider,
+  type WithQueryProviderProps,
+} from "./WithQueryProvider";
+
+export {
+  useSPARQLQuery,
+  useSPARQLQueryWithTransform,
+  prefetchSPARQLQuery,
+  type SPARQLQueryResult,
+  type UseSPARQLQueryOptions,
+  type UseSPARQLQueryWithTransformOptions,
+} from "./useSPARQLQuery";

--- a/packages/obsidian-plugin/src/infrastructure/query/useSPARQLQuery.ts
+++ b/packages/obsidian-plugin/src/infrastructure/query/useSPARQLQuery.ts
@@ -1,0 +1,96 @@
+import { useQuery, UseQueryOptions, UseQueryResult } from "@tanstack/react-query";
+import type { SolutionMapping, Triple } from "@exocortex/core";
+import type { QueryResult } from "../../application/api/SPARQLApi";
+import type ExocortexPlugin from "../../ExocortexPlugin";
+import { getQueryClient } from "./QueryClientSetup";
+
+export type SPARQLQueryResult = SolutionMapping[] | Triple[];
+
+export interface UseSPARQLQueryOptions {
+  enabled?: boolean;
+  staleTime?: number;
+  gcTime?: number;
+  refetchOnMount?: boolean | "always";
+  refetchOnWindowFocus?: boolean;
+}
+
+function generateQueryKey(queryString: string): readonly string[] {
+  const normalizedQuery = queryString.trim().replace(/\s+/g, " ");
+  return ["sparql", normalizedQuery] as const;
+}
+
+export function useSPARQLQuery(
+  plugin: ExocortexPlugin,
+  queryString: string,
+  options: UseSPARQLQueryOptions = {}
+): UseQueryResult<QueryResult, Error> {
+  const sparqlApi = plugin.getSPARQLApi?.();
+
+  const queryFn = async (): Promise<QueryResult> => {
+    if (!sparqlApi) {
+      throw new Error("SPARQL API not available");
+    }
+    return sparqlApi.query(queryString);
+  };
+
+  const queryOptions: UseQueryOptions<QueryResult, Error> = {
+    queryKey: generateQueryKey(queryString),
+    queryFn,
+    enabled: options.enabled !== false && !!sparqlApi,
+    staleTime: options.staleTime,
+    gcTime: options.gcTime,
+    refetchOnMount: options.refetchOnMount ?? false,
+    refetchOnWindowFocus: options.refetchOnWindowFocus ?? false,
+  };
+
+  return useQuery(queryOptions);
+}
+
+export interface UseSPARQLQueryWithTransformOptions<T> extends UseSPARQLQueryOptions {
+  transform: (result: QueryResult) => T;
+}
+
+export function useSPARQLQueryWithTransform<T>(
+  plugin: ExocortexPlugin,
+  queryString: string,
+  options: UseSPARQLQueryWithTransformOptions<T>
+): UseQueryResult<T, Error> {
+  const sparqlApi = plugin.getSPARQLApi?.();
+
+  const queryFn = async (): Promise<T> => {
+    if (!sparqlApi) {
+      throw new Error("SPARQL API not available");
+    }
+    const result = await sparqlApi.query(queryString);
+    return options.transform(result);
+  };
+
+  const queryOptions: UseQueryOptions<T, Error> = {
+    queryKey: [...generateQueryKey(queryString), "transformed"],
+    queryFn,
+    enabled: options.enabled !== false && !!sparqlApi,
+    staleTime: options.staleTime,
+    gcTime: options.gcTime,
+    refetchOnMount: options.refetchOnMount ?? false,
+    refetchOnWindowFocus: options.refetchOnWindowFocus ?? false,
+  };
+
+  return useQuery(queryOptions);
+}
+
+export function prefetchSPARQLQuery(
+  plugin: ExocortexPlugin,
+  queryString: string
+): Promise<void> {
+  const sparqlApi = plugin.getSPARQLApi?.();
+  if (!sparqlApi) {
+    return Promise.resolve();
+  }
+
+  const queryClient = getQueryClient();
+
+  return queryClient.prefetchQuery({
+    queryKey: generateQueryKey(queryString),
+    queryFn: () => sparqlApi.query(queryString),
+  });
+}

--- a/packages/obsidian-plugin/tests/unit/QueryClientSetup.test.ts
+++ b/packages/obsidian-plugin/tests/unit/QueryClientSetup.test.ts
@@ -1,0 +1,164 @@
+import { QueryClient } from "@tanstack/react-query";
+import {
+  createQueryClient,
+  getQueryClient,
+  setQueryClient,
+  invalidateAllQueries,
+  invalidateSPARQLQueries,
+  clearQueryCache,
+  getCacheStatistics,
+} from "../../src/infrastructure/query/QueryClientSetup";
+
+describe("QueryClientSetup", () => {
+  let originalClient: QueryClient | null = null;
+
+  beforeEach(() => {
+    originalClient = null;
+    try {
+      originalClient = getQueryClient();
+    } catch {
+      // No client set
+    }
+    clearQueryCache();
+  });
+
+  afterEach(() => {
+    if (originalClient) {
+      setQueryClient(originalClient);
+    }
+  });
+
+  describe("createQueryClient", () => {
+    it("should create a QueryClient with default options", () => {
+      const client = createQueryClient();
+
+      expect(client).toBeInstanceOf(QueryClient);
+      const defaultOptions = client.getDefaultOptions();
+      expect(defaultOptions.queries?.staleTime).toBe(5 * 60 * 1000);
+      expect(defaultOptions.queries?.gcTime).toBe(10 * 60 * 1000);
+      expect(defaultOptions.queries?.retry).toBe(1);
+      expect(defaultOptions.queries?.refetchOnWindowFocus).toBe(false);
+    });
+
+    it("should create a QueryClient with custom staleTime", () => {
+      const customStaleTime = 60 * 1000;
+      const client = createQueryClient({ staleTime: customStaleTime });
+
+      const defaultOptions = client.getDefaultOptions();
+      expect(defaultOptions.queries?.staleTime).toBe(customStaleTime);
+    });
+
+    it("should create a QueryClient with custom gcTime", () => {
+      const customGcTime = 30 * 60 * 1000;
+      const client = createQueryClient({ gcTime: customGcTime });
+
+      const defaultOptions = client.getDefaultOptions();
+      expect(defaultOptions.queries?.gcTime).toBe(customGcTime);
+    });
+
+    it("should create a QueryClient with custom retry", () => {
+      const client = createQueryClient({ retry: 3 });
+
+      const defaultOptions = client.getDefaultOptions();
+      expect(defaultOptions.queries?.retry).toBe(3);
+    });
+
+    it("should create a QueryClient with refetchOnWindowFocus enabled", () => {
+      const client = createQueryClient({ refetchOnWindowFocus: true });
+
+      const defaultOptions = client.getDefaultOptions();
+      expect(defaultOptions.queries?.refetchOnWindowFocus).toBe(true);
+    });
+  });
+
+  describe("getQueryClient", () => {
+    it("should return the same instance on multiple calls", () => {
+      const client1 = getQueryClient();
+      const client2 = getQueryClient();
+
+      expect(client1).toBe(client2);
+    });
+
+    it("should create a client if none exists", () => {
+      const newClient = createQueryClient();
+      setQueryClient(newClient);
+
+      const retrievedClient = getQueryClient();
+      expect(retrievedClient).toBe(newClient);
+    });
+  });
+
+  describe("setQueryClient", () => {
+    it("should set a new query client", () => {
+      const newClient = createQueryClient({ staleTime: 1000 });
+      setQueryClient(newClient);
+
+      const retrievedClient = getQueryClient();
+      expect(retrievedClient).toBe(newClient);
+      expect(retrievedClient.getDefaultOptions().queries?.staleTime).toBe(1000);
+    });
+  });
+
+  describe("invalidateAllQueries", () => {
+    it("should return a promise", async () => {
+      const result = invalidateAllQueries();
+      expect(result).toBeInstanceOf(Promise);
+      await result;
+    });
+  });
+
+  describe("invalidateSPARQLQueries", () => {
+    it("should return a promise", async () => {
+      const result = invalidateSPARQLQueries();
+      expect(result).toBeInstanceOf(Promise);
+      await result;
+    });
+
+    it("should invalidate queries with sparql key", async () => {
+      const client = getQueryClient();
+      const invalidateSpy = jest.spyOn(client, "invalidateQueries");
+
+      await invalidateSPARQLQueries();
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["sparql"] });
+      invalidateSpy.mockRestore();
+    });
+  });
+
+  describe("clearQueryCache", () => {
+    it("should clear the query cache", () => {
+      const client = getQueryClient();
+      const clearSpy = jest.spyOn(client, "clear");
+
+      clearQueryCache();
+
+      expect(clearSpy).toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
+  });
+
+  describe("getCacheStatistics", () => {
+    it("should return cache statistics with initial values", () => {
+      const stats = getCacheStatistics();
+
+      expect(stats).toHaveProperty("totalQueries");
+      expect(stats).toHaveProperty("staleQueries");
+      expect(stats).toHaveProperty("fetchingQueries");
+      expect(stats).toHaveProperty("cacheSize");
+      expect(typeof stats.totalQueries).toBe("number");
+      expect(typeof stats.staleQueries).toBe("number");
+      expect(typeof stats.fetchingQueries).toBe("number");
+      expect(typeof stats.cacheSize).toBe("number");
+    });
+
+    it("should return zero queries for empty cache", () => {
+      clearQueryCache();
+      const stats = getCacheStatistics();
+
+      expect(stats.totalQueries).toBe(0);
+      expect(stats.staleQueries).toBe(0);
+      expect(stats.fetchingQueries).toBe(0);
+      expect(stats.cacheSize).toBe(0);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/useSPARQLQuery.test.ts
+++ b/packages/obsidian-plugin/tests/unit/useSPARQLQuery.test.ts
@@ -1,0 +1,266 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useSPARQLQuery, useSPARQLQueryWithTransform, prefetchSPARQLQuery } from "../../src/infrastructure/query/useSPARQLQuery";
+import { setQueryClient, getQueryClient, clearQueryCache } from "../../src/infrastructure/query/QueryClientSetup";
+import type ExocortexPlugin from "../../src/ExocortexPlugin";
+import type { QueryResult } from "../../src/application/api/SPARQLApi";
+
+const mockQueryResult: QueryResult = {
+  type: "SELECT",
+  bindings: [
+    { name: { termType: "Literal", value: "Test 1" } },
+    { name: { termType: "Literal", value: "Test 2" } },
+  ],
+};
+
+const createMockPlugin = (sparqlApi: any = null): ExocortexPlugin => ({
+  getSPARQLApi: () => sparqlApi,
+} as unknown as ExocortexPlugin);
+
+const createMockSPARQLApi = (queryFn = jest.fn().mockResolvedValue(mockQueryResult)) => ({
+  query: queryFn,
+});
+
+const createWrapper = (queryClient: QueryClient) => {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe("useSPARQLQuery", () => {
+  let queryClient: QueryClient;
+  let originalClient: QueryClient;
+
+  beforeEach(() => {
+    originalClient = getQueryClient();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+        },
+      },
+    });
+    setQueryClient(queryClient);
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    setQueryClient(originalClient);
+  });
+
+  describe("basic functionality", () => {
+    it("should return loading state initially", () => {
+      const mockApi = createMockSPARQLApi();
+      const plugin = createMockPlugin(mockApi);
+      const wrapper = createWrapper(queryClient);
+
+      const { result } = renderHook(
+        () => useSPARQLQuery(plugin, "SELECT * WHERE { ?s ?p ?o }"),
+        { wrapper }
+      );
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+    });
+
+    it("should fetch data successfully", async () => {
+      const mockApi = createMockSPARQLApi();
+      const plugin = createMockPlugin(mockApi);
+      const wrapper = createWrapper(queryClient);
+
+      const { result } = renderHook(
+        () => useSPARQLQuery(plugin, "SELECT * WHERE { ?s ?p ?o }"),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toEqual(mockQueryResult);
+      expect(mockApi.query).toHaveBeenCalledWith("SELECT * WHERE { ?s ?p ?o }");
+    });
+
+    it("should return error when SPARQL API is not available", async () => {
+      const plugin = createMockPlugin(null);
+      const wrapper = createWrapper(queryClient);
+
+      const { result } = renderHook(
+        () => useSPARQLQuery(plugin, "SELECT * WHERE { ?s ?p ?o }"),
+        { wrapper }
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.fetchStatus).toBe("idle");
+    });
+
+    it("should handle query errors", async () => {
+      const mockError = new Error("Query execution failed");
+      const mockApi = createMockSPARQLApi(jest.fn().mockRejectedValue(mockError));
+      const plugin = createMockPlugin(mockApi);
+      const wrapper = createWrapper(queryClient);
+
+      const { result } = renderHook(
+        () => useSPARQLQuery(plugin, "INVALID QUERY"),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error).toBe(mockError);
+    });
+  });
+
+  describe("options", () => {
+    it("should respect enabled option", () => {
+      const mockApi = createMockSPARQLApi();
+      const plugin = createMockPlugin(mockApi);
+      const wrapper = createWrapper(queryClient);
+
+      const { result } = renderHook(
+        () => useSPARQLQuery(plugin, "SELECT * WHERE { ?s ?p ?o }", { enabled: false }),
+        { wrapper }
+      );
+
+      expect(result.current.fetchStatus).toBe("idle");
+      expect(mockApi.query).not.toHaveBeenCalled();
+    });
+
+    it("should use custom staleTime", async () => {
+      const mockApi = createMockSPARQLApi();
+      const plugin = createMockPlugin(mockApi);
+      const wrapper = createWrapper(queryClient);
+
+      const { result } = renderHook(
+        () => useSPARQLQuery(plugin, "SELECT * WHERE { ?s ?p ?o }", { staleTime: 60000 }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.isStale).toBe(false);
+    });
+  });
+
+  describe("query key normalization", () => {
+    it("should normalize whitespace in query strings", async () => {
+      const mockApi = createMockSPARQLApi();
+      const plugin = createMockPlugin(mockApi);
+      const wrapper = createWrapper(queryClient);
+
+      const { result: result1 } = renderHook(
+        () => useSPARQLQuery(plugin, "SELECT * WHERE { ?s ?p ?o }"),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result1.current.isSuccess).toBe(true));
+
+      const { result: result2 } = renderHook(
+        () => useSPARQLQuery(plugin, "SELECT *   WHERE   { ?s ?p ?o }"),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result2.current.isSuccess).toBe(true));
+
+      expect(mockApi.query).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("useSPARQLQueryWithTransform", () => {
+  let queryClient: QueryClient;
+  let originalClient: QueryClient;
+
+  beforeEach(() => {
+    originalClient = getQueryClient();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+        },
+      },
+    });
+    setQueryClient(queryClient);
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    setQueryClient(originalClient);
+  });
+
+  it("should transform query results", async () => {
+    const mockApi = createMockSPARQLApi();
+    const plugin = createMockPlugin(mockApi);
+    const wrapper = createWrapper(queryClient);
+
+    const transform = (result: QueryResult) => {
+      if (result.type === "SELECT") {
+        return result.bindings.length;
+      }
+      return 0;
+    };
+
+    const { result } = renderHook(
+      () => useSPARQLQueryWithTransform(plugin, "SELECT * WHERE { ?s ?p ?o }", { transform }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBe(2);
+  });
+
+  it("should handle transform errors gracefully", async () => {
+    const mockApi = createMockSPARQLApi();
+    const plugin = createMockPlugin(mockApi);
+    const wrapper = createWrapper(queryClient);
+
+    const transform = () => {
+      throw new Error("Transform failed");
+    };
+
+    const { result } = renderHook(
+      () => useSPARQLQueryWithTransform(plugin, "SELECT * WHERE { ?s ?p ?o }", { transform }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe("Transform failed");
+  });
+});
+
+describe("prefetchSPARQLQuery", () => {
+  let originalClient: QueryClient;
+
+  beforeEach(() => {
+    originalClient = getQueryClient();
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    setQueryClient(queryClient);
+  });
+
+  afterEach(() => {
+    clearQueryCache();
+    setQueryClient(originalClient);
+  });
+
+  it("should resolve immediately when SPARQL API is not available", async () => {
+    const plugin = createMockPlugin(null);
+
+    await expect(prefetchSPARQLQuery(plugin, "SELECT * WHERE { ?s ?p ?o }")).resolves.toBeUndefined();
+  });
+
+  it("should prefetch query and populate cache", async () => {
+    const mockApi = createMockSPARQLApi();
+    const plugin = createMockPlugin(mockApi);
+
+    await prefetchSPARQLQuery(plugin, "SELECT * WHERE { ?s ?p ?o }");
+
+    expect(mockApi.query).toHaveBeenCalledWith("SELECT * WHERE { ?s ?p ?o }");
+  });
+});


### PR DESCRIPTION
## Summary

Implements query caching and memoization infrastructure using React Query (@tanstack/react-query) for improved performance and reduced redundant SPARQL query execution.

### New Infrastructure

- **QueryClientSetup.ts**: Global QueryClient configuration with 5-minute stale time and 10-minute garbage collection
- **QueryProvider.tsx**: React context provider with automatic cache invalidation on file changes (debounced 500ms)
- **useSPARQLQuery.ts**: Custom React hooks for cached SPARQL query execution:
  - `useSPARQLQuery`: Basic query execution with caching
  - `useSPARQLQueryWithTransform`: Query with result transformation
  - `prefetchSPARQLQuery`: Prefetch queries for improved UX
- **WithQueryProvider.tsx**: Wrapper component for easy integration with existing renderers
- **getCacheStatistics**: Cache statistics for debugging and monitoring

### Key Features

- Automatic cache invalidation when vault files change
- Query key normalization for whitespace-insensitive caching
- Configurable stale time and garbage collection
- Support for query transformation and prefetching

### Testing

- Added 25 new unit tests for caching infrastructure
- All 1840+ unit tests passing
- All 55 UI tests passing
- BDD coverage: 100%

## Test Plan

- [x] Run unit tests: `npm run test:unit`
- [x] Run UI tests: `npm run test:ui`
- [x] Run type checking: `npm run check:types`
- [x] Run lint: `npm run lint`
- [ ] Verify CI passes

Closes #441