### PR TITLE
feat: add visual property editor modal (#439)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Exocortex is a powerful Obsidian plugin that transforms your notes into an inter
 - 📦 **Archive Filtering**: Toggle visibility of archived tasks and projects in DailyNote layouts (default: hidden)
 - ⚡ **High Performance**: O(1) relation lookups via reverse indexing
 - 📱 **Mobile Compatible**: Full touch-optimized UI for desktop and mobile
-- ⌨️ **24 Commands**: Comprehensive command palette integration for all operations
+- ⌨️ **25 Commands**: Comprehensive command palette integration for all operations
+- ✏️ **Visual Property Editor**: Edit frontmatter properties through form interface with auto-complete for wiki-links
 - 🎨 **Action Buttons**: Context-aware UI buttons for quick access to relevant commands
 - 🔍 **SPARQL Query Blocks**: Execute semantic queries directly in markdown with `sparql` code blocks - results auto-refresh on vault changes
 

--- a/packages/core/src/domain/commands/CommandVisibility.ts
+++ b/packages/core/src/domain/commands/CommandVisibility.ts
@@ -593,3 +593,11 @@ export function canCreateTaskForDailyNote(
 
   return isCurrentDateGteDay(dailyNoteDate);
 }
+
+/**
+ * Can execute "Edit Properties" command
+ * Available for: any file with frontmatter (has any properties)
+ */
+export function canEditProperties(context: CommandVisibilityContext): boolean {
+  return context.metadata !== null && Object.keys(context.metadata).length > 0;
+}

--- a/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
+++ b/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
@@ -49,6 +49,7 @@ import { ConvertTaskToProjectCommand } from "./ConvertTaskToProjectCommand";
 import { ConvertProjectToTaskCommand } from "./ConvertProjectToTaskCommand";
 import { SetFocusAreaCommand } from "./SetFocusAreaCommand";
 import { OpenQueryBuilderCommand } from "./OpenQueryBuilderCommand";
+import { EditPropertiesCommand } from "./EditPropertiesCommand";
 
 export class CommandRegistry {
   private commands: ICommand[] = [];
@@ -109,6 +110,7 @@ export class CommandRegistry {
       new ConvertProjectToTaskCommand(assetConversionService),
       new SetFocusAreaCommand(app, plugin),
       new OpenQueryBuilderCommand(app, plugin),
+      new EditPropertiesCommand(app),
     ];
   }
 

--- a/packages/obsidian-plugin/src/application/commands/EditPropertiesCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/EditPropertiesCommand.ts
@@ -1,0 +1,38 @@
+import { App, TFile, Notice } from "obsidian";
+import { ICommand } from "./ICommand";
+import { CommandVisibilityContext, canEditProperties, LoggingService } from "@exocortex/core";
+import { PropertyEditorModal } from "../../presentation/modals/PropertyEditorModal";
+
+export class EditPropertiesCommand implements ICommand {
+  id = "edit-properties";
+  name = "Edit properties";
+
+  constructor(private app: App) {}
+
+  checkCallback = (
+    checking: boolean,
+    file: TFile,
+    context: CommandVisibilityContext | null,
+  ): boolean => {
+    if (!context || !canEditProperties(context)) return false;
+
+    if (!checking) {
+      this.execute(file).catch((error) => {
+        new Notice(`Failed to edit properties: ${error.message}`);
+        LoggingService.error("Edit properties error", error);
+      });
+    }
+
+    return true;
+  };
+
+  private async execute(file: TFile): Promise<void> {
+    const modal = new PropertyEditorModal(this.app, file, (result) => {
+      if (!result.cancelled) {
+        const changedCount = Object.keys(result.properties).length;
+        new Notice(`Properties updated: ${file.basename} (${changedCount} properties)`);
+      }
+    });
+    modal.open();
+  }
+}

--- a/packages/obsidian-plugin/src/application/commands/index.ts
+++ b/packages/obsidian-plugin/src/application/commands/index.ts
@@ -26,3 +26,4 @@ export { ReloadLayoutCommand } from "./ReloadLayoutCommand";
 export { TogglePropertiesVisibilityCommand } from "./TogglePropertiesVisibilityCommand";
 export { ToggleLayoutVisibilityCommand } from "./ToggleLayoutVisibilityCommand";
 export { ToggleArchivedAssetsCommand } from "./ToggleArchivedAssetsCommand";
+export { EditPropertiesCommand } from "./EditPropertiesCommand";

--- a/packages/obsidian-plugin/src/presentation/modals/PropertyEditorModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/PropertyEditorModal.ts
@@ -1,0 +1,407 @@
+import { App, Modal, TFile } from "obsidian";
+import { PropertyUpdateService } from "../../application/services/PropertyUpdateService";
+import { WikiLinkSuggestModal } from "./WikiLinkSuggestModal";
+
+export interface PropertyEditorResult {
+  properties: Record<string, any>;
+  cancelled: boolean;
+}
+
+export interface PropertyFieldConfig {
+  key: string;
+  type: "text" | "number" | "boolean" | "select" | "wikilink" | "readonly";
+  label: string;
+  options?: { value: string; label: string }[];
+  placeholder?: string;
+}
+
+export class PropertyEditorModal extends Modal {
+  private properties: Record<string, any> = {};
+  private originalProperties: Record<string, any> = {};
+  private onSubmit: (result: PropertyEditorResult) => void;
+  private file: TFile;
+  private propertyUpdateService: PropertyUpdateService;
+  private inputElements: Map<string, HTMLInputElement | HTMLSelectElement> = new Map();
+
+  constructor(
+    app: App,
+    file: TFile,
+    onSubmit: (result: PropertyEditorResult) => void,
+  ) {
+    super(app);
+    this.file = file;
+    this.onSubmit = onSubmit;
+    this.propertyUpdateService = new PropertyUpdateService(app);
+    this.loadProperties();
+  }
+
+  private loadProperties(): void {
+    const cache = this.app.metadataCache.getFileCache(this.file);
+    if (cache?.frontmatter) {
+      this.properties = { ...cache.frontmatter };
+      delete this.properties.position;
+      this.originalProperties = { ...this.properties };
+    }
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+
+    contentEl.addClass("exocortex-property-editor-modal");
+
+    contentEl.createEl("h2", { text: "Edit properties" });
+
+    contentEl.createEl("p", {
+      text: this.file.basename,
+      cls: "exocortex-modal-filename exocortex-modal-description",
+    });
+
+    const formContainer = contentEl.createDiv({
+      cls: "exocortex-property-form",
+    });
+
+    this.renderPropertyFields(formContainer);
+
+    const buttonContainer = contentEl.createDiv({
+      cls: "modal-button-container",
+    });
+
+    const saveButton = buttonContainer.createEl("button", {
+      text: "Save",
+      cls: "mod-cta",
+    });
+    saveButton.addEventListener("click", () => this.submit());
+
+    const cancelButton = buttonContainer.createEl("button", {
+      text: "Cancel",
+    });
+    cancelButton.addEventListener("click", () => this.cancel());
+
+    contentEl.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        this.cancel();
+      }
+    });
+  }
+
+  private renderPropertyFields(container: HTMLElement): void {
+    const sortedKeys = Object.keys(this.properties).sort();
+
+    if (sortedKeys.length === 0) {
+      container.createEl("p", {
+        text: "No properties found in frontmatter.",
+        cls: "exocortex-modal-description",
+      });
+      return;
+    }
+
+    for (const key of sortedKeys) {
+      const value = this.properties[key];
+      const fieldConfig = this.inferFieldConfig(key, value);
+      this.renderField(container, fieldConfig, value);
+    }
+  }
+
+  private inferFieldConfig(key: string, value: any): PropertyFieldConfig {
+    if (key === "exo__Asset_uid" || key.endsWith("_createdAt")) {
+      return { key, type: "readonly", label: this.formatLabel(key) };
+    }
+
+    if (this.isWikiLink(value)) {
+      return { key, type: "wikilink", label: this.formatLabel(key) };
+    }
+
+    if (key === "ems__Effort_status") {
+      return {
+        key,
+        type: "select",
+        label: this.formatLabel(key),
+        options: [
+          { value: '"[[ems__EffortStatusDraft]]"', label: "Draft" },
+          { value: '"[[ems__EffortStatusBacklog]]"', label: "Backlog" },
+          { value: '"[[ems__EffortStatusAnalysis]]"', label: "Analysis" },
+          { value: '"[[ems__EffortStatusToDo]]"', label: "To Do" },
+          { value: '"[[ems__EffortStatusDoing]]"', label: "Doing" },
+          { value: '"[[ems__EffortStatusDone]]"', label: "Done" },
+          { value: '"[[ems__EffortStatusTrashed]]"', label: "Trashed" },
+        ],
+      };
+    }
+
+    if (key === "ems__Task_size") {
+      return {
+        key,
+        type: "select",
+        label: this.formatLabel(key),
+        options: [
+          { value: "", label: "Not specified" },
+          { value: '"[[ems__TaskSize_XXS]]"', label: "XXS" },
+          { value: '"[[ems__TaskSize_XS]]"', label: "XS" },
+          { value: '"[[ems__TaskSize_S]]"', label: "S" },
+          { value: '"[[ems__TaskSize_M]]"', label: "M" },
+          { value: '"[[ems__TaskSize_L]]"', label: "L" },
+          { value: '"[[ems__TaskSize_XL]]"', label: "XL" },
+        ],
+      };
+    }
+
+    if (typeof value === "boolean") {
+      return { key, type: "boolean", label: this.formatLabel(key) };
+    }
+
+    if (typeof value === "number") {
+      return { key, type: "number", label: this.formatLabel(key) };
+    }
+
+    return { key, type: "text", label: this.formatLabel(key) };
+  }
+
+  private isWikiLink(value: any): boolean {
+    if (typeof value !== "string") return false;
+    return /^\[\[.+\]\]$/.test(value) || /^"\[\[.+\]\]"$/.test(value);
+  }
+
+  private formatLabel(key: string): string {
+    const parts = key.split("__");
+    const lastPart = parts[parts.length - 1];
+    const withoutPrefix = lastPart.replace(/^[A-Z][a-z]+_/, "");
+    return withoutPrefix
+      .replace(/_/g, " ")
+      .replace(/([a-z])([A-Z])/g, "$1 $2")
+      .toLowerCase();
+  }
+
+  private renderField(
+    container: HTMLElement,
+    config: PropertyFieldConfig,
+    value: any,
+  ): void {
+    const fieldContainer = container.createDiv({
+      cls: "exocortex-property-field",
+    });
+
+    fieldContainer.createEl("label", {
+      text: config.label,
+      cls: "exocortex-property-label",
+    });
+
+    switch (config.type) {
+      case "readonly":
+        this.renderReadonlyField(fieldContainer, config, value);
+        break;
+      case "select":
+        this.renderSelectField(fieldContainer, config, value);
+        break;
+      case "boolean":
+        this.renderBooleanField(fieldContainer, config, value);
+        break;
+      case "number":
+        this.renderNumberField(fieldContainer, config, value);
+        break;
+      case "wikilink":
+        this.renderWikiLinkField(fieldContainer, config, value);
+        break;
+      default:
+        this.renderTextField(fieldContainer, config, value);
+    }
+  }
+
+  private renderReadonlyField(
+    container: HTMLElement,
+    _config: PropertyFieldConfig,
+    value: any,
+  ): void {
+    const displayValue = this.formatDisplayValue(value);
+    container.createEl("span", {
+      text: displayValue,
+      cls: "exocortex-property-readonly",
+    });
+  }
+
+  private renderSelectField(
+    container: HTMLElement,
+    config: PropertyFieldConfig,
+    value: any,
+  ): void {
+    const selectEl = container.createEl("select", {
+      cls: "exocortex-modal-select dropdown",
+    });
+
+    for (const option of config.options || []) {
+      const optionEl = selectEl.createEl("option", {
+        value: option.value,
+        text: option.label,
+      });
+
+      const currentValue = this.formatDisplayValue(value);
+      const optionValue = this.formatDisplayValue(option.value);
+      if (currentValue === optionValue) {
+        optionEl.selected = true;
+      }
+    }
+
+    selectEl.addEventListener("change", () => {
+      this.properties[config.key] = selectEl.value || null;
+    });
+
+    this.inputElements.set(config.key, selectEl);
+  }
+
+  private renderBooleanField(
+    container: HTMLElement,
+    config: PropertyFieldConfig,
+    value: any,
+  ): void {
+    const checkboxWrapper = container.createDiv({
+      cls: "exocortex-modal-checkbox-wrapper",
+    });
+
+    const checkboxEl = checkboxWrapper.createEl("input", {
+      type: "checkbox",
+    }) as HTMLInputElement;
+    checkboxEl.checked = Boolean(value);
+
+    checkboxEl.addEventListener("change", () => {
+      this.properties[config.key] = checkboxEl.checked;
+    });
+
+    this.inputElements.set(config.key, checkboxEl);
+  }
+
+  private renderNumberField(
+    container: HTMLElement,
+    config: PropertyFieldConfig,
+    value: any,
+  ): void {
+    const inputEl = container.createEl("input", {
+      type: "number",
+      cls: "exocortex-modal-input",
+    }) as HTMLInputElement;
+    inputEl.value = String(value ?? "");
+
+    inputEl.addEventListener("input", () => {
+      const numValue = inputEl.value === "" ? null : Number(inputEl.value);
+      this.properties[config.key] = numValue;
+    });
+
+    this.inputElements.set(config.key, inputEl);
+  }
+
+  private renderWikiLinkField(
+    container: HTMLElement,
+    config: PropertyFieldConfig,
+    value: any,
+  ): void {
+    const inputWrapper = container.createDiv({
+      cls: "exocortex-wikilink-input-wrapper",
+    });
+
+    const inputEl = inputWrapper.createEl("input", {
+      type: "text",
+      cls: "exocortex-modal-input",
+      placeholder: "[[file-name]]",
+    }) as HTMLInputElement;
+    inputEl.value = this.formatDisplayValue(value);
+
+    inputEl.addEventListener("input", () => {
+      this.properties[config.key] = this.normalizeWikiLink(inputEl.value);
+    });
+
+    const browseButton = inputWrapper.createEl("button", {
+      text: "...",
+      cls: "exocortex-browse-button",
+    });
+    browseButton.addEventListener("click", () => {
+      this.openFileSuggest(config.key, inputEl);
+    });
+
+    this.inputElements.set(config.key, inputEl);
+  }
+
+  private renderTextField(
+    container: HTMLElement,
+    config: PropertyFieldConfig,
+    value: any,
+  ): void {
+    const inputEl = container.createEl("input", {
+      type: "text",
+      cls: "exocortex-modal-input",
+      placeholder: config.placeholder || "",
+    }) as HTMLInputElement;
+    inputEl.value = String(value ?? "");
+
+    inputEl.addEventListener("input", () => {
+      this.properties[config.key] = inputEl.value || null;
+    });
+
+    this.inputElements.set(config.key, inputEl);
+  }
+
+  private formatDisplayValue(value: any): string {
+    if (value === null || value === undefined) return "";
+    if (typeof value === "string") {
+      return value.replace(/^"|"$/g, "");
+    }
+    if (Array.isArray(value)) {
+      return value.map((v) => this.formatDisplayValue(v)).join(", ");
+    }
+    return String(value);
+  }
+
+  private normalizeWikiLink(value: string): string {
+    if (!value) return "";
+    const trimmed = value.trim();
+    if (trimmed.startsWith("[[") && trimmed.endsWith("]]")) {
+      return `"${trimmed}"`;
+    }
+    return trimmed;
+  }
+
+  private openFileSuggest(propertyKey: string, inputEl: HTMLInputElement): void {
+    const suggestModal = new WikiLinkSuggestModal(this.app, (result) => {
+      if (result.wikiLink && result.file) {
+        inputEl.value = `[[${result.file.basename}]]`;
+        this.properties[propertyKey] = result.wikiLink;
+      }
+    });
+    suggestModal.open();
+  }
+
+  private async submit(): Promise<void> {
+    const changedProperties: Record<string, any> = {};
+
+    for (const [key, newValue] of Object.entries(this.properties)) {
+      const originalValue = this.originalProperties[key];
+      if (JSON.stringify(newValue) !== JSON.stringify(originalValue)) {
+        changedProperties[key] = newValue;
+      }
+    }
+
+    if (Object.keys(changedProperties).length > 0) {
+      for (const [key, value] of Object.entries(changedProperties)) {
+        await this.propertyUpdateService.updateProperty(this.file, key, value);
+      }
+    }
+
+    this.onSubmit({
+      properties: this.properties,
+      cancelled: false,
+    });
+    this.close();
+  }
+
+  private cancel(): void {
+    this.onSubmit({
+      properties: this.originalProperties,
+      cancelled: true,
+    });
+    this.close();
+  }
+
+  override onClose(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    this.inputElements.clear();
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/modals/WikiLinkSuggestModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/WikiLinkSuggestModal.ts
@@ -1,0 +1,40 @@
+import { App, FuzzySuggestModal, TFile } from "obsidian";
+
+export interface WikiLinkSuggestResult {
+  file: TFile | null;
+  wikiLink: string | null;
+}
+
+export class WikiLinkSuggestModal extends FuzzySuggestModal<TFile> {
+  private onSelect: (result: WikiLinkSuggestResult) => void;
+  private files: TFile[];
+
+  constructor(app: App, onSelect: (result: WikiLinkSuggestResult) => void) {
+    super(app);
+    this.onSelect = onSelect;
+    this.files = this.app.vault.getMarkdownFiles();
+    this.setPlaceholder("Search for a file...");
+  }
+
+  override getItems(): TFile[] {
+    return this.files;
+  }
+
+  override getItemText(file: TFile): string {
+    return file.basename;
+  }
+
+  override onChooseItem(file: TFile, _evt: MouseEvent | KeyboardEvent): void {
+    this.onSelect({
+      file,
+      wikiLink: `"[[${file.basename}]]"`,
+    });
+  }
+
+  override onNoSuggestion(): void {
+    this.onSelect({
+      file: null,
+      wikiLink: null,
+    });
+  }
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -1952,3 +1952,52 @@
   border-radius: 3px;
   background-color: var(--background-modifier-error-hover);
 }
+
+/* ============================================================================
+   Property Editor Modal
+   ============================================================================ */
+
+.exocortex-property-editor-modal .exocortex-property-form {
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.exocortex-property-editor-modal .exocortex-property-field {
+  margin-bottom: 12px;
+}
+
+.exocortex-property-editor-modal .exocortex-property-label {
+  display: block;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
+.exocortex-property-editor-modal .exocortex-property-readonly {
+  color: var(--text-muted);
+  font-family: var(--font-monospace);
+}
+
+.exocortex-property-editor-modal .exocortex-modal-select,
+.exocortex-property-editor-modal .exocortex-modal-input {
+  width: 100%;
+}
+
+.exocortex-property-editor-modal .exocortex-modal-checkbox-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.exocortex-property-editor-modal .exocortex-wikilink-input-wrapper {
+  display: flex;
+  gap: 8px;
+}
+
+.exocortex-property-editor-modal .exocortex-wikilink-input-wrapper .exocortex-modal-input {
+  flex: 1;
+}
+
+.exocortex-property-editor-modal .exocortex-browse-button {
+  padding: 4px 12px;
+}

--- a/packages/obsidian-plugin/tests/__mocks__/obsidian.ts
+++ b/packages/obsidian-plugin/tests/__mocks__/obsidian.ts
@@ -252,6 +252,32 @@ export class Modal {
   onClose(): void {}
 }
 
+export class FuzzySuggestModal<T> {
+  app: App;
+  inputEl: HTMLInputElement;
+  resultContainerEl: HTMLElement;
+
+  constructor(app: App) {
+    this.app = app;
+    this.inputEl = document.createElement("input");
+    this.resultContainerEl = document.createElement("div");
+  }
+
+  open(): void {}
+  close(): void {}
+  setPlaceholder(placeholder: string): void {
+    this.inputEl.placeholder = placeholder;
+  }
+  getItems(): T[] {
+    return [];
+  }
+  getItemText(item: T): string {
+    return "";
+  }
+  onChooseItem(item: T, evt: MouseEvent | KeyboardEvent): void {}
+  onNoSuggestion(): void {}
+}
+
 export class PluginSettingTab {
   app: App;
   containerEl: HTMLElement;

--- a/packages/obsidian-plugin/tests/unit/CommandManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CommandManager.test.ts
@@ -147,7 +147,7 @@ describe("CommandManager", () => {
         commandManager.registerAllCommands(mockPlugin);
       }).not.toThrow();
 
-      expect(mockPlugin.addCommand).toHaveBeenCalledTimes(31);
+      expect(mockPlugin.addCommand).toHaveBeenCalledTimes(32);
     });
 
     it("should register commands with correct IDs", () => {
@@ -189,6 +189,7 @@ describe("CommandManager", () => {
       );
       expect(registeredCommandIds).toContain("set-focus-area");
       expect(registeredCommandIds).toContain("open-sparql-query-builder");
+      expect(registeredCommandIds).toContain("edit-properties");
     });
 
     it("should register commands with correct names", () => {
@@ -227,6 +228,7 @@ describe("CommandManager", () => {
       expect(registeredNames).toContain("Toggle layout visibility");
       expect(registeredNames).toContain("Toggle archived assets visibility");
       expect(registeredNames).toContain("open sparql query builder");
+      expect(registeredNames).toContain("Edit properties");
     });
 
     it("should register commands with checkCallback or callback function", () => {
@@ -285,6 +287,7 @@ describe("CommandManager", () => {
       "rename-to-uid",
       "vote-on-effort",
       "copy-label-to-aliases",
+      "edit-properties",
     ];
 
     checkCallbackCommands.forEach((commandId) => {

--- a/packages/obsidian-plugin/tests/unit/CommandVisibility.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CommandVisibility.test.ts
@@ -24,6 +24,7 @@ import {
   canConvertProjectToTask,
   canCreateTaskForDailyNote,
   canCreateSubclass,
+  canEditProperties,
   AssetClass,
 } from "@exocortex/core";
 
@@ -2583,6 +2584,68 @@ describe("CommandVisibility", () => {
         expectedFolder: null,
       };
       expect(canCreateSubclass(context)).toBe(false);
+    });
+  });
+
+  describe("canEditProperties", () => {
+    it("should return true when metadata has properties", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__Task]]",
+        currentStatus: null,
+        metadata: { exo__Asset_label: "Test" },
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canEditProperties(context)).toBe(true);
+    });
+
+    it("should return true for any asset class with frontmatter", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[exo__Class]]",
+        currentStatus: null,
+        metadata: { exo__Asset_uid: "123-456" },
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canEditProperties(context)).toBe(true);
+    });
+
+    it("should return false when metadata is null", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__Task]]",
+        currentStatus: null,
+        metadata: null,
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canEditProperties(context)).toBe(false);
+    });
+
+    it("should return false when metadata is empty object", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__Task]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canEditProperties(context)).toBe(false);
+    });
+
+    it("should return true even for archived assets", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__Task]]",
+        currentStatus: null,
+        metadata: { exo__Asset_label: "Test" },
+        isArchived: true,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canEditProperties(context)).toBe(true);
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/commands-index.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands-index.test.ts
@@ -49,15 +49,15 @@ describe("Commands Index Exports", () => {
     });
   });
 
-  it("should export exactly 27 command classes and 1 registry", () => {
+  it("should export exactly 28 command classes and 1 registry", () => {
     // Filter out type exports (which don't appear at runtime)
     const exports = Object.keys(commandsIndex);
     const commandClasses = exports.filter((key) => key.endsWith("Command"));
     const registryClasses = exports.filter((key) => key.endsWith("Registry"));
 
-    expect(commandClasses.length).toBe(26); // All commands
+    expect(commandClasses.length).toBe(27); // All commands
     expect(registryClasses.length).toBe(1); // CommandRegistry
-    expect(exports.length).toBe(27); // Total exports (excluding ICommand type)
+    expect(exports.length).toBe(28); // Total exports (excluding ICommand type)
   });
 
   it("should have all exported classes be constructable", () => {


### PR DESCRIPTION
## Summary
- Add PropertyEditorModal for editing frontmatter properties through a form interface
- Add WikiLinkSuggestModal with fuzzy search for file selection
- Add Edit Properties command accessible from right-click menu

## Features
- **Type-specific inputs**: Text, number, boolean, select, wikilink, and readonly fields
- **Auto-complete**: WikiLink fields use FuzzySuggestModal for file selection
- **Smart property detection**: Automatically infers field type from property name and value
- **Minimal writes**: Only saves properties that have changed
- **Status/Size dropdowns**: Pre-defined options for effort status and task size

## Technical Changes
- `PropertyEditorModal.ts`: Main modal with form rendering and property management
- `WikiLinkSuggestModal.ts`: Fuzzy search modal extending Obsidian's FuzzySuggestModal
- `EditPropertiesCommand.ts`: Command to open the modal from right-click menu
- `canEditProperties()`: Visibility function in CommandVisibility.ts
- CSS styles in styles.css for the property editor modal

## Test plan
- [x] Unit tests for canEditProperties visibility function
- [x] Command registration tests updated (32 commands)
- [x] Commands index tests updated (28 exports)
- [x] All unit tests pass (803 tests)
- [x] Component tests pass (354 tests)
- [x] Lint passes (no errors)

Closes #439