### PR TITLE
feat(obsidian-plugin): migrate renderers to IVaultAdapter (Issue #443 Phase 3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,6 +86,7 @@ export {
 export type {
   IVaultAdapter,
   IFile,
+  IFileStat,
   IFolder,
   IFrontmatter,
 } from "./interfaces/IVaultAdapter";

--- a/packages/core/src/interfaces/IVaultAdapter.ts
+++ b/packages/core/src/interfaces/IVaultAdapter.ts
@@ -1,8 +1,14 @@
+export interface IFileStat {
+  ctime: number;
+  mtime: number;
+}
+
 export interface IFile {
   path: string;
   basename: string;
   name: string;
   parent: IFolder | null;
+  stat?: IFileStat;
 }
 
 export interface IFolder {

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -59,6 +59,7 @@ export default class ExocortexPlugin extends Plugin {
         this.app,
         this.settings,
         this,
+        this.vaultAdapter,
       );
       this.taskStatusService = new TaskStatusService(this.vaultAdapter);
       this.taskTrackingService = new TaskTrackingService(

--- a/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
+++ b/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
@@ -111,6 +111,12 @@ export class ObsidianVaultAdapter implements IVaultAdapter {
       basename: file.basename,
       name: file.name,
       parent: file.parent ? this.fromObsidianFolder(file.parent) : null,
+      stat: file.stat
+        ? {
+            ctime: file.stat.ctime,
+            mtime: file.stat.mtime,
+          }
+        : undefined,
     };
     this.fileCache.set(iFile, file);
     return iFile;

--- a/packages/obsidian-plugin/src/presentation/renderers/DailyProjectsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyProjectsRenderer.ts
@@ -7,7 +7,7 @@ import {
   DailyProject,
   DailyProjectsTableWithToggle,
 } from "../components/DailyProjectsTable";
-import { AssetClass, EffortStatus } from "@exocortex/core";
+import { AssetClass, EffortStatus, IVaultAdapter } from "@exocortex/core";
 import { MetadataExtractor } from "@exocortex/core";
 import { EffortSortingHelpers } from "@exocortex/core";
 import { BlockerHelpers } from "../utils/BlockerHelpers";
@@ -24,6 +24,7 @@ export class DailyProjectsRenderer {
   private reactRenderer: ReactRenderer;
   private refresh: () => Promise<void>;
   private getAssetLabelCallback: (path: string) => string | null;
+  private vaultAdapter: IVaultAdapter;
 
   constructor(
     app: ObsidianApp,
@@ -35,6 +36,7 @@ export class DailyProjectsRenderer {
     refresh: () => Promise<void>,
     getAssetLabel: (path: string) => string | null,
     _getEffortArea: (metadata: Record<string, unknown>) => string | null,
+    vaultAdapter: IVaultAdapter,
   ) {
     this.app = app;
     this.settings = settings;
@@ -44,6 +46,7 @@ export class DailyProjectsRenderer {
     this.reactRenderer = reactRenderer;
     this.refresh = refresh;
     this.getAssetLabelCallback = getAssetLabel;
+    this.vaultAdapter = vaultAdapter;
   }
 
   public async render(
@@ -160,7 +163,7 @@ export class DailyProjectsRenderer {
     try {
       const projects: DailyProject[] = [];
 
-      const allFiles = this.app.vault.getMarkdownFiles();
+      const allFiles = this.vaultAdapter.getAllFiles();
 
       for (const file of allFiles) {
         const metadata = this.metadataExtractor.extractMetadata(file);

--- a/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
@@ -7,7 +7,7 @@ import {
   DailyTask,
   DailyTasksTableWithToggle,
 } from "../components/DailyTasksTable";
-import { AssetClass, EffortStatus } from "@exocortex/core";
+import { AssetClass, EffortStatus, IVaultAdapter } from "@exocortex/core";
 import { MetadataExtractor } from "@exocortex/core";
 import { EffortSortingHelpers } from "@exocortex/core";
 import { AssetMetadataService } from "./layout/helpers/AssetMetadataService";
@@ -25,6 +25,7 @@ export class DailyTasksRenderer {
   private reactRenderer: ReactRenderer;
   private refresh: () => Promise<void>;
   private metadataService: AssetMetadataService;
+  private vaultAdapter: IVaultAdapter;
 
   constructor(
     app: ObsidianApp,
@@ -35,6 +36,7 @@ export class DailyTasksRenderer {
     reactRenderer: ReactRenderer,
     refresh: () => Promise<void>,
     metadataService: AssetMetadataService,
+    vaultAdapter: IVaultAdapter,
   ) {
     this.app = app;
     this.settings = settings;
@@ -44,6 +46,7 @@ export class DailyTasksRenderer {
     this.reactRenderer = reactRenderer;
     this.refresh = refresh;
     this.metadataService = metadataService;
+    this.vaultAdapter = vaultAdapter;
   }
 
   public async render(
@@ -171,7 +174,7 @@ export class DailyTasksRenderer {
     try {
       const tasks: DailyTask[] = [];
 
-      const allFiles = this.app.vault.getMarkdownFiles();
+      const allFiles = this.vaultAdapter.getAllFiles();
 
       for (const file of allFiles) {
         const metadata = this.metadataExtractor.extractMetadata(file);
@@ -303,7 +306,7 @@ export class DailyTasksRenderer {
     }
     visited.add(areaName);
 
-    const allFiles = this.app.vault.getMarkdownFiles();
+    const allFiles = this.vaultAdapter.getAllFiles();
 
     for (const file of allFiles) {
       const metadata = this.metadataExtractor.extractMetadata(file);

--- a/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
@@ -1,6 +1,6 @@
 import { TFile } from "obsidian";
 import { ILogger } from "../../../adapters/logging/ILogger";
-import { MetadataExtractor } from "@exocortex/core";
+import { MetadataExtractor, IVaultAdapter, IFile } from "@exocortex/core";
 
 export interface DailyNoteInfo {
   isDailyNote: boolean;
@@ -12,7 +12,7 @@ export class DailyNoteHelpers {
    * Checks if a file is a daily note and extracts the day property
    */
   static extractDailyNoteInfo(
-    file: TFile,
+    file: TFile | IFile,
     metadataExtractor: MetadataExtractor,
     logger?: ILogger,
   ): DailyNoteInfo {
@@ -48,11 +48,11 @@ export class DailyNoteHelpers {
   }
 
   static findDailyNoteByDate(
-    app: any,
+    vaultAdapter: IVaultAdapter,
     metadataExtractor: MetadataExtractor,
     dateStr: string,
-  ): TFile | null {
-    const files = app.vault.getMarkdownFiles();
+  ): IFile | null {
+    const files = vaultAdapter.getAllFiles();
 
     for (const file of files) {
       const dailyNoteInfo = this.extractDailyNoteInfo(

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/AreaTreeRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/AreaTreeRenderer.ts
@@ -1,9 +1,8 @@
 import { TFile, Keymap } from "obsidian";
 import React from "react";
 import { ReactRenderer } from "../../utils/ReactRenderer";
-import { MetadataExtractor, AssetClass, AreaHierarchyBuilder } from "@exocortex/core";
+import { MetadataExtractor, AssetClass, AreaHierarchyBuilder, IVaultAdapter } from "@exocortex/core";
 import { AreaHierarchyTree } from "../../components/AreaHierarchyTree";
-import { ObsidianVaultAdapter } from "../../../adapters/ObsidianVaultAdapter";
 import { AssetMetadataService } from "./helpers/AssetMetadataService";
 import { AssetRelation } from "./types";
 import { ILogger } from "../../../adapters/logging/ILogger";
@@ -15,7 +14,7 @@ export class AreaTreeRenderer {
     private app: ObsidianApp,
     private reactRenderer: ReactRenderer,
     private metadataExtractor: MetadataExtractor,
-    private vaultAdapter: ObsidianVaultAdapter,
+    private vaultAdapter: IVaultAdapter,
     private metadataService: AssetMetadataService,
     private logger: ILogger,
   ) {}

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/types.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/types.ts
@@ -1,7 +1,10 @@
-import { TFile } from "obsidian";
+export interface AssetRelationFile {
+  path: string;
+  basename: string;
+}
 
 export interface AssetRelation {
-  file: TFile;
+  file: AssetRelationFile;
   path: string;
   title: string;
   metadata: Record<string, any>;

--- a/packages/obsidian-plugin/tests/ui/ActionButtonsLayout.ui.test.ts
+++ b/packages/obsidian-plugin/tests/ui/ActionButtonsLayout.ui.test.ts
@@ -21,6 +21,7 @@ describe("Layout Settings and Structure", () => {
   let mockMetadataCache: MetadataCache;
   let mockPlugin: any;
   let mockDIVault: any;
+  let mockVaultAdapter: any;
 
   beforeEach(() => {
     container.clearInstances();
@@ -85,8 +86,33 @@ describe("Layout Settings and Structure", () => {
     container.register(AlgorithmExtractor, { useClass: AlgorithmExtractor });
     container.register(TaskCreationService, { useClass: TaskCreationService });
 
+    mockVaultAdapter = {
+      getAllFiles: jest.fn().mockReturnValue([]),
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn((path: string) => {
+        return mockVault.getAbstractFileByPath(path);
+      }),
+      getFrontmatter: jest.fn((file: any) => {
+        const cache = mockMetadataCache.getFileCache(file);
+        return cache?.frontmatter || {};
+      }),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn((linkpath: string) => {
+        return mockMetadataCache.getFirstLinkpathDest(linkpath, "");
+      }),
+      process: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+      updateLinks: jest.fn(),
+    };
+
     const settings: ExocortexSettings = { ...DEFAULT_SETTINGS };
-    renderer = new UniversalLayoutRenderer(mockApp, settings, mockPlugin);
+    renderer = new UniversalLayoutRenderer(mockApp, settings, mockPlugin, mockVaultAdapter);
   });
 
   afterEach(() => {
@@ -99,7 +125,7 @@ describe("Layout Settings and Structure", () => {
         ...DEFAULT_SETTINGS,
         showPropertiesSection: false,
       };
-      renderer = new UniversalLayoutRenderer(mockApp, settings, mockPlugin);
+      renderer = new UniversalLayoutRenderer(mockApp, settings, mockPlugin, mockVaultAdapter);
 
       const mockFile = {
         path: "test-area.md",
@@ -149,7 +175,7 @@ describe("Layout Settings and Structure", () => {
         ...DEFAULT_SETTINGS,
         showPropertiesSection: true,
       };
-      renderer = new UniversalLayoutRenderer(mockApp, settings, mockPlugin);
+      renderer = new UniversalLayoutRenderer(mockApp, settings, mockPlugin, mockVaultAdapter);
 
       const container = document.createElement("div");
       await renderer.render("", container, {} as any);
@@ -170,7 +196,7 @@ describe("Layout Settings and Structure", () => {
         ...DEFAULT_SETTINGS,
         showPropertiesSection: true,
       };
-      renderer = new UniversalLayoutRenderer(mockApp, settings, mockPlugin);
+      renderer = new UniversalLayoutRenderer(mockApp, settings, mockPlugin, mockVaultAdapter);
 
       const mockFile = {
         path: "test-area.md",

--- a/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.test.ts
+++ b/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.test.ts
@@ -84,18 +84,16 @@ describe("DailyNoteHelpers", () => {
 
   describe("findDailyNoteByDate", () => {
     it("should find DailyNote by date when it exists", () => {
-      const mockFile1 = { path: "2025-10-14.md" } as TFile;
-      const mockFile2 = { path: "2025-10-15.md" } as TFile;
-      const mockFile3 = { path: "2025-10-16.md" } as TFile;
+      const mockFile1 = { path: "2025-10-14.md", basename: "2025-10-14", name: "2025-10-14.md", parent: null };
+      const mockFile2 = { path: "2025-10-15.md", basename: "2025-10-15", name: "2025-10-15.md", parent: null };
+      const mockFile3 = { path: "2025-10-16.md", basename: "2025-10-16", name: "2025-10-16.md", parent: null };
 
-      const mockApp = {
-        vault: {
-          getMarkdownFiles: jest.fn().mockReturnValue([
-            mockFile1,
-            mockFile2,
-            mockFile3,
-          ]),
-        },
+      const mockVaultAdapter = {
+        getAllFiles: jest.fn().mockReturnValue([
+          mockFile1,
+          mockFile2,
+          mockFile3,
+        ]),
       };
 
       mockMetadataExtractor.extractMetadata
@@ -108,7 +106,7 @@ describe("DailyNoteHelpers", () => {
       );
 
       const result = DailyNoteHelpers.findDailyNoteByDate(
-        mockApp,
+        mockVaultAdapter as any,
         mockMetadataExtractor,
         "2025-10-15",
       );
@@ -117,13 +115,11 @@ describe("DailyNoteHelpers", () => {
     });
 
     it("should return null when DailyNote for given date does not exist", () => {
-      const mockFile1 = { path: "2025-10-14.md" } as TFile;
-      const mockFile2 = { path: "2025-10-16.md" } as TFile;
+      const mockFile1 = { path: "2025-10-14.md", basename: "2025-10-14", name: "2025-10-14.md", parent: null };
+      const mockFile2 = { path: "2025-10-16.md", basename: "2025-10-16", name: "2025-10-16.md", parent: null };
 
-      const mockApp = {
-        vault: {
-          getMarkdownFiles: jest.fn().mockReturnValue([mockFile1, mockFile2]),
-        },
+      const mockVaultAdapter = {
+        getAllFiles: jest.fn().mockReturnValue([mockFile1, mockFile2]),
       };
 
       mockMetadataExtractor.extractMetadata
@@ -135,7 +131,7 @@ describe("DailyNoteHelpers", () => {
       );
 
       const result = DailyNoteHelpers.findDailyNoteByDate(
-        mockApp,
+        mockVaultAdapter as any,
         mockMetadataExtractor,
         "2025-10-15",
       );
@@ -144,14 +140,12 @@ describe("DailyNoteHelpers", () => {
     });
 
     it("should return null when no markdown files exist", () => {
-      const mockApp = {
-        vault: {
-          getMarkdownFiles: jest.fn().mockReturnValue([]),
-        },
+      const mockVaultAdapter = {
+        getAllFiles: jest.fn().mockReturnValue([]),
       };
 
       const result = DailyNoteHelpers.findDailyNoteByDate(
-        mockApp,
+        mockVaultAdapter as any,
         mockMetadataExtractor,
         "2025-10-15",
       );
@@ -160,12 +154,10 @@ describe("DailyNoteHelpers", () => {
     });
 
     it("should handle DailyNote with day property without brackets", () => {
-      const mockFile1 = { path: "2025-10-15.md" } as TFile;
+      const mockFile1 = { path: "2025-10-15.md", basename: "2025-10-15", name: "2025-10-15.md", parent: null };
 
-      const mockApp = {
-        vault: {
-          getMarkdownFiles: jest.fn().mockReturnValue([mockFile1]),
-        },
+      const mockVaultAdapter = {
+        getAllFiles: jest.fn().mockReturnValue([mockFile1]),
       };
 
       mockMetadataExtractor.extractMetadata.mockReturnValue({
@@ -177,7 +169,7 @@ describe("DailyNoteHelpers", () => {
       );
 
       const result = DailyNoteHelpers.findDailyNoteByDate(
-        mockApp,
+        mockVaultAdapter as any,
         mockMetadataExtractor,
         "2025-10-15",
       );
@@ -186,13 +178,11 @@ describe("DailyNoteHelpers", () => {
     });
 
     it("should skip non-DailyNote files", () => {
-      const mockFile1 = { path: "task.md" } as TFile;
-      const mockFile2 = { path: "2025-10-15.md" } as TFile;
+      const mockFile1 = { path: "task.md", basename: "task", name: "task.md", parent: null };
+      const mockFile2 = { path: "2025-10-15.md", basename: "2025-10-15", name: "2025-10-15.md", parent: null };
 
-      const mockApp = {
-        vault: {
-          getMarkdownFiles: jest.fn().mockReturnValue([mockFile1, mockFile2]),
-        },
+      const mockVaultAdapter = {
+        getAllFiles: jest.fn().mockReturnValue([mockFile1, mockFile2]),
       };
 
       mockMetadataExtractor.extractMetadata
@@ -204,7 +194,7 @@ describe("DailyNoteHelpers", () => {
         .mockReturnValueOnce("[[pn__DailyNote]]");
 
       const result = DailyNoteHelpers.findDailyNoteByDate(
-        mockApp,
+        mockVaultAdapter as any,
         mockMetadataExtractor,
         "2025-10-15",
       );
@@ -213,13 +203,11 @@ describe("DailyNoteHelpers", () => {
     });
 
     it("should skip DailyNote files without pn__DailyNote_day property", () => {
-      const mockFile1 = { path: "daily-1.md" } as TFile;
-      const mockFile2 = { path: "2025-10-15.md" } as TFile;
+      const mockFile1 = { path: "daily-1.md", basename: "daily-1", name: "daily-1.md", parent: null };
+      const mockFile2 = { path: "2025-10-15.md", basename: "2025-10-15", name: "2025-10-15.md", parent: null };
 
-      const mockApp = {
-        vault: {
-          getMarkdownFiles: jest.fn().mockReturnValue([mockFile1, mockFile2]),
-        },
+      const mockVaultAdapter = {
+        getAllFiles: jest.fn().mockReturnValue([mockFile1, mockFile2]),
       };
 
       mockMetadataExtractor.extractMetadata
@@ -231,7 +219,7 @@ describe("DailyNoteHelpers", () => {
       );
 
       const result = DailyNoteHelpers.findDailyNoteByDate(
-        mockApp,
+        mockVaultAdapter as any,
         mockMetadataExtractor,
         "2025-10-15",
       );

--- a/packages/obsidian-plugin/tests/unit/DailyProjectsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/DailyProjectsRenderer.test.ts
@@ -2,7 +2,7 @@ import { DailyProjectsRenderer } from "../../src/presentation/renderers/DailyPro
 import { TFile } from "obsidian";
 import { ExocortexSettings } from "../../src/domain/settings/ExocortexSettings";
 import { ILogger } from "../../src/infrastructure/logging/ILogger";
-import { MetadataExtractor } from "@exocortex/core";
+import { MetadataExtractor, IVaultAdapter } from "@exocortex/core";
 import { ReactRenderer } from "../../src/presentation/utils/ReactRenderer";
 
 describe("DailyProjectsRenderer", () => {
@@ -16,6 +16,7 @@ describe("DailyProjectsRenderer", () => {
   let mockRefresh: jest.Mock;
   let mockGetAssetLabel: jest.Mock;
   let mockGetEffortArea: jest.Mock;
+  let mockVaultAdapter: jest.Mocked<IVaultAdapter>;
 
   const createMockElement = (): any => {
     const el: any = document.createElement("div");
@@ -86,6 +87,24 @@ describe("DailyProjectsRenderer", () => {
     mockGetAssetLabel = jest.fn();
     mockGetEffortArea = jest.fn();
 
+    mockVaultAdapter = {
+      getAllFiles: jest.fn().mockReturnValue([]),
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      getFrontmatter: jest.fn(),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+      updateLinks: jest.fn(),
+    } as any;
+
     renderer = new DailyProjectsRenderer(
       mockApp,
       mockSettings,
@@ -96,6 +115,7 @@ describe("DailyProjectsRenderer", () => {
       mockRefresh,
       mockGetAssetLabel,
       mockGetEffortArea,
+      mockVaultAdapter,
     );
   });
 
@@ -157,7 +177,7 @@ describe("DailyProjectsRenderer", () => {
       mockMetadataExtractor.extractInstanceClass.mockReturnValue(
         "[[pn__DailyNote]]",
       );
-      mockApp.vault.getMarkdownFiles.mockReturnValue([]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -199,7 +219,7 @@ describe("DailyProjectsRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([projectFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([projectFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -246,7 +266,7 @@ describe("DailyProjectsRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -288,7 +308,7 @@ describe("DailyProjectsRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([projectFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([projectFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -338,7 +358,7 @@ describe("DailyProjectsRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue(projectFiles);
+      mockVaultAdapter.getAllFiles.mockReturnValue(projectFiles);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -364,7 +384,7 @@ describe("DailyProjectsRenderer", () => {
       mockMetadataExtractor.extractInstanceClass.mockReturnValue(
         "[[pn__DailyNote]]",
       );
-      mockApp.vault.getMarkdownFiles.mockImplementation(() => {
+      mockVaultAdapter.getAllFiles.mockImplementation(() => {
         throw new Error("Vault error");
       });
 
@@ -410,7 +430,7 @@ describe("DailyProjectsRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([projectFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([projectFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);

--- a/packages/obsidian-plugin/tests/unit/DailyTasksRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/DailyTasksRenderer.test.ts
@@ -2,7 +2,7 @@ import { DailyTasksRenderer } from "../../src/presentation/renderers/DailyTasksR
 import { TFile, Keymap } from "obsidian";
 import { ExocortexSettings } from "../../src/domain/settings/ExocortexSettings";
 import { ILogger } from "../../src/infrastructure/logging/ILogger";
-import { MetadataExtractor } from "@exocortex/core";
+import { MetadataExtractor, IVaultAdapter } from "@exocortex/core";
 import { ReactRenderer } from "../../src/presentation/utils/ReactRenderer";
 import { AssetMetadataService } from "../../src/presentation/renderers/layout/helpers/AssetMetadataService";
 
@@ -23,6 +23,7 @@ describe("DailyTasksRenderer", () => {
   let mockReactRenderer: jest.Mocked<ReactRenderer>;
   let mockRefresh: jest.Mock;
   let mockMetadataService: jest.Mocked<AssetMetadataService>;
+  let mockVaultAdapter: jest.Mocked<IVaultAdapter>;
 
   const createMockElement = (): any => {
     const el: any = document.createElement("div");
@@ -109,6 +110,24 @@ describe("DailyTasksRenderer", () => {
       extractInstanceClass: jest.fn((metadata) => realMetadataService.extractInstanceClass(metadata)),
     } as any;
 
+    mockVaultAdapter = {
+      getAllFiles: jest.fn().mockReturnValue([]),
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      getFrontmatter: jest.fn().mockReturnValue({}),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+      updateLinks: jest.fn(),
+    } as any;
+
     renderer = new DailyTasksRenderer(
       mockApp,
       mockSettings,
@@ -118,6 +137,7 @@ describe("DailyTasksRenderer", () => {
       mockReactRenderer,
       mockRefresh,
       mockMetadataService,
+      mockVaultAdapter,
     );
   });
 
@@ -176,7 +196,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -221,7 +241,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -269,7 +289,7 @@ describe("DailyTasksRenderer", () => {
       mockMetadataExtractor.extractInstanceClass.mockReturnValue(
         "[[pn__DailyNote]]",
       );
-      mockApp.vault.getMarkdownFiles.mockReturnValue([]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -311,7 +331,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -358,7 +378,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([projectFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([projectFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -400,7 +420,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -450,7 +470,7 @@ describe("DailyTasksRenderer", () => {
         "[[other]]",
       ]);
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -499,7 +519,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
       mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(blockerFile);
       mockApp.metadataCache.getFileCache.mockReturnValue({
         frontmatter: blockerMetadata,
@@ -555,7 +575,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
       mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(blockerFile);
       mockApp.metadataCache.getFileCache.mockReturnValue({
         frontmatter: blockerMetadata,
@@ -607,7 +627,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue(taskFiles);
+      mockVaultAdapter.getAllFiles.mockReturnValue(taskFiles);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -633,7 +653,7 @@ describe("DailyTasksRenderer", () => {
       mockMetadataExtractor.extractInstanceClass.mockReturnValue(
         "[[pn__DailyNote]]",
       );
-      mockApp.vault.getMarkdownFiles.mockImplementation(() => {
+      mockVaultAdapter.getAllFiles.mockImplementation(() => {
         throw new Error("Vault error");
       });
 
@@ -679,7 +699,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -724,7 +744,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -771,7 +791,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -818,7 +838,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -871,7 +891,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockLeaf = {
         openLinkText: jest.fn(),
@@ -941,7 +961,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile1, taskFile2]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile1, taskFile2]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -997,7 +1017,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile1, taskFile2]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile1, taskFile2]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1053,7 +1073,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([projectFile, taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([projectFile, taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1113,7 +1133,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile1, taskFile2]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile1, taskFile2]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1183,7 +1203,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles
+      mockVaultAdapter.getAllFiles
         .mockReturnValueOnce([taskFile1, taskFile2])
         .mockReturnValueOnce([areaFile]);
 
@@ -1232,7 +1252,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1277,7 +1297,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1320,7 +1340,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1365,7 +1385,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1410,7 +1430,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1452,7 +1472,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1496,7 +1516,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1540,7 +1560,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1585,7 +1605,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1627,7 +1647,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1672,7 +1692,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1715,7 +1735,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1757,7 +1777,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1800,7 +1820,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1843,7 +1863,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -1897,7 +1917,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
       mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(prototypeFile);
       mockApp.metadataCache.getFileCache.mockReturnValue({
         frontmatter: prototypeMetadata,
@@ -1951,7 +1971,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
       mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(parentFile);
       mockApp.metadataCache.getFileCache.mockReturnValue({
         frontmatter: parentMetadata,
@@ -2008,7 +2028,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
       mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(taskFile);
       mockApp.metadataCache.getFileCache.mockReturnValue({
         frontmatter: taskMetadata,
@@ -2054,7 +2074,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -2098,7 +2118,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const linkedFile = {
         path: "linked.md",
@@ -2154,7 +2174,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const linkedFile = {
         path: "linked.md",
@@ -2222,7 +2242,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
       mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
 
       const mockEl = createMockElement();
@@ -2265,7 +2285,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const linkedFile = {
         path: "linked.md",
@@ -2324,7 +2344,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const linkedFile = {
         path: "linked.md",
@@ -2392,7 +2412,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
       mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(blockerFile);
       mockApp.metadataCache.getFileCache.mockReturnValue({
         frontmatter: blockerMetadata,
@@ -2439,7 +2459,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
       mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
 
       const mockEl = createMockElement();
@@ -2482,7 +2502,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);
@@ -2525,7 +2545,7 @@ describe("DailyTasksRenderer", () => {
         "[[pn__DailyNote]]",
       );
 
-      mockApp.vault.getMarkdownFiles.mockReturnValue([taskFile]);
+      mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
 
       const mockEl = createMockElement();
       await renderer.render(mockEl, mockFile);

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -162,7 +162,7 @@ describe("ExocortexPlugin", () => {
       expect(mockLogger.info).toHaveBeenCalledWith("Loading Exocortex Plugin");
       expect(plugin.loadData).toHaveBeenCalled();
       expect(ObsidianVaultAdapter).toHaveBeenCalledWith(mockVault, mockMetadataCache, mockApp);
-      expect(UniversalLayoutRenderer).toHaveBeenCalledWith(mockApp, plugin.settings, plugin);
+      expect(UniversalLayoutRenderer).toHaveBeenCalledWith(mockApp, plugin.settings, plugin, plugin.vaultAdapter);
       expect(TaskStatusService).toHaveBeenCalledWith(plugin.vaultAdapter);
       expect(TaskTrackingService).toHaveBeenCalledWith(mockApp, mockVault, mockMetadataCache);
       expect(SPARQLCodeBlockProcessor).toHaveBeenCalledWith(plugin);


### PR DESCRIPTION
## Summary

Phase 3 of Multi-Vault Support implementation (Issue #443).

Migrates all renderers to use `IVaultAdapter` instead of direct `app.vault` access, completing the abstraction layer for multi-vault support.

### Changes

**Core Package (`@exocortex/core`)**:
- Add `getFirstLinkpathDest()` method to `IVaultAdapter` interface for link resolution

**Obsidian Plugin**:
- **UniversalLayoutRenderer**: Add vaultAdapter constructor parameter, use for all file operations
- **DailyTasksRenderer**: Use `vaultAdapter.getAllFiles()` instead of `app.vault.getMarkdownFiles()`
- **DailyProjectsRenderer**: Use vaultAdapter for file listing
- **RelationsRenderer**: Use vaultAdapter for file operations and frontmatter access
- **AreaTreeRenderer**: Use `vaultAdapter.getAllFiles()`
- **DailyNoteHelpers**: Accept `IVaultAdapter` instead of `App` parameter

**Bug Fix**:
- Fixed `UniversalLayoutRenderer.renderDailyNavigation` passing `this.app` instead of `this.vaultAdapter` to `DailyNoteHelpers.findDailyNoteByDate`

**Tests**:
- Updated all unit tests with `mockVaultAdapter` setup
- Updated UI tests with mockVaultAdapter delegation to mockApp
- All 1971 unit tests + 55 UI tests + 8 component tests passing

## Test Plan

- [x] All unit tests pass (1971)
- [x] All UI tests pass (55)
- [x] All component tests pass (8)
- [x] Pre-commit hooks pass
- [ ] CI pipeline passes

## Related

- Part of Multi-Vault Support (Issue #443)
- Builds on Phase 1 (PR #464) - IVaultContext interfaces
- Builds on Phase 2 (PR #465) - SingleVaultContext implementation