### PR TITLE
docs: add Fresh Worktree Component Test Failures troubleshooting

### DIFF
--- a/packages/obsidian-plugin/CLAUDE.md
+++ b/packages/obsidian-plugin/CLAUDE.md
@@ -1063,6 +1063,21 @@ setError({ message: "error", queryString: "SELECT ..." });
 
 **Prevention**: Use TypeScript IntelliSense/autocomplete to discover correct property names. Always read interface definitions before first use.
 
+### Fresh Worktree Component Test Failures
+
+**Problem**: Component tests fail with "Cannot find module '@exocortex/core/dist/..." in fresh worktrees
+
+**Root Cause**: Fresh worktrees don't have built dist folders needed for Playwright CT subpath imports.
+
+**Solution**:
+```bash
+npm install
+npm run build  # Required before running component tests!
+npm run test:component
+```
+
+**Prevention**: Always run `npm run build` after `npm install` in new worktrees. The pre-commit hook runs component tests, so build is needed before first commit.
+
 ### E2E Testing Critical Lessons
 
 **5 key lessons from v12.15.45-49 debugging (5 versions, 4 failures):**


### PR DESCRIPTION
## Summary

Adds troubleshooting entry for fresh worktree component test failures based on learnings from Issue #443 Phase 3 implementation.

### Changes

- Added "Fresh Worktree Component Test Failures" section to `packages/obsidian-plugin/CLAUDE.md`
- Documents the need to run `npm run build` before component tests in fresh worktrees
- Explains root cause (subpath imports require dist folder)

### Background

During Phase 3 implementation, the pre-commit hook failed because component tests couldn't find `@exocortex/core/dist/...`. This is a common gotcha for fresh worktrees.

## Test Plan

- [x] Documentation-only change
- [ ] CI passes