### PR TITLE
refactor: standardize DI across 18+ services using tsyringe container

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,6 +103,16 @@ export type { IConfiguration } from "./interfaces/IConfiguration";
 export type { INotificationService } from "./interfaces/INotificationService";
 export { DI_TOKENS, type DIToken } from "./interfaces/tokens";
 
+// DI Container exports
+export {
+  registerCoreServices,
+  createChildContainer,
+  getContainer,
+  resetContainer,
+  container,
+  type DependencyContainer,
+} from "./infrastructure/container";
+
 // Types exports
 export type { SupervisionFormData } from "./types/SupervisionFormData";
 

--- a/packages/core/src/infrastructure/container.ts
+++ b/packages/core/src/infrastructure/container.ts
@@ -1,0 +1,179 @@
+import "reflect-metadata";
+import { container, DependencyContainer } from "tsyringe";
+import { DI_TOKENS } from "../interfaces/tokens";
+
+// Import all services
+import { TaskCreationService } from "../services/TaskCreationService";
+import { TaskFrontmatterGenerator } from "../services/TaskFrontmatterGenerator";
+import { AlgorithmExtractor } from "../services/AlgorithmExtractor";
+import { PropertyCleanupService } from "../services/PropertyCleanupService";
+import { ProjectCreationService } from "../services/ProjectCreationService";
+import { AreaCreationService } from "../services/AreaCreationService";
+import { TaskStatusService } from "../services/TaskStatusService";
+import { EffortStatusWorkflow } from "../services/EffortStatusWorkflow";
+import { StatusTimestampService } from "../services/StatusTimestampService";
+import { FolderRepairService } from "../services/FolderRepairService";
+import { LabelToAliasService } from "../services/LabelToAliasService";
+import { RenameToUidService } from "../services/RenameToUidService";
+import { EffortVotingService } from "../services/EffortVotingService";
+import { PlanningService } from "../services/PlanningService";
+import { SessionEventService } from "../services/SessionEventService";
+import { AssetConversionService } from "../services/AssetConversionService";
+import { ClassCreationService } from "../services/ClassCreationService";
+import { ConceptCreationService } from "../services/ConceptCreationService";
+import { FleetingNoteCreationService } from "../services/FleetingNoteCreationService";
+import { SupervisionCreationService } from "../services/SupervisionCreationService";
+import { NoteToRDFConverter } from "../services/NoteToRDFConverter";
+import { AreaHierarchyBuilder } from "../services/AreaHierarchyBuilder";
+import { URIConstructionService } from "../services/URIConstructionService";
+
+/**
+ * Register all core services with the DI container.
+ * Services are registered with their corresponding tokens for interface-based injection.
+ *
+ * @param childContainer - Optional child container. If not provided, uses global container.
+ */
+export function registerCoreServices(
+  childContainer?: DependencyContainer,
+): void {
+  const targetContainer = childContainer || container;
+
+  // Frontmatter services (no dependencies)
+  targetContainer.registerSingleton(
+    DI_TOKENS.TaskFrontmatterGenerator,
+    TaskFrontmatterGenerator,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.AlgorithmExtractor,
+    AlgorithmExtractor,
+  );
+
+  // Status workflow (no dependencies)
+  targetContainer.registerSingleton(
+    DI_TOKENS.EffortStatusWorkflow,
+    EffortStatusWorkflow,
+  );
+
+  // Status services (depend on IVaultAdapter)
+  targetContainer.registerSingleton(
+    DI_TOKENS.StatusTimestampService,
+    StatusTimestampService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.TaskStatusService,
+    TaskStatusService,
+  );
+
+  // Creation services (depend on IVaultAdapter)
+  targetContainer.registerSingleton(
+    DI_TOKENS.TaskCreationService,
+    TaskCreationService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.ProjectCreationService,
+    ProjectCreationService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.AreaCreationService,
+    AreaCreationService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.ClassCreationService,
+    ClassCreationService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.ConceptCreationService,
+    ConceptCreationService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.FleetingNoteCreationService,
+    FleetingNoteCreationService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.SupervisionCreationService,
+    SupervisionCreationService,
+  );
+
+  // Utility services (depend on IVaultAdapter)
+  targetContainer.registerSingleton(
+    DI_TOKENS.PropertyCleanupService,
+    PropertyCleanupService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.FolderRepairService,
+    FolderRepairService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.LabelToAliasService,
+    LabelToAliasService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.RenameToUidService,
+    RenameToUidService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.PlanningService,
+    PlanningService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.EffortVotingService,
+    EffortVotingService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.SessionEventService,
+    SessionEventService,
+  );
+
+  // Conversion services (depend on IVaultAdapter)
+  targetContainer.registerSingleton(
+    DI_TOKENS.AssetConversionService,
+    AssetConversionService,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.NoteToRDFConverter,
+    NoteToRDFConverter,
+  );
+
+  // Query services (depend on IVaultAdapter)
+  targetContainer.registerSingleton(
+    DI_TOKENS.AreaHierarchyBuilder,
+    AreaHierarchyBuilder,
+  );
+
+  // URI Construction (depends on IFileSystemAdapter)
+  targetContainer.registerSingleton(
+    DI_TOKENS.URIConstructionService,
+    URIConstructionService,
+  );
+}
+
+/**
+ * Create a child container for isolated testing or scoped instances.
+ * Child containers inherit registrations from parent but can override them.
+ *
+ * @returns A new child container
+ */
+export function createChildContainer(): DependencyContainer {
+  return container.createChildContainer();
+}
+
+/**
+ * Get the global container instance.
+ * Use this for application-level service resolution.
+ *
+ * @returns The global DI container
+ */
+export function getContainer(): DependencyContainer {
+  return container;
+}
+
+/**
+ * Reset the container by clearing all registrations.
+ * Useful for testing to ensure clean state between tests.
+ */
+export function resetContainer(): void {
+  container.reset();
+}
+
+export { container };
+export type { DependencyContainer };

--- a/packages/core/src/interfaces/tokens.ts
+++ b/packages/core/src/interfaces/tokens.ts
@@ -1,6 +1,14 @@
 /**
  * Dependency Injection Tokens
  * Symbol-based tokens for TSyringe container registration
+ *
+ * Categories:
+ * - Infrastructure adapters: Storage and vault access
+ * - Cross-cutting concerns: Logging, events, configuration
+ * - Creation services: Asset/entity creation
+ * - Status services: Workflow and status management
+ * - Utility services: Property cleanup, folder repair, etc.
+ * - Query services: Hierarchy builders, URI construction
  */
 
 export const DI_TOKENS = {
@@ -17,6 +25,41 @@ export const DI_TOKENS = {
   IEventBus: Symbol.for("IEventBus"),
   IConfiguration: Symbol.for("IConfiguration"),
   INotificationService: Symbol.for("INotificationService"),
+
+  // Creation services
+  TaskCreationService: Symbol.for("TaskCreationService"),
+  ProjectCreationService: Symbol.for("ProjectCreationService"),
+  AreaCreationService: Symbol.for("AreaCreationService"),
+  ClassCreationService: Symbol.for("ClassCreationService"),
+  ConceptCreationService: Symbol.for("ConceptCreationService"),
+  FleetingNoteCreationService: Symbol.for("FleetingNoteCreationService"),
+  SupervisionCreationService: Symbol.for("SupervisionCreationService"),
+
+  // Frontmatter services
+  TaskFrontmatterGenerator: Symbol.for("TaskFrontmatterGenerator"),
+  AlgorithmExtractor: Symbol.for("AlgorithmExtractor"),
+
+  // Status services
+  TaskStatusService: Symbol.for("TaskStatusService"),
+  EffortStatusWorkflow: Symbol.for("EffortStatusWorkflow"),
+  StatusTimestampService: Symbol.for("StatusTimestampService"),
+
+  // Utility services
+  PropertyCleanupService: Symbol.for("PropertyCleanupService"),
+  FolderRepairService: Symbol.for("FolderRepairService"),
+  LabelToAliasService: Symbol.for("LabelToAliasService"),
+  RenameToUidService: Symbol.for("RenameToUidService"),
+  PlanningService: Symbol.for("PlanningService"),
+  EffortVotingService: Symbol.for("EffortVotingService"),
+  SessionEventService: Symbol.for("SessionEventService"),
+
+  // Conversion services
+  AssetConversionService: Symbol.for("AssetConversionService"),
+  NoteToRDFConverter: Symbol.for("NoteToRDFConverter"),
+
+  // Query services
+  AreaHierarchyBuilder: Symbol.for("AreaHierarchyBuilder"),
+  URIConstructionService: Symbol.for("URIConstructionService"),
 } as const;
 
-export type DIToken = typeof DI_TOKENS[keyof typeof DI_TOKENS];
+export type DIToken = (typeof DI_TOKENS)[keyof typeof DI_TOKENS];

--- a/packages/core/src/services/AreaCreationService.ts
+++ b/packages/core/src/services/AreaCreationService.ts
@@ -1,12 +1,17 @@
+import { injectable, inject } from "tsyringe";
 import { v4 as uuidv4 } from "uuid";
 import { AssetClass } from "../domain/constants";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { MetadataExtractor } from "../utilities/MetadataExtractor";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
+@injectable()
 export class AreaCreationService {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   async createChildArea(
     sourceFile: IFile,

--- a/packages/core/src/services/AreaHierarchyBuilder.ts
+++ b/packages/core/src/services/AreaHierarchyBuilder.ts
@@ -1,6 +1,8 @@
+import { injectable, inject } from "tsyringe";
 import { AreaNode, AreaNodeData } from "../domain/models/AreaNode";
 import { AssetClass } from "../domain/constants";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
 export interface AssetRelation {
   path: string;
@@ -10,8 +12,11 @@ export interface AssetRelation {
   metadata: Record<string, any>;
 }
 
+@injectable()
 export class AreaHierarchyBuilder {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   buildHierarchy(
     currentAreaPath: string,

--- a/packages/core/src/services/AssetConversionService.ts
+++ b/packages/core/src/services/AssetConversionService.ts
@@ -1,7 +1,9 @@
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { injectable, inject } from "tsyringe";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
 import { AssetClass } from "../domain/constants";
 import { FrontmatterService } from "../utilities/FrontmatterService";
 import { LoggingService } from "./LoggingService";
+import { DI_TOKENS } from "../interfaces/tokens";
 
 /**
  * AssetConversionService
@@ -12,10 +14,13 @@ import { LoggingService } from "./LoggingService";
  * @module services
  * @since 1.0.0
  */
+@injectable()
 export class AssetConversionService {
   private frontmatterService: FrontmatterService;
 
-  constructor(private vault: IVaultAdapter) {
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {
     this.frontmatterService = new FrontmatterService();
   }
 

--- a/packages/core/src/services/ClassCreationService.ts
+++ b/packages/core/src/services/ClassCreationService.ts
@@ -1,10 +1,15 @@
+import { injectable, inject } from "tsyringe";
 import { v4 as uuidv4 } from "uuid";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
+@injectable()
 export class ClassCreationService {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   async createSubclass(
     parentFile: IFile,

--- a/packages/core/src/services/ConceptCreationService.ts
+++ b/packages/core/src/services/ConceptCreationService.ts
@@ -1,11 +1,16 @@
+import { injectable, inject } from "tsyringe";
 import { v4 as uuidv4 } from "uuid";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
 import { AssetClass } from "../domain/constants";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
+@injectable()
 export class ConceptCreationService {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   async createNarrowerConcept(
     parentFile: IFile,

--- a/packages/core/src/services/EffortStatusWorkflow.ts
+++ b/packages/core/src/services/EffortStatusWorkflow.ts
@@ -1,5 +1,7 @@
+import { injectable } from "tsyringe";
 import { AssetClass, EffortStatus } from "../domain/constants";
 
+@injectable()
 export class EffortStatusWorkflow {
   getPreviousStatus(
     currentStatus: string,

--- a/packages/core/src/services/EffortVotingService.ts
+++ b/packages/core/src/services/EffortVotingService.ts
@@ -1,11 +1,16 @@
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { injectable, inject } from "tsyringe";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
 /**
  * Service for managing effort voting functionality
  * Handles incrementing ems__Effort_votes property on Tasks/Projects
  */
+@injectable()
 export class EffortVotingService {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   /**
    * Increment the vote count for an effort

--- a/packages/core/src/services/FleetingNoteCreationService.ts
+++ b/packages/core/src/services/FleetingNoteCreationService.ts
@@ -1,17 +1,22 @@
+import { injectable, inject } from "tsyringe";
 import { v4 as uuidv4 } from "uuid";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
 /**
  * Service responsible for creating fleeting note assets.
  *
  * Generates required frontmatter and persists the file inside the inbox folder.
  */
+@injectable()
 export class FleetingNoteCreationService {
   private static readonly INBOX_FOLDER = "01 Inbox";
 
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   /**
    * Creates a new fleeting note asset using provided label as display name.

--- a/packages/core/src/services/FolderRepairService.ts
+++ b/packages/core/src/services/FolderRepairService.ts
@@ -1,10 +1,15 @@
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { injectable, inject } from "tsyringe";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
 /**
  * Service for repairing asset folder locations based on exo__Asset_isDefinedBy references
  */
+@injectable()
 export class FolderRepairService {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   /**
    * Get the expected folder for an asset based on its exo__Asset_isDefinedBy property

--- a/packages/core/src/services/LabelToAliasService.ts
+++ b/packages/core/src/services/LabelToAliasService.ts
@@ -1,7 +1,12 @@
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { injectable, inject } from "tsyringe";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
+@injectable()
 export class LabelToAliasService {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   async copyLabelToAliases(file: IFile): Promise<void> {
     const fileContent = await this.vault.read(file);

--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -1,8 +1,10 @@
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { injectable, inject } from "tsyringe";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
 import { Triple } from "../domain/models/rdf/Triple";
 import { IRI } from "../domain/models/rdf/IRI";
 import { Literal } from "../domain/models/rdf/Literal";
 import { Namespace } from "../domain/models/rdf/Namespace";
+import { DI_TOKENS } from "../interfaces/tokens";
 
 /**
  * Service for converting Obsidian notes (frontmatter + wikilinks) to RDF triples.
@@ -13,10 +15,13 @@ import { Namespace } from "../domain/models/rdf/Namespace";
  * const triples = await converter.convertNote(file);
  * ```
  */
+@injectable()
 export class NoteToRDFConverter {
   private readonly OBSIDIAN_VAULT_SCHEME = "obsidian://vault/";
 
-  constructor(private readonly vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private readonly vault: IVaultAdapter,
+  ) {}
 
   /**
    * Converts a single note to RDF triples.

--- a/packages/core/src/services/PlanningService.ts
+++ b/packages/core/src/services/PlanningService.ts
@@ -1,11 +1,16 @@
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { injectable, inject } from "tsyringe";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
 import { FrontmatterService } from "../utilities/FrontmatterService";
 import { DateFormatter } from "../utilities/DateFormatter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
+@injectable()
 export class PlanningService {
   private frontmatterService: FrontmatterService;
 
-  constructor(private vault: IVaultAdapter) {
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {
     this.frontmatterService = new FrontmatterService();
   }
 

--- a/packages/core/src/services/ProjectCreationService.ts
+++ b/packages/core/src/services/ProjectCreationService.ts
@@ -1,10 +1,12 @@
+import { injectable, inject } from "tsyringe";
 import { v4 as uuidv4 } from "uuid";
 import { WikiLinkHelpers } from "../utilities/WikiLinkHelpers";
 import { AssetClass } from "../domain/constants";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { MetadataExtractor } from "../utilities/MetadataExtractor";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
 /**
  * Mapping of source class to effort property name
@@ -16,8 +18,11 @@ const EFFORT_PROPERTY_MAP: Record<string, string> = {
   [AssetClass.PROJECT]: "ems__Effort_parent",
 };
 
+@injectable()
 export class ProjectCreationService {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   async createProject(
     sourceFile: IFile,

--- a/packages/core/src/services/RenameToUidService.ts
+++ b/packages/core/src/services/RenameToUidService.ts
@@ -1,7 +1,12 @@
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { injectable, inject } from "tsyringe";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
+@injectable()
 export class RenameToUidService {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   async renameToUid(file: IFile, metadata: Record<string, any>): Promise<void> {
     const uid = metadata.exo__Asset_uid;

--- a/packages/core/src/services/SessionEventService.ts
+++ b/packages/core/src/services/SessionEventService.ts
@@ -1,20 +1,28 @@
+import { injectable, inject } from "tsyringe";
 import { v4 as uuidv4 } from "uuid";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
 import { AssetClass } from "../domain/constants";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
+import { DI_TOKENS } from "../interfaces/tokens";
 
 /**
  * Service for managing area focus session event tracking
  * Creates SessionStartEvent and SessionEndEvent assets when users activate/deactivate focus areas
  */
+@injectable()
 export class SessionEventService {
   private folderPathCache: string | null = null;
+  private defaultOntologyAsset: string | null = null;
 
   constructor(
-    private vault: IVaultAdapter,
-    private defaultOntologyAsset: string | null = null,
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
   ) {}
+
+  setDefaultOntologyAsset(asset: string | null): void {
+    this.defaultOntologyAsset = asset;
+    this.folderPathCache = null;
+  }
 
   /**
    * Create a session start event when user activates a focus area

--- a/packages/core/src/services/StatusTimestampService.ts
+++ b/packages/core/src/services/StatusTimestampService.ts
@@ -1,11 +1,16 @@
+import { injectable, inject } from "tsyringe";
 import { FrontmatterService } from "../utilities/FrontmatterService";
 import { DateFormatter } from "../utilities/DateFormatter";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
+@injectable()
 export class StatusTimestampService {
   private frontmatterService: FrontmatterService;
 
-  constructor(private vault: IVaultAdapter) {
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {
     this.frontmatterService = new FrontmatterService();
   }
 

--- a/packages/core/src/services/SupervisionCreationService.ts
+++ b/packages/core/src/services/SupervisionCreationService.ts
@@ -1,10 +1,15 @@
+import { injectable, inject } from "tsyringe";
 import { v4 as uuidv4 } from "uuid";
 import { SupervisionFormData } from "../types/SupervisionFormData";
 import { DateFormatter } from "../utilities/DateFormatter";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
+@injectable()
 export class SupervisionCreationService {
-  constructor(private vault: IVaultAdapter) {}
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
 
   async createSupervision(formData: SupervisionFormData): Promise<IFile> {
     const uid = uuidv4();

--- a/packages/core/src/services/TaskStatusService.ts
+++ b/packages/core/src/services/TaskStatusService.ts
@@ -1,18 +1,21 @@
+import { injectable, inject } from "tsyringe";
 import { FrontmatterService } from "../utilities/FrontmatterService";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { EffortStatusWorkflow } from "./EffortStatusWorkflow";
 import { StatusTimestampService } from "./StatusTimestampService";
-import { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
+@injectable()
 export class TaskStatusService {
   private frontmatterService: FrontmatterService;
-  private workflow: EffortStatusWorkflow;
-  private timestampService: StatusTimestampService;
 
-  constructor(private vault: IVaultAdapter) {
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+    private workflow: EffortStatusWorkflow,
+    private timestampService: StatusTimestampService,
+  ) {
     this.frontmatterService = new FrontmatterService();
-    this.workflow = new EffortStatusWorkflow();
-    this.timestampService = new StatusTimestampService(vault);
   }
 
   async setDraftStatus(taskFile: IFile): Promise<void> {

--- a/packages/core/src/services/URIConstructionService.ts
+++ b/packages/core/src/services/URIConstructionService.ts
@@ -1,4 +1,6 @@
-import { IFileSystemAdapter } from "../interfaces/IFileSystemAdapter";
+import { injectable, inject } from "tsyringe";
+import type { IFileSystemAdapter } from "../interfaces/IFileSystemAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
 
 export interface URIConstructionOptions {
   defaultOntologyURL?: string;
@@ -10,17 +12,22 @@ export interface AssetMetadata {
   frontmatter?: Record<string, any>;
 }
 
+@injectable()
 export class URIConstructionService {
-  private readonly defaultOntologyURL: string;
-  private readonly strictValidation: boolean;
+  private defaultOntologyURL: string = "https://exocortex.my/default/";
+  private strictValidation: boolean = true;
 
   constructor(
-    private readonly fileSystem: IFileSystemAdapter,
-    options?: URIConstructionOptions,
-  ) {
-    this.defaultOntologyURL =
-      options?.defaultOntologyURL || "https://exocortex.my/default/";
-    this.strictValidation = options?.strictValidation ?? true;
+    @inject(DI_TOKENS.IFileSystemAdapter) private readonly fileSystem: IFileSystemAdapter,
+  ) {}
+
+  configure(options?: URIConstructionOptions): void {
+    if (options?.defaultOntologyURL) {
+      this.defaultOntologyURL = options.defaultOntologyURL;
+    }
+    if (options?.strictValidation !== undefined) {
+      this.strictValidation = options.strictValidation;
+    }
   }
 
   async constructAssetURI(asset: AssetMetadata): Promise<string> {

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -5,6 +5,7 @@ import {
   Plugin,
   TFile,
 } from "obsidian";
+import { container } from "tsyringe";
 import { UniversalLayoutRenderer } from "./presentation/renderers/UniversalLayoutRenderer";
 import { ILogger } from "./adapters/logging/ILogger";
 import { LoggerFactory } from "./adapters/logging/LoggerFactory";
@@ -61,7 +62,7 @@ export default class ExocortexPlugin extends Plugin {
         this,
         this.vaultAdapter,
       );
-      this.taskStatusService = new TaskStatusService(this.vaultAdapter);
+      this.taskStatusService = container.resolve(TaskStatusService);
       this.taskTrackingService = new TaskTrackingService(
         this.app,
         this.app.vault,

--- a/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
+++ b/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
@@ -15,6 +15,8 @@ import {
   LabelToAliasService,
   AssetConversionService,
   FleetingNoteCreationService,
+  DI_TOKENS,
+  registerCoreServices,
 } from "@exocortex/core";
 import { LoggerFactory } from "../../adapters/logging/LoggerFactory";
 
@@ -62,21 +64,28 @@ export class CommandRegistry {
   ) {
     this.vaultAdapter = new ObsidianVaultAdapter(app.vault, app.metadataCache, app);
 
-    // Create logger for services (Phase 1 DI infrastructure)
+    // Create logger for services
     const logger = LoggerFactory.create("CommandRegistry");
 
-    // Phase 2: Resolve TaskCreationService from DI container
+    // Register infrastructure dependencies with DI container
+    container.register(DI_TOKENS.IVaultAdapter, { useValue: this.vaultAdapter });
+    container.register(DI_TOKENS.ILogger, { useValue: logger });
+
+    // Register all core services
+    registerCoreServices();
+
+    // Resolve services from DI container
     const taskCreationService = container.resolve(TaskCreationService);
-    const projectCreationService = new ProjectCreationService(this.vaultAdapter);
-    const taskStatusService = new TaskStatusService(this.vaultAdapter);
-    const propertyCleanupService = new PropertyCleanupService(this.vaultAdapter, logger);
-    const folderRepairService = new FolderRepairService(this.vaultAdapter);
-    const supervisionCreationService = new SupervisionCreationService(this.vaultAdapter);
-    const renameToUidService = new RenameToUidService(this.vaultAdapter);
-    const effortVotingService = new EffortVotingService(this.vaultAdapter);
-    const labelToAliasService = new LabelToAliasService(this.vaultAdapter);
-    const assetConversionService = new AssetConversionService(this.vaultAdapter);
-    const fleetingNoteCreationService = new FleetingNoteCreationService(this.vaultAdapter);
+    const projectCreationService = container.resolve(ProjectCreationService);
+    const taskStatusService = container.resolve(TaskStatusService);
+    const propertyCleanupService = container.resolve(PropertyCleanupService);
+    const folderRepairService = container.resolve(FolderRepairService);
+    const supervisionCreationService = container.resolve(SupervisionCreationService);
+    const renameToUidService = container.resolve(RenameToUidService);
+    const effortVotingService = container.resolve(EffortVotingService);
+    const labelToAliasService = container.resolve(LabelToAliasService);
+    const assetConversionService = container.resolve(AssetConversionService);
+    const fleetingNoteCreationService = container.resolve(FleetingNoteCreationService);
 
     this.commands = [
       new CreateTaskCommand(app, taskCreationService, this.vaultAdapter),

--- a/packages/obsidian-plugin/src/application/commands/SetFocusAreaCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/SetFocusAreaCommand.ts
@@ -1,4 +1,5 @@
 import { App, Notice } from "obsidian";
+import { container } from "tsyringe";
 import { ICommand } from "./ICommand";
 import { ExocortexPluginInterface } from "../../types";
 import {
@@ -16,8 +17,8 @@ export class SetFocusAreaCommand implements ICommand {
     private app: App,
     private plugin: ExocortexPluginInterface,
   ) {
-    this.sessionEventService = new SessionEventService(
-      this.plugin.vaultAdapter,
+    this.sessionEventService = container.resolve(SessionEventService);
+    this.sessionEventService.setDefaultOntologyAsset(
       (this.plugin.settings?.defaultOntologyAsset as string | null) ?? null,
     );
   }

--- a/packages/obsidian-plugin/src/infrastructure/di/PluginContainer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/di/PluginContainer.ts
@@ -3,9 +3,7 @@ import { container } from "tsyringe";
 import { App, Plugin } from "obsidian";
 import {
   DI_TOKENS,
-  TaskFrontmatterGenerator,
-  AlgorithmExtractor,
-  TaskCreationService,
+  registerCoreServices,
 } from "@exocortex/core";
 import { ObsidianLogger } from "./ObsidianLogger";
 import { ObsidianEventBus } from "./ObsidianEventBus";
@@ -58,10 +56,8 @@ export class PluginContainer {
       useFactory: () => new SingleVaultManager(vaultContext),
     });
 
-    // Register TaskCreationService and its dependencies explicitly as singletons
-    container.registerSingleton(TaskFrontmatterGenerator);
-    container.registerSingleton(AlgorithmExtractor);
-    container.registerSingleton(TaskCreationService);
+    // Register all core services (lazy resolution - dependencies resolved on demand)
+    registerCoreServices();
   }
 
   static reset(): void {

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -100,19 +100,19 @@ export class UniversalLayoutRenderer {
     this.backlinksCacheManager = new BacklinksCacheManager(this.app);
     this.vaultAdapter = vaultAdapter;
     this.metadataExtractor = new MetadataExtractor(this.vaultAdapter);
-    // Phase 2: Resolve TaskCreationService from DI container
+    // Resolve all services from DI container
     this.taskCreationService = container.resolve(TaskCreationService);
-    this.projectCreationService = new ProjectCreationService(this.vaultAdapter);
-    this.areaCreationService = new AreaCreationService(this.vaultAdapter);
-    this.classCreationService = new ClassCreationService(this.vaultAdapter);
-    this.conceptCreationService = new ConceptCreationService(this.vaultAdapter);
-    this.taskStatusService = new TaskStatusService(this.vaultAdapter);
-    this.propertyCleanupService = new PropertyCleanupService(this.vaultAdapter, this.logger);
-    this.folderRepairService = new FolderRepairService(this.vaultAdapter);
-    this.renameToUidService = new RenameToUidService(this.vaultAdapter);
-    this.effortVotingService = new EffortVotingService(this.vaultAdapter);
-    this.labelToAliasService = new LabelToAliasService(this.vaultAdapter);
-    this.assetConversionService = new AssetConversionService(this.vaultAdapter);
+    this.projectCreationService = container.resolve(ProjectCreationService);
+    this.areaCreationService = container.resolve(AreaCreationService);
+    this.classCreationService = container.resolve(ClassCreationService);
+    this.conceptCreationService = container.resolve(ConceptCreationService);
+    this.taskStatusService = container.resolve(TaskStatusService);
+    this.propertyCleanupService = container.resolve(PropertyCleanupService);
+    this.folderRepairService = container.resolve(FolderRepairService);
+    this.renameToUidService = container.resolve(RenameToUidService);
+    this.effortVotingService = container.resolve(EffortVotingService);
+    this.labelToAliasService = container.resolve(LabelToAliasService);
+    this.assetConversionService = container.resolve(AssetConversionService);
 
     this.metadataService = new AssetMetadataService(this.app);
 

--- a/packages/obsidian-plugin/tests/ui/ActionButtonsLayout.ui.test.ts
+++ b/packages/obsidian-plugin/tests/ui/ActionButtonsLayout.ui.test.ts
@@ -9,9 +9,8 @@ import {
 import {
   DI_TOKENS,
   IVaultAdapter,
-  TaskFrontmatterGenerator,
-  AlgorithmExtractor,
-  TaskCreationService,
+  registerCoreServices,
+  resetContainer,
 } from "@exocortex/core";
 
 describe("Layout Settings and Structure", () => {
@@ -24,7 +23,7 @@ describe("Layout Settings and Structure", () => {
   let mockVaultAdapter: any;
 
   beforeEach(() => {
-    container.clearInstances();
+    resetContainer();
 
     mockVault = {
       getAbstractFileByPath: jest.fn((path: string) => {
@@ -74,17 +73,27 @@ describe("Layout Settings and Structure", () => {
       },
     };
 
-    // Setup DI container for TaskCreationService
+    // Setup DI container with all required dependencies
     mockDIVault = {
       create: jest.fn().mockResolvedValue({ path: "test-task.md" }),
       read: jest.fn().mockResolvedValue(""),
       modify: jest.fn().mockResolvedValue(undefined),
+      getAllFiles: jest.fn().mockReturnValue([]),
+      getFrontmatter: jest.fn().mockReturnValue({}),
+      exists: jest.fn().mockResolvedValue(true),
+      updateFrontmatter: jest.fn().mockResolvedValue(undefined),
     };
 
-    container.registerInstance<IVaultAdapter>(DI_TOKENS.IVaultAdapter, mockDIVault);
-    container.register(TaskFrontmatterGenerator, { useClass: TaskFrontmatterGenerator });
-    container.register(AlgorithmExtractor, { useClass: AlgorithmExtractor });
-    container.register(TaskCreationService, { useClass: TaskCreationService });
+    const mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+    };
+
+    container.register(DI_TOKENS.IVaultAdapter, { useValue: mockDIVault });
+    container.register(DI_TOKENS.ILogger, { useValue: mockLogger });
+    registerCoreServices();
 
     mockVaultAdapter = {
       getAllFiles: jest.fn().mockReturnValue([]),
@@ -116,7 +125,7 @@ describe("Layout Settings and Structure", () => {
   });
 
   afterEach(() => {
-    container.clearInstances();
+    resetContainer();
   });
 
   describe("Properties Section Visibility", () => {

--- a/packages/obsidian-plugin/tests/unit/TaskStatusService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/TaskStatusService.test.ts
@@ -1,17 +1,40 @@
-import { TaskStatusService } from "@exocortex/core";
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { TaskStatusService, DI_TOKENS, registerCoreServices, resetContainer } from "@exocortex/core";
 import { TFile, Vault } from "obsidian";
 
 describe("TaskStatusService", () => {
   let service: TaskStatusService;
-  let mockVault: jest.Mocked<Vault>;
+  let mockVault: any;
 
   beforeEach(() => {
+    resetContainer();
+
     mockVault = {
       read: jest.fn(),
       modify: jest.fn(),
-    } as unknown as jest.Mocked<Vault>;
+      getAllFiles: jest.fn().mockReturnValue([]),
+      getFrontmatter: jest.fn().mockReturnValue({}),
+      exists: jest.fn().mockResolvedValue(true),
+      updateFrontmatter: jest.fn().mockResolvedValue(undefined),
+    };
 
-    service = new TaskStatusService(mockVault);
+    const mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+    };
+
+    container.register(DI_TOKENS.IVaultAdapter, { useValue: mockVault });
+    container.register(DI_TOKENS.ILogger, { useValue: mockLogger });
+    registerCoreServices();
+
+    service = container.resolve(TaskStatusService);
+  });
+
+  afterEach(() => {
+    resetContainer();
   });
 
   describe("markTaskAsDone", () => {

--- a/packages/obsidian-plugin/tests/unit/UniversalLayoutRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/UniversalLayoutRenderer.test.ts
@@ -6,9 +6,8 @@ import { TFile } from "obsidian";
 import {
   DI_TOKENS,
   IVaultAdapter,
-  TaskFrontmatterGenerator,
-  AlgorithmExtractor,
-  TaskCreationService,
+  registerCoreServices,
+  resetContainer,
 } from "@exocortex/core";
 
 describe("UniversalLayoutRenderer", () => {
@@ -19,7 +18,7 @@ describe("UniversalLayoutRenderer", () => {
   let mockVaultAdapter: any;
 
   beforeEach(() => {
-    container.clearInstances();
+    resetContainer();
     jest.useFakeTimers();
 
     mockApp = {
@@ -71,21 +70,31 @@ describe("UniversalLayoutRenderer", () => {
       updateLinks: jest.fn(),
     };
 
-    // Setup DI container for TaskCreationService
+    // Setup DI container with all required dependencies
     mockVault = {
       create: jest.fn().mockResolvedValue({ path: "test-task.md" }),
       read: jest.fn().mockResolvedValue(""),
       modify: jest.fn().mockResolvedValue(undefined),
+      getAllFiles: jest.fn().mockReturnValue([]),
+      getFrontmatter: jest.fn().mockReturnValue({}),
+      exists: jest.fn().mockResolvedValue(true),
+      updateFrontmatter: jest.fn().mockResolvedValue(undefined),
     };
 
-    container.registerInstance<IVaultAdapter>(DI_TOKENS.IVaultAdapter, mockVault);
-    container.register(TaskFrontmatterGenerator, { useClass: TaskFrontmatterGenerator });
-    container.register(AlgorithmExtractor, { useClass: AlgorithmExtractor });
-    container.register(TaskCreationService, { useClass: TaskCreationService });
+    const mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    container.register(DI_TOKENS.IVaultAdapter, { useValue: mockVault });
+    container.register(DI_TOKENS.ILogger, { useValue: mockLogger });
+    registerCoreServices();
   });
 
   afterEach(() => {
-    container.clearInstances();
+    resetContainer();
     jest.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary

Implements Issue #469 - DI Standardization for the Exocortex project.

**Key Changes:**
- Add `@injectable()` decorator and `@inject()` DI tokens to 18+ services
- Create centralized `container.ts` with `registerCoreServices()` function
- Add new DI tokens for all services (SessionEventService, SupervisionCreationService, etc.)
- Update `PluginContainer` to use `registerCoreServices()` instead of manual registration
- Migrate `ExocortexPlugin` to use `container.resolve(TaskStatusService)`
- Update `UniversalLayoutRenderer` to resolve 12 services from DI container
- Fix test files with proper DI container setup (`resetContainer`, `registerCoreServices`)
- All services now registered as lazy singletons for consistent behavior

**Services Migrated:**
- TaskStatusService, PropertyCleanupService, TaskCreationService
- ProjectCreationService, AreaCreationService, ClassCreationService
- ConceptCreationService, FolderRepairService, RenameToUidService
- EffortVotingService, LabelToAliasService, AssetConversionService
- SessionEventService, FleetingNoteCreationService, PlanningService
- StatusTimestampService, URIConstructionService, NoteToRDFConverter
- AreaHierarchyBuilder, SupervisionCreationService, EffortStatusWorkflow

## Test Plan

- [x] All unit tests pass (1971 passed, 9 skipped)
- [x] All UI tests pass (55 passed)
- [x] All component tests pass (354 passed, 39 skipped)
- [x] BDD coverage 100% (222/222 scenarios)
- [x] TypeScript compilation passes
- [x] Lint passes (only warnings)
- [x] Build passes

Closes #469