### PR TITLE
fix(cli): Add reflect-metadata import to CLI entry point (#490)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import "reflect-metadata";
 import { Command } from "commander";
 import { sparqlQueryCommand } from "./commands/sparql-query.js";
 import { commandCommand } from "./commands/command.js";


### PR DESCRIPTION
Closes #490

## Summary
- Added `import 'reflect-metadata'` to CLI entry point
- Fixes tsyringe DI container initialization without manual `--require` flag

## Before
```bash
node packages/cli/dist/index.js sparql query "..."
# Error: tsyringe requires a reflect polyfill
```

## After
```bash
node packages/cli/dist/index.js sparql query "..."
# ✅ Works without --require flag
```

## Testing
- Verified CLI runs without `--require reflect-metadata` flag
- All unit tests pass