### PR TITLE
feat(sparql): Implement FILTER expression support (#486)

### DIFF
--- a/packages/cli/tests/unit/commands/sparql-query.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query.test.ts
@@ -35,7 +35,7 @@ jest.unstable_mockModule("@exocortex/core", () => ({
   AlgebraSerializer: jest.fn(() => ({
     toString: jest.fn().mockReturnValue("BGP()"),
   })),
-  BGPExecutor: jest.fn(() => ({
+  QueryExecutor: jest.fn(() => ({
     executeAll: jest.fn().mockResolvedValue([]),
   })),
   NoteToRDFConverter: jest.fn(() => ({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,7 @@ export { OptionalExecutor } from "./infrastructure/sparql/executors/OptionalExec
 export { UnionExecutor } from "./infrastructure/sparql/executors/UnionExecutor";
 export { ConstructExecutor } from "./infrastructure/sparql/executors/ConstructExecutor";
 export { DescribeExecutor } from "./infrastructure/sparql/executors/DescribeExecutor";
+export { QueryExecutor } from "./infrastructure/sparql/executors/QueryExecutor";
 export { SolutionMapping } from "./infrastructure/sparql/SolutionMapping";
 export { BuiltInFunctions } from "./infrastructure/sparql/filters/BuiltInFunctions";
 export { AggregateFunctions } from "./infrastructure/sparql/aggregates/AggregateFunctions";

--- a/packages/core/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -135,6 +135,34 @@ export class FilterExecutor {
         const flags = expr.args[2] ? String(this.evaluateExpression(expr.args[2], solution)) : undefined;
         return BuiltInFunctions.regex(text, pattern, flags);
 
+      // W3C SPARQL 1.1 String Functions
+      case "contains":
+        const containsStr = String(this.evaluateExpression(expr.args[0], solution));
+        const containsSubstr = String(this.evaluateExpression(expr.args[1], solution));
+        return BuiltInFunctions.contains(containsStr, containsSubstr);
+
+      case "strstarts":
+        const startsStr = String(this.evaluateExpression(expr.args[0], solution));
+        const startsPrefix = String(this.evaluateExpression(expr.args[1], solution));
+        return BuiltInFunctions.strStarts(startsStr, startsPrefix);
+
+      case "strends":
+        const endsStr = String(this.evaluateExpression(expr.args[0], solution));
+        const endsSuffix = String(this.evaluateExpression(expr.args[1], solution));
+        return BuiltInFunctions.strEnds(endsStr, endsSuffix);
+
+      case "strlen":
+        const lenStr = String(this.evaluateExpression(expr.args[0], solution));
+        return BuiltInFunctions.strlen(lenStr);
+
+      case "ucase":
+        const ucaseStr = String(this.evaluateExpression(expr.args[0], solution));
+        return BuiltInFunctions.ucase(ucaseStr);
+
+      case "lcase":
+        const lcaseStr = String(this.evaluateExpression(expr.args[0], solution));
+        return BuiltInFunctions.lcase(lcaseStr);
+
       default:
         throw new FilterExecutorError(`Unknown function: ${funcName}`);
     }

--- a/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -1,0 +1,268 @@
+import type { ITripleStore } from "../../../interfaces/ITripleStore";
+import type {
+  AlgebraOperation,
+  BGPOperation,
+  FilterOperation,
+  JoinOperation,
+  LeftJoinOperation,
+  UnionOperation,
+  ProjectOperation,
+  OrderByOperation,
+  SliceOperation,
+  DistinctOperation,
+} from "../algebra/AlgebraOperation";
+import type { SolutionMapping } from "../SolutionMapping";
+import { BGPExecutor } from "./BGPExecutor";
+import { FilterExecutor } from "./FilterExecutor";
+import { OptionalExecutor } from "./OptionalExecutor";
+import { UnionExecutor } from "./UnionExecutor";
+
+export class QueryExecutorError extends Error {
+  constructor(message: string, cause?: Error) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "QueryExecutorError";
+  }
+}
+
+/**
+ * Executes SPARQL algebra operations against a triple store.
+ * Coordinates all specialized executors (BGP, Filter, Join, etc.)
+ * to produce query results.
+ */
+export class QueryExecutor {
+  private readonly bgpExecutor: BGPExecutor;
+  private readonly filterExecutor: FilterExecutor;
+  private readonly optionalExecutor: OptionalExecutor;
+  private readonly unionExecutor: UnionExecutor;
+
+  constructor(tripleStore: ITripleStore) {
+    this.bgpExecutor = new BGPExecutor(tripleStore);
+    this.filterExecutor = new FilterExecutor();
+    this.optionalExecutor = new OptionalExecutor();
+    this.unionExecutor = new UnionExecutor();
+  }
+
+  /**
+   * Execute an algebra operation and return solution mappings.
+   */
+  async executeAll(operation: AlgebraOperation): Promise<SolutionMapping[]> {
+    const results: SolutionMapping[] = [];
+    for await (const solution of this.execute(operation)) {
+      results.push(solution);
+    }
+    return results;
+  }
+
+  /**
+   * Execute an algebra operation and stream solution mappings.
+   */
+  async *execute(operation: AlgebraOperation): AsyncIterableIterator<SolutionMapping> {
+    switch (operation.type) {
+      case "bgp":
+        yield* this.executeBGP(operation);
+        break;
+
+      case "filter":
+        yield* this.executeFilter(operation);
+        break;
+
+      case "join":
+        yield* this.executeJoin(operation);
+        break;
+
+      case "leftjoin":
+        yield* this.executeLeftJoin(operation);
+        break;
+
+      case "union":
+        yield* this.executeUnion(operation);
+        break;
+
+      case "project":
+        yield* this.executeProject(operation);
+        break;
+
+      case "orderby":
+        yield* this.executeOrderBy(operation);
+        break;
+
+      case "slice":
+        yield* this.executeSlice(operation);
+        break;
+
+      case "distinct":
+        yield* this.executeDistinct(operation);
+        break;
+
+      default:
+        throw new QueryExecutorError(`Unknown operation type: ${(operation as any).type}`);
+    }
+  }
+
+  private async *executeBGP(operation: BGPOperation): AsyncIterableIterator<SolutionMapping> {
+    yield* this.bgpExecutor.execute(operation);
+  }
+
+  private async *executeFilter(operation: FilterOperation): AsyncIterableIterator<SolutionMapping> {
+    const inputSolutions = this.execute(operation.input);
+    yield* this.filterExecutor.execute(operation, inputSolutions);
+  }
+
+  private async *executeJoin(operation: JoinOperation): AsyncIterableIterator<SolutionMapping> {
+    // Collect left solutions
+    const leftSolutions: SolutionMapping[] = [];
+    for await (const solution of this.execute(operation.left)) {
+      leftSolutions.push(solution);
+    }
+
+    // For each left solution, execute right and merge compatible
+    for (const leftSolution of leftSolutions) {
+      for await (const rightSolution of this.execute(operation.right)) {
+        const merged = leftSolution.merge(rightSolution);
+        if (merged !== null) {
+          yield merged;
+        }
+      }
+    }
+  }
+
+  private async *executeLeftJoin(operation: LeftJoinOperation): AsyncIterableIterator<SolutionMapping> {
+    // Collect solutions from both sides
+    const leftSolutions: SolutionMapping[] = [];
+    for await (const solution of this.execute(operation.left)) {
+      leftSolutions.push(solution);
+    }
+
+    const rightSolutions: SolutionMapping[] = [];
+    for await (const solution of this.execute(operation.right)) {
+      rightSolutions.push(solution);
+    }
+
+    // Use OptionalExecutor for left join semantics
+    async function* leftGen() {
+      for (const s of leftSolutions) yield s;
+    }
+    async function* rightGen() {
+      for (const s of rightSolutions) yield s;
+    }
+
+    yield* this.optionalExecutor.execute(leftGen(), rightGen());
+  }
+
+  private async *executeUnion(operation: UnionOperation): AsyncIterableIterator<SolutionMapping> {
+    // Collect solutions from both sides
+    const leftSolutions: SolutionMapping[] = [];
+    for await (const solution of this.execute(operation.left)) {
+      leftSolutions.push(solution);
+    }
+
+    const rightSolutions: SolutionMapping[] = [];
+    for await (const solution of this.execute(operation.right)) {
+      rightSolutions.push(solution);
+    }
+
+    // Use UnionExecutor
+    async function* leftGen() {
+      for (const s of leftSolutions) yield s;
+    }
+    async function* rightGen() {
+      for (const s of rightSolutions) yield s;
+    }
+
+    yield* this.unionExecutor.execute(leftGen(), rightGen());
+  }
+
+  private async *executeProject(operation: ProjectOperation): AsyncIterableIterator<SolutionMapping> {
+    // Project passes through to input, variable filtering happens at result formatting
+    for await (const solution of this.execute(operation.input)) {
+      yield solution;
+    }
+  }
+
+  private async *executeOrderBy(operation: OrderByOperation): AsyncIterableIterator<SolutionMapping> {
+    // Collect all solutions for sorting
+    const solutions: SolutionMapping[] = [];
+    for await (const solution of this.execute(operation.input)) {
+      solutions.push(solution);
+    }
+
+    // Sort by comparators
+    solutions.sort((a, b) => {
+      for (const comparator of operation.comparators) {
+        const aValue = this.getExpressionValue(comparator.expression, a);
+        const bValue = this.getExpressionValue(comparator.expression, b);
+
+        let comparison = 0;
+        if (aValue === undefined && bValue === undefined) {
+          comparison = 0;
+        } else if (aValue === undefined) {
+          comparison = 1; // undefined values go last
+        } else if (bValue === undefined) {
+          comparison = -1;
+        } else if (typeof aValue === "number" && typeof bValue === "number") {
+          comparison = aValue - bValue;
+        } else {
+          comparison = String(aValue).localeCompare(String(bValue));
+        }
+
+        if (comparator.descending) {
+          comparison = -comparison;
+        }
+
+        if (comparison !== 0) {
+          return comparison;
+        }
+      }
+      return 0;
+    });
+
+    for (const solution of solutions) {
+      yield solution;
+    }
+  }
+
+  private async *executeSlice(operation: SliceOperation): AsyncIterableIterator<SolutionMapping> {
+    let count = 0;
+    const offset = operation.offset ?? 0;
+    const limit = operation.limit;
+
+    for await (const solution of this.execute(operation.input)) {
+      if (count >= offset) {
+        if (limit !== undefined && count - offset >= limit) {
+          break;
+        }
+        yield solution;
+      }
+      count++;
+    }
+  }
+
+  private async *executeDistinct(operation: DistinctOperation): AsyncIterableIterator<SolutionMapping> {
+    const seen = new Set<string>();
+
+    for await (const solution of this.execute(operation.input)) {
+      const key = this.getSolutionKey(solution);
+      if (!seen.has(key)) {
+        seen.add(key);
+        yield solution;
+      }
+    }
+  }
+
+  private getExpressionValue(expr: any, solution: SolutionMapping): any {
+    if (expr.type === "variable") {
+      const term = solution.get(expr.name);
+      if (term) {
+        return (term as any).value ?? (term as any).id ?? String(term);
+      }
+      return undefined;
+    }
+    return expr.value;
+  }
+
+  private getSolutionKey(solution: SolutionMapping): string {
+    const json = solution.toJSON();
+    const keys = Object.keys(json).sort();
+    return keys.map((k) => `${k}=${json[k]}`).join("|");
+  }
+}

--- a/packages/core/src/infrastructure/sparql/filters/BuiltInFunctions.ts
+++ b/packages/core/src/infrastructure/sparql/filters/BuiltInFunctions.ts
@@ -139,6 +139,33 @@ export class BuiltInFunctions {
     return String(value);
   }
 
+  // W3C SPARQL 1.1 String Functions
+  // https://www.w3.org/TR/sparql11-query/#func-contains
+
+  static contains(str: string, substr: string): boolean {
+    return str.includes(substr);
+  }
+
+  static strStarts(str: string, prefix: string): boolean {
+    return str.startsWith(prefix);
+  }
+
+  static strEnds(str: string, suffix: string): boolean {
+    return str.endsWith(suffix);
+  }
+
+  static strlen(str: string): number {
+    return str.length;
+  }
+
+  static ucase(str: string): string {
+    return str.toUpperCase();
+  }
+
+  static lcase(str: string): string {
+    return str.toLowerCase();
+  }
+
   static logicalAnd(operands: boolean[]): boolean {
     return operands.every((op) => op === true);
   }

--- a/packages/core/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.test.ts
@@ -204,6 +204,74 @@ describe("BuiltInFunctions", () => {
     });
   });
 
+  describe("CONTAINS", () => {
+    it("should return true when string contains substring", () => {
+      expect(BuiltInFunctions.contains("hello world", "world")).toBe(true);
+    });
+
+    it("should return false when string does not contain substring", () => {
+      expect(BuiltInFunctions.contains("hello world", "foo")).toBe(false);
+    });
+
+    it("should be case-sensitive by default", () => {
+      expect(BuiltInFunctions.contains("Hello World", "hello")).toBe(false);
+    });
+
+    it("should handle empty substring", () => {
+      expect(BuiltInFunctions.contains("hello", "")).toBe(true);
+    });
+
+    it("should handle empty string", () => {
+      expect(BuiltInFunctions.contains("", "test")).toBe(false);
+    });
+
+    it("should handle Cyrillic text", () => {
+      expect(BuiltInFunctions.contains("Поспать после обеда", "Поспать")).toBe(true);
+    });
+  });
+
+  describe("STRSTARTS", () => {
+    it("should return true when string starts with prefix", () => {
+      expect(BuiltInFunctions.strStarts("hello world", "hello")).toBe(true);
+    });
+
+    it("should return false when string does not start with prefix", () => {
+      expect(BuiltInFunctions.strStarts("hello world", "world")).toBe(false);
+    });
+  });
+
+  describe("STRENDS", () => {
+    it("should return true when string ends with suffix", () => {
+      expect(BuiltInFunctions.strEnds("hello world", "world")).toBe(true);
+    });
+
+    it("should return false when string does not end with suffix", () => {
+      expect(BuiltInFunctions.strEnds("hello world", "hello")).toBe(false);
+    });
+  });
+
+  describe("STRLEN", () => {
+    it("should return length of string", () => {
+      expect(BuiltInFunctions.strlen("hello")).toBe(5);
+    });
+
+    it("should return 0 for empty string", () => {
+      expect(BuiltInFunctions.strlen("")).toBe(0);
+    });
+  });
+
+  describe("UCASE", () => {
+    it("should convert string to uppercase", () => {
+      expect(BuiltInFunctions.ucase("hello")).toBe("HELLO");
+    });
+  });
+
+  describe("LCASE", () => {
+    it("should convert string to lowercase", () => {
+      expect(BuiltInFunctions.lcase("HELLO")).toBe("hello");
+    });
+  });
+
   describe("Logical Operators", () => {
     it("should perform logical AND", () => {
       expect(BuiltInFunctions.logicalAnd([true, true])).toBe(true);


### PR DESCRIPTION
Closes #486

## Summary
- Added `QueryExecutor` class to orchestrate all algebra operations (BGP, Filter, Join, LeftJoin, Union, Project, OrderBy, Slice, Distinct)
- Added SPARQL 1.1 string functions: `CONTAINS`, `STRSTARTS`, `STRENDS`, `STRLEN`, `UCASE`, `LCASE`
- Fixed `AlgebraOptimizer` to handle empty BGP in FILTER joins (rewrites `Join(Filter(emptyBGP), BGP)` → `Filter(BGP)`)
- Updated CLI to use `QueryExecutor` instead of `BGPExecutor`

## Testing

```bash
node --require reflect-metadata packages/cli/dist/index.js sparql query \
  'SELECT ?s ?label WHERE { ?s <https://exocortex.my/ontology/exo#Asset_label> ?label . FILTER(CONTAINS(STR(?label), "Task")) } LIMIT 5' \
  --vault /path/to/vault
```

## Changes
- `packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts` - NEW
- `packages/core/src/infrastructure/sparql/filters/BuiltInFunctions.ts` - Added string functions
- `packages/core/src/infrastructure/sparql/executors/FilterExecutor.ts` - Added CONTAINS, etc.
- `packages/core/src/infrastructure/sparql/algebra/AlgebraOptimizer.ts` - Fixed empty BGP handling
- `packages/cli/src/commands/sparql-query.ts` - Use QueryExecutor
- Tests updated