### PR TITLE
feat(sparql): Add aggregate functions support (#489)

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -7,7 +7,9 @@ export type AlgebraOperation =
   | ProjectOperation
   | OrderByOperation
   | SliceOperation
-  | DistinctOperation;
+  | DistinctOperation
+  | GroupOperation
+  | ExtendOperation;
 
 export interface BGPOperation {
   type: "bgp";
@@ -132,5 +134,32 @@ export interface SliceOperation {
 
 export interface DistinctOperation {
   type: "distinct";
+  input: AlgebraOperation;
+}
+
+export interface GroupOperation {
+  type: "group";
+  variables: string[];
+  aggregates: AggregateBinding[];
+  input: AlgebraOperation;
+}
+
+export interface AggregateBinding {
+  variable: string;
+  expression: AggregateExpression;
+}
+
+export interface AggregateExpression {
+  type: "aggregate";
+  aggregation: "count" | "sum" | "avg" | "min" | "max" | "group_concat";
+  expression?: Expression;
+  distinct: boolean;
+  separator?: string;
+}
+
+export interface ExtendOperation {
+  type: "extend";
+  variable: string;
+  expression: Expression | AggregateExpression;
   input: AlgebraOperation;
 }

--- a/packages/core/src/infrastructure/sparql/executors/AggregateExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/AggregateExecutor.ts
@@ -1,0 +1,242 @@
+import type { GroupOperation, AggregateExpression, Expression } from "../algebra/AlgebraOperation";
+import type { SolutionMapping } from "../SolutionMapping";
+
+export class AggregateExecutorError extends Error {
+  constructor(message: string, cause?: Error) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "AggregateExecutorError";
+  }
+}
+
+export class AggregateExecutor {
+  execute(
+    operation: GroupOperation,
+    inputSolutions: SolutionMapping[]
+  ): SolutionMapping[] {
+    const groups = this.groupSolutions(inputSolutions, operation.variables);
+    const results: SolutionMapping[] = [];
+
+    for (const [_groupKey, groupSolutions] of groups.entries()) {
+      const resultBindings: Map<string, any> = new Map();
+
+      for (const varName of operation.variables) {
+        if (groupSolutions.length > 0) {
+          const term = groupSolutions[0].get(varName);
+          if (term) {
+            resultBindings.set(varName, term);
+          }
+        }
+      }
+
+      for (const aggregate of operation.aggregates) {
+        const value = this.computeAggregate(
+          aggregate.expression,
+          groupSolutions
+        );
+        resultBindings.set(aggregate.variable, value);
+      }
+
+      if (groupSolutions.length > 0) {
+        const result = groupSolutions[0].clone();
+        for (const [key, value] of resultBindings.entries()) {
+          result.set(key, value);
+        }
+        results.push(result);
+      } else {
+        const result = new (groupSolutions[0]?.constructor as any || Map)();
+        for (const [key, value] of resultBindings.entries()) {
+          result.set(key, value);
+        }
+        results.push(result);
+      }
+    }
+
+    if (results.length === 0 && operation.aggregates.length > 0) {
+      const emptyResult = this.createEmptyAggregateResult(operation);
+      if (emptyResult) {
+        results.push(emptyResult);
+      }
+    }
+
+    return results;
+  }
+
+  private groupSolutions(
+    solutions: SolutionMapping[],
+    groupVariables: string[]
+  ): Map<string, SolutionMapping[]> {
+    const groups = new Map<string, SolutionMapping[]>();
+
+    if (groupVariables.length === 0) {
+      groups.set("", solutions);
+      return groups;
+    }
+
+    for (const solution of solutions) {
+      const key = this.computeGroupKey(solution, groupVariables);
+      const existing = groups.get(key);
+      if (existing) {
+        existing.push(solution);
+      } else {
+        groups.set(key, [solution]);
+      }
+    }
+
+    return groups;
+  }
+
+  private computeGroupKey(solution: SolutionMapping, variables: string[]): string {
+    return variables
+      .map((v) => {
+        const term = solution.get(v);
+        if (!term) return "";
+        return this.termToString(term);
+      })
+      .join("|");
+  }
+
+  private termToString(term: any): string {
+    if (term && typeof term === "object") {
+      if ("value" in term) return String(term.value);
+      if ("id" in term) return String(term.id);
+    }
+    return String(term);
+  }
+
+  private computeAggregate(
+    expr: AggregateExpression,
+    solutions: SolutionMapping[]
+  ): any {
+    const values = this.extractValues(expr, solutions);
+
+    switch (expr.aggregation) {
+      case "count":
+        return this.computeCount(values, expr.distinct);
+
+      case "sum":
+        return this.computeSum(values);
+
+      case "avg":
+        return this.computeAvg(values);
+
+      case "min":
+        return this.computeMin(values);
+
+      case "max":
+        return this.computeMax(values);
+
+      case "group_concat":
+        return this.computeGroupConcat(values, expr.separator || " ", expr.distinct);
+
+      default:
+        throw new AggregateExecutorError(`Unknown aggregation function: ${expr.aggregation}`);
+    }
+  }
+
+  private extractValues(expr: AggregateExpression, solutions: SolutionMapping[]): any[] {
+    if (!expr.expression) {
+      return solutions.map(() => 1);
+    }
+
+    const values: any[] = [];
+    for (const solution of solutions) {
+      const value = this.evaluateExpression(expr.expression, solution);
+      if (value !== undefined && value !== null) {
+        values.push(value);
+      }
+    }
+
+    return values;
+  }
+
+  private evaluateExpression(expr: Expression, solution: SolutionMapping): any {
+    if (expr.type === "variable") {
+      const term = solution.get(expr.name);
+      if (!term) return undefined;
+
+      if (typeof term === "object" && "value" in term) {
+        return term.value;
+      }
+      return term;
+    }
+
+    if (expr.type === "literal") {
+      return expr.value;
+    }
+
+    return undefined;
+  }
+
+  private computeCount(values: any[], distinct: boolean): number {
+    if (distinct) {
+      return new Set(values.map((v) => String(v))).size;
+    }
+    return values.length;
+  }
+
+  private computeSum(values: any[]): number {
+    const nums = values.map((v) => parseFloat(String(v))).filter((n) => !isNaN(n));
+    return nums.reduce((acc, n) => acc + n, 0);
+  }
+
+  private computeAvg(values: any[]): number {
+    const nums = values.map((v) => parseFloat(String(v))).filter((n) => !isNaN(n));
+    if (nums.length === 0) return 0;
+    return nums.reduce((acc, n) => acc + n, 0) / nums.length;
+  }
+
+  private computeMin(values: any[]): any {
+    if (values.length === 0) return undefined;
+
+    const nums = values.map((v) => parseFloat(String(v))).filter((n) => !isNaN(n));
+    if (nums.length > 0) {
+      return Math.min(...nums);
+    }
+
+    const strs = values.map((v) => String(v));
+    return strs.reduce((min, s) => (s < min ? s : min), strs[0]);
+  }
+
+  private computeMax(values: any[]): any {
+    if (values.length === 0) return undefined;
+
+    const nums = values.map((v) => parseFloat(String(v))).filter((n) => !isNaN(n));
+    if (nums.length > 0) {
+      return Math.max(...nums);
+    }
+
+    const strs = values.map((v) => String(v));
+    return strs.reduce((max, s) => (s > max ? s : max), strs[0]);
+  }
+
+  private computeGroupConcat(values: any[], separator: string, distinct: boolean): string {
+    let strs = values.map((v) => String(v));
+
+    if (distinct) {
+      strs = [...new Set(strs)];
+    }
+
+    return strs.join(separator);
+  }
+
+  private createEmptyAggregateResult(operation: GroupOperation): SolutionMapping | null {
+    const { SolutionMapping: SM } = require("../SolutionMapping");
+    const result = new SM();
+
+    for (const aggregate of operation.aggregates) {
+      switch (aggregate.expression.aggregation) {
+        case "count":
+          result.set(aggregate.variable, 0);
+          break;
+        case "sum":
+        case "avg":
+          result.set(aggregate.variable, 0);
+          break;
+        default:
+          result.set(aggregate.variable, undefined);
+      }
+    }
+
+    return result;
+  }
+}

--- a/packages/core/tests/unit/infrastructure/sparql/AggregateExecutor.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/AggregateExecutor.test.ts
@@ -1,0 +1,350 @@
+import { AggregateExecutor } from "../../../../src/infrastructure/sparql/executors/AggregateExecutor";
+import { SolutionMapping } from "../../../../src/infrastructure/sparql/SolutionMapping";
+import type { GroupOperation, AggregateBinding, AggregateExpression } from "../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+
+describe("AggregateExecutor", () => {
+  let executor: AggregateExecutor;
+
+  beforeEach(() => {
+    executor = new AggregateExecutor();
+  });
+
+  const createSolution = (bindings: Record<string, any>): SolutionMapping => {
+    const solution = new SolutionMapping();
+    for (const [key, value] of Object.entries(bindings)) {
+      solution.set(key, value);
+    }
+    return solution;
+  };
+
+  const createGroupOperation = (
+    variables: string[],
+    aggregates: AggregateBinding[],
+    input: any = { type: "bgp", patterns: [] }
+  ): GroupOperation => ({
+    type: "group",
+    variables,
+    aggregates,
+    input,
+  });
+
+  const createCountAggregate = (variable: string, distinct = false): AggregateBinding => ({
+    variable,
+    expression: {
+      type: "aggregate",
+      aggregation: "count",
+      distinct,
+    },
+  });
+
+  const createSumAggregate = (variable: string, varName: string): AggregateBinding => ({
+    variable,
+    expression: {
+      type: "aggregate",
+      aggregation: "sum",
+      expression: { type: "variable", name: varName },
+      distinct: false,
+    },
+  });
+
+  const createAvgAggregate = (variable: string, varName: string): AggregateBinding => ({
+    variable,
+    expression: {
+      type: "aggregate",
+      aggregation: "avg",
+      expression: { type: "variable", name: varName },
+      distinct: false,
+    },
+  });
+
+  const createMinAggregate = (variable: string, varName: string): AggregateBinding => ({
+    variable,
+    expression: {
+      type: "aggregate",
+      aggregation: "min",
+      expression: { type: "variable", name: varName },
+      distinct: false,
+    },
+  });
+
+  const createMaxAggregate = (variable: string, varName: string): AggregateBinding => ({
+    variable,
+    expression: {
+      type: "aggregate",
+      aggregation: "max",
+      expression: { type: "variable", name: varName },
+      distinct: false,
+    },
+  });
+
+  const createGroupConcatAggregate = (
+    variable: string,
+    varName: string,
+    separator = " ",
+    distinct = false
+  ): AggregateBinding => ({
+    variable,
+    expression: {
+      type: "aggregate",
+      aggregation: "group_concat",
+      expression: { type: "variable", name: varName },
+      separator,
+      distinct,
+    },
+  });
+
+  describe("COUNT", () => {
+    it("should count all solutions without grouping", () => {
+      const solutions = [
+        createSolution({ x: "a" }),
+        createSolution({ x: "b" }),
+        createSolution({ x: "c" }),
+      ];
+
+      const operation = createGroupOperation([], [createCountAggregate("count")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("count")).toBe(3);
+    });
+
+    it("should count with GROUP BY", () => {
+      const solutions = [
+        createSolution({ class: "Task", x: "1" }),
+        createSolution({ class: "Task", x: "2" }),
+        createSolution({ class: "Project", x: "3" }),
+      ];
+
+      const operation = createGroupOperation(["class"], [createCountAggregate("count")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(2);
+
+      // Use toJSON() for string comparison since get() returns RDF terms
+      const taskResult = results.find((r) => r.toJSON()["class"] === "Task");
+      const projectResult = results.find((r) => r.toJSON()["class"] === "Project");
+
+      expect(taskResult?.get("count")).toBe(2);
+      expect(projectResult?.get("count")).toBe(1);
+    });
+
+    it("should count distinct values", () => {
+      const solutions = [
+        createSolution({ x: "a" }),
+        createSolution({ x: "a" }),
+        createSolution({ x: "b" }),
+      ];
+
+      // COUNT(DISTINCT ?x) - must specify expression for distinct
+      const operation = createGroupOperation([], [{
+        variable: "count",
+        expression: {
+          type: "aggregate",
+          aggregation: "count",
+          expression: { type: "variable", name: "x" },
+          distinct: true,
+        },
+      }]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("count")).toBe(2); // distinct: 'a' and 'b'
+    });
+  });
+
+  describe("SUM", () => {
+    it("should sum numeric values", () => {
+      const solutions = [
+        createSolution({ value: 10 }),
+        createSolution({ value: 20 }),
+        createSolution({ value: 30 }),
+      ];
+
+      const operation = createGroupOperation([], [createSumAggregate("total", "value")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("total")).toBe(60);
+    });
+
+    it("should handle string numbers", () => {
+      const solutions = [
+        createSolution({ value: "10" }),
+        createSolution({ value: "20" }),
+      ];
+
+      const operation = createGroupOperation([], [createSumAggregate("total", "value")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("total")).toBe(30);
+    });
+  });
+
+  describe("AVG", () => {
+    it("should compute average", () => {
+      const solutions = [
+        createSolution({ value: 10 }),
+        createSolution({ value: 20 }),
+        createSolution({ value: 30 }),
+      ];
+
+      const operation = createGroupOperation([], [createAvgAggregate("avg", "value")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("avg")).toBe(20);
+    });
+
+    it("should return 0 for empty input", () => {
+      const solutions: SolutionMapping[] = [];
+
+      const operation = createGroupOperation([], [createAvgAggregate("avg", "value")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("avg")).toBe(0);
+    });
+  });
+
+  describe("MIN", () => {
+    it("should find minimum numeric value", () => {
+      const solutions = [
+        createSolution({ value: 30 }),
+        createSolution({ value: 10 }),
+        createSolution({ value: 20 }),
+      ];
+
+      const operation = createGroupOperation([], [createMinAggregate("min", "value")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("min")).toBe(10);
+    });
+
+    it("should find minimum string value", () => {
+      const solutions = [
+        createSolution({ value: "charlie" }),
+        createSolution({ value: "alpha" }),
+        createSolution({ value: "bravo" }),
+      ];
+
+      const operation = createGroupOperation([], [createMinAggregate("min", "value")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("min")).toBe("alpha");
+    });
+  });
+
+  describe("MAX", () => {
+    it("should find maximum numeric value", () => {
+      const solutions = [
+        createSolution({ value: 10 }),
+        createSolution({ value: 30 }),
+        createSolution({ value: 20 }),
+      ];
+
+      const operation = createGroupOperation([], [createMaxAggregate("max", "value")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("max")).toBe(30);
+    });
+  });
+
+  describe("GROUP_CONCAT", () => {
+    it("should concatenate values with default separator", () => {
+      const solutions = [
+        createSolution({ name: "Alice" }),
+        createSolution({ name: "Bob" }),
+        createSolution({ name: "Charlie" }),
+      ];
+
+      const operation = createGroupOperation([], [createGroupConcatAggregate("names", "name")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("names")).toBe("Alice Bob Charlie");
+    });
+
+    it("should concatenate values with custom separator", () => {
+      const solutions = [
+        createSolution({ name: "Alice" }),
+        createSolution({ name: "Bob" }),
+      ];
+
+      const operation = createGroupOperation([], [createGroupConcatAggregate("names", "name", ", ")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("names")).toBe("Alice, Bob");
+    });
+
+    it("should handle distinct values", () => {
+      const solutions = [
+        createSolution({ name: "Alice" }),
+        createSolution({ name: "Alice" }),
+        createSolution({ name: "Bob" }),
+      ];
+
+      const operation = createGroupOperation([], [createGroupConcatAggregate("names", "name", " ", true)]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("names")).toBe("Alice Bob");
+    });
+  });
+
+  describe("Multiple aggregates", () => {
+    it("should compute multiple aggregates in one query", () => {
+      const solutions = [
+        createSolution({ value: 10 }),
+        createSolution({ value: 20 }),
+        createSolution({ value: 30 }),
+      ];
+
+      const operation = createGroupOperation([], [
+        createCountAggregate("count"),
+        createSumAggregate("total", "value"),
+        createAvgAggregate("average", "value"),
+        createMinAggregate("minimum", "value"),
+        createMaxAggregate("maximum", "value"),
+      ]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("count")).toBe(3);
+      expect(results[0].get("total")).toBe(60);
+      expect(results[0].get("average")).toBe(20);
+      expect(results[0].get("minimum")).toBe(10);
+      expect(results[0].get("maximum")).toBe(30);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle empty input with COUNT returning 0", () => {
+      const solutions: SolutionMapping[] = [];
+
+      const operation = createGroupOperation([], [createCountAggregate("count")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("count")).toBe(0);
+    });
+
+    it("should handle missing values in aggregation", () => {
+      const solutions = [
+        createSolution({ value: 10 }),
+        createSolution({}), // missing 'value'
+        createSolution({ value: 20 }),
+      ];
+
+      const operation = createGroupOperation([], [createSumAggregate("total", "value")]);
+      const results = executor.execute(operation, solutions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].get("total")).toBe(30); // Only valid values summed
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements SPARQL aggregate functions for the query engine (Issue #489):

- **COUNT** - Count solutions (with DISTINCT support)
- **SUM** - Sum numeric values
- **AVG** - Calculate average
- **MIN** - Find minimum value
- **MAX** - Find maximum value
- **GROUP_CONCAT** - Concatenate values (with separator and DISTINCT)

Also adds **GROUP BY** clause support for grouping solutions before aggregation.

## Changes

- `AlgebraOperation.ts`: Add GroupOperation, ExtendOperation, AggregateExpression types
- `AlgebraTranslator.ts`: Parse GROUP BY clauses and aggregate expressions
- `AggregateExecutor.ts`: New executor with all aggregation functions
- `QueryExecutor.ts`: Add group/extend operation handlers
- `AggregateExecutor.test.ts`: 16 unit tests covering all aggregate functions

## Example Query

```sparql
SELECT ?class (COUNT(?s) AS ?count)
WHERE {
  ?s <http://example.org/type> ?class .
}
GROUP BY ?class
```

## Test Plan

- [x] TypeScript type checking passes
- [x] 16 new unit tests for AggregateExecutor pass
- [ ] CI build passes
- [ ] CI tests pass

Closes #489