### PR TITLE
docs(sparql): Create SPARQL query documentation (#492)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,13 +20,17 @@ npx exocortex-cli [command]
 exocortex --help
 ```
 
-### SPARQL Query (NEW!)
+### SPARQL Query
 
-Execute SPARQL queries against your Obsidian vault as an RDF knowledge graph:
+Execute SPARQL queries against your Obsidian vault as an RDF knowledge graph.
+
+**Documentation:**
+- [SPARQL Guide](docs/SPARQL_GUIDE.md) - Complete query reference
+- [SPARQL Cookbook](docs/SPARQL_COOKBOOK.md) - Real-world examples
+- [Ontology Reference](docs/ONTOLOGY_REFERENCE.md) - Available predicates
 
 ```bash
-exocortex sparql query "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10" \
-  --vault ~/vault
+exo query "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10" --vault ~/vault
 ```
 
 **Options:**
@@ -40,27 +44,27 @@ exocortex sparql query "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10" \
 **Examples:**
 
 ```bash
-# Find all tasks with high effort
-exocortex sparql query \
-  "PREFIX ems: <http://exocortex.org/ems/>
-   SELECT ?task ?label ?effort
+# Find all tasks
+exo query \
+  "PREFIX exo: <https://exocortex.my/ontology/exo#>
+   PREFIX ems: <https://exocortex.my/ontology/ems#>
+   SELECT ?task ?label
    WHERE {
-     ?task <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ems:Task .
-     ?task ems:label ?label .
-     ?task ems:effort ?effort .
+     ?task exo:Instance_class ems:Task .
+     ?task exo:Asset_label ?label .
    }" \
   --vault ~/vault
 
 # Query from file
-exocortex sparql query queries/high-effort-tasks.sparql --vault ~/vault
+exo query queries/my-query.sparql --vault ~/vault
 
 # JSON output for automation
-exocortex sparql query "SELECT ?s ?p ?o WHERE { ?s ?p ?o }" \
+exo query "SELECT ?s ?p ?o WHERE { ?s ?p ?o }" \
   --vault ~/vault \
   --format json > results.json
 
-# Show query plan
-exocortex sparql query "SELECT ?task WHERE { ?task <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://exocortex.org/ems/Task> }" \
+# Show query plan and stats
+exo query "SELECT ?task WHERE { ?task exo:Instance_class ems:Task }" \
   --vault ~/vault \
   --explain \
   --stats

--- a/packages/cli/docs/ONTOLOGY_REFERENCE.md
+++ b/packages/cli/docs/ONTOLOGY_REFERENCE.md
@@ -1,0 +1,592 @@
+# Exocortex Ontology Reference
+
+**Version**: 1.0
+**Last Updated**: 2025-11-30
+**Purpose**: Complete reference of predicates and URIs for SPARQL queries
+
+---
+
+## Table of Contents
+
+1. [Namespaces](#namespaces)
+2. [Asset Classes](#asset-classes)
+3. [Core Predicates (exo:)](#core-predicates-exo)
+4. [Effort Management Predicates (ems:)](#effort-management-predicates-ems)
+5. [Status Values](#status-values)
+6. [URI Patterns](#uri-patterns)
+7. [Example Queries by Class](#example-queries-by-class)
+
+---
+
+## Namespaces
+
+### Standard Prefixes
+
+Use these PREFIX declarations in your SPARQL queries:
+
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+```
+
+### Namespace URIs
+
+| Prefix | Full URI | Purpose |
+|--------|----------|---------|
+| `rdf:` | `http://www.w3.org/1999/02/22-rdf-syntax-ns#` | RDF standard vocabulary |
+| `rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` | RDF Schema vocabulary |
+| `xsd:` | `http://www.w3.org/2001/XMLSchema#` | XML Schema datatypes |
+| `exo:` | `https://exocortex.my/ontology/exo#` | Exocortex core vocabulary |
+| `ems:` | `https://exocortex.my/ontology/ems#` | Effort Management System |
+
+---
+
+## Asset Classes
+
+### Class URIs
+
+| Class | URI | Frontmatter Value |
+|-------|-----|-------------------|
+| Task | `ems:Task` | `ems__Task` |
+| Project | `ems:Project` | `ems__Project` |
+| Area | `ems:Area` | `ems__Area` |
+| Meeting | `ems:Meeting` | `ems__Meeting` |
+| Initiative | `ems:Initiative` | `ems__Initiative` |
+| TaskPrototype | `ems:TaskPrototype` | `ems__TaskPrototype` |
+| MeetingPrototype | `ems:MeetingPrototype` | `ems__MeetingPrototype` |
+
+### Query Examples
+
+```sparql
+# Find all tasks
+SELECT ?task WHERE { ?task exo:Instance_class ems:Task }
+
+# Find all projects
+SELECT ?project WHERE { ?project exo:Instance_class ems:Project }
+
+# Find all areas
+SELECT ?area WHERE { ?area exo:Instance_class ems:Area }
+
+# Find all prototypes
+SELECT ?proto WHERE {
+  { ?proto exo:Instance_class ems:TaskPrototype }
+  UNION
+  { ?proto exo:Instance_class ems:MeetingPrototype }
+}
+```
+
+---
+
+## Core Predicates (exo:)
+
+These predicates apply to ALL asset types.
+
+### exo:Asset_uid
+
+**UUID identifier for the asset**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/exo#Asset_uid` |
+| Frontmatter | `exo__Asset_uid` |
+| Type | Literal (UUID v4 string) |
+| Required | Yes |
+
+```sparql
+SELECT ?asset ?uid WHERE {
+  ?asset exo:Asset_uid ?uid .
+}
+```
+
+### exo:Asset_label
+
+**Human-readable name**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/exo#Asset_label` |
+| Frontmatter | `exo__Asset_label` |
+| Type | Literal (string) |
+| Required | Yes |
+
+```sparql
+SELECT ?asset ?label WHERE {
+  ?asset exo:Asset_label ?label .
+  FILTER(CONTAINS(?label, "Review"))
+}
+```
+
+### exo:Asset_createdAt
+
+**Creation timestamp**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/exo#Asset_createdAt` |
+| Frontmatter | `exo__Asset_createdAt` |
+| Type | Literal (ISO 8601 timestamp) |
+| Required | Yes |
+
+```sparql
+SELECT ?asset ?created WHERE {
+  ?asset exo:Asset_createdAt ?created .
+  FILTER(STR(?created) >= "2025-11-01")
+}
+ORDER BY DESC(?created)
+```
+
+### exo:Instance_class
+
+**Asset type classification**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/exo#Instance_class` |
+| Frontmatter | `exo__Instance_class` |
+| Type | IRI (class reference) |
+| Required | Yes |
+
+```sparql
+SELECT ?asset ?class WHERE {
+  ?asset exo:Instance_class ?class .
+}
+```
+
+### exo:Asset_isArchived
+
+**Archive status**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/exo#Asset_isArchived` |
+| Frontmatter | `exo__Asset_isArchived` |
+| Type | Literal (boolean) |
+| Required | No |
+
+```sparql
+SELECT ?asset ?label WHERE {
+  ?asset exo:Asset_label ?label .
+  ?asset exo:Asset_isArchived "true" .
+}
+```
+
+### exo:Asset_prototype
+
+**Reference to template/prototype**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/exo#Asset_prototype` |
+| Frontmatter | `exo__Asset_prototype` |
+| Type | IRI (reference to prototype note) |
+| Required | For instances from prototypes |
+
+```sparql
+SELECT ?task ?label ?prototype WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task exo:Asset_prototype ?prototype .
+}
+```
+
+### exo:Asset_isDefinedBy
+
+**Ontology reference**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/exo#Asset_isDefinedBy` |
+| Frontmatter | `exo__Asset_isDefinedBy` |
+| Type | IRI (reference to ontology note) |
+| Required | Yes |
+
+```sparql
+SELECT ?asset ?ontology WHERE {
+  ?asset exo:Asset_isDefinedBy ?ontology .
+}
+```
+
+---
+
+## Effort Management Predicates (ems:)
+
+These predicates apply to efforts (Tasks, Projects, Meetings).
+
+### ems:Effort_status
+
+**Current workflow status**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Effort_status` |
+| Frontmatter | `ems__Effort_status` |
+| Type | IRI (status class reference) |
+| Values | See [Status Values](#status-values) |
+
+```sparql
+SELECT ?task ?label ?status WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_status ?status .
+  FILTER(CONTAINS(STR(?status), "Doing"))
+}
+```
+
+### ems:Effort_area
+
+**Parent area reference**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Effort_area` |
+| Frontmatter | `ems__Effort_area` |
+| Type | IRI (reference to area note) |
+| Required | For tasks created from areas |
+
+```sparql
+SELECT ?task ?label ?area WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_area ?area .
+}
+```
+
+### ems:Effort_parent
+
+**Parent project/initiative reference**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Effort_parent` |
+| Frontmatter | `ems__Effort_parent` |
+| Type | IRI (reference to project/initiative note) |
+| Required | For tasks/projects with parent |
+
+```sparql
+SELECT ?task ?label ?project WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_parent ?project .
+}
+```
+
+### ems:Effort_votes
+
+**Priority vote count**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Effort_votes` |
+| Frontmatter | `ems__Effort_votes` |
+| Type | Literal (integer) |
+| Default | 0 |
+
+```sparql
+SELECT ?task ?label ?votes WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_votes ?votes .
+  FILTER(?votes > 0)
+}
+ORDER BY DESC(?votes)
+```
+
+### ems:Effort_day
+
+**Planned execution day**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Effort_day` |
+| Frontmatter | `ems__Effort_day` |
+| Type | IRI or Literal (date reference) |
+| Format | WikiLink to date: `[[YYYY-MM-DD]]` |
+
+```sparql
+SELECT ?task ?label ?day WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_day ?day .
+  FILTER(CONTAINS(STR(?day), "2025-11-30"))
+}
+```
+
+### ems:Effort_startTimestamp
+
+**When effort started (entered Doing)**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Effort_startTimestamp` |
+| Frontmatter | `ems__Effort_startTimestamp` |
+| Type | Literal (ISO 8601 timestamp) |
+
+```sparql
+SELECT ?task ?label ?started WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_startTimestamp ?started .
+}
+ORDER BY DESC(?started)
+```
+
+### ems:Effort_endTimestamp
+
+**When effort paused/stopped**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Effort_endTimestamp` |
+| Frontmatter | `ems__Effort_endTimestamp` |
+| Type | Literal (ISO 8601 timestamp) |
+
+```sparql
+SELECT ?task ?label ?ended WHERE {
+  ?task ems:Effort_endTimestamp ?ended .
+  ?task exo:Asset_label ?label .
+}
+```
+
+### ems:Effort_resolutionTimestamp
+
+**When effort completed (moved to Done)**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Effort_resolutionTimestamp` |
+| Frontmatter | `ems__Effort_resolutionTimestamp` |
+| Type | Literal (ISO 8601 timestamp) |
+
+```sparql
+SELECT ?task ?label ?completed WHERE {
+  ?task ems:Effort_resolutionTimestamp ?completed .
+  ?task exo:Asset_label ?label .
+  FILTER(STR(?completed) >= "2025-11-25")
+}
+ORDER BY DESC(?completed)
+```
+
+### ems:Effort_plannedStartTimestamp
+
+**Planned start time (for scheduling)**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Effort_plannedStartTimestamp` |
+| Frontmatter | `ems__Effort_plannedStartTimestamp` |
+| Type | Literal (ISO 8601 timestamp) |
+
+```sparql
+SELECT ?task ?label ?planned WHERE {
+  ?task ems:Effort_plannedStartTimestamp ?planned .
+  ?task exo:Asset_label ?label .
+}
+ORDER BY ?planned
+```
+
+### ems:Task_size
+
+**Task size estimate**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Task_size` |
+| Frontmatter | `ems__Task_size` |
+| Type | Literal (S, M, L, XL) |
+| Applies to | Tasks only |
+
+```sparql
+SELECT ?task ?label ?size WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Task_size ?size .
+}
+```
+
+### ems:Area_parent
+
+**Parent area (for area hierarchy)**
+
+| Property | Value |
+|----------|-------|
+| URI | `https://exocortex.my/ontology/ems#Area_parent` |
+| Frontmatter | `ems__Area_parent` |
+| Type | IRI (reference to parent area note) |
+| Applies to | Areas only |
+
+```sparql
+SELECT ?area ?label ?parent WHERE {
+  ?area exo:Instance_class ems:Area .
+  ?area exo:Asset_label ?label .
+  OPTIONAL { ?area ems:Area_parent ?parent }
+}
+```
+
+---
+
+## Status Values
+
+### Status URIs
+
+| Status | URI | Frontmatter Value |
+|--------|-----|-------------------|
+| Draft | `ems:EffortStatusDraft` | `ems__EffortStatusDraft` |
+| Backlog | `ems:EffortStatusBacklog` | `ems__EffortStatusBacklog` |
+| Analysis | `ems:EffortStatusAnalysis` | `ems__EffortStatusAnalysis` |
+| ToDo | `ems:EffortStatusToDo` | `ems__EffortStatusToDo` |
+| Doing | `ems:EffortStatusDoing` | `ems__EffortStatusDoing` |
+| Done | `ems:EffortStatusDone` | `ems__EffortStatusDone` |
+| Trashed | `ems:EffortStatusTrashed` | `ems__EffortStatusTrashed` |
+
+### Status Workflow
+
+```
+Draft → Backlog → Analysis → ToDo → Doing → Done
+          ↓                            ↓
+        Trashed ←──────────────────────┘
+```
+
+### Query by Status
+
+```sparql
+# Tasks in Backlog
+SELECT ?task ?label WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_status ?status .
+  FILTER(CONTAINS(STR(?status), "Backlog"))
+}
+
+# Tasks NOT done or trashed
+SELECT ?task ?label ?status WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_status ?status .
+  FILTER(!CONTAINS(STR(?status), "Done"))
+  FILTER(!CONTAINS(STR(?status), "Trashed"))
+}
+```
+
+---
+
+## URI Patterns
+
+### Note URIs
+
+Notes are represented as IRIs with the `obsidian://vault/` scheme:
+
+```
+obsidian://vault/{encoded-path}
+```
+
+Example:
+- Note path: `Tasks/Review PR #123.md`
+- URI: `obsidian://vault/Tasks%2FReview%20PR%20%23123.md`
+
+### Predicate URIs
+
+Predicates follow the pattern:
+```
+https://exocortex.my/ontology/{namespace}#{PropertyName}
+```
+
+Examples:
+- `https://exocortex.my/ontology/exo#Asset_label`
+- `https://exocortex.my/ontology/ems#Effort_status`
+
+### Class URIs
+
+Classes follow the pattern:
+```
+https://exocortex.my/ontology/ems#{ClassName}
+```
+
+Examples:
+- `https://exocortex.my/ontology/ems#Task`
+- `https://exocortex.my/ontology/ems#Project`
+
+---
+
+## Example Queries by Class
+
+### Tasks
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?status ?area ?votes ?size WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  OPTIONAL { ?task ems:Effort_status ?status }
+  OPTIONAL { ?task ems:Effort_area ?area }
+  OPTIONAL { ?task ems:Effort_votes ?votes }
+  OPTIONAL { ?task ems:Task_size ?size }
+}
+ORDER BY DESC(?votes) ?label
+```
+
+### Projects
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?project ?label ?status ?area ?votes WHERE {
+  ?project exo:Instance_class ems:Project .
+  ?project exo:Asset_label ?label .
+  OPTIONAL { ?project ems:Effort_status ?status }
+  OPTIONAL { ?project ems:Effort_area ?area }
+  OPTIONAL { ?project ems:Effort_votes ?votes }
+}
+ORDER BY ?label
+```
+
+### Areas
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?area ?label ?parent WHERE {
+  ?area exo:Instance_class ems:Area .
+  ?area exo:Asset_label ?label .
+  OPTIONAL { ?area ems:Area_parent ?parent }
+}
+ORDER BY ?parent ?label
+```
+
+### All Efforts (Tasks + Projects + Meetings)
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?effort ?label ?class ?status WHERE {
+  ?effort exo:Instance_class ?class .
+  ?effort exo:Asset_label ?label .
+  OPTIONAL { ?effort ems:Effort_status ?status }
+  FILTER(
+    ?class = ems:Task ||
+    ?class = ems:Project ||
+    ?class = ems:Meeting
+  )
+}
+ORDER BY ?class ?label
+```
+
+---
+
+## Related Documentation
+
+- [SPARQL Guide](SPARQL_GUIDE.md) - Complete query reference
+- [SPARQL Cookbook](SPARQL_COOKBOOK.md) - Practical examples
+- [Property Schema](../../docs/PROPERTY_SCHEMA.md) - Frontmatter properties
+
+---
+
+**Maintainer**: @kitelev
+**Related Issues**: #492 (SPARQL Documentation)

--- a/packages/cli/docs/SPARQL_COOKBOOK.md
+++ b/packages/cli/docs/SPARQL_COOKBOOK.md
@@ -1,0 +1,571 @@
+# SPARQL Cookbook
+
+**Version**: 1.0
+**Last Updated**: 2025-11-30
+**Purpose**: Real-world query examples for common Exocortex use cases
+
+---
+
+## Table of Contents
+
+1. [Task Management](#task-management)
+2. [Project Tracking](#project-tracking)
+3. [Daily Planning](#daily-planning)
+4. [Analytics & Reporting](#analytics--reporting)
+5. [Search & Discovery](#search--discovery)
+6. [Data Quality](#data-quality)
+
+---
+
+## Standard Prefixes
+
+Use these prefixes in all queries:
+
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+```
+
+---
+
+## Task Management
+
+### Find All Active Tasks
+
+Tasks that are currently in "Doing" status:
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_status ?status .
+  FILTER(CONTAINS(STR(?status), "EffortStatusDoing"))
+}
+```
+
+### Find Tasks by Status
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?status WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_status ?status .
+  FILTER(CONTAINS(STR(?status), "EffortStatusBacklog"))
+}
+ORDER BY ?label
+```
+
+### Find High-Priority Tasks (Most Voted)
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?votes WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_votes ?votes .
+  FILTER(?votes > 0)
+}
+ORDER BY DESC(?votes)
+LIMIT 10
+```
+
+### Find Tasks Without Votes
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  OPTIONAL { ?task ems:Effort_votes ?votes }
+  FILTER(!BOUND(?votes) || ?votes = 0)
+}
+```
+
+### Find Overdue Tasks
+
+Tasks planned for past dates but not completed:
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?day ?status WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_day ?day .
+  ?task ems:Effort_status ?status .
+  FILTER(!CONTAINS(STR(?status), "Done"))
+  FILTER(!CONTAINS(STR(?status), "Trashed"))
+  FILTER(STR(?day) < "2025-11-30")
+}
+ORDER BY ?day
+```
+
+### Find Tasks by Size
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?size WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Task_size ?size .
+  FILTER(?size = "L" || ?size = "XL")
+}
+```
+
+### Find Tasks with Keyword in Label
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  FILTER(CONTAINS(LCASE(?label), "review"))
+}
+```
+
+---
+
+## Project Tracking
+
+### List All Projects with Status
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?project ?label ?status WHERE {
+  ?project exo:Instance_class ems:Project .
+  ?project exo:Asset_label ?label .
+  ?project ems:Effort_status ?status .
+}
+ORDER BY ?status ?label
+```
+
+### Count Tasks per Project
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?project ?projectLabel (COUNT(?task) AS ?taskCount) WHERE {
+  ?project exo:Instance_class ems:Project .
+  ?project exo:Asset_label ?projectLabel .
+  ?task ems:Effort_parent ?project .
+  ?task exo:Instance_class ems:Task .
+}
+GROUP BY ?project ?projectLabel
+ORDER BY DESC(?taskCount)
+```
+
+### Find Project Tasks by Status
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?project ?projectLabel ?status (COUNT(?task) AS ?count) WHERE {
+  ?project exo:Instance_class ems:Project .
+  ?project exo:Asset_label ?projectLabel .
+  ?task ems:Effort_parent ?project .
+  ?task ems:Effort_status ?status .
+}
+GROUP BY ?project ?projectLabel ?status
+ORDER BY ?projectLabel ?status
+```
+
+### Find Projects with No Tasks
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?project ?label WHERE {
+  ?project exo:Instance_class ems:Project .
+  ?project exo:Asset_label ?label .
+  FILTER NOT EXISTS {
+    ?task ems:Effort_parent ?project .
+  }
+}
+```
+
+---
+
+## Daily Planning
+
+### Tasks Planned for Today
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?status WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_day ?day .
+  ?task ems:Effort_status ?status .
+  FILTER(CONTAINS(STR(?day), "2025-11-30"))
+}
+ORDER BY ?label
+```
+
+### Tasks with Planned Start Time
+
+Evening tasks with specific start times:
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?plannedStart WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_plannedStartTimestamp ?plannedStart .
+}
+ORDER BY ?plannedStart
+```
+
+### Completed Tasks This Week
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?completedAt WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_resolutionTimestamp ?completedAt .
+  FILTER(STR(?completedAt) >= "2025-11-25")
+}
+ORDER BY DESC(?completedAt)
+```
+
+### Tasks Started But Not Completed
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?startedAt WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_startTimestamp ?startedAt .
+  ?task ems:Effort_status ?status .
+  FILTER(!CONTAINS(STR(?status), "Done"))
+}
+ORDER BY ?startedAt
+```
+
+---
+
+## Analytics & Reporting
+
+### Task Count by Status
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?status (COUNT(?task) AS ?count) WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task ems:Effort_status ?status .
+}
+GROUP BY ?status
+ORDER BY DESC(?count)
+```
+
+### Task Count by Area
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?area (COUNT(?task) AS ?taskCount) WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task ems:Effort_area ?area .
+}
+GROUP BY ?area
+ORDER BY DESC(?taskCount)
+```
+
+### Task Count by Size
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?size (COUNT(?task) AS ?count) WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task ems:Task_size ?size .
+}
+GROUP BY ?size
+ORDER BY ?size
+```
+
+### Total Votes by Area
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?area (SUM(?votes) AS ?totalVotes) (AVG(?votes) AS ?avgVotes) WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task ems:Effort_area ?area .
+  ?task ems:Effort_votes ?votes .
+}
+GROUP BY ?area
+ORDER BY DESC(?totalVotes)
+```
+
+### Average Votes per Task Size
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?size (AVG(?votes) AS ?avgVotes) (COUNT(?task) AS ?count) WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task ems:Task_size ?size .
+  ?task ems:Effort_votes ?votes .
+}
+GROUP BY ?size
+ORDER BY ?size
+```
+
+### Asset Class Distribution
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT ?class (COUNT(?asset) AS ?count) WHERE {
+  ?asset exo:Instance_class ?class .
+}
+GROUP BY ?class
+ORDER BY DESC(?count)
+```
+
+### Creation Timeline
+
+Assets created in the last 7 days:
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT ?asset ?label ?created WHERE {
+  ?asset exo:Asset_label ?label .
+  ?asset exo:Asset_createdAt ?created .
+  FILTER(STR(?created) >= "2025-11-24")
+}
+ORDER BY DESC(?created)
+```
+
+---
+
+## Search & Discovery
+
+### Find Assets by Label Pattern
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT ?asset ?label ?class WHERE {
+  ?asset exo:Asset_label ?label .
+  ?asset exo:Instance_class ?class .
+  FILTER(REGEX(?label, "PR #\\d+", "i"))
+}
+```
+
+### Find All Areas
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?area ?label WHERE {
+  ?area exo:Instance_class ems:Area .
+  ?area exo:Asset_label ?label .
+}
+ORDER BY ?label
+```
+
+### Find Area Hierarchy
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?area ?label ?parent WHERE {
+  ?area exo:Instance_class ems:Area .
+  ?area exo:Asset_label ?label .
+  OPTIONAL { ?area ems:Area_parent ?parent }
+}
+ORDER BY ?parent ?label
+```
+
+### Find Task Prototypes
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?prototype ?label WHERE {
+  ?prototype exo:Instance_class ems:TaskPrototype .
+  ?prototype exo:Asset_label ?label .
+}
+ORDER BY ?label
+```
+
+### Find Tasks from Prototype
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label ?prototype WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task exo:Asset_prototype ?prototype .
+}
+ORDER BY ?prototype ?label
+```
+
+### Full-Text Search
+
+Search across all labels:
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT ?asset ?label ?class WHERE {
+  ?asset exo:Asset_label ?label .
+  ?asset exo:Instance_class ?class .
+  FILTER(CONTAINS(LCASE(?label), "meeting"))
+}
+ORDER BY ?class ?label
+```
+
+---
+
+## Data Quality
+
+### Find Assets Without Labels
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT ?asset WHERE {
+  ?asset exo:Asset_uid ?uid .
+  FILTER NOT EXISTS { ?asset exo:Asset_label ?label }
+}
+```
+
+### Find Tasks Without Status
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  FILTER NOT EXISTS { ?task ems:Effort_status ?status }
+}
+```
+
+### Find Tasks Without Area
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  FILTER NOT EXISTS { ?task ems:Effort_area ?area }
+  FILTER NOT EXISTS { ?task ems:Effort_parent ?parent }
+}
+```
+
+### Find Archived Assets
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT ?asset ?label WHERE {
+  ?asset exo:Asset_label ?label .
+  ?asset exo:Asset_isArchived ?archived .
+  FILTER(?archived = "true" || ?archived = true)
+}
+```
+
+### Find Duplicate Labels
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+SELECT ?label (COUNT(?asset) AS ?count) WHERE {
+  ?asset exo:Asset_label ?label .
+}
+GROUP BY ?label
+HAVING (COUNT(?asset) > 1)
+ORDER BY DESC(?count)
+```
+
+---
+
+## Tips & Best Practices
+
+### Performance Tips
+
+1. **Use LIMIT** for exploratory queries
+2. **Add specific patterns first** to reduce intermediate results
+3. **Use `--stats`** to identify slow queries
+4. **Avoid `SELECT *`** in production queries
+
+### Query Writing Tips
+
+1. **Start simple**, then add complexity
+2. **Use OPTIONAL** for nullable properties
+3. **Use FILTER EXISTS/NOT EXISTS** for presence checks
+4. **Test with `--explain`** to understand query plan
+
+### Debugging Tips
+
+```bash
+# Check what predicates exist in vault
+exo query 'SELECT DISTINCT ?p WHERE { ?s ?p ?o } LIMIT 100'
+
+# Check sample values for a predicate
+exo query 'SELECT ?o WHERE { ?s exo:Instance_class ?o } LIMIT 10'
+
+# Verify namespace URIs
+exo query 'SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 5' --format json
+```
+
+---
+
+## Related Documentation
+
+- [SPARQL Guide](SPARQL_GUIDE.md) - Complete query reference
+- [Ontology Reference](ONTOLOGY_REFERENCE.md) - Available predicates
+- [Property Schema](../../docs/PROPERTY_SCHEMA.md) - Frontmatter properties
+
+---
+
+**Maintainer**: @kitelev
+**Related Issues**: #492 (SPARQL Documentation)

--- a/packages/cli/docs/SPARQL_GUIDE.md
+++ b/packages/cli/docs/SPARQL_GUIDE.md
@@ -1,0 +1,557 @@
+# SPARQL Query Guide
+
+**Version**: 1.0
+**Last Updated**: 2025-11-30
+**Purpose**: Complete guide to querying your Obsidian vault with SPARQL
+
+---
+
+## Table of Contents
+
+1. [Quick Start](#quick-start)
+2. [Installation](#installation)
+3. [Basic Queries](#basic-queries)
+4. [Query Reference](#query-reference)
+5. [FILTER Expressions](#filter-expressions)
+6. [JOIN Patterns](#join-patterns)
+7. [Aggregates](#aggregates)
+8. [Output Formats](#output-formats)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## Quick Start
+
+### Your First Query
+
+List all tasks in your vault:
+
+```bash
+exo query 'SELECT ?task ?label WHERE {
+  ?task <https://exocortex.my/ontology/exo#Instance_class> <https://exocortex.my/ontology/ems#Task> .
+  ?task <https://exocortex.my/ontology/exo#Asset_label> ?label .
+}'
+```
+
+### Using Prefixes (Recommended)
+
+```bash
+exo query 'PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+}'
+```
+
+### Query from File
+
+Save your query to a `.sparql` file and run:
+
+```bash
+# Create query file
+cat > my-query.sparql << 'EOF'
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task ?label WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+}
+EOF
+
+# Execute query
+exo query my-query.sparql
+```
+
+---
+
+## Installation
+
+### Prerequisites
+
+- Node.js 18+
+- An Obsidian vault with Exocortex-formatted notes
+
+### Install CLI
+
+```bash
+npm install -g @exocortex/cli
+```
+
+### Verify Installation
+
+```bash
+exo --version
+exo query --help
+```
+
+---
+
+## Basic Queries
+
+### Command Syntax
+
+```bash
+exo query <query> [options]
+```
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--vault <path>` | Path to Obsidian vault | Current directory |
+| `--format <type>` | Output format: `table`, `json`, `csv` | `table` |
+| `--explain` | Show optimized query plan | Off |
+| `--stats` | Show execution statistics | Off |
+| `--no-optimize` | Disable query optimization | Optimized |
+
+### Examples
+
+```bash
+# Query with explicit vault path
+exo query 'SELECT * WHERE { ?s ?p ?o } LIMIT 10' --vault ~/Obsidian/MyVault
+
+# Output as JSON
+exo query 'SELECT ?task WHERE { ?task a ems:Task }' --format json
+
+# Show query plan
+exo query 'SELECT ?task WHERE { ?task a ems:Task }' --explain
+
+# Show execution statistics
+exo query 'SELECT ?task WHERE { ?task a ems:Task }' --stats
+```
+
+---
+
+## Query Reference
+
+### SELECT Syntax
+
+```sparql
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT [DISTINCT] ?var1 ?var2 ...
+WHERE {
+  # Triple patterns
+  ?subject ?predicate ?object .
+}
+[ORDER BY ?var [DESC(?var)]]
+[LIMIT n]
+[OFFSET n]
+```
+
+### Variable Binding
+
+Variables start with `?` and bind to values matching patterns:
+
+```sparql
+# ?task binds to any subject with Instance_class = Task
+?task exo:Instance_class ems:Task .
+
+# ?label binds to the Asset_label of ?task
+?task exo:Asset_label ?label .
+```
+
+### Literal Values
+
+```sparql
+# String literal
+?task exo:Asset_label "My Task" .
+
+# Numeric literal
+?task ems:Effort_votes 5 .
+```
+
+### ORDER BY
+
+```sparql
+# Ascending (default)
+SELECT ?task ?votes WHERE {
+  ?task ems:Effort_votes ?votes .
+}
+ORDER BY ?votes
+
+# Descending
+ORDER BY DESC(?votes)
+
+# Multiple criteria
+ORDER BY DESC(?votes) ?label
+```
+
+### LIMIT and OFFSET
+
+```sparql
+# First 10 results
+SELECT ?task WHERE { ?task a ems:Task } LIMIT 10
+
+# Skip first 20, get next 10
+SELECT ?task WHERE { ?task a ems:Task } LIMIT 10 OFFSET 20
+```
+
+### DISTINCT
+
+```sparql
+# Remove duplicate results
+SELECT DISTINCT ?area WHERE {
+  ?task ems:Effort_area ?area .
+}
+```
+
+---
+
+## FILTER Expressions
+
+### Comparison Operators
+
+```sparql
+# Equal
+FILTER(?votes = 5)
+
+# Not equal
+FILTER(?votes != 0)
+
+# Greater than / Less than
+FILTER(?votes > 3)
+FILTER(?votes < 10)
+
+# Greater or equal / Less or equal
+FILTER(?votes >= 3)
+FILTER(?votes <= 10)
+```
+
+### String Functions
+
+```sparql
+# Contains substring
+FILTER(CONTAINS(?label, "Review"))
+
+# Starts with prefix
+FILTER(STRSTARTS(?label, "Meeting"))
+
+# Ends with suffix
+FILTER(STRENDS(?label, "2025"))
+
+# Regular expression
+FILTER(REGEX(?label, "^PR #\\d+"))
+
+# Case-insensitive regex
+FILTER(REGEX(?label, "meeting", "i"))
+```
+
+### String Manipulation
+
+```sparql
+# Convert to string
+STR(?value)
+
+# String length
+STRLEN(?label)
+
+# Substring (1-based index)
+SUBSTR(?label, 1, 10)
+
+# Case conversion
+UCASE(?label)
+LCASE(?label)
+
+# Replace text
+REPLACE(?label, "old", "new")
+
+# Concatenate
+CONCAT(?first, " ", ?last)
+```
+
+### Numeric Functions
+
+```sparql
+# Absolute value
+ABS(?number)
+
+# Ceiling (round up)
+CEIL(?number)
+
+# Floor (round down)
+FLOOR(?number)
+
+# Round to nearest
+ROUND(?number)
+```
+
+### Type Checking
+
+```sparql
+# Check if variable is bound
+FILTER(BOUND(?area))
+FILTER(!BOUND(?parent))
+
+# Check term type
+FILTER(ISURI(?subject))
+FILTER(ISIRI(?subject))
+FILTER(ISLITERAL(?value))
+FILTER(ISBLANK(?node))
+FILTER(ISNUMERIC(?votes))
+```
+
+### Logical Operators
+
+```sparql
+# AND
+FILTER(?votes > 0 && CONTAINS(?label, "Review"))
+
+# OR
+FILTER(?status = "Doing" || ?status = "ToDo")
+
+# NOT
+FILTER(!CONTAINS(?label, "Draft"))
+```
+
+### Arithmetic
+
+```sparql
+# Basic operations in SELECT
+SELECT ?task ((?votes * 2) AS ?doubledVotes) WHERE {
+  ?task ems:Effort_votes ?votes .
+}
+```
+
+---
+
+## JOIN Patterns
+
+### Basic Join (AND)
+
+Multiple patterns in the same block perform an inner join:
+
+```sparql
+SELECT ?task ?label ?status WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  ?task ems:Effort_status ?status .
+}
+```
+
+### OPTIONAL (Left Join)
+
+Include results even if optional pattern doesn't match:
+
+```sparql
+SELECT ?task ?label ?area WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task exo:Asset_label ?label .
+  OPTIONAL { ?task ems:Effort_area ?area }
+}
+```
+
+### UNION
+
+Combine results from alternative patterns:
+
+```sparql
+SELECT ?item ?label WHERE {
+  {
+    ?item exo:Instance_class ems:Task .
+    ?item exo:Asset_label ?label .
+  }
+  UNION
+  {
+    ?item exo:Instance_class ems:Project .
+    ?item exo:Asset_label ?label .
+  }
+}
+```
+
+---
+
+## Aggregates
+
+### COUNT
+
+```sparql
+# Count all tasks
+SELECT (COUNT(?task) AS ?total) WHERE {
+  ?task exo:Instance_class ems:Task .
+}
+
+# Count distinct areas
+SELECT (COUNT(DISTINCT ?area) AS ?areaCount) WHERE {
+  ?task ems:Effort_area ?area .
+}
+```
+
+### SUM
+
+```sparql
+# Total votes across all tasks
+SELECT (SUM(?votes) AS ?totalVotes) WHERE {
+  ?task ems:Effort_votes ?votes .
+}
+```
+
+### AVG
+
+```sparql
+# Average votes per task
+SELECT (AVG(?votes) AS ?avgVotes) WHERE {
+  ?task ems:Effort_votes ?votes .
+}
+```
+
+### MIN / MAX
+
+```sparql
+# Highest and lowest vote counts
+SELECT (MIN(?votes) AS ?minVotes) (MAX(?votes) AS ?maxVotes) WHERE {
+  ?task ems:Effort_votes ?votes .
+}
+```
+
+### GROUP_CONCAT
+
+```sparql
+# List all task labels per area
+SELECT ?area (GROUP_CONCAT(?label; SEPARATOR=", ") AS ?tasks) WHERE {
+  ?task ems:Effort_area ?area .
+  ?task exo:Asset_label ?label .
+}
+GROUP BY ?area
+```
+
+### GROUP BY
+
+```sparql
+# Count tasks per status
+SELECT ?status (COUNT(?task) AS ?count) WHERE {
+  ?task exo:Instance_class ems:Task .
+  ?task ems:Effort_status ?status .
+}
+GROUP BY ?status
+ORDER BY DESC(?count)
+
+# Count tasks per area
+SELECT ?area (COUNT(?task) AS ?taskCount) WHERE {
+  ?task ems:Effort_area ?area .
+}
+GROUP BY ?area
+```
+
+---
+
+## Output Formats
+
+### Table (Default)
+
+```bash
+exo query 'SELECT ?task ?label WHERE { ... }' --format table
+```
+
+Output:
+```
+┌─────────────────────────────────────────────┬────────────────────┐
+│ task                                        │ label              │
+├─────────────────────────────────────────────┼────────────────────┤
+│ obsidian://vault/Tasks/Review%20PR%20123.md │ Review PR #123     │
+│ obsidian://vault/Tasks/Fix%20Bug.md         │ Fix Bug            │
+└─────────────────────────────────────────────┴────────────────────┘
+```
+
+### JSON
+
+```bash
+exo query 'SELECT ?task ?label WHERE { ... }' --format json
+```
+
+Output:
+```json
+[
+  {
+    "task": "obsidian://vault/Tasks/Review%20PR%20123.md",
+    "label": "Review PR #123"
+  },
+  {
+    "task": "obsidian://vault/Tasks/Fix%20Bug.md",
+    "label": "Fix Bug"
+  }
+]
+```
+
+### CSV
+
+```bash
+exo query 'SELECT ?task ?label WHERE { ... }' --format csv
+```
+
+Output:
+```csv
+task,label
+obsidian://vault/Tasks/Review%20PR%20123.md,Review PR #123
+obsidian://vault/Tasks/Fix%20Bug.md,Fix Bug
+```
+
+---
+
+## Troubleshooting
+
+### "Vault not found"
+
+```
+Error: Vault not found: /path/to/vault
+```
+
+**Solution**: Specify the correct vault path:
+```bash
+exo query 'SELECT ...' --vault /correct/path/to/vault
+```
+
+### "Parse error"
+
+```
+Error: Parse error on line 1: Unexpected token
+```
+
+**Solution**: Check SPARQL syntax:
+- Ensure PREFIX declarations end without a period
+- Triple patterns must end with a period
+- Strings must be properly quoted
+
+### Empty Results
+
+**Possible causes**:
+1. No matching data in vault
+2. Incorrect predicate URIs (check namespace)
+3. Filter too restrictive
+
+**Debug steps**:
+```bash
+# Check what predicates exist
+exo query 'SELECT DISTINCT ?p WHERE { ?s ?p ?o } LIMIT 50'
+
+# Check specific predicate
+exo query 'SELECT ?s ?o WHERE { ?s <https://exocortex.my/ontology/exo#Asset_label> ?o } LIMIT 10'
+```
+
+### Query Too Slow
+
+**Solutions**:
+1. Add LIMIT to reduce results
+2. Use more specific patterns (reduce BGP size)
+3. Check `--stats` for bottleneck identification
+
+```bash
+exo query 'SELECT ...' --stats
+```
+
+---
+
+## Related Documentation
+
+- [SPARQL Cookbook](SPARQL_COOKBOOK.md) - Practical query examples
+- [Ontology Reference](ONTOLOGY_REFERENCE.md) - Available predicates
+- [Property Schema](../../docs/PROPERTY_SCHEMA.md) - Frontmatter properties
+
+---
+
+**Maintainer**: @kitelev
+**Related Issues**: #492 (SPARQL Documentation)


### PR DESCRIPTION
## Summary

Comprehensive documentation for the SPARQL Query Engine (Issue #492):

### Files Created

1. **`SPARQL_GUIDE.md`** (~500 lines)
   - Quick start guide with first query examples
   - Installation and CLI usage
   - Complete query reference (SELECT, ORDER BY, LIMIT, DISTINCT)
   - FILTER expressions (comparison, string, numeric, type checking)
   - JOIN patterns (basic join, OPTIONAL, UNION)
   - Aggregate functions (COUNT, SUM, AVG, MIN, MAX, GROUP_CONCAT)
   - Output formats (table, JSON, CSV)
   - Troubleshooting guide

2. **`SPARQL_COOKBOOK.md`** (~600 lines)
   - Task management queries (find active tasks, high-priority, overdue)
   - Project tracking queries (count tasks per project, project status)
   - Daily planning queries (tasks planned for today, completion tracking)
   - Analytics & reporting queries (task counts by status/area/size)
   - Search & discovery queries (full-text search, area hierarchy)
   - Data quality queries (missing labels, duplicate detection)

3. **`ONTOLOGY_REFERENCE.md`** (~500 lines)
   - Namespace definitions (exo:, ems:, rdf:, rdfs:, xsd:)
   - Asset class URIs (Task, Project, Area, Meeting, etc.)
   - Core predicates (exo:Asset_label, exo:Instance_class, etc.)
   - Effort predicates (ems:Effort_status, ems:Effort_votes, etc.)
   - Status values and workflow diagram
   - URI patterns for notes and predicates

### README Updates

- Fix namespace URIs to match actual implementation
- Add links to new documentation files

## Test Plan

- [x] Documentation files are syntactically correct markdown
- [x] All query examples use correct namespace URIs
- [x] Cross-links between docs work
- [ ] CI build passes

Closes #492