### PR TITLE
feat(sparql): implement BIND for computed variables (#498)

### DIFF
--- a/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -291,17 +291,18 @@ export class QueryExecutor {
     expr: ExtendOperation["expression"],
     solution: SolutionMapping
   ): any {
-    if (expr.type === "variable") {
-      return solution.get(expr.name);
-    }
-    if (expr.type === "literal") {
-      return expr.value;
-    }
     if (expr.type === "aggregate") {
       // Aggregates in extend are handled at the group level
       return undefined;
     }
-    return undefined;
+
+    // Use FilterExecutor's evaluateExpression for all other expression types
+    // This handles: variable, literal, function (REPLACE, STR, etc.), comparison, logical
+    try {
+      return this.filterExecutor.evaluateExpression(expr as any, solution);
+    } catch {
+      return undefined;
+    }
   }
 
   private getExpressionValue(expr: any, solution: SolutionMapping): any {

--- a/packages/core/src/infrastructure/sparql/filters/BuiltInFunctions.ts
+++ b/packages/core/src/infrastructure/sparql/filters/BuiltInFunctions.ts
@@ -166,6 +166,62 @@ export class BuiltInFunctions {
     return str.toLowerCase();
   }
 
+  /**
+   * SPARQL 1.1 REPLACE function.
+   * https://www.w3.org/TR/sparql11-query/#func-replace
+   */
+  static replace(str: string, pattern: string, replacement: string, flags?: string): string {
+    try {
+      const regex = new RegExp(pattern, flags || "g");
+      return str.replace(regex, replacement);
+    } catch (error) {
+      throw new Error(`REPLACE: invalid pattern '${pattern}': ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Parse a date string to a timestamp (milliseconds since epoch).
+   * Custom function for date comparison support.
+   */
+  static parseDate(dateStr: string): number {
+    const date = new Date(dateStr);
+    if (isNaN(date.getTime())) {
+      throw new Error(`PARSEDATE: invalid date string '${dateStr}'`);
+    }
+    return date.getTime();
+  }
+
+  /**
+   * Check if date1 is before date2.
+   * Custom function for date comparison support.
+   */
+  static dateBefore(date1: string, date2: string): boolean {
+    const d1 = this.parseDate(date1);
+    const d2 = this.parseDate(date2);
+    return d1 < d2;
+  }
+
+  /**
+   * Check if date1 is after date2.
+   * Custom function for date comparison support.
+   */
+  static dateAfter(date1: string, date2: string): boolean {
+    const d1 = this.parseDate(date1);
+    const d2 = this.parseDate(date2);
+    return d1 > d2;
+  }
+
+  /**
+   * Check if date is within a range [start, end].
+   * Custom function for date comparison support.
+   */
+  static dateInRange(date: string, start: string, end: string): boolean {
+    const d = this.parseDate(date);
+    const s = this.parseDate(start);
+    const e = this.parseDate(end);
+    return d >= s && d <= e;
+  }
+
   static logicalAnd(operands: boolean[]): boolean {
     return operands.every((op) => op === true);
   }


### PR DESCRIPTION
## Summary
- Implement BIND(expression AS ?variable) syntax for creating computed variables
- Support function expressions in BIND (REPLACE, STR, CONTAINS, etc.)
- Support nested function calls (e.g., BIND(REPLACE(REPLACE(?x, "a", ""), "b", "") AS ?y))
- Support FILTER on bound variables

## Implementation
- Add `translateBind()` to AlgebraTranslator to convert BIND patterns to extend operations
- Separate BIND patterns in `translateWhere()` and apply after base patterns but before FILTER
- Make `FilterExecutor.evaluateExpression()` public for reuse in BIND expression evaluation
- Enhance `QueryExecutor.evaluateExtendExpression()` to use FilterExecutor for full function support

## Test plan
- [x] 6 unit tests for BIND translation (variable copy, REPLACE, STR, nested REPLACE, multiple BINDs, BIND+FILTER)
- [x] 241 SPARQL tests pass
- [x] CLI integration test on real vault:
  ```sparql
  SELECT ?s ?className WHERE {
    ?s <exo:Instance_class> ?class .
    BIND(REPLACE(REPLACE(?class, "\\[\\[", ""), "\\]\\]", "") AS ?className)
    FILTER(CONTAINS(?className, "Task"))
  }
  ```

Closes #498