### PR TITLE
feat(sparql): implement EXISTS and NOT EXISTS filter functions

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -57,7 +57,8 @@ export type Expression =
   | LogicalExpression
   | FunctionCallExpression
   | VariableExpression
-  | LiteralExpression;
+  | LiteralExpression
+  | ExistsExpression;
 
 export interface ComparisonExpression {
   type: "comparison";
@@ -87,6 +88,12 @@ export interface LiteralExpression {
   type: "literal";
   value: string | number | boolean;
   datatype?: string;
+}
+
+export interface ExistsExpression {
+  type: "exists";
+  negated: boolean;
+  pattern: AlgebraOperation;
 }
 
 export interface JoinOperation {


### PR DESCRIPTION
## Summary

Implements SPARQL v1.1 EXISTS and NOT EXISTS expressions for subpattern existence testing within FILTER clauses.

- Add `ExistsExpression` type to AlgebraOperation with `negated` flag and `pattern`
- Add `translateExistsExpression` to AlgebraTranslator for sparqljs AST parsing
- Add async EXISTS evaluation path in FilterExecutor with `ExistsEvaluator` callback
- Wire up EXISTS pattern execution in QueryExecutor with solution merging

## Features

- `EXISTS` returns true when subpattern matches at least one result
- `NOT EXISTS` returns true when subpattern produces no results
- Solution bindings from outer scope are available inside EXISTS
- Inner bindings do not leak to outer scope (proper scoping)
- Works with complex patterns (OPTIONAL, FILTER inside EXISTS)
- Combines correctly with logical operators (AND, OR, NOT)

## Example Queries Enabled

```sparql
# Find projects that have at least one task
SELECT ?project ?name WHERE {
  ?project exo:Instance_class "ems__Project" .
  ?project exo:Asset_label ?name .
  FILTER EXISTS { ?task ems:Effort_parent ?project }
}

# Find tasks with no blockers
SELECT ?task WHERE {
  ?task exo:Instance_class "ems__Task" .
  FILTER NOT EXISTS { ?task ems:Task_blockedBy ?blocker }
}
```

## Test Plan

- [x] 10 AlgebraTranslator tests for EXISTS translation
- [x] 15 FilterExecutor tests for EXISTS evaluation
- [x] All unit tests pass (2208 tests)
- [x] All UI tests pass (55 tests)
- [ ] CI pipeline passes

Closes #499