### PR TITLE
feat(sparql): add SPARQL 1.1 property path support

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -18,11 +18,60 @@ export interface BGPOperation {
 
 export interface Triple {
   subject: TripleElement;
-  predicate: TripleElement;
+  predicate: TripleElement | PropertyPath;
   object: TripleElement;
 }
 
 export type TripleElement = Variable | IRI | Literal | BlankNode;
+
+/**
+ * Property path expression for SPARQL 1.1 property paths.
+ * Supports: sequence (/), alternative (|), inverse (^),
+ * oneOrMore (+), zeroOrMore (*), zeroOrOne (?)
+ */
+export type PropertyPath =
+  | SequencePath
+  | AlternativePath
+  | InversePath
+  | OneOrMorePath
+  | ZeroOrMorePath
+  | ZeroOrOnePath;
+
+export interface SequencePath {
+  type: "path";
+  pathType: "/";
+  items: (IRI | PropertyPath)[];
+}
+
+export interface AlternativePath {
+  type: "path";
+  pathType: "|";
+  items: (IRI | PropertyPath)[];
+}
+
+export interface InversePath {
+  type: "path";
+  pathType: "^";
+  items: [IRI | PropertyPath]; // Single item
+}
+
+export interface OneOrMorePath {
+  type: "path";
+  pathType: "+";
+  items: [IRI | PropertyPath]; // Single item
+}
+
+export interface ZeroOrMorePath {
+  type: "path";
+  pathType: "*";
+  items: [IRI | PropertyPath]; // Single item
+}
+
+export interface ZeroOrOnePath {
+  type: "path";
+  pathType: "?";
+  items: [IRI | PropertyPath]; // Single item
+}
 
 export interface Variable {
   type: "variable";

--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraSerializer.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraSerializer.ts
@@ -1,4 +1,4 @@
-import type { AlgebraOperation, Expression, Triple, TripleElement } from "./AlgebraOperation";
+import type { AlgebraOperation, Expression, Triple, TripleElement, PropertyPath } from "./AlgebraOperation";
 
 export class AlgebraSerializer {
   toString(operation: AlgebraOperation, indent: number = 0): string {
@@ -45,7 +45,42 @@ export class AlgebraSerializer {
   }
 
   private tripleToString(triple: Triple): string {
-    return `${this.elementToString(triple.subject)} ${this.elementToString(triple.predicate)} ${this.elementToString(triple.object)}`;
+    return `${this.elementToString(triple.subject)} ${this.predicateToString(triple.predicate)} ${this.elementToString(triple.object)}`;
+  }
+
+  private predicateToString(predicate: TripleElement | PropertyPath): string {
+    if (this.isPropertyPath(predicate)) {
+      return this.propertyPathToString(predicate);
+    }
+    return this.elementToString(predicate);
+  }
+
+  private isPropertyPath(element: TripleElement | PropertyPath): element is PropertyPath {
+    return element.type === "path";
+  }
+
+  private propertyPathToString(path: PropertyPath): string {
+    const items = path.items.map((item) => {
+      if (item.type === "path") {
+        return `(${this.propertyPathToString(item)})`;
+      }
+      return `<${item.value}>`;
+    });
+
+    switch (path.pathType) {
+      case "/":
+        return items.join("/");
+      case "|":
+        return items.join("|");
+      case "^":
+        return `^${items[0]}`;
+      case "+":
+        return `${items[0]}+`;
+      case "*":
+        return `${items[0]}*`;
+      case "?":
+        return `${items[0]}?`;
+    }
   }
 
   private elementToString(element: TripleElement): string {

--- a/packages/core/src/infrastructure/sparql/executors/ConstructExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/ConstructExecutor.ts
@@ -4,7 +4,7 @@ import { IRI } from "../../../domain/models/rdf/IRI";
 import { Literal } from "../../../domain/models/rdf/Literal";
 import { BlankNode } from "../../../domain/models/rdf/BlankNode";
 import type { Subject, Predicate, Object as RDFObject } from "../../../domain/models/rdf/Triple";
-import type { Triple as AlgebraTriple, TripleElement } from "../algebra/AlgebraOperation";
+import type { Triple as AlgebraTriple, TripleElement, PropertyPath } from "../algebra/AlgebraOperation";
 
 export class ConstructExecutor {
   async execute(template: AlgebraTriple[], solutions: SolutionMapping[]): Promise<Triple[]> {
@@ -31,11 +31,20 @@ export class ConstructExecutor {
   }
 
   private instantiateTriple(pattern: AlgebraTriple, solution: SolutionMapping): Triple {
+    // Property paths are not supported in CONSTRUCT templates
+    if (this.isPropertyPath(pattern.predicate)) {
+      throw new Error("Property paths are not supported in CONSTRUCT templates");
+    }
+
     const subject = this.instantiateElement(pattern.subject, solution) as Subject;
     const predicate = this.instantiateElement(pattern.predicate, solution) as Predicate;
     const object = this.instantiateElement(pattern.object, solution) as RDFObject;
 
     return new Triple(subject, predicate, object);
+  }
+
+  private isPropertyPath(predicate: TripleElement | PropertyPath): predicate is PropertyPath {
+    return predicate.type === "path";
   }
 
   private instantiateElement(element: TripleElement, solution: SolutionMapping): Subject | Predicate | RDFObject {

--- a/packages/core/src/infrastructure/sparql/executors/PropertyPathExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/PropertyPathExecutor.ts
@@ -1,0 +1,408 @@
+import type { ITripleStore } from "../../../interfaces/ITripleStore";
+import type { Triple as AlgebraTriple, TripleElement, PropertyPath, IRI } from "../algebra/AlgebraOperation";
+import { SolutionMapping } from "../SolutionMapping";
+import { IRI as RDFiri } from "../../../domain/models/rdf/IRI";
+import { BlankNode } from "../../../domain/models/rdf/BlankNode";
+import type { Subject, Object as RDFObject } from "../../../domain/models/rdf/Triple";
+
+export class PropertyPathExecutorError extends Error {
+  constructor(message: string, cause?: Error) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "PropertyPathExecutorError";
+  }
+}
+
+/**
+ * Executes property path expressions against a triple store.
+ *
+ * Supports SPARQL 1.1 property paths:
+ * - Sequence (/) - matches path elements in order
+ * - Alternative (|) - matches any of the alternatives
+ * - Inverse (^) - reverses direction
+ * - OneOrMore (+) - transitive closure, at least one step
+ * - ZeroOrMore (*) - transitive closure, including zero steps
+ * - ZeroOrOne (?) - optional single step
+ */
+export class PropertyPathExecutor {
+  private readonly MAX_DEPTH = 100; // Prevent infinite loops
+
+  constructor(private readonly tripleStore: ITripleStore) {}
+
+  /**
+   * Execute a property path pattern and return solution mappings.
+   */
+  async *execute(
+    subject: TripleElement,
+    path: PropertyPath,
+    object: TripleElement
+  ): AsyncIterableIterator<SolutionMapping> {
+    // Get start and end nodes
+    const startNodes = await this.resolveElement(subject);
+    const endNodes = this.isVariable(object) ? null : await this.resolveElement(object);
+
+    for (const startNode of startNodes) {
+      const reachable = await this.evaluatePath(startNode, path, endNodes);
+
+      for (const endNode of reachable) {
+        const mapping = new SolutionMapping();
+
+        if (this.isVariable(subject)) {
+          mapping.set(subject.value, startNode);
+        }
+        if (this.isVariable(object)) {
+          mapping.set(object.value, endNode);
+        }
+
+        yield mapping;
+      }
+    }
+  }
+
+  /**
+   * Execute with an existing solution mapping.
+   * Instantiates variables from the solution before evaluating.
+   */
+  async *executeWithBindings(
+    pattern: AlgebraTriple,
+    existingSolution: SolutionMapping
+  ): AsyncIterableIterator<SolutionMapping> {
+    if (!this.isPropertyPath(pattern.predicate)) {
+      throw new PropertyPathExecutorError("Predicate is not a property path");
+    }
+
+    // Instantiate subject and object with existing bindings
+    const subject = this.instantiateElement(pattern.subject, existingSolution);
+    const object = this.instantiateElement(pattern.object, existingSolution);
+
+    for await (const newMapping of this.execute(subject, pattern.predicate, object)) {
+      const merged = existingSolution.merge(newMapping);
+      if (merged !== null) {
+        yield merged;
+      }
+    }
+  }
+
+  /**
+   * Evaluate a property path from a starting node.
+   * Returns all reachable nodes.
+   */
+  private async evaluatePath(
+    start: Subject | RDFObject,
+    path: PropertyPath,
+    targetNodes: Set<Subject | RDFObject> | null
+  ): Promise<Set<Subject | RDFObject>> {
+    switch (path.pathType) {
+      case "/":
+        return this.evaluateSequencePath(start, path.items, targetNodes);
+      case "|":
+        return this.evaluateAlternativePath(start, path.items, targetNodes);
+      case "^":
+        return this.evaluateInversePath(start, path.items[0], targetNodes);
+      case "+":
+        return this.evaluateOneOrMorePath(start, path.items[0], targetNodes);
+      case "*":
+        return this.evaluateZeroOrMorePath(start, path.items[0], targetNodes);
+      case "?":
+        return this.evaluateZeroOrOnePath(start, path.items[0], targetNodes);
+    }
+  }
+
+  /**
+   * Sequence path: a / b / c
+   * Match predicates in order.
+   */
+  private async evaluateSequencePath(
+    start: Subject | RDFObject,
+    items: (IRI | PropertyPath)[],
+    targetNodes: Set<Subject | RDFObject> | null
+  ): Promise<Set<Subject | RDFObject>> {
+    let current = new Set<Subject | RDFObject>([start]);
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      const isLast = i === items.length - 1;
+      const nextNodes = new Set<Subject | RDFObject>();
+
+      for (const node of current) {
+        const reachable = await this.evaluatePathItem(
+          node,
+          item,
+          isLast ? targetNodes : null
+        );
+        for (const r of reachable) {
+          nextNodes.add(r);
+        }
+      }
+
+      current = nextNodes;
+      if (current.size === 0) break;
+    }
+
+    return current;
+  }
+
+  /**
+   * Alternative path: a | b
+   * Match any of the alternatives.
+   */
+  private async evaluateAlternativePath(
+    start: Subject | RDFObject,
+    items: (IRI | PropertyPath)[],
+    targetNodes: Set<Subject | RDFObject> | null
+  ): Promise<Set<Subject | RDFObject>> {
+    const result = new Set<Subject | RDFObject>();
+
+    for (const item of items) {
+      const reachable = await this.evaluatePathItem(start, item, targetNodes);
+      for (const node of reachable) {
+        result.add(node);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Inverse path: ^predicate
+   * Traverse in reverse direction.
+   */
+  private async evaluateInversePath(
+    start: Subject | RDFObject,
+    item: IRI | PropertyPath,
+    targetNodes: Set<Subject | RDFObject> | null
+  ): Promise<Set<Subject | RDFObject>> {
+    // For inverse, we swap the direction: find triples where start is the object
+    if (item.type === "iri") {
+      const predicate = new RDFiri(item.value);
+      const triples = await this.tripleStore.match(undefined, predicate, start as RDFObject);
+
+      const result = new Set<Subject | RDFObject>();
+      for (const triple of triples) {
+        if (targetNodes === null || this.nodeInSet(triple.subject, targetNodes)) {
+          result.add(triple.subject);
+        }
+      }
+      return result;
+    } else {
+      // Nested path - create inverse path and evaluate
+      return this.evaluatePath(start, this.invertPath(item), targetNodes);
+    }
+  }
+
+  /**
+   * OneOrMore path: predicate+
+   * Transitive closure, at least one step.
+   */
+  private async evaluateOneOrMorePath(
+    start: Subject | RDFObject,
+    item: IRI | PropertyPath,
+    targetNodes: Set<Subject | RDFObject> | null
+  ): Promise<Set<Subject | RDFObject>> {
+    const visited = new Set<string>();
+    const result = new Set<Subject | RDFObject>();
+    const queue: { node: Subject | RDFObject; depth: number }[] = [{ node: start, depth: 0 }];
+
+    while (queue.length > 0) {
+      const { node, depth } = queue.shift()!;
+
+      if (depth >= this.MAX_DEPTH) continue;
+
+      const reachable = await this.evaluatePathItem(node, item, null);
+
+      for (const nextNode of reachable) {
+        const key = this.nodeToKey(nextNode);
+
+        // Add to result (only nodes reachable in 1+ steps)
+        if (targetNodes === null || this.nodeInSet(nextNode, targetNodes)) {
+          result.add(nextNode);
+        }
+
+        // Continue traversal if not visited
+        if (!visited.has(key)) {
+          visited.add(key);
+          queue.push({ node: nextNode, depth: depth + 1 });
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * ZeroOrMore path: predicate*
+   * Transitive closure, including zero steps.
+   */
+  private async evaluateZeroOrMorePath(
+    start: Subject | RDFObject,
+    item: IRI | PropertyPath,
+    targetNodes: Set<Subject | RDFObject> | null
+  ): Promise<Set<Subject | RDFObject>> {
+    const result = await this.evaluateOneOrMorePath(start, item, targetNodes);
+
+    // Also include start node (zero steps)
+    if (targetNodes === null || this.nodeInSet(start, targetNodes)) {
+      result.add(start);
+    }
+
+    return result;
+  }
+
+  /**
+   * ZeroOrOne path: predicate?
+   * Optional single step.
+   */
+  private async evaluateZeroOrOnePath(
+    start: Subject | RDFObject,
+    item: IRI | PropertyPath,
+    targetNodes: Set<Subject | RDFObject> | null
+  ): Promise<Set<Subject | RDFObject>> {
+    const result = new Set<Subject | RDFObject>();
+
+    // Zero steps - include start
+    if (targetNodes === null || this.nodeInSet(start, targetNodes)) {
+      result.add(start);
+    }
+
+    // One step
+    const oneStep = await this.evaluatePathItem(start, item, targetNodes);
+    for (const node of oneStep) {
+      result.add(node);
+    }
+
+    return result;
+  }
+
+  /**
+   * Evaluate a single path item (IRI or nested path).
+   */
+  private async evaluatePathItem(
+    start: Subject | RDFObject,
+    item: IRI | PropertyPath,
+    targetNodes: Set<Subject | RDFObject> | null
+  ): Promise<Set<Subject | RDFObject>> {
+    if (item.type === "iri") {
+      // Simple predicate - query triple store
+      const predicate = new RDFiri(item.value);
+      const triples = await this.tripleStore.match(start as Subject, predicate, undefined);
+
+      const result = new Set<Subject | RDFObject>();
+      for (const triple of triples) {
+        if (targetNodes === null || this.nodeInSet(triple.object, targetNodes)) {
+          result.add(triple.object);
+        }
+      }
+      return result;
+    } else {
+      // Nested path - recursively evaluate
+      return this.evaluatePath(start, item, targetNodes);
+    }
+  }
+
+  /**
+   * Invert a property path (swap direction).
+   */
+  private invertPath(path: PropertyPath): PropertyPath {
+    switch (path.pathType) {
+      case "^":
+        // Double inverse cancels out
+        return path.items[0] as PropertyPath;
+      case "/":
+        // Reverse sequence and invert each element
+        return {
+          type: "path",
+          pathType: "/",
+          items: [...path.items].reverse().map((item) =>
+            item.type === "iri" ? { type: "path", pathType: "^", items: [item] } as PropertyPath : this.invertPath(item)
+          ),
+        };
+      case "|":
+        // Invert each alternative
+        return {
+          type: "path",
+          pathType: "|",
+          items: path.items.map((item) =>
+            item.type === "iri" ? { type: "path", pathType: "^", items: [item] } as PropertyPath : this.invertPath(item)
+          ),
+        };
+      case "+":
+      case "*":
+      case "?":
+        // Invert the inner path
+        const innerInverted = path.items[0].type === "iri"
+          ? { type: "path", pathType: "^", items: [path.items[0]] } as PropertyPath
+          : this.invertPath(path.items[0]);
+        return {
+          type: "path",
+          pathType: path.pathType,
+          items: [innerInverted],
+        } as PropertyPath;
+    }
+  }
+
+  /**
+   * Resolve a triple element to a set of RDF nodes.
+   */
+  private async resolveElement(element: TripleElement): Promise<Set<Subject | RDFObject>> {
+    if (this.isVariable(element)) {
+      // For unbound variables, we need to get all possible values
+      // This is done by the caller who iterates all subjects/objects
+      const allNodes = new Set<Subject | RDFObject>();
+      const allTriples = await this.tripleStore.match(undefined, undefined, undefined);
+      for (const triple of allTriples) {
+        allNodes.add(triple.subject);
+        allNodes.add(triple.object);
+      }
+      return allNodes;
+    }
+
+    const result = new Set<Subject | RDFObject>();
+    switch (element.type) {
+      case "iri":
+        result.add(new RDFiri(element.value));
+        break;
+      case "blank":
+        result.add(new BlankNode(element.value));
+        break;
+      default:
+        throw new PropertyPathExecutorError(`Unsupported element type in subject/object position: ${element.type}`);
+    }
+    return result;
+  }
+
+  /**
+   * Instantiate an element with solution bindings.
+   */
+  private instantiateElement(element: TripleElement, solution: SolutionMapping): TripleElement {
+    if (this.isVariable(element)) {
+      const bound = solution.get(element.value);
+      if (bound) {
+        if (bound instanceof RDFiri) {
+          return { type: "iri", value: bound.value };
+        } else if (bound instanceof BlankNode) {
+          return { type: "blank", value: bound.id };
+        }
+      }
+    }
+    return element;
+  }
+
+  private isVariable(element: TripleElement): boolean {
+    return element.type === "variable";
+  }
+
+  private isPropertyPath(predicate: TripleElement | PropertyPath): predicate is PropertyPath {
+    return predicate.type === "path";
+  }
+
+  private nodeToKey(node: Subject | RDFObject): string {
+    return node.toString();
+  }
+
+  private nodeInSet(node: Subject | RDFObject, set: Set<Subject | RDFObject>): boolean {
+    const key = this.nodeToKey(node);
+    for (const n of set) {
+      if (this.nodeToKey(n) === key) return true;
+    }
+    return false;
+  }
+}

--- a/packages/core/tests/unit/infrastructure/sparql/executors/PropertyPathExecutor.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/executors/PropertyPathExecutor.test.ts
@@ -1,0 +1,491 @@
+import { PropertyPathExecutor, PropertyPathExecutorError } from "../../../../../src/infrastructure/sparql/executors/PropertyPathExecutor";
+import type { ITripleStore } from "../../../../../src/interfaces/ITripleStore";
+import { Triple } from "../../../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../../../src/domain/models/rdf/Literal";
+import type { TripleElement, PropertyPath, IRI as AlgebraIRI } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
+
+describe("PropertyPathExecutor", () => {
+  let executor: PropertyPathExecutor;
+  let mockTripleStore: jest.Mocked<ITripleStore>;
+  let triples: Triple[];
+
+  // Helper to create IRI
+  const iri = (value: string): IRI => new IRI(value);
+  const literal = (value: string): Literal => new Literal(value);
+
+  // Helper to create algebra elements
+  const algebraIri = (value: string): AlgebraIRI => ({ type: "iri", value });
+  const algebraVar = (name: string): TripleElement => ({ type: "variable", value: name });
+
+  // Helper to create property paths
+  const simplePath = (predicate: string): PropertyPath => ({
+    type: "path",
+    pathType: "+",
+    items: [algebraIri(predicate)],
+  });
+
+  beforeEach(() => {
+    triples = [];
+    mockTripleStore = {
+      add: jest.fn(),
+      match: jest.fn().mockImplementation((s, p, o) => {
+        return Promise.resolve(
+          triples.filter((t) => {
+            if (s !== undefined && t.subject.toString() !== s.toString()) return false;
+            if (p !== undefined && t.predicate.toString() !== p.toString()) return false;
+            if (o !== undefined && t.object.toString() !== o.toString()) return false;
+            return true;
+          })
+        );
+      }),
+      clear: jest.fn(),
+      size: jest.fn().mockReturnValue(triples.length),
+      getTriples: jest.fn().mockReturnValue(triples),
+    };
+
+    executor = new PropertyPathExecutor(mockTripleStore);
+  });
+
+  // Helper to collect results
+  async function collectResults(
+    subject: TripleElement,
+    path: PropertyPath,
+    object: TripleElement
+  ): Promise<SolutionMapping[]> {
+    const results: SolutionMapping[] = [];
+    for await (const mapping of executor.execute(subject, path, object)) {
+      results.push(mapping);
+    }
+    return results;
+  }
+
+  describe("Simple IRI path (single step)", () => {
+    it("should match single predicate step", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:knows"), iri("ex:b")),
+        new Triple(iri("ex:b"), iri("ex:knows"), iri("ex:c")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "+",
+        items: [algebraIri("ex:knows")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("target"));
+
+      expect(results.length).toBe(2);
+      const targets = results.map((r) => r.get("target")?.toString());
+      expect(targets).toContain("<ex:b>");
+      expect(targets).toContain("<ex:c>");
+    });
+  });
+
+  describe("OneOrMore path (+)", () => {
+    it("should find transitive closure with depth 1", async () => {
+      triples = [new Triple(iri("ex:a"), iri("ex:parent"), iri("ex:b"))];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "+",
+        items: [algebraIri("ex:parent")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("ancestor"));
+
+      expect(results.length).toBe(1);
+      expect(results[0].get("ancestor")?.toString()).toBe("<ex:b>");
+    });
+
+    it("should find transitive closure with depth 3", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:parent"), iri("ex:b")),
+        new Triple(iri("ex:b"), iri("ex:parent"), iri("ex:c")),
+        new Triple(iri("ex:c"), iri("ex:parent"), iri("ex:d")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "+",
+        items: [algebraIri("ex:parent")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("ancestor"));
+
+      expect(results.length).toBe(3);
+      const ancestors = results.map((r) => r.get("ancestor")?.toString());
+      expect(ancestors).toContain("<ex:b>");
+      expect(ancestors).toContain("<ex:c>");
+      expect(ancestors).toContain("<ex:d>");
+    });
+
+    it("should handle cycles without infinite loop", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:next"), iri("ex:b")),
+        new Triple(iri("ex:b"), iri("ex:next"), iri("ex:c")),
+        new Triple(iri("ex:c"), iri("ex:next"), iri("ex:a")), // Cycle back to a
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "+",
+        items: [algebraIri("ex:next")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("node"));
+
+      expect(results.length).toBe(3);
+      const nodes = results.map((r) => r.get("node")?.toString());
+      expect(nodes).toContain("<ex:a>");
+      expect(nodes).toContain("<ex:b>");
+      expect(nodes).toContain("<ex:c>");
+    });
+
+    it("should not include start node (one or more steps required)", async () => {
+      triples = [new Triple(iri("ex:a"), iri("ex:next"), iri("ex:b"))];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "+",
+        items: [algebraIri("ex:next")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("node"));
+
+      expect(results.length).toBe(1);
+      expect(results[0].get("node")?.toString()).toBe("<ex:b>");
+    });
+  });
+
+  describe("ZeroOrMore path (*)", () => {
+    it("should include start node (zero steps)", async () => {
+      triples = [new Triple(iri("ex:a"), iri("ex:next"), iri("ex:b"))];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "*",
+        items: [algebraIri("ex:next")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("node"));
+
+      expect(results.length).toBe(2);
+      const nodes = results.map((r) => r.get("node")?.toString());
+      expect(nodes).toContain("<ex:a>"); // Zero steps
+      expect(nodes).toContain("<ex:b>"); // One step
+    });
+
+    it("should return only start when no matching predicates", async () => {
+      triples = [new Triple(iri("ex:a"), iri("ex:other"), iri("ex:b"))];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "*",
+        items: [algebraIri("ex:next")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("node"));
+
+      expect(results.length).toBe(1);
+      expect(results[0].get("node")?.toString()).toBe("<ex:a>");
+    });
+  });
+
+  describe("ZeroOrOne path (?)", () => {
+    it("should include start node and one step", async () => {
+      triples = [new Triple(iri("ex:a"), iri("ex:next"), iri("ex:b"))];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "?",
+        items: [algebraIri("ex:next")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("node"));
+
+      expect(results.length).toBe(2);
+      const nodes = results.map((r) => r.get("node")?.toString());
+      expect(nodes).toContain("<ex:a>"); // Zero steps
+      expect(nodes).toContain("<ex:b>"); // One step
+    });
+
+    it("should not include nodes at depth 2", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:next"), iri("ex:b")),
+        new Triple(iri("ex:b"), iri("ex:next"), iri("ex:c")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "?",
+        items: [algebraIri("ex:next")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("node"));
+
+      expect(results.length).toBe(2);
+      const nodes = results.map((r) => r.get("node")?.toString());
+      expect(nodes).toContain("<ex:a>");
+      expect(nodes).toContain("<ex:b>");
+      expect(nodes).not.toContain("<ex:c>"); // Too far
+    });
+  });
+
+  describe("Inverse path (^)", () => {
+    it("should traverse in reverse direction", async () => {
+      triples = [
+        new Triple(iri("ex:child"), iri("ex:parent"), iri("ex:adult")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "^",
+        items: [algebraIri("ex:parent")],
+      };
+
+      const results = await collectResults(algebraIri("ex:adult"), path, algebraVar("child"));
+
+      expect(results.length).toBe(1);
+      expect(results[0].get("child")?.toString()).toBe("<ex:child>");
+    });
+
+    it("should find multiple inverse matches", async () => {
+      triples = [
+        new Triple(iri("ex:child1"), iri("ex:parent"), iri("ex:adult")),
+        new Triple(iri("ex:child2"), iri("ex:parent"), iri("ex:adult")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "^",
+        items: [algebraIri("ex:parent")],
+      };
+
+      const results = await collectResults(algebraIri("ex:adult"), path, algebraVar("child"));
+
+      expect(results.length).toBe(2);
+      const children = results.map((r) => r.get("child")?.toString());
+      expect(children).toContain("<ex:child1>");
+      expect(children).toContain("<ex:child2>");
+    });
+  });
+
+  describe("Sequence path (/)", () => {
+    it("should match two predicates in sequence", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:knows"), iri("ex:b")),
+        new Triple(iri("ex:b"), iri("ex:likes"), iri("ex:c")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "/",
+        items: [algebraIri("ex:knows"), algebraIri("ex:likes")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("target"));
+
+      expect(results.length).toBe(1);
+      expect(results[0].get("target")?.toString()).toBe("<ex:c>");
+    });
+
+    it("should match three predicates in sequence", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:p1"), iri("ex:b")),
+        new Triple(iri("ex:b"), iri("ex:p2"), iri("ex:c")),
+        new Triple(iri("ex:c"), iri("ex:p3"), iri("ex:d")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "/",
+        items: [algebraIri("ex:p1"), algebraIri("ex:p2"), algebraIri("ex:p3")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("target"));
+
+      expect(results.length).toBe(1);
+      expect(results[0].get("target")?.toString()).toBe("<ex:d>");
+    });
+
+    it("should return empty when sequence breaks", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:p1"), iri("ex:b")),
+        // Missing: ex:b ex:p2 ?
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "/",
+        items: [algebraIri("ex:p1"), algebraIri("ex:p2")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("target"));
+
+      expect(results.length).toBe(0);
+    });
+  });
+
+  describe("Alternative path (|)", () => {
+    it("should match either predicate", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:knows"), iri("ex:b")),
+        new Triple(iri("ex:a"), iri("ex:likes"), iri("ex:c")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "|",
+        items: [algebraIri("ex:knows"), algebraIri("ex:likes")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("target"));
+
+      expect(results.length).toBe(2);
+      const targets = results.map((r) => r.get("target")?.toString());
+      expect(targets).toContain("<ex:b>");
+      expect(targets).toContain("<ex:c>");
+    });
+
+    it("should match only one when other has no results", async () => {
+      triples = [new Triple(iri("ex:a"), iri("ex:knows"), iri("ex:b"))];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "|",
+        items: [algebraIri("ex:knows"), algebraIri("ex:likes")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("target"));
+
+      expect(results.length).toBe(1);
+      expect(results[0].get("target")?.toString()).toBe("<ex:b>");
+    });
+  });
+
+  describe("Nested paths", () => {
+    it("should handle sequence inside oneOrMore", async () => {
+      // Pattern: (ex:parent/ex:parent)+ - find ancestors at even depths
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:parent"), iri("ex:b")),
+        new Triple(iri("ex:b"), iri("ex:parent"), iri("ex:c")),
+        new Triple(iri("ex:c"), iri("ex:parent"), iri("ex:d")),
+        new Triple(iri("ex:d"), iri("ex:parent"), iri("ex:e")),
+      ];
+
+      const innerPath: PropertyPath = {
+        type: "path",
+        pathType: "/",
+        items: [algebraIri("ex:parent"), algebraIri("ex:parent")],
+      };
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "+",
+        items: [innerPath],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("ancestor"));
+
+      // Should reach c (2 steps) and e (4 steps)
+      expect(results.length).toBe(2);
+      const ancestors = results.map((r) => r.get("ancestor")?.toString());
+      expect(ancestors).toContain("<ex:c>");
+      expect(ancestors).toContain("<ex:e>");
+    });
+
+    it("should handle alternative inside zeroOrMore", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:knows"), iri("ex:b")),
+        new Triple(iri("ex:b"), iri("ex:likes"), iri("ex:c")),
+      ];
+
+      const innerPath: PropertyPath = {
+        type: "path",
+        pathType: "|",
+        items: [algebraIri("ex:knows"), algebraIri("ex:likes")],
+      };
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "*",
+        items: [innerPath],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraVar("node"));
+
+      expect(results.length).toBe(3);
+      const nodes = results.map((r) => r.get("node")?.toString());
+      expect(nodes).toContain("<ex:a>"); // Zero steps
+      expect(nodes).toContain("<ex:b>"); // One step via knows
+      expect(nodes).toContain("<ex:c>"); // Two steps via knows/likes
+    });
+  });
+
+  describe("With bound target", () => {
+    it("should filter results to match target", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:next"), iri("ex:b")),
+        new Triple(iri("ex:b"), iri("ex:next"), iri("ex:c")),
+        new Triple(iri("ex:c"), iri("ex:next"), iri("ex:d")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "+",
+        items: [algebraIri("ex:next")],
+      };
+
+      // Look for path from a to c specifically
+      const results = await collectResults(algebraIri("ex:a"), path, algebraIri("ex:c"));
+
+      expect(results.length).toBe(1);
+    });
+
+    it("should return empty when target not reachable", async () => {
+      triples = [
+        new Triple(iri("ex:a"), iri("ex:next"), iri("ex:b")),
+      ];
+
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "+",
+        items: [algebraIri("ex:next")],
+      };
+
+      const results = await collectResults(algebraIri("ex:a"), path, algebraIri("ex:c"));
+
+      expect(results.length).toBe(0);
+    });
+  });
+
+  describe("executeWithBindings", () => {
+    it("should use existing bindings for subject", async () => {
+      triples = [new Triple(iri("ex:a"), iri("ex:next"), iri("ex:b"))];
+
+      const existingSolution = new SolutionMapping();
+      existingSolution.set("start", iri("ex:a"));
+
+      const pattern = {
+        subject: { type: "variable" as const, value: "start" },
+        predicate: {
+          type: "path" as const,
+          pathType: "+" as const,
+          items: [algebraIri("ex:next")],
+        },
+        object: { type: "variable" as const, value: "end" },
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const mapping of executor.executeWithBindings(pattern, existingSolution)) {
+        results.push(mapping);
+      }
+
+      expect(results.length).toBe(1);
+      expect(results[0].get("start")?.toString()).toBe("<ex:a>");
+      expect(results[0].get("end")?.toString()).toBe("<ex:b>");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements SPARQL 1.1 property paths for transitive queries
- Enables ancestor/descendant traversal with `+`, `*`, `?`, `^`, `/`, `|` operators
- Supports nested path expressions for complex patterns

## Changes
- Add PropertyPath types to AlgebraOperation.ts (6 path types)
- Update AlgebraTranslator to parse sparqljs path AST
- Implement PropertyPathExecutor for path evaluation with cycle detection
- Update BGPExecutor and ConstructExecutor for PropertyPath type safety
- Update AlgebraSerializer for path serialization

## Example Queries Enabled
```sparql
# Find all ancestors (transitive)
SELECT ?ancestor WHERE { ?person ex:parent+ ?ancestor }

# Find parent or grandparent (zero or more)
SELECT ?related WHERE { ?person ex:parent* ?related }

# Find children (inverse)
SELECT ?child WHERE { ?parent ^ex:parent ?child }

# Find grandparent (sequence)
SELECT ?gp WHERE { ?person ex:parent/ex:parent ?gp }

# Find related by knows or likes (alternative)
SELECT ?friend WHERE { ?person (ex:knows|ex:likes) ?friend }
```

## Test Plan
- [x] 8 unit tests for AlgebraTranslator property path parsing
- [x] 20 unit tests for PropertyPathExecutor (all path types, cycles, nested paths)
- [x] All 1985 existing tests pass
- [ ] CI pipeline checks

Closes #500