### PR TITLE
feat(sparql): implement SPARQL 1.1 subquery support (#501)

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -9,7 +9,8 @@ export type AlgebraOperation =
   | SliceOperation
   | DistinctOperation
   | GroupOperation
-  | ExtendOperation;
+  | ExtendOperation
+  | SubqueryOperation;
 
 export interface BGPOperation {
   type: "bgp";
@@ -218,4 +219,21 @@ export interface ExtendOperation {
   variable: string;
   expression: Expression | AggregateExpression;
   input: AlgebraOperation;
+}
+
+/**
+ * Subquery operation for nested SELECT queries.
+ * A subquery is a complete SELECT query that produces solution mappings
+ * which are then joined with the outer query.
+ *
+ * Example:
+ * SELECT ?name WHERE {
+ *   { SELECT ?x WHERE { ?x :hasAge ?age } ORDER BY ?age LIMIT 10 }
+ *   ?x :hasName ?name .
+ * }
+ */
+export interface SubqueryOperation {
+  type: "subquery";
+  /** The complete algebra tree for the inner SELECT query */
+  query: AlgebraOperation;
 }

--- a/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -12,6 +12,7 @@ import type {
   DistinctOperation,
   GroupOperation,
   ExtendOperation,
+  SubqueryOperation,
 } from "../algebra/AlgebraOperation";
 import type { SolutionMapping } from "../SolutionMapping";
 import { BGPExecutor } from "./BGPExecutor";
@@ -132,6 +133,10 @@ export class QueryExecutor {
 
       case "extend":
         yield* this.executeExtend(operation);
+        break;
+
+      case "subquery":
+        yield* this.executeSubquery(operation);
         break;
 
       default:
@@ -312,6 +317,20 @@ export class QueryExecutor {
       }
       yield clone;
     }
+  }
+
+  /**
+   * Execute a subquery.
+   * Subqueries are complete SELECT queries that produce solution mappings
+   * which are then joined with the outer query. The inner query is executed
+   * independently and its results are yielded back to be processed by the
+   * outer query's join/pattern matching.
+   */
+  private async *executeSubquery(operation: SubqueryOperation): AsyncIterableIterator<SolutionMapping> {
+    // Execute the inner query and yield its results
+    // The inner query has already been translated to algebra (project, filter, etc.)
+    // so we just recursively execute it
+    yield* this.execute(operation.query);
   }
 
   private evaluateExtendExpression(


### PR DESCRIPTION
## Summary

Implements SPARQL 1.1 subquery support, allowing nested SELECT queries within WHERE clauses. This enables complex query composition from simpler parts.

Closes #501

## Changes

- **AlgebraOperation.ts**: Add `SubqueryOperation` type to the algebra operation union
- **AlgebraTranslator.ts**: Implement subquery translation from sparqljs AST
- **AlgebraSerializer.ts**: Add subquery serialization for debugging
- **QueryExecutor.ts**: Implement recursive subquery execution

## Supported Features

- Simple subqueries with SELECT/WHERE
- Subqueries with FILTER, ORDER BY, LIMIT, OFFSET
- Subqueries with DISTINCT and GROUP BY
- Nested subqueries (subquery inside subquery)
- Subqueries with UNION and OPTIONAL inside
- Proper variable projection from inner queries

## Example Query

```sparql
SELECT ?name ?count WHERE {
  ?person a :Person .
  ?person :name ?name .
  {
    SELECT ?person (COUNT(?task) AS ?count) WHERE {
      ?task :assignedTo ?person .
    } GROUP BY ?person
  }
}
```

## Test Plan

- [x] 14 unit tests added covering all subquery variations
- [x] All 54 AlgebraTranslator tests pass
- [x] TypeScript compilation passes
- [x] All existing tests pass (2208 unit tests + 55 UI tests)