### PR TITLE
feat(sparql): implement MINUS operator for set difference

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -4,6 +4,7 @@ export type AlgebraOperation =
   | JoinOperation
   | LeftJoinOperation
   | UnionOperation
+  | MinusOperation
   | ProjectOperation
   | OrderByOperation
   | SliceOperation
@@ -177,6 +178,28 @@ export interface LeftJoinOperation {
 
 export interface UnionOperation {
   type: "union";
+  left: AlgebraOperation;
+  right: AlgebraOperation;
+}
+
+/**
+ * MINUS operation for set difference.
+ * Removes solutions from left that are compatible with any solution in right.
+ *
+ * Semantics (SPARQL 1.1):
+ * - Two solutions are compatible if shared variables have the same values
+ * - If no variables are shared, solutions are always compatible (MINUS removes nothing)
+ * - Different from FILTER NOT EXISTS which evaluates patterns per-solution
+ *
+ * Example:
+ * SELECT ?task WHERE {
+ *   ?task a ems:Task .
+ *   MINUS { ?task ems:status "done" }
+ * }
+ * Returns all tasks except those with status "done"
+ */
+export interface MinusOperation {
+  type: "minus";
   left: AlgebraOperation;
   right: AlgebraOperation;
 }

--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraSerializer.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraSerializer.ts
@@ -21,6 +21,9 @@ export class AlgebraSerializer {
       case "union":
         return `${prefix}Union(\n${this.toString(operation.left, indent + 1)}\n${this.toString(operation.right, indent + 1)}\n${prefix})`;
 
+      case "minus":
+        return `${prefix}Minus(\n${this.toString(operation.left, indent + 1)}\n${this.toString(operation.right, indent + 1)}\n${prefix})`;
+
       case "project":
         return `${prefix}Project [${operation.variables.map((v) => `?${v}`).join(", ")}](\n${this.toString(operation.input, indent + 1)}\n${prefix})`;
 

--- a/packages/core/src/infrastructure/sparql/executors/MinusExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/MinusExecutor.ts
@@ -1,0 +1,149 @@
+import type { SolutionMapping } from "../SolutionMapping";
+
+/**
+ * Executes SPARQL MINUS operator for set difference.
+ *
+ * MINUS removes solutions from the left side that are **compatible** with
+ * any solution from the right side.
+ *
+ * Semantics (SPARQL 1.1 Section 18.5):
+ * - Two solutions μ1 and μ2 are compatible if for every variable v in
+ *   dom(μ1) ∩ dom(μ2), we have μ1(v) = μ2(v)
+ * - Diff(Ω1, Ω2) = { μ | μ in Ω1 such that for all μ' in Ω2, μ and μ' are not compatible }
+ *
+ * Key difference from FILTER NOT EXISTS:
+ * - MINUS operates on solution sets: removes left solutions compatible with ANY right solution
+ * - FILTER NOT EXISTS evaluates the pattern for EACH left solution with substituted variables
+ * - If patterns have no shared variables, MINUS removes nothing (solutions always compatible)
+ * - FILTER NOT EXISTS would remove everything if pattern matches
+ *
+ * Example:
+ * ```sparql
+ * SELECT ?task WHERE {
+ *   ?task a ems:Task .
+ *   MINUS { ?task ems:status "done" }
+ * }
+ * ```
+ * Returns all tasks except those with status "done"
+ */
+export class MinusExecutor {
+  /**
+   * Execute MINUS operation: remove left solutions compatible with any right solution.
+   *
+   * @param leftSolutions - The input solution set (preceding patterns)
+   * @param rightSolutions - The solutions to subtract (MINUS pattern results)
+   * @returns Solutions from left that are NOT compatible with any solution in right
+   */
+  async *execute(
+    leftSolutions: AsyncIterableIterator<SolutionMapping>,
+    rightSolutions: AsyncIterableIterator<SolutionMapping>
+  ): AsyncIterableIterator<SolutionMapping> {
+    // Collect both solution sets (need random access for compatibility checks)
+    const leftArray: SolutionMapping[] = [];
+    for await (const solution of leftSolutions) {
+      leftArray.push(solution);
+    }
+
+    const rightArray: SolutionMapping[] = [];
+    for await (const solution of rightSolutions) {
+      rightArray.push(solution);
+    }
+
+    // For each left solution, check if compatible with ANY right solution
+    for (const leftSolution of leftArray) {
+      let shouldExclude = false;
+
+      for (const rightSolution of rightArray) {
+        if (this.areCompatible(leftSolution, rightSolution)) {
+          shouldExclude = true;
+          break; // No need to check further
+        }
+      }
+
+      // Only yield solutions that are NOT compatible with any right solution
+      if (!shouldExclude) {
+        yield leftSolution;
+      }
+    }
+  }
+
+  /**
+   * Execute MINUS with pre-collected solution arrays.
+   * Convenience method for testing and when solutions are already collected.
+   */
+  async executeAll(
+    leftSolutions: SolutionMapping[],
+    rightSolutions: SolutionMapping[]
+  ): Promise<SolutionMapping[]> {
+    const results: SolutionMapping[] = [];
+
+    async function* generateLeft() {
+      for (const solution of leftSolutions) {
+        yield solution;
+      }
+    }
+
+    async function* generateRight() {
+      for (const solution of rightSolutions) {
+        yield solution;
+      }
+    }
+
+    for await (const solution of this.execute(generateLeft(), generateRight())) {
+      results.push(solution);
+    }
+
+    return results;
+  }
+
+  /**
+   * Check if two solution mappings are compatible for MINUS semantics.
+   *
+   * SPARQL 1.1 Diff semantics (Section 18.5):
+   * Diff(Ω1, Ω2) = { μ | μ in Ω1 such that for all μ' in Ω2,
+   *                 μ and μ' are NOT compatible OR dom(μ) ∩ dom(μ') = ∅ }
+   *
+   * This means μ is KEPT if:
+   * - For all μ' in Ω2: either they disagree on some shared variable, OR they have no shared variables
+   *
+   * This means μ is REMOVED if:
+   * - There exists μ' in Ω2: they agree on all shared variables AND they have at least one shared variable
+   *
+   * @param left - Left solution mapping
+   * @param right - Right solution mapping
+   * @returns true if the left solution should be excluded (i.e., it's compatible with right
+   *          AND they share at least one variable)
+   */
+  private areCompatible(left: SolutionMapping, right: SolutionMapping): boolean {
+    const leftVars = left.variables();
+    const rightVars = new Set(right.variables());
+
+    // Find shared variables
+    const sharedVars = leftVars.filter((v) => rightVars.has(v));
+
+    // If no shared variables, domains are disjoint - solutions are NOT "compatible" for MINUS
+    // (MINUS with no shared variables removes nothing)
+    if (sharedVars.length === 0) {
+      return false;
+    }
+
+    // Check if all shared variables have the same value
+    for (const varName of sharedVars) {
+      const leftValue = left.get(varName);
+      const rightValue = right.get(varName);
+
+      if (leftValue === undefined || rightValue === undefined) {
+        // Unbound variable - not compatible
+        return false;
+      }
+
+      // Compare string representations (works for IRI, Literal, BlankNode)
+      if (leftValue.toString() !== rightValue.toString()) {
+        return false;
+      }
+    }
+
+    // All shared variables agree - solutions are compatible, left should be excluded
+    return true;
+  }
+}

--- a/packages/core/tests/unit/infrastructure/sparql/executors/MinusExecutor.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/executors/MinusExecutor.test.ts
@@ -1,0 +1,285 @@
+import { MinusExecutor } from "../../../../../src/infrastructure/sparql/executors/MinusExecutor";
+import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
+import { IRI } from "../../../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../../../src/domain/models/rdf/Literal";
+
+describe("MinusExecutor", () => {
+  let executor: MinusExecutor;
+
+  beforeEach(() => {
+    executor = new MinusExecutor();
+  });
+
+  describe("Basic MINUS operations", () => {
+    it("should remove matching solutions from left", async () => {
+      // Left: task1, task2, task3
+      // Right: task2 (done)
+      // Result: task1, task3
+      const left = [
+        createSolution({ task: "http://example.org/task1" }),
+        createSolution({ task: "http://example.org/task2" }),
+        createSolution({ task: "http://example.org/task3" }),
+      ];
+
+      const right = [createSolution({ task: "http://example.org/task2" })];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(2);
+      expect((results[0].get("task") as IRI).value).toBe("http://example.org/task1");
+      expect((results[1].get("task") as IRI).value).toBe("http://example.org/task3");
+    });
+
+    it("should preserve all left solutions when right is empty", async () => {
+      const left = [
+        createSolution({ task: "http://example.org/task1" }),
+        createSolution({ task: "http://example.org/task2" }),
+      ];
+
+      const right: SolutionMapping[] = [];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(2);
+    });
+
+    it("should return empty when all left solutions match right", async () => {
+      const left = [
+        createSolution({ task: "http://example.org/task1" }),
+        createSolution({ task: "http://example.org/task2" }),
+      ];
+
+      const right = [
+        createSolution({ task: "http://example.org/task1" }),
+        createSolution({ task: "http://example.org/task2" }),
+      ];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(0);
+    });
+
+    it("should handle empty left side", async () => {
+      const left: SolutionMapping[] = [];
+
+      const right = [createSolution({ task: "http://example.org/task1" })];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("MINUS with no shared variables (disjoint domains)", () => {
+    it("should preserve all left solutions when no variables are shared", async () => {
+      // SPARQL 1.1 spec: MINUS with disjoint domains removes nothing
+      // Left has ?task, Right has ?project (different variables)
+      const left = [
+        createSolution({ task: "http://example.org/task1" }),
+        createSolution({ task: "http://example.org/task2" }),
+      ];
+
+      const right = [
+        createSolution({ project: "http://example.org/project1" }),
+        createSolution({ project: "http://example.org/project2" }),
+      ];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(2);
+      expect((results[0].get("task") as IRI).value).toBe("http://example.org/task1");
+      expect((results[1].get("task") as IRI).value).toBe("http://example.org/task2");
+    });
+  });
+
+  describe("MINUS with multiple shared variables", () => {
+    it("should only exclude when ALL shared variables match", async () => {
+      // Left: (task1, labelA), (task2, labelB)
+      // Right: (task1, labelA) - exact match
+      // Result: (task2, labelB) - task1/labelA excluded
+      const left = [
+        createSolutionMulti({ task: "http://example.org/task1", label: "Label A" }),
+        createSolutionMulti({ task: "http://example.org/task2", label: "Label B" }),
+      ];
+
+      const right = [
+        createSolutionMulti({ task: "http://example.org/task1", label: "Label A" }),
+      ];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(1);
+      expect((results[0].get("task") as IRI).value).toBe("http://example.org/task2");
+    });
+
+    it("should preserve when shared variables have different values", async () => {
+      // Left: (task1, labelA)
+      // Right: (task1, labelB) - task matches, but label differs
+      // Result: (task1, labelA) preserved because label doesn't match
+      const left = [
+        createSolutionMulti({ task: "http://example.org/task1", label: "Label A" }),
+      ];
+
+      const right = [
+        createSolutionMulti({ task: "http://example.org/task1", label: "Label B" }),
+      ];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(1);
+      expect((results[0].get("task") as IRI).value).toBe("http://example.org/task1");
+    });
+  });
+
+  describe("MINUS with partial variable overlap", () => {
+    it("should check only shared variables for compatibility", async () => {
+      // Left: {task, label}
+      // Right: {task, status} - only task is shared
+      // Compatibility is based on shared variable (task) only
+      const left = [
+        createSolutionMulti({ task: "http://example.org/task1", label: "Label A" }),
+        createSolutionMulti({ task: "http://example.org/task2", label: "Label B" }),
+      ];
+
+      const right = [
+        createSolutionMulti({ task: "http://example.org/task1", status: "done" }),
+      ];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(1);
+      // task1 excluded (shared var 'task' matches), task2 preserved
+      expect((results[0].get("task") as IRI).value).toBe("http://example.org/task2");
+    });
+  });
+
+  describe("MINUS with literals", () => {
+    it("should correctly compare literal values", async () => {
+      const left = [
+        createLiteralSolution({ status: "active" }),
+        createLiteralSolution({ status: "done" }),
+        createLiteralSolution({ status: "pending" }),
+      ];
+
+      const right = [createLiteralSolution({ status: "done" })];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(2);
+      expect((results[0].get("status") as Literal).value).toBe("active");
+      expect((results[1].get("status") as Literal).value).toBe("pending");
+    });
+  });
+
+  describe("MINUS with multiple right solutions", () => {
+    it("should exclude if compatible with ANY right solution", async () => {
+      // Left: task1, task2, task3, task4
+      // Right: task1 (done), task3 (done)
+      // Result: task2, task4
+      const left = [
+        createSolution({ task: "http://example.org/task1" }),
+        createSolution({ task: "http://example.org/task2" }),
+        createSolution({ task: "http://example.org/task3" }),
+        createSolution({ task: "http://example.org/task4" }),
+      ];
+
+      const right = [
+        createSolution({ task: "http://example.org/task1" }),
+        createSolution({ task: "http://example.org/task3" }),
+      ];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(2);
+      expect((results[0].get("task") as IRI).value).toBe("http://example.org/task2");
+      expect((results[1].get("task") as IRI).value).toBe("http://example.org/task4");
+    });
+  });
+
+  describe("Streaming execution via AsyncIterator", () => {
+    it("should work correctly with async iteration", async () => {
+      const left = [
+        createSolution({ task: "http://example.org/task1" }),
+        createSolution({ task: "http://example.org/task2" }),
+        createSolution({ task: "http://example.org/task3" }),
+      ];
+
+      const right = [createSolution({ task: "http://example.org/task2" })];
+
+      async function* leftGen(): AsyncIterableIterator<SolutionMapping> {
+        for (const s of left) yield s;
+      }
+
+      async function* rightGen(): AsyncIterableIterator<SolutionMapping> {
+        for (const s of right) yield s;
+      }
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(leftGen(), rightGen())) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(2);
+      expect((results[0].get("task") as IRI).value).toBe("http://example.org/task1");
+      expect((results[1].get("task") as IRI).value).toBe("http://example.org/task3");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle empty solution mappings", async () => {
+      // Empty solution on left should be preserved if right has variables
+      const left = [new SolutionMapping()];
+      const right = [createSolution({ task: "http://example.org/task1" })];
+
+      const results = await executor.executeAll(left, right);
+      // No shared variables -> not compatible -> preserved
+      expect(results).toHaveLength(1);
+    });
+
+    it("should handle both sides having empty solutions", async () => {
+      const left = [new SolutionMapping()];
+      const right = [new SolutionMapping()];
+
+      // No shared variables (both empty) -> not compatible -> preserved
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(1);
+    });
+
+    it("should preserve order of left solutions", async () => {
+      const left = [
+        createSolution({ task: "http://example.org/task3" }),
+        createSolution({ task: "http://example.org/task1" }),
+        createSolution({ task: "http://example.org/task2" }),
+      ];
+
+      const right: SolutionMapping[] = [];
+
+      const results = await executor.executeAll(left, right);
+      expect(results).toHaveLength(3);
+      expect((results[0].get("task") as IRI).value).toBe("http://example.org/task3");
+      expect((results[1].get("task") as IRI).value).toBe("http://example.org/task1");
+      expect((results[2].get("task") as IRI).value).toBe("http://example.org/task2");
+    });
+  });
+});
+
+// Helper functions to create solution mappings
+function createSolution(bindings: Record<string, string>): SolutionMapping {
+  const s = new SolutionMapping();
+  for (const [key, value] of Object.entries(bindings)) {
+    s.set(key, new IRI(value));
+  }
+  return s;
+}
+
+function createSolutionMulti(bindings: {
+  task: string;
+  label?: string;
+  status?: string;
+}): SolutionMapping {
+  const s = new SolutionMapping();
+  s.set("task", new IRI(bindings.task));
+  if (bindings.label) {
+    s.set("label", new Literal(bindings.label));
+  }
+  if (bindings.status) {
+    s.set("status", new Literal(bindings.status));
+  }
+  return s;
+}
+
+function createLiteralSolution(bindings: { status: string }): SolutionMapping {
+  const s = new SolutionMapping();
+  s.set("status", new Literal(bindings.status));
+  return s;
+}


### PR DESCRIPTION
## Summary

Implements SPARQL 1.1 MINUS operator for set difference operations. MINUS removes solutions from the left side that are compatible with any solution from the right side.

Closes #518

## Changes

### New Files
- `MinusExecutor.ts`: Core MINUS execution logic with proper compatibility checks
- `MinusExecutor.test.ts`: Comprehensive unit tests (14 test cases)

### Modified Files
- `AlgebraOperation.ts`: Added `MinusOperation` type
- `AlgebraTranslator.ts`: Parse MINUS patterns from sparqljs AST
- `QueryExecutor.ts`: Integrate MinusExecutor for execution
- `AlgebraOptimizer.ts`: Traverse MINUS nodes for optimization
- `AlgebraSerializer.ts`: Serialize MINUS for debugging
- `AlgebraTranslator.test.ts`: Added 3 translation tests for MINUS

## Key Semantics (SPARQL 1.1 Section 18.5)

- Two solutions are **compatible** if shared variables have same values
- If no shared variables (disjoint domains), MINUS removes nothing
- Different from FILTER NOT EXISTS which evaluates per-solution

## Use Cases

```sparql
# Find tasks not assigned to any project
SELECT ?task ?title WHERE {
  ?task a ems:Task .
  ?task ems:title ?title .
  MINUS { ?project ems:tasks ?task . }
}

# Find areas without any projects
SELECT ?area ?name WHERE {
  ?area a ems:Area .
  ?area ems:name ?name .
  MINUS { ?area ems:projects ?project . }
}

# Find orphan files (not linked from anywhere)
SELECT ?file WHERE {
  ?file a exo:File .
  MINUS { ?other ?pred ?file . }
}
```

## Test Plan

- [x] 14 unit tests for MinusExecutor covering:
  - Basic MINUS operations
  - Disjoint domains (no shared variables)
  - Multiple shared variables
  - Partial variable overlap
  - Literal value comparison
  - Multiple right solutions
  - Streaming execution via AsyncIterator
  - Edge cases (empty solutions, order preservation)
- [x] 3 AlgebraTranslator tests for MINUS parsing
- [x] TypeScript type check passes
- [x] Unit tests pass