### PR TITLE
fix(plugin): Timestamp property editor incorrectly applies timezone conversion

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
@@ -1,4 +1,9 @@
 import React, { useState, useRef, useEffect } from "react";
+import {
+  parseLocalDate,
+  formatForInput,
+  formatDisplayValue,
+} from "../../utils/dateTimeUtils";
 
 export interface DateTimePropertyFieldProps {
   value: string | null;
@@ -54,122 +59,6 @@ export const DateTimePropertyField: React.FC<DateTimePropertyFieldProps> = ({
     };
   }, [isOpen, onBlur]);
 
-  const formatDisplayValue = (isoString: string | null): string => {
-    if (!isoString) return "Empty";
-
-    try {
-      const date = new Date(isoString);
-      if (isNaN(date.getTime())) return isoString;
-
-      const hasTime =
-        isoString.includes("T") ||
-        date.getHours() !== 0 ||
-        date.getMinutes() !== 0;
-
-      if (hasTime) {
-        return date.toLocaleString(undefined, {
-          year: "numeric",
-          month: "short",
-          day: "numeric",
-          hour: "2-digit",
-          minute: "2-digit",
-          hour12: false,
-        });
-      } else {
-        return date.toLocaleDateString(undefined, {
-          year: "numeric",
-          month: "short",
-          day: "numeric",
-        });
-      }
-    } catch {
-      return isoString;
-    }
-  };
-
-  const formatForInput = (isoString: string): string => {
-    try {
-      const date = new Date(isoString);
-      if (isNaN(date.getTime())) return isoString;
-
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, "0");
-      const day = String(date.getDate()).padStart(2, "0");
-      const hours = String(date.getHours()).padStart(2, "0");
-      const minutes = String(date.getMinutes()).padStart(2, "0");
-
-      if (date.getHours() !== 0 || date.getMinutes() !== 0) {
-        return `${year}-${month}-${day} ${hours}:${minutes}`;
-      } else {
-        return `${year}-${month}-${day}`;
-      }
-    } catch {
-      return isoString;
-    }
-  };
-
-  const parseDate = (input: string): Date | null => {
-    if (!input.trim()) return null;
-
-    const lowerInput = input.toLowerCase().trim();
-
-    if (lowerInput === "today") {
-      const date = new Date();
-      date.setHours(0, 0, 0, 0);
-      return date;
-    }
-
-    if (lowerInput === "tomorrow") {
-      const date = new Date();
-      date.setDate(date.getDate() + 1);
-      date.setHours(0, 0, 0, 0);
-      return date;
-    }
-
-    if (lowerInput === "yesterday") {
-      const date = new Date();
-      date.setDate(date.getDate() - 1);
-      date.setHours(0, 0, 0, 0);
-      return date;
-    }
-
-    if (lowerInput === "next week") {
-      const date = new Date();
-      date.setDate(date.getDate() + 7);
-      date.setHours(0, 0, 0, 0);
-      return date;
-    }
-
-    const inDaysMatch = lowerInput.match(/^in (\d+) days?$/i);
-    if (inDaysMatch) {
-      const days = parseInt(inDaysMatch[1]);
-      const date = new Date();
-      date.setDate(date.getDate() + days);
-      date.setHours(0, 0, 0, 0);
-      return date;
-    }
-
-    const inWeeksMatch = lowerInput.match(/^in (\d+) weeks?$/i);
-    if (inWeeksMatch) {
-      const weeks = parseInt(inWeeksMatch[1]);
-      const date = new Date();
-      date.setDate(date.getDate() + weeks * 7);
-      date.setHours(0, 0, 0, 0);
-      return date;
-    }
-
-    try {
-      const date = new Date(input);
-      if (!isNaN(date.getTime())) {
-        return date;
-      }
-    } catch {
-      // Fall through
-    }
-
-    return null;
-  };
-
   const handleToggle = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -202,7 +91,7 @@ export const DateTimePropertyField: React.FC<DateTimePropertyFieldProps> = ({
       return;
     }
 
-    const parsed = parseDate(textInput);
+    const parsed = parseLocalDate(textInput);
 
     if (parsed) {
       onChange(parsed.toISOString());

--- a/packages/obsidian-plugin/src/presentation/utils/dateTimeUtils.ts
+++ b/packages/obsidian-plugin/src/presentation/utils/dateTimeUtils.ts
@@ -1,0 +1,159 @@
+/**
+ * Utility functions for date/time parsing and formatting in property editors.
+ *
+ * Key design principle: All user input is interpreted as LOCAL time.
+ * - Input: User enters "2025-12-02 13:03" meaning 1:03 PM in their timezone
+ * - Storage: Converted to UTC ISO string (e.g., "2025-12-02T08:03:00.000Z" if UTC+5)
+ * - Display: UTC string converted back to local time for display
+ */
+
+/**
+ * Parses a user input string into a Date object.
+ * Interprets the input as LOCAL time, not UTC.
+ *
+ * Supports:
+ * - ISO-like formats: "2025-12-02", "2025-12-02 13:03", "2025-12-02T13:03:22"
+ * - Natural language: "today", "tomorrow", "yesterday", "next week"
+ * - Relative dates: "in 3 days", "in 2 weeks"
+ *
+ * @param input - The user's date input string
+ * @returns A Date object in local time, or null if parsing fails
+ */
+export function parseLocalDate(input: string): Date | null {
+  if (!input.trim()) return null;
+
+  const lowerInput = input.toLowerCase().trim();
+
+  // Natural language shortcuts
+  if (lowerInput === "today") {
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  if (lowerInput === "tomorrow") {
+    const date = new Date();
+    date.setDate(date.getDate() + 1);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  if (lowerInput === "yesterday") {
+    const date = new Date();
+    date.setDate(date.getDate() - 1);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  if (lowerInput === "next week") {
+    const date = new Date();
+    date.setDate(date.getDate() + 7);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  // Relative days: "in X days"
+  const inDaysMatch = lowerInput.match(/^in (\d+) days?$/i);
+  if (inDaysMatch) {
+    const days = parseInt(inDaysMatch[1]);
+    const date = new Date();
+    date.setDate(date.getDate() + days);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  // Relative weeks: "in X weeks"
+  const inWeeksMatch = lowerInput.match(/^in (\d+) weeks?$/i);
+  if (inWeeksMatch) {
+    const weeks = parseInt(inWeeksMatch[1]);
+    const date = new Date();
+    date.setDate(date.getDate() + weeks * 7);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  try {
+    // Normalize input: replace space with 'T' to ensure consistent local time parsing
+    // "2025-12-02 13:03" → "2025-12-02T13:03" (parsed as local time)
+    // This avoids browser inconsistencies where "YYYY-MM-DD HH:MM" may be parsed as UTC
+    const normalizedInput = input.trim().replace(/^(\d{4}-\d{2}-\d{2})\s+/, "$1T");
+    const date = new Date(normalizedInput);
+    if (!isNaN(date.getTime())) {
+      return date;
+    }
+  } catch {
+    // Fall through
+  }
+
+  return null;
+}
+
+/**
+ * Formats an ISO date string for display in a date input field.
+ * Converts UTC time to local time for editing.
+ *
+ * @param isoString - An ISO 8601 date string (typically from storage)
+ * @returns A formatted string like "2025-12-02 13:03" in local time
+ */
+export function formatForInput(isoString: string): string {
+  try {
+    const date = new Date(isoString);
+    if (isNaN(date.getTime())) return isoString;
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+
+    // Only include time if it's not midnight
+    if (date.getHours() !== 0 || date.getMinutes() !== 0 || date.getSeconds() !== 0) {
+      return `${year}-${month}-${day} ${hours}:${minutes}`;
+    } else {
+      return `${year}-${month}-${day}`;
+    }
+  } catch {
+    return isoString;
+  }
+}
+
+/**
+ * Formats an ISO date string for display to the user.
+ * Converts UTC time to local time using locale-aware formatting.
+ *
+ * @param isoString - An ISO 8601 date string (typically from storage), or null
+ * @returns A localized date string like "Dec 2, 2025, 13:03" or "Empty" if null
+ */
+export function formatDisplayValue(isoString: string | null): string {
+  if (!isoString) return "Empty";
+
+  try {
+    const date = new Date(isoString);
+    if (isNaN(date.getTime())) return isoString;
+
+    // Check if the original string includes time information
+    const hasTime =
+      isoString.includes("T") ||
+      date.getHours() !== 0 ||
+      date.getMinutes() !== 0;
+
+    if (hasTime) {
+      return date.toLocaleString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      });
+    } else {
+      return date.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    }
+  } catch {
+    return isoString;
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/property-editor/dateTimeUtils.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/dateTimeUtils.test.ts
@@ -1,0 +1,333 @@
+import {
+  parseLocalDate,
+  formatForInput,
+  formatDisplayValue,
+} from "../../../src/presentation/utils/dateTimeUtils";
+
+describe("dateTimeUtils", () => {
+  describe("parseLocalDate", () => {
+    describe("empty and whitespace input", () => {
+      it("should return null for empty string", () => {
+        expect(parseLocalDate("")).toBeNull();
+      });
+
+      it("should return null for whitespace-only string", () => {
+        expect(parseLocalDate("   ")).toBeNull();
+      });
+    });
+
+    describe("natural language dates", () => {
+      it("should parse 'today' as midnight local time", () => {
+        const result = parseLocalDate("today");
+        expect(result).not.toBeNull();
+
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
+        expect(result?.getFullYear()).toBe(today.getFullYear());
+        expect(result?.getMonth()).toBe(today.getMonth());
+        expect(result?.getDate()).toBe(today.getDate());
+        expect(result?.getHours()).toBe(0);
+        expect(result?.getMinutes()).toBe(0);
+      });
+
+      it("should parse 'tomorrow' as tomorrow at midnight", () => {
+        const result = parseLocalDate("tomorrow");
+        expect(result).not.toBeNull();
+
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 1);
+        tomorrow.setHours(0, 0, 0, 0);
+
+        expect(result?.getFullYear()).toBe(tomorrow.getFullYear());
+        expect(result?.getMonth()).toBe(tomorrow.getMonth());
+        expect(result?.getDate()).toBe(tomorrow.getDate());
+      });
+
+      it("should parse 'yesterday' as yesterday at midnight", () => {
+        const result = parseLocalDate("yesterday");
+        expect(result).not.toBeNull();
+
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+        yesterday.setHours(0, 0, 0, 0);
+
+        expect(result?.getFullYear()).toBe(yesterday.getFullYear());
+        expect(result?.getMonth()).toBe(yesterday.getMonth());
+        expect(result?.getDate()).toBe(yesterday.getDate());
+      });
+
+      it("should parse 'next week' as 7 days from now", () => {
+        const result = parseLocalDate("next week");
+        expect(result).not.toBeNull();
+
+        const nextWeek = new Date();
+        nextWeek.setDate(nextWeek.getDate() + 7);
+        nextWeek.setHours(0, 0, 0, 0);
+
+        expect(result?.getFullYear()).toBe(nextWeek.getFullYear());
+        expect(result?.getMonth()).toBe(nextWeek.getMonth());
+        expect(result?.getDate()).toBe(nextWeek.getDate());
+      });
+
+      it("should be case-insensitive", () => {
+        expect(parseLocalDate("TODAY")).not.toBeNull();
+        expect(parseLocalDate("Tomorrow")).not.toBeNull();
+        expect(parseLocalDate("NEXT WEEK")).not.toBeNull();
+      });
+    });
+
+    describe("relative dates", () => {
+      it("should parse 'in 3 days'", () => {
+        const result = parseLocalDate("in 3 days");
+        expect(result).not.toBeNull();
+
+        const expected = new Date();
+        expected.setDate(expected.getDate() + 3);
+        expected.setHours(0, 0, 0, 0);
+
+        expect(result?.getDate()).toBe(expected.getDate());
+      });
+
+      it("should parse 'in 1 day' (singular)", () => {
+        const result = parseLocalDate("in 1 day");
+        expect(result).not.toBeNull();
+
+        const expected = new Date();
+        expected.setDate(expected.getDate() + 1);
+
+        expect(result?.getDate()).toBe(expected.getDate());
+      });
+
+      it("should parse 'in 2 weeks'", () => {
+        const result = parseLocalDate("in 2 weeks");
+        expect(result).not.toBeNull();
+
+        const expected = new Date();
+        expected.setDate(expected.getDate() + 14);
+        expected.setHours(0, 0, 0, 0);
+
+        expect(result?.getDate()).toBe(expected.getDate());
+      });
+    });
+
+    describe("ISO-style date formats", () => {
+      it("should parse date-only format (YYYY-MM-DD)", () => {
+        const result = parseLocalDate("2025-12-02");
+        expect(result).not.toBeNull();
+        expect(result?.getFullYear()).toBe(2025);
+        expect(result?.getMonth()).toBe(11); // December is 11
+        expect(result?.getDate()).toBe(2);
+      });
+
+      it("should parse date with time using T separator", () => {
+        const result = parseLocalDate("2025-12-02T13:03:22");
+        expect(result).not.toBeNull();
+        expect(result?.getFullYear()).toBe(2025);
+        expect(result?.getMonth()).toBe(11);
+        expect(result?.getDate()).toBe(2);
+        expect(result?.getHours()).toBe(13);
+        expect(result?.getMinutes()).toBe(3);
+      });
+
+      it("should parse date with time using space separator (normalized to local time)", () => {
+        // This is the key fix: space-separated format should be treated as local time
+        const result = parseLocalDate("2025-12-02 13:03");
+        expect(result).not.toBeNull();
+        expect(result?.getFullYear()).toBe(2025);
+        expect(result?.getMonth()).toBe(11);
+        expect(result?.getDate()).toBe(2);
+        // Hours should be 13 (local time), not converted from UTC
+        expect(result?.getHours()).toBe(13);
+        expect(result?.getMinutes()).toBe(3);
+      });
+
+      it("should parse date with seconds", () => {
+        const result = parseLocalDate("2025-12-02 13:03:22");
+        expect(result).not.toBeNull();
+        expect(result?.getHours()).toBe(13);
+        expect(result?.getMinutes()).toBe(3);
+        expect(result?.getSeconds()).toBe(22);
+      });
+    });
+
+    describe("timezone handling", () => {
+      it("should store date as UTC when converted to ISO string", () => {
+        // Parse a local time
+        const localDate = parseLocalDate("2025-12-02 13:03");
+        expect(localDate).not.toBeNull();
+
+        // Convert to ISO string (UTC)
+        const isoString = localDate!.toISOString();
+
+        // The ISO string should represent the same point in time
+        // When we parse it back and get local hours, it should match
+        const parsedBack = new Date(isoString);
+        expect(parsedBack.getHours()).toBe(13);
+        expect(parsedBack.getMinutes()).toBe(3);
+      });
+
+      it("should maintain roundtrip consistency: input → store → display", () => {
+        // Simulate the full roundtrip:
+        // 1. User enters "2025-12-02 13:03" (local time)
+        const userInput = "2025-12-02 13:03";
+        const parsed = parseLocalDate(userInput);
+        expect(parsed).not.toBeNull();
+
+        // 2. Store as UTC ISO string
+        const storedValue = parsed!.toISOString();
+
+        // 3. Format back for display
+        const displayValue = formatForInput(storedValue);
+
+        // 4. Display should match user's original input (local time)
+        expect(displayValue).toBe("2025-12-02 13:03");
+      });
+    });
+
+    describe("invalid input", () => {
+      it("should return null for invalid date string", () => {
+        expect(parseLocalDate("not a date")).toBeNull();
+      });
+
+      it("should return null for completely invalid input", () => {
+        expect(parseLocalDate("abc123")).toBeNull();
+        expect(parseLocalDate("random text here")).toBeNull();
+      });
+    });
+  });
+
+  describe("formatForInput", () => {
+    it("should return original string for invalid ISO string", () => {
+      expect(formatForInput("not a date")).toBe("not a date");
+    });
+
+    it("should format UTC midnight as date-only (local time)", () => {
+      // UTC midnight will show as local time
+      // Test with a date that's clearly midnight in UTC
+      const utcMidnight = "2025-06-15T00:00:00.000Z";
+      const result = formatForInput(utcMidnight);
+
+      // Parse the stored value and check local components
+      const date = new Date(utcMidnight);
+      const expectedYear = date.getFullYear();
+      const expectedMonth = String(date.getMonth() + 1).padStart(2, "0");
+      const expectedDay = String(date.getDate()).padStart(2, "0");
+
+      // If local time has non-zero hours (due to timezone offset),
+      // it should include time; otherwise just date
+      if (date.getHours() !== 0 || date.getMinutes() !== 0) {
+        const expectedHours = String(date.getHours()).padStart(2, "0");
+        const expectedMinutes = String(date.getMinutes()).padStart(2, "0");
+        expect(result).toBe(
+          `${expectedYear}-${expectedMonth}-${expectedDay} ${expectedHours}:${expectedMinutes}`,
+        );
+      } else {
+        expect(result).toBe(`${expectedYear}-${expectedMonth}-${expectedDay}`);
+      }
+    });
+
+    it("should format date with time correctly", () => {
+      // Use a specific UTC time
+      const utcTime = "2025-12-02T08:03:00.000Z";
+      const result = formatForInput(utcTime);
+
+      // Parse and get local components
+      const date = new Date(utcTime);
+      const expectedYear = date.getFullYear();
+      const expectedMonth = String(date.getMonth() + 1).padStart(2, "0");
+      const expectedDay = String(date.getDate()).padStart(2, "0");
+      const expectedHours = String(date.getHours()).padStart(2, "0");
+      const expectedMinutes = String(date.getMinutes()).padStart(2, "0");
+
+      expect(result).toBe(
+        `${expectedYear}-${expectedMonth}-${expectedDay} ${expectedHours}:${expectedMinutes}`,
+      );
+    });
+
+    it("should use local time for display, not UTC", () => {
+      // Create a date at a specific UTC time
+      const utcTime = "2025-12-02T15:30:00.000Z";
+      const date = new Date(utcTime);
+
+      // Get what the local hour should be
+      const localHour = date.getHours();
+
+      const result = formatForInput(utcTime);
+
+      // Result should contain the local hour, not 15 (UTC)
+      // Unless we're in UTC timezone, in which case they're the same
+      expect(result).toContain(String(localHour).padStart(2, "0"));
+    });
+  });
+
+  describe("formatDisplayValue", () => {
+    it("should return 'Empty' for null", () => {
+      expect(formatDisplayValue(null)).toBe("Empty");
+    });
+
+    it("should return original string for invalid date", () => {
+      expect(formatDisplayValue("not a date")).toBe("not a date");
+    });
+
+    it("should include time component for datetime values", () => {
+      const result = formatDisplayValue("2024-11-11T15:30:00.000Z");
+      expect(result).toContain(":");
+    });
+
+    it("should format in 24-hour format (no AM/PM)", () => {
+      const result = formatDisplayValue("2024-11-11T15:30:00.000Z");
+      expect(result).not.toContain("AM");
+      expect(result).not.toContain("PM");
+      expect(result).not.toContain("am");
+      expect(result).not.toContain("pm");
+    });
+
+    it("should include year, month, and day", () => {
+      const result = formatDisplayValue("2024-11-11T15:30:00.000Z");
+      // The exact format depends on locale, but should contain these components
+      expect(result).toContain("2024");
+      expect(result).toContain("11"); // day
+      // Month could be "Nov" or "11" depending on locale
+    });
+  });
+
+  describe("timezone roundtrip scenarios", () => {
+    it("should handle editing and re-saving without drift", () => {
+      // Simulate: user enters time → save → open editor → save again
+      // The value should not drift due to timezone conversions
+
+      const originalInput = "2025-12-02 13:03";
+
+      // First save
+      const firstParse = parseLocalDate(originalInput);
+      const firstSave = firstParse!.toISOString();
+
+      // Open editor (format for input)
+      const displayedValue = formatForInput(firstSave);
+
+      // Second save (user doesn't change anything)
+      const secondParse = parseLocalDate(displayedValue);
+      const secondSave = secondParse!.toISOString();
+
+      // Values should be identical - no drift
+      expect(secondSave).toBe(firstSave);
+    });
+
+    it("should preserve time across multiple edit cycles", () => {
+      const originalInput = "2025-06-15 09:30";
+      let currentValue = parseLocalDate(originalInput)!.toISOString();
+
+      // Simulate 5 edit cycles
+      for (let i = 0; i < 5; i++) {
+        const displayed = formatForInput(currentValue);
+        const parsed = parseLocalDate(displayed);
+        currentValue = parsed!.toISOString();
+      }
+
+      // Final display should match original input
+      const finalDisplay = formatForInput(currentValue);
+      expect(finalDisplay).toBe(originalInput);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes timestamp property editor timezone conversion issue (#540)
- Extracts date utilities to `dateTimeUtils.ts` for better testability
- Normalizes space-separated dates to T-format before parsing to ensure consistent local time interpretation

## Problem
When manually editing timestamp properties, the plugin inconsistently handled date parsing. The format `2025-12-02 13:03` (space-separated) may be parsed as UTC in some browsers, while `2025-12-02T13:03` is consistently parsed as local time. This caused the displayed time to not match the user's input in certain environments.

## Solution
Normalize input strings by replacing the space with 'T' before parsing:
- `"2025-12-02 13:03"` → `"2025-12-02T13:03"` (parsed as local time)

This ensures consistent local time interpretation across all browsers.

## Test plan
- [x] Unit tests for `parseLocalDate`, `formatForInput`, `formatDisplayValue`
- [x] Timezone roundtrip tests (input → store → display → re-edit)
- [x] TypeScript compilation passes
- [x] ESLint passes
- [ ] CI pipeline (build, unit tests, component tests, E2E tests)

Closes #540