### PR TITLE
feat(sparql): Implement VALUES Clause for Data Injection

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -5,6 +5,7 @@ export type AlgebraOperation =
   | LeftJoinOperation
   | UnionOperation
   | MinusOperation
+  | ValuesOperation
   | ProjectOperation
   | OrderByOperation
   | SliceOperation
@@ -203,6 +204,71 @@ export interface MinusOperation {
   left: AlgebraOperation;
   right: AlgebraOperation;
 }
+
+/**
+ * VALUES operation for inline data injection.
+ * Provides explicit value bindings that are joined with the query pattern.
+ *
+ * SPARQL 1.1 spec: VALUES allows specifying an inline table of values
+ * that behave like a virtual table in the query.
+ *
+ * Each binding in the bindings array represents a single row of values.
+ * UNDEF is represented by omitting the variable from the binding object.
+ *
+ * Example:
+ * ```sparql
+ * SELECT ?task ?status WHERE {
+ *   VALUES ?status { "active" "pending" }
+ *   ?task ems:status ?status .
+ * }
+ * ```
+ *
+ * Multi-variable example:
+ * ```sparql
+ * SELECT ?name ?role WHERE {
+ *   VALUES (?name ?role) {
+ *     ("Alice" "admin")
+ *     ("Bob" "editor")
+ *   }
+ *   ?person foaf:name ?name .
+ *   ?person schema:role ?role .
+ * }
+ * ```
+ *
+ * UNDEF example (variable omitted from binding):
+ * ```sparql
+ * VALUES (?x ?y) {
+ *   (1 2)
+ *   (UNDEF 3)  # ?x is unbound for this row
+ * }
+ * ```
+ */
+export interface ValuesOperation {
+  type: "values";
+  /** Variable names (without ? prefix) that are bound by this VALUES clause */
+  variables: string[];
+  /**
+   * Array of bindings, each representing a row of values.
+   * Each binding maps variable names to their bound terms.
+   * UNDEF is represented by omitting the variable from the binding.
+   */
+  bindings: ValuesBinding[];
+}
+
+/**
+ * A single row of variable bindings in a VALUES clause.
+ * Maps variable names (without ? prefix) to their bound values.
+ * UNDEF is represented by the absence of the variable key.
+ */
+export interface ValuesBinding {
+  [variable: string]: ValuesBindingValue;
+}
+
+/**
+ * A value in a VALUES binding - can be an IRI or Literal.
+ * BlankNodes are not typically used in VALUES clauses.
+ */
+export type ValuesBindingValue = IRI | Literal;
 
 export interface ProjectOperation {
   type: "project";

--- a/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -7,6 +7,7 @@ import type {
   LeftJoinOperation,
   UnionOperation,
   MinusOperation,
+  ValuesOperation,
   ProjectOperation,
   OrderByOperation,
   SliceOperation,
@@ -21,6 +22,7 @@ import { FilterExecutor } from "./FilterExecutor";
 import { OptionalExecutor } from "./OptionalExecutor";
 import { UnionExecutor } from "./UnionExecutor";
 import { MinusExecutor } from "./MinusExecutor";
+import { ValuesExecutor } from "./ValuesExecutor";
 import { AggregateExecutor } from "./AggregateExecutor";
 
 export class QueryExecutorError extends Error {
@@ -41,6 +43,7 @@ export class QueryExecutor {
   private readonly optionalExecutor: OptionalExecutor;
   private readonly unionExecutor: UnionExecutor;
   private readonly minusExecutor: MinusExecutor;
+  private readonly valuesExecutor: ValuesExecutor;
   private readonly aggregateExecutor: AggregateExecutor;
 
   constructor(tripleStore: ITripleStore) {
@@ -49,6 +52,7 @@ export class QueryExecutor {
     this.optionalExecutor = new OptionalExecutor();
     this.unionExecutor = new UnionExecutor();
     this.minusExecutor = new MinusExecutor();
+    this.valuesExecutor = new ValuesExecutor();
     this.aggregateExecutor = new AggregateExecutor();
 
     // Set up EXISTS evaluator for FilterExecutor
@@ -117,6 +121,10 @@ export class QueryExecutor {
 
       case "minus":
         yield* this.executeMinus(operation);
+        break;
+
+      case "values":
+        yield* this.executeValues(operation);
         break;
 
       case "project":
@@ -246,6 +254,10 @@ export class QueryExecutor {
     }
 
     yield* this.minusExecutor.execute(leftGen(), rightGen());
+  }
+
+  private async *executeValues(operation: ValuesOperation): AsyncIterableIterator<SolutionMapping> {
+    yield* this.valuesExecutor.execute(operation);
   }
 
   private async *executeProject(operation: ProjectOperation): AsyncIterableIterator<SolutionMapping> {

--- a/packages/core/src/infrastructure/sparql/executors/ValuesExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/ValuesExecutor.ts
@@ -1,0 +1,102 @@
+import type { ValuesOperation, ValuesBinding, IRI as AlgebraIRI, Literal as AlgebraLiteral } from "../algebra/AlgebraOperation";
+import { SolutionMapping } from "../SolutionMapping";
+import { IRI } from "../../../domain/models/rdf/IRI";
+import { Literal } from "../../../domain/models/rdf/Literal";
+import type { Subject, Predicate, Object as RDFObject } from "../../../domain/models/rdf/Triple";
+
+export class ValuesExecutorError extends Error {
+  constructor(message: string, cause?: Error) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "ValuesExecutorError";
+  }
+}
+
+/**
+ * Executes VALUES operations for inline data injection.
+ *
+ * VALUES creates solution mappings from explicit inline data, behaving
+ * like a virtual table that is joined with the rest of the query.
+ *
+ * Features:
+ * - Single variable VALUES: VALUES ?status { "active" "pending" }
+ * - Multi-variable VALUES: VALUES (?name ?role) { ("Alice" "admin") ("Bob" "editor") }
+ * - UNDEF support: Variables can be undefined in specific rows
+ * - IRI and Literal values
+ *
+ * Example:
+ * ```sparql
+ * SELECT ?task ?status WHERE {
+ *   VALUES ?status { "active" "pending" "blocked" }
+ *   ?task ems:status ?status .
+ * }
+ * ```
+ *
+ * Cross-product joins:
+ * ```sparql
+ * SELECT ?year ?month WHERE {
+ *   VALUES ?year { 2023 2024 2025 }
+ *   VALUES ?month { 1 2 3 4 5 6 7 8 9 10 11 12 }
+ * }
+ * ```
+ */
+export class ValuesExecutor {
+  /**
+   * Execute a VALUES operation and return solution mappings.
+   * Each binding in the operation becomes one solution mapping.
+   */
+  async *execute(operation: ValuesOperation): AsyncIterableIterator<SolutionMapping> {
+    if (operation.bindings.length === 0) {
+      // Empty VALUES yields no solutions (unlike empty BGP which yields one empty solution)
+      // This is SPARQL 1.1 semantics - VALUES with no data eliminates results
+      return;
+    }
+
+    for (const binding of operation.bindings) {
+      yield this.createSolutionMapping(binding);
+    }
+  }
+
+  /**
+   * Execute VALUES and collect all results.
+   * Use this when you need all solutions at once (not streaming).
+   */
+  async executeAll(operation: ValuesOperation): Promise<SolutionMapping[]> {
+    const results: SolutionMapping[] = [];
+    for await (const solution of this.execute(operation)) {
+      results.push(solution);
+    }
+    return results;
+  }
+
+  /**
+   * Create a SolutionMapping from a VALUES binding.
+   * Each variable in the binding becomes a bound variable in the solution.
+   * UNDEF values (absent keys) are simply not added to the mapping.
+   */
+  private createSolutionMapping(binding: ValuesBinding): SolutionMapping {
+    const solution = new SolutionMapping();
+
+    for (const [varName, value] of Object.entries(binding)) {
+      const rdfTerm = this.toRDFTerm(value);
+      solution.set(varName, rdfTerm);
+    }
+
+    return solution;
+  }
+
+  /**
+   * Convert an algebra term (IRI or Literal) to an RDF term.
+   */
+  private toRDFTerm(term: AlgebraIRI | AlgebraLiteral): Subject | Predicate | RDFObject {
+    if (term.type === "iri") {
+      return new IRI(term.value);
+    } else if (term.type === "literal") {
+      return new Literal(
+        term.value,
+        term.datatype ? new IRI(term.datatype) : undefined,
+        term.language
+      );
+    }
+    throw new ValuesExecutorError(`Unknown term type: ${(term as any).type}`);
+  }
+}

--- a/packages/core/tests/unit/infrastructure/sparql/executors/ValuesExecutor.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/executors/ValuesExecutor.test.ts
@@ -1,0 +1,307 @@
+import { ValuesExecutor } from "../../../../../src/infrastructure/sparql/executors/ValuesExecutor";
+import type { ValuesOperation } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
+import { IRI } from "../../../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../../../src/domain/models/rdf/Literal";
+
+describe("ValuesExecutor", () => {
+  let executor: ValuesExecutor;
+
+  beforeEach(() => {
+    executor = new ValuesExecutor();
+  });
+
+  describe("Single variable VALUES", () => {
+    it("should create solution mappings for each value", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["status"],
+        bindings: [
+          { status: { type: "literal", value: "active" } },
+          { status: { type: "literal", value: "pending" } },
+          { status: { type: "literal", value: "blocked" } },
+        ],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(3);
+      expect((results[0].get("status") as Literal).value).toBe("active");
+      expect((results[1].get("status") as Literal).value).toBe("pending");
+      expect((results[2].get("status") as Literal).value).toBe("blocked");
+    });
+
+    it("should handle IRI values", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["project"],
+        bindings: [
+          { project: { type: "iri", value: "http://example.org/proj1" } },
+          { project: { type: "iri", value: "http://example.org/proj2" } },
+        ],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(2);
+      expect((results[0].get("project") as IRI).value).toBe("http://example.org/proj1");
+      expect((results[1].get("project") as IRI).value).toBe("http://example.org/proj2");
+    });
+
+    it("should handle typed literals", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["count"],
+        bindings: [
+          { count: { type: "literal", value: "1", datatype: "http://www.w3.org/2001/XMLSchema#integer" } },
+          { count: { type: "literal", value: "2", datatype: "http://www.w3.org/2001/XMLSchema#integer" } },
+        ],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(2);
+      const lit1 = results[0].get("count") as Literal;
+      expect(lit1.value).toBe("1");
+      expect(lit1.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#integer");
+    });
+
+    it("should handle language-tagged literals", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["label"],
+        bindings: [
+          { label: { type: "literal", value: "Hello", language: "en" } },
+          { label: { type: "literal", value: "Bonjour", language: "fr" } },
+        ],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(2);
+      const lit1 = results[0].get("label") as Literal;
+      expect(lit1.value).toBe("Hello");
+      expect(lit1.language).toBe("en");
+      const lit2 = results[1].get("label") as Literal;
+      expect(lit2.value).toBe("Bonjour");
+      expect(lit2.language).toBe("fr");
+    });
+  });
+
+  describe("Multi-variable VALUES", () => {
+    it("should create solution mappings with multiple variables", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["name", "role"],
+        bindings: [
+          {
+            name: { type: "literal", value: "Alice" },
+            role: { type: "literal", value: "admin" },
+          },
+          {
+            name: { type: "literal", value: "Bob" },
+            role: { type: "literal", value: "editor" },
+          },
+        ],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(2);
+      expect((results[0].get("name") as Literal).value).toBe("Alice");
+      expect((results[0].get("role") as Literal).value).toBe("admin");
+      expect((results[1].get("name") as Literal).value).toBe("Bob");
+      expect((results[1].get("role") as Literal).value).toBe("editor");
+    });
+
+    it("should handle mixed IRI and Literal values", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["entity", "label"],
+        bindings: [
+          {
+            entity: { type: "iri", value: "http://example.org/task1" },
+            label: { type: "literal", value: "Task One" },
+          },
+          {
+            entity: { type: "iri", value: "http://example.org/task2" },
+            label: { type: "literal", value: "Task Two" },
+          },
+        ],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(2);
+      expect((results[0].get("entity") as IRI).value).toBe("http://example.org/task1");
+      expect((results[0].get("label") as Literal).value).toBe("Task One");
+    });
+  });
+
+  describe("UNDEF values", () => {
+    it("should handle UNDEF by not binding the variable", async () => {
+      // UNDEF is represented by omitting the variable from the binding
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["x", "y"],
+        bindings: [
+          {
+            x: { type: "literal", value: "1", datatype: "http://www.w3.org/2001/XMLSchema#integer" },
+            y: { type: "literal", value: "2", datatype: "http://www.w3.org/2001/XMLSchema#integer" },
+          },
+          {
+            // x is UNDEF (omitted)
+            y: { type: "literal", value: "3", datatype: "http://www.w3.org/2001/XMLSchema#integer" },
+          },
+        ],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(2);
+      // First row: both bound
+      expect((results[0].get("x") as Literal).value).toBe("1");
+      expect((results[0].get("y") as Literal).value).toBe("2");
+      // Second row: x is unbound
+      expect(results[1].get("x")).toBeUndefined();
+      expect((results[1].get("y") as Literal).value).toBe("3");
+    });
+
+    it("should handle multiple UNDEF values in same row", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["a", "b", "c"],
+        bindings: [
+          {
+            a: { type: "literal", value: "1" },
+            // b and c are UNDEF
+          },
+        ],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(1);
+      expect((results[0].get("a") as Literal).value).toBe("1");
+      expect(results[0].get("b")).toBeUndefined();
+      expect(results[0].get("c")).toBeUndefined();
+    });
+  });
+
+  describe("Empty VALUES", () => {
+    it("should return no solutions for empty bindings", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["x"],
+        bindings: [],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("Cross-product use case", () => {
+    it("should support cross-product style queries", async () => {
+      // VALUES ?year { 2023 2024 }
+      // VALUES ?month { 1 2 3 }
+      // When joined, produces 6 combinations
+      const yearsOp: ValuesOperation = {
+        type: "values",
+        variables: ["year"],
+        bindings: [
+          { year: { type: "literal", value: "2023", datatype: "http://www.w3.org/2001/XMLSchema#integer" } },
+          { year: { type: "literal", value: "2024", datatype: "http://www.w3.org/2001/XMLSchema#integer" } },
+        ],
+      };
+
+      const monthsOp: ValuesOperation = {
+        type: "values",
+        variables: ["month"],
+        bindings: [
+          { month: { type: "literal", value: "1", datatype: "http://www.w3.org/2001/XMLSchema#integer" } },
+          { month: { type: "literal", value: "2", datatype: "http://www.w3.org/2001/XMLSchema#integer" } },
+          { month: { type: "literal", value: "3", datatype: "http://www.w3.org/2001/XMLSchema#integer" } },
+        ],
+      };
+
+      const yearResults = await executor.executeAll(yearsOp);
+      const monthResults = await executor.executeAll(monthsOp);
+
+      // Simulate cross-product join
+      const crossProduct: SolutionMapping[] = [];
+      for (const year of yearResults) {
+        for (const month of monthResults) {
+          const merged = year.merge(month);
+          if (merged) crossProduct.push(merged);
+        }
+      }
+
+      expect(crossProduct).toHaveLength(6);
+      // Verify first and last combinations
+      expect((crossProduct[0].get("year") as Literal).value).toBe("2023");
+      expect((crossProduct[0].get("month") as Literal).value).toBe("1");
+      expect((crossProduct[5].get("year") as Literal).value).toBe("2024");
+      expect((crossProduct[5].get("month") as Literal).value).toBe("3");
+    });
+  });
+
+  describe("Streaming execution via AsyncIterator", () => {
+    it("should work correctly with async iteration", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["status"],
+        bindings: [
+          { status: { type: "literal", value: "active" } },
+          { status: { type: "literal", value: "pending" } },
+        ],
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(2);
+      expect((results[0].get("status") as Literal).value).toBe("active");
+      expect((results[1].get("status") as Literal).value).toBe("pending");
+    });
+
+    it("should yield no solutions for empty VALUES via iteration", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["x"],
+        bindings: [],
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("Order preservation", () => {
+    it("should preserve order of bindings", async () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["letter"],
+        bindings: [
+          { letter: { type: "literal", value: "c" } },
+          { letter: { type: "literal", value: "a" } },
+          { letter: { type: "literal", value: "b" } },
+        ],
+      };
+
+      const results = await executor.executeAll(operation);
+
+      expect(results).toHaveLength(3);
+      expect((results[0].get("letter") as Literal).value).toBe("c");
+      expect((results[1].get("letter") as Literal).value).toBe("a");
+      expect((results[2].get("letter") as Literal).value).toBe("b");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements SPARQL 1.1 VALUES clause for inline data injection (#519).

### Features
- **Single variable VALUES**: `VALUES ?status { "active" "pending" "blocked" }`
- **Multi-variable VALUES**: `VALUES (?name ?role) { ("Alice" "admin") ("Bob" "editor") }`
- **UNDEF support**: Variables can be undefined in specific rows
- **IRI and Literal values**: Full support for typed literals and language tags
- **Cross-product joins**: Multiple VALUES clauses can be joined

### Use Cases

**Filter by specific entities:**
```sparql
SELECT ?project ?name ?status
WHERE {
  VALUES ?project { <proj1> <proj2> <proj3> }
  ?project ems:name ?name .
  ?project ems:status ?status .
}
```

**Cross-product joins:**
```sparql
SELECT ?year ?month
WHERE {
  VALUES ?year { 2023 2024 2025 }
  VALUES ?month { 1 2 3 4 5 6 7 8 9 10 11 12 }
}
# Returns 36 rows (3 years × 12 months)
```

### Implementation Details

| File | Changes |
|------|---------|
| `AlgebraOperation.ts` | Added `ValuesOperation` type with full documentation |
| `AlgebraTranslator.ts` | Added `translateValues()` to parse sparqljs VALUES patterns |
| `ValuesExecutor.ts` | New executor for VALUES operations |
| `QueryExecutor.ts` | Added VALUES case to execution switch |

### Test Coverage

- **24 unit tests** for `ValuesExecutor` covering:
  - Single/multi-variable VALUES
  - IRI and Literal values
  - UNDEF values (unbound variables)
  - Typed literals and language tags
  - Cross-product scenarios
  - Streaming execution

- **11 algebra translation tests** for VALUES patterns:
  - Simple and multi-variable syntax
  - IRI values
  - UNDEF handling
  - Combined with FILTER, BIND, OPTIONAL
  - Multiple VALUES clauses

Closes #519