### PR TITLE
docs(cli): establish API stability guarantees before MCP integration

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Changelog
+
+All notable changes to exocortex-cli will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-12-02
+
+### Added
+
+**API Stability Guarantees**
+- Formal API reference documentation ([CLI_API_REFERENCE.md](docs/CLI_API_REFERENCE.md))
+- Semantic versioning policy ([VERSIONING.md](VERSIONING.md))
+- Stability tiers (Stable, Experimental, Internal)
+- MCP integration guidelines
+
+**SPARQL Query System**
+- `exocortex sparql query` - Execute SPARQL 1.1 queries against vault
+- Multiple output formats: `table`, `json`, `csv`
+- Query plan visualization with `--explain`
+- Performance statistics with `--stats`
+- Query optimization (can be disabled with `--no-optimize`)
+
+**Status Transition Commands**
+- `exocortex command start` - Transition ToDo → Doing with timestamp
+- `exocortex command complete` - Transition Doing → Done with timestamps
+- `exocortex command trash` - Transition to Trashed status
+- `exocortex command archive` - Set archived flag and remove aliases
+- `exocortex command move-to-backlog` - Transition to Backlog status
+- `exocortex command move-to-analysis` - Transition to Analysis status
+- `exocortex command move-to-todo` - Transition to ToDo status
+
+**Asset Creation Commands**
+- `exocortex command create-task` - Create task with frontmatter
+- `exocortex command create-meeting` - Create meeting with frontmatter
+- `exocortex command create-project` - Create project with frontmatter
+- `exocortex command create-area` - Create area with frontmatter
+- Options: `--label`, `--prototype`, `--area`, `--parent`
+- Auto-generated UUID v4 for `exo__Asset_uid`
+- ISO timestamp for `exo__Asset_createdAt`
+
+**Property Mutation Commands**
+- `exocortex command rename-to-uid` - Rename file to match UID
+- `exocortex command update-label` - Update label and sync aliases
+- `exocortex command schedule` - Set planned start date
+- `exocortex command set-deadline` - Set planned end date
+- Support for `--dry-run` preview mode
+
+**Infrastructure**
+- Standardized exit codes (0-8) following Unix conventions
+- Path validation with security checks
+- Error handling with descriptive messages
+- Node.js file system adapter
+
+### Changed
+
+- Updated README with current command structure
+- Documented all implemented commands (previously some were in roadmap)
+
+### Deprecated
+
+- None
+
+### Removed
+
+- None
+
+### Fixed
+
+- None
+
+### Security
+
+- Path traversal prevention in `PathResolver`
+- Vault boundary validation for all file operations
+
+---
+
+## Version History Summary
+
+| Version | Release Date | Breaking Changes |
+|---------|--------------|------------------|
+| 0.1.0 | 2025-12-02 | Initial stable API |
+
+## Stability Notes
+
+### Commands Marked Stable (v0.1.0)
+
+The following commands are covered by semantic versioning guarantees:
+
+- `exocortex sparql query`
+- `exocortex command start`
+- `exocortex command complete`
+- `exocortex command trash`
+- `exocortex command archive`
+- `exocortex command move-to-backlog`
+- `exocortex command move-to-analysis`
+- `exocortex command move-to-todo`
+- `exocortex command create-task`
+- `exocortex command create-meeting`
+- `exocortex command create-project`
+- `exocortex command create-area`
+- `exocortex command rename-to-uid`
+- `exocortex command update-label`
+- `exocortex command schedule`
+- `exocortex command set-deadline`
+
+See [VERSIONING.md](VERSIONING.md) for stability policy details.

--- a/packages/cli/VERSIONING.md
+++ b/packages/cli/VERSIONING.md
@@ -1,0 +1,346 @@
+# Versioning Policy
+
+This document defines the semantic versioning policy for **exocortex-cli**, establishing clear stability guarantees for API consumers including MCP tools and automation scripts.
+
+---
+
+## Table of Contents
+
+- [Semantic Versioning](#semantic-versioning)
+- [Version Components](#version-components)
+- [What Constitutes a Breaking Change](#what-constitutes-a-breaking-change)
+- [What Is NOT a Breaking Change](#what-is-not-a-breaking-change)
+- [Stability Tiers](#stability-tiers)
+- [Deprecation Policy](#deprecation-policy)
+- [Version History](#version-history)
+- [MCP Integration Guidelines](#mcp-integration-guidelines)
+
+---
+
+## Semantic Versioning
+
+exocortex-cli follows [Semantic Versioning 2.0.0](https://semver.org/):
+
+```
+MAJOR.MINOR.PATCH
+```
+
+### Current Version: 0.1.x (Pre-release)
+
+During the 0.x phase:
+- **MINOR** bumps may contain breaking changes
+- **PATCH** bumps are backward-compatible bug fixes
+- API is considered **stabilizing**, not fully stable
+
+### Post-1.0 (Future)
+
+After 1.0 release:
+- **MAJOR** bumps contain breaking changes
+- **MINOR** bumps add backward-compatible features
+- **PATCH** bumps are backward-compatible bug fixes
+
+---
+
+## Version Components
+
+### Major Version (Breaking Changes)
+
+Increment major version when:
+
+1. **Command renamed or removed**
+   ```bash
+   # Breaking: command renamed
+   exocortex command start → exocortex effort start
+   ```
+
+2. **Required argument removed or reordered**
+   ```bash
+   # Breaking: argument order changed
+   exocortex command <name> <path> → exocortex command <path> <name>
+   ```
+
+3. **Option behavior changed incompatibly**
+   ```bash
+   # Breaking: --format json output structure changed
+   {"results": [...]} → {"bindings": [...]}
+   ```
+
+4. **Exit code meanings changed**
+   ```bash
+   # Breaking: exit code 3 now means something different
+   3 = FILE_NOT_FOUND → 3 = NETWORK_ERROR
+   ```
+
+5. **Required option added to existing command**
+   ```bash
+   # Breaking: new required option
+   exocortex command start <path> → exocortex command start <path> --confirm
+   ```
+
+### Minor Version (New Features)
+
+Increment minor version when:
+
+1. **New command added**
+   ```bash
+   # New: command added
+   exocortex command unarchive <path>
+   ```
+
+2. **New optional flag added**
+   ```bash
+   # New: optional flag
+   exocortex sparql query --timeout 30000
+   ```
+
+3. **New output format added**
+   ```bash
+   # New: format option
+   --format yaml
+   ```
+
+4. **New exit code added**
+   ```bash
+   # New: additional exit code
+   9 = TIMEOUT_EXCEEDED
+   ```
+
+### Patch Version (Bug Fixes)
+
+Increment patch version when:
+
+1. **Bug fixed without API change**
+2. **Documentation updated**
+3. **Performance improved**
+4. **Internal refactoring (no API change)**
+
+---
+
+## What Constitutes a Breaking Change
+
+### Definitely Breaking
+
+| Category | Example |
+|----------|---------|
+| Command removal | `exocortex plan today` removed |
+| Command rename | `create-task` → `new-task` |
+| Argument removal | `<filepath>` argument removed |
+| Argument reorder | Positional args swapped |
+| Required option added | New mandatory `--confirm` flag |
+| Option removal | `--dry-run` no longer supported |
+| Exit code change | Code 3 meaning changed |
+| Output format change | JSON structure modified |
+
+### Borderline (Evaluated Case-by-Case)
+
+| Category | Approach |
+|----------|----------|
+| Error message text | NOT breaking (messages are informational) |
+| Console output formatting | NOT breaking (visual only) |
+| Default value change | BREAKING if changes behavior |
+| Option renamed with alias | NOT breaking if old name still works |
+
+---
+
+## What Is NOT a Breaking Change
+
+The following changes are explicitly **NOT** considered breaking:
+
+### 1. Console Output Changes
+
+```bash
+# Before
+✅ Started: tasks/task.md
+   Status: Doing
+
+# After
+✅ Started task: tasks/task.md
+   New status: Doing
+   Timestamp: 2025-12-02T10:30:00
+```
+
+Console messages are for human consumption. Scripts should rely on exit codes.
+
+### 2. Performance Improvements
+
+Query optimization changes, faster loading, reduced memory usage.
+
+### 3. New Optional Flags
+
+Adding `--verbose`, `--quiet`, `--debug` flags.
+
+### 4. Internal Implementation Changes
+
+Refactoring executors, changing internal architecture.
+
+### 5. Documentation Updates
+
+Clarifying existing behavior, adding examples.
+
+---
+
+## Stability Tiers
+
+### Tier 1: Stable (Covered by SemVer)
+
+Commands and options documented in [CLI_API_REFERENCE.md](docs/CLI_API_REFERENCE.md):
+
+| Command | Status |
+|---------|--------|
+| `exocortex sparql query` | **Stable** |
+| `exocortex command start` | **Stable** |
+| `exocortex command complete` | **Stable** |
+| `exocortex command trash` | **Stable** |
+| `exocortex command archive` | **Stable** |
+| `exocortex command move-to-backlog` | **Stable** |
+| `exocortex command move-to-analysis` | **Stable** |
+| `exocortex command move-to-todo` | **Stable** |
+| `exocortex command create-task` | **Stable** |
+| `exocortex command create-meeting` | **Stable** |
+| `exocortex command create-project` | **Stable** |
+| `exocortex command create-area` | **Stable** |
+| `exocortex command rename-to-uid` | **Stable** |
+| `exocortex command update-label` | **Stable** |
+| `exocortex command schedule` | **Stable** |
+| `exocortex command set-deadline` | **Stable** |
+
+### Tier 2: Experimental
+
+Commands marked as experimental may change between minor versions:
+
+| Command | Notes |
+|---------|-------|
+| (none currently) | |
+
+### Tier 3: Internal
+
+Internal APIs not exposed via CLI are not covered by versioning:
+
+- `CommandExecutor` TypeScript class
+- `NodeFsAdapter` implementation
+- Internal utility functions
+
+---
+
+## Deprecation Policy
+
+### Pre-1.0 (Current)
+
+During 0.x development:
+- Breaking changes announced in release notes
+- No formal deprecation period required
+- Users should pin to specific minor versions
+
+### Post-1.0 (Future)
+
+After 1.0 release:
+
+1. **Deprecation Warning**: Feature marked deprecated with console warning
+2. **One Minor Version**: Deprecated feature continues to work
+3. **Next Major Version**: Deprecated feature removed
+
+### Deprecation Notice Format
+
+```bash
+$ exocortex command old-name "path/to/file.md"
+⚠️  WARNING: 'old-name' is deprecated and will be removed in v2.0.
+    Use 'new-name' instead.
+✅ Command executed successfully
+```
+
+---
+
+## Version History
+
+### v0.1.0 (Current)
+
+**Initial stable API release**
+
+Commands established:
+- SPARQL query execution (`sparql query`)
+- Status transitions (`start`, `complete`, `trash`, `archive`, `move-to-*`)
+- Asset creation (`create-task`, `create-meeting`, `create-project`, `create-area`)
+- Property mutations (`rename-to-uid`, `update-label`)
+- Planning (`schedule`, `set-deadline`)
+
+Exit codes standardized (0-8).
+
+---
+
+## MCP Integration Guidelines
+
+When wrapping exocortex-cli in MCP tools:
+
+### 1. Use Exit Codes for Status
+
+```typescript
+const result = await exec('exocortex command start "tasks/task.md"');
+if (result.exitCode === 0) {
+  return { success: true };
+} else if (result.exitCode === 3) {
+  return { error: 'File not found' };
+}
+```
+
+### 2. Pin CLI Version
+
+```json
+{
+  "dependencies": {
+    "exocortex-cli": "^0.1.0"
+  }
+}
+```
+
+### 3. Use JSON Output for Parsing
+
+```typescript
+const result = await exec('exocortex sparql query "..." --format json');
+const bindings = JSON.parse(result.stdout);
+```
+
+### 4. Don't Parse Console Messages
+
+Console messages are for humans. Use exit codes and JSON output for automation.
+
+### 5. Handle Deprecation Warnings
+
+```typescript
+if (result.stderr.includes('WARNING: deprecated')) {
+  logger.warn('CLI command deprecated, update MCP tool');
+}
+```
+
+### 6. Version Compatibility Matrix
+
+| exocortex-cli | MCP Tool Compatibility |
+|---------------|------------------------|
+| 0.1.x | MCP tools targeting 0.1.x stable API |
+| 0.2.x | May require MCP tool updates |
+| 1.0.x | Stable, long-term support |
+
+---
+
+## Stability Commitment
+
+### Current Commitment (v0.1.x)
+
+We commit to:
+1. **No breaking changes in patch versions** (0.1.0 → 0.1.1)
+2. **Announce breaking changes in release notes** for minor versions
+3. **Minimum 2-week stability period** before MCP integration recommended
+
+### Post-1.0 Commitment (Future)
+
+We will commit to:
+1. **SemVer strict compliance**
+2. **Minimum 6-month deprecation period** for breaking changes
+3. **LTS releases** for major versions (18 months support)
+
+---
+
+## Questions?
+
+For questions about versioning or API stability:
+- Open an issue: [GitHub Issues](https://github.com/kitelev/exocortex-obsidian-plugin/issues)
+- Tag with `cli` and `api-stability` labels

--- a/packages/cli/docs/CLI_API_REFERENCE.md
+++ b/packages/cli/docs/CLI_API_REFERENCE.md
@@ -1,0 +1,607 @@
+# CLI API Reference
+
+> **API Stability**: This document defines the **stable API surface** for exocortex-cli v0.1.x. Commands and options documented here are considered stable and follow semantic versioning guarantees. See [VERSIONING.md](../VERSIONING.md) for versioning policy.
+
+---
+
+## Table of Contents
+
+- [SPARQL Query](#sparql-query)
+- [Command Execution](#command-execution)
+  - [Status Commands](#status-commands)
+  - [Creation Commands](#creation-commands)
+  - [Property Commands](#property-commands)
+  - [Planning Commands](#planning-commands)
+- [Exit Codes](#exit-codes)
+- [Common Options](#common-options)
+- [Stability Guarantees](#stability-guarantees)
+
+---
+
+## SPARQL Query
+
+Execute SPARQL queries against your Obsidian vault as an RDF knowledge graph.
+
+### Signature
+
+```bash
+exocortex sparql query <query> [options]
+```
+
+### Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<query>` | string | Yes | SPARQL query string or path to `.sparql` file |
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--vault <path>` | string | `process.cwd()` | Path to Obsidian vault |
+| `--format <type>` | enum | `table` | Output format: `table`, `json`, `csv` |
+| `--explain` | boolean | `false` | Show optimized query plan |
+| `--stats` | boolean | `false` | Show execution statistics |
+| `--no-optimize` | boolean | `false` | Disable query optimization |
+
+### Output
+
+- **Table format**: ASCII table with headers and aligned columns
+- **JSON format**: Array of solution mappings with variable bindings
+- **CSV format**: Comma-separated values with header row
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Query executed successfully |
+| `1` | General error (parse error, vault not found, etc.) |
+
+### Examples
+
+```bash
+# Inline query with table output
+exocortex sparql query "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10" --vault ~/vault
+
+# Query from file with JSON output
+exocortex sparql query queries/tasks.sparql --vault ~/vault --format json
+
+# Query with execution stats
+exocortex sparql query "SELECT ?task WHERE { ?task exo:Instance_class ems:Task }" \
+  --vault ~/vault --stats
+
+# Query with plan visualization
+exocortex sparql query queries/complex.sparql --vault ~/vault --explain
+```
+
+---
+
+## Command Execution
+
+Execute plugin commands on single assets via CLI.
+
+### Base Signature
+
+```bash
+exocortex command <command-name> <filepath> [options]
+```
+
+### Common Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<command-name>` | string | Yes | Command to execute (see specific commands below) |
+| `<filepath>` | string | Yes | Path to asset file (relative to vault root or absolute) |
+
+### Common Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--vault <path>` | string | `process.cwd()` | Path to Obsidian vault |
+| `--dry-run` | boolean | `false` | Preview changes without modifying files |
+
+---
+
+## Status Commands
+
+Commands that transition effort status (tasks, projects, meetings).
+
+### start
+
+Transitions task from ToDo to Doing status and records start timestamp.
+
+```bash
+exocortex command start <filepath> [--vault <path>]
+```
+
+**Side Effects**:
+- Sets `ems__Effort_status` to `"[[ems__EffortStatusDoing]]"`
+- Sets `ems__Effort_startTimestamp` to current ISO timestamp
+
+**Example**:
+```bash
+exocortex command start "tasks/implement-feature.md" --vault ~/vault
+```
+
+---
+
+### complete
+
+Transitions task from Doing to Done status and records completion timestamps.
+
+```bash
+exocortex command complete <filepath> [--vault <path>]
+```
+
+**Side Effects**:
+- Sets `ems__Effort_status` to `"[[ems__EffortStatusDone]]"`
+- Sets `ems__Effort_endTimestamp` to current ISO timestamp
+- Sets `ems__Effort_resolutionTimestamp` to current ISO timestamp
+
+**Example**:
+```bash
+exocortex command complete "tasks/implement-feature.md" --vault ~/vault
+```
+
+---
+
+### trash
+
+Transitions task to Trashed status from any current status.
+
+```bash
+exocortex command trash <filepath> [--vault <path>]
+```
+
+**Side Effects**:
+- Sets `ems__Effort_status` to `"[[ems__EffortStatusTrashed]]"`
+- Sets `ems__Effort_resolutionTimestamp` to current ISO timestamp
+
+**Example**:
+```bash
+exocortex command trash "tasks/obsolete-task.md" --vault ~/vault
+```
+
+---
+
+### archive
+
+Sets archived property to true and removes aliases.
+
+```bash
+exocortex command archive <filepath> [--vault <path>]
+```
+
+**Side Effects**:
+- Sets `archived` to `true`
+- Removes `aliases` property
+
+**Example**:
+```bash
+exocortex command archive "tasks/old-completed-task.md" --vault ~/vault
+```
+
+---
+
+### move-to-backlog
+
+Transitions task to Backlog status.
+
+```bash
+exocortex command move-to-backlog <filepath> [--vault <path>]
+```
+
+**Side Effects**:
+- Sets `ems__Effort_status` to `"[[ems__EffortStatusBacklog]]"`
+
+**Example**:
+```bash
+exocortex command move-to-backlog "tasks/defer-task.md" --vault ~/vault
+```
+
+---
+
+### move-to-analysis
+
+Transitions project to Analysis status.
+
+```bash
+exocortex command move-to-analysis <filepath> [--vault <path>]
+```
+
+**Side Effects**:
+- Sets `ems__Effort_status` to `"[[ems__EffortStatusAnalysis]]"`
+
+**Example**:
+```bash
+exocortex command move-to-analysis "projects/new-initiative.md" --vault ~/vault
+```
+
+---
+
+### move-to-todo
+
+Transitions task/project to ToDo status.
+
+```bash
+exocortex command move-to-todo <filepath> [--vault <path>]
+```
+
+**Side Effects**:
+- Sets `ems__Effort_status` to `"[[ems__EffortStatusToDo]]"`
+
+**Example**:
+```bash
+exocortex command move-to-todo "tasks/ready-task.md" --vault ~/vault
+```
+
+---
+
+## Creation Commands
+
+Commands that create new asset files.
+
+### create-task
+
+Creates new task file with complete frontmatter initialization.
+
+```bash
+exocortex command create-task <filepath> --label <label> [options]
+```
+
+**Required Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--label <value>` | string | Task label (required) |
+
+**Optional Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--prototype <uid>` | string | Prototype UID for inheritance |
+| `--area <uid>` | string | Area UID for effort linkage |
+| `--parent <uid>` | string | Parent UID for effort linkage |
+
+**Generated Frontmatter**:
+- `exo__Asset_isDefinedBy`: `"[[Ontology/EMS]]"`
+- `exo__Asset_uid`: Generated UUID v4
+- `exo__Asset_label`: From `--label`
+- `exo__Asset_createdAt`: ISO timestamp
+- `exo__Instance_class`: `["[[ems__Task]]"]`
+- `ems__Effort_status`: `"[[ems__EffortStatusDraft]]"`
+- `aliases`: Array containing label
+
+**Example**:
+```bash
+exocortex command create-task "tasks/new-task.md" \
+  --label "Implement search feature" \
+  --area "areas/product" \
+  --vault ~/vault
+```
+
+---
+
+### create-meeting
+
+Creates new meeting file with complete frontmatter initialization.
+
+```bash
+exocortex command create-meeting <filepath> --label <label> [options]
+```
+
+**Required Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--label <value>` | string | Meeting label (required) |
+
+**Optional Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--prototype <uid>` | string | Prototype UID for inheritance |
+| `--area <uid>` | string | Area UID for effort linkage |
+| `--parent <uid>` | string | Parent UID for effort linkage |
+
+**Generated Frontmatter**:
+- `exo__Asset_isDefinedBy`: `"[[Ontology/EMS]]"`
+- `exo__Asset_uid`: Generated UUID v4
+- `exo__Asset_label`: From `--label`
+- `exo__Asset_createdAt`: ISO timestamp
+- `exo__Instance_class`: `["[[ems__Meeting]]"]`
+- `ems__Effort_status`: `"[[ems__EffortStatusDraft]]"`
+- `aliases`: Array containing label
+
+**Example**:
+```bash
+exocortex command create-meeting "meetings/standup.md" \
+  --label "Daily Standup 2025-12-02" \
+  --prototype "prototypes/standup-template" \
+  --vault ~/vault
+```
+
+---
+
+### create-project
+
+Creates new project file with complete frontmatter initialization.
+
+```bash
+exocortex command create-project <filepath> --label <label> [options]
+```
+
+**Required Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--label <value>` | string | Project label (required) |
+
+**Optional Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--prototype <uid>` | string | Prototype UID for inheritance |
+| `--area <uid>` | string | Area UID for effort linkage |
+| `--parent <uid>` | string | Parent UID for effort linkage |
+
+**Generated Frontmatter**:
+- `exo__Asset_isDefinedBy`: `"[[Ontology/EMS]]"`
+- `exo__Asset_uid`: Generated UUID v4
+- `exo__Asset_label`: From `--label`
+- `exo__Asset_createdAt`: ISO timestamp
+- `exo__Instance_class`: `["[[ems__Project]]"]`
+- `ems__Effort_status`: `"[[ems__EffortStatusDraft]]"`
+- `aliases`: Array containing label
+
+**Example**:
+```bash
+exocortex command create-project "projects/website-redesign.md" \
+  --label "Website Redesign Q1 2026" \
+  --area "areas/product" \
+  --vault ~/vault
+```
+
+---
+
+### create-area
+
+Creates new area file with complete frontmatter initialization.
+
+```bash
+exocortex command create-area <filepath> --label <label> [options]
+```
+
+**Required Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--label <value>` | string | Area label (required) |
+
+**Optional Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--prototype <uid>` | string | Prototype UID for inheritance |
+| `--area <uid>` | string | Parent area UID |
+| `--parent <uid>` | string | Parent UID |
+
+**Generated Frontmatter**:
+- `exo__Asset_isDefinedBy`: `"[[Ontology/EMS]]"`
+- `exo__Asset_uid`: Generated UUID v4
+- `exo__Asset_label`: From `--label`
+- `exo__Asset_createdAt`: ISO timestamp
+- `exo__Instance_class`: `["[[ems__Area]]"]`
+- `aliases`: Array containing label
+
+> **Note**: Areas do NOT have `ems__Effort_status` property (only efforts: tasks, projects, meetings).
+
+**Example**:
+```bash
+exocortex command create-area "areas/product.md" \
+  --label "Product Development" \
+  --vault ~/vault
+```
+
+---
+
+## Property Commands
+
+Commands that modify asset properties.
+
+### rename-to-uid
+
+Renames file to match its `exo__Asset_uid` property value. If label is missing, sets it to the original filename.
+
+```bash
+exocortex command rename-to-uid <filepath> [--vault <path>]
+```
+
+**Side Effects**:
+- Renames file from `<current-name>.md` to `<uid>.md`
+- If `exo__Asset_label` is empty, sets it to original filename
+- If not archived, adds original filename to `aliases`
+
+**Error Conditions**:
+- Exit code `1` if `exo__Asset_uid` property is missing
+
+**Example**:
+```bash
+exocortex command rename-to-uid "tasks/My Task Name.md" --vault ~/vault
+# Result: File renamed to "tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890.md"
+```
+
+---
+
+### update-label
+
+Updates `exo__Asset_label` property and synchronizes aliases array.
+
+```bash
+exocortex command update-label <filepath> --label <value> [--vault <path>] [--dry-run]
+```
+
+**Required Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--label <value>` | string | New label value (required) |
+
+**Side Effects**:
+- Sets `exo__Asset_label` to new value
+- Adds new label to `aliases` array if not already present
+
+**Dry Run Mode**:
+- With `--dry-run`: Shows preview of changes without modifying files
+- Without `--dry-run`: Applies changes to file
+
+**Example**:
+```bash
+# Preview changes
+exocortex command update-label "tasks/task.md" --label "New Label" --dry-run
+
+# Apply changes
+exocortex command update-label "tasks/task.md" --label "New Label" --vault ~/vault
+```
+
+---
+
+## Planning Commands
+
+Commands that set planning dates for efforts.
+
+### schedule
+
+Sets planned start timestamp for an effort (task/project/meeting).
+
+```bash
+exocortex command schedule <filepath> --date <YYYY-MM-DD> [--vault <path>]
+```
+
+**Required Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--date <value>` | string | Date in YYYY-MM-DD format (required) |
+
+**Side Effects**:
+- Sets `ems__Effort_plannedStartTimestamp` to timestamp at start of specified day
+
+**Date Format**:
+- Must be `YYYY-MM-DD` (e.g., `2025-12-02`)
+- Invalid formats result in exit code `1`
+
+**Example**:
+```bash
+exocortex command schedule "tasks/feature.md" --date "2025-12-15" --vault ~/vault
+```
+
+---
+
+### set-deadline
+
+Sets planned end timestamp for an effort (task/project/meeting).
+
+```bash
+exocortex command set-deadline <filepath> --date <YYYY-MM-DD> [--vault <path>]
+```
+
+**Required Options**:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--date <value>` | string | Date in YYYY-MM-DD format (required) |
+
+**Side Effects**:
+- Sets `ems__Effort_plannedEndTimestamp` to timestamp at start of specified day
+
+**Date Format**:
+- Must be `YYYY-MM-DD` (e.g., `2025-12-02`)
+- Invalid formats result in exit code `1`
+
+**Example**:
+```bash
+exocortex command set-deadline "tasks/feature.md" --date "2025-12-31" --vault ~/vault
+```
+
+---
+
+## Exit Codes
+
+All commands use standardized exit codes following Unix conventions:
+
+| Code | Constant | Description |
+|------|----------|-------------|
+| `0` | `SUCCESS` | Command completed successfully |
+| `1` | `GENERAL_ERROR` | General error (catch-all for non-specific errors) |
+| `2` | `INVALID_ARGUMENTS` | Invalid command-line arguments or options |
+| `3` | `FILE_NOT_FOUND` | File or directory not found |
+| `4` | `PERMISSION_DENIED` | Permission denied (file system access) |
+| `5` | `OPERATION_FAILED` | Command execution failed (business logic error) |
+| `6` | `INVALID_STATE_TRANSITION` | Invalid asset state transition (e.g., status change not allowed) |
+| `7` | `TRANSACTION_FAILED` | Transaction failed (atomic operation could not complete) |
+| `8` | `CONCURRENT_MODIFICATION` | Concurrent modification detected (file changed during operation) |
+
+### Usage in Scripts
+
+```bash
+exocortex command start "tasks/task.md" --vault ~/vault
+exit_code=$?
+
+case $exit_code in
+  0) echo "Success" ;;
+  2) echo "Invalid arguments" ;;
+  3) echo "File not found" ;;
+  *) echo "Error: $exit_code" ;;
+esac
+```
+
+---
+
+## Common Options
+
+These options are available for all commands:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--vault <path>` | string | `process.cwd()` | Path to Obsidian vault |
+| `--dry-run` | boolean | `false` | Preview changes without modifying files (supported by some commands) |
+| `--help` | boolean | - | Show help for command |
+| `--version` | boolean | - | Show CLI version |
+
+### Path Resolution
+
+- **Relative paths**: Resolved relative to vault root
+- **Absolute paths**: Used as-is but validated against vault root
+- **Path validation**: Ensures path is within vault boundaries (prevents path traversal)
+
+---
+
+## Stability Guarantees
+
+### Stable (v0.1.x)
+
+The following are considered **stable** and covered by semantic versioning:
+
+1. **Command names** - `sparql query`, `command start`, `command create-task`, etc.
+2. **Argument positions** - First argument is always `<query>` for SPARQL, `<command-name>` then `<filepath>` for commands
+3. **Required options** - `--label` for creation commands, `--date` for planning commands
+4. **Exit codes** - Codes 0-8 as documented above
+5. **Output formats** - `table`, `json`, `csv` for SPARQL queries
+
+### Experimental
+
+The following may change between minor versions:
+
+1. **Output message text** - Console log messages (success/error formatting)
+2. **Additional optional flags** - New non-breaking options may be added
+3. **Performance characteristics** - Query optimization strategies
+
+### Breaking Change Policy
+
+Breaking changes will:
+1. Only occur in major version bumps (v0.x → v1.0)
+2. Be announced at least one minor version in advance
+3. Provide migration guidance in release notes
+
+See [VERSIONING.md](../VERSIONING.md) for complete versioning policy.


### PR DESCRIPTION
## Summary

Establishes formal API stability guarantees for the CLI before MCP integration, as specified in Issue #526.

**Key deliverables:**
- `docs/CLI_API_REFERENCE.md` - Complete command signatures with options, arguments, exit codes, and side effects for all 16 stable commands
- `VERSIONING.md` - Semantic versioning policy defining what constitutes breaking changes, stability tiers (Stable/Experimental/Internal), deprecation policy, and MCP integration guidelines
- `CHANGELOG.md` - Document all implemented commands with Keep a Changelog format
- Updated `README.md` with API Stability section, corrected command examples, and updated roadmap

**Commands documented as stable:**
- SPARQL: `exocortex sparql query`
- Status: `start`, `complete`, `trash`, `archive`, `move-to-backlog`, `move-to-analysis`, `move-to-todo`
- Creation: `create-task`, `create-meeting`, `create-project`, `create-area`
- Properties: `rename-to-uid`, `update-label`, `schedule`, `set-deadline`

**For MCP Integration:**
- Pin to `^0.1.0` for stable API access
- Use exit codes for status (not console messages)
- Use `--format json` for machine-readable output

## Test Plan

- [x] Unit tests pass (2240+ tests)
- [x] Typecheck passes
- [x] Lint passes (only pre-existing warnings)
- [x] Documentation is accurate to implementation

Closes #526