### PR TITLE
fix: Layout overflow with many assets + Edit mode styling consistency

### DIFF
--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2173,3 +2173,232 @@
     font-size: 16px; /* Prevents zoom on iOS */
   }
 }
+
+/* ============================================================================
+   Edit Mode Styling Consistency - Match Reading Mode
+   Issue #547: Edit mode uses larger font and ignores width constraints
+   ============================================================================ */
+
+/*
+ * In Obsidian, Edit mode uses .cm-content (CodeMirror) while Reading mode
+ * uses .markdown-preview-view. These selectors ensure Exocortex layouts
+ * render consistently in both modes.
+ */
+
+/* Base container styling for Edit mode to match Reading mode */
+.cm-content .exocortex-action-buttons-container,
+.cm-content .exocortex-properties-section,
+.cm-content .exocortex-daily-tasks-section,
+.cm-content .exocortex-assets-relations,
+.cm-content .exocortex-area-tree,
+.cm-content .exocortex-relations-wrapper,
+.cm-scroller .exocortex-action-buttons-container,
+.cm-scroller .exocortex-properties-section,
+.cm-scroller .exocortex-daily-tasks-section,
+.cm-scroller .exocortex-assets-relations,
+.cm-scroller .exocortex-area-tree,
+.cm-scroller .exocortex-relations-wrapper {
+  /* Inherit font-size from Reading mode (not CodeMirror's larger default) */
+  font-size: var(--font-text-size, 16px);
+  /* Respect the same line-height as Reading mode */
+  line-height: var(--line-height-normal, 1.5);
+  /* Use normal font weight (CodeMirror sometimes uses monospace defaults) */
+  font-family: var(--font-text);
+}
+
+/* Ensure tables in Edit mode have consistent sizing */
+.cm-content .exocortex-relations-table,
+.cm-content .exocortex-properties-table,
+.cm-content .exocortex-tasks-table,
+.cm-content .exocortex-projects-table,
+.cm-scroller .exocortex-relations-table,
+.cm-scroller .exocortex-properties-table,
+.cm-scroller .exocortex-tasks-table,
+.cm-scroller .exocortex-projects-table {
+  font-size: inherit;
+}
+
+/* Table cell text should match Reading mode */
+.cm-content .exocortex-relations-table th,
+.cm-content .exocortex-relations-table td,
+.cm-content .exocortex-properties-table th,
+.cm-content .exocortex-properties-table td,
+.cm-content .exocortex-tasks-table th,
+.cm-content .exocortex-tasks-table td,
+.cm-content .exocortex-projects-table th,
+.cm-content .exocortex-projects-table td,
+.cm-scroller .exocortex-relations-table th,
+.cm-scroller .exocortex-relations-table td,
+.cm-scroller .exocortex-properties-table th,
+.cm-scroller .exocortex-properties-table td,
+.cm-scroller .exocortex-tasks-table th,
+.cm-scroller .exocortex-tasks-table td,
+.cm-scroller .exocortex-projects-table th,
+.cm-scroller .exocortex-projects-table td {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+/*
+ * Width constraint: Respect "wide line width" setting in Edit mode
+ * Obsidian uses --file-line-width CSS variable for this
+ */
+.cm-content .exocortex-action-buttons-container,
+.cm-content .exocortex-properties-section,
+.cm-content .exocortex-daily-tasks-section,
+.cm-content .exocortex-assets-relations,
+.cm-content .exocortex-area-tree,
+.cm-scroller .exocortex-action-buttons-container,
+.cm-scroller .exocortex-properties-section,
+.cm-scroller .exocortex-daily-tasks-section,
+.cm-scroller .exocortex-assets-relations,
+.cm-scroller .exocortex-area-tree {
+  /* Respect Obsidian's "Readable line length" / "wide line width" setting */
+  max-width: var(--file-line-width, 100%);
+  /* Center the content like in Reading mode */
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Buttons and controls should match Reading mode styling */
+.cm-content .exocortex-action-button,
+.cm-scroller .exocortex-action-button {
+  font-size: 0.875em;
+  font-family: var(--font-text);
+}
+
+/* Toggle buttons in Edit mode */
+.cm-content .exocortex-toggle-effort-votes,
+.cm-content .exocortex-toggle-archived,
+.cm-scroller .exocortex-toggle-effort-votes,
+.cm-scroller .exocortex-toggle-archived {
+  font-size: 12px;
+  font-family: var(--font-text);
+}
+
+/* ============================================================================
+   Large Asset Layouts - Virtualization Container Styles
+   Issue #547: Layout breaks with many assets
+   ============================================================================ */
+
+/* Virtualized relations table container */
+.exocortex-relations-virtualized {
+  width: 100%;
+  position: relative;
+}
+
+/* Sticky header for virtualized table */
+.exocortex-relations-table-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--background-primary);
+}
+
+/* Virtual scroll container with proper overflow handling */
+.exocortex-virtual-scroll-container {
+  width: 100%;
+  max-height: 400px;
+  overflow: auto;
+  border: 1px solid var(--background-modifier-border);
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+}
+
+/* Inner virtual table positioning */
+.exocortex-virtual-table {
+  position: relative;
+  width: 100%;
+}
+
+/* Ensure table body can handle absolute positioning */
+.exocortex-virtual-table tbody {
+  position: relative;
+}
+
+/* Grouped relations container - prevent horizontal overflow */
+.exocortex-relations-grouped {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* Relations wrapper - handle overflow gracefully */
+.exocortex-relations-wrapper {
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+/* Controls row should not cause horizontal scrolling */
+.exocortex-relations-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+/* Asset Relations section - proper container behavior */
+.exocortex-assets-relations {
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+/* Table overflow handling for very wide tables */
+.exocortex-relations-table {
+  min-width: 100%;
+  table-layout: auto;
+}
+
+/* Prevent cell content from causing overflow */
+.exocortex-relations-table td,
+.exocortex-relations-table th {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Allow first column (Name) to be wider */
+.exocortex-relations-table td.asset-name,
+.exocortex-relations-table th:first-child {
+  max-width: 400px;
+}
+
+/* Responsive adjustments for virtualized tables */
+@media (max-width: 768px) {
+  .exocortex-virtual-scroll-container {
+    max-height: 300px;
+  }
+
+  .exocortex-relations-table td,
+  .exocortex-relations-table th {
+    max-width: 200px;
+    font-size: 0.9em;
+    padding: 6px 8px;
+  }
+
+  .exocortex-relations-table td.asset-name,
+  .exocortex-relations-table th:first-child {
+    max-width: 250px;
+  }
+}
+
+/* High contrast mode for virtualized containers */
+@media (prefers-contrast: high) {
+  .exocortex-virtual-scroll-container {
+    border-width: 2px;
+  }
+
+  .exocortex-relations-table-header {
+    border-bottom: 2px solid var(--background-modifier-border);
+  }
+}
+
+/* Reduced motion - no animations for scroll */
+@media (prefers-reduced-motion: reduce) {
+  .exocortex-virtual-scroll-container {
+    scroll-behavior: auto;
+  }
+}

--- a/packages/obsidian-plugin/tests/e2e/specs/layout-overflow-styling.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/layout-overflow-styling.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect } from "@playwright/test";
+import { ObsidianLauncher } from "../utils/obsidian-launcher";
+import * as path from "path";
+
+/**
+ * E2E Tests for Issue #547: Layout overflow and Edit mode styling consistency
+ *
+ * Tests verify:
+ * 1. Layout handles assets without horizontal overflow
+ * 2. Edit mode styling matches Reading mode
+ * 3. Tables respect container width constraints
+ */
+test.describe("Layout Overflow and Styling Consistency", () => {
+  let launcher: ObsidianLauncher;
+  let vaultPath: string;
+
+  test.beforeEach(async () => {
+    vaultPath = path.join(__dirname, "../test-vault");
+    launcher = new ObsidianLauncher(vaultPath);
+    await launcher.launch();
+  });
+
+  test.afterEach(async () => {
+    await launcher.close();
+  });
+
+  test("should not have horizontal overflow in asset relations section", async () => {
+    // Open a task that has relations
+    await launcher.openFile("Tasks/vote-scroll-test-task.md");
+
+    const window = await launcher.getWindow();
+    await launcher.waitForModalsToClose(10000);
+
+    // Wait for the layout to render
+    await launcher.waitForElement(".exocortex-buttons-section", 30000);
+
+    // Check if asset relations section exists
+    const relationsSection = window.locator(".exocortex-assets-relations");
+    const relationsVisible = await relationsSection
+      .isVisible({ timeout: 5000 })
+      .catch(() => false);
+
+    if (relationsVisible) {
+      // Check that the section doesn't cause horizontal scrolling
+      const overflowInfo = await relationsSection.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        const parent = el.parentElement;
+        return {
+          sectionWidth: el.scrollWidth,
+          sectionClientWidth: el.clientWidth,
+          parentWidth: parent?.clientWidth || 0,
+          overflow: style.overflow,
+          overflowX: style.overflowX,
+          hasHorizontalScroll: el.scrollWidth > el.clientWidth,
+        };
+      });
+
+      // Section should not overflow its container
+      expect(overflowInfo.hasHorizontalScroll).toBe(false);
+    }
+  });
+
+  test("should have consistent font sizes in Exocortex containers", async () => {
+    await launcher.openFile("Tasks/vote-scroll-test-task.md");
+
+    const window = await launcher.getWindow();
+    await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-buttons-section", 30000);
+
+    // Check font sizes in different Exocortex sections
+    const sections = [
+      ".exocortex-action-buttons-container",
+      ".exocortex-properties-section",
+      ".exocortex-assets-relations",
+    ];
+
+    const fontSizes: number[] = [];
+
+    for (const selector of sections) {
+      const section = window.locator(selector);
+      const isVisible = await section.isVisible({ timeout: 3000 }).catch(() => false);
+
+      if (isVisible) {
+        const fontSize = await section.evaluate((el) => {
+          const computed = window.getComputedStyle(el);
+          return parseFloat(computed.fontSize);
+        });
+
+        fontSizes.push(fontSize);
+      }
+    }
+
+    if (fontSizes.length > 1) {
+      // All visible sections should have similar font sizes (within 4px tolerance)
+      const avgFontSize = fontSizes.reduce((a, b) => a + b, 0) / fontSizes.length;
+
+      for (const fontSize of fontSizes) {
+        expect(Math.abs(fontSize - avgFontSize)).toBeLessThanOrEqual(4);
+      }
+    }
+  });
+
+  test("should have tables that fit within container width", async () => {
+    await launcher.openFile("Tasks/vote-scroll-test-task.md");
+
+    const window = await launcher.getWindow();
+    await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-buttons-section", 30000);
+
+    // Check all Exocortex tables
+    const tables = window.locator(
+      ".exocortex-relations-table, .exocortex-properties-table, .exocortex-tasks-table, .exocortex-projects-table"
+    );
+    const tableCount = await tables.count();
+
+    for (let i = 0; i < tableCount; i++) {
+      const table = tables.nth(i);
+      const isVisible = await table.isVisible().catch(() => false);
+
+      if (isVisible) {
+        const tableInfo = await table.evaluate((el) => {
+          const tableRect = el.getBoundingClientRect();
+          const parent = el.closest(".exocortex-section-content") ||
+                        el.closest(".relation-group-content") ||
+                        el.parentElement;
+
+          const parentRect = parent?.getBoundingClientRect();
+
+          return {
+            tableWidth: tableRect.width,
+            parentWidth: parentRect?.width || 0,
+            tableOverflow: el.scrollWidth > el.clientWidth,
+          };
+        });
+
+        // Table should not overflow its parent container significantly
+        if (tableInfo.parentWidth > 0) {
+          expect(tableInfo.tableWidth).toBeLessThanOrEqual(tableInfo.parentWidth + 50);
+        }
+      }
+    }
+  });
+
+  test("should render controls row without causing horizontal scroll", async () => {
+    await launcher.openFile("Tasks/vote-scroll-test-task.md");
+
+    const window = await launcher.getWindow();
+    await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-buttons-section", 30000);
+
+    // Check if relations controls exist
+    const controls = window.locator(".exocortex-relations-controls");
+    const controlsVisible = await controls.isVisible({ timeout: 3000 }).catch(() => false);
+
+    if (controlsVisible) {
+      const controlsInfo = await controls.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        return {
+          display: style.display,
+          flexWrap: style.flexWrap,
+          hasOverflow: el.scrollWidth > el.clientWidth,
+        };
+      });
+
+      // Controls should use flexbox with wrap
+      expect(controlsInfo.display).toBe("flex");
+      expect(controlsInfo.flexWrap).toBe("wrap");
+      expect(controlsInfo.hasOverflow).toBe(false);
+    }
+  });
+
+  test("should apply text ellipsis to long cell content", async () => {
+    await launcher.openFile("Tasks/vote-scroll-test-task.md");
+
+    const window = await launcher.getWindow();
+    await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-buttons-section", 30000);
+
+    // Check table cells for overflow handling
+    const cells = window.locator(".exocortex-relations-table td");
+    const cellCount = await cells.count();
+
+    if (cellCount > 0) {
+      const firstCell = cells.first();
+      const cellStyle = await firstCell.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        return {
+          overflow: style.overflow,
+          textOverflow: style.textOverflow,
+          whiteSpace: style.whiteSpace,
+          maxWidth: style.maxWidth,
+        };
+      });
+
+      // Cells should have overflow handling
+      expect(cellStyle.overflow).toBe("hidden");
+      expect(cellStyle.textOverflow).toBe("ellipsis");
+      expect(cellStyle.whiteSpace).toBe("nowrap");
+    }
+  });
+
+  test("should have virtualization container with proper styling when many assets", async () => {
+    await launcher.openFile("Tasks/vote-scroll-test-task.md");
+
+    const window = await launcher.getWindow();
+    await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-buttons-section", 30000);
+
+    // Check for virtualized container (appears when >50 items)
+    const virtualContainer = window.locator(".exocortex-virtual-scroll-container");
+    const hasVirtualization = await virtualContainer.isVisible({ timeout: 3000 }).catch(() => false);
+
+    if (hasVirtualization) {
+      const containerStyle = await virtualContainer.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        return {
+          maxHeight: style.maxHeight,
+          overflow: style.overflow,
+          width: style.width,
+        };
+      });
+
+      // Virtualized container should have proper constraints
+      expect(containerStyle.maxHeight).not.toBe("none");
+      expect(containerStyle.overflow).toContain("auto");
+    }
+  });
+
+  test("should respect width constraints for layout sections", async () => {
+    await launcher.openFile("Tasks/vote-scroll-test-task.md");
+
+    const window = await launcher.getWindow();
+    await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-buttons-section", 30000);
+
+    // Get viewport width
+    const viewportWidth = await window.evaluate(() => window.innerWidth);
+
+    // Check main layout sections
+    const sections = [
+      ".exocortex-action-buttons-container",
+      ".exocortex-properties-section",
+      ".exocortex-daily-tasks-section",
+      ".exocortex-assets-relations",
+    ];
+
+    for (const selector of sections) {
+      const section = window.locator(selector);
+      const isVisible = await section.isVisible({ timeout: 3000 }).catch(() => false);
+
+      if (isVisible) {
+        const sectionBox = await section.boundingBox();
+
+        if (sectionBox) {
+          // Section should not extend beyond viewport
+          expect(sectionBox.width).toBeLessThanOrEqual(viewportWidth);
+          // Section should have reasonable width (not collapsed to 0)
+          expect(sectionBox.width).toBeGreaterThan(100);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #547

### Issue 1: Layout breaks with many assets
- Added CSS for virtualized table containers (`.exocortex-relations-virtualized`, `.exocortex-virtual-scroll-container`)
- Added sticky header for virtualized tables (`.exocortex-relations-table-header`)
- Added text-overflow ellipsis for long cell content to prevent horizontal overflow
- Added proper overflow handling for grouped relations (`.exocortex-relations-grouped`)
- Added responsive adjustments for mobile viewports

### Issue 2: Edit mode styling inconsistent with Reading mode
- Added CSS rules for `.cm-content` (Edit mode) to match `.markdown-preview-view` (Reading mode)
- Uses Obsidian CSS variables (`--font-text-size`, `--font-text`, `--line-height-normal`)
- Respects `--file-line-width` for "Readable line length" / "wide line width" setting
- Applied consistent font-size and line-height across Edit and Reading modes
- Centered layout content like in Reading mode

## Technical Details

### CSS Changes (styles.css +265 lines)
1. **Edit Mode Consistency** (lines 2177-2277):
   - `.cm-content .exocortex-*` selectors match `.markdown-preview-view` styling
   - Inherits `var(--font-text-size)` and `var(--font-text)` from Obsidian
   - Applies `max-width: var(--file-line-width)` to respect user's readable line width setting

2. **Virtualization Container** (lines 2279-2404):
   - `.exocortex-virtual-scroll-container` with max-height: 400px and overflow: auto
   - Sticky header for smooth scrolling with header visible
   - Cell overflow handling with text-ellipsis
   - High contrast and reduced motion accessibility support

### E2E Tests Added
- `layout-overflow-styling.spec.ts` with 7 test cases:
  - Horizontal overflow prevention
  - Font size consistency
  - Table width constraints
  - Control row layout
  - Text ellipsis for long content
  - Virtualization container styling
  - Width constraints respect

## Test Plan
- [x] Unit tests pass (2008 tests)
- [x] Lint passes (only pre-existing warnings)
- [x] TypeScript type check passes
- [ ] E2E tests (require manual Obsidian testing or CI)
- [ ] Manual verification in Obsidian with Edit/Reading mode toggle