### PR TITLE
fix(release): update root manifest.json for BRAT compatibility

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -143,7 +143,15 @@ jobs:
             fs.writeFileSync('packages/obsidian-plugin/manifest.json', JSON.stringify(manifest, null, 2) + '\n');
           "
 
-          echo "Updated package.json and manifest.json to version $NEW_VERSION"
+          # Update root manifest.json (required for BRAT to detect releases)
+          node -e "
+            const fs = require('fs');
+            const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
+            manifest.version = '$NEW_VERSION';
+            fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n');
+          "
+
+          echo "Updated package.json and manifest.json files to version $NEW_VERSION"
 
       - name: Install dependencies
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
@@ -192,12 +200,20 @@ jobs:
           echo "Generated changelog:"
           cat release_notes.md
 
-      - name: Create git tag
+      - name: Commit version updates
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
         run: |
           NEW_VERSION="${{ steps.new_version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json manifest.json packages/obsidian-plugin/manifest.json
+          git commit -m "chore(release): bump version to $NEW_VERSION [skip ci]"
+          git push origin main
+
+      - name: Create git tag
+        if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
+        run: |
+          NEW_VERSION="${{ steps.new_version.outputs.version }}"
           git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
           git push origin "v$NEW_VERSION"
 
@@ -218,6 +234,6 @@ jobs:
       - name: Summary
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
         run: |
-          echo "✅ Release v${{ steps.new_version.outputs.version }} created successfully"
+          echo "✅ Release v${{ steps.new_version.outputs.version }} created successfully!"
           echo "📦 Tag: v${{ steps.new_version.outputs.version }}"
           echo "📝 Changelog generated from commits"


### PR DESCRIPTION
## Summary

Fixes BRAT installation issue where plugin couldn't be installed because BRAT couldn't detect releases.

**Root cause**: BRAT checks the `manifest.json` in the repository root to detect available releases. The auto-release workflow was only updating `packages/obsidian-plugin/manifest.json` but not the root `manifest.json`, causing BRAT to see version `0.0.0-dev` and report:
> The release is not complete and cannot be downloaded. main.js is missing from the Release

**Changes**:
- Update root `manifest.json` with version during release (in addition to `packages/obsidian-plugin/manifest.json`)
- Commit and push version updates to repository before creating git tag
- Use `[skip ci]` in commit message to prevent infinite CI loops

## Test plan

- [ ] Verify CI passes (workflow file YAML syntax already validated locally)
- [ ] After merge, verify next release updates root `manifest.json` in repo
- [ ] Test BRAT installation with new release

Closes #553