### PR TITLE
fix: table renders empty when layout contains many assets

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from "react";
+import React, { useMemo, useRef, useState, useLayoutEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { MetadataHelpers, EffortSortingHelpers } from "@exocortex/core";
 import { useTableSortStore, useUIStore } from "../stores";
@@ -262,17 +262,25 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   const VIRTUALIZATION_THRESHOLD = 50;
   const parentRef = useRef<HTMLDivElement>(null);
 
+  // Track when parent element is mounted for virtualizer initialization
+  const [isParentMounted, setIsParentMounted] = useState(false);
+
+  useLayoutEffect(() => {
+    if (parentRef.current && !isParentMounted) {
+      setIsParentMounted(true);
+    }
+  }, [isParentMounted]);
+
   const shouldVirtualize = displayedTasks.length > VIRTUALIZATION_THRESHOLD;
 
-  // Only initialize virtualizer when we need virtualization
-  // This prevents issues with empty virtual items on first render
+  // Only initialize virtualizer when we need virtualization AND parent is mounted
   const rowVirtualizer = useVirtualizer({
     count: shouldVirtualize ? displayedTasks.length : 0,
     getScrollElement: () => parentRef.current,
     estimateSize: () => ROW_HEIGHT,
     overscan: 5,
     // Enable smooth scrolling and ensure proper initialization
-    enabled: shouldVirtualize,
+    enabled: shouldVirtualize && isParentMounted,
   });
 
   const renderRow = (task: DailyTask, index: number, style?: React.CSSProperties) => {
@@ -467,7 +475,13 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
 
   // Get virtual items - may be empty on first render if parentRef is not yet set
   const virtualItems = rowVirtualizer.getVirtualItems();
-  const totalSize = rowVirtualizer.getTotalSize();
+  const virtualizerTotalSize = rowVirtualizer.getTotalSize();
+
+  // Calculate fallback height when virtualizer hasn't initialized yet
+  // This ensures content is visible even before the parent ref is mounted
+  const totalSize = virtualizerTotalSize > 0
+    ? virtualizerTotalSize
+    : displayedTasks.length * ROW_HEIGHT;
 
   return (
     <div className="exocortex-daily-tasks exocortex-virtualized">


### PR DESCRIPTION
## Summary

Fixes the bug where tables render empty when the layout contains many assets (>50 items, triggering virtualization).

### Root Cause

When `useVirtualizer` is initialized, `parentRef.current` is `null` on the first render because the DOM element hasn't been mounted yet. This causes:
1. `getVirtualItems()` to return an empty array
2. `getTotalSize()` to return 0
3. The wrapper div to have `height: 0px`, making all content invisible

### Solution

1. **Track parent mount state**: Added `useLayoutEffect` with `isParentMounted` state to track when the scroll container ref is available
2. **Conditional virtualizer enable**: Only enable virtualizer when `shouldVirtualize && isParentMounted`
3. **Fallback height calculation**: When `getTotalSize()` returns 0, calculate fallback height as `itemCount * ROW_HEIGHT`

### Changes

- `AssetRelationsTable.tsx`: Fix virtualization initialization
- `DailyTasksTable.tsx`: Apply same fix for consistency
- `DailyProjectsTable.tsx`: Apply same fix for consistency
- `AssetRelationsTable.spec.tsx`: Add 5 comprehensive virtualization tests

### Test Plan

- [x] Unit tests pass
- [x] Build succeeds
- [x] New virtualization tests pass:
  - Table with 51 items (threshold+1, virtualization active) 
  - Table with 100 items (large dataset)
  - Table with 50 items (at threshold, no virtualization)
  - Scroll behavior with virtualized table
  - Sorting with virtualized table
- [ ] CI pipeline green

Closes #549