### PR TITLE
fix(ci): skip pre-commit hooks in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -207,7 +207,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json manifest.json packages/obsidian-plugin/manifest.json
-          git commit -m "chore(release): bump version to $NEW_VERSION [skip ci]"
+          # Skip pre-commit hooks - tests already passed in CI workflow that triggered this release
+          git commit --no-verify -m "chore(release): bump version to $NEW_VERSION [skip ci]"
           git push origin main
 
       - name: Create git tag


### PR DESCRIPTION
## Summary
- Fixed auto-release workflow failing due to missing Playwright browsers
- Added `--no-verify` flag to git commit to skip pre-commit hooks in CI
- Tests already pass in CI workflow before auto-release runs, so no need to re-run them

## Root Cause
The auto-release workflow runs on `ubuntu-latest` which doesn't have Playwright browsers installed. The pre-commit hook in `.husky/pre-commit` runs `npm test`, which includes component tests that require Playwright browsers.

## Fix
Skip pre-commit hooks when committing version updates in auto-release workflow since:
1. CI workflow already ran all tests before triggering auto-release
2. The only change being committed is version bump in package.json/manifest.json

Fixes: https://github.com/kitelev/exocortex-obsidian-plugin/actions/runs/19893760611