### PR TITLE
fix: remove 50-item hard limit from DailyNote Tasks and Projects blocks

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/DailyProjectsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyProjectsRenderer.ts
@@ -243,7 +243,7 @@ export class DailyProjectsRenderer {
 
       projects.sort((a, b) => EffortSortingHelpers.sortByPriority(a, b));
 
-      return projects.slice(0, 50);
+      return projects;
     } catch (error) {
       this.logger.error("Failed to get daily projects", { error });
       return [];

--- a/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
@@ -288,7 +288,7 @@ export class DailyTasksRenderer {
 
       filteredTasks.sort((a, b) => EffortSortingHelpers.sortByPriority(a, b));
 
-      return filteredTasks.slice(0, 50);
+      return filteredTasks;
     } catch (error) {
       this.logger.error("Failed to get daily tasks", { error });
       return [];

--- a/packages/obsidian-plugin/tests/unit/DailyProjectsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/DailyProjectsRenderer.test.ts
@@ -319,7 +319,7 @@ describe("DailyProjectsRenderer", () => {
       );
     });
 
-    it("should limit results to 50 projects", async () => {
+    it("should return all projects without artificial limit", async () => {
       const mockFile = {
         path: "test.md",
         parent: { path: "DailyNotes" },
@@ -366,7 +366,9 @@ describe("DailyProjectsRenderer", () => {
       expect(mockReactRenderer.render).toHaveBeenCalled();
       const renderCall = mockReactRenderer.render.mock.calls[0];
       const projects = renderCall[1].props.projects;
-      expect(projects.length).toBe(50);
+      // No artificial limit - all 60 projects should be returned
+      // UI component handles virtualization for large lists
+      expect(projects.length).toBe(60);
     });
 
     it("should handle error gracefully", async () => {

--- a/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.render.test.ts
+++ b/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.render.test.ts
@@ -461,7 +461,7 @@ describe("DailyTasksRenderer - render", () => {
     expect(tasks[0].isBlocked).toBe(false);
   });
 
-  it("should limit results to 50 tasks", async () => {
+  it("should return all tasks without artificial limit", async () => {
     const mockFile = {
       path: "test.md",
       parent: { path: "DailyNotes" },
@@ -508,7 +508,9 @@ describe("DailyTasksRenderer - render", () => {
     expect(ctx.mockReactRenderer.render).toHaveBeenCalled();
     const renderCall = ctx.mockReactRenderer.render.mock.calls[0];
     const tasks = renderCall[1].props.tasks;
-    expect(tasks.length).toBe(50);
+    // No artificial limit - all 60 tasks should be returned
+    // UI component handles virtualization for large lists
+    expect(tasks.length).toBe(60);
   });
 
   it("should handle error gracefully", async () => {


### PR DESCRIPTION
## Summary

Removes the hard-coded limit of 50 items from `DailyTasksRenderer` and `DailyProjectsRenderer` that prevented archived tasks/projects from being displayed even when "Show Archived" was enabled.

## Root Cause

The `slice(0, 50)` was applied **after** filtering and sorting by priority, so when there were 50+ high-priority non-archived items, archived items never reached the UI component - they were simply cut off.

## Solution

Removed the limit entirely. The UI components already have virtualization (via `@tanstack/react-virtual`) that efficiently handles large lists (virtualizes at 50+ items), so there's no performance concern.

## Files Changed

- `DailyTasksRenderer.ts:291` - Removed `.slice(0, 50)`
- `DailyProjectsRenderer.ts:246` - Removed `.slice(0, 50)`
- Updated corresponding tests to verify all items are returned

## Test Plan

- [x] Unit tests pass (updated tests to verify no limit)
- [x] Component tests pass (366 tests)
- [x] Build succeeds

Closes #563