### PR TITLE
fix(ci): fix auto-release failing due to branch protection

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -200,21 +200,16 @@ jobs:
           echo "Generated changelog:"
           cat release_notes.md
 
-      - name: Commit version updates
+      - name: Create git tag with version updates
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
         run: |
           NEW_VERSION="${{ steps.new_version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Commit version updates locally (not pushed to main due to branch protection)
           git add package.json manifest.json packages/obsidian-plugin/manifest.json
-          # Skip pre-commit hooks - tests already passed in CI workflow that triggered this release
-          git commit --no-verify -m "chore(release): bump version to $NEW_VERSION [skip ci]"
-          git push origin main
-
-      - name: Create git tag
-        if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
-        run: |
-          NEW_VERSION="${{ steps.new_version.outputs.version }}"
+          git commit --no-verify -m "chore(release): bump version to $NEW_VERSION"
+          # Create and push only the tag (tags bypass branch protection)
           git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
           git push origin "v$NEW_VERSION"
 


### PR DESCRIPTION
## Summary

- Auto-release workflow was failing at "Commit version updates" step
- Root cause: Branch protection rules (`enforce_admins: true` + required status checks) prevent direct pushes to main
- Solution: Create tag with version bump commit locally without pushing to main branch

## Technical Details

The workflow was trying to `git push origin main` which fails because:
1. `enforce_admins: true` - rules apply even to GitHub Actions bot
2. `required_status_checks` - pushes require CI to pass first

Tags can still be pushed since they bypass branch protection rules. The manifest.json in the release will have the correct version since it's updated before building.

## Test plan

- [ ] Merge this PR
- [ ] Check that next auto-release workflow run succeeds
- [ ] Verify release has correct version in manifest.json