### PR TITLE
fix(ci): use PAT for pushing to protected main branch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Get last release tag
         id: last_tag


### PR DESCRIPTION
## Summary

- Auto-release workflow failing at "Commit version updates" step since PR #555
- Root cause: Branch protection (`enforce_admins: true`) prevents `GITHUB_TOKEN` from pushing to main
- Solution: Use `RELEASE_PAT` secret for checkout to enable push with proper permissions

## Technical Details

The workflow needs to push version bump commits to main branch. `GITHUB_TOKEN` cannot bypass branch protection rules by design.

Using a PAT (Personal Access Token) during `actions/checkout` configures git to use that token for all operations, including push.

## Setup Required

After merging, create and add the PAT:

1. **Create PAT:** https://github.com/settings/tokens → Generate new token (classic)
   - Scope: `repo` (full control)
   - Note: "exocortex auto-release"

2. **Add secret:** Repository Settings → Secrets → Actions → New repository secret
   - Name: `RELEASE_PAT`
   - Value: the generated token

3. **Verify permissions:** Ensure the token owner is listed in branch protection "Restrict who can push to matching branches" or has admin access

## Alternative: Disable enforce_admins

If you don't want to use a PAT, you can disable `enforce_admins` in branch protection settings. This will allow GitHub Actions bot to push directly.

## Test plan

- [ ] Merge this PR
- [ ] Add `RELEASE_PAT` secret
- [ ] Trigger a new commit to main
- [ ] Verify auto-release workflow succeeds