### PR TITLE
revert(ci): remove broken BRAT compatibility changes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -143,15 +143,7 @@ jobs:
             fs.writeFileSync('packages/obsidian-plugin/manifest.json', JSON.stringify(manifest, null, 2) + '\n');
           "
 
-          # Update root manifest.json (required for BRAT to detect releases)
-          node -e "
-            const fs = require('fs');
-            const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
-            manifest.version = '$NEW_VERSION';
-            fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n');
-          "
-
-          echo "Updated package.json and manifest.json files to version $NEW_VERSION"
+          echo "Updated package.json and manifest.json to version $NEW_VERSION"
 
       - name: Install dependencies
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
@@ -200,21 +192,12 @@ jobs:
           echo "Generated changelog:"
           cat release_notes.md
 
-      - name: Commit version updates
+      - name: Create git tag
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
         run: |
           NEW_VERSION="${{ steps.new_version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json manifest.json packages/obsidian-plugin/manifest.json
-          # Skip pre-commit hooks - tests already passed in CI workflow that triggered this release
-          git commit --no-verify -m "chore(release): bump version to $NEW_VERSION [skip ci]"
-          git push origin main
-
-      - name: Create git tag
-        if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
-        run: |
-          NEW_VERSION="${{ steps.new_version.outputs.version }}"
           git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
           git push origin "v$NEW_VERSION"
 
@@ -235,7 +218,6 @@ jobs:
       - name: Summary
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
         run: |
-          echo "✅ Release v${{ steps.new_version.outputs.version }} created successfully!"
+          echo "✅ Release v${{ steps.new_version.outputs.version }} created successfully"
           echo "📦 Tag: v${{ steps.new_version.outputs.version }}"
           echo "📝 Changelog generated from commits"
-


### PR DESCRIPTION
## Summary

- Reverts changes from PR #555 and #558 that added version commit push to main
- Returns workflow to the working state from 2 weeks ago (before Dec 3)

## What was removed

1. **"Commit version updates" step** - pushed version bump to main, failed due to branch protection
2. **Root manifest.json update** - BRAT compatibility workaround that required the push
3. **--no-verify flag** - no longer needed without commit step

## Why it broke

Branch protection rules (`enforce_admins: true` + required status checks) prevent `GITHUB_TOKEN` from pushing directly to main.

## Test plan

- [ ] Merge this PR
- [ ] Verify next CI run triggers Auto Release workflow
- [ ] Confirm release is created successfully with correct version