### PR TITLE
fix: display human-readable status labels in Tasks table

### DIFF
--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
@@ -189,3 +189,40 @@ export function getPropertyByName(
   const schema = getPropertySchemaForClass(instanceClass);
   return schema.find((prop) => prop.name === propertyName);
 }
+
+/**
+ * Converts an effort status URI to a human-readable label.
+ * Handles various input formats: raw URI, wiki-link wrapped, or already a label.
+ *
+ * @param statusValue - The status value (e.g., "ems__EffortStatusDoing", "[[ems__EffortStatusDoing]]", "Doing")
+ * @returns The human-readable label (e.g., "Doing") or the original value if not found
+ */
+export function getStatusLabel(statusValue: string | null | undefined): string {
+  if (!statusValue) return "-";
+
+  const statusStr = String(statusValue);
+
+  // Try to find a matching status value in the list
+  for (const status of EFFORT_STATUS_VALUES) {
+    // Match against full wiki-link format: [[ems__EffortStatusDoing]]
+    if (status.value === statusStr) {
+      return status.label;
+    }
+    // Match against wiki-link wrapped: [[ems__EffortStatusDoing]]
+    if (status.value === `[[${statusStr}]]`) {
+      return status.label;
+    }
+    // Match against raw URI: ems__EffortStatusDoing
+    const rawUri = status.value.replace(/^\[\[|\]\]$/g, "");
+    if (rawUri === statusStr) {
+      return status.label;
+    }
+    // Match against label itself (already human-readable)
+    if (status.label.toLowerCase() === statusStr.toLowerCase()) {
+      return status.label;
+    }
+  }
+
+  // If no match found, return the original value (might be a custom status)
+  return statusStr;
+}

--- a/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
@@ -13,6 +13,7 @@ import { EffortSortingHelpers } from "@exocortex/core";
 import { AssetMetadataService } from "./layout/helpers/AssetMetadataService";
 import { DailyNoteHelpers } from "./helpers/DailyNoteHelpers";
 import { BlockerHelpers } from "../utils/BlockerHelpers";
+import { getStatusLabel } from "../../domain/property-editor/PropertySchemas";
 
 type ObsidianApp = any;
 
@@ -248,7 +249,7 @@ export class DailyTasksRenderer {
           endTime,
           startTimestamp: startTimestamp || plannedStartTimestamp || null,
           endTimestamp: endTimestamp || plannedEndTimestamp || null,
-          status: effortStatusStr,
+          status: getStatusLabel(effortStatusStr),
           metadata,
           isDone,
           isTrashed,

--- a/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
@@ -5,6 +5,7 @@ import {
   getPropertySchemaForClass,
   getEditableProperties,
   getPropertyByName,
+  getStatusLabel,
   type PropertySchemaDefinition,
 } from "../../../src/domain/property-editor/PropertySchemas";
 
@@ -307,6 +308,50 @@ describe("PropertySchemas", () => {
       const votesProperty = getPropertyByName("ems__Task", "ems__Effort_votes");
       expect(votesProperty?.type).toBe("number");
       expect(votesProperty?.min).toBe(0);
+    });
+  });
+
+  describe("getStatusLabel", () => {
+    it("should return human-readable label for raw URI", () => {
+      expect(getStatusLabel("ems__EffortStatusDoing")).toBe("Doing");
+      expect(getStatusLabel("ems__EffortStatusDone")).toBe("Done");
+      expect(getStatusLabel("ems__EffortStatusTrashed")).toBe("Trashed");
+      expect(getStatusLabel("ems__EffortStatusDraft")).toBe("Draft");
+      expect(getStatusLabel("ems__EffortStatusBacklog")).toBe("Backlog");
+      expect(getStatusLabel("ems__EffortStatusAnalysis")).toBe("Analysis");
+      expect(getStatusLabel("ems__EffortStatusToDo")).toBe("To Do");
+    });
+
+    it("should return human-readable label for wiki-link wrapped URI", () => {
+      expect(getStatusLabel("[[ems__EffortStatusDoing]]")).toBe("Doing");
+      expect(getStatusLabel("[[ems__EffortStatusDone]]")).toBe("Done");
+      expect(getStatusLabel("[[ems__EffortStatusToDo]]")).toBe("To Do");
+    });
+
+    it("should return the label as-is if already human-readable", () => {
+      expect(getStatusLabel("Doing")).toBe("Doing");
+      expect(getStatusLabel("Done")).toBe("Done");
+      expect(getStatusLabel("To Do")).toBe("To Do");
+    });
+
+    it("should handle case-insensitive label matching", () => {
+      expect(getStatusLabel("doing")).toBe("Doing");
+      expect(getStatusLabel("DONE")).toBe("Done");
+      expect(getStatusLabel("to do")).toBe("To Do");
+    });
+
+    it("should return dash for null or undefined", () => {
+      expect(getStatusLabel(null)).toBe("-");
+      expect(getStatusLabel(undefined)).toBe("-");
+    });
+
+    it("should return dash for empty string", () => {
+      expect(getStatusLabel("")).toBe("-");
+    });
+
+    it("should return original value for unknown status", () => {
+      expect(getStatusLabel("unknown_status")).toBe("unknown_status");
+      expect(getStatusLabel("CustomStatus")).toBe("CustomStatus");
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the remaining issue from #571 where the Status column was showing raw URIs (`ems__EffortStatusDoing`) instead of user-friendly labels (`Doing`).

## Changes

- **Add `getStatusLabel()` function** to `PropertySchemas.ts` to convert status URIs to human-readable labels
- **Update `DailyTasksRenderer`** to use the new function when setting task status
- **Add 7 unit tests** for the `getStatusLabel` function covering various input formats

## Technical Details

The `getStatusLabel()` function handles multiple input formats:
- Raw URIs: `ems__EffortStatusDoing` → `Doing`
- Wiki-links: `[[ems__EffortStatusDone]]` → `Done`
- Already readable: `doing` → `Doing` (case-insensitive)
- Unknown statuses: returned as-is for custom statuses
- Empty/null values: return `-`

## Test plan

- [x] Unit tests pass (2024 passed, 9 skipped)
- [x] Component tests pass (366 passed)
- [x] TypeScript build succeeds
- [x] ESLint passes (warnings only, no errors)
- [ ] Visual verification in Obsidian:
  - Status column shows readable labels (Draft, Backlog, To Do, Doing, Done, Trashed)
  - No truncated URIs visible in Status column

Closes #571