### PR TITLE
fix: serialize JavaScript Date objects as ISO 8601 xsd:dateTime

### DIFF
--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -181,6 +181,11 @@ export class NoteToRDFConverter {
       );
     }
 
+    // Handle Date objects (js-yaml auto-parses ISO 8601 strings to Date)
+    if (value instanceof Date) {
+      return new Literal(value.toISOString(), Namespace.XSD.term("dateTime"));
+    }
+
     return new Literal(String(value));
   }
 


### PR DESCRIPTION
## Summary
- Fix Date object serialization in NoteToRDFConverter
- `js-yaml` automatically parses ISO 8601 strings as JavaScript Date objects
- These were being serialized as JavaScript Date strings (`"Mon Nov 03 2025..."`)
- Now properly serialize back to ISO 8601 format with `xsd:dateTime` datatype

## Problem
PR #575 added `xsd:dateTime` support, but the fix only worked for string values. When `js-yaml` parses frontmatter, it converts ISO 8601 strings to JavaScript `Date` objects. The converter was then calling `String(date)` which produces JavaScript Date format, not ISO 8601.

Example:
- **Input file:** `ems__Effort_startTimestamp: 2025-11-03T10:39:54`
- **After js-yaml parse:** `Date` object
- **Previous output:** `"Mon Nov 03 2025 15:39:54 GMT+0500"`
- **New output:** `"2025-11-03T10:39:54.000Z"^^xsd:dateTime`

## Test plan
- [x] Added unit test for Date object serialization
- [x] All existing tests pass