### PR TITLE
fix(cli): read version from package.json instead of hardcoded 0.1.0

### DIFF
--- a/packages/cli/esbuild.config.mjs
+++ b/packages/cli/esbuild.config.mjs
@@ -57,6 +57,7 @@ await esbuild.build({
   ],
   define: {
     "process.env.NODE_ENV": prod ? '"production"' : '"development"',
+    "__CLI_VERSION__": JSON.stringify(packageJson.version),
   },
   logLevel: "info",
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,12 +7,15 @@ import { commandCommand } from "./commands/command.js";
 import { watchCommand } from "./commands/watch.js";
 import { batchCommand } from "./commands/batch.js";
 
+// Version injected at build time by esbuild (see esbuild.config.mjs)
+declare const __CLI_VERSION__: string;
+
 const program = new Command();
 
 program
   .name("exocortex")
   .description("CLI tool for Exocortex knowledge management system")
-  .version("0.1.0");
+  .version(__CLI_VERSION__);
 
 program
   .command("sparql")


### PR DESCRIPTION
## Summary

- CLI now reads version from `package.json` at build time via esbuild's `define` feature
- `exocortex-cli --version` outputs the actual package version (e.g., `13.97.0` after release)
- Version automatically updates during releases without manual changes

## Changes

- **esbuild.config.mjs**: Added `__CLI_VERSION__` define that injects `package.json` version
- **index.ts**: Replaced hardcoded `"0.1.0"` with injected `__CLI_VERSION__` constant

## Test plan

- [x] Build succeeds: `npm run build -w packages/cli`
- [x] Version output matches package.json: `node dist/index.js --version`
- [x] All unit tests pass: `npm run test:unit`
- [x] Lint passes: `npm run lint`

Closes #587