### PR TITLE
feat(sparql): Support date arithmetic and aggregation for sleep analysis queries

### DIFF
--- a/packages/core/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -535,6 +535,28 @@ export class FilterExecutor {
       case "now":
         return BuiltInFunctions.now();
 
+      // XSD Type casting functions - for SPARQL dateTime arithmetic (Issue #534)
+      // xsd:dateTime(?value) casts a value to dateTime for arithmetic operations
+      case "datetime":
+      case "xsd:datetime": {
+        const dtValue = this.evaluateExpression(expr.args[0], solution);
+        return BuiltInFunctions.xsdDateTime(this.getStringValue(dtValue));
+      }
+
+      // xsd:integer(?value) casts a value to integer for arithmetic operations
+      case "integer":
+      case "xsd:integer": {
+        const intValue = this.evaluateExpression(expr.args[0], solution);
+        return BuiltInFunctions.xsdInteger(this.getStringValue(intValue));
+      }
+
+      // xsd:decimal(?value) casts a value to decimal for arithmetic operations
+      case "decimal":
+      case "xsd:decimal": {
+        const decValue = this.evaluateExpression(expr.args[0], solution);
+        return BuiltInFunctions.xsdDecimal(this.getStringValue(decValue));
+      }
+
       // Duration conversion functions (for arithmetic results)
       case "mstominutes":
         const msMinArg = Number(this.evaluateExpression(expr.args[0], solution));

--- a/packages/core/src/infrastructure/sparql/filters/BuiltInFunctions.ts
+++ b/packages/core/src/infrastructure/sparql/filters/BuiltInFunctions.ts
@@ -598,4 +598,56 @@ export class BuiltInFunctions {
   static if<T>(condition: boolean, thenValue: T, elseValue: T): T {
     return condition ? thenValue : elseValue;
   }
+
+  // XSD Type Casting Functions
+  // https://www.w3.org/TR/sparql11-query/#FunctionMapping
+
+  /**
+   * XSD dateTime constructor/cast function.
+   * Converts a string value to an xsd:dateTime Literal.
+   * Used for dateTime arithmetic: xsd:dateTime(?end) - xsd:dateTime(?start)
+   *
+   * @param value - String representation of dateTime (ISO 8601 or JS Date format)
+   * @returns Literal with xsd:dateTime datatype
+   */
+  static xsdDateTime(value: string): Literal {
+    // Parse the date to validate it
+    const date = new Date(value);
+    if (isNaN(date.getTime())) {
+      throw new Error(`xsd:dateTime: invalid date string '${value}'`);
+    }
+    // Return as ISO 8601 string with xsd:dateTime datatype
+    return new Literal(date.toISOString(), new IRI("http://www.w3.org/2001/XMLSchema#dateTime"));
+  }
+
+  /**
+   * XSD integer constructor/cast function.
+   * Converts a string/number value to an xsd:integer Literal.
+   * Used for duration calculations.
+   *
+   * @param value - String or numeric representation of integer
+   * @returns Literal with xsd:integer datatype
+   */
+  static xsdInteger(value: string): Literal {
+    const num = parseInt(value, 10);
+    if (isNaN(num)) {
+      throw new Error(`xsd:integer: cannot convert '${value}' to integer`);
+    }
+    return new Literal(String(num), new IRI("http://www.w3.org/2001/XMLSchema#integer"));
+  }
+
+  /**
+   * XSD decimal constructor/cast function.
+   * Converts a string/number value to an xsd:decimal Literal.
+   *
+   * @param value - String or numeric representation of decimal
+   * @returns Literal with xsd:decimal datatype
+   */
+  static xsdDecimal(value: string): Literal {
+    const num = parseFloat(value);
+    if (isNaN(num)) {
+      throw new Error(`xsd:decimal: cannot convert '${value}' to decimal`);
+    }
+    return new Literal(String(num), new IRI("http://www.w3.org/2001/XMLSchema#decimal"));
+  }
 }


### PR DESCRIPTION
## Summary

Fixes Issue #534 - Support date arithmetic and aggregation for sleep analysis queries

### Changes:
- **Blocker 1 Fix**: Aggregate functions (COUNT/AVG/SUM) now return ONLY GROUP BY variables + aggregate variables (previously returned extra pattern variables from input solutions)
- **Blocker 3 Fix**: Added xsd:dateTime(), xsd:integer(), xsd:decimal() casting functions for type conversion, enabling date arithmetic operations like `xsd:dateTime(?end) - xsd:dateTime(?start)`

### Files Changed:
- `AggregateExecutor.ts` - Fixed to create fresh SolutionMapping with only required variables
- `FilterExecutor.ts` - Added handlers for xsd:dateTime, xsd:integer, xsd:decimal functions
- `BuiltInFunctions.ts` - Added static methods for XSD type casting

### Tests Added:
- 3 tests for aggregate variable filtering (Issue #534 Blocker 1)
- 22 tests for XSD type casting functions
- 6 tests for sleep analysis query patterns

## Test plan
- [x] All unit tests pass (2000+ tests)
- [x] Component tests pass (378+ tests)
- [x] TypeScript compiles without errors
- [x] Tests specifically validate Issue #534 scenarios

Closes #534