### PR TITLE
chore(ci): remove manual workflow_dispatch from npm-publish-cli

### DIFF
--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -3,12 +3,6 @@ name: Publish CLI to npm
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g., 0.1.0)'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -30,16 +24,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
-      - name: Get version from release tag or input
+      - name: Get version from release tag
         id: version
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            # Extract version from tag (remove 'v' prefix if present)
-            VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"
-          fi
+          # Extract version from tag (remove 'v' prefix if present)
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
 


### PR DESCRIPTION
## Summary
- Убран ручной триггер `workflow_dispatch` из workflow публикации в npm
- Теперь публикация возможна только через автоматизированный релиз
- Это предотвращает несоответствия версий и дублирующие публикации

## Changes
- Removed `workflow_dispatch` trigger with version input
- Simplified version extraction (no longer checking event type)