### PR TITLE
fix(ui): remove max-width:0 from table header to fix column alignment (#594)

### DIFF
--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2462,8 +2462,9 @@
 }
 
 /* Colgroup column width definitions - ensures alignment across separate tables */
+/* Name column: No explicit width - takes remaining space after fixed columns */
 .exocortex-tasks-table col.col-name {
-  width: auto;
+  /* Intentionally no width set - distributes remaining space */
 }
 
 .exocortex-tasks-table col.col-start {
@@ -2494,11 +2495,19 @@
   white-space: nowrap;
 }
 
-/* Name column - flexible, takes remaining space */
+/* Name column - flexible, takes remaining space after fixed columns
+ * With table-layout: fixed, we must NOT use max-width:0 on <th> headers
+ * because it confuses the column width calculation. Only <td> cells use that trick.
+ */
 .exocortex-tasks-table th.task-name-header,
 .exocortex-tasks-table td.task-name {
-  max-width: 0; /* Forces text-overflow to work with table-layout: fixed */
+  /* Width is implicit - takes all remaining space after fixed columns */
   min-width: 100px;
+}
+
+.exocortex-tasks-table td.task-name {
+  /* Override: Data cells need max-width:0 trick for text-overflow ellipsis */
+  max-width: 0;
 }
 
 /* Start column - fixed width for time display (HH:MM or MM-DD HH:MM) */


### PR DESCRIPTION
## Summary

Fixes remaining column alignment issue in Tasks table (#594).

The previous fix (PR #595) applied `max-width:0` to BOTH `<th>` headers AND `<td>` data cells, which confused the browser's column width calculation in `table-layout:fixed` mode.

## Changes

- Remove `max-width:0` from `th.task-name-header` (header must have natural width for layout calculation)
- Keep `max-width:0` only on `td.task-name` (for text-overflow ellipsis)
- Remove explicit `width:auto` from `col.col-name` (let browser distribute remaining space naturally)
- Add explanatory comments for future maintenance

## Root Cause Analysis

With `table-layout:fixed`, the browser uses the first row's cell widths to calculate column widths. Setting `max-width:0` on header cells caused the Name column to be calculated with minimal width, pushing other columns to the right side of the table.

## Test Plan

- [x] Build passes
- [x] Unit tests pass (803 tests)
- [x] Lint passes (only pre-existing warnings)
- [ ] Manual test: Verify Tasks table alignment with 12+ tasks in Daily Note
- [ ] Manual test: Toggle "Show Archived" and verify alignment preserved
- [ ] Manual test: Verify text ellipsis still works for long task names

Closes #594