### PR TITLE
fix: prevent double-shift of plannedEndTimestamp on recursive metadata change

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -273,6 +273,8 @@ export default class ExocortexPlugin extends Plugin {
           `Detected ems__Effort_endTimestamp change in ${file.path}: ${String(previousEndTimestamp)} → ${String(currentEndTimestamp)}`,
         );
 
+        cachedMetadata.ems__Effort_endTimestamp = currentEndTimestamp;
+
         const parsedDate = new Date(currentEndTimestamp);
         if (!isNaN(parsedDate.getTime())) {
           await this.taskStatusService.syncEffortEndTimestamp(file, parsedDate);
@@ -289,6 +291,9 @@ export default class ExocortexPlugin extends Plugin {
         this.logger.info(
           `Detected ems__Effort_plannedStartTimestamp change in ${file.path}: ${String(previousPlannedStartTimestamp)} → ${String(currentPlannedStartTimestamp)}`,
         );
+
+        cachedMetadata.ems__Effort_plannedStartTimestamp =
+          currentPlannedStartTimestamp;
 
         const currentDate = new Date(
           String(currentPlannedStartTimestamp),
@@ -318,6 +323,8 @@ export default class ExocortexPlugin extends Plugin {
         this.logger.info(
           `Detected exo__Asset_label change in ${file.path}: ${String(previousAssetLabel)} → ${currentAssetLabel}`,
         );
+
+        cachedMetadata.exo__Asset_label = currentAssetLabel;
 
         await this.aliasSyncService.syncAliases(
           file,


### PR DESCRIPTION
## Summary

Fixes the bug where changing `ems__Effort_plannedStartTimestamp` by +5 minutes resulted in `ems__Effort_plannedEndTimestamp` shifting by +10 minutes (double the expected delta).

### Root Cause

When `handleMetadataChange` detected a change in `plannedStartTimestamp` and called `shiftPlannedEndTimestamp`, the file modification triggered a new `metadata-changed` event from Obsidian. The cache wasn't updated until after all handlers completed (line 340), so the recursive call saw the same "change" and shifted the timestamp **again**.

### Fix

Update the cached metadata **immediately** after detecting a change, **before** calling any async methods that modify the file. This prevents recursive calls from seeing stale cache data.

Applied the same fix to all three change handlers for consistency:
- `ems__Effort_endTimestamp` → `syncEffortEndTimestamp`
- `ems__Effort_plannedStartTimestamp` → `shiftPlannedEndTimestamp`
- `exo__Asset_label` → `syncAliases`

## Test Plan

- [x] Added test: `should not double-shift plannedEndTimestamp on recursive metadata change event`
- [x] Added test: `should not double-sync endTimestamp on recursive metadata change event`
- [x] All existing ExocortexPlugin tests pass (55 tests)
- [x] All unit tests pass (803 tests)
- [x] All component tests pass (378 tests)
- [ ] CI pipeline green

Fixes #603