### PR TITLE
perf: fix prototype URI normalization causing query mismatch

### DIFF
--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -104,17 +104,25 @@ export class NoteToRDFConverter {
   /**
    * Converts a note path to an obsidian:// IRI.
    *
+   * Uses encodeURI (not encodeURIComponent) to preserve forward slashes
+   * while encoding spaces and other special characters. This ensures
+   * consistent URI normalization for exact SPARQL query matches.
+   *
    * @param path - The note path (e.g., "path/to/note.md")
    * @returns IRI with obsidian:// scheme
    *
    * @example
    * ```typescript
    * const iri = converter.notePathToIRI("My Folder/My Note.md");
-   * // Returns: obsidian://vault/My Folder/My Note.md
+   * // Returns: obsidian://vault/My%20Folder/My%20Note.md
    * ```
    */
   notePathToIRI(path: string): IRI {
-    const encodedPath = encodeURIComponent(path);
+    // Use encodeURI to preserve forward slashes (/) while encoding
+    // spaces and other special characters. This fixes query mismatch
+    // issues where exact URI matches fail due to inconsistent encoding.
+    // See: https://github.com/kitelev/exocortex-obsidian-plugin/issues/621
+    const encodedPath = encodeURI(path);
     return new IRI(`${this.OBSIDIAN_VAULT_SCHEME}${encodedPath}`);
   }
 


### PR DESCRIPTION
## Summary
- Use `encodeURI` instead of `encodeURIComponent` to preserve forward slashes (/)
- This fixes SPARQL exact match queries failing due to inconsistent URI encoding  
- Prototype URIs like `obsidian://vault/path/to/note.md` now correctly preserve slashes

## Root Cause
`encodeURIComponent` encodes `/` as `%2F`, causing URI mismatches:
- Subject IRI: `obsidian://vault/03%20Knowledge%2Fkitelev%2Ffile.md`
- Query IRI: `obsidian://vault/03%20Knowledge/kitelev/file.md`

## Solution
Changed `notePathToIRI()` to use `encodeURI()` which:
- Preserves forward slashes (`/`) for path structure
- Still encodes spaces (`%20`) and special characters
- Produces consistent URIs for both subjects and objects

## Tests Added
- 8 new tests for URI normalization (Issue #621)
- Tests cover: slashes, spaces, Cyrillic, brackets, deep paths, UUIDs
- Fixed pre-existing test bug: `exocortex.org` → `exocortex.my`

## Impact
**Before fix**: Exact URI match `<obsidian://vault/03%20Knowledge%2Fkitelev%2Ffile.md>` returns 2 results  
**After fix**: Same query returns 10 results (same as FILTER+CONTAINS workaround)

## Test Plan
- [x] Unit tests pass locally
- [x] Component tests pass locally
- [ ] CI pipeline passes

Closes #621