### PR TITLE
chore: default 'Create in new tab' checkbox to unchecked

### DIFF
--- a/packages/obsidian-plugin/src/presentation/modals/LabelInputModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/LabelInputModal.ts
@@ -13,7 +13,7 @@ export interface LabelInputModalResult {
 export class LabelInputModal extends Modal {
   private label = "";
   private taskSize: string | null = null;
-  private openInNewTab = true;
+  private openInNewTab = false;
   private onSubmit: (result: LabelInputModalResult) => void;
   private inputEl: HTMLInputElement | null = null;
   private taskSizeSelectEl: HTMLSelectElement | null = null;

--- a/packages/obsidian-plugin/tests/unit/LabelInputModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/LabelInputModal.test.ts
@@ -162,7 +162,7 @@ describe("LabelInputModal", () => {
       });
     });
 
-    it("should create open-in-new-tab checkbox checked by default", () => {
+    it("should create open-in-new-tab checkbox unchecked by default", () => {
       modal.onOpen();
 
       expect(mockContentEl.createEl).toHaveBeenCalledWith(
@@ -171,7 +171,7 @@ describe("LabelInputModal", () => {
           type: "checkbox",
         }),
       );
-      expect(mockCheckboxEl.checked).toBe(true);
+      expect(mockCheckboxEl.checked).toBe(false);
     });
   });
 
@@ -314,7 +314,7 @@ describe("LabelInputModal", () => {
       expect(onSubmitSpy).toHaveBeenCalledWith({
         label: "Test Label",
         taskSize: null,
-        openInNewTab: true,
+        openInNewTab: false,
       });
       expect(modal.close).toHaveBeenCalled();
     });
@@ -328,7 +328,7 @@ describe("LabelInputModal", () => {
       expect(onSubmitSpy).toHaveBeenCalledWith({
         label: null,
         taskSize: null,
-        openInNewTab: true,
+        openInNewTab: false,
       });
       expect(modal.close).toHaveBeenCalled();
     });
@@ -342,17 +342,17 @@ describe("LabelInputModal", () => {
       expect(onSubmitSpy).toHaveBeenCalledWith({
         label: "Task Name",
         taskSize: '"[[ems__TaskSize_M]]"',
-        openInNewTab: true,
+        openInNewTab: false,
       });
       expect(modal.close).toHaveBeenCalled();
     });
 
-    it("should submit with openInNewTab false when checkbox unchecked", () => {
+    it("should submit with openInNewTab true when checkbox checked", () => {
       modal.contentEl = mockContentEl;
       modal.close = jest.fn();
       modal.onOpen();
 
-      mockCheckboxEl.checked = false;
+      mockCheckboxEl.checked = true;
       mockCheckboxEl.dispatchEvent(new Event("change"));
 
       modal["submit"]();
@@ -360,7 +360,7 @@ describe("LabelInputModal", () => {
       expect(onSubmitSpy).toHaveBeenCalledWith({
         label: null,
         taskSize: null,
-        openInNewTab: false,
+        openInNewTab: true,
       });
       expect(modal.close).toHaveBeenCalled();
     });
@@ -381,7 +381,7 @@ describe("LabelInputModal", () => {
       expect(onSubmitSpy).toHaveBeenCalledWith({
         label: null,
         taskSize: null,
-        openInNewTab: true,
+        openInNewTab: false,
       });
       expect(modal.close).toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- Changes the default value of `openInNewTab` from `true` to `false` in `LabelInputModal`
- New assets will now open in the **current tab** by default instead of a new tab
- Updated related tests to match new default behavior

## Test Plan

- [x] Unit tests updated and passing
- [x] Build passes
- [x] Lint passes (warnings only, no errors)

Closes #626