### PR TITLE
fix(table): fix column alignment (#594) - width on TH/TD instead of COL

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
@@ -512,20 +512,8 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
     );
   };
 
-  /**
-   * Renders <colgroup> for consistent column widths across header/body tables.
-   * This is essential for virtualized tables where header and body are separate.
-   */
-  const renderColGroup = () => (
-    <colgroup>
-      <col className="col-name" />
-      <col className="col-start" />
-      <col className="col-end" />
-      <col className="col-status" />
-      {showEffortArea && <col className="col-effort-area" />}
-      {showEffortVotes && <col className="col-votes" />}
-    </colgroup>
-  );
+  // NOTE: <colgroup> removed - column widths are now set via CSS on TH/TD elements
+  // This is more reliable than COL elements, which only work with table-layout: fixed
 
   const renderTableHeader = () => (
     <thead>
@@ -596,7 +584,6 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
     return (
       <div className="exocortex-daily-tasks">
         <table className="exocortex-tasks-table">
-          {renderColGroup()}
           {renderTableHeader()}
           <tbody>
             {displayedTasks.map((task, index) => renderRow(task, index))}
@@ -619,7 +606,6 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   return (
     <div className="exocortex-daily-tasks exocortex-virtualized">
       <table className="exocortex-tasks-table exocortex-tasks-table-header">
-        {renderColGroup()}
         {renderTableHeader()}
       </table>
       <div
@@ -647,7 +633,6 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
               width: "100%",
             }}
           >
-            {renderColGroup()}
             <tbody>
               {virtualItems.length > 0 ? (
                 virtualItems.map((virtualRow) => {

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2441,54 +2441,29 @@
 
 /*
  * Fixes for inconsistent column alignment (Issue #594):
- * - Uses natural table layout (NOT table-layout: fixed)
- * - Explicit widths on data columns (Start, End, Status)
- * - Name column takes remaining space with min-width
- * - Prevents long task names from breaking layout
+ * - Uses table-layout: fixed for predictable column widths
+ * - Explicit widths on TH/TD elements (not just COL - which is ignored without table-layout: fixed)
+ * - Name column takes remaining space
  *
- * Column width strategy:
- * - Name: flexible (remaining space, min-width: 200px)
+ * Column width strategy (applied to both TH and TD):
+ * - Name: auto (takes remaining space after fixed columns)
  * - Start: 90px
  * - End: 90px
  * - Status: 100px
  * - Area: 120px (when visible)
  * - Votes: 70px (when visible)
  *
- * NOTE: table-layout: fixed was removed because it causes misalignment
- * between header and body when they are separate tables (virtualization).
+ * CRITICAL: Widths MUST be on TH/TD elements, not just COL.
+ * COL widths only work with table-layout: fixed, but TH/TD widths
+ * are respected by the browser's table layout algorithm.
  */
 
 .exocortex-tasks-table {
   width: 100%;
-  /* Natural table layout - browser calculates column widths based on content and explicit widths */
+  table-layout: fixed;
 }
 
-/* Colgroup column widths - used by natural table layout */
-.exocortex-tasks-table col.col-name {
-  /* No fixed width - takes remaining space */
-}
-
-.exocortex-tasks-table col.col-start {
-  width: 90px;
-}
-
-.exocortex-tasks-table col.col-end {
-  width: 90px;
-}
-
-.exocortex-tasks-table col.col-status {
-  width: 100px;
-}
-
-.exocortex-tasks-table col.col-effort-area {
-  width: 120px;
-}
-
-.exocortex-tasks-table col.col-votes {
-  width: 70px;
-}
-
-/* Base cell styling */
+/* Base cell styling - overflow handling */
 .exocortex-tasks-table th,
 .exocortex-tasks-table td {
   overflow: hidden;
@@ -2496,40 +2471,42 @@
   white-space: nowrap;
 }
 
-/* Name column - flexible with minimum width */
+/* Name column - takes remaining space (auto width with table-layout: fixed) */
 .exocortex-tasks-table th.task-name-header,
 .exocortex-tasks-table td.task-name {
-  min-width: 200px;
-  max-width: 500px;
+  /* No width = takes remaining space after fixed-width columns */
 }
 
-/* Start column - width from colgroup, center-aligned */
+/* Start column - fixed width */
 .exocortex-tasks-table th.task-start-header,
 .exocortex-tasks-table td.task-start {
+  width: 90px;
   text-align: center;
 }
 
-/* End column - width from colgroup, center-aligned */
+/* End column - fixed width */
 .exocortex-tasks-table th.task-end-header,
 .exocortex-tasks-table td.task-end {
+  width: 90px;
   text-align: center;
 }
 
-/* Status column - width from colgroup */
+/* Status column - fixed width */
 .exocortex-tasks-table th.task-status-header,
 .exocortex-tasks-table td.task-status {
-  /* Width from colgroup col.col-status */
+  width: 100px;
 }
 
-/* Effort Area column (optional) - width from colgroup */
+/* Effort Area column (optional) - fixed width */
 .exocortex-tasks-table th.task-effort-area-header,
 .exocortex-tasks-table td.task-effort-area {
-  /* Width from colgroup col.col-effort-area */
+  width: 120px;
 }
 
-/* Votes column (optional) - width from colgroup, center-aligned */
+/* Votes column (optional) - fixed width */
 .exocortex-tasks-table th.task-votes-header,
 .exocortex-tasks-table td.task-effort-votes {
+  width: 70px;
   text-align: center;
 }
 
@@ -2563,28 +2540,27 @@
 
 /* Mobile responsive - narrower columns on small screens */
 @media (max-width: 768px) {
-  .exocortex-tasks-table col.col-start,
-  .exocortex-tasks-table col.col-end {
-    width: 70px;
-  }
-
-  .exocortex-tasks-table col.col-status {
-    width: 65px;
-  }
-
-  .exocortex-tasks-table col.col-effort-area {
-    width: 80px;
-  }
-
-  .exocortex-tasks-table col.col-votes {
-    width: 50px;
-  }
-
   .exocortex-tasks-table th.task-start-header,
   .exocortex-tasks-table td.task-start,
   .exocortex-tasks-table th.task-end-header,
   .exocortex-tasks-table td.task-end {
+    width: 70px;
     font-size: 0.85em;
+  }
+
+  .exocortex-tasks-table th.task-status-header,
+  .exocortex-tasks-table td.task-status {
+    width: 65px;
+  }
+
+  .exocortex-tasks-table th.task-effort-area-header,
+  .exocortex-tasks-table td.task-effort-area {
+    width: 80px;
+  }
+
+  .exocortex-tasks-table th.task-votes-header,
+  .exocortex-tasks-table td.task-effort-votes {
+    width: 50px;
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes column alignment issue in DailyTasksTable by setting width on TH/TD elements instead of COL elements.

## Root Cause Analysis
**Previous attempts failed because:**
- CSS `width` on `<col>` elements is **ignored** without `table-layout: fixed`
- Earlier fixes added colgroup with col widths, but without `table-layout: fixed` the browser uses natural layout algorithm which ignores col widths

## Solution
1. Add `table-layout: fixed` to `.exocortex-tasks-table`
2. Set explicit width on TH/TD elements (not COL): Start=90px, End=90px, Status=100px, etc.
3. Name column takes remaining space (no width = auto)
4. Remove unused colgroup from DailyTasksTable.tsx

## Changes
- **styles.css**: Added `table-layout: fixed`, moved widths from col to th/td selectors
- **DailyTasksTable.tsx**: Removed colgroup (no longer needed, widths set via CSS)

## Test plan
- [ ] Visual verification: columns should be aligned (Name | Start | End | Status)
- [ ] E2E tests for table alignment should pass

Closes #594