### PR TITLE
fix(table): sync column widths in virtualized mode (#594)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
@@ -512,8 +512,19 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
     );
   };
 
-  // NOTE: <colgroup> removed - column widths are now set via CSS on TH/TD elements
-  // This is more reliable than COL elements, which only work with table-layout: fixed
+  // Colgroup for synchronizing column widths between header and body tables
+  // in virtualized mode. With table-layout: fixed, col widths are respected.
+  // Widths must match CSS definitions in styles.css for .exocortex-tasks-table
+  const renderColGroup = () => (
+    <colgroup>
+      <col className="col-name" />
+      <col className="col-start" style={{ width: "90px" }} />
+      <col className="col-end" style={{ width: "90px" }} />
+      <col className="col-status" style={{ width: "100px" }} />
+      {showEffortArea && <col className="col-effort-area" style={{ width: "120px" }} />}
+      {showEffortVotes && <col className="col-votes" style={{ width: "70px" }} />}
+    </colgroup>
+  );
 
   const renderTableHeader = () => (
     <thead>
@@ -584,6 +595,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
     return (
       <div className="exocortex-daily-tasks">
         <table className="exocortex-tasks-table">
+          {renderColGroup()}
           {renderTableHeader()}
           <tbody>
             {displayedTasks.map((task, index) => renderRow(task, index))}
@@ -606,6 +618,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   return (
     <div className="exocortex-daily-tasks exocortex-virtualized">
       <table className="exocortex-tasks-table exocortex-tasks-table-header">
+        {renderColGroup()}
         {renderTableHeader()}
       </table>
       <div
@@ -633,6 +646,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
               width: "100%",
             }}
           >
+            {renderColGroup()}
             <tbody>
               {virtualItems.length > 0 ? (
                 virtualItems.map((virtualRow) => {


### PR DESCRIPTION
## Summary
Follow-up fix for Issue #594: Column alignment breaks when toggling showArchived/showEmptySlots in specific order.

## Root Cause
In virtualized mode (>50 rows), header and body are rendered as **separate tables**. Each table calculates column widths independently, causing misalignment when:
1. Toggle Empty Slots first → table renders with X rows
2. Toggle Archived → table re-renders with different row count
3. Column widths become desynchronized

## Solution
Add `<colgroup>` with explicit column widths to **all three table variants**:
- Non-virtualized: single table with colgroup
- Virtualized header: colgroup with same widths
- Virtualized body: colgroup with same widths

This ensures column width synchronization regardless of toggle order.

## Test plan
- [x] TypeScript check passes
- [x] Unit tests pass
- [ ] CI checks pass
- [ ] Verify in Obsidian: toggle Empty Slots first, then Archived - columns stay aligned