### PR TITLE
test: Add tests for missing Property Field components

### DIFF
--- a/packages/obsidian-plugin/tests/component/property-editor/fields/BooleanField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/property-editor/fields/BooleanField.spec.tsx
@@ -1,0 +1,273 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { BooleanField } from "../../../../src/presentation/components/property-editor/fields/BooleanField";
+import type { PropertySchemaDefinition } from "../../../../src/domain/property-editor/PropertySchemas";
+
+const createProperty = (
+  overrides: Partial<PropertySchemaDefinition> = {},
+): PropertySchemaDefinition => ({
+  name: "testBoolean",
+  type: "boolean",
+  required: false,
+  label: "Test Boolean",
+  ...overrides,
+});
+
+test.describe("BooleanField Component", () => {
+  test("should render checkbox with label", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toBeVisible();
+
+    // Check for checkbox
+    const checkbox = component.locator("input[type='checkbox']");
+    await expect(checkbox).toBeVisible();
+
+    // Check for label
+    const label = component.locator("label.property-editor-label");
+    await expect(label).toHaveText("Test Boolean");
+  });
+
+  test("should show checked state when value is true", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={true}
+        onChange={() => {}}
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    await expect(checkbox).toBeChecked();
+  });
+
+  test("should show unchecked state when value is false", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    await expect(checkbox).not.toBeChecked();
+  });
+
+  test("should treat string 'true' as checked", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value="true"
+        onChange={() => {}}
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    await expect(checkbox).toBeChecked();
+  });
+
+  test("should treat string 'yes' as checked", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value="yes"
+        onChange={() => {}}
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    await expect(checkbox).toBeChecked();
+  });
+
+  test("should call onChange with true when clicking unchecked checkbox", async ({ mount }) => {
+    let changedValue: boolean | undefined;
+    const onChange = (value: boolean) => {
+      changedValue = value;
+    };
+    const property = createProperty();
+
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={onChange}
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    // Use click() instead of check() - click always triggers the event
+    await checkbox.click();
+
+    await expect.poll(() => changedValue).toBe(true);
+  });
+
+  test("should call onChange with false when clicking checked checkbox", async ({ mount }) => {
+    let changedValue: boolean | undefined;
+    const onChange = (value: boolean) => {
+      changedValue = value;
+    };
+    const property = createProperty();
+
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={true}
+        onChange={onChange}
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    // Use click() instead of uncheck() - click always triggers the event
+    await checkbox.click();
+
+    await expect.poll(() => changedValue).toBe(false);
+  });
+
+  test("should show required indicator when property is required", async ({ mount }) => {
+    const property = createProperty({ required: true });
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).toBeVisible();
+    await expect(requiredIndicator).toHaveText("*");
+  });
+
+  test("should NOT show required indicator when property is not required", async ({ mount }) => {
+    const property = createProperty({ required: false });
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).not.toBeVisible();
+  });
+
+  test("should show description when provided", async ({ mount }) => {
+    const property = createProperty({ description: "This is a test description" });
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).toBeVisible();
+    await expect(description).toHaveText("This is a test description");
+  });
+
+  test("should NOT show description when not provided", async ({ mount }) => {
+    const property = createProperty({ description: undefined });
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).not.toBeVisible();
+  });
+
+  test("should show error message when error is provided", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+        error="This field has an error"
+      />,
+    );
+
+    const errorMessage = component.locator(".property-editor-error");
+    await expect(errorMessage).toBeVisible();
+    await expect(errorMessage).toHaveText("This field has an error");
+  });
+
+  test("should apply has-error class when error is provided", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+        error="Error"
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    await expect(checkbox).toHaveClass(/has-error/);
+  });
+
+  test("should disable checkbox when property is readOnly", async ({ mount }) => {
+    const property = createProperty({ readOnly: true });
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={true}
+        onChange={() => {}}
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    await expect(checkbox).toBeDisabled();
+  });
+
+  test("should enable checkbox when property is not readOnly", async ({ mount }) => {
+    const property = createProperty({ readOnly: false });
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    await expect(checkbox).toBeEnabled();
+  });
+
+  test("should have correct id linking checkbox and label", async ({ mount }) => {
+    const property = createProperty({ name: "exo__Asset_isArchived" });
+    const component = await mount(
+      <BooleanField
+        property={property}
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+
+    const checkbox = component.locator("input[type='checkbox']");
+    const label = component.locator("label.property-editor-label");
+
+    const checkboxId = await checkbox.getAttribute("id");
+    const labelFor = await label.getAttribute("for");
+
+    expect(checkboxId).toBe("property-exo__Asset_isArchived");
+    expect(labelFor).toBe(checkboxId);
+  });
+});

--- a/packages/obsidian-plugin/tests/component/property-editor/fields/NumberField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/property-editor/fields/NumberField.spec.tsx
@@ -1,0 +1,294 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { NumberField } from "../../../../src/presentation/components/property-editor/fields/NumberField";
+import type { PropertySchemaDefinition } from "../../../../src/domain/property-editor/PropertySchemas";
+
+const createProperty = (
+  overrides: Partial<PropertySchemaDefinition> = {},
+): PropertySchemaDefinition => ({
+  name: "testNumber",
+  type: "number",
+  required: false,
+  label: "Test Number",
+  ...overrides,
+});
+
+test.describe("NumberField Component", () => {
+  test("should render number input with label", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toBeVisible();
+
+    // Check for number input
+    const input = component.locator("input[type='number']");
+    await expect(input).toBeVisible();
+
+    // Check for label
+    const label = component.locator("label.property-editor-label");
+    await expect(label).toHaveText("Test Number");
+  });
+
+  test("should display numeric value correctly", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={42}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toHaveValue("42");
+  });
+
+  test("should handle string value by parsing to number", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <NumberField
+        property={property}
+        value="123"
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toHaveValue("123");
+  });
+
+  test("should call onChange with parsed number value", async ({ mount }) => {
+    let changedValue: number | undefined;
+    const onChange = (value: number) => {
+      changedValue = value;
+    };
+    const property = createProperty();
+
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={onChange}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await input.fill("99");
+
+    await expect.poll(() => changedValue).toBe(99);
+  });
+
+  test("should call onChange with 0 when input is cleared", async ({ mount }) => {
+    let changedValue: number | undefined;
+    const onChange = (value: number) => {
+      changedValue = value;
+    };
+    const property = createProperty();
+
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={42}
+        onChange={onChange}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await input.fill("");
+
+    await expect.poll(() => changedValue).toBe(0);
+  });
+
+  test("should show required indicator when property is required", async ({ mount }) => {
+    const property = createProperty({ required: true });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).toBeVisible();
+    await expect(requiredIndicator).toHaveText("*");
+  });
+
+  test("should NOT show required indicator when property is not required", async ({ mount }) => {
+    const property = createProperty({ required: false });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).not.toBeVisible();
+  });
+
+  test("should show description when provided", async ({ mount }) => {
+    const property = createProperty({ description: "Enter a number value" });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).toBeVisible();
+    await expect(description).toHaveText("Enter a number value");
+  });
+
+  test("should NOT show description when not provided", async ({ mount }) => {
+    const property = createProperty({ description: undefined });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).not.toBeVisible();
+  });
+
+  test("should show error message when error is provided", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={() => {}}
+        error="Invalid number value"
+      />,
+    );
+
+    const errorMessage = component.locator(".property-editor-error");
+    await expect(errorMessage).toBeVisible();
+    await expect(errorMessage).toHaveText("Invalid number value");
+  });
+
+  test("should apply has-error class when error is provided", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={() => {}}
+        error="Error"
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toHaveClass(/has-error/);
+  });
+
+  test("should disable input when property is readOnly", async ({ mount }) => {
+    const property = createProperty({ readOnly: true });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={10}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toBeDisabled();
+  });
+
+  test("should enable input when property is not readOnly", async ({ mount }) => {
+    const property = createProperty({ readOnly: false });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toBeEnabled();
+  });
+
+  test("should set min attribute when property has min", async ({ mount }) => {
+    const property = createProperty({ min: 0 });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={5}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toHaveAttribute("min", "0");
+  });
+
+  test("should set max attribute when property has max", async ({ mount }) => {
+    const property = createProperty({ max: 100 });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={50}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toHaveAttribute("max", "100");
+  });
+
+  test("should set both min and max attributes when both are provided", async ({ mount }) => {
+    const property = createProperty({ min: 1, max: 10 });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={5}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toHaveAttribute("min", "1");
+    await expect(input).toHaveAttribute("max", "10");
+  });
+
+  test("should use label as placeholder", async ({ mount }) => {
+    const property = createProperty({ label: "Priority Votes" });
+    const component = await mount(
+      <NumberField
+        property={property}
+        value={0}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toHaveAttribute("placeholder", "Priority Votes");
+  });
+
+  test("should display empty when value is NaN", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <NumberField
+        property={property}
+        value="not-a-number"
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='number']");
+    await expect(input).toHaveValue("");
+  });
+});

--- a/packages/obsidian-plugin/tests/component/property-editor/fields/SelectField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/property-editor/fields/SelectField.spec.tsx
@@ -1,0 +1,302 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { SelectField } from "../../../../src/presentation/components/property-editor/fields/SelectField";
+import type { PropertySchemaDefinition } from "../../../../src/domain/property-editor/PropertySchemas";
+import {
+  EFFORT_STATUS_VALUES,
+  TASK_SIZE_VALUES,
+} from "../../../../src/domain/property-editor/PropertySchemas";
+
+const createStatusProperty = (
+  overrides: Partial<PropertySchemaDefinition> = {},
+): PropertySchemaDefinition => ({
+  name: "ems__Effort_status",
+  type: "status-select",
+  required: true,
+  label: "Status",
+  ...overrides,
+});
+
+const createSizeProperty = (
+  overrides: Partial<PropertySchemaDefinition> = {},
+): PropertySchemaDefinition => ({
+  name: "ems__Task_size",
+  type: "size-select",
+  required: false,
+  label: "Size",
+  ...overrides,
+});
+
+test.describe("SelectField Component", () => {
+  test("should render select with label", async ({ mount }) => {
+    const property = createStatusProperty();
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toBeVisible();
+
+    // Check for select
+    const select = component.locator("select");
+    await expect(select).toBeVisible();
+
+    // Check for label
+    const label = component.locator("label.property-editor-label");
+    await expect(label).toHaveText("Status*");
+  });
+
+  test("should have all status options for status-select type", async ({ mount }) => {
+    const property = createStatusProperty();
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const select = component.locator("select");
+
+    // Verify all status options are present (options are attached even if not visible in closed dropdown)
+    for (const status of EFFORT_STATUS_VALUES) {
+      const option = select.locator(`option[value="${status.value}"]`);
+      await expect(option).toBeAttached();
+      await expect(option).toHaveText(status.label);
+    }
+  });
+
+  test("should have all size options for size-select type", async ({ mount }) => {
+    const property = createSizeProperty();
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const select = component.locator("select");
+
+    // Verify all size options are present (options are attached even if not visible in closed dropdown)
+    for (const size of TASK_SIZE_VALUES) {
+      const option = select.locator(`option[value="${size.value}"]`);
+      await expect(option).toBeAttached();
+      await expect(option).toHaveText(size.label);
+    }
+  });
+
+  test("should display selected value correctly", async ({ mount }) => {
+    const property = createStatusProperty();
+    const component = await mount(
+      <SelectField
+        property={property}
+        value="[[ems__EffortStatusDoing]]"
+        onChange={() => {}}
+      />,
+    );
+
+    const select = component.locator("select");
+    await expect(select).toHaveValue("[[ems__EffortStatusDoing]]");
+  });
+
+  test("should call onChange when selection changes", async ({ mount }) => {
+    let changedValue: string | undefined;
+    const onChange = (value: string) => {
+      changedValue = value;
+    };
+    const property = createStatusProperty();
+
+    const component = await mount(
+      <SelectField
+        property={property}
+        value="[[ems__EffortStatusBacklog]]"
+        onChange={onChange}
+      />,
+    );
+
+    const select = component.locator("select");
+    await select.selectOption("[[ems__EffortStatusDone]]");
+
+    await expect.poll(() => changedValue).toBe("[[ems__EffortStatusDone]]");
+  });
+
+  test("should have 'Not specified' option when property is not required", async ({ mount }) => {
+    const property = createSizeProperty({ required: false });
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const select = component.locator("select");
+    const notSpecifiedOption = select.locator("option[value='']");
+    await expect(notSpecifiedOption).toBeAttached();
+    await expect(notSpecifiedOption).toHaveText("Not specified");
+  });
+
+  test("should NOT have 'Not specified' option when property is required", async ({ mount }) => {
+    const property = createStatusProperty({ required: true });
+    const component = await mount(
+      <SelectField
+        property={property}
+        value="[[ems__EffortStatusDraft]]"
+        onChange={() => {}}
+      />,
+    );
+
+    const select = component.locator("select");
+    const notSpecifiedOption = select.locator("option[value='']");
+    await expect(notSpecifiedOption).toHaveCount(0);
+  });
+
+  test("should show required indicator when property is required", async ({ mount }) => {
+    const property = createStatusProperty({ required: true });
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).toBeVisible();
+    await expect(requiredIndicator).toHaveText("*");
+  });
+
+  test("should NOT show required indicator when property is not required", async ({ mount }) => {
+    const property = createSizeProperty({ required: false });
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).not.toBeVisible();
+  });
+
+  test("should show description when provided", async ({ mount }) => {
+    const property = createStatusProperty({ description: "Current workflow status" });
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).toBeVisible();
+    await expect(description).toHaveText("Current workflow status");
+  });
+
+  test("should NOT show description when not provided", async ({ mount }) => {
+    const property = createStatusProperty({ description: undefined });
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).not.toBeVisible();
+  });
+
+  test("should show error message when error is provided", async ({ mount }) => {
+    const property = createStatusProperty();
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+        error="Status is required"
+      />,
+    );
+
+    const errorMessage = component.locator(".property-editor-error");
+    await expect(errorMessage).toBeVisible();
+    await expect(errorMessage).toHaveText("Status is required");
+  });
+
+  test("should apply has-error class when error is provided", async ({ mount }) => {
+    const property = createStatusProperty();
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+        error="Error"
+      />,
+    );
+
+    const select = component.locator("select");
+    await expect(select).toHaveClass(/has-error/);
+  });
+
+  test("should disable select when property is readOnly", async ({ mount }) => {
+    const property = createStatusProperty({ readOnly: true });
+    const component = await mount(
+      <SelectField
+        property={property}
+        value="[[ems__EffortStatusDoing]]"
+        onChange={() => {}}
+      />,
+    );
+
+    const select = component.locator("select");
+    await expect(select).toBeDisabled();
+  });
+
+  test("should enable select when property is not readOnly", async ({ mount }) => {
+    const property = createStatusProperty({ readOnly: false });
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const select = component.locator("select");
+    await expect(select).toBeEnabled();
+  });
+
+  test("should normalize value by removing quotes", async ({ mount }) => {
+    const property = createStatusProperty();
+    const component = await mount(
+      <SelectField
+        property={property}
+        value='"[[ems__EffortStatusDoing]]"'
+        onChange={() => {}}
+      />,
+    );
+
+    const select = component.locator("select");
+    // The normalized value should match the option without quotes
+    await expect(select).toHaveValue("[[ems__EffortStatusDoing]]");
+  });
+
+  test("should have dropdown class for styling", async ({ mount }) => {
+    const property = createStatusProperty();
+    const component = await mount(
+      <SelectField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const select = component.locator("select");
+    await expect(select).toHaveClass(/dropdown/);
+  });
+});

--- a/packages/obsidian-plugin/tests/component/property-editor/fields/TextField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/property-editor/fields/TextField.spec.tsx
@@ -1,0 +1,266 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { TextField } from "../../../../src/presentation/components/property-editor/fields/TextField";
+import type { PropertySchemaDefinition } from "../../../../src/domain/property-editor/PropertySchemas";
+
+const createProperty = (
+  overrides: Partial<PropertySchemaDefinition> = {},
+): PropertySchemaDefinition => ({
+  name: "exo__Asset_label",
+  type: "text",
+  required: true,
+  label: "Label",
+  ...overrides,
+});
+
+test.describe("TextField Component", () => {
+  test("should render text input with label", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toBeVisible();
+
+    // Check for text input
+    const input = component.locator("input[type='text']");
+    await expect(input).toBeVisible();
+
+    // Check for label
+    const label = component.locator("label.property-editor-label");
+    await expect(label).toHaveText("Label*");
+  });
+
+  test("should display value correctly", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TextField
+        property={property}
+        value="Test Value"
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveValue("Test Value");
+  });
+
+  test("should display empty string when value is null or undefined", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TextField
+        property={property}
+        value={undefined as unknown as string}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveValue("");
+  });
+
+  test("should call onChange when input value changes", async ({ mount }) => {
+    let changedValue: string | undefined;
+    const onChange = (value: string) => {
+      changedValue = value;
+    };
+    const property = createProperty();
+
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={onChange}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await input.fill("New Value");
+
+    await expect.poll(() => changedValue).toBe("New Value");
+  });
+
+  test("should call onChange immediately on input (not on blur)", async ({ mount }) => {
+    let changedValue: string | undefined;
+    const onChange = (value: string) => {
+      changedValue = value;
+    };
+    const property = createProperty();
+
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={onChange}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await input.fill("test");
+
+    // onChange should be called immediately (not waiting for blur)
+    await expect.poll(() => changedValue).toBe("test");
+  });
+
+  test("should show required indicator when property is required", async ({ mount }) => {
+    const property = createProperty({ required: true });
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).toBeVisible();
+    await expect(requiredIndicator).toHaveText("*");
+  });
+
+  test("should NOT show required indicator when property is not required", async ({ mount }) => {
+    const property = createProperty({ required: false });
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).not.toBeVisible();
+  });
+
+  test("should show description when provided", async ({ mount }) => {
+    const property = createProperty({ description: "Display name for the asset" });
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).toBeVisible();
+    await expect(description).toHaveText("Display name for the asset");
+  });
+
+  test("should NOT show description when not provided", async ({ mount }) => {
+    const property = createProperty({ description: undefined });
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).not.toBeVisible();
+  });
+
+  test("should show error message when error is provided", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+        error="Label is required"
+      />,
+    );
+
+    const errorMessage = component.locator(".property-editor-error");
+    await expect(errorMessage).toBeVisible();
+    await expect(errorMessage).toHaveText("Label is required");
+  });
+
+  test("should apply has-error class when error is provided", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+        error="Error"
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveClass(/has-error/);
+  });
+
+  test("should NOT apply has-error class when no error", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).not.toHaveClass(/has-error/);
+  });
+
+  test("should disable input when property is readOnly", async ({ mount }) => {
+    const property = createProperty({ readOnly: true });
+    const component = await mount(
+      <TextField
+        property={property}
+        value="Read Only Value"
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toBeDisabled();
+  });
+
+  test("should enable input when property is not readOnly", async ({ mount }) => {
+    const property = createProperty({ readOnly: false });
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toBeEnabled();
+  });
+
+  test("should use label as placeholder", async ({ mount }) => {
+    const property = createProperty({ label: "Asset Name" });
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveAttribute("placeholder", "Asset Name");
+  });
+
+  test("should have property-editor-input class", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TextField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveClass(/property-editor-input/);
+  });
+});

--- a/packages/obsidian-plugin/tests/component/property-editor/fields/TimestampField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/property-editor/fields/TimestampField.spec.tsx
@@ -1,0 +1,213 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { TimestampField } from "../../../../src/presentation/components/property-editor/fields/TimestampField";
+import type { PropertySchemaDefinition } from "../../../../src/domain/property-editor/PropertySchemas";
+
+const createProperty = (
+  overrides: Partial<PropertySchemaDefinition> = {},
+): PropertySchemaDefinition => ({
+  name: "exo__Asset_createdAt",
+  type: "timestamp",
+  required: true,
+  label: "Created at",
+  readOnly: true,
+  ...overrides,
+});
+
+test.describe("TimestampField Component", () => {
+  test("should render timestamp display with label", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-11-11T10:30:00.000Z"
+      />,
+    );
+
+    await expect(component).toBeVisible();
+
+    // Check for timestamp display
+    const display = component.locator(".timestamp-display");
+    await expect(display).toBeVisible();
+
+    // Check for label
+    const label = component.locator("label.property-editor-label");
+    await expect(label).toHaveText("Created at*");
+  });
+
+  test("should display 'Not set' when value is empty", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value=""
+      />,
+    );
+
+    const display = component.locator(".timestamp-display");
+    await expect(display).toHaveText("Not set");
+  });
+
+  test("should display 'Not set' when value is undefined", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value={undefined as unknown as string}
+      />,
+    );
+
+    const display = component.locator(".timestamp-display");
+    await expect(display).toHaveText("Not set");
+  });
+
+  test("should format valid timestamp to locale string", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-11-11T10:30:00.000Z"
+      />,
+    );
+
+    const display = component.locator(".timestamp-display");
+    const text = await display.textContent();
+
+    // Should contain date and time components
+    expect(text).toContain("2024");
+    expect(text).toContain("11");
+    // The exact format depends on locale, but should have time components
+    expect(text?.length).toBeGreaterThan(0);
+    expect(text).not.toBe("Not set");
+  });
+
+  test("should display 'Invalid Date' when timestamp is invalid", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="invalid-timestamp"
+      />,
+    );
+
+    const display = component.locator(".timestamp-display");
+    // new Date("invalid-timestamp").toLocaleString() returns "Invalid Date"
+    await expect(display).toHaveText("Invalid Date");
+  });
+
+  test("should show required indicator when property is required", async ({ mount }) => {
+    const property = createProperty({ required: true });
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-11-11T10:30:00.000Z"
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).toBeVisible();
+    await expect(requiredIndicator).toHaveText("*");
+  });
+
+  test("should NOT show required indicator when property is not required", async ({ mount }) => {
+    const property = createProperty({ required: false });
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-11-11T10:30:00.000Z"
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).not.toBeVisible();
+  });
+
+  test("should show description when provided", async ({ mount }) => {
+    const property = createProperty({ description: "Creation timestamp" });
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-11-11T10:30:00.000Z"
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).toBeVisible();
+    await expect(description).toHaveText("Creation timestamp");
+  });
+
+  test("should NOT show description when not provided", async ({ mount }) => {
+    const property = createProperty({ description: undefined });
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-11-11T10:30:00.000Z"
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).not.toBeVisible();
+  });
+
+  test("should have property-editor-timestamp-field class", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-11-11T10:30:00.000Z"
+      />,
+    );
+
+    await expect(component).toHaveClass(/property-editor-timestamp-field/);
+  });
+
+  test("should format date-only timestamp correctly", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-01-15T00:00:00.000Z"
+      />,
+    );
+
+    const display = component.locator(".timestamp-display");
+    const text = await display.textContent();
+
+    // Should contain date components
+    expect(text).toContain("2024");
+    expect(text).not.toBe("Not set");
+  });
+
+  test("should handle ISO date without time", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-06-15"
+      />,
+    );
+
+    const display = component.locator(".timestamp-display");
+    const text = await display.textContent();
+
+    // Should parse and display the date
+    expect(text).toContain("2024");
+    expect(text).not.toBe("Not set");
+  });
+
+  test("should be read-only display (no input elements)", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <TimestampField
+        property={property}
+        value="2024-11-11T10:30:00.000Z"
+      />,
+    );
+
+    // TimestampField is read-only, so no input elements should exist
+    const input = component.locator("input");
+    await expect(input).not.toBeVisible();
+
+    const select = component.locator("select");
+    await expect(select).not.toBeVisible();
+  });
+});

--- a/packages/obsidian-plugin/tests/component/property-editor/fields/WikiLinkField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/property-editor/fields/WikiLinkField.spec.tsx
@@ -1,0 +1,356 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { WikiLinkField } from "../../../../src/presentation/components/property-editor/fields/WikiLinkField";
+import type { PropertySchemaDefinition } from "../../../../src/domain/property-editor/PropertySchemas";
+
+const createProperty = (
+  overrides: Partial<PropertySchemaDefinition> = {},
+): PropertySchemaDefinition => ({
+  name: "ems__Effort_area",
+  type: "wikilink",
+  required: false,
+  label: "Area",
+  ...overrides,
+});
+
+test.describe("WikiLinkField Component", () => {
+  test("should render input with label and wikilink brackets", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    await expect(component).toBeVisible();
+
+    // Check for input
+    const input = component.locator("input[type='text']");
+    await expect(input).toBeVisible();
+
+    // Check for label
+    const label = component.locator("label.property-editor-label");
+    await expect(label).toHaveText("Area");
+
+    // Check for wikilink brackets
+    const prefix = component.locator(".wikilink-prefix");
+    await expect(prefix).toHaveText("[[");
+
+    const suffix = component.locator(".wikilink-suffix");
+    await expect(suffix).toHaveText("]]");
+  });
+
+  test("should display value without wikilink brackets", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value="[[ems__Area/Work]]"
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveValue("ems__Area/Work");
+  });
+
+  test("should strip quotes from value after removing brackets", async ({ mount }) => {
+    const property = createProperty();
+    // The regex in the component removes [[ and ]] first, then quotes
+    // For value "[[value]]" with outer quotes: first regex removes [[ and ]] -> "value"
+    // Then second regex removes outer quotes -> value
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value={'"ems__Area/Personal"'}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    // After removing brackets (none) and quotes, we get: ems__Area/Personal
+    await expect(input).toHaveValue("ems__Area/Personal");
+  });
+
+  test("should call onChange with wikilink-wrapped value", async ({ mount }) => {
+    let changedValue: string | undefined;
+    const onChange = (value: string) => {
+      changedValue = value;
+    };
+    const property = createProperty();
+
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={onChange}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await input.fill("NewArea");
+
+    await expect.poll(() => changedValue).toBe("[[NewArea]]");
+  });
+
+  test("should NOT double-wrap if value already starts with [[", async ({ mount }) => {
+    let changedValue: string | undefined;
+    const onChange = (value: string) => {
+      changedValue = value;
+    };
+    const property = createProperty();
+
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={onChange}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await input.fill("[[AlreadyWrapped]]");
+
+    await expect.poll(() => changedValue).toBe("[[AlreadyWrapped]]");
+  });
+
+  test("should allow empty value", async ({ mount }) => {
+    let changedValue: string | undefined;
+    const onChange = (value: string) => {
+      changedValue = value;
+    };
+    const property = createProperty();
+
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value="[[SomeValue]]"
+        onChange={onChange}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await input.clear();
+
+    // Empty value should be passed through
+    await expect.poll(() => changedValue).toBe("");
+  });
+
+  test("should show required indicator when property is required", async ({ mount }) => {
+    const property = createProperty({ required: true });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).toBeVisible();
+    await expect(requiredIndicator).toHaveText("*");
+  });
+
+  test("should NOT show required indicator when property is not required", async ({ mount }) => {
+    const property = createProperty({ required: false });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const requiredIndicator = component.locator(".required-indicator");
+    await expect(requiredIndicator).not.toBeVisible();
+  });
+
+  test("should show description when provided", async ({ mount }) => {
+    const property = createProperty({ description: "Parent area" });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).toBeVisible();
+    await expect(description).toHaveText("Parent area");
+  });
+
+  test("should NOT show description when not provided", async ({ mount }) => {
+    const property = createProperty({ description: undefined });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const description = component.locator(".property-editor-description");
+    await expect(description).not.toBeVisible();
+  });
+
+  test("should show error message when error is provided", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+        error="Invalid link reference"
+      />,
+    );
+
+    const errorMessage = component.locator(".property-editor-error");
+    await expect(errorMessage).toBeVisible();
+    await expect(errorMessage).toHaveText("Invalid link reference");
+  });
+
+  test("should apply has-error class when error is provided", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+        error="Error"
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveClass(/has-error/);
+  });
+
+  test("should disable input when property is readOnly", async ({ mount }) => {
+    const property = createProperty({ readOnly: true });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value="[[SomeArea]]"
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toBeDisabled();
+  });
+
+  test("should enable input when property is not readOnly", async ({ mount }) => {
+    const property = createProperty({ readOnly: false });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toBeEnabled();
+  });
+
+  test("should show filter hint when filter is provided", async ({ mount }) => {
+    const property = createProperty({ filter: ["ems__Area"] });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const hint = component.locator(".property-editor-hint");
+    await expect(hint).toBeVisible();
+    await expect(hint).toHaveText("Accepts: ems__Area");
+  });
+
+  test("should show multiple filters in hint", async ({ mount }) => {
+    const property = createProperty({ filter: ["ems__Project", "ems__Initiative"] });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const hint = component.locator(".property-editor-hint");
+    await expect(hint).toBeVisible();
+    await expect(hint).toHaveText("Accepts: ems__Project, ems__Initiative");
+  });
+
+  test("should NOT show filter hint when filter is empty", async ({ mount }) => {
+    const property = createProperty({ filter: [] });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const hint = component.locator(".property-editor-hint");
+    await expect(hint).not.toBeVisible();
+  });
+
+  test("should NOT show filter hint when filter is not provided", async ({ mount }) => {
+    const property = createProperty({ filter: undefined });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const hint = component.locator(".property-editor-hint");
+    await expect(hint).not.toBeVisible();
+  });
+
+  test("should use lowercase label as placeholder", async ({ mount }) => {
+    const property = createProperty({ label: "Parent Area" });
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveAttribute("placeholder", "Enter parent area");
+  });
+
+  test("should have wikilink-input class on input", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveClass(/wikilink-input/);
+  });
+
+  test("should display empty when value is null", async ({ mount }) => {
+    const property = createProperty();
+    const component = await mount(
+      <WikiLinkField
+        property={property}
+        value={null as unknown as string}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = component.locator("input[type='text']");
+    await expect(input).toHaveValue("");
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive component tests for the property editor field components. This completes the test coverage for property editing functionality.

### New Tests (101 total)

| Component | Tests | Coverage |
|-----------|-------|----------|
| BooleanField | 16 | Checkbox behavior, string value conversion ("true"/"yes"), required indicator, description, error state, readOnly |
| NumberField | 18 | Numeric input, string-to-number parsing, min/max attributes, empty input (returns 0), NaN handling |
| SelectField | 17 | Status/size dropdown options, "Not specified" option, option text/values, quote normalization |
| TextField | 15 | Text input, onChange behavior, placeholder, error state, readOnly |
| TimestampField | 13 | Timestamp formatting, "Not set" for empty, "Invalid Date" for invalid, read-only display |
| WikiLinkField | 22 | Wikilink brackets display, value stripping, auto-wrapping on input, filter hints |

### Key Test Patterns

- Used `toBeAttached()` for select options (instead of `toBeVisible()`)
- Used `click()` for checkbox toggle (instead of `check()`/`uncheck()`)
- Tested both required and optional property schemas
- Verified error states and CSS classes

## Test Plan

- [x] All 101 new tests pass locally
- [x] Unit tests pass (342 tests)
- [x] Component tests pass (479 tests)
- [ ] CI pipeline passes

Closes #619