### PR TITLE
fix(sparql): Fix Instance_class literal matching inconsistency

### DIFF
--- a/packages/core/src/domain/models/rdf/Literal.ts
+++ b/packages/core/src/domain/models/rdf/Literal.ts
@@ -1,5 +1,8 @@
 import { IRI } from "./IRI";
 
+/** XSD string datatype URI for RDF 1.1 compatibility */
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
 export class Literal {
   private readonly _value: string;
   private readonly _datatype?: IRI;
@@ -31,24 +34,50 @@ export class Literal {
     return this._language;
   }
 
+  /**
+   * Check if this literal equals another literal.
+   *
+   * Per RDF 1.1 semantics, plain literals (no datatype) are equivalent to
+   * xsd:string typed literals. This method treats them as equal.
+   *
+   * @see https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
+   */
   equals(other: Literal): boolean {
     if (this._value !== other._value) {
       return false;
     }
 
-    if (this._datatype && other._datatype) {
-      if (!this._datatype.equals(other._datatype)) {
-        return false;
-      }
-    } else if (this._datatype || other._datatype) {
-      return false;
-    }
-
+    // Language-tagged literals must match exactly
     if (this._language !== other._language) {
       return false;
     }
 
-    return true;
+    // Handle datatype comparison with RDF 1.1 xsd:string equivalence
+    const thisDatatype = this.normalizedDatatype();
+    const otherDatatype = other.normalizedDatatype();
+
+    if (thisDatatype && otherDatatype) {
+      return thisDatatype === otherDatatype;
+    }
+
+    // Both are null (plain literal or xsd:string) = equal
+    return thisDatatype === otherDatatype;
+  }
+
+  /**
+   * Get normalized datatype for equality comparison.
+   * Returns null for plain literals and xsd:string (they are equivalent).
+   * Returns the datatype URI string for other typed literals.
+   */
+  private normalizedDatatype(): string | null {
+    if (!this._datatype) {
+      return null;
+    }
+    // Treat xsd:string as equivalent to plain literal (no datatype)
+    if (this._datatype.value === XSD_STRING) {
+      return null;
+    }
+    return this._datatype.value;
   }
 
   toString(): string {

--- a/packages/core/tests/unit/domain/rdf/Literal.test.ts
+++ b/packages/core/tests/unit/domain/rdf/Literal.test.ts
@@ -64,10 +64,35 @@ describe("Literal", () => {
 
     it("should return false for same value but different datatypes", () => {
       const dt1 = new IRI("http://www.w3.org/2001/XMLSchema#integer");
-      const dt2 = new IRI("http://www.w3.org/2001/XMLSchema#string");
+      const dt2 = new IRI("http://www.w3.org/2001/XMLSchema#decimal");
       const lit1 = new Literal("42", dt1);
       const lit2 = new Literal("42", dt2);
       expect(lit1.equals(lit2)).toBe(false);
+    });
+
+    // RDF 1.1 semantics: plain literals and xsd:string literals are equivalent
+    // https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
+    it("should treat plain literal as equal to xsd:string literal (RDF 1.1)", () => {
+      const xsdString = new IRI("http://www.w3.org/2001/XMLSchema#string");
+      const plain = new Literal("test");
+      const typed = new Literal("test", xsdString);
+      expect(plain.equals(typed)).toBe(true);
+      expect(typed.equals(plain)).toBe(true);
+    });
+
+    it("should treat two xsd:string literals as equal", () => {
+      const xsdString = new IRI("http://www.w3.org/2001/XMLSchema#string");
+      const lit1 = new Literal("test", xsdString);
+      const lit2 = new Literal("test", xsdString);
+      expect(lit1.equals(lit2)).toBe(true);
+    });
+
+    it("should not treat xsd:string as equal to other datatypes", () => {
+      const xsdString = new IRI("http://www.w3.org/2001/XMLSchema#string");
+      const xsdInteger = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+      const stringLit = new Literal("42", xsdString);
+      const integerLit = new Literal("42", xsdInteger);
+      expect(stringLit.equals(integerLit)).toBe(false);
     });
 
     it("should return true for literals with same language", () => {


### PR DESCRIPTION
## Summary

Fixes #613 - SPARQL queries with literal matching (like `?s exo:Instance_class '[[ems__Task]]'`) now work correctly.

## Problem

Per RDF 1.1 semantics, plain literals (no datatype) are semantically equivalent to `xsd:string` typed literals. The issue was:

- Data is stored as plain literals (no datatype): `new Literal("[[ems__Task]]")`
- SPARQL parser creates `xsd:string` typed literals from `'...'` syntax
- Triple store keys didn't match due to different datatype serialization

## Solution

Implemented RDF 1.1 `xsd:string` equivalence in:

1. **`InMemoryTripleStore.getNodeKey()`**: Normalize `xsd:string` literals to plain literals in the key generation. This ensures matching works correctly.

2. **`Literal.equals()`**: Treat `xsd:string` as equivalent to no datatype (plain literal) for proper comparison semantics.

## Changes

- `packages/core/src/domain/models/rdf/Literal.ts` - Added RDF 1.1 xsd:string equivalence in `equals()`
- `packages/core/src/infrastructure/rdf/InMemoryTripleStore.ts` - Normalize xsd:string in `getNodeKey()`
- Added 7 new tests for RDF 1.1 literal equivalence

## Test Plan

- [x] `Literal.equals()` treats plain literal and xsd:string literal as equal
- [x] `InMemoryTripleStore.match()` finds plain literal when querying with xsd:string
- [x] `InMemoryTripleStore.match()` finds xsd:string literal when querying with plain literal
- [x] `BGPExecutor` matches xsd:string literal against plain literal
- [x] Other datatypes (xsd:integer, etc.) are NOT treated as equivalent
- [x] All existing tests pass
- [x] TypeScript type check passes
- [x] Lint passes (only existing warnings)