### PR TITLE
fix: add PROJECT_PROTOTYPE to Create Instance button visibility

### DIFF
--- a/packages/core/src/domain/commands/visibility/AssetVisibilityRules.ts
+++ b/packages/core/src/domain/commands/visibility/AssetVisibilityRules.ts
@@ -29,7 +29,7 @@ export function canCreateEvent(context: CommandVisibilityContext): boolean {
  * Available for: Any asset class that inherits from exo__Prototype
  *
  * This includes:
- * - Known prototype classes: ems__TaskPrototype, ems__MeetingPrototype, exo__EventPrototype
+ * - Known prototype classes: ems__TaskPrototype, ems__MeetingPrototype, exo__EventPrototype, ems__ProjectPrototype
  * - Any custom class with exo__Class_superClass pointing to exo__Prototype (directly or transitively)
  *
  * The check works in two modes:
@@ -41,7 +41,8 @@ export function canCreateInstance(context: CommandVisibilityContext): boolean {
   if (
     hasClass(context.instanceClass, AssetClass.TASK_PROTOTYPE) ||
     hasClass(context.instanceClass, AssetClass.MEETING_PROTOTYPE) ||
-    hasClass(context.instanceClass, AssetClass.EVENT_PROTOTYPE)
+    hasClass(context.instanceClass, AssetClass.EVENT_PROTOTYPE) ||
+    hasClass(context.instanceClass, AssetClass.PROJECT_PROTOTYPE)
   ) {
     return true;
   }

--- a/packages/core/src/domain/constants/AssetClass.ts
+++ b/packages/core/src/domain/constants/AssetClass.ts
@@ -7,6 +7,7 @@ export enum AssetClass {
   TASK_PROTOTYPE = "ems__TaskPrototype",
   MEETING_PROTOTYPE = "ems__MeetingPrototype",
   EVENT_PROTOTYPE = "exo__EventPrototype",
+  PROJECT_PROTOTYPE = "ems__ProjectPrototype",
   EVENT = "exo__Event",
   DAILY_NOTE = "pn__DailyNote",
   CONCEPT = "ims__Concept",

--- a/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.instance.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.instance.test.ts
@@ -116,6 +116,42 @@ describe("CommandVisibility - Instance/Subclass Commands", () => {
       expect(canCreateInstance(context)).toBe(true);
     });
 
+    it("should return true for ems__ProjectPrototype", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__ProjectPrototype]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateInstance(context)).toBe(true);
+    });
+
+    it("should return true for ProjectPrototype without brackets", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "ems__ProjectPrototype",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateInstance(context)).toBe(true);
+    });
+
+    it("should return true for array with ems__ProjectPrototype", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: ["[[ems__ProjectPrototype]]", "[[SomeOtherClass]]"],
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCreateInstance(context)).toBe(true);
+    });
+
     it("should return true for array with exo__EventPrototype", () => {
       const context: CommandVisibilityContext = {
         instanceClass: ["[[exo__EventPrototype]]", "[[SomeOtherClass]]"],


### PR DESCRIPTION
## Summary

The "Create Instance" button was not appearing for assets with `exo__Instance_class: ems__ProjectPrototype`. This was because `ems__ProjectPrototype` was missing from the known prototype types in the `canCreateInstance()` function.

### Root Cause

PR #643 implemented dynamic prototype detection via `exo__Class_superClass` for class **definitions** (assets with `exo__Instance_class: exo__Class`), but not for **instances** of those prototype classes.

For example:
- `ems__ProjectPrototype.md` (the class definition) → button shows ✅
- An asset with `exo__Instance_class: ems__ProjectPrototype` → button was NOT showing ❌

### Solution

Add `PROJECT_PROTOTYPE` to the list of known prototype types (alongside `TASK_PROTOTYPE`, `MEETING_PROTOTYPE`, `EVENT_PROTOTYPE`).

### Changes

- Add `PROJECT_PROTOTYPE = "ems__ProjectPrototype"` to `AssetClass` enum
- Add `PROJECT_PROTOTYPE` check to `canCreateInstance()` function
- Add 3 unit tests for `ems__ProjectPrototype` visibility

### Test Plan

- [x] Unit tests pass (3 new tests for ProjectPrototype)
- [x] Build succeeds
- [x] Type check passes
- [x] Lint passes (only pre-existing warnings)

### Related

- Follows up on PR #643 which implemented the inheritance-based detection
- GitHub Issue #641 (already closed, but this completes the fix)