### PR TITLE
feat: add exo__Asset_prototype property to created instances

### DIFF
--- a/packages/core/src/services/TaskFrontmatterGenerator.ts
+++ b/packages/core/src/services/TaskFrontmatterGenerator.ts
@@ -5,6 +5,7 @@ import { WikiLinkHelpers } from "../utilities/WikiLinkHelpers";
 import { MetadataExtractor } from "../utilities/MetadataExtractor";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
 import { AssetClass } from "../domain/constants";
+import { isPrototypeClass } from "../domain/commands/visibility/helpers";
 
 const EFFORT_PROPERTY_MAP: Record<string, string> = {
   [AssetClass.AREA]: "ems__Effort_area",
@@ -53,6 +54,10 @@ export class TaskFrontmatterGenerator {
 
     if (effortProperty) {
       frontmatter[effortProperty] = `"[[${sourceName}]]"`;
+    } else if (isPrototypeClass(sourceClass, sourceMetadata)) {
+      // For custom prototype classes that inherit from exo__Prototype,
+      // set exo__Asset_prototype to link instance back to its prototype
+      frontmatter["exo__Asset_prototype"] = `"[[${sourceName}]]"`;
     }
 
     let finalLabel = label;


### PR DESCRIPTION
## Summary

When creating instances from prototype classes that inherit from `exo__Prototype`, the created instance now includes an `exo__Asset_prototype` property linking back to the source prototype.

### Changes
- Modified `TaskFrontmatterGenerator` to detect custom prototype classes using `isPrototypeClass` helper
- For classes that inherit from `exo__Prototype` (directly or transitively), sets `exo__Asset_prototype` property in the created instance's frontmatter
- Added 3 unit tests covering:
  - Direct inheritance from `exo__Prototype`
  - Transitive inheritance (custom_class → base_prototype → exo__Prototype)
  - Non-prototype classes should NOT get `exo__Asset_prototype`

### Example

**Before (issue #645)**: Creating instance from custom prototype:
```yaml
---
exo__Instance_class: "[[ems__Task]]"
ems__Effort_status: "[[ems__EffortStatusDraft]]"
---
```

**After**: Created instance now includes prototype reference:
```yaml
---
exo__Instance_class: "[[ems__Task]]"
ems__Effort_status: "[[ems__EffortStatusDraft]]"
exo__Asset_prototype: "[[Morning Routine]]"  # NEW!
---
```

This enables:
- Querying all instances of a specific prototype via SPARQL
- Understanding provenance of instances
- Future features like "Show all instances" on prototype notes

## Test plan
- [x] Unit tests pass for new functionality
- [x] Existing tests continue to pass
- [x] TypeScript compiles without errors
- [x] Build succeeds

Closes #648