### PR TITLE
fix: add PROJECT_PROTOTYPE to EFFORT_PROPERTY_MAP - exo__Asset_prototype not set on instances

### DIFF
--- a/packages/core/src/services/TaskFrontmatterGenerator.ts
+++ b/packages/core/src/services/TaskFrontmatterGenerator.ts
@@ -13,6 +13,7 @@ const EFFORT_PROPERTY_MAP: Record<string, string> = {
   [AssetClass.TASK_PROTOTYPE]: "exo__Asset_prototype",
   [AssetClass.MEETING_PROTOTYPE]: "exo__Asset_prototype",
   [AssetClass.EVENT_PROTOTYPE]: "exo__Asset_prototype",
+  [AssetClass.PROJECT_PROTOTYPE]: "exo__Asset_prototype",
 };
 
 const INSTANCE_CLASS_MAP: Record<string, string> = {
@@ -21,6 +22,7 @@ const INSTANCE_CLASS_MAP: Record<string, string> = {
   [AssetClass.TASK_PROTOTYPE]: AssetClass.TASK,
   [AssetClass.MEETING_PROTOTYPE]: AssetClass.MEETING,
   [AssetClass.EVENT_PROTOTYPE]: AssetClass.EVENT,
+  [AssetClass.PROJECT_PROTOTYPE]: AssetClass.PROJECT,
 };
 
 @injectable()

--- a/packages/obsidian-plugin/tests/unit/TaskCreationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/TaskCreationService.test.ts
@@ -375,6 +375,26 @@ describe("TaskCreationService", () => {
       );
     });
 
+    it("should create ems__Project instance from ProjectPrototype with exo__Asset_prototype", () => {
+      const sourceMetadata = {
+        exo__Asset_isDefinedBy: '"[[!toos]]"',
+      };
+
+      const frontmatter = service.generateTaskFrontmatter(
+        sourceMetadata,
+        "Sprint Template",
+        "ems__ProjectPrototype",
+        "Sprint Q1 2025",
+      );
+
+      expect(frontmatter.exo__Instance_class).toEqual(['"[[ems__Project]]"']);
+      expect(frontmatter.exo__Asset_prototype).toBe('"[[Sprint Template]]"');
+      expect(frontmatter.exo__Asset_label).toBe("Sprint Q1 2025");
+      expect(frontmatter.ems__Effort_status).toBe(
+        '"[[ems__EffortStatusDraft]]"',
+      );
+    });
+
     it("should auto-generate label from exo__Asset_label + date for ems__Meeting when no label provided", () => {
       const sourceMetadata = {
         exo__Asset_isDefinedBy: '"[[!toos]]"',


### PR DESCRIPTION
## Summary
- Add missing `ems__ProjectPrototype` mapping to `EFFORT_PROPERTY_MAP` (sets `exo__Asset_prototype`)
- Add missing `ems__ProjectPrototype` mapping to `INSTANCE_CLASS_MAP` (creates `ems__Project` instances)
- Add unit test covering PROJECT_PROTOTYPE → Project instance creation

## Problem
When users create instances from ProjectPrototype assets, the `exo__Asset_prototype` field was not being set in frontmatter because `PROJECT_PROTOTYPE` was missing from both mapping constants in `TaskFrontmatterGenerator.ts`.

## Solution
Added `PROJECT_PROTOTYPE` entries to both maps, consistent with existing TASK_PROTOTYPE, MEETING_PROTOTYPE, and EVENT_PROTOTYPE mappings.

## Test plan
- [x] Added unit test for ProjectPrototype → Project instance creation
- [x] Verified all existing tests pass (342 unit tests, 505 component tests)

Closes #650