### PR TITLE
feat: Create DynamicFrontmatterGenerator for generating frontmatter from property values

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,11 @@ export { StatusTimestampService } from "./services/StatusTimestampService";
 export { SupervisionCreationService } from "./services/SupervisionCreationService";
 export { FleetingNoteCreationService } from "./services/FleetingNoteCreationService";
 export { TaskFrontmatterGenerator } from "./services/TaskFrontmatterGenerator";
+export {
+  DynamicFrontmatterGenerator,
+  type PropertyFieldType,
+  type PropertyDefinition,
+} from "./services/DynamicFrontmatterGenerator";
 export { AlgorithmExtractor } from "./services/AlgorithmExtractor";
 export { PlanningService } from "./services/PlanningService";
 export { AssetConversionService } from "./services/AssetConversionService";

--- a/packages/core/src/infrastructure/container.ts
+++ b/packages/core/src/infrastructure/container.ts
@@ -5,6 +5,7 @@ import { DI_TOKENS } from "../interfaces/tokens";
 // Import all services
 import { TaskCreationService } from "../services/TaskCreationService";
 import { TaskFrontmatterGenerator } from "../services/TaskFrontmatterGenerator";
+import { DynamicFrontmatterGenerator } from "../services/DynamicFrontmatterGenerator";
 import { AlgorithmExtractor } from "../services/AlgorithmExtractor";
 import { PropertyCleanupService } from "../services/PropertyCleanupService";
 import { ProjectCreationService } from "../services/ProjectCreationService";
@@ -42,6 +43,10 @@ export function registerCoreServices(
   targetContainer.registerSingleton(
     DI_TOKENS.TaskFrontmatterGenerator,
     TaskFrontmatterGenerator,
+  );
+  targetContainer.registerSingleton(
+    DI_TOKENS.DynamicFrontmatterGenerator,
+    DynamicFrontmatterGenerator,
   );
   targetContainer.registerSingleton(
     DI_TOKENS.AlgorithmExtractor,

--- a/packages/core/src/interfaces/tokens.ts
+++ b/packages/core/src/interfaces/tokens.ts
@@ -37,6 +37,7 @@ export const DI_TOKENS = {
 
   // Frontmatter services
   TaskFrontmatterGenerator: Symbol.for("TaskFrontmatterGenerator"),
+  DynamicFrontmatterGenerator: Symbol.for("DynamicFrontmatterGenerator"),
   AlgorithmExtractor: Symbol.for("AlgorithmExtractor"),
 
   // Status services

--- a/packages/core/src/services/DynamicFrontmatterGenerator.ts
+++ b/packages/core/src/services/DynamicFrontmatterGenerator.ts
@@ -1,0 +1,360 @@
+import { injectable } from "tsyringe";
+import { v4 as uuidv4 } from "uuid";
+import { DateFormatter } from "../utilities/DateFormatter";
+
+/**
+ * Property field type enumeration.
+ * Represents the different types of properties that can be set on an asset.
+ */
+export type PropertyFieldType =
+  | "text"
+  | "status-select"
+  | "size-select"
+  | "wikilink"
+  | "number"
+  | "boolean"
+  | "timestamp";
+
+/**
+ * Property definition for dynamic frontmatter generation.
+ * Describes a property's metadata including its type for proper formatting.
+ */
+export interface PropertyDefinition {
+  name: string;
+  type: PropertyFieldType;
+  required?: boolean;
+}
+
+/**
+ * DynamicFrontmatterGenerator
+ *
+ * Service that converts property values to properly formatted YAML frontmatter.
+ * Handles different data types with appropriate formatting:
+ * - Text: Quoted strings
+ * - Wikilink/Reference: `"[[assetName]]"` format
+ * - Number: Raw numeric values
+ * - Boolean: true/false
+ * - Timestamp: ISO 8601 format
+ * - Status/Size selects: Quoted wikilinks
+ *
+ * @example
+ * ```typescript
+ * const generator = new DynamicFrontmatterGenerator();
+ *
+ * const values = {
+ *   exo__Asset_label: "My Task",
+ *   ems__Effort_status: "[[ems__EffortStatusDraft]]",
+ *   ems__Effort_votes: 5,
+ *   exo__Asset_isArchived: false
+ * };
+ *
+ * const properties = [
+ *   { name: "exo__Asset_label", type: "text" },
+ *   { name: "ems__Effort_status", type: "status-select" },
+ *   { name: "ems__Effort_votes", type: "number" },
+ *   { name: "exo__Asset_isArchived", type: "boolean" }
+ * ];
+ *
+ * const frontmatter = generator.generate("ems__Task", values, properties);
+ * ```
+ */
+@injectable()
+export class DynamicFrontmatterGenerator {
+  /**
+   * Generate frontmatter object from property values.
+   *
+   * @param className - The class name of the asset being created (e.g., "ems__Task")
+   * @param values - Record of property names to their values
+   * @param properties - Array of property definitions with type information
+   * @param options - Optional configuration for frontmatter generation
+   * @returns Record<string, any> - Frontmatter object ready for YAML serialization
+   */
+  generate(
+    className: string,
+    values: Record<string, any>,
+    properties: PropertyDefinition[],
+    options?: {
+      /** Custom UID to use instead of generating a new one */
+      uid?: string;
+      /** Custom creation timestamp to use */
+      createdAt?: string;
+      /** isDefinedBy value for ontology reference */
+      isDefinedBy?: string;
+    },
+  ): Record<string, any> {
+    const frontmatter: Record<string, any> = {};
+    const now = new Date();
+
+    // Set required system properties
+    if (options?.isDefinedBy) {
+      frontmatter["exo__Asset_isDefinedBy"] = this.ensureQuoted(
+        options.isDefinedBy,
+      );
+    }
+    frontmatter["exo__Asset_uid"] = options?.uid || uuidv4();
+    frontmatter["exo__Asset_createdAt"] =
+      options?.createdAt || DateFormatter.toLocalTimestamp(now);
+    frontmatter["exo__Instance_class"] = [this.formatWikilink(className)];
+
+    // Create a map of property names to their types for quick lookup
+    const propertyTypeMap = new Map<string, PropertyFieldType>();
+    for (const prop of properties) {
+      propertyTypeMap.set(prop.name, prop.type);
+    }
+
+    // Process each value according to its property type
+    for (const [propertyName, value] of Object.entries(values)) {
+      // Skip null/undefined values
+      if (value === null || value === undefined) {
+        continue;
+      }
+
+      // Skip system properties that are already set
+      if (
+        propertyName === "exo__Asset_uid" ||
+        propertyName === "exo__Asset_createdAt" ||
+        propertyName === "exo__Instance_class" ||
+        propertyName === "exo__Asset_isDefinedBy"
+      ) {
+        continue;
+      }
+
+      const propertyType = propertyTypeMap.get(propertyName);
+      frontmatter[propertyName] = this.formatValue(value, propertyType);
+    }
+
+    // Handle aliases if label is provided
+    const label = values["exo__Asset_label"];
+    if (label && typeof label === "string" && label.trim() !== "") {
+      const trimmedLabel = label.trim();
+      frontmatter["exo__Asset_label"] = trimmedLabel;
+      frontmatter["aliases"] = [trimmedLabel];
+    }
+
+    return frontmatter;
+  }
+
+  /**
+   * Format a single value according to its property type.
+   *
+   * @param value - The value to format
+   * @param type - The property type (optional, defaults to text)
+   * @returns Formatted value for YAML frontmatter
+   */
+  formatValue(value: any, type?: PropertyFieldType): any {
+    // Handle empty/null values
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    // If type is not specified, infer from value
+    if (!type) {
+      return this.formatInferredValue(value);
+    }
+
+    switch (type) {
+      case "text":
+        return this.formatText(value);
+
+      case "wikilink":
+        return this.formatWikilink(value);
+
+      case "status-select":
+      case "size-select":
+        // These are wikilinks that should be quoted
+        return this.formatWikilink(value);
+
+      case "number":
+        return this.formatNumber(value);
+
+      case "boolean":
+        return this.formatBoolean(value);
+
+      case "timestamp":
+        return this.formatTimestamp(value);
+
+      default:
+        // Unknown type, treat as text
+        return this.formatText(value);
+    }
+  }
+
+  /**
+   * Format a text value as a string.
+   * Numbers and booleans are converted to strings for text fields.
+   */
+  private formatText(value: any): string {
+    if (typeof value === "string") {
+      return value;
+    }
+    return String(value);
+  }
+
+  /**
+   * Format a value as a wikilink.
+   * Ensures the value is in `"[[assetName]]"` format.
+   *
+   * @param value - The value to format as wikilink
+   * @returns Quoted wikilink string
+   */
+  private formatWikilink(value: any): string {
+    const strValue = String(value);
+
+    // Already in quoted wikilink format
+    if (strValue.startsWith('"[[') && strValue.endsWith(']]"')) {
+      return strValue;
+    }
+
+    // Already in wikilink format, just quote it
+    if (strValue.startsWith("[[") && strValue.endsWith("]]")) {
+      return `"${strValue}"`;
+    }
+
+    // Raw value, wrap in wikilink and quote
+    return `"[[${strValue}]]"`;
+  }
+
+  /**
+   * Format a value as a number.
+   * Parses strings to numbers, returns 0 for invalid values.
+   */
+  private formatNumber(value: any): number {
+    if (typeof value === "number") {
+      return value;
+    }
+    const parsed = Number(value);
+    return isNaN(parsed) ? 0 : parsed;
+  }
+
+  /**
+   * Format a value as a boolean.
+   * Handles various truthy/falsy representations.
+   */
+  private formatBoolean(value: any): boolean {
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "string") {
+      const normalized = value.toLowerCase().trim();
+      return normalized === "true" || normalized === "yes" || normalized === "1";
+    }
+    if (typeof value === "number") {
+      return value !== 0;
+    }
+    return Boolean(value);
+  }
+
+  /**
+   * Format a value as an ISO 8601 timestamp.
+   * Handles Date objects, ISO strings, and timestamps.
+   *
+   * @param value - Date, string, or number to format
+   * @returns ISO 8601 timestamp string (YYYY-MM-DDTHH:mm:ss)
+   */
+  private formatTimestamp(value: any): string {
+    if (value instanceof Date) {
+      return DateFormatter.toLocalTimestamp(value);
+    }
+
+    if (typeof value === "string") {
+      // If already in local timestamp format, return as-is
+      if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) {
+        return value;
+      }
+      // If in ISO UTC format, convert to local format
+      if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(value)) {
+        return value.replace("Z", "");
+      }
+      // Try to parse as date
+      const date = new Date(value);
+      if (!isNaN(date.getTime())) {
+        return DateFormatter.toLocalTimestamp(date);
+      }
+      return value;
+    }
+
+    if (typeof value === "number") {
+      const date = new Date(value);
+      if (!isNaN(date.getTime())) {
+        return DateFormatter.toLocalTimestamp(date);
+      }
+    }
+
+    return String(value);
+  }
+
+  /**
+   * Format a value with inferred type when no type is specified.
+   */
+  private formatInferredValue(value: any): any {
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "number") {
+      return value;
+    }
+    if (value instanceof Date) {
+      return DateFormatter.toLocalTimestamp(value);
+    }
+    if (typeof value === "string") {
+      // Check if it looks like a wikilink
+      if (value.startsWith("[[") || value.startsWith('"[[')) {
+        return this.formatWikilink(value);
+      }
+      return value;
+    }
+    return String(value);
+  }
+
+  /**
+   * Ensure a string value is quoted for YAML.
+   * Used for string values that need explicit quoting.
+   */
+  private ensureQuoted(value: string): string {
+    if (!value || value === '""') return '""';
+    if (value.startsWith('"') && value.endsWith('"')) return value;
+    return `"${value}"`;
+  }
+
+  /**
+   * Generate frontmatter content as a YAML string.
+   * Convenience method that combines generation and serialization.
+   *
+   * @param className - The class name of the asset
+   * @param values - Record of property names to their values
+   * @param properties - Array of property definitions
+   * @param options - Optional configuration
+   * @returns YAML frontmatter string with --- delimiters
+   */
+  generateYAML(
+    className: string,
+    values: Record<string, any>,
+    properties: PropertyDefinition[],
+    options?: {
+      uid?: string;
+      createdAt?: string;
+      isDefinedBy?: string;
+    },
+  ): string {
+    const frontmatter = this.generate(className, values, properties, options);
+    return this.toYAML(frontmatter);
+  }
+
+  /**
+   * Convert a frontmatter object to YAML string format.
+   *
+   * @param frontmatter - The frontmatter object
+   * @returns YAML string with --- delimiters
+   */
+  private toYAML(frontmatter: Record<string, any>): string {
+    const lines = Object.entries(frontmatter).map(([key, value]) => {
+      if (Array.isArray(value)) {
+        const arrayItems = value.map((item) => `  - ${item}`).join("\n");
+        return `${key}:\n${arrayItems}`;
+      }
+      return `${key}: ${value}`;
+    });
+
+    return `---\n${lines.join("\n")}\n---`;
+  }
+}

--- a/packages/core/tests/services/DynamicFrontmatterGenerator.test.ts
+++ b/packages/core/tests/services/DynamicFrontmatterGenerator.test.ts
@@ -1,0 +1,575 @@
+import { DynamicFrontmatterGenerator, PropertyDefinition, PropertyFieldType } from "../../src/services/DynamicFrontmatterGenerator";
+import { DateFormatter } from "../../src/utilities/DateFormatter";
+
+describe("DynamicFrontmatterGenerator", () => {
+  let generator: DynamicFrontmatterGenerator;
+
+  beforeEach(() => {
+    generator = new DynamicFrontmatterGenerator();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-12-07T10:30:00"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("generate", () => {
+    describe("system properties", () => {
+      it("should generate frontmatter with required system properties", () => {
+        const properties: PropertyDefinition[] = [];
+        const values = {};
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_uid"]).toBeDefined();
+        expect(result["exo__Asset_createdAt"]).toBe("2025-12-07T10:30:00");
+        expect(result["exo__Instance_class"]).toEqual(['"[[ems__Task]]"']);
+      });
+
+      it("should use provided uid", () => {
+        const customUid = "custom-uuid-1234";
+        const result = generator.generate("ems__Task", {}, [], { uid: customUid });
+
+        expect(result["exo__Asset_uid"]).toBe(customUid);
+      });
+
+      it("should use provided createdAt", () => {
+        const customTimestamp = "2025-01-01T00:00:00";
+        const result = generator.generate("ems__Task", {}, [], { createdAt: customTimestamp });
+
+        expect(result["exo__Asset_createdAt"]).toBe(customTimestamp);
+      });
+
+      it("should set isDefinedBy when provided", () => {
+        const result = generator.generate("ems__Task", {}, [], {
+          isDefinedBy: "[[exo]]",
+        });
+
+        expect(result["exo__Asset_isDefinedBy"]).toBe('"[[exo]]"');
+      });
+
+      it("should quote isDefinedBy if not already quoted", () => {
+        const result = generator.generate("ems__Task", {}, [], {
+          isDefinedBy: "exo",
+        });
+
+        expect(result["exo__Asset_isDefinedBy"]).toBe('"exo"');
+      });
+    });
+
+    describe("text properties", () => {
+      it("should handle text property", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_label", type: "text" },
+        ];
+        const values = { exo__Asset_label: "My Task Label" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_label"]).toBe("My Task Label");
+      });
+
+      it("should convert number to string for text property", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "description", type: "text" },
+        ];
+        const values = { description: 12345 };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["description"]).toBe("12345");
+      });
+
+      it("should create aliases from label", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_label", type: "text" },
+        ];
+        const values = { exo__Asset_label: "Task Name" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_label"]).toBe("Task Name");
+        expect(result["aliases"]).toEqual(["Task Name"]);
+      });
+
+      it("should trim label and aliases", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_label", type: "text" },
+        ];
+        const values = { exo__Asset_label: "  Task Name  " };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_label"]).toBe("Task Name");
+        expect(result["aliases"]).toEqual(["Task Name"]);
+      });
+
+      it("should not set aliases if label is empty", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_label", type: "text" },
+        ];
+        const values = { exo__Asset_label: "   " };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_label"]).toBeUndefined();
+        expect(result["aliases"]).toBeUndefined();
+      });
+    });
+
+    describe("wikilink properties", () => {
+      it("should format raw value as wikilink", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_area", type: "wikilink" },
+        ];
+        const values = { ems__Effort_area: "Work" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_area"]).toBe('"[[Work]]"');
+      });
+
+      it("should quote wikilink that is already in [[]] format", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_area", type: "wikilink" },
+        ];
+        const values = { ems__Effort_area: "[[Work]]" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_area"]).toBe('"[[Work]]"');
+      });
+
+      it("should not double-quote already quoted wikilink", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_area", type: "wikilink" },
+        ];
+        const values = { ems__Effort_area: '"[[Work]]"' };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_area"]).toBe('"[[Work]]"');
+      });
+    });
+
+    describe("status-select properties", () => {
+      it("should format status-select as wikilink", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_status", type: "status-select" },
+        ];
+        const values = { ems__Effort_status: "ems__EffortStatusDraft" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_status"]).toBe('"[[ems__EffortStatusDraft]]"');
+      });
+
+      it("should handle status-select already in wikilink format", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_status", type: "status-select" },
+        ];
+        const values = { ems__Effort_status: "[[ems__EffortStatusDoing]]" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_status"]).toBe('"[[ems__EffortStatusDoing]]"');
+      });
+    });
+
+    describe("size-select properties", () => {
+      it("should format size-select as wikilink", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Task_size", type: "size-select" },
+        ];
+        const values = { ems__Task_size: "ems__TaskSize_M" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Task_size"]).toBe('"[[ems__TaskSize_M]]"');
+      });
+    });
+
+    describe("number properties", () => {
+      it("should preserve number value", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_votes", type: "number" },
+        ];
+        const values = { ems__Effort_votes: 5 };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_votes"]).toBe(5);
+      });
+
+      it("should parse string to number", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_votes", type: "number" },
+        ];
+        const values = { ems__Effort_votes: "10" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_votes"]).toBe(10);
+      });
+
+      it("should return 0 for invalid number", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_votes", type: "number" },
+        ];
+        const values = { ems__Effort_votes: "invalid" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_votes"]).toBe(0);
+      });
+
+      it("should handle negative numbers", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "score", type: "number" },
+        ];
+        const values = { score: -5 };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["score"]).toBe(-5);
+      });
+
+      it("should handle decimal numbers", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "rating", type: "number" },
+        ];
+        const values = { rating: 3.5 };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["rating"]).toBe(3.5);
+      });
+    });
+
+    describe("boolean properties", () => {
+      it("should preserve boolean true", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_isArchived", type: "boolean" },
+        ];
+        const values = { exo__Asset_isArchived: true };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_isArchived"]).toBe(true);
+      });
+
+      it("should preserve boolean false", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_isArchived", type: "boolean" },
+        ];
+        const values = { exo__Asset_isArchived: false };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_isArchived"]).toBe(false);
+      });
+
+      it("should parse string 'true' to boolean", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_isArchived", type: "boolean" },
+        ];
+        const values = { exo__Asset_isArchived: "true" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_isArchived"]).toBe(true);
+      });
+
+      it("should parse string 'false' to boolean", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_isArchived", type: "boolean" },
+        ];
+        const values = { exo__Asset_isArchived: "false" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_isArchived"]).toBe(false);
+      });
+
+      it("should parse string 'yes' to boolean true", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "active", type: "boolean" },
+        ];
+        const values = { active: "yes" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["active"]).toBe(true);
+      });
+
+      it("should parse string '1' to boolean true", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "enabled", type: "boolean" },
+        ];
+        const values = { enabled: "1" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["enabled"]).toBe(true);
+      });
+
+      it("should parse number 1 to boolean true", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "enabled", type: "boolean" },
+        ];
+        const values = { enabled: 1 };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["enabled"]).toBe(true);
+      });
+
+      it("should parse number 0 to boolean false", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "enabled", type: "boolean" },
+        ];
+        const values = { enabled: 0 };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["enabled"]).toBe(false);
+      });
+    });
+
+    describe("timestamp properties", () => {
+      it("should format Date object as timestamp", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_startTimestamp", type: "timestamp" },
+        ];
+        const values = { ems__Effort_startTimestamp: new Date("2025-06-15T14:30:00") };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_startTimestamp"]).toBe("2025-06-15T14:30:00");
+      });
+
+      it("should preserve local timestamp string", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "ems__Effort_endTimestamp", type: "timestamp" },
+        ];
+        const values = { ems__Effort_endTimestamp: "2025-06-15T18:00:00" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["ems__Effort_endTimestamp"]).toBe("2025-06-15T18:00:00");
+      });
+
+      it("should convert UTC timestamp to local format", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "timestamp", type: "timestamp" },
+        ];
+        const values = { timestamp: "2025-06-15T14:30:00Z" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["timestamp"]).toBe("2025-06-15T14:30:00");
+      });
+
+      it("should parse numeric timestamp", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "timestamp", type: "timestamp" },
+        ];
+        const values = { timestamp: new Date("2025-06-15T14:30:00").getTime() };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["timestamp"]).toBe("2025-06-15T14:30:00");
+      });
+    });
+
+    describe("null and undefined values", () => {
+      it("should skip null values", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "description", type: "text" },
+        ];
+        const values = { description: null };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["description"]).toBeUndefined();
+      });
+
+      it("should skip undefined values", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "description", type: "text" },
+        ];
+        const values = { description: undefined };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["description"]).toBeUndefined();
+      });
+    });
+
+    describe("values without property definition", () => {
+      it("should infer type for string value", () => {
+        const properties: PropertyDefinition[] = [];
+        const values = { custom_field: "some text" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["custom_field"]).toBe("some text");
+      });
+
+      it("should infer type for number value", () => {
+        const properties: PropertyDefinition[] = [];
+        const values = { custom_number: 42 };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["custom_number"]).toBe(42);
+      });
+
+      it("should infer type for boolean value", () => {
+        const properties: PropertyDefinition[] = [];
+        const values = { custom_flag: true };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["custom_flag"]).toBe(true);
+      });
+
+      it("should infer wikilink type for [[]] value", () => {
+        const properties: PropertyDefinition[] = [];
+        const values = { custom_ref: "[[SomeAsset]]" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["custom_ref"]).toBe('"[[SomeAsset]]"');
+      });
+
+      it("should infer Date type", () => {
+        const properties: PropertyDefinition[] = [];
+        const values = { custom_date: new Date("2025-06-15T14:30:00") };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["custom_date"]).toBe("2025-06-15T14:30:00");
+      });
+    });
+
+    describe("system property protection", () => {
+      it("should not override uid from values", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_uid", type: "text" },
+        ];
+        const values = { exo__Asset_uid: "user-provided-uid" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        // System uid should be generated, not use user value
+        expect(result["exo__Asset_uid"]).toBeDefined();
+        expect(result["exo__Asset_uid"]).not.toBe("user-provided-uid");
+      });
+
+      it("should not override createdAt from values", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_createdAt", type: "timestamp" },
+        ];
+        const values = { exo__Asset_createdAt: "2020-01-01T00:00:00" };
+
+        const result = generator.generate("ems__Task", values, properties);
+
+        expect(result["exo__Asset_createdAt"]).toBe("2025-12-07T10:30:00");
+      });
+    });
+
+    describe("complex scenarios", () => {
+      it("should generate complete task frontmatter", () => {
+        const properties: PropertyDefinition[] = [
+          { name: "exo__Asset_label", type: "text" },
+          { name: "ems__Effort_status", type: "status-select" },
+          { name: "ems__Effort_area", type: "wikilink" },
+          { name: "ems__Task_size", type: "size-select" },
+          { name: "ems__Effort_votes", type: "number" },
+          { name: "exo__Asset_isArchived", type: "boolean" },
+        ];
+        const values = {
+          exo__Asset_label: "Complete Documentation",
+          ems__Effort_status: "[[ems__EffortStatusDoing]]",
+          ems__Effort_area: "Work",
+          ems__Task_size: "ems__TaskSize_L",
+          ems__Effort_votes: 3,
+          exo__Asset_isArchived: false,
+        };
+
+        const result = generator.generate("ems__Task", values, properties, {
+          isDefinedBy: "[[exo]]",
+        });
+
+        expect(result["exo__Asset_isDefinedBy"]).toBe('"[[exo]]"');
+        expect(result["exo__Asset_uid"]).toBeDefined();
+        expect(result["exo__Asset_createdAt"]).toBe("2025-12-07T10:30:00");
+        expect(result["exo__Instance_class"]).toEqual(['"[[ems__Task]]"']);
+        expect(result["exo__Asset_label"]).toBe("Complete Documentation");
+        expect(result["aliases"]).toEqual(["Complete Documentation"]);
+        expect(result["ems__Effort_status"]).toBe('"[[ems__EffortStatusDoing]]"');
+        expect(result["ems__Effort_area"]).toBe('"[[Work]]"');
+        expect(result["ems__Task_size"]).toBe('"[[ems__TaskSize_L]]"');
+        expect(result["ems__Effort_votes"]).toBe(3);
+        expect(result["exo__Asset_isArchived"]).toBe(false);
+      });
+    });
+  });
+
+  describe("formatValue", () => {
+    it("should return null for null value", () => {
+      const result = generator.formatValue(null, "text");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for undefined value", () => {
+      const result = generator.formatValue(undefined, "text");
+      expect(result).toBeNull();
+    });
+
+    it("should format text without explicit type", () => {
+      const result = generator.formatValue("hello", undefined);
+      expect(result).toBe("hello");
+    });
+
+    it("should handle unknown type as text", () => {
+      const result = generator.formatValue("value", "unknown-type" as PropertyFieldType);
+      expect(result).toBe("value");
+    });
+  });
+
+  describe("generateYAML", () => {
+    it("should generate YAML string with frontmatter delimiters", () => {
+      const properties: PropertyDefinition[] = [
+        { name: "exo__Asset_label", type: "text" },
+      ];
+      const values = { exo__Asset_label: "My Task" };
+
+      const result = generator.generateYAML("ems__Task", values, properties);
+
+      expect(result).toContain("---");
+      expect(result).toMatch(/^---\n/);
+      expect(result).toMatch(/\n---$/);
+      expect(result).toContain("exo__Asset_label: My Task");
+      expect(result).toContain("exo__Asset_uid:");
+      expect(result).toContain("exo__Asset_createdAt: 2025-12-07T10:30:00");
+      expect(result).toContain("exo__Instance_class:");
+    });
+
+    it("should format array properties correctly in YAML", () => {
+      const properties: PropertyDefinition[] = [
+        { name: "exo__Asset_label", type: "text" },
+      ];
+      const values = { exo__Asset_label: "Task Name" };
+
+      const result = generator.generateYAML("ems__Task", values, properties);
+
+      expect(result).toContain("exo__Instance_class:");
+      expect(result).toContain('  - "[[ems__Task]]"');
+      expect(result).toContain("aliases:");
+      expect(result).toContain("  - Task Name");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `DynamicFrontmatterGenerator` service that converts property values to properly formatted YAML frontmatter
- Handles all `PropertyFieldType` values (text, wikilink, status-select, size-select, number, boolean, timestamp)
- Includes DI registration with `DI_TOKENS.DynamicFrontmatterGenerator`
- Exports `PropertyFieldType` and `PropertyDefinition` types from `@exocortex/core`
- 44 comprehensive unit tests covering all property types and edge cases

## Test plan

- [x] All unit tests pass (44 new tests for DynamicFrontmatterGenerator)
- [x] Core package builds successfully
- [x] Component tests pass
- [x] No regressions in existing tests

Closes #658