### PR TITLE
fix: normalize Property_domain wiki-links to URI references

### DIFF
--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -160,6 +160,14 @@ export class NoteToRDFConverter {
         if (targetFile) {
           return this.notePathToIRI(targetFile.path);
         }
+        // If target file not found but wikilink is a class reference,
+        // expand to namespace URI (Issue #667, #668: normalize Instance_class/Property_domain)
+        if (this.isClassReference(wikilink)) {
+          const classIRI = this.expandClassValue(wikilink);
+          if (classIRI) {
+            return classIRI;
+          }
+        }
         return new Literal(cleanValue);
       }
 


### PR DESCRIPTION
## Summary

When `exo__Property_domain` (or `exo__Instance_class`) contains wiki-links like `[[ems__Effort]]`, the RDF indexer now correctly expands them to namespace URIs instead of storing them as literals when the target file is not found.

### Problem

Property path queries require URI for JOIN:
```sparql
# BROKEN - domain is sometimes literal
SELECT ?property WHERE {
  ?targetClass exo:Class_superClass* ?class .
  ?property exo:Property_domain ?class .  # FAILS when domain is literal
}
```

### Solution

The `NoteToRDFConverter.valueToRDFObject()` now checks if an unresolved wiki-link is a class reference (`ems__*` or `exo__*`) and expands it to a namespace URI:

```typescript
// Before: [[ems__Effort]] → Literal("[[ems__Effort]]")
// After:  [[ems__Effort]] → IRI(<https://exocortex.my/ontology/ems#Effort>)
```

### Changes

- **NoteToRDFConverter**: When wiki-link target not found, check if it's a class reference and expand to namespace URI
- **6 unit tests** covering:
  - `[[ems__*]]` class expansion
  - `[[exo__*]]` class expansion  
  - File-based fallback when file exists
  - Non-class literal preservation (e.g., `[[Development]]` stays literal)
  - Quoted wiki-link handling

## Test plan

- [x] Unit tests pass (40 tests in NoteToRDFConverter)
- [x] ClassPropertiesQuery integration tests pass (10 tests)
- [x] Build passes
- [ ] CI pipeline passes

Closes #668