### PR TITLE
refactor: normalize Property_domain from mixed formats to URI reference

### DIFF
--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -160,6 +160,15 @@ export class NoteToRDFConverter {
         if (targetFile) {
           return this.notePathToIRI(targetFile.path);
         }
+        // If wikilink target not found but looks like a class reference,
+        // expand to namespace IRI (e.g., [[ems__Effort]] → ems:Effort)
+        // This normalizes Property_domain values for property path queries
+        if (this.isClassReference(wikilink)) {
+          const classIRI = this.expandClassValue(wikilink);
+          if (classIRI) {
+            return classIRI;
+          }
+        }
         return new Literal(cleanValue);
       }
 


### PR DESCRIPTION
## Summary

- Normalize `exo:Property_domain` wiki-links to namespace IRIs when target file not found
- Enable property path queries to work with class hierarchy
- Add unit tests for Property_domain normalization

## Context

**Issue:** #668

Property path queries for class hierarchy require URI references:

```sparql
SELECT ?property WHERE {
  ?targetClass exo:Class_superClass* ?class .
  ?property exo:Property_domain ?class .  # Fails when domain is literal
}
```

Previously, `Property_domain` with wiki-link values like `[[ems__Effort]]` would become literal strings when the target file was not found. This broke JOINs in property path queries.

**Solution:**
When a wiki-link like `[[ems__Effort]]` is encountered and the target file is not found, check if the extracted wikilink text matches a class reference pattern (`ems__*` or `exo__*`). If so, expand it to a namespace IRI (`ems:Effort`).

## Test plan

- [x] Unit tests for Property_domain wiki-link to namespace IRI conversion
- [x] Unit tests for handling both ems__ and exo__ prefixes
- [x] Unit tests for file IRI when target file exists
- [x] Unit tests for quoted wiki-links
- [x] Unit tests for non-wikilink class references
- [x] Unit tests for keeping literals when wiki-link is not a class reference
- [x] Unit tests for array of Property_domain values
- [x] All 2130+ unit tests pass
- [x] All 505 component tests pass
- [x] Build succeeds

Closes #668