### PR TITLE
feat: Define PropertyDefinition types and field type mappings

### DIFF
--- a/packages/core/src/domain/types/PropertyDefinition.ts
+++ b/packages/core/src/domain/types/PropertyDefinition.ts
@@ -1,0 +1,238 @@
+import { PropertyFieldType } from "./PropertyFieldType";
+
+/**
+ * Property definition interface.
+ * Describes the metadata for a property that can be used in dynamic forms.
+ *
+ * @example
+ * ```typescript
+ * const labelProperty: PropertyDefinition = {
+ *   uri: "exo:Asset_label",
+ *   name: "exo__Asset_label",
+ *   label: "Label",
+ *   fieldType: PropertyFieldType.Text,
+ *   required: true,
+ *   description: "Display label for the asset"
+ * };
+ *
+ * const statusProperty: PropertyDefinition = {
+ *   uri: "ems:Effort_status",
+ *   name: "ems__Effort_status",
+ *   label: "Status",
+ *   fieldType: PropertyFieldType.StatusSelect,
+ *   rangeType: "https://exocortex.my/ontology/ems#EffortStatus"
+ * };
+ * ```
+ */
+export interface PropertyDefinition {
+  /**
+   * Property URI in prefixed form (e.g., "exo:Asset_label", "ems:Effort_status").
+   * This is the RDF identifier for the property.
+   */
+  uri: string;
+
+  /**
+   * Property name in frontmatter format (e.g., "exo__Asset_label").
+   * This is the key used in YAML frontmatter.
+   */
+  name: string;
+
+  /**
+   * Human-readable label for the property (e.g., "Label", "Status").
+   * Used for UI display in forms and tables.
+   */
+  label: string;
+
+  /**
+   * Field type for rendering in UI forms.
+   * Determines how the property value should be input/edited.
+   */
+  fieldType: PropertyFieldType;
+
+  /**
+   * Whether this property is required.
+   * Required properties must have a value when creating/editing an asset.
+   * @default false
+   */
+  required?: boolean;
+
+  /**
+   * Human-readable description of the property.
+   * Often sourced from rdfs:comment in the ontology.
+   */
+  description?: string;
+
+  /**
+   * The RDF range type IRI (e.g., "http://www.w3.org/2001/XMLSchema#string").
+   * Used for validation and type inference.
+   */
+  rangeType?: string;
+
+  /**
+   * Whether this property is deprecated.
+   * Deprecated properties should still be displayed but marked as such.
+   * @default false
+   */
+  deprecated?: boolean;
+
+  /**
+   * For enum/select fields, the allowed values.
+   * Each option has a value (stored) and label (displayed).
+   */
+  options?: PropertyOption[];
+
+  /**
+   * Default value for the property.
+   * Used when creating new assets.
+   */
+  defaultValue?: unknown;
+
+  /**
+   * Minimum value for numeric fields.
+   */
+  minValue?: number;
+
+  /**
+   * Maximum value for numeric fields.
+   */
+  maxValue?: number;
+
+  /**
+   * Maximum length for text fields.
+   */
+  maxLength?: number;
+
+  /**
+   * Regular expression pattern for validation.
+   */
+  pattern?: string;
+
+  /**
+   * Whether the property can have multiple values (array).
+   * @default false
+   */
+  isMultiValue?: boolean;
+
+  /**
+   * Order hint for sorting properties in forms.
+   * Lower numbers appear first.
+   */
+  order?: number;
+
+  /**
+   * Grouping category for organizing properties in forms.
+   */
+  group?: string;
+}
+
+/**
+ * Option for enum/select property fields.
+ */
+export interface PropertyOption {
+  /**
+   * The value to store (e.g., wikilink to status asset).
+   */
+  value: string;
+
+  /**
+   * Human-readable label for display.
+   */
+  label: string;
+
+  /**
+   * Optional description for the option.
+   */
+  description?: string;
+
+  /**
+   * Optional icon or color for visual differentiation.
+   */
+  icon?: string;
+}
+
+/**
+ * Convert a frontmatter property name to a prefixed URI.
+ *
+ * @param propertyName - Property name in frontmatter format (e.g., "exo__Asset_label")
+ * @returns Prefixed URI (e.g., "exo:Asset_label")
+ *
+ * @example
+ * ```typescript
+ * propertyNameToUri("exo__Asset_label");
+ * // Returns: "exo:Asset_label"
+ *
+ * propertyNameToUri("ems__Effort_status");
+ * // Returns: "ems:Effort_status"
+ * ```
+ */
+export function propertyNameToUri(propertyName: string): string {
+  // Replace double underscore with colon for prefix
+  return propertyName.replace(/^([a-z]+)__/, "$1:");
+}
+
+/**
+ * Convert a prefixed URI to a frontmatter property name.
+ *
+ * @param uri - Prefixed URI (e.g., "exo:Asset_label")
+ * @returns Property name in frontmatter format (e.g., "exo__Asset_label")
+ *
+ * @example
+ * ```typescript
+ * uriToPropertyName("exo:Asset_label");
+ * // Returns: "exo__Asset_label"
+ *
+ * uriToPropertyName("ems:Effort_status");
+ * // Returns: "ems__Effort_status"
+ * ```
+ */
+export function uriToPropertyName(uri: string): string {
+  // Handle full IRI
+  if (uri.startsWith("http://") || uri.startsWith("https://")) {
+    const match = uri.match(/\/([a-z]+)#([A-Za-z0-9_]+)$/);
+    if (match) {
+      return `${match[1]}__${match[2]}`;
+    }
+    // Fallback: extract last segment
+    const lastHash = uri.lastIndexOf("#");
+    const lastSlash = uri.lastIndexOf("/");
+    const separator = Math.max(lastHash, lastSlash);
+    return separator >= 0 ? uri.substring(separator + 1) : uri;
+  }
+
+  // Handle prefixed URI
+  return uri.replace(/^([a-z]+):/, "$1__");
+}
+
+/**
+ * Extract human-readable label from a property name or URI.
+ *
+ * @param propertyNameOrUri - Property name or URI
+ * @returns Human-readable label
+ *
+ * @example
+ * ```typescript
+ * extractPropertyLabel("exo__Asset_label");
+ * // Returns: "Label"
+ *
+ * extractPropertyLabel("ems__Effort_startTimestamp");
+ * // Returns: "Start Timestamp"
+ * ```
+ */
+export function extractPropertyLabel(propertyNameOrUri: string): string {
+  // Convert URI to property name if needed
+  const propertyName = propertyNameOrUri.includes(":")
+    ? uriToPropertyName(propertyNameOrUri)
+    : propertyNameOrUri;
+
+  // Remove prefix (exo__, ems__, etc.)
+  const withoutPrefix = propertyName.replace(/^[a-z]+__/, "");
+
+  // Split on underscore (e.g., "Asset_label" -> "label")
+  const parts = withoutPrefix.split("_");
+  const propertyPart = parts.length > 1 ? parts.slice(1).join(" ") : parts[0];
+
+  // Convert camelCase to spaces and capitalize first letter
+  return propertyPart
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/^./, (s) => s.toUpperCase());
+}

--- a/packages/core/src/domain/types/PropertyFieldType.ts
+++ b/packages/core/src/domain/types/PropertyFieldType.ts
@@ -1,0 +1,220 @@
+/**
+ * Property field type enumeration.
+ * Represents the different types of properties that can be rendered in UI forms.
+ * These types map to RDF range types (xsd:string, xsd:dateTime, etc.)
+ */
+export enum PropertyFieldType {
+  /** Plain text field */
+  Text = "text",
+
+  /** Numeric value field */
+  Number = "number",
+
+  /** Date-only field (xsd:date) */
+  Date = "date",
+
+  /** Date and time field (xsd:dateTime) */
+  DateTime = "datetime",
+
+  /** Boolean checkbox field */
+  Boolean = "boolean",
+
+  /** Reference to another asset (wikilink) */
+  Reference = "reference",
+
+  /** Fixed set of enumerated values */
+  Enum = "enum",
+
+  /** Status selection dropdown (e.g., EffortStatus) */
+  StatusSelect = "status-select",
+
+  /** Size selection dropdown (e.g., TaskSize) */
+  SizeSelect = "size-select",
+
+  /** Wikilink field for asset references */
+  Wikilink = "wikilink",
+
+  /** Timestamp field (ISO 8601 format) */
+  Timestamp = "timestamp",
+
+  /** Unknown or unmapped field type */
+  Unknown = "unknown",
+}
+
+/**
+ * XSD namespace URI for XML Schema datatypes.
+ */
+const XSD_NS = "http://www.w3.org/2001/XMLSchema#";
+
+/**
+ * Exocortex ontology namespace URIs.
+ */
+const EXO_NS = "https://exocortex.my/ontology/exo#";
+const EMS_NS = "https://exocortex.my/ontology/ems#";
+
+/**
+ * Map RDF range type IRI to PropertyFieldType.
+ *
+ * Converts XSD datatypes and custom ontology types to their
+ * corresponding UI field types for form rendering.
+ *
+ * @param rangeType - The RDF range type IRI (e.g., "http://www.w3.org/2001/XMLSchema#string")
+ * @returns The corresponding PropertyFieldType
+ *
+ * @example
+ * ```typescript
+ * rangeToFieldType("http://www.w3.org/2001/XMLSchema#dateTime");
+ * // Returns: PropertyFieldType.DateTime
+ *
+ * rangeToFieldType("http://www.w3.org/2001/XMLSchema#string");
+ * // Returns: PropertyFieldType.Text
+ *
+ * rangeToFieldType("https://exocortex.my/ontology/ems#EffortStatus");
+ * // Returns: PropertyFieldType.StatusSelect
+ * ```
+ */
+export function rangeToFieldType(rangeType?: string): PropertyFieldType {
+  if (!rangeType) {
+    return PropertyFieldType.Unknown;
+  }
+
+  // Normalize the range type (handle both full IRI and prefixed forms)
+  const normalizedType = rangeType.trim();
+
+  // Empty string after trim is considered unknown
+  if (!normalizedType) {
+    return PropertyFieldType.Unknown;
+  }
+
+  // Check for XSD types (full IRI)
+  if (normalizedType.startsWith(XSD_NS)) {
+    const localName = normalizedType.substring(XSD_NS.length);
+    return xsdTypeToFieldType(localName);
+  }
+
+  // Check for XSD types (prefixed form)
+  if (normalizedType.startsWith("xsd:")) {
+    const localName = normalizedType.substring(4);
+    return xsdTypeToFieldType(localName);
+  }
+
+  // Check for XMLSchema# pattern in the IRI
+  if (normalizedType.includes("XMLSchema#")) {
+    const hashIndex = normalizedType.indexOf("XMLSchema#");
+    const localName = normalizedType.substring(hashIndex + 10);
+    return xsdTypeToFieldType(localName);
+  }
+
+  // Check for EMS types
+  if (normalizedType.startsWith(EMS_NS) || normalizedType.startsWith("ems:")) {
+    return emsTypeToFieldType(normalizedType);
+  }
+
+  // Check for EXO types
+  if (normalizedType.startsWith(EXO_NS) || normalizedType.startsWith("exo:")) {
+    return PropertyFieldType.Reference;
+  }
+
+  // Check for known class references
+  if (isClassReference(normalizedType)) {
+    return PropertyFieldType.Reference;
+  }
+
+  // Default to text for unknown types
+  return PropertyFieldType.Text;
+}
+
+/**
+ * Map XSD local name to PropertyFieldType.
+ */
+function xsdTypeToFieldType(localName: string): PropertyFieldType {
+  switch (localName.toLowerCase()) {
+    case "string":
+    case "normalizedstring":
+    case "token":
+    case "language":
+    case "nmtoken":
+    case "name":
+    case "ncname":
+    case "anyuri":
+      return PropertyFieldType.Text;
+
+    case "integer":
+    case "int":
+    case "long":
+    case "short":
+    case "byte":
+    case "nonnegativeinteger":
+    case "positiveinteger":
+    case "nonpositiveinteger":
+    case "negativeinteger":
+    case "unsignedlong":
+    case "unsignedint":
+    case "unsignedshort":
+    case "unsignedbyte":
+    case "decimal":
+    case "float":
+    case "double":
+      return PropertyFieldType.Number;
+
+    case "date":
+      return PropertyFieldType.Date;
+
+    case "datetime":
+    case "datetimestamp":
+      return PropertyFieldType.DateTime;
+
+    case "boolean":
+      return PropertyFieldType.Boolean;
+
+    case "time":
+      return PropertyFieldType.Timestamp;
+
+    default:
+      return PropertyFieldType.Text;
+  }
+}
+
+/**
+ * Map EMS namespace types to PropertyFieldType.
+ */
+function emsTypeToFieldType(typeIri: string): PropertyFieldType {
+  const normalizedType = typeIri.toLowerCase();
+
+  if (normalizedType.includes("effortstatus")) {
+    return PropertyFieldType.StatusSelect;
+  }
+
+  if (normalizedType.includes("tasksize")) {
+    return PropertyFieldType.SizeSelect;
+  }
+
+  // Default to reference for other EMS types (likely class references)
+  return PropertyFieldType.Reference;
+}
+
+/**
+ * Check if the type IRI represents a class reference.
+ */
+function isClassReference(typeIri: string): boolean {
+  const lowerType = typeIri.toLowerCase();
+
+  // Check for common class patterns
+  if (lowerType.includes("exocortex.my/ontology")) {
+    return true;
+  }
+
+  // Check for known class names
+  const classPatterns = [
+    "asset",
+    "task",
+    "project",
+    "area",
+    "effort",
+    "class",
+    "property",
+    "concept",
+  ];
+
+  return classPatterns.some((pattern) => lowerType.includes(pattern));
+}

--- a/packages/core/src/domain/types/index.ts
+++ b/packages/core/src/domain/types/index.ts
@@ -1,0 +1,8 @@
+export { PropertyFieldType, rangeToFieldType } from "./PropertyFieldType";
+export {
+  type PropertyDefinition,
+  type PropertyOption,
+  propertyNameToUri,
+  uriToPropertyName,
+  extractPropertyLabel,
+} from "./PropertyDefinition";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,19 @@ export * from "./domain/models/rdf";
 export * from "./domain/commands/CommandVisibility";
 export type { IPropertyValidationService, ValidationResult } from "./domain/services/IPropertyValidationService";
 
+// Property definition types
+export {
+  PropertyFieldType,
+  rangeToFieldType,
+} from "./domain/types/PropertyFieldType";
+export {
+  type PropertyDefinition,
+  type PropertyOption,
+  propertyNameToUri,
+  uriToPropertyName,
+  extractPropertyLabel,
+} from "./domain/types/PropertyDefinition";
+
 // Services exports
 export { TaskCreationService } from "./services/TaskCreationService";
 export { ProjectCreationService } from "./services/ProjectCreationService";
@@ -33,8 +46,8 @@ export { FleetingNoteCreationService } from "./services/FleetingNoteCreationServ
 export { TaskFrontmatterGenerator } from "./services/TaskFrontmatterGenerator";
 export {
   DynamicFrontmatterGenerator,
-  type PropertyFieldType,
-  type PropertyDefinition,
+  type LegacyPropertyFieldType,
+  type FrontmatterPropertyDefinition,
 } from "./services/DynamicFrontmatterGenerator";
 export { AlgorithmExtractor } from "./services/AlgorithmExtractor";
 export { PlanningService } from "./services/PlanningService";

--- a/packages/core/src/services/DynamicFrontmatterGenerator.ts
+++ b/packages/core/src/services/DynamicFrontmatterGenerator.ts
@@ -3,10 +3,10 @@ import { v4 as uuidv4 } from "uuid";
 import { DateFormatter } from "../utilities/DateFormatter";
 
 /**
- * Property field type enumeration.
- * Represents the different types of properties that can be set on an asset.
+ * Legacy property field type for backwards compatibility.
+ * @deprecated Use PropertyFieldType enum from domain/types instead.
  */
-export type PropertyFieldType =
+export type LegacyPropertyFieldType =
   | "text"
   | "status-select"
   | "size-select"
@@ -16,12 +16,15 @@ export type PropertyFieldType =
   | "timestamp";
 
 /**
- * Property definition for dynamic frontmatter generation.
- * Describes a property's metadata including its type for proper formatting.
+ * Simple property definition for frontmatter generation.
+ * For more comprehensive property definitions, use PropertyDefinition from domain/types.
  */
-export interface PropertyDefinition {
+export interface FrontmatterPropertyDefinition {
+  /** Property name (e.g., "exo__Asset_label") */
   name: string;
-  type: PropertyFieldType;
+  /** Field type for formatting */
+  type: LegacyPropertyFieldType;
+  /** Whether this property is required */
   required?: boolean;
 }
 
@@ -72,7 +75,7 @@ export class DynamicFrontmatterGenerator {
   generate(
     className: string,
     values: Record<string, any>,
-    properties: PropertyDefinition[],
+    properties: FrontmatterPropertyDefinition[],
     options?: {
       /** Custom UID to use instead of generating a new one */
       uid?: string;
@@ -97,7 +100,7 @@ export class DynamicFrontmatterGenerator {
     frontmatter["exo__Instance_class"] = [this.formatWikilink(className)];
 
     // Create a map of property names to their types for quick lookup
-    const propertyTypeMap = new Map<string, PropertyFieldType>();
+    const propertyTypeMap = new Map<string, LegacyPropertyFieldType>();
     for (const prop of properties) {
       propertyTypeMap.set(prop.name, prop.type);
     }
@@ -141,7 +144,7 @@ export class DynamicFrontmatterGenerator {
    * @param type - The property type (optional, defaults to text)
    * @returns Formatted value for YAML frontmatter
    */
-  formatValue(value: any, type?: PropertyFieldType): any {
+  formatValue(value: any, type?: LegacyPropertyFieldType): any {
     // Handle empty/null values
     if (value === null || value === undefined) {
       return null;
@@ -329,7 +332,7 @@ export class DynamicFrontmatterGenerator {
   generateYAML(
     className: string,
     values: Record<string, any>,
-    properties: PropertyDefinition[],
+    properties: FrontmatterPropertyDefinition[],
     options?: {
       uid?: string;
       createdAt?: string;

--- a/packages/obsidian-plugin/src/application/services/OntologySchemaService.ts
+++ b/packages/obsidian-plugin/src/application/services/OntologySchemaService.ts
@@ -1,5 +1,5 @@
 import { SPARQLQueryService } from "./SPARQLQueryService";
-import type { PropertyFieldType } from "@exocortex/core";
+import { PropertyFieldType } from "@exocortex/core";
 
 /**
  * Extended property definition for ontology-driven forms.
@@ -256,29 +256,29 @@ export class OntologySchemaService {
    */
   private rangeToFieldType(rangeType?: string): PropertyFieldType {
     if (!rangeType) {
-      return "text";
+      return PropertyFieldType.Text;
     }
 
     // Check for XSD types
     if (rangeType.includes("XMLSchema#") || rangeType.startsWith("xsd:")) {
       if (rangeType.includes("dateTime") || rangeType.includes("date")) {
-        return "timestamp";
+        return PropertyFieldType.Timestamp;
       }
       if (rangeType.includes("integer") || rangeType.includes("decimal") || rangeType.includes("float") || rangeType.includes("double")) {
-        return "number";
+        return PropertyFieldType.Number;
       }
       if (rangeType.includes("boolean")) {
-        return "boolean";
+        return PropertyFieldType.Boolean;
       }
-      return "text";
+      return PropertyFieldType.Text;
     }
 
     // Check for EMS/EXO types
     if (rangeType.includes("EffortStatus")) {
-      return "status-select";
+      return PropertyFieldType.StatusSelect;
     }
     if (rangeType.includes("TaskSize")) {
-      return "size-select";
+      return PropertyFieldType.SizeSelect;
     }
 
     // Check if it's a reference to another class
@@ -289,10 +289,10 @@ export class OntologySchemaService {
       rangeType.includes("Project") ||
       rangeType.includes("Area")
     ) {
-      return "wikilink";
+      return PropertyFieldType.Wikilink;
     }
 
-    return "text";
+    return PropertyFieldType.Text;
   }
 
   /**
@@ -304,7 +304,7 @@ export class OntologySchemaService {
       {
         uri: "exo__Asset_label",
         label: "Label",
-        fieldType: "text",
+        fieldType: PropertyFieldType.Text,
         deprecated: false,
         required: false,
         description: "Display label for the asset",
@@ -318,7 +318,7 @@ export class OntologySchemaService {
         {
           uri: "ems__Effort_taskSize",
           label: "Task Size",
-          fieldType: "size-select",
+          fieldType: PropertyFieldType.SizeSelect,
           deprecated: false,
           required: false,
           description: "Estimated size of the task",
@@ -326,7 +326,7 @@ export class OntologySchemaService {
         {
           uri: "ems__Effort_status",
           label: "Status",
-          fieldType: "status-select",
+          fieldType: PropertyFieldType.StatusSelect,
           deprecated: false,
           required: false,
           description: "Current status of the effort",

--- a/packages/obsidian-plugin/tests/unit/domain/types/PropertyDefinition.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/types/PropertyDefinition.test.ts
@@ -1,0 +1,217 @@
+import {
+  PropertyFieldType,
+  PropertyDefinition,
+  propertyNameToUri,
+  uriToPropertyName,
+  extractPropertyLabel,
+} from "@exocortex/core";
+
+describe("PropertyDefinition interface", () => {
+  it("should allow creating a minimal property definition", () => {
+    const prop: PropertyDefinition = {
+      uri: "exo:Asset_label",
+      name: "exo__Asset_label",
+      label: "Label",
+      fieldType: PropertyFieldType.Text,
+    };
+
+    expect(prop.uri).toBe("exo:Asset_label");
+    expect(prop.name).toBe("exo__Asset_label");
+    expect(prop.label).toBe("Label");
+    expect(prop.fieldType).toBe(PropertyFieldType.Text);
+  });
+
+  it("should allow creating a full property definition", () => {
+    const prop: PropertyDefinition = {
+      uri: "ems:Effort_status",
+      name: "ems__Effort_status",
+      label: "Status",
+      fieldType: PropertyFieldType.StatusSelect,
+      required: true,
+      description: "Current status of the effort",
+      rangeType: "https://exocortex.my/ontology/ems#EffortStatus",
+      deprecated: false,
+      options: [
+        { value: "[[ems__EffortStatusDraft]]", label: "Draft" },
+        { value: "[[ems__EffortStatusActive]]", label: "Active" },
+      ],
+      defaultValue: "[[ems__EffortStatusDraft]]",
+      order: 1,
+      group: "Status",
+    };
+
+    expect(prop.required).toBe(true);
+    expect(prop.description).toBe("Current status of the effort");
+    expect(prop.options).toHaveLength(2);
+    expect(prop.options![0].value).toBe("[[ems__EffortStatusDraft]]");
+    expect(prop.order).toBe(1);
+    expect(prop.group).toBe("Status");
+  });
+
+  it("should allow creating a numeric property definition with constraints", () => {
+    const prop: PropertyDefinition = {
+      uri: "ems:Effort_votes",
+      name: "ems__Effort_votes",
+      label: "Votes",
+      fieldType: PropertyFieldType.Number,
+      minValue: 0,
+      maxValue: 100,
+      defaultValue: 0,
+    };
+
+    expect(prop.minValue).toBe(0);
+    expect(prop.maxValue).toBe(100);
+  });
+
+  it("should allow creating a text property definition with constraints", () => {
+    const prop: PropertyDefinition = {
+      uri: "exo:Asset_label",
+      name: "exo__Asset_label",
+      label: "Label",
+      fieldType: PropertyFieldType.Text,
+      maxLength: 255,
+      pattern: "^[a-zA-Z0-9\\s]+$",
+    };
+
+    expect(prop.maxLength).toBe(255);
+    expect(prop.pattern).toBe("^[a-zA-Z0-9\\s]+$");
+  });
+
+  it("should allow creating a multi-value property definition", () => {
+    const prop: PropertyDefinition = {
+      uri: "exo:Asset_tags",
+      name: "exo__Asset_tags",
+      label: "Tags",
+      fieldType: PropertyFieldType.Reference,
+      isMultiValue: true,
+    };
+
+    expect(prop.isMultiValue).toBe(true);
+  });
+});
+
+describe("propertyNameToUri", () => {
+  it("should convert exo__ prefix to exo:", () => {
+    expect(propertyNameToUri("exo__Asset_label")).toBe("exo:Asset_label");
+  });
+
+  it("should convert ems__ prefix to ems:", () => {
+    expect(propertyNameToUri("ems__Effort_status")).toBe("ems:Effort_status");
+  });
+
+  it("should preserve property names without recognized prefix", () => {
+    expect(propertyNameToUri("custom__Property_name")).toBe(
+      "custom:Property_name",
+    );
+  });
+
+  it("should handle properties without prefix", () => {
+    expect(propertyNameToUri("simpleProperty")).toBe("simpleProperty");
+  });
+
+  it("should handle empty string", () => {
+    expect(propertyNameToUri("")).toBe("");
+  });
+});
+
+describe("uriToPropertyName", () => {
+  describe("prefixed URIs", () => {
+    it("should convert exo: prefix to exo__", () => {
+      expect(uriToPropertyName("exo:Asset_label")).toBe("exo__Asset_label");
+    });
+
+    it("should convert ems: prefix to ems__", () => {
+      expect(uriToPropertyName("ems:Effort_status")).toBe("ems__Effort_status");
+    });
+
+    it("should handle other prefixes", () => {
+      expect(uriToPropertyName("custom:Property_name")).toBe(
+        "custom__Property_name",
+      );
+    });
+  });
+
+  describe("full IRIs", () => {
+    it("should extract property name from exo namespace IRI", () => {
+      expect(
+        uriToPropertyName("https://exocortex.my/ontology/exo#Asset_label"),
+      ).toBe("exo__Asset_label");
+    });
+
+    it("should extract property name from ems namespace IRI", () => {
+      expect(
+        uriToPropertyName("https://exocortex.my/ontology/ems#Effort_status"),
+      ).toBe("ems__Effort_status");
+    });
+
+    it("should extract namespace and property for unknown namespaces", () => {
+      expect(
+        uriToPropertyName("https://example.org/ontology#SomeProperty"),
+      ).toBe("ontology__SomeProperty");
+    });
+
+    it("should handle IRIs with slash separator", () => {
+      expect(
+        uriToPropertyName("https://example.org/ontology/SomeProperty"),
+      ).toBe("SomeProperty");
+    });
+  });
+
+  it("should handle empty string", () => {
+    expect(uriToPropertyName("")).toBe("");
+  });
+});
+
+describe("extractPropertyLabel", () => {
+  describe("from property names", () => {
+    it("should extract label from exo__ prefixed property", () => {
+      expect(extractPropertyLabel("exo__Asset_label")).toBe("Label");
+    });
+
+    it("should extract label from ems__ prefixed property", () => {
+      expect(extractPropertyLabel("ems__Effort_status")).toBe("Status");
+    });
+
+    it("should handle camelCase in property part", () => {
+      expect(extractPropertyLabel("ems__Effort_startTimestamp")).toBe(
+        "Start Timestamp",
+      );
+    });
+
+    it("should handle property without underscore after class", () => {
+      expect(extractPropertyLabel("exo__Asset")).toBe("Asset");
+    });
+
+    it("should handle multi-part property names", () => {
+      expect(extractPropertyLabel("ems__Task_expectedDuration")).toBe(
+        "Expected Duration",
+      );
+    });
+  });
+
+  describe("from URIs", () => {
+    it("should extract label from prefixed URI", () => {
+      expect(extractPropertyLabel("exo:Asset_label")).toBe("Label");
+    });
+
+    it("should extract label from full IRI", () => {
+      expect(
+        extractPropertyLabel("https://exocortex.my/ontology/exo#Asset_label"),
+      ).toBe("Label");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should capitalize first letter", () => {
+      expect(extractPropertyLabel("exo__Asset_name")).toBe("Name");
+    });
+
+    it("should handle all uppercase", () => {
+      expect(extractPropertyLabel("exo__Asset_URL")).toBe("URL");
+    });
+
+    it("should handle camelCase single word property", () => {
+      expect(extractPropertyLabel("simpleProperty")).toBe("Simple Property");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/types/PropertyFieldType.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/types/PropertyFieldType.test.ts
@@ -1,0 +1,274 @@
+import {
+  PropertyFieldType,
+  rangeToFieldType,
+} from "@exocortex/core";
+
+describe("PropertyFieldType", () => {
+  describe("enum values", () => {
+    it("should have correct string values", () => {
+      expect(PropertyFieldType.Text).toBe("text");
+      expect(PropertyFieldType.Number).toBe("number");
+      expect(PropertyFieldType.Date).toBe("date");
+      expect(PropertyFieldType.DateTime).toBe("datetime");
+      expect(PropertyFieldType.Boolean).toBe("boolean");
+      expect(PropertyFieldType.Reference).toBe("reference");
+      expect(PropertyFieldType.Enum).toBe("enum");
+      expect(PropertyFieldType.StatusSelect).toBe("status-select");
+      expect(PropertyFieldType.SizeSelect).toBe("size-select");
+      expect(PropertyFieldType.Wikilink).toBe("wikilink");
+      expect(PropertyFieldType.Timestamp).toBe("timestamp");
+      expect(PropertyFieldType.Unknown).toBe("unknown");
+    });
+  });
+});
+
+describe("rangeToFieldType", () => {
+  describe("when rangeType is undefined or empty", () => {
+    it("should return Unknown for undefined", () => {
+      expect(rangeToFieldType(undefined)).toBe(PropertyFieldType.Unknown);
+    });
+
+    it("should return Unknown for empty string", () => {
+      expect(rangeToFieldType("")).toBe(PropertyFieldType.Unknown);
+    });
+
+    it("should return Unknown for whitespace-only string", () => {
+      expect(rangeToFieldType("   ")).toBe(PropertyFieldType.Unknown);
+    });
+  });
+
+  describe("XSD string types", () => {
+    it("should return Text for xsd:string (full IRI)", () => {
+      expect(
+        rangeToFieldType("http://www.w3.org/2001/XMLSchema#string"),
+      ).toBe(PropertyFieldType.Text);
+    });
+
+    it("should return Text for xsd:string (prefixed)", () => {
+      expect(rangeToFieldType("xsd:string")).toBe(PropertyFieldType.Text);
+    });
+
+    it("should return Text for xsd:normalizedString", () => {
+      expect(rangeToFieldType("xsd:normalizedString")).toBe(
+        PropertyFieldType.Text,
+      );
+    });
+
+    it("should return Text for xsd:token", () => {
+      expect(rangeToFieldType("xsd:token")).toBe(PropertyFieldType.Text);
+    });
+
+    it("should return Text for xsd:anyURI", () => {
+      expect(rangeToFieldType("xsd:anyURI")).toBe(PropertyFieldType.Text);
+    });
+  });
+
+  describe("XSD numeric types", () => {
+    it("should return Number for xsd:integer (full IRI)", () => {
+      expect(
+        rangeToFieldType("http://www.w3.org/2001/XMLSchema#integer"),
+      ).toBe(PropertyFieldType.Number);
+    });
+
+    it("should return Number for xsd:integer (prefixed)", () => {
+      expect(rangeToFieldType("xsd:integer")).toBe(PropertyFieldType.Number);
+    });
+
+    it("should return Number for xsd:int", () => {
+      expect(rangeToFieldType("xsd:int")).toBe(PropertyFieldType.Number);
+    });
+
+    it("should return Number for xsd:long", () => {
+      expect(rangeToFieldType("xsd:long")).toBe(PropertyFieldType.Number);
+    });
+
+    it("should return Number for xsd:short", () => {
+      expect(rangeToFieldType("xsd:short")).toBe(PropertyFieldType.Number);
+    });
+
+    it("should return Number for xsd:byte", () => {
+      expect(rangeToFieldType("xsd:byte")).toBe(PropertyFieldType.Number);
+    });
+
+    it("should return Number for xsd:decimal", () => {
+      expect(rangeToFieldType("xsd:decimal")).toBe(PropertyFieldType.Number);
+    });
+
+    it("should return Number for xsd:float", () => {
+      expect(rangeToFieldType("xsd:float")).toBe(PropertyFieldType.Number);
+    });
+
+    it("should return Number for xsd:double", () => {
+      expect(rangeToFieldType("xsd:double")).toBe(PropertyFieldType.Number);
+    });
+
+    it("should return Number for xsd:nonNegativeInteger", () => {
+      expect(rangeToFieldType("xsd:nonNegativeInteger")).toBe(
+        PropertyFieldType.Number,
+      );
+    });
+
+    it("should return Number for xsd:positiveInteger", () => {
+      expect(rangeToFieldType("xsd:positiveInteger")).toBe(
+        PropertyFieldType.Number,
+      );
+    });
+
+    it("should return Number for xsd:unsignedInt", () => {
+      expect(rangeToFieldType("xsd:unsignedInt")).toBe(
+        PropertyFieldType.Number,
+      );
+    });
+  });
+
+  describe("XSD date and time types", () => {
+    it("should return Date for xsd:date (full IRI)", () => {
+      expect(rangeToFieldType("http://www.w3.org/2001/XMLSchema#date")).toBe(
+        PropertyFieldType.Date,
+      );
+    });
+
+    it("should return Date for xsd:date (prefixed)", () => {
+      expect(rangeToFieldType("xsd:date")).toBe(PropertyFieldType.Date);
+    });
+
+    it("should return DateTime for xsd:dateTime (full IRI)", () => {
+      expect(
+        rangeToFieldType("http://www.w3.org/2001/XMLSchema#dateTime"),
+      ).toBe(PropertyFieldType.DateTime);
+    });
+
+    it("should return DateTime for xsd:dateTime (prefixed)", () => {
+      expect(rangeToFieldType("xsd:dateTime")).toBe(PropertyFieldType.DateTime);
+    });
+
+    it("should return DateTime for xsd:dateTimeStamp", () => {
+      expect(rangeToFieldType("xsd:dateTimeStamp")).toBe(
+        PropertyFieldType.DateTime,
+      );
+    });
+
+    it("should return Timestamp for xsd:time", () => {
+      expect(rangeToFieldType("xsd:time")).toBe(PropertyFieldType.Timestamp);
+    });
+  });
+
+  describe("XSD boolean type", () => {
+    it("should return Boolean for xsd:boolean (full IRI)", () => {
+      expect(
+        rangeToFieldType("http://www.w3.org/2001/XMLSchema#boolean"),
+      ).toBe(PropertyFieldType.Boolean);
+    });
+
+    it("should return Boolean for xsd:boolean (prefixed)", () => {
+      expect(rangeToFieldType("xsd:boolean")).toBe(PropertyFieldType.Boolean);
+    });
+  });
+
+  describe("EMS namespace types", () => {
+    it("should return StatusSelect for ems:EffortStatus", () => {
+      expect(
+        rangeToFieldType("https://exocortex.my/ontology/ems#EffortStatus"),
+      ).toBe(PropertyFieldType.StatusSelect);
+    });
+
+    it("should return StatusSelect for ems:EffortStatus (prefixed)", () => {
+      expect(rangeToFieldType("ems:EffortStatus")).toBe(
+        PropertyFieldType.StatusSelect,
+      );
+    });
+
+    it("should return SizeSelect for ems:TaskSize", () => {
+      expect(
+        rangeToFieldType("https://exocortex.my/ontology/ems#TaskSize"),
+      ).toBe(PropertyFieldType.SizeSelect);
+    });
+
+    it("should return SizeSelect for ems:TaskSize (prefixed)", () => {
+      expect(rangeToFieldType("ems:TaskSize")).toBe(
+        PropertyFieldType.SizeSelect,
+      );
+    });
+
+    it("should return Reference for other EMS types", () => {
+      expect(rangeToFieldType("https://exocortex.my/ontology/ems#Task")).toBe(
+        PropertyFieldType.Reference,
+      );
+    });
+  });
+
+  describe("EXO namespace types", () => {
+    it("should return Reference for exo:Asset", () => {
+      expect(
+        rangeToFieldType("https://exocortex.my/ontology/exo#Asset"),
+      ).toBe(PropertyFieldType.Reference);
+    });
+
+    it("should return Reference for exo:Asset (prefixed)", () => {
+      expect(rangeToFieldType("exo:Asset")).toBe(PropertyFieldType.Reference);
+    });
+  });
+
+  describe("class reference detection", () => {
+    it("should return Reference for Asset in IRI", () => {
+      expect(
+        rangeToFieldType("https://example.org/ontology#Asset"),
+      ).toBe(PropertyFieldType.Reference);
+    });
+
+    it("should return Reference for Task in IRI", () => {
+      expect(
+        rangeToFieldType("https://example.org/ontology#Task"),
+      ).toBe(PropertyFieldType.Reference);
+    });
+
+    it("should return Reference for Project in IRI", () => {
+      expect(
+        rangeToFieldType("https://example.org/ontology#Project"),
+      ).toBe(PropertyFieldType.Reference);
+    });
+
+    it("should return Reference for Area in IRI", () => {
+      expect(
+        rangeToFieldType("https://example.org/ontology#Area"),
+      ).toBe(PropertyFieldType.Reference);
+    });
+
+    it("should return Reference for exocortex.my/ontology IRIs", () => {
+      expect(
+        rangeToFieldType("https://exocortex.my/ontology/custom#SomeClass"),
+      ).toBe(PropertyFieldType.Reference);
+    });
+  });
+
+  describe("unknown types", () => {
+    it("should return Text for unrecognized XSD types", () => {
+      expect(rangeToFieldType("xsd:unknownType")).toBe(PropertyFieldType.Text);
+    });
+
+    it("should return Text for arbitrary string", () => {
+      expect(rangeToFieldType("some:random:value")).toBe(PropertyFieldType.Text);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle leading/trailing whitespace", () => {
+      expect(rangeToFieldType("  xsd:string  ")).toBe(PropertyFieldType.Text);
+    });
+
+    it("should be case-insensitive for XSD types", () => {
+      expect(rangeToFieldType("xsd:STRING")).toBe(PropertyFieldType.Text);
+      expect(rangeToFieldType("xsd:DateTime")).toBe(PropertyFieldType.DateTime);
+      expect(rangeToFieldType("xsd:BOOLEAN")).toBe(PropertyFieldType.Boolean);
+    });
+
+    it("should handle mixed case EMS types", () => {
+      expect(rangeToFieldType("ems:effortStatus")).toBe(
+        PropertyFieldType.StatusSelect,
+      );
+      expect(rangeToFieldType("ems:TASKSIZE")).toBe(
+        PropertyFieldType.SizeSelect,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `PropertyFieldType` enum with 12 field types mapping RDF range types to UI field types
- Adds `PropertyDefinition` interface for comprehensive property metadata
- Adds `rangeToFieldType()` function to convert XSD datatypes to field types
- Adds helper functions for URI conversion: `propertyNameToUri()`, `uriToPropertyName()`, `extractPropertyLabel()`
- Updates `OntologySchemaService` to use new `PropertyFieldType` enum values
- Adds 74 unit tests for all new types and functions

## Changes

### New Files
- `packages/core/src/domain/types/PropertyFieldType.ts` - Enum and mapping function
- `packages/core/src/domain/types/PropertyDefinition.ts` - Interface and helpers
- `packages/core/src/domain/types/index.ts` - Barrel export
- `packages/obsidian-plugin/tests/unit/domain/types/*.test.ts` - Unit tests

### Modified Files
- `packages/core/src/index.ts` - Export new types
- `packages/core/src/services/DynamicFrontmatterGenerator.ts` - Renamed legacy types for backwards compat
- `packages/obsidian-plugin/src/application/services/OntologySchemaService.ts` - Use enum values

## Test plan

- [x] All 74 new unit tests pass
- [x] Existing tests pass (2212+ tests)
- [x] TypeScript compilation succeeds
- [x] Build succeeds

Closes #654