### PR TITLE
docs: document dynamic property fields feature and ontology extension guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,44 @@ result.bindings.forEach(binding => {
 - Property URIs: `<http://exocortex.ai/ontology#PropertyName>`
 - Vault paths: `<vault://path/to/file.md>`
 
+## 🧩 Dynamic Property Fields (Experimental)
+
+Automatically generate asset creation forms based on your RDF ontology definitions. Instead of fixed forms, the plugin reads your ontology to determine which fields should appear when creating assets.
+
+### Key Features
+
+- **Ontology-Driven Forms**: Fields generated from `rdfs:domain` property definitions
+- **Property Inheritance**: Child classes inherit properties from parent classes
+- **Type-Specific Widgets**: Automatic field type detection based on `rdfs:range`:
+  - `xsd:string` → Text input
+  - `xsd:dateTime` → DateTime picker
+  - `xsd:integer` → Number input
+  - `xsd:boolean` → Toggle switch
+  - Asset references → Wikilink input
+- **Deprecated Property Hiding**: Properties marked `owl:deprecated true` are automatically hidden
+- **Graceful Fallback**: Uses basic fields when ontology is unavailable
+
+### Enabling the Feature
+
+1. Open Obsidian Settings
+2. Navigate to **Exocortex** section
+3. Enable **"Use dynamic property fields"** toggle
+4. Create assets using commands like "Create Task" - the modal will show ontology-defined fields
+
+### How It Works
+
+When you invoke a creation command (e.g., "Create Task"):
+
+1. The plugin queries your ontology for properties where `rdfs:domain` matches the target class
+2. Traverses class hierarchy via `rdfs:subClassOf` to find inherited properties
+3. Filters out deprecated properties
+4. Renders appropriate field types based on `rdfs:range`
+
+### Documentation
+
+- **[Dynamic Fields Guide](./docs/DYNAMIC_FIELDS.md)** - Complete feature documentation
+- **[Ontology Extension Guide](./docs/ONTOLOGY_EXTENSION.md)** - Add custom properties to your ontology
+
 ## ⚙️ Plugin Settings
 
 Access via Settings → Exocortex.
@@ -512,6 +550,7 @@ Access via Settings → Exocortex.
 | **Show Layout** | On | Display automatic layout sections in reading mode |
 | **Show Properties Section** | On | Include properties table in layout |
 | **Show Archived Assets** | Off | Display archived assets in relations table with reduced opacity |
+| **Use Dynamic Property Fields** | Off | Generate modal fields from ontology (experimental) |
 
 Additional internal settings:
 - **Active Focus Area**: Current focus area for daily tasks filtering (set via "Set Active Focus" button)
@@ -755,6 +794,8 @@ For plugin developers and contributors:
 
 ### Advanced Topics
 
+- **[Dynamic Property Fields Guide](./docs/DYNAMIC_FIELDS.md)** - Ontology-driven asset creation forms
+- **[Ontology Extension Guide](./docs/ONTOLOGY_EXTENSION.md)** - Add custom properties to your ontology
 - **[Performance Guide](./docs/Performance-Guide.md)** - Optimization tips and benchmarks
 - **[Troubleshooting](./docs/Troubleshooting.md)** - Common issues and solutions
 - **[Property Schema](./docs/PROPERTY_SCHEMA.md)** - Complete frontmatter property reference

--- a/docs/DYNAMIC_FIELDS.md
+++ b/docs/DYNAMIC_FIELDS.md
@@ -1,0 +1,264 @@
+# Dynamic Property Fields Guide
+
+> **Status**: Experimental Feature (v14.x+)
+>
+> This feature is under active development. Enable via Settings to try it out.
+
+## Overview
+
+Dynamic Property Fields automatically generate asset creation forms based on your RDF ontology definitions. Instead of hardcoded forms with fixed fields, the plugin reads your ontology to determine which properties should appear when creating Tasks, Projects, or any other asset type.
+
+### Key Benefits
+
+- **Ontology-Driven Forms**: Fields are generated from your `rdfs:domain` definitions
+- **Property Inheritance**: Child classes inherit properties from parent classes (e.g., Task inherits from Effort, which inherits from Asset)
+- **Type-Specific Widgets**: Automatic field type detection based on `rdfs:range`:
+  - `xsd:string` → Text input
+  - `xsd:dateTime` → DateTime picker
+  - `xsd:integer` → Number input
+  - `xsd:boolean` → Toggle switch
+  - `ems__EffortStatus` → Status dropdown
+  - `ems__TaskSize` → Size dropdown
+  - Asset references → Wikilink input
+- **Deprecated Property Hiding**: Properties marked `owl:deprecated true` are automatically hidden
+- **Graceful Fallback**: When ontology is unavailable, falls back to basic label + task size fields
+
+## Enabling the Feature
+
+1. Open Obsidian Settings
+2. Navigate to **Exocortex** section
+3. Enable **"Use dynamic property fields"** toggle
+4. The setting takes effect immediately for all creation commands
+
+![Settings Toggle](../docs/diagrams/settings-dynamic-fields.png)
+
+## How It Works
+
+### 1. Class Property Resolution
+
+When you invoke a creation command (e.g., "Create Task"), the plugin:
+
+1. Queries the RDF ontology for properties where `rdfs:domain` matches the target class
+2. Traverses the class hierarchy via `rdfs:subClassOf` to find inherited properties
+3. Filters out deprecated properties (`owl:deprecated true`)
+4. Sorts properties alphabetically by label
+
+```sparql
+# Example: What properties does ems__Task have?
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?property ?label ?range WHERE {
+  ?property rdfs:domain ems:Task .
+  OPTIONAL { ?property rdfs:label ?label }
+  OPTIONAL { ?property rdfs:range ?range }
+}
+```
+
+### 2. Field Type Detection
+
+The `rdfs:range` property determines the field type:
+
+| Range Type | Field Type | UI Widget |
+|------------|------------|-----------|
+| `xsd:string` | text | Text input |
+| `xsd:dateTime` | timestamp | DateTime picker |
+| `xsd:integer`, `xsd:decimal` | number | Number input |
+| `xsd:boolean` | boolean | Toggle switch |
+| `ems:EffortStatus` | status-select | Status dropdown |
+| `ems:TaskSize` | size-select | Size dropdown |
+| Any class reference | wikilink | Wikilink input |
+
+### 3. Modal Rendering
+
+The `DynamicAssetCreationModal` renders fields based on property definitions:
+
+```typescript
+// For each property in the ontology
+for (const prop of properties) {
+  switch (prop.fieldType) {
+    case "text":
+      // Render text input
+      break;
+    case "timestamp":
+      // Render datetime-local input
+      break;
+    case "number":
+      // Render number input
+      break;
+    case "boolean":
+      // Render toggle
+      break;
+    case "status-select":
+      // Render status dropdown
+      break;
+    case "size-select":
+      // Render task size dropdown
+      break;
+    case "wikilink":
+      // Render wikilink input with auto-wrapping
+      break;
+  }
+}
+```
+
+## Usage Examples
+
+### Creating a Task with Dynamic Fields
+
+1. Navigate to a Project or Area note
+2. Click "Create Task" button or use Command Palette
+3. Fill in the dynamically generated form:
+   - **Label**: Display name for the task
+   - **Task Size**: XXS, XS, S, or M
+   - **Status**: Draft, Active, Done, or Cancelled
+   - **Parent**: Auto-filled with current note
+   - **Area**: Inherited from parent
+4. Click "Create" to generate the task
+
+### Creating a Project with Custom Properties
+
+If your ontology defines custom properties for Projects (e.g., `ems__Project_budget`), these will appear automatically in the creation modal.
+
+## Ontology Requirements
+
+For dynamic fields to work, your ontology must define:
+
+### 1. Class Definitions
+
+```turtle
+ems:Task a rdfs:Class ;
+    rdfs:subClassOf ems:Effort ;
+    rdfs:label "Task" .
+```
+
+### 2. Property Definitions with Domain
+
+```turtle
+ems:Effort_taskSize a rdf:Property ;
+    rdfs:domain ems:Task ;
+    rdfs:range ems:TaskSize ;
+    rdfs:label "Task Size" ;
+    rdfs:comment "Estimated size of the task" .
+```
+
+### 3. Range Types for Field Detection
+
+```turtle
+# For text fields
+exo:Asset_label a rdf:Property ;
+    rdfs:domain exo:Asset ;
+    rdfs:range xsd:string .
+
+# For datetime fields
+ems:Effort_startTimestamp a rdf:Property ;
+    rdfs:domain ems:Effort ;
+    rdfs:range xsd:dateTime .
+```
+
+See [Ontology Extension Guide](./ONTOLOGY_EXTENSION.md) for detailed instructions on adding custom properties.
+
+## Fallback Behavior
+
+When the ontology is unavailable or contains no properties for a class, the modal falls back to default fields:
+
+### For Tasks (`ems__Task`)
+
+- Label (text)
+- Task Size (dropdown)
+- Open in new tab (toggle)
+
+### For Other Classes
+
+- Label (text)
+- Open in new tab (toggle)
+
+## Troubleshooting
+
+### "Loading properties..." never completes
+
+**Cause**: SPARQL query to ontology is failing.
+
+**Solution**:
+1. Check that your vault contains ontology files with `exo__Instance_class: exo__Ontology`
+2. Verify the default ontology is set in Settings
+3. Check the console for SPARQL errors (Cmd/Ctrl+Shift+I → Console)
+
+### Properties not appearing
+
+**Cause**: Properties may not have correct `rdfs:domain` or may be deprecated.
+
+**Solution**:
+1. Verify the property has `rdfs:domain` matching the target class
+2. Check if property has `owl:deprecated true` (deprecated properties are hidden)
+3. Use SPARQL Query Builder to inspect the ontology
+
+### Wrong field type
+
+**Cause**: The `rdfs:range` type is not recognized.
+
+**Solution**:
+1. Ensure `rdfs:range` uses standard XSD types or known EMS/EXO types
+2. Unknown range types default to text fields
+3. Check the type mapping table above
+
+## Architecture
+
+### Components
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   CreateTaskCommand                      │
+│  - Checks useDynamicPropertyFields setting              │
+│  - Opens appropriate modal                               │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+        ┌───────────────┴───────────────┐
+        ▼                               ▼
+┌───────────────────┐       ┌───────────────────────────┐
+│  LabelInputModal  │       │ DynamicAssetCreationModal │
+│  (fallback)       │       │ (ontology-driven)         │
+└───────────────────┘       └─────────────┬─────────────┘
+                                          │
+                            ┌─────────────┴─────────────┐
+                            ▼                           │
+                ┌───────────────────────┐               │
+                │ OntologySchemaService │               │
+                │ - getClassProperties  │               │
+                │ - getClassHierarchy   │               │
+                │ - isDeprecatedProperty│               │
+                └───────────────────────┘               │
+                            │                           │
+                            ▼                           │
+                ┌───────────────────────┐               │
+                │  SPARQLQueryService   │◄──────────────┘
+                │  (queries ontology)   │
+                └───────────────────────┘
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `DynamicAssetCreationModal.ts` | Modal UI with dynamic field rendering |
+| `OntologySchemaService.ts` | Queries class properties from ontology |
+| `ExocortexSettings.ts` | Contains `useDynamicPropertyFields` setting |
+| `ExocortexSettingTab.ts` | Settings UI with toggle |
+| `CreateTaskCommand.ts` | Uses setting to choose modal type |
+
+## Related Documentation
+
+- [Ontology Extension Guide](./ONTOLOGY_EXTENSION.md) - Add custom properties to your ontology
+- [SPARQL User Guide](./sparql/User-Guide.md) - Query your ontology data
+- [Property Schema Reference](./PROPERTY_SCHEMA.md) - Standard frontmatter properties
+- [Getting Started](./Getting-Started.md) - Initial plugin setup
+
+## Version History
+
+| Version | Changes |
+|---------|---------|
+| v14.x | Initial experimental release |
+| - | Dynamic field generation from ontology |
+| - | Property inheritance support |
+| - | Type-specific field widgets |
+| - | Deprecated property filtering |

--- a/docs/ONTOLOGY_EXTENSION.md
+++ b/docs/ONTOLOGY_EXTENSION.md
@@ -1,0 +1,378 @@
+# Ontology Extension Guide
+
+> Learn how to extend the Exocortex ontology with custom properties that automatically appear in asset creation modals.
+
+## Overview
+
+The Exocortex ontology defines the structure of your knowledge base: what types of assets exist (Task, Project, Area, etc.) and what properties they have. When you enable [Dynamic Property Fields](./DYNAMIC_FIELDS.md), the plugin reads this ontology to generate creation forms automatically.
+
+This guide shows you how to:
+
+1. Understand the existing ontology structure
+2. Add custom properties to existing classes
+3. Create new classes with their own properties
+4. Validate your ontology extensions
+
+## Prerequisites
+
+- Basic understanding of RDF/RDFS concepts
+- Exocortex plugin installed and configured
+- Default ontology asset set in plugin settings
+
+## Understanding the Ontology Structure
+
+### Where the Ontology Lives
+
+Ontology definitions are stored in markdown notes with frontmatter. The plugin recognizes ontology files by:
+
+```yaml
+---
+exo__Instance_class: exo__Ontology
+exo__Ontology_url: "https://exocortex.my/ontology/ems#"
+---
+```
+
+### Class Hierarchy
+
+The Exocortex ontology follows a class hierarchy:
+
+```
+exo__Asset (base class)
+├── ems__Effort (time-tracked work)
+│   ├── ems__Task (individual task)
+│   ├── ems__Project (collection of tasks)
+│   ├── ems__Meeting (scheduled event)
+│   └── ems__Initiative (high-level goal)
+├── ems__Area (organizational container)
+├── pn__DailyNote (daily planning note)
+└── exo__Ontology (ontology definition)
+```
+
+### Property Domains
+
+Properties are linked to classes via `rdfs:domain`:
+
+```turtle
+# This property belongs to ems__Effort and all its subclasses
+ems:Effort_status a rdf:Property ;
+    rdfs:domain ems:Effort ;
+    rdfs:range ems:EffortStatus .
+```
+
+When you add a property with `rdfs:domain ems:Effort`, it automatically appears in creation modals for:
+- `ems__Task` (extends Effort)
+- `ems__Project` (extends Effort)
+- `ems__Meeting` (extends Effort)
+- `ems__Initiative` (extends Effort)
+
+## Adding Custom Properties
+
+### Step 1: Choose the Right Domain
+
+Decide which class(es) should have your new property:
+
+| If you want the property on... | Set rdfs:domain to... |
+|-------------------------------|----------------------|
+| All assets | `exo:Asset` |
+| All time-tracked work | `ems:Effort` |
+| Tasks only | `ems:Task` |
+| Projects only | `ems:Project` |
+| Areas only | `ems:Area` |
+
+### Step 2: Define the Property
+
+Add the property definition to your ontology file. The property must include:
+
+1. **URI**: Unique identifier following naming conventions
+2. **rdfs:domain**: Which class(es) have this property
+3. **rdfs:range**: What type of value it holds
+4. **rdfs:label**: Human-readable name (shown in modal)
+5. **rdfs:comment** (optional): Description (shown as tooltip)
+
+#### Example: Add Priority Property to Tasks
+
+```turtle
+# In your ontology file body:
+
+ems:Task_priority a rdf:Property ;
+    rdfs:domain ems:Task ;
+    rdfs:range xsd:integer ;
+    rdfs:label "Priority" ;
+    rdfs:comment "Task priority (1-5, where 1 is highest)" .
+```
+
+In markdown frontmatter format:
+
+```yaml
+---
+exo__Instance_class: rdf__Property
+exo__Asset_label: "Task Priority"
+rdf__Property_domain: "[[ems__Task]]"
+rdf__Property_range: xsd:integer
+rdfs__label: "Priority"
+rdfs__comment: "Task priority (1-5, where 1 is highest)"
+---
+
+# Task Priority Property
+
+This property defines the priority level for tasks.
+```
+
+### Step 3: Choose the Right Range Type
+
+The `rdfs:range` determines what UI widget appears in the modal:
+
+#### Text Input
+
+```turtle
+myns:Project_clientName a rdf:Property ;
+    rdfs:domain ems:Project ;
+    rdfs:range xsd:string ;
+    rdfs:label "Client Name" .
+```
+
+#### Number Input
+
+```turtle
+myns:Project_budget a rdf:Property ;
+    rdfs:domain ems:Project ;
+    rdfs:range xsd:decimal ;
+    rdfs:label "Budget" ;
+    rdfs:comment "Project budget in dollars" .
+```
+
+#### DateTime Picker
+
+```turtle
+myns:Meeting_scheduledFor a rdf:Property ;
+    rdfs:domain ems:Meeting ;
+    rdfs:range xsd:dateTime ;
+    rdfs:label "Scheduled For" .
+```
+
+#### Toggle (Boolean)
+
+```turtle
+myns:Task_requiresReview a rdf:Property ;
+    rdfs:domain ems:Task ;
+    rdfs:range xsd:boolean ;
+    rdfs:label "Requires Review" ;
+    rdfs:comment "Whether this task needs peer review before completion" .
+```
+
+#### Wikilink Reference
+
+```turtle
+myns:Task_assignee a rdf:Property ;
+    rdfs:domain ems:Task ;
+    rdfs:range ems:Person ;
+    rdfs:label "Assignee" ;
+    rdfs:comment "Person responsible for this task" .
+```
+
+### Step 4: Verify in Modal
+
+1. Enable "Use dynamic property fields" in Settings
+2. Navigate to a note where you can create the target asset type
+3. Invoke the creation command
+4. Verify your new property appears in the modal
+
+## Creating Custom Classes
+
+### Step 1: Define the Class
+
+```turtle
+myns:Sprint a rdfs:Class ;
+    rdfs:subClassOf ems:Effort ;
+    rdfs:label "Sprint" ;
+    rdfs:comment "A time-boxed development iteration" .
+```
+
+### Step 2: Add Class-Specific Properties
+
+```turtle
+myns:Sprint_velocity a rdf:Property ;
+    rdfs:domain myns:Sprint ;
+    rdfs:range xsd:integer ;
+    rdfs:label "Velocity" ;
+    rdfs:comment "Story points completed in this sprint" .
+
+myns:Sprint_goal a rdf:Property ;
+    rdfs:domain myns:Sprint ;
+    rdfs:range xsd:string ;
+    rdfs:label "Sprint Goal" .
+```
+
+### Step 3: Register for Commands
+
+To use your custom class with Exocortex commands, instances must use the class name in frontmatter:
+
+```yaml
+---
+exo__Instance_class: myns__Sprint
+exo__Asset_label: "Sprint 42"
+myns__Sprint_velocity: 21
+myns__Sprint_goal: "Complete user authentication"
+---
+```
+
+## Deprecating Properties
+
+When a property is no longer recommended for use, mark it as deprecated:
+
+```turtle
+ems:Effort_oldStatus a rdf:Property ;
+    rdfs:domain ems:Effort ;
+    rdfs:range xsd:string ;
+    rdfs:label "Old Status" ;
+    owl:deprecated true .
+```
+
+Deprecated properties:
+- Are hidden from creation modals
+- Continue to work in existing assets
+- Can be queried via SPARQL
+- Should be migrated over time
+
+## Namespace Conventions
+
+### Standard Namespaces
+
+| Prefix | URI | Purpose |
+|--------|-----|---------|
+| `exo` | `https://exocortex.my/ontology/exo#` | Core asset properties |
+| `ems` | `https://exocortex.my/ontology/ems#` | Effort management system |
+| `pn` | `https://exocortex.my/ontology/pn#` | Personal notes |
+| `rdfs` | `http://www.w3.org/2000/01/rdf-schema#` | RDF Schema |
+| `xsd` | `http://www.w3.org/2001/XMLSchema#` | XML Schema datatypes |
+| `owl` | `http://www.w3.org/2002/07/owl#` | OWL ontology |
+
+### Custom Namespace
+
+For your own extensions, use a consistent prefix:
+
+```turtle
+# Define your namespace
+@prefix myns: <https://example.com/ontology/myns#> .
+
+# Use it for properties
+myns:Task_customField a rdf:Property ;
+    rdfs:domain ems:Task ;
+    rdfs:range xsd:string .
+```
+
+In frontmatter, use double-underscore format:
+
+```yaml
+myns__Task_customField: "value"
+```
+
+## Complete Example: Adding a Team Property
+
+### 1. Create the Team Class
+
+```yaml
+---
+exo__Instance_class: rdfs__Class
+exo__Asset_label: "Team"
+rdfs__subClassOf: "[[exo__Asset]]"
+rdfs__comment: "A group of people working together"
+---
+
+# Team Class
+
+Represents a team that can be assigned to projects and tasks.
+```
+
+### 2. Add Team Property to Efforts
+
+```yaml
+---
+exo__Instance_class: rdf__Property
+exo__Asset_label: "Team"
+rdf__Property_domain: "[[ems__Effort]]"
+rdf__Property_range: "[[myns__Team]]"
+rdfs__label: "Team"
+rdfs__comment: "The team responsible for this effort"
+---
+
+# Team Property
+
+Assigns a team to any effort (task, project, meeting, etc.).
+```
+
+### 3. Create Team Instances
+
+```yaml
+---
+exo__Instance_class: myns__Team
+exo__Asset_label: "Frontend Team"
+myns__Team_memberCount: 5
+---
+
+# Frontend Team
+
+The team responsible for UI development.
+```
+
+### 4. Use in Tasks
+
+```yaml
+---
+exo__Instance_class: ems__Task
+exo__Asset_label: "Implement login form"
+ems__Effort_team: "[[Frontend Team]]"
+ems__Effort_status: "[[ems__EffortStatusToDo]]"
+---
+```
+
+## Validation Checklist
+
+Before expecting your property to appear in modals:
+
+- [ ] Property has `rdfs:domain` matching target class (or parent class)
+- [ ] Property has `rdfs:range` with recognized type
+- [ ] Property has `rdfs:label` for display name
+- [ ] Property is NOT marked `owl:deprecated true`
+- [ ] Ontology file has `exo__Instance_class: exo__Ontology`
+- [ ] Default ontology is set in plugin settings
+- [ ] "Use dynamic property fields" is enabled in settings
+
+## Troubleshooting
+
+### Property Not Appearing in Modal
+
+1. **Check domain**: Is `rdfs:domain` set to the correct class?
+2. **Check inheritance**: Does the target class extend the domain class?
+3. **Check deprecated**: Is `owl:deprecated` set to `true`?
+4. **Refresh ontology**: Close and reopen the modal
+
+### Wrong Field Type
+
+1. **Check range**: Is `rdfs:range` using a recognized type?
+2. **Use standard types**: Prefer `xsd:string`, `xsd:dateTime`, `xsd:integer`, `xsd:boolean`
+3. **For dropdowns**: Range must reference a class like `ems:EffortStatus`
+
+### SPARQL Verification
+
+Use the Query Builder to verify your ontology:
+
+```sparql
+# List all properties for a class
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?property ?label ?range WHERE {
+  ?property rdfs:domain ems:Task .
+  OPTIONAL { ?property rdfs:label ?label }
+  OPTIONAL { ?property rdfs:range ?range }
+}
+ORDER BY ?label
+```
+
+## Related Documentation
+
+- [Dynamic Property Fields Guide](./DYNAMIC_FIELDS.md) - How the feature works
+- [SPARQL User Guide](./sparql/User-Guide.md) - Query your ontology
+- [Property Schema Reference](./PROPERTY_SCHEMA.md) - Standard properties
+- [ExoRDF Mapping](./rdf/ExoRDF-Mapping.md) - RDF/RDFS mapping details


### PR DESCRIPTION
## Summary

Comprehensive documentation for the Dynamic Property Fields experimental feature (#661).

- **docs/DYNAMIC_FIELDS.md**: Complete guide covering feature overview, enabling the toggle, how property resolution works, field type detection, architecture, and troubleshooting
- **docs/ONTOLOGY_EXTENSION.md**: Tutorial for extending the ontology with custom properties and classes
- **README.md**: Updated with new section and links

## Changes

### New Files
- `docs/DYNAMIC_FIELDS.md` (~250 lines) - Complete feature documentation
- `docs/ONTOLOGY_EXTENSION.md` (~350 lines) - Ontology extension tutorial

### Updated Files
- `README.md` - Added Dynamic Property Fields section after SPARQL, updated Plugin Settings table, added links in Advanced Topics

## Test plan

- [x] Documentation only - no code changes
- [x] Lint passes (only pre-existing warnings)
- [x] All file links resolve correctly
- [ ] CI pipeline passes

Closes #661