### PR TITLE
feat: extend CreateInstanceCommand to use dynamic property fields

### DIFF
--- a/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
+++ b/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
@@ -90,7 +90,7 @@ export class CommandRegistry {
     this.commands = [
       new CreateTaskCommand(app, taskCreationService, this.vaultAdapter, plugin),
       new CreateProjectCommand(app, projectCreationService, this.vaultAdapter),
-      new CreateInstanceCommand(app, taskCreationService, this.vaultAdapter),
+      new CreateInstanceCommand(app, taskCreationService, this.vaultAdapter, plugin),
       new CreateFleetingNoteCommand(app, fleetingNoteCreationService, this.vaultAdapter),
       new CreateRelatedTaskCommand(app, taskCreationService, this.vaultAdapter),
       new SetDraftStatusCommand(taskStatusService),


### PR DESCRIPTION
## Summary
- Extends `CreateInstanceCommand` to use the `useDynamicPropertyFields` feature toggle
- When toggle is ON, uses `DynamicAssetCreationModal` with the class name from context
- When toggle is OFF, falls back to `LabelInputModal` (existing behavior)
- Works for any class type (Task, Effort, custom classes)

## Changes
- Updated `CreateInstanceCommand` constructor to accept `ExocortexPluginInterface`
- Added `showModal()` method that selects modal based on feature toggle
- Updated `CommandRegistry` to pass plugin reference to command
- Added 5 new unit tests for dynamic modal functionality

## Test Plan
- [x] Unit tests pass (16 tests, 5 new)
- [x] Component tests pass (505 passed)
- [x] Build succeeds
- [x] Existing behavior preserved when toggle is OFF

## Acceptance Criteria
- [x] CreateInstanceCommand checks feature toggle
- [x] Uses className parameter from context
- [x] Uses DynamicAssetCreationModal when toggle ON
- [x] Works for any class (Task, Effort, custom)
- [x] Fallback to old behavior when toggle OFF

Closes #659