### PR TITLE
test: add regression tests for angle bracket handling in filenames

### DIFF
--- a/packages/core/tests/unit/domain/rdf/IRI.test.ts
+++ b/packages/core/tests/unit/domain/rdf/IRI.test.ts
@@ -120,4 +120,43 @@ describe("IRI", () => {
       expect(iri.value).toBe("https://example.com/リソース");
     });
   });
+
+  // Issue #682: Ensure angle brackets are handled correctly in IRIs
+  describe("angle bracket handling (Issue #682)", () => {
+    it("should accept percent-encoded angle brackets in obsidian:// URI", () => {
+      const iri = new IRI("obsidian://vault/File%3Ctest%3E.md");
+      expect(iri.value).toBe("obsidian://vault/File%3Ctest%3E.md");
+    });
+
+    it("should accept unencoded angle brackets in obsidian:// URI", () => {
+      // Node.js URL API is lenient and accepts these
+      const iri = new IRI("obsidian://vault/File<test>.md");
+      expect(iri.value).toBe("obsidian://vault/File<test>.md");
+    });
+
+    it("should accept percent-encoded angle brackets in https:// URI", () => {
+      const iri = new IRI("https://example.com/File%3Ctest%3E.md");
+      expect(iri.value).toBe("https://example.com/File%3Ctest%3E.md");
+    });
+
+    it("should accept unencoded angle brackets in https:// URI", () => {
+      // Node.js URL API is lenient and accepts these
+      const iri = new IRI("https://example.com/File<test>.md");
+      expect(iri.value).toBe("https://example.com/File<test>.md");
+    });
+
+    it("should accept generic type syntax in namespace URIs", () => {
+      const iri = new IRI("https://exocortex.my/ontology/exo#Query<?>");
+      expect(iri.value).toBe("https://exocortex.my/ontology/exo#Query<?>");
+    });
+
+    it("should accept complex generic type in file path", () => {
+      const iri = new IRI(
+        "obsidian://vault/01%20Inbox/GetAreaChain%20(exo__Query%3Cems__Area%3E).md"
+      );
+      expect(iri.value).toBe(
+        "obsidian://vault/01%20Inbox/GetAreaChain%20(exo__Query%3Cems__Area%3E).md"
+      );
+    });
+  });
 });

--- a/packages/core/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/core/tests/unit/services/NoteToRDFConverter.test.ts
@@ -1146,5 +1146,45 @@ describe("NoteToRDFConverter", () => {
         expect((iri.value.match(/\//g) || []).length).toBe(9);
       });
     });
+
+    // Issue #682: Ensure angle brackets in filenames are properly encoded
+    describe("angle bracket encoding (Issue #682)", () => {
+      it("should encode angle brackets in filename to %3C and %3E", () => {
+        const iri = converter.notePathToIRI("Notes/File<test>.md");
+        expect(iri.value).toBe("obsidian://vault/Notes/File%3Ctest%3E.md");
+        // Verify angle brackets are NOT present unencoded
+        expect(iri.value).not.toContain("<");
+        expect(iri.value).not.toContain(">");
+      });
+
+      it("should handle generic type syntax in filenames (common ontology pattern)", () => {
+        const iri = converter.notePathToIRI("01 Inbox/GetAreaChain (exo__Query<ems__Area>).md");
+        expect(iri.value).toBe(
+          "obsidian://vault/01%20Inbox/GetAreaChain%20(exo__Query%3Cems__Area%3E).md"
+        );
+        // Verify spaces, angle brackets are encoded but slashes preserved
+        expect(iri.value).not.toContain(" ");
+        expect(iri.value).not.toContain("<");
+        expect(iri.value).not.toContain(">");
+        expect(iri.value).not.toContain("%2F");
+      });
+
+      it("should handle multiple angle bracket pairs in filename", () => {
+        const iri = converter.notePathToIRI("Types/Map<K, V> extends Collection<T>.md");
+        expect(iri.value).toBe(
+          "obsidian://vault/Types/Map%3CK,%20V%3E%20extends%20Collection%3CT%3E.md"
+        );
+      });
+
+      it("should handle angle brackets in folder path", () => {
+        const iri = converter.notePathToIRI("Generic<Types>/SpecificType.md");
+        expect(iri.value).toBe("obsidian://vault/Generic%3CTypes%3E/SpecificType.md");
+      });
+
+      it("should encode nested generic types", () => {
+        const iri = converter.notePathToIRI("Query<List<Item>>.md");
+        expect(iri.value).toBe("obsidian://vault/Query%3CList%3CItem%3E%3E.md");
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

**Issue #682 cannot be reproduced with the current codebase.**

Testing confirms that:
1. `encodeURI()` correctly encodes angle brackets to `%3C` and `%3E`
2. The `IRI` class accepts both encoded and unencoded angle brackets
3. Files with angle brackets in names are correctly processed by the CLI

The issue description incorrectly stated that `encodeURI()` does not encode angle brackets - it does.

## What Changed

Added 11 regression tests to prevent any future regressions:

**IRI class tests (6 tests):**
- Accept percent-encoded angle brackets in obsidian:// URI
- Accept unencoded angle brackets in obsidian:// URI
- Accept percent-encoded angle brackets in https:// URI
- Accept unencoded angle brackets in https:// URI
- Accept generic type syntax in namespace URIs
- Accept complex generic type in file path

**NoteToRDFConverter tests (5 tests):**
- Encode angle brackets in filename to `%3C` and `%3E`
- Handle generic type syntax in filenames (common ontology pattern)
- Handle multiple angle bracket pairs in filename
- Handle angle brackets in folder path
- Encode nested generic types

## Test Plan

- [x] All 11 new tests pass
- [x] Full test suite passes
- [x] Manual verification with files containing angle brackets

Closes #682