### PR TITLE
docs: document EditPropertiesCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Exocortex is a powerful Obsidian plugin that transforms your notes into an inter
 - 📦 **Archive Filtering**: Toggle visibility of archived tasks and projects in DailyNote layouts (default: hidden)
 - ⚡ **High Performance**: O(1) relation lookups via reverse indexing
 - 📱 **Mobile Compatible**: Full touch-optimized UI for desktop and mobile
-- ⌨️ **24 Commands**: Comprehensive command palette integration for all operations
+- ⌨️ **32 Commands**: Comprehensive command palette integration for all operations
 - 🎨 **Action Buttons**: Context-aware UI buttons for quick access to relevant commands
 - 🔍 **SPARQL Query Blocks**: Execute semantic queries directly in markdown with `sparql` code blocks - results auto-refresh on vault changes
 
@@ -151,7 +151,7 @@ Keep your vault organized:
 | **Repair Folder** | Assets with exo__Asset_isDefinedBy | Move file to correct folder based on reference |
 | **Rename to UID** | Filename ≠ exo__Asset_uid | Rename file to match UID, preserve label |
 
-### System Commands (6)
+### System Commands (7)
 
 Control plugin behavior and visualization:
 
@@ -162,6 +162,7 @@ Control plugin behavior and visualization:
 | **Toggle Layout Visibility** | Yes | Show/hide entire layout section |
 | **Toggle Properties Visibility** | Yes | Show/hide properties table |
 | **Toggle Archived Assets Visibility** | Yes | Show/hide archived assets in layout tables (persists in settings) |
+| **Edit Properties** | With frontmatter | Open modal for editing frontmatter properties |
 | **Open SPARQL Query Builder** | Yes | Visual query builder with templates, live preview, and copy-to-clipboard |
 
 ## 🏷️ Frontmatter Properties Reference

--- a/docs/Command-Reference.md
+++ b/docs/Command-Reference.md
@@ -604,6 +604,31 @@ Archived assets represent completed or inactive items that you want to keep for 
 
 Special-purpose commands.
 
+### Edit Properties
+
+**Command ID**: `edit-properties`
+**Keyboard**: Cmd/Ctrl + P → "Edit Properties"
+
+**Purpose**: Open a dedicated modal for editing frontmatter properties of the current note.
+
+**Usage**:
+1. Open any note with frontmatter
+2. Cmd/Ctrl + P → "Edit Properties"
+3. Modal shows all editable properties for the note's class
+4. Modify values using appropriate field types (text, datetime, toggles)
+5. Click Save to apply changes
+
+**Features**:
+- Class-aware property display (shows relevant properties for the note type)
+- Type-specific editors (datetime picker, text input, toggles)
+- Wiki-link property support
+- Validation before save
+- Layout auto-refresh after save
+
+**Visibility**: Available on notes with frontmatter.
+
+---
+
 ### Open Query Builder
 
 **Command ID**: `open-query-builder`
@@ -657,6 +682,7 @@ Special-purpose commands.
 | Toggle Properties Visibility | View | Cmd/Ctrl+P | Yes |
 | Toggle Archived Assets Visibility | View | Cmd/Ctrl+P | Yes |
 | Reload Layout | View | Cmd/Ctrl+P | Yes |
+| Edit Properties | Utility | Cmd/Ctrl+P | No |
 | Open Query Builder | Utility | Cmd/Ctrl+P | Yes |
 
 ---
@@ -673,6 +699,7 @@ Commands appear contextually based on note type and state:
 | `ems__Project` | Create Task, Status commands, Planning commands, Convert to Task |
 | `ems__Area` | Create Project |
 | `pn__DailyNote` | Create Task, Set Focus Area |
+| Any (with frontmatter) | Edit Properties |
 | Any | Clean Properties, Reload Layout, Open Query Builder, Toggle Archived Assets Visibility |
 
 ### By Status


### PR DESCRIPTION
## Summary

Documents the previously undocumented `EditPropertiesCommand` in the documentation.

### Changes
- Add Edit Properties command documentation to `docs/Command-Reference.md`
- Add Edit Properties to README.md System Commands table (7 commands now)
- Update command count in README features from 24 to 32 (was outdated)

### Clarification on Issue #697

The issue mentioned three commands as undocumented:
- `ConvertTaskToProjectCommand` - **Already documented** in Command-Reference.md (lines 472-487)
- `ConvertProjectToTaskCommand` - **Already documented** in Command-Reference.md (lines 491-505)
- `EditPropertiesCommand` - **Was missing**, now documented

Only EditPropertiesCommand was actually undocumented.

Closes #697