### PR TITLE
docs: clarify Create Fleeting Note vs Add Supervision commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,14 +215,15 @@ Keep your vault organized:
 | **Repair Folder** | Assets with exo__Asset_isDefinedBy | Move file to correct folder based on reference |
 | **Rename to UID** | Filename ≠ exo__Asset_uid | Rename file to match UID, preserve label |
 
-### System Commands (7)
+### System Commands (8)
 
 Control plugin behavior and visualization:
 
 | Command | Always Available | Action |
 |---------|-----------------|--------|
 | **Reload Layout** | Yes | Manually refresh layout rendering |
-| **Add Supervision** | Yes | Create CBT-format fleeting note in 01 Inbox |
+| **Create Fleeting Note** | Yes | Create quick-capture note with label in 01 Inbox |
+| **Add Supervision** | Yes | Create CBT diary record (structured fleeting note with situation/emotions/thoughts/behavior) |
 | **Toggle Layout Visibility** | Yes | Show/hide entire layout section |
 | **Toggle Properties Visibility** | Yes | Show/hide properties table |
 | **Toggle Archived Assets Visibility** | Yes | Show/hide archived assets in layout tables (persists in settings) |

--- a/docs/Command-Reference.md
+++ b/docs/Command-Reference.md
@@ -139,14 +139,37 @@ ems__Effort_status: "[[ems__EffortStatusBacklog]]"
 **Button**: "Add Supervision"
 **Keyboard**: Cmd/Ctrl + P → "Add Supervision"
 
-**Purpose**: Create supervision relationship for tracking oversight.
+**Purpose**: Create a structured CBT (Cognitive Behavioral Therapy) diary record for self-reflection.
 
 **Usage**:
-1. Open note to supervise
-2. Click "Add Supervision" button
-3. Fill form with supervisor details
+1. Cmd/Ctrl + P → "Add Supervision"
+2. Fill form with CBT fields:
+   - **Situation/trigger**: What happened
+   - **Emotions**: How you felt
+   - **Thoughts**: What you were thinking
+   - **Behavior**: What you did
+   - **Short-term consequences**: Immediate effects
+   - **Long-term consequences**: Future implications
+3. Click OK
 
-**Visibility**: Available on effort assets.
+**Result**: Creates specialized fleeting note in `01 Inbox/` with:
+```yaml
+---
+exo__Instance_class: ztlk__FleetingNote
+ztlk__FleetingNote_type: "[[CBT-Diary Record]]"
+---
+
+- Ситуация/триггер: [situation]
+- Эмоции: [emotions]
+- Мысли: [thoughts]
+- Поведение: [behavior]
+- Краткосрочные последствия поведения: [short-term]
+- Долгосрочные последствия поведения: [long-term]
+```
+
+**Visibility**: Always available.
+
+**Note**: This is a specialized fleeting note for CBT self-reflection. For simple quick-capture notes, use [Create Fleeting Note](#create-fleeting-note).
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes documentation inconsistency between "Create Fleeting Note" and "Add Supervision" commands.

### Changes

**README.md:**
- Added missing "Create Fleeting Note" command to System Commands table
- Updated command count from 7 to 8
- Clarified that "Add Supervision" creates CBT diary records, not generic fleeting notes

**Command-Reference.md:**
- Fixed misleading "Add Supervision" description (was: "supervision relationship for tracking oversight")
- Documented actual CBT diary functionality with all form fields
- Added example YAML output showing frontmatter and body structure
- Added cross-reference to "Create Fleeting Note" for users who want simple quick-capture

### Investigation Summary

Both commands exist and serve different purposes:

| Command | Purpose | Output |
|---------|---------|--------|
| Create Fleeting Note | Quick capture with just a label | Generic fleeting note |
| Add Supervision | CBT diary record | Structured note with situation/emotions/thoughts/behavior/consequences |

Closes #695