### PR TITLE
docs: update ARCHITECTURE.md service count (14 → 25)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -539,27 +539,39 @@ describe("PropertyCleanupService with DI", () => {
 
 ## 🔧 Component Responsibilities
 
-### Services (14 Total)
+### Services (25 Total)
 
 | Service | Responsibility | LOC | Dependencies | Pure Logic % |
 |---------|----------------|-----|--------------|--------------|
-| **TaskCreationService** | Create tasks from areas/projects/prototypes | 354 | Vault | 60% |
-| **ProjectCreationService** | Create projects from areas/initiatives | 80 | Vault | 60% |
-| **ConceptCreationService** | Create narrower concepts | 65 | Vault | 70% |
+| **AlgorithmExtractor** | Extract H2 sections from markdown content | 32 | None | **100%** ✅ |
 | **AreaCreationService** | Create child areas | 66 | Vault | 60% |
-| **TaskStatusService** | Manage effort status transitions | 372 | Vault | 70% |
-| **EffortVotingService** | Increment effort vote counts | 98 | Vault | 80% |
-| **PropertyCleanupService** | Remove empty properties from frontmatter | 133 | Vault | 80% |
-| **LabelToAliasService** | Copy labels to aliases array | 68 | Vault | 70% |
-| **SupervisionCreationService** | Create CBT supervision notes | 71 | Vault | 80% |
-| **AreaHierarchyBuilder** | Build area hierarchy trees | 195 | Vault, MetadataCache | 50% |
-| **FrontmatterService** | Parse/manipulate YAML frontmatter | 303 | **None** | **100%** ✅ |
-| **RenameToUidService** | Rename files to UID format | 49 | App.fileManager | 0% |
-| **FolderRepairService** | Move files to expected folders | 114 | Vault, MetadataCache | 10% |
+| **AreaHierarchyBuilder** | Build area hierarchy trees | 163 | Vault, MetadataCache | 50% |
+| **AssetConversionService** | Convert between asset classes (Task↔Project) | 147 | Vault | 70% |
+| **ClassCreationService** | Create subclasses in ontology | 76 | Vault | 60% |
+| **ConceptCreationService** | Create narrower concepts | 69 | Vault | 70% |
+| **DynamicFrontmatterGenerator** | Generate YAML frontmatter from property definitions | 363 | None | **100%** ✅ |
+| **EffortStatusWorkflow** | Determine previous status in workflow | 66 | None | **100%** ✅ |
+| **EffortVotingService** | Increment effort vote counts | 103 | Vault | 80% |
+| **FleetingNoteCreationService** | Create fleeting note assets in inbox | 57 | Vault | 70% |
+| **FolderRepairService** | Move files to expected folders | 118 | Vault, MetadataCache | 10% |
+| **LabelToAliasService** | Copy labels to aliases array | 74 | Vault | 70% |
+| **LoggingService** | Centralized logging with debug/info/warn/error | 29 | None | **100%** ✅ |
+| **NoteToRDFConverter** | Convert Obsidian notes to RDF triples | 323 | Vault | 60% |
+| **PlanningService** | Set plannedStartTimestamp on tasks | 37 | Vault | 70% |
+| **ProjectCreationService** | Create projects from areas/initiatives | 86 | Vault | 60% |
+| **PropertyCleanupService** | Remove empty properties from frontmatter | 144 | Vault | 80% |
+| **RenameToUidService** | Rename files to UID format | 93 | App.fileManager | 0% |
+| **SessionEventService** | Track focus session start/end events | 116 | Vault | 60% |
+| **StatusTimestampService** | Manage start/end/resolution timestamps | 153 | Vault | 70% |
+| **SupervisionCreationService** | Create CBT supervision notes | 76 | Vault | 80% |
+| **TaskCreationService** | Create tasks from areas/projects/prototypes | 186 | Vault | 60% |
+| **TaskFrontmatterGenerator** | Generate frontmatter for new tasks | 125 | None | **100%** ✅ |
+| **TaskStatusService** | Manage effort status transitions | 290 | Vault | 70% |
+| **URIConstructionService** | Construct URIs for assets | 111 | FileSystem | 50% |
 
-**Total Lines**: ~2,175 (services only)
+**Total Lines**: ~3,103 (services only)
 
-### Utilities (5 Total)
+### Utilities (6 Total)
 
 | Utility | Purpose | LOC | Obsidian Deps | Type |
 |---------|---------|-----|---------------|------|


### PR DESCRIPTION
## Summary

Fixes #692 - ARCHITECTURE.md understates service count

Updates the services section to accurately reflect all **25 services** in `packages/core/src/services/`.

### Changes

**Added 12 missing services:**
| Service | Responsibility |
|---------|----------------|
| AlgorithmExtractor | Extract H2 sections from markdown content |
| AssetConversionService | Convert between asset classes (Task↔Project) |
| ClassCreationService | Create subclasses in ontology |
| DynamicFrontmatterGenerator | Generate YAML frontmatter from property definitions |
| EffortStatusWorkflow | Determine previous status in workflow |
| FleetingNoteCreationService | Create fleeting note assets in inbox |
| LoggingService | Centralized logging with debug/info/warn/error |
| NoteToRDFConverter | Convert Obsidian notes to RDF triples |
| PlanningService | Set plannedStartTimestamp on tasks |
| SessionEventService | Track focus session start/end events |
| StatusTimestampService | Manage start/end/resolution timestamps |
| TaskFrontmatterGenerator | Generate frontmatter for new tasks |
| URIConstructionService | Construct URIs for assets |

**Also fixes:**
- Updated total line count from ~2,175 to ~3,103
- Fixed utilities count from "5 Total" to "6 Total" (table lists 6)
- Updated LOC values to match current implementation
- Removed duplicate FrontmatterService from services (it's in utilities)

## Test Plan

- [x] Verified actual service count via `ls packages/core/src/services/*.ts | wc -l` (25 files)
- [x] Verified line counts match actual implementation
- [x] All unit tests pass
- [x] No lint errors introduced