### PR TITLE
docs: update command count from 26 to 32 in documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -136,7 +136,7 @@ Exocortex follows **Clean Architecture** principles with clear separation of con
 **Location**: `packages/core/src/application/services/`
 
 **Components**:
-- `CommandManager` - Facade for all 26 commands
+- `CommandManager` - Facade for all 32 commands
 - 14 specialized services (TaskCreationService, ProjectCreationService, etc.)
 
 **Dependencies**: Domain layer, IFileSystemAdapter interface

--- a/docs/adr/0007-command-visibility-strategy.md
+++ b/docs/adr/0007-command-visibility-strategy.md
@@ -206,7 +206,7 @@ describe('CommandVisibility', () => {
 
 - **File**: `src/domain/commands/CommandVisibility.ts`
 - **Test**: `tests/unit/CommandVisibility.test.ts`
-- **Users**: CommandManager (26 commands), ButtonGroupsBuilder
+- **Users**: CommandManager (32 commands), ButtonGroupsBuilder
 - **Coverage**: 79% (target: 95% in Issue #123)
 
 ## Future

--- a/docs/diagrams/architecture-overview.mmd
+++ b/docs/diagrams/architecture-overview.mmd
@@ -15,7 +15,7 @@ graph TB
     end
 
     subgraph Application Layer
-        CommandMgr[CommandManager<br/>Facade for 26 commands]
+        CommandMgr[CommandManager<br/>Facade for 32 commands]
     end
 
     subgraph Infrastructure Layer - Services


### PR DESCRIPTION
## Summary

Update documentation to reflect the actual 32 commands registered in CommandRegistry.ts.

### Changes
- ARCHITECTURE.md line 139: 26 → 32 commands
- docs/diagrams/architecture-overview.mmd line 18: 26 → 32 commands  
- docs/adr/0007-command-visibility-strategy.md line 209: 26 → 32 commands

Note: README.md already shows correct count (32) per verification.

Closes #691