### PR TITLE
fix: Layout only renders in Reading Mode, not Edit Mode

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -203,6 +203,13 @@ export default class ExocortexPlugin extends Plugin {
       return;
     }
 
+    // Only render in Reading Mode (Preview), not in Edit Mode (Source/Live Preview)
+    // getMode() returns 'preview' for Reading Mode, 'source' for Edit Mode
+    const mode = view.getMode();
+    if (mode !== "preview") {
+      return;
+    }
+
     // Get the container element from the view
     // Use containerEl which contains the entire view DOM
     const viewContainer = view.containerEl;


### PR DESCRIPTION
## Summary

Fixes the layout rendering behavior to show in Reading Mode (Preview) only, not in Edit Mode (Live Preview).

**Problem:**
- Layout was displaying in Edit Mode but not in Reading Mode
- Users couldn't see related assets while reading notes
- Forced users to switch to Edit Mode to view relationships

**Solution:**
- Added `view.getMode()` check in `autoRenderLayout()`
- Layout now renders only when mode is `'preview'` (Reading Mode)
- Layout does NOT render in `'source'` mode (Edit Mode)

## Changes

- `packages/obsidian-plugin/src/ExocortexPlugin.ts`: Added mode check
- `packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts`: Added 3 new tests for mode-specific behavior

## Test Plan

- [x] Unit tests pass locally
- [x] Lint passes
- [x] Type checking passes
- [ ] CI pipeline passes
- [ ] Manual test: Open note in Reading Mode → Layout visible
- [ ] Manual test: Open note in Edit Mode → Layout not visible
- [ ] Manual test: Switch between modes → Layout appears/disappears correctly

Closes #723