### PR TITLE
feat: Implement IN / NOT IN operators for SPARQL

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -115,7 +115,8 @@ export type Expression =
   | RawFunctionCallExpression
   | VariableExpression
   | LiteralExpression
-  | ExistsExpression;
+  | ExistsExpression
+  | InExpression;
 
 export interface ComparisonExpression {
   type: "comparison";
@@ -165,6 +166,31 @@ export interface ExistsExpression {
   type: "exists";
   negated: boolean;
   pattern: AlgebraOperation;
+}
+
+/**
+ * IN / NOT IN expression for set membership testing.
+ * SPARQL 1.1 Section 17.4.1.5: Tests whether a value is in a list of values.
+ *
+ * Example:
+ * ```sparql
+ * FILTER(?status IN ("active", "pending", "review"))
+ * FILTER(?priority NOT IN (1, 2))
+ * ```
+ *
+ * Semantics:
+ * - IN returns true if the expression equals any value in the list
+ * - NOT IN returns true if the expression does not equal any value in the list
+ * - Comparison uses RDF term equality (=)
+ */
+export interface InExpression {
+  type: "in";
+  /** The expression being tested */
+  expression: Expression;
+  /** List of values to test against */
+  list: Expression[];
+  /** True for NOT IN, false for IN */
+  negated: boolean;
 }
 
 export interface JoinOperation {


### PR DESCRIPTION
## Summary

Implements SPARQL 1.1 IN and NOT IN operators (Section 17.4.1.5) for set membership testing.

**Before (verbose):**
```sparql
FILTER(?status = "active" || ?status = "pending" || ?status = "review")
```

**After (clean):**
```sparql
FILTER(?status IN ("active", "pending", "review"))
```

## Changes

- Added `InExpression` type to `AlgebraOperation.ts` with proper JSDoc documentation
- Added `translateInExpression` method to `AlgebraTranslator.ts` to parse `in`/`notin` operators from sparqljs
- Added `evaluateIn` method to `FilterExecutor.ts` using `BuiltInFunctions.compare` for RDF term equality
- Added recursive IN check in `expressionContainsExists` for proper EXISTS handling

## Test Coverage

**AlgebraTranslator tests (8 tests):**
- Translates IN with literal list
- Translates NOT IN operator
- Translates IN with numeric values
- Translates IN with variable in list
- Translates IN with empty list
- Translates IN combined with AND
- Translates IN combined with OR
- Translates NOT IN with complex filter

**FilterExecutor tests (8 tests):**
- IN matches when value is in list of numbers
- IN matches when value is in list of strings
- IN does not match when value is not in list
- IN works with variables in list
- IN handles empty list (no matches)
- NOT IN matches when value is NOT in list
- NOT IN matches all when list is empty
- NOT IN excludes items with blocked statuses

Closes #718