### PR TITLE
feat(sparql): implement ENCODE_FOR_URI function

### DIFF
--- a/packages/core/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -658,6 +658,21 @@ export class FilterExecutor {
           ? this.evaluateExpression(expr.args[1], solution)
           : this.evaluateExpression(expr.args[2], solution);
 
+      // SPARQL 1.1 String URI Functions
+      case "encode_for_uri":
+        const encodeArg = this.getStringValue(this.evaluateExpression(expr.args[0], solution));
+        return BuiltInFunctions.encodeForUri(encodeArg);
+
+      // SPARQL 1.1 RDF Term Functions
+      case "isnumeric":
+        const numericArg = this.getTermFromExpression(expr.args[0], solution);
+        return BuiltInFunctions.isNumeric(numericArg);
+
+      case "sameterm":
+        const sameTerm1 = this.getTermFromExpression(expr.args[0], solution);
+        const sameTerm2 = this.getTermFromExpression(expr.args[1], solution);
+        return BuiltInFunctions.sameTerm(sameTerm1, sameTerm2);
+
       default:
         throw new FilterExecutorError(`Unknown function: ${funcName}`);
     }

--- a/packages/core/src/infrastructure/sparql/filters/BuiltInFunctions.ts
+++ b/packages/core/src/infrastructure/sparql/filters/BuiltInFunctions.ts
@@ -739,6 +739,28 @@ export class BuiltInFunctions {
     return new Literal(String(num), new IRI("http://www.w3.org/2001/XMLSchema#decimal"));
   }
 
+  // SPARQL 1.1 String Functions (URI)
+  // https://www.w3.org/TR/sparql11-query/#func-encode
+
+  /**
+   * SPARQL 1.1 ENCODE_FOR_URI function.
+   * https://www.w3.org/TR/sparql11-query/#func-encode
+   *
+   * Percent-encodes a string for safe inclusion in a URI.
+   * Encodes all characters except unreserved characters (A-Z, a-z, 0-9, -, _, ., ~).
+   *
+   * @param str - String to encode
+   * @returns Percent-encoded string
+   *
+   * Examples:
+   * - ENCODE_FOR_URI("hello world") → "hello%20world"
+   * - ENCODE_FOR_URI("a/b?c=d") → "a%2Fb%3Fc%3Dd"
+   * - ENCODE_FOR_URI("Los Angeles") → "Los%20Angeles"
+   */
+  static encodeForUri(str: string): string {
+    return encodeURIComponent(str);
+  }
+
   // SPARQL 1.1 RDF Term Functions
   // https://www.w3.org/TR/sparql11-query/#func-sameTerm
 


### PR DESCRIPTION
## Summary

Implements the SPARQL 1.1 ENCODE_FOR_URI() function per Section 17.4.3.11, and wires existing `isNumeric` and `sameTerm` functions into the FilterExecutor.

### Changes

- **ENCODE_FOR_URI()**: Percent-encodes strings for safe URI inclusion
  - Encodes all characters except unreserved (A-Z, a-z, 0-9, -, _, ., ~)
  - Example: `ENCODE_FOR_URI("hello world")` → `"hello%20world"`
  - Example: `ENCODE_FOR_URI("a/b?c=d")` → `"a%2Fb%3Fc%3Dd"`

- **isNumeric()**: Wired existing BuiltInFunctions implementation into FilterExecutor
- **sameTerm()**: Wired existing BuiltInFunctions implementation into FilterExecutor

### Test Coverage

- 6 tests for ENCODE_FOR_URI (spaces, URL special chars, unicode, unreserved chars)
- 5 tests for isNumeric (integer, decimal, string, IRI, mixed filtering)
- 6 tests for sameTerm (identical IRIs, different IRIs, typed literals, cross-type)

## Test Plan

- [x] All 17 new tests pass
- [x] Existing 399 SPARQL tests pass
- [x] TypeScript compilation succeeds

Closes #717