### PR TITLE
feat: Implement SERVICE clause for federated SPARQL queries

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -15,7 +15,8 @@ export type AlgebraOperation =
   | ExtendOperation
   | SubqueryOperation
   | ConstructOperation
-  | AskOperation;
+  | AskOperation
+  | ServiceOperation;
 
 export interface BGPOperation {
   type: "bgp";
@@ -435,4 +436,51 @@ export interface AskOperation {
   type: "ask";
   /** The WHERE clause algebra pattern to test for existence */
   where: AlgebraOperation;
+}
+
+/**
+ * SERVICE operation for federated queries.
+ * Executes a graph pattern against a remote SPARQL endpoint.
+ *
+ * SPARQL 1.1 Federated Query:
+ * https://www.w3.org/TR/sparql11-federated-query/
+ *
+ * The SERVICE clause allows querying external SPARQL endpoints within
+ * a local query. Results from the remote endpoint are joined with
+ * local query patterns.
+ *
+ * Example:
+ * ```sparql
+ * SELECT ?s ?label ?dbpediaLabel
+ * WHERE {
+ *   ?s <label> ?label .
+ *   SERVICE <http://dbpedia.org/sparql> {
+ *     ?s rdfs:label ?dbpediaLabel .
+ *     FILTER(LANG(?dbpediaLabel) = 'en')
+ *   }
+ * }
+ * ```
+ *
+ * SILENT keyword:
+ * When SILENT is specified, errors from the remote endpoint are suppressed
+ * and the SERVICE pattern returns an empty result set instead of failing.
+ *
+ * Example with SILENT:
+ * ```sparql
+ * SELECT ?s ?name WHERE {
+ *   ?s a :Person .
+ *   SERVICE SILENT <http://example.org/sparql> {
+ *     ?s foaf:name ?name .
+ *   }
+ * }
+ * ```
+ */
+export interface ServiceOperation {
+  type: "service";
+  /** The URI of the remote SPARQL endpoint */
+  endpoint: string;
+  /** The graph pattern to execute at the remote endpoint */
+  pattern: AlgebraOperation;
+  /** If true, errors from the remote endpoint are suppressed */
+  silent: boolean;
 }

--- a/packages/core/src/infrastructure/sparql/algebra/SPARQLGenerator.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/SPARQLGenerator.ts
@@ -1,0 +1,446 @@
+import type {
+  AlgebraOperation,
+  BGPOperation,
+  ValuesOperation,
+  Expression,
+  Triple,
+  TripleElement,
+  PropertyPath,
+  IRI,
+  Literal,
+} from "./AlgebraOperation";
+
+export class SPARQLGeneratorError extends Error {
+  constructor(message: string, cause?: Error) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "SPARQLGeneratorError";
+  }
+}
+
+/**
+ * Generates SPARQL query strings from algebra operations.
+ *
+ * This is used by the ServiceExecutor to convert inner patterns
+ * of SERVICE clauses back to SPARQL syntax for remote execution.
+ *
+ * Unlike AlgebraSerializer (which produces debug output), this generator
+ * produces valid SPARQL queries that can be executed by remote endpoints.
+ */
+export class SPARQLGenerator {
+  /**
+   * Collect all variables used in an algebra operation.
+   * Used to generate SELECT variable list.
+   */
+  collectVariables(operation: AlgebraOperation): Set<string> {
+    const variables = new Set<string>();
+    this.collectVariablesFromOperation(operation, variables);
+    return variables;
+  }
+
+  /**
+   * Generate a SELECT query from an algebra operation.
+   * This is the main entry point for SERVICE clause pattern generation.
+   *
+   * @param operation - The algebra operation to convert
+   * @returns A valid SPARQL SELECT query string
+   */
+  generateSelect(operation: AlgebraOperation): string {
+    const variables = this.collectVariables(operation);
+    const varList = variables.size > 0
+      ? Array.from(variables).map((v) => `?${v}`).join(" ")
+      : "*";
+
+    const whereClause = this.generateWhereClause(operation);
+
+    return `SELECT ${varList} WHERE {\n${whereClause}\n}`;
+  }
+
+  /**
+   * Generate WHERE clause body from an algebra operation.
+   */
+  private generateWhereClause(operation: AlgebraOperation, indent: number = 2): string {
+    const pad = " ".repeat(indent);
+
+    switch (operation.type) {
+      case "bgp":
+        return this.generateBGP(operation, indent);
+
+      case "filter":
+        return `${this.generateWhereClause(operation.input, indent)}\n${pad}FILTER(${this.generateExpression(operation.expression)})`;
+
+      case "join":
+        return `${this.generateWhereClause(operation.left, indent)}\n${this.generateWhereClause(operation.right, indent)}`;
+
+      case "leftjoin": {
+        const left = this.generateWhereClause(operation.left, indent);
+        const right = this.generateWhereClause(operation.right, indent + 2);
+        return `${left}\n${pad}OPTIONAL {\n${right}\n${pad}}`;
+      }
+
+      case "union": {
+        const left = this.generateWhereClause(operation.left, indent + 2);
+        const right = this.generateWhereClause(operation.right, indent + 2);
+        return `${pad}{\n${left}\n${pad}}\n${pad}UNION\n${pad}{\n${right}\n${pad}}`;
+      }
+
+      case "values":
+        return this.generateValues(operation, indent);
+
+      case "extend": {
+        const inputClause = this.generateWhereClause(operation.input, indent);
+        const expr = this.generateExpression(operation.expression as Expression);
+        return `${inputClause}\n${pad}BIND(${expr} AS ?${operation.variable})`;
+      }
+
+      case "project":
+      case "distinct":
+      case "reduced":
+        // These are handled at the outer SELECT level
+        return this.generateWhereClause(operation.input, indent);
+
+      case "orderby":
+      case "slice":
+      case "group":
+        // These modifiers aren't typically used in SERVICE inner patterns
+        // but we support input extraction
+        return this.generateWhereClause(operation.input, indent);
+
+      case "subquery": {
+        const innerQuery = this.generateSelect(operation.query);
+        const indentedQuery = innerQuery.split("\n").map((line) => pad + line).join("\n");
+        return `${pad}{\n${indentedQuery}\n${pad}}`;
+      }
+
+      default:
+        throw new SPARQLGeneratorError(`Unsupported operation type for SPARQL generation: ${(operation as any).type}`);
+    }
+  }
+
+  /**
+   * Generate triple patterns from a BGP operation.
+   */
+  private generateBGP(operation: BGPOperation, indent: number): string {
+    const pad = " ".repeat(indent);
+    return operation.triples
+      .map((t) => `${pad}${this.generateTriple(t)} .`)
+      .join("\n");
+  }
+
+  /**
+   * Generate a single triple pattern.
+   */
+  private generateTriple(triple: Triple): string {
+    const subject = this.generateElement(triple.subject);
+    const predicate = this.generatePredicate(triple.predicate);
+    const object = this.generateElement(triple.object);
+    return `${subject} ${predicate} ${object}`;
+  }
+
+  /**
+   * Generate predicate (may be IRI or property path).
+   */
+  private generatePredicate(predicate: TripleElement | PropertyPath): string {
+    if ("pathType" in predicate) {
+      return this.generatePropertyPath(predicate);
+    }
+    return this.generateElement(predicate);
+  }
+
+  /**
+   * Generate property path expression.
+   */
+  private generatePropertyPath(path: PropertyPath): string {
+    const items = path.items.map((item) => {
+      if ("pathType" in item) {
+        return `(${this.generatePropertyPath(item)})`;
+      }
+      return `<${item.value}>`;
+    });
+
+    switch (path.pathType) {
+      case "/":
+        return items.join("/");
+      case "|":
+        return items.join("|");
+      case "^":
+        return `^${items[0]}`;
+      case "+":
+        return `${items[0]}+`;
+      case "*":
+        return `${items[0]}*`;
+      case "?":
+        return `${items[0]}?`;
+    }
+  }
+
+  /**
+   * Generate a triple element (variable, IRI, literal, or blank node).
+   */
+  private generateElement(element: TripleElement): string {
+    switch (element.type) {
+      case "variable":
+        return `?${element.value}`;
+
+      case "iri":
+        return `<${element.value}>`;
+
+      case "literal": {
+        // Escape special characters in literal value
+        const escapedValue = element.value
+          .replace(/\\/g, "\\\\")
+          .replace(/"/g, '\\"')
+          .replace(/\n/g, "\\n")
+          .replace(/\r/g, "\\r")
+          .replace(/\t/g, "\\t");
+
+        let str = `"${escapedValue}"`;
+        if (element.language) {
+          str += `@${element.language}`;
+        } else if (element.datatype) {
+          str += `^^<${element.datatype}>`;
+        }
+        return str;
+      }
+
+      case "blank":
+        return `_:${element.value}`;
+
+      default:
+        throw new SPARQLGeneratorError(`Unknown element type: ${(element as any).type}`);
+    }
+  }
+
+  /**
+   * Generate VALUES clause.
+   */
+  private generateValues(operation: ValuesOperation, indent: number): string {
+    const pad = " ".repeat(indent);
+
+    if (operation.variables.length === 0 || operation.bindings.length === 0) {
+      return "";
+    }
+
+    if (operation.variables.length === 1) {
+      // Single variable syntax: VALUES ?var { "val1" "val2" }
+      const varName = operation.variables[0];
+      const values = operation.bindings
+        .map((b) => {
+          const val = b[varName];
+          return val ? this.generateValuesTerm(val) : "UNDEF";
+        })
+        .join(" ");
+      return `${pad}VALUES ?${varName} { ${values} }`;
+    }
+
+    // Multi-variable syntax: VALUES (?var1 ?var2) { ("v1" "v2") }
+    const varList = operation.variables.map((v) => `?${v}`).join(" ");
+    const rows = operation.bindings.map((b) => {
+      const values = operation.variables.map((v) => {
+        const val = b[v];
+        return val ? this.generateValuesTerm(val) : "UNDEF";
+      });
+      return `(${values.join(" ")})`;
+    });
+    return `${pad}VALUES (${varList}) {\n${rows.map((r) => `${pad}  ${r}`).join("\n")}\n${pad}}`;
+  }
+
+  /**
+   * Generate a term for VALUES clause.
+   */
+  private generateValuesTerm(term: IRI | Literal): string {
+    if (term.type === "iri") {
+      return `<${term.value}>`;
+    }
+
+    // Literal
+    const escapedValue = term.value
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"');
+    let str = `"${escapedValue}"`;
+    if (term.language) {
+      str += `@${term.language}`;
+    } else if (term.datatype) {
+      str += `^^<${term.datatype}>`;
+    }
+    return str;
+  }
+
+  /**
+   * Generate a filter expression.
+   */
+  private generateExpression(expr: Expression): string {
+    switch (expr.type) {
+      case "variable":
+        return `?${expr.name}`;
+
+      case "literal":
+        if (typeof expr.value === "string") {
+          const escaped = expr.value
+            .replace(/\\/g, "\\\\")
+            .replace(/"/g, '\\"');
+          return `"${escaped}"`;
+        }
+        if (typeof expr.value === "boolean") {
+          return expr.value ? "true" : "false";
+        }
+        return String(expr.value);
+
+      case "comparison":
+        return `(${this.generateExpression(expr.left)} ${expr.operator} ${this.generateExpression(expr.right)})`;
+
+      case "logical":
+        if (expr.operator === "!") {
+          return `!(${this.generateExpression(expr.operands[0])})`;
+        }
+        return `(${expr.operands.map((o) => this.generateExpression(o)).join(` ${expr.operator} `)})`;
+
+      case "arithmetic":
+        return `(${this.generateExpression(expr.left)} ${expr.operator} ${this.generateExpression(expr.right)})`;
+
+      case "function":
+        return `${expr.function.toUpperCase()}(${expr.args.map((a) => this.generateExpression(a)).join(", ")})`;
+
+      case "functionCall": {
+        const funcName = typeof expr.function === "string"
+          ? expr.function
+          : expr.function.value;
+        return `${funcName.toUpperCase()}(${expr.args.map((a) => this.generateExpression(a)).join(", ")})`;
+      }
+
+      case "exists":
+        return `${expr.negated ? "NOT EXISTS" : "EXISTS"} { ${this.generateWhereClause(expr.pattern, 0)} }`;
+
+      case "in": {
+        const testExpr = this.generateExpression(expr.expression);
+        const list = expr.list.map((item) => this.generateExpression(item)).join(", ");
+        return expr.negated
+          ? `${testExpr} NOT IN (${list})`
+          : `${testExpr} IN (${list})`;
+      }
+
+      default:
+        throw new SPARQLGeneratorError(`Unknown expression type: ${(expr as any).type}`);
+    }
+  }
+
+  /**
+   * Recursively collect variables from an operation.
+   */
+  private collectVariablesFromOperation(operation: AlgebraOperation, variables: Set<string>): void {
+    switch (operation.type) {
+      case "bgp":
+        for (const triple of operation.triples) {
+          this.collectVariablesFromTriple(triple, variables);
+        }
+        break;
+
+      case "filter":
+        this.collectVariablesFromOperation(operation.input, variables);
+        this.collectVariablesFromExpression(operation.expression, variables);
+        break;
+
+      case "join":
+      case "leftjoin":
+      case "union":
+      case "minus":
+        this.collectVariablesFromOperation(operation.left, variables);
+        this.collectVariablesFromOperation(operation.right, variables);
+        break;
+
+      case "values":
+        for (const varName of operation.variables) {
+          variables.add(varName);
+        }
+        break;
+
+      case "project":
+        for (const varName of operation.variables) {
+          variables.add(varName);
+        }
+        this.collectVariablesFromOperation(operation.input, variables);
+        break;
+
+      case "extend":
+        variables.add(operation.variable);
+        this.collectVariablesFromOperation(operation.input, variables);
+        break;
+
+      case "orderby":
+      case "slice":
+      case "distinct":
+      case "reduced":
+        this.collectVariablesFromOperation(operation.input, variables);
+        break;
+
+      case "group":
+        for (const varName of operation.variables) {
+          variables.add(varName);
+        }
+        for (const agg of operation.aggregates) {
+          variables.add(agg.variable);
+        }
+        this.collectVariablesFromOperation(operation.input, variables);
+        break;
+
+      case "subquery":
+        this.collectVariablesFromOperation(operation.query, variables);
+        break;
+    }
+  }
+
+  /**
+   * Collect variables from a triple.
+   */
+  private collectVariablesFromTriple(triple: Triple, variables: Set<string>): void {
+    if (triple.subject.type === "variable") {
+      variables.add(triple.subject.value);
+    }
+    if ("type" in triple.predicate && triple.predicate.type === "variable") {
+      variables.add(triple.predicate.value);
+    }
+    if (triple.object.type === "variable") {
+      variables.add(triple.object.value);
+    }
+  }
+
+  /**
+   * Collect variables from an expression.
+   */
+  private collectVariablesFromExpression(expr: Expression, variables: Set<string>): void {
+    switch (expr.type) {
+      case "variable":
+        variables.add(expr.name);
+        break;
+
+      case "comparison":
+      case "arithmetic":
+        this.collectVariablesFromExpression(expr.left, variables);
+        this.collectVariablesFromExpression(expr.right, variables);
+        break;
+
+      case "logical":
+        for (const operand of expr.operands) {
+          this.collectVariablesFromExpression(operand, variables);
+        }
+        break;
+
+      case "function":
+      case "functionCall":
+        for (const arg of expr.args) {
+          this.collectVariablesFromExpression(arg, variables);
+        }
+        break;
+
+      case "exists":
+        this.collectVariablesFromOperation(expr.pattern, variables);
+        break;
+
+      case "in":
+        this.collectVariablesFromExpression(expr.expression, variables);
+        for (const item of expr.list) {
+          this.collectVariablesFromExpression(item, variables);
+        }
+        break;
+    }
+  }
+}

--- a/packages/core/src/infrastructure/sparql/executors/ServiceExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/ServiceExecutor.ts
@@ -1,0 +1,287 @@
+import type { ServiceOperation } from "../algebra/AlgebraOperation";
+import { SolutionMapping } from "../SolutionMapping";
+import { IRI } from "../../../domain/models/rdf/IRI";
+import { Literal } from "../../../domain/models/rdf/Literal";
+import { BlankNode } from "../../../domain/models/rdf/BlankNode";
+import type { Subject, Predicate, Object as RDFObject } from "../../../domain/models/rdf/Triple";
+
+export class ServiceExecutorError extends Error {
+  constructor(message: string, cause?: Error) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "ServiceExecutorError";
+  }
+}
+
+/**
+ * Result format for SPARQL JSON query results.
+ * Follows SPARQL 1.1 Query Results JSON Format specification.
+ * https://www.w3.org/TR/sparql11-results-json/
+ */
+interface SPARQLJsonResult {
+  head: {
+    vars: string[];
+  };
+  results: {
+    bindings: SPARQLJsonBinding[];
+  };
+}
+
+interface SPARQLJsonBinding {
+  [variable: string]: {
+    type: "uri" | "literal" | "bnode";
+    value: string;
+    "xml:lang"?: string;
+    datatype?: string;
+  };
+}
+
+/**
+ * Configuration options for SERVICE execution.
+ */
+export interface ServiceExecutorConfig {
+  /**
+   * Default timeout in milliseconds for HTTP requests to SPARQL endpoints.
+   * Default: 30000 (30 seconds)
+   */
+  timeout?: number;
+
+  /**
+   * Custom HTTP client for making requests. If not provided, uses global fetch.
+   * This allows for dependency injection in testing.
+   */
+  httpClient?: (url: string, options: RequestInit) => Promise<Response>;
+
+  /**
+   * Maximum number of retries on transient failures.
+   * Default: 2
+   */
+  maxRetries?: number;
+
+  /**
+   * Delay between retries in milliseconds.
+   * Default: 1000 (1 second)
+   */
+  retryDelay?: number;
+}
+
+/**
+ * Executes SERVICE operations for federated SPARQL queries.
+ *
+ * SERVICE allows querying external SPARQL endpoints within a local query.
+ * This executor sends SPARQL queries to remote endpoints via HTTP and
+ * converts the results to SolutionMappings for joining with local patterns.
+ *
+ * Features:
+ * - Executes graph patterns against remote SPARQL endpoints
+ * - SILENT mode for graceful error handling
+ * - Configurable timeouts and retries
+ * - Supports SPARQL JSON result format
+ *
+ * SPARQL 1.1 Federated Query:
+ * https://www.w3.org/TR/sparql11-federated-query/
+ *
+ * Example:
+ * ```sparql
+ * SELECT ?s ?label ?dbpediaLabel
+ * WHERE {
+ *   ?s <label> ?label .
+ *   SERVICE <http://dbpedia.org/sparql> {
+ *     ?s rdfs:label ?dbpediaLabel .
+ *     FILTER(LANG(?dbpediaLabel) = 'en')
+ *   }
+ * }
+ * ```
+ */
+export class ServiceExecutor {
+  private readonly timeout: number;
+  private readonly httpClient: (url: string, options: RequestInit) => Promise<Response>;
+  private readonly maxRetries: number;
+  private readonly retryDelay: number;
+
+  constructor(config: ServiceExecutorConfig = {}) {
+    this.timeout = config.timeout ?? 30000;
+    this.httpClient = config.httpClient ?? ((url, options) => fetch(url, options));
+    this.maxRetries = config.maxRetries ?? 2;
+    this.retryDelay = config.retryDelay ?? 1000;
+  }
+
+  /**
+   * Execute a SERVICE operation by querying a remote SPARQL endpoint.
+   *
+   * The inner pattern is converted to a SPARQL query, sent to the endpoint,
+   * and results are converted to SolutionMappings.
+   *
+   * @param operation - The SERVICE operation with endpoint, pattern, and silent flag
+   * @param queryGenerator - Function to convert an algebra operation to SPARQL string
+   * @returns AsyncIterableIterator of SolutionMappings from the remote endpoint
+   */
+  async *execute(
+    operation: ServiceOperation,
+    queryGenerator: (pattern: ServiceOperation["pattern"]) => string
+  ): AsyncIterableIterator<SolutionMapping> {
+    try {
+      // Generate SPARQL query from the inner pattern
+      const sparqlQuery = queryGenerator(operation.pattern);
+
+      // Execute against remote endpoint
+      const results = await this.executeRemoteQuery(operation.endpoint, sparqlQuery);
+
+      // Yield solution mappings from results
+      for (const solution of results) {
+        yield solution;
+      }
+    } catch (error) {
+      if (operation.silent) {
+        // SILENT mode: suppress errors and return empty results
+        return;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Execute a SPARQL query against a remote endpoint.
+   *
+   * Uses HTTP POST with application/sparql-query content type.
+   * Expects SPARQL JSON results format in response.
+   */
+  private async executeRemoteQuery(
+    endpoint: string,
+    query: string
+  ): Promise<SolutionMapping[]> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+        try {
+          const response = await this.httpClient(endpoint, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/sparql-query",
+              "Accept": "application/sparql-results+json",
+            },
+            body: query,
+            signal: controller.signal,
+          });
+
+          if (!response.ok) {
+            throw new ServiceExecutorError(
+              `Remote SPARQL endpoint returned ${response.status}: ${response.statusText}`
+            );
+          }
+
+          const json = await response.json() as SPARQLJsonResult;
+          return this.parseJsonResults(json);
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+
+        // Check if error is retryable (network errors, timeouts, 5xx responses)
+        if (this.isRetryableError(lastError) && attempt < this.maxRetries) {
+          await this.delay(this.retryDelay);
+          continue;
+        }
+
+        throw new ServiceExecutorError(
+          `Failed to query remote SPARQL endpoint ${endpoint}: ${lastError.message}`,
+          lastError
+        );
+      }
+    }
+
+    throw new ServiceExecutorError(
+      `Failed to query remote SPARQL endpoint ${endpoint} after ${this.maxRetries + 1} attempts`,
+      lastError
+    );
+  }
+
+  /**
+   * Parse SPARQL JSON results format into SolutionMappings.
+   *
+   * SPARQL 1.1 Query Results JSON Format:
+   * https://www.w3.org/TR/sparql11-results-json/
+   */
+  private parseJsonResults(json: SPARQLJsonResult): SolutionMapping[] {
+    if (!json.results || !Array.isArray(json.results.bindings)) {
+      return [];
+    }
+
+    return json.results.bindings.map((binding) => this.parseBinding(binding));
+  }
+
+  /**
+   * Parse a single SPARQL JSON binding into a SolutionMapping.
+   */
+  private parseBinding(binding: SPARQLJsonBinding): SolutionMapping {
+    const solution = new SolutionMapping();
+
+    for (const [varName, value] of Object.entries(binding)) {
+      const rdfTerm = this.parseRDFTerm(value);
+      solution.set(varName, rdfTerm);
+    }
+
+    return solution;
+  }
+
+  /**
+   * Parse a SPARQL JSON RDF term into an IRI, Literal, or BlankNode.
+   */
+  private parseRDFTerm(term: SPARQLJsonBinding[string]): Subject | Predicate | RDFObject {
+    switch (term.type) {
+      case "uri":
+        return new IRI(term.value);
+
+      case "literal": {
+        const datatype = term.datatype ? new IRI(term.datatype) : undefined;
+        return new Literal(term.value, datatype, term["xml:lang"]);
+      }
+
+      case "bnode":
+        return new BlankNode(term.value);
+
+      default:
+        throw new ServiceExecutorError(`Unknown RDF term type: ${(term as any).type}`);
+    }
+  }
+
+  /**
+   * Check if an error is retryable (transient network issues).
+   */
+  private isRetryableError(error: Error): boolean {
+    const message = error.message.toLowerCase();
+
+    // Aborted (timeout)
+    if (error.name === "AbortError") {
+      return true;
+    }
+
+    // Network errors
+    if (
+      message.includes("network") ||
+      message.includes("econnreset") ||
+      message.includes("econnrefused") ||
+      message.includes("etimedout")
+    ) {
+      return true;
+    }
+
+    // 5xx server errors
+    if (message.includes("returned 5")) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Delay for a specified number of milliseconds.
+   */
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/core/tests/unit/infrastructure/sparql/algebra/SPARQLGenerator.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/algebra/SPARQLGenerator.test.ts
@@ -1,0 +1,597 @@
+import { SPARQLGenerator } from "../../../../../src/infrastructure/sparql/algebra/SPARQLGenerator";
+import type {
+  BGPOperation,
+  FilterOperation,
+  JoinOperation,
+  LeftJoinOperation,
+  ValuesOperation,
+  ExtendOperation,
+} from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+
+describe("SPARQLGenerator", () => {
+  let generator: SPARQLGenerator;
+
+  beforeEach(() => {
+    generator = new SPARQLGenerator();
+  });
+
+  describe("generateSelect", () => {
+    it("should generate SELECT query from BGP", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: { type: "iri", value: "http://example.org/name" },
+            object: { type: "variable", value: "name" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("SELECT");
+      expect(result).toContain("?s");
+      expect(result).toContain("?name");
+      expect(result).toContain("WHERE");
+      expect(result).toContain("<http://example.org/name>");
+    });
+
+    it("should generate SELECT * for operations with no variables", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("SELECT *");
+    });
+  });
+
+  describe("BGP generation", () => {
+    it("should generate simple triple pattern", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: { type: "iri", value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" },
+            object: { type: "iri", value: "http://example.org/Person" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Person>");
+    });
+
+    it("should generate multiple triple patterns", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: { type: "iri", value: "http://example.org/name" },
+            object: { type: "variable", value: "name" },
+          },
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: { type: "iri", value: "http://example.org/age" },
+            object: { type: "variable", value: "age" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("<http://example.org/name>");
+      expect(result).toContain("<http://example.org/age>");
+    });
+
+    it("should escape special characters in literals", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: { type: "iri", value: "http://example.org/label" },
+            object: { type: "literal", value: 'Hello "World"\nNew Line' },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain('\\"'); // Escaped quote
+      expect(result).toContain('\\n'); // Escaped newline
+    });
+
+    it("should generate language-tagged literals", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: { type: "iri", value: "http://example.org/label" },
+            object: { type: "literal", value: "Bonjour", language: "fr" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain('"Bonjour"@fr');
+    });
+
+    it("should generate typed literals", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: { type: "iri", value: "http://example.org/count" },
+            object: { type: "literal", value: "42", datatype: "http://www.w3.org/2001/XMLSchema#integer" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain('"42"^^<http://www.w3.org/2001/XMLSchema#integer>');
+    });
+
+    it("should generate blank nodes", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "blank", value: "b0" },
+            predicate: { type: "iri", value: "http://example.org/name" },
+            object: { type: "variable", value: "name" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("_:b0");
+    });
+  });
+
+  describe("FILTER generation", () => {
+    it("should generate comparison filter", () => {
+      const operation: FilterOperation = {
+        type: "filter",
+        expression: {
+          type: "comparison",
+          operator: ">",
+          left: { type: "variable", name: "age" },
+          right: { type: "literal", value: 18 },
+        },
+        input: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: "http://example.org/age" },
+              object: { type: "variable", value: "age" },
+            },
+          ],
+        },
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("FILTER");
+      expect(result).toContain("?age");
+      expect(result).toContain(">");
+      expect(result).toContain("18");
+    });
+
+    it("should generate logical AND filter", () => {
+      const operation: FilterOperation = {
+        type: "filter",
+        expression: {
+          type: "logical",
+          operator: "&&",
+          operands: [
+            {
+              type: "comparison",
+              operator: ">",
+              left: { type: "variable", name: "x" },
+              right: { type: "literal", value: 0 },
+            },
+            {
+              type: "comparison",
+              operator: "<",
+              left: { type: "variable", name: "x" },
+              right: { type: "literal", value: 100 },
+            },
+          ],
+        },
+        input: { type: "bgp", triples: [] },
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("&&");
+    });
+
+    it("should generate NOT filter", () => {
+      const operation: FilterOperation = {
+        type: "filter",
+        expression: {
+          type: "logical",
+          operator: "!",
+          operands: [
+            {
+              type: "comparison",
+              operator: "=",
+              left: { type: "variable", name: "x" },
+              right: { type: "literal", value: "test" },
+            },
+          ],
+        },
+        input: { type: "bgp", triples: [] },
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("!(");
+    });
+
+    it("should generate function call in filter", () => {
+      const operation: FilterOperation = {
+        type: "filter",
+        expression: {
+          type: "function",
+          function: "bound",
+          args: [{ type: "variable", name: "x" }],
+        },
+        input: { type: "bgp", triples: [] },
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("BOUND(?x)");
+    });
+  });
+
+  describe("OPTIONAL (LeftJoin) generation", () => {
+    it("should generate OPTIONAL clause", () => {
+      const operation: LeftJoinOperation = {
+        type: "leftjoin",
+        left: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: "http://example.org/name" },
+              object: { type: "variable", value: "name" },
+            },
+          ],
+        },
+        right: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: "http://example.org/email" },
+              object: { type: "variable", value: "email" },
+            },
+          ],
+        },
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("OPTIONAL");
+      expect(result).toContain("?email");
+    });
+  });
+
+  describe("VALUES generation", () => {
+    it("should generate single-variable VALUES", () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["status"],
+        bindings: [
+          { status: { type: "literal", value: "active" } },
+          { status: { type: "literal", value: "pending" } },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("VALUES ?status");
+      expect(result).toContain('"active"');
+      expect(result).toContain('"pending"');
+    });
+
+    it("should generate multi-variable VALUES", () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["x", "y"],
+        bindings: [
+          { x: { type: "literal", value: "1" }, y: { type: "literal", value: "2" } },
+          { x: { type: "literal", value: "3" }, y: { type: "literal", value: "4" } },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("VALUES (?x ?y)");
+      expect(result).toMatch(/\("1"\s+"2"\)/);
+      expect(result).toMatch(/\("3"\s+"4"\)/);
+    });
+
+    it("should generate UNDEF for missing bindings", () => {
+      const operation: ValuesOperation = {
+        type: "values",
+        variables: ["x", "y"],
+        bindings: [
+          { x: { type: "literal", value: "1" } }, // y is UNDEF
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("UNDEF");
+    });
+  });
+
+  describe("BIND generation", () => {
+    it("should generate BIND clause", () => {
+      const operation: ExtendOperation = {
+        type: "extend",
+        variable: "doubled",
+        expression: {
+          type: "arithmetic",
+          operator: "*",
+          left: { type: "variable", name: "x" },
+          right: { type: "literal", value: 2 },
+        },
+        input: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: "http://example.org/value" },
+              object: { type: "variable", value: "x" },
+            },
+          ],
+        },
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("BIND");
+      expect(result).toContain("?doubled");
+      expect(result).toContain("*");
+    });
+  });
+
+  describe("JOIN generation", () => {
+    it("should generate joined patterns", () => {
+      const operation: JoinOperation = {
+        type: "join",
+        left: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: "http://example.org/name" },
+              object: { type: "variable", value: "name" },
+            },
+          ],
+        },
+        right: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: "http://example.org/age" },
+              object: { type: "variable", value: "age" },
+            },
+          ],
+        },
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("<http://example.org/name>");
+      expect(result).toContain("<http://example.org/age>");
+    });
+  });
+
+  describe("Variable collection", () => {
+    it("should collect variables from BGP", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: { type: "iri", value: "http://example.org/prop" },
+            object: { type: "variable", value: "o" },
+          },
+        ],
+      };
+
+      const variables = generator.collectVariables(operation);
+
+      expect(variables).toContain("s");
+      expect(variables).toContain("o");
+      expect(variables.size).toBe(2);
+    });
+
+    it("should collect variables from nested operations", () => {
+      const operation: JoinOperation = {
+        type: "join",
+        left: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "a" },
+              predicate: { type: "iri", value: "http://example.org/prop" },
+              object: { type: "variable", value: "b" },
+            },
+          ],
+        },
+        right: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "b" },
+              predicate: { type: "iri", value: "http://example.org/prop" },
+              object: { type: "variable", value: "c" },
+            },
+          ],
+        },
+      };
+
+      const variables = generator.collectVariables(operation);
+
+      expect(variables).toContain("a");
+      expect(variables).toContain("b");
+      expect(variables).toContain("c");
+      expect(variables.size).toBe(3);
+    });
+  });
+
+  describe("Property paths", () => {
+    it("should generate sequence path", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: {
+              type: "path",
+              pathType: "/",
+              items: [
+                { type: "iri", value: "http://example.org/a" },
+                { type: "iri", value: "http://example.org/b" },
+              ],
+            },
+            object: { type: "variable", value: "o" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("<http://example.org/a>/<http://example.org/b>");
+    });
+
+    it("should generate alternative path", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: {
+              type: "path",
+              pathType: "|",
+              items: [
+                { type: "iri", value: "http://example.org/a" },
+                { type: "iri", value: "http://example.org/b" },
+              ],
+            },
+            object: { type: "variable", value: "o" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("<http://example.org/a>|<http://example.org/b>");
+    });
+
+    it("should generate inverse path", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: {
+              type: "path",
+              pathType: "^",
+              items: [{ type: "iri", value: "http://example.org/prop" }],
+            },
+            object: { type: "variable", value: "o" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("^<http://example.org/prop>");
+    });
+
+    it("should generate oneOrMore path", () => {
+      const operation: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "variable", value: "s" },
+            predicate: {
+              type: "path",
+              pathType: "+",
+              items: [{ type: "iri", value: "http://example.org/subClassOf" }],
+            },
+            object: { type: "variable", value: "o" },
+          },
+        ],
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("<http://example.org/subClassOf>+");
+    });
+  });
+
+  describe("IN expression", () => {
+    it("should generate IN filter", () => {
+      const operation: FilterOperation = {
+        type: "filter",
+        expression: {
+          type: "in",
+          expression: { type: "variable", name: "status" },
+          list: [
+            { type: "literal", value: "active" },
+            { type: "literal", value: "pending" },
+          ],
+          negated: false,
+        },
+        input: { type: "bgp", triples: [] },
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("?status IN");
+      expect(result).toContain('"active"');
+      expect(result).toContain('"pending"');
+    });
+
+    it("should generate NOT IN filter", () => {
+      const operation: FilterOperation = {
+        type: "filter",
+        expression: {
+          type: "in",
+          expression: { type: "variable", name: "status" },
+          list: [
+            { type: "literal", value: "deleted" },
+          ],
+          negated: true,
+        },
+        input: { type: "bgp", triples: [] },
+      };
+
+      const result = generator.generateSelect(operation);
+
+      expect(result).toContain("NOT IN");
+    });
+  });
+});

--- a/packages/core/tests/unit/infrastructure/sparql/executors/ServiceExecutor.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/executors/ServiceExecutor.test.ts
@@ -1,0 +1,713 @@
+import { ServiceExecutor, ServiceExecutorError } from "../../../../../src/infrastructure/sparql/executors/ServiceExecutor";
+import type { ServiceOperation } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
+import { IRI } from "../../../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../../../src/domain/models/rdf/Literal";
+
+describe("ServiceExecutor", () => {
+  // Mock HTTP client for testing
+  const createMockHttpClient = (responseData: any, status = 200, statusText = "OK") => {
+    return jest.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText,
+      json: jest.fn().mockResolvedValue(responseData),
+    } as unknown as Response);
+  };
+
+  // Mock query generator - just wraps the pattern in a simple SELECT
+  const mockQueryGenerator = jest.fn((pattern) => {
+    return `SELECT * WHERE { PATTERN }`;
+  });
+
+  beforeEach(() => {
+    mockQueryGenerator.mockClear();
+  });
+
+  describe("Basic execution", () => {
+    it("should execute SERVICE against remote endpoint and return results", async () => {
+      const mockResponse = {
+        head: { vars: ["s", "name"] },
+        results: {
+          bindings: [
+            {
+              s: { type: "uri", value: "http://example.org/entity1" },
+              name: { type: "literal", value: "Entity One" },
+            },
+            {
+              s: { type: "uri", value: "http://example.org/entity2" },
+              name: { type: "literal", value: "Entity Two" },
+            },
+          ],
+        },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: "http://example.org/name" },
+              object: { type: "variable", value: "name" },
+            },
+          ],
+        },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(2);
+      expect((results[0].get("s") as IRI).value).toBe("http://example.org/entity1");
+      expect((results[0].get("name") as Literal).value).toBe("Entity One");
+      expect((results[1].get("s") as IRI).value).toBe("http://example.org/entity2");
+      expect((results[1].get("name") as Literal).value).toBe("Entity Two");
+
+      // Verify HTTP call
+      expect(mockHttp).toHaveBeenCalledTimes(1);
+      expect(mockHttp).toHaveBeenCalledWith(
+        "http://example.org/sparql",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/sparql-query",
+            "Accept": "application/sparql-results+json",
+          }),
+        })
+      );
+    });
+
+    it("should handle empty results from remote endpoint", async () => {
+      const mockResponse = {
+        head: { vars: ["s", "name"] },
+        results: { bindings: [] },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: {
+          type: "bgp",
+          triples: [],
+        },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("RDF term parsing", () => {
+    it("should parse URI terms correctly", async () => {
+      const mockResponse = {
+        head: { vars: ["entity"] },
+        results: {
+          bindings: [
+            { entity: { type: "uri", value: "http://dbpedia.org/resource/Paris" } },
+          ],
+        },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(1);
+      const entity = results[0].get("entity") as IRI;
+      expect(entity).toBeInstanceOf(IRI);
+      expect(entity.value).toBe("http://dbpedia.org/resource/Paris");
+    });
+
+    it("should parse plain literals correctly", async () => {
+      const mockResponse = {
+        head: { vars: ["label"] },
+        results: {
+          bindings: [
+            { label: { type: "literal", value: "Hello World" } },
+          ],
+        },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(1);
+      const label = results[0].get("label") as Literal;
+      expect(label).toBeInstanceOf(Literal);
+      expect(label.value).toBe("Hello World");
+    });
+
+    it("should parse language-tagged literals correctly", async () => {
+      const mockResponse = {
+        head: { vars: ["label"] },
+        results: {
+          bindings: [
+            { label: { type: "literal", value: "Bonjour", "xml:lang": "fr" } },
+          ],
+        },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(1);
+      const label = results[0].get("label") as Literal;
+      expect(label.value).toBe("Bonjour");
+      expect(label.language).toBe("fr");
+    });
+
+    it("should parse typed literals correctly", async () => {
+      const mockResponse = {
+        head: { vars: ["count"] },
+        results: {
+          bindings: [
+            {
+              count: {
+                type: "literal",
+                value: "42",
+                datatype: "http://www.w3.org/2001/XMLSchema#integer",
+              },
+            },
+          ],
+        },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(1);
+      const count = results[0].get("count") as Literal;
+      expect(count.value).toBe("42");
+      expect(count.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#integer");
+    });
+
+    it("should parse blank nodes correctly", async () => {
+      const mockResponse = {
+        head: { vars: ["bnode"] },
+        results: {
+          bindings: [
+            { bnode: { type: "bnode", value: "b0" } },
+          ],
+        },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(1);
+      const bnode = results[0].get("bnode");
+      expect(bnode).toBeDefined();
+    });
+  });
+
+  describe("SILENT mode", () => {
+    it("should suppress errors and return empty results when SILENT is true", async () => {
+      const mockHttp = jest.fn().mockRejectedValue(new Error("Network error"));
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: true, // SILENT mode enabled
+      };
+
+      const results: SolutionMapping[] = [];
+      // Should NOT throw
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(0);
+    });
+
+    it("should throw error when SILENT is false and request fails", async () => {
+      const mockHttp = jest.fn().mockRejectedValue(new Error("Network error"));
+      const executor = new ServiceExecutor({ httpClient: mockHttp, maxRetries: 0 });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false, // SILENT mode disabled
+      };
+
+      const results: SolutionMapping[] = [];
+      await expect(async () => {
+        for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+          results.push(solution);
+        }
+      }).rejects.toThrow(ServiceExecutorError);
+    });
+
+    it("should suppress HTTP 4xx errors in SILENT mode", async () => {
+      const mockHttp = createMockHttpClient({}, 404, "Not Found");
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: true,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(0);
+    });
+
+    it("should suppress HTTP 5xx errors in SILENT mode", async () => {
+      const mockHttp = createMockHttpClient({}, 503, "Service Unavailable");
+      const executor = new ServiceExecutor({ httpClient: mockHttp, maxRetries: 0 });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: true,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should throw ServiceExecutorError for HTTP errors when not SILENT", async () => {
+      const mockHttp = createMockHttpClient({}, 500, "Internal Server Error");
+      const executor = new ServiceExecutor({ httpClient: mockHttp, maxRetries: 0 });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      await expect(async () => {
+        for await (const _solution of executor.execute(operation, mockQueryGenerator)) {
+          // consume iterator
+        }
+      }).rejects.toThrow(ServiceExecutorError);
+    });
+
+    it("should include endpoint URL in error message", async () => {
+      const mockHttp = createMockHttpClient({}, 404, "Not Found");
+      const executor = new ServiceExecutor({ httpClient: mockHttp, maxRetries: 0 });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/special-sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      try {
+        for await (const _solution of executor.execute(operation, mockQueryGenerator)) {
+          // consume iterator
+        }
+        fail("Should have thrown");
+      } catch (error) {
+        expect((error as Error).message).toContain("http://example.org/special-sparql");
+      }
+    });
+  });
+
+  describe("Retry behavior", () => {
+    it("should retry on transient failures", async () => {
+      let callCount = 0;
+      const mockHttp = jest.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("ECONNRESET");
+        }
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            head: { vars: ["x"] },
+            results: { bindings: [{ x: { type: "literal", value: "success" } }] },
+          }),
+        };
+      });
+
+      const executor = new ServiceExecutor({
+        httpClient: mockHttp,
+        maxRetries: 2,
+        retryDelay: 10, // Short delay for tests
+      });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(1);
+      expect(callCount).toBe(2); // First failed, second succeeded
+    });
+
+    it("should not retry on non-retryable errors", async () => {
+      let callCount = 0;
+      const mockHttp = jest.fn().mockImplementation(async () => {
+        callCount++;
+        return {
+          ok: false,
+          status: 400,
+          statusText: "Bad Request",
+          json: async () => ({}),
+        };
+      });
+
+      const executor = new ServiceExecutor({
+        httpClient: mockHttp,
+        maxRetries: 2,
+        retryDelay: 10,
+      });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      await expect(async () => {
+        for await (const _solution of executor.execute(operation, mockQueryGenerator)) {
+          // consume iterator
+        }
+      }).rejects.toThrow();
+
+      expect(callCount).toBe(1); // No retries for 400 error
+    });
+
+    it("should retry on 5xx errors", async () => {
+      let callCount = 0;
+      const mockHttp = jest.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return {
+            ok: false,
+            status: 503,
+            statusText: "Service Unavailable",
+            json: async () => ({}),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            head: { vars: ["x"] },
+            results: { bindings: [] },
+          }),
+        };
+      });
+
+      const executor = new ServiceExecutor({
+        httpClient: mockHttp,
+        maxRetries: 2,
+        retryDelay: 10,
+      });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(callCount).toBe(3); // Two retries then success
+    });
+  });
+
+  describe("Configuration", () => {
+    it("should use custom timeout", async () => {
+      // This test verifies the timeout is passed to abort controller
+      const mockHttp = jest.fn().mockImplementation(async (url, options) => {
+        // Verify signal is present
+        expect(options.signal).toBeDefined();
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            head: { vars: [] },
+            results: { bindings: [] },
+          }),
+        };
+      });
+
+      const executor = new ServiceExecutor({
+        httpClient: mockHttp,
+        timeout: 5000,
+      });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      for await (const _solution of executor.execute(operation, mockQueryGenerator)) {
+        // consume iterator
+      }
+
+      expect(mockHttp).toHaveBeenCalled();
+    });
+  });
+
+  describe("Query generation", () => {
+    it("should call query generator with the pattern", async () => {
+      const mockResponse = {
+        head: { vars: [] },
+        results: { bindings: [] },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+      const customGenerator = jest.fn(() => "SELECT ?s WHERE { ?s ?p ?o }");
+
+      const innerPattern = {
+        type: "bgp" as const,
+        triples: [
+          {
+            subject: { type: "variable" as const, value: "s" },
+            predicate: { type: "iri" as const, value: "http://example.org/prop" },
+            object: { type: "variable" as const, value: "o" },
+          },
+        ],
+      };
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: innerPattern,
+        silent: false,
+      };
+
+      for await (const _solution of executor.execute(operation, customGenerator)) {
+        // consume iterator
+      }
+
+      expect(customGenerator).toHaveBeenCalledWith(innerPattern);
+    });
+
+    it("should send generated query to remote endpoint", async () => {
+      const mockResponse = {
+        head: { vars: [] },
+        results: { bindings: [] },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+      const customGenerator = jest.fn(() => "SELECT ?custom WHERE { ?custom a ?type }");
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      for await (const _solution of executor.execute(operation, customGenerator)) {
+        // consume iterator
+      }
+
+      expect(mockHttp).toHaveBeenCalledWith(
+        "http://example.org/sparql",
+        expect.objectContaining({
+          body: "SELECT ?custom WHERE { ?custom a ?type }",
+        })
+      );
+    });
+  });
+
+  describe("Multiple bindings in row", () => {
+    it("should handle rows with multiple variable bindings", async () => {
+      const mockResponse = {
+        head: { vars: ["person", "name", "age"] },
+        results: {
+          bindings: [
+            {
+              person: { type: "uri", value: "http://example.org/person/1" },
+              name: { type: "literal", value: "Alice" },
+              age: { type: "literal", value: "30", datatype: "http://www.w3.org/2001/XMLSchema#integer" },
+            },
+            {
+              person: { type: "uri", value: "http://example.org/person/2" },
+              name: { type: "literal", value: "Bob" },
+              age: { type: "literal", value: "25", datatype: "http://www.w3.org/2001/XMLSchema#integer" },
+            },
+          ],
+        },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(2);
+
+      // First row
+      expect((results[0].get("person") as IRI).value).toBe("http://example.org/person/1");
+      expect((results[0].get("name") as Literal).value).toBe("Alice");
+      expect((results[0].get("age") as Literal).value).toBe("30");
+
+      // Second row
+      expect((results[1].get("person") as IRI).value).toBe("http://example.org/person/2");
+      expect((results[1].get("name") as Literal).value).toBe("Bob");
+      expect((results[1].get("age") as Literal).value).toBe("25");
+    });
+
+    it("should handle rows with missing bindings (unbound variables)", async () => {
+      const mockResponse = {
+        head: { vars: ["x", "y"] },
+        results: {
+          bindings: [
+            {
+              x: { type: "literal", value: "1" },
+              // y is unbound
+            },
+            {
+              x: { type: "literal", value: "2" },
+              y: { type: "literal", value: "Y" },
+            },
+          ],
+        },
+      };
+
+      const mockHttp = createMockHttpClient(mockResponse);
+      const executor = new ServiceExecutor({ httpClient: mockHttp });
+
+      const operation: ServiceOperation = {
+        type: "service",
+        endpoint: "http://example.org/sparql",
+        pattern: { type: "bgp", triples: [] },
+        silent: false,
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, mockQueryGenerator)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(2);
+
+      // First row - y is unbound
+      expect((results[0].get("x") as Literal).value).toBe("1");
+      expect(results[0].get("y")).toBeUndefined();
+
+      // Second row - both bound
+      expect((results[1].get("x") as Literal).value).toBe("2");
+      expect((results[1].get("y") as Literal).value).toBe("Y");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR implements the SPARQL 1.1 Federated Query extension, allowing queries to remote SPARQL endpoints from within a local query using the SERVICE clause.

**Closes #722**

## Implementation Details

### New Components

1. **ServiceOperation** (`AlgebraOperation.ts`)
   - New algebra operation type for representing SERVICE clauses
   - Stores endpoint URL, inner pattern, and silent flag

2. **ServiceExecutor** (`ServiceExecutor.ts`)
   - Executes SERVICE operations via HTTP SPARQL protocol
   - Features:
     - HTTP POST with `application/sparql-query` content type
     - SPARQL JSON results format parsing
     - Configurable timeouts and retries
     - SILENT mode for graceful error handling
     - Support for all RDF term types (URIs, Literals, Blank Nodes)

3. **SPARQLGenerator** (`SPARQLGenerator.ts`)
   - Converts algebra operations back to SPARQL query strings
   - Used to send inner patterns to remote endpoints
   - Supports BGP, FILTER, OPTIONAL, VALUES, BIND, property paths

4. **AlgebraTranslator** (updated)
   - Translates sparqljs SERVICE AST to ServiceOperation

5. **QueryExecutor** (updated)
   - Integrates ServiceExecutor for SERVICE clause execution

### Example Usage

```sparql
SELECT ?s ?label ?dbpediaLabel
WHERE {
  ?s <label> ?label .
  SERVICE <http://dbpedia.org/sparql> {
    ?s rdfs:label ?dbpediaLabel .
    FILTER(LANG(?dbpediaLabel) = 'en')
  }
}
```

With SILENT keyword for graceful failure handling:

```sparql
SELECT ?s ?name WHERE {
  ?s a :Person .
  SERVICE SILENT <http://example.org/sparql> {
    ?s foaf:name ?name .
  }
}
```

## Test Coverage

- **ServiceExecutor**: 21 tests
  - Basic execution and result parsing
  - RDF term parsing (URI, Literal, Blank Node)
  - SILENT mode error suppression
  - Retry behavior for transient failures
  - Timeout handling
  - Query generator integration

- **SPARQLGenerator**: 26 tests
  - BGP, FILTER, OPTIONAL, VALUES, BIND generation
  - Property path generation
  - Variable collection
  - IN/NOT IN expressions

- **AlgebraTranslator**: 6 new SERVICE tests
  - Simple SERVICE clause
  - SERVICE SILENT
  - Multiple inner triples
  - Inner FILTER
  - Multiple SERVICE clauses
  - SERVICE within OPTIONAL

## Test Plan

- [x] Unit tests pass locally
- [x] TypeScript compilation succeeds
- [ ] CI pipeline passes (build-and-test + e2e-tests)
- [ ] PR merged to main
- [ ] Auto-release workflow creates GitHub release