### PR TITLE
feat: Implement GRAPH Clause for Named Graphs

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -16,7 +16,8 @@ export type AlgebraOperation =
   | SubqueryOperation
   | ConstructOperation
   | AskOperation
-  | ServiceOperation;
+  | ServiceOperation
+  | GraphOperation;
 
 export interface BGPOperation {
   type: "bgp";
@@ -483,4 +484,51 @@ export interface ServiceOperation {
   pattern: AlgebraOperation;
   /** If true, errors from the remote endpoint are suppressed */
   silent: boolean;
+}
+
+/**
+ * GRAPH operation for named graph patterns.
+ * Evaluates a graph pattern against a specific named graph in the dataset.
+ *
+ * SPARQL 1.1 spec Section 13.3:
+ * https://www.w3.org/TR/sparql11-query/#queryDataset
+ *
+ * The GRAPH keyword restricts pattern matching to a specific named graph.
+ * The graph can be specified as:
+ * - A concrete IRI: GRAPH <http://example.org/graph1> { ... }
+ * - A variable: GRAPH ?g { ... } (matches all named graphs, binding ?g)
+ *
+ * Examples:
+ * ```sparql
+ * # Query a specific named graph
+ * SELECT ?s ?p ?o
+ * WHERE {
+ *   GRAPH <http://example.org/graph1> {
+ *     ?s ?p ?o
+ *   }
+ * }
+ *
+ * # Query all named graphs, binding graph name to ?g
+ * SELECT ?g ?s ?p ?o
+ * WHERE {
+ *   GRAPH ?g {
+ *     ?s ?p ?o
+ *   }
+ * }
+ * ```
+ *
+ * Dataset management with FROM/FROM NAMED:
+ * - FROM clauses specify the default graph (merged from multiple sources)
+ * - FROM NAMED clauses specify available named graphs
+ * - Without FROM/FROM NAMED, all graphs in the dataset are available
+ */
+export interface GraphOperation {
+  type: "graph";
+  /**
+   * The named graph to match against.
+   * Can be an IRI (concrete graph name) or Variable (match all named graphs).
+   */
+  name: IRI | Variable;
+  /** The graph pattern to evaluate within the named graph */
+  pattern: AlgebraOperation;
 }

--- a/packages/core/src/infrastructure/sparql/executors/GraphExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/GraphExecutor.ts
@@ -1,0 +1,139 @@
+import type { GraphOperation, AlgebraOperation, IRI, Variable } from "../algebra/AlgebraOperation";
+import { SolutionMapping } from "../SolutionMapping";
+import type { ITripleStore } from "../../../interfaces/ITripleStore";
+import { IRI as IRIClass } from "../../../domain/models/rdf/IRI";
+
+export class GraphExecutorError extends Error {
+  constructor(message: string, cause?: Error) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "GraphExecutorError";
+  }
+}
+
+/**
+ * Executes GRAPH operations for named graph queries.
+ *
+ * GRAPH allows querying specific named graphs within an RDF dataset.
+ * This executor handles both:
+ * - Concrete graph names: GRAPH <http://example.org/g1> { ... }
+ * - Graph variables: GRAPH ?g { ... } (iterates over all named graphs)
+ *
+ * SPARQL 1.1 spec Section 13.3:
+ * https://www.w3.org/TR/sparql11-query/#queryDataset
+ *
+ * Example:
+ * ```sparql
+ * # Query a specific named graph
+ * SELECT ?s ?p ?o
+ * WHERE {
+ *   GRAPH <http://example.org/graph1> {
+ *     ?s ?p ?o
+ *   }
+ * }
+ *
+ * # Query all named graphs, binding graph name to ?g
+ * SELECT ?g ?s ?p ?o
+ * WHERE {
+ *   GRAPH ?g {
+ *     ?s ?p ?o
+ *   }
+ * }
+ * ```
+ */
+export class GraphExecutor {
+  constructor(private readonly tripleStore: ITripleStore) {}
+
+  /**
+   * Execute a GRAPH operation.
+   *
+   * @param operation - The GRAPH operation with graph name and pattern
+   * @param executePattern - Function to recursively execute inner pattern
+   * @param currentSolution - Current solution mapping (for variable graph bindings)
+   * @returns AsyncIterableIterator of SolutionMappings
+   */
+  async *execute(
+    operation: GraphOperation,
+    executePattern: (pattern: AlgebraOperation, graphContext?: IRIClass) => AsyncIterableIterator<SolutionMapping>,
+    currentSolution?: SolutionMapping
+  ): AsyncIterableIterator<SolutionMapping> {
+    const graphName = operation.name;
+
+    if (graphName.type === "iri") {
+      // Concrete graph name: execute pattern against the specific named graph
+      yield* this.executeWithGraph(operation.pattern, graphName, executePattern);
+    } else if (graphName.type === "variable") {
+      // Variable graph name: iterate over all named graphs
+      yield* this.executeWithGraphVariable(operation, graphName, executePattern, currentSolution);
+    } else {
+      throw new GraphExecutorError(`Invalid graph name type: ${(graphName as any).type}`);
+    }
+  }
+
+  /**
+   * Execute pattern against a specific named graph.
+   */
+  private async *executeWithGraph(
+    pattern: AlgebraOperation,
+    graphName: IRI,
+    executePattern: (pattern: AlgebraOperation, graphContext?: IRIClass) => AsyncIterableIterator<SolutionMapping>
+  ): AsyncIterableIterator<SolutionMapping> {
+    // Create IRI instance from algebra IRI
+    const graphIRI = new IRIClass(graphName.value);
+
+    // Check if the named graph exists (optional - depends on implementation)
+    if (this.tripleStore.hasGraph) {
+      const exists = await this.tripleStore.hasGraph(graphIRI);
+      if (!exists) {
+        // Named graph doesn't exist - return empty results
+        // Per SPARQL 1.1 semantics, querying a non-existent graph returns no results
+        return;
+      }
+    }
+
+    // Execute the inner pattern in the context of this named graph
+    yield* executePattern(pattern, graphIRI);
+  }
+
+  /**
+   * Execute pattern with a graph variable, iterating over all named graphs.
+   */
+  private async *executeWithGraphVariable(
+    operation: GraphOperation,
+    graphVariable: Variable,
+    executePattern: (pattern: AlgebraOperation, graphContext?: IRIClass) => AsyncIterableIterator<SolutionMapping>,
+    currentSolution?: SolutionMapping
+  ): AsyncIterableIterator<SolutionMapping> {
+    // Check if the graph variable is already bound in the current solution
+    if (currentSolution) {
+      const boundValue = currentSolution.get(graphVariable.value);
+      if (boundValue && boundValue instanceof IRIClass) {
+        // Variable already bound - execute only against that specific graph
+        yield* this.executeWithGraph(
+          operation.pattern,
+          { type: "iri", value: boundValue.value },
+          executePattern
+        );
+        return;
+      }
+    }
+
+    // Get all named graphs
+    if (!this.tripleStore.getNamedGraphs) {
+      // Triple store doesn't support named graphs - return empty results
+      return;
+    }
+
+    const namedGraphs = await this.tripleStore.getNamedGraphs();
+
+    // Iterate over each named graph
+    for (const graphIRI of namedGraphs) {
+      // Execute pattern in this graph's context
+      for await (const solution of executePattern(operation.pattern, graphIRI)) {
+        // Bind the graph variable to this graph's IRI
+        const extendedSolution = solution.clone();
+        extendedSolution.set(graphVariable.value, graphIRI);
+        yield extendedSolution;
+      }
+    }
+  }
+}

--- a/packages/core/src/interfaces/ITripleStore.ts
+++ b/packages/core/src/interfaces/ITripleStore.ts
@@ -1,4 +1,12 @@
 import { Triple, Subject, Predicate, Object as RDFObject } from "../domain/models/rdf/Triple";
+import { IRI } from "../domain/models/rdf/IRI";
+
+/**
+ * Graph identifier for named graph operations.
+ * - undefined: default graph
+ * - IRI: named graph
+ */
+export type GraphName = IRI | undefined;
 
 export interface ITripleStore {
   add(triple: Triple): Promise<void>;
@@ -46,6 +54,71 @@ export interface ITripleStore {
    * @returns Array of subjects whose URI contains the UUID
    */
   findSubjectsByUUIDSync?(uuid: string): Subject[];
+
+  // ===== Named Graph Support (SPARQL 1.1 Section 13.3) =====
+
+  /**
+   * Add a triple to a specific named graph.
+   *
+   * @param triple - The triple to add
+   * @param graph - The graph name (undefined for default graph)
+   */
+  addToGraph?(triple: Triple, graph: GraphName): Promise<void>;
+
+  /**
+   * Remove a triple from a specific named graph.
+   *
+   * @param triple - The triple to remove
+   * @param graph - The graph name (undefined for default graph)
+   * @returns true if the triple was removed, false if it didn't exist
+   */
+  removeFromGraph?(triple: Triple, graph: GraphName): Promise<boolean>;
+
+  /**
+   * Match triples within a specific named graph.
+   *
+   * @param subject - Subject filter (undefined for any)
+   * @param predicate - Predicate filter (undefined for any)
+   * @param object - Object filter (undefined for any)
+   * @param graph - The graph name (undefined for default graph)
+   * @returns Array of matching triples
+   */
+  matchInGraph?(
+    subject?: Subject,
+    predicate?: Predicate,
+    object?: RDFObject,
+    graph?: GraphName
+  ): Promise<Triple[]>;
+
+  /**
+   * Get all named graphs in the dataset.
+   *
+   * @returns Array of graph IRIs (does not include the default graph)
+   */
+  getNamedGraphs?(): Promise<IRI[]>;
+
+  /**
+   * Check if a named graph exists in the dataset.
+   *
+   * @param graph - The graph name to check
+   * @returns true if the graph exists and contains at least one triple
+   */
+  hasGraph?(graph: IRI): Promise<boolean>;
+
+  /**
+   * Clear all triples from a specific named graph.
+   *
+   * @param graph - The graph name (undefined for default graph)
+   */
+  clearGraph?(graph: GraphName): Promise<void>;
+
+  /**
+   * Get the count of triples in a specific named graph.
+   *
+   * @param graph - The graph name (undefined for default graph)
+   * @returns Number of triples in the graph
+   */
+  countInGraph?(graph: GraphName): Promise<number>;
 }
 
 export interface ITransaction {

--- a/packages/core/tests/unit/infrastructure/sparql/executors/GraphExecutor.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/executors/GraphExecutor.test.ts
@@ -1,0 +1,498 @@
+import { GraphExecutor, GraphExecutorError } from "../../../../../src/infrastructure/sparql/executors/GraphExecutor";
+import { GraphOperation, AlgebraOperation } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
+import { IRI } from "../../../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../../../src/domain/models/rdf/Literal";
+import { Triple } from "../../../../../src/domain/models/rdf/Triple";
+import { InMemoryTripleStore } from "../../../../../src/infrastructure/rdf/InMemoryTripleStore";
+
+describe("GraphExecutor", () => {
+  let tripleStore: InMemoryTripleStore;
+  let executor: GraphExecutor;
+
+  // Helper to create pattern executor that simulates BGP execution
+  const createMockPatternExecutor = (solutions: SolutionMapping[]) => {
+    return async function* (_pattern: AlgebraOperation, _graphContext?: IRI): AsyncIterableIterator<SolutionMapping> {
+      for (const solution of solutions) {
+        yield solution;
+      }
+    };
+  };
+
+  beforeEach(async () => {
+    tripleStore = new InMemoryTripleStore();
+    executor = new GraphExecutor(tripleStore);
+
+    // Set up test data in default graph
+    await tripleStore.add(
+      new Triple(
+        new IRI("http://example.org/subject1"),
+        new IRI("http://example.org/predicate"),
+        new Literal("Default graph value")
+      )
+    );
+
+    // Set up test data in named graph 1
+    await tripleStore.addToGraph(
+      new Triple(
+        new IRI("http://example.org/s1"),
+        new IRI("http://example.org/p1"),
+        new Literal("Graph 1 value 1")
+      ),
+      new IRI("http://example.org/graph1")
+    );
+    await tripleStore.addToGraph(
+      new Triple(
+        new IRI("http://example.org/s2"),
+        new IRI("http://example.org/p1"),
+        new Literal("Graph 1 value 2")
+      ),
+      new IRI("http://example.org/graph1")
+    );
+
+    // Set up test data in named graph 2
+    await tripleStore.addToGraph(
+      new Triple(
+        new IRI("http://example.org/s3"),
+        new IRI("http://example.org/p2"),
+        new Literal("Graph 2 value")
+      ),
+      new IRI("http://example.org/graph2")
+    );
+  });
+
+  describe("GRAPH with concrete IRI", () => {
+    it("should execute pattern against specific named graph", async () => {
+      // Create solutions that would come from the named graph
+      const expectedSolutions: SolutionMapping[] = [
+        (() => {
+          const s = new SolutionMapping();
+          s.set("s", new IRI("http://example.org/s1"));
+          s.set("o", new Literal("Graph 1 value 1"));
+          return s;
+        })(),
+        (() => {
+          const s = new SolutionMapping();
+          s.set("s", new IRI("http://example.org/s2"));
+          s.set("o", new Literal("Graph 1 value 2"));
+          return s;
+        })(),
+      ];
+
+      const operation: GraphOperation = {
+        type: "graph",
+        name: { type: "iri", value: "http://example.org/graph1" },
+        pattern: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: "http://example.org/p1" },
+              object: { type: "variable", value: "o" },
+            },
+          ],
+        },
+      };
+
+      const patternExecutor = createMockPatternExecutor(expectedSolutions);
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, patternExecutor)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(2);
+      expect((results[0].get("s") as IRI).value).toBe("http://example.org/s1");
+      expect((results[1].get("s") as IRI).value).toBe("http://example.org/s2");
+    });
+
+    it("should return empty results for non-existent named graph", async () => {
+      const operation: GraphOperation = {
+        type: "graph",
+        name: { type: "iri", value: "http://example.org/nonexistent" },
+        pattern: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "variable", value: "p" },
+              object: { type: "variable", value: "o" },
+            },
+          ],
+        },
+      };
+
+      const patternExecutor = createMockPatternExecutor([]);
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, patternExecutor)) {
+        results.push(solution);
+      }
+
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("GRAPH with variable", () => {
+    it("should iterate over all named graphs and bind graph variable", async () => {
+      // Track which graph context is being used
+      let graphContextsUsed: string[] = [];
+
+      const patternExecutor = async function* (
+        _pattern: AlgebraOperation,
+        graphContext?: IRI
+      ): AsyncIterableIterator<SolutionMapping> {
+        if (graphContext) {
+          graphContextsUsed.push(graphContext.value);
+
+          // Simulate returning data from each graph
+          const solution = new SolutionMapping();
+          solution.set("s", new IRI(`http://example.org/subject-in-${graphContext.value.split('/').pop()}`));
+          yield solution;
+        }
+      };
+
+      const operation: GraphOperation = {
+        type: "graph",
+        name: { type: "variable", value: "g" },
+        pattern: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "variable", value: "p" },
+              object: { type: "variable", value: "o" },
+            },
+          ],
+        },
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, patternExecutor)) {
+        results.push(solution);
+      }
+
+      // Should have one result per named graph (2 named graphs)
+      expect(results).toHaveLength(2);
+
+      // Each result should have the ?g variable bound to the graph IRI
+      const graphBindings = results.map((r) => (r.get("g") as IRI).value).sort();
+      expect(graphBindings).toContain("http://example.org/graph1");
+      expect(graphBindings).toContain("http://example.org/graph2");
+    });
+
+    it("should use bound graph variable value when already in solution", async () => {
+      // Create a solution with ?g already bound
+      const boundSolution = new SolutionMapping();
+      boundSolution.set("g", new IRI("http://example.org/graph1"));
+
+      // Track if pattern was executed with correct graph context
+      let graphContextUsed: string | undefined;
+
+      const patternExecutor = async function* (
+        _pattern: AlgebraOperation,
+        graphContext?: IRI
+      ): AsyncIterableIterator<SolutionMapping> {
+        graphContextUsed = graphContext?.value;
+        const solution = new SolutionMapping();
+        solution.set("s", new IRI("http://example.org/subject"));
+        yield solution;
+      };
+
+      const operation: GraphOperation = {
+        type: "graph",
+        name: { type: "variable", value: "g" },
+        pattern: {
+          type: "bgp",
+          triples: [],
+        },
+      };
+
+      const results: SolutionMapping[] = [];
+      for await (const solution of executor.execute(operation, patternExecutor, boundSolution)) {
+        results.push(solution);
+      }
+
+      // Should only execute against the bound graph
+      expect(graphContextUsed).toBe("http://example.org/graph1");
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should throw error for invalid graph name type", async () => {
+      const operation: GraphOperation = {
+        type: "graph",
+        name: { type: "literal" as any, value: "invalid" },
+        pattern: {
+          type: "bgp",
+          triples: [],
+        },
+      };
+
+      const patternExecutor = createMockPatternExecutor([]);
+
+      await expect(async () => {
+        const results: SolutionMapping[] = [];
+        for await (const solution of executor.execute(operation, patternExecutor)) {
+          results.push(solution);
+        }
+      }).rejects.toThrow(GraphExecutorError);
+    });
+  });
+
+  describe("Integration with InMemoryTripleStore", () => {
+    it("should correctly query named graph storage", async () => {
+      // Verify named graphs exist
+      const graphs = await tripleStore.getNamedGraphs();
+      expect(graphs).toHaveLength(2);
+
+      // Verify triples in graph1
+      const graph1Triples = await tripleStore.matchInGraph(
+        undefined,
+        undefined,
+        undefined,
+        new IRI("http://example.org/graph1")
+      );
+      expect(graph1Triples).toHaveLength(2);
+
+      // Verify triples in graph2
+      const graph2Triples = await tripleStore.matchInGraph(
+        undefined,
+        undefined,
+        undefined,
+        new IRI("http://example.org/graph2")
+      );
+      expect(graph2Triples).toHaveLength(1);
+
+      // Verify default graph is separate
+      const defaultTriples = await tripleStore.match();
+      expect(defaultTriples).toHaveLength(1);
+    });
+  });
+});
+
+describe("InMemoryTripleStore Named Graph Support", () => {
+  let store: InMemoryTripleStore;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+  });
+
+  describe("addToGraph", () => {
+    it("should add triple to default graph when graph is undefined", async () => {
+      const triple = new Triple(
+        new IRI("http://example.org/s"),
+        new IRI("http://example.org/p"),
+        new Literal("value")
+      );
+
+      await store.addToGraph(triple, undefined);
+
+      const results = await store.match();
+      expect(results).toHaveLength(1);
+      expect(results[0].subject).toEqual(triple.subject);
+    });
+
+    it("should add triple to named graph when graph IRI provided", async () => {
+      const triple = new Triple(
+        new IRI("http://example.org/s"),
+        new IRI("http://example.org/p"),
+        new Literal("value")
+      );
+      const graphIRI = new IRI("http://example.org/graph1");
+
+      await store.addToGraph(triple, graphIRI);
+
+      // Should not be in default graph
+      const defaultResults = await store.match();
+      expect(defaultResults).toHaveLength(0);
+
+      // Should be in named graph
+      const graphResults = await store.matchInGraph(undefined, undefined, undefined, graphIRI);
+      expect(graphResults).toHaveLength(1);
+      expect(graphResults[0].subject).toEqual(triple.subject);
+    });
+  });
+
+  describe("matchInGraph", () => {
+    it("should match triples only in the specified named graph", async () => {
+      const triple1 = new Triple(
+        new IRI("http://example.org/s1"),
+        new IRI("http://example.org/p"),
+        new Literal("value1")
+      );
+      const triple2 = new Triple(
+        new IRI("http://example.org/s2"),
+        new IRI("http://example.org/p"),
+        new Literal("value2")
+      );
+      const graph1 = new IRI("http://example.org/graph1");
+      const graph2 = new IRI("http://example.org/graph2");
+
+      await store.addToGraph(triple1, graph1);
+      await store.addToGraph(triple2, graph2);
+
+      // Query graph1
+      const graph1Results = await store.matchInGraph(undefined, undefined, undefined, graph1);
+      expect(graph1Results).toHaveLength(1);
+      expect((graph1Results[0].object as Literal).value).toBe("value1");
+
+      // Query graph2
+      const graph2Results = await store.matchInGraph(undefined, undefined, undefined, graph2);
+      expect(graph2Results).toHaveLength(1);
+      expect((graph2Results[0].object as Literal).value).toBe("value2");
+    });
+
+    it("should return empty results for non-existent graph", async () => {
+      const results = await store.matchInGraph(
+        undefined,
+        undefined,
+        undefined,
+        new IRI("http://example.org/nonexistent")
+      );
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("getNamedGraphs", () => {
+    it("should return all named graph IRIs", async () => {
+      await store.addToGraph(
+        new Triple(new IRI("http://example.org/s1"), new IRI("http://example.org/p"), new Literal("v1")),
+        new IRI("http://example.org/graph1")
+      );
+      await store.addToGraph(
+        new Triple(new IRI("http://example.org/s2"), new IRI("http://example.org/p"), new Literal("v2")),
+        new IRI("http://example.org/graph2")
+      );
+      await store.addToGraph(
+        new Triple(new IRI("http://example.org/s3"), new IRI("http://example.org/p"), new Literal("v3")),
+        new IRI("http://example.org/graph3")
+      );
+
+      const graphs = await store.getNamedGraphs();
+      expect(graphs).toHaveLength(3);
+
+      const graphNames = graphs.map((g) => g.value).sort();
+      expect(graphNames).toEqual([
+        "http://example.org/graph1",
+        "http://example.org/graph2",
+        "http://example.org/graph3",
+      ]);
+    });
+
+    it("should not include default graph", async () => {
+      await store.add(
+        new Triple(new IRI("http://example.org/s"), new IRI("http://example.org/p"), new Literal("default"))
+      );
+      await store.addToGraph(
+        new Triple(new IRI("http://example.org/s"), new IRI("http://example.org/p"), new Literal("named")),
+        new IRI("http://example.org/graph1")
+      );
+
+      const graphs = await store.getNamedGraphs();
+      expect(graphs).toHaveLength(1);
+      expect(graphs[0].value).toBe("http://example.org/graph1");
+    });
+  });
+
+  describe("hasGraph", () => {
+    it("should return true for existing graph with triples", async () => {
+      await store.addToGraph(
+        new Triple(new IRI("http://example.org/s"), new IRI("http://example.org/p"), new Literal("v")),
+        new IRI("http://example.org/graph1")
+      );
+
+      const exists = await store.hasGraph(new IRI("http://example.org/graph1"));
+      expect(exists).toBe(true);
+    });
+
+    it("should return false for non-existent graph", async () => {
+      const exists = await store.hasGraph(new IRI("http://example.org/nonexistent"));
+      expect(exists).toBe(false);
+    });
+  });
+
+  describe("clearGraph", () => {
+    it("should clear only the specified named graph", async () => {
+      await store.addToGraph(
+        new Triple(new IRI("http://example.org/s1"), new IRI("http://example.org/p"), new Literal("v1")),
+        new IRI("http://example.org/graph1")
+      );
+      await store.addToGraph(
+        new Triple(new IRI("http://example.org/s2"), new IRI("http://example.org/p"), new Literal("v2")),
+        new IRI("http://example.org/graph2")
+      );
+
+      await store.clearGraph(new IRI("http://example.org/graph1"));
+
+      // Graph1 should be empty
+      const graph1Results = await store.matchInGraph(
+        undefined,
+        undefined,
+        undefined,
+        new IRI("http://example.org/graph1")
+      );
+      expect(graph1Results).toHaveLength(0);
+
+      // Graph2 should still have data
+      const graph2Results = await store.matchInGraph(
+        undefined,
+        undefined,
+        undefined,
+        new IRI("http://example.org/graph2")
+      );
+      expect(graph2Results).toHaveLength(1);
+    });
+  });
+
+  describe("countInGraph", () => {
+    it("should return correct count for named graph", async () => {
+      await store.addToGraph(
+        new Triple(new IRI("http://example.org/s1"), new IRI("http://example.org/p"), new Literal("v1")),
+        new IRI("http://example.org/graph1")
+      );
+      await store.addToGraph(
+        new Triple(new IRI("http://example.org/s2"), new IRI("http://example.org/p"), new Literal("v2")),
+        new IRI("http://example.org/graph1")
+      );
+
+      const count = await store.countInGraph(new IRI("http://example.org/graph1"));
+      expect(count).toBe(2);
+    });
+
+    it("should return 0 for non-existent graph", async () => {
+      const count = await store.countInGraph(new IRI("http://example.org/nonexistent"));
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("removeFromGraph", () => {
+    it("should remove triple from specific named graph", async () => {
+      const triple = new Triple(
+        new IRI("http://example.org/s"),
+        new IRI("http://example.org/p"),
+        new Literal("value")
+      );
+      const graphIRI = new IRI("http://example.org/graph1");
+
+      await store.addToGraph(triple, graphIRI);
+      expect(await store.countInGraph(graphIRI)).toBe(1);
+
+      const removed = await store.removeFromGraph(triple, graphIRI);
+      expect(removed).toBe(true);
+      expect(await store.countInGraph(graphIRI)).toBe(0);
+    });
+
+    it("should return false when removing non-existent triple", async () => {
+      const triple = new Triple(
+        new IRI("http://example.org/s"),
+        new IRI("http://example.org/p"),
+        new Literal("value")
+      );
+
+      const removed = await store.removeFromGraph(triple, new IRI("http://example.org/graph1"));
+      expect(removed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements SPARQL 1.1 GRAPH clause support for querying named graphs in RDF datasets
- Supports both concrete graph names (`GRAPH <uri> { ... }`) and graph variables (`GRAPH ?g { ... }`)
- Adds named graph storage and querying to InMemoryTripleStore
- Creates GraphExecutor for GRAPH clause evaluation with 19 comprehensive tests

## Changes

### Algebra
- Added `GraphOperation` type to `AlgebraOperation.ts`
- Updated `AlgebraTranslator` to handle GRAPH patterns with both IRI and variable names
- Fixed `translateUnion` to properly handle GRAPH patterns within UNION branches

### Triple Store
- Extended `ITripleStore` interface with named graph methods:
  - `addToGraph`, `removeFromGraph`, `matchInGraph`
  - `getNamedGraphs`, `hasGraph`, `clearGraph`, `countInGraph`
- Implemented named graph support in `InMemoryTripleStore` using nested stores

### Executors
- Created `GraphExecutor` for GRAPH clause evaluation
- Added `executeInGraph` to `BGPExecutor` for graph-scoped pattern matching
- Updated `QueryExecutor` to dispatch GRAPH operations

### Tests
- 19 tests for GraphExecutor covering:
  - Concrete graph name queries
  - Graph variable iteration
  - Pre-bound graph variables
  - Error handling for invalid graph names
- 12 tests for AlgebraTranslator GRAPH parsing
- Tests for InMemoryTripleStore named graph operations

## Test plan
- [x] All 19 GraphExecutor tests pass
- [x] All 12 AlgebraTranslator GRAPH tests pass
- [x] All InMemoryTripleStore named graph tests pass
- [x] Unit test suite passes (396 tests)

Closes #721