### PR TITLE
feat: [Test Quality] Standardize Test Patterns and Create Mock Factory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3285,6 +3285,10 @@
       "resolved": "packages/obsidian-plugin",
       "link": true
     },
+    "node_modules/@exocortex/test-utils": {
+      "resolved": "packages/test-utils",
+      "link": true
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -16453,6 +16457,20 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "packages/test-utils": {
+      "name": "@exocortex/test-utils",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "jest": "^30.2.0",
+        "ts-jest": "^29.4.5",
+        "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "obsidian": "*"
       }
     }
   }

--- a/packages/test-utils/jest.config.js
+++ b/packages/test-utils/jest.config.js
@@ -1,0 +1,19 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/tests"],
+  moduleFileExtensions: ["ts", "js"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        tsconfig: "tsconfig.json",
+      },
+    ],
+  },
+  moduleNameMapper: {
+    "^@exocortex/test-utils$": "<rootDir>/src/index.ts",
+  },
+};

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@exocortex/test-utils",
+  "version": "1.0.0",
+  "description": "Shared test utilities and mock factories for Exocortex packages",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "test": "jest",
+    "lint": "eslint src --ext .ts"
+  },
+  "keywords": [
+    "testing",
+    "mocks",
+    "factories"
+  ],
+  "author": "A. Kitelev",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "^30.2.0",
+    "ts-jest": "^29.4.5",
+    "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "obsidian": "*"
+  }
+}

--- a/packages/test-utils/src/factories/area.factory.ts
+++ b/packages/test-utils/src/factories/area.factory.ts
@@ -1,0 +1,204 @@
+/**
+ * Area factory for creating test data.
+ *
+ * @example
+ * // Simple area
+ * const area = AreaFactory.create();
+ *
+ * // Area with children
+ * const parentArea = AreaFactory.create({ label: "Work" });
+ * const childArea = AreaFactory.withParent(parentArea.basename);
+ *
+ * // Archived area
+ * const archivedArea = AreaFactory.archived();
+ */
+
+import type {
+  AreaFixture,
+  FileInfo,
+  Metadata,
+} from "../types";
+
+let areaCounter = 0;
+
+/**
+ * Reset the area counter. Call this in beforeEach() to ensure deterministic IDs.
+ */
+export function resetAreaCounter(): void {
+  areaCounter = 0;
+}
+
+/**
+ * Generate a unique ID for areas.
+ */
+function generateId(): string {
+  areaCounter++;
+  return `area-${areaCounter}`;
+}
+
+/**
+ * Default area fixture values.
+ */
+const DEFAULT_AREA: Omit<AreaFixture, "path" | "basename" | "label"> = {
+  isArchived: false,
+  createdAt: Date.now(),
+};
+
+/**
+ * Area factory for creating test fixtures.
+ */
+export const AreaFactory = {
+  /**
+   * Create an area fixture with optional overrides.
+   */
+  create(overrides: Partial<AreaFixture> = {}): AreaFixture {
+    const id = generateId();
+    const basename = overrides.basename ?? id;
+
+    return {
+      path: overrides.path ?? `areas/${basename}.md`,
+      basename,
+      label: overrides.label ?? `Test Area ${areaCounter}`,
+      parent: overrides.parent,
+      isArchived: overrides.isArchived ?? DEFAULT_AREA.isArchived,
+      createdAt: overrides.createdAt ?? DEFAULT_AREA.createdAt,
+    };
+  },
+
+  /**
+   * Create multiple area fixtures.
+   */
+  createMany(count: number, overrides: Partial<AreaFixture> = {}): AreaFixture[] {
+    return Array.from({ length: count }, () => AreaFactory.create(overrides));
+  },
+
+  // Convenience methods
+
+  /**
+   * Create an archived area.
+   */
+  archived(overrides: Partial<AreaFixture> = {}): AreaFixture {
+    return AreaFactory.create({ isArchived: true, ...overrides });
+  },
+
+  /**
+   * Create an area with a parent (sub-area).
+   */
+  withParent(parent: string, overrides: Partial<AreaFixture> = {}): AreaFixture {
+    return AreaFactory.create({ parent, ...overrides });
+  },
+
+  // Pre-defined common areas
+
+  /**
+   * Create a Work area.
+   */
+  work(overrides: Partial<AreaFixture> = {}): AreaFixture {
+    return AreaFactory.create({
+      label: "Work",
+      basename: "work-area",
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a Personal area.
+   */
+  personal(overrides: Partial<AreaFixture> = {}): AreaFixture {
+    return AreaFactory.create({
+      label: "Personal",
+      basename: "personal-area",
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a Health area.
+   */
+  health(overrides: Partial<AreaFixture> = {}): AreaFixture {
+    return AreaFactory.create({
+      label: "Health",
+      basename: "health-area",
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a Learning area.
+   */
+  learning(overrides: Partial<AreaFixture> = {}): AreaFixture {
+    return AreaFactory.create({
+      label: "Learning",
+      basename: "learning-area",
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a hierarchical area structure.
+   */
+  hierarchy(): {
+    root: AreaFixture;
+    child1: AreaFixture;
+    child2: AreaFixture;
+    grandchild: AreaFixture;
+  } {
+    const root = AreaFactory.create({ label: "Root Area", basename: "root-area" });
+    const child1 = AreaFactory.withParent(root.basename, {
+      label: "Child Area 1",
+      basename: "child-area-1",
+    });
+    const child2 = AreaFactory.withParent(root.basename, {
+      label: "Child Area 2",
+      basename: "child-area-2",
+    });
+    const grandchild = AreaFactory.withParent(child1.basename, {
+      label: "Grandchild Area",
+      basename: "grandchild-area",
+    });
+
+    return { root, child1, child2, grandchild };
+  },
+
+  // Metadata conversion
+
+  /**
+   * Convert an AreaFixture to frontmatter metadata format.
+   */
+  toMetadata(fixture: AreaFixture): Metadata {
+    const metadata: Metadata = {
+      exo__Instance_class: "[[ems__Area]]",
+      exo__Asset_label: fixture.label,
+      exo__Asset_uid: fixture.basename,
+      exo__Asset_createdAt: fixture.createdAt,
+      exo__Asset_isArchived: fixture.isArchived,
+    };
+
+    if (fixture.parent) {
+      metadata.ems__Area_parent = `[[${fixture.parent}]]`;
+    }
+
+    return metadata;
+  },
+
+  /**
+   * Convert an AreaFixture to a TFile-like object.
+   */
+  toFile(fixture: AreaFixture): FileInfo & { stat: object; vault: null; parent: null; extension: string } {
+    return {
+      path: fixture.path,
+      basename: fixture.basename,
+      name: `${fixture.basename}.md`,
+      extension: "md",
+      parent: null,
+      vault: null,
+      stat: {
+        ctime: fixture.createdAt ?? Date.now(),
+        mtime: Date.now(),
+        size: 0,
+      },
+    };
+  },
+};
+
+export default AreaFactory;

--- a/packages/test-utils/src/factories/index.ts
+++ b/packages/test-utils/src/factories/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Test factories for creating mock data.
+ *
+ * @example
+ * import { TaskFactory, ProjectFactory, AreaFactory } from "@exocortex/test-utils";
+ *
+ * // Create fixtures
+ * const task = TaskFactory.doing();
+ * const project = ProjectFactory.inArea("work-area");
+ * const area = AreaFactory.work();
+ *
+ * // Create DailyTask for React components
+ * const dailyTask = TaskFactory.createDailyTask();
+ *
+ * // Reset counters in beforeEach
+ * beforeEach(() => {
+ *   resetAllCounters();
+ * });
+ */
+
+export { TaskFactory, resetTaskCounter } from "./task.factory";
+export { ProjectFactory, resetProjectCounter } from "./project.factory";
+export { AreaFactory, resetAreaCounter } from "./area.factory";
+export { MeetingFactory, resetMeetingCounter } from "./meeting.factory";
+
+import { resetTaskCounter } from "./task.factory";
+import { resetProjectCounter } from "./project.factory";
+import { resetAreaCounter } from "./area.factory";
+import { resetMeetingCounter } from "./meeting.factory";
+
+/**
+ * Reset all factory counters. Call this in beforeEach() for deterministic test data.
+ */
+export function resetAllCounters(): void {
+  resetTaskCounter();
+  resetProjectCounter();
+  resetAreaCounter();
+  resetMeetingCounter();
+}

--- a/packages/test-utils/src/factories/meeting.factory.ts
+++ b/packages/test-utils/src/factories/meeting.factory.ts
@@ -1,0 +1,335 @@
+/**
+ * Meeting factory for creating test data.
+ *
+ * @example
+ * // Simple meeting
+ * const meeting = MeetingFactory.create();
+ *
+ * // Meeting scheduled for tomorrow
+ * const futureMeeting = MeetingFactory.scheduled(Date.now() + 86400000);
+ *
+ * // Completed meeting
+ * const completedMeeting = MeetingFactory.done();
+ */
+
+import type {
+  MeetingFixture,
+  DailyTask,
+  EffortStatus,
+  EffortStatusName,
+  FileInfo,
+  Metadata,
+} from "../types";
+
+let meetingCounter = 0;
+
+/**
+ * Reset the meeting counter. Call this in beforeEach() to ensure deterministic IDs.
+ */
+export function resetMeetingCounter(): void {
+  meetingCounter = 0;
+}
+
+/**
+ * Map human-readable status names to wikilink format.
+ */
+const STATUS_MAP: Record<EffortStatusName, EffortStatus> = {
+  Draft: "ems__EffortStatusDraft",
+  Backlog: "ems__EffortStatusBacklog",
+  Analysis: "ems__EffortStatusAnalysis",
+  "To Do": "ems__EffortStatusToDo",
+  Doing: "ems__EffortStatusDoing",
+  Done: "ems__EffortStatusDone",
+  Trashed: "ems__EffortStatusTrashed",
+};
+
+/**
+ * Normalize status to the ems__ format.
+ */
+function normalizeStatus(status: EffortStatus | EffortStatusName): EffortStatus {
+  if (status.startsWith("ems__")) {
+    return status as EffortStatus;
+  }
+  return STATUS_MAP[status as EffortStatusName] || "ems__EffortStatusDraft";
+}
+
+/**
+ * Check if a status indicates "done" state.
+ */
+function isDoneStatus(status: EffortStatus): boolean {
+  return status === "ems__EffortStatusDone";
+}
+
+/**
+ * Check if a status indicates "trashed" state.
+ */
+function isTrashedStatus(status: EffortStatus): boolean {
+  return status === "ems__EffortStatusTrashed";
+}
+
+/**
+ * Check if a status indicates "doing" state.
+ */
+function isDoingStatus(status: EffortStatus): boolean {
+  return status === "ems__EffortStatusDoing";
+}
+
+/**
+ * Generate a unique ID for meetings.
+ */
+function generateId(): string {
+  meetingCounter++;
+  return `meeting-${meetingCounter}`;
+}
+
+/**
+ * Default meeting fixture values.
+ */
+const DEFAULT_MEETING: Omit<MeetingFixture, "path" | "basename" | "label"> = {
+  status: "ems__EffortStatusDraft",
+  votes: 0,
+  isArchived: false,
+  createdAt: Date.now(),
+};
+
+/**
+ * Meeting factory for creating test fixtures.
+ */
+export const MeetingFactory = {
+  /**
+   * Create a meeting fixture with optional overrides.
+   */
+  create(overrides: Partial<MeetingFixture> = {}): MeetingFixture {
+    const id = generateId();
+    const basename = overrides.basename ?? id;
+    const normalizedStatus = normalizeStatus(
+      overrides.status ?? DEFAULT_MEETING.status
+    );
+
+    return {
+      path: overrides.path ?? `meetings/${basename}.md`,
+      basename,
+      label: overrides.label ?? `Test Meeting ${meetingCounter}`,
+      status: normalizedStatus,
+      votes: overrides.votes ?? DEFAULT_MEETING.votes,
+      area: overrides.area,
+      parent: overrides.parent,
+      day: overrides.day,
+      isArchived: overrides.isArchived ?? DEFAULT_MEETING.isArchived,
+      createdAt: overrides.createdAt ?? DEFAULT_MEETING.createdAt,
+      startTimestamp: overrides.startTimestamp,
+      endTimestamp: overrides.endTimestamp,
+      scheduledAt: overrides.scheduledAt,
+      blockers: overrides.blockers,
+    };
+  },
+
+  /**
+   * Create multiple meeting fixtures.
+   */
+  createMany(count: number, overrides: Partial<MeetingFixture> = {}): MeetingFixture[] {
+    return Array.from({ length: count }, () => MeetingFactory.create(overrides));
+  },
+
+  // Convenience methods for common states
+
+  /**
+   * Create a meeting scheduled at a specific time.
+   */
+  scheduled(scheduledAt: number, overrides: Partial<MeetingFixture> = {}): MeetingFixture {
+    return MeetingFactory.create({
+      status: "To Do",
+      scheduledAt,
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a meeting scheduled for today.
+   */
+  today(overrides: Partial<MeetingFixture> = {}): MeetingFixture {
+    const today = new Date();
+    today.setHours(14, 0, 0, 0); // 2 PM today
+    return MeetingFactory.scheduled(today.getTime(), overrides);
+  },
+
+  /**
+   * Create a meeting scheduled for tomorrow.
+   */
+  tomorrow(overrides: Partial<MeetingFixture> = {}): MeetingFixture {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(14, 0, 0, 0); // 2 PM tomorrow
+    return MeetingFactory.scheduled(tomorrow.getTime(), overrides);
+  },
+
+  /**
+   * Create a past meeting.
+   */
+  past(overrides: Partial<MeetingFixture> = {}): MeetingFixture {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(14, 0, 0, 0);
+    return MeetingFactory.scheduled(yesterday.getTime(), overrides);
+  },
+
+  /**
+   * Create a Doing meeting (in progress).
+   */
+  doing(overrides: Partial<MeetingFixture> = {}): MeetingFixture {
+    return MeetingFactory.create({
+      status: "Doing",
+      startTimestamp: overrides.startTimestamp ?? Date.now(),
+      scheduledAt: Date.now(),
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a Done meeting.
+   */
+  done(overrides: Partial<MeetingFixture> = {}): MeetingFixture {
+    const defaultStart = Date.now() - 3600000;
+    const startTimestamp = overrides.startTimestamp ?? defaultStart;
+    const scheduledAtValue = typeof startTimestamp === "number" ? startTimestamp : defaultStart;
+    return MeetingFactory.create({
+      status: "Done",
+      startTimestamp,
+      endTimestamp: overrides.endTimestamp ?? Date.now(),
+      scheduledAt: scheduledAtValue,
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a Trashed meeting.
+   */
+  trashed(overrides: Partial<MeetingFixture> = {}): MeetingFixture {
+    return MeetingFactory.create({ status: "Trashed", ...overrides });
+  },
+
+  /**
+   * Create a meeting under a project.
+   */
+  withParent(parent: string, overrides: Partial<MeetingFixture> = {}): MeetingFixture {
+    return MeetingFactory.create({ parent, ...overrides });
+  },
+
+  // DailyTask factory methods for React component tests (meetings appear as DailyTask with isMeeting=true)
+
+  /**
+   * Create a DailyTask representing a meeting for React component tests.
+   */
+  createDailyMeeting(overrides: Partial<DailyTask> = {}): DailyTask {
+    const id = generateId();
+    const basename = overrides.file?.basename ?? id;
+    const path = overrides.path ?? overrides.file?.path ?? `meetings/${basename}.md`;
+    const status = overrides.status ?? "ems__EffortStatusToDo";
+    const normalizedStatus = status.startsWith("ems__")
+      ? status
+      : STATUS_MAP[status as EffortStatusName] ?? "ems__EffortStatusToDo";
+
+    return {
+      file: {
+        path,
+        basename,
+        ...overrides.file,
+      },
+      path,
+      title: overrides.title ?? basename,
+      label: overrides.label ?? `Test Meeting ${meetingCounter}`,
+      startTime: overrides.startTime ?? "14:00",
+      endTime: overrides.endTime ?? "15:00",
+      startTimestamp: overrides.startTimestamp ?? null,
+      endTimestamp: overrides.endTimestamp ?? null,
+      status: normalizedStatus,
+      metadata: overrides.metadata ?? {},
+      isDone: overrides.isDone ?? isDoneStatus(normalizedStatus as EffortStatus),
+      isTrashed: overrides.isTrashed ?? isTrashedStatus(normalizedStatus as EffortStatus),
+      isDoing: overrides.isDoing ?? isDoingStatus(normalizedStatus as EffortStatus),
+      isMeeting: overrides.isMeeting ?? true, // Always true for meetings
+      isBlocked: overrides.isBlocked ?? false,
+      isEmptySlot: overrides.isEmptySlot,
+    };
+  },
+
+  /**
+   * Create multiple DailyMeetings.
+   */
+  createManyDailyMeetings(
+    count: number,
+    overrides: Partial<DailyTask> = {}
+  ): DailyTask[] {
+    return Array.from({ length: count }, () =>
+      MeetingFactory.createDailyMeeting(overrides)
+    );
+  },
+
+  // Metadata conversion
+
+  /**
+   * Convert a MeetingFixture to frontmatter metadata format.
+   */
+  toMetadata(fixture: MeetingFixture): Metadata {
+    const normalizedStatus = normalizeStatus(fixture.status);
+    const metadata: Metadata = {
+      exo__Instance_class: "[[ems__Meeting]]",
+      exo__Asset_label: fixture.label,
+      exo__Asset_uid: fixture.basename,
+      exo__Asset_createdAt: fixture.createdAt,
+      exo__Asset_isArchived: fixture.isArchived,
+      ems__Effort_status: `[[${normalizedStatus}]]`,
+    };
+
+    if (fixture.votes !== undefined && fixture.votes > 0) {
+      metadata.ems__Effort_votes = fixture.votes;
+    }
+
+    if (fixture.area) {
+      metadata.ems__Effort_area = `[[${fixture.area}]]`;
+    }
+
+    if (fixture.parent) {
+      metadata.ems__Effort_parent = `[[${fixture.parent}]]`;
+    }
+
+    if (fixture.day) {
+      metadata.ems__Effort_day = `[[${fixture.day}]]`;
+    }
+
+    if (fixture.startTimestamp) {
+      metadata.ems__Effort_startTimestamp = fixture.startTimestamp;
+    }
+
+    if (fixture.endTimestamp) {
+      metadata.ems__Effort_endTimestamp = fixture.endTimestamp;
+    }
+
+    if (fixture.scheduledAt) {
+      metadata.ems__Meeting_scheduledAt = fixture.scheduledAt;
+    }
+
+    return metadata;
+  },
+
+  /**
+   * Convert a MeetingFixture to a TFile-like object.
+   */
+  toFile(fixture: MeetingFixture): FileInfo & { stat: object; vault: null; parent: null; extension: string } {
+    return {
+      path: fixture.path,
+      basename: fixture.basename,
+      name: `${fixture.basename}.md`,
+      extension: "md",
+      parent: null,
+      vault: null,
+      stat: {
+        ctime: fixture.createdAt ?? Date.now(),
+        mtime: Date.now(),
+        size: 0,
+      },
+    };
+  },
+};
+
+export default MeetingFactory;

--- a/packages/test-utils/src/factories/project.factory.ts
+++ b/packages/test-utils/src/factories/project.factory.ts
@@ -1,0 +1,359 @@
+/**
+ * Project factory for creating test data.
+ *
+ * @example
+ * // Simple project
+ * const project = ProjectFactory.create();
+ *
+ * // Project with specific status
+ * const doingProject = ProjectFactory.doing();
+ *
+ * // DailyProject for React components
+ * const dailyProject = ProjectFactory.createDailyProject();
+ */
+
+import type {
+  ProjectFixture,
+  DailyProject,
+  EffortStatus,
+  EffortStatusName,
+  FileInfo,
+  Metadata,
+} from "../types";
+
+let projectCounter = 0;
+
+/**
+ * Reset the project counter. Call this in beforeEach() to ensure deterministic IDs.
+ */
+export function resetProjectCounter(): void {
+  projectCounter = 0;
+}
+
+/**
+ * Map human-readable status names to wikilink format.
+ */
+const STATUS_MAP: Record<EffortStatusName, EffortStatus> = {
+  Draft: "ems__EffortStatusDraft",
+  Backlog: "ems__EffortStatusBacklog",
+  Analysis: "ems__EffortStatusAnalysis",
+  "To Do": "ems__EffortStatusToDo",
+  Doing: "ems__EffortStatusDoing",
+  Done: "ems__EffortStatusDone",
+  Trashed: "ems__EffortStatusTrashed",
+};
+
+/**
+ * Normalize status to the ems__ format.
+ */
+function normalizeStatus(status: EffortStatus | EffortStatusName): EffortStatus {
+  if (status.startsWith("ems__")) {
+    return status as EffortStatus;
+  }
+  return STATUS_MAP[status as EffortStatusName] || "ems__EffortStatusDraft";
+}
+
+/**
+ * Check if a status indicates "done" state.
+ */
+function isDoneStatus(status: EffortStatus): boolean {
+  return status === "ems__EffortStatusDone";
+}
+
+/**
+ * Check if a status indicates "trashed" state.
+ */
+function isTrashedStatus(status: EffortStatus): boolean {
+  return status === "ems__EffortStatusTrashed";
+}
+
+/**
+ * Generate a unique ID for projects.
+ */
+function generateId(): string {
+  projectCounter++;
+  return `project-${projectCounter}`;
+}
+
+/**
+ * Default project fixture values.
+ */
+const DEFAULT_PROJECT: Omit<ProjectFixture, "path" | "basename" | "label"> = {
+  status: "ems__EffortStatusDraft",
+  votes: 0,
+  isArchived: false,
+  createdAt: Date.now(),
+};
+
+/**
+ * Project factory for creating test fixtures.
+ */
+export const ProjectFactory = {
+  /**
+   * Create a project fixture with optional overrides.
+   */
+  create(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    const id = generateId();
+    const basename = overrides.basename ?? id;
+    const normalizedStatus = normalizeStatus(
+      overrides.status ?? DEFAULT_PROJECT.status
+    );
+
+    return {
+      path: overrides.path ?? `projects/${basename}.md`,
+      basename,
+      label: overrides.label ?? `Test Project ${projectCounter}`,
+      status: normalizedStatus,
+      votes: overrides.votes ?? DEFAULT_PROJECT.votes,
+      area: overrides.area,
+      parent: overrides.parent,
+      isArchived: overrides.isArchived ?? DEFAULT_PROJECT.isArchived,
+      createdAt: overrides.createdAt ?? DEFAULT_PROJECT.createdAt,
+      blockers: overrides.blockers,
+    };
+  },
+
+  /**
+   * Create multiple project fixtures.
+   */
+  createMany(count: number, overrides: Partial<ProjectFixture> = {}): ProjectFixture[] {
+    return Array.from({ length: count }, () => ProjectFactory.create(overrides));
+  },
+
+  // Convenience methods for common states
+
+  /**
+   * Create a Draft project.
+   */
+  draft(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ status: "Draft", ...overrides });
+  },
+
+  /**
+   * Create a Backlog project.
+   */
+  backlog(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ status: "Backlog", ...overrides });
+  },
+
+  /**
+   * Create an Analysis project.
+   */
+  analysis(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ status: "Analysis", ...overrides });
+  },
+
+  /**
+   * Create a To Do project.
+   */
+  todo(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ status: "To Do", ...overrides });
+  },
+
+  /**
+   * Create a Doing project.
+   */
+  doing(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ status: "Doing", ...overrides });
+  },
+
+  /**
+   * Create a Done project.
+   */
+  done(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ status: "Done", ...overrides });
+  },
+
+  /**
+   * Create a Trashed project.
+   */
+  trashed(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ status: "Trashed", ...overrides });
+  },
+
+  /**
+   * Create an archived project (Done + isArchived).
+   */
+  archived(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.done({ isArchived: true, ...overrides });
+  },
+
+  /**
+   * Create a blocked project.
+   */
+  blocked(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    const blockerProject = ProjectFactory.create();
+    return ProjectFactory.create({
+      blockers: [blockerProject.path],
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a project with votes.
+   */
+  withVotes(votes: number, overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ votes, ...overrides });
+  },
+
+  /**
+   * Create a project under a parent initiative/project.
+   */
+  withParent(parent: string, overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ parent, ...overrides });
+  },
+
+  /**
+   * Create a project in an area.
+   */
+  inArea(area: string, overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ area, ...overrides });
+  },
+
+  // DailyProject factory methods for React component tests
+
+  /**
+   * Create a DailyProject for React component tests.
+   */
+  createDailyProject(overrides: Partial<DailyProject> = {}): DailyProject {
+    const id = generateId();
+    const basename = overrides.file?.basename ?? id;
+    const path = overrides.path ?? overrides.file?.path ?? `projects/${basename}.md`;
+    const status = overrides.status ?? "ems__EffortStatusDraft";
+    const normalizedStatus = status.startsWith("ems__")
+      ? status
+      : STATUS_MAP[status as EffortStatusName] ?? "ems__EffortStatusDraft";
+
+    return {
+      file: {
+        path,
+        basename,
+        ...overrides.file,
+      },
+      path,
+      title: overrides.title ?? basename,
+      label: overrides.label ?? `Test Project ${projectCounter}`,
+      startTime: overrides.startTime ?? "",
+      endTime: overrides.endTime ?? "",
+      startTimestamp: overrides.startTimestamp ?? null,
+      endTimestamp: overrides.endTimestamp ?? null,
+      status: normalizedStatus,
+      metadata: overrides.metadata ?? {},
+      isDone: overrides.isDone ?? isDoneStatus(normalizedStatus as EffortStatus),
+      isTrashed: overrides.isTrashed ?? isTrashedStatus(normalizedStatus as EffortStatus),
+      isBlocked: overrides.isBlocked ?? false,
+    };
+  },
+
+  /**
+   * Create multiple DailyProjects for React component tests.
+   */
+  createManyDailyProjects(
+    count: number,
+    overrides: Partial<DailyProject> = {}
+  ): DailyProject[] {
+    return Array.from({ length: count }, () =>
+      ProjectFactory.createDailyProject(overrides)
+    );
+  },
+
+  // DailyProject convenience methods
+
+  /**
+   * Create a DailyProject with Doing status.
+   */
+  dailyProjectDoing(overrides: Partial<DailyProject> = {}): DailyProject {
+    return ProjectFactory.createDailyProject({
+      status: "ems__EffortStatusDoing",
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a DailyProject with Done status.
+   */
+  dailyProjectDone(overrides: Partial<DailyProject> = {}): DailyProject {
+    return ProjectFactory.createDailyProject({
+      status: "ems__EffortStatusDone",
+      isDone: true,
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a DailyProject with Trashed status.
+   */
+  dailyProjectTrashed(overrides: Partial<DailyProject> = {}): DailyProject {
+    return ProjectFactory.createDailyProject({
+      status: "ems__EffortStatusTrashed",
+      isTrashed: true,
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a blocked DailyProject.
+   */
+  dailyProjectBlocked(overrides: Partial<DailyProject> = {}): DailyProject {
+    return ProjectFactory.createDailyProject({
+      isBlocked: true,
+      ...overrides,
+    });
+  },
+
+  // Metadata conversion
+
+  /**
+   * Convert a ProjectFixture to frontmatter metadata format.
+   */
+  toMetadata(fixture: ProjectFixture): Metadata {
+    const normalizedStatus = normalizeStatus(fixture.status);
+    const metadata: Metadata = {
+      exo__Instance_class: "[[ems__Project]]",
+      exo__Asset_label: fixture.label,
+      exo__Asset_uid: fixture.basename,
+      exo__Asset_createdAt: fixture.createdAt,
+      exo__Asset_isArchived: fixture.isArchived,
+      ems__Effort_status: `[[${normalizedStatus}]]`,
+    };
+
+    if (fixture.votes !== undefined && fixture.votes > 0) {
+      metadata.ems__Effort_votes = fixture.votes;
+    }
+
+    if (fixture.area) {
+      metadata.ems__Effort_area = `[[${fixture.area}]]`;
+    }
+
+    if (fixture.parent) {
+      metadata.ems__Effort_parent = `[[${fixture.parent}]]`;
+    }
+
+    if (fixture.blockers && fixture.blockers.length > 0) {
+      metadata.ems__Project_blockedBy = fixture.blockers.map((b) => `[[${b}]]`);
+    }
+
+    return metadata;
+  },
+
+  /**
+   * Convert a ProjectFixture to a TFile-like object.
+   */
+  toFile(fixture: ProjectFixture): FileInfo & { stat: object; vault: null; parent: null; extension: string } {
+    return {
+      path: fixture.path,
+      basename: fixture.basename,
+      name: `${fixture.basename}.md`,
+      extension: "md",
+      parent: null,
+      vault: null,
+      stat: {
+        ctime: fixture.createdAt ?? Date.now(),
+        mtime: Date.now(),
+        size: 0,
+      },
+    };
+  },
+};
+
+export default ProjectFactory;

--- a/packages/test-utils/src/factories/task.factory.ts
+++ b/packages/test-utils/src/factories/task.factory.ts
@@ -1,0 +1,467 @@
+/**
+ * Task factory for creating test data.
+ *
+ * @example
+ * // Simple task
+ * const task = TaskFactory.create();
+ *
+ * // Task with specific status
+ * const doingTask = TaskFactory.doing();
+ *
+ * // Task with custom properties
+ * const customTask = TaskFactory.create({
+ *   label: "Custom Task",
+ *   status: "To Do",
+ *   votes: 5,
+ * });
+ *
+ * // DailyTask for React components
+ * const dailyTask = TaskFactory.createDailyTask();
+ *
+ * // Multiple tasks
+ * const tasks = TaskFactory.createMany(5);
+ */
+
+import type {
+  TaskFixture,
+  DailyTask,
+  EffortStatus,
+  EffortStatusName,
+  TaskSize,
+  FileInfo,
+  Metadata,
+} from "../types";
+
+let taskCounter = 0;
+
+/**
+ * Reset the task counter. Call this in beforeEach() to ensure deterministic IDs.
+ */
+export function resetTaskCounter(): void {
+  taskCounter = 0;
+}
+
+/**
+ * Map human-readable status names to wikilink format.
+ */
+const STATUS_MAP: Record<EffortStatusName, EffortStatus> = {
+  Draft: "ems__EffortStatusDraft",
+  Backlog: "ems__EffortStatusBacklog",
+  Analysis: "ems__EffortStatusAnalysis",
+  "To Do": "ems__EffortStatusToDo",
+  Doing: "ems__EffortStatusDoing",
+  Done: "ems__EffortStatusDone",
+  Trashed: "ems__EffortStatusTrashed",
+};
+
+/**
+ * Map task sizes to wikilink format.
+ */
+const SIZE_MAP: Record<TaskSize, string> = {
+  XXS: "[[ems__TaskSize_XXS]]",
+  XS: "[[ems__TaskSize_XS]]",
+  S: "[[ems__TaskSize_S]]",
+  M: "[[ems__TaskSize_M]]",
+  L: "[[ems__TaskSize_L]]",
+  XL: "[[ems__TaskSize_XL]]",
+};
+
+/**
+ * Normalize status to the ems__ format.
+ */
+function normalizeStatus(status: EffortStatus | EffortStatusName): EffortStatus {
+  if (status.startsWith("ems__")) {
+    return status as EffortStatus;
+  }
+  return STATUS_MAP[status as EffortStatusName] || "ems__EffortStatusDraft";
+}
+
+/**
+ * Check if a status indicates "done" state.
+ */
+function isDoneStatus(status: EffortStatus): boolean {
+  return status === "ems__EffortStatusDone";
+}
+
+/**
+ * Check if a status indicates "trashed" state.
+ */
+function isTrashedStatus(status: EffortStatus): boolean {
+  return status === "ems__EffortStatusTrashed";
+}
+
+/**
+ * Check if a status indicates "doing" state.
+ */
+function isDoingStatus(status: EffortStatus): boolean {
+  return status === "ems__EffortStatusDoing";
+}
+
+/**
+ * Generate a unique ID for tasks.
+ */
+function generateId(): string {
+  taskCounter++;
+  return `task-${taskCounter}`;
+}
+
+/**
+ * Default task fixture values.
+ */
+const DEFAULT_TASK: Omit<TaskFixture, "path" | "basename" | "label"> = {
+  status: "ems__EffortStatusDraft",
+  votes: 0,
+  isArchived: false,
+  createdAt: Date.now(),
+};
+
+/**
+ * Task factory for creating test fixtures.
+ */
+export const TaskFactory = {
+  /**
+   * Create a task fixture with optional overrides.
+   */
+  create(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    const id = generateId();
+    const basename = overrides.basename ?? id;
+    const normalizedStatus = normalizeStatus(
+      overrides.status ?? DEFAULT_TASK.status
+    );
+
+    return {
+      path: overrides.path ?? `tasks/${basename}.md`,
+      basename,
+      label: overrides.label ?? `Test Task ${taskCounter}`,
+      status: normalizedStatus,
+      size: overrides.size,
+      votes: overrides.votes ?? DEFAULT_TASK.votes,
+      area: overrides.area,
+      parent: overrides.parent,
+      day: overrides.day,
+      isArchived: overrides.isArchived ?? DEFAULT_TASK.isArchived,
+      createdAt: overrides.createdAt ?? DEFAULT_TASK.createdAt,
+      startTimestamp: overrides.startTimestamp,
+      endTimestamp: overrides.endTimestamp,
+      blockers: overrides.blockers,
+    };
+  },
+
+  /**
+   * Create multiple task fixtures.
+   */
+  createMany(count: number, overrides: Partial<TaskFixture> = {}): TaskFixture[] {
+    return Array.from({ length: count }, () => TaskFactory.create(overrides));
+  },
+
+  // Convenience methods for common states
+
+  /**
+   * Create a Draft task.
+   */
+  draft(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ status: "Draft", ...overrides });
+  },
+
+  /**
+   * Create a Backlog task.
+   */
+  backlog(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ status: "Backlog", ...overrides });
+  },
+
+  /**
+   * Create an Analysis task.
+   */
+  analysis(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ status: "Analysis", ...overrides });
+  },
+
+  /**
+   * Create a To Do task.
+   */
+  todo(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ status: "To Do", ...overrides });
+  },
+
+  /**
+   * Create a Doing task with start timestamp.
+   */
+  doing(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({
+      status: "Doing",
+      startTimestamp: overrides.startTimestamp ?? Date.now(),
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a Done task with start and end timestamps.
+   */
+  done(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    const startTimestamp = overrides.startTimestamp ?? Date.now() - 3600000; // 1 hour ago
+    return TaskFactory.create({
+      status: "Done",
+      startTimestamp,
+      endTimestamp: overrides.endTimestamp ?? Date.now(),
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a Trashed task.
+   */
+  trashed(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ status: "Trashed", ...overrides });
+  },
+
+  /**
+   * Create an archived task (Done + isArchived).
+   */
+  archived(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.done({ isArchived: true, ...overrides });
+  },
+
+  /**
+   * Create a blocked task.
+   */
+  blocked(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    const blockerTask = TaskFactory.create();
+    return TaskFactory.create({
+      blockers: [blockerTask.path],
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a task with a specific size.
+   */
+  withSize(size: TaskSize, overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ size, ...overrides });
+  },
+
+  /**
+   * Create a task with votes.
+   */
+  withVotes(votes: number, overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ votes, ...overrides });
+  },
+
+  /**
+   * Create a task under a parent project.
+   */
+  withParent(parent: string, overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ parent, ...overrides });
+  },
+
+  /**
+   * Create a task in an area.
+   */
+  inArea(area: string, overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ area, ...overrides });
+  },
+
+  /**
+   * Create a task scheduled for a specific day.
+   */
+  forDay(day: string, overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ day, ...overrides });
+  },
+
+  // DailyTask factory methods for React component tests
+
+  /**
+   * Create a DailyTask for React component tests.
+   */
+  createDailyTask(overrides: Partial<DailyTask> = {}): DailyTask {
+    const id = generateId();
+    const basename = overrides.file?.basename ?? id;
+    const path = overrides.path ?? overrides.file?.path ?? `tasks/${basename}.md`;
+    const status = overrides.status ?? "ems__EffortStatusDraft";
+    const normalizedStatus = status.startsWith("ems__")
+      ? status
+      : STATUS_MAP[status as EffortStatusName] ?? "ems__EffortStatusDraft";
+
+    return {
+      file: {
+        path,
+        basename,
+        ...overrides.file,
+      },
+      path,
+      title: overrides.title ?? basename,
+      label: overrides.label ?? `Test Task ${taskCounter}`,
+      startTime: overrides.startTime ?? "",
+      endTime: overrides.endTime ?? "",
+      startTimestamp: overrides.startTimestamp ?? null,
+      endTimestamp: overrides.endTimestamp ?? null,
+      status: normalizedStatus,
+      metadata: overrides.metadata ?? {},
+      isDone: overrides.isDone ?? isDoneStatus(normalizedStatus as EffortStatus),
+      isTrashed: overrides.isTrashed ?? isTrashedStatus(normalizedStatus as EffortStatus),
+      isDoing: overrides.isDoing ?? isDoingStatus(normalizedStatus as EffortStatus),
+      isMeeting: overrides.isMeeting ?? false,
+      isBlocked: overrides.isBlocked ?? false,
+      isEmptySlot: overrides.isEmptySlot,
+    };
+  },
+
+  /**
+   * Create multiple DailyTasks for React component tests.
+   */
+  createManyDailyTasks(
+    count: number,
+    overrides: Partial<DailyTask> = {}
+  ): DailyTask[] {
+    return Array.from({ length: count }, () =>
+      TaskFactory.createDailyTask(overrides)
+    );
+  },
+
+  // DailyTask convenience methods
+
+  /**
+   * Create a DailyTask with Doing status.
+   */
+  dailyTaskDoing(overrides: Partial<DailyTask> = {}): DailyTask {
+    return TaskFactory.createDailyTask({
+      status: "ems__EffortStatusDoing",
+      isDoing: true,
+      startTime: overrides.startTime ?? "09:00",
+      startTimestamp: overrides.startTimestamp ?? Date.now(),
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a DailyTask with Done status.
+   */
+  dailyTaskDone(overrides: Partial<DailyTask> = {}): DailyTask {
+    return TaskFactory.createDailyTask({
+      status: "ems__EffortStatusDone",
+      isDone: true,
+      startTime: overrides.startTime ?? "09:00",
+      endTime: overrides.endTime ?? "10:00",
+      startTimestamp: overrides.startTimestamp ?? Date.now() - 3600000,
+      endTimestamp: overrides.endTimestamp ?? Date.now(),
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a DailyTask with Trashed status.
+   */
+  dailyTaskTrashed(overrides: Partial<DailyTask> = {}): DailyTask {
+    return TaskFactory.createDailyTask({
+      status: "ems__EffortStatusTrashed",
+      isTrashed: true,
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a DailyTask that is a meeting.
+   */
+  dailyTaskMeeting(overrides: Partial<DailyTask> = {}): DailyTask {
+    return TaskFactory.createDailyTask({
+      isMeeting: true,
+      startTime: overrides.startTime ?? "14:00",
+      endTime: overrides.endTime ?? "15:00",
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create a blocked DailyTask.
+   */
+  dailyTaskBlocked(overrides: Partial<DailyTask> = {}): DailyTask {
+    return TaskFactory.createDailyTask({
+      isBlocked: true,
+      ...overrides,
+    });
+  },
+
+  /**
+   * Create an empty slot DailyTask.
+   */
+  dailyTaskEmptySlot(overrides: Partial<DailyTask> = {}): DailyTask {
+    return TaskFactory.createDailyTask({
+      isEmptySlot: true,
+      label: "",
+      title: "",
+      ...overrides,
+    });
+  },
+
+  // Metadata conversion
+
+  /**
+   * Convert a TaskFixture to frontmatter metadata format.
+   */
+  toMetadata(fixture: TaskFixture): Metadata {
+    const normalizedStatus = normalizeStatus(fixture.status);
+    const metadata: Metadata = {
+      exo__Instance_class: "[[ems__Task]]",
+      exo__Asset_label: fixture.label,
+      exo__Asset_uid: fixture.basename,
+      exo__Asset_createdAt: fixture.createdAt,
+      exo__Asset_isArchived: fixture.isArchived,
+      ems__Effort_status: `[[${normalizedStatus}]]`,
+    };
+
+    if (fixture.votes !== undefined && fixture.votes > 0) {
+      metadata.ems__Effort_votes = fixture.votes;
+    }
+
+    if (fixture.area) {
+      metadata.ems__Effort_area = `[[${fixture.area}]]`;
+    }
+
+    if (fixture.parent) {
+      metadata.ems__Effort_parent = `[[${fixture.parent}]]`;
+    }
+
+    if (fixture.size) {
+      metadata.ems__Task_size = SIZE_MAP[fixture.size];
+    }
+
+    if (fixture.day) {
+      metadata.ems__Effort_day = `[[${fixture.day}]]`;
+    }
+
+    if (fixture.startTimestamp) {
+      metadata.ems__Effort_startTimestamp = fixture.startTimestamp;
+    }
+
+    if (fixture.endTimestamp) {
+      metadata.ems__Effort_endTimestamp = fixture.endTimestamp;
+    }
+
+    if (fixture.blockers && fixture.blockers.length > 0) {
+      metadata.ems__Task_blockedBy = fixture.blockers.map((b) => `[[${b}]]`);
+    }
+
+    return metadata;
+  },
+
+  /**
+   * Convert a TaskFixture to a TFile-like object.
+   */
+  toFile(fixture: TaskFixture): FileInfo & { stat: object; vault: null; parent: null; extension: string } {
+    return {
+      path: fixture.path,
+      basename: fixture.basename,
+      name: `${fixture.basename}.md`,
+      extension: "md",
+      parent: null,
+      vault: null,
+      stat: {
+        ctime: fixture.createdAt ?? Date.now(),
+        mtime: Date.now(),
+        size: 0,
+      },
+    };
+  },
+};
+
+export default TaskFactory;

--- a/packages/test-utils/src/helpers/async.helpers.ts
+++ b/packages/test-utils/src/helpers/async.helpers.ts
@@ -1,0 +1,302 @@
+/**
+ * Async test helpers for waiting and retrying.
+ *
+ * @example
+ * import { flushPromises, waitForCondition, waitForDomElement, retry } from "@exocortex/test-utils";
+ *
+ * // Flush microtask queue
+ * await flushPromises();
+ *
+ * // Wait for condition
+ * await waitForCondition(() => service.isReady);
+ *
+ * // Wait for DOM element
+ * const element = await waitForDomElement(container, '.my-class');
+ *
+ * // Retry with exponential backoff
+ * await retry(() => expect(value).toBe(true));
+ */
+
+/**
+ * Flushes the microtask queue by waiting for all pending promises to resolve.
+ * Use this instead of `await new Promise(resolve => setTimeout(resolve, 0))`.
+ *
+ * @example
+ * // ❌ WRONG - Fixed timeout
+ * await new Promise(resolve => setTimeout(resolve, 50));
+ *
+ * // ✅ CORRECT - Flush microtasks
+ * await flushPromises();
+ */
+export function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Waits for React to complete rendering by running multiple microtask cycles.
+ * Use this for UI tests where React components need time to render.
+ *
+ * @param cycles - Number of microtask cycles to wait (default: 10)
+ * @returns Promise that resolves after React has had time to render
+ *
+ * @example
+ * // ❌ WRONG - Single flush may not be enough for React
+ * await flushPromises();
+ *
+ * // ✅ CORRECT - Multiple cycles for React rendering
+ * await waitForReact();
+ */
+export async function waitForReact(cycles: number = 10): Promise<void> {
+  for (let i = 0; i < cycles; i++) {
+    await flushPromises();
+  }
+}
+
+/**
+ * Options for waitForCondition.
+ */
+export interface WaitForConditionOptions {
+  /** Maximum time to wait in ms (default: 5000) */
+  timeout?: number;
+  /** Polling interval in ms (default: 50) */
+  interval?: number;
+  /** Custom error message on timeout */
+  message?: string;
+}
+
+/**
+ * Waits until a condition function returns true, with configurable timeout and interval.
+ * Use this instead of fixed `setTimeout` delays when waiting for async state changes.
+ *
+ * @param condition - Function that returns true when condition is met
+ * @param options - Configuration options
+ * @throws Error if condition is not met within timeout
+ *
+ * @example
+ * // ❌ WRONG - Fixed timeout that may be too short or too long
+ * await new Promise(resolve => setTimeout(resolve, 200));
+ * expect(service.isReady).toBe(true);
+ *
+ * // ✅ CORRECT - Wait for actual condition
+ * await waitForCondition(() => service.isReady);
+ * expect(service.isReady).toBe(true);
+ */
+export async function waitForCondition(
+  condition: () => boolean | Promise<boolean>,
+  options: WaitForConditionOptions = {}
+): Promise<void> {
+  const {
+    timeout = 5000,
+    interval = 50,
+    message = "Condition not met within timeout",
+  } = options;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeout) {
+    const result = await condition();
+    if (result) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+
+  throw new Error(`${message} (waited ${timeout}ms)`);
+}
+
+/**
+ * Options for waitForDomElement.
+ */
+export interface WaitForDomElementOptions {
+  /** Maximum time to wait in ms (default: 5000) */
+  timeout?: number;
+  /** Polling interval in ms (default: 50) */
+  interval?: number;
+}
+
+/**
+ * Waits for a DOM element to appear, with configurable timeout.
+ * Use this instead of fixed delays when waiting for React to render.
+ *
+ * @param container - The container element to search in
+ * @param selector - CSS selector for the element to wait for
+ * @param options - Configuration options
+ * @returns The found element
+ * @throws Error if element is not found within timeout
+ *
+ * @example
+ * // ❌ WRONG - Fixed timeout hoping React has rendered
+ * await new Promise(resolve => setTimeout(resolve, 200));
+ * expect(domContainer.querySelector('.my-class')).toBeTruthy();
+ *
+ * // ✅ CORRECT - Wait for actual DOM element
+ * const element = await waitForDomElement(domContainer, '.my-class');
+ * expect(element).toBeTruthy();
+ */
+export async function waitForDomElement(
+  container: Element,
+  selector: string,
+  options: WaitForDomElementOptions = {}
+): Promise<Element> {
+  const { timeout = 5000, interval = 50 } = options;
+
+  await waitForCondition(() => container.querySelector(selector) !== null, {
+    timeout,
+    interval,
+    message: `Element "${selector}" not found`,
+  });
+
+  const element = container.querySelector(selector);
+  if (!element) {
+    throw new Error(`Element "${selector}" not found after wait`);
+  }
+  return element;
+}
+
+/**
+ * Waits for multiple DOM elements to appear.
+ *
+ * @param container - The container element to search in
+ * @param selector - CSS selector for the elements to wait for
+ * @param minCount - Minimum number of elements to wait for (default: 1)
+ * @param options - Configuration options
+ * @returns NodeList of found elements
+ */
+export async function waitForDomElements(
+  container: Element,
+  selector: string,
+  minCount: number = 1,
+  options: WaitForDomElementOptions = {}
+): Promise<NodeListOf<Element>> {
+  const { timeout = 5000, interval = 50 } = options;
+
+  await waitForCondition(
+    () => container.querySelectorAll(selector).length >= minCount,
+    {
+      timeout,
+      interval,
+      message: `Expected at least ${minCount} elements matching "${selector}"`,
+    }
+  );
+
+  return container.querySelectorAll(selector);
+}
+
+/**
+ * Waits for a DOM element to be removed.
+ *
+ * @param container - The container element to search in
+ * @param selector - CSS selector for the element that should be removed
+ * @param options - Configuration options
+ */
+export async function waitForDomElementRemoval(
+  container: Element,
+  selector: string,
+  options: WaitForDomElementOptions = {}
+): Promise<void> {
+  const { timeout = 5000, interval = 50 } = options;
+
+  await waitForCondition(() => container.querySelector(selector) === null, {
+    timeout,
+    interval,
+    message: `Element "${selector}" was not removed`,
+  });
+}
+
+/**
+ * Options for retry.
+ */
+export interface RetryOptions {
+  /** Maximum number of retries (default: 3) */
+  retries?: number;
+  /** Initial delay between retries in ms (default: 100) */
+  delay?: number;
+  /** Backoff multiplier (default: 2) */
+  backoff?: number;
+}
+
+/**
+ * Retries an async function with exponential backoff.
+ * Use this for operations that may fail transiently (network, file I/O).
+ *
+ * @param fn - Async function to retry
+ * @param options - Configuration options
+ * @returns The result of the function
+ * @throws The last error if all retries fail
+ *
+ * @example
+ * // ❌ WRONG - Fixed retries with constant delay
+ * for (let i = 0; i < 10; i++) {
+ *   if (condition) break;
+ *   await sleep(50);
+ * }
+ *
+ * // ✅ CORRECT - Exponential backoff retry
+ * await retry(() => {
+ *   expect(condition).toBe(true);
+ * }, { retries: 3, delay: 100, backoff: 2 });
+ */
+export async function retry<T>(
+  fn: () => T | Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const { retries = 3, delay = 100, backoff = 2 } = options;
+  let lastError: Error | undefined;
+
+  for (let i = 0; i <= retries; i++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (i < retries) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, delay * Math.pow(backoff, i))
+        );
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Creates a delayed promise for testing timeouts.
+ * Prefer waitForCondition over this for actual tests.
+ *
+ * @param ms - Milliseconds to delay
+ * @returns Promise that resolves after the delay
+ */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Creates a promise that rejects after a timeout.
+ * Useful for testing timeout handling.
+ *
+ * @param ms - Milliseconds until rejection
+ * @param message - Error message
+ * @returns Promise that rejects after the timeout
+ */
+export function rejectAfter(ms: number, message: string = "Timeout"): Promise<never> {
+  return new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(message)), ms)
+  );
+}
+
+/**
+ * Races a promise against a timeout.
+ * Useful for ensuring tests don't hang.
+ *
+ * @param promise - The promise to race
+ * @param ms - Maximum time to wait
+ * @param message - Error message on timeout
+ * @returns The result of the promise
+ * @throws Error if the timeout is reached
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string = "Operation timed out"
+): Promise<T> {
+  return Promise.race([promise, rejectAfter(ms, message)]) as Promise<T>;
+}

--- a/packages/test-utils/src/helpers/index.ts
+++ b/packages/test-utils/src/helpers/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Test helpers for common testing patterns.
+ */
+
+export * from "./obsidian.helpers";
+export * from "./async.helpers";

--- a/packages/test-utils/src/helpers/obsidian.helpers.ts
+++ b/packages/test-utils/src/helpers/obsidian.helpers.ts
@@ -1,0 +1,386 @@
+/**
+ * Obsidian mock helpers for unit tests.
+ *
+ * @example
+ * import { createMockApp, createMockPlugin, createMockTFile } from "@exocortex/test-utils";
+ *
+ * const mockApp = createMockApp();
+ * const mockPlugin = createMockPlugin();
+ * const mockFile = createMockTFile("path/to/file.md");
+ */
+
+import type { FileInfo, Metadata } from "../types";
+
+/**
+ * Create a mock TFile object.
+ */
+export function createMockTFile(
+  path: string,
+  overrides: Partial<{
+    basename: string;
+    name: string;
+    extension: string;
+    content: string;
+    frontmatter: Metadata;
+  }> = {}
+): FileInfo & { stat: object; vault: null; parent: null; extension: string } {
+  const basename = overrides.basename ?? path.split("/").pop()?.replace(/\.md$/, "") ?? "file";
+  const name = overrides.name ?? `${basename}.md`;
+  const extension = overrides.extension ?? "md";
+
+  return {
+    path,
+    basename,
+    name,
+    extension,
+    parent: null,
+    vault: null,
+    stat: {
+      ctime: Date.now(),
+      mtime: Date.now(),
+      size: overrides.content?.length ?? 0,
+    },
+  };
+}
+
+/**
+ * Mock element interface with Obsidian-style DOM methods.
+ */
+export interface MockObsidianElement {
+  createDiv: jest.Mock;
+  createEl: jest.Mock;
+  createSpan: jest.Mock;
+  empty: jest.Mock;
+  appendChild: (node: Node) => Node;
+  innerHTML: string;
+  className: string;
+  textContent: string | null;
+  querySelector: (selector: string) => Element | null;
+  querySelectorAll: (selector: string) => NodeListOf<Element>;
+}
+
+/**
+ * Create a mock HTMLElement with Obsidian-specific methods.
+ * Returns an any type for maximum compatibility with various test scenarios.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createMockElement(): any {
+  const el = document.createElement("div");
+
+  const createDivFn = jest.fn((opts?: { cls?: string; text?: string }) => {
+    const div = document.createElement("div");
+    if (opts?.cls) div.className = opts.cls;
+    if (opts?.text) div.textContent = opts.text;
+    el.appendChild(div);
+
+    // Add nested methods
+    (div as unknown as MockObsidianElement).createDiv = jest.fn(createDivFn);
+    (div as unknown as MockObsidianElement).createEl = jest.fn((tag: string, options?: { cls?: string; text?: string; attr?: Record<string, string> }) => {
+      const element = document.createElement(tag);
+      if (options?.cls) element.className = options.cls;
+      if (options?.text) element.textContent = options.text;
+      if (options?.attr) {
+        Object.entries(options.attr).forEach(([key, value]) => {
+          element.setAttribute(key, value);
+        });
+      }
+      div.appendChild(element);
+      return element;
+    });
+    (div as unknown as MockObsidianElement).createSpan = jest.fn((options?: { text?: string; cls?: string }) => {
+      const span = document.createElement("span");
+      if (options?.text) span.textContent = options.text;
+      if (options?.cls) span.className = options.cls;
+      div.appendChild(span);
+      return span;
+    });
+
+    return div;
+  });
+
+  (el as unknown as MockObsidianElement).createDiv = createDivFn;
+
+  (el as unknown as MockObsidianElement).createEl = jest.fn((tag: string, options?: { cls?: string; text?: string; attr?: Record<string, string> }) => {
+    const element = document.createElement(tag);
+    if (options?.cls) element.className = options.cls;
+    if (options?.text) element.textContent = options.text;
+    if (options?.attr) {
+      Object.entries(options.attr).forEach(([key, value]) => {
+        element.setAttribute(key, value);
+      });
+    }
+    el.appendChild(element);
+    return element;
+  });
+
+  (el as unknown as MockObsidianElement).createSpan = jest.fn((options?: { text?: string; cls?: string }) => {
+    const span = document.createElement("span");
+    if (options?.text) span.textContent = options.text;
+    if (options?.cls) span.className = options.cls;
+    el.appendChild(span);
+    return span;
+  });
+
+  (el as unknown as MockObsidianElement).empty = jest.fn(() => {
+    el.innerHTML = "";
+  });
+
+  return el;
+}
+
+/**
+ * Create a mock Obsidian App object.
+ */
+export function createMockApp(overrides?: Partial<{
+  vault: Partial<MockVault>;
+  metadataCache: Partial<MockMetadataCache>;
+  workspace: Partial<MockWorkspace>;
+  fileManager: Partial<MockFileManager>;
+}>): MockApp {
+  return {
+    vault: {
+      getMarkdownFiles: jest.fn().mockReturnValue([]),
+      getAbstractFileByPath: jest.fn(),
+      read: jest.fn(),
+      modify: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      rename: jest.fn(),
+      getFiles: jest.fn().mockReturnValue([]),
+      getName: jest.fn().mockReturnValue("Test Vault"),
+      ...overrides?.vault,
+    },
+    metadataCache: {
+      getFileCache: jest.fn().mockReturnValue({ frontmatter: {} }),
+      getFirstLinkpathDest: jest.fn(),
+      getBacklinksForFile: jest.fn().mockReturnValue({ data: new Map() }),
+      on: jest.fn(),
+      off: jest.fn(),
+      resolvedLinks: {},
+      unresolvedLinks: {},
+      ...overrides?.metadataCache,
+    },
+    workspace: {
+      getLeaf: jest.fn().mockReturnValue({
+        openLinkText: jest.fn(),
+        openFile: jest.fn(),
+      }),
+      openLinkText: jest.fn(),
+      setActiveLeaf: jest.fn(),
+      getActiveFile: jest.fn(),
+      ...overrides?.workspace,
+    },
+    fileManager: {
+      processFrontMatter: jest.fn(),
+      ...overrides?.fileManager,
+    },
+  };
+}
+
+/**
+ * Create a mock Exocortex plugin object.
+ */
+export function createMockPlugin(overrides?: Partial<{
+  settings: Partial<MockSettings>;
+  app: MockApp;
+}>): MockPlugin {
+  return {
+    settings: {
+      currentOntology: null,
+      showLayoutSection: true,
+      showPropertiesSection: true,
+      showArchivedAssets: false,
+      votesColumnVisible: true,
+      showEffortArea: true,
+      showEffortVotes: true,
+      activeFocusArea: null,
+      ...overrides?.settings,
+    },
+    saveSettings: jest.fn().mockResolvedValue(undefined),
+    refreshLayout: jest.fn(),
+    app: overrides?.app ?? createMockApp(),
+  };
+}
+
+/**
+ * Create a mock metadata record.
+ */
+export function createMockMetadata(overrides?: Metadata): Metadata {
+  return {
+    exo__Asset_label: "Test Asset",
+    exo__Instance_class: "ems__Task",
+    created: "2024-01-01",
+    modified: "2024-01-01",
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock Logger.
+ */
+export function createMockLogger(): MockLogger {
+  return {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  };
+}
+
+/**
+ * Create a mock ReactRenderer.
+ */
+export function createMockReactRenderer(): MockReactRenderer {
+  return {
+    render: jest.fn(),
+    unmount: jest.fn(),
+  };
+}
+
+/**
+ * Create a mock VaultAdapter.
+ */
+export function createMockVaultAdapter(overrides?: Partial<MockVaultAdapter>): MockVaultAdapter {
+  return {
+    getAllFiles: jest.fn().mockReturnValue([]),
+    read: jest.fn(),
+    create: jest.fn(),
+    modify: jest.fn(),
+    delete: jest.fn(),
+    exists: jest.fn(),
+    getAbstractFileByPath: jest.fn(),
+    getFrontmatter: jest.fn().mockReturnValue({}),
+    updateFrontmatter: jest.fn(),
+    rename: jest.fn(),
+    createFolder: jest.fn(),
+    getFirstLinkpathDest: jest.fn(),
+    process: jest.fn(),
+    getDefaultNewFileParent: jest.fn(),
+    updateLinks: jest.fn(),
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock MetadataExtractor.
+ */
+export function createMockMetadataExtractor(overrides?: Partial<MockMetadataExtractor>): MockMetadataExtractor {
+  return {
+    extractMetadata: jest.fn().mockReturnValue({}),
+    extractInstanceClass: jest.fn(),
+    extractStatus: jest.fn(),
+    extractIsArchived: jest.fn(),
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock BacklinksCacheManager.
+ */
+export function createMockBacklinksCacheManager(overrides?: Partial<MockBacklinksCacheManager>): MockBacklinksCacheManager {
+  return {
+    getBacklinks: jest.fn().mockReturnValue([]),
+    ...overrides,
+  };
+}
+
+// Type definitions for mocks
+
+export interface MockVault {
+  getMarkdownFiles: jest.Mock;
+  getAbstractFileByPath: jest.Mock;
+  read: jest.Mock;
+  modify: jest.Mock;
+  create: jest.Mock;
+  delete: jest.Mock;
+  rename: jest.Mock;
+  getFiles: jest.Mock;
+  getName: jest.Mock;
+}
+
+export interface MockMetadataCache {
+  getFileCache: jest.Mock;
+  getFirstLinkpathDest: jest.Mock;
+  getBacklinksForFile: jest.Mock;
+  on: jest.Mock;
+  off: jest.Mock;
+  resolvedLinks: Record<string, unknown>;
+  unresolvedLinks: Record<string, unknown>;
+}
+
+export interface MockWorkspace {
+  getLeaf: jest.Mock;
+  openLinkText: jest.Mock;
+  setActiveLeaf: jest.Mock;
+  getActiveFile: jest.Mock;
+}
+
+export interface MockFileManager {
+  processFrontMatter: jest.Mock;
+}
+
+export interface MockApp {
+  vault: MockVault;
+  metadataCache: MockMetadataCache;
+  workspace: MockWorkspace;
+  fileManager: MockFileManager;
+}
+
+export interface MockSettings {
+  currentOntology: string | null;
+  showLayoutSection: boolean;
+  showPropertiesSection: boolean;
+  showArchivedAssets: boolean;
+  votesColumnVisible: boolean;
+  showEffortArea: boolean;
+  showEffortVotes: boolean;
+  activeFocusArea: string | null;
+}
+
+export interface MockPlugin {
+  settings: MockSettings;
+  saveSettings: jest.Mock;
+  refreshLayout: jest.Mock;
+  app: MockApp;
+}
+
+export interface MockLogger {
+  info: jest.Mock;
+  debug: jest.Mock;
+  error: jest.Mock;
+  warn: jest.Mock;
+}
+
+export interface MockReactRenderer {
+  render: jest.Mock;
+  unmount: jest.Mock;
+}
+
+export interface MockVaultAdapter {
+  getAllFiles: jest.Mock;
+  read: jest.Mock;
+  create: jest.Mock;
+  modify: jest.Mock;
+  delete: jest.Mock;
+  exists: jest.Mock;
+  getAbstractFileByPath: jest.Mock;
+  getFrontmatter: jest.Mock;
+  updateFrontmatter: jest.Mock;
+  rename: jest.Mock;
+  createFolder: jest.Mock;
+  getFirstLinkpathDest: jest.Mock;
+  process: jest.Mock;
+  getDefaultNewFileParent: jest.Mock;
+  updateLinks: jest.Mock;
+}
+
+export interface MockMetadataExtractor {
+  extractMetadata: jest.Mock;
+  extractInstanceClass: jest.Mock;
+  extractStatus: jest.Mock;
+  extractIsArchived: jest.Mock;
+}
+
+export interface MockBacklinksCacheManager {
+  getBacklinks: jest.Mock;
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,0 +1,109 @@
+/**
+ * @exocortex/test-utils
+ *
+ * Shared test utilities and mock factories for Exocortex packages.
+ *
+ * @example
+ * import {
+ *   TaskFactory,
+ *   ProjectFactory,
+ *   AreaFactory,
+ *   MeetingFactory,
+ *   createMockApp,
+ *   createMockPlugin,
+ *   flushPromises,
+ *   waitForCondition,
+ *   resetAllCounters,
+ * } from "@exocortex/test-utils";
+ *
+ * describe("MyComponent", () => {
+ *   beforeEach(() => {
+ *     resetAllCounters(); // Reset factory counters for deterministic IDs
+ *   });
+ *
+ *   it("should render tasks", () => {
+ *     const tasks = [
+ *       TaskFactory.doing({ label: "In Progress Task" }),
+ *       TaskFactory.done({ label: "Completed Task" }),
+ *     ];
+ *     // ... test with tasks
+ *   });
+ *
+ *   it("should use mock app", () => {
+ *     const mockApp = createMockApp();
+ *     // ... test with mockApp
+ *   });
+ * });
+ */
+
+// Types
+export * from "./types";
+
+// Factories
+export {
+  TaskFactory,
+  resetTaskCounter,
+} from "./factories/task.factory";
+
+export {
+  ProjectFactory,
+  resetProjectCounter,
+} from "./factories/project.factory";
+
+export {
+  AreaFactory,
+  resetAreaCounter,
+} from "./factories/area.factory";
+
+export {
+  MeetingFactory,
+  resetMeetingCounter,
+} from "./factories/meeting.factory";
+
+export { resetAllCounters } from "./factories";
+
+// Helpers
+export {
+  // Obsidian mocks
+  createMockTFile,
+  createMockElement,
+  createMockApp,
+  createMockPlugin,
+  createMockMetadata,
+  createMockLogger,
+  createMockReactRenderer,
+  createMockVaultAdapter,
+  createMockMetadataExtractor,
+  createMockBacklinksCacheManager,
+  // Types
+  type MockVault,
+  type MockMetadataCache,
+  type MockWorkspace,
+  type MockFileManager,
+  type MockApp,
+  type MockSettings,
+  type MockPlugin,
+  type MockLogger,
+  type MockReactRenderer,
+  type MockVaultAdapter,
+  type MockMetadataExtractor,
+  type MockBacklinksCacheManager,
+} from "./helpers/obsidian.helpers";
+
+export {
+  // Async helpers
+  flushPromises,
+  waitForReact,
+  waitForCondition,
+  waitForDomElement,
+  waitForDomElements,
+  waitForDomElementRemoval,
+  retry,
+  delay,
+  rejectAfter,
+  withTimeout,
+  // Types
+  type WaitForConditionOptions,
+  type WaitForDomElementOptions,
+  type RetryOptions,
+} from "./helpers/async.helpers";

--- a/packages/test-utils/src/types.ts
+++ b/packages/test-utils/src/types.ts
@@ -1,0 +1,182 @@
+/**
+ * Types for test utilities and mock factories.
+ * These types mirror production interfaces but are simplified for testing.
+ */
+
+/**
+ * Effort status values matching the domain constants.
+ */
+export type EffortStatus =
+  | "ems__EffortStatusDraft"
+  | "ems__EffortStatusBacklog"
+  | "ems__EffortStatusAnalysis"
+  | "ems__EffortStatusToDo"
+  | "ems__EffortStatusDoing"
+  | "ems__EffortStatusDone"
+  | "ems__EffortStatusTrashed";
+
+/**
+ * Human-readable status names for convenience.
+ */
+export type EffortStatusName =
+  | "Draft"
+  | "Backlog"
+  | "Analysis"
+  | "To Do"
+  | "Doing"
+  | "Done"
+  | "Trashed";
+
+/**
+ * Task size values matching the domain constants.
+ */
+export type TaskSize = "XXS" | "XS" | "S" | "M" | "L" | "XL";
+
+/**
+ * Asset class values matching the domain constants.
+ */
+export type AssetClass =
+  | "ems__Area"
+  | "ems__Task"
+  | "ems__Project"
+  | "ems__Meeting"
+  | "ems__Initiative"
+  | "ems__TaskPrototype"
+  | "ems__MeetingPrototype"
+  | "exo__EventPrototype"
+  | "ems__ProjectPrototype"
+  | "exo__Event"
+  | "pn__DailyNote"
+  | "ims__Concept"
+  | "ems__SessionStartEvent"
+  | "ems__SessionEndEvent"
+  | "exo__Prototype"
+  | "exo__Class";
+
+/**
+ * File info structure (simplified TFile).
+ */
+export interface FileInfo {
+  path: string;
+  basename: string;
+  name?: string;
+  extension?: string;
+}
+
+/**
+ * Base interface for all fixture types.
+ */
+export interface BaseFixture {
+  path: string;
+  basename: string;
+  label: string;
+  isArchived?: boolean;
+  createdAt?: number;
+}
+
+/**
+ * Task fixture for unit tests.
+ */
+export interface TaskFixture extends BaseFixture {
+  status: EffortStatus | EffortStatusName;
+  size?: TaskSize;
+  votes?: number;
+  area?: string;
+  parent?: string;
+  day?: string;
+  startTimestamp?: number | string | null;
+  endTimestamp?: number | string | null;
+  blockers?: string[];
+}
+
+/**
+ * Project fixture for unit tests.
+ */
+export interface ProjectFixture extends BaseFixture {
+  status: EffortStatus | EffortStatusName;
+  votes?: number;
+  area?: string;
+  parent?: string;
+  blockers?: string[];
+}
+
+/**
+ * Area fixture for unit tests.
+ */
+export interface AreaFixture extends BaseFixture {
+  parent?: string;
+}
+
+/**
+ * Meeting fixture for unit tests.
+ */
+export interface MeetingFixture extends TaskFixture {
+  scheduledAt?: number;
+}
+
+/**
+ * Concept fixture for unit tests.
+ */
+export interface ConceptFixture extends BaseFixture {}
+
+/**
+ * DailyTask interface matching the React component interface.
+ */
+export interface DailyTask {
+  file: FileInfo;
+  path: string;
+  title: string;
+  label: string;
+  startTime: string;
+  endTime: string;
+  startTimestamp: string | number | null;
+  endTimestamp: string | number | null;
+  status: string;
+  metadata: Record<string, unknown>;
+  isDone: boolean;
+  isTrashed: boolean;
+  isDoing: boolean;
+  isMeeting: boolean;
+  isBlocked: boolean;
+  isEmptySlot?: boolean;
+}
+
+/**
+ * DailyProject interface matching the React component interface.
+ */
+export interface DailyProject {
+  file: FileInfo;
+  path: string;
+  title: string;
+  label: string;
+  startTime: string;
+  endTime: string;
+  startTimestamp: string | number | null;
+  endTimestamp: string | number | null;
+  status: string;
+  metadata: Record<string, unknown>;
+  isDone: boolean;
+  isTrashed: boolean;
+  isBlocked: boolean;
+}
+
+/**
+ * Asset relation for backlinks/relations tests.
+ */
+export interface AssetRelation {
+  file: FileInfo;
+  path: string;
+  title: string;
+  metadata: Record<string, unknown>;
+  propertyName: string;
+  isBodyLink: boolean;
+  isArchived: boolean;
+  isBlocked: boolean;
+  created: number;
+  modified: number;
+}
+
+/**
+ * Metadata record type.
+ */
+export type Metadata = Record<string, unknown>;

--- a/packages/test-utils/tests/factories.test.ts
+++ b/packages/test-utils/tests/factories.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Tests for factory functions.
+ */
+
+import {
+  TaskFactory,
+  ProjectFactory,
+  AreaFactory,
+  MeetingFactory,
+  resetAllCounters,
+} from "../src";
+
+describe("TaskFactory", () => {
+  beforeEach(() => {
+    resetAllCounters();
+  });
+
+  describe("create", () => {
+    it("should create a task with default values", () => {
+      const task = TaskFactory.create();
+
+      expect(task.path).toBe("tasks/task-1.md");
+      expect(task.basename).toBe("task-1");
+      expect(task.label).toBe("Test Task 1");
+      expect(task.status).toBe("ems__EffortStatusDraft");
+      expect(task.votes).toBe(0);
+      expect(task.isArchived).toBe(false);
+    });
+
+    it("should create a task with custom values", () => {
+      const task = TaskFactory.create({
+        label: "Custom Task",
+        status: "To Do",
+        votes: 5,
+      });
+
+      expect(task.label).toBe("Custom Task");
+      expect(task.status).toBe("ems__EffortStatusToDo");
+      expect(task.votes).toBe(5);
+    });
+
+    it("should generate sequential IDs", () => {
+      const task1 = TaskFactory.create();
+      const task2 = TaskFactory.create();
+      const task3 = TaskFactory.create();
+
+      expect(task1.basename).toBe("task-1");
+      expect(task2.basename).toBe("task-2");
+      expect(task3.basename).toBe("task-3");
+    });
+  });
+
+  describe("createMany", () => {
+    it("should create multiple tasks", () => {
+      const tasks = TaskFactory.createMany(3);
+
+      expect(tasks).toHaveLength(3);
+      expect(tasks[0].basename).toBe("task-1");
+      expect(tasks[1].basename).toBe("task-2");
+      expect(tasks[2].basename).toBe("task-3");
+    });
+
+    it("should apply overrides to all tasks", () => {
+      const tasks = TaskFactory.createMany(3, { status: "Doing" });
+
+      expect(tasks[0].status).toBe("ems__EffortStatusDoing");
+      expect(tasks[1].status).toBe("ems__EffortStatusDoing");
+      expect(tasks[2].status).toBe("ems__EffortStatusDoing");
+    });
+  });
+
+  describe("status convenience methods", () => {
+    it("should create draft task", () => {
+      const task = TaskFactory.draft();
+      expect(task.status).toBe("ems__EffortStatusDraft");
+    });
+
+    it("should create backlog task", () => {
+      const task = TaskFactory.backlog();
+      expect(task.status).toBe("ems__EffortStatusBacklog");
+    });
+
+    it("should create analysis task", () => {
+      const task = TaskFactory.analysis();
+      expect(task.status).toBe("ems__EffortStatusAnalysis");
+    });
+
+    it("should create todo task", () => {
+      const task = TaskFactory.todo();
+      expect(task.status).toBe("ems__EffortStatusToDo");
+    });
+
+    it("should create doing task with startTimestamp", () => {
+      const task = TaskFactory.doing();
+      expect(task.status).toBe("ems__EffortStatusDoing");
+      expect(task.startTimestamp).toBeDefined();
+    });
+
+    it("should create done task with timestamps", () => {
+      const task = TaskFactory.done();
+      expect(task.status).toBe("ems__EffortStatusDone");
+      expect(task.startTimestamp).toBeDefined();
+      expect(task.endTimestamp).toBeDefined();
+    });
+
+    it("should create trashed task", () => {
+      const task = TaskFactory.trashed();
+      expect(task.status).toBe("ems__EffortStatusTrashed");
+    });
+
+    it("should create archived task", () => {
+      const task = TaskFactory.archived();
+      expect(task.status).toBe("ems__EffortStatusDone");
+      expect(task.isArchived).toBe(true);
+    });
+  });
+
+  describe("relationship methods", () => {
+    it("should create task with parent", () => {
+      const task = TaskFactory.withParent("project-1");
+      expect(task.parent).toBe("project-1");
+    });
+
+    it("should create task in area", () => {
+      const task = TaskFactory.inArea("work-area");
+      expect(task.area).toBe("work-area");
+    });
+
+    it("should create task for day", () => {
+      const task = TaskFactory.forDay("2024-01-15");
+      expect(task.day).toBe("2024-01-15");
+    });
+  });
+
+  describe("createDailyTask", () => {
+    it("should create a DailyTask with correct structure", () => {
+      const dailyTask = TaskFactory.createDailyTask();
+
+      expect(dailyTask.file).toBeDefined();
+      expect(dailyTask.file.path).toBe(dailyTask.path);
+      expect(dailyTask.status).toBe("ems__EffortStatusDraft");
+      expect(dailyTask.isDone).toBe(false);
+      expect(dailyTask.isTrashed).toBe(false);
+      expect(dailyTask.isDoing).toBe(false);
+      expect(dailyTask.isMeeting).toBe(false);
+      expect(dailyTask.isBlocked).toBe(false);
+    });
+
+    it("should create DailyTask with Doing status", () => {
+      const dailyTask = TaskFactory.dailyTaskDoing();
+
+      expect(dailyTask.status).toBe("ems__EffortStatusDoing");
+      expect(dailyTask.isDoing).toBe(true);
+      expect(dailyTask.startTime).toBe("09:00");
+    });
+
+    it("should create DailyTask with Done status", () => {
+      const dailyTask = TaskFactory.dailyTaskDone();
+
+      expect(dailyTask.status).toBe("ems__EffortStatusDone");
+      expect(dailyTask.isDone).toBe(true);
+    });
+
+    it("should create blocked DailyTask", () => {
+      const dailyTask = TaskFactory.dailyTaskBlocked();
+
+      expect(dailyTask.isBlocked).toBe(true);
+    });
+
+    it("should create meeting DailyTask", () => {
+      const dailyTask = TaskFactory.dailyTaskMeeting();
+
+      expect(dailyTask.isMeeting).toBe(true);
+      expect(dailyTask.startTime).toBe("14:00");
+      expect(dailyTask.endTime).toBe("15:00");
+    });
+  });
+
+  describe("toMetadata", () => {
+    it("should convert task fixture to metadata format", () => {
+      const task = TaskFactory.create({
+        label: "Test",
+        status: "To Do",
+        votes: 3,
+        size: "M",
+        area: "work-area",
+        parent: "project-1",
+      });
+
+      const metadata = TaskFactory.toMetadata(task);
+
+      expect(metadata.exo__Instance_class).toBe("[[ems__Task]]");
+      expect(metadata.exo__Asset_label).toBe("Test");
+      expect(metadata.ems__Effort_status).toBe("[[ems__EffortStatusToDo]]");
+      expect(metadata.ems__Effort_votes).toBe(3);
+      expect(metadata.ems__Task_size).toBe("[[ems__TaskSize_M]]");
+      expect(metadata.ems__Effort_area).toBe("[[work-area]]");
+      expect(metadata.ems__Effort_parent).toBe("[[project-1]]");
+    });
+  });
+
+  describe("toFile", () => {
+    it("should convert task fixture to TFile-like object", () => {
+      const task = TaskFactory.create({ basename: "my-task" });
+      const file = TaskFactory.toFile(task);
+
+      expect(file.path).toBe(task.path);
+      expect(file.basename).toBe("my-task");
+      expect(file.name).toBe("my-task.md");
+      expect(file.extension).toBe("md");
+    });
+  });
+});
+
+describe("ProjectFactory", () => {
+  beforeEach(() => {
+    resetAllCounters();
+  });
+
+  it("should create a project with default values", () => {
+    const project = ProjectFactory.create();
+
+    expect(project.path).toBe("projects/project-1.md");
+    expect(project.basename).toBe("project-1");
+    expect(project.label).toBe("Test Project 1");
+    expect(project.status).toBe("ems__EffortStatusDraft");
+  });
+
+  it("should create project with custom status", () => {
+    const project = ProjectFactory.doing();
+    expect(project.status).toBe("ems__EffortStatusDoing");
+  });
+
+  it("should create DailyProject", () => {
+    const dailyProject = ProjectFactory.createDailyProject();
+
+    expect(dailyProject.file).toBeDefined();
+    expect(dailyProject.status).toBe("ems__EffortStatusDraft");
+    expect(dailyProject.isDone).toBe(false);
+    expect(dailyProject.isTrashed).toBe(false);
+    expect(dailyProject.isBlocked).toBe(false);
+  });
+
+  it("should convert project to metadata", () => {
+    const project = ProjectFactory.create({ label: "My Project", area: "work" });
+    const metadata = ProjectFactory.toMetadata(project);
+
+    expect(metadata.exo__Instance_class).toBe("[[ems__Project]]");
+    expect(metadata.exo__Asset_label).toBe("My Project");
+    expect(metadata.ems__Effort_area).toBe("[[work]]");
+  });
+});
+
+describe("AreaFactory", () => {
+  beforeEach(() => {
+    resetAllCounters();
+  });
+
+  it("should create an area with default values", () => {
+    const area = AreaFactory.create();
+
+    expect(area.path).toBe("areas/area-1.md");
+    expect(area.basename).toBe("area-1");
+    expect(area.label).toBe("Test Area 1");
+    expect(area.isArchived).toBe(false);
+  });
+
+  it("should create area with parent", () => {
+    const area = AreaFactory.withParent("parent-area");
+    expect(area.parent).toBe("parent-area");
+  });
+
+  it("should create work area", () => {
+    const area = AreaFactory.work();
+    expect(area.label).toBe("Work");
+    expect(area.basename).toBe("work-area");
+  });
+
+  it("should create personal area", () => {
+    const area = AreaFactory.personal();
+    expect(area.label).toBe("Personal");
+    expect(area.basename).toBe("personal-area");
+  });
+
+  it("should create area hierarchy", () => {
+    const { root, child1, child2, grandchild } = AreaFactory.hierarchy();
+
+    expect(root.parent).toBeUndefined();
+    expect(child1.parent).toBe(root.basename);
+    expect(child2.parent).toBe(root.basename);
+    expect(grandchild.parent).toBe(child1.basename);
+  });
+
+  it("should convert area to metadata", () => {
+    const area = AreaFactory.withParent("parent-area", { label: "Sub Area" });
+    const metadata = AreaFactory.toMetadata(area);
+
+    expect(metadata.exo__Instance_class).toBe("[[ems__Area]]");
+    expect(metadata.exo__Asset_label).toBe("Sub Area");
+    expect(metadata.ems__Area_parent).toBe("[[parent-area]]");
+  });
+});
+
+describe("MeetingFactory", () => {
+  beforeEach(() => {
+    resetAllCounters();
+  });
+
+  it("should create a meeting with default values", () => {
+    const meeting = MeetingFactory.create();
+
+    expect(meeting.path).toBe("meetings/meeting-1.md");
+    expect(meeting.basename).toBe("meeting-1");
+    expect(meeting.label).toBe("Test Meeting 1");
+  });
+
+  it("should create scheduled meeting", () => {
+    const scheduledAt = Date.now() + 86400000; // tomorrow
+    const meeting = MeetingFactory.scheduled(scheduledAt);
+
+    expect(meeting.status).toBe("ems__EffortStatusToDo");
+    expect(meeting.scheduledAt).toBe(scheduledAt);
+  });
+
+  it("should create meeting for today", () => {
+    const meeting = MeetingFactory.today();
+
+    expect(meeting.scheduledAt).toBeDefined();
+    const scheduledDate = new Date(meeting.scheduledAt!);
+    const today = new Date();
+    expect(scheduledDate.getDate()).toBe(today.getDate());
+  });
+
+  it("should create done meeting", () => {
+    const meeting = MeetingFactory.done();
+
+    expect(meeting.status).toBe("ems__EffortStatusDone");
+    expect(meeting.startTimestamp).toBeDefined();
+    expect(meeting.endTimestamp).toBeDefined();
+  });
+
+  it("should create DailyMeeting", () => {
+    const dailyMeeting = MeetingFactory.createDailyMeeting();
+
+    expect(dailyMeeting.isMeeting).toBe(true);
+    expect(dailyMeeting.startTime).toBe("14:00");
+    expect(dailyMeeting.endTime).toBe("15:00");
+  });
+
+  it("should convert meeting to metadata", () => {
+    const meeting = MeetingFactory.scheduled(Date.now(), { parent: "project-1" });
+    const metadata = MeetingFactory.toMetadata(meeting);
+
+    expect(metadata.exo__Instance_class).toBe("[[ems__Meeting]]");
+    expect(metadata.ems__Meeting_scheduledAt).toBeDefined();
+    expect(metadata.ems__Effort_parent).toBe("[[project-1]]");
+  });
+});
+
+describe("resetAllCounters", () => {
+  it("should reset all factory counters", () => {
+    // Create some items
+    TaskFactory.create();
+    TaskFactory.create();
+    ProjectFactory.create();
+    AreaFactory.create();
+    MeetingFactory.create();
+
+    // Reset
+    resetAllCounters();
+
+    // New items should start from 1
+    const task = TaskFactory.create();
+    const project = ProjectFactory.create();
+    const area = AreaFactory.create();
+    const meeting = MeetingFactory.create();
+
+    expect(task.basename).toBe("task-1");
+    expect(project.basename).toBe("project-1");
+    expect(area.basename).toBe("area-1");
+    expect(meeting.basename).toBe("meeting-1");
+  });
+});

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary

Implements GitHub Issue #749: Standardize Test Patterns and Create Mock Factory.

This PR introduces the `@exocortex/test-utils` package with comprehensive mock factories and test helpers to address inconsistent test data creation patterns across the codebase.

## Changes

### New Package: `@exocortex/test-utils`

**Factories:**
- `TaskFactory`: Create task fixtures with all status variants (draft, backlog, analysis, todo, doing, done, trashed), DailyTask for React components, and metadata conversion
- `ProjectFactory`: Create project fixtures with status methods and DailyProject for React components
- `AreaFactory`: Create area fixtures with hierarchy support and common presets (work, personal, health, learning)
- `MeetingFactory`: Create meeting fixtures with scheduling methods (today, tomorrow, scheduled) and DailyMeeting

**Helpers:**
- Obsidian mocks: `createMockApp`, `createMockPlugin`, `createMockTFile`, `createMockElement`, `createMockVaultAdapter`, `createMockLogger`, etc.
- Async utilities: `flushPromises`, `waitForReact`, `waitForCondition`, `waitForDomElement`, `retry` with exponential backoff, `withTimeout`

### Usage Example

```typescript
import {
  TaskFactory,
  ProjectFactory,
  createMockApp,
  resetAllCounters,
  flushPromises,
} from "@exocortex/test-utils";

describe("MyComponent", () => {
  beforeEach(() => {
    resetAllCounters(); // Reset factory counters for deterministic IDs
  });

  it("should render tasks", () => {
    const tasks = [
      TaskFactory.doing({ label: "In Progress Task" }),
      TaskFactory.done({ label: "Completed Task" }),
      TaskFactory.blocked({ label: "Blocked Task" }),
    ];
    // ... test with tasks
  });

  it("should use mock app", async () => {
    const mockApp = createMockApp();
    // ... test with mockApp
    await flushPromises();
  });
});
```

## Test Plan

- [x] 40 unit tests for factory validation pass
- [x] All existing unit tests pass (396 tests)
- [x] TypeScript type checking passes
- [x] ESLint passes (existing warnings only)

Closes #749