### PR TITLE
fix: Add null/undefined checks for potentially null values

### DIFF
--- a/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
@@ -67,13 +67,18 @@ export class CreateInstanceCommand implements ICommand {
       ? this.app.workspace.getLeaf("tab")
       : this.app.workspace.getLeaf(false);
     const tfile = this.vaultAdapter.toTFile(createdFile);
+    if (!tfile) {
+      throw new Error(`Failed to convert created file to TFile: ${createdFile.path}`);
+    }
     await leaf.openFile(tfile);
 
     this.app.workspace.setActiveLeaf(leaf, { focus: true });
 
     const maxAttempts = 20;
+    const targetPath = tfile.path;
     for (let i = 0; i < maxAttempts; i++) {
-      if (this.app.workspace.getActiveFile()?.path === tfile.path) {
+      const activeFile = this.app.workspace.getActiveFile();
+      if (activeFile?.path === targetPath) {
         break;
       }
       await new Promise((resolve) => setTimeout(resolve, 100));

--- a/packages/obsidian-plugin/src/presentation/renderers/helpers/IncrementalUpdateHandler.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/helpers/IncrementalUpdateHandler.ts
@@ -69,10 +69,10 @@ export class IncrementalUpdateHandler {
     config: UniversalLayoutConfig,
     renderHeader: RenderHeaderFn,
   ): Promise<void> {
-    const container = rootContainer.querySelector(
-      IncrementalUpdateHandler.SECTION_SELECTORS[section]
-    ) as HTMLElement;
-    if (!container) return;
+    const selector = IncrementalUpdateHandler.SECTION_SELECTORS[section];
+    const containerElement = rootContainer.querySelector(selector);
+    if (!(containerElement instanceof HTMLElement)) return;
+    const container = containerElement;
 
     switch (section) {
       case LayoutSection.PROPERTIES:


### PR DESCRIPTION
## Summary
- Replace unsafe type assertion with `instanceof` check in IncrementalUpdateHandler.ts for `querySelector` results
- Add explicit null check for TFile conversion in CreateInstanceCommand.ts
- Extract loop variable outside the loop condition for clarity

## Changes
### IncrementalUpdateHandler.ts (lines 71-74)
- **Before**: Used unsafe type assertion `as HTMLElement` on `querySelector` result
- **After**: Uses proper `instanceof HTMLElement` runtime check to ensure type safety

### CreateInstanceCommand.ts (line 76)
- **Before**: `tfile` could potentially be null from `vaultAdapter.toTFile()`, causing runtime errors
- **After**: Added explicit null check with descriptive error message
- Also extracted `targetPath` variable for clearer loop condition

## Impact
- Prevents "Cannot read property of null" runtime errors
- Improves TypeScript type safety by removing unsafe type assertions
- Better error messages when file conversion fails

## Test plan
- [x] Unit tests pass (545 tests)
- [x] Component tests pass (536 tests)
- [x] TypeScript type checking passes
- [x] Lint passes (only pre-existing warnings)

Closes #779