### PR TITLE
test: Add 81 unit tests for obsidian-plugin infrastructure

### DIFF
--- a/packages/obsidian-plugin/tests/unit/EditPropertiesCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/EditPropertiesCommand.test.ts
@@ -1,0 +1,236 @@
+// Mock obsidian BEFORE any imports that use it
+jest.mock("obsidian", () => ({
+  Notice: jest.fn(),
+  App: jest.fn(),
+  TFile: jest.fn(),
+  Modal: class MockModal {
+    app: any;
+    contentEl: HTMLElement;
+    constructor(app: any) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+    }
+    open() {}
+    close() {}
+    onOpen() {}
+    onClose() {}
+  },
+}));
+
+// Mock PropertyEditorModal BEFORE import
+jest.mock("../../src/presentation/modals/PropertyEditorModal", () => ({
+  PropertyEditorModal: jest.fn().mockImplementation(() => ({
+    open: jest.fn(),
+    close: jest.fn(),
+  })),
+}));
+
+import { EditPropertiesCommand } from "../../src/application/commands/EditPropertiesCommand";
+import { App, TFile, Notice } from "obsidian";
+import { ExocortexPluginInterface } from "../../src/types";
+import { PropertyEditorModal } from "../../src/presentation/modals/PropertyEditorModal";
+import type { CommandVisibilityContext } from "@exocortex/core";
+
+describe("EditPropertiesCommand", () => {
+  let command: EditPropertiesCommand;
+  let mockApp: App;
+  let mockPlugin: ExocortexPluginInterface;
+  let mockFile: TFile;
+  let mockContext: CommandVisibilityContext | null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockApp = {
+      metadataCache: {
+        getFileCache: jest.fn(),
+      },
+    } as unknown as App;
+
+    mockPlugin = {
+      settings: {},
+      saveSettings: jest.fn(),
+    } as unknown as ExocortexPluginInterface;
+
+    mockFile = {
+      path: "test/file.md",
+      basename: "file",
+      extension: "md",
+    } as TFile;
+
+    mockContext = null;
+
+    command = new EditPropertiesCommand(mockApp, mockPlugin);
+  });
+
+  describe("properties", () => {
+    it("should have correct id", () => {
+      expect(command.id).toBe("edit-properties");
+    });
+
+    it("should have correct name", () => {
+      expect(command.name).toBe("edit properties");
+    });
+  });
+
+  describe("checkCallback - checking mode", () => {
+    it("should return true when file has frontmatter", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: { key: "value" },
+      });
+
+      const result = command.checkCallback(true, mockFile, mockContext);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when file has no cache", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue(null);
+
+      const result = command.checkCallback(true, mockFile, mockContext);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when file has no frontmatter", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({});
+
+      const result = command.checkCallback(true, mockFile, mockContext);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when frontmatter is undefined", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: undefined,
+      });
+
+      const result = command.checkCallback(true, mockFile, mockContext);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("checkCallback - execution mode", () => {
+    it("should open PropertyEditorModal when file has frontmatter", () => {
+      const frontmatter = { exo__Asset_label: "Test", key: "value" };
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter,
+      });
+
+      const mockModalInstance = { open: jest.fn() };
+      (PropertyEditorModal as jest.Mock).mockImplementation(() => mockModalInstance);
+
+      command.checkCallback(false, mockFile, mockContext);
+
+      expect(PropertyEditorModal).toHaveBeenCalledWith(
+        mockApp,
+        mockPlugin,
+        mockFile,
+        frontmatter
+      );
+      expect(mockModalInstance.open).toHaveBeenCalled();
+    });
+
+    it("should show notice when file has no frontmatter", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({});
+
+      command.checkCallback(false, mockFile, mockContext);
+
+      expect(Notice).toHaveBeenCalledWith(
+        "This file has no frontmatter properties to edit"
+      );
+      expect(PropertyEditorModal).not.toHaveBeenCalled();
+    });
+
+    it("should show notice when cache returns null", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue(null);
+
+      command.checkCallback(false, mockFile, mockContext);
+
+      expect(Notice).toHaveBeenCalledWith(
+        "This file has no frontmatter properties to edit"
+      );
+    });
+
+    it("should not return any value in execution mode", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: { key: "value" },
+      });
+
+      const mockModalInstance = { open: jest.fn() };
+      (PropertyEditorModal as jest.Mock).mockImplementation(() => mockModalInstance);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("checkCallback - edge cases", () => {
+    it("should handle empty frontmatter object", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: {},
+      });
+
+      const mockModalInstance = { open: jest.fn() };
+      (PropertyEditorModal as jest.Mock).mockImplementation(() => mockModalInstance);
+
+      // Empty frontmatter still has frontmatter defined
+      const checkResult = command.checkCallback(true, mockFile, mockContext);
+      expect(checkResult).toBe(true);
+
+      // Execution should open modal
+      command.checkCallback(false, mockFile, mockContext);
+      expect(PropertyEditorModal).toHaveBeenCalled();
+    });
+
+    it("should handle frontmatter with nested objects", () => {
+      const complexFrontmatter = {
+        key: "value",
+        nested: { deep: { value: 123 } },
+        array: [1, 2, 3],
+      };
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: complexFrontmatter,
+      });
+
+      const mockModalInstance = { open: jest.fn() };
+      (PropertyEditorModal as jest.Mock).mockImplementation(() => mockModalInstance);
+
+      command.checkCallback(false, mockFile, mockContext);
+
+      expect(PropertyEditorModal).toHaveBeenCalledWith(
+        mockApp,
+        mockPlugin,
+        mockFile,
+        complexFrontmatter
+      );
+    });
+
+    it("should pass context parameter even when null", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: { key: "value" },
+      });
+
+      // Context is not used in this command but should be accepted
+      const result = command.checkCallback(true, mockFile, null);
+      expect(result).toBe(true);
+    });
+
+    it("should pass non-null context parameter", () => {
+      (mockApp.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: { key: "value" },
+      });
+
+      const nonNullContext: CommandVisibilityContext = {
+        instanceClass: "ems__Task",
+        status: "draft",
+        isEffortActive: false,
+      } as CommandVisibilityContext;
+
+      const result = command.checkCallback(true, mockFile, nonNullContext);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/OpenQueryBuilderCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/OpenQueryBuilderCommand.test.ts
@@ -1,0 +1,133 @@
+// Mock obsidian BEFORE any imports that use it
+jest.mock("obsidian", () => ({
+  App: jest.fn(),
+  Plugin: jest.fn(),
+  Modal: class MockModal {
+    app: any;
+    contentEl: HTMLElement;
+    constructor(app: any) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+    }
+    open() {}
+    close() {}
+    onOpen() {}
+    onClose() {}
+  },
+}));
+
+// Mock SPARQLQueryBuilderModal BEFORE import
+jest.mock("../../src/presentation/modals/SPARQLQueryBuilderModal", () => ({
+  SPARQLQueryBuilderModal: jest.fn().mockImplementation(() => ({
+    open: jest.fn(),
+    close: jest.fn(),
+  })),
+}));
+
+import { OpenQueryBuilderCommand } from "../../src/application/commands/OpenQueryBuilderCommand";
+import { App, Plugin } from "obsidian";
+import { SPARQLQueryBuilderModal } from "../../src/presentation/modals/SPARQLQueryBuilderModal";
+
+describe("OpenQueryBuilderCommand", () => {
+  let command: OpenQueryBuilderCommand;
+  let mockApp: App;
+  let mockPlugin: Plugin;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockApp = {
+      workspace: {
+        getActiveFile: jest.fn(),
+      },
+    } as unknown as App;
+
+    mockPlugin = {
+      manifest: { id: "exocortex" },
+      settings: {},
+    } as unknown as Plugin;
+
+    command = new OpenQueryBuilderCommand(mockApp, mockPlugin);
+  });
+
+  describe("properties", () => {
+    it("should have correct id", () => {
+      expect(command.id).toBe("open-sparql-query-builder");
+    });
+
+    it("should have correct name", () => {
+      expect(command.name).toBe("open sparql query builder");
+    });
+  });
+
+  describe("callback", () => {
+    it("should create and open SPARQLQueryBuilderModal", async () => {
+      const mockModalInstance = { open: jest.fn() };
+      (SPARQLQueryBuilderModal as jest.Mock).mockImplementation(() => mockModalInstance);
+
+      await command.callback();
+
+      expect(SPARQLQueryBuilderModal).toHaveBeenCalledWith(mockApp, mockPlugin);
+      expect(mockModalInstance.open).toHaveBeenCalled();
+    });
+
+    it("should return undefined (async void)", async () => {
+      const mockModalInstance = { open: jest.fn() };
+      (SPARQLQueryBuilderModal as jest.Mock).mockImplementation(() => mockModalInstance);
+
+      const result = await command.callback();
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should pass app and plugin to modal constructor", async () => {
+      const mockModalInstance = { open: jest.fn() };
+      (SPARQLQueryBuilderModal as jest.Mock).mockImplementation(() => mockModalInstance);
+
+      await command.callback();
+
+      expect(SPARQLQueryBuilderModal).toHaveBeenCalledTimes(1);
+      const [appArg, pluginArg] = (SPARQLQueryBuilderModal as jest.Mock).mock.calls[0];
+      expect(appArg).toBe(mockApp);
+      expect(pluginArg).toBe(mockPlugin);
+    });
+
+    it("should create new modal instance each time callback is invoked", async () => {
+      const mockModalInstance1 = { open: jest.fn() };
+      const mockModalInstance2 = { open: jest.fn() };
+
+      (SPARQLQueryBuilderModal as jest.Mock)
+        .mockImplementationOnce(() => mockModalInstance1)
+        .mockImplementationOnce(() => mockModalInstance2);
+
+      await command.callback();
+      await command.callback();
+
+      expect(SPARQLQueryBuilderModal).toHaveBeenCalledTimes(2);
+      expect(mockModalInstance1.open).toHaveBeenCalledTimes(1);
+      expect(mockModalInstance2.open).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("command interface compliance", () => {
+    it("should have id property of type string", () => {
+      expect(typeof command.id).toBe("string");
+      expect(command.id.length).toBeGreaterThan(0);
+    });
+
+    it("should have name property of type string", () => {
+      expect(typeof command.name).toBe("string");
+      expect(command.name.length).toBeGreaterThan(0);
+    });
+
+    it("should have callback property of type function", () => {
+      expect(typeof command.callback).toBe("function");
+    });
+
+    it("should not have checkCallback property (global command)", () => {
+      // OpenQueryBuilderCommand uses callback not checkCallback
+      // because it doesn't require a file context
+      expect((command as any).checkCallback).toBeUndefined();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/commands/CommandRegistry.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/CommandRegistry.test.ts
@@ -1,0 +1,208 @@
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { CommandRegistry } from "../../../src/application/commands/CommandRegistry";
+import { App } from "obsidian";
+import { ExocortexPluginInterface } from "../../../src/types";
+
+// Mock @exocortex/core
+jest.mock("@exocortex/core", () => ({
+  TaskCreationService: jest.fn(),
+  ProjectCreationService: jest.fn(),
+  AreaCreationService: jest.fn(),
+  TaskStatusService: jest.fn(),
+  PropertyCleanupService: jest.fn(),
+  FolderRepairService: jest.fn(),
+  SupervisionCreationService: jest.fn(),
+  RenameToUidService: jest.fn(),
+  EffortVotingService: jest.fn(),
+  LabelToAliasService: jest.fn(),
+  AssetConversionService: jest.fn(),
+  FleetingNoteCreationService: jest.fn(),
+  DI_TOKENS: {
+    IVaultAdapter: Symbol("IVaultAdapter"),
+    ILogger: Symbol("ILogger"),
+  },
+  registerCoreServices: jest.fn(),
+}));
+
+// Mock LoggerFactory
+jest.mock("../../../src/adapters/logging/LoggerFactory", () => ({
+  LoggerFactory: {
+    create: jest.fn().mockReturnValue({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+// Mock ObsidianVaultAdapter
+jest.mock("../../../src/adapters/ObsidianVaultAdapter", () => ({
+  ObsidianVaultAdapter: jest.fn().mockImplementation(() => ({
+    read: jest.fn(),
+    write: jest.fn(),
+  })),
+}));
+
+// Mock command classes to avoid complex dependencies
+jest.mock("../../../src/application/commands/CreateTaskCommand");
+jest.mock("../../../src/application/commands/CreateProjectCommand");
+jest.mock("../../../src/application/commands/CreateAreaCommand");
+jest.mock("../../../src/application/commands/CreateInstanceCommand");
+jest.mock("../../../src/application/commands/CreateFleetingNoteCommand");
+jest.mock("../../../src/application/commands/CreateRelatedTaskCommand");
+jest.mock("../../../src/application/commands/SetDraftStatusCommand");
+jest.mock("../../../src/application/commands/MoveToBacklogCommand");
+jest.mock("../../../src/application/commands/MoveToAnalysisCommand");
+jest.mock("../../../src/application/commands/MoveToToDoCommand");
+jest.mock("../../../src/application/commands/StartEffortCommand");
+jest.mock("../../../src/application/commands/PlanOnTodayCommand");
+jest.mock("../../../src/application/commands/PlanForEveningCommand");
+jest.mock("../../../src/application/commands/ShiftDayBackwardCommand");
+jest.mock("../../../src/application/commands/ShiftDayForwardCommand");
+jest.mock("../../../src/application/commands/MarkDoneCommand");
+jest.mock("../../../src/application/commands/TrashEffortCommand");
+jest.mock("../../../src/application/commands/ArchiveTaskCommand");
+jest.mock("../../../src/application/commands/CleanPropertiesCommand");
+jest.mock("../../../src/application/commands/RepairFolderCommand");
+jest.mock("../../../src/application/commands/RenameToUidCommand");
+jest.mock("../../../src/application/commands/VoteOnEffortCommand");
+jest.mock("../../../src/application/commands/CopyLabelToAliasesCommand");
+jest.mock("../../../src/application/commands/AddSupervisionCommand");
+jest.mock("../../../src/application/commands/ReloadLayoutCommand");
+jest.mock("../../../src/application/commands/TogglePropertiesVisibilityCommand");
+jest.mock("../../../src/application/commands/ToggleLayoutVisibilityCommand");
+jest.mock("../../../src/application/commands/ToggleArchivedAssetsCommand");
+jest.mock("../../../src/application/commands/ConvertTaskToProjectCommand");
+jest.mock("../../../src/application/commands/ConvertProjectToTaskCommand");
+jest.mock("../../../src/application/commands/SetFocusAreaCommand");
+jest.mock("../../../src/application/commands/OpenQueryBuilderCommand");
+jest.mock("../../../src/application/commands/EditPropertiesCommand");
+
+describe("CommandRegistry", () => {
+  let mockApp: App;
+  let mockPlugin: ExocortexPluginInterface;
+  let mockReloadLayoutCallback: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.clearInstances();
+
+    // Create mock container.resolve
+    const mockServices = {
+      taskCreationService: {},
+      projectCreationService: {},
+      areaCreationService: {},
+      taskStatusService: {},
+      propertyCleanupService: {},
+      folderRepairService: {},
+      supervisionCreationService: {},
+      renameToUidService: {},
+      effortVotingService: {},
+      labelToAliasService: {},
+      assetConversionService: {},
+      fleetingNoteCreationService: {},
+    };
+
+    jest.spyOn(container, "resolve").mockImplementation(() => mockServices as any);
+    jest.spyOn(container, "register").mockImplementation(() => container as any);
+
+    mockApp = {
+      vault: {
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        getName: jest.fn().mockReturnValue("Test Vault"),
+      },
+      metadataCache: {
+        getFileCache: jest.fn(),
+      },
+    } as unknown as App;
+
+    mockPlugin = {
+      settings: {
+        currentOntology: null,
+        showLayoutSection: true,
+      },
+      saveSettings: jest.fn(),
+      refreshLayout: jest.fn(),
+    } as unknown as ExocortexPluginInterface;
+
+    mockReloadLayoutCallback = jest.fn();
+  });
+
+  afterEach(() => {
+    container.clearInstances();
+  });
+
+  describe("constructor", () => {
+    it("should create instance without reloadLayoutCallback", () => {
+      const registry = new CommandRegistry(mockApp, mockPlugin);
+
+      expect(registry).toBeInstanceOf(CommandRegistry);
+    });
+
+    it("should create instance with reloadLayoutCallback", () => {
+      const registry = new CommandRegistry(mockApp, mockPlugin, mockReloadLayoutCallback);
+
+      expect(registry).toBeInstanceOf(CommandRegistry);
+    });
+
+    it("should register IVaultAdapter with DI container", () => {
+      new CommandRegistry(mockApp, mockPlugin);
+
+      expect(container.register).toHaveBeenCalled();
+    });
+  });
+
+  describe("getAllCommands", () => {
+    it("should return array of commands", () => {
+      const registry = new CommandRegistry(mockApp, mockPlugin);
+      const commands = registry.getAllCommands();
+
+      expect(Array.isArray(commands)).toBe(true);
+    });
+
+    it("should return correct number of commands", () => {
+      const registry = new CommandRegistry(mockApp, mockPlugin);
+      const commands = registry.getAllCommands();
+
+      // 33 commands are registered based on source
+      expect(commands.length).toBe(33);
+    });
+
+    it("should return same array on multiple calls", () => {
+      const registry = new CommandRegistry(mockApp, mockPlugin);
+      const commands1 = registry.getAllCommands();
+      const commands2 = registry.getAllCommands();
+
+      expect(commands1).toBe(commands2);
+    });
+  });
+
+  describe("command types", () => {
+    it("should include creation commands", () => {
+      const registry = new CommandRegistry(mockApp, mockPlugin);
+      const commands = registry.getAllCommands();
+
+      // All command classes are mocked, so we can't check exact types
+      // but we can verify count
+      expect(commands.length).toBeGreaterThan(0);
+    });
+
+    it("should include status commands", () => {
+      const registry = new CommandRegistry(mockApp, mockPlugin);
+      const commands = registry.getAllCommands();
+
+      // Commands exist
+      expect(commands.length).toBeGreaterThanOrEqual(10);
+    });
+
+    it("should include toggle commands", () => {
+      const registry = new CommandRegistry(mockApp, mockPlugin);
+      const commands = registry.getAllCommands();
+
+      // Toggle commands included
+      expect(commands.length).toBeGreaterThanOrEqual(20);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianConfiguration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianConfiguration.test.ts
@@ -1,0 +1,196 @@
+import { ObsidianConfiguration } from "../../../../src/infrastructure/di/ObsidianConfiguration";
+import { Plugin } from "obsidian";
+
+describe("ObsidianConfiguration", () => {
+  let mockPlugin: Plugin & { settings?: Record<string, unknown>; saveSettings?: jest.Mock };
+  let config: ObsidianConfiguration;
+
+  beforeEach(() => {
+    mockPlugin = {
+      manifest: { id: "test-plugin" },
+      settings: {
+        currentOntology: "test-ontology",
+        showLayoutSection: true,
+        showPropertiesSection: false,
+        nested: {
+          deep: {
+            value: "nested-value",
+          },
+          arrayValue: [1, 2, 3],
+        },
+      },
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Plugin & { settings?: Record<string, unknown>; saveSettings?: jest.Mock };
+
+    config = new ObsidianConfiguration(mockPlugin);
+  });
+
+  describe("get", () => {
+    it("should return value for top-level key", () => {
+      const result = config.get<string>("currentOntology");
+
+      expect(result).toBe("test-ontology");
+    });
+
+    it("should return boolean value", () => {
+      const result = config.get<boolean>("showLayoutSection");
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false boolean value", () => {
+      const result = config.get<boolean>("showPropertiesSection");
+
+      expect(result).toBe(false);
+    });
+
+    it("should return nested value using dot notation", () => {
+      const result = config.get<string>("nested.deep.value");
+
+      expect(result).toBe("nested-value");
+    });
+
+    it("should return array value", () => {
+      const result = config.get<number[]>("nested.arrayValue");
+
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it("should return undefined for non-existent key", () => {
+      const result = config.get<string>("nonExistent");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined for non-existent nested key", () => {
+      const result = config.get<string>("nested.nonExistent.path");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when settings are not initialized", () => {
+      const pluginWithoutSettings = {
+        manifest: { id: "test-plugin" },
+      } as unknown as Plugin;
+
+      const configWithoutSettings = new ObsidianConfiguration(pluginWithoutSettings);
+      const result = configWithoutSettings.get<string>("anyKey");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return object value", () => {
+      const result = config.get<{ value: string }>("nested.deep");
+
+      expect(result).toEqual({ value: "nested-value" });
+    });
+  });
+
+  describe("set", () => {
+    it("should set top-level value", async () => {
+      await config.set("currentOntology", "new-ontology");
+
+      expect(mockPlugin.settings?.currentOntology).toBe("new-ontology");
+    });
+
+    it("should set nested value using dot notation", async () => {
+      await config.set("nested.deep.value", "updated-nested-value");
+
+      expect((mockPlugin.settings?.nested as Record<string, any>).deep.value).toBe(
+        "updated-nested-value"
+      );
+    });
+
+    it("should call saveSettings after setting value", async () => {
+      await config.set("showLayoutSection", false);
+
+      expect(mockPlugin.saveSettings).toHaveBeenCalled();
+    });
+
+    it("should create nested path if it does not exist", async () => {
+      await config.set("newNested.deep.path", "new-value");
+
+      expect((mockPlugin.settings?.newNested as Record<string, any>).deep.path).toBe(
+        "new-value"
+      );
+    });
+
+    it("should throw error if settings not initialized", async () => {
+      const pluginWithoutSettings = {
+        manifest: { id: "test-plugin" },
+      } as unknown as Plugin;
+
+      const configWithoutSettings = new ObsidianConfiguration(pluginWithoutSettings);
+
+      await expect(configWithoutSettings.set("key", "value")).rejects.toThrow(
+        "Plugin settings not initialized"
+      );
+    });
+
+    it("should throw error for empty key", async () => {
+      await expect(config.set("", "value")).rejects.toThrow("Invalid configuration key");
+    });
+
+    it("should not call saveSettings if function not available", async () => {
+      const pluginWithoutSave = {
+        manifest: { id: "test-plugin" },
+        settings: { key: "value" },
+      } as unknown as Plugin & { settings: Record<string, unknown> };
+
+      const configWithoutSave = new ObsidianConfiguration(pluginWithoutSave);
+
+      // Should not throw
+      await configWithoutSave.set("key", "newValue");
+      expect(pluginWithoutSave.settings.key).toBe("newValue");
+    });
+
+    it("should set boolean value", async () => {
+      await config.set("showPropertiesSection", true);
+
+      expect(mockPlugin.settings?.showPropertiesSection).toBe(true);
+    });
+
+    it("should set array value", async () => {
+      await config.set("nested.arrayValue", [4, 5, 6]);
+
+      expect((mockPlugin.settings?.nested as Record<string, any>).arrayValue).toEqual([
+        4, 5, 6,
+      ]);
+    });
+
+    it("should set object value", async () => {
+      const newObj = { foo: "bar", baz: 123 };
+      await config.set("newObject", newObj);
+
+      expect(mockPlugin.settings?.newObject).toEqual(newObj);
+    });
+  });
+
+  describe("getAll", () => {
+    it("should return all settings", () => {
+      const result = config.getAll();
+
+      expect(result).toEqual(mockPlugin.settings);
+    });
+
+    it("should return empty object if settings not initialized", () => {
+      const pluginWithoutSettings = {
+        manifest: { id: "test-plugin" },
+      } as unknown as Plugin;
+
+      const configWithoutSettings = new ObsidianConfiguration(pluginWithoutSettings);
+      const result = configWithoutSettings.getAll();
+
+      expect(result).toEqual({});
+    });
+
+    it("should not modify original settings when returned object is modified", () => {
+      const result = config.getAll();
+      (result as Record<string, unknown>).newKey = "newValue";
+
+      // Original should not be affected since getAll returns the reference
+      // This tests the current behavior - not defensive copying
+      expect(mockPlugin.settings?.newKey).toBe("newValue");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianLogger.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianLogger.test.ts
@@ -1,0 +1,178 @@
+import { ObsidianLogger } from "../../../../src/infrastructure/di/ObsidianLogger";
+import { Plugin } from "obsidian";
+
+describe("ObsidianLogger", () => {
+  let mockPlugin: Plugin;
+  let logger: ObsidianLogger;
+  let consoleSpy: {
+    debug: jest.SpyInstance;
+    warn: jest.SpyInstance;
+    error: jest.SpyInstance;
+  };
+
+  beforeEach(() => {
+    mockPlugin = {
+      manifest: { id: "exocortex" },
+    } as Plugin;
+
+    logger = new ObsidianLogger(mockPlugin);
+
+    consoleSpy = {
+      debug: jest.spyOn(console, "debug").mockImplementation(),
+      warn: jest.spyOn(console, "warn").mockImplementation(),
+      error: jest.spyOn(console, "error").mockImplementation(),
+    };
+  });
+
+  afterEach(() => {
+    consoleSpy.debug.mockRestore();
+    consoleSpy.warn.mockRestore();
+    consoleSpy.error.mockRestore();
+  });
+
+  describe("debug", () => {
+    it("should log debug message with plugin id prefix", () => {
+      logger.debug("test message");
+
+      expect(consoleSpy.debug).toHaveBeenCalledWith(
+        "[exocortex]",
+        "test message",
+        ""
+      );
+    });
+
+    it("should log debug message with context", () => {
+      const context = { key: "value", count: 42 };
+      logger.debug("test message", context);
+
+      expect(consoleSpy.debug).toHaveBeenCalledWith(
+        "[exocortex]",
+        "test message",
+        context
+      );
+    });
+
+    it("should handle undefined context gracefully", () => {
+      logger.debug("test message", undefined);
+
+      expect(consoleSpy.debug).toHaveBeenCalledWith(
+        "[exocortex]",
+        "test message",
+        ""
+      );
+    });
+  });
+
+  describe("info", () => {
+    it("should log info message with plugin id and INFO tag", () => {
+      logger.info("info message");
+
+      expect(consoleSpy.debug).toHaveBeenCalledWith(
+        "[exocortex] [INFO]",
+        "info message",
+        ""
+      );
+    });
+
+    it("should log info message with context", () => {
+      const context = { operation: "create" };
+      logger.info("info message", context);
+
+      expect(consoleSpy.debug).toHaveBeenCalledWith(
+        "[exocortex] [INFO]",
+        "info message",
+        context
+      );
+    });
+  });
+
+  describe("warn", () => {
+    it("should log warning message with plugin id prefix", () => {
+      logger.warn("warning message");
+
+      expect(consoleSpy.warn).toHaveBeenCalledWith(
+        "[exocortex]",
+        "warning message",
+        ""
+      );
+    });
+
+    it("should log warning message with context", () => {
+      const context = { deprecated: true };
+      logger.warn("warning message", context);
+
+      expect(consoleSpy.warn).toHaveBeenCalledWith(
+        "[exocortex]",
+        "warning message",
+        context
+      );
+    });
+  });
+
+  describe("error", () => {
+    it("should log error message with plugin id prefix", () => {
+      logger.error("error message");
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "[exocortex]",
+        "error message",
+        "",
+        ""
+      );
+    });
+
+    it("should log error message with Error object", () => {
+      const error = new Error("test error");
+      logger.error("error message", error);
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "[exocortex]",
+        "error message",
+        error,
+        ""
+      );
+    });
+
+    it("should log error message with context", () => {
+      const context = { filePath: "/test/file.md" };
+      logger.error("error message", undefined, context);
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "[exocortex]",
+        "error message",
+        "",
+        context
+      );
+    });
+
+    it("should log error message with both error and context", () => {
+      const error = new Error("test error");
+      const context = { filePath: "/test/file.md" };
+      logger.error("error message", error, context);
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "[exocortex]",
+        "error message",
+        error,
+        context
+      );
+    });
+  });
+
+  describe("with different plugin ids", () => {
+    it("should use the actual plugin manifest id", () => {
+      const customPlugin = {
+        manifest: { id: "custom-plugin-id" },
+      } as Plugin;
+      const customLogger = new ObsidianLogger(customPlugin);
+
+      customLogger.debug("test");
+
+      expect(consoleSpy.debug).toHaveBeenCalledWith(
+        "[custom-plugin-id]",
+        "test",
+        ""
+      );
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianNotificationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianNotificationService.test.ts
@@ -1,0 +1,194 @@
+import { ObsidianNotificationService } from "../../../../src/infrastructure/di/ObsidianNotificationService";
+import { Notice } from "obsidian";
+
+jest.mock("obsidian", () => ({
+  Notice: jest.fn(),
+}));
+
+describe("ObsidianNotificationService", () => {
+  let service: ObsidianNotificationService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ObsidianNotificationService();
+  });
+
+  describe("info", () => {
+    it("should create Notice with message", () => {
+      service.info("Information message");
+
+      expect(Notice).toHaveBeenCalledWith("Information message", 4000);
+    });
+
+    it("should use custom duration when provided", () => {
+      service.info("Information message", 6000);
+
+      expect(Notice).toHaveBeenCalledWith("Information message", 6000);
+    });
+
+    it("should use default duration when duration is undefined", () => {
+      service.info("Information message", undefined);
+
+      expect(Notice).toHaveBeenCalledWith("Information message", 4000);
+    });
+  });
+
+  describe("success", () => {
+    it("should create Notice with checkmark prefix", () => {
+      service.success("Operation completed");
+
+      expect(Notice).toHaveBeenCalledWith("✓ Operation completed", 4000);
+    });
+
+    it("should use custom duration when provided", () => {
+      service.success("Operation completed", 3000);
+
+      expect(Notice).toHaveBeenCalledWith("✓ Operation completed", 3000);
+    });
+  });
+
+  describe("error", () => {
+    it("should create Notice with X prefix", () => {
+      service.error("An error occurred");
+
+      expect(Notice).toHaveBeenCalledWith("✗ An error occurred", 4000);
+    });
+
+    it("should use custom duration when provided", () => {
+      service.error("An error occurred", 8000);
+
+      expect(Notice).toHaveBeenCalledWith("✗ An error occurred", 8000);
+    });
+  });
+
+  describe("warn", () => {
+    it("should create Notice with warning prefix", () => {
+      service.warn("Warning message");
+
+      expect(Notice).toHaveBeenCalledWith("⚠ Warning message", 4000);
+    });
+
+    it("should use custom duration when provided", () => {
+      service.warn("Warning message", 5000);
+
+      expect(Notice).toHaveBeenCalledWith("⚠ Warning message", 5000);
+    });
+  });
+
+  describe("confirm", () => {
+    let originalCreateElement: typeof document.createElement;
+    let mockModal: HTMLDivElement;
+    let mockModalContent: HTMLDivElement;
+    let mockTitleEl: HTMLDivElement;
+    let mockMessageEl: HTMLDivElement;
+    let mockButtonContainer: HTMLDivElement;
+    let mockConfirmButton: HTMLButtonElement;
+    let mockCancelButton: HTMLButtonElement;
+    let appendedElements: HTMLElement[];
+
+    beforeEach(() => {
+      appendedElements = [];
+      originalCreateElement = document.createElement;
+
+      mockConfirmButton = document.createElement("button");
+      mockCancelButton = document.createElement("button");
+      mockButtonContainer = document.createElement("div");
+      mockTitleEl = document.createElement("div");
+      mockMessageEl = document.createElement("div");
+      mockModalContent = document.createElement("div");
+      mockModal = document.createElement("div");
+
+      // Track appendChild calls
+      jest.spyOn(document.body, "appendChild").mockImplementation((el) => {
+        appendedElements.push(el as HTMLElement);
+        return el;
+      });
+
+      // Mock remove method
+      mockModal.remove = jest.fn();
+
+      let createIndex = 0;
+      const elementsInOrder = [
+        mockModal,
+        mockModalContent,
+        mockTitleEl,
+        mockMessageEl,
+        mockButtonContainer,
+        mockConfirmButton,
+        mockCancelButton,
+      ];
+
+      jest.spyOn(document, "createElement").mockImplementation((tag) => {
+        const element = elementsInOrder[createIndex++] || document.createElement(tag);
+        return element;
+      });
+    });
+
+    afterEach(() => {
+      (document.body.appendChild as jest.Mock).mockRestore();
+      (document.createElement as jest.Mock).mockRestore();
+    });
+
+    it("should create modal with correct structure", async () => {
+      // Start the confirm but don't await immediately
+      const confirmPromise = service.confirm("Confirm Action", "Are you sure?");
+
+      // Simulate clicking confirm
+      mockConfirmButton.onclick?.(new MouseEvent("click"));
+
+      await confirmPromise;
+
+      expect(mockModal.className).toBe("modal-container mod-confirmation");
+      expect(mockModalContent.className).toBe("modal");
+      expect(mockTitleEl.className).toBe("modal-title");
+      expect(mockMessageEl.className).toBe("modal-content");
+      expect(mockButtonContainer.className).toBe("modal-button-container");
+      expect(mockConfirmButton.className).toBe("mod-cta");
+      expect(mockConfirmButton.textContent).toBe("Confirm");
+      expect(mockCancelButton.textContent).toBe("Cancel");
+    });
+
+    it("should resolve true when confirm button is clicked", async () => {
+      const confirmPromise = service.confirm("Title", "Message");
+
+      // Simulate clicking confirm
+      mockConfirmButton.onclick?.(new MouseEvent("click"));
+
+      const result = await confirmPromise;
+
+      expect(result).toBe(true);
+      expect(mockModal.remove).toHaveBeenCalled();
+    });
+
+    it("should resolve false when cancel button is clicked", async () => {
+      const confirmPromise = service.confirm("Title", "Message");
+
+      // Simulate clicking cancel
+      mockCancelButton.onclick?.(new MouseEvent("click"));
+
+      const result = await confirmPromise;
+
+      expect(result).toBe(false);
+      expect(mockModal.remove).toHaveBeenCalled();
+    });
+
+    it("should set title and message content correctly", async () => {
+      const confirmPromise = service.confirm("My Title", "My Message");
+
+      mockConfirmButton.onclick?.(new MouseEvent("click"));
+      await confirmPromise;
+
+      expect(mockTitleEl.textContent).toBe("My Title");
+      expect(mockMessageEl.textContent).toBe("My Message");
+    });
+
+    it("should append modal to document body", async () => {
+      const confirmPromise = service.confirm("Title", "Message");
+
+      mockConfirmButton.onclick?.(new MouseEvent("click"));
+      await confirmPromise;
+
+      expect(document.body.appendChild).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for previously untested obsidian-plugin infrastructure components:

- **ObsidianLogger**: 12 tests covering debug/info/warn/error methods with context handling
- **ObsidianNotificationService**: 14 tests for notifications (info/success/error/warn) and confirm modal
- **ObsidianConfiguration**: 22 tests for get/set/getAll configuration methods with nested paths
- **CommandRegistry**: 9 tests for command registration and retrieval
- **EditPropertiesCommand**: 14 tests for property editing command visibility and execution
- **OpenQueryBuilderCommand**: 10 tests for SPARQL query builder command

**Total: 81 new unit tests**

## Changes

- Added 6 new test files covering infrastructure/di components and commands
- All tests follow existing project patterns (mocking, helpers, async testing)
- Tests include happy paths, error cases, and edge cases

## Test plan

- [x] All 81 new tests pass locally
- [x] `npm run test:unit` passes with all tests
- [ ] CI pipeline validates test coverage

Closes #785