### PR TITLE
feat: Restore lowered coverage thresholds (branches: 67% → 70%+)

### DIFF
--- a/docs/TEST-PYRAMID.md
+++ b/docs/TEST-PYRAMID.md
@@ -51,7 +51,7 @@ The Exocortex project follows the **Test Pyramid** architecture pattern, which p
 
 | Package | Statements | Branches | Functions | Lines |
 |---------|------------|----------|-----------|-------|
-| obsidian-plugin | 75% | 67% | 70% | 75% |
+| obsidian-plugin | 80% | 70% | 73% | 80% |
 | core | 95% | 95% | 95% | 95% |
 | cli | 65% | 60% | 70% | 65% |
 
@@ -146,10 +146,10 @@ test-coverage:
 
 | Metric | Required | Current | Status |
 |--------|----------|---------|--------|
-| Statements | 75% | 80.51% | ✅ |
-| Branches | 67% | 71.09% | ✅ |
-| Functions | 70% | 72.89% | ✅ |
-| Lines | 75% | 80.72% | ✅ |
+| Statements | 80% | 82.64% | ✅ |
+| Branches | 70% | 72.32% | ✅ |
+| Functions | 73% | 75.76% | ✅ |
+| Lines | 80% | 82.91% | ✅ |
 
 #### core Package
 
@@ -164,24 +164,29 @@ test-coverage:
 
 | Metric | Required | Current | Status |
 |--------|----------|---------|--------|
-| Statements | 65% | 69.39% | ✅ |
+| Statements | 65% | 69.29% | ✅ |
 | Branches | 60% | 62.97% | ✅ |
 | Functions | 70% | 77.43% | ✅ |
-| Lines | 65% | 69.09% | ✅ |
+| Lines | 65% | 68.99% | ✅ |
 
 ---
 
 ## Coverage Progression Goals
 
+### Completed (December 2025)
+
+- [x] obsidian-plugin: 80% statements, 70% branches (Issue #786)
+- [x] Restored coverage thresholds from temporary reduction
+
 ### Short-term (Q1 2026)
 
-- [ ] obsidian-plugin: 80% statements, 70% branches
+- [ ] obsidian-plugin: 85% statements, 75% branches
 - [ ] cli: 75% statements, 70% branches
 - [ ] Core package coverage collection working in CI
 
 ### Medium-term (Q2-Q3 2026)
 
-- [ ] obsidian-plugin: 85% statements, 75% branches
+- [ ] obsidian-plugin: 85% statements, 80% branches
 - [ ] cli: 80% statements, 75% branches
 - [ ] All packages integrated in coverage report
 

--- a/packages/obsidian-plugin/jest.config.js
+++ b/packages/obsidian-plugin/jest.config.js
@@ -36,18 +36,18 @@ module.exports = {
   },
   // Coverage thresholds per Test Pyramid policy (docs/TEST-PYRAMID.md)
   // These are enforced in CI via .github/workflows/ci.yml
+  // Restored from temporary reduction (Issue #786)
   coverageThreshold: {
     global: {
-      statements: 75, // CI threshold (current: ~80%)
-      branches: 67,   // CI threshold (current: ~71%)
-      functions: 70,  // CI threshold (current: ~73%)
-      lines: 75,      // CI threshold (current: ~81%)
+      statements: 80, // Restored (current: ~83%)
+      branches: 70,   // Restored from 67% (current: ~72%)
+      functions: 73,  // Restored (current: ~76%)
+      lines: 80,      // Restored (current: ~83%)
     },
   },
   // 🎯 COVERAGE POLICY (see docs/TEST-PYRAMID.md):
-  // - obsidian-plugin: 75% statements, 67% branches, 70% functions, 75% lines
-  // - Short-term goal: 80% statements, 70% branches
-  // - Long-term goal: 85% statements, 80% branches
+  // - obsidian-plugin: 80% statements, 70% branches, 73% functions, 80% lines
+  // - Target goal: 85% statements, 75% branches, 80% functions, 85% lines
   // Note: setupFilesAfterEnv moved to memory optimization section above
   // Handle ES modules and other transformations in CI
   // Transform @exocortex/core package files


### PR DESCRIPTION
## Summary

Closes #786

Restores coverage thresholds that were temporarily lowered for incremental layout updates. The codebase now exceeds the original requirements.

### Changes

**obsidian-plugin jest.config.js:**
- statements: 75% → 80% (current: 82.64%)
- branches: 67% → 70% (current: 72.32%)
- functions: 70% → 73% (current: 75.76%)
- lines: 75% → 80% (current: 82.91%)

**TEST-PYRAMID.md:**
- Updated coverage targets table
- Updated current coverage percentages
- Added "Completed (December 2025)" section in progression goals
- Marked threshold restoration as complete

### Verification

All tests pass with new thresholds:
- obsidian-plugin: 2720 tests passing
- cli: 545 tests passing

## Test Plan

- [x] Run `COVERAGE=true bash scripts/test-ci-batched.sh` - all tests pass
- [x] Coverage exceeds new thresholds by 2-3% margin
- [ ] CI pipeline passes with new thresholds