### PR TITLE
test: Add negative tests for error handling (141 scenarios)

### DIFF
--- a/packages/obsidian-plugin/tests/unit/error-handling/CreateInstanceCommand.error.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/CreateInstanceCommand.error.test.ts
@@ -1,0 +1,617 @@
+/**
+ * CreateInstanceCommand Error Handling Tests
+ *
+ * Tests error scenarios for:
+ * - Modal failures and cancellations
+ * - Task creation service failures
+ * - File conversion errors
+ * - Workspace operation errors
+ * - Non-Error throwable handling
+ *
+ * Issue: #788 - Add negative tests for error handling
+ */
+
+import { flushPromises } from "../helpers/testHelpers";
+import { CreateInstanceCommand } from "../../../src/application/commands/CreateInstanceCommand";
+import { App, TFile, Notice, WorkspaceLeaf } from "obsidian";
+import {
+  TaskCreationService,
+  CommandVisibilityContext,
+  LoggingService,
+  WikiLinkHelpers,
+  AssetClass,
+} from "@exocortex/core";
+import { LabelInputModal } from "../../../src/presentation/modals/LabelInputModal";
+import { DynamicAssetCreationModal } from "../../../src/presentation/modals/DynamicAssetCreationModal";
+import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
+import { ExocortexPluginInterface } from "../../../src/types";
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual("obsidian"),
+  Notice: jest.fn(),
+}));
+jest.mock("../../../src/presentation/modals/LabelInputModal");
+jest.mock("../../../src/presentation/modals/DynamicAssetCreationModal");
+jest.mock("@exocortex/core", () => ({
+  ...jest.requireActual("@exocortex/core"),
+  canCreateInstance: jest.fn(),
+  LoggingService: {
+    error: jest.fn(),
+  },
+  WikiLinkHelpers: {
+    normalize: jest.fn(),
+  },
+  AssetClass: {
+    MEETING_PROTOTYPE: "MeetingPrototype",
+  },
+}));
+
+describe("CreateInstanceCommand Error Handling", () => {
+  let command: CreateInstanceCommand;
+  let mockApp: jest.Mocked<App>;
+  let mockTaskCreationService: jest.Mocked<TaskCreationService>;
+  let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
+  let mockPlugin: jest.Mocked<ExocortexPluginInterface>;
+  let mockFile: jest.Mocked<TFile>;
+  let mockContext: CommandVisibilityContext;
+  let mockLeaf: jest.Mocked<WorkspaceLeaf>;
+  let mockTFile: jest.Mocked<TFile>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const { WikiLinkHelpers } = require("@exocortex/core");
+    WikiLinkHelpers.normalize.mockImplementation((str: string) => str);
+
+    mockLeaf = {
+      openFile: jest.fn(),
+    } as unknown as jest.Mocked<WorkspaceLeaf>;
+
+    mockTFile = {
+      path: "new-instance.md",
+      basename: "new-instance",
+    } as jest.Mocked<TFile>;
+
+    mockApp = {
+      workspace: {
+        getLeaf: jest.fn().mockReturnValue(mockLeaf),
+        setActiveLeaf: jest.fn(),
+        getActiveFile: jest.fn().mockReturnValue(mockTFile),
+      },
+      metadataCache: {
+        getFileCache: jest.fn().mockReturnValue({
+          frontmatter: { key: "value" },
+        }),
+      },
+    } as unknown as jest.Mocked<App>;
+
+    mockTaskCreationService = {
+      createTask: jest.fn(),
+    } as unknown as jest.Mocked<TaskCreationService>;
+
+    mockVaultAdapter = {
+      toTFile: jest.fn().mockReturnValue(mockTFile),
+    } as unknown as jest.Mocked<ObsidianVaultAdapter>;
+
+    mockPlugin = {
+      settings: {
+        useDynamicPropertyFields: false,
+      },
+    } as unknown as jest.Mocked<ExocortexPluginInterface>;
+
+    mockFile = {
+      path: "test-file.md",
+      basename: "test-file",
+    } as jest.Mocked<TFile>;
+
+    mockContext = {
+      instanceClass: "Task",
+      status: "Active",
+      archived: false,
+      isDraft: false,
+    };
+
+    command = new CreateInstanceCommand(
+      mockApp,
+      mockTaskCreationService,
+      mockVaultAdapter,
+      mockPlugin
+    );
+  });
+
+  describe("Modal Error Handling", () => {
+    const mockCanCreateInstance = require("@exocortex/core").canCreateInstance;
+
+    it("should handle modal throwing an error during open", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+
+      // Mock modal to throw an error
+      (LabelInputModal as jest.Mock).mockImplementation(() => ({
+        open: jest.fn(() => {
+          throw new Error("Modal initialization failed");
+        }),
+      }));
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      expect(LoggingService.error).toHaveBeenCalledWith(
+        "Create instance error",
+        expect.any(Error)
+      );
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: Modal initialization failed"
+      );
+    });
+
+    it("should handle modal callback never being called (modal hangs)", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+
+      // Mock modal that opens but never calls callback (simulating hung modal)
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          // Modal opens but never resolves - simulates a hung/stuck modal
+          // Callback is never invoked
+        }),
+      }));
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      // Modal never called callback, so createTask should not be called
+      expect(mockTaskCreationService.createTask).not.toHaveBeenCalled();
+    });
+
+    it("should handle DynamicAssetCreationModal throwing error", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      mockPlugin.settings.useDynamicPropertyFields = true;
+
+      (DynamicAssetCreationModal as jest.Mock).mockImplementation(() => ({
+        open: jest.fn(() => {
+          throw new Error("Dynamic modal failed to load schema");
+        }),
+      }));
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      expect(LoggingService.error).toHaveBeenCalledWith(
+        "Create instance error",
+        expect.any(Error)
+      );
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: Dynamic modal failed to load schema"
+      );
+    });
+  });
+
+  describe("Task Creation Service Error Handling", () => {
+    const mockCanCreateInstance = require("@exocortex/core").canCreateInstance;
+
+    it("should handle network error during task creation", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const networkError = new Error("Network request failed: ETIMEDOUT");
+      mockTaskCreationService.createTask.mockRejectedValue(networkError);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: Network request failed: ETIMEDOUT"
+      );
+      expect(LoggingService.error).toHaveBeenCalledWith(
+        "Create instance error",
+        networkError
+      );
+    });
+
+    it("should handle permission denied error during task creation", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const permissionError = new Error("EACCES: permission denied");
+      mockTaskCreationService.createTask.mockRejectedValue(permissionError);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: EACCES: permission denied"
+      );
+    });
+
+    it("should handle disk full error during task creation", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const diskFullError = new Error("ENOSPC: no space left on device");
+      mockTaskCreationService.createTask.mockRejectedValue(diskFullError);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: ENOSPC: no space left on device"
+      );
+    });
+
+    it("should handle file already exists error", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const existsError = new Error("File already exists: task.md");
+      mockTaskCreationService.createTask.mockRejectedValue(existsError);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: File already exists: task.md"
+      );
+    });
+
+    it("should handle undefined error object", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      mockTaskCreationService.createTask.mockRejectedValue(undefined);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: undefined"
+      );
+    });
+
+    it("should handle non-Error throwable (string)", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      mockTaskCreationService.createTask.mockRejectedValue(
+        "String error message"
+      );
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: String error message"
+      );
+    });
+
+    it("should handle non-Error throwable (number)", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      mockTaskCreationService.createTask.mockRejectedValue(404);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith("Failed to create instance: 404");
+    });
+  });
+
+  describe("File Conversion Error Handling", () => {
+    const mockCanCreateInstance = require("@exocortex/core").canCreateInstance;
+
+    it("should throw error when toTFile returns null", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockVaultAdapter.toTFile.mockReturnValue(null as any);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to create instance:")
+      );
+    });
+
+    it("should handle toTFile throwing an error", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockVaultAdapter.toTFile.mockImplementation(() => {
+        throw new Error("File not found in vault cache");
+      });
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: File not found in vault cache"
+      );
+    });
+  });
+
+  describe("Workspace Operation Error Handling", () => {
+    const mockCanCreateInstance = require("@exocortex/core").canCreateInstance;
+
+    it("should handle openFile failure", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockLeaf.openFile.mockRejectedValue(new Error("Cannot open file"));
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: Cannot open file"
+      );
+    });
+
+    it("should handle getLeaf returning null", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      (mockApp.workspace.getLeaf as jest.Mock).mockReturnValue(null);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      // Should fail when trying to call openFile on null leaf
+      expect(Notice).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to create instance:")
+      );
+    });
+
+    it("should handle setActiveLeaf error", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      (mockApp.workspace.setActiveLeaf as jest.Mock).mockImplementation(() => {
+        throw new Error("Workspace state invalid");
+      });
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: Workspace state invalid"
+      );
+    });
+  });
+
+  describe("Context and Input Validation Errors", () => {
+    const mockCanCreateInstance = require("@exocortex/core").canCreateInstance;
+
+    it("should handle empty instanceClass array", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const emptyContext = {
+        ...mockContext,
+        instanceClass: [],
+      };
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, emptyContext);
+      await flushPromises();
+
+      // Should call createTask with empty string for sourceClass
+      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
+        mockFile,
+        { key: "value" },
+        "",
+        "Test",
+        "small"
+      );
+    });
+
+    it("should handle undefined instanceClass", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const undefinedContext = {
+        ...mockContext,
+        instanceClass: undefined as any,
+      };
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, undefinedContext);
+      await flushPromises();
+
+      // Should handle undefined gracefully
+      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
+        mockFile,
+        { key: "value" },
+        "",
+        "Test",
+        "small"
+      );
+    });
+
+    it("should handle useDynamicPropertyFields being undefined", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      // Settings exists but useDynamicPropertyFields is undefined
+      mockPlugin.settings = {} as any;
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      // Should use nullish coalescing for useDynamicPropertyFields
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      // Should fall back to LabelInputModal (dynamic fields false by default)
+      expect(LabelInputModal).toHaveBeenCalled();
+    });
+  });
+
+  describe("Timeout and Long-Running Operation Handling", () => {
+    const mockCanCreateInstance = require("@exocortex/core").canCreateInstance;
+
+    it("should handle file never becoming active (timeout scenario)", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+
+      // File never becomes active (returns different file)
+      const differentFile = {
+        path: "different-file.md",
+        basename: "different-file",
+      } as jest.Mocked<TFile>;
+      (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue(
+        differentFile
+      );
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      // Wait for all timeout iterations (20 * 100ms)
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      // Should still show success notice even if file didn't become active
+      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+    });
+
+    it("should handle getActiveFile returning null consistently", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+
+      (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue(null);
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(() => callback({ label: "Test", taskSize: "small" }), 0);
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      // Wait for polling to complete
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+    });
+  });
+
+  describe("Open in New Tab Option Error Handling", () => {
+    const mockCanCreateInstance = require("@exocortex/core").canCreateInstance;
+
+    it("should handle error when opening in new tab", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+
+      // Make getLeaf("tab") fail
+      (mockApp.workspace.getLeaf as jest.Mock).mockImplementation(
+        (option: string | boolean) => {
+          if (option === "tab") {
+            throw new Error("Cannot create new tab");
+          }
+          return mockLeaf;
+        }
+      );
+
+      (LabelInputModal as jest.Mock).mockImplementation((app, callback) => ({
+        open: jest.fn(() => {
+          setTimeout(
+            () => callback({ label: "Test", taskSize: "small", openInNewTab: true }),
+            0
+          );
+        }),
+      }));
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to create instance: Cannot create new tab"
+      );
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/error-handling/ObsidianVaultAdapter.error.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/ObsidianVaultAdapter.error.test.ts
@@ -1,0 +1,610 @@
+/**
+ * ObsidianVaultAdapter Error Handling Tests
+ *
+ * Tests error scenarios for:
+ * - Missing metadata cache
+ * - File operation failures
+ * - Permission errors
+ * - Path resolution errors
+ * - Concurrent modification errors
+ * - Invalid input handling
+ *
+ * Issue: #788 - Add negative tests for error handling
+ */
+
+import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
+import { Vault, TFile, TFolder, MetadataCache, App, FileManager } from "obsidian";
+import { IFile, IFolder } from "@exocortex/core";
+
+describe("ObsidianVaultAdapter Error Handling", () => {
+  let adapter: ObsidianVaultAdapter;
+  let mockVault: jest.Mocked<Vault>;
+  let mockMetadataCache: jest.Mocked<MetadataCache>;
+  let mockApp: jest.Mocked<App>;
+  let mockFileManager: jest.Mocked<FileManager>;
+  let mockTFile: TFile;
+  let mockTFolder: TFolder;
+
+  beforeEach(() => {
+    mockTFile = Object.create(TFile.prototype);
+    Object.assign(mockTFile, {
+      path: "test/file.md",
+      basename: "file",
+      name: "file.md",
+      parent: null,
+    });
+
+    mockTFolder = Object.create(TFolder.prototype);
+    Object.assign(mockTFolder, {
+      path: "test",
+      name: "test",
+    });
+
+    mockFileManager = {
+      trashFile: jest.fn(),
+      renameFile: jest.fn(),
+      processFrontMatter: jest.fn(),
+      getNewFileParent: jest.fn(),
+    } as unknown as jest.Mocked<FileManager>;
+
+    mockVault = {
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      getMarkdownFiles: jest.fn(),
+      createFolder: jest.fn(),
+      process: jest.fn(),
+    } as unknown as jest.Mocked<Vault>;
+
+    mockMetadataCache = {
+      getFileCache: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      resolvedLinks: {},
+    } as unknown as jest.Mocked<MetadataCache>;
+
+    mockApp = {
+      fileManager: mockFileManager,
+      metadataCache: mockMetadataCache,
+    } as unknown as jest.Mocked<App>;
+
+    adapter = new ObsidianVaultAdapter(mockVault, mockMetadataCache, mockApp);
+  });
+
+  describe("Read Operation Errors", () => {
+    it("should throw error when reading non-existent file", async () => {
+      const file: IFile = {
+        path: "nonexistent.md",
+        basename: "nonexistent",
+        name: "nonexistent.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      await expect(adapter.read(file)).rejects.toThrow("File not found: nonexistent.md");
+    });
+
+    it("should throw error when reading a folder as file", async () => {
+      const file: IFile = {
+        path: "folder",
+        basename: "folder",
+        name: "folder",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFolder);
+
+      await expect(adapter.read(file)).rejects.toThrow("File not found: folder");
+    });
+
+    it("should handle vault read error", async () => {
+      const file: IFile = {
+        path: "test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockVault.read.mockRejectedValue(new Error("EACCES: permission denied"));
+
+      await expect(adapter.read(file)).rejects.toThrow("EACCES: permission denied");
+    });
+
+    it("should handle ENOENT error from vault", async () => {
+      const file: IFile = {
+        path: "deleted.md",
+        basename: "deleted",
+        name: "deleted.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      const enoentError = new Error("ENOENT: no such file or directory");
+      (enoentError as any).code = "ENOENT";
+      mockVault.read.mockRejectedValue(enoentError);
+
+      await expect(adapter.read(file)).rejects.toThrow("ENOENT: no such file or directory");
+    });
+
+    it("should handle disk read timeout", async () => {
+      const file: IFile = {
+        path: "slow.md",
+        basename: "slow",
+        name: "slow.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockVault.read.mockRejectedValue(new Error("ETIMEDOUT: operation timed out"));
+
+      await expect(adapter.read(file)).rejects.toThrow("ETIMEDOUT: operation timed out");
+    });
+  });
+
+  describe("Create Operation Errors", () => {
+    it("should handle file already exists error", async () => {
+      mockVault.create.mockRejectedValue(new Error("File already exists"));
+
+      await expect(adapter.create("existing.md", "content")).rejects.toThrow("File already exists");
+    });
+
+    it("should handle invalid path characters", async () => {
+      mockVault.create.mockRejectedValue(new Error("Invalid path: contains invalid characters"));
+
+      await expect(adapter.create("file<>:.md", "content")).rejects.toThrow("Invalid path");
+    });
+
+    it("should handle parent folder not found", async () => {
+      mockVault.create.mockRejectedValue(new Error("Parent folder does not exist"));
+
+      await expect(adapter.create("nonexistent/folder/file.md", "content")).rejects.toThrow(
+        "Parent folder does not exist"
+      );
+    });
+
+    it("should handle disk full error", async () => {
+      mockVault.create.mockRejectedValue(new Error("ENOSPC: no space left on device"));
+
+      await expect(adapter.create("new.md", "content")).rejects.toThrow("ENOSPC: no space left on device");
+    });
+
+    it("should handle permission denied on create", async () => {
+      mockVault.create.mockRejectedValue(new Error("EACCES: permission denied"));
+
+      await expect(adapter.create("readonly/file.md", "content")).rejects.toThrow("EACCES: permission denied");
+    });
+
+    it("should handle path too long error", async () => {
+      const longPath = "a".repeat(500) + ".md";
+      mockVault.create.mockRejectedValue(new Error("ENAMETOOLONG: file name too long"));
+
+      await expect(adapter.create(longPath, "content")).rejects.toThrow("ENAMETOOLONG: file name too long");
+    });
+  });
+
+  describe("Modify Operation Errors", () => {
+    it("should throw error when modifying non-existent file", async () => {
+      const file: IFile = {
+        path: "nonexistent.md",
+        basename: "nonexistent",
+        name: "nonexistent.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      await expect(adapter.modify(file, "new content")).rejects.toThrow("File not found: nonexistent.md");
+    });
+
+    it("should handle concurrent modification error", async () => {
+      const file: IFile = {
+        path: "test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockVault.modify.mockRejectedValue(new Error("File was modified by another process"));
+
+      await expect(adapter.modify(file, "content")).rejects.toThrow("File was modified by another process");
+    });
+
+    it("should handle read-only file error", async () => {
+      const file: IFile = {
+        path: "readonly.md",
+        basename: "readonly",
+        name: "readonly.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockVault.modify.mockRejectedValue(new Error("EPERM: operation not permitted"));
+
+      await expect(adapter.modify(file, "content")).rejects.toThrow("EPERM: operation not permitted");
+    });
+
+    it("should handle I/O error during modification", async () => {
+      const file: IFile = {
+        path: "test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockVault.modify.mockRejectedValue(new Error("EIO: i/o error"));
+
+      await expect(adapter.modify(file, "content")).rejects.toThrow("EIO: i/o error");
+    });
+  });
+
+  describe("Delete Operation Errors", () => {
+    it("should throw error when deleting non-existent file", async () => {
+      const file: IFile = {
+        path: "nonexistent.md",
+        basename: "nonexistent",
+        name: "nonexistent.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      await expect(adapter.delete(file)).rejects.toThrow("File not found: nonexistent.md");
+    });
+
+    it("should handle trash operation failure", async () => {
+      const file: IFile = {
+        path: "test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockFileManager.trashFile.mockRejectedValue(new Error("Trash operation failed"));
+
+      await expect(adapter.delete(file)).rejects.toThrow("Trash operation failed");
+    });
+
+    it("should handle file in use error", async () => {
+      const file: IFile = {
+        path: "locked.md",
+        basename: "locked",
+        name: "locked.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockFileManager.trashFile.mockRejectedValue(new Error("EBUSY: resource busy or locked"));
+
+      await expect(adapter.delete(file)).rejects.toThrow("EBUSY: resource busy or locked");
+    });
+  });
+
+  describe("Rename Operation Errors", () => {
+    it("should throw error when renaming non-existent file", async () => {
+      const file: IFile = {
+        path: "nonexistent.md",
+        basename: "nonexistent",
+        name: "nonexistent.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      await expect(adapter.rename(file, "new.md")).rejects.toThrow("File not found: nonexistent.md");
+    });
+
+    it("should handle target path already exists", async () => {
+      const file: IFile = {
+        path: "original.md",
+        basename: "original",
+        name: "original.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockFileManager.renameFile.mockRejectedValue(new Error("Target path already exists"));
+
+      await expect(adapter.rename(file, "existing.md")).rejects.toThrow("Target path already exists");
+    });
+
+    it("should handle cross-device rename error", async () => {
+      const file: IFile = {
+        path: "test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockFileManager.renameFile.mockRejectedValue(new Error("EXDEV: cross-device link not permitted"));
+
+      await expect(adapter.rename(file, "/other/device/file.md")).rejects.toThrow("EXDEV: cross-device link");
+    });
+
+    it("should handle invalid new filename", async () => {
+      const file: IFile = {
+        path: "test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockFileManager.renameFile.mockRejectedValue(new Error("Invalid filename"));
+
+      await expect(adapter.rename(file, "file<>:.md")).rejects.toThrow("Invalid filename");
+    });
+  });
+
+  describe("CreateFolder Operation Errors", () => {
+    it("should handle folder already exists", async () => {
+      mockVault.createFolder.mockRejectedValue(new Error("Folder already exists"));
+
+      await expect(adapter.createFolder("existing")).rejects.toThrow("Folder already exists");
+    });
+
+    it("should handle nested folder creation failure", async () => {
+      mockVault.createFolder.mockRejectedValue(new Error("Parent folder does not exist"));
+
+      await expect(adapter.createFolder("a/b/c/d")).rejects.toThrow("Parent folder does not exist");
+    });
+
+    it("should handle invalid folder name", async () => {
+      mockVault.createFolder.mockRejectedValue(new Error("Invalid folder name"));
+
+      await expect(adapter.createFolder("folder/with:invalid<chars>")).rejects.toThrow("Invalid folder name");
+    });
+  });
+
+  describe("UpdateFrontmatter Operation Errors", () => {
+    it("should handle processFrontMatter failure", async () => {
+      const file: IFile = {
+        path: "test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: {} } as any);
+      mockFileManager.processFrontMatter.mockRejectedValue(
+        new Error("Failed to process frontmatter: invalid YAML")
+      );
+
+      await expect(
+        adapter.updateFrontmatter(file, (fm) => ({ ...fm, key: "value" }))
+      ).rejects.toThrow("Failed to process frontmatter");
+    });
+
+    it("should handle corrupted frontmatter", async () => {
+      const file: IFile = {
+        path: "corrupted.md",
+        basename: "corrupted",
+        name: "corrupted.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: undefined, // Corrupted
+      } as any);
+
+      // Should use empty object as fallback
+      await adapter.updateFrontmatter(file, (fm) => ({ ...fm, key: "value" }));
+
+      expect(mockFileManager.processFrontMatter).toHaveBeenCalled();
+    });
+
+    it("should handle updater function throwing error", async () => {
+      const file: IFile = {
+        path: "test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: {} } as any);
+      mockFileManager.processFrontMatter.mockImplementation(async (f, processor) => {
+        processor({});
+      });
+
+      await expect(
+        adapter.updateFrontmatter(file, () => {
+          throw new Error("Updater function failed");
+        })
+      ).rejects.toThrow("Updater function failed");
+    });
+  });
+
+  describe("Process Operation Errors", () => {
+    it("should throw error when processing non-existent file", async () => {
+      const file: IFile = {
+        path: "nonexistent.md",
+        basename: "nonexistent",
+        name: "nonexistent.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      await expect(adapter.process(file, (c) => c)).rejects.toThrow("File not found: nonexistent.md");
+    });
+
+    it("should handle processor function throwing error", async () => {
+      const file: IFile = {
+        path: "test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFile);
+      mockVault.process.mockImplementation(async (f, fn) => {
+        return fn("content");
+      });
+
+      await expect(
+        adapter.process(file, () => {
+          throw new Error("Processing failed");
+        })
+      ).rejects.toThrow("Processing failed");
+    });
+  });
+
+  describe("GetFirstLinkpathDest Errors", () => {
+    it("should return null for broken link", () => {
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(null);
+
+      const result = adapter.getFirstLinkpathDest("[[BrokenLink]]", "source.md");
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle empty linkpath", () => {
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(null);
+
+      const result = adapter.getFirstLinkpathDest("", "source.md");
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle circular link reference", () => {
+      // Self-referencing link
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(mockTFile);
+
+      const result = adapter.getFirstLinkpathDest("[[test/file]]", "test/file.md");
+
+      expect(result).toBeDefined();
+      expect(result?.path).toBe("test/file.md");
+    });
+  });
+
+  describe("ToTFile Conversion Errors", () => {
+    it("should throw error for non-existent file", () => {
+      const file: IFile = {
+        path: "missing.md",
+        basename: "missing",
+        name: "missing.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      expect(() => adapter.toTFile(file)).toThrow("File not found: missing.md");
+    });
+
+    it("should throw error when path points to folder", () => {
+      const file: IFile = {
+        path: "folder",
+        basename: "folder",
+        name: "folder",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(mockTFolder);
+
+      expect(() => adapter.toTFile(file)).toThrow("File not found: folder");
+    });
+  });
+
+  describe("GetDefaultNewFileParent Errors", () => {
+    it("should return null when fileManager returns null", () => {
+      mockFileManager.getNewFileParent.mockReturnValue(null as any);
+
+      const result = adapter.getDefaultNewFileParent();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("UpdateLinks Errors", () => {
+    beforeEach(() => {
+      mockApp.metadataCache = {
+        ...mockMetadataCache,
+        resolvedLinks: {
+          "source.md": {
+            "target.md": 1,
+          },
+        },
+      } as any;
+    });
+
+    it("should handle read error during link update", async () => {
+      const sourceFile = Object.create(TFile.prototype);
+      Object.assign(sourceFile, { path: "source.md" });
+
+      mockVault.getAbstractFileByPath.mockReturnValue(sourceFile);
+      mockVault.read.mockRejectedValue(new Error("Cannot read file"));
+
+      await expect(adapter.updateLinks("target.md", "new-target.md", "target")).rejects.toThrow("Cannot read file");
+    });
+
+    it("should handle modify error during link update", async () => {
+      const sourceFile = Object.create(TFile.prototype);
+      Object.assign(sourceFile, { path: "source.md" });
+
+      mockVault.getAbstractFileByPath.mockReturnValue(sourceFile);
+      mockVault.read.mockResolvedValue("Content with [[target]]");
+      mockVault.modify.mockRejectedValue(new Error("Cannot modify file"));
+
+      await expect(adapter.updateLinks("target.md", "new-target.md", "target")).rejects.toThrow("Cannot modify file");
+    });
+
+    it("should handle no files with links gracefully", async () => {
+      mockApp.metadataCache.resolvedLinks = {};
+
+      // Should complete without error
+      await adapter.updateLinks("target.md", "new-target.md", "target");
+
+      expect(mockVault.read).not.toHaveBeenCalled();
+      expect(mockVault.modify).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Edge Cases with Invalid Input", () => {
+    it("should handle file with empty path", async () => {
+      const file: IFile = {
+        path: "",
+        basename: "",
+        name: "",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      await expect(adapter.read(file)).rejects.toThrow("File not found: ");
+    });
+
+    it("should handle file with whitespace-only path", async () => {
+      const file: IFile = {
+        path: "   ",
+        basename: "   ",
+        name: "   ",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      await expect(adapter.read(file)).rejects.toThrow("File not found:    ");
+    });
+
+    it("should handle file with null path property", async () => {
+      const file: IFile = {
+        path: null as any,
+        basename: "test",
+        name: "test.md",
+        parent: null,
+      };
+
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      await expect(adapter.read(file)).rejects.toThrow();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/error-handling/SPARQLApi.error.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/SPARQLApi.error.test.ts
@@ -1,0 +1,290 @@
+/**
+ * SPARQLApi Error Handling Tests
+ *
+ * Tests error scenarios for:
+ * - Query service errors
+ * - Refresh errors
+ * - Dispose errors
+ * - Triple store access errors
+ *
+ * Issue: #788 - Add negative tests for error handling
+ */
+
+import { SPARQLApi } from "../../../src/application/api/SPARQLApi";
+import { SPARQLQueryService } from "../../../src/application/services/SPARQLQueryService";
+import type ExocortexPlugin from "../../../src/ExocortexPlugin";
+import type { App } from "obsidian";
+import { ServiceError, ValidationError } from "@exocortex/core";
+
+jest.mock("../../../src/application/services/SPARQLQueryService");
+
+describe("SPARQLApi Error Handling", () => {
+  let api: SPARQLApi;
+  let mockPlugin: ExocortexPlugin;
+  let mockApp: App;
+  let mockQueryService: jest.Mocked<SPARQLQueryService>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockApp = {} as App;
+    mockPlugin = {
+      app: mockApp,
+    } as ExocortexPlugin;
+
+    mockQueryService = {
+      query: jest.fn(),
+      refresh: jest.fn(),
+      dispose: jest.fn(),
+      getTripleStore: jest.fn().mockReturnValue({}),
+    } as any;
+
+    (SPARQLQueryService as jest.Mock).mockImplementation(() => mockQueryService);
+
+    api = new SPARQLApi(mockPlugin);
+  });
+
+  describe("Query Error Handling", () => {
+    it("should propagate ServiceError from query service", async () => {
+      const serviceError = new ServiceError("Query execution failed", {
+        service: "SPARQLQueryService",
+        operation: "query",
+      });
+      mockQueryService.query.mockRejectedValue(serviceError);
+
+      await expect(api.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toThrow(ServiceError);
+      await expect(api.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toThrow("Query execution failed");
+    });
+
+    it("should propagate ValidationError from query service", async () => {
+      const validationError = new ValidationError("Invalid SPARQL syntax", {
+        query: "INVALID",
+      });
+      mockQueryService.query.mockRejectedValue(validationError);
+
+      await expect(api.query("INVALID")).rejects.toThrow(ValidationError);
+      await expect(api.query("INVALID")).rejects.toThrow("Invalid SPARQL syntax");
+    });
+
+    it("should propagate generic Error from query service", async () => {
+      const genericError = new Error("Unknown error occurred");
+      mockQueryService.query.mockRejectedValue(genericError);
+
+      await expect(api.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toThrow("Unknown error occurred");
+    });
+
+    it("should handle timeout errors", async () => {
+      const timeoutError = new Error("Query timeout after 30000ms");
+      mockQueryService.query.mockRejectedValue(timeoutError);
+
+      await expect(api.query("SELECT * WHERE { ?s ?p ?o . ?o ?p2 ?o2 }")).rejects.toThrow(
+        "Query timeout"
+      );
+    });
+
+    it("should handle memory errors", async () => {
+      const memoryError = new Error("JavaScript heap out of memory");
+      mockQueryService.query.mockRejectedValue(memoryError);
+
+      await expect(api.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toThrow(
+        "JavaScript heap out of memory"
+      );
+    });
+
+    it("should return correct count even when query returns empty results", async () => {
+      mockQueryService.query.mockResolvedValue([]);
+
+      const result = await api.query("SELECT * WHERE { ?s ?p ?o }");
+
+      expect(result.bindings).toEqual([]);
+      expect(result.count).toBe(0);
+    });
+
+    it("should handle null returned from query service", async () => {
+      mockQueryService.query.mockResolvedValue(null as any);
+
+      // This should handle null gracefully or throw
+      await expect(api.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toThrow();
+    });
+
+    it("should handle undefined returned from query service", async () => {
+      mockQueryService.query.mockResolvedValue(undefined as any);
+
+      await expect(api.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toThrow();
+    });
+  });
+
+  describe("Refresh Error Handling", () => {
+    it("should propagate refresh errors", async () => {
+      const refreshError = new Error("Failed to refresh: vault unavailable");
+      mockQueryService.refresh.mockRejectedValue(refreshError);
+
+      await expect(api.refresh()).rejects.toThrow("Failed to refresh: vault unavailable");
+    });
+
+    it("should handle network timeout during refresh", async () => {
+      const timeoutError = new Error("ETIMEDOUT");
+      mockQueryService.refresh.mockRejectedValue(timeoutError);
+
+      await expect(api.refresh()).rejects.toThrow("ETIMEDOUT");
+    });
+
+    it("should handle permission errors during refresh", async () => {
+      const permissionError = new Error("EACCES: permission denied");
+      mockQueryService.refresh.mockRejectedValue(permissionError);
+
+      await expect(api.refresh()).rejects.toThrow("EACCES: permission denied");
+    });
+  });
+
+  describe("Dispose Error Handling", () => {
+    it("should propagate dispose errors", async () => {
+      const disposeError = new Error("Failed to dispose resources");
+      mockQueryService.dispose.mockRejectedValue(disposeError);
+
+      await expect(api.dispose()).rejects.toThrow("Failed to dispose resources");
+    });
+
+    it("should handle async dispose errors", async () => {
+      mockQueryService.dispose.mockRejectedValue(new Error("Async dispose failed"));
+
+      await expect(api.dispose()).rejects.toThrow("Async dispose failed");
+    });
+  });
+
+  describe("Triple Store Error Handling", () => {
+    it("should handle getTripleStore returning null", () => {
+      mockQueryService.getTripleStore.mockReturnValue(null as any);
+
+      const tripleStore = api.getTripleStore();
+
+      expect(tripleStore).toBeNull();
+    });
+
+    it("should handle getTripleStore throwing error", () => {
+      mockQueryService.getTripleStore.mockImplementation(() => {
+        throw new Error("Triple store not initialized");
+      });
+
+      expect(() => api.getTripleStore()).toThrow("Triple store not initialized");
+    });
+  });
+
+  describe("Error Type Preservation", () => {
+    it("should preserve ServiceError type and context", async () => {
+      const context = {
+        service: "SPARQLQueryService",
+        operation: "query",
+        query: "SELECT * WHERE { ?s ?p ?o }",
+      };
+      const serviceError = new ServiceError("Query failed", context);
+      mockQueryService.query.mockRejectedValue(serviceError);
+
+      try {
+        await api.query("SELECT * WHERE { ?s ?p ?o }");
+        fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ServiceError);
+        expect((error as ServiceError).context).toEqual(context);
+      }
+    });
+
+    it("should preserve ValidationError type and context", async () => {
+      const context = {
+        query: "INVALID QUERY",
+        originalError: "Unexpected token",
+      };
+      const validationError = new ValidationError("Invalid query", context);
+      mockQueryService.query.mockRejectedValue(validationError);
+
+      try {
+        await api.query("INVALID QUERY");
+        fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ValidationError);
+        expect((error as ValidationError).context).toEqual(context);
+      }
+    });
+
+    it("should preserve error stack trace", async () => {
+      const originalError = new Error("Original error with stack");
+      mockQueryService.query.mockRejectedValue(originalError);
+
+      try {
+        await api.query("SELECT * WHERE { ?s ?p ?o }");
+        fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBe(originalError);
+        expect((error as Error).stack).toBeDefined();
+        expect((error as Error).stack).toContain("Original error with stack");
+      }
+    });
+  });
+
+  describe("Concurrent Operation Errors", () => {
+    it("should handle concurrent query errors independently", async () => {
+      const error1 = new Error("Query 1 failed");
+      const error2 = new Error("Query 2 failed");
+
+      mockQueryService.query
+        .mockRejectedValueOnce(error1)
+        .mockRejectedValueOnce(error2);
+
+      const promise1 = api.query("SELECT * WHERE { ?s ?p ?o } LIMIT 1");
+      const promise2 = api.query("SELECT * WHERE { ?s ?p ?o } LIMIT 2");
+
+      await expect(promise1).rejects.toThrow("Query 1 failed");
+      await expect(promise2).rejects.toThrow("Query 2 failed");
+    });
+
+    it("should handle mixed success and failure in concurrent queries", async () => {
+      mockQueryService.query
+        .mockResolvedValueOnce([{ var: "value1" }] as any)
+        .mockRejectedValueOnce(new Error("Query 2 failed"));
+
+      const promise1 = api.query("SELECT * WHERE { ?s ?p ?o } LIMIT 1");
+      const promise2 = api.query("SELECT * WHERE { ?s ?p ?o } LIMIT 2");
+
+      const result1 = await promise1;
+      expect(result1.count).toBe(1);
+
+      await expect(promise2).rejects.toThrow("Query 2 failed");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle empty query string", async () => {
+      mockQueryService.query.mockRejectedValue(new Error("Empty query"));
+
+      await expect(api.query("")).rejects.toThrow("Empty query");
+    });
+
+    it("should handle query with only whitespace", async () => {
+      mockQueryService.query.mockRejectedValue(new Error("Invalid query: whitespace only"));
+
+      await expect(api.query("   \n\t   ")).rejects.toThrow("Invalid query");
+    });
+
+    it("should handle very long query strings", async () => {
+      const longQuery = "SELECT " + "?var".repeat(10000) + " WHERE { ?s ?p ?o }";
+      mockQueryService.query.mockRejectedValue(new Error("Query too long"));
+
+      await expect(api.query(longQuery)).rejects.toThrow("Query too long");
+    });
+
+    it("should handle query with special characters", async () => {
+      const queryWithSpecialChars = 'SELECT * WHERE { ?s rdfs:label "test\0value" }';
+      mockQueryService.query.mockRejectedValue(new Error("Invalid character in query"));
+
+      await expect(api.query(queryWithSpecialChars)).rejects.toThrow("Invalid character");
+    });
+
+    it("should handle query with unicode characters", async () => {
+      const unicodeQuery = 'SELECT * WHERE { ?s rdfs:label "日本語" }';
+      mockQueryService.query.mockResolvedValue([{ s: "result" }] as any);
+
+      const result = await api.query(unicodeQuery);
+      expect(result.count).toBe(1);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/error-handling/SPARQLCodeBlockProcessor.error.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/SPARQLCodeBlockProcessor.error.test.ts
@@ -1,0 +1,518 @@
+/**
+ * SPARQLCodeBlockProcessor Error Handling Tests
+ *
+ * Tests error scenarios for:
+ * - Invalid SPARQL query syntax
+ * - Triple store initialization failures
+ * - Query execution errors
+ * - Parser errors with line/column info
+ * - Refresh errors
+ * - Non-Error throwable handling
+ *
+ * Issue: #788 - Add negative tests for error handling
+ */
+
+import type { MarkdownPostProcessorContext, App, Vault, MetadataCache, EventRef } from "obsidian";
+import { SPARQLCodeBlockProcessor } from "../../../src/application/processors/SPARQLCodeBlockProcessor";
+import type ExocortexPlugin from "../../../src/ExocortexPlugin";
+import { SPARQLParseError } from "@exocortex/core";
+
+// Mock Notice
+const mockNotice = jest.fn();
+jest.mock("obsidian", () => ({
+  Notice: function (message: string, timeout?: number) {
+    mockNotice(message, timeout);
+  },
+  MarkdownRenderChild: class MockMarkdownRenderChild {
+    containerEl: HTMLElement;
+    constructor(containerEl: HTMLElement) {
+      this.containerEl = containerEl;
+    }
+    onload(): void {}
+    onunload(): void {}
+  },
+}));
+
+describe("SPARQLCodeBlockProcessor Error Handling", () => {
+  let processor: SPARQLCodeBlockProcessor;
+  let mockPlugin: ExocortexPlugin;
+  let mockContext: MarkdownPostProcessorContext;
+  let mockEl: HTMLElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNotice.mockClear();
+
+    mockPlugin = {
+      app: {
+        vault: {} as Vault,
+        metadataCache: {
+          on: jest.fn().mockReturnValue({} as EventRef),
+          offref: jest.fn(),
+        } as unknown as MetadataCache,
+      } as App,
+    } as ExocortexPlugin;
+
+    mockContext = {
+      addChild: jest.fn(),
+    } as any;
+
+    mockEl = document.createElement("div");
+
+    processor = new SPARQLCodeBlockProcessor(mockPlugin);
+  });
+
+  describe("Invalid Query Syntax Errors", () => {
+    it("should handle malformed SELECT query", async () => {
+      // Mock ensureTripleStoreLoaded to succeed
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+
+      // Mock executeQuery to throw parse error
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(
+        new Error("Expected 'WHERE' but found 'FROM'")
+      );
+
+      await processor.process("SELECT * FROM", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle empty query string", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(
+        new Error("Empty query string")
+      );
+
+      await processor.process("", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle query with invalid characters", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(
+        new Error("Unexpected character '$' at position 10")
+      );
+
+      await processor.process("SELECT $invalid WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle unclosed brackets in query", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(
+        new Error("Unexpected end of input: unclosed '{'")
+      );
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle SPARQLParseError with line and column info", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+
+      const parseError = new SPARQLParseError("Syntax error", 5, 10);
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(parseError);
+
+      await processor.process("SELECT\n* WHERE { ?s ?p ?o", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+
+      // Verify the error view was rendered with line/column info
+      const container = mockEl.querySelector(".sparql-results-container");
+      expect(container).toBeDefined();
+    });
+
+    it("should handle invalid PREFIX declarations", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(
+        new Error("Invalid PREFIX: missing colon")
+      );
+
+      await processor.process(
+        "PREFIX exo <http://example.org/>\nSELECT * WHERE { ?s ?p ?o }",
+        mockEl,
+        mockContext
+      );
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+  });
+
+  describe("Triple Store Initialization Errors", () => {
+    it("should handle triple store initialization failure", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue(
+        new Error("Failed to initialize triple store")
+      );
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle vault adapter creation failure", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue(
+        new Error("Vault not available")
+      );
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle RDF conversion failure", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue(
+        new Error("Failed to convert vault to RDF: Invalid frontmatter format")
+      );
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle out of memory during triple store loading", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue(
+        new Error("JavaScript heap out of memory")
+      );
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+  });
+
+  describe("Query Execution Errors", () => {
+    it("should handle triple store not initialized error", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).tripleStore = null;
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle unsupported operation type error", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(
+        new Error("Cannot execute operation type: unsupported")
+      );
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("Cannot execute operation type:"),
+        5000
+      );
+    });
+
+    it("should handle CONSTRUCT query execution error", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(
+        new Error("CONSTRUCT template invalid")
+      );
+
+      await processor.process(
+        "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+        mockEl,
+        mockContext
+      );
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle timeout during query execution", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(
+        new Error("Query execution timeout after 30000ms")
+      );
+
+      await processor.process(
+        "SELECT * WHERE { ?s ?p ?o . ?o ?p2 ?o2 }",
+        mockEl,
+        mockContext
+      );
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("Query execution timeout"),
+        5000
+      );
+    });
+  });
+
+  describe("Non-Error Throwable Handling", () => {
+    it("should handle string thrown as error", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue(
+        "String error thrown"
+      );
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("String error thrown"),
+        5000
+      );
+    });
+
+    it("should handle number thrown as error", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue(500);
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("500"),
+        5000
+      );
+    });
+
+    it("should handle object thrown as error", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue({
+        code: "ERR_CUSTOM",
+        message: "Custom error object",
+      });
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle null thrown as error", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue(null);
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+
+    it("should handle undefined thrown as error", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue(undefined);
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+  });
+
+  describe("Refresh Query Error Handling", () => {
+    it("should handle refresh error gracefully", async () => {
+      const container = document.createElement("div");
+      const el = document.createElement("div");
+      const source = "SELECT * WHERE { ?s ?p ?o }";
+
+      // Set up active query
+      (processor as any).activeQueries.set(el, {
+        source,
+        lastResults: [],
+      });
+
+      const error = new Error("Refresh failed: vault unavailable");
+      (processor as any).invalidateTripleStore = jest.fn();
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue(error);
+      (processor as any).renderError = jest.fn();
+
+      await (processor as any).refreshQuery(el, container, source);
+
+      expect((processor as any).renderError).toHaveBeenCalledWith(error, container, source);
+    });
+
+    it("should handle refresh error during query execution", async () => {
+      const container = document.createElement("div");
+      const el = document.createElement("div");
+      const source = "SELECT * WHERE { ?s ?p ?o }";
+
+      (processor as any).activeQueries.set(el, {
+        source,
+        lastResults: [],
+      });
+
+      (processor as any).invalidateTripleStore = jest.fn();
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).showRefreshIndicator = jest.fn();
+      (processor as any).executeQuery = jest.fn().mockRejectedValue(
+        new Error("Query execution failed during refresh")
+      );
+      (processor as any).renderError = jest.fn();
+
+      await (processor as any).refreshQuery(el, container, source);
+
+      expect((processor as any).renderError).toHaveBeenCalledWith(
+        expect.any(Error),
+        container,
+        source
+      );
+    });
+
+    it("should handle non-Error during refresh", async () => {
+      const container = document.createElement("div");
+      const el = document.createElement("div");
+      const source = "SELECT * WHERE { ?s ?p ?o }";
+
+      (processor as any).activeQueries.set(el, {
+        source,
+        lastResults: [],
+      });
+
+      (processor as any).invalidateTripleStore = jest.fn();
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockRejectedValue("String error");
+      (processor as any).renderError = jest.fn();
+
+      await (processor as any).refreshQuery(el, container, source);
+
+      // Should convert string to Error
+      expect((processor as any).renderError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "String error" }),
+        container,
+        source
+      );
+    });
+  });
+
+  describe("Concurrent Loading Error Handling", () => {
+    it("should handle error while waiting for another load", async () => {
+      // Simulate isLoading state
+      (processor as any).isLoading = true;
+      (processor as any).tripleStore = null;
+
+      // Create a promise that will resolve after initial wait
+      let resolveLoad: () => void;
+      const loadPromise = new Promise<void>((resolve) => {
+        resolveLoad = resolve;
+      });
+
+      // Start the process
+      const processPromise = processor.process(
+        "SELECT * WHERE { ?s ?p ?o }",
+        mockEl,
+        mockContext
+      );
+
+      // Simulate load completing with error
+      setTimeout(() => {
+        (processor as any).isLoading = false;
+        // Triple store is still null, so executeQuery will fail
+        resolveLoad!();
+      }, 150);
+
+      await processPromise;
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("SPARQL query error:"),
+        5000
+      );
+    });
+  });
+
+  describe("DOM and Rendering Error Handling", () => {
+    it("should handle container modification during rendering", async () => {
+      (processor as any).ensureTripleStoreLoaded = jest.fn().mockResolvedValue(undefined);
+      (processor as any).executeQuery = jest.fn().mockResolvedValue([]);
+
+      // Make renderResults throw an error
+      (processor as any).renderResults = jest.fn().mockImplementation(() => {
+        throw new Error("React rendering failed");
+      });
+
+      await processor.process("SELECT * WHERE { ?s ?p ?o }", mockEl, mockContext);
+
+      expect(mockNotice).toHaveBeenCalledWith(
+        expect.stringContaining("React rendering failed"),
+        5000
+      );
+    });
+  });
+
+  describe("Cleanup Error Handling", () => {
+    it("should handle cleanup when activeQueries is empty", () => {
+      expect(() => processor.cleanup()).not.toThrow();
+      expect(processor.getActiveQueryCount()).toBe(0);
+    });
+
+    it("should clear all queries during cleanup when no eventRef errors", () => {
+      const el1 = document.createElement("div");
+      const el2 = document.createElement("div");
+
+      (processor as any).activeQueries.set(el1, {
+        source: "query1",
+        lastResults: [],
+        refreshTimeout: setTimeout(() => {}, 1000),
+        eventRef: {},
+      });
+
+      (processor as any).activeQueries.set(el2, {
+        source: "query2",
+        lastResults: [],
+      });
+
+      // Mock offref to work normally
+      (mockPlugin.app.metadataCache.offref as jest.Mock).mockImplementation(() => {
+        // No-op - successful offref
+      });
+
+      // Cleanup should clear all queries
+      processor.cleanup();
+
+      expect(processor.getActiveQueryCount()).toBe(0);
+    });
+
+    it("should clear timeouts during cleanup", () => {
+      const el = document.createElement("div");
+      const timeout = setTimeout(() => {}, 10000);
+
+      (processor as any).activeQueries.set(el, {
+        source: "query",
+        lastResults: [],
+        refreshTimeout: timeout,
+      });
+
+      processor.cleanup();
+
+      expect(processor.getActiveQueryCount()).toBe(0);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/error-handling/SPARQLQueryService.error.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/SPARQLQueryService.error.test.ts
@@ -1,0 +1,467 @@
+/**
+ * SPARQLQueryService Error Handling Tests
+ *
+ * Tests error scenarios for:
+ * - Initialization failures
+ * - Query parsing errors
+ * - Query execution errors
+ * - Indexer refresh failures
+ * - File update errors
+ * - Service error wrapping
+ *
+ * Issue: #788 - Add negative tests for error handling
+ */
+
+import { App, TFile } from "obsidian";
+import { SPARQLQueryService } from "../../../src/application/services/SPARQLQueryService";
+import {
+  ServiceError,
+  ValidationError,
+  type ILogger,
+  type INotificationService,
+} from "@exocortex/core";
+
+// Mock dependencies
+jest.mock("../../../src/infrastructure/VaultRDFIndexer", () => ({
+  VaultRDFIndexer: jest.fn().mockImplementation(() => ({
+    initialize: jest.fn(),
+    refresh: jest.fn(),
+    updateFile: jest.fn(),
+    dispose: jest.fn(),
+    getTripleStore: jest.fn(),
+  })),
+}));
+
+jest.mock("../../../src/adapters/logging/LoggerFactory", () => ({
+  LoggerFactory: {
+    create: jest.fn().mockReturnValue({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+describe("SPARQLQueryService Error Handling", () => {
+  let mockApp: jest.Mocked<App>;
+  let mockLogger: jest.Mocked<ILogger>;
+  let mockNotifier: jest.Mocked<INotificationService>;
+  let mockIndexer: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockApp = {
+      vault: {},
+      metadataCache: {},
+    } as unknown as jest.Mocked<App>;
+
+    mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    mockNotifier = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      success: jest.fn(),
+      confirm: jest.fn().mockResolvedValue(false),
+    };
+
+    // Get mock indexer instance
+    const { VaultRDFIndexer } = require("../../../src/infrastructure/VaultRDFIndexer");
+    mockIndexer = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      refresh: jest.fn().mockResolvedValue(undefined),
+      updateFile: jest.fn().mockResolvedValue(undefined),
+      dispose: jest.fn(),
+      getTripleStore: jest.fn().mockReturnValue({}),
+    };
+    VaultRDFIndexer.mockImplementation(() => mockIndexer);
+  });
+
+  describe("Initialization Errors", () => {
+    it("should throw ServiceError when indexer initialization fails", async () => {
+      mockIndexer.initialize.mockRejectedValue(new Error("Vault access denied"));
+
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      await expect(service.initialize()).rejects.toThrow(ServiceError);
+      await expect(service.initialize()).rejects.toThrow("failed to initialize sparql query service");
+    });
+
+    it("should include original error message in ServiceError context", async () => {
+      const originalError = new Error("Network timeout during vault scan");
+      mockIndexer.initialize.mockRejectedValue(originalError);
+
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      try {
+        await service.initialize();
+        fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ServiceError);
+        expect((error as ServiceError).context).toEqual(
+          expect.objectContaining({
+            service: "SPARQLQueryService",
+            operation: "initialize",
+            originalError: "Network timeout during vault scan",
+          })
+        );
+      }
+    });
+
+    it("should handle non-Error throwable during initialization", async () => {
+      mockIndexer.initialize.mockRejectedValue("String error");
+
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      await expect(service.initialize()).rejects.toThrow(ServiceError);
+    });
+
+    it("should not reinitialize if already initialized", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      await service.initialize();
+      await service.initialize();
+
+      expect(mockIndexer.initialize).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Query Execution Errors", () => {
+    it("should throw ServiceError when executor not initialized", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      // Initialize but make getTripleStore return something that causes executor to be null
+      mockIndexer.initialize.mockImplementation(() => {
+        mockIndexer.getTripleStore.mockReturnValue(null);
+      });
+
+      // Force the service into an inconsistent state
+      (service as any).isInitialized = true;
+      (service as any).executor = null;
+
+      await expect(service.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toThrow(ServiceError);
+      await expect(service.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toThrow("query executor not initialized");
+    });
+
+    it("should throw ValidationError for parse errors (containing 'parse' in message)", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      // Initialize successfully
+      await service.initialize();
+
+      // Mock parser to throw error containing 'parse' - triggers ValidationError
+      const mockParser = {
+        parse: jest.fn().mockImplementation(() => {
+          throw new Error("Failed to parse: Unexpected token at line 1");
+        }),
+      };
+      (service as any).parser = mockParser;
+
+      await expect(service.query("INVALID SPARQL")).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw ValidationError for syntax errors (containing 'syntax' in message)", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      await service.initialize();
+
+      // Mock parser to throw error containing 'syntax' - triggers ValidationError
+      const mockParser = {
+        parse: jest.fn().mockImplementation(() => {
+          throw new Error("syntax error: missing WHERE clause");
+        }),
+      };
+      (service as any).parser = mockParser;
+
+      await expect(service.query("SELECT *")).rejects.toThrow(ValidationError);
+    });
+
+    it("should include query in ValidationError context", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      const badQuery = "SELECT $invalid";
+      // Error message must contain 'parse' or 'syntax' to be classified as ValidationError
+      const mockParser = {
+        parse: jest.fn().mockImplementation(() => {
+          throw new Error("parse error: invalid variable");
+        }),
+      };
+      (service as any).parser = mockParser;
+
+      try {
+        await service.query(badQuery);
+        fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ValidationError);
+        expect((error as ValidationError).context).toEqual(
+          expect.objectContaining({
+            query: badQuery,
+          })
+        );
+      }
+    });
+
+    it("should throw ServiceError for non-parse execution errors", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      const mockParser = { parse: jest.fn().mockReturnValue({ type: "query" }) };
+      const mockTranslator = {
+        translate: jest.fn().mockImplementation(() => {
+          throw new Error("Translation failed: unsupported construct");
+        }),
+      };
+      (service as any).parser = mockParser;
+      (service as any).translator = mockTranslator;
+
+      await expect(service.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toThrow(ServiceError);
+    });
+
+    it("should re-throw ServiceError without wrapping", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      const existingServiceError = new ServiceError("Already a service error", {});
+      const mockParser = {
+        parse: jest.fn().mockImplementation(() => {
+          throw existingServiceError;
+        }),
+      };
+      (service as any).parser = mockParser;
+
+      await expect(service.query("SELECT * WHERE { ?s ?p ?o }")).rejects.toBe(existingServiceError);
+    });
+
+    it("should auto-initialize when querying before initialization", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      // Mock a working parser/translator/optimizer/executor
+      const mockTripleStore = {
+        match: jest.fn().mockReturnValue([]),
+      };
+      mockIndexer.getTripleStore.mockReturnValue(mockTripleStore);
+
+      const mockParser = { parse: jest.fn().mockReturnValue({ type: "query" }) };
+      const mockTranslator = { translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }) };
+      const mockOptimizer = { optimize: jest.fn().mockImplementation((x) => x) };
+
+      (service as any).parser = mockParser;
+      (service as any).translator = mockTranslator;
+      (service as any).optimizer = mockOptimizer;
+
+      // This should trigger auto-initialization
+      try {
+        await service.query("SELECT * WHERE { ?s ?p ?o }");
+      } catch {
+        // Query might fail, but initialization should have been called
+      }
+
+      expect(mockIndexer.initialize).toHaveBeenCalled();
+    });
+  });
+
+  describe("Refresh Errors", () => {
+    it("should handle indexer refresh failure", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      mockIndexer.refresh.mockRejectedValue(new Error("Refresh failed: vault locked"));
+
+      // The refresh method uses executeWithRetry, which may retry and eventually fail
+      await expect(service.refresh()).rejects.toThrow();
+    });
+
+    it("should handle network error during refresh", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      const networkError = new Error("ETIMEDOUT");
+      mockIndexer.refresh.mockRejectedValue(networkError);
+
+      await expect(service.refresh()).rejects.toThrow();
+    });
+  });
+
+  describe("UpdateFile Errors", () => {
+    it("should handle file update failure", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      const mockFile = { path: "test.md" } as TFile;
+      mockIndexer.updateFile.mockRejectedValue(new Error("File update failed"));
+
+      await expect(service.updateFile(mockFile)).rejects.toThrow();
+    });
+
+    it("should handle file not found during update", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      const mockFile = { path: "nonexistent.md" } as TFile;
+      mockIndexer.updateFile.mockRejectedValue(new Error("File not found: nonexistent.md"));
+
+      await expect(service.updateFile(mockFile)).rejects.toThrow();
+    });
+
+    it("should handle corrupted file during update", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      const mockFile = { path: "corrupted.md" } as TFile;
+      mockIndexer.updateFile.mockRejectedValue(new Error("Invalid frontmatter: malformed YAML"));
+
+      await expect(service.updateFile(mockFile)).rejects.toThrow();
+    });
+  });
+
+  describe("Dispose Behavior", () => {
+    it("should propagate dispose errors from indexer", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      mockIndexer.dispose.mockImplementation(() => {
+        throw new Error("Dispose error");
+      });
+
+      // Current implementation propagates indexer.dispose errors
+      await expect(service.dispose()).rejects.toThrow("Dispose error");
+    });
+
+    it("should reset state after successful dispose", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      // Reset dispose mock to succeed
+      mockIndexer.dispose.mockImplementation(() => {});
+
+      await service.dispose();
+
+      // Service should be in uninitialized state
+      expect((service as any).isInitialized).toBe(false);
+      expect((service as any).executor).toBeNull();
+    });
+
+    it("should allow reinitialization after dispose", async () => {
+      // Reset dispose mock to succeed and clear init calls
+      mockIndexer.dispose.mockImplementation(() => {});
+      mockIndexer.initialize.mockClear();
+
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+      await service.dispose();
+
+      // Should be able to initialize again
+      await service.initialize();
+
+      expect(mockIndexer.initialize).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Error Handler Integration", () => {
+    it("should wrap init errors in ServiceError", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      mockIndexer.initialize.mockRejectedValue(new Error("Init failed"));
+
+      await expect(service.initialize()).rejects.toBeInstanceOf(ServiceError);
+    });
+
+    it("should classify parse errors as ValidationError", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      // Error message must contain 'parse' to be classified as ValidationError
+      const mockParser = {
+        parse: jest.fn().mockImplementation(() => {
+          throw new Error("Failed to parse query");
+        }),
+      };
+      (service as any).parser = mockParser;
+
+      await expect(service.query("INVALID")).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    it("should classify other errors as ServiceError", async () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+      await service.initialize();
+
+      // Error message without 'parse' or 'syntax' - becomes ServiceError
+      const mockParser = {
+        parse: jest.fn().mockImplementation(() => {
+          throw new Error("Unknown execution error");
+        }),
+      };
+      (service as any).parser = mockParser;
+
+      await expect(service.query("INVALID")).rejects.toBeInstanceOf(ServiceError);
+    });
+  });
+
+  describe("Constructor with Dependencies", () => {
+    it("should use custom logger when provided", () => {
+      const customLogger: ILogger = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+
+      const service = new SPARQLQueryService(mockApp, customLogger, mockNotifier);
+
+      expect((service as any).logger).toBe(customLogger);
+    });
+
+    it("should be creatable with all parameters", () => {
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      expect(service).toBeDefined();
+      expect((service as any).errorHandler).toBeDefined();
+    });
+  });
+
+  describe("Initialization Behavior", () => {
+    it("should not reinitialize when already initialized", async () => {
+      // Clear mocks for accurate call count
+      mockIndexer.initialize.mockClear();
+      mockIndexer.dispose.mockImplementation(() => {});
+
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      // First initialization
+      await service.initialize();
+
+      // Second initialization attempt (should be skipped)
+      await service.initialize();
+
+      // Should only have called indexer.initialize once
+      expect(mockIndexer.initialize).toHaveBeenCalledTimes(1);
+    });
+
+    it("should auto-initialize when querying uninitialized service", async () => {
+      // Clear mocks to get fresh call count
+      mockIndexer.initialize.mockClear();
+      mockIndexer.dispose.mockImplementation(() => {});
+
+      const service = new SPARQLQueryService(mockApp, mockLogger, mockNotifier);
+
+      // Query without explicit initialization
+      // This will trigger auto-initialization, then fail due to mock not being fully set up
+      try {
+        await service.query("SELECT * WHERE { ?s ?p ?o }");
+      } catch {
+        // Expected - query will fail but init should have been called
+      }
+
+      // Initialization should have been triggered
+      expect(mockIndexer.initialize).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive negative tests for error handling across 5 key components:

- **CreateInstanceCommand**: 21 tests covering modal failures, service errors, file conversion, workspace operations
- **SPARQLCodeBlockProcessor**: 27 tests covering invalid queries, triple store initialization, query execution errors
- **ObsidianVaultAdapter**: 42 tests covering file operations, permission errors, concurrent modifications
- **SPARQLQueryService**: 26 tests covering initialization, parsing, execution, error classification
- **SPARQLApi**: 25 tests covering query service errors, refresh/dispose, error type preservation

### Error Scenarios Covered

1. ✅ CreateInstanceCommand when modal fails
2. ✅ SPARQLCodeBlockProcessor with invalid queries
3. ✅ ObsidianVaultAdapter with missing metadata cache
4. ✅ Network failures (ETIMEDOUT errors)
5. ✅ File system errors (ENOENT, EACCES, EPERM, ENOSPC)
6. ✅ Permission errors
7. ✅ Concurrent modification errors
8. ✅ Timeout scenarios
9. ✅ Invalid input handling (null, undefined, empty strings)
10. ✅ Resource exhaustion (heap out of memory simulation)

### Additional Coverage

- Non-Error throwable handling (strings, numbers, objects, null, undefined)
- Error type preservation (ServiceError vs ValidationError)
- Error context verification
- User-friendly error messages

## Test Results

All 141 new tests pass:
- CreateInstanceCommand.error.test.ts: 21 tests ✅
- ObsidianVaultAdapter.error.test.ts: 42 tests ✅
- SPARQLCodeBlockProcessor.error.test.ts: 27 tests ✅
- SPARQLQueryService.error.test.ts: 26 tests ✅
- SPARQLApi.error.test.ts: 25 tests ✅

## Test Plan

- [x] All new error tests pass locally
- [x] No regressions in existing tests
- [x] CI pipeline should pass

Closes #788