### PR TITLE
feat: Add event unregistration in EventListenerManager

### DIFF
--- a/packages/obsidian-plugin/src/adapters/events/EventListenerManager.ts
+++ b/packages/obsidian-plugin/src/adapters/events/EventListenerManager.ts
@@ -7,11 +7,43 @@ interface EventListenerRecord {
 export class EventListenerManager {
   private listeners: EventListenerRecord[] = [];
 
-  register(element: HTMLElement, type: string, handler: EventListener): void {
+  /**
+   * Registers an event listener on an element and tracks it for cleanup.
+   * @returns Unsubscribe function to remove this specific listener
+   */
+  register(element: HTMLElement, type: string, handler: EventListener): () => void {
     element.addEventListener(type, handler);
     this.listeners.push({ element, type, handler });
+
+    // Return unsubscribe function
+    return () => this.unregister(element, type, handler);
   }
 
+  /**
+   * Unregisters a specific event listener.
+   * @returns true if the listener was found and removed, false otherwise
+   */
+  unregister(element: HTMLElement, type: string, handler: EventListener): boolean {
+    const index = this.listeners.findIndex(
+      (record) =>
+        record.element === element &&
+        record.type === type &&
+        record.handler === handler
+    );
+
+    if (index !== -1) {
+      element.removeEventListener(type, handler);
+      this.listeners.splice(index, 1);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Removes all registered event listeners.
+   * Should be called in component unmount or plugin unload.
+   */
   cleanup(): void {
     this.listeners.forEach(({ element, type, handler }) => {
       element.removeEventListener(type, handler);
@@ -19,6 +51,9 @@ export class EventListenerManager {
     this.listeners = [];
   }
 
+  /**
+   * Returns the total number of tracked listeners.
+   */
   getListenerCount(): number {
     return this.listeners.length;
   }


### PR DESCRIPTION
## Summary
- Add `unregister()` method for individual listener removal
- Update `register()` to return unsubscribe function for easy cleanup
- Add comprehensive unit tests for new functionality

## Changes
- **EventListenerManager.ts**: Added `unregister()` method and updated `register()` to return unsubscribe function
- **EventListenerManager.test.ts**: Added 18 new test cases for unregister, unsubscribe functions, and component lifecycle integration

## Test plan
- [x] Unit tests pass locally
- [x] TypeScript type checks pass
- [x] ESLint passes (no new errors)
- [ ] CI pipeline (build-and-test + e2e-tests)

## Acceptance Criteria from Issue #792
- [x] offEvent() method added (implemented as `unregister()`)
- [x] cleanup() already called in onunload() (verified existing implementation)
- [x] All handlers properly unregistered via unsubscribe function
- [x] Memory stable over plugin reload cycles (tested in unit tests)

Closes #792