### PR TITLE
refactor: Use config object pattern for ButtonGroupsBuilder constructor

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -2,20 +2,22 @@ import { TFile } from "obsidian";
 import { ILogger } from '@plugin/adapters/logging/ILogger';
 import { ExocortexSettings } from '@plugin/domain/settings/ExocortexSettings';
 import { ButtonGroup } from '@plugin/presentation/components/ActionButtonsGroup';
-import { CommandVisibilityContext } from "@exocortex/core";
-import { TaskCreationService } from "@exocortex/core";
-import { ProjectCreationService } from "@exocortex/core";
-import { AreaCreationService } from "@exocortex/core";
-import { ClassCreationService } from "@exocortex/core";
-import { ConceptCreationService } from "@exocortex/core";
-import { TaskStatusService } from "@exocortex/core";
-import { PropertyCleanupService } from "@exocortex/core";
-import { FolderRepairService } from "@exocortex/core";
-import { RenameToUidService } from "@exocortex/core";
-import { EffortVotingService } from "@exocortex/core";
-import { LabelToAliasService } from "@exocortex/core";
-import { AssetConversionService } from "@exocortex/core";
-import { MetadataExtractor } from "@exocortex/core";
+import {
+  CommandVisibilityContext,
+  TaskCreationService,
+  ProjectCreationService,
+  AreaCreationService,
+  ClassCreationService,
+  ConceptCreationService,
+  TaskStatusService,
+  PropertyCleanupService,
+  FolderRepairService,
+  RenameToUidService,
+  EffortVotingService,
+  LabelToAliasService,
+  AssetConversionService,
+  MetadataExtractor,
+} from "@exocortex/core";
 import {
   ButtonBuilderContext,
   ButtonBuilderServices,
@@ -29,6 +31,49 @@ import {
 import { ObsidianApp, ExocortexPluginInterface } from '@plugin/types';
 
 /**
+ * Configuration object for ButtonGroupsBuilder.
+ * Groups related parameters together for better readability and maintainability.
+ */
+export interface ButtonGroupsBuilderConfig {
+  /** Obsidian app instance */
+  app: ObsidianApp;
+  /** Plugin settings */
+  settings: ExocortexSettings;
+  /** Plugin instance for save operations */
+  plugin: ExocortexPluginInterface;
+  /** Service for creating tasks */
+  taskCreationService: TaskCreationService;
+  /** Service for creating projects */
+  projectCreationService: ProjectCreationService;
+  /** Service for creating areas */
+  areaCreationService: AreaCreationService;
+  /** Service for creating classes */
+  classCreationService: ClassCreationService;
+  /** Service for creating concepts */
+  conceptCreationService: ConceptCreationService;
+  /** Service for task status operations */
+  taskStatusService: TaskStatusService;
+  /** Service for cleaning up properties */
+  propertyCleanupService: PropertyCleanupService;
+  /** Service for repairing folder locations */
+  folderRepairService: FolderRepairService;
+  /** Service for renaming files to UID */
+  renameToUidService: RenameToUidService;
+  /** Service for voting on efforts */
+  effortVotingService: EffortVotingService;
+  /** Service for copying label to aliases */
+  labelToAliasService: LabelToAliasService;
+  /** Service for converting between task and project */
+  assetConversionService: AssetConversionService;
+  /** Extractor for file metadata */
+  metadataExtractor: MetadataExtractor;
+  /** Logger instance */
+  logger: ILogger;
+  /** Callback to refresh the view */
+  refresh: () => Promise<void>;
+}
+
+/**
  * Orchestrator for building button groups.
  *
  * Delegates to specialized button group builders:
@@ -38,29 +83,44 @@ import { ObsidianApp, ExocortexPluginInterface } from '@plugin/types';
  * - MaintenanceButtonGroupBuilder: Trash, Archive, Clean Properties, etc.
  */
 export class ButtonGroupsBuilder {
+  private app: ObsidianApp;
+  private settings: ExocortexSettings;
+  private plugin: ExocortexPluginInterface;
+  private metadataExtractor: MetadataExtractor;
+  private logger: ILogger;
+  private refresh: () => Promise<void>;
   private services: ButtonBuilderServices;
   private builders: IButtonGroupBuilder[];
 
-  constructor(
-    private app: ObsidianApp,
-    private settings: ExocortexSettings,
-    private plugin: ExocortexPluginInterface,
-    taskCreationService: TaskCreationService,
-    projectCreationService: ProjectCreationService,
-    areaCreationService: AreaCreationService,
-    classCreationService: ClassCreationService,
-    conceptCreationService: ConceptCreationService,
-    taskStatusService: TaskStatusService,
-    propertyCleanupService: PropertyCleanupService,
-    folderRepairService: FolderRepairService,
-    renameToUidService: RenameToUidService,
-    effortVotingService: EffortVotingService,
-    labelToAliasService: LabelToAliasService,
-    assetConversionService: AssetConversionService,
-    private metadataExtractor: MetadataExtractor,
-    private logger: ILogger,
-    private refresh: () => Promise<void>,
-  ) {
+  constructor(config: ButtonGroupsBuilderConfig) {
+    const {
+      app,
+      settings,
+      plugin,
+      taskCreationService,
+      projectCreationService,
+      areaCreationService,
+      classCreationService,
+      conceptCreationService,
+      taskStatusService,
+      propertyCleanupService,
+      folderRepairService,
+      renameToUidService,
+      effortVotingService,
+      labelToAliasService,
+      assetConversionService,
+      metadataExtractor,
+      logger,
+      refresh,
+    } = config;
+
+    this.app = app;
+    this.settings = settings;
+    this.plugin = plugin;
+    this.metadataExtractor = metadataExtractor;
+    this.logger = logger;
+    this.refresh = refresh;
+
     // Aggregate services for button builders
     this.services = {
       taskCreationService,

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -108,13 +108,26 @@ export class UniversalLayoutRenderer {
       this.app, this.settings, this.reactRenderer, this.backlinksCacheManager,
       this.metadataService, this.plugin, () => this.refresh(), this.vaultAdapter);
 
-    this.buttonGroupsBuilder = new ButtonGroupsBuilder(
-      this.app, this.settings, this.plugin,
-      services.taskCreation, services.projectCreation, services.areaCreation,
-      services.classCreation, services.conceptCreation, services.taskStatus,
-      services.propertyCleanup, services.folderRepair, services.renameToUid,
-      services.effortVoting, services.labelToAlias, services.assetConversion,
-      this.metadataExtractor, this.logger, () => this.refresh());
+    this.buttonGroupsBuilder = new ButtonGroupsBuilder({
+      app: this.app,
+      settings: this.settings,
+      plugin: this.plugin,
+      taskCreationService: services.taskCreation,
+      projectCreationService: services.projectCreation,
+      areaCreationService: services.areaCreation,
+      classCreationService: services.classCreation,
+      conceptCreationService: services.conceptCreation,
+      taskStatusService: services.taskStatus,
+      propertyCleanupService: services.propertyCleanup,
+      folderRepairService: services.folderRepair,
+      renameToUidService: services.renameToUid,
+      effortVotingService: services.effortVoting,
+      labelToAliasService: services.labelToAlias,
+      assetConversionService: services.assetConversion,
+      metadataExtractor: this.metadataExtractor,
+      logger: this.logger,
+      refresh: () => this.refresh(),
+    });
 
     this.dailyTasksRenderer = new DailyTasksRenderer(
       this.app, this.settings, this.plugin, this.logger,

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.fixtures.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.fixtures.ts
@@ -1,4 +1,4 @@
-import { ButtonGroupsBuilder } from "../../../../src/presentation/builders/ButtonGroupsBuilder";
+import { ButtonGroupsBuilder, ButtonGroupsBuilderConfig } from "../../../../src/presentation/builders/ButtonGroupsBuilder";
 import { TFile } from "obsidian";
 import { ExocortexSettings } from "../../../../src/domain/settings/ExocortexSettings";
 import {
@@ -139,26 +139,26 @@ export function setupButtonGroupsBuilderTest(): ButtonGroupsBuilderTestContext {
 
   const mockRefresh = jest.fn();
 
-  const builder = new ButtonGroupsBuilder(
-    mockApp,
-    mockSettings,
-    mockPlugin,
-    mockTaskCreationService,
-    mockProjectCreationService,
-    mockAreaCreationService,
-    mockClassCreationService,
-    mockConceptCreationService,
-    mockTaskStatusService,
-    mockPropertyCleanupService,
-    mockFolderRepairService,
-    mockRenameToUidService,
-    mockEffortVotingService,
-    mockLabelToAliasService,
-    mockAssetConversionService,
-    mockMetadataExtractor,
-    mockLogger,
-    mockRefresh,
-  );
+  const builder = new ButtonGroupsBuilder({
+    app: mockApp,
+    settings: mockSettings,
+    plugin: mockPlugin,
+    taskCreationService: mockTaskCreationService,
+    projectCreationService: mockProjectCreationService,
+    areaCreationService: mockAreaCreationService,
+    classCreationService: mockClassCreationService,
+    conceptCreationService: mockConceptCreationService,
+    taskStatusService: mockTaskStatusService,
+    propertyCleanupService: mockPropertyCleanupService,
+    folderRepairService: mockFolderRepairService,
+    renameToUidService: mockRenameToUidService,
+    effortVotingService: mockEffortVotingService,
+    labelToAliasService: mockLabelToAliasService,
+    assetConversionService: mockAssetConversionService,
+    metadataExtractor: mockMetadataExtractor,
+    logger: mockLogger,
+    refresh: mockRefresh,
+  });
 
   return {
     builder,
@@ -183,4 +183,4 @@ export function setupButtonGroupsBuilderTest(): ButtonGroupsBuilderTestContext {
   };
 }
 
-export { TFile, ButtonGroupsBuilder };
+export { TFile, ButtonGroupsBuilder, ButtonGroupsBuilderConfig };


### PR DESCRIPTION
## Summary

Refactors `ButtonGroupsBuilder` constructor from 16 positional parameters to a single configuration object, improving code readability and maintainability.

### Changes

- **Created `ButtonGroupsBuilderConfig` interface** with JSDoc documentation for all properties
- **Refactored constructor** to accept single config object with destructuring
- **Updated `UniversalLayoutRenderer`** to use named parameters
- **Updated test fixtures** to use the new config pattern

### Before

```typescript
constructor(
  app: ObsidianApp,
  settings: ExocortexSettings,
  plugin: ExocortexPluginInterface,
  taskCreationService: TaskCreationService,
  projectCreationService: ProjectCreationService,
  // ... 11 more parameters
)
```

### After

```typescript
constructor(config: ButtonGroupsBuilderConfig) {
  const { app, settings, plugin, taskCreationService, ... } = config;
}
```

### Benefits

- **Self-documenting API**: Named parameters make code more readable
- **Prevents parameter swap errors**: No risk of passing parameters in wrong order
- **Easier to extend**: Adding new optional parameters is simpler
- **Better IDE support**: IntelliSense shows parameter names

## Test Plan

- [x] All unit tests pass (803 tests)
- [x] TypeScript type checking passes
- [x] Linting passes
- [x] Build passes

Closes #798