### PR TITLE
ci: Add E2E test artifacts on failure (videos, screenshots, traces)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,11 +562,11 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
-      - name: Upload E2E test results (screenshots) for shard ${{ matrix.shard }}
+      - name: Upload E2E test artifacts (videos, screenshots, traces) for shard ${{ matrix.shard }}
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-results-${{ matrix.shard }}
+          name: e2e-test-artifacts-${{ matrix.shard }}
           path: test-results-e2e/
           retention-days: 7
           if-no-files-found: ignore
@@ -607,6 +607,14 @@ jobs:
           path: all-blob-reports
           merge-multiple: true
 
+      - name: Download all test artifacts (videos, screenshots, traces)
+        if: always()
+        uses: actions/download-artifact@v4
+        with:
+          pattern: e2e-test-artifacts-*
+          path: all-test-artifacts
+          merge-multiple: true
+
       - name: Merge E2E reports
         run: |
           npx playwright merge-reports --reporter html ./all-blob-reports
@@ -619,6 +627,15 @@ jobs:
           name: e2e-test-report
           path: playwright-report/
           retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Upload merged test artifacts (videos, screenshots, traces)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-artifacts
+          path: all-test-artifacts/
+          retention-days: 7
           if-no-files-found: ignore
 
   performance-tests:

--- a/packages/obsidian-plugin/playwright-e2e.config.ts
+++ b/packages/obsidian-plugin/playwright-e2e.config.ts
@@ -26,11 +26,14 @@ export default defineConfig({
     ["./playwright-no-flaky-reporter.ts"],
   ],
 
+  // Output directory for test artifacts (videos, screenshots, traces)
+  outputDir: "test-results",
+
   use: {
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
     screenshot: "only-on-failure",
-    // Disabled video in CI to speed up tests
-    video: process.env.CI ? "off" : "retain-on-failure",
+    // Enable video recording for failures to aid debugging in CI
+    video: "retain-on-failure",
     launchOptions: {
       args: [
         "--disable-dev-shm-usage",


### PR DESCRIPTION
## Summary

Enable video recording and trace capture for E2E test failures to improve debugging in CI.

Closes #803

## Changes

### Playwright E2E Config (`playwright-e2e.config.ts`)
- Enable video recording on failure (`video: "retain-on-failure"`) - was disabled in CI
- Enable trace retention on failure (`trace: "retain-on-failure"`) - was only `on-first-retry`
- Add explicit `outputDir: "test-results"` for test artifacts

### CI Workflow (`.github/workflows/ci.yml`)
- Rename artifact from `e2e-test-results-*` to `e2e-test-artifacts-*` to reflect content
- Add step to download and merge all test artifacts from shards
- Upload merged artifacts as `e2e-test-artifacts` for easier access

## Test Plan

- [x] Unit tests pass locally
- [x] TypeScript compiles without errors
- [ ] CI pipeline passes
- [ ] On test failure, artifacts include:
  - Screenshots
  - Videos
  - Trace files

## Acceptance Criteria (from Issue #803)

- [x] Video recording enabled for failures
- [x] Screenshots captured on failure (already was enabled)
- [x] Traces available for debugging
- [x] Artifacts uploaded to GitHub
- [x] Retention policy configured (7 days)