### PR TITLE
ci: increase test-component timeout from 10 to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
 
   test-component:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     container:
       image: mcr.microsoft.com/playwright:v1.56.1-jammy
 


### PR DESCRIPTION
## Summary
Component tests were timing out consistently at 10 minutes in CI, causing Dependabot PRs (e.g., #848) to be blocked.

## Changes
- Increase `test-component` job timeout from 10 to 15 minutes

## Impact
- Allows component tests to complete successfully
- Unblocks Dependabot dependency updates
- No functional code changes