### PR TITLE
feat: integrate OntologySchemaService into CreateTask and CreateInstance commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "jest-environment-obsidian": "^0.0.1",
         "jsdom": "^26.1.0",
         "lint-staged": "^16.2.7",
-        "obsidian": "*",
+        "obsidian": "latest",
         "preact": "^10.28.0",
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.6",
@@ -125,7 +125,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1960,7 +1959,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
       "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1970,7 +1968,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
       "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -2101,7 +2098,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2125,7 +2121,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2143,7 +2138,6 @@
       "integrity": "sha512-36cIyplE1iDl12s4k6lBVpceua8tKLklFTf7CUITPrNHTLlQ/KBr7NYUUHviPzCbj2Ox3BPTZ6qkSLd6WMvVQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cucumber/ci-environment": "12.0.0",
         "@cucumber/cucumber-expressions": "18.0.1",
@@ -2378,7 +2372,6 @@
       "integrity": "sha512-vKJVJ6h4HCktG870wgYUUskNpFxbFI0WmAkVLPTz1LlLwJX7/KOBqFcr2/L3u0pPoHjbLRW+IpbiXLT2T13/wg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cucumber/messages": ">=31.0.0 <32"
       }
@@ -2541,7 +2534,6 @@
       "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@cucumber/messages": ">=17.1.1"
       }
@@ -2552,7 +2544,6 @@
       "integrity": "sha512-Dqhatp4AjMsH9SREfWz3Q8nlGuwJMTW7YAW5L3OzRId86ZUEu/a8vIL1RO2c0agQefuBS2SVH9fEZ66ovrMYRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "class-transformer": "0.5.1",
         "reflect-metadata": "0.2.2"
@@ -3226,7 +3217,6 @@
       "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4987,7 +4977,6 @@
       "integrity": "sha512-DynQ5vYjfBGpZxPmRA2NIsacU942yAkxW+pNENX47lIj9WIF56oJsI2JuFISlQZ7HIm1UCa/bk9RPalzyxfJMw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.0.0",
         "@stryker-mutator/api": "9.4.0",
@@ -5952,7 +5941,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -5970,7 +5958,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6077,7 +6064,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -6600,7 +6586,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7201,7 +7186,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -8121,7 +8105,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8858,7 +8841,6 @@
       "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11236,7 +11218,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -12886,7 +12867,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -14010,7 +13990,6 @@
       "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.11.0.tgz",
       "integrity": "sha512-lVqN9AmDWHzhNATi2tDnjqVgI6WUYKeT+lIsAycAyLt4XCC6zRsWzb+tFCiB7Rn3PpttefjoovilhYwvS4Iqxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/codemirror": "5.60.8",
         "moment": "2.29.4"
@@ -14459,7 +14438,6 @@
       "integrity": "sha512-rytDAoiXr3+t6OIP3WGlDd0ouCUG1iCWzkcY3++Nreuoi17y6T5i/zRhe6uYfoVcxq6YU+sBtJouuRDsq8vvqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -14644,7 +14622,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14654,7 +14631,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16104,7 +16080,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16319,7 +16294,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16407,7 +16381,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -16610,7 +16583,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16625,7 +16597,6 @@
       "integrity": "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.49.0",
         "@typescript-eslint/parser": "8.49.0",
@@ -17489,7 +17460,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18204,7 +18174,7 @@
         "@tanstack/react-query": "^5.90.12",
         "@tanstack/react-virtual": "^3.13.13",
         "d3": "^7.9.0",
-        "obsidian": "*",
+        "obsidian": "latest",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "reflect-metadata": "^0.2.2",

--- a/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
+++ b/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
@@ -20,6 +20,8 @@ import {
   registerCoreServices,
 } from "@exocortex/core";
 import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
+import { SPARQLQueryService } from '@plugin/application/services/SPARQLQueryService';
+import { OntologySchemaService } from '@plugin/application/services/OntologySchemaService';
 
 import { CreateTaskCommand } from "./CreateTaskCommand";
 import { CreateProjectCommand } from "./CreateProjectCommand";
@@ -90,11 +92,15 @@ export class CommandRegistry {
     const assetConversionService = container.resolve(AssetConversionService);
     const fleetingNoteCreationService = container.resolve(FleetingNoteCreationService);
 
+    // Create ontology schema service for dynamic forms
+    const sparqlQueryService = new SPARQLQueryService(app, logger);
+    const ontologySchemaService = new OntologySchemaService(sparqlQueryService);
+
     this.commands = [
-      new CreateTaskCommand(app, taskCreationService, this.vaultAdapter, plugin),
+      new CreateTaskCommand(app, taskCreationService, this.vaultAdapter, plugin, ontologySchemaService),
       new CreateProjectCommand(app, projectCreationService, this.vaultAdapter),
       new CreateAreaCommand(app, areaCreationService, this.vaultAdapter),
-      new CreateInstanceCommand(app, taskCreationService, this.vaultAdapter, plugin),
+      new CreateInstanceCommand(app, taskCreationService, this.vaultAdapter, plugin, ontologySchemaService),
       new CreateFleetingNoteCommand(app, fleetingNoteCreationService, this.vaultAdapter),
       new CreateRelatedTaskCommand(app, taskCreationService, this.vaultAdapter),
       new SetDraftStatusCommand(taskStatusService),

--- a/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
@@ -12,6 +12,7 @@ import { LabelInputModal, type LabelInputModalResult } from '@plugin/presentatio
 import { DynamicAssetCreationModal, type DynamicAssetCreationResult } from '@plugin/presentation/modals/DynamicAssetCreationModal';
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
 import { ExocortexPluginInterface } from '@plugin/types';
+import type { OntologySchemaService } from '@plugin/application/services/OntologySchemaService';
 
 export class CreateInstanceCommand implements ICommand {
   id = "create-instance";
@@ -22,6 +23,7 @@ export class CreateInstanceCommand implements ICommand {
     private taskCreationService: TaskCreationService,
     private vaultAdapter: ObsidianVaultAdapter,
     private plugin: ExocortexPluginInterface,
+    private schemaService?: OntologySchemaService,
   ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
@@ -101,6 +103,7 @@ export class CreateInstanceCommand implements ICommand {
           this.app,
           className,
           resolve,
+          this.schemaService,
         ).open();
       });
     }

--- a/packages/obsidian-plugin/src/application/commands/CreateTaskCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateTaskCommand.ts
@@ -11,6 +11,7 @@ import { LabelInputModal, type LabelInputModalResult } from '@plugin/presentatio
 import { DynamicAssetCreationModal, type DynamicAssetCreationResult } from '@plugin/presentation/modals/DynamicAssetCreationModal';
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
 import { ExocortexPluginInterface } from '@plugin/types';
+import type { OntologySchemaService } from '@plugin/application/services/OntologySchemaService';
 
 export class CreateTaskCommand implements ICommand {
   id = "create-task";
@@ -21,6 +22,7 @@ export class CreateTaskCommand implements ICommand {
     private taskCreationService: TaskCreationService,
     private vaultAdapter: ObsidianVaultAdapter,
     private plugin: ExocortexPluginInterface,
+    private schemaService?: OntologySchemaService,
   ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
@@ -96,6 +98,7 @@ export class CreateTaskCommand implements ICommand {
           this.app,
           "ems__Task",
           resolve,
+          this.schemaService,
         ).open();
       });
     }

--- a/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
@@ -407,7 +407,8 @@ describe("CreateInstanceCommand", () => {
       expect(DynamicAssetCreationModal).toHaveBeenCalledWith(
         mockApp,
         "Task",
-        expect.any(Function)
+        expect.any(Function),
+        undefined, // schemaService (optional)
       );
       expect(LabelInputModal).not.toHaveBeenCalled();
 
@@ -480,7 +481,8 @@ describe("CreateInstanceCommand", () => {
       expect(DynamicAssetCreationModal).toHaveBeenCalledWith(
         mockApp,
         "ems__Effort",
-        expect.any(Function)
+        expect.any(Function),
+        undefined, // schemaService (optional)
       );
 
       expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(

--- a/packages/obsidian-plugin/tests/unit/commands/CommandRegistry.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/CommandRegistry.test.ts
@@ -80,6 +80,25 @@ jest.mock("../../../src/application/commands/SetFocusAreaCommand");
 jest.mock("../../../src/application/commands/OpenQueryBuilderCommand");
 jest.mock("../../../src/application/commands/EditPropertiesCommand");
 
+// Mock SPARQLQueryService and OntologySchemaService
+jest.mock("../../../src/application/services/SPARQLQueryService", () => ({
+  SPARQLQueryService: jest.fn().mockImplementation(() => ({
+    initialize: jest.fn(),
+    query: jest.fn(),
+    refresh: jest.fn(),
+    dispose: jest.fn(),
+  })),
+}));
+
+jest.mock("../../../src/application/services/OntologySchemaService", () => ({
+  OntologySchemaService: jest.fn().mockImplementation(() => ({
+    getClassProperties: jest.fn(),
+    getClassHierarchy: jest.fn(),
+    isDeprecatedProperty: jest.fn(),
+    getDefaultProperties: jest.fn(),
+  })),
+}));
+
 describe("CommandRegistry", () => {
   let mockApp: App;
   let mockPlugin: ExocortexPluginInterface;


### PR DESCRIPTION
## Summary
- Add SPARQLQueryService and OntologySchemaService creation in CommandRegistry
- Pass OntologySchemaService to CreateTaskCommand and CreateInstanceCommand
- DynamicAssetCreationModal now receives schemaService for dynamic form fields

## Problem
When `useDynamicPropertyFields` setting is enabled, CreateTask and CreateInstance commands were creating DynamicAssetCreationModal without passing the OntologySchemaService. This caused the modal to fall back to basic fields (Label + Task Size) instead of dynamically loading class properties from the RDF ontology.

## Solution
1. In `CommandRegistry.ts`:
   - Create `SPARQLQueryService` (auto-initializes on first query)
   - Create `OntologySchemaService` using the SPARQL service
   - Pass `OntologySchemaService` to `CreateTaskCommand` and `CreateInstanceCommand`

2. In `CreateTaskCommand.ts` and `CreateInstanceCommand.ts`:
   - Accept optional `schemaService` parameter in constructor
   - Pass `schemaService` to `DynamicAssetCreationModal`

3. Updated tests:
   - Mock `SPARQLQueryService` and `OntologySchemaService` in CommandRegistry tests
   - Update CreateInstanceCommand tests to expect 4th parameter in modal constructor

## Test plan
- [x] Unit tests pass locally
- [ ] CI pipeline green
- [ ] Manual test: Enable "Dynamic property fields" toggle → Create Task → Modal shows ontology-driven fields

Closes #864