### PR TITLE
fix: Component tests fail in CI with 4ms timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     container:
-      image: mcr.microsoft.com/playwright:v1.56.1-jammy
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
     steps:
       - name: Checkout
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     container:
-      image: mcr.microsoft.com/playwright:v1.56.1-jammy
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
     steps:
       - name: Checkout
@@ -349,7 +349,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: mcr.microsoft.com/playwright:v1.56.1-jammy
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
     steps:
       - name: Checkout
@@ -642,7 +642,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: mcr.microsoft.com/playwright:v1.56.1-jammy
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Fixes the component test failures in CI where all 563 tests were failing in ~4ms with "context canceled" errors.

### Root Cause

The `package-lock.json` was auto-upgraded to **Playwright 1.57.0** during `npm install`, but the CI container was still using **v1.56.1**. This version mismatch caused the Playwright browser executables in the container to not match the expected version, causing all tests to fail immediately.

### Fix

Updated all 4 Playwright container references in `ci.yml` from `v1.56.1-jammy` to `v1.57.0-jammy`:
- `test-unit`
- `test-coverage`
- `test-component`
- `performance-tests`

## Test plan

- [x] Unit tests pass locally
- [ ] CI pipeline passes with new container version
- [ ] Component tests complete successfully (not in 4ms)

Closes #884