### PR TITLE
feat: add ability to hide Time and Status columns in DailyNote tasks table

### DIFF
--- a/packages/obsidian-plugin/src/presentation/stores/types.ts
+++ b/packages/obsidian-plugin/src/presentation/stores/types.ts
@@ -10,6 +10,8 @@ export interface UISettings {
   showFullDateInEffortTimes: boolean;
   focusMode: boolean;
   showEmptySlots: boolean;
+  showTime: boolean;
+  showStatus: boolean;
 }
 
 export interface UIStore extends UISettings {
@@ -19,6 +21,8 @@ export interface UIStore extends UISettings {
   toggleFullDate: () => void;
   toggleFocusMode: () => void;
   toggleEmptySlots: () => void;
+  toggleTime: () => void;
+  toggleStatus: () => void;
   resetToDefaults: () => void;
 }
 

--- a/packages/obsidian-plugin/src/presentation/stores/uiStore.ts
+++ b/packages/obsidian-plugin/src/presentation/stores/uiStore.ts
@@ -9,6 +9,8 @@ const DEFAULT_UI_SETTINGS: UISettings = {
   showFullDateInEffortTimes: false,
   focusMode: false,
   showEmptySlots: true,
+  showTime: true,
+  showStatus: true,
 };
 
 export const useUIStore = create<UIStore>()(
@@ -61,6 +63,20 @@ export const useUIStore = create<UIStore>()(
             "toggleEmptySlots",
           ),
 
+        toggleTime: () =>
+          set(
+            (state) => ({ showTime: !state.showTime }),
+            false,
+            "toggleTime",
+          ),
+
+        toggleStatus: () =>
+          set(
+            (state) => ({ showStatus: !state.showStatus }),
+            false,
+            "toggleStatus",
+          ),
+
         resetToDefaults: () =>
           set(DEFAULT_UI_SETTINGS, false, "resetToDefaults"),
       }),
@@ -73,6 +89,8 @@ export const useUIStore = create<UIStore>()(
           showFullDateInEffortTimes: state.showFullDateInEffortTimes,
           focusMode: state.focusMode,
           showEmptySlots: state.showEmptySlots,
+          showTime: state.showTime,
+          showStatus: state.showStatus,
         }),
       },
     ),

--- a/packages/obsidian-plugin/tests/unit/stores/uiStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/stores/uiStore.test.ts
@@ -31,6 +31,9 @@ describe("UIStore", () => {
       showEffortVotes: false,
       showFullDateInEffortTimes: false,
       focusMode: false,
+      showEmptySlots: true,
+      showTime: true,
+      showStatus: true,
     });
   });
 
@@ -43,6 +46,9 @@ describe("UIStore", () => {
       expect(state.showEffortVotes).toBe(false);
       expect(state.showFullDateInEffortTimes).toBe(false);
       expect(state.focusMode).toBe(false);
+      expect(state.showEmptySlots).toBe(true);
+      expect(state.showTime).toBe(true);
+      expect(state.showStatus).toBe(true);
     });
   });
 
@@ -155,6 +161,60 @@ describe("UIStore", () => {
     });
   });
 
+  describe("toggleTime", () => {
+    it("should toggle showTime from true to false", () => {
+      expect(useUIStore.getState().showTime).toBe(true);
+
+      useUIStore.getState().toggleTime();
+
+      expect(useUIStore.getState().showTime).toBe(false);
+    });
+
+    it("should toggle showTime from false to true", () => {
+      useUIStore.setState({ showTime: false });
+
+      useUIStore.getState().toggleTime();
+
+      expect(useUIStore.getState().showTime).toBe(true);
+    });
+
+    it("should not affect other settings when toggling", () => {
+      useUIStore.setState({ showEffortArea: true, showStatus: true });
+
+      useUIStore.getState().toggleTime();
+
+      expect(useUIStore.getState().showEffortArea).toBe(true);
+      expect(useUIStore.getState().showStatus).toBe(true);
+    });
+  });
+
+  describe("toggleStatus", () => {
+    it("should toggle showStatus from true to false", () => {
+      expect(useUIStore.getState().showStatus).toBe(true);
+
+      useUIStore.getState().toggleStatus();
+
+      expect(useUIStore.getState().showStatus).toBe(false);
+    });
+
+    it("should toggle showStatus from false to true", () => {
+      useUIStore.setState({ showStatus: false });
+
+      useUIStore.getState().toggleStatus();
+
+      expect(useUIStore.getState().showStatus).toBe(true);
+    });
+
+    it("should not affect other settings when toggling", () => {
+      useUIStore.setState({ showEffortArea: true, showTime: true });
+
+      useUIStore.getState().toggleStatus();
+
+      expect(useUIStore.getState().showEffortArea).toBe(true);
+      expect(useUIStore.getState().showTime).toBe(true);
+    });
+  });
+
   describe("resetToDefaults", () => {
     it("should reset all settings to defaults", () => {
       useUIStore.setState({
@@ -163,6 +223,9 @@ describe("UIStore", () => {
         showEffortVotes: true,
         showFullDateInEffortTimes: true,
         focusMode: true,
+        showEmptySlots: false,
+        showTime: false,
+        showStatus: false,
       });
 
       useUIStore.getState().resetToDefaults();
@@ -173,6 +236,9 @@ describe("UIStore", () => {
       expect(state.showEffortVotes).toBe(false);
       expect(state.showFullDateInEffortTimes).toBe(false);
       expect(state.focusMode).toBe(false);
+      expect(state.showEmptySlots).toBe(true);
+      expect(state.showTime).toBe(true);
+      expect(state.showStatus).toBe(true);
     });
 
     it("should work when already at defaults", () => {
@@ -184,6 +250,9 @@ describe("UIStore", () => {
       expect(state.showEffortVotes).toBe(false);
       expect(state.showFullDateInEffortTimes).toBe(false);
       expect(state.focusMode).toBe(false);
+      expect(state.showEmptySlots).toBe(true);
+      expect(state.showTime).toBe(true);
+      expect(state.showStatus).toBe(true);
     });
   });
 
@@ -202,6 +271,8 @@ describe("UIStore", () => {
       useUIStore.getState().toggleEffortVotes();
       useUIStore.getState().toggleFullDate();
       useUIStore.getState().toggleFocusMode();
+      useUIStore.getState().toggleTime();
+      useUIStore.getState().toggleStatus();
 
       const state = useUIStore.getState();
       expect(state.showArchived).toBe(true);
@@ -209,6 +280,8 @@ describe("UIStore", () => {
       expect(state.showEffortVotes).toBe(true);
       expect(state.showFullDateInEffortTimes).toBe(true);
       expect(state.focusMode).toBe(true);
+      expect(state.showTime).toBe(false); // Default is true, so toggle makes it false
+      expect(state.showStatus).toBe(false); // Default is true, so toggle makes it false
     });
   });
 });
@@ -222,6 +295,9 @@ describe("getUIDefaults", () => {
     expect(defaults.showEffortVotes).toBe(false);
     expect(defaults.showFullDateInEffortTimes).toBe(false);
     expect(defaults.focusMode).toBe(false);
+    expect(defaults.showEmptySlots).toBe(true);
+    expect(defaults.showTime).toBe(true);
+    expect(defaults.showStatus).toBe(true);
   });
 
   it("should return a new object each time", () => {


### PR DESCRIPTION
## Summary

Adds the ability to hide/show Time (Start/End) and Status columns in the DailyNote tasks table, following the existing pattern used for Effort Area and Votes columns.

**Changes:**
- Add `showTime` and `showStatus` settings to UIStore with Zustand persist
- Add `toggleTime` and `toggleStatus` actions to UIStore
- Update `DailyTasksTable` to conditionally render Start/End and Status columns based on settings
- Add toggle buttons ("Hide/Show Time" and "Hide/Show Status") to the control panel
- Default values: `showTime=true`, `showStatus=true` (columns visible by default)

## Test plan

- [x] Unit tests pass (`npm run test:unit`)
- [x] TypeScript type check passes (`npm run check:types`)
- [x] Lint passes (only pre-existing warnings)
- [ ] CI pipeline passes
- [ ] Manual verification in Obsidian

## Screenshots

N/A - UI toggle buttons follow existing pattern (same styling as Effort Area/Votes toggles)

Closes #883