### PR TITLE
fix: [P0] Fix overwritten property error in DailyProjectsRenderer test

### DIFF
--- a/packages/obsidian-plugin/tests/unit/DailyProjectsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/DailyProjectsRenderer.test.ts
@@ -418,7 +418,6 @@ describe("DailyProjectsRenderer", () => {
       const projectMetadata = {
         exo__Instance_class: "[[ems__Project]]",
         ems__Effort_day: "[[2025-10-20]]",
-        ems__Effort_startTimestamp: "2025-10-20T09:00:00",
         ems__Effort_status: "[[ems__EffortStatusDoing]]",
         ems__Effort_startTimestamp: "2025-10-20T09:00:00.000Z",
         ems__Effort_endTimestamp: "2025-10-20T17:00:00.000Z",


### PR DESCRIPTION
## Summary

- Removed duplicate `ems__Effort_startTimestamp` property in `DailyProjectsRenderer.test.ts` (line 421)
- Kept the ISO format version with milliseconds (`.000Z`) as the canonical value

## Technical Details

The test object had the same property defined twice:
```typescript
// BEFORE (line 421 & 423):
ems__Effort_startTimestamp: "2025-10-20T09:00:00",    // redundant
ems__Effort_startTimestamp: "2025-10-20T09:00:00.000Z", // kept

// AFTER:
ems__Effort_startTimestamp: "2025-10-20T09:00:00.000Z",
```

## Test Plan

- [x] Unit tests pass (587 tests)
- [x] CodeQL alert #154 resolved

Closes #896