### PR TITLE
fix: [P0] Fix weak cryptography and insecure randomness (6 alerts)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,24 @@
+# CodeQL Configuration for Exocortex
+# This configuration excludes false positives for SPARQL 1.1 specification-mandated functions.
+#
+# The SPARQL 1.1 specification (https://www.w3.org/TR/sparql11-query/) requires implementations
+# to support MD5 and SHA1 hash functions for data hashing purposes:
+# - MD5: https://www.w3.org/TR/sparql11-query/#func-md5
+# - SHA1: https://www.w3.org/TR/sparql11-query/#func-sha1
+#
+# These functions are used for data checksums and content identification,
+# NOT for security purposes (passwords, encryption keys, etc.).
+
+name: "Exocortex CodeQL Configuration"
+
+queries:
+  - uses: security-extended
+  - uses: security-and-quality
+
+query-filters:
+  # Exclude weak cryptographic algorithm alerts for SPARQL 1.1 hash functions.
+  # MD5 and SHA1 are required by SPARQL 1.1 specification for data hashing.
+  - exclude:
+      id: js/weak-cryptographic-algorithm
+      paths:
+        - packages/exocortex/src/infrastructure/sparql/filters/BuiltInFunctions.ts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,8 +38,8 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          # Use default queries plus security-extended
-          queries: security-extended,security-and-quality
+          # Use custom configuration that excludes false positives for SPARQL 1.1 spec-mandated functions
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
## Summary

- Replace `Math.random()` with `crypto.randomBytes()` in BNODE function for cryptographically secure unique ID generation
- Replace `Math.random()` with `crypto.randomBytes()` in RAND function for better randomness quality  
- Add crypto import and remove redundant `require()` calls in hash functions
- Add CodeQL configuration to exclude SPARQL 1.1 spec-mandated MD5/SHA1 hash functions from weak-crypto alerts

## Technical Details

### Insecure Randomness Fixes

The SPARQL BNODE() and RAND() functions previously used `Math.random()` which is not cryptographically secure. Now using `crypto.randomBytes()`:

```typescript
// BNODE: Generate unique blank node ID
const uniqueId = `b${crypto.randomBytes(8).toString("hex")}`;

// RAND: Generate random number in [0, 1)
const randomBytes = crypto.randomBytes(4);
const randomUint32 = randomBytes.readUInt32BE(0);
return randomUint32 / 0x100000000;
```

### Weak Cryptographic Algorithm Handling

MD5 and SHA1 are **required by SPARQL 1.1 specification** for data hashing (not security):
- [MD5 spec](https://www.w3.org/TR/sparql11-query/#func-md5)
- [SHA1 spec](https://www.w3.org/TR/sparql11-query/#func-sha1)

Added CodeQL configuration to exclude these spec-mandated functions from weak-crypto alerts while maintaining security scanning for actual security-sensitive code.

## Test Plan

- [x] Unit tests pass (`npm run test:unit`)
- [x] Type checking passes (`npm run check:types`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)

Closes #898