### PR TITLE
fix: [P1] Fix superfluous trailing arguments (5 alerts)

### DIFF
--- a/packages/exocortex/tests/unit/services/SessionEventService.test.ts
+++ b/packages/exocortex/tests/unit/services/SessionEventService.test.ts
@@ -29,7 +29,7 @@ describe("SessionEventService", () => {
 
     mockVault.exists.mockResolvedValue(true);
 
-    service = new SessionEventService(mockVault, null);
+    service = new SessionEventService(mockVault);
   });
 
   describe("createSessionStartEvent", () => {
@@ -64,7 +64,8 @@ describe("SessionEventService", () => {
     });
 
     it("should use ontology asset folder and isDefinedBy when ontology is set", async () => {
-      const ontologyService = new SessionEventService(mockVault, "kitelev");
+      const ontologyService = new SessionEventService(mockVault);
+      ontologyService.setDefaultOntologyAsset("kitelev");
       const areaName = "Work";
       const mockOntologyFile: IFile = {
         path: "People/kitelev.md",
@@ -256,7 +257,8 @@ describe("SessionEventService", () => {
     });
 
     it("should use ontology asset folder for end events", async () => {
-      const ontologyService = new SessionEventService(mockVault, "myOntology");
+      const ontologyService = new SessionEventService(mockVault);
+      ontologyService.setDefaultOntologyAsset("myOntology");
       const areaName = "Work";
       const mockOntologyFile: IFile = {
         path: "Ontologies/myOntology.md",
@@ -286,7 +288,8 @@ describe("SessionEventService", () => {
     });
 
     it("should create ontology folder if it does not exist", async () => {
-      const ontologyService = new SessionEventService(mockVault, "myOntology");
+      const ontologyService = new SessionEventService(mockVault);
+      ontologyService.setDefaultOntologyAsset("myOntology");
       const areaName = "Work";
       const mockOntologyFile: IFile = {
         path: "Ontologies/myOntology.md",

--- a/packages/exocortex/tests/unit/services/URIConstructionService.test.ts
+++ b/packages/exocortex/tests/unit/services/URIConstructionService.test.ts
@@ -64,9 +64,8 @@ describe("URIConstructionService", () => {
     });
 
     it("should use fallback for missing UID in non-strict mode", async () => {
-      const serviceNonStrict = new URIConstructionService(mockFileSystem, {
-        strictValidation: false,
-      });
+      const serviceNonStrict = new URIConstructionService(mockFileSystem);
+      serviceNonStrict.configure({ strictValidation: false });
 
       const asset = {
         path: "Tasks/review-pr.md",


### PR DESCRIPTION
## Summary
- Fixes 5 CodeQL alerts for superfluous trailing arguments in test constructors
- Updates test patterns to use correct API methods instead of passing extra constructor arguments

## Changes
- `SessionEventService.test.ts`: Use `setDefaultOntologyAsset()` method instead of constructor argument
- `URIConstructionService.test.ts`: Use `configure()` method instead of constructor argument

## Technical Details
The CodeQL alert `js/superfluous-trailing-arguments` flagged function calls with extra arguments that were being silently ignored:

| File | Line | Fix |
|------|------|-----|
| SessionEventService.test.ts | 32 | Remove `null` argument |
| SessionEventService.test.ts | 67 | Use `setDefaultOntologyAsset("kitelev")` |
| SessionEventService.test.ts | 259 | Use `setDefaultOntologyAsset("myOntology")` |
| SessionEventService.test.ts | 289 | Use `setDefaultOntologyAsset("myOntology")` |
| URIConstructionService.test.ts | 67 | Use `configure({ strictValidation: false })` |

## Test plan
- [x] All unit tests pass locally (587 passed)
- [x] TypeScript type checking passes
- [x] ESLint passes (pre-existing warnings only)

Closes #899