### PR TITLE
fix: [P1] Fix superfluous trailing arguments (10 alerts)

### DIFF
--- a/packages/exocortex/tests/unit/services/SessionEventService.test.ts
+++ b/packages/exocortex/tests/unit/services/SessionEventService.test.ts
@@ -29,7 +29,7 @@ describe("SessionEventService", () => {
 
     mockVault.exists.mockResolvedValue(true);
 
-    service = new SessionEventService(mockVault, null);
+    service = new SessionEventService(mockVault);
   });
 
   describe("createSessionStartEvent", () => {
@@ -64,7 +64,8 @@ describe("SessionEventService", () => {
     });
 
     it("should use ontology asset folder and isDefinedBy when ontology is set", async () => {
-      const ontologyService = new SessionEventService(mockVault, "kitelev");
+      const ontologyService = new SessionEventService(mockVault);
+      ontologyService.setDefaultOntologyAsset("kitelev");
       const areaName = "Work";
       const mockOntologyFile: IFile = {
         path: "People/kitelev.md",
@@ -256,7 +257,8 @@ describe("SessionEventService", () => {
     });
 
     it("should use ontology asset folder for end events", async () => {
-      const ontologyService = new SessionEventService(mockVault, "myOntology");
+      const ontologyService = new SessionEventService(mockVault);
+      ontologyService.setDefaultOntologyAsset("myOntology");
       const areaName = "Work";
       const mockOntologyFile: IFile = {
         path: "Ontologies/myOntology.md",
@@ -286,7 +288,8 @@ describe("SessionEventService", () => {
     });
 
     it("should create ontology folder if it does not exist", async () => {
-      const ontologyService = new SessionEventService(mockVault, "myOntology");
+      const ontologyService = new SessionEventService(mockVault);
+      ontologyService.setDefaultOntologyAsset("myOntology");
       const areaName = "Work";
       const mockOntologyFile: IFile = {
         path: "Ontologies/myOntology.md",

--- a/packages/exocortex/tests/unit/services/URIConstructionService.test.ts
+++ b/packages/exocortex/tests/unit/services/URIConstructionService.test.ts
@@ -64,9 +64,8 @@ describe("URIConstructionService", () => {
     });
 
     it("should use fallback for missing UID in non-strict mode", async () => {
-      const serviceNonStrict = new URIConstructionService(mockFileSystem, {
-        strictValidation: false,
-      });
+      const serviceNonStrict = new URIConstructionService(mockFileSystem);
+      serviceNonStrict.configure({ strictValidation: false });
 
       const asset = {
         path: "Tasks/review-pr.md",


### PR DESCRIPTION
## Summary

Fix CodeQL alerts `js/superfluous-trailing-arguments` by updating test files to use the correct API pattern for configuring services.

### Changes

- **SessionEventService.test.ts**: Replace constructor's second argument with `setDefaultOntologyAsset()` method calls (4 occurrences)
- **URIConstructionService.test.ts**: Replace constructor's second argument with `configure()` method call (1 occurrence)

### Root Cause

Both services were refactored at some point to use dependency injection via `tsyringe`, which only allows constructor parameters decorated with `@inject()`. Configuration options were moved to separate methods:
- `SessionEventService.setDefaultOntologyAsset(asset: string | null)`
- `URIConstructionService.configure(options: URIConstructionOptions)`

The tests were not updated to reflect this API change, resulting in extra arguments being passed to constructors that ignore them.

### Verification

- ✅ All obsidian-plugin unit tests pass (151 test suites)
- ✅ All CLI tests pass (33 test suites)
- ✅ TypeScript compilation successful
- ✅ Lint checks pass

Closes #899