### PR TITLE
fix: [P1] Fix superfluous trailing arguments (5 alerts)

### DIFF
--- a/packages/exocortex/tests/unit/services/SessionEventService.test.ts
+++ b/packages/exocortex/tests/unit/services/SessionEventService.test.ts
@@ -29,7 +29,7 @@ describe("SessionEventService", () => {
 
     mockVault.exists.mockResolvedValue(true);
 
-    service = new SessionEventService(mockVault, null);
+    service = new SessionEventService(mockVault);
   });
 
   describe("createSessionStartEvent", () => {
@@ -64,7 +64,8 @@ describe("SessionEventService", () => {
     });
 
     it("should use ontology asset folder and isDefinedBy when ontology is set", async () => {
-      const ontologyService = new SessionEventService(mockVault, "kitelev");
+      const ontologyService = new SessionEventService(mockVault);
+      ontologyService.setDefaultOntologyAsset("kitelev");
       const areaName = "Work";
       const mockOntologyFile: IFile = {
         path: "People/kitelev.md",
@@ -256,7 +257,8 @@ describe("SessionEventService", () => {
     });
 
     it("should use ontology asset folder for end events", async () => {
-      const ontologyService = new SessionEventService(mockVault, "myOntology");
+      const ontologyService = new SessionEventService(mockVault);
+      ontologyService.setDefaultOntologyAsset("myOntology");
       const areaName = "Work";
       const mockOntologyFile: IFile = {
         path: "Ontologies/myOntology.md",
@@ -286,7 +288,8 @@ describe("SessionEventService", () => {
     });
 
     it("should create ontology folder if it does not exist", async () => {
-      const ontologyService = new SessionEventService(mockVault, "myOntology");
+      const ontologyService = new SessionEventService(mockVault);
+      ontologyService.setDefaultOntologyAsset("myOntology");
       const areaName = "Work";
       const mockOntologyFile: IFile = {
         path: "Ontologies/myOntology.md",

--- a/packages/exocortex/tests/unit/services/URIConstructionService.test.ts
+++ b/packages/exocortex/tests/unit/services/URIConstructionService.test.ts
@@ -64,9 +64,8 @@ describe("URIConstructionService", () => {
     });
 
     it("should use fallback for missing UID in non-strict mode", async () => {
-      const serviceNonStrict = new URIConstructionService(mockFileSystem, {
-        strictValidation: false,
-      });
+      const serviceNonStrict = new URIConstructionService(mockFileSystem);
+      serviceNonStrict.configure({ strictValidation: false });
 
       const asset = {
         path: "Tasks/review-pr.md",


### PR DESCRIPTION
## Summary

Fixes 5 CodeQL `js/superfluous-trailing-arguments` alerts by updating test files to use proper service APIs instead of passing unused constructor arguments.

### Changes

1. **SessionEventService.test.ts** (4 alerts)
   - Removed second argument from `new SessionEventService(mockVault, null)`
   - Changed `new SessionEventService(mockVault, "ontologyName")` to use `setDefaultOntologyAsset("ontologyName")` method

2. **URIConstructionService.test.ts** (1 alert)
   - Changed `new URIConstructionService(mockFileSystem, { strictValidation: false })` to use `configure({ strictValidation: false })` method

### Root Cause

The service constructors were refactored to use setter/configure methods, but the tests continued to pass extra arguments that were silently ignored.

## Test plan

- [x] Unit tests pass locally
- [x] Build succeeds
- [ ] CI passes

Closes #899