### PR TITLE
fix: [P1] resolve code quality warnings (CodeQL alerts)

### DIFF
--- a/packages/cli/src/executors/BatchExecutor.ts
+++ b/packages/cli/src/executors/BatchExecutor.ts
@@ -101,7 +101,6 @@ export class BatchExecutor {
     const results: BatchOperationResult[] = [];
     let succeeded = 0;
     let failed = 0;
-    let rolledBack = false;
 
     if (operations.length === 0) {
       return {
@@ -179,7 +178,8 @@ export class BatchExecutor {
     }
 
     // Commit transaction if atomic mode and all succeeded
-    if (atomic && !this.dryRun && !rolledBack) {
+    // Note: If we reach here, no rollback occurred (early return on rollback)
+    if (atomic && !this.dryRun) {
       await this.transactionManager.commit();
     }
 
@@ -193,7 +193,7 @@ export class BatchExecutor {
       results,
       durationMs: Date.now() - startTime,
       atomic,
-      ...(atomic && { rolledBack }),
+      ...(atomic && { rolledBack: false }),
     };
   }
 

--- a/packages/obsidian-plugin/specs/step_definitions/instance-class-links.steps.ts
+++ b/packages/obsidian-plugin/specs/step_definitions/instance-class-links.steps.ts
@@ -161,8 +161,9 @@ Then(
 Then("Instance Class column displays {string}", function (this: ExocortexWorld, expectedText: string) {
   const instanceClass = this.currentNote?.frontmatter.exo__Instance_class;
   if (expectedText === "-" || expectedText === "") {
+    // Check for empty/falsy instance class (null, undefined, or empty string)
     assert.ok(
-      !instanceClass || instanceClass === "" || instanceClass === null,
+      !instanceClass || instanceClass === "",
       "Expected empty or null instance class",
     );
   } else {
@@ -172,8 +173,9 @@ Then("Instance Class column displays {string}", function (this: ExocortexWorld, 
 
 Then("Instance Class column is empty", function (this: ExocortexWorld) {
   const instanceClass = this.currentNote?.frontmatter.exo__Instance_class;
+  // Check for empty/falsy instance class (null, undefined, or empty string)
   assert.ok(
-    !instanceClass || instanceClass === "" || instanceClass === null,
+    !instanceClass || instanceClass === "",
     "Instance class should be empty",
   );
 });

--- a/packages/obsidian-plugin/tests/e2e/utils/obsidian-launcher.ts
+++ b/packages/obsidian-plugin/tests/e2e/utils/obsidian-launcher.ts
@@ -119,11 +119,10 @@ export class ObsidianLauncher {
       "[ObsidianLauncher] DOM loaded, waiting for window.app to become available...",
     );
 
-    let pollCount = 0;
     const maxPolls = 60;
     let appFound = false;
 
-    while (pollCount < maxPolls && !appFound) {
+    for (let pollCount = 0; pollCount < maxPolls; pollCount++) {
       const pollResult = await this.window.evaluate(() => {
         const win = window as any;
         return {
@@ -150,7 +149,6 @@ export class ObsidianLauncher {
       }
 
       await this.window.waitForTimeout(1000);
-      pollCount++;
     }
 
     if (!appFound) {


### PR DESCRIPTION
## Summary

Fixes 4 actionable CodeQL code quality alerts:

- **BatchExecutor.ts**: Remove unused `rolledBack` variable and trivial `!rolledBack` check
  - The variable was initialized to `false` and never modified before the check at line 182
  - Early return at line 176 handles the rollback case, making the variable always `false`
  
- **obsidian-launcher.ts**: Convert `while` loop with `!appFound` to `for` loop
  - Eliminates trivial conditional that was flagged as "always evaluates to true" 
  - Logic preserved: loop breaks when app is found via `break` statement
  
- **instance-class-links.steps.ts**: Remove redundant `=== null` comparisons
  - The `!instanceClass` falsy check already covers null values
  - Removes 2 type-incompatible comparisons (string vs null)

## What's Not Fixed

9 alerts in `main.js` are from bundled React 19.2.0 internals (minified variable names like `x6`, `y5`, `n2`). These are third-party code issues, not our source code.

## Test Results

- ✅ All 606 unit tests pass
- ✅ Build succeeds
- ✅ Lint passes (7 pre-existing warnings unrelated to these changes)

Closes #901