### PR TITLE
chore: improve CodeQL config to prevent main.js alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -17,7 +17,10 @@ paths-ignore:
   - "**/*.test.ts"
   - "**/*.test.tsx"
   - "**/*.spec.ts"
-  - "packages/obsidian-plugin/main.js"  # Generated bundled output
+  - "packages/obsidian-plugin/main.js"      # Generated bundled output
+  - "packages/obsidian-plugin/main.js.map"  # Source maps
+  - "**/debug-main.js"                      # Debug builds
+  - "**/debug-main.ts"                      # Debug builds
 
 # Query filters to suppress intentional false positives
 query-filters:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,8 +43,9 @@ jobs:
           # Use custom config to handle SPARQL 1.1 spec-required patterns
           config-file: ./.github/codeql/codeql-config.yml
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      # Note: For JavaScript/TypeScript, CodeQL can analyze source directly
+      # without autobuild. Skipping autobuild prevents analysis of generated
+      # bundled files (main.js) which contain third-party library code.
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

Improves CodeQL configuration to prevent future false positive alerts from bundled main.js:

1. **Skip autobuild step** - For JavaScript/TypeScript, CodeQL can analyze source directly without building. This prevents main.js from being generated during analysis.

2. **Additional exclusions** - Added exclusions for:
   - `main.js.map` - Source maps
   - `debug-main.js` - Debug builds
   - `debug-main.ts` - Debug build sources

## Background

After fixing the 13 code quality alerts in #916, there were still 75+ alerts in `main.js` from bundled third-party code (reflect-metadata, sparqljs, etc.). While these are already in `paths-ignore`, the autobuild step was generating main.js during analysis, leading to continued alerts.

## Test plan

- [x] No source code changes
- [ ] CI pipeline passes
- [ ] CodeQL scan runs without main.js alerts