### PR TITLE
fix: [P1] Fix incomplete sanitization (2 alerts)

### DIFF
--- a/packages/obsidian-plugin/specs/step_definitions/area-task-creation.steps.ts
+++ b/packages/obsidian-plugin/specs/step_definitions/area-task-creation.steps.ts
@@ -169,8 +169,8 @@ Then(
     const baseName = this.lastCreatedNote?.file.basename || "";
     const formatRegex = nameFormat
       .replace("{timestamp}", "\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}")
-      .replace("{", "\\{")
-      .replace("}", "\\}");
+      .replace(/\{/g, "\\{")
+      .replace(/\}/g, "\\}");
     assert.ok(
       new RegExp(formatRegex).test(baseName) || baseName.startsWith("Task"),
       `Note name "${baseName}" should match format "${nameFormat}"`,


### PR DESCRIPTION
## Summary

- Uses regex with global flag (`/g`) instead of string literals in `.replace()` calls
- Fixes CodeQL alert `js/incomplete-sanitization` (2 alerts) in `area-task-creation.steps.ts`
- The issue was that `.replace("{", "\\{")` only replaces the first occurrence

## Changes

- Changed `.replace("{", "\\{")` to `.replace(/\{/g, "\\{")`
- Changed `.replace("}", "\\}")` to `.replace(/\}/g, "\\}")`

## Test Plan

- [x] Unit tests pass (`npm run test:unit`)
- [x] Lint check passes (`npm run lint`)
- [x] All checks pass (`npm run check:all`)

Closes #902