### PR TITLE
fix: [P1] Fix incomplete sanitization (2 alerts)

### DIFF
--- a/packages/obsidian-plugin/specs/step_definitions/area-task-creation.steps.ts
+++ b/packages/obsidian-plugin/specs/step_definitions/area-task-creation.steps.ts
@@ -169,8 +169,8 @@ Then(
     const baseName = this.lastCreatedNote?.file.basename || "";
     const formatRegex = nameFormat
       .replace("{timestamp}", "\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}")
-      .replace("{", "\\{")
-      .replace("}", "\\}");
+      .replace(/\{/g, "\\{")
+      .replace(/\}/g, "\\}");
     assert.ok(
       new RegExp(formatRegex).test(baseName) || baseName.startsWith("Task"),
       `Note name "${baseName}" should match format "${nameFormat}"`,


### PR DESCRIPTION
## Summary
- Uses global regex (`/\{/g` and `/\}/g`) instead of string literals for replacing curly braces
- Ensures all occurrences are escaped, not just the first one

This fixes CodeQL alerts #2 and #3 (`js/incomplete-sanitization`) in `packages/obsidian-plugin/specs/step_definitions/area-task-creation.steps.ts`.

## Technical Details

**Before (only first occurrence replaced):**
```typescript
.replace("{", "\\{")
.replace("}", "\\}")
```

**After (all occurrences replaced):**
```typescript
.replace(/\{/g, "\\{")
.replace(/\}/g, "\\}")
```

## Test Plan
- [x] Unit tests pass locally
- [ ] CI pipeline passes

Closes #902