### PR TITLE
fix(cli): [P2] Remove unused variables in source code (~6 alerts)

### DIFF
--- a/packages/cli/src/commands/batch-repair.ts
+++ b/packages/cli/src/commands/batch-repair.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { resolve, relative, join } from "path";
+import { resolve } from "path";
 import { BatchExecutor, type BatchResult, type BatchOperation } from "../executors/BatchExecutor.js";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
@@ -145,7 +145,6 @@ export function batchRepairCommand(): Command {
         }
 
         // Execute batch with custom progress tracking
-        const startTime = Date.now();
         const executor = new BatchExecutor(vaultPath, options.dryRun);
 
         // We can't directly hook into BatchExecutor's progress, so we'll use the results

--- a/packages/cli/src/executors/BatchExecutor.ts
+++ b/packages/cli/src/executors/BatchExecutor.ts
@@ -3,12 +3,7 @@ import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { PathResolver } from "../utils/PathResolver.js";
 import { FrontmatterService, DateFormatter } from "exocortex";
 import { TransactionManager } from "../utils/TransactionManager.js";
-import { ExitCodes } from "../utils/ExitCodes.js";
-import {
-  FileNotFoundError,
-  InvalidArgumentsError,
-  OperationFailedError,
-} from "../utils/errors/index.js";
+import { InvalidArgumentsError } from "../utils/errors/index.js";
 
 /**
  * Represents a single operation in a batch
@@ -272,8 +267,8 @@ export class BatchExecutor {
         "",
       );
 
-      // Read file to verify it exists
-      const content = await this.fsAdapter.readFile(relativePath);
+      // Read file to verify it exists (throws if not found)
+      await this.fsAdapter.readFile(relativePath);
 
       if (this.dryRun) {
         return {

--- a/packages/cli/src/utils/ErrorHandler.ts
+++ b/packages/cli/src/utils/ErrorHandler.ts
@@ -2,7 +2,6 @@ import { ExitCodes } from "./ExitCodes.js";
 import { CLIError } from "./errors/CLIError.js";
 import {
   ErrorCode,
-  ErrorCategory,
   ResponseBuilder,
   type StructuredErrorResponse,
 } from "../responses/index.js";


### PR DESCRIPTION
## Summary

Removes unused variables and imports detected by CodeQL in CLI source files:

- **batch-repair.ts**: Removed unused `join`, `relative` imports and `startTime` variable
- **ErrorHandler.ts**: Removed unused `ErrorCategory` import  
- **BatchExecutor.ts**: Removed unused `ExitCodes`, `FileNotFoundError`, `OperationFailedError` imports and `content` variable

## Test Plan

- [x] All unit tests pass (587 passed)
- [x] Build succeeds
- [x] Lint passes (only pre-existing warnings)

Closes #903