### PR TITLE
fix(tests): [P3] Remove unused variables in tests (~30 files)

### DIFF
--- a/packages/cli/tests/integration/watch.integration.test.ts
+++ b/packages/cli/tests/integration/watch.integration.test.ts
@@ -1,11 +1,4 @@
-import {
-  jest,
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-} from "@jest/globals";
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { spawn, ChildProcess } from "child_process";
 import * as fs from "fs";
 import * as path from "path";

--- a/packages/cli/tests/unit/adapters/NodeFsAdapter.test.ts
+++ b/packages/cli/tests/unit/adapters/NodeFsAdapter.test.ts
@@ -334,7 +334,7 @@ aliases:
     it("should accept custom root path", async () => {
       mockGlob.mockResolvedValue(["/test/vault/custom/file.md"]);
 
-      const result = await adapter.getMarkdownFiles("custom");
+      await adapter.getMarkdownFiles("custom");
 
       expect(mockGlob).toHaveBeenCalledWith(
         expect.stringContaining("/test/vault/custom/**/*.md"),

--- a/packages/cli/tests/unit/commands/batch-repair.test.ts
+++ b/packages/cli/tests/unit/commands/batch-repair.test.ts
@@ -1,11 +1,4 @@
-import {
-  jest,
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-} from "@jest/globals";
+import { describe, it, expect } from "@jest/globals";
 
 // Import the command creator
 import { batchRepairCommand } from "../../../src/commands/batch-repair.js";

--- a/packages/cli/tests/unit/commands/sparql-query.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query.test.ts
@@ -1,6 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs";
-import { SolutionMapping, IRI, Literal } from "exocortex";
 
 // Mock dependencies
 const mockTableFormatter = {

--- a/packages/cli/tests/unit/commands/watch.test.ts
+++ b/packages/cli/tests/unit/commands/watch.test.ts
@@ -1,11 +1,4 @@
-import {
-  jest,
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-} from "@jest/globals";
+import { describe, it, expect } from "@jest/globals";
 
 import { watchCommand } from "../../../src/commands/watch.js";
 

--- a/packages/cli/tests/unit/executors/BatchExecutor.test.ts
+++ b/packages/cli/tests/unit/executors/BatchExecutor.test.ts
@@ -6,7 +6,6 @@ import {
   beforeEach,
   afterEach,
 } from "@jest/globals";
-import { ExitCodes } from "../../../src/utils/ExitCodes.js";
 
 // Mock dependencies before importing BatchExecutor
 const mockPathResolverInstance = {

--- a/packages/cli/tests/unit/executors/CommandExecutor.test.ts
+++ b/packages/cli/tests/unit/executors/CommandExecutor.test.ts
@@ -1,4 +1,4 @@
-import { jest, describe, it, expect, beforeEach, afterEach, beforeAll } from "@jest/globals";
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { ExitCodes } from "../../../src/utils/ExitCodes.js";
 
 // Mock dependencies before importing CommandExecutor

--- a/packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts
+++ b/packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts
@@ -80,9 +80,8 @@ jest.unstable_mockModule("exocortex", () => ({
 }));
 
 // Dynamic import after mocks
-const { FolderRepairExecutor } = await import(
-  "../../../src/executors/commands/FolderRepairExecutor.js"
-);
+// FolderRepairExecutor is indirectly used through CommandExecutor.executeRepairFolder()
+await import("../../../src/executors/commands/FolderRepairExecutor.js");
 const { CommandExecutor } = await import("../../../src/executors/CommandExecutor.js");
 
 describe("FolderRepairExecutor", () => {

--- a/packages/cli/tests/unit/utils/TransactionManager.test.ts
+++ b/packages/cli/tests/unit/utils/TransactionManager.test.ts
@@ -1,6 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
-import crypto from "crypto";
 
 const { TransactionManager } = await import("../../../src/utils/TransactionManager.js");
 

--- a/packages/cli/tests/unit/utils/errors/CLIError.test.ts
+++ b/packages/cli/tests/unit/utils/errors/CLIError.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "@jest/globals";
+import { describe, it, expect } from "@jest/globals";
 import { ExitCodes } from "../../../../src/utils/ExitCodes.js";
 import { ErrorCode } from "../../../../src/responses/index.js";
 

--- a/packages/exocortex/tests/integration/sparql/query-pipeline.test.ts
+++ b/packages/exocortex/tests/integration/sparql/query-pipeline.test.ts
@@ -18,11 +18,7 @@ import { Literal } from "../../../src/domain/models/rdf/Literal";
 
 // Standard namespace URIs
 const RDF_TYPE = new IRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
-const RDFS_LABEL = new IRI("http://www.w3.org/2000/01/rdf-schema#label");
-const RDFS_SUBCLASS_OF = new IRI("http://www.w3.org/2000/01/rdf-schema#subClassOf");
 const XSD_STRING = new IRI("http://www.w3.org/2001/XMLSchema#string");
-const XSD_INTEGER = new IRI("http://www.w3.org/2001/XMLSchema#integer");
-const XSD_DATE = new IRI("http://www.w3.org/2001/XMLSchema#date");
 const XSD_DATETIME = new IRI("http://www.w3.org/2001/XMLSchema#dateTime");
 
 // Exocortex-specific namespaces

--- a/packages/exocortex/tests/integration/sparql/real-world-patterns.test.ts
+++ b/packages/exocortex/tests/integration/sparql/real-world-patterns.test.ts
@@ -19,9 +19,7 @@ import { Literal } from "../../../src/domain/models/rdf/Literal";
 // Standard namespace URIs
 const RDF_TYPE = new IRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
 const XSD_STRING = new IRI("http://www.w3.org/2001/XMLSchema#string");
-const XSD_INTEGER = new IRI("http://www.w3.org/2001/XMLSchema#integer");
 const XSD_DATETIME = new IRI("http://www.w3.org/2001/XMLSchema#dateTime");
-const XSD_DECIMAL = new IRI("http://www.w3.org/2001/XMLSchema#decimal");
 
 // Exocortex-specific namespaces
 const EXO = "https://exocortex.my/ontology/exo#";
@@ -38,8 +36,6 @@ const EMS_EFFORT_STATUS = new IRI(`${EMS}Effort_status`);
 const EMS_EFFORT_PARENT = new IRI(`${EMS}Effort_parent`);
 const EMS_EFFORT_START_TIMESTAMP = new IRI(`${EMS}Effort_startTimestamp`);
 const EMS_EFFORT_END_TIMESTAMP = new IRI(`${EMS}Effort_endTimestamp`);
-const EMS_VOTE_VALUE = new IRI(`${EMS}Vote_value`);
-const EMS_VOTE_TIMESTAMP = new IRI(`${EMS}Vote_timestamp`);
 
 describe("Real-World SPARQL Query Patterns", () => {
   let parser: SPARQLParser;

--- a/packages/exocortex/tests/performance/SPARQLQueryPerformance.test.ts
+++ b/packages/exocortex/tests/performance/SPARQLQueryPerformance.test.ts
@@ -151,8 +151,6 @@ describe("SPARQL Query Performance", () => {
   };
 
   describe("Small dataset (1K triples)", () => {
-    const TRIPLE_COUNT = 1000;
-
     beforeAll(async () => {
       store = new InMemoryTripleStore();
       executor = new QueryExecutor(store);

--- a/packages/exocortex/tests/services/DynamicFrontmatterGenerator.test.ts
+++ b/packages/exocortex/tests/services/DynamicFrontmatterGenerator.test.ts
@@ -1,5 +1,4 @@
 import { DynamicFrontmatterGenerator, PropertyDefinition, PropertyFieldType } from "../../src/services/DynamicFrontmatterGenerator";
-import { DateFormatter } from "../../src/utilities/DateFormatter";
 
 describe("DynamicFrontmatterGenerator", () => {
   let generator: DynamicFrontmatterGenerator;

--- a/packages/exocortex/tests/unit/application/errors/ApplicationErrorHandler.test.ts
+++ b/packages/exocortex/tests/unit/application/errors/ApplicationErrorHandler.test.ts
@@ -6,7 +6,6 @@ import {
 import {
   NetworkError,
   ValidationError,
-  ApplicationError,
 } from "../../../../src/domain/errors/index.js";
 
 describe("ApplicationErrorHandler", () => {
@@ -112,8 +111,6 @@ describe("ApplicationErrorHandler", () => {
         backoffMultiplier: 2,
         maxDelayMs: 10000,
       });
-
-      const delays: number[] = [];
       const operation = jest
         .fn()
         .mockImplementation(

--- a/packages/exocortex/tests/unit/domain/rdf/Namespace.test.ts
+++ b/packages/exocortex/tests/unit/domain/rdf/Namespace.test.ts
@@ -1,5 +1,4 @@
 import { Namespace } from "../../../../src/domain/models/rdf/Namespace";
-import { IRI } from "../../../../src/domain/models/rdf/IRI";
 
 describe("Namespace", () => {
   describe("constructor", () => {

--- a/packages/exocortex/tests/unit/infrastructure/rdf/InMemoryTripleStore.error.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/rdf/InMemoryTripleStore.error.test.ts
@@ -14,7 +14,6 @@ import { InMemoryTripleStore } from "../../../../src/infrastructure/rdf/InMemory
 import { Triple } from "../../../../src/domain/models/rdf/Triple";
 import { IRI } from "../../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../../src/domain/models/rdf/Literal";
-import { BlankNode } from "../../../../src/domain/models/rdf/BlankNode";
 
 describe("InMemoryTripleStore Edge Cases", () => {
   let store: InMemoryTripleStore;

--- a/packages/exocortex/tests/unit/infrastructure/rdf/InMemoryTripleStore.rdf-mapping.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/rdf/InMemoryTripleStore.rdf-mapping.test.ts
@@ -1,7 +1,5 @@
 import { InMemoryTripleStore } from "../../../../src/infrastructure/rdf/InMemoryTripleStore";
 import { RDFVocabularyMapper } from "../../../../src/infrastructure/rdf/RDFVocabularyMapper";
-import { Triple } from "../../../../src/domain/models/rdf/Triple";
-import { IRI } from "../../../../src/domain/models/rdf/IRI";
 import { Namespace } from "../../../../src/domain/models/rdf/Namespace";
 
 describe("InMemoryTripleStore RDF/RDFS Mapping Integration", () => {

--- a/packages/exocortex/tests/unit/infrastructure/rdf/RDFVocabularyMapper.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/rdf/RDFVocabularyMapper.test.ts
@@ -1,5 +1,4 @@
 import { RDFVocabularyMapper } from "../../../../src/infrastructure/rdf/RDFVocabularyMapper";
-import { Namespace } from "../../../../src/domain/models/rdf/Namespace";
 import { IRI } from "../../../../src/domain/models/rdf/IRI";
 
 describe("RDFVocabularyMapper", () => {

--- a/packages/exocortex/tests/unit/infrastructure/sparql/AlgebraOptimizer.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/AlgebraOptimizer.test.ts
@@ -227,7 +227,7 @@ describe("AlgebraOptimizer", () => {
     it("estimates cost for BGP operations", () => {
       const query = "SELECT ?s ?p ?o WHERE { ?s ?p ?o }";
       const ast = parser.parse(query);
-      const algebra = translator.translate(ast);
+      translator.translate(ast);
 
       expect(optimizer).toBeTruthy();
     });

--- a/packages/exocortex/tests/unit/infrastructure/sparql/SPARQLParser.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/SPARQLParser.test.ts
@@ -1,4 +1,4 @@
-import { SPARQLParser, SPARQLParseError, SelectQuery, ConstructQuery } from "../../../../src/infrastructure/sparql/SPARQLParser";
+import { SPARQLParser, SPARQLParseError, SelectQuery } from "../../../../src/infrastructure/sparql/SPARQLParser";
 
 describe("SPARQLParser", () => {
   let parser: SPARQLParser;

--- a/packages/exocortex/tests/unit/infrastructure/sparql/aggregates/AggregateFunctions.error.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/aggregates/AggregateFunctions.error.test.ts
@@ -15,13 +15,9 @@ import { AggregateFunctions } from "../../../../../src/infrastructure/sparql/agg
 import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
 import { IRI } from "../../../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../../../src/domain/models/rdf/Literal";
-import { BlankNode } from "../../../../../src/domain/models/rdf/BlankNode";
 
 describe("AggregateFunctions Error Scenarios", () => {
   const xsdInt = new IRI("http://www.w3.org/2001/XMLSchema#integer");
-  const xsdDecimal = new IRI("http://www.w3.org/2001/XMLSchema#decimal");
-  const xsdDouble = new IRI("http://www.w3.org/2001/XMLSchema#double");
-  const xsdString = new IRI("http://www.w3.org/2001/XMLSchema#string");
 
   describe("COUNT edge cases", () => {
     it("should return 0 for empty solution set", () => {

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/BGPExecutor.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/BGPExecutor.test.ts
@@ -1,9 +1,9 @@
-import { BGPExecutor, BGPExecutorError } from "../../../../../src/infrastructure/sparql/executors/BGPExecutor";
+import { BGPExecutor } from "../../../../../src/infrastructure/sparql/executors/BGPExecutor";
 import { InMemoryTripleStore } from "../../../../../src/infrastructure/rdf/InMemoryTripleStore";
 import { Triple } from "../../../../../src/domain/models/rdf/Triple";
 import { IRI } from "../../../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../../../src/domain/models/rdf/Literal";
-import type { BGPOperation, PropertyPath } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import type { BGPOperation } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
 
 describe("BGPExecutor", () => {
   let tripleStore: InMemoryTripleStore;

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.error.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.error.test.ts
@@ -19,10 +19,6 @@ import type { FilterOperation } from "../../../../../src/infrastructure/sparql/a
 describe("FilterExecutor Error Scenarios", () => {
   let executor: FilterExecutor;
   const xsdInt = new IRI("http://www.w3.org/2001/XMLSchema#integer");
-  const xsdDouble = new IRI("http://www.w3.org/2001/XMLSchema#double");
-  const xsdDecimal = new IRI("http://www.w3.org/2001/XMLSchema#decimal");
-  const xsdString = new IRI("http://www.w3.org/2001/XMLSchema#string");
-  const xsdDateTime = new IRI("http://www.w3.org/2001/XMLSchema#dateTime");
 
   beforeEach(() => {
     executor = new FilterExecutor();

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.test.ts
@@ -1,8 +1,8 @@
-import { FilterExecutor, ExistsEvaluator } from "../../../../../src/infrastructure/sparql/executors/FilterExecutor";
+import { FilterExecutor } from "../../../../../src/infrastructure/sparql/executors/FilterExecutor";
 import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
 import { IRI } from "../../../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../../../src/domain/models/rdf/Literal";
-import type { FilterOperation, AlgebraOperation, ExistsExpression, InExpression } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import type { FilterOperation } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
 
 describe("FilterExecutor", () => {
   let executor: FilterExecutor;

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/PropertyPathExecutor.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/PropertyPathExecutor.test.ts
@@ -1,4 +1,4 @@
-import { PropertyPathExecutor, PropertyPathExecutorError } from "../../../../../src/infrastructure/sparql/executors/PropertyPathExecutor";
+import { PropertyPathExecutor } from "../../../../../src/infrastructure/sparql/executors/PropertyPathExecutor";
 import type { ITripleStore } from "../../../../../src/interfaces/ITripleStore";
 import { Triple } from "../../../../../src/domain/models/rdf/Triple";
 import { IRI } from "../../../../../src/domain/models/rdf/IRI";

--- a/packages/exocortex/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.error.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.error.test.ts
@@ -13,7 +13,6 @@
 import { BuiltInFunctions } from "../../../../../src/infrastructure/sparql/filters/BuiltInFunctions";
 import { IRI } from "../../../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../../../src/domain/models/rdf/Literal";
-import { BlankNode } from "../../../../../src/domain/models/rdf/BlankNode";
 
 describe("BuiltInFunctions Error Scenarios", () => {
   describe("STR function errors", () => {

--- a/packages/obsidian-plugin/tests/ui/ActionButtonsLayout.ui.test.ts
+++ b/packages/obsidian-plugin/tests/ui/ActionButtonsLayout.ui.test.ts
@@ -2,14 +2,10 @@ import "reflect-metadata";
 import { container } from "tsyringe";
 import { TFile, Vault, MetadataCache } from "obsidian";
 import { UniversalLayoutRenderer } from "../../src/presentation/renderers/UniversalLayoutRenderer";
-import {
-  ExocortexSettings,
-  DEFAULT_SETTINGS,
-} from "../../src/domain/settings/ExocortexSettings";
+import { DEFAULT_SETTINGS } from "../../src/domain/settings/ExocortexSettings";
 import { flushPromises } from "../unit/helpers/testHelpers";
 import {
   DI_TOKENS,
-  IVaultAdapter,
   registerCoreServices,
   resetContainer,
 } from "exocortex";

--- a/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
+++ b/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
@@ -9,14 +9,13 @@
 
 import "reflect-metadata";
 import { container } from "tsyringe";
-import { App, TFile, MarkdownPostProcessorContext } from "obsidian";
+import { App, TFile } from "obsidian";
 import { UniversalLayoutRenderer } from "../../src/presentation/renderers/UniversalLayoutRenderer";
 import { FileBuilder, ListBuilder } from "./helpers/FileBuilder";
 import { DEFAULT_SETTINGS } from "../../src/domain/settings/ExocortexSettings";
 import { waitForReact, waitForDomElement } from "../unit/helpers/testHelpers";
 import {
   DI_TOKENS,
-  IVaultAdapter,
   registerCoreServices,
   resetContainer,
 } from "exocortex";

--- a/packages/obsidian-plugin/tests/unit/RDFToGraphDataConverter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RDFToGraphDataConverter.test.ts
@@ -1,5 +1,5 @@
 import { RDFToGraphDataConverter } from "../../src/application/utils/RDFToGraphDataConverter";
-import type { Triple, GraphData, GraphNode, GraphEdge } from "exocortex";
+import type { Triple, GraphData } from "exocortex";
 
 describe("RDFToGraphDataConverter", () => {
   describe("convert", () => {


### PR DESCRIPTION
## Summary

Remove unused variables, imports, and constants in test files flagged by CodeQL analysis (`js/unused-local-variable` rule).

**Changes:**
- packages/cli/tests: 11 files fixed
- packages/exocortex/tests: 17 files fixed
- packages/obsidian-plugin/tests: 3 files fixed

**Patterns fixed:**
- Removed unused imports (e.g., `jest`, `beforeEach`, `beforeAll`, types)
- Removed unused constants (e.g., XSD_INTEGER, XSD_DECIMAL, unused namespace URIs)
- Removed unused local variables (e.g., assignment results not used)

All unit tests pass after changes.

## Test plan
- [x] Run `npm run test:unit` - all tests pass
- [ ] CI pipeline passes (build-and-test, e2e-tests)
- [ ] CodeQL analysis shows reduced alerts

Closes #904