### PR TITLE
fix(codeql): exclude test-vault main.js from semicolon warnings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -19,6 +19,7 @@ paths-ignore:
   - "**/*.spec.ts"
   - "packages/obsidian-plugin/main.js"      # Generated bundled output
   - "packages/obsidian-plugin/main.js.map"  # Source maps
+  - "**/test-vault/**/main.js"              # Test vault generated plugin copy
   - "**/debug-main.js"                      # Debug builds
   - "**/debug-main.ts"                      # Debug builds
 


### PR DESCRIPTION
## Summary
- Add test-vault plugin main.js to CodeQL paths-ignore configuration
- The file at `packages/obsidian-plugin/tests/e2e/test-vault/.obsidian/plugins/exocortex/main.js` is a generated esbuild bundle that should not be scanned for code quality issues

## Context
CodeQL detected 28 automatic semicolon insertion warnings (js/automatic-semicolon-insertion) in main.js. Since this file is generated code from esbuild, the appropriate fix is to exclude it from scanning rather than trying to modify the bundler output.

The existing CodeQL config already excludes `packages/obsidian-plugin/main.js` (the build output), but the test vault copy at a different path was still being scanned.

## Test plan
- [x] Verify CodeQL config syntax is valid
- [x] Run unit tests to ensure no regressions

Closes #905