### PR TITLE
feat(sparql): implement TZ function returning xsd:dayTimeDuration (SPARQL 1.1)

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -578,9 +578,12 @@ export class FilterExecutor {
         return BuiltInFunctions.seconds(secondsDate);
 
       case "timezone":
+        const timezoneDate = this.getStringValue(this.evaluateExpression(expr.args[0], solution));
+        return BuiltInFunctions.timezone(timezoneDate);
+
       case "tz":
         const tzDate = this.getStringValue(this.evaluateExpression(expr.args[0], solution));
-        return BuiltInFunctions.timezone(tzDate);
+        return BuiltInFunctions.tz(tzDate);
 
       case "now":
         return BuiltInFunctions.now();

--- a/packages/exocortex/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.test.ts
@@ -1040,6 +1040,78 @@ describe("BuiltInFunctions", () => {
       });
     });
 
+    describe("TIMEZONE", () => {
+      it("should return PT0S for UTC (Z)", () => {
+        const result = BuiltInFunctions.timezone("2025-01-01T12:00:00Z");
+        expect(result).toBeInstanceOf(Literal);
+        expect(result.value).toBe("PT0S");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should return positive duration for positive offset", () => {
+        const result = BuiltInFunctions.timezone("2025-01-01T12:00:00+05:00");
+        expect(result).toBeInstanceOf(Literal);
+        expect(result.value).toBe("PT5H");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should return negative duration for negative offset", () => {
+        const result = BuiltInFunctions.timezone("2025-01-01T12:00:00-08:00");
+        expect(result).toBeInstanceOf(Literal);
+        expect(result.value).toBe("-PT8H");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should handle offset with minutes", () => {
+        const result = BuiltInFunctions.timezone("2025-01-01T12:00:00+05:30");
+        expect(result).toBeInstanceOf(Literal);
+        expect(result.value).toBe("PT5H30M");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should handle negative offset with minutes", () => {
+        const result = BuiltInFunctions.timezone("2025-01-01T12:00:00-09:45");
+        expect(result).toBeInstanceOf(Literal);
+        expect(result.value).toBe("-PT9H45M");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should throw for invalid date", () => {
+        expect(() => BuiltInFunctions.timezone("invalid")).toThrow("TIMEZONE: invalid date string");
+      });
+    });
+
+    describe("TZ", () => {
+      it("should return Z for UTC", () => {
+        const result = BuiltInFunctions.tz("2025-01-01T12:00:00Z");
+        expect(result).toBe("Z");
+      });
+
+      it("should return positive offset string", () => {
+        const result = BuiltInFunctions.tz("2025-01-01T12:00:00+05:00");
+        expect(result).toBe("+05:00");
+      });
+
+      it("should return negative offset string", () => {
+        const result = BuiltInFunctions.tz("2025-01-01T12:00:00-08:30");
+        expect(result).toBe("-08:30");
+      });
+
+      it("should return empty string when no timezone", () => {
+        const result = BuiltInFunctions.tz("2025-01-01T12:00:00");
+        expect(result).toBe("");
+      });
+
+      it("should return empty string for date without time", () => {
+        const result = BuiltInFunctions.tz("2025-01-01");
+        expect(result).toBe("");
+      });
+
+      it("should throw for invalid date", () => {
+        expect(() => BuiltInFunctions.tz("invalid")).toThrow("TZ: invalid date string");
+      });
+    });
+
     describe("NOW", () => {
       it("should return ISO string format", () => {
         const result = BuiltInFunctions.now();


### PR DESCRIPTION
## Summary

Implements the SPARQL 1.1 TZ function and updates TIMEZONE function for spec compliance.

### Changes

- **TZ()**: Returns timezone as simple literal (string)
  - `TZ("2025-01-01T12:00:00Z")` → `"Z"`
  - `TZ("2025-01-01T12:00:00+05:00")` → `"+05:00"`
  - `TZ("2025-01-01T12:00:00")` → `""` (empty string when no timezone)

- **TIMEZONE()**: Returns `xsd:dayTimeDuration` typed literal (SPARQL 1.1 compliant)
  - `TIMEZONE("2025-01-01T12:00:00Z")` → `"PT0S"^^xsd:dayTimeDuration`
  - `TIMEZONE("2025-01-01T12:00:00+05:00")` → `"PT5H"^^xsd:dayTimeDuration`
  - `TIMEZONE("2025-01-01T12:00:00-08:30")` → `"-PT8H30M"^^xsd:dayTimeDuration`

- Separated TZ and TIMEZONE in FilterExecutor (previously aliased to same function)

### Test Plan

- [x] 6 unit tests for TIMEZONE function (UTC, positive/negative offsets, with minutes)
- [x] 6 unit tests for TZ function (UTC, positive/negative offsets, no timezone, invalid date)
- [x] All existing tests pass

Closes #928