### PR TITLE
feat: Add xsd:dayTimeDuration datatype support (SPARQL 1.1)

### DIFF
--- a/packages/exocortex/src/domain/models/rdf/Duration.ts
+++ b/packages/exocortex/src/domain/models/rdf/Duration.ts
@@ -1,0 +1,397 @@
+import { IRI } from "./IRI";
+import { Literal } from "./Literal";
+
+/** XSD dayTimeDuration datatype URI */
+export const XSD_DAYTIME_DURATION = "http://www.w3.org/2001/XMLSchema#dayTimeDuration";
+
+/** XSD dateTime datatype URI */
+export const XSD_DATETIME = "http://www.w3.org/2001/XMLSchema#dateTime";
+
+/**
+ * Represents an xsd:dayTimeDuration value.
+ * Format: [-]P[nD][T[nH][nM][n.nS]]
+ *
+ * Examples:
+ * - "PT5H" - 5 hours
+ * - "-PT8H30M" - negative 8 hours 30 minutes
+ * - "P1DT2H" - 1 day and 2 hours
+ * - "PT0S" - zero duration
+ *
+ * @see https://www.w3.org/TR/xpath-functions/#dt-dayTimeDuration
+ * @see https://www.w3.org/TR/sparql11-query/#operandDataTypes
+ */
+export class Duration {
+  /** Total duration in milliseconds (signed) */
+  private readonly _totalMs: number;
+
+  /**
+   * Create a Duration from milliseconds.
+   * @param totalMs Total milliseconds (can be negative)
+   */
+  constructor(totalMs: number) {
+    this._totalMs = totalMs;
+  }
+
+  /**
+   * Get total duration in milliseconds.
+   */
+  get totalMilliseconds(): number {
+    return this._totalMs;
+  }
+
+  /**
+   * Get total duration in seconds (decimal).
+   */
+  get totalSeconds(): number {
+    return this._totalMs / 1000;
+  }
+
+  /**
+   * Get total duration in minutes (decimal).
+   */
+  get totalMinutes(): number {
+    return this._totalMs / (1000 * 60);
+  }
+
+  /**
+   * Get total duration in hours (decimal).
+   */
+  get totalHours(): number {
+    return this._totalMs / (1000 * 60 * 60);
+  }
+
+  /**
+   * Get total duration in days (decimal).
+   */
+  get totalDays(): number {
+    return this._totalMs / (1000 * 60 * 60 * 24);
+  }
+
+  /**
+   * Check if duration is negative.
+   */
+  get isNegative(): boolean {
+    return this._totalMs < 0;
+  }
+
+  /**
+   * Get components of the duration.
+   * Returns decomposed days, hours, minutes, seconds (all non-negative).
+   */
+  get components(): { days: number; hours: number; minutes: number; seconds: number } {
+    const absMs = Math.abs(this._totalMs);
+
+    const totalSeconds = absMs / 1000;
+    const days = Math.floor(totalSeconds / 86400);
+    const remainingAfterDays = totalSeconds % 86400;
+    const hours = Math.floor(remainingAfterDays / 3600);
+    const remainingAfterHours = remainingAfterDays % 3600;
+    const minutes = Math.floor(remainingAfterHours / 60);
+    const seconds = remainingAfterHours % 60;
+
+    return { days, hours, minutes, seconds };
+  }
+
+  /**
+   * Parse an xsd:dayTimeDuration string.
+   * Format: [-]P[nD][T[nH][nM][n.nS]]
+   *
+   * @param durationStr Duration string in ISO 8601 duration format
+   * @returns Duration instance
+   * @throws Error if format is invalid
+   *
+   * Examples:
+   * - "PT5H" → 5 hours
+   * - "-PT8H30M" → -8 hours 30 minutes
+   * - "P1DT2H" → 1 day 2 hours
+   * - "PT0S" → 0
+   * - "P0D" → 0
+   * - "PT1.5S" → 1.5 seconds
+   */
+  static parse(durationStr: string): Duration {
+    if (!durationStr || typeof durationStr !== "string") {
+      throw new Error(`Invalid duration: ${durationStr}`);
+    }
+
+    const trimmed = durationStr.trim();
+
+    // Check for negative duration
+    let isNegative = false;
+    let str = trimmed;
+    if (str.startsWith("-")) {
+      isNegative = true;
+      str = str.substring(1);
+    }
+
+    // Must start with P
+    if (!str.startsWith("P")) {
+      throw new Error(`Invalid dayTimeDuration format: ${durationStr} (must start with 'P' or '-P')`);
+    }
+
+    str = str.substring(1); // Remove P
+
+    let totalMs = 0;
+
+    // Parse days (before T)
+    const tIndex = str.indexOf("T");
+    if (tIndex === -1) {
+      // No time component - only days allowed
+      if (str.length > 0) {
+        const dayMatch = str.match(/^(\d+(?:\.\d+)?)D$/);
+        if (dayMatch) {
+          totalMs += parseFloat(dayMatch[1]) * 24 * 60 * 60 * 1000;
+        } else if (str !== "") {
+          throw new Error(
+            `Invalid dayTimeDuration format: ${durationStr} (date component must be nD or empty)`
+          );
+        }
+      }
+    } else {
+      // Has time component
+      const datePart = str.substring(0, tIndex);
+      const timePart = str.substring(tIndex + 1);
+
+      // Parse days from date part
+      if (datePart.length > 0) {
+        const dayMatch = datePart.match(/^(\d+(?:\.\d+)?)D$/);
+        if (dayMatch) {
+          totalMs += parseFloat(dayMatch[1]) * 24 * 60 * 60 * 1000;
+        } else {
+          throw new Error(
+            `Invalid dayTimeDuration format: ${durationStr} (date component must be nD or empty)`
+          );
+        }
+      }
+
+      // Parse time part: nH, nM, n.nS
+      if (timePart.length === 0) {
+        throw new Error(`Invalid dayTimeDuration format: ${durationStr} (T must be followed by time components)`);
+      }
+
+      // Use regex to extract H, M, S components
+      let remaining = timePart;
+
+      // Hours
+      const hoursMatch = remaining.match(/^(\d+(?:\.\d+)?)H/);
+      if (hoursMatch) {
+        totalMs += parseFloat(hoursMatch[1]) * 60 * 60 * 1000;
+        remaining = remaining.substring(hoursMatch[0].length);
+      }
+
+      // Minutes
+      const minutesMatch = remaining.match(/^(\d+(?:\.\d+)?)M/);
+      if (minutesMatch) {
+        totalMs += parseFloat(minutesMatch[1]) * 60 * 1000;
+        remaining = remaining.substring(minutesMatch[0].length);
+      }
+
+      // Seconds
+      const secondsMatch = remaining.match(/^(\d+(?:\.\d+)?)S$/);
+      if (secondsMatch) {
+        totalMs += parseFloat(secondsMatch[1]) * 1000;
+        remaining = "";
+      }
+
+      if (remaining.length > 0) {
+        throw new Error(`Invalid dayTimeDuration format: ${durationStr} (invalid time component: ${remaining})`);
+      }
+    }
+
+    return new Duration(isNegative ? -totalMs : totalMs);
+  }
+
+  /**
+   * Try to parse a duration string, returning null if invalid.
+   */
+  static tryParse(durationStr: string): Duration | null {
+    try {
+      return Duration.parse(durationStr);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Create a Duration from individual components.
+   */
+  static fromComponents(
+    days: number = 0,
+    hours: number = 0,
+    minutes: number = 0,
+    seconds: number = 0,
+    milliseconds: number = 0,
+    negative: boolean = false
+  ): Duration {
+    let totalMs = days * 24 * 60 * 60 * 1000 + hours * 60 * 60 * 1000 + minutes * 60 * 1000 + seconds * 1000 + milliseconds;
+
+    if (negative) {
+      totalMs = -totalMs;
+    }
+
+    return new Duration(totalMs);
+  }
+
+  /**
+   * Create a Duration from the difference between two dates.
+   * @param end End date
+   * @param start Start date
+   * @returns Duration representing (end - start)
+   */
+  static fromDateDiff(end: Date, start: Date): Duration {
+    return new Duration(end.getTime() - start.getTime());
+  }
+
+  /**
+   * Convert to xsd:dayTimeDuration string format.
+   * Returns the canonical lexical form.
+   */
+  toString(): string {
+    if (this._totalMs === 0) {
+      return "PT0S";
+    }
+
+    const { days, hours, minutes, seconds } = this.components;
+    const negative = this.isNegative;
+
+    let result = negative ? "-P" : "P";
+
+    if (days > 0) {
+      result += `${days}D`;
+    }
+
+    if (hours > 0 || minutes > 0 || seconds > 0) {
+      result += "T";
+      if (hours > 0) {
+        result += `${hours}H`;
+      }
+      if (minutes > 0) {
+        result += `${minutes}M`;
+      }
+      if (seconds > 0) {
+        // Handle decimal seconds
+        if (Number.isInteger(seconds)) {
+          result += `${seconds}S`;
+        } else {
+          result += `${seconds.toFixed(3).replace(/\.?0+$/, "")}S`;
+        }
+      }
+    }
+
+    // If only days and result ends with D, that's fine
+    // If we only have negative zero scenario, return PT0S
+    if (result === "-P" || result === "P") {
+      return "PT0S";
+    }
+
+    return result;
+  }
+
+  /**
+   * Convert to an RDF Literal with xsd:dayTimeDuration datatype.
+   */
+  toLiteral(): Literal {
+    return new Literal(this.toString(), new IRI(XSD_DAYTIME_DURATION));
+  }
+
+  /**
+   * Add this duration to a Date, returning a new Date.
+   */
+  addToDate(date: Date): Date {
+    return new Date(date.getTime() + this._totalMs);
+  }
+
+  /**
+   * Subtract this duration from a Date, returning a new Date.
+   */
+  subtractFromDate(date: Date): Date {
+    return new Date(date.getTime() - this._totalMs);
+  }
+
+  /**
+   * Add another duration to this duration.
+   */
+  add(other: Duration): Duration {
+    return new Duration(this._totalMs + other._totalMs);
+  }
+
+  /**
+   * Subtract another duration from this duration.
+   */
+  subtract(other: Duration): Duration {
+    return new Duration(this._totalMs - other._totalMs);
+  }
+
+  /**
+   * Multiply duration by a scalar.
+   */
+  multiply(scalar: number): Duration {
+    return new Duration(this._totalMs * scalar);
+  }
+
+  /**
+   * Divide duration by a scalar.
+   */
+  divide(scalar: number): Duration {
+    if (scalar === 0) {
+      throw new Error("Cannot divide duration by zero");
+    }
+    return new Duration(this._totalMs / scalar);
+  }
+
+  /**
+   * Negate the duration (flip sign).
+   */
+  negate(): Duration {
+    return new Duration(-this._totalMs);
+  }
+
+  /**
+   * Get the absolute value of the duration.
+   */
+  abs(): Duration {
+    return new Duration(Math.abs(this._totalMs));
+  }
+
+  /**
+   * Compare two durations.
+   * @returns negative if this < other, 0 if equal, positive if this > other
+   */
+  compareTo(other: Duration): number {
+    return this._totalMs - other._totalMs;
+  }
+
+  /**
+   * Check equality with another duration.
+   */
+  equals(other: Duration): boolean {
+    return this._totalMs === other._totalMs;
+  }
+
+  /**
+   * Check if this duration is less than another.
+   */
+  lessThan(other: Duration): boolean {
+    return this._totalMs < other._totalMs;
+  }
+
+  /**
+   * Check if this duration is greater than another.
+   */
+  greaterThan(other: Duration): boolean {
+    return this._totalMs > other._totalMs;
+  }
+
+  /**
+   * Check if this duration is less than or equal to another.
+   */
+  lessThanOrEqual(other: Duration): boolean {
+    return this._totalMs <= other._totalMs;
+  }
+
+  /**
+   * Check if this duration is greater than or equal to another.
+   */
+  greaterThanOrEqual(other: Duration): boolean {
+    return this._totalMs >= other._totalMs;
+  }
+}

--- a/packages/exocortex/src/domain/models/rdf/index.ts
+++ b/packages/exocortex/src/domain/models/rdf/index.ts
@@ -3,3 +3,4 @@ export { Literal } from "./Literal";
 export { BlankNode } from "./BlankNode";
 export { Namespace } from "./Namespace";
 export { Triple, type Subject, type Predicate, type Object } from "./Triple";
+export { Duration, XSD_DAYTIME_DURATION, XSD_DATETIME } from "./Duration";

--- a/packages/exocortex/tests/unit/domain/models/rdf/Duration.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/rdf/Duration.test.ts
@@ -1,0 +1,466 @@
+import { Duration, XSD_DAYTIME_DURATION } from "../../../../../src/domain/models/rdf/Duration";
+import { IRI } from "../../../../../src/domain/models/rdf/IRI";
+
+describe("Duration", () => {
+  describe("parse", () => {
+    describe("valid formats", () => {
+      it('should parse "PT5H" as 5 hours', () => {
+        const duration = Duration.parse("PT5H");
+        expect(duration.totalHours).toBe(5);
+        expect(duration.totalMilliseconds).toBe(5 * 60 * 60 * 1000);
+      });
+
+      it('should parse "PT30M" as 30 minutes', () => {
+        const duration = Duration.parse("PT30M");
+        expect(duration.totalMinutes).toBe(30);
+        expect(duration.totalMilliseconds).toBe(30 * 60 * 1000);
+      });
+
+      it('should parse "PT45S" as 45 seconds', () => {
+        const duration = Duration.parse("PT45S");
+        expect(duration.totalSeconds).toBe(45);
+        expect(duration.totalMilliseconds).toBe(45 * 1000);
+      });
+
+      it('should parse "P1D" as 1 day', () => {
+        const duration = Duration.parse("P1D");
+        expect(duration.totalDays).toBe(1);
+        expect(duration.totalMilliseconds).toBe(24 * 60 * 60 * 1000);
+      });
+
+      it('should parse "P1DT2H" as 1 day 2 hours', () => {
+        const duration = Duration.parse("P1DT2H");
+        expect(duration.totalDays).toBe(1 + 2 / 24);
+        expect(duration.totalHours).toBe(26);
+      });
+
+      it('should parse "PT8H30M" as 8 hours 30 minutes', () => {
+        const duration = Duration.parse("PT8H30M");
+        expect(duration.totalHours).toBe(8.5);
+        expect(duration.totalMinutes).toBe(510);
+      });
+
+      it('should parse "PT1H30M45S" as 1 hour 30 minutes 45 seconds', () => {
+        const duration = Duration.parse("PT1H30M45S");
+        expect(duration.totalSeconds).toBe(3600 + 1800 + 45);
+      });
+
+      it('should parse "PT1.5S" as 1.5 seconds', () => {
+        const duration = Duration.parse("PT1.5S");
+        expect(duration.totalMilliseconds).toBe(1500);
+      });
+
+      it('should parse "P0D" as zero duration', () => {
+        const duration = Duration.parse("P0D");
+        expect(duration.totalMilliseconds).toBe(0);
+      });
+
+      it('should parse "PT0S" as zero duration', () => {
+        const duration = Duration.parse("PT0S");
+        expect(duration.totalMilliseconds).toBe(0);
+      });
+
+      it('should parse "P2DT3H4M5S" as full duration', () => {
+        const duration = Duration.parse("P2DT3H4M5S");
+        const expected = 2 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000 + 4 * 60 * 1000 + 5 * 1000;
+        expect(duration.totalMilliseconds).toBe(expected);
+      });
+    });
+
+    describe("negative durations", () => {
+      it('should parse "-PT5H" as negative 5 hours', () => {
+        const duration = Duration.parse("-PT5H");
+        expect(duration.isNegative).toBe(true);
+        expect(duration.totalHours).toBe(-5);
+        expect(duration.totalMilliseconds).toBe(-5 * 60 * 60 * 1000);
+      });
+
+      it('should parse "-PT8H30M" as negative 8 hours 30 minutes', () => {
+        const duration = Duration.parse("-PT8H30M");
+        expect(duration.isNegative).toBe(true);
+        expect(duration.totalMinutes).toBe(-510);
+      });
+
+      it('should parse "-P1DT2H" as negative 1 day 2 hours', () => {
+        const duration = Duration.parse("-P1DT2H");
+        expect(duration.isNegative).toBe(true);
+        expect(duration.totalHours).toBe(-26);
+      });
+    });
+
+    describe("invalid formats", () => {
+      it("should throw for empty string", () => {
+        expect(() => Duration.parse("")).toThrow("Invalid duration");
+      });
+
+      it("should throw for string without P prefix", () => {
+        expect(() => Duration.parse("T5H")).toThrow("must start with 'P'");
+      });
+
+      it("should throw for invalid components", () => {
+        expect(() => Duration.parse("P5Y")).toThrow("Invalid dayTimeDuration format");
+      });
+
+      it("should throw for empty T section", () => {
+        expect(() => Duration.parse("PT")).toThrow("T must be followed by time components");
+      });
+
+      it("should throw for malformed input", () => {
+        expect(() => Duration.parse("not a duration")).toThrow();
+      });
+    });
+  });
+
+  describe("tryParse", () => {
+    it("should return Duration for valid input", () => {
+      const duration = Duration.tryParse("PT5H");
+      expect(duration).not.toBeNull();
+      expect(duration!.totalHours).toBe(5);
+    });
+
+    it("should return null for invalid input", () => {
+      const duration = Duration.tryParse("invalid");
+      expect(duration).toBeNull();
+    });
+  });
+
+  describe("fromComponents", () => {
+    it("should create duration from components", () => {
+      const duration = Duration.fromComponents(1, 2, 30, 45);
+      expect(duration.components.days).toBe(1);
+      expect(duration.components.hours).toBe(2);
+      expect(duration.components.minutes).toBe(30);
+      expect(duration.components.seconds).toBe(45);
+    });
+
+    it("should create negative duration", () => {
+      const duration = Duration.fromComponents(0, 5, 0, 0, 0, true);
+      expect(duration.isNegative).toBe(true);
+      expect(duration.totalHours).toBe(-5);
+    });
+
+    it("should handle milliseconds", () => {
+      const duration = Duration.fromComponents(0, 0, 0, 0, 500);
+      expect(duration.totalMilliseconds).toBe(500);
+    });
+  });
+
+  describe("fromDateDiff", () => {
+    it("should calculate duration between two dates", () => {
+      const start = new Date("2025-01-01T12:00:00Z");
+      const end = new Date("2025-01-01T17:00:00Z");
+      const duration = Duration.fromDateDiff(end, start);
+      expect(duration.totalHours).toBe(5);
+    });
+
+    it("should return negative duration when end is before start", () => {
+      const start = new Date("2025-01-01T17:00:00Z");
+      const end = new Date("2025-01-01T12:00:00Z");
+      const duration = Duration.fromDateDiff(end, start);
+      expect(duration.isNegative).toBe(true);
+      expect(duration.totalHours).toBe(-5);
+    });
+
+    it("should handle day boundaries", () => {
+      const start = new Date("2025-01-01T00:00:00Z");
+      const end = new Date("2025-01-02T00:00:00Z");
+      const duration = Duration.fromDateDiff(end, start);
+      expect(duration.totalDays).toBe(1);
+    });
+  });
+
+  describe("toString", () => {
+    it("should serialize zero duration as PT0S", () => {
+      const duration = new Duration(0);
+      expect(duration.toString()).toBe("PT0S");
+    });
+
+    it("should serialize 5 hours as PT5H", () => {
+      const duration = Duration.fromComponents(0, 5, 0, 0);
+      expect(duration.toString()).toBe("PT5H");
+    });
+
+    it("should serialize 30 minutes as PT30M", () => {
+      const duration = Duration.fromComponents(0, 0, 30, 0);
+      expect(duration.toString()).toBe("PT30M");
+    });
+
+    it("should serialize 1 day as P1D", () => {
+      const duration = Duration.fromComponents(1, 0, 0, 0);
+      expect(duration.toString()).toBe("P1D");
+    });
+
+    it("should serialize complex duration", () => {
+      const duration = Duration.fromComponents(1, 2, 30, 45);
+      expect(duration.toString()).toBe("P1DT2H30M45S");
+    });
+
+    it("should serialize negative duration", () => {
+      const duration = Duration.fromComponents(0, 5, 30, 0, 0, true);
+      expect(duration.toString()).toBe("-PT5H30M");
+    });
+  });
+
+  describe("toLiteral", () => {
+    it("should create Literal with correct datatype", () => {
+      const duration = Duration.parse("PT5H");
+      const literal = duration.toLiteral();
+      expect(literal.datatype?.value).toBe(XSD_DAYTIME_DURATION);
+      expect(literal.value).toBe("PT5H");
+    });
+  });
+
+  describe("arithmetic operations", () => {
+    describe("addToDate", () => {
+      it("should add duration to date", () => {
+        const date = new Date("2025-01-01T12:00:00Z");
+        const duration = Duration.parse("PT5H");
+        const result = duration.addToDate(date);
+        expect(result.toISOString()).toBe("2025-01-01T17:00:00.000Z");
+      });
+
+      it("should handle negative duration", () => {
+        const date = new Date("2025-01-01T12:00:00Z");
+        const duration = Duration.parse("-PT5H");
+        const result = duration.addToDate(date);
+        expect(result.toISOString()).toBe("2025-01-01T07:00:00.000Z");
+      });
+    });
+
+    describe("subtractFromDate", () => {
+      it("should subtract duration from date", () => {
+        const date = new Date("2025-01-01T12:00:00Z");
+        const duration = Duration.parse("PT5H");
+        const result = duration.subtractFromDate(date);
+        expect(result.toISOString()).toBe("2025-01-01T07:00:00.000Z");
+      });
+    });
+
+    describe("add", () => {
+      it("should add two durations", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT3H");
+        const result = d1.add(d2);
+        expect(result.totalHours).toBe(8);
+      });
+
+      it("should handle negative durations", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("-PT3H");
+        const result = d1.add(d2);
+        expect(result.totalHours).toBe(2);
+      });
+    });
+
+    describe("subtract", () => {
+      it("should subtract durations", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT3H");
+        const result = d1.subtract(d2);
+        expect(result.totalHours).toBe(2);
+      });
+
+      it("should produce negative result when appropriate", () => {
+        const d1 = Duration.parse("PT3H");
+        const d2 = Duration.parse("PT5H");
+        const result = d1.subtract(d2);
+        expect(result.totalHours).toBe(-2);
+        expect(result.isNegative).toBe(true);
+      });
+    });
+
+    describe("multiply", () => {
+      it("should multiply duration by scalar", () => {
+        const duration = Duration.parse("PT1H");
+        const result = duration.multiply(3);
+        expect(result.totalHours).toBe(3);
+      });
+
+      it("should handle fractional multiplier", () => {
+        const duration = Duration.parse("PT1H");
+        const result = duration.multiply(0.5);
+        expect(result.totalMinutes).toBe(30);
+      });
+
+      it("should handle negative multiplier", () => {
+        const duration = Duration.parse("PT1H");
+        const result = duration.multiply(-2);
+        expect(result.totalHours).toBe(-2);
+        expect(result.isNegative).toBe(true);
+      });
+    });
+
+    describe("divide", () => {
+      it("should divide duration by scalar", () => {
+        const duration = Duration.parse("PT6H");
+        const result = duration.divide(2);
+        expect(result.totalHours).toBe(3);
+      });
+
+      it("should throw on division by zero", () => {
+        const duration = Duration.parse("PT1H");
+        expect(() => duration.divide(0)).toThrow("Cannot divide duration by zero");
+      });
+    });
+
+    describe("negate", () => {
+      it("should negate positive duration", () => {
+        const duration = Duration.parse("PT5H");
+        const result = duration.negate();
+        expect(result.isNegative).toBe(true);
+        expect(result.totalHours).toBe(-5);
+      });
+
+      it("should negate negative duration", () => {
+        const duration = Duration.parse("-PT5H");
+        const result = duration.negate();
+        expect(result.isNegative).toBe(false);
+        expect(result.totalHours).toBe(5);
+      });
+    });
+
+    describe("abs", () => {
+      it("should return absolute value of negative duration", () => {
+        const duration = Duration.parse("-PT5H");
+        const result = duration.abs();
+        expect(result.isNegative).toBe(false);
+        expect(result.totalHours).toBe(5);
+      });
+
+      it("should return same value for positive duration", () => {
+        const duration = Duration.parse("PT5H");
+        const result = duration.abs();
+        expect(result.totalHours).toBe(5);
+      });
+    });
+  });
+
+  describe("comparison operations", () => {
+    describe("compareTo", () => {
+      it("should return negative when this < other", () => {
+        const d1 = Duration.parse("PT3H");
+        const d2 = Duration.parse("PT5H");
+        expect(d1.compareTo(d2)).toBeLessThan(0);
+      });
+
+      it("should return positive when this > other", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT3H");
+        expect(d1.compareTo(d2)).toBeGreaterThan(0);
+      });
+
+      it("should return zero when equal", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT5H");
+        expect(d1.compareTo(d2)).toBe(0);
+      });
+    });
+
+    describe("equals", () => {
+      it("should return true for equal durations", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT5H");
+        expect(d1.equals(d2)).toBe(true);
+      });
+
+      it("should return false for different durations", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT3H");
+        expect(d1.equals(d2)).toBe(false);
+      });
+
+      it("should consider equivalent representations equal", () => {
+        const d1 = Duration.parse("PT60M");
+        const d2 = Duration.parse("PT1H");
+        expect(d1.equals(d2)).toBe(true);
+      });
+    });
+
+    describe("lessThan", () => {
+      it("should return true when this < other", () => {
+        const d1 = Duration.parse("PT3H");
+        const d2 = Duration.parse("PT5H");
+        expect(d1.lessThan(d2)).toBe(true);
+      });
+
+      it("should return false when this >= other", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT3H");
+        expect(d1.lessThan(d2)).toBe(false);
+      });
+    });
+
+    describe("greaterThan", () => {
+      it("should return true when this > other", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT3H");
+        expect(d1.greaterThan(d2)).toBe(true);
+      });
+
+      it("should return false when this <= other", () => {
+        const d1 = Duration.parse("PT3H");
+        const d2 = Duration.parse("PT5H");
+        expect(d1.greaterThan(d2)).toBe(false);
+      });
+    });
+
+    describe("lessThanOrEqual", () => {
+      it("should return true when this < other", () => {
+        const d1 = Duration.parse("PT3H");
+        const d2 = Duration.parse("PT5H");
+        expect(d1.lessThanOrEqual(d2)).toBe(true);
+      });
+
+      it("should return true when equal", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT5H");
+        expect(d1.lessThanOrEqual(d2)).toBe(true);
+      });
+
+      it("should return false when this > other", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT3H");
+        expect(d1.lessThanOrEqual(d2)).toBe(false);
+      });
+    });
+
+    describe("greaterThanOrEqual", () => {
+      it("should return true when this > other", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT3H");
+        expect(d1.greaterThanOrEqual(d2)).toBe(true);
+      });
+
+      it("should return true when equal", () => {
+        const d1 = Duration.parse("PT5H");
+        const d2 = Duration.parse("PT5H");
+        expect(d1.greaterThanOrEqual(d2)).toBe(true);
+      });
+
+      it("should return false when this < other", () => {
+        const d1 = Duration.parse("PT3H");
+        const d2 = Duration.parse("PT5H");
+        expect(d1.greaterThanOrEqual(d2)).toBe(false);
+      });
+    });
+  });
+
+  describe("components accessor", () => {
+    it("should decompose duration correctly", () => {
+      const duration = Duration.fromComponents(2, 5, 30, 45);
+      const { days, hours, minutes, seconds } = duration.components;
+      expect(days).toBe(2);
+      expect(hours).toBe(5);
+      expect(minutes).toBe(30);
+      expect(seconds).toBe(45);
+    });
+
+    it("should return positive components for negative duration", () => {
+      const duration = Duration.parse("-PT5H30M");
+      const { hours, minutes } = duration.components;
+      expect(hours).toBe(5);
+      expect(minutes).toBe(30);
+      expect(duration.isNegative).toBe(true);
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.test.ts
@@ -2440,4 +2440,354 @@ describe("BuiltInFunctions", () => {
       });
     });
   });
+
+  // =========================================================================
+  // xsd:dayTimeDuration Functions (SPARQL 1.1)
+  // https://www.w3.org/TR/xpath-functions/#dt-dayTimeDuration
+  // =========================================================================
+
+  describe("xsd:dayTimeDuration functions", () => {
+    describe("xsdDayTimeDuration constructor", () => {
+      it("should parse PT5H as 5 hours", () => {
+        const result = BuiltInFunctions.xsdDayTimeDuration("PT5H");
+        expect(result.value).toBe("PT5H");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should parse PT30M as 30 minutes", () => {
+        const result = BuiltInFunctions.xsdDayTimeDuration("PT30M");
+        expect(result.value).toBe("PT30M");
+      });
+
+      it("should parse P1DT2H as 1 day 2 hours", () => {
+        const result = BuiltInFunctions.xsdDayTimeDuration("P1DT2H");
+        expect(result.value).toBe("P1DT2H");
+      });
+
+      it("should parse negative duration -PT8H30M", () => {
+        const result = BuiltInFunctions.xsdDayTimeDuration("-PT8H30M");
+        expect(result.value).toBe("-PT8H30M");
+      });
+
+      it("should parse PT0S as zero duration", () => {
+        const result = BuiltInFunctions.xsdDayTimeDuration("PT0S");
+        expect(result.value).toBe("PT0S");
+      });
+
+      it("should throw for invalid duration format", () => {
+        expect(() => BuiltInFunctions.xsdDayTimeDuration("invalid")).toThrow();
+      });
+    });
+
+    describe("isDayTimeDuration", () => {
+      it("should return true for xsd:dayTimeDuration literal", () => {
+        const duration = BuiltInFunctions.xsdDayTimeDuration("PT5H");
+        expect(BuiltInFunctions.isDayTimeDuration(duration)).toBe(true);
+      });
+
+      it("should return false for xsd:integer literal", () => {
+        const xsdInteger = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+        const literal = new Literal("42", xsdInteger);
+        expect(BuiltInFunctions.isDayTimeDuration(literal)).toBe(false);
+      });
+
+      it("should return false for plain literal", () => {
+        const literal = new Literal("PT5H");
+        expect(BuiltInFunctions.isDayTimeDuration(literal)).toBe(false);
+      });
+
+      it("should return false for IRI", () => {
+        const iri = new IRI("http://example.org/resource");
+        expect(BuiltInFunctions.isDayTimeDuration(iri)).toBe(false);
+      });
+
+      it("should return false for undefined", () => {
+        expect(BuiltInFunctions.isDayTimeDuration(undefined)).toBe(false);
+      });
+    });
+
+    describe("subtractDateTimes", () => {
+      it("should return P1D for 1 day difference", () => {
+        const result = BuiltInFunctions.subtractDateTimes(
+          "2025-01-02T12:00:00Z",
+          "2025-01-01T12:00:00Z"
+        );
+        expect(result.value).toBe("P1D");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should return PT5H for 5 hour difference", () => {
+        const result = BuiltInFunctions.subtractDateTimes(
+          "2025-01-01T17:00:00Z",
+          "2025-01-01T12:00:00Z"
+        );
+        expect(result.value).toBe("PT5H");
+      });
+
+      it("should return negative duration when first is before second", () => {
+        const result = BuiltInFunctions.subtractDateTimes(
+          "2025-01-01T12:00:00Z",
+          "2025-01-01T17:00:00Z"
+        );
+        expect(result.value).toBe("-PT5H");
+      });
+
+      it("should throw for invalid first dateTime", () => {
+        expect(() =>
+          BuiltInFunctions.subtractDateTimes("invalid", "2025-01-01T12:00:00Z")
+        ).toThrow("invalid first dateTime");
+      });
+
+      it("should throw for invalid second dateTime", () => {
+        expect(() =>
+          BuiltInFunctions.subtractDateTimes("2025-01-01T12:00:00Z", "invalid")
+        ).toThrow("invalid second dateTime");
+      });
+    });
+
+    describe("addDurationToDateTime", () => {
+      it("should add 1 day to dateTime", () => {
+        const result = BuiltInFunctions.addDurationToDateTime(
+          "2025-01-01T12:00:00Z",
+          "P1D"
+        );
+        expect(result.value).toBe("2025-01-02T12:00:00.000Z");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dateTime");
+      });
+
+      it("should add 5 hours to dateTime", () => {
+        const result = BuiltInFunctions.addDurationToDateTime(
+          "2025-01-01T12:00:00Z",
+          "PT5H"
+        );
+        expect(result.value).toBe("2025-01-01T17:00:00.000Z");
+      });
+
+      it("should handle negative duration", () => {
+        const result = BuiltInFunctions.addDurationToDateTime(
+          "2025-01-01T12:00:00Z",
+          "-PT5H"
+        );
+        expect(result.value).toBe("2025-01-01T07:00:00.000Z");
+      });
+
+      it("should throw for invalid dateTime", () => {
+        expect(() =>
+          BuiltInFunctions.addDurationToDateTime("invalid", "PT5H")
+        ).toThrow("invalid dateTime");
+      });
+    });
+
+    describe("subtractDurationFromDateTime", () => {
+      it("should subtract 1 day from dateTime", () => {
+        const result = BuiltInFunctions.subtractDurationFromDateTime(
+          "2025-01-02T12:00:00Z",
+          "P1D"
+        );
+        expect(result.value).toBe("2025-01-01T12:00:00.000Z");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dateTime");
+      });
+
+      it("should subtract 5 hours from dateTime", () => {
+        const result = BuiltInFunctions.subtractDurationFromDateTime(
+          "2025-01-01T17:00:00Z",
+          "PT5H"
+        );
+        expect(result.value).toBe("2025-01-01T12:00:00.000Z");
+      });
+
+      it("should throw for invalid dateTime", () => {
+        expect(() =>
+          BuiltInFunctions.subtractDurationFromDateTime("invalid", "PT5H")
+        ).toThrow("invalid dateTime");
+      });
+    });
+
+    describe("addDurations", () => {
+      it("should add two durations", () => {
+        const result = BuiltInFunctions.addDurations("PT5H", "PT3H");
+        expect(result.value).toBe("PT8H");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should add duration with negative", () => {
+        const result = BuiltInFunctions.addDurations("PT5H", "-PT3H");
+        expect(result.value).toBe("PT2H");
+      });
+
+      it("should add complex durations", () => {
+        const result = BuiltInFunctions.addDurations("P1DT2H", "PT3H30M");
+        expect(result.value).toBe("P1DT5H30M");
+      });
+    });
+
+    describe("subtractDurations", () => {
+      it("should subtract two durations", () => {
+        const result = BuiltInFunctions.subtractDurations("PT5H", "PT3H");
+        expect(result.value).toBe("PT2H");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should produce negative result", () => {
+        const result = BuiltInFunctions.subtractDurations("PT3H", "PT5H");
+        expect(result.value).toBe("-PT2H");
+      });
+    });
+
+    describe("multiplyDuration", () => {
+      it("should multiply duration by integer", () => {
+        const result = BuiltInFunctions.multiplyDuration("PT1H", 3);
+        expect(result.value).toBe("PT3H");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should multiply duration by fraction", () => {
+        const result = BuiltInFunctions.multiplyDuration("PT1H", 0.5);
+        expect(result.value).toBe("PT30M");
+      });
+
+      it("should produce negative with negative multiplier", () => {
+        const result = BuiltInFunctions.multiplyDuration("PT1H", -2);
+        expect(result.value).toBe("-PT2H");
+      });
+    });
+
+    describe("divideDuration", () => {
+      it("should divide duration by integer", () => {
+        const result = BuiltInFunctions.divideDuration("PT6H", 2);
+        expect(result.value).toBe("PT3H");
+        expect(result.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      });
+
+      it("should throw on division by zero", () => {
+        expect(() => BuiltInFunctions.divideDuration("PT1H", 0)).toThrow();
+      });
+    });
+
+    describe("compareDurations", () => {
+      it("should return -1 when first < second", () => {
+        const result = BuiltInFunctions.compareDurations("PT3H", "PT5H");
+        expect(result).toBe(-1);
+      });
+
+      it("should return 1 when first > second", () => {
+        const result = BuiltInFunctions.compareDurations("PT5H", "PT3H");
+        expect(result).toBe(1);
+      });
+
+      it("should return 0 when equal", () => {
+        const result = BuiltInFunctions.compareDurations("PT5H", "PT5H");
+        expect(result).toBe(0);
+      });
+
+      it("should compare equivalent representations as equal", () => {
+        const result = BuiltInFunctions.compareDurations("PT60M", "PT1H");
+        expect(result).toBe(0);
+      });
+    });
+
+    describe("daysFromDuration", () => {
+      it("should extract days component", () => {
+        expect(BuiltInFunctions.daysFromDuration("P2DT5H")).toBe(2);
+      });
+
+      it("should return 0 for time-only duration", () => {
+        expect(BuiltInFunctions.daysFromDuration("PT5H")).toBe(0);
+      });
+
+      it("should return negative for negative duration", () => {
+        expect(BuiltInFunctions.daysFromDuration("-P2DT5H")).toBe(-2);
+      });
+    });
+
+    describe("hoursFromDuration", () => {
+      it("should extract hours component", () => {
+        expect(BuiltInFunctions.hoursFromDuration("P1DT5H30M")).toBe(5);
+      });
+
+      it("should return negative for negative duration", () => {
+        expect(BuiltInFunctions.hoursFromDuration("-PT5H")).toBe(-5);
+      });
+    });
+
+    describe("minutesFromDuration", () => {
+      it("should extract minutes component", () => {
+        expect(BuiltInFunctions.minutesFromDuration("PT5H30M")).toBe(30);
+      });
+
+      it("should return negative for negative duration", () => {
+        expect(BuiltInFunctions.minutesFromDuration("-PT30M")).toBe(-30);
+      });
+    });
+
+    describe("secondsFromDuration", () => {
+      it("should extract seconds component", () => {
+        expect(BuiltInFunctions.secondsFromDuration("PT30M45S")).toBe(45);
+      });
+
+      it("should handle decimal seconds", () => {
+        expect(BuiltInFunctions.secondsFromDuration("PT1.5S")).toBe(1.5);
+      });
+
+      it("should return negative for negative duration", () => {
+        expect(BuiltInFunctions.secondsFromDuration("-PT45S")).toBe(-45);
+      });
+    });
+
+    describe("durationToSeconds", () => {
+      it("should convert 1 hour to 3600 seconds", () => {
+        expect(BuiltInFunctions.durationToSeconds("PT1H")).toBe(3600);
+      });
+
+      it("should convert 1 day to seconds", () => {
+        expect(BuiltInFunctions.durationToSeconds("P1D")).toBe(86400);
+      });
+
+      it("should handle negative duration", () => {
+        expect(BuiltInFunctions.durationToSeconds("-PT1H")).toBe(-3600);
+      });
+    });
+
+    describe("durationToMinutes", () => {
+      it("should convert 1 hour to 60 minutes", () => {
+        expect(BuiltInFunctions.durationToMinutes("PT1H")).toBe(60);
+      });
+
+      it("should convert 90 minutes correctly", () => {
+        expect(BuiltInFunctions.durationToMinutes("PT1H30M")).toBe(90);
+      });
+    });
+
+    describe("durationToHours", () => {
+      it("should convert 1 day to 24 hours", () => {
+        expect(BuiltInFunctions.durationToHours("P1D")).toBe(24);
+      });
+
+      it("should convert 90 minutes to 1.5 hours", () => {
+        expect(BuiltInFunctions.durationToHours("PT1H30M")).toBe(1.5);
+      });
+    });
+
+    describe("duration comparison in compare function", () => {
+      it("should compare dayTimeDuration literals correctly", () => {
+        const d1 = BuiltInFunctions.xsdDayTimeDuration("PT3H");
+        const d2 = BuiltInFunctions.xsdDayTimeDuration("PT5H");
+
+        expect(BuiltInFunctions.compare(d1, d2, "<")).toBe(true);
+        expect(BuiltInFunctions.compare(d1, d2, ">")).toBe(false);
+        expect(BuiltInFunctions.compare(d1, d2, "=")).toBe(false);
+        expect(BuiltInFunctions.compare(d1, d2, "!=")).toBe(true);
+        expect(BuiltInFunctions.compare(d1, d2, "<=")).toBe(true);
+        expect(BuiltInFunctions.compare(d1, d2, ">=")).toBe(false);
+      });
+
+      it("should compare equal durations", () => {
+        const d1 = BuiltInFunctions.xsdDayTimeDuration("PT60M");
+        const d2 = BuiltInFunctions.xsdDayTimeDuration("PT1H");
+
+        expect(BuiltInFunctions.compare(d1, d2, "=")).toBe(true);
+        expect(BuiltInFunctions.compare(d1, d2, "!=")).toBe(false);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements complete xsd:dayTimeDuration support for SPARQL 1.1 queries:

- **Duration class** with ISO 8601 parsing (`[-]P[nD][T[nH][nM][n.nS]]`)
- **DateTime arithmetic**: dateTime +/- duration returns xsd:dateTime
- **DateTime subtraction**: dateTime - dateTime returns xsd:dayTimeDuration  
- **Duration arithmetic**: duration +/- duration, duration * number, duration / number
- **Duration comparison**: `<`, `<=`, `=`, `>=`, `>` for duration values
- **Accessor functions**: `days()`, `hours()`, `minutes()`, `seconds()`
- **Conversion functions**: `durationToSeconds()`, `durationToMinutes()`, `durationToHours()`

## Files Changed

- `packages/exocortex/src/domain/models/rdf/Duration.ts` - Core Duration class
- `packages/exocortex/src/infrastructure/sparql/filters/BuiltInFunctions.ts` - Duration functions
- `packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts` - Duration-aware arithmetic
- `packages/exocortex/src/domain/models/rdf/index.ts` - Export Duration

## Test Coverage

- 466 lines of unit tests for Duration class
- 350 lines of tests for BuiltInFunctions duration support
- Covers parsing, serialization, arithmetic, and comparison operations

## Example Usage

```sparql
# Calculate time since event
SELECT ?event ?timeSince WHERE {
  ?event :timestamp ?ts .
  BIND(NOW() - ?ts AS ?timeSince)
}

# Find events older than 30 days
SELECT ?event WHERE {
  ?event :timestamp ?ts .
  FILTER(NOW() - ?ts > "P30D"^^xsd:dayTimeDuration)
}

# Add duration to timestamp
SELECT ?newTime WHERE {
  BIND("2025-01-01T00:00:00Z"^^xsd:dateTime + "PT1H30M"^^xsd:dayTimeDuration AS ?newTime)
}
```

Closes #929