### PR TITLE
feat: Implement INSERT DATA operation (SPARQL 1.1 Update)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -90,7 +90,7 @@ export { RDFVocabularyMapper } from "./infrastructure/rdf/RDFVocabularyMapper";
 export { NoteToRDFConverter } from "./services/NoteToRDFConverter";
 
 // SPARQL Engine exports
-export { SPARQLParser, SPARQLParseError, type SPARQLQuery, type SelectQuery, type ConstructQuery } from "./infrastructure/sparql/SPARQLParser";
+export { SPARQLParser, SPARQLParseError, type SPARQLQuery, type SelectQuery, type ConstructQuery, type Update, type UpdateOperation } from "./infrastructure/sparql/SPARQLParser";
 export { AlgebraTranslator } from "./infrastructure/sparql/algebra/AlgebraTranslator";
 export { AlgebraOptimizer } from "./infrastructure/sparql/algebra/AlgebraOptimizer";
 export { AlgebraSerializer } from "./infrastructure/sparql/algebra/AlgebraSerializer";
@@ -107,6 +107,7 @@ export { UnionExecutor } from "./infrastructure/sparql/executors/UnionExecutor";
 export { ConstructExecutor } from "./infrastructure/sparql/executors/ConstructExecutor";
 export { DescribeExecutor } from "./infrastructure/sparql/executors/DescribeExecutor";
 export { QueryExecutor } from "./infrastructure/sparql/executors/QueryExecutor";
+export { UpdateExecutor, UpdateExecutorError, type UpdateResult } from "./infrastructure/sparql/executors/UpdateExecutor";
 export { SolutionMapping } from "./infrastructure/sparql/SolutionMapping";
 export { BuiltInFunctions } from "./infrastructure/sparql/filters/BuiltInFunctions";
 export { AggregateFunctions } from "./infrastructure/sparql/aggregates/AggregateFunctions";

--- a/packages/exocortex/src/infrastructure/sparql/SPARQLParser.ts
+++ b/packages/exocortex/src/infrastructure/sparql/SPARQLParser.ts
@@ -18,6 +18,8 @@ export type SelectQuery = sparqljs.SelectQuery;
 export type ConstructQuery = sparqljs.ConstructQuery;
 export type AskQuery = sparqljs.AskQuery;
 export type DescribeQuery = sparqljs.DescribeQuery;
+export type Update = sparqljs.Update;
+export type UpdateOperation = sparqljs.UpdateOperation;
 export type QueryType = "SELECT" | "CONSTRUCT" | "ASK" | "DESCRIBE";
 
 export class SPARQLParser {
@@ -89,6 +91,30 @@ export class SPARQLParser {
 
   isDescribeQuery(query: SPARQLQuery): query is DescribeQuery {
     return "queryType" in query && query.type === "query" && query.queryType === "DESCRIBE";
+  }
+
+  /**
+   * Check if a parsed query is an UPDATE request.
+   * UPDATE requests contain one or more update operations (INSERT DATA, DELETE DATA, etc.)
+   */
+  isUpdateQuery(query: SPARQLQuery): query is Update {
+    return query.type === "update";
+  }
+
+  /**
+   * Check if an update operation is an INSERT DATA operation.
+   * INSERT DATA adds static triples without a WHERE clause.
+   */
+  isInsertDataOperation(operation: UpdateOperation): boolean {
+    return "updateType" in operation && operation.updateType === "insert";
+  }
+
+  /**
+   * Check if an update operation is a DELETE DATA operation.
+   * DELETE DATA removes static triples without a WHERE clause.
+   */
+  isDeleteDataOperation(operation: UpdateOperation): boolean {
+    return "updateType" in operation && operation.updateType === "delete";
   }
 
   private validateQuery(query: any): void {

--- a/packages/exocortex/src/infrastructure/sparql/executors/UpdateExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/UpdateExecutor.ts
@@ -1,0 +1,330 @@
+import type { ITripleStore, GraphName } from "../../../interfaces/ITripleStore";
+import type { Update, UpdateOperation } from "../SPARQLParser";
+import { Triple, Subject, Predicate, Object as RDFObject } from "../../../domain/models/rdf/Triple";
+import { IRI } from "../../../domain/models/rdf/IRI";
+import { Literal } from "../../../domain/models/rdf/Literal";
+import { BlankNode } from "../../../domain/models/rdf/BlankNode";
+import type * as sparqljs from "sparqljs";
+
+export class UpdateExecutorError extends Error {
+  constructor(message: string, cause?: Error) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "UpdateExecutorError";
+  }
+}
+
+/**
+ * Result of executing an UPDATE operation.
+ */
+export interface UpdateResult {
+  /** Type of update that was executed */
+  type: "insert" | "delete" | "insertdelete" | "deletewhere" | "clear" | "drop" | "load" | "create" | "copy" | "move" | "add";
+  /** Number of triples inserted (for INSERT operations) */
+  inserted?: number;
+  /** Number of triples deleted (for DELETE operations) */
+  deleted?: number;
+  /** Whether the operation succeeded */
+  success: boolean;
+}
+
+/**
+ * Executes SPARQL UPDATE operations against a triple store.
+ *
+ * SPARQL 1.1 Update specification:
+ * https://www.w3.org/TR/sparql11-update/
+ *
+ * Currently supported operations:
+ * - INSERT DATA: Add static triples to the graph
+ *
+ * Future operations (not yet implemented):
+ * - DELETE DATA: Remove static triples from the graph
+ * - INSERT/DELETE: Modify triples based on WHERE clause
+ * - CLEAR: Remove all triples from a graph
+ * - DROP: Remove a graph
+ * - LOAD: Load triples from an external source
+ * - CREATE: Create an empty graph
+ * - COPY/MOVE/ADD: Graph management operations
+ */
+export class UpdateExecutor {
+  private readonly tripleStore: ITripleStore;
+
+  constructor(tripleStore: ITripleStore) {
+    this.tripleStore = tripleStore;
+  }
+
+  /**
+   * Execute an UPDATE request containing one or more update operations.
+   *
+   * @param update - The parsed UPDATE request from sparqljs
+   * @returns Array of results, one for each update operation
+   */
+  async execute(update: Update): Promise<UpdateResult[]> {
+    if (update.type !== "update") {
+      throw new UpdateExecutorError("Expected UPDATE request");
+    }
+
+    const results: UpdateResult[] = [];
+
+    for (const operation of update.updates) {
+      const result = await this.executeOperation(operation);
+      results.push(result);
+    }
+
+    return results;
+  }
+
+  /**
+   * Execute a single update operation.
+   */
+  private async executeOperation(operation: UpdateOperation): Promise<UpdateResult> {
+    // Check for InsertDeleteOperation types
+    if ("updateType" in operation) {
+      switch (operation.updateType) {
+        case "insert":
+          return this.executeInsertData(operation);
+        case "delete":
+          return this.executeDeleteData(operation);
+        case "insertdelete":
+          throw new UpdateExecutorError("INSERT/DELETE with WHERE clause not yet implemented");
+        case "deletewhere":
+          throw new UpdateExecutorError("DELETE WHERE not yet implemented");
+        default:
+          throw new UpdateExecutorError(`Unknown update type: ${(operation as any).updateType}`);
+      }
+    }
+
+    // Check for ManagementOperation types
+    if ("type" in operation) {
+      switch (operation.type) {
+        case "clear":
+        case "drop":
+        case "load":
+        case "create":
+        case "copy":
+        case "move":
+        case "add":
+          throw new UpdateExecutorError(`${operation.type.toUpperCase()} operation not yet implemented`);
+        default:
+          throw new UpdateExecutorError(`Unknown operation type: ${(operation as any).type}`);
+      }
+    }
+
+    throw new UpdateExecutorError("Unknown update operation structure");
+  }
+
+  /**
+   * Execute INSERT DATA operation.
+   *
+   * INSERT DATA adds static triples to the graph without a WHERE clause.
+   * Triples can be added to the default graph or to named graphs.
+   *
+   * SPARQL 1.1 specification:
+   * https://www.w3.org/TR/sparql11-update/#insertData
+   *
+   * Examples:
+   * ```sparql
+   * INSERT DATA {
+   *   <http://example/s> <http://example/p> "value" .
+   * }
+   *
+   * INSERT DATA {
+   *   GRAPH <http://example/g1> {
+   *     <http://example/s> <http://example/p> "value" .
+   *   }
+   * }
+   * ```
+   */
+  private async executeInsertData(operation: sparqljs.InsertDeleteOperation): Promise<UpdateResult> {
+    if (operation.updateType !== "insert") {
+      throw new UpdateExecutorError("Expected INSERT DATA operation");
+    }
+
+    // sparqljs represents INSERT DATA as { updateType: "insert", insert: Quads[] }
+    const insertData = operation as { updateType: "insert"; insert: sparqljs.Quads[]; graph?: sparqljs.GraphOrDefault };
+
+    let insertedCount = 0;
+
+    // Process each quad pattern in the insert array
+    for (const quads of insertData.insert) {
+      if (quads.type === "bgp") {
+        // Default graph triples
+        const graphName = this.resolveGraphName(insertData.graph);
+        insertedCount += await this.insertTriples(quads.triples, graphName);
+      } else if (quads.type === "graph") {
+        // Named graph triples
+        const graphQuads = quads as sparqljs.GraphQuads;
+        const graphName = this.parseGraphName(graphQuads.name);
+        insertedCount += await this.insertTriples(graphQuads.triples, graphName);
+      }
+    }
+
+    return {
+      type: "insert",
+      inserted: insertedCount,
+      success: true,
+    };
+  }
+
+  /**
+   * Execute DELETE DATA operation.
+   *
+   * DELETE DATA removes static triples from the graph without a WHERE clause.
+   *
+   * SPARQL 1.1 specification:
+   * https://www.w3.org/TR/sparql11-update/#deleteData
+   */
+  private async executeDeleteData(operation: sparqljs.InsertDeleteOperation): Promise<UpdateResult> {
+    if (operation.updateType !== "delete") {
+      throw new UpdateExecutorError("Expected DELETE DATA operation");
+    }
+
+    const deleteData = operation as { updateType: "delete"; delete: sparqljs.Quads[]; graph?: sparqljs.GraphOrDefault };
+
+    let deletedCount = 0;
+
+    for (const quads of deleteData.delete) {
+      if (quads.type === "bgp") {
+        const graphName = this.resolveGraphName(deleteData.graph);
+        deletedCount += await this.deleteTriples(quads.triples, graphName);
+      } else if (quads.type === "graph") {
+        const graphQuads = quads as sparqljs.GraphQuads;
+        const graphName = this.parseGraphName(graphQuads.name);
+        deletedCount += await this.deleteTriples(graphQuads.triples, graphName);
+      }
+    }
+
+    return {
+      type: "delete",
+      deleted: deletedCount,
+      success: true,
+    };
+  }
+
+  /**
+   * Insert triples into the triple store.
+   */
+  private async insertTriples(triples: sparqljs.Triple[], graphName: GraphName): Promise<number> {
+    let count = 0;
+
+    for (const sparqljsTriple of triples) {
+      const triple = this.convertTriple(sparqljsTriple);
+
+      if (graphName && this.tripleStore.addToGraph) {
+        await this.tripleStore.addToGraph(triple, graphName);
+      } else {
+        await this.tripleStore.add(triple);
+      }
+      count++;
+    }
+
+    return count;
+  }
+
+  /**
+   * Delete triples from the triple store.
+   */
+  private async deleteTriples(triples: sparqljs.Triple[], graphName: GraphName): Promise<number> {
+    let count = 0;
+
+    for (const sparqljsTriple of triples) {
+      const triple = this.convertTriple(sparqljsTriple);
+
+      let removed: boolean;
+      if (graphName && this.tripleStore.removeFromGraph) {
+        removed = await this.tripleStore.removeFromGraph(triple, graphName);
+      } else {
+        removed = await this.tripleStore.remove(triple);
+      }
+
+      if (removed) {
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  /**
+   * Convert a sparqljs Triple to our domain Triple.
+   */
+  private convertTriple(sparqljsTriple: sparqljs.Triple): Triple {
+    return new Triple(
+      this.convertSubject(sparqljsTriple.subject),
+      this.convertPredicate(sparqljsTriple.predicate),
+      this.convertObject(sparqljsTriple.object)
+    );
+  }
+
+  /**
+   * Convert a sparqljs subject term to our domain Subject.
+   */
+  private convertSubject(term: sparqljs.Term): Subject {
+    if (term.termType === "NamedNode") {
+      return new IRI(term.value);
+    }
+    if (term.termType === "BlankNode") {
+      return new BlankNode(term.value);
+    }
+    throw new UpdateExecutorError(`Invalid subject term type: ${term.termType}. Variables are not allowed in INSERT DATA.`);
+  }
+
+  /**
+   * Convert a sparqljs predicate term to our domain Predicate.
+   */
+  private convertPredicate(term: sparqljs.Term | sparqljs.PropertyPath): Predicate {
+    if ("termType" in term && term.termType === "NamedNode") {
+      return new IRI(term.value);
+    }
+    throw new UpdateExecutorError(`Invalid predicate term type. Only IRIs are allowed in INSERT DATA.`);
+  }
+
+  /**
+   * Convert a sparqljs object term to our domain Object.
+   */
+  private convertObject(term: sparqljs.Term): RDFObject {
+    if (term.termType === "NamedNode") {
+      return new IRI(term.value);
+    }
+    if (term.termType === "BlankNode") {
+      return new BlankNode(term.value);
+    }
+    if (term.termType === "Literal") {
+      const literal = term as sparqljs.LiteralTerm;
+      if (literal.language) {
+        return new Literal(literal.value, undefined, literal.language);
+      }
+      if (literal.datatype) {
+        return new Literal(literal.value, new IRI(literal.datatype.value));
+      }
+      return new Literal(literal.value);
+    }
+    throw new UpdateExecutorError(`Invalid object term type: ${term.termType}. Variables are not allowed in INSERT DATA.`);
+  }
+
+  /**
+   * Resolve a GraphOrDefault to a GraphName.
+   */
+  private resolveGraphName(graph?: sparqljs.GraphOrDefault): GraphName {
+    if (!graph) {
+      return undefined; // Default graph
+    }
+    if (graph.default) {
+      return undefined; // Explicitly the default graph
+    }
+    if (graph.name) {
+      return new IRI(graph.name.value);
+    }
+    return undefined;
+  }
+
+  /**
+   * Parse a graph name term to GraphName.
+   * In INSERT DATA and DELETE DATA, the graph name must be an IRI (not a variable).
+   */
+  private parseGraphName(term: sparqljs.IriTerm | sparqljs.VariableTerm): GraphName {
+    if (term.termType === "Variable") {
+      throw new UpdateExecutorError("Variables are not allowed as graph names in INSERT DATA / DELETE DATA.");
+    }
+    return new IRI(term.value);
+  }
+}

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/UpdateExecutor.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/UpdateExecutor.test.ts
@@ -1,0 +1,543 @@
+import { UpdateExecutor, UpdateExecutorError } from "../../../../../src/infrastructure/sparql/executors/UpdateExecutor";
+import { SPARQLParser } from "../../../../../src/infrastructure/sparql/SPARQLParser";
+import { InMemoryTripleStore } from "../../../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { IRI } from "../../../../../src/domain/models/rdf/IRI";
+import type { Update } from "../../../../../src/infrastructure/sparql/SPARQLParser";
+
+describe("UpdateExecutor", () => {
+  let executor: UpdateExecutor;
+  let tripleStore: InMemoryTripleStore;
+  let parser: SPARQLParser;
+
+  beforeEach(() => {
+    tripleStore = new InMemoryTripleStore();
+    executor = new UpdateExecutor(tripleStore);
+    parser = new SPARQLParser();
+  });
+
+  describe("INSERT DATA", () => {
+    it("should insert a single triple into default graph", async () => {
+      const query = `
+        INSERT DATA {
+          <http://example.org/subject> <http://example.org/predicate> "value" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].type).toBe("insert");
+      expect(results[0].inserted).toBe(1);
+      expect(results[0].success).toBe(true);
+
+      // Verify triple was added
+      const triples = await tripleStore.match(
+        new IRI("http://example.org/subject"),
+        new IRI("http://example.org/predicate")
+      );
+      expect(triples).toHaveLength(1);
+      expect(triples[0].object.toString()).toContain("value");
+    });
+
+    it("should insert multiple triples into default graph", async () => {
+      const query = `
+        INSERT DATA {
+          <http://example.org/s1> <http://example.org/p1> "value1" .
+          <http://example.org/s2> <http://example.org/p2> "value2" .
+          <http://example.org/s3> <http://example.org/p3> "value3" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].inserted).toBe(3);
+
+      // Verify all triples were added
+      const count = await tripleStore.count();
+      expect(count).toBe(3);
+    });
+
+    it("should insert triple with IRI object", async () => {
+      const query = `
+        INSERT DATA {
+          <http://example.org/subject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Class> .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await executor.execute(parsed);
+
+      const triples = await tripleStore.match(
+        new IRI("http://example.org/subject"),
+        new IRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+      );
+      expect(triples).toHaveLength(1);
+      expect(triples[0].object).toBeInstanceOf(IRI);
+    });
+
+    it("should insert triple with typed literal", async () => {
+      const query = `
+        INSERT DATA {
+          <http://example.org/subject> <http://example.org/age> "25"^^<http://www.w3.org/2001/XMLSchema#integer> .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await executor.execute(parsed);
+
+      const triples = await tripleStore.match(
+        new IRI("http://example.org/subject"),
+        new IRI("http://example.org/age")
+      );
+      expect(triples).toHaveLength(1);
+      expect(triples[0].object.toString()).toContain("25");
+    });
+
+    it("should insert triple with language-tagged literal", async () => {
+      const query = `
+        INSERT DATA {
+          <http://example.org/subject> <http://example.org/label> "Hello"@en .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await executor.execute(parsed);
+
+      const triples = await tripleStore.match(
+        new IRI("http://example.org/subject"),
+        new IRI("http://example.org/label")
+      );
+      expect(triples).toHaveLength(1);
+      expect(triples[0].object.toString()).toContain("@en");
+    });
+
+    it("should insert triples into named graph", async () => {
+      const query = `
+        INSERT DATA {
+          GRAPH <http://example.org/graph1> {
+            <http://example.org/s> <http://example.org/p> "value" .
+          }
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].inserted).toBe(1);
+
+      // Verify triple was added to named graph
+      const triples = await tripleStore.matchInGraph(
+        new IRI("http://example.org/s"),
+        new IRI("http://example.org/p"),
+        undefined,
+        new IRI("http://example.org/graph1")
+      );
+      expect(triples).toHaveLength(1);
+
+      // Verify triple is NOT in default graph
+      const defaultTriples = await tripleStore.match(
+        new IRI("http://example.org/s"),
+        new IRI("http://example.org/p")
+      );
+      expect(defaultTriples).toHaveLength(0);
+    });
+
+    it("should insert triples into multiple named graphs", async () => {
+      const query = `
+        INSERT DATA {
+          GRAPH <http://example.org/g1> {
+            <http://example.org/s1> <http://example.org/p1> "v1" .
+          }
+          GRAPH <http://example.org/g2> {
+            <http://example.org/s2> <http://example.org/p2> "v2" .
+          }
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results[0].inserted).toBe(2);
+
+      // Verify triples in respective graphs
+      const g1Triples = await tripleStore.matchInGraph(
+        new IRI("http://example.org/s1"),
+        undefined,
+        undefined,
+        new IRI("http://example.org/g1")
+      );
+      expect(g1Triples).toHaveLength(1);
+
+      const g2Triples = await tripleStore.matchInGraph(
+        new IRI("http://example.org/s2"),
+        undefined,
+        undefined,
+        new IRI("http://example.org/g2")
+      );
+      expect(g2Triples).toHaveLength(1);
+    });
+
+    it("should handle prefixed URIs", async () => {
+      const query = `
+        PREFIX ex: <http://example.org/>
+        INSERT DATA {
+          ex:subject ex:predicate "value" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await executor.execute(parsed);
+
+      const triples = await tripleStore.match(
+        new IRI("http://example.org/subject"),
+        new IRI("http://example.org/predicate")
+      );
+      expect(triples).toHaveLength(1);
+    });
+
+    it("should handle blank nodes", async () => {
+      const query = `
+        INSERT DATA {
+          _:b1 <http://example.org/predicate> "value" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results[0].inserted).toBe(1);
+
+      // Verify triple was added (blank node subject)
+      const count = await tripleStore.count();
+      expect(count).toBe(1);
+    });
+
+    it("should not duplicate existing triples", async () => {
+      const query = `
+        INSERT DATA {
+          <http://example.org/s> <http://example.org/p> "value" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+
+      // Insert twice
+      await executor.execute(parsed);
+      await executor.execute(parsed);
+
+      // Should still have only 1 triple (InMemoryTripleStore deduplicates)
+      const count = await tripleStore.count();
+      expect(count).toBe(1);
+    });
+  });
+
+  describe("DELETE DATA", () => {
+    beforeEach(async () => {
+      // Pre-populate the store
+      const insertQuery = `
+        INSERT DATA {
+          <http://example.org/s1> <http://example.org/p1> "v1" .
+          <http://example.org/s2> <http://example.org/p2> "v2" .
+          <http://example.org/s3> <http://example.org/p3> "v3" .
+        }
+      `;
+      const parsed = parser.parse(insertQuery) as Update;
+      await executor.execute(parsed);
+    });
+
+    it("should delete a single triple from default graph", async () => {
+      const query = `
+        DELETE DATA {
+          <http://example.org/s1> <http://example.org/p1> "v1" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].type).toBe("delete");
+      expect(results[0].deleted).toBe(1);
+      expect(results[0].success).toBe(true);
+
+      // Verify triple was removed
+      const triples = await tripleStore.match(
+        new IRI("http://example.org/s1")
+      );
+      expect(triples).toHaveLength(0);
+
+      // Verify other triples still exist
+      const count = await tripleStore.count();
+      expect(count).toBe(2);
+    });
+
+    it("should delete multiple triples from default graph", async () => {
+      const query = `
+        DELETE DATA {
+          <http://example.org/s1> <http://example.org/p1> "v1" .
+          <http://example.org/s2> <http://example.org/p2> "v2" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results[0].deleted).toBe(2);
+
+      const count = await tripleStore.count();
+      expect(count).toBe(1);
+    });
+
+    it("should handle deletion of non-existent triple (returns 0 deleted)", async () => {
+      const query = `
+        DELETE DATA {
+          <http://example.org/nonexistent> <http://example.org/p> "value" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results[0].deleted).toBe(0);
+      expect(results[0].success).toBe(true);
+
+      // Verify no triples were removed
+      const count = await tripleStore.count();
+      expect(count).toBe(3);
+    });
+
+    it("should delete triples from named graph", async () => {
+      // First insert into named graph
+      const insertQuery = `
+        INSERT DATA {
+          GRAPH <http://example.org/g1> {
+            <http://example.org/ns> <http://example.org/np> "nv" .
+          }
+        }
+      `;
+      const insertParsed = parser.parse(insertQuery) as Update;
+      await executor.execute(insertParsed);
+
+      // Then delete from named graph
+      const deleteQuery = `
+        DELETE DATA {
+          GRAPH <http://example.org/g1> {
+            <http://example.org/ns> <http://example.org/np> "nv" .
+          }
+        }
+      `;
+      const deleteParsed = parser.parse(deleteQuery) as Update;
+      const results = await executor.execute(deleteParsed);
+
+      expect(results[0].deleted).toBe(1);
+
+      // Verify triple was removed from named graph
+      const triples = await tripleStore.matchInGraph(
+        undefined,
+        undefined,
+        undefined,
+        new IRI("http://example.org/g1")
+      );
+      expect(triples).toHaveLength(0);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should throw error for non-update query", async () => {
+      const selectQuery = parser.parse("SELECT * WHERE { ?s ?p ?o }");
+
+      await expect(executor.execute(selectQuery as any)).rejects.toThrow(
+        UpdateExecutorError
+      );
+    });
+
+    it("should throw error for unsupported INSERT/DELETE with WHERE", async () => {
+      // Note: sparqljs parses this differently, but we test the error path
+      const query = `
+        DELETE { ?s <http://example.org/p> ?o }
+        INSERT { ?s <http://example.org/p> "new" }
+        WHERE { ?s <http://example.org/p> ?o }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await expect(executor.execute(parsed)).rejects.toThrow(
+        "INSERT/DELETE with WHERE clause not yet implemented"
+      );
+    });
+
+    it("should throw error for DELETE WHERE", async () => {
+      const query = `
+        DELETE WHERE { ?s <http://example.org/p> ?o }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await expect(executor.execute(parsed)).rejects.toThrow(
+        "DELETE WHERE not yet implemented"
+      );
+    });
+
+    it("should throw error for CLEAR operation", async () => {
+      const query = `
+        CLEAR GRAPH <http://example.org/g1>
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await expect(executor.execute(parsed)).rejects.toThrow(
+        "CLEAR operation not yet implemented"
+      );
+    });
+
+    it("should throw error for DROP operation", async () => {
+      const query = `
+        DROP GRAPH <http://example.org/g1>
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await expect(executor.execute(parsed)).rejects.toThrow(
+        "DROP operation not yet implemented"
+      );
+    });
+
+    it("should throw error for LOAD operation", async () => {
+      const query = `
+        LOAD <http://example.org/data.ttl>
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await expect(executor.execute(parsed)).rejects.toThrow(
+        "LOAD operation not yet implemented"
+      );
+    });
+
+    it("should throw error for CREATE operation", async () => {
+      const query = `
+        CREATE GRAPH <http://example.org/newgraph>
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      await expect(executor.execute(parsed)).rejects.toThrow(
+        "CREATE operation not yet implemented"
+      );
+    });
+  });
+
+  describe("Multiple operations in single update", () => {
+    it("should execute multiple operations sequentially", async () => {
+      const query = `
+        INSERT DATA {
+          <http://example.org/s1> <http://example.org/p1> "v1" .
+        } ;
+        INSERT DATA {
+          <http://example.org/s2> <http://example.org/p2> "v2" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].type).toBe("insert");
+      expect(results[0].inserted).toBe(1);
+      expect(results[1].type).toBe("insert");
+      expect(results[1].inserted).toBe(1);
+
+      const count = await tripleStore.count();
+      expect(count).toBe(2);
+    });
+
+    it("should execute INSERT then DELETE", async () => {
+      const query = `
+        INSERT DATA {
+          <http://example.org/s> <http://example.org/p> "initial" .
+        } ;
+        DELETE DATA {
+          <http://example.org/s> <http://example.org/p> "initial" .
+        } ;
+        INSERT DATA {
+          <http://example.org/s> <http://example.org/p> "updated" .
+        }
+      `;
+
+      const parsed = parser.parse(query) as Update;
+      const results = await executor.execute(parsed);
+
+      expect(results).toHaveLength(3);
+
+      // Verify final state
+      const triples = await tripleStore.match(
+        new IRI("http://example.org/s"),
+        new IRI("http://example.org/p")
+      );
+      expect(triples).toHaveLength(1);
+      expect(triples[0].object.toString()).toContain("updated");
+    });
+  });
+});
+
+describe("SPARQLParser UPDATE support", () => {
+  let parser: SPARQLParser;
+
+  beforeEach(() => {
+    parser = new SPARQLParser();
+  });
+
+  it("should parse INSERT DATA query", () => {
+    const query = `
+      INSERT DATA {
+        <http://example.org/s> <http://example.org/p> "value" .
+      }
+    `;
+
+    const parsed = parser.parse(query);
+    expect(parser.isUpdateQuery(parsed)).toBe(true);
+  });
+
+  it("should parse DELETE DATA query", () => {
+    const query = `
+      DELETE DATA {
+        <http://example.org/s> <http://example.org/p> "value" .
+      }
+    `;
+
+    const parsed = parser.parse(query);
+    expect(parser.isUpdateQuery(parsed)).toBe(true);
+  });
+
+  it("should distinguish UPDATE from SELECT", () => {
+    const selectQuery = parser.parse("SELECT * WHERE { ?s ?p ?o }");
+    const updateQuery = parser.parse("INSERT DATA { <http://example.org/s> <http://example.org/p> 'o' . }");
+
+    expect(parser.isUpdateQuery(selectQuery)).toBe(false);
+    expect(parser.isSelectQuery(selectQuery)).toBe(true);
+    expect(parser.isUpdateQuery(updateQuery)).toBe(true);
+    expect(parser.isSelectQuery(updateQuery)).toBe(false);
+  });
+
+  it("should identify INSERT DATA operation type", () => {
+    const query = `INSERT DATA { <http://example.org/s> <http://example.org/p> 'o' . }`;
+    const parsed = parser.parse(query);
+
+    expect(parser.isUpdateQuery(parsed)).toBe(true);
+    if (parser.isUpdateQuery(parsed)) {
+      expect(parsed.updates).toHaveLength(1);
+      expect(parser.isInsertDataOperation(parsed.updates[0])).toBe(true);
+      expect(parser.isDeleteDataOperation(parsed.updates[0])).toBe(false);
+    }
+  });
+
+  it("should identify DELETE DATA operation type", () => {
+    const query = `DELETE DATA { <http://example.org/s> <http://example.org/p> 'o' . }`;
+    const parsed = parser.parse(query);
+
+    expect(parser.isUpdateQuery(parsed)).toBe(true);
+    if (parser.isUpdateQuery(parsed)) {
+      expect(parsed.updates).toHaveLength(1);
+      expect(parser.isDeleteDataOperation(parsed.updates[0])).toBe(true);
+      expect(parser.isInsertDataOperation(parsed.updates[0])).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Implements the INSERT DATA operation for adding static triples to the graph. This is the first SPARQL 1.1 Update operation to be supported.

Closes #930

## Changes
- Add `UpdateExecutor` class for handling UPDATE operations
- Add `isUpdateQuery()`, `isInsertDataOperation()`, `isDeleteDataOperation()` methods to `SPARQLParser`
- Export `Update`, `UpdateOperation` types from `SPARQLParser`
- Support for:
  - INSERT DATA with default graph
  - INSERT DATA with named graphs (GRAPH clause)
  - DELETE DATA operation (basic implementation)
  - Multiple operations in single UPDATE request

## Test Plan
- [x] 28 new unit tests added for UpdateExecutor
- [x] All existing tests pass
- [x] Build succeeds
- [x] Lint passes (only pre-existing warnings)

## Example Usage
```sparql
-- Insert single triple
INSERT DATA {
  <http://example/s> <http://example/p> "value" .
}

-- Insert into named graph
INSERT DATA {
  GRAPH <http://example/graph1> {
    <http://example/s> <http://example/p> "value" .
  }
}

-- Delete triple
DELETE DATA {
  <http://example/s> <http://example/p> "value" .
}
```

## Files Changed
- `packages/exocortex/src/infrastructure/sparql/SPARQLParser.ts` - Added update query type guards
- `packages/exocortex/src/infrastructure/sparql/executors/UpdateExecutor.ts` - New executor for UPDATE operations
- `packages/exocortex/tests/unit/infrastructure/sparql/executors/UpdateExecutor.test.ts` - 28 test cases
- `packages/exocortex/src/index.ts` - Export new types and executor