### PR TITLE
docs: Remove broken links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,12 +330,10 @@ On **collective level** — multiple exocortexes form **noosphere**.
 
 ### Getting Started
 - **[Installation Guide](./docs/Getting-Started.md)** — Step-by-step setup
-- **[First Steps](./docs/First-Steps.md)** — Your first knowledge assets
 
 ### By Interface
 
 **Obsidian Plugin:**
-- **[Plugin User Guide](./docs/obsidian/User-Guide.md)** — Complete feature reference
 - **[Command Reference](./docs/Command-Reference.md)** — All 32 commands documented
 
 **CLI:**


### PR DESCRIPTION
## Summary
- Removed link to `./docs/First-Steps.md` (file doesn't exist)
- Removed link to `./docs/obsidian/User-Guide.md` (directory doesn't exist)

## Verification
All remaining links in the README Documentation section were verified as working:
- ✅ `./docs/Getting-Started.md`
- ✅ `./docs/Command-Reference.md`
- ✅ `./docs/cli/Command-Reference.md`
- ✅ `./docs/cli/Scripting-Patterns.md`
- ✅ `./docs/api/Core-API.md`
- ✅ `./ARCHITECTURE.md`
- ✅ `./docs/sparql/User-Guide.md`
- ✅ `./docs/sparql/Query-Examples.md`
- ✅ `./CLAUDE.md`
- ✅ `./LICENSE`

## Test plan
- [x] Verify broken links removed
- [x] Verify remaining links still work