### PR TITLE
feat: Add comprehensive SPARQL 1.1 compliance test suite

### DIFF
--- a/packages/exocortex/tests/compliance/sparql/aggregates.test.ts
+++ b/packages/exocortex/tests/compliance/sparql/aggregates.test.ts
@@ -1,0 +1,195 @@
+/**
+ * SPARQL 1.1 Aggregates Compliance Tests
+ *
+ * Coverage Status:
+ * - COUNT: ✅ Implemented
+ * - COUNT DISTINCT: ✅ Implemented
+ * - SUM: ✅ Implemented
+ * - AVG: ✅ Implemented
+ * - MIN: ✅ Implemented
+ * - MAX: ✅ Implemented
+ * - GROUP BY: ✅ Implemented
+ * - HAVING: ⚠️ Partial (not correctly filtering)
+ * - GROUP_CONCAT: ❌ Not tested
+ * - SAMPLE: ❌ Not tested
+ */
+
+import {
+  createTestEnvironment,
+  loadTestData,
+  executeQuery,
+  buildPrefixes,
+  TEST_DATA,
+} from "./sparql-test-utils";
+
+describe("SPARQL 1.1 Aggregates Compliance", () => {
+  describe("COUNT", () => {
+    it("should count all results", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT (COUNT(*) AS ?count) WHERE {
+          ?person foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].count).toBe(3);
+    });
+
+    it("should count distinct values", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (COUNT(DISTINCT ?category) AS ?count) WHERE {
+          ?item ex:category ?category
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].count).toBe(2);
+    });
+  });
+
+  describe("SUM", () => {
+    it("should sum numeric values", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (SUM(?value) AS ?total) WHERE {
+          ?item ex:value ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].total).toBe(150);
+    });
+  });
+
+  describe("AVG", () => {
+    it("should calculate average", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (AVG(?value) AS ?average) WHERE {
+          ?item ex:value ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].average).toBe(30);
+    });
+  });
+
+  describe("MIN", () => {
+    it("should find minimum value", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (MIN(?value) AS ?min) WHERE {
+          ?item ex:value ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].min).toBe(10);
+    });
+  });
+
+  describe("MAX", () => {
+    it("should find maximum value", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (MAX(?value) AS ?max) WHERE {
+          ?item ex:value ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].max).toBe(50);
+    });
+  });
+
+  describe("GROUP BY", () => {
+    it("should group results by variable", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT ?category (SUM(?value) AS ?total) WHERE {
+          ?item ex:category ?category .
+          ?item ex:value ?value
+        }
+        GROUP BY ?category
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+      const catA = results.find((r) => r.category === "A");
+      const catB = results.find((r) => r.category === "B");
+      expect(catA?.total).toBe(30);
+      expect(catB?.total).toBe(120);
+    });
+  });
+
+  describe("HAVING", () => {
+    // HAVING is not correctly filtering grouped results
+    it.skip("should filter grouped results", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT ?category (SUM(?value) AS ?total) WHERE {
+          ?item ex:category ?category .
+          ?item ex:value ?value
+        }
+        GROUP BY ?category
+        HAVING (SUM(?value) > 50)
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].category).toBe("B");
+    });
+
+    it("should return all groups when HAVING is present (current behavior)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT ?category (SUM(?value) AS ?total) WHERE {
+          ?item ex:category ?category .
+          ?item ex:value ?value
+        }
+        GROUP BY ?category
+        HAVING (SUM(?value) > 50)
+      `;
+
+      const results = await executeQuery(executor, query);
+      // Current implementation doesn't filter by HAVING
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/packages/exocortex/tests/compliance/sparql/built-in-functions.test.ts
+++ b/packages/exocortex/tests/compliance/sparql/built-in-functions.test.ts
@@ -1,0 +1,619 @@
+/**
+ * SPARQL 1.1 Built-in Functions Compliance Tests
+ *
+ * Coverage Status:
+ * String Functions:
+ * - STRLEN: ⚠️ Returns string instead of number
+ * - SUBSTR: ✅ Implemented
+ * - UCASE: ✅ Implemented
+ * - LCASE: ✅ Implemented
+ * - CONCAT: ✅ Implemented
+ * - CONTAINS: ✅ Implemented
+ * - STRSTARTS: ✅ Implemented
+ * - STRENDS: ✅ Implemented
+ * - REPLACE: ✅ Implemented
+ *
+ * Numeric Functions:
+ * - ABS: ❌ Not working (returns undefined)
+ * - ROUND: ❌ Not working (returns undefined)
+ * - CEIL: ❌ Not working (returns undefined)
+ * - FLOOR: ❌ Not working (returns undefined)
+ *
+ * Date/Time Functions:
+ * - YEAR: ⚠️ Returns string instead of number
+ * - MONTH: ⚠️ Returns string instead of number
+ * - DAY: ⚠️ Returns string instead of number
+ * - HOURS: ⚠️ Returns string (and may have timezone issues)
+ * - MINUTES: ⚠️ Returns string instead of number
+ * - NOW: ✅ Implemented
+ *
+ * Type Functions:
+ * - BOUND: ⚠️ Partial (returns string "true"/"false")
+ * - IF: ✅ Implemented
+ * - COALESCE: ⚠️ Partial (only returns when first value exists)
+ * - isIRI: ⚠️ Returns string instead of boolean
+ * - isLiteral: ⚠️ Returns string instead of boolean
+ * - isNumeric: ⚠️ Returns string instead of boolean
+ * - STR: ✅ Implemented
+ *
+ * Hash Functions:
+ * - MD5: ✅ Implemented
+ * - SHA1: ✅ Implemented
+ *
+ * Constructor Functions:
+ * - IRI: ⚠️ Partial (nested IRI(CONCAT(...)) not working)
+ * - STRDT: ⚠️ Partial (not working)
+ */
+
+import {
+  createTestEnvironment,
+  loadTestData,
+  executeQuery,
+  buildPrefixes,
+  TEST_DATA,
+  iri,
+  triple,
+  xsd,
+  PREFIXES,
+} from "./sparql-test-utils";
+
+describe("SPARQL 1.1 Built-in Functions Compliance", () => {
+  describe("String Functions", () => {
+    it("should evaluate STRLEN (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (STRLEN(?name) AS ?len) WHERE {
+          ?person foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      const alice = results.find((r) => r.name === "Alice");
+      // Current implementation returns string instead of number
+      expect(alice?.len).toBe("5");
+    });
+
+    it("should evaluate SUBSTR", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (SUBSTR(?name, 1, 3) AS ?sub) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].sub).toBe("Ali");
+    });
+
+    it("should evaluate UCASE", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (UCASE(?name) AS ?upper) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].upper).toBe("ALICE");
+    });
+
+    it("should evaluate LCASE", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (LCASE(?name) AS ?lower) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].lower).toBe("alice");
+    });
+
+    it("should evaluate CONCAT", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT (CONCAT(?name, " Smith") AS ?fullName) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].fullName).toBe("Alice Smith");
+    });
+
+    it("should evaluate CONTAINS", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+          FILTER(CONTAINS(?name, "lic"))
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("Alice");
+    });
+
+    it("should evaluate STRSTARTS", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+          FILTER(STRSTARTS(?name, "A"))
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("Alice");
+    });
+
+    it("should evaluate STRENDS", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+          FILTER(STRENDS(?name, "e"))
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+    });
+
+    it("should evaluate REPLACE", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT (REPLACE(?name, "Alice", "Alicia") AS ?newName) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].newName).toBe("Alicia");
+    });
+  });
+
+  describe("Numeric Functions", () => {
+    // ABS not working - returns undefined
+    it.skip("should evaluate ABS", async () => {
+      const { store, executor } = createTestEnvironment();
+      const ex = PREFIXES.ex;
+      await loadTestData(store, [
+        triple(iri(`${ex}item`), iri(`${ex}value`), xsd.integer(-42)),
+      ]);
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (ABS(?value) AS ?abs) WHERE {
+          ex:item ex:value ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].abs).toBe(42);
+    });
+
+    it("should return result with ABS (current behavior: returns undefined)", async () => {
+      const { store, executor } = createTestEnvironment();
+      const ex = PREFIXES.ex;
+      await loadTestData(store, [
+        triple(iri(`${ex}item`), iri(`${ex}value`), xsd.integer(-42)),
+      ]);
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT ?value (ABS(?value) AS ?abs) WHERE {
+          ex:item ex:value ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      // ABS function returns undefined in current implementation
+      expect(results[0].value).toBe(-42);
+    });
+
+    // ROUND not working - returns undefined
+    it.skip("should evaluate ROUND", async () => {
+      const { store, executor } = createTestEnvironment();
+      const ex = PREFIXES.ex;
+      await loadTestData(store, [
+        triple(iri(`${ex}item`), iri(`${ex}value`), xsd.decimal("3.7")),
+      ]);
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (ROUND(?value) AS ?rounded) WHERE {
+          ex:item ex:value ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].rounded).toBe(4);
+    });
+
+    // CEIL not working - returns undefined
+    it.skip("should evaluate CEIL", async () => {
+      const { store, executor } = createTestEnvironment();
+      const ex = PREFIXES.ex;
+      await loadTestData(store, [
+        triple(iri(`${ex}item`), iri(`${ex}value`), xsd.decimal("3.2")),
+      ]);
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (CEIL(?value) AS ?ceiling) WHERE {
+          ex:item ex:value ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].ceiling).toBe(4);
+    });
+
+    // FLOOR not working - returns undefined
+    it.skip("should evaluate FLOOR", async () => {
+      const { store, executor } = createTestEnvironment();
+      const ex = PREFIXES.ex;
+      await loadTestData(store, [
+        triple(iri(`${ex}item`), iri(`${ex}value`), xsd.decimal("3.7")),
+      ]);
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (FLOOR(?value) AS ?floor) WHERE {
+          ex:item ex:value ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].floor).toBe(3);
+    });
+  });
+
+  describe("Date/Time Functions", () => {
+    it("should evaluate YEAR (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.dateTimeData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (YEAR(?date) AS ?year) WHERE {
+          ex:event1 ex:date ?date
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      // Current implementation returns string instead of number
+      expect(results[0].year).toBe("2024");
+    });
+
+    it("should evaluate MONTH (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.dateTimeData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (MONTH(?date) AS ?month) WHERE {
+          ex:event2 ex:date ?date
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      // Current implementation returns string instead of number
+      expect(results[0].month).toBe("6");
+    });
+
+    it("should evaluate DAY (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.dateTimeData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (DAY(?date) AS ?day) WHERE {
+          ex:event3 ex:date ?date
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      // Current implementation returns string instead of number
+      expect(results[0].day).toBe("25");
+    });
+
+    it("should evaluate HOURS (returns string, may have timezone offset)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.dateTimeData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (HOURS(?date) AS ?hours) WHERE {
+          ex:event1 ex:date ?date
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      // Current implementation may return string and apply local timezone offset
+      // Expected 10 (UTC), but may get different value based on system timezone
+      expect(typeof results[0].hours).toBe("string");
+    });
+
+    it("should evaluate MINUTES (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.dateTimeData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT (MINUTES(?date) AS ?minutes) WHERE {
+          ex:event1 ex:date ?date
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      // Current implementation returns string instead of number
+      expect(results[0].minutes).toBe("30");
+    });
+
+    it("should evaluate NOW", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT (NOW() AS ?now) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].now).toBeDefined();
+    });
+  });
+
+  describe("Type Functions", () => {
+    it("should evaluate BOUND (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (BOUND(?mbox) AS ?hasMbox) WHERE {
+          ?person foaf:name ?name
+          OPTIONAL { ?person foaf:mbox ?mbox }
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      // OPTIONAL currently only returns matching rows
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      const alice = results.find((r) => r.name === "Alice");
+      if (alice) {
+        // BOUND returns string "true" or "false"
+        expect(alice.hasMbox).toBe("true");
+      }
+    });
+
+    it("should evaluate IF", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (IF(?age > 30, "senior", "junior") AS ?category) WHERE {
+          ?person foaf:name ?name .
+          ?person foaf:age ?age
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      const alice = results.find((r) => r.name === "Alice");
+      expect(alice?.category).toBe("junior");
+      const charlie = results.find((r) => r.name === "Charlie");
+      expect(charlie?.category).toBe("senior");
+    });
+
+    // COALESCE with OPTIONAL not working as expected
+    it.skip("should evaluate COALESCE with fallback", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (COALESCE(?mbox, "no-email") AS ?email) WHERE {
+          ?person foaf:name ?name
+          OPTIONAL { ?person foaf:mbox ?mbox }
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      const alice = results.find((r) => r.name === "Alice");
+      expect(alice?.email).toBe("mailto:alice@example.org");
+      const bob = results.find((r) => r.name === "Bob");
+      expect(bob?.email).toBe("no-email");
+    });
+
+    it("should evaluate isIRI (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (isIRI(?mbox) AS ?isUri) WHERE {
+          ex:alice foaf:name ?name .
+          ex:alice foaf:mbox ?mbox
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      // isIRI returns string "true" instead of boolean true
+      expect(results[0].isUri).toBe("true");
+    });
+
+    it("should evaluate isLiteral (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (isLiteral(?name) AS ?isLit) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      // isLiteral returns string "true" instead of boolean true
+      expect(results[0].isLit).toBe("true");
+    });
+
+    it("should evaluate isNumeric (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?age (isNumeric(?age) AS ?isNum) WHERE {
+          ex:alice foaf:age ?age
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      // isNumeric returns string "true" instead of boolean true
+      expect(results[0].isNum).toBe("true");
+    });
+
+    it("should evaluate STR", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT (STR(?age) AS ?ageStr) WHERE {
+          ex:alice foaf:age ?age
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].ageStr).toBe("30");
+    });
+  });
+
+  describe("Hash Functions", () => {
+    it("should evaluate MD5", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT (MD5(?name) AS ?hash) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(typeof results[0].hash).toBe("string");
+    });
+
+    it("should evaluate SHA1", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT (SHA1(?name) AS ?hash) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(typeof results[0].hash).toBe("string");
+    });
+  });
+
+  describe("Constructor Functions", () => {
+    // IRI constructor with nested CONCAT not working
+    it.skip("should evaluate IRI constructor", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT (IRI(CONCAT("http://example.org/", ?name)) AS ?personIri) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].personIri).toBe("http://example.org/Alice");
+    });
+
+    // STRDT not working
+    it.skip("should evaluate STRDT", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex", "xsd")}
+        SELECT (STRDT("42", xsd:integer) AS ?num) WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].num).toBe(42);
+    });
+  });
+});

--- a/packages/exocortex/tests/compliance/sparql/graph-patterns.test.ts
+++ b/packages/exocortex/tests/compliance/sparql/graph-patterns.test.ts
@@ -1,0 +1,227 @@
+/**
+ * SPARQL 1.1 Graph Patterns Compliance Tests
+ *
+ * Coverage Status:
+ * - BGP: ✅ Implemented
+ * - OPTIONAL: ⚠️ Partial (only returns matching results, not left outer join)
+ * - UNION: ✅ Implemented
+ * - MINUS: ⚠️ Partial (not correctly excluding)
+ * - FILTER: ✅ Implemented
+ * - VALUES: ✅ Implemented
+ * - BIND: ⚠️ Partial (returns string instead of typed value)
+ * - GRAPH: ❌ Not implemented
+ */
+
+import {
+  createTestEnvironment,
+  loadTestData,
+  executeQuery,
+  buildPrefixes,
+  TEST_DATA,
+} from "./sparql-test-utils";
+
+describe("SPARQL 1.1 Graph Patterns Compliance", () => {
+  describe("Basic Graph Pattern (BGP)", () => {
+    it("should match simple triple pattern", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ex:alice foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("Alice");
+    });
+
+    it("should match multiple triple patterns", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name ?age WHERE {
+          ex:alice foaf:name ?name .
+          ex:alice foaf:age ?age
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("Alice");
+      expect(results[0].age).toBe(30);
+    });
+  });
+
+  describe("OPTIONAL", () => {
+    // OPTIONAL currently only returns rows where the optional pattern matches
+    // This is incorrect - it should return all rows from the left side
+    it.skip("should include optional matches when present (left outer join)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?person ?name ?mbox WHERE {
+          ?person foaf:name ?name
+          OPTIONAL { ?person foaf:mbox ?mbox }
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      const alice = results.find((r) => r.name === "Alice");
+      expect(alice?.mbox).toBeDefined();
+      const bob = results.find((r) => r.name === "Bob");
+      expect(bob?.mbox).toBeUndefined();
+    });
+
+    it("should return results when optional pattern matches", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?person ?name ?mbox WHERE {
+          ?person foaf:name ?name
+          OPTIONAL { ?person foaf:mbox ?mbox }
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      // Currently returns only the row with mbox (Alice)
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      const alice = results.find((r) => r.name === "Alice");
+      expect(alice?.mbox).toBeDefined();
+    });
+  });
+
+  describe("UNION", () => {
+    it("should combine results from multiple patterns", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          { ex:alice foaf:name ?name }
+          UNION
+          { ex:bob foaf:name ?name }
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+      const names = results.map((r) => r.name);
+      expect(names).toContain("Alice");
+      expect(names).toContain("Bob");
+    });
+  });
+
+  describe("MINUS", () => {
+    // MINUS is not correctly excluding matching patterns
+    it.skip("should exclude matching patterns", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?person ?name WHERE {
+          ?person foaf:name ?name
+          MINUS { ?person foaf:mbox ?mbox }
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+      const names = results.map((r) => r.name);
+      expect(names).not.toContain("Alice");
+    });
+  });
+
+  describe("FILTER", () => {
+    it("should filter with comparison operators", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name ?age WHERE {
+          ?person foaf:name ?name .
+          ?person foaf:age ?age
+          FILTER (?age > 25)
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+      results.forEach((r) => {
+        expect(Number(r.age)).toBeGreaterThan(25);
+      });
+    });
+
+    it("should filter with REGEX", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+          FILTER (REGEX(?name, "^A"))
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("Alice");
+    });
+  });
+
+  describe("VALUES", () => {
+    it("should inline data with single variable", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?person ?name WHERE {
+          VALUES ?person { ex:alice ex:bob }
+          ?person foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+      const names = results.map((r) => r.name);
+      expect(names).toContain("Alice");
+      expect(names).toContain("Bob");
+    });
+  });
+
+  describe("BIND", () => {
+    it("should bind expression result to variable (as string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name ?doubleAge WHERE {
+          ?person foaf:name ?name .
+          ?person foaf:age ?age
+          BIND (?age * 2 AS ?doubleAge)
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      const alice = results.find((r) => r.name === "Alice");
+      // Note: BIND returns string values for computed expressions
+      expect(alice?.doubleAge).toBe("60");
+    });
+  });
+});

--- a/packages/exocortex/tests/compliance/sparql/property-paths.test.ts
+++ b/packages/exocortex/tests/compliance/sparql/property-paths.test.ts
@@ -1,0 +1,152 @@
+/**
+ * SPARQL 1.1 Property Paths Compliance Tests
+ *
+ * Coverage Status:
+ * - Sequence Path (/): ✅ Implemented
+ * - Alternative Path (|): ✅ Implemented
+ * - Inverse Path (^): ✅ Implemented
+ * - Zero or More (*): ✅ Implemented
+ * - One or More (+): ✅ Implemented
+ * - Zero or One (?): ✅ Implemented
+ * - Negated Property Set (!): ❌ Not implemented
+ */
+
+import {
+  createTestEnvironment,
+  loadTestData,
+  executeQuery,
+  buildPrefixes,
+  TEST_DATA,
+} from "./sparql-test-utils";
+
+describe("SPARQL 1.1 Property Paths Compliance", () => {
+  describe("Sequence Path (/)", () => {
+    it("should follow sequence of properties", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?friend WHERE {
+          ex:alice foaf:knows/foaf:name ?friend
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].friend).toBe("Bob");
+    });
+  });
+
+  describe("Alternative Path (|)", () => {
+    it("should match either property", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?value WHERE {
+          ex:alice (foaf:name|foaf:mbox) ?value
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+    });
+  });
+
+  describe("Inverse Path (^)", () => {
+    it("should follow property in reverse direction", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?knower WHERE {
+          ex:bob ^foaf:knows ?knower
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].knower).toBe("http://example.org/alice");
+    });
+  });
+
+  describe("Zero or More (*)", () => {
+    it("should match transitive closure", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.hierarchy());
+
+      const query = `
+        ${buildPrefixes("ex", "rdfs")}
+        SELECT ?class WHERE {
+          ex:Dog rdfs:subClassOf* ?class
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("One or More (+)", () => {
+    it("should match at least one step", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.hierarchy());
+
+      const query = `
+        ${buildPrefixes("ex", "rdfs")}
+        SELECT ?class WHERE {
+          ex:Dog rdfs:subClassOf+ ?class
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBeGreaterThanOrEqual(2);
+      const classes = results.map((r) => r.class);
+      expect(classes).not.toContain("http://example.org/Dog");
+    });
+  });
+
+  describe("Zero or One (?)", () => {
+    it("should match zero or one step", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.hierarchy());
+
+      const query = `
+        ${buildPrefixes("ex", "rdfs")}
+        SELECT ?class WHERE {
+          ex:Dog rdfs:subClassOf? ?class
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBeGreaterThanOrEqual(2);
+      const classes = results.map((r) => r.class);
+      expect(classes).toContain("http://example.org/Dog");
+    });
+  });
+
+  describe("Negated Property Set (!)", () => {
+    // Negated property sets are not yet implemented in AlgebraTranslator
+    it.skip("should match properties not in set", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?p ?o WHERE {
+          ex:alice !foaf:name ?o
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBeGreaterThanOrEqual(2);
+      const hasName = results.some(
+        (r) => r.o === "Alice"
+      );
+      expect(hasName).toBe(false);
+    });
+  });
+});

--- a/packages/exocortex/tests/compliance/sparql/query-forms.test.ts
+++ b/packages/exocortex/tests/compliance/sparql/query-forms.test.ts
@@ -1,0 +1,133 @@
+/**
+ * SPARQL 1.1 Query Forms Compliance Tests
+ *
+ * Coverage Status:
+ * - SELECT: ✅ Implemented
+ * - ASK: ❌ Not implemented (QueryExecutor doesn't support 'ask' operation type)
+ * - CONSTRUCT: ❌ Not implemented (QueryExecutor doesn't support 'construct' operation type)
+ * - DESCRIBE: ❌ Not implemented
+ */
+
+import {
+  createTestEnvironment,
+  loadTestData,
+  executeQuery,
+  executeConstructQuery,
+  buildPrefixes,
+  TEST_DATA,
+} from "./sparql-test-utils";
+
+describe("SPARQL 1.1 Query Forms Compliance", () => {
+  describe("SELECT", () => {
+    it("should return selected variables", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      const names = results.map((r) => r.name);
+      expect(names).toContain("Alice");
+      expect(names).toContain("Bob");
+      expect(names).toContain("Charlie");
+    });
+
+    it("should handle SELECT *", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT * WHERE {
+          ex:alice foaf:name ?name .
+          ex:alice foaf:age ?age
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("Alice");
+      expect(results[0].age).toBe(30);
+    });
+
+    it("should handle SELECT with expressions (returns string)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name (?age * 2 AS ?doubleAge) WHERE {
+          ?person foaf:name ?name .
+          ?person foaf:age ?age
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      const alice = results.find((r) => r.name === "Alice");
+      // Note: Computed expressions return strings, not numbers
+      // This is a known limitation tracked for future improvement
+      expect(alice?.doubleAge).toBe("60");
+    });
+  });
+
+  describe("ASK", () => {
+    // ASK queries are not yet implemented in QueryExecutor
+    it.skip("should return true when pattern matches", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        ASK WHERE {
+          ex:alice foaf:name "Alice"
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(1);
+    });
+
+    // ASK queries are not yet implemented in QueryExecutor
+    it.skip("should return empty when pattern does not match", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        ASK WHERE {
+          ex:alice foaf:name "NonExistent"
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(0);
+    });
+  });
+
+  describe("CONSTRUCT", () => {
+    // CONSTRUCT queries are not yet implemented in QueryExecutor
+    it.skip("should construct new triples from pattern", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        CONSTRUCT {
+          ?person ex:hasName ?name
+        } WHERE {
+          ?person foaf:name ?name
+        }
+      `;
+
+      const triples = await executeConstructQuery(executor, query);
+      expect(triples.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/packages/exocortex/tests/compliance/sparql/solution-modifiers.test.ts
+++ b/packages/exocortex/tests/compliance/sparql/solution-modifiers.test.ts
@@ -1,0 +1,300 @@
+/**
+ * SPARQL 1.1 Solution Modifiers Compliance Tests
+ *
+ * Coverage Status:
+ * - DISTINCT: ⚠️ Partial (not correctly deduplicating)
+ * - REDUCED: ✅ Implemented
+ * - ORDER BY: ✅ Implemented
+ * - ORDER BY DESC: ✅ Implemented
+ * - ORDER BY multiple: ✅ Implemented
+ * - ORDER BY expression: ⚠️ Partial (STRLEN expression not working)
+ * - LIMIT: ✅ Implemented
+ * - OFFSET: ✅ Implemented
+ * - Pagination (LIMIT + OFFSET): ✅ Implemented
+ */
+
+import {
+  createTestEnvironment,
+  loadTestData,
+  executeQuery,
+  buildPrefixes,
+  TEST_DATA,
+} from "./sparql-test-utils";
+
+describe("SPARQL 1.1 Solution Modifiers Compliance", () => {
+  describe("DISTINCT", () => {
+    // DISTINCT is not correctly deduplicating results
+    it.skip("should remove duplicate solutions", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT DISTINCT ?category WHERE {
+          ?item ex:category ?category
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+      const categories = results.map((r) => r.category);
+      expect(categories).toContain("A");
+      expect(categories).toContain("B");
+    });
+
+    it("should return results with DISTINCT (current behavior: not deduplicating)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT DISTINCT ?category WHERE {
+          ?item ex:category ?category
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      // Current implementation returns 5 (not deduped) instead of 2
+      expect(results.length).toBeGreaterThanOrEqual(2);
+      const categories = results.map((r) => r.category);
+      expect(categories).toContain("A");
+      expect(categories).toContain("B");
+    });
+  });
+
+  describe("REDUCED", () => {
+    it("should allow but not require duplicate elimination", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT REDUCED ?category WHERE {
+          ?item ex:category ?category
+        }
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBeGreaterThanOrEqual(2);
+      expect(results.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  describe("ORDER BY", () => {
+    it("should order results ascending", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name ?age WHERE {
+          ?person foaf:name ?name .
+          ?person foaf:age ?age
+        }
+        ORDER BY ?age
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      expect(results[0].age).toBe(25);
+      expect(results[1].age).toBe(30);
+      expect(results[2].age).toBe(35);
+    });
+
+    it("should order results descending", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name ?age WHERE {
+          ?person foaf:name ?name .
+          ?person foaf:age ?age
+        }
+        ORDER BY DESC(?age)
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      expect(results[0].age).toBe(35);
+      expect(results[1].age).toBe(30);
+      expect(results[2].age).toBe(25);
+    });
+
+    it("should order by multiple variables", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT ?category ?value WHERE {
+          ?item ex:category ?category .
+          ?item ex:value ?value
+        }
+        ORDER BY ?category DESC(?value)
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(5);
+      expect(results[0].category).toBe("A");
+      expect(results[0].value).toBe(20);
+      expect(results[1].category).toBe("A");
+      expect(results[1].value).toBe(10);
+    });
+
+    // ORDER BY expression (STRLEN) not working correctly
+    it.skip("should order by expression", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+        }
+        ORDER BY STRLEN(?name)
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      expect(results[0].name).toBe("Bob");
+      expect(results[1].name).toBe("Alice");
+      expect(results[2].name).toBe("Charlie");
+    });
+
+    it("should return results with ORDER BY expression (current behavior: not sorting by expression)", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+        }
+        ORDER BY STRLEN(?name)
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+      // Current implementation doesn't properly sort by expression
+      const names = results.map((r) => r.name);
+      expect(names).toContain("Alice");
+      expect(names).toContain("Bob");
+      expect(names).toContain("Charlie");
+    });
+  });
+
+  describe("LIMIT", () => {
+    it("should limit number of results", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+        }
+        LIMIT 2
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+    });
+
+    it("should return all when limit exceeds result count", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+        }
+        LIMIT 100
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(3);
+    });
+  });
+
+  describe("OFFSET", () => {
+    it("should skip first N results", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name ?age WHERE {
+          ?person foaf:name ?name .
+          ?person foaf:age ?age
+        }
+        ORDER BY ?age
+        OFFSET 1
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+      expect(results[0].age).toBe(30);
+      expect(results[1].age).toBe(35);
+    });
+
+    it("should return empty when offset exceeds result count", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT ?name WHERE {
+          ?person foaf:name ?name
+        }
+        OFFSET 100
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(0);
+    });
+  });
+
+  describe("LIMIT + OFFSET (Pagination)", () => {
+    it("should paginate results correctly", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.numericData());
+
+      const query = `
+        ${buildPrefixes("ex")}
+        SELECT ?value WHERE {
+          ?item ex:value ?value
+        }
+        ORDER BY ?value
+        LIMIT 2
+        OFFSET 2
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+      expect(results[0].value).toBe(30);
+      expect(results[1].value).toBe(40);
+    });
+
+    it("should handle combined modifiers", async () => {
+      const { store, executor } = createTestEnvironment();
+      await loadTestData(store, TEST_DATA.foafPersons());
+
+      const query = `
+        ${buildPrefixes("foaf", "ex")}
+        SELECT DISTINCT ?age WHERE {
+          ?person foaf:age ?age
+        }
+        ORDER BY DESC(?age)
+        LIMIT 2
+        OFFSET 1
+      `;
+
+      const results = await executeQuery(executor, query);
+      expect(results.length).toBe(2);
+      expect(results[0].age).toBe(30);
+      expect(results[1].age).toBe(25);
+    });
+  });
+});

--- a/packages/exocortex/tests/compliance/sparql/sparql-test-utils.ts
+++ b/packages/exocortex/tests/compliance/sparql/sparql-test-utils.ts
@@ -1,0 +1,289 @@
+/**
+ * Shared test utilities for SPARQL compliance tests
+ */
+
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { QueryExecutor } from "../../../src/infrastructure/sparql/executors/QueryExecutor";
+import { SPARQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+import { AlgebraTranslator } from "../../../src/infrastructure/sparql/algebra/AlgebraTranslator";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { BlankNode } from "../../../src/domain/models/rdf/BlankNode";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+
+// Re-export for convenience
+export { InMemoryTripleStore, QueryExecutor, IRI, Literal, BlankNode, Triple };
+
+/**
+ * Common prefixes used in tests
+ */
+export const PREFIXES: Record<string, string> = {
+  foaf: "http://xmlns.com/foaf/0.1/",
+  ex: "http://example.org/",
+  xsd: "http://www.w3.org/2001/XMLSchema#",
+  rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  rdfs: "http://www.w3.org/2000/01/rdf-schema#",
+};
+
+/**
+ * Build PREFIX declarations for SPARQL queries
+ */
+export function buildPrefixes(...prefixNames: string[]): string {
+  return prefixNames
+    .map((name) => `PREFIX ${name}: <${PREFIXES[name]}>`)
+    .join("\n");
+}
+
+/**
+ * Create IRI helper
+ */
+export function iri(value: string): IRI {
+  return new IRI(value);
+}
+
+/**
+ * Create Literal helper
+ */
+export function literal(
+  value: string,
+  datatypeOrLang?: string,
+  isLangTag = false
+): Literal {
+  if (isLangTag && datatypeOrLang) {
+    return new Literal(value, undefined, datatypeOrLang);
+  }
+  return new Literal(value, datatypeOrLang ? new IRI(datatypeOrLang) : undefined);
+}
+
+/**
+ * Create BlankNode helper
+ */
+export function bnode(id: string): BlankNode {
+  return new BlankNode(id);
+}
+
+/**
+ * Create Triple helper
+ */
+export function triple(
+  subject: IRI | BlankNode,
+  predicate: IRI,
+  object: IRI | Literal | BlankNode
+): Triple {
+  return new Triple(subject, predicate, object);
+}
+
+/**
+ * XSD typed literal helpers
+ */
+export const xsd = {
+  integer: (value: number): Literal =>
+    new Literal(String(value), new IRI(PREFIXES.xsd + "integer")),
+  decimal: (value: string): Literal =>
+    new Literal(value, new IRI(PREFIXES.xsd + "decimal")),
+  double: (value: number): Literal =>
+    new Literal(String(value), new IRI(PREFIXES.xsd + "double")),
+  boolean: (value: boolean): Literal =>
+    new Literal(String(value), new IRI(PREFIXES.xsd + "boolean")),
+  string: (value: string): Literal =>
+    new Literal(value, new IRI(PREFIXES.xsd + "string")),
+  dateTime: (value: string): Literal =>
+    new Literal(value, new IRI(PREFIXES.xsd + "dateTime")),
+  date: (value: string): Literal =>
+    new Literal(value, new IRI(PREFIXES.xsd + "date")),
+};
+
+/**
+ * Test environment with all SPARQL components
+ */
+export interface TestEnvironment {
+  store: InMemoryTripleStore;
+  executor: QueryExecutor;
+  parser: SPARQLParser;
+  translator: AlgebraTranslator;
+}
+
+/**
+ * Create test environment with store and executor
+ */
+export function createTestEnvironment(): TestEnvironment {
+  const store = new InMemoryTripleStore();
+  const executor = new QueryExecutor(store);
+  const parser = new SPARQLParser();
+  const translator = new AlgebraTranslator();
+  return { store, executor, parser, translator };
+}
+
+/**
+ * Load test data into store
+ */
+export async function loadTestData(
+  store: InMemoryTripleStore,
+  triples: Triple[]
+): Promise<void> {
+  for (const t of triples) {
+    await store.add(t);
+  }
+}
+
+/**
+ * Extract native JavaScript value from RDF term
+ */
+function extractValue(term: IRI | Literal | BlankNode): unknown {
+  if (term instanceof Literal) {
+    const value = term.value;
+    const datatype = term.datatype?.value;
+
+    if (datatype) {
+      if (datatype.includes("integer") || datatype.includes("int") ||
+          datatype.includes("decimal") || datatype.includes("double") ||
+          datatype.includes("float")) {
+        return parseFloat(value);
+      }
+      if (datatype.includes("boolean")) {
+        return value === "true";
+      }
+    }
+    return value;
+  }
+
+  if (term instanceof IRI) {
+    return term.value;
+  }
+
+  if (term instanceof BlankNode) {
+    return `_:${term.id}`;
+  }
+
+  return String(term);
+}
+
+/**
+ * Execute SELECT/ASK query and convert results to JSON for easier assertions
+ */
+export async function executeQuery(
+  executor: QueryExecutor,
+  query: string
+): Promise<Record<string, unknown>[]> {
+  const parser = new SPARQLParser();
+  const translator = new AlgebraTranslator();
+
+  const parsed = parser.parse(query);
+  const algebra = translator.translate(parsed);
+  const results: Record<string, unknown>[] = [];
+
+  for await (const solution of executor.execute(algebra)) {
+    const obj: Record<string, unknown> = {};
+    for (const variable of solution.variables()) {
+      const term = solution.get(variable);
+      if (term) {
+        obj[variable] = extractValue(term as IRI | Literal | BlankNode);
+      }
+    }
+    results.push(obj);
+  }
+
+  return results;
+}
+
+/**
+ * Execute CONSTRUCT/DESCRIBE query and return triples
+ */
+export async function executeConstructQuery(
+  executor: QueryExecutor,
+  query: string
+): Promise<Triple[]> {
+  const parser = new SPARQLParser();
+  const translator = new AlgebraTranslator();
+
+  const parsed = parser.parse(query);
+  const algebra = translator.translate(parsed);
+  const triples: Triple[] = [];
+
+  for await (const solution of executor.execute(algebra)) {
+    const subject = solution.get("s") || solution.get("subject");
+    const predicate = solution.get("p") || solution.get("predicate");
+    const object = solution.get("o") || solution.get("object");
+
+    if (subject && predicate && object) {
+      triples.push(new Triple(
+        subject as IRI | BlankNode,
+        predicate as IRI,
+        object as IRI | Literal | BlankNode
+      ));
+    }
+  }
+
+  return triples;
+}
+
+/**
+ * Standard test data sets
+ */
+export const TEST_DATA = {
+  foafPersons: (): Triple[] => {
+    const foaf = PREFIXES.foaf;
+    const ex = PREFIXES.ex;
+    return [
+      triple(iri(`${ex}alice`), iri(`${foaf}name`), literal("Alice")),
+      triple(iri(`${ex}alice`), iri(`${foaf}age`), xsd.integer(30)),
+      triple(iri(`${ex}alice`), iri(`${foaf}mbox`), iri("mailto:alice@example.org")),
+      triple(iri(`${ex}alice`), iri(`${foaf}knows`), iri(`${ex}bob`)),
+      triple(iri(`${ex}bob`), iri(`${foaf}name`), literal("Bob")),
+      triple(iri(`${ex}bob`), iri(`${foaf}age`), xsd.integer(25)),
+      triple(iri(`${ex}bob`), iri(`${foaf}knows`), iri(`${ex}charlie`)),
+      triple(iri(`${ex}charlie`), iri(`${foaf}name`), literal("Charlie")),
+      triple(iri(`${ex}charlie`), iri(`${foaf}age`), xsd.integer(35)),
+    ];
+  },
+
+  hierarchy: (): Triple[] => {
+    const ex = PREFIXES.ex;
+    const rdfs = PREFIXES.rdfs;
+    return [
+      triple(iri(`${ex}Dog`), iri(`${rdfs}subClassOf`), iri(`${ex}Animal`)),
+      triple(iri(`${ex}Cat`), iri(`${rdfs}subClassOf`), iri(`${ex}Animal`)),
+      triple(iri(`${ex}Mammal`), iri(`${rdfs}subClassOf`), iri(`${ex}Animal`)),
+      triple(iri(`${ex}Dog`), iri(`${rdfs}subClassOf`), iri(`${ex}Mammal`)),
+      triple(iri(`${ex}Cat`), iri(`${rdfs}subClassOf`), iri(`${ex}Mammal`)),
+      triple(iri(`${ex}wheel`), iri(`${ex}partOf`), iri(`${ex}car`)),
+      triple(iri(`${ex}engine`), iri(`${ex}partOf`), iri(`${ex}car`)),
+      triple(iri(`${ex}piston`), iri(`${ex}partOf`), iri(`${ex}engine`)),
+    ];
+  },
+
+  numericData: (): Triple[] => {
+    const ex = PREFIXES.ex;
+    return [
+      triple(iri(`${ex}item1`), iri(`${ex}value`), xsd.integer(10)),
+      triple(iri(`${ex}item1`), iri(`${ex}category`), literal("A")),
+      triple(iri(`${ex}item2`), iri(`${ex}value`), xsd.integer(20)),
+      triple(iri(`${ex}item2`), iri(`${ex}category`), literal("A")),
+      triple(iri(`${ex}item3`), iri(`${ex}value`), xsd.integer(30)),
+      triple(iri(`${ex}item3`), iri(`${ex}category`), literal("B")),
+      triple(iri(`${ex}item4`), iri(`${ex}value`), xsd.integer(40)),
+      triple(iri(`${ex}item4`), iri(`${ex}category`), literal("B")),
+      triple(iri(`${ex}item5`), iri(`${ex}value`), xsd.integer(50)),
+      triple(iri(`${ex}item5`), iri(`${ex}category`), literal("B")),
+    ];
+  },
+
+  stringData: (): Triple[] => {
+    const ex = PREFIXES.ex;
+    return [
+      triple(iri(`${ex}doc1`), iri(`${ex}title`), literal("Hello World")),
+      triple(iri(`${ex}doc1`), iri(`${ex}lang`), literal("Bonjour", "fr", true)),
+      triple(iri(`${ex}doc2`), iri(`${ex}title`), literal("SPARQL Tutorial")),
+      triple(iri(`${ex}doc2`), iri(`${ex}content`), literal("Learn SPARQL")),
+    ];
+  },
+
+  dateTimeData: (): Triple[] => {
+    const ex = PREFIXES.ex;
+    return [
+      triple(iri(`${ex}event1`), iri(`${ex}date`), xsd.dateTime("2024-01-15T10:30:00Z")),
+      triple(iri(`${ex}event2`), iri(`${ex}date`), xsd.dateTime("2024-06-20T14:00:00Z")),
+      triple(iri(`${ex}event3`), iri(`${ex}date`), xsd.dateTime("2024-12-25T00:00:00Z")),
+    ];
+  },
+};


### PR DESCRIPTION
## Summary

This PR implements a comprehensive SPARQL 1.1 compliance test suite that systematically tests all major SPARQL features and documents the current implementation status.

### What This PR Does
- Creates a new `tests/compliance/sparql/` directory for SPARQL compliance testing
- Adds 77 tests covering 6 major SPARQL feature categories
- Documents implementation status (✅ working, ⚠️ partial, ❌ not implemented)
- Provides clear baseline for future SPARQL implementation improvements

### Test Categories

| Category | Tests | Status |
|----------|-------|--------|
| Query Forms | 3 | SELECT ✅, ASK/CONSTRUCT ❌ |
| Graph Patterns | 10 | BGP/FILTER/UNION/VALUES ✅, OPTIONAL/MINUS ⚠️ |
| Property Paths | 7 | All working except Negated (!) |
| Aggregates | 8 | COUNT/SUM/AVG/MIN/MAX/GROUP BY ✅, HAVING ⚠️ |
| Built-in Functions | 30+ | String ✅, Numeric ❌, DateTime ⚠️ |
| Solution Modifiers | 12 | ORDER BY/LIMIT/OFFSET ✅, DISTINCT ⚠️ |

### Key Findings
- 61 tests passing, 16 skipped (features not implemented)
- Core query functionality (SELECT, BGP, FILTER) is solid
- Property paths work well
- Some type coercion issues (functions returning strings instead of numbers)
- ASK/CONSTRUCT query forms not yet implemented

Closes #932

## Test Plan
- [x] All 61 enabled tests pass locally
- [x] Tests run correctly in CI
- [x] No existing tests broken