### PR TITLE
feat: Domain Models for Layout System

### DIFF
--- a/packages/obsidian-plugin/src/domain/layout/Layout.ts
+++ b/packages/obsidian-plugin/src/domain/layout/Layout.ts
@@ -1,0 +1,346 @@
+import type { LayoutColumn } from "./LayoutColumn";
+import type { LayoutFilter } from "./LayoutFilter";
+import type { LayoutSort } from "./LayoutSort";
+import type { LayoutGroup } from "./LayoutGroup";
+
+/**
+ * Layout type enumeration.
+ * Defines the visual representation style for the layout.
+ */
+export enum LayoutType {
+  /** Table layout with rows and columns */
+  Table = "exo__TableLayout",
+
+  /** Kanban board with lanes/columns */
+  Kanban = "exo__KanbanLayout",
+
+  /** Graph visualization of relationships */
+  Graph = "exo__GraphLayout",
+
+  /** Calendar view for time-based data */
+  Calendar = "exo__CalendarLayout",
+
+  /** Simple list view */
+  List = "exo__ListLayout",
+}
+
+/**
+ * Calendar view modes.
+ */
+export type CalendarView = "day" | "week" | "month";
+
+/**
+ * Base Layout interface.
+ * Defines the common structure for all layout types.
+ *
+ * Maps to ontology class: exo__Layout
+ *
+ * Properties from ontology:
+ * - exo__Layout_targetClass: The class of assets to display
+ * - exo__Layout_columns: Array of column definitions (for table layouts)
+ * - exo__Layout_filters: Array of filter definitions
+ * - exo__Layout_defaultSort: Default sort definition
+ * - exo__Layout_groupBy: Grouping definition
+ */
+export interface BaseLayout {
+  /**
+   * Unique identifier for the layout.
+   * Corresponds to exo__Asset_uid in frontmatter.
+   */
+  uid: string;
+
+  /**
+   * Human-readable label for the layout.
+   * Corresponds to exo__Asset_label in frontmatter.
+   */
+  label: string;
+
+  /**
+   * Description of the layout.
+   * Corresponds to exo__Asset_description in frontmatter.
+   */
+  description?: string;
+
+  /**
+   * The layout type (table, kanban, graph, calendar, list).
+   * Derived from exo__Instance_class.
+   */
+  type: LayoutType;
+
+  /**
+   * Reference to the target class of assets to display.
+   * Value is a wikilink reference like "[[ems__Task]]".
+   * Maps to exo__Layout_targetClass.
+   */
+  targetClass: string;
+
+  /**
+   * Array of filter definitions.
+   * Maps to exo__Layout_filters.
+   */
+  filters?: LayoutFilter[];
+
+  /**
+   * Default sort definition.
+   * Maps to exo__Layout_defaultSort.
+   */
+  defaultSort?: LayoutSort;
+
+  /**
+   * Grouping definition.
+   * Maps to exo__Layout_groupBy.
+   */
+  groupBy?: LayoutGroup;
+}
+
+/**
+ * Table Layout interface.
+ * Extends BaseLayout with table-specific properties.
+ */
+export interface TableLayout extends BaseLayout {
+  type: LayoutType.Table;
+
+  /**
+   * Array of column definitions.
+   * Maps to exo__Layout_columns.
+   */
+  columns: LayoutColumn[];
+}
+
+/**
+ * Kanban Layout interface.
+ * Extends BaseLayout with kanban-specific properties.
+ */
+export interface KanbanLayout extends BaseLayout {
+  type: LayoutType.Kanban;
+
+  /**
+   * Reference to the property used for lane grouping.
+   * Typically a status property like "[[ems__Effort_status]]".
+   * Maps to exo__KanbanLayout_laneProperty.
+   */
+  laneProperty: string;
+
+  /**
+   * Explicit list of lanes (columns) in order.
+   * Each lane is a wikilink to a status/value asset.
+   * Maps to exo__KanbanLayout_lanes.
+   */
+  lanes?: string[];
+
+  /**
+   * Optional column definitions for card content.
+   * Maps to exo__Layout_columns.
+   */
+  columns?: LayoutColumn[];
+}
+
+/**
+ * Graph Layout interface.
+ * Extends BaseLayout with graph-specific properties.
+ */
+export interface GraphLayout extends BaseLayout {
+  type: LayoutType.Graph;
+
+  /**
+   * Reference to the property used for node labels.
+   * Maps to exo__GraphLayout_nodeLabel.
+   */
+  nodeLabel?: string;
+
+  /**
+   * Array of property references for edges.
+   * Maps to exo__GraphLayout_edgeProperties.
+   */
+  edgeProperties?: string[];
+
+  /**
+   * Maximum depth of graph traversal.
+   * Maps to exo__GraphLayout_depth.
+   * @default 1
+   */
+  depth?: number;
+}
+
+/**
+ * Calendar Layout interface.
+ * Extends BaseLayout with calendar-specific properties.
+ */
+export interface CalendarLayout extends BaseLayout {
+  type: LayoutType.Calendar;
+
+  /**
+   * Reference to the property containing start date/time.
+   * Maps to exo__CalendarLayout_startProperty.
+   */
+  startProperty: string;
+
+  /**
+   * Reference to the property containing end date/time.
+   * Maps to exo__CalendarLayout_endProperty.
+   */
+  endProperty?: string;
+
+  /**
+   * Default calendar view mode.
+   * Maps to exo__CalendarLayout_view.
+   * @default "week"
+   */
+  view?: CalendarView;
+}
+
+/**
+ * List Layout interface.
+ * Extends BaseLayout with list-specific properties.
+ */
+export interface ListLayout extends BaseLayout {
+  type: LayoutType.List;
+
+  /**
+   * Template string for list item rendering.
+   * Can include property placeholders like {{label}} or {{status}}.
+   * Maps to exo__ListLayout_template.
+   */
+  template?: string;
+
+  /**
+   * Whether to show the class icon for each item.
+   * Maps to exo__ListLayout_showIcon.
+   * @default false
+   */
+  showIcon?: boolean;
+}
+
+/**
+ * Union type for all layout types.
+ */
+export type Layout =
+  | TableLayout
+  | KanbanLayout
+  | GraphLayout
+  | CalendarLayout
+  | ListLayout;
+
+/**
+ * Extract the LayoutType from an instance class wikilink or array of wikilinks.
+ *
+ * @param instanceClass - The instance class value from frontmatter
+ * @returns The corresponding LayoutType or null if not a layout type
+ */
+export function getLayoutTypeFromInstanceClass(
+  instanceClass: unknown,
+): LayoutType | null {
+  const classes = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
+
+  for (const cls of classes) {
+    if (typeof cls !== "string") continue;
+
+    // Extract class name from wikilink
+    const match = cls.match(/\[\[([^\]]+)\]\]/);
+    const className = match ? match[1] : cls;
+
+    switch (className) {
+      case "exo__TableLayout":
+        return LayoutType.Table;
+      case "exo__KanbanLayout":
+        return LayoutType.Kanban;
+      case "exo__GraphLayout":
+        return LayoutType.Graph;
+      case "exo__CalendarLayout":
+        return LayoutType.Calendar;
+      case "exo__ListLayout":
+        return LayoutType.List;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if a frontmatter object represents a Layout asset.
+ *
+ * @param frontmatter - The frontmatter object to check
+ * @returns True if this is a layout asset
+ */
+export function isLayoutFrontmatter(
+  frontmatter: Record<string, unknown>,
+): boolean {
+  const instanceClass = frontmatter["exo__Instance_class"];
+  return getLayoutTypeFromInstanceClass(instanceClass) !== null;
+}
+
+/**
+ * Create a base Layout object from frontmatter data.
+ * Use this when you don't need the specific layout type properties.
+ *
+ * @param frontmatter - The YAML frontmatter object from an Obsidian note
+ * @returns A BaseLayout object or null if required fields are missing
+ */
+export function createBaseLayoutFromFrontmatter(
+  frontmatter: Record<string, unknown>,
+): BaseLayout | null {
+  const uid = frontmatter["exo__Asset_uid"] as string | undefined;
+  const label = frontmatter["exo__Asset_label"] as string | undefined;
+  const instanceClass = frontmatter["exo__Instance_class"];
+  const targetClass = frontmatter["exo__Layout_targetClass"] as
+    | string
+    | undefined;
+
+  const layoutType = getLayoutTypeFromInstanceClass(instanceClass);
+
+  if (!uid || !label || !layoutType || !targetClass) {
+    return null;
+  }
+
+  return {
+    uid,
+    label,
+    description: frontmatter["exo__Asset_description"] as string | undefined,
+    type: layoutType,
+    targetClass,
+    // Note: filters, defaultSort, and groupBy would need to be resolved
+    // from their wikilink references - this requires vault access
+  };
+}
+
+/**
+ * Type guard for TableLayout.
+ */
+export function isTableLayout(layout: Layout): layout is TableLayout {
+  return layout.type === LayoutType.Table;
+}
+
+/**
+ * Type guard for KanbanLayout.
+ */
+export function isKanbanLayout(layout: Layout): layout is KanbanLayout {
+  return layout.type === LayoutType.Kanban;
+}
+
+/**
+ * Type guard for GraphLayout.
+ */
+export function isGraphLayout(layout: Layout): layout is GraphLayout {
+  return layout.type === LayoutType.Graph;
+}
+
+/**
+ * Type guard for CalendarLayout.
+ */
+export function isCalendarLayout(layout: Layout): layout is CalendarLayout {
+  return layout.type === LayoutType.Calendar;
+}
+
+/**
+ * Type guard for ListLayout.
+ */
+export function isListLayout(layout: Layout): layout is ListLayout {
+  return layout.type === LayoutType.List;
+}
+
+/**
+ * Check if a calendar view value is valid.
+ */
+export function isValidCalendarView(value: unknown): value is CalendarView {
+  return value === "day" || value === "week" || value === "month";
+}

--- a/packages/obsidian-plugin/src/domain/layout/LayoutColumn.ts
+++ b/packages/obsidian-plugin/src/domain/layout/LayoutColumn.ts
@@ -1,0 +1,225 @@
+/**
+ * Column renderer type for layout columns.
+ * Determines how the column value is displayed in the UI.
+ */
+export type ColumnRenderer =
+  | "text"
+  | "link"
+  | "badge"
+  | "progress"
+  | "datetime"
+  | "duration"
+  | "number"
+  | "boolean"
+  | "tags"
+  | "image"
+  | "custom";
+
+/**
+ * Layout Column interface.
+ * Defines a column in a table-based layout.
+ *
+ * Maps to ontology class: exo__LayoutColumn
+ *
+ * Properties from ontology:
+ * - exo__LayoutColumn_property: Reference to the property to display
+ * - exo__LayoutColumn_header: Column header text
+ * - exo__LayoutColumn_width: Column width (px, %, auto, fr)
+ * - exo__LayoutColumn_renderer: How to render the value
+ * - exo__LayoutColumn_editable: Whether inline editing is allowed
+ * - exo__LayoutColumn_sortable: Whether column can be sorted
+ *
+ * @example
+ * ```typescript
+ * const labelColumn: LayoutColumn = {
+ *   uid: "60000000-0000-0000-0000-000000000010",
+ *   label: "Task Label Column",
+ *   property: "[[exo__Asset_label]]",
+ *   header: "Задача",
+ *   width: "1fr",
+ *   renderer: "link",
+ *   editable: true,
+ *   sortable: true
+ * };
+ * ```
+ */
+export interface LayoutColumn {
+  /**
+   * Unique identifier for the column definition.
+   * Corresponds to exo__Asset_uid in frontmatter.
+   */
+  uid: string;
+
+  /**
+   * Human-readable label for the column definition.
+   * Corresponds to exo__Asset_label in frontmatter.
+   */
+  label: string;
+
+  /**
+   * Description of the column.
+   * Corresponds to exo__Asset_description in frontmatter.
+   */
+  description?: string;
+
+  /**
+   * Reference to the property to display in this column.
+   * Value is a wikilink reference like "[[exo__Asset_label]]".
+   * Maps to exo__LayoutColumn_property.
+   */
+  property: string;
+
+  /**
+   * Column header text displayed in the table header.
+   * If not specified, derived from property label.
+   * Maps to exo__LayoutColumn_header.
+   */
+  header?: string;
+
+  /**
+   * Column width specification.
+   * Can be: px value ("100px"), percentage ("20%"), "auto", or grid fr ("1fr").
+   * Maps to exo__LayoutColumn_width.
+   */
+  width?: string;
+
+  /**
+   * How to render the column value.
+   * Maps to exo__LayoutColumn_renderer.
+   * @default "text"
+   */
+  renderer?: ColumnRenderer;
+
+  /**
+   * Whether inline editing is enabled for this column.
+   * Maps to exo__LayoutColumn_editable.
+   * @default false
+   */
+  editable?: boolean;
+
+  /**
+   * Whether the table can be sorted by this column.
+   * Maps to exo__LayoutColumn_sortable.
+   * @default false
+   */
+  sortable?: boolean;
+}
+
+/**
+ * Create a LayoutColumn from frontmatter data.
+ *
+ * @param frontmatter - The YAML frontmatter object from an Obsidian note
+ * @returns A LayoutColumn object or null if required fields are missing
+ *
+ * @example
+ * ```typescript
+ * const frontmatter = {
+ *   exo__Asset_uid: "60000000-0000-0000-0000-000000000010",
+ *   exo__Asset_label: "Task Label Column",
+ *   exo__LayoutColumn_property: "[[exo__Asset_label]]",
+ *   exo__LayoutColumn_header: "Задача",
+ *   exo__LayoutColumn_width: "1fr",
+ *   exo__LayoutColumn_renderer: "link",
+ *   exo__LayoutColumn_editable: true,
+ *   exo__LayoutColumn_sortable: true
+ * };
+ * const column = createLayoutColumnFromFrontmatter(frontmatter);
+ * ```
+ */
+export function createLayoutColumnFromFrontmatter(
+  frontmatter: Record<string, unknown>,
+): LayoutColumn | null {
+  const uid = frontmatter["exo__Asset_uid"] as string | undefined;
+  const label = frontmatter["exo__Asset_label"] as string | undefined;
+  const property = frontmatter["exo__LayoutColumn_property"] as
+    | string
+    | undefined;
+
+  if (!uid || !label || !property) {
+    return null;
+  }
+
+  const renderer = frontmatter["exo__LayoutColumn_renderer"] as
+    | string
+    | undefined;
+
+  return {
+    uid,
+    label,
+    description: frontmatter["exo__Asset_description"] as string | undefined,
+    property,
+    header: frontmatter["exo__LayoutColumn_header"] as string | undefined,
+    width: frontmatter["exo__LayoutColumn_width"] as string | undefined,
+    renderer: isValidColumnRenderer(renderer) ? renderer : "text",
+    editable: Boolean(frontmatter["exo__LayoutColumn_editable"]),
+    sortable: Boolean(frontmatter["exo__LayoutColumn_sortable"]),
+  };
+}
+
+/**
+ * Check if a value is a valid ColumnRenderer.
+ *
+ * @param value - The value to check
+ * @returns True if the value is a valid ColumnRenderer
+ */
+export function isValidColumnRenderer(
+  value: unknown,
+): value is ColumnRenderer {
+  const validRenderers: ColumnRenderer[] = [
+    "text",
+    "link",
+    "badge",
+    "progress",
+    "datetime",
+    "duration",
+    "number",
+    "boolean",
+    "tags",
+    "image",
+    "custom",
+  ];
+  return typeof value === "string" && validRenderers.includes(value as ColumnRenderer);
+}
+
+/**
+ * Get the default header text for a column based on its property.
+ *
+ * @param property - The property wikilink reference
+ * @returns The derived header text
+ *
+ * @example
+ * ```typescript
+ * getDefaultColumnHeader("[[exo__Asset_label]]");
+ * // Returns: "Label"
+ *
+ * getDefaultColumnHeader("[[ems__Effort_startTimestamp]]");
+ * // Returns: "Start Timestamp"
+ * ```
+ */
+export function getDefaultColumnHeader(property: string): string {
+  // Extract property name from wikilink
+  const match = property.match(/\[\[([^\]]+)\]\]/);
+  const propertyName = match ? match[1] : property;
+
+  // Remove prefix (exo__, ems__, etc.)
+  const withoutPrefix = propertyName.replace(/^[a-z]+__/, "");
+
+  // Split on underscore (e.g., "Asset_label" -> ["Asset", "label"])
+  const parts = withoutPrefix.split("_");
+
+  // For class properties like "Asset_label", take parts after class name (index 1+)
+  // For simple properties like "lowercase_property", use all parts
+  // Heuristic: if first part is PascalCase (class name), skip it
+  const isPascalCase = parts[0] && /^[A-Z]/.test(parts[0]);
+  const propertyParts = isPascalCase && parts.length > 1 ? parts.slice(1) : parts;
+
+  // Join parts with space
+  const propertyPart = propertyParts.join(" ");
+
+  // Convert camelCase to spaces and capitalize each word
+  return propertyPart
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/packages/obsidian-plugin/src/domain/layout/LayoutFilter.ts
+++ b/packages/obsidian-plugin/src/domain/layout/LayoutFilter.ts
@@ -1,0 +1,207 @@
+/**
+ * Filter operators for comparing property values.
+ */
+export type FilterOperator =
+  | "eq" // Equal
+  | "ne" // Not equal
+  | "gt" // Greater than
+  | "gte" // Greater than or equal
+  | "lt" // Less than
+  | "lte" // Less than or equal
+  | "contains" // String contains
+  | "startsWith" // String starts with
+  | "endsWith" // String ends with
+  | "in" // Value in list
+  | "notIn" // Value not in list
+  | "isNull" // Value is null/undefined
+  | "isNotNull"; // Value is not null/undefined
+
+/**
+ * Layout Filter interface.
+ * Defines filtering conditions for assets in a Layout.
+ *
+ * Maps to ontology class: exo__LayoutFilter
+ *
+ * Filters can be either:
+ * 1. Simple property-based filters with operator and value
+ * 2. Complex SPARQL-based filters with a WHERE clause
+ *
+ * Properties from ontology:
+ * - exo__LayoutFilter_property: Reference to the property to filter
+ * - exo__LayoutFilter_operator: Comparison operator
+ * - exo__LayoutFilter_value: Value to compare against
+ * - exo__LayoutFilter_sparql: SPARQL WHERE clause for complex filters
+ *
+ * @example
+ * Simple filter:
+ * ```typescript
+ * const activeTasksFilter: LayoutFilter = {
+ *   uid: "filter-001",
+ *   label: "Active Tasks Filter",
+ *   property: "[[ems__Effort_status]]",
+ *   operator: "ne",
+ *   value: "[[ems__EffortStatus_Done]]"
+ * };
+ * ```
+ *
+ * SPARQL filter:
+ * ```typescript
+ * const todayFilter: LayoutFilter = {
+ *   uid: "filter-002",
+ *   label: "Today Filter",
+ *   sparql: `
+ *     ?asset ems:Task_currentEffort ?effort .
+ *     ?effort ems:Effort_startTimestamp ?start .
+ *     FILTER(?start >= NOW() - "P1D"^^xsd:duration)
+ *   `
+ * };
+ * ```
+ */
+export interface LayoutFilter {
+  /**
+   * Unique identifier for the filter definition.
+   * Corresponds to exo__Asset_uid in frontmatter.
+   */
+  uid: string;
+
+  /**
+   * Human-readable label for the filter.
+   * Corresponds to exo__Asset_label in frontmatter.
+   */
+  label: string;
+
+  /**
+   * Description of the filter.
+   * Corresponds to exo__Asset_description in frontmatter.
+   */
+  description?: string;
+
+  /**
+   * Reference to the property to filter by.
+   * Value is a wikilink reference like "[[ems__Effort_status]]".
+   * Maps to exo__LayoutFilter_property.
+   * Optional if using SPARQL filter.
+   */
+  property?: string;
+
+  /**
+   * Comparison operator for simple filters.
+   * Maps to exo__LayoutFilter_operator.
+   * Optional if using SPARQL filter.
+   */
+  operator?: FilterOperator;
+
+  /**
+   * Value to compare against for simple filters.
+   * Can be a literal value or wikilink reference.
+   * Maps to exo__LayoutFilter_value.
+   * Optional if using SPARQL filter or isNull/isNotNull operators.
+   */
+  value?: string;
+
+  /**
+   * SPARQL WHERE clause for complex filters.
+   * Should use ?asset as the main variable binding.
+   * Maps to exo__LayoutFilter_sparql.
+   * Optional if using simple property filter.
+   */
+  sparql?: string;
+}
+
+/**
+ * Create a LayoutFilter from frontmatter data.
+ *
+ * @param frontmatter - The YAML frontmatter object from an Obsidian note
+ * @returns A LayoutFilter object or null if required fields are missing
+ *
+ * @example
+ * ```typescript
+ * const frontmatter = {
+ *   exo__Asset_uid: "60000000-0000-0000-0000-000000000030",
+ *   exo__Asset_label: "Today Filter",
+ *   exo__LayoutFilter_sparql: "?asset ems:Task_currentEffort ?effort ..."
+ * };
+ * const filter = createLayoutFilterFromFrontmatter(frontmatter);
+ * ```
+ */
+export function createLayoutFilterFromFrontmatter(
+  frontmatter: Record<string, unknown>,
+): LayoutFilter | null {
+  const uid = frontmatter["exo__Asset_uid"] as string | undefined;
+  const label = frontmatter["exo__Asset_label"] as string | undefined;
+
+  if (!uid || !label) {
+    return null;
+  }
+
+  const property = frontmatter["exo__LayoutFilter_property"] as
+    | string
+    | undefined;
+  const operator = frontmatter["exo__LayoutFilter_operator"] as
+    | string
+    | undefined;
+  const value = frontmatter["exo__LayoutFilter_value"] as string | undefined;
+  const sparql = frontmatter["exo__LayoutFilter_sparql"] as string | undefined;
+
+  // Must have either simple filter (property + operator) or SPARQL filter
+  if (!sparql && !property) {
+    return null;
+  }
+
+  return {
+    uid,
+    label,
+    description: frontmatter["exo__Asset_description"] as string | undefined,
+    property,
+    operator: isValidFilterOperator(operator) ? operator : undefined,
+    value,
+    sparql,
+  };
+}
+
+/**
+ * Check if a value is a valid FilterOperator.
+ *
+ * @param value - The value to check
+ * @returns True if the value is a valid FilterOperator
+ */
+export function isValidFilterOperator(
+  value: unknown,
+): value is FilterOperator {
+  const validOperators: FilterOperator[] = [
+    "eq",
+    "ne",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "contains",
+    "startsWith",
+    "endsWith",
+    "in",
+    "notIn",
+    "isNull",
+    "isNotNull",
+  ];
+  return typeof value === "string" && validOperators.includes(value as FilterOperator);
+}
+
+/**
+ * Check if a filter is a simple property-based filter.
+ *
+ * @param filter - The filter to check
+ * @returns True if the filter is a simple property filter
+ */
+export function isSimpleFilter(filter: LayoutFilter): boolean {
+  return Boolean(filter.property && filter.operator);
+}
+
+/**
+ * Check if a filter is a SPARQL-based filter.
+ *
+ * @param filter - The filter to check
+ * @returns True if the filter uses SPARQL
+ */
+export function isSparqlFilter(filter: LayoutFilter): boolean {
+  return Boolean(filter.sparql);
+}

--- a/packages/obsidian-plugin/src/domain/layout/LayoutGroup.ts
+++ b/packages/obsidian-plugin/src/domain/layout/LayoutGroup.ts
@@ -1,0 +1,139 @@
+/**
+ * Sort order for groups.
+ * Determines how groups are ordered when displaying grouped data.
+ */
+export type GroupSortOrder = "asc" | "desc" | "custom";
+
+/**
+ * Layout Group interface.
+ * Defines how assets are grouped within a Layout.
+ *
+ * Maps to ontology class: exo__LayoutGroup
+ *
+ * Properties from ontology:
+ * - exo__LayoutGroup_property: Reference to the property to group by
+ * - exo__LayoutGroup_collapsed: Whether groups are collapsed by default
+ * - exo__LayoutGroup_showCount: Whether to show item count in group header
+ * - exo__LayoutGroup_sortGroups: How to order the groups
+ *
+ * @example
+ * ```typescript
+ * const groupByProject: LayoutGroup = {
+ *   uid: "group-001",
+ *   label: "Group by Project",
+ *   property: "[[ems__Task_project]]",
+ *   collapsed: false,
+ *   showCount: true,
+ *   sortGroups: "asc"
+ * };
+ * ```
+ */
+export interface LayoutGroup {
+  /**
+   * Unique identifier for the group definition.
+   * Corresponds to exo__Asset_uid in frontmatter.
+   */
+  uid: string;
+
+  /**
+   * Human-readable label for the group definition.
+   * Corresponds to exo__Asset_label in frontmatter.
+   */
+  label: string;
+
+  /**
+   * Description of the grouping.
+   * Corresponds to exo__Asset_description in frontmatter.
+   */
+  description?: string;
+
+  /**
+   * Reference to the property to group by.
+   * Value is a wikilink reference like "[[ems__Task_project]]".
+   * Maps to exo__LayoutGroup_property.
+   */
+  property: string;
+
+  /**
+   * Whether groups are collapsed by default.
+   * Maps to exo__LayoutGroup_collapsed.
+   * @default false
+   */
+  collapsed?: boolean;
+
+  /**
+   * Whether to show the count of items in each group header.
+   * Maps to exo__LayoutGroup_showCount.
+   * @default true
+   */
+  showCount?: boolean;
+
+  /**
+   * How to order the groups.
+   * - "asc": Alphabetically ascending
+   * - "desc": Alphabetically descending
+   * - "custom": Custom order (defined elsewhere)
+   * Maps to exo__LayoutGroup_sortGroups.
+   * @default "asc"
+   */
+  sortGroups?: GroupSortOrder;
+}
+
+/**
+ * Create a LayoutGroup from frontmatter data.
+ *
+ * @param frontmatter - The YAML frontmatter object from an Obsidian note
+ * @returns A LayoutGroup object or null if required fields are missing
+ *
+ * @example
+ * ```typescript
+ * const frontmatter = {
+ *   exo__Asset_uid: "group-001",
+ *   exo__Asset_label: "Group by Project",
+ *   exo__LayoutGroup_property: "[[ems__Task_project]]",
+ *   exo__LayoutGroup_collapsed: false,
+ *   exo__LayoutGroup_showCount: true,
+ *   exo__LayoutGroup_sortGroups: "asc"
+ * };
+ * const group = createLayoutGroupFromFrontmatter(frontmatter);
+ * ```
+ */
+export function createLayoutGroupFromFrontmatter(
+  frontmatter: Record<string, unknown>,
+): LayoutGroup | null {
+  const uid = frontmatter["exo__Asset_uid"] as string | undefined;
+  const label = frontmatter["exo__Asset_label"] as string | undefined;
+  const property = frontmatter["exo__LayoutGroup_property"] as
+    | string
+    | undefined;
+
+  if (!uid || !label || !property) {
+    return null;
+  }
+
+  const sortGroups = frontmatter["exo__LayoutGroup_sortGroups"] as
+    | string
+    | undefined;
+
+  return {
+    uid,
+    label,
+    description: frontmatter["exo__Asset_description"] as string | undefined,
+    property,
+    collapsed: Boolean(frontmatter["exo__LayoutGroup_collapsed"]),
+    showCount: frontmatter["exo__LayoutGroup_showCount"] !== false,
+    sortGroups: isValidGroupSortOrder(sortGroups) ? sortGroups : "asc",
+  };
+}
+
+/**
+ * Check if a value is a valid GroupSortOrder.
+ *
+ * @param value - The value to check
+ * @returns True if the value is a valid GroupSortOrder
+ */
+export function isValidGroupSortOrder(
+  value: unknown,
+): value is GroupSortOrder {
+  return value === "asc" || value === "desc" || value === "custom";
+}

--- a/packages/obsidian-plugin/src/domain/layout/LayoutSort.ts
+++ b/packages/obsidian-plugin/src/domain/layout/LayoutSort.ts
@@ -1,0 +1,144 @@
+/**
+ * Sort direction for layout sorting.
+ * Determines whether items are sorted in ascending or descending order.
+ */
+export type SortDirection = "asc" | "desc";
+
+/**
+ * Position for null values in sorted results.
+ * Determines whether null/undefined values appear first or last.
+ */
+export type NullsPosition = "first" | "last";
+
+/**
+ * Layout Sort interface.
+ * Defines how assets are sorted within a Layout.
+ *
+ * Maps to ontology class: exo__LayoutSort
+ *
+ * Properties from ontology:
+ * - exo__LayoutSort_property: Reference to the property to sort by
+ * - exo__LayoutSort_direction: Sort direction (asc/desc)
+ * - exo__LayoutSort_nullsPosition: Where to place null values
+ *
+ * @example
+ * ```typescript
+ * const sortByStartTime: LayoutSort = {
+ *   uid: "60000000-0000-0000-0000-000000000020",
+ *   label: "Sort by Start Time",
+ *   property: "[[ems__Effort_startTimestamp]]",
+ *   direction: "desc",
+ *   nullsPosition: "last"
+ * };
+ * ```
+ */
+export interface LayoutSort {
+  /**
+   * Unique identifier for the sort definition.
+   * Corresponds to exo__Asset_uid in frontmatter.
+   */
+  uid: string;
+
+  /**
+   * Human-readable label for the sort definition.
+   * Corresponds to exo__Asset_label in frontmatter.
+   */
+  label: string;
+
+  /**
+   * Description of the sort definition.
+   * Corresponds to exo__Asset_description in frontmatter.
+   */
+  description?: string;
+
+  /**
+   * Reference to the property to sort by.
+   * Value is a wikilink reference like "[[ems__Effort_startTimestamp]]".
+   * Maps to exo__LayoutSort_property.
+   */
+  property: string;
+
+  /**
+   * Sort direction: ascending or descending.
+   * Maps to exo__LayoutSort_direction.
+   * @default "asc"
+   */
+  direction: SortDirection;
+
+  /**
+   * Position for null/undefined values in the sorted list.
+   * Maps to exo__LayoutSort_nullsPosition.
+   * @default "last"
+   */
+  nullsPosition?: NullsPosition;
+}
+
+/**
+ * Create a LayoutSort from frontmatter data.
+ *
+ * @param frontmatter - The YAML frontmatter object from an Obsidian note
+ * @returns A LayoutSort object or null if required fields are missing
+ *
+ * @example
+ * ```typescript
+ * const frontmatter = {
+ *   exo__Asset_uid: "60000000-0000-0000-0000-000000000020",
+ *   exo__Asset_label: "Sort by Start Time",
+ *   exo__LayoutSort_property: "[[ems__Effort_startTimestamp]]",
+ *   exo__LayoutSort_direction: "desc",
+ *   exo__LayoutSort_nullsPosition: "last"
+ * };
+ * const sort = createLayoutSortFromFrontmatter(frontmatter);
+ * ```
+ */
+export function createLayoutSortFromFrontmatter(
+  frontmatter: Record<string, unknown>,
+): LayoutSort | null {
+  const uid = frontmatter["exo__Asset_uid"] as string | undefined;
+  const label = frontmatter["exo__Asset_label"] as string | undefined;
+  const property = frontmatter["exo__LayoutSort_property"] as string | undefined;
+  const direction = frontmatter["exo__LayoutSort_direction"] as
+    | string
+    | undefined;
+  const nullsPosition = frontmatter["exo__LayoutSort_nullsPosition"] as
+    | string
+    | undefined;
+
+  if (!uid || !label || !property) {
+    return null;
+  }
+
+  const normalizedDirection: SortDirection =
+    direction === "desc" ? "desc" : "asc";
+  const normalizedNullsPosition: NullsPosition =
+    nullsPosition === "first" ? "first" : "last";
+
+  return {
+    uid,
+    label,
+    description: frontmatter["exo__Asset_description"] as string | undefined,
+    property,
+    direction: normalizedDirection,
+    nullsPosition: normalizedNullsPosition,
+  };
+}
+
+/**
+ * Check if a value is a valid SortDirection.
+ *
+ * @param value - The value to check
+ * @returns True if the value is a valid SortDirection
+ */
+export function isValidSortDirection(value: unknown): value is SortDirection {
+  return value === "asc" || value === "desc";
+}
+
+/**
+ * Check if a value is a valid NullsPosition.
+ *
+ * @param value - The value to check
+ * @returns True if the value is a valid NullsPosition
+ */
+export function isValidNullsPosition(value: unknown): value is NullsPosition {
+  return value === "first" || value === "last";
+}

--- a/packages/obsidian-plugin/src/domain/layout/index.ts
+++ b/packages/obsidian-plugin/src/domain/layout/index.ts
@@ -1,0 +1,98 @@
+/**
+ * Layout Domain Models
+ *
+ * This module exports TypeScript types and interfaces for the Exocortex Layout system.
+ * These types map to the ontology classes defined in exo__Layout and related classes.
+ *
+ * Layout System Overview:
+ * - Layout: Base class for visual representations (Table, Kanban, Graph, Calendar, List)
+ * - LayoutColumn: Column definition for table-based layouts
+ * - LayoutFilter: Filter conditions for asset selection
+ * - LayoutSort: Sort order definition
+ * - LayoutGroup: Grouping definition for organizing assets
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   Layout,
+ *   LayoutType,
+ *   TableLayout,
+ *   KanbanLayout,
+ *   LayoutColumn,
+ *   LayoutFilter,
+ *   LayoutSort,
+ *   LayoutGroup,
+ *   isTableLayout,
+ *   isKanbanLayout,
+ * } from "./domain/layout";
+ *
+ * // Check layout type
+ * if (isTableLayout(layout)) {
+ *   console.log("Columns:", layout.columns.length);
+ * }
+ *
+ * // Create from frontmatter
+ * const filter = createLayoutFilterFromFrontmatter(frontmatter);
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// Layout types
+export {
+  LayoutType,
+  type CalendarView,
+  type BaseLayout,
+  type TableLayout,
+  type KanbanLayout,
+  type GraphLayout,
+  type CalendarLayout,
+  type ListLayout,
+  type Layout,
+  getLayoutTypeFromInstanceClass,
+  isLayoutFrontmatter,
+  createBaseLayoutFromFrontmatter,
+  isTableLayout,
+  isKanbanLayout,
+  isGraphLayout,
+  isCalendarLayout,
+  isListLayout,
+  isValidCalendarView,
+} from "./Layout";
+
+// LayoutColumn types
+export {
+  type ColumnRenderer,
+  type LayoutColumn,
+  createLayoutColumnFromFrontmatter,
+  isValidColumnRenderer,
+  getDefaultColumnHeader,
+} from "./LayoutColumn";
+
+// LayoutFilter types
+export {
+  type FilterOperator,
+  type LayoutFilter,
+  createLayoutFilterFromFrontmatter,
+  isValidFilterOperator,
+  isSimpleFilter,
+  isSparqlFilter,
+} from "./LayoutFilter";
+
+// LayoutSort types
+export {
+  type SortDirection,
+  type NullsPosition,
+  type LayoutSort,
+  createLayoutSortFromFrontmatter,
+  isValidSortDirection,
+  isValidNullsPosition,
+} from "./LayoutSort";
+
+// LayoutGroup types
+export {
+  type GroupSortOrder,
+  type LayoutGroup,
+  createLayoutGroupFromFrontmatter,
+  isValidGroupSortOrder,
+} from "./LayoutGroup";

--- a/packages/obsidian-plugin/tests/unit/domain/layout/Layout.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/layout/Layout.test.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  LayoutType,
+  getLayoutTypeFromInstanceClass,
+  isLayoutFrontmatter,
+  createBaseLayoutFromFrontmatter,
+  isTableLayout,
+  isKanbanLayout,
+  isGraphLayout,
+  isCalendarLayout,
+  isListLayout,
+  isValidCalendarView,
+  type Layout,
+  type TableLayout,
+  type KanbanLayout,
+  type GraphLayout,
+  type CalendarLayout,
+  type ListLayout,
+  type BaseLayout,
+} from "../../../../src/domain/layout/Layout";
+
+describe("Layout", () => {
+  describe("LayoutType enum", () => {
+    it("should have correct values", () => {
+      expect(LayoutType.Table).toBe("exo__TableLayout");
+      expect(LayoutType.Kanban).toBe("exo__KanbanLayout");
+      expect(LayoutType.Graph).toBe("exo__GraphLayout");
+      expect(LayoutType.Calendar).toBe("exo__CalendarLayout");
+      expect(LayoutType.List).toBe("exo__ListLayout");
+    });
+  });
+
+  describe("getLayoutTypeFromInstanceClass", () => {
+    it("should return Table for exo__TableLayout wikilink", () => {
+      expect(getLayoutTypeFromInstanceClass("[[exo__TableLayout]]")).toBe(
+        LayoutType.Table,
+      );
+    });
+
+    it("should return Kanban for exo__KanbanLayout wikilink", () => {
+      expect(getLayoutTypeFromInstanceClass("[[exo__KanbanLayout]]")).toBe(
+        LayoutType.Kanban,
+      );
+    });
+
+    it("should return Graph for exo__GraphLayout wikilink", () => {
+      expect(getLayoutTypeFromInstanceClass("[[exo__GraphLayout]]")).toBe(
+        LayoutType.Graph,
+      );
+    });
+
+    it("should return Calendar for exo__CalendarLayout wikilink", () => {
+      expect(getLayoutTypeFromInstanceClass("[[exo__CalendarLayout]]")).toBe(
+        LayoutType.Calendar,
+      );
+    });
+
+    it("should return List for exo__ListLayout wikilink", () => {
+      expect(getLayoutTypeFromInstanceClass("[[exo__ListLayout]]")).toBe(
+        LayoutType.List,
+      );
+    });
+
+    it("should return layout type from array of instance classes", () => {
+      expect(
+        getLayoutTypeFromInstanceClass(["[[exo__Asset]]", "[[exo__TableLayout]]"]),
+      ).toBe(LayoutType.Table);
+    });
+
+    it("should return first matching layout type from array", () => {
+      expect(
+        getLayoutTypeFromInstanceClass([
+          "[[exo__TableLayout]]",
+          "[[exo__KanbanLayout]]",
+        ]),
+      ).toBe(LayoutType.Table);
+    });
+
+    it("should return layout type from plain string (no wikilink)", () => {
+      expect(getLayoutTypeFromInstanceClass("exo__TableLayout")).toBe(
+        LayoutType.Table,
+      );
+    });
+
+    it("should return null for non-layout class", () => {
+      expect(getLayoutTypeFromInstanceClass("[[ems__Task]]")).toBeNull();
+      expect(getLayoutTypeFromInstanceClass("[[exo__Asset]]")).toBeNull();
+    });
+
+    it("should return null for invalid input", () => {
+      expect(getLayoutTypeFromInstanceClass(null)).toBeNull();
+      expect(getLayoutTypeFromInstanceClass(undefined)).toBeNull();
+      expect(getLayoutTypeFromInstanceClass(123)).toBeNull();
+      expect(getLayoutTypeFromInstanceClass({})).toBeNull();
+    });
+
+    it("should return null for empty array", () => {
+      expect(getLayoutTypeFromInstanceClass([])).toBeNull();
+    });
+  });
+
+  describe("isLayoutFrontmatter", () => {
+    it("should return true for valid layout frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: "[[exo__TableLayout]]",
+      };
+
+      expect(isLayoutFrontmatter(frontmatter)).toBe(true);
+    });
+
+    it("should return true for layout frontmatter with array class", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exo__Asset]]", "[[exo__KanbanLayout]]"],
+      };
+
+      expect(isLayoutFrontmatter(frontmatter)).toBe(true);
+    });
+
+    it("should return false for non-layout frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: "[[ems__Task]]",
+      };
+
+      expect(isLayoutFrontmatter(frontmatter)).toBe(false);
+    });
+
+    it("should return false for frontmatter without instance class", () => {
+      const frontmatter = {
+        exo__Asset_label: "Some Asset",
+      };
+
+      expect(isLayoutFrontmatter(frontmatter)).toBe(false);
+    });
+  });
+
+  describe("createBaseLayoutFromFrontmatter", () => {
+    it("should create a BaseLayout from valid frontmatter", () => {
+      const frontmatter = {
+        exo__Asset_uid: "layout-001",
+        exo__Asset_label: "Daily Tasks Layout",
+        exo__Asset_description: "Table of daily tasks",
+        exo__Instance_class: "[[exo__TableLayout]]",
+        exo__Layout_targetClass: "[[ems__Task]]",
+      };
+
+      const result = createBaseLayoutFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.uid).toBe("layout-001");
+      expect(result!.label).toBe("Daily Tasks Layout");
+      expect(result!.description).toBe("Table of daily tasks");
+      expect(result!.type).toBe(LayoutType.Table);
+      expect(result!.targetClass).toBe("[[ems__Task]]");
+    });
+
+    it("should return null when uid is missing", () => {
+      const frontmatter = {
+        exo__Asset_label: "Daily Tasks Layout",
+        exo__Instance_class: "[[exo__TableLayout]]",
+        exo__Layout_targetClass: "[[ems__Task]]",
+      };
+
+      const result = createBaseLayoutFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when label is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "layout-001",
+        exo__Instance_class: "[[exo__TableLayout]]",
+        exo__Layout_targetClass: "[[ems__Task]]",
+      };
+
+      const result = createBaseLayoutFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when instance class is not a layout type", () => {
+      const frontmatter = {
+        exo__Asset_uid: "layout-001",
+        exo__Asset_label: "Not a Layout",
+        exo__Instance_class: "[[ems__Task]]",
+        exo__Layout_targetClass: "[[ems__Task]]",
+      };
+
+      const result = createBaseLayoutFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when targetClass is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "layout-001",
+        exo__Asset_label: "Daily Tasks Layout",
+        exo__Instance_class: "[[exo__TableLayout]]",
+      };
+
+      const result = createBaseLayoutFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle description being undefined", () => {
+      const frontmatter = {
+        exo__Asset_uid: "layout-001",
+        exo__Asset_label: "Daily Tasks Layout",
+        exo__Instance_class: "[[exo__TableLayout]]",
+        exo__Layout_targetClass: "[[ems__Task]]",
+      };
+
+      const result = createBaseLayoutFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.description).toBeUndefined();
+    });
+
+    it("should create BaseLayout for all layout types", () => {
+      const layoutTypes = [
+        { class: "[[exo__TableLayout]]", expected: LayoutType.Table },
+        { class: "[[exo__KanbanLayout]]", expected: LayoutType.Kanban },
+        { class: "[[exo__GraphLayout]]", expected: LayoutType.Graph },
+        { class: "[[exo__CalendarLayout]]", expected: LayoutType.Calendar },
+        { class: "[[exo__ListLayout]]", expected: LayoutType.List },
+      ];
+
+      for (const { class: cls, expected } of layoutTypes) {
+        const frontmatter = {
+          exo__Asset_uid: `layout-${expected}`,
+          exo__Asset_label: `${expected} Layout`,
+          exo__Instance_class: cls,
+          exo__Layout_targetClass: "[[ems__Task]]",
+        };
+
+        const result = createBaseLayoutFromFrontmatter(frontmatter);
+        expect(result).not.toBeNull();
+        expect(result!.type).toBe(expected);
+      }
+    });
+  });
+
+  describe("type guards", () => {
+    const tableLayout: TableLayout = {
+      uid: "table-001",
+      label: "Table Layout",
+      type: LayoutType.Table,
+      targetClass: "[[ems__Task]]",
+      columns: [],
+    };
+
+    const kanbanLayout: KanbanLayout = {
+      uid: "kanban-001",
+      label: "Kanban Layout",
+      type: LayoutType.Kanban,
+      targetClass: "[[ems__Task]]",
+      laneProperty: "[[ems__Effort_status]]",
+    };
+
+    const graphLayout: GraphLayout = {
+      uid: "graph-001",
+      label: "Graph Layout",
+      type: LayoutType.Graph,
+      targetClass: "[[ems__Task]]",
+    };
+
+    const calendarLayout: CalendarLayout = {
+      uid: "calendar-001",
+      label: "Calendar Layout",
+      type: LayoutType.Calendar,
+      targetClass: "[[ems__Effort]]",
+      startProperty: "[[ems__Effort_startTimestamp]]",
+    };
+
+    const listLayout: ListLayout = {
+      uid: "list-001",
+      label: "List Layout",
+      type: LayoutType.List,
+      targetClass: "[[ems__Task]]",
+    };
+
+    describe("isTableLayout", () => {
+      it("should return true for TableLayout", () => {
+        expect(isTableLayout(tableLayout)).toBe(true);
+      });
+
+      it("should return false for other layout types", () => {
+        expect(isTableLayout(kanbanLayout)).toBe(false);
+        expect(isTableLayout(graphLayout)).toBe(false);
+        expect(isTableLayout(calendarLayout)).toBe(false);
+        expect(isTableLayout(listLayout)).toBe(false);
+      });
+    });
+
+    describe("isKanbanLayout", () => {
+      it("should return true for KanbanLayout", () => {
+        expect(isKanbanLayout(kanbanLayout)).toBe(true);
+      });
+
+      it("should return false for other layout types", () => {
+        expect(isKanbanLayout(tableLayout)).toBe(false);
+        expect(isKanbanLayout(graphLayout)).toBe(false);
+        expect(isKanbanLayout(calendarLayout)).toBe(false);
+        expect(isKanbanLayout(listLayout)).toBe(false);
+      });
+    });
+
+    describe("isGraphLayout", () => {
+      it("should return true for GraphLayout", () => {
+        expect(isGraphLayout(graphLayout)).toBe(true);
+      });
+
+      it("should return false for other layout types", () => {
+        expect(isGraphLayout(tableLayout)).toBe(false);
+        expect(isGraphLayout(kanbanLayout)).toBe(false);
+        expect(isGraphLayout(calendarLayout)).toBe(false);
+        expect(isGraphLayout(listLayout)).toBe(false);
+      });
+    });
+
+    describe("isCalendarLayout", () => {
+      it("should return true for CalendarLayout", () => {
+        expect(isCalendarLayout(calendarLayout)).toBe(true);
+      });
+
+      it("should return false for other layout types", () => {
+        expect(isCalendarLayout(tableLayout)).toBe(false);
+        expect(isCalendarLayout(kanbanLayout)).toBe(false);
+        expect(isCalendarLayout(graphLayout)).toBe(false);
+        expect(isCalendarLayout(listLayout)).toBe(false);
+      });
+    });
+
+    describe("isListLayout", () => {
+      it("should return true for ListLayout", () => {
+        expect(isListLayout(listLayout)).toBe(true);
+      });
+
+      it("should return false for other layout types", () => {
+        expect(isListLayout(tableLayout)).toBe(false);
+        expect(isListLayout(kanbanLayout)).toBe(false);
+        expect(isListLayout(graphLayout)).toBe(false);
+        expect(isListLayout(calendarLayout)).toBe(false);
+      });
+    });
+  });
+
+  describe("isValidCalendarView", () => {
+    it('should return true for "day"', () => {
+      expect(isValidCalendarView("day")).toBe(true);
+    });
+
+    it('should return true for "week"', () => {
+      expect(isValidCalendarView("week")).toBe(true);
+    });
+
+    it('should return true for "month"', () => {
+      expect(isValidCalendarView("month")).toBe(true);
+    });
+
+    it("should return false for invalid string values", () => {
+      expect(isValidCalendarView("year")).toBe(false);
+      expect(isValidCalendarView("")).toBe(false);
+      expect(isValidCalendarView("Day")).toBe(false);
+      expect(isValidCalendarView("WEEK")).toBe(false);
+    });
+
+    it("should return false for non-string values", () => {
+      expect(isValidCalendarView(null)).toBe(false);
+      expect(isValidCalendarView(undefined)).toBe(false);
+      expect(isValidCalendarView(123)).toBe(false);
+      expect(isValidCalendarView(true)).toBe(false);
+    });
+  });
+
+  describe("type definitions", () => {
+    it("should allow creating TableLayout with columns", () => {
+      const layout: TableLayout = {
+        uid: "layout-001",
+        label: "Task Table",
+        type: LayoutType.Table,
+        targetClass: "[[ems__Task]]",
+        columns: [
+          {
+            uid: "col-001",
+            label: "Label Column",
+            property: "[[exo__Asset_label]]",
+          },
+        ],
+      };
+
+      expect(layout.type).toBe(LayoutType.Table);
+      expect(layout.columns.length).toBe(1);
+    });
+
+    it("should allow creating KanbanLayout with lanes", () => {
+      const layout: KanbanLayout = {
+        uid: "layout-001",
+        label: "Task Kanban",
+        type: LayoutType.Kanban,
+        targetClass: "[[ems__Task]]",
+        laneProperty: "[[ems__Effort_status]]",
+        lanes: [
+          "[[ems__EffortStatus_Queued]]",
+          "[[ems__EffortStatus_Doing]]",
+          "[[ems__EffortStatus_Done]]",
+        ],
+      };
+
+      expect(layout.type).toBe(LayoutType.Kanban);
+      expect(layout.lanes).toHaveLength(3);
+    });
+
+    it("should allow creating GraphLayout with edge properties", () => {
+      const layout: GraphLayout = {
+        uid: "layout-001",
+        label: "Task Graph",
+        type: LayoutType.Graph,
+        targetClass: "[[ems__Task]]",
+        nodeLabel: "[[exo__Asset_label]]",
+        edgeProperties: ["[[ems__Task_project]]", "[[ems__Task_blockedBy]]"],
+        depth: 2,
+      };
+
+      expect(layout.type).toBe(LayoutType.Graph);
+      expect(layout.edgeProperties).toHaveLength(2);
+    });
+
+    it("should allow creating CalendarLayout with time properties", () => {
+      const layout: CalendarLayout = {
+        uid: "layout-001",
+        label: "Effort Calendar",
+        type: LayoutType.Calendar,
+        targetClass: "[[ems__Effort]]",
+        startProperty: "[[ems__Effort_startTimestamp]]",
+        endProperty: "[[ems__Effort_endTimestamp]]",
+        view: "week",
+      };
+
+      expect(layout.type).toBe(LayoutType.Calendar);
+      expect(layout.view).toBe("week");
+    });
+
+    it("should allow creating ListLayout with template", () => {
+      const layout: ListLayout = {
+        uid: "layout-001",
+        label: "Task List",
+        type: LayoutType.List,
+        targetClass: "[[ems__Task]]",
+        template: "{{label}} — {{status}}",
+        showIcon: true,
+      };
+
+      expect(layout.type).toBe(LayoutType.List);
+      expect(layout.template).toBe("{{label}} — {{status}}");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/layout/LayoutColumn.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/layout/LayoutColumn.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  createLayoutColumnFromFrontmatter,
+  isValidColumnRenderer,
+  getDefaultColumnHeader,
+  type LayoutColumn,
+  type ColumnRenderer,
+} from "../../../../src/domain/layout/LayoutColumn";
+
+describe("LayoutColumn", () => {
+  describe("createLayoutColumnFromFrontmatter", () => {
+    it("should create a LayoutColumn from valid frontmatter", () => {
+      const frontmatter = {
+        exo__Asset_uid: "60000000-0000-0000-0000-000000000010",
+        exo__Asset_label: "Task Label Column",
+        exo__Asset_description: "Column showing task label",
+        exo__LayoutColumn_property: "[[exo__Asset_label]]",
+        exo__LayoutColumn_header: "Задача",
+        exo__LayoutColumn_width: "1fr",
+        exo__LayoutColumn_renderer: "link",
+        exo__LayoutColumn_editable: true,
+        exo__LayoutColumn_sortable: true,
+      };
+
+      const result = createLayoutColumnFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.uid).toBe("60000000-0000-0000-0000-000000000010");
+      expect(result!.label).toBe("Task Label Column");
+      expect(result!.description).toBe("Column showing task label");
+      expect(result!.property).toBe("[[exo__Asset_label]]");
+      expect(result!.header).toBe("Задача");
+      expect(result!.width).toBe("1fr");
+      expect(result!.renderer).toBe("link");
+      expect(result!.editable).toBe(true);
+      expect(result!.sortable).toBe(true);
+    });
+
+    it("should return null when uid is missing", () => {
+      const frontmatter = {
+        exo__Asset_label: "Task Label Column",
+        exo__LayoutColumn_property: "[[exo__Asset_label]]",
+      };
+
+      const result = createLayoutColumnFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when label is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "col-001",
+        exo__LayoutColumn_property: "[[exo__Asset_label]]",
+      };
+
+      const result = createLayoutColumnFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when property is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "col-001",
+        exo__Asset_label: "Task Label Column",
+      };
+
+      const result = createLayoutColumnFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it('should default renderer to "text" when not specified', () => {
+      const frontmatter = {
+        exo__Asset_uid: "col-001",
+        exo__Asset_label: "Text Column",
+        exo__LayoutColumn_property: "[[exo__Asset_label]]",
+      };
+
+      const result = createLayoutColumnFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.renderer).toBe("text");
+    });
+
+    it('should default renderer to "text" for invalid renderer value', () => {
+      const frontmatter = {
+        exo__Asset_uid: "col-001",
+        exo__Asset_label: "Invalid Renderer Column",
+        exo__LayoutColumn_property: "[[exo__Asset_label]]",
+        exo__LayoutColumn_renderer: "invalid_renderer",
+      };
+
+      const result = createLayoutColumnFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.renderer).toBe("text");
+    });
+
+    it("should default editable to false when not specified", () => {
+      const frontmatter = {
+        exo__Asset_uid: "col-001",
+        exo__Asset_label: "Non-editable Column",
+        exo__LayoutColumn_property: "[[exo__Asset_label]]",
+      };
+
+      const result = createLayoutColumnFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.editable).toBe(false);
+    });
+
+    it("should default sortable to false when not specified", () => {
+      const frontmatter = {
+        exo__Asset_uid: "col-001",
+        exo__Asset_label: "Non-sortable Column",
+        exo__LayoutColumn_property: "[[exo__Asset_label]]",
+      };
+
+      const result = createLayoutColumnFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.sortable).toBe(false);
+    });
+
+    it("should handle all valid renderer types", () => {
+      const renderers: ColumnRenderer[] = [
+        "text",
+        "link",
+        "badge",
+        "progress",
+        "datetime",
+        "duration",
+        "number",
+        "boolean",
+        "tags",
+        "image",
+        "custom",
+      ];
+
+      for (const renderer of renderers) {
+        const frontmatter = {
+          exo__Asset_uid: `col-${renderer}`,
+          exo__Asset_label: `${renderer} Column`,
+          exo__LayoutColumn_property: "[[some_property]]",
+          exo__LayoutColumn_renderer: renderer,
+        };
+
+        const result = createLayoutColumnFromFrontmatter(frontmatter);
+        expect(result).not.toBeNull();
+        expect(result!.renderer).toBe(renderer);
+      }
+    });
+
+    it("should handle optional fields being undefined", () => {
+      const frontmatter = {
+        exo__Asset_uid: "col-001",
+        exo__Asset_label: "Minimal Column",
+        exo__LayoutColumn_property: "[[exo__Asset_label]]",
+      };
+
+      const result = createLayoutColumnFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.description).toBeUndefined();
+      expect(result!.header).toBeUndefined();
+      expect(result!.width).toBeUndefined();
+    });
+  });
+
+  describe("isValidColumnRenderer", () => {
+    it("should return true for all valid renderers", () => {
+      const validRenderers = [
+        "text",
+        "link",
+        "badge",
+        "progress",
+        "datetime",
+        "duration",
+        "number",
+        "boolean",
+        "tags",
+        "image",
+        "custom",
+      ];
+
+      for (const renderer of validRenderers) {
+        expect(isValidColumnRenderer(renderer)).toBe(true);
+      }
+    });
+
+    it("should return false for invalid renderer strings", () => {
+      expect(isValidColumnRenderer("invalid")).toBe(false);
+      expect(isValidColumnRenderer("")).toBe(false);
+      expect(isValidColumnRenderer("TEXT")).toBe(false);
+      expect(isValidColumnRenderer("Link")).toBe(false);
+    });
+
+    it("should return false for non-string values", () => {
+      expect(isValidColumnRenderer(null)).toBe(false);
+      expect(isValidColumnRenderer(undefined)).toBe(false);
+      expect(isValidColumnRenderer(123)).toBe(false);
+      expect(isValidColumnRenderer(true)).toBe(false);
+      expect(isValidColumnRenderer({})).toBe(false);
+      expect(isValidColumnRenderer([])).toBe(false);
+    });
+  });
+
+  describe("getDefaultColumnHeader", () => {
+    it("should extract header from simple property wikilink", () => {
+      expect(getDefaultColumnHeader("[[exo__Asset_label]]")).toBe("Label");
+    });
+
+    it("should extract header from compound property name", () => {
+      expect(getDefaultColumnHeader("[[ems__Effort_startTimestamp]]")).toBe(
+        "Start Timestamp",
+      );
+    });
+
+    it("should handle camelCase in property name", () => {
+      expect(getDefaultColumnHeader("[[ems__Task_currentEffort]]")).toBe(
+        "Current Effort",
+      );
+    });
+
+    it("should handle property without wikilink brackets", () => {
+      expect(getDefaultColumnHeader("exo__Asset_label")).toBe("Label");
+    });
+
+    it("should handle single-part property name", () => {
+      expect(getDefaultColumnHeader("[[exo__Asset]]")).toBe("Asset");
+    });
+
+    it("should capitalize first letter", () => {
+      expect(getDefaultColumnHeader("[[some__lowercase_property]]")).toBe(
+        "Lowercase Property",
+      );
+    });
+  });
+
+  describe("type safety", () => {
+    it("should allow creating LayoutColumn with all fields", () => {
+      const column: LayoutColumn = {
+        uid: "col-001",
+        label: "Full Column",
+        description: "A fully specified column",
+        property: "[[exo__Asset_label]]",
+        header: "Custom Header",
+        width: "200px",
+        renderer: "link",
+        editable: true,
+        sortable: true,
+      };
+
+      expect(column.uid).toBe("col-001");
+      expect(column.renderer).toBe("link");
+    });
+
+    it("should allow creating LayoutColumn with minimal fields", () => {
+      const column: LayoutColumn = {
+        uid: "col-001",
+        label: "Minimal Column",
+        property: "[[exo__Asset_label]]",
+      };
+
+      expect(column.uid).toBe("col-001");
+      expect(column.header).toBeUndefined();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/layout/LayoutFilter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/layout/LayoutFilter.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  createLayoutFilterFromFrontmatter,
+  isValidFilterOperator,
+  isSimpleFilter,
+  isSparqlFilter,
+  type LayoutFilter,
+  type FilterOperator,
+} from "../../../../src/domain/layout/LayoutFilter";
+
+describe("LayoutFilter", () => {
+  describe("createLayoutFilterFromFrontmatter", () => {
+    it("should create a simple LayoutFilter from valid frontmatter", () => {
+      const frontmatter = {
+        exo__Asset_uid: "filter-001",
+        exo__Asset_label: "Active Tasks Filter",
+        exo__Asset_description: "Filter out completed tasks",
+        exo__LayoutFilter_property: "[[ems__Effort_status]]",
+        exo__LayoutFilter_operator: "ne",
+        exo__LayoutFilter_value: "[[ems__EffortStatus_Done]]",
+      };
+
+      const result = createLayoutFilterFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.uid).toBe("filter-001");
+      expect(result!.label).toBe("Active Tasks Filter");
+      expect(result!.description).toBe("Filter out completed tasks");
+      expect(result!.property).toBe("[[ems__Effort_status]]");
+      expect(result!.operator).toBe("ne");
+      expect(result!.value).toBe("[[ems__EffortStatus_Done]]");
+      expect(result!.sparql).toBeUndefined();
+    });
+
+    it("should create a SPARQL LayoutFilter from valid frontmatter", () => {
+      const sparqlQuery = `
+        ?asset ems:Task_currentEffort ?effort .
+        ?effort ems:Effort_startTimestamp ?start .
+        FILTER(?start >= NOW() - "P1D"^^xsd:duration)
+      `;
+      const frontmatter = {
+        exo__Asset_uid: "filter-002",
+        exo__Asset_label: "Today Filter",
+        exo__Asset_description: "Filter tasks started today",
+        exo__LayoutFilter_sparql: sparqlQuery,
+      };
+
+      const result = createLayoutFilterFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.uid).toBe("filter-002");
+      expect(result!.label).toBe("Today Filter");
+      expect(result!.sparql).toBe(sparqlQuery);
+      expect(result!.property).toBeUndefined();
+      expect(result!.operator).toBeUndefined();
+    });
+
+    it("should return null when uid is missing", () => {
+      const frontmatter = {
+        exo__Asset_label: "No UID Filter",
+        exo__LayoutFilter_property: "[[ems__Effort_status]]",
+        exo__LayoutFilter_operator: "eq",
+      };
+
+      const result = createLayoutFilterFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when label is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "filter-001",
+        exo__LayoutFilter_property: "[[ems__Effort_status]]",
+        exo__LayoutFilter_operator: "eq",
+      };
+
+      const result = createLayoutFilterFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when neither property nor sparql is present", () => {
+      const frontmatter = {
+        exo__Asset_uid: "filter-001",
+        exo__Asset_label: "Invalid Filter",
+        exo__LayoutFilter_operator: "eq",
+        exo__LayoutFilter_value: "some value",
+      };
+
+      const result = createLayoutFilterFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle all valid filter operators", () => {
+      const operators: FilterOperator[] = [
+        "eq",
+        "ne",
+        "gt",
+        "gte",
+        "lt",
+        "lte",
+        "contains",
+        "startsWith",
+        "endsWith",
+        "in",
+        "notIn",
+        "isNull",
+        "isNotNull",
+      ];
+
+      for (const operator of operators) {
+        const frontmatter = {
+          exo__Asset_uid: `filter-${operator}`,
+          exo__Asset_label: `${operator} Filter`,
+          exo__LayoutFilter_property: "[[some_property]]",
+          exo__LayoutFilter_operator: operator,
+        };
+
+        const result = createLayoutFilterFromFrontmatter(frontmatter);
+        expect(result).not.toBeNull();
+        expect(result!.operator).toBe(operator);
+      }
+    });
+
+    it("should set operator to undefined for invalid operator value", () => {
+      const frontmatter = {
+        exo__Asset_uid: "filter-001",
+        exo__Asset_label: "Invalid Operator Filter",
+        exo__LayoutFilter_property: "[[some_property]]",
+        exo__LayoutFilter_operator: "invalid_operator",
+      };
+
+      const result = createLayoutFilterFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.operator).toBeUndefined();
+    });
+
+    it("should handle filter with both property and sparql", () => {
+      const frontmatter = {
+        exo__Asset_uid: "filter-001",
+        exo__Asset_label: "Complex Filter",
+        exo__LayoutFilter_property: "[[ems__Effort_status]]",
+        exo__LayoutFilter_operator: "eq",
+        exo__LayoutFilter_sparql: "?asset ?p ?o",
+      };
+
+      const result = createLayoutFilterFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.property).toBe("[[ems__Effort_status]]");
+      expect(result!.sparql).toBe("?asset ?p ?o");
+    });
+
+    it("should handle value being undefined for isNull operator", () => {
+      const frontmatter = {
+        exo__Asset_uid: "filter-001",
+        exo__Asset_label: "Null Check Filter",
+        exo__LayoutFilter_property: "[[some_property]]",
+        exo__LayoutFilter_operator: "isNull",
+      };
+
+      const result = createLayoutFilterFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.operator).toBe("isNull");
+      expect(result!.value).toBeUndefined();
+    });
+  });
+
+  describe("isValidFilterOperator", () => {
+    it("should return true for all valid operators", () => {
+      const validOperators = [
+        "eq",
+        "ne",
+        "gt",
+        "gte",
+        "lt",
+        "lte",
+        "contains",
+        "startsWith",
+        "endsWith",
+        "in",
+        "notIn",
+        "isNull",
+        "isNotNull",
+      ];
+
+      for (const op of validOperators) {
+        expect(isValidFilterOperator(op)).toBe(true);
+      }
+    });
+
+    it("should return false for invalid operator strings", () => {
+      expect(isValidFilterOperator("invalid")).toBe(false);
+      expect(isValidFilterOperator("")).toBe(false);
+      expect(isValidFilterOperator("EQ")).toBe(false);
+      expect(isValidFilterOperator("equal")).toBe(false);
+      expect(isValidFilterOperator("=")).toBe(false);
+      expect(isValidFilterOperator("!=")).toBe(false);
+    });
+
+    it("should return false for non-string values", () => {
+      expect(isValidFilterOperator(null)).toBe(false);
+      expect(isValidFilterOperator(undefined)).toBe(false);
+      expect(isValidFilterOperator(123)).toBe(false);
+      expect(isValidFilterOperator(true)).toBe(false);
+      expect(isValidFilterOperator({})).toBe(false);
+    });
+  });
+
+  describe("isSimpleFilter", () => {
+    it("should return true for filter with property and operator", () => {
+      const filter: LayoutFilter = {
+        uid: "filter-001",
+        label: "Simple Filter",
+        property: "[[some_property]]",
+        operator: "eq",
+        value: "some value",
+      };
+
+      expect(isSimpleFilter(filter)).toBe(true);
+    });
+
+    it("should return false for filter without property", () => {
+      const filter: LayoutFilter = {
+        uid: "filter-001",
+        label: "SPARQL Only Filter",
+        sparql: "?asset ?p ?o",
+      };
+
+      expect(isSimpleFilter(filter)).toBe(false);
+    });
+
+    it("should return false for filter without operator", () => {
+      const filter: LayoutFilter = {
+        uid: "filter-001",
+        label: "Property Only Filter",
+        property: "[[some_property]]",
+      };
+
+      expect(isSimpleFilter(filter)).toBe(false);
+    });
+  });
+
+  describe("isSparqlFilter", () => {
+    it("should return true for filter with sparql", () => {
+      const filter: LayoutFilter = {
+        uid: "filter-001",
+        label: "SPARQL Filter",
+        sparql: "?asset ?p ?o",
+      };
+
+      expect(isSparqlFilter(filter)).toBe(true);
+    });
+
+    it("should return false for filter without sparql", () => {
+      const filter: LayoutFilter = {
+        uid: "filter-001",
+        label: "Simple Filter",
+        property: "[[some_property]]",
+        operator: "eq",
+      };
+
+      expect(isSparqlFilter(filter)).toBe(false);
+    });
+
+    it("should return true for filter with both property and sparql", () => {
+      const filter: LayoutFilter = {
+        uid: "filter-001",
+        label: "Combined Filter",
+        property: "[[some_property]]",
+        operator: "eq",
+        sparql: "?asset ?p ?o",
+      };
+
+      expect(isSparqlFilter(filter)).toBe(true);
+    });
+  });
+
+  describe("type safety", () => {
+    it("should allow creating LayoutFilter with all fields", () => {
+      const filter: LayoutFilter = {
+        uid: "filter-001",
+        label: "Full Filter",
+        description: "A fully specified filter",
+        property: "[[ems__Effort_status]]",
+        operator: "ne",
+        value: "[[ems__EffortStatus_Done]]",
+        sparql: "OPTIONAL { ?asset ?p ?o }",
+      };
+
+      expect(filter.uid).toBe("filter-001");
+      expect(filter.operator).toBe("ne");
+    });
+
+    it("should allow creating minimal SPARQL filter", () => {
+      const filter: LayoutFilter = {
+        uid: "filter-001",
+        label: "Minimal SPARQL Filter",
+        sparql: "?asset ?p ?o",
+      };
+
+      expect(filter.uid).toBe("filter-001");
+      expect(filter.property).toBeUndefined();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/layout/LayoutGroup.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/layout/LayoutGroup.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  createLayoutGroupFromFrontmatter,
+  isValidGroupSortOrder,
+  type LayoutGroup,
+  type GroupSortOrder,
+} from "../../../../src/domain/layout/LayoutGroup";
+
+describe("LayoutGroup", () => {
+  describe("createLayoutGroupFromFrontmatter", () => {
+    it("should create a LayoutGroup from valid frontmatter", () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "Group by Project",
+        exo__Asset_description: "Group tasks by their parent project",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+        exo__LayoutGroup_collapsed: false,
+        exo__LayoutGroup_showCount: true,
+        exo__LayoutGroup_sortGroups: "asc",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.uid).toBe("group-001");
+      expect(result!.label).toBe("Group by Project");
+      expect(result!.description).toBe("Group tasks by their parent project");
+      expect(result!.property).toBe("[[ems__Task_project]]");
+      expect(result!.collapsed).toBe(false);
+      expect(result!.showCount).toBe(true);
+      expect(result!.sortGroups).toBe("asc");
+    });
+
+    it("should return null when uid is missing", () => {
+      const frontmatter = {
+        exo__Asset_label: "Group by Project",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when label is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when property is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "Group by Project",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should default collapsed to false when not specified", () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "Default Collapsed Group",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.collapsed).toBe(false);
+    });
+
+    it("should set collapsed to true when specified", () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "Collapsed Group",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+        exo__LayoutGroup_collapsed: true,
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.collapsed).toBe(true);
+    });
+
+    it("should default showCount to true when not specified", () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "Default ShowCount Group",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.showCount).toBe(true);
+    });
+
+    it("should set showCount to false when explicitly set", () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "No Count Group",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+        exo__LayoutGroup_showCount: false,
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.showCount).toBe(false);
+    });
+
+    it('should default sortGroups to "asc" when not specified', () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "Default Sort Group",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.sortGroups).toBe("asc");
+    });
+
+    it('should handle sortGroups "desc"', () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "Descending Sort Group",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+        exo__LayoutGroup_sortGroups: "desc",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.sortGroups).toBe("desc");
+    });
+
+    it('should handle sortGroups "custom"', () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "Custom Sort Group",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+        exo__LayoutGroup_sortGroups: "custom",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.sortGroups).toBe("custom");
+    });
+
+    it('should default sortGroups to "asc" for invalid value', () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "Invalid Sort Group",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+        exo__LayoutGroup_sortGroups: "invalid",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.sortGroups).toBe("asc");
+    });
+
+    it("should handle description being undefined", () => {
+      const frontmatter = {
+        exo__Asset_uid: "group-001",
+        exo__Asset_label: "No Description Group",
+        exo__LayoutGroup_property: "[[ems__Task_project]]",
+      };
+
+      const result = createLayoutGroupFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.description).toBeUndefined();
+    });
+  });
+
+  describe("isValidGroupSortOrder", () => {
+    it('should return true for "asc"', () => {
+      expect(isValidGroupSortOrder("asc")).toBe(true);
+    });
+
+    it('should return true for "desc"', () => {
+      expect(isValidGroupSortOrder("desc")).toBe(true);
+    });
+
+    it('should return true for "custom"', () => {
+      expect(isValidGroupSortOrder("custom")).toBe(true);
+    });
+
+    it("should return false for invalid string values", () => {
+      expect(isValidGroupSortOrder("ascending")).toBe(false);
+      expect(isValidGroupSortOrder("descending")).toBe(false);
+      expect(isValidGroupSortOrder("")).toBe(false);
+      expect(isValidGroupSortOrder("ASC")).toBe(false);
+      expect(isValidGroupSortOrder("DESC")).toBe(false);
+    });
+
+    it("should return false for non-string values", () => {
+      expect(isValidGroupSortOrder(null)).toBe(false);
+      expect(isValidGroupSortOrder(undefined)).toBe(false);
+      expect(isValidGroupSortOrder(123)).toBe(false);
+      expect(isValidGroupSortOrder(true)).toBe(false);
+      expect(isValidGroupSortOrder({})).toBe(false);
+    });
+  });
+
+  describe("type safety", () => {
+    it("should allow creating LayoutGroup with all fields", () => {
+      const group: LayoutGroup = {
+        uid: "group-001",
+        label: "Full Group",
+        description: "A fully specified group",
+        property: "[[ems__Task_project]]",
+        collapsed: true,
+        showCount: true,
+        sortGroups: "desc",
+      };
+
+      expect(group.uid).toBe("group-001");
+      expect(group.sortGroups).toBe("desc");
+    });
+
+    it("should allow creating LayoutGroup with minimal fields", () => {
+      const group: LayoutGroup = {
+        uid: "group-001",
+        label: "Minimal Group",
+        property: "[[ems__Task_project]]",
+      };
+
+      expect(group.uid).toBe("group-001");
+      expect(group.collapsed).toBeUndefined();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/layout/LayoutSort.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/layout/LayoutSort.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  createLayoutSortFromFrontmatter,
+  isValidSortDirection,
+  isValidNullsPosition,
+  type LayoutSort,
+  type SortDirection,
+  type NullsPosition,
+} from "../../../../src/domain/layout/LayoutSort";
+
+describe("LayoutSort", () => {
+  describe("createLayoutSortFromFrontmatter", () => {
+    it("should create a LayoutSort from valid frontmatter", () => {
+      const frontmatter = {
+        exo__Asset_uid: "60000000-0000-0000-0000-000000000020",
+        exo__Asset_label: "Sort by Start Time",
+        exo__Asset_description: "Sort by start timestamp descending",
+        exo__LayoutSort_property: "[[ems__Effort_startTimestamp]]",
+        exo__LayoutSort_direction: "desc",
+        exo__LayoutSort_nullsPosition: "last",
+      };
+
+      const result = createLayoutSortFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.uid).toBe("60000000-0000-0000-0000-000000000020");
+      expect(result!.label).toBe("Sort by Start Time");
+      expect(result!.description).toBe("Sort by start timestamp descending");
+      expect(result!.property).toBe("[[ems__Effort_startTimestamp]]");
+      expect(result!.direction).toBe("desc");
+      expect(result!.nullsPosition).toBe("last");
+    });
+
+    it("should return null when uid is missing", () => {
+      const frontmatter = {
+        exo__Asset_label: "Sort by Start Time",
+        exo__LayoutSort_property: "[[ems__Effort_startTimestamp]]",
+        exo__LayoutSort_direction: "desc",
+      };
+
+      const result = createLayoutSortFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when label is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "60000000-0000-0000-0000-000000000020",
+        exo__LayoutSort_property: "[[ems__Effort_startTimestamp]]",
+        exo__LayoutSort_direction: "desc",
+      };
+
+      const result = createLayoutSortFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when property is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "60000000-0000-0000-0000-000000000020",
+        exo__Asset_label: "Sort by Start Time",
+        exo__LayoutSort_direction: "desc",
+      };
+
+      const result = createLayoutSortFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should default direction to asc when not specified", () => {
+      const frontmatter = {
+        exo__Asset_uid: "sort-001",
+        exo__Asset_label: "Default Sort",
+        exo__LayoutSort_property: "[[exo__Asset_label]]",
+      };
+
+      const result = createLayoutSortFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.direction).toBe("asc");
+    });
+
+    it("should default direction to asc when invalid value", () => {
+      const frontmatter = {
+        exo__Asset_uid: "sort-001",
+        exo__Asset_label: "Invalid Direction Sort",
+        exo__LayoutSort_property: "[[exo__Asset_label]]",
+        exo__LayoutSort_direction: "invalid",
+      };
+
+      const result = createLayoutSortFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.direction).toBe("asc");
+    });
+
+    it("should default nullsPosition to last when not specified", () => {
+      const frontmatter = {
+        exo__Asset_uid: "sort-001",
+        exo__Asset_label: "Default Nulls Sort",
+        exo__LayoutSort_property: "[[exo__Asset_label]]",
+        exo__LayoutSort_direction: "asc",
+      };
+
+      const result = createLayoutSortFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.nullsPosition).toBe("last");
+    });
+
+    it("should set nullsPosition to first when specified", () => {
+      const frontmatter = {
+        exo__Asset_uid: "sort-001",
+        exo__Asset_label: "Nulls First Sort",
+        exo__LayoutSort_property: "[[exo__Asset_label]]",
+        exo__LayoutSort_direction: "asc",
+        exo__LayoutSort_nullsPosition: "first",
+      };
+
+      const result = createLayoutSortFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.nullsPosition).toBe("first");
+    });
+
+    it("should handle description being undefined", () => {
+      const frontmatter = {
+        exo__Asset_uid: "sort-001",
+        exo__Asset_label: "No Description Sort",
+        exo__LayoutSort_property: "[[exo__Asset_label]]",
+        exo__LayoutSort_direction: "asc",
+      };
+
+      const result = createLayoutSortFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result!.description).toBeUndefined();
+    });
+  });
+
+  describe("isValidSortDirection", () => {
+    it('should return true for "asc"', () => {
+      expect(isValidSortDirection("asc")).toBe(true);
+    });
+
+    it('should return true for "desc"', () => {
+      expect(isValidSortDirection("desc")).toBe(true);
+    });
+
+    it("should return false for invalid string", () => {
+      expect(isValidSortDirection("ascending")).toBe(false);
+      expect(isValidSortDirection("descending")).toBe(false);
+      expect(isValidSortDirection("")).toBe(false);
+    });
+
+    it("should return false for non-string values", () => {
+      expect(isValidSortDirection(null)).toBe(false);
+      expect(isValidSortDirection(undefined)).toBe(false);
+      expect(isValidSortDirection(123)).toBe(false);
+      expect(isValidSortDirection(true)).toBe(false);
+      expect(isValidSortDirection({})).toBe(false);
+    });
+  });
+
+  describe("isValidNullsPosition", () => {
+    it('should return true for "first"', () => {
+      expect(isValidNullsPosition("first")).toBe(true);
+    });
+
+    it('should return true for "last"', () => {
+      expect(isValidNullsPosition("last")).toBe(true);
+    });
+
+    it("should return false for invalid string", () => {
+      expect(isValidNullsPosition("beginning")).toBe(false);
+      expect(isValidNullsPosition("end")).toBe(false);
+      expect(isValidNullsPosition("")).toBe(false);
+    });
+
+    it("should return false for non-string values", () => {
+      expect(isValidNullsPosition(null)).toBe(false);
+      expect(isValidNullsPosition(undefined)).toBe(false);
+      expect(isValidNullsPosition(123)).toBe(false);
+      expect(isValidNullsPosition(true)).toBe(false);
+    });
+  });
+
+  describe("type safety", () => {
+    it("should allow creating LayoutSort with all fields", () => {
+      const sort: LayoutSort = {
+        uid: "sort-001",
+        label: "Test Sort",
+        description: "A test sort definition",
+        property: "[[exo__Asset_label]]",
+        direction: "asc",
+        nullsPosition: "last",
+      };
+
+      expect(sort.uid).toBe("sort-001");
+      expect(sort.label).toBe("Test Sort");
+      expect(sort.direction).toBe("asc");
+    });
+
+    it("should allow creating LayoutSort with minimal fields", () => {
+      const sort: LayoutSort = {
+        uid: "sort-001",
+        label: "Minimal Sort",
+        property: "[[exo__Asset_label]]",
+        direction: "desc",
+      };
+
+      expect(sort.uid).toBe("sort-001");
+      expect(sort.direction).toBe("desc");
+      expect(sort.nullsPosition).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Domain Models for Layout System as specified in #964.

### Changes

- **Layout.ts**: Core layout types - `LayoutType` enum mapping to ontology classes (`exo__TableLayout`, `exo__KanbanLayout`, etc.), `BaseLayout` interface, and specialized interfaces for each layout type (`TableLayout`, `KanbanLayout`, `GraphLayout`, `CalendarLayout`, `ListLayout`). Includes type guards and factory function `createBaseLayoutFromFrontmatter()`.

- **LayoutColumn.ts**: Column definitions with `ColumnRenderer` type supporting 11 renderer types (text, link, badge, progress, datetime, duration, number, boolean, tags, image, custom). Factory function `createLayoutColumnFromFrontmatter()` and helper `getDefaultColumnHeader()`.

- **LayoutFilter.ts**: Filter definitions supporting both simple property filters (`FilterOperator` with 13 operators) and SPARQL filters. Type helpers `isSimpleFilter()` and `isSparqlFilter()`.

- **LayoutSort.ts**: Sort definitions with `SortDirection` (asc/desc) and `NullsPosition` (first/last) types.

- **LayoutGroup.ts**: Grouping definitions with `GroupSortOrder` type (asc, desc, custom).

- **index.ts**: Barrel export file for all types, interfaces, and functions.

### Testing

- 5 comprehensive test files with 139 test cases
- All tests passing (3425 passed across project)
- Coverage target >80% achieved

## Test plan

- [x] All unit tests pass (`npm run test:unit`)
- [x] Type guards correctly identify layout types
- [x] Factory functions handle missing/invalid frontmatter gracefully
- [x] All layout types mapped correctly to ontology classes

Closes #964