### PR TITLE
feat(layout): add LayoutService orchestrator for layout rendering pipeline

### DIFF
--- a/packages/obsidian-plugin/src/application/layout/LayoutService.ts
+++ b/packages/obsidian-plugin/src/application/layout/LayoutService.ts
@@ -1,0 +1,641 @@
+/**
+ * LayoutService - Orchestrator for Layout rendering pipeline
+ *
+ * Coordinates the entire layout rendering process:
+ * 1. Parse layout definition from vault file (LayoutParser)
+ * 2. Build SPARQL query from layout (LayoutQueryBuilder)
+ * 3. Execute query against triple store (SPARQLQueryService)
+ * 4. Transform results into TableRow format for rendering
+ * 5. Handle cell edits via frontmatter updates
+ * 6. Handle sort changes with re-query
+ *
+ * @module application/layout
+ * @since 1.0.0
+ */
+
+import { TFile, type App } from "obsidian";
+import type {
+  IVaultAdapter,
+  IFile,
+  SolutionMapping,
+  ILogger,
+  INotificationService,
+} from "exocortex";
+import { Literal, IRI } from "exocortex";
+
+import type {
+  Layout,
+  LayoutColumn,
+  LayoutSort,
+} from "../../domain/layout";
+import { isTableLayout, isKanbanLayout } from "../../domain/layout";
+import { LayoutParser, type LayoutParseOptions } from "../../infrastructure/layout/LayoutParser";
+import { LayoutQueryBuilder, type QueryBuildOptions } from "./LayoutQueryBuilder";
+import type { TableRow, CellValue } from "../../presentation/renderers/cell-renderers";
+import { SPARQLQueryService } from "../services/SPARQLQueryService";
+import { LoggerFactory } from "@plugin/adapters/logging/LoggerFactory";
+
+/**
+ * Result of a layout render operation
+ */
+export interface LayoutRenderResult {
+  /** Whether rendering was successful */
+  success: boolean;
+  /** The parsed layout definition */
+  layout?: Layout;
+  /** Row data for rendering */
+  rows?: TableRow[];
+  /** Generated SPARQL query (for debugging) */
+  query?: string;
+  /** Variable mapping from query builder */
+  variables?: string[];
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Options for layout rendering
+ */
+export interface LayoutRenderOptions extends LayoutParseOptions, QueryBuildOptions {
+  /**
+   * Whether to cache parsed layouts.
+   * @default true
+   */
+  useCache?: boolean;
+}
+
+/**
+ * Result of a cell edit operation
+ */
+export interface CellEditResult {
+  /** Whether edit was successful */
+  success: boolean;
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * LayoutService - Orchestrates the complete layout rendering pipeline
+ *
+ * @example
+ * ```typescript
+ * const layoutService = new LayoutService(app, vaultAdapter);
+ * await layoutService.initialize();
+ *
+ * // Render a layout
+ * const result = await layoutService.renderLayout(layoutFile);
+ * if (result.success) {
+ *   // Use result.layout and result.rows with TableLayoutRenderer
+ * }
+ *
+ * // Handle cell edit
+ * await layoutService.handleCellEdit(assetPath, columnUid, newValue);
+ * ```
+ */
+export class LayoutService {
+  private readonly app: App;
+  private readonly vaultAdapter: IVaultAdapter;
+  private readonly parser: LayoutParser;
+  private readonly queryBuilder: LayoutQueryBuilder;
+  private readonly sparqlService: SPARQLQueryService;
+  private readonly logger: ILogger;
+  private isInitialized = false;
+
+  /**
+   * Cache for rendered layouts with their data
+   */
+  private readonly layoutCache: Map<string, LayoutRenderResult> = new Map();
+
+  constructor(
+    app: App,
+    vaultAdapter: IVaultAdapter,
+    logger?: ILogger,
+    notifier?: INotificationService
+  ) {
+    this.app = app;
+    this.vaultAdapter = vaultAdapter;
+
+    const defaultLogger = LoggerFactory.create("LayoutService");
+    this.logger = logger || {
+      debug: defaultLogger.debug.bind(defaultLogger),
+      info: defaultLogger.info.bind(defaultLogger),
+      warn: defaultLogger.warn.bind(defaultLogger),
+      error: defaultLogger.error.bind(defaultLogger),
+    };
+
+    this.parser = new LayoutParser(vaultAdapter);
+    this.queryBuilder = new LayoutQueryBuilder();
+    this.sparqlService = new SPARQLQueryService(app, this.logger, notifier);
+  }
+
+  /**
+   * Initialize the service.
+   * Must be called before any other operations.
+   */
+  async initialize(): Promise<void> {
+    if (this.isInitialized) {
+      return;
+    }
+
+    await this.sparqlService.initialize();
+    this.isInitialized = true;
+    this.logger.info("LayoutService initialized");
+  }
+
+  /**
+   * Render a layout from a vault file.
+   *
+   * Complete pipeline:
+   * 1. Parse layout definition
+   * 2. Build SPARQL query
+   * 3. Execute query
+   * 4. Transform results to TableRow format
+   *
+   * @param layoutFile - The layout definition file
+   * @param options - Rendering options
+   * @returns Render result with layout and rows
+   */
+  async renderLayout(
+    layoutFile: IFile,
+    options: LayoutRenderOptions = {}
+  ): Promise<LayoutRenderResult> {
+    const { useCache = true } = options;
+
+    // Check cache
+    if (useCache) {
+      const cached = this.layoutCache.get(layoutFile.path);
+      if (cached && cached.success) {
+        return cached;
+      }
+    }
+
+    try {
+      // Ensure initialized
+      if (!this.isInitialized) {
+        await this.initialize();
+      }
+
+      // Step 1: Parse layout
+      const parseResult = await this.parser.parseFromFile(layoutFile, options);
+      if (!parseResult.success || !parseResult.layout) {
+        return {
+          success: false,
+          error: parseResult.error || "Failed to parse layout",
+        };
+      }
+
+      const layout = parseResult.layout;
+
+      // Step 2: Build query
+      const queryResult = this.queryBuilder.build(layout, options);
+      if (!queryResult.success || !queryResult.query) {
+        return {
+          success: false,
+          layout,
+          error: queryResult.error || "Failed to build query",
+        };
+      }
+
+      // Step 3: Execute query
+      const solutions = await this.sparqlService.query(queryResult.query);
+
+      // Step 4: Transform to TableRow format
+      const columns = this.getLayoutColumns(layout);
+      const rows = this.transformToTableRows(
+        solutions,
+        columns,
+        queryResult.variables || []
+      );
+
+      const result: LayoutRenderResult = {
+        success: true,
+        layout,
+        rows,
+        query: queryResult.query,
+        variables: queryResult.variables,
+      };
+
+      // Cache the result
+      if (useCache) {
+        this.layoutCache.set(layoutFile.path, result);
+      }
+
+      return result;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to render layout: ${errorMessage}`);
+      return {
+        success: false,
+        error: `Layout rendering failed: ${errorMessage}`,
+      };
+    }
+  }
+
+  /**
+   * Render a layout from a wikilink reference.
+   *
+   * @param wikilink - The wikilink reference (e.g., "[[MyTableLayout]]")
+   * @param sourcePath - Source path for resolving relative links
+   * @param options - Rendering options
+   * @returns Render result
+   */
+  async renderLayoutFromWikiLink(
+    wikilink: string,
+    sourcePath: string = "",
+    options: LayoutRenderOptions = {}
+  ): Promise<LayoutRenderResult> {
+    const layout = await this.parser.parseFromWikiLink(wikilink, sourcePath, options);
+    if (!layout) {
+      return {
+        success: false,
+        error: `Failed to resolve layout from wikilink: ${wikilink}`,
+      };
+    }
+
+    // Need to find the file for the layout to use renderLayout
+    // For now, build the result directly
+    try {
+      // Ensure initialized
+      if (!this.isInitialized) {
+        await this.initialize();
+      }
+
+      // Build query
+      const queryResult = this.queryBuilder.build(layout, options);
+      if (!queryResult.success || !queryResult.query) {
+        return {
+          success: false,
+          layout,
+          error: queryResult.error || "Failed to build query",
+        };
+      }
+
+      // Execute query
+      const solutions = await this.sparqlService.query(queryResult.query);
+
+      // Transform to TableRow format
+      const columns = this.getLayoutColumns(layout);
+      const rows = this.transformToTableRows(
+        solutions,
+        columns,
+        queryResult.variables || []
+      );
+
+      return {
+        success: true,
+        layout,
+        rows,
+        query: queryResult.query,
+        variables: queryResult.variables,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to render layout from wikilink: ${errorMessage}`);
+      return {
+        success: false,
+        error: `Layout rendering failed: ${errorMessage}`,
+      };
+    }
+  }
+
+  /**
+   * Handle a cell edit operation.
+   *
+   * Updates the frontmatter of the asset file with the new value.
+   *
+   * @param assetPath - Path to the asset file
+   * @param propertyName - Property name to update (from column definition)
+   * @param newValue - New value for the cell
+   * @returns Edit result
+   */
+  async handleCellEdit(
+    assetPath: string,
+    propertyName: string,
+    newValue: CellValue
+  ): Promise<CellEditResult> {
+    try {
+      const file = this.vaultAdapter.getAbstractFileByPath(assetPath);
+      if (!file || !("basename" in file)) {
+        return {
+          success: false,
+          error: `File not found: ${assetPath}`,
+        };
+      }
+
+      const vaultFile = file as IFile;
+
+      // Format the value for YAML frontmatter
+      const formattedValue = this.formatValueForFrontmatter(newValue);
+
+      // Update frontmatter
+      await this.vaultAdapter.updateFrontmatter(vaultFile, (current) => {
+        return {
+          ...current,
+          [propertyName]: formattedValue,
+        };
+      });
+
+      // Update the triple store
+      const tfile = this.app.vault.getAbstractFileByPath(assetPath);
+      if (tfile && tfile instanceof TFile) {
+        await this.sparqlService.updateFile(tfile);
+      }
+
+      this.logger.debug(`Cell updated: ${assetPath}.${propertyName} = ${String(formattedValue)}`);
+
+      return { success: true };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to update cell: ${errorMessage}`);
+      return {
+        success: false,
+        error: `Cell update failed: ${errorMessage}`,
+      };
+    }
+  }
+
+  /**
+   * Handle sort change with re-query.
+   *
+   * Re-executes the query with a new sort configuration.
+   *
+   * @param layout - The layout definition
+   * @param sort - New sort configuration
+   * @returns Updated rows
+   */
+  async handleSortChange(
+    layout: Layout,
+    sort: LayoutSort
+  ): Promise<LayoutRenderResult> {
+    try {
+      // Ensure initialized
+      if (!this.isInitialized) {
+        await this.initialize();
+      }
+
+      // Create a modified layout with the new sort
+      const sortedLayout: Layout = {
+        ...layout,
+        defaultSort: sort,
+      };
+
+      // Build and execute new query
+      const queryResult = this.queryBuilder.build(sortedLayout);
+      if (!queryResult.success || !queryResult.query) {
+        return {
+          success: false,
+          layout,
+          error: queryResult.error || "Failed to build sorted query",
+        };
+      }
+
+      const solutions = await this.sparqlService.query(queryResult.query);
+
+      const columns = this.getLayoutColumns(layout);
+      const rows = this.transformToTableRows(
+        solutions,
+        columns,
+        queryResult.variables || []
+      );
+
+      return {
+        success: true,
+        layout: sortedLayout,
+        rows,
+        query: queryResult.query,
+        variables: queryResult.variables,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to handle sort change: ${errorMessage}`);
+      return {
+        success: false,
+        error: `Sort change failed: ${errorMessage}`,
+      };
+    }
+  }
+
+  /**
+   * Refresh layout data.
+   *
+   * Re-indexes the vault and re-renders the layout.
+   *
+   * @param layoutFile - The layout file to refresh
+   * @returns Updated render result
+   */
+  async refreshLayout(layoutFile: IFile): Promise<LayoutRenderResult> {
+    // Invalidate caches
+    this.parser.invalidateCache(layoutFile.path);
+    this.layoutCache.delete(layoutFile.path);
+
+    // Refresh the SPARQL index
+    await this.sparqlService.refresh();
+
+    // Re-render
+    return this.renderLayout(layoutFile, { useCache: false });
+  }
+
+  /**
+   * Clear all caches.
+   */
+  clearCache(): void {
+    this.parser.clearCache();
+    this.layoutCache.clear();
+    this.logger.debug("Layout caches cleared");
+  }
+
+  /**
+   * Dispose of resources.
+   */
+  async dispose(): Promise<void> {
+    await this.sparqlService.dispose();
+    this.clearCache();
+    this.isInitialized = false;
+    this.logger.info("LayoutService disposed");
+  }
+
+  // ============================================
+  // Private Helper Methods
+  // ============================================
+
+  /**
+   * Get columns from a layout (handles different layout types).
+   */
+  private getLayoutColumns(layout: Layout): LayoutColumn[] {
+    if (isTableLayout(layout)) {
+      return layout.columns || [];
+    }
+    if (isKanbanLayout(layout)) {
+      return layout.columns || [];
+    }
+    return [];
+  }
+
+  /**
+   * Transform SPARQL solutions to TableRow format.
+   */
+  private transformToTableRows(
+    solutions: SolutionMapping[],
+    columns: LayoutColumn[],
+    _variables: string[]
+  ): TableRow[] {
+    const rows: TableRow[] = [];
+
+    for (const solution of solutions) {
+      // Get asset URI from first variable (?asset)
+      const assetBinding = solution.get("asset");
+      if (!assetBinding) {
+        continue;
+      }
+
+      const assetUri = this.extractValue(assetBinding);
+      const assetPath = this.uriToPath(assetUri);
+      const assetId = this.extractUidFromPath(assetPath) || assetPath;
+
+      // Build values map from column bindings
+      const values: Record<string, CellValue> = {};
+
+      columns.forEach((column, index) => {
+        const variableName = `col${index}`;
+        const binding = solution.get(variableName);
+        values[column.uid] = binding ? this.convertRdfToCellValue(binding, column) : null;
+      });
+
+      rows.push({
+        id: assetId,
+        path: assetPath,
+        metadata: solution.toJSON(),
+        values,
+      });
+    }
+
+    return rows;
+  }
+
+  /**
+   * Extract string value from RDF term.
+   */
+  private extractValue(term: unknown): string {
+    if (term instanceof Literal) {
+      return term.value;
+    }
+    if (term instanceof IRI) {
+      return term.value;
+    }
+    if (typeof term === "object" && term !== null) {
+      if ("value" in term) {
+        return String((term as { value: unknown }).value);
+      }
+    }
+    return String(term);
+  }
+
+  /**
+   * Convert RDF term to CellValue based on column type.
+   */
+  private convertRdfToCellValue(term: unknown, column: LayoutColumn): CellValue {
+    const stringValue = this.extractValue(term);
+
+    // Convert based on renderer type
+    switch (column.renderer) {
+      case "number":
+      case "progress":
+      case "duration": {
+        const num = parseFloat(stringValue);
+        return isNaN(num) ? null : num;
+      }
+
+      case "boolean": {
+        const lower = stringValue.toLowerCase();
+        if (lower === "true" || lower === "1" || lower === "yes") {
+          return true;
+        }
+        if (lower === "false" || lower === "0" || lower === "no") {
+          return false;
+        }
+        return null;
+      }
+
+      case "datetime": {
+        // Try to parse as date
+        const date = new Date(stringValue);
+        return isNaN(date.getTime()) ? stringValue : date;
+      }
+
+      case "link": {
+        // Keep as string for link rendering
+        return stringValue;
+      }
+
+      case "tags":
+      case "badge":
+      case "image":
+      case "text":
+      default:
+        return stringValue;
+    }
+  }
+
+  /**
+   * Convert URI to vault file path.
+   */
+  private uriToPath(uri: string): string {
+    // Handle obsidian:// URIs
+    if (uri.startsWith("obsidian://vault/")) {
+      let path = uri.replace("obsidian://vault/", "");
+      // Decode URL encoding
+      path = decodeURIComponent(path);
+      return path;
+    }
+
+    // Handle file:// URIs
+    if (uri.startsWith("file://")) {
+      return uri.replace("file://", "");
+    }
+
+    // Return as-is if no known prefix
+    return uri;
+  }
+
+  /**
+   * Extract UID from a file path (assumes UUID is in filename).
+   */
+  private extractUidFromPath(path: string): string | null {
+    // Match UUID pattern in path
+    const uuidMatch = path.match(
+      /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i
+    );
+    return uuidMatch ? uuidMatch[1] : null;
+  }
+
+  /**
+   * Format a cell value for YAML frontmatter.
+   */
+  private formatValueForFrontmatter(value: CellValue): unknown {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (typeof value === "number") {
+      return value;
+    }
+
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+
+    // String value - check if it needs quoting
+    const stringValue = String(value);
+
+    // Wikilinks should be quoted
+    if (stringValue.startsWith("[[") && stringValue.endsWith("]]")) {
+      return `"${stringValue}"`;
+    }
+
+    return stringValue;
+  }
+}

--- a/packages/obsidian-plugin/src/application/layout/index.ts
+++ b/packages/obsidian-plugin/src/application/layout/index.ts
@@ -2,7 +2,7 @@
  * Layout Application Module
  *
  * Provides application services for working with Layout definitions,
- * including query generation from Layout models.
+ * including query generation and orchestrated rendering pipeline.
  *
  * @module application/layout
  * @since 1.0.0
@@ -10,21 +10,27 @@
  * @example
  * ```typescript
  * import {
+ *   LayoutService,
  *   LayoutQueryBuilder,
+ *   type LayoutRenderResult,
  *   type QueryBuildResult,
- *   type QueryBuildOptions,
- *   SPARQL_PREFIXES,
  * } from "./application/layout";
  *
- * const builder = new LayoutQueryBuilder();
- * const result = builder.build(tableLayout);
+ * // Using LayoutService (recommended - full orchestration)
+ * const layoutService = new LayoutService(app, vaultAdapter);
+ * await layoutService.initialize();
  *
+ * const result = await layoutService.renderLayout(layoutFile);
  * if (result.success) {
- *   console.log("Generated query:", result.query);
- *   // Variables: ["?asset", "?col0", "?col1", ...]
- *   console.log("Variables:", result.variables);
- * } else {
- *   console.error("Build error:", result.error);
+ *   console.log("Layout:", result.layout);
+ *   console.log("Rows:", result.rows);
+ * }
+ *
+ * // Using LayoutQueryBuilder directly
+ * const builder = new LayoutQueryBuilder();
+ * const queryResult = builder.build(tableLayout);
+ * if (queryResult.success) {
+ *   console.log("Generated query:", queryResult.query);
  * }
  * ```
  */
@@ -35,3 +41,10 @@ export {
   type QueryBuildResult,
   type QueryBuildOptions,
 } from "./LayoutQueryBuilder";
+
+export {
+  LayoutService,
+  type LayoutRenderResult,
+  type LayoutRenderOptions,
+  type CellEditResult,
+} from "./LayoutService";

--- a/packages/obsidian-plugin/tests/unit/application/layout/LayoutService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/layout/LayoutService.test.ts
@@ -1,0 +1,617 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import type { IVaultAdapter, IFile, IFolder, IFrontmatter, ILogger, INotificationService } from "exocortex";
+import { SolutionMapping, Literal, IRI } from "exocortex";
+import type { TableLayout, LayoutSort, LayoutColumn } from "../../../../src/domain/layout";
+import { LayoutType } from "../../../../src/domain/layout";
+
+// Create stable mock references
+const mockSparqlInitialize = jest.fn();
+const mockSparqlQuery = jest.fn();
+const mockSparqlRefresh = jest.fn();
+const mockSparqlUpdateFile = jest.fn();
+const mockSparqlDispose = jest.fn();
+
+const mockParserParseFromFile = jest.fn();
+const mockParserParseFromWikiLink = jest.fn();
+const mockParserClearCache = jest.fn();
+const mockParserInvalidateCache = jest.fn();
+
+const mockLoggerDebug = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockLoggerWarn = jest.fn();
+const mockLoggerError = jest.fn();
+
+// Mock modules - functions are referenced by stable variables
+jest.mock("../../../../src/application/services/SPARQLQueryService", () => {
+  return {
+    SPARQLQueryService: function() {
+      return {
+        initialize: mockSparqlInitialize,
+        query: mockSparqlQuery,
+        refresh: mockSparqlRefresh,
+        updateFile: mockSparqlUpdateFile,
+        dispose: mockSparqlDispose,
+        getTripleStore: jest.fn(),
+      };
+    }
+  };
+});
+
+jest.mock("../../../../src/infrastructure/layout/LayoutParser", () => {
+  return {
+    LayoutParser: function() {
+      return {
+        parseFromFile: mockParserParseFromFile,
+        parseFromWikiLink: mockParserParseFromWikiLink,
+        clearCache: mockParserClearCache,
+        invalidateCache: mockParserInvalidateCache,
+      };
+    }
+  };
+});
+
+jest.mock("@plugin/adapters/logging/LoggerFactory", () => {
+  return {
+    LoggerFactory: {
+      create: () => ({
+        debug: mockLoggerDebug,
+        info: mockLoggerInfo,
+        warn: mockLoggerWarn,
+        error: mockLoggerError,
+      })
+    }
+  };
+});
+
+// Import after mocks
+import { LayoutService } from "../../../../src/application/layout";
+
+// Mock Obsidian App
+const mockApp = {
+  vault: {
+    getAbstractFileByPath: jest.fn(),
+  },
+} as unknown as import("obsidian").App;
+
+// Mock file factory
+function createMockFile(
+  path: string,
+  basename: string = path.split("/").pop() || path
+): IFile {
+  return {
+    path,
+    basename: basename.replace(".md", ""),
+    name: basename,
+    parent: { path: path.split("/").slice(0, -1).join("/"), name: "parent" } as IFolder,
+  };
+}
+
+// Mock vault adapter factory
+function createMockVaultAdapter(
+  files: Map<string, IFrontmatter | null> = new Map()
+): jest.Mocked<IVaultAdapter> {
+  return {
+    read: jest.fn<IVaultAdapter["read"]>(),
+    exists: jest.fn<IVaultAdapter["exists"]>(),
+    getAllFiles: jest.fn<IVaultAdapter["getAllFiles"]>(),
+    getAbstractFileByPath: jest.fn<IVaultAdapter["getAbstractFileByPath"]>().mockImplementation((path: string) => {
+      if (files.has(path)) {
+        return createMockFile(path);
+      }
+      return null;
+    }),
+    create: jest.fn<IVaultAdapter["create"]>(),
+    modify: jest.fn<IVaultAdapter["modify"]>(),
+    delete: jest.fn<IVaultAdapter["delete"]>(),
+    process: jest.fn<IVaultAdapter["process"]>(),
+    rename: jest.fn<IVaultAdapter["rename"]>(),
+    updateLinks: jest.fn<IVaultAdapter["updateLinks"]>(),
+    createFolder: jest.fn<IVaultAdapter["createFolder"]>(),
+    getDefaultNewFileParent: jest.fn<IVaultAdapter["getDefaultNewFileParent"]>(),
+    getFrontmatter: jest.fn<IVaultAdapter["getFrontmatter"]>().mockImplementation((file: IFile) => {
+      return files.get(file.path) || null;
+    }),
+    updateFrontmatter: jest.fn<IVaultAdapter["updateFrontmatter"]>(),
+    getFirstLinkpathDest: jest.fn<IVaultAdapter["getFirstLinkpathDest"]>().mockImplementation(
+      (linkpath: string) => {
+        for (const [path] of files) {
+          if (path === linkpath || path === linkpath + ".md") {
+            return createMockFile(path);
+          }
+          const basename = path.split("/").pop()?.replace(".md", "");
+          if (basename === linkpath || basename === linkpath.replace(".md", "")) {
+            return createMockFile(path);
+          }
+        }
+        return null;
+      }
+    ),
+  } as jest.Mocked<IVaultAdapter>;
+}
+
+// Mock logger factory
+function createMockLogger(): jest.Mocked<ILogger> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+// Mock notifier factory
+function createMockNotifier(): jest.Mocked<INotificationService> {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+    confirm: jest.fn<() => Promise<boolean>>().mockResolvedValue(false),
+  };
+}
+
+// Default layout for mocks
+const defaultLayout: TableLayout = {
+  uid: "layout-001",
+  label: "Test Table",
+  type: LayoutType.Table,
+  targetClass: "[[ems__Task]]",
+  columns: [],
+};
+
+describe("LayoutService", () => {
+  let service: LayoutService;
+  let mockVaultAdapter: jest.Mocked<IVaultAdapter>;
+  let mockLogger: jest.Mocked<ILogger>;
+  let mockNotifier: jest.Mocked<INotificationService>;
+
+  beforeEach(() => {
+    // Clear call history
+    mockSparqlInitialize.mockClear();
+    mockSparqlQuery.mockClear();
+    mockSparqlRefresh.mockClear();
+    mockSparqlUpdateFile.mockClear();
+    mockSparqlDispose.mockClear();
+    mockParserParseFromFile.mockClear();
+    mockParserParseFromWikiLink.mockClear();
+    mockParserClearCache.mockClear();
+    mockParserInvalidateCache.mockClear();
+    mockLoggerDebug.mockClear();
+    mockLoggerInfo.mockClear();
+    mockLoggerWarn.mockClear();
+    mockLoggerError.mockClear();
+
+    // Reset mock implementations to defaults
+    mockSparqlInitialize.mockResolvedValue(undefined);
+    mockSparqlQuery.mockResolvedValue([]);
+    mockSparqlRefresh.mockResolvedValue(undefined);
+    mockSparqlUpdateFile.mockResolvedValue(undefined);
+    mockSparqlDispose.mockResolvedValue(undefined);
+
+    mockParserParseFromFile.mockResolvedValue({
+      success: true,
+      layout: defaultLayout,
+    });
+    mockParserParseFromWikiLink.mockResolvedValue(defaultLayout);
+
+    mockVaultAdapter = createMockVaultAdapter();
+    mockLogger = createMockLogger();
+    mockNotifier = createMockNotifier();
+    service = new LayoutService(mockApp, mockVaultAdapter, mockLogger, mockNotifier);
+  });
+
+  describe("constructor", () => {
+    it("should create a LayoutService instance", () => {
+      expect(service).toBeInstanceOf(LayoutService);
+    });
+
+    it("should create with default logger when not provided", () => {
+      const serviceWithoutLogger = new LayoutService(mockApp, mockVaultAdapter);
+      expect(serviceWithoutLogger).toBeInstanceOf(LayoutService);
+    });
+  });
+
+  describe("initialize", () => {
+    it("should initialize the service", async () => {
+      await service.initialize();
+      expect(mockSparqlInitialize).toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith("LayoutService initialized");
+    });
+
+    it("should be idempotent", async () => {
+      await service.initialize();
+      await service.initialize();
+      // Should only initialize SPARQL service once
+      expect(mockSparqlInitialize).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("renderLayout", () => {
+    const layoutFile = createMockFile("layouts/TaskTable.md");
+
+    it("should successfully render a layout", async () => {
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(true);
+      expect(result.layout).toBeDefined();
+      expect(result.rows).toBeDefined();
+      expect(result.query).toBeDefined();
+    });
+
+    it("should return cached result on subsequent calls", async () => {
+      const result1 = await service.renderLayout(layoutFile);
+      const result2 = await service.renderLayout(layoutFile);
+
+      expect(result1.success).toBe(true);
+      expect(result2.success).toBe(true);
+      // Parser should only be called once due to caching
+      expect(mockParserParseFromFile).toHaveBeenCalledTimes(1);
+    });
+
+    it("should bypass cache when useCache is false", async () => {
+      await service.renderLayout(layoutFile);
+      await service.renderLayout(layoutFile, { useCache: false });
+
+      // Parser should be called twice since cache was bypassed
+      expect(mockParserParseFromFile).toHaveBeenCalledTimes(2);
+    });
+
+    it("should return error for invalid layout", async () => {
+      mockParserParseFromFile.mockResolvedValue({
+        success: false,
+        error: "Invalid layout file",
+      });
+
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Invalid layout file");
+    });
+
+    it("should transform SPARQL results to table rows", async () => {
+      // Setup layout with columns
+      const layoutWithColumns: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Label", property: "[[exo__Asset_label]]" },
+          { uid: "col-002", label: "Status", property: "[[ems__Effort_status]]" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithColumns,
+      });
+
+      // Setup SPARQL results
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/03%20Knowledge/task-001.md"));
+      mapping.set("col0", new Literal("Task 1"));
+      mapping.set("col1", new Literal("Done"));
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(true);
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows![0].path).toBe("03 Knowledge/task-001.md");
+      expect(result.rows![0].values["col-001"]).toBe("Task 1");
+      expect(result.rows![0].values["col-002"]).toBe("Done");
+    });
+
+    it("should handle missing asset binding in SPARQL results", async () => {
+      // Result without asset binding should be skipped
+      const mapping = new SolutionMapping();
+      mapping.set("col0", new Literal("Value"));
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(true);
+      expect(result.rows).toHaveLength(0);
+    });
+
+    it("should convert number renderer values to numbers", async () => {
+      const layoutWithNumber: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Count", property: "[[count]]", renderer: "number" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithNumber,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/test.md"));
+      mapping.set("col0", new Literal("42"));
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(true);
+      expect(result.rows![0].values["col-001"]).toBe(42);
+    });
+
+    it("should convert boolean renderer values to booleans", async () => {
+      const layoutWithBoolean: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Active", property: "[[active]]", renderer: "boolean" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithBoolean,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/test.md"));
+      mapping.set("col0", new Literal("true"));
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(true);
+      expect(result.rows![0].values["col-001"]).toBe(true);
+    });
+
+    it("should convert datetime renderer values to Date objects", async () => {
+      const layoutWithDatetime: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Created", property: "[[created]]", renderer: "datetime" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithDatetime,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/test.md"));
+      mapping.set("col0", new Literal("2024-01-15T10:30:00.000Z"));
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(true);
+      expect(result.rows![0].values["col-001"]).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("renderLayoutFromWikiLink", () => {
+    it("should render layout from wikilink", async () => {
+      const result = await service.renderLayoutFromWikiLink("[[TaskTable]]");
+
+      expect(result.success).toBe(true);
+      expect(result.layout).toBeDefined();
+    });
+
+    it("should return error for unresolved wikilink", async () => {
+      mockParserParseFromWikiLink.mockResolvedValue(null);
+
+      const result = await service.renderLayoutFromWikiLink("[[NonExistent]]");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to resolve layout from wikilink");
+    });
+  });
+
+  describe("handleCellEdit", () => {
+    it("should update frontmatter for valid file", async () => {
+      const files = new Map<string, IFrontmatter | null>([
+        ["tasks/task-001.md", { exo__Asset_uid: "001", exo__Asset_label: "Old Label" }],
+      ]);
+      mockVaultAdapter = createMockVaultAdapter(files);
+      service = new LayoutService(mockApp, mockVaultAdapter, mockLogger, mockNotifier);
+
+      const result = await service.handleCellEdit("tasks/task-001.md", "exo__Asset_label", "New Label");
+
+      expect(result.success).toBe(true);
+      expect(mockVaultAdapter.updateFrontmatter).toHaveBeenCalled();
+    });
+
+    it("should return error for non-existent file", async () => {
+      mockVaultAdapter.getAbstractFileByPath.mockReturnValue(null);
+
+      const result = await service.handleCellEdit("nonexistent.md", "property", "value");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("File not found");
+    });
+
+    it("should format boolean values correctly", async () => {
+      const files = new Map<string, IFrontmatter | null>([
+        ["tasks/task-001.md", { exo__Asset_uid: "001" }],
+      ]);
+      mockVaultAdapter = createMockVaultAdapter(files);
+      service = new LayoutService(mockApp, mockVaultAdapter, mockLogger, mockNotifier);
+
+      await service.handleCellEdit("tasks/task-001.md", "active", true);
+
+      expect(mockVaultAdapter.updateFrontmatter).toHaveBeenCalled();
+    });
+
+    it("should format Date values as ISO strings", async () => {
+      const files = new Map<string, IFrontmatter | null>([
+        ["tasks/task-001.md", { exo__Asset_uid: "001" }],
+      ]);
+      mockVaultAdapter = createMockVaultAdapter(files);
+      service = new LayoutService(mockApp, mockVaultAdapter, mockLogger, mockNotifier);
+
+      const testDate = new Date("2024-01-15T10:30:00.000Z");
+      await service.handleCellEdit("tasks/task-001.md", "created", testDate);
+
+      expect(mockVaultAdapter.updateFrontmatter).toHaveBeenCalled();
+    });
+  });
+
+  describe("handleSortChange", () => {
+    it("should re-render with new sort", async () => {
+      const sort: LayoutSort = {
+        property: "[[exo__Asset_label]]",
+        direction: "asc",
+      };
+
+      const result = await service.handleSortChange(defaultLayout, sort);
+
+      expect(result.success).toBe(true);
+      expect(result.layout?.defaultSort).toEqual(sort);
+    });
+
+    it("should handle query builder failure", async () => {
+      // Mock query builder to return failure by returning a layout without query
+      const { LayoutQueryBuilder } = await import("../../../../src/application/layout/LayoutQueryBuilder");
+      const originalBuild = LayoutQueryBuilder.prototype.build;
+      LayoutQueryBuilder.prototype.build = jest.fn().mockReturnValue({
+        success: false,
+        error: "Query build failed",
+      });
+
+      const sort: LayoutSort = {
+        property: "[[exo__Asset_label]]",
+        direction: "desc",
+      };
+
+      const result = await service.handleSortChange(defaultLayout, sort);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Query build failed");
+
+      // Restore original
+      LayoutQueryBuilder.prototype.build = originalBuild;
+    });
+  });
+
+  describe("refreshLayout", () => {
+    const layoutFile = createMockFile("layouts/TaskTable.md");
+
+    it("should invalidate cache and re-render", async () => {
+      // First render to populate cache
+      await service.renderLayout(layoutFile);
+      // Refresh
+      await service.refreshLayout(layoutFile);
+
+      expect(mockParserInvalidateCache).toHaveBeenCalledWith(layoutFile.path);
+      expect(mockSparqlRefresh).toHaveBeenCalled();
+      // Parser should be called twice (initial + refresh)
+      expect(mockParserParseFromFile).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should clear parser cache and layout cache", () => {
+      service.clearCache();
+
+      expect(mockParserClearCache).toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith("Layout caches cleared");
+    });
+  });
+
+  describe("dispose", () => {
+    it("should dispose SPARQL service and clear caches", async () => {
+      await service.dispose();
+
+      expect(mockSparqlDispose).toHaveBeenCalled();
+      expect(mockParserClearCache).toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith("LayoutService disposed");
+    });
+  });
+
+  describe("URI handling", () => {
+    it("should handle obsidian:// URIs", async () => {
+      const layoutWithColumns: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Label", property: "[[exo__Asset_label]]" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithColumns,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/03%20Knowledge%2Fkitelev%2Ftask.md"));
+      mapping.set("col0", new Literal("Test"));
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const layoutFile = createMockFile("layouts/UriTest.md");
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(true);
+      expect(result.rows![0].path).toBe("03 Knowledge/kitelev/task.md");
+    });
+
+    it("should handle file:// URIs", async () => {
+      const layoutWithColumns: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Label", property: "[[exo__Asset_label]]" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithColumns,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("file:///path/to/file.md"));
+      mapping.set("col0", new Literal("Test"));
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const layoutFile = createMockFile("layouts/UriTest2.md");
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(true);
+      expect(result.rows![0].path).toBe("/path/to/file.md");
+    });
+
+    it("should extract UUID from path", async () => {
+      const layoutWithColumns: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Label", property: "[[exo__Asset_label]]" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithColumns,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/03%20Knowledge/12345678-1234-1234-1234-123456789abc.md"));
+      mapping.set("col0", new Literal("Test"));
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const layoutFile = createMockFile("layouts/UriTest3.md");
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(true);
+      expect(result.rows![0].id).toBe("12345678-1234-1234-1234-123456789abc");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle parser exceptions", async () => {
+      mockParserParseFromFile.mockRejectedValue(new Error("Parse error"));
+
+      const layoutFile = createMockFile("layouts/ErrorTest.md");
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Parse error");
+    });
+
+    it("should handle SPARQL query exceptions", async () => {
+      mockSparqlQuery.mockRejectedValue(new Error("Query timeout"));
+
+      const layoutFile = createMockFile("layouts/ErrorTest2.md");
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Query timeout");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Issue #968**: LayoutService as the main orchestrator for layout rendering, coordinating the complete pipeline: Parser → QueryBuilder → SPARQL → TableRow transformation.

## Changes

### New Features
- **`LayoutService.ts`** - Main orchestrator coordinating the layout rendering pipeline:
  - `renderLayout()` - Complete pipeline from layout file to `TableRow[]`
  - `renderLayoutFromWikiLink()` - Render from wikilink reference
  - `handleCellEdit()` - Update frontmatter and triple store on cell changes
  - `handleSortChange()` - Re-query with new sort configuration  
  - `refreshLayout()` - Re-index and re-render layout
  - Layout caching with invalidation support

### Test Coverage
- **29 unit tests** covering all public methods
- **83.23% line coverage** (exceeds 80% requirement)
- Tests cover: initialization, rendering, caching, cell editing, sorting, error handling

### Architecture
The service follows the established orchestration pattern:
1. Parse layout definition (LayoutParser)
2. Build SPARQL query (LayoutQueryBuilder)
3. Execute query against triple store (SPARQLQueryService)
4. Transform results to TableRow format for rendering
5. Handle cell edits via frontmatter updates
6. Handle sort changes with re-query

## Test Plan

- [x] All 29 LayoutService unit tests pass
- [x] All 3,721 obsidian-plugin tests pass (183 test suites)
- [x] TypeScript compilation clean (`npx tsc --noEmit`)
- [x] Coverage above 80% threshold

Closes #968