### PR TITLE
feat: KanbanLayoutRenderer Component

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/kanban/KanbanCard.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/kanban/KanbanCard.tsx
@@ -1,0 +1,155 @@
+/**
+ * KanbanCard Component
+ *
+ * Renders a single card in the Kanban board.
+ * Supports drag-and-drop and displays card content based on columns.
+ *
+ * @module presentation/renderers/kanban
+ * @since 1.0.0
+ */
+import React from "react";
+
+import type { KanbanCardProps } from "./types";
+import { getCellRenderer } from "../cell-renderers";
+
+/**
+ * KanbanCard - Renders a single Kanban card
+ *
+ * Features:
+ * - Displays card title from values
+ * - Shows additional column data
+ * - Draggable with HTML5 Drag and Drop API
+ * - Link click navigation
+ */
+export const KanbanCard: React.FC<KanbanCardProps> = ({
+  card,
+  columns = [],
+  isDraggable = true,
+  isDragging = false,
+  onLinkClick,
+  onDragStart,
+  onDragEnd,
+}) => {
+  // Get primary display value (first column or asset label)
+  const primaryColumn = columns[0];
+  const primaryValue = primaryColumn
+    ? card.values[primaryColumn.uid]
+    : card.values["label"] || card.id;
+
+  // Additional columns (excluding the first)
+  const additionalColumns = columns.slice(1);
+
+  const handleDragStart = (event: React.DragEvent) => {
+    if (!isDraggable) return;
+
+    // Set drag data
+    event.dataTransfer.setData("text/plain", card.id);
+    event.dataTransfer.setData("application/json", JSON.stringify({
+      cardId: card.id,
+      sourceLaneId: card.laneId,
+    }));
+    event.dataTransfer.effectAllowed = "move";
+
+    onDragStart?.(event);
+  };
+
+  const handleDragEnd = (event: React.DragEvent) => {
+    onDragEnd?.(event);
+  };
+
+  const handleCardClick = (event: React.MouseEvent) => {
+    // Navigate to card file on click (if not dragging)
+    if (!isDragging && onLinkClick && card.path) {
+      onLinkClick(card.path, event);
+    }
+  };
+
+  return (
+    <div
+      className={`exo-kanban-card ${isDragging ? "exo-kanban-card-dragging" : ""} ${isDraggable ? "exo-kanban-card-draggable" : ""}`}
+      draggable={isDraggable}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onClick={handleCardClick}
+      data-card-id={card.id}
+      data-path={card.path}
+    >
+      {/* Card Header - Primary Value */}
+      <div className="exo-kanban-card-header">
+        {primaryColumn ? (
+          <CardCellRenderer
+            value={primaryValue}
+            column={primaryColumn}
+            assetPath={card.path}
+            onLinkClick={onLinkClick}
+          />
+        ) : (
+          <span className="exo-kanban-card-title">{String(primaryValue)}</span>
+        )}
+      </div>
+
+      {/* Card Body - Additional Columns */}
+      {additionalColumns.length > 0 && (
+        <div className="exo-kanban-card-body">
+          {additionalColumns.map((column) => {
+            const value = card.values[column.uid];
+            if (value === null || value === undefined || value === "") {
+              return null;
+            }
+
+            return (
+              <div
+                key={column.uid}
+                className={`exo-kanban-card-field exo-kanban-card-field-${column.renderer || "text"}`}
+              >
+                {column.header && (
+                  <span className="exo-kanban-card-field-label">
+                    {column.header}:
+                  </span>
+                )}
+                <CardCellRenderer
+                  value={value}
+                  column={column}
+                  assetPath={card.path}
+                  onLinkClick={onLinkClick}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * CardCellRenderer - Renders a cell value within a card
+ */
+interface CardCellRendererProps {
+  value: unknown;
+  column: { uid: string; renderer?: string; header?: string; property: string };
+  assetPath?: string;
+  onLinkClick?: (path: string, event: React.MouseEvent) => void;
+}
+
+const CardCellRenderer: React.FC<CardCellRendererProps> = ({
+  value,
+  column,
+  assetPath,
+  onLinkClick,
+}) => {
+  const CellRenderer = getCellRenderer(column.renderer as import("../cell-renderers").ColumnRenderer);
+
+  return (
+    <span className="exo-kanban-card-value">
+      <CellRenderer
+        value={value as import("../cell-renderers").CellValue}
+        column={column as import("../../../domain/layout").LayoutColumn}
+        assetPath={assetPath}
+        onLinkClick={onLinkClick}
+      />
+    </span>
+  );
+};
+
+export default KanbanCard;

--- a/packages/obsidian-plugin/src/presentation/renderers/kanban/KanbanLane.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/kanban/KanbanLane.tsx
@@ -1,0 +1,142 @@
+/**
+ * KanbanLane Component
+ *
+ * Renders a single lane (column) in the Kanban board.
+ * Supports collapsing, drag-and-drop target, and card count display.
+ *
+ * @module presentation/renderers/kanban
+ * @since 1.0.0
+ */
+import React from "react";
+
+import type { KanbanLaneProps } from "./types";
+import { KanbanCard } from "./KanbanCard";
+
+/**
+ * KanbanLane - Renders a single Kanban lane
+ *
+ * Features:
+ * - Lane header with title and card count
+ * - Collapsible lane body
+ * - Drag-and-drop target for cards
+ * - Optional max cards display with "show more"
+ */
+export const KanbanLane: React.FC<KanbanLaneProps> = ({
+  lane,
+  cards,
+  columns = [],
+  isDropTarget = true,
+  isDragOver = false,
+  onToggle,
+  onCardLinkClick,
+  options = {},
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onCardDragStart,
+}) => {
+  const {
+    collapsible = true,
+    maxCardsPerLane,
+    showCount = true,
+  } = options;
+
+  // Determine which cards to show
+  const visibleCards = maxCardsPerLane
+    ? cards.slice(0, maxCardsPerLane)
+    : cards;
+  const hiddenCount = maxCardsPerLane
+    ? Math.max(0, cards.length - maxCardsPerLane)
+    : 0;
+
+  const handleHeaderClick = () => {
+    if (collapsible && onToggle) {
+      onToggle(!lane.collapsed);
+    }
+  };
+
+  const handleDragOver = (event: React.DragEvent) => {
+    if (!isDropTarget) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    onDragOver?.(event);
+  };
+
+  const handleDragLeave = (event: React.DragEvent) => {
+    onDragLeave?.(event);
+  };
+
+  const handleDrop = (event: React.DragEvent) => {
+    if (!isDropTarget) return;
+    event.preventDefault();
+    onDrop?.(event);
+  };
+
+  const handleCardDragStart = (cardId: string, event: React.DragEvent) => {
+    onCardDragStart?.(cardId, event);
+  };
+
+  return (
+    <div
+      className={`exo-kanban-lane ${lane.collapsed ? "exo-kanban-lane-collapsed" : ""} ${isDragOver ? "exo-kanban-lane-drag-over" : ""}`}
+      data-lane-id={lane.id}
+      style={lane.color ? { "--lane-color": lane.color } as React.CSSProperties : undefined}
+    >
+      {/* Lane Header */}
+      <div
+        className={`exo-kanban-lane-header ${collapsible ? "exo-kanban-lane-header-collapsible" : ""}`}
+        onClick={handleHeaderClick}
+      >
+        <div className="exo-kanban-lane-title">
+          {collapsible && (
+            <span className="exo-kanban-lane-chevron">
+              {lane.collapsed ? "▸" : "▾"}
+            </span>
+          )}
+          <span className="exo-kanban-lane-label">{lane.label}</span>
+        </div>
+        {showCount && (
+          <span className="exo-kanban-lane-count">{cards.length}</span>
+        )}
+      </div>
+
+      {/* Lane Body */}
+      {!lane.collapsed && (
+        <div
+          className="exo-kanban-lane-body"
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {visibleCards.length === 0 ? (
+            <div className="exo-kanban-lane-empty">
+              <span className="exo-kanban-lane-empty-text">No items</span>
+            </div>
+          ) : (
+            <>
+              {visibleCards.map((card) => (
+                <KanbanCard
+                  key={card.id}
+                  card={card}
+                  columns={columns}
+                  isDraggable={isDropTarget}
+                  onLinkClick={onCardLinkClick}
+                  onDragStart={(event) => handleCardDragStart(card.id, event)}
+                />
+              ))}
+              {hiddenCount > 0 && (
+                <div className="exo-kanban-lane-more">
+                  <span className="exo-kanban-lane-more-text">
+                    +{hiddenCount} more
+                  </span>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default KanbanLane;

--- a/packages/obsidian-plugin/src/presentation/renderers/kanban/KanbanLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/kanban/KanbanLayoutRenderer.tsx
@@ -1,0 +1,294 @@
+/**
+ * KanbanLayoutRenderer Component
+ *
+ * Renders a KanbanLayout definition as an interactive Kanban board with:
+ * - Lanes grouped by laneProperty values
+ * - Draggable cards with HTML5 Drag and Drop API
+ * - Collapsible lanes
+ * - Card content from column definitions
+ * - CSS styles following Obsidian theme
+ *
+ * @module presentation/renderers/kanban
+ * @since 1.0.0
+ */
+import React, { useState, useMemo, useCallback } from "react";
+
+import type {
+  KanbanLayoutRendererProps,
+  KanbanCard,
+  KanbanLane,
+  KanbanLayoutOptions,
+} from "./types";
+import { extractLabelFromWikilink } from "./types";
+import { KanbanLane as KanbanLaneComponent } from "./KanbanLane";
+
+/**
+ * Default Kanban layout options
+ */
+const defaultOptions: KanbanLayoutOptions = {
+  draggable: true,
+  collapsible: true,
+  showCount: true,
+  laneWidth: "280px",
+  cardHeight: "auto",
+};
+
+/**
+ * KanbanLayoutRenderer - Renders a KanbanLayout as an interactive board
+ *
+ * @example
+ * ```tsx
+ * <KanbanLayoutRenderer
+ *   layout={kanbanLayout}
+ *   cards={cards}
+ *   onCardMove={(cardId, property, newValue) => {
+ *     // Update card's lane property via SPARQL UPDATE
+ *   }}
+ * />
+ * ```
+ */
+export const KanbanLayoutRenderer: React.FC<KanbanLayoutRendererProps> = ({
+  layout,
+  cards,
+  lanes: propLanes,
+  onCardMove,
+  onLinkClick,
+  onCellChange: _onCellChange, // Reserved for future inline editing
+  onLaneToggle,
+  options: propOptions,
+  className,
+}) => {
+  const options = { ...defaultOptions, ...propOptions };
+
+  // Track collapsed lanes
+  const [collapsedLanes, setCollapsedLanes] = useState<Set<string>>(new Set());
+
+  // Track currently dragged card
+  const [dragState, setDragState] = useState<{
+    cardId: string | null;
+    sourceLaneId: string | null;
+  }>({ cardId: null, sourceLaneId: null });
+
+  // Track which lane is being hovered during drag
+  const [dragOverLaneId, setDragOverLaneId] = useState<string | null>(null);
+
+  /**
+   * Derive lanes from data or use explicit lanes
+   */
+  const lanes: KanbanLane[] = useMemo(() => {
+    if (propLanes && propLanes.length > 0) {
+      // Use provided lanes, adding collapsed state
+      return propLanes.map((lane) => ({
+        ...lane,
+        collapsed: collapsedLanes.has(lane.id),
+      }));
+    }
+
+    // Derive lanes from layout.lanes or card data
+    const laneSet = new Set<string>();
+
+    // First add explicit lanes from layout in order
+    if (layout.lanes && layout.lanes.length > 0) {
+      for (const laneDef of layout.lanes) {
+        laneSet.add(laneDef);
+      }
+    }
+
+    // Then add any lanes found in card data that aren't in explicit list
+    for (const card of cards) {
+      if (card.laneId && !laneSet.has(card.laneId)) {
+        laneSet.add(card.laneId);
+      }
+    }
+
+    // Convert to KanbanLane objects
+    const derivedLanes: KanbanLane[] = [];
+    let order = 0;
+
+    for (const laneId of laneSet) {
+      derivedLanes.push({
+        id: laneId,
+        label: extractLabelFromWikilink(laneId),
+        collapsed: collapsedLanes.has(laneId),
+        order: order++,
+      });
+    }
+
+    return derivedLanes;
+  }, [propLanes, layout.lanes, cards, collapsedLanes]);
+
+  /**
+   * Group cards by lane
+   */
+  const cardsByLane = useMemo(() => {
+    const grouped = new Map<string, KanbanCard[]>();
+
+    // Initialize all lanes with empty arrays
+    for (const lane of lanes) {
+      grouped.set(lane.id, []);
+    }
+
+    // Group cards into lanes
+    for (const card of cards) {
+      const laneCards = grouped.get(card.laneId);
+      if (laneCards) {
+        laneCards.push(card);
+      } else {
+        // Card belongs to unknown lane - skip or add to first lane
+        const firstLane = lanes[0];
+        if (firstLane) {
+          const firstLaneCards = grouped.get(firstLane.id) || [];
+          firstLaneCards.push({ ...card, laneId: firstLane.id });
+          grouped.set(firstLane.id, firstLaneCards);
+        }
+      }
+    }
+
+    return grouped;
+  }, [cards, lanes]);
+
+  /**
+   * Handle lane collapse toggle
+   */
+  const handleLaneToggle = useCallback(
+    (laneId: string, collapsed: boolean) => {
+      setCollapsedLanes((prev) => {
+        const next = new Set(prev);
+        if (collapsed) {
+          next.add(laneId);
+        } else {
+          next.delete(laneId);
+        }
+        return next;
+      });
+
+      onLaneToggle?.(laneId, collapsed);
+    },
+    [onLaneToggle]
+  );
+
+  /**
+   * Handle card drag start
+   */
+  const handleCardDragStart = useCallback(
+    (laneId: string, cardId: string, _event: React.DragEvent) => {
+      setDragState({ cardId, sourceLaneId: laneId });
+    },
+    []
+  );
+
+  /**
+   * Handle drag over lane
+   */
+  const handleDragOverLane = useCallback(
+    (laneId: string, _event: React.DragEvent) => {
+      if (dragState.cardId && laneId !== dragOverLaneId) {
+        setDragOverLaneId(laneId);
+      }
+    },
+    [dragState.cardId, dragOverLaneId]
+  );
+
+  /**
+   * Handle drag leave lane
+   */
+  const handleDragLeaveLane = useCallback(
+    (_laneId: string, event: React.DragEvent) => {
+      // Only clear if actually leaving the lane (not entering a child)
+      const relatedTarget = event.relatedTarget as HTMLElement | null;
+      const currentTarget = event.currentTarget as HTMLElement;
+
+      if (!relatedTarget || !currentTarget.contains(relatedTarget)) {
+        setDragOverLaneId(null);
+      }
+    },
+    []
+  );
+
+  /**
+   * Handle card drop on lane
+   */
+  const handleDropOnLane = useCallback(
+    (laneId: string, event: React.DragEvent) => {
+      event.preventDefault();
+      setDragOverLaneId(null);
+
+      const { cardId, sourceLaneId } = dragState;
+
+      // Reset drag state
+      setDragState({ cardId: null, sourceLaneId: null });
+
+      // If dropped on same lane, no-op
+      if (!cardId || laneId === sourceLaneId) {
+        return;
+      }
+
+      // Notify parent of card move
+      if (onCardMove) {
+        onCardMove(cardId, layout.laneProperty, laneId);
+      }
+    },
+    [dragState, layout.laneProperty, onCardMove]
+  );
+
+  /**
+   * Handle drag end (cleanup if dropped outside valid target)
+   */
+  const handleDragEnd = useCallback(() => {
+    setDragState({ cardId: null, sourceLaneId: null });
+    setDragOverLaneId(null);
+  }, []);
+
+  // Empty state
+  if (lanes.length === 0) {
+    return (
+      <div className={`exo-kanban-board exo-kanban-board-empty ${className || ""}`}>
+        <div className="exo-kanban-empty-message">
+          No lanes defined. Configure lanes in your KanbanLayout or add items with status values.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`exo-kanban-board ${className || ""}`}
+      style={{
+        "--lane-width": options.laneWidth,
+        "--card-height": options.cardHeight,
+      } as React.CSSProperties}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="exo-kanban-board-header">
+        <h3 className="exo-kanban-board-title">{layout.label}</h3>
+        <span className="exo-kanban-board-count">
+          {cards.length} item{cards.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div className="exo-kanban-lanes">
+        {lanes.map((lane) => (
+          <KanbanLaneComponent
+            key={lane.id}
+            lane={lane}
+            cards={cardsByLane.get(lane.id) || []}
+            columns={layout.columns}
+            isDropTarget={options.draggable}
+            isDragOver={dragOverLaneId === lane.id}
+            onToggle={(collapsed) => handleLaneToggle(lane.id, collapsed)}
+            onCardLinkClick={onLinkClick}
+            options={options}
+            onDragOver={(event) => handleDragOverLane(lane.id, event)}
+            onDragLeave={(event) => handleDragLeaveLane(lane.id, event)}
+            onDrop={(event) => handleDropOnLane(lane.id, event)}
+            onCardDragStart={(cardId, event) =>
+              handleCardDragStart(lane.id, cardId, event)
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default KanbanLayoutRenderer;

--- a/packages/obsidian-plugin/src/presentation/renderers/kanban/index.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/kanban/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Kanban Components
+ *
+ * This module exports all Kanban board components and types
+ * for use with KanbanLayout.
+ *
+ * @packageDocumentation
+ */
+
+// Main renderer
+export { KanbanLayoutRenderer } from "./KanbanLayoutRenderer";
+export { default as KanbanLayoutRendererDefault } from "./KanbanLayoutRenderer";
+
+// Sub-components
+export { KanbanLane } from "./KanbanLane";
+export { default as KanbanLaneDefault } from "./KanbanLane";
+export { KanbanCard } from "./KanbanCard";
+export { default as KanbanCardDefault } from "./KanbanCard";
+
+// Types
+export type {
+  KanbanLayoutRendererProps,
+  KanbanLayoutOptions,
+  KanbanLaneProps,
+  KanbanCardProps,
+  KanbanLane as KanbanLaneType,
+  KanbanCard as KanbanCardType,
+  KanbanDragResult,
+} from "./types";
+
+// Utilities
+export {
+  extractLabelFromWikilink,
+  extractPathFromWikilink,
+} from "./types";

--- a/packages/obsidian-plugin/src/presentation/renderers/kanban/types.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/kanban/types.ts
@@ -1,0 +1,257 @@
+/**
+ * Kanban Types
+ *
+ * Defines the types and interfaces for Kanban board components.
+ *
+ * @module presentation/renderers/kanban
+ * @since 1.0.0
+ */
+
+import type { LayoutColumn } from "../../../domain/layout";
+import type { CellValue, TableRow } from "../cell-renderers";
+
+/**
+ * Lane configuration for Kanban board
+ */
+export interface KanbanLane {
+  /** Lane ID (from laneProperty value or explicit lane reference) */
+  id: string;
+
+  /** Display label for the lane */
+  label: string;
+
+  /** Whether the lane is collapsed */
+  collapsed?: boolean;
+
+  /** Lane order index */
+  order?: number;
+
+  /** Optional color for the lane */
+  color?: string;
+}
+
+/**
+ * Card data for Kanban board (extends TableRow)
+ */
+export interface KanbanCard extends TableRow {
+  /** The lane this card belongs to */
+  laneId: string;
+
+  /** Card order within the lane */
+  order?: number;
+}
+
+/**
+ * Drag result from drag-and-drop operation
+ */
+export interface KanbanDragResult {
+  /** Card ID being dragged */
+  cardId: string;
+
+  /** Source lane ID */
+  sourceLaneId: string;
+
+  /** Destination lane ID */
+  destinationLaneId: string;
+
+  /** Index within source lane (before removal) */
+  sourceIndex: number;
+
+  /** Index within destination lane (after drop) */
+  destinationIndex: number;
+}
+
+/**
+ * Props for KanbanLayoutRenderer
+ */
+export interface KanbanLayoutRendererProps {
+  /**
+   * The KanbanLayout definition
+   */
+  layout: {
+    uid: string;
+    label: string;
+    laneProperty: string;
+    lanes?: string[];
+    columns?: LayoutColumn[];
+  };
+
+  /**
+   * Card data to display
+   */
+  cards: KanbanCard[];
+
+  /**
+   * Lane definitions (if not derived from data)
+   */
+  lanes?: KanbanLane[];
+
+  /**
+   * Handler for card move operations (drag-and-drop)
+   * @param cardId - The card being moved
+   * @param property - The property to update (laneProperty)
+   * @param newValue - The new lane value
+   */
+  onCardMove?: (cardId: string, property: string, newValue: string) => void;
+
+  /**
+   * Handler for link clicks (navigation)
+   */
+  onLinkClick?: (path: string, event: React.MouseEvent) => void;
+
+  /**
+   * Handler for card cell value changes
+   */
+  onCellChange?: (cardId: string, columnUid: string, newValue: CellValue) => void;
+
+  /**
+   * Handler for lane collapse toggle
+   */
+  onLaneToggle?: (laneId: string, collapsed: boolean) => void;
+
+  /**
+   * Layout options
+   */
+  options?: KanbanLayoutOptions;
+
+  /**
+   * Custom CSS class name
+   */
+  className?: string;
+}
+
+/**
+ * Options for Kanban board rendering
+ */
+export interface KanbanLayoutOptions {
+  /** Whether drag-and-drop is enabled */
+  draggable?: boolean;
+
+  /** Whether lanes can be collapsed */
+  collapsible?: boolean;
+
+  /** Maximum cards per lane to show (rest are hidden) */
+  maxCardsPerLane?: number;
+
+  /** Show card count in lane header */
+  showCount?: boolean;
+
+  /** Column width (CSS value) */
+  laneWidth?: string;
+
+  /** Card height (CSS value or 'auto') */
+  cardHeight?: string;
+}
+
+/**
+ * Props for KanbanLane component
+ */
+export interface KanbanLaneProps {
+  /** Lane configuration */
+  lane: KanbanLane;
+
+  /** Cards in this lane */
+  cards: KanbanCard[];
+
+  /** Columns to display on cards */
+  columns?: LayoutColumn[];
+
+  /** Whether lane is droppable (drag target) */
+  isDropTarget?: boolean;
+
+  /** Whether lane is currently receiving drag */
+  isDragOver?: boolean;
+
+  /** Handler for lane header click (collapse toggle) */
+  onToggle?: (collapsed: boolean) => void;
+
+  /** Handler for card link click */
+  onCardLinkClick?: (path: string, event: React.MouseEvent) => void;
+
+  /** Options */
+  options?: KanbanLayoutOptions;
+
+  /** Drag event handlers */
+  onDragOver?: (event: React.DragEvent) => void;
+  onDragLeave?: (event: React.DragEvent) => void;
+  onDrop?: (event: React.DragEvent) => void;
+
+  /** Card drag start handler */
+  onCardDragStart?: (cardId: string, event: React.DragEvent) => void;
+}
+
+/**
+ * Props for KanbanCard component
+ */
+export interface KanbanCardProps {
+  /** Card data */
+  card: KanbanCard;
+
+  /** Columns to display */
+  columns?: LayoutColumn[];
+
+  /** Whether card is draggable */
+  isDraggable?: boolean;
+
+  /** Whether card is currently being dragged */
+  isDragging?: boolean;
+
+  /** Handler for card link click */
+  onLinkClick?: (path: string, event: React.MouseEvent) => void;
+
+  /** Drag event handlers */
+  onDragStart?: (event: React.DragEvent) => void;
+  onDragEnd?: (event: React.DragEvent) => void;
+}
+
+/**
+ * Extract label from wikilink reference.
+ * "[[path/to/file|Label]]" -> "Label"
+ * "[[path/to/file]]" -> "file"
+ *
+ * @param wikilink - The wikilink reference
+ * @returns The extracted label
+ */
+export function extractLabelFromWikilink(wikilink: string): string {
+  // Handle [[target|Label]] format
+  const pipedMatch = wikilink.match(/\[\[([^|\]]+)\|([^\]]+)\]\]/);
+  if (pipedMatch) {
+    return pipedMatch[2];
+  }
+
+  // Handle [[target]] format - extract filename
+  const match = wikilink.match(/\[\[([^\]]+)\]\]/);
+  if (match) {
+    const path = match[1];
+    // Get last segment (filename without path)
+    const segments = path.split("/");
+    const filename = segments[segments.length - 1];
+    // Remove .md extension if present
+    return filename.replace(/\.md$/, "");
+  }
+
+  return wikilink;
+}
+
+/**
+ * Extract target path from wikilink reference.
+ * "[[path/to/file|Label]]" -> "path/to/file"
+ *
+ * @param wikilink - The wikilink reference
+ * @returns The target path
+ */
+export function extractPathFromWikilink(wikilink: string): string {
+  // Handle [[target|Label]] format
+  const pipedMatch = wikilink.match(/\[\[([^|\]]+)\|([^\]]+)\]\]/);
+  if (pipedMatch) {
+    return pipedMatch[1];
+  }
+
+  // Handle [[target]] format
+  const match = wikilink.match(/\[\[([^\]]+)\]\]/);
+  if (match) {
+    return match[1];
+  }
+
+  return wikilink;
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -3297,3 +3297,365 @@
     transition: none;
   }
 }
+
+/* ============================================================================
+   Kanban Board Styles
+
+   CSS for KanbanLayoutRenderer, KanbanLane, and KanbanCard components.
+   Follows Obsidian theme variables for consistent appearance.
+   ============================================================================ */
+
+/* Kanban Board Container */
+.exo-kanban-board {
+  --lane-width: 280px;
+  --card-height: auto;
+  --kanban-gap: 16px;
+  --kanban-card-gap: 8px;
+
+  width: 100%;
+  margin: 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--kanban-gap);
+}
+
+.exo-kanban-board-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+}
+
+.exo-kanban-board-title {
+  margin: 0;
+  font-size: 1.1em;
+  font-weight: 600;
+  color: var(--text-normal);
+}
+
+.exo-kanban-board-count {
+  color: var(--text-muted);
+  font-size: 0.9em;
+}
+
+/* Kanban Lanes Container */
+.exo-kanban-lanes {
+  display: flex;
+  gap: var(--kanban-gap);
+  overflow-x: auto;
+  padding-bottom: 8px;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Empty Board State */
+.exo-kanban-board-empty {
+  padding: 24px;
+  text-align: center;
+}
+
+.exo-kanban-empty-message {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ============================================================================
+   Kanban Lane Styles
+   ============================================================================ */
+
+.exo-kanban-lane {
+  flex: 0 0 var(--lane-width);
+  width: var(--lane-width);
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--background-secondary);
+  border-radius: 8px;
+  border: 1px solid var(--background-modifier-border);
+  overflow: hidden;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.exo-kanban-lane-collapsed {
+  min-height: auto;
+}
+
+/* Lane drag over state */
+.exo-kanban-lane-drag-over {
+  border-color: var(--interactive-accent);
+  box-shadow: 0 0 0 2px var(--interactive-accent-hover);
+}
+
+/* Lane Header */
+.exo-kanban-lane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px;
+  background-color: var(--background-secondary-alt);
+  border-bottom: 1px solid var(--background-modifier-border);
+  user-select: none;
+}
+
+.exo-kanban-lane-header-collapsible {
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.exo-kanban-lane-header-collapsible:hover {
+  background-color: var(--background-modifier-hover);
+}
+
+.exo-kanban-lane-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  color: var(--text-normal);
+}
+
+.exo-kanban-lane-chevron {
+  font-size: 0.9em;
+  color: var(--text-muted);
+}
+
+.exo-kanban-lane-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.exo-kanban-lane-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background-color: var(--background-modifier-border);
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+/* Lane Body */
+.exo-kanban-lane-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--kanban-card-gap);
+  padding: 8px;
+  overflow-y: auto;
+  min-height: 100px;
+}
+
+/* Lane Empty State */
+.exo-kanban-lane-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 80px;
+  border: 2px dashed var(--background-modifier-border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 0.9em;
+}
+
+.exo-kanban-lane-empty-text {
+  font-style: italic;
+}
+
+/* Lane "Show More" */
+.exo-kanban-lane-more {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  color: var(--text-muted);
+  font-size: 0.85em;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+}
+
+.exo-kanban-lane-more:hover {
+  background-color: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+/* ============================================================================
+   Kanban Card Styles
+   ============================================================================ */
+
+.exo-kanban-card {
+  background-color: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  cursor: default;
+  transition: box-shadow 0.15s ease, transform 0.15s ease, opacity 0.15s ease;
+}
+
+.exo-kanban-card-draggable {
+  cursor: grab;
+}
+
+.exo-kanban-card-draggable:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.exo-kanban-card-draggable:active {
+  cursor: grabbing;
+}
+
+/* Card dragging state */
+.exo-kanban-card-dragging {
+  opacity: 0.5;
+  transform: scale(1.02);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+/* Card Header (Primary Value) */
+.exo-kanban-card-header {
+  margin-bottom: 6px;
+}
+
+.exo-kanban-card-title {
+  font-weight: 500;
+  color: var(--text-normal);
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.exo-kanban-card-header a {
+  color: var(--text-accent);
+  text-decoration: none;
+}
+
+.exo-kanban-card-header a:hover {
+  text-decoration: underline;
+}
+
+/* Card Body (Additional Fields) */
+.exo-kanban-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 6px;
+  border-top: 1px solid var(--background-modifier-border);
+  font-size: 0.9em;
+}
+
+.exo-kanban-card-field {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  color: var(--text-muted);
+}
+
+.exo-kanban-card-field-label {
+  font-size: 0.85em;
+  color: var(--text-faint);
+  flex-shrink: 0;
+}
+
+.exo-kanban-card-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Card field type-specific styles */
+.exo-kanban-card-field-badge .exo-kanban-card-value {
+  white-space: normal;
+}
+
+.exo-kanban-card-field-tags .exo-kanban-card-value {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.exo-kanban-card-field-progress {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.exo-kanban-card-field-progress .exo-kanban-card-value {
+  margin-top: 2px;
+}
+
+/* ============================================================================
+   Kanban Mobile Responsive Styles
+   ============================================================================ */
+
+@media (max-width: 768px) {
+  .exo-kanban-board {
+    --lane-width: 240px;
+    --kanban-gap: 12px;
+  }
+
+  .exo-kanban-lanes {
+    padding-bottom: 12px;
+  }
+
+  .exo-kanban-lane-header {
+    padding: 10px;
+  }
+
+  .exo-kanban-card {
+    padding: 8px 10px;
+  }
+
+  .exo-kanban-card-body {
+    font-size: 0.85em;
+  }
+}
+
+/* Very small screens - single column layout */
+@media (max-width: 480px) {
+  .exo-kanban-board {
+    --lane-width: calc(100vw - 48px);
+  }
+
+  .exo-kanban-lanes {
+    flex-direction: column;
+    overflow-x: visible;
+  }
+
+  .exo-kanban-lane {
+    flex: none;
+    width: 100%;
+    min-height: auto;
+  }
+
+  .exo-kanban-lane-body {
+    min-height: 60px;
+  }
+}
+
+/* ============================================================================
+   Kanban High Contrast and Accessibility
+   ============================================================================ */
+
+@media (prefers-contrast: high) {
+  .exo-kanban-lane {
+    border-width: 2px;
+  }
+
+  .exo-kanban-card {
+    border-width: 2px;
+  }
+
+  .exo-kanban-lane-drag-over {
+    box-shadow: 0 0 0 3px var(--interactive-accent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .exo-kanban-card,
+  .exo-kanban-lane,
+  .exo-kanban-lane-header-collapsible,
+  .exo-kanban-lane-more {
+    transition: none;
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/kanban/KanbanCard.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/kanban/KanbanCard.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * KanbanCard Unit Tests
+ *
+ * Tests for the KanbanCard component.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { KanbanCard } from "@plugin/presentation/renderers/kanban/KanbanCard";
+import type { KanbanCard as KanbanCardType } from "@plugin/presentation/renderers/kanban/types";
+import type { LayoutColumn } from "@plugin/domain/layout";
+
+describe("KanbanCard", () => {
+  const createColumn = (overrides: Partial<LayoutColumn> = {}): LayoutColumn => ({
+    uid: "col-1",
+    label: "Label",
+    property: "[[exo__Asset_label]]",
+    header: "Name",
+    width: "auto",
+    renderer: "text",
+    editable: false,
+    sortable: true,
+    ...overrides,
+  });
+
+  const createCard = (overrides: Partial<KanbanCardType> = {}): KanbanCardType => ({
+    id: "card-1",
+    path: "/path/to/asset.md",
+    metadata: {},
+    values: { "col-1": "Test Card" },
+    laneId: "[[todo]]",
+    ...overrides,
+  });
+
+  describe("Basic Rendering", () => {
+    it("renders card with primary value", () => {
+      const card = createCard();
+      const columns = [createColumn()];
+
+      render(<KanbanCard card={card} columns={columns} />);
+
+      expect(screen.getByText("Test Card")).toBeInTheDocument();
+    });
+
+    it("renders card with multiple columns", () => {
+      const card = createCard({
+        values: {
+          "col-1": "Task Name",
+          "col-2": "High Priority",
+          "col-3": "Due Tomorrow",
+        },
+      });
+      const columns = [
+        createColumn({ uid: "col-1", header: "Name" }),
+        createColumn({ uid: "col-2", header: "Priority" }),
+        createColumn({ uid: "col-3", header: "Due Date" }),
+      ];
+
+      render(<KanbanCard card={card} columns={columns} />);
+
+      expect(screen.getByText("Task Name")).toBeInTheDocument();
+      expect(screen.getByText("High Priority")).toBeInTheDocument();
+      expect(screen.getByText("Due Tomorrow")).toBeInTheDocument();
+    });
+
+    it("does not render empty field values", () => {
+      const card = createCard({
+        values: {
+          "col-1": "Task Name",
+          "col-2": "", // Empty
+          "col-3": null, // Null
+        },
+      });
+      const columns = [
+        createColumn({ uid: "col-1", header: "Name" }),
+        createColumn({ uid: "col-2", header: "Priority" }),
+        createColumn({ uid: "col-3", header: "Due Date" }),
+      ];
+
+      const { container } = render(<KanbanCard card={card} columns={columns} />);
+
+      // Only the body should contain Name
+      const fieldLabels = container.querySelectorAll(".exo-kanban-card-field-label");
+      // Additional fields should be empty (skipped)
+      expect(fieldLabels.length).toBe(0); // No field labels since empty values are skipped
+    });
+  });
+
+  describe("Draggable Behavior", () => {
+    it("is draggable by default", () => {
+      const card = createCard();
+
+      const { container } = render(<KanbanCard card={card} isDraggable={true} />);
+
+      const cardElement = container.querySelector(".exo-kanban-card");
+      expect(cardElement).toHaveAttribute("draggable", "true");
+      expect(cardElement).toHaveClass("exo-kanban-card-draggable");
+    });
+
+    it("is not draggable when isDraggable is false", () => {
+      const card = createCard();
+
+      const { container } = render(<KanbanCard card={card} isDraggable={false} />);
+
+      const cardElement = container.querySelector(".exo-kanban-card");
+      expect(cardElement).toHaveAttribute("draggable", "false");
+      expect(cardElement).not.toHaveClass("exo-kanban-card-draggable");
+    });
+
+    it("calls onDragStart handler", () => {
+      const onDragStart = jest.fn();
+      const card = createCard();
+
+      const { container } = render(
+        <KanbanCard card={card} onDragStart={onDragStart} />
+      );
+
+      const cardElement = container.querySelector(".exo-kanban-card");
+      fireEvent.dragStart(cardElement!, {
+        dataTransfer: {
+          setData: jest.fn(),
+          effectAllowed: "move",
+        },
+      });
+
+      expect(onDragStart).toHaveBeenCalled();
+    });
+
+    it("calls onDragEnd handler", () => {
+      const onDragEnd = jest.fn();
+      const card = createCard();
+
+      const { container } = render(
+        <KanbanCard card={card} onDragEnd={onDragEnd} />
+      );
+
+      const cardElement = container.querySelector(".exo-kanban-card");
+      fireEvent.dragEnd(cardElement!);
+
+      expect(onDragEnd).toHaveBeenCalled();
+    });
+  });
+
+  describe("Click Navigation", () => {
+    it("calls onLinkClick with card path on click", () => {
+      const onLinkClick = jest.fn();
+      const card = createCard({ path: "/my/file.md" });
+
+      const { container } = render(
+        <KanbanCard card={card} onLinkClick={onLinkClick} />
+      );
+
+      const cardElement = container.querySelector(".exo-kanban-card");
+      fireEvent.click(cardElement!);
+
+      expect(onLinkClick).toHaveBeenCalledWith("/my/file.md", expect.any(Object));
+    });
+
+    it("does not call onLinkClick when dragging", () => {
+      const onLinkClick = jest.fn();
+      const card = createCard();
+
+      const { container } = render(
+        <KanbanCard card={card} onLinkClick={onLinkClick} isDragging={true} />
+      );
+
+      const cardElement = container.querySelector(".exo-kanban-card");
+      fireEvent.click(cardElement!);
+
+      expect(onLinkClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Dragging State", () => {
+    it("applies dragging class when isDragging is true", () => {
+      const card = createCard();
+
+      const { container } = render(<KanbanCard card={card} isDragging={true} />);
+
+      const cardElement = container.querySelector(".exo-kanban-card");
+      expect(cardElement).toHaveClass("exo-kanban-card-dragging");
+    });
+  });
+
+  describe("Data Attributes", () => {
+    it("includes data-card-id attribute", () => {
+      const card = createCard({ id: "unique-card-123" });
+
+      const { container } = render(<KanbanCard card={card} />);
+
+      const cardElement = container.querySelector(".exo-kanban-card");
+      expect(cardElement).toHaveAttribute("data-card-id", "unique-card-123");
+    });
+
+    it("includes data-path attribute", () => {
+      const card = createCard({ path: "/path/to/file.md" });
+
+      const { container } = render(<KanbanCard card={card} />);
+
+      const cardElement = container.querySelector(".exo-kanban-card");
+      expect(cardElement).toHaveAttribute("data-path", "/path/to/file.md");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/kanban/KanbanLane.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/kanban/KanbanLane.test.tsx
@@ -1,0 +1,334 @@
+/**
+ * KanbanLane Unit Tests
+ *
+ * Tests for the KanbanLane component.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { KanbanLane } from "@plugin/presentation/renderers/kanban/KanbanLane";
+import type {
+  KanbanLane as KanbanLaneType,
+  KanbanCard,
+} from "@plugin/presentation/renderers/kanban/types";
+import type { LayoutColumn } from "@plugin/domain/layout";
+
+describe("KanbanLane", () => {
+  const createColumn = (overrides: Partial<LayoutColumn> = {}): LayoutColumn => ({
+    uid: "col-1",
+    label: "Label",
+    property: "[[exo__Asset_label]]",
+    header: "Name",
+    width: "auto",
+    renderer: "text",
+    editable: false,
+    sortable: true,
+    ...overrides,
+  });
+
+  const createLane = (overrides: Partial<KanbanLaneType> = {}): KanbanLaneType => ({
+    id: "lane-1",
+    label: "Test Lane",
+    collapsed: false,
+    ...overrides,
+  });
+
+  const createCard = (overrides: Partial<KanbanCard> = {}): KanbanCard => ({
+    id: "card-1",
+    path: "/path/to/asset.md",
+    metadata: {},
+    values: { "col-1": "Test Card" },
+    laneId: "lane-1",
+    ...overrides,
+  });
+
+  describe("Basic Rendering", () => {
+    it("renders lane with header", () => {
+      const lane = createLane({ label: "To Do" });
+      const cards: KanbanCard[] = [];
+
+      render(<KanbanLane lane={lane} cards={cards} />);
+
+      expect(screen.getByText("To Do")).toBeInTheDocument();
+    });
+
+    it("renders cards in lane", () => {
+      const lane = createLane();
+      const cards = [
+        createCard({ id: "card-1", values: { "col-1": "Task 1" } }),
+        createCard({ id: "card-2", values: { "col-1": "Task 2" } }),
+      ];
+      const columns = [createColumn()];
+
+      render(<KanbanLane lane={lane} cards={cards} columns={columns} />);
+
+      expect(screen.getByText("Task 1")).toBeInTheDocument();
+      expect(screen.getByText("Task 2")).toBeInTheDocument();
+    });
+
+    it("shows card count by default", () => {
+      const lane = createLane();
+      const cards = [
+        createCard({ id: "card-1" }),
+        createCard({ id: "card-2" }),
+        createCard({ id: "card-3" }),
+      ];
+
+      render(<KanbanLane lane={lane} cards={cards} />);
+
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("hides card count when showCount is false", () => {
+      const lane = createLane();
+      const cards = [createCard()];
+
+      const { container } = render(
+        <KanbanLane
+          lane={lane}
+          cards={cards}
+          options={{ showCount: false }}
+        />
+      );
+
+      const countBadge = container.querySelector(".exo-kanban-lane-count");
+      expect(countBadge).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Empty State", () => {
+    it("shows empty placeholder when no cards", () => {
+      const lane = createLane();
+      const cards: KanbanCard[] = [];
+
+      render(<KanbanLane lane={lane} cards={cards} />);
+
+      expect(screen.getByText(/no items/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("Collapse Behavior", () => {
+    it("renders collapsed lane without body", () => {
+      const lane = createLane({ collapsed: true });
+      const cards = [createCard({ values: { "col-1": "Hidden Card" } })];
+      const columns = [createColumn()];
+
+      render(<KanbanLane lane={lane} cards={cards} columns={columns} />);
+
+      expect(screen.queryByText("Hidden Card")).not.toBeInTheDocument();
+    });
+
+    it("calls onToggle when header is clicked", () => {
+      const onToggle = jest.fn();
+      const lane = createLane();
+      const cards: KanbanCard[] = [];
+
+      render(
+        <KanbanLane
+          lane={lane}
+          cards={cards}
+          onToggle={onToggle}
+        />
+      );
+
+      const header = screen.getByText("Test Lane");
+      fireEvent.click(header);
+
+      expect(onToggle).toHaveBeenCalledWith(true); // Toggle to collapsed
+    });
+
+    it("does not call onToggle when collapsible is false", () => {
+      const onToggle = jest.fn();
+      const lane = createLane();
+      const cards: KanbanCard[] = [];
+
+      render(
+        <KanbanLane
+          lane={lane}
+          cards={cards}
+          onToggle={onToggle}
+          options={{ collapsible: false }}
+        />
+      );
+
+      const header = screen.getByText("Test Lane");
+      fireEvent.click(header);
+
+      expect(onToggle).not.toHaveBeenCalled();
+    });
+
+    it("shows chevron for collapsible lanes", () => {
+      const lane = createLane();
+      const cards: KanbanCard[] = [];
+
+      const { container } = render(
+        <KanbanLane lane={lane} cards={cards} />
+      );
+
+      const chevron = container.querySelector(".exo-kanban-lane-chevron");
+      expect(chevron).toBeInTheDocument();
+      expect(chevron).toHaveTextContent("▾"); // Expanded chevron
+    });
+
+    it("shows collapsed chevron when lane is collapsed", () => {
+      const lane = createLane({ collapsed: true });
+      const cards: KanbanCard[] = [];
+
+      const { container } = render(
+        <KanbanLane lane={lane} cards={cards} />
+      );
+
+      const chevron = container.querySelector(".exo-kanban-lane-chevron");
+      expect(chevron).toHaveTextContent("▸"); // Collapsed chevron
+    });
+  });
+
+  describe("Max Cards Per Lane", () => {
+    it("limits visible cards to maxCardsPerLane", () => {
+      const lane = createLane();
+      const cards = Array.from({ length: 5 }, (_, i) =>
+        createCard({
+          id: `card-${i}`,
+          values: { "col-1": `Card ${i}` },
+        })
+      );
+      const columns = [createColumn()];
+
+      render(
+        <KanbanLane
+          lane={lane}
+          cards={cards}
+          columns={columns}
+          options={{ maxCardsPerLane: 3 }}
+        />
+      );
+
+      expect(screen.getByText("Card 0")).toBeInTheDocument();
+      expect(screen.getByText("Card 1")).toBeInTheDocument();
+      expect(screen.getByText("Card 2")).toBeInTheDocument();
+      expect(screen.queryByText("Card 3")).not.toBeInTheDocument();
+      expect(screen.queryByText("Card 4")).not.toBeInTheDocument();
+    });
+
+    it("shows '+N more' when cards are hidden", () => {
+      const lane = createLane();
+      const cards = Array.from({ length: 5 }, (_, i) =>
+        createCard({ id: `card-${i}` })
+      );
+
+      render(
+        <KanbanLane
+          lane={lane}
+          cards={cards}
+          options={{ maxCardsPerLane: 3 }}
+        />
+      );
+
+      expect(screen.getByText("+2 more")).toBeInTheDocument();
+    });
+  });
+
+  describe("Drag and Drop Target", () => {
+    it("applies drag-over class when isDragOver is true", () => {
+      const lane = createLane();
+      const cards: KanbanCard[] = [];
+
+      const { container } = render(
+        <KanbanLane lane={lane} cards={cards} isDragOver={true} />
+      );
+
+      const laneElement = container.querySelector(".exo-kanban-lane");
+      expect(laneElement).toHaveClass("exo-kanban-lane-drag-over");
+    });
+
+    it("calls onDragOver handler", () => {
+      const onDragOver = jest.fn();
+      const lane = createLane();
+      const cards: KanbanCard[] = [];
+
+      const { container } = render(
+        <KanbanLane
+          lane={lane}
+          cards={cards}
+          onDragOver={onDragOver}
+        />
+      );
+
+      const laneBody = container.querySelector(".exo-kanban-lane-body");
+      const dataTransfer = { dropEffect: "" };
+      fireEvent.dragOver(laneBody!, { dataTransfer });
+
+      expect(onDragOver).toHaveBeenCalled();
+    });
+
+    it("calls onDrop handler", () => {
+      const onDrop = jest.fn();
+      const lane = createLane();
+      const cards: KanbanCard[] = [];
+
+      const { container } = render(
+        <KanbanLane
+          lane={lane}
+          cards={cards}
+          onDrop={onDrop}
+        />
+      );
+
+      const laneBody = container.querySelector(".exo-kanban-lane-body");
+      fireEvent.drop(laneBody!, { preventDefault: jest.fn() });
+
+      expect(onDrop).toHaveBeenCalled();
+    });
+
+    it("does not handle drag events when isDropTarget is false", () => {
+      const onDragOver = jest.fn();
+      const onDrop = jest.fn();
+      const lane = createLane();
+      const cards: KanbanCard[] = [];
+
+      const { container } = render(
+        <KanbanLane
+          lane={lane}
+          cards={cards}
+          isDropTarget={false}
+          onDragOver={onDragOver}
+          onDrop={onDrop}
+        />
+      );
+
+      const laneBody = container.querySelector(".exo-kanban-lane-body");
+      const dataTransfer = { dropEffect: "" };
+      fireEvent.dragOver(laneBody!, { dataTransfer });
+      fireEvent.drop(laneBody!);
+
+      expect(onDragOver).not.toHaveBeenCalled();
+      expect(onDrop).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Data Attributes", () => {
+    it("includes data-lane-id attribute", () => {
+      const lane = createLane({ id: "unique-lane-123" });
+      const cards: KanbanCard[] = [];
+
+      const { container } = render(<KanbanLane lane={lane} cards={cards} />);
+
+      const laneElement = container.querySelector(".exo-kanban-lane");
+      expect(laneElement).toHaveAttribute("data-lane-id", "unique-lane-123");
+    });
+  });
+
+  describe("Lane Color", () => {
+    it("applies custom lane color via CSS variable", () => {
+      const lane = createLane({ color: "#ff0000" });
+      const cards: KanbanCard[] = [];
+
+      const { container } = render(<KanbanLane lane={lane} cards={cards} />);
+
+      const laneElement = container.querySelector(".exo-kanban-lane");
+      expect(laneElement).toHaveStyle({ "--lane-color": "#ff0000" });
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/kanban/KanbanLayoutRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/kanban/KanbanLayoutRenderer.test.tsx
@@ -1,0 +1,421 @@
+/**
+ * KanbanLayoutRenderer Unit Tests
+ *
+ * Tests for the KanbanLayoutRenderer component including:
+ * - Basic rendering
+ * - Lane rendering from layout
+ * - Card grouping by lane
+ * - Empty state handling
+ * - Lane collapse functionality
+ * - Drag and drop behavior
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { KanbanLayoutRenderer } from "@plugin/presentation/renderers/kanban/KanbanLayoutRenderer";
+import type {
+  KanbanCard,
+  KanbanLane,
+} from "@plugin/presentation/renderers/kanban/types";
+import type { LayoutColumn } from "@plugin/domain/layout";
+
+describe("KanbanLayoutRenderer", () => {
+  // Test fixtures
+  const createColumn = (overrides: Partial<LayoutColumn> = {}): LayoutColumn => ({
+    uid: "col-1",
+    label: "Test Column",
+    property: "[[exo__Asset_label]]",
+    header: "Name",
+    width: "auto",
+    renderer: "text",
+    editable: false,
+    sortable: true,
+    ...overrides,
+  });
+
+  const createLayout = (overrides: Partial<Parameters<typeof KanbanLayoutRenderer>[0]["layout"]> = {}) => ({
+    uid: "kanban-1",
+    label: "Test Kanban",
+    laneProperty: "[[ems__Effort_status]]",
+    lanes: ["[[todo]]", "[[doing]]", "[[done]]"],
+    columns: [createColumn()],
+    ...overrides,
+  });
+
+  const createCard = (overrides: Partial<KanbanCard> = {}): KanbanCard => ({
+    id: "card-1",
+    path: "/path/to/asset.md",
+    metadata: {},
+    values: { "col-1": "Test Card" },
+    laneId: "[[todo]]",
+    ...overrides,
+  });
+
+  describe("Basic Rendering", () => {
+    it("renders a kanban board with header", () => {
+      const layout = createLayout();
+      const cards = [createCard()];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+        />
+      );
+
+      expect(screen.getByText("Test Kanban")).toBeInTheDocument();
+      expect(screen.getByText("1 item")).toBeInTheDocument();
+    });
+
+    it("renders lanes from layout definition", () => {
+      const layout = createLayout({
+        lanes: ["[[todo]]", "[[doing]]", "[[done]]"],
+      });
+      const cards: KanbanCard[] = [];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+        />
+      );
+
+      expect(screen.getByText("todo")).toBeInTheDocument();
+      expect(screen.getByText("doing")).toBeInTheDocument();
+      expect(screen.getByText("done")).toBeInTheDocument();
+    });
+
+    it("renders cards in correct lanes", () => {
+      const layout = createLayout();
+      const cards = [
+        createCard({ id: "card-1", laneId: "[[todo]]", values: { "col-1": "Task 1" } }),
+        createCard({ id: "card-2", laneId: "[[doing]]", values: { "col-1": "Task 2" } }),
+        createCard({ id: "card-3", laneId: "[[done]]", values: { "col-1": "Task 3" } }),
+      ];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+        />
+      );
+
+      expect(screen.getByText("Task 1")).toBeInTheDocument();
+      expect(screen.getByText("Task 2")).toBeInTheDocument();
+      expect(screen.getByText("Task 3")).toBeInTheDocument();
+    });
+
+    it("displays correct card count per lane", () => {
+      const layout = createLayout();
+      const cards = [
+        createCard({ id: "card-1", laneId: "[[todo]]" }),
+        createCard({ id: "card-2", laneId: "[[todo]]" }),
+        createCard({ id: "card-3", laneId: "[[doing]]" }),
+      ];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+        />
+      );
+
+      // Lane counts should be displayed
+      const counts = screen.getAllByText(/^[0-3]$/);
+      expect(counts.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("Empty State", () => {
+    it("renders empty message when no lanes defined", () => {
+      const layout = createLayout({ lanes: [] });
+      const cards: KanbanCard[] = [];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+        />
+      );
+
+      expect(screen.getByText(/no lanes defined/i)).toBeInTheDocument();
+    });
+
+    it("renders empty lane placeholder", () => {
+      const layout = createLayout();
+      const cards: KanbanCard[] = [];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+        />
+      );
+
+      const emptyMessages = screen.getAllByText(/no items/i);
+      expect(emptyMessages.length).toBe(3); // One for each lane
+    });
+  });
+
+  describe("Lane Collapse", () => {
+    it("toggles lane collapse on header click", () => {
+      const layout = createLayout();
+      const cards = [createCard()];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+        />
+      );
+
+      // Find the lane header for "todo"
+      const laneHeaders = screen.getAllByText("todo");
+      const laneHeader = laneHeaders[0];
+
+      // Cards should be visible initially
+      expect(screen.getByText("Test Card")).toBeInTheDocument();
+
+      // Click to collapse
+      fireEvent.click(laneHeader);
+
+      // Card should be hidden in collapsed lane
+      expect(screen.queryByText("Test Card")).not.toBeInTheDocument();
+    });
+
+    it("calls onLaneToggle handler when lane is toggled", () => {
+      const onLaneToggle = jest.fn();
+      const layout = createLayout();
+      const cards: KanbanCard[] = [];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+          onLaneToggle={onLaneToggle}
+        />
+      );
+
+      // Click lane header to toggle
+      const laneHeader = screen.getAllByText("todo")[0];
+      fireEvent.click(laneHeader);
+
+      expect(onLaneToggle).toHaveBeenCalledWith("[[todo]]", true);
+    });
+  });
+
+  describe("Drag and Drop", () => {
+    it("calls onCardMove when card is dropped on new lane", () => {
+      const onCardMove = jest.fn();
+      const layout = createLayout();
+      const cards = [createCard({ id: "card-1", laneId: "[[todo]]" })];
+
+      const { container } = render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+          onCardMove={onCardMove}
+        />
+      );
+
+      // Find card and target lane
+      const card = container.querySelector('[data-card-id="card-1"]');
+      const lanes = container.querySelectorAll(".exo-kanban-lane-body");
+      const targetLane = lanes[1]; // "doing" lane
+
+      // Simulate drag start
+      fireEvent.dragStart(card!, {
+        dataTransfer: {
+          setData: jest.fn(),
+          effectAllowed: "move",
+        },
+      });
+
+      // Simulate drag over target lane
+      fireEvent.dragOver(targetLane, {
+        preventDefault: jest.fn(),
+        dataTransfer: { dropEffect: "move" },
+      });
+
+      // Simulate drop
+      fireEvent.drop(targetLane, {
+        preventDefault: jest.fn(),
+      });
+
+      expect(onCardMove).toHaveBeenCalledWith(
+        "card-1",
+        "[[ems__Effort_status]]",
+        "[[doing]]"
+      );
+    });
+
+    it("does not call onCardMove when dropped on same lane", () => {
+      const onCardMove = jest.fn();
+      const layout = createLayout();
+      const cards = [createCard({ id: "card-1", laneId: "[[todo]]" })];
+
+      const { container } = render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+          onCardMove={onCardMove}
+        />
+      );
+
+      // Find card and source lane
+      const card = container.querySelector('[data-card-id="card-1"]');
+      const lanes = container.querySelectorAll(".exo-kanban-lane-body");
+      const sourceLane = lanes[0]; // "todo" lane (same as card)
+
+      // Simulate drag start
+      fireEvent.dragStart(card!, {
+        dataTransfer: {
+          setData: jest.fn(),
+          effectAllowed: "move",
+        },
+      });
+
+      // Simulate drop on same lane
+      fireEvent.drop(sourceLane, {
+        preventDefault: jest.fn(),
+      });
+
+      expect(onCardMove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Custom className", () => {
+    it("applies custom className to container", () => {
+      const layout = createLayout();
+      const cards: KanbanCard[] = [];
+
+      const { container } = render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+          lanes={[
+            { id: "[[todo]]", label: "To Do" },
+          ]}
+          className="custom-class"
+        />
+      );
+
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+
+  describe("Lane Options", () => {
+    it("respects maxCardsPerLane option", () => {
+      const layout = createLayout();
+      const cards = Array.from({ length: 5 }, (_, i) =>
+        createCard({
+          id: `card-${i}`,
+          laneId: "[[todo]]",
+          values: { "col-1": `Card ${i}` },
+        })
+      );
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+          options={{ maxCardsPerLane: 3 }}
+        />
+      );
+
+      // Should show first 3 cards
+      expect(screen.getByText("Card 0")).toBeInTheDocument();
+      expect(screen.getByText("Card 1")).toBeInTheDocument();
+      expect(screen.getByText("Card 2")).toBeInTheDocument();
+
+      // Should not show card 3 and 4
+      expect(screen.queryByText("Card 3")).not.toBeInTheDocument();
+      expect(screen.queryByText("Card 4")).not.toBeInTheDocument();
+
+      // Should show "+2 more"
+      expect(screen.getByText("+2 more")).toBeInTheDocument();
+    });
+
+    it("respects collapsible option", () => {
+      const onLaneToggle = jest.fn();
+      const layout = createLayout();
+      const cards: KanbanCard[] = [];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+          onLaneToggle={onLaneToggle}
+          options={{ collapsible: false }}
+        />
+      );
+
+      // Click lane header
+      const laneHeader = screen.getAllByText("todo")[0];
+      fireEvent.click(laneHeader);
+
+      // Should not toggle when collapsible is false
+      expect(onLaneToggle).not.toHaveBeenCalled();
+    });
+
+    it("hides count when showCount is false", () => {
+      const layout = createLayout();
+      const cards = [createCard()];
+
+      const { container } = render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+          options={{ showCount: false }}
+        />
+      );
+
+      // Lane count badges should not be present
+      const countBadges = container.querySelectorAll(".exo-kanban-lane-count");
+      expect(countBadges.length).toBe(0);
+    });
+  });
+
+  describe("Provided Lanes", () => {
+    it("uses provided lanes instead of deriving from layout", () => {
+      const layout = createLayout({ lanes: [] }); // No lanes in layout
+      const cards = [createCard({ laneId: "custom-lane" })];
+      const lanes: KanbanLane[] = [
+        { id: "custom-lane", label: "Custom Lane" },
+      ];
+
+      render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+          lanes={lanes}
+        />
+      );
+
+      expect(screen.getByText("Custom Lane")).toBeInTheDocument();
+    });
+  });
+
+  describe("Link Click Handler", () => {
+    it("calls onLinkClick when card is clicked", () => {
+      const onLinkClick = jest.fn();
+      const layout = createLayout();
+      const cards = [createCard()];
+
+      const { container } = render(
+        <KanbanLayoutRenderer
+          layout={layout}
+          cards={cards}
+          onLinkClick={onLinkClick}
+        />
+      );
+
+      const card = container.querySelector('[data-card-id="card-1"]');
+      fireEvent.click(card!);
+
+      expect(onLinkClick).toHaveBeenCalledWith("/path/to/asset.md", expect.any(Object));
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/kanban/types.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/kanban/types.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Kanban Types Utility Tests
+ *
+ * Tests for the utility functions in the kanban/types module.
+ */
+
+import {
+  extractLabelFromWikilink,
+  extractPathFromWikilink,
+} from "@plugin/presentation/renderers/kanban/types";
+
+describe("Kanban Types Utilities", () => {
+  describe("extractLabelFromWikilink", () => {
+    it("extracts label from piped wikilink", () => {
+      expect(extractLabelFromWikilink("[[path/to/file|Display Label]]")).toBe("Display Label");
+    });
+
+    it("extracts filename from simple wikilink", () => {
+      expect(extractLabelFromWikilink("[[path/to/filename]]")).toBe("filename");
+    });
+
+    it("extracts filename from single-segment wikilink", () => {
+      expect(extractLabelFromWikilink("[[filename]]")).toBe("filename");
+    });
+
+    it("removes .md extension from filename", () => {
+      expect(extractLabelFromWikilink("[[path/to/file.md]]")).toBe("file");
+    });
+
+    it("returns original string if not a wikilink", () => {
+      expect(extractLabelFromWikilink("not a wikilink")).toBe("not a wikilink");
+    });
+
+    it("handles wikilink with nested path", () => {
+      expect(extractLabelFromWikilink("[[deep/nested/path/to/myfile]]")).toBe("myfile");
+    });
+
+    it("handles wikilink with special characters in label", () => {
+      expect(extractLabelFromWikilink("[[file|Label with spaces & symbols!]]")).toBe("Label with spaces & symbols!");
+    });
+  });
+
+  describe("extractPathFromWikilink", () => {
+    it("extracts path from piped wikilink", () => {
+      expect(extractPathFromWikilink("[[path/to/file|Label]]")).toBe("path/to/file");
+    });
+
+    it("extracts path from simple wikilink", () => {
+      expect(extractPathFromWikilink("[[path/to/file]]")).toBe("path/to/file");
+    });
+
+    it("extracts path from single-segment wikilink", () => {
+      expect(extractPathFromWikilink("[[filename]]")).toBe("filename");
+    });
+
+    it("returns original string if not a wikilink", () => {
+      expect(extractPathFromWikilink("not a wikilink")).toBe("not a wikilink");
+    });
+
+    it("handles wikilink with .md extension", () => {
+      expect(extractPathFromWikilink("[[path/to/file.md|Label]]")).toBe("path/to/file.md");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements KanbanLayoutRenderer for Issue #970
- Provides Kanban board view for visualizing Tasks/Assets by status
- Uses HTML5 Drag and Drop API for card movement between lanes
- CSS styles following Obsidian theme variables

## Changes

### Components
- `KanbanLayoutRenderer.tsx` - Main board component with drag-and-drop coordination
- `KanbanLane.tsx` - Lane/column component with collapse support and drop target
- `KanbanCard.tsx` - Card component using cell renderers
- `types.ts` - TypeScript types and wikilink utility functions
- `index.ts` - Module exports

### Features
- Render lanes from `KanbanLayout.laneProperty`
- Cards with task summary using existing cell renderers
- HTML5 Drag-and-Drop API for moving cards between lanes
- `onCardMove` callback for SPARQL UPDATE integration
- Collapsible lanes with `onLaneToggle` callback
- Responsive CSS with mobile support

### Tests
- `KanbanLayoutRenderer.test.tsx` - Board rendering, lanes, drag-and-drop, options
- `KanbanLane.test.tsx` - Lane rendering, collapse, drop target behavior
- `KanbanCard.test.tsx` - Card rendering, drag behavior, click navigation
- `types.test.ts` - Wikilink extraction utilities

## Test plan
- [x] Unit tests pass (`npm run test:unit`)
- [x] TypeScript type check passes (`npm run check:types`)
- [x] Lint check passes with no new errors
- [ ] CI pipeline passes

Closes #970