### PR TITLE
feat: LayoutActions Renderer — action buttons in table layouts

### DIFF
--- a/packages/obsidian-plugin/src/domain/layout/Layout.ts
+++ b/packages/obsidian-plugin/src/domain/layout/Layout.ts
@@ -2,6 +2,7 @@ import type { LayoutColumn } from "./LayoutColumn";
 import type { LayoutFilter } from "./LayoutFilter";
 import type { LayoutSort } from "./LayoutSort";
 import type { LayoutGroup } from "./LayoutGroup";
+import type { LayoutActions } from "./LayoutActions";
 
 /**
  * Layout type enumeration.
@@ -91,6 +92,12 @@ export interface BaseLayout {
    * Maps to exo__Layout_groupBy.
    */
   groupBy?: LayoutGroup;
+
+  /**
+   * Action buttons definition.
+   * Maps to exo__Layout_actions.
+   */
+  actions?: LayoutActions;
 }
 
 /**

--- a/packages/obsidian-plugin/src/domain/layout/LayoutActions.ts
+++ b/packages/obsidian-plugin/src/domain/layout/LayoutActions.ts
@@ -1,0 +1,258 @@
+/**
+ * LayoutActions Domain Model
+ *
+ * Defines the structure for action buttons that can be displayed in layout rows.
+ * Maps to ontology class: exo__LayoutActions
+ *
+ * @module domain/layout
+ * @since 1.0.0
+ */
+
+/**
+ * Position where action buttons should be displayed
+ */
+export type ActionPosition = "column" | "inline" | "hover" | "contextMenu";
+
+/**
+ * Reference to a command that can be executed as an action button
+ */
+export interface CommandRef {
+  /**
+   * Unique identifier of the command.
+   * Corresponds to exo__Asset_uid.
+   */
+  uid: string;
+
+  /**
+   * Human-readable label for the command.
+   * Corresponds to exo__Asset_label.
+   */
+  label: string;
+
+  /**
+   * Icon identifier for the button.
+   * Corresponds to exo__Command_icon.
+   * Uses Lucide icon names (e.g., "play-circle", "stop-circle", "check-circle")
+   */
+  icon?: string;
+
+  /**
+   * SPARQL ASK query to check if command is applicable.
+   * The query should use $target as placeholder for the asset URI.
+   * If the query returns true, the command button is visible/enabled.
+   */
+  preconditionSparql?: string;
+
+  /**
+   * SPARQL UPDATE query to execute when the button is clicked.
+   * Uses $target for the asset URI and $now for current timestamp.
+   */
+  groundingSparql?: string;
+}
+
+/**
+ * LayoutActions interface.
+ * Defines a set of action buttons for layout rows.
+ *
+ * Maps to ontology class: exo__LayoutActions
+ *
+ * Properties from ontology:
+ * - exo__LayoutActions_commands: List of command references
+ * - exo__LayoutActions_position: Where to display buttons
+ * - exo__LayoutActions_showLabels: Whether to show text labels
+ */
+export interface LayoutActions {
+  /**
+   * Unique identifier for the LayoutActions definition.
+   * Corresponds to exo__Asset_uid.
+   */
+  uid: string;
+
+  /**
+   * Human-readable label.
+   * Corresponds to exo__Asset_label.
+   */
+  label: string;
+
+  /**
+   * List of commands to display as buttons.
+   * Maps to exo__LayoutActions_commands.
+   */
+  commands: CommandRef[];
+
+  /**
+   * Where to display the action buttons.
+   * Maps to exo__LayoutActions_position.
+   * @default "column"
+   */
+  position: ActionPosition;
+
+  /**
+   * Whether to show text labels alongside icons.
+   * Maps to exo__LayoutActions_showLabels.
+   * @default false
+   */
+  showLabels: boolean;
+}
+
+/**
+ * Check if a string is a valid ActionPosition
+ */
+export function isValidActionPosition(value: unknown): value is ActionPosition {
+  return value === "column" || value === "inline" || value === "hover" || value === "contextMenu";
+}
+
+/**
+ * Create a LayoutActions object from frontmatter data.
+ *
+ * @param frontmatter - The YAML frontmatter object
+ * @returns LayoutActions or null if required fields are missing
+ */
+export function createLayoutActionsFromFrontmatter(
+  frontmatter: Record<string, unknown>,
+): Partial<LayoutActions> | null {
+  const uid = frontmatter["exo__Asset_uid"] as string | undefined;
+  const label = frontmatter["exo__Asset_label"] as string | undefined;
+
+  if (!uid || !label) {
+    return null;
+  }
+
+  const positionValue = frontmatter["exo__LayoutActions_position"];
+  const position: ActionPosition = isValidActionPosition(positionValue)
+    ? positionValue
+    : "column";
+
+  const showLabels = frontmatter["exo__LayoutActions_showLabels"] === true;
+
+  // Commands need to be resolved separately (they are wikilinks)
+  // We return a partial object here, commands will be populated by the parser
+  return {
+    uid,
+    label,
+    commands: [], // Will be populated by LayoutParser
+    position,
+    showLabels,
+  };
+}
+
+/**
+ * Create a CommandRef object from frontmatter data.
+ *
+ * @param frontmatter - The YAML frontmatter object from a Command asset
+ * @returns CommandRef or null if required fields are missing
+ */
+export function createCommandRefFromFrontmatter(
+  frontmatter: Record<string, unknown>,
+): Partial<CommandRef> | null {
+  const uid = frontmatter["exo__Asset_uid"] as string | undefined;
+  const label = frontmatter["exo__Asset_label"] as string | undefined;
+
+  if (!uid || !label) {
+    return null;
+  }
+
+  const icon = frontmatter["exo__Command_icon"] as string | undefined;
+
+  // Note: preconditionSparql and groundingSparql come from linked assets
+  // and need to be resolved separately by the parser
+  return {
+    uid,
+    label,
+    icon,
+    // preconditionSparql and groundingSparql will be populated by LayoutParser
+  };
+}
+
+/**
+ * Check if a frontmatter object represents a LayoutActions asset.
+ */
+export function isLayoutActionsFrontmatter(
+  frontmatter: Record<string, unknown>,
+): boolean {
+  const instanceClass = frontmatter["exo__Instance_class"];
+  const classes = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
+
+  for (const cls of classes) {
+    if (typeof cls !== "string") continue;
+
+    // Extract class name from wikilink
+    const match = cls.match(/\[\[([^\]]+)\]\]/);
+    const className = match ? match[1] : cls;
+
+    if (className === "exo__LayoutActions") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a frontmatter object represents a Command asset.
+ */
+export function isCommandFrontmatter(
+  frontmatter: Record<string, unknown>,
+): boolean {
+  const instanceClass = frontmatter["exo__Instance_class"];
+  const classes = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
+
+  for (const cls of classes) {
+    if (typeof cls !== "string") continue;
+
+    const match = cls.match(/\[\[([^\]]+)\]\]/);
+    const className = match ? match[1] : cls;
+
+    if (className === "exocmd__Command") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a frontmatter object represents a Precondition asset.
+ */
+export function isPreconditionFrontmatter(
+  frontmatter: Record<string, unknown>,
+): boolean {
+  const instanceClass = frontmatter["exo__Instance_class"];
+  const classes = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
+
+  for (const cls of classes) {
+    if (typeof cls !== "string") continue;
+
+    const match = cls.match(/\[\[([^\]]+)\]\]/);
+    const className = match ? match[1] : cls;
+
+    if (className === "exocmd__Precondition") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a frontmatter object represents a SparqlGrounding asset.
+ */
+export function isSparqlGroundingFrontmatter(
+  frontmatter: Record<string, unknown>,
+): boolean {
+  const instanceClass = frontmatter["exo__Instance_class"];
+  const classes = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
+
+  for (const cls of classes) {
+    if (typeof cls !== "string") continue;
+
+    const match = cls.match(/\[\[([^\]]+)\]\]/);
+    const className = match ? match[1] : cls;
+
+    if (className === "exocmd__SparqlGrounding") {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/obsidian-plugin/src/domain/layout/index.ts
+++ b/packages/obsidian-plugin/src/domain/layout/index.ts
@@ -96,3 +96,17 @@ export {
   createLayoutGroupFromFrontmatter,
   isValidGroupSortOrder,
 } from "./LayoutGroup";
+
+// LayoutActions types
+export {
+  type ActionPosition,
+  type CommandRef,
+  type LayoutActions,
+  isValidActionPosition,
+  createLayoutActionsFromFrontmatter,
+  createCommandRefFromFrontmatter,
+  isLayoutActionsFrontmatter,
+  isCommandFrontmatter,
+  isPreconditionFrontmatter,
+  isSparqlGroundingFrontmatter,
+} from "./LayoutActions";

--- a/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/ActionsRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/ActionsRenderer.tsx
@@ -1,0 +1,302 @@
+/**
+ * ActionsRenderer - Renders action buttons for layout rows
+ *
+ * Displays a set of command buttons based on LayoutActions configuration.
+ * Each button can:
+ * - Show an icon and/or label
+ * - Have visibility controlled by a SPARQL ASK precondition
+ * - Execute a SPARQL UPDATE when clicked
+ *
+ * @module presentation/renderers/cell-renderers
+ * @since 1.0.0
+ */
+import React, { useState, useEffect, useCallback } from "react";
+import type { CommandRef, LayoutActions } from "../../../domain/layout";
+
+/**
+ * Icon mapping from Lucide icon names to emoji or Unicode symbols.
+ * These match common command icons from the ontology.
+ */
+const iconMap: Record<string, string> = {
+  // Task status icons
+  "play-circle": "▶️",
+  "play": "▶️",
+  "stop-circle": "⏹️",
+  "stop": "⏹️",
+  "check-circle": "✅",
+  "check": "✅",
+  "circle-check": "✅",
+  "pause-circle": "⏸️",
+  "pause": "⏸️",
+
+  // Common action icons
+  "refresh-cw": "🔄",
+  "rotate-cw": "🔄",
+  "trash-2": "🗑️",
+  "trash": "🗑️",
+  "edit": "✏️",
+  "pencil": "✏️",
+  "plus": "➕",
+  "plus-circle": "➕",
+  "minus": "➖",
+  "minus-circle": "➖",
+  "star": "⭐",
+  "heart": "❤️",
+  "flag": "🚩",
+  "archive": "📦",
+  "folder": "📁",
+  "file": "📄",
+  "copy": "📋",
+  "link": "🔗",
+  "eye": "👁️",
+  "eye-off": "🙈",
+  "clock": "⏰",
+  "calendar": "📅",
+  "user": "👤",
+  "users": "👥",
+  "mail": "📧",
+  "send": "📤",
+  "download": "📥",
+  "upload": "📤",
+  "settings": "⚙️",
+  "more-horizontal": "⋯",
+  "more-vertical": "⋮",
+};
+
+/**
+ * Get display icon for a command
+ */
+function getIcon(iconName?: string): string {
+  if (!iconName) return "⚡";
+  return iconMap[iconName] || iconMap[iconName.toLowerCase()] || "⚡";
+}
+
+/**
+ * Props for ActionsRenderer component
+ */
+export interface ActionsRendererProps {
+  /**
+   * The LayoutActions definition
+   */
+  actions: LayoutActions;
+
+  /**
+   * URI of the asset this row represents
+   */
+  assetUri: string;
+
+  /**
+   * Path to the asset file (for display)
+   */
+  assetPath?: string;
+
+  /**
+   * Callback to check if a command precondition is satisfied.
+   * Returns true if the command should be visible/enabled.
+   * @param sparql - The SPARQL ASK query with $target placeholder
+   * @param assetUri - The URI to substitute for $target
+   */
+  onCheckPrecondition?: (sparql: string, assetUri: string) => Promise<boolean>;
+
+  /**
+   * Callback to execute a command grounding.
+   * @param sparql - The SPARQL UPDATE query with $target and $now placeholders
+   * @param assetUri - The URI to substitute for $target
+   */
+  onExecuteCommand?: (sparql: string, assetUri: string) => Promise<void>;
+
+  /**
+   * Whether buttons are disabled (e.g., during execution)
+   */
+  disabled?: boolean;
+
+  /**
+   * Custom class name
+   */
+  className?: string;
+}
+
+/**
+ * State for each command button
+ */
+interface CommandState {
+  visible: boolean;
+  loading: boolean;
+  executing: boolean;
+}
+
+/**
+ * ActionsRenderer - Renders action buttons for a layout row
+ */
+export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
+  actions,
+  assetUri,
+  assetPath,
+  onCheckPrecondition,
+  onExecuteCommand,
+  disabled = false,
+  className,
+}) => {
+  const { commands, showLabels, position } = actions;
+
+  // State for each command
+  const [commandStates, setCommandStates] = useState<Record<string, CommandState>>(() => {
+    const initial: Record<string, CommandState> = {};
+    for (const cmd of commands) {
+      initial[cmd.uid] = {
+        visible: !cmd.preconditionSparql, // Visible by default if no precondition
+        loading: !!cmd.preconditionSparql, // Loading if has precondition
+        executing: false,
+      };
+    }
+    return initial;
+  });
+
+  // Check preconditions on mount and when assetUri changes
+  useEffect(() => {
+    const checkPreconditions = async () => {
+      if (!onCheckPrecondition) {
+        // No precondition checker, show all commands
+        setCommandStates((prev) => {
+          const next: Record<string, CommandState> = {};
+          for (const cmd of commands) {
+            next[cmd.uid] = { ...prev[cmd.uid], visible: true, loading: false };
+          }
+          return next;
+        });
+        return;
+      }
+
+      // Check each command's precondition
+      for (const cmd of commands) {
+        if (!cmd.preconditionSparql) {
+          setCommandStates((prev) => ({
+            ...prev,
+            [cmd.uid]: { ...prev[cmd.uid], visible: true, loading: false },
+          }));
+          continue;
+        }
+
+        try {
+          const result = await onCheckPrecondition(cmd.preconditionSparql, assetUri);
+          setCommandStates((prev) => ({
+            ...prev,
+            [cmd.uid]: { ...prev[cmd.uid], visible: result, loading: false },
+          }));
+        } catch (error) {
+          console.error(`Precondition check failed for ${cmd.label}:`, error);
+          // Hide on error
+          setCommandStates((prev) => ({
+            ...prev,
+            [cmd.uid]: { ...prev[cmd.uid], visible: false, loading: false },
+          }));
+        }
+      }
+    };
+
+    checkPreconditions();
+  }, [assetUri, commands, onCheckPrecondition]);
+
+  // Handle button click
+  const handleClick = useCallback(
+    async (cmd: CommandRef, event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!cmd.groundingSparql || !onExecuteCommand) {
+        console.warn(`No grounding SPARQL for command: ${cmd.label}`);
+        return;
+      }
+
+      // Set executing state
+      setCommandStates((prev) => ({
+        ...prev,
+        [cmd.uid]: { ...prev[cmd.uid], executing: true },
+      }));
+
+      try {
+        await onExecuteCommand(cmd.groundingSparql, assetUri);
+
+        // After execution, re-check all preconditions (state may have changed)
+        if (onCheckPrecondition) {
+          for (const c of commands) {
+            if (!c.preconditionSparql) continue;
+            try {
+              const result = await onCheckPrecondition(c.preconditionSparql, assetUri);
+              setCommandStates((prev) => ({
+                ...prev,
+                [c.uid]: { ...prev[c.uid], visible: result },
+              }));
+            } catch {
+              // Keep current visibility on error
+            }
+          }
+        }
+      } catch (error) {
+        console.error(`Command execution failed for ${cmd.label}:`, error);
+      } finally {
+        setCommandStates((prev) => ({
+          ...prev,
+          [cmd.uid]: { ...prev[cmd.uid], executing: false },
+        }));
+      }
+    },
+    [assetUri, commands, onCheckPrecondition, onExecuteCommand],
+  );
+
+  // Render a single button
+  const renderButton = (cmd: CommandRef) => {
+    const state = commandStates[cmd.uid];
+    if (!state) return null;
+
+    // Hide if loading or not visible
+    if (state.loading) {
+      return (
+        <span
+          key={cmd.uid}
+          className="exo-action-button exo-action-button-loading"
+          title="Loading..."
+        >
+          ⏳
+        </span>
+      );
+    }
+
+    if (!state.visible) {
+      return null;
+    }
+
+    const icon = getIcon(cmd.icon);
+    const isDisabled = disabled || state.executing;
+
+    return (
+      <button
+        key={cmd.uid}
+        className={`exo-action-button ${state.executing ? "exo-action-button-executing" : ""} ${isDisabled ? "exo-action-button-disabled" : ""}`}
+        onClick={(e) => handleClick(cmd, e)}
+        disabled={isDisabled}
+        title={cmd.label}
+        aria-label={cmd.label}
+        data-command-uid={cmd.uid}
+      >
+        <span className="exo-action-button-icon">{state.executing ? "⏳" : icon}</span>
+        {showLabels && <span className="exo-action-button-label">{cmd.label}</span>}
+      </button>
+    );
+  };
+
+  // Get position-specific class
+  const positionClass = `exo-actions-${position || "column"}`;
+
+  return (
+    <div
+      className={`exo-actions-container ${positionClass} ${className || ""}`}
+      data-asset-uri={assetUri}
+      data-asset-path={assetPath}
+    >
+      {commands.map(renderButton)}
+    </div>
+  );
+};
+
+export default ActionsRenderer;

--- a/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/index.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/index.ts
@@ -29,6 +29,8 @@ export { ProgressRenderer } from "./ProgressRenderer";
 export { NumberRenderer } from "./NumberRenderer";
 export { TagsRenderer } from "./TagsRenderer";
 export { ImageRenderer } from "./ImageRenderer";
+export { ActionsRenderer } from "./ActionsRenderer";
+export type { ActionsRendererProps } from "./ActionsRenderer";
 
 // Re-export ColumnRenderer type from domain
 export type { ColumnRenderer } from "../../../domain/layout";

--- a/packages/obsidian-plugin/tests/unit/domain/layout/LayoutActions.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/layout/LayoutActions.test.ts
@@ -1,0 +1,258 @@
+/**
+ * LayoutActions Domain Model Tests
+ *
+ * Tests for LayoutActions, CommandRef, and related helper functions.
+ */
+import {
+  isValidActionPosition,
+  createLayoutActionsFromFrontmatter,
+  createCommandRefFromFrontmatter,
+  isLayoutActionsFrontmatter,
+  isCommandFrontmatter,
+  isPreconditionFrontmatter,
+  isSparqlGroundingFrontmatter,
+} from "../../../../src/domain/layout/LayoutActions";
+
+describe("LayoutActions Domain Model", () => {
+  describe("isValidActionPosition", () => {
+    it("should return true for valid action positions", () => {
+      expect(isValidActionPosition("column")).toBe(true);
+      expect(isValidActionPosition("inline")).toBe(true);
+      expect(isValidActionPosition("hover")).toBe(true);
+      expect(isValidActionPosition("contextMenu")).toBe(true);
+    });
+
+    it("should return false for invalid action positions", () => {
+      expect(isValidActionPosition("invalid")).toBe(false);
+      expect(isValidActionPosition("")).toBe(false);
+      expect(isValidActionPosition(null)).toBe(false);
+      expect(isValidActionPosition(undefined)).toBe(false);
+      expect(isValidActionPosition(123)).toBe(false);
+    });
+  });
+
+  describe("createLayoutActionsFromFrontmatter", () => {
+    it("should create LayoutActions from valid frontmatter", () => {
+      const frontmatter = {
+        exo__Asset_uid: "test-uid",
+        exo__Asset_label: "Test Actions",
+        exo__LayoutActions_position: "column",
+        exo__LayoutActions_showLabels: true,
+      };
+
+      const result = createLayoutActionsFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result?.uid).toBe("test-uid");
+      expect(result?.label).toBe("Test Actions");
+      expect(result?.position).toBe("column");
+      expect(result?.showLabels).toBe(true);
+      expect(result?.commands).toEqual([]);
+    });
+
+    it("should use default position when not specified", () => {
+      const frontmatter = {
+        exo__Asset_uid: "test-uid",
+        exo__Asset_label: "Test Actions",
+      };
+
+      const result = createLayoutActionsFromFrontmatter(frontmatter);
+
+      expect(result?.position).toBe("column");
+    });
+
+    it("should default showLabels to false", () => {
+      const frontmatter = {
+        exo__Asset_uid: "test-uid",
+        exo__Asset_label: "Test Actions",
+      };
+
+      const result = createLayoutActionsFromFrontmatter(frontmatter);
+
+      expect(result?.showLabels).toBe(false);
+    });
+
+    it("should return null when uid is missing", () => {
+      const frontmatter = {
+        exo__Asset_label: "Test Actions",
+      };
+
+      const result = createLayoutActionsFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when label is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "test-uid",
+      };
+
+      const result = createLayoutActionsFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle invalid position gracefully", () => {
+      const frontmatter = {
+        exo__Asset_uid: "test-uid",
+        exo__Asset_label: "Test Actions",
+        exo__LayoutActions_position: "invalid",
+      };
+
+      const result = createLayoutActionsFromFrontmatter(frontmatter);
+
+      expect(result?.position).toBe("column"); // Falls back to default
+    });
+  });
+
+  describe("createCommandRefFromFrontmatter", () => {
+    it("should create CommandRef from valid frontmatter", () => {
+      const frontmatter = {
+        exo__Asset_uid: "cmd-uid",
+        exo__Asset_label: "Start Task",
+        exo__Command_icon: "play-circle",
+      };
+
+      const result = createCommandRefFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result?.uid).toBe("cmd-uid");
+      expect(result?.label).toBe("Start Task");
+      expect(result?.icon).toBe("play-circle");
+    });
+
+    it("should return null when uid is missing", () => {
+      const frontmatter = {
+        exo__Asset_label: "Start Task",
+      };
+
+      const result = createCommandRefFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when label is missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "cmd-uid",
+      };
+
+      const result = createCommandRefFromFrontmatter(frontmatter);
+
+      expect(result).toBeNull();
+    });
+
+    it("should allow optional icon", () => {
+      const frontmatter = {
+        exo__Asset_uid: "cmd-uid",
+        exo__Asset_label: "Start Task",
+      };
+
+      const result = createCommandRefFromFrontmatter(frontmatter);
+
+      expect(result).not.toBeNull();
+      expect(result?.icon).toBeUndefined();
+    });
+  });
+
+  describe("isLayoutActionsFrontmatter", () => {
+    it("should return true for LayoutActions frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exo__LayoutActions]]"],
+      };
+
+      expect(isLayoutActionsFrontmatter(frontmatter)).toBe(true);
+    });
+
+    it("should return true for single string instance class", () => {
+      const frontmatter = {
+        exo__Instance_class: "[[exo__LayoutActions]]",
+      };
+
+      expect(isLayoutActionsFrontmatter(frontmatter)).toBe(true);
+    });
+
+    it("should return true when LayoutActions is among multiple classes", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exo__Asset]]", "[[exo__LayoutActions]]"],
+      };
+
+      expect(isLayoutActionsFrontmatter(frontmatter)).toBe(true);
+    });
+
+    it("should return false for non-LayoutActions frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exo__TableLayout]]"],
+      };
+
+      expect(isLayoutActionsFrontmatter(frontmatter)).toBe(false);
+    });
+
+    it("should return false for empty frontmatter", () => {
+      const frontmatter = {};
+
+      expect(isLayoutActionsFrontmatter(frontmatter)).toBe(false);
+    });
+
+    it("should handle class name without wikilink brackets", () => {
+      const frontmatter = {
+        exo__Instance_class: "exo__LayoutActions",
+      };
+
+      expect(isLayoutActionsFrontmatter(frontmatter)).toBe(true);
+    });
+  });
+
+  describe("isCommandFrontmatter", () => {
+    it("should return true for Command frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exocmd__Command]]"],
+      };
+
+      expect(isCommandFrontmatter(frontmatter)).toBe(true);
+    });
+
+    it("should return false for non-Command frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exo__LayoutActions]]"],
+      };
+
+      expect(isCommandFrontmatter(frontmatter)).toBe(false);
+    });
+  });
+
+  describe("isPreconditionFrontmatter", () => {
+    it("should return true for Precondition frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exocmd__Precondition]]"],
+      };
+
+      expect(isPreconditionFrontmatter(frontmatter)).toBe(true);
+    });
+
+    it("should return false for non-Precondition frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exocmd__Command]]"],
+      };
+
+      expect(isPreconditionFrontmatter(frontmatter)).toBe(false);
+    });
+  });
+
+  describe("isSparqlGroundingFrontmatter", () => {
+    it("should return true for SparqlGrounding frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exocmd__SparqlGrounding]]"],
+      };
+
+      expect(isSparqlGroundingFrontmatter(frontmatter)).toBe(true);
+    });
+
+    it("should return false for non-SparqlGrounding frontmatter", () => {
+      const frontmatter = {
+        exo__Instance_class: ["[[exocmd__Command]]"],
+      };
+
+      expect(isSparqlGroundingFrontmatter(frontmatter)).toBe(false);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ActionsRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ActionsRenderer.test.tsx
@@ -1,0 +1,429 @@
+/**
+ * ActionsRenderer Component Tests
+ *
+ * Tests for the ActionsRenderer component that displays action buttons.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ActionsRenderer } from "../../../../../src/presentation/renderers/cell-renderers/ActionsRenderer";
+import type { LayoutActions, CommandRef } from "../../../../../src/domain/layout";
+
+describe("ActionsRenderer", () => {
+  const createMockActions = (overrides: Partial<LayoutActions> = {}): LayoutActions => ({
+    uid: "actions-uid",
+    label: "Test Actions",
+    commands: [
+      {
+        uid: "cmd-1",
+        label: "Start",
+        icon: "play-circle",
+        preconditionSparql: undefined,
+        groundingSparql: "DELETE {} INSERT {} WHERE {}",
+      },
+    ],
+    position: "column",
+    showLabels: false,
+    ...overrides,
+  });
+
+  const defaultProps = {
+    assetUri: "obsidian://vault/test-asset.md",
+    assetPath: "test-asset.md",
+  };
+
+  describe("Basic Rendering", () => {
+    it("should render action buttons container", () => {
+      const actions = createMockActions();
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("should render button with correct icon", () => {
+      const actions = createMockActions();
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      // The icon should be rendered (▶️ for play-circle)
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("title", "Start");
+    });
+
+    it("should render multiple buttons for multiple commands", () => {
+      const actions = createMockActions({
+        commands: [
+          { uid: "cmd-1", label: "Start", icon: "play-circle" },
+          { uid: "cmd-2", label: "Stop", icon: "stop-circle" },
+          { uid: "cmd-3", label: "Complete", icon: "check-circle" },
+        ],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getAllByRole("button")).toHaveLength(3);
+    });
+
+    it("should show labels when showLabels is true", () => {
+      const actions = createMockActions({
+        showLabels: true,
+        commands: [{ uid: "cmd-1", label: "Start Task", icon: "play-circle" }],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getByText("Start Task")).toBeInTheDocument();
+    });
+
+    it("should not show labels when showLabels is false", () => {
+      const actions = createMockActions({
+        showLabels: false,
+        commands: [{ uid: "cmd-1", label: "Start Task", icon: "play-circle" }],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      // Label should only be in title attribute, not visible text
+      expect(screen.queryByText("Start Task")).not.toBeInTheDocument();
+      expect(screen.getByRole("button")).toHaveAttribute("title", "Start Task");
+    });
+  });
+
+  describe("Precondition Checking", () => {
+    it("should check preconditions on mount", async () => {
+      const onCheckPrecondition = jest.fn().mockResolvedValue(true);
+      const actions = createMockActions({
+        commands: [
+          {
+            uid: "cmd-1",
+            label: "Start",
+            icon: "play-circle",
+            preconditionSparql: "ASK { ?s ?p ?o }",
+          },
+        ],
+      });
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          onCheckPrecondition={onCheckPrecondition}
+        />
+      );
+
+      await waitFor(() => {
+        expect(onCheckPrecondition).toHaveBeenCalledWith(
+          "ASK { ?s ?p ?o }",
+          defaultProps.assetUri
+        );
+      });
+    });
+
+    it("should hide button when precondition returns false", async () => {
+      const onCheckPrecondition = jest.fn().mockResolvedValue(false);
+      const actions = createMockActions({
+        commands: [
+          {
+            uid: "cmd-1",
+            label: "Start",
+            icon: "play-circle",
+            preconditionSparql: "ASK { ?s ?p ?o }",
+          },
+        ],
+      });
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          onCheckPrecondition={onCheckPrecondition}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      });
+    });
+
+    it("should show button when precondition returns true", async () => {
+      const onCheckPrecondition = jest.fn().mockResolvedValue(true);
+      const actions = createMockActions({
+        commands: [
+          {
+            uid: "cmd-1",
+            label: "Start",
+            icon: "play-circle",
+            preconditionSparql: "ASK { ?s ?p ?o }",
+          },
+        ],
+      });
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          onCheckPrecondition={onCheckPrecondition}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("button")).toBeInTheDocument();
+      });
+    });
+
+    it("should show button when no precondition is defined", () => {
+      const actions = createMockActions({
+        commands: [
+          {
+            uid: "cmd-1",
+            label: "Start",
+            icon: "play-circle",
+            preconditionSparql: undefined,
+          },
+        ],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+  });
+
+  describe("Command Execution", () => {
+    it("should execute command on button click", async () => {
+      const onExecuteCommand = jest.fn().mockResolvedValue(undefined);
+      const groundingSparql = "DELETE {} INSERT {} WHERE {}";
+      const actions = createMockActions({
+        commands: [
+          {
+            uid: "cmd-1",
+            label: "Start",
+            icon: "play-circle",
+            groundingSparql,
+          },
+        ],
+      });
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          onExecuteCommand={onExecuteCommand}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      await waitFor(() => {
+        expect(onExecuteCommand).toHaveBeenCalledWith(
+          groundingSparql,
+          defaultProps.assetUri
+        );
+      });
+    });
+
+    it("should re-check preconditions after command execution", async () => {
+      const onCheckPrecondition = jest.fn().mockResolvedValue(true);
+      const onExecuteCommand = jest.fn().mockResolvedValue(undefined);
+      const actions = createMockActions({
+        commands: [
+          {
+            uid: "cmd-1",
+            label: "Start",
+            icon: "play-circle",
+            preconditionSparql: "ASK { ?s ?p ?o }",
+            groundingSparql: "DELETE {} INSERT {} WHERE {}",
+          },
+        ],
+      });
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          onCheckPrecondition={onCheckPrecondition}
+          onExecuteCommand={onExecuteCommand}
+        />
+      );
+
+      // Wait for initial precondition check
+      await waitFor(() => {
+        expect(onCheckPrecondition).toHaveBeenCalledTimes(1);
+      });
+
+      // Click the button
+      fireEvent.click(screen.getByRole("button"));
+
+      // Wait for re-check after execution
+      await waitFor(() => {
+        expect(onCheckPrecondition).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe("Disabled State", () => {
+    it("should disable buttons when disabled prop is true", () => {
+      const actions = createMockActions();
+
+      render(
+        <ActionsRenderer actions={actions} {...defaultProps} disabled={true} />
+      );
+
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    it("should not execute command when disabled", async () => {
+      const onExecuteCommand = jest.fn();
+      const actions = createMockActions({
+        commands: [
+          {
+            uid: "cmd-1",
+            label: "Start",
+            icon: "play-circle",
+            groundingSparql: "DELETE {} INSERT {} WHERE {}",
+          },
+        ],
+      });
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          disabled={true}
+          onExecuteCommand={onExecuteCommand}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      // Disabled buttons don't fire click events
+      expect(onExecuteCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Position Classes", () => {
+    it("should apply column position class", () => {
+      const actions = createMockActions({ position: "column" });
+
+      const { container } = render(
+        <ActionsRenderer actions={actions} {...defaultProps} />
+      );
+
+      expect(container.querySelector(".exo-actions-column")).toBeInTheDocument();
+    });
+
+    it("should apply inline position class", () => {
+      const actions = createMockActions({ position: "inline" });
+
+      const { container } = render(
+        <ActionsRenderer actions={actions} {...defaultProps} />
+      );
+
+      expect(container.querySelector(".exo-actions-inline")).toBeInTheDocument();
+    });
+
+    it("should apply hover position class", () => {
+      const actions = createMockActions({ position: "hover" });
+
+      const { container } = render(
+        <ActionsRenderer actions={actions} {...defaultProps} />
+      );
+
+      expect(container.querySelector(".exo-actions-hover")).toBeInTheDocument();
+    });
+  });
+
+  describe("Data Attributes", () => {
+    it("should include asset URI data attribute", () => {
+      const actions = createMockActions();
+
+      const { container } = render(
+        <ActionsRenderer actions={actions} {...defaultProps} />
+      );
+
+      expect(container.querySelector("[data-asset-uri]")).toHaveAttribute(
+        "data-asset-uri",
+        defaultProps.assetUri
+      );
+    });
+
+    it("should include asset path data attribute", () => {
+      const actions = createMockActions();
+
+      const { container } = render(
+        <ActionsRenderer actions={actions} {...defaultProps} />
+      );
+
+      expect(container.querySelector("[data-asset-path]")).toHaveAttribute(
+        "data-asset-path",
+        defaultProps.assetPath
+      );
+    });
+
+    it("should include command UID data attribute on buttons", () => {
+      const actions = createMockActions({
+        commands: [{ uid: "cmd-test-uid", label: "Test", icon: "check" }],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getByRole("button")).toHaveAttribute(
+        "data-command-uid",
+        "cmd-test-uid"
+      );
+    });
+  });
+
+  describe("Icon Mapping", () => {
+    it("should render play icon for play-circle", () => {
+      const actions = createMockActions({
+        commands: [{ uid: "cmd-1", label: "Start", icon: "play-circle" }],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getByText("▶️")).toBeInTheDocument();
+    });
+
+    it("should render stop icon for stop-circle", () => {
+      const actions = createMockActions({
+        commands: [{ uid: "cmd-1", label: "Stop", icon: "stop-circle" }],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getByText("⏹️")).toBeInTheDocument();
+    });
+
+    it("should render check icon for check-circle", () => {
+      const actions = createMockActions({
+        commands: [{ uid: "cmd-1", label: "Complete", icon: "check-circle" }],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getByText("✅")).toBeInTheDocument();
+    });
+
+    it("should use default icon when icon is not mapped", () => {
+      const actions = createMockActions({
+        commands: [{ uid: "cmd-1", label: "Custom", icon: "unknown-icon" }],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getByText("⚡")).toBeInTheDocument();
+    });
+
+    it("should use default icon when icon is not provided", () => {
+      const actions = createMockActions({
+        commands: [{ uid: "cmd-1", label: "No Icon" }],
+      });
+
+      render(<ActionsRenderer actions={actions} {...defaultProps} />);
+
+      expect(screen.getByText("⚡")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements rendering of action buttons based on the `LayoutActions` ontology class:

- **Domain Model**: Added `LayoutActions`, `CommandRef` types with validation functions
- **Parser**: Extended `LayoutParser` to load actions, commands, preconditions, and groundings from linked assets
- **Renderer**: Created `ActionsRenderer` component with icon mapping and state management
- **Integration**: Updated `TableLayoutRenderer` to show actions column when `position: column`

## Features

- Icon mapping from Lucide icons to emoji (▶️ play, ⏹️ stop, ✅ check, etc.)
- Precondition checking via SPARQL ASK callback for button visibility
- Command execution via SPARQL UPDATE callback on button click  
- Support for `showLabels` option (icons only vs icons + text)
- Position support: `column` (as separate column in table)
- Re-checking preconditions after command execution

## Test Coverage

- 24 domain model tests (LayoutActions.test.ts)
- 24 component tests (ActionsRenderer.test.tsx)
- All existing tests pass

## Technical Details

Based on ontology:
- `exo__LayoutActions`: Container with commands list, position, showLabels
- `exocmd__Command`: Icon, label, precondition, grounding links
- `exocmd__Precondition`: SPARQL ASK query (button visible when true)
- `exocmd__SparqlGrounding`: SPARQL UPDATE query (executed on click)

Closes #998