### PR TITLE
feat: Support CONSTRUCT with quoted triples for RDF-Star

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/executors/ConstructExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/ConstructExecutor.ts
@@ -3,8 +3,15 @@ import { Triple } from "../../../domain/models/rdf/Triple";
 import { IRI } from "../../../domain/models/rdf/IRI";
 import { Literal } from "../../../domain/models/rdf/Literal";
 import { BlankNode } from "../../../domain/models/rdf/BlankNode";
+import { QuotedTriple as RDFQuotedTriple } from "../../../domain/models/rdf/QuotedTriple";
 import type { Subject, Predicate, Object as RDFObject } from "../../../domain/models/rdf/Triple";
-import type { Triple as AlgebraTriple, TripleElement, PropertyPath } from "../algebra/AlgebraOperation";
+import type { QuotedSubject, QuotedPredicate, QuotedObject } from "../../../domain/models/rdf/QuotedTriple";
+import type {
+  Triple as AlgebraTriple,
+  TripleElement,
+  PropertyPath,
+  QuotedTriple as AlgebraQuotedTriple,
+} from "../algebra/AlgebraOperation";
 
 export class ConstructExecutor {
   async execute(template: AlgebraTriple[], solutions: SolutionMapping[]): Promise<Triple[]> {
@@ -72,6 +79,146 @@ export class ConstructExecutor {
       return new BlankNode(element.value);
     }
 
+    if (element.type === "quoted") {
+      return this.instantiateQuotedTriple(element, solution);
+    }
+
     throw new Error(`Unknown element type: ${(element as any).type}`);
+  }
+
+  /**
+   * Instantiate a quoted triple from an algebra QuotedTriple pattern.
+   * Supports RDF-Star CONSTRUCT templates with quoted triples.
+   *
+   * Example SPARQL:
+   * ```sparql
+   * CONSTRUCT {
+   *   <<( ?person :hasName ?name )>> :source :Database .
+   * }
+   * WHERE {
+   *   ?person :name ?name .
+   * }
+   * ```
+   *
+   * Variables inside the quoted triple are substituted with bound values.
+   * Supports nested quoted triples for complex provenance graphs.
+   *
+   * @param element - The algebra QuotedTriple pattern with potential variables
+   * @param solution - Variable bindings from WHERE clause evaluation
+   * @returns Instantiated RDF QuotedTriple with all variables substituted
+   * @throws Error if any variable in the quoted triple is unbound
+   */
+  private instantiateQuotedTriple(
+    element: AlgebraQuotedTriple,
+    solution: SolutionMapping
+  ): RDFQuotedTriple {
+    // Instantiate subject (can be IRI, BlankNode, or nested QuotedTriple)
+    const subject = this.instantiateQuotedSubject(element.subject, solution);
+
+    // Instantiate predicate (must be IRI, but may be a variable)
+    const predicate = this.instantiateQuotedPredicate(element.predicate, solution);
+
+    // Instantiate object (can be IRI, BlankNode, Literal, or nested QuotedTriple)
+    const object = this.instantiateQuotedObject(element.object, solution);
+
+    return new RDFQuotedTriple(subject, predicate, object);
+  }
+
+  /**
+   * Instantiate a quoted triple subject from an algebra element.
+   * Subjects in quoted triples can be IRI, BlankNode, or another QuotedTriple.
+   */
+  private instantiateQuotedSubject(
+    element: TripleElement,
+    solution: SolutionMapping
+  ): QuotedSubject {
+    if (element.type === "variable") {
+      const bound = solution.get(element.value);
+      if (!bound) {
+        throw new Error(`Unbound variable in quoted triple subject: ${element.value}`);
+      }
+      // Validate that the bound value is valid for subject position
+      if (bound instanceof Literal) {
+        throw new Error("Literals cannot appear in quoted triple subject position");
+      }
+      return bound as QuotedSubject;
+    }
+
+    if (element.type === "iri") {
+      return new IRI(element.value);
+    }
+
+    if (element.type === "blank") {
+      return new BlankNode(element.value);
+    }
+
+    if (element.type === "quoted") {
+      return this.instantiateQuotedTriple(element, solution);
+    }
+
+    throw new Error(`Invalid element type for quoted triple subject: ${element.type}`);
+  }
+
+  /**
+   * Instantiate a quoted triple predicate from an algebra element.
+   * Predicates in quoted triples must be IRIs.
+   */
+  private instantiateQuotedPredicate(
+    element: { type: "iri"; value: string } | { type: "variable"; value: string },
+    solution: SolutionMapping
+  ): QuotedPredicate {
+    if (element.type === "variable") {
+      const bound = solution.get(element.value);
+      if (!bound) {
+        throw new Error(`Unbound variable in quoted triple predicate: ${element.value}`);
+      }
+      if (!(bound instanceof IRI)) {
+        throw new Error("Quoted triple predicate must be an IRI");
+      }
+      return bound;
+    }
+
+    return new IRI(element.value);
+  }
+
+  /**
+   * Instantiate a quoted triple object from an algebra element.
+   * Objects in quoted triples can be IRI, BlankNode, Literal, or another QuotedTriple.
+   */
+  private instantiateQuotedObject(
+    element: TripleElement,
+    solution: SolutionMapping
+  ): QuotedObject {
+    if (element.type === "variable") {
+      const bound = solution.get(element.value);
+      if (!bound) {
+        throw new Error(`Unbound variable in quoted triple object: ${element.value}`);
+      }
+      return bound as QuotedObject;
+    }
+
+    if (element.type === "iri") {
+      return new IRI(element.value);
+    }
+
+    if (element.type === "blank") {
+      return new BlankNode(element.value);
+    }
+
+    if (element.type === "literal") {
+      return new Literal(
+        element.value,
+        element.datatype ? new IRI(element.datatype) : undefined,
+        element.language
+      );
+    }
+
+    if (element.type === "quoted") {
+      return this.instantiateQuotedTriple(element, solution);
+    }
+
+    // TypeScript exhaustiveness check - this should never be reached
+    const _exhaustiveCheck: never = element;
+    throw new Error(`Invalid element type for quoted triple object: ${(_exhaustiveCheck as TripleElement).type}`);
   }
 }

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/ConstructExecutor.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/ConstructExecutor.test.ts
@@ -2,7 +2,12 @@ import { ConstructExecutor } from "../../../../../src/infrastructure/sparql/exec
 import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
 import { IRI } from "../../../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../../../src/domain/models/rdf/Literal";
-import type { Triple as AlgebraTriple } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import { BlankNode } from "../../../../../src/domain/models/rdf/BlankNode";
+import { QuotedTriple } from "../../../../../src/domain/models/rdf/QuotedTriple";
+import type {
+  Triple as AlgebraTriple,
+  QuotedTriple as AlgebraQuotedTriple,
+} from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
 
 describe("ConstructExecutor", () => {
   let executor: ConstructExecutor;
@@ -83,5 +88,402 @@ describe("ConstructExecutor", () => {
 
     const triples = await executor.execute(template, [solution]);
     expect(triples).toHaveLength(0);
+  });
+
+  describe("RDF-Star CONSTRUCT with Quoted Triples", () => {
+    it("should construct triples with quoted triple in subject position", async () => {
+      // CONSTRUCT { <<( ?person :hasName ?name )>> :source :Database . }
+      const quotedTripleSubject: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "person" },
+        predicate: { type: "iri", value: "http://example.org/hasName" },
+        object: { type: "variable", value: "name" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTripleSubject,
+          predicate: { type: "iri", value: "http://example.org/source" },
+          object: { type: "iri", value: "http://example.org/Database" },
+        },
+      ];
+
+      const solution = new SolutionMapping();
+      solution.set("person", new IRI("http://example.org/Alice"));
+      solution.set("name", new Literal("Alice Smith"));
+
+      const triples = await executor.execute(template, [solution]);
+
+      expect(triples).toHaveLength(1);
+      // Subject should be a QuotedTriple
+      expect(triples[0].subject).toBeInstanceOf(QuotedTriple);
+      const qt = triples[0].subject as QuotedTriple;
+      expect(qt.subject).toBeInstanceOf(IRI);
+      expect((qt.subject as IRI).value).toBe("http://example.org/Alice");
+      expect(qt.predicate.value).toBe("http://example.org/hasName");
+      expect(qt.object).toBeInstanceOf(Literal);
+      expect((qt.object as Literal).value).toBe("Alice Smith");
+      // Predicate and object of outer triple
+      expect(triples[0].predicate.value).toBe("http://example.org/source");
+      expect((triples[0].object as IRI).value).toBe("http://example.org/Database");
+    });
+
+    it("should construct triples with quoted triple in object position", async () => {
+      // CONSTRUCT { :Observation :claims <<( ?s ?p ?o )>> . }
+      const quotedTripleObject: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "s" },
+        predicate: { type: "variable", value: "p" },
+        object: { type: "variable", value: "o" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: { type: "iri", value: "http://example.org/Observation" },
+          predicate: { type: "iri", value: "http://example.org/claims" },
+          object: quotedTripleObject,
+        },
+      ];
+
+      const solution = new SolutionMapping();
+      solution.set("s", new IRI("http://example.org/Bob"));
+      solution.set("p", new IRI("http://example.org/likes"));
+      solution.set("o", new IRI("http://example.org/Pizza"));
+
+      const triples = await executor.execute(template, [solution]);
+
+      expect(triples).toHaveLength(1);
+      expect((triples[0].subject as IRI).value).toBe("http://example.org/Observation");
+      // Object should be a QuotedTriple
+      expect(triples[0].object).toBeInstanceOf(QuotedTriple);
+      const qt = triples[0].object as QuotedTriple;
+      expect((qt.subject as IRI).value).toBe("http://example.org/Bob");
+      expect(qt.predicate.value).toBe("http://example.org/likes");
+      expect((qt.object as IRI).value).toBe("http://example.org/Pizza");
+    });
+
+    it("should construct triples with nested quoted triples", async () => {
+      // CONSTRUCT { <<( <<( ?inner_s ?inner_p ?inner_o )>> :assertedBy ?source )>> :timestamp ?time . }
+      const innerQuotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "inner_s" },
+        predicate: { type: "iri", value: "http://example.org/knows" },
+        object: { type: "variable", value: "inner_o" },
+      };
+
+      const outerQuotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: innerQuotedTriple,
+        predicate: { type: "iri", value: "http://example.org/assertedBy" },
+        object: { type: "variable", value: "source" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: outerQuotedTriple,
+          predicate: { type: "iri", value: "http://example.org/timestamp" },
+          object: { type: "variable", value: "time" },
+        },
+      ];
+
+      const solution = new SolutionMapping();
+      solution.set("inner_s", new IRI("http://example.org/Alice"));
+      solution.set("inner_o", new IRI("http://example.org/Bob"));
+      solution.set("source", new IRI("http://example.org/Wikipedia"));
+      solution.set("time", new Literal("2025-01-01T00:00:00Z", new IRI("http://www.w3.org/2001/XMLSchema#dateTime")));
+
+      const triples = await executor.execute(template, [solution]);
+
+      expect(triples).toHaveLength(1);
+      // Subject is a QuotedTriple
+      expect(triples[0].subject).toBeInstanceOf(QuotedTriple);
+      const outer = triples[0].subject as QuotedTriple;
+      // Outer subject is also a QuotedTriple (nested)
+      expect(outer.subject).toBeInstanceOf(QuotedTriple);
+      const inner = outer.subject as QuotedTriple;
+      expect((inner.subject as IRI).value).toBe("http://example.org/Alice");
+      expect(inner.predicate.value).toBe("http://example.org/knows");
+      expect((inner.object as IRI).value).toBe("http://example.org/Bob");
+      // Outer predicate and object
+      expect(outer.predicate.value).toBe("http://example.org/assertedBy");
+      expect((outer.object as IRI).value).toBe("http://example.org/Wikipedia");
+    });
+
+    it("should construct multiple triples with quoted triples for provenance", async () => {
+      // CONSTRUCT {
+      //   <<( ?person :hasName ?name )>> :source :Database .
+      //   <<( ?person :hasName ?name )>> :confidence "0.95"^^xsd:decimal .
+      // }
+      const quotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "person" },
+        predicate: { type: "iri", value: "http://example.org/hasName" },
+        object: { type: "variable", value: "name" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/source" },
+          object: { type: "iri", value: "http://example.org/Database" },
+        },
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/confidence" },
+          object: {
+            type: "literal",
+            value: "0.95",
+            datatype: "http://www.w3.org/2001/XMLSchema#decimal",
+          },
+        },
+      ];
+
+      const solution = new SolutionMapping();
+      solution.set("person", new IRI("http://example.org/Alice"));
+      solution.set("name", new Literal("Alice Smith"));
+
+      const triples = await executor.execute(template, [solution]);
+
+      expect(triples).toHaveLength(2);
+      // Both triples should have the same quoted triple as subject
+      expect(triples[0].subject).toBeInstanceOf(QuotedTriple);
+      expect(triples[1].subject).toBeInstanceOf(QuotedTriple);
+      // Verify predicates
+      expect(triples[0].predicate.value).toBe("http://example.org/source");
+      expect(triples[1].predicate.value).toBe("http://example.org/confidence");
+    });
+
+    it("should construct triples from multiple solutions with quoted triples", async () => {
+      // CONSTRUCT { <<( ?person :hasName ?name )>> :source :Database . }
+      // with two solutions
+      const quotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "person" },
+        predicate: { type: "iri", value: "http://example.org/hasName" },
+        object: { type: "variable", value: "name" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/source" },
+          object: { type: "iri", value: "http://example.org/Database" },
+        },
+      ];
+
+      const solution1 = new SolutionMapping();
+      solution1.set("person", new IRI("http://example.org/Alice"));
+      solution1.set("name", new Literal("Alice Smith"));
+
+      const solution2 = new SolutionMapping();
+      solution2.set("person", new IRI("http://example.org/Bob"));
+      solution2.set("name", new Literal("Bob Jones"));
+
+      const triples = await executor.execute(template, [solution1, solution2]);
+
+      expect(triples).toHaveLength(2);
+      // First triple from Alice
+      const qt1 = triples[0].subject as QuotedTriple;
+      expect((qt1.subject as IRI).value).toBe("http://example.org/Alice");
+      expect((qt1.object as Literal).value).toBe("Alice Smith");
+      // Second triple from Bob
+      const qt2 = triples[1].subject as QuotedTriple;
+      expect((qt2.subject as IRI).value).toBe("http://example.org/Bob");
+      expect((qt2.object as Literal).value).toBe("Bob Jones");
+    });
+
+    it("should eliminate duplicate quoted triples", async () => {
+      // Two identical solutions should produce only one triple
+      const quotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "person" },
+        predicate: { type: "iri", value: "http://example.org/hasName" },
+        object: { type: "variable", value: "name" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/source" },
+          object: { type: "iri", value: "http://example.org/Database" },
+        },
+      ];
+
+      const solution1 = new SolutionMapping();
+      solution1.set("person", new IRI("http://example.org/Alice"));
+      solution1.set("name", new Literal("Alice Smith"));
+
+      const solution2 = new SolutionMapping();
+      solution2.set("person", new IRI("http://example.org/Alice"));
+      solution2.set("name", new Literal("Alice Smith"));
+
+      const triples = await executor.execute(template, [solution1, solution2]);
+
+      expect(triples).toHaveLength(1);
+    });
+
+    it("should skip quoted triples with unbound variables", async () => {
+      const quotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "person" },
+        predicate: { type: "iri", value: "http://example.org/hasName" },
+        object: { type: "variable", value: "name" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/source" },
+          object: { type: "iri", value: "http://example.org/Database" },
+        },
+      ];
+
+      // Only person is bound, name is missing
+      const solution = new SolutionMapping();
+      solution.set("person", new IRI("http://example.org/Alice"));
+
+      const triples = await executor.execute(template, [solution]);
+
+      expect(triples).toHaveLength(0);
+    });
+
+    it("should handle quoted triples with blank nodes", async () => {
+      const quotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "blank", value: "b1" },
+        predicate: { type: "iri", value: "http://example.org/hasValue" },
+        object: { type: "variable", value: "value" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/certainty" },
+          object: { type: "literal", value: "high" },
+        },
+      ];
+
+      const solution = new SolutionMapping();
+      solution.set("value", new Literal("42"));
+
+      const triples = await executor.execute(template, [solution]);
+
+      expect(triples).toHaveLength(1);
+      const qt = triples[0].subject as QuotedTriple;
+      expect(qt.subject).toBeInstanceOf(BlankNode);
+      expect((qt.subject as BlankNode).id).toBe("b1");
+    });
+
+    it("should handle concrete quoted triples without variables", async () => {
+      // CONSTRUCT { <<( :Alice :knows :Bob )>> :source :Wikipedia . }
+      const quotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "iri", value: "http://example.org/Alice" },
+        predicate: { type: "iri", value: "http://example.org/knows" },
+        object: { type: "iri", value: "http://example.org/Bob" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/source" },
+          object: { type: "iri", value: "http://example.org/Wikipedia" },
+        },
+      ];
+
+      const solution = new SolutionMapping(); // Empty solution - no variables needed
+
+      const triples = await executor.execute(template, [solution]);
+
+      expect(triples).toHaveLength(1);
+      const qt = triples[0].subject as QuotedTriple;
+      expect((qt.subject as IRI).value).toBe("http://example.org/Alice");
+      expect(qt.predicate.value).toBe("http://example.org/knows");
+      expect((qt.object as IRI).value).toBe("http://example.org/Bob");
+    });
+
+    it("should handle quoted triple predicate as variable", async () => {
+      // CONSTRUCT { <<( ?s ?p ?o )>> :derived true . }
+      const quotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "s" },
+        predicate: { type: "variable", value: "p" },
+        object: { type: "variable", value: "o" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/derived" },
+          object: { type: "literal", value: "true", datatype: "http://www.w3.org/2001/XMLSchema#boolean" },
+        },
+      ];
+
+      const solution = new SolutionMapping();
+      solution.set("s", new IRI("http://example.org/Alice"));
+      solution.set("p", new IRI("http://example.org/friend"));
+      solution.set("o", new IRI("http://example.org/Bob"));
+
+      const triples = await executor.execute(template, [solution]);
+
+      expect(triples).toHaveLength(1);
+      const qt = triples[0].subject as QuotedTriple;
+      expect(qt.predicate.value).toBe("http://example.org/friend");
+    });
+
+    it("should reject non-IRI bound to quoted triple predicate variable", async () => {
+      // Variable in predicate position bound to non-IRI should skip
+      const quotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "s" },
+        predicate: { type: "variable", value: "p" },
+        object: { type: "variable", value: "o" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/derived" },
+          object: { type: "literal", value: "true" },
+        },
+      ];
+
+      const solution = new SolutionMapping();
+      solution.set("s", new IRI("http://example.org/Alice"));
+      solution.set("p", new Literal("not-an-iri")); // Invalid: predicate must be IRI
+      solution.set("o", new IRI("http://example.org/Bob"));
+
+      const triples = await executor.execute(template, [solution]);
+
+      // Should skip this pattern due to invalid predicate
+      expect(triples).toHaveLength(0);
+    });
+
+    it("should reject literal bound to quoted triple subject variable", async () => {
+      // Variable in subject position bound to Literal should skip
+      const quotedTriple: AlgebraQuotedTriple = {
+        type: "quoted",
+        subject: { type: "variable", value: "s" },
+        predicate: { type: "iri", value: "http://example.org/prop" },
+        object: { type: "variable", value: "o" },
+      };
+
+      const template: AlgebraTriple[] = [
+        {
+          subject: quotedTriple,
+          predicate: { type: "iri", value: "http://example.org/meta" },
+          object: { type: "literal", value: "value" },
+        },
+      ];
+
+      const solution = new SolutionMapping();
+      solution.set("s", new Literal("invalid-subject")); // Invalid: subject cannot be Literal
+      solution.set("o", new IRI("http://example.org/object"));
+
+      const triples = await executor.execute(template, [solution]);
+
+      // Should skip this pattern due to invalid subject
+      expect(triples).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Implement support for constructing RDF graphs with quoted triples using SPARQL CONSTRUCT queries (Issue #957). This enables generating RDF-Star output graphs from query results.

**Use case**: Transform regular RDF into RDF-Star by adding provenance metadata.

## Changes

### ConstructExecutor.ts
- Add `instantiateQuotedTriple()` method for handling quoted triple patterns in CONSTRUCT templates
- Add `instantiateQuotedSubject()` for validating subject positions (IRI, BlankNode, or nested QuotedTriple)
- Add `instantiateQuotedPredicate()` for IRI validation (predicates must be IRI)
- Add `instantiateQuotedObject()` for full object type support (IRI, BlankNode, Literal, or nested QuotedTriple)
- Support nested quoted triples for complex provenance graphs

### Type safety
- Validate that predicates bound to variables are IRIs
- Validate that subjects bound to variables are not Literals
- TypeScript exhaustiveness checking with `never` type guard

## Example SPARQL Supported

```sparql
PREFIX : <http://example.org/>

CONSTRUCT {
  <<( ?person :hasName ?name )>> :source :Database .
  <<( ?person :hasName ?name )>> :confidence "0.95"^^xsd:decimal .
}
WHERE {
  ?person :name ?name .
}
```

**Input:**
```turtle
:Alice :name "Alice Smith" .
:Bob :name "Bob Jones" .
```

**Output (RDF-Star):**
```turtle
<<( :Alice :hasName "Alice Smith" )>> :source :Database .
<<( :Alice :hasName "Alice Smith" )>> :confidence 0.95 .
<<( :Bob :hasName "Bob Jones" )>> :source :Database .
<<( :Bob :hasName "Bob Jones" )>> :confidence 0.95 .
```

## Test Plan

- [x] 12 new tests for quoted triples in CONSTRUCT templates
- [x] Tests for quoted triples in subject position
- [x] Tests for quoted triples in object position
- [x] Tests for nested quoted triples
- [x] Tests for multiple solutions with quoted triples
- [x] Tests for duplicate elimination
- [x] Tests for unbound variable handling
- [x] Tests for blank nodes in quoted triples
- [x] Tests for variable predicates in quoted triples
- [x] Tests for type validation (reject non-IRI predicates, reject Literal subjects)

Closes #957