### PR TITLE
feat: Implement ADJUST() function for timezone adjustment

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -642,6 +642,16 @@ export class FilterExecutor {
         const tzDate = this.getStringValue(this.evaluateExpression(expr.args[0], solution));
         return BuiltInFunctions.tz(tzDate);
 
+      // SPARQL 1.2 ADJUST function for timezone adjustment (Issue #976)
+      case "adjust": {
+        const adjustDateTime = this.evaluateExpression(expr.args[0], solution);
+        // Second argument (timezone) is optional
+        const adjustTimezone = expr.args.length > 1
+          ? this.evaluateExpression(expr.args[1], solution)
+          : undefined;
+        return BuiltInFunctions.adjust(adjustDateTime, adjustTimezone);
+      }
+
       case "now":
         return BuiltInFunctions.now();
 


### PR DESCRIPTION
## Summary

Implements the SPARQL 1.2 ADJUST function (Issue #976) that adjusts a dateTime value to a different timezone while preserving the instant in time.

### Features
- `ADJUST(dateTime, timezone)` - converts to target timezone
- `ADJUST(dateTime)` - removes timezone information  
- Supports xsd:dayTimeDuration format for timezone (e.g., "PT5H", "-PT5H30M")
- Handles date rollovers when crossing midnight
- Preserves milliseconds if present
- Validates timezone offset range (-14:00 to +14:00)

### Acceptance Criteria
- ✅ `ADJUST("2025-01-15T10:00:00Z", "PT5H")` returns `"2025-01-15T15:00:00+05:00"`
- ✅ `ADJUST("2025-01-15T10:00:00Z")` returns `"2025-01-15T10:00:00"` (no TZ)

### Test Plan
- [x] Unit tests for adjusting to different timezones (+05:00, -05:00, +05:30)
- [x] Unit tests for removing timezone (single arg)
- [x] Unit tests for date change when crossing midnight
- [x] Unit tests for Literal inputs
- [x] Unit tests for error handling (invalid dateTime, invalid timezone, out of range)
- [x] FilterExecutor integration to handle `ADJUST` function calls

Closes #976