### PR TITLE
feat: Implement annotation syntax for triple patterns (SPARQL 1.2)

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/SPARQLParser.ts
+++ b/packages/exocortex/src/infrastructure/sparql/SPARQLParser.ts
@@ -47,8 +47,11 @@ export class SPARQLParser {
   constructor(options?: SPARQLParserOptions) {
     // Enable SPARQL-Star (RDF-Star) support for triple patterns in subject/object positions
     // SPARQL 1.2 spec: https://w3c.github.io/sparql-12/spec/
+    // This enables:
+    // - Quoted triples: << :Alice :knows :Bob >>
+    // - Annotation syntax: ?s :knows ?o {| :source ?doc |} .
     this.parser = new sparqljs.Parser({ sparqlStar: true });
-    this.generator = new sparqljs.Generator();
+    this.generator = new sparqljs.Generator({ sparqlStar: true });
     this.caseWhenTransformer = new CaseWhenTransformer();
     this.prefixStarTransformer = new PrefixStarTransformer(options?.vocabularyResolver);
   }


### PR DESCRIPTION
## Summary

Implements SPARQL 1.2 annotation syntax `{| ... |}` for triple patterns, providing a shorthand for annotating triples directly in query patterns.

**SPARQL 1.2 annotation syntax:**
```sparql
?s :knows ?o {| :source ?doc |} .
```

**Equivalent to:**
```sparql
?s :knows ?o .
<<( ?s :knows ?o )>> :source ?doc .
```

## Changes

- Enable `sparqlStar` option for sparqljs Generator (was only enabled for Parser)
- Add comprehensive unit tests for annotation syntax (18 new tests)

## Test Coverage

- ✅ Basic annotation parsing
- ✅ Multiple predicates with semicolon separator
- ✅ Literal and IRI values in annotations
- ✅ Multiple annotated triple patterns
- ✅ Expansion to quoted triple patterns (verified AST structure)
- ✅ Round-trip serialization
- ✅ Combined with FILTER, OPTIONAL, ORDER BY
- ✅ CONSTRUCT and ASK queries
- ✅ Integration with PREFIX*

## Test Plan

- [x] All 72 SPARQLParser tests pass locally
- [x] Full unit test suite passes
- [ ] CI pipeline passes (build-and-test + e2e-tests)

Closes #979