### PR TITLE
feat(rdf): implement DirectionalLiteral data model extension

### DIFF
--- a/packages/exocortex/src/domain/models/rdf/Literal.ts
+++ b/packages/exocortex/src/domain/models/rdf/Literal.ts
@@ -3,12 +3,30 @@ import { IRI } from "./IRI";
 /** XSD string datatype URI for RDF 1.1 compatibility */
 const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
 
+/** Valid base directions for SPARQL 1.2 directional language tags */
+export type BaseDirection = "ltr" | "rtl";
+
+/**
+ * Result of parsing a directional language tag.
+ * Format: `lang--dir` (e.g., `ar--rtl`, `en--ltr`)
+ */
+export interface ParsedLanguageTag {
+  language: string;
+  direction?: BaseDirection;
+}
+
 export class Literal {
   private readonly _value: string;
   private readonly _datatype?: IRI;
   private readonly _language?: string;
+  private readonly _direction?: BaseDirection;
 
-  constructor(value: string, datatype?: IRI, language?: string) {
+  constructor(
+    value: string,
+    datatype?: IRI,
+    language?: string,
+    direction?: BaseDirection
+  ) {
     if (value.length === 0) {
       throw new Error("Literal value cannot be empty");
     }
@@ -17,9 +35,18 @@ export class Literal {
       throw new Error("Literal cannot have both datatype and language tag");
     }
 
+    if (direction && !language) {
+      throw new Error("Literal cannot have direction without language tag");
+    }
+
+    if (direction && direction !== "ltr" && direction !== "rtl") {
+      throw new Error('Direction must be "ltr" or "rtl"');
+    }
+
     this._value = value;
     this._datatype = datatype;
     this._language = language ? language.toLowerCase() : undefined;
+    this._direction = direction;
   }
 
   get value(): string {
@@ -35,12 +62,31 @@ export class Literal {
   }
 
   /**
+   * Get the base direction for bidirectional text.
+   * SPARQL 1.2 extension for directional language tags.
+   * @see https://w3c.github.io/rdf-dir-literal/
+   */
+  get direction(): BaseDirection | undefined {
+    return this._direction;
+  }
+
+  /**
+   * Check if this literal has a direction (is a directional literal).
+   */
+  hasDirection(): boolean {
+    return this._direction !== undefined;
+  }
+
+  /**
    * Check if this literal equals another literal.
    *
    * Per RDF 1.1 semantics, plain literals (no datatype) are equivalent to
    * xsd:string typed literals. This method treats them as equal.
    *
+   * For SPARQL 1.2 directional literals, direction must also match.
+   *
    * @see https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
+   * @see https://w3c.github.io/rdf-dir-literal/
    */
   equals(other: Literal): boolean {
     if (this._value !== other._value) {
@@ -49,6 +95,11 @@ export class Literal {
 
     // Language-tagged literals must match exactly
     if (this._language !== other._language) {
+      return false;
+    }
+
+    // Direction must match for directional literals (SPARQL 1.2)
+    if (this._direction !== other._direction) {
       return false;
     }
 
@@ -80,6 +131,10 @@ export class Literal {
     return this._datatype.value;
   }
 
+  /**
+   * Serialize the literal to a string representation.
+   * For directional literals, uses the format: `"value"@lang--dir`
+   */
   toString(): string {
     let result = `"${this._value}"`;
 
@@ -87,8 +142,89 @@ export class Literal {
       result += `^^<${this._datatype.value}>`;
     } else if (this._language) {
       result += `@${this._language}`;
+      if (this._direction) {
+        result += `--${this._direction}`;
+      }
     }
 
     return result;
   }
+}
+
+/**
+ * Parse a language tag that may include a direction suffix.
+ * SPARQL 1.2 directional language tags have format: `lang--dir`
+ *
+ * @param tag - The language tag to parse (e.g., "ar--rtl", "en", "en-US--ltr")
+ * @returns Parsed language and optional direction
+ *
+ * @example
+ * parseLanguageTag("ar--rtl") // { language: "ar", direction: "rtl" }
+ * parseLanguageTag("en") // { language: "en", direction: undefined }
+ * parseLanguageTag("en-US--ltr") // { language: "en-us", direction: "ltr" }
+ */
+export function parseLanguageTag(tag: string): ParsedLanguageTag {
+  const directionSeparator = "--";
+  const separatorIndex = tag.lastIndexOf(directionSeparator);
+
+  if (separatorIndex === -1) {
+    return { language: tag.toLowerCase() };
+  }
+
+  const potentialDirection = tag.substring(
+    separatorIndex + directionSeparator.length
+  );
+  const language = tag.substring(0, separatorIndex);
+
+  // Only recognize "ltr" and "rtl" as valid directions
+  if (potentialDirection === "ltr" || potentialDirection === "rtl") {
+    return {
+      language: language.toLowerCase(),
+      direction: potentialDirection,
+    };
+  }
+
+  // If not a valid direction, treat the whole thing as the language tag
+  return { language: tag.toLowerCase() };
+}
+
+/**
+ * Create a directional literal with language and direction.
+ * This is a factory function for creating SPARQL 1.2 directional literals.
+ *
+ * @param value - The literal value
+ * @param language - The language tag (e.g., "ar", "en-US")
+ * @param direction - The base direction ("ltr" or "rtl")
+ * @returns A new Literal with direction
+ *
+ * @example
+ * createDirectionalLiteral("مرحبا", "ar", "rtl")
+ * createDirectionalLiteral("Hello", "en", "ltr")
+ */
+export function createDirectionalLiteral(
+  value: string,
+  language: string,
+  direction?: BaseDirection
+): Literal {
+  return new Literal(value, undefined, language, direction);
+}
+
+/**
+ * Create a literal from a language tag string that may include direction.
+ * Parses the tag and creates the appropriate literal.
+ *
+ * @param value - The literal value
+ * @param languageTag - The full language tag (e.g., "ar--rtl", "en-US--ltr")
+ * @returns A new Literal, with direction if specified in the tag
+ *
+ * @example
+ * createLiteralFromLanguageTag("مرحبا", "ar--rtl")
+ * // Returns: Literal { value: "مرحبا", language: "ar", direction: "rtl" }
+ */
+export function createLiteralFromLanguageTag(
+  value: string,
+  languageTag: string
+): Literal {
+  const { language, direction } = parseLanguageTag(languageTag);
+  return new Literal(value, undefined, language, direction);
 }

--- a/packages/exocortex/src/domain/models/rdf/index.ts
+++ b/packages/exocortex/src/domain/models/rdf/index.ts
@@ -1,5 +1,12 @@
 export { IRI } from "./IRI";
-export { Literal } from "./Literal";
+export {
+  Literal,
+  type BaseDirection,
+  type ParsedLanguageTag,
+  parseLanguageTag,
+  createDirectionalLiteral,
+  createLiteralFromLanguageTag,
+} from "./Literal";
 export { BlankNode } from "./BlankNode";
 export { Namespace } from "./Namespace";
 export { Triple, type Subject, type Predicate, type Object } from "./Triple";

--- a/packages/exocortex/tests/unit/domain/rdf/Literal.test.ts
+++ b/packages/exocortex/tests/unit/domain/rdf/Literal.test.ts
@@ -1,4 +1,9 @@
-import { Literal } from "../../../../src/domain/models/rdf/Literal";
+import {
+  Literal,
+  parseLanguageTag,
+  createDirectionalLiteral,
+  createLiteralFromLanguageTag,
+} from "../../../../src/domain/models/rdf/Literal";
 import { IRI } from "../../../../src/domain/models/rdf/IRI";
 
 describe("Literal", () => {
@@ -151,6 +156,166 @@ describe("Literal", () => {
       const datatype = new IRI("http://www.w3.org/2001/XMLSchema#dateTime");
       const literal = new Literal("2025-11-01T00:00:00Z", datatype);
       expect(literal.value).toBe("2025-11-01T00:00:00Z");
+    });
+  });
+
+  describe("SPARQL 1.2 directional literals", () => {
+    describe("constructor with direction", () => {
+      it("should create directional literal with rtl direction", () => {
+        const literal = new Literal("مرحبا", undefined, "ar", "rtl");
+        expect(literal.value).toBe("مرحبا");
+        expect(literal.language).toBe("ar");
+        expect(literal.direction).toBe("rtl");
+        expect(literal.hasDirection()).toBe(true);
+      });
+
+      it("should create directional literal with ltr direction", () => {
+        const literal = new Literal("Hello", undefined, "en", "ltr");
+        expect(literal.value).toBe("Hello");
+        expect(literal.language).toBe("en");
+        expect(literal.direction).toBe("ltr");
+        expect(literal.hasDirection()).toBe(true);
+      });
+
+      it("should create literal with language but no direction", () => {
+        const literal = new Literal("Hello", undefined, "en");
+        expect(literal.language).toBe("en");
+        expect(literal.direction).toBeUndefined();
+        expect(literal.hasDirection()).toBe(false);
+      });
+
+      it("should throw error when direction provided without language", () => {
+        expect(() => new Literal("Hello", undefined, undefined, "ltr")).toThrow(
+          "Literal cannot have direction without language tag"
+        );
+      });
+
+    });
+
+    describe("equals with direction", () => {
+      it("should return true for literals with same direction", () => {
+        const lit1 = new Literal("مرحبا", undefined, "ar", "rtl");
+        const lit2 = new Literal("مرحبا", undefined, "ar", "rtl");
+        expect(lit1.equals(lit2)).toBe(true);
+      });
+
+      it("should return false for same value/language but different direction", () => {
+        const lit1 = new Literal("Hello", undefined, "en", "ltr");
+        const lit2 = new Literal("Hello", undefined, "en", "rtl");
+        expect(lit1.equals(lit2)).toBe(false);
+      });
+
+      it("should return false when one has direction and other does not", () => {
+        const withDir = new Literal("Hello", undefined, "en", "ltr");
+        const withoutDir = new Literal("Hello", undefined, "en");
+        expect(withDir.equals(withoutDir)).toBe(false);
+        expect(withoutDir.equals(withDir)).toBe(false);
+      });
+    });
+
+    describe("toString with direction", () => {
+      it("should serialize directional literal with lang--dir format", () => {
+        const literal = new Literal("مرحبا", undefined, "ar", "rtl");
+        expect(literal.toString()).toBe('"مرحبا"@ar--rtl');
+      });
+
+      it("should serialize ltr directional literal", () => {
+        const literal = new Literal("Hello", undefined, "en", "ltr");
+        expect(literal.toString()).toBe('"Hello"@en--ltr');
+      });
+
+      it("should not include direction in toString if not present", () => {
+        const literal = new Literal("Hello", undefined, "en");
+        expect(literal.toString()).toBe('"Hello"@en');
+      });
+    });
+  });
+
+  describe("parseLanguageTag", () => {
+    it("should parse simple language tag without direction", () => {
+      const result = parseLanguageTag("en");
+      expect(result.language).toBe("en");
+      expect(result.direction).toBeUndefined();
+    });
+
+    it("should parse language tag with rtl direction", () => {
+      const result = parseLanguageTag("ar--rtl");
+      expect(result.language).toBe("ar");
+      expect(result.direction).toBe("rtl");
+    });
+
+    it("should parse language tag with ltr direction", () => {
+      const result = parseLanguageTag("en--ltr");
+      expect(result.language).toBe("en");
+      expect(result.direction).toBe("ltr");
+    });
+
+    it("should parse complex language tag with direction", () => {
+      const result = parseLanguageTag("en-US--ltr");
+      expect(result.language).toBe("en-us");
+      expect(result.direction).toBe("ltr");
+    });
+
+    it("should normalize language to lowercase", () => {
+      const result = parseLanguageTag("EN-US--ltr");
+      expect(result.language).toBe("en-us");
+    });
+
+    it("should treat invalid direction as part of language tag", () => {
+      const result = parseLanguageTag("en--invalid");
+      expect(result.language).toBe("en--invalid");
+      expect(result.direction).toBeUndefined();
+    });
+
+    it("should handle tag with multiple dashes in language part", () => {
+      const result = parseLanguageTag("zh-Hans-CN--ltr");
+      expect(result.language).toBe("zh-hans-cn");
+      expect(result.direction).toBe("ltr");
+    });
+  });
+
+  describe("createDirectionalLiteral", () => {
+    it("should create directional literal with rtl", () => {
+      const literal = createDirectionalLiteral("مرحبا", "ar", "rtl");
+      expect(literal.value).toBe("مرحبا");
+      expect(literal.language).toBe("ar");
+      expect(literal.direction).toBe("rtl");
+    });
+
+    it("should create directional literal with ltr", () => {
+      const literal = createDirectionalLiteral("Hello", "en", "ltr");
+      expect(literal.value).toBe("Hello");
+      expect(literal.language).toBe("en");
+      expect(literal.direction).toBe("ltr");
+    });
+
+    it("should create literal without direction when not specified", () => {
+      const literal = createDirectionalLiteral("Hello", "en");
+      expect(literal.language).toBe("en");
+      expect(literal.direction).toBeUndefined();
+    });
+  });
+
+  describe("createLiteralFromLanguageTag", () => {
+    it("should create literal from tag with direction", () => {
+      const literal = createLiteralFromLanguageTag("مرحبا", "ar--rtl");
+      expect(literal.value).toBe("مرحبا");
+      expect(literal.language).toBe("ar");
+      expect(literal.direction).toBe("rtl");
+    });
+
+    it("should create literal from tag without direction", () => {
+      const literal = createLiteralFromLanguageTag("Hello", "en");
+      expect(literal.value).toBe("Hello");
+      expect(literal.language).toBe("en");
+      expect(literal.direction).toBeUndefined();
+    });
+
+    it("should create literal from complex tag with direction", () => {
+      const literal = createLiteralFromLanguageTag("你好", "zh-Hans--ltr");
+      expect(literal.value).toBe("你好");
+      expect(literal.language).toBe("zh-hans");
+      expect(literal.direction).toBe("ltr");
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements SPARQL 1.2 directional language tag support for the `Literal` class as described in Issue #985.

### Changes

- **Literal class extension**:
  - Added `direction` property (`'ltr'` | `'rtl'`) for bidirectional text support
  - Added `hasDirection()` method to check if literal has direction
  - Updated `equals()` to compare direction for directional literals
  - Updated `toString()` to serialize format `"value"@lang--dir`

- **Helper functions**:
  - `parseLanguageTag(tag)` - Parses language tags with optional direction suffix
  - `createDirectionalLiteral(value, language, direction)` - Factory for directional literals
  - `createLiteralFromLanguageTag(value, languageTag)` - Creates literal from composite tag

- **Type exports**:
  - `BaseDirection` type (`'ltr' | 'rtl'`)
  - `ParsedLanguageTag` interface

### Test Coverage

- 23 new unit tests covering:
  - Constructor with direction
  - Equality comparison with direction
  - toString serialization
  - parseLanguageTag parsing
  - Factory functions

All tests pass (45 total for Literal.test.ts).

### Acceptance Criteria

- [x] `createDirectionalLiteral("مرحبا", "ar", "rtl")` creates valid DirectionalLiteral
- [x] `parseLanguageTag("ar--rtl")` returns `{ language: "ar", direction: "rtl" }`
- [x] Unit test: create directional literal
- [x] Unit test: parse language tag with direction
- [x] Unit test: serialize directional literal
- [x] Unit test: equality comparison with direction

### Notes

This is a prerequisite for implementing SPARQL 1.2 functions:
- `LANGDIR()` - Get direction of literal
- `STRLANGDIR()` - Create literal with language and direction  
- `hasLANGDIR()` - Check if literal has direction

Closes #985