### PR TITLE
feat: implement xsd:time subtraction operator

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -280,6 +280,7 @@ export class FilterExecutor {
    * Supports:
    * - Numeric arithmetic
    * - xsd:date - xsd:date = xsd:dayTimeDuration (day-only format like "P14D")
+   * - xsd:time - xsd:time = xsd:dayTimeDuration
    * - xsd:dateTime - xsd:dateTime = xsd:dayTimeDuration
    * - xsd:dateTime +/- xsd:dayTimeDuration = xsd:dateTime
    * - xsd:dayTimeDuration +/- xsd:dayTimeDuration = xsd:dayTimeDuration
@@ -294,6 +295,11 @@ export class FilterExecutor {
     // Must check before dateTime since isDateTimeValue also matches dates
     if (expr.operator === "-" && this.isDateValue(left) && this.isDateValue(right)) {
       return BuiltInFunctions.dateDiff(left, right);
+    }
+
+    // Special handling for xsd:time - xsd:time = dayTimeDuration
+    if (expr.operator === "-" && this.isTimeValue(left) && this.isTimeValue(right)) {
+      return BuiltInFunctions.timeDiff(left, right);
     }
 
     // Special handling for dateTime - dateTime = dayTimeDuration
@@ -451,6 +457,18 @@ export class FilterExecutor {
       const datatypeValue = value.datatype?.value || "";
       // Only match xsd:date, NOT xsd:dateTime
       return datatypeValue === "http://www.w3.org/2001/XMLSchema#date";
+    }
+    return false;
+  }
+
+  /**
+   * Check if a value represents an xsd:time.
+   * Used for time subtraction (time - time = dayTimeDuration).
+   */
+  private isTimeValue(value: any): boolean {
+    if (value instanceof Literal) {
+      const datatypeValue = value.datatype?.value || "";
+      return datatypeValue === "http://www.w3.org/2001/XMLSchema#time";
     }
     return false;
   }


### PR DESCRIPTION
## Summary
Implement `xsd:time - xsd:time = xsd:dayTimeDuration` per SPARQL 1.2 specification.

### Changes
- Add `timeDiff()` function in `BuiltInFunctions.ts` for time subtraction
- Add `isTime()` type check function
- Add `isTimeValue()` in `FilterExecutor.ts` for arithmetic expression handling
- Add `parseXSDTime()` private helper for parsing xsd:time strings

### Behavior
```sparql
"14:30:00"^^xsd:time - "10:00:00"^^xsd:time  → "PT4H30M"^^xsd:dayTimeDuration
"08:00:00"^^xsd:time - "23:00:00"^^xsd:time  → "-PT15H"^^xsd:dayTimeDuration
"12:00:00"^^xsd:time - "12:00:00"^^xsd:time  → "PT0S"^^xsd:dayTimeDuration
```

### Features Implemented
- ✅ Same time → PT0S
- ✅ Morning - evening → negative duration
- ✅ With seconds/milliseconds precision
- ✅ Timezone handling (Z, +offset, -offset)
- ✅ 24:00:00 end-of-day support
- ✅ Error handling for non-time operands

### Test Coverage
- 27 unit tests for `isTime()` and `timeDiff()`
- 6 integration tests in FilterExecutor

Closes #963

## Test Plan
- [x] Run unit tests: `npm test -- packages/exocortex/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.test.ts -t "xsd:time"`
- [x] Build passes: `npm run build`
- [ ] CI pipeline passes