### PR TITLE
feat: Parse directional language tag syntax in literals

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/DirectionalLangTagTransformer.ts
+++ b/packages/exocortex/src/infrastructure/sparql/DirectionalLangTagTransformer.ts
@@ -1,0 +1,123 @@
+/**
+ * DirectionalLangTagTransformer - Transforms SPARQL 1.2 directional language tags.
+ *
+ * SPARQL 1.2 introduces directional language tags with the syntax `@lang--dir`
+ * where `dir` is either "ltr" (left-to-right) or "rtl" (right-to-left).
+ *
+ * Since sparqljs doesn't support this syntax natively, this transformer:
+ * 1. Extracts direction info from language tags
+ * 2. Transforms the query to use regular language tags for parsing
+ * 3. Stores direction information for post-processing
+ *
+ * Examples:
+ * - `"مرحبا"@ar--rtl` → `"مرحبا"@ar` (with direction="rtl" stored)
+ * - `"Hello"@en--ltr` → `"Hello"@en` (with direction="ltr" stored)
+ * - `"Bonjour"@fr` → `"Bonjour"@fr` (no change, no direction)
+ *
+ * @see https://w3c.github.io/rdf-dir-literal/
+ */
+
+export type BaseDirection = "ltr" | "rtl";
+
+export interface DirectionMapping {
+  /** The language tag without direction suffix */
+  language: string;
+  /** The direction extracted from the tag */
+  direction: BaseDirection;
+  /** Original full tag including direction */
+  originalTag: string;
+}
+
+export class DirectionalLangTagTransformer {
+  /**
+   * Regex to find directional language tags.
+   * Matches patterns like @ar--rtl or @en-US--ltr after a string literal.
+   *
+   * Pattern breakdown:
+   * - (`["'])  - Opening quote (captured for reference)
+   * - ((?:[^\\]|\\.)*?)  - String content (non-greedy, handles escapes)
+   * - \1  - Matching closing quote
+   * - @  - Language tag marker
+   * - ([a-zA-Z]+(?:-[a-zA-Z0-9]+)*)  - Language tag (e.g., en, ar, en-US)
+   * - --  - Direction separator
+   * - (ltr|rtl)  - Direction value
+   */
+  private static readonly DIRECTIONAL_TAG_REGEX =
+    /(["'])((?:[^\\]|\\.)*?)\1@([a-zA-Z]+(?:-[a-zA-Z0-9]+)*)--(ltr|rtl)/g;
+
+  /**
+   * Stores mappings from transformed language tags to their original direction info.
+   * Key: normalized lowercase language tag, Value: direction
+   */
+  private directionMappings: Map<string, BaseDirection> = new Map();
+
+  /**
+   * Transform a SPARQL query by converting directional language tags to regular tags.
+   *
+   * @param query - The SPARQL query string with potential directional language tags
+   * @returns The transformed query with direction suffixes removed
+   */
+  transform(query: string): string {
+    this.directionMappings.clear();
+
+    return query.replace(
+      DirectionalLangTagTransformer.DIRECTIONAL_TAG_REGEX,
+      (_match, quote, stringContent, langTag, direction) => {
+        // Store the direction mapping
+        const normalizedLang = langTag.toLowerCase();
+        this.directionMappings.set(normalizedLang, direction as BaseDirection);
+
+        // Return the literal without direction suffix
+        return `${quote}${stringContent}${quote}@${langTag}`;
+      }
+    );
+  }
+
+  /**
+   * Check if a language tag has a direction mapping stored.
+   *
+   * @param languageTag - The language tag to check (will be normalized to lowercase)
+   * @returns The direction if found, undefined otherwise
+   */
+  getDirection(languageTag: string): BaseDirection | undefined {
+    return this.directionMappings.get(languageTag.toLowerCase());
+  }
+
+  /**
+   * Get all stored direction mappings.
+   *
+   * @returns Map of language tags to their directions
+   */
+  getAllMappings(): Map<string, BaseDirection> {
+    return new Map(this.directionMappings);
+  }
+
+  /**
+   * Check if the query contains any directional language tags.
+   *
+   * @param query - The SPARQL query string to check
+   * @returns true if the query contains directional language tags
+   */
+  hasDirectionalTags(query: string): boolean {
+    DirectionalLangTagTransformer.DIRECTIONAL_TAG_REGEX.lastIndex = 0;
+    return DirectionalLangTagTransformer.DIRECTIONAL_TAG_REGEX.test(query);
+  }
+
+  /**
+   * Clear all stored direction mappings.
+   * Call this before processing a new query.
+   */
+  clearMappings(): void {
+    this.directionMappings.clear();
+  }
+}
+
+/**
+ * Error thrown when directional language tag transformation fails.
+ */
+export class DirectionalLangTagTransformerError extends Error {
+  constructor(message: string) {
+    super(`Directional language tag transformation error: ${message}`);
+    this.name = "DirectionalLangTagTransformerError";
+  }
+}

--- a/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -120,6 +120,13 @@ export interface Literal {
   value: string;
   datatype?: string;
   language?: string;
+  /**
+   * Base direction for bidirectional text (SPARQL 1.2).
+   * Used with language-tagged literals for directional language tags.
+   * Format: `"text"@lang--dir` where dir is "ltr" or "rtl".
+   * @see https://w3c.github.io/rdf-dir-literal/
+   */
+  direction?: "ltr" | "rtl";
 }
 
 export interface BlankNode {

--- a/packages/exocortex/src/infrastructure/sparql/executors/BGPExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/BGPExecutor.ts
@@ -347,6 +347,7 @@ export class BGPExecutor {
         if (pattern.value !== term.value) return false;
         if (pattern.datatype !== term.datatype?.value) return false;
         if (pattern.language !== term.language) return false;
+        if (pattern.direction !== term.direction) return false;
         return true;
       case "blank":
         return term instanceof BlankNode && pattern.value === term.id;
@@ -551,7 +552,8 @@ export class BGPExecutor {
         return new Literal(
           element.value,
           element.datatype ? new IRI(element.datatype) : undefined,
-          element.language
+          element.language,
+          element.direction
         );
       case "blank":
         return new BlankNode(element.value);
@@ -580,6 +582,7 @@ export class BGPExecutor {
         value: term.value,
         datatype: term.datatype?.value,
         language: term.language,
+        direction: term.direction,
       };
     } else if (term instanceof BlankNode) {
       return {

--- a/packages/exocortex/src/infrastructure/sparql/executors/ValuesExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/ValuesExecutor.ts
@@ -94,7 +94,8 @@ export class ValuesExecutor {
       return new Literal(
         term.value,
         term.datatype ? new IRI(term.datatype) : undefined,
-        term.language
+        term.language,
+        term.direction
       );
     }
     throw new ValuesExecutorError(`Unknown term type: ${(term as any).type}`);

--- a/packages/exocortex/tests/unit/infrastructure/sparql/DirectionalLangTagTransformer.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/DirectionalLangTagTransformer.test.ts
@@ -1,0 +1,164 @@
+import { DirectionalLangTagTransformer } from "../../../../src/infrastructure/sparql/DirectionalLangTagTransformer";
+
+describe("DirectionalLangTagTransformer", () => {
+  let transformer: DirectionalLangTagTransformer;
+
+  beforeEach(() => {
+    transformer = new DirectionalLangTagTransformer();
+  });
+
+  describe("transform", () => {
+    it("should transform @ar--rtl to @ar and store direction", () => {
+      const query = `SELECT * WHERE { ?s ?p "مرحبا"@ar--rtl }`;
+      const result = transformer.transform(query);
+
+      expect(result).toBe(`SELECT * WHERE { ?s ?p "مرحبا"@ar }`);
+      expect(transformer.getDirection("ar")).toBe("rtl");
+    });
+
+    it("should transform @en--ltr to @en and store direction", () => {
+      const query = `SELECT * WHERE { ?s ?p "Hello"@en--ltr }`;
+      const result = transformer.transform(query);
+
+      expect(result).toBe(`SELECT * WHERE { ?s ?p "Hello"@en }`);
+      expect(transformer.getDirection("en")).toBe("ltr");
+    });
+
+    it("should transform @he--rtl to @he and store direction", () => {
+      const query = `SELECT * WHERE { ?s ?p "שלום"@he--rtl }`;
+      const result = transformer.transform(query);
+
+      expect(result).toBe(`SELECT * WHERE { ?s ?p "שלום"@he }`);
+      expect(transformer.getDirection("he")).toBe("rtl");
+    });
+
+    it("should handle complex language tags with region codes", () => {
+      const query = `SELECT * WHERE { ?s ?p "Hello"@en-US--ltr }`;
+      const result = transformer.transform(query);
+
+      expect(result).toBe(`SELECT * WHERE { ?s ?p "Hello"@en-US }`);
+      expect(transformer.getDirection("en-us")).toBe("ltr");
+    });
+
+    it("should handle multiple directional literals in same query", () => {
+      const query = `SELECT * WHERE {
+        ?s ?p "مرحبا"@ar--rtl .
+        ?s ?q "Hello"@en--ltr .
+      }`;
+      const result = transformer.transform(query);
+
+      expect(result).toContain(`"مرحبا"@ar`);
+      expect(result).toContain(`"Hello"@en`);
+      expect(result).not.toContain("--rtl");
+      expect(result).not.toContain("--ltr");
+      expect(transformer.getDirection("ar")).toBe("rtl");
+      expect(transformer.getDirection("en")).toBe("ltr");
+    });
+
+    it("should not transform regular language tags without direction", () => {
+      const query = `SELECT * WHERE { ?s ?p "Bonjour"@fr }`;
+      const result = transformer.transform(query);
+
+      expect(result).toBe(query);
+      expect(transformer.getDirection("fr")).toBeUndefined();
+    });
+
+    it("should handle single-quoted strings", () => {
+      const query = `SELECT * WHERE { ?s ?p 'مرحبا'@ar--rtl }`;
+      const result = transformer.transform(query);
+
+      expect(result).toBe(`SELECT * WHERE { ?s ?p 'مرحبا'@ar }`);
+      expect(transformer.getDirection("ar")).toBe("rtl");
+    });
+
+    it("should handle escaped quotes in strings", () => {
+      const query = `SELECT * WHERE { ?s ?p "Hello \\"world\\""@en--ltr }`;
+      const result = transformer.transform(query);
+
+      expect(result).toBe(`SELECT * WHERE { ?s ?p "Hello \\"world\\""@en }`);
+      expect(transformer.getDirection("en")).toBe("ltr");
+    });
+
+    it("should normalize language tag to lowercase for storage", () => {
+      const query = `SELECT * WHERE { ?s ?p "Hello"@EN-US--ltr }`;
+      transformer.transform(query);
+
+      // Direction should be retrievable with lowercase
+      expect(transformer.getDirection("en-us")).toBe("ltr");
+      expect(transformer.getDirection("EN-US")).toBe("ltr");
+    });
+  });
+
+  describe("hasDirectionalTags", () => {
+    it("should return true for queries with directional tags", () => {
+      const query = `SELECT * WHERE { ?s ?p "مرحبا"@ar--rtl }`;
+      expect(transformer.hasDirectionalTags(query)).toBe(true);
+    });
+
+    it("should return false for queries without directional tags", () => {
+      const query = `SELECT * WHERE { ?s ?p "Hello"@en }`;
+      expect(transformer.hasDirectionalTags(query)).toBe(false);
+    });
+
+    it("should return false for empty query", () => {
+      expect(transformer.hasDirectionalTags("")).toBe(false);
+    });
+  });
+
+  describe("getAllMappings", () => {
+    it("should return all stored direction mappings", () => {
+      const query = `SELECT * WHERE {
+        ?s ?p "مرحبا"@ar--rtl .
+        ?s ?q "Hello"@en--ltr .
+        ?s ?r "שלום"@he--rtl .
+      }`;
+      transformer.transform(query);
+
+      const mappings = transformer.getAllMappings();
+      expect(mappings.size).toBe(3);
+      expect(mappings.get("ar")).toBe("rtl");
+      expect(mappings.get("en")).toBe("ltr");
+      expect(mappings.get("he")).toBe("rtl");
+    });
+
+    it("should return a copy of mappings (not internal reference)", () => {
+      const query = `SELECT * WHERE { ?s ?p "Hello"@en--ltr }`;
+      transformer.transform(query);
+
+      const mappings1 = transformer.getAllMappings();
+      const mappings2 = transformer.getAllMappings();
+      expect(mappings1).not.toBe(mappings2);
+      expect(mappings1).toEqual(mappings2);
+    });
+  });
+
+  describe("clearMappings", () => {
+    it("should clear all stored direction mappings", () => {
+      const query = `SELECT * WHERE { ?s ?p "Hello"@en--ltr }`;
+      transformer.transform(query);
+
+      expect(transformer.getDirection("en")).toBe("ltr");
+
+      transformer.clearMappings();
+
+      expect(transformer.getDirection("en")).toBeUndefined();
+      expect(transformer.getAllMappings().size).toBe(0);
+    });
+  });
+
+  describe("multiple transform calls", () => {
+    it("should clear previous mappings on new transform call", () => {
+      const query1 = `SELECT * WHERE { ?s ?p "مرحبا"@ar--rtl }`;
+      transformer.transform(query1);
+      expect(transformer.getDirection("ar")).toBe("rtl");
+
+      const query2 = `SELECT * WHERE { ?s ?p "Hello"@en--ltr }`;
+      transformer.transform(query2);
+
+      // Previous mapping should be cleared
+      expect(transformer.getDirection("ar")).toBeUndefined();
+      // New mapping should be present
+      expect(transformer.getDirection("en")).toBe("ltr");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements SPARQL 1.2 directional language tags support for bidirectional text rendering.

### Changes
- Add `DirectionalLangTagTransformer` class to parse `@lang--dir` syntax (e.g., `@ar--rtl`, `@en--ltr`)
- Update `SPARQLParser` to transform directional tags before sparqljs parsing
- Add `direction` field to `Literal` interface in `AlgebraOperation`
- Update `AlgebraTranslator` to pass direction mappings to literal elements
- Update `BGPExecutor` and `ValuesExecutor` to handle direction in Literals

### Supported Syntax
- `"مرحبا"@ar--rtl` - Arabic, right-to-left
- `"Hello"@en--ltr` - English, left-to-right  
- `"שלום"@he--rtl` - Hebrew, right-to-left

### Backwards Compatibility
Regular language tags (e.g., `@en`, `@fr`) continue to work without changes.

## Test Plan
- [x] Unit tests for `DirectionalLangTagTransformer` (16 tests)
- [x] Unit tests for `SPARQLParser` directional language tag support (12 tests)
- [x] Unit tests for `AlgebraTranslator` directional language tag handling (6 tests)
- [x] Verify all existing tests pass
- [x] Build passes without TypeScript errors

Closes #991