### PR TITLE
feat: parse triple term syntax <<( s p o )>> for RDF-Star

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/TripleTermTransformer.ts
+++ b/packages/exocortex/src/infrastructure/sparql/TripleTermTransformer.ts
@@ -1,0 +1,319 @@
+/**
+ * TripleTermTransformer - Transforms SPARQL 1.2 triple term syntax to standard RDF-Star syntax.
+ *
+ * SPARQL 1.2 introduces an alternative triple term syntax using parentheses:
+ * `<<( subject predicate object )>>` which is equivalent to `<< subject predicate object >>`.
+ *
+ * The underlying sparqljs parser supports the standard `<< >>` syntax when sparqlStar mode
+ * is enabled, but not the parenthesized `<<( )>>` variant.
+ *
+ * This transformer enables the parenthesized syntax by converting:
+ *
+ * ```sparql
+ * FILTER(?triple = <<( :Alice :knows :Bob )>>)
+ * ```
+ *
+ * to:
+ *
+ * ```sparql
+ * FILTER(?triple = << :Alice :knows :Bob >>)
+ * ```
+ *
+ * Supports:
+ * - Basic triple terms: <<( :s :p :o )>>
+ * - Triple terms with variables: <<( ?s :p ?o )>>
+ * - Nested triple terms: <<( <<( :s :p :o )>> :source :doc )>>
+ * - Multiple triple terms in a query
+ * - Triple terms in FILTER, BIND, SELECT expressions, and graph patterns
+ *
+ * @see https://w3c.github.io/sparql-12/spec/ - SPARQL 1.2 Specification
+ * @see https://w3c.github.io/rdf-star/cg-spec/ - RDF-Star Specification
+ */
+export class TripleTermTransformer {
+  /**
+   * Transform all triple term syntax `<<( s p o )>>` to standard `<< s p o >>`.
+   *
+   * @param query - The SPARQL query string that may contain <<( )>> syntax
+   * @returns The transformed query with <<( )>> replaced by << >>
+   * @throws TripleTermTransformerError if syntax is malformed
+   */
+  transform(query: string): string {
+    // Keep transforming until no more <<( patterns are found
+    // (handles nested triple terms)
+    let result = query;
+    let transformed: string;
+    let iterationCount = 0;
+    const maxIterations = 100; // Prevent infinite loops
+
+    do {
+      transformed = result;
+      result = this.transformSinglePass(result);
+      iterationCount++;
+      if (iterationCount > maxIterations) {
+        throw new TripleTermTransformerError(
+          "Too many nested triple terms (max 100 iterations)"
+        );
+      }
+    } while (result !== transformed);
+
+    return result;
+  }
+
+  /**
+   * Check if a query contains triple term syntax that needs transformation.
+   * This method correctly handles string literals (won't match <<( inside strings).
+   *
+   * @param query - The SPARQL query to check
+   * @returns true if the query contains <<( )>> syntax
+   */
+  hasTripleTermSyntax(query: string): boolean {
+    // Use findTripleTermPositions which handles string literals correctly
+    return this.findTripleTermPositions(query).length > 0;
+  }
+
+  /**
+   * Perform a single pass of triple term transformation.
+   * Finds and transforms the innermost triple terms first.
+   */
+  private transformSinglePass(query: string): string {
+    // Find all <<( positions (skipping those inside strings)
+    const positions = this.findTripleTermPositions(query);
+
+    if (positions.length === 0) {
+      return query;
+    }
+
+    let result = query;
+
+    // Process in reverse order to maintain valid positions
+    for (let i = positions.length - 1; i >= 0; i--) {
+      const startPos = positions[i];
+      const tripleTerm = this.extractTripleTerm(result, startPos);
+      if (tripleTerm) {
+        const standardSyntax = this.convertToStandardSyntax(tripleTerm.content);
+        result =
+          result.substring(0, startPos) +
+          standardSyntax +
+          result.substring(startPos + tripleTerm.length);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Find all <<( positions that are NOT inside string literals.
+   */
+  private findTripleTermPositions(query: string): number[] {
+    const positions: number[] = [];
+    let pos = 0;
+
+    while (pos < query.length) {
+      // Skip string literals (single quoted)
+      if (query[pos] === "'") {
+        pos = this.skipStringLiteral(query, pos, "'");
+        continue;
+      }
+
+      // Skip string literals (double quoted)
+      if (query[pos] === '"') {
+        pos = this.skipStringLiteral(query, pos, '"');
+        continue;
+      }
+
+      // Check for <<( pattern
+      if (
+        query.substring(pos, pos + 2) === "<<" &&
+        this.isParenthesizedTripleTerm(query, pos)
+      ) {
+        positions.push(pos);
+        pos += 2;
+        continue;
+      }
+
+      pos++;
+    }
+
+    return positions;
+  }
+
+  /**
+   * Skip over a string literal and return the position after the closing quote.
+   */
+  private skipStringLiteral(query: string, pos: number, quote: string): number {
+    // Check for long string literal (triple quotes)
+    const tripleQuote = quote.repeat(3);
+    if (query.substring(pos, pos + 3) === tripleQuote) {
+      pos += 3;
+      while (pos < query.length) {
+        if (query.substring(pos, pos + 3) === tripleQuote) {
+          return pos + 3;
+        }
+        if (query[pos] === "\\") pos++;
+        pos++;
+      }
+      return pos;
+    }
+
+    // Single quote string
+    pos++;
+    while (pos < query.length && query[pos] !== quote) {
+      if (query[pos] === "\\") pos++; // Skip escaped characters
+      pos++;
+    }
+    return pos + 1; // Skip closing quote
+  }
+
+  /**
+   * Check if the << at position is followed by ( (with optional whitespace).
+   */
+  private isParenthesizedTripleTerm(query: string, pos: number): boolean {
+    let checkPos = pos + 2; // After <<
+    // Skip whitespace
+    while (checkPos < query.length && /\s/.test(query[checkPos])) {
+      checkPos++;
+    }
+    return query[checkPos] === "(";
+  }
+
+  /**
+   * Extract a complete <<( ... )>> triple term expression from the query string.
+   */
+  private extractTripleTerm(
+    query: string,
+    startPos: number
+  ): { content: string; length: number } | null {
+    // Skip << and find opening (
+    let pos = startPos + 2;
+    while (pos < query.length && /\s/.test(query[pos])) {
+      pos++;
+    }
+
+    if (query[pos] !== "(") {
+      return null;
+    }
+
+    // Find matching )>> accounting for nested structures
+    pos++; // Skip opening (
+    let depth = 1;
+
+    while (pos < query.length && depth > 0) {
+      // Skip strings
+      if (query[pos] === "'" || query[pos] === '"') {
+        pos = this.skipStringLiteral(query, pos, query[pos]);
+        continue;
+      }
+
+      // Check for nested <<(
+      if (
+        query.substring(pos, pos + 2) === "<<" &&
+        this.isParenthesizedTripleTerm(query, pos)
+      ) {
+        // Skip to the opening ( of nested term and increase depth
+        pos += 2;
+        while (pos < query.length && /\s/.test(query[pos])) {
+          pos++;
+        }
+        if (query[pos] === "(") {
+          depth++;
+          pos++;
+        }
+        continue;
+      }
+
+      // Check for standard << (without parentheses) - skip over it
+      if (query.substring(pos, pos + 2) === "<<") {
+        pos += 2;
+        // Find matching >>
+        let nestedDepth = 1;
+        while (pos < query.length && nestedDepth > 0) {
+          if (query[pos] === "'" || query[pos] === '"') {
+            pos = this.skipStringLiteral(query, pos, query[pos]);
+            continue;
+          }
+          if (query.substring(pos, pos + 2) === "<<") {
+            nestedDepth++;
+            pos += 2;
+            continue;
+          }
+          if (query.substring(pos, pos + 2) === ">>") {
+            nestedDepth--;
+            pos += 2;
+            continue;
+          }
+          pos++;
+        }
+        continue;
+      }
+
+      // Track parentheses
+      if (query[pos] === "(") {
+        depth++;
+        pos++;
+        continue;
+      }
+
+      // Check for )>>
+      if (query[pos] === ")") {
+        // Look ahead for >>
+        let lookAhead = pos + 1;
+        while (lookAhead < query.length && /\s/.test(query[lookAhead])) {
+          lookAhead++;
+        }
+
+        if (query.substring(lookAhead, lookAhead + 2) === ">>") {
+          depth--;
+          if (depth === 0) {
+            const content = query.substring(startPos, lookAhead + 2);
+            return { content, length: content.length };
+          }
+          pos = lookAhead + 2;
+          continue;
+        }
+
+        // Regular parenthesis, not part of )>>
+        pos++;
+        continue;
+      }
+
+      pos++;
+    }
+
+    if (depth > 0) {
+      throw new TripleTermTransformerError(
+        `Unclosed triple term at position ${startPos}: missing )>>`
+      );
+    }
+
+    return null;
+  }
+
+  /**
+   * Convert <<( s p o )>> to << s p o >>.
+   */
+  private convertToStandardSyntax(tripleTerm: string): string {
+    // Remove <<( at start and )>> at end, preserving internal content
+    // Handle optional whitespace: <<( content )>> -> << content >>
+
+    // Match pattern: <<\s*(\s* content \s*)\s*>>
+    const match = tripleTerm.match(/^<<\s*\(\s*([\s\S]*?)\s*\)\s*>>$/);
+    if (!match) {
+      throw new TripleTermTransformerError(
+        `Invalid triple term syntax: ${tripleTerm.substring(0, 50)}...`
+      );
+    }
+
+    const content = match[1];
+    return `<< ${content} >>`;
+  }
+}
+
+/**
+ * Error thrown when triple term transformation fails.
+ */
+export class TripleTermTransformerError extends Error {
+  constructor(message: string) {
+    super(`Triple term transformation error: ${message}`);
+    this.name = "TripleTermTransformerError";
+  }
+}

--- a/packages/exocortex/tests/unit/infrastructure/sparql/TripleTermTransformer.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/TripleTermTransformer.test.ts
@@ -1,0 +1,259 @@
+import {
+  TripleTermTransformer,
+  TripleTermTransformerError,
+} from "../../../../src/infrastructure/sparql/TripleTermTransformer";
+
+describe("TripleTermTransformer", () => {
+  let transformer: TripleTermTransformer;
+
+  beforeEach(() => {
+    transformer = new TripleTermTransformer();
+  });
+
+  describe("hasTripleTermSyntax", () => {
+    it("should return true for query with <<( syntax", () => {
+      const query = `SELECT * WHERE { <<( :Alice :knows :Bob )>> ?p ?o }`;
+      expect(transformer.hasTripleTermSyntax(query)).toBe(true);
+    });
+
+    it("should return true for query with whitespace in <<( syntax", () => {
+      const query = `SELECT * WHERE { << ( :Alice :knows :Bob ) >> ?p ?o }`;
+      expect(transformer.hasTripleTermSyntax(query)).toBe(true);
+    });
+
+    it("should return false for query with standard << >> syntax", () => {
+      const query = `SELECT * WHERE { << :Alice :knows :Bob >> ?p ?o }`;
+      expect(transformer.hasTripleTermSyntax(query)).toBe(false);
+    });
+
+    it("should return false for query without triple terms", () => {
+      const query = `SELECT * WHERE { ?s ?p ?o }`;
+      expect(transformer.hasTripleTermSyntax(query)).toBe(false);
+    });
+
+    it("should return false for <<( inside a string literal", () => {
+      const query = `SELECT * WHERE { ?s ?p "test <<( not a triple )>>" }`;
+      expect(transformer.hasTripleTermSyntax(query)).toBe(false);
+    });
+  });
+
+  describe("transform", () => {
+    describe("basic transformation", () => {
+      it("should transform simple <<( )>> to << >>", () => {
+        const query = `SELECT * WHERE { <<( :Alice :knows :Bob )>> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << :Alice :knows :Bob >> ?p ?o }`);
+      });
+
+      it("should transform with extra whitespace", () => {
+        const query = `SELECT * WHERE { <<(  :Alice  :knows  :Bob  )>> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << :Alice  :knows  :Bob >> ?p ?o }`);
+      });
+
+      it("should transform with whitespace around brackets", () => {
+        const query = `SELECT * WHERE { << ( :Alice :knows :Bob ) >> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << :Alice :knows :Bob >> ?p ?o }`);
+      });
+
+      it("should transform with variables", () => {
+        const query = `SELECT * WHERE { <<( ?s :knows ?o )>> ?p ?v }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << ?s :knows ?o >> ?p ?v }`);
+      });
+
+      it("should transform with full IRIs", () => {
+        const query = `SELECT * WHERE { <<( <http://example.org/Alice> <http://example.org/knows> <http://example.org/Bob> )>> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << <http://example.org/Alice> <http://example.org/knows> <http://example.org/Bob> >> ?p ?o }`);
+      });
+
+      it("should transform with literal object", () => {
+        const query = `SELECT * WHERE { <<( :Alice :name "Alice Smith" )>> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << :Alice :name "Alice Smith" >> ?p ?o }`);
+      });
+
+      it("should transform with typed literal object", () => {
+        const query = `SELECT * WHERE { <<( :Alice :age "30"^^xsd:integer )>> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << :Alice :age "30"^^xsd:integer >> ?p ?o }`);
+      });
+
+      it("should transform with language-tagged literal object", () => {
+        const query = `SELECT * WHERE { <<( :Alice :name "Alice"@en )>> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << :Alice :name "Alice"@en >> ?p ?o }`);
+      });
+
+      it("should transform with blank node subject", () => {
+        const query = `SELECT * WHERE { <<( _:b1 :knows :Bob )>> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << _:b1 :knows :Bob >> ?p ?o }`);
+      });
+    });
+
+    describe("multiple triple terms", () => {
+      it("should transform multiple triple terms in a query", () => {
+        const query = `SELECT * WHERE {
+          <<( :Alice :knows :Bob )>> :source ?src1 .
+          <<( :Bob :knows :Carol )>> :source ?src2 .
+        }`;
+        const result = transformer.transform(query);
+        expect(result).toContain("<< :Alice :knows :Bob >>");
+        expect(result).toContain("<< :Bob :knows :Carol >>");
+        expect(result).not.toContain("<<(");
+        expect(result).not.toContain(")>>");
+      });
+    });
+
+    describe("nested triple terms", () => {
+      it("should transform nested triple term (triple as subject)", () => {
+        const query = `SELECT * WHERE { <<( <<( :Alice :knows :Bob )>> :source :Wikipedia )>> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << << :Alice :knows :Bob >> :source :Wikipedia >> ?p ?o }`);
+      });
+
+      it("should transform nested triple term (triple as object)", () => {
+        const query = `SELECT * WHERE { ?s ?p <<( :doc :claims <<( :Alice :knows :Bob )>> )>> }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { ?s ?p << :doc :claims << :Alice :knows :Bob >> >> }`);
+      });
+
+      it("should transform deeply nested triple terms", () => {
+        const query = `SELECT * WHERE { <<( <<( <<( :A :b :C )>> :source :D )>> :time ?t )>> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(`SELECT * WHERE { << << << :A :b :C >> :source :D >> :time ?t >> ?p ?o }`);
+      });
+    });
+
+    describe("triple terms in expressions", () => {
+      it("should transform triple term in FILTER", () => {
+        const query = `PREFIX : <http://example.org/>
+SELECT * WHERE {
+  ?triple ?p ?o .
+  FILTER(?triple = <<( :Alice :knows :Bob )>>)
+}`;
+        const result = transformer.transform(query);
+        expect(result).toContain("FILTER(?triple = << :Alice :knows :Bob >>)");
+      });
+
+      it("should transform triple term in BIND", () => {
+        const query = `PREFIX : <http://example.org/>
+SELECT * WHERE {
+  BIND(<<( :Alice :knows :Bob )>> AS ?triple)
+  ?triple ?p ?o .
+}`;
+        const result = transformer.transform(query);
+        expect(result).toContain("BIND(<< :Alice :knows :Bob >> AS ?triple)");
+      });
+
+      it("should transform triple term in SELECT expression", () => {
+        const query = `PREFIX : <http://example.org/>
+SELECT (<<( :Alice :knows :Bob )>> AS ?triple) WHERE { ?s ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toContain("(<< :Alice :knows :Bob >> AS ?triple)");
+      });
+    });
+
+    describe("preserves standard syntax", () => {
+      it("should not modify standard << >> syntax", () => {
+        const query = `SELECT * WHERE { << :Alice :knows :Bob >> ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(query);
+      });
+
+      it("should not modify queries without triple terms", () => {
+        const query = `SELECT ?s ?p ?o WHERE { ?s ?p ?o }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(query);
+      });
+    });
+
+    describe("string literal handling", () => {
+      it("should not transform <<( inside single-quoted string", () => {
+        const query = `SELECT * WHERE { ?s ?p '<<( not a triple )>>' }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(query);
+      });
+
+      it("should not transform <<( inside double-quoted string", () => {
+        const query = `SELECT * WHERE { ?s ?p "<<( not a triple )>>" }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(query);
+      });
+
+      it("should not transform <<( inside triple-quoted string", () => {
+        const query = `SELECT * WHERE { ?s ?p """<<( not a triple )>>""" }`;
+        const result = transformer.transform(query);
+        expect(result).toBe(query);
+      });
+
+      it("should handle query with both string and real triple term", () => {
+        const query = `SELECT * WHERE {
+          <<( :Alice :knows :Bob )>> :comment "this is not <<( a triple )>>" .
+        }`;
+        const result = transformer.transform(query);
+        expect(result).toContain("<< :Alice :knows :Bob >>");
+        expect(result).toContain('"this is not <<( a triple )>>"');
+      });
+    });
+
+    describe("error handling", () => {
+      it("should throw error for unclosed triple term", () => {
+        const query = `SELECT * WHERE { <<( :Alice :knows :Bob ?p ?o }`;
+        expect(() => transformer.transform(query)).toThrow(TripleTermTransformerError);
+        expect(() => transformer.transform(query)).toThrow("Unclosed triple term");
+      });
+
+      it("should handle deeply nested triple terms without error", () => {
+        // Even deeply nested triple terms should transform successfully
+        // The max iterations only guards against infinite loops, not deep nesting
+        let nestedQuery = ":A :b :C";
+        for (let i = 0; i < 50; i++) {
+          nestedQuery = `<<( ${nestedQuery} )>>`;
+        }
+        const query = `SELECT * WHERE { ${nestedQuery} ?p ?o }`;
+        const result = transformer.transform(query);
+        // Should have transformed all <<( )>> to << >>
+        expect(result).not.toContain("<<(");
+        expect(result).not.toContain(")>>");
+        // Should contain the standard syntax
+        expect(result).toContain("<< :A :b :C >>");
+      });
+    });
+
+    describe("edge cases", () => {
+      it("should handle empty query", () => {
+        const result = transformer.transform("");
+        expect(result).toBe("");
+      });
+
+      it("should handle query with only whitespace", () => {
+        const result = transformer.transform("   \n\t  ");
+        expect(result).toBe("   \n\t  ");
+      });
+
+      it("should handle mixed << >> and <<( )>> syntax", () => {
+        const query = `SELECT * WHERE {
+          << :Alice :knows :Bob >> :source ?src1 .
+          <<( :Bob :knows :Carol )>> :source ?src2 .
+        }`;
+        const result = transformer.transform(query);
+        expect(result).toContain("<< :Alice :knows :Bob >>");
+        expect(result).toContain("<< :Bob :knows :Carol >>");
+        expect(result).not.toContain("<<(");
+      });
+
+      it("should handle annotation syntax with standard << >>", () => {
+        const query = `PREFIX : <http://example.org/>
+SELECT * WHERE {
+  ?s :knows ?o {| :source ?doc |} .
+}`;
+        const result = transformer.transform(query);
+        expect(result).toBe(query);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements SPARQL 1.2 triple term syntax parsing. The `<<( s p o )>>` syntax is an alternative way to write quoted triples, equivalent to the standard `<< s p o >>` syntax.

**Before (standard syntax only):**
```sparql
SELECT * WHERE { << :Alice :knows :Bob >> :source ?doc }
```

**After (both syntaxes supported):**
```sparql
SELECT * WHERE { <<( :Alice :knows :Bob )>> :source ?doc }
```

## Changes

- **TripleTermTransformer**: New transformer that converts `<<( s p o )>>` to `<< s p o >>`
- **SPARQLParser integration**: Transformer integrated into both sync and async parsing paths
- **hasTripleTermSyntax()**: New detection method for the alternative syntax

## Features

- ✅ Basic triple term syntax: `<<( :s :p :o )>>`
- ✅ Triple terms with variables: `<<( ?s :p ?o )>>`
- ✅ Nested triple terms: `<<( <<( :s :p :o )>> :source :doc )>>`
- ✅ Multiple triple terms in a query
- ✅ String literal handling (won't transform `<<(` inside strings)
- ✅ Combined with other SPARQL 1.2 features (annotations, CASE WHEN, PREFIX*)

## Test Plan

- [x] 33 unit tests for TripleTermTransformer
- [x] Integration tests in SPARQLParser.test.ts
- [x] Combined feature tests (with annotations, CASE WHEN, PREFIX*, directional lang tags)
- [x] Full test suite passes (587+ tests)

Closes #955