### PR TITLE
fix(plugin): synchronize column widths in virtualized DailyTasksTable

### DIFF
--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2538,6 +2538,12 @@
   border-top: none;
 }
 
+/* Header wrapper for virtualized mode - syncs width with scroll container (Issue #941) */
+.exocortex-virtualized .exocortex-tasks-table-header-wrapper {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 /* ============================================================================
    Mobile Layout Fix (Issue #877)
    ============================================================================ */


### PR DESCRIPTION
## Summary

Fixes column misalignment in DailyTasksTable when rendering >50 rows in virtualized mode.

## Problem

In virtualized mode, the component renders header and body as **separate tables**. The "Name" column has no fixed width (uses remaining space), but each table calculates "remaining space" independently. When a scrollbar is present in the body table container but not the header, columns misalign.

## Solution

- **Measure header column width**: Added `headerTableRef` to capture the header table and measure the "Name" column's actual rendered width
- **Apply measured width to body**: Modified `renderColGroup(forBody)` to accept a parameter and apply inline width style to body table's Name column
- **CSS sync**: Added CSS rule for header wrapper to ensure proper container width matching

## Technical Details

- Uses `useLayoutEffect` to measure after DOM paint but before browser paint
- Re-measures on window resize (scrollbar might appear/disappear)
- Only applies in virtualized mode (>50 rows)

## Testing

- Unit tests pass (`npm run test:unit`)
- No new lint errors introduced
- Manual verification: column alignment correct with various row counts

Fixes #941