### PR TITLE
fix: Obsidian plugin incorrectly saves ems__Effort_plannedEndTimestamp with +20 hour offset

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/properties/DateTimePropertyField.tsx
@@ -3,6 +3,7 @@ import {
   parseLocalDate,
   formatForInput,
   formatDisplayValue,
+  formatToLocalTimestamp,
 } from '@plugin/presentation/utils/dateTimeUtils';
 
 export interface DateTimePropertyFieldProps {
@@ -94,7 +95,9 @@ export const DateTimePropertyField: React.FC<DateTimePropertyFieldProps> = ({
     const parsed = parseLocalDate(textInput);
 
     if (parsed) {
-      onChange(parsed.toISOString());
+      // Store as local timestamp (without Z suffix) for consistency with the rest of codebase
+      // This avoids timezone conversion issues when the value is later parsed
+      onChange(formatToLocalTimestamp(parsed));
       setIsOpen(false);
       setError(null);
       onBlur?.();

--- a/packages/obsidian-plugin/src/presentation/components/property-fields/DateTimePropertyField.ts
+++ b/packages/obsidian-plugin/src/presentation/components/property-fields/DateTimePropertyField.ts
@@ -108,17 +108,28 @@ export class DateTimePropertyField {
   }
 
   /**
-   * Format datetime-local input value to ISO 8601 string with timezone.
+   * Format datetime-local input value to local timestamp string.
+   * Format: YYYY-MM-DDTHH:mm:ss (no timezone suffix)
+   *
+   * This format is consistent with DateFormatter.toLocalTimestamp() in @exocortex/core,
+   * avoiding timezone conversion issues when the value is later parsed.
    */
   private formatToISO(value: string): string {
     if (!value) return "";
 
     // datetime-local gives us YYYY-MM-DDTHH:mm format
     try {
-      // Create date from the local time input and convert to ISO
+      // Create date from the local time input and format as local timestamp
       const date = new Date(value);
       if (!isNaN(date.getTime())) {
-        return date.toISOString();
+        // Format as local timestamp (without Z suffix)
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, "0");
+        const day = String(date.getDate()).padStart(2, "0");
+        const hours = String(date.getHours()).padStart(2, "0");
+        const minutes = String(date.getMinutes()).padStart(2, "0");
+        const seconds = String(date.getSeconds()).padStart(2, "0");
+        return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
       }
     } catch {
       // Fall through
@@ -201,17 +212,24 @@ export class DateTimePropertyField {
   }
 
   /**
-   * Get current datetime in ISO format.
+   * Get current datetime in local timestamp format.
    */
   static now(): string {
-    return new Date().toISOString();
+    return DateTimePropertyField.formatDate(new Date());
   }
 
   /**
-   * Format a Date object to ISO 8601 string.
+   * Format a Date object to local timestamp string.
+   * Format: YYYY-MM-DDTHH:mm:ss (no timezone suffix)
    */
   static formatDate(date: Date): string {
-    return date.toISOString();
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    const seconds = String(date.getSeconds()).padStart(2, "0");
+    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/utils/dateTimeUtils.ts
+++ b/packages/obsidian-plugin/src/presentation/utils/dateTimeUtils.ts
@@ -3,8 +3,12 @@
  *
  * Key design principle: All user input is interpreted as LOCAL time.
  * - Input: User enters "2025-12-02 13:03" meaning 1:03 PM in their timezone
- * - Storage: Converted to UTC ISO string (e.g., "2025-12-02T08:03:00.000Z" if UTC+5)
- * - Display: UTC string converted back to local time for display
+ * - Storage: Stored as local timestamp string (e.g., "2025-12-02T13:03:00") WITHOUT timezone suffix
+ * - Display: Local timestamp string displayed directly (no conversion needed)
+ *
+ * IMPORTANT: This is consistent with how timestamps are stored elsewhere in the codebase
+ * (TaskStatusService, StatusTimestampService) using DateFormatter.toLocalTimestamp().
+ * Storing without Z suffix avoids timezone conversion issues when parsing.
  */
 
 /**
@@ -115,6 +119,26 @@ export function formatForInput(isoString: string): string {
   } catch {
     return isoString;
   }
+}
+
+/**
+ * Formats a Date object as a local timestamp string for storage.
+ * Format: YYYY-MM-DDTHH:mm:ss (no timezone suffix)
+ *
+ * This format is consistent with DateFormatter.toLocalTimestamp() in @exocortex/core.
+ *
+ * @param date - The Date object to format
+ * @returns A local timestamp string like "2025-12-02T13:03:00"
+ */
+export function formatToLocalTimestamp(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
 }
 
 /**

--- a/packages/obsidian-plugin/tests/unit/property-fields/DateTimePropertyField.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-fields/DateTimePropertyField.test.ts
@@ -216,15 +216,17 @@ describe("DateTimePropertyField", () => {
   });
 
   describe("static methods", () => {
-    it("should generate current datetime with now()", () => {
+    it("should generate current datetime with now() in local timestamp format", () => {
       const now = DateTimePropertyField.now();
-      expect(now).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      // Local timestamp format: YYYY-MM-DDTHH:mm:ss (no Z suffix)
+      expect(now).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
     });
 
-    it("should format Date object with formatDate()", () => {
-      const date = new Date("2024-12-31T14:30:00.000Z");
+    it("should format Date object with formatDate() as local timestamp", () => {
+      // Create a date and format it - result should match local time components
+      const date = new Date(2024, 11, 31, 14, 30, 0); // Dec 31, 2024, 14:30:00 local
       const formatted = DateTimePropertyField.formatDate(date);
-      expect(formatted).toBe("2024-12-31T14:30:00.000Z");
+      expect(formatted).toBe("2024-12-31T14:30:00");
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the timezone offset issue where `ems__Effort_plannedEndTimestamp` would be saved with an incorrect +20 hour offset when edited via the UI.

### Root Cause

The `DateTimePropertyField` components were using `toISOString()` which stores datetime values as UTC with Z suffix (e.g., `2025-12-17T15:05:00.000Z`). However, the rest of the codebase (`TaskStatusService`, `StatusTimestampService`, `DateFormatter.toLocalTimestamp()`) stores timestamps without the Z suffix (e.g., `2025-12-17T20:05:00`).

When a value stored without Z suffix was later edited and re-saved with Z suffix, the JavaScript Date parser would interpret them differently, causing a timezone offset drift on subsequent edits.

### Solution

- Added `formatToLocalTimestamp()` function to `dateTimeUtils.ts` to produce consistent local timestamp format
- Updated `DateTimePropertyField.tsx` (React component) to use `formatToLocalTimestamp` instead of `toISOString()`
- Updated `DateTimePropertyField.ts` (non-React class) to format as local timestamp
- Updated static methods `now()` and `formatDate()` to use local format
- Added comprehensive tests for `formatToLocalTimestamp` and updated existing tests

### Test Plan

- [x] Unit tests pass for `dateTimeUtils.test.ts` (including new tests for `formatToLocalTimestamp`)
- [x] Unit tests pass for `DateTimePropertyField.test.ts` (updated for new format)
- [x] Full test suite passes (`npm run test:unit`)
- [x] Build passes (`npm run build`)
- [x] Lint check passes for changed files
- [ ] Manual testing: edit `plannedEndTimestamp` in Obsidian, verify saved value matches input

Closes #1052