### PR TITLE
fix(mobile): Table layout issues - text truncation and unbalanced column proportions

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/DailyProjectsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyProjectsTable.tsx
@@ -211,7 +211,7 @@ export const DailyProjectsTable: React.FC<DailyProjectsTableProps> = ({
       data-path={project.path}
       style={style}
     >
-      <td className="project-name">
+      <td className="project-name" title={getDisplayName(project)}>
         <a
           data-href={project.path}
           onClick={(e) => {
@@ -221,6 +221,7 @@ export const DailyProjectsTable: React.FC<DailyProjectsTableProps> = ({
           }}
           className="internal-link"
           style={{ cursor: "pointer" }}
+          title={getDisplayName(project)}
         >
           {getDisplayName(project)}
         </a>

--- a/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
@@ -487,7 +487,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
         data-path={task.path}
         style={style}
       >
-        <td className="task-name">
+        <td className="task-name" title={getDisplayName(task)}>
           <a
             data-href={task.path}
             onClick={(e) => {
@@ -497,6 +497,7 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
             }}
             className="internal-link"
             style={{ cursor: "pointer" }}
+            title={getDisplayName(task)}
           >
             {getDisplayName(task)}
           </a>

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2571,41 +2571,51 @@
     -webkit-overflow-scrolling: touch;
   }
 
-  /* Table maintains minimum readable width */
+  /* Table maintains minimum readable width - reduced to allow more name space */
   .exocortex-daily-tasks .exocortex-tasks-table {
-    min-width: 550px;
+    min-width: 420px;
   }
 
-  /* Name column - ensure minimum readable width */
+  /* Name column - flexible width, takes remaining space after fixed columns */
   .exocortex-tasks-table th.task-name-header,
   .exocortex-tasks-table td.task-name {
-    min-width: 150px;
+    min-width: 180px;
+    max-width: none;
   }
 
-  /* Time columns - compact but readable */
+  /* Time columns - compact for "HH:mm" format (Issue #1055) */
   .exocortex-tasks-table th.task-start-header,
   .exocortex-tasks-table td.task-start,
   .exocortex-tasks-table th.task-end-header,
   .exocortex-tasks-table td.task-end {
-    width: 70px;
+    width: 55px;
+    min-width: 55px;
+    max-width: 55px;
     font-size: 0.85em;
+    padding: 6px 4px;
   }
 
   /* Status column - compact */
   .exocortex-tasks-table th.task-status-header,
   .exocortex-tasks-table td.task-status {
-    width: 65px;
+    width: 60px;
+    min-width: 60px;
+    max-width: 60px;
   }
 
   /* Optional columns - compact when visible */
   .exocortex-tasks-table th.task-effort-area-header,
   .exocortex-tasks-table td.task-effort-area {
-    width: 80px;
+    width: 70px;
+    min-width: 70px;
+    max-width: 70px;
   }
 
   .exocortex-tasks-table th.task-votes-header,
   .exocortex-tasks-table td.task-effort-votes {
-    width: 50px;
+    width: 45px;
+    min-width: 45px;
+    max-width: 45px;
   }
 
   /* Virtualized table container - also needs horizontal scroll */
@@ -2616,7 +2626,7 @@
 
   .exocortex-virtualized .exocortex-tasks-table-header,
   .exocortex-virtualized .exocortex-virtual-scroll-container .exocortex-tasks-table {
-    min-width: 550px;
+    min-width: 420px;
   }
 
   /* Controls wrapper - prevent from being too wide */
@@ -2691,7 +2701,7 @@
   white-space: nowrap;
 }
 
-/* Mobile responsive - Projects table also needs horizontal scroll (Issue #877) */
+/* Mobile responsive - Projects table also needs horizontal scroll (Issue #877, #1055) */
 @media (max-width: 768px) {
   /* Projects section and table container get horizontal scroll */
   .exocortex-daily-projects-section,
@@ -2700,33 +2710,37 @@
     -webkit-overflow-scrolling: touch;
   }
 
-  /* Projects table maintains minimum readable width */
+  /* Projects table maintains minimum readable width - reduced for more name space */
   .exocortex-daily-projects-section .exocortex-projects-table,
   .exocortex-daily-projects .exocortex-projects-table {
-    min-width: 450px;
+    min-width: 350px;
   }
 
-  /* Name column - ensure minimum readable width */
+  /* Name column - flexible width, takes remaining space after fixed columns */
   .exocortex-projects-table th:first-child,
   .exocortex-projects-table td.project-name {
     min-width: 150px;
+    max-width: none;
   }
 
+  /* Time columns - compact for "HH:mm" format (Issue #1055) */
   .exocortex-projects-table th:nth-child(2),
   .exocortex-projects-table td.project-start,
   .exocortex-projects-table th:nth-child(3),
   .exocortex-projects-table td.project-end {
-    width: 70px;
-    min-width: 70px;
-    max-width: 70px;
+    width: 55px;
+    min-width: 55px;
+    max-width: 55px;
     font-size: 0.85em;
+    padding: 6px 4px;
   }
 
+  /* Status column - compact */
   .exocortex-projects-table th:nth-child(4),
   .exocortex-projects-table td.project-status {
-    width: 70px;
-    min-width: 70px;
-    max-width: 70px;
+    width: 60px;
+    min-width: 60px;
+    max-width: 60px;
   }
 }
 


### PR DESCRIPTION
## Summary

Fix mobile table layout issues on iOS/mobile Obsidian:
- **Compact time columns**: Reduced Start/End column widths from 70px to 55px (sufficient for HH:mm format)
- **Flexible name column**: Name column now takes remaining space (min 180px) instead of being compressed
- **Tooltips for truncated text**: Added title attributes to task/project names for tooltip on hover/long-press
- **Reduced minimum table width**: From 550px to 420px for better mobile fit

## Changes

### CSS Changes (styles.css)
- Mobile media query (@media max-width: 768px):
  - Time columns: 55px width (was 70px) with reduced padding
  - Status column: 60px width (was 65px)
  - Name column: min-width 180px, max-width none (flexible)
  - Table min-width: 420px (was 550px)
- Applied same fixes to DailyProjectsTable (min-width 350px)

### Component Changes
- `DailyTasksTable.tsx`: Added title attribute to task name cells and links
- `DailyProjectsTable.tsx`: Added title attribute to project name cells and links

## Test Plan

- [x] Unit tests pass (`npm run test:unit`)
- [x] TypeScript type check passes (`npm run check:types`)
- [x] ESLint check on modified files (no new errors)
- [ ] Manual test on mobile Obsidian (user verification needed)

Closes #1055