### PR TITLE
refactor(quality): Simplify trivial/useless conditionals

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -29,6 +29,7 @@ paths-ignore:
 # The filter-sarif action removes these known false positives:
 # - js/weak-cryptographic-algorithm in BuiltInFunctions.ts (SPARQL 1.1 spec compliance)
 # - js/insecure-randomness in BuiltInFunctions.ts (SPARQL 1.1 RAND() function)
+# - js/trivial-conditional in main.js (minified bundled code artifacts)
 #
 # SECURITY CONTEXT:
 # MD5 and SHA1 hash functions are required by W3C SPARQL 1.1 specification:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,6 +68,7 @@ jobs:
             -**/BuiltInFunctions.ts:js/insecure-randomness
             -**/main.js:js/useless-expression
             -**/main.js:js/automatic-semicolon-insertion
+            -**/main.js:js/trivial-conditional
           input: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
           output: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
 


### PR DESCRIPTION
## Summary
Filter out stale `js/trivial-conditional` CodeQL alerts from bundled `main.js` file.

## Changes
- Added `js/trivial-conditional` filter pattern for `main.js` in CodeQL workflow
- Updated config documentation to reflect the new filter

## Context
The 3 alerts from Issue #1065 are all false positives:
- **BatchExecutor.ts line 182**: Already fixed - `!rolledBack` check was removed in commit c2b73f2
- **obsidian-launcher.ts line 126**: Already fixed - `while(!appFound)` replaced with `for` loop
- **main.js line 8**: Bundled/minified output artifact - not actual source code

The source code issues were already resolved in previous commits. The only remaining action is to filter the `main.js` alert (bundled output should not be analyzed for code quality).

Closes #1065