### PR TITLE
fix(quality): fix comparisons between incompatible types

### DIFF
--- a/packages/obsidian-plugin/specs/step_definitions/instance-class-links.steps.ts
+++ b/packages/obsidian-plugin/specs/step_definitions/instance-class-links.steps.ts
@@ -161,11 +161,12 @@ Then(
 Then("Instance Class column displays {string}", function (this: ExocortexWorld, expectedText: string) {
   const instanceClass = this.currentNote?.frontmatter.exo__Instance_class;
   if (expectedText === "-" || expectedText === "") {
-    // Check for empty/falsy instance class (null, undefined, or empty string)
-    assert.ok(
-      !instanceClass || instanceClass === "",
-      "Expected empty or null instance class",
-    );
+    // Check for empty/falsy instance class (null, undefined, empty string, or empty array)
+    const isEmpty =
+      !instanceClass ||
+      (typeof instanceClass === "string" && instanceClass === "") ||
+      (Array.isArray(instanceClass) && instanceClass.length === 0);
+    assert.ok(isEmpty, "Expected empty or null instance class");
   } else {
     assert.ok(instanceClass, "Expected instance class to exist");
   }
@@ -173,11 +174,12 @@ Then("Instance Class column displays {string}", function (this: ExocortexWorld, 
 
 Then("Instance Class column is empty", function (this: ExocortexWorld) {
   const instanceClass = this.currentNote?.frontmatter.exo__Instance_class;
-  // Check for empty/falsy instance class (null, undefined, or empty string)
-  assert.ok(
-    !instanceClass || instanceClass === "",
-    "Instance class should be empty",
-  );
+  // Check for empty/falsy instance class (null, undefined, empty string, or empty array)
+  const isEmpty =
+    !instanceClass ||
+    (typeof instanceClass === "string" && instanceClass === "") ||
+    (Array.isArray(instanceClass) && instanceClass.length === 0);
+  assert.ok(isEmpty, "Instance class should be empty");
 });
 
 Then("no error is thrown", function (this: ExocortexWorld) {


### PR DESCRIPTION
## Summary
Fixed CodeQL alert `js/comparison-between-incompatible-types` in `instance-class-links.steps.ts`.

### Problem
The `instanceClass` variable from frontmatter can be:
- `string` (e.g., `"ems__Task"`)
- `string[]` (e.g., `["ems__Task", "ems__Meeting"]`)  
- `null` or `undefined`

Comparing an array to empty string using `===` will never be true, which CodeQL correctly identifies as a comparison between incompatible types.

### Solution
- Check `typeof === "string"` before comparing to `""`
- Check `Array.isArray()` and `.length` for array case
- Keep `!instanceClass` for null/undefined cases

### Changes
- Updated 2 assertions in `instance-class-links.steps.ts`:
  - Line 166: "Instance Class column displays" step
  - Line 178: "Instance Class column is empty" step

Closes #1066