### PR TITLE
fix(quality): filter use-before-declaration alerts from bundled main.js

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,9 +57,11 @@ jobs:
           # Output SARIF file for post-processing
           output: sarif-results
 
-      # Filter out known false positives before uploading
-      # MD5/SHA1 usage in SPARQL is required by W3C spec, not for security
-      # main.js is a bundled file with minified third-party code (React, etc.)
+      # Filter out known false positives before uploading:
+      # - BuiltInFunctions.ts: MD5/SHA1 usage in SPARQL is required by W3C spec
+      # - main.js: Bundled file with minified third-party code (reflect-metadata, etc.)
+      #   The "use-before-declaration" alerts come from reflect-metadata's polyfill
+      #   patterns which are valid hoisted `var` declarations
       - name: Filter SARIF for known false positives
         uses: advanced-security/filter-sarif@v1
         with:
@@ -69,6 +71,7 @@ jobs:
             -**/main.js:js/useless-expression
             -**/main.js:js/automatic-semicolon-insertion
             -**/main.js:js/trivial-conditional
+            -**/main.js:js/use-before-declaration
           input: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
           output: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
 


### PR DESCRIPTION
## Summary
Filter CodeQL false positives for `js/use-before-declaration` in the bundled `main.js` file.

## Problem
CodeQL detected 3 warnings for "variable not declared before use" in `packages/obsidian-plugin/main.js`:
- Variable `n2` at column 3683
- Variable `x6` at column 77399
- Variable `y5` at column 77432

These variables are from the `reflect-metadata` polyfill which uses hoisted `var` declarations - a valid JavaScript pattern.

## Solution
Added `js/use-before-declaration` to the SARIF filter patterns for `main.js` in the CodeQL workflow, consistent with other bundled code alerts that are already filtered.

## Why this is the right fix
1. `main.js` is a generated/bundled file by esbuild, not source code
2. The patterns come from `reflect-metadata` (third-party dependency)
3. Hoisted `var` declarations are valid JavaScript (the code works correctly)
4. Other bundled code patterns (`js/useless-expression`, `js/trivial-conditional`) are already filtered

Closes #1067