### PR TITLE
fix(quality): filter unreachable-statement alerts from bundled main.js

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,8 +60,9 @@ jobs:
       # Filter out known false positives before uploading:
       # - BuiltInFunctions.ts: MD5/SHA1 usage in SPARQL is required by W3C spec
       # - main.js: Bundled file with minified third-party code (reflect-metadata, etc.)
-      #   The "use-before-declaration" alerts come from reflect-metadata's polyfill
-      #   patterns which are valid hoisted `var` declarations
+      #   Alerts from main.js are filtered because the bundled output includes polyfills
+      #   and minified library code where patterns like unreachable statements, hoisted
+      #   var declarations, and trivial conditionals are valid optimization artifacts
       - name: Filter SARIF for known false positives
         uses: advanced-security/filter-sarif@v1
         with:
@@ -72,6 +73,7 @@ jobs:
             -**/main.js:js/automatic-semicolon-insertion
             -**/main.js:js/trivial-conditional
             -**/main.js:js/use-before-declaration
+            -**/main.js:js/unreachable-statement
           input: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
           output: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
 

--- a/flaky-report.json
+++ b/flaky-report.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": "2025-12-16T18:22:21.080Z",
+  "timestamp": "2025-12-20T20:05:05.689Z",
   "totalFlaky": 0,
   "tests": [],
   "summary": {
-    "totalTests": 4058,
+    "totalTests": 4062,
     "totalSuites": 197,
     "flakyPercentage": 0
   }


### PR DESCRIPTION
## Summary

Filter `js/unreachable-statement` CodeQL alerts from the bundled `main.js` file.

The bundled `main.js` contains:
- Third-party code (reflect-metadata, polyfills)
- Minified output from esbuild

Unreachable statements in these contexts are valid optimization artifacts - dead code elimination, polyfill fallbacks, and minification patterns that CodeQL flags but are not actual issues.

This follows the same pattern as other filtered alerts from `main.js`:
- `js/useless-expression`
- `js/automatic-semicolon-insertion`
- `js/trivial-conditional`
- `js/use-before-declaration`

## Changes

- Added `js/unreachable-statement` to the SARIF filter patterns
- Updated comment to better explain why main.js alerts are filtered

Closes #1068

## Test Plan

- [x] YAML syntax validated
- [x] Unit tests pass
- [ ] CI pipeline passes (CodeQL workflow)