### PR TITLE
fix(quality): filter redundant-operation alerts from bundled main.js

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,6 +74,7 @@ jobs:
             -**/main.js:js/trivial-conditional
             -**/main.js:js/use-before-declaration
             -**/main.js:js/unreachable-statement
+            -**/main.js:js/redundant-operation
           input: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
           output: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
 


### PR DESCRIPTION
## Summary

- Add `js/redundant-operation` to CodeQL filter-sarif patterns for main.js
- The bundled main.js file contains minified third-party code where redundant operation patterns (like x - x, x && x) may appear as valid optimization artifacts
- These CodeQL alerts are false positives when detected in bundled output files

Closes #1069

## Test plan

- [x] Unit tests pass locally
- [ ] CI pipeline passes