### PR TITLE
fix(quality): remove duplicate property in UniversalLayoutRenderer.ui.test.ts

### DIFF
--- a/flaky-report.json
+++ b/flaky-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-12-20T20:05:05.689Z",
+  "timestamp": "2025-12-20T20:32:50.393Z",
   "totalFlaky": 0,
   "tests": [],
   "summary": {

--- a/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
+++ b/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
@@ -1925,7 +1925,6 @@ describe("UniversalLayoutRenderer UI Integration", () => {
                 ems__Effort_status: "[[ems__EffortStatusDoing]]",
                 ems__Effort_day: "[[2025-10-16]]",
                 ems__Effort_startTimestamp: "2025-10-16T09:00:00",
-                ems__Effort_startTimestamp: "2025-10-16T09:00:00",
               },
             };
           }


### PR DESCRIPTION
## Summary
- Removes duplicate `ems__Effort_startTimestamp` property in test object literal
- This was a copy-paste error detected by CodeQL (js/duplicate-property warning)
- The second definition was removed as both had the same value

## Test plan
- [x] Unit tests pass locally
- [ ] CI pipeline green

Closes #1070