### PR TITLE
refactor(quality): Remove unneeded defensive code in main.js

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,7 +62,8 @@ jobs:
       # - main.js: Bundled file with minified third-party code (reflect-metadata, etc.)
       #   Alerts from main.js are filtered because the bundled output includes polyfills
       #   and minified library code where patterns like unreachable statements, hoisted
-      #   var declarations, and trivial conditionals are valid optimization artifacts
+      #   var declarations, trivial conditionals, and unneeded defensive code are valid
+      #   optimization artifacts from esbuild's CommonJS/ESM interop helpers
       - name: Filter SARIF for known false positives
         uses: advanced-security/filter-sarif@v1
         with:
@@ -75,6 +76,7 @@ jobs:
             -**/main.js:js/use-before-declaration
             -**/main.js:js/unreachable-statement
             -**/main.js:js/redundant-operation
+            -**/main.js:js/unneeded-defensive-code
           input: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
           output: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
 


### PR DESCRIPTION
## Summary
- Add `js/unneeded-defensive-code` to CodeQL SARIF filter for `main.js`
- Update comment to explain the filtering rationale

## Problem
CodeQL detected 3 "unneeded defensive code" alerts at lines 13-15 of `packages/obsidian-plugin/main.js`. These are false positives because the file is a **generated/bundled file by esbuild**, not source code.

The alerts stem from esbuild's CommonJS/ESM interop helper code:
```javascript
var ut=(t,e,a)=>(a=t!=null?$h(Ih(t)):{},Ro(e||!t||!t.__esModule?Xl(a,"default",{value:t,enumerable:!0}):a,t))
```

This pattern contains guards like `t!=null` followed by `!t` checks which CodeQL flags as redundant. However, these are valid optimization artifacts from the bundler, not actual code quality issues.

## Solution
Filter `js/unneeded-defensive-code` from `main.js` in the CodeQL SARIF filter, consistent with other bundled code patterns already filtered (trivial-conditional, redundant-operation, etc.).

## Test Plan
- [x] Unit tests pass (587 passed)
- [ ] CI pipeline passes

Closes #1071