### PR TITLE
refactor(core): Remove unused variables and imports

### DIFF
--- a/packages/exocortex/tests/integration/sparql/query-pipeline.test.ts
+++ b/packages/exocortex/tests/integration/sparql/query-pipeline.test.ts
@@ -42,7 +42,6 @@ const EMS_EFFORT_END_TIMESTAMP = new IRI(`${EMS}Effort_endTimestamp`);
  */
 class TestDataBuilder {
   private triples: Triple[] = [];
-  private counter = 0;
 
   /**
    * Create a task with label and optional metadata

--- a/packages/exocortex/tests/unit/infrastructure/sparql/AlgebraOptimizer.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/AlgebraOptimizer.test.ts
@@ -1,20 +1,16 @@
 import { SPARQLParser } from "../../../../src/infrastructure/sparql/SPARQLParser";
 import { AlgebraTranslator } from "../../../../src/infrastructure/sparql/algebra/AlgebraTranslator";
 import { AlgebraOptimizer } from "../../../../src/infrastructure/sparql/algebra/AlgebraOptimizer";
-import { AlgebraSerializer } from "../../../../src/infrastructure/sparql/algebra/AlgebraSerializer";
-import type { AlgebraOperation, FilterOperation, JoinOperation } from "../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
 
 describe("AlgebraOptimizer", () => {
   let parser: SPARQLParser;
   let translator: AlgebraTranslator;
   let optimizer: AlgebraOptimizer;
-  let serializer: AlgebraSerializer;
 
   beforeEach(() => {
     parser = new SPARQLParser();
     translator = new AlgebraTranslator();
     optimizer = new AlgebraOptimizer();
-    serializer = new AlgebraSerializer();
   });
 
   describe("Filter Push-Down", () => {

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.error.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.error.test.ts
@@ -19,6 +19,9 @@ import type { FilterOperation } from "../../../../../src/infrastructure/sparql/a
 describe("FilterExecutor Error Scenarios", () => {
   let executor: FilterExecutor;
   const xsdInt = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+  const xsdDouble = new IRI("http://www.w3.org/2001/XMLSchema#double");
+  const xsdDecimal = new IRI("http://www.w3.org/2001/XMLSchema#decimal");
+  const xsdDateTime = new IRI("http://www.w3.org/2001/XMLSchema#dateTime");
 
   beforeEach(() => {
     executor = new FilterExecutor();


### PR DESCRIPTION
## Summary

- Remove unused imports and variables detected by CodeQL in test files
- Add missing XSD datatype constants that were being used but not defined

## Changes

### AlgebraOptimizer.test.ts
- Remove unused imports: `AlgebraSerializer`, `FilterOperation`, `JoinOperation`
- Remove unused variable: `serializer`

### FilterExecutor.error.test.ts
- Add missing constants: `xsdDouble`, `xsdDecimal`, `xsdDateTime`
- These were being used in tests but were never defined, causing CodeQL alerts

### query-pipeline.test.ts
- Remove unused private field: `counter` from TestDataBuilder class

## Test Plan

- [x] All affected tests pass (AlgebraOptimizer, FilterExecutor.error, query-pipeline)
- [x] Full unit test suite passes

Fixes #1074