### PR TITLE
fix(security): P0: Fix insecure randomness in FilterExecutor

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -29,6 +29,7 @@ paths-ignore:
 # The filter-sarif action removes these known false positives:
 # - js/weak-cryptographic-algorithm in BuiltInFunctions.ts (SPARQL 1.1 spec compliance)
 # - js/insecure-randomness in BuiltInFunctions.ts (SPARQL 1.1 RAND() function)
+# - js/insecure-randomness in FilterExecutor.ts (calls RAND() for SPARQL queries)
 # - js/trivial-conditional in main.js (minified bundled code artifacts)
 #
 # SECURITY CONTEXT:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,8 @@ jobs:
           output: sarif-results
 
       # Filter out known false positives before uploading:
-      # - BuiltInFunctions.ts: MD5/SHA1 usage in SPARQL is required by W3C spec
+      # - BuiltInFunctions.ts: MD5/SHA1 and RAND() usage in SPARQL is required by W3C spec
+      # - FilterExecutor.ts: Calls RAND() function - same SPARQL 1.1 spec compliance
       # - main.js: Bundled file with minified third-party code (reflect-metadata, etc.)
       #   Alerts from main.js are filtered because the bundled output includes polyfills
       #   and minified library code where patterns like unreachable statements, hoisted
@@ -70,6 +71,7 @@ jobs:
           patterns: |
             -**/BuiltInFunctions.ts:js/weak-cryptographic-algorithm
             -**/BuiltInFunctions.ts:js/insecure-randomness
+            -**/FilterExecutor.ts:js/insecure-randomness
             -**/main.js:js/useless-expression
             -**/main.js:js/automatic-semicolon-insertion
             -**/main.js:js/trivial-conditional

--- a/flaky-report.json
+++ b/flaky-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-12-20T20:32:50.393Z",
+  "timestamp": "2025-12-21T04:50:03.265Z",
   "totalFlaky": 0,
   "tests": [],
   "summary": {

--- a/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -896,6 +896,9 @@ export class FilterExecutor {
         return BuiltInFunctions.floor(floorArg);
 
       case "rand":
+        // SPARQL 1.1 RAND() function - uses pseudo-random for query logic (sampling, shuffling).
+        // NOT for security purposes. See W3C spec: https://www.w3.org/TR/sparql11-query/#func-rand
+        // CodeQL js/insecure-randomness alert is filtered in .github/workflows/codeql.yml
         return BuiltInFunctions.rand();
 
       // SPARQL 1.1 Conditional Functions


### PR DESCRIPTION
## Summary

Resolves CodeQL `js/insecure-randomness` security alert at FilterExecutor.ts:1109 by properly filtering this known false positive.

**Root Cause:** The alert appears at the SPARQL `RAND()` function call site in FilterExecutor.ts. This is NOT an actual security issue because:
- `RAND()` is a W3C SPARQL 1.1 specification-required function
- It is used for query logic (sampling, shuffling), NOT security purposes  
- The SPARQL spec explicitly allows non-cryptographic PRNGs

**Solution:** Added FilterExecutor.ts to the SARIF filter patterns (alongside BuiltInFunctions.ts which was already filtered).

## Changes

- `.github/workflows/codeql.yml`: Add filter pattern for FilterExecutor.ts
- `.github/codeql/codeql-config.yml`: Document the suppression
- `FilterExecutor.ts`: Add clarifying comment at RAND() call site

## Test Plan

- [x] Unit tests pass (587 passed)
- [x] No new lint errors introduced
- [x] CodeQL workflow will filter the alert after merge

Closes #1091