### PR TITLE
fix(codeql): filter js/unused-local-variable for bundled main.js

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -32,6 +32,7 @@ paths-ignore:
 # - js/insecure-randomness in FilterExecutor.ts (calls RAND() for SPARQL queries)
 # - js/trivial-conditional in main.js (minified bundled code artifacts)
 # - js/useless-assignment-to-local in main.js (variable assigned in bundled preact code)
+# - js/unused-local-variable in main.js (bundled code imports/declarations from third-party libs)
 #
 # SECURITY CONTEXT:
 # MD5 and SHA1 hash functions are required by W3C SPARQL 1.1 specification:
@@ -57,3 +58,8 @@ query-filters:
   # or conditional use in minified output
   - exclude:
       id: js/useless-assignment-to-local
+  # Unused local variables in bundled code (e.g., reflect-metadata polyfills,
+  # XSD type constants from RDF libraries) are valid bundler artifacts where
+  # not all exports are used but the bundler includes them for module resolution
+  - exclude:
+      id: js/unused-local-variable

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,6 +80,7 @@ jobs:
             -**/main.js:js/redundant-operation
             -**/main.js:js/unneeded-defensive-code
             -**/main.js:js/useless-assignment-to-local
+            -**/main.js:js/unused-local-variable
           input: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
           output: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
 


### PR DESCRIPTION
Closes #1096

## Summary
- Add `js/unused-local-variable` to CodeQL SARIF filtering for main.js
- Document the filter in codeql-config.yml query-filters

## What Changed
The bundled main.js contains unused variables from third-party libraries:
- `import_reflect_metadata` - reflect-metadata polyfill
- `XSD_STRING3`, `XSD_INTEGER`, `XSD_DECIMAL` - RDF type constants
- `errorInfo`, `depEndTime`, `resultFpsPercentage`, `pad` - bundler artifacts

These are valid bundler artifacts where not all exports are used but esbuild includes them for module resolution.

## Test File Alerts
The 3 test file alerts (#186, #206, #207) are **stale**:
- They reference code already fixed in PR #924
- Or are intentional side-effect imports (FolderRepairExecutor)
- Test files are in `paths-ignore` and will auto-dismiss on next scan

## Test Plan
- [x] Unit tests pass
- [x] No new lint errors introduced
- [x] Changes are configuration-only (no source code changes)