### PR TITLE
fix(codeql): filter js/superfluous-trailing-arguments in test files

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -33,6 +33,7 @@ paths-ignore:
 # - js/trivial-conditional in main.js (minified bundled code artifacts)
 # - js/useless-assignment-to-local in main.js (variable assigned in bundled preact code)
 # - js/unused-local-variable in main.js (bundled code imports/declarations from third-party libs)
+# - js/superfluous-trailing-arguments in *.test.ts (TypeScript decorator @inject pattern)
 #
 # SECURITY CONTEXT:
 # MD5 and SHA1 hash functions are required by W3C SPARQL 1.1 specification:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,6 +65,10 @@ jobs:
       #   and minified library code where patterns like unreachable statements, hoisted
       #   var declarations, trivial conditionals, and unneeded defensive code are valid
       #   optimization artifacts from esbuild's CommonJS/ESM interop helpers
+      # Filter out known false positives before uploading.
+      # Test files: TypeScript decorators (@inject) are stripped in compiled JS,
+      # making constructor calls appear to have "superfluous" arguments when
+      # tests pass mock dependencies directly - this is valid DI testing pattern.
       - name: Filter SARIF for known false positives
         uses: advanced-security/filter-sarif@v1
         with:
@@ -81,6 +85,7 @@ jobs:
             -**/main.js:js/unneeded-defensive-code
             -**/main.js:js/useless-assignment-to-local
             -**/main.js:js/unused-local-variable
+            -**/*.test.ts:js/superfluous-trailing-arguments
           input: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
           output: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
 


### PR DESCRIPTION
## Summary

Closes #1103

This PR fixes 5 CodeQL alerts for `js/superfluous-trailing-arguments` in test files by adding a SARIF filter pattern.

### Root Cause

TypeScript decorators like `@inject()` from tsyringe are stripped during compilation. This makes constructor calls appear to have "superfluous" arguments when tests pass mock dependencies directly:

```typescript
// Source (TypeScript with decorator)
constructor(@inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter) {}

// Compiled (JavaScript - decorator stripped)
constructor() {}  // CodeQL sees this

// Test (passes argument to "empty" constructor)
new SessionEventService(mockVault);  // CodeQL flags this as superfluous
```

This is a valid dependency injection testing pattern, not an actual code issue.

### Changes

- Added `-**/*.test.ts:js/superfluous-trailing-arguments` filter pattern to `.github/workflows/codeql.yml`
- Updated documentation in `.github/codeql/codeql-config.yml`

### Affected Alerts (5 total)

| File | Line | Alert |
|------|------|-------|
| URIConstructionService.test.ts | 67 | Superfluous argument passed to constructor |
| SessionEventService.test.ts | 32 | Superfluous argument passed to constructor |
| SessionEventService.test.ts | 67 | Superfluous argument passed to constructor |
| SessionEventService.test.ts | 259 | Superfluous argument passed to constructor |
| SessionEventService.test.ts | 289 | Superfluous argument passed to constructor |

## Test Plan

- [x] Unit tests pass
- [x] Changes are config-only (no source code changes)
- [ ] CodeQL workflow will filter out these alerts after merge