### PR TITLE
fix(quality): Fix useless assignment to local variable (Issue #1102)

### DIFF
--- a/packages/exocortex/src/utilities/FilenameValidator.ts
+++ b/packages/exocortex/src/utilities/FilenameValidator.ts
@@ -103,35 +103,35 @@ export class FilenameValidator {
       errors.push("Filename should not end with a space");
     }
 
-    // Trim whitespace for further checks
-    let sanitized = name.trim();
+    // Trim whitespace for validation checks
+    const trimmedName = name.trim();
 
     // Check for invalid characters
-    if (this.INVALID_CHARS_PATTERN.test(sanitized)) {
+    if (this.INVALID_CHARS_PATTERN.test(trimmedName)) {
       errors.push("Filename contains invalid characters: / \\ : * ? \" < > |");
     }
 
     // Check for reserved Windows names
-    const baseName = this.getBaseName(sanitized);
+    const baseName = this.getBaseName(trimmedName);
     if (this.RESERVED_NAMES.has(baseName.toUpperCase())) {
       errors.push(`"${baseName}" is a reserved filename on Windows`);
     }
 
     // Check for length
-    if (sanitized.length > maxLength) {
+    if (trimmedName.length > maxLength) {
       errors.push(`Filename exceeds maximum length of ${maxLength} characters`);
     }
 
     // Check for leading/trailing dots (problematic on Windows)
-    if (sanitized.startsWith(".")) {
+    if (trimmedName.startsWith(".")) {
       errors.push("Filename should not start with a dot");
     }
-    if (sanitized.endsWith(".")) {
+    if (trimmedName.endsWith(".")) {
       errors.push("Filename should not end with a dot");
     }
 
     // Create sanitized version
-    sanitized = this.sanitize(name, { maxLength, replacementChar });
+    const sanitized = this.sanitize(name, { maxLength, replacementChar });
 
     return {
       valid: errors.length === 0,


### PR DESCRIPTION
## Summary
- Fix code scanning alert #147 (js/useless-assignment-to-local) in FilenameValidator.ts
- Rename intermediate variable from `sanitized` to `trimmedName` to clarify intent
- Use `const` instead of `let` for the final `sanitized` variable

## Root Cause
The variable `sanitized` was being assigned twice:
1. First with `name.trim()` for validation checks (line 107)
2. Then completely overwritten with `this.sanitize()` result (line 134)

The first assignment was unused because only the second value was returned.

## Changes
- Renamed the validation variable to `trimmedName` to make intent clear
- Declare `sanitized` with `const` only when the final value is computed
- No functional change - just code clarity improvement

## Related Alerts
This fix resolves:
- Alert #147: `packages/core/src/utilities/FilenameValidator.ts:92`
- Alert #150: `packages/obsidian-plugin/main.js:81` (bundled from FilenameValidator)

Note: Alerts #148, #196 are from bundled third-party code (jison parser, reflect-metadata) and are already filtered in codeql.yml.

## Test Plan
- [x] Unit tests pass locally
- [x] Type checking passes
- [ ] CI pipeline passes

Closes #1102