### PR TITLE
fix(codeql): filter js/unused-local-variable in test files and scripts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -34,6 +34,8 @@ paths-ignore:
 # - js/useless-assignment-to-local in main.js (variable assigned in bundled preact code)
 # - js/unused-local-variable in main.js (bundled code imports/declarations from third-party libs)
 # - js/superfluous-trailing-arguments in *.test.ts (TypeScript decorator @inject pattern)
+# - js/unused-local-variable in tests/** (test fixture variables, mock callbacks, intentional unused)
+# - js/unused-local-variable in scripts/* (development utility scripts)
 #
 # SECURITY CONTEXT:
 # MD5 and SHA1 hash functions are required by W3C SPARQL 1.1 specification:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -86,6 +86,11 @@ jobs:
             -**/main.js:js/useless-assignment-to-local
             -**/main.js:js/unused-local-variable
             -**/*.test.ts:js/superfluous-trailing-arguments
+            -**/*.test.ts:js/unused-local-variable
+            -**/*.test.tsx:js/unused-local-variable
+            -**/tests/**:js/unused-local-variable
+            -**/specs/**:js/unused-local-variable
+            -scripts/*:js/unused-local-variable
           input: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
           output: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
 


### PR DESCRIPTION
## Summary

Add filter patterns to exclude `js/unused-local-variable` CodeQL alerts from:
- Test files (`*.test.ts`, `*.test.tsx`, `tests/**`)
- Spec files (`specs/**`)
- Development scripts (`scripts/*`)

## Why This Change

These locations contain intentionally unused variables for:
- **Test fixture setup and mock callbacks** - Variables like `mockTrashReasonModalCallback` are set up in fixtures but triggered conditionally in tests
- **Development utility scripts** - Loop variables and intermediate results in build/report scripts
- **Type-only imports** - Imports used only for TypeScript type annotations

## Changes

- `.github/workflows/codeql.yml`: Added filter patterns for test files and scripts
- `.github/codeql/codeql-config.yml`: Updated documentation of filtered patterns

## Test Plan

- [x] Unit tests pass
- [x] No new code changes, only CodeQL configuration

Closes #1106