### PR TITLE
fix(codeql): document js/unneeded-defensive-code filter in config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -31,6 +31,7 @@ paths-ignore:
 # - js/insecure-randomness in BuiltInFunctions.ts (SPARQL 1.1 RAND() function)
 # - js/insecure-randomness in FilterExecutor.ts (calls RAND() for SPARQL queries)
 # - js/trivial-conditional in main.js (minified bundled code artifacts)
+# - js/unneeded-defensive-code in main.js (tslib __extends helper null checks)
 # - js/useless-assignment-to-local in main.js (variable assigned in bundled preact code)
 # - js/unused-local-variable in main.js (bundled code imports/declarations from third-party libs)
 # - js/superfluous-trailing-arguments in *.test.ts (TypeScript decorator @inject pattern)
@@ -66,3 +67,8 @@ query-filters:
   # not all exports are used but the bundler includes them for module resolution
   - exclude:
       id: js/unused-local-variable
+  # Unneeded defensive code in bundled code (e.g., tslib's __extends helper)
+  # generates _super !== null checks that are always true because the parent
+  # class reference is guaranteed to exist in TypeScript class inheritance
+  - exclude:
+      id: js/unneeded-defensive-code


### PR DESCRIPTION
## Summary

- Document `js/unneeded-defensive-code` filter in codeql-config.yml comments
- Add corresponding `query-filters` entry for consistency with filter-sarif action

## Background

The filter was already added to `codeql.yml` (filter-sarif action) in PR #1088, but the config file comments and query-filters section were not updated to reflect this.

The unneeded-defensive-code alerts come from tslib's `__extends` helper which generates `_super !== null` checks that are always true because the parent class reference is guaranteed to exist in TypeScript class inheritance.

## Test plan

- [x] Unit tests pass
- [x] TypeCheck passes  
- [ ] CI pipeline passes
- [ ] CodeQL scan runs and doesn't report new alerts

Closes #1115