### PR TITLE
fix: remove redundant identical operands (closes #1116)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -60,8 +60,7 @@ const SingleTable: React.FC<SingleTableProps> = ({
   };
 
   const getInstanceClass = (metadata: Record<string, unknown>): WikiLink => {
-    const instanceClassRaw =
-      metadata?.exo__Instance_class || metadata?.["exo__Instance_class"] || "-";
+    const instanceClassRaw = metadata?.exo__Instance_class || "-";
 
     const instanceClass = Array.isArray(instanceClassRaw)
       ? instanceClassRaw[0] || "-"


### PR DESCRIPTION
## Summary

Fixed code scanning alert #21 (`js/redundant-operation`) by removing redundant identical operands in `AssetRelationsTable.tsx`.

### Problem

The code:
```typescript
metadata?.exo__Instance_class || metadata?.["exo__Instance_class"] || "-"
```

Used two syntactically different but semantically identical operands. In JavaScript/TypeScript, `obj.prop` and `obj["prop"]` access the same property, so the second operand was redundant and would never be evaluated.

### Solution

Simplified to:
```typescript
metadata?.exo__Instance_class || "-"
```

## Test Plan

- [x] Unit tests pass
- [x] TypeScript type-checking passes
- [x] Build succeeds
- [x] No new lint errors introduced

Closes #1116