### PR TITLE
fix: P1: Fix Comparison between inconvertible types (3 alerts)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -32,6 +32,8 @@ paths-ignore:
 # - js/insecure-randomness in FilterExecutor.ts (calls RAND() for SPARQL queries)
 # - js/trivial-conditional in main.js (minified bundled code artifacts)
 # - js/unneeded-defensive-code in main.js (tslib __extends helper null checks)
+# - js/comparison-between-incompatible-types in main.js (minified React scheduler code type checks)
+# - js/comparison-between-incompatible-types in specs/** (BDD step definitions with dynamic frontmatter types)
 # - js/useless-assignment-to-local in main.js (variable assigned in bundled preact code)
 # - js/unused-local-variable in main.js (bundled code imports/declarations from third-party libs)
 # - js/superfluous-trailing-arguments in *.test.ts (TypeScript decorator @inject pattern)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,11 +85,13 @@ jobs:
             -**/main.js:js/unneeded-defensive-code
             -**/main.js:js/useless-assignment-to-local
             -**/main.js:js/unused-local-variable
+            -**/main.js:js/comparison-between-incompatible-types
             -**/*.test.ts:js/superfluous-trailing-arguments
             -**/*.test.ts:js/unused-local-variable
             -**/*.test.tsx:js/unused-local-variable
             -**/tests/**:js/unused-local-variable
             -**/specs/**:js/unused-local-variable
+            -**/specs/**:js/comparison-between-incompatible-types
             -scripts/*:js/unused-local-variable
           input: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif
           output: ${{ steps.analyze.outputs.sarif-output }}/javascript.sarif


### PR DESCRIPTION
## Summary
- Filter `js/comparison-between-incompatible-types` CodeQL alerts from bundled and test files
- Add exclusion for `main.js` (minified React scheduler code)
- Add exclusion for `specs/**` (BDD step definitions with dynamic frontmatter types)

## Technical Details

### Alert Locations
1. `packages/obsidian-plugin/main.js:6` - Minified React scheduler code
2. `packages/obsidian-plugin/specs/step_definitions/instance-class-links.steps.ts:176` - BDD test
3. `packages/obsidian-plugin/specs/step_definitions/instance-class-links.steps.ts:165` - BDD test

### Why These Are False Positives

**main.js**: The bundled output contains minified third-party React code where type checks appear as incompatible type comparisons. This is a bundler artifact, not a code quality issue in our source code.

**specs/*.steps.ts**: The BDD step definitions use `MockFrontmatter` with `[key: string]: any` typing. CodeQL incorrectly infers that `frontmatter.exo__Instance_class` cannot be null based on incomplete type analysis, when in fact:
- The property can be null (set explicitly in test: `exo__Instance_class: null`)
- The optional chaining `this.currentNote?.frontmatter.exo__Instance_class` returns undefined if currentNote is null

## Test plan
- [x] Unit tests pass
- [ ] CI pipeline green
- [ ] CodeQL workflow filters alerts correctly

Closes #1119