### PR TITLE
fix: P0: Fix Incomplete string escaping or encoding (2 alerts)

### DIFF
--- a/packages/obsidian-plugin/specs/step_definitions/area-task-creation.steps.ts
+++ b/packages/obsidian-plugin/specs/step_definitions/area-task-creation.steps.ts
@@ -170,7 +170,8 @@ Then(
     // First, escape all regex special characters in the format string to prevent ReDoS,
     // then replace the {timestamp} placeholder with the timestamp pattern
     const escapedFormat = escapeRegexSpecialChars(nameFormat);
-    const formatRegex = escapedFormat.replace(
+    // Use replaceAll to replace ALL occurrences of the escaped placeholder pattern
+    const formatRegex = escapedFormat.replaceAll(
       escapeRegexSpecialChars("{timestamp}"),
       "\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}",
     );


### PR DESCRIPTION
## Summary

Fix CodeQL alert `js/incomplete-sanitization` (2 occurrences) by replacing `String.prototype.replace()` with `String.prototype.replaceAll()` in BDD step definitions.

### Problem

The code at `area-task-creation.steps.ts:170` used `.replace()` to substitute the `{timestamp}` placeholder in format strings:

```typescript
const formatRegex = escapedFormat.replace(
  escapeRegexSpecialChars("{timestamp}"),
  "\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}",
);
```

CodeQL correctly identified that `String.prototype.replace()` with a string pattern only replaces the **first** occurrence. If `nameFormat` contained multiple `{timestamp}` placeholders, only the first would be substituted.

### Solution

Use `String.prototype.replaceAll()` to ensure all occurrences are replaced:

```typescript
const formatRegex = escapedFormat.replaceAll(
  escapeRegexSpecialChars("{timestamp}"),
  "\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}",
);
```

### Verification

- ✅ Unit tests pass
- ✅ TypeScript type check passes
- ✅ Build successful

Closes #1121