### PR TITLE
fix: P1: Fix Comparison between inconvertible types (3 alerts)

### DIFF
--- a/packages/obsidian-plugin/specs/step_definitions/instance-class-links.steps.ts
+++ b/packages/obsidian-plugin/specs/step_definitions/instance-class-links.steps.ts
@@ -2,6 +2,18 @@ import { Given, When, Then } from "@cucumber/cucumber";
 import { ExocortexWorld } from "../support/world.js";
 import assert from "assert";
 
+/**
+ * Helper function to check if an instance class value is empty.
+ * Handles null, undefined, empty string, and empty array cases.
+ * Written as a separate function to avoid CodeQL comparison type issues.
+ */
+function isEmptyInstanceClass(value: unknown): boolean {
+  if (value == null) return true; // covers null and undefined
+  if (typeof value === "string") return value === "";
+  if (Array.isArray(value)) return value.length === 0;
+  return false;
+}
+
 // ============================================
 // Instance Class Display Tests
 // ============================================
@@ -162,10 +174,7 @@ Then("Instance Class column displays {string}", function (this: ExocortexWorld, 
   const instanceClass = this.currentNote?.frontmatter.exo__Instance_class;
   if (expectedText === "-" || expectedText === "") {
     // Check for empty/falsy instance class (null, undefined, empty string, or empty array)
-    const isEmpty =
-      !instanceClass ||
-      (typeof instanceClass === "string" && instanceClass === "") ||
-      (Array.isArray(instanceClass) && instanceClass.length === 0);
+    const isEmpty = isEmptyInstanceClass(instanceClass);
     assert.ok(isEmpty, "Expected empty or null instance class");
   } else {
     assert.ok(instanceClass, "Expected instance class to exist");
@@ -175,10 +184,7 @@ Then("Instance Class column displays {string}", function (this: ExocortexWorld, 
 Then("Instance Class column is empty", function (this: ExocortexWorld) {
   const instanceClass = this.currentNote?.frontmatter.exo__Instance_class;
   // Check for empty/falsy instance class (null, undefined, empty string, or empty array)
-  const isEmpty =
-    !instanceClass ||
-    (typeof instanceClass === "string" && instanceClass === "") ||
-    (Array.isArray(instanceClass) && instanceClass.length === 0);
+  const isEmpty = isEmptyInstanceClass(instanceClass);
   assert.ok(isEmpty, "Instance class should be empty");
 });
 


### PR DESCRIPTION
## Summary

Fixes CodeQL code scanning alert #1130 (js/comparison-between-incompatible-types) by refactoring the instance class emptiness check.

### Changes

- Extracted the inline isEmpty check to a helper function `isEmptyInstanceClass()` with proper type guards
- The function uses explicit `value == null` check first (covers both null and undefined)
- Then uses `typeof` guard before comparing to empty string
- This avoids CodeQL flagging the comparison as being between incompatible types

### Technical Details

The original code:
```typescript
const isEmpty =
  !instanceClass ||
  (typeof instanceClass === "string" && instanceClass === "") ||
  (Array.isArray(instanceClass) && instanceClass.length === 0);
```

Was flagged because after `typeof instanceClass === "string"` narrows the type, CodeQL saw the subsequent empty string comparison as comparing incompatible types.

The new helper function:
```typescript
function isEmptyInstanceClass(value: unknown): boolean {
  if (value == null) return true;
  if (typeof value === "string") return value === "";
  if (Array.isArray(value)) return value.length === 0;
  return false;
}
```

Uses proper sequential type narrowing that CodeQL can analyze correctly.

### Note on main.js Alert

The alert in `main.js:6` is from the bundled `reflect-metadata` library and is already filtered in `.github/workflows/codeql.yml` via the filter-sarif action. This is a known false positive in third-party code.

## Test Plan

- [x] TypeScript type check passes (`npm run check:types`)
- [x] Unit tests pass (`npm run test:unit` - 587 passed)
- [ ] CI pipeline passes

Closes #1130