### PR TITLE
fix: P0: Fix Incomplete string escaping or encoding (2 alerts)

### DIFF
--- a/packages/obsidian-plugin/specs/step_definitions/area-task-creation.steps.ts
+++ b/packages/obsidian-plugin/specs/step_definitions/area-task-creation.steps.ts
@@ -167,14 +167,15 @@ Then(
     assert.ok(this.lastCreatedNote, "Expected a new note to be created");
     // Verify name matches format (e.g., "Task-{timestamp}")
     const baseName = this.lastCreatedNote?.file.basename || "";
-    // First, escape all regex special characters in the format string to prevent ReDoS,
-    // then replace the {timestamp} placeholder with the timestamp pattern
-    const escapedFormat = escapeRegexSpecialChars(nameFormat);
-    // Use replaceAll to replace ALL occurrences of the escaped placeholder pattern
-    const formatRegex = escapedFormat.replaceAll(
-      escapeRegexSpecialChars("{timestamp}"),
-      "\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}",
-    );
+    // Build regex pattern from name format by:
+    // 1. Splitting on {timestamp} placeholder (before escaping, to handle literal text)
+    // 2. Escaping each literal part for use in regex
+    // 3. Joining with timestamp pattern
+    const TIMESTAMP_PLACEHOLDER = "{timestamp}";
+    const TIMESTAMP_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}";
+    const parts = nameFormat.split(TIMESTAMP_PLACEHOLDER);
+    const escapedParts = parts.map(escapeRegexSpecialChars);
+    const formatRegex = escapedParts.join(TIMESTAMP_REGEX);
     assert.ok(
       new RegExp(formatRegex).test(baseName) || baseName.startsWith("Task"),
       `Note name "${baseName}" should match format "${nameFormat}"`,


### PR DESCRIPTION
## Summary

Fixes CodeQL js/incomplete-sanitization alerts (2 occurrences) in BDD step definitions.

The previous approach used `replaceAll` on an escaped pattern which confused CodeQL's heuristics about incomplete escaping:

```typescript
// Before - triggers CodeQL false positive
const escapedFormat = escapeRegexSpecialChars(nameFormat);
const formatRegex = escapedFormat.replaceAll(
  escapeRegexSpecialChars("{timestamp}"),
  "\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}",
);
```

The new split/join approach is clearer and avoids the false positive:

```typescript
// After - clear intent, no false positive
const parts = nameFormat.split(TIMESTAMP_PLACEHOLDER);
const escapedParts = parts.map(escapeRegexSpecialChars);
const formatRegex = escapedParts.join(TIMESTAMP_REGEX);
```

### Changes
- Refactored timestamp placeholder replacement to use split/join pattern
- Functionally equivalent behavior
- Resolves CodeQL js/incomplete-sanitization alerts

## Test plan
- [x] Unit tests pass
- [x] TypeScript type checking passes
- [ ] CI pipeline passes
- [ ] CodeQL analysis passes (no new alerts)

Closes #1138