### PR TITLE
feat(plugin): Add toggle for showing/hiding archived Areas in hierarchy block

### DIFF
--- a/flaky-report.json
+++ b/flaky-report.json
@@ -1,10 +1,10 @@
 {
-  "timestamp": "2025-12-21T05:21:15.310Z",
+  "timestamp": "2025-12-23T04:25:05.324Z",
   "totalFlaky": 0,
   "tests": [],
   "summary": {
-    "totalTests": 4062,
-    "totalSuites": 197,
+    "totalTests": 4083,
+    "totalSuites": 198,
     "flakyPercentage": 0
   }
 }

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/AreaTreeRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/AreaTreeRenderer.ts
@@ -2,7 +2,7 @@ import { TFile, Keymap } from "obsidian";
 import React from "react";
 import { ReactRenderer } from '@plugin/presentation/utils/ReactRenderer';
 import { MetadataExtractor, AssetClass, AreaHierarchyBuilder, IVaultAdapter } from "exocortex";
-import { AreaHierarchyTree, type AreaClickEvent } from '@plugin/presentation/components/AreaHierarchyTree';
+import { AreaHierarchyTreeWithToggle, type AreaClickEvent } from '@plugin/presentation/components/AreaHierarchyTree';
 import { AssetMetadataService } from "./helpers/AssetMetadataService";
 import { AssetRelation } from "./types";
 import { ILogger } from '@plugin/adapters/logging/ILogger';
@@ -72,7 +72,7 @@ export class AreaTreeRenderer {
 
     this.reactRenderer.render(
       treeContainer,
-      React.createElement(AreaHierarchyTree, {
+      React.createElement(AreaHierarchyTreeWithToggle, {
         tree,
         currentAreaPath: file.path,
         onAreaClick: async (path: string, event: AreaClickEvent) => {

--- a/packages/obsidian-plugin/tests/unit/AreaTreeRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AreaTreeRenderer.test.ts
@@ -31,6 +31,7 @@ jest.mock("exocortex", () => ({
 
 jest.mock("../../src/presentation/components/AreaHierarchyTree", () => ({
   AreaHierarchyTree: jest.fn(() => null),
+  AreaHierarchyTreeWithToggle: jest.fn(() => null),
 }));
 
 describe("AreaTreeRenderer", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/components/AreaHierarchyTree.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/AreaHierarchyTree.test.tsx
@@ -1,0 +1,462 @@
+/**
+ * AreaHierarchyTree Unit Tests
+ *
+ * Tests for the AreaHierarchyTree and AreaHierarchyTreeWithToggle components.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  AreaHierarchyTree,
+  AreaHierarchyTreeWithToggle,
+  AreaNode,
+  AreaHierarchyTreeProps,
+  AreaHierarchyTreeWithToggleProps,
+} from "../../../../src/presentation/components/AreaHierarchyTree";
+
+// Mock the uiStore
+const mockToggleArchived = jest.fn();
+
+// Create mock implementation for each selector call
+jest.mock("../../../../src/presentation/stores", () => ({
+  useUIStore: jest.fn((selector) => {
+    // The component calls useUIStore twice with different selectors
+    // First with (state) => state.showArchived
+    // Second with (state) => state.toggleArchived
+    const selectorStr = selector.toString();
+    if (selectorStr.includes("showArchived") && !selectorStr.includes("toggleArchived")) {
+      return false; // default showArchived value
+    }
+    if (selectorStr.includes("toggleArchived")) {
+      return mockToggleArchived;
+    }
+    return undefined;
+  }),
+}));
+
+describe("AreaHierarchyTree", () => {
+  const createMockTree = (overrides: Partial<AreaNode> = {}): AreaNode => ({
+    path: "root",
+    title: "Root Area",
+    label: "Root",
+    isArchived: false,
+    depth: 0,
+    children: [
+      {
+        path: "child1.md",
+        title: "Child Area 1",
+        label: "Child 1",
+        isArchived: false,
+        depth: 1,
+        children: [],
+      },
+      {
+        path: "child2.md",
+        title: "Child Area 2",
+        label: "Child 2",
+        isArchived: true,
+        depth: 1,
+        children: [
+          {
+            path: "grandchild.md",
+            title: "Grandchild Area",
+            label: "Grandchild",
+            isArchived: false,
+            depth: 2,
+            children: [],
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  });
+
+  const createProps = (overrides: Partial<AreaHierarchyTreeProps> = {}): AreaHierarchyTreeProps => ({
+    tree: createMockTree(),
+    currentAreaPath: "child1.md",
+    onAreaClick: jest.fn(),
+    getAssetLabel: jest.fn(),
+    ...overrides,
+  });
+
+  describe("AreaHierarchyTree component", () => {
+    it("should render without crashing", () => {
+      const props = createProps();
+      const element = AreaHierarchyTree(props);
+      expect(element).not.toBeNull();
+    });
+
+    it("should return null when tree has no children", () => {
+      const props = createProps({
+        tree: createMockTree({ children: [] }),
+      });
+      const element = AreaHierarchyTree(props);
+      expect(element).toBeNull();
+    });
+
+    it("should render with correct wrapper class", () => {
+      const props = createProps();
+      const element = AreaHierarchyTree(props);
+      expect(element?.props.className).toBe("exocortex-area-tree");
+    });
+
+    it("should render Area Hierarchy heading", () => {
+      const props = createProps();
+      const element = AreaHierarchyTree(props);
+
+      const findH3 = (el: React.ReactElement): React.ReactElement | null => {
+        if (el.type === "h3") return el;
+        if (!el.props?.children) return null;
+
+        const children = Array.isArray(el.props.children)
+          ? el.props.children
+          : [el.props.children];
+
+        for (const child of children) {
+          if (child && typeof child === "object" && "type" in child) {
+            const found = findH3(child as React.ReactElement);
+            if (found) return found;
+          }
+        }
+        return null;
+      };
+
+      const heading = findH3(element as React.ReactElement);
+      expect(heading).not.toBeNull();
+      expect(heading?.props.children).toBe("Area Hierarchy");
+    });
+
+    it("should render table with tree role", () => {
+      const props = createProps();
+      const element = AreaHierarchyTree(props);
+
+      const findTable = (el: React.ReactElement): React.ReactElement | null => {
+        if (el.type === "table") return el;
+        if (!el.props?.children) return null;
+
+        const children = Array.isArray(el.props.children)
+          ? el.props.children
+          : [el.props.children];
+
+        for (const child of children) {
+          if (child && typeof child === "object" && "type" in child) {
+            const found = findTable(child as React.ReactElement);
+            if (found) return found;
+          }
+        }
+        return null;
+      };
+
+      const table = findTable(element as React.ReactElement);
+      expect(table).not.toBeNull();
+      expect(table?.props.role).toBe("tree");
+      expect(table?.props["aria-label"]).toBe("Area hierarchy tree");
+    });
+  });
+});
+
+describe("AreaHierarchyTreeWithToggle", () => {
+  beforeEach(() => {
+    mockToggleArchived.mockClear();
+  });
+
+  const createMockTree = (overrides: Partial<AreaNode> = {}): AreaNode => ({
+    path: "root",
+    title: "Root Area",
+    label: "Root",
+    isArchived: false,
+    depth: 0,
+    children: [
+      {
+        path: "child1.md",
+        title: "Child Area 1",
+        label: "Child 1",
+        isArchived: false,
+        depth: 1,
+        children: [],
+      },
+      {
+        path: "child2.md",
+        title: "Child Area 2",
+        label: "Child 2",
+        isArchived: true,
+        depth: 1,
+        children: [
+          {
+            path: "grandchild.md",
+            title: "Grandchild Area",
+            label: "Grandchild",
+            isArchived: false,
+            depth: 2,
+            children: [],
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  });
+
+  const createProps = (overrides: Partial<AreaHierarchyTreeWithToggleProps> = {}): AreaHierarchyTreeWithToggleProps => ({
+    tree: createMockTree(),
+    currentAreaPath: "child1.md",
+    onAreaClick: jest.fn(),
+    getAssetLabel: jest.fn(),
+    ...overrides,
+  });
+
+  describe("component structure", () => {
+    it("should render without crashing", () => {
+      const props = createProps();
+      const { container } = render(<AreaHierarchyTreeWithToggle {...props} />);
+      expect(container.querySelector(".exocortex-area-tree-wrapper")).toBeInTheDocument();
+    });
+
+    it("should render toggle button", () => {
+      const props = createProps();
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+      const button = screen.getByRole("button", { name: /archived/i });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveClass("exocortex-toggle-archived");
+    });
+
+    it("should show 'Show Archived' text when showArchived is false", () => {
+      const props = createProps({ showArchived: false });
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+      expect(screen.getByRole("button")).toHaveTextContent("Show Archived");
+    });
+
+    it("should show 'Hide Archived' text when showArchived is true", () => {
+      const props = createProps({ showArchived: true });
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+      expect(screen.getByRole("button", { name: /archived/i })).toHaveTextContent("Hide Archived");
+    });
+
+    it("should call onToggleArchived when button is clicked", () => {
+      const onToggleArchived = jest.fn();
+      const props = createProps({ onToggleArchived });
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /archived/i }));
+      expect(onToggleArchived).toHaveBeenCalled();
+    });
+
+    it("should have functional toggle button when no onToggleArchived prop", () => {
+      // When no onToggleArchived prop, it falls back to store.toggleArchived
+      // We test that the button is clickable without throwing
+      const props = createProps();
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      const button = screen.getByRole("button", { name: /archived/i });
+      expect(button).toBeInTheDocument();
+      // Button should be functional (no error when clicked)
+      // Note: Store mock behavior is tested via prop-based tests
+    });
+  });
+
+  describe("filtering logic", () => {
+    it("should filter out archived areas when showArchived is false", () => {
+      const props = createProps({ showArchived: false });
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      // Child 1 (not archived) should be present
+      expect(screen.getByText("Child 1")).toBeInTheDocument();
+
+      // Child 2 (archived) should not be present
+      expect(screen.queryByText("Child 2")).not.toBeInTheDocument();
+    });
+
+    it("should show all areas including archived when showArchived is true", () => {
+      const props = createProps({ showArchived: true });
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      expect(screen.getByText("Child 1")).toBeInTheDocument();
+      expect(screen.getByText("Child 2")).toBeInTheDocument();
+    });
+
+    it("should show 'No areas to display' when all areas are filtered out", () => {
+      const allArchivedTree: AreaNode = {
+        path: "root",
+        title: "Root",
+        label: "Root",
+        isArchived: false,
+        depth: 0,
+        children: [
+          {
+            path: "archived1.md",
+            title: "Archived 1",
+            label: "Archived 1",
+            isArchived: true,
+            depth: 1,
+            children: [],
+          },
+        ],
+      };
+
+      const props = createProps({
+        tree: allArchivedTree,
+        showArchived: false,
+      });
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      expect(screen.getByText("No areas to display")).toBeInTheDocument();
+    });
+
+    it("should also filter out children of archived areas", () => {
+      const props = createProps({ showArchived: false });
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      // Child 2's grandchild should not appear since Child 2 is archived
+      expect(screen.queryByText("Grandchild")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("empty tree handling", () => {
+    it("should handle tree with no children", () => {
+      const props = createProps({
+        tree: createMockTree({ children: [] }),
+        showArchived: false,
+      });
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      expect(screen.getByText("No areas to display")).toBeInTheDocument();
+    });
+
+    it("should still show toggle button when tree is empty", () => {
+      const props = createProps({
+        tree: createMockTree({ children: [] }),
+      });
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      expect(screen.getByRole("button", { name: /archived/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("fallback behavior", () => {
+    it("should fall back to store when showArchived prop is undefined", () => {
+      // When no showArchived prop is provided, the component falls back to store
+      // Testing this behavior: store defaults to false (mocked above)
+      const props = createProps();
+      delete (props as Partial<AreaHierarchyTreeWithToggleProps>).showArchived;
+
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      // With store showArchived = false (default), archived areas should be hidden
+      expect(screen.queryByText("Child 2")).not.toBeInTheDocument();
+      expect(screen.getByText("Child 1")).toBeInTheDocument();
+    });
+
+    it("should prefer explicit prop value over store value", () => {
+      // Test that explicit prop takes precedence
+      const props = createProps({ showArchived: true });
+
+      render(<AreaHierarchyTreeWithToggle {...props} />);
+
+      // Prop says true, so all areas should be visible
+      expect(screen.getByText("Child 1")).toBeInTheDocument();
+      expect(screen.getByText("Child 2")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("filterArchivedAreas logic", () => {
+  beforeEach(() => {
+    mockToggleArchived.mockClear();
+  });
+
+  it("should preserve non-archived areas at all depths", () => {
+    const deepTree: AreaNode = {
+      path: "root",
+      title: "Root",
+      label: "Root",
+      isArchived: false,
+      depth: 0,
+      children: [
+        {
+          path: "level1.md",
+          title: "Level 1",
+          label: "Level 1",
+          isArchived: false,
+          depth: 1,
+          children: [
+            {
+              path: "level2.md",
+              title: "Level 2",
+              label: "Level 2",
+              isArchived: false,
+              depth: 2,
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    render(
+      <AreaHierarchyTreeWithToggle
+        tree={deepTree}
+        currentAreaPath="level1.md"
+        showArchived={false}
+      />
+    );
+
+    expect(screen.getByText("Level 1")).toBeInTheDocument();
+
+    // Expand Level 1 to see Level 2
+    const toggleButton = screen.getByRole("button", { name: /expand level 1/i });
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByText("Level 2")).toBeInTheDocument();
+  });
+
+  it("should handle mixed archived/non-archived at same level", () => {
+    const mixedTree: AreaNode = {
+      path: "root",
+      title: "Root",
+      label: "Root",
+      isArchived: false,
+      depth: 0,
+      children: [
+        {
+          path: "active1.md",
+          title: "Active 1",
+          label: "Active 1",
+          isArchived: false,
+          depth: 1,
+          children: [],
+        },
+        {
+          path: "archived.md",
+          title: "Archived",
+          label: "Archived",
+          isArchived: true,
+          depth: 1,
+          children: [],
+        },
+        {
+          path: "active2.md",
+          title: "Active 2",
+          label: "Active 2",
+          isArchived: false,
+          depth: 1,
+          children: [],
+        },
+      ],
+    };
+
+    render(
+      <AreaHierarchyTreeWithToggle
+        tree={mixedTree}
+        currentAreaPath="active1.md"
+        showArchived={false}
+      />
+    );
+
+    // Should show 2 active areas
+    expect(screen.getByText("Active 1")).toBeInTheDocument();
+    expect(screen.getByText("Active 2")).toBeInTheDocument();
+
+    // Should hide archived
+    expect(screen.queryByText("Archived")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Added `AreaHierarchyTreeWithToggle` wrapper component with toggle button for archived areas
- Implemented recursive filtering to exclude archived areas and their children when toggle is OFF
- Connected to uiStore's `showArchived` state for persistence across sessions
- Updated `AreaTreeRenderer` to use the new wrapper component
- Added comprehensive unit tests for the toggle functionality

## Changes

1. **AreaHierarchyTree.tsx**: Added `AreaHierarchyTreeWithToggle` component with:
   - Toggle button above the tree (similar to DailyTasksTable and AssetRelationsTable)
   - Recursive `filterArchivedAreas` function that excludes archived areas and all their children
   - Integration with uiStore for state persistence
   - Support for both prop-based and store-based toggle control
   - Empty state message when all areas are filtered out

2. **AreaTreeRenderer.ts**: Updated to use `AreaHierarchyTreeWithToggle` instead of `AreaHierarchyTree`

3. **Tests**: Added unit tests covering:
   - Toggle button rendering and text changes (Show/Hide Archived)
   - Filtering logic for archived areas
   - Children of archived areas are also filtered
   - Empty tree handling
   - Store integration fallback behavior

## Test plan

- [x] Toggle button appears above Area hierarchy tree
- [x] Default state hides archived Areas
- [x] Clicking toggle shows/hides archived Areas
- [x] Archived Areas' children are also filtered when parent is archived
- [x] "No areas to display" message shown when all areas are filtered
- [x] Toggle state persists via uiStore
- [x] Unit tests pass

Closes #1142