### PR TITLE
feat: Show exo__Asset_label in File Explorer instead of filename

### DIFF
--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -9,6 +9,7 @@ export interface ExocortexSettings {
   showFullDateInEffortTimes: boolean;
   showDailyNoteProjects: boolean;
   useDynamicPropertyFields: boolean;
+  showLabelsInFileExplorer: boolean;
   [key: string]: unknown;
 }
 
@@ -23,4 +24,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   showFullDateInEffortTimes: false,
   showDailyNoteProjects: true,
   useDynamicPropertyFields: false,
+  showLabelsInFileExplorer: true,
 };

--- a/packages/obsidian-plugin/src/presentation/file-explorer/FileExplorerPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/file-explorer/FileExplorerPatch.ts
@@ -1,0 +1,331 @@
+import { TFile, WorkspaceLeaf, Plugin, CachedMetadata } from "obsidian";
+
+/**
+ * FileExplorerPatch - Patches Obsidian's File Explorer to show exo__Asset_label instead of filenames
+ *
+ * This patch intercepts the File Explorer's rendering to display meaningful labels
+ * for notes that have exo__Asset_label set in their frontmatter. Falls back to
+ * the original filename if no label is set.
+ *
+ * Implementation approach:
+ * - Uses MutationObserver to detect File Explorer DOM changes
+ * - Patches file items by modifying their inner text content
+ * - Listens for metadata changes to update labels dynamically
+ * - Stores original filenames as data attributes for tooltips
+ */
+export class FileExplorerPatch {
+  private app: Plugin["app"];
+  private plugin: Plugin;
+  private observer: MutationObserver | null = null;
+  private enabled = false;
+  private patchedElements: WeakMap<HTMLElement, string> = new WeakMap();
+  private metadataChangeHandler: (file: TFile, data: string, cache: CachedMetadata) => void;
+
+  constructor(plugin: Plugin) {
+    this.plugin = plugin;
+    this.app = plugin.app;
+    this.metadataChangeHandler = this.handleMetadataChange.bind(this);
+  }
+
+  /**
+   * Enable the File Explorer label patch
+   */
+  enable(): void {
+    if (this.enabled) return;
+    this.enabled = true;
+
+    // Initial patch of existing File Explorer
+    this.patchFileExplorer();
+
+    // Set up observer for dynamic content
+    this.setupObserver();
+
+    // Listen for metadata changes to update labels
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("changed", this.metadataChangeHandler)
+    );
+
+    // Re-patch when workspace layout changes (e.g., File Explorer reopened)
+    this.plugin.registerEvent(
+      this.app.workspace.on("layout-change", () => {
+        // Use setTimeout to ensure DOM is updated
+        setTimeout(() => this.patchFileExplorer(), 100);
+      })
+    );
+  }
+
+  /**
+   * Disable the File Explorer label patch and restore original filenames
+   */
+  disable(): void {
+    if (!this.enabled) return;
+    this.enabled = false;
+
+    // Disconnect observer
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+
+    // Restore all patched elements
+    this.restoreAllLabels();
+  }
+
+  /**
+   * Cleanup resources when plugin unloads
+   */
+  cleanup(): void {
+    this.disable();
+  }
+
+  /**
+   * Find all File Explorer leaves in the workspace
+   */
+  private getFileExplorerLeaves(): WorkspaceLeaf[] {
+    // getLeavesOfType might not exist in test environment
+    if (typeof this.app.workspace.getLeavesOfType !== "function") {
+      return [];
+    }
+    const leaves = this.app.workspace.getLeavesOfType("file-explorer");
+    // Ensure we return an array even if the API returns undefined
+    return Array.isArray(leaves) ? leaves : [];
+  }
+
+  /**
+   * Patch all file items in the File Explorer
+   */
+  private patchFileExplorer(): void {
+    if (!this.enabled) return;
+
+    const leaves = this.getFileExplorerLeaves();
+    for (const leaf of leaves) {
+      const container = leaf.view.containerEl;
+      this.patchFileItems(container);
+    }
+  }
+
+  /**
+   * Patch file items within a container element
+   */
+  private patchFileItems(container: HTMLElement): void {
+    // File Explorer uses tree-item elements with file-tree-item class
+    const fileItems = container.querySelectorAll<HTMLElement>(
+      ".tree-item.nav-file"
+    );
+
+    for (const item of Array.from(fileItems)) {
+      this.patchFileItem(item);
+    }
+  }
+
+  /**
+   * Patch a single file item element
+   */
+  private patchFileItem(item: HTMLElement): void {
+    // Get the title element (inner text of the nav-file-title)
+    const titleEl = item.querySelector<HTMLElement>(".nav-file-title-content");
+    if (!titleEl) return;
+
+    // Get the file path from the data attribute
+    const titleWrapper = item.querySelector<HTMLElement>(".nav-file-title");
+    if (!titleWrapper) return;
+
+    const filePath = titleWrapper.getAttribute("data-path");
+    if (!filePath) return;
+
+    // Get the file
+    const file = this.app.vault.getAbstractFileByPath(filePath);
+    if (!(file instanceof TFile) || file.extension !== "md") return;
+
+    // Get the asset label from frontmatter
+    const label = this.getAssetLabel(file);
+    if (!label) return;
+
+    // Store original filename in data attribute for tooltip
+    const originalName = file.basename;
+    if (!titleEl.hasAttribute("data-original-name")) {
+      titleEl.setAttribute("data-original-name", originalName);
+    }
+
+    // Only update if different from current
+    if (titleEl.textContent !== label) {
+      titleEl.textContent = label;
+      this.patchedElements.set(titleEl, originalName);
+
+      // Add tooltip with original filename
+      titleWrapper.setAttribute("aria-label", `${label}\n(${originalName}.md)`);
+    }
+  }
+
+  /**
+   * Get the exo__Asset_label from a file's frontmatter
+   */
+  private getAssetLabel(file: TFile): string | null {
+    const cache = this.app.metadataCache.getFileCache(file);
+    const frontmatter = cache?.frontmatter;
+
+    if (!frontmatter) return null;
+
+    const label = frontmatter.exo__Asset_label;
+    if (label && typeof label === "string" && label.trim() !== "") {
+      return label.trim();
+    }
+
+    // Fall back to prototype label if available
+    const prototypeRef = frontmatter.exo__Asset_prototype;
+    if (prototypeRef) {
+      const prototypePath =
+        typeof prototypeRef === "string"
+          ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
+          : null;
+
+      if (prototypePath) {
+        let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+          prototypePath,
+          ""
+        );
+
+        // Try with .md extension if not found
+        if (!prototypeFile && !prototypePath.endsWith(".md")) {
+          prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+            prototypePath + ".md",
+            ""
+          );
+        }
+
+        if (prototypeFile instanceof TFile) {
+          const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
+          const prototypeMetadata = prototypeCache?.frontmatter;
+
+          if (prototypeMetadata) {
+            const prototypeLabel = prototypeMetadata.exo__Asset_label;
+            if (
+              prototypeLabel &&
+              typeof prototypeLabel === "string" &&
+              prototypeLabel.trim() !== ""
+            ) {
+              return prototypeLabel.trim();
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Set up MutationObserver to detect File Explorer DOM changes
+   */
+  private setupObserver(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+
+    this.observer = new MutationObserver((mutations) => {
+      if (!this.enabled) return;
+
+      for (const mutation of mutations) {
+        // Check for added nodes
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (node instanceof HTMLElement) {
+            // Check if this is a file item or contains file items
+            if (node.classList?.contains("nav-file")) {
+              this.patchFileItem(node);
+            } else {
+              // Check for nested file items
+              const fileItems = node.querySelectorAll<HTMLElement>(
+                ".tree-item.nav-file"
+              );
+              for (const item of Array.from(fileItems)) {
+                this.patchFileItem(item);
+              }
+            }
+          }
+        }
+      }
+    });
+
+    // Observe all File Explorer containers
+    const leaves = this.getFileExplorerLeaves();
+    for (const leaf of leaves) {
+      const container = leaf.view.containerEl;
+      this.observer.observe(container, {
+        childList: true,
+        subtree: true,
+      });
+    }
+  }
+
+  /**
+   * Handle metadata changes to update labels
+   */
+  private handleMetadataChange(file: TFile): void {
+    if (!this.enabled) return;
+    if (file.extension !== "md") return;
+
+    // Find and update the file item for this file
+    const leaves = this.getFileExplorerLeaves();
+    for (const leaf of leaves) {
+      const container = leaf.view.containerEl;
+      const titleWrapper = container.querySelector<HTMLElement>(
+        `.nav-file-title[data-path="${file.path}"]`
+      );
+
+      if (titleWrapper) {
+        const item = titleWrapper.closest<HTMLElement>(".tree-item.nav-file");
+        if (item) {
+          // Get current label
+          const newLabel = this.getAssetLabel(file);
+          const titleEl = item.querySelector<HTMLElement>(".nav-file-title-content");
+
+          if (titleEl) {
+            if (newLabel) {
+              // Update with new label
+              const originalName = titleEl.getAttribute("data-original-name") || file.basename;
+              titleEl.textContent = newLabel;
+              titleWrapper.setAttribute("aria-label", `${newLabel}\n(${originalName}.md)`);
+              this.patchedElements.set(titleEl, originalName);
+            } else {
+              // Restore original filename if label was removed
+              const originalName = titleEl.getAttribute("data-original-name");
+              if (originalName) {
+                titleEl.textContent = originalName;
+                titleWrapper.removeAttribute("aria-label");
+                this.patchedElements.delete(titleEl);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Restore all patched elements to their original filenames
+   */
+  private restoreAllLabels(): void {
+    const leaves = this.getFileExplorerLeaves();
+    for (const leaf of leaves) {
+      const container = leaf.view.containerEl;
+      const titleElements = container.querySelectorAll<HTMLElement>(
+        ".nav-file-title-content[data-original-name]"
+      );
+
+      for (const titleEl of Array.from(titleElements)) {
+        const originalName = titleEl.getAttribute("data-original-name");
+        if (originalName) {
+          titleEl.textContent = originalName;
+          titleEl.removeAttribute("data-original-name");
+
+          const titleWrapper = titleEl.closest<HTMLElement>(".nav-file-title");
+          if (titleWrapper) {
+            titleWrapper.removeAttribute("aria-label");
+          }
+        }
+      }
+    }
+
+    this.patchedElements = new WeakMap();
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -138,5 +138,20 @@ export class ExocortexSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           }),
       );
+
+    new Setting(containerEl)
+      .setName("Show labels in File Explorer")
+      .setDesc(
+        "Display exo__Asset_label instead of filenames in the File Explorer sidebar",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showLabelsInFileExplorer)
+          .onChange(async (value) => {
+            this.plugin.settings.showLabelsInFileExplorer = value;
+            await this.plugin.saveSettings();
+            this.plugin.toggleFileExplorerLabels(value);
+          }),
+      );
   }
 }

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -93,6 +93,7 @@ describe("ExocortexPlugin", () => {
     mockWorkspace = {
       getActiveViewOfType: jest.fn().mockReturnValue(mockView),
       getActiveFile: jest.fn(),
+      getLeavesOfType: jest.fn().mockReturnValue([]),
       on: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
     };
 

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -301,7 +301,7 @@ describe("ExocortexSettingTab", () => {
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
       expect(getOntologySpy).toHaveBeenCalledTimes(1);
-      expect(MockSetting).toHaveBeenCalledTimes(6);
+      expect(MockSetting).toHaveBeenCalledTimes(7);
     });
 
     it("should render ontology dropdown with correct options", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/file-explorer/FileExplorerPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/file-explorer/FileExplorerPatch.test.ts
@@ -1,0 +1,304 @@
+import { FileExplorerPatch } from "../../../../src/presentation/file-explorer/FileExplorerPatch";
+import { TFile, WorkspaceLeaf, Plugin, CachedMetadata } from "obsidian";
+
+describe("FileExplorerPatch", () => {
+  let patch: FileExplorerPatch;
+  let mockPlugin: any;
+  let mockApp: any;
+  let mockWorkspaceLeaf: any;
+  let mockContainerEl: HTMLElement;
+
+  beforeEach(() => {
+    // Create mock DOM elements
+    mockContainerEl = document.createElement("div");
+
+    mockWorkspaceLeaf = {
+      view: {
+        containerEl: mockContainerEl,
+      },
+    };
+
+    mockApp = {
+      workspace: {
+        getLeavesOfType: jest.fn().mockReturnValue([mockWorkspaceLeaf]),
+        on: jest.fn().mockReturnValue({ id: "test" }),
+      },
+      vault: {
+        getAbstractFileByPath: jest.fn(),
+      },
+      metadataCache: {
+        getFileCache: jest.fn(),
+        getFirstLinkpathDest: jest.fn(),
+        on: jest.fn().mockReturnValue({ id: "test" }),
+      },
+    };
+
+    mockPlugin = {
+      app: mockApp,
+      registerEvent: jest.fn(),
+    };
+
+    patch = new FileExplorerPatch(mockPlugin);
+  });
+
+  afterEach(() => {
+    patch.cleanup();
+    jest.clearAllMocks();
+  });
+
+  describe("enable", () => {
+    it("should register metadata change event on enable", () => {
+      patch.enable();
+
+      expect(mockPlugin.registerEvent).toHaveBeenCalled();
+      expect(mockApp.metadataCache.on).toHaveBeenCalledWith(
+        "changed",
+        expect.any(Function)
+      );
+    });
+
+    it("should register layout change event on enable", () => {
+      patch.enable();
+
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        "layout-change",
+        expect.any(Function)
+      );
+    });
+
+    it("should not double-enable", () => {
+      patch.enable();
+      patch.enable();
+
+      // Should only register events once (2 calls: metadata + layout)
+      expect(mockPlugin.registerEvent).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("disable", () => {
+    it("should restore original filenames on disable", () => {
+      // Set up a patched file item
+      const fileItem = document.createElement("div");
+      fileItem.className = "tree-item nav-file";
+
+      const titleWrapper = document.createElement("div");
+      titleWrapper.className = "nav-file-title";
+      titleWrapper.setAttribute("data-path", "test-file.md");
+
+      const titleContent = document.createElement("div");
+      titleContent.className = "nav-file-title-content";
+      titleContent.textContent = "Asset Label";
+      titleContent.setAttribute("data-original-name", "test-file");
+
+      titleWrapper.appendChild(titleContent);
+      fileItem.appendChild(titleWrapper);
+      mockContainerEl.appendChild(fileItem);
+
+      patch.enable();
+      patch.disable();
+
+      expect(titleContent.textContent).toBe("test-file");
+      expect(titleContent.hasAttribute("data-original-name")).toBe(false);
+    });
+
+    it("should not error when disabling without enabling", () => {
+      expect(() => patch.disable()).not.toThrow();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should disable patch on cleanup", () => {
+      patch.enable();
+      patch.cleanup();
+
+      // Calling enable again should work (indicates cleanup was successful)
+      expect(() => patch.enable()).not.toThrow();
+    });
+  });
+
+  describe("getAssetLabel (via patching)", () => {
+    it("should get label from frontmatter", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Test Label",
+        },
+      });
+
+      // Create file item in DOM
+      const fileItem = document.createElement("div");
+      fileItem.className = "tree-item nav-file";
+
+      const titleWrapper = document.createElement("div");
+      titleWrapper.className = "nav-file-title";
+      titleWrapper.setAttribute("data-path", "test-file.md");
+
+      const titleContent = document.createElement("div");
+      titleContent.className = "nav-file-title-content";
+      titleContent.textContent = "test-file";
+
+      titleWrapper.appendChild(titleContent);
+      fileItem.appendChild(titleWrapper);
+      mockContainerEl.appendChild(fileItem);
+
+      patch.enable();
+
+      expect(titleContent.textContent).toBe("Test Label");
+      expect(titleWrapper.getAttribute("aria-label")).toContain("Test Label");
+      expect(titleWrapper.getAttribute("aria-label")).toContain("test-file.md");
+    });
+
+    it("should fallback to prototype label", () => {
+      const mockFile = new TFile();
+      const mockPrototypeFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      Object.defineProperty(mockPrototypeFile, "extension", { value: "md" });
+
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache
+        .mockReturnValueOnce({
+          frontmatter: {
+            exo__Asset_prototype: "[[prototype-path]]",
+          },
+        })
+        .mockReturnValueOnce({
+          frontmatter: {
+            exo__Asset_label: "Prototype Label",
+          },
+        });
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockPrototypeFile);
+
+      // Create file item in DOM
+      const fileItem = document.createElement("div");
+      fileItem.className = "tree-item nav-file";
+
+      const titleWrapper = document.createElement("div");
+      titleWrapper.className = "nav-file-title";
+      titleWrapper.setAttribute("data-path", "test-file.md");
+
+      const titleContent = document.createElement("div");
+      titleContent.className = "nav-file-title-content";
+      titleContent.textContent = "test-file";
+
+      titleWrapper.appendChild(titleContent);
+      fileItem.appendChild(titleWrapper);
+      mockContainerEl.appendChild(fileItem);
+
+      patch.enable();
+
+      expect(titleContent.textContent).toBe("Prototype Label");
+    });
+
+    it("should not change non-markdown files", () => {
+      const mockFile = {
+        extension: "png",
+        basename: "image",
+      };
+
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      // Create file item in DOM
+      const fileItem = document.createElement("div");
+      fileItem.className = "tree-item nav-file";
+
+      const titleWrapper = document.createElement("div");
+      titleWrapper.className = "nav-file-title";
+      titleWrapper.setAttribute("data-path", "image.png");
+
+      const titleContent = document.createElement("div");
+      titleContent.className = "nav-file-title-content";
+      titleContent.textContent = "image";
+
+      titleWrapper.appendChild(titleContent);
+      fileItem.appendChild(titleWrapper);
+      mockContainerEl.appendChild(fileItem);
+
+      patch.enable();
+
+      expect(titleContent.textContent).toBe("image");
+    });
+
+    it("should not change files without label", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "no-label" });
+
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {},
+      });
+
+      // Create file item in DOM
+      const fileItem = document.createElement("div");
+      fileItem.className = "tree-item nav-file";
+
+      const titleWrapper = document.createElement("div");
+      titleWrapper.className = "nav-file-title";
+      titleWrapper.setAttribute("data-path", "no-label.md");
+
+      const titleContent = document.createElement("div");
+      titleContent.className = "nav-file-title-content";
+      titleContent.textContent = "no-label";
+
+      titleWrapper.appendChild(titleContent);
+      fileItem.appendChild(titleWrapper);
+      mockContainerEl.appendChild(fileItem);
+
+      patch.enable();
+
+      expect(titleContent.textContent).toBe("no-label");
+    });
+  });
+
+  describe("metadata change handling", () => {
+    it("should update label when metadata changes", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      Object.defineProperty(mockFile, "path", { value: "test-file.md" });
+
+      // Create file item in DOM
+      const fileItem = document.createElement("div");
+      fileItem.className = "tree-item nav-file";
+
+      const titleWrapper = document.createElement("div");
+      titleWrapper.className = "nav-file-title";
+      titleWrapper.setAttribute("data-path", "test-file.md");
+
+      const titleContent = document.createElement("div");
+      titleContent.className = "nav-file-title-content";
+      titleContent.textContent = "Old Label";
+      titleContent.setAttribute("data-original-name", "test-file");
+
+      titleWrapper.appendChild(titleContent);
+      fileItem.appendChild(titleWrapper);
+      mockContainerEl.appendChild(fileItem);
+
+      // Set up mock to return new label
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "New Label",
+        },
+      });
+
+      patch.enable();
+
+      // Simulate metadata change by getting the callback and calling it
+      const metadataCallback = mockApp.metadataCache.on.mock.calls.find(
+        (call: [string, Function]) => call[0] === "changed"
+      )?.[1];
+
+      if (metadataCallback) {
+        metadataCallback(mockFile);
+      }
+
+      expect(titleContent.textContent).toBe("New Label");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implement File Explorer title replacement to display `exo__Asset_label` instead of UUID-based filenames in Obsidian's sidebar.

**Key changes:**
- Add `FileExplorerPatch` class that patches File Explorer item rendering
- Use `MutationObserver` to detect and patch new file items dynamically
- Display `exo__Asset_label` from frontmatter when available
- Fall back to prototype label if direct label not set
- Add tooltip showing original filename on hover
- Add settings toggle "Show labels in File Explorer" (enabled by default)
- Listen for metadata changes to update labels in real-time
- Clean restore of original filenames when disabled

## Test plan

- [x] Unit tests for `FileExplorerPatch` class (12 tests)
- [ ] Manual testing in Obsidian vault with UUID-named files
- [ ] Verify settings toggle enables/disables the feature
- [ ] Verify labels update when `exo__Asset_label` changes
- [ ] Verify prototype label fallback works correctly

Closes #1143