### PR TITLE
feat: Template system for display names

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -296,6 +296,25 @@ export default class ExocortexPlugin extends Plugin {
     }
   }
 
+  /**
+   * Apply display name template changes
+   * Called from settings when the displayNameTemplate changes
+   * Triggers re-evaluation of tab titles and file explorer labels
+   */
+  applyDisplayNameTemplate(): void {
+    // Re-apply file explorer labels with new template
+    if (this.settings.showLabelsInFileExplorer && this.fileExplorerPatch) {
+      this.fileExplorerPatch.disable();
+      this.fileExplorerPatch.enable();
+    }
+
+    // Re-apply tab title labels with new template
+    if (this.settings.showLabelsInTabTitles && this.tabTitlePatch) {
+      this.tabTitlePatch.disable();
+      this.tabTitlePatch.enable();
+    }
+  }
+
   private autoRenderLayout(): void {
     // Remove existing auto-rendered layouts
     this.removeAutoRenderedLayouts();

--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
@@ -1,0 +1,212 @@
+/**
+ * DisplayNameTemplateEngine - Renders display names from templates
+ *
+ * Template syntax:
+ * - {{field}} - Replaced with frontmatter field value
+ * - {{field.nested}} - Dot-notation for nested fields (e.g., {{custom.priority}})
+ * - {{_basename}} - Original filename without extension
+ * - {{_created}} - File creation date
+ *
+ * Special handling:
+ * - Wikilink syntax [[link]] is stripped from values
+ * - Empty template results fall back to label or basename
+ *
+ * Example templates:
+ * - "{{exo__Asset_label}}" - Just the label (default)
+ * - "{{exo__Asset_label}}: {{ems__Effort_status}}" - Label with status
+ * - "[{{exo__Instance_class}}] {{exo__Asset_label}}" - Class prefix
+ * - "{{_basename}} - {{exo__Asset_label}}" - Filename with label
+ */
+export class DisplayNameTemplateEngine {
+  private static readonly PLACEHOLDER_PATTERN = /\{\{([^}]+)\}\}/g;
+  private static readonly WIKILINK_PATTERN = /^\[\[|\]\]$/g;
+
+  constructor(private readonly template: string) {}
+
+  /**
+   * Render the template with provided metadata
+   *
+   * @param metadata - Frontmatter metadata object
+   * @param basename - Original filename without extension
+   * @param createdDate - Optional file creation date
+   * @returns Rendered display name, or null if template produces empty result
+   */
+  render(
+    metadata: Record<string, unknown>,
+    basename: string,
+    createdDate?: Date
+  ): string | null {
+    if (!this.template || this.template.trim() === "") {
+      return null;
+    }
+
+    const result = this.template.replace(
+      DisplayNameTemplateEngine.PLACEHOLDER_PATTERN,
+      (_, key: string) => {
+        const trimmedKey = key.trim();
+        return this.resolveValue(trimmedKey, metadata, basename, createdDate);
+      }
+    );
+
+    // Return null if template produces empty or whitespace-only result
+    const trimmedResult = result.trim();
+    if (trimmedResult === "") {
+      return null;
+    }
+
+    return trimmedResult;
+  }
+
+  /**
+   * Resolve a placeholder value
+   */
+  private resolveValue(
+    key: string,
+    metadata: Record<string, unknown>,
+    basename: string,
+    createdDate?: Date
+  ): string {
+    // Handle special variables
+    if (key === "_basename") {
+      return basename;
+    }
+
+    if (key === "_created") {
+      if (createdDate) {
+        return this.formatDate(createdDate);
+      }
+      return "";
+    }
+
+    // Handle dot notation for nested fields
+    const value = this.getNestedValue(metadata, key);
+    return this.formatValue(value);
+  }
+
+  /**
+   * Get nested value from object using dot notation
+   */
+  private getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+    const parts = path.split(".");
+    let current: unknown = obj;
+
+    for (const part of parts) {
+      if (current === null || current === undefined) {
+        return undefined;
+      }
+
+      if (typeof current !== "object") {
+        return undefined;
+      }
+
+      current = (current as Record<string, unknown>)[part];
+    }
+
+    return current;
+  }
+
+  /**
+   * Format a value for display
+   */
+  private formatValue(value: unknown): string {
+    if (value === null || value === undefined) {
+      return "";
+    }
+
+    if (typeof value === "string") {
+      // Strip wikilink syntax
+      return value.replace(DisplayNameTemplateEngine.WIKILINK_PATTERN, "").trim();
+    }
+
+    if (Array.isArray(value)) {
+      // For arrays, use the first value
+      if (value.length === 0) {
+        return "";
+      }
+      return this.formatValue(value[0]);
+    }
+
+    if (typeof value === "object") {
+      // For objects, try to stringify
+      return JSON.stringify(value);
+    }
+
+    return String(value);
+  }
+
+  /**
+   * Format a date for display
+   */
+  private formatDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  /**
+   * Get the template string
+   */
+  getTemplate(): string {
+    return this.template;
+  }
+
+  /**
+   * Check if template is valid (has at least one placeholder)
+   */
+  isValid(): boolean {
+    if (!this.template || this.template.trim() === "") {
+      return false;
+    }
+    // Use a fresh regex without 'g' flag to avoid state issues
+    return /\{\{[^}]+\}\}/.test(this.template);
+  }
+
+  /**
+   * Extract all placeholder keys from template
+   */
+  getPlaceholders(): string[] {
+    const placeholders: string[] = [];
+    const regex = /\{\{([^}]+)\}\}/g;
+    let match;
+
+    while ((match = regex.exec(this.template)) !== null) {
+      placeholders.push(match[1].trim());
+    }
+
+    return placeholders;
+  }
+}
+
+/**
+ * Preset templates for common display name patterns
+ */
+export const DISPLAY_NAME_PRESETS = {
+  default: {
+    name: "Label only (default)",
+    template: "{{exo__Asset_label}}",
+  },
+  labelWithStatus: {
+    name: "Label with status",
+    template: "{{exo__Asset_label}}: {{ems__Effort_status}}",
+  },
+  classPrefix: {
+    name: "Class prefix",
+    template: "[{{exo__Instance_class}}] {{exo__Asset_label}}",
+  },
+  basenameWithLabel: {
+    name: "Filename with label",
+    template: "{{_basename}} - {{exo__Asset_label}}",
+  },
+  datePrefix: {
+    name: "Date prefix",
+    template: "{{_created}} - {{exo__Asset_label}}",
+  },
+} as const;
+
+export type DisplayNamePresetKey = keyof typeof DISPLAY_NAME_PRESETS;
+
+/**
+ * Default template (just shows label)
+ */
+export const DEFAULT_DISPLAY_NAME_TEMPLATE = DISPLAY_NAME_PRESETS.default.template;

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -11,6 +11,7 @@ export interface ExocortexSettings {
   useDynamicPropertyFields: boolean;
   showLabelsInFileExplorer: boolean;
   showLabelsInTabTitles: boolean;
+  displayNameTemplate: string;
   [key: string]: unknown;
 }
 
@@ -27,4 +28,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   useDynamicPropertyFields: false,
   showLabelsInFileExplorer: true,
   showLabelsInTabTitles: true,
+  displayNameTemplate: "{{exo__Asset_label}}",
 };

--- a/packages/obsidian-plugin/src/presentation/file-explorer/FileExplorerPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/file-explorer/FileExplorerPatch.ts
@@ -1,4 +1,6 @@
 import { TFile, WorkspaceLeaf, Plugin, CachedMetadata } from "obsidian";
+import { DisplayNameTemplateEngine, DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+import type { ExocortexSettings } from "@plugin/domain/settings/ExocortexSettings";
 
 /**
  * FileExplorerPatch - Patches Obsidian's File Explorer to show exo__Asset_label instead of filenames
@@ -13,18 +15,30 @@ import { TFile, WorkspaceLeaf, Plugin, CachedMetadata } from "obsidian";
  * - Listens for metadata changes to update labels dynamically
  * - Stores original filenames as data attributes for tooltips
  */
+// Plugin interface to access settings
+interface PluginWithSettings extends Plugin {
+  settings: ExocortexSettings;
+}
+
 export class FileExplorerPatch {
   private app: Plugin["app"];
-  private plugin: Plugin;
+  private plugin: PluginWithSettings;
   private observer: MutationObserver | null = null;
   private enabled = false;
   private patchedElements: WeakMap<HTMLElement, string> = new WeakMap();
   private metadataChangeHandler: (file: TFile, data: string, cache: CachedMetadata) => void;
 
   constructor(plugin: Plugin) {
-    this.plugin = plugin;
+    this.plugin = plugin as PluginWithSettings;
     this.app = plugin.app;
     this.metadataChangeHandler = this.handleMetadataChange.bind(this);
+  }
+
+  /**
+   * Get the display name template from settings
+   */
+  private getTemplate(): string {
+    return this.plugin.settings?.displayNameTemplate || DEFAULT_DISPLAY_NAME_TEMPLATE;
   }
 
   /**
@@ -158,7 +172,7 @@ export class FileExplorerPatch {
   }
 
   /**
-   * Get the exo__Asset_label from a file's frontmatter
+   * Get the display name from a file's frontmatter using the template engine
    */
   private getAssetLabel(file: TFile): string | null {
     const cache = this.app.metadataCache.getFileCache(file);
@@ -166,12 +180,28 @@ export class FileExplorerPatch {
 
     if (!frontmatter) return null;
 
+    // Build metadata for template rendering
+    const metadata = this.buildTemplateMetadata(frontmatter, file);
+
+    // Get creation date if available
+    const createdDate = file.stat?.ctime ? new Date(file.stat.ctime) : undefined;
+
+    // Use template engine to render display name
+    const template = this.getTemplate();
+    const engine = new DisplayNameTemplateEngine(template);
+    const displayName = engine.render(metadata, file.basename, createdDate);
+
+    if (displayName) {
+      return displayName;
+    }
+
+    // Fallback: try direct exo__Asset_label from frontmatter
     const label = frontmatter.exo__Asset_label;
     if (label && typeof label === "string" && label.trim() !== "") {
       return label.trim();
     }
 
-    // Fall back to prototype label if available
+    // Fallback: try prototype label if available
     const prototypeRef = frontmatter.exo__Asset_prototype;
     if (prototypeRef) {
       const prototypePath =
@@ -212,6 +242,52 @@ export class FileExplorerPatch {
     }
 
     return null;
+  }
+
+  /**
+   * Build metadata object for template rendering, merging frontmatter with prototype data
+   */
+  private buildTemplateMetadata(
+    frontmatter: Record<string, unknown>,
+    _file: TFile
+  ): Record<string, unknown> {
+    const metadata = { ...frontmatter };
+
+    // If label is missing, try to get from prototype
+    if (!metadata.exo__Asset_label) {
+      const prototypeRef = metadata.exo__Asset_prototype;
+      if (prototypeRef) {
+        const prototypePath =
+          typeof prototypeRef === "string"
+            ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
+            : null;
+
+        if (prototypePath) {
+          let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+            prototypePath,
+            ""
+          );
+
+          if (!prototypeFile && !prototypePath.endsWith(".md")) {
+            prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+              prototypePath + ".md",
+              ""
+            );
+          }
+
+          if (prototypeFile instanceof TFile) {
+            const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
+            const prototypeMetadata = prototypeCache?.frontmatter;
+
+            if (prototypeMetadata?.exo__Asset_label) {
+              metadata.exo__Asset_label = prototypeMetadata.exo__Asset_label;
+            }
+          }
+        }
+      }
+    }
+
+    return metadata;
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -28,6 +28,8 @@ describe("ExocortexSettingTab", () => {
   beforeEach(() => {
     mockContainerEl = {
       empty: jest.fn(),
+      createEl: jest.fn().mockReturnValue(document.createElement("div")),
+      createDiv: jest.fn().mockReturnValue(document.createElement("div")),
     };
 
     mockPlugin = createMockPlugin({
@@ -38,9 +40,15 @@ describe("ExocortexSettingTab", () => {
         showArchivedAssets: false,
         showDailyNoteProjects: true,
         useDynamicPropertyFields: false,
+        showLabelsInFileExplorer: true,
+        showLabelsInTabTitles: true,
+        displayNameTemplate: "{{exo__Asset_label}}",
       },
       saveSettings: jest.fn().mockResolvedValue(undefined),
       refreshLayout: jest.fn(),
+      toggleFileExplorerLabels: jest.fn(),
+      toggleTabTitleLabels: jest.fn(),
+      applyDisplayNameTemplate: jest.fn(),
     });
 
     mockApp = createMockApp();
@@ -67,6 +75,15 @@ describe("ExocortexSettingTab", () => {
             onChange: jest.fn().mockReturnThis(),
           };
           callback(toggle);
+          return setting;
+        }),
+        addText: jest.fn().mockImplementation((callback) => {
+          const text = {
+            setPlaceholder: jest.fn().mockReturnThis(),
+            setValue: jest.fn().mockReturnThis(),
+            onChange: jest.fn().mockReturnThis(),
+          };
+          callback(text);
           return setting;
         }),
       };
@@ -301,7 +318,8 @@ describe("ExocortexSettingTab", () => {
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
       expect(getOntologySpy).toHaveBeenCalledTimes(1);
-      expect(MockSetting).toHaveBeenCalledTimes(8);
+      // 8 original settings + 2 template settings (preset dropdown + custom template text)
+      expect(MockSetting).toHaveBeenCalledTimes(10);
     });
 
     it("should render ontology dropdown with correct options", () => {
@@ -327,6 +345,15 @@ describe("ExocortexSettingTab", () => {
             return setting;
           }),
           addToggle: jest.fn().mockReturnThis(),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
+            return setting;
+          }),
         };
         return setting;
       });
@@ -351,7 +378,8 @@ describe("ExocortexSettingTab", () => {
     it("should handle ontology dropdown change", async () => {
       jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue(["Ontology1"]);
 
-      let onChangeCallback: ((value: string) => Promise<void>) | undefined;
+      // Track onChange callbacks for each dropdown
+      const onChangeCallbacks: Array<(value: string) => Promise<void>> = [];
       MockSetting.mockImplementation((containerEl: any) => {
         const setting = {
           containerEl,
@@ -362,7 +390,7 @@ describe("ExocortexSettingTab", () => {
               addOption: jest.fn().mockReturnThis(),
               setValue: jest.fn().mockReturnThis(),
               onChange: jest.fn().mockImplementation((cb) => {
-                onChangeCallback = cb;
+                onChangeCallbacks.push(cb);
                 return dropdown;
               }),
             };
@@ -370,23 +398,33 @@ describe("ExocortexSettingTab", () => {
             return setting;
           }),
           addToggle: jest.fn().mockReturnThis(),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
+            return setting;
+          }),
         };
         return setting;
       });
 
       settingTab.display();
 
-      // Trigger onChange
-      if (onChangeCallback) {
-        await onChangeCallback("Ontology1");
+      // First dropdown onChange is for ontology
+      const ontologyOnChange = onChangeCallbacks[0];
+      if (ontologyOnChange) {
+        await ontologyOnChange("Ontology1");
       }
 
       expect(mockPlugin.settings.defaultOntologyAsset).toBe("Ontology1");
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
 
       // Test clearing the value
-      if (onChangeCallback) {
-        await onChangeCallback("");
+      if (ontologyOnChange) {
+        await ontologyOnChange("");
       }
 
       expect(mockPlugin.settings.defaultOntologyAsset).toBeNull();
@@ -426,6 +464,15 @@ describe("ExocortexSettingTab", () => {
               return toggle;
             });
             callback(toggle);
+            return setting;
+          }),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
             return setting;
           }),
         };
@@ -483,6 +530,15 @@ describe("ExocortexSettingTab", () => {
             callback(toggle);
             return setting;
           }),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
+            return setting;
+          }),
         };
         return setting;
       });
@@ -535,6 +591,15 @@ describe("ExocortexSettingTab", () => {
               return toggle;
             });
             callback(toggle);
+            return setting;
+          }),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
             return setting;
           }),
         };
@@ -591,6 +656,15 @@ describe("ExocortexSettingTab", () => {
             callback(toggle);
             return setting;
           }),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
+            return setting;
+          }),
         };
         return setting;
       });
@@ -645,6 +719,15 @@ describe("ExocortexSettingTab", () => {
             callback(toggle);
             return setting;
           }),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
+            return setting;
+          }),
         };
         return setting;
       });
@@ -671,7 +754,8 @@ describe("ExocortexSettingTab", () => {
         "OtherOntology",
       ]);
 
-      let dropdownSetValue: string | undefined;
+      // Track dropdown values by dropdown index
+      const dropdownValues: string[] = [];
       MockSetting.mockImplementation((containerEl: any) => {
         const setting = {
           containerEl,
@@ -681,7 +765,7 @@ describe("ExocortexSettingTab", () => {
             const dropdown = {
               addOption: jest.fn().mockReturnThis(),
               setValue: jest.fn().mockImplementation((value: string) => {
-                dropdownSetValue = value;
+                dropdownValues.push(value);
                 return dropdown;
               }),
               onChange: jest.fn().mockReturnThis(),
@@ -690,13 +774,23 @@ describe("ExocortexSettingTab", () => {
             return setting;
           }),
           addToggle: jest.fn().mockReturnThis(),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
+            return setting;
+          }),
         };
         return setting;
       });
 
       settingTab.display();
 
-      expect(dropdownSetValue).toBe("ExistingOntology");
+      // First dropdown is the ontology dropdown, which should have ExistingOntology
+      expect(dropdownValues[0]).toBe("ExistingOntology");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameTemplateEngine.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameTemplateEngine.test.ts
@@ -1,0 +1,384 @@
+import {
+  DisplayNameTemplateEngine,
+  DISPLAY_NAME_PRESETS,
+  DEFAULT_DISPLAY_NAME_TEMPLATE,
+} from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+
+describe("DisplayNameTemplateEngine", () => {
+  describe("render", () => {
+    it("should render simple placeholder", () => {
+      const engine = new DisplayNameTemplateEngine("{{exo__Asset_label}}");
+      const result = engine.render(
+        { exo__Asset_label: "My Task" },
+        "my-task"
+      );
+      expect(result).toBe("My Task");
+    });
+
+    it("should render multiple placeholders", () => {
+      const engine = new DisplayNameTemplateEngine(
+        "{{exo__Asset_label}}: {{ems__Effort_status}}"
+      );
+      const result = engine.render(
+        {
+          exo__Asset_label: "My Task",
+          ems__Effort_status: "IN_PROGRESS",
+        },
+        "my-task"
+      );
+      expect(result).toBe("My Task: IN_PROGRESS");
+    });
+
+    it("should render _basename placeholder", () => {
+      const engine = new DisplayNameTemplateEngine(
+        "{{_basename}} - {{exo__Asset_label}}"
+      );
+      const result = engine.render(
+        { exo__Asset_label: "My Task" },
+        "2025-01-15-my-task"
+      );
+      expect(result).toBe("2025-01-15-my-task - My Task");
+    });
+
+    it("should render _created placeholder", () => {
+      const engine = new DisplayNameTemplateEngine(
+        "{{_created}} - {{exo__Asset_label}}"
+      );
+      const date = new Date("2025-01-15T10:00:00.000Z");
+      const result = engine.render(
+        { exo__Asset_label: "My Task" },
+        "my-task",
+        date
+      );
+      expect(result).toBe("2025-01-15 - My Task");
+    });
+
+    it("should handle missing _created date", () => {
+      const engine = new DisplayNameTemplateEngine(
+        "{{_created}} - {{exo__Asset_label}}"
+      );
+      const result = engine.render(
+        { exo__Asset_label: "My Task" },
+        "my-task"
+      );
+      expect(result).toBe("- My Task");
+    });
+
+    it("should render class prefix pattern", () => {
+      const engine = new DisplayNameTemplateEngine(
+        "[{{exo__Instance_class}}] {{exo__Asset_label}}"
+      );
+      const result = engine.render(
+        {
+          exo__Asset_label: "Fix Login Bug",
+          exo__Instance_class: "ems__Task",
+        },
+        "fix-login-bug"
+      );
+      expect(result).toBe("[ems__Task] Fix Login Bug");
+    });
+
+    it("should handle missing field with empty string in result", () => {
+      const engine = new DisplayNameTemplateEngine(
+        "{{exo__Asset_label}}: {{ems__Effort_status}}"
+      );
+      const result = engine.render(
+        { exo__Asset_label: "My Task" },
+        "my-task"
+      );
+      // Missing field is replaced with empty string, producing "My Task: "
+      expect(result).toBe("My Task:");
+    });
+
+    it("should strip wikilink syntax from values", () => {
+      const engine = new DisplayNameTemplateEngine("{{exo__Asset_label}}");
+      const result = engine.render(
+        { exo__Asset_label: "[[My Task]]" },
+        "my-task"
+      );
+      expect(result).toBe("My Task");
+    });
+
+    it("should handle array values by using first element", () => {
+      const engine = new DisplayNameTemplateEngine("{{exo__Instance_class}}");
+      const result = engine.render(
+        { exo__Instance_class: ["ems__Task", "ems__Project"] },
+        "my-file"
+      );
+      expect(result).toBe("ems__Task");
+    });
+
+    it("should handle empty array with null result", () => {
+      const engine = new DisplayNameTemplateEngine("{{tags}}");
+      const result = engine.render(
+        { tags: [] },
+        "my-file"
+      );
+      // Template produces empty result, so null is returned
+      expect(result).toBeNull();
+    });
+
+    it("should return null for empty template result", () => {
+      const engine = new DisplayNameTemplateEngine("{{missing_field}}");
+      const result = engine.render({}, "my-file");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for empty template", () => {
+      const engine = new DisplayNameTemplateEngine("");
+      const result = engine.render({ exo__Asset_label: "My Task" }, "my-file");
+      expect(result).toBeNull();
+    });
+
+    it("should handle whitespace-only template result", () => {
+      const engine = new DisplayNameTemplateEngine("   {{missing}}   ");
+      const result = engine.render({}, "my-file");
+      expect(result).toBeNull();
+    });
+
+    it("should trim whitespace from result", () => {
+      const engine = new DisplayNameTemplateEngine("  {{exo__Asset_label}}  ");
+      const result = engine.render(
+        { exo__Asset_label: "My Task" },
+        "my-file"
+      );
+      expect(result).toBe("My Task");
+    });
+  });
+
+  describe("nested fields (dot notation)", () => {
+    it("should resolve nested field values", () => {
+      const engine = new DisplayNameTemplateEngine("{{custom.priority}}");
+      const result = engine.render(
+        { custom: { priority: "high" } },
+        "my-file"
+      );
+      expect(result).toBe("high");
+    });
+
+    it("should resolve deeply nested field values", () => {
+      const engine = new DisplayNameTemplateEngine("{{a.b.c.d}}");
+      const result = engine.render(
+        { a: { b: { c: { d: "deep value" } } } },
+        "my-file"
+      );
+      expect(result).toBe("deep value");
+    });
+
+    it("should handle missing nested path with null result", () => {
+      const engine = new DisplayNameTemplateEngine("{{custom.nonexistent}}");
+      const result = engine.render(
+        { custom: { priority: "high" } },
+        "my-file"
+      );
+      // Template produces empty result, so null is returned
+      expect(result).toBeNull();
+    });
+
+    it("should handle null in nested path with null result", () => {
+      const engine = new DisplayNameTemplateEngine("{{custom.nested}}");
+      const result = engine.render(
+        { custom: null },
+        "my-file"
+      );
+      // Template produces empty result, so null is returned
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getTemplate", () => {
+    it("should return the template string", () => {
+      const template = "{{exo__Asset_label}}";
+      const engine = new DisplayNameTemplateEngine(template);
+      expect(engine.getTemplate()).toBe(template);
+    });
+  });
+
+  describe("isValid", () => {
+    it("should return true for valid template with placeholder", () => {
+      const engine = new DisplayNameTemplateEngine("{{exo__Asset_label}}");
+      expect(engine.isValid()).toBe(true);
+    });
+
+    it("should return true for template with multiple placeholders", () => {
+      const engine = new DisplayNameTemplateEngine(
+        "{{label}} - {{status}}"
+      );
+      expect(engine.isValid()).toBe(true);
+    });
+
+    it("should return false for empty template", () => {
+      const engine = new DisplayNameTemplateEngine("");
+      expect(engine.isValid()).toBe(false);
+    });
+
+    it("should return false for template without placeholders", () => {
+      const engine = new DisplayNameTemplateEngine("Static text only");
+      expect(engine.isValid()).toBe(false);
+    });
+
+    it("should return false for whitespace-only template", () => {
+      const engine = new DisplayNameTemplateEngine("   ");
+      expect(engine.isValid()).toBe(false);
+    });
+  });
+
+  describe("getPlaceholders", () => {
+    it("should extract single placeholder", () => {
+      const engine = new DisplayNameTemplateEngine("{{exo__Asset_label}}");
+      expect(engine.getPlaceholders()).toEqual(["exo__Asset_label"]);
+    });
+
+    it("should extract multiple placeholders", () => {
+      const engine = new DisplayNameTemplateEngine(
+        "{{label}} - {{status}} - {{_basename}}"
+      );
+      expect(engine.getPlaceholders()).toEqual(["label", "status", "_basename"]);
+    });
+
+    it("should return empty array for template without placeholders", () => {
+      const engine = new DisplayNameTemplateEngine("Static text");
+      expect(engine.getPlaceholders()).toEqual([]);
+    });
+
+    it("should trim whitespace from placeholder keys", () => {
+      const engine = new DisplayNameTemplateEngine("{{ label }} - {{  status  }}");
+      expect(engine.getPlaceholders()).toEqual(["label", "status"]);
+    });
+  });
+
+  describe("presets", () => {
+    it("should have default preset", () => {
+      expect(DISPLAY_NAME_PRESETS.default).toBeDefined();
+      expect(DISPLAY_NAME_PRESETS.default.template).toBe("{{exo__Asset_label}}");
+    });
+
+    it("should have labelWithStatus preset", () => {
+      expect(DISPLAY_NAME_PRESETS.labelWithStatus).toBeDefined();
+      expect(DISPLAY_NAME_PRESETS.labelWithStatus.template).toBe(
+        "{{exo__Asset_label}}: {{ems__Effort_status}}"
+      );
+    });
+
+    it("should have classPrefix preset", () => {
+      expect(DISPLAY_NAME_PRESETS.classPrefix).toBeDefined();
+      expect(DISPLAY_NAME_PRESETS.classPrefix.template).toBe(
+        "[{{exo__Instance_class}}] {{exo__Asset_label}}"
+      );
+    });
+
+    it("should have basenameWithLabel preset", () => {
+      expect(DISPLAY_NAME_PRESETS.basenameWithLabel).toBeDefined();
+      expect(DISPLAY_NAME_PRESETS.basenameWithLabel.template).toBe(
+        "{{_basename}} - {{exo__Asset_label}}"
+      );
+    });
+
+    it("should have datePrefix preset", () => {
+      expect(DISPLAY_NAME_PRESETS.datePrefix).toBeDefined();
+      expect(DISPLAY_NAME_PRESETS.datePrefix.template).toBe(
+        "{{_created}} - {{exo__Asset_label}}"
+      );
+    });
+
+    it("should export DEFAULT_DISPLAY_NAME_TEMPLATE", () => {
+      expect(DEFAULT_DISPLAY_NAME_TEMPLATE).toBe("{{exo__Asset_label}}");
+    });
+  });
+
+  describe("preset rendering", () => {
+    const sampleMetadata = {
+      exo__Asset_label: "Fix Login Bug",
+      exo__Instance_class: "ems__Task",
+      ems__Effort_status: "🟡 IN_PROGRESS",
+    };
+
+    it("should render default preset", () => {
+      const engine = new DisplayNameTemplateEngine(
+        DISPLAY_NAME_PRESETS.default.template
+      );
+      expect(engine.render(sampleMetadata, "fix-login-bug")).toBe("Fix Login Bug");
+    });
+
+    it("should render labelWithStatus preset", () => {
+      const engine = new DisplayNameTemplateEngine(
+        DISPLAY_NAME_PRESETS.labelWithStatus.template
+      );
+      expect(engine.render(sampleMetadata, "fix-login-bug")).toBe(
+        "Fix Login Bug: 🟡 IN_PROGRESS"
+      );
+    });
+
+    it("should render classPrefix preset", () => {
+      const engine = new DisplayNameTemplateEngine(
+        DISPLAY_NAME_PRESETS.classPrefix.template
+      );
+      expect(engine.render(sampleMetadata, "fix-login-bug")).toBe(
+        "[ems__Task] Fix Login Bug"
+      );
+    });
+
+    it("should render basenameWithLabel preset", () => {
+      const engine = new DisplayNameTemplateEngine(
+        DISPLAY_NAME_PRESETS.basenameWithLabel.template
+      );
+      expect(engine.render(sampleMetadata, "2025-01-15-bug")).toBe(
+        "2025-01-15-bug - Fix Login Bug"
+      );
+    });
+
+    it("should render datePrefix preset", () => {
+      const engine = new DisplayNameTemplateEngine(
+        DISPLAY_NAME_PRESETS.datePrefix.template
+      );
+      const date = new Date("2025-01-15");
+      expect(engine.render(sampleMetadata, "bug", date)).toBe(
+        "2025-01-15 - Fix Login Bug"
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle numeric values", () => {
+      const engine = new DisplayNameTemplateEngine("Count: {{count}}");
+      const result = engine.render({ count: 42 }, "my-file");
+      expect(result).toBe("Count: 42");
+    });
+
+    it("should handle boolean values", () => {
+      const engine = new DisplayNameTemplateEngine("Active: {{active}}");
+      const result = engine.render({ active: true }, "my-file");
+      expect(result).toBe("Active: true");
+    });
+
+    it("should handle null values", () => {
+      const engine = new DisplayNameTemplateEngine("{{nullField}}");
+      const result = engine.render({ nullField: null }, "my-file");
+      expect(result).toBeNull();
+    });
+
+    it("should handle undefined values", () => {
+      const engine = new DisplayNameTemplateEngine("{{undefinedField}}");
+      const result = engine.render({ undefinedField: undefined }, "my-file");
+      expect(result).toBeNull();
+    });
+
+    it("should handle object values by stringifying", () => {
+      const engine = new DisplayNameTemplateEngine("{{obj}}");
+      const result = engine.render({ obj: { a: 1 } }, "my-file");
+      expect(result).toBe('{"a":1}');
+    });
+
+    it("should handle special characters in template", () => {
+      const engine = new DisplayNameTemplateEngine("🎯 {{exo__Asset_label}} ✅");
+      const result = engine.render({ exo__Asset_label: "Done" }, "my-file");
+      expect(result).toBe("🎯 Done ✅");
+    });
+
+    it("should handle curly braces in values", () => {
+      const engine = new DisplayNameTemplateEngine("{{code}}");
+      const result = engine.render({ code: "function() {}" }, "my-file");
+      expect(result).toBe("function() {}");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Introduces a template system that allows users to customize how asset names are displayed in tab titles and file explorer using mustache-style syntax.

Closes #1145

## Features

- **Template Engine**: `DisplayNameTemplateEngine` class with `{{field}}` placeholder syntax
- **Field Support**: 
  - Frontmatter fields (e.g., `{{exo__Asset_label}}`, `{{ems__Effort_status}}`)
  - Nested fields via dot notation (e.g., `{{custom.priority}}`)
  - Special variables: `{{_basename}}` (filename), `{{_created}}` (creation date)
- **Preset Templates**:
  - Label only (default): `{{exo__Asset_label}}`
  - Label with status: `{{exo__Asset_label}}: {{ems__Effort_status}}`
  - Class prefix: `[{{exo__Instance_class}}] {{exo__Asset_label}}`
  - Filename with label: `{{_basename}} - {{exo__Asset_label}}`
  - Date prefix: `{{_created}} - {{exo__Asset_label}}`
- **Settings UI**:
  - Template preset dropdown for common patterns
  - Custom template text input
  - Live preview with sample data
  - Syntax help section

## Technical Changes

- New `DisplayNameTemplateEngine` class in `domain/display-name/`
- New `displayNameTemplate` setting with default `{{exo__Asset_label}}`
- `applyDisplayNameTemplate()` method in plugin for settings refresh
- Integration with `TabTitlePatch` and `FileExplorerPatch` to use template
- 40+ unit tests for `DisplayNameTemplateEngine`
- Updated `ExocortexSettingTab` tests for new settings

## Test Plan

- [x] Unit tests pass for `DisplayNameTemplateEngine`
- [x] Template rendering with various placeholder combinations
- [x] Nested field resolution
- [x] Special variables (_basename, _created)
- [x] Empty/missing field handling
- [x] Wikilink syntax stripping
- [x] Settings tab tests updated for new UI
- [x] Full test suite passes
- [x] TypeScript compilation passes
- [x] ESLint passes (only pre-existing warnings)