### PR TITLE
feat: Node and edge type system with ontology support

### DIFF
--- a/packages/exocortex/src/domain/models/GraphTypes.ts
+++ b/packages/exocortex/src/domain/models/GraphTypes.ts
@@ -1,0 +1,449 @@
+/**
+ * Type system for graph nodes and edges with RDF/OWL ontology support.
+ * Enables semantic typing, custom styling, filtering, and grouping.
+ */
+
+/**
+ * Standard RDF/OWL type predicates.
+ */
+export const RDF_TYPE_PREDICATES = {
+  /** rdf:type - the standard RDF type predicate */
+  RDF_TYPE: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+  /** rdfs:Class - RDFS class definition */
+  RDFS_CLASS: "http://www.w3.org/2000/01/rdf-schema#Class",
+  /** owl:Class - OWL class definition */
+  OWL_CLASS: "http://www.w3.org/2002/07/owl#Class",
+  /** rdfs:subClassOf - class hierarchy */
+  RDFS_SUBCLASS_OF: "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+  /** owl:equivalentClass - class equivalence */
+  OWL_EQUIVALENT_CLASS: "http://www.w3.org/2002/07/owl#equivalentClass",
+  /** rdfs:label - human-readable label */
+  RDFS_LABEL: "http://www.w3.org/2000/01/rdf-schema#label",
+  /** rdfs:comment - description */
+  RDFS_COMMENT: "http://www.w3.org/2000/01/rdf-schema#comment",
+} as const;
+
+/**
+ * Style properties for graph nodes.
+ */
+export interface NodeStyle {
+  /** Fill color (hex, rgb, or named color) */
+  color?: string;
+  /** Border color */
+  borderColor?: string;
+  /** Border width in pixels */
+  borderWidth?: number;
+  /** Node radius/size */
+  size?: number;
+  /** Shape: circle, square, diamond, triangle */
+  shape?: "circle" | "square" | "diamond" | "triangle" | "hexagon";
+  /** Icon identifier or URL */
+  icon?: string;
+  /** Opacity (0-1) */
+  opacity?: number;
+  /** Shadow for emphasis */
+  shadow?: boolean;
+  /** Animation effect */
+  animation?: "none" | "pulse" | "glow";
+}
+
+/**
+ * Style properties for graph edges.
+ */
+export interface EdgeStyle {
+  /** Line color */
+  color?: string;
+  /** Line width in pixels */
+  width?: number;
+  /** Line style */
+  lineStyle?: "solid" | "dashed" | "dotted";
+  /** Arrow style for directed edges */
+  arrow?: "none" | "standard" | "triangle" | "circle";
+  /** Curvature (0 = straight, positive = curved) */
+  curvature?: number;
+  /** Opacity (0-1) */
+  opacity?: number;
+  /** Show label on edge */
+  showLabel?: boolean;
+  /** Label position along edge (0-1) */
+  labelPosition?: number;
+}
+
+/**
+ * Type source indicating where the type was derived from.
+ */
+export type TypeSource =
+  | "rdf:type"           // Standard RDF type assertion
+  | "rdfs:Class"         // RDFS class definition
+  | "owl:Class"          // OWL class definition
+  | "exo:Instance_class" // Exocortex instance class
+  | "inferred"           // Inferred from class hierarchy
+  | "custom";            // Custom/user-defined
+
+/**
+ * Definition of a node type in the graph.
+ */
+export interface NodeTypeDefinition {
+  /** Unique type URI or identifier */
+  uri: string;
+  /** Human-readable label */
+  label: string;
+  /** Optional description */
+  description?: string;
+  /** Parent type URI(s) for inheritance */
+  parentTypes?: string[];
+  /** Source of this type definition */
+  source: TypeSource;
+  /** Default styling for nodes of this type */
+  style: NodeStyle;
+  /** Priority for styling conflicts (higher = more specific) */
+  priority: number;
+  /** Whether this type is deprecated */
+  deprecated?: boolean;
+  /** Custom metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Definition of an edge type in the graph.
+ */
+export interface EdgeTypeDefinition {
+  /** Unique type URI or identifier (predicate) */
+  uri: string;
+  /** Human-readable label */
+  label: string;
+  /** Optional description */
+  description?: string;
+  /** Source domain (node types that can be sources) */
+  domain?: string[];
+  /** Target range (node types that can be targets) */
+  range?: string[];
+  /** Whether this edge is symmetric (bidirectional) */
+  symmetric?: boolean;
+  /** Inverse predicate URI if any */
+  inverse?: string;
+  /** Source of this type definition */
+  source: TypeSource;
+  /** Default styling for edges of this type */
+  style: EdgeStyle;
+  /** Priority for styling conflicts */
+  priority: number;
+  /** Custom metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Type information attached to a graph node.
+ */
+export interface NodeTypeInfo {
+  /** Primary type URI */
+  primaryType: string;
+  /** All type URIs (including inherited) */
+  types: string[];
+  /** Resolved style (merged from all types) */
+  resolvedStyle: NodeStyle;
+  /** Source of primary type */
+  source: TypeSource;
+}
+
+/**
+ * Type information attached to a graph edge.
+ */
+export interface EdgeTypeInfo {
+  /** Primary type URI (predicate) */
+  primaryType: string;
+  /** Resolved style */
+  resolvedStyle: EdgeStyle;
+  /** Source of type */
+  source: TypeSource;
+}
+
+/**
+ * Filter options for type-based queries.
+ */
+export interface TypeFilter {
+  /** Include only these node types */
+  includeNodeTypes?: string[];
+  /** Exclude these node types */
+  excludeNodeTypes?: string[];
+  /** Include only these edge types */
+  includeEdgeTypes?: string[];
+  /** Exclude these edge types */
+  excludeEdgeTypes?: string[];
+  /** Include inferred types */
+  includeInferred?: boolean;
+  /** Include deprecated types */
+  includeDeprecated?: boolean;
+}
+
+/**
+ * Grouping configuration for type-based clustering.
+ */
+export interface TypeGrouping {
+  /** Group nodes by type */
+  groupByNodeType?: boolean;
+  /** Group nodes by parent type (higher level) */
+  groupByParentType?: boolean;
+  /** Specific type level for grouping (0 = leaf, higher = more general) */
+  groupLevel?: number;
+  /** Maximum number of groups (excess becomes "Other") */
+  maxGroups?: number;
+  /** Custom grouping function */
+  customGroupFn?: (types: string[]) => string;
+}
+
+/**
+ * A group of nodes by type.
+ */
+export interface TypeGroup {
+  /** Group identifier (type URI) */
+  id: string;
+  /** Group label */
+  label: string;
+  /** Node IDs in this group */
+  nodeIds: string[];
+  /** Edge IDs within this group */
+  internalEdgeIds: string[];
+  /** Edge IDs connecting to other groups */
+  externalEdgeIds: string[];
+  /** Group color for visualization */
+  color?: string;
+  /** Group statistics */
+  stats: {
+    nodeCount: number;
+    internalEdgeCount: number;
+    externalEdgeCount: number;
+  };
+}
+
+/**
+ * Validation result for type checking.
+ */
+export interface TypeValidationResult {
+  /** Whether validation passed */
+  valid: boolean;
+  /** Validation errors */
+  errors: TypeValidationError[];
+  /** Validation warnings */
+  warnings: TypeValidationWarning[];
+}
+
+/**
+ * A type validation error.
+ */
+export interface TypeValidationError {
+  /** Error code */
+  code: string;
+  /** Error message */
+  message: string;
+  /** Affected node/edge ID */
+  elementId?: string;
+  /** Expected type(s) */
+  expected?: string[];
+  /** Actual type(s) */
+  actual?: string[];
+}
+
+/**
+ * A type validation warning.
+ */
+export interface TypeValidationWarning {
+  /** Warning code */
+  code: string;
+  /** Warning message */
+  message: string;
+  /** Affected node/edge ID */
+  elementId?: string;
+  /** Suggestion for resolution */
+  suggestion?: string;
+}
+
+/**
+ * Events emitted by the type registry.
+ */
+export type TypeRegistryEvent =
+  | { type: "type-added"; typeUri: string; definition: NodeTypeDefinition | EdgeTypeDefinition }
+  | { type: "type-updated"; typeUri: string; definition: NodeTypeDefinition | EdgeTypeDefinition }
+  | { type: "type-removed"; typeUri: string }
+  | { type: "hierarchy-updated"; rootTypes: string[] };
+
+/**
+ * Callback for type registry event subscriptions.
+ */
+export type TypeRegistryEventCallback = (event: TypeRegistryEvent) => void;
+
+/**
+ * Options for resolving node/edge styles from types.
+ */
+export interface StyleResolutionOptions {
+  /** Merge styles from all types (vs. use highest priority) */
+  mergeStyles?: boolean;
+  /** Apply parent type styles first */
+  inheritParentStyles?: boolean;
+  /** Default style to use as base */
+  defaultNodeStyle?: NodeStyle;
+  defaultEdgeStyle?: EdgeStyle;
+}
+
+/**
+ * Default node style values.
+ */
+export const DEFAULT_NODE_STYLE: Required<NodeStyle> = {
+  color: "#6366f1",
+  borderColor: "#4f46e5",
+  borderWidth: 2,
+  size: 30,
+  shape: "circle",
+  icon: "",
+  opacity: 1,
+  shadow: false,
+  animation: "none",
+};
+
+/**
+ * Default edge style values.
+ */
+export const DEFAULT_EDGE_STYLE: Required<EdgeStyle> = {
+  color: "#9ca3af",
+  width: 1,
+  lineStyle: "solid",
+  arrow: "standard",
+  curvature: 0,
+  opacity: 0.6,
+  showLabel: false,
+  labelPosition: 0.5,
+};
+
+/**
+ * Built-in node type styles based on common ontology classes.
+ */
+export const BUILT_IN_NODE_STYLES: Record<string, Partial<NodeStyle>> = {
+  // RDF/OWL meta types
+  "http://www.w3.org/2000/01/rdf-schema#Class": {
+    color: "#f59e0b",
+    shape: "diamond",
+    size: 40,
+  },
+  "http://www.w3.org/2002/07/owl#Class": {
+    color: "#f59e0b",
+    shape: "diamond",
+    size: 40,
+  },
+  // Exocortex types
+  "ems__Task": {
+    color: "#22c55e",
+    shape: "circle",
+  },
+  "ems__Project": {
+    color: "#3b82f6",
+    shape: "square",
+  },
+  "ems__Area": {
+    color: "#8b5cf6",
+    shape: "hexagon",
+    size: 40,
+  },
+  "ems__Meeting": {
+    color: "#ec4899",
+    shape: "circle",
+  },
+  "exo__Class": {
+    color: "#f59e0b",
+    shape: "diamond",
+  },
+  "ims__Person": {
+    color: "#06b6d4",
+    shape: "circle",
+  },
+};
+
+/**
+ * Built-in edge type styles based on common predicates.
+ */
+export const BUILT_IN_EDGE_STYLES: Record<string, Partial<EdgeStyle>> = {
+  // RDF/OWL relationships
+  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+    color: "#f59e0b",
+    lineStyle: "dashed",
+    arrow: "standard",
+  },
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf": {
+    color: "#8b5cf6",
+    width: 2,
+    arrow: "triangle",
+  },
+  // Exocortex relationships
+  "https://exocortex.my/ontology/ems#Effort_parent": {
+    color: "#6366f1",
+    width: 2,
+    arrow: "standard",
+  },
+  "https://exocortex.my/ontology/exo#Asset_prototype": {
+    color: "#f59e0b",
+    lineStyle: "dashed",
+    arrow: "circle",
+  },
+  "https://exocortex.my/ontology/exo#references": {
+    color: "#22c55e",
+    opacity: 0.4,
+    arrow: "standard",
+  },
+};
+
+/**
+ * Helper to merge two node styles, with source taking precedence.
+ */
+export function mergeNodeStyles(base: NodeStyle, override: NodeStyle): NodeStyle {
+  return {
+    ...base,
+    ...Object.fromEntries(
+      Object.entries(override).filter(([, v]) => v !== undefined)
+    ),
+  };
+}
+
+/**
+ * Helper to merge two edge styles, with source taking precedence.
+ */
+export function mergeEdgeStyles(base: EdgeStyle, override: EdgeStyle): EdgeStyle {
+  return {
+    ...base,
+    ...Object.fromEntries(
+      Object.entries(override).filter(([, v]) => v !== undefined)
+    ),
+  };
+}
+
+/**
+ * Extract local name from a URI.
+ */
+export function extractLocalName(uri: string): string {
+  const hashIndex = uri.lastIndexOf("#");
+  const slashIndex = uri.lastIndexOf("/");
+  const separatorIndex = Math.max(hashIndex, slashIndex);
+  if (separatorIndex >= 0) {
+    return uri.substring(separatorIndex + 1);
+  }
+  return uri;
+}
+
+/**
+ * Check if a type URI is an OWL/RDFS class type.
+ */
+export function isClassType(uri: string): boolean {
+  return uri === RDF_TYPE_PREDICATES.RDFS_CLASS || uri === RDF_TYPE_PREDICATES.OWL_CLASS;
+}
+
+/**
+ * Check if a predicate URI is a type predicate.
+ */
+export function isTypePredicate(predicateUri: string): boolean {
+  return predicateUri === RDF_TYPE_PREDICATES.RDF_TYPE;
+}
+
+/**
+ * Check if a predicate URI is a subclass predicate.
+ */
+export function isSubClassPredicate(predicateUri: string): boolean {
+  return predicateUri === RDF_TYPE_PREDICATES.RDFS_SUBCLASS_OF;
+}

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -4,6 +4,7 @@ export * from "./domain/constants/EffortStatus";
 export * from "./domain/models/GraphNode";
 export * from "./domain/models/GraphData";
 export * from "./domain/models/GraphEdge";
+export * from "./domain/models/GraphTypes";
 export * from "./domain/models/AreaNode";
 export * from "./domain/models/rdf";
 export * from "./domain/commands/CommandVisibility";
@@ -67,6 +68,10 @@ export {
   GraphQueryService,
   type GraphQueryServiceConfig,
 } from "./services/GraphQueryService";
+export {
+  TypeRegistry,
+  type TypeRegistryConfig,
+} from "./services/TypeRegistry";
 
 // Utilities exports
 export { FrontmatterService } from "./utilities/FrontmatterService";

--- a/packages/exocortex/src/services/TypeRegistry.ts
+++ b/packages/exocortex/src/services/TypeRegistry.ts
@@ -1,0 +1,792 @@
+/**
+ * Registry for managing graph node and edge type definitions.
+ * Provides type lookup, inheritance resolution, and style merging.
+ */
+
+import type { ITripleStore } from "../interfaces/ITripleStore";
+import { IRI } from "../domain/models/rdf/IRI";
+import { BlankNode } from "../domain/models/rdf/BlankNode";
+import { Literal } from "../domain/models/rdf/Literal";
+import type { Subject, Object as RDFObject } from "../domain/models/rdf/Triple";
+import {
+  NodeTypeDefinition,
+  EdgeTypeDefinition,
+  NodeStyle,
+  EdgeStyle,
+  NodeTypeInfo,
+  EdgeTypeInfo,
+  TypeSource,
+  TypeFilter,
+  TypeGrouping,
+  TypeGroup,
+  TypeValidationResult,
+  TypeValidationError,
+  TypeValidationWarning,
+  TypeRegistryEvent,
+  TypeRegistryEventCallback,
+  StyleResolutionOptions,
+  RDF_TYPE_PREDICATES,
+  DEFAULT_NODE_STYLE,
+  DEFAULT_EDGE_STYLE,
+  BUILT_IN_NODE_STYLES,
+  BUILT_IN_EDGE_STYLES,
+  mergeNodeStyles,
+  mergeEdgeStyles,
+  extractLocalName,
+  isClassType,
+} from "../domain/models/GraphTypes";
+import type { GraphNode } from "../domain/models/GraphNode";
+import type { GraphEdge } from "../domain/models/GraphEdge";
+
+/**
+ * Configuration for TypeRegistry.
+ */
+export interface TypeRegistryConfig {
+  /** Auto-register types from triple store on first query */
+  autoDiscoverTypes?: boolean;
+  /** Include built-in styles */
+  includeBuiltInStyles?: boolean;
+  /** Default style resolution options */
+  styleResolution?: StyleResolutionOptions;
+  /** Maximum inheritance depth for type hierarchy */
+  maxInheritanceDepth?: number;
+}
+
+/**
+ * Registry for managing graph type definitions.
+ */
+export class TypeRegistry {
+  private readonly tripleStore: ITripleStore | null;
+  private readonly config: Required<TypeRegistryConfig>;
+  private readonly nodeTypes: Map<string, NodeTypeDefinition> = new Map();
+  private readonly edgeTypes: Map<string, EdgeTypeDefinition> = new Map();
+  private readonly typeHierarchy: Map<string, string[]> = new Map(); // type -> parent types
+  private readonly subscribers: Set<TypeRegistryEventCallback> = new Set();
+  private discoveryComplete: boolean = false;
+
+  constructor(tripleStore: ITripleStore | null = null, config: TypeRegistryConfig = {}) {
+    this.tripleStore = tripleStore;
+    this.config = {
+      autoDiscoverTypes: config.autoDiscoverTypes ?? true,
+      includeBuiltInStyles: config.includeBuiltInStyles ?? true,
+      styleResolution: config.styleResolution ?? {
+        mergeStyles: true,
+        inheritParentStyles: true,
+        defaultNodeStyle: DEFAULT_NODE_STYLE,
+        defaultEdgeStyle: DEFAULT_EDGE_STYLE,
+      },
+      maxInheritanceDepth: config.maxInheritanceDepth ?? 10,
+    };
+
+    if (this.config.includeBuiltInStyles) {
+      this.registerBuiltInTypes();
+    }
+  }
+
+  /**
+   * Register a node type definition.
+   */
+  registerNodeType(definition: NodeTypeDefinition): void {
+    const existing = this.nodeTypes.get(definition.uri);
+    const eventType = existing ? "type-updated" : "type-added";
+
+    this.nodeTypes.set(definition.uri, definition);
+
+    // Update hierarchy if parent types specified
+    if (definition.parentTypes && definition.parentTypes.length > 0) {
+      this.typeHierarchy.set(definition.uri, definition.parentTypes);
+    }
+
+    this.emit({ type: eventType, typeUri: definition.uri, definition });
+  }
+
+  /**
+   * Register an edge type definition.
+   */
+  registerEdgeType(definition: EdgeTypeDefinition): void {
+    const existing = this.edgeTypes.get(definition.uri);
+    const eventType = existing ? "type-updated" : "type-added";
+
+    this.edgeTypes.set(definition.uri, definition);
+    this.emit({ type: eventType, typeUri: definition.uri, definition });
+  }
+
+  /**
+   * Unregister a type.
+   */
+  unregisterType(uri: string): void {
+    const wasNode = this.nodeTypes.delete(uri);
+    const wasEdge = this.edgeTypes.delete(uri);
+    this.typeHierarchy.delete(uri);
+
+    if (wasNode || wasEdge) {
+      this.emit({ type: "type-removed", typeUri: uri });
+    }
+  }
+
+  /**
+   * Get a node type definition by URI.
+   */
+  getNodeType(uri: string): NodeTypeDefinition | undefined {
+    return this.nodeTypes.get(uri);
+  }
+
+  /**
+   * Get an edge type definition by URI.
+   */
+  getEdgeType(uri: string): EdgeTypeDefinition | undefined {
+    return this.edgeTypes.get(uri);
+  }
+
+  /**
+   * Get all registered node types.
+   */
+  getAllNodeTypes(): NodeTypeDefinition[] {
+    return Array.from(this.nodeTypes.values());
+  }
+
+  /**
+   * Get all registered edge types.
+   */
+  getAllEdgeTypes(): EdgeTypeDefinition[] {
+    return Array.from(this.edgeTypes.values());
+  }
+
+  /**
+   * Get parent types for a type (direct and inherited).
+   * @param typeUri The type URI to get parents for
+   * @param depth Maximum depth of inheritance to traverse (1 = direct parents only)
+   */
+  getParentTypes(typeUri: string, depth: number = this.config.maxInheritanceDepth): string[] {
+    const parents: string[] = [];
+    const visited = new Set<string>();
+    const queue: Array<{ uri: string; currentDepth: number }> = [{ uri: typeUri, currentDepth: 0 }];
+
+    while (queue.length > 0) {
+      const { uri, currentDepth } = queue.shift()!;
+
+      if (visited.has(uri)) continue;
+      visited.add(uri);
+
+      // Only traverse children if we haven't exceeded depth
+      if (currentDepth >= depth) continue;
+
+      const directParents = this.typeHierarchy.get(uri) ?? [];
+      for (const parent of directParents) {
+        if (!visited.has(parent)) {
+          parents.push(parent);
+          queue.push({ uri: parent, currentDepth: currentDepth + 1 });
+        }
+      }
+    }
+
+    return parents;
+  }
+
+  /**
+   * Get child types for a type (direct descendants).
+   */
+  getChildTypes(typeUri: string): string[] {
+    const children: string[] = [];
+    for (const [uri, parents] of this.typeHierarchy) {
+      if (parents.includes(typeUri)) {
+        children.push(uri);
+      }
+    }
+    return children;
+  }
+
+  /**
+   * Check if typeA is a subtype of typeB.
+   */
+  isSubtypeOf(typeA: string, typeB: string): boolean {
+    if (typeA === typeB) return true;
+    const parents = this.getParentTypes(typeA);
+    return parents.includes(typeB);
+  }
+
+  /**
+   * Resolve type information for a graph node.
+   */
+  resolveNodeType(node: GraphNode): NodeTypeInfo {
+    const types: string[] = [];
+    let primaryType: string = "unknown";
+    let source: TypeSource = "custom";
+
+    // Get type from assetClass (exo:Instance_class)
+    if (node.assetClass) {
+      const normalizedClass = this.normalizeTypeUri(node.assetClass);
+      types.push(normalizedClass);
+      primaryType = normalizedClass;
+      source = "exo:Instance_class";
+    }
+
+    // Get rdf:type from properties
+    const rdfType = node.properties?.[RDF_TYPE_PREDICATES.RDF_TYPE] as string | undefined;
+    if (rdfType && !types.includes(rdfType)) {
+      types.push(rdfType);
+      if (primaryType === "unknown") {
+        primaryType = rdfType;
+        source = "rdf:type";
+      }
+    }
+
+    // Add inferred parent types
+    for (const type of [...types]) {
+      const parents = this.getParentTypes(type);
+      for (const parent of parents) {
+        if (!types.includes(parent)) {
+          types.push(parent);
+        }
+      }
+    }
+
+    // Resolve style
+    const resolvedStyle = this.resolveNodeStyle(types);
+
+    return {
+      primaryType,
+      types,
+      resolvedStyle,
+      source,
+    };
+  }
+
+  /**
+   * Resolve type information for a graph edge.
+   */
+  resolveEdgeType(edge: GraphEdge): EdgeTypeInfo {
+    const predicateUri = edge.predicate ?? edge.type;
+    const source: TypeSource = edge.predicate ? "rdf:type" : "custom";
+
+    const resolvedStyle = this.resolveEdgeStyle(predicateUri);
+
+    return {
+      primaryType: predicateUri,
+      resolvedStyle,
+      source,
+    };
+  }
+
+  /**
+   * Resolve node style from a list of types.
+   */
+  resolveNodeStyle(types: string[]): NodeStyle {
+    const { mergeStyles, defaultNodeStyle } = this.config.styleResolution;
+    let style: NodeStyle = { ...defaultNodeStyle };
+
+    // Get all type definitions sorted by priority
+    const definitions: NodeTypeDefinition[] = [];
+    for (const type of types) {
+      const def = this.nodeTypes.get(type);
+      if (def) {
+        definitions.push(def);
+      }
+    }
+
+    // Sort by priority (lower first, so higher priority overwrites)
+    definitions.sort((a, b) => a.priority - b.priority);
+
+    if (mergeStyles) {
+      // Merge all styles
+      for (const def of definitions) {
+        style = mergeNodeStyles(style, def.style);
+      }
+    } else if (definitions.length > 0) {
+      // Use highest priority only
+      const highest = definitions[definitions.length - 1];
+      style = mergeNodeStyles(style, highest.style);
+    }
+
+    return style;
+  }
+
+  /**
+   * Resolve edge style from a predicate URI.
+   */
+  resolveEdgeStyle(predicateUri: string): EdgeStyle {
+    const { defaultEdgeStyle } = this.config.styleResolution;
+    let style: EdgeStyle = { ...defaultEdgeStyle };
+
+    const def = this.edgeTypes.get(predicateUri);
+    if (def) {
+      style = mergeEdgeStyles(style, def.style);
+    }
+
+    return style;
+  }
+
+  /**
+   * Filter nodes by type.
+   */
+  filterNodes(nodes: GraphNode[], filter: TypeFilter): GraphNode[] {
+    return nodes.filter(node => {
+      const typeInfo = this.resolveNodeType(node);
+
+      // Check include filter
+      if (filter.includeNodeTypes && filter.includeNodeTypes.length > 0) {
+        const matches = filter.includeNodeTypes.some(t =>
+          typeInfo.types.includes(t) ||
+          (filter.includeInferred && this.isSubtypeOf(typeInfo.primaryType, t))
+        );
+        if (!matches) return false;
+      }
+
+      // Check exclude filter
+      if (filter.excludeNodeTypes && filter.excludeNodeTypes.length > 0) {
+        const matches = filter.excludeNodeTypes.some(t =>
+          typeInfo.types.includes(t) ||
+          (filter.includeInferred && this.isSubtypeOf(typeInfo.primaryType, t))
+        );
+        if (matches) return false;
+      }
+
+      // Check deprecated
+      if (!filter.includeDeprecated) {
+        const def = this.nodeTypes.get(typeInfo.primaryType);
+        if (def?.deprecated) return false;
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * Filter edges by type.
+   */
+  filterEdges(edges: GraphEdge[], filter: TypeFilter): GraphEdge[] {
+    return edges.filter(edge => {
+      const predicateUri = edge.predicate ?? edge.type;
+
+      // Check include filter
+      if (filter.includeEdgeTypes && filter.includeEdgeTypes.length > 0) {
+        if (!filter.includeEdgeTypes.includes(predicateUri)) {
+          return false;
+        }
+      }
+
+      // Check exclude filter
+      if (filter.excludeEdgeTypes && filter.excludeEdgeTypes.length > 0) {
+        if (filter.excludeEdgeTypes.includes(predicateUri)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * Group nodes by type.
+   */
+  groupNodesByType(
+    nodes: GraphNode[],
+    edges: GraphEdge[],
+    grouping: TypeGrouping = {}
+  ): TypeGroup[] {
+    const {
+      groupByNodeType = true,
+      groupByParentType = false,
+      groupLevel = 0,
+      maxGroups = 20,
+      customGroupFn,
+    } = grouping;
+
+    const groups = new Map<string, { nodeIds: Set<string>; label: string }>();
+
+    for (const node of nodes) {
+      const typeInfo = this.resolveNodeType(node);
+
+      let groupId: string;
+      if (customGroupFn) {
+        groupId = customGroupFn(typeInfo.types);
+      } else if (groupByParentType && typeInfo.types.length > groupLevel) {
+        groupId = typeInfo.types[groupLevel] ?? typeInfo.primaryType;
+      } else if (groupByNodeType) {
+        groupId = typeInfo.primaryType;
+      } else {
+        groupId = "all";
+      }
+
+      if (!groups.has(groupId)) {
+        const def = this.nodeTypes.get(groupId);
+        const label = def?.label ?? extractLocalName(groupId);
+        groups.set(groupId, { nodeIds: new Set(), label });
+      }
+      groups.get(groupId)!.nodeIds.add(node.id);
+    }
+
+    // Limit groups if needed
+    let groupArray = Array.from(groups.entries()).map(([id, data]) => ({
+      id,
+      label: data.label,
+      nodeIds: Array.from(data.nodeIds),
+    }));
+
+    if (groupArray.length > maxGroups) {
+      // Sort by size and keep top N
+      groupArray.sort((a, b) => b.nodeIds.length - a.nodeIds.length);
+      const topGroups = groupArray.slice(0, maxGroups - 1);
+      const otherNodes = groupArray.slice(maxGroups - 1).flatMap(g => g.nodeIds);
+      topGroups.push({ id: "other", label: "Other", nodeIds: otherNodes });
+      groupArray = topGroups;
+    }
+
+    // Calculate edge statistics for each group
+    const nodeToGroup = new Map<string, string>();
+    for (const group of groupArray) {
+      for (const nodeId of group.nodeIds) {
+        nodeToGroup.set(nodeId, group.id);
+      }
+    }
+
+    return groupArray.map((g, index) => {
+      const nodeIdSet = new Set(g.nodeIds);
+      const internalEdgeIds: string[] = [];
+      const externalEdgeIds: string[] = [];
+
+      for (const edge of edges) {
+        const sourceInGroup = nodeIdSet.has(edge.source);
+        const targetInGroup = nodeIdSet.has(edge.target);
+
+        if (sourceInGroup && targetInGroup) {
+          if (edge.id) internalEdgeIds.push(edge.id);
+        } else if (sourceInGroup || targetInGroup) {
+          if (edge.id) externalEdgeIds.push(edge.id);
+        }
+      }
+
+      // Generate color based on index
+      const hue = (index * 137.5) % 360; // Golden angle for good distribution
+      const color = `hsl(${hue}, 70%, 50%)`;
+
+      return {
+        id: g.id,
+        label: g.label,
+        nodeIds: g.nodeIds,
+        internalEdgeIds,
+        externalEdgeIds,
+        color,
+        stats: {
+          nodeCount: g.nodeIds.length,
+          internalEdgeCount: internalEdgeIds.length,
+          externalEdgeCount: externalEdgeIds.length,
+        },
+      };
+    });
+  }
+
+  /**
+   * Validate types for nodes and edges.
+   */
+  validateTypes(nodes: GraphNode[], edges: GraphEdge[]): TypeValidationResult {
+    const errors: TypeValidationError[] = [];
+    const warnings: TypeValidationWarning[] = [];
+
+    // Validate node types
+    for (const node of nodes) {
+      const typeInfo = this.resolveNodeType(node);
+
+      // Check if type is registered
+      if (typeInfo.primaryType !== "unknown") {
+        const def = this.nodeTypes.get(typeInfo.primaryType);
+        if (!def && typeInfo.source !== "inferred") {
+          warnings.push({
+            code: "UNREGISTERED_NODE_TYPE",
+            message: `Node type "${typeInfo.primaryType}" is not registered`,
+            elementId: node.id,
+            suggestion: `Register the type with registerNodeType()`,
+          });
+        }
+
+        // Check for deprecated types
+        if (def?.deprecated) {
+          warnings.push({
+            code: "DEPRECATED_NODE_TYPE",
+            message: `Node uses deprecated type "${typeInfo.primaryType}"`,
+            elementId: node.id,
+            suggestion: `Migrate to a non-deprecated type`,
+          });
+        }
+      } else {
+        warnings.push({
+          code: "MISSING_NODE_TYPE",
+          message: `Node has no type information`,
+          elementId: node.id,
+          suggestion: `Add exo:Instance_class or rdf:type to the node`,
+        });
+      }
+    }
+
+    // Validate edge types
+    for (const edge of edges) {
+      const predicateUri = edge.predicate ?? edge.type;
+      const def = this.edgeTypes.get(predicateUri);
+
+      // Check domain/range constraints
+      if (def?.domain && def.domain.length > 0) {
+        const sourceNode = nodes.find(n => n.id === edge.source);
+        if (sourceNode) {
+          const sourceTypeInfo = this.resolveNodeType(sourceNode);
+          const domainMatch = def.domain.some(d => sourceTypeInfo.types.includes(d));
+          if (!domainMatch) {
+            errors.push({
+              code: "DOMAIN_VIOLATION",
+              message: `Edge source does not match expected domain`,
+              elementId: edge.id,
+              expected: def.domain,
+              actual: sourceTypeInfo.types,
+            });
+          }
+        }
+      }
+
+      if (def?.range && def.range.length > 0) {
+        const targetNode = nodes.find(n => n.id === edge.target);
+        if (targetNode) {
+          const targetTypeInfo = this.resolveNodeType(targetNode);
+          const rangeMatch = def.range.some(r => targetTypeInfo.types.includes(r));
+          if (!rangeMatch) {
+            errors.push({
+              code: "RANGE_VIOLATION",
+              message: `Edge target does not match expected range`,
+              elementId: edge.id,
+              expected: def.range,
+              actual: targetTypeInfo.types,
+            });
+          }
+        }
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+    };
+  }
+
+  /**
+   * Discover and register types from the triple store.
+   */
+  async discoverTypes(): Promise<void> {
+    if (!this.tripleStore || this.discoveryComplete) return;
+
+    // Find all rdfs:Class and owl:Class definitions
+    const classTriples = await this.tripleStore.match(
+      undefined,
+      new IRI(RDF_TYPE_PREDICATES.RDF_TYPE),
+      undefined
+    );
+
+    for (const triple of classTriples) {
+      const typeUri = this.getObjectValue(triple.object);
+      if (!typeUri) continue;
+
+      if (isClassType(typeUri)) {
+        // This is a class definition
+        const classUri = this.getSubjectValue(triple.subject);
+        if (classUri) {
+          await this.discoverNodeType(classUri);
+        }
+      }
+    }
+
+    // Find subclass relationships for hierarchy
+    const subClassTriples = await this.tripleStore.match(
+      undefined,
+      new IRI(RDF_TYPE_PREDICATES.RDFS_SUBCLASS_OF),
+      undefined
+    );
+
+    for (const triple of subClassTriples) {
+      const childUri = this.getSubjectValue(triple.subject);
+      const parentUri = this.getObjectValue(triple.object);
+      if (childUri && parentUri) {
+        const existing = this.typeHierarchy.get(childUri) ?? [];
+        if (!existing.includes(parentUri)) {
+          existing.push(parentUri);
+          this.typeHierarchy.set(childUri, existing);
+
+          // Update node type definition if exists
+          const def = this.nodeTypes.get(childUri);
+          if (def) {
+            def.parentTypes = existing;
+          }
+        }
+      }
+    }
+
+    this.discoveryComplete = true;
+    this.emit({ type: "hierarchy-updated", rootTypes: this.getRootTypes() });
+  }
+
+  /**
+   * Subscribe to registry events.
+   */
+  subscribe(callback: TypeRegistryEventCallback): () => void {
+    this.subscribers.add(callback);
+    return () => this.subscribers.delete(callback);
+  }
+
+  /**
+   * Clear all registered types.
+   */
+  clear(): void {
+    this.nodeTypes.clear();
+    this.edgeTypes.clear();
+    this.typeHierarchy.clear();
+    this.discoveryComplete = false;
+
+    if (this.config.includeBuiltInStyles) {
+      this.registerBuiltInTypes();
+    }
+  }
+
+  // Private methods
+
+  private registerBuiltInTypes(): void {
+    // Register built-in node types
+    for (const [uri, style] of Object.entries(BUILT_IN_NODE_STYLES)) {
+      this.nodeTypes.set(uri, {
+        uri,
+        label: extractLocalName(uri),
+        source: "custom",
+        style: mergeNodeStyles(DEFAULT_NODE_STYLE, style),
+        priority: 1,
+      });
+    }
+
+    // Register built-in edge types
+    for (const [uri, style] of Object.entries(BUILT_IN_EDGE_STYLES)) {
+      this.edgeTypes.set(uri, {
+        uri,
+        label: extractLocalName(uri),
+        source: "custom",
+        style: mergeEdgeStyles(DEFAULT_EDGE_STYLE, style),
+        priority: 1,
+      });
+    }
+  }
+
+  private async discoverNodeType(classUri: string): Promise<void> {
+    if (this.nodeTypes.has(classUri) || !this.tripleStore) return;
+
+    // Get label and comment
+    const labelTriples = await this.tripleStore.match(
+      new IRI(classUri),
+      new IRI(RDF_TYPE_PREDICATES.RDFS_LABEL),
+      undefined
+    );
+    const commentTriples = await this.tripleStore.match(
+      new IRI(classUri),
+      new IRI(RDF_TYPE_PREDICATES.RDFS_COMMENT),
+      undefined
+    );
+
+    const label = labelTriples.length > 0
+      ? this.getObjectValue(labelTriples[0].object) ?? extractLocalName(classUri)
+      : extractLocalName(classUri);
+
+    const description = commentTriples.length > 0
+      ? this.getObjectValue(commentTriples[0].object)
+      : undefined;
+
+    // Determine source
+    let source: TypeSource = "rdfs:Class";
+    const typeTriples = await this.tripleStore.match(
+      new IRI(classUri),
+      new IRI(RDF_TYPE_PREDICATES.RDF_TYPE),
+      undefined
+    );
+    for (const t of typeTriples) {
+      const typeValue = this.getObjectValue(t.object);
+      if (typeValue === RDF_TYPE_PREDICATES.OWL_CLASS) {
+        source = "owl:Class";
+        break;
+      }
+    }
+
+    // Get built-in style if available
+    const builtInStyle = BUILT_IN_NODE_STYLES[classUri] ?? BUILT_IN_NODE_STYLES[extractLocalName(classUri)];
+
+    const definition: NodeTypeDefinition = {
+      uri: classUri,
+      label,
+      description,
+      source,
+      style: mergeNodeStyles(DEFAULT_NODE_STYLE, builtInStyle ?? {}),
+      priority: 1,
+    };
+
+    this.registerNodeType(definition);
+  }
+
+  private normalizeTypeUri(typeValue: string): string {
+    // Handle wiki-link format [[ems__Task]]
+    const wikiLinkMatch = typeValue.match(/^\[\[(.+?)\]\]$/);
+    if (wikiLinkMatch) {
+      return wikiLinkMatch[1];
+    }
+    return typeValue;
+  }
+
+  private getSubjectValue(subject: Subject): string | undefined {
+    if (subject instanceof IRI) {
+      return subject.value;
+    }
+    if (subject instanceof BlankNode) {
+      return `_:${subject.id}`;
+    }
+    // QuotedTriple - use duck typing
+    if (typeof subject === "object" && subject !== null && "termType" in subject) {
+      return subject.toString();
+    }
+    return undefined;
+  }
+
+  private getObjectValue(object: RDFObject): string | undefined {
+    if (object instanceof Literal) {
+      return object.value;
+    }
+    if (object instanceof IRI) {
+      return object.value;
+    }
+    if (object instanceof BlankNode) {
+      return `_:${object.id}`;
+    }
+    return undefined;
+  }
+
+  private getRootTypes(): string[] {
+    // Types that have no parents
+    const allParents = new Set<string>();
+    for (const parents of this.typeHierarchy.values()) {
+      for (const p of parents) {
+        allParents.add(p);
+      }
+    }
+
+    const rootTypes: string[] = [];
+    for (const uri of this.nodeTypes.keys()) {
+      if (!this.typeHierarchy.has(uri) || this.typeHierarchy.get(uri)!.length === 0) {
+        // Also check if this type is a parent of something (otherwise it's just a leaf)
+        if (allParents.has(uri)) {
+          rootTypes.push(uri);
+        }
+      }
+    }
+
+    return rootTypes;
+  }
+
+  private emit(event: TypeRegistryEvent): void {
+    for (const callback of this.subscribers) {
+      try {
+        callback(event);
+      } catch (error) {
+        console.error("TypeRegistry: error in subscriber callback", error);
+      }
+    }
+  }
+}

--- a/packages/exocortex/tests/unit/domain/models/GraphTypes.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/GraphTypes.test.ts
@@ -1,0 +1,318 @@
+import {
+  RDF_TYPE_PREDICATES,
+  NodeStyle,
+  EdgeStyle,
+  NodeTypeDefinition,
+  EdgeTypeDefinition,
+  DEFAULT_NODE_STYLE,
+  DEFAULT_EDGE_STYLE,
+  BUILT_IN_NODE_STYLES,
+  BUILT_IN_EDGE_STYLES,
+  mergeNodeStyles,
+  mergeEdgeStyles,
+  extractLocalName,
+  isClassType,
+  isTypePredicate,
+  isSubClassPredicate,
+} from "../../../../src/domain/models/GraphTypes";
+
+describe("GraphTypes", () => {
+  describe("RDF_TYPE_PREDICATES", () => {
+    it("should have correct RDF type URI", () => {
+      expect(RDF_TYPE_PREDICATES.RDF_TYPE).toBe(
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+      );
+    });
+
+    it("should have correct RDFS Class URI", () => {
+      expect(RDF_TYPE_PREDICATES.RDFS_CLASS).toBe(
+        "http://www.w3.org/2000/01/rdf-schema#Class"
+      );
+    });
+
+    it("should have correct OWL Class URI", () => {
+      expect(RDF_TYPE_PREDICATES.OWL_CLASS).toBe(
+        "http://www.w3.org/2002/07/owl#Class"
+      );
+    });
+
+    it("should have correct rdfs:subClassOf URI", () => {
+      expect(RDF_TYPE_PREDICATES.RDFS_SUBCLASS_OF).toBe(
+        "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      );
+    });
+  });
+
+  describe("DEFAULT_NODE_STYLE", () => {
+    it("should have all required properties", () => {
+      expect(DEFAULT_NODE_STYLE.color).toBeDefined();
+      expect(DEFAULT_NODE_STYLE.borderColor).toBeDefined();
+      expect(DEFAULT_NODE_STYLE.borderWidth).toBeDefined();
+      expect(DEFAULT_NODE_STYLE.size).toBeDefined();
+      expect(DEFAULT_NODE_STYLE.shape).toBe("circle");
+      expect(DEFAULT_NODE_STYLE.opacity).toBe(1);
+      expect(DEFAULT_NODE_STYLE.shadow).toBe(false);
+      expect(DEFAULT_NODE_STYLE.animation).toBe("none");
+    });
+  });
+
+  describe("DEFAULT_EDGE_STYLE", () => {
+    it("should have all required properties", () => {
+      expect(DEFAULT_EDGE_STYLE.color).toBeDefined();
+      expect(DEFAULT_EDGE_STYLE.width).toBe(1);
+      expect(DEFAULT_EDGE_STYLE.lineStyle).toBe("solid");
+      expect(DEFAULT_EDGE_STYLE.arrow).toBe("standard");
+      expect(DEFAULT_EDGE_STYLE.curvature).toBe(0);
+      expect(DEFAULT_EDGE_STYLE.opacity).toBeDefined();
+      expect(DEFAULT_EDGE_STYLE.showLabel).toBe(false);
+      expect(DEFAULT_EDGE_STYLE.labelPosition).toBe(0.5);
+    });
+  });
+
+  describe("BUILT_IN_NODE_STYLES", () => {
+    it("should have style for ems__Task", () => {
+      expect(BUILT_IN_NODE_STYLES["ems__Task"]).toBeDefined();
+      expect(BUILT_IN_NODE_STYLES["ems__Task"].color).toBe("#22c55e");
+      expect(BUILT_IN_NODE_STYLES["ems__Task"].shape).toBe("circle");
+    });
+
+    it("should have style for ems__Project", () => {
+      expect(BUILT_IN_NODE_STYLES["ems__Project"]).toBeDefined();
+      expect(BUILT_IN_NODE_STYLES["ems__Project"].color).toBe("#3b82f6");
+      expect(BUILT_IN_NODE_STYLES["ems__Project"].shape).toBe("square");
+    });
+
+    it("should have style for ems__Area", () => {
+      expect(BUILT_IN_NODE_STYLES["ems__Area"]).toBeDefined();
+      expect(BUILT_IN_NODE_STYLES["ems__Area"].shape).toBe("hexagon");
+    });
+
+    it("should have style for rdfs:Class", () => {
+      expect(BUILT_IN_NODE_STYLES[RDF_TYPE_PREDICATES.RDFS_CLASS]).toBeDefined();
+      expect(BUILT_IN_NODE_STYLES[RDF_TYPE_PREDICATES.RDFS_CLASS].shape).toBe("diamond");
+    });
+
+    it("should have style for owl:Class", () => {
+      expect(BUILT_IN_NODE_STYLES[RDF_TYPE_PREDICATES.OWL_CLASS]).toBeDefined();
+      expect(BUILT_IN_NODE_STYLES[RDF_TYPE_PREDICATES.OWL_CLASS].shape).toBe("diamond");
+    });
+  });
+
+  describe("BUILT_IN_EDGE_STYLES", () => {
+    it("should have style for rdf:type", () => {
+      expect(BUILT_IN_EDGE_STYLES[RDF_TYPE_PREDICATES.RDF_TYPE]).toBeDefined();
+      expect(BUILT_IN_EDGE_STYLES[RDF_TYPE_PREDICATES.RDF_TYPE].lineStyle).toBe("dashed");
+    });
+
+    it("should have style for rdfs:subClassOf", () => {
+      expect(BUILT_IN_EDGE_STYLES[RDF_TYPE_PREDICATES.RDFS_SUBCLASS_OF]).toBeDefined();
+      expect(BUILT_IN_EDGE_STYLES[RDF_TYPE_PREDICATES.RDFS_SUBCLASS_OF].arrow).toBe("triangle");
+    });
+
+    it("should have style for ems:Effort_parent", () => {
+      const parentUri = "https://exocortex.my/ontology/ems#Effort_parent";
+      expect(BUILT_IN_EDGE_STYLES[parentUri]).toBeDefined();
+    });
+  });
+
+  describe("mergeNodeStyles", () => {
+    it("should merge two node styles", () => {
+      const base: NodeStyle = { color: "#ff0000", size: 20 };
+      const override: NodeStyle = { size: 30, shape: "square" };
+
+      const result = mergeNodeStyles(base, override);
+
+      expect(result.color).toBe("#ff0000");
+      expect(result.size).toBe(30);
+      expect(result.shape).toBe("square");
+    });
+
+    it("should not include undefined values from override", () => {
+      const base: NodeStyle = { color: "#ff0000", size: 20 };
+      const override: NodeStyle = { size: undefined };
+
+      const result = mergeNodeStyles(base, override);
+
+      expect(result.color).toBe("#ff0000");
+      expect(result.size).toBe(20); // Not overwritten by undefined
+    });
+
+    it("should handle empty override", () => {
+      const base: NodeStyle = { color: "#ff0000", size: 20 };
+      const override: NodeStyle = {};
+
+      const result = mergeNodeStyles(base, override);
+
+      expect(result.color).toBe("#ff0000");
+      expect(result.size).toBe(20);
+    });
+
+    it("should handle empty base", () => {
+      const base: NodeStyle = {};
+      const override: NodeStyle = { color: "#00ff00", size: 25 };
+
+      const result = mergeNodeStyles(base, override);
+
+      expect(result.color).toBe("#00ff00");
+      expect(result.size).toBe(25);
+    });
+  });
+
+  describe("mergeEdgeStyles", () => {
+    it("should merge two edge styles", () => {
+      const base: EdgeStyle = { color: "#ff0000", width: 2 };
+      const override: EdgeStyle = { width: 3, lineStyle: "dashed" };
+
+      const result = mergeEdgeStyles(base, override);
+
+      expect(result.color).toBe("#ff0000");
+      expect(result.width).toBe(3);
+      expect(result.lineStyle).toBe("dashed");
+    });
+
+    it("should not include undefined values from override", () => {
+      const base: EdgeStyle = { color: "#ff0000", width: 2 };
+      const override: EdgeStyle = { width: undefined };
+
+      const result = mergeEdgeStyles(base, override);
+
+      expect(result.color).toBe("#ff0000");
+      expect(result.width).toBe(2);
+    });
+  });
+
+  describe("extractLocalName", () => {
+    it("should extract local name from URI with hash", () => {
+      expect(extractLocalName("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")).toBe("type");
+    });
+
+    it("should extract local name from URI with slash", () => {
+      expect(extractLocalName("http://example.org/ontology/Person")).toBe("Person");
+    });
+
+    it("should return full string if no separator", () => {
+      expect(extractLocalName("Task")).toBe("Task");
+    });
+
+    it("should prefer hash over slash", () => {
+      expect(extractLocalName("http://example.org/ns#localName")).toBe("localName");
+    });
+  });
+
+  describe("isClassType", () => {
+    it("should return true for rdfs:Class", () => {
+      expect(isClassType(RDF_TYPE_PREDICATES.RDFS_CLASS)).toBe(true);
+    });
+
+    it("should return true for owl:Class", () => {
+      expect(isClassType(RDF_TYPE_PREDICATES.OWL_CLASS)).toBe(true);
+    });
+
+    it("should return false for other URIs", () => {
+      expect(isClassType("http://example.org/SomeClass")).toBe(false);
+      expect(isClassType(RDF_TYPE_PREDICATES.RDF_TYPE)).toBe(false);
+    });
+  });
+
+  describe("isTypePredicate", () => {
+    it("should return true for rdf:type", () => {
+      expect(isTypePredicate(RDF_TYPE_PREDICATES.RDF_TYPE)).toBe(true);
+    });
+
+    it("should return false for other predicates", () => {
+      expect(isTypePredicate(RDF_TYPE_PREDICATES.RDFS_SUBCLASS_OF)).toBe(false);
+      expect(isTypePredicate("http://example.org/somePredicate")).toBe(false);
+    });
+  });
+
+  describe("isSubClassPredicate", () => {
+    it("should return true for rdfs:subClassOf", () => {
+      expect(isSubClassPredicate(RDF_TYPE_PREDICATES.RDFS_SUBCLASS_OF)).toBe(true);
+    });
+
+    it("should return false for other predicates", () => {
+      expect(isSubClassPredicate(RDF_TYPE_PREDICATES.RDF_TYPE)).toBe(false);
+      expect(isSubClassPredicate("http://example.org/somePredicate")).toBe(false);
+    });
+  });
+
+  describe("TypeScript type definitions", () => {
+    it("should allow creating NodeTypeDefinition", () => {
+      const def: NodeTypeDefinition = {
+        uri: "http://example.org/Task",
+        label: "Task",
+        source: "rdfs:Class",
+        style: { color: "#00ff00" },
+        priority: 1,
+      };
+
+      expect(def.uri).toBe("http://example.org/Task");
+      expect(def.source).toBe("rdfs:Class");
+    });
+
+    it("should allow creating EdgeTypeDefinition with domain and range", () => {
+      const def: EdgeTypeDefinition = {
+        uri: "http://example.org/hasParent",
+        label: "has parent",
+        domain: ["http://example.org/Task"],
+        range: ["http://example.org/Project"],
+        source: "rdf:type",
+        style: { color: "#0000ff" },
+        priority: 1,
+      };
+
+      expect(def.domain).toContain("http://example.org/Task");
+      expect(def.range).toContain("http://example.org/Project");
+    });
+
+    it("should support all TypeSource values", () => {
+      const sources: Array<NodeTypeDefinition["source"]> = [
+        "rdf:type",
+        "rdfs:Class",
+        "owl:Class",
+        "exo:Instance_class",
+        "inferred",
+        "custom",
+      ];
+
+      sources.forEach(source => {
+        const def: NodeTypeDefinition = {
+          uri: "test",
+          label: "test",
+          source,
+          style: {},
+          priority: 1,
+        };
+        expect(def.source).toBe(source);
+      });
+    });
+
+    it("should support all node shapes", () => {
+      const shapes: Array<NonNullable<NodeStyle["shape"]>> = [
+        "circle",
+        "square",
+        "diamond",
+        "triangle",
+        "hexagon",
+      ];
+
+      shapes.forEach(shape => {
+        const style: NodeStyle = { shape };
+        expect(style.shape).toBe(shape);
+      });
+    });
+
+    it("should support all edge line styles", () => {
+      const lineStyles: Array<NonNullable<EdgeStyle["lineStyle"]>> = [
+        "solid",
+        "dashed",
+        "dotted",
+      ];
+
+      lineStyles.forEach(lineStyle => {
+        const style: EdgeStyle = { lineStyle };
+        expect(style.lineStyle).toBe(lineStyle);
+      });
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/services/TypeRegistry.test.ts
+++ b/packages/exocortex/tests/unit/services/TypeRegistry.test.ts
@@ -1,0 +1,825 @@
+import { TypeRegistry } from "../../../src/services/TypeRegistry";
+import {
+  NodeTypeDefinition,
+  EdgeTypeDefinition,
+  TypeFilter,
+  TypeGrouping,
+  RDF_TYPE_PREDICATES,
+  DEFAULT_NODE_STYLE,
+  DEFAULT_EDGE_STYLE,
+} from "../../../src/domain/models/GraphTypes";
+import { GraphNode } from "../../../src/domain/models/GraphNode";
+import { GraphEdge } from "../../../src/domain/models/GraphEdge";
+
+describe("TypeRegistry", () => {
+  let registry: TypeRegistry;
+
+  beforeEach(() => {
+    registry = new TypeRegistry(null, { includeBuiltInStyles: false });
+  });
+
+  describe("constructor", () => {
+    it("should create empty registry when includeBuiltInStyles is false", () => {
+      expect(registry.getAllNodeTypes()).toHaveLength(0);
+      expect(registry.getAllEdgeTypes()).toHaveLength(0);
+    });
+
+    it("should include built-in styles when enabled", () => {
+      const registryWithBuiltIn = new TypeRegistry(null, { includeBuiltInStyles: true });
+      expect(registryWithBuiltIn.getAllNodeTypes().length).toBeGreaterThan(0);
+      expect(registryWithBuiltIn.getAllEdgeTypes().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("registerNodeType", () => {
+    it("should register a new node type", () => {
+      const def: NodeTypeDefinition = {
+        uri: "http://example.org/Task",
+        label: "Task",
+        source: "custom",
+        style: { color: "#00ff00" },
+        priority: 1,
+      };
+
+      registry.registerNodeType(def);
+
+      expect(registry.getNodeType("http://example.org/Task")).toEqual(def);
+    });
+
+    it("should update existing node type", () => {
+      const def1: NodeTypeDefinition = {
+        uri: "http://example.org/Task",
+        label: "Task",
+        source: "custom",
+        style: { color: "#00ff00" },
+        priority: 1,
+      };
+
+      const def2: NodeTypeDefinition = {
+        uri: "http://example.org/Task",
+        label: "Updated Task",
+        source: "custom",
+        style: { color: "#ff0000" },
+        priority: 2,
+      };
+
+      registry.registerNodeType(def1);
+      registry.registerNodeType(def2);
+
+      const result = registry.getNodeType("http://example.org/Task");
+      expect(result?.label).toBe("Updated Task");
+      expect(result?.style.color).toBe("#ff0000");
+    });
+
+    it("should emit type-added event for new type", () => {
+      const events: string[] = [];
+      registry.subscribe(event => events.push(event.type));
+
+      registry.registerNodeType({
+        uri: "http://example.org/Task",
+        label: "Task",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      expect(events).toContain("type-added");
+    });
+
+    it("should emit type-updated event for existing type", () => {
+      registry.registerNodeType({
+        uri: "http://example.org/Task",
+        label: "Task",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      const events: string[] = [];
+      registry.subscribe(event => events.push(event.type));
+
+      registry.registerNodeType({
+        uri: "http://example.org/Task",
+        label: "Updated",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      expect(events).toContain("type-updated");
+    });
+  });
+
+  describe("registerEdgeType", () => {
+    it("should register a new edge type", () => {
+      const def: EdgeTypeDefinition = {
+        uri: "http://example.org/hasParent",
+        label: "has parent",
+        source: "custom",
+        style: { color: "#0000ff" },
+        priority: 1,
+      };
+
+      registry.registerEdgeType(def);
+
+      expect(registry.getEdgeType("http://example.org/hasParent")).toEqual(def);
+    });
+
+    it("should register edge type with domain and range", () => {
+      const def: EdgeTypeDefinition = {
+        uri: "http://example.org/assignedTo",
+        label: "assigned to",
+        domain: ["http://example.org/Task"],
+        range: ["http://example.org/Person"],
+        source: "custom",
+        style: {},
+        priority: 1,
+      };
+
+      registry.registerEdgeType(def);
+
+      const result = registry.getEdgeType("http://example.org/assignedTo");
+      expect(result?.domain).toContain("http://example.org/Task");
+      expect(result?.range).toContain("http://example.org/Person");
+    });
+  });
+
+  describe("unregisterType", () => {
+    it("should unregister a node type", () => {
+      registry.registerNodeType({
+        uri: "http://example.org/Task",
+        label: "Task",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      registry.unregisterType("http://example.org/Task");
+
+      expect(registry.getNodeType("http://example.org/Task")).toBeUndefined();
+    });
+
+    it("should emit type-removed event", () => {
+      registry.registerNodeType({
+        uri: "http://example.org/Task",
+        label: "Task",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      const events: string[] = [];
+      registry.subscribe(event => events.push(event.type));
+
+      registry.unregisterType("http://example.org/Task");
+
+      expect(events).toContain("type-removed");
+    });
+  });
+
+  describe("type hierarchy", () => {
+    beforeEach(() => {
+      // Set up a type hierarchy: Task -> Effort -> Thing
+      registry.registerNodeType({
+        uri: "http://example.org/Thing",
+        label: "Thing",
+        source: "custom",
+        style: { color: "#aaaaaa" },
+        priority: 0,
+      });
+
+      registry.registerNodeType({
+        uri: "http://example.org/Effort",
+        label: "Effort",
+        parentTypes: ["http://example.org/Thing"],
+        source: "custom",
+        style: { color: "#666666" },
+        priority: 1,
+      });
+
+      registry.registerNodeType({
+        uri: "http://example.org/Task",
+        label: "Task",
+        parentTypes: ["http://example.org/Effort"],
+        source: "custom",
+        style: { color: "#00ff00" },
+        priority: 2,
+      });
+    });
+
+    it("should return direct parent types", () => {
+      const parents = registry.getParentTypes("http://example.org/Task");
+      expect(parents).toContain("http://example.org/Effort");
+    });
+
+    it("should return inherited parent types", () => {
+      const parents = registry.getParentTypes("http://example.org/Task");
+      expect(parents).toContain("http://example.org/Effort");
+      expect(parents).toContain("http://example.org/Thing");
+    });
+
+    it("should respect max depth", () => {
+      const parents = registry.getParentTypes("http://example.org/Task", 1);
+      expect(parents).toContain("http://example.org/Effort");
+      expect(parents).not.toContain("http://example.org/Thing");
+    });
+
+    it("should return child types", () => {
+      const children = registry.getChildTypes("http://example.org/Effort");
+      expect(children).toContain("http://example.org/Task");
+    });
+
+    it("should check subtype relationship", () => {
+      expect(registry.isSubtypeOf("http://example.org/Task", "http://example.org/Effort")).toBe(true);
+      expect(registry.isSubtypeOf("http://example.org/Task", "http://example.org/Thing")).toBe(true);
+      expect(registry.isSubtypeOf("http://example.org/Thing", "http://example.org/Task")).toBe(false);
+    });
+
+    it("should return true for same type in isSubtypeOf", () => {
+      expect(registry.isSubtypeOf("http://example.org/Task", "http://example.org/Task")).toBe(true);
+    });
+  });
+
+  describe("resolveNodeType", () => {
+    beforeEach(() => {
+      registry.registerNodeType({
+        uri: "ems__Task",
+        label: "Task",
+        source: "exo:Instance_class",
+        style: { color: "#00ff00", shape: "circle" },
+        priority: 1,
+      });
+    });
+
+    it("should resolve type from assetClass", () => {
+      const node: GraphNode = {
+        id: "test-node",
+        path: "test.md",
+        title: "Test",
+        label: "Test",
+        assetClass: "[[ems__Task]]",
+        isArchived: false,
+      };
+
+      const typeInfo = registry.resolveNodeType(node);
+
+      expect(typeInfo.primaryType).toBe("ems__Task");
+      expect(typeInfo.types).toContain("ems__Task");
+      expect(typeInfo.source).toBe("exo:Instance_class");
+    });
+
+    it("should resolve style from type", () => {
+      const node: GraphNode = {
+        id: "test-node",
+        path: "test.md",
+        title: "Test",
+        label: "Test",
+        assetClass: "ems__Task",
+        isArchived: false,
+      };
+
+      const typeInfo = registry.resolveNodeType(node);
+
+      expect(typeInfo.resolvedStyle.color).toBe("#00ff00");
+      expect(typeInfo.resolvedStyle.shape).toBe("circle");
+    });
+
+    it("should return unknown type when no type info", () => {
+      const node: GraphNode = {
+        id: "test-node",
+        path: "test.md",
+        title: "Test",
+        label: "Test",
+        isArchived: false,
+      };
+
+      const typeInfo = registry.resolveNodeType(node);
+
+      expect(typeInfo.primaryType).toBe("unknown");
+    });
+
+    it("should include rdf:type from properties", () => {
+      const node: GraphNode = {
+        id: "test-node",
+        path: "test.md",
+        title: "Test",
+        label: "Test",
+        isArchived: false,
+        properties: {
+          [RDF_TYPE_PREDICATES.RDF_TYPE]: "http://example.org/CustomType",
+        },
+      };
+
+      const typeInfo = registry.resolveNodeType(node);
+
+      expect(typeInfo.types).toContain("http://example.org/CustomType");
+    });
+  });
+
+  describe("resolveEdgeType", () => {
+    beforeEach(() => {
+      registry.registerEdgeType({
+        uri: "http://example.org/parent",
+        label: "parent",
+        source: "custom",
+        style: { color: "#0000ff", width: 2 },
+        priority: 1,
+      });
+    });
+
+    it("should resolve type from predicate", () => {
+      const edge: GraphEdge = {
+        id: "edge-1",
+        source: "node-1",
+        target: "node-2",
+        type: "semantic",
+        predicate: "http://example.org/parent",
+      };
+
+      const typeInfo = registry.resolveEdgeType(edge);
+
+      expect(typeInfo.primaryType).toBe("http://example.org/parent");
+      expect(typeInfo.resolvedStyle.color).toBe("#0000ff");
+      expect(typeInfo.resolvedStyle.width).toBe(2);
+    });
+
+    it("should fall back to edge type when no predicate", () => {
+      const edge: GraphEdge = {
+        id: "edge-1",
+        source: "node-1",
+        target: "node-2",
+        type: "hierarchy",
+      };
+
+      const typeInfo = registry.resolveEdgeType(edge);
+
+      expect(typeInfo.primaryType).toBe("hierarchy");
+    });
+  });
+
+  describe("style resolution", () => {
+    it("should merge styles from multiple types by priority", () => {
+      registry.registerNodeType({
+        uri: "http://example.org/Base",
+        label: "Base",
+        source: "custom",
+        style: { color: "#ff0000", size: 20, shape: "circle" },
+        priority: 1,
+      });
+
+      registry.registerNodeType({
+        uri: "http://example.org/Derived",
+        label: "Derived",
+        source: "custom",
+        style: { color: "#00ff00", borderWidth: 3 },
+        priority: 2,
+      });
+
+      const style = registry.resolveNodeStyle([
+        "http://example.org/Base",
+        "http://example.org/Derived",
+      ]);
+
+      // Higher priority color wins
+      expect(style.color).toBe("#00ff00");
+      // Other properties from both are merged
+      expect(style.size).toBe(20);
+      expect(style.borderWidth).toBe(3);
+    });
+
+    it("should use default style when no types match", () => {
+      const style = registry.resolveNodeStyle(["http://example.org/Unknown"]);
+
+      // Should fall back to default
+      expect(style.color).toBe(DEFAULT_NODE_STYLE.color);
+      expect(style.shape).toBe(DEFAULT_NODE_STYLE.shape);
+    });
+  });
+
+  describe("filterNodes", () => {
+    const nodes: GraphNode[] = [
+      { id: "1", path: "1.md", title: "Task 1", label: "T1", assetClass: "ems__Task", isArchived: false },
+      { id: "2", path: "2.md", title: "Project 1", label: "P1", assetClass: "ems__Project", isArchived: false },
+      { id: "3", path: "3.md", title: "Task 2", label: "T2", assetClass: "ems__Task", isArchived: false },
+      { id: "4", path: "4.md", title: "Area 1", label: "A1", assetClass: "ems__Area", isArchived: false },
+    ];
+
+    beforeEach(() => {
+      registry.registerNodeType({
+        uri: "ems__Task",
+        label: "Task",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+      registry.registerNodeType({
+        uri: "ems__Project",
+        label: "Project",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+      registry.registerNodeType({
+        uri: "ems__Area",
+        label: "Area",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+    });
+
+    it("should include only specified types", () => {
+      const filter: TypeFilter = {
+        includeNodeTypes: ["ems__Task"],
+      };
+
+      const filtered = registry.filterNodes(nodes, filter);
+
+      expect(filtered).toHaveLength(2);
+      expect(filtered.every(n => n.assetClass === "ems__Task")).toBe(true);
+    });
+
+    it("should exclude specified types", () => {
+      const filter: TypeFilter = {
+        excludeNodeTypes: ["ems__Task"],
+      };
+
+      const filtered = registry.filterNodes(nodes, filter);
+
+      expect(filtered).toHaveLength(2);
+      expect(filtered.some(n => n.assetClass === "ems__Task")).toBe(false);
+    });
+
+    it("should combine include and exclude", () => {
+      const filter: TypeFilter = {
+        includeNodeTypes: ["ems__Task", "ems__Project"],
+        excludeNodeTypes: ["ems__Project"],
+      };
+
+      const filtered = registry.filterNodes(nodes, filter);
+
+      expect(filtered).toHaveLength(2);
+      expect(filtered.every(n => n.assetClass === "ems__Task")).toBe(true);
+    });
+
+    it("should exclude deprecated types by default", () => {
+      registry.registerNodeType({
+        uri: "ems__OldTask",
+        label: "Old Task",
+        source: "custom",
+        style: {},
+        priority: 1,
+        deprecated: true,
+      });
+
+      const nodesWithDeprecated: GraphNode[] = [
+        ...nodes,
+        { id: "5", path: "5.md", title: "Old", label: "O", assetClass: "ems__OldTask", isArchived: false },
+      ];
+
+      const filtered = registry.filterNodes(nodesWithDeprecated, {});
+
+      expect(filtered.some(n => n.assetClass === "ems__OldTask")).toBe(false);
+    });
+
+    it("should include deprecated types when specified", () => {
+      registry.registerNodeType({
+        uri: "ems__OldTask",
+        label: "Old Task",
+        source: "custom",
+        style: {},
+        priority: 1,
+        deprecated: true,
+      });
+
+      const nodesWithDeprecated: GraphNode[] = [
+        { id: "5", path: "5.md", title: "Old", label: "O", assetClass: "ems__OldTask", isArchived: false },
+      ];
+
+      const filtered = registry.filterNodes(nodesWithDeprecated, {
+        includeDeprecated: true,
+      });
+
+      expect(filtered).toHaveLength(1);
+    });
+  });
+
+  describe("filterEdges", () => {
+    const edges: GraphEdge[] = [
+      { id: "e1", source: "1", target: "2", type: "hierarchy", predicate: "http://ex.org/parent" },
+      { id: "e2", source: "2", target: "3", type: "reference", predicate: "http://ex.org/refs" },
+      { id: "e3", source: "1", target: "3", type: "hierarchy", predicate: "http://ex.org/parent" },
+    ];
+
+    it("should include only specified types", () => {
+      const filter: TypeFilter = {
+        includeEdgeTypes: ["http://ex.org/parent"],
+      };
+
+      const filtered = registry.filterEdges(edges, filter);
+
+      expect(filtered).toHaveLength(2);
+      expect(filtered.every(e => e.predicate === "http://ex.org/parent")).toBe(true);
+    });
+
+    it("should exclude specified types", () => {
+      const filter: TypeFilter = {
+        excludeEdgeTypes: ["http://ex.org/parent"],
+      };
+
+      const filtered = registry.filterEdges(edges, filter);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].predicate).toBe("http://ex.org/refs");
+    });
+  });
+
+  describe("groupNodesByType", () => {
+    const nodes: GraphNode[] = [
+      { id: "1", path: "1.md", title: "Task 1", label: "T1", assetClass: "ems__Task", isArchived: false },
+      { id: "2", path: "2.md", title: "Task 2", label: "T2", assetClass: "ems__Task", isArchived: false },
+      { id: "3", path: "3.md", title: "Project 1", label: "P1", assetClass: "ems__Project", isArchived: false },
+      { id: "4", path: "4.md", title: "Area 1", label: "A1", assetClass: "ems__Area", isArchived: false },
+    ];
+
+    const edges: GraphEdge[] = [
+      { id: "e1", source: "1", target: "2", type: "reference" },
+      { id: "e2", source: "1", target: "3", type: "hierarchy" },
+      { id: "e3", source: "3", target: "4", type: "hierarchy" },
+    ];
+
+    it("should group nodes by type", () => {
+      const groups = registry.groupNodesByType(nodes, edges);
+
+      expect(groups.length).toBe(3);
+
+      const taskGroup = groups.find(g => g.id === "ems__Task");
+      expect(taskGroup?.nodeIds).toHaveLength(2);
+      expect(taskGroup?.nodeIds).toContain("1");
+      expect(taskGroup?.nodeIds).toContain("2");
+
+      const projectGroup = groups.find(g => g.id === "ems__Project");
+      expect(projectGroup?.nodeIds).toHaveLength(1);
+    });
+
+    it("should calculate edge statistics", () => {
+      const groups = registry.groupNodesByType(nodes, edges);
+
+      const taskGroup = groups.find(g => g.id === "ems__Task");
+      expect(taskGroup?.stats.internalEdgeCount).toBe(1); // e1: 1->2
+      expect(taskGroup?.stats.externalEdgeCount).toBe(1); // e2: 1->3
+    });
+
+    it("should limit number of groups", () => {
+      const manyNodes: GraphNode[] = [];
+      for (let i = 0; i < 50; i++) {
+        manyNodes.push({
+          id: `${i}`,
+          path: `${i}.md`,
+          title: `Node ${i}`,
+          label: `N${i}`,
+          assetClass: `type_${i % 30}`, // 30 different types
+          isArchived: false,
+        });
+      }
+
+      const groups = registry.groupNodesByType(manyNodes, [], { maxGroups: 5 });
+
+      expect(groups.length).toBe(5);
+      expect(groups.some(g => g.id === "other")).toBe(true);
+    });
+
+    it("should support custom grouping function", () => {
+      const grouping: TypeGrouping = {
+        customGroupFn: (types) => types[0].startsWith("ems__") ? "ems" : "other",
+      };
+
+      const groups = registry.groupNodesByType(nodes, edges, grouping);
+
+      expect(groups.length).toBe(1); // All are ems__
+      expect(groups[0].id).toBe("ems");
+      expect(groups[0].nodeIds).toHaveLength(4);
+    });
+
+    it("should assign colors to groups", () => {
+      const groups = registry.groupNodesByType(nodes, edges);
+
+      for (const group of groups) {
+        expect(group.color).toBeDefined();
+        // Allow decimal values in hsl, e.g., "hsl(137.5, 70%, 50%)"
+        expect(group.color).toMatch(/^hsl\([\d.]+, 70%, 50%\)$/);
+      }
+    });
+  });
+
+  describe("validateTypes", () => {
+    const nodes: GraphNode[] = [
+      { id: "1", path: "1.md", title: "Task", label: "T", assetClass: "ems__Task", isArchived: false },
+      { id: "2", path: "2.md", title: "Unknown", label: "U", isArchived: false },
+    ];
+
+    const edges: GraphEdge[] = [
+      { id: "e1", source: "1", target: "2", type: "semantic", predicate: "http://ex.org/link" },
+    ];
+
+    beforeEach(() => {
+      registry.registerNodeType({
+        uri: "ems__Task",
+        label: "Task",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+    });
+
+    it("should validate nodes and return result", () => {
+      const result = registry.validateTypes(nodes, edges);
+
+      expect(result.valid).toBe(true); // No errors (warnings don't fail)
+      expect(result.warnings.length).toBeGreaterThan(0); // Has warnings
+    });
+
+    it("should warn about unregistered types", () => {
+      const result = registry.validateTypes(nodes, edges);
+
+      const warning = result.warnings.find(w => w.code === "MISSING_NODE_TYPE");
+      expect(warning).toBeDefined();
+      expect(warning?.elementId).toBe("2");
+    });
+
+    it("should check domain constraints", () => {
+      registry.registerEdgeType({
+        uri: "http://ex.org/taskLink",
+        label: "task link",
+        domain: ["ems__Project"], // Only projects can be sources
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      registry.registerNodeType({
+        uri: "ems__Project",
+        label: "Project",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      const edgesWithConstraint: GraphEdge[] = [
+        { id: "e1", source: "1", target: "2", type: "semantic", predicate: "http://ex.org/taskLink" },
+      ];
+
+      const result = registry.validateTypes(nodes, edgesWithConstraint);
+
+      expect(result.valid).toBe(false);
+      const error = result.errors.find(e => e.code === "DOMAIN_VIOLATION");
+      expect(error).toBeDefined();
+    });
+
+    it("should check range constraints", () => {
+      registry.registerEdgeType({
+        uri: "http://ex.org/hasTarget",
+        label: "has target",
+        range: ["ems__Project"], // Only projects can be targets
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      registry.registerNodeType({
+        uri: "ems__Project",
+        label: "Project",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      const edgesWithConstraint: GraphEdge[] = [
+        { id: "e1", source: "1", target: "2", type: "semantic", predicate: "http://ex.org/hasTarget" },
+      ];
+
+      const result = registry.validateTypes(nodes, edgesWithConstraint);
+
+      // Node 2 has no assetClass, so it won't match ems__Project
+      expect(result.valid).toBe(false);
+      const error = result.errors.find(e => e.code === "RANGE_VIOLATION");
+      expect(error).toBeDefined();
+    });
+
+    it("should warn about deprecated types", () => {
+      registry.registerNodeType({
+        uri: "ems__OldType",
+        label: "Old Type",
+        source: "custom",
+        style: {},
+        priority: 1,
+        deprecated: true,
+      });
+
+      const nodesWithDeprecated: GraphNode[] = [
+        { id: "1", path: "1.md", title: "Old", label: "O", assetClass: "ems__OldType", isArchived: false },
+      ];
+
+      const result = registry.validateTypes(nodesWithDeprecated, []);
+
+      const warning = result.warnings.find(w => w.code === "DEPRECATED_NODE_TYPE");
+      expect(warning).toBeDefined();
+    });
+  });
+
+  describe("clear", () => {
+    it("should clear all registered types", () => {
+      registry.registerNodeType({
+        uri: "test",
+        label: "Test",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      registry.clear();
+
+      expect(registry.getAllNodeTypes()).toHaveLength(0);
+      expect(registry.getAllEdgeTypes()).toHaveLength(0);
+    });
+
+    it("should re-register built-in types when enabled", () => {
+      const registryWithBuiltIn = new TypeRegistry(null, { includeBuiltInStyles: true });
+      const initialCount = registryWithBuiltIn.getAllNodeTypes().length;
+
+      registryWithBuiltIn.registerNodeType({
+        uri: "custom",
+        label: "Custom",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      registryWithBuiltIn.clear();
+
+      expect(registryWithBuiltIn.getAllNodeTypes().length).toBe(initialCount);
+    });
+  });
+
+  describe("subscribe", () => {
+    it("should call callback on events", () => {
+      const events: string[] = [];
+      registry.subscribe(event => events.push(event.type));
+
+      registry.registerNodeType({
+        uri: "test",
+        label: "Test",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      expect(events).toContain("type-added");
+    });
+
+    it("should allow unsubscribing", () => {
+      const events: string[] = [];
+      const unsubscribe = registry.subscribe(event => events.push(event.type));
+
+      registry.registerNodeType({
+        uri: "test1",
+        label: "Test 1",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      unsubscribe();
+
+      registry.registerNodeType({
+        uri: "test2",
+        label: "Test 2",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      expect(events).toHaveLength(1);
+    });
+
+    it("should continue even if callback throws", () => {
+      const events: string[] = [];
+
+      registry.subscribe(() => {
+        throw new Error("Test error");
+      });
+      registry.subscribe(event => events.push(event.type));
+
+      // Should not throw
+      registry.registerNodeType({
+        uri: "test",
+        label: "Test",
+        source: "custom",
+        style: {},
+        priority: 1,
+      });
+
+      expect(events).toContain("type-added");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements a comprehensive type system for graph nodes and edges with RDF/OWL ontology support.

### Changes

**GraphTypes.ts** - Core type definitions:
- `NodeTypeDefinition` and `EdgeTypeDefinition` interfaces for semantic types
- `NodeStyle` and `EdgeStyle` interfaces with customizable visual properties (color, shape, size, opacity, animation, etc.)
- `TypeFilter` for include/exclude filtering by semantic types
- `TypeGrouping` for clustering nodes by type hierarchy
- `TypeValidationResult` for domain/range validation
- `TypeRegistryEvent` union type for type change subscriptions
- Built-in styles for RDF/OWL meta-types (`rdfs:Class`, `owl:Class`) and Exocortex types (`ems__Task`, `ems__Project`, `ems__Area`, etc.)
- Helper functions: `mergeNodeStyles`, `mergeEdgeStyles`, `extractLocalName`, `isClassType`, `isTypePredicate`, `isSubClassPredicate`
- Default styles with sensible defaults

**TypeRegistry.ts** - Type management service:
- Type registration for nodes and edges with `registerNodeType()` and `registerEdgeType()`
- Type hierarchy management with `getParentTypes()`, `isSubtypeOf()`, and configurable max depth
- Style resolution with inheritance and priority-based merging
- Type-based filtering with `filterNodes()` and `filterEdges()` methods
- Type-based grouping with `groupNodesByType()` supporting customizable group levels
- Domain/range validation for edge types with detailed error/warning reporting
- Auto-discovery of types from triple store via `discoverTypes()`
- Event subscription system for type changes

### Testing

82 passing tests:
- 36 tests for GraphTypes (constants, interfaces, helper functions, built-in styles)
- 46 tests for TypeRegistry (registration, hierarchy, resolution, filtering, grouping, validation, discovery)

Closes #1152