### PR TITLE
fix(security): prevent prototype pollution in deepMerge

### DIFF
--- a/flaky-report.json
+++ b/flaky-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-12-25T05:12:12.450Z",
+  "timestamp": "2025-12-25T08:17:16.057Z",
   "totalFlaky": 0,
   "tests": [],
   "summary": {

--- a/packages/obsidian-plugin/flaky-report-playwright.json
+++ b/packages/obsidian-plugin/flaky-report-playwright.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-12-25T05:12:20.536Z",
+  "timestamp": "2025-12-25T08:16:05.406Z",
   "totalFlaky": 0,
   "tests": [],
   "summary": {

--- a/packages/obsidian-plugin/src/presentation/stores/physicsWorkerStore/physics.worker.ts
+++ b/packages/obsidian-plugin/src/presentation/stores/physicsWorkerStore/physics.worker.ts
@@ -695,9 +695,21 @@ function sendError(error: unknown): void {
   sendMessage({ type: "error", message: errorMessage, stack });
 }
 
+/**
+ * Checks if a property name is safe (not a prototype pollution vector)
+ */
+function isSafePropertyName(key: string): boolean {
+  return key !== "__proto__" && key !== "constructor" && key !== "prototype";
+}
+
 function deepMerge<T extends object>(target: T, source: Partial<T>): T {
   const output = { ...target };
   for (const key of Object.keys(source) as (keyof T)[]) {
+    // Skip dangerous property names to prevent prototype pollution
+    if (!isSafePropertyName(key as string)) {
+      continue;
+    }
+
     const sourceValue = source[key];
     const targetValue = target[key];
 


### PR DESCRIPTION
## Summary
- Fix remote property injection (prototype pollution) vulnerability in `deepMerge` function
- Added `isSafePropertyName()` helper to filter dangerous property names (`__proto__`, `constructor`, `prototype`)
- Resolves 2 code scanning alerts (IDs 292, 293)

## Security Issue
The `deepMerge` function in `physics.worker.ts` was vulnerable to prototype pollution. When merging configuration objects received from message events, an attacker could inject properties like `__proto__` to pollute the Object prototype, potentially leading to:
- Denial of service
- Property access hijacking
- Security bypass

## Solution
Added a guard function `isSafePropertyName()` that checks if a property name is safe (not `__proto__`, `constructor`, or `prototype`) before performing the merge operation.

## Test plan
- [x] TypeScript types check pass
- [x] Unit tests pass (587 tests)
- [ ] CI pipeline passes

Closes #1212