### PR TITLE
feat: Display TaskPrototype links in Properties with printName template

### DIFF
--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -56,6 +56,8 @@ export interface ExocortexSettings {
   useDynamicPropertyFields: boolean;
   showLabelsInFileExplorer: boolean;
   showLabelsInTabTitles: boolean;
+  /** Apply display name templates to links in Obsidian's Properties block */
+  showLabelsInProperties: boolean;
   /** @deprecated Use displayNameSettings.defaultTemplate instead */
   displayNameTemplate: string;
   sortByDisplayName: boolean;
@@ -77,6 +79,7 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   useDynamicPropertyFields: false,
   showLabelsInFileExplorer: true,
   showLabelsInTabTitles: true,
+  showLabelsInProperties: true,
   displayNameTemplate: "{{exo__Asset_label}}",
   sortByDisplayName: false,
   displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS,

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
@@ -1,0 +1,375 @@
+import { TFile, Plugin, CachedMetadata } from "obsidian";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
+
+/**
+ * PropertiesLinkPatch - Patches Obsidian's Properties block to show display names for links
+ *
+ * This patch intercepts the Properties block's rendering to display meaningful labels
+ * for links that point to notes with exo__Asset_label set in their frontmatter.
+ * Uses per-class templates (e.g., "{{exo__Asset_label}} (TaskPrototype)").
+ *
+ * Implementation approach:
+ * - Uses MutationObserver to detect Properties block DOM changes
+ * - Finds internal links within .metadata-container
+ * - Replaces link text with resolved display name while preserving link behavior
+ * - Listens for metadata changes to update labels dynamically
+ * - Stores original text as data attributes for restoration
+ */
+
+interface PluginWithSettings extends Plugin {
+  settings: ExocortexSettings;
+}
+
+export class PropertiesLinkPatch {
+  private app: Plugin["app"];
+  private plugin: PluginWithSettings;
+  private observer: MutationObserver | null = null;
+  private enabled = false;
+  private patchedElements: WeakMap<HTMLElement, string> = new WeakMap();
+  private metadataChangeHandler: (file: TFile, data: string, cache: CachedMetadata) => void;
+
+  constructor(plugin: Plugin) {
+    this.plugin = plugin as PluginWithSettings;
+    this.app = plugin.app;
+    this.metadataChangeHandler = this.handleMetadataChange.bind(this);
+  }
+
+  /**
+   * Get the display name settings
+   */
+  private getDisplayNameSettings(): DisplayNameSettings {
+    if (this.plugin.settings?.displayNameSettings) {
+      return this.plugin.settings.displayNameSettings;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional backwards compatibility
+    const template = this.plugin.settings?.displayNameTemplate || DEFAULT_DISPLAY_NAME_TEMPLATE;
+    return {
+      defaultTemplate: template,
+      classTemplates: {},
+      statusEmojis: {},
+    };
+  }
+
+  /**
+   * Create a DisplayNameResolver with current settings
+   */
+  private createResolver(): DisplayNameResolver {
+    return new DisplayNameResolver(this.getDisplayNameSettings());
+  }
+
+  /**
+   * Enable the Properties link patch
+   */
+  enable(): void {
+    if (this.enabled) return;
+    this.enabled = true;
+
+    // Initial patch of existing Properties blocks
+    this.patchAllPropertiesBlocks();
+
+    // Set up observer for dynamic content
+    this.setupObserver();
+
+    // Listen for metadata changes to update labels
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("changed", this.metadataChangeHandler)
+    );
+
+    // Re-patch when workspace layout changes
+    this.plugin.registerEvent(
+      this.app.workspace.on("layout-change", () => {
+        setTimeout(() => this.patchAllPropertiesBlocks(), 100);
+      })
+    );
+
+    // Re-patch when active leaf changes
+    this.plugin.registerEvent(
+      this.app.workspace.on("active-leaf-change", () => {
+        setTimeout(() => this.patchAllPropertiesBlocks(), 100);
+      })
+    );
+  }
+
+  /**
+   * Disable the Properties link patch and restore original text
+   */
+  disable(): void {
+    if (!this.enabled) return;
+    this.enabled = false;
+
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+
+    this.restoreAllLabels();
+  }
+
+  /**
+   * Cleanup resources when plugin unloads
+   */
+  cleanup(): void {
+    this.disable();
+  }
+
+  /**
+   * Patch all Properties blocks in visible views
+   */
+  private patchAllPropertiesBlocks(): void {
+    if (!this.enabled) return;
+
+    // Get all markdown views
+    if (typeof this.app.workspace.getLeavesOfType === "function") {
+      const leaves = this.app.workspace.getLeavesOfType("markdown");
+      if (Array.isArray(leaves)) {
+        for (const leaf of leaves) {
+          const container = leaf.view.containerEl;
+          this.patchPropertiesBlock(container);
+        }
+      }
+    }
+  }
+
+  /**
+   * Patch links within a Properties block container
+   */
+  private patchPropertiesBlock(container: HTMLElement): void {
+    // Find the metadata container (Properties block)
+    const metadataContainer = container.querySelector<HTMLElement>(".metadata-container");
+    if (!metadataContainer) return;
+
+    // Find all internal links within the Properties block
+    // Obsidian uses various selectors for links in properties:
+    // - .internal-link (standard internal links)
+    // - .multi-select-pill-content (for multi-value properties)
+    // - a[data-href] (any link with href data)
+    const linkSelectors = [
+      ".internal-link",
+      ".multi-select-pill-content .internal-link",
+      'a[data-href]:not(.internal-link)',
+    ];
+
+    const links = metadataContainer.querySelectorAll<HTMLElement>(
+      linkSelectors.join(", ")
+    );
+
+    for (const link of Array.from(links)) {
+      this.patchLink(link);
+    }
+  }
+
+  /**
+   * Patch a single link element
+   */
+  private patchLink(linkEl: HTMLElement): void {
+    // Get the file path from data-href attribute
+    const dataHref = linkEl.getAttribute("data-href");
+    if (!dataHref) return;
+
+    // Try to find the linked file
+    const file = this.resolveFile(dataHref);
+    if (!file) return;
+
+    // Get the display name for this file
+    const displayName = this.getDisplayName(file);
+    if (!displayName) return;
+
+    // Store original text for restoration
+    const originalText = linkEl.textContent || "";
+    if (!linkEl.hasAttribute("data-original-text")) {
+      linkEl.setAttribute("data-original-text", originalText);
+    }
+
+    // Only update if different from current text
+    if (linkEl.textContent !== displayName) {
+      linkEl.textContent = displayName;
+      this.patchedElements.set(linkEl, originalText);
+
+      // Add tooltip with original filename
+      linkEl.setAttribute("aria-label", `${displayName}\n(${file.basename}.md)`);
+    }
+  }
+
+  /**
+   * Resolve a file path to a TFile
+   */
+  private resolveFile(linkPath: string): TFile | null {
+    // Clean up the path
+    const cleanPath = linkPath
+      .replace(/^\[\[|\]\]$/g, "") // Remove wikilink brackets
+      .replace(/^"|"$/g, "") // Remove quotes
+      .trim();
+
+    if (!cleanPath) return null;
+
+    // Try to find the file
+    let file = this.app.metadataCache.getFirstLinkpathDest(cleanPath, "");
+
+    // Try with .md extension if not found
+    if (!file && !cleanPath.endsWith(".md")) {
+      file = this.app.metadataCache.getFirstLinkpathDest(cleanPath + ".md", "");
+    }
+
+    if (file instanceof TFile && file.extension === "md") {
+      return file;
+    }
+
+    return null;
+  }
+
+  /**
+   * Get the display name for a file using per-class template resolution
+   */
+  private getDisplayName(file: TFile): string | null {
+    const cache = this.app.metadataCache.getFileCache(file);
+    const frontmatter = cache?.frontmatter;
+
+    if (!frontmatter) return null;
+
+    // Build metadata for template rendering
+    const metadata = this.buildTemplateMetadata(frontmatter, file);
+
+    // Get creation date if available
+    const createdDate = file.stat?.ctime ? new Date(file.stat.ctime) : undefined;
+
+    // Use DisplayNameResolver for per-class template resolution
+    const resolver = this.createResolver();
+    const displayName = resolver.resolve({
+      metadata,
+      basename: file.basename,
+      createdDate,
+    });
+
+    return displayName;
+  }
+
+  /**
+   * Build metadata object for template rendering, merging frontmatter with prototype data
+   */
+  private buildTemplateMetadata(
+    frontmatter: Record<string, unknown>,
+    _file: TFile
+  ): Record<string, unknown> {
+    const metadata = { ...frontmatter };
+
+    // If label is missing, try to get from prototype
+    if (!metadata.exo__Asset_label) {
+      const prototypeRef = metadata.exo__Asset_prototype;
+      if (prototypeRef) {
+        const prototypePath =
+          typeof prototypeRef === "string"
+            ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
+            : null;
+
+        if (prototypePath) {
+          let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+            prototypePath,
+            ""
+          );
+
+          if (!prototypeFile && !prototypePath.endsWith(".md")) {
+            prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+              prototypePath + ".md",
+              ""
+            );
+          }
+
+          if (prototypeFile instanceof TFile) {
+            const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
+            const prototypeMetadata = prototypeCache?.frontmatter;
+
+            if (prototypeMetadata?.exo__Asset_label) {
+              metadata.exo__Asset_label = prototypeMetadata.exo__Asset_label;
+            }
+          }
+        }
+      }
+    }
+
+    return metadata;
+  }
+
+  /**
+   * Set up MutationObserver to detect Properties block DOM changes
+   */
+  private setupObserver(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+
+    this.observer = new MutationObserver((mutations) => {
+      if (!this.enabled) return;
+
+      for (const mutation of mutations) {
+        // Check for added nodes that might be metadata containers or links
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (node instanceof HTMLElement) {
+            // Check if this is a metadata container
+            if (node.classList?.contains("metadata-container")) {
+              this.patchPropertiesBlock(node.parentElement || node);
+            } else if (node.querySelector?.(".metadata-container")) {
+              // Check for nested metadata containers
+              this.patchPropertiesBlock(node);
+            } else if (
+              node.classList?.contains("internal-link") ||
+              node.hasAttribute?.("data-href")
+            ) {
+              // Direct link added
+              this.patchLink(node);
+            } else {
+              // Check for links within added nodes
+              const links = node.querySelectorAll<HTMLElement>(
+                ".metadata-container .internal-link, .metadata-container a[data-href]"
+              );
+              for (const link of Array.from(links)) {
+                this.patchLink(link);
+              }
+            }
+          }
+        }
+      }
+    });
+
+    // Observe the document body for changes
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  /**
+   * Handle metadata changes to update labels
+   */
+  private handleMetadataChange(file: TFile): void {
+    if (!this.enabled) return;
+    if (file.extension !== "md") return;
+
+    // Re-patch all Properties blocks to pick up changes
+    // This is simpler and more reliable than trying to find specific elements
+    this.patchAllPropertiesBlocks();
+  }
+
+  /**
+   * Restore all patched elements to their original text
+   */
+  private restoreAllLabels(): void {
+    // Find all elements with original text stored
+    const patchedLinks = document.querySelectorAll<HTMLElement>(
+      ".metadata-container [data-original-text]"
+    );
+
+    for (const link of Array.from(patchedLinks)) {
+      const originalText = link.getAttribute("data-original-text");
+      if (originalText) {
+        link.textContent = originalText;
+        link.removeAttribute("data-original-text");
+        link.removeAttribute("aria-label");
+      }
+    }
+
+    this.patchedElements = new WeakMap();
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -173,6 +173,21 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Show labels in properties block")
+      .setDesc(
+        "Display asset labels instead of filenames in the Properties block links",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showLabelsInProperties)
+          .onChange(async (value) => {
+            this.plugin.settings.showLabelsInProperties = value;
+            await this.plugin.saveSettings();
+            this.plugin.togglePropertiesLabels(value);
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Sort file explorer by display name")
       .setDesc(
         "Sort files by their display name (exo__Asset_label) instead of filename. " +

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -349,8 +349,8 @@ describe("ExocortexSettingTab", () => {
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
       expect(getOntologySpy).toHaveBeenCalledTimes(1);
-      // 9 original settings + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button = 25
-      expect(MockSetting).toHaveBeenCalledTimes(25);
+      // 10 original settings (added properties block) + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button = 26
+      expect(MockSetting).toHaveBeenCalledTimes(26);
     });
 
     it("should render ontology dropdown with correct options", () => {


### PR DESCRIPTION
## Summary
- Add setting to apply per-class display name templates to links in Obsidian's Properties block
- Users can now see formatted labels like "Morning routine (TaskPrototype)" instead of raw UUIDs
- Feature is enabled by default and can be toggled in Settings

## Changes
- Add `showLabelsInProperties` setting (enabled by default)
- Add toggle in Settings tab under display options
- Create `PropertiesLinkPatch` using MutationObserver pattern (similar to existing FileExplorerPatch and TabTitlePatch)
- Reuse existing `DisplayNameResolver` for template resolution
- Update `ExocortexPlugin` with initialization, cleanup, and toggle method
- Update `applyDisplayNameTemplate` to include Properties patch

## Technical Implementation
The implementation follows the same patterns as existing `FileExplorerPatch` and `TabTitlePatch`:
- Uses MutationObserver to detect Properties block DOM changes
- Finds internal links within `.metadata-container`
- Replaces link text with resolved display name while preserving link behavior
- Listens for metadata changes to update labels dynamically
- Stores original text as data attributes for restoration when disabled

## Test plan
- [x] Build passes
- [x] Unit tests pass (updated ExocortexSettingTab.test.ts for new setting count)
- [x] Lint passes
- [ ] Manual testing in Obsidian vault with TaskPrototype links

Closes #1200