### PR TITLE
fix: prevent infinite loop in HierarchicalLayout for self-loop edges

### DIFF
--- a/packages/obsidian-plugin/jest.config.js
+++ b/packages/obsidian-plugin/jest.config.js
@@ -17,9 +17,6 @@ module.exports = {
     "/tests/unit/ReactRenderer.test.tsx",
     "/tests/unit/SPARQLGraphView.test.tsx",
     "/tests/unit/LayoutErrorFallback.test.tsx",
-    // Temporarily skip HierarchicalLayout tests - causes Jest to hang in CI
-    // TODO: Investigate Jest hanging issue with this test file
-    "/tests/unit/presentation/renderers/graph/HierarchicalLayout.test.ts",
   ],
   collectCoverageFrom: [
     "<rootDir>/src/**/*.ts",
@@ -33,9 +30,6 @@ module.exports = {
     // Exclude IncrementalRenderer - requires WebGL/PixiJS rendering which is unavailable in JSDOM
     // DirtyTracker (its core logic) is fully tested separately
     "!**/IncrementalRenderer.ts",
-    // Temporarily exclude HierarchicalLayout - test causes Jest to hang in CI
-    // TODO: Investigate and fix the Jest hanging issue
-    "!**/HierarchicalLayout.ts",
     // Exclude 3D graph components - require WebGL context unavailable in JSDOM
     // Scene3DManager uses Three.js WebGL renderer
     "!**/3d/Scene3DManager.ts",

--- a/packages/obsidian-plugin/src/presentation/renderers/graph/HierarchicalLayout.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/graph/HierarchicalLayout.ts
@@ -304,8 +304,8 @@ export class HierarchicalLayout {
       const sourceId = typeof edge.source === "string" ? edge.source : edge.source.id;
       const targetId = typeof edge.target === "string" ? edge.target : edge.target.id;
 
-      // Skip edges with missing nodes
-      if (!this.nodeMap.has(sourceId) || !this.nodeMap.has(targetId)) {
+      // Skip edges with missing nodes or self-loops
+      if (!this.nodeMap.has(sourceId) || !this.nodeMap.has(targetId) || sourceId === targetId) {
         continue;
       }
 
@@ -427,6 +427,9 @@ export class HierarchicalLayout {
 
       const neighbors = this.adjacency.get(nodeId) || new Set();
       for (const neighborId of neighbors) {
+        // Skip self-loops to prevent infinite loop
+        if (neighborId === nodeId) continue;
+
         const newRank = rank + 1;
         const currentRank = ranks.get(neighborId);
 


### PR DESCRIPTION
## Summary

Fixes Jest hanging issue in CI when running `HierarchicalLayout.test.ts`.

## Root Cause

Self-loop edges (where `source === target`) caused an infinite loop in `assignRanksLongestPath()` during the BFS traversal. The algorithm kept incrementing the rank of the same node indefinitely:

1. Node "a" starts at rank 0
2. Look at neighbors of "a", which includes "a" itself (self-loop)
3. `newRank = 0 + 1 = 1`
4. Since 1 > 0, update rank and push to queue
5. Repeat forever... 💀

## Fix

- Skip self-loops during graph initialization (`initializeGraph`)
- Add defensive check in BFS traversal (`assignRanksLongestPath`)

## Changes

- `HierarchicalLayout.ts`: Skip self-loop edges in initialization and BFS
- `jest.config.js`: Re-enable HierarchicalLayout tests (removed from `testPathIgnorePatterns` and `collectCoverageFrom` exclusions)

## Test Plan

- [x] All 63 HierarchicalLayout tests pass
- [x] Self-loop edge test case passes (specifically the one that was causing the hang)
- [x] Build succeeds
- [x] Unit tests pass

Closes #1228