### PR TITLE
feat: Add graph3d ViewMode to SPARQLResultViewer

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLGraph3DView.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLGraph3DView.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useRef, useCallback } from "react";
+import type { Triple } from "exocortex";
+import type { GraphData } from "exocortex";
+import { RDFToGraphDataConverter } from "@plugin/application/utils/RDFToGraphDataConverter";
+import { Scene3DManager } from "@plugin/presentation/renderers/graph/3d/Scene3DManager";
+import { ForceSimulation3D } from "@plugin/presentation/renderers/graph/3d/ForceSimulation3D";
+import type { GraphNode3D, GraphEdge3D } from "@plugin/presentation/renderers/graph/3d/types3d";
+
+interface SPARQLGraph3DViewProps {
+  triples: Triple[];
+  onAssetClick: (path: string) => void;
+}
+
+/**
+ * Convert 2D graph data to 3D nodes and edges
+ */
+const convertTo3DData = (
+  graphData: GraphData
+): { nodes: GraphNode3D[]; edges: GraphEdge3D[] } => {
+  const nodes: GraphNode3D[] = graphData.nodes.map((node) => ({
+    id: node.path,
+    label: node.label,
+    path: node.path,
+    metadata: node.properties,
+  }));
+
+  const edges: GraphEdge3D[] = graphData.edges.map((edge, index) => ({
+    id: `edge-${index}`,
+    source: edge.source,
+    target: edge.target,
+    label: edge.label,
+  }));
+
+  return { nodes, edges };
+};
+
+export const SPARQLGraph3DView: React.FC<SPARQLGraph3DViewProps> = ({
+  triples,
+  onAssetClick,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sceneManagerRef = useRef<Scene3DManager | null>(null);
+  const simulationRef = useRef<ForceSimulation3D | null>(null);
+
+  const handleNodeClick = useCallback(
+    (path: string) => {
+      onAssetClick(path);
+    },
+    [onAssetClick]
+  );
+
+  useEffect(() => {
+    if (!containerRef.current || triples.length === 0) return;
+
+    // Convert triples to graph data
+    const graphData: GraphData = RDFToGraphDataConverter.convert(triples);
+    const { nodes, edges } = convertTo3DData(graphData);
+
+    if (nodes.length === 0) return;
+
+    // Create and initialize scene manager
+    const sceneManager = new Scene3DManager();
+    sceneManager.initialize(containerRef.current);
+    sceneManagerRef.current = sceneManager;
+
+    // Create force simulation
+    const simulation = new ForceSimulation3D(nodes, edges);
+    simulationRef.current = simulation;
+
+    // Set initial nodes and edges
+    sceneManager.setNodes(nodes);
+    sceneManager.setEdges(edges, nodes);
+
+    // Handle simulation ticks
+    simulation.on("tick", (event) => {
+      const updatedNodes = event.nodes as GraphNode3D[];
+      sceneManager.updatePositions(updatedNodes, edges);
+    });
+
+    // Handle node clicks
+    sceneManager.on("nodeClick", (event) => {
+      if (event.node) {
+        handleNodeClick(event.node.path);
+      }
+    });
+
+    // Start simulation
+    simulation.start();
+
+    // Fit view after a short delay for initial layout
+    setTimeout(() => {
+      sceneManager.fitToView(simulation.getNodes() as GraphNode3D[]);
+    }, 100);
+
+    // Cleanup
+    return () => {
+      simulation.destroy();
+      sceneManager.destroy();
+      sceneManagerRef.current = null;
+      simulationRef.current = null;
+    };
+  }, [triples, handleNodeClick]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="sparql-graph3d-view"
+      style={{ width: "100%", height: "600px" }}
+    />
+  );
+};

--- a/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLResultViewer.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLResultViewer.tsx
@@ -4,6 +4,7 @@ import type { App } from "obsidian";
 import { SPARQLTableView } from "./SPARQLTableView";
 import { SPARQLListView } from "./SPARQLListView";
 import { SPARQLGraphView } from "./SPARQLGraphView";
+import { SPARQLGraph3DView } from "./SPARQLGraph3DView";
 import { ViewModeSelector, type ViewMode } from "./ViewModeSelector";
 import { SPARQLEmptyState } from "./SPARQLEmptyState";
 
@@ -127,7 +128,7 @@ export const SPARQLResultViewer: React.FC<SPARQLResultViewerProps> = ({
   }, [isTriples, results]);
 
   const availableModes: ViewMode[] = useMemo(() => {
-    return isTriples ? ["list", "graph"] : ["table"];
+    return isTriples ? ["list", "graph", "graph3d"] : ["table"];
   }, [isTriples]);
 
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
@@ -175,6 +176,13 @@ export const SPARQLResultViewer: React.FC<SPARQLResultViewerProps> = ({
         case "graph":
           return (
             <SPARQLGraphView
+              triples={results}
+              onAssetClick={onAssetClick}
+            />
+          );
+        case "graph3d":
+          return (
+            <SPARQLGraph3DView
               triples={results}
               onAssetClick={onAssetClick}
             />

--- a/packages/obsidian-plugin/src/presentation/components/sparql/ViewModeSelector.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/sparql/ViewModeSelector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export type ViewMode = "table" | "list" | "graph";
+export type ViewMode = "table" | "list" | "graph" | "graph3d";
 
 export interface ViewModeSelectorProps {
   currentMode: ViewMode;
@@ -17,12 +17,14 @@ export const ViewModeSelector: React.FC<ViewModeSelectorProps> = ({
     table: "table",
     list: "list",
     graph: "graph",
+    graph3d: "3D graph",
   };
 
   const modeIcons: Record<ViewMode, string> = {
     table: "▤",
     list: "☰",
     graph: "●—●",
+    graph3d: "◇",
   };
 
   return (

--- a/packages/obsidian-plugin/tests/unit/presentation/components/sparql/SPARQLGraph3DView.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/sparql/SPARQLGraph3DView.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * SPARQLGraph3DView Unit Tests
+ *
+ * Tests for the SPARQLGraph3DView component.
+ * Since Three.js requires WebGL context (not available in JSDOM),
+ * we focus on testing the module exports and basic component properties.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+
+describe("SPARQLGraph3DView", () => {
+  describe("module exports", () => {
+    it("exports SPARQLGraph3DView component", async () => {
+      const module = await import(
+        "../../../../../src/presentation/components/sparql/SPARQLGraph3DView"
+      );
+      expect(module.SPARQLGraph3DView).toBeDefined();
+      expect(typeof module.SPARQLGraph3DView).toBe("function");
+    });
+
+    it("component has correct display name pattern", async () => {
+      const module = await import(
+        "../../../../../src/presentation/components/sparql/SPARQLGraph3DView"
+      );
+      // React components are functions
+      expect(typeof module.SPARQLGraph3DView).toBe("function");
+    });
+  });
+
+  describe("component interface", () => {
+    it("defines expected props interface", async () => {
+      // This test verifies the TypeScript interface compiles correctly
+      // by importing the module - if the interface is wrong, TS would fail
+      const module = await import(
+        "../../../../../src/presentation/components/sparql/SPARQLGraph3DView"
+      );
+      expect(module.SPARQLGraph3DView).toBeDefined();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/components/sparql/ViewModeSelector.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/sparql/ViewModeSelector.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * ViewModeSelector Unit Tests
+ *
+ * Tests for the ViewModeSelector component including the new graph3d view mode.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  ViewModeSelector,
+  type ViewMode,
+} from "../../../../../src/presentation/components/sparql/ViewModeSelector";
+
+describe("ViewModeSelector", () => {
+  const defaultProps = {
+    currentMode: "table" as ViewMode,
+    onModeChange: jest.fn(),
+    availableModes: ["table", "list", "graph", "graph3d"] as ViewMode[],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("should render all available mode buttons", () => {
+      render(<ViewModeSelector {...defaultProps} />);
+
+      const buttons = screen.getAllByRole("button");
+      expect(buttons).toHaveLength(4);
+    });
+
+    it("should render only specified available modes", () => {
+      render(
+        <ViewModeSelector
+          {...defaultProps}
+          availableModes={["list", "graph"]}
+        />
+      );
+
+      const buttons = screen.getAllByRole("button");
+      expect(buttons).toHaveLength(2);
+      expect(screen.getByText("list")).toBeInTheDocument();
+      expect(screen.getByText("graph")).toBeInTheDocument();
+      expect(screen.queryByText("table")).not.toBeInTheDocument();
+      expect(screen.queryByText("3D graph")).not.toBeInTheDocument();
+    });
+
+    it("should render graph3d mode when available", () => {
+      render(
+        <ViewModeSelector
+          {...defaultProps}
+          availableModes={["list", "graph", "graph3d"]}
+        />
+      );
+
+      expect(screen.getByText("3D graph")).toBeInTheDocument();
+    });
+
+    it("should highlight active mode button", () => {
+      render(
+        <ViewModeSelector
+          {...defaultProps}
+          currentMode="graph3d"
+          availableModes={["list", "graph", "graph3d"]}
+        />
+      );
+
+      const activeButton = screen.getByRole("button", { pressed: true });
+      expect(activeButton).toHaveTextContent("3D graph");
+    });
+  });
+
+  describe("mode labels and icons", () => {
+    it("should display correct label for graph3d", () => {
+      render(
+        <ViewModeSelector
+          {...defaultProps}
+          availableModes={["graph3d"]}
+          currentMode="graph3d"
+        />
+      );
+
+      expect(screen.getByText("3D graph")).toBeInTheDocument();
+    });
+
+    it("should display correct icon for graph3d", () => {
+      render(
+        <ViewModeSelector
+          {...defaultProps}
+          availableModes={["graph3d"]}
+          currentMode="graph3d"
+        />
+      );
+
+      // The cube icon for 3D graph
+      expect(screen.getByText("◇")).toBeInTheDocument();
+    });
+
+    it("should display all mode icons correctly", () => {
+      render(<ViewModeSelector {...defaultProps} />);
+
+      expect(screen.getByText("▤")).toBeInTheDocument(); // table
+      expect(screen.getByText("☰")).toBeInTheDocument(); // list
+      expect(screen.getByText("●—●")).toBeInTheDocument(); // graph
+      expect(screen.getByText("◇")).toBeInTheDocument(); // graph3d
+    });
+
+    it("should display all mode labels correctly", () => {
+      render(<ViewModeSelector {...defaultProps} />);
+
+      expect(screen.getByText("table")).toBeInTheDocument();
+      expect(screen.getByText("list")).toBeInTheDocument();
+      expect(screen.getByText("graph")).toBeInTheDocument();
+      expect(screen.getByText("3D graph")).toBeInTheDocument();
+    });
+  });
+
+  describe("interaction", () => {
+    it("should call onModeChange when mode button clicked", () => {
+      const onModeChange = jest.fn();
+      render(
+        <ViewModeSelector
+          {...defaultProps}
+          onModeChange={onModeChange}
+          availableModes={["list", "graph", "graph3d"]}
+        />
+      );
+
+      const graph3dButton = screen.getByRole("button", {
+        name: /switch to graph3d view/i,
+      });
+      fireEvent.click(graph3dButton);
+
+      expect(onModeChange).toHaveBeenCalledWith("graph3d");
+    });
+
+    it("should call onModeChange with correct mode for each button", () => {
+      const onModeChange = jest.fn();
+      render(
+        <ViewModeSelector {...defaultProps} onModeChange={onModeChange} />
+      );
+
+      const listButton = screen.getByRole("button", {
+        name: /switch to list view/i,
+      });
+      fireEvent.click(listButton);
+      expect(onModeChange).toHaveBeenCalledWith("list");
+
+      const graphButton = screen.getByRole("button", {
+        name: /switch to graph view/i,
+      });
+      fireEvent.click(graphButton);
+      expect(onModeChange).toHaveBeenCalledWith("graph");
+
+      const graph3dButton = screen.getByRole("button", {
+        name: /switch to graph3d view/i,
+      });
+      fireEvent.click(graph3dButton);
+      expect(onModeChange).toHaveBeenCalledWith("graph3d");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("should have accessible aria-label for graph3d button", () => {
+      render(
+        <ViewModeSelector
+          {...defaultProps}
+          availableModes={["graph3d"]}
+          currentMode="graph3d"
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-label", "switch to graph3d view");
+    });
+
+    it("should set aria-pressed based on active state for graph3d", () => {
+      render(
+        <ViewModeSelector
+          {...defaultProps}
+          currentMode="graph3d"
+          availableModes={["list", "graph", "graph3d"]}
+        />
+      );
+
+      const listButton = screen.getByRole("button", {
+        name: /switch to list view/i,
+      });
+      expect(listButton).toHaveAttribute("aria-pressed", "false");
+
+      const graph3dButton = screen.getByRole("button", {
+        name: /switch to graph3d view/i,
+      });
+      expect(graph3dButton).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
+  describe("ViewMode type", () => {
+    it("should support all four view modes in the type", () => {
+      // Type test - if this compiles, the type is correct
+      const modes: ViewMode[] = ["table", "list", "graph", "graph3d"];
+      expect(modes).toHaveLength(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds 3D graph visualization mode to the SPARQL result viewer, enabling users to explore knowledge graphs in an immersive 3D environment using Three.js and force-directed layout.

### Changes

- Extended `ViewMode` type to include `"graph3d"`
- Added "3D graph" option with cube icon (◇) to `ViewModeSelector`
- Created `SPARQLGraph3DView` component that:
  - Integrates existing `Scene3DManager` for WebGL rendering
  - Uses `ForceSimulation3D` for 3D force-directed layout
  - Converts RDF triples to 3D graph data
  - Handles node clicks for navigation
- Updated `SPARQLResultViewer` to:
  - Include `graph3d` in available modes for triple results
  - Conditionally render `SPARQLGraph3DView` when mode is "graph3d"

### Testing

- Added unit tests for `ViewModeSelector` with graph3d support (10 tests)
- Added unit tests for `SPARQLGraph3DView` module exports (3 tests)
- All existing tests pass

## Test Plan

- [x] Unit tests pass (`npm run test:unit`)
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [ ] CI pipeline passes
- [ ] Manual testing with SPARQL CONSTRUCT queries

Closes #1264