### PR TITLE
perf: Optimize 3D graph rendering (LOD, frustum culling, WebGL recovery)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/graph/3d/Graph3DPerformanceManager.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/graph/3d/Graph3DPerformanceManager.ts
@@ -1,0 +1,765 @@
+/**
+ * Graph3DPerformanceManager - Performance optimization for 3D graph rendering
+ *
+ * Provides:
+ * - LOD (Level of Detail): Distance-based label opacity fading
+ * - Frustum Culling: Skip rendering off-screen nodes
+ * - WebGL Context Recovery: Automatic recovery on context loss
+ *
+ * Performance targets:
+ * - 30+ FPS with 500 nodes (LOD + culling enabled)
+ * - Zero crashes on WebGL context loss
+ * - Smooth LOD transitions (no popping)
+ *
+ * @module presentation/renderers/graph/3d
+ * @since 1.0.0
+ */
+
+import * as THREE from "three";
+
+/**
+ * LOD (Level of Detail) configuration
+ */
+export interface LODConfig {
+  /** Enable LOD system */
+  enabled: boolean;
+
+  /** Distance at which labels start fading (world units) */
+  labelFadeStart: number;
+
+  /** Distance at which labels are fully hidden (world units) */
+  labelFadeEnd: number;
+
+  /** Minimum opacity for labels during fade (0-1) */
+  labelMinOpacity: number;
+
+  /** Distance at which node detail reduces (world units) */
+  nodeDetailFadeStart: number;
+
+  /** Distance at which nodes use minimum detail (world units) */
+  nodeDetailFadeEnd: number;
+}
+
+/**
+ * Frustum culling configuration
+ */
+export interface FrustumCullingConfig {
+  /** Enable frustum culling */
+  enabled: boolean;
+
+  /** Padding around frustum for culling (world units) - prevents popping */
+  padding: number;
+
+  /** Update culling every N frames (reduces CPU overhead) */
+  updateInterval: number;
+}
+
+/**
+ * WebGL context recovery configuration
+ */
+export interface WebGLRecoveryConfig {
+  /** Enable automatic context recovery */
+  enabled: boolean;
+
+  /** Maximum recovery attempts before giving up */
+  maxAttempts: number;
+
+  /** Delay between recovery attempts (ms) */
+  retryDelay: number;
+
+  /** Show recovery UI message */
+  showRecoveryMessage: boolean;
+}
+
+/**
+ * Full performance configuration
+ */
+export interface PerformanceConfig {
+  lod: LODConfig;
+  frustumCulling: FrustumCullingConfig;
+  webglRecovery: WebGLRecoveryConfig;
+}
+
+/**
+ * Default LOD configuration optimized for 500 nodes
+ */
+export const DEFAULT_LOD_CONFIG: LODConfig = {
+  enabled: true,
+  labelFadeStart: 150,
+  labelFadeEnd: 250,
+  labelMinOpacity: 0,
+  nodeDetailFadeStart: 200,
+  nodeDetailFadeEnd: 400,
+};
+
+/**
+ * Default frustum culling configuration
+ */
+export const DEFAULT_FRUSTUM_CULLING_CONFIG: FrustumCullingConfig = {
+  enabled: true,
+  padding: 50,
+  updateInterval: 2,
+};
+
+/**
+ * Default WebGL recovery configuration
+ */
+export const DEFAULT_WEBGL_RECOVERY_CONFIG: WebGLRecoveryConfig = {
+  enabled: true,
+  maxAttempts: 3,
+  retryDelay: 1000,
+  showRecoveryMessage: true,
+};
+
+/**
+ * Default performance configuration
+ */
+export const DEFAULT_PERFORMANCE_CONFIG: PerformanceConfig = {
+  lod: DEFAULT_LOD_CONFIG,
+  frustumCulling: DEFAULT_FRUSTUM_CULLING_CONFIG,
+  webglRecovery: DEFAULT_WEBGL_RECOVERY_CONFIG,
+};
+
+/**
+ * Visibility state for a node
+ */
+export interface NodeVisibility {
+  /** Whether node is in frustum */
+  inFrustum: boolean;
+
+  /** Distance from camera */
+  distanceToCamera: number;
+
+  /** Computed label opacity based on LOD */
+  labelOpacity: number;
+
+  /** Whether label should be visible */
+  labelVisible: boolean;
+
+  /** Node detail level (0-1, 1 = full detail) */
+  detailLevel: number;
+}
+
+/**
+ * Performance event types
+ */
+export type PerformanceEventType =
+  | "webglContextLost"
+  | "webglContextRestored"
+  | "recoveryStarted"
+  | "recoveryComplete"
+  | "recoveryFailed"
+  | "performanceUpdate";
+
+/**
+ * Performance event data
+ */
+export interface PerformanceEvent {
+  type: PerformanceEventType;
+  message?: string;
+  stats?: PerformanceStats;
+  attempt?: number;
+  maxAttempts?: number;
+}
+
+/**
+ * Performance event listener
+ */
+export type PerformanceEventListener = (event: PerformanceEvent) => void;
+
+/**
+ * Performance statistics
+ */
+export interface PerformanceStats {
+  /** Current FPS */
+  fps: number;
+
+  /** Total nodes */
+  totalNodes: number;
+
+  /** Visible nodes (after culling) */
+  visibleNodes: number;
+
+  /** Hidden nodes (culled) */
+  culledNodes: number;
+
+  /** Nodes with visible labels */
+  labelsVisible: number;
+
+  /** Average distance to camera */
+  averageDistance: number;
+
+  /** Culling efficiency (% nodes culled) */
+  cullingEfficiency: number;
+}
+
+/**
+ * Graph3DPerformanceManager - Manages rendering performance optimizations
+ *
+ * @example
+ * ```typescript
+ * const perfManager = new Graph3DPerformanceManager(renderer, camera);
+ * perfManager.initialize();
+ *
+ * // In render loop
+ * const visibility = perfManager.calculateNodeVisibility(nodePosition);
+ * if (visibility.inFrustum) {
+ *   // Render node with visibility.labelOpacity
+ * }
+ *
+ * // Listen for WebGL recovery events
+ * perfManager.on('recoveryComplete', () => {
+ *   // Re-render scene
+ * });
+ * ```
+ */
+export class Graph3DPerformanceManager {
+  private config: PerformanceConfig;
+  private camera: THREE.PerspectiveCamera | null = null;
+  private renderer: THREE.WebGLRenderer | null = null;
+  private container: HTMLElement | null = null;
+
+  // Frustum culling
+  private frustum: THREE.Frustum = new THREE.Frustum();
+  private projScreenMatrix: THREE.Matrix4 = new THREE.Matrix4();
+  private frameCount = 0;
+
+  // WebGL recovery
+  private recoveryAttempts = 0;
+  private isRecovering = false;
+  private contextLostHandler: ((event: Event) => void) | null = null;
+  private contextRestoredHandler: ((event: Event) => void) | null = null;
+  private onRecoveryComplete: (() => void) | null = null;
+
+  // Event system
+  private eventListeners: Map<PerformanceEventType, Set<PerformanceEventListener>> =
+    new Map();
+
+  // Performance tracking
+  private lastFrameTime = 0;
+  private frameTimeAccumulator = 0;
+  private frameCountForFps = 0;
+  private currentFps = 60;
+  private visibilityCache: Map<string, NodeVisibility> = new Map();
+
+  constructor(config: Partial<PerformanceConfig> = {}) {
+    this.config = {
+      lod: { ...DEFAULT_LOD_CONFIG, ...config.lod },
+      frustumCulling: { ...DEFAULT_FRUSTUM_CULLING_CONFIG, ...config.frustumCulling },
+      webglRecovery: { ...DEFAULT_WEBGL_RECOVERY_CONFIG, ...config.webglRecovery },
+    };
+
+    // Initialize event listener maps
+    const eventTypes: PerformanceEventType[] = [
+      "webglContextLost",
+      "webglContextRestored",
+      "recoveryStarted",
+      "recoveryComplete",
+      "recoveryFailed",
+      "performanceUpdate",
+    ];
+    for (const type of eventTypes) {
+      this.eventListeners.set(type, new Set());
+    }
+  }
+
+  /**
+   * Initialize the performance manager
+   *
+   * @param renderer - Three.js WebGL renderer
+   * @param camera - Three.js perspective camera
+   * @param container - Container element for recovery UI
+   * @param onRecoveryComplete - Callback when context is restored
+   */
+  initialize(
+    renderer: THREE.WebGLRenderer,
+    camera: THREE.PerspectiveCamera,
+    container: HTMLElement,
+    onRecoveryComplete?: () => void
+  ): void {
+    this.renderer = renderer;
+    this.camera = camera;
+    this.container = container;
+    this.onRecoveryComplete = onRecoveryComplete ?? null;
+
+    // Setup WebGL context loss/restore handlers
+    if (this.config.webglRecovery.enabled) {
+      this.setupWebGLRecovery();
+    }
+
+    this.lastFrameTime = performance.now();
+  }
+
+  /**
+   * Setup WebGL context loss and restore handlers
+   */
+  private setupWebGLRecovery(): void {
+    if (!this.renderer) return;
+
+    const canvas = this.renderer.domElement;
+
+    this.contextLostHandler = (event: Event) => {
+      event.preventDefault();
+      this.handleContextLost();
+    };
+
+    this.contextRestoredHandler = () => {
+      this.handleContextRestored();
+    };
+
+    canvas.addEventListener("webglcontextlost", this.contextLostHandler);
+    canvas.addEventListener("webglcontextrestored", this.contextRestoredHandler);
+  }
+
+  /**
+   * Handle WebGL context lost event
+   */
+  private handleContextLost(): void {
+    this.emit("webglContextLost", {
+      type: "webglContextLost",
+      message: "WebGL context lost. Attempting recovery...",
+    });
+
+    this.isRecovering = true;
+    this.recoveryAttempts = 0;
+
+    // Show recovery message if configured
+    if (this.config.webglRecovery.showRecoveryMessage && this.container) {
+      this.showRecoveryUI("Recovering...");
+    }
+
+    this.emit("recoveryStarted", {
+      type: "recoveryStarted",
+      message: "Starting WebGL context recovery",
+      attempt: 1,
+      maxAttempts: this.config.webglRecovery.maxAttempts,
+    });
+  }
+
+  /**
+   * Handle WebGL context restored event
+   */
+  private handleContextRestored(): void {
+    this.recoveryAttempts++;
+
+    if (this.recoveryAttempts <= this.config.webglRecovery.maxAttempts) {
+      this.emit("webglContextRestored", {
+        type: "webglContextRestored",
+        message: `WebGL context restored (attempt ${this.recoveryAttempts})`,
+        attempt: this.recoveryAttempts,
+      });
+
+      // Hide recovery UI
+      this.hideRecoveryUI();
+
+      // Notify that recovery is complete
+      this.isRecovering = false;
+
+      this.emit("recoveryComplete", {
+        type: "recoveryComplete",
+        message: "WebGL context recovery successful",
+        attempt: this.recoveryAttempts,
+      });
+
+      // Call recovery callback
+      if (this.onRecoveryComplete) {
+        this.onRecoveryComplete();
+      }
+    } else {
+      this.emit("recoveryFailed", {
+        type: "recoveryFailed",
+        message: `WebGL context recovery failed after ${this.config.webglRecovery.maxAttempts} attempts`,
+        attempt: this.recoveryAttempts,
+        maxAttempts: this.config.webglRecovery.maxAttempts,
+      });
+
+      // Show permanent error message
+      if (this.config.webglRecovery.showRecoveryMessage && this.container) {
+        this.showRecoveryUI("WebGL Error - Please refresh the page");
+      }
+    }
+  }
+
+  /**
+   * Show recovery UI overlay
+   *
+   * CSS classes used:
+   * - .graph3d-recovery-overlay: Base overlay styling
+   * - .graph3d-recovery-overlay--visible: Shows the overlay
+   * - .graph3d-recovery-overlay--hidden: Hides the overlay
+   */
+  private showRecoveryUI(message: string): void {
+    if (!this.container) return;
+
+    // Check if recovery overlay already exists
+    let overlay = this.container.querySelector(
+      ".graph3d-recovery-overlay"
+    ) as HTMLElement;
+
+    if (!overlay) {
+      overlay = document.createElement("div");
+      overlay.className = "graph3d-recovery-overlay graph3d-recovery-overlay--visible";
+      // Add relative positioning class to container
+      this.container.classList.add("graph3d-container--relative");
+      this.container.appendChild(overlay);
+    }
+
+    overlay.textContent = message;
+    overlay.classList.remove("graph3d-recovery-overlay--hidden");
+    overlay.classList.add("graph3d-recovery-overlay--visible");
+  }
+
+  /**
+   * Hide recovery UI overlay
+   */
+  private hideRecoveryUI(): void {
+    if (!this.container) return;
+
+    const overlay = this.container.querySelector(
+      ".graph3d-recovery-overlay"
+    ) as HTMLElement;
+
+    if (overlay) {
+      overlay.classList.remove("graph3d-recovery-overlay--visible");
+      overlay.classList.add("graph3d-recovery-overlay--hidden");
+    }
+  }
+
+  /**
+   * Update frustum for culling calculations
+   *
+   * Call this once per frame before calculating visibility
+   */
+  updateFrustum(): void {
+    if (!this.camera || !this.config.frustumCulling.enabled) return;
+
+    // Only update frustum on configured interval
+    this.frameCount++;
+    if (this.frameCount % this.config.frustumCulling.updateInterval !== 0) {
+      return;
+    }
+
+    // Update projection screen matrix
+    this.camera.updateMatrixWorld();
+    this.projScreenMatrix.multiplyMatrices(
+      this.camera.projectionMatrix,
+      this.camera.matrixWorldInverse
+    );
+
+    // Update frustum from matrix
+    this.frustum.setFromProjectionMatrix(this.projScreenMatrix);
+
+    // Clear visibility cache when frustum updates
+    this.visibilityCache.clear();
+  }
+
+  /**
+   * Calculate visibility state for a node
+   *
+   * @param nodeId - Unique node identifier for caching
+   * @param position - Node position in world space
+   * @param radius - Node radius for frustum intersection
+   * @returns Visibility state including LOD calculations
+   */
+  calculateNodeVisibility(
+    nodeId: string,
+    position: THREE.Vector3,
+    radius: number = 10
+  ): NodeVisibility {
+    // Check cache first
+    const cached = this.visibilityCache.get(nodeId);
+    if (cached) {
+      return cached;
+    }
+
+    const result: NodeVisibility = {
+      inFrustum: true,
+      distanceToCamera: 0,
+      labelOpacity: 1,
+      labelVisible: true,
+      detailLevel: 1,
+    };
+
+    if (!this.camera) {
+      return result;
+    }
+
+    // Calculate distance to camera
+    result.distanceToCamera = position.distanceTo(this.camera.position);
+
+    // Frustum culling check
+    if (this.config.frustumCulling.enabled) {
+      // Create sphere for intersection test with padding
+      const testRadius = radius + this.config.frustumCulling.padding;
+      const sphere = new THREE.Sphere(position, testRadius);
+      result.inFrustum = this.frustum.intersectsSphere(sphere);
+    }
+
+    // LOD calculations (only if LOD enabled and in frustum)
+    if (this.config.lod.enabled && result.inFrustum) {
+      // Label opacity based on distance
+      result.labelOpacity = this.calculateLabelOpacity(result.distanceToCamera);
+      result.labelVisible = result.labelOpacity > 0.01;
+
+      // Detail level based on distance
+      result.detailLevel = this.calculateDetailLevel(result.distanceToCamera);
+    } else if (!result.inFrustum) {
+      result.labelVisible = false;
+      result.labelOpacity = 0;
+      result.detailLevel = 0;
+    }
+
+    // Cache result
+    this.visibilityCache.set(nodeId, result);
+
+    return result;
+  }
+
+  /**
+   * Calculate label opacity based on distance (smooth fade)
+   */
+  private calculateLabelOpacity(distance: number): number {
+    const { labelFadeStart, labelFadeEnd, labelMinOpacity } = this.config.lod;
+
+    if (distance <= labelFadeStart) {
+      return 1;
+    }
+
+    if (distance >= labelFadeEnd) {
+      return labelMinOpacity;
+    }
+
+    // Smooth interpolation using ease-out
+    const t = (distance - labelFadeStart) / (labelFadeEnd - labelFadeStart);
+    const eased = 1 - Math.pow(t, 2); // Quadratic ease-out
+
+    return labelMinOpacity + (1 - labelMinOpacity) * eased;
+  }
+
+  /**
+   * Calculate detail level based on distance
+   */
+  private calculateDetailLevel(distance: number): number {
+    const { nodeDetailFadeStart, nodeDetailFadeEnd } = this.config.lod;
+
+    if (distance <= nodeDetailFadeStart) {
+      return 1;
+    }
+
+    if (distance >= nodeDetailFadeEnd) {
+      return 0.2; // Minimum detail level
+    }
+
+    // Linear interpolation
+    const t = (distance - nodeDetailFadeStart) / (nodeDetailFadeEnd - nodeDetailFadeStart);
+    return 1 - t * 0.8; // Maps to 1.0 -> 0.2
+  }
+
+  /**
+   * Batch calculate visibility for multiple nodes
+   *
+   * @param nodes - Array of nodes with id and position
+   * @param getPosition - Function to get position for a node
+   * @param getRadius - Optional function to get radius for a node
+   * @returns Map of node ID to visibility state
+   */
+  calculateBatchVisibility<T extends { id: string }>(
+    nodes: T[],
+    getPosition: (node: T) => THREE.Vector3,
+    getRadius?: (node: T) => number
+  ): Map<string, NodeVisibility> {
+    const results = new Map<string, NodeVisibility>();
+
+    for (const node of nodes) {
+      const position = getPosition(node);
+      const radius = getRadius ? getRadius(node) : 10;
+      results.set(node.id, this.calculateNodeVisibility(node.id, position, radius));
+    }
+
+    return results;
+  }
+
+  /**
+   * Update FPS counter
+   *
+   * Call this once per frame
+   */
+  updateFPS(): void {
+    const now = performance.now();
+    const delta = now - this.lastFrameTime;
+    this.lastFrameTime = now;
+
+    this.frameTimeAccumulator += delta;
+    this.frameCountForFps++;
+
+    // Update FPS every second
+    if (this.frameTimeAccumulator >= 1000) {
+      this.currentFps = Math.round(
+        (this.frameCountForFps * 1000) / this.frameTimeAccumulator
+      );
+      this.frameTimeAccumulator = 0;
+      this.frameCountForFps = 0;
+    }
+  }
+
+  /**
+   * Get current performance statistics
+   */
+  getStats(): PerformanceStats {
+    let totalNodes = 0;
+    let visibleNodes = 0;
+    let labelsVisible = 0;
+    let totalDistance = 0;
+
+    for (const visibility of this.visibilityCache.values()) {
+      totalNodes++;
+      if (visibility.inFrustum) {
+        visibleNodes++;
+        totalDistance += visibility.distanceToCamera;
+      }
+      if (visibility.labelVisible) {
+        labelsVisible++;
+      }
+    }
+
+    const averageDistance = visibleNodes > 0 ? totalDistance / visibleNodes : 0;
+    const culledNodes = totalNodes - visibleNodes;
+    const cullingEfficiency = totalNodes > 0 ? (culledNodes / totalNodes) * 100 : 0;
+
+    return {
+      fps: this.currentFps,
+      totalNodes,
+      visibleNodes,
+      culledNodes,
+      labelsVisible,
+      averageDistance,
+      cullingEfficiency,
+    };
+  }
+
+  /**
+   * Get current FPS
+   */
+  getFPS(): number {
+    return this.currentFps;
+  }
+
+  /**
+   * Check if currently recovering from context loss
+   */
+  isInRecovery(): boolean {
+    return this.isRecovering;
+  }
+
+  /**
+   * Update configuration
+   */
+  setConfig(config: Partial<PerformanceConfig>): void {
+    if (config.lod) {
+      this.config.lod = { ...this.config.lod, ...config.lod };
+    }
+    if (config.frustumCulling) {
+      this.config.frustumCulling = { ...this.config.frustumCulling, ...config.frustumCulling };
+    }
+    if (config.webglRecovery) {
+      this.config.webglRecovery = { ...this.config.webglRecovery, ...config.webglRecovery };
+    }
+
+    // Clear cache when config changes
+    this.visibilityCache.clear();
+  }
+
+  /**
+   * Get current configuration
+   */
+  getConfig(): PerformanceConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Enable/disable LOD
+   */
+  setLODEnabled(enabled: boolean): void {
+    this.config.lod.enabled = enabled;
+    this.visibilityCache.clear();
+  }
+
+  /**
+   * Enable/disable frustum culling
+   */
+  setFrustumCullingEnabled(enabled: boolean): void {
+    this.config.frustumCulling.enabled = enabled;
+    this.visibilityCache.clear();
+  }
+
+  /**
+   * Clear visibility cache (call when camera or nodes change significantly)
+   */
+  clearCache(): void {
+    this.visibilityCache.clear();
+  }
+
+  /**
+   * Add event listener
+   */
+  on(eventType: PerformanceEventType, listener: PerformanceEventListener): void {
+    this.eventListeners.get(eventType)?.add(listener);
+  }
+
+  /**
+   * Remove event listener
+   */
+  off(eventType: PerformanceEventType, listener: PerformanceEventListener): void {
+    this.eventListeners.get(eventType)?.delete(listener);
+  }
+
+  /**
+   * Emit event to listeners
+   */
+  private emit(eventType: PerformanceEventType, event: PerformanceEvent): void {
+    const listeners = this.eventListeners.get(eventType);
+    if (listeners) {
+      for (const listener of listeners) {
+        try {
+          listener(event);
+        } catch (error) {
+          console.error(`Error in Graph3DPerformanceManager event listener:`, error);
+        }
+      }
+    }
+  }
+
+  /**
+   * Destroy the performance manager and cleanup
+   */
+  destroy(): void {
+    // Remove WebGL context handlers
+    if (this.renderer && this.contextLostHandler && this.contextRestoredHandler) {
+      const canvas = this.renderer.domElement;
+      canvas.removeEventListener("webglcontextlost", this.contextLostHandler);
+      canvas.removeEventListener("webglcontextrestored", this.contextRestoredHandler);
+    }
+
+    // Hide recovery UI if visible
+    this.hideRecoveryUI();
+
+    // Clear all caches and references
+    this.visibilityCache.clear();
+    this.eventListeners.clear();
+    this.camera = null;
+    this.renderer = null;
+    this.container = null;
+    this.onRecoveryComplete = null;
+    this.contextLostHandler = null;
+    this.contextRestoredHandler = null;
+  }
+}
+
+/**
+ * Factory function to create Graph3DPerformanceManager
+ */
+export function createGraph3DPerformanceManager(
+  config?: Partial<PerformanceConfig>
+): Graph3DPerformanceManager {
+  return new Graph3DPerformanceManager(config);
+}

--- a/packages/obsidian-plugin/src/presentation/renderers/graph/3d/index.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/graph/3d/index.ts
@@ -10,6 +10,9 @@
  * - Theme-aware coloring (dark/light mode support)
  * - Ontology-based node coloring
  * - Predicate-based edge coloring
+ * - LOD (Level of Detail) for labels
+ * - Frustum culling for off-screen nodes
+ * - WebGL context loss recovery
  *
  * @module presentation/renderers/graph/3d
  * @since 1.0.0
@@ -17,6 +20,27 @@
 
 // Scene manager
 export { Scene3DManager, createScene3DManager } from "./Scene3DManager";
+
+// Performance manager
+export {
+  Graph3DPerformanceManager,
+  createGraph3DPerformanceManager,
+  DEFAULT_LOD_CONFIG,
+  DEFAULT_FRUSTUM_CULLING_CONFIG,
+  DEFAULT_WEBGL_RECOVERY_CONFIG,
+  DEFAULT_PERFORMANCE_CONFIG,
+} from "./Graph3DPerformanceManager";
+export type {
+  LODConfig,
+  FrustumCullingConfig,
+  WebGLRecoveryConfig,
+  PerformanceConfig,
+  NodeVisibility,
+  PerformanceEventType,
+  PerformanceEvent,
+  PerformanceEventListener,
+  PerformanceStats,
+} from "./Graph3DPerformanceManager";
 
 // Force simulation
 export {

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -4859,3 +4859,35 @@
 .theme-light .exo-graph3d-toolbar__separator {
   background-color: rgba(0, 0, 0, 0.15);
 }
+
+/* ============================================================================
+   3D Graph WebGL Recovery Overlay
+   ============================================================================ */
+
+.graph3d-container--relative {
+  position: relative;
+}
+
+.graph3d-recovery-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  font-size: 16px;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.graph3d-recovery-overlay--visible {
+  display: flex;
+}
+
+.graph3d-recovery-overlay--hidden {
+  display: none;
+}

--- a/packages/obsidian-plugin/tests/__mocks__/three.ts
+++ b/packages/obsidian-plugin/tests/__mocks__/three.ts
@@ -44,6 +44,12 @@ export class Vector3 {
     this.z = v.z;
     return this;
   }
+  distanceTo(v: Vector3): number {
+    const dx = this.x - v.x;
+    const dy = this.y - v.y;
+    const dz = this.z - v.z;
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  }
 }
 
 // Mock Color class
@@ -90,6 +96,19 @@ export class Scene {
   }
 }
 
+// Mock Matrix4 class (must be before PerspectiveCamera)
+export class Matrix4 {
+  elements: number[] = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+  multiplyMatrices(_a: Matrix4, _b: Matrix4): this {
+    return this;
+  }
+
+  copy(_m: Matrix4): this {
+    return this;
+  }
+}
+
 // Mock Camera classes
 export class PerspectiveCamera {
   fov: number;
@@ -99,6 +118,8 @@ export class PerspectiveCamera {
   position: Vector3 = new Vector3();
   up: Vector3 = new Vector3(0, 1, 0);
   zoom = 1;
+  projectionMatrix: Matrix4 = new Matrix4();
+  matrixWorldInverse: Matrix4 = new Matrix4();
 
   constructor(fov = 50, aspect = 1, near = 0.1, far = 2000) {
     this.fov = fov;
@@ -112,6 +133,10 @@ export class PerspectiveCamera {
   }
 
   updateProjectionMatrix(): void {
+    // No-op
+  }
+
+  updateMatrixWorld(): void {
     // No-op
   }
 }
@@ -346,5 +371,50 @@ export class Raycaster {
 
   intersectObjects(_objects: unknown[], _recursive?: boolean): { point: Vector3; object: unknown }[] {
     return [];
+  }
+}
+
+// Mock Sphere class
+export class Sphere {
+  center: Vector3;
+  radius: number;
+
+  constructor(center?: Vector3, radius?: number) {
+    this.center = center ?? new Vector3();
+    this.radius = radius ?? 1;
+  }
+}
+
+// Mock Frustum class
+export class Frustum {
+  planes: { normal: Vector3; constant: number }[] = [];
+
+  setFromProjectionMatrix(_m: Matrix4): this {
+    // Create 6 frustum planes (simplified)
+    this.planes = [
+      { normal: new Vector3(1, 0, 0), constant: 1000 },
+      { normal: new Vector3(-1, 0, 0), constant: 1000 },
+      { normal: new Vector3(0, 1, 0), constant: 1000 },
+      { normal: new Vector3(0, -1, 0), constant: 1000 },
+      { normal: new Vector3(0, 0, 1), constant: 1000 },
+      { normal: new Vector3(0, 0, -1), constant: 1000 },
+    ];
+    return this;
+  }
+
+  intersectsSphere(sphere: Sphere): boolean {
+    // Simple frustum test: check if sphere center is within reasonable bounds
+    const center = sphere.center;
+    const radius = sphere.radius;
+
+    // Nodes within 500 units of origin are considered in frustum
+    const maxDistance = 500;
+    const distance = Math.sqrt(center.x * center.x + center.y * center.y + center.z * center.z);
+
+    return distance - radius < maxDistance;
+  }
+
+  containsPoint(_point: Vector3): boolean {
+    return true;
   }
 }

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/graph/3d/Graph3DPerformanceManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/graph/3d/Graph3DPerformanceManager.test.ts
@@ -1,0 +1,771 @@
+/**
+ * Graph3DPerformanceManager Unit Tests
+ *
+ * Tests for LOD (Level of Detail), frustum culling, and WebGL context recovery.
+ * These tests verify the performance optimization logic without requiring WebGL.
+ */
+
+import * as THREE from "three";
+import {
+  Graph3DPerformanceManager,
+  createGraph3DPerformanceManager,
+  DEFAULT_LOD_CONFIG,
+  DEFAULT_FRUSTUM_CULLING_CONFIG,
+  DEFAULT_WEBGL_RECOVERY_CONFIG,
+  DEFAULT_PERFORMANCE_CONFIG,
+  type PerformanceConfig,
+  type LODConfig,
+  type FrustumCullingConfig,
+  type WebGLRecoveryConfig,
+  type NodeVisibility,
+  type PerformanceEvent,
+  type PerformanceStats,
+} from "@plugin/presentation/renderers/graph/3d/Graph3DPerformanceManager";
+
+describe("Graph3DPerformanceManager", () => {
+  describe("module exports", () => {
+    it("exports Graph3DPerformanceManager class", () => {
+      expect(Graph3DPerformanceManager).toBeDefined();
+      expect(typeof Graph3DPerformanceManager).toBe("function");
+    });
+
+    it("exports createGraph3DPerformanceManager factory function", () => {
+      expect(createGraph3DPerformanceManager).toBeDefined();
+      expect(typeof createGraph3DPerformanceManager).toBe("function");
+    });
+
+    it("exports default configs", () => {
+      expect(DEFAULT_LOD_CONFIG).toBeDefined();
+      expect(DEFAULT_FRUSTUM_CULLING_CONFIG).toBeDefined();
+      expect(DEFAULT_WEBGL_RECOVERY_CONFIG).toBeDefined();
+      expect(DEFAULT_PERFORMANCE_CONFIG).toBeDefined();
+    });
+  });
+
+  describe("default configurations", () => {
+    it("has valid LOD config", () => {
+      expect(DEFAULT_LOD_CONFIG.enabled).toBe(true);
+      expect(DEFAULT_LOD_CONFIG.labelFadeStart).toBe(150);
+      expect(DEFAULT_LOD_CONFIG.labelFadeEnd).toBe(250);
+      expect(DEFAULT_LOD_CONFIG.labelMinOpacity).toBe(0);
+      expect(DEFAULT_LOD_CONFIG.nodeDetailFadeStart).toBe(200);
+      expect(DEFAULT_LOD_CONFIG.nodeDetailFadeEnd).toBe(400);
+    });
+
+    it("has valid frustum culling config", () => {
+      expect(DEFAULT_FRUSTUM_CULLING_CONFIG.enabled).toBe(true);
+      expect(DEFAULT_FRUSTUM_CULLING_CONFIG.padding).toBe(50);
+      expect(DEFAULT_FRUSTUM_CULLING_CONFIG.updateInterval).toBe(2);
+    });
+
+    it("has valid WebGL recovery config", () => {
+      expect(DEFAULT_WEBGL_RECOVERY_CONFIG.enabled).toBe(true);
+      expect(DEFAULT_WEBGL_RECOVERY_CONFIG.maxAttempts).toBe(3);
+      expect(DEFAULT_WEBGL_RECOVERY_CONFIG.retryDelay).toBe(1000);
+      expect(DEFAULT_WEBGL_RECOVERY_CONFIG.showRecoveryMessage).toBe(true);
+    });
+  });
+
+  describe("constructor", () => {
+    it("creates instance with default options", () => {
+      const manager = new Graph3DPerformanceManager();
+      expect(manager).toBeDefined();
+    });
+
+    it("creates instance with custom LOD config", () => {
+      const manager = new Graph3DPerformanceManager({
+        lod: {
+          enabled: false,
+          labelFadeStart: 100,
+          labelFadeEnd: 200,
+          labelMinOpacity: 0.1,
+          nodeDetailFadeStart: 150,
+          nodeDetailFadeEnd: 300,
+        },
+      });
+      expect(manager).toBeDefined();
+      expect(manager.getConfig().lod.enabled).toBe(false);
+      expect(manager.getConfig().lod.labelFadeStart).toBe(100);
+    });
+
+    it("creates instance with custom frustum culling config", () => {
+      const manager = new Graph3DPerformanceManager({
+        frustumCulling: {
+          enabled: false,
+          padding: 100,
+          updateInterval: 5,
+        },
+      });
+      expect(manager).toBeDefined();
+      expect(manager.getConfig().frustumCulling.enabled).toBe(false);
+    });
+
+    it("creates instance with custom WebGL recovery config", () => {
+      const manager = new Graph3DPerformanceManager({
+        webglRecovery: {
+          enabled: false,
+          maxAttempts: 5,
+          retryDelay: 2000,
+          showRecoveryMessage: false,
+        },
+      });
+      expect(manager).toBeDefined();
+      expect(manager.getConfig().webglRecovery.maxAttempts).toBe(5);
+    });
+
+    it("creates instance via factory function", () => {
+      const manager = createGraph3DPerformanceManager();
+      expect(manager).toBeDefined();
+    });
+  });
+
+  describe("LOD calculations", () => {
+    let manager: Graph3DPerformanceManager;
+    let camera: THREE.PerspectiveCamera;
+
+    beforeEach(() => {
+      manager = new Graph3DPerformanceManager({
+        lod: {
+          enabled: true,
+          labelFadeStart: 100,
+          labelFadeEnd: 200,
+          labelMinOpacity: 0,
+          nodeDetailFadeStart: 150,
+          nodeDetailFadeEnd: 300,
+        },
+        frustumCulling: {
+          enabled: false, // Disable frustum culling for LOD tests
+          padding: 50,
+          updateInterval: 1,
+        },
+      });
+      camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10000);
+      camera.position.set(0, 0, 100);
+      camera.updateMatrixWorld();
+    });
+
+    it("returns full opacity for close nodes", () => {
+      // Manually set camera for visibility calculation
+      (manager as any).camera = camera;
+
+      const position = new THREE.Vector3(0, 0, 50);
+      const visibility = manager.calculateNodeVisibility("node1", position, 10);
+
+      expect(visibility.labelOpacity).toBe(1);
+      expect(visibility.labelVisible).toBe(true);
+      expect(visibility.detailLevel).toBe(1);
+    });
+
+    it("returns reduced opacity for mid-distance nodes", () => {
+      (manager as any).camera = camera;
+
+      // Node at 150 distance from camera at (0,0,100)
+      // Camera at (0,0,100), node at (0,0,-50) = 150 distance
+      const position = new THREE.Vector3(0, 0, -50);
+      const visibility = manager.calculateNodeVisibility("node2", position, 10);
+
+      // Distance is 150, which is between 100 and 200
+      expect(visibility.labelOpacity).toBeLessThan(1);
+      expect(visibility.labelOpacity).toBeGreaterThan(0);
+      expect(visibility.labelVisible).toBe(true);
+    });
+
+    it("returns zero opacity for far nodes", () => {
+      (manager as any).camera = camera;
+
+      // Node at 250 distance
+      const position = new THREE.Vector3(0, 0, -150);
+      const visibility = manager.calculateNodeVisibility("node3", position, 10);
+
+      expect(visibility.labelOpacity).toBe(0);
+      expect(visibility.labelVisible).toBe(false);
+    });
+
+    it("returns reduced detail level for distant nodes", () => {
+      (manager as any).camera = camera;
+
+      // Node at 250 distance (between 150 and 300)
+      const position = new THREE.Vector3(0, 0, -150);
+      const visibility = manager.calculateNodeVisibility("node4", position, 10);
+
+      expect(visibility.detailLevel).toBeLessThan(1);
+      expect(visibility.detailLevel).toBeGreaterThan(0.2);
+    });
+
+    it("caches visibility calculations", () => {
+      (manager as any).camera = camera;
+
+      const position = new THREE.Vector3(0, 0, 0);
+
+      // First calculation
+      const visibility1 = manager.calculateNodeVisibility("node5", position, 10);
+
+      // Second calculation should return cached value
+      const visibility2 = manager.calculateNodeVisibility("node5", position, 10);
+
+      expect(visibility1).toBe(visibility2);
+    });
+
+    it("clears cache when requested", () => {
+      (manager as any).camera = camera;
+
+      const position = new THREE.Vector3(0, 0, 0);
+
+      const visibility1 = manager.calculateNodeVisibility("node6", position, 10);
+      manager.clearCache();
+      const visibility2 = manager.calculateNodeVisibility("node6", position, 10);
+
+      // Different objects after cache clear
+      expect(visibility1).not.toBe(visibility2);
+      // But same values
+      expect(visibility1.labelOpacity).toBe(visibility2.labelOpacity);
+    });
+  });
+
+  describe("frustum culling", () => {
+    let manager: Graph3DPerformanceManager;
+    let camera: THREE.PerspectiveCamera;
+
+    beforeEach(() => {
+      manager = new Graph3DPerformanceManager({
+        lod: {
+          enabled: false, // Disable LOD for frustum tests
+          labelFadeStart: 100,
+          labelFadeEnd: 200,
+          labelMinOpacity: 0,
+          nodeDetailFadeStart: 150,
+          nodeDetailFadeEnd: 300,
+        },
+        frustumCulling: {
+          enabled: true,
+          padding: 10,
+          updateInterval: 1,
+        },
+      });
+      camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10000);
+      camera.position.set(0, 0, 100);
+      camera.lookAt(0, 0, 0);
+      camera.updateMatrixWorld();
+
+      // Manually inject camera and update frustum
+      (manager as any).camera = camera;
+      manager.updateFrustum();
+    });
+
+    it("returns inFrustum=true for visible nodes", () => {
+      const position = new THREE.Vector3(0, 0, 0);
+      const visibility = manager.calculateNodeVisibility("visible1", position, 10);
+
+      expect(visibility.inFrustum).toBe(true);
+    });
+
+    it("returns inFrustum=false for off-screen nodes", () => {
+      // Node far to the side, outside camera view
+      const position = new THREE.Vector3(1000, 0, 0);
+      const visibility = manager.calculateNodeVisibility("offscreen1", position, 10);
+
+      expect(visibility.inFrustum).toBe(false);
+    });
+
+    it("considers padding when culling", () => {
+      // Create manager with larger padding
+      const managerWithPadding = new Graph3DPerformanceManager({
+        frustumCulling: {
+          enabled: true,
+          padding: 1000, // Large padding
+          updateInterval: 1,
+        },
+      });
+      (managerWithPadding as any).camera = camera;
+      managerWithPadding.updateFrustum();
+
+      // Node that would normally be culled
+      const position = new THREE.Vector3(500, 0, 0);
+      const visibility = managerWithPadding.calculateNodeVisibility("padded1", position, 10);
+
+      // With large padding, it should be in frustum
+      expect(visibility.inFrustum).toBe(true);
+
+      managerWithPadding.destroy();
+    });
+
+    it("updates frustum based on interval", () => {
+      // Frame 1
+      manager.updateFrustum();
+      // Frame 2 - should update (interval is 1)
+      manager.updateFrustum();
+
+      // Create manager with interval of 3
+      const managerWithInterval = new Graph3DPerformanceManager({
+        frustumCulling: {
+          enabled: true,
+          padding: 10,
+          updateInterval: 3,
+        },
+      });
+
+      // Should update on frame 3, 6, 9, etc.
+      managerWithInterval.updateFrustum(); // frame 1 - no update
+      managerWithInterval.updateFrustum(); // frame 2 - no update
+      managerWithInterval.updateFrustum(); // frame 3 - update
+
+      managerWithInterval.destroy();
+    });
+  });
+
+  describe("batch visibility calculation", () => {
+    let manager: Graph3DPerformanceManager;
+    let camera: THREE.PerspectiveCamera;
+
+    beforeEach(() => {
+      manager = new Graph3DPerformanceManager();
+      camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10000);
+      camera.position.set(0, 0, 100);
+      camera.updateMatrixWorld();
+      (manager as any).camera = camera;
+    });
+
+    it("calculates visibility for multiple nodes", () => {
+      const nodes = [
+        { id: "n1", x: 0, y: 0, z: 0 },
+        { id: "n2", x: 10, y: 10, z: 10 },
+        { id: "n3", x: -10, y: -10, z: -10 },
+      ];
+
+      const results = manager.calculateBatchVisibility(
+        nodes,
+        (node) => new THREE.Vector3(node.x, node.y, node.z)
+      );
+
+      expect(results.size).toBe(3);
+      expect(results.has("n1")).toBe(true);
+      expect(results.has("n2")).toBe(true);
+      expect(results.has("n3")).toBe(true);
+    });
+
+    it("uses custom radius function", () => {
+      const nodes = [
+        { id: "n1", x: 0, y: 0, z: 0, size: 5 },
+        { id: "n2", x: 10, y: 10, z: 10, size: 20 },
+      ];
+
+      const results = manager.calculateBatchVisibility(
+        nodes,
+        (node) => new THREE.Vector3(node.x, node.y, node.z),
+        (node) => node.size
+      );
+
+      expect(results.size).toBe(2);
+    });
+  });
+
+  describe("FPS tracking", () => {
+    let manager: Graph3DPerformanceManager;
+
+    beforeEach(() => {
+      manager = new Graph3DPerformanceManager();
+    });
+
+    it("returns default FPS initially", () => {
+      expect(manager.getFPS()).toBe(60);
+    });
+
+    it("updates FPS counter", () => {
+      // Call updateFPS multiple times
+      for (let i = 0; i < 60; i++) {
+        manager.updateFPS();
+      }
+
+      // FPS should be calculated (value depends on actual performance)
+      const fps = manager.getFPS();
+      expect(typeof fps).toBe("number");
+    });
+  });
+
+  describe("performance stats", () => {
+    let manager: Graph3DPerformanceManager;
+    let camera: THREE.PerspectiveCamera;
+
+    beforeEach(() => {
+      manager = new Graph3DPerformanceManager();
+      camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10000);
+      camera.position.set(0, 0, 100);
+      camera.updateMatrixWorld();
+      (manager as any).camera = camera;
+    });
+
+    it("returns empty stats initially", () => {
+      const stats = manager.getStats();
+
+      expect(stats.totalNodes).toBe(0);
+      expect(stats.visibleNodes).toBe(0);
+      expect(stats.culledNodes).toBe(0);
+      expect(stats.labelsVisible).toBe(0);
+    });
+
+    it("returns stats after visibility calculations", () => {
+      // Calculate some visibilities
+      manager.calculateNodeVisibility("n1", new THREE.Vector3(0, 0, 0), 10);
+      manager.calculateNodeVisibility("n2", new THREE.Vector3(10, 0, 0), 10);
+      manager.calculateNodeVisibility("n3", new THREE.Vector3(20, 0, 0), 10);
+
+      const stats = manager.getStats();
+
+      expect(stats.totalNodes).toBe(3);
+      expect(stats.visibleNodes).toBeGreaterThanOrEqual(0);
+    });
+
+    it("calculates culling efficiency", () => {
+      manager.calculateNodeVisibility("n1", new THREE.Vector3(0, 0, 0), 10);
+      manager.calculateNodeVisibility("n2", new THREE.Vector3(1000, 0, 0), 10); // Off-screen
+
+      const stats = manager.getStats();
+
+      expect(stats.cullingEfficiency).toBeGreaterThanOrEqual(0);
+      expect(stats.cullingEfficiency).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe("configuration management", () => {
+    let manager: Graph3DPerformanceManager;
+
+    beforeEach(() => {
+      manager = new Graph3DPerformanceManager();
+    });
+
+    it("returns current config", () => {
+      const config = manager.getConfig();
+
+      expect(config.lod).toBeDefined();
+      expect(config.frustumCulling).toBeDefined();
+      expect(config.webglRecovery).toBeDefined();
+    });
+
+    it("updates LOD config", () => {
+      manager.setConfig({
+        lod: { labelFadeStart: 200 },
+      } as any);
+
+      expect(manager.getConfig().lod.labelFadeStart).toBe(200);
+    });
+
+    it("updates frustum culling config", () => {
+      manager.setConfig({
+        frustumCulling: { padding: 100 },
+      } as any);
+
+      expect(manager.getConfig().frustumCulling.padding).toBe(100);
+    });
+
+    it("clears cache when config changes", () => {
+      const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10000);
+      (manager as any).camera = camera;
+
+      manager.calculateNodeVisibility("n1", new THREE.Vector3(0, 0, 0), 10);
+      expect(manager.getStats().totalNodes).toBe(1);
+
+      manager.setConfig({ lod: { labelFadeStart: 200 } } as any);
+
+      // Cache should be cleared
+      expect(manager.getStats().totalNodes).toBe(0);
+    });
+
+    it("enables/disables LOD", () => {
+      manager.setLODEnabled(false);
+      expect(manager.getConfig().lod.enabled).toBe(false);
+
+      manager.setLODEnabled(true);
+      expect(manager.getConfig().lod.enabled).toBe(true);
+    });
+
+    it("enables/disables frustum culling", () => {
+      manager.setFrustumCullingEnabled(false);
+      expect(manager.getConfig().frustumCulling.enabled).toBe(false);
+
+      manager.setFrustumCullingEnabled(true);
+      expect(manager.getConfig().frustumCulling.enabled).toBe(true);
+    });
+  });
+
+  describe("event system", () => {
+    let manager: Graph3DPerformanceManager;
+
+    beforeEach(() => {
+      manager = new Graph3DPerformanceManager();
+    });
+
+    it("adds and removes event listeners", () => {
+      const listener = jest.fn();
+
+      manager.on("webglContextLost", listener);
+      manager.off("webglContextLost", listener);
+
+      // Should not throw
+      expect(true).toBe(true);
+    });
+
+    it("supports all event types", () => {
+      const listener = jest.fn();
+
+      const eventTypes: Array<
+        | "webglContextLost"
+        | "webglContextRestored"
+        | "recoveryStarted"
+        | "recoveryComplete"
+        | "recoveryFailed"
+        | "performanceUpdate"
+      > = [
+        "webglContextLost",
+        "webglContextRestored",
+        "recoveryStarted",
+        "recoveryComplete",
+        "recoveryFailed",
+        "performanceUpdate",
+      ];
+
+      for (const eventType of eventTypes) {
+        expect(() => manager.on(eventType, listener)).not.toThrow();
+        expect(() => manager.off(eventType, listener)).not.toThrow();
+      }
+    });
+  });
+
+  describe("recovery state", () => {
+    let manager: Graph3DPerformanceManager;
+
+    beforeEach(() => {
+      manager = new Graph3DPerformanceManager();
+    });
+
+    it("returns false for isInRecovery initially", () => {
+      expect(manager.isInRecovery()).toBe(false);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("destroys without errors", () => {
+      const manager = new Graph3DPerformanceManager();
+      expect(() => manager.destroy()).not.toThrow();
+    });
+
+    it("is safe to destroy multiple times", () => {
+      const manager = new Graph3DPerformanceManager();
+      manager.destroy();
+      expect(() => manager.destroy()).not.toThrow();
+    });
+
+    it("clears all state on destroy", () => {
+      const manager = new Graph3DPerformanceManager();
+      const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10000);
+      (manager as any).camera = camera;
+
+      manager.calculateNodeVisibility("n1", new THREE.Vector3(0, 0, 0), 10);
+      manager.destroy();
+
+      expect(manager.getStats().totalNodes).toBe(0);
+    });
+  });
+
+  describe("Scene3DManager integration (without initialization)", () => {
+    it("accepts performance config in constructor", async () => {
+      // Dynamic import to avoid circular dependency issues
+      const { Scene3DManager } = await import(
+        "@plugin/presentation/renderers/graph/3d/Scene3DManager"
+      );
+
+      const manager = new Scene3DManager(
+        {},
+        {},
+        {},
+        {},
+        {},
+        {
+          lod: { enabled: true, labelFadeStart: 100 },
+          frustumCulling: { enabled: true, padding: 50 },
+        }
+      );
+
+      expect(manager).toBeDefined();
+      expect(manager.isInitialized()).toBe(false);
+      expect(manager.getLODEnabled()).toBe(true);
+      expect(manager.getFrustumCullingEnabled()).toBe(true);
+
+      manager.destroy();
+    });
+
+    it("can toggle LOD and frustum culling", async () => {
+      const { Scene3DManager } = await import(
+        "@plugin/presentation/renderers/graph/3d/Scene3DManager"
+      );
+
+      const manager = new Scene3DManager();
+
+      manager.setLODEnabled(false);
+      expect(manager.getLODEnabled()).toBe(false);
+
+      manager.setFrustumCullingEnabled(false);
+      expect(manager.getFrustumCullingEnabled()).toBe(false);
+
+      manager.destroy();
+    });
+
+    it("returns null for performance stats before initialization", async () => {
+      const { Scene3DManager } = await import(
+        "@plugin/presentation/renderers/graph/3d/Scene3DManager"
+      );
+
+      const manager = new Scene3DManager();
+
+      expect(manager.getPerformanceStats()).toBeNull();
+      expect(manager.getPerformanceManager()).toBeNull();
+
+      manager.destroy();
+    });
+  });
+});
+
+describe("LOD opacity calculation edge cases", () => {
+  let manager: Graph3DPerformanceManager;
+  let camera: THREE.PerspectiveCamera;
+
+  beforeEach(() => {
+    manager = new Graph3DPerformanceManager({
+      lod: {
+        enabled: true,
+        labelFadeStart: 100,
+        labelFadeEnd: 200,
+        labelMinOpacity: 0,
+        nodeDetailFadeStart: 100,
+        nodeDetailFadeEnd: 200,
+      },
+      frustumCulling: { enabled: false, padding: 50, updateInterval: 1 },
+    });
+    camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10000);
+    camera.position.set(0, 0, 0);
+    camera.updateMatrixWorld();
+    (manager as any).camera = camera;
+  });
+
+  afterEach(() => {
+    manager.destroy();
+  });
+
+  it("returns exactly 1 at labelFadeStart distance", () => {
+    const position = new THREE.Vector3(0, 0, 100);
+    const visibility = manager.calculateNodeVisibility("exact100", position, 5);
+
+    expect(visibility.labelOpacity).toBe(1);
+  });
+
+  it("returns exactly minOpacity at labelFadeEnd distance", () => {
+    const position = new THREE.Vector3(0, 0, 200);
+    const visibility = manager.calculateNodeVisibility("exact200", position, 5);
+
+    expect(visibility.labelOpacity).toBe(0);
+  });
+
+  it("handles zero distance", () => {
+    const position = new THREE.Vector3(0, 0, 0);
+    const visibility = manager.calculateNodeVisibility("origin", position, 5);
+
+    expect(visibility.labelOpacity).toBe(1);
+    expect(visibility.distanceToCamera).toBe(0);
+  });
+
+  it("uses smooth interpolation (not linear)", () => {
+    // Test at midpoint (150)
+    const position = new THREE.Vector3(0, 0, 150);
+    const visibility = manager.calculateNodeVisibility("midpoint", position, 5);
+
+    // With quadratic ease-out, at t=0.5, eased = 1 - 0.25 = 0.75
+    // So opacity should be around 0.75, not 0.5
+    expect(visibility.labelOpacity).toBeGreaterThan(0.5);
+    expect(visibility.labelOpacity).toBeLessThan(1);
+  });
+});
+
+describe("WebGL recovery simulation", () => {
+  let manager: Graph3DPerformanceManager | null = null;
+
+  beforeEach(() => {
+    manager = new Graph3DPerformanceManager({
+      webglRecovery: {
+        enabled: true,
+        maxAttempts: 3,
+        retryDelay: 100,
+        showRecoveryMessage: false, // Disable UI for tests
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (manager) {
+      manager.destroy();
+      manager = null;
+    }
+  });
+
+  it("emits events on context loss simulation", () => {
+    const contextLostListener = jest.fn();
+    const recoveryStartedListener = jest.fn();
+
+    manager!.on("webglContextLost", contextLostListener);
+    manager!.on("recoveryStarted", recoveryStartedListener);
+
+    // Manually trigger context lost handling
+    (manager as any).handleContextLost();
+
+    expect(contextLostListener).toHaveBeenCalledTimes(1);
+    expect(recoveryStartedListener).toHaveBeenCalledTimes(1);
+    expect(manager!.isInRecovery()).toBe(true);
+  });
+
+  it("emits events on context restore simulation", () => {
+    const contextRestoredListener = jest.fn();
+    const recoveryCompleteListener = jest.fn();
+
+    manager!.on("webglContextRestored", contextRestoredListener);
+    manager!.on("recoveryComplete", recoveryCompleteListener);
+
+    // Simulate context loss first
+    (manager as any).handleContextLost();
+
+    // Then restore
+    (manager as any).handleContextRestored();
+
+    expect(contextRestoredListener).toHaveBeenCalledTimes(1);
+    expect(recoveryCompleteListener).toHaveBeenCalledTimes(1);
+    expect(manager!.isInRecovery()).toBe(false);
+  });
+
+  it("emits failure event after max attempts", () => {
+    const recoveryFailedListener = jest.fn();
+    manager!.on("recoveryFailed", recoveryFailedListener);
+
+    // Simulate context loss
+    (manager as any).handleContextLost();
+
+    // Restore 4 times (exceeding maxAttempts of 3)
+    (manager as any).handleContextRestored(); // attempt 1
+    (manager as any).handleContextRestored(); // attempt 2
+    (manager as any).handleContextRestored(); // attempt 3
+    (manager as any).handleContextRestored(); // attempt 4 - exceeds max
+
+    expect(recoveryFailedListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls recovery complete callback", () => {
+    const recoveryCallback = jest.fn();
+
+    // Create new manager with callback
+    const managerWithCallback = new Graph3DPerformanceManager();
+    (managerWithCallback as any).onRecoveryComplete = recoveryCallback;
+
+    (managerWithCallback as any).handleContextLost();
+    (managerWithCallback as any).handleContextRestored();
+
+    expect(recoveryCallback).toHaveBeenCalledTimes(1);
+
+    managerWithCallback.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

Implements performance optimizations for 3D graph visualization to maintain 30+ FPS with larger graphs (up to 500 nodes):

- **LOD (Level of Detail)**: Distance-based label opacity fading with smooth transitions
- **Frustum Culling**: Skip rendering off-screen nodes using Three.js Frustum API
- **WebGL Context Recovery**: Automatic recovery on context loss with user feedback

## Changes

### New Files
- `Graph3DPerformanceManager.ts` - Centralized performance optimization manager
- `Graph3DPerformanceManager.test.ts` - 51 unit tests (>80% coverage)

### Modified Files
- `Scene3DManager.ts` - Integrated performance manager, added LOD/culling methods
- `index.ts` - Export new performance types and manager
- `styles.css` - Added recovery overlay CSS classes
- `tests/__mocks__/three.ts` - Added Frustum, Sphere, Matrix4 mocks

## Implementation Details

### LOD System
- Labels start fading at 150 units camera distance
- Full fade at 250 units (configurable)
- Smooth quadratic ease-out transition (no popping)
- Node detail level also reduces with distance

### Frustum Culling
- Uses Three.js Frustum.intersectsSphere() for efficient testing
- Includes padding (50 units) to prevent popping at edges
- Updates every 2 frames (configurable) to reduce CPU overhead
- Edges hidden when both connected nodes are culled

### WebGL Recovery
- Listens for webglcontextlost/webglcontextrestored events
- Shows "Recovering..." overlay during context loss
- Recreates all materials and textures after restore
- Configurable max retry attempts (default: 3)

## Test Plan

- [x] 51 new unit tests pass
- [x] All 7752 existing tests pass
- [x] Build succeeds
- [x] Lint passes (no new errors)

## Performance Expectations

- 30+ FPS with 500 nodes (LOD + culling enabled)
- Zero crashes on WebGL context loss
- Smooth LOD transitions with no visual popping

Closes #1269