### PR TITLE
feat: Add mobile/touch support for 3D graph

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/graph/3d/TouchGestureManager.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/graph/3d/TouchGestureManager.ts
@@ -1,0 +1,473 @@
+/**
+ * TouchGestureManager - Mobile touch gesture support for 3D graph
+ *
+ * Provides touch gesture handling for:
+ * - Tap to select nodes
+ * - Long-press for context actions
+ * - Pinch-to-zoom (handled by OrbitControls)
+ * - Two-finger rotation (handled by OrbitControls)
+ * - Single-finger pan (handled by OrbitControls)
+ *
+ * OrbitControls from Three.js already handles the multi-touch gestures,
+ * this manager focuses on tap/touch-to-select functionality.
+ *
+ * @module presentation/renderers/graph/3d
+ * @since 1.0.0
+ */
+
+/**
+ * Configuration for touch gesture handling
+ */
+export interface TouchGestureConfig {
+  /** Maximum movement (in pixels) before tap becomes a drag */
+  tapThreshold: number;
+
+  /** Maximum time (in ms) for a touch to count as a tap */
+  tapTimeout: number;
+
+  /** Time (in ms) to trigger long press */
+  longPressTimeout: number;
+
+  /** Enable haptic feedback on supported devices */
+  enableHapticFeedback: boolean;
+
+  /** Enable double-tap to zoom to fit */
+  enableDoubleTap: boolean;
+
+  /** Double-tap maximum interval (in ms) */
+  doubleTapTimeout: number;
+}
+
+/**
+ * Default touch gesture configuration
+ */
+export const DEFAULT_TOUCH_GESTURE_CONFIG: TouchGestureConfig = {
+  tapThreshold: 10,
+  tapTimeout: 300,
+  longPressTimeout: 500,
+  enableHapticFeedback: true,
+  enableDoubleTap: true,
+  doubleTapTimeout: 300,
+};
+
+/**
+ * Touch gesture event types
+ */
+export type TouchGestureEventType =
+  | "tap"
+  | "doubleTap"
+  | "longPress"
+  | "touchStart"
+  | "touchMove"
+  | "touchEnd";
+
+/**
+ * Touch gesture event data
+ */
+export interface TouchGestureEvent {
+  type: TouchGestureEventType;
+  /** X position relative to element */
+  x: number;
+  /** Y position relative to element */
+  y: number;
+  /** Original touch event */
+  originalEvent?: TouchEvent;
+  /** Number of active touches */
+  touchCount?: number;
+}
+
+/**
+ * Event listener callback for touch gesture events
+ */
+export type TouchGestureEventListener = (event: TouchGestureEvent) => void;
+
+/**
+ * Touch state tracking
+ */
+interface TouchState {
+  startX: number;
+  startY: number;
+  startTime: number;
+  identifier: number;
+}
+
+/**
+ * TouchGestureManager - Handles touch gestures for 3D graph
+ *
+ * @example
+ * ```typescript
+ * const manager = new TouchGestureManager(canvas);
+ *
+ * manager.on('tap', (event) => {
+ *   console.log('Tap at:', event.x, event.y);
+ * });
+ *
+ * manager.on('doubleTap', (event) => {
+ *   console.log('Double tap at:', event.x, event.y);
+ * });
+ *
+ * manager.destroy();
+ * ```
+ */
+export class TouchGestureManager {
+  private element: HTMLElement;
+  private config: TouchGestureConfig;
+  private eventListeners: Map<TouchGestureEventType, Set<TouchGestureEventListener>> =
+    new Map();
+
+  private touchStates: Map<number, TouchState> = new Map();
+  private longPressTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastTapTime = 0;
+  private lastTapX = 0;
+  private lastTapY = 0;
+  private destroyed = false;
+
+  // Bound event handlers for proper removal
+  private boundTouchStart: (e: TouchEvent) => void;
+  private boundTouchMove: (e: TouchEvent) => void;
+  private boundTouchEnd: (e: TouchEvent) => void;
+  private boundTouchCancel: (e: TouchEvent) => void;
+
+  constructor(
+    element: HTMLElement,
+    config: Partial<TouchGestureConfig> = {}
+  ) {
+    this.element = element;
+    this.config = { ...DEFAULT_TOUCH_GESTURE_CONFIG, ...config };
+
+    // Initialize event listener maps
+    const eventTypes: TouchGestureEventType[] = [
+      "tap",
+      "doubleTap",
+      "longPress",
+      "touchStart",
+      "touchMove",
+      "touchEnd",
+    ];
+    for (const type of eventTypes) {
+      this.eventListeners.set(type, new Set());
+    }
+
+    // Bind handlers
+    this.boundTouchStart = this.handleTouchStart.bind(this);
+    this.boundTouchMove = this.handleTouchMove.bind(this);
+    this.boundTouchEnd = this.handleTouchEnd.bind(this);
+    this.boundTouchCancel = this.handleTouchCancel.bind(this);
+
+    // Add event listeners
+    this.element.addEventListener("touchstart", this.boundTouchStart, {
+      passive: false,
+    });
+    this.element.addEventListener("touchmove", this.boundTouchMove, {
+      passive: false,
+    });
+    this.element.addEventListener("touchend", this.boundTouchEnd, {
+      passive: false,
+    });
+    this.element.addEventListener("touchcancel", this.boundTouchCancel, {
+      passive: false,
+    });
+  }
+
+  /**
+   * Handle touch start event
+   */
+  private handleTouchStart(event: TouchEvent): void {
+    if (this.destroyed) return;
+
+    const rect = this.element.getBoundingClientRect();
+
+    for (let i = 0; i < event.changedTouches.length; i++) {
+      const touch = event.changedTouches[i];
+      const x = touch.clientX - rect.left;
+      const y = touch.clientY - rect.top;
+
+      this.touchStates.set(touch.identifier, {
+        startX: x,
+        startY: y,
+        startTime: Date.now(),
+        identifier: touch.identifier,
+      });
+
+      this.emit("touchStart", {
+        type: "touchStart",
+        x,
+        y,
+        originalEvent: event,
+        touchCount: event.touches.length,
+      });
+    }
+
+    // Start long press timer only for single touch
+    if (event.touches.length === 1) {
+      this.startLongPressTimer(event);
+    } else {
+      this.cancelLongPressTimer();
+    }
+  }
+
+  /**
+   * Handle touch move event
+   */
+  private handleTouchMove(event: TouchEvent): void {
+    if (this.destroyed) return;
+
+    const rect = this.element.getBoundingClientRect();
+
+    for (let i = 0; i < event.changedTouches.length; i++) {
+      const touch = event.changedTouches[i];
+      const state = this.touchStates.get(touch.identifier);
+
+      if (state) {
+        const x = touch.clientX - rect.left;
+        const y = touch.clientY - rect.top;
+        const dx = x - state.startX;
+        const dy = y - state.startY;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+
+        // If moved beyond threshold, cancel long press
+        if (distance > this.config.tapThreshold) {
+          this.cancelLongPressTimer();
+        }
+
+        this.emit("touchMove", {
+          type: "touchMove",
+          x,
+          y,
+          originalEvent: event,
+          touchCount: event.touches.length,
+        });
+      }
+    }
+  }
+
+  /**
+   * Handle touch end event
+   */
+  private handleTouchEnd(event: TouchEvent): void {
+    if (this.destroyed) return;
+
+    this.cancelLongPressTimer();
+
+    const rect = this.element.getBoundingClientRect();
+    const now = Date.now();
+
+    for (let i = 0; i < event.changedTouches.length; i++) {
+      const touch = event.changedTouches[i];
+      const state = this.touchStates.get(touch.identifier);
+
+      if (state) {
+        const x = touch.clientX - rect.left;
+        const y = touch.clientY - rect.top;
+        const dx = x - state.startX;
+        const dy = y - state.startY;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        const duration = now - state.startTime;
+
+        this.emit("touchEnd", {
+          type: "touchEnd",
+          x,
+          y,
+          originalEvent: event,
+          touchCount: event.touches.length,
+        });
+
+        // Check if this is a tap (small movement, short duration, single touch)
+        if (
+          distance < this.config.tapThreshold &&
+          duration < this.config.tapTimeout &&
+          event.touches.length === 0 // No remaining touches
+        ) {
+          // Check for double tap
+          if (this.config.enableDoubleTap) {
+            const timeSinceLastTap = now - this.lastTapTime;
+            const distFromLastTap = Math.sqrt(
+              Math.pow(x - this.lastTapX, 2) + Math.pow(y - this.lastTapY, 2)
+            );
+
+            if (
+              timeSinceLastTap < this.config.doubleTapTimeout &&
+              distFromLastTap < this.config.tapThreshold * 2
+            ) {
+              // Double tap detected
+              this.emit("doubleTap", {
+                type: "doubleTap",
+                x,
+                y,
+                originalEvent: event,
+              });
+              this.triggerHapticFeedback();
+              this.lastTapTime = 0; // Reset to prevent triple-tap detection
+            } else {
+              // Single tap - wait for potential double tap
+              this.lastTapTime = now;
+              this.lastTapX = x;
+              this.lastTapY = y;
+
+              // Emit tap immediately (don't wait for double tap timeout)
+              this.emit("tap", {
+                type: "tap",
+                x,
+                y,
+                originalEvent: event,
+              });
+              this.triggerHapticFeedback();
+            }
+          } else {
+            // Double tap disabled, emit tap immediately
+            this.emit("tap", {
+              type: "tap",
+              x,
+              y,
+              originalEvent: event,
+            });
+            this.triggerHapticFeedback();
+          }
+        }
+
+        this.touchStates.delete(touch.identifier);
+      }
+    }
+  }
+
+  /**
+   * Handle touch cancel event
+   */
+  private handleTouchCancel(event: TouchEvent): void {
+    if (this.destroyed) return;
+
+    this.cancelLongPressTimer();
+
+    for (let i = 0; i < event.changedTouches.length; i++) {
+      const touch = event.changedTouches[i];
+      this.touchStates.delete(touch.identifier);
+    }
+  }
+
+  /**
+   * Start long press timer
+   */
+  private startLongPressTimer(event: TouchEvent): void {
+    this.cancelLongPressTimer();
+
+    const touch = event.touches[0];
+    const rect = this.element.getBoundingClientRect();
+    const x = touch.clientX - rect.left;
+    const y = touch.clientY - rect.top;
+
+    this.longPressTimer = setTimeout(() => {
+      this.emit("longPress", {
+        type: "longPress",
+        x,
+        y,
+        originalEvent: event,
+      });
+      this.triggerHapticFeedback();
+    }, this.config.longPressTimeout);
+  }
+
+  /**
+   * Cancel long press timer
+   */
+  private cancelLongPressTimer(): void {
+    if (this.longPressTimer !== null) {
+      clearTimeout(this.longPressTimer);
+      this.longPressTimer = null;
+    }
+  }
+
+  /**
+   * Trigger haptic feedback if available
+   */
+  private triggerHapticFeedback(): void {
+    if (!this.config.enableHapticFeedback) return;
+
+    // Use Vibration API if available
+    if (
+      "vibrate" in navigator &&
+      typeof navigator.vibrate === "function"
+    ) {
+      navigator.vibrate(10);
+    }
+  }
+
+  /**
+   * Add event listener
+   */
+  on(eventType: TouchGestureEventType, listener: TouchGestureEventListener): void {
+    this.eventListeners.get(eventType)?.add(listener);
+  }
+
+  /**
+   * Remove event listener
+   */
+  off(eventType: TouchGestureEventType, listener: TouchGestureEventListener): void {
+    this.eventListeners.get(eventType)?.delete(listener);
+  }
+
+  /**
+   * Emit event to listeners
+   */
+  private emit(eventType: TouchGestureEventType, event: TouchGestureEvent): void {
+    const listeners = this.eventListeners.get(eventType);
+    if (listeners) {
+      for (const listener of listeners) {
+        try {
+          listener(event);
+        } catch (error) {
+          console.error("Error in TouchGestureManager event listener:", error);
+        }
+      }
+    }
+  }
+
+  /**
+   * Check if device supports touch
+   */
+  static isTouchDevice(): boolean {
+    return (
+      "ontouchstart" in window ||
+      navigator.maxTouchPoints > 0
+    );
+  }
+
+  /**
+   * Update configuration
+   */
+  setConfig(config: Partial<TouchGestureConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  /**
+   * Get current configuration
+   */
+  getConfig(): TouchGestureConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Destroy the manager and remove event listeners
+   */
+  destroy(): void {
+    this.destroyed = true;
+    this.cancelLongPressTimer();
+
+    this.element.removeEventListener("touchstart", this.boundTouchStart);
+    this.element.removeEventListener("touchmove", this.boundTouchMove);
+    this.element.removeEventListener("touchend", this.boundTouchEnd);
+    this.element.removeEventListener("touchcancel", this.boundTouchCancel);
+
+    this.touchStates.clear();
+    this.eventListeners.clear();
+  }
+}
+
+/**
+ * Factory function to create TouchGestureManager
+ */
+export function createTouchGestureManager(
+  element: HTMLElement,
+  config?: Partial<TouchGestureConfig>
+): TouchGestureManager {
+  return new TouchGestureManager(element, config);
+}

--- a/packages/obsidian-plugin/src/presentation/renderers/graph/3d/index.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/graph/3d/index.ts
@@ -19,7 +19,20 @@
  */
 
 // Scene manager
-export { Scene3DManager, createScene3DManager } from "./Scene3DManager";
+export { Scene3DManager, createScene3DManager, isTouchDevice } from "./Scene3DManager";
+
+// Touch gesture manager
+export {
+  TouchGestureManager,
+  createTouchGestureManager,
+  DEFAULT_TOUCH_GESTURE_CONFIG,
+} from "./TouchGestureManager";
+export type {
+  TouchGestureConfig,
+  TouchGestureEventType,
+  TouchGestureEvent,
+  TouchGestureEventListener,
+} from "./TouchGestureManager";
 
 // Performance manager
 export {

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -4861,6 +4861,96 @@
 }
 
 /* ============================================================================
+   3D Graph Mobile/Touch Support (WCAG AAA: 48x48px minimum touch targets)
+   ============================================================================ */
+
+/* Touch-friendly toolbar on mobile devices */
+@media (pointer: coarse), (hover: none) {
+  .exo-graph3d-toolbar {
+    gap: 8px;
+    padding: 8px;
+    border-radius: 12px;
+  }
+
+  .exo-graph3d-toolbar__btn {
+    /* WCAG AAA compliance: 48x48px minimum touch target */
+    width: 48px;
+    height: 48px;
+    border-radius: 8px;
+    /* Larger icon size for better visibility */
+    font-size: 20px;
+  }
+
+  .exo-graph3d-toolbar__btn svg {
+    width: 24px;
+    height: 24px;
+  }
+
+  .exo-graph3d-toolbar__separator {
+    height: 32px;
+    margin: 0 8px;
+  }
+}
+
+/* Even larger touch targets on small screens (phones) */
+@media (pointer: coarse) and (max-width: 480px) {
+  .exo-graph3d-toolbar {
+    /* Full width toolbar at bottom for easier thumb access */
+    top: auto;
+    bottom: 16px;
+    left: 16px;
+    right: 16px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .exo-graph3d-toolbar__btn {
+    /* Slightly larger on phones */
+    width: 52px;
+    height: 52px;
+  }
+
+  .sparql-graph3d-view--fullscreen .exo-graph3d-toolbar {
+    top: auto;
+    bottom: 20px;
+    left: 20px;
+    right: 20px;
+  }
+}
+
+/* Tablet-specific adjustments */
+@media (pointer: coarse) and (min-width: 481px) and (max-width: 1024px) {
+  .exo-graph3d-toolbar {
+    top: 16px;
+    right: 16px;
+  }
+}
+
+/* Prevent accidental text selection during touch interactions */
+.exo-graph3d-toolbar,
+.exo-graph3d-toolbar__btn {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+}
+
+/* Active state for touch (more prominent feedback) */
+@media (pointer: coarse) {
+  .exo-graph3d-toolbar__btn:active {
+    transform: scale(0.92);
+    background-color: rgba(147, 153, 178, 0.25);
+  }
+
+  .exo-graph3d-toolbar__btn--active:active {
+    transform: scale(0.92);
+    background-color: var(--interactive-accent-hover, #5855e4);
+  }
+}
+
+/* ============================================================================
    3D Graph WebGL Recovery Overlay
    ============================================================================ */
 

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/graph/3d/TouchGestureManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/graph/3d/TouchGestureManager.test.ts
@@ -1,0 +1,245 @@
+/**
+ * TouchGestureManager Tests
+ *
+ * Tests for mobile touch gesture handling in 3D graph visualization.
+ * Uses direct method invocation since jsdom doesn't fully support TouchEvent.
+ *
+ * @module tests/presentation/renderers/graph/3d
+ */
+
+import {
+  TouchGestureManager,
+  createTouchGestureManager,
+  DEFAULT_TOUCH_GESTURE_CONFIG,
+  type TouchGestureConfig,
+} from "../../../../../../src/presentation/renderers/graph/3d/TouchGestureManager";
+
+// Mock element with getBoundingClientRect
+function createMockElement(): HTMLElement {
+  const element = document.createElement("div");
+  element.getBoundingClientRect = jest.fn().mockReturnValue({
+    left: 0,
+    top: 0,
+    width: 800,
+    height: 600,
+    right: 800,
+    bottom: 600,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
+  return element;
+}
+
+describe("TouchGestureManager", () => {
+  let element: HTMLElement;
+  let manager: TouchGestureManager;
+
+  beforeEach(() => {
+    element = createMockElement();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    if (manager) {
+      manager.destroy();
+    }
+    jest.useRealTimers();
+  });
+
+  describe("initialization", () => {
+    it("should create with default config", () => {
+      manager = new TouchGestureManager(element);
+      const config = manager.getConfig();
+
+      expect(config.tapThreshold).toBe(DEFAULT_TOUCH_GESTURE_CONFIG.tapThreshold);
+      expect(config.tapTimeout).toBe(DEFAULT_TOUCH_GESTURE_CONFIG.tapTimeout);
+      expect(config.longPressTimeout).toBe(DEFAULT_TOUCH_GESTURE_CONFIG.longPressTimeout);
+      expect(config.enableHapticFeedback).toBe(DEFAULT_TOUCH_GESTURE_CONFIG.enableHapticFeedback);
+      expect(config.enableDoubleTap).toBe(DEFAULT_TOUCH_GESTURE_CONFIG.enableDoubleTap);
+      expect(config.doubleTapTimeout).toBe(DEFAULT_TOUCH_GESTURE_CONFIG.doubleTapTimeout);
+    });
+
+    it("should accept custom config", () => {
+      const customConfig: Partial<TouchGestureConfig> = {
+        tapThreshold: 20,
+        longPressTimeout: 1000,
+        enableHapticFeedback: false,
+      };
+
+      manager = new TouchGestureManager(element, customConfig);
+      const config = manager.getConfig();
+
+      expect(config.tapThreshold).toBe(20);
+      expect(config.longPressTimeout).toBe(1000);
+      expect(config.enableHapticFeedback).toBe(false);
+      expect(config.tapTimeout).toBe(DEFAULT_TOUCH_GESTURE_CONFIG.tapTimeout); // unchanged
+    });
+
+    it("should use factory function", () => {
+      manager = createTouchGestureManager(element, { tapThreshold: 15 });
+      expect(manager.getConfig().tapThreshold).toBe(15);
+    });
+
+    it("should have default tap threshold of 10 pixels", () => {
+      expect(DEFAULT_TOUCH_GESTURE_CONFIG.tapThreshold).toBe(10);
+    });
+
+    it("should have default tap timeout of 300ms", () => {
+      expect(DEFAULT_TOUCH_GESTURE_CONFIG.tapTimeout).toBe(300);
+    });
+
+    it("should have default long press timeout of 500ms", () => {
+      expect(DEFAULT_TOUCH_GESTURE_CONFIG.longPressTimeout).toBe(500);
+    });
+
+    it("should have default double tap timeout of 300ms", () => {
+      expect(DEFAULT_TOUCH_GESTURE_CONFIG.doubleTapTimeout).toBe(300);
+    });
+
+    it("should enable haptic feedback by default", () => {
+      expect(DEFAULT_TOUCH_GESTURE_CONFIG.enableHapticFeedback).toBe(true);
+    });
+
+    it("should enable double tap by default", () => {
+      expect(DEFAULT_TOUCH_GESTURE_CONFIG.enableDoubleTap).toBe(true);
+    });
+  });
+
+  describe("configuration updates", () => {
+    it("should update config at runtime", () => {
+      manager = new TouchGestureManager(element);
+      expect(manager.getConfig().tapThreshold).toBe(10);
+
+      manager.setConfig({ tapThreshold: 25 });
+      expect(manager.getConfig().tapThreshold).toBe(25);
+    });
+
+    it("should preserve other config values when updating one value", () => {
+      manager = new TouchGestureManager(element, {
+        tapThreshold: 15,
+        longPressTimeout: 600,
+      });
+
+      manager.setConfig({ tapThreshold: 20 });
+
+      expect(manager.getConfig().tapThreshold).toBe(20);
+      expect(manager.getConfig().longPressTimeout).toBe(600);
+    });
+  });
+
+  describe("touch device detection", () => {
+    it("should detect touch capability", () => {
+      // Note: In jsdom, this will be based on navigator.maxTouchPoints
+      const result = TouchGestureManager.isTouchDevice();
+      expect(typeof result).toBe("boolean");
+    });
+
+    it("should return consistent result", () => {
+      // Multiple calls should return the same result
+      const result1 = TouchGestureManager.isTouchDevice();
+      const result2 = TouchGestureManager.isTouchDevice();
+      expect(result1).toBe(result2);
+    });
+  });
+
+  describe("event listener management", () => {
+    it("should allow adding event listeners", () => {
+      manager = new TouchGestureManager(element);
+      const handler = jest.fn();
+
+      // Should not throw
+      expect(() => manager.on("tap", handler)).not.toThrow();
+    });
+
+    it("should allow removing event listeners", () => {
+      manager = new TouchGestureManager(element);
+      const handler = jest.fn();
+
+      manager.on("tap", handler);
+      // Should not throw
+      expect(() => manager.off("tap", handler)).not.toThrow();
+    });
+
+    it("should support all event types", () => {
+      manager = new TouchGestureManager(element);
+      const handler = jest.fn();
+
+      // Should not throw for any event type
+      expect(() => manager.on("tap", handler)).not.toThrow();
+      expect(() => manager.on("doubleTap", handler)).not.toThrow();
+      expect(() => manager.on("longPress", handler)).not.toThrow();
+      expect(() => manager.on("touchStart", handler)).not.toThrow();
+      expect(() => manager.on("touchMove", handler)).not.toThrow();
+      expect(() => manager.on("touchEnd", handler)).not.toThrow();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should clean up on destroy", () => {
+      manager = new TouchGestureManager(element);
+
+      // Should not throw
+      expect(() => manager.destroy()).not.toThrow();
+    });
+
+    it("should allow multiple destroy calls", () => {
+      manager = new TouchGestureManager(element);
+
+      manager.destroy();
+      // Second call should not throw
+      expect(() => manager.destroy()).not.toThrow();
+    });
+  });
+
+  describe("configuration defaults validation", () => {
+    it("should have valid default config values", () => {
+      const config = DEFAULT_TOUCH_GESTURE_CONFIG;
+
+      // Tap threshold should be reasonable (5-20 pixels typical)
+      expect(config.tapThreshold).toBeGreaterThanOrEqual(5);
+      expect(config.tapThreshold).toBeLessThanOrEqual(20);
+
+      // Tap timeout should be reasonable (100-500ms typical)
+      expect(config.tapTimeout).toBeGreaterThanOrEqual(100);
+      expect(config.tapTimeout).toBeLessThanOrEqual(500);
+
+      // Long press should be longer than tap timeout
+      expect(config.longPressTimeout).toBeGreaterThan(config.tapTimeout);
+
+      // Double tap should be similar to tap timeout
+      expect(config.doubleTapTimeout).toBeGreaterThanOrEqual(200);
+      expect(config.doubleTapTimeout).toBeLessThanOrEqual(500);
+    });
+
+    it("should have WCAG-friendly defaults", () => {
+      const config = DEFAULT_TOUCH_GESTURE_CONFIG;
+
+      // Tap threshold of 10px is reasonable for touch
+      expect(config.tapThreshold).toBe(10);
+
+      // Long press of 500ms follows platform conventions
+      expect(config.longPressTimeout).toBe(500);
+    });
+  });
+
+  describe("factory function", () => {
+    it("should create manager with factory function", () => {
+      const factoryManager = createTouchGestureManager(element);
+      expect(factoryManager).toBeInstanceOf(TouchGestureManager);
+      factoryManager.destroy();
+    });
+
+    it("should pass config to factory function", () => {
+      const customConfig: Partial<TouchGestureConfig> = {
+        tapThreshold: 30,
+        enableDoubleTap: false,
+      };
+
+      const factoryManager = createTouchGestureManager(element, customConfig);
+      expect(factoryManager.getConfig().tapThreshold).toBe(30);
+      expect(factoryManager.getConfig().enableDoubleTap).toBe(false);
+      factoryManager.destroy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive mobile/touch support for the 3D graph visualization:

- **Touch Gesture Manager**: New component handling tap, double-tap, and long-press gestures
- **Tap to select**: Touch nodes to navigate to assets (equivalent to click)
- **Double-tap to fit**: Quickly fit all nodes in view
- **Touch-friendly controls**: WCAG AAA compliant 48x48px minimum touch targets

### Implementation Details

#### TouchGestureManager (`TouchGestureManager.ts`)
- Handles tap detection (with movement/time thresholds)
- Double-tap detection for quick fit-to-view
- Long-press detection for future context menu support
- Haptic feedback on supported devices
- Configurable thresholds and timeouts

#### Scene3DManager Integration
- OrbitControls already supports pinch-to-zoom, two-finger rotation, and single-finger pan
- Added touch event handlers for tap-to-select and double-tap-to-fit
- Long-press prepares for future context menu functionality

#### CSS Mobile Styles
- 48x48px minimum touch targets (WCAG AAA)
- 52x52px on phones for thumb-friendly access  
- Bottom toolbar placement on small screens
- Prevents accidental text selection
- Enhanced active state feedback

### Test Coverage
- 22 unit tests for TouchGestureManager
- Tests cover configuration, event listeners, and cleanup

## Test Plan

- [x] Unit tests pass (22 new tests)
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual testing on iOS Safari
- [ ] Manual testing on Android Chrome

Closes #1270