### PR TITLE
feat(obsidian-plugin): Enable 'Rename to UID' command for all assets with mismatched filenames

### DIFF
--- a/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
+++ b/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
@@ -70,7 +70,6 @@ export function canRepairFolder(context: CommandVisibilityContext): boolean {
 /**
  * Can execute "Rename to UID" command
  * Available for: Any asset where filename doesn't match exo__Asset_uid
- * Excluded: ims__Concept assets (concepts should keep their semantic names)
  */
 export function canRenameToUid(
   context: CommandVisibilityContext,
@@ -78,8 +77,6 @@ export function canRenameToUid(
 ): boolean {
   const uid = context.metadata.exo__Asset_uid;
   if (!uid) return false;
-
-  if (hasClass(context.instanceClass, AssetClass.CONCEPT)) return false;
 
   return currentFilename !== uid;
 }


### PR DESCRIPTION
## Summary

Remove the class-based restriction that previously excluded `ims__Concept` assets from the "Rename to UID" command.

### Changes

- Removed the `ims__Concept` exclusion from `canRenameToUid()` in `AssetVisibilityRules.ts`
- Updated the JSDoc comment to reflect the new unified behavior

### Behavior After Change

The command is now available for **ALL** asset types where:
- Asset has `exo__Asset_uid` property
- Current filename doesn't match the UID

This provides a unified, consistent behavior across all asset types without special-casing based on asset class.

Closes #1298