### PR TITLE
fix: bug: Wikilinks in body not replaced with target asset's exo:Asset_label

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLTableView.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/sparql/SPARQLTableView.tsx
@@ -1,5 +1,9 @@
 import React, { useState, useMemo } from "react";
 import type { SolutionMapping } from "exocortex";
+import {
+  containsWikilinks,
+  parseEmbeddedWikilinks,
+} from "@plugin/presentation/utils/WikilinkLabelResolver";
 
 export interface SPARQLTableViewProps {
   results: SolutionMapping[];
@@ -53,6 +57,7 @@ const renderValue = (
     return "-";
   }
 
+  // Check if the entire value is a standalone wikilink
   if (isWikiLink(value)) {
     const parsed = parseWikiLink(value);
     let displayText: string;
@@ -82,6 +87,36 @@ const renderValue = (
       >
         {displayText}
       </a>
+    );
+  }
+
+  // Check if value contains embedded wikilinks (e.g., "• [[uuid]]" or "text [[link]] more")
+  if (containsWikilinks(value)) {
+    const segments = parseEmbeddedWikilinks(value, getAssetLabel);
+
+    return (
+      <>
+        {segments.map((segment, index) => {
+          if (segment.type === "wikilink" && segment.target) {
+            return (
+              <a
+                key={index}
+                data-href={segment.target}
+                className="internal-link"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onAssetClick?.(segment.target!, e);
+                }}
+                style={{ cursor: "pointer" }}
+              >
+                {segment.displayText}
+              </a>
+            );
+          }
+          return <React.Fragment key={index}>{segment.content}</React.Fragment>;
+        })}
+      </>
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes issue where wikilinks embedded within text content (e.g., `• [[uuid]]`) were not being resolved to display the target asset's `exo:Asset_label`. 

### Root Cause
The existing `isWikiLink` check used a regex `^\[\[.*?\]\]$` which only matched **standalone** wikilinks, not wikilinks embedded within text.

### Changes
- Added `containsWikilinks()` utility function to detect any wikilinks in text
- Added `parseEmbeddedWikilinks()` utility to segment text into text and wikilink parts
- Updated `renderValue` in both `SPARQLTableView.tsx` and `SPARQLListView.tsx` to handle embedded wikilinks by rendering them as clickable links with resolved labels
- Added 14 comprehensive tests for the new utility functions

### Test Plan
- [x] Existing tests pass (38 WikilinkLabelResolver tests)
- [x] Build compiles successfully
- [x] New tests for `containsWikilinks()` and `parseEmbeddedWikilinks()`

Closes #1306