### PR TITLE
docs: add user guide for graph export functionality

### DIFF
--- a/packages/obsidian-plugin/docs/graph-view/README.md
+++ b/packages/obsidian-plugin/docs/graph-view/README.md
@@ -52,6 +52,7 @@ simulation.start();
 - [Styling](./guides/styling.md) - Node/edge customization
 - [Interactions](./guides/interactions.md) - Selection, drag, zoom, context menus
 - [Performance](./guides/performance.md) - Large graph optimization
+- [Export](./guides/export.md) - PNG, JPEG, WebP, SVG export
 - [Accessibility](./guides/accessibility.md) - WCAG compliance and screen readers
 - [Migration](./guides/migration.md) - Version upgrade guide
 
@@ -61,6 +62,7 @@ simulation.start();
 - [ForceSimulation](./api/physics-engine.md) - Physics simulation API
 - [LayoutManager](./api/layout-engine.md) - Layout algorithms API
 - [PixiGraphRenderer](./api/renderer.md) - WebGL2 renderer API
+- [ExportManager](./api/export-manager.md) - Image export API
 - [Events](./api/events.md) - Event system reference
 
 ### Examples
@@ -69,6 +71,7 @@ simulation.start();
 - [Custom Layout](./examples/custom-layout.md) - Custom layout implementation
 - [Semantic Graph](./examples/semantic-graph.md) - RDF/SPARQL integration
 - [Large Scale](./examples/large-scale.md) - 100K+ node optimization
+- [Export](./examples/export.md) - Image export examples
 
 ### Architecture
 - [Overview](./architecture/overview.md) - High-level architecture

--- a/packages/obsidian-plugin/docs/graph-view/api/export-manager.md
+++ b/packages/obsidian-plugin/docs/graph-view/api/export-manager.md
@@ -1,0 +1,471 @@
+# ExportManager API
+
+The `ExportManager` class provides graph export functionality supporting PNG, JPEG, WebP, and SVG formats with high-DPI display support.
+
+## Import
+
+```typescript
+import {
+  ExportManager,
+  createExportManager,
+  type ExportOptions,
+  type ExportResult,
+  type ExportNode,
+  type ExportEdge,
+  type ExportEvent,
+  type ExportManagerConfig,
+  type ExportStats,
+} from "@exocortex/obsidian-plugin";
+```
+
+## Class: ExportManager
+
+### Constructor
+
+```typescript
+new ExportManager(config?: Partial<ExportManagerConfig>)
+```
+
+Creates a new ExportManager instance with optional configuration.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `config` | `Partial<ExportManagerConfig>` | Optional configuration overrides |
+
+**Example:**
+
+```typescript
+const manager = new ExportManager({
+  maxDimension: 8192,
+  timeout: 60000,
+  defaultOptions: {
+    format: "png",
+    scale: 2,
+  },
+});
+```
+
+### Methods
+
+#### export()
+
+```typescript
+async export(
+  nodes: ExportNode[],
+  edges: ExportEdge[],
+  options?: Partial<ExportOptions>
+): Promise<ExportResult>
+```
+
+Export graph to specified format.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `nodes` | `ExportNode[]` | Array of nodes to export |
+| `edges` | `ExportEdge[]` | Array of edges to export |
+| `options` | `Partial<ExportOptions>` | Export options |
+
+**Returns:** `Promise<ExportResult>` - Export result containing blob, data URL, dimensions
+
+**Throws:**
+- `Error` if dimensions exceed maximum allowed
+- `Error` if canvas context creation fails
+- `Error` if blob creation fails
+
+**Example:**
+
+```typescript
+const result = await manager.export(nodes, edges, {
+  format: "png",
+  scale: 2,
+  backgroundColor: "#ffffff",
+});
+```
+
+#### download()
+
+```typescript
+download(result: ExportResult, filename?: string): void
+```
+
+Download export result as file.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `result` | `ExportResult` | - | Export result to download |
+| `filename` | `string` | `"graph-export"` | Filename without extension |
+
+**Example:**
+
+```typescript
+manager.download(result, "my-knowledge-graph");
+// Downloads: my-knowledge-graph.png
+```
+
+#### copyToClipboard()
+
+```typescript
+async copyToClipboard(result: ExportResult): Promise<void>
+```
+
+Copy export result to clipboard.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result` | `ExportResult` | Export result to copy |
+
+**Notes:**
+- Raster formats (PNG, JPEG, WebP) are copied as images
+- SVG format is copied as text
+
+**Example:**
+
+```typescript
+await manager.copyToClipboard(result);
+```
+
+#### cancel()
+
+```typescript
+cancel(): void
+```
+
+Cancel ongoing export operation.
+
+**Example:**
+
+```typescript
+const exportPromise = manager.export(nodes, edges);
+
+// Later...
+manager.cancel();
+```
+
+#### addEventListener()
+
+```typescript
+addEventListener(listener: ExportEventListener): void
+```
+
+Add event listener for export events.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `listener` | `ExportEventListener` | Event handler function |
+
+**Example:**
+
+```typescript
+manager.addEventListener((event) => {
+  if (event.type === "progress") {
+    console.log(`Progress: ${event.progress}%`);
+  }
+});
+```
+
+#### removeEventListener()
+
+```typescript
+removeEventListener(listener: ExportEventListener): void
+```
+
+Remove event listener.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `listener` | `ExportEventListener` | Event handler to remove |
+
+#### getStats()
+
+```typescript
+getStats(): ExportStats
+```
+
+Get export statistics.
+
+**Returns:** `ExportStats` - Copy of current statistics
+
+**Example:**
+
+```typescript
+const stats = manager.getStats();
+console.log(`Success rate: ${stats.successfulExports / stats.totalExports * 100}%`);
+```
+
+#### resetStats()
+
+```typescript
+resetStats(): void
+```
+
+Reset export statistics to zero.
+
+## Factory Function
+
+### createExportManager()
+
+```typescript
+function createExportManager(
+  config?: Partial<ExportManagerConfig>
+): ExportManager
+```
+
+Factory function to create ExportManager instance.
+
+**Example:**
+
+```typescript
+const manager = createExportManager({
+  defaultOptions: { format: "svg" },
+});
+```
+
+## Types
+
+### ExportFormat
+
+```typescript
+type ExportFormat = "png" | "jpeg" | "webp" | "svg";
+```
+
+Supported export formats.
+
+### ExportOptions
+
+```typescript
+interface ExportOptions {
+  format: ExportFormat;        // Output format (default: "png")
+  quality: number;             // Quality 0-1 for lossy formats (default: 0.92)
+  scale: number;               // DPI scale factor (default: devicePixelRatio)
+  backgroundColor: string | null;  // Background color or null for transparent
+  padding: number;             // Padding in pixels (default: 50)
+  includeLabels: boolean;      // Include node labels (default: true)
+  includeEdges: boolean;       // Include edges (default: true)
+  customBounds?: ExportBounds; // Custom export region
+  metadata?: Record<string, string>;  // Metadata for PNG/SVG
+  filename?: string;           // Download filename
+}
+```
+
+### ExportBounds
+
+```typescript
+interface ExportBounds {
+  x: number;      // Top-left X coordinate
+  y: number;      // Top-left Y coordinate
+  width: number;  // Export width
+  height: number; // Export height
+}
+```
+
+### ExportResult
+
+```typescript
+interface ExportResult {
+  blob: Blob;       // Binary data
+  dataUrl: string;  // Base64 data URL
+  width: number;    // Pixel width
+  height: number;   // Pixel height
+  format: ExportFormat;  // Format used
+  fileSize: number; // File size in bytes
+}
+```
+
+### ExportNode
+
+```typescript
+interface ExportNode {
+  id: string;       // Unique identifier
+  label: string;    // Display text
+  x: number;        // X coordinate
+  y: number;        // Y coordinate
+  radius?: number;  // Node radius (default: 8)
+  color?: number | string;  // Fill color
+  group?: string;   // Category for styling
+}
+```
+
+### ExportEdge
+
+```typescript
+interface ExportEdge {
+  id: string;       // Unique identifier
+  sourceId: string; // Source node ID
+  targetId: string; // Target node ID
+  label?: string;   // Edge label
+  color?: number | string;  // Line color
+  width?: number;   // Line width (default: 1)
+}
+```
+
+### ExportEvent
+
+```typescript
+interface ExportEvent {
+  type: ExportEventType;
+  progress?: number;     // 0-100 for progress events
+  result?: ExportResult; // For complete events
+  error?: Error;         // For error events
+  timestamp: number;     // Event timestamp
+}
+
+type ExportEventType = "start" | "progress" | "complete" | "error" | "cancel";
+```
+
+### ExportEventListener
+
+```typescript
+type ExportEventListener = (event: ExportEvent) => void;
+```
+
+### ExportManagerConfig
+
+```typescript
+interface ExportManagerConfig {
+  defaultOptions: Partial<ExportOptions>;  // Default export options
+  maxDimension: number;   // Maximum dimension (default: 16384)
+  timeout: number;        // Timeout in ms (default: 30000)
+  showProgress: boolean;  // Show progress (default: true)
+}
+```
+
+### ExportStats
+
+```typescript
+interface ExportStats {
+  totalExports: number;      // Total export count
+  successfulExports: number; // Successful count
+  failedExports: number;     // Failed count
+  lastExportTime?: number;   // Last export timestamp
+  averageDuration: number;   // Average duration in ms
+}
+```
+
+## Constants
+
+### DEFAULT_EXPORT_OPTIONS
+
+```typescript
+const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
+  format: "png",
+  quality: 0.92,
+  scale: window.devicePixelRatio || 1,
+  backgroundColor: "#ffffff",
+  padding: 50,
+  includeLabels: true,
+  includeEdges: true,
+};
+```
+
+### DEFAULT_EXPORT_MANAGER_CONFIG
+
+```typescript
+const DEFAULT_EXPORT_MANAGER_CONFIG: ExportManagerConfig = {
+  defaultOptions: DEFAULT_EXPORT_OPTIONS,
+  maxDimension: 16384,
+  timeout: 30000,
+  showProgress: true,
+};
+```
+
+### EXPORT_MIME_TYPES
+
+```typescript
+const EXPORT_MIME_TYPES: Record<ExportFormat, string> = {
+  png: "image/png",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+};
+```
+
+### EXPORT_FILE_EXTENSIONS
+
+```typescript
+const EXPORT_FILE_EXTENSIONS: Record<ExportFormat, string> = {
+  png: ".png",
+  jpeg: ".jpg",
+  webp: ".webp",
+  svg: ".svg",
+};
+```
+
+## Events
+
+The ExportManager emits events during export:
+
+| Event | When | Properties |
+|-------|------|------------|
+| `start` | Export begins | `timestamp` |
+| `progress` | During export | `progress` (0-100), `timestamp` |
+| `complete` | Export succeeds | `result`, `timestamp` |
+| `error` | Export fails | `error`, `timestamp` |
+| `cancel` | Export cancelled | `timestamp` |
+
+**Example:**
+
+```typescript
+manager.addEventListener((event) => {
+  switch (event.type) {
+    case "start":
+      showSpinner();
+      break;
+    case "progress":
+      updateProgress(event.progress!);
+      break;
+    case "complete":
+      hideSpinner();
+      displayImage(event.result!.dataUrl);
+      break;
+    case "error":
+      hideSpinner();
+      showError(event.error!.message);
+      break;
+    case "cancel":
+      hideSpinner();
+      break;
+  }
+});
+```
+
+## Error Handling
+
+The export method throws errors for:
+
+| Error Message | Cause | Solution |
+|---------------|-------|----------|
+| `"Export dimensions exceed maximum"` | Graph too large | Reduce scale or use custom bounds |
+| `"Export dimensions must be positive"` | Invalid bounds | Ensure width/height > 0 |
+| `"Failed to create canvas context"` | Browser limitation | Try smaller export |
+| `"Failed to create blob from canvas"` | Memory issue | Reduce scale or graph size |
+
+**Example:**
+
+```typescript
+try {
+  const result = await manager.export(nodes, edges);
+} catch (error) {
+  if (error.message.includes("exceed maximum")) {
+    // Try with lower scale
+    const result = await manager.export(nodes, edges, { scale: 1 });
+  }
+}
+```
+
+## See Also
+
+- [Export Guide](../guides/export.md) - User guide with examples
+- [Export Examples](../examples/export.md) - Copy-paste code samples
+- [API Overview](./index.md) - Full API reference

--- a/packages/obsidian-plugin/docs/graph-view/api/index.md
+++ b/packages/obsidian-plugin/docs/graph-view/api/index.md
@@ -267,6 +267,9 @@ renderer.destroy();
 - [LayoutManager](./layout-engine.md) - Layout algorithms
 - [PixiGraphRenderer](./renderer.md) - WebGL2 rendering
 
+### Export
+- [ExportManager](./export-manager.md) - Image export (PNG, JPEG, WebP, SVG)
+
 ### Event System
 - [Events](./events.md) - Event types and handlers
 

--- a/packages/obsidian-plugin/docs/graph-view/examples/export.md
+++ b/packages/obsidian-plugin/docs/graph-view/examples/export.md
@@ -1,0 +1,506 @@
+# Graph Export Examples
+
+Complete, copy-paste ready examples for exporting graphs to various formats.
+
+## Basic Export
+
+Export a simple graph to PNG:
+
+```typescript
+import {
+  ExportManager,
+  type ExportNode,
+  type ExportEdge,
+} from "@exocortex/obsidian-plugin";
+
+// Sample graph data
+const nodes: ExportNode[] = [
+  { id: "philosophy", label: "Philosophy", x: 0, y: 0, color: "#6366f1", radius: 14 },
+  { id: "science", label: "Science", x: 150, y: -50, color: "#22c55e", radius: 12 },
+  { id: "art", label: "Art", x: 150, y: 50, color: "#f59e0b", radius: 12 },
+  { id: "mathematics", label: "Mathematics", x: 300, y: -100, color: "#ef4444", radius: 10 },
+  { id: "physics", label: "Physics", x: 300, y: 0, color: "#22c55e", radius: 10 },
+  { id: "music", label: "Music", x: 300, y: 100, color: "#f59e0b", radius: 10 },
+];
+
+const edges: ExportEdge[] = [
+  { id: "e1", sourceId: "philosophy", targetId: "science", color: "#64748b" },
+  { id: "e2", sourceId: "philosophy", targetId: "art", color: "#64748b" },
+  { id: "e3", sourceId: "science", targetId: "mathematics", color: "#64748b" },
+  { id: "e4", sourceId: "science", targetId: "physics", color: "#64748b" },
+  { id: "e5", sourceId: "art", targetId: "music", color: "#64748b" },
+];
+
+// Create export manager and export
+const exportManager = new ExportManager();
+
+const result = await exportManager.export(nodes, edges, {
+  format: "png",
+  scale: 2,
+  backgroundColor: "#1e293b",
+  padding: 50,
+  includeLabels: true,
+  includeEdges: true,
+});
+
+// Download the file
+exportManager.download(result, "knowledge-tree");
+
+console.log(`Exported ${result.width}x${result.height} PNG (${(result.fileSize / 1024).toFixed(1)} KB)`);
+```
+
+## Export All Formats
+
+Export the same graph to all supported formats for comparison:
+
+```typescript
+import {
+  ExportManager,
+  createExportManager,
+  type ExportNode,
+  type ExportEdge,
+  type ExportFormat,
+} from "@exocortex/obsidian-plugin";
+
+const nodes: ExportNode[] = [
+  { id: "n1", label: "Central", x: 200, y: 200, color: "#6366f1", radius: 16 },
+  { id: "n2", label: "North", x: 200, y: 50, color: "#22c55e", radius: 10 },
+  { id: "n3", label: "East", x: 350, y: 200, color: "#f59e0b", radius: 10 },
+  { id: "n4", label: "South", x: 200, y: 350, color: "#ef4444", radius: 10 },
+  { id: "n5", label: "West", x: 50, y: 200, color: "#8b5cf6", radius: 10 },
+];
+
+const edges: ExportEdge[] = [
+  { id: "e1", sourceId: "n1", targetId: "n2", width: 2 },
+  { id: "e2", sourceId: "n1", targetId: "n3", width: 2 },
+  { id: "e3", sourceId: "n1", targetId: "n4", width: 2 },
+  { id: "e4", sourceId: "n1", targetId: "n5", width: 2 },
+];
+
+const exportManager = createExportManager();
+
+// Export to all formats
+const formats: ExportFormat[] = ["png", "jpeg", "webp", "svg"];
+const results: { format: ExportFormat; size: number }[] = [];
+
+for (const format of formats) {
+  const result = await exportManager.export(nodes, edges, {
+    format,
+    scale: 2,
+    quality: 0.92,
+    backgroundColor: "#ffffff",
+    padding: 60,
+  });
+
+  results.push({ format, size: result.fileSize });
+  exportManager.download(result, `graph-comparison-${format}`);
+}
+
+// Compare file sizes
+console.log("Format comparison:");
+for (const r of results) {
+  console.log(`  ${r.format.toUpperCase()}: ${(r.size / 1024).toFixed(1)} KB`);
+}
+```
+
+## High-Resolution Print Export
+
+Export for print at 300 DPI:
+
+```typescript
+import { ExportManager, type ExportNode, type ExportEdge } from "@exocortex/obsidian-plugin";
+
+const nodes: ExportNode[] = [
+  { id: "root", label: "Research Project", x: 400, y: 50, color: "#1e40af", radius: 20 },
+  { id: "lit", label: "Literature Review", x: 200, y: 200, color: "#0891b2", radius: 14 },
+  { id: "method", label: "Methodology", x: 400, y: 200, color: "#059669", radius: 14 },
+  { id: "data", label: "Data Collection", x: 600, y: 200, color: "#ca8a04", radius: 14 },
+  { id: "analysis", label: "Analysis", x: 300, y: 350, color: "#dc2626", radius: 14 },
+  { id: "conclusion", label: "Conclusions", x: 500, y: 350, color: "#7c3aed", radius: 14 },
+];
+
+const edges: ExportEdge[] = [
+  { id: "e1", sourceId: "root", targetId: "lit", width: 2 },
+  { id: "e2", sourceId: "root", targetId: "method", width: 2 },
+  { id: "e3", sourceId: "root", targetId: "data", width: 2 },
+  { id: "e4", sourceId: "lit", targetId: "analysis", width: 2 },
+  { id: "e5", sourceId: "method", targetId: "analysis", width: 2 },
+  { id: "e6", sourceId: "data", targetId: "analysis", width: 2 },
+  { id: "e7", sourceId: "analysis", targetId: "conclusion", width: 2 },
+];
+
+const exportManager = new ExportManager();
+
+// Export as SVG for infinite scalability
+const svgResult = await exportManager.export(nodes, edges, {
+  format: "svg",
+  scale: 3, // 3x for high DPI printing
+  backgroundColor: "#ffffff",
+  padding: 100,
+  includeLabels: true,
+  metadata: {
+    title: "Research Project Structure",
+    author: "Research Team",
+    description: "High-level project workflow diagram",
+    created: new Date().toISOString(),
+  },
+});
+
+exportManager.download(svgResult, "research-project-print");
+
+// Also export high-res PNG for presentations
+const pngResult = await exportManager.export(nodes, edges, {
+  format: "png",
+  scale: 4, // 4x scale = ~384 DPI on standard displays
+  backgroundColor: "#ffffff",
+  padding: 100,
+});
+
+exportManager.download(pngResult, "research-project-presentation");
+
+console.log(`SVG: ${(svgResult.fileSize / 1024).toFixed(1)} KB (vector, infinite scale)`);
+console.log(`PNG: ${(pngResult.fileSize / 1024).toFixed(1)} KB (${pngResult.width}x${pngResult.height}px)`);
+```
+
+## Transparent Background for Overlays
+
+Export with transparency for use in presentations or designs:
+
+```typescript
+import { ExportManager, type ExportNode, type ExportEdge } from "@exocortex/obsidian-plugin";
+
+const nodes: ExportNode[] = [
+  { id: "a", label: "Concept A", x: 100, y: 100, color: "#3b82f6", radius: 15 },
+  { id: "b", label: "Concept B", x: 250, y: 80, color: "#10b981", radius: 12 },
+  { id: "c", label: "Concept C", x: 250, y: 150, color: "#f59e0b", radius: 12 },
+  { id: "d", label: "Concept D", x: 400, y: 100, color: "#ef4444", radius: 15 },
+];
+
+const edges: ExportEdge[] = [
+  { id: "e1", sourceId: "a", targetId: "b", color: "#94a3b8", width: 2 },
+  { id: "e2", sourceId: "a", targetId: "c", color: "#94a3b8", width: 2 },
+  { id: "e3", sourceId: "b", targetId: "d", color: "#94a3b8", width: 2 },
+  { id: "e4", sourceId: "c", targetId: "d", color: "#94a3b8", width: 2 },
+];
+
+const exportManager = new ExportManager();
+
+// PNG with transparent background
+const result = await exportManager.export(nodes, edges, {
+  format: "png",
+  scale: 2,
+  backgroundColor: null, // Transparent!
+  padding: 40,
+});
+
+exportManager.download(result, "concept-overlay");
+console.log("Exported PNG with transparent background");
+
+// WebP also supports transparency
+const webpResult = await exportManager.export(nodes, edges, {
+  format: "webp",
+  scale: 2,
+  quality: 0.9,
+  backgroundColor: null,
+  padding: 40,
+});
+
+exportManager.download(webpResult, "concept-overlay-webp");
+console.log(`WebP transparent: ${(webpResult.fileSize / 1024).toFixed(1)} KB`);
+```
+
+## Export with Progress Monitoring
+
+Show export progress for large graphs:
+
+```typescript
+import {
+  ExportManager,
+  type ExportNode,
+  type ExportEdge,
+  type ExportEvent,
+} from "@exocortex/obsidian-plugin";
+
+// Generate large graph
+function generateLargeGraph(nodeCount: number): { nodes: ExportNode[]; edges: ExportEdge[] } {
+  const nodes: ExportNode[] = [];
+  const edges: ExportEdge[] = [];
+
+  const colors = ["#6366f1", "#22c55e", "#f59e0b", "#ef4444", "#8b5cf6"];
+
+  for (let i = 0; i < nodeCount; i++) {
+    const angle = (i / nodeCount) * Math.PI * 2;
+    const radius = 200 + Math.random() * 100;
+
+    nodes.push({
+      id: `node-${i}`,
+      label: `Node ${i}`,
+      x: 300 + Math.cos(angle) * radius,
+      y: 300 + Math.sin(angle) * radius,
+      color: colors[i % colors.length],
+      radius: 6 + Math.random() * 4,
+    });
+
+    // Connect to previous nodes
+    if (i > 0) {
+      const connectTo = Math.floor(Math.random() * i);
+      edges.push({
+        id: `edge-${i}`,
+        sourceId: `node-${i}`,
+        targetId: `node-${connectTo}`,
+        color: "#64748b",
+      });
+    }
+  }
+
+  return { nodes, edges };
+}
+
+// Create UI elements
+const progressBar = document.getElementById("progress-bar") as HTMLProgressElement;
+const statusText = document.getElementById("status") as HTMLSpanElement;
+const cancelBtn = document.getElementById("cancel-btn") as HTMLButtonElement;
+
+const { nodes, edges } = generateLargeGraph(500);
+const exportManager = new ExportManager();
+
+// Set up progress listener
+exportManager.addEventListener((event: ExportEvent) => {
+  switch (event.type) {
+    case "start":
+      statusText.textContent = "Starting export...";
+      progressBar.value = 0;
+      cancelBtn.disabled = false;
+      break;
+
+    case "progress":
+      progressBar.value = event.progress ?? 0;
+      statusText.textContent = `Exporting: ${event.progress}%`;
+      break;
+
+    case "complete":
+      statusText.textContent = `Complete! ${(event.result!.fileSize / 1024).toFixed(1)} KB`;
+      progressBar.value = 100;
+      cancelBtn.disabled = true;
+      break;
+
+    case "error":
+      statusText.textContent = `Error: ${event.error?.message}`;
+      cancelBtn.disabled = true;
+      break;
+
+    case "cancel":
+      statusText.textContent = "Export cancelled";
+      cancelBtn.disabled = true;
+      break;
+  }
+});
+
+// Cancel button handler
+cancelBtn.onclick = () => exportManager.cancel();
+
+// Start export
+try {
+  const result = await exportManager.export(nodes, edges, {
+    format: "png",
+    scale: 2,
+    backgroundColor: "#0f172a",
+    padding: 50,
+  });
+
+  exportManager.download(result, "large-graph");
+} catch (error) {
+  console.error("Export failed:", error);
+}
+```
+
+## Partial Graph Export
+
+Export only a specific region of a large graph:
+
+```typescript
+import { ExportManager, type ExportNode, type ExportEdge } from "@exocortex/obsidian-plugin";
+
+// Large graph with many nodes spread across a wide area
+const nodes: ExportNode[] = [
+  // Cluster 1 (top-left region)
+  { id: "c1-1", label: "Cluster 1 - A", x: 100, y: 100, color: "#3b82f6" },
+  { id: "c1-2", label: "Cluster 1 - B", x: 150, y: 80, color: "#3b82f6" },
+  { id: "c1-3", label: "Cluster 1 - C", x: 200, y: 120, color: "#3b82f6" },
+
+  // Cluster 2 (center region)
+  { id: "c2-1", label: "Cluster 2 - A", x: 450, y: 300, color: "#22c55e" },
+  { id: "c2-2", label: "Cluster 2 - B", x: 500, y: 250, color: "#22c55e" },
+  { id: "c2-3", label: "Cluster 2 - C", x: 550, y: 320, color: "#22c55e" },
+
+  // Cluster 3 (bottom-right region)
+  { id: "c3-1", label: "Cluster 3 - A", x: 800, y: 500, color: "#f59e0b" },
+  { id: "c3-2", label: "Cluster 3 - B", x: 850, y: 480, color: "#f59e0b" },
+  { id: "c3-3", label: "Cluster 3 - C", x: 900, y: 520, color: "#f59e0b" },
+];
+
+const edges: ExportEdge[] = [
+  // Intra-cluster edges
+  { id: "e1", sourceId: "c1-1", targetId: "c1-2" },
+  { id: "e2", sourceId: "c1-2", targetId: "c1-3" },
+  { id: "e3", sourceId: "c2-1", targetId: "c2-2" },
+  { id: "e4", sourceId: "c2-2", targetId: "c2-3" },
+  { id: "e5", sourceId: "c3-1", targetId: "c3-2" },
+  { id: "e6", sourceId: "c3-2", targetId: "c3-3" },
+  // Inter-cluster edges
+  { id: "e7", sourceId: "c1-3", targetId: "c2-1" },
+  { id: "e8", sourceId: "c2-3", targetId: "c3-1" },
+];
+
+const exportManager = new ExportManager();
+
+// Export only Cluster 2 (center region)
+const cluster2Result = await exportManager.export(nodes, edges, {
+  format: "png",
+  scale: 2,
+  backgroundColor: "#1e293b",
+  customBounds: {
+    x: 400,   // Left edge of export region
+    y: 200,   // Top edge of export region
+    width: 200,  // Export width
+    height: 200, // Export height
+  },
+});
+
+exportManager.download(cluster2Result, "cluster-2-detail");
+console.log(`Cluster 2 export: ${cluster2Result.width}x${cluster2Result.height}px`);
+
+// Export full graph for comparison
+const fullResult = await exportManager.export(nodes, edges, {
+  format: "png",
+  scale: 1, // Lower scale for full graph
+  backgroundColor: "#1e293b",
+  padding: 50,
+});
+
+exportManager.download(fullResult, "full-graph-overview");
+console.log(`Full graph: ${fullResult.width}x${fullResult.height}px`);
+```
+
+## Copy to Clipboard
+
+Export and copy directly to clipboard for pasting:
+
+```typescript
+import { ExportManager, type ExportNode, type ExportEdge } from "@exocortex/obsidian-plugin";
+
+const nodes: ExportNode[] = [
+  { id: "idea", label: "Main Idea", x: 200, y: 100, color: "#6366f1", radius: 14 },
+  { id: "sub1", label: "Sub-topic 1", x: 100, y: 200, color: "#22c55e", radius: 10 },
+  { id: "sub2", label: "Sub-topic 2", x: 200, y: 250, color: "#22c55e", radius: 10 },
+  { id: "sub3", label: "Sub-topic 3", x: 300, y: 200, color: "#22c55e", radius: 10 },
+];
+
+const edges: ExportEdge[] = [
+  { id: "e1", sourceId: "idea", targetId: "sub1" },
+  { id: "e2", sourceId: "idea", targetId: "sub2" },
+  { id: "e3", sourceId: "idea", targetId: "sub3" },
+];
+
+const exportManager = new ExportManager();
+
+// Export as PNG and copy to clipboard
+const pngResult = await exportManager.export(nodes, edges, {
+  format: "png",
+  scale: 2,
+  backgroundColor: "#ffffff",
+  padding: 30,
+});
+
+await exportManager.copyToClipboard(pngResult);
+console.log("PNG copied to clipboard! Paste into any application.");
+
+// Export as SVG and copy to clipboard (copies as text)
+const svgResult = await exportManager.export(nodes, edges, {
+  format: "svg",
+  scale: 1,
+  backgroundColor: "#ffffff",
+  padding: 30,
+});
+
+await exportManager.copyToClipboard(svgResult);
+console.log("SVG copied to clipboard as text! Paste into code editors or vector apps.");
+```
+
+## Export Statistics Dashboard
+
+Track export metrics over time:
+
+```typescript
+import {
+  ExportManager,
+  type ExportNode,
+  type ExportEdge,
+  type ExportStats,
+} from "@exocortex/obsidian-plugin";
+
+const exportManager = new ExportManager();
+
+// Sample graph
+const nodes: ExportNode[] = [
+  { id: "a", label: "A", x: 100, y: 100, color: "#6366f1" },
+  { id: "b", label: "B", x: 200, y: 100, color: "#22c55e" },
+  { id: "c", label: "C", x: 150, y: 200, color: "#f59e0b" },
+];
+
+const edges: ExportEdge[] = [
+  { id: "e1", sourceId: "a", targetId: "b" },
+  { id: "e2", sourceId: "b", targetId: "c" },
+  { id: "e3", sourceId: "c", targetId: "a" },
+];
+
+// Perform multiple exports
+const formats = ["png", "jpeg", "webp", "svg"] as const;
+
+for (const format of formats) {
+  try {
+    await exportManager.export(nodes, edges, { format });
+    console.log(`${format.toUpperCase()} export successful`);
+  } catch (error) {
+    console.error(`${format.toUpperCase()} export failed:`, error);
+  }
+}
+
+// Intentionally trigger an error
+try {
+  const hugeNodes: ExportNode[] = [
+    { id: "n1", label: "Test", x: 0, y: 0 },
+    { id: "n2", label: "Test", x: 50000, y: 50000 },
+  ];
+  await exportManager.export(hugeNodes, []);
+} catch {
+  console.log("Expected error for oversized export");
+}
+
+// Display statistics
+function displayStats(stats: ExportStats): void {
+  console.log("\n📊 Export Statistics:");
+  console.log(`  Total exports:      ${stats.totalExports}`);
+  console.log(`  Successful:         ${stats.successfulExports}`);
+  console.log(`  Failed:             ${stats.failedExports}`);
+  console.log(`  Success rate:       ${((stats.successfulExports / stats.totalExports) * 100).toFixed(1)}%`);
+  console.log(`  Average duration:   ${stats.averageDuration.toFixed(0)}ms`);
+  if (stats.lastExportTime) {
+    console.log(`  Last export:        ${new Date(stats.lastExportTime).toLocaleString()}`);
+  }
+}
+
+displayStats(exportManager.getStats());
+
+// Reset and start fresh
+exportManager.resetStats();
+console.log("\n🔄 Statistics reset");
+displayStats(exportManager.getStats());
+```
+
+## See Also
+
+- [Export Guide](../guides/export.md) - Complete export documentation
+- [Styling Guide](../guides/styling.md) - Node and edge customization
+- [Performance Guide](../guides/performance.md) - Large graph optimization
+- [API Reference](../api/index.md) - ExportManager API

--- a/packages/obsidian-plugin/docs/graph-view/guides/export.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/export.md
@@ -1,0 +1,480 @@
+# Graph Export Guide
+
+Export your knowledge graphs to various image formats for sharing, presentations, or archival purposes. The Graph View supports PNG, JPEG, WebP, and SVG export with customizable options.
+
+## Quick Start
+
+```typescript
+import { ExportManager } from "@exocortex/obsidian-plugin";
+
+// Create export manager
+const exportManager = new ExportManager();
+
+// Export graph as PNG
+const result = await exportManager.export(nodes, edges, {
+  format: "png",
+  scale: 2,
+  backgroundColor: "#ffffff",
+  padding: 50,
+});
+
+// Download the file
+exportManager.download(result, "my-knowledge-graph");
+```
+
+## Supported Formats
+
+| Format | Extension | Best For | Transparency | Quality Options |
+|--------|-----------|----------|--------------|-----------------|
+| **PNG** | `.png` | General use, highest quality | Yes | N/A (lossless) |
+| **JPEG** | `.jpg` | Photos, smaller files | No | 0.0 - 1.0 |
+| **WebP** | `.webp` | Modern web, best compression | Yes | 0.0 - 1.0 |
+| **SVG** | `.svg` | Print, infinite scaling | Yes | N/A (vector) |
+
+### Format Selection Guide
+
+- **PNG** (Default): Best for general use. Lossless compression preserves all details. Supports transparency.
+- **JPEG**: Best for large graphs where file size matters. No transparency support.
+- **WebP**: Modern format with excellent compression. 25-35% smaller than PNG at same quality.
+- **SVG**: Vector format, scales infinitely without quality loss. Ideal for print or embedding.
+
+## Export Options
+
+### Basic Options
+
+```typescript
+interface ExportOptions {
+  // Output format (default: "png")
+  format: "png" | "jpeg" | "webp" | "svg";
+
+  // Quality for lossy formats (0-1, default: 0.92)
+  quality: number;
+
+  // DPI scale factor (default: window.devicePixelRatio || 1)
+  scale: number;
+
+  // Background color or null for transparent (default: "#ffffff")
+  backgroundColor: string | null;
+
+  // Padding around graph in pixels (default: 50)
+  padding: number;
+
+  // Include node labels (default: true)
+  includeLabels: boolean;
+
+  // Include edges (default: true)
+  includeEdges: boolean;
+}
+```
+
+### Advanced Options
+
+```typescript
+interface AdvancedExportOptions extends ExportOptions {
+  // Custom bounds for export area
+  customBounds?: {
+    x: number;      // Top-left X coordinate
+    y: number;      // Top-left Y coordinate
+    width: number;  // Export width
+    height: number; // Export height
+  };
+
+  // Metadata to embed (PNG, SVG only)
+  metadata?: {
+    title?: string;
+    author?: string;
+    description?: string;
+    [key: string]: string | undefined;
+  };
+
+  // Custom filename for download
+  filename?: string;
+}
+```
+
+## Common Use Cases
+
+### High-Resolution Export for Print
+
+For print materials, use 2x or 3x scale with SVG:
+
+```typescript
+const result = await exportManager.export(nodes, edges, {
+  format: "svg",
+  scale: 3,
+  backgroundColor: "#ffffff",
+  padding: 100,
+  metadata: {
+    title: "Knowledge Graph - Q4 2025",
+    author: "Research Team",
+  },
+});
+
+exportManager.download(result, "knowledge-graph-print");
+```
+
+### Transparent Background for Slides
+
+Export with transparent background for presentation overlays:
+
+```typescript
+const result = await exportManager.export(nodes, edges, {
+  format: "png",
+  scale: 2,
+  backgroundColor: null, // Transparent
+  padding: 50,
+});
+```
+
+### Compact Export for Web
+
+Optimize for web use with WebP and adjusted quality:
+
+```typescript
+const result = await exportManager.export(nodes, edges, {
+  format: "webp",
+  quality: 0.85, // Good balance of quality/size
+  scale: 1,
+  padding: 30,
+});
+
+console.log(`File size: ${(result.fileSize / 1024).toFixed(1)} KB`);
+```
+
+### Export Specific Region
+
+Export only a portion of the graph:
+
+```typescript
+const result = await exportManager.export(nodes, edges, {
+  format: "png",
+  customBounds: {
+    x: 100,
+    y: 100,
+    width: 800,
+    height: 600,
+  },
+});
+```
+
+### Nodes Only (No Edges)
+
+Export just the nodes without edge connections:
+
+```typescript
+const result = await exportManager.export(nodes, edges, {
+  format: "png",
+  includeEdges: false,
+  includeLabels: true,
+});
+```
+
+## Programmatic Export
+
+### Using Export Result
+
+The export result contains all data needed for display or further processing:
+
+```typescript
+interface ExportResult {
+  blob: Blob;       // Binary data
+  dataUrl: string;  // Base64 data URL
+  width: number;    // Pixel width
+  height: number;   // Pixel height
+  format: string;   // Format used
+  fileSize: number; // Bytes
+}
+
+// Display in image element
+const img = document.createElement("img");
+img.src = result.dataUrl;
+document.body.appendChild(img);
+
+// Upload to server
+const formData = new FormData();
+formData.append("image", result.blob, "graph.png");
+await fetch("/api/upload", { method: "POST", body: formData });
+```
+
+### Copy to Clipboard
+
+Copy export directly to clipboard:
+
+```typescript
+await exportManager.copyToClipboard(result);
+
+// For SVG, copies as text
+// For raster formats, copies as image
+```
+
+### Progress Monitoring
+
+Track export progress for large graphs:
+
+```typescript
+exportManager.addEventListener((event) => {
+  switch (event.type) {
+    case "start":
+      console.log("Export started");
+      showSpinner();
+      break;
+
+    case "progress":
+      console.log(`Progress: ${event.progress}%`);
+      updateProgressBar(event.progress);
+      break;
+
+    case "complete":
+      console.log("Export complete", event.result);
+      hideSpinner();
+      break;
+
+    case "error":
+      console.error("Export failed:", event.error);
+      showError(event.error.message);
+      break;
+
+    case "cancel":
+      console.log("Export cancelled");
+      hideSpinner();
+      break;
+  }
+});
+```
+
+### Cancel Export
+
+Cancel a long-running export:
+
+```typescript
+// Start export
+const exportPromise = exportManager.export(nodes, edges, options);
+
+// Cancel button handler
+cancelButton.onclick = () => {
+  exportManager.cancel();
+};
+```
+
+## Export Statistics
+
+Track export metrics for monitoring or debugging:
+
+```typescript
+// After multiple exports
+const stats = exportManager.getStats();
+
+console.log(`Total exports: ${stats.totalExports}`);
+console.log(`Successful: ${stats.successfulExports}`);
+console.log(`Failed: ${stats.failedExports}`);
+console.log(`Average duration: ${stats.averageDuration.toFixed(0)}ms`);
+
+// Reset statistics
+exportManager.resetStats();
+```
+
+## Configuration
+
+### Manager Configuration
+
+Configure default behavior at construction:
+
+```typescript
+import { ExportManager, type ExportManagerConfig } from "@exocortex/obsidian-plugin";
+
+const config: Partial<ExportManagerConfig> = {
+  // Maximum export dimension (default: 16384)
+  maxDimension: 8192,
+
+  // Export timeout in ms (default: 30000)
+  timeout: 60000,
+
+  // Show progress notifications (default: true)
+  showProgress: true,
+
+  // Default export options
+  defaultOptions: {
+    format: "png",
+    scale: 2,
+    backgroundColor: "#1a1a2e",
+    padding: 100,
+  },
+};
+
+const exportManager = new ExportManager(config);
+```
+
+### Factory Function
+
+Use the factory function for quick setup:
+
+```typescript
+import { createExportManager } from "@exocortex/obsidian-plugin";
+
+const exportManager = createExportManager({
+  maxDimension: 8192,
+  defaultOptions: {
+    format: "svg",
+    scale: 2,
+  },
+});
+```
+
+## Node and Edge Data
+
+### Node Format
+
+Nodes require position and label information:
+
+```typescript
+interface ExportNode {
+  id: string;       // Unique identifier
+  label: string;    // Display text
+  x: number;        // X position
+  y: number;        // Y position
+  radius?: number;  // Node size (default: 8)
+  color?: number | string;  // Fill color (hex)
+  group?: string;   // Category for styling
+}
+
+// Example nodes
+const nodes: ExportNode[] = [
+  { id: "1", label: "Philosophy", x: 100, y: 100, radius: 12, color: "#6366f1" },
+  { id: "2", label: "Science", x: 200, y: 150, radius: 10, color: "#22c55e" },
+  { id: "3", label: "Art", x: 150, y: 250, radius: 8, color: "#f59e0b" },
+];
+```
+
+### Edge Format
+
+Edges connect nodes by ID:
+
+```typescript
+interface ExportEdge {
+  id: string;       // Unique identifier
+  sourceId: string; // Source node ID
+  targetId: string; // Target node ID
+  label?: string;   // Edge label
+  color?: number | string;  // Line color
+  width?: number;   // Line width (default: 1)
+}
+
+// Example edges
+const edges: ExportEdge[] = [
+  { id: "e1", sourceId: "1", targetId: "2", color: "#64748b" },
+  { id: "e2", sourceId: "2", targetId: "3", width: 2 },
+  { id: "e3", sourceId: "1", targetId: "3", label: "influences" },
+];
+```
+
+## Best Practices
+
+### Performance Tips
+
+1. **Large graphs**: Use lower scale (1x) and PNG for fastest export
+2. **High quality**: Use SVG for infinite scalability
+3. **File size**: Use WebP with 0.85 quality for best compression
+4. **Memory**: Monitor `maxDimension` to prevent browser crashes
+
+### Quality Guidelines
+
+| Use Case | Format | Scale | Quality |
+|----------|--------|-------|---------|
+| Web preview | WebP | 1x | 0.8 |
+| Documentation | PNG | 2x | N/A |
+| Presentation | PNG | 2x | N/A |
+| Print (300 DPI) | SVG | 3x | N/A |
+| Social media | JPEG | 1x | 0.9 |
+
+### Error Handling
+
+```typescript
+try {
+  const result = await exportManager.export(nodes, edges, options);
+  exportManager.download(result, "my-graph");
+} catch (error) {
+  if (error.message.includes("exceed maximum")) {
+    // Dimensions too large
+    console.error("Graph too large. Try reducing scale or using custom bounds.");
+  } else if (error.message.includes("canvas context")) {
+    // Browser limitation
+    console.error("Browser canvas error. Try a smaller export.");
+  } else {
+    console.error("Export failed:", error.message);
+  }
+}
+```
+
+## Troubleshooting
+
+### Export Fails with "exceed maximum" Error
+
+The export dimensions exceed browser limits. Solutions:
+
+```typescript
+// Option 1: Reduce scale
+const result = await exportManager.export(nodes, edges, {
+  scale: 1, // Instead of 2 or higher
+});
+
+// Option 2: Use custom bounds for partial export
+const result = await exportManager.export(nodes, edges, {
+  customBounds: { x: 0, y: 0, width: 2000, height: 2000 },
+});
+
+// Option 3: Configure lower max dimension
+const manager = new ExportManager({ maxDimension: 8192 });
+```
+
+### Transparent Background Shows Black
+
+PNG and WebP support transparency, but JPEG does not:
+
+```typescript
+// Wrong: JPEG doesn't support transparency
+const result = await exportManager.export(nodes, edges, {
+  format: "jpeg",
+  backgroundColor: null, // Will be black!
+});
+
+// Correct: Use PNG or WebP for transparency
+const result = await exportManager.export(nodes, edges, {
+  format: "png",
+  backgroundColor: null, // Transparent works!
+});
+```
+
+### Labels Appear Blurry
+
+Increase scale factor for sharper text:
+
+```typescript
+const result = await exportManager.export(nodes, edges, {
+  scale: 2, // Minimum 2x for readable labels
+  includeLabels: true,
+});
+```
+
+### SVG Export Not Rendering Correctly
+
+Ensure node colors are valid:
+
+```typescript
+// Wrong: Invalid color values
+const nodes = [
+  { id: "1", label: "Test", x: 0, y: 0, color: "invalid" },
+];
+
+// Correct: Use hex numbers or strings
+const nodes = [
+  { id: "1", label: "Test", x: 0, y: 0, color: 0x6366f1 },
+  { id: "2", label: "Test", x: 100, y: 0, color: "#22c55e" },
+];
+```
+
+## See Also
+
+- [API Reference](../api/index.md) - ExportManager API details
+- [Styling Guide](./styling.md) - Node and edge customization
+- [Performance Guide](./performance.md) - Large graph optimization
+- [Basic Graph Example](../examples/basic-graph.md) - Getting started


### PR DESCRIPTION
## Summary

- Created comprehensive export user guide at `docs/graph-view/guides/export.md`
- Added copy-paste ready examples at `docs/graph-view/examples/export.md`
- Added ExportManager API reference at `docs/graph-view/api/export-manager.md`
- Updated README.md with links to export documentation
- Updated api/index.md with ExportManager section

## Documentation Added

### User Guide (`guides/export.md`)
- Quick start example
- Supported formats comparison table (PNG, JPEG, WebP, SVG)
- Export options reference
- Common use cases (print, transparent background, web, partial export)
- Programmatic export with progress monitoring
- Configuration and best practices
- Troubleshooting section

### Examples (`examples/export.md`)
- Basic export
- Export all formats comparison
- High-resolution print export
- Transparent background for overlays
- Progress monitoring with UI
- Partial graph export
- Copy to clipboard
- Export statistics dashboard

### API Reference (`api/export-manager.md`)
- Complete type definitions
- Method signatures with parameters
- Event system documentation
- Error handling guide
- Constants reference

## Test Plan
- [x] Build passes
- [x] Unit tests pass
- [x] Documentation links are correct
- [x] Examples are syntactically correct TypeScript

Closes #1310