### PR TITLE
docs: Fix outdated import patterns in basic-usage.md

### DIFF
--- a/packages/obsidian-plugin/docs/graph-view/README.md
+++ b/packages/obsidian-plugin/docs/graph-view/README.md
@@ -24,7 +24,7 @@ import {
   GraphLayoutRenderer,
   buildGraphData,
   ForceSimulation,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Build graph from table data
 const graphData = buildGraphData(tableRows, "label", ["links", "references"]);

--- a/packages/obsidian-plugin/docs/graph-view/api/events.md
+++ b/packages/obsidian-plugin/docs/graph-view/api/events.md
@@ -22,7 +22,7 @@ manager.once("eventType", callback);
 ### ForceSimulation
 
 ```typescript
-import { ForceSimulation } from "@exocortex/obsidian-plugin";
+import { ForceSimulation } from "./presentation/renderers/graph";
 
 const simulation = new ForceSimulation();
 
@@ -44,8 +44,8 @@ simulation.on("end", () => {
 ### SelectionManager
 
 ```typescript
-import { SelectionManager } from "@exocortex/obsidian-plugin";
-import type { SelectionEvent } from "@exocortex/obsidian-plugin";
+import { SelectionManager } from "./presentation/renderers/graph";
+import type { SelectionEvent } from "./presentation/renderers/graph";
 
 const selectionManager = new SelectionManager();
 
@@ -97,8 +97,8 @@ interface SelectionEvent {
 ### HoverManager
 
 ```typescript
-import { HoverManager } from "@exocortex/obsidian-plugin";
-import type { HoverEvent } from "@exocortex/obsidian-plugin";
+import { HoverManager } from "./presentation/renderers/graph";
+import type { HoverEvent } from "./presentation/renderers/graph";
 
 const hoverManager = new HoverManager();
 
@@ -138,8 +138,8 @@ interface HoverEvent {
 ### ViewportController
 
 ```typescript
-import { ViewportController } from "@exocortex/obsidian-plugin";
-import type { ViewportEvent } from "@exocortex/obsidian-plugin";
+import { ViewportController } from "./presentation/renderers/graph";
+import type { ViewportEvent } from "./presentation/renderers/graph";
 
 const viewportController = new ViewportController(container);
 
@@ -189,8 +189,8 @@ interface ViewportEvent {
 ### KeyboardManager
 
 ```typescript
-import { KeyboardManager } from "@exocortex/obsidian-plugin";
-import type { KeyboardEvent_Custom } from "@exocortex/obsidian-plugin";
+import { KeyboardManager } from "./presentation/renderers/graph";
+import type { KeyboardEvent_Custom } from "./presentation/renderers/graph";
 
 const keyboardManager = new KeyboardManager();
 
@@ -241,8 +241,8 @@ interface KeyboardEvent_Custom {
 ### NavigationManager
 
 ```typescript
-import { NavigationManager } from "@exocortex/obsidian-plugin";
-import type { NavigationEvent } from "@exocortex/obsidian-plugin";
+import { NavigationManager } from "./presentation/renderers/graph";
+import type { NavigationEvent } from "./presentation/renderers/graph";
 
 const navigationManager = new NavigationManager();
 
@@ -283,8 +283,8 @@ interface NavigationEvent {
 ### ContextMenuManager
 
 ```typescript
-import { ContextMenuManager } from "@exocortex/obsidian-plugin";
-import type { ContextMenuEvent } from "@exocortex/obsidian-plugin";
+import { ContextMenuManager } from "./presentation/renderers/graph";
+import type { ContextMenuEvent } from "./presentation/renderers/graph";
 
 const contextMenuManager = new ContextMenuManager();
 
@@ -339,8 +339,8 @@ interface ContextMenuItem {
 ### LayoutManager
 
 ```typescript
-import { LayoutManager } from "@exocortex/obsidian-plugin";
-import type { LayoutManagerEvent } from "@exocortex/obsidian-plugin";
+import { LayoutManager } from "./presentation/renderers/graph";
+import type { LayoutManagerEvent } from "./presentation/renderers/graph";
 
 const layoutManager = new LayoutManager();
 
@@ -373,8 +373,8 @@ layoutManager.on("transitionEnd", () => {
 ### PerformanceProfiler
 
 ```typescript
-import { PerformanceProfiler, getGlobalProfiler } from "@exocortex/obsidian-plugin";
-import type { ProfilerEvent } from "@exocortex/obsidian-plugin";
+import { PerformanceProfiler, getGlobalProfiler } from "./presentation/renderers/graph";
+import type { ProfilerEvent } from "./presentation/renderers/graph";
 
 const profiler = getGlobalProfiler();
 
@@ -394,8 +394,8 @@ profiler.on("warning", (event: { message: string; severity: string }) => {
 ### GPUMemoryManager
 
 ```typescript
-import { GPUMemoryManager, getGlobalMemoryManager } from "@exocortex/obsidian-plugin";
-import type { MemoryEvent } from "@exocortex/obsidian-plugin";
+import { GPUMemoryManager, getGlobalMemoryManager } from "./presentation/renderers/graph";
+import type { MemoryEvent } from "./presentation/renderers/graph";
 
 const memoryManager = getGlobalMemoryManager();
 
@@ -418,8 +418,8 @@ memoryManager.on("gc", (event: { freed: number }) => {
 ### AccessibilityManager
 
 ```typescript
-import { AccessibilityManager } from "@exocortex/obsidian-plugin";
-import type { A11yEvent } from "@exocortex/obsidian-plugin";
+import { AccessibilityManager } from "./presentation/renderers/graph";
+import type { A11yEvent } from "./presentation/renderers/graph";
 
 const a11yManager = new AccessibilityManager();
 

--- a/packages/obsidian-plugin/docs/graph-view/api/export-manager.md
+++ b/packages/obsidian-plugin/docs/graph-view/api/export-manager.md
@@ -15,7 +15,7 @@ import {
   type ExportEvent,
   type ExportManagerConfig,
   type ExportStats,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ## Class: ExportManager

--- a/packages/obsidian-plugin/docs/graph-view/api/graph-view.md
+++ b/packages/obsidian-plugin/docs/graph-view/api/graph-view.md
@@ -5,8 +5,8 @@ The main React component for rendering graph visualizations.
 ## Import
 
 ```typescript
-import { GraphLayoutRenderer } from "@exocortex/obsidian-plugin";
-import type { GraphLayoutRendererProps, GraphNode, GraphEdge } from "@exocortex/obsidian-plugin";
+import { GraphLayoutRenderer } from "./presentation/renderers/graph";
+import type { GraphLayoutRendererProps, GraphNode, GraphEdge } from "./presentation/renderers/graph";
 ```
 
 ## Props
@@ -34,7 +34,7 @@ interface GraphLayoutRendererProps {
 
 ```tsx
 import React from "react";
-import { GraphLayoutRenderer } from "@exocortex/obsidian-plugin";
+import { GraphLayoutRenderer } from "./presentation/renderers/graph";
 
 function MyGraph() {
   const nodes = [
@@ -321,7 +321,7 @@ import type {
   GraphEdge,
   GraphData,
   GraphLayoutOptions,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 const MyGraph: React.FC = () => {
   const ref = useRef<GraphLayoutRendererRef>(null);

--- a/packages/obsidian-plugin/docs/graph-view/api/index.md
+++ b/packages/obsidian-plugin/docs/graph-view/api/index.md
@@ -77,7 +77,7 @@ import {
   NodeRenderer,
   EdgeRenderer,
   LabelRenderer,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ### Type Imports
@@ -92,7 +92,7 @@ import type {
   SimulationLink,
   NodeVisualStyle,
   EdgeVisualStyle,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ### Force System Imports
@@ -108,7 +108,7 @@ import {
   forceX,
   forceY,
   FORCE_PRESETS,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ### Layout Algorithm Imports
@@ -121,7 +121,7 @@ import {
   LayoutManager,
   detectCommunities,
   CommunityLayout,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ### Interaction Manager Imports
@@ -134,7 +134,7 @@ import {
   KeyboardManager,
   NavigationManager,
   ContextMenuManager,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ## Key Concepts

--- a/packages/obsidian-plugin/docs/graph-view/api/layout-engine.md
+++ b/packages/obsidian-plugin/docs/graph-view/api/layout-engine.md
@@ -13,7 +13,7 @@ import {
   TemporalLayout,
   detectCommunities,
   LayoutPluginRegistry,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 import type {
   LayoutAlgorithmName,
@@ -22,7 +22,7 @@ import type {
   HierarchicalLayoutOptions,
   RadialLayoutOptions,
   TemporalLayoutOptions,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ## LayoutManager
@@ -158,7 +158,7 @@ layout.setRoots(["node-1", "node-2"]);
 ### Presets
 
 ```typescript
-import { HIERARCHICAL_PRESETS } from "@exocortex/obsidian-plugin";
+import { HIERARCHICAL_PRESETS } from "./presentation/renderers/graph";
 
 const layout = new HierarchicalLayout(HIERARCHICAL_PRESETS.topDown);
 const layout = new HierarchicalLayout(HIERARCHICAL_PRESETS.leftRight);
@@ -232,7 +232,7 @@ const rings = layout.getRings();
 ### Presets
 
 ```typescript
-import { RADIAL_PRESETS } from "@exocortex/obsidian-plugin";
+import { RADIAL_PRESETS } from "./presentation/renderers/graph";
 
 const layout = new RadialLayout(RADIAL_PRESETS.balanced);
 const layout = new RadialLayout(RADIAL_PRESETS.compact);
@@ -294,7 +294,7 @@ const lanes: Lane[] = layout.getLanes();
 ### Presets
 
 ```typescript
-import { TEMPORAL_PRESETS } from "@exocortex/obsidian-plugin";
+import { TEMPORAL_PRESETS } from "./presentation/renderers/graph";
 
 const layout = new TemporalLayout(TEMPORAL_PRESETS.timeline);
 const layout = new TemporalLayout(TEMPORAL_PRESETS.swimlane);
@@ -326,7 +326,7 @@ for (const marker of markers) {
 Detect communities using the Louvain algorithm:
 
 ```typescript
-import { detectCommunities, CommunityLayout } from "@exocortex/obsidian-plugin";
+import { detectCommunities, CommunityLayout } from "./presentation/renderers/graph";
 
 // Detect communities
 const result = detectCommunities(nodes, edges, {
@@ -365,7 +365,7 @@ import {
   layoutPluginRegistry,
   createLayoutPlugin,
   BaseLayoutAlgorithm,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Create custom layout
 class MyCustomLayout extends BaseLayoutAlgorithm {
@@ -421,7 +421,7 @@ const suitable = layoutPluginRegistry.getForGraphType("tree");
 Available easing functions for transitions:
 
 ```typescript
-import { getEasingFunction, EASING_FUNCTIONS } from "@exocortex/obsidian-plugin";
+import { getEasingFunction, EASING_FUNCTIONS } from "./presentation/renderers/graph";
 
 // Available easings
 const easings = [

--- a/packages/obsidian-plugin/docs/graph-view/api/physics-engine.md
+++ b/packages/obsidian-plugin/docs/graph-view/api/physics-engine.md
@@ -15,7 +15,7 @@ import {
   forceX,
   forceY,
   FORCE_PRESETS,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 import type {
   SimulationNode,
@@ -23,7 +23,7 @@ import type {
   Force,
   ForceSimulationConfig,
   SimulationMetrics,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ## Constructor
@@ -202,7 +202,7 @@ console.log(`Avg tick: ${metrics.avgTickTime}ms`);
 Centers the graph at a specific point:
 
 ```typescript
-import { forceCenter } from "@exocortex/obsidian-plugin";
+import { forceCenter } from "./presentation/renderers/graph";
 
 simulation.force("center", forceCenter(width / 2, height / 2));
 
@@ -217,7 +217,7 @@ simulation.force("center", center);
 Applies charge-based repulsion/attraction:
 
 ```typescript
-import { forceManyBody } from "@exocortex/obsidian-plugin";
+import { forceManyBody } from "./presentation/renderers/graph";
 
 const charge = forceManyBody()
   .strength(-300)        // Negative for repulsion
@@ -233,7 +233,7 @@ simulation.force("charge", charge);
 Applies link constraints:
 
 ```typescript
-import { forceLink } from "@exocortex/obsidian-plugin";
+import { forceLink } from "./presentation/renderers/graph";
 
 const links = [
   { source: "1", target: "2" },
@@ -254,7 +254,7 @@ simulation.force("link", linkForce);
 Prevents node overlap:
 
 ```typescript
-import { forceCollide } from "@exocortex/obsidian-plugin";
+import { forceCollide } from "./presentation/renderers/graph";
 
 const collide = forceCollide()
   .radius((d) => d.radius + 2)  // Collision radius
@@ -269,7 +269,7 @@ simulation.force("collide", collide);
 Pulls nodes toward a circular path:
 
 ```typescript
-import { forceRadial } from "@exocortex/obsidian-plugin";
+import { forceRadial } from "./presentation/renderers/graph";
 
 const radial = forceRadial(200, width / 2, height / 2)
   .strength(0.1);
@@ -282,7 +282,7 @@ simulation.force("radial", radial);
 Position forces along axes:
 
 ```typescript
-import { forceX, forceY } from "@exocortex/obsidian-plugin";
+import { forceX, forceY } from "./presentation/renderers/graph";
 
 // Pull nodes toward center X
 simulation.force("x", forceX(width / 2).strength(0.05));
@@ -303,7 +303,7 @@ simulation.force("x", forceX((d) => {
 Pre-configured force combinations:
 
 ```typescript
-import { FORCE_PRESETS } from "@exocortex/obsidian-plugin";
+import { FORCE_PRESETS } from "./presentation/renderers/graph";
 
 // Available presets
 FORCE_PRESETS.default     // Balanced for general use
@@ -387,7 +387,7 @@ function onDragEnd(node: SimulationNode) {
 For large graphs (1000+ nodes), the Barnes-Hut algorithm provides O(n log n) performance:
 
 ```typescript
-import { BarnesHutForce, createBarnesHutForce } from "@exocortex/obsidian-plugin";
+import { BarnesHutForce, createBarnesHutForce } from "./presentation/renderers/graph";
 
 // Create Barnes-Hut force
 const bhForce = createBarnesHutForce({

--- a/packages/obsidian-plugin/docs/graph-view/api/renderer.md
+++ b/packages/obsidian-plugin/docs/graph-view/api/renderer.md
@@ -12,7 +12,7 @@ import {
   LabelRenderer,
   BatchedNodeRenderer,
   IncrementalRenderer,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 import type {
   PixiGraphRendererOptions,
@@ -23,7 +23,7 @@ import type {
   RenderedNode,
   RenderedEdge,
   RenderedLabel,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ## PixiGraphRenderer
@@ -202,7 +202,7 @@ nodeRenderer.dispose();
 ### Node Shapes
 
 ```typescript
-import { SHAPE_DRAWERS } from "@exocortex/obsidian-plugin";
+import { SHAPE_DRAWERS } from "./presentation/renderers/graph";
 
 // Available shapes
 const shapes: NodeShape[] = [
@@ -371,7 +371,7 @@ labelRenderer.setVisibility(true);   // Show all labels
 ### Label Positioning
 
 ```typescript
-import { calculateOptimalLabelPosition } from "@exocortex/obsidian-plugin";
+import { calculateOptimalLabelPosition } from "./presentation/renderers/graph";
 
 // Find best position avoiding overlaps
 const position = calculateOptimalLabelPosition(
@@ -458,7 +458,7 @@ incrementalRenderer.render();
 ### Use Object Pooling
 
 ```typescript
-import { PoolManager, getGlobalPoolManager } from "@exocortex/obsidian-plugin";
+import { PoolManager, getGlobalPoolManager } from "./presentation/renderers/graph";
 
 const poolManager = getGlobalPoolManager();
 
@@ -470,7 +470,7 @@ poolManager.prewarm("vector2d", 1000);
 ### Use Visibility Culling
 
 ```typescript
-import { VisibilityCuller } from "@exocortex/obsidian-plugin";
+import { VisibilityCuller } from "./presentation/renderers/graph";
 
 const culler = new VisibilityCuller({
   margin: 50,  // Pixels outside viewport to include
@@ -486,7 +486,7 @@ nodeRenderer.renderNodes(visibleNodes);
 ### Use Level of Detail
 
 ```typescript
-import { LODSystem, LODLevel } from "@exocortex/obsidian-plugin";
+import { LODSystem, LODLevel } from "./presentation/renderers/graph";
 
 const lodSystem = new LODSystem();
 

--- a/packages/obsidian-plugin/docs/graph-view/architecture/extension-points.md
+++ b/packages/obsidian-plugin/docs/graph-view/architecture/extension-points.md
@@ -38,7 +38,7 @@ type GraphType =
 ### Creating a Layout Plugin
 
 ```typescript
-import { createLayoutPlugin, BaseLayoutAlgorithm } from "@exocortex/obsidian-plugin";
+import { createLayoutPlugin, BaseLayoutAlgorithm } from "./presentation/renderers/graph";
 
 class GridLayout extends BaseLayoutAlgorithm {
   compute(nodes: GraphNode[], edges: GraphEdge[]): LayoutResult {
@@ -87,7 +87,7 @@ const gridPlugin = createLayoutPlugin({
 ### Registering Plugins
 
 ```typescript
-import { layoutPluginRegistry } from "@exocortex/obsidian-plugin";
+import { layoutPluginRegistry } from "./presentation/renderers/graph";
 
 // Register plugin
 layoutPluginRegistry.register(gridPlugin);
@@ -196,7 +196,7 @@ simulation.force("group", forceGroup("group").strength(0.2).distance(50));
 ### Node Shape Renderer
 
 ```typescript
-import { SHAPE_DRAWERS, Graphics } from "@exocortex/obsidian-plugin";
+import { SHAPE_DRAWERS, Graphics } from "./presentation/renderers/graph";
 
 // Register custom shape
 SHAPE_DRAWERS.cloud = (graphics: Graphics, x: number, y: number, radius: number) => {

--- a/packages/obsidian-plugin/docs/graph-view/examples/basic-graph.md
+++ b/packages/obsidian-plugin/docs/graph-view/examples/basic-graph.md
@@ -16,8 +16,8 @@ import {
   LabelRenderer,
   ViewportController,
   SelectionManager,
-} from "@exocortex/obsidian-plugin";
-import type { GraphNode, GraphEdge, SimulationNode } from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
+import type { GraphNode, GraphEdge, SimulationNode } from "./presentation/renderers/graph";
 
 // 1. Define graph data
 const nodes: GraphNode[] = [
@@ -201,8 +201,8 @@ function cleanup(): void {
 
 ```tsx
 import React, { useEffect, useRef } from "react";
-import { GraphLayoutRenderer } from "@exocortex/obsidian-plugin";
-import type { GraphNode, GraphEdge } from "@exocortex/obsidian-plugin";
+import { GraphLayoutRenderer } from "./presentation/renderers/graph";
+import type { GraphNode, GraphEdge } from "./presentation/renderers/graph";
 
 const BasicGraph: React.FC = () => {
   const nodes: GraphNode[] = [

--- a/packages/obsidian-plugin/docs/graph-view/examples/custom-layout.md
+++ b/packages/obsidian-plugin/docs/graph-view/examples/custom-layout.md
@@ -11,8 +11,8 @@ import {
   BaseLayoutAlgorithm,
   createLayoutPlugin,
   layoutPluginRegistry,
-} from "@exocortex/obsidian-plugin";
-import type { GraphNode, GraphEdge, LayoutResult } from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
+import type { GraphNode, GraphEdge, LayoutResult } from "./presentation/renderers/graph";
 
 interface SpiralLayoutOptions {
   centerX: number;
@@ -99,7 +99,7 @@ layoutPluginRegistry.register(spiralPlugin);
 A force layout with alignment constraints:
 
 ```typescript
-import { ForceSimulation, forceCenter, forceManyBody, forceLink, forceY } from "@exocortex/obsidian-plugin";
+import { ForceSimulation, forceCenter, forceManyBody, forceLink, forceY } from "./presentation/renderers/graph";
 
 interface GroupConstraintOptions {
   groupKey: string;
@@ -248,7 +248,7 @@ class SwimlaneLayout extends BaseLayoutAlgorithm<SwimlaneLayoutOptions> {
 Combines community detection with force simulation:
 
 ```typescript
-import { detectCommunities } from "@exocortex/obsidian-plugin";
+import { detectCommunities } from "./presentation/renderers/graph";
 
 class ClusterForceLayout extends BaseLayoutAlgorithm {
   compute(nodes: GraphNode[], edges: GraphEdge[]): LayoutResult {

--- a/packages/obsidian-plugin/docs/graph-view/examples/dynamic-data.md
+++ b/packages/obsidian-plugin/docs/graph-view/examples/dynamic-data.md
@@ -10,8 +10,8 @@ import {
   forceCenter,
   forceManyBody,
   forceLink,
-} from "@exocortex/obsidian-plugin";
-import type { GraphNode, GraphEdge, SimulationNode } from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
+import type { GraphNode, GraphEdge, SimulationNode } from "./presentation/renderers/graph";
 
 class DynamicGraphManager {
   private nodes: SimulationNode[] = [];
@@ -160,7 +160,7 @@ class DynamicGraphManager {
 
 ```tsx
 import { useState, useEffect, useCallback } from "react";
-import type { GraphNode, GraphEdge } from "@exocortex/obsidian-plugin";
+import type { GraphNode, GraphEdge } from "./presentation/renderers/graph";
 
 interface GraphDataState {
   nodes: GraphNode[];
@@ -399,7 +399,7 @@ class VaultGraphSync extends Events {
 
 ```tsx
 import React, { useState, useEffect, useCallback } from "react";
-import { GraphLayoutRenderer } from "@exocortex/obsidian-plugin";
+import { GraphLayoutRenderer } from "./presentation/renderers/graph";
 
 const DynamicGraphView: React.FC<{ dataSource: DataSource }> = ({ dataSource }) => {
   const { nodes, edges, isLoading, addNode, removeNode } = useDynamicGraph(dataSource);

--- a/packages/obsidian-plugin/docs/graph-view/examples/export.md
+++ b/packages/obsidian-plugin/docs/graph-view/examples/export.md
@@ -11,7 +11,7 @@ import {
   ExportManager,
   type ExportNode,
   type ExportEdge,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Sample graph data
 const nodes: ExportNode[] = [
@@ -60,7 +60,7 @@ import {
   type ExportNode,
   type ExportEdge,
   type ExportFormat,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 const nodes: ExportNode[] = [
   { id: "n1", label: "Central", x: 200, y: 200, color: "#6366f1", radius: 16 },
@@ -108,7 +108,7 @@ for (const r of results) {
 Export for print at 300 DPI:
 
 ```typescript
-import { ExportManager, type ExportNode, type ExportEdge } from "@exocortex/obsidian-plugin";
+import { ExportManager, type ExportNode, type ExportEdge } from "./presentation/renderers/graph";
 
 const nodes: ExportNode[] = [
   { id: "root", label: "Research Project", x: 400, y: 50, color: "#1e40af", radius: 20 },
@@ -167,7 +167,7 @@ console.log(`PNG: ${(pngResult.fileSize / 1024).toFixed(1)} KB (${pngResult.widt
 Export with transparency for use in presentations or designs:
 
 ```typescript
-import { ExportManager, type ExportNode, type ExportEdge } from "@exocortex/obsidian-plugin";
+import { ExportManager, type ExportNode, type ExportEdge } from "./presentation/renderers/graph";
 
 const nodes: ExportNode[] = [
   { id: "a", label: "Concept A", x: 100, y: 100, color: "#3b82f6", radius: 15 },
@@ -219,7 +219,7 @@ import {
   type ExportNode,
   type ExportEdge,
   type ExportEvent,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Generate large graph
 function generateLargeGraph(nodeCount: number): { nodes: ExportNode[]; edges: ExportEdge[] } {
@@ -319,7 +319,7 @@ try {
 Export only a specific region of a large graph:
 
 ```typescript
-import { ExportManager, type ExportNode, type ExportEdge } from "@exocortex/obsidian-plugin";
+import { ExportManager, type ExportNode, type ExportEdge } from "./presentation/renderers/graph";
 
 // Large graph with many nodes spread across a wide area
 const nodes: ExportNode[] = [
@@ -387,7 +387,7 @@ console.log(`Full graph: ${fullResult.width}x${fullResult.height}px`);
 Export and copy directly to clipboard for pasting:
 
 ```typescript
-import { ExportManager, type ExportNode, type ExportEdge } from "@exocortex/obsidian-plugin";
+import { ExportManager, type ExportNode, type ExportEdge } from "./presentation/renderers/graph";
 
 const nodes: ExportNode[] = [
   { id: "idea", label: "Main Idea", x: 200, y: 100, color: "#6366f1", radius: 14 },
@@ -437,7 +437,7 @@ import {
   type ExportNode,
   type ExportEdge,
   type ExportStats,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 const exportManager = new ExportManager();
 

--- a/packages/obsidian-plugin/docs/graph-view/examples/large-scale.md
+++ b/packages/obsidian-plugin/docs/graph-view/examples/large-scale.md
@@ -13,8 +13,8 @@ import {
   BatchedNodeRenderer,
   QuadTree,
   WebGPUAccelerator,
-} from "@exocortex/obsidian-plugin";
-import type { GraphNode, GraphEdge, LODLevel } from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
+import type { GraphNode, GraphEdge, LODLevel } from "./presentation/renderers/graph";
 
 // Performance configuration for large graphs
 const largeGraphConfig = {
@@ -436,7 +436,7 @@ class WebGPUForceSimulation {
 ## Clustering for Overview
 
 ```typescript
-import { detectCommunities, ClusterLayout } from "@exocortex/obsidian-plugin";
+import { detectCommunities, ClusterLayout } from "./presentation/renderers/graph";
 
 class ClusteredGraphView {
   private clusters: Map<number, GraphNode[]> = new Map();
@@ -567,7 +567,7 @@ import {
   forceCenter,
   forceManyBody,
   forceLink,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 interface LargeGraphProps {
   dataSource: GraphDataSource;

--- a/packages/obsidian-plugin/docs/graph-view/examples/semantic-graph.md
+++ b/packages/obsidian-plugin/docs/graph-view/examples/semantic-graph.md
@@ -9,8 +9,8 @@ import {
   GraphLayoutRenderer,
   TripleStoreManager,
   buildGraphData,
-} from "@exocortex/obsidian-plugin";
-import type { GraphNode, GraphEdge, Triple } from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
+import type { GraphNode, GraphEdge, Triple } from "./presentation/renderers/graph";
 
 // 1. Create triple store
 const tripleStore = new TripleStoreManager();
@@ -129,7 +129,7 @@ function SemanticGraphView() {
 ## SPARQL Query Integration
 
 ```typescript
-import { SPARQLEngine, QueryExecutor } from "@exocortex/obsidian-plugin";
+import { SPARQLEngine, QueryExecutor } from "./presentation/renderers/graph";
 
 class KnowledgeGraphBuilder {
   private engine: SPARQLEngine;
@@ -268,7 +268,7 @@ class KnowledgeGraphBuilder {
 ## Ontology-Driven Visualization
 
 ```typescript
-import { OntologyManager, InferenceEngine } from "@exocortex/obsidian-plugin";
+import { OntologyManager, InferenceEngine } from "./presentation/renderers/graph";
 
 interface OntologyConfig {
   classes: Record<string, ClassConfig>;
@@ -345,7 +345,7 @@ applyOntologyStyles(nodes, edges, exocortexOntology);
 ## Inference and Reasoning
 
 ```typescript
-import { InferenceEngine, TransitiveClosureReasoner } from "@exocortex/obsidian-plugin";
+import { InferenceEngine, TransitiveClosureReasoner } from "./presentation/renderers/graph";
 
 class SemanticGraphEnricher {
   private reasoner: TransitiveClosureReasoner;
@@ -414,7 +414,7 @@ class SemanticGraphEnricher {
 ## Path Finding
 
 ```typescript
-import { PathFinder, ShortestPathAlgorithm } from "@exocortex/obsidian-plugin";
+import { PathFinder, ShortestPathAlgorithm } from "./presentation/renderers/graph";
 
 class SemanticPathFinder {
   private pathFinder: PathFinder;
@@ -472,7 +472,7 @@ import {
   GraphLayoutRenderer,
   TripleStoreManager,
   HierarchicalLayout,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 function SemanticKnowledgeGraph({ vault }: { vault: Vault }) {
   const [graphData, setGraphData] = useState<{ nodes: GraphNode[]; edges: GraphEdge[] }>({

--- a/packages/obsidian-plugin/docs/graph-view/getting-started/configuration.md
+++ b/packages/obsidian-plugin/docs/graph-view/getting-started/configuration.md
@@ -60,7 +60,7 @@ interface ForceSimulationConfig {
 ### Force Presets
 
 ```typescript
-import { FORCE_PRESETS } from "@exocortex/obsidian-plugin";
+import { FORCE_PRESETS } from "./presentation/renderers/graph";
 
 // Available presets
 const presets = {

--- a/packages/obsidian-plugin/docs/graph-view/getting-started/installation.md
+++ b/packages/obsidian-plugin/docs/graph-view/getting-started/installation.md
@@ -74,7 +74,7 @@ For accelerated physics simulation on large graphs (10K+ nodes), WebGPU is recom
 Check WebGPU support:
 
 ```typescript
-import { isWebGPUAvailable } from "@exocortex/obsidian-plugin";
+import { isWebGPUAvailable } from "./presentation/renderers/graph";
 
 if (await isWebGPUAvailable()) {
   console.log("WebGPU acceleration available!");
@@ -166,7 +166,7 @@ import {
   // Utilities
   buildGraphData,
   detectCommunities,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ### Type Imports
@@ -179,7 +179,7 @@ import type {
   GraphLayoutOptions,
   SimulationNode,
   SimulationLink,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 ```
 
 ## Verifying Installation
@@ -187,7 +187,7 @@ import type {
 Run this code to verify the installation:
 
 ```typescript
-import { ForceSimulation, forceCenter } from "@exocortex/obsidian-plugin";
+import { ForceSimulation, forceCenter } from "./presentation/renderers/graph";
 
 const simulation = new ForceSimulation();
 simulation.force("center", forceCenter(400, 300));

--- a/packages/obsidian-plugin/docs/graph-view/getting-started/obsidian-integration.md
+++ b/packages/obsidian-plugin/docs/graph-view/getting-started/obsidian-integration.md
@@ -10,7 +10,7 @@ This guide covers integrating the Graph View with Obsidian plugins, including fi
 import { Plugin, ItemView, WorkspaceLeaf } from "obsidian";
 import React from "react";
 import { createRoot, Root } from "react-dom/client";
-import { GraphLayoutRenderer } from "@exocortex/obsidian-plugin";
+import { GraphLayoutRenderer } from "./presentation/renderers/graph";
 
 const GRAPH_VIEW_TYPE = "exocortex-graph-view";
 
@@ -209,7 +209,7 @@ class GraphViewSync {
 
 ```typescript
 import { TFile, CachedMetadata } from "obsidian";
-import type { GraphNode, GraphEdge } from "@exocortex/obsidian-plugin";
+import type { GraphNode, GraphEdge } from "./presentation/renderers/graph";
 
 class VaultGraphBuilder {
   constructor(private app: App) {}
@@ -420,7 +420,7 @@ class ThemeObserver {
 
 ```typescript
 import { Menu } from "obsidian";
-import { ContextMenuManager, createDefaultProviders } from "@exocortex/obsidian-plugin";
+import { ContextMenuManager, createDefaultProviders } from "./presentation/renderers/graph";
 
 class ObsidianContextMenuProvider {
   constructor(

--- a/packages/obsidian-plugin/docs/graph-view/guides/accessibility.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/accessibility.md
@@ -42,7 +42,7 @@ import {
   AccessibilityManager,
   createAccessibilityManager,
   DEFAULT_ACCESSIBILITY_MANAGER_CONFIG,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Using the factory function (recommended)
 const a11y = createAccessibilityManager(container, {
@@ -193,7 +193,7 @@ import {
   VirtualCursor,
   createVirtualCursor,
   DEFAULT_VIRTUAL_CURSOR_CONFIG,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 const cursor = createVirtualCursor({
   maxHistorySize: 50,        // Maximum navigation history entries
@@ -420,7 +420,7 @@ const screenReaderType = a11y.detectScreenReader();
 // Returns: "nvda" | "jaws" | "voiceover" | "narrator" | "orca" | "unknown"
 
 // Get capabilities for a screen reader type
-import { getScreenReaderCapabilities } from "@exocortex/obsidian-plugin";
+import { getScreenReaderCapabilities } from "./presentation/renderers/graph";
 
 const capabilities = getScreenReaderCapabilities("voiceover");
 console.log(capabilities.supportsLiveRegions); // true
@@ -472,7 +472,7 @@ if (a11y.isHighContrastActive()) {
 ### Built-in High Contrast Themes
 
 ```typescript
-import { HIGH_CONTRAST_THEMES } from "@exocortex/obsidian-plugin";
+import { HIGH_CONTRAST_THEMES } from "./presentation/renderers/graph";
 
 // Dark theme (white on black)
 const darkTheme = HIGH_CONTRAST_THEMES.dark;
@@ -544,7 +544,7 @@ High contrast mode is automatically detected from system preferences:
 ### Reduced Motion Configuration
 
 ```typescript
-import { DEFAULT_REDUCED_MOTION_CONFIG } from "@exocortex/obsidian-plugin";
+import { DEFAULT_REDUCED_MOTION_CONFIG } from "./presentation/renderers/graph";
 
 interface ReducedMotionConfig {
   disableAnimations: boolean;   // Disable all animations
@@ -674,7 +674,7 @@ import {
   // Aliased exports to avoid naming conflicts
   a11yGetContrastRatio,
   a11yMeetsWCAGAA,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Calculate contrast ratio
 const foreground = "#FFFFFF";
@@ -714,7 +714,7 @@ import {
   getContrastRatio,
   meetsWCAGAA,
   AccessibilityManager,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 describe("Graph Accessibility", () => {
   let container: HTMLElement;

--- a/packages/obsidian-plugin/docs/graph-view/guides/data-sources.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/data-sources.md
@@ -7,7 +7,7 @@ This guide covers different ways to load and manage graph data.
 The simplest approach is providing graph data directly:
 
 ```typescript
-import type { GraphNode, GraphEdge } from "@exocortex/obsidian-plugin";
+import type { GraphNode, GraphEdge } from "./presentation/renderers/graph";
 
 const nodes: GraphNode[] = [
   { id: "1", label: "Project Alpha", path: "projects/alpha.md", group: "project" },
@@ -27,8 +27,8 @@ const edges: GraphEdge[] = [
 Convert tabular data (e.g., from Obsidian frontmatter) to graph format:
 
 ```typescript
-import { buildGraphData, rowsToNodes, extractEdges } from "@exocortex/obsidian-plugin";
-import type { TableRow, GraphData } from "@exocortex/obsidian-plugin";
+import { buildGraphData, rowsToNodes, extractEdges } from "./presentation/renderers/graph";
+import type { TableRow, GraphData } from "./presentation/renderers/graph";
 
 // Table rows from Obsidian query
 const tableRows: TableRow[] = [
@@ -63,8 +63,8 @@ const edges = extractEdges(tableRows, ["tasks", "references"]);
 For semantic graph data, integrate with a triple store:
 
 ```typescript
-import { GraphTooltipDataProvider } from "@exocortex/obsidian-plugin";
-import type { TripleStore, Triple } from "@exocortex/obsidian-plugin";
+import { GraphTooltipDataProvider } from "./presentation/renderers/graph";
+import type { TripleStore, Triple } from "./presentation/renderers/graph";
 
 // Implement triple store adapter
 class MyTripleStore implements TripleStore {
@@ -103,8 +103,8 @@ const dataProvider = new GraphTooltipDataProvider({
 Execute SPARQL queries to build graph data:
 
 ```typescript
-import { ClusterQueryExecutor } from "@exocortex/obsidian-plugin";
-import type { ClusterQueryResult, TripleStoreAdapter } from "@exocortex/obsidian-plugin";
+import { ClusterQueryExecutor } from "./presentation/renderers/graph";
+import type { ClusterQueryResult, TripleStoreAdapter } from "./presentation/renderers/graph";
 
 // Create query executor
 const executor = new ClusterQueryExecutor({
@@ -362,7 +362,7 @@ function GraphWithRealTimeData() {
 Filter graph data before rendering:
 
 ```typescript
-import { FilterManager, createTypeFilter, createPredicateFilter } from "@exocortex/obsidian-plugin";
+import { FilterManager, createTypeFilter, createPredicateFilter } from "./presentation/renderers/graph";
 
 const filterManager = new FilterManager();
 

--- a/packages/obsidian-plugin/docs/graph-view/guides/edge-bundling.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/edge-bundling.md
@@ -23,7 +23,7 @@ Passthrough bundler that returns straight edges. Use for:
 - Simple graphs where bundling is unnecessary
 
 ```typescript
-import { createStubBundler } from "@exocortex/obsidian-plugin";
+import { createStubBundler } from "./presentation/renderers/graph";
 
 const bundler = createStubBundler();
 const bundledEdges = bundler.bundle(edges, nodes);
@@ -41,7 +41,7 @@ Implements the Force-Directed Edge Bundling algorithm by Holten & van Wijk (2009
 - Configurable bundling strength
 
 ```typescript
-import { createFDEBBundler } from "@exocortex/obsidian-plugin";
+import { createFDEBBundler } from "./presentation/renderers/graph";
 
 const bundler = createFDEBBundler({
   iterations: 60,           // Number of simulation iterations
@@ -83,7 +83,7 @@ Implements hierarchical edge bundling based on Holten (2006). Routes edges throu
 - Optimal for tree-like data structures
 
 ```typescript
-import { createHierarchicalBundler } from "@exocortex/obsidian-plugin";
+import { createHierarchicalBundler } from "./presentation/renderers/graph";
 
 const bundler = createHierarchicalBundler({
   beta: 0.85,              // Bundling tightness (0 = straight, 1 = follow hierarchy)
@@ -108,7 +108,7 @@ const bundledEdges = bundler.bundle(edges, nodes);
 ### Basic Usage
 
 ```typescript
-import { createEdgeBundler } from "@exocortex/obsidian-plugin";
+import { createEdgeBundler } from "./presentation/renderers/graph";
 
 // Create bundler using factory (recommended)
 const bundler = createEdgeBundler("fdeb");
@@ -131,7 +131,7 @@ for (const edge of bundledEdges) {
 ### With Statistics
 
 ```typescript
-import { createFDEBBundler } from "@exocortex/obsidian-plugin";
+import { createFDEBBundler } from "./presentation/renderers/graph";
 
 const bundler = createFDEBBundler();
 const result = bundler.bundleWithStats(edges, nodeMap);
@@ -145,7 +145,7 @@ console.log(`Avg compatibility: ${result.averageCompatibility.toFixed(3)}`);
 ### Rendering Bundled Edges
 
 ```typescript
-import { createFDEBBundler } from "@exocortex/obsidian-plugin";
+import { createFDEBBundler } from "./presentation/renderers/graph";
 
 const bundler = createFDEBBundler();
 const bundledEdges = bundler.bundle(edges, nodeMap);
@@ -370,7 +370,7 @@ import {
   scale,          // Scale vector by scalar
   lerp,           // Linear interpolation
   projectOntoLine // Project point onto line segment
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Example: Calculate edge length
 const length = distance(sourcePos, targetPos);

--- a/packages/obsidian-plugin/docs/graph-view/guides/export.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/export.md
@@ -5,7 +5,7 @@ Export your knowledge graphs to various image formats for sharing, presentations
 ## Quick Start
 
 ```typescript
-import { ExportManager } from "@exocortex/obsidian-plugin";
+import { ExportManager } from "./presentation/renderers/graph";
 
 // Create export manager
 const exportManager = new ExportManager();
@@ -280,7 +280,7 @@ exportManager.resetStats();
 Configure default behavior at construction:
 
 ```typescript
-import { ExportManager, type ExportManagerConfig } from "@exocortex/obsidian-plugin";
+import { ExportManager, type ExportManagerConfig } from "./presentation/renderers/graph";
 
 const config: Partial<ExportManagerConfig> = {
   // Maximum export dimension (default: 16384)
@@ -309,7 +309,7 @@ const exportManager = new ExportManager(config);
 Use the factory function for quick setup:
 
 ```typescript
-import { createExportManager } from "@exocortex/obsidian-plugin";
+import { createExportManager } from "./presentation/renderers/graph";
 
 const exportManager = createExportManager({
   maxDimension: 8192,

--- a/packages/obsidian-plugin/docs/graph-view/guides/filtering.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/filtering.md
@@ -19,7 +19,7 @@ The Filter Panel is the primary UI for managing graph filters:
 ### Programmatic Filtering
 
 ```typescript
-import { FilterManager, createTypeFilter, generateFilterId } from "@exocortex/obsidian-plugin";
+import { FilterManager, createTypeFilter, generateFilterId } from "./presentation/renderers/graph";
 
 // Get the filter manager
 const filterManager = new FilterManager();
@@ -48,7 +48,7 @@ const { nodeIds, edgeIds } = filterManager.getFilteredResults();
 Filter nodes by their RDF type (asset class). This is the most common filter type.
 
 ```typescript
-import { createTypeFilter, generateFilterId } from "@exocortex/obsidian-plugin";
+import { createTypeFilter, generateFilterId } from "./presentation/renderers/graph";
 
 // Show only tasks
 const showTasks = createTypeFilter(
@@ -81,7 +81,7 @@ filterManager.addFilter(showTasks);
 Filter based on edge types (relationships between nodes).
 
 ```typescript
-import { createPredicateFilter, generateFilterId } from "@exocortex/obsidian-plugin";
+import { createPredicateFilter, generateFilterId } from "./presentation/renderers/graph";
 
 // Show only hierarchy relationships
 const hierarchyOnly = createPredicateFilter(
@@ -106,7 +106,7 @@ filterManager.addFilter(hierarchyOnly);
 Filter nodes by property values with comparison operators.
 
 ```typescript
-import { createLiteralFilter, generateFilterId } from "@exocortex/obsidian-plugin";
+import { createLiteralFilter, generateFilterId } from "./presentation/renderers/graph";
 
 // Filter tasks by status
 const completedTasks = createLiteralFilter(
@@ -153,7 +153,7 @@ filterManager.addFilter(completedTasks);
 Show nodes within a certain distance (hops) from a starting node. Uses BFS traversal.
 
 ```typescript
-import { createPathFilter, generateFilterId } from "@exocortex/obsidian-plugin";
+import { createPathFilter, generateFilterId } from "./presentation/renderers/graph";
 
 // Show all nodes within 2 hops of a specific node
 const neighborhood = createPathFilter(
@@ -178,7 +178,7 @@ filterManager.addFilter(neighborhood);
 Combine multiple filters with logical operators (AND, OR, NOT).
 
 ```typescript
-import { createCompositeFilter, createTypeFilter, generateFilterId } from "@exocortex/obsidian-plugin";
+import { createCompositeFilter, createTypeFilter, generateFilterId } from "./presentation/renderers/graph";
 
 // Create child filters
 const tasksFilter = createTypeFilter(
@@ -219,7 +219,7 @@ filterManager.addFilter(combinedFilter);
 The `FilterPanel` component provides an interactive UI for managing filters:
 
 ```tsx
-import { FilterPanel } from "@exocortex/obsidian-plugin";
+import { FilterPanel } from "./presentation/renderers/graph";
 
 function MyGraphView() {
   const [visibleNodeTypes, setVisibleNodeTypes] = useState(new Set<string>());
@@ -272,7 +272,7 @@ function MyGraphView() {
 Customize which filter sections are visible:
 
 ```typescript
-import { FilterPanelConfig, DEFAULT_FILTER_PANEL_CONFIG } from "@exocortex/obsidian-plugin";
+import { FilterPanelConfig, DEFAULT_FILTER_PANEL_CONFIG } from "./presentation/renderers/graph";
 
 const customConfig: FilterPanelConfig = {
   ...DEFAULT_FILTER_PANEL_CONFIG,

--- a/packages/obsidian-plugin/docs/graph-view/guides/interactions.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/interactions.md
@@ -7,7 +7,7 @@ This guide covers user interactions including selection, dragging, zooming, and 
 ### Single Selection
 
 ```typescript
-import { SelectionManager, DEFAULT_SELECTION_MANAGER_CONFIG } from "@exocortex/obsidian-plugin";
+import { SelectionManager, DEFAULT_SELECTION_MANAGER_CONFIG } from "./presentation/renderers/graph";
 
 const selectionManager = new SelectionManager({
   multiSelect: false,      // Only single selection
@@ -77,7 +77,7 @@ selectionManager.on("boxEnd", (event) => {
 ### Basic Hover
 
 ```typescript
-import { HoverManager, DEFAULT_HOVER_MANAGER_CONFIG } from "@exocortex/obsidian-plugin";
+import { HoverManager, DEFAULT_HOVER_MANAGER_CONFIG } from "./presentation/renderers/graph";
 
 const hoverManager = new HoverManager({
   hoverDelay: 200,         // Wait before hover triggers
@@ -109,7 +109,7 @@ hoverManager.on("leave", (event) => {
 ### Rich Tooltips
 
 ```typescript
-import { TooltipRenderer, GraphTooltipDataProvider } from "@exocortex/obsidian-plugin";
+import { TooltipRenderer, GraphTooltipDataProvider } from "./presentation/renderers/graph";
 
 const tooltipProvider = new GraphTooltipDataProvider({
   tripleStore: myTripleStore,
@@ -139,7 +139,7 @@ hoverManager.on("leave", () => {
 ### Viewport Control
 
 ```typescript
-import { ViewportController, DEFAULT_VIEWPORT_CONTROLLER_CONFIG } from "@exocortex/obsidian-plugin";
+import { ViewportController, DEFAULT_VIEWPORT_CONTROLLER_CONFIG } from "./presentation/renderers/graph";
 
 const viewport = new ViewportController(container, {
   pannable: true,
@@ -207,7 +207,7 @@ const viewport = new ViewportController(container, {
 ### Node Dragging
 
 ```typescript
-import { ForceSimulation } from "@exocortex/obsidian-plugin";
+import { ForceSimulation } from "./presentation/renderers/graph";
 
 let draggedNode: SimulationNode | null = null;
 
@@ -285,7 +285,7 @@ function onDoubleClick(nodeId: string): void {
 ### Setup
 
 ```typescript
-import { KeyboardManager, NavigationManager, DEFAULT_KEY_BINDINGS } from "@exocortex/obsidian-plugin";
+import { KeyboardManager, NavigationManager, DEFAULT_KEY_BINDINGS } from "./presentation/renderers/graph";
 
 const keyboardManager = new KeyboardManager({
   enabled: true,
@@ -392,7 +392,7 @@ import {
   ContextMenuManager,
   ContextMenuRenderer,
   createDefaultProviders,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 const contextMenuManager = new ContextMenuManager();
 const contextMenuRenderer = new ContextMenuRenderer(container);
@@ -420,7 +420,7 @@ contextMenuManager.on("close", () => {
 ### Custom Menu Items
 
 ```typescript
-import { ContextMenuProvider, ContextMenuItem } from "@exocortex/obsidian-plugin";
+import { ContextMenuProvider, ContextMenuItem } from "./presentation/renderers/graph";
 
 const customProvider: ContextMenuProvider = {
   id: "custom",
@@ -462,7 +462,7 @@ contextMenuManager.addProvider(customProvider);
 ### Focus Indicator
 
 ```typescript
-import { FocusIndicator, DEFAULT_FOCUS_INDICATOR_STYLE } from "@exocortex/obsidian-plugin";
+import { FocusIndicator, DEFAULT_FOCUS_INDICATOR_STYLE } from "./presentation/renderers/graph";
 
 const focusIndicator = new FocusIndicator(renderer.app, {
   style: {

--- a/packages/obsidian-plugin/docs/graph-view/guides/layouts.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/layouts.md
@@ -33,7 +33,7 @@ import {
   forceLink,
   forceCollide,
   FORCE_PRESETS,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Basic setup
 const simulation = new ForceSimulation()
@@ -95,7 +95,7 @@ For tree structures and directed acyclic graphs (DAGs).
 ### Configuration
 
 ```typescript
-import { HierarchicalLayout, HIERARCHICAL_PRESETS } from "@exocortex/obsidian-plugin";
+import { HierarchicalLayout, HIERARCHICAL_PRESETS } from "./presentation/renderers/graph";
 
 const layout = new HierarchicalLayout({
   direction: "TB",           // Top to Bottom
@@ -150,7 +150,7 @@ Circular arrangement with focus node at center.
 ### Configuration
 
 ```typescript
-import { RadialLayout, RADIAL_PRESETS } from "@exocortex/obsidian-plugin";
+import { RadialLayout, RADIAL_PRESETS } from "./presentation/renderers/graph";
 
 const layout = new RadialLayout({
   focusNode: selectedNodeId,  // Center node
@@ -204,7 +204,7 @@ Timeline-based layout for chronological data.
 ### Configuration
 
 ```typescript
-import { TemporalLayout, TEMPORAL_PRESETS } from "@exocortex/obsidian-plugin";
+import { TemporalLayout, TEMPORAL_PRESETS } from "./presentation/renderers/graph";
 
 const layout = new TemporalLayout({
   orientation: "horizontal",
@@ -254,7 +254,7 @@ Automatically detect and visualize communities.
 ### Configuration
 
 ```typescript
-import { detectCommunities, CommunityLayout, assignCommunityColors } from "@exocortex/obsidian-plugin";
+import { detectCommunities, CommunityLayout, assignCommunityColors } from "./presentation/renderers/graph";
 
 // Detect communities
 const detection = detectCommunities(nodes, edges, {
@@ -291,7 +291,7 @@ const result = layout.compute(nodes, edges);
 Smoothly animate between layouts:
 
 ```typescript
-import { LayoutTransitionManager, TRANSITION_PRESETS } from "@exocortex/obsidian-plugin";
+import { LayoutTransitionManager, TRANSITION_PRESETS } from "./presentation/renderers/graph";
 
 const transitionManager = new LayoutTransitionManager({
   duration: 500,
@@ -325,7 +325,7 @@ await transitionManager.transition(oldPositions, newResult.nodes, {
 Create custom layout algorithms:
 
 ```typescript
-import { BaseLayoutAlgorithm, LayoutPluginRegistry, layoutPluginRegistry } from "@exocortex/obsidian-plugin";
+import { BaseLayoutAlgorithm, LayoutPluginRegistry, layoutPluginRegistry } from "./presentation/renderers/graph";
 
 class CircularLayout extends BaseLayoutAlgorithm {
   compute(nodes: GraphNode[], edges: GraphEdge[]): LayoutResult {

--- a/packages/obsidian-plugin/docs/graph-view/guides/migration.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/migration.md
@@ -24,7 +24,7 @@ import { ForceSimulation } from "@exocortex/obsidian-plugin/physics";
 
 **After:**
 ```typescript
-import { PixiGraphRenderer, ForceSimulation } from "@exocortex/obsidian-plugin";
+import { PixiGraphRenderer, ForceSimulation } from "./presentation/renderers/graph";
 ```
 
 All graph-related exports are now available from the main package entry point.
@@ -66,7 +66,7 @@ simulation.force("charge", {
 
 **After:**
 ```typescript
-import { forceManyBody } from "@exocortex/obsidian-plugin";
+import { forceManyBody } from "./presentation/renderers/graph";
 
 simulation.force("charge", forceManyBody().strength(-300));
 ```
@@ -115,7 +115,7 @@ import {
   RadialLayout,
   TemporalLayout,
   LayoutManager,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Switch layouts with animation
 const layoutManager = new LayoutManager();
@@ -128,7 +128,7 @@ await layoutManager.transitionTo("hierarchical", {
 #### Accessibility
 
 ```typescript
-import { AccessibilityManager } from "@exocortex/obsidian-plugin";
+import { AccessibilityManager } from "./presentation/renderers/graph";
 
 const a11yManager = new AccessibilityManager({
   screenReaderSupport: true,
@@ -144,7 +144,7 @@ import {
   LODSystem,
   VisibilityCuller,
   BatchedNodeRenderer,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Automatic performance optimization
 const autoOptimizer = new AutoOptimizer({ targetFPS: 60 });

--- a/packages/obsidian-plugin/docs/graph-view/guides/path-finding.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/path-finding.md
@@ -20,7 +20,7 @@ import {
   PathFindingManager,
   createPathFinder,
   createPathFindingManager,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Create path finder with default options
 const pathFinder = createPathFinder();
@@ -47,7 +47,7 @@ The `PathFinder` class implements graph path finding algorithms.
 ### Creation
 
 ```typescript
-import { PathFinder, createPathFinder } from "@exocortex/obsidian-plugin";
+import { PathFinder, createPathFinder } from "./presentation/renderers/graph";
 
 // Using factory function (recommended)
 const pathFinder = createPathFinder({
@@ -66,7 +66,7 @@ const pathFinder = new PathFinder({
 ### Setting Graph Data
 
 ```typescript
-import type { GraphNode, GraphEdge } from "@exocortex/obsidian-plugin";
+import type { GraphNode, GraphEdge } from "./presentation/renderers/graph";
 
 const nodes: GraphNode[] = [
   { id: "A", label: "Node A", path: "/A.md" },
@@ -374,7 +374,7 @@ For UI integration, use `PathFindingManager` which handles:
 ### Basic Usage
 
 ```typescript
-import { createPathFindingManager } from "@exocortex/obsidian-plugin";
+import { createPathFindingManager } from "./presentation/renderers/graph";
 
 const manager = createPathFindingManager();
 
@@ -620,7 +620,7 @@ if (!result.found) {
 import {
   createPathFindingManager,
   PathFindingEventType,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 // Setup
 const manager = createPathFindingManager({

--- a/packages/obsidian-plugin/docs/graph-view/guides/performance.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/performance.md
@@ -18,7 +18,7 @@ This guide covers optimizing Graph View for large graphs (1K to 100K+ nodes).
 For O(n log n) many-body force calculation:
 
 ```typescript
-import { ForceSimulation, forceManyBody, BarnesHutForce } from "@exocortex/obsidian-plugin";
+import { ForceSimulation, forceManyBody, BarnesHutForce } from "./presentation/renderers/graph";
 
 const simulation = new ForceSimulation()
   .force("charge", forceManyBody()
@@ -38,7 +38,7 @@ const simulation = new ForceSimulation()
 GPU-accelerated simulation for 10K+ nodes:
 
 ```typescript
-import { WebGPUPhysics, isWebGPUAvailable, createWebGPUPhysics } from "@exocortex/obsidian-plugin";
+import { WebGPUPhysics, isWebGPUAvailable, createWebGPUPhysics } from "./presentation/renderers/graph";
 
 if (await isWebGPUAvailable()) {
   const physics = await createWebGPUPhysics({
@@ -91,7 +91,7 @@ render();
 Reduce visual complexity at low zoom:
 
 ```typescript
-import { LODSystem, createLODSystem, LODLevel } from "@exocortex/obsidian-plugin";
+import { LODSystem, createLODSystem, LODLevel } from "./presentation/renderers/graph";
 
 const lodSystem = createLODSystem({
   thresholds: [
@@ -129,7 +129,7 @@ viewport.on("change", (event) => {
 Only render visible elements:
 
 ```typescript
-import { VisibilityCuller, DEFAULT_VISIBILITY_CULLER_CONFIG } from "@exocortex/obsidian-plugin";
+import { VisibilityCuller, DEFAULT_VISIBILITY_CULLER_CONFIG } from "./presentation/renderers/graph";
 
 const culler = new VisibilityCuller({
   margin: 50,  // Include nodes slightly outside viewport
@@ -150,7 +150,7 @@ function render(): void {
 Use instanced drawing for many similar nodes:
 
 ```typescript
-import { BatchedNodeRenderer, createBatchedNodeRenderer } from "@exocortex/obsidian-plugin";
+import { BatchedNodeRenderer, createBatchedNodeRenderer } from "./presentation/renderers/graph";
 
 const batchRenderer = createBatchedNodeRenderer(renderer.app, {
   maxBatchSize: 1000,
@@ -176,7 +176,7 @@ batchRenderer.render();
 Only re-render changed elements:
 
 ```typescript
-import { IncrementalRenderer, DirtyTracker } from "@exocortex/obsidian-plugin";
+import { IncrementalRenderer, DirtyTracker } from "./presentation/renderers/graph";
 
 const dirtyTracker = new DirtyTracker();
 const incrementalRenderer = new IncrementalRenderer({
@@ -214,7 +214,7 @@ import {
   createPoolManager,
   getGlobalPoolManager,
   POOL_NAMES,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 const poolManager = getGlobalPoolManager();
 
@@ -233,7 +233,7 @@ poolManager.release(POOL_NAMES.VECTOR_2D, vector);
 ### GPU Memory Management
 
 ```typescript
-import { GPUMemoryManager, getGlobalMemoryManager, MemoryPressure } from "@exocortex/obsidian-plugin";
+import { GPUMemoryManager, getGlobalMemoryManager, MemoryPressure } from "./presentation/renderers/graph";
 
 const memoryManager = getGlobalMemoryManager();
 
@@ -287,7 +287,7 @@ nodeRenderer.setShapeAtlas(shapeAtlas);
 Virtual scrolling for very large graphs:
 
 ```typescript
-import { ViewportWindowManager, createViewportWindowManager } from "@exocortex/obsidian-plugin";
+import { ViewportWindowManager, createViewportWindowManager } from "./presentation/renderers/graph";
 
 const windowManager = createViewportWindowManager({
   windowSize: 2000,    // Pixels per window
@@ -315,7 +315,7 @@ windowManager.on("windowChange", (event) => {
 ### Built-in Profiler
 
 ```typescript
-import { PerformanceProfiler, getGlobalProfiler } from "@exocortex/obsidian-plugin";
+import { PerformanceProfiler, getGlobalProfiler } from "./presentation/renderers/graph";
 
 const profiler = getGlobalProfiler();
 profiler.enable();
@@ -344,7 +344,7 @@ for (const [name, timing] of sections) {
 ### Bottleneck Detection
 
 ```typescript
-import { BottleneckDetector, createBottleneckDetector } from "@exocortex/obsidian-plugin";
+import { BottleneckDetector, createBottleneckDetector } from "./presentation/renderers/graph";
 
 const detector = createBottleneckDetector({
   sampleSize: 60,        // Frames to analyze
@@ -366,7 +366,7 @@ detector.on("bottleneck", (analysis) => {
 Automatic performance tuning:
 
 ```typescript
-import { AutoOptimizer, createAutoOptimizer } from "@exocortex/obsidian-plugin";
+import { AutoOptimizer, createAutoOptimizer } from "./presentation/renderers/graph";
 
 const optimizer = createAutoOptimizer({
   targetFPS: 60,
@@ -400,7 +400,7 @@ optimizer.start();
 ## Performance Dashboard
 
 ```typescript
-import { PerformanceMetricsDashboard, PerformanceDashboardButton } from "@exocortex/obsidian-plugin";
+import { PerformanceMetricsDashboard, PerformanceDashboardButton } from "./presentation/renderers/graph";
 
 // Add dashboard button
 const button = new PerformanceDashboardButton({

--- a/packages/obsidian-plugin/docs/graph-view/guides/search.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/search.md
@@ -17,7 +17,7 @@ The Graph View includes a powerful search system for finding nodes by text, navi
 ### Programmatic Search
 
 ```typescript
-import { SearchManager } from "@exocortex/obsidian-plugin";
+import { SearchManager } from "./presentation/renderers/graph";
 
 // Create search manager
 const searchManager = new SearchManager();
@@ -49,7 +49,7 @@ import {
   SearchManager,
   SearchManagerConfig,
   DEFAULT_SEARCH_MANAGER_CONFIG,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 const config: Partial<SearchManagerConfig> = {
   searchOptions: {
@@ -176,7 +176,7 @@ const matchedIds = searchManager.getMatchedNodeIds();
 Subscribe to search events for real-time updates:
 
 ```typescript
-import { SearchEvent, SearchEventListener } from "@exocortex/obsidian-plugin";
+import { SearchEvent, SearchEventListener } from "./presentation/renderers/graph";
 
 const handleSearchEvent: SearchEventListener = (event: SearchEvent) => {
   switch (event.type) {
@@ -241,7 +241,7 @@ The TypeColorManager provides type-based coloring and a visual legend for the gr
 import {
   TypeColorManager,
   TypeColorManagerConfig,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 const config: Partial<TypeColorManagerConfig> = {
   paletteId: "default",           // Color palette to use
@@ -430,7 +430,7 @@ colorManager.addEventListener((event) => {
 When `enforceContrast` is enabled, generated colors are checked for WCAG AA compliance:
 
 ```typescript
-import { meetsWCAGAA } from "@exocortex/obsidian-plugin";
+import { meetsWCAGAA } from "./presentation/renderers/graph";
 
 // Check if colors meet contrast requirements
 const isAccessible = meetsWCAGAA(
@@ -449,7 +449,7 @@ import {
   SearchManager,
   TypeColorManager,
   GraphNode,
-} from "@exocortex/obsidian-plugin";
+} from "./presentation/renderers/graph";
 
 class GraphSearchController {
   private searchManager: SearchManager;

--- a/packages/obsidian-plugin/docs/graph-view/guides/styling.md
+++ b/packages/obsidian-plugin/docs/graph-view/guides/styling.md
@@ -7,8 +7,8 @@ This guide covers visual customization of nodes, edges, and labels.
 ### Basic Node Styles
 
 ```typescript
-import { NodeRenderer, DEFAULT_NODE_STYLE } from "@exocortex/obsidian-plugin";
-import type { NodeVisualStyle } from "@exocortex/obsidian-plugin";
+import { NodeRenderer, DEFAULT_NODE_STYLE } from "./presentation/renderers/graph";
+import type { NodeVisualStyle } from "./presentation/renderers/graph";
 
 const nodeStyle: NodeVisualStyle = {
   fill: 0x6366f1,        // Indigo fill
@@ -29,8 +29,8 @@ nodeRenderer.renderNode({
 ### Node Shapes
 
 ```typescript
-import { SHAPE_DRAWERS } from "@exocortex/obsidian-plugin";
-import type { NodeShape } from "@exocortex/obsidian-plugin";
+import { SHAPE_DRAWERS } from "./presentation/renderers/graph";
+import type { NodeShape } from "./presentation/renderers/graph";
 
 // Available shapes
 const shapes: NodeShape[] = [
@@ -91,8 +91,8 @@ function getConnectionColor(count: number): number {
 ### Node Size Scaling
 
 ```typescript
-import { calculateNodeRadius } from "@exocortex/obsidian-plugin";
-import type { RadiusScalingMode } from "@exocortex/obsidian-plugin";
+import { calculateNodeRadius } from "./presentation/renderers/graph";
+import type { RadiusScalingMode } from "./presentation/renderers/graph";
 
 // Scale by connection count
 const radius = calculateNodeRadius({
@@ -122,8 +122,8 @@ function scaleRadius(value: number, mode: RadiusScalingMode): number {
 ### Basic Edge Styles
 
 ```typescript
-import { EdgeRenderer, DEFAULT_EDGE_STYLE } from "@exocortex/obsidian-plugin";
-import type { EdgeVisualStyle } from "@exocortex/obsidian-plugin";
+import { EdgeRenderer, DEFAULT_EDGE_STYLE } from "./presentation/renderers/graph";
+import type { EdgeVisualStyle } from "./presentation/renderers/graph";
 
 const edgeStyle: EdgeVisualStyle = {
   color: 0x4a4a6a,       // Gray-blue
@@ -143,7 +143,7 @@ edgeRenderer.renderEdge({
 ### Curve Types
 
 ```typescript
-import type { CurveType } from "@exocortex/obsidian-plugin";
+import type { CurveType } from "./presentation/renderers/graph";
 
 // Straight line
 edgeRenderer.renderEdge({
@@ -176,7 +176,7 @@ edgeRenderer.renderEdge({
 ### Arrow Styles
 
 ```typescript
-import type { ArrowType, ArrowPosition } from "@exocortex/obsidian-plugin";
+import type { ArrowType, ArrowPosition } from "./presentation/renderers/graph";
 
 edgeRenderer.renderEdge({
   ...edge,
@@ -241,8 +241,8 @@ edgeRenderer.renderEdge({
 ### Basic Label Styles
 
 ```typescript
-import { LabelRenderer, DEFAULT_LABEL_STYLE } from "@exocortex/obsidian-plugin";
-import type { LabelVisualStyle } from "@exocortex/obsidian-plugin";
+import { LabelRenderer, DEFAULT_LABEL_STYLE } from "./presentation/renderers/graph";
+import type { LabelVisualStyle } from "./presentation/renderers/graph";
 
 const labelStyle: LabelVisualStyle = {
   fontFamily: "Inter, system-ui, sans-serif",
@@ -266,8 +266,8 @@ labelRenderer.renderLabel({
 ### Label Positioning
 
 ```typescript
-import { calculateOptimalLabelPosition } from "@exocortex/obsidian-plugin";
-import type { LabelAnchor } from "@exocortex/obsidian-plugin";
+import { calculateOptimalLabelPosition } from "./presentation/renderers/graph";
+import type { LabelAnchor } from "./presentation/renderers/graph";
 
 // Predefined positions
 const positions: LabelAnchor[] = [
@@ -373,8 +373,8 @@ function applyTheme(theme: "dark" | "light"): void {
 Style by ontology class:
 
 ```typescript
-import { DEFAULT_NODE_TYPE_CONFIGS } from "@exocortex/obsidian-plugin";
-import type { NodeTypeConfig, OntologyClass } from "@exocortex/obsidian-plugin";
+import { DEFAULT_NODE_TYPE_CONFIGS } from "./presentation/renderers/graph";
+import type { NodeTypeConfig, OntologyClass } from "./presentation/renderers/graph";
 
 const nodeTypeConfigs: Record<OntologyClass, NodeTypeConfig> = {
   "ems__Area": {
@@ -454,7 +454,7 @@ function getNodeStyle(node: GraphNode, state: NodeRenderState): NodeVisualStyle 
 Prepare styles for image export:
 
 ```typescript
-import { ExportManager } from "@exocortex/obsidian-plugin";
+import { ExportManager } from "./presentation/renderers/graph";
 
 const exportManager = new ExportManager(renderer);
 


### PR DESCRIPTION
## Summary
- Make `GraphLayoutRenderer` the primary example in basic-usage.md
- Update all import statements from `@exocortex/obsidian-plugin` to relative paths `./presentation/renderers/graph`
- Move manual PixiJS/ForceSimulation setup to "Advanced" section
- Update 31 documentation files for consistency

## Test plan
- [x] Build succeeds
- [x] Unit tests pass
- [x] Documentation files have correct import patterns

Closes #1316