### PR TITLE
feat: show Create Task button in all DailyNote assets

### DIFF
--- a/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
+++ b/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
@@ -5,7 +5,6 @@ import {
   hasEmptyProperties,
   needsFolderRepair,
   extractDailyNoteDate,
-  isCurrentDateGteDay,
   isPrototypeClass,
 } from "./helpers";
 import { AssetClass } from "../../constants";
@@ -128,7 +127,7 @@ export function canCreateSubclass(
 
 /**
  * Can execute "Create Task for DailyNote" command
- * Available for: pn__DailyNote assets when current date >= pn__DailyNote_day
+ * Available for: all pn__DailyNote assets (past, present, and future dates)
  */
 export function canCreateTaskForDailyNote(
   context: CommandVisibilityContext,
@@ -139,5 +138,5 @@ export function canCreateTaskForDailyNote(
   const dailyNoteDate = extractDailyNoteDate(context.metadata);
   if (!dailyNoteDate) return false;
 
-  return isCurrentDateGteDay(dailyNoteDate);
+  return true;
 }

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
@@ -725,7 +725,7 @@ describe("ButtonGroupsBuilder - build", () => {
     expect(createTaskButton?.label).toBe("Create Task");
   });
 
-  it("should not show Create Task button for DailyNote with future date", async () => {
+  it("should show Create Task button for DailyNote with future date", async () => {
     const mockFile = {
       path: "2099-12-31.md",
       parent: { path: "Daily" },
@@ -750,7 +750,7 @@ describe("ButtonGroupsBuilder - build", () => {
     const createTaskButton = creationGroup?.buttons.find(
       (b) => b.id === "create-task-for-dailynote",
     );
-    expect(createTaskButton?.visible ?? false).toBe(false);
+    expect(createTaskButton?.visible).toBe(true);
   });
 
   it("should handle DailyNote with wiki-link date format", async () => {

--- a/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.taskCreation.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.taskCreation.test.ts
@@ -184,7 +184,7 @@ describe("CommandVisibility - Task Creation Commands", () => {
       expect(canCreateTaskForDailyNote(context)).toBe(true);
     });
 
-    it("should return false for DailyNote with future date", () => {
+    it("should return true for DailyNote with future date", () => {
       const future = new Date();
       future.setFullYear(future.getFullYear() + 1);
       const futureStr = `${future.getFullYear()}-${String(future.getMonth() + 1).padStart(2, "0")}-${String(future.getDate()).padStart(2, "0")}`;
@@ -199,7 +199,7 @@ describe("CommandVisibility - Task Creation Commands", () => {
         currentFolder: "",
         expectedFolder: null,
       };
-      expect(canCreateTaskForDailyNote(context)).toBe(false);
+      expect(canCreateTaskForDailyNote(context)).toBe(true);
     });
 
     it("should return false for non-DailyNote asset", () => {


### PR DESCRIPTION
## Summary

- Remove date restriction from `canCreateTaskForDailyNote` visibility rule
- The Create Task button is now visible for ALL DailyNote assets regardless of date
- Users can now plan ahead by creating tasks for future dates

## Changes

- Modified `packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts` to remove the `isCurrentDateGteDay` check
- Updated test expectations in both unit test files

## Acceptance Criteria from Issue

- ✅ Create Task button visible for DailyNote with past date
- ✅ Create Task button visible for DailyNote with today's date
- ✅ Create Task button visible for DailyNote with future date (NEW)
- ✅ Button not visible for non-DailyNote assets (no regression)
- ✅ Button not visible for archived DailyNote (no regression)

Closes #1331