### PR TITLE
docs: add documentation for 3D graph visualization module

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,8 +365,11 @@ See **[SPARQL 1.2 Features](./docs/sparql/SPARQL-1.2-Features.md)** for complete
 - **[SPARQL 1.2 Features](./docs/sparql/SPARQL-1.2-Features.md)** — LATERAL, PREFIX*, directionality, and more
 - **[SPARQL 1.2 Migration](./docs/sparql/SPARQL-1.2-Migration.md)** — Upgrading from SPARQL 1.1
 
-### Graph View & Inference
-- **[Inference & Reasoning Guide](./docs/graph-view/guides/inference.md)** — RDFS/OWL inference, neighborhood exploration, justifications
+### Graph View & Visualization
+- **[Graph View Overview](./docs/graph-view/README.md)** — Introduction to 2D and 3D graph visualization
+- **[3D Visualization Guide](./docs/graph-view/guides/3d-visualization.md)** — WebGL-powered 3D graph exploration
+- **[Configuration Reference](./docs/graph-view/guides/configuration.md)** — All configuration options for graph views
+- **[Inference & Reasoning Guide](./docs/graph-view/guides/inference.md)** — RDFS/OWL inference, neighborhood exploration
 
 ### Layout Code Blocks
 

--- a/docs/graph-view/README.md
+++ b/docs/graph-view/README.md
@@ -1,0 +1,81 @@
+# Graph View Documentation
+
+Interactive visualization of your knowledge graph with support for both 2D and 3D rendering.
+
+## Overview
+
+The Graph View module provides:
+- **2D Graph Visualization** — Fast, canvas-based rendering for exploring relationships
+- **3D Graph Visualization** — WebGL-powered immersive 3D exploration using Three.js
+- **Force-Directed Layouts** — Automatic node positioning based on relationships
+- **Semantic Coloring** — Nodes and edges colored by ontology namespace
+- **Interactive Navigation** — Zoom, pan, rotate, and click-to-open nodes
+
+## Quick Start
+
+### Enabling 3D Mode
+
+The 3D visualization is available in the Graph View panel:
+
+1. Open Graph View via `Ctrl/Cmd + Shift + G` or Command Palette
+2. Click the **3D** toggle button in the toolbar
+3. Use mouse/touch to orbit, pan, and zoom
+
+### Navigation Controls
+
+| Action | Mouse | Touch |
+|--------|-------|-------|
+| Orbit/Rotate | Left-click + drag | One finger drag |
+| Pan | Right-click + drag | Two finger drag |
+| Zoom | Scroll wheel | Pinch |
+| Select Node | Click | Tap |
+| Fit to View | Double-click background | Double-tap |
+
+## Documentation
+
+### User Guides
+- **[3D Visualization Guide](./guides/3d-visualization.md)** — Complete guide to 3D mode
+- **[Inference & Reasoning](./guides/inference.md)** — RDFS/OWL inference in graph view
+
+### Configuration
+- **[Configuration Reference](./guides/configuration.md)** — All configuration options for 2D and 3D modes
+
+### Examples
+- **[3D Graph Examples](./examples/3d-graph.md)** — Common use cases and code snippets
+
+## Architecture
+
+```
+graph-view/
+├── 2d/                    # 2D Canvas-based rendering
+│   ├── ForceSimulation2D  # D3-style force layout
+│   └── CanvasRenderer     # HTML5 Canvas rendering
+│
+├── 3d/                    # 3D WebGL rendering (Three.js)
+│   ├── Scene3DManager     # WebGL scene, camera, controls
+│   ├── ForceSimulation3D  # 3D force-directed layout
+│   ├── Graph3DThemeService    # Theme-aware coloring
+│   ├── Graph3DPerformanceManager  # LOD, frustum culling
+│   └── TouchGestureManager    # Mobile touch support
+│
+├── search/                # Search functionality
+└── GraphViewPanel         # Main UI container
+```
+
+## Performance
+
+### 3D Mode Performance Targets
+
+| Graph Size | Target FPS | Optimizations Enabled |
+|------------|------------|----------------------|
+| < 100 nodes | 60 FPS | None required |
+| 100-500 nodes | 30+ FPS | LOD for labels |
+| 500-1000 nodes | 30+ FPS | LOD + Frustum culling |
+| > 1000 nodes | 20+ FPS | All optimizations |
+
+See **[3D Visualization Guide](./guides/3d-visualization.md#performance-optimization)** for tuning options.
+
+## Related Documentation
+
+- **[SPARQL Query Examples](../sparql/Query-Examples.md)** — Query patterns for graph exploration
+- **[Core API](../api/Core-API.md)** — Programmatic graph access

--- a/docs/graph-view/examples/3d-graph.md
+++ b/docs/graph-view/examples/3d-graph.md
@@ -1,0 +1,440 @@
+# 3D Graph Examples
+
+Practical examples for using the 3D graph visualization module.
+
+## Basic Usage
+
+### Creating a 3D Scene
+
+```typescript
+import {
+  Scene3DManager,
+  ForceSimulation3D,
+  createScene3DManager,
+  createForceSimulation3D
+} from '@exocortex/obsidian-plugin';
+
+// Create and initialize the scene
+const sceneManager = createScene3DManager();
+sceneManager.initialize(document.getElementById('graph-container'));
+
+// Prepare graph data
+const nodes = [
+  { id: '1', label: 'Project A', path: '/projects/a.md' },
+  { id: '2', label: 'Task 1', path: '/tasks/1.md' },
+  { id: '3', label: 'Task 2', path: '/tasks/2.md' },
+  { id: '4', label: 'Concept X', path: '/concepts/x.md' }
+];
+
+const edges = [
+  { id: 'e1', source: '1', target: '2', label: 'contains' },
+  { id: 'e2', source: '1', target: '3', label: 'contains' },
+  { id: 'e3', source: '2', target: '4', label: 'relates' }
+];
+
+// Set up force simulation
+const simulation = createForceSimulation3D(nodes, edges);
+
+// Connect simulation to scene
+simulation.on('tick', (event) => {
+  sceneManager.updatePositions(event.nodes, edges);
+});
+
+// Render initial graph
+sceneManager.setNodes(nodes);
+sceneManager.setEdges(edges, nodes);
+
+// Start simulation
+simulation.start();
+```
+
+### Handling Node Clicks
+
+```typescript
+sceneManager.on('nodeClick', (event) => {
+  console.log('Clicked node:', event.node.label);
+  console.log('File path:', event.node.path);
+  console.log('3D position:', event.worldPosition);
+
+  // Open the file in Obsidian
+  app.workspace.openLinkText(event.node.path, '', false);
+});
+
+sceneManager.on('nodeHover', (event) => {
+  console.log('Hovering:', event.node.label);
+  // Show tooltip, highlight connected edges, etc.
+});
+
+sceneManager.on('nodeHoverEnd', (event) => {
+  console.log('Stopped hovering:', event.node.label);
+  // Hide tooltip, remove highlights
+});
+```
+
+## Custom Node Coloring
+
+### Color by Ontology Namespace
+
+```typescript
+import { Graph3DThemeService } from '@exocortex/obsidian-plugin';
+
+const themeService = new Graph3DThemeService();
+
+// Color nodes based on their ontology
+const coloredNodes = nodes.map(node => ({
+  ...node,
+  color: themeService.getNodeColorFromUri(node.metadata?.rdfType ?? '')
+}));
+
+sceneManager.setNodes(coloredNodes);
+```
+
+### Color by Custom Property
+
+```typescript
+// Color nodes by status
+const statusColors = {
+  'todo': '#F5A623',     // Orange
+  'doing': '#4A90E2',    // Blue
+  'done': '#7ED321',     // Green
+  'blocked': '#E74C3C'   // Red
+};
+
+const coloredNodes = nodes.map(node => ({
+  ...node,
+  color: statusColors[node.metadata?.status] ?? '#95A5A6'
+}));
+
+sceneManager.setNodes(coloredNodes);
+```
+
+### Dynamic Color Updates
+
+```typescript
+// Update all node colors based on a function
+sceneManager.updateAllNodeColors((node) => {
+  const age = calculateAge(node.metadata?.createdAt);
+  // Newer nodes are brighter blue, older nodes fade to gray
+  const brightness = Math.max(0.3, 1 - age / 365);
+  return colorLerp(0x4A90E2, 0x95A5A6, 1 - brightness);
+});
+
+// Update single node color
+sceneManager.updateNodeColor('node-123', 0xFF0000);
+```
+
+## Camera Control
+
+### Programmatic Camera Movement
+
+```typescript
+// Move camera to specific position
+sceneManager.setCameraPosition(
+  { x: 100, y: 50, z: 300 },  // Camera position
+  { x: 0, y: 0, z: 0 }        // Look-at target
+);
+
+// Fit all nodes in view
+sceneManager.fitToView(nodes, 1.5); // 1.5 = padding factor
+
+// Reset camera with animation
+sceneManager.resetCamera(500); // 500ms animation
+
+// Enable auto-rotate
+sceneManager.setAutoRotate(true, 1.0); // speed = 1.0
+```
+
+### Save and Restore Camera State
+
+```typescript
+// Save current view
+const savedViewport = sceneManager.getViewport();
+
+// Later, restore the view
+sceneManager.setCameraPosition(
+  savedViewport.cameraPosition,
+  savedViewport.cameraTarget
+);
+```
+
+## Performance Optimization
+
+### Large Graph Optimization
+
+```typescript
+// For graphs with 500+ nodes
+const sceneManager = createScene3DManager(
+  // Scene config
+  {
+    antialias: false,
+    pixelRatio: 1,
+    enableFog: true
+  },
+  // Node style - lower detail
+  {
+    segments: 8
+  },
+  // Edge style
+  {},
+  // Label style
+  {},
+  // Controls config
+  {},
+  // Performance config
+  {
+    lod: {
+      enabled: true,
+      labelFadeStart: 100,
+      labelFadeEnd: 150
+    },
+    frustumCulling: {
+      enabled: true,
+      updateInterval: 1
+    }
+  }
+);
+```
+
+### Toggle Performance Features
+
+```typescript
+// Enable/disable LOD dynamically
+sceneManager.setLODEnabled(true);
+
+// Enable/disable frustum culling
+sceneManager.setFrustumCullingEnabled(true);
+
+// Check current state
+console.log('LOD enabled:', sceneManager.getLODEnabled());
+console.log('Culling enabled:', sceneManager.getFrustumCullingEnabled());
+```
+
+### Monitor Performance
+
+```typescript
+// Get renderer stats
+const stats = sceneManager.getStats();
+console.log('FPS:', stats.fps);
+console.log('Visible nodes:', stats.nodeCount);
+console.log('Draw calls:', stats.drawCalls);
+console.log('Triangles:', stats.triangles);
+
+// Get detailed performance stats
+const perfStats = sceneManager.getPerformanceStats();
+console.log('Culled nodes:', perfStats?.culledNodes);
+console.log('Culling efficiency:', perfStats?.cullingEfficiency + '%');
+```
+
+## Force Simulation Control
+
+### Custom Force Parameters
+
+```typescript
+const simulation = createForceSimulation3D(nodes, edges, {
+  chargeStrength: -500,    // Stronger repulsion
+  linkDistance: 150,       // Longer edge length
+  centerStrength: 0.05,    // Weaker center pull
+  collisionRadius: 2.0,    // Larger collision detection
+  velocityDecay: 0.3       // Less damping = more movement
+});
+```
+
+### Control Simulation Lifecycle
+
+```typescript
+// Start with custom alpha
+simulation.start(0.5);
+
+// Pause simulation
+simulation.stop();
+
+// Resume simulation
+simulation.restart(0.3);
+
+// Check if running
+console.log('Running:', simulation.isRunning());
+
+// Get current alpha (energy level)
+console.log('Alpha:', simulation.getAlpha());
+```
+
+### Pin Nodes to Fixed Positions
+
+```typescript
+// Pin a node at specific position
+simulation.pinNode('node-1', { x: 0, y: 0, z: 0 });
+
+// Unpin a node
+simulation.unpinNode('node-1');
+
+// Check if node is pinned
+const isPinned = simulation.isNodePinned('node-1');
+```
+
+## Theme Integration
+
+### Listen for Theme Changes
+
+```typescript
+import { Graph3DThemeService } from '@exocortex/obsidian-plugin';
+
+const themeService = new Graph3DThemeService();
+
+themeService.on('themeChange', (event) => {
+  console.log('Theme changed to:', event.mode);
+
+  // Update scene colors
+  const colors = event.colors;
+  sceneManager.setBackgroundColor(parseInt(colors.background.slice(1), 16));
+  sceneManager.setFogColor(parseInt(colors.fogColor.slice(1), 16));
+  sceneManager.setLabelStyle(colors.labelColor, colors.labelBackground);
+
+  // Update node colors
+  sceneManager.updateAllNodeColors((node) => {
+    const namespace = themeService.getNamespaceFromUri(node.metadata?.rdfType);
+    return parseInt(colors.nodeColors[namespace].slice(1), 16);
+  });
+});
+```
+
+### Manual Theme Detection
+
+```typescript
+const themeService = new Graph3DThemeService();
+
+// Get current theme mode
+const mode = themeService.getThemeMode(); // 'dark' or 'light'
+
+// Get theme colors
+const colors = themeService.getThemeColors();
+console.log('Background:', colors.background);
+console.log('Node colors:', colors.nodeColors);
+```
+
+## Event Handling
+
+### All Available Events
+
+```typescript
+// Node events
+sceneManager.on('nodeClick', (e) => { /* ... */ });
+sceneManager.on('nodeHover', (e) => { /* ... */ });
+sceneManager.on('nodeHoverEnd', (e) => { /* ... */ });
+
+// Edge events
+sceneManager.on('edgeClick', (e) => { /* ... */ });
+sceneManager.on('edgeHover', (e) => { /* ... */ });
+sceneManager.on('edgeHoverEnd', (e) => { /* ... */ });
+
+// Background events
+sceneManager.on('backgroundClick', (e) => { /* ... */ });
+
+// Camera events
+sceneManager.on('cameraChange', (e) => {
+  console.log('Camera moved to:', e.worldPosition);
+});
+
+// Render events (every frame)
+sceneManager.on('render', () => {
+  // Called every frame - use sparingly!
+});
+
+// Simulation events
+simulation.on('tick', (e) => {
+  console.log('Alpha:', e.alpha);
+  console.log('Node positions updated');
+});
+
+simulation.on('end', (e) => {
+  console.log('Simulation converged at alpha:', e.alpha);
+});
+```
+
+### Remove Event Listeners
+
+```typescript
+const handler = (event) => { /* ... */ };
+
+// Add listener
+sceneManager.on('nodeClick', handler);
+
+// Remove listener
+sceneManager.off('nodeClick', handler);
+```
+
+## Cleanup
+
+### Proper Resource Disposal
+
+```typescript
+// Stop simulation first
+simulation.stop();
+
+// Destroy scene manager (releases all GPU resources)
+sceneManager.destroy();
+
+// Destroy theme service
+themeService.destroy();
+```
+
+## Integration with Obsidian
+
+### Opening Files from Nodes
+
+```typescript
+sceneManager.on('nodeClick', async (event) => {
+  const file = app.vault.getAbstractFileByPath(event.node.path);
+  if (file instanceof TFile) {
+    await app.workspace.openLinkText(event.node.path, '', false);
+  }
+});
+```
+
+### Building Graph from Vault
+
+```typescript
+import { SparqlService } from '@exocortex/obsidian-plugin';
+
+// Query all assets and relationships
+const sparqlService = new SparqlService(vaultAdapter);
+const results = await sparqlService.query(`
+  SELECT ?asset ?label ?relatedAsset ?relatedLabel ?predicate
+  WHERE {
+    ?asset exo:Asset_label ?label .
+    OPTIONAL {
+      ?asset ?predicate ?relatedAsset .
+      ?relatedAsset exo:Asset_label ?relatedLabel .
+      FILTER(?predicate != exo:Asset_label)
+    }
+  }
+`);
+
+// Convert to graph data
+const nodes = new Map();
+const edges = [];
+
+for (const binding of results) {
+  // Add nodes
+  if (!nodes.has(binding.asset.value)) {
+    nodes.set(binding.asset.value, {
+      id: binding.asset.value,
+      label: binding.label.value,
+      path: uriToPath(binding.asset.value)
+    });
+  }
+
+  // Add edges
+  if (binding.relatedAsset) {
+    edges.push({
+      id: `${binding.asset.value}-${binding.predicate.value}-${binding.relatedAsset.value}`,
+      source: binding.asset.value,
+      target: binding.relatedAsset.value,
+      label: binding.predicate.value.split('#').pop()
+    });
+  }
+}
+
+// Render graph
+sceneManager.setNodes([...nodes.values()]);
+sceneManager.setEdges(edges, [...nodes.values()]);
+```

--- a/docs/graph-view/guides/3d-visualization.md
+++ b/docs/graph-view/guides/3d-visualization.md
@@ -1,0 +1,295 @@
+# 3D Graph Visualization Guide
+
+Complete guide to using the 3D graph visualization mode in Exocortex.
+
+## Overview
+
+The 3D visualization module renders your knowledge graph in a three-dimensional space using WebGL2 and Three.js. This provides:
+
+- **Immersive exploration** — Navigate through your knowledge in 3D space
+- **Better spatial relationships** — See complex connections without edge overlap
+- **Force-directed layout** — Nodes automatically arrange based on relationships
+- **Theme-aware coloring** — Nodes colored by ontology namespace
+
+## Getting Started
+
+### Enabling 3D Mode
+
+1. Open Graph View via `Ctrl/Cmd + Shift + G` or Command Palette → "Open Graph View"
+2. Click the **3D** toggle button in the toolbar (top-right)
+3. The view transitions from 2D canvas to 3D WebGL rendering
+
+### Basic Navigation
+
+| Action | Mouse | Touch | Keyboard |
+|--------|-------|-------|----------|
+| **Orbit/Rotate** | Left-click + drag | One finger drag | Arrow keys |
+| **Pan** | Right-click + drag | Two finger drag | Shift + arrows |
+| **Zoom** | Scroll wheel | Pinch gesture | +/- keys |
+| **Select Node** | Click | Tap | — |
+| **Fit to View** | Double-click background | Double-tap | F key |
+| **Reset Camera** | — | — | R key |
+
+### Node Interaction
+
+- **Single click**: Select node, opens file in new pane
+- **Hover**: Highlights node and connected edges
+- **Long press** (mobile): Same as click
+
+## Visual Features
+
+### Ontology-Based Node Coloring
+
+Nodes are automatically colored based on their ontology namespace:
+
+| Namespace | Color (Dark) | Color (Light) | Usage |
+|-----------|--------------|---------------|-------|
+| `exo#` | Blue (#4A90E2) | Blue (#2563EB) | Exocortex core types |
+| `ems#` | Green (#7ED321) | Green (#16A34A) | Tasks, Projects, Areas |
+| `ims#` | Purple (#9B59B6) | Purple (#7C3AED) | Concepts, Notes |
+| `rdf#` | Orange (#F5A623) | Orange (#D97706) | RDF vocabulary |
+| `owl#` | Red (#E74C3C) | Red (#DC2626) | OWL vocabulary |
+| Unknown | Gray (#95A5A6) | Gray (#6B7280) | Custom namespaces |
+
+### Edge Coloring by Predicate
+
+Edges are colored based on relationship type:
+
+| Predicate | Color | Description |
+|-----------|-------|-------------|
+| `rdf:type` | Orange | Class membership |
+| `rdfs:subClassOf` | Purple | Class hierarchy |
+| `owl:sameAs` | Blue | Identity |
+| Default | Slate gray | All other predicates |
+
+### Labels
+
+Node labels display asset labels with:
+- **Billboard behavior**: Labels always face the camera
+- **Distance-based fading**: Labels fade out at distance for performance
+- **Theme-aware styling**: Text/background adapt to dark/light mode
+
+## Force-Directed Layout
+
+The 3D layout uses force simulation with these forces:
+
+### Force Types
+
+1. **Center Force** — Pulls nodes toward center
+2. **Charge Force** — Repels nodes from each other
+3. **Link Force** — Attracts connected nodes
+4. **Collision Force** — Prevents node overlap
+
+### Layout Behavior
+
+The simulation runs automatically when:
+- Graph data is loaded
+- Nodes are added/removed
+- User triggers manual restart
+
+Simulation stops when forces stabilize (alpha < 0.01).
+
+### Pinning Nodes
+
+You can pin nodes to fixed positions:
+- Hold `Shift` + drag to pin a node
+- Pinned nodes won't move during simulation
+- Useful for creating custom layouts
+
+## Performance Optimization
+
+### Performance Targets
+
+| Graph Size | Target FPS | Enabled Optimizations |
+|------------|------------|----------------------|
+| < 100 nodes | 60 FPS | None required |
+| 100-500 nodes | 30+ FPS | LOD for labels |
+| 500-1000 nodes | 30+ FPS | LOD + Frustum culling |
+| > 1000 nodes | 20+ FPS | All optimizations |
+
+### Level of Detail (LOD)
+
+LOD automatically:
+- Fades label opacity based on camera distance
+- Hides labels for distant nodes (saves GPU draw calls)
+- Configurable fade distances
+
+Default LOD settings:
+```typescript
+{
+  labelFadeStart: 150,    // Start fading at 150 units
+  labelFadeEnd: 250,      // Fully hidden at 250 units
+  labelMinOpacity: 0      // Minimum opacity (fully transparent)
+}
+```
+
+### Frustum Culling
+
+Frustum culling automatically:
+- Hides nodes outside camera view
+- Hides edges connected to culled nodes
+- Reduces GPU workload for large graphs
+
+### WebGL Context Recovery
+
+The system automatically recovers from WebGL context loss:
+- Re-creates all GPU resources (materials, textures)
+- Maximum 3 recovery attempts
+- Shows recovery message in UI
+
+### Performance Tips
+
+1. **Large graphs (1000+ nodes)**: Enable frustum culling
+2. **Mobile devices**: Reduce pixel ratio, enable all optimizations
+3. **Complex scenes**: Hide labels (`L` key) when navigating
+4. **Slow machines**: Reduce node detail segments
+
+## Configuration
+
+See **[Configuration Reference](./configuration.md)** for all available options.
+
+### Quick Configuration Examples
+
+#### High Performance Mode
+```typescript
+{
+  config: {
+    antialias: false,
+    pixelRatio: 1
+  },
+  performanceConfig: {
+    lod: { enabled: true },
+    frustumCulling: { enabled: true }
+  }
+}
+```
+
+#### High Quality Mode
+```typescript
+{
+  config: {
+    antialias: true,
+    pixelRatio: 2
+  },
+  nodeStyle: {
+    segments: 32  // Smoother spheres
+  }
+}
+```
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `L` | Toggle labels visibility |
+| `A` | Toggle auto-rotate |
+| `F` | Fit all nodes in view |
+| `R` | Reset camera position |
+| `+` / `-` | Zoom in/out |
+| Arrow keys | Orbit camera |
+| `Shift` + arrows | Pan camera |
+
+## Touch Gestures (Mobile/Tablet)
+
+| Gesture | Action |
+|---------|--------|
+| One finger drag | Orbit camera |
+| Two finger drag | Pan camera |
+| Pinch | Zoom |
+| Tap | Select node |
+| Double-tap | Fit to view |
+| Long press | Select node (alternative) |
+
+## Theming
+
+The 3D view automatically adapts to Obsidian's theme:
+
+### Dark Mode
+- Background: `#1E1E1E`
+- Labels: Light text on semi-transparent dark background
+- Fog: Matches background for depth fade
+
+### Light Mode
+- Background: `#F5F5F5`
+- Labels: Dark text on semi-transparent light background
+- Fog: Matches background
+
+Theme changes are detected automatically via MutationObserver.
+
+## Troubleshooting
+
+### Black Screen / No Rendering
+
+1. **Check WebGL2 support**: Visit [get.webgl.org](https://get.webgl.org) to verify
+2. **Update graphics drivers**: WebGL2 requires modern drivers
+3. **Try disabling hardware acceleration**: If using integrated graphics
+
+### Low FPS / Stuttering
+
+1. Enable all performance optimizations (LOD + frustum culling)
+2. Reduce pixel ratio to 1
+3. Disable anti-aliasing
+4. Hide labels when navigating
+
+### Labels Not Visible
+
+1. Check LOD settings — labels may be faded at current distance
+2. Press `L` to toggle labels on
+3. Zoom closer to nodes
+
+### Context Loss (WebGL crash)
+
+This happens when GPU resources are exhausted:
+1. Reduce graph size (filter nodes)
+2. Lower quality settings
+3. Close other GPU-intensive applications
+
+## API Reference
+
+For programmatic access to 3D visualization:
+
+### Scene3DManager
+
+Main class for 3D scene management:
+
+```typescript
+import { Scene3DManager } from '@exocortex/obsidian-plugin';
+
+const manager = new Scene3DManager({
+  backgroundColor: 0x1a1a2e,
+  antialias: true
+});
+
+manager.initialize(containerElement);
+manager.setNodes(nodes);
+manager.setEdges(edges, nodes);
+
+// Event handling
+manager.on('nodeClick', (event) => {
+  console.log('Clicked:', event.node.label);
+});
+
+// Cleanup
+manager.destroy();
+```
+
+### ForceSimulation3D
+
+Force-directed layout in 3D:
+
+```typescript
+import { ForceSimulation3D } from '@exocortex/obsidian-plugin';
+
+const simulation = new ForceSimulation3D(nodes, edges, {
+  chargeStrength: -300,
+  linkDistance: 100
+});
+
+simulation.on('tick', (event) => {
+  manager.updatePositions(event.nodes, edges);
+});
+
+simulation.start();
+```
+
+See **[Configuration Reference](./configuration.md)** for complete API documentation.

--- a/docs/graph-view/guides/configuration.md
+++ b/docs/graph-view/guides/configuration.md
@@ -1,0 +1,662 @@
+# Graph View Configuration Reference
+
+Complete reference for all configuration options in 2D and 3D graph visualization modes.
+
+## 3D Scene Configuration
+
+### Scene3DConfig
+
+Main configuration for the 3D scene:
+
+```typescript
+interface Scene3DConfig {
+  /** Background color (hex number). Default: 0x1a1a2e */
+  backgroundColor: number;
+
+  /** Ambient light intensity (0-1). Default: 0.4 */
+  ambientLightIntensity: number;
+
+  /** Directional light intensity (0-1). Default: 0.8 */
+  directionalLightIntensity: number;
+
+  /** Camera field of view in degrees. Default: 60 */
+  cameraFov: number;
+
+  /** Camera near clipping plane. Default: 0.1 */
+  cameraNear: number;
+
+  /** Camera far clipping plane. Default: 10000 */
+  cameraFar: number;
+
+  /** Enable anti-aliasing. Default: true */
+  antialias: boolean;
+
+  /** Device pixel ratio. Default: min(devicePixelRatio, 2) */
+  pixelRatio: number;
+
+  /** Initial camera distance from center. Default: 500 */
+  cameraDistance: number;
+
+  /** Enable fog for depth perception. Default: true */
+  enableFog: boolean;
+
+  /** Fog near distance. Default: 500 */
+  fogNear: number;
+
+  /** Fog far distance. Default: 2000 */
+  fogFar: number;
+}
+```
+
+### Default Values
+
+```typescript
+const DEFAULT_SCENE_3D_CONFIG = {
+  backgroundColor: 0x1a1a2e,
+  ambientLightIntensity: 0.4,
+  directionalLightIntensity: 0.8,
+  cameraFov: 60,
+  cameraNear: 0.1,
+  cameraFar: 10000,
+  antialias: true,
+  pixelRatio: Math.min(window.devicePixelRatio, 2),
+  cameraDistance: 500,
+  enableFog: true,
+  fogNear: 500,
+  fogFar: 2000
+};
+```
+
+## Node Style Configuration
+
+### Node3DStyle
+
+Visual appearance of nodes:
+
+```typescript
+interface Node3DStyle {
+  /** Base radius in world units. Default: 8 */
+  radius: number;
+
+  /** Node color (hex number). Default: 0x6366f1 */
+  color: number;
+
+  /** Emissive color for glow effect. Default: 0x6366f1 */
+  emissive: number;
+
+  /** Emissive intensity. Default: 0.2 */
+  emissiveIntensity: number;
+
+  /** Material roughness (0-1). Default: 0.7 */
+  roughness: number;
+
+  /** Material metalness (0-1). Default: 0.3 */
+  metalness: number;
+
+  /** Sphere segments (detail level). Default: 16 */
+  segments: number;
+}
+```
+
+### Default Values
+
+```typescript
+const DEFAULT_NODE_3D_STYLE = {
+  radius: 8,
+  color: 0x6366f1,
+  emissive: 0x6366f1,
+  emissiveIntensity: 0.2,
+  roughness: 0.7,
+  metalness: 0.3,
+  segments: 16
+};
+```
+
+## Edge Style Configuration
+
+### Edge3DStyle
+
+Visual appearance of edges:
+
+```typescript
+interface Edge3DStyle {
+  /** Line width in pixels. Default: 1 */
+  lineWidth: number;
+
+  /** Line color (hex number). Default: 0x64748b */
+  color: number;
+
+  /** Line opacity (0-1). Default: 0.6 */
+  opacity: number;
+
+  /** Use tube geometry instead of lines. Default: false */
+  useTube: boolean;
+
+  /** Tube radius (if using tubes). Default: 0.5 */
+  tubeRadius: number;
+
+  /** Tube segments (detail level). Default: 8 */
+  tubeSegments: number;
+}
+```
+
+### Default Values
+
+```typescript
+const DEFAULT_EDGE_3D_STYLE = {
+  lineWidth: 1,
+  color: 0x64748b,
+  opacity: 0.6,
+  useTube: false,
+  tubeRadius: 0.5,
+  tubeSegments: 8
+};
+```
+
+## Label Style Configuration
+
+### Label3DStyle
+
+Visual appearance of labels:
+
+```typescript
+interface Label3DStyle {
+  /** Font size in pixels. Default: 14 */
+  fontSize: number;
+
+  /** Font family. Default: "Inter, system-ui, sans-serif" */
+  fontFamily: string;
+
+  /** Text color (CSS color). Default: "#e2e8f0" */
+  color: string;
+
+  /** Background color (CSS color or null). Default: "rgba(26, 26, 46, 0.8)" */
+  backgroundColor: string | null;
+
+  /** Padding around text. Default: 4 */
+  padding: number;
+
+  /** Billboard behavior - always face camera. Default: true */
+  billboard: boolean;
+
+  /** Scale factor for sprite size. Default: 1 */
+  scale: number;
+
+  /** Y offset from node center. Default: 12 */
+  yOffset: number;
+}
+```
+
+### Default Values
+
+```typescript
+const DEFAULT_LABEL_3D_STYLE = {
+  fontSize: 14,
+  fontFamily: "Inter, system-ui, sans-serif",
+  color: "#e2e8f0",
+  backgroundColor: "rgba(26, 26, 46, 0.8)",
+  padding: 4,
+  billboard: true,
+  scale: 1,
+  yOffset: 12
+};
+```
+
+## Orbit Controls Configuration
+
+### OrbitControlsConfig
+
+Camera orbit controls settings:
+
+```typescript
+interface OrbitControlsConfig {
+  /** Enable orbit rotation. Default: true */
+  enableRotate: boolean;
+
+  /** Enable zoom. Default: true */
+  enableZoom: boolean;
+
+  /** Enable panning. Default: true */
+  enablePan: boolean;
+
+  /** Enable damping (inertia). Default: true */
+  enableDamping: boolean;
+
+  /** Damping factor. Default: 0.05 */
+  dampingFactor: number;
+
+  /** Rotation speed multiplier. Default: 1.0 */
+  rotateSpeed: number;
+
+  /** Zoom speed multiplier. Default: 1.0 */
+  zoomSpeed: number;
+
+  /** Pan speed multiplier. Default: 1.0 */
+  panSpeed: number;
+
+  /** Minimum zoom distance. Default: 10 */
+  minDistance: number;
+
+  /** Maximum zoom distance. Default: 5000 */
+  maxDistance: number;
+
+  /** Minimum polar angle (vertical rotation limit). Default: 0 */
+  minPolarAngle: number;
+
+  /** Maximum polar angle (vertical rotation limit). Default: Math.PI */
+  maxPolarAngle: number;
+
+  /** Auto-rotate the scene. Default: false */
+  autoRotate: boolean;
+
+  /** Auto-rotate speed. Default: 2.0 */
+  autoRotateSpeed: number;
+}
+```
+
+### Default Values
+
+```typescript
+const DEFAULT_ORBIT_CONTROLS_CONFIG = {
+  enableRotate: true,
+  enableZoom: true,
+  enablePan: true,
+  enableDamping: true,
+  dampingFactor: 0.05,
+  rotateSpeed: 1.0,
+  zoomSpeed: 1.0,
+  panSpeed: 1.0,
+  minDistance: 10,
+  maxDistance: 5000,
+  minPolarAngle: 0,
+  maxPolarAngle: Math.PI,
+  autoRotate: false,
+  autoRotateSpeed: 2.0
+};
+```
+
+## Force Simulation Configuration
+
+### ForceSimulation3DConfig
+
+Force-directed layout settings:
+
+```typescript
+interface ForceSimulation3DConfig {
+  /** Repulsion strength between nodes. Default: -300 */
+  chargeStrength: number;
+
+  /** Target distance between linked nodes. Default: 100 */
+  linkDistance: number;
+
+  /** Center attraction strength. Default: 0.1 */
+  centerStrength: number;
+
+  /** Collision detection radius multiplier. Default: 1.5 */
+  collisionRadius: number;
+
+  /** Simulation alpha (energy level). Default: 1 */
+  alpha: number;
+
+  /** Target alpha for convergence. Default: 0 */
+  alphaTarget: number;
+
+  /** Alpha decay rate per tick. Default: 0.0228 */
+  alphaDecay: number;
+
+  /** Velocity decay (damping) per tick. Default: 0.4 */
+  velocityDecay: number;
+
+  /** Minimum alpha before stopping. Default: 0.01 */
+  alphaMin: number;
+
+  /** Use Barnes-Hut optimization. Default: true */
+  useBarnesHut: boolean;
+
+  /** Barnes-Hut theta parameter. Default: 0.9 */
+  theta: number;
+}
+```
+
+### Default Values
+
+```typescript
+const DEFAULT_FORCE_SIMULATION_3D_CONFIG = {
+  chargeStrength: -300,
+  linkDistance: 100,
+  centerStrength: 0.1,
+  collisionRadius: 1.5,
+  alpha: 1,
+  alphaTarget: 0,
+  alphaDecay: 0.0228,
+  velocityDecay: 0.4,
+  alphaMin: 0.01,
+  useBarnesHut: true,
+  theta: 0.9
+};
+```
+
+## Performance Configuration
+
+### LODConfig
+
+Level of Detail settings:
+
+```typescript
+interface LODConfig {
+  /** Enable LOD system. Default: true */
+  enabled: boolean;
+
+  /** Distance at which labels start fading. Default: 150 */
+  labelFadeStart: number;
+
+  /** Distance at which labels are fully hidden. Default: 250 */
+  labelFadeEnd: number;
+
+  /** Minimum opacity for labels during fade (0-1). Default: 0 */
+  labelMinOpacity: number;
+
+  /** Distance at which node detail reduces. Default: 200 */
+  nodeDetailFadeStart: number;
+
+  /** Distance at which nodes use minimum detail. Default: 400 */
+  nodeDetailFadeEnd: number;
+}
+```
+
+### FrustumCullingConfig
+
+Frustum culling settings:
+
+```typescript
+interface FrustumCullingConfig {
+  /** Enable frustum culling. Default: true */
+  enabled: boolean;
+
+  /** Padding around frustum for culling. Default: 50 */
+  padding: number;
+
+  /** Update culling every N frames. Default: 2 */
+  updateInterval: number;
+}
+```
+
+### WebGLRecoveryConfig
+
+WebGL context recovery settings:
+
+```typescript
+interface WebGLRecoveryConfig {
+  /** Enable automatic context recovery. Default: true */
+  enabled: boolean;
+
+  /** Maximum recovery attempts. Default: 3 */
+  maxAttempts: number;
+
+  /** Delay between recovery attempts (ms). Default: 1000 */
+  retryDelay: number;
+
+  /** Show recovery UI message. Default: true */
+  showRecoveryMessage: boolean;
+}
+```
+
+### Default Performance Values
+
+```typescript
+const DEFAULT_LOD_CONFIG = {
+  enabled: true,
+  labelFadeStart: 150,
+  labelFadeEnd: 250,
+  labelMinOpacity: 0,
+  nodeDetailFadeStart: 200,
+  nodeDetailFadeEnd: 400
+};
+
+const DEFAULT_FRUSTUM_CULLING_CONFIG = {
+  enabled: true,
+  padding: 50,
+  updateInterval: 2
+};
+
+const DEFAULT_WEBGL_RECOVERY_CONFIG = {
+  enabled: true,
+  maxAttempts: 3,
+  retryDelay: 1000,
+  showRecoveryMessage: true
+};
+```
+
+## Theme Configuration
+
+### ThemeColors
+
+Color configuration for a theme:
+
+```typescript
+interface ThemeColors {
+  /** Scene background color (hex) */
+  background: string;
+
+  /** Node colors by ontology namespace */
+  nodeColors: Record<OntologyNamespace, string>;
+
+  /** Edge colors by predicate type */
+  edgeColors: {
+    rdfType: string;
+    subClassOf: string;
+    sameAs: string;
+    default: string;
+  };
+
+  /** Label text color */
+  labelColor: string;
+
+  /** Label background color */
+  labelBackground: string;
+
+  /** Fog color */
+  fogColor: string;
+}
+```
+
+### Default Theme Configuration
+
+```typescript
+const DEFAULT_THEME_CONFIG = {
+  dark: {
+    background: "#1E1E1E",
+    nodeColors: {
+      exo: "#4A90E2",
+      ems: "#7ED321",
+      ims: "#9B59B6",
+      rdf: "#F5A623",
+      rdfs: "#E67E22",
+      owl: "#E74C3C",
+      xsd: "#1ABC9C",
+      unknown: "#95A5A6"
+    },
+    edgeColors: {
+      rdfType: "#F5A623",
+      subClassOf: "#9B59B6",
+      sameAs: "#3498DB",
+      default: "#64748B"
+    },
+    labelColor: "#E2E8F0",
+    labelBackground: "rgba(30, 30, 30, 0.85)",
+    fogColor: "#1E1E1E"
+  },
+  light: {
+    background: "#F5F5F5",
+    nodeColors: {
+      exo: "#2563EB",
+      ems: "#16A34A",
+      ims: "#7C3AED",
+      rdf: "#D97706",
+      rdfs: "#C2410C",
+      owl: "#DC2626",
+      xsd: "#0D9488",
+      unknown: "#6B7280"
+    },
+    edgeColors: {
+      rdfType: "#D97706",
+      subClassOf: "#7C3AED",
+      sameAs: "#2563EB",
+      default: "#475569"
+    },
+    labelColor: "#1E293B",
+    labelBackground: "rgba(245, 245, 245, 0.85)",
+    fogColor: "#F5F5F5"
+  }
+};
+```
+
+## Touch Gesture Configuration
+
+### TouchGestureConfig
+
+Touch gesture settings for mobile devices:
+
+```typescript
+interface TouchGestureConfig {
+  /** Enable tap gesture. Default: true */
+  enableTap: boolean;
+
+  /** Enable double-tap gesture. Default: true */
+  enableDoubleTap: boolean;
+
+  /** Enable long press gesture. Default: true */
+  enableLongPress: boolean;
+
+  /** Maximum movement for tap detection (pixels). Default: 10 */
+  tapMaxMovement: number;
+
+  /** Maximum duration for tap detection (ms). Default: 300 */
+  tapMaxDuration: number;
+
+  /** Maximum interval between double-taps (ms). Default: 300 */
+  doubleTapMaxInterval: number;
+
+  /** Duration for long press detection (ms). Default: 500 */
+  longPressDuration: number;
+}
+```
+
+### Default Values
+
+```typescript
+const DEFAULT_TOUCH_GESTURE_CONFIG = {
+  enableTap: true,
+  enableDoubleTap: true,
+  enableLongPress: true,
+  tapMaxMovement: 10,
+  tapMaxDuration: 300,
+  doubleTapMaxInterval: 300,
+  longPressDuration: 500
+};
+```
+
+## Configuration Examples
+
+### High Performance Mode
+
+Optimized for large graphs (1000+ nodes):
+
+```typescript
+const highPerformanceConfig = {
+  config: {
+    antialias: false,
+    pixelRatio: 1,
+    enableFog: false
+  },
+  nodeStyle: {
+    segments: 8  // Lower detail spheres
+  },
+  performanceConfig: {
+    lod: {
+      enabled: true,
+      labelFadeStart: 100,
+      labelFadeEnd: 150
+    },
+    frustumCulling: {
+      enabled: true,
+      updateInterval: 1
+    }
+  }
+};
+```
+
+### High Quality Mode
+
+Maximum visual quality:
+
+```typescript
+const highQualityConfig = {
+  config: {
+    antialias: true,
+    pixelRatio: 2,
+    enableFog: true
+  },
+  nodeStyle: {
+    segments: 32,
+    emissiveIntensity: 0.3
+  },
+  edgeStyle: {
+    useTube: true,
+    tubeRadius: 0.8
+  },
+  performanceConfig: {
+    lod: { enabled: false },
+    frustumCulling: { enabled: false }
+  }
+};
+```
+
+### Mobile-Optimized Mode
+
+Optimized for touch devices:
+
+```typescript
+const mobileConfig = {
+  config: {
+    antialias: false,
+    pixelRatio: 1
+  },
+  controlsConfig: {
+    rotateSpeed: 0.5,
+    panSpeed: 0.5,
+    zoomSpeed: 0.5
+  },
+  performanceConfig: {
+    lod: { enabled: true },
+    frustumCulling: { enabled: true }
+  },
+  touchGestureConfig: {
+    longPressDuration: 400  // Faster long press
+  }
+};
+```
+
+### Custom Theme Mode
+
+Custom color scheme:
+
+```typescript
+const customThemeConfig = {
+  themeConfig: {
+    dark: {
+      background: "#0a0a0a",
+      nodeColors: {
+        exo: "#ff6b6b",
+        ems: "#4ecdc4",
+        ims: "#45b7d1",
+        rdf: "#f9ca24",
+        rdfs: "#f0932b",
+        owl: "#eb4d4b",
+        xsd: "#6ab04c",
+        unknown: "#535c68"
+      }
+    }
+  }
+};
+```


### PR DESCRIPTION
## Summary
- Create comprehensive documentation for the 3D graph visualization module
- Document Scene3DManager, ForceSimulation3D, Graph3DThemeService, and Graph3DPerformanceManager
- Add configuration reference with all 3D-specific options
- Include code examples for common use cases

## Changes
- `docs/graph-view/README.md` — Overview of 2D/3D graph visualization
- `docs/graph-view/guides/3d-visualization.md` — Complete user guide
- `docs/graph-view/guides/configuration.md` — All configuration options
- `docs/graph-view/examples/3d-graph.md` — Code examples
- `README.md` — Added links to new documentation

## Test plan
- [ ] Documentation renders correctly in GitHub
- [ ] All links are valid
- [ ] Code examples are syntactically correct

Closes #1309