### PR TITLE
feat(graph-view): Semantic Physics - ontology-driven force modifiers

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/graph/SemanticForceModifier.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/graph/SemanticForceModifier.ts
@@ -1,0 +1,368 @@
+/**
+ * SemanticForceModifier - Ontology-driven force modifiers for graph physics
+ *
+ * Translates RDF/OWL predicates into physical force modifiers that affect
+ * the force-directed graph layout. This creates semantic clustering where:
+ * - Related nodes (rdfs:subClassOf, dcterms:isPartOf) attract more strongly
+ * - Unrelated nodes (owl:disjointWith) repel more strongly
+ * - Nodes of different types naturally separate
+ *
+ * @module presentation/renderers/graph
+ * @since 1.0.0
+ */
+
+import type {
+  SemanticForceConfig,
+  SemanticPhysicsConfig,
+} from "../../stores/graphConfigStore/types";
+import type { SimulationLink, SimulationNode } from "./ForceSimulation";
+
+/**
+ * Extended link interface with predicate information
+ */
+export interface SemanticLink<N extends SimulationNode = SimulationNode>
+  extends SimulationLink<N> {
+  /** RDF predicate URI for this link */
+  predicate?: string;
+}
+
+/**
+ * Extended node interface with type information
+ */
+export interface SemanticNode extends SimulationNode {
+  /** rdf:type URIs for this node */
+  types?: string[];
+}
+
+/**
+ * Force modifier result for a link or node pair
+ */
+export interface ForceModifier {
+  /** Attraction multiplier (>1 = stronger pull) */
+  attraction: number;
+  /** Repulsion multiplier (>1 = stronger push) */
+  repulsion: number;
+}
+
+/**
+ * Cache key for node pair type comparison
+ */
+type NodePairKey = string;
+
+/**
+ * SemanticForceModifier - Computes force modifiers based on ontology relationships
+ *
+ * @example
+ * ```typescript
+ * const modifier = new SemanticForceModifier(config);
+ *
+ * // Get modifier for a link
+ * const linkMod = modifier.getLinkModifier(link);
+ * const adjustedStrength = baseStrength * linkMod.attraction;
+ *
+ * // Get modifier for a node pair
+ * const pairMod = modifier.getNodePairModifier(nodeA, nodeB);
+ * const adjustedRepulsion = baseRepulsion * pairMod.repulsion;
+ * ```
+ */
+export class SemanticForceModifier {
+  private config: SemanticPhysicsConfig;
+  private predicateMap: Map<string, SemanticForceConfig>;
+  private typePairCache: Map<NodePairKey, ForceModifier>;
+  private readonly DEFAULT_MODIFIER: ForceModifier = {
+    attraction: 1.0,
+    repulsion: 1.0,
+  };
+
+  constructor(config: SemanticPhysicsConfig) {
+    this.config = config;
+    this.predicateMap = new Map();
+    this.typePairCache = new Map();
+    this.buildPredicateMap();
+  }
+
+  /**
+   * Build lookup map from predicate to force config
+   */
+  private buildPredicateMap(): void {
+    this.predicateMap.clear();
+    for (const predConfig of this.config.predicates) {
+      this.predicateMap.set(predConfig.predicate, predConfig);
+    }
+  }
+
+  /**
+   * Update configuration and rebuild caches
+   */
+  updateConfig(config: SemanticPhysicsConfig): void {
+    this.config = config;
+    this.buildPredicateMap();
+    this.typePairCache.clear();
+  }
+
+  /**
+   * Check if semantic physics is enabled
+   */
+  isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  /**
+   * Get force modifier for a link based on its predicate
+   *
+   * @param link - Link with optional predicate property
+   * @returns Force modifier for attraction/repulsion
+   */
+  getLinkModifier<N extends SimulationNode>(
+    link: SemanticLink<N>
+  ): ForceModifier {
+    if (!this.config.enabled) {
+      return this.DEFAULT_MODIFIER;
+    }
+
+    const predicate = link.predicate;
+    if (!predicate) {
+      return {
+        attraction: this.config.defaultAttractionMultiplier,
+        repulsion: this.config.defaultRepulsionMultiplier,
+      };
+    }
+
+    const config = this.predicateMap.get(predicate);
+    if (config) {
+      return {
+        attraction: config.attractionMultiplier,
+        repulsion: config.repulsionMultiplier,
+      };
+    }
+
+    // Check for prefixed predicate matches (e.g., "rdfs:subClassOf" matches "http://...#subClassOf")
+    const localName = this.extractLocalName(predicate);
+    for (const [configPredicate, configValue] of this.predicateMap) {
+      if (
+        this.extractLocalName(configPredicate) === localName ||
+        predicate.endsWith(configPredicate) ||
+        configPredicate.endsWith(predicate)
+      ) {
+        return {
+          attraction: configValue.attractionMultiplier,
+          repulsion: configValue.repulsionMultiplier,
+        };
+      }
+    }
+
+    return {
+      attraction: this.config.defaultAttractionMultiplier,
+      repulsion: this.config.defaultRepulsionMultiplier,
+    };
+  }
+
+  /**
+   * Get force modifier for a pair of nodes based on their types
+   *
+   * @param nodeA - First node
+   * @param nodeB - Second node
+   * @returns Force modifier for repulsion between nodes
+   */
+  getNodePairModifier(nodeA: SemanticNode, nodeB: SemanticNode): ForceModifier {
+    if (!this.config.enabled || !this.config.typeBasedRepulsion) {
+      return this.DEFAULT_MODIFIER;
+    }
+
+    const typesA = nodeA.types || [];
+    const typesB = nodeB.types || [];
+
+    // If either node has no type information, use default
+    if (typesA.length === 0 || typesB.length === 0) {
+      return this.DEFAULT_MODIFIER;
+    }
+
+    // Check cache
+    const cacheKey = this.getNodePairCacheKey(nodeA.id, nodeB.id);
+    const cached = this.typePairCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    // Check if nodes share any types
+    const sharedTypes = this.hasSharedTypes(typesA, typesB);
+
+    const modifier: ForceModifier = sharedTypes
+      ? this.DEFAULT_MODIFIER
+      : {
+          attraction: 1.0,
+          repulsion: this.config.differentTypeRepulsionMultiplier,
+        };
+
+    // Cache the result
+    this.typePairCache.set(cacheKey, modifier);
+
+    return modifier;
+  }
+
+  /**
+   * Get combined force modifier for a link considering both predicate and node types
+   *
+   * @param link - Link with source and target nodes
+   * @returns Combined force modifier
+   */
+  getCombinedLinkModifier<N extends SemanticNode>(
+    link: SemanticLink<N>
+  ): ForceModifier {
+    if (!this.config.enabled) {
+      return this.DEFAULT_MODIFIER;
+    }
+
+    const linkMod = this.getLinkModifier(link);
+
+    // If source/target are resolved to nodes, also consider types
+    const source = link.source as N | string;
+    const target = link.target as N | string;
+
+    if (typeof source === "object" && typeof target === "object") {
+      const pairMod = this.getNodePairModifier(source, target);
+      return {
+        attraction: linkMod.attraction,
+        repulsion: Math.max(linkMod.repulsion, pairMod.repulsion),
+      };
+    }
+
+    return linkMod;
+  }
+
+  /**
+   * Compute attraction strength for a link
+   *
+   * @param baseStrength - Base link strength from physics config
+   * @param link - Link to compute strength for
+   * @returns Adjusted strength
+   */
+  computeLinkStrength<N extends SimulationNode>(
+    baseStrength: number,
+    link: SemanticLink<N>
+  ): number {
+    const modifier = this.getLinkModifier(link);
+    return baseStrength * modifier.attraction;
+  }
+
+  /**
+   * Compute repulsion strength between two nodes
+   *
+   * @param baseStrength - Base charge strength from physics config
+   * @param nodeA - First node
+   * @param nodeB - Second node
+   * @returns Adjusted strength (more negative = stronger repulsion)
+   */
+  computeRepulsionStrength(
+    baseStrength: number,
+    nodeA: SemanticNode,
+    nodeB: SemanticNode
+  ): number {
+    const modifier = this.getNodePairModifier(nodeA, nodeB);
+    return baseStrength * modifier.repulsion;
+  }
+
+  /**
+   * Clear the type pair cache (call when graph structure changes)
+   */
+  clearCache(): void {
+    this.typePairCache.clear();
+  }
+
+  /**
+   * Get the current configuration
+   */
+  getConfig(): SemanticPhysicsConfig {
+    return this.config;
+  }
+
+  /**
+   * Get all configured predicate patterns
+   */
+  getConfiguredPredicates(): string[] {
+    return Array.from(this.predicateMap.keys());
+  }
+
+  /**
+   * Check if a predicate has a specific configuration
+   */
+  hasPredicateConfig(predicate: string): boolean {
+    if (this.predicateMap.has(predicate)) {
+      return true;
+    }
+    const localName = this.extractLocalName(predicate);
+    for (const configPredicate of this.predicateMap.keys()) {
+      if (
+        this.extractLocalName(configPredicate) === localName ||
+        predicate.endsWith(configPredicate) ||
+        configPredicate.endsWith(predicate)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // ============================================================
+  // Private Helpers
+  // ============================================================
+
+  /**
+   * Extract local name from URI (after # or last /) or prefixed name (after :)
+   */
+  private extractLocalName(uri: string): string {
+    const hashIndex = uri.lastIndexOf("#");
+    if (hashIndex !== -1) {
+      return uri.substring(hashIndex + 1);
+    }
+    const slashIndex = uri.lastIndexOf("/");
+    if (slashIndex !== -1) {
+      return uri.substring(slashIndex + 1);
+    }
+    // Handle prefixed names like "rdfs:subClassOf" -> "subClassOf"
+    const colonIndex = uri.lastIndexOf(":");
+    if (colonIndex !== -1) {
+      return uri.substring(colonIndex + 1);
+    }
+    return uri;
+  }
+
+  /**
+   * Generate cache key for node pair (order-independent)
+   */
+  private getNodePairCacheKey(idA: string, idB: string): NodePairKey {
+    return idA < idB ? `${idA}:${idB}` : `${idB}:${idA}`;
+  }
+
+  /**
+   * Check if two type arrays share any common types
+   */
+  private hasSharedTypes(typesA: string[], typesB: string[]): boolean {
+    const setA = new Set(typesA);
+    for (const typeB of typesB) {
+      if (setA.has(typeB)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+/**
+ * Default semantic physics configuration
+ */
+export const DEFAULT_SEMANTIC_PHYSICS_CONFIG: SemanticPhysicsConfig = {
+  enabled: true,
+  predicates: [
+    // Attraction modifiers
+    { predicate: "rdfs:subClassOf", attractionMultiplier: 2.0, repulsionMultiplier: 1.0 },
+    { predicate: "exo:Asset_prototype", attractionMultiplier: 1.8, repulsionMultiplier: 1.0 },
+    { predicate: "dcterms:isPartOf", attractionMultiplier: 1.5, repulsionMultiplier: 1.0 },
+    // Repulsion modifiers
+    { predicate: "owl:disjointWith", attractionMultiplier: 1.0, repulsionMultiplier: 3.0 },
+  ],
+  defaultAttractionMultiplier: 1.0,
+  defaultRepulsionMultiplier: 1.0,
+  typeBasedRepulsion: true,
+  differentTypeRepulsionMultiplier: 1.3,
+};

--- a/packages/obsidian-plugin/src/presentation/renderers/graph/index.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/graph/index.ts
@@ -66,11 +66,14 @@ export {
   forceRadial,
   forceX,
   forceY,
+  forceSemanticLink,
+  DEFAULT_SEMANTIC_LINK_CONFIG,
 } from "./ForceSimulation";
 
 export type {
   ForceCenterConfig,
   ForceLinkConfig,
+  ForceSemanticLinkConfig,
   ForceManyBodyConfig,
   ForceCollideConfig,
   ForceRadialConfig,
@@ -95,6 +98,17 @@ export {
   mergeForceConfiguration,
   validateForceConfiguration,
 } from "./ForceSimulation";
+
+// Semantic physics - ontology-driven force modifiers
+export {
+  SemanticForceModifier,
+  DEFAULT_SEMANTIC_PHYSICS_CONFIG,
+} from "./SemanticForceModifier";
+export type {
+  SemanticLink,
+  SemanticNode,
+  ForceModifier,
+} from "./SemanticForceModifier";
 
 // PixiJS WebGL2 renderer for high-performance graph rendering
 export { PixiGraphRenderer } from "./PixiGraphRenderer";

--- a/packages/obsidian-plugin/src/presentation/stores/graphConfigStore/index.ts
+++ b/packages/obsidian-plugin/src/presentation/stores/graphConfigStore/index.ts
@@ -72,6 +72,8 @@ export type {
   ChargeForceConfig,
   CollisionForceConfig,
   RadialForceConfig,
+  SemanticForceConfig,
+  SemanticPhysicsConfig,
   // Rendering types
   RenderingConfig,
   PerformanceConfig,

--- a/packages/obsidian-plugin/src/presentation/stores/graphConfigStore/types.ts
+++ b/packages/obsidian-plugin/src/presentation/stores/graphConfigStore/types.ts
@@ -96,6 +96,46 @@ export interface RadialForceConfig {
 }
 
 /**
+ * Semantic force configuration for a specific predicate.
+ * Translates RDF/OWL predicates into physical force modifiers.
+ *
+ * @example
+ * // Make rdfs:subClassOf relationships pull nodes 2x closer
+ * { predicate: 'rdfs:subClassOf', attractionMultiplier: 2.0, repulsionMultiplier: 1.0 }
+ *
+ * @example
+ * // Make owl:disjointWith relationships push nodes 3x apart
+ * { predicate: 'owl:disjointWith', attractionMultiplier: 1.0, repulsionMultiplier: 3.0 }
+ */
+export interface SemanticForceConfig {
+  /** Predicate URI (e.g., 'rdfs:subClassOf', 'owl:disjointWith', 'exo:Asset_prototype') */
+  predicate: string;
+  /** Attraction force multiplier (1.0 = default, >1 = stronger attraction) */
+  attractionMultiplier: number;
+  /** Repulsion force multiplier (1.0 = default, >1 = stronger repulsion) */
+  repulsionMultiplier: number;
+}
+
+/**
+ * Semantic physics configuration.
+ * Controls how ontology relationships affect force-directed layout.
+ */
+export interface SemanticPhysicsConfig {
+  /** Enable semantic force modifiers */
+  enabled: boolean;
+  /** Per-predicate force configurations */
+  predicates: SemanticForceConfig[];
+  /** Default attraction multiplier for unconfigured predicates */
+  defaultAttractionMultiplier: number;
+  /** Default repulsion multiplier for unconfigured predicates */
+  defaultRepulsionMultiplier: number;
+  /** Apply type-based repulsion (different rdf:type = increased repulsion) */
+  typeBasedRepulsion: boolean;
+  /** Repulsion multiplier for nodes with different types */
+  differentTypeRepulsionMultiplier: number;
+}
+
+/**
  * Complete physics configuration
  */
 export interface PhysicsConfig {
@@ -113,6 +153,8 @@ export interface PhysicsConfig {
   collision: CollisionForceConfig;
   /** Radial force */
   radial: RadialForceConfig;
+  /** Semantic force modifiers based on ontology relationships */
+  semantic: SemanticPhysicsConfig;
 }
 
 // ============================================================

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/graph/SemanticForceModifier.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/graph/SemanticForceModifier.test.ts
@@ -1,0 +1,398 @@
+/**
+ * SemanticForceModifier Unit Tests
+ *
+ * Tests for ontology-driven force modifiers that affect graph physics
+ * based on RDF/OWL predicates and type relationships.
+ */
+
+import {
+  SemanticForceModifier,
+  DEFAULT_SEMANTIC_PHYSICS_CONFIG,
+  type SemanticLink,
+  type SemanticNode,
+  type ForceModifier,
+} from "@plugin/presentation/renderers/graph/SemanticForceModifier";
+import type { SemanticPhysicsConfig } from "@plugin/presentation/stores/graphConfigStore/types";
+
+// ============================================================
+// Test Helpers
+// ============================================================
+
+function createSemanticNode(
+  id: string,
+  types: string[] = []
+): SemanticNode {
+  return {
+    id,
+    index: 0,
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    mass: 1,
+    radius: 8,
+    types,
+  };
+}
+
+function createSemanticLink(
+  source: string | SemanticNode,
+  target: string | SemanticNode,
+  predicate?: string
+): SemanticLink {
+  return {
+    source,
+    target,
+    predicate,
+  };
+}
+
+function createTestConfig(
+  overrides?: Partial<SemanticPhysicsConfig>
+): SemanticPhysicsConfig {
+  return {
+    enabled: true,
+    predicates: [
+      { predicate: "rdfs:subClassOf", attractionMultiplier: 2.0, repulsionMultiplier: 1.0 },
+      { predicate: "owl:disjointWith", attractionMultiplier: 1.0, repulsionMultiplier: 3.0 },
+      { predicate: "dcterms:isPartOf", attractionMultiplier: 1.5, repulsionMultiplier: 1.0 },
+    ],
+    defaultAttractionMultiplier: 1.0,
+    defaultRepulsionMultiplier: 1.0,
+    typeBasedRepulsion: true,
+    differentTypeRepulsionMultiplier: 1.3,
+    ...overrides,
+  };
+}
+
+// ============================================================
+// SemanticForceModifier Tests
+// ============================================================
+
+describe("SemanticForceModifier", () => {
+  describe("constructor", () => {
+    it("should create modifier with given configuration", () => {
+      const config = createTestConfig();
+      const modifier = new SemanticForceModifier(config);
+
+      expect(modifier.isEnabled()).toBe(true);
+      expect(modifier.getConfig()).toEqual(config);
+    });
+
+    it("should handle disabled configuration", () => {
+      const config = createTestConfig({ enabled: false });
+      const modifier = new SemanticForceModifier(config);
+
+      expect(modifier.isEnabled()).toBe(false);
+    });
+  });
+
+  describe("getLinkModifier", () => {
+    it("should return default modifier when disabled", () => {
+      const config = createTestConfig({ enabled: false });
+      const modifier = new SemanticForceModifier(config);
+      const link = createSemanticLink("a", "b", "rdfs:subClassOf");
+
+      const result = modifier.getLinkModifier(link);
+
+      expect(result.attraction).toBe(1.0);
+      expect(result.repulsion).toBe(1.0);
+    });
+
+    it("should return configured multiplier for matching predicate", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const link = createSemanticLink("a", "b", "rdfs:subClassOf");
+
+      const result = modifier.getLinkModifier(link);
+
+      expect(result.attraction).toBe(2.0);
+      expect(result.repulsion).toBe(1.0);
+    });
+
+    it("should return repulsion multiplier for disjoint predicate", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const link = createSemanticLink("a", "b", "owl:disjointWith");
+
+      const result = modifier.getLinkModifier(link);
+
+      expect(result.attraction).toBe(1.0);
+      expect(result.repulsion).toBe(3.0);
+    });
+
+    it("should return default multipliers for unconfigured predicate", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const link = createSemanticLink("a", "b", "unknown:predicate");
+
+      const result = modifier.getLinkModifier(link);
+
+      expect(result.attraction).toBe(1.0);
+      expect(result.repulsion).toBe(1.0);
+    });
+
+    it("should return default multipliers for link without predicate", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const link = createSemanticLink("a", "b");
+
+      const result = modifier.getLinkModifier(link);
+
+      expect(result.attraction).toBe(1.0);
+      expect(result.repulsion).toBe(1.0);
+    });
+
+    it("should match predicate by local name", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const link = createSemanticLink("a", "b", "http://www.w3.org/2000/01/rdf-schema#subClassOf");
+
+      // The extractLocalName should match "subClassOf" with the configured "rdfs:subClassOf"
+      const result = modifier.getLinkModifier(link);
+
+      // Should match because local name "subClassOf" is checked
+      expect(result.attraction).toBe(2.0);
+    });
+  });
+
+  describe("getNodePairModifier", () => {
+    it("should return default modifier when disabled", () => {
+      const config = createTestConfig({ enabled: false });
+      const modifier = new SemanticForceModifier(config);
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      const nodeB = createSemanticNode("b", ["Type2"]);
+
+      const result = modifier.getNodePairModifier(nodeA, nodeB);
+
+      expect(result.attraction).toBe(1.0);
+      expect(result.repulsion).toBe(1.0);
+    });
+
+    it("should return default modifier when typeBasedRepulsion is disabled", () => {
+      const config = createTestConfig({ typeBasedRepulsion: false });
+      const modifier = new SemanticForceModifier(config);
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      const nodeB = createSemanticNode("b", ["Type2"]);
+
+      const result = modifier.getNodePairModifier(nodeA, nodeB);
+
+      expect(result.attraction).toBe(1.0);
+      expect(result.repulsion).toBe(1.0);
+    });
+
+    it("should return default modifier for nodes with same type", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const nodeA = createSemanticNode("a", ["Type1", "Type2"]);
+      const nodeB = createSemanticNode("b", ["Type1", "Type3"]);
+
+      const result = modifier.getNodePairModifier(nodeA, nodeB);
+
+      expect(result.attraction).toBe(1.0);
+      expect(result.repulsion).toBe(1.0);
+    });
+
+    it("should return increased repulsion for nodes with different types", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      const nodeB = createSemanticNode("b", ["Type2"]);
+
+      const result = modifier.getNodePairModifier(nodeA, nodeB);
+
+      expect(result.attraction).toBe(1.0);
+      expect(result.repulsion).toBe(1.3);
+    });
+
+    it("should return default modifier when either node has no types", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      const nodeB = createSemanticNode("b", []);
+
+      const result = modifier.getNodePairModifier(nodeA, nodeB);
+
+      expect(result.attraction).toBe(1.0);
+      expect(result.repulsion).toBe(1.0);
+    });
+
+    it("should cache node pair results", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      const nodeB = createSemanticNode("b", ["Type2"]);
+
+      // First call
+      const result1 = modifier.getNodePairModifier(nodeA, nodeB);
+      // Second call with same nodes (should use cache)
+      const result2 = modifier.getNodePairModifier(nodeA, nodeB);
+      // Reversed order (should use same cache entry)
+      const result3 = modifier.getNodePairModifier(nodeB, nodeA);
+
+      expect(result1).toEqual(result2);
+      expect(result1).toEqual(result3);
+    });
+  });
+
+  describe("computeLinkStrength", () => {
+    it("should apply attraction multiplier to base strength", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const link = createSemanticLink("a", "b", "rdfs:subClassOf");
+      const baseStrength = 1.0;
+
+      const result = modifier.computeLinkStrength(baseStrength, link);
+
+      expect(result).toBe(2.0); // baseStrength * attractionMultiplier
+    });
+
+    it("should return base strength when disabled", () => {
+      const config = createTestConfig({ enabled: false });
+      const modifier = new SemanticForceModifier(config);
+      const link = createSemanticLink("a", "b", "rdfs:subClassOf");
+      const baseStrength = 1.0;
+
+      const result = modifier.computeLinkStrength(baseStrength, link);
+
+      expect(result).toBe(1.0);
+    });
+  });
+
+  describe("computeRepulsionStrength", () => {
+    it("should apply repulsion multiplier for different types", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      const nodeB = createSemanticNode("b", ["Type2"]);
+      const baseStrength = -300;
+
+      const result = modifier.computeRepulsionStrength(baseStrength, nodeA, nodeB);
+
+      expect(result).toBe(-390); // baseStrength * differentTypeRepulsionMultiplier (1.3)
+    });
+
+    it("should return base strength for same types", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      const nodeB = createSemanticNode("b", ["Type1"]);
+      const baseStrength = -300;
+
+      const result = modifier.computeRepulsionStrength(baseStrength, nodeA, nodeB);
+
+      expect(result).toBe(-300);
+    });
+  });
+
+  describe("getCombinedLinkModifier", () => {
+    it("should combine link and node pair modifiers", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      nodeA.index = 0;
+      const nodeB = createSemanticNode("b", ["Type2"]);
+      nodeB.index = 1;
+      const link: SemanticLink<SemanticNode> = {
+        source: nodeA,
+        target: nodeB,
+        predicate: "rdfs:subClassOf",
+      };
+
+      const result = modifier.getCombinedLinkModifier(link);
+
+      expect(result.attraction).toBe(2.0); // From predicate
+      expect(result.repulsion).toBe(1.3); // From different types (max of 1.0 and 1.3)
+    });
+  });
+
+  describe("updateConfig", () => {
+    it("should update configuration and clear caches", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      const nodeB = createSemanticNode("b", ["Type2"]);
+
+      // Prime the cache
+      modifier.getNodePairModifier(nodeA, nodeB);
+
+      // Update config with higher multiplier
+      const newConfig = createTestConfig({ differentTypeRepulsionMultiplier: 2.0 });
+      modifier.updateConfig(newConfig);
+
+      // Should use new config value
+      const result = modifier.getNodePairModifier(nodeA, nodeB);
+      expect(result.repulsion).toBe(2.0);
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should clear the type pair cache", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+      const nodeA = createSemanticNode("a", ["Type1"]);
+      const nodeB = createSemanticNode("b", ["Type2"]);
+
+      // Prime the cache
+      modifier.getNodePairModifier(nodeA, nodeB);
+
+      // Clear cache
+      modifier.clearCache();
+
+      // Next call should compute again (no way to verify directly, but no error)
+      const result = modifier.getNodePairModifier(nodeA, nodeB);
+      expect(result.repulsion).toBe(1.3);
+    });
+  });
+
+  describe("getConfiguredPredicates", () => {
+    it("should return list of configured predicates", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+
+      const predicates = modifier.getConfiguredPredicates();
+
+      expect(predicates).toContain("rdfs:subClassOf");
+      expect(predicates).toContain("owl:disjointWith");
+      expect(predicates).toContain("dcterms:isPartOf");
+      expect(predicates).toHaveLength(3);
+    });
+  });
+
+  describe("hasPredicateConfig", () => {
+    it("should return true for configured predicate", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+
+      expect(modifier.hasPredicateConfig("rdfs:subClassOf")).toBe(true);
+      expect(modifier.hasPredicateConfig("owl:disjointWith")).toBe(true);
+    });
+
+    it("should return false for unconfigured predicate", () => {
+      const modifier = new SemanticForceModifier(createTestConfig());
+
+      expect(modifier.hasPredicateConfig("unknown:predicate")).toBe(false);
+    });
+  });
+});
+
+describe("DEFAULT_SEMANTIC_PHYSICS_CONFIG", () => {
+  it("should have semantic physics enabled by default", () => {
+    expect(DEFAULT_SEMANTIC_PHYSICS_CONFIG.enabled).toBe(true);
+  });
+
+  it("should include standard ontology predicates", () => {
+    const predicates = DEFAULT_SEMANTIC_PHYSICS_CONFIG.predicates.map(p => p.predicate);
+
+    expect(predicates).toContain("rdfs:subClassOf");
+    expect(predicates).toContain("exo:Asset_prototype");
+    expect(predicates).toContain("dcterms:isPartOf");
+    expect(predicates).toContain("owl:disjointWith");
+  });
+
+  it("should have rdfs:subClassOf with 2x attraction", () => {
+    const subClassConfig = DEFAULT_SEMANTIC_PHYSICS_CONFIG.predicates.find(
+      p => p.predicate === "rdfs:subClassOf"
+    );
+
+    expect(subClassConfig?.attractionMultiplier).toBe(2.0);
+    expect(subClassConfig?.repulsionMultiplier).toBe(1.0);
+  });
+
+  it("should have owl:disjointWith with 3x repulsion", () => {
+    const disjointConfig = DEFAULT_SEMANTIC_PHYSICS_CONFIG.predicates.find(
+      p => p.predicate === "owl:disjointWith"
+    );
+
+    expect(disjointConfig?.attractionMultiplier).toBe(1.0);
+    expect(disjointConfig?.repulsionMultiplier).toBe(3.0);
+  });
+
+  it("should enable type-based repulsion by default", () => {
+    expect(DEFAULT_SEMANTIC_PHYSICS_CONFIG.typeBasedRepulsion).toBe(true);
+    expect(DEFAULT_SEMANTIC_PHYSICS_CONFIG.differentTypeRepulsionMultiplier).toBe(1.3);
+  });
+});


### PR DESCRIPTION
## Summary

Implement ontology-driven force modifiers that translate RDF/OWL predicates into physical forces affecting the force-directed graph layout. This creates semantic clustering where related nodes attract more strongly and unrelated nodes repel more strongly.

### Key Features

- **Predicate-based Force Modifiers**
  - `rdfs:subClassOf`: 2.0x attraction (hierarchical clustering)
  - `exo:Asset_prototype`: 1.8x attraction (template clustering)
  - `dcterms:isPartOf`: 1.5x attraction (compositional grouping)
  - `owl:disjointWith`: 3.0x repulsion (semantic separation)

- **Type-based Repulsion**
  - Nodes with different `rdf:type` receive 1.3x repulsion multiplier
  - Helps visually separate different asset classes

- **Flexible Configuration**
  - `SemanticPhysicsConfig` for enabling/disabling and customizing modifiers
  - Support for custom predicate patterns with configurable multipliers
  - Local name matching for both full URIs and prefixed predicates

### Technical Implementation

- `SemanticForceModifier` service for computing attraction/repulsion multipliers
- `forceSemanticLink` wrapper function for d3-force integration
- Type pair caching for O(1) repeated lookups
- 29 comprehensive unit tests

Closes #1345

## Test plan

- [x] Unit tests for SemanticForceModifier (29 tests passing)
- [x] Build passes
- [x] Lint passes on changed files
- [ ] CI pipeline passes