### PR TITLE
feat: implement Exo 0.0.3 file format support in @exocortex/core

### DIFF
--- a/packages/exocortex/src/domain/models/exo003/Exo003Parser.ts
+++ b/packages/exocortex/src/domain/models/exo003/Exo003Parser.ts
@@ -1,0 +1,495 @@
+import {
+  Exo003MetadataType,
+  Exo003Metadata,
+  Exo003NamespaceMetadata,
+  Exo003AnchorMetadata,
+  Exo003BlankNodeMetadata,
+  Exo003StatementMetadata,
+  Exo003BodyMetadata,
+  ALLOWED_PROPERTIES,
+  REQUIRED_PROPERTIES,
+  DEFAULT_LANGUAGE_TAG,
+} from "./types";
+import { Exo003UUIDGenerator } from "./UUIDGenerator";
+import { IRI } from "../rdf/IRI";
+import { Literal, createDirectionalLiteral } from "../rdf/Literal";
+import { BlankNode } from "../rdf/BlankNode";
+import { Triple, Subject, Predicate, Object as RDFObject } from "../rdf/Triple";
+
+/**
+ * Result of parsing an Exo 0.0.3 file.
+ */
+export interface Exo003ParseResult {
+  /** Whether parsing succeeded */
+  success: boolean;
+
+  /** The parsed metadata (if successful) */
+  metadata?: Exo003Metadata;
+
+  /** The body content of the file (for Body type) */
+  bodyContent?: string;
+
+  /** Validation errors (if unsuccessful) */
+  errors?: string[];
+}
+
+/**
+ * Result of validating Exo 0.0.3 frontmatter.
+ */
+export interface Exo003ValidationResult {
+  /** Whether validation passed */
+  valid: boolean;
+
+  /** List of validation errors */
+  errors: string[];
+
+  /** List of warnings (non-fatal issues) */
+  warnings: string[];
+}
+
+/**
+ * Parser and validator for Exo 0.0.3 file format.
+ *
+ * This class provides methods to:
+ * - Parse frontmatter into typed metadata objects
+ * - Validate frontmatter against allowed/required properties
+ * - Convert metadata back to RDF triples
+ */
+export class Exo003Parser {
+  /**
+   * Parse frontmatter into Exo 0.0.3 metadata.
+   *
+   * @param frontmatter - The frontmatter object to parse
+   * @param bodyContent - Optional body content for Body type files
+   * @returns Parse result with metadata or errors
+   */
+  static parse(
+    frontmatter: Record<string, unknown>,
+    bodyContent?: string
+  ): Exo003ParseResult {
+    const validation = this.validate(frontmatter);
+
+    if (!validation.valid) {
+      return {
+        success: false,
+        errors: validation.errors,
+      };
+    }
+
+    const metadataType = frontmatter["exo__metadataType"] as Exo003MetadataType;
+
+    try {
+      const metadata = this.parseByType(frontmatter, metadataType);
+      return {
+        success: true,
+        metadata,
+        bodyContent: metadataType === Exo003MetadataType.Body ? bodyContent : undefined,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        errors: [error instanceof Error ? error.message : String(error)],
+      };
+    }
+  }
+
+  /**
+   * Validate frontmatter against Exo 0.0.3 schema.
+   *
+   * Checks:
+   * 1. Required properties are present
+   * 2. No forbidden properties are present
+   * 3. Property values have correct types
+   *
+   * @param frontmatter - The frontmatter to validate
+   * @returns Validation result with errors and warnings
+   */
+  static validate(frontmatter: Record<string, unknown>): Exo003ValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    // Check for metadataType
+    if (!frontmatter["exo__metadataType"]) {
+      errors.push("Missing required property: exo__metadataType");
+      return { valid: false, errors, warnings };
+    }
+
+    const metadataType = frontmatter["exo__metadataType"] as string;
+
+    // Validate metadataType is a known type
+    if (!Object.values(Exo003MetadataType).includes(metadataType as Exo003MetadataType)) {
+      errors.push(
+        `Invalid exo__metadataType: ${metadataType}. Valid types: ${Object.values(
+          Exo003MetadataType
+        ).join(", ")}`
+      );
+      return { valid: false, errors, warnings };
+    }
+
+    const type = metadataType as Exo003MetadataType;
+    const allowedProps = ALLOWED_PROPERTIES[type];
+    const requiredProps = REQUIRED_PROPERTIES[type];
+
+    // Check required properties
+    for (const prop of requiredProps) {
+      if (frontmatter[prop] === undefined || frontmatter[prop] === null) {
+        errors.push(`Missing required property: ${prop}`);
+      }
+    }
+
+    // Check for forbidden properties
+    for (const prop of Object.keys(frontmatter)) {
+      if (!allowedProps.includes(prop)) {
+        errors.push(`Forbidden property for ${type}: ${prop}`);
+      }
+    }
+
+    // Type-specific validation
+    switch (type) {
+      case Exo003MetadataType.Namespace:
+        this.validateNamespaceMetadata(frontmatter, errors);
+        break;
+      case Exo003MetadataType.Anchor:
+        this.validateAnchorMetadata(frontmatter, errors);
+        break;
+      case Exo003MetadataType.BlankNode:
+        this.validateBlankNodeMetadata(frontmatter, errors);
+        break;
+      case Exo003MetadataType.Statement:
+        this.validateStatementMetadata(frontmatter, errors);
+        break;
+      case Exo003MetadataType.Body:
+        this.validateBodyMetadata(frontmatter, errors, warnings);
+        break;
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+    };
+  }
+
+  /**
+   * Parse frontmatter by metadata type.
+   */
+  private static parseByType(
+    frontmatter: Record<string, unknown>,
+    type: Exo003MetadataType
+  ): Exo003Metadata {
+    const base = {
+      exo__Asset_uid: frontmatter["exo__Asset_uid"] as string,
+      exo__Asset_createdAt: frontmatter["exo__Asset_createdAt"] as string,
+      exo__metadataType: type,
+      exo__Asset_isDefinedBy: frontmatter["exo__Asset_isDefinedBy"] as string | undefined,
+    };
+
+    switch (type) {
+      case Exo003MetadataType.Namespace:
+        return {
+          ...base,
+          exo__metadataType: Exo003MetadataType.Namespace,
+          exo__Namespace_prefix: frontmatter["exo__Namespace_prefix"] as string,
+          exo__Namespace_uri: frontmatter["exo__Namespace_uri"] as string,
+        } satisfies Exo003NamespaceMetadata;
+
+      case Exo003MetadataType.Anchor:
+        return {
+          ...base,
+          exo__metadataType: Exo003MetadataType.Anchor,
+          exo__Anchor_localName: frontmatter["exo__Anchor_localName"] as string,
+          exo__Asset_label: frontmatter["exo__Asset_label"] as string | undefined,
+        } satisfies Exo003AnchorMetadata;
+
+      case Exo003MetadataType.BlankNode:
+        return {
+          ...base,
+          exo__metadataType: Exo003MetadataType.BlankNode,
+          exo__BlankNode_id: frontmatter["exo__BlankNode_id"] as string,
+          exo__Asset_label: frontmatter["exo__Asset_label"] as string | undefined,
+        } satisfies Exo003BlankNodeMetadata;
+
+      case Exo003MetadataType.Statement:
+        return {
+          ...base,
+          exo__metadataType: Exo003MetadataType.Statement,
+          exo__Statement_subject: frontmatter["exo__Statement_subject"] as string,
+          exo__Statement_predicate: frontmatter["exo__Statement_predicate"] as string,
+          exo__Statement_object: frontmatter["exo__Statement_object"] as string,
+        } satisfies Exo003StatementMetadata;
+
+      case Exo003MetadataType.Body:
+        return {
+          ...base,
+          exo__metadataType: Exo003MetadataType.Body,
+          exo__Body_datatype: frontmatter["exo__Body_datatype"] as string | undefined,
+          exo__Body_language: frontmatter["exo__Body_language"] as string | undefined,
+          exo__Body_direction: frontmatter["exo__Body_direction"] as "ltr" | "rtl" | undefined,
+        } satisfies Exo003BodyMetadata;
+    }
+  }
+
+  /**
+   * Validate namespace-specific properties.
+   */
+  private static validateNamespaceMetadata(
+    frontmatter: Record<string, unknown>,
+    errors: string[]
+  ): void {
+    const prefix = frontmatter["exo__Namespace_prefix"];
+    const uri = frontmatter["exo__Namespace_uri"];
+
+    if (prefix && typeof prefix !== "string") {
+      errors.push("exo__Namespace_prefix must be a string");
+    } else if (prefix && !/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(prefix as string)) {
+      errors.push(
+        "exo__Namespace_prefix must start with a letter and contain only letters, numbers, underscores, and hyphens"
+      );
+    }
+
+    if (uri && typeof uri !== "string") {
+      errors.push("exo__Namespace_uri must be a string");
+    } else if (uri) {
+      try {
+        new IRI(uri as string);
+      } catch {
+        errors.push(`exo__Namespace_uri is not a valid IRI: ${uri}`);
+      }
+    }
+  }
+
+  /**
+   * Validate anchor-specific properties.
+   */
+  private static validateAnchorMetadata(
+    frontmatter: Record<string, unknown>,
+    errors: string[]
+  ): void {
+    const localName = frontmatter["exo__Anchor_localName"];
+
+    if (localName !== undefined && localName !== null && typeof localName !== "string") {
+      errors.push("exo__Anchor_localName must be a string");
+    } else if (typeof localName === "string" && localName.trim().length === 0) {
+      errors.push("exo__Anchor_localName cannot be empty");
+    }
+  }
+
+  /**
+   * Validate blank node-specific properties.
+   */
+  private static validateBlankNodeMetadata(
+    frontmatter: Record<string, unknown>,
+    errors: string[]
+  ): void {
+    const id = frontmatter["exo__BlankNode_id"];
+
+    if (id !== undefined && id !== null && typeof id !== "string") {
+      errors.push("exo__BlankNode_id must be a string");
+    } else if (typeof id === "string" && id.trim().length === 0) {
+      errors.push("exo__BlankNode_id cannot be empty");
+    }
+  }
+
+  /**
+   * Validate statement-specific properties.
+   */
+  private static validateStatementMetadata(
+    frontmatter: Record<string, unknown>,
+    errors: string[]
+  ): void {
+    const subject = frontmatter["exo__Statement_subject"];
+    const predicate = frontmatter["exo__Statement_predicate"];
+    const object = frontmatter["exo__Statement_object"];
+
+    // Subject, predicate, and object should be wikilinks or URIs
+    for (const [name, value] of [
+      ["exo__Statement_subject", subject],
+      ["exo__Statement_predicate", predicate],
+      ["exo__Statement_object", object],
+    ]) {
+      if (value && typeof value !== "string") {
+        errors.push(`${name} must be a string`);
+      }
+    }
+  }
+
+  /**
+   * Validate body-specific properties.
+   */
+  private static validateBodyMetadata(
+    frontmatter: Record<string, unknown>,
+    errors: string[],
+    warnings: string[]
+  ): void {
+    const datatype = frontmatter["exo__Body_datatype"];
+    const language = frontmatter["exo__Body_language"];
+    const direction = frontmatter["exo__Body_direction"];
+
+    // Cannot have both datatype and language
+    if (datatype && language) {
+      errors.push("Body cannot have both exo__Body_datatype and exo__Body_language");
+    }
+
+    // Direction requires language
+    if (direction && !language) {
+      errors.push("exo__Body_direction requires exo__Body_language to be set");
+    }
+
+    // Validate direction value
+    if (direction && direction !== "ltr" && direction !== "rtl") {
+      errors.push('exo__Body_direction must be "ltr" or "rtl"');
+    }
+
+    // Validate datatype is a valid IRI
+    if (datatype && typeof datatype === "string") {
+      try {
+        new IRI(datatype);
+      } catch {
+        errors.push(`exo__Body_datatype is not a valid IRI: ${datatype}`);
+      }
+    }
+
+    // Warn if no language or datatype (will use default language)
+    if (!datatype && !language) {
+      warnings.push(
+        `No language or datatype specified. Will use default language tag: @${DEFAULT_LANGUAGE_TAG}`
+      );
+    }
+  }
+
+  /**
+   * Convert an Exo 0.0.3 statement metadata to an RDF Triple.
+   *
+   * @param metadata - The statement metadata
+   * @param resolveReference - Function to resolve wikilink references to URIs
+   * @param bodyContent - Optional body content if object is a literal
+   * @returns The RDF Triple
+   */
+  static toTriple(
+    metadata: Exo003StatementMetadata,
+    resolveReference: (ref: string) => {
+      type: "iri" | "blank" | "literal";
+      value: string;
+      language?: string;
+      direction?: "ltr" | "rtl";
+      datatype?: string;
+    },
+    bodyContent?: string
+  ): Triple {
+    // Resolve subject
+    const subjectRef = resolveReference(metadata.exo__Statement_subject);
+    let subject: Subject;
+    if (subjectRef.type === "iri") {
+      subject = new IRI(subjectRef.value);
+    } else if (subjectRef.type === "blank") {
+      subject = new BlankNode(subjectRef.value);
+    } else {
+      throw new Error("Statement subject cannot be a literal");
+    }
+
+    // Resolve predicate (must be IRI)
+    const predicateRef = resolveReference(metadata.exo__Statement_predicate);
+    if (predicateRef.type !== "iri") {
+      throw new Error("Statement predicate must be an IRI");
+    }
+    const predicate: Predicate = new IRI(predicateRef.value);
+
+    // Resolve object
+    const objectRef = resolveReference(metadata.exo__Statement_object);
+    let object: RDFObject;
+    if (objectRef.type === "iri") {
+      object = new IRI(objectRef.value);
+    } else if (objectRef.type === "blank") {
+      object = new BlankNode(objectRef.value);
+    } else {
+      // Literal
+      const value = bodyContent || objectRef.value;
+      if (objectRef.datatype) {
+        object = new Literal(value, new IRI(objectRef.datatype));
+      } else {
+        const language = objectRef.language || DEFAULT_LANGUAGE_TAG;
+        object = createDirectionalLiteral(value, language, objectRef.direction);
+      }
+    }
+
+    return new Triple(subject, predicate, object);
+  }
+
+  /**
+   * Create a Literal from Exo 0.0.3 body metadata.
+   *
+   * @param metadata - The body metadata
+   * @param content - The literal content from the file body
+   * @returns A Literal with appropriate language/datatype
+   */
+  static toLiteral(metadata: Exo003BodyMetadata, content: string): Literal {
+    if (metadata.exo__Body_datatype) {
+      return new Literal(content, new IRI(metadata.exo__Body_datatype));
+    }
+
+    const language = metadata.exo__Body_language || DEFAULT_LANGUAGE_TAG;
+    return createDirectionalLiteral(content, language, metadata.exo__Body_direction);
+  }
+
+  /**
+   * Check if a frontmatter object is valid Exo 0.0.3 format.
+   *
+   * @param frontmatter - The frontmatter to check
+   * @returns True if this is valid Exo 0.0.3 format
+   */
+  static isExo003Format(frontmatter: Record<string, unknown>): boolean {
+    const metadataType = frontmatter["exo__metadataType"];
+    return (
+      typeof metadataType === "string" &&
+      Object.values(Exo003MetadataType).includes(metadataType as Exo003MetadataType)
+    );
+  }
+
+  /**
+   * Generate deterministic UUID for metadata.
+   *
+   * @param metadata - The metadata to generate UUID for
+   * @param namespaceUri - The namespace URI for anchors
+   * @returns Generated UUID
+   */
+  static generateUUID(metadata: Exo003Metadata, namespaceUri?: string): string {
+    switch (metadata.exo__metadataType) {
+      case Exo003MetadataType.Namespace:
+        return Exo003UUIDGenerator.generateNamespaceUUID(
+          (metadata as Exo003NamespaceMetadata).exo__Namespace_uri
+        );
+
+      case Exo003MetadataType.Anchor:
+        if (!namespaceUri) {
+          throw new Error("Namespace URI required for anchor UUID generation");
+        }
+        return Exo003UUIDGenerator.generateAssetUUID(
+          namespaceUri,
+          (metadata as Exo003AnchorMetadata).exo__Anchor_localName
+        );
+
+      case Exo003MetadataType.BlankNode:
+        return Exo003UUIDGenerator.generateBlankNodeUUID(
+          (metadata as Exo003BlankNodeMetadata).exo__BlankNode_id
+        );
+
+      case Exo003MetadataType.Statement: {
+        const stmt = metadata as Exo003StatementMetadata;
+        return Exo003UUIDGenerator.generateStatementUUID(
+          stmt.exo__Statement_subject,
+          stmt.exo__Statement_predicate,
+          stmt.exo__Statement_object
+        );
+      }
+
+      case Exo003MetadataType.Body: {
+        const body = metadata as Exo003BodyMetadata;
+        return Exo003UUIDGenerator.generateBodyUUID("", {
+          language: body.exo__Body_language,
+          direction: body.exo__Body_direction,
+          datatype: body.exo__Body_datatype,
+        });
+      }
+    }
+  }
+}

--- a/packages/exocortex/src/domain/models/exo003/UUIDGenerator.ts
+++ b/packages/exocortex/src/domain/models/exo003/UUIDGenerator.ts
@@ -1,0 +1,253 @@
+import { v5 as uuidv5 } from "uuid";
+import { UUID_URL_NAMESPACE } from "./types";
+
+/**
+ * Two-level namespace UUID generator for Exo 0.0.3.
+ *
+ * The UUID generation follows a deterministic two-level scheme:
+ *
+ * Level 1: Namespace UUID
+ * - Generated from the namespace URI using UUID v5 with URL_NAMESPACE
+ * - Example: namespace "https://exocortex.my/ontology/exo#" produces a stable UUID
+ *
+ * Level 2: Asset UUID
+ * - Generated from the asset's local identifier using UUID v5 with the namespace UUID
+ * - Example: anchor "Person" within exo namespace produces a stable UUID
+ *
+ * This ensures:
+ * 1. Same inputs always produce same UUID (deterministic/idempotent)
+ * 2. Different namespaces produce different UUIDs for same local names
+ * 3. Full URI can be reconstructed from namespace + local name
+ */
+export class Exo003UUIDGenerator {
+  /**
+   * Generate a namespace UUID from a namespace URI.
+   *
+   * @param namespaceUri - The full namespace URI (e.g., "https://exocortex.my/ontology/exo#")
+   * @returns UUID v5 generated from the namespace URI
+   *
+   * @example
+   * ```typescript
+   * const nsUuid = Exo003UUIDGenerator.generateNamespaceUUID("https://exocortex.my/ontology/exo#");
+   * // Always returns the same UUID for the same namespace URI
+   * ```
+   */
+  static generateNamespaceUUID(namespaceUri: string): string {
+    if (!namespaceUri || namespaceUri.trim().length === 0) {
+      throw new Error("Namespace URI cannot be empty");
+    }
+    return uuidv5(namespaceUri, UUID_URL_NAMESPACE);
+  }
+
+  /**
+   * Generate an asset UUID using the two-level namespace scheme.
+   *
+   * @param namespaceUri - The namespace URI the asset belongs to
+   * @param localIdentifier - The local identifier within the namespace
+   * @returns UUID v5 generated from namespace UUID + local identifier
+   *
+   * @example
+   * ```typescript
+   * // Generate UUID for exo:Person
+   * const uuid = Exo003UUIDGenerator.generateAssetUUID(
+   *   "https://exocortex.my/ontology/exo#",
+   *   "Person"
+   * );
+   * // Always returns the same UUID for the same namespace + local identifier
+   * ```
+   */
+  static generateAssetUUID(namespaceUri: string, localIdentifier: string): string {
+    if (!localIdentifier || localIdentifier.trim().length === 0) {
+      throw new Error("Local identifier cannot be empty");
+    }
+
+    const namespaceUuid = this.generateNamespaceUUID(namespaceUri);
+    return uuidv5(localIdentifier, namespaceUuid);
+  }
+
+  /**
+   * Generate a UUID for a full IRI.
+   *
+   * This method automatically splits the IRI into namespace and local name,
+   * then generates a deterministic UUID using the two-level scheme.
+   *
+   * @param iri - The full IRI (e.g., "https://exocortex.my/ontology/exo#Person")
+   * @returns UUID v5 generated from the IRI
+   *
+   * @example
+   * ```typescript
+   * const uuid = Exo003UUIDGenerator.generateFromIRI("https://exocortex.my/ontology/exo#Person");
+   * // Equivalent to: generateAssetUUID("https://exocortex.my/ontology/exo#", "Person")
+   * ```
+   */
+  static generateFromIRI(iri: string): string {
+    if (!iri || iri.trim().length === 0) {
+      throw new Error("IRI cannot be empty");
+    }
+
+    const { namespace, localName } = this.splitIRI(iri);
+
+    if (!localName) {
+      // If no local name, treat the entire IRI as the identifier
+      // Use a generic namespace for this case
+      return uuidv5(iri, UUID_URL_NAMESPACE);
+    }
+
+    return this.generateAssetUUID(namespace, localName);
+  }
+
+  /**
+   * Generate a UUID for a blank node.
+   *
+   * Blank node UUIDs are generated using the blank node ID within a special
+   * blank node namespace to ensure uniqueness.
+   *
+   * @param blankNodeId - The blank node identifier (e.g., "b1", "node123")
+   * @param contextUri - Optional context URI for scoping (e.g., file path)
+   * @returns UUID v5 generated for the blank node
+   *
+   * @example
+   * ```typescript
+   * const uuid = Exo003UUIDGenerator.generateBlankNodeUUID("b1", "file:///path/to/context.md");
+   * ```
+   */
+  static generateBlankNodeUUID(blankNodeId: string, contextUri?: string): string {
+    if (!blankNodeId || blankNodeId.trim().length === 0) {
+      throw new Error("Blank node ID cannot be empty");
+    }
+
+    // Use a special namespace for blank nodes
+    const blankNodeNamespace = "urn:exocortex:blank-node:";
+    const fullId = contextUri ? `${contextUri}#${blankNodeId}` : blankNodeId;
+
+    return this.generateAssetUUID(blankNodeNamespace, fullId);
+  }
+
+  /**
+   * Generate a UUID for a statement (triple).
+   *
+   * Statement UUIDs are generated from the combination of subject, predicate,
+   * and object URIs, ensuring the same triple always gets the same UUID.
+   *
+   * @param subjectUri - The subject URI or blank node ID
+   * @param predicateUri - The predicate URI
+   * @param objectUri - The object URI, blank node ID, or literal identifier
+   * @returns UUID v5 generated for the statement
+   *
+   * @example
+   * ```typescript
+   * const uuid = Exo003UUIDGenerator.generateStatementUUID(
+   *   "https://exocortex.my/ontology/exo#Person",
+   *   "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+   *   "http://www.w3.org/2000/01/rdf-schema#Class"
+   * );
+   * ```
+   */
+  static generateStatementUUID(
+    subjectUri: string,
+    predicateUri: string,
+    objectUri: string
+  ): string {
+    if (!subjectUri || !predicateUri || !objectUri) {
+      throw new Error("Subject, predicate, and object cannot be empty");
+    }
+
+    // Use a special namespace for statements
+    const statementNamespace = "urn:exocortex:statement:";
+
+    // Combine the triple components into a deterministic identifier
+    const tripleIdentifier = `${subjectUri}\t${predicateUri}\t${objectUri}`;
+
+    return this.generateAssetUUID(statementNamespace, tripleIdentifier);
+  }
+
+  /**
+   * Generate a UUID for a body (literal content).
+   *
+   * Body UUIDs are generated from a hash of the content combined with
+   * optional language and datatype information.
+   *
+   * @param content - The literal content
+   * @param options - Optional language, direction, and datatype
+   * @returns UUID v5 generated for the body
+   *
+   * @example
+   * ```typescript
+   * const uuid = Exo003UUIDGenerator.generateBodyUUID("Hello, World!", { language: "en" });
+   * ```
+   */
+  static generateBodyUUID(
+    content: string,
+    options?: {
+      language?: string;
+      direction?: "ltr" | "rtl";
+      datatype?: string;
+    }
+  ): string {
+    // Use a special namespace for body content
+    const bodyNamespace = "urn:exocortex:body:";
+
+    // Build identifier from content and options
+    let identifier = content;
+
+    if (options?.datatype) {
+      identifier += `^^${options.datatype}`;
+    } else if (options?.language) {
+      identifier += `@${options.language}`;
+      if (options.direction) {
+        identifier += `--${options.direction}`;
+      }
+    }
+
+    return this.generateAssetUUID(bodyNamespace, identifier);
+  }
+
+  /**
+   * Split an IRI into namespace and local name.
+   *
+   * Supports both hash (#) and slash (/) separators:
+   * - https://exocortex.my/ontology/exo#Person → { namespace: "...exo#", localName: "Person" }
+   * - http://example.org/vocab/Person → { namespace: "...vocab/", localName: "Person" }
+   *
+   * @param iri - The IRI to split
+   * @returns Object with namespace and localName
+   */
+  static splitIRI(iri: string): { namespace: string; localName: string } {
+    // Try hash separator first
+    const hashIndex = iri.lastIndexOf("#");
+    if (hashIndex !== -1 && hashIndex < iri.length - 1) {
+      return {
+        namespace: iri.substring(0, hashIndex + 1),
+        localName: iri.substring(hashIndex + 1),
+      };
+    }
+
+    // Try slash separator (but not in protocol)
+    const slashIndex = iri.lastIndexOf("/");
+    const protocolEnd = iri.indexOf("://");
+    if (slashIndex !== -1 && slashIndex > protocolEnd + 2 && slashIndex < iri.length - 1) {
+      return {
+        namespace: iri.substring(0, slashIndex + 1),
+        localName: iri.substring(slashIndex + 1),
+      };
+    }
+
+    // No separator found - return entire IRI as namespace with empty local name
+    return {
+      namespace: iri,
+      localName: "",
+    };
+  }
+
+  /**
+   * Validate that a string is a valid UUID v4 or v5.
+   *
+   * @param uuid - The string to validate
+   * @returns True if valid UUID format
+   */
+  static isValidUUID(uuid: string): boolean {
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    return uuidRegex.test(uuid);
+  }
+}

--- a/packages/exocortex/src/domain/models/exo003/index.ts
+++ b/packages/exocortex/src/domain/models/exo003/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Exo 0.0.3 File Format Support
+ *
+ * This module provides types, parsers, and utilities for working with
+ * the Exo 0.0.3 file format where each RDF triple is stored as a separate file.
+ *
+ * @packageDocumentation
+ */
+
+// Types and constants
+export {
+  Exo003MetadataType,
+  ALLOWED_PROPERTIES,
+  REQUIRED_PROPERTIES,
+  DEFAULT_LANGUAGE_TAG,
+  UUID_URL_NAMESPACE,
+} from "./types";
+
+export type {
+  Exo003BaseMetadata,
+  Exo003NamespaceMetadata,
+  Exo003AnchorMetadata,
+  Exo003BlankNodeMetadata,
+  Exo003StatementMetadata,
+  Exo003BodyMetadata,
+  Exo003Metadata,
+} from "./types";
+
+// UUID Generator
+export { Exo003UUIDGenerator } from "./UUIDGenerator";
+
+// Parser and Validator
+export { Exo003Parser } from "./Exo003Parser";
+export type { Exo003ParseResult, Exo003ValidationResult } from "./Exo003Parser";

--- a/packages/exocortex/src/domain/models/exo003/types.ts
+++ b/packages/exocortex/src/domain/models/exo003/types.ts
@@ -1,0 +1,257 @@
+/**
+ * Exo 0.0.3 File Format Types
+ *
+ * In Exo 0.0.3, each RDF triple is stored as a separate file.
+ * This architectural change provides:
+ * - Granular version control - Each statement tracked independently
+ * - Conflict-free collaboration - Multiple users can modify different aspects simultaneously
+ * - Clear semantic structure - File type determines RDF meaning
+ * - Optimized for Obsidian - Native integration with vault file system
+ */
+
+/**
+ * Metadata types supported by Exo 0.0.3 file format.
+ * Each type represents a different kind of RDF construct stored as a file.
+ */
+export enum Exo003MetadataType {
+  /**
+   * Namespace declaration file.
+   * Defines a prefix-to-URI mapping used across the knowledge base.
+   */
+  Namespace = "namespace",
+
+  /**
+   * Anchor file - represents a named resource (IRI).
+   * Each anchor has a unique URI within its namespace.
+   */
+  Anchor = "anchor",
+
+  /**
+   * Blank node file - represents an anonymous resource.
+   * Used for resources that don't have a global identifier.
+   */
+  BlankNode = "blank_node",
+
+  /**
+   * Statement file - represents an RDF triple (subject, predicate, object).
+   * The core building block of the knowledge base.
+   */
+  Statement = "statement",
+
+  /**
+   * Body file - contains the textual content of a resource.
+   * Used for literals, descriptions, and other text content.
+   */
+  Body = "body",
+}
+
+/**
+ * Base interface for all Exo 0.0.3 file metadata.
+ */
+export interface Exo003BaseMetadata {
+  /** Unique identifier for this file (UUID v5) */
+  exo__Asset_uid: string;
+
+  /** Creation timestamp in local format (YYYY-MM-DDTHH:mm:ss) */
+  exo__Asset_createdAt: string;
+
+  /** The metadata type determining how this file is interpreted */
+  exo__metadataType: Exo003MetadataType;
+
+  /** Reference to the namespace this asset belongs to */
+  exo__Asset_isDefinedBy?: string;
+}
+
+/**
+ * Metadata for namespace files.
+ * Defines prefix-to-URI mappings for the knowledge base.
+ */
+export interface Exo003NamespaceMetadata extends Exo003BaseMetadata {
+  exo__metadataType: Exo003MetadataType.Namespace;
+
+  /** The namespace prefix (e.g., "exo", "ems", "foaf") */
+  exo__Namespace_prefix: string;
+
+  /** The full URI for this namespace */
+  exo__Namespace_uri: string;
+}
+
+/**
+ * Metadata for anchor files (named resources).
+ * Represents a resource with a globally unique URI.
+ */
+export interface Exo003AnchorMetadata extends Exo003BaseMetadata {
+  exo__metadataType: Exo003MetadataType.Anchor;
+
+  /** The local name within the namespace (e.g., "Person", "Task") */
+  exo__Anchor_localName: string;
+
+  /** Human-readable label for this anchor */
+  exo__Asset_label?: string;
+}
+
+/**
+ * Metadata for blank node files (anonymous resources).
+ * Represents a resource without a global identifier.
+ */
+export interface Exo003BlankNodeMetadata extends Exo003BaseMetadata {
+  exo__metadataType: Exo003MetadataType.BlankNode;
+
+  /** The blank node identifier (local to this knowledge base) */
+  exo__BlankNode_id: string;
+
+  /** Human-readable label for this blank node */
+  exo__Asset_label?: string;
+}
+
+/**
+ * Metadata for statement files (RDF triples).
+ * Represents a single subject-predicate-object triple.
+ */
+export interface Exo003StatementMetadata extends Exo003BaseMetadata {
+  exo__metadataType: Exo003MetadataType.Statement;
+
+  /** Reference to the subject (anchor, blank node, or statement file) */
+  exo__Statement_subject: string;
+
+  /** Reference to the predicate (anchor file representing a property) */
+  exo__Statement_predicate: string;
+
+  /** Reference to the object (anchor, blank node, statement, or body file) */
+  exo__Statement_object: string;
+}
+
+/**
+ * Metadata for body files (literal content).
+ * Contains textual content and optional language/datatype information.
+ */
+export interface Exo003BodyMetadata extends Exo003BaseMetadata {
+  exo__metadataType: Exo003MetadataType.Body;
+
+  /** The XSD datatype URI (if typed literal) */
+  exo__Body_datatype?: string;
+
+  /** Language tag (if language-tagged string, defaults to "ru") */
+  exo__Body_language?: string;
+
+  /** Base direction for bidirectional text ("ltr" or "rtl") */
+  exo__Body_direction?: "ltr" | "rtl";
+}
+
+/**
+ * Union type for all Exo 0.0.3 metadata types.
+ */
+export type Exo003Metadata =
+  | Exo003NamespaceMetadata
+  | Exo003AnchorMetadata
+  | Exo003BlankNodeMetadata
+  | Exo003StatementMetadata
+  | Exo003BodyMetadata;
+
+/**
+ * Allowed frontmatter properties for each metadata type.
+ * Properties not in this list are forbidden and should trigger validation errors.
+ */
+export const ALLOWED_PROPERTIES: Record<Exo003MetadataType, readonly string[]> = {
+  [Exo003MetadataType.Namespace]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+    "exo__Asset_isDefinedBy",
+    "exo__Namespace_prefix",
+    "exo__Namespace_uri",
+  ] as const,
+
+  [Exo003MetadataType.Anchor]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+    "exo__Asset_isDefinedBy",
+    "exo__Anchor_localName",
+    "exo__Asset_label",
+    "aliases",
+  ] as const,
+
+  [Exo003MetadataType.BlankNode]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+    "exo__Asset_isDefinedBy",
+    "exo__BlankNode_id",
+    "exo__Asset_label",
+    "aliases",
+  ] as const,
+
+  [Exo003MetadataType.Statement]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+    "exo__Asset_isDefinedBy",
+    "exo__Statement_subject",
+    "exo__Statement_predicate",
+    "exo__Statement_object",
+  ] as const,
+
+  [Exo003MetadataType.Body]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+    "exo__Asset_isDefinedBy",
+    "exo__Body_datatype",
+    "exo__Body_language",
+    "exo__Body_direction",
+  ] as const,
+};
+
+/**
+ * Required frontmatter properties for each metadata type.
+ */
+export const REQUIRED_PROPERTIES: Record<Exo003MetadataType, readonly string[]> = {
+  [Exo003MetadataType.Namespace]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+    "exo__Namespace_prefix",
+    "exo__Namespace_uri",
+  ] as const,
+
+  [Exo003MetadataType.Anchor]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+    "exo__Anchor_localName",
+  ] as const,
+
+  [Exo003MetadataType.BlankNode]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+    "exo__BlankNode_id",
+  ] as const,
+
+  [Exo003MetadataType.Statement]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+    "exo__Statement_subject",
+    "exo__Statement_predicate",
+    "exo__Statement_object",
+  ] as const,
+
+  [Exo003MetadataType.Body]: [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__metadataType",
+  ] as const,
+};
+
+/**
+ * Default language tag for literals without explicit language specification.
+ */
+export const DEFAULT_LANGUAGE_TAG = "ru";
+
+/**
+ * UUID v5 namespace for URL-based UUIDs (RFC 4122).
+ * Used as the first level of the two-level namespace scheme.
+ */
+export const UUID_URL_NAMESPACE = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -7,6 +7,7 @@ export * from "./domain/models/GraphEdge";
 export * from "./domain/models/GraphTypes";
 export * from "./domain/models/AreaNode";
 export * from "./domain/models/rdf";
+export * from "./domain/models/exo003";
 export * from "./domain/commands/CommandVisibility";
 export type { IPropertyValidationService, ValidationResult } from "./domain/services/IPropertyValidationService";
 

--- a/packages/exocortex/tests/unit/domain/models/exo003/Exo003Parser.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/exo003/Exo003Parser.test.ts
@@ -1,0 +1,505 @@
+import {
+  Exo003Parser,
+  Exo003MetadataType,
+  Exo003NamespaceMetadata,
+  Exo003AnchorMetadata,
+  Exo003BlankNodeMetadata,
+  Exo003StatementMetadata,
+  Exo003BodyMetadata,
+  DEFAULT_LANGUAGE_TAG,
+} from "../../../../../src/domain/models/exo003";
+import { Literal } from "../../../../../src/domain/models/rdf/Literal";
+
+describe("Exo003Parser", () => {
+  describe("validate", () => {
+    describe("common validation", () => {
+      it("should fail when exo__metadataType is missing", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Missing required property: exo__metadataType");
+      });
+
+      it("should fail for unknown metadata type", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: "unknown_type",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain("Invalid exo__metadataType");
+      });
+
+      it("should fail when required properties are missing", () => {
+        const result = Exo003Parser.validate({
+          exo__metadataType: Exo003MetadataType.Namespace,
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          // Missing exo__Asset_uid, exo__Namespace_prefix, exo__Namespace_uri
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Missing required property: exo__Asset_uid");
+        expect(result.errors).toContain("Missing required property: exo__Namespace_prefix");
+        expect(result.errors).toContain("Missing required property: exo__Namespace_uri");
+      });
+
+      it("should fail when forbidden properties are present", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Namespace,
+          exo__Namespace_prefix: "exo",
+          exo__Namespace_uri: "https://exocortex.my/ontology/exo#",
+          forbidden_property: "value", // Not allowed
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Forbidden property for namespace: forbidden_property");
+      });
+    });
+
+    describe("namespace validation", () => {
+      it("should pass for valid namespace metadata", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Namespace,
+          exo__Namespace_prefix: "exo",
+          exo__Namespace_uri: "https://exocortex.my/ontology/exo#",
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+      });
+
+      it("should fail for invalid namespace prefix", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Namespace,
+          exo__Namespace_prefix: "123invalid", // Must start with letter
+          exo__Namespace_uri: "https://exocortex.my/ontology/exo#",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain("exo__Namespace_prefix must start with a letter");
+      });
+
+      it("should fail for invalid namespace URI", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Namespace,
+          exo__Namespace_prefix: "exo",
+          exo__Namespace_uri: "not a valid uri",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain("exo__Namespace_uri is not a valid IRI");
+      });
+    });
+
+    describe("anchor validation", () => {
+      it("should pass for valid anchor metadata", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Anchor,
+          exo__Anchor_localName: "Person",
+        });
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should fail for empty anchor local name", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Anchor,
+          exo__Anchor_localName: "   ",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain("exo__Anchor_localName cannot be empty");
+      });
+    });
+
+    describe("blank_node validation", () => {
+      it("should pass for valid blank node metadata", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.BlankNode,
+          exo__BlankNode_id: "b1",
+        });
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should fail for empty blank node id", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.BlankNode,
+          exo__BlankNode_id: "",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain("exo__BlankNode_id cannot be empty");
+      });
+    });
+
+    describe("statement validation", () => {
+      it("should pass for valid statement metadata", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Statement,
+          exo__Statement_subject: "[[person-123]]",
+          exo__Statement_predicate: "[[rdf-type]]",
+          exo__Statement_object: "[[rdfs-class]]",
+        });
+
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe("body validation", () => {
+      it("should pass for valid body metadata with language", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Body,
+          exo__Body_language: "en",
+        });
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should pass for valid body metadata with datatype", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Body,
+          exo__Body_datatype: "http://www.w3.org/2001/XMLSchema#integer",
+        });
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should fail when both language and datatype are specified", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Body,
+          exo__Body_language: "en",
+          exo__Body_datatype: "http://www.w3.org/2001/XMLSchema#string",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain(
+          "Body cannot have both exo__Body_datatype and exo__Body_language"
+        );
+      });
+
+      it("should fail when direction is specified without language", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Body,
+          exo__Body_direction: "rtl",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain(
+          "exo__Body_direction requires exo__Body_language to be set"
+        );
+      });
+
+      it("should fail for invalid direction value", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Body,
+          exo__Body_language: "ar",
+          exo__Body_direction: "invalid",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain('exo__Body_direction must be "ltr" or "rtl"');
+      });
+
+      it("should warn when no language or datatype is specified", () => {
+        const result = Exo003Parser.validate({
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Body,
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.warnings).toContain(
+          `No language or datatype specified. Will use default language tag: @${DEFAULT_LANGUAGE_TAG}`
+        );
+      });
+    });
+  });
+
+  describe("parse", () => {
+    it("should parse valid namespace metadata", () => {
+      const result = Exo003Parser.parse({
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Namespace,
+        exo__Namespace_prefix: "exo",
+        exo__Namespace_uri: "https://exocortex.my/ontology/exo#",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.metadata).toBeDefined();
+      expect(result.metadata?.exo__metadataType).toBe(Exo003MetadataType.Namespace);
+
+      const namespace = result.metadata as Exo003NamespaceMetadata;
+      expect(namespace.exo__Namespace_prefix).toBe("exo");
+      expect(namespace.exo__Namespace_uri).toBe("https://exocortex.my/ontology/exo#");
+    });
+
+    it("should parse valid anchor metadata", () => {
+      const result = Exo003Parser.parse({
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Anchor,
+        exo__Anchor_localName: "Person",
+        exo__Asset_label: "Person Class",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.metadata).toBeDefined();
+
+      const anchor = result.metadata as Exo003AnchorMetadata;
+      expect(anchor.exo__Anchor_localName).toBe("Person");
+      expect(anchor.exo__Asset_label).toBe("Person Class");
+    });
+
+    it("should parse valid blank node metadata", () => {
+      const result = Exo003Parser.parse({
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.BlankNode,
+        exo__BlankNode_id: "b1",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.metadata).toBeDefined();
+
+      const blankNode = result.metadata as Exo003BlankNodeMetadata;
+      expect(blankNode.exo__BlankNode_id).toBe("b1");
+    });
+
+    it("should parse valid statement metadata", () => {
+      const result = Exo003Parser.parse({
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Statement,
+        exo__Statement_subject: "[[person-123]]",
+        exo__Statement_predicate: "[[rdf-type]]",
+        exo__Statement_object: "[[rdfs-class]]",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.metadata).toBeDefined();
+
+      const statement = result.metadata as Exo003StatementMetadata;
+      expect(statement.exo__Statement_subject).toBe("[[person-123]]");
+      expect(statement.exo__Statement_predicate).toBe("[[rdf-type]]");
+      expect(statement.exo__Statement_object).toBe("[[rdfs-class]]");
+    });
+
+    it("should parse valid body metadata and include body content", () => {
+      const result = Exo003Parser.parse(
+        {
+          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+          exo__Asset_createdAt: "2025-01-04T12:00:00",
+          exo__metadataType: Exo003MetadataType.Body,
+          exo__Body_language: "en",
+        },
+        "Hello, World!"
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.metadata).toBeDefined();
+      expect(result.bodyContent).toBe("Hello, World!");
+
+      const body = result.metadata as Exo003BodyMetadata;
+      expect(body.exo__Body_language).toBe("en");
+    });
+
+    it("should return errors for invalid frontmatter", () => {
+      const result = Exo003Parser.parse({
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Namespace,
+        // Missing required properties
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("toLiteral", () => {
+    it("should create literal with specified language", () => {
+      const metadata: Exo003BodyMetadata = {
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Body,
+        exo__Body_language: "en",
+      };
+
+      const literal = Exo003Parser.toLiteral(metadata, "Hello, World!");
+
+      expect(literal.value).toBe("Hello, World!");
+      expect(literal.language).toBe("en");
+      expect(literal.datatype).toBeUndefined();
+    });
+
+    it("should create literal with default language when not specified", () => {
+      const metadata: Exo003BodyMetadata = {
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Body,
+      };
+
+      const literal = Exo003Parser.toLiteral(metadata, "Привет, мир!");
+
+      expect(literal.value).toBe("Привет, мир!");
+      expect(literal.language).toBe(DEFAULT_LANGUAGE_TAG);
+    });
+
+    it("should create literal with direction", () => {
+      const metadata: Exo003BodyMetadata = {
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Body,
+        exo__Body_language: "ar",
+        exo__Body_direction: "rtl",
+      };
+
+      const literal = Exo003Parser.toLiteral(metadata, "مرحبا");
+
+      expect(literal.value).toBe("مرحبا");
+      expect(literal.language).toBe("ar");
+      expect(literal.direction).toBe("rtl");
+    });
+
+    it("should create typed literal with datatype", () => {
+      const metadata: Exo003BodyMetadata = {
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Body,
+        exo__Body_datatype: "http://www.w3.org/2001/XMLSchema#integer",
+      };
+
+      const literal = Exo003Parser.toLiteral(metadata, "42");
+
+      expect(literal.value).toBe("42");
+      expect(literal.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#integer");
+      expect(literal.language).toBeUndefined();
+    });
+  });
+
+  describe("isExo003Format", () => {
+    it("should return true for valid Exo 0.0.3 frontmatter", () => {
+      expect(
+        Exo003Parser.isExo003Format({
+          exo__metadataType: Exo003MetadataType.Namespace,
+        })
+      ).toBe(true);
+
+      expect(
+        Exo003Parser.isExo003Format({
+          exo__metadataType: Exo003MetadataType.Statement,
+        })
+      ).toBe(true);
+    });
+
+    it("should return false for non-Exo 0.0.3 frontmatter", () => {
+      expect(
+        Exo003Parser.isExo003Format({
+          exo__Instance_class: "ems__Task",
+        })
+      ).toBe(false);
+
+      expect(
+        Exo003Parser.isExo003Format({
+          exo__metadataType: "unknown_type",
+        })
+      ).toBe(false);
+
+      expect(Exo003Parser.isExo003Format({})).toBe(false);
+    });
+  });
+
+  describe("toTriple", () => {
+    it("should convert statement metadata to Triple", () => {
+      const metadata: Exo003StatementMetadata = {
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Statement,
+        exo__Statement_subject: "[[person-123]]",
+        exo__Statement_predicate: "[[rdf-type]]",
+        exo__Statement_object: "[[rdfs-class]]",
+      };
+
+      const resolveReference = (ref: string) => {
+        const mappings: Record<string, { type: "iri" | "blank" | "literal"; value: string }> = {
+          "[[person-123]]": { type: "iri", value: "https://exocortex.my/ontology/exo#Person" },
+          "[[rdf-type]]": { type: "iri", value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" },
+          "[[rdfs-class]]": { type: "iri", value: "http://www.w3.org/2000/01/rdf-schema#Class" },
+        };
+        return mappings[ref] || { type: "iri" as const, value: ref };
+      };
+
+      const triple = Exo003Parser.toTriple(metadata, resolveReference);
+
+      expect(triple.subject.toString()).toBe("https://exocortex.my/ontology/exo#Person");
+      expect(triple.predicate.toString()).toBe(
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+      );
+      expect(triple.object.toString()).toBe("http://www.w3.org/2000/01/rdf-schema#Class");
+    });
+
+    it("should handle literal objects with body content", () => {
+      const metadata: Exo003StatementMetadata = {
+        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
+        exo__Asset_createdAt: "2025-01-04T12:00:00",
+        exo__metadataType: Exo003MetadataType.Statement,
+        exo__Statement_subject: "[[person-123]]",
+        exo__Statement_predicate: "[[rdfs-label]]",
+        exo__Statement_object: "[[label-body]]",
+      };
+
+      const resolveReference = (ref: string) => {
+        const mappings: Record<
+          string,
+          { type: "iri" | "blank" | "literal"; value: string; language?: string }
+        > = {
+          "[[person-123]]": { type: "iri", value: "https://exocortex.my/ontology/exo#Person" },
+          "[[rdfs-label]]": { type: "iri", value: "http://www.w3.org/2000/01/rdf-schema#label" },
+          "[[label-body]]": { type: "literal", value: "", language: "en" },
+        };
+        return mappings[ref] || { type: "iri" as const, value: ref };
+      };
+
+      const triple = Exo003Parser.toTriple(metadata, resolveReference, "Person Class");
+
+      expect(triple.object).toBeInstanceOf(Literal);
+      expect((triple.object as Literal).value).toBe("Person Class");
+      expect((triple.object as Literal).language).toBe("en");
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/domain/models/exo003/UUIDGenerator.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/exo003/UUIDGenerator.test.ts
@@ -1,0 +1,289 @@
+import { Exo003UUIDGenerator } from "../../../../../src/domain/models/exo003/UUIDGenerator";
+
+describe("Exo003UUIDGenerator", () => {
+  describe("generateNamespaceUUID", () => {
+    it("should generate deterministic UUID for the same namespace URI", () => {
+      const uri = "https://exocortex.my/ontology/exo#";
+      const uuid1 = Exo003UUIDGenerator.generateNamespaceUUID(uri);
+      const uuid2 = Exo003UUIDGenerator.generateNamespaceUUID(uri);
+
+      expect(uuid1).toBe(uuid2);
+      expect(Exo003UUIDGenerator.isValidUUID(uuid1)).toBe(true);
+    });
+
+    it("should generate different UUIDs for different namespace URIs", () => {
+      const uri1 = "https://exocortex.my/ontology/exo#";
+      const uri2 = "https://exocortex.my/ontology/ems#";
+
+      const uuid1 = Exo003UUIDGenerator.generateNamespaceUUID(uri1);
+      const uuid2 = Exo003UUIDGenerator.generateNamespaceUUID(uri2);
+
+      expect(uuid1).not.toBe(uuid2);
+    });
+
+    it("should throw error for empty namespace URI", () => {
+      expect(() => Exo003UUIDGenerator.generateNamespaceUUID("")).toThrow(
+        "Namespace URI cannot be empty"
+      );
+    });
+
+    it("should throw error for whitespace-only namespace URI", () => {
+      expect(() => Exo003UUIDGenerator.generateNamespaceUUID("   ")).toThrow(
+        "Namespace URI cannot be empty"
+      );
+    });
+  });
+
+  describe("generateAssetUUID", () => {
+    it("should generate deterministic UUID using two-level scheme", () => {
+      const namespaceUri = "https://exocortex.my/ontology/exo#";
+      const localName = "Person";
+
+      const uuid1 = Exo003UUIDGenerator.generateAssetUUID(namespaceUri, localName);
+      const uuid2 = Exo003UUIDGenerator.generateAssetUUID(namespaceUri, localName);
+
+      expect(uuid1).toBe(uuid2);
+      expect(Exo003UUIDGenerator.isValidUUID(uuid1)).toBe(true);
+    });
+
+    it("should generate different UUIDs for same local name in different namespaces", () => {
+      const localName = "Task";
+
+      const uuid1 = Exo003UUIDGenerator.generateAssetUUID(
+        "https://exocortex.my/ontology/exo#",
+        localName
+      );
+      const uuid2 = Exo003UUIDGenerator.generateAssetUUID(
+        "https://exocortex.my/ontology/ems#",
+        localName
+      );
+
+      expect(uuid1).not.toBe(uuid2);
+    });
+
+    it("should generate different UUIDs for different local names in same namespace", () => {
+      const namespaceUri = "https://exocortex.my/ontology/exo#";
+
+      const uuid1 = Exo003UUIDGenerator.generateAssetUUID(namespaceUri, "Person");
+      const uuid2 = Exo003UUIDGenerator.generateAssetUUID(namespaceUri, "Organization");
+
+      expect(uuid1).not.toBe(uuid2);
+    });
+
+    it("should throw error for empty local identifier", () => {
+      expect(() =>
+        Exo003UUIDGenerator.generateAssetUUID(
+          "https://exocortex.my/ontology/exo#",
+          ""
+        )
+      ).toThrow("Local identifier cannot be empty");
+    });
+  });
+
+  describe("generateFromIRI", () => {
+    it("should generate UUID from hash-style IRI", () => {
+      const iri = "https://exocortex.my/ontology/exo#Person";
+      const uuid = Exo003UUIDGenerator.generateFromIRI(iri);
+
+      // Should be same as generateAssetUUID with split components
+      const expected = Exo003UUIDGenerator.generateAssetUUID(
+        "https://exocortex.my/ontology/exo#",
+        "Person"
+      );
+
+      expect(uuid).toBe(expected);
+    });
+
+    it("should generate UUID from slash-style IRI", () => {
+      const iri = "http://example.org/vocab/Person";
+      const uuid = Exo003UUIDGenerator.generateFromIRI(iri);
+
+      // Should be same as generateAssetUUID with split components
+      const expected = Exo003UUIDGenerator.generateAssetUUID(
+        "http://example.org/vocab/",
+        "Person"
+      );
+
+      expect(uuid).toBe(expected);
+    });
+
+    it("should handle IRI without local name separator", () => {
+      const iri = "urn:isbn:0451450523";
+      const uuid = Exo003UUIDGenerator.generateFromIRI(iri);
+
+      expect(Exo003UUIDGenerator.isValidUUID(uuid)).toBe(true);
+    });
+
+    it("should throw error for empty IRI", () => {
+      expect(() => Exo003UUIDGenerator.generateFromIRI("")).toThrow(
+        "IRI cannot be empty"
+      );
+    });
+  });
+
+  describe("generateBlankNodeUUID", () => {
+    it("should generate deterministic UUID for same blank node ID", () => {
+      const uuid1 = Exo003UUIDGenerator.generateBlankNodeUUID("b1");
+      const uuid2 = Exo003UUIDGenerator.generateBlankNodeUUID("b1");
+
+      expect(uuid1).toBe(uuid2);
+      expect(Exo003UUIDGenerator.isValidUUID(uuid1)).toBe(true);
+    });
+
+    it("should generate different UUIDs for different blank node IDs", () => {
+      const uuid1 = Exo003UUIDGenerator.generateBlankNodeUUID("b1");
+      const uuid2 = Exo003UUIDGenerator.generateBlankNodeUUID("b2");
+
+      expect(uuid1).not.toBe(uuid2);
+    });
+
+    it("should include context URI in UUID generation", () => {
+      const uuid1 = Exo003UUIDGenerator.generateBlankNodeUUID("b1", "file:///a.md");
+      const uuid2 = Exo003UUIDGenerator.generateBlankNodeUUID("b1", "file:///b.md");
+
+      expect(uuid1).not.toBe(uuid2);
+    });
+
+    it("should throw error for empty blank node ID", () => {
+      expect(() => Exo003UUIDGenerator.generateBlankNodeUUID("")).toThrow(
+        "Blank node ID cannot be empty"
+      );
+    });
+  });
+
+  describe("generateStatementUUID", () => {
+    it("should generate deterministic UUID for same triple", () => {
+      const uuid1 = Exo003UUIDGenerator.generateStatementUUID(
+        "https://exocortex.my/ontology/exo#Person",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://www.w3.org/2000/01/rdf-schema#Class"
+      );
+      const uuid2 = Exo003UUIDGenerator.generateStatementUUID(
+        "https://exocortex.my/ontology/exo#Person",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://www.w3.org/2000/01/rdf-schema#Class"
+      );
+
+      expect(uuid1).toBe(uuid2);
+      expect(Exo003UUIDGenerator.isValidUUID(uuid1)).toBe(true);
+    });
+
+    it("should generate different UUIDs for different triples", () => {
+      const uuid1 = Exo003UUIDGenerator.generateStatementUUID(
+        "https://exocortex.my/ontology/exo#Person",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://www.w3.org/2000/01/rdf-schema#Class"
+      );
+      const uuid2 = Exo003UUIDGenerator.generateStatementUUID(
+        "https://exocortex.my/ontology/exo#Organization",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://www.w3.org/2000/01/rdf-schema#Class"
+      );
+
+      expect(uuid1).not.toBe(uuid2);
+    });
+
+    it("should throw error for empty components", () => {
+      expect(() =>
+        Exo003UUIDGenerator.generateStatementUUID(
+          "",
+          "http://predicate",
+          "http://object"
+        )
+      ).toThrow("Subject, predicate, and object cannot be empty");
+    });
+  });
+
+  describe("generateBodyUUID", () => {
+    it("should generate deterministic UUID for same content", () => {
+      const uuid1 = Exo003UUIDGenerator.generateBodyUUID("Hello, World!");
+      const uuid2 = Exo003UUIDGenerator.generateBodyUUID("Hello, World!");
+
+      expect(uuid1).toBe(uuid2);
+      expect(Exo003UUIDGenerator.isValidUUID(uuid1)).toBe(true);
+    });
+
+    it("should generate different UUIDs for content with different language tags", () => {
+      const uuid1 = Exo003UUIDGenerator.generateBodyUUID("Hello", { language: "en" });
+      const uuid2 = Exo003UUIDGenerator.generateBodyUUID("Hello", { language: "de" });
+
+      expect(uuid1).not.toBe(uuid2);
+    });
+
+    it("should include direction in UUID generation", () => {
+      const uuid1 = Exo003UUIDGenerator.generateBodyUUID("مرحبا", {
+        language: "ar",
+        direction: "rtl",
+      });
+      const uuid2 = Exo003UUIDGenerator.generateBodyUUID("مرحبا", {
+        language: "ar",
+      });
+
+      expect(uuid1).not.toBe(uuid2);
+    });
+
+    it("should include datatype in UUID generation", () => {
+      const uuid1 = Exo003UUIDGenerator.generateBodyUUID("42", {
+        datatype: "http://www.w3.org/2001/XMLSchema#integer",
+      });
+      const uuid2 = Exo003UUIDGenerator.generateBodyUUID("42", {
+        datatype: "http://www.w3.org/2001/XMLSchema#string",
+      });
+
+      expect(uuid1).not.toBe(uuid2);
+    });
+  });
+
+  describe("splitIRI", () => {
+    it("should split hash-style IRIs correctly", () => {
+      const result = Exo003UUIDGenerator.splitIRI(
+        "https://exocortex.my/ontology/exo#Person"
+      );
+
+      expect(result.namespace).toBe("https://exocortex.my/ontology/exo#");
+      expect(result.localName).toBe("Person");
+    });
+
+    it("should split slash-style IRIs correctly", () => {
+      const result = Exo003UUIDGenerator.splitIRI(
+        "http://example.org/vocab/Person"
+      );
+
+      expect(result.namespace).toBe("http://example.org/vocab/");
+      expect(result.localName).toBe("Person");
+    });
+
+    it("should handle IRI with no local name separator", () => {
+      const result = Exo003UUIDGenerator.splitIRI("urn:isbn:0451450523");
+
+      expect(result.namespace).toBe("urn:isbn:0451450523");
+      expect(result.localName).toBe("");
+    });
+
+    it("should prefer hash over slash for separation", () => {
+      const result = Exo003UUIDGenerator.splitIRI(
+        "http://example.org/vocab#Person"
+      );
+
+      expect(result.namespace).toBe("http://example.org/vocab#");
+      expect(result.localName).toBe("Person");
+    });
+  });
+
+  describe("isValidUUID", () => {
+    it("should return true for valid UUIDs", () => {
+      expect(
+        Exo003UUIDGenerator.isValidUUID("550e8400-e29b-41d4-a716-446655440000")
+      ).toBe(true);
+      expect(
+        Exo003UUIDGenerator.isValidUUID("6BA7B810-9DAD-11D1-80B4-00C04FD430C8")
+      ).toBe(true);
+    });
+
+    it("should return false for invalid UUIDs", () => {
+      expect(Exo003UUIDGenerator.isValidUUID("not-a-uuid")).toBe(false);
+      expect(Exo003UUIDGenerator.isValidUUID("550e8400-e29b-41d4-a716")).toBe(false);
+      expect(Exo003UUIDGenerator.isValidUUID("")).toBe(false);
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/domain/models/exo003/types.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/exo003/types.test.ts
@@ -1,0 +1,155 @@
+import {
+  Exo003MetadataType,
+  ALLOWED_PROPERTIES,
+  REQUIRED_PROPERTIES,
+  DEFAULT_LANGUAGE_TAG,
+  UUID_URL_NAMESPACE,
+} from "../../../../../src/domain/models/exo003/types";
+
+describe("Exo003 Types", () => {
+  describe("Exo003MetadataType", () => {
+    it("should define all expected metadata types", () => {
+      expect(Exo003MetadataType.Namespace).toBe("namespace");
+      expect(Exo003MetadataType.Anchor).toBe("anchor");
+      expect(Exo003MetadataType.BlankNode).toBe("blank_node");
+      expect(Exo003MetadataType.Statement).toBe("statement");
+      expect(Exo003MetadataType.Body).toBe("body");
+    });
+
+    it("should have exactly 5 metadata types", () => {
+      const types = Object.values(Exo003MetadataType);
+      expect(types).toHaveLength(5);
+    });
+  });
+
+  describe("ALLOWED_PROPERTIES", () => {
+    it("should define allowed properties for all metadata types", () => {
+      expect(ALLOWED_PROPERTIES[Exo003MetadataType.Namespace]).toBeDefined();
+      expect(ALLOWED_PROPERTIES[Exo003MetadataType.Anchor]).toBeDefined();
+      expect(ALLOWED_PROPERTIES[Exo003MetadataType.BlankNode]).toBeDefined();
+      expect(ALLOWED_PROPERTIES[Exo003MetadataType.Statement]).toBeDefined();
+      expect(ALLOWED_PROPERTIES[Exo003MetadataType.Body]).toBeDefined();
+    });
+
+    it("should include common base properties for all types", () => {
+      for (const type of Object.values(Exo003MetadataType)) {
+        const props = ALLOWED_PROPERTIES[type];
+        expect(props).toContain("exo__Asset_uid");
+        expect(props).toContain("exo__Asset_createdAt");
+        expect(props).toContain("exo__metadataType");
+      }
+    });
+
+    it("should include namespace-specific properties", () => {
+      const props = ALLOWED_PROPERTIES[Exo003MetadataType.Namespace];
+      expect(props).toContain("exo__Namespace_prefix");
+      expect(props).toContain("exo__Namespace_uri");
+    });
+
+    it("should include anchor-specific properties", () => {
+      const props = ALLOWED_PROPERTIES[Exo003MetadataType.Anchor];
+      expect(props).toContain("exo__Anchor_localName");
+      expect(props).toContain("exo__Asset_label");
+      expect(props).toContain("aliases");
+    });
+
+    it("should include blank_node-specific properties", () => {
+      const props = ALLOWED_PROPERTIES[Exo003MetadataType.BlankNode];
+      expect(props).toContain("exo__BlankNode_id");
+      expect(props).toContain("exo__Asset_label");
+    });
+
+    it("should include statement-specific properties", () => {
+      const props = ALLOWED_PROPERTIES[Exo003MetadataType.Statement];
+      expect(props).toContain("exo__Statement_subject");
+      expect(props).toContain("exo__Statement_predicate");
+      expect(props).toContain("exo__Statement_object");
+    });
+
+    it("should include body-specific properties", () => {
+      const props = ALLOWED_PROPERTIES[Exo003MetadataType.Body];
+      expect(props).toContain("exo__Body_datatype");
+      expect(props).toContain("exo__Body_language");
+      expect(props).toContain("exo__Body_direction");
+    });
+  });
+
+  describe("REQUIRED_PROPERTIES", () => {
+    it("should define required properties for all metadata types", () => {
+      expect(REQUIRED_PROPERTIES[Exo003MetadataType.Namespace]).toBeDefined();
+      expect(REQUIRED_PROPERTIES[Exo003MetadataType.Anchor]).toBeDefined();
+      expect(REQUIRED_PROPERTIES[Exo003MetadataType.BlankNode]).toBeDefined();
+      expect(REQUIRED_PROPERTIES[Exo003MetadataType.Statement]).toBeDefined();
+      expect(REQUIRED_PROPERTIES[Exo003MetadataType.Body]).toBeDefined();
+    });
+
+    it("should require common base properties for all types", () => {
+      for (const type of Object.values(Exo003MetadataType)) {
+        const props = REQUIRED_PROPERTIES[type];
+        expect(props).toContain("exo__Asset_uid");
+        expect(props).toContain("exo__Asset_createdAt");
+        expect(props).toContain("exo__metadataType");
+      }
+    });
+
+    it("should have required properties as subset of allowed properties", () => {
+      for (const type of Object.values(Exo003MetadataType)) {
+        const required = REQUIRED_PROPERTIES[type];
+        const allowed = ALLOWED_PROPERTIES[type];
+
+        for (const prop of required) {
+          expect(allowed).toContain(prop);
+        }
+      }
+    });
+
+    it("should require namespace-specific properties", () => {
+      const props = REQUIRED_PROPERTIES[Exo003MetadataType.Namespace];
+      expect(props).toContain("exo__Namespace_prefix");
+      expect(props).toContain("exo__Namespace_uri");
+    });
+
+    it("should require anchor local name", () => {
+      const props = REQUIRED_PROPERTIES[Exo003MetadataType.Anchor];
+      expect(props).toContain("exo__Anchor_localName");
+    });
+
+    it("should require blank node id", () => {
+      const props = REQUIRED_PROPERTIES[Exo003MetadataType.BlankNode];
+      expect(props).toContain("exo__BlankNode_id");
+    });
+
+    it("should require all statement components", () => {
+      const props = REQUIRED_PROPERTIES[Exo003MetadataType.Statement];
+      expect(props).toContain("exo__Statement_subject");
+      expect(props).toContain("exo__Statement_predicate");
+      expect(props).toContain("exo__Statement_object");
+    });
+
+    it("should not require body content metadata (optional)", () => {
+      const props = REQUIRED_PROPERTIES[Exo003MetadataType.Body];
+      expect(props).not.toContain("exo__Body_datatype");
+      expect(props).not.toContain("exo__Body_language");
+      expect(props).not.toContain("exo__Body_direction");
+    });
+  });
+
+  describe("DEFAULT_LANGUAGE_TAG", () => {
+    it("should be 'ru' (Russian)", () => {
+      expect(DEFAULT_LANGUAGE_TAG).toBe("ru");
+    });
+  });
+
+  describe("UUID_URL_NAMESPACE", () => {
+    it("should be the RFC 4122 URL namespace UUID", () => {
+      // This is the standard UUID namespace for URLs from RFC 4122
+      expect(UUID_URL_NAMESPACE).toBe("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+    });
+
+    it("should be a valid UUID format", () => {
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      expect(uuidRegex.test(UUID_URL_NAMESPACE)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implement Exo 0.0.3 file format where each RDF triple is stored as a separate file
- Add two-level namespace UUID generation scheme (deterministic, idempotent)
- Support 5 metadata types: namespace, anchor, blank_node, statement, body
- Implement strict frontmatter property validation with allowlist
- Handle language-tagged literals with default @ru

## Key Components

### 1. Metadata Types (`types.ts`)
- `Exo003MetadataType` enum with 5 types
- `ALLOWED_PROPERTIES` - strict property allowlist per type
- `REQUIRED_PROPERTIES` - required properties per type
- `DEFAULT_LANGUAGE_TAG = "ru"`

### 2. UUID Generator (`UUIDGenerator.ts`)
- Two-level namespace scheme using UUID v5
- `generateNamespaceUUID(uri)` - Level 1
- `generateAssetUUID(namespace, localId)` - Level 2  
- Specialized generators for blank nodes, statements, bodies
- Same inputs always produce same UUID (idempotent)

### 3. Parser & Validator (`Exo003Parser.ts`)
- `parse()` - Parse frontmatter into typed metadata
- `validate()` - Validate against schema
- `toTriple()` - Convert to RDF Triple
- `toLiteral()` - Create Literal with language/datatype
- `isExo003Format()` - Check if frontmatter is Exo 0.0.3

## Test Plan

- [x] 81 unit tests covering all components
- [x] All existing tests pass (only unrelated flaky perf test fails)
- [x] Build succeeds
- [x] TypeScript compiles without errors

## Benefits

- Granular version control - each statement tracked independently
- Conflict-free collaboration - multiple users can modify different aspects
- Clear semantic structure - file type determines RDF meaning
- Optimized for Obsidian - native integration with vault file system

Closes #1351