### PR TITLE
fix(exo003): Align implementation with approved specification

### DIFF
--- a/packages/exocortex/src/domain/models/exo003/Exo003Parser.ts
+++ b/packages/exocortex/src/domain/models/exo003/Exo003Parser.ts
@@ -76,7 +76,7 @@ export class Exo003Parser {
       };
     }
 
-    const metadataType = frontmatter["exo__metadataType"] as Exo003MetadataType;
+    const metadataType = frontmatter["metadata"] as Exo003MetadataType;
 
     try {
       const metadata = this.parseByType(frontmatter, metadataType);
@@ -108,18 +108,18 @@ export class Exo003Parser {
     const errors: string[] = [];
     const warnings: string[] = [];
 
-    // Check for metadataType
-    if (!frontmatter["exo__metadataType"]) {
-      errors.push("Missing required property: exo__metadataType");
+    // Check for metadata type
+    if (!frontmatter["metadata"]) {
+      errors.push("Missing required property: metadata");
       return { valid: false, errors, warnings };
     }
 
-    const metadataType = frontmatter["exo__metadataType"] as string;
+    const metadataType = frontmatter["metadata"] as string;
 
-    // Validate metadataType is a known type
+    // Validate metadata is a known type
     if (!Object.values(Exo003MetadataType).includes(metadataType as Exo003MetadataType)) {
       errors.push(
-        `Invalid exo__metadataType: ${metadataType}. Valid types: ${Object.values(
+        `Invalid metadata: ${metadataType}. Valid types: ${Object.values(
           Exo003MetadataType
         ).join(", ")}`
       );
@@ -178,53 +178,52 @@ export class Exo003Parser {
     type: Exo003MetadataType
   ): Exo003Metadata {
     const base = {
-      exo__Asset_uid: frontmatter["exo__Asset_uid"] as string,
-      exo__Asset_createdAt: frontmatter["exo__Asset_createdAt"] as string,
-      exo__metadataType: type,
-      exo__Asset_isDefinedBy: frontmatter["exo__Asset_isDefinedBy"] as string | undefined,
+      metadata: type,
+      aliases: frontmatter["aliases"] as string[] | undefined,
     };
 
     switch (type) {
       case Exo003MetadataType.Namespace:
         return {
           ...base,
-          exo__metadataType: Exo003MetadataType.Namespace,
-          exo__Namespace_prefix: frontmatter["exo__Namespace_prefix"] as string,
-          exo__Namespace_uri: frontmatter["exo__Namespace_uri"] as string,
+          metadata: Exo003MetadataType.Namespace,
+          uri: frontmatter["uri"] as string,
         } satisfies Exo003NamespaceMetadata;
 
       case Exo003MetadataType.Anchor:
         return {
           ...base,
-          exo__metadataType: Exo003MetadataType.Anchor,
-          exo__Anchor_localName: frontmatter["exo__Anchor_localName"] as string,
-          exo__Asset_label: frontmatter["exo__Asset_label"] as string | undefined,
+          metadata: Exo003MetadataType.Anchor,
+          localName: frontmatter["localName"] as string,
+          label: frontmatter["label"] as string | undefined,
         } satisfies Exo003AnchorMetadata;
 
       case Exo003MetadataType.BlankNode:
         return {
           ...base,
-          exo__metadataType: Exo003MetadataType.BlankNode,
-          exo__BlankNode_id: frontmatter["exo__BlankNode_id"] as string,
-          exo__Asset_label: frontmatter["exo__Asset_label"] as string | undefined,
+          metadata: Exo003MetadataType.BlankNode,
+          id: frontmatter["id"] as string,
+          label: frontmatter["label"] as string | undefined,
         } satisfies Exo003BlankNodeMetadata;
 
       case Exo003MetadataType.Statement:
         return {
           ...base,
-          exo__metadataType: Exo003MetadataType.Statement,
-          exo__Statement_subject: frontmatter["exo__Statement_subject"] as string,
-          exo__Statement_predicate: frontmatter["exo__Statement_predicate"] as string,
-          exo__Statement_object: frontmatter["exo__Statement_object"] as string,
+          metadata: Exo003MetadataType.Statement,
+          subject: frontmatter["subject"] as string,
+          predicate: frontmatter["predicate"] as string,
+          object: frontmatter["object"] as string,
         } satisfies Exo003StatementMetadata;
 
       case Exo003MetadataType.Body:
         return {
           ...base,
-          exo__metadataType: Exo003MetadataType.Body,
-          exo__Body_datatype: frontmatter["exo__Body_datatype"] as string | undefined,
-          exo__Body_language: frontmatter["exo__Body_language"] as string | undefined,
-          exo__Body_direction: frontmatter["exo__Body_direction"] as "ltr" | "rtl" | undefined,
+          metadata: Exo003MetadataType.Body,
+          subject: frontmatter["subject"] as string,
+          predicate: frontmatter["predicate"] as string,
+          datatype: frontmatter["datatype"] as string | undefined,
+          language: frontmatter["language"] as string | undefined,
+          direction: frontmatter["direction"] as "ltr" | "rtl" | undefined,
         } satisfies Exo003BodyMetadata;
     }
   }
@@ -236,24 +235,15 @@ export class Exo003Parser {
     frontmatter: Record<string, unknown>,
     errors: string[]
   ): void {
-    const prefix = frontmatter["exo__Namespace_prefix"];
-    const uri = frontmatter["exo__Namespace_uri"];
-
-    if (prefix && typeof prefix !== "string") {
-      errors.push("exo__Namespace_prefix must be a string");
-    } else if (prefix && !/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(prefix as string)) {
-      errors.push(
-        "exo__Namespace_prefix must start with a letter and contain only letters, numbers, underscores, and hyphens"
-      );
-    }
+    const uri = frontmatter["uri"];
 
     if (uri && typeof uri !== "string") {
-      errors.push("exo__Namespace_uri must be a string");
+      errors.push("uri must be a string");
     } else if (uri) {
       try {
         new IRI(uri as string);
       } catch {
-        errors.push(`exo__Namespace_uri is not a valid IRI: ${uri}`);
+        errors.push(`uri is not a valid IRI: ${String(uri)}`);
       }
     }
   }
@@ -265,12 +255,12 @@ export class Exo003Parser {
     frontmatter: Record<string, unknown>,
     errors: string[]
   ): void {
-    const localName = frontmatter["exo__Anchor_localName"];
+    const localName = frontmatter["localName"];
 
     if (localName !== undefined && localName !== null && typeof localName !== "string") {
-      errors.push("exo__Anchor_localName must be a string");
+      errors.push("localName must be a string");
     } else if (typeof localName === "string" && localName.trim().length === 0) {
-      errors.push("exo__Anchor_localName cannot be empty");
+      errors.push("localName cannot be empty");
     }
   }
 
@@ -281,12 +271,12 @@ export class Exo003Parser {
     frontmatter: Record<string, unknown>,
     errors: string[]
   ): void {
-    const id = frontmatter["exo__BlankNode_id"];
+    const id = frontmatter["id"];
 
     if (id !== undefined && id !== null && typeof id !== "string") {
-      errors.push("exo__BlankNode_id must be a string");
+      errors.push("id must be a string");
     } else if (typeof id === "string" && id.trim().length === 0) {
-      errors.push("exo__BlankNode_id cannot be empty");
+      errors.push("id cannot be empty");
     }
   }
 
@@ -297,16 +287,17 @@ export class Exo003Parser {
     frontmatter: Record<string, unknown>,
     errors: string[]
   ): void {
-    const subject = frontmatter["exo__Statement_subject"];
-    const predicate = frontmatter["exo__Statement_predicate"];
-    const object = frontmatter["exo__Statement_object"];
+    const subject = frontmatter["subject"];
+    const predicate = frontmatter["predicate"];
+    const object = frontmatter["object"];
 
     // Subject, predicate, and object should be wikilinks or URIs
-    for (const [name, value] of [
-      ["exo__Statement_subject", subject],
-      ["exo__Statement_predicate", predicate],
-      ["exo__Statement_object", object],
-    ]) {
+    const entries: [string, unknown][] = [
+      ["subject", subject],
+      ["predicate", predicate],
+      ["object", object],
+    ];
+    for (const [name, value] of entries) {
       if (value && typeof value !== "string") {
         errors.push(`${name} must be a string`);
       }
@@ -321,23 +312,23 @@ export class Exo003Parser {
     errors: string[],
     warnings: string[]
   ): void {
-    const datatype = frontmatter["exo__Body_datatype"];
-    const language = frontmatter["exo__Body_language"];
-    const direction = frontmatter["exo__Body_direction"];
+    const datatype = frontmatter["datatype"];
+    const language = frontmatter["language"];
+    const direction = frontmatter["direction"];
 
     // Cannot have both datatype and language
     if (datatype && language) {
-      errors.push("Body cannot have both exo__Body_datatype and exo__Body_language");
+      errors.push("Body cannot have both datatype and language");
     }
 
     // Direction requires language
     if (direction && !language) {
-      errors.push("exo__Body_direction requires exo__Body_language to be set");
+      errors.push("direction requires language to be set");
     }
 
     // Validate direction value
     if (direction && direction !== "ltr" && direction !== "rtl") {
-      errors.push('exo__Body_direction must be "ltr" or "rtl"');
+      errors.push('direction must be "ltr" or "rtl"');
     }
 
     // Validate datatype is a valid IRI
@@ -345,7 +336,7 @@ export class Exo003Parser {
       try {
         new IRI(datatype);
       } catch {
-        errors.push(`exo__Body_datatype is not a valid IRI: ${datatype}`);
+        errors.push(`datatype is not a valid IRI: ${datatype}`);
       }
     }
 
@@ -377,7 +368,7 @@ export class Exo003Parser {
     bodyContent?: string
   ): Triple {
     // Resolve subject
-    const subjectRef = resolveReference(metadata.exo__Statement_subject);
+    const subjectRef = resolveReference(metadata.subject);
     let subject: Subject;
     if (subjectRef.type === "iri") {
       subject = new IRI(subjectRef.value);
@@ -388,14 +379,14 @@ export class Exo003Parser {
     }
 
     // Resolve predicate (must be IRI)
-    const predicateRef = resolveReference(metadata.exo__Statement_predicate);
+    const predicateRef = resolveReference(metadata.predicate);
     if (predicateRef.type !== "iri") {
       throw new Error("Statement predicate must be an IRI");
     }
     const predicate: Predicate = new IRI(predicateRef.value);
 
     // Resolve object
-    const objectRef = resolveReference(metadata.exo__Statement_object);
+    const objectRef = resolveReference(metadata.object);
     let object: RDFObject;
     if (objectRef.type === "iri") {
       object = new IRI(objectRef.value);
@@ -423,12 +414,12 @@ export class Exo003Parser {
    * @returns A Literal with appropriate language/datatype
    */
   static toLiteral(metadata: Exo003BodyMetadata, content: string): Literal {
-    if (metadata.exo__Body_datatype) {
-      return new Literal(content, new IRI(metadata.exo__Body_datatype));
+    if (metadata.datatype) {
+      return new Literal(content, new IRI(metadata.datatype));
     }
 
-    const language = metadata.exo__Body_language || DEFAULT_LANGUAGE_TAG;
-    return createDirectionalLiteral(content, language, metadata.exo__Body_direction);
+    const language = metadata.language || DEFAULT_LANGUAGE_TAG;
+    return createDirectionalLiteral(content, language, metadata.direction);
   }
 
   /**
@@ -438,7 +429,7 @@ export class Exo003Parser {
    * @returns True if this is valid Exo 0.0.3 format
    */
   static isExo003Format(frontmatter: Record<string, unknown>): boolean {
-    const metadataType = frontmatter["exo__metadataType"];
+    const metadataType = frontmatter["metadata"];
     return (
       typeof metadataType === "string" &&
       Object.values(Exo003MetadataType).includes(metadataType as Exo003MetadataType)
@@ -453,10 +444,10 @@ export class Exo003Parser {
    * @returns Generated UUID
    */
   static generateUUID(metadata: Exo003Metadata, namespaceUri?: string): string {
-    switch (metadata.exo__metadataType) {
+    switch (metadata.metadata) {
       case Exo003MetadataType.Namespace:
         return Exo003UUIDGenerator.generateNamespaceUUID(
-          (metadata as Exo003NamespaceMetadata).exo__Namespace_uri
+          (metadata as Exo003NamespaceMetadata).uri
         );
 
       case Exo003MetadataType.Anchor:
@@ -465,29 +456,29 @@ export class Exo003Parser {
         }
         return Exo003UUIDGenerator.generateAssetUUID(
           namespaceUri,
-          (metadata as Exo003AnchorMetadata).exo__Anchor_localName
+          (metadata as Exo003AnchorMetadata).localName
         );
 
       case Exo003MetadataType.BlankNode:
         return Exo003UUIDGenerator.generateBlankNodeUUID(
-          (metadata as Exo003BlankNodeMetadata).exo__BlankNode_id
+          (metadata as Exo003BlankNodeMetadata).id
         );
 
       case Exo003MetadataType.Statement: {
         const stmt = metadata as Exo003StatementMetadata;
         return Exo003UUIDGenerator.generateStatementUUID(
-          stmt.exo__Statement_subject,
-          stmt.exo__Statement_predicate,
-          stmt.exo__Statement_object
+          stmt.subject,
+          stmt.predicate,
+          stmt.object
         );
       }
 
       case Exo003MetadataType.Body: {
         const body = metadata as Exo003BodyMetadata;
         return Exo003UUIDGenerator.generateBodyUUID("", {
-          language: body.exo__Body_language,
-          direction: body.exo__Body_direction,
-          datatype: body.exo__Body_datatype,
+          language: body.language,
+          direction: body.direction,
+          datatype: body.datatype,
         });
       }
     }

--- a/packages/exocortex/tests/unit/domain/models/exo003/Exo003Parser.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/exo003/Exo003Parser.test.ts
@@ -13,47 +13,36 @@ import { Literal } from "../../../../../src/domain/models/rdf/Literal";
 describe("Exo003Parser", () => {
   describe("validate", () => {
     describe("common validation", () => {
-      it("should fail when exo__metadataType is missing", () => {
-        const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-        });
+      it("should fail when metadata is missing", () => {
+        const result = Exo003Parser.validate({});
 
         expect(result.valid).toBe(false);
-        expect(result.errors).toContain("Missing required property: exo__metadataType");
+        expect(result.errors).toContain("Missing required property: metadata");
       });
 
       it("should fail for unknown metadata type", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: "unknown_type",
+          metadata: "unknown_type",
         });
 
         expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain("Invalid exo__metadataType");
+        expect(result.errors[0]).toContain("Invalid metadata");
       });
 
       it("should fail when required properties are missing", () => {
         const result = Exo003Parser.validate({
-          exo__metadataType: Exo003MetadataType.Namespace,
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          // Missing exo__Asset_uid, exo__Namespace_prefix, exo__Namespace_uri
+          metadata: Exo003MetadataType.Namespace,
+          // Missing uri
         });
 
         expect(result.valid).toBe(false);
-        expect(result.errors).toContain("Missing required property: exo__Asset_uid");
-        expect(result.errors).toContain("Missing required property: exo__Namespace_prefix");
-        expect(result.errors).toContain("Missing required property: exo__Namespace_uri");
+        expect(result.errors).toContain("Missing required property: uri");
       });
 
       it("should fail when forbidden properties are present", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Namespace,
-          exo__Namespace_prefix: "exo",
-          exo__Namespace_uri: "https://exocortex.my/ontology/exo#",
+          metadata: Exo003MetadataType.Namespace,
+          uri: "https://exocortex.my/ontology/exo#",
           forbidden_property: "value", // Not allowed
         });
 
@@ -65,51 +54,30 @@ describe("Exo003Parser", () => {
     describe("namespace validation", () => {
       it("should pass for valid namespace metadata", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Namespace,
-          exo__Namespace_prefix: "exo",
-          exo__Namespace_uri: "https://exocortex.my/ontology/exo#",
+          metadata: Exo003MetadataType.Namespace,
+          uri: "https://exocortex.my/ontology/exo#",
         });
 
         expect(result.valid).toBe(true);
         expect(result.errors).toHaveLength(0);
       });
 
-      it("should fail for invalid namespace prefix", () => {
-        const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Namespace,
-          exo__Namespace_prefix: "123invalid", // Must start with letter
-          exo__Namespace_uri: "https://exocortex.my/ontology/exo#",
-        });
-
-        expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain("exo__Namespace_prefix must start with a letter");
-      });
-
       it("should fail for invalid namespace URI", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Namespace,
-          exo__Namespace_prefix: "exo",
-          exo__Namespace_uri: "not a valid uri",
+          metadata: Exo003MetadataType.Namespace,
+          uri: "not a valid uri",
         });
 
         expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain("exo__Namespace_uri is not a valid IRI");
+        expect(result.errors[0]).toContain("uri is not a valid IRI");
       });
     });
 
     describe("anchor validation", () => {
       it("should pass for valid anchor metadata", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Anchor,
-          exo__Anchor_localName: "Person",
+          metadata: Exo003MetadataType.Anchor,
+          localName: "Person",
         });
 
         expect(result.valid).toBe(true);
@@ -117,24 +85,20 @@ describe("Exo003Parser", () => {
 
       it("should fail for empty anchor local name", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Anchor,
-          exo__Anchor_localName: "   ",
+          metadata: Exo003MetadataType.Anchor,
+          localName: "   ",
         });
 
         expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain("exo__Anchor_localName cannot be empty");
+        expect(result.errors[0]).toContain("localName cannot be empty");
       });
     });
 
     describe("blank_node validation", () => {
       it("should pass for valid blank node metadata", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.BlankNode,
-          exo__BlankNode_id: "b1",
+          metadata: Exo003MetadataType.BlankNode,
+          id: "b1",
         });
 
         expect(result.valid).toBe(true);
@@ -142,26 +106,22 @@ describe("Exo003Parser", () => {
 
       it("should fail for empty blank node id", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.BlankNode,
-          exo__BlankNode_id: "",
+          metadata: Exo003MetadataType.BlankNode,
+          id: "",
         });
 
         expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain("exo__BlankNode_id cannot be empty");
+        expect(result.errors[0]).toContain("id cannot be empty");
       });
     });
 
     describe("statement validation", () => {
       it("should pass for valid statement metadata", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Statement,
-          exo__Statement_subject: "[[person-123]]",
-          exo__Statement_predicate: "[[rdf-type]]",
-          exo__Statement_object: "[[rdfs-class]]",
+          metadata: Exo003MetadataType.Statement,
+          subject: "[[person-123]]",
+          predicate: "[[rdf-type]]",
+          object: "[[rdfs-class]]",
         });
 
         expect(result.valid).toBe(true);
@@ -171,10 +131,10 @@ describe("Exo003Parser", () => {
     describe("body validation", () => {
       it("should pass for valid body metadata with language", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Body,
-          exo__Body_language: "en",
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[rdfs-label]]",
+          language: "en",
         });
 
         expect(result.valid).toBe(true);
@@ -182,10 +142,10 @@ describe("Exo003Parser", () => {
 
       it("should pass for valid body metadata with datatype", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Body,
-          exo__Body_datatype: "http://www.w3.org/2001/XMLSchema#integer",
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[xsd-integer-value]]",
+          datatype: "http://www.w3.org/2001/XMLSchema#integer",
         });
 
         expect(result.valid).toBe(true);
@@ -193,51 +153,51 @@ describe("Exo003Parser", () => {
 
       it("should fail when both language and datatype are specified", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Body,
-          exo__Body_language: "en",
-          exo__Body_datatype: "http://www.w3.org/2001/XMLSchema#string",
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[rdfs-label]]",
+          language: "en",
+          datatype: "http://www.w3.org/2001/XMLSchema#string",
         });
 
         expect(result.valid).toBe(false);
         expect(result.errors[0]).toContain(
-          "Body cannot have both exo__Body_datatype and exo__Body_language"
+          "Body cannot have both datatype and language"
         );
       });
 
       it("should fail when direction is specified without language", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Body,
-          exo__Body_direction: "rtl",
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[rdfs-label]]",
+          direction: "rtl",
         });
 
         expect(result.valid).toBe(false);
         expect(result.errors[0]).toContain(
-          "exo__Body_direction requires exo__Body_language to be set"
+          "direction requires language to be set"
         );
       });
 
       it("should fail for invalid direction value", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Body,
-          exo__Body_language: "ar",
-          exo__Body_direction: "invalid",
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[rdfs-label]]",
+          language: "ar",
+          direction: "invalid",
         });
 
         expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain('exo__Body_direction must be "ltr" or "rtl"');
+        expect(result.errors[0]).toContain('direction must be "ltr" or "rtl"');
       });
 
       it("should warn when no language or datatype is specified", () => {
         const result = Exo003Parser.validate({
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Body,
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[rdfs-label]]",
         });
 
         expect(result.valid).toBe(true);
@@ -251,80 +211,70 @@ describe("Exo003Parser", () => {
   describe("parse", () => {
     it("should parse valid namespace metadata", () => {
       const result = Exo003Parser.parse({
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Namespace,
-        exo__Namespace_prefix: "exo",
-        exo__Namespace_uri: "https://exocortex.my/ontology/exo#",
+        metadata: Exo003MetadataType.Namespace,
+        uri: "https://exocortex.my/ontology/exo#",
       });
 
       expect(result.success).toBe(true);
       expect(result.metadata).toBeDefined();
-      expect(result.metadata?.exo__metadataType).toBe(Exo003MetadataType.Namespace);
+      expect(result.metadata?.metadata).toBe(Exo003MetadataType.Namespace);
 
       const namespace = result.metadata as Exo003NamespaceMetadata;
-      expect(namespace.exo__Namespace_prefix).toBe("exo");
-      expect(namespace.exo__Namespace_uri).toBe("https://exocortex.my/ontology/exo#");
+      expect(namespace.uri).toBe("https://exocortex.my/ontology/exo#");
     });
 
     it("should parse valid anchor metadata", () => {
       const result = Exo003Parser.parse({
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Anchor,
-        exo__Anchor_localName: "Person",
-        exo__Asset_label: "Person Class",
+        metadata: Exo003MetadataType.Anchor,
+        localName: "Person",
+        label: "Person Class",
       });
 
       expect(result.success).toBe(true);
       expect(result.metadata).toBeDefined();
 
       const anchor = result.metadata as Exo003AnchorMetadata;
-      expect(anchor.exo__Anchor_localName).toBe("Person");
-      expect(anchor.exo__Asset_label).toBe("Person Class");
+      expect(anchor.localName).toBe("Person");
+      expect(anchor.label).toBe("Person Class");
     });
 
     it("should parse valid blank node metadata", () => {
       const result = Exo003Parser.parse({
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.BlankNode,
-        exo__BlankNode_id: "b1",
+        metadata: Exo003MetadataType.BlankNode,
+        id: "b1",
       });
 
       expect(result.success).toBe(true);
       expect(result.metadata).toBeDefined();
 
       const blankNode = result.metadata as Exo003BlankNodeMetadata;
-      expect(blankNode.exo__BlankNode_id).toBe("b1");
+      expect(blankNode.id).toBe("b1");
     });
 
     it("should parse valid statement metadata", () => {
       const result = Exo003Parser.parse({
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Statement,
-        exo__Statement_subject: "[[person-123]]",
-        exo__Statement_predicate: "[[rdf-type]]",
-        exo__Statement_object: "[[rdfs-class]]",
+        metadata: Exo003MetadataType.Statement,
+        subject: "[[person-123]]",
+        predicate: "[[rdf-type]]",
+        object: "[[rdfs-class]]",
       });
 
       expect(result.success).toBe(true);
       expect(result.metadata).toBeDefined();
 
       const statement = result.metadata as Exo003StatementMetadata;
-      expect(statement.exo__Statement_subject).toBe("[[person-123]]");
-      expect(statement.exo__Statement_predicate).toBe("[[rdf-type]]");
-      expect(statement.exo__Statement_object).toBe("[[rdfs-class]]");
+      expect(statement.subject).toBe("[[person-123]]");
+      expect(statement.predicate).toBe("[[rdf-type]]");
+      expect(statement.object).toBe("[[rdfs-class]]");
     });
 
     it("should parse valid body metadata and include body content", () => {
       const result = Exo003Parser.parse(
         {
-          exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-          exo__Asset_createdAt: "2025-01-04T12:00:00",
-          exo__metadataType: Exo003MetadataType.Body,
-          exo__Body_language: "en",
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[rdfs-label]]",
+          language: "en",
         },
         "Hello, World!"
       );
@@ -334,15 +284,13 @@ describe("Exo003Parser", () => {
       expect(result.bodyContent).toBe("Hello, World!");
 
       const body = result.metadata as Exo003BodyMetadata;
-      expect(body.exo__Body_language).toBe("en");
+      expect(body.language).toBe("en");
     });
 
     it("should return errors for invalid frontmatter", () => {
       const result = Exo003Parser.parse({
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Namespace,
-        // Missing required properties
+        metadata: Exo003MetadataType.Namespace,
+        // Missing required uri property
       });
 
       expect(result.success).toBe(false);
@@ -354,10 +302,10 @@ describe("Exo003Parser", () => {
   describe("toLiteral", () => {
     it("should create literal with specified language", () => {
       const metadata: Exo003BodyMetadata = {
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Body,
-        exo__Body_language: "en",
+        metadata: Exo003MetadataType.Body,
+        subject: "[[person-123]]",
+        predicate: "[[rdfs-label]]",
+        language: "en",
       };
 
       const literal = Exo003Parser.toLiteral(metadata, "Hello, World!");
@@ -369,9 +317,9 @@ describe("Exo003Parser", () => {
 
     it("should create literal with default language when not specified", () => {
       const metadata: Exo003BodyMetadata = {
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Body,
+        metadata: Exo003MetadataType.Body,
+        subject: "[[person-123]]",
+        predicate: "[[rdfs-label]]",
       };
 
       const literal = Exo003Parser.toLiteral(metadata, "Привет, мир!");
@@ -382,11 +330,11 @@ describe("Exo003Parser", () => {
 
     it("should create literal with direction", () => {
       const metadata: Exo003BodyMetadata = {
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Body,
-        exo__Body_language: "ar",
-        exo__Body_direction: "rtl",
+        metadata: Exo003MetadataType.Body,
+        subject: "[[person-123]]",
+        predicate: "[[rdfs-label]]",
+        language: "ar",
+        direction: "rtl",
       };
 
       const literal = Exo003Parser.toLiteral(metadata, "مرحبا");
@@ -398,10 +346,10 @@ describe("Exo003Parser", () => {
 
     it("should create typed literal with datatype", () => {
       const metadata: Exo003BodyMetadata = {
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Body,
-        exo__Body_datatype: "http://www.w3.org/2001/XMLSchema#integer",
+        metadata: Exo003MetadataType.Body,
+        subject: "[[person-123]]",
+        predicate: "[[age]]",
+        datatype: "http://www.w3.org/2001/XMLSchema#integer",
       };
 
       const literal = Exo003Parser.toLiteral(metadata, "42");
@@ -416,13 +364,13 @@ describe("Exo003Parser", () => {
     it("should return true for valid Exo 0.0.3 frontmatter", () => {
       expect(
         Exo003Parser.isExo003Format({
-          exo__metadataType: Exo003MetadataType.Namespace,
+          metadata: Exo003MetadataType.Namespace,
         })
       ).toBe(true);
 
       expect(
         Exo003Parser.isExo003Format({
-          exo__metadataType: Exo003MetadataType.Statement,
+          metadata: Exo003MetadataType.Statement,
         })
       ).toBe(true);
     });
@@ -436,7 +384,7 @@ describe("Exo003Parser", () => {
 
       expect(
         Exo003Parser.isExo003Format({
-          exo__metadataType: "unknown_type",
+          metadata: "unknown_type",
         })
       ).toBe(false);
 
@@ -447,12 +395,10 @@ describe("Exo003Parser", () => {
   describe("toTriple", () => {
     it("should convert statement metadata to Triple", () => {
       const metadata: Exo003StatementMetadata = {
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Statement,
-        exo__Statement_subject: "[[person-123]]",
-        exo__Statement_predicate: "[[rdf-type]]",
-        exo__Statement_object: "[[rdfs-class]]",
+        metadata: Exo003MetadataType.Statement,
+        subject: "[[person-123]]",
+        predicate: "[[rdf-type]]",
+        object: "[[rdfs-class]]",
       };
 
       const resolveReference = (ref: string) => {
@@ -475,12 +421,10 @@ describe("Exo003Parser", () => {
 
     it("should handle literal objects with body content", () => {
       const metadata: Exo003StatementMetadata = {
-        exo__Asset_uid: "550e8400-e29b-41d4-a716-446655440000",
-        exo__Asset_createdAt: "2025-01-04T12:00:00",
-        exo__metadataType: Exo003MetadataType.Statement,
-        exo__Statement_subject: "[[person-123]]",
-        exo__Statement_predicate: "[[rdfs-label]]",
-        exo__Statement_object: "[[label-body]]",
+        metadata: Exo003MetadataType.Statement,
+        subject: "[[person-123]]",
+        predicate: "[[rdfs-label]]",
+        object: "[[label-body]]",
       };
 
       const resolveReference = (ref: string) => {

--- a/packages/exocortex/tests/unit/domain/models/exo003/types.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/exo003/types.test.ts
@@ -31,46 +31,65 @@ describe("Exo003 Types", () => {
       expect(ALLOWED_PROPERTIES[Exo003MetadataType.Body]).toBeDefined();
     });
 
-    it("should include common base properties for all types", () => {
+    it("should include 'metadata' property for all types", () => {
       for (const type of Object.values(Exo003MetadataType)) {
         const props = ALLOWED_PROPERTIES[type];
-        expect(props).toContain("exo__Asset_uid");
-        expect(props).toContain("exo__Asset_createdAt");
-        expect(props).toContain("exo__metadataType");
+        expect(props).toContain("metadata");
+      }
+    });
+
+    it("should include aliases for types that support it", () => {
+      // All types support aliases per specification
+      for (const type of Object.values(Exo003MetadataType)) {
+        const props = ALLOWED_PROPERTIES[type];
+        expect(props).toContain("aliases");
       }
     });
 
     it("should include namespace-specific properties", () => {
       const props = ALLOWED_PROPERTIES[Exo003MetadataType.Namespace];
-      expect(props).toContain("exo__Namespace_prefix");
-      expect(props).toContain("exo__Namespace_uri");
+      expect(props).toContain("uri");
+      // prefix is no longer part of frontmatter per spec
+      expect(props).not.toContain("prefix");
     });
 
     it("should include anchor-specific properties", () => {
       const props = ALLOWED_PROPERTIES[Exo003MetadataType.Anchor];
-      expect(props).toContain("exo__Anchor_localName");
-      expect(props).toContain("exo__Asset_label");
+      expect(props).toContain("localName");
+      expect(props).toContain("label");
       expect(props).toContain("aliases");
     });
 
     it("should include blank_node-specific properties", () => {
       const props = ALLOWED_PROPERTIES[Exo003MetadataType.BlankNode];
-      expect(props).toContain("exo__BlankNode_id");
-      expect(props).toContain("exo__Asset_label");
+      expect(props).toContain("id");
+      expect(props).toContain("label");
     });
 
     it("should include statement-specific properties", () => {
       const props = ALLOWED_PROPERTIES[Exo003MetadataType.Statement];
-      expect(props).toContain("exo__Statement_subject");
-      expect(props).toContain("exo__Statement_predicate");
-      expect(props).toContain("exo__Statement_object");
+      expect(props).toContain("subject");
+      expect(props).toContain("predicate");
+      expect(props).toContain("object");
     });
 
     it("should include body-specific properties", () => {
       const props = ALLOWED_PROPERTIES[Exo003MetadataType.Body];
-      expect(props).toContain("exo__Body_datatype");
-      expect(props).toContain("exo__Body_language");
-      expect(props).toContain("exo__Body_direction");
+      expect(props).toContain("subject");
+      expect(props).toContain("predicate");
+      expect(props).toContain("datatype");
+      expect(props).toContain("language");
+      expect(props).toContain("direction");
+    });
+
+    it("should NOT include uid and createdAt (stored as statements, not frontmatter)", () => {
+      for (const type of Object.values(Exo003MetadataType)) {
+        const props = ALLOWED_PROPERTIES[type];
+        expect(props).not.toContain("uid");
+        expect(props).not.toContain("createdAt");
+        expect(props).not.toContain("exo__Asset_uid");
+        expect(props).not.toContain("exo__Asset_createdAt");
+      }
     });
   });
 
@@ -83,12 +102,10 @@ describe("Exo003 Types", () => {
       expect(REQUIRED_PROPERTIES[Exo003MetadataType.Body]).toBeDefined();
     });
 
-    it("should require common base properties for all types", () => {
+    it("should require 'metadata' property for all types", () => {
       for (const type of Object.values(Exo003MetadataType)) {
         const props = REQUIRED_PROPERTIES[type];
-        expect(props).toContain("exo__Asset_uid");
-        expect(props).toContain("exo__Asset_createdAt");
-        expect(props).toContain("exo__metadataType");
+        expect(props).toContain("metadata");
       }
     });
 
@@ -103,34 +120,39 @@ describe("Exo003 Types", () => {
       }
     });
 
-    it("should require namespace-specific properties", () => {
+    it("should require namespace uri", () => {
       const props = REQUIRED_PROPERTIES[Exo003MetadataType.Namespace];
-      expect(props).toContain("exo__Namespace_prefix");
-      expect(props).toContain("exo__Namespace_uri");
+      expect(props).toContain("uri");
     });
 
-    it("should require anchor local name", () => {
+    it("should require anchor localName", () => {
       const props = REQUIRED_PROPERTIES[Exo003MetadataType.Anchor];
-      expect(props).toContain("exo__Anchor_localName");
+      expect(props).toContain("localName");
     });
 
     it("should require blank node id", () => {
       const props = REQUIRED_PROPERTIES[Exo003MetadataType.BlankNode];
-      expect(props).toContain("exo__BlankNode_id");
+      expect(props).toContain("id");
     });
 
     it("should require all statement components", () => {
       const props = REQUIRED_PROPERTIES[Exo003MetadataType.Statement];
-      expect(props).toContain("exo__Statement_subject");
-      expect(props).toContain("exo__Statement_predicate");
-      expect(props).toContain("exo__Statement_object");
+      expect(props).toContain("subject");
+      expect(props).toContain("predicate");
+      expect(props).toContain("object");
+    });
+
+    it("should require body subject and predicate", () => {
+      const props = REQUIRED_PROPERTIES[Exo003MetadataType.Body];
+      expect(props).toContain("subject");
+      expect(props).toContain("predicate");
     });
 
     it("should not require body content metadata (optional)", () => {
       const props = REQUIRED_PROPERTIES[Exo003MetadataType.Body];
-      expect(props).not.toContain("exo__Body_datatype");
-      expect(props).not.toContain("exo__Body_language");
-      expect(props).not.toContain("exo__Body_direction");
+      expect(props).not.toContain("datatype");
+      expect(props).not.toContain("language");
+      expect(props).not.toContain("direction");
     });
   });
 


### PR DESCRIPTION
Closes #1353

## Summary

This PR aligns the Exo 0.0.3 file format implementation with the approved specification:

- **Minimal frontmatter property names**: Changed from verbose prefixed names (`exo__metadataType`, `exo__Namespace_uri`, `exo__Statement_subject`, etc.) to short names (`metadata`, `uri`, `subject`, `predicate`, `object`)
- **Removed uid/createdAt from frontmatter**: Per spec, these should be stored as RDF statements, not in frontmatter
- **Added subject/predicate to body metadata**: Per specification requirements
- **Fixed lint errors**: Template literal type issues in error messages

## Files Changed

- `packages/exocortex/src/domain/models/exo003/types.ts` - Updated interfaces and ALLOWED_PROPERTIES/REQUIRED_PROPERTIES
- `packages/exocortex/src/domain/models/exo003/Exo003Parser.ts` - Updated property references
- `packages/exocortex/tests/unit/domain/models/exo003/*.test.ts` - Updated tests

## Test Plan

- [x] All 83 exo003 unit tests pass
- [x] Build passes
- [ ] CI pipeline validates changes