### PR TITLE
fix(exo003): Strict frontmatter allowlist - anchor uses uri, body has no datatype/language

### DIFF
--- a/packages/exocortex/tests/unit/domain/models/exo003/Exo003Parser.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/exo003/Exo003Parser.test.ts
@@ -74,44 +74,66 @@ describe("Exo003Parser", () => {
     });
 
     describe("anchor validation", () => {
-      it("should pass for valid anchor metadata", () => {
+      it("should pass for valid anchor metadata with uri", () => {
         const result = Exo003Parser.validate({
           metadata: Exo003MetadataType.Anchor,
-          localName: "Person",
+          uri: "https://exocortex.my/kitelev/63967e73-2e3e-4394-8b26-86373b292cb5",
         });
 
         expect(result.valid).toBe(true);
       });
 
-      it("should fail for empty anchor local name", () => {
+      it("should fail for invalid anchor uri", () => {
         const result = Exo003Parser.validate({
           metadata: Exo003MetadataType.Anchor,
-          localName: "   ",
+          uri: "not a valid uri",
         });
 
         expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain("localName cannot be empty");
+        expect(result.errors[0]).toContain("uri is not a valid IRI");
+      });
+
+      it("should reject forbidden localName property", () => {
+        const result = Exo003Parser.validate({
+          metadata: Exo003MetadataType.Anchor,
+          uri: "https://exocortex.my/kitelev/test",
+          localName: "Person", // NOT allowed per spec
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Forbidden property for anchor: localName");
       });
     });
 
     describe("blank_node validation", () => {
-      it("should pass for valid blank node metadata", () => {
+      it("should pass for valid blank node metadata with uri", () => {
         const result = Exo003Parser.validate({
           metadata: Exo003MetadataType.BlankNode,
-          id: "b1",
+          uri: "https://exocortex.my/kitelev/_:bnode-abc123",
         });
 
         expect(result.valid).toBe(true);
       });
 
-      it("should fail for empty blank node id", () => {
+      it("should fail for invalid blank node uri", () => {
         const result = Exo003Parser.validate({
           metadata: Exo003MetadataType.BlankNode,
-          id: "",
+          uri: "not a valid uri",
         });
 
         expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain("id cannot be empty");
+        expect(result.errors[0]).toContain("uri is not a valid IRI");
+      });
+
+      it("should reject forbidden id property", () => {
+        const result = Exo003Parser.validate({
+          metadata: Exo003MetadataType.BlankNode,
+          uri: "https://exocortex.my/kitelev/_:bnode-test",
+          id: "b1", // NOT allowed per spec
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Forbidden property for blank_node: id");
       });
     });
 
@@ -129,81 +151,62 @@ describe("Exo003Parser", () => {
     });
 
     describe("body validation", () => {
-      it("should pass for valid body metadata with language", () => {
+      it("should pass for valid body metadata (minimal: subject, predicate)", () => {
         const result = Exo003Parser.validate({
           metadata: Exo003MetadataType.Body,
           subject: "[[person-123]]",
           predicate: "[[rdfs-label]]",
-          language: "en",
         });
 
         expect(result.valid).toBe(true);
       });
 
-      it("should pass for valid body metadata with datatype", () => {
+      it("should reject forbidden language property", () => {
+        const result = Exo003Parser.validate({
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[rdfs-label]]",
+          language: "en", // NOT allowed per spec
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Forbidden property for body: language");
+      });
+
+      it("should reject forbidden datatype property", () => {
         const result = Exo003Parser.validate({
           metadata: Exo003MetadataType.Body,
           subject: "[[person-123]]",
           predicate: "[[xsd-integer-value]]",
-          datatype: "http://www.w3.org/2001/XMLSchema#integer",
+          datatype: "http://www.w3.org/2001/XMLSchema#integer", // NOT allowed per spec
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Forbidden property for body: datatype");
+      });
+
+      it("should reject forbidden direction property", () => {
+        const result = Exo003Parser.validate({
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[rdfs-label]]",
+          direction: "rtl", // NOT allowed per spec
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Forbidden property for body: direction");
+      });
+
+      it("should pass with valid aliases", () => {
+        const result = Exo003Parser.validate({
+          metadata: Exo003MetadataType.Body,
+          subject: "[[person-123]]",
+          predicate: "[[rdfs-label]]",
+          aliases: ["kitelev:person-123 rdfs:label"],
         });
 
         expect(result.valid).toBe(true);
-      });
-
-      it("should fail when both language and datatype are specified", () => {
-        const result = Exo003Parser.validate({
-          metadata: Exo003MetadataType.Body,
-          subject: "[[person-123]]",
-          predicate: "[[rdfs-label]]",
-          language: "en",
-          datatype: "http://www.w3.org/2001/XMLSchema#string",
-        });
-
-        expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain(
-          "Body cannot have both datatype and language"
-        );
-      });
-
-      it("should fail when direction is specified without language", () => {
-        const result = Exo003Parser.validate({
-          metadata: Exo003MetadataType.Body,
-          subject: "[[person-123]]",
-          predicate: "[[rdfs-label]]",
-          direction: "rtl",
-        });
-
-        expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain(
-          "direction requires language to be set"
-        );
-      });
-
-      it("should fail for invalid direction value", () => {
-        const result = Exo003Parser.validate({
-          metadata: Exo003MetadataType.Body,
-          subject: "[[person-123]]",
-          predicate: "[[rdfs-label]]",
-          language: "ar",
-          direction: "invalid",
-        });
-
-        expect(result.valid).toBe(false);
-        expect(result.errors[0]).toContain('direction must be "ltr" or "rtl"');
-      });
-
-      it("should warn when no language or datatype is specified", () => {
-        const result = Exo003Parser.validate({
-          metadata: Exo003MetadataType.Body,
-          subject: "[[person-123]]",
-          predicate: "[[rdfs-label]]",
-        });
-
-        expect(result.valid).toBe(true);
-        expect(result.warnings).toContain(
-          `No language or datatype specified. Will use default language tag: @${DEFAULT_LANGUAGE_TAG}`
-        );
+        expect(result.warnings).toHaveLength(0);
       });
     });
   });
@@ -223,32 +226,32 @@ describe("Exo003Parser", () => {
       expect(namespace.uri).toBe("https://exocortex.my/ontology/exo#");
     });
 
-    it("should parse valid anchor metadata", () => {
+    it("should parse valid anchor metadata with uri", () => {
       const result = Exo003Parser.parse({
         metadata: Exo003MetadataType.Anchor,
-        localName: "Person",
-        label: "Person Class",
+        uri: "https://exocortex.my/kitelev/63967e73-2e3e-4394-8b26-86373b292cb5",
+        aliases: ["kitelev:63967e73-2e3e-4394-8b26-86373b292cb5"],
       });
 
       expect(result.success).toBe(true);
       expect(result.metadata).toBeDefined();
 
       const anchor = result.metadata as Exo003AnchorMetadata;
-      expect(anchor.localName).toBe("Person");
-      expect(anchor.label).toBe("Person Class");
+      expect(anchor.uri).toBe("https://exocortex.my/kitelev/63967e73-2e3e-4394-8b26-86373b292cb5");
+      expect(anchor.aliases).toEqual(["kitelev:63967e73-2e3e-4394-8b26-86373b292cb5"]);
     });
 
-    it("should parse valid blank node metadata", () => {
+    it("should parse valid blank node metadata with uri", () => {
       const result = Exo003Parser.parse({
         metadata: Exo003MetadataType.BlankNode,
-        id: "b1",
+        uri: "https://exocortex.my/kitelev/_:bnode-abc123",
       });
 
       expect(result.success).toBe(true);
       expect(result.metadata).toBeDefined();
 
       const blankNode = result.metadata as Exo003BlankNodeMetadata;
-      expect(blankNode.id).toBe("b1");
+      expect(blankNode.uri).toBe("https://exocortex.my/kitelev/_:bnode-abc123");
     });
 
     it("should parse valid statement metadata", () => {
@@ -274,7 +277,6 @@ describe("Exo003Parser", () => {
           metadata: Exo003MetadataType.Body,
           subject: "[[person-123]]",
           predicate: "[[rdfs-label]]",
-          language: "en",
         },
         "Hello, World!"
       );
@@ -284,7 +286,8 @@ describe("Exo003Parser", () => {
       expect(result.bodyContent).toBe("Hello, World!");
 
       const body = result.metadata as Exo003BodyMetadata;
-      expect(body.language).toBe("en");
+      expect(body.subject).toBe("[[person-123]]");
+      expect(body.predicate).toBe("[[rdfs-label]]");
     });
 
     it("should return errors for invalid frontmatter", () => {
@@ -300,22 +303,21 @@ describe("Exo003Parser", () => {
   });
 
   describe("toLiteral", () => {
-    it("should create literal with specified language", () => {
+    it("should create literal with language from TBox options", () => {
       const metadata: Exo003BodyMetadata = {
         metadata: Exo003MetadataType.Body,
         subject: "[[person-123]]",
         predicate: "[[rdfs-label]]",
-        language: "en",
       };
 
-      const literal = Exo003Parser.toLiteral(metadata, "Hello, World!");
+      const literal = Exo003Parser.toLiteral(metadata, "Hello, World!", { language: "en" });
 
       expect(literal.value).toBe("Hello, World!");
       expect(literal.language).toBe("en");
       expect(literal.datatype).toBeUndefined();
     });
 
-    it("should create literal with default language when not specified", () => {
+    it("should create literal with default language when no options specified", () => {
       const metadata: Exo003BodyMetadata = {
         metadata: Exo003MetadataType.Body,
         subject: "[[person-123]]",
@@ -328,31 +330,33 @@ describe("Exo003Parser", () => {
       expect(literal.language).toBe(DEFAULT_LANGUAGE_TAG);
     });
 
-    it("should create literal with direction", () => {
+    it("should create literal with direction from TBox options", () => {
       const metadata: Exo003BodyMetadata = {
         metadata: Exo003MetadataType.Body,
         subject: "[[person-123]]",
         predicate: "[[rdfs-label]]",
-        language: "ar",
-        direction: "rtl",
       };
 
-      const literal = Exo003Parser.toLiteral(metadata, "مرحبا");
+      const literal = Exo003Parser.toLiteral(metadata, "مرحبا", {
+        language: "ar",
+        direction: "rtl",
+      });
 
       expect(literal.value).toBe("مرحبا");
       expect(literal.language).toBe("ar");
       expect(literal.direction).toBe("rtl");
     });
 
-    it("should create typed literal with datatype", () => {
+    it("should create typed literal with datatype from TBox options", () => {
       const metadata: Exo003BodyMetadata = {
         metadata: Exo003MetadataType.Body,
         subject: "[[person-123]]",
         predicate: "[[age]]",
-        datatype: "http://www.w3.org/2001/XMLSchema#integer",
       };
 
-      const literal = Exo003Parser.toLiteral(metadata, "42");
+      const literal = Exo003Parser.toLiteral(metadata, "42", {
+        datatype: "http://www.w3.org/2001/XMLSchema#integer",
+      });
 
       expect(literal.value).toBe("42");
       expect(literal.datatype?.value).toBe("http://www.w3.org/2001/XMLSchema#integer");

--- a/packages/exocortex/tests/unit/domain/models/exo003/types.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/exo003/types.test.ts
@@ -53,17 +53,22 @@ describe("Exo003 Types", () => {
       expect(props).not.toContain("prefix");
     });
 
-    it("should include anchor-specific properties", () => {
+    it("should include anchor-specific properties (strict spec: only uri)", () => {
       const props = ALLOWED_PROPERTIES[Exo003MetadataType.Anchor];
-      expect(props).toContain("localName");
-      expect(props).toContain("label");
+      expect(props).toContain("uri");
       expect(props).toContain("aliases");
+      // localName and label are NOT allowed per spec
+      expect(props).not.toContain("localName");
+      expect(props).not.toContain("label");
     });
 
-    it("should include blank_node-specific properties", () => {
+    it("should include blank_node-specific properties (strict spec: only uri)", () => {
       const props = ALLOWED_PROPERTIES[Exo003MetadataType.BlankNode];
-      expect(props).toContain("id");
-      expect(props).toContain("label");
+      expect(props).toContain("uri");
+      expect(props).toContain("aliases");
+      // id and label are NOT allowed per spec
+      expect(props).not.toContain("id");
+      expect(props).not.toContain("label");
     });
 
     it("should include statement-specific properties", () => {
@@ -73,13 +78,15 @@ describe("Exo003 Types", () => {
       expect(props).toContain("object");
     });
 
-    it("should include body-specific properties", () => {
+    it("should include body-specific properties (strict spec: no datatype/language/direction)", () => {
       const props = ALLOWED_PROPERTIES[Exo003MetadataType.Body];
       expect(props).toContain("subject");
       expect(props).toContain("predicate");
-      expect(props).toContain("datatype");
-      expect(props).toContain("language");
-      expect(props).toContain("direction");
+      expect(props).toContain("aliases");
+      // datatype, language, direction are NOT allowed per spec
+      expect(props).not.toContain("datatype");
+      expect(props).not.toContain("language");
+      expect(props).not.toContain("direction");
     });
 
     it("should NOT include uid and createdAt (stored as statements, not frontmatter)", () => {
@@ -125,14 +132,18 @@ describe("Exo003 Types", () => {
       expect(props).toContain("uri");
     });
 
-    it("should require anchor localName", () => {
+    it("should require anchor uri (strict spec)", () => {
       const props = REQUIRED_PROPERTIES[Exo003MetadataType.Anchor];
-      expect(props).toContain("localName");
+      expect(props).toContain("uri");
+      // localName is NOT required/allowed per spec
+      expect(props).not.toContain("localName");
     });
 
-    it("should require blank node id", () => {
+    it("should require blank node uri (strict spec)", () => {
       const props = REQUIRED_PROPERTIES[Exo003MetadataType.BlankNode];
-      expect(props).toContain("id");
+      expect(props).toContain("uri");
+      // id is NOT required/allowed per spec
+      expect(props).not.toContain("id");
     });
 
     it("should require all statement components", () => {
@@ -148,11 +159,13 @@ describe("Exo003 Types", () => {
       expect(props).toContain("predicate");
     });
 
-    it("should not require body content metadata (optional)", () => {
-      const props = REQUIRED_PROPERTIES[Exo003MetadataType.Body];
-      expect(props).not.toContain("datatype");
-      expect(props).not.toContain("language");
-      expect(props).not.toContain("direction");
+    it("should not have body content metadata (strict spec: no datatype/language/direction)", () => {
+      // Per spec, body does NOT have datatype/language/direction in frontmatter
+      // These are derived from TBox
+      const allowed = ALLOWED_PROPERTIES[Exo003MetadataType.Body];
+      expect(allowed).not.toContain("datatype");
+      expect(allowed).not.toContain("language");
+      expect(allowed).not.toContain("direction");
     });
   });
 


### PR DESCRIPTION
## Summary

Implement strict frontmatter allowlist per Exo 0.0.3 specification from vault-2025:

- **Anchor**: uses `uri` property instead of deprecated `localName`/`label`
- **BlankNode**: uses `uri` property instead of deprecated `id`/`label`
- **Body**: removed `datatype`, `language`, `direction` from frontmatter (derived from TBox via `rdfs:range`)

## Allowed Frontmatter Properties

| Type | Allowed Properties |
|------|-------------------|
| namespace | `metadata`, `uri`, `aliases` |
| anchor | `metadata`, `uri`, `aliases` |
| blank_node | `metadata`, `uri`, `aliases` |
| statement | `metadata`, `subject`, `predicate`, `object`, `aliases` |
| body | `metadata`, `subject`, `predicate`, `aliases` |

## Changes

- Updated `types.ts`:
  - `Exo003AnchorMetadata`: replaced `localName`/`label` with `uri`
  - `Exo003BlankNodeMetadata`: replaced `id`/`label` with `uri`
  - `Exo003BodyMetadata`: removed `datatype`/`language`/`direction`
  - Updated `ALLOWED_PROPERTIES` and `REQUIRED_PROPERTIES` constants

- Updated `Exo003Parser.ts`:
  - Updated validators for anchor, blank_node, body types
  - `toLiteral()` now takes TBox options parameter for language/datatype

- Updated tests to verify strict allowlist enforcement

## Test Plan

- [ ] Build passes
- [ ] Unit tests for types.test.ts pass
- [ ] Unit tests for Exo003Parser.test.ts pass
- [ ] CI pipeline passes

Closes #1361