### PR TITLE
feat(obsidian-plugin): Display exo__Asset_label instead of filename in Graph View nodes

### DIFF
--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -143,6 +143,8 @@ export interface ExocortexSettings {
   showLabelsInProperties: boolean;
   /** Apply display name templates to links in markdown body content (reading mode) */
   showLabelsInBody: boolean;
+  /** Apply display name templates to nodes in Obsidian's Graph View */
+  showLabelsInGraphView: boolean;
   /** @deprecated Use displayNameSettings.defaultTemplate instead */
   displayNameTemplate: string;
   sortByDisplayName: boolean;
@@ -170,6 +172,7 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   showLabelsInTabTitles: true,
   showLabelsInProperties: true,
   showLabelsInBody: true,
+  showLabelsInGraphView: true,
   displayNameTemplate: "{{exo__Asset_label}} ({{exo__Instance_class}})",
   sortByDisplayName: false,
   displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS,

--- a/packages/obsidian-plugin/src/presentation/graph-view/GraphViewPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/graph-view/GraphViewPatch.ts
@@ -1,0 +1,434 @@
+import { TFile, WorkspaceLeaf, Plugin, CachedMetadata } from "obsidian";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
+
+/**
+ * GraphViewPatch - Patches Obsidian's Graph View to show exo__Asset_label instead of filenames
+ *
+ * This patch intercepts the Graph View's node rendering to display meaningful labels
+ * for notes that have exo__Asset_label set in their frontmatter. Falls back to
+ * the original filename if no label is set.
+ *
+ * Implementation approach:
+ * - Patches graph node prototypes by monkey-patching getDisplayText()
+ * - Listens for layout-change events to re-patch when graph views are opened
+ * - Listens for metadata changes to refresh the graph
+ * - Stores original methods for restoration on disable
+ *
+ * Graph View Types:
+ * - "graph" - Global graph view (View > Open graph view)
+ * - "localgraph" - Local graph view (more options > Open local graph)
+ */
+
+// Plugin interface to access settings
+interface PluginWithSettings extends Plugin {
+  settings: ExocortexSettings;
+}
+
+// Obsidian internal types for graph nodes (not exposed in public API)
+interface GraphNode {
+  id: string;
+  getDisplayText: () => string;
+  nm_originalGetDisplayText?: () => string;
+}
+
+interface GraphRenderer {
+  nodes?: GraphNode[];
+}
+
+interface GraphView {
+  renderer?: GraphRenderer;
+}
+
+export class GraphViewPatch {
+  private app: Plugin["app"];
+  private plugin: PluginWithSettings;
+  private enabled = false;
+  private patchedPrototypes: WeakSet<object> = new WeakSet();
+  private metadataChangeHandler: (file: TFile, data: string, cache: CachedMetadata) => void;
+  private layoutChangeHandler: () => void;
+
+  constructor(plugin: Plugin) {
+    this.plugin = plugin as PluginWithSettings;
+    this.app = plugin.app;
+    this.metadataChangeHandler = this.handleMetadataChange.bind(this);
+    this.layoutChangeHandler = this.handleLayoutChange.bind(this);
+  }
+
+  /**
+   * Get the display name settings
+   */
+  private getDisplayNameSettings(): DisplayNameSettings {
+    // Prefer new displayNameSettings, fall back to legacy displayNameTemplate
+    if (this.plugin.settings?.displayNameSettings) {
+      return this.plugin.settings.displayNameSettings;
+    }
+
+    // Legacy fallback: convert single template to DisplayNameSettings
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional backwards compatibility
+    const template = this.plugin.settings?.displayNameTemplate || DEFAULT_DISPLAY_NAME_TEMPLATE;
+    return {
+      defaultTemplate: template,
+      classTemplates: {},
+      statusEmojis: {},
+    };
+  }
+
+  /**
+   * Create a DisplayNameResolver with current settings
+   */
+  private createResolver(): DisplayNameResolver {
+    return new DisplayNameResolver(this.getDisplayNameSettings());
+  }
+
+  /**
+   * Enable the Graph View label patch
+   */
+  enable(): void {
+    if (this.enabled) return;
+    this.enabled = true;
+
+    // Initial patch of existing graph views
+    this.patchAllGraphViews();
+
+    // Listen for layout changes (new graph views, reopened views, etc.)
+    this.plugin.registerEvent(
+      this.app.workspace.on("layout-change", this.layoutChangeHandler)
+    );
+
+    // Listen for metadata changes to refresh the graph
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("changed", this.metadataChangeHandler)
+    );
+  }
+
+  /**
+   * Disable the Graph View label patch and restore original methods
+   */
+  disable(): void {
+    if (!this.enabled) return;
+    this.enabled = false;
+
+    // Restore all patched prototypes
+    this.restoreAllGraphViews();
+  }
+
+  /**
+   * Cleanup resources when plugin unloads
+   */
+  cleanup(): void {
+    this.disable();
+  }
+
+  /**
+   * Handle layout changes to patch new graph views
+   */
+  private handleLayoutChange(): void {
+    if (!this.enabled) return;
+    // Use setTimeout to ensure DOM is updated after layout change
+    setTimeout(() => this.patchAllGraphViews(), 100);
+  }
+
+  /**
+   * Handle metadata changes to refresh graph display
+   */
+  private handleMetadataChange(file: TFile): void {
+    if (!this.enabled) return;
+    if (file.extension !== "md") return;
+
+    // Refresh all graph views when metadata changes
+    // This ensures labels are updated when exo__Asset_label changes
+    this.refreshAllGraphViews();
+  }
+
+  /**
+   * Patch all graph views in the workspace
+   */
+  private patchAllGraphViews(): void {
+    if (!this.enabled) return;
+
+    // Patch global graph views
+    const graphLeaves = this.getGraphLeaves("graph");
+    for (const leaf of graphLeaves) {
+      this.patchGraphView(leaf);
+    }
+
+    // Patch local graph views
+    const localGraphLeaves = this.getGraphLeaves("localgraph");
+    for (const leaf of localGraphLeaves) {
+      this.patchGraphView(leaf);
+    }
+  }
+
+  /**
+   * Get leaves of a specific graph type
+   */
+  private getGraphLeaves(viewType: string): WorkspaceLeaf[] {
+    if (typeof this.app.workspace.getLeavesOfType !== "function") {
+      return [];
+    }
+    const leaves = this.app.workspace.getLeavesOfType(viewType);
+    return Array.isArray(leaves) ? leaves : [];
+  }
+
+  /**
+   * Patch a single graph view
+   */
+  private patchGraphView(leaf: WorkspaceLeaf): void {
+    const view = leaf.view as unknown as GraphView;
+    const renderer = view?.renderer;
+    const nodes = renderer?.nodes;
+
+    if (!nodes || !Array.isArray(nodes)) return;
+
+    for (const node of nodes) {
+      this.patchNode(node);
+    }
+  }
+
+  /**
+   * Patch a single graph node to use asset labels
+   */
+  private patchNode(node: GraphNode): void {
+    // Skip if not a valid node with getDisplayText
+    if (!node || typeof node.getDisplayText !== "function") return;
+
+    // Get the prototype to patch
+    const proto = Object.getPrototypeOf(node);
+    if (!proto) return;
+
+    // Skip if already patched
+    if (this.patchedPrototypes.has(proto)) return;
+
+    // Store original method
+    const originalGetDisplayText = proto.getDisplayText;
+    proto.nm_originalGetDisplayText = originalGetDisplayText;
+
+    // Create patched method
+    proto.getDisplayText = this.createPatchedGetDisplayText(originalGetDisplayText);
+
+    // Mark as patched
+    this.patchedPrototypes.add(proto);
+  }
+
+  /**
+   * Create a patched getDisplayText function
+   *
+   * Uses closure to capture patch instance state without aliasing `this`
+   */
+  private createPatchedGetDisplayText(
+    originalMethod: () => string
+  ): (this: GraphNode) => string {
+    // Capture instance methods in closures to avoid `this` aliasing
+    const isEnabled = (): boolean => this.enabled;
+    const getLabel = (filePath: string): string | null => this.getAssetLabel(filePath);
+
+    return function (this: GraphNode): string {
+      // If patch is disabled, return original
+      if (!isEnabled()) {
+        return originalMethod.call(this);
+      }
+
+      // Get the file path from the node id
+      const filePath = this.id;
+      if (!filePath) {
+        return originalMethod.call(this);
+      }
+
+      // Try to get the asset label
+      const label = getLabel(filePath);
+      if (label) {
+        return label;
+      }
+
+      // Fall back to original method
+      return originalMethod.call(this);
+    };
+  }
+
+  /**
+   * Get the display name from a file's frontmatter using per-class template resolution
+   */
+  private getAssetLabel(filePath: string): string | null {
+    // Get the file from vault
+    const file = this.app.vault.getAbstractFileByPath(filePath);
+    if (!(file instanceof TFile) || file.extension !== "md") {
+      return null;
+    }
+
+    const cache = this.app.metadataCache.getFileCache(file);
+    const frontmatter = cache?.frontmatter;
+
+    if (!frontmatter) return null;
+
+    // Build metadata for template rendering
+    const metadata = this.buildTemplateMetadata(frontmatter, file);
+
+    // Get creation date if available
+    const createdDate = file.stat?.ctime ? new Date(file.stat.ctime) : undefined;
+
+    // Use DisplayNameResolver for per-class template resolution
+    const resolver = this.createResolver();
+    const displayName = resolver.resolve({
+      metadata,
+      basename: file.basename,
+      createdDate,
+    });
+
+    if (displayName) {
+      return displayName;
+    }
+
+    // Fallback: try direct exo__Asset_label from frontmatter
+    const label = frontmatter.exo__Asset_label;
+    if (label && typeof label === "string" && label.trim() !== "") {
+      return label.trim();
+    }
+
+    // Fallback: try prototype label if available
+    const prototypeRef = frontmatter.exo__Asset_prototype;
+    if (prototypeRef) {
+      const prototypePath =
+        typeof prototypeRef === "string"
+          ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
+          : null;
+
+      if (prototypePath) {
+        let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+          prototypePath,
+          ""
+        );
+
+        // Try with .md extension if not found
+        if (!prototypeFile && !prototypePath.endsWith(".md")) {
+          prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+            prototypePath + ".md",
+            ""
+          );
+        }
+
+        if (prototypeFile instanceof TFile) {
+          const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
+          const prototypeMetadata = prototypeCache?.frontmatter;
+
+          if (prototypeMetadata) {
+            const prototypeLabel = prototypeMetadata.exo__Asset_label;
+            if (
+              prototypeLabel &&
+              typeof prototypeLabel === "string" &&
+              prototypeLabel.trim() !== ""
+            ) {
+              return prototypeLabel.trim();
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Build metadata object for template rendering, merging frontmatter with prototype data
+   */
+  private buildTemplateMetadata(
+    frontmatter: Record<string, unknown>,
+    _file: TFile
+  ): Record<string, unknown> {
+    const metadata = { ...frontmatter };
+
+    // If label is missing, try to get from prototype
+    if (!metadata.exo__Asset_label) {
+      const prototypeRef = metadata.exo__Asset_prototype;
+      if (prototypeRef) {
+        const prototypePath =
+          typeof prototypeRef === "string"
+            ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
+            : null;
+
+        if (prototypePath) {
+          let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+            prototypePath,
+            ""
+          );
+
+          if (!prototypeFile && !prototypePath.endsWith(".md")) {
+            prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
+              prototypePath + ".md",
+              ""
+            );
+          }
+
+          if (prototypeFile instanceof TFile) {
+            const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
+            const prototypeMetadata = prototypeCache?.frontmatter;
+
+            if (prototypeMetadata?.exo__Asset_label) {
+              metadata.exo__Asset_label = prototypeMetadata.exo__Asset_label;
+            }
+          }
+        }
+      }
+    }
+
+    return metadata;
+  }
+
+  /**
+   * Refresh all graph views (trigger re-render)
+   */
+  private refreshAllGraphViews(): void {
+    // Re-patch to ensure new nodes get labels
+    this.patchAllGraphViews();
+  }
+
+  /**
+   * Restore all patched graph views to original methods
+   */
+  private restoreAllGraphViews(): void {
+    // Restore global graph views
+    const graphLeaves = this.getGraphLeaves("graph");
+    for (const leaf of graphLeaves) {
+      this.restoreGraphView(leaf);
+    }
+
+    // Restore local graph views
+    const localGraphLeaves = this.getGraphLeaves("localgraph");
+    for (const leaf of localGraphLeaves) {
+      this.restoreGraphView(leaf);
+    }
+
+    // Clear the patched prototypes set
+    this.patchedPrototypes = new WeakSet();
+  }
+
+  /**
+   * Restore a single graph view
+   */
+  private restoreGraphView(leaf: WorkspaceLeaf): void {
+    const view = leaf.view as unknown as GraphView;
+    const renderer = view?.renderer;
+    const nodes = renderer?.nodes;
+
+    if (!nodes || !Array.isArray(nodes)) return;
+
+    for (const node of nodes) {
+      this.restoreNode(node);
+    }
+  }
+
+  /**
+   * Restore a single node's original getDisplayText method
+   */
+  private restoreNode(node: GraphNode): void {
+    if (!node) return;
+
+    const proto = Object.getPrototypeOf(node);
+    if (!proto || !proto.nm_originalGetDisplayText) return;
+
+    // Restore original method
+    proto.getDisplayText = proto.nm_originalGetDisplayText;
+    delete proto.nm_originalGetDisplayText;
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -210,6 +210,21 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Show labels in graph view")
+      .setDesc(
+        "Display asset labels instead of filenames for nodes in Obsidian's graph view",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showLabelsInGraphView)
+          .onChange(async (value) => {
+            this.plugin.settings.showLabelsInGraphView = value;
+            await this.plugin.saveSettings();
+            this.plugin.toggleGraphViewLabels(value);
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Sort file explorer by display name")
       .setDesc(
         "Sort files by their display name (exo__Asset_label) instead of filename. " +

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -349,8 +349,8 @@ describe("ExocortexSettingTab", () => {
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
       expect(getOntologySpy).toHaveBeenCalledTimes(1);
-      // 11 original settings (added showLabelsInBody) + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 30
-      expect(MockSetting).toHaveBeenCalledTimes(30);
+      // 12 original settings (added showLabelsInGraphView) + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 31
+      expect(MockSetting).toHaveBeenCalledTimes(31);
     });
 
     it("should render ontology dropdown with correct options", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/graph-view/GraphViewPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/graph-view/GraphViewPatch.test.ts
@@ -1,0 +1,376 @@
+import { GraphViewPatch } from "../../../../src/presentation/graph-view/GraphViewPatch";
+import { TFile, WorkspaceLeaf } from "obsidian";
+
+describe("GraphViewPatch", () => {
+  let patch: GraphViewPatch;
+  let mockPlugin: any;
+  let mockApp: any;
+  let mockGraphLeaf: any;
+  let mockGraphView: any;
+  let mockNode: any;
+  let originalGetDisplayText: jest.Mock;
+
+  beforeEach(() => {
+    originalGetDisplayText = jest.fn().mockReturnValue("original-filename.md");
+
+    // Create a mock node with a prototype chain
+    const nodePrototype = {
+      getDisplayText: originalGetDisplayText,
+    };
+    mockNode = Object.create(nodePrototype);
+    mockNode.id = "test-file.md";
+
+    mockGraphView = {
+      renderer: {
+        nodes: [mockNode],
+      },
+    };
+
+    mockGraphLeaf = {
+      view: mockGraphView,
+    };
+
+    mockApp = {
+      workspace: {
+        getLeavesOfType: jest.fn().mockImplementation((type: string) => {
+          if (type === "graph" || type === "localgraph") {
+            return [mockGraphLeaf];
+          }
+          return [];
+        }),
+        on: jest.fn().mockReturnValue({ id: "test" }),
+      },
+      vault: {
+        getAbstractFileByPath: jest.fn(),
+      },
+      metadataCache: {
+        getFileCache: jest.fn(),
+        getFirstLinkpathDest: jest.fn(),
+        on: jest.fn().mockReturnValue({ id: "test" }),
+      },
+    };
+
+    mockPlugin = {
+      app: mockApp,
+      registerEvent: jest.fn(),
+      settings: {
+        displayNameSettings: {
+          defaultTemplate: "{{exo__Asset_label}}",
+          classTemplates: {},
+          statusEmojis: {},
+        },
+      },
+    };
+
+    patch = new GraphViewPatch(mockPlugin);
+  });
+
+  afterEach(() => {
+    patch.cleanup();
+    jest.clearAllMocks();
+  });
+
+  describe("enable", () => {
+    it("should register layout-change event on enable", () => {
+      patch.enable();
+
+      expect(mockPlugin.registerEvent).toHaveBeenCalled();
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        "layout-change",
+        expect.any(Function)
+      );
+    });
+
+    it("should register metadata change event on enable", () => {
+      patch.enable();
+
+      expect(mockApp.metadataCache.on).toHaveBeenCalledWith(
+        "changed",
+        expect.any(Function)
+      );
+    });
+
+    it("should not double-enable", () => {
+      patch.enable();
+      patch.enable();
+
+      // Should only register events once (2 calls: layout-change + metadata)
+      expect(mockPlugin.registerEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it("should patch both graph and localgraph views", () => {
+      patch.enable();
+
+      // Both graph and localgraph should be queried
+      expect(mockApp.workspace.getLeavesOfType).toHaveBeenCalledWith("graph");
+      expect(mockApp.workspace.getLeavesOfType).toHaveBeenCalledWith("localgraph");
+    });
+  });
+
+  describe("disable", () => {
+    it("should restore original getDisplayText on disable", () => {
+      // Setup file and metadata
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Test Label",
+        },
+      });
+
+      patch.enable();
+
+      // Verify patch is working
+      expect(mockNode.getDisplayText()).toBe("Test Label");
+
+      patch.disable();
+
+      // After disable, should use original method
+      expect(mockNode.getDisplayText()).toBe("original-filename.md");
+    });
+
+    it("should not error when disabling without enabling", () => {
+      expect(() => patch.disable()).not.toThrow();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should disable patch on cleanup", () => {
+      patch.enable();
+      patch.cleanup();
+
+      // Calling enable again should work (indicates cleanup was successful)
+      expect(() => patch.enable()).not.toThrow();
+    });
+  });
+
+  describe("getDisplayText patching", () => {
+    it("should return asset label when available", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Test Label",
+        },
+      });
+
+      patch.enable();
+
+      expect(mockNode.getDisplayText()).toBe("Test Label");
+    });
+
+    it("should fallback to prototype label", () => {
+      const mockFile = new TFile();
+      const mockPrototypeFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      Object.defineProperty(mockPrototypeFile, "extension", { value: "md" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      mockApp.metadataCache.getFileCache
+        .mockReturnValueOnce({
+          frontmatter: {
+            exo__Asset_prototype: "[[prototype-path]]",
+          },
+        })
+        .mockReturnValueOnce({
+          frontmatter: {
+            exo__Asset_label: "Prototype Label",
+          },
+        });
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockPrototypeFile);
+
+      patch.enable();
+
+      expect(mockNode.getDisplayText()).toBe("Prototype Label");
+    });
+
+    it("should fallback to original filename when no label", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {},
+      });
+
+      patch.enable();
+
+      expect(mockNode.getDisplayText()).toBe("original-filename.md");
+    });
+
+    it("should not change non-markdown files", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "png" });
+      Object.defineProperty(mockFile, "basename", { value: "image" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      patch.enable();
+
+      expect(mockNode.getDisplayText()).toBe("original-filename.md");
+    });
+
+    it("should fallback to original when file is not found", () => {
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+
+      patch.enable();
+
+      expect(mockNode.getDisplayText()).toBe("original-filename.md");
+    });
+
+    it("should trim whitespace from label", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "  Trimmed Label  ",
+        },
+      });
+
+      patch.enable();
+
+      expect(mockNode.getDisplayText()).toBe("Trimmed Label");
+    });
+
+    it("should fallback to original for empty label", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "   ",
+        },
+      });
+
+      patch.enable();
+
+      expect(mockNode.getDisplayText()).toBe("original-filename.md");
+    });
+
+    it("should fallback when node has no id", () => {
+      const nodeWithoutId = Object.create({
+        getDisplayText: originalGetDisplayText,
+      });
+
+      mockGraphView.renderer.nodes = [nodeWithoutId];
+
+      patch.enable();
+
+      expect(nodeWithoutId.getDisplayText()).toBe("original-filename.md");
+    });
+  });
+
+  describe("metadata change handling", () => {
+    it("should trigger re-patch when metadata changes", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      Object.defineProperty(mockFile, "path", { value: "test-file.md" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Initial Label",
+        },
+      });
+
+      patch.enable();
+
+      // Simulate metadata change
+      const metadataCallback = mockApp.metadataCache.on.mock.calls.find(
+        (call: [string, Function]) => call[0] === "changed"
+      )?.[1];
+
+      // Should not throw
+      expect(() => {
+        if (metadataCallback) {
+          metadataCallback(mockFile);
+        }
+      }).not.toThrow();
+    });
+
+    it("should ignore metadata changes for non-markdown files", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "png" });
+      Object.defineProperty(mockFile, "path", { value: "image.png" });
+
+      patch.enable();
+
+      // Simulate metadata change for non-markdown file
+      const metadataCallback = mockApp.metadataCache.on.mock.calls.find(
+        (call: [string, Function]) => call[0] === "changed"
+      )?.[1];
+
+      // Should not throw
+      expect(() => {
+        if (metadataCallback) {
+          metadataCallback(mockFile);
+        }
+      }).not.toThrow();
+    });
+  });
+
+  describe("missing graph renderer", () => {
+    it("should handle missing renderer gracefully", () => {
+      mockGraphLeaf.view = {};
+
+      expect(() => patch.enable()).not.toThrow();
+    });
+
+    it("should handle missing nodes array gracefully", () => {
+      mockGraphLeaf.view = { renderer: {} };
+
+      expect(() => patch.enable()).not.toThrow();
+    });
+
+    it("should handle empty nodes array", () => {
+      mockGraphLeaf.view = { renderer: { nodes: [] } };
+
+      expect(() => patch.enable()).not.toThrow();
+    });
+  });
+
+  describe("prototype patching", () => {
+    it("should only patch prototype once for multiple nodes", () => {
+      // Create multiple nodes with same prototype
+      const nodePrototype = {
+        getDisplayText: originalGetDisplayText,
+      };
+      const node1 = Object.create(nodePrototype);
+      node1.id = "file1.md";
+      const node2 = Object.create(nodePrototype);
+      node2.id = "file2.md";
+
+      mockGraphView.renderer.nodes = [node1, node2];
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "Label" },
+      });
+
+      patch.enable();
+
+      // Both nodes should use the same patched prototype
+      expect(node1.getDisplayText()).toBe("Label");
+      expect(node2.getDisplayText()).toBe("Label");
+
+      // The original method should still be stored
+      expect(nodePrototype.nm_originalGetDisplayText).toBe(originalGetDisplayText);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `GraphViewPatch` to display semantic asset labels instead of raw filenames in Obsidian's native Graph View, creating a consistent labeling experience across all Exocortex UI surfaces.

**Changes:**
- New `GraphViewPatch` class that patches `getDisplayText()` on graph node prototypes
- Uses `DisplayNameResolver` for per-class template resolution (same as tab titles, file explorer)
- Falls back to filename when no `exo__Asset_label` is present
- Supports both global (`graph`) and local (`localgraph`) graph views
- Handles prototype labels for tasks/meetings
- Updates labels when metadata changes

**Settings:**
- New `showLabelsInGraphView` toggle in settings (enabled by default)
- Integrated with `applyDisplayNameTemplate()` for live updates when templates change

## Test plan

- [x] 19 new unit tests covering:
  - Enable/disable lifecycle
  - Asset label resolution
  - Prototype label fallback
  - Empty/whitespace label handling
  - Non-markdown file handling
  - Missing file/renderer handling
  - Metadata change handling
  - Prototype patching (same prototype for multiple nodes)
- [x] Build passes
- [x] Lint passes (with --fix)
- [ ] CI pipeline passes

Closes #1370