### PR TITLE
fix: CLI SPARQL: Statement files still not indexed - regression from #1377

### DIFF
--- a/packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts
+++ b/packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts
@@ -143,4 +143,153 @@ describe("FileSystemVaultAdapter", () => {
       expect(files[0].path).toBe("03 Knowledge/kitelev/personal.md");
     });
   });
+
+  describe("getFirstLinkpathDest() vault-wide search", () => {
+    /**
+     * Issue #1380: Statement files in Exo 0.0.3 format use wikilinks like [[UUID|alias]]
+     * where the UUID file may be in a different directory than the source file.
+     *
+     * Example: A statement file in exo/ references [[uuid|rdfs:subPropertyOf]]
+     * where the anchor file is in rdfs/ directory.
+     *
+     * The adapter should search the entire vault for matching basenames when
+     * relative resolution fails.
+     */
+
+    it("should resolve wikilink in same directory (strategy 1)", () => {
+      // Setup: source file and target file in same directory
+      existsSyncSpy.mockImplementation((filepath: string) => {
+        // Relative resolution should find the file
+        return filepath === "/test/vault/exo/target-uuid.md";
+      });
+
+      const result = adapter.getFirstLinkpathDest(
+        "target-uuid",
+        "exo/source-file.md"
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.path).toBe("exo/target-uuid.md");
+    });
+
+    it("should resolve wikilink from vault root (strategy 2)", () => {
+      existsSyncSpy.mockImplementation((filepath: string) => {
+        // Relative fails, but root-relative works
+        return filepath === "/test/vault/target.md";
+      });
+
+      const result = adapter.getFirstLinkpathDest(
+        "target",
+        "subfolder/source.md"
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.path).toBe("target.md");
+    });
+
+    it("should search entire vault for cross-directory wikilinks (strategy 3)", () => {
+      // This is the key fix for Issue #1380
+      // Source is in exo/, target is in rdfs/
+      existsSyncSpy.mockImplementation((filepath: string) => {
+        // Both relative and root-relative resolution fail
+        if (filepath === "/test/vault/exo/cross-dir-uuid.md") return false;
+        if (filepath === "/test/vault/cross-dir-uuid.md") return false;
+        // Vault-wide search finds it
+        return false;
+      });
+
+      // Mock walkDirectory to find the file in rdfs/
+      readdirSyncSpy.mockImplementation((dir: any) => {
+        if (dir === rootPath) {
+          return [
+            { name: "exo", isDirectory: () => true, isFile: () => false },
+            { name: "rdfs", isDirectory: () => true, isFile: () => false },
+          ] as any;
+        }
+        if (dir === "/test/vault/exo") {
+          return [
+            { name: "source-file.md", isDirectory: () => false, isFile: () => true },
+          ] as any;
+        }
+        if (dir === "/test/vault/rdfs") {
+          return [
+            { name: "cross-dir-uuid.md", isDirectory: () => false, isFile: () => true },
+          ] as any;
+        }
+        return [];
+      });
+
+      const result = adapter.getFirstLinkpathDest(
+        "cross-dir-uuid",
+        "exo/source-file.md"
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.path).toBe("rdfs/cross-dir-uuid.md");
+    });
+
+    it("should return null when file not found anywhere in vault", () => {
+      existsSyncSpy.mockReturnValue(false);
+      readdirSyncSpy.mockImplementation(() => []);
+
+      const result = adapter.getFirstLinkpathDest(
+        "nonexistent-uuid",
+        "source.md"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle wikilinks with .md extension", () => {
+      existsSyncSpy.mockImplementation((filepath: string) => {
+        return filepath === "/test/vault/subfolder/target.md";
+      });
+
+      const result = adapter.getFirstLinkpathDest(
+        "target.md",
+        "subfolder/source.md"
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.path).toBe("subfolder/target.md");
+    });
+
+    it("should prefer relative resolution over vault-wide search", () => {
+      // If file exists relative to source, should use that even if another file
+      // with same basename exists elsewhere
+      existsSyncSpy.mockImplementation((filepath: string) => {
+        // Relative resolution finds file in same directory
+        return filepath === "/test/vault/folder1/shared-name.md";
+      });
+
+      // Even if another file with same name exists in folder2
+      readdirSyncSpy.mockImplementation((dir: any) => {
+        if (dir === rootPath) {
+          return [
+            { name: "folder1", isDirectory: () => true, isFile: () => false },
+            { name: "folder2", isDirectory: () => true, isFile: () => false },
+          ] as any;
+        }
+        if (dir === "/test/vault/folder1") {
+          return [
+            { name: "shared-name.md", isDirectory: () => false, isFile: () => true },
+          ] as any;
+        }
+        if (dir === "/test/vault/folder2") {
+          return [
+            { name: "shared-name.md", isDirectory: () => false, isFile: () => true },
+          ] as any;
+        }
+        return [];
+      });
+
+      const result = adapter.getFirstLinkpathDest(
+        "shared-name",
+        "folder1/source.md"
+      );
+
+      // Should use relative resolution (folder1), not vault-wide search
+      expect(result?.path).toBe("folder1/shared-name.md");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Implements vault-wide wikilink resolution in FileSystemVaultAdapter
- Fixes regression from #1377 where statement files referencing anchor files in different directories (exo/, rdfs/, owl/) were not being indexed
- Uses 3-strategy resolution matching Obsidian behavior:
  1. Relative to source file's directory
  2. From vault root
  3. Search entire vault by basename

## Test plan

- [x] Added unit tests for vault-wide wikilink resolution (6 test cases)
- [x] Tests pass locally
- [x] Build compiles successfully

Closes #1380