### PR TITLE
fix(ci): reduce flaky tests - skip timing tests in CI and increase E2E timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,11 +509,11 @@ jobs:
           if-no-files-found: ignore
 
   # E2E tests with sharding for faster execution
-  # Target: 5 minutes (down from 15 minutes)
+  # Target: 8 minutes per shard (increased from 5 to reduce flaky cancellations - Issue #1384)
   # Note: Named e2e-shard-* to avoid conflict with branch protection rule for "e2e-tests"
   e2e-shard:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     needs: build
     strategy:
       fail-fast: false
@@ -542,6 +542,17 @@ jobs:
           tags: exocortex-e2e:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Log diagnostic info
+        run: |
+          echo "=== E2E Shard ${{ matrix.shard }}/4 Diagnostic Info ==="
+          echo "Runner: $RUNNER_NAME"
+          echo "Runner OS: $RUNNER_OS"
+          echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "Available memory: $(free -m 2>/dev/null | head -2 || echo 'N/A')"
+          echo "Available disk: $(df -h . | tail -1 || echo 'N/A')"
+          echo "CPU info: $(nproc) cores"
+          echo "============================================="
 
       - name: Run E2E tests (shard ${{ matrix.shard }}/4)
         run: |

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/graph/Quadtree.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/graph/Quadtree.test.ts
@@ -249,7 +249,12 @@ describe("Quadtree", () => {
   });
 
   describe("performance", () => {
-    it("should handle large number of points", () => {
+    // Performance tests are skipped in CI due to runner variability (Issue #1384)
+    // CI runners have inconsistent CPU performance leading to flaky timing failures
+    const isCI = process.env.CI === "true";
+    const itOrSkip = isCI ? it.skip : it;
+
+    itOrSkip("should handle large number of points", () => {
       const points: TestPoint[] = [];
       for (let i = 0; i < 10000; i++) {
         points.push({
@@ -272,7 +277,26 @@ describe("Quadtree", () => {
         tree.find(Math.random() * 1000, Math.random() * 1000);
       }
       const findTime = performance.now() - findStart;
-      expect(findTime).toBeLessThan(5000); // 1000 finds in < 5 seconds (relaxed for CI)
+      expect(findTime).toBeLessThan(5000); // 1000 finds in < 5 seconds
+    });
+
+    // Minimal performance sanity check that DOES run in CI
+    it("should build and query without hanging", () => {
+      const points: TestPoint[] = [];
+      for (let i = 0; i < 100; i++) {
+        points.push({
+          x: Math.random() * 100,
+          y: Math.random() * 100,
+          id: `node-${i}`,
+        });
+      }
+
+      const tree = new Quadtree(points);
+      expect(tree.size()).toBe(100);
+
+      // Just verify it completes (no timing constraint)
+      const found = tree.find(50, 50);
+      expect(found).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Skip Quadtree performance test in CI environment due to inconsistent runner CPU performance
- Increase E2E shard timeout from 5 to 8 minutes to reduce random cancellations
- Add diagnostic logging to E2E jobs for better debugging

## Changes
- `packages/obsidian-plugin/tests/unit/presentation/renderers/graph/Quadtree.test.ts`:
  - Skip timing-sensitive performance test when `CI=true`
  - Add minimal sanity check that always runs (no timing constraints)
- `.github/workflows/ci.yml`:
  - Increase `e2e-shard` timeout from 5 to 8 minutes
  - Add diagnostic info step logging runner, memory, disk, CPU

## Testing
- [x] Build passes
- [x] Type check passes
- [x] Unit tests pass with CI=true (performance test correctly skipped)
- [x] Lint (pre-existing issues, not from this PR)

## Verification
- Performance test skipped in CI environment ✅
- Sanity check test runs in all environments ✅

## Acceptance Criteria
- [x] Quadtree test does not fail due to timing variability (skipped in CI)
- [x] E2E timeout increased to reduce cancellations
- [x] CI logs include diagnostic info for future debugging

Fixes #1384