### PR TITLE
feat: [Commands] Define Create commands in RDF (Task, Project, Area)

### DIFF
--- a/packages/obsidian-plugin/src/application/commands/RdfCommandRegistry.ts
+++ b/packages/obsidian-plugin/src/application/commands/RdfCommandRegistry.ts
@@ -77,24 +77,23 @@ export class RdfCommandRegistry {
 
   /**
    * SPARQL query to retrieve all commands from RDF.
-   * Queries for instances of ems-ui:Command class with their properties.
+   * Queries for instances of exo-ui:Command class with their properties.
    */
   private static readonly COMMANDS_QUERY = `
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-    PREFIX exo: <https://exocortex.my/ontology/exo#>
-    PREFIX ems-ui: <https://exocortex.my/ontology/ems-ui#>
+    PREFIX exo-ui: <https://exocortex.my/ontology/exo-ui#>
 
     SELECT ?cmd ?id ?name ?icon ?hotkey ?action ?condition ?headless
     WHERE {
-      ?cmd a ems-ui:Command .
-      ?cmd ems-ui:Command_id ?id .
-      ?cmd ems-ui:Command_name ?name .
-      OPTIONAL { ?cmd ems-ui:Command_icon ?icon }
-      OPTIONAL { ?cmd ems-ui:Command_hotkey ?hotkey }
-      OPTIONAL { ?cmd ems-ui:Command_action ?action }
-      OPTIONAL { ?cmd ems-ui:Command_condition ?condition }
-      OPTIONAL { ?cmd ems-ui:Command_headless ?headless }
+      ?cmd a exo-ui:Command .
+      ?cmd exo-ui:Command_id ?id .
+      ?cmd exo-ui:Command_name ?name .
+      OPTIONAL { ?cmd exo-ui:Command_icon ?icon }
+      OPTIONAL { ?cmd exo-ui:Command_hotkey ?hotkey }
+      OPTIONAL { ?cmd exo-ui:Command_action ?action }
+      OPTIONAL { ?cmd exo-ui:Command_condition ?condition }
+      OPTIONAL { ?cmd exo-ui:Command_headless ?headless }
     }
   `;
 


### PR DESCRIPTION
## Summary

Defines Create commands (Task, Project, Area) in RDF for RDF-driven command architecture.

## Changes

### RdfCommandRegistry Fix

Updated SPARQL query to use correct namespace:
- Changed from `ems-ui:Command` to `exo-ui:Command` type
- Changed from `ems-ui:Command_*` to `exo-ui:Command_*` properties

The ontology defines commands as `exo-ui:Command` class with `exo-ui:Command_*` properties, but the registry was incorrectly looking for `ems-ui:` namespace.

### Ontology Changes

PR kitelev/exocortex-public-ontologies#19 adds the command properties:

**CreateTaskCommand:**
- Command_id: "create-task"
- Command_name: "Create Task"
- Command_icon: "plus-circle"
- Command_hotkey: "Mod+Shift+T"

**CreateProjectCommand:**
- Command_id: "create-project"
- Command_name: "Create Project"
- Command_icon: "folder-plus"
- Command_hotkey: "Mod+Shift+P"

**CreateAreaCommand:**
- Command_id: "create-area"
- Command_name: "Create Area"
- Command_icon: "map"
- Command_hotkey: "Mod+Shift+A"

## Test Plan

- [x] Build passes
- [x] Unit tests pass (CLI tests)
- [x] Lint passes for changed file
- [ ] CI pipeline passes

## Acceptance Criteria

- [x] CreateTaskCommand defined (Mod+Shift+T)
- [x] CreateProjectCommand defined (Mod+Shift+P)
- [x] CreateAreaCommand defined (Mod+Shift+A)
- [x] All have hotkeys following convention (Mod+Shift+Letter)

Closes #1439