### PR TITLE
feat(plugin): implement ObsidianUIProvider for native UI interactions

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/ObsidianUIProvider.ts
+++ b/packages/obsidian-plugin/src/infrastructure/ObsidianUIProvider.ts
@@ -1,0 +1,482 @@
+/**
+ * ObsidianUIProvider - Implements IUIProvider for Obsidian environment
+ *
+ * Provides native Obsidian UI interactions (modals, notices, navigation)
+ * for the unified UI abstraction layer.
+ *
+ * @see Issue #1398: [Plugin] Implement ObsidianUIProvider
+ * @see /Users/kitelev/vault-2025/03 Knowledge/concepts/RDF-Driven Architecture Implementation Plan (Note).md (lines 1300-1342)
+ */
+
+import { App, Modal, Notice, TFile } from "obsidian";
+import type { IUIProvider, ModalOptions, SelectOptions } from "exocortex";
+
+/**
+ * Obsidian-specific modal for text input
+ */
+class InputModal extends Modal {
+  private result = "";
+  private submitted = false;
+
+  constructor(
+    app: App,
+    private options: ModalOptions,
+    private onSubmit: (value: string) => void,
+    private onCancel: () => void
+  ) {
+    super(app);
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+
+    contentEl.createEl("h2", { text: this.options.title });
+
+    const inputContainer = contentEl.createDiv({
+      cls: "exocortex-modal-input-container",
+    });
+
+    const inputEl = inputContainer.createEl("input", {
+      type: "text",
+      placeholder: this.options.placeholder || "",
+      cls: "exocortex-modal-input",
+    });
+
+    if (this.options.defaultValue) {
+      inputEl.value = this.options.defaultValue;
+      this.result = this.options.defaultValue;
+    }
+
+    inputEl.addEventListener("input", (e) => {
+      this.result = (e.target as HTMLInputElement).value;
+    });
+
+    inputEl.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        this.submit();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        this.cancel();
+      }
+    });
+
+    const buttonContainer = contentEl.createDiv({
+      cls: "modal-button-container",
+    });
+
+    const submitButton = buttonContainer.createEl("button", {
+      text: this.options.submitLabel || "Submit",
+      cls: "mod-cta",
+    });
+    submitButton.addEventListener("click", () => this.submit());
+
+    const cancelButton = buttonContainer.createEl("button", {
+      text: "Cancel",
+    });
+    cancelButton.addEventListener("click", () => this.cancel());
+
+    // Focus input after modal is open
+    setTimeout(() => inputEl.focus(), 50);
+  }
+
+  private submit(): void {
+    this.submitted = true;
+    this.close();
+    this.onSubmit(this.result);
+  }
+
+  private cancel(): void {
+    this.close();
+    this.onCancel();
+  }
+
+  override onClose(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    // If modal was closed without submitting (e.g., clicking outside)
+    if (!this.submitted) {
+      this.onCancel();
+    }
+  }
+}
+
+/**
+ * Obsidian-specific modal for selecting from a list
+ */
+class SelectModal<T> extends Modal {
+  private selectedItem: T | null = null;
+  private submitted = false;
+  private filteredItems: T[];
+  private selectEl: HTMLSelectElement | null = null;
+  private searchInputEl: HTMLInputElement | null = null;
+
+  constructor(
+    app: App,
+    private options: SelectOptions<T>,
+    private onSubmit: (value: T) => void,
+    private onCancel: () => void
+  ) {
+    super(app);
+    this.filteredItems = [...options.items];
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+
+    contentEl.createEl("h2", { text: this.options.title });
+
+    // Search input for filtering
+    if (this.options.placeholder) {
+      const searchContainer = contentEl.createDiv({
+        cls: "exocortex-modal-search-container",
+      });
+
+      this.searchInputEl = searchContainer.createEl("input", {
+        type: "text",
+        placeholder: this.options.placeholder,
+        cls: "exocortex-modal-input",
+      });
+
+      this.searchInputEl.addEventListener("input", (e) => {
+        this.filterItems((e.target as HTMLInputElement).value);
+      });
+
+      this.searchInputEl.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          this.cancel();
+        } else if (e.key === "Enter" && this.selectedItem) {
+          e.preventDefault();
+          this.submit();
+        }
+      });
+    }
+
+    // Select dropdown
+    const selectContainer = contentEl.createDiv({
+      cls: "exocortex-modal-input-container",
+    });
+
+    this.selectEl = selectContainer.createEl("select", {
+      cls: "exocortex-modal-select dropdown",
+    });
+
+    this.renderOptions();
+
+    this.selectEl.addEventListener("change", (e) => {
+      const index = parseInt((e.target as HTMLSelectElement).value, 10);
+      if (!isNaN(index) && index >= 0 && index < this.filteredItems.length) {
+        this.selectedItem = this.filteredItems[index];
+      }
+    });
+
+    this.selectEl.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        this.cancel();
+      } else if (e.key === "Enter" && this.selectedItem) {
+        e.preventDefault();
+        this.submit();
+      }
+    });
+
+    // Buttons
+    const buttonContainer = contentEl.createDiv({
+      cls: "modal-button-container",
+    });
+
+    const submitButton = buttonContainer.createEl("button", {
+      text: "Select",
+      cls: "mod-cta",
+    });
+    submitButton.addEventListener("click", () => this.submit());
+
+    const cancelButton = buttonContainer.createEl("button", {
+      text: "Cancel",
+    });
+    cancelButton.addEventListener("click", () => this.cancel());
+
+    // Focus search or select
+    setTimeout(() => {
+      if (this.searchInputEl) {
+        this.searchInputEl.focus();
+      } else {
+        this.selectEl?.focus();
+      }
+    }, 50);
+  }
+
+  private filterItems(query: string): void {
+    const lowerQuery = query.toLowerCase().trim();
+
+    if (!lowerQuery) {
+      this.filteredItems = [...this.options.items];
+    } else {
+      this.filteredItems = this.options.items.filter((item) =>
+        this.options.getLabel(item).toLowerCase().includes(lowerQuery)
+      );
+    }
+
+    this.renderOptions();
+
+    // Auto-select first if available
+    if (this.filteredItems.length > 0) {
+      this.selectedItem = this.filteredItems[0];
+      if (this.selectEl) {
+        this.selectEl.value = "0";
+      }
+    } else {
+      this.selectedItem = null;
+    }
+  }
+
+  private renderOptions(): void {
+    if (!this.selectEl) return;
+
+    // Clear existing options
+    while (this.selectEl.firstChild) {
+      this.selectEl.removeChild(this.selectEl.firstChild);
+    }
+
+    // Add placeholder option
+    const placeholder = this.selectEl.createEl("option", {
+      value: "",
+      text: "Select an item...",
+    });
+    placeholder.disabled = true;
+    placeholder.selected = !this.selectedItem;
+
+    // Add items
+    this.filteredItems.forEach((item, index) => {
+      const selectEl = this.selectEl;
+      if (!selectEl) return;
+
+      const option = selectEl.createEl("option", {
+        value: String(index),
+        text: this.options.getLabel(item),
+      });
+
+      if (this.selectedItem === item) {
+        option.selected = true;
+      }
+    });
+  }
+
+  private submit(): void {
+    if (!this.selectedItem) return;
+
+    this.submitted = true;
+    this.close();
+    this.onSubmit(this.selectedItem);
+  }
+
+  private cancel(): void {
+    this.close();
+    this.onCancel();
+  }
+
+  override onClose(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    // If modal was closed without submitting
+    if (!this.submitted) {
+      this.onCancel();
+    }
+  }
+}
+
+/**
+ * Obsidian-specific modal for confirmation dialogs
+ */
+class ConfirmModal extends Modal {
+  private resolved = false;
+
+  constructor(
+    app: App,
+    private message: string,
+    private onResolve: (confirmed: boolean) => void
+  ) {
+    super(app);
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+
+    contentEl.createEl("h2", { text: "Confirm" });
+    contentEl.createEl("p", { text: this.message });
+
+    const buttonContainer = contentEl.createDiv({
+      cls: "modal-button-container",
+    });
+
+    const confirmButton = buttonContainer.createEl("button", {
+      text: "Confirm",
+      cls: "mod-cta",
+    });
+    confirmButton.addEventListener("click", () => this.confirm());
+
+    const cancelButton = buttonContainer.createEl("button", {
+      text: "Cancel",
+    });
+    cancelButton.addEventListener("click", () => this.cancel());
+
+    // Handle keyboard
+    contentEl.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        this.confirm();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        this.cancel();
+      }
+    });
+
+    // Focus confirm button
+    setTimeout(() => confirmButton.focus(), 50);
+  }
+
+  private confirm(): void {
+    this.resolved = true;
+    this.close();
+    this.onResolve(true);
+  }
+
+  private cancel(): void {
+    this.resolved = true;
+    this.close();
+    this.onResolve(false);
+  }
+
+  override onClose(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    // If modal was closed without explicit choice
+    if (!this.resolved) {
+      this.onResolve(false);
+    }
+  }
+}
+
+/**
+ * Obsidian UI Provider - implements IUIProvider for native Obsidian interactions
+ *
+ * Provides:
+ * - Input modals using Obsidian Modal API
+ * - Selection modals with search/filter
+ * - Confirmation dialogs
+ * - Notification via Obsidian Notice
+ * - Navigation using Obsidian workspace
+ *
+ * @example
+ * ```typescript
+ * const provider = new ObsidianUIProvider(app);
+ *
+ * // Show input modal
+ * const name = await provider.showInputModal({
+ *   title: "Enter name",
+ *   placeholder: "Name..."
+ * });
+ *
+ * // Show selection modal
+ * const selected = await provider.showSelectModal({
+ *   title: "Select item",
+ *   items: items,
+ *   getLabel: (item) => item.name
+ * });
+ *
+ * // Show confirmation
+ * const confirmed = await provider.showConfirm("Delete this?");
+ *
+ * // Show notification
+ * provider.notify("Operation completed!");
+ *
+ * // Navigate to file
+ * await provider.navigate("path/to/file.md");
+ * ```
+ */
+export class ObsidianUIProvider implements IUIProvider {
+  /**
+   * Obsidian provider is NOT headless - it has full UI capabilities
+   */
+  readonly isHeadless = false;
+
+  constructor(private app: App) {}
+
+  /**
+   * Show an input modal and return the entered value
+   *
+   * @param options - Modal configuration
+   * @returns Promise resolving to the entered string
+   * @throws Error if modal is cancelled (rejected promise)
+   */
+  async showInputModal(options: ModalOptions): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const modal = new InputModal(
+        this.app,
+        options,
+        resolve,
+        () => reject(new Error("Modal cancelled"))
+      );
+      modal.open();
+    });
+  }
+
+  /**
+   * Show a selection modal and return the selected item
+   *
+   * @template T - Type of items in the selection list
+   * @param options - Selection modal configuration
+   * @returns Promise resolving to the selected item
+   * @throws Error if modal is cancelled (rejected promise)
+   */
+  async showSelectModal<T>(options: SelectOptions<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const modal = new SelectModal(
+        this.app,
+        options,
+        resolve,
+        () => reject(new Error("Modal cancelled"))
+      );
+      modal.open();
+    });
+  }
+
+  /**
+   * Show a confirmation dialog
+   *
+   * @param message - Message to display
+   * @returns Promise resolving to true (confirmed) or false (cancelled)
+   */
+  async showConfirm(message: string): Promise<boolean> {
+    return new Promise((resolve) => {
+      const modal = new ConfirmModal(this.app, message, resolve);
+      modal.open();
+    });
+  }
+
+  /**
+   * Display a notification using Obsidian Notice
+   *
+   * @param message - Message to display
+   * @param duration - Display duration in milliseconds (default: 3000)
+   */
+  notify(message: string, duration = 3000): void {
+    new Notice(message, duration);
+  }
+
+  /**
+   * Navigate to an asset by opening its file in the workspace
+   *
+   * @param target - File path to navigate to
+   */
+  async navigate(target: string): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(target);
+    if (file instanceof TFile) {
+      await this.app.workspace.getLeaf().openFile(file);
+    }
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/infrastructure/ObsidianUIProvider.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/ObsidianUIProvider.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for ObsidianUIProvider - implements IUIProvider for Obsidian environment
+ *
+ * TDD: Write failing tests first (RED phase)
+ *
+ * @see Issue #1398: [Plugin] Implement ObsidianUIProvider
+ * @see /Users/kitelev/vault-2025/03 Knowledge/concepts/RDF-Driven Architecture Implementation Plan (Note).md (lines 1300-1342)
+ */
+
+import { App, TFile, Notice } from "obsidian";
+import { HeadlessError } from "exocortex";
+import type { IUIProvider, ModalOptions, SelectOptions } from "exocortex";
+import { ObsidianUIProvider } from "@plugin/infrastructure/ObsidianUIProvider";
+
+describe("ObsidianUIProvider", () => {
+  let mockApp: App;
+  let provider: ObsidianUIProvider;
+
+  beforeEach(() => {
+    mockApp = new App();
+    provider = new ObsidianUIProvider(mockApp);
+  });
+
+  describe("interface compliance", () => {
+    it("should implement IUIProvider interface", () => {
+      // Type assertion ensures interface compliance at compile time
+      const uiProvider: IUIProvider = provider;
+      expect(uiProvider).toBeDefined();
+    });
+
+    it("should have isHeadless set to false", () => {
+      expect(provider.isHeadless).toBe(false);
+    });
+
+    it("should have all required methods", () => {
+      expect(typeof provider.showInputModal).toBe("function");
+      expect(typeof provider.showSelectModal).toBe("function");
+      expect(typeof provider.showConfirm).toBe("function");
+      expect(typeof provider.notify).toBe("function");
+      expect(typeof provider.navigate).toBe("function");
+    });
+  });
+
+  describe("notify", () => {
+    it("should create a Notice with the message", () => {
+      // Notice is mocked in __mocks__/obsidian.ts
+      provider.notify("Test notification");
+      // Just verify no error is thrown - Notice is mocked
+      expect(true).toBe(true);
+    });
+
+    it("should accept optional duration parameter", () => {
+      provider.notify("Test notification", 5000);
+      // Just verify no error is thrown
+      expect(true).toBe(true);
+    });
+
+    it("should use default duration when not specified", () => {
+      provider.notify("Test notification");
+      // Just verify no error is thrown
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("navigate", () => {
+    it("should open file when valid path is provided", async () => {
+      // Setup mock file
+      const mockFile = new TFile("test/file.md");
+      mockApp.vault.__addMockFile("test/file.md");
+
+      // Mock workspace.getLeaf().openFile
+      const mockOpenFile = jest.fn().mockResolvedValue(undefined);
+      const mockLeaf = { openFile: mockOpenFile };
+      jest.spyOn(mockApp.workspace, "getLeaf").mockReturnValue(mockLeaf as any);
+      jest
+        .spyOn(mockApp.vault, "getAbstractFileByPath")
+        .mockReturnValue(mockFile);
+
+      await provider.navigate("test/file.md");
+
+      expect(mockApp.vault.getAbstractFileByPath).toHaveBeenCalledWith(
+        "test/file.md"
+      );
+      expect(mockApp.workspace.getLeaf).toHaveBeenCalled();
+      expect(mockOpenFile).toHaveBeenCalledWith(mockFile);
+    });
+
+    it("should not throw when file does not exist", async () => {
+      jest.spyOn(mockApp.vault, "getAbstractFileByPath").mockReturnValue(null);
+
+      // Should not throw
+      await expect(provider.navigate("nonexistent/file.md")).resolves.not.toThrow();
+    });
+
+    it("should not open folder as file", async () => {
+      // Mock returning a folder instead of file
+      const mockFolder = { path: "test/folder" }; // Not a TFile
+      jest
+        .spyOn(mockApp.vault, "getAbstractFileByPath")
+        .mockReturnValue(mockFolder as any);
+
+      const mockOpenFile = jest.fn();
+      jest.spyOn(mockApp.workspace, "getLeaf").mockReturnValue({
+        openFile: mockOpenFile,
+      } as any);
+
+      await provider.navigate("test/folder");
+
+      // Should not call openFile for folders
+      expect(mockOpenFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("showInputModal", () => {
+    it("should return a promise", () => {
+      const options: ModalOptions = {
+        title: "Test Input",
+        placeholder: "Enter value",
+      };
+
+      // Note: In actual test, the modal would need to be resolved
+      // For unit test, we verify the method exists and returns a promise
+      const result = provider.showInputModal(options);
+      expect(result).toBeInstanceOf(Promise);
+    });
+
+    it("should accept all ModalOptions properties", async () => {
+      const options: ModalOptions = {
+        title: "Test Input",
+        placeholder: "Enter something",
+        defaultValue: "default",
+        submitLabel: "Save",
+      };
+
+      // The promise will hang without manual resolution in tests
+      // This tests that the method accepts all options without error
+      const result = provider.showInputModal(options);
+      expect(result).toBeInstanceOf(Promise);
+    });
+  });
+
+  describe("showSelectModal", () => {
+    it("should return a promise", () => {
+      const options: SelectOptions<string> = {
+        title: "Select Item",
+        items: ["item1", "item2", "item3"],
+        getLabel: (item) => item,
+      };
+
+      const result = provider.showSelectModal(options);
+      expect(result).toBeInstanceOf(Promise);
+    });
+
+    it("should accept generic type parameter", () => {
+      interface TestItem {
+        id: string;
+        name: string;
+      }
+
+      const options: SelectOptions<TestItem> = {
+        title: "Select Test Item",
+        items: [
+          { id: "1", name: "First" },
+          { id: "2", name: "Second" },
+        ],
+        getLabel: (item) => item.name,
+        placeholder: "Search items...",
+      };
+
+      const result = provider.showSelectModal(options);
+      expect(result).toBeInstanceOf(Promise);
+    });
+  });
+
+  describe("showConfirm", () => {
+    it("should return a promise of boolean", () => {
+      const result = provider.showConfirm("Are you sure?");
+      expect(result).toBeInstanceOf(Promise);
+    });
+
+    it("should accept message parameter", () => {
+      // This tests that the method accepts the message without error
+      const result = provider.showConfirm("Delete this item?");
+      expect(result).toBeInstanceOf(Promise);
+    });
+  });
+
+  describe("constructor", () => {
+    it("should store app reference", () => {
+      const newProvider = new ObsidianUIProvider(mockApp);
+      // The app should be accessible for modal creation
+      expect(newProvider).toBeDefined();
+      expect(newProvider.isHeadless).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implement ObsidianUIProvider in obsidian-plugin package that provides native Obsidian UI interactions for the unified UI abstraction layer.

### Key features:
- **InputModal**: Text input with keyboard support (Enter/Escape), placeholder, default value
- **SelectModal**: Searchable selection list with filtering and generic type support
- **ConfirmModal**: Boolean confirmation dialogs
- **notify()**: Uses Obsidian Notice API with configurable duration
- **navigate()**: Opens files in workspace using Obsidian API
- **isHeadless = false**: Full UI capabilities (unlike CLI provider)

### Implementation details:
- Implements `IUIProvider` interface from @exocortex/core (Issue #1397)
- Uses native Obsidian Modal API for all dialogs
- All modals support keyboard navigation
- Proper cleanup on modal close

## Test Plan

- [x] Unit tests for ObsidianUIProvider (16 tests)
- [x] Interface compliance tests
- [x] isHeadless property verification
- [x] Method existence checks
- [x] Build passes
- [x] No lint errors in new code

## Dependencies

- **Blocked by**: #1397 (IUIProvider interface) - CLOSED
- **Blocks**: #1400 (ActionContext integration)

Closes #1398