### PR TITLE
feat(core): add uiProvider to ActionContext

### DIFF
--- a/packages/exocortex/src/domain/types/ActionContext.ts
+++ b/packages/exocortex/src/domain/types/ActionContext.ts
@@ -1,0 +1,65 @@
+/**
+ * ActionContext - Context object for Action handlers
+ *
+ * Provides Actions with access to all necessary services and state
+ * for executing operations in both Obsidian and CLI environments.
+ *
+ * @see /Users/kitelev/vault-2025/03 Knowledge/concepts/RDF-Driven Architecture Implementation Plan (Note).md
+ * Phase 2: IUIProvider + Headless Mode (lines 1386-1403)
+ *
+ * Issue #1400: Add uiProvider to ActionContext
+ * @see https://github.com/kitelev/exocortex/issues/1400
+ */
+
+import { ITripleStore } from "../../interfaces/ITripleStore";
+import { IUIProvider } from "../ports/IUIProvider";
+import { IFile } from "../../interfaces/IVaultAdapter";
+
+/**
+ * Context object passed to Action handlers.
+ *
+ * Actions receive this context to access:
+ * - tripleStore: For SPARQL queries and triple manipulation
+ * - uiProvider: For UI operations (modals, notifications, navigation)
+ * - currentAsset: The currently active file (optional)
+ * - cliArgs: CLI arguments when running in headless mode (optional)
+ *
+ * @example
+ * ```typescript
+ * async function handleAction(ctx: ActionContext): Promise<void> {
+ *   // Check if running headless (CLI)
+ *   if (ctx.uiProvider.isHeadless) {
+ *     // Use CLI arguments instead of modal
+ *     const targetProject = ctx.cliArgs?.project;
+ *     if (!targetProject) {
+ *       throw new HeadlessError('Select project', 'Use --project <name>');
+ *     }
+ *   } else {
+ *     // Show interactive modal
+ *     const targetProject = await ctx.uiProvider.showInputModal({
+ *       title: 'Select Project',
+ *       placeholder: 'Enter project name...'
+ *     });
+ *   }
+ * }
+ * ```
+ */
+export interface ActionContext {
+  /** Current asset file (if any) */
+  currentAsset?: IFile;
+
+  /** Triple store for SPARQL queries */
+  tripleStore: ITripleStore;
+
+  /**
+   * UI provider (Obsidian modals or CLI fallback)
+   *
+   * Use `uiProvider.isHeadless` to check execution mode:
+   * - true: CLI mode, avoid interactive operations
+   * - false: Obsidian mode, can use modals and UI
+   */
+  uiProvider: IUIProvider;
+
+  /** CLI arguments (if running in CLI mode) */
+  cliArgs?: Record<string, string>;
+}

--- a/packages/exocortex/src/domain/types/index.ts
+++ b/packages/exocortex/src/domain/types/index.ts
@@ -6,3 +6,4 @@ export {
   uriToPropertyName,
   extractPropertyLabel,
 } from "./PropertyDefinition";
+export { type ActionContext } from "./ActionContext";

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -314,6 +314,9 @@ export {
   type SelectOptions,
 } from "./domain/ports/IUIProvider";
 
+// Action Context export
+export type { ActionContext } from "./domain/types/ActionContext";
+
 // DI Container exports
 export {
   registerCoreServices,

--- a/packages/exocortex/tests/unit/domain/types/ActionContext.test.ts
+++ b/packages/exocortex/tests/unit/domain/types/ActionContext.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for ActionContext interface
+ *
+ * Issue #1400: Add uiProvider to ActionContext
+ * @see https://github.com/kitelev/exocortex/issues/1400
+ */
+import { ITripleStore } from "../../../../src/interfaces/ITripleStore";
+import { IUIProvider } from "../../../../src/domain/ports/IUIProvider";
+import { IFile } from "../../../../src/interfaces/IVaultAdapter";
+
+// Import the interface being tested - this should fail initially (TDD RED)
+import { ActionContext } from "../../../../src/domain/types/ActionContext";
+
+describe("ActionContext", () => {
+  describe("interface structure", () => {
+    it("should have uiProvider field of type IUIProvider", () => {
+      // Create a mock IUIProvider
+      const mockUIProvider: IUIProvider = {
+        showInputModal: jest.fn(),
+        showSelectModal: jest.fn(),
+        showConfirm: jest.fn(),
+        notify: jest.fn(),
+        navigate: jest.fn(),
+        isHeadless: false,
+      };
+
+      // Create a mock ITripleStore (minimal implementation)
+      const mockTripleStore: ITripleStore = {
+        add: jest.fn(),
+        remove: jest.fn(),
+        has: jest.fn(),
+        match: jest.fn(),
+        addAll: jest.fn(),
+        removeAll: jest.fn(),
+        clear: jest.fn(),
+        count: jest.fn(),
+        subjects: jest.fn(),
+        predicates: jest.fn(),
+        objects: jest.fn(),
+        beginTransaction: jest.fn(),
+      };
+
+      // Create an ActionContext with uiProvider
+      const context: ActionContext = {
+        tripleStore: mockTripleStore,
+        uiProvider: mockUIProvider,
+      };
+
+      // Verify the interface accepts uiProvider
+      expect(context.uiProvider).toBe(mockUIProvider);
+      expect(context.uiProvider.isHeadless).toBe(false);
+      expect(context.tripleStore).toBe(mockTripleStore);
+    });
+
+    it("should allow optional currentAsset field", () => {
+      const mockUIProvider: IUIProvider = {
+        showInputModal: jest.fn(),
+        showSelectModal: jest.fn(),
+        showConfirm: jest.fn(),
+        notify: jest.fn(),
+        navigate: jest.fn(),
+        isHeadless: true,
+      };
+
+      const mockTripleStore: ITripleStore = {
+        add: jest.fn(),
+        remove: jest.fn(),
+        has: jest.fn(),
+        match: jest.fn(),
+        addAll: jest.fn(),
+        removeAll: jest.fn(),
+        clear: jest.fn(),
+        count: jest.fn(),
+        subjects: jest.fn(),
+        predicates: jest.fn(),
+        objects: jest.fn(),
+        beginTransaction: jest.fn(),
+      };
+
+      const mockFile: IFile = {
+        path: "/test/file.md",
+        basename: "file",
+        name: "file.md",
+        parent: null,
+      };
+
+      // Create context with optional currentAsset
+      const contextWithAsset: ActionContext = {
+        tripleStore: mockTripleStore,
+        uiProvider: mockUIProvider,
+        currentAsset: mockFile,
+      };
+
+      expect(contextWithAsset.currentAsset).toBe(mockFile);
+      expect(contextWithAsset.uiProvider.isHeadless).toBe(true);
+    });
+
+    it("should allow optional cliArgs field", () => {
+      const mockUIProvider: IUIProvider = {
+        showInputModal: jest.fn(),
+        showSelectModal: jest.fn(),
+        showConfirm: jest.fn(),
+        notify: jest.fn(),
+        navigate: jest.fn(),
+        isHeadless: true,
+      };
+
+      const mockTripleStore: ITripleStore = {
+        add: jest.fn(),
+        remove: jest.fn(),
+        has: jest.fn(),
+        match: jest.fn(),
+        addAll: jest.fn(),
+        removeAll: jest.fn(),
+        clear: jest.fn(),
+        count: jest.fn(),
+        subjects: jest.fn(),
+        predicates: jest.fn(),
+        objects: jest.fn(),
+        beginTransaction: jest.fn(),
+      };
+
+      const cliArgs = {
+        project: "test-project",
+        force: "true",
+      };
+
+      // Create context with CLI arguments
+      const contextWithCliArgs: ActionContext = {
+        tripleStore: mockTripleStore,
+        uiProvider: mockUIProvider,
+        cliArgs,
+      };
+
+      expect(contextWithCliArgs.cliArgs).toEqual(cliArgs);
+      expect(contextWithCliArgs.cliArgs?.project).toBe("test-project");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ActionContext` interface for Action handlers
- Interface includes `uiProvider` field for CLI/Obsidian UI abstraction
- Comprehensive documentation with usage example

## Changes

- New file: `packages/exocortex/src/domain/types/ActionContext.ts`
- Updated exports in `packages/exocortex/src/domain/types/index.ts`
- Updated exports in `packages/exocortex/src/index.ts`
- New test file: `packages/exocortex/tests/unit/domain/types/ActionContext.test.ts` (3 tests)

## ActionContext Interface

```typescript
export interface ActionContext {
  currentAsset?: IFile;        // Optional file reference
  tripleStore: ITripleStore;   // For SPARQL queries
  uiProvider: IUIProvider;     // CLI/Obsidian UI abstraction
  cliArgs?: Record<string, string>;  // Optional CLI arguments
}
```

## Testing

- [x] 3 unit tests verifying interface structure
- [x] Tests verify `uiProvider` field of type `IUIProvider`
- [x] Tests verify optional fields (`currentAsset`, `cliArgs`)
- [x] Build passes (`npm run build`)
- [x] All related tests pass

## Verification

- [x] ActionContext compiles with uiProvider field
- [x] Type exported from package
- [x] TDD workflow followed (test written first, then implementation)

## Part of Phase 2: IUIProvider + Headless Mode

See: `/Users/kitelev/vault-2025/03 Knowledge/concepts/RDF-Driven Architecture Implementation Plan (Note).md` (lines 1386-1403)

Closes #1400