### PR TITLE
feat(core): create ActionTypes.ts with interfaces

### DIFF
--- a/packages/exocortex/src/domain/types/ActionTypes.ts
+++ b/packages/exocortex/src/domain/types/ActionTypes.ts
@@ -1,0 +1,116 @@
+/**
+ * ActionTypes - Type definitions for Action system
+ *
+ * Provides type-safe interfaces for the ActionInterpreter runtime.
+ * All handlers follow consistent contracts defined here.
+ *
+ * @see /Users/kitelev/vault-2025/03 Knowledge/concepts/RDF-Driven Architecture Implementation Plan (Note).md
+ * Phase 3: ActionInterpreter Runtime (lines 1426-1467)
+ *
+ * Issue #1403: Create ActionTypes.ts with interfaces
+ * @see https://github.com/kitelev/exocortex/issues/1403
+ */
+
+import { IFile } from "../../interfaces/IVaultAdapter";
+import { ActionContext } from "./ActionContext";
+
+/**
+ * Result object returned by Action handlers.
+ *
+ * @example Success with navigation
+ * ```typescript
+ * const result: ActionResult = {
+ *   success: true,
+ *   message: "Task created successfully",
+ *   navigateTo: newTaskFile,
+ *   refresh: true
+ * };
+ * ```
+ *
+ * @example Failure with error message
+ * ```typescript
+ * const result: ActionResult = {
+ *   success: false,
+ *   message: "Failed to create task: missing required property"
+ * };
+ * ```
+ */
+export interface ActionResult {
+  /** Whether action succeeded */
+  success: boolean;
+
+  /** Success/error message */
+  message?: string;
+
+  /** Asset to navigate to after action */
+  navigateTo?: IFile;
+
+  /** Whether to refresh UI */
+  refresh?: boolean;
+
+  /** Data returned by action (for composite actions) */
+  data?: unknown;
+}
+
+/**
+ * Definition of an action loaded from RDF.
+ *
+ * Actions are defined in the triple store using exo-ui ontology,
+ * and this interface represents the parsed definition.
+ *
+ * @example
+ * ```typescript
+ * const definition: ActionDefinition = {
+ *   type: "exo-ui:CreateAssetAction",
+ *   params: {
+ *     assetClass: "Task",
+ *     defaultStatus: "active"
+ *   }
+ * };
+ * ```
+ */
+export interface ActionDefinition {
+  /** Action type URI (e.g., exo-ui:CreateAssetAction) */
+  type: string;
+
+  /** Action parameters from RDF */
+  params: Record<string, unknown>;
+}
+
+/**
+ * Handler function for executing actions.
+ *
+ * Handlers receive the action definition (from RDF) and execution context,
+ * and return a result indicating success/failure and any side effects.
+ *
+ * @example
+ * ```typescript
+ * const createAssetHandler: ActionHandler = async (definition, context) => {
+ *   const assetClass = definition.params.assetClass as string;
+ *
+ *   // Check if running headless
+ *   if (context.uiProvider.isHeadless) {
+ *     // Use CLI args instead of modal
+ *     const name = context.cliArgs?.name;
+ *     if (!name) {
+ *       return { success: false, message: "Missing --name argument" };
+ *     }
+ *   } else {
+ *     // Show interactive modal
+ *     const name = await context.uiProvider.showInputModal({
+ *       title: `Create ${assetClass}`,
+ *       placeholder: "Enter name..."
+ *     });
+ *   }
+ *
+ *   // Create asset using triple store
+ *   // ...
+ *
+ *   return { success: true, navigateTo: newFile, refresh: true };
+ * };
+ * ```
+ */
+export type ActionHandler = (
+  definition: ActionDefinition,
+  context: ActionContext
+) => Promise<ActionResult>;

--- a/packages/exocortex/src/domain/types/index.ts
+++ b/packages/exocortex/src/domain/types/index.ts
@@ -7,3 +7,8 @@ export {
   extractPropertyLabel,
 } from "./PropertyDefinition";
 export { type ActionContext } from "./ActionContext";
+export {
+  type ActionResult,
+  type ActionDefinition,
+  type ActionHandler,
+} from "./ActionTypes";

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -314,8 +314,13 @@ export {
   type SelectOptions,
 } from "./domain/ports/IUIProvider";
 
-// Action Context export
+// Action Types exports
 export type { ActionContext } from "./domain/types/ActionContext";
+export type {
+  ActionResult,
+  ActionDefinition,
+  ActionHandler,
+} from "./domain/types/ActionTypes";
 
 // DI Container exports
 export {

--- a/packages/exocortex/tests/unit/domain/types/ActionTypes.test.ts
+++ b/packages/exocortex/tests/unit/domain/types/ActionTypes.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for ActionTypes interfaces
+ *
+ * Issue #1403: Create ActionTypes.ts with interfaces
+ * @see https://github.com/kitelev/exocortex/issues/1403
+ *
+ * Tests for:
+ * - ActionResult interface
+ * - ActionDefinition interface
+ * - ActionHandler type
+ */
+import { ITripleStore } from "../../../../src/interfaces/ITripleStore";
+import { IUIProvider } from "../../../../src/domain/ports/IUIProvider";
+import { IFile } from "../../../../src/interfaces/IVaultAdapter";
+
+// Import the types being tested - this should fail initially (TDD RED)
+import {
+  ActionResult,
+  ActionDefinition,
+  ActionHandler,
+} from "../../../../src/domain/types/ActionTypes";
+import { ActionContext } from "../../../../src/domain/types/ActionContext";
+
+describe("ActionTypes", () => {
+  // Helper to create mock context
+  const createMockContext = (): ActionContext => {
+    const mockUIProvider: IUIProvider = {
+      showInputModal: jest.fn(),
+      showSelectModal: jest.fn(),
+      showConfirm: jest.fn(),
+      notify: jest.fn(),
+      navigate: jest.fn(),
+      isHeadless: false,
+    };
+
+    const mockTripleStore: ITripleStore = {
+      add: jest.fn(),
+      remove: jest.fn(),
+      has: jest.fn(),
+      match: jest.fn(),
+      addAll: jest.fn(),
+      removeAll: jest.fn(),
+      clear: jest.fn(),
+      count: jest.fn(),
+      subjects: jest.fn(),
+      predicates: jest.fn(),
+      objects: jest.fn(),
+      beginTransaction: jest.fn(),
+    };
+
+    return {
+      tripleStore: mockTripleStore,
+      uiProvider: mockUIProvider,
+    };
+  };
+
+  describe("ActionResult interface", () => {
+    it("should allow success result with just success flag", () => {
+      const result: ActionResult = {
+        success: true,
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBeUndefined();
+      expect(result.navigateTo).toBeUndefined();
+      expect(result.refresh).toBeUndefined();
+      expect(result.data).toBeUndefined();
+    });
+
+    it("should allow failure result with message", () => {
+      const result: ActionResult = {
+        success: false,
+        message: "Operation failed: invalid asset",
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Operation failed: invalid asset");
+    });
+
+    it("should allow success result with navigateTo file", () => {
+      const mockFile: IFile = {
+        path: "/projects/new-project.md",
+        basename: "new-project",
+        name: "new-project.md",
+        parent: null,
+      };
+
+      const result: ActionResult = {
+        success: true,
+        message: "Project created successfully",
+        navigateTo: mockFile,
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.navigateTo).toBe(mockFile);
+      expect(result.navigateTo?.path).toBe("/projects/new-project.md");
+    });
+
+    it("should allow result with refresh flag", () => {
+      const result: ActionResult = {
+        success: true,
+        refresh: true,
+      };
+
+      expect(result.refresh).toBe(true);
+    });
+
+    it("should allow result with arbitrary data payload", () => {
+      const result: ActionResult = {
+        success: true,
+        data: {
+          createdAssets: ["asset-1", "asset-2"],
+          processedCount: 2,
+        },
+      };
+
+      expect(result.data).toEqual({
+        createdAssets: ["asset-1", "asset-2"],
+        processedCount: 2,
+      });
+    });
+
+    it("should allow full result with all fields", () => {
+      const mockFile: IFile = {
+        path: "/tasks/task-123.md",
+        basename: "task-123",
+        name: "task-123.md",
+        parent: null,
+      };
+
+      const result: ActionResult = {
+        success: true,
+        message: "Task created and linked to project",
+        navigateTo: mockFile,
+        refresh: true,
+        data: { taskId: "123" },
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("Task created and linked to project");
+      expect(result.navigateTo).toBe(mockFile);
+      expect(result.refresh).toBe(true);
+      expect(result.data).toEqual({ taskId: "123" });
+    });
+  });
+
+  describe("ActionDefinition interface", () => {
+    it("should have type and params fields", () => {
+      const definition: ActionDefinition = {
+        type: "exo-ui:CreateAssetAction",
+        params: {},
+      };
+
+      expect(definition.type).toBe("exo-ui:CreateAssetAction");
+      expect(definition.params).toEqual({});
+    });
+
+    it("should allow params with various value types", () => {
+      const definition: ActionDefinition = {
+        type: "exo-ui:UpdatePropertyAction",
+        params: {
+          property: "exo:Asset_status",
+          value: "completed",
+          assetUri: "https://exocortex.my/assets/task-123",
+          timestamp: 1704067200000,
+          force: true,
+        },
+      };
+
+      expect(definition.type).toBe("exo-ui:UpdatePropertyAction");
+      expect(definition.params.property).toBe("exo:Asset_status");
+      expect(definition.params.value).toBe("completed");
+      expect(definition.params.assetUri).toBe("https://exocortex.my/assets/task-123");
+      expect(definition.params.timestamp).toBe(1704067200000);
+      expect(definition.params.force).toBe(true);
+    });
+
+    it("should allow nested params objects", () => {
+      const definition: ActionDefinition = {
+        type: "exo-ui:CompositeAction",
+        params: {
+          actions: [
+            { type: "exo-ui:CreateAssetAction", params: { class: "Task" } },
+            { type: "exo-ui:NavigateAction", params: { target: "created" } },
+          ],
+          sequential: true,
+        },
+      };
+
+      expect(definition.params.actions).toHaveLength(2);
+      expect(definition.params.sequential).toBe(true);
+    });
+  });
+
+  describe("ActionHandler type", () => {
+    it("should be a function taking definition and context, returning Promise<ActionResult>", async () => {
+      const handler: ActionHandler = async (
+        definition: ActionDefinition,
+        context: ActionContext
+      ): Promise<ActionResult> => {
+        return {
+          success: true,
+          message: `Executed action: ${definition.type}`,
+        };
+      };
+
+      const definition: ActionDefinition = {
+        type: "exo-ui:TestAction",
+        params: {},
+      };
+
+      const context = createMockContext();
+      const result = await handler(definition, context);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("Executed action: exo-ui:TestAction");
+    });
+
+    it("should allow handler to access definition params", async () => {
+      const handler: ActionHandler = async (definition, context) => {
+        const targetClass = definition.params.assetClass as string;
+        return {
+          success: true,
+          message: `Creating asset of class: ${targetClass}`,
+        };
+      };
+
+      const result = await handler(
+        {
+          type: "exo-ui:CreateAssetAction",
+          params: { assetClass: "Task" },
+        },
+        createMockContext()
+      );
+
+      expect(result.message).toBe("Creating asset of class: Task");
+    });
+
+    it("should allow handler to access context services", async () => {
+      const handler: ActionHandler = async (definition, context) => {
+        // Access uiProvider from context
+        const isHeadless = context.uiProvider.isHeadless;
+        return {
+          success: true,
+          data: { headlessMode: isHeadless },
+        };
+      };
+
+      const result = await handler(
+        { type: "exo-ui:CheckModeAction", params: {} },
+        createMockContext()
+      );
+
+      expect(result.data).toEqual({ headlessMode: false });
+    });
+
+    it("should allow handler to return failure result", async () => {
+      const handler: ActionHandler = async (definition, context) => {
+        if (!definition.params.required) {
+          return {
+            success: false,
+            message: "Missing required parameter",
+          };
+        }
+        return { success: true };
+      };
+
+      const result = await handler(
+        { type: "exo-ui:ValidateAction", params: {} },
+        createMockContext()
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Missing required parameter");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add type-safe interfaces for ActionInterpreter runtime
- Export types from @exocortex/core package
- Add comprehensive test coverage (13 tests)

## Changes
- Create `packages/exocortex/src/domain/types/ActionTypes.ts` with:
  - `ActionResult` - Result object returned by Action handlers
  - `ActionDefinition` - Definition of an action loaded from RDF
  - `ActionHandler` - Handler function type for executing actions
- Export new types from `domain/types/index.ts`
- Export new types from `packages/exocortex/src/index.ts`
- Add 13 unit tests verifying interface contracts

## Testing
- [x] Added 13 unit tests for ActionTypes interfaces
- [x] All existing tests pass (714 tests)
- [x] Build compiles successfully
- [x] Lint passes for new files

## Verification
- [x] `npm run build` — PASSED
- [x] `npm run test:unit` — PASSED (714 tests)
- [x] `npx eslint packages/exocortex/src/domain/types/ActionTypes.ts` — PASSED

## Acceptance Criteria
- [x] ActionTypes.ts created
- [x] 4 interfaces/types defined (ActionContext existed, added ActionResult, ActionDefinition, ActionHandler)
- [x] Exported from @exocortex/core

Closes #1403