### PR TITLE
feat(core): [Core] Implement ActionInterpreter base structure

### DIFF
--- a/packages/exocortex/src/domain/services/ActionInterpreter.ts
+++ b/packages/exocortex/src/domain/services/ActionInterpreter.ts
@@ -1,0 +1,306 @@
+/**
+ * ActionInterpreter - RDF-driven action execution engine
+ *
+ * Orchestrates action execution by loading action definitions from the triple store
+ * and dispatching them to registered handlers.
+ *
+ * @see /Users/kitelev/vault-2025/03 Knowledge/concepts/RDF-Driven Architecture Implementation Plan (Note).md
+ * Phase 3: ActionInterpreter Runtime (lines 1469-1640)
+ *
+ * Issue #1404: Implement ActionInterpreter base structure
+ * @see https://github.com/kitelev/exocortex/issues/1404
+ */
+
+import { ITripleStore } from "../../interfaces/ITripleStore";
+import { IRI } from "../models/rdf/IRI";
+import { ActionContext } from "../types/ActionContext";
+import {
+  ActionResult,
+  ActionDefinition,
+  ActionHandler,
+} from "../types/ActionTypes";
+
+/**
+ * Namespace URI for exo-ui ontology
+ */
+const EXO_UI_NS = "https://exocortex.my/ontology/exo-ui#";
+
+/**
+ * RDF type predicate URI
+ */
+const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+/**
+ * ActionInterpreter - orchestrates RDF-driven action execution
+ *
+ * This is the core of the declarative UI system. Actions are defined in RDF
+ * using the exo-ui ontology, and this interpreter loads and executes them.
+ *
+ * Fixed Verbs (8 built-in action types):
+ * 1. CreateAssetAction - Create new asset from template
+ * 2. UpdatePropertyAction - Update asset property
+ * 3. NavigateAction - Navigate to asset
+ * 4. ExecuteSPARQLAction - Execute SPARQL query
+ * 5. ShowModalAction - Show modal dialog
+ * 6. TriggerHookAction - Trigger external webhook
+ * 7. CustomHandlerAction - Delegate to registered TypeScript handler
+ * 8. CompositeAction - Execute multiple actions in sequence
+ *
+ * @example
+ * ```typescript
+ * const interpreter = new ActionInterpreter(tripleStore);
+ *
+ * // Register custom handler (escape hatch)
+ * interpreter.registerCustomHandler('custom:MyHandler', async (def, ctx) => {
+ *   // Custom logic
+ *   return { success: true };
+ * });
+ *
+ * // Execute action by URI
+ * const result = await interpreter.execute(
+ *   'https://exocortex.my/actions/create-task-1',
+ *   context
+ * );
+ * ```
+ */
+export class ActionInterpreter {
+  /**
+   * Registry of built-in action handlers (Fixed Verbs)
+   */
+  private handlers: Map<string, ActionHandler> = new Map();
+
+  /**
+   * Registry of custom handlers (escape hatch for TypeScript logic)
+   */
+  private customHandlers: Map<string, ActionHandler> = new Map();
+
+  constructor(private tripleStore: ITripleStore) {
+    this.registerBuiltinHandlers();
+  }
+
+  /**
+   * Register all 8 Fixed Verb handlers
+   */
+  private registerBuiltinHandlers(): void {
+    // Fixed Verbs - НЕ расширяются через RDF
+    this.handlers.set("exo-ui:CreateAssetAction", this.createAssetHandler);
+    this.handlers.set("exo-ui:UpdatePropertyAction", this.updatePropertyHandler);
+    this.handlers.set("exo-ui:NavigateAction", this.navigateHandler);
+    this.handlers.set("exo-ui:ExecuteSPARQLAction", this.executeSparqlHandler);
+    this.handlers.set("exo-ui:ShowModalAction", this.showModalHandler);
+    this.handlers.set("exo-ui:TriggerHookAction", this.triggerHookHandler);
+    this.handlers.set("exo-ui:CustomHandlerAction", this.customHandler);
+    this.handlers.set("exo-ui:CompositeAction", this.compositeHandler);
+  }
+
+  /**
+   * Register custom handler (escape hatch for TypeScript logic)
+   *
+   * @param handlerId - Unique handler identifier
+   * @param handler - Handler function to execute
+   */
+  registerCustomHandler(handlerId: string, handler: ActionHandler): void {
+    this.customHandlers.set(handlerId, handler);
+  }
+
+  /**
+   * Check if a handler is registered for the given action type
+   *
+   * @param actionType - Action type URI (e.g., "exo-ui:CreateAssetAction")
+   * @returns true if handler exists
+   */
+  hasHandler(actionType: string): boolean {
+    return this.handlers.has(actionType) || this.customHandlers.has(actionType);
+  }
+
+  /**
+   * Execute action by URI
+   *
+   * @param actionUri - URI of the action in the triple store
+   * @param context - Execution context with services and state
+   * @returns Result of action execution
+   */
+  async execute(
+    actionUri: string,
+    context: ActionContext
+  ): Promise<ActionResult> {
+    // 1. Load action definition from triple store
+    let definition: ActionDefinition;
+    try {
+      definition = await this.loadActionDefinition(actionUri);
+    } catch (error) {
+      return {
+        success: false,
+        message: `Failed to load action definition: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    // 2. Find handler for action type
+    const handler =
+      this.handlers.get(definition.type) ||
+      this.customHandlers.get(definition.type);
+
+    if (!handler) {
+      return {
+        success: false,
+        message: `Unknown action type: ${definition.type}`,
+      };
+    }
+
+    // 3. Execute handler
+    return handler(definition, context);
+  }
+
+  /**
+   * Load action definition from triple store
+   *
+   * Queries the triple store to get:
+   * - Action type (rdf:type)
+   * - Action parameters (exo-ui:* properties)
+   *
+   * @param actionUri - URI of the action
+   * @returns Parsed action definition
+   * @throws Error if action type not found
+   */
+  private async loadActionDefinition(
+    actionUri: string
+  ): Promise<ActionDefinition> {
+    // Query all triples for this action
+    const actionIRI = new IRI(actionUri);
+    const triples = await this.tripleStore.match(actionIRI, undefined, undefined);
+
+    // Find action type
+    let actionType: string | undefined;
+    const params: Record<string, unknown> = {};
+
+    for (const triple of triples) {
+      const predicateValue =
+        "value" in triple.predicate ? triple.predicate.value : String(triple.predicate);
+
+      // Check if this is the rdf:type triple
+      if (predicateValue === RDF_TYPE) {
+        const objectValue =
+          "value" in triple.object ? triple.object.value : String(triple.object);
+
+        // Extract action type from full URI (e.g., exo-ui:CreateAssetAction)
+        if (objectValue.startsWith(EXO_UI_NS)) {
+          actionType = "exo-ui:" + objectValue.substring(EXO_UI_NS.length);
+        }
+      } else if (predicateValue.startsWith(EXO_UI_NS)) {
+        // Extract param name and value
+        const paramName = predicateValue.substring(EXO_UI_NS.length);
+        const objectValue =
+          "value" in triple.object ? triple.object.value : String(triple.object);
+        params[paramName] = objectValue;
+      }
+    }
+
+    if (!actionType) {
+      throw new Error(`Action type not found for: ${actionUri}`);
+    }
+
+    return {
+      type: actionType,
+      params,
+    };
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // FIXED VERBS IMPLEMENTATIONS (Stub - to be implemented in #1405-#1411)
+  // ═══════════════════════════════════════════════════════════════
+
+  /**
+   * Create new asset from template
+   * @see Issue #1405
+   */
+  private createAssetHandler: ActionHandler = async (def, _ctx) => {
+    return {
+      success: false,
+      message: `Not implemented: CreateAssetAction (targetClass: ${String(def.params.targetClass)})`,
+    };
+  };
+
+  /**
+   * Update asset property
+   * @see Issue #1406
+   */
+  private updatePropertyHandler: ActionHandler = async (def, _ctx) => {
+    return {
+      success: false,
+      message: `Not implemented: UpdatePropertyAction (property: ${String(def.params.targetProperty)})`,
+    };
+  };
+
+  /**
+   * Navigate to asset
+   * @see Issue #1407
+   */
+  private navigateHandler: ActionHandler = async (def, _ctx) => {
+    return {
+      success: false,
+      message: `Not implemented: NavigateAction (target: ${String(def.params.target)})`,
+    };
+  };
+
+  /**
+   * Execute SPARQL query
+   * @see Issue #1408
+   */
+  private executeSparqlHandler: ActionHandler = async (_def, _ctx) => {
+    return {
+      success: false,
+      message: `Not implemented: ExecuteSPARQLAction`,
+    };
+  };
+
+  /**
+   * Show modal dialog
+   * @see Issue #1409
+   */
+  private showModalHandler: ActionHandler = async (def, _ctx) => {
+    return {
+      success: false,
+      message: `Not implemented: ShowModalAction (modalType: ${String(def.params.modalType)})`,
+    };
+  };
+
+  /**
+   * Trigger external webhook
+   * @see Issue #1410
+   */
+  private triggerHookHandler: ActionHandler = async (def, _ctx) => {
+    return {
+      success: false,
+      message: `Not implemented: TriggerHookAction (hookName: ${String(def.params.hookName)})`,
+    };
+  };
+
+  /**
+   * Delegate to custom TypeScript handler
+   * @see Issue #1411
+   */
+  private customHandler: ActionHandler = async (def, ctx) => {
+    const handlerId = def.params.handler as string;
+    const handler = this.customHandlers.get(handlerId);
+
+    if (!handler) {
+      return {
+        success: false,
+        message: `Custom handler not found: ${handlerId}`,
+      };
+    }
+
+    return handler(def, ctx);
+  };
+
+  /**
+   * Execute multiple actions in sequence
+   * @see Issue #1412
+   */
+  private compositeHandler: ActionHandler = async (_def, _ctx) => {
+    return {
+      success: false,
+      message: `Not implemented: CompositeAction`,
+    };
+  };
+}

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -322,6 +322,9 @@ export type {
   ActionHandler,
 } from "./domain/types/ActionTypes";
 
+// Action Interpreter export
+export { ActionInterpreter } from "./domain/services/ActionInterpreter";
+
 // DI Container exports
 export {
   registerCoreServices,

--- a/packages/exocortex/tests/unit/domain/services/ActionInterpreter.test.ts
+++ b/packages/exocortex/tests/unit/domain/services/ActionInterpreter.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Tests for ActionInterpreter - Action execution engine
+ *
+ * Issue #1404: Implement ActionInterpreter base structure
+ * @see https://github.com/kitelev/exocortex/issues/1404
+ *
+ * Tests for:
+ * - Constructor and handler registration
+ * - execute() method
+ * - loadActionDefinition() method
+ * - Error handling for unknown action types
+ */
+
+import { ITripleStore } from "../../../../src/interfaces/ITripleStore";
+import { IUIProvider } from "../../../../src/domain/ports/IUIProvider";
+import { ActionContext } from "../../../../src/domain/types/ActionContext";
+import {
+  ActionResult,
+  ActionDefinition,
+  ActionHandler,
+} from "../../../../src/domain/types/ActionTypes";
+import { ActionInterpreter } from "../../../../src/domain/services/ActionInterpreter";
+
+describe("ActionInterpreter", () => {
+  let mockTripleStore: ITripleStore;
+  let mockUIProvider: IUIProvider;
+  let mockContext: ActionContext;
+
+  beforeEach(() => {
+    mockUIProvider = {
+      showInputModal: jest.fn(),
+      showSelectModal: jest.fn(),
+      showConfirm: jest.fn(),
+      notify: jest.fn(),
+      navigate: jest.fn(),
+      isHeadless: false,
+    };
+
+    mockTripleStore = {
+      add: jest.fn(),
+      remove: jest.fn(),
+      has: jest.fn(),
+      match: jest.fn(),
+      addAll: jest.fn(),
+      removeAll: jest.fn(),
+      clear: jest.fn(),
+      count: jest.fn(),
+      subjects: jest.fn(),
+      predicates: jest.fn(),
+      objects: jest.fn(),
+      beginTransaction: jest.fn(),
+    };
+
+    mockContext = {
+      tripleStore: mockTripleStore,
+      uiProvider: mockUIProvider,
+    };
+  });
+
+  describe("constructor and handler registration", () => {
+    it("should create instance with tripleStore", () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter).toBeInstanceOf(ActionInterpreter);
+    });
+
+    it("should register all 8 built-in handlers on construction", () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      // Check that all 8 Fixed Verbs are registered
+      const expectedHandlers = [
+        "exo-ui:CreateAssetAction",
+        "exo-ui:UpdatePropertyAction",
+        "exo-ui:NavigateAction",
+        "exo-ui:ExecuteSPARQLAction",
+        "exo-ui:ShowModalAction",
+        "exo-ui:TriggerHookAction",
+        "exo-ui:CustomHandlerAction",
+        "exo-ui:CompositeAction",
+      ];
+
+      for (const handlerType of expectedHandlers) {
+        expect(interpreter.hasHandler(handlerType)).toBe(true);
+      }
+    });
+
+    it("should allow registering custom handlers", () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      const customHandler: ActionHandler = async () => ({
+        success: true,
+        message: "Custom handler executed",
+      });
+
+      interpreter.registerCustomHandler("custom:MyAction", customHandler);
+
+      expect(interpreter.hasHandler("custom:MyAction")).toBe(true);
+    });
+  });
+
+  describe("execute() method", () => {
+    it("should return error for unknown action type", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      // Mock loadActionDefinition to return an unknown action type
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "unknown:NonExistentAction",
+        params: {},
+      });
+
+      const result = await interpreter.execute(
+        "https://exocortex.my/actions/unknown-action",
+        mockContext
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Unknown action type");
+      expect(result.message).toContain("unknown:NonExistentAction");
+    });
+
+    it("should execute registered handler with definition and context", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      // Mock the loadActionDefinition to return a known type
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "exo-ui:CreateAssetAction",
+        params: { targetClass: "Task" },
+      });
+
+      const result = await interpreter.execute(
+        "https://exocortex.my/actions/create-task-1",
+        mockContext
+      );
+
+      // Should call handler (stub returns not implemented)
+      expect(result).toBeDefined();
+      expect(typeof result.success).toBe("boolean");
+    });
+
+    it("should pass action definition params to handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      let receivedDefinition: ActionDefinition | undefined;
+      const captureHandler: ActionHandler = async (def, ctx) => {
+        receivedDefinition = def;
+        return { success: true };
+      };
+
+      interpreter.registerCustomHandler("test:CaptureAction", captureHandler);
+
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "test:CaptureAction",
+        params: { key: "value", num: 42 },
+      });
+
+      await interpreter.execute("https://exocortex.my/test/action", mockContext);
+
+      expect(receivedDefinition).toBeDefined();
+      expect(receivedDefinition?.type).toBe("test:CaptureAction");
+      expect(receivedDefinition?.params.key).toBe("value");
+      expect(receivedDefinition?.params.num).toBe(42);
+    });
+
+    it("should pass context to handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      let receivedContext: ActionContext | undefined;
+      const captureHandler: ActionHandler = async (def, ctx) => {
+        receivedContext = ctx;
+        return { success: true };
+      };
+
+      interpreter.registerCustomHandler("test:ContextAction", captureHandler);
+
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "test:ContextAction",
+        params: {},
+      });
+
+      await interpreter.execute("https://exocortex.my/test/ctx", mockContext);
+
+      expect(receivedContext).toBeDefined();
+      expect(receivedContext?.tripleStore).toBe(mockTripleStore);
+      expect(receivedContext?.uiProvider).toBe(mockUIProvider);
+    });
+  });
+
+  describe("loadActionDefinition() method", () => {
+    it("should query triple store for action definition", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      // Mock match to return triples that define an action
+      (mockTripleStore.match as jest.Mock).mockResolvedValue([]);
+
+      try {
+        await (interpreter as any).loadActionDefinition(
+          "https://exocortex.my/actions/test-action"
+        );
+      } catch (e) {
+        // Expected to throw since no action type found
+      }
+
+      // Should have queried the triple store
+      expect(mockTripleStore.match).toHaveBeenCalled();
+    });
+
+    it("should parse action type from triple store results", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      // Mock triple store to return type triple
+      const typeIRI = {
+        termType: "NamedNode" as const,
+        value: "https://exocortex.my/ontology/exo-ui#CreateAssetAction",
+      };
+      const actionIRI = {
+        termType: "NamedNode" as const,
+        value: "https://exocortex.my/actions/create-1",
+      };
+      const rdfType = {
+        termType: "NamedNode" as const,
+        value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+      };
+
+      (mockTripleStore.match as jest.Mock).mockResolvedValue([
+        {
+          subject: actionIRI,
+          predicate: rdfType,
+          object: typeIRI,
+          toString: () => "<action> a <type>",
+        },
+      ]);
+
+      const definition = await (interpreter as any).loadActionDefinition(
+        "https://exocortex.my/actions/create-1"
+      );
+
+      expect(definition.type).toBe("exo-ui:CreateAssetAction");
+    });
+
+    it("should extract params from triple store results", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      const actionIRI = {
+        termType: "NamedNode" as const,
+        value: "https://exocortex.my/actions/create-1",
+      };
+      const typeIRI = {
+        termType: "NamedNode" as const,
+        value: "https://exocortex.my/ontology/exo-ui#CreateAssetAction",
+      };
+      const rdfType = {
+        termType: "NamedNode" as const,
+        value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+      };
+      const targetClassPredicate = {
+        termType: "NamedNode" as const,
+        value: "https://exocortex.my/ontology/exo-ui#targetClass",
+      };
+      const targetClassValue = {
+        termType: "Literal" as const,
+        value: "Task",
+      };
+
+      (mockTripleStore.match as jest.Mock).mockResolvedValue([
+        {
+          subject: actionIRI,
+          predicate: rdfType,
+          object: typeIRI,
+          toString: () => "<action> a <CreateAssetAction>",
+        },
+        {
+          subject: actionIRI,
+          predicate: targetClassPredicate,
+          object: targetClassValue,
+          toString: () => "<action> exo-ui:targetClass Task",
+        },
+      ]);
+
+      const definition = await (interpreter as any).loadActionDefinition(
+        "https://exocortex.my/actions/create-1"
+      );
+
+      expect(definition.params.targetClass).toBe("Task");
+    });
+
+    it("should throw error if action type not found", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      (mockTripleStore.match as jest.Mock).mockResolvedValue([]);
+
+      await expect(
+        (interpreter as any).loadActionDefinition(
+          "https://exocortex.my/actions/unknown"
+        )
+      ).rejects.toThrow("Action type not found");
+    });
+  });
+
+  describe("built-in handlers (stub implementations)", () => {
+    it("should have CreateAssetAction handler that returns not implemented", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "exo-ui:CreateAssetAction",
+        params: { targetClass: "Task" },
+      });
+
+      const result = await interpreter.execute("test:action", mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Not implemented");
+    });
+
+    it("should have UpdatePropertyAction handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter.hasHandler("exo-ui:UpdatePropertyAction")).toBe(true);
+    });
+
+    it("should have NavigateAction handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter.hasHandler("exo-ui:NavigateAction")).toBe(true);
+    });
+
+    it("should have ExecuteSPARQLAction handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter.hasHandler("exo-ui:ExecuteSPARQLAction")).toBe(true);
+    });
+
+    it("should have ShowModalAction handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter.hasHandler("exo-ui:ShowModalAction")).toBe(true);
+    });
+
+    it("should have TriggerHookAction handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter.hasHandler("exo-ui:TriggerHookAction")).toBe(true);
+    });
+
+    it("should have CustomHandlerAction handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter.hasHandler("exo-ui:CustomHandlerAction")).toBe(true);
+    });
+
+    it("should have CompositeAction handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter.hasHandler("exo-ui:CompositeAction")).toBe(true);
+    });
+  });
+
+  describe("hasHandler() method", () => {
+    it("should return true for registered handlers", () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter.hasHandler("exo-ui:CreateAssetAction")).toBe(true);
+    });
+
+    it("should return false for unregistered handlers", () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      expect(interpreter.hasHandler("unknown:Action")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the ActionInterpreter orchestrator for RDF-driven action execution. This is the foundation for declarative UI buttons that execute actions defined in the ontology.

**Closes #1404**

## Changes

- **ActionInterpreter class** with handler registry (8 Fixed Verbs)
- **execute() method** for action dispatch by URI
- **loadActionDefinition() method** to parse RDF actions from triple store
- **Stub implementations** for all 8 handlers (to be implemented in #1405-#1411):
  - CreateAssetAction, UpdatePropertyAction, NavigateAction
  - ExecuteSPARQLAction, ShowModalAction, TriggerHookAction
  - CustomHandlerAction, CompositeAction
- **registerCustomHandler()** escape hatch for TypeScript logic
- **hasHandler()** method for checking registered handlers
- **Export from @exocortex/core** - ActionInterpreter is now part of public API

## Test Plan

- [x] ActionInterpreter compiles
- [x] All 8 handlers registered (verified by hasHandler() tests)
- [x] execute() returns error for unknown type
- [x] Unit test for loadActionDefinition()
- [x] 21 unit tests covering all acceptance criteria

## Technical Details

### Architecture

```
ActionInterpreter
├── handlers: Map<string, ActionHandler>       # Built-in Fixed Verbs
├── customHandlers: Map<string, ActionHandler> # Escape hatch for TS logic
├── execute(actionUri, context) → ActionResult
└── loadActionDefinition(actionUri) → ActionDefinition
```

### Fixed Verbs (8 action types)

| Type | Description | Future Issue |
|------|-------------|--------------|
| CreateAssetAction | Create new asset | #1405 |
| UpdatePropertyAction | Update property | #1406 |
| NavigateAction | Navigate to asset | #1407 |
| ExecuteSPARQLAction | Run SPARQL query | #1408 |
| ShowModalAction | Show modal dialog | #1409 |
| TriggerHookAction | Trigger webhook | #1410 |
| CustomHandlerAction | Delegate to TS handler | #1411 |
| CompositeAction | Multiple actions | #1412 |