### PR TITLE
feat(core): implement CustomHandlerAction + CompositeAction handlers

### DIFF
--- a/packages/exocortex/src/domain/services/ActionInterpreter.ts
+++ b/packages/exocortex/src/domain/services/ActionInterpreter.ts
@@ -693,12 +693,73 @@ export class ActionInterpreter {
 
   /**
    * Execute multiple actions in sequence
-   * @see Issue #1412
+   *
+   * Parameters:
+   * - actions: JSON array of action URIs to execute sequentially
+   *
+   * The handler:
+   * 1. Parses the actions array from JSON string
+   * 2. Executes each action in sequence
+   * 3. Stops on first failure, returning that failure result
+   * 4. Passes data from each action to the next via context.previousResult
+   * 5. Returns success with refresh=true when all actions complete
+   *
+   * @see Issue #1411
+   * @see /Users/kitelev/vault-2025/03 Knowledge/concepts/RDF-Driven Architecture Implementation Plan (Note).md
+   * Phase 3: ActionInterpreter Runtime (lines 1615-1640)
    */
-  private compositeHandler: ActionHandler = async (_def, _ctx) => {
+  private compositeHandler: ActionHandler = async (def, ctx) => {
+    const actionsParam = def.params.actions as string | undefined;
+
+    // Validate actions parameter
+    if (!actionsParam) {
+      return {
+        success: false,
+        message: "CompositeAction requires 'actions' parameter",
+      };
+    }
+
+    // Parse actions array from JSON string
+    let actionUris: string[];
+    try {
+      actionUris = JSON.parse(actionsParam) as string[];
+    } catch (error) {
+      return {
+        success: false,
+        message: `Invalid actions JSON: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    // Validate it's an array
+    if (!Array.isArray(actionUris)) {
+      return {
+        success: false,
+        message: "CompositeAction 'actions' must be a JSON array of action URIs",
+      };
+    }
+
+    // Execute actions sequentially
+    let currentContext = ctx;
+
+    for (const actionUri of actionUris) {
+      const result = await this.execute(actionUri, currentContext);
+
+      if (!result.success) {
+        // Stop on first failure
+        return result;
+      }
+
+      // Pass data to next action via context.previousResult
+      currentContext = {
+        ...currentContext,
+        previousResult: result.data,
+      };
+    }
+
+    // All actions completed successfully
     return {
-      success: false,
-      message: `Not implemented: CompositeAction`,
+      success: true,
+      refresh: true,
     };
   };
 }

--- a/packages/exocortex/src/domain/types/ActionContext.ts
+++ b/packages/exocortex/src/domain/types/ActionContext.ts
@@ -62,4 +62,19 @@ export interface ActionContext {
 
   /** CLI arguments (if running in CLI mode) */
   cliArgs?: Record<string, string>;
+
+  /**
+   * Result data from previous action in CompositeAction sequence.
+   *
+   * When actions are executed sequentially in a CompositeAction,
+   * each action's result.data is passed to the next action via
+   * this property, enabling data flow between actions.
+   *
+   * @example
+   * ```typescript
+   * // Action 2 can access data from Action 1:
+   * const previousData = ctx.previousResult;
+   * ```
+   */
+  previousResult?: unknown;
 }

--- a/packages/exocortex/tests/unit/domain/services/ActionInterpreter.test.ts
+++ b/packages/exocortex/tests/unit/domain/services/ActionInterpreter.test.ts
@@ -1650,4 +1650,314 @@ describe("ActionInterpreter", () => {
       );
     });
   });
+
+  describe("CustomHandlerAction handler (Issue #1411)", () => {
+    it("should find and execute registered custom handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      // Register a custom handler
+      let handlerCalled = false;
+      let receivedDef: ActionDefinition | undefined;
+      let receivedCtx: ActionContext | undefined;
+
+      interpreter.registerCustomHandler("custom:MyHandler", async (def, ctx) => {
+        handlerCalled = true;
+        receivedDef = def;
+        receivedCtx = ctx;
+        return { success: true, data: { customResult: "value" } };
+      });
+
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "exo-ui:CustomHandlerAction",
+        params: {
+          handler: "custom:MyHandler",
+          customParam: "test-value",
+        },
+      });
+
+      const result = await interpreter.execute("test:custom-action", mockContext);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ customResult: "value" });
+      expect(handlerCalled).toBe(true);
+      expect(receivedDef?.params.customParam).toBe("test-value");
+      expect(receivedCtx?.tripleStore).toBe(mockTripleStore);
+    });
+
+    it("should return error if custom handler not found", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "exo-ui:CustomHandlerAction",
+        params: {
+          handler: "custom:NonExistentHandler",
+        },
+      });
+
+      const result = await interpreter.execute("test:custom-action", mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Custom handler not found");
+      expect(result.message).toContain("custom:NonExistentHandler");
+    });
+
+    it("should pass all params from definition to custom handler", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      let capturedParams: Record<string, unknown> = {};
+
+      interpreter.registerCustomHandler("custom:ParamCapture", async (def) => {
+        capturedParams = def.params;
+        return { success: true };
+      });
+
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "exo-ui:CustomHandlerAction",
+        params: {
+          handler: "custom:ParamCapture",
+          param1: "value1",
+          param2: 42,
+          param3: true,
+        },
+      });
+
+      await interpreter.execute("test:custom-action", mockContext);
+
+      expect(capturedParams.param1).toBe("value1");
+      expect(capturedParams.param2).toBe(42);
+      expect(capturedParams.param3).toBe(true);
+    });
+
+    it("should propagate custom handler failure", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      interpreter.registerCustomHandler("custom:FailingHandler", async () => {
+        return { success: false, message: "Custom handler error" };
+      });
+
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "exo-ui:CustomHandlerAction",
+        params: {
+          handler: "custom:FailingHandler",
+        },
+      });
+
+      const result = await interpreter.execute("test:custom-action", mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Custom handler error");
+    });
+  });
+
+  describe("CompositeAction handler (Issue #1411)", () => {
+    it("should execute actions sequentially", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      const executionOrder: string[] = [];
+
+      interpreter.registerCustomHandler("custom:Action1", async () => {
+        executionOrder.push("action1");
+        return { success: true };
+      });
+
+      interpreter.registerCustomHandler("custom:Action2", async () => {
+        executionOrder.push("action2");
+        return { success: true };
+      });
+
+      interpreter.registerCustomHandler("custom:Action3", async () => {
+        executionOrder.push("action3");
+        return { success: true };
+      });
+
+      // Mock loadActionDefinition to return different definitions based on URI
+      const loadActionSpy = jest.spyOn(interpreter as any, "loadActionDefinition");
+      loadActionSpy.mockImplementation(async (uri) => {
+        if (uri === "test:composite-action") {
+          return {
+            type: "exo-ui:CompositeAction",
+            params: {
+              actions: JSON.stringify([
+                "test:action1",
+                "test:action2",
+                "test:action3",
+              ]),
+            },
+          };
+        }
+        if (uri === "test:action1") {
+          return { type: "exo-ui:CustomHandlerAction", params: { handler: "custom:Action1" } };
+        }
+        if (uri === "test:action2") {
+          return { type: "exo-ui:CustomHandlerAction", params: { handler: "custom:Action2" } };
+        }
+        if (uri === "test:action3") {
+          return { type: "exo-ui:CustomHandlerAction", params: { handler: "custom:Action3" } };
+        }
+        throw new Error(`Unknown action: ${uri}`);
+      });
+
+      const result = await interpreter.execute("test:composite-action", mockContext);
+
+      expect(result.success).toBe(true);
+      expect(executionOrder).toEqual(["action1", "action2", "action3"]);
+    });
+
+    it("should stop on first failure", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      const executionOrder: string[] = [];
+
+      interpreter.registerCustomHandler("custom:Action1", async () => {
+        executionOrder.push("action1");
+        return { success: true };
+      });
+
+      interpreter.registerCustomHandler("custom:FailingAction", async () => {
+        executionOrder.push("failing");
+        return { success: false, message: "Action failed!" };
+      });
+
+      interpreter.registerCustomHandler("custom:Action3", async () => {
+        executionOrder.push("action3");
+        return { success: true };
+      });
+
+      const loadActionSpy = jest.spyOn(interpreter as any, "loadActionDefinition");
+      loadActionSpy.mockImplementation(async (uri) => {
+        if (uri === "test:composite-action") {
+          return {
+            type: "exo-ui:CompositeAction",
+            params: {
+              actions: JSON.stringify([
+                "test:action1",
+                "test:failing",
+                "test:action3",
+              ]),
+            },
+          };
+        }
+        if (uri === "test:action1") {
+          return { type: "exo-ui:CustomHandlerAction", params: { handler: "custom:Action1" } };
+        }
+        if (uri === "test:failing") {
+          return { type: "exo-ui:CustomHandlerAction", params: { handler: "custom:FailingAction" } };
+        }
+        if (uri === "test:action3") {
+          return { type: "exo-ui:CustomHandlerAction", params: { handler: "custom:Action3" } };
+        }
+        throw new Error(`Unknown action: ${uri}`);
+      });
+
+      const result = await interpreter.execute("test:composite-action", mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Action failed!");
+      // Action3 should NOT be executed
+      expect(executionOrder).toEqual(["action1", "failing"]);
+    });
+
+    it("should pass data from previous action via context.previousResult", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      let capturedPreviousResult: unknown;
+
+      interpreter.registerCustomHandler("custom:Producer", async () => {
+        return { success: true, data: { producedValue: "from-producer" } };
+      });
+
+      interpreter.registerCustomHandler("custom:Consumer", async (_def, ctx) => {
+        capturedPreviousResult = ctx.previousResult;
+        return { success: true };
+      });
+
+      const loadActionSpy = jest.spyOn(interpreter as any, "loadActionDefinition");
+      loadActionSpy.mockImplementation(async (uri) => {
+        if (uri === "test:composite-action") {
+          return {
+            type: "exo-ui:CompositeAction",
+            params: {
+              actions: JSON.stringify([
+                "test:producer",
+                "test:consumer",
+              ]),
+            },
+          };
+        }
+        if (uri === "test:producer") {
+          return { type: "exo-ui:CustomHandlerAction", params: { handler: "custom:Producer" } };
+        }
+        if (uri === "test:consumer") {
+          return { type: "exo-ui:CustomHandlerAction", params: { handler: "custom:Consumer" } };
+        }
+        throw new Error(`Unknown action: ${uri}`);
+      });
+
+      const result = await interpreter.execute("test:composite-action", mockContext);
+
+      expect(result.success).toBe(true);
+      expect(capturedPreviousResult).toEqual({ producedValue: "from-producer" });
+    });
+
+    it("should return success with refresh true for successful composite execution", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      interpreter.registerCustomHandler("custom:SimpleAction", async () => {
+        return { success: true };
+      });
+
+      const loadActionSpy = jest.spyOn(interpreter as any, "loadActionDefinition");
+      loadActionSpy.mockImplementation(async (uri) => {
+        if (uri === "test:composite-action") {
+          return {
+            type: "exo-ui:CompositeAction",
+            params: {
+              actions: JSON.stringify(["test:simple"]),
+            },
+          };
+        }
+        if (uri === "test:simple") {
+          return { type: "exo-ui:CustomHandlerAction", params: { handler: "custom:SimpleAction" } };
+        }
+        throw new Error(`Unknown action: ${uri}`);
+      });
+
+      const result = await interpreter.execute("test:composite-action", mockContext);
+
+      expect(result.success).toBe(true);
+      expect(result.refresh).toBe(true);
+    });
+
+    it("should handle empty actions array gracefully", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "exo-ui:CompositeAction",
+        params: {
+          actions: JSON.stringify([]),
+        },
+      });
+
+      const result = await interpreter.execute("test:composite-action", mockContext);
+
+      // Empty composite should succeed (no actions to fail)
+      expect(result.success).toBe(true);
+    });
+
+    it("should return error if actions param is not provided", async () => {
+      const interpreter = new ActionInterpreter(mockTripleStore);
+
+      jest.spyOn(interpreter as any, "loadActionDefinition").mockResolvedValue({
+        type: "exo-ui:CompositeAction",
+        params: {
+          // No actions param
+        },
+      });
+
+      const result = await interpreter.execute("test:composite-action", mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("actions");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implement the final two Fixed Verbs for RDF-driven action execution (Phase 3, Handlers 7-8/8):

- **CustomHandlerAction**: Escape hatch for custom TypeScript handlers
- **CompositeAction**: Sequential execution of multiple actions

## Changes

### CustomHandlerAction (Handler #7)
- Already implemented in previous commit (#1410), added comprehensive tests
- Finds and executes registered TypeScript handlers by `handlerId`
- Returns error if handler not found
- Passes all params and context to custom handler

### CompositeAction (Handler #8)
- Executes multiple actions sequentially
- Stops on first failure and returns that failure result
- Passes data between actions via `context.previousResult`
- Returns success with `refresh=true` when all actions complete
- Validates `actions` parameter is present and valid JSON array

### ActionContext Enhancement
- Added `previousResult?: unknown` property to enable data flow between actions in CompositeAction sequences

## Test Coverage

- 4 tests for CustomHandlerAction:
  - Find and execute registered handler
  - Error when handler not found
  - Pass all params to handler
  - Propagate handler failures

- 6 tests for CompositeAction:
  - Execute actions sequentially
  - Stop on first failure
  - Pass data via previousResult
  - Return success with refresh=true
  - Handle empty actions array
  - Error when actions param missing

**All 70 ActionInterpreter tests passing**

## Test Plan
- [x] CustomHandler finds registered handlers
- [x] CompositeAction executes sequentially
- [x] Stops on first failure
- [x] Unit tests (10 new tests)
- [x] Build passes
- [x] Existing tests pass

Closes #1411