### PR TITLE
docs: [Docs] Update documentation for Milestone v1.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1465,10 +1465,156 @@ interface ActionContext {
 | Developer-only | User-configurable |
 | Single platform | CLI + Obsidian |
 
+### Phase 3: ActionInterpreter Runtime (IMPLEMENTED)
+
+The `ActionInterpreter` is the execution engine that brings RDF-Driven Architecture to life. It loads action definitions from the triple store and dispatches them to appropriate handlers.
+
+#### ActionInterpreter Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                        ActionInterpreter Runtime                                 │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│   ┌─────────────────────────────────────────────────────────────────────────┐   │
+│   │                         execute(actionUri, context)                      │   │
+│   │                                                                          │   │
+│   │   1. loadActionDefinition(uri)  ──────────────────────────────┐         │   │
+│   │      ↓                                                         ↓         │   │
+│   │   ┌──────────────────────┐                          ┌────────────────┐  │   │
+│   │   │  Triple Store Query  │  ──→ rdf:type ──→       │ ActionDefinition│  │   │
+│   │   │  ?action ?p ?o       │  ──→ exo-ui:* ──→       │ {type, params}  │  │   │
+│   │   └──────────────────────┘                          └────────────────┘  │   │
+│   │                                                               ↓          │   │
+│   │   2. Find handler for type                                    ↓          │   │
+│   │      ↓                                                                   │   │
+│   │   ┌────────────────────────────────────────────────────────────────┐    │   │
+│   │   │                     Handler Registry                            │    │   │
+│   │   │  ┌─────────────────────┐  ┌─────────────────────────────────┐  │    │   │
+│   │   │  │  Built-in Handlers  │  │      Custom Handlers            │  │    │   │
+│   │   │  │  (Fixed Verbs)      │  │   (TypeScript escape hatch)     │  │    │   │
+│   │   │  └─────────────────────┘  └─────────────────────────────────┘  │    │   │
+│   │   └────────────────────────────────────────────────────────────────┘    │   │
+│   │                                                               ↓          │   │
+│   │   3. Execute handler(definition, context)                     ↓          │   │
+│   │      ↓                                                                   │   │
+│   │   ┌──────────────────────────────────────────────────────────────────┐  │   │
+│   │   │                      ActionResult                                 │  │   │
+│   │   │  { success, message?, navigateTo?, refresh?, data? }             │  │   │
+│   │   └──────────────────────────────────────────────────────────────────┘  │   │
+│   └─────────────────────────────────────────────────────────────────────────┘   │
+│                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+#### Complete Fixed Verbs (8 Types)
+
+| Verb | Handler | Parameters | Description |
+|------|---------|------------|-------------|
+| `CreateAssetAction` | `createAssetHandler` | `targetClass`, `template?`, `location?` | Creates new asset using GenericAssetCreationService |
+| `UpdatePropertyAction` | `updatePropertyHandler` | `targetProperty`, `targetValue`, `targetAsset?` | Updates frontmatter property on current or specified asset |
+| `NavigateAction` | `navigateHandler` | `target` (URI or SPARQL query) | Navigates to asset by URI or first SPARQL result |
+| `ExecuteSPARQLAction` | `executeSparqlHandler` | `query` | Executes SPARQL SELECT query and returns results |
+| `ShowModalAction` | `showModalHandler` | `modalType`, `modalParams`, `Action_cliAlternative?` | Shows input/select/confirm modal (throws HeadlessError in CLI) |
+| `TriggerHookAction` | `triggerHookHandler` | `hookName`, `payload?` | Dispatches webhook event via WebhookService |
+| `CustomHandlerAction` | `customHandler` | `handler` (handler ID) | Delegates to registered TypeScript handler |
+| `CompositeAction` | `compositeHandler` | `actions` (JSON array of URIs) | Executes actions sequentially, passes data via `ctx.previousResult` |
+
+#### Usage Example
+
+```typescript
+import { ActionInterpreter } from 'exocortex';
+
+// Initialize with dependencies
+const interpreter = new ActionInterpreter(
+  tripleStore,
+  assetCreationService,
+  vaultAdapter,
+  fileSystem,
+  webhookService,
+  uiProvider
+);
+
+// Register custom handler for specialized logic
+interpreter.registerCustomHandler('custom:ExportProject', async (def, ctx) => {
+  const projectId = def.params.projectId as string;
+  const format = def.params.format as string || 'json';
+
+  // Custom export logic
+  const exportData = await exportProject(projectId, format);
+
+  return {
+    success: true,
+    data: { exportedFile: exportData.path },
+    message: `Project exported to ${exportData.path}`
+  };
+});
+
+// Execute action defined in RDF
+const result = await interpreter.execute(
+  'https://exocortex.my/actions/create-weekly-task',
+  {
+    tripleStore,
+    uiProvider: obsidianUIProvider,
+    currentAsset: activeFile
+  }
+);
+```
+
+#### HeadlessError: CLI Mode Support
+
+When actions require UI interaction but run in CLI mode:
+
+```typescript
+// CreateAssetAction in CLI mode without --location throws:
+// HeadlessError: "CreateAssetAction without location" requires UI.
+//   CLI alternative: --location <path>
+
+// ShowModalAction always throws in CLI mode:
+// HeadlessError: "ShowModalAction" requires UI.
+//   CLI alternative: Use appropriate CLI arguments
+
+// Solution: Actions can specify Action_cliAlternative in RDF
+// exo-ui:myAction exo-ui:Action_cliAlternative "--value <string>" .
+```
+
+#### CompositeAction Data Flow
+
+```
+Action 1          Action 2              Action 3
+   │                 │                     │
+   │ execute()       │                     │
+   ↓                 │                     │
+┌──────────┐        │                     │
+│ result = │        │                     │
+│ {        │        │                     │
+│  success │        │                     │
+│  data: X │─────────→ ctx.previousResult │
+│ }        │        │     = X             │
+└──────────┘        │                     │
+                    ↓                     │
+               ┌──────────┐              │
+               │ result = │              │
+               │ {        │              │
+               │  data: Y │──────────────→ ctx.previousResult
+               │ }        │              │     = Y
+               └──────────┘              │
+                                         ↓
+                                    ┌──────────┐
+                                    │ result = │
+                                    │ {        │
+                                    │  refresh │
+                                    │ }        │
+                                    └──────────┘
+```
+
 ### Related Files
 
-- `packages/exocortex/src/domain/ports/IUIProvider.ts` — Interface definition
-- `packages/exocortex/src/domain/types/ActionContext.ts` — Context type
+- `packages/exocortex/src/domain/services/ActionInterpreter.ts` — Main implementation
+- `packages/exocortex/src/domain/types/ActionTypes.ts` — Type definitions
+- `packages/exocortex/src/domain/types/ActionContext.ts` — Context interface
+- `packages/exocortex/src/domain/ports/IUIProvider.ts` — UI abstraction interface
+- `packages/exocortex/tests/unit/domain/services/ActionInterpreter.test.ts` — 312 lines of tests
 - `exocortex-public-ontologies/exo-ui/` — UI ontology (planned)
 
 ---
@@ -1543,6 +1689,7 @@ graph TB
 | 1.1 | 2025-11-26 | Added Error Handling section (#438) |
 | 1.2 | 2025-11-29 | Documented CommandVisibility domain segregation (#468) |
 | 1.3 | 2026-01-07 | Added RDF-Driven Architecture section (Milestone v1.0 #1401) |
+| 1.4 | 2026-01-07 | Added ActionInterpreter Runtime documentation (Issue #1414) |
 
 ---
 

--- a/packages/exocortex/README.md
+++ b/packages/exocortex/README.md
@@ -305,6 +305,155 @@ export interface IFileSystemAdapter {
 
 See `@exocortex/cli` package for Node.js implementation example.
 
+## ActionInterpreter: RDF-Driven Action Execution
+
+The `ActionInterpreter` is the core of the declarative UI system. Actions are defined in RDF using the `exo-ui` ontology, and this interpreter loads and executes them.
+
+### Fixed Verbs (8 Built-in Action Types)
+
+| Action Type | Description |
+|-------------|-------------|
+| `CreateAssetAction` | Create new asset from template |
+| `UpdatePropertyAction` | Update asset property |
+| `NavigateAction` | Navigate to asset or SPARQL query result |
+| `ExecuteSPARQLAction` | Execute SPARQL query |
+| `ShowModalAction` | Show modal dialog (input, select, confirm) |
+| `TriggerHookAction` | Trigger external webhook |
+| `CustomHandlerAction` | Delegate to registered TypeScript handler |
+| `CompositeAction` | Execute multiple actions in sequence |
+
+### Basic Usage
+
+```typescript
+import { ActionInterpreter, ActionContext, ITripleStore, IUIProvider } from 'exocortex';
+
+// Create interpreter with dependencies
+const interpreter = new ActionInterpreter(
+  tripleStore,           // Required: ITripleStore for RDF queries
+  assetCreationService,  // Optional: For CreateAssetAction
+  vaultAdapter,          // Optional: For UpdatePropertyAction
+  fileSystem,            // Optional: For NavigateAction
+  webhookService,        // Optional: For TriggerHookAction
+  uiProvider             // Optional: Default IUIProvider
+);
+
+// Execute action by URI
+const context: ActionContext = {
+  tripleStore: tripleStore,
+  uiProvider: obsidianUIProvider,
+  currentAsset: currentFile,
+  cliArgs: { label: 'My Task' }  // For CLI mode
+};
+
+const result = await interpreter.execute(
+  'https://exocortex.my/actions/create-task-1',
+  context
+);
+
+if (result.success) {
+  console.log('Action completed', result.navigateTo, result.data);
+} else {
+  console.error('Action failed:', result.message);
+}
+```
+
+### Custom Handlers (Escape Hatch)
+
+Register custom TypeScript handlers for specialized logic:
+
+```typescript
+// Register custom handler
+interpreter.registerCustomHandler('custom:SyncToRemote', async (def, ctx) => {
+  const projectId = def.params.projectId as string;
+
+  // Custom sync logic
+  await syncProjectToRemote(projectId);
+
+  return {
+    success: true,
+    message: 'Project synced successfully',
+    data: { projectId, syncedAt: new Date().toISOString() }
+  };
+});
+
+// Check if handler exists
+if (interpreter.hasHandler('custom:SyncToRemote')) {
+  // Handler is registered
+}
+```
+
+### Headless Mode (CLI)
+
+The ActionInterpreter supports both Obsidian (interactive) and CLI (headless) modes:
+
+```typescript
+// In CLI mode, check isHeadless and use cliArgs
+async function handleCreateTask(ctx: ActionContext): Promise<void> {
+  if (ctx.uiProvider.isHeadless) {
+    // CLI mode: use command-line arguments
+    const label = ctx.cliArgs?.label;
+    if (!label) {
+      throw new HeadlessError(
+        'CreateAssetAction without label',
+        'Use --label <name> argument'
+      );
+    }
+    // Create with label from CLI
+  } else {
+    // Obsidian mode: show interactive modal
+    const label = await ctx.uiProvider.showInputModal({
+      title: 'Enter task label',
+      placeholder: 'Task name...'
+    });
+  }
+}
+```
+
+### CompositeAction: Chaining Actions
+
+Execute multiple actions in sequence, passing data between them:
+
+```typescript
+// Define composite action in RDF
+// exo-ui:myComposite a exo-ui:CompositeAction ;
+//   exo-ui:actions '["action:step1", "action:step2", "action:step3"]' .
+
+// Each action's result.data is passed to next via ctx.previousResult
+interpreter.registerCustomHandler('custom:ProcessData', async (def, ctx) => {
+  const previousData = ctx.previousResult as { value: number };
+  const newValue = previousData.value * 2;
+
+  return {
+    success: true,
+    data: { value: newValue }  // Passed to next action
+  };
+});
+```
+
+### ActionResult Interface
+
+```typescript
+interface ActionResult {
+  success: boolean;      // Whether action succeeded
+  message?: string;      // Success/error message
+  navigateTo?: IFile;    // Asset to navigate to after action
+  refresh?: boolean;     // Whether to refresh UI
+  data?: unknown;        // Data returned by action (for composites)
+}
+```
+
+### ActionContext Interface
+
+```typescript
+interface ActionContext {
+  currentAsset?: IFile;              // Current file (if any)
+  tripleStore: ITripleStore;         // For SPARQL queries
+  uiProvider: IUIProvider;           // UI abstraction
+  cliArgs?: Record<string, string>;  // CLI arguments (headless mode)
+  previousResult?: unknown;          // Data from previous action in composite
+}
+```
+
 ## Constants
 
 ### AssetClass


### PR DESCRIPTION
## Summary
- Documents ActionInterpreter runtime for Phase 3 of RDF-Driven Architecture
- Adds API documentation, usage examples, and architecture diagrams
- Documents all 8 Fixed Verbs, custom handlers, and headless mode support

## Changes

### packages/exocortex/README.md
- Added ActionInterpreter section with:
  - Overview of 8 Fixed Verbs (action types)
  - Basic usage example with constructor parameters
  - Custom handler registration (`registerCustomHandler`)
  - Headless mode (CLI) support with `HeadlessError`
  - `CompositeAction` data flow via `ctx.previousResult`
  - `ActionResult` and `ActionContext` interface documentation

### ARCHITECTURE.md
- Added **Phase 3: ActionInterpreter Runtime (IMPLEMENTED)** section
- Runtime architecture diagram (execute flow)
- Complete Fixed Verbs table with handlers, parameters, description
- Usage example with custom handler registration
- HeadlessError documentation for CLI mode
- CompositeAction data flow diagram
- Related files list including test coverage (312 lines)
- Updated revision history (v1.4)

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] Documentation changes are markdown only - no code changes
- [x] All code examples are syntactically correct TypeScript
- [x] Cross-links between docs work

Closes #1414