### PR TITLE
feat(plugin): create RdfButtonGroupsBuilder for RDF-driven buttons

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/RdfButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/RdfButtonGroupsBuilder.ts
@@ -1,0 +1,388 @@
+/**
+ * RdfButtonGroupsBuilder
+ *
+ * Loads button groups and buttons from RDF definitions and filters by conditions.
+ * Part of the RDF-Driven Architecture implementation for Milestone v1.3.
+ *
+ * This builder queries the triple store for ButtonGroup and Button instances,
+ * evaluates visibility conditions, and builds ActionButton arrays ready for rendering.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1417
+ * @module presentation/builders
+ * @since 1.3.0
+ */
+
+import { SPARQLQueryService } from "@plugin/application/services/SPARQLQueryService";
+import { LoggerFactory } from "@plugin/adapters/logging/LoggerFactory";
+import type { ILogger, SolutionMapping } from "exocortex";
+import type { ActionButton, ButtonGroup } from "@plugin/presentation/components/ActionButtonsGroup";
+
+/**
+ * Interface for executing actions based on RDF action URIs.
+ *
+ * ActionInterpreter is responsible for translating action URIs
+ * (like `ems-ui:StartAction`) into actual operations on assets.
+ *
+ * @see Issue #1439 for ActionInterpreter implementation
+ */
+export interface ActionInterpreter {
+  /**
+   * Execute an action by its URI with given context.
+   *
+   * @param actionUri - URI of the action to execute (e.g., `ems-ui:StartAction`)
+   * @param context - Execution context containing asset URI and other parameters
+   * @returns Promise resolving to action result
+   */
+  execute(actionUri: string, context: ActionContext): Promise<ActionResult>;
+}
+
+/**
+ * Context passed to action execution.
+ */
+export interface ActionContext {
+  /** URI of the current asset the action operates on */
+  currentAsset: string;
+}
+
+/**
+ * Result of an action execution.
+ */
+export interface ActionResult {
+  /** Whether the action succeeded */
+  success: boolean;
+  /** Optional navigation target after action */
+  navigateTo?: string;
+  /** Optional error message if action failed */
+  error?: string;
+}
+
+/**
+ * Interface for evaluating button visibility conditions.
+ *
+ * ConditionEvaluator checks SPARQL-based conditions to determine
+ * whether a button should be visible for the current asset.
+ *
+ * @see Issue #1405 for ConditionEvaluator implementation
+ */
+export interface ConditionEvaluator {
+  /**
+   * Evaluate a condition for the given asset.
+   *
+   * @param conditionUri - URI of the condition to evaluate
+   * @param assetUri - URI of the asset to check against
+   * @returns Promise resolving to true if condition is met
+   */
+  evaluate(conditionUri: string, assetUri: string): Promise<boolean>;
+}
+
+/**
+ * Internal representation of a button group definition from RDF.
+ */
+interface GroupDef {
+  uri: string;
+  label: string;
+  order?: string;
+}
+
+/**
+ * Internal representation of a button definition from RDF.
+ */
+interface ButtonDef {
+  uri: string;
+  label: string;
+  icon?: string;
+  variant?: string;
+  order?: string;
+  action: string;
+  condition?: string;
+  tooltip?: string;
+}
+
+/**
+ * RdfButtonGroupsBuilder loads button groups from RDF and filters by conditions.
+ *
+ * Architecture:
+ * - Queries triple store for ButtonGroup instances using SPARQL
+ * - For each group, queries Button instances belonging to that group
+ * - Evaluates visibility conditions using ConditionEvaluator
+ * - Builds onClick handlers that delegate to ActionInterpreter
+ *
+ * @example
+ * ```typescript
+ * const builder = new RdfButtonGroupsBuilder(
+ *   sparqlService,
+ *   actionInterpreter,
+ *   conditionEvaluator
+ * );
+ * const groups = await builder.buildButtonGroups(assetUri);
+ * // groups is ready to pass to ActionButtonsGroup component
+ * ```
+ */
+export class RdfButtonGroupsBuilder {
+  private sparqlService: SPARQLQueryService;
+  private actionInterpreter: ActionInterpreter;
+  private conditionEvaluator: ConditionEvaluator;
+  private logger: ILogger;
+
+  /**
+   * SPARQL query to retrieve all button groups from RDF.
+   */
+  private static readonly BUTTON_GROUPS_QUERY = `
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX exo-ui: <https://exocortex.my/ontology/exo-ui#>
+
+    SELECT ?group ?label ?order
+    WHERE {
+      ?group a exo-ui:ButtonGroup .
+      ?group rdfs:label ?label .
+      OPTIONAL { ?group exo-ui:ButtonGroup_order ?order }
+    }
+    ORDER BY ?order
+  `;
+
+  /**
+   * SPARQL query template to retrieve buttons for a specific group.
+   * Use buildButtonsQuery() to generate the actual query.
+   */
+  private static readonly BUTTONS_QUERY_TEMPLATE = `
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX exo-ui: <https://exocortex.my/ontology/exo-ui#>
+
+    SELECT ?button ?label ?icon ?variant ?order ?action ?condition ?tooltip
+    WHERE {
+      ?button a exo-ui:Button .
+      ?button exo-ui:Button_group <GROUP_URI> .
+      ?button exo-ui:Button_label ?label .
+      ?button exo-ui:Button_action ?action .
+      OPTIONAL { ?button exo-ui:Button_icon ?icon }
+      OPTIONAL { ?button exo-ui:Button_variant ?variant }
+      OPTIONAL { ?button exo-ui:Button_order ?order }
+      OPTIONAL { ?button exo-ui:Button_condition ?condition }
+      OPTIONAL { ?button exo-ui:Button_tooltip ?tooltip }
+    }
+    ORDER BY ?order
+  `;
+
+  constructor(
+    sparqlService: SPARQLQueryService,
+    actionInterpreter: ActionInterpreter,
+    conditionEvaluator: ConditionEvaluator,
+  ) {
+    this.sparqlService = sparqlService;
+    this.actionInterpreter = actionInterpreter;
+    this.conditionEvaluator = conditionEvaluator;
+    this.logger = LoggerFactory.create("RdfButtonGroupsBuilder");
+  }
+
+  /**
+   * Build button groups for the given asset.
+   *
+   * This method:
+   * 1. Loads all button groups from RDF
+   * 2. For each group, loads and filters buttons by condition
+   * 3. Returns only groups with at least one visible button
+   *
+   * @param assetUri - URI of the asset to build buttons for
+   * @returns Array of button groups with visible buttons
+   */
+  async buildButtonGroups(assetUri: string): Promise<ButtonGroup[]> {
+    try {
+      this.logger.debug("Building button groups for asset", { assetUri });
+
+      // 1. Load all button groups
+      const groupDefs = await this.loadButtonGroups();
+
+      // 2. For each group, load and filter buttons
+      const result: ButtonGroup[] = [];
+
+      for (const groupDef of groupDefs) {
+        const buttons = await this.loadButtonsForGroup(groupDef.uri, assetUri);
+
+        if (buttons.length > 0) {
+          result.push({
+            id: groupDef.uri,
+            title: groupDef.label,
+            buttons,
+          });
+        }
+      }
+
+      this.logger.debug("Built button groups", {
+        assetUri,
+        groupCount: result.length,
+      });
+
+      return result;
+    } catch (err) {
+      this.logger.error(`Failed to build button groups: ${String(err)}`);
+      return [];
+    }
+  }
+
+  /**
+   * Load all button group definitions from RDF.
+   *
+   * @returns Array of group definitions
+   */
+  private async loadButtonGroups(): Promise<GroupDef[]> {
+    try {
+      const results = await this.sparqlService.query(
+        RdfButtonGroupsBuilder.BUTTON_GROUPS_QUERY,
+      );
+
+      return results
+        .map((result) => this.parseGroupResult(result))
+        .filter((def): def is GroupDef => def !== null);
+    } catch (err) {
+      this.logger.error(`Failed to load button groups: ${String(err)}`);
+      return [];
+    }
+  }
+
+  /**
+   * Parse a SPARQL result row into a GroupDef.
+   */
+  private parseGroupResult(result: SolutionMapping): GroupDef | null {
+    const uri = this.extractValueFromMapping(result, "group");
+    const label = this.extractValueFromMapping(result, "label");
+
+    if (!uri || !label) {
+      return null;
+    }
+
+    return {
+      uri,
+      label,
+      order: this.extractValueFromMapping(result, "order"),
+    };
+  }
+
+  /**
+   * Load buttons for a specific group and filter by condition.
+   *
+   * @param groupUri - URI of the button group
+   * @param assetUri - URI of the current asset (for condition evaluation)
+   * @returns Array of ActionButton objects for visible buttons
+   */
+  private async loadButtonsForGroup(
+    groupUri: string,
+    assetUri: string,
+  ): Promise<ActionButton[]> {
+    try {
+      // Build query with specific group URI
+      const query = this.buildButtonsQuery(groupUri);
+      const results = await this.sparqlService.query(query);
+
+      const buttonDefs = results
+        .map((result) => this.parseButtonResult(result))
+        .filter((def): def is ButtonDef => def !== null);
+
+      // Filter by condition and build ActionButton objects
+      const buttons: ActionButton[] = [];
+
+      for (const def of buttonDefs) {
+        // Check visibility condition
+        if (def.condition) {
+          try {
+            const visible = await this.conditionEvaluator.evaluate(
+              def.condition,
+              assetUri,
+            );
+            if (!visible) {
+              continue;
+            }
+          } catch (err) {
+            this.logger.warn(
+              `Condition evaluation failed for button ${def.uri}: ${String(err)}`,
+            );
+            continue; // Skip button if condition evaluation fails
+          }
+        }
+
+        buttons.push(this.buildActionButton(def, assetUri));
+      }
+
+      return buttons;
+    } catch (err) {
+      this.logger.error(
+        `Failed to load buttons for group ${groupUri}: ${String(err)}`,
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Build SPARQL query for buttons in a specific group.
+   */
+  private buildButtonsQuery(groupUri: string): string {
+    return RdfButtonGroupsBuilder.BUTTONS_QUERY_TEMPLATE.replace(
+      "GROUP_URI",
+      groupUri,
+    );
+  }
+
+  /**
+   * Parse a SPARQL result row into a ButtonDef.
+   */
+  private parseButtonResult(result: SolutionMapping): ButtonDef | null {
+    const uri = this.extractValueFromMapping(result, "button");
+    const label = this.extractValueFromMapping(result, "label");
+    const action = this.extractValueFromMapping(result, "action");
+
+    if (!uri || !label || !action) {
+      return null;
+    }
+
+    return {
+      uri,
+      label,
+      icon: this.extractValueFromMapping(result, "icon"),
+      variant: this.extractValueFromMapping(result, "variant"),
+      order: this.extractValueFromMapping(result, "order"),
+      action,
+      condition: this.extractValueFromMapping(result, "condition"),
+      tooltip: this.extractValueFromMapping(result, "tooltip"),
+    };
+  }
+
+  /**
+   * Build an ActionButton from a button definition.
+   */
+  private buildActionButton(def: ButtonDef, assetUri: string): ActionButton {
+    const actionInterpreter = this.actionInterpreter;
+
+    return {
+      id: def.uri,
+      label: def.label,
+      icon: def.icon,
+      variant: (def.variant as ActionButton["variant"]) || "secondary",
+      tooltip: def.tooltip,
+      onClick: async () => {
+        await actionInterpreter.execute(def.action, { currentAsset: assetUri });
+      },
+    };
+  }
+
+  /**
+   * Extract string value from SolutionMapping.
+   */
+  private extractValueFromMapping(
+    mapping: SolutionMapping,
+    variable: string,
+  ): string | undefined {
+    const value = mapping.get(variable);
+
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+
+    // IRI or Literal or BlankNode all have value property
+    if (typeof value === "object" && "value" in value) {
+      return String((value as { value: unknown }).value);
+    }
+
+    return String(value);
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
@@ -9,6 +9,10 @@ export interface ActionButton {
   onClick: () => void | Promise<void>;
   variant?: "primary" | "secondary" | "success" | "warning" | "danger";
   visible?: boolean;
+  /** Lucide icon name (optional) */
+  icon?: string;
+  /** Tooltip text (optional) */
+  tooltip?: string;
 }
 
 /**

--- a/packages/obsidian-plugin/tests/unit/builders/RdfButtonGroupsBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/RdfButtonGroupsBuilder.test.ts
@@ -1,0 +1,552 @@
+/**
+ * RdfButtonGroupsBuilder Unit Tests
+ *
+ * Tests for RDF-driven button groups loading with condition filtering.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1417
+ */
+
+import "reflect-metadata";
+import {
+  RdfButtonGroupsBuilder,
+  ActionInterpreter,
+  ConditionEvaluator,
+} from "../../../src/presentation/builders/RdfButtonGroupsBuilder";
+import { SPARQLQueryService } from "../../../src/application/services/SPARQLQueryService";
+import { App } from "obsidian";
+
+/**
+ * Helper to create a mock SolutionMapping that behaves like the real class.
+ * The real SolutionMapping uses .get(variableName) to retrieve values.
+ */
+function createMockSolutionMapping(bindings: Record<string, string | undefined>): { get: (key: string) => { value: string } | undefined } {
+  return {
+    get: (key: string) => {
+      const value = bindings[key];
+      if (value === undefined) {
+        return undefined;
+      }
+      return { value };
+    },
+  };
+}
+
+// Mock SPARQLQueryService
+jest.mock("../../../src/application/services/SPARQLQueryService", () => ({
+  SPARQLQueryService: jest.fn().mockImplementation(() => ({
+    initialize: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn().mockResolvedValue([]),
+    refresh: jest.fn().mockResolvedValue(undefined),
+    dispose: jest.fn(),
+    getTripleStore: jest.fn(),
+  })),
+}));
+
+// Mock LoggerFactory - use arrow function without jest.fn() to survive clearAllMocks
+jest.mock("../../../src/adapters/logging/LoggerFactory", () => ({
+  LoggerFactory: {
+    create: () => ({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+describe("RdfButtonGroupsBuilder", () => {
+  let mockApp: App;
+  let mockSparqlService: jest.Mocked<SPARQLQueryService>;
+  let mockActionInterpreter: jest.Mocked<ActionInterpreter>;
+  let mockConditionEvaluator: jest.Mocked<ConditionEvaluator>;
+  let builder: RdfButtonGroupsBuilder;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockApp = {
+      vault: {
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        getName: jest.fn().mockReturnValue("Test Vault"),
+      },
+      metadataCache: {
+        getFileCache: jest.fn(),
+      },
+      workspace: {
+        getActiveFile: jest.fn(),
+      },
+    } as unknown as App;
+
+    mockSparqlService = new SPARQLQueryService(
+      mockApp,
+    ) as jest.Mocked<SPARQLQueryService>;
+    mockSparqlService.query = jest.fn().mockResolvedValue([]);
+    mockSparqlService.initialize = jest.fn().mockResolvedValue(undefined);
+
+    mockActionInterpreter = {
+      execute: jest.fn().mockResolvedValue({ success: true }),
+    } as unknown as jest.Mocked<ActionInterpreter>;
+
+    mockConditionEvaluator = {
+      evaluate: jest.fn().mockResolvedValue(true),
+    } as unknown as jest.Mocked<ConditionEvaluator>;
+
+    builder = new RdfButtonGroupsBuilder(
+      mockSparqlService,
+      mockActionInterpreter,
+      mockConditionEvaluator,
+    );
+  });
+
+  describe("constructor", () => {
+    it("should create instance with sparql service, action interpreter, and condition evaluator", () => {
+      expect(builder).toBeInstanceOf(RdfButtonGroupsBuilder);
+    });
+  });
+
+  describe("buildButtonGroups", () => {
+    it("should return empty array when no button groups in RDF", async () => {
+      mockSparqlService.query.mockResolvedValue([]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups).toEqual([]);
+    });
+
+    it("should load button groups from RDF", async () => {
+      // First query: button groups
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        // Second query: buttons for StatusGroup
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:StartButton",
+            label: "Start",
+            icon: "play",
+            variant: "primary",
+            order: "1",
+            action: "test:StartAction",
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].id).toBe("test:StatusGroup");
+      expect(groups[0].title).toBe("Status");
+    });
+
+    it("should filter buttons by condition", async () => {
+      // First query: button groups
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        // Second query: buttons with conditions
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:StartButton",
+            label: "Start",
+            action: "test:StartAction",
+            condition: "test:IsToDoCondition",
+          }),
+          createMockSolutionMapping({
+            button: "test:DoneButton",
+            label: "Done",
+            action: "test:DoneAction",
+            condition: "test:IsDoingCondition",
+          }),
+        ]);
+
+      // First button condition: true, second: false
+      mockConditionEvaluator.evaluate
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].buttons).toHaveLength(1);
+      expect(groups[0].buttons[0].label).toBe("Start");
+    });
+
+    it("should include buttons without condition (always visible)", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:MaintenanceGroup",
+            label: "Maintenance",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:CleanupButton",
+            label: "Cleanup",
+            action: "test:CleanupAction",
+            // No condition - always visible
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].buttons).toHaveLength(1);
+      expect(groups[0].buttons[0].label).toBe("Cleanup");
+    });
+
+    it("should exclude empty groups (all buttons filtered)", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:StartButton",
+            label: "Start",
+            action: "test:StartAction",
+            condition: "test:NeverTrueCondition",
+          }),
+        ]);
+
+      // All conditions false
+      mockConditionEvaluator.evaluate.mockResolvedValue(false);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups).toHaveLength(0);
+    });
+
+    it("should preserve button order from RDF", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:Button3",
+            label: "Third",
+            action: "test:Action3",
+            order: "3",
+          }),
+          createMockSolutionMapping({
+            button: "test:Button1",
+            label: "First",
+            action: "test:Action1",
+            order: "1",
+          }),
+          createMockSolutionMapping({
+            button: "test:Button2",
+            label: "Second",
+            action: "test:Action2",
+            order: "2",
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      // Buttons should be sorted by order from SPARQL ORDER BY
+      expect(groups[0].buttons[0].label).toBe("Third");
+      expect(groups[0].buttons[1].label).toBe("First");
+      expect(groups[0].buttons[2].label).toBe("Second");
+    });
+  });
+
+  describe("onClick executes ActionInterpreter", () => {
+    it("should execute action through ActionInterpreter when button clicked", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:StartButton",
+            label: "Start",
+            action: "test:StartAction",
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+      const startButton = groups[0].buttons[0];
+
+      // Click the button
+      await startButton.onClick();
+
+      expect(mockActionInterpreter.execute).toHaveBeenCalledWith(
+        "test:StartAction",
+        { currentAsset: "test:asset1" },
+      );
+    });
+
+    it("should pass currentAsset context to ActionInterpreter", async () => {
+      const assetUri = "https://exocortex.my/vault/my-task.md";
+
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:DoneButton",
+            label: "Done",
+            action: "test:MarkDoneAction",
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups(assetUri);
+      await groups[0].buttons[0].onClick();
+
+      expect(mockActionInterpreter.execute).toHaveBeenCalledWith(
+        "test:MarkDoneAction",
+        { currentAsset: assetUri },
+      );
+    });
+  });
+
+  describe("button properties", () => {
+    it("should parse button variant from RDF", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:DangerButton",
+            label: "Delete",
+            action: "test:DeleteAction",
+            variant: "danger",
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups[0].buttons[0].variant).toBe("danger");
+    });
+
+    it("should default variant to secondary when not specified", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:Button",
+            label: "Action",
+            action: "test:Action",
+            // No variant
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups[0].buttons[0].variant).toBe("secondary");
+    });
+
+    it("should parse icon from RDF", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:PlayButton",
+            label: "Play",
+            action: "test:PlayAction",
+            icon: "play-circle",
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups[0].buttons[0].icon).toBe("play-circle");
+    });
+
+    it("should parse tooltip from RDF", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:HelpButton",
+            label: "Help",
+            action: "test:HelpAction",
+            tooltip: "Click for help",
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups[0].buttons[0].tooltip).toBe("Click for help");
+    });
+  });
+
+  describe("multiple button groups", () => {
+    it("should load multiple button groups", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+          createMockSolutionMapping({
+            group: "test:PlanningGroup",
+            label: "Planning",
+            order: "2",
+          }),
+        ])
+        // Buttons for StatusGroup
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:StartButton",
+            label: "Start",
+            action: "test:StartAction",
+          }),
+        ])
+        // Buttons for PlanningGroup
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:PlanButton",
+            label: "Plan Today",
+            action: "test:PlanAction",
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups).toHaveLength(2);
+      expect(groups[0].title).toBe("Status");
+      expect(groups[1].title).toBe("Planning");
+    });
+
+    it("should preserve group order from RDF", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:ThirdGroup",
+            label: "Third",
+            order: "3",
+          }),
+          createMockSolutionMapping({
+            group: "test:FirstGroup",
+            label: "First",
+            order: "1",
+          }),
+          createMockSolutionMapping({
+            group: "test:SecondGroup",
+            label: "Second",
+            order: "2",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:B1",
+            label: "B1",
+            action: "test:A1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:B2",
+            label: "B2",
+            action: "test:A2",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:B3",
+            label: "B3",
+            action: "test:A3",
+          }),
+        ]);
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      // Groups should be in order from SPARQL ORDER BY
+      expect(groups[0].title).toBe("Third");
+      expect(groups[1].title).toBe("First");
+      expect(groups[2].title).toBe("Second");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle SPARQL query errors gracefully", async () => {
+      mockSparqlService.query.mockRejectedValue(new Error("SPARQL error"));
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      expect(groups).toEqual([]);
+    });
+
+    it("should handle condition evaluation errors gracefully", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "test:StatusGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "test:Button",
+            label: "Action",
+            action: "test:Action",
+            condition: "test:BadCondition",
+          }),
+        ]);
+
+      mockConditionEvaluator.evaluate.mockRejectedValue(
+        new Error("Condition error"),
+      );
+
+      const groups = await builder.buildButtonGroups("test:asset1");
+
+      // Button with failed condition should be excluded
+      expect(groups).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `RdfButtonGroupsBuilder` that loads button groups from RDF triple store
- Filters buttons by conditions using `ConditionEvaluator`
- `onClick` handlers execute `ActionInterpreter` with asset context
- Extends `ActionButton` interface with `icon` and `tooltip` properties

## Test Plan
- [x] Loads ButtonGroups from RDF
- [x] Filters buttons by condition
- [x] onClick executes ActionInterpreter
- [x] Unit tests with mock SPARQL results (26 tests)

## Technical Details
- Uses `SPARQLQueryService` for querying button groups and buttons
- SPARQL queries follow ORDER BY for proper group/button ordering
- Graceful error handling for SPARQL and condition evaluation failures
- Default variant is `secondary` when not specified in RDF

Closes #1417