### PR TITLE
feat(buttons): define TrashButton with ShowModalAction

### DIFF
--- a/packages/exocortex/tests/unit/domain/services/ActionInterpreter.test.ts
+++ b/packages/exocortex/tests/unit/domain/services/ActionInterpreter.test.ts
@@ -2572,4 +2572,380 @@ describe("ActionInterpreter", () => {
       expect(mockVaultAdapter.updateFrontmatter).toHaveBeenCalled();
     });
   });
+
+  /**
+   * TrashAction CompositeAction Tests (Issue #1421)
+   *
+   * Tests for TrashAction which is a CompositeAction containing:
+   * - ShowTrashReasonModal (ShowModalAction for input)
+   * - SetStatusTrashedAction (UpdatePropertyAction for ems:Effort_status → ems:EffortStatusTrashed)
+   *
+   * Key difference from DoneAction: Action_headless = false (UI-only!)
+   * In CLI mode, ShowModalAction will fail with HeadlessError.
+   *
+   * RDF Definition:
+   * ```turtle
+   * ems-ui:TrashAction a exo-ui:CompositeAction ;
+   *     exo-ui:Action_actions (ems-ui:ShowTrashReasonModal ems-ui:SetStatusTrashedAction) ;
+   *     exo-ui:Action_headless false .
+   *
+   * ems-ui:ShowTrashReasonModal a exo-ui:ShowModalAction ;
+   *     exo-ui:Action_modalType "input" ;
+   *     exo-ui:Action_modalParams "{\"title\": \"Trash Reason\", \"placeholder\": \"Why are you trashing this?\"}" ;
+   *     exo-ui:Action_cliAlternative "--reason \"text\"" .
+   *
+   * ems-ui:SetStatusTrashedAction a exo-ui:UpdatePropertyAction ;
+   *     exo-ui:Action_targetProperty ems:Effort_status ;
+   *     exo-ui:Action_targetValue ems:EffortStatusTrashed .
+   * ```
+   *
+   * @see https://github.com/kitelev/exocortex/issues/1421
+   */
+  describe("TrashAction CompositeAction (Issue #1421)", () => {
+    let mockVaultAdapter: jest.Mocked<IVaultAdapter>;
+    let mockFile: IFile;
+
+    beforeEach(() => {
+      mockFile = {
+        path: "efforts/active-task.md",
+        basename: "active-task",
+        name: "active-task.md",
+        parent: { path: "efforts", name: "efforts" },
+      };
+
+      mockVaultAdapter = {
+        read: jest.fn(),
+        exists: jest.fn(),
+        getAllFiles: jest.fn(),
+        getAbstractFileByPath: jest.fn(),
+        create: jest.fn(),
+        modify: jest.fn(),
+        delete: jest.fn(),
+        process: jest.fn(),
+        rename: jest.fn(),
+        updateLinks: jest.fn(),
+        createFolder: jest.fn(),
+        getDefaultNewFileParent: jest.fn(),
+        getFrontmatter: jest.fn(),
+        updateFrontmatter: jest.fn().mockResolvedValue(undefined),
+        getFirstLinkpathDest: jest.fn(),
+      } as jest.Mocked<IVaultAdapter>;
+    });
+
+    it("should execute ShowTrashReasonModal and SetStatusTrashedAction in sequence in UI mode", async () => {
+      const interpreter = new ActionInterpreter(
+        mockTripleStore,
+        undefined,
+        mockVaultAdapter
+      );
+
+      const uiProvider = createMockUIProvider(false); // UI mode
+      (uiProvider.showInputModal as jest.Mock).mockResolvedValue("No longer needed");
+
+      const executionOrder: string[] = [];
+
+      const loadActionSpy = jest.spyOn(interpreter as any, "loadActionDefinition");
+      loadActionSpy.mockImplementation(async (uri) => {
+        if (uri === "ems-ui:TrashAction") {
+          return {
+            type: "exo-ui:CompositeAction",
+            params: {
+              actions: JSON.stringify([
+                "ems-ui:ShowTrashReasonModal",
+                "ems-ui:SetStatusTrashedAction",
+              ]),
+              Action_headless: false, // UI-only!
+            },
+          };
+        }
+        if (uri === "ems-ui:ShowTrashReasonModal") {
+          executionOrder.push("modal");
+          return {
+            type: "exo-ui:ShowModalAction",
+            params: {
+              modalType: "input",
+              modalParams: JSON.stringify({
+                title: "Trash Reason",
+                placeholder: "Why are you trashing this?",
+              }),
+              Action_cliAlternative: "--reason \"text\"",
+            },
+          };
+        }
+        if (uri === "ems-ui:SetStatusTrashedAction") {
+          executionOrder.push("status");
+          return {
+            type: "exo-ui:UpdatePropertyAction",
+            params: {
+              targetProperty: "ems__Effort_status",
+              targetValue: "ems__EffortStatusTrashed",
+            },
+          };
+        }
+        throw new Error(`Unknown action: ${uri}`);
+      });
+
+      const contextWithAsset: ActionContext = {
+        tripleStore: mockTripleStore,
+        uiProvider,
+        currentAsset: mockFile,
+      };
+
+      const result = await interpreter.execute("ems-ui:TrashAction", contextWithAsset);
+
+      expect(result.success).toBe(true);
+      expect(result.refresh).toBe(true);
+      // Both sub-actions should execute in order
+      expect(executionOrder).toEqual(["modal", "status"]);
+      // Modal should be shown
+      expect(uiProvider.showInputModal).toHaveBeenCalledWith({
+        title: "Trash Reason",
+        placeholder: "Why are you trashing this?",
+      });
+      // Status should be updated
+      expect(mockVaultAdapter.updateFrontmatter).toHaveBeenCalled();
+    });
+
+    it("should fail in headless (CLI) mode with HeadlessError and cliAlternative suggestion", async () => {
+      const interpreter = new ActionInterpreter(
+        mockTripleStore,
+        undefined,
+        mockVaultAdapter
+      );
+
+      const loadActionSpy = jest.spyOn(interpreter as any, "loadActionDefinition");
+      loadActionSpy.mockImplementation(async (uri) => {
+        if (uri === "ems-ui:TrashAction") {
+          return {
+            type: "exo-ui:CompositeAction",
+            params: {
+              actions: JSON.stringify([
+                "ems-ui:ShowTrashReasonModal",
+                "ems-ui:SetStatusTrashedAction",
+              ]),
+              Action_headless: false, // UI-only!
+            },
+          };
+        }
+        if (uri === "ems-ui:ShowTrashReasonModal") {
+          return {
+            type: "exo-ui:ShowModalAction",
+            params: {
+              modalType: "input",
+              modalParams: JSON.stringify({
+                title: "Trash Reason",
+                placeholder: "Why are you trashing this?",
+              }),
+              Action_cliAlternative: "--reason \"text\"",
+            },
+          };
+        }
+        throw new Error(`Unknown action: ${uri}`);
+      });
+
+      const headlessContext: ActionContext = {
+        tripleStore: mockTripleStore,
+        uiProvider: createMockUIProvider(true), // Headless mode
+        currentAsset: mockFile,
+      };
+
+      const result = await interpreter.execute("ems-ui:TrashAction", headlessContext);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("requires UI");
+      expect(result.message).toContain("--reason");
+    });
+
+    it("should stop TrashAction execution if ShowTrashReasonModal is cancelled", async () => {
+      const interpreter = new ActionInterpreter(
+        mockTripleStore,
+        undefined,
+        mockVaultAdapter
+      );
+
+      const uiProvider = createMockUIProvider(false);
+      (uiProvider.showInputModal as jest.Mock).mockRejectedValue(
+        new Error("User cancelled")
+      );
+
+      const executionOrder: string[] = [];
+
+      const loadActionSpy = jest.spyOn(interpreter as any, "loadActionDefinition");
+      loadActionSpy.mockImplementation(async (uri) => {
+        if (uri === "ems-ui:TrashAction") {
+          return {
+            type: "exo-ui:CompositeAction",
+            params: {
+              actions: JSON.stringify([
+                "ems-ui:ShowTrashReasonModal",
+                "ems-ui:SetStatusTrashedAction",
+              ]),
+            },
+          };
+        }
+        if (uri === "ems-ui:ShowTrashReasonModal") {
+          executionOrder.push("modal");
+          return {
+            type: "exo-ui:ShowModalAction",
+            params: {
+              modalType: "input",
+              modalParams: JSON.stringify({ title: "Trash Reason" }),
+            },
+          };
+        }
+        if (uri === "ems-ui:SetStatusTrashedAction") {
+          executionOrder.push("status");
+          return {
+            type: "exo-ui:UpdatePropertyAction",
+            params: {
+              targetProperty: "ems__Effort_status",
+              targetValue: "ems__EffortStatusTrashed",
+            },
+          };
+        }
+        throw new Error(`Unknown action: ${uri}`);
+      });
+
+      const contextWithAsset: ActionContext = {
+        tripleStore: mockTripleStore,
+        uiProvider,
+        currentAsset: mockFile,
+      };
+
+      const result = await interpreter.execute("ems-ui:TrashAction", contextWithAsset);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("User cancelled");
+      // SetStatusTrashedAction should NOT be executed after modal cancellation
+      expect(executionOrder).toEqual(["modal"]);
+      expect(mockVaultAdapter.updateFrontmatter).not.toHaveBeenCalled();
+    });
+
+    it("should set ems__Effort_status to ems__EffortStatusTrashed", async () => {
+      const interpreter = new ActionInterpreter(
+        mockTripleStore,
+        undefined,
+        mockVaultAdapter
+      );
+
+      const uiProvider = createMockUIProvider(false);
+      (uiProvider.showInputModal as jest.Mock).mockResolvedValue("Duplicate task");
+
+      let capturedFrontmatter: Record<string, unknown> = {};
+
+      mockVaultAdapter.updateFrontmatter.mockImplementation(
+        async (_file, updaterFn) => {
+          const testFrontmatter = { ems__Effort_status: "ems__EffortStatusDoing" };
+          capturedFrontmatter = updaterFn(testFrontmatter);
+          return undefined;
+        }
+      );
+
+      const loadActionSpy = jest.spyOn(interpreter as any, "loadActionDefinition");
+      loadActionSpy.mockImplementation(async (uri) => {
+        if (uri === "ems-ui:TrashAction") {
+          return {
+            type: "exo-ui:CompositeAction",
+            params: {
+              actions: JSON.stringify([
+                "ems-ui:ShowTrashReasonModal",
+                "ems-ui:SetStatusTrashedAction",
+              ]),
+            },
+          };
+        }
+        if (uri === "ems-ui:ShowTrashReasonModal") {
+          return {
+            type: "exo-ui:ShowModalAction",
+            params: {
+              modalType: "input",
+              modalParams: JSON.stringify({ title: "Trash Reason" }),
+            },
+          };
+        }
+        if (uri === "ems-ui:SetStatusTrashedAction") {
+          return {
+            type: "exo-ui:UpdatePropertyAction",
+            params: {
+              targetProperty: "ems__Effort_status",
+              targetValue: "ems__EffortStatusTrashed",
+            },
+          };
+        }
+        throw new Error(`Unknown action: ${uri}`);
+      });
+
+      const contextWithAsset: ActionContext = {
+        tripleStore: mockTripleStore,
+        uiProvider,
+        currentAsset: mockFile,
+      };
+
+      const result = await interpreter.execute("ems-ui:TrashAction", contextWithAsset);
+
+      expect(result.success).toBe(true);
+      expect(capturedFrontmatter["ems__Effort_status"]).toBe("ems__EffortStatusTrashed");
+    });
+
+    it("should pass user input from ShowTrashReasonModal to next action via previousResult", async () => {
+      const interpreter = new ActionInterpreter(
+        mockTripleStore,
+        undefined,
+        mockVaultAdapter
+      );
+
+      const uiProvider = createMockUIProvider(false);
+      const trashReason = "This task is obsolete";
+      (uiProvider.showInputModal as jest.Mock).mockResolvedValue(trashReason);
+
+      let capturedPreviousResult: unknown;
+
+      interpreter.registerCustomHandler("custom:LogReason", async (_def, ctx) => {
+        capturedPreviousResult = ctx.previousResult;
+        return { success: true };
+      });
+
+      const loadActionSpy = jest.spyOn(interpreter as any, "loadActionDefinition");
+      loadActionSpy.mockImplementation(async (uri) => {
+        if (uri === "ems-ui:TrashWithReasonAction") {
+          return {
+            type: "exo-ui:CompositeAction",
+            params: {
+              actions: JSON.stringify([
+                "ems-ui:ShowTrashReasonModal",
+                "custom:LogReason",
+              ]),
+            },
+          };
+        }
+        if (uri === "ems-ui:ShowTrashReasonModal") {
+          return {
+            type: "exo-ui:ShowModalAction",
+            params: {
+              modalType: "input",
+              modalParams: JSON.stringify({ title: "Trash Reason" }),
+            },
+          };
+        }
+        if (uri === "custom:LogReason") {
+          return {
+            type: "exo-ui:CustomHandlerAction",
+            params: { handler: "custom:LogReason" },
+          };
+        }
+        throw new Error(`Unknown action: ${uri}`);
+      });
+
+      const contextWithAsset: ActionContext = {
+        tripleStore: mockTripleStore,
+        uiProvider,
+        currentAsset: mockFile,
+      };
+
+      const result = await interpreter.execute("ems-ui:TrashWithReasonAction", contextWithAsset);
+
+      expect(result.success).toBe(true);
+      expect(capturedPreviousResult).toBe(trashReason);
+    });
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/builders/RdfButtonGroupsBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/RdfButtonGroupsBuilder.test.ts
@@ -1060,4 +1060,251 @@ describe("RdfButtonGroupsBuilder", () => {
       expect(groups[0].buttons[1].label).toBe("Done");
     });
   });
+
+  /**
+   * TrashButton with ShowModalAction Tests (Issue #1421)
+   *
+   * Tests for TrashButton which uses CompositeAction containing:
+   * - ShowTrashReasonModal (ShowModalAction for input)
+   * - SetStatusTrashedAction (UpdatePropertyAction for ems:Effort_status → ems:EffortStatusTrashed)
+   *
+   * Key difference from other buttons: Action_headless = false (UI-only!)
+   * In CLI mode, this will throw HeadlessError with Action_cliAlternative suggestion.
+   *
+   * RDF Definition:
+   * ```turtle
+   * ems-ui:TrashButton a exo-ui:Button ;
+   *     rdfs:label "Trash" ;
+   *     exo-ui:Button_icon "trash" ;
+   *     exo-ui:Button_variant "danger" ;
+   *     exo-ui:Button_group exo-ui:StatusButtonGroup ;
+   *     exo-ui:Button_order 100 ;
+   *     exo-ui:Button_action ems-ui:TrashAction ;
+   *     exo-ui:Button_condition ems-ui:IsNotTrashedCondition .
+   *
+   * ems-ui:TrashAction a exo-ui:CompositeAction ;
+   *     exo-ui:Action_actions (ems-ui:ShowTrashReasonModal ems-ui:SetStatusTrashedAction) ;
+   *     exo-ui:Action_headless false .
+   *
+   * ems-ui:ShowTrashReasonModal a exo-ui:ShowModalAction ;
+   *     exo-ui:Action_modalType "input" ;
+   *     exo-ui:Action_modalParams "{\"title\": \"Trash Reason\", \"placeholder\": \"Why are you trashing this?\"}" ;
+   *     exo-ui:Action_cliAlternative "--reason \"text\"" .
+   *
+   * ems-ui:SetStatusTrashedAction a exo-ui:UpdatePropertyAction ;
+   *     exo-ui:Action_targetProperty ems:Effort_status ;
+   *     exo-ui:Action_targetValue ems:EffortStatusTrashed .
+   *
+   * ems-ui:IsNotTrashedCondition a exo-ui:Condition ;
+   *     exo-ui:Condition_not ems-ui:IsTrashedCondition .
+   * ```
+   *
+   * @see https://github.com/kitelev/exocortex/issues/1421
+   */
+  describe("TrashButton with ShowModalAction (Issue #1421)", () => {
+    it("should load TrashButton with danger variant and trash icon from RDF", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "https://exocortex.my/ontology/exo-ui#StatusButtonGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "https://exocortex.my/ontology/ems-ui#TrashButton",
+            label: "Trash",
+            icon: "trash",
+            variant: "danger",
+            order: "100",
+            action: "https://exocortex.my/ontology/ems-ui#TrashAction",
+            condition: "https://exocortex.my/ontology/ems-ui#IsNotTrashedCondition",
+          }),
+        ]);
+
+      // Condition passes (asset is NOT trashed)
+      mockConditionEvaluator.evaluate.mockResolvedValue(true);
+
+      const groups = await builder.buildButtonGroups("test:active-task");
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].buttons).toHaveLength(1);
+
+      const trashButton = groups[0].buttons[0];
+      expect(trashButton.label).toBe("Trash");
+      expect(trashButton.icon).toBe("trash");
+      expect(trashButton.variant).toBe("danger");
+    });
+
+    it("should hide TrashButton when IsNotTrashedCondition is false (asset already trashed)", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "https://exocortex.my/ontology/exo-ui#StatusButtonGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "https://exocortex.my/ontology/ems-ui#TrashButton",
+            label: "Trash",
+            icon: "trash",
+            variant: "danger",
+            action: "https://exocortex.my/ontology/ems-ui#TrashAction",
+            condition: "https://exocortex.my/ontology/ems-ui#IsNotTrashedCondition",
+          }),
+        ]);
+
+      // Condition fails (asset IS already trashed)
+      mockConditionEvaluator.evaluate.mockResolvedValue(false);
+
+      const groups = await builder.buildButtonGroups("test:trashed-task");
+
+      // Group should be empty because TrashButton is filtered out
+      expect(groups).toHaveLength(0);
+    });
+
+    it("should execute TrashAction (CompositeAction with ShowModalAction) through ActionInterpreter when clicked", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "https://exocortex.my/ontology/exo-ui#StatusButtonGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "https://exocortex.my/ontology/ems-ui#TrashButton",
+            label: "Trash",
+            action: "https://exocortex.my/ontology/ems-ui#TrashAction",
+            condition: "https://exocortex.my/ontology/ems-ui#IsNotTrashedCondition",
+          }),
+        ]);
+
+      mockConditionEvaluator.evaluate.mockResolvedValue(true);
+      mockActionInterpreter.execute.mockResolvedValue({
+        success: true,
+        refresh: true,
+      });
+
+      const assetUri = "https://exocortex.my/vault/active-task.md";
+      const groups = await builder.buildButtonGroups(assetUri);
+      const trashButton = groups[0].buttons[0];
+
+      // Click the TrashButton
+      await trashButton.onClick();
+
+      // ActionInterpreter should be called with TrashAction URI
+      expect(mockActionInterpreter.execute).toHaveBeenCalledWith(
+        "https://exocortex.my/ontology/ems-ui#TrashAction",
+        { currentAsset: assetUri },
+      );
+    });
+
+    it("should evaluate IsNotTrashedCondition with correct asset URI", async () => {
+      const assetUri = "https://exocortex.my/vault/my-effort.md";
+
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "https://exocortex.my/ontology/exo-ui#StatusButtonGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "https://exocortex.my/ontology/ems-ui#TrashButton",
+            label: "Trash",
+            action: "https://exocortex.my/ontology/ems-ui#TrashAction",
+            condition: "https://exocortex.my/ontology/ems-ui#IsNotTrashedCondition",
+          }),
+        ]);
+
+      mockConditionEvaluator.evaluate.mockResolvedValue(true);
+
+      await builder.buildButtonGroups(assetUri);
+
+      // ConditionEvaluator should be called with IsNotTrashedCondition and asset URI
+      expect(mockConditionEvaluator.evaluate).toHaveBeenCalledWith(
+        "https://exocortex.my/ontology/ems-ui#IsNotTrashedCondition",
+        assetUri,
+      );
+    });
+
+    it("should show TrashButton at high order (100) after other status buttons", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "https://exocortex.my/ontology/exo-ui#StatusButtonGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "https://exocortex.my/ontology/ems-ui#StartButton",
+            label: "Start",
+            icon: "play",
+            variant: "primary",
+            order: "10",
+            action: "https://exocortex.my/ontology/ems-ui#StartAction",
+            condition: "https://exocortex.my/ontology/ems-ui#IsToDoCondition",
+          }),
+          createMockSolutionMapping({
+            button: "https://exocortex.my/ontology/ems-ui#TrashButton",
+            label: "Trash",
+            icon: "trash",
+            variant: "danger",
+            order: "100",
+            action: "https://exocortex.my/ontology/ems-ui#TrashAction",
+            condition: "https://exocortex.my/ontology/ems-ui#IsNotTrashedCondition",
+          }),
+        ]);
+
+      // Both conditions pass
+      mockConditionEvaluator.evaluate.mockResolvedValue(true);
+
+      const groups = await builder.buildButtonGroups("test:todo-task");
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].buttons).toHaveLength(2);
+      // Start should come before Trash (order 10 vs 100)
+      expect(groups[0].buttons[0].label).toBe("Start");
+      expect(groups[0].buttons[1].label).toBe("Trash");
+    });
+
+    it("should show TrashButton for any non-trashed status (Draft, Backlog, ToDo, Doing, Done)", async () => {
+      mockSparqlService.query
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            group: "https://exocortex.my/ontology/exo-ui#StatusButtonGroup",
+            label: "Status",
+            order: "1",
+          }),
+        ])
+        .mockResolvedValueOnce([
+          createMockSolutionMapping({
+            button: "https://exocortex.my/ontology/ems-ui#TrashButton",
+            label: "Trash",
+            icon: "trash",
+            variant: "danger",
+            action: "https://exocortex.my/ontology/ems-ui#TrashAction",
+            condition: "https://exocortex.my/ontology/ems-ui#IsNotTrashedCondition",
+          }),
+        ]);
+
+      // IsNotTrashedCondition passes (asset is in Draft status, NOT trashed)
+      mockConditionEvaluator.evaluate.mockResolvedValue(true);
+
+      const groups = await builder.buildButtonGroups("test:draft-task");
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].buttons).toHaveLength(1);
+      expect(groups[0].buttons[0].label).toBe("Trash");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Define RDF definitions for TrashButton with ShowModalAction for trash reason input.

**Фаза 4, Status Button 4/6**: TrashButton uses ShowModalAction for entering trash reason.

## Changes

### RDF Definitions (as test fixtures)

```turtle
# --- Trash Button (Any → Trashed) ---
ems-ui:TrashButton a exo-ui:Button ;
    rdfs:label "Trash" ;
    exo-ui:Button_icon "trash" ;
    exo-ui:Button_variant "danger" ;
    exo-ui:Button_group exo-ui:StatusButtonGroup ;
    exo-ui:Button_order 100 ;
    exo-ui:Button_action ems-ui:TrashAction ;
    exo-ui:Button_condition ems-ui:IsNotTrashedCondition .

ems-ui:TrashAction a exo-ui:CompositeAction ;
    exo-ui:Action_actions (
        ems-ui:ShowTrashReasonModal
        ems-ui:SetStatusTrashedAction
    ) ;
    exo-ui:Action_headless false .  # UI-only!

ems-ui:ShowTrashReasonModal a exo-ui:ShowModalAction ;
    exo-ui:Action_modalType "input" ;
    exo-ui:Action_modalParams "{\"title\": \"Trash Reason\", \"placeholder\": \"Why are you trashing this?\"}" ;
    exo-ui:Action_cliAlternative "--reason \"text\"" .

ems-ui:SetStatusTrashedAction a exo-ui:UpdatePropertyAction ;
    exo-ui:Action_targetProperty ems:Effort_status ;
    exo-ui:Action_targetValue ems:EffortStatusTrashed .

ems-ui:IsNotTrashedCondition a exo-ui:Condition ;
    exo-ui:Condition_not ems-ui:IsTrashedCondition .
```

### Key Differences from Other Status Buttons

| Aspect | DoneButton/PauseButton | TrashButton |
|--------|------------------------|-------------|
| Action_headless | true | **false** (UI-only) |
| Modal | None | ShowTrashReasonModal (input) |
| CLI | Works directly | Fails with HeadlessError, suggests `--reason` |

### Tests Added

**RdfButtonGroupsBuilder.test.ts** (6 tests):
- Load TrashButton with danger variant and trash icon
- Hide when IsNotTrashedCondition is false
- Execute TrashAction through ActionInterpreter
- Evaluate IsNotTrashedCondition with correct asset URI
- Show TrashButton at high order (100) after other buttons
- Show TrashButton for any non-trashed status

**ActionInterpreter.test.ts** (5 tests):
- Execute ShowTrashReasonModal and SetStatusTrashedAction in sequence
- Fail in headless mode with HeadlessError and cliAlternative
- Stop execution if modal is cancelled
- Set status to Trashed
- Pass user input to next action via previousResult

## Test Results

```
Test Suites: 37 passed
Tests: 675 passed (+ 11 new)
```

Closes #1421