### PR TITLE
feat(plugin): add settings UI toggle for RDF buttons migration

### DIFF
--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -150,6 +150,23 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      // eslint-disable-next-line obsidianmd/ui/sentence-case
+      .setName("Use RDF buttons")
+      .setDesc(
+        // eslint-disable-next-line obsidianmd/ui/sentence-case
+        "Enable RDF-driven button rendering (experimental)",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.useRdfButtons)
+          .onChange(async (value) => {
+            this.plugin.settings.useRdfButtons = value;
+            await this.plugin.saveSettings();
+            this.plugin.refreshLayout();
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Show labels in file explorer")
       .setDesc(
         "Display asset labels instead of filenames in the file explorer sidebar",

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -349,8 +349,8 @@ describe("ExocortexSettingTab", () => {
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
       expect(getOntologySpy).toHaveBeenCalledTimes(1);
-      // 12 original settings (added showLabelsInGraphView) + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 31
-      expect(MockSetting).toHaveBeenCalledTimes(31);
+      // 12 original settings (added showLabelsInGraphView) + 1 useRdfButtons + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 32
+      expect(MockSetting).toHaveBeenCalledTimes(32);
     });
 
     it("should render ontology dropdown with correct options", () => {
@@ -902,6 +902,125 @@ describe("ExocortexSettingTab", () => {
 
       // First dropdown is the ontology dropdown, which should have ExistingOntology
       expect(dropdownValues[0]).toBe("ExistingOntology");
+    });
+
+    it("should render Use RDF Buttons toggle", () => {
+      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
+
+      let settingNames: string[] = [];
+      MockSetting.mockImplementation((containerEl: any) => {
+        const setting = {
+          containerEl,
+          setName: jest.fn().mockImplementation((name: string) => {
+            settingNames.push(name);
+            return setting;
+          }),
+          setDesc: jest.fn().mockReturnThis(),
+          setHeading: jest.fn().mockReturnThis(),
+          addDropdown: jest.fn().mockReturnThis(),
+          addToggle: jest.fn().mockImplementation((callback) => {
+            const toggle = {
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(toggle);
+            return setting;
+          }),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
+            return setting;
+          }),
+          addButton: jest.fn().mockImplementation((callback) => {
+            const button = {
+              setButtonText: jest.fn().mockReturnThis(),
+              onClick: jest.fn().mockReturnThis(),
+              setCta: jest.fn().mockReturnThis(),
+            };
+            callback(button);
+            return setting;
+          }),
+        };
+        return setting;
+      });
+
+      settingTab.display();
+
+      // Check that "Use RDF Buttons" setting is rendered
+      expect(settingNames).toContain("Use RDF buttons");
+    });
+
+    it("should handle Use RDF Buttons toggle change", async () => {
+      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
+
+      // Add useRdfButtons to mock settings
+      mockPlugin.settings.useRdfButtons = false;
+
+      let toggleCallbacks: any[] = [];
+      let settingNames: string[] = [];
+      MockSetting.mockImplementation((containerEl: any) => {
+        const setting = {
+          containerEl,
+          setName: jest.fn().mockImplementation((name: string) => {
+            settingNames.push(name);
+            return setting;
+          }),
+          setDesc: jest.fn().mockReturnThis(),
+          setHeading: jest.fn().mockReturnThis(),
+          addDropdown: jest.fn().mockReturnThis(),
+          addToggle: jest.fn().mockImplementation((callback) => {
+            const toggle = {
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            toggleCallbacks.push({ toggle, callback, onChange: null, settingName: settingNames[settingNames.length - 1] });
+            toggle.onChange.mockImplementation((cb: any) => {
+              toggleCallbacks[toggleCallbacks.length - 1].onChange = cb;
+              return toggle;
+            });
+            callback(toggle);
+            return setting;
+          }),
+          addText: jest.fn().mockImplementation((callback) => {
+            const text = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+            };
+            callback(text);
+            return setting;
+          }),
+          addButton: jest.fn().mockImplementation((callback) => {
+            const button = {
+              setButtonText: jest.fn().mockReturnThis(),
+              onClick: jest.fn().mockReturnThis(),
+              setCta: jest.fn().mockReturnThis(),
+            };
+            callback(button);
+            return setting;
+          }),
+        };
+        return setting;
+      });
+
+      settingTab.display();
+
+      // Find the RDF buttons toggle by setting name
+      const rdfToggle = toggleCallbacks.find((t) => t.settingName === "Use RDF buttons");
+      expect(rdfToggle).toBeDefined();
+      expect(rdfToggle.toggle.setValue).toHaveBeenCalledWith(false);
+
+      if (rdfToggle?.onChange) {
+        await rdfToggle.onChange(true);
+      }
+
+      expect(mockPlugin.settings.useRdfButtons).toBe(true);
+      expect(mockPlugin.saveSettings).toHaveBeenCalled();
+      expect(mockPlugin.refreshLayout).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Added "Use RDF buttons" toggle in Settings panel
- Toggle enables/disables RDF-driven button rendering (experimental feature)
- Calls `refreshLayout()` on toggle to immediately update the UI
- Added comprehensive unit tests for the new setting

This completes the side-by-side migration capability for Phase 4 of the RDF-Driven Architecture Implementation Plan.

## Technical Details

The toggle was added after "Use dynamic property fields" since both are experimental features. When enabled:
- `UniversalLayoutRenderer` tries RDF buttons first via `RdfButtonGroupsBuilder`
- Falls back to legacy `ButtonGroupsBuilder` if no RDF buttons found or on error

The setting (`useRdfButtons`) and conditional logic in `UniversalLayoutRenderer` were already implemented in PR #1518. This PR adds the missing UI toggle.

## Test Plan

- [x] Unit tests for new setting (render + onChange behavior)
- [x] Updated existing setting count test (31 → 32 settings)
- [x] Build passes
- [x] Lint passes (with eslint-disable for RDF abbreviation)
- [x] All unit tests pass

Closes #1430