### PR TITLE
docs: [Docs] Update documentation for Milestone v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,56 @@ See the [RDF-Driven Architecture Plan](./docs/RDF-Driven-Architecture.md) for co
 
 ---
 
+## RDF-Driven Buttons (Milestone v1.2)
+
+**Vision:** All UI buttons are defined declaratively in RDF ontologies — no TypeScript code required to customize workflows.
+
+### Built-in Button Groups
+
+Exocortex ships with 29 buttons organized into 4 groups:
+
+| Group | Buttons | Purpose |
+|-------|---------|---------|
+| **Creation** | Create Task, Create Project, Create Area, Create Instance, Create Related Task, Create Narrower Concept, Create Subclass, Create Task (DailyNote) | Create new assets from context |
+| **Status** | Set Draft, Move to Backlog, Move to Analysis, Move to ToDo, Start Effort, Mark Done, Rollback Status | Transition task lifecycle |
+| **Planning** | Set Active Focus, Plan on Today, Plan for Evening, Shift Day ◀, Shift Day ▶, Vote | Time-based planning |
+| **Maintenance** | Trash, Archive, Clean Properties, Repair Folder, Rename to UID, Copy Label to Aliases, Convert to Project, Convert to Task | Asset maintenance |
+
+### Button Visibility
+
+Buttons automatically show/hide based on context:
+
+```yaml
+# Button shows only when:
+# - Asset is a Task or Project
+# - Status is "Doing"
+# - Not archived
+condition:
+  assetClass: [ems:Task, ems:Project]
+  propertyValue:
+    property: ems:Effort_status
+    value: "[[emsstatus__Doing]]"
+  isArchived: false
+```
+
+### Custom Buttons via RDF
+
+Add your own buttons without TypeScript:
+
+```turtle
+my:ReviewButton a exo-ui:Button ;
+    rdfs:label "Request Review" ;
+    exo-ui:Button_icon "eye" ;
+    exo-ui:Button_variant "primary" ;
+    exo-ui:Button_group exo-ui:StatusButtonGroup ;
+    exo-ui:Button_action my:SetReviewStatusAction ;
+    exo-ui:Button_condition my:IsDoingCondition .
+```
+
+See **[Button Reference](./docs/BUTTONS.md)** for complete documentation and **[Custom Buttons Tutorial](./docs/tutorials/CUSTOM-BUTTONS.md)** for step-by-step guide.
+
+---
+
 ## Key Features
 
 ### Semantic Query System (SPARQL)
@@ -509,6 +559,8 @@ See **[SPARQL 1.2 Features](./docs/sparql/SPARQL-1.2-Features.md)** for complete
 
 **Obsidian Plugin:**
 - **[RDF-Driven Commands](./docs/COMMANDS.md)** — All 36 commands, RDF structure, conditions, hotkeys
+- **[RDF-Driven Buttons](./docs/BUTTONS.md)** — All 29 buttons, visibility conditions, customization
+- **[Custom Buttons Tutorial](./docs/tutorials/CUSTOM-BUTTONS.md)** — Step-by-step guide to adding custom buttons
 - **[Command Reference](./docs/Command-Reference.md)** — Legacy command documentation
 
 **CLI:**

--- a/docs/BUTTONS.md
+++ b/docs/BUTTONS.md
@@ -1,0 +1,302 @@
+# RDF-Driven Buttons Reference
+
+> Complete reference for Exocortex's 29 built-in buttons. All buttons are defined in RDF ontologies and can be customized without TypeScript code.
+
+## Overview
+
+Exocortex provides a declarative button system where:
+- **Buttons** are UI elements that trigger actions
+- **Actions** define what happens when clicked (update property, create asset, navigate, etc.)
+- **Conditions** control when buttons are visible
+- **Groups** organize buttons into logical categories
+
+```
+┌────────────┐    ┌────────────┐    ┌────────────┐
+│   Button   │───▶│   Action   │───▶│  Service   │
+│ (UI/RDF)   │    │  (What)    │    │  (How)     │
+└────────────┘    └────────────┘    └────────────┘
+      │
+      ▼
+┌────────────┐
+│ Condition  │
+│ (When)     │
+└────────────┘
+```
+
+## Button Groups
+
+### Creation Group
+
+Buttons for creating new assets from the current context.
+
+| Button | ID | Icon | Variant | Visible When |
+|--------|-----|------|---------|--------------|
+| **Create Task** | `create-task` | — | primary | Asset is Area, Project, or Task |
+| **Create Project** | `create-project` | — | primary | Asset is Area or Project |
+| **Create Area** | `create-area` | — | primary | Asset is Area |
+| **Create Instance** | `create-instance` | — | primary | Asset is Prototype (Task/Meeting) |
+| **Create Related Task** | `create-related-task` | — | primary | Asset is Concept |
+| **Create Narrower Concept** | `create-narrower-concept` | — | primary | Asset is Concept |
+| **Create Subclass** | `create-subclass` | — | primary | Asset is Class |
+| **Create Task (DailyNote)** | `create-task-for-dailynote` | — | primary | Asset is DailyNote |
+
+**Example — Create Task Button:**
+```turtle
+ems-ui:CreateTaskButton a exo-ui:Button ;
+    rdfs:label "Create Task" ;
+    exo-ui:Button_variant "primary" ;
+    exo-ui:Button_group exo-ui:CreationButtonGroup ;
+    exo-ui:Button_action ems-ui:CreateTaskAction ;
+    exo-ui:Button_condition ems-ui:CanCreateTaskCondition .
+```
+
+### Status Group
+
+Buttons for transitioning task lifecycle status.
+
+| Button | ID | Icon | Variant | Visible When |
+|--------|-----|------|---------|--------------|
+| **Set Draft Status** | `set-draft-status` | — | secondary | Task/Project not Draft, not archived |
+| **Move to Backlog** | `move-to-backlog` | — | secondary | Task/Project in Draft |
+| **Move to Analysis** | `move-to-analysis` | — | secondary | Task/Project in Backlog |
+| **Move to ToDo** | `move-to-todo` | — | secondary | Task/Project in Backlog or Analysis |
+| **Start Effort** | `start-effort` | — | secondary | Task/Project in ToDo |
+| **Mark Done** | `mark-done` | — | success | Task/Project in Doing |
+| **Rollback Status** | `rollback-status` | — | warning | Has previous status to rollback to |
+
+**Status Lifecycle:**
+```
+Draft → Backlog → Analysis → ToDo → Doing → Done
+                     │
+                     └──────────→ Trashed
+```
+
+**Example — Mark Done Button:**
+```turtle
+ems-ui:DoneButton a exo-ui:Button ;
+    rdfs:label "Mark Done" ;
+    exo-ui:Button_variant "success" ;
+    exo-ui:Button_group exo-ui:StatusButtonGroup ;
+    exo-ui:Button_action ems-ui:MarkDoneAction ;
+    exo-ui:Button_condition ems-ui:IsDoingCondition .
+```
+
+### Planning Group
+
+Buttons for time-based planning and prioritization.
+
+| Button | ID | Icon | Variant | Visible When |
+|--------|-----|------|---------|--------------|
+| **Set Active Focus** | `set-active-focus` | — | warning | Asset is Area |
+| **Plan on Today** | `plan-on-today` | — | warning | Task/Project in ToDo/Doing |
+| **Plan for Evening** | `plan-for-evening` | — | warning | Task/Project in ToDo/Doing |
+| **Shift Day ◀** | `shift-day-backward` | — | warning | Task/Project with planned date |
+| **Shift Day ▶** | `shift-day-forward` | — | warning | Task/Project with planned date |
+| **Vote** | `vote-on-effort` | — | warning | Asset is Effort (Task/Project/Meeting) |
+
+**Example — Plan on Today Button:**
+```turtle
+ems-ui:PlanTodayButton a exo-ui:Button ;
+    rdfs:label "Plan on Today" ;
+    exo-ui:Button_variant "warning" ;
+    exo-ui:Button_group exo-ui:PlanningButtonGroup ;
+    exo-ui:Button_action ems-ui:PlanTodayAction ;
+    exo-ui:Button_condition ems-ui:CanPlanOnTodayCondition .
+```
+
+### Maintenance Group
+
+Buttons for asset maintenance and cleanup.
+
+| Button | ID | Icon | Variant | Visible When |
+|--------|-----|------|---------|--------------|
+| **Trash** | `trash` | — | danger | Effort (Task/Project) not trashed |
+| **Archive** | `archive` | — | danger | Task/Project completed, not archived |
+| **Clean Properties** | `clean-properties` | — | secondary | Any asset with empty properties |
+| **Repair Folder** | `repair-folder` | — | secondary | Asset in wrong folder |
+| **Rename to UID** | `rename-to-uid` | — | secondary | Filename ≠ UID |
+| **Copy Label to Aliases** | `copy-label-to-aliases` | — | secondary | Any asset |
+| **Convert to Project** | `convert-task-to-project` | — | primary | Asset is Task |
+| **Convert to Task** | `convert-project-to-task` | — | primary | Asset is Project |
+
+**Example — Cleanup Button:**
+```turtle
+ems-ui:CleanupButton a exo-ui:Button ;
+    rdfs:label "Clean Properties" ;
+    exo-ui:Button_variant "secondary" ;
+    exo-ui:Button_group exo-ui:MaintenanceButtonGroup ;
+    exo-ui:Button_action ems-ui:CleanupAction ;
+    exo-ui:Button_condition ems-ui:HasEmptyPropertiesCondition .
+```
+
+## Conditions Reference
+
+Conditions control when buttons are visible. They can check:
+
+### Asset Class Conditions
+
+| Condition | True When |
+|-----------|-----------|
+| `canCreateTask` | Asset is Area, Project, or Task |
+| `canCreateProject` | Asset is Area or Project |
+| `canCreateChildArea` | Asset is Area |
+| `canCreateInstance` | Asset is TaskPrototype or MeetingPrototype |
+| `canCreateRelatedTask` | Asset is Concept |
+| `canCreateNarrowerConcept` | Asset is Concept |
+| `canCreateSubclass` | Asset is Class |
+| `canCreateTaskForDailyNote` | Asset is DailyNote |
+
+### Status Conditions
+
+| Condition | True When |
+|-----------|-----------|
+| `canSetDraftStatus` | Task/Project, not Draft, not archived |
+| `canMoveToBacklog` | Task/Project in Draft |
+| `canMoveToAnalysis` | Task/Project in Backlog |
+| `canMoveToToDo` | Task/Project in Backlog or Analysis |
+| `canStartEffort` | Task/Project in ToDo |
+| `canMarkDone` | Task/Project in Doing |
+| `canRollbackStatus` | Has status history entry |
+
+### Planning Conditions
+
+| Condition | True When |
+|-----------|-----------|
+| `canPlanOnToday` | Task/Project in ToDo or Doing |
+| `canPlanForEvening` | Task/Project in ToDo or Doing |
+| `canShiftDayBackward` | Task/Project has plannedStartTimestamp |
+| `canShiftDayForward` | Task/Project has plannedStartTimestamp |
+| `canVoteOnEffort` | Asset is Effort (Task/Project/Meeting) |
+| `canSetActiveFocus` | Asset is Area |
+
+### Maintenance Conditions
+
+| Condition | True When |
+|-----------|-----------|
+| `canTrashEffort` | Effort not trashed |
+| `canArchiveTask` | Task/Project completed, not archived |
+| `canCleanProperties` | Asset has empty property values |
+| `canRepairFolder` | Current folder ≠ expected folder |
+| `canRenameToUid` | Filename ≠ exo__Asset_uid |
+| `canCopyLabelToAliases` | Any asset |
+| `canConvertTaskToProject` | Asset is Task |
+| `canConvertProjectToTask` | Asset is Project |
+
+## Button Variants
+
+Visual styles for buttons:
+
+| Variant | Use Case | Color |
+|---------|----------|-------|
+| `primary` | Main actions (Create) | Blue |
+| `secondary` | Supporting actions | Gray |
+| `success` | Positive completion | Green |
+| `warning` | Attention-needed actions | Orange |
+| `danger` | Destructive actions | Red |
+
+## Actions Reference
+
+Actions define what happens when a button is clicked.
+
+### Built-in Action Types
+
+| Action Type | Description | Parameters |
+|-------------|-------------|------------|
+| `CreateAssetAction` | Create new asset | `targetClass`, `template`, `location` |
+| `UpdatePropertyAction` | Update property value | `targetProperty`, `targetValue`, `targetAsset` |
+| `NavigateAction` | Navigate to asset/SPARQL result | `target` |
+| `ExecuteSPARQLAction` | Execute SPARQL query | `query`, `resultHandler` |
+| `ShowModalAction` | Show interactive modal | `modalType`, `modalParams` |
+| `TriggerHookAction` | Trigger webhook/hook | `hookName`, `payload` |
+| `CustomHandlerAction` | Call TypeScript handler | `handler` |
+| `CompositeAction` | Execute sequence | `actions` |
+
+### Headless Support (CLI)
+
+Actions marked with `exo-ui:Action_headless true` work in both Obsidian and CLI.
+
+| Action | Headless? |
+|--------|-----------|
+| `CreateAssetAction` | Yes |
+| `UpdatePropertyAction` | Yes |
+| `NavigateAction` | Yes |
+| `ExecuteSPARQLAction` | Yes |
+| `ShowModalAction` | No |
+| `TriggerHookAction` | No |
+| `CustomHandlerAction` | Depends on handler |
+
+## RDF Ontology Structure
+
+Buttons are defined in the `ems-ui` namespace in [exocortex-public-ontologies](https://github.com/kitelev/exocortex-public-ontologies).
+
+### Namespace
+
+```turtle
+@prefix ems-ui: <https://exocortex.my/ontology/ems-ui#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+```
+
+### Button Definition Schema
+
+```turtle
+# Button
+ems-ui:MyButton a exo-ui:Button ;
+    rdfs:label "My Button"@en ;
+    exo-ui:Button_icon "icon-name" ;           # Lucide icon
+    exo-ui:Button_variant "primary" ;          # primary|secondary|success|warning|danger
+    exo-ui:Button_group exo-ui:StatusButtonGroup ;
+    exo-ui:Button_action ems-ui:MyAction ;
+    exo-ui:Button_condition ems-ui:MyCondition ;
+    exo-ui:Button_order "10" ;                 # Sort order within group
+    exo-ui:Button_tooltip "Helpful tooltip" .
+
+# Action
+ems-ui:MyAction a exo-ui:UpdatePropertyAction ;
+    exo-ui:Action_targetProperty ems:Effort_status ;
+    exo-ui:Action_targetValue "[[emsstatus__Done]]" ;
+    exo-ui:Action_headless true .
+
+# Condition
+ems-ui:MyCondition a exo-ui:Condition ;
+    exo-ui:Condition_assetClass ems:Task ;
+    exo-ui:Condition_propertyValue "[[emsstatus__Doing]]" .
+```
+
+## Customization
+
+### Adding Custom Buttons
+
+See **[Custom Buttons Tutorial](./tutorials/CUSTOM-BUTTONS.md)** for step-by-step guide.
+
+Quick example:
+```turtle
+@prefix my: <https://my-vault.example/ontology/my#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+
+my:ReviewButton a exo-ui:Button ;
+    rdfs:label "Request Review" ;
+    exo-ui:Button_icon "eye" ;
+    exo-ui:Button_variant "primary" ;
+    exo-ui:Button_group exo-ui:StatusButtonGroup ;
+    exo-ui:Button_action my:SetReviewStatusAction ;
+    exo-ui:Button_condition my:IsDoingCondition .
+```
+
+### Disabling Built-in Buttons
+
+To hide a built-in button, create a condition that always returns false:
+
+```turtle
+# Override the button's condition
+ems-ui:CreateTaskButton exo-ui:Button_condition my:AlwaysFalseCondition .
+
+my:AlwaysFalseCondition a exo-ui:Condition ;
+    exo-ui:Condition_sparql "ASK { FILTER(false) }" .
+```
+
+## See Also
+
+- **[Custom Buttons Tutorial](./tutorials/CUSTOM-BUTTONS.md)** — Step-by-step guide
+- **[RDF-Driven Commands](./COMMANDS.md)** — Command palette commands
+- **[exo-ui Ontology](https://github.com/kitelev/exocortex-public-ontologies/tree/main/exo-ui)** — Source RDF definitions
+- **[ems-ui Ontology](https://github.com/kitelev/exocortex-public-ontologies/tree/main/ems-ui)** — Button instances

--- a/docs/tutorials/CUSTOM-BUTTONS.md
+++ b/docs/tutorials/CUSTOM-BUTTONS.md
@@ -1,0 +1,351 @@
+# Custom Buttons Tutorial
+
+> Step-by-step guide to adding custom buttons to Exocortex without writing TypeScript code.
+
+## Prerequisites
+
+- Exocortex plugin installed in Obsidian
+- Basic understanding of RDF/Turtle syntax
+- Access to your vault's ontology folder
+
+## Overview
+
+Custom buttons are defined in RDF (Turtle format) and automatically appear in the Exocortex UI. This tutorial covers:
+
+1. Creating a simple button
+2. Defining actions (what happens when clicked)
+3. Defining conditions (when the button appears)
+4. Advanced patterns
+
+## Quick Start
+
+### Step 1: Create Your Ontology File
+
+Create a new file `my-buttons.ttl` in your vault's ontology folder:
+
+```turtle
+@prefix my: <https://my-vault.example/ontology/my#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ems: <https://exocortex.my/ontology/ems#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+# My first custom button
+my:HelloButton a exo-ui:Button ;
+    rdfs:label "Hello World" ;
+    exo-ui:Button_variant "primary" ;
+    exo-ui:Button_group exo-ui:MaintenanceButtonGroup ;
+    exo-ui:Button_action my:HelloAction ;
+    exo-ui:Button_condition my:AlwaysShowCondition .
+
+# Action: Show a notification
+my:HelloAction a exo-ui:CustomHandlerAction ;
+    exo-ui:Action_handler "notify" ;
+    exo-ui:Action_headless false .
+
+# Condition: Always visible
+my:AlwaysShowCondition a exo-ui:Condition ;
+    exo-ui:Condition_sparql "ASK { ?s ?p ?o }" .
+```
+
+### Step 2: Import the Ontology
+
+Exocortex automatically loads `.ttl` files from the ontology folder on startup. Restart Obsidian or use the "Reload Exocortex" command.
+
+### Step 3: Test Your Button
+
+Open any asset note. Your "Hello World" button should appear in the Maintenance button group.
+
+## Detailed Guide
+
+### Button Properties
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `rdfs:label` | Yes | Button text displayed in UI |
+| `exo-ui:Button_variant` | Yes | Visual style: `primary`, `secondary`, `success`, `warning`, `danger` |
+| `exo-ui:Button_group` | Yes | Which group: `CreationButtonGroup`, `StatusButtonGroup`, `PlanningButtonGroup`, `MaintenanceButtonGroup` |
+| `exo-ui:Button_action` | Yes | What happens when clicked |
+| `exo-ui:Button_condition` | Yes | When the button is visible |
+| `exo-ui:Button_icon` | No | Lucide icon name (e.g., `eye`, `check`, `trash`) |
+| `exo-ui:Button_order` | No | Sort order within group (lower = first) |
+| `exo-ui:Button_tooltip` | No | Hover text |
+
+### Action Types
+
+#### UpdatePropertyAction — Change a Property
+
+Most common action. Updates a property on the current asset.
+
+```turtle
+my:SetPriorityHighAction a exo-ui:UpdatePropertyAction ;
+    exo-ui:Action_targetProperty ems:Effort_priority ;
+    exo-ui:Action_targetValue "high" ;
+    exo-ui:Action_headless true .
+```
+
+**Parameters:**
+- `Action_targetProperty` — Property URI to update
+- `Action_targetValue` — New value (literal or wikilink)
+- `Action_targetAsset` — (Optional) Different asset to update
+
+#### CreateAssetAction — Create New Asset
+
+Create a new asset based on a template.
+
+```turtle
+my:CreateMeetingNoteAction a exo-ui:CreateAssetAction ;
+    exo-ui:Action_targetClass ems:Meeting ;
+    exo-ui:Action_template "[[templates/Meeting Template]]" ;
+    exo-ui:Action_location "meetings/{{date}}" ;
+    exo-ui:Action_headless true .
+```
+
+**Parameters:**
+- `Action_targetClass` — Class of new asset
+- `Action_template` — Template note to use
+- `Action_location` — Folder path (supports `{{date}}`, `{{asset.label}}`)
+
+#### NavigateAction — Open Another Asset
+
+Navigate to a related asset or SPARQL query result.
+
+```turtle
+my:GoToProjectAction a exo-ui:NavigateAction ;
+    exo-ui:Action_target "{{asset.partOf}}" ;
+    exo-ui:Action_headless true .
+```
+
+**Parameters:**
+- `Action_target` — Asset URI, wikilink, or SPARQL SELECT query
+
+#### CompositeAction — Multiple Actions
+
+Execute several actions in sequence.
+
+```turtle
+my:CompleteAndArchiveAction a exo-ui:CompositeAction ;
+    exo-ui:Action_actions (
+        my:MarkDoneAction
+        my:ArchiveAction
+    ) ;
+    exo-ui:Action_headless true .
+```
+
+### Condition Types
+
+#### Asset Class Condition
+
+Show button only for specific asset types.
+
+```turtle
+my:IsTaskCondition a exo-ui:Condition ;
+    exo-ui:Condition_assetClass ems:Task .
+```
+
+Multiple classes (OR logic):
+```turtle
+my:IsTaskOrProjectCondition a exo-ui:Condition ;
+    exo-ui:Condition_assetClass ems:Task, ems:Project .
+```
+
+#### Property Value Condition
+
+Show button when property has specific value.
+
+```turtle
+my:IsDoingCondition a exo-ui:Condition ;
+    exo-ui:Condition_assetClass ems:Task ;
+    exo-ui:Condition_hasProperty ems:Effort_status ;
+    exo-ui:Condition_propertyValue "[[emsstatus__Doing]]" .
+```
+
+#### SPARQL Condition
+
+Most flexible — use any SPARQL ASK query.
+
+```turtle
+my:HasBlockersCondition a exo-ui:Condition ;
+    exo-ui:Condition_sparql """
+        ASK {
+            ?asset ems:Task_blockedBy ?blocker .
+            ?blocker ems:Effort_status ?status .
+            FILTER(?status != "[[emsstatus__Done]]")
+        }
+    """ .
+```
+
+The `?asset` variable is automatically bound to the current asset.
+
+#### Compound Conditions
+
+Combine conditions with AND/OR/NOT:
+
+```turtle
+# AND: Both conditions must be true
+my:TaskInDoingCondition a exo-ui:Condition ;
+    exo-ui:Condition_and (
+        my:IsTaskCondition
+        my:StatusIsDoingCondition
+    ) .
+
+# OR: At least one must be true
+my:TaskOrProjectCondition a exo-ui:Condition ;
+    exo-ui:Condition_or (
+        my:IsTaskCondition
+        my:IsProjectCondition
+    ) .
+
+# NOT: Condition must be false
+my:NotArchivedCondition a exo-ui:Condition ;
+    exo-ui:Condition_not my:IsArchivedCondition .
+```
+
+## Real-World Examples
+
+### Example 1: "Request Review" Button
+
+Add a button that sets a custom "review-requested" status.
+
+```turtle
+@prefix my: <https://my-vault.example/ontology/my#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ems: <https://exocortex.my/ontology/ems#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+my:RequestReviewButton a exo-ui:Button ;
+    rdfs:label "Request Review" ;
+    exo-ui:Button_icon "eye" ;
+    exo-ui:Button_variant "warning" ;
+    exo-ui:Button_group exo-ui:StatusButtonGroup ;
+    exo-ui:Button_action my:SetReviewRequestedAction ;
+    exo-ui:Button_condition my:CanRequestReviewCondition ;
+    exo-ui:Button_order "50" .
+
+my:SetReviewRequestedAction a exo-ui:UpdatePropertyAction ;
+    exo-ui:Action_targetProperty my:review_status ;
+    exo-ui:Action_targetValue "requested" ;
+    exo-ui:Action_headless true .
+
+my:CanRequestReviewCondition a exo-ui:Condition ;
+    exo-ui:Condition_assetClass ems:Task ;
+    exo-ui:Condition_sparql """
+        ASK {
+            ?asset ems:Effort_status "[[emsstatus__Doing]]" .
+            FILTER NOT EXISTS { ?asset my:review_status "requested" }
+        }
+    """ .
+```
+
+### Example 2: "Quick Meeting Note" Button
+
+Create a meeting note linked to the current project.
+
+```turtle
+my:QuickMeetingButton a exo-ui:Button ;
+    rdfs:label "Meeting Note" ;
+    exo-ui:Button_icon "calendar" ;
+    exo-ui:Button_variant "primary" ;
+    exo-ui:Button_group exo-ui:CreationButtonGroup ;
+    exo-ui:Button_action my:CreateMeetingAction ;
+    exo-ui:Button_condition my:IsProjectCondition ;
+    exo-ui:Button_order "100" .
+
+my:CreateMeetingAction a exo-ui:CreateAssetAction ;
+    exo-ui:Action_targetClass ems:Meeting ;
+    exo-ui:Action_template "[[templates/Meeting]]" ;
+    exo-ui:Action_location "meetings/{{date}}" ;
+    exo-ui:Action_headless true .
+
+my:IsProjectCondition a exo-ui:Condition ;
+    exo-ui:Condition_assetClass ems:Project .
+```
+
+### Example 3: "Bump Priority" Toggle Button
+
+Cycle through priority levels: low → medium → high → low.
+
+```turtle
+my:BumpPriorityButton a exo-ui:Button ;
+    rdfs:label "Bump Priority" ;
+    exo-ui:Button_icon "arrow-up" ;
+    exo-ui:Button_variant "secondary" ;
+    exo-ui:Button_group exo-ui:PlanningButtonGroup ;
+    exo-ui:Button_action my:BumpPriorityAction ;
+    exo-ui:Button_condition my:IsEffortCondition .
+
+my:BumpPriorityAction a exo-ui:CustomHandlerAction ;
+    exo-ui:Action_handler "cyclePriority" ;
+    exo-ui:Action_headless false .
+
+my:IsEffortCondition a exo-ui:Condition ;
+    exo-ui:Condition_assetClass ems:Task, ems:Project .
+```
+
+> Note: `CustomHandlerAction` requires a registered TypeScript handler. For property updates, use `UpdatePropertyAction`.
+
+## Best Practices
+
+### Naming Conventions
+
+- Use a consistent prefix for your custom ontology (`my:`, `workflow:`, etc.)
+- Name buttons descriptively: `my:RequestReviewButton`, not `my:Button1`
+- Name actions by what they do: `my:SetReviewRequestedAction`
+- Name conditions by what they check: `my:CanRequestReviewCondition`
+
+### Button Order
+
+- Use `Button_order` to control position within group
+- Built-in buttons use orders 10-90
+- Use 100+ for custom buttons to appear after built-ins
+- Use negative numbers to appear before built-ins
+
+### Headless Support
+
+- Set `Action_headless true` for actions that should work in CLI
+- Interactive actions (modals, confirmations) must use `Action_headless false`
+
+### Testing
+
+1. Check the browser console for RDF parsing errors
+2. Use SPARQL queries in Obsidian to verify conditions
+3. Test with assets in different states
+
+## Troubleshooting
+
+### Button Not Appearing
+
+1. **Check condition** — Is the condition satisfied for current asset?
+   ```sparql
+   ASK { <current-asset-uri> ems:Effort_status "[[emsstatus__Doing]]" }
+   ```
+
+2. **Check RDF syntax** — Look for Turtle parsing errors in console
+
+3. **Check group** — Is the button in a valid group?
+
+4. **Reload plugin** — Changes require restart or "Reload Exocortex"
+
+### Action Not Working
+
+1. **Check action type** — Is it the right action class?
+
+2. **Check parameters** — All required parameters present?
+
+3. **Check headless flag** — CLI usage requires `Action_headless true`
+
+### Condition Always False
+
+1. **Test SPARQL** — Run the condition query manually:
+   ```sparql
+   ASK {
+     # Your condition query with ?asset bound to actual URI
+   }
+   ```
+
+2. **Check variable binding** — `?asset` is automatically bound
+
+## See Also
+
+- **[Button Reference](../BUTTONS.md)** — Complete button reference
+- **[RDF-Driven Commands](../COMMANDS.md)** — Custom commands
+- **[exo-ui Ontology](https://github.com/kitelev/exocortex-public-ontologies/tree/main/exo-ui)** — Schema definition


### PR DESCRIPTION
## Summary

- Added comprehensive RDF-Driven Buttons documentation for Milestone v1.2
- Created reference documentation for all 29 built-in buttons
- Added step-by-step tutorial for creating custom buttons

## Changes

### README.md
- Added "RDF-Driven Buttons (Milestone v1.2)" section with button groups overview
- Added documentation links in the Documentation section

### New Files
- `docs/BUTTONS.md` - Complete button reference (302 lines)
  - All 29 buttons organized by group (Creation, Status, Planning, Maintenance)
  - Conditions reference
  - Actions reference
  - RDF ontology structure
  - Customization examples

- `docs/tutorials/CUSTOM-BUTTONS.md` - Step-by-step tutorial (351 lines)
  - Quick start guide
  - Detailed property reference
  - Action types with examples
  - Condition types with examples
  - Real-world examples (Request Review, Quick Meeting, Bump Priority)
  - Best practices and troubleshooting

## Test Plan

- [x] Build passes (`npm run build`)
- [x] Lint passes (no new errors introduced)
- [x] Documentation links are valid
- [x] Code examples are syntactically correct

## Related Issues

Closes #1431

## Notes

The issue mentions updating `exocortex-public-ontologies/ems-ui/README.md`, but that is a separate repository. The documentation created here links to the ontology source repository appropriately. A follow-up issue can be created for the ontologies repo if needed.