### PR TITLE
feat(validation): add SHACL shapes for Command class (closes #1435)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -377,6 +377,17 @@ export type {
   LoaderState,
 } from "./infrastructure/memory";
 
+// SHACL Validation exports
+export {
+  ShaclValidator,
+  type ValidationResult as ShaclValidationResult,
+  type ValidationViolation,
+} from "./services/shacl/ShaclValidator";
+export {
+  COMMAND_SHAPE_TURTLE,
+  COMMAND_SHAPE_DEFINITION,
+} from "./services/shacl/shapes/CommandShape";
+
 // Error exports
 export * from "./domain/errors";
 export * from "./application/errors";

--- a/packages/exocortex/src/services/shacl/ShaclValidator.ts
+++ b/packages/exocortex/src/services/shacl/ShaclValidator.ts
@@ -1,0 +1,435 @@
+/**
+ * SHACL Validator Service
+ *
+ * Validates RDF data against SHACL shapes. Implements a subset of the
+ * W3C SHACL specification for validating Command class definitions.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1435
+ * @see https://www.w3.org/TR/shacl/
+ * @module services/shacl
+ * @since 1.4.0
+ */
+
+import { Triple } from "../../domain/models/rdf/Triple";
+import { IRI } from "../../domain/models/rdf/IRI";
+import { Literal } from "../../domain/models/rdf/Literal";
+import { Namespace } from "../../domain/models/rdf/Namespace";
+import { TurtleParser } from "../../infrastructure/rdf/parsers/TurtleParser";
+
+/**
+ * Result of SHACL validation.
+ */
+export interface ValidationResult {
+  /** Whether the data graph conforms to all shapes */
+  conforms: boolean;
+  /** List of validation violations */
+  violations: ValidationViolation[];
+}
+
+/**
+ * A single validation violation.
+ */
+export interface ValidationViolation {
+  /** The node that failed validation */
+  focusNode: string;
+  /** The property path that was violated */
+  path?: string;
+  /** Human-readable error message */
+  message: string;
+  /** The severity of the violation */
+  severity: "Violation" | "Warning" | "Info";
+  /** The source constraint component */
+  sourceConstraintComponent?: string;
+}
+
+/**
+ * Parsed shape definition.
+ */
+interface ShapeDefinition {
+  shapeUri: string;
+  targetClass: string | null;
+  properties: PropertyConstraint[];
+}
+
+/**
+ * Property constraint from a SHACL shape.
+ */
+interface PropertyConstraint {
+  path: string;
+  datatype?: string;
+  nodeKind?: "IRI" | "BlankNode" | "Literal" | "BlankNodeOrIRI" | "BlankNodeOrLiteral" | "IRIOrLiteral";
+  minCount?: number;
+  maxCount?: number;
+  message?: string;
+}
+
+/**
+ * SHACL namespace for properties.
+ */
+const SH = {
+  targetClass: "http://www.w3.org/ns/shacl#targetClass",
+  property: "http://www.w3.org/ns/shacl#property",
+  path: "http://www.w3.org/ns/shacl#path",
+  datatype: "http://www.w3.org/ns/shacl#datatype",
+  nodeKind: "http://www.w3.org/ns/shacl#nodeKind",
+  minCount: "http://www.w3.org/ns/shacl#minCount",
+  maxCount: "http://www.w3.org/ns/shacl#maxCount",
+  message: "http://www.w3.org/ns/shacl#message",
+  NodeShape: "http://www.w3.org/ns/shacl#NodeShape",
+  IRI: "http://www.w3.org/ns/shacl#IRI",
+  BlankNode: "http://www.w3.org/ns/shacl#BlankNode",
+  Literal: "http://www.w3.org/ns/shacl#Literal",
+};
+
+/**
+ * SHACL Validator for RDF data.
+ *
+ * Validates RDF data graphs against SHACL shape graphs.
+ * Currently supports a subset of SHACL Core:
+ * - sh:targetClass
+ * - sh:property
+ * - sh:path
+ * - sh:datatype
+ * - sh:nodeKind (sh:IRI)
+ * - sh:minCount
+ * - sh:maxCount
+ * - sh:message
+ *
+ * @example
+ * ```typescript
+ * const validator = new ShaclValidator();
+ * const result = await validator.validate(dataRdf, shapesRdf);
+ * if (!result.conforms) {
+ *   console.log("Violations:", result.violations);
+ * }
+ * ```
+ */
+export class ShaclValidator {
+  private readonly turtleParser: TurtleParser;
+  private readonly shapesPrefixes: Record<string, string> = {
+    sh: "http://www.w3.org/ns/shacl#",
+    xsd: Namespace.XSD.iri.value,
+    rdf: Namespace.RDF.iri.value,
+    rdfs: Namespace.RDFS.iri.value,
+    "exo-ui": "https://exocortex.my/ontology/exo-ui#",
+  };
+
+  constructor() {
+    this.turtleParser = new TurtleParser();
+  }
+
+  /**
+   * Validate RDF data against SHACL shapes.
+   *
+   * @param dataTurtle - RDF data in Turtle format
+   * @param shapesTurtle - SHACL shapes in Turtle format
+   * @returns Validation result with conformance status and violations
+   */
+  async validate(dataTurtle: string, shapesTurtle: string): Promise<ValidationResult> {
+    // Handle empty data graph - should conform
+    if (!dataTurtle || dataTurtle.trim() === "") {
+      return { conforms: true, violations: [] };
+    }
+
+    // Parse shapes graph
+    const shapes = this.parseShapes(shapesTurtle);
+
+    // Parse data graph
+    const dataTriples = this.parseData(dataTurtle);
+
+    // Validate data against shapes
+    const violations: ValidationViolation[] = [];
+
+    for (const shape of shapes) {
+      if (!shape.targetClass) {
+        continue;
+      }
+
+      // Find all instances of the target class
+      const targetInstances = this.findInstancesOf(dataTriples, shape.targetClass);
+
+      // Validate each instance against the shape
+      for (const instance of targetInstances) {
+        const instanceViolations = this.validateInstance(dataTriples, instance, shape);
+        violations.push(...instanceViolations);
+      }
+    }
+
+    return {
+      conforms: violations.length === 0,
+      violations,
+    };
+  }
+
+  /**
+   * Parse SHACL shapes from Turtle format.
+   */
+  private parseShapes(shapesTurtle: string): ShapeDefinition[] {
+    const triples = this.parseWithExpandedSyntax(shapesTurtle);
+    const shapes: ShapeDefinition[] = [];
+    const blankNodeProperties: Map<string, Triple[]> = new Map();
+
+    // Group triples by subject
+    const triplesBySubject = new Map<string, Triple[]>();
+    for (const triple of triples) {
+      const subjectStr = this.nodeToString(triple.subject);
+      const subjectTriples = triplesBySubject.get(subjectStr) ?? [];
+      if (subjectTriples.length === 0) {
+        triplesBySubject.set(subjectStr, subjectTriples);
+      }
+      subjectTriples.push(triple);
+
+      // Track blank node definitions
+      if (subjectStr.startsWith("_:")) {
+        const blankTriples = blankNodeProperties.get(subjectStr) ?? [];
+        if (blankTriples.length === 0) {
+          blankNodeProperties.set(subjectStr, blankTriples);
+        }
+        blankTriples.push(triple);
+      }
+    }
+
+    // Find all NodeShapes
+    for (const [subject, subjectTriples] of triplesBySubject.entries()) {
+      const isNodeShape = subjectTriples.some(
+        (t) =>
+          t.predicate.value === Namespace.RDF.iri.value + "type" &&
+          t.object instanceof IRI &&
+          t.object.value === SH.NodeShape
+      );
+
+      if (!isNodeShape) {
+        continue;
+      }
+
+      // Extract targetClass
+      const targetClassTriple = subjectTriples.find(
+        (t) => t.predicate.value === SH.targetClass
+      );
+      const targetClass = targetClassTriple?.object instanceof IRI
+        ? targetClassTriple.object.value
+        : null;
+
+      // Extract properties
+      const properties: PropertyConstraint[] = [];
+      const propertyTriples = subjectTriples.filter(
+        (t) => t.predicate.value === SH.property
+      );
+
+      for (const propTriple of propertyTriples) {
+        const propNodeStr = this.nodeToString(propTriple.object);
+        const propNodeTriples = blankNodeProperties.get(propNodeStr) || [];
+
+        const constraint = this.parsePropertyConstraint(propNodeTriples);
+        if (constraint) {
+          properties.push(constraint);
+        }
+      }
+
+      shapes.push({
+        shapeUri: subject,
+        targetClass,
+        properties,
+      });
+    }
+
+    return shapes;
+  }
+
+  /**
+   * Parse a property constraint from blank node triples.
+   */
+  private parsePropertyConstraint(triples: Triple[]): PropertyConstraint | null {
+    let path: string | null = null;
+    let datatype: string | undefined;
+    let nodeKind: PropertyConstraint["nodeKind"] | undefined;
+    let minCount: number | undefined;
+    let maxCount: number | undefined;
+    let message: string | undefined;
+
+    for (const triple of triples) {
+      const pred = triple.predicate.value;
+
+      if (pred === SH.path && triple.object instanceof IRI) {
+        path = triple.object.value;
+      } else if (pred === SH.datatype && triple.object instanceof IRI) {
+        datatype = triple.object.value;
+      } else if (pred === SH.nodeKind && triple.object instanceof IRI) {
+        if (triple.object.value === SH.IRI) {
+          nodeKind = "IRI";
+        } else if (triple.object.value === SH.BlankNode) {
+          nodeKind = "BlankNode";
+        } else if (triple.object.value === SH.Literal) {
+          nodeKind = "Literal";
+        }
+      } else if (pred === SH.minCount && triple.object instanceof Literal) {
+        minCount = parseInt(triple.object.value, 10);
+      } else if (pred === SH.maxCount && triple.object instanceof Literal) {
+        maxCount = parseInt(triple.object.value, 10);
+      } else if (pred === SH.message && triple.object instanceof Literal) {
+        message = triple.object.value;
+      }
+    }
+
+    if (!path) {
+      return null;
+    }
+
+    return { path, datatype, nodeKind, minCount, maxCount, message };
+  }
+
+  /**
+   * Parse data Turtle using the standard parser.
+   */
+  private parseData(dataTurtle: string): Triple[] {
+    try {
+      return this.parseWithExpandedSyntax(dataTurtle);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Parse Turtle using the built-in parser.
+   * The shape format uses simple statements without semicolons for compatibility.
+   */
+  private parseWithExpandedSyntax(turtle: string): Triple[] {
+    return this.turtleParser.parse(turtle, { prefixes: this.shapesPrefixes });
+  }
+
+  /**
+   * Find all instances of a given RDF class.
+   */
+  private findInstancesOf(triples: Triple[], classUri: string): IRI[] {
+    const instances: IRI[] = [];
+
+    for (const triple of triples) {
+      if (
+        triple.predicate.value === Namespace.RDF.iri.value + "type" &&
+        triple.object instanceof IRI &&
+        triple.object.value === classUri &&
+        triple.subject instanceof IRI
+      ) {
+        instances.push(triple.subject);
+      }
+    }
+
+    return instances;
+  }
+
+  /**
+   * Validate a single instance against a shape.
+   */
+  private validateInstance(
+    triples: Triple[],
+    instance: IRI,
+    shape: ShapeDefinition
+  ): ValidationViolation[] {
+    const violations: ValidationViolation[] = [];
+
+    for (const constraint of shape.properties) {
+      const propertyViolations = this.validatePropertyConstraint(
+        triples,
+        instance,
+        constraint
+      );
+      violations.push(...propertyViolations);
+    }
+
+    return violations;
+  }
+
+  /**
+   * Validate a property constraint for an instance.
+   */
+  private validatePropertyConstraint(
+    triples: Triple[],
+    instance: IRI,
+    constraint: PropertyConstraint
+  ): ValidationViolation[] {
+    const violations: ValidationViolation[] = [];
+
+    // Find all values for this property
+    const values = triples.filter(
+      (t) =>
+        t.subject instanceof IRI &&
+        t.subject.equals(instance) &&
+        t.predicate.value === constraint.path
+    );
+
+    const count = values.length;
+    const pathLocalName = constraint.path.split("#").pop() || constraint.path.split("/").pop() || constraint.path;
+
+    // Check minCount
+    if (constraint.minCount !== undefined && count < constraint.minCount) {
+      violations.push({
+        focusNode: instance.value,
+        path: pathLocalName,
+        message: constraint.message || `Property ${pathLocalName} requires at least ${constraint.minCount} value(s), found ${count}`,
+        severity: "Violation",
+        sourceConstraintComponent: "MinCountConstraintComponent",
+      });
+    }
+
+    // Check maxCount
+    if (constraint.maxCount !== undefined && count > constraint.maxCount) {
+      violations.push({
+        focusNode: instance.value,
+        path: pathLocalName,
+        message: constraint.message || `Property ${pathLocalName} allows at most ${constraint.maxCount} value(s), found ${count}`,
+        severity: "Violation",
+        sourceConstraintComponent: "MaxCountConstraintComponent",
+      });
+    }
+
+    // Check datatype and nodeKind for each value
+    for (const triple of values) {
+      if (constraint.datatype) {
+        if (!(triple.object instanceof Literal)) {
+          violations.push({
+            focusNode: instance.value,
+            path: pathLocalName,
+            message: constraint.message || `Property ${pathLocalName} value must be a literal with datatype ${constraint.datatype}`,
+            severity: "Violation",
+            sourceConstraintComponent: "DatatypeConstraintComponent",
+          });
+        } else if (triple.object.datatype && triple.object.datatype.value !== constraint.datatype) {
+          violations.push({
+            focusNode: instance.value,
+            path: pathLocalName,
+            message: constraint.message || `Property ${pathLocalName} value has wrong datatype: expected ${constraint.datatype}, got ${triple.object.datatype.value}`,
+            severity: "Violation",
+            sourceConstraintComponent: "DatatypeConstraintComponent",
+          });
+        }
+      }
+
+      if (constraint.nodeKind === "IRI" && !(triple.object instanceof IRI)) {
+        violations.push({
+          focusNode: instance.value,
+          path: pathLocalName,
+          message: constraint.message || `Property ${pathLocalName} value must be an IRI`,
+          severity: "Violation",
+          sourceConstraintComponent: "NodeKindConstraintComponent",
+        });
+      }
+    }
+
+    return violations;
+  }
+
+  /**
+   * Convert an RDF node to string for map keys.
+   */
+  private nodeToString(node: Triple["subject"] | Triple["object"]): string {
+    if (node instanceof IRI) {
+      return node.value;
+    } else if (node instanceof Literal) {
+      return `"${node.value}"`;
+    } else if ("id" in node) {
+      // BlankNode
+      return `_:${(node as { id: string }).id}`;
+    }
+    return String(node);
+  }
+}

--- a/packages/exocortex/src/services/shacl/index.ts
+++ b/packages/exocortex/src/services/shacl/index.ts
@@ -1,0 +1,13 @@
+/**
+ * SHACL Validation Module
+ *
+ * Provides SHACL validation for RDF data against shape definitions.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1435
+ * @module services/shacl
+ * @since 1.4.0
+ */
+
+export { ShaclValidator } from "./ShaclValidator";
+export type { ValidationResult, ValidationViolation } from "./ShaclValidator";
+export { COMMAND_SHAPE_TURTLE, COMMAND_SHAPE_DEFINITION } from "./shapes/CommandShape";

--- a/packages/exocortex/src/services/shacl/shapes/CommandShape.ts
+++ b/packages/exocortex/src/services/shacl/shapes/CommandShape.ts
@@ -1,0 +1,132 @@
+/**
+ * CommandShape SHACL Definition
+ *
+ * SHACL shapes for validating Command class instances in RDF.
+ * Ensures command definitions have required properties and correct datatypes.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1435
+ * @module services/shacl/shapes
+ * @since 1.4.0
+ */
+
+/**
+ * SHACL shape for exo-ui:Command class.
+ *
+ * Required properties:
+ * - exo-ui:Command_id (xsd:string, exactly 1)
+ * - exo-ui:Command_name (xsd:string, min 1)
+ * - exo-ui:Command_action (IRI, min 1)
+ *
+ * Optional properties:
+ * - exo-ui:Command_icon (xsd:string)
+ * - exo-ui:Command_hotkey (xsd:string)
+ * - exo-ui:Command_condition (IRI or string)
+ * - exo-ui:Command_headless (xsd:boolean)
+ *
+ * Note: This shape is defined using named blank nodes for compatibility
+ * with the basic TurtleParser. Each sh:property is defined as a separate
+ * blank node with explicit sh:property triples linking to the main shape.
+ */
+export const COMMAND_SHAPE_TURTLE = `
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+
+exo-ui:CommandShape rdf:type sh:NodeShape .
+exo-ui:CommandShape sh:targetClass exo-ui:Command .
+
+exo-ui:CommandShape sh:property _:prop_id .
+_:prop_id sh:path exo-ui:Command_id .
+_:prop_id sh:datatype xsd:string .
+_:prop_id sh:minCount "1" .
+_:prop_id sh:maxCount "1" .
+_:prop_id sh:message "Command must have exactly one id (xsd:string)" .
+
+exo-ui:CommandShape sh:property _:prop_name .
+_:prop_name sh:path exo-ui:Command_name .
+_:prop_name sh:datatype xsd:string .
+_:prop_name sh:minCount "1" .
+_:prop_name sh:message "Command must have a name (xsd:string)" .
+
+exo-ui:CommandShape sh:property _:prop_action .
+_:prop_action sh:path exo-ui:Command_action .
+_:prop_action sh:nodeKind sh:IRI .
+_:prop_action sh:minCount "1" .
+_:prop_action sh:message "Command must have an action IRI" .
+
+exo-ui:CommandShape sh:property _:prop_icon .
+_:prop_icon sh:path exo-ui:Command_icon .
+_:prop_icon sh:datatype xsd:string .
+_:prop_icon sh:maxCount "1" .
+_:prop_icon sh:message "Command icon must be a string" .
+
+exo-ui:CommandShape sh:property _:prop_hotkey .
+_:prop_hotkey sh:path exo-ui:Command_hotkey .
+_:prop_hotkey sh:datatype xsd:string .
+_:prop_hotkey sh:maxCount "1" .
+_:prop_hotkey sh:message "Command hotkey must be a string" .
+
+exo-ui:CommandShape sh:property _:prop_condition .
+_:prop_condition sh:path exo-ui:Command_condition .
+_:prop_condition sh:maxCount "1" .
+_:prop_condition sh:message "Command condition should be an IRI reference or SPARQL string" .
+
+exo-ui:CommandShape sh:property _:prop_headless .
+_:prop_headless sh:path exo-ui:Command_headless .
+_:prop_headless sh:datatype xsd:boolean .
+_:prop_headless sh:maxCount "1" .
+_:prop_headless sh:message "Command headless flag must be a boolean" .
+`;
+
+/**
+ * Raw SHACL shape as a TypeScript object for programmatic access.
+ * Useful for unit testing and runtime shape generation.
+ */
+export const COMMAND_SHAPE_DEFINITION = {
+  targetClass: "https://exocortex.my/ontology/exo-ui#Command",
+  properties: {
+    id: {
+      path: "https://exocortex.my/ontology/exo-ui#Command_id",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+      minCount: 1,
+      maxCount: 1,
+      required: true,
+    },
+    name: {
+      path: "https://exocortex.my/ontology/exo-ui#Command_name",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+      minCount: 1,
+      required: true,
+    },
+    action: {
+      path: "https://exocortex.my/ontology/exo-ui#Command_action",
+      nodeKind: "IRI",
+      minCount: 1,
+      required: true,
+    },
+    icon: {
+      path: "https://exocortex.my/ontology/exo-ui#Command_icon",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+      maxCount: 1,
+      required: false,
+    },
+    hotkey: {
+      path: "https://exocortex.my/ontology/exo-ui#Command_hotkey",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+      maxCount: 1,
+      required: false,
+    },
+    condition: {
+      path: "https://exocortex.my/ontology/exo-ui#Command_condition",
+      maxCount: 1,
+      required: false,
+    },
+    headless: {
+      path: "https://exocortex.my/ontology/exo-ui#Command_headless",
+      datatype: "http://www.w3.org/2001/XMLSchema#boolean",
+      maxCount: 1,
+      required: false,
+    },
+  },
+};

--- a/packages/exocortex/tests/unit/services/shacl/CommandShapeValidator.test.ts
+++ b/packages/exocortex/tests/unit/services/shacl/CommandShapeValidator.test.ts
@@ -1,0 +1,313 @@
+/**
+ * CommandShape SHACL Validation Tests
+ *
+ * Tests for SHACL validation of Command class definitions in RDF.
+ * Part of v1.4 SHACL Validation milestone.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1435
+ * @module tests/services/shacl
+ * @since 1.4.0
+ */
+
+import { ShaclValidator, ValidationResult } from "../../../../src/services/shacl/ShaclValidator";
+import { COMMAND_SHAPE_TURTLE } from "../../../../src/services/shacl/shapes/CommandShape";
+
+describe("CommandShape SHACL Validation (Issue #1435)", () => {
+  let validator: ShaclValidator;
+
+  beforeEach(() => {
+    validator = new ShaclValidator();
+  });
+
+  describe("Valid Command Definitions", () => {
+    it("should pass for valid command with all required properties", async () => {
+      // Note: Using simple Turtle format (one triple per line) as parser doesn't support semicolons
+      const validCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyCommand rdf:type exo-ui:Command .
+ex:MyCommand exo-ui:Command_id "my-command"^^xsd:string .
+ex:MyCommand exo-ui:Command_name "My Command"^^xsd:string .
+ex:MyCommand exo-ui:Command_action ex:MyAction .
+      `;
+
+      const result = await validator.validate(validCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it("should pass for command with all properties including optional ones", async () => {
+      const fullCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:CreateTaskCommand rdf:type exo-ui:Command .
+ex:CreateTaskCommand exo-ui:Command_id "exocortex:create-task"^^xsd:string .
+ex:CreateTaskCommand exo-ui:Command_name "Create Task"^^xsd:string .
+ex:CreateTaskCommand exo-ui:Command_action ex:CreateTaskAction .
+ex:CreateTaskCommand exo-ui:Command_icon "plus-circle"^^xsd:string .
+ex:CreateTaskCommand exo-ui:Command_hotkey "Mod+Shift+T"^^xsd:string .
+ex:CreateTaskCommand exo-ui:Command_condition ex:AlwaysTrueCondition .
+      `;
+
+      const result = await validator.validate(fullCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it("should pass for multiple valid commands", async () => {
+      const multipleCommandsRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:Command1 rdf:type exo-ui:Command .
+ex:Command1 exo-ui:Command_id "cmd1"^^xsd:string .
+ex:Command1 exo-ui:Command_name "Command 1"^^xsd:string .
+ex:Command1 exo-ui:Command_action ex:Action1 .
+
+ex:Command2 rdf:type exo-ui:Command .
+ex:Command2 exo-ui:Command_id "cmd2"^^xsd:string .
+ex:Command2 exo-ui:Command_name "Command 2"^^xsd:string .
+ex:Command2 exo-ui:Command_action ex:Action2 .
+      `;
+
+      const result = await validator.validate(multipleCommandsRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(true);
+    });
+  });
+
+  describe("Invalid Command Definitions - Missing Required Properties", () => {
+    it("should fail for command without id", async () => {
+      const invalidCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyCommand rdf:type exo-ui:Command .
+ex:MyCommand exo-ui:Command_name "My Command"^^xsd:string .
+ex:MyCommand exo-ui:Command_action ex:MyAction .
+      `;
+
+      const result = await validator.validate(invalidCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.length).toBeGreaterThan(0);
+      expect(result.violations.some(v => v.path?.includes("Command_id"))).toBe(true);
+    });
+
+    it("should fail for command without name", async () => {
+      const invalidCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyCommand rdf:type exo-ui:Command .
+ex:MyCommand exo-ui:Command_id "my-command"^^xsd:string .
+ex:MyCommand exo-ui:Command_action ex:MyAction .
+      `;
+
+      const result = await validator.validate(invalidCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v => v.path?.includes("Command_name"))).toBe(true);
+    });
+
+    it("should fail for command without action", async () => {
+      const invalidCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyCommand rdf:type exo-ui:Command .
+ex:MyCommand exo-ui:Command_id "my-command"^^xsd:string .
+ex:MyCommand exo-ui:Command_name "My Command"^^xsd:string .
+      `;
+
+      const result = await validator.validate(invalidCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v => v.path?.includes("Command_action"))).toBe(true);
+    });
+
+    it("should fail for command missing all required properties", async () => {
+      const invalidCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:EmptyCommand rdf:type exo-ui:Command .
+      `;
+
+      const result = await validator.validate(invalidCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("Invalid Command Definitions - Cardinality Violations", () => {
+    it("should fail for command with multiple ids", async () => {
+      const invalidCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyCommand rdf:type exo-ui:Command .
+ex:MyCommand exo-ui:Command_id "my-command"^^xsd:string .
+ex:MyCommand exo-ui:Command_id "another-id"^^xsd:string .
+ex:MyCommand exo-ui:Command_name "My Command"^^xsd:string .
+ex:MyCommand exo-ui:Command_action ex:MyAction .
+      `;
+
+      const result = await validator.validate(invalidCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v =>
+        v.message?.toLowerCase().includes("exactly one") ||
+        v.message?.toLowerCase().includes("maxcount") ||
+        v.message?.toLowerCase().includes("at most")
+      )).toBe(true);
+    });
+  });
+
+  describe("Invalid Command Definitions - Wrong Datatypes", () => {
+    it("should fail for command with non-string id", async () => {
+      const invalidCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyCommand rdf:type exo-ui:Command .
+ex:MyCommand exo-ui:Command_id "123"^^xsd:integer .
+ex:MyCommand exo-ui:Command_name "My Command"^^xsd:string .
+ex:MyCommand exo-ui:Command_action ex:MyAction .
+      `;
+
+      const result = await validator.validate(invalidCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v => v.path?.includes("Command_id"))).toBe(true);
+    });
+
+    it("should fail for command with non-IRI action", async () => {
+      const invalidCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyCommand rdf:type exo-ui:Command .
+ex:MyCommand exo-ui:Command_id "my-command"^^xsd:string .
+ex:MyCommand exo-ui:Command_name "My Command"^^xsd:string .
+ex:MyCommand exo-ui:Command_action "not-an-iri"^^xsd:string .
+      `;
+
+      const result = await validator.validate(invalidCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v => v.path?.includes("Command_action"))).toBe(true);
+    });
+  });
+
+  describe("Validation Result Details", () => {
+    it("should include descriptive error messages", async () => {
+      const invalidCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyCommand rdf:type exo-ui:Command .
+      `;
+
+      const result = await validator.validate(invalidCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+
+      // Check that each violation has required fields
+      for (const violation of result.violations) {
+        expect(violation.focusNode).toBeDefined();
+        expect(violation.message).toBeDefined();
+        expect(violation.message.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("should identify the focus node in violations", async () => {
+      const invalidCommandRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:BadCommand rdf:type exo-ui:Command .
+      `;
+
+      const result = await validator.validate(invalidCommandRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v =>
+        v.focusNode?.includes("BadCommand")
+      )).toBe(true);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle empty data graph", async () => {
+      const emptyRdf = "";
+
+      const result = await validator.validate(emptyRdf, COMMAND_SHAPE_TURTLE);
+
+      // Empty graph should conform (no instances to validate)
+      expect(result.conforms).toBe(true);
+    });
+
+    it("should handle data graph with no Command instances", async () => {
+      const noCommandsRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ex: <https://example.org/> .
+
+ex:SomeOtherThing rdf:type ex:NotACommand .
+ex:SomeOtherThing ex:someProperty "value" .
+      `;
+
+      const result = await validator.validate(noCommandsRdf, COMMAND_SHAPE_TURTLE);
+
+      // No commands = nothing to validate = conforms
+      expect(result.conforms).toBe(true);
+    });
+
+    it("should validate only Command instances, ignoring other types", async () => {
+      const mixedRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:ValidCommand rdf:type exo-ui:Command .
+ex:ValidCommand exo-ui:Command_id "valid"^^xsd:string .
+ex:ValidCommand exo-ui:Command_name "Valid Command"^^xsd:string .
+ex:ValidCommand exo-ui:Command_action ex:SomeAction .
+
+ex:SomeOtherThing rdf:type ex:NotACommand .
+ex:SomeOtherThing ex:randomProperty "value" .
+      `;
+
+      const result = await validator.validate(mixedRdf, COMMAND_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add SHACL validator service for validating RDF data against shape definitions
- Create CommandShape defining constraints for exo-ui:Command class
- Enable validation of command definitions at import time

## Changes

- **ShaclValidator**: New service implementing subset of W3C SHACL spec
  - Supports: sh:targetClass, sh:property, sh:path, sh:datatype, sh:nodeKind, sh:minCount, sh:maxCount, sh:message
  - Returns ValidationResult with conforms status and detailed violations
- **CommandShape.ttl**: SHACL shape for Command class validation
  - Required: Command_id (xsd:string, exactly 1), Command_name (xsd:string), Command_action (IRI)
  - Optional: Command_icon, Command_hotkey, Command_condition, Command_headless
- **Exports**: ShaclValidator, ValidationResult, ValidationViolation, COMMAND_SHAPE_TURTLE, COMMAND_SHAPE_DEFINITION

## Testing

- [x] 15 unit tests covering:
  - Valid command definitions (3 tests)
  - Missing required properties (4 tests)
  - Cardinality violations (1 test)
  - Wrong datatypes (2 tests)
  - Validation result details (2 tests)
  - Edge cases (3 tests)
- [x] All tests passing locally

## Verification

- [x] `npm run lint` - No new errors in SHACL files
- [x] Unit tests pass: 15/15

## Acceptance Criteria

- [x] SHACL shapes created for Command class
- [x] Required properties validated (id, name, action)
- [x] Optional properties defined (icon, hotkey, condition, headless)
- [x] Cardinality constraints enforced (id exactly 1, others max 1)
- [x] Datatype constraints enforced (string for text, IRI for references)
- [x] Validation returns descriptive error messages
- [x] Integrated with @exocortex package exports

Closes #1435