### PR TITLE
feat(validation): add SHACL shapes for Button class

### DIFF
--- a/packages/exocortex/src/services/shacl/index.ts
+++ b/packages/exocortex/src/services/shacl/index.ts
@@ -11,3 +11,4 @@
 export { ShaclValidator } from "./ShaclValidator";
 export type { ValidationResult, ValidationViolation } from "./ShaclValidator";
 export { COMMAND_SHAPE_TURTLE, COMMAND_SHAPE_DEFINITION } from "./shapes/CommandShape";
+export { BUTTON_SHAPE_TURTLE, BUTTON_SHAPE_DEFINITION } from "./shapes/ButtonShape";

--- a/packages/exocortex/src/services/shacl/shapes/ButtonShape.ts
+++ b/packages/exocortex/src/services/shacl/shapes/ButtonShape.ts
@@ -1,0 +1,160 @@
+/**
+ * ButtonShape SHACL Definition
+ *
+ * SHACL shapes for validating Button class instances in RDF.
+ * Ensures button definitions have required properties and correct datatypes.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1444
+ * @module services/shacl/shapes
+ * @since 1.4.0
+ */
+
+/**
+ * SHACL shape for exo-ui:Button class.
+ *
+ * Required properties:
+ * - exo-ui:Button_id (xsd:string, exactly 1)
+ * - exo-ui:Button_action (IRI, min 1)
+ *
+ * Optional properties:
+ * - exo-ui:Button_label (xsd:string)
+ * - exo-ui:Button_icon (xsd:string)
+ * - exo-ui:Button_tooltip (xsd:string)
+ * - exo-ui:Button_condition (IRI)
+ * - exo-ui:Button_group (IRI)
+ * - exo-ui:Button_order (xsd:integer)
+ * - exo-ui:Button_variant (xsd:string)
+ *
+ * Note: This shape is defined using named blank nodes for compatibility
+ * with the basic TurtleParser. Each sh:property is defined as a separate
+ * blank node with explicit sh:property triples linking to the main shape.
+ */
+export const BUTTON_SHAPE_TURTLE = `
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+
+exo-ui:ButtonShape rdf:type sh:NodeShape .
+exo-ui:ButtonShape sh:targetClass exo-ui:Button .
+
+exo-ui:ButtonShape sh:property _:prop_id .
+_:prop_id sh:path exo-ui:Button_id .
+_:prop_id sh:datatype xsd:string .
+_:prop_id sh:minCount "1" .
+_:prop_id sh:maxCount "1" .
+_:prop_id sh:message "Button must have exactly one id (xsd:string)" .
+
+exo-ui:ButtonShape sh:property _:prop_action .
+_:prop_action sh:path exo-ui:Button_action .
+_:prop_action sh:nodeKind sh:IRI .
+_:prop_action sh:minCount "1" .
+_:prop_action sh:message "Button must have an action IRI" .
+
+exo-ui:ButtonShape sh:property _:prop_label .
+_:prop_label sh:path exo-ui:Button_label .
+_:prop_label sh:datatype xsd:string .
+_:prop_label sh:maxCount "1" .
+_:prop_label sh:message "Button label must be a string" .
+
+exo-ui:ButtonShape sh:property _:prop_icon .
+_:prop_icon sh:path exo-ui:Button_icon .
+_:prop_icon sh:datatype xsd:string .
+_:prop_icon sh:maxCount "1" .
+_:prop_icon sh:message "Button icon must be a string" .
+
+exo-ui:ButtonShape sh:property _:prop_tooltip .
+_:prop_tooltip sh:path exo-ui:Button_tooltip .
+_:prop_tooltip sh:datatype xsd:string .
+_:prop_tooltip sh:maxCount "1" .
+_:prop_tooltip sh:message "Button tooltip must be a string" .
+
+exo-ui:ButtonShape sh:property _:prop_condition .
+_:prop_condition sh:path exo-ui:Button_condition .
+_:prop_condition sh:nodeKind sh:IRI .
+_:prop_condition sh:maxCount "1" .
+_:prop_condition sh:message "Button condition must be an IRI reference" .
+
+exo-ui:ButtonShape sh:property _:prop_group .
+_:prop_group sh:path exo-ui:Button_group .
+_:prop_group sh:nodeKind sh:IRI .
+_:prop_group sh:maxCount "1" .
+_:prop_group sh:message "Button group must be an IRI reference" .
+
+exo-ui:ButtonShape sh:property _:prop_order .
+_:prop_order sh:path exo-ui:Button_order .
+_:prop_order sh:datatype xsd:integer .
+_:prop_order sh:maxCount "1" .
+_:prop_order sh:message "Button order must be an integer" .
+
+exo-ui:ButtonShape sh:property _:prop_variant .
+_:prop_variant sh:path exo-ui:Button_variant .
+_:prop_variant sh:datatype xsd:string .
+_:prop_variant sh:maxCount "1" .
+_:prop_variant sh:message "Button variant must be a string" .
+`;
+
+/**
+ * Raw SHACL shape as a TypeScript object for programmatic access.
+ * Useful for unit testing and runtime shape generation.
+ */
+export const BUTTON_SHAPE_DEFINITION = {
+  targetClass: "https://exocortex.my/ontology/exo-ui#Button",
+  properties: {
+    id: {
+      path: "https://exocortex.my/ontology/exo-ui#Button_id",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+      minCount: 1,
+      maxCount: 1,
+      required: true,
+    },
+    action: {
+      path: "https://exocortex.my/ontology/exo-ui#Button_action",
+      nodeKind: "IRI",
+      minCount: 1,
+      required: true,
+    },
+    label: {
+      path: "https://exocortex.my/ontology/exo-ui#Button_label",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+      maxCount: 1,
+      required: false,
+    },
+    icon: {
+      path: "https://exocortex.my/ontology/exo-ui#Button_icon",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+      maxCount: 1,
+      required: false,
+    },
+    tooltip: {
+      path: "https://exocortex.my/ontology/exo-ui#Button_tooltip",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+      maxCount: 1,
+      required: false,
+    },
+    condition: {
+      path: "https://exocortex.my/ontology/exo-ui#Button_condition",
+      nodeKind: "IRI",
+      maxCount: 1,
+      required: false,
+    },
+    group: {
+      path: "https://exocortex.my/ontology/exo-ui#Button_group",
+      nodeKind: "IRI",
+      maxCount: 1,
+      required: false,
+    },
+    order: {
+      path: "https://exocortex.my/ontology/exo-ui#Button_order",
+      datatype: "http://www.w3.org/2001/XMLSchema#integer",
+      maxCount: 1,
+      required: false,
+    },
+    variant: {
+      path: "https://exocortex.my/ontology/exo-ui#Button_variant",
+      datatype: "http://www.w3.org/2001/XMLSchema#string",
+      maxCount: 1,
+      required: false,
+    },
+  },
+};

--- a/packages/exocortex/tests/unit/services/shacl/ButtonShapeValidator.test.ts
+++ b/packages/exocortex/tests/unit/services/shacl/ButtonShapeValidator.test.ts
@@ -1,0 +1,289 @@
+/**
+ * ButtonShape SHACL Validation Tests
+ *
+ * Tests for SHACL validation of Button class definitions in RDF.
+ * Part of v1.4 SHACL Validation milestone.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1444
+ * @module tests/services/shacl
+ * @since 1.4.0
+ */
+
+import { ShaclValidator, ValidationResult } from "../../../../src/services/shacl/ShaclValidator";
+import { BUTTON_SHAPE_TURTLE } from "../../../../src/services/shacl/shapes/ButtonShape";
+
+describe("ButtonShape SHACL Validation (Issue #1444)", () => {
+  let validator: ShaclValidator;
+
+  beforeEach(() => {
+    validator = new ShaclValidator();
+  });
+
+  describe("Valid Button Definitions", () => {
+    it("should pass for valid button with all required properties", async () => {
+      // Note: Using simple Turtle format (one triple per line) as parser doesn't support semicolons
+      const validButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyButton rdf:type exo-ui:Button .
+ex:MyButton exo-ui:Button_id "my-button"^^xsd:string .
+ex:MyButton exo-ui:Button_action ex:MyAction .
+      `;
+
+      const result = await validator.validate(validButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it("should pass for button with all properties including optional ones", async () => {
+      const fullButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:CreateTaskButton rdf:type exo-ui:Button .
+ex:CreateTaskButton exo-ui:Button_id "create-task-btn"^^xsd:string .
+ex:CreateTaskButton exo-ui:Button_action ex:CreateTaskAction .
+ex:CreateTaskButton exo-ui:Button_label "Create Task"^^xsd:string .
+ex:CreateTaskButton exo-ui:Button_icon "plus-circle"^^xsd:string .
+ex:CreateTaskButton exo-ui:Button_tooltip "Create a new task"^^xsd:string .
+ex:CreateTaskButton exo-ui:Button_condition ex:HasActiveProject .
+ex:CreateTaskButton exo-ui:Button_group ex:StatusButtonGroup .
+ex:CreateTaskButton exo-ui:Button_order "10"^^xsd:integer .
+ex:CreateTaskButton exo-ui:Button_variant "primary"^^xsd:string .
+      `;
+
+      const result = await validator.validate(fullButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it("should pass for multiple valid buttons", async () => {
+      const multipleButtonsRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:Button1 rdf:type exo-ui:Button .
+ex:Button1 exo-ui:Button_id "btn1"^^xsd:string .
+ex:Button1 exo-ui:Button_action ex:Action1 .
+
+ex:Button2 rdf:type exo-ui:Button .
+ex:Button2 exo-ui:Button_id "btn2"^^xsd:string .
+ex:Button2 exo-ui:Button_action ex:Action2 .
+      `;
+
+      const result = await validator.validate(multipleButtonsRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(true);
+    });
+  });
+
+  describe("Invalid Button Definitions - Missing Required Properties", () => {
+    it("should fail for button without id", async () => {
+      const invalidButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyButton rdf:type exo-ui:Button .
+ex:MyButton exo-ui:Button_action ex:MyAction .
+      `;
+
+      const result = await validator.validate(invalidButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.length).toBeGreaterThan(0);
+      expect(result.violations.some(v => v.path?.includes("Button_id"))).toBe(true);
+    });
+
+    it("should fail for button without action", async () => {
+      const invalidButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyButton rdf:type exo-ui:Button .
+ex:MyButton exo-ui:Button_id "my-button"^^xsd:string .
+      `;
+
+      const result = await validator.validate(invalidButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v => v.path?.includes("Button_action"))).toBe(true);
+    });
+
+    it("should fail for button missing all required properties", async () => {
+      const invalidButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:EmptyButton rdf:type exo-ui:Button .
+      `;
+
+      const result = await validator.validate(invalidButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("Invalid Button Definitions - Cardinality Violations", () => {
+    it("should fail for button with multiple ids", async () => {
+      const invalidButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyButton rdf:type exo-ui:Button .
+ex:MyButton exo-ui:Button_id "my-button"^^xsd:string .
+ex:MyButton exo-ui:Button_id "another-id"^^xsd:string .
+ex:MyButton exo-ui:Button_action ex:MyAction .
+      `;
+
+      const result = await validator.validate(invalidButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v =>
+        v.message?.toLowerCase().includes("exactly one") ||
+        v.message?.toLowerCase().includes("maxcount") ||
+        v.message?.toLowerCase().includes("at most")
+      )).toBe(true);
+    });
+  });
+
+  describe("Invalid Button Definitions - Wrong Datatypes", () => {
+    it("should fail for button with non-string id", async () => {
+      const invalidButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyButton rdf:type exo-ui:Button .
+ex:MyButton exo-ui:Button_id "123"^^xsd:integer .
+ex:MyButton exo-ui:Button_action ex:MyAction .
+      `;
+
+      const result = await validator.validate(invalidButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v => v.path?.includes("Button_id"))).toBe(true);
+    });
+
+    it("should fail for button with non-IRI action", async () => {
+      const invalidButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyButton rdf:type exo-ui:Button .
+ex:MyButton exo-ui:Button_id "my-button"^^xsd:string .
+ex:MyButton exo-ui:Button_action "not-an-iri"^^xsd:string .
+      `;
+
+      const result = await validator.validate(invalidButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v => v.path?.includes("Button_action"))).toBe(true);
+    });
+  });
+
+  describe("Validation Result Details", () => {
+    it("should include descriptive error messages", async () => {
+      const invalidButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyButton rdf:type exo-ui:Button .
+      `;
+
+      const result = await validator.validate(invalidButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+
+      // Check that each violation has required fields
+      for (const violation of result.violations) {
+        expect(violation.focusNode).toBeDefined();
+        expect(violation.message).toBeDefined();
+        expect(violation.message.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("should identify the focus node in violations", async () => {
+      const invalidButtonRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:BadButton rdf:type exo-ui:Button .
+      `;
+
+      const result = await validator.validate(invalidButtonRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v =>
+        v.focusNode?.includes("BadButton")
+      )).toBe(true);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle empty data graph", async () => {
+      const emptyRdf = "";
+
+      const result = await validator.validate(emptyRdf, BUTTON_SHAPE_TURTLE);
+
+      // Empty graph should conform (no instances to validate)
+      expect(result.conforms).toBe(true);
+    });
+
+    it("should handle data graph with no Button instances", async () => {
+      const noButtonsRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ex: <https://example.org/> .
+
+ex:SomeOtherThing rdf:type ex:NotAButton .
+ex:SomeOtherThing ex:someProperty "value" .
+      `;
+
+      const result = await validator.validate(noButtonsRdf, BUTTON_SHAPE_TURTLE);
+
+      // No buttons = nothing to validate = conforms
+      expect(result.conforms).toBe(true);
+    });
+
+    it("should validate only Button instances, ignoring other types", async () => {
+      const mixedRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:ValidButton rdf:type exo-ui:Button .
+ex:ValidButton exo-ui:Button_id "valid"^^xsd:string .
+ex:ValidButton exo-ui:Button_action ex:SomeAction .
+
+ex:SomeOtherThing rdf:type ex:NotAButton .
+ex:SomeOtherThing ex:randomProperty "value" .
+      `;
+
+      const result = await validator.validate(mixedRdf, BUTTON_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add SHACL shapes for validating Button class instances in RDF.

### Changes
- **ButtonShape.ts**: SHACL constraints for `exo-ui:Button` class
  - Required: `Button_id` (xsd:string, exactly 1), `Button_action` (IRI, min 1)
  - Optional: label, icon, tooltip, condition, group, order, variant
- **ButtonShapeValidator.test.ts**: 14 comprehensive tests
- **index.ts**: Export ButtonShape

### Test Coverage
- Valid button definitions (all required, with optionals, multiple buttons)
- Missing required properties detection
- Cardinality violation detection
- Wrong datatype detection
- Validation result details
- Edge cases (empty graph, no Button instances)

All 14 tests pass.

## Test Plan
- [x] Run `npx jest --config packages/exocortex/jest.config.js --testPathPatterns="ButtonShapeValidator"` - 14 tests pass
- [x] Run `npm run test:unit` - All tests pass
- [x] Run `npm run build` - Build succeeds
- [x] Lint passes for modified files

Closes #1444