### PR TITLE
feat(shacl): Make Action_headless property required

### DIFF
--- a/packages/exocortex/src/services/shacl/shapes/ActionShape.ts
+++ b/packages/exocortex/src/services/shacl/shapes/ActionShape.ts
@@ -23,10 +23,12 @@
 /**
  * SHACL shape for base exo-ui:Action class.
  *
+ * Required properties:
+ * - exo-ui:Action_headless (xsd:boolean) - Whether action runs without UI (Issue #1446)
+ *
  * Optional properties (inherited by all subclasses):
  * - exo-ui:Action_cliCommand (xsd:string) - CLI command alternative
  * - exo-ui:Action_cliAlternative (xsd:string) - CLI argument syntax
- * - exo-ui:Action_headless (xsd:boolean) - Whether action runs without UI
  *
  * Note: This shape is defined using named blank nodes for compatibility
  * with the basic TurtleParser. Each sh:property is defined as a separate
@@ -56,8 +58,9 @@ _:prop_cliAlternative sh:message "Action cliAlternative must be a string" .
 exo-ui:ActionShape sh:property _:prop_headless .
 _:prop_headless sh:path exo-ui:Action_headless .
 _:prop_headless sh:datatype xsd:boolean .
+_:prop_headless sh:minCount "1" .
 _:prop_headless sh:maxCount "1" .
-_:prop_headless sh:message "Action headless must be a boolean" .
+_:prop_headless sh:message "Action must declare headless capability" .
 `;
 
 /**
@@ -222,8 +225,9 @@ export const ACTION_SHAPE_DEFINITION = {
     headless: {
       path: "https://exocortex.my/ontology/exo-ui#Action_headless",
       datatype: "http://www.w3.org/2001/XMLSchema#boolean",
+      minCount: 1,
       maxCount: 1,
-      required: false,
+      required: true,
     },
   },
 };

--- a/packages/exocortex/tests/unit/services/shacl/ActionShapeValidator.test.ts
+++ b/packages/exocortex/tests/unit/services/shacl/ActionShapeValidator.test.ts
@@ -20,7 +20,7 @@ describe("ActionShape SHACL Validation (Issue #1445)", () => {
   });
 
   describe("Base Action Shape Validation", () => {
-    it("should pass for valid base Action with required properties", async () => {
+    it("should pass for valid base Action with required properties (including headless)", async () => {
       const validActionRdf = `
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -28,16 +28,17 @@ describe("ActionShape SHACL Validation (Issue #1445)", () => {
 @prefix ex: <https://example.org/> .
 
 ex:MyAction rdf:type exo-ui:Action .
+ex:MyAction exo-ui:Action_headless "true"^^xsd:boolean .
       `;
 
       const result = await validator.validate(validActionRdf, ACTION_SHAPE_TURTLE);
 
-      // Base Action has no required properties - should pass
+      // Base Action requires Action_headless (Issue #1446)
       expect(result.conforms).toBe(true);
       expect(result.violations).toHaveLength(0);
     });
 
-    it("should pass for Action with optional cliCommand property", async () => {
+    it("should pass for Action with optional cliCommand property and required headless", async () => {
       const actionWithCliRdf = `
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -46,6 +47,7 @@ ex:MyAction rdf:type exo-ui:Action .
 
 ex:MyAction rdf:type exo-ui:Action .
 ex:MyAction exo-ui:Action_cliCommand "exocortex-cli task start"^^xsd:string .
+ex:MyAction exo-ui:Action_headless "true"^^xsd:boolean .
       `;
 
       const result = await validator.validate(actionWithCliRdf, ACTION_SHAPE_TURTLE);
@@ -101,6 +103,24 @@ ex:MyAction exo-ui:Action_headless "not-a-bool"^^xsd:string .
 
       expect(result.conforms).toBe(false);
       expect(result.violations.some(v => v.path?.includes("Action_headless"))).toBe(true);
+    });
+
+    it("should fail for Action without Action_headless (required property) - Issue #1446", async () => {
+      const actionWithoutHeadlessRdf = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix exo-ui: <https://exocortex.my/ontology/exo-ui#> .
+@prefix ex: <https://example.org/> .
+
+ex:MyAction rdf:type exo-ui:Action .
+ex:MyAction exo-ui:Action_cliCommand "exocortex-cli do-something"^^xsd:string .
+      `;
+
+      const result = await validator.validate(actionWithoutHeadlessRdf, ACTION_SHAPE_TURTLE);
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations.some(v => v.path?.includes("Action_headless"))).toBe(true);
+      expect(result.violations.some(v => v.message?.includes("must declare headless"))).toBe(true);
     });
   });
 
@@ -408,6 +428,7 @@ ex:SomeOtherThing ex:someProperty "value" .
 @prefix ex: <https://example.org/> .
 
 ex:ValidAction rdf:type exo-ui:Action .
+ex:ValidAction exo-ui:Action_headless "false"^^xsd:boolean .
 
 ex:SomeOtherThing rdf:type ex:NotAnAction .
 ex:SomeOtherThing ex:randomProperty "value" .


### PR DESCRIPTION
## Summary

- Make `Action_headless` property required (minCount 1) in base Action SHACL shape
- Update error message to "Action must declare headless capability"
- Ensures all actions explicitly declare CLI compatibility

## Changes

- `packages/exocortex/src/services/shacl/shapes/ActionShape.ts`:
  - Add `sh:minCount "1"` to `_:prop_headless` constraint
  - Update `sh:message` to "Action must declare headless capability"
  - Update TypeScript definition `ACTION_SHAPE_DEFINITION.properties.headless.required` to `true`
  - Update doc comment to reflect headless is now required

- `packages/exocortex/tests/unit/services/shacl/ActionShapeValidator.test.ts`:
  - Add test case for validation failure when Action_headless is missing (Issue #1446)
  - Update existing tests to include required headless property

## Testing

- [x] Added regression test for Issue #1446
- [x] All 27 ActionShapeValidator tests pass
- [x] Build succeeds

## Verification

- [x] `npm run build` — PASSED
- [x] `npx jest tests/unit/services/shacl/ActionShapeValidator.test.ts` — PASSED (27/27)

## Acceptance Criteria

- [x] Action_headless property shape has minCount 1 (required)
- [x] datatype xsd:boolean enforced
- [x] Clear error message "Action must declare headless capability"
- [x] Tests pass

Closes #1446