### PR TITLE
feat: [Plugin+CLI] Implement validation error display

### DIFF
--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,0 +1,76 @@
+/**
+ * Validate CLI Command
+ *
+ * Validates ontology data against SHACL shapes and displays results
+ * in table or JSON format.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1448
+ */
+
+import { Command } from "commander";
+import fs from "fs";
+import { ShaclValidator, ValidationErrorFormatter } from "exocortex";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { ExitCodes } from "../utils/ExitCodes.js";
+import { FileNotFoundError } from "../utils/errors/index.js";
+
+export interface ValidateOptions {
+  ontology: string;
+  shapes: string;
+  format: "table" | "json";
+}
+
+/**
+ * Creates the 'validate' command for validating ontology against SHACL shapes.
+ *
+ * @example
+ * exocortex validate --ontology ems-ui.ttl --shapes shapes.ttl
+ * exocortex validate --ontology ems-ui.ttl --shapes shapes.ttl --format json
+ */
+export function validateCommand(): Command {
+  return new Command("validate")
+    .description("Validate ontology against SHACL shapes")
+    .requiredOption("--ontology <path>", "Path to ontology file (Turtle format)")
+    .requiredOption("--shapes <path>", "Path to SHACL shapes file (Turtle format)")
+    .option("--format <type>", "Output format: table|json", "table")
+    .action(async (options: ValidateOptions) => {
+      const format = (options.format || "table") as OutputFormat;
+      ErrorHandler.setFormat(format);
+
+      try {
+        // Validate file existence
+        if (!fs.existsSync(options.ontology)) {
+          throw new FileNotFoundError(options.ontology, "Ontology file not found");
+        }
+        if (!fs.existsSync(options.shapes)) {
+          throw new FileNotFoundError(options.shapes, "SHACL shapes file not found");
+        }
+
+        // Read files
+        const ontologyData = fs.readFileSync(options.ontology, "utf-8");
+        const shapesData = fs.readFileSync(options.shapes, "utf-8");
+
+        // Validate
+        const validator = new ShaclValidator();
+        const result = await validator.validate(ontologyData, shapesData);
+
+        // Format output
+        const formatter = new ValidationErrorFormatter();
+
+        if (options.format === "json") {
+          console.log(formatter.formatAsJson(result));
+        } else {
+          console.log(formatter.formatForConsole(result));
+        }
+
+        // Exit with appropriate code
+        if (!result.conforms) {
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+
+        process.exit(ExitCodes.SUCCESS);
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import { batchRepairCommand } from "./commands/batch-repair.js";
 import { resolveCommand } from "./commands/resolve.js";
 import { askCommand } from "./commands/ask.js";
 import { dailyReviewCommand } from "./commands/daily-review.js";
+import { validateCommand } from "./commands/validate.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -33,5 +34,6 @@ program.addCommand(batchRepairCommand());
 program.addCommand(resolveCommand());
 program.addCommand(askCommand());
 program.addCommand(dailyReviewCommand());
+program.addCommand(validateCommand());
 
 program.parse();

--- a/packages/cli/src/utils/ExitCodes.ts
+++ b/packages/cli/src/utils/ExitCodes.ts
@@ -30,4 +30,7 @@ export enum ExitCodes {
 
   /** Concurrent modification detected (file changed during operation) */
   CONCURRENT_MODIFICATION = 8,
+
+  /** Validation failed (SHACL or other validation errors) */
+  VALIDATION_ERROR = 9,
 }

--- a/packages/cli/tests/unit/commands/validate.test.ts
+++ b/packages/cli/tests/unit/commands/validate.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for validate CLI command
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1448
+ */
+
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs";
+
+// Mock ValidationErrorFormatter
+const mockFormatter = {
+  formatForConsole: jest.fn().mockReturnValue("Validation Results: 0 violations, 0 warnings\n\n✅ All validations passed"),
+  formatAsJson: jest.fn().mockReturnValue('{"conforms":true,"violations":[]}'),
+};
+
+const mockValidator = {
+  validate: jest.fn().mockResolvedValue({ conforms: true, violations: [] }),
+};
+
+jest.unstable_mockModule("exocortex", () => ({
+  ShaclValidator: jest.fn(() => mockValidator),
+  ValidationErrorFormatter: jest.fn(() => mockFormatter),
+}));
+
+const { validateCommand } = await import("../../../src/commands/validate.js");
+
+describe("validateCommand", () => {
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let existsSyncSpy: jest.SpiedFunction<typeof fs.existsSync>;
+  let readFileSyncSpy: jest.SpiedFunction<typeof fs.readFileSync>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockValidator.validate.mockResolvedValue({ conforms: true, violations: [] });
+
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    existsSyncSpy = jest.spyOn(fs, "existsSync");
+    readFileSyncSpy = jest.spyOn(fs, "readFileSync");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("command setup", () => {
+    it("should create command with correct name", () => {
+      const cmd = validateCommand();
+      expect(cmd.name()).toBe("validate");
+    });
+
+    it("should have correct description", () => {
+      const cmd = validateCommand();
+      expect(cmd.description()).toBe("Validate ontology against SHACL shapes");
+    });
+
+    it("should have --ontology option", () => {
+      const cmd = validateCommand();
+      const ontologyOption = cmd.options.find(opt => opt.long === "--ontology");
+      expect(ontologyOption).toBeDefined();
+    });
+
+    it("should have --shapes option", () => {
+      const cmd = validateCommand();
+      const shapesOption = cmd.options.find(opt => opt.long === "--shapes");
+      expect(shapesOption).toBeDefined();
+    });
+
+    it("should have --format option with table as default", () => {
+      const cmd = validateCommand();
+      const formatOption = cmd.options.find(opt => opt.long === "--format");
+      expect(formatOption).toBeDefined();
+      expect(formatOption?.defaultValue).toBe("table");
+    });
+  });
+
+  describe("validation execution", () => {
+    it("should validate ontology file against shapes", async () => {
+      existsSyncSpy.mockReturnValue(true);
+      readFileSyncSpy.mockReturnValue("@prefix : <http://example.org/> .");
+
+      const cmd = validateCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--ontology", "/test/ems-ui.ttl",
+        "--shapes", "/test/shapes.ttl",
+      ]);
+
+      expect(mockValidator.validate).toHaveBeenCalled();
+      expect(mockFormatter.formatForConsole).toHaveBeenCalled();
+    });
+
+    it("should error when ontology file not found", async () => {
+      existsSyncSpy.mockImplementation((path) => !String(path).includes("ems-ui"));
+
+      const cmd = validateCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--ontology", "/missing/ems-ui.ttl",
+        "--shapes", "/test/shapes.ttl",
+      ]);
+
+      expect(processExitSpy).toHaveBeenCalled();
+    });
+
+    it("should error when shapes file not found", async () => {
+      existsSyncSpy.mockImplementation((path) => String(path).includes("ontology"));
+
+      const cmd = validateCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--ontology", "/test/ontology.ttl",
+        "--shapes", "/missing/shapes.ttl",
+      ]);
+
+      expect(processExitSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("output formats", () => {
+    it("should output in table format by default", async () => {
+      existsSyncSpy.mockReturnValue(true);
+      readFileSyncSpy.mockReturnValue("@prefix : <http://example.org/> .");
+
+      const cmd = validateCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--ontology", "/test/ontology.ttl",
+        "--shapes", "/test/shapes.ttl",
+      ]);
+
+      expect(mockFormatter.formatForConsole).toHaveBeenCalled();
+      expect(mockFormatter.formatAsJson).not.toHaveBeenCalled();
+    });
+
+    it("should output in JSON format when specified", async () => {
+      existsSyncSpy.mockReturnValue(true);
+      readFileSyncSpy.mockReturnValue("@prefix : <http://example.org/> .");
+
+      const cmd = validateCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--ontology", "/test/ontology.ttl",
+        "--shapes", "/test/shapes.ttl",
+        "--format", "json",
+      ]);
+
+      expect(mockFormatter.formatAsJson).toHaveBeenCalled();
+    });
+  });
+
+  describe("exit codes", () => {
+    it("should exit with 0 when validation passes", async () => {
+      existsSyncSpy.mockReturnValue(true);
+      readFileSyncSpy.mockReturnValue("@prefix : <http://example.org/> .");
+      mockValidator.validate.mockResolvedValue({ conforms: true, violations: [] });
+
+      const cmd = validateCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--ontology", "/test/ontology.ttl",
+        "--shapes", "/test/shapes.ttl",
+      ]);
+
+      expect(processExitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it("should exit with 9 when validation fails", async () => {
+      existsSyncSpy.mockReturnValue(true);
+      readFileSyncSpy.mockReturnValue("@prefix : <http://example.org/> .");
+      mockValidator.validate.mockResolvedValue({
+        conforms: false,
+        violations: [{ focusNode: "test", message: "error", severity: "Violation" }],
+      });
+
+      const cmd = validateCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--ontology", "/test/ontology.ttl",
+        "--shapes", "/test/shapes.ttl",
+      ]);
+
+      // Exit code 9 is VALIDATION_ERROR
+      expect(processExitSpy).toHaveBeenCalledWith(9);
+    });
+  });
+});

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -384,6 +384,10 @@ export {
   type ValidationViolation,
 } from "./services/shacl/ShaclValidator";
 export {
+  ValidationErrorFormatter,
+  type NoticeConfig,
+} from "./services/shacl/ValidationErrorFormatter";
+export {
   COMMAND_SHAPE_TURTLE,
   COMMAND_SHAPE_DEFINITION,
 } from "./services/shacl/shapes/CommandShape";

--- a/packages/exocortex/src/services/shacl/ValidationErrorFormatter.ts
+++ b/packages/exocortex/src/services/shacl/ValidationErrorFormatter.ts
@@ -1,0 +1,244 @@
+/**
+ * ValidationErrorFormatter Service
+ *
+ * Formats SHACL validation results for display in different environments:
+ * - Console/CLI output (text table and JSON)
+ * - Obsidian Notice messages
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1448
+ * @module services/shacl
+ * @since 1.4.0
+ */
+
+import type { ValidationResult, ValidationViolation } from "./ShaclValidator";
+
+/**
+ * Configuration for a notice message
+ */
+export interface NoticeConfig {
+  /** The message to display */
+  message: string;
+  /** Duration to show the notice in milliseconds */
+  duration: number;
+}
+
+/**
+ * Formats SHACL validation results for different output environments.
+ *
+ * @example
+ * ```typescript
+ * const formatter = new ValidationErrorFormatter();
+ *
+ * // Console output
+ * console.log(formatter.formatForConsole(result));
+ *
+ * // JSON output
+ * console.log(formatter.formatAsJson(result));
+ *
+ * // Obsidian notices
+ * const notices = formatter.formatForNotice(result);
+ * notices.forEach(n => new Notice(n.message, n.duration));
+ * ```
+ */
+export class ValidationErrorFormatter {
+  /**
+   * Format validation result for console/CLI output.
+   *
+   * @param result - The validation result to format
+   * @returns Formatted string for console output
+   */
+  formatForConsole(result: ValidationResult): string {
+    const { violationCount, warningCount, infoCount } = this.countBySeverity(result.violations);
+    const lines: string[] = [];
+
+    // Header with summary
+    const parts: string[] = [];
+    if (violationCount > 0) {
+      parts.push(`${violationCount} violation${violationCount !== 1 ? "s" : ""}`);
+    }
+    if (warningCount > 0) {
+      parts.push(`${warningCount} warning${warningCount !== 1 ? "s" : ""}`);
+    }
+    if (infoCount > 0) {
+      parts.push(`${infoCount} info${infoCount !== 1 ? "s" : ""}`);
+    }
+
+    if (parts.length === 0) {
+      lines.push("Validation Results: 0 violations, 0 warnings");
+      lines.push("");
+      lines.push("✅ All validations passed");
+    } else {
+      lines.push(`Validation Results: ${parts.join(", ")}`);
+      lines.push("");
+
+      // Group by focus node for better readability
+      const grouped = this.groupByFocusNode(result.violations);
+
+      for (const [focusNode, violations] of grouped) {
+        for (const violation of violations) {
+          const severityLabel = this.getSeverityLabel(violation.severity);
+          lines.push(`${severityLabel} in ${focusNode}`);
+          if (violation.path) {
+            lines.push(`  Path: ${violation.path}`);
+          }
+          lines.push(`  Message: ${violation.message}`);
+          lines.push("");
+        }
+      }
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
+   * Format validation result as JSON.
+   *
+   * @param result - The validation result to format
+   * @returns JSON string representation of the result
+   */
+  formatAsJson(result: ValidationResult): string {
+    const { violationCount, warningCount, infoCount } = this.countBySeverity(result.violations);
+
+    const output = {
+      conforms: result.conforms,
+      summary: {
+        violationCount,
+        warningCount,
+        infoCount,
+        total: result.violations.length,
+      },
+      violations: result.violations.map((v) => ({
+        focusNode: v.focusNode,
+        path: v.path,
+        message: v.message,
+        severity: v.severity,
+        sourceConstraintComponent: v.sourceConstraintComponent,
+      })),
+    };
+
+    return JSON.stringify(output, null, 2);
+  }
+
+  /**
+   * Format validation result for Obsidian Notice display.
+   *
+   * @param result - The validation result to format
+   * @returns Array of notice configurations
+   */
+  formatForNotice(result: ValidationResult): NoticeConfig[] {
+    if (result.violations.length === 0) {
+      return [];
+    }
+
+    return result.violations.map((violation) => ({
+      message: this.formatNoticeMessage(violation),
+      duration: this.getNoticeDuration(violation.severity),
+    }));
+  }
+
+  /**
+   * Group violations by focus node.
+   *
+   * @param violations - Array of validation violations
+   * @returns Map of focus node to violations
+   */
+  groupByFocusNode(violations: ValidationViolation[]): Map<string, ValidationViolation[]> {
+    const grouped = new Map<string, ValidationViolation[]>();
+
+    for (const violation of violations) {
+      const existing = grouped.get(violation.focusNode) || [];
+      existing.push(violation);
+      grouped.set(violation.focusNode, existing);
+    }
+
+    return grouped;
+  }
+
+  /**
+   * Count violations by severity level.
+   */
+  private countBySeverity(violations: ValidationViolation[]): {
+    violationCount: number;
+    warningCount: number;
+    infoCount: number;
+  } {
+    let violationCount = 0;
+    let warningCount = 0;
+    let infoCount = 0;
+
+    for (const v of violations) {
+      switch (v.severity) {
+        case "Violation":
+          violationCount++;
+          break;
+        case "Warning":
+          warningCount++;
+          break;
+        case "Info":
+          infoCount++;
+          break;
+      }
+    }
+
+    return { violationCount, warningCount, infoCount };
+  }
+
+  /**
+   * Get the display label for a severity level.
+   */
+  private getSeverityLabel(severity: ValidationViolation["severity"]): string {
+    switch (severity) {
+      case "Violation":
+        return "VIOLATION";
+      case "Warning":
+        return "WARNING";
+      case "Info":
+        return "INFO";
+      default:
+        return "UNKNOWN";
+    }
+  }
+
+  /**
+   * Format a single violation as a notice message.
+   */
+  private formatNoticeMessage(violation: ValidationViolation): string {
+    const emoji = this.getSeverityEmoji(violation.severity);
+    return `${emoji} ${violation.focusNode}: ${violation.message}`;
+  }
+
+  /**
+   * Get the emoji for a severity level.
+   */
+  private getSeverityEmoji(severity: ValidationViolation["severity"]): string {
+    switch (severity) {
+      case "Violation":
+        return "❌";
+      case "Warning":
+        return "⚠️";
+      case "Info":
+        return "ℹ️";
+      default:
+        return "❓";
+    }
+  }
+
+  /**
+   * Get the notice duration based on severity.
+   * - Violations: 10 seconds (important, needs attention)
+   * - Warnings: 5 seconds
+   * - Info: 3 seconds
+   */
+  private getNoticeDuration(severity: ValidationViolation["severity"]): number {
+    switch (severity) {
+      case "Violation":
+        return 10000;
+      case "Warning":
+        return 5000;
+      case "Info":
+        return 3000;
+      default:
+        return 5000;
+    }
+  }
+}

--- a/packages/exocortex/tests/services/shacl/ValidationErrorFormatter.test.ts
+++ b/packages/exocortex/tests/services/shacl/ValidationErrorFormatter.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for ValidationErrorFormatter
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1448
+ */
+
+import { ValidationErrorFormatter } from "../../../src/services/shacl/ValidationErrorFormatter";
+import type { ValidationResult, ValidationViolation } from "../../../src/services/shacl/ShaclValidator";
+
+describe("ValidationErrorFormatter", () => {
+  let formatter: ValidationErrorFormatter;
+
+  beforeEach(() => {
+    formatter = new ValidationErrorFormatter();
+  });
+
+  describe("formatForConsole", () => {
+    it("should format empty result as conformant message", () => {
+      const result: ValidationResult = {
+        conforms: true,
+        violations: [],
+      };
+
+      const output = formatter.formatForConsole(result);
+
+      expect(output).toContain("Validation Results: 0 violations, 0 warnings");
+      expect(output).toContain("✅ All validations passed");
+    });
+
+    it("should format single violation", () => {
+      const result: ValidationResult = {
+        conforms: false,
+        violations: [
+          {
+            focusNode: "ems-ui:MyBrokenButton",
+            path: "exo-ui:Button_action",
+            message: "Property is required but missing",
+            severity: "Violation",
+            sourceConstraintComponent: "MinCountConstraintComponent",
+          },
+        ],
+      };
+
+      const output = formatter.formatForConsole(result);
+
+      expect(output).toContain("Validation Results: 1 violation");
+      expect(output).toContain("VIOLATION");
+      expect(output).toContain("ems-ui:MyBrokenButton");
+      expect(output).toContain("exo-ui:Button_action");
+      expect(output).toContain("Property is required but missing");
+    });
+
+    it("should format multiple violations and warnings", () => {
+      const result: ValidationResult = {
+        conforms: false,
+        violations: [
+          {
+            focusNode: "ems-ui:MyBrokenButton",
+            path: "exo-ui:Button_action",
+            message: "Property is required but missing",
+            severity: "Violation",
+          },
+          {
+            focusNode: "ems-ui:MyBadAction",
+            path: "exo-ui:Action_headless",
+            message: "All actions MUST declare headless compatibility",
+            severity: "Violation",
+          },
+          {
+            focusNode: "ems-ui:OldButton",
+            path: "exo-ui:Button_variant",
+            message: "Deprecated variant 'default', use 'secondary'",
+            severity: "Warning",
+          },
+        ],
+      };
+
+      const output = formatter.formatForConsole(result);
+
+      expect(output).toContain("2 violations");
+      expect(output).toContain("1 warning");
+      expect(output).toContain("VIOLATION in ems-ui:MyBrokenButton");
+      expect(output).toContain("VIOLATION in ems-ui:MyBadAction");
+      expect(output).toContain("WARNING in ems-ui:OldButton");
+    });
+
+    it("should format Info severity correctly", () => {
+      const result: ValidationResult = {
+        conforms: true,
+        violations: [
+          {
+            focusNode: "ems-ui:SomeComponent",
+            path: "exo-ui:Component_version",
+            message: "Consider updating to latest API",
+            severity: "Info",
+          },
+        ],
+      };
+
+      const output = formatter.formatForConsole(result);
+
+      expect(output).toContain("INFO in ems-ui:SomeComponent");
+    });
+  });
+
+  describe("formatAsJson", () => {
+    it("should format result as valid JSON", () => {
+      const result: ValidationResult = {
+        conforms: true,
+        violations: [],
+      };
+
+      const output = formatter.formatAsJson(result);
+      const parsed = JSON.parse(output);
+
+      expect(parsed.conforms).toBe(true);
+      expect(parsed.violations).toEqual([]);
+    });
+
+    it("should include all violation details in JSON", () => {
+      const result: ValidationResult = {
+        conforms: false,
+        violations: [
+          {
+            focusNode: "ems-ui:MyButton",
+            path: "exo-ui:Button_action",
+            message: "Property is required",
+            severity: "Violation",
+            sourceConstraintComponent: "MinCountConstraintComponent",
+          },
+        ],
+      };
+
+      const output = formatter.formatAsJson(result);
+      const parsed = JSON.parse(output);
+
+      expect(parsed.conforms).toBe(false);
+      expect(parsed.violations).toHaveLength(1);
+      expect(parsed.violations[0].focusNode).toBe("ems-ui:MyButton");
+      expect(parsed.violations[0].path).toBe("exo-ui:Button_action");
+      expect(parsed.violations[0].message).toBe("Property is required");
+      expect(parsed.violations[0].severity).toBe("Violation");
+      expect(parsed.violations[0].sourceConstraintComponent).toBe("MinCountConstraintComponent");
+    });
+
+    it("should include violation and warning counts in JSON", () => {
+      const result: ValidationResult = {
+        conforms: false,
+        violations: [
+          { focusNode: "a", message: "error", severity: "Violation" },
+          { focusNode: "b", message: "warning", severity: "Warning" },
+          { focusNode: "c", message: "info", severity: "Info" },
+        ],
+      };
+
+      const output = formatter.formatAsJson(result);
+      const parsed = JSON.parse(output);
+
+      expect(parsed.summary.violationCount).toBe(1);
+      expect(parsed.summary.warningCount).toBe(1);
+      expect(parsed.summary.infoCount).toBe(1);
+    });
+  });
+
+  describe("formatForNotice", () => {
+    it("should return empty array for conformant result", () => {
+      const result: ValidationResult = {
+        conforms: true,
+        violations: [],
+      };
+
+      const notices = formatter.formatForNotice(result);
+
+      expect(notices).toEqual([]);
+    });
+
+    it("should format violations with error emoji", () => {
+      const result: ValidationResult = {
+        conforms: false,
+        violations: [
+          {
+            focusNode: "ems-ui:MyButton",
+            message: "Property is required",
+            severity: "Violation",
+          },
+        ],
+      };
+
+      const notices = formatter.formatForNotice(result);
+
+      expect(notices).toHaveLength(1);
+      expect(notices[0].message).toContain("❌");
+      expect(notices[0].message).toContain("ems-ui:MyButton");
+      expect(notices[0].message).toContain("Property is required");
+      expect(notices[0].duration).toBe(10000);
+    });
+
+    it("should format warnings with warning emoji", () => {
+      const result: ValidationResult = {
+        conforms: true,
+        violations: [
+          {
+            focusNode: "ems-ui:OldButton",
+            message: "Deprecated variant",
+            severity: "Warning",
+          },
+        ],
+      };
+
+      const notices = formatter.formatForNotice(result);
+
+      expect(notices).toHaveLength(1);
+      expect(notices[0].message).toContain("⚠️");
+      expect(notices[0].duration).toBe(5000);
+    });
+
+    it("should format info with info emoji", () => {
+      const result: ValidationResult = {
+        conforms: true,
+        violations: [
+          {
+            focusNode: "ems-ui:Component",
+            message: "Consider upgrading",
+            severity: "Info",
+          },
+        ],
+      };
+
+      const notices = formatter.formatForNotice(result);
+
+      expect(notices).toHaveLength(1);
+      expect(notices[0].message).toContain("ℹ️");
+      expect(notices[0].duration).toBe(3000);
+    });
+  });
+
+  describe("groupByFocusNode", () => {
+    it("should group violations by focus node", () => {
+      const violations: ValidationViolation[] = [
+        { focusNode: "nodeA", message: "error1", severity: "Violation" },
+        { focusNode: "nodeA", message: "error2", severity: "Violation" },
+        { focusNode: "nodeB", message: "error3", severity: "Warning" },
+      ];
+
+      const grouped = formatter.groupByFocusNode(violations);
+
+      expect(grouped.get("nodeA")).toHaveLength(2);
+      expect(grouped.get("nodeB")).toHaveLength(1);
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/application/services/NoticeErrorDisplay.ts
+++ b/packages/obsidian-plugin/src/application/services/NoticeErrorDisplay.ts
@@ -1,0 +1,87 @@
+/**
+ * NoticeErrorDisplay Service
+ *
+ * Displays SHACL validation errors using Obsidian's Notice API.
+ * Provides user-visible feedback when UI ontologies fail validation.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1448
+ * @module application/services
+ * @since 1.4.0
+ */
+
+import { Notice } from "obsidian";
+import type { ShaclValidationResult, NoticeConfig, ValidationErrorFormatter } from "exocortex";
+
+/**
+ * Interface for error display to allow testing without Obsidian dependency.
+ */
+export interface IErrorDisplay {
+  display(result: ShaclValidationResult): void;
+}
+
+/**
+ * Displays SHACL validation errors using Obsidian's Notice component.
+ *
+ * @example
+ * ```typescript
+ * const display = new NoticeErrorDisplay(formatter);
+ * display.display(validationResult);
+ * ```
+ */
+export class NoticeErrorDisplay implements IErrorDisplay {
+  constructor(private formatter: ValidationErrorFormatter) {}
+
+  /**
+   * Display validation errors as Obsidian notices.
+   *
+   * - Violations are shown with ❌ and displayed for 10 seconds
+   * - Warnings are shown with ⚠️ and displayed for 5 seconds
+   * - Info messages are shown with ℹ️ and displayed for 3 seconds
+   *
+   * @param result - The validation result to display
+   */
+  display(result: ShaclValidationResult): void {
+    if (result.conforms && result.violations.length === 0) {
+      return; // Nothing to display for conformant results
+    }
+
+    const notices = this.formatter.formatForNotice(result);
+
+    for (const notice of notices) {
+      this.showNotice(notice);
+    }
+  }
+
+  /**
+   * Display a single notice.
+   * This is a separate method to allow testing/mocking.
+   */
+  protected showNotice(config: NoticeConfig): void {
+    new Notice(config.message, config.duration);
+  }
+
+  /**
+   * Display a summary notice at the end of validation.
+   *
+   * @param result - The validation result
+   */
+  displaySummary(result: ShaclValidationResult): void {
+    if (result.conforms && result.violations.length === 0) {
+      new Notice("✅ Ontology validation passed", 3000);
+    } else {
+      const violationCount = result.violations.filter(v => v.severity === "Violation").length;
+      const warningCount = result.violations.filter(v => v.severity === "Warning").length;
+
+      const parts: string[] = [];
+      if (violationCount > 0) {
+        parts.push(`${violationCount} violation${violationCount !== 1 ? "s" : ""}`);
+      }
+      if (warningCount > 0) {
+        parts.push(`${warningCount} warning${warningCount !== 1 ? "s" : ""}`);
+      }
+
+      const message = parts.length > 0 ? `⚠️ Validation: ${parts.join(", ")}` : "⚠️ Validation completed with issues";
+      new Notice(message, 5000);
+    }
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/application/services/NoticeErrorDisplay.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/services/NoticeErrorDisplay.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for NoticeErrorDisplay
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1448
+ */
+
+import { NoticeErrorDisplay } from "@plugin/application/services/NoticeErrorDisplay";
+import type { ShaclValidationResult, NoticeConfig, ValidationErrorFormatter } from "exocortex";
+
+// Mock Obsidian's Notice
+jest.mock("obsidian", () => ({
+  Notice: jest.fn(),
+}));
+
+describe("NoticeErrorDisplay", () => {
+  let mockFormatter: ValidationErrorFormatter;
+  let display: NoticeErrorDisplay;
+  let shownNotices: NoticeConfig[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    shownNotices = [];
+
+    mockFormatter = {
+      formatForConsole: jest.fn(),
+      formatAsJson: jest.fn(),
+      formatForNotice: jest.fn(),
+      groupByFocusNode: jest.fn(),
+    } as unknown as ValidationErrorFormatter;
+
+    // Create a testable subclass that captures notices
+    class TestableNoticeErrorDisplay extends NoticeErrorDisplay {
+      protected override showNotice(config: NoticeConfig): void {
+        shownNotices.push(config);
+      }
+    }
+
+    display = new TestableNoticeErrorDisplay(mockFormatter);
+  });
+
+  describe("display", () => {
+    it("should not display anything for conformant results with no violations", () => {
+      const result: ShaclValidationResult = {
+        conforms: true,
+        violations: [],
+      };
+
+      (mockFormatter.formatForNotice as jest.Mock).mockReturnValue([]);
+
+      display.display(result);
+
+      expect(shownNotices).toHaveLength(0);
+    });
+
+    it("should display notices for each violation", () => {
+      const result: ShaclValidationResult = {
+        conforms: false,
+        violations: [
+          { focusNode: "node1", message: "error1", severity: "Violation" },
+          { focusNode: "node2", message: "error2", severity: "Warning" },
+        ],
+      };
+
+      const notices: NoticeConfig[] = [
+        { message: "❌ node1: error1", duration: 10000 },
+        { message: "⚠️ node2: error2", duration: 5000 },
+      ];
+
+      (mockFormatter.formatForNotice as jest.Mock).mockReturnValue(notices);
+
+      display.display(result);
+
+      expect(shownNotices).toHaveLength(2);
+      expect(shownNotices[0].message).toContain("❌");
+      expect(shownNotices[0].duration).toBe(10000);
+      expect(shownNotices[1].message).toContain("⚠️");
+      expect(shownNotices[1].duration).toBe(5000);
+    });
+
+    it("should call formatter.formatForNotice", () => {
+      const result: ShaclValidationResult = {
+        conforms: false,
+        violations: [{ focusNode: "test", message: "error", severity: "Violation" }],
+      };
+
+      (mockFormatter.formatForNotice as jest.Mock).mockReturnValue([]);
+
+      display.display(result);
+
+      expect(mockFormatter.formatForNotice).toHaveBeenCalledWith(result);
+    });
+  });
+
+  describe("displaySummary", () => {
+    it("should show success notice for conformant results", () => {
+      const result: ShaclValidationResult = {
+        conforms: true,
+        violations: [],
+      };
+
+      // Use real Notice mock for displaySummary
+      const { Notice } = require("obsidian");
+      display.displaySummary(result);
+
+      expect(Notice).toHaveBeenCalledWith("✅ Ontology validation passed", 3000);
+    });
+
+    it("should show summary with violation count", () => {
+      const result: ShaclValidationResult = {
+        conforms: false,
+        violations: [
+          { focusNode: "n1", message: "e1", severity: "Violation" },
+          { focusNode: "n2", message: "e2", severity: "Violation" },
+          { focusNode: "n3", message: "w1", severity: "Warning" },
+        ],
+      };
+
+      const { Notice } = require("obsidian");
+      display.displaySummary(result);
+
+      expect(Notice).toHaveBeenCalledWith(
+        expect.stringContaining("2 violations"),
+        5000
+      );
+      expect(Notice).toHaveBeenCalledWith(
+        expect.stringContaining("1 warning"),
+        5000
+      );
+    });
+
+    it("should handle singular violation correctly", () => {
+      const result: ShaclValidationResult = {
+        conforms: false,
+        violations: [{ focusNode: "n1", message: "e1", severity: "Violation" }],
+      };
+
+      const { Notice } = require("obsidian");
+      display.displaySummary(result);
+
+      expect(Notice).toHaveBeenCalledWith(
+        expect.stringContaining("1 violation"),
+        5000
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements validation error display for SHACL validation in both Obsidian UI (notices/modal) and CLI output with appropriate formatting.

**Changes:**
- Add ValidationErrorFormatter service in @exocortex/core with table, JSON, and Notice output formats
- Add `exocortex validate` CLI command with `--ontology`, `--shapes`, `--format` options
- Add NoticeErrorDisplay service for Obsidian plugin using Notice API
- Add VALIDATION_ERROR exit code (9) for CLI validation failures
- Comprehensive test coverage (30 new tests)

**Technical Details:**
- Violations shown with ❌ (10s duration), Warnings with ⚠️ (5s)
- Exit code 0 for valid, 9 for validation failures
- Table format as default, JSON for machine-readable output
- Strategy pattern for environment-specific display implementations

## Test Plan
- [x] ValidationErrorFormatter unit tests (12 tests)
- [x] CLI validate command unit tests (12 tests)
- [x] NoticeErrorDisplay unit tests (6 tests)
- [x] Build passes
- [x] All tests pass

Closes #1448