### PR TITLE
feat(core): implement LayoutSelector service for RDF-driven layouts

### DIFF
--- a/packages/exocortex/src/domain/services/LayoutSelector.ts
+++ b/packages/exocortex/src/domain/services/LayoutSelector.ts
@@ -1,0 +1,449 @@
+/**
+ * LayoutSelector - RDF-driven layout selection service
+ *
+ * Selects the appropriate layout based on an asset's rdf:type classes,
+ * choosing class-specific layouts when available and falling back to
+ * DefaultAssetLayout otherwise.
+ *
+ * @see /Users/kitelev/vault-2025/03 Knowledge/concepts/RDF-Driven Architecture Implementation Plan (Note).md
+ * Phase 6.6: Layout Selection mechanism (lines 2782-2816)
+ *
+ * Issue #1459: Implement LayoutSelector service in ActionInterpreter
+ * @see https://github.com/kitelev/exocortex/issues/1459
+ *
+ * Algorithm:
+ * 1. Get all classes of asset (rdf:type)
+ * 2. For each class, find Layout with Layout_appliesTo = class
+ * 3. If found → use class-specific layout
+ * 4. If not found → use DefaultAssetLayout
+ *
+ * Class priority:
+ * 1. Most specific (pn:DailyNote)
+ * 2. Parent class (ems:Effort)
+ * 3. Default (exo:Asset)
+ */
+
+import { ITripleStore } from "../../interfaces/ITripleStore";
+import { IRI } from "../models/rdf/IRI";
+import { BlankNode } from "../models/rdf/BlankNode";
+import type { Subject } from "../models/rdf/Triple";
+
+/**
+ * Namespace URIs used in layout selection
+ */
+const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const RDF_NS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+const RDFS_NS = "http://www.w3.org/2000/01/rdf-schema#";
+const EXO_UI_NS = "https://exocortex.my/ontology/exo-ui#";
+const EXO_NS = "https://exocortex.my/ontology/exo#";
+
+/**
+ * Layout block renderer types
+ */
+export type LayoutBlockRenderer =
+  | "identity"
+  | "classification"
+  | "relations-table"
+  | "backlinks-table"
+  | "usage-context"
+  | "markdown"
+  | string;
+
+/**
+ * Layout block definition loaded from RDF
+ */
+export interface LayoutBlock {
+  /**
+   * Block URI (e.g., "exo-ui:IdentityBlock")
+   */
+  uri: string;
+
+  /**
+   * SPARQL query template with ?asset placeholder
+   */
+  query: string;
+
+  /**
+   * Renderer component name
+   */
+  renderer: LayoutBlockRenderer;
+
+  /**
+   * Display order in the layout (1-based)
+   */
+  order: number;
+
+  /**
+   * Whether this block can be rendered without UI (CLI-compatible)
+   * @default true
+   */
+  headless: boolean;
+}
+
+/**
+ * Layout definition with its blocks
+ */
+export interface Layout {
+  /**
+   * Layout URI (e.g., "exo-ui:DefaultAssetLayout")
+   */
+  uri: string;
+
+  /**
+   * Human-readable label
+   */
+  label: string;
+
+  /**
+   * Asset classes this layout applies to
+   */
+  appliesTo: string[];
+
+  /**
+   * Ordered list of blocks in this layout
+   */
+  blocks: LayoutBlock[];
+}
+
+/**
+ * LayoutSelector - Selects appropriate layout based on asset's rdf:type
+ *
+ * @example
+ * ```typescript
+ * const selector = new LayoutSelector(tripleStore);
+ *
+ * // Select layout for an asset
+ * const layout = await selector.selectLayout('https://exocortex.my/assets/task-123');
+ * console.log(layout?.uri); // 'exo-ui:TaskLayout' or 'exo-ui:DefaultAssetLayout'
+ *
+ * // Load specific layout with blocks
+ * const defaultLayout = await selector.loadLayout('exo-ui:DefaultAssetLayout');
+ * for (const block of defaultLayout.blocks) {
+ *   console.log(block.renderer, block.order);
+ * }
+ * ```
+ */
+export class LayoutSelector {
+  /**
+   * Cache for loaded layouts
+   */
+  private readonly layoutCache: Map<string, Layout | null> = new Map();
+
+  /**
+   * Cache for class-to-layout mappings
+   */
+  private readonly classLayoutCache: Map<string, string | null> = new Map();
+
+  constructor(private readonly tripleStore: ITripleStore) {}
+
+  /**
+   * Select the appropriate layout for an asset based on its rdf:type classes.
+   *
+   * @param assetUri - URI of the asset to find layout for
+   * @returns Layout definition, or null if no layout found
+   */
+  async selectLayout(assetUri: string): Promise<Layout | null> {
+    // 1. Get all classes of the asset
+    const classes = await this.getAssetClasses(assetUri);
+
+    if (classes.length === 0) {
+      // Fallback to DefaultAssetLayout if no classes
+      return this.loadLayout(`${EXO_UI_NS}DefaultAssetLayout`);
+    }
+
+    // 2. Get all available layouts with their appliesTo classes
+    const layoutMappings = await this.getLayoutMappings();
+
+    // 3. Find matching layout by class priority
+    // Classes are assumed to be ordered by specificity (most specific first)
+    for (const classUri of classes) {
+      const layoutUri = layoutMappings.get(classUri);
+      if (layoutUri) {
+        return this.loadLayout(layoutUri);
+      }
+    }
+
+    // 4. Fallback: Check for DefaultAssetLayout (applies to exo:Asset)
+    const defaultLayoutUri = layoutMappings.get(`${EXO_NS}Asset`);
+    if (defaultLayoutUri) {
+      return this.loadLayout(defaultLayoutUri);
+    }
+
+    // Final fallback
+    return this.loadLayout(`${EXO_UI_NS}DefaultAssetLayout`);
+  }
+
+  /**
+   * Load a layout definition with all its blocks.
+   *
+   * @param layoutUri - URI of the layout to load
+   * @returns Layout with blocks, or null if not found
+   */
+  async loadLayout(layoutUri: string): Promise<Layout | null> {
+    // Check cache first
+    if (this.layoutCache.has(layoutUri)) {
+      return this.layoutCache.get(layoutUri) ?? null;
+    }
+
+    try {
+      // Get layout label
+      const labelTriples = await this.tripleStore.match(
+        new IRI(layoutUri),
+        new IRI(`${RDFS_NS}label`),
+        undefined
+      );
+
+      const label = labelTriples.length > 0
+        ? this.extractStringValue(labelTriples[0].object)
+        : "Unnamed Layout";
+
+      // Get blocks (may be direct references or RDF list)
+      const blockTriples = await this.tripleStore.match(
+        new IRI(layoutUri),
+        new IRI(`${EXO_UI_NS}Layout_blocks`),
+        undefined
+      );
+
+      const blocks: LayoutBlock[] = [];
+      const processedBlockUris = new Set<string>();
+
+      for (const triple of blockTriples) {
+        const blockRefValue = this.extractStringValue(triple.object);
+
+        // Check if it's a blank node (RDF list)
+        if (blockRefValue.startsWith("_:")) {
+          // Traverse RDF list
+          const listBlocks = await this.traverseRdfList(blockRefValue);
+          for (const blockUri of listBlocks) {
+            if (!processedBlockUris.has(blockUri)) {
+              processedBlockUris.add(blockUri);
+              const block = await this.loadBlock(blockUri);
+              if (block) {
+                blocks.push(block);
+              }
+            }
+          }
+        } else {
+          // Direct block reference
+          if (!processedBlockUris.has(blockRefValue)) {
+            processedBlockUris.add(blockRefValue);
+            const block = await this.loadBlock(blockRefValue);
+            if (block) {
+              blocks.push(block);
+            }
+          }
+        }
+      }
+
+      // Sort blocks by order
+      blocks.sort((a, b) => a.order - b.order);
+
+      // Get appliesTo classes
+      const appliesToTriples = await this.tripleStore.match(
+        new IRI(layoutUri),
+        new IRI(`${EXO_UI_NS}Layout_appliesTo`),
+        undefined
+      );
+
+      const appliesTo = appliesToTriples.map(t => this.extractStringValue(t.object));
+
+      const layout: Layout = {
+        uri: layoutUri,
+        label,
+        appliesTo,
+        blocks,
+      };
+
+      // Cache the result
+      this.layoutCache.set(layoutUri, layout);
+
+      return layout;
+    } catch {
+      // Cache null for failed lookups to avoid repeated failures
+      this.layoutCache.set(layoutUri, null);
+      return null;
+    }
+  }
+
+  /**
+   * Clear all caches.
+   * Call this when RDF data changes.
+   */
+  clearCache(): void {
+    this.layoutCache.clear();
+    this.classLayoutCache.clear();
+  }
+
+  // ============================================
+  // Private Helper Methods
+  // ============================================
+
+  /**
+   * Get all rdf:type classes for an asset.
+   */
+  private async getAssetClasses(assetUri: string): Promise<string[]> {
+    const triples = await this.tripleStore.match(
+      new IRI(assetUri),
+      new IRI(RDF_TYPE),
+      undefined
+    );
+
+    return triples.map(t => this.extractStringValue(t.object));
+  }
+
+  /**
+   * Get all layout mappings (class URI → layout URI).
+   */
+  private async getLayoutMappings(): Promise<Map<string, string>> {
+    const mappings = new Map<string, string>();
+
+    // Query for all Layout_appliesTo triples
+    const triples = await this.tripleStore.match(
+      undefined,
+      new IRI(`${EXO_UI_NS}Layout_appliesTo`),
+      undefined
+    );
+
+    for (const triple of triples) {
+      const layoutUri = this.extractStringValue(triple.subject);
+      const classUri = this.extractStringValue(triple.object);
+      mappings.set(classUri, layoutUri);
+    }
+
+    return mappings;
+  }
+
+  /**
+   * Load a single layout block by URI.
+   */
+  private async loadBlock(blockUri: string): Promise<LayoutBlock | null> {
+    try {
+      // Get block order
+      const orderTriples = await this.tripleStore.match(
+        new IRI(blockUri),
+        new IRI(`${EXO_UI_NS}LayoutBlock_order`),
+        undefined
+      );
+      const order = orderTriples.length > 0
+        ? parseInt(this.extractStringValue(orderTriples[0].object), 10)
+        : 0;
+
+      // Get block query
+      const queryTriples = await this.tripleStore.match(
+        new IRI(blockUri),
+        new IRI(`${EXO_UI_NS}LayoutBlock_query`),
+        undefined
+      );
+      const query = queryTriples.length > 0
+        ? this.extractStringValue(queryTriples[0].object)
+        : "";
+
+      // Get block renderer
+      const rendererTriples = await this.tripleStore.match(
+        new IRI(blockUri),
+        new IRI(`${EXO_UI_NS}LayoutBlock_renderer`),
+        undefined
+      );
+      const renderer = rendererTriples.length > 0
+        ? this.extractStringValue(rendererTriples[0].object)
+        : "text";
+
+      // Get headless flag
+      const headlessTriples = await this.tripleStore.match(
+        new IRI(blockUri),
+        new IRI(`${EXO_UI_NS}LayoutBlock_headless`),
+        undefined
+      );
+      const headless = headlessTriples.length > 0
+        ? this.extractStringValue(headlessTriples[0].object) !== "false"
+        : true;
+
+      return {
+        uri: blockUri,
+        query,
+        renderer,
+        order,
+        headless,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Traverse an RDF list and return all element URIs.
+   * RDF list structure: head -> rdf:first -> element, rdf:rest -> next node (or rdf:nil)
+   */
+  private async traverseRdfList(listNodeUri: string): Promise<string[]> {
+    const elements: string[] = [];
+    let currentNode = listNodeUri;
+    const visitedNodes = new Set<string>();
+
+    while (currentNode && currentNode !== `${RDF_NS}nil`) {
+      // Prevent infinite loops
+      if (visitedNodes.has(currentNode)) {
+        break;
+      }
+      visitedNodes.add(currentNode);
+
+      // Create subject from URI (handles blank nodes)
+      const subject = this.createSubject(currentNode);
+
+      // Get rdf:first (the element)
+      const firstTriples = await this.tripleStore.match(
+        subject,
+        new IRI(`${RDF_NS}first`),
+        undefined
+      );
+
+      if (firstTriples.length > 0) {
+        const elementUri = this.extractStringValue(firstTriples[0].object);
+        elements.push(elementUri);
+      }
+
+      // Get rdf:rest (next node)
+      const restTriples = await this.tripleStore.match(
+        subject,
+        new IRI(`${RDF_NS}rest`),
+        undefined
+      );
+
+      if (restTriples.length > 0) {
+        currentNode = this.extractStringValue(restTriples[0].object);
+      } else {
+        break;
+      }
+    }
+
+    return elements;
+  }
+
+  /**
+   * Extract string value from an RDF term.
+   */
+  private extractStringValue(term: unknown): string {
+    if (!term) {
+      return "";
+    }
+    if (typeof term === "object" && "value" in term) {
+      return String((term as { value: unknown }).value);
+    }
+    // Handle BlankNode specially - return the full _:id format
+    if (term instanceof BlankNode) {
+      return term.toString();
+    }
+    return String(term);
+  }
+
+  /**
+   * Create an RDF subject (IRI or BlankNode) from a URI string.
+   * Handles blank node notation (_:id).
+   */
+  private createSubject(uri: string): Subject {
+    if (uri.startsWith("_:")) {
+      // Remove _: prefix for BlankNode constructor
+      return new BlankNode(uri.substring(2));
+    }
+    return new IRI(uri);
+  }
+}

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -325,6 +325,14 @@ export type {
 // Action Interpreter export
 export { ActionInterpreter } from "./domain/services/ActionInterpreter";
 
+// Layout Selector export
+export {
+  LayoutSelector,
+  type Layout,
+  type LayoutBlock,
+  type LayoutBlockRenderer,
+} from "./domain/services/LayoutSelector";
+
 // Condition Evaluator export
 export { ConditionEvaluator } from "./domain/services/ConditionEvaluator";
 

--- a/packages/exocortex/tests/unit/domain/services/LayoutSelector.test.ts
+++ b/packages/exocortex/tests/unit/domain/services/LayoutSelector.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Tests for LayoutSelector - RDF-driven layout selection service
+ *
+ * Issue #1459: Implement LayoutSelector service in ActionInterpreter
+ * @see https://github.com/kitelev/exocortex/issues/1459
+ *
+ * Tests for:
+ * - selectLayout() - Select layout based on asset's rdf:type classes
+ * - loadLayout() - Load layout definition with blocks from RDF
+ * - Caching behavior for layout definitions
+ * - Class priority (most specific → parent → default)
+ */
+
+import { ITripleStore } from "../../../../src/interfaces/ITripleStore";
+import { IRI } from "../../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../../src/domain/models/rdf/Literal";
+import { Triple, Subject } from "../../../../src/domain/models/rdf/Triple";
+import { BlankNode } from "../../../../src/domain/models/rdf/BlankNode";
+import { LayoutSelector } from "../../../../src/domain/services/LayoutSelector";
+import type { Layout, LayoutBlock } from "../../../../src/domain/services/LayoutSelector";
+
+describe("LayoutSelector", () => {
+  let mockTripleStore: jest.Mocked<ITripleStore>;
+
+  /**
+   * Extract string representation from a subject (IRI or BlankNode).
+   */
+  const getSubjectString = (subject: Subject | undefined): string => {
+    if (!subject) return "";
+    if (subject instanceof IRI) return subject.value;
+    if (subject instanceof BlankNode) return subject.toString(); // Returns _:id
+    if ("value" in subject) return String((subject as { value: unknown }).value);
+    return String(subject);
+  };
+
+  /**
+   * Create a mock triple for testing.
+   */
+  const createTriple = (
+    subject: string,
+    predicate: string,
+    object: string | number | boolean
+  ): Triple => {
+    // Handle blank node subjects
+    let subjectTerm: Subject;
+    if (subject.startsWith("_:")) {
+      subjectTerm = new BlankNode(subject.substring(2));
+    } else {
+      subjectTerm = new IRI(subject);
+    }
+    const predicateIRI = new IRI(predicate);
+
+    // Handle blank node objects
+    let objectTerm;
+    if (typeof object === "string" && object.startsWith("_:")) {
+      objectTerm = new BlankNode(object.substring(2));
+    } else if (typeof object === "string" && object.startsWith("http")) {
+      objectTerm = new IRI(object);
+    } else {
+      objectTerm = new Literal(String(object));
+    }
+
+    return new Triple(subjectTerm, predicateIRI, objectTerm);
+  };
+
+  beforeEach(() => {
+    mockTripleStore = {
+      add: jest.fn(),
+      remove: jest.fn(),
+      has: jest.fn(),
+      match: jest.fn(),
+      addAll: jest.fn(),
+      removeAll: jest.fn(),
+      clear: jest.fn(),
+      count: jest.fn(),
+      subjects: jest.fn(),
+      predicates: jest.fn(),
+      objects: jest.fn(),
+      beginTransaction: jest.fn(),
+    } as jest.Mocked<ITripleStore>;
+  });
+
+  describe("constructor", () => {
+    it("should create instance with triple store", () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      expect(selector).toBeInstanceOf(LayoutSelector);
+    });
+  });
+
+  describe("selectLayout() method", () => {
+    const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+    const EXO_UI_NS = "https://exocortex.my/ontology/exo-ui#";
+    const EXO_NS = "https://exocortex.my/ontology/exo#";
+    const EMS_NS = "https://exocortex.my/ontology/ems#";
+    const PN_NS = "https://exocortex.my/ontology/pn#";
+
+    it("should return AreaLayout for Area asset", async () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      const assetUri = "https://exocortex.my/assets/area-123";
+
+      // Asset has rdf:type ems:Area
+      mockTripleStore.match.mockImplementation(async (subject, predicate) => {
+        const subjectStr = subject && "value" in subject ? subject.value : "";
+        const predStr = predicate && "value" in predicate ? predicate.value : "";
+
+        // Query 1: Get asset's classes
+        if (subjectStr === assetUri && predStr === RDF_TYPE) {
+          return [
+            createTriple(assetUri, RDF_TYPE, `${EMS_NS}Area`),
+          ];
+        }
+
+        // Query 2: Find layout for ems:Area class
+        if (predStr === `${EXO_UI_NS}Layout_appliesTo`) {
+          return [
+            createTriple(`${EXO_UI_NS}AreaLayout`, `${EXO_UI_NS}Layout_appliesTo`, `${EMS_NS}Area`),
+          ];
+        }
+
+        return [];
+      });
+
+      const layout = await selector.selectLayout(assetUri);
+
+      expect(layout).toBeDefined();
+      expect(layout!.uri).toBe(`${EXO_UI_NS}AreaLayout`);
+    });
+
+    it("should return DailyNoteLayout for DailyNote asset", async () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      const assetUri = "https://exocortex.my/assets/daily-note-2025-01-08";
+
+      // Asset has rdf:type pn:DailyNote
+      mockTripleStore.match.mockImplementation(async (subject, predicate) => {
+        const subjectStr = subject && "value" in subject ? subject.value : "";
+        const predStr = predicate && "value" in predicate ? predicate.value : "";
+
+        // Query 1: Get asset's classes
+        if (subjectStr === assetUri && predStr === RDF_TYPE) {
+          return [
+            createTriple(assetUri, RDF_TYPE, `${PN_NS}DailyNote`),
+          ];
+        }
+
+        // Query 2: Find layout for pn:DailyNote class
+        if (predStr === `${EXO_UI_NS}Layout_appliesTo`) {
+          return [
+            createTriple(`${EXO_UI_NS}DailyNoteLayout`, `${EXO_UI_NS}Layout_appliesTo`, `${PN_NS}DailyNote`),
+          ];
+        }
+
+        return [];
+      });
+
+      const layout = await selector.selectLayout(assetUri);
+
+      expect(layout).toBeDefined();
+      expect(layout!.uri).toBe(`${EXO_UI_NS}DailyNoteLayout`);
+    });
+
+    it("should return DefaultAssetLayout for unknown class", async () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      const assetUri = "https://exocortex.my/assets/unknown-123";
+
+      // Asset has rdf:type exo:UnknownClass (no specific layout defined)
+      mockTripleStore.match.mockImplementation(async (subject, predicate) => {
+        const subjectStr = subject && "value" in subject ? subject.value : "";
+        const predStr = predicate && "value" in predicate ? predicate.value : "";
+
+        // Query 1: Get asset's classes
+        if (subjectStr === assetUri && predStr === RDF_TYPE) {
+          return [
+            createTriple(assetUri, RDF_TYPE, `${EXO_NS}UnknownClass`),
+          ];
+        }
+
+        // Query 2: No layout for UnknownClass, but DefaultAssetLayout applies to exo:Asset
+        if (predStr === `${EXO_UI_NS}Layout_appliesTo`) {
+          return [
+            createTriple(`${EXO_UI_NS}DefaultAssetLayout`, `${EXO_UI_NS}Layout_appliesTo`, `${EXO_NS}Asset`),
+          ];
+        }
+
+        return [];
+      });
+
+      const layout = await selector.selectLayout(assetUri);
+
+      expect(layout).toBeDefined();
+      expect(layout!.uri).toBe(`${EXO_UI_NS}DefaultAssetLayout`);
+    });
+
+    it("should prioritize most specific class layout", async () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      const assetUri = "https://exocortex.my/assets/daily-note-123";
+
+      // Asset has multiple rdf:type: pn:DailyNote AND ems:Effort
+      // Should choose pn:DailyNote (more specific) over ems:Effort (parent class)
+      mockTripleStore.match.mockImplementation(async (subject, predicate) => {
+        const subjectStr = subject && "value" in subject ? subject.value : "";
+        const predStr = predicate && "value" in predicate ? predicate.value : "";
+
+        // Query 1: Get asset's classes - ordered by specificity
+        if (subjectStr === assetUri && predStr === RDF_TYPE) {
+          return [
+            createTriple(assetUri, RDF_TYPE, `${PN_NS}DailyNote`),
+            createTriple(assetUri, RDF_TYPE, `${EMS_NS}Effort`),
+            createTriple(assetUri, RDF_TYPE, `${EXO_NS}Asset`),
+          ];
+        }
+
+        // Query 2: Find layouts
+        if (predStr === `${EXO_UI_NS}Layout_appliesTo`) {
+          return [
+            createTriple(`${EXO_UI_NS}DailyNoteLayout`, `${EXO_UI_NS}Layout_appliesTo`, `${PN_NS}DailyNote`),
+            createTriple(`${EXO_UI_NS}EffortLayout`, `${EXO_UI_NS}Layout_appliesTo`, `${EMS_NS}Effort`),
+            createTriple(`${EXO_UI_NS}DefaultAssetLayout`, `${EXO_UI_NS}Layout_appliesTo`, `${EXO_NS}Asset`),
+          ];
+        }
+
+        return [];
+      });
+
+      const layout = await selector.selectLayout(assetUri);
+
+      expect(layout).toBeDefined();
+      expect(layout!.uri).toBe(`${EXO_UI_NS}DailyNoteLayout`);
+    });
+  });
+
+  describe("loadLayout() method", () => {
+    const EXO_UI_NS = "https://exocortex.my/ontology/exo-ui#";
+    const RDFS_NS = "http://www.w3.org/2000/01/rdf-schema#";
+    const RDF_NS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+
+    it("should load layout with blocks in correct order", async () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      const layoutUri = `${EXO_UI_NS}DefaultAssetLayout`;
+
+      // Mock layout definition with blocks
+      mockTripleStore.match.mockImplementation(async (subject, predicate) => {
+        const subjectStr = subject && "value" in subject ? subject.value : "";
+        const predStr = predicate && "value" in predicate ? predicate.value : "";
+
+        // Layout label
+        if (subjectStr === layoutUri && predStr === `${RDFS_NS}label`) {
+          return [createTriple(layoutUri, `${RDFS_NS}label`, "Default Asset Layout")];
+        }
+
+        // Layout blocks (RDF list - simplified)
+        if (subjectStr === layoutUri && predStr === `${EXO_UI_NS}Layout_blocks`) {
+          return [
+            createTriple(layoutUri, `${EXO_UI_NS}Layout_blocks`, `${EXO_UI_NS}IdentityBlock`),
+            createTriple(layoutUri, `${EXO_UI_NS}Layout_blocks`, `${EXO_UI_NS}ClassificationBlock`),
+          ];
+        }
+
+        // Block 1 properties
+        if (subjectStr === `${EXO_UI_NS}IdentityBlock`) {
+          if (predStr === `${EXO_UI_NS}LayoutBlock_order`) {
+            return [createTriple(`${EXO_UI_NS}IdentityBlock`, predStr, 1)];
+          }
+          if (predStr === `${EXO_UI_NS}LayoutBlock_query`) {
+            return [createTriple(`${EXO_UI_NS}IdentityBlock`, predStr, "SELECT ?label WHERE { ?asset rdfs:label ?label }")];
+          }
+          if (predStr === `${EXO_UI_NS}LayoutBlock_renderer`) {
+            return [createTriple(`${EXO_UI_NS}IdentityBlock`, predStr, "identity")];
+          }
+          if (predStr === `${EXO_UI_NS}LayoutBlock_headless`) {
+            return [createTriple(`${EXO_UI_NS}IdentityBlock`, predStr, true)];
+          }
+        }
+
+        // Block 2 properties
+        if (subjectStr === `${EXO_UI_NS}ClassificationBlock`) {
+          if (predStr === `${EXO_UI_NS}LayoutBlock_order`) {
+            return [createTriple(`${EXO_UI_NS}ClassificationBlock`, predStr, 2)];
+          }
+          if (predStr === `${EXO_UI_NS}LayoutBlock_query`) {
+            return [createTriple(`${EXO_UI_NS}ClassificationBlock`, predStr, "SELECT ?class WHERE { ?asset rdf:type ?class }")];
+          }
+          if (predStr === `${EXO_UI_NS}LayoutBlock_renderer`) {
+            return [createTriple(`${EXO_UI_NS}ClassificationBlock`, predStr, "classification")];
+          }
+          if (predStr === `${EXO_UI_NS}LayoutBlock_headless`) {
+            return [createTriple(`${EXO_UI_NS}ClassificationBlock`, predStr, false)];
+          }
+        }
+
+        return [];
+      });
+
+      const layout = await selector.loadLayout(layoutUri);
+
+      expect(layout).toBeDefined();
+      expect(layout!.uri).toBe(layoutUri);
+      expect(layout!.label).toBe("Default Asset Layout");
+      expect(layout!.blocks).toHaveLength(2);
+
+      // Verify blocks are ordered correctly
+      expect(layout!.blocks[0].order).toBe(1);
+      expect(layout!.blocks[0].renderer).toBe("identity");
+      expect(layout!.blocks[1].order).toBe(2);
+      expect(layout!.blocks[1].renderer).toBe("classification");
+    });
+
+    it("should correctly traverse RDF list for blocks", async () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      const layoutUri = `${EXO_UI_NS}TestLayout`;
+
+      // RDF list structure: layoutUri -> _:list1 -> _:list2 -> rdf:nil
+      // This tests rdf:rest*/rdf:first property path
+      mockTripleStore.match.mockImplementation(async (subject, predicate) => {
+        const subjectStr = getSubjectString(subject as Subject);
+        const predStr = predicate && "value" in predicate ? predicate.value : "";
+
+        // Layout label
+        if (subjectStr === layoutUri && predStr === `${RDFS_NS}label`) {
+          return [createTriple(layoutUri, `${RDFS_NS}label`, "Test Layout")];
+        }
+
+        // Layout_blocks points to head of RDF list
+        if (subjectStr === layoutUri && predStr === `${EXO_UI_NS}Layout_blocks`) {
+          return [createTriple(layoutUri, `${EXO_UI_NS}Layout_blocks`, "_:list1")];
+        }
+
+        // RDF list node 1: first = Block1, rest = _:list2
+        if (subjectStr === "_:list1") {
+          if (predStr === `${RDF_NS}first`) {
+            return [createTriple("_:list1", `${RDF_NS}first`, `${EXO_UI_NS}Block1`)];
+          }
+          if (predStr === `${RDF_NS}rest`) {
+            return [createTriple("_:list1", `${RDF_NS}rest`, "_:list2")];
+          }
+        }
+
+        // RDF list node 2: first = Block2, rest = rdf:nil
+        if (subjectStr === "_:list2") {
+          if (predStr === `${RDF_NS}first`) {
+            return [createTriple("_:list2", `${RDF_NS}first`, `${EXO_UI_NS}Block2`)];
+          }
+          if (predStr === `${RDF_NS}rest`) {
+            return [createTriple("_:list2", `${RDF_NS}rest`, `${RDF_NS}nil`)];
+          }
+        }
+
+        // Block properties
+        if (subjectStr === `${EXO_UI_NS}Block1`) {
+          if (predStr === `${EXO_UI_NS}LayoutBlock_order`) {
+            return [createTriple(`${EXO_UI_NS}Block1`, predStr, 1)];
+          }
+          if (predStr === `${EXO_UI_NS}LayoutBlock_renderer`) {
+            return [createTriple(`${EXO_UI_NS}Block1`, predStr, "block1-renderer")];
+          }
+        }
+
+        if (subjectStr === `${EXO_UI_NS}Block2`) {
+          if (predStr === `${EXO_UI_NS}LayoutBlock_order`) {
+            return [createTriple(`${EXO_UI_NS}Block2`, predStr, 2)];
+          }
+          if (predStr === `${EXO_UI_NS}LayoutBlock_renderer`) {
+            return [createTriple(`${EXO_UI_NS}Block2`, predStr, "block2-renderer")];
+          }
+        }
+
+        return [];
+      });
+
+      const layout = await selector.loadLayout(layoutUri);
+
+      expect(layout).toBeDefined();
+      expect(layout!.blocks).toHaveLength(2);
+      expect(layout!.blocks[0].renderer).toBe("block1-renderer");
+      expect(layout!.blocks[1].renderer).toBe("block2-renderer");
+    });
+
+    it("should return blocks sorted by order", async () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      const layoutUri = `${EXO_UI_NS}OrderTestLayout`;
+
+      // Blocks returned in wrong order - should be sorted by LayoutBlock_order
+      mockTripleStore.match.mockImplementation(async (subject, predicate) => {
+        const subjectStr = subject && "value" in subject ? subject.value : "";
+        const predStr = predicate && "value" in predicate ? predicate.value : "";
+
+        if (subjectStr === layoutUri && predStr === `${RDFS_NS}label`) {
+          return [createTriple(layoutUri, `${RDFS_NS}label`, "Order Test")];
+        }
+
+        // Blocks in reverse order
+        if (subjectStr === layoutUri && predStr === `${EXO_UI_NS}Layout_blocks`) {
+          return [
+            createTriple(layoutUri, `${EXO_UI_NS}Layout_blocks`, `${EXO_UI_NS}Block3`),
+            createTriple(layoutUri, `${EXO_UI_NS}Layout_blocks`, `${EXO_UI_NS}Block1`),
+            createTriple(layoutUri, `${EXO_UI_NS}Layout_blocks`, `${EXO_UI_NS}Block2`),
+          ];
+        }
+
+        // Block orders
+        if (subjectStr === `${EXO_UI_NS}Block1` && predStr === `${EXO_UI_NS}LayoutBlock_order`) {
+          return [createTriple(`${EXO_UI_NS}Block1`, predStr, 1)];
+        }
+        if (subjectStr === `${EXO_UI_NS}Block2` && predStr === `${EXO_UI_NS}LayoutBlock_order`) {
+          return [createTriple(`${EXO_UI_NS}Block2`, predStr, 2)];
+        }
+        if (subjectStr === `${EXO_UI_NS}Block3` && predStr === `${EXO_UI_NS}LayoutBlock_order`) {
+          return [createTriple(`${EXO_UI_NS}Block3`, predStr, 3)];
+        }
+
+        return [];
+      });
+
+      const layout = await selector.loadLayout(layoutUri);
+
+      expect(layout).toBeDefined();
+      expect(layout!.blocks).toHaveLength(3);
+      expect(layout!.blocks[0].uri).toContain("Block1");
+      expect(layout!.blocks[0].order).toBe(1);
+      expect(layout!.blocks[1].uri).toContain("Block2");
+      expect(layout!.blocks[1].order).toBe(2);
+      expect(layout!.blocks[2].uri).toContain("Block3");
+      expect(layout!.blocks[2].order).toBe(3);
+    });
+  });
+
+  describe("caching behavior", () => {
+    const EXO_UI_NS = "https://exocortex.my/ontology/exo-ui#";
+    const RDFS_NS = "http://www.w3.org/2000/01/rdf-schema#";
+
+    it("should cache loaded layouts", async () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      const layoutUri = `${EXO_UI_NS}CachedLayout`;
+
+      mockTripleStore.match.mockImplementation(async (subject, predicate) => {
+        const subjectStr = subject && "value" in subject ? subject.value : "";
+        const predStr = predicate && "value" in predicate ? predicate.value : "";
+
+        if (subjectStr === layoutUri && predStr === `${RDFS_NS}label`) {
+          return [createTriple(layoutUri, `${RDFS_NS}label`, "Cached Layout")];
+        }
+        if (subjectStr === layoutUri && predStr === `${EXO_UI_NS}Layout_blocks`) {
+          return [];
+        }
+        return [];
+      });
+
+      // First call - loads from triple store
+      const layout1 = await selector.loadLayout(layoutUri);
+      const matchCallCount1 = mockTripleStore.match.mock.calls.length;
+
+      // Second call - should use cache
+      const layout2 = await selector.loadLayout(layoutUri);
+      const matchCallCount2 = mockTripleStore.match.mock.calls.length;
+
+      expect(layout1).toBeDefined();
+      expect(layout2).toBeDefined();
+      expect(layout1).toEqual(layout2);
+      // No additional calls to triple store
+      expect(matchCallCount2).toBe(matchCallCount1);
+    });
+
+    it("should allow clearing the cache", async () => {
+      const selector = new LayoutSelector(mockTripleStore);
+      const layoutUri = `${EXO_UI_NS}ClearableLayout`;
+
+      mockTripleStore.match.mockImplementation(async (subject, predicate) => {
+        const subjectStr = subject && "value" in subject ? subject.value : "";
+        const predStr = predicate && "value" in predicate ? predicate.value : "";
+
+        if (subjectStr === layoutUri && predStr === `${RDFS_NS}label`) {
+          return [createTriple(layoutUri, `${RDFS_NS}label`, "Clearable Layout")];
+        }
+        if (subjectStr === layoutUri && predStr === `${EXO_UI_NS}Layout_blocks`) {
+          return [];
+        }
+        return [];
+      });
+
+      // First call
+      await selector.loadLayout(layoutUri);
+      const matchCallCount1 = mockTripleStore.match.mock.calls.length;
+
+      // Clear cache
+      selector.clearCache();
+
+      // Second call - should query again
+      await selector.loadLayout(layoutUri);
+      const matchCallCount2 = mockTripleStore.match.mock.calls.length;
+
+      // Should have made more calls after cache clear
+      expect(matchCallCount2).toBeGreaterThan(matchCallCount1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #1459 - Phase 6.6 of RDF-Driven Architecture Implementation Plan.

**LayoutSelector** is a domain service that selects the appropriate layout based on asset's `rdf:type` classes, choosing class-specific layouts when available and falling back to `DefaultAssetLayout` otherwise.

## What's Implemented

### New Files
- `packages/exocortex/src/domain/services/LayoutSelector.ts` - The main service
- `packages/exocortex/tests/unit/domain/services/LayoutSelector.test.ts` - 10 unit tests

### Key Features
- `selectLayout(assetUri)`: Finds class-specific layout or falls back to default
- `loadLayout(layoutUri)`: Loads layout definition with blocks from RDF
- RDF list traversal support (`rdf:rest*/rdf:first` property path)
- Caching for layout definitions
- Class priority handling (most specific → parent → default)

### Algorithm
1. Get all classes of asset (`rdf:type`)
2. For each class, find Layout with `Layout_appliesTo` = class
3. If found → use class-specific layout
4. If not found → use `DefaultAssetLayout`

## Test Plan

- [x] Test: Area asset → AreaLayout selected
- [x] Test: DailyNote asset → DailyNoteLayout selected  
- [x] Test: Unknown class → DefaultAssetLayout selected
- [x] Test: RDF list correctly traversed
- [x] Test: Blocks returned in order
- [x] Test: Caching behavior
- [x] Test: Cache clearing

All 10 tests pass.

## Related Issues

- Closes #1459
- Blocked by: #1458 (DailyNoteLayout) ✅ CLOSED
- Blocks: #1460 (Refactor renderers)

## Checklist

- [x] TDD approach (tests written first)
- [x] All tests pass (10/10)
- [x] Build passes
- [x] Lint passes (no new errors)
- [x] Exported from `@exocortex/core` package