### PR TITLE
feat(core): create ActionBridge for RDF-to-ActionInterpreter mapping

### DIFF
--- a/packages/obsidian-plugin/src/application/bridges/ActionBridge.ts
+++ b/packages/obsidian-plugin/src/application/bridges/ActionBridge.ts
@@ -1,0 +1,123 @@
+/**
+ * ActionBridge - Adapter for RDF-to-ActionInterpreter mapping
+ *
+ * Maps RDF action definitions (from RdfCommandRegistry) to ActionInterpreter's
+ * ActionDefinition type. This bridges the gap between RDF-based command definitions
+ * and the core action execution engine.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1997
+ * @module application/bridges
+ * @since 13.302.0
+ */
+
+import { ActionDefinition } from "exocortex";
+
+/**
+ * RDF action definition as extracted from the triple store.
+ *
+ * Represents an action loaded from RDF with its full namespace URI type
+ * and associated parameters.
+ *
+ * @example
+ * ```typescript
+ * const rdfAction: RdfAction = {
+ *   type: "https://exocortex.my/ontology/exo-ui#CreateAssetAction",
+ *   params: { assetClass: "Task", location: "/Projects" }
+ * };
+ * ```
+ */
+export interface RdfAction {
+  /** Full URI type from RDF (e.g., https://exocortex.my/ontology/exo-ui#CreateAssetAction) */
+  type: string;
+
+  /** Action parameters from RDF triples */
+  params: Record<string, unknown>;
+}
+
+/**
+ * Error thrown when an RDF action type cannot be mapped to ActionInterpreter.
+ *
+ * This error indicates that the RDF action type is not one of the 8 Fixed Verbs
+ * supported by ActionInterpreter.
+ */
+export class ActionMappingError extends Error {
+  override name = "ActionMappingError";
+
+  constructor(actionType: string) {
+    super(`Unknown action type: ${actionType}`);
+  }
+}
+
+/**
+ * ActionBridge - Adapter between RDF action definitions and ActionInterpreter
+ *
+ * Converts full RDF URI types to ActionInterpreter's prefixed format (exo-ui:*)
+ * and validates that only supported Fixed Verb types are used.
+ *
+ * Architecture:
+ * - Layer: Application (Adapter between Presentation → Domain)
+ * - Pattern: Adapter (GoF), Dependency Inversion (SOLID)
+ *
+ * @example
+ * ```typescript
+ * const bridge = new ActionBridge();
+ * const definition = bridge.toActionDefinition({
+ *   type: "https://exocortex.my/ontology/exo-ui#CreateAssetAction",
+ *   params: { assetClass: "Task" }
+ * });
+ * // definition = { type: "exo-ui:CreateAssetAction", params: { assetClass: "Task" } }
+ * ```
+ */
+export class ActionBridge {
+  /**
+   * Namespace URI for exo-ui ontology
+   */
+  private static readonly EXO_UI_NS = "https://exocortex.my/ontology/exo-ui#";
+
+  /**
+   * Supported action types (8 Fixed Verbs from ActionInterpreter)
+   */
+  private static readonly SUPPORTED_TYPES = new Set([
+    "CreateAssetAction",
+    "UpdatePropertyAction",
+    "NavigateAction",
+    "ExecuteSPARQLAction",
+    "ShowModalAction",
+    "TriggerHookAction",
+    "CustomHandlerAction",
+    "CompositeAction",
+  ]);
+
+  /**
+   * Convert RDF action definition to ActionInterpreter's ActionDefinition.
+   *
+   * Maps the full RDF URI type to the prefixed format expected by ActionInterpreter
+   * (e.g., "exo-ui:CreateAssetAction") and passes through all parameters.
+   *
+   * @param rdfAction - RDF action definition with full URI type
+   * @returns ActionDefinition with prefixed type for ActionInterpreter
+   * @throws ActionMappingError if the action type is not a supported Fixed Verb
+   */
+  toActionDefinition(rdfAction: RdfAction): ActionDefinition {
+    const { type, params } = rdfAction;
+
+    // Validate the type starts with exo-ui namespace
+    if (!type.startsWith(ActionBridge.EXO_UI_NS)) {
+      throw new ActionMappingError(type);
+    }
+
+    // Extract the action type name (e.g., "CreateAssetAction")
+    const actionTypeName = type.substring(ActionBridge.EXO_UI_NS.length);
+
+    // Validate it's one of the 8 Fixed Verbs
+    if (!ActionBridge.SUPPORTED_TYPES.has(actionTypeName)) {
+      throw new ActionMappingError(type);
+    }
+
+    // Map to ActionInterpreter's prefixed format
+    return {
+      type: `exo-ui:${actionTypeName}`,
+      params,
+    };
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/application/bridges/ActionBridge.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/bridges/ActionBridge.test.ts
@@ -1,0 +1,185 @@
+/**
+ * ActionBridge Unit Tests
+ *
+ * Tests for the ActionBridge adapter class that maps RDF action definitions
+ * to ActionInterpreter's ActionDefinition type.
+ *
+ * @see https://github.com/kitelev/exocortex/issues/1997
+ * @module tests/unit/application/bridges
+ */
+
+import "reflect-metadata";
+import {
+  ActionBridge,
+  ActionMappingError,
+  RdfAction,
+} from "../../../../src/application/bridges/ActionBridge";
+
+describe("ActionBridge", () => {
+  describe("toActionDefinition", () => {
+    describe("Feature: ActionBridge RDF-to-ActionInterpreter mapping", () => {
+      describe("Scenario: Map RDF CreateAsset action to ActionInterpreter", () => {
+        it("should map exo-ui:CreateAssetAction to ActionDefinition format", () => {
+          // Given an RDF action definition with type "exo-ui:CreateAssetAction"
+          const rdfAction: RdfAction = {
+            type: "https://exocortex.my/ontology/exo-ui#CreateAssetAction",
+            params: { assetClass: "Task" },
+          };
+
+          // When ActionBridge.toActionDefinition() is called
+          const bridge = new ActionBridge();
+          const result = bridge.toActionDefinition(rdfAction);
+
+          // Then it returns ActionDefinition with type "exo-ui:CreateAssetAction"
+          expect(result.type).toBe("exo-ui:CreateAssetAction");
+          expect(result.params).toEqual({ assetClass: "Task" });
+        });
+      });
+
+      describe("Scenario: Handle unknown action type", () => {
+        it("should throw ActionMappingError for unknown action type", () => {
+          // Given an RDF action definition with unknown type
+          const rdfAction: RdfAction = {
+            type: "https://exocortex.my/ontology/exo-ui#UnknownAction",
+            params: {},
+          };
+
+          // When ActionBridge.toActionDefinition() is called
+          const bridge = new ActionBridge();
+
+          // Then it throws ActionMappingError
+          expect(() => bridge.toActionDefinition(rdfAction)).toThrow(ActionMappingError);
+          expect(() => bridge.toActionDefinition(rdfAction)).toThrow(
+            /Unknown action type.*UnknownAction/
+          );
+        });
+      });
+    });
+
+    describe("All 8 Fixed Verb types mapping", () => {
+      const fixedVerbs = [
+        {
+          rdfType: "https://exocortex.my/ontology/exo-ui#CreateAssetAction",
+          expected: "exo-ui:CreateAssetAction",
+        },
+        {
+          rdfType: "https://exocortex.my/ontology/exo-ui#UpdatePropertyAction",
+          expected: "exo-ui:UpdatePropertyAction",
+        },
+        {
+          rdfType: "https://exocortex.my/ontology/exo-ui#NavigateAction",
+          expected: "exo-ui:NavigateAction",
+        },
+        {
+          rdfType: "https://exocortex.my/ontology/exo-ui#ExecuteSPARQLAction",
+          expected: "exo-ui:ExecuteSPARQLAction",
+        },
+        {
+          rdfType: "https://exocortex.my/ontology/exo-ui#ShowModalAction",
+          expected: "exo-ui:ShowModalAction",
+        },
+        {
+          rdfType: "https://exocortex.my/ontology/exo-ui#TriggerHookAction",
+          expected: "exo-ui:TriggerHookAction",
+        },
+        {
+          rdfType: "https://exocortex.my/ontology/exo-ui#CustomHandlerAction",
+          expected: "exo-ui:CustomHandlerAction",
+        },
+        {
+          rdfType: "https://exocortex.my/ontology/exo-ui#CompositeAction",
+          expected: "exo-ui:CompositeAction",
+        },
+      ];
+
+      it.each(fixedVerbs)(
+        "should map $rdfType to $expected",
+        ({ rdfType, expected }) => {
+          const rdfAction: RdfAction = {
+            type: rdfType,
+            params: { testParam: "value" },
+          };
+
+          const bridge = new ActionBridge();
+          const result = bridge.toActionDefinition(rdfAction);
+
+          expect(result.type).toBe(expected);
+          expect(result.params).toEqual({ testParam: "value" });
+        }
+      );
+    });
+
+    describe("Params extraction", () => {
+      it("should preserve all params from RDF action", () => {
+        const rdfAction: RdfAction = {
+          type: "https://exocortex.my/ontology/exo-ui#CreateAssetAction",
+          params: {
+            assetClass: "Task",
+            defaultStatus: "active",
+            location: "/path/to/folder",
+            complex: { nested: { value: 123 } },
+          },
+        };
+
+        const bridge = new ActionBridge();
+        const result = bridge.toActionDefinition(rdfAction);
+
+        expect(result.params).toEqual({
+          assetClass: "Task",
+          defaultStatus: "active",
+          location: "/path/to/folder",
+          complex: { nested: { value: 123 } },
+        });
+      });
+
+      it("should handle empty params", () => {
+        const rdfAction: RdfAction = {
+          type: "https://exocortex.my/ontology/exo-ui#NavigateAction",
+          params: {},
+        };
+
+        const bridge = new ActionBridge();
+        const result = bridge.toActionDefinition(rdfAction);
+
+        expect(result.params).toEqual({});
+      });
+    });
+
+    describe("Edge cases", () => {
+      it("should handle type with different namespace prefix", () => {
+        // Non-exo-ui namespace should throw error
+        const rdfAction: RdfAction = {
+          type: "https://other.namespace/CreateAssetAction",
+          params: {},
+        };
+
+        const bridge = new ActionBridge();
+        expect(() => bridge.toActionDefinition(rdfAction)).toThrow(ActionMappingError);
+      });
+
+      it("should handle type that is close but not exact match", () => {
+        // Similar but not exact action type name
+        const rdfAction: RdfAction = {
+          type: "https://exocortex.my/ontology/exo-ui#CreateAsset", // Missing "Action"
+          params: {},
+        };
+
+        const bridge = new ActionBridge();
+        expect(() => bridge.toActionDefinition(rdfAction)).toThrow(ActionMappingError);
+      });
+    });
+  });
+});
+
+describe("ActionMappingError", () => {
+  it("should include action type in error message", () => {
+    const error = new ActionMappingError("https://exocortex.my/ontology/exo-ui#UnknownType");
+    expect(error.message).toContain("UnknownType");
+    expect(error.name).toBe("ActionMappingError");
+  });
+
+  it("should be instanceof Error", () => {
+    const error = new ActionMappingError("test");
+    expect(error).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## Summary

Create ActionBridge adapter class to map RDF action definitions (from RdfCommandRegistry) to ActionInterpreter's `ActionDefinition` type. This bridges the gap between RDF-based command definitions and the core action execution engine.

## Changes

- Add `ActionBridge` class with `toActionDefinition()` method
- Map all 8 Fixed Verb types from full RDF URIs to prefixed format (e.g., `exo-ui:CreateAssetAction`)
- Add `ActionMappingError` for unknown action types
- Add `RdfAction` interface for RDF action definitions
- 16 unit tests with 100% code coverage

## Technical Details

### Architecture
- **Layer:** Application (Adapter between Presentation → Domain)
- **Package:** `@exocortex/obsidian-plugin`
- **Pattern:** Adapter (GoF), Dependency Inversion (SOLID)

### 8 Fixed Verb Types Mapped
1. `CreateAssetAction`
2. `UpdatePropertyAction`
3. `NavigateAction`
4. `ExecuteSPARQLAction`
5. `ShowModalAction`
6. `TriggerHookAction`
7. `CustomHandlerAction`
8. `CompositeAction`

## Test Plan

- [x] All 16 unit tests pass
- [x] 100% code coverage for ActionBridge.ts
- [x] BDD scenarios from issue implemented:
  - Map RDF CreateAsset action to ActionInterpreter format
  - Handle unknown action types with ActionMappingError
- [x] All 8 Fixed Verb types mapped correctly
- [x] Edge cases tested (wrong namespace, partial matches)

## Verification

```bash
npm run build           # ✅ Passes
npm run lint 2>&1 | grep ActionBridge  # ✅ No lint errors
cd packages/obsidian-plugin && npx jest tests/unit/application/bridges/ActionBridge.test.ts --coverage  # ✅ 100% coverage
```

## Acceptance Criteria

- [x] ActionBridge class created with `toActionDefinition()` method
- [x] All 8 Fixed Verb types mapped correctly
- [x] Unknown types throw `ActionMappingError`
- [x] Unit tests written following TDD
- [x] All tests pass (`npm test`)
- [x] Code coverage ≥ 90% for ActionBridge (actual: 100%)

Closes #1997