### PR TITLE
feat: remove useRdfButtons feature flag

### DIFF
--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -154,8 +154,6 @@ export interface ExocortexSettings {
   webhookSettings: WebhookSettings;
   /** Semantic search settings */
   semanticSearchSettings: SemanticSearchSettings;
-  /** Use RDF-driven button rendering (experimental) */
-  useRdfButtons: boolean;
   [key: string]: unknown;
 }
 
@@ -180,5 +178,4 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS,
   webhookSettings: DEFAULT_WEBHOOK_SETTINGS,
   semanticSearchSettings: DEFAULT_SEMANTIC_SEARCH_SETTINGS,
-  useRdfButtons: false, // Disabled by default, enable for RDF-driven UI
 };

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -115,10 +115,8 @@ export class UniversalLayoutRenderer {
   }
 
   private initializeRenderers(): void {
-    // Initialize RDF button support only when feature flag is enabled
-    if (this.settings.useRdfButtons) {
-      this.initializeRdfButtonSupport();
-    }
+    // Initialize RDF button support (always enabled after validation)
+    this.initializeRdfButtonSupport();
 
     this.propertiesRenderer = new PropertiesRenderer(
       this.app, this.reactRenderer, this.metadataExtractor, this.metadataService);

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -150,23 +150,6 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      // eslint-disable-next-line obsidianmd/ui/sentence-case
-      .setName("Use RDF buttons")
-      .setDesc(
-        // eslint-disable-next-line obsidianmd/ui/sentence-case
-        "Enable RDF-driven button rendering (experimental)",
-      )
-      .addToggle((toggle) =>
-        toggle
-          .setValue(this.plugin.settings.useRdfButtons)
-          .onChange(async (value) => {
-            this.plugin.settings.useRdfButtons = value;
-            await this.plugin.saveSettings();
-            this.plugin.refreshLayout();
-          }),
-      );
-
-    new Setting(containerEl)
       .setName("Show labels in file explorer")
       .setDesc(
         "Display asset labels instead of filenames in the file explorer sidebar",

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -349,8 +349,8 @@ describe("ExocortexSettingTab", () => {
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
       expect(getOntologySpy).toHaveBeenCalledTimes(1);
-      // 12 original settings (added showLabelsInGraphView) + 1 useRdfButtons + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 32
-      expect(MockSetting).toHaveBeenCalledTimes(32);
+      // 12 original settings (added showLabelsInGraphView) + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 31
+      expect(MockSetting).toHaveBeenCalledTimes(31);
     });
 
     it("should render ontology dropdown with correct options", () => {
@@ -904,123 +904,5 @@ describe("ExocortexSettingTab", () => {
       expect(dropdownValues[0]).toBe("ExistingOntology");
     });
 
-    it("should render Use RDF Buttons toggle", () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
-      let settingNames: string[] = [];
-      MockSetting.mockImplementation((containerEl: any) => {
-        const setting = {
-          containerEl,
-          setName: jest.fn().mockImplementation((name: string) => {
-            settingNames.push(name);
-            return setting;
-          }),
-          setDesc: jest.fn().mockReturnThis(),
-          setHeading: jest.fn().mockReturnThis(),
-          addDropdown: jest.fn().mockReturnThis(),
-          addToggle: jest.fn().mockImplementation((callback) => {
-            const toggle = {
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            callback(toggle);
-            return setting;
-          }),
-          addText: jest.fn().mockImplementation((callback) => {
-            const text = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            callback(text);
-            return setting;
-          }),
-          addButton: jest.fn().mockImplementation((callback) => {
-            const button = {
-              setButtonText: jest.fn().mockReturnThis(),
-              onClick: jest.fn().mockReturnThis(),
-              setCta: jest.fn().mockReturnThis(),
-            };
-            callback(button);
-            return setting;
-          }),
-        };
-        return setting;
-      });
-
-      settingTab.display();
-
-      // Check that "Use RDF Buttons" setting is rendered
-      expect(settingNames).toContain("Use RDF buttons");
-    });
-
-    it("should handle Use RDF Buttons toggle change", async () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
-      // Add useRdfButtons to mock settings
-      mockPlugin.settings.useRdfButtons = false;
-
-      let toggleCallbacks: any[] = [];
-      let settingNames: string[] = [];
-      MockSetting.mockImplementation((containerEl: any) => {
-        const setting = {
-          containerEl,
-          setName: jest.fn().mockImplementation((name: string) => {
-            settingNames.push(name);
-            return setting;
-          }),
-          setDesc: jest.fn().mockReturnThis(),
-          setHeading: jest.fn().mockReturnThis(),
-          addDropdown: jest.fn().mockReturnThis(),
-          addToggle: jest.fn().mockImplementation((callback) => {
-            const toggle = {
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            toggleCallbacks.push({ toggle, callback, onChange: null, settingName: settingNames[settingNames.length - 1] });
-            toggle.onChange.mockImplementation((cb: any) => {
-              toggleCallbacks[toggleCallbacks.length - 1].onChange = cb;
-              return toggle;
-            });
-            callback(toggle);
-            return setting;
-          }),
-          addText: jest.fn().mockImplementation((callback) => {
-            const text = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            callback(text);
-            return setting;
-          }),
-          addButton: jest.fn().mockImplementation((callback) => {
-            const button = {
-              setButtonText: jest.fn().mockReturnThis(),
-              onClick: jest.fn().mockReturnThis(),
-              setCta: jest.fn().mockReturnThis(),
-            };
-            callback(button);
-            return setting;
-          }),
-        };
-        return setting;
-      });
-
-      settingTab.display();
-
-      // Find the RDF buttons toggle by setting name
-      const rdfToggle = toggleCallbacks.find((t) => t.settingName === "Use RDF buttons");
-      expect(rdfToggle).toBeDefined();
-      expect(rdfToggle.toggle.setValue).toHaveBeenCalledWith(false);
-
-      if (rdfToggle?.onChange) {
-        await rdfToggle.onChange(true);
-      }
-
-      expect(mockPlugin.settings.useRdfButtons).toBe(true);
-      expect(mockPlugin.saveSettings).toHaveBeenCalled();
-      expect(mockPlugin.refreshLayout).toHaveBeenCalled();
-    });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/integration/RdfButtonGroupsIntegration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/RdfButtonGroupsIntegration.test.ts
@@ -70,7 +70,6 @@ describe("RdfButtonGroupsBuilder Integration with UniversalLayoutRenderer", () =
       showLayoutByDefault: true,
       showArchivedAssets: false,
       showDailyNoteProjects: false,
-      useRdfButtons: true, // Enable RDF button rendering
     } as ExocortexSettings;
 
     mockPlugin = {
@@ -132,14 +131,11 @@ describe("RdfButtonGroupsBuilder Integration with UniversalLayoutRenderer", () =
   });
 
   describe("RdfButtonGroupsBuilder instantiation", () => {
-    it("should have rdfButtonGroupsBuilder property when useRdfButtons is true", () => {
-      // mockSettings already has useRdfButtons: true (set in beforeEach)
-      expect(mockSettings.useRdfButtons).toBe(true);
-
+    it("should always have rdfButtonGroupsBuilder property", () => {
       const renderer = new UniversalLayoutRenderer(mockApp, mockSettings, mockPlugin, mockVaultAdapter);
       const renderer_any = renderer as any;
 
-      // The renderer should have rdfButtonGroupsBuilder when feature flag is enabled
+      // The renderer should always have rdfButtonGroupsBuilder (feature flag removed after validation)
       expect(renderer_any.rdfButtonGroupsBuilder).toBeDefined();
     });
   });
@@ -340,62 +336,8 @@ describe("RdfButtonGroupsBuilder Integration with UniversalLayoutRenderer", () =
     });
   });
 
-  describe("Feature flag: useRdfButtons", () => {
-    it("should initialize RdfButtonGroupsBuilder when useRdfButtons is true", () => {
-      mockSettings.useRdfButtons = true;
-
-      const renderer = new UniversalLayoutRenderer(mockApp, mockSettings, mockPlugin, mockVaultAdapter);
-      const renderer_any = renderer as any;
-
-      expect(renderer_any.rdfButtonGroupsBuilder).toBeDefined();
-    });
-
-    it("should NOT initialize RdfButtonGroupsBuilder when useRdfButtons is false", () => {
-      mockSettings.useRdfButtons = false;
-
-      const renderer = new UniversalLayoutRenderer(mockApp, mockSettings, mockPlugin, mockVaultAdapter);
-      const renderer_any = renderer as any;
-
-      expect(renderer_any.rdfButtonGroupsBuilder).toBeUndefined();
-    });
-
-    it("should NOT render buttons when useRdfButtons is false", async () => {
-      mockSettings.useRdfButtons = false;
-
-      const renderer = new UniversalLayoutRenderer(mockApp, mockSettings, mockPlugin, mockVaultAdapter);
-      const renderer_any = renderer as any;
-
-      const mockFile = {
-        path: "test.md",
-        basename: "test",
-      } as TFile;
-
-      mockApp.workspace.getActiveFile.mockReturnValue(mockFile);
-
-      // Mock other dependencies
-      renderer_any.dailyNavRenderer = { render: jest.fn() };
-      renderer_any.propertiesRenderer = { render: jest.fn().mockResolvedValue(undefined) };
-      renderer_any.dailyTasksRenderer = { render: jest.fn().mockResolvedValue(undefined) };
-      renderer_any.dailyProjectsRenderer = { render: jest.fn().mockResolvedValue(undefined) };
-      renderer_any.areaTreeRenderer = { render: jest.fn().mockResolvedValue(undefined) };
-      renderer_any.relationsRenderer = {
-        render: jest.fn().mockResolvedValue(undefined),
-        getAssetRelations: jest.fn().mockResolvedValue([]),
-      };
-      renderer_any.backlinksCacheManager = { getBacklinks: jest.fn().mockReturnValue(new Map()) };
-      renderer_any.metadataExtractor = { extractMetadata: jest.fn().mockReturnValue({}) };
-
-      const el = document.createElement("div");
-      await renderer.render("", el, {} as any);
-
-      // No button container should be created when feature flag is disabled
-      const buttonsContainer = el.querySelector(".exocortex-buttons-section");
-      expect(buttonsContainer).toBeNull();
-    });
-
-    it("should render buttons when useRdfButtons is true and buttons exist", async () => {
-      mockSettings.useRdfButtons = true;
-
+  describe("Button rendering behavior", () => {
+    it("should render buttons when buttons exist", async () => {
       const renderer = new UniversalLayoutRenderer(mockApp, mockSettings, mockPlugin, mockVaultAdapter);
       const renderer_any = renderer as any;
 
@@ -441,9 +383,46 @@ describe("RdfButtonGroupsBuilder Integration with UniversalLayoutRenderer", () =
       const el = document.createElement("div");
       await renderer.render("", el, {} as any);
 
-      // Buttons container should be created when feature flag is enabled and buttons exist
+      // Buttons container should be created when buttons exist
       const buttonsContainer = el.querySelector(".exocortex-buttons-section");
       expect(buttonsContainer).not.toBeNull();
+    });
+
+    it("should NOT render buttons container when no buttons exist", async () => {
+      const renderer = new UniversalLayoutRenderer(mockApp, mockSettings, mockPlugin, mockVaultAdapter);
+      const renderer_any = renderer as any;
+
+      const mockFile = {
+        path: "test.md",
+        basename: "test",
+      } as TFile;
+
+      mockApp.workspace.getActiveFile.mockReturnValue(mockFile);
+
+      // Mock RDF button builder to return empty (no buttons defined)
+      renderer_any.rdfButtonGroupsBuilder = {
+        buildButtonGroups: jest.fn().mockResolvedValue([]),
+      };
+
+      // Mock other dependencies
+      renderer_any.dailyNavRenderer = { render: jest.fn() };
+      renderer_any.propertiesRenderer = { render: jest.fn().mockResolvedValue(undefined) };
+      renderer_any.dailyTasksRenderer = { render: jest.fn().mockResolvedValue(undefined) };
+      renderer_any.dailyProjectsRenderer = { render: jest.fn().mockResolvedValue(undefined) };
+      renderer_any.areaTreeRenderer = { render: jest.fn().mockResolvedValue(undefined) };
+      renderer_any.relationsRenderer = {
+        render: jest.fn().mockResolvedValue(undefined),
+        getAssetRelations: jest.fn().mockResolvedValue([]),
+      };
+      renderer_any.backlinksCacheManager = { getBacklinks: jest.fn().mockReturnValue(new Map()) };
+      renderer_any.metadataExtractor = { extractMetadata: jest.fn().mockReturnValue({}) };
+
+      const el = document.createElement("div");
+      await renderer.render("", el, {} as any);
+
+      // No button container should be created when there are no buttons
+      const buttonsContainer = el.querySelector(".exocortex-buttons-section");
+      expect(buttonsContainer).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

Remove the `useRdfButtons` feature flag after parallel rendering validation confirmed identical behavior (Issue #2006, PR #2037).

## Changes

- Remove `useRdfButtons` from `ExocortexSettings` interface and defaults
- Remove feature flag toggle from `ExocortexSettingTab` UI
- Always initialize `RdfButtonGroupsBuilder` in `UniversalLayoutRenderer`
- Update tests to reflect always-enabled RDF buttons

## Related Issues

- Closes #2007
- Blocked by: #2006 (CLOSED via PR #2037)
- Part of Milestone: v14.0 - Legacy Code Cleanup

## Acceptance Criteria

- [x] Feature flag removed from settings
- [x] RdfButtonGroupsBuilder is default renderer
- [x] Old code paths removed (conditional initialization)
- [x] All tests pass

## Test Plan

- [x] Build succeeds (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Integration tests updated and pass
- [x] Settings tab tests updated (reduced setting count by 1)