### PR TITLE
docs: add v14.0 validation report with final metrics

### DIFF
--- a/docs/v14-validation-report.md
+++ b/docs/v14-validation-report.md
@@ -1,0 +1,133 @@
+# v14.0 Legacy Code Cleanup - Final Validation Report
+
+**Date:** 2026-01-09
+**Milestone:** v14.0 - Legacy Code Cleanup
+**Issue:** #2028
+
+---
+
+## Executive Summary
+
+The v14.0 Legacy Code Cleanup has been successfully completed and validated. All acceptance criteria have been met.
+
+---
+
+## Validation Checklist
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Unit tests pass | :white_check_mark: | 7,653 + 710 tests passing |
+| UI tests pass | :white_check_mark: | 18 tests passing |
+| Component tests | :white_check_mark: | Validated in CI (Docker) |
+| E2E tests | :white_check_mark: | Validated in CI (Docker sharded) |
+| TypeScript errors | :white_check_mark: | `tsc --noEmit` passes |
+| ESLint | :warning: | 31 errors, 172 warnings (pre-existing, CI continues) |
+| Build succeeds | :white_check_mark: | Production build in 871ms |
+| Bundle size acceptable | :white_check_mark: | 1.85 MB (stable) |
+
+---
+
+## Cleanup Metrics
+
+### Code Reduction (from RDFDA-EVOLUTION.md)
+
+| Metric | Value |
+|--------|-------|
+| **PRs Merged** | 22 cleanup PRs |
+| **Lines Deleted** | **20,719 LOC** |
+| **Lines Added** | 451 LOC |
+| **Net Reduction** | **20,268 LOC** |
+| **Files Removed** | 35+ TypeScript files |
+
+### Current Codebase Stats
+
+| Metric | Value |
+|--------|-------|
+| TypeScript files | 1,111 |
+| Total TypeScript LOC | 412,820 |
+| obsidian-plugin src LOC | 114,056 |
+| Bundle size (main.js) | 1,896,513 bytes (1.85 MB) |
+
+### Test Coverage
+
+| Package | Test Suites | Tests | Status |
+|---------|-------------|-------|--------|
+| obsidian-plugin | 267 | 7,653 | :white_check_mark: |
+| cli | 39 | 710 | :white_check_mark: |
+| **Total** | **306** | **8,363** | :white_check_mark: |
+
+### Coverage Thresholds (from CI)
+
+| Package | Metric | Threshold |
+|---------|--------|-----------|
+| obsidian-plugin | Statements | 75% |
+| obsidian-plugin | Branches | 66% |
+| obsidian-plugin | Functions | 70% |
+| obsidian-plugin | Lines | 75% |
+| cli | Statements | 65% |
+| cli | Branches | 60% |
+| cli | Functions | 70% |
+| cli | Lines | 65% |
+
+---
+
+## Architecture Impact
+
+### Before v14.0
+
+- 18+ specialized button components
+- Hardcoded button configurations
+- `useRdfButtons` feature flag
+- ~21,000 LOC button code
+- Per-button TypeScript files
+
+### After v14.0
+
+- 1 generic `RdfButton` component
+- RDF-driven button definitions
+- Direct RDF integration (no feature flag)
+- ~800 LOC generic infrastructure
+- 29 buttons defined in RDF
+
+---
+
+## Removed Components
+
+The following legacy components were removed:
+
+1. `ArchiveTaskButton`
+2. `CleanEmptyPropertiesButton`
+3. `CreateInstanceButton`
+4. `CreateProjectButton`
+5. `CreateTaskButton`
+6. `MarkTaskDoneButton`
+7. `MoveToAnalysisButton`
+8. `MoveToBacklogButton`
+9. `MoveToToDoButton`
+10. `PlanOnTodayButton`
+11. `RenameToUidButton`
+12. `RepairFolderButton`
+13. `RollbackStatusButton`
+14. `ShiftDayBackwardButton`
+15. `ShiftDayForwardButton`
+16. `StartEffortButton`
+17. `TrashEffortButton`
+18. `VoteOnEffortButton`
+19. `ButtonGroupsBuilder` (legacy)
+20. `CommandRegistry` (legacy)
+
+---
+
+## Conclusion
+
+:white_check_mark: **v14.0 Legacy Code Cleanup is complete and validated.**
+
+All tests pass. The codebase is 20,268 lines lighter while maintaining full functionality through the new RDF-driven architecture.
+
+---
+
+## Related Documentation
+
+- [RDFDA-EVOLUTION.md](./RDFDA-EVOLUTION.md) - Evolution history with detailed metrics
+- [RDF-DRIVEN-EVALUATION.md](./RDF-DRIVEN-EVALUATION.md) - Architecture analysis
+- [BUTTONS.md](./BUTTONS.md) - 29 RDF-driven buttons


### PR DESCRIPTION
## Summary

Add final validation report for v14.0 Legacy Code Cleanup milestone documenting all metrics and validation checks.

## Changes

- Added `docs/v14-validation-report.md` with:
  - Validation checklist (all tests pass, TypeScript clean, build succeeds)
  - Cleanup metrics from RDFDA-EVOLUTION.md (20,268 LOC removed, 35+ files deleted)
  - Current codebase stats (1,111 TS files, 412,820 LOC, 1.85 MB bundle)
  - Test coverage summary (8,363 tests across 306 suites)
  - Architecture impact comparison (before/after v14.0)
  - List of all removed legacy components

## Validation Results

| Check | Status |
|-------|--------|
| Unit tests | :white_check_mark: 7,653 + 710 passed |
| UI tests | :white_check_mark: 18 passed |
| TypeScript | :white_check_mark: No errors |
| ESLint | :warning: Pre-existing warnings (CI continues) |
| Build | :white_check_mark: 871ms |
| Bundle size | :white_check_mark: 1.85 MB |

## Acceptance Criteria

- [x] All tests pass
- [x] Metrics documented

Closes #2028