### PR TITLE
chore: bump version to 15.0.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "exocortex",
   "name": "Exocortex",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "minAppVersion": "1.5.0",
   "description": "Configurable UI system for Obsidian with ontology-driven layouts",
   "author": "A. Kitelev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exocortex-monorepo",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Exocortex: A configurable UI system for Obsidian that transforms knowledge management through ontology-driven layouts and semantic capabilities",
   "main": "main.js",
   "workspaces": [


### PR DESCRIPTION
## Summary
- Bump version to 15.0.1 after rollback to v13.266.10 and major version bump to 15.0.0

## Changes
- Updated `package.json` version to 15.0.1
- Updated `manifest.json` version to 15.0.1

## Test plan
- [ ] CI passes
- [ ] Release workflow triggers on merge