### PR TITLE
fix(ci): update coverage thresholds in CI workflow after graph removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,30 +185,31 @@ jobs:
           LINES=$(cat "$COVERAGE_FILE" | jq -r '.total.lines.pct')
 
           echo "📊 obsidian-plugin Coverage Report:"
-          echo "  Statements: ${STATEMENTS}% (required: 75%)"
-          echo "  Branches:   ${BRANCHES}% (required: 67%)"
-          echo "  Functions:  ${FUNCTIONS}% (required: 70%)"
-          echo "  Lines:      ${LINES}% (required: 75%)"
+          echo "  Statements: ${STATEMENTS}% (required: 76%)"
+          echo "  Branches:   ${BRANCHES}% (required: 64%)"
+          echo "  Functions:  ${FUNCTIONS}% (required: 69%)"
+          echo "  Lines:      ${LINES}% (required: 76%)"
 
           # Check if coverage meets thresholds using awk for floating point comparison
+          # Updated thresholds after graph visualization removal (Issue #2083)
           FAILED=0
-          if [ $(echo "$STATEMENTS < 75" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
-            echo "❌ Statement coverage ${STATEMENTS}% is below 75% threshold"
+          if [ $(echo "$STATEMENTS < 76" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
+            echo "❌ Statement coverage ${STATEMENTS}% is below 76% threshold"
             FAILED=1
           fi
 
-          if [ $(echo "$BRANCHES < 67" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
-            echo "❌ Branch coverage ${BRANCHES}% is below 67% threshold"
+          if [ $(echo "$BRANCHES < 64" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
+            echo "❌ Branch coverage ${BRANCHES}% is below 64% threshold"
             FAILED=1
           fi
 
-          if [ $(echo "$FUNCTIONS < 70" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
-            echo "❌ Function coverage ${FUNCTIONS}% is below 70% threshold"
+          if [ $(echo "$FUNCTIONS < 69" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
+            echo "❌ Function coverage ${FUNCTIONS}% is below 69% threshold"
             FAILED=1
           fi
 
-          if [ $(echo "$LINES < 75" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
-            echo "❌ Line coverage ${LINES}% is below 75% threshold"
+          if [ $(echo "$LINES < 76" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
+            echo "❌ Line coverage ${LINES}% is below 76% threshold"
             FAILED=1
           fi
 


### PR DESCRIPTION
## Summary

Follow-up to PRs #2086 and #2087.

The jest.config.js thresholds were updated in PR #2087, but the CI workflow in `.github/workflows/ci.yml` still had the old thresholds, causing main CI to fail.

### Changes
Update obsidian-plugin coverage thresholds in CI workflow:
- Statements: 75% → 76%
- Branches: 67% → 64%
- Functions: 70% → 69%
- Lines: 75% → 76%

### Why This Happened
The auto-merge merged PR #2087 before I could push the amended commit with CI workflow changes. This PR completes the threshold alignment.

### Test Plan
- [x] CI coverage check will now pass

Related: #2083, #2086, #2087