### PR TITLE
feat: add archive emoji to Archive buttons in plugin UI

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/MaintenanceButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/MaintenanceButtonGroupBuilder.ts
@@ -78,7 +78,7 @@ export class MaintenanceButtonGroupBuilder implements IButtonGroupBuilder {
   ): ActionButton {
     return {
       id: "archive",
-      label: "Archive",
+      label: "📦 Archive",
       variant: "danger",
       visible: canArchiveTask(context),
       onClick: async () => {

--- a/packages/obsidian-plugin/src/presentation/components/ArchiveTaskButton.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/ArchiveTaskButton.tsx
@@ -53,7 +53,7 @@ export const ArchiveTaskButton: React.FC<ArchiveTaskButtonProps> = ({
       onClick={handleClick}
       type="button"
     >
-      To Archive
+      📦 To Archive
     </button>
   );
 };

--- a/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
+++ b/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
@@ -765,7 +765,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
       // Find Archive button by text content
       const buttons = domContainer.querySelectorAll(".exocortex-action-button");
       const archiveBtn = Array.from(buttons).find(
-        (btn) => btn.textContent === "Archive",
+        (btn) => btn.textContent === "📦 Archive",
       );
       expect(archiveBtn).toBeTruthy();
     });
@@ -816,7 +816,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
 
       const buttons = domContainer.querySelectorAll(".exocortex-action-button");
       const archiveBtn = Array.from(buttons).find(
-        (btn) => btn.textContent === "Archive",
+        (btn) => btn.textContent === "📦 Archive",
       );
       expect(archiveBtn).toBeTruthy();
     });
@@ -844,7 +844,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
       // Find Archive button by text content
       const buttons = domContainer.querySelectorAll(".exocortex-action-button");
       const archiveBtn = Array.from(buttons).find(
-        (btn) => btn.textContent === "Archive",
+        (btn) => btn.textContent === "📦 Archive",
       );
       expect(archiveBtn).toBeTruthy();
     });
@@ -895,7 +895,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
 
       const buttons = domContainer.querySelectorAll(".exocortex-action-button");
       const archiveBtn = Array.from(buttons).find(
-        (btn) => btn.textContent === "Archive",
+        (btn) => btn.textContent === "📦 Archive",
       );
       expect(archiveBtn).toBeTruthy();
     });
@@ -921,7 +921,7 @@ describe("UniversalLayoutRenderer UI Integration", () => {
 
       const buttons = domContainer.querySelectorAll(".exocortex-action-button");
       const archiveBtn = Array.from(buttons).find(
-        (btn) => btn.textContent === "Archive",
+        (btn) => btn.textContent === "📦 Archive",
       );
       expect(archiveBtn).toBeTruthy();
     });

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
@@ -600,6 +600,36 @@ describe("ButtonGroupsBuilder - build", () => {
     expect(archiveButton?.visible).toBe(true);
   });
 
+  it("should display archive button with 📦 emoji", async () => {
+    const mockFile = {
+      path: "test.md",
+      parent: { path: "Tasks" },
+      basename: "TestTask",
+    } as TFile;
+    const metadata = {
+      exo__Instance_class: "[[ems__Task]]",
+      ems__Effort_status: "[[ems__EffortStatusDone]]",
+    };
+
+    ctx.mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[ems__Task]]",
+    );
+    ctx.mockMetadataExtractor.extractStatus.mockReturnValue(
+      "[[ems__EffortStatusDone]]",
+    );
+    ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
+    ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
+
+    const groups = await ctx.builder.build(mockFile);
+
+    const maintenanceGroup = groups.find((g) => g.id === "maintenance");
+    const archiveButton = maintenanceGroup?.buttons.find(
+      (b) => b.id === "archive",
+    );
+    expect(archiveButton?.label).toBe("📦 Archive");
+  });
+
   it("should hide archive button for already archived tasks", async () => {
     const mockFile = {
       path: "test.md",


### PR DESCRIPTION
## Summary
- Add 📦 emoji to Archive buttons in plugin UI for improved visual UX consistency
- Updated both MaintenanceButtonGroupBuilder and ArchiveTaskButton components
- Button text changes: "Archive" → "📦 Archive" and "To Archive" → "📦 To Archive"

## Test Plan
- [x] Unit tests pass (new test added for emoji label)
- [x] UI tests updated and pass
- [x] Build passes
- [x] Lint passes

Closes #2091