### PR TITLE
fix: Support wikilink aliases in effort status parsing

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/property-fields/SizeSelectPropertyField.ts
+++ b/packages/obsidian-plugin/src/presentation/components/property-fields/SizeSelectPropertyField.ts
@@ -1,5 +1,6 @@
 import { Setting } from "obsidian";
 import type { SizeSelectPropertyFieldProps, ValidationResult } from "./types";
+import { WikilinkLabelResolver } from "@plugin/presentation/utils/WikilinkLabelResolver";
 
 /**
  * Task size options for size select.
@@ -101,6 +102,7 @@ export class SizeSelectPropertyField {
 
   /**
    * Normalize value to match option format.
+   * Supports wikilinks with aliases (e.g., [[ems__TaskSize_M|Medium]])
    */
   private normalizeValue(value: string): string {
     if (!value) return "";
@@ -112,8 +114,18 @@ export class SizeSelectPropertyField {
       }
     }
 
-    // Try to match without brackets or quotes
-    const cleanValue = value.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "");
+    // Remove outer quotes first
+    let cleanValue = value.replace(/^"|"$/g, "");
+
+    // Parse wikilink to extract target (handles aliases like [[target|alias]])
+    const parsed = WikilinkLabelResolver.parseWikilink(cleanValue);
+    if (parsed) {
+      cleanValue = parsed.target;
+    } else {
+      // Fallback: remove brackets if not a valid wikilink format
+      cleanValue = cleanValue.replace(/^\[\[|\]\]$/g, "");
+    }
+
     for (const option of TASK_SIZE_OPTIONS) {
       const cleanOption = option.value.replace(/^\[\[|\]\]$/g, "");
       if (cleanOption === cleanValue) {
@@ -150,11 +162,23 @@ export class SizeSelectPropertyField {
 
   /**
    * Get the display label for a size value.
+   * Supports wikilinks with aliases (e.g., [[ems__TaskSize_M|Medium]])
    */
   static getLabel(value: string): string {
     if (!value) return "-";
 
-    const cleanValue = value.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "");
+    // Remove outer quotes first
+    let cleanValue = value.replace(/^"|"$/g, "");
+
+    // Parse wikilink to extract target (handles aliases like [[target|alias]])
+    const parsed = WikilinkLabelResolver.parseWikilink(cleanValue);
+    if (parsed) {
+      cleanValue = parsed.target;
+    } else {
+      // Fallback: remove brackets if not a valid wikilink format
+      cleanValue = cleanValue.replace(/^\[\[|\]\]$/g, "");
+    }
+
     for (const option of TASK_SIZE_OPTIONS) {
       const cleanOption = option.value.replace(/^\[\[|\]\]$/g, "");
       if (cleanOption === cleanValue) {

--- a/packages/obsidian-plugin/src/presentation/components/property-fields/StatusSelectPropertyField.ts
+++ b/packages/obsidian-plugin/src/presentation/components/property-fields/StatusSelectPropertyField.ts
@@ -1,5 +1,6 @@
 import { Setting } from "obsidian";
 import type { StatusSelectPropertyFieldProps, ValidationResult } from "./types";
+import { WikilinkLabelResolver } from "@plugin/presentation/utils/WikilinkLabelResolver";
 
 /**
  * Status options for effort status select.
@@ -102,6 +103,7 @@ export class StatusSelectPropertyField {
 
   /**
    * Normalize value to match option format.
+   * Supports wikilinks with aliases (e.g., [[ems__EffortStatusBacklog|Беклог]])
    */
   private normalizeValue(value: string): string {
     if (!value) return "";
@@ -113,9 +115,17 @@ export class StatusSelectPropertyField {
       }
     }
 
-    // Strip quotes first, then brackets to get base status name
-    let cleanValue = value.replace(/^"|"$/g, ""); // Remove outer quotes
-    cleanValue = cleanValue.replace(/^\[\[|\]\]$/g, ""); // Remove brackets
+    // Strip quotes first
+    let cleanValue = value.replace(/^"|"$/g, "");
+
+    // Parse wikilink to extract target (handles aliases like [[target|alias]])
+    const parsed = WikilinkLabelResolver.parseWikilink(cleanValue);
+    if (parsed) {
+      cleanValue = parsed.target;
+    } else {
+      // Fallback: remove brackets if not a valid wikilink format
+      cleanValue = cleanValue.replace(/^\[\[|\]\]$/g, "");
+    }
 
     for (const option of EFFORT_STATUS_OPTIONS) {
       const cleanOption = option.value.replace(/^\[\[|\]\]$/g, "");
@@ -146,11 +156,23 @@ export class StatusSelectPropertyField {
 
   /**
    * Get the display label for a status value.
+   * Supports wikilinks with aliases (e.g., [[ems__EffortStatusBacklog|Беклог]])
    */
   static getLabel(value: string): string {
     if (!value) return "-";
 
-    const cleanValue = value.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "");
+    // Remove outer quotes first
+    let cleanValue = value.replace(/^"|"$/g, "");
+
+    // Parse wikilink to extract target (handles aliases like [[target|alias]])
+    const parsed = WikilinkLabelResolver.parseWikilink(cleanValue);
+    if (parsed) {
+      cleanValue = parsed.target;
+    } else {
+      // Fallback: remove brackets if not a valid wikilink format
+      cleanValue = cleanValue.replace(/^\[\[|\]\]$/g, "");
+    }
+
     for (const option of EFFORT_STATUS_OPTIONS) {
       const cleanOption = option.value.replace(/^\[\[|\]\]$/g, "");
       if (cleanOption === cleanValue) {

--- a/packages/obsidian-plugin/tests/unit/property-fields/StatusSelectPropertyField.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-fields/StatusSelectPropertyField.test.ts
@@ -216,6 +216,72 @@ describe("StatusSelectPropertyField", () => {
       ) as HTMLSelectElement | null;
       expect(select!.value).toBe("[[ems__EffortStatusDoing]]");
     });
+
+    describe("Issue #2098: wikilink alias handling", () => {
+      it("should normalize wikilink with English alias", () => {
+        new StatusSelectPropertyField(containerEl, {
+          property: {
+            uri: "ems:status",
+            name: "ems__Effort_status",
+            label: "Status",
+            fieldType: PropertyFieldType.StatusSelect,
+          },
+          value: "[[ems__EffortStatusBacklog|Backlog]]",
+          onChange: jest.fn(),
+        });
+
+        const select = containerEl.querySelector(
+          "select",
+        ) as HTMLSelectElement | null;
+        expect(select!.value).toBe("[[ems__EffortStatusBacklog]]");
+      });
+
+      it("should normalize wikilink with Russian alias", () => {
+        new StatusSelectPropertyField(containerEl, {
+          property: {
+            uri: "ems:status",
+            name: "ems__Effort_status",
+            label: "Status",
+            fieldType: PropertyFieldType.StatusSelect,
+          },
+          value: "[[ems__EffortStatusBacklog|Беклог]]",
+          onChange: jest.fn(),
+        });
+
+        const select = containerEl.querySelector(
+          "select",
+        ) as HTMLSelectElement | null;
+        expect(select!.value).toBe("[[ems__EffortStatusBacklog]]");
+      });
+
+      it("should normalize wikilink with alias for all status types", () => {
+        const statusCases = [
+          { input: "[[ems__EffortStatusDraft|Draft]]", expected: "[[ems__EffortStatusDraft]]" },
+          { input: "[[ems__EffortStatusBacklog|ems:Backlog]]", expected: "[[ems__EffortStatusBacklog]]" },
+          { input: "[[ems__EffortStatusDoing|В работе]]", expected: "[[ems__EffortStatusDoing]]" },
+          { input: "[[ems__EffortStatusDone|Готово]]", expected: "[[ems__EffortStatusDone]]" },
+          { input: "[[ems__EffortStatusTrashed|Удалено]]", expected: "[[ems__EffortStatusTrashed]]" },
+        ];
+
+        for (const { input, expected } of statusCases) {
+          const testContainer = document.createElement("div");
+          new StatusSelectPropertyField(testContainer, {
+            property: {
+              uri: "ems:status",
+              name: "ems__Effort_status",
+              label: "Status",
+              fieldType: PropertyFieldType.StatusSelect,
+            },
+            value: input,
+            onChange: jest.fn(),
+          });
+
+          const select = testContainer.querySelector("select") as HTMLSelectElement | null;
+          expect(select!.value).toBe(expected);
+          testContainer.remove();
+        }
+      });
+    });
   });
 
   describe("getLabel static method", () => {
@@ -245,6 +311,30 @@ describe("StatusSelectPropertyField", () => {
       expect(StatusSelectPropertyField.getLabel("unknown_status")).toBe(
         "unknown_status",
       );
+    });
+
+    describe("Issue #2098: wikilink alias handling", () => {
+      it("should return correct label for wikilink with English alias", () => {
+        expect(StatusSelectPropertyField.getLabel("[[ems__EffortStatusDoing|Doing]]")).toBe(
+          "Doing",
+        );
+      });
+
+      it("should return correct label for wikilink with Russian alias", () => {
+        expect(StatusSelectPropertyField.getLabel("[[ems__EffortStatusBacklog|Беклог]]")).toBe(
+          "Backlog",
+        );
+      });
+
+      it("should return correct label for all status types with aliases", () => {
+        expect(StatusSelectPropertyField.getLabel("[[ems__EffortStatusDraft|Черновик]]")).toBe("Draft");
+        expect(StatusSelectPropertyField.getLabel("[[ems__EffortStatusBacklog|ems:Backlog]]")).toBe("Backlog");
+        expect(StatusSelectPropertyField.getLabel("[[ems__EffortStatusAnalysis|Анализ]]")).toBe("Analysis");
+        expect(StatusSelectPropertyField.getLabel("[[ems__EffortStatusToDo|К выполнению]]")).toBe("To Do");
+        expect(StatusSelectPropertyField.getLabel("[[ems__EffortStatusDoing|В работе]]")).toBe("Doing");
+        expect(StatusSelectPropertyField.getLabel("[[ems__EffortStatusDone|Готово]]")).toBe("Done");
+        expect(StatusSelectPropertyField.getLabel("[[ems__EffortStatusTrashed|Удалено]]")).toBe("Trashed");
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
Fix effort status button functionality to correctly parse wikilinks with aliases (e.g., `[[ems__EffortStatusBacklog|Беклог]]`) by extracting only the UID part before the pipe symbol.

## Changes
- **StatusSelectPropertyField.ts**: Updated `normalizeValue()` and `getLabel()` to use `WikilinkLabelResolver.parseWikilink()` for extracting UID from wikilinks with aliases
- **SizeSelectPropertyField.ts**: Applied same fix for consistency
- Added 6 comprehensive unit tests covering wikilink alias handling

## Test plan
- [x] Unit tests added for wikilink alias parsing (6 new tests)
- [x] All existing tests pass (665 tests)
- [x] Build succeeds
- [x] Lint passes (no new warnings)

## Acceptance Criteria
- [x] Wikilinks with English aliases work: `[[ems__EffortStatusBacklog|Backlog]]`
- [x] Wikilinks with Russian aliases work: `[[ems__EffortStatusBacklog|Беклог]]`
- [x] All status types supported: Draft, Backlog, Analysis, ToDo, Doing, Done, Trashed
- [x] Non-aliased wikilinks continue to work: `[[ems__EffortStatusBacklog]]`
- [x] Reuses existing `WikilinkLabelResolver.parseWikilink()` utility

Fixes #2098