### PR TITLE
fix(plugin): preserve user-defined wikilink aliases in link patching

### DIFF
--- a/packages/obsidian-plugin/src/presentation/body/BodyLinkPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/body/BodyLinkPatch.ts
@@ -179,6 +179,12 @@ export class BodyLinkPatch {
 
   /**
    * Patch a single link element
+   *
+   * IMPORTANT: Preserves user-defined aliases (Issue #2097).
+   * If the current textContent differs from the file basename AND the cleaned data-href,
+   * the user provided an explicit alias and we should not overwrite it.
+   * However, if we already patched this link (has data-body-patched),
+   * we should re-patch to pick up metadata changes.
    */
   private patchLink(linkEl: HTMLElement): void {
     // Get the file path from data-href attribute
@@ -189,12 +195,33 @@ export class BodyLinkPatch {
     const file = this.resolveFile(dataHref);
     if (!file) return;
 
+    // Clean the data-href to get what Obsidian would show for a bare wikilink
+    const cleanedDataHref = dataHref
+      .replace(/^\[\[|\]\]$/g, "") // Remove wikilink brackets
+      .replace(/^"|"$/g, "") // Remove quotes
+      .replace(/\.md$/, "") // Remove .md extension
+      .trim();
+
+    // Check for user-defined alias (Issue #2097)
+    // If textContent differs from BOTH file basename AND cleaned data-href,
+    // user provided explicit alias. BUT: if already patched, allow re-patching.
+    const currentText = (linkEl.textContent || "").trim();
+    const wasAlreadyPatched = linkEl.hasAttribute("data-body-patched");
+    const matchesBasename = currentText === file.basename;
+    const matchesDataHref = currentText === cleanedDataHref;
+    const hasUserAlias = currentText !== "" && !matchesBasename && !matchesDataHref && !wasAlreadyPatched;
+
+    if (hasUserAlias) {
+      // User provided explicit alias - preserve it, don't overwrite
+      return;
+    }
+
     // Get the display name for this file
     const displayName = this.getDisplayName(file);
     if (!displayName) return;
 
-    // Store original text for restoration
-    const originalText = linkEl.textContent || "";
+    // Store original text for restoration (use data-original-text if already stored)
+    const originalText = linkEl.getAttribute("data-original-text") || linkEl.textContent || "";
     if (!linkEl.hasAttribute("data-original-text")) {
       linkEl.setAttribute("data-original-text", originalText);
     }

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
@@ -167,6 +167,11 @@ export class PropertiesLinkPatch {
    * IMPORTANT: In multi-value properties, Obsidian places child elements like
    * remove buttons (×) inside the link element. We must preserve these by updating
    * only the text nodes, not replacing the entire innerHTML via textContent.
+   *
+   * IMPORTANT: Preserves user-defined aliases (Issue #2097).
+   * If the current textContent differs from the file basename AND the cleaned data-href,
+   * the user provided an explicit alias and we should not overwrite it.
+   * However, if we already patched this link (has data-original-text), allow re-patching.
    */
   private patchLink(linkEl: HTMLElement): void {
     // Get the file path from data-href attribute
@@ -177,12 +182,32 @@ export class PropertiesLinkPatch {
     const file = this.resolveFile(dataHref);
     if (!file) return;
 
+    // Clean the data-href to get what Obsidian would show for a bare wikilink
+    const cleanedDataHref = dataHref
+      .replace(/^\[\[|\]\]$/g, "") // Remove wikilink brackets
+      .replace(/^"|"$/g, "") // Remove quotes
+      .replace(/\.md$/, "") // Remove .md extension
+      .trim();
+
+    // Check for user-defined alias (Issue #2097)
+    // Get text content excluding interactive elements (like delete buttons)
+    const currentText = this.getTextContentForAliasCheck(linkEl).trim();
+    const wasAlreadyPatched = linkEl.hasAttribute("data-original-text");
+    const matchesBasename = currentText === file.basename;
+    const matchesDataHref = currentText === cleanedDataHref;
+    const hasUserAlias = currentText !== "" && !matchesBasename && !matchesDataHref && !wasAlreadyPatched;
+
+    if (hasUserAlias) {
+      // User provided explicit alias - preserve it, don't overwrite
+      return;
+    }
+
     // Get the display name for this file
     const displayName = this.getDisplayName(file);
     if (!displayName) return;
 
-    // Store original text for restoration (before any modifications)
-    const originalText = this.getTextContent(linkEl);
+    // Store original text for restoration (use data-original-text if already stored)
+    const originalText = linkEl.getAttribute("data-original-text") || this.getTextContent(linkEl);
     if (!linkEl.hasAttribute("data-original-text")) {
       linkEl.setAttribute("data-original-text", originalText);
     }
@@ -210,6 +235,33 @@ export class PropertiesLinkPatch {
       }
     }
     return text.trim() || el.textContent || "";
+  }
+
+  /**
+   * Get text content for alias detection, excluding interactive elements
+   * This is used to determine if user provided a custom alias.
+   * Excludes delete buttons and other interactive elements from the text.
+   */
+  private getTextContentForAliasCheck(el: HTMLElement): string {
+    let text = "";
+    for (const node of Array.from(el.childNodes)) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        text += node.textContent || "";
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const element = node as Element;
+        // Exclude interactive elements (delete buttons, etc.)
+        if (
+          element.classList?.contains("multi-select-pill-remove-button") ||
+          element.tagName === "BUTTON" ||
+          element.getAttribute("aria-label") === "Remove"
+        ) {
+          continue;
+        }
+        // Include text from non-interactive child elements (like text wrapper spans)
+        text += element.textContent || "";
+      }
+    }
+    return text.trim();
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/presentation/body/BodyLinkPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/body/BodyLinkPatch.test.ts
@@ -402,6 +402,90 @@ describe("BodyLinkPatch", () => {
     });
   });
 
+  describe("user-defined alias preservation (issue #2097)", () => {
+    it("should preserve user-defined alias when link has custom text (not matching file basename)", () => {
+      // User wrote [[uuid|My Custom Name]] - Obsidian renders this with textContent="My Custom Name"
+      mockLink.textContent = "My Custom Name";
+      mockLink.setAttribute("data-href", "f2dccb6a-802d-48d3-8e8a-2c4264197692");
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "f2dccb6a-802d-48d3-8e8a-2c4264197692" });
+      Object.defineProperty(mockFile, "stat", {
+        value: { ctime: Date.now() },
+      });
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Auto Label from Metadata",
+          exo__Instance_class: "ems__Task",
+        },
+      });
+
+      patch.enable();
+
+      // User alias should be preserved - NOT overwritten with resolved label
+      expect(mockLink.textContent).toBe("My Custom Name");
+      // Should NOT be marked as patched since we preserved the alias
+      expect(mockLink.getAttribute("data-body-patched")).toBeNull();
+    });
+
+    it("should resolve label for bare wikilinks (text matches file basename)", () => {
+      // User wrote [[uuid]] - Obsidian renders this with textContent="uuid"
+      mockLink.textContent = "f2dccb6a-802d-48d3-8e8a-2c4264197692";
+      mockLink.setAttribute("data-href", "f2dccb6a-802d-48d3-8e8a-2c4264197692");
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "f2dccb6a-802d-48d3-8e8a-2c4264197692" });
+      Object.defineProperty(mockFile, "stat", {
+        value: { ctime: Date.now() },
+      });
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Task Label",
+          exo__Instance_class: "ems__Task",
+        },
+      });
+
+      patch.enable();
+
+      // Bare wikilink - label should be resolved
+      expect(mockLink.textContent).toBe("Task Label (ems__Task)");
+      expect(mockLink.getAttribute("data-body-patched")).toBe("true");
+    });
+
+    it("should preserve alias even when it differs only by whitespace from basename", () => {
+      // Edge case: user alias might have trimmed whitespace
+      mockLink.textContent = "Custom Alias";
+      mockLink.setAttribute("data-href", "custom-alias");
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "custom-alias" });
+      Object.defineProperty(mockFile, "stat", {
+        value: { ctime: Date.now() },
+      });
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Some Label",
+          exo__Instance_class: "ems__Task",
+        },
+      });
+
+      patch.enable();
+
+      // "Custom Alias" differs from "custom-alias" basename - preserve user alias
+      expect(mockLink.textContent).toBe("Custom Alias");
+      expect(mockLink.getAttribute("data-body-patched")).toBeNull();
+    });
+  });
+
   describe("metadata change handling", () => {
     it("should update link text when metadata changes", () => {
       const mockFile = new TFile();

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLinkPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLinkPatch.test.ts
@@ -342,10 +342,12 @@ describe("PropertiesLinkPatch", () => {
 
     it("should not preserve generic span elements as text wrappers", () => {
       // Create a link with both a text wrapper span and a delete button
+      // NOTE: Link points to "test-file" (from beforeEach data-href), so
+      // the text wrapper should also contain "test-file" to simulate a bare wikilink
       mockLink.innerHTML = "";
       const textSpan = document.createElement("span");
       textSpan.className = "some-text-wrapper";
-      textSpan.textContent = "uuid-text";
+      textSpan.textContent = "test-file"; // Matches data-href (bare wikilink scenario)
       mockLink.appendChild(textSpan);
 
       const deleteButton = document.createElement("span");
@@ -381,6 +383,90 @@ describe("PropertiesLinkPatch", () => {
       const preservedButton = mockLink.querySelector(".multi-select-pill-remove-button");
       expect(preservedButton).not.toBeNull();
       expect(preservedButton?.textContent).toBe("×");
+    });
+  });
+
+  describe("user-defined alias preservation (issue #2097)", () => {
+    it("should preserve user-defined alias when link has custom text (not matching file basename)", () => {
+      // User wrote [[uuid|My Custom Name]] - Obsidian renders this with textContent="My Custom Name"
+      mockLink.textContent = "My Custom Name";
+      mockLink.setAttribute("data-href", "f2dccb6a-802d-48d3-8e8a-2c4264197692");
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "f2dccb6a-802d-48d3-8e8a-2c4264197692" });
+      Object.defineProperty(mockFile, "stat", {
+        value: { ctime: Date.now() },
+      });
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Auto Label from Metadata",
+          exo__Instance_class: "ems__Task",
+        },
+      });
+
+      patch.enable();
+
+      // User alias should be preserved - NOT overwritten with resolved label
+      expect(mockLink.textContent).toBe("My Custom Name");
+      // Should NOT have data-original-text since we didn't patch
+      expect(mockLink.getAttribute("data-original-text")).toBeNull();
+    });
+
+    it("should resolve label for bare wikilinks (text matches file basename)", () => {
+      // User wrote [[uuid]] - Obsidian renders this with textContent="uuid"
+      mockLink.textContent = "f2dccb6a-802d-48d3-8e8a-2c4264197692";
+      mockLink.setAttribute("data-href", "f2dccb6a-802d-48d3-8e8a-2c4264197692");
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "f2dccb6a-802d-48d3-8e8a-2c4264197692" });
+      Object.defineProperty(mockFile, "stat", {
+        value: { ctime: Date.now() },
+      });
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Task Label",
+          exo__Instance_class: "ems__Task",
+        },
+      });
+
+      patch.enable();
+
+      // Bare wikilink - label should be resolved
+      expect(mockLink.textContent).toBe("Task Label (ems__Task)");
+      expect(mockLink.getAttribute("data-original-text")).toBe("f2dccb6a-802d-48d3-8e8a-2c4264197692");
+    });
+
+    it("should preserve alias even when it differs only by case/formatting from basename", () => {
+      // Edge case: user alias might have different case
+      mockLink.textContent = "Custom Alias";
+      mockLink.setAttribute("data-href", "custom-alias");
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "custom-alias" });
+      Object.defineProperty(mockFile, "stat", {
+        value: { ctime: Date.now() },
+      });
+
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "Some Label",
+          exo__Instance_class: "ems__Task",
+        },
+      });
+
+      patch.enable();
+
+      // "Custom Alias" differs from "custom-alias" basename - preserve user alias
+      expect(mockLink.textContent).toBe("Custom Alias");
+      expect(mockLink.getAttribute("data-original-text")).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix link patching to preserve user-defined wikilink aliases instead of overwriting them
- Add alias detection logic to both `BodyLinkPatch` and `PropertiesLinkPatch`
- Add comprehensive tests for alias preservation scenarios

## Changes
- Added alias detection in `patchLink()`: if textContent differs from both file basename AND cleaned data-href, treat it as user alias
- Added `getTextContentForAliasCheck()` helper to exclude interactive elements (delete buttons) from alias detection
- Updated tests to verify alias preservation for `[[uuid|Custom Alias]]` format
- Updated existing test to use consistent mock data

## Testing
- [x] Added regression tests for Issue #2097
- [x] Added edge case tests (different formatting, whitespace)
- [x] All existing tests pass (4247 plugin tests + 665 CLI tests)
- [x] Build passes
- [x] Lint passes (0 errors, 15 pre-existing warnings)

## Verification
- `[[uuid|My Custom Name]]` → preserves "My Custom Name" ✅
- `[[uuid]]` → resolves to `exo__Asset_label` as before ✅
- Metadata changes on already-patched links update correctly ✅

Fixes #2097