### PR TITLE
feat(rdf): Dual storage for UUID-based wikilinks (File IRI + UUID Literal)

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -106,20 +106,23 @@ export class NoteToRDFConverter {
           const objectNode = this.valueToClassURI(val);
           triples.push(new Triple(subject, predicate, objectNode));
         } else {
-          const objectNode = await this.valueToRDFObject(val, file);
-          triples.push(new Triple(subject, predicate, objectNode));
+          // Issue #2102: valueToRDFObject now returns array for dual storage support
+          const objectNodes = await this.valueToRDFObject(val, file);
+          for (const objectNode of objectNodes) {
+            triples.push(new Triple(subject, predicate, objectNode));
 
-          // Issue #871: Generate additional RDFS triple for properties with vocabulary mappings
-          // This enables SPARQL queries using standard RDFS predicates like rdfs:domain, rdfs:range
-          // to work with Exocortex ontology properties.
-          if (this.vocabularyMapper.hasMappingFor(key) && objectNode instanceof IRI) {
-            const mappedTriple = this.vocabularyMapper.generateMappedTriple(
-              subject,
-              key,
-              objectNode,
-            );
-            if (mappedTriple) {
-              triples.push(mappedTriple);
+            // Issue #871: Generate additional RDFS triple for properties with vocabulary mappings
+            // This enables SPARQL queries using standard RDFS predicates like rdfs:domain, rdfs:range
+            // to work with Exocortex ontology properties.
+            if (this.vocabularyMapper.hasMappingFor(key) && objectNode instanceof IRI) {
+              const mappedTriple = this.vocabularyMapper.generateMappedTriple(
+                subject,
+                key,
+                objectNode,
+              );
+              if (mappedTriple) {
+                triples.push(mappedTriple);
+              }
             }
           }
         }
@@ -464,10 +467,20 @@ export class NoteToRDFConverter {
     throw new Error(`Invalid property key: ${key}`);
   }
 
+  /**
+   * Converts a frontmatter value to RDF object(s).
+   *
+   * Issue #2102: For UUID-based wikilinks, returns both File IRI and UUID Literal
+   * to enable SPARQL queries that search by UUID string.
+   *
+   * @param value - The frontmatter value to convert
+   * @param sourceFile - The source file for resolving wikilinks
+   * @returns Array of RDF objects (IRI or Literal). UUID wikilinks return [IRI, Literal].
+   */
   private async valueToRDFObject(
     value: any,
     sourceFile: IFile
-  ): Promise<IRI | Literal> {
+  ): Promise<(IRI | Literal)[]> {
     if (typeof value === "string") {
       const cleanValue = this.removeQuotes(value);
 
@@ -478,51 +491,61 @@ export class NoteToRDFConverter {
           sourceFile.path
         );
         if (targetFile) {
-          return this.notePathToIRI(targetFile.path);
+          const fileIRI = this.notePathToIRI(targetFile.path);
+
+          // Issue #2102: If wikilink is a UUID, store both IRI and Literal
+          // This enables SPARQL queries like:
+          // ?s exo:Asset_prototype "e3347bcf-bb50-4fb7-9064-14266469384b"
+          if (this.isUUID(wikilink)) {
+            const uuidLiteral = new Literal(wikilink);
+            return [fileIRI, uuidLiteral];
+          }
+
+          return [fileIRI];
         }
         // If target file not found but wikilink is a class reference,
         // expand to namespace URI (Issue #667, #668: normalize Instance_class/Property_domain)
         if (this.isClassReference(wikilink)) {
           const classIRI = this.expandClassValue(wikilink);
           if (classIRI) {
-            return classIRI;
+            return [classIRI];
           }
         }
-        return new Literal(cleanValue);
+        return [new Literal(cleanValue)];
       }
 
       if (this.isClassReference(cleanValue)) {
         const classIRI = this.expandClassValue(cleanValue);
         if (classIRI) {
-          return classIRI;
+          return [classIRI];
         }
       }
 
       // Check for ISO 8601 dateTime format and apply xsd:dateTime datatype
       if (this.isISO8601DateTime(cleanValue)) {
-        return new Literal(cleanValue, Namespace.XSD.term("dateTime"));
+        return [new Literal(cleanValue, Namespace.XSD.term("dateTime"))];
       }
 
-      return new Literal(cleanValue);
+      return [new Literal(cleanValue)];
     }
 
     if (typeof value === "boolean") {
-      return new Literal(value.toString());
+      return [new Literal(value.toString())];
     }
 
     if (typeof value === "number") {
-      return new Literal(
+      return [new Literal(
         value.toString(),
         Namespace.XSD.term("decimal")
-      );
+      )];
     }
 
     // Handle Date objects (js-yaml auto-parses ISO 8601 strings to Date)
     if (value instanceof Date) {
-      return new Literal(value.toISOString(), Namespace.XSD.term("dateTime"));
+      return [new Literal(value.toISOString(), Namespace.XSD.term("dateTime"))];
     }
 
-    return new Literal(String(value));
+    return [new Literal(String(value))];
   }
 
   /**
@@ -606,6 +629,27 @@ export class NoteToRDFConverter {
     // Invalid: "ems__Effort_blocker сделать массивом" (contains spaces)
     return (value.startsWith("ems__") || value.startsWith("exo__"))
       && !/\s/.test(value);
+  }
+
+  /**
+   * Check if a string is a valid UUID format.
+   *
+   * Issue #2102: Used to detect UUID-based wikilinks for dual storage
+   * (both File IRI and UUID Literal).
+   *
+   * @param value - String to check
+   * @returns True if value is a valid UUID format
+   *
+   * @example
+   * ```typescript
+   * isUUID("e3347bcf-bb50-4fb7-9064-14266469384b")  // → true
+   * isUUID("ems__Task")                              // → false
+   * isUUID("My Document")                            // → false
+   * ```
+   */
+  isUUID(value: string): boolean {
+    const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    return uuidPattern.test(value);
   }
 
   private expandClassValue(value: string): IRI | null {

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -2397,4 +2397,230 @@ It can contain **markdown** formatting.
       });
     });
   });
+
+  // Issue #2102: Dual storage for UUID-based wikilinks
+  describe("Dual storage for UUID-based wikilinks (Issue #2102)", () => {
+    const file: IFile = {
+      path: "test-note.md",
+      basename: "test-note",
+      name: "test-note.md",
+      parent: null,
+    };
+
+    describe("isUUID helper method", () => {
+      it("should detect valid lowercase UUIDs", () => {
+        expect(converter.isUUID("e3347bcf-bb50-4fb7-9064-14266469384b")).toBe(true);
+        expect(converter.isUUID("f2dccb6a-802d-48d3-8e8a-2c4264197692")).toBe(true);
+        expect(converter.isUUID("2d369bb0-159f-4639-911d-ec2c585e8d00")).toBe(true);
+      });
+
+      it("should detect valid uppercase UUIDs", () => {
+        expect(converter.isUUID("E3347BCF-BB50-4FB7-9064-14266469384B")).toBe(true);
+      });
+
+      it("should detect valid mixed-case UUIDs", () => {
+        expect(converter.isUUID("e3347BCF-bb50-4FB7-9064-14266469384b")).toBe(true);
+      });
+
+      it("should reject non-UUID strings", () => {
+        expect(converter.isUUID("not-a-uuid")).toBe(false);
+        expect(converter.isUUID("ems__Task")).toBe(false);
+        expect(converter.isUUID("My Document")).toBe(false);
+        expect(converter.isUUID("123")).toBe(false);
+        expect(converter.isUUID("")).toBe(false);
+      });
+
+      it("should reject UUIDs without dashes", () => {
+        expect(converter.isUUID("e3347bcfbb504fb7906414266469384b")).toBe(false);
+      });
+
+      it("should reject UUIDs with wrong format", () => {
+        expect(converter.isUUID("e3347bcf-bb50-4fb7-9064-14266469384")).toBe(false); // too short
+        expect(converter.isUUID("e3347bcf-bb50-4fb7-9064-14266469384bb")).toBe(false); // too long
+        expect(converter.isUUID("g3347bcf-bb50-4fb7-9064-14266469384b")).toBe(false); // invalid char
+      });
+    });
+
+    describe("valueToRDFObjects dual storage", () => {
+      it("should return array with IRI and Literal for UUID wikilink when file exists", async () => {
+        const uuid = "e3347bcf-bb50-4fb7-9064-14266469384b";
+        const targetFile: IFile = {
+          path: `03 Knowledge/kitelev/${uuid}.md`,
+          basename: uuid,
+          name: `${uuid}.md`,
+          parent: null,
+        };
+
+        mockVault.getFirstLinkpathDest.mockReturnValue(targetFile);
+
+        const frontmatter: IFrontmatter = {
+          exo__Asset_prototype: `[[${uuid}]]`,
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+        mockVault.read.mockResolvedValue("---\nsome: yaml\n---\n");
+
+        const triples = await converter.convertNote(file);
+
+        // Find triples for exo__Asset_prototype
+        const prototypeTriples = triples.filter((t) =>
+          (t.predicate as IRI).value.includes("Asset_prototype")
+        );
+
+        // Should have 2 triples: one with IRI (file reference), one with Literal (UUID)
+        expect(prototypeTriples.length).toBe(2);
+
+        // One should be an IRI (file path)
+        const iriTriple = prototypeTriples.find((t) => t.object instanceof IRI);
+        expect(iriTriple).toBeDefined();
+        expect((iriTriple!.object as IRI).value).toContain("obsidian://vault/");
+        expect((iriTriple!.object as IRI).value).toContain(uuid);
+
+        // One should be a Literal (UUID string)
+        const literalTriple = prototypeTriples.find((t) => t.object instanceof Literal);
+        expect(literalTriple).toBeDefined();
+        expect((literalTriple!.object as Literal).value).toBe(uuid);
+      });
+
+      it("should return array with single IRI for non-UUID wikilink", async () => {
+        const targetFile: IFile = {
+          path: "Development.md",
+          basename: "Development",
+          name: "Development.md",
+          parent: null,
+        };
+
+        mockVault.getFirstLinkpathDest.mockReturnValue(targetFile);
+
+        const frontmatter: IFrontmatter = {
+          ems__Effort_area: "[[Development]]",
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+        mockVault.read.mockResolvedValue("---\nsome: yaml\n---\n");
+
+        const triples = await converter.convertNote(file);
+
+        // Find triples for ems__Effort_area
+        const areaTriples = triples.filter((t) =>
+          (t.predicate as IRI).value.includes("Effort_area")
+        );
+
+        // Should have 1 triple (non-UUID wikilink)
+        expect(areaTriples.length).toBe(1);
+        expect(areaTriples[0].object).toBeInstanceOf(IRI);
+        expect((areaTriples[0].object as IRI).value).toContain("obsidian://vault/Development.md");
+      });
+
+      it("should store UUID literal without brackets when extracting from wikilink", async () => {
+        const uuid = "f2dccb6a-802d-48d3-8e8a-2c4264197692";
+        const targetFile: IFile = {
+          path: `inbox/${uuid}.md`,
+          basename: uuid,
+          name: `${uuid}.md`,
+          parent: null,
+        };
+
+        mockVault.getFirstLinkpathDest.mockReturnValue(targetFile);
+
+        const frontmatter: IFrontmatter = {
+          exo__Asset_prototype: `[[${uuid}]]`,
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+        mockVault.read.mockResolvedValue("---\nsome: yaml\n---\n");
+
+        const triples = await converter.convertNote(file);
+
+        const prototypeTriples = triples.filter((t) =>
+          (t.predicate as IRI).value.includes("Asset_prototype")
+        );
+
+        const literalTriple = prototypeTriples.find((t) => t.object instanceof Literal);
+        expect(literalTriple).toBeDefined();
+        // UUID should be stored without the wikilink brackets
+        expect((literalTriple!.object as Literal).value).toBe(uuid);
+        expect((literalTriple!.object as Literal).value).not.toContain("[[");
+        expect((literalTriple!.object as Literal).value).not.toContain("]]");
+      });
+
+      it("should handle array of UUID wikilinks", async () => {
+        const uuid1 = "e3347bcf-bb50-4fb7-9064-14266469384b";
+        const uuid2 = "f2dccb6a-802d-48d3-8e8a-2c4264197692";
+
+        mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+          if (linkpath === uuid1) {
+            return {
+              path: `knowledge/${uuid1}.md`,
+              basename: uuid1,
+              name: `${uuid1}.md`,
+              parent: null,
+            };
+          }
+          if (linkpath === uuid2) {
+            return {
+              path: `knowledge/${uuid2}.md`,
+              basename: uuid2,
+              name: `${uuid2}.md`,
+              parent: null,
+            };
+          }
+          return null;
+        });
+
+        const frontmatter: IFrontmatter = {
+          exo__Asset_references: [`[[${uuid1}]]`, `[[${uuid2}]]`],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+        mockVault.read.mockResolvedValue("---\nsome: yaml\n---\n");
+
+        const triples = await converter.convertNote(file);
+
+        const referenceTriples = triples.filter((t) =>
+          (t.predicate as IRI).value.includes("Asset_references")
+        );
+
+        // Each UUID wikilink should produce 2 triples (IRI + Literal)
+        // So 2 UUIDs * 2 triples = 4 triples
+        expect(referenceTriples.length).toBe(4);
+
+        const iriTriples = referenceTriples.filter((t) => t.object instanceof IRI);
+        const literalTriples = referenceTriples.filter((t) => t.object instanceof Literal);
+
+        expect(iriTriples.length).toBe(2);
+        expect(literalTriples.length).toBe(2);
+
+        // Verify UUIDs are stored as literals
+        const literalValues = literalTriples.map((t) => (t.object as Literal).value);
+        expect(literalValues).toContain(uuid1);
+        expect(literalValues).toContain(uuid2);
+      });
+
+      it("should not create duplicate Literal when wikilink target file doesn't exist", async () => {
+        const uuid = "e3347bcf-bb50-4fb7-9064-14266469384b";
+
+        // File not found
+        mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+        const frontmatter: IFrontmatter = {
+          exo__Asset_prototype: `[[${uuid}]]`,
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+        mockVault.read.mockResolvedValue("---\nsome: yaml\n---\n");
+
+        const triples = await converter.convertNote(file);
+
+        const prototypeTriples = triples.filter((t) =>
+          (t.predicate as IRI).value.includes("Asset_prototype")
+        );
+
+        // When file doesn't exist, should fall back to literal (existing behavior)
+        // Should be 1 triple, not 2 (no dual storage when file doesn't exist)
+        expect(prototypeTriples.length).toBe(1);
+        expect(prototypeTriples[0].object).toBeInstanceOf(Literal);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- **Enable SPARQL queries to find assets by UUID literals** by storing both File IRI and UUID Literal for UUID-based wikilinks in RDF conversion
- Add `isUUID()` helper method to detect valid UUID format
- Modify `valueToRDFObject()` return type from single value to array for dual storage support
- Update `convertLegacyNote()` to handle array returns by flattening triples

## Problem Solved
Previously, UUID-based wikilinks like `[[e3347bcf-bb50-4fb7-9064-14266469384b]]` were only stored as File IRIs:
```turtle
<...> exo:Asset_prototype <obsidian://vault/.../e3347bcf-bb50-4fb7-9064-14266469384b.md> .
```

This caused SPARQL queries searching for UUID literals to fail:
```sparql
?s exo:Asset_prototype "e3347bcf-bb50-4fb7-9064-14266469384b"  # ❌ No results
```

## Solution
Now UUID wikilinks store **both** representations:
```turtle
<...> exo:Asset_prototype <obsidian://vault/.../e3347bcf-bb50-4fb7-9064-14266469384b.md> .
<...> exo:Asset_prototype "e3347bcf-bb50-4fb7-9064-14266469384b" .
```

This enables SPARQL queries using either form:
- By File IRI: `?s exo:Asset_prototype <obsidian://...>` ✅
- By UUID Literal: `?s exo:Asset_prototype "e3347bcf-bb50-4fb7-9064-14266469384b"` ✅

## Test Plan
- [x] `isUUID()` detects valid lowercase, uppercase, and mixed-case UUIDs
- [x] `isUUID()` rejects non-UUID strings, UUIDs without dashes, wrong format
- [x] `valueToRDFObject()` returns `[IRI, Literal]` for UUID wikilinks
- [x] `valueToRDFObject()` returns `[IRI]` for non-UUID wikilinks
- [x] UUID literal stored without brackets (clean UUID string)
- [x] Array of UUID wikilinks handled correctly
- [x] No duplicate Literal when file doesn't exist

**Test coverage:** 11 new tests added

Closes #2102