### PR TITLE
feat(core): support UID-based class identifier for ems__TaskPrototype

### DIFF
--- a/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
+++ b/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
@@ -37,8 +37,10 @@ export function canCreateEvent(context: CommandVisibilityContext): boolean {
  */
 export function canCreateInstance(context: CommandVisibilityContext): boolean {
   // Check for known prototype instance classes (backward compatibility)
+  // Includes both string-based and UID-based identifiers (Issue #2110)
   if (
     hasClass(context.instanceClass, AssetClass.TASK_PROTOTYPE) ||
+    hasClass(context.instanceClass, AssetClass.TASK_PROTOTYPE_UID) ||
     hasClass(context.instanceClass, AssetClass.MEETING_PROTOTYPE) ||
     hasClass(context.instanceClass, AssetClass.EVENT_PROTOTYPE) ||
     hasClass(context.instanceClass, AssetClass.PROJECT_PROTOTYPE)

--- a/packages/exocortex/src/domain/constants/AssetClass.ts
+++ b/packages/exocortex/src/domain/constants/AssetClass.ts
@@ -5,6 +5,8 @@ export enum AssetClass {
   MEETING = "ems__Meeting",
   INITIATIVE = "ems__Initiative",
   TASK_PROTOTYPE = "ems__TaskPrototype",
+  /** UID-based identifier for ems__TaskPrototype (Issue #2110) */
+  TASK_PROTOTYPE_UID = "75302770-279e-4a59-ba85-09df29725713",
   MEETING_PROTOTYPE = "ems__MeetingPrototype",
   EVENT_PROTOTYPE = "exo__EventPrototype",
   PROJECT_PROTOTYPE = "ems__ProjectPrototype",

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -101,6 +101,8 @@ export const DEFAULT_DISPLAY_NAME_SETTINGS: DisplayNameSettings = {
 
   classTemplates: {
     "ems__TaskPrototype": "{{exo__Asset_label}} (TaskPrototype)",
+    // UID-based identifier for ems__TaskPrototype (Issue #2110)
+    "75302770-279e-4a59-ba85-09df29725713": "{{exo__Asset_label}} (TaskPrototype)",
     "ems__Task": "{{exo__Asset_label}} {{statusEmoji}}",
     "ems__Project": "{{exo__Asset_label}}",
     "ems__Area": "{{exo__Asset_label}}",

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/CreationButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/CreationButtonGroupBuilder.ts
@@ -102,7 +102,10 @@ export class CreationButtonGroupBuilder implements IButtonGroupBuilder {
         onClick: async () => {
           const sourceClass = this.normalizeClass(instanceClass);
           const isMeeting = sourceClass === AssetClass.MEETING_PROTOTYPE;
-          const defaultValue = isMeeting || sourceClass === AssetClass.TASK_PROTOTYPE
+          // Support both string-based and UID-based TaskPrototype identifiers (Issue #2110)
+          const isTaskPrototype = sourceClass === AssetClass.TASK_PROTOTYPE ||
+            sourceClass === AssetClass.TASK_PROTOTYPE_UID;
+          const defaultValue = isMeeting || isTaskPrototype
             ? this.generateDefaultLabel(metadata, file.basename)
             : "";
           const result = await promptForLabel(app, defaultValue, !isMeeting);

--- a/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.instance.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.instance.test.ts
@@ -32,6 +32,59 @@ describe("CommandVisibility - Instance/Subclass Commands", () => {
       expect(canCreateInstance(context)).toBe(true);
     });
 
+    // UID-based class identifier tests for Issue #2110
+    describe("UID-based class identifier for TaskPrototype", () => {
+      const TASK_PROTOTYPE_UID = "75302770-279e-4a59-ba85-09df29725713";
+
+      it("should return true for TaskPrototype UID with wiki-link brackets", () => {
+        const context: CommandVisibilityContext = {
+          instanceClass: `[[${TASK_PROTOTYPE_UID}]]`,
+          currentStatus: null,
+          metadata: {},
+          isArchived: false,
+          currentFolder: "",
+          expectedFolder: null,
+        };
+        expect(canCreateInstance(context)).toBe(true);
+      });
+
+      it("should return true for TaskPrototype UID without brackets", () => {
+        const context: CommandVisibilityContext = {
+          instanceClass: TASK_PROTOTYPE_UID,
+          currentStatus: null,
+          metadata: {},
+          isArchived: false,
+          currentFolder: "",
+          expectedFolder: null,
+        };
+        expect(canCreateInstance(context)).toBe(true);
+      });
+
+      it("should return true for array with TaskPrototype UID", () => {
+        const context: CommandVisibilityContext = {
+          instanceClass: [`[[${TASK_PROTOTYPE_UID}]]`, "[[SomeOtherClass]]"],
+          currentStatus: null,
+          metadata: {},
+          isArchived: false,
+          currentFolder: "",
+          expectedFolder: null,
+        };
+        expect(canCreateInstance(context)).toBe(true);
+      });
+
+      it("should return true for mixed array with string name and UID", () => {
+        const context: CommandVisibilityContext = {
+          instanceClass: ["[[SomeOtherClass]]", `[[${TASK_PROTOTYPE_UID}]]`],
+          currentStatus: null,
+          metadata: {},
+          isArchived: false,
+          currentFolder: "",
+          expectedFolder: null,
+        };
+        expect(canCreateInstance(context)).toBe(true);
+      });
+    });
+
     it("should return false for ems__Task", () => {
       const context: CommandVisibilityContext = {
         instanceClass: "[[ems__Task]]",


### PR DESCRIPTION
## Summary

Add support for UID-based class identifier `75302770-279e-4a59-ba85-09df29725713` alongside existing `ems__TaskPrototype` string-based identifier, enabling the "Create Instance" feature to work with both naming conventions.

## Changes

- **AssetClass.ts**: Added `TASK_PROTOTYPE_UID` constant with value `75302770-279e-4a59-ba85-09df29725713`
- **AssetVisibilityRules.ts**: Updated `canCreateInstance()` to check for both string-based and UID-based identifiers
- **CreationButtonGroupBuilder.ts**: Updated "Create Instance" button to generate default labels for UID variant
- **ExocortexSettings.ts**: Added display name template for UID-based class (`(TaskPrototype)` suffix)
- **CommandVisibility.instance.test.ts**: Added 4 comprehensive tests for UID-based identifier support

## Testing

- [x] Added 4 new tests for UID-based identifier support
- [x] All existing tests pass (665 passed)
- [x] Build passes
- [x] Lint passes (no new warnings)

## Verification

- [x] `npm run build` - PASSED
- [x] `npm run test:unit` - PASSED (665 tests)
- [x] `npm run lint` - PASSED (no new errors)

## Acceptance Criteria

- [x] "Create Instance" button appears for assets with `exo__Instance_class: "[[75302770-279e-4a59-ba85-09df29725713]]"`
- [x] "Create Instance" button still works for assets with `exo__Instance_class: "ems__TaskPrototype"` (backward compatibility)
- [x] Default label is generated for TaskPrototype UID variant
- [x] Display name template is configured for UID-based class

Closes #2110