### PR TITLE
feat: Highlight overlapping planned task periods in DailyNote table

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
@@ -40,6 +40,19 @@ export interface DailyTasksTableProps {
   showStatus?: boolean;
 }
 
+/**
+ * Detect if two time periods overlap.
+ * Uses strict inequality (< not <=) so touching periods (end1 === start2) are not considered overlapping.
+ */
+const periodsOverlap = (
+  start1: number,
+  end1: number,
+  start2: number,
+  end2: number,
+): boolean => {
+  return start1 < end2 && start2 < end1;
+};
+
 export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   tasks,
   onTaskClick,
@@ -76,6 +89,55 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
   const showEmptySlots = propShowEmptySlots ?? storeShowEmptySlots;
   const showTime = propShowTime ?? storeShowTime;
   const showStatus = propShowStatus ?? storeShowStatus;
+
+  /**
+   * Find tasks with overlapping planned periods.
+   * Only considers tasks that have both plannedStartTimestamp and plannedEndTimestamp.
+   * Returns a Set of task paths that have overlapping periods.
+   */
+  const tasksWithOverlaps = useMemo(() => {
+    const overlapping = new Set<string>();
+
+    // Filter tasks with valid planned timestamps
+    const tasksWithPlannedTimes = tasks.filter((task) => {
+      const start = task.metadata.ems__Effort_plannedStartTimestamp;
+      const end = task.metadata.ems__Effort_plannedEndTimestamp;
+      return start != null && end != null;
+    });
+
+    // Compare each pair of tasks for overlap
+    for (let i = 0; i < tasksWithPlannedTimes.length; i++) {
+      const task1 = tasksWithPlannedTimes[i];
+      const start1Str = task1.metadata.ems__Effort_plannedStartTimestamp;
+      const end1Str = task1.metadata.ems__Effort_plannedEndTimestamp;
+
+      // Parse timestamps - handle both ISO strings and numeric timestamps
+      const start1 = new Date(start1Str as string | number).getTime();
+      const end1 = new Date(end1Str as string | number).getTime();
+
+      // Skip if timestamps are invalid
+      if (isNaN(start1) || isNaN(end1)) continue;
+
+      for (let j = i + 1; j < tasksWithPlannedTimes.length; j++) {
+        const task2 = tasksWithPlannedTimes[j];
+        const start2Str = task2.metadata.ems__Effort_plannedStartTimestamp;
+        const end2Str = task2.metadata.ems__Effort_plannedEndTimestamp;
+
+        const start2 = new Date(start2Str as string | number).getTime();
+        const end2 = new Date(end2Str as string | number).getTime();
+
+        // Skip if timestamps are invalid
+        if (isNaN(start2) || isNaN(end2)) continue;
+
+        if (periodsOverlap(start1, end1, start2, end2)) {
+          overlapping.add(task1.path);
+          overlapping.add(task2.path);
+        }
+      }
+    }
+
+    return overlapping;
+  }, [tasks]);
 
   const handleSort = (column: string) => {
     toggleSort("dailyTasks", column);
@@ -481,10 +543,13 @@ export const DailyTasksTable: React.FC<DailyTasksTableProps> = ({
       }
     }
 
+    const hasOverlap = tasksWithOverlaps.has(task.path);
+
     return (
       <tr
         key={`${task.path}-${index}`}
         data-path={task.path}
+        className={hasOverlap ? "task-overlap-conflict" : undefined}
         style={style}
       >
         <td className="task-name" title={getDisplayName(task)}>

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2800,6 +2800,24 @@
   font-style: italic;
 }
 
+/* Overlapping planned periods - schedule conflict highlight */
+.exocortex-tasks-table tr.task-overlap-conflict {
+  background-color: rgba(139, 0, 0, 0.12);  /* Dark red, pleasant for eyes */
+}
+
+.exocortex-tasks-table tr.task-overlap-conflict:hover {
+  background-color: rgba(139, 0, 0, 0.18);  /* Slightly stronger on hover */
+}
+
+/* Dark theme variant */
+.theme-dark .exocortex-tasks-table tr.task-overlap-conflict {
+  background-color: rgba(178, 34, 34, 0.15);  /* Firebrick, slightly lighter for dark mode */
+}
+
+.theme-dark .exocortex-tasks-table tr.task-overlap-conflict:hover {
+  background-color: rgba(178, 34, 34, 0.22);
+}
+
 /* Virtualized table-specific styles for proper alignment */
 .exocortex-virtualized .exocortex-tasks-table-header {
   border-bottom: none;

--- a/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
@@ -2016,3 +2016,329 @@ test.describe("Large Data Volume Rendering (100 records)", () => {
     await expect(scrollContainer).toHaveCSS("overflow", "auto");
   });
 });
+
+test.describe("Overlapping Planned Task Periods Highlighting", () => {
+  test("should highlight rows with overlapping planned periods", async ({
+    mount,
+  }) => {
+    const overlappingTasks: DailyTask[] = [
+      {
+        file: { path: "task1.md", basename: "task1" },
+        path: "task1.md",
+        title: "Task 1",
+        label: "Task 1",
+        startTime: "09:00",
+        endTime: "10:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T09:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T10:30:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "task2.md", basename: "task2" },
+        path: "task2.md",
+        title: "Task 2",
+        label: "Task 2",
+        startTime: "10:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTable tasks={overlappingTasks} />,
+    );
+
+    // Both tasks should have the overlap conflict class since they overlap
+    // Task 1: 09:00-10:30, Task 2: 10:00-11:00 → overlap between 10:00-10:30
+    const task1Row = component.locator('tr[data-path="task1.md"]');
+    const task2Row = component.locator('tr[data-path="task2.md"]');
+
+    await expect(task1Row).toHaveClass(/task-overlap-conflict/);
+    await expect(task2Row).toHaveClass(/task-overlap-conflict/);
+  });
+
+  test("should not highlight rows without overlapping periods", async ({
+    mount,
+  }) => {
+    const nonOverlappingTasks: DailyTask[] = [
+      {
+        file: { path: "task1.md", basename: "task1" },
+        path: "task1.md",
+        title: "Task 1",
+        label: "Task 1",
+        startTime: "09:00",
+        endTime: "10:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T09:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T10:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "task2.md", basename: "task2" },
+        path: "task2.md",
+        title: "Task 2",
+        label: "Task 2",
+        startTime: "10:30",
+        endTime: "11:30",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T10:30:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:30:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTable tasks={nonOverlappingTasks} />,
+    );
+
+    // No overlap: Task 1 ends at 10:00, Task 2 starts at 10:30
+    const task1Row = component.locator('tr[data-path="task1.md"]');
+    const task2Row = component.locator('tr[data-path="task2.md"]');
+
+    const task1Class = await task1Row.getAttribute("class");
+    const task2Class = await task2Row.getAttribute("class");
+
+    expect(task1Class).not.toContain("task-overlap-conflict");
+    expect(task2Class).not.toContain("task-overlap-conflict");
+  });
+
+  test("should skip tasks without planned timestamps", async ({
+    mount,
+  }) => {
+    const mixedTasks: DailyTask[] = [
+      {
+        file: { path: "task1.md", basename: "task1" },
+        path: "task1.md",
+        title: "Task 1",
+        label: "Task 1",
+        startTime: "09:00",
+        endTime: "10:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T09:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T10:30:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "task2.md", basename: "task2" },
+        path: "task2.md",
+        title: "Task 2 - No Planned Times",
+        label: "Task 2 - No Planned Times",
+        startTime: "10:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {},  // No planned timestamps
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTable tasks={mixedTasks} />,
+    );
+
+    // Task 1 has planned timestamps but no other task overlaps (task2 has none)
+    // So neither should be marked as overlapping
+    const task1Row = component.locator('tr[data-path="task1.md"]');
+    const task2Row = component.locator('tr[data-path="task2.md"]');
+
+    const task1Class = await task1Row.getAttribute("class");
+    const task2Class = await task2Row.getAttribute("class");
+
+    expect(task1Class).not.toContain("task-overlap-conflict");
+    expect(task2Class).not.toContain("task-overlap-conflict");
+  });
+
+  test("should not consider touching periods as overlapping (end = start)", async ({
+    mount,
+  }) => {
+    const touchingTasks: DailyTask[] = [
+      {
+        file: { path: "task1.md", basename: "task1" },
+        path: "task1.md",
+        title: "Task 1",
+        label: "Task 1",
+        startTime: "09:00",
+        endTime: "10:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T09:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T10:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "task2.md", basename: "task2" },
+        path: "task2.md",
+        title: "Task 2",
+        label: "Task 2",
+        startTime: "10:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTable tasks={touchingTasks} />,
+    );
+
+    // Task 1 ends at exactly 10:00, Task 2 starts at exactly 10:00
+    // This should NOT be considered an overlap (touching, not overlapping)
+    const task1Row = component.locator('tr[data-path="task1.md"]');
+    const task2Row = component.locator('tr[data-path="task2.md"]');
+
+    const task1Class = await task1Row.getAttribute("class");
+    const task2Class = await task2Row.getAttribute("class");
+
+    expect(task1Class).not.toContain("task-overlap-conflict");
+    expect(task2Class).not.toContain("task-overlap-conflict");
+  });
+
+  test("should highlight multiple overlapping tasks correctly", async ({
+    mount,
+  }) => {
+    const multipleOverlaps: DailyTask[] = [
+      {
+        file: { path: "task1.md", basename: "task1" },
+        path: "task1.md",
+        title: "Task 1",
+        label: "Task 1",
+        startTime: "09:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T09:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "task2.md", basename: "task2" },
+        path: "task2.md",
+        title: "Task 2",
+        label: "Task 2",
+        startTime: "10:00",
+        endTime: "12:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T12:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "task3.md", basename: "task3" },
+        path: "task3.md",
+        title: "Task 3",
+        label: "Task 3",
+        startTime: "14:00",
+        endTime: "15:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T14:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T15:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTable tasks={multipleOverlaps} />,
+    );
+
+    // Task 1 (09:00-11:00) overlaps with Task 2 (10:00-12:00)
+    // Task 3 (14:00-15:00) does not overlap with anyone
+    const task1Row = component.locator('tr[data-path="task1.md"]');
+    const task2Row = component.locator('tr[data-path="task2.md"]');
+    const task3Row = component.locator('tr[data-path="task3.md"]');
+
+    await expect(task1Row).toHaveClass(/task-overlap-conflict/);
+    await expect(task2Row).toHaveClass(/task-overlap-conflict/);
+
+    const task3Class = await task3Row.getAttribute("class");
+    expect(task3Class).not.toContain("task-overlap-conflict");
+  });
+});


### PR DESCRIPTION
## Summary
- Add visual highlighting for tasks with overlapping planned periods (`ems__Effort_plannedStartTimestamp`/`ems__Effort_plannedEndTimestamp`) to help users identify scheduling conflicts at a glance
- Implement `periodsOverlap()` utility with strict inequality so touching periods are not considered overlapping
- Add `tasksWithOverlaps` useMemo hook for efficient O(n²) overlap detection
- Apply `task-overlap-conflict` CSS class with dark red background (light/dark theme support)

## Test plan
- [x] Component tests verify overlapping tasks get highlight class
- [x] Component tests verify non-overlapping tasks don't get highlight class
- [x] Component tests verify tasks without planned timestamps are skipped
- [x] Component tests verify touching periods (end === start) are not considered overlapping
- [x] Build passes
- [x] Lint passes
- [x] Unit tests pass

Closes #2108