### PR TITLE
fix(plugin): Apply scrollbar width fix to AssetRelationsTable and TableLayoutRenderer

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef, useLayoutEffect } from "react";
+import React, { useState, useMemo, useRef, useLayoutEffect, useCallback, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 export interface AssetRelation {
@@ -253,6 +253,36 @@ const SingleTable: React.FC<SingleTableProps> = ({
 
   const shouldVirtualize = sortedItems.length > VIRTUALIZATION_THRESHOLD;
 
+  // Synchronize column widths between header and body tables in virtualized mode
+  // This fixes misalignment caused by scrollbar width difference (Issue #941, #2116)
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+
+  // Measure scrollbar width when scroll container is mounted
+  const measureWidths = useCallback(() => {
+    if (!parentRef.current) return;
+
+    const scrollContainer = parentRef.current;
+    // Scrollbar width = total width - client width (visible content area)
+    const sbWidth = scrollContainer.offsetWidth - scrollContainer.clientWidth;
+    setScrollbarWidth(sbWidth);
+  }, []);
+
+  // Measure widths when virtualized mode is active and parent is mounted
+  useLayoutEffect(() => {
+    if (shouldVirtualize && isParentMounted) {
+      measureWidths();
+    }
+  }, [shouldVirtualize, isParentMounted, measureWidths]);
+
+  // Re-measure on window resize (scrollbar might appear/disappear)
+  useEffect(() => {
+    if (!shouldVirtualize) return;
+
+    const handleResize = () => measureWidths();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [shouldVirtualize, measureWidths]);
+
   // Only initialize virtualizer when we need virtualization AND parent is mounted
   const rowVirtualizer = useVirtualizer({
     count: shouldVirtualize ? sortedItems.length : 0,
@@ -406,10 +436,18 @@ const SingleTable: React.FC<SingleTableProps> = ({
 
   return (
     <div className="exocortex-relations-virtualized">
-      <table className="exocortex-relations-table exocortex-relations-table-header" style={{ tableLayout: "fixed", width: "100%" }}>
-        {renderColGroup()}
-        {renderTableHeader()}
-      </table>
+      {/* Header wrapper with padding-right to account for scrollbar width (Issue #941, #2116) */}
+      <div
+        className="exocortex-relations-table-header-wrapper"
+        style={{
+          paddingRight: scrollbarWidth > 0 ? `${scrollbarWidth}px` : undefined,
+        }}
+      >
+        <table className="exocortex-relations-table exocortex-relations-table-header" style={{ tableLayout: "fixed", width: "100%" }}>
+          {renderColGroup()}
+          {renderTableHeader()}
+        </table>
+      </div>
       <div
         ref={parentRef}
         className="exocortex-virtual-scroll-container"

--- a/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
@@ -11,7 +11,7 @@
  * @module presentation/renderers
  * @since 1.0.0
  */
-import React, { useState, useMemo, useCallback, useRef, useLayoutEffect } from "react";
+import React, { useState, useMemo, useCallback, useRef, useLayoutEffect, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import type { TableLayout, LayoutColumn } from "../../domain/layout";
@@ -280,6 +280,36 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
   const shouldVirtualize =
     options.virtualize && sortedRows.length > VIRTUALIZATION_THRESHOLD;
 
+  // Synchronize column widths between header and body tables in virtualized mode
+  // This fixes misalignment caused by scrollbar width difference (Issue #941, #2116)
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+
+  // Measure scrollbar width when scroll container is mounted
+  const measureWidths = useCallback(() => {
+    if (!parentRef.current) return;
+
+    const scrollContainer = parentRef.current;
+    // Scrollbar width = total width - client width (visible content area)
+    const sbWidth = scrollContainer.offsetWidth - scrollContainer.clientWidth;
+    setScrollbarWidth(sbWidth);
+  }, []);
+
+  // Measure widths when virtualized mode is active and parent is mounted
+  useLayoutEffect(() => {
+    if (shouldVirtualize && isParentMounted) {
+      measureWidths();
+    }
+  }, [shouldVirtualize, isParentMounted, measureWidths]);
+
+  // Re-measure on window resize (scrollbar might appear/disappear)
+  useEffect(() => {
+    if (!shouldVirtualize) return;
+
+    const handleResize = () => measureWidths();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [shouldVirtualize, measureWidths]);
+
   const rowVirtualizer = useVirtualizer({
     count: shouldVirtualize ? sortedRows.length : 0,
     getScrollElement: () => parentRef.current,
@@ -455,11 +485,18 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
 
   return (
     <div className={`exo-layout-table-container exo-layout-virtualized ${className || ""}`}>
-      {/* Fixed header table */}
-      <table className="exo-layout-table exo-layout-table-header-fixed">
-        {renderColGroup()}
-        {renderTableHeader()}
-      </table>
+      {/* Header wrapper with padding-right to account for scrollbar width (Issue #941, #2116) */}
+      <div
+        className="exo-layout-table-header-wrapper"
+        style={{
+          paddingRight: scrollbarWidth > 0 ? `${scrollbarWidth}px` : undefined,
+        }}
+      >
+        <table className="exo-layout-table exo-layout-table-header-fixed">
+          {renderColGroup()}
+          {renderTableHeader()}
+        </table>
+      </div>
 
       {/* Scrollable body */}
       <div


### PR DESCRIPTION
## Summary
- Applied scrollbar width compensation fix to `AssetRelationsTable` and `TableLayoutRenderer`
- Fixes column misalignment in virtualized tables (>50 rows)
- Same proven pattern from `DailyTasksTable.tsx` (Issue #941)

## Changes
- `AssetRelationsTable.tsx`: Added `scrollbarWidth` state, `measureWidths` callback, and header wrapper with `paddingRight`
- `TableLayoutRenderer.tsx`: Added `scrollbarWidth` state, `measureWidths` callback, and header wrapper with `paddingRight`

## Testing
- [x] Build passes
- [x] Unit tests pass (665 tests)
- [x] Lint passes (only pre-existing warnings)

## Acceptance Criteria
- [x] `AssetRelationsTable` has scrollbar width compensation
- [x] `TableLayoutRenderer` has scrollbar width compensation
- [x] Columns align correctly in virtualized tables (>50 rows)
- [x] Works in pn__DailyNote layouts

## Fix Pattern Applied

```tsx
// 1. State for scrollbar width
const [scrollbarWidth, setScrollbarWidth] = useState(0);

// 2. useCallback to measure scrollbar width
const measureWidths = useCallback(() => {
  if (!parentRef.current) return;
  const sbWidth = parentRef.current.offsetWidth - parentRef.current.clientWidth;
  setScrollbarWidth(sbWidth);
}, []);

// 3. useLayoutEffect to measure when virtualized
useLayoutEffect(() => {
  if (shouldVirtualize && isParentMounted) {
    measureWidths();
  }
}, [shouldVirtualize, isParentMounted, measureWidths]);

// 4. useEffect for resize listener
useEffect(() => {
  if (!shouldVirtualize) return;
  const handleResize = () => measureWidths();
  window.addEventListener("resize", handleResize);
  return () => window.removeEventListener("resize", handleResize);
}, [shouldVirtualize, measureWidths]);

// 5. Header wrapper with paddingRight
<div style={{ paddingRight: scrollbarWidth > 0 ? `${scrollbarWidth}px` : undefined }}>
  <table>...</table>
</div>
```

Fixes #2116