### PR TITLE
feat(overlap): extend ems__Context exclusion to prototype-based tasks

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
@@ -54,17 +54,10 @@ const periodsOverlap = (
 };
 
 /**
- * Check if a task is a context task (has ems__Context class).
- * Context tasks describe WHERE or HOW other tasks are executed, not WHAT is being done.
- * They should be excluded from overlap detection to avoid false-positive scheduling conflicts.
- *
- * Handles multiple formats:
- * - Single string: "ems__Context" or "[[ems__Context]]"
- * - Array: ["[[ems__Task]]", "[[ems__Context]]"]
+ * Check if a class list contains ems__Context class.
+ * Handles both string and array formats.
  */
-const isContextTask = (metadata: Record<string, unknown>): boolean => {
-  const classes = metadata.exo__Instance_class;
-
+const classListHasContext = (classes: unknown): boolean => {
   if (classes == null) {
     return false;
   }
@@ -77,6 +70,34 @@ const isContextTask = (metadata: Record<string, unknown>): boolean => {
 
   if (typeof classes === 'string') {
     return classes.includes('ems__Context');
+  }
+
+  return false;
+};
+
+/**
+ * Check if a task is a context task (has ems__Context class).
+ * Context tasks describe WHERE or HOW other tasks are executed, not WHAT is being done.
+ * They should be excluded from overlap detection to avoid false-positive scheduling conflicts.
+ *
+ * This function checks for ems__Context in two places:
+ * 1. Direct class membership via exo__Instance_class
+ * 2. Prototype's class membership via _prototypeClasses (pre-resolved by renderer)
+ *
+ * Handles multiple formats:
+ * - Single string: "ems__Context" or "[[ems__Context]]"
+ * - Array: ["[[ems__Task]]", "[[ems__Context]]"]
+ */
+const isContextTask = (metadata: Record<string, unknown>): boolean => {
+  // Check direct class membership
+  if (classListHasContext(metadata.exo__Instance_class)) {
+    return true;
+  }
+
+  // Check prototype's classes (Issue #2131)
+  // _prototypeClasses is pre-resolved by the renderer for tasks with exo__Instance_prototype
+  if (classListHasContext(metadata._prototypeClasses)) {
+    return true;
   }
 
   return false;

--- a/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
@@ -7,7 +7,7 @@ import {
   DailyTask,
   DailyTasksTableWithToggle,
 } from '@plugin/presentation/components/DailyTasksTable';
-import { AssetClass, EffortStatus, IVaultAdapter } from "exocortex";
+import { AssetClass, EffortStatus, IVaultAdapter, IFile } from "exocortex";
 import { MetadataExtractor } from "exocortex";
 import { EffortSortingHelpers } from "exocortex";
 import { AssetMetadataService } from "./layout/helpers/AssetMetadataService";
@@ -235,6 +235,13 @@ export class DailyTasksRenderer {
 
         const isBlocked = BlockerHelpers.isEffortBlocked(this.app, metadata);
 
+        // Resolve prototype classes for overlap detection (Issue #2131)
+        // If task has a prototype, look up the prototype's classes
+        const prototypeClasses = this.resolvePrototypeClasses(metadata, allFiles);
+        const enrichedMetadata = prototypeClasses
+          ? { ...metadata, _prototypeClasses: prototypeClasses }
+          : metadata;
+
         tasks.push({
           file: {
             path: file.path,
@@ -248,7 +255,7 @@ export class DailyTasksRenderer {
           startTimestamp: startTimestamp || plannedStartTimestamp || null,
           endTimestamp: endTimestamp || plannedEndTimestamp || null,
           status: getStatusLabel(effortStatusStr),
-          metadata,
+          metadata: enrichedMetadata,
           isDone,
           isTrashed,
           isDoing,
@@ -292,6 +299,58 @@ export class DailyTasksRenderer {
       this.logger.error("Failed to get daily tasks", { error });
       return [];
     }
+  }
+
+  /**
+   * Extract target UID from wikilink format.
+   * Handles: "[[uid|alias]]", "[[uid]]", "uid"
+   */
+  private extractWikilinkTarget(value: string): string | null {
+    if (!value) return null;
+
+    // Match [[target|alias]] or [[target]]
+    const wikilinkMatch = value.match(/\[\[([^\]|]+)/);
+    if (wikilinkMatch) {
+      return wikilinkMatch[1].trim();
+    }
+
+    // Already a plain string (UID)
+    return value.trim();
+  }
+
+  /**
+   * Resolve prototype's classes for a task with exo__Instance_prototype.
+   * Returns the prototype's exo__Instance_class if found, null otherwise.
+   *
+   * @param metadata - Task's metadata containing potential exo__Instance_prototype
+   * @param allFiles - All files in vault for prototype lookup
+   * @returns Prototype's classes or null if not found
+   */
+  private resolvePrototypeClasses(
+    metadata: Record<string, unknown>,
+    allFiles: IFile[],
+  ): unknown {
+    const prototypeRef = metadata.exo__Instance_prototype;
+    if (!prototypeRef || typeof prototypeRef !== 'string') {
+      return null;
+    }
+
+    const prototypeTarget = this.extractWikilinkTarget(prototypeRef);
+    if (!prototypeTarget) {
+      return null;
+    }
+
+    // Find prototype file by basename or path
+    const prototypeFile = allFiles.find(
+      (f) => f.basename === prototypeTarget || f.path === prototypeTarget || f.path.includes(prototypeTarget)
+    );
+
+    if (!prototypeFile) {
+      return null;
+    }
+
+    const prototypeMetadata = this.metadataExtractor.extractMetadata(prototypeFile);
+    return prototypeMetadata.exo__Instance_class || null;
   }
 
   private getChildAreas(

--- a/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
@@ -2677,3 +2677,251 @@ test.describe("Context Task Overlap Exclusion (Issue #2128)", () => {
     await expect(task2Row).toHaveClass(/task-overlap-conflict/);
   });
 });
+
+test.describe("Prototype-based Context Task Exclusion (Issue #2131)", () => {
+  test("should exclude task whose prototype has ems__Context class from overlap detection", async ({
+    mount,
+  }) => {
+    // This task has a prototype that has ems__Context class
+    // It should be treated as a context task for overlap detection purposes
+    const tasksWithPrototypeContext: DailyTask[] = [
+      {
+        file: { path: "regular-task.md", basename: "regular-task" },
+        path: "regular-task.md",
+        title: "Regular Task",
+        label: "Regular Task",
+        startTime: "09:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T09:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "commute-instance.md", basename: "commute-instance" },
+        path: "commute-instance.md",
+        title: "Morning Commute",
+        label: "Morning Commute",
+        startTime: "10:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          // Task has a prototype that is a Context
+          exo__Instance_prototype: "[[commute-prototype|Commute]]",
+          // The prototype's classes are passed as resolved metadata
+          _prototypeClasses: ["[[ems__Task]]", "[[ems__Context]]"],
+          ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTable tasks={tasksWithPrototypeContext} />,
+    );
+
+    // Prototype-based context task overlaps with regular task
+    // BUT should be excluded from overlap detection because prototype has ems__Context
+    const regularTaskRow = component.locator('tr[data-path="regular-task.md"]');
+    const prototypeContextTaskRow = component.locator('tr[data-path="commute-instance.md"]');
+
+    await expect(regularTaskRow).not.toHaveClass(/task-overlap-conflict/);
+    await expect(prototypeContextTaskRow).not.toHaveClass(/task-overlap-conflict/);
+  });
+
+  test("should exclude task whose prototype has ems__Context class (single string format)", async ({
+    mount,
+  }) => {
+    const tasksWithPrototypeContextString: DailyTask[] = [
+      {
+        file: { path: "regular-task.md", basename: "regular-task" },
+        path: "regular-task.md",
+        title: "Regular Task",
+        label: "Regular Task",
+        startTime: "09:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T09:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "lunch-break.md", basename: "lunch-break" },
+        path: "lunch-break.md",
+        title: "Lunch Break",
+        label: "Lunch Break",
+        startTime: "10:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          exo__Instance_prototype: "[[lunch-prototype|Lunch]]",
+          _prototypeClasses: "[[ems__Context]]",
+          ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTable tasks={tasksWithPrototypeContextString} />,
+    );
+
+    const regularTaskRow = component.locator('tr[data-path="regular-task.md"]');
+    const lunchTaskRow = component.locator('tr[data-path="lunch-break.md"]');
+
+    await expect(regularTaskRow).not.toHaveClass(/task-overlap-conflict/);
+    await expect(lunchTaskRow).not.toHaveClass(/task-overlap-conflict/);
+  });
+
+  test("should NOT exclude task whose prototype does NOT have ems__Context class", async ({
+    mount,
+  }) => {
+    const tasksWithNonContextPrototype: DailyTask[] = [
+      {
+        file: { path: "task1.md", basename: "task1" },
+        path: "task1.md",
+        title: "Task 1",
+        label: "Task 1",
+        startTime: "09:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T09:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "task2.md", basename: "task2" },
+        path: "task2.md",
+        title: "Task from Prototype",
+        label: "Task from Prototype",
+        startTime: "10:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          exo__Instance_prototype: "[[some-prototype|Some Task]]",
+          // Prototype has ems__Task class, but NOT ems__Context
+          _prototypeClasses: ["[[ems__Task]]"],
+          ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTable tasks={tasksWithNonContextPrototype} />,
+    );
+
+    // Prototype does NOT have ems__Context, so should participate in overlap detection
+    const task1Row = component.locator('tr[data-path="task1.md"]');
+    const task2Row = component.locator('tr[data-path="task2.md"]');
+
+    await expect(task1Row).toHaveClass(/task-overlap-conflict/);
+    await expect(task2Row).toHaveClass(/task-overlap-conflict/);
+  });
+
+  test("should handle missing _prototypeClasses gracefully", async ({
+    mount,
+  }) => {
+    const tasksWithPrototypeNoClasses: DailyTask[] = [
+      {
+        file: { path: "task1.md", basename: "task1" },
+        path: "task1.md",
+        title: "Task 1",
+        label: "Task 1",
+        startTime: "09:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          ems__Effort_plannedStartTimestamp: "2025-01-15T09:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+      {
+        file: { path: "task2.md", basename: "task2" },
+        path: "task2.md",
+        title: "Task with Prototype",
+        label: "Task with Prototype",
+        startTime: "10:00",
+        endTime: "11:00",
+        startTimestamp: null,
+        endTimestamp: null,
+        status: "ems__EffortStatusInProgress",
+        metadata: {
+          // Has prototype reference but _prototypeClasses not resolved
+          exo__Instance_prototype: "[[some-prototype|Some Task]]",
+          // _prototypeClasses is missing - should handle gracefully
+          ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
+          ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
+        },
+        isDone: false,
+        isTrashed: false,
+        isDoing: false,
+        isMeeting: false,
+        isBlocked: false,
+      },
+    ];
+
+    const component = await mount(
+      <DailyTasksTable tasks={tasksWithPrototypeNoClasses} />,
+    );
+
+    // Without resolved _prototypeClasses, should participate in overlap detection
+    const task1Row = component.locator('tr[data-path="task1.md"]');
+    const task2Row = component.locator('tr[data-path="task2.md"]');
+
+    await expect(task1Row).toHaveClass(/task-overlap-conflict/);
+    await expect(task2Row).toHaveClass(/task-overlap-conflict/);
+  });
+});


### PR DESCRIPTION
## Summary

Extends the overlap detection exclusion logic to recognize tasks whose prototype has `ems__Context` class, treating them as context tasks even if they don't directly declare the class.

- Tasks with `exo__Instance_prototype` pointing to a prototype with `ems__Context` class are now excluded from overlap detection
- Follows the principle that if a prototype represents a context, all its instances should be treated as contexts
- Reduces maintenance overhead for recurring contextual tasks like "Commute" or "Lunch Break"

## Changes

- Add `classListHasContext` helper for reusable class checking
- Update `isContextTask` to check both direct and prototype classes  
- Add `resolvePrototypeClasses` method to `DailyTasksRenderer` for prototype lookup
- Add `_prototypeClasses` metadata enrichment during task data preparation
- Add 4 new component tests covering prototype-based context detection

## Testing

- [x] TDD: Tests written first, failed, then passed after implementation
- [x] 4 new component tests for prototype-based context detection (Issue #2131)
  - Task with prototype having `ems__Context` in array format
  - Task with prototype having `ems__Context` as single string
  - Task with prototype NOT having `ems__Context` (should participate in overlap)
  - Task with missing `_prototypeClasses` (graceful handling)
- [x] All 678 unit tests pass
- [x] 551 component tests pass (1 unrelated visual snapshot test fails - pre-existing issue)
- [x] Build succeeds
- [x] Lint passes (warnings only)

## Verification

- [x] `npm run build` — PASSED
- [x] `npm run lint` — PASSED (warnings only)  
- [x] `npm run test:unit` — PASSED (678 tests)
- [x] `npm run test:component -- --grep "Prototype-based Context"` — PASSED (4 tests)

Closes #2131