### PR TITLE
fix: Add block reference support to WikilinkLabelViewPlugin (Live Preview)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/editor-extensions/WikilinkLabelViewPlugin.ts
+++ b/packages/obsidian-plugin/src/presentation/editor-extensions/WikilinkLabelViewPlugin.ts
@@ -23,6 +23,10 @@ export interface WikilinkMatch {
   targetPath: string;
   /** Whether the wikilink has an explicit alias */
   hasAlias: boolean;
+  /** Optional block reference ID (e.g., "jgp9nz" from [[file#^jgp9nz]]) */
+  blockId?: string;
+  /** Optional heading reference (e.g., "Heading" from [[file#Heading]]) */
+  headingRef?: string;
 }
 
 /**
@@ -127,10 +131,20 @@ export class WikilinkLabelViewPlugin {
       }
 
       // Resolve the label for this target
-      const label = WikilinkLabelViewPlugin.resolveLabel(
+      const baseLabel = WikilinkLabelViewPlugin.resolveLabel(
         this.metadataCache,
         wikilink.targetPath,
       );
+
+      // Build display text with block or heading reference suffix
+      let label = baseLabel;
+      if (label) {
+        if (wikilink.blockId) {
+          label = `${label} > ^${wikilink.blockId}`;
+        } else if (wikilink.headingRef) {
+          label = `${label} > ${wikilink.headingRef}`;
+        }
+      }
 
       // Only create decoration if we found a label different from the target
       if (label && label !== wikilink.targetPath) {
@@ -163,6 +177,12 @@ export class WikilinkLabelViewPlugin {
    * Parse wikilinks from text, extracting only those without aliases.
    * This is a static method for easier testing.
    *
+   * Supports:
+   * - Simple wikilinks: [[target]]
+   * - Block references: [[target#^blockId]]
+   * - Heading references: [[target#Heading]]
+   * - Wikilinks with aliases are excluded: [[target|alias]]
+   *
    * @param text - The text to parse
    * @param offset - Offset to add to positions (for viewport-based parsing)
    * @returns Array of WikilinkMatch objects for wikilinks without aliases
@@ -170,14 +190,20 @@ export class WikilinkLabelViewPlugin {
   static parseWikilinksFromText(text: string, offset: number): WikilinkMatch[] {
     const matches: WikilinkMatch[] = [];
 
-    // Pattern: [[target]] or [[target|alias]]
-    // We only want [[target]] without pipe
-    const wikilinkPattern = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+    // Pattern: [[target]] or [[target#^blockId]] or [[target#Heading]] or [[target|alias]]
+    // Captures:
+    // 1. target (no #, ], or |)
+    // 2. optional block reference (^alphanumeric after #)
+    // 3. optional heading reference (text after # without ^ and without ] or |)
+    // 4. optional alias (after |)
+    const wikilinkPattern = /\[\[([^#\]|]+)(?:#\^([a-zA-Z0-9]+))?(?:#([^\]|^]+))?(?:\|([^\]]+))?\]\]/g;
 
     let match;
     while ((match = wikilinkPattern.exec(text)) !== null) {
       const targetPath = match[1].trim();
-      const alias = match[2]?.trim();
+      const blockId = match[2]?.trim();
+      const headingRef = match[3]?.trim();
+      const alias = match[4]?.trim();
 
       // Only include wikilinks WITHOUT aliases
       if (!alias) {
@@ -186,6 +212,8 @@ export class WikilinkLabelViewPlugin {
           to: offset + match.index + match[0].length,
           targetPath,
           hasAlias: false,
+          blockId,
+          headingRef,
         });
       }
     }

--- a/packages/obsidian-plugin/tests/unit/presentation/editor-extensions/WikilinkLabelViewPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/editor-extensions/WikilinkLabelViewPlugin.test.ts
@@ -22,6 +22,8 @@ describe("WikilinkLabelViewPlugin", () => {
         to: 21, // [[abc123-def456]] = 17 chars, starts at 4, ends at 4+17=21
         targetPath: "abc123-def456",
         hasAlias: false,
+        blockId: undefined,
+        headingRef: undefined,
       });
     });
 
@@ -89,6 +91,72 @@ describe("WikilinkLabelViewPlugin", () => {
 
       expect(matches).toHaveLength(1);
       expect(matches[0].targetPath).toBe("369c1b17-1296-4ec8-bdb9-c73fb74c0085");
+    });
+
+    it("should parse block reference wikilink", () => {
+      const matches = WikilinkLabelViewPlugin.parseWikilinksFromText(
+        "[[5764fb33-9cb1-43a4-a9be-43c534922798#^jgp9nz]]",
+        0
+      );
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].targetPath).toBe("5764fb33-9cb1-43a4-a9be-43c534922798");
+      expect(matches[0].blockId).toBe("jgp9nz");
+      expect(matches[0].headingRef).toBeUndefined();
+      expect(matches[0].hasAlias).toBe(false);
+    });
+
+    it("should parse heading reference wikilink", () => {
+      const matches = WikilinkLabelViewPlugin.parseWikilinksFromText(
+        "[[some-file#My Heading]]",
+        0
+      );
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].targetPath).toBe("some-file");
+      expect(matches[0].headingRef).toBe("My Heading");
+      expect(matches[0].blockId).toBeUndefined();
+      expect(matches[0].hasAlias).toBe(false);
+    });
+
+    it("should skip block reference wikilink with alias", () => {
+      const matches = WikilinkLabelViewPlugin.parseWikilinksFromText(
+        "[[file#^block|Custom Alias]]",
+        0
+      );
+
+      // Wikilinks with aliases should be skipped
+      expect(matches).toHaveLength(0);
+    });
+
+    it("should skip heading reference wikilink with alias", () => {
+      const matches = WikilinkLabelViewPlugin.parseWikilinksFromText(
+        "[[file#Heading|Custom Alias]]",
+        0
+      );
+
+      // Wikilinks with aliases should be skipped
+      expect(matches).toHaveLength(0);
+    });
+
+    it("should handle mixed wikilinks with block references", () => {
+      const matches = WikilinkLabelViewPlugin.parseWikilinksFromText(
+        "[[uuid1]] and [[uuid2#^block]] and [[uuid3#Heading]]",
+        0
+      );
+
+      expect(matches).toHaveLength(3);
+      expect(matches[0].targetPath).toBe("uuid1");
+      expect(matches[0].blockId).toBeUndefined();
+      expect(matches[0].headingRef).toBeUndefined();
+
+      expect(matches[1].targetPath).toBe("uuid2");
+      expect(matches[1].blockId).toBe("block");
+      expect(matches[1].headingRef).toBeUndefined();
+
+      expect(matches[2].targetPath).toBe("uuid3");
+      expect(matches[2].blockId).toBeUndefined();
+      expect(matches[2].headingRef).toBe("Heading");
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes incomplete implementation of Issue #2133 - block references were not working in **Live Preview** mode
- `WikilinkLabelViewPlugin.ts` was missing from the original PR #2134, which only updated `BodyLinkPatch.ts` (Reading View)

## Changes
- **WikilinkMatch interface**: Added `blockId` and `headingRef` optional fields
- **parseWikilinksFromText()**: Updated regex to capture `#^blockId` and `#Heading` patterns
- **buildDecorations()**: Appends ` > ^blockId` or ` > Heading` suffix to resolved label

## Test Plan
- [x] Unit tests pass (`npm run test:unit`)
- [x] Type check passes (`npx tsc --noEmit`)
- [ ] Manual test in Obsidian: `[[uuid#^blockid]]` displays as `"Label > ^blockid"` in Live Preview
- [ ] CI passes

## Related
- Completes #2133
- Follow-up to #2134