### PR TITLE
fix(overlap): use exo__Asset_prototype instead of exo__Instance_prototype

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
@@ -95,7 +95,7 @@ const isContextTask = (metadata: Record<string, unknown>): boolean => {
   }
 
   // Check prototype's classes (Issue #2131)
-  // _prototypeClasses is pre-resolved by the renderer for tasks with exo__Instance_prototype
+  // _prototypeClasses is pre-resolved by the renderer for tasks with exo__Asset_prototype
   if (classListHasContext(metadata._prototypeClasses)) {
     return true;
   }

--- a/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
@@ -319,10 +319,10 @@ export class DailyTasksRenderer {
   }
 
   /**
-   * Resolve prototype's classes for a task with exo__Instance_prototype.
+   * Resolve prototype's classes for a task with exo__Asset_prototype.
    * Returns the prototype's exo__Instance_class if found, null otherwise.
    *
-   * @param metadata - Task's metadata containing potential exo__Instance_prototype
+   * @param metadata - Task's metadata containing potential exo__Asset_prototype
    * @param allFiles - All files in vault for prototype lookup
    * @returns Prototype's classes or null if not found
    */
@@ -330,7 +330,7 @@ export class DailyTasksRenderer {
     metadata: Record<string, unknown>,
     allFiles: IFile[],
   ): unknown {
-    const prototypeRef = metadata.exo__Instance_prototype;
+    const prototypeRef = metadata.exo__Asset_prototype;
     if (!prototypeRef || typeof prototypeRef !== 'string') {
       return null;
     }

--- a/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
@@ -2717,7 +2717,7 @@ test.describe("Prototype-based Context Task Exclusion (Issue #2131)", () => {
         status: "ems__EffortStatusInProgress",
         metadata: {
           // Task has a prototype that is a Context
-          exo__Instance_prototype: "[[commute-prototype|Commute]]",
+          exo__Asset_prototype: "[[commute-prototype|Commute]]",
           // The prototype's classes are passed as resolved metadata
           _prototypeClasses: ["[[ems__Task]]", "[[ems__Context]]"],
           ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
@@ -2779,7 +2779,7 @@ test.describe("Prototype-based Context Task Exclusion (Issue #2131)", () => {
         endTimestamp: null,
         status: "ems__EffortStatusInProgress",
         metadata: {
-          exo__Instance_prototype: "[[lunch-prototype|Lunch]]",
+          exo__Asset_prototype: "[[lunch-prototype|Lunch]]",
           _prototypeClasses: "[[ems__Context]]",
           ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
           ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",
@@ -2838,7 +2838,7 @@ test.describe("Prototype-based Context Task Exclusion (Issue #2131)", () => {
         endTimestamp: null,
         status: "ems__EffortStatusInProgress",
         metadata: {
-          exo__Instance_prototype: "[[some-prototype|Some Task]]",
+          exo__Asset_prototype: "[[some-prototype|Some Task]]",
           // Prototype has ems__Task class, but NOT ems__Context
           _prototypeClasses: ["[[ems__Task]]"],
           ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
@@ -2900,7 +2900,7 @@ test.describe("Prototype-based Context Task Exclusion (Issue #2131)", () => {
         status: "ems__EffortStatusInProgress",
         metadata: {
           // Has prototype reference but _prototypeClasses not resolved
-          exo__Instance_prototype: "[[some-prototype|Some Task]]",
+          exo__Asset_prototype: "[[some-prototype|Some Task]]",
           // _prototypeClasses is missing - should handle gracefully
           ems__Effort_plannedStartTimestamp: "2025-01-15T10:00:00",
           ems__Effort_plannedEndTimestamp: "2025-01-15T11:00:00",

--- a/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.edgeCases.test.ts
+++ b/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.edgeCases.test.ts
@@ -198,4 +198,70 @@ describe("DailyTasksRenderer - edge cases and error handling", () => {
     expect(tasks[0].startTime).toBeTruthy();
     expect(tasks[0].endTime).toBeTruthy();
   });
+
+  // Issue #2135: Prototype class resolution uses wrong property name
+  it("should resolve prototype classes using exo__Asset_prototype (Issue #2135)", async () => {
+    const mockFile = {
+      path: "test.md",
+      parent: { path: "DailyNotes" },
+      basename: "2025-10-20",
+    } as TFile;
+    const dailyNoteMetadata = {
+      exo__Instance_class: "[[pn__DailyNote]]",
+      pn__DailyNote_day: "[[2025-10-20]]",
+    };
+
+    const taskFile = {
+      path: "task.md",
+      basename: "task",
+    } as TFile;
+
+    const prototypeFile = {
+      path: "fb3d12b2-9552-4866-a31e-2b5f65ea433c.md",
+      basename: "fb3d12b2-9552-4866-a31e-2b5f65ea433c",
+    } as TFile;
+
+    // Task has exo__Asset_prototype (correct property used in vault)
+    const taskMetadata = {
+      exo__Instance_class: "[[ems__Task]]",
+      ems__Effort_day: "[[2025-10-20]]",
+      ems__Effort_startTimestamp: "2025-10-20T09:00:00",
+      ems__Effort_status: "[[ems__EffortStatusDoing]]",
+      exo__Asset_prototype: "[[fb3d12b2-9552-4866-a31e-2b5f65ea433c]]",
+    };
+
+    // Prototype has ems__Context class (should exclude from overlap detection)
+    const prototypeMetadata = {
+      exo__Instance_class: ["[[ems__Task]]", "[[ems__Context]]"],
+    };
+
+    // The metadata extractor is called in this order:
+    // 1. For the DailyNote file (in render method)
+    // 2. For the task file (in getDailyTasks loop - first the task, then prototype is skipped since it's not a task for the day)
+    // 3. For the prototype file (in getDailyTasks - it doesn't match day filter, but we check prototype file anyway)
+    // 4. For the prototype file (in resolvePrototypeClasses)
+    ctx.mockMetadataExtractor.extractMetadata
+      .mockImplementation((file: any) => {
+        if (file.path === "test.md") return dailyNoteMetadata;
+        if (file.path === "task.md") return taskMetadata;
+        if (file.path === "fb3d12b2-9552-4866-a31e-2b5f65ea433c.md") return prototypeMetadata;
+        return {};
+      });
+
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[pn__DailyNote]]",
+    );
+
+    ctx.mockVaultAdapter.getAllFiles.mockReturnValue([taskFile, prototypeFile]);
+
+    const mockEl = createMockElement();
+    await ctx.renderer.render(mockEl, mockFile);
+
+    expect(ctx.mockReactRenderer.render).toHaveBeenCalled();
+    const renderCall = ctx.mockReactRenderer.render.mock.calls[0];
+    const tasks = renderCall[1].props.tasks;
+
+    // _prototypeClasses should be resolved from prototype's exo__Instance_class
+    expect(tasks[0].metadata._prototypeClasses).toEqual(["[[ems__Task]]", "[[ems__Context]]"]);
+  });
 });


### PR DESCRIPTION
## Summary
- Fix property name from `exo__Instance_prototype` to `exo__Asset_prototype` in overlap detection
- The prototype class resolution was using wrong property name (only 6 vault occurrences vs 3098 for correct name)

## Changes
- Fix property name in `DailyTasksRenderer.resolvePrototypeClasses()` (line 333)
- Update JSDoc comments to reflect correct property name
- Update component tests in `DailyTasksTable.spec.tsx` to use correct property name
- Add regression test in `DailyTasksRenderer.edgeCases.test.ts` for Issue #2135

## Testing
- [x] Added regression test that verifies prototype classes are resolved using `exo__Asset_prototype`
- [x] All existing tests pass (4334 tests)
- [x] Build passes
- [x] Lint passes (only existing warnings)

## Verification
- [x] `npm run build` — PASSED
- [x] `npm run test:unit` — PASSED (4334 tests)
- [x] `npm run lint` — PASSED (0 errors)

## Acceptance Criteria
- [x] Change property name from `exo__Instance_prototype` to `exo__Asset_prototype`
- [x] Update all related tests
- [x] Task with `exo__Asset_prototype` now has its prototype classes resolved for overlap detection

Fixes #2135