### PR TITLE
feat(plugin): add setting to disable automatic plannedEndTimestamp adjustment

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -958,21 +958,28 @@ export default class ExocortexPlugin extends Plugin {
         cachedMetadata.ems__Effort_plannedStartTimestamp =
           currentPlannedStartTimestamp;
 
-        const currentDate = new Date(
-          String(currentPlannedStartTimestamp),
-        );
-        const previousDate = previousPlannedStartTimestamp
-          ? new Date(String(previousPlannedStartTimestamp))
-          : null;
+        // Issue #2142: Check setting before auto-adjusting plannedEndTimestamp
+        // When disabled, skip automatic adjustment to prevent double-shift with Obsidian Sync
+        if (!this.settings.autoAdjustPlannedEndTimestamp) {
+          this.logger.info(
+            `Skipping plannedEndTimestamp adjustment - autoAdjustPlannedEndTimestamp is disabled`,
+          );
+        } else {
+          const currentDate = new Date(
+            String(currentPlannedStartTimestamp),
+          );
+          const previousDate = previousPlannedStartTimestamp
+            ? new Date(String(previousPlannedStartTimestamp))
+            : null;
 
-        if (
-          !isNaN(currentDate.getTime()) &&
-          previousDate &&
-          !isNaN(previousDate.getTime())
-        ) {
-          const deltaMs = currentDate.getTime() - previousDate.getTime();
+          if (
+            !isNaN(currentDate.getTime()) &&
+            previousDate &&
+            !isNaN(previousDate.getTime())
+          ) {
+            const deltaMs = currentDate.getTime() - previousDate.getTime();
 
-          // Issue #2095: Idempotency check for Obsidian Sync
+            // Issue #2095: Idempotency check for Obsidian Sync
           // When synced from another device, plannedEndTimestamp may already be shifted.
           // Check if the current plannedEndTimestamp equals the expected value to avoid double-shift.
           const currentPlannedEndTimestamp =
@@ -1034,6 +1041,7 @@ export default class ExocortexPlugin extends Plugin {
               `Shifted ems__Effort_plannedEndTimestamp by ${deltaMs}ms`,
             );
           }
+        }
         }
       }
 

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -158,6 +158,12 @@ export interface ExocortexSettings {
   webhookSettings: WebhookSettings;
   /** Semantic search settings */
   semanticSearchSettings: SemanticSearchSettings;
+  /**
+   * Auto-adjust plannedEndTimestamp when plannedStartTimestamp changes.
+   * Disabled by default to prevent double-shift issues with Obsidian Sync.
+   * @see Issue #2142
+   */
+  autoAdjustPlannedEndTimestamp: boolean;
   [key: string]: unknown;
 }
 
@@ -183,4 +189,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS,
   webhookSettings: DEFAULT_WEBHOOK_SETTINGS,
   semanticSearchSettings: DEFAULT_SEMANTIC_SEARCH_SETTINGS,
+  autoAdjustPlannedEndTimestamp: false,
 };

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -150,6 +150,21 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Auto-adjust planned end time")
+      .setDesc(
+        "Automatically shift plannedEndTimestamp when plannedStartTimestamp changes. " +
+        "Disable if using Obsidian Sync to prevent duplicate shifts.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.autoAdjustPlannedEndTimestamp)
+          .onChange(async (value) => {
+            this.plugin.settings.autoAdjustPlannedEndTimestamp = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Show labels in file explorer")
       .setDesc(
         "Display asset labels instead of filenames in the file explorer sidebar",

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -323,6 +323,32 @@ describe("ExocortexPlugin", () => {
       expect(plugin.settings.useDynamicPropertyFields).toBe(false);
     });
 
+    it("should have autoAdjustPlannedEndTimestamp disabled by default (Issue #2142)", async () => {
+      // Arrange
+      plugin.loadData = jest.fn().mockResolvedValue(null);
+
+      // Act
+      await plugin.loadSettings();
+
+      // Assert
+      // Default should be false to prevent double-shift issues with Obsidian Sync
+      expect(plugin.settings.autoAdjustPlannedEndTimestamp).toBe(false);
+    });
+
+    it("should persist autoAdjustPlannedEndTimestamp setting when enabled", async () => {
+      // Arrange
+      const savedSettings = {
+        autoAdjustPlannedEndTimestamp: true,
+      };
+      plugin.loadData = jest.fn().mockResolvedValue(savedSettings);
+
+      // Act
+      await plugin.loadSettings();
+
+      // Assert
+      expect(plugin.settings.autoAdjustPlannedEndTimestamp).toBe(true);
+    });
+
     it("should persist useDynamicPropertyFields setting when enabled", async () => {
       // Arrange
       const savedSettings = {
@@ -573,6 +599,9 @@ describe("ExocortexPlugin", () => {
 
     it("should handle planned start timestamp change", async () => {
       // Arrange
+      // Enable auto-adjust setting (disabled by default since Issue #2142)
+      plugin.settings.autoAdjustPlannedEndTimestamp = true;
+
       const metadata = {
         ems__Effort_plannedStartTimestamp: "2023-11-01T08:00:00Z",
       };
@@ -621,6 +650,9 @@ describe("ExocortexPlugin", () => {
     });
 
     it("should not double-shift plannedEndTimestamp on recursive metadata change event", async () => {
+      // Enable auto-adjust setting (disabled by default since Issue #2142)
+      plugin.settings.autoAdjustPlannedEndTimestamp = true;
+
       const metadata = {
         ems__Effort_plannedStartTimestamp: "2023-11-01T08:00:00Z",
       };
@@ -644,6 +676,9 @@ describe("ExocortexPlugin", () => {
     });
 
     it("should not shift plannedEndTimestamp when synced via Obsidian Sync (idempotent fix for Issue #2095)", async () => {
+      // Enable auto-adjust setting (disabled by default since Issue #2142)
+      plugin.settings.autoAdjustPlannedEndTimestamp = true;
+
       // Scenario: Device A changes plannedStartTimestamp and shifts plannedEndTimestamp.
       // When synced to Device B via Obsidian Sync, Device B receives the already-shifted
       // plannedEndTimestamp. The plugin should detect this and NOT shift again.
@@ -687,7 +722,90 @@ describe("ExocortexPlugin", () => {
       expect(mockTaskStatusService.shiftPlannedEndTimestamp).not.toHaveBeenCalled();
     });
 
+    it("should NOT shift plannedEndTimestamp when autoAdjustPlannedEndTimestamp setting is false (Issue #2142)", async () => {
+      // Scenario: User has disabled auto-adjustment to prevent issues with Obsidian Sync.
+      // When plannedStartTimestamp changes, plannedEndTimestamp should NOT be auto-shifted.
+
+      // Ensure setting is disabled (default)
+      plugin.settings.autoAdjustPlannedEndTimestamp = false;
+
+      // Initial state
+      const metadataInitial = {
+        ems__Effort_plannedStartTimestamp: "2023-11-01T08:00:00",
+        ems__Effort_plannedEndTimestamp: "2023-11-01T10:00:00",
+      };
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: metadataInitial,
+      });
+
+      // Cache the initial state
+      await (plugin as any).handleMetadataChange(mockFile);
+
+      // Clear mock call counts from initial caching
+      jest.clearAllMocks();
+
+      // User changes plannedStartTimestamp
+      const metadataAfterChange = {
+        ems__Effort_plannedStartTimestamp: "2023-11-01T09:00:00",  // +1 hour
+        ems__Effort_plannedEndTimestamp: "2023-11-01T10:00:00",    // NOT shifted
+      };
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: metadataAfterChange,
+      });
+
+      // Handle the metadata change
+      await (plugin as any).handleMetadataChange(mockFile);
+
+      // The plugin should NOT shift plannedEndTimestamp because setting is disabled
+      expect(mockTaskStatusService.shiftPlannedEndTimestamp).not.toHaveBeenCalled();
+    });
+
+    it("should shift plannedEndTimestamp when autoAdjustPlannedEndTimestamp setting is true (Issue #2142)", async () => {
+      // Scenario: User has enabled auto-adjustment. Normal behavior should apply.
+
+      // Enable the setting
+      plugin.settings.autoAdjustPlannedEndTimestamp = true;
+
+      // Initial state
+      const metadataInitial = {
+        ems__Effort_plannedStartTimestamp: "2023-11-01T08:00:00",
+        ems__Effort_plannedEndTimestamp: "2023-11-01T10:00:00",
+      };
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: metadataInitial,
+      });
+
+      // Cache the initial state
+      await (plugin as any).handleMetadataChange(mockFile);
+
+      // Clear mock call counts from initial caching
+      jest.clearAllMocks();
+
+      // User changes plannedStartTimestamp
+      const metadataAfterChange = {
+        ems__Effort_plannedStartTimestamp: "2023-11-01T09:00:00",  // +1 hour
+        ems__Effort_plannedEndTimestamp: "2023-11-01T10:00:00",    // NOT shifted yet
+      };
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: metadataAfterChange,
+      });
+
+      // Handle the metadata change
+      await (plugin as any).handleMetadataChange(mockFile);
+
+      // The plugin SHOULD shift plannedEndTimestamp because setting is enabled
+      const expectedDelta = 60 * 60 * 1000; // 1 hour in ms
+      expect(mockTaskStatusService.shiftPlannedEndTimestamp).toHaveBeenCalledTimes(1);
+      expect(mockTaskStatusService.shiftPlannedEndTimestamp).toHaveBeenCalledWith(
+        mockFile,
+        expectedDelta
+      );
+    });
+
     it("should still shift plannedEndTimestamp on local change (Issue #2095 edge case)", async () => {
+      // Enable auto-adjust setting (disabled by default since Issue #2142)
+      plugin.settings.autoAdjustPlannedEndTimestamp = true;
+
       // Scenario: User changes plannedStartTimestamp locally on the same device.
       // The plannedEndTimestamp hasn't been shifted yet, so it should be shifted.
       //

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -349,8 +349,8 @@ describe("ExocortexSettingTab", () => {
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
       expect(getOntologySpy).toHaveBeenCalledTimes(1);
-      // 13 original settings (added showLabelsInLivePreview) + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 32
-      expect(MockSetting).toHaveBeenCalledTimes(32);
+      // 14 original settings (added autoAdjustPlannedEndTimestamp Issue #2142) + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 33
+      expect(MockSetting).toHaveBeenCalledTimes(33);
     });
 
     it("should render ontology dropdown with correct options", () => {


### PR DESCRIPTION
## Summary
- Add toggle setting to disable automatic `plannedEndTimestamp` adjustment when `plannedStartTimestamp` changes
- Default is **disabled** (false) to prevent double-shift issues with Obsidian Sync
- Users can enable if they want the auto-adjustment behavior and don't use Sync

## Changes
- Add `autoAdjustPlannedEndTimestamp` to `ExocortexSettings` interface with default `false`
- Add toggle in settings UI labeled "Auto-adjust planned end time" with Sync caveat description
- Guard adjustment logic with setting check in `handleMetadataChange`
- Update existing tests to enable setting when testing adjustment behavior
- Add new tests for setting behavior (disabled → no shift, enabled → shift)

## Testing
- [x] Added unit test for default value verification (Issue #2142)
- [x] Added unit test for disabled setting behavior  
- [x] Added unit test for enabled setting behavior
- [x] Updated existing tests to enable setting when expecting adjustment
- [x] All existing tests pass

## Verification
- [x] `npm run build` — PASSED
- [x] `npm run test:unit` — PASSED  
- [x] `npm run lint` — PASSED (no errors, pre-existing warnings only)

## Acceptance Criteria
- [x] Add `autoAdjustPlannedEndTimestamp: boolean` field to settings interface
- [x] Set default value to `false` in `DEFAULT_SETTINGS`
- [x] Add toggle control in settings tab with description explaining Sync caveat
- [x] Wrap adjustment logic with early-return guard when setting is false
- [x] Write unit tests asserting adjustment is skipped when false, applied when true

Closes #2142