### PR TITLE
fix(plugin): Graph View labels now display exo__Asset_label values

### DIFF
--- a/packages/obsidian-plugin/src/presentation/graph-view/GraphViewPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/graph-view/GraphViewPatch.ts
@@ -27,14 +27,20 @@ interface PluginWithSettings extends Plugin {
 }
 
 // Obsidian internal types for graph nodes (not exposed in public API)
+interface GraphNodeText {
+  text: string;
+}
+
 interface GraphNode {
   id: string;
+  text?: GraphNodeText;
   getDisplayText: () => string;
   nm_originalGetDisplayText?: () => string;
 }
 
 interface GraphRenderer {
   nodes?: GraphNode[];
+  changed?: () => void;
 }
 
 interface GraphView {
@@ -184,6 +190,28 @@ export class GraphViewPatch {
 
     for (const node of nodes) {
       this.patchNode(node);
+      // Update node.text.text with the display text after patching
+      this.updateNodeText(node);
+    }
+
+    // Signal the renderer that changes have occurred to trigger visual refresh
+    if (typeof renderer?.changed === "function") {
+      renderer.changed();
+    }
+  }
+
+  /**
+   * Update a node's text.text property with its display text
+   * This is necessary because Obsidian's Graph View caches the text
+   * and doesn't call getDisplayText() on every render.
+   */
+  private updateNodeText(node: GraphNode): void {
+    if (!node || !node.text) return;
+
+    // Get the display text (will use patched method if prototype was patched)
+    const displayText = node.getDisplayText();
+    if (displayText) {
+      node.text.text = displayText;
     }
   }
 
@@ -379,8 +407,43 @@ export class GraphViewPatch {
    * Refresh all graph views (trigger re-render)
    */
   private refreshAllGraphViews(): void {
-    // Re-patch to ensure new nodes get labels
-    this.patchAllGraphViews();
+    if (!this.enabled) return;
+
+    // Refresh global graph views
+    const graphLeaves = this.getGraphLeaves("graph");
+    for (const leaf of graphLeaves) {
+      this.refreshGraphView(leaf);
+    }
+
+    // Refresh local graph views
+    const localGraphLeaves = this.getGraphLeaves("localgraph");
+    for (const leaf of localGraphLeaves) {
+      this.refreshGraphView(leaf);
+    }
+  }
+
+  /**
+   * Refresh a single graph view by updating node text and signaling changes
+   */
+  private refreshGraphView(leaf: WorkspaceLeaf): void {
+    const view = leaf.view as unknown as GraphView;
+    const renderer = view?.renderer;
+    const nodes = renderer?.nodes;
+
+    if (!nodes || !Array.isArray(nodes)) return;
+
+    // Update text for all nodes
+    for (const node of nodes) {
+      // Patch new nodes if they haven't been patched yet
+      this.patchNode(node);
+      // Update the node's text property
+      this.updateNodeText(node);
+    }
+
+    // Signal the renderer to refresh
+    if (typeof renderer?.changed === "function") {
+      renderer.changed();
+    }
   }
 
   /**
@@ -415,6 +478,13 @@ export class GraphViewPatch {
 
     for (const node of nodes) {
       this.restoreNode(node);
+      // Restore the node's text to the original display text
+      this.updateNodeText(node);
+    }
+
+    // Signal the renderer to refresh with restored text
+    if (typeof renderer?.changed === "function") {
+      renderer.changed();
     }
   }
 

--- a/packages/obsidian-plugin/tests/unit/presentation/graph-view/GraphViewPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/graph-view/GraphViewPatch.test.ts
@@ -373,4 +373,195 @@ describe("GraphViewPatch", () => {
       expect(nodePrototype.nm_originalGetDisplayText).toBe(originalGetDisplayText);
     });
   });
+
+  describe("Issue #2151: node.text.text update and renderer.changed()", () => {
+    it("should update node.text.text after patching prototype", () => {
+      // Create a mock node with text property (like Obsidian's Graph View nodes)
+      const nodePrototype = {
+        getDisplayText: originalGetDisplayText,
+      };
+      const mockNodeWithText = Object.create(nodePrototype);
+      mockNodeWithText.id = "test-file.md";
+      mockNodeWithText.text = { text: "original-filename.md" };
+
+      mockGraphView.renderer = {
+        nodes: [mockNodeWithText],
+        changed: jest.fn(),
+      };
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "My Custom Label" },
+      });
+
+      patch.enable();
+
+      // The node.text.text should be updated with the label
+      expect(mockNodeWithText.text.text).toBe("My Custom Label");
+    });
+
+    it("should call renderer.changed() after updating node labels", () => {
+      const nodePrototype = {
+        getDisplayText: originalGetDisplayText,
+      };
+      const mockNodeWithText = Object.create(nodePrototype);
+      mockNodeWithText.id = "test-file.md";
+      mockNodeWithText.text = { text: "original-filename.md" };
+
+      const mockChanged = jest.fn();
+      mockGraphView.renderer = {
+        nodes: [mockNodeWithText],
+        changed: mockChanged,
+      };
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "My Custom Label" },
+      });
+
+      patch.enable();
+
+      // renderer.changed() should be called to trigger visual refresh
+      expect(mockChanged).toHaveBeenCalled();
+    });
+
+    it("should update multiple nodes' text.text values", () => {
+      const nodePrototype = {
+        getDisplayText: originalGetDisplayText,
+      };
+      const node1 = Object.create(nodePrototype);
+      node1.id = "file1.md";
+      node1.text = { text: "file1.md" };
+
+      const node2 = Object.create(nodePrototype);
+      node2.id = "file2.md";
+      node2.text = { text: "file2.md" };
+
+      mockGraphView.renderer = {
+        nodes: [node1, node2],
+        changed: jest.fn(),
+      };
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "Updated Label" },
+      });
+
+      patch.enable();
+
+      // Both nodes' text should be updated
+      expect(node1.text.text).toBe("Updated Label");
+      expect(node2.text.text).toBe("Updated Label");
+    });
+
+    it("should restore node.text.text to original on disable", () => {
+      const nodePrototype = {
+        getDisplayText: originalGetDisplayText,
+      };
+      const mockNodeWithText = Object.create(nodePrototype);
+      mockNodeWithText.id = "test-file.md";
+      mockNodeWithText.text = { text: "original-filename.md" };
+
+      const mockChanged = jest.fn();
+      mockGraphView.renderer = {
+        nodes: [mockNodeWithText],
+        changed: mockChanged,
+      };
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "My Custom Label" },
+      });
+
+      patch.enable();
+      expect(mockNodeWithText.text.text).toBe("My Custom Label");
+
+      patch.disable();
+      // After disable, text should be restored to original
+      expect(mockNodeWithText.text.text).toBe("original-filename.md");
+    });
+
+    it("should handle nodes without text property gracefully", () => {
+      const nodePrototype = {
+        getDisplayText: originalGetDisplayText,
+      };
+      const nodeWithoutText = Object.create(nodePrototype);
+      nodeWithoutText.id = "test-file.md";
+      // No text property
+
+      mockGraphView.renderer = {
+        nodes: [nodeWithoutText],
+        changed: jest.fn(),
+      };
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "My Custom Label" },
+      });
+
+      // Should not throw when node doesn't have text property
+      expect(() => patch.enable()).not.toThrow();
+    });
+
+    it("should refresh node.text.text when metadata changes", () => {
+      const nodePrototype = {
+        getDisplayText: originalGetDisplayText,
+      };
+      const mockNodeWithText = Object.create(nodePrototype);
+      mockNodeWithText.id = "test-file.md";
+      mockNodeWithText.text = { text: "original-filename.md" };
+
+      const mockChanged = jest.fn();
+      mockGraphView.renderer = {
+        nodes: [mockNodeWithText],
+        changed: mockChanged,
+      };
+
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "test-file" });
+      Object.defineProperty(mockFile, "path", { value: "test-file.md" });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      // Initial label
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "Initial Label" },
+      });
+
+      patch.enable();
+      expect(mockNodeWithText.text.text).toBe("Initial Label");
+
+      // Update the label
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "Updated Label" },
+      });
+
+      // Simulate metadata change
+      const metadataCallback = mockApp.metadataCache.on.mock.calls.find(
+        (call: [string, Function]) => call[0] === "changed"
+      )?.[1];
+
+      if (metadataCallback) {
+        metadataCallback(mockFile);
+      }
+
+      // The node.text.text should be updated with new label
+      expect(mockNodeWithText.text.text).toBe("Updated Label");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fix Graph View nodes displaying filenames (UUIDs) instead of `exo__Asset_label` values
- Update `node.text.text` cache after patching prototypes
- Call `renderer.changed()` to trigger visual refresh

## Root Cause Analysis

The `GraphViewPatch` correctly patched the `getDisplayText()` method on node prototypes, but Obsidian's Graph View caches label text in `node.text.text` property. Simply patching the method wasn't enough because:
1. The cached text was never updated
2. The renderer wasn't notified of changes

This was discovered by analyzing the [Node Masquerade](https://github.com/ElsaTam/obsidian-node-masquerade) plugin which implements similar functionality.

## Changes

- Added `updateNodeText()` method to update `node.text.text` property after patching
- Added `refreshGraphView()` method for handling metadata changes
- Updated `GraphNode` interface to include optional `text` property
- Updated `GraphRenderer` interface to include `changed()` method

## Testing

- [x] Added 6 new tests covering Issue #2151 scenarios:
  - `should update node.text.text after patching prototype`
  - `should call renderer.changed() after updating node labels`
  - `should update multiple nodes' text.text values`
  - `should restore node.text.text to original on disable`
  - `should handle nodes without text property gracefully`
  - `should refresh node.text.text when metadata changes`
- [x] All existing tests pass
- [x] Build succeeds
- [x] Lint passes (only pre-existing warnings)

## Verification

- [x] `npm run build` — PASSED
- [x] `npm run lint` — PASSED (0 errors, 15 pre-existing warnings)
- [x] `npm run test:unit` — PASSED (4354 tests)

## Acceptance Criteria

- [x] Graph nodes display `exo__Asset_label` when setting is enabled
- [x] Nodes without labels show filename as fallback
- [x] Toggle in settings immediately affects Graph View (via metadata change handler)
- [x] Works with both local and global Graph Views

Fixes #2151