### PR TITLE
refactor(plugin): remove deprecated "Default ontology asset" setting

### DIFF
--- a/packages/exocortex/src/services/SessionEventService.ts
+++ b/packages/exocortex/src/services/SessionEventService.ts
@@ -13,16 +13,10 @@ import { DI_TOKENS } from "../interfaces/tokens";
 @injectable()
 export class SessionEventService {
   private folderPathCache: string | null = null;
-  private defaultOntologyAsset: string | null = null;
 
   constructor(
     @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
   ) {}
-
-  setDefaultOntologyAsset(asset: string | null): void {
-    this.defaultOntologyAsset = asset;
-    this.folderPathCache = null;
-  }
 
   /**
    * Create a session start event when user activates a focus area
@@ -43,33 +37,15 @@ export class SessionEventService {
   }
 
   /**
-   * Find the folder path where the ontology asset is located
-   * @returns Folder path for ontology asset or vault's default new file location as fallback
+   * Get the folder path for session events
+   * @returns Vault's default new file location
    */
-  private async getOntologyAssetFolder(): Promise<string> {
+  private getSessionEventFolder(): string {
     // Return cached value if available
     if (this.folderPathCache !== null) {
       return this.folderPathCache;
     }
 
-    if (!this.defaultOntologyAsset) {
-      const defaultFolder = this.vault.getDefaultNewFileParent();
-      this.folderPathCache = defaultFolder?.path || "";
-      return this.folderPathCache;
-    }
-
-    const allFiles = this.vault.getAllFiles();
-
-    for (const file of allFiles) {
-      // Match by basename without extension
-      if (file.basename === this.defaultOntologyAsset) {
-        const folderPath = file.parent?.path || "";
-        this.folderPathCache = folderPath;
-        return this.folderPathCache;
-      }
-    }
-
-    // Fallback to vault's default new file location if ontology asset not found
     const defaultFolder = this.vault.getDefaultNewFileParent();
     this.folderPathCache = defaultFolder?.path || "";
     return this.folderPathCache;
@@ -88,21 +64,17 @@ export class SessionEventService {
     const uid = uuidv4();
     const timestamp = DateFormatter.toLocalTimestamp(new Date());
 
-    const ontologyRef = this.defaultOntologyAsset
-      ? `"[[${this.defaultOntologyAsset}]]"`
-      : '"[[!kitelev]]"';
-
     const frontmatter = {
       exo__Asset_uid: uid,
       exo__Asset_createdAt: timestamp,
-      exo__Asset_isDefinedBy: ontologyRef,
+      exo__Asset_isDefinedBy: '"[[!kitelev]]"',
       exo__Instance_class: [`"[[${eventType}]]"`],
       ems__SessionEvent_timestamp: timestamp,
       ems__Session_area: `"[[${areaName}]]"`,
     };
 
     const fileContent = MetadataHelpers.buildFileContent(frontmatter);
-    const folderPath = await this.getOntologyAssetFolder();
+    const folderPath = this.getSessionEventFolder();
 
     // Ensure folder exists before creating file
     if (folderPath && !(await this.vault.exists(folderPath))) {

--- a/packages/exocortex/tests/unit/services/SessionEventService.test.ts
+++ b/packages/exocortex/tests/unit/services/SessionEventService.test.ts
@@ -63,40 +63,27 @@ describe("SessionEventService", () => {
       expect(fileContent).not.toContain("aliases");
     });
 
-    it("should use ontology asset folder and isDefinedBy when ontology is set", async () => {
-      const ontologyService = new SessionEventService(mockVault);
-      ontologyService.setDefaultOntologyAsset("kitelev");
+    it("should always use default ontology reference (!kitelev)", async () => {
       const areaName = "Work";
-      const mockOntologyFile: IFile = {
-        path: "People/kitelev.md",
-        basename: "kitelev",
-        name: "kitelev.md",
-        parent: {
-          path: "People",
-          name: "People",
-        } as any,
-      };
       const mockCreatedFile: IFile = {
-        path: "People/test-uid.md",
+        path: "test-uid.md",
         basename: "test-uid",
         name: "test-uid.md",
         parent: null,
       };
 
-      mockVault.getAllFiles.mockReturnValue([mockOntologyFile]);
+      mockVault.getAllFiles.mockReturnValue([]);
       mockVault.create.mockResolvedValue(mockCreatedFile);
 
-      const result = await ontologyService.createSessionStartEvent(areaName);
+      const result = await service.createSessionStartEvent(areaName);
 
       expect(mockVault.create).toHaveBeenCalled();
       expect(result).toBe(mockCreatedFile);
 
       const createCall = mockVault.create.mock.calls[0];
-      const [filePath, fileContent] = createCall;
+      const [, fileContent] = createCall;
 
-      expect(filePath).toMatch(/^People\/.+\.md$/);
-      expect(fileContent).toContain('"[[kitelev]]"');
-      expect(fileContent).not.toContain('"[[!kitelev]]"');
+      expect(fileContent).toContain('"[[!kitelev]]"');
     });
 
     it("should use correct timestamp format (ISO 8601)", async () => {
@@ -256,65 +243,24 @@ describe("SessionEventService", () => {
       ).resolves.toBe(mockCreatedFile);
     });
 
-    it("should use ontology asset folder for end events", async () => {
-      const ontologyService = new SessionEventService(mockVault);
-      ontologyService.setDefaultOntologyAsset("myOntology");
+    it("should use default folder for end events", async () => {
       const areaName = "Work";
-      const mockOntologyFile: IFile = {
-        path: "Ontologies/myOntology.md",
-        basename: "myOntology",
-        name: "myOntology.md",
-        parent: {
-          path: "Ontologies",
-          name: "Ontologies",
-        } as any,
-      };
       const mockCreatedFile: IFile = {
-        path: "Ontologies/test-uid.md",
+        path: "test-uid.md",
         basename: "test-uid",
         name: "test-uid.md",
         parent: null,
       };
 
-      mockVault.getAllFiles.mockReturnValue([mockOntologyFile]);
+      mockVault.getAllFiles.mockReturnValue([]);
       mockVault.create.mockResolvedValue(mockCreatedFile);
 
-      await ontologyService.createSessionEndEvent(areaName);
+      await service.createSessionEndEvent(areaName);
 
       const createCall = mockVault.create.mock.calls[0];
       const [filePath] = createCall;
 
-      expect(filePath).toMatch(/^Ontologies\/.+\.md$/);
-    });
-
-    it("should create ontology folder if it does not exist", async () => {
-      const ontologyService = new SessionEventService(mockVault);
-      ontologyService.setDefaultOntologyAsset("myOntology");
-      const areaName = "Work";
-      const mockOntologyFile: IFile = {
-        path: "Ontologies/myOntology.md",
-        basename: "myOntology",
-        name: "myOntology.md",
-        parent: {
-          path: "Ontologies",
-          name: "Ontologies",
-        } as any,
-      };
-      const mockCreatedFile: IFile = {
-        path: "Ontologies/test-uid.md",
-        basename: "test-uid",
-        name: "test-uid.md",
-        parent: null,
-      };
-
-      mockVault.getAllFiles.mockReturnValue([mockOntologyFile]);
-      mockVault.exists.mockResolvedValue(false);
-      mockVault.create.mockResolvedValue(mockCreatedFile);
-
-      await ontologyService.createSessionEndEvent(areaName);
-
-      expect(mockVault.createFolder).toHaveBeenCalledWith("Ontologies");
-      expect(mockVault.create).toHaveBeenCalled();
+      expect(filePath).toMatch(/^[0-9a-f-]+\.md$/);
     });
   });
 });

--- a/packages/obsidian-plugin/src/application/commands/SetFocusAreaCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/SetFocusAreaCommand.ts
@@ -20,9 +20,6 @@ export class SetFocusAreaCommand implements ICommand {
     private plugin: ExocortexPluginInterface,
   ) {
     this.sessionEventService = container.resolve(SessionEventService);
-    this.sessionEventService.setDefaultOntologyAsset(
-      (this.plugin.settings?.defaultOntologyAsset as string | null) ?? null,
-    );
   }
 
   callback = async (): Promise<void> => {

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -135,7 +135,6 @@ export interface ExocortexSettings {
   activeFocusArea: string | null;
   showEffortArea: boolean;
   showEffortVotes: boolean;
-  defaultOntologyAsset: string | null;
   showFullDateInEffortTimes: boolean;
   showDailyNoteProjects: boolean;
   useDynamicPropertyFields: boolean;
@@ -174,7 +173,6 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   activeFocusArea: null,
   showEffortArea: false,
   showEffortVotes: false,
-  defaultOntologyAsset: null,
   showFullDateInEffortTimes: false,
   showDailyNoteProjects: true,
   useDynamicPropertyFields: false,

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -19,65 +19,10 @@ export class ExocortexSettingTab extends PluginSettingTab {
     this.plugin = plugin;
   }
 
-  private getOntologyAssets(): string[] {
-    const files = this.app.vault.getMarkdownFiles();
-    const ontologyAssets: string[] = [];
-
-    for (const file of files) {
-      const cache = this.app.metadataCache.getFileCache(file);
-      const frontmatter = cache?.frontmatter;
-
-      if (!frontmatter) continue;
-
-      // Check if file has exo__Instance_class containing exo__Ontology
-      const instanceClass = frontmatter.exo__Instance_class;
-      if (!instanceClass) continue;
-
-      const classArray = Array.isArray(instanceClass)
-        ? instanceClass
-        : [instanceClass];
-
-      const hasOntologyClass = classArray.some(
-        (cls: string) =>
-          cls === "exo__Ontology" ||
-          cls === '"[[exo__Ontology]]"' ||
-          cls === "[[exo__Ontology]]",
-      );
-
-      if (hasOntologyClass) {
-        ontologyAssets.push(file.basename);
-      }
-    }
-
-    return ontologyAssets.sort((a, b) => a.localeCompare(b));
-  }
-
   display(): void {
     const { containerEl } = this;
 
     containerEl.empty();
-
-    // Cache ontology assets once per display
-    const ontologyAssets = this.getOntologyAssets();
-
-    new Setting(containerEl)
-      .setName("Default ontology asset")
-      .setDesc("Choose the ontology asset to use for created events")
-      .addDropdown((dropdown) => {
-
-        dropdown.addOption("", "None (use events folder)");
-        
-        ontologyAssets.forEach((assetName) => {
-          dropdown.addOption(assetName, assetName);
-        });
-        
-        dropdown
-          .setValue(this.plugin.settings.defaultOntologyAsset || "")
-          .onChange(async (value) => {
-            this.plugin.settings.defaultOntologyAsset = value || null;
-            await this.plugin.saveSettings();
-          });
-      });
 
     new Setting(containerEl)
       .setName("Show layout")

--- a/packages/obsidian-plugin/tests/e2e/specs/dynamic-property-fields.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/dynamic-property-fields.spec.ts
@@ -31,7 +31,6 @@ test.describe("Dynamic Property Fields E2E", () => {
       activeFocusArea: null,
       showEffortArea: false,
       showEffortVotes: false,
-      defaultOntologyAsset: null,
       showFullDateInEffortTimes: false,
       showDailyNoteProjects: true,
       useDynamicPropertyFields: true, // Enable dynamic fields
@@ -51,7 +50,6 @@ test.describe("Dynamic Property Fields E2E", () => {
       activeFocusArea: null,
       showEffortArea: false,
       showEffortVotes: false,
-      defaultOntologyAsset: null,
       showFullDateInEffortTimes: false,
       showDailyNoteProjects: true,
       useDynamicPropertyFields: false, // Disable dynamic fields
@@ -444,7 +442,6 @@ test.describe("Dynamic Property Fields - Feature Toggle", () => {
       activeFocusArea: null,
       showEffortArea: false,
       showEffortVotes: false,
-      defaultOntologyAsset: null,
       showFullDateInEffortTimes: false,
       showDailyNoteProjects: true,
       useDynamicPropertyFields: false, // Disabled

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -1,6 +1,6 @@
 import { ExocortexSettingTab } from "../../src/presentation/settings/ExocortexSettingTab";
 import { Setting } from "obsidian";
-import { createMockApp, createMockTFile, createMockPlugin } from "./helpers/testHelpers";
+import { createMockApp, createMockPlugin } from "./helpers/testHelpers";
 
 // Two-step mock pattern for constructor functions
 jest.mock("obsidian", () => ({
@@ -44,7 +44,6 @@ describe("ExocortexSettingTab", () => {
 
     mockPlugin = createMockPlugin({
       settings: {
-        defaultOntologyAsset: null,
         layoutVisible: true,
         showPropertiesSection: true,
         showArchivedAssets: false,
@@ -127,376 +126,26 @@ describe("ExocortexSettingTab", () => {
     settingTab.containerEl = mockContainerEl;
   });
 
-  describe("getOntologyAssets", () => {
-    it("should find files with exo__Ontology class", () => {
-      const mockFiles = [
-        createMockTFile("ontology1.md"),
-        createMockTFile("ontology2.md"),
-        createMockTFile("not-ontology.md"),
-      ];
-
-      mockApp.vault.getMarkdownFiles.mockReturnValue(mockFiles);
-      mockApp.metadataCache.getFileCache.mockImplementation((file: any) => {
-        if (file.basename === "ontology1") {
-          return {
-            frontmatter: {
-              exo__Instance_class: "exo__Ontology",
-            },
-          };
-        } else if (file.basename === "ontology2") {
-          return {
-            frontmatter: {
-              exo__Instance_class: "[[exo__Ontology]]",
-            },
-          };
-        } else {
-          return {
-            frontmatter: {
-              exo__Instance_class: "ems__Task",
-            },
-          };
-        }
-      });
-
-      const result = settingTab["getOntologyAssets"]();
-
-      expect(result).toEqual(["ontology1", "ontology2"]);
-      expect(mockApp.vault.getMarkdownFiles).toHaveBeenCalled();
-    });
-
-    it("should handle multiple class formats", () => {
-      const mockFiles = [
-        createMockTFile("ontology-plain.md"),
-        createMockTFile("ontology-linked.md"),
-        createMockTFile("ontology-quoted.md"),
-      ];
-
-      mockApp.vault.getMarkdownFiles.mockReturnValue(mockFiles);
-      mockApp.metadataCache.getFileCache.mockImplementation((file: any) => {
-        if (file.basename === "ontology-plain") {
-          return {
-            frontmatter: {
-              exo__Instance_class: "exo__Ontology",
-            },
-          };
-        } else if (file.basename === "ontology-linked") {
-          return {
-            frontmatter: {
-              exo__Instance_class: "[[exo__Ontology]]",
-            },
-          };
-        } else if (file.basename === "ontology-quoted") {
-          return {
-            frontmatter: {
-              exo__Instance_class: '"[[exo__Ontology]]"',
-            },
-          };
-        }
-        return null;
-      });
-
-      const result = settingTab["getOntologyAssets"]();
-
-      expect(result).toEqual(["ontology-linked", "ontology-plain", "ontology-quoted"]);
-    });
-
-    it("should handle array of classes", () => {
-      const mockFiles = [
-        createMockTFile("multi-class.md"),
-      ];
-
-      mockApp.vault.getMarkdownFiles.mockReturnValue(mockFiles);
-      mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: ["ems__Task", "exo__Ontology", "ems__Project"],
-        },
-      });
-
-      const result = settingTab["getOntologyAssets"]();
-
-      expect(result).toEqual(["multi-class"]);
-    });
-
-    it("should sort results alphabetically", () => {
-      const mockFiles = [
-        createMockTFile("zebra.md"),
-        createMockTFile("apple.md"),
-        createMockTFile("middle.md"),
-      ];
-
-      mockApp.vault.getMarkdownFiles.mockReturnValue(mockFiles);
-      mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "exo__Ontology",
-        },
-      });
-
-      const result = settingTab["getOntologyAssets"]();
-
-      expect(result).toEqual(["apple", "middle", "zebra"]);
-    });
-
-    it("should ignore files without frontmatter", () => {
-      const mockFiles = [
-        createMockTFile("no-frontmatter.md"),
-        createMockTFile("with-frontmatter.md"),
-      ];
-
-      mockApp.vault.getMarkdownFiles.mockReturnValue(mockFiles);
-      mockApp.metadataCache.getFileCache.mockImplementation((file: any) => {
-        if (file.basename === "no-frontmatter") {
-          return { frontmatter: null };
-        }
-        return {
-          frontmatter: {
-            exo__Instance_class: "exo__Ontology",
-          },
-        };
-      });
-
-      const result = settingTab["getOntologyAssets"]();
-
-      expect(result).toEqual(["with-frontmatter"]);
-    });
-
-    it("should ignore files without exo__Instance_class", () => {
-      const mockFiles = [
-        createMockTFile("no-class.md"),
-        createMockTFile("with-class.md"),
-      ];
-
-      mockApp.vault.getMarkdownFiles.mockReturnValue(mockFiles);
-      mockApp.metadataCache.getFileCache.mockImplementation((file: any) => {
-        if (file.basename === "no-class") {
-          return {
-            frontmatter: {
-              other_property: "value",
-            },
-          };
-        }
-        return {
-          frontmatter: {
-            exo__Instance_class: "exo__Ontology",
-          },
-        };
-      });
-
-      const result = settingTab["getOntologyAssets"]();
-
-      expect(result).toEqual(["with-class"]);
-    });
-
-    it("should ignore files with non-ontology classes", () => {
-      const mockFiles = [
-        createMockTFile("task.md"),
-        createMockTFile("project.md"),
-        createMockTFile("ontology.md"),
-      ];
-
-      mockApp.vault.getMarkdownFiles.mockReturnValue(mockFiles);
-      mockApp.metadataCache.getFileCache.mockImplementation((file: any) => {
-        if (file.basename === "task") {
-          return {
-            frontmatter: {
-              exo__Instance_class: "ems__Task",
-            },
-          };
-        } else if (file.basename === "project") {
-          return {
-            frontmatter: {
-              exo__Instance_class: "ems__Project",
-            },
-          };
-        }
-        return {
-          frontmatter: {
-            exo__Instance_class: "exo__Ontology",
-          },
-        };
-      });
-
-      const result = settingTab["getOntologyAssets"]();
-
-      expect(result).toEqual(["ontology"]);
-    });
-
-    it("should return empty array when no ontologies found", () => {
-      const mockFiles = [
-        createMockTFile("file1.md"),
-        createMockTFile("file2.md"),
-      ];
-
-      mockApp.vault.getMarkdownFiles.mockReturnValue(mockFiles);
-      mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "ems__Task",
-        },
-      });
-
-      const result = settingTab["getOntologyAssets"]();
-
-      expect(result).toEqual([]);
-    });
-  });
-
   describe("display", () => {
     it("should render all settings", () => {
-      const getOntologySpy = jest
-        .spyOn(settingTab as any, "getOntologyAssets")
-        .mockReturnValue(["Ontology1", "Ontology2"]);
-
       settingTab.display();
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
-      expect(getOntologySpy).toHaveBeenCalledTimes(1);
-      // 14 original settings (added autoAdjustPlannedEndTimestamp Issue #2142) + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 33
-      expect(MockSetting).toHaveBeenCalledTimes(33);
+      // 13 original settings (removed ontology dropdown, kept autoAdjustPlannedEndTimestamp Issue #2142) + 3 headings + 1 default template + 6 per-class templates + 5 status emojis + 1 reset button + 3 webhook settings (heading, toggle, add button) = 32
+      expect(MockSetting).toHaveBeenCalledTimes(32);
     });
 
-    it("should render ontology dropdown with correct options", () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([
-        "Ontology1",
-        "Ontology2",
-      ]);
-
-      let dropdownCallbacks: any[] = [];
-      MockSetting.mockImplementation((containerEl: any) => {
-        const setting = {
-          containerEl,
-          setName: jest.fn().mockReturnThis(),
-          setDesc: jest.fn().mockReturnThis(),
-          setHeading: jest.fn().mockReturnThis(),
-          addDropdown: jest.fn().mockImplementation((callback) => {
-            const dropdown = {
-              addOption: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            dropdownCallbacks.push({ dropdown, callback });
-            callback(dropdown);
-            return setting;
-          }),
-          addToggle: jest.fn().mockReturnThis(),
-          addText: jest.fn().mockImplementation((callback) => {
-            const text = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            callback(text);
-            return setting;
-          }),
-          addButton: jest.fn().mockImplementation((callback) => {
-            const button = {
-              setButtonText: jest.fn().mockReturnThis(),
-              onClick: jest.fn().mockReturnThis(),
-              setCta: jest.fn().mockReturnThis(),
-            };
-            callback(button);
-            return setting;
-          }),
-        };
-        return setting;
-      });
-
+    it("should render layout visibility toggle as first setting", () => {
       settingTab.display();
 
-      // First Setting should be the ontology dropdown
       const firstSetting = (MockSetting as jest.Mock).mock.results[0].value;
-      expect(firstSetting.setName).toHaveBeenCalledWith("Default ontology asset");
+      expect(firstSetting.setName).toHaveBeenCalledWith("Show layout");
       expect(firstSetting.setDesc).toHaveBeenCalledWith(
-        "Choose the ontology asset to use for created events"
-      );
-
-      // Check dropdown options
-      const { dropdown } = dropdownCallbacks[0];
-      expect(dropdown.addOption).toHaveBeenCalledWith("", "None (use events folder)");
-      expect(dropdown.addOption).toHaveBeenCalledWith("Ontology1", "Ontology1");
-      expect(dropdown.addOption).toHaveBeenCalledWith("Ontology2", "Ontology2");
-      expect(dropdown.setValue).toHaveBeenCalledWith("");
-    });
-
-    it("should handle ontology dropdown change", async () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue(["Ontology1"]);
-
-      // Track onChange callbacks for each dropdown
-      const onChangeCallbacks: Array<(value: string) => Promise<void>> = [];
-      MockSetting.mockImplementation((containerEl: any) => {
-        const setting = {
-          containerEl,
-          setName: jest.fn().mockReturnThis(),
-          setDesc: jest.fn().mockReturnThis(),
-          setHeading: jest.fn().mockReturnThis(),
-          addDropdown: jest.fn().mockImplementation((callback) => {
-            const dropdown = {
-              addOption: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockImplementation((cb) => {
-                onChangeCallbacks.push(cb);
-                return dropdown;
-              }),
-            };
-            callback(dropdown);
-            return setting;
-          }),
-          addToggle: jest.fn().mockReturnThis(),
-          addText: jest.fn().mockImplementation((callback) => {
-            const text = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            callback(text);
-            return setting;
-          }),
-          addButton: jest.fn().mockImplementation((callback) => {
-            const button = {
-              setButtonText: jest.fn().mockReturnThis(),
-              onClick: jest.fn().mockReturnThis(),
-              setCta: jest.fn().mockReturnThis(),
-            };
-            callback(button);
-            return setting;
-          }),
-        };
-        return setting;
-      });
-
-      settingTab.display();
-
-      // First dropdown onChange is for ontology
-      const ontologyOnChange = onChangeCallbacks[0];
-      if (ontologyOnChange) {
-        await ontologyOnChange("Ontology1");
-      }
-
-      expect(mockPlugin.settings.defaultOntologyAsset).toBe("Ontology1");
-      expect(mockPlugin.saveSettings).toHaveBeenCalled();
-
-      // Test clearing the value
-      if (ontologyOnChange) {
-        await ontologyOnChange("");
-      }
-
-      expect(mockPlugin.settings.defaultOntologyAsset).toBeNull();
-      expect(mockPlugin.saveSettings).toHaveBeenCalledTimes(2);
-    });
-
-    it("should render layout visibility toggle", () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
-      settingTab.display();
-
-      const secondSetting = (MockSetting as jest.Mock).mock.results[1].value;
-      expect(secondSetting.setName).toHaveBeenCalledWith("Show layout");
-      expect(secondSetting.setDesc).toHaveBeenCalledWith(
         "Display the automatic layout below metadata in reading mode"
       );
     });
 
     it("should handle layout visibility toggle change", async () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
       let toggleCallbacks: any[] = [];
       MockSetting.mockImplementation((containerEl: any) => {
         const setting = {
@@ -542,7 +191,7 @@ describe("ExocortexSettingTab", () => {
 
       settingTab.display();
 
-      // Second setting's toggle (layout visibility)
+      // First setting's toggle (layout visibility)
       const layoutToggle = toggleCallbacks[0];
       expect(layoutToggle.toggle.setValue).toHaveBeenCalledWith(true);
 
@@ -557,20 +206,16 @@ describe("ExocortexSettingTab", () => {
     });
 
     it("should render properties section toggle", () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
       settingTab.display();
 
-      const thirdSetting = (MockSetting as jest.Mock).mock.results[2].value;
-      expect(thirdSetting.setName).toHaveBeenCalledWith("Show properties section");
-      expect(thirdSetting.setDesc).toHaveBeenCalledWith(
+      const secondSetting = (MockSetting as jest.Mock).mock.results[1].value;
+      expect(secondSetting.setName).toHaveBeenCalledWith("Show properties section");
+      expect(secondSetting.setDesc).toHaveBeenCalledWith(
         "Display the properties table in the layout"
       );
     });
 
     it("should handle properties section toggle change", async () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
       let toggleCallbacks: any[] = [];
       MockSetting.mockImplementation((containerEl: any) => {
         const setting = {
@@ -616,7 +261,7 @@ describe("ExocortexSettingTab", () => {
 
       settingTab.display();
 
-      // Third setting's toggle (properties section)
+      // Second setting's toggle (properties section)
       const propertiesToggle = toggleCallbacks[1];
       expect(propertiesToggle.toggle.setValue).toHaveBeenCalledWith(true);
 
@@ -630,20 +275,16 @@ describe("ExocortexSettingTab", () => {
     });
 
     it("should render archived assets toggle", () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
       settingTab.display();
 
-      const fourthSetting = (MockSetting as jest.Mock).mock.results[3].value;
-      expect(fourthSetting.setName).toHaveBeenCalledWith("Show archived assets");
-      expect(fourthSetting.setDesc).toHaveBeenCalledWith(
+      const thirdSetting = (MockSetting as jest.Mock).mock.results[2].value;
+      expect(thirdSetting.setName).toHaveBeenCalledWith("Show archived assets");
+      expect(thirdSetting.setDesc).toHaveBeenCalledWith(
         "Display archived assets in relations table with visual distinction"
       );
     });
 
     it("should handle archived assets toggle change", async () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
       let toggleCallbacks: any[] = [];
       MockSetting.mockImplementation((containerEl: any) => {
         const setting = {
@@ -689,7 +330,7 @@ describe("ExocortexSettingTab", () => {
 
       settingTab.display();
 
-      // Fourth setting's toggle (archived assets)
+      // Third setting's toggle (archived assets)
       const archivedToggle = toggleCallbacks[2];
       expect(archivedToggle.toggle.setValue).toHaveBeenCalledWith(false);
 
@@ -703,20 +344,16 @@ describe("ExocortexSettingTab", () => {
     });
 
     it("should render Daily Note Projects toggle", () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
       settingTab.display();
 
-      const fifthSetting = (MockSetting as jest.Mock).mock.results[4].value;
-      expect(fifthSetting.setName).toHaveBeenCalledWith("Show projects in daily notes");
-      expect(fifthSetting.setDesc).toHaveBeenCalledWith(
+      const fourthSetting = (MockSetting as jest.Mock).mock.results[3].value;
+      expect(fourthSetting.setName).toHaveBeenCalledWith("Show projects in daily notes");
+      expect(fourthSetting.setDesc).toHaveBeenCalledWith(
         "Display the projects section in the layout for daily notes"
       );
     });
 
     it("should handle Daily Note Projects toggle change", async () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
       let toggleCallbacks: any[] = [];
       MockSetting.mockImplementation((containerEl: any) => {
         const setting = {
@@ -762,7 +399,7 @@ describe("ExocortexSettingTab", () => {
 
       settingTab.display();
 
-      // Fifth setting's toggle (Daily Note Projects)
+      // Fourth setting's toggle (Daily Note Projects)
       const dailyProjectsToggle = toggleCallbacks[3];
       expect(dailyProjectsToggle.toggle.setValue).toHaveBeenCalledWith(true);
 
@@ -776,20 +413,16 @@ describe("ExocortexSettingTab", () => {
     });
 
     it("should render Dynamic Property Fields toggle", () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
       settingTab.display();
 
-      const sixthSetting = (MockSetting as jest.Mock).mock.results[5].value;
-      expect(sixthSetting.setName).toHaveBeenCalledWith("Use dynamic property fields");
-      expect(sixthSetting.setDesc).toHaveBeenCalledWith(
+      const fifthSetting = (MockSetting as jest.Mock).mock.results[4].value;
+      expect(fifthSetting.setName).toHaveBeenCalledWith("Use dynamic property fields");
+      expect(fifthSetting.setDesc).toHaveBeenCalledWith(
         "Generate modal fields from ontology (experimental)"
       );
     });
 
     it("should handle Dynamic Property Fields toggle change", async () => {
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([]);
-
       let toggleCallbacks: any[] = [];
       MockSetting.mockImplementation((containerEl: any) => {
         const setting = {
@@ -835,7 +468,7 @@ describe("ExocortexSettingTab", () => {
 
       settingTab.display();
 
-      // Sixth setting's toggle (Dynamic Property Fields)
+      // Fifth setting's toggle (Dynamic Property Fields)
       const dynamicFieldsToggle = toggleCallbacks[4];
       expect(dynamicFieldsToggle.toggle.setValue).toHaveBeenCalledWith(false);
 
@@ -846,62 +479,6 @@ describe("ExocortexSettingTab", () => {
       expect(mockPlugin.settings.useDynamicPropertyFields).toBe(true);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
       // Should NOT call refreshLayout (unlike other toggles)
-    });
-
-    it("should set dropdown value to existing setting", () => {
-      mockPlugin.settings.defaultOntologyAsset = "ExistingOntology";
-      jest.spyOn(settingTab as any, "getOntologyAssets").mockReturnValue([
-        "ExistingOntology",
-        "OtherOntology",
-      ]);
-
-      // Track dropdown values by dropdown index
-      const dropdownValues: string[] = [];
-      MockSetting.mockImplementation((containerEl: any) => {
-        const setting = {
-          containerEl,
-          setName: jest.fn().mockReturnThis(),
-          setDesc: jest.fn().mockReturnThis(),
-          setHeading: jest.fn().mockReturnThis(),
-          addDropdown: jest.fn().mockImplementation((callback) => {
-            const dropdown = {
-              addOption: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockImplementation((value: string) => {
-                dropdownValues.push(value);
-                return dropdown;
-              }),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            callback(dropdown);
-            return setting;
-          }),
-          addToggle: jest.fn().mockReturnThis(),
-          addText: jest.fn().mockImplementation((callback) => {
-            const text = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            callback(text);
-            return setting;
-          }),
-          addButton: jest.fn().mockImplementation((callback) => {
-            const button = {
-              setButtonText: jest.fn().mockReturnThis(),
-              onClick: jest.fn().mockReturnThis(),
-              setCta: jest.fn().mockReturnThis(),
-            };
-            callback(button);
-            return setting;
-          }),
-        };
-        return setting;
-      });
-
-      settingTab.display();
-
-      // First dropdown is the ontology dropdown, which should have ExistingOntology
-      expect(dropdownValues[0]).toBe("ExistingOntology");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/SetFocusAreaCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SetFocusAreaCommand.test.ts
@@ -52,7 +52,6 @@ describe("SetFocusAreaCommand", () => {
     mockPlugin = {
       settings: {
         activeFocusArea: null,
-        defaultOntologyAsset: null,
       },
       saveSettings: jest.fn(),
       refreshLayout: jest.fn(),

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.fixtures.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.fixtures.ts
@@ -112,7 +112,6 @@ export const setupCommandManagerTest = (): CommandManagerTestContext => {
       showPropertiesSection: true,
       layoutVisible: true,
       showArchivedAssets: false,
-      defaultOntologyAsset: null,
     },
     saveSettings: jest.fn().mockResolvedValue(undefined),
     refreshLayout: jest.fn(),


### PR DESCRIPTION
## Summary

Remove the deprecated "Default ontology asset" setting from the Obsidian plugin Settings UI and delete all associated logic, as this configuration is no longer needed and adds unnecessary complexity.

## Changes

- **ExocortexSettingTab.ts**: Removed UI dropdown and `getOntologyAssets()` method
- **ExocortexSettings.ts**: Removed `defaultOntologyAsset` from interface and `DEFAULT_SETTINGS`
- **SetFocusAreaCommand.ts**: Removed `setDefaultOntologyAsset()` call
- **SessionEventService.ts**: Simplified to always use default folder and ontology reference (`!kitelev`)
- **Tests**: Updated all test fixtures to remove `defaultOntologyAsset` references

## Testing

- [x] Build passes
- [x] All unit tests pass (678 tests)
- [x] Lint passes (0 errors)
- [x] TypeScript check passes

## Acceptance Criteria

- [x] UI dropdown removed from Settings
- [x] `getOntologyAssets()` method removed
- [x] `defaultOntologyAsset` removed from settings interface
- [x] `setDefaultOntologyAsset()` removed from command
- [x] SessionEventService simplified to use default behavior
- [x] Tests updated

Closes #2145