### PR TITLE
fix(table): align virtualized table columns with header widths

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
@@ -284,7 +284,13 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
   // This fixes misalignment caused by scrollbar width difference (Issue #941, #2116)
   const [scrollbarWidth, setScrollbarWidth] = useState(0);
 
-  // Measure scrollbar width when scroll container is mounted
+  // Track computed pixel widths for virtualized cells (Issue #2152)
+  // When rows have position: absolute, table-layout: fixed doesn't work
+  // We measure header cell widths and apply them explicitly to body cells
+  const headerTableRef = useRef<HTMLTableElement>(null);
+  const [computedColumnWidths, setComputedColumnWidths] = useState<number[]>([]);
+
+  // Measure scrollbar width and column widths when scroll container is mounted
   const measureWidths = useCallback(() => {
     if (!parentRef.current) return;
 
@@ -292,6 +298,17 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
     // Scrollbar width = total width - client width (visible content area)
     const sbWidth = scrollContainer.offsetWidth - scrollContainer.clientWidth;
     setScrollbarWidth(sbWidth);
+
+    // Measure header cell widths for virtualized row alignment (Issue #2152)
+    if (headerTableRef.current) {
+      const headerCells = headerTableRef.current.querySelectorAll("thead th");
+      const widths: number[] = [];
+      headerCells.forEach((cell) => {
+        // Use offsetWidth to get the actual rendered pixel width
+        widths.push((cell as HTMLElement).offsetWidth);
+      });
+      setComputedColumnWidths(widths);
+    }
   }, []);
 
   // Measure widths when virtualized mode is active and parent is mounted
@@ -301,7 +318,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
     }
   }, [shouldVirtualize, isParentMounted, measureWidths]);
 
-  // Re-measure on window resize (scrollbar might appear/disappear)
+  // Re-measure on window resize (scrollbar might appear/disappear, column widths change)
   useEffect(() => {
     if (!shouldVirtualize) return;
 
@@ -346,7 +363,8 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
   };
 
   // Render cell
-  const renderCell = (row: TableRow, column: LayoutColumn) => {
+  // computedWidth is used in virtualized mode to apply measured pixel widths (Issue #2152)
+  const renderCell = (row: TableRow, column: LayoutColumn, columnIndex: number, useComputedWidth: boolean) => {
     const value = row.values[column.uid];
     const CellRenderer = getCellRenderer(column.renderer);
     const isEditing =
@@ -354,11 +372,17 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
     const isClickable =
       options.editable && column.editable && !isEditing;
 
+    // In virtualized mode, use computed pixel widths to ensure alignment
+    // when rows have position: absolute (Issue #2152)
+    const cellWidth = useComputedWidth && computedColumnWidths[columnIndex]
+      ? `${computedColumnWidths[columnIndex]}px`
+      : parseColumnWidth(column.width);
+
     return (
       <td
         key={column.uid}
         className={`exo-layout-cell exo-layout-cell-${column.renderer || "text"} ${isEditing ? "exo-layout-cell-editing" : ""} ${isClickable ? "exo-layout-cell-editable" : ""}`}
-        style={{ width: parseColumnWidth(column.width) }}
+        style={{ width: cellWidth }}
         onClick={() => !isEditing && handleCellClick(row.id, column)}
       >
         <CellRenderer
@@ -396,7 +420,8 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
   };
 
   // Render row
-  const renderRow = (row: TableRow, _index: number, style?: React.CSSProperties) => {
+  // useComputedWidth is true for virtualized rows to apply measured pixel widths (Issue #2152)
+  const renderRow = (row: TableRow, _index: number, style?: React.CSSProperties, useComputedWidth = false) => {
     return (
       <tr
         key={row.id}
@@ -405,7 +430,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
         data-path={row.path}
         style={style}
       >
-        {columns.map((column) => renderCell(row, column))}
+        {columns.map((column, columnIndex) => renderCell(row, column, columnIndex, useComputedWidth))}
         {renderActionsCell(row)}
       </tr>
     );
@@ -492,7 +517,8 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
           paddingRight: scrollbarWidth > 0 ? `${scrollbarWidth}px` : undefined,
         }}
       >
-        <table className="exo-layout-table exo-layout-table-header-fixed">
+        {/* Header table with ref for measuring column widths (Issue #2152) */}
+        <table ref={headerTableRef} className="exo-layout-table exo-layout-table-header-fixed">
           {renderColGroup()}
           {renderTableHeader()}
         </table>
@@ -525,6 +551,9 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
               {virtualItems.length > 0 ? (
                 virtualItems.map((virtualRow) => {
                   const row = sortedRows[virtualRow.index];
+                  // Pass useComputedWidth=true for virtualized rows (Issue #2152)
+                  // This ensures cells use measured pixel widths instead of
+                  // percentage/auto widths that don't work with position: absolute
                   return renderRow(row, virtualRow.index, {
                     position: "absolute",
                     top: 0,
@@ -532,7 +561,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
                     width: "100%",
                     height: `${virtualRow.size}px`,
                     transform: `translateY(${virtualRow.start}px)`,
-                  });
+                  }, true);
                 })
               ) : (
                 // Fallback: render all rows if virtualizer hasn't initialized

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/TableLayoutRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/TableLayoutRenderer.test.tsx
@@ -20,11 +20,13 @@ import { LayoutType } from "@plugin/domain/layout";
 import type { TableRow } from "@plugin/presentation/renderers/cell-renderers";
 
 // Mock @tanstack/react-virtual
+const mockUseVirtualizer = jest.fn(() => ({
+  getVirtualItems: () => [],
+  getTotalSize: () => 0,
+}));
+
 jest.mock("@tanstack/react-virtual", () => ({
-  useVirtualizer: jest.fn(() => ({
-    getVirtualItems: () => [],
-    getTotalSize: () => 0,
-  })),
+  useVirtualizer: (...args: unknown[]) => mockUseVirtualizer(...args),
 }));
 
 describe("TableLayoutRenderer", () => {
@@ -421,6 +423,275 @@ describe("TableLayoutRenderer", () => {
       fireEvent.click(link);
 
       expect(onLinkClick).toHaveBeenCalledWith("target", expect.any(Object));
+    });
+  });
+
+  describe("Issue #2152: Virtualized Table Column Alignment", () => {
+    // These tests verify that virtualized rows maintain proper column widths
+    // even when position: absolute is applied.
+    //
+    // The fix measures header cell widths and applies them as explicit pixel
+    // widths to virtualized body cells. This ensures cells stay aligned even
+    // when rows have position: absolute (which breaks table-layout: fixed).
+    //
+    // Note: In jsdom, offsetWidth returns 0, so we test the rendering structure
+    // rather than actual computed widths. The important behavior is that:
+    // 1. Virtualized mode renders the header table with a ref for measurement
+    // 2. Virtualized rows get useComputedWidth=true passed to renderRow
+    // 3. The fallback to column.width works when computed widths aren't available
+
+    afterEach(() => {
+      // Reset the mock after each test
+      mockUseVirtualizer.mockReset();
+      mockUseVirtualizer.mockImplementation(() => ({
+        getVirtualItems: () => [],
+        getTotalSize: () => 0,
+      }));
+    });
+
+    it("renders virtualized mode with proper structure for column width synchronization", () => {
+      // Mock virtualizer to return virtual items (simulating >50 rows)
+      mockUseVirtualizer.mockImplementation(() => ({
+        getVirtualItems: () => [
+          { index: 0, start: 0, size: 35, key: "0" },
+          { index: 1, start: 35, size: 35, key: "1" },
+          { index: 2, start: 70, size: 35, key: "2" },
+        ],
+        getTotalSize: () => 1750, // 50 rows * 35px
+      }));
+
+      const columns = [
+        createColumn({ uid: "col-1", header: "Name", width: "200px" }),
+        createColumn({ uid: "col-2", header: "Status", width: "100px" }),
+        createColumn({ uid: "col-3", header: "Date", width: "150px" }),
+      ];
+      const layout = createLayout(columns);
+
+      // Create >50 rows to trigger virtualization
+      const rows = Array.from({ length: 51 }, (_, i) =>
+        createRow({
+          id: `row-${i}`,
+          values: {
+            "col-1": `Name ${i}`,
+            "col-2": `Status ${i}`,
+            "col-3": `2024-01-${String(i + 1).padStart(2, "0")}`,
+          },
+        })
+      );
+
+      const { container } = render(
+        <TableLayoutRenderer
+          layout={layout}
+          rows={rows}
+          options={{ virtualize: true }}
+        />
+      );
+
+      // Check that virtualized mode is active
+      expect(container.querySelector(".exo-layout-virtualized")).toBeInTheDocument();
+
+      // Verify the structure for width synchronization:
+      // 1. Header table exists with header-fixed class
+      const headerTable = container.querySelector(".exo-layout-table-header-fixed");
+      expect(headerTable).toBeInTheDocument();
+
+      // 2. Virtual table exists for body rows
+      const virtualTable = container.querySelector(".exo-layout-virtual-table");
+      expect(virtualTable).toBeInTheDocument();
+
+      // 3. Both tables have colgroups with matching column count
+      const headerCols = headerTable?.querySelectorAll("colgroup col");
+      const bodyCols = virtualTable?.querySelectorAll("colgroup col");
+      expect(headerCols?.length).toBe(3);
+      expect(bodyCols?.length).toBe(3);
+
+      // 4. Body cells have width styles (fallback to column.width when computed widths unavailable)
+      const cells = virtualTable?.querySelectorAll("tbody tr:first-child td");
+      expect(cells?.length).toBe(3);
+      // In jsdom, computed widths are 0, so cells use column.width fallback
+      expect(cells?.[0]).toHaveStyle({ width: "200px" });
+      expect(cells?.[1]).toHaveStyle({ width: "100px" });
+      expect(cells?.[2]).toHaveStyle({ width: "150px" });
+    });
+
+    it("colgroup widths match between header and body tables in virtualized mode", () => {
+      mockUseVirtualizer.mockImplementation(() => ({
+        getVirtualItems: () => [
+          { index: 0, start: 0, size: 35, key: "0" },
+        ],
+        getTotalSize: () => 1750,
+      }));
+
+      const columns = [
+        createColumn({ uid: "col-1", header: "Name", width: "40%" }),
+        createColumn({ uid: "col-2", header: "Status", width: "30%" }),
+        createColumn({ uid: "col-3", header: "Actions", width: "30%" }),
+      ];
+      const layout = createLayout(columns);
+
+      const rows = Array.from({ length: 51 }, (_, i) =>
+        createRow({
+          id: `row-${i}`,
+          values: {
+            "col-1": `Name ${i}`,
+            "col-2": `Status ${i}`,
+            "col-3": `Action ${i}`,
+          },
+        })
+      );
+
+      const { container } = render(
+        <TableLayoutRenderer
+          layout={layout}
+          rows={rows}
+          options={{ virtualize: true }}
+        />
+      );
+
+      // Both header table and body table should have matching colgroups
+      const colgroups = container.querySelectorAll("colgroup");
+      expect(colgroups.length).toBe(2); // One in header, one in body
+
+      // Get col elements from both tables
+      const headerCols = colgroups[0]?.querySelectorAll("col");
+      const bodyCols = colgroups[1]?.querySelectorAll("col");
+
+      expect(headerCols?.length).toBe(bodyCols?.length);
+
+      // Widths should match
+      headerCols?.forEach((col, i) => {
+        const bodyCol = bodyCols?.[i];
+        expect(col.style.width).toBe(bodyCol?.style.width);
+      });
+    });
+
+    it("virtualized rows have position: absolute style applied", () => {
+      mockUseVirtualizer.mockImplementation(() => ({
+        getVirtualItems: () => [
+          { index: 0, start: 0, size: 35, key: "0" },
+          { index: 1, start: 35, size: 35, key: "1" },
+        ],
+        getTotalSize: () => 1750,
+      }));
+
+      const columns = [
+        createColumn({ uid: "col-1", header: "Name", width: "200px" }),
+        createColumn({ uid: "col-2", header: "Status", width: "100px" }),
+      ];
+      const layout = createLayout(columns);
+
+      const rows = Array.from({ length: 51 }, (_, i) =>
+        createRow({
+          id: `row-${i}`,
+          values: {
+            "col-1": `Name ${i}`,
+            "col-2": `Status ${i}`,
+          },
+        })
+      );
+
+      const { container } = render(
+        <TableLayoutRenderer
+          layout={layout}
+          rows={rows}
+          options={{ virtualize: true }}
+        />
+      );
+
+      // Virtualized rows should have position: absolute
+      const virtualTableRows = container.querySelectorAll(".exo-layout-virtual-table tbody tr");
+      expect(virtualTableRows.length).toBe(2);
+
+      virtualTableRows.forEach((row) => {
+        expect(row).toHaveStyle({ position: "absolute" });
+      });
+    });
+
+    it("handles window resize events in virtualized mode", () => {
+      mockUseVirtualizer.mockImplementation(() => ({
+        getVirtualItems: () => [
+          { index: 0, start: 0, size: 35, key: "0" },
+        ],
+        getTotalSize: () => 1750,
+      }));
+
+      const columns = [
+        createColumn({ uid: "col-1", header: "Name", width: "200px" }),
+        createColumn({ uid: "col-2", header: "Status", width: "100px" }),
+      ];
+      const layout = createLayout(columns);
+
+      const rows = Array.from({ length: 51 }, (_, i) =>
+        createRow({
+          id: `row-${i}`,
+          values: {
+            "col-1": `Name ${i}`,
+            "col-2": `Status ${i}`,
+          },
+        })
+      );
+
+      const { container } = render(
+        <TableLayoutRenderer
+          layout={layout}
+          rows={rows}
+          options={{ virtualize: true }}
+        />
+      );
+
+      // Verify virtualized container is rendered
+      expect(container.querySelector(".exo-layout-virtualized")).toBeInTheDocument();
+
+      // Trigger resize event - should not throw
+      fireEvent(window, new Event("resize"));
+
+      // Cells should still have width styles after resize
+      const cells = container.querySelectorAll(".exo-layout-virtual-table tbody td");
+      expect(cells.length).toBeGreaterThanOrEqual(2);
+      expect(cells[0]).toHaveStyle({ width: "200px" });
+      expect(cells[1]).toHaveStyle({ width: "100px" });
+    });
+
+    it("non-virtualized tables render normally", () => {
+      // Reset mock to default (no virtual items)
+      mockUseVirtualizer.mockImplementation(() => ({
+        getVirtualItems: () => [],
+        getTotalSize: () => 0,
+      }));
+
+      const columns = [
+        createColumn({ uid: "col-1", header: "Name", width: "200px" }),
+        createColumn({ uid: "col-2", header: "Status", width: "100px" }),
+      ];
+      const layout = createLayout(columns);
+
+      // Less than 50 rows - should not trigger virtualization
+      const rows = Array.from({ length: 10 }, (_, i) =>
+        createRow({
+          id: `row-${i}`,
+          values: {
+            "col-1": `Name ${i}`,
+            "col-2": `Status ${i}`,
+          },
+        })
+      );
+
+      const { container } = render(
+        <TableLayoutRenderer
+          layout={layout}
+          rows={rows}
+          options={{ virtualize: true }}
+        />
+      );
+
+      // Should NOT be in virtualized mode
+      expect(container.querySelector(".exo-layout-virtualized")).not.toBeInTheDocument();
+
+      // Regular table cells should still have width from column definition
+      const cells = container.querySelectorAll("tbody td");
+      expect(cells.length).toBeGreaterThanOrEqual(2);
+      expect(cells[0]).toHaveStyle({ width: "200px" });
+      expect(cells[1]).toHaveStyle({ width: "100px" });
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes column misalignment in virtualized tables (>50 rows) by measuring header cell widths and applying them explicitly to body cells.

## Problem

When tables exceed 50 rows, virtualization applies `position: absolute` to `<tr>` elements for scroll performance. This breaks `table-layout: fixed` because:
1. Absolutely positioned rows are removed from document flow
2. `<td>` cells lose their relationship with `<colgroup>` width definitions
3. Cells collapse to minimum content width, appearing "slammed together"

## Solution

Implement **Option B** from the issue: measure header widths and apply explicitly.

1. Add `headerTableRef` to measure header cell `offsetWidth` values after render
2. Store computed pixel widths in state (`computedColumnWidths`)
3. Pass `useComputedWidth=true` to virtualized rows in `renderRow()`
4. Apply measured pixel widths instead of percentage/auto values when rendering cells
5. Re-measure on window resize to maintain alignment

## Changes

- `TableLayoutRenderer.tsx`:
  - Add `headerTableRef` and `computedColumnWidths` state
  - Update `measureWidths()` to also measure header cell widths
  - Update `renderCell()` to accept and use computed widths
  - Update `renderRow()` to pass `useComputedWidth` flag
  - Apply computed widths in virtualized mode

- `TableLayoutRenderer.test.tsx`:
  - Add 5 new tests for Issue #2152
  - Test virtualized mode structure
  - Test colgroup width matching
  - Test position: absolute on rows
  - Test resize event handling
  - Test non-virtualized fallback

## Testing

- [x] Added 5 regression tests for Issue #2152
- [x] All 24 TableLayoutRenderer tests pass
- [x] Full unit test suite passes (678 tests)
- [x] Build succeeds
- [x] Lint passes (warnings only, no errors)

## Acceptance Criteria

- [x] Tables with >50 rows display correct column alignment
- [x] Column widths match between header and body rows
- [x] Virtualization performance is not degraded (only measures on mount/resize)
- [x] Works correctly when window is resized

Fixes #2152