### PR TITLE
feat(cli): add progress indicator for long-running SPARQL queries

### DIFF
--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -22,6 +22,7 @@ import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { ResponseBuilder, type QueryResult, type ConstructResult } from "../responses/index.js";
 import { CacheManager } from "../cache/CacheManager.js";
+import { ProgressIndicator } from "../utils/ProgressIndicator.js";
 
 export interface SparqlQueryOptions {
   vault: string;
@@ -133,18 +134,21 @@ export function sparqlQueryCommand(): Command {
           console.log();
         }
 
-        if (outputFormat === "text") {
-          console.log(`🎯 Executing query...`);
-        }
         const execStartTime = Date.now();
-
         const executor = new QueryExecutor(tripleStore);
+
+        // Progress indicator for long-running query execution (TTY mode only)
+        const progressIndicator = outputFormat === "text"
+          ? new ProgressIndicator("Executing query", { delayMs: 2000 })
+          : null;
 
         // Execute based on query type
         if (executor.isConstructQuery(algebra)) {
           // CONSTRUCT query - returns triples
+          progressIndicator?.start();
           const resultTriples = await executor.executeConstruct(algebra);
           const execDuration = Date.now() - execStartTime;
+          progressIndicator?.stop();
           const totalDuration = Date.now() - startTime;
 
           if (outputFormat === "json") {
@@ -188,8 +192,10 @@ export function sparqlQueryCommand(): Command {
           }
         } else {
           // SELECT query - returns solution mappings
+          progressIndicator?.start();
           const results = await executor.executeAll(algebra);
           const execDuration = Date.now() - execStartTime;
+          progressIndicator?.stop();
           const totalDuration = Date.now() - startTime;
 
           if (outputFormat === "json") {

--- a/packages/cli/src/utils/ProgressIndicator.ts
+++ b/packages/cli/src/utils/ProgressIndicator.ts
@@ -1,0 +1,181 @@
+import ora, { type Ora } from "ora";
+
+export interface ProgressIndicatorOptions {
+  /**
+   * Delay in milliseconds before showing the spinner.
+   * This prevents visual noise for fast operations.
+   * @default 2000
+   */
+  delayMs?: number;
+}
+
+/**
+ * ProgressIndicator provides visual feedback for long-running CLI operations.
+ *
+ * Features:
+ * - Shows spinner only after delay threshold (default 2s) to avoid visual noise
+ * - Displays elapsed time while running
+ * - Respects TTY mode - no output when piped
+ * - Clean completion/failure messages
+ *
+ * @example
+ * ```typescript
+ * const progress = new ProgressIndicator("Loading vault");
+ * progress.start();
+ * // ... long operation ...
+ * progress.succeed("Loaded 1000 triples");
+ *
+ * // Or use wrap for async operations
+ * const result = await progress.wrap(async () => {
+ *   return await loadData();
+ * });
+ * ```
+ */
+export class ProgressIndicator {
+  private readonly spinner: Ora;
+  private readonly message: string;
+  private readonly delayMs: number;
+  private delayTimeout: ReturnType<typeof setTimeout> | null = null;
+  private updateInterval: ReturnType<typeof setInterval> | null = null;
+  private startTime: number = 0;
+  private isSpinnerVisible: boolean = false;
+  private readonly isTTY: boolean;
+
+  constructor(message: string, options: ProgressIndicatorOptions = {}) {
+    this.message = message;
+    this.delayMs = options.delayMs ?? 2000;
+    this.isTTY = Boolean(process.stdout.isTTY);
+    this.spinner = ora({
+      text: message,
+      // Disable spinner in non-TTY mode
+      isEnabled: this.isTTY,
+    });
+  }
+
+  /**
+   * Start the progress indicator.
+   * The spinner will only become visible after the configured delay.
+   */
+  start(): void {
+    if (!this.isTTY) {
+      // No visual indicator in non-TTY mode
+      return;
+    }
+
+    this.startTime = Date.now();
+
+    // Schedule spinner to appear after delay
+    this.delayTimeout = setTimeout(() => {
+      this.showSpinner();
+    }, this.delayMs);
+  }
+
+  private showSpinner(): void {
+    if (!this.isTTY || this.isSpinnerVisible) {
+      return;
+    }
+
+    this.isSpinnerVisible = true;
+    this.updateSpinnerText();
+    this.spinner.start();
+
+    // Start interval to update elapsed time
+    this.updateInterval = setInterval(() => {
+      this.updateSpinnerText();
+    }, 1000);
+  }
+
+  private updateSpinnerText(): void {
+    const elapsed = Date.now() - this.startTime;
+    const formattedTime = this.formatElapsedTime(elapsed);
+    this.spinner.text = `${this.message} (${formattedTime})`;
+  }
+
+  private formatElapsedTime(ms: number): string {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+
+    if (minutes > 0) {
+      return `${minutes}m ${seconds}s`;
+    }
+    return `${seconds}s`;
+  }
+
+  private cleanup(): void {
+    if (this.delayTimeout) {
+      clearTimeout(this.delayTimeout);
+      this.delayTimeout = null;
+    }
+    if (this.updateInterval) {
+      clearInterval(this.updateInterval);
+      this.updateInterval = null;
+    }
+  }
+
+  /**
+   * Stop the progress indicator with a success message.
+   * If the operation completed before the delay threshold,
+   * no visual output is produced.
+   */
+  succeed(message?: string): void {
+    this.cleanup();
+
+    if (this.isSpinnerVisible) {
+      this.spinner.succeed(message);
+    }
+    this.isSpinnerVisible = false;
+  }
+
+  /**
+   * Stop the progress indicator with a failure message.
+   * If the operation failed before the delay threshold,
+   * no visual output is produced.
+   */
+  fail(message?: string): void {
+    this.cleanup();
+
+    if (this.isSpinnerVisible) {
+      this.spinner.fail(message);
+    }
+    this.isSpinnerVisible = false;
+  }
+
+  /**
+   * Stop the progress indicator without any completion message.
+   */
+  stop(): void {
+    this.cleanup();
+
+    if (this.isSpinnerVisible) {
+      this.spinner.stop();
+    }
+    this.isSpinnerVisible = false;
+  }
+
+  /**
+   * Wrap an async operation with progress indication.
+   * Automatically handles start/succeed/fail lifecycle.
+   *
+   * @param operation - The async operation to execute
+   * @param successMessage - Optional message to show on success
+   * @returns The result of the operation
+   * @throws Rethrows any error from the operation after showing failure
+   */
+  async wrap<T>(
+    operation: () => Promise<T>,
+    successMessage?: string
+  ): Promise<T> {
+    this.start();
+
+    try {
+      const result = await operation();
+      this.succeed(successMessage);
+      return result;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Operation failed";
+      this.fail(errorMessage);
+      throw error;
+    }
+  }
+}

--- a/packages/cli/tests/unit/utils/ProgressIndicator.test.ts
+++ b/packages/cli/tests/unit/utils/ProgressIndicator.test.ts
@@ -1,0 +1,285 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+// Mock ora - must be before importing ProgressIndicator
+const mockOraInstance = {
+  start: jest.fn().mockReturnThis(),
+  stop: jest.fn().mockReturnThis(),
+  succeed: jest.fn().mockReturnThis(),
+  fail: jest.fn().mockReturnThis(),
+  text: "",
+};
+
+const mockOra = jest.fn().mockReturnValue(mockOraInstance);
+
+jest.unstable_mockModule("ora", () => ({
+  default: mockOra,
+}));
+
+// Import after mocking
+const { ProgressIndicator } = await import("../../../src/utils/ProgressIndicator.js");
+
+describe("ProgressIndicator", () => {
+  let originalIsTTY: boolean | undefined;
+  let setTimeoutSpy: jest.SpiedFunction<typeof setTimeout>;
+  let clearTimeoutSpy: jest.SpiedFunction<typeof clearTimeout>;
+  let setIntervalSpy: jest.SpiedFunction<typeof setInterval>;
+  let clearIntervalSpy: jest.SpiedFunction<typeof clearInterval>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalIsTTY = process.stdout.isTTY;
+
+    // Mock timers
+    jest.useFakeTimers();
+    setTimeoutSpy = jest.spyOn(global, "setTimeout");
+    clearTimeoutSpy = jest.spyOn(global, "clearTimeout");
+    setIntervalSpy = jest.spyOn(global, "setInterval");
+    clearIntervalSpy = jest.spyOn(global, "clearInterval");
+
+    // Reset mock instance
+    mockOraInstance.start.mockClear();
+    mockOraInstance.stop.mockClear();
+    mockOraInstance.succeed.mockClear();
+    mockOraInstance.fail.mockClear();
+  });
+
+  afterEach(() => {
+    process.stdout.isTTY = originalIsTTY;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should create indicator with default delay of 2000ms", () => {
+      const indicator = new ProgressIndicator("Testing");
+      expect(indicator).toBeDefined();
+    });
+
+    it("should create indicator with custom delay", () => {
+      const indicator = new ProgressIndicator("Testing", { delayMs: 5000 });
+      expect(indicator).toBeDefined();
+    });
+  });
+
+  describe("start", () => {
+    it("should NOT show spinner immediately for fast operations", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+
+      // Spinner should not be started immediately
+      expect(mockOraInstance.start).not.toHaveBeenCalled();
+    });
+
+    it("should show spinner after 2000ms delay (default)", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+
+      // Advance time by 1999ms - should not show spinner
+      jest.advanceTimersByTime(1999);
+      expect(mockOraInstance.start).not.toHaveBeenCalled();
+
+      // Advance by 1 more ms (total 2000ms) - should show spinner
+      jest.advanceTimersByTime(1);
+      expect(mockOraInstance.start).toHaveBeenCalled();
+    });
+
+    it("should show spinner after custom delay", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading", { delayMs: 3000 });
+
+      indicator.start();
+
+      jest.advanceTimersByTime(2999);
+      expect(mockOraInstance.start).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      expect(mockOraInstance.start).toHaveBeenCalled();
+    });
+
+    it("should NOT show spinner in non-TTY mode", () => {
+      process.stdout.isTTY = false;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+
+      // Even after delay, should not show spinner
+      jest.advanceTimersByTime(5000);
+      expect(mockOraInstance.start).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stop with success", () => {
+    it("should stop spinner cleanly if it was shown", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+      jest.advanceTimersByTime(2000); // Trigger spinner display
+
+      indicator.succeed("Done!");
+
+      expect(mockOraInstance.succeed).toHaveBeenCalledWith("Done!");
+    });
+
+    it("should NOT show any spinner output for fast operations (<2s)", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+      jest.advanceTimersByTime(1500); // Less than 2s
+
+      indicator.succeed("Done!");
+
+      // Spinner was never started, so succeed should not be called
+      expect(mockOraInstance.start).not.toHaveBeenCalled();
+      expect(mockOraInstance.succeed).not.toHaveBeenCalled();
+    });
+
+    it("should clear pending timeout when stopped early", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+      indicator.succeed("Done!");
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("stop with failure", () => {
+    it("should stop spinner with error message if shown", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+      jest.advanceTimersByTime(2000);
+
+      indicator.fail("Error occurred");
+
+      expect(mockOraInstance.fail).toHaveBeenCalledWith("Error occurred");
+    });
+
+    it("should NOT show any spinner output for fast failing operations (<2s)", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+      jest.advanceTimersByTime(500);
+
+      indicator.fail("Error");
+
+      expect(mockOraInstance.start).not.toHaveBeenCalled();
+      expect(mockOraInstance.fail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("elapsed time display", () => {
+    it("should update spinner text with elapsed time while running", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+
+      // Trigger spinner to show
+      jest.advanceTimersByTime(2000);
+      expect(mockOraInstance.start).toHaveBeenCalled();
+
+      // Advance 1 more second - should update text with elapsed time
+      jest.advanceTimersByTime(1000);
+
+      // Check that text was updated (the indicator should show elapsed time)
+      // The text update happens via interval or direct property assignment
+      expect(mockOraInstance.text).toContain("3s");
+    });
+
+    it("should format elapsed time correctly", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Processing");
+
+      indicator.start();
+      jest.advanceTimersByTime(2000); // Show spinner
+
+      // Advance to 65 seconds (1m 5s)
+      jest.advanceTimersByTime(63000);
+
+      // Text should show minutes and seconds
+      expect(mockOraInstance.text).toMatch(/1m 5s/);
+    });
+  });
+
+  describe("wrap async operation", () => {
+    it("should provide wrap method for easy async operation progress", async () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading data");
+
+      const mockAsyncOp = jest.fn<() => Promise<string>>().mockImplementation(
+        () => new Promise(resolve => {
+          // This simulates a slow operation
+          setTimeout(() => resolve("result"), 3000);
+        })
+      );
+
+      const resultPromise = indicator.wrap(mockAsyncOp);
+
+      // Operation started but spinner not yet visible
+      expect(mockOraInstance.start).not.toHaveBeenCalled();
+
+      // Advance past delay threshold
+      jest.advanceTimersByTime(2000);
+      expect(mockOraInstance.start).toHaveBeenCalled();
+
+      // Complete the operation
+      jest.advanceTimersByTime(1000);
+
+      const result = await resultPromise;
+      expect(result).toBe("result");
+      expect(mockOraInstance.succeed).toHaveBeenCalled();
+    });
+
+    it("should handle errors in wrapped async operations", async () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      const mockFailingOp = jest.fn<() => Promise<never>>().mockImplementation(
+        () => new Promise((_, reject) => {
+          setTimeout(() => reject(new Error("Failed")), 3000);
+        })
+      );
+
+      const resultPromise = indicator.wrap(mockFailingOp);
+
+      // Advance past delay and operation duration
+      jest.advanceTimersByTime(3000);
+
+      await expect(resultPromise).rejects.toThrow("Failed");
+      expect(mockOraInstance.fail).toHaveBeenCalled();
+    });
+  });
+
+  describe("TTY detection", () => {
+    it("should detect non-TTY environment (piped output)", () => {
+      process.stdout.isTTY = undefined;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+      jest.advanceTimersByTime(5000);
+
+      // No spinner in non-TTY mode
+      expect(mockOraInstance.start).not.toHaveBeenCalled();
+    });
+
+    it("should detect TTY environment", () => {
+      process.stdout.isTTY = true;
+      const indicator = new ProgressIndicator("Loading");
+
+      indicator.start();
+      jest.advanceTimersByTime(2000);
+
+      expect(mockOraInstance.start).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add visual progress feedback for long-running SPARQL queries in CLI
- Shows spinner with elapsed time after 2 second delay
- No visual noise for fast queries (<2s)

## Changes
- Add `ProgressIndicator` utility class using `ora` library
- Integrate progress indicator into `sparql-query` command execution phase
- Add comprehensive unit tests (17 test cases)

## Testing
- [x] Added unit tests for ProgressIndicator (17 test cases)
- [x] All existing tests pass (704 passed)
- [x] Build succeeds
- [x] Lint passes

## Verification
- [x] Spinner shows after 2s delay (default)
- [x] Elapsed time displayed while running
- [x] Clean completion/error handling
- [x] No output in non-TTY mode (piping)

## Acceptance Criteria
- [x] Show spinner after 2 seconds of query execution
- [x] Display elapsed time while waiting
- [x] Clear indicator on completion/error
- [x] No visual noise for fast queries (<2s)
- [x] Works in both TTY and pipe modes

Closes #2161