### PR TITLE
docs: update documentation to match v15.0.1 codebase

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Exocortex Architecture
 
-**Version**: 0.0.0-dev
-**Last Updated**: 2025-10-26
-**Status**: Current State (Before Core Extraction)
+**Version**: 15.0.1
+**Last Updated**: 2026-02-19
+**Status**: Monorepo v15.x (Clean Architecture)
 
 ---
 
@@ -47,21 +47,21 @@ Exocortex is a **knowledge management technology** that provides:
 ### Core Technologies
 
 ```yaml
-Language: TypeScript 4.8.4
+Language: TypeScript 5.9.3
 Runtime: Obsidian Plugin API 1.5.0+
-UI Framework: React 19.2.0
-Build Tool: ESBuild 0.17.3
+UI Framework: React 19.2.3
+Build Tool: ESBuild 0.27.1
 Package Manager: npm
 ```
 
 ### Testing Stack
 
 ```yaml
-Unit Tests: Jest 30.0.5 + ts-jest
+Unit Tests: Jest 30.2.0 + ts-jest
 UI Tests: jest-environment-obsidian 0.0.1
-Component Tests: Playwright CT 1.55.1
-E2E Tests: Playwright 1.55.1 (Docker)
-Coverage: Jest coverage (current: 44%, target: 95%)
+Component Tests: Playwright CT 1.56.1
+E2E Tests: Playwright 1.56.1 (Docker)
+Coverage: Jest coverage (current: 80%, target: 95%)
 BDD: Gherkin features (current: 80% coverage)
 ```
 
@@ -69,7 +69,7 @@ BDD: Gherkin features (current: 80% coverage)
 
 ```yaml
 Linter: ESLint 9.38.0
-  - typescript-eslint 8.46.2
+  - typescript-eslint 8.49.0
   - eslint-plugin-obsidianmd 0.1.6 (official)
 Formatter: Prettier 3.6.2
 Pre-commit: Husky 9.1.7
@@ -1382,7 +1382,7 @@ graph TB
 **For Users**:
 - ✅ CLI for automation (Claude Code integration)
 - ✅ Faster development (parallel Core/Plugin work)
-- ✅ More reliable (Core has 80% test coverage, 803 unit tests)
+- ✅ More reliable (Core has 80% test coverage, 740+ unit tests)
 - ✅ Batch operations without Obsidian running
 
 **For Developers**:
@@ -1412,6 +1412,7 @@ graph TB
 | 1.0 | 2025-10-26 | Initial architecture documentation (pre-#122) |
 | 1.1 | 2025-11-26 | Added Error Handling section (#438) |
 | 1.2 | 2025-11-29 | Documented CommandVisibility domain segregation (#468) |
+| 1.3 | 2026-02-19 | Updated to v15.0.1: tech stack versions, test counts (#2176) |
 
 ---
 

--- a/docs/IOS_LIVE_ACTIVITIES_SPECIFICATION.md
+++ b/docs/IOS_LIVE_ACTIVITIES_SPECIFICATION.md
@@ -228,7 +228,7 @@ When a user starts working on a task (changes status to `[[ems__EffortStatusDoin
 - Deployment Target: iOS 16.1+
 
 **Obsidian Plugin:**
-- Language: TypeScript 4.9+
+- Language: TypeScript 5.9+
 - Runtime: Obsidian Plugin API 1.5.0+
 - Build Tool: ESBuild
 - Storage: Obsidian Vault API + FileManager

--- a/docs/cli/Integration-Examples.md
+++ b/docs/cli/Integration-Examples.md
@@ -45,7 +45,7 @@ jobs:
           node-version: '18'
 
       - name: Install Exocortex CLI
-        run: npm install -g @exocortex/cli
+        run: npm install -g @kitelev/exocortex-cli
 
       - name: Create task from issue
         env:
@@ -106,7 +106,7 @@ jobs:
           path: vault
 
       - name: Install Exocortex CLI
-        run: npm install -g @exocortex/cli
+        run: npm install -g @kitelev/exocortex-cli
 
       - name: Extract task UID from PR
         id: extract
@@ -172,7 +172,7 @@ jobs:
           token: ${{ secrets.VAULT_TOKEN }}
 
       - name: Install Exocortex CLI
-        run: npm install -g @exocortex/cli
+        run: npm install -g @kitelev/exocortex-cli
 
       - name: Generate status report
         run: |
@@ -238,7 +238,7 @@ update_tasks:
     - main
   script:
     - git clone https://gitlab.com/username/my-vault.git vault
-    - npm install -g @exocortex/cli
+    - npm install -g @kitelev/exocortex-cli
 
     # Extract task UIDs from commit messages
     - |
@@ -280,7 +280,7 @@ archive_tasks:
     - schedules
   script:
     - git clone https://gitlab.com/username/my-vault.git vault
-    - npm install -g @exocortex/cli
+    - npm install -g @kitelev/exocortex-cli
 
     # Archive tasks completed >30 days ago
     - |


### PR DESCRIPTION
## Summary

Updates project documentation to reflect the current v15.0.1 monorepo structure and technology versions.

## Changes

### ARCHITECTURE.md
- **Version**: `0.0.0-dev` → `15.0.1`
- **Last Updated**: `2025-10-26` → `2026-02-19`
- **Status**: `Current State (Before Core Extraction)` → `Monorepo v15.x (Clean Architecture)`
- **Technology stack versions**:
  - TypeScript `4.8.4` → `5.9.3`
  - React `19.2.0` → `19.2.3`
  - ESBuild `0.17.3` → `0.27.1`
  - Jest `30.0.5` → `30.2.0`
  - Playwright CT `1.55.1` → `1.56.1`
  - typescript-eslint `8.46.2` → `8.49.0`
- **Test metrics**: `803 unit tests` → `740+ unit tests`
- **Coverage**: `44%` → `80%`
- Added revision history entry for v1.3

### docs/IOS_LIVE_ACTIVITIES_SPECIFICATION.md
- TypeScript version requirement: `4.9+` → `5.9+`

### docs/cli/Integration-Examples.md
- Fixed CLI package name: `@exocortex/cli` → `@kitelev/exocortex-cli` (5 occurrences)

## Verification

- [x] All version numbers verified against `package.json`
- [x] Build passes: `npm run build`
- [x] Lint passes: `npm run lint`
- [x] Package names use current naming (`@kitelev/exocortex-cli`)

## Test Plan

Documentation-only changes. No functional code changes.

- [x] All technology versions match `package.json`
- [x] All package names use current naming
- [x] Revision history updated

Closes #2176