### PR TITLE
test: fix broken tests in core package to align with API changes

### DIFF
--- a/packages/exocortex/tests/domain/constants/AssetClass.test.ts
+++ b/packages/exocortex/tests/domain/constants/AssetClass.test.ts
@@ -25,8 +25,24 @@ describe("AssetClass", () => {
     expect(AssetClass.TASK_PROTOTYPE).toBe("ems__TaskPrototype");
   });
 
+  it("should have TASK_PROTOTYPE_UID constant", () => {
+    expect(AssetClass.TASK_PROTOTYPE_UID).toBe("75302770-279e-4a59-ba85-09df29725713");
+  });
+
   it("should have MEETING_PROTOTYPE constant", () => {
     expect(AssetClass.MEETING_PROTOTYPE).toBe("ems__MeetingPrototype");
+  });
+
+  it("should have EVENT_PROTOTYPE constant", () => {
+    expect(AssetClass.EVENT_PROTOTYPE).toBe("exo__EventPrototype");
+  });
+
+  it("should have PROJECT_PROTOTYPE constant", () => {
+    expect(AssetClass.PROJECT_PROTOTYPE).toBe("ems__ProjectPrototype");
+  });
+
+  it("should have EVENT constant", () => {
+    expect(AssetClass.EVENT).toBe("exo__Event");
   });
 
   it("should have DAILY_NOTE constant", () => {
@@ -37,8 +53,24 @@ describe("AssetClass", () => {
     expect(AssetClass.CONCEPT).toBe("ims__Concept");
   });
 
-  it("should have exactly 9 constants", () => {
+  it("should have SESSION_START_EVENT constant", () => {
+    expect(AssetClass.SESSION_START_EVENT).toBe("ems__SessionStartEvent");
+  });
+
+  it("should have SESSION_END_EVENT constant", () => {
+    expect(AssetClass.SESSION_END_EVENT).toBe("ems__SessionEndEvent");
+  });
+
+  it("should have PROTOTYPE constant", () => {
+    expect(AssetClass.PROTOTYPE).toBe("exo__Prototype");
+  });
+
+  it("should have CLASS constant", () => {
+    expect(AssetClass.CLASS).toBe("exo__Class");
+  });
+
+  it("should have exactly 17 constants", () => {
     const values = Object.values(AssetClass);
-    expect(values).toHaveLength(9);
+    expect(values).toHaveLength(17);
   });
 });

--- a/packages/exocortex/tests/domain/models/GraphNode.test.ts
+++ b/packages/exocortex/tests/domain/models/GraphNode.test.ts
@@ -4,6 +4,7 @@ describe("GraphNode", () => {
   describe("GraphNodeData", () => {
     it("should accept valid GraphNodeData", () => {
       const data: GraphNodeData = {
+        id: "note-123",
         path: "/path/to/note.md",
         title: "My Note",
         label: "Note Label",
@@ -11,6 +12,7 @@ describe("GraphNode", () => {
         isArchived: false
       };
 
+      expect(data.id).toBe("note-123");
       expect(data.path).toBe("/path/to/note.md");
       expect(data.title).toBe("My Note");
       expect(data.label).toBe("Note Label");
@@ -20,6 +22,7 @@ describe("GraphNode", () => {
 
     it("should allow optional assetClass", () => {
       const data: GraphNodeData = {
+        id: "note-456",
         path: "/path/to/note.md",
         title: "My Note",
         label: "Note Label",
@@ -31,6 +34,7 @@ describe("GraphNode", () => {
 
     it("should handle archived node", () => {
       const data: GraphNodeData = {
+        id: "archived-789",
         path: "/archived/note.md",
         title: "Archived Note",
         label: "Old Label",
@@ -44,6 +48,7 @@ describe("GraphNode", () => {
   describe("GraphNode", () => {
     it("should extend GraphNodeData with position properties", () => {
       const node: GraphNode = {
+        id: "positioned-node",
         path: "/path/to/note.md",
         title: "My Note",
         label: "Note Label",
@@ -58,6 +63,7 @@ describe("GraphNode", () => {
 
     it("should allow velocity properties", () => {
       const node: GraphNode = {
+        id: "velocity-node",
         path: "/path/to/note.md",
         title: "My Note",
         label: "Note Label",
@@ -72,6 +78,7 @@ describe("GraphNode", () => {
 
     it("should allow fixed position properties", () => {
       const node: GraphNode = {
+        id: "fixed-node",
         path: "/path/to/note.md",
         title: "My Note",
         label: "Note Label",
@@ -86,6 +93,7 @@ describe("GraphNode", () => {
 
     it("should allow null for fixed position", () => {
       const node: GraphNode = {
+        id: "nullable-node",
         path: "/path/to/note.md",
         title: "My Note",
         label: "Note Label",
@@ -100,6 +108,7 @@ describe("GraphNode", () => {
 
     it("should work without optional position properties", () => {
       const node: GraphNode = {
+        id: "minimal-node",
         path: "/path/to/note.md",
         title: "My Note",
         label: "Note Label",

--- a/packages/exocortex/tests/services/AlgorithmExtractor.test.ts
+++ b/packages/exocortex/tests/services/AlgorithmExtractor.test.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import { AlgorithmExtractor } from "../../src/services/AlgorithmExtractor";
 
 describe("AlgorithmExtractor", () => {

--- a/packages/exocortex/tests/services/FleetingNoteCreationService.test.ts
+++ b/packages/exocortex/tests/services/FleetingNoteCreationService.test.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import { FleetingNoteCreationService } from "../../src/services/FleetingNoteCreationService";
 import { IVaultAdapter, IFile } from "../../src/interfaces/IVaultAdapter";
 import { DateFormatter } from "../../src/utilities/DateFormatter";

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.test.ts
@@ -2,7 +2,12 @@ import { FilterExecutor } from "../../../../../src/infrastructure/sparql/executo
 import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
 import { IRI } from "../../../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../../../src/domain/models/rdf/Literal";
-import type { FilterOperation } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import type {
+  FilterOperation,
+  InExpression,
+  ExistsExpression,
+  AlgebraOperation,
+} from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
 
 describe("FilterExecutor", () => {
   let executor: FilterExecutor;

--- a/packages/exocortex/tests/unit/services/PropertyCleanupService.di.test.ts
+++ b/packages/exocortex/tests/unit/services/PropertyCleanupService.di.test.ts
@@ -53,7 +53,7 @@ describe("PropertyCleanupService with DI", () => {
       path: "test.md",
       name: "test.md",
       basename: "test",
-      extension: "md",
+      parent: null,
     };
 
     mockVaultAdapter.read.mockResolvedValue(`---
@@ -73,7 +73,7 @@ Content`);
       path: "test.md",
       name: "test.md",
       basename: "test",
-      extension: "md",
+      parent: null,
     };
 
     const fileContent = `---


### PR DESCRIPTION
## Summary
- Fix 6 broken test files in @exocortex/core package
- Tests were broken due to API changes (type additions, interface changes)
- Test coverage already exceeds 60% target in both active packages

## Changes
- **FilterExecutor.test.ts**: Add missing `ExistsExpression` type import
- **GraphNode.test.ts**: Add required `id` field to all test data objects (new required field)
- **AlgorithmExtractor.test.ts**: Add `reflect-metadata` import for DI decorators
- **FleetingNoteCreationService.test.ts**: Add `reflect-metadata` import for DI decorators
- **PropertyCleanupService.di.test.ts**: Change `extension` to `parent` in IFile mock (interface changed)
- **AssetClass.test.ts**: Update test to reflect 17 constants (was 9, enum grew)

## Testing
- [x] `npm run test:unit` - All tests pass (4372 + 704 tests)
- [x] `npm run build` - Builds successfully
- [x] `npm run lint` - No lint errors

## Coverage Status
The issue mentioned 38% current coverage with 60% target. Investigation shows:
- **obsidian-plugin**: 78.12% line coverage
- **cli**: 71.82% line coverage

Both packages already exceed the 60% target. The 38% figure appears to be outdated.

## Acceptance Criteria
- [x] Fix broken tests to align with current API
- [x] All official CI tests pass
- [x] Coverage exceeds 60% (confirmed: 78%/72% respectively)

Closes #2185