### PR TITLE
docs: Document architecture decisions in ADR format

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ This project is developed primarily by AI agents (Claude Code, GitHub Copilot) f
 | **[CLAUDE.md](./CLAUDE.md)** | AI agent guidelines, worktree rules |
 | **[AI Development Patterns](./docs/AI-DEVELOPMENT-PATTERNS.md)** | Lessons from 96+ completed issues |
 | **[Architecture Guide](./ARCHITECTURE.md)** | Clean Architecture patterns |
+| **[Architecture Decision Records](./docs/adr/)** | Key architectural decisions (ADRs) |
 
 ---
 

--- a/docs/adr/0008-clean-architecture-adoption.md
+++ b/docs/adr/0008-clean-architecture-adoption.md
@@ -1,0 +1,191 @@
+# ADR-0008: Adopt Clean Architecture
+
+## Status
+
+✅ **Accepted** (Implemented)
+
+## Context
+
+The Exocortex codebase needs a scalable architecture that:
+- Separates business logic from infrastructure concerns
+- Enables testability through dependency injection
+- Supports multiple interfaces (CLI, Obsidian plugin, potential Web/Mobile)
+- Maintains long-term maintainability as the project grows
+
+### Problem
+
+Early versions of the Obsidian plugin mixed business logic directly with Obsidian API calls:
+
+```typescript
+// OLD: Tightly coupled code
+export class TaskService {
+  constructor(private vault: Vault) {}  // Obsidian-specific
+
+  async createTask(label: string): Promise<TFile> {
+    const uid = uuidv4();
+    const content = `---\nexo__Asset_uid: ${uid}\n---\n`;
+    return await this.vault.create(`${uid}.md`, content);  // Direct Obsidian call
+  }
+}
+```
+
+This caused several problems:
+1. **Untestable**: Required full Obsidian environment for testing
+2. **Not reusable**: Business logic locked inside plugin
+3. **Hard to maintain**: Changes to Obsidian API required changes throughout codebase
+4. **No CLI support**: Could not automate tasks via command line
+
+## Decision
+
+We adopt **Clean Architecture** with four distinct layers:
+
+```
+┌─────────────────────────────────────────────────┐
+│        PRESENTATION (Obsidian Plugin)           │
+│  React components, Renderers, Modals, Views     │
+├─────────────────────────────────────────────────┤
+│            APPLICATION (exocortex)              │
+│  CommandManager, Services, Use Cases            │
+├─────────────────────────────────────────────────┤
+│              DOMAIN (exocortex)                 │
+│  Entities, Constants, Business Rules            │
+├─────────────────────────────────────────────────┤
+│           INFRASTRUCTURE (adapters)             │
+│  ObsidianVaultAdapter, NodeFsAdapter, etc.      │
+└─────────────────────────────────────────────────┘
+```
+
+### The Dependency Rule
+
+**Inner layers NEVER depend on outer layers.**
+
+- Domain knows nothing about Application, Infrastructure, or Presentation
+- Application knows Domain but not Infrastructure or Presentation
+- Infrastructure implements interfaces defined by Application
+- Presentation uses Application services through DI
+
+### Implementation
+
+**Monorepo Structure:**
+
+```
+packages/
+├── exocortex/                 # Core (Domain + Application)
+│   └── src/
+│       ├── domain/            # Business entities, constants
+│       ├── application/       # Use cases, services
+│       └── infrastructure/    # Interfaces, pure utilities
+├── obsidian-plugin/           # Presentation + Obsidian adapters
+│   └── src/
+│       ├── presentation/      # React components, UI
+│       └── infrastructure/    # ObsidianVaultAdapter
+└── cli/                       # CLI Presentation + Node adapters
+    └── src/
+        ├── executors/         # CLI commands
+        └── infrastructure/    # NodeFsAdapter
+```
+
+**Dependency Injection with TSyringe:**
+
+```typescript
+// Domain Layer (no dependencies)
+export interface IFileSystemAdapter {
+  readFile(path: string): Promise<string>;
+  writeFile(path: string, content: string): Promise<void>;
+  createFile(path: string, content: string): Promise<void>;
+}
+
+// Application Layer (uses interface)
+@injectable()
+export class TaskCreationService {
+  constructor(
+    @inject("IFileSystemAdapter") private fs: IFileSystemAdapter
+  ) {}
+
+  async createTask(label: string): Promise<string> {
+    const frontmatter = this.generateTaskFrontmatter(label);  // Pure
+    const content = MetadataHelpers.buildFileContent(frontmatter);  // Pure
+    await this.fs.createFile(path, content);  // Via interface
+    return path;
+  }
+}
+
+// Infrastructure Layer (implements interface)
+@injectable()
+export class ObsidianVaultAdapter implements IFileSystemAdapter {
+  constructor(private vault: Vault) {}
+
+  async createFile(path: string, content: string): Promise<void> {
+    await this.vault.create(path, content);
+  }
+}
+```
+
+## Consequences
+
+### Positive
+
+- **Testability**: Business logic tests require no Obsidian mocks
+- **Reusability**: Core logic works in CLI, plugin, and future adapters
+- **Maintainability**: Changes isolated to specific layers
+- **Parallel development**: Teams can work on different adapters independently
+- **Framework agnostic**: Business logic survives framework changes
+- **Clear boundaries**: Easy to understand what belongs where
+
+### Negative
+
+- **More abstractions**: Additional interfaces, adapters, DI containers
+- **Learning curve**: Developers must understand Clean Architecture concepts
+- **Initial overhead**: Setting up DI and monorepo structure takes time
+- **More files**: Layer separation results in more source files
+
+### Mitigations
+
+1. **Documentation**: ARCHITECTURE.md explains layer responsibilities
+2. **TSyringe**: Lightweight DI (~2KB) with minimal boilerplate
+3. **Templates**: Standard patterns for new services documented in PATTERNS.md
+4. **Code review**: Enforce layer boundaries in PR reviews
+
+## Alternatives Considered
+
+### Alternative 1: Traditional Layered Architecture
+
+```
+Presentation → Business Logic → Data Access
+```
+
+**Rejected because**:
+- Business logic layer can become coupled to data access
+- Testing still requires mocking database/storage
+- No clear separation for multiple adapters
+
+### Alternative 2: No Architecture (Pragmatic)
+
+Keep business logic mixed with framework code, refactor only when needed.
+
+**Rejected because**:
+- CLI requirement made refactoring inevitable
+- Testing pain was already significant
+- Future Web/Mobile adapters would be impossible
+
+### Alternative 3: Hexagonal Architecture (Ports & Adapters)
+
+Very similar to Clean Architecture but with different terminology.
+
+**Why we chose Clean Architecture instead**:
+- Better documentation and community resources
+- More explicit layer names (Domain, Application, Infrastructure)
+- Same benefits as Hexagonal with clearer structure
+
+## Related
+
+- **ADR-0006**: Pure Functions Separation (predecessor)
+- **ADR-0009**: Domain Separation Strategy (detailed domain boundaries)
+- **Issue #122**: Core Extraction (implementation)
+- **Documentation**: ARCHITECTURE.md
+
+---
+
+**Date**: 2026-02-20
+**Author**: AI Development Team
+**Related Issues**: #122 (Core Extraction), #2188 (ADR Documentation)

--- a/docs/adr/0009-domain-separation-strategy.md
+++ b/docs/adr/0009-domain-separation-strategy.md
@@ -1,0 +1,196 @@
+# ADR-0009: Domain Separation Strategy
+
+## Status
+
+✅ **Accepted** (Implemented)
+
+## Context
+
+With Clean Architecture adopted (ADR-0008), we need to define clear boundaries between domain concepts and ensure the monorepo structure supports independent evolution of each package.
+
+### Problem
+
+The codebase manages several distinct domains:
+- **Asset Management**: Tasks, Projects, Areas, Concepts, Prototypes
+- **Status Workflows**: Effort lifecycle (Draft → Done)
+- **Knowledge Organization**: Hierarchies, relationships, graphs
+- **User Interface**: Obsidian-specific rendering
+- **Automation**: CLI commands for scripting
+
+Without clear domain boundaries:
+- Code duplication across packages
+- Unclear ownership of shared concepts
+- Breaking changes cascade unpredictably
+- Testing becomes complex
+
+## Decision
+
+We adopt a **Monorepo with Package Domains** strategy:
+
+### Package Boundaries
+
+```
+packages/
+├── exocortex/              # DOMAIN: Core business logic
+│   ├── domain/             # Entities, constants, value objects
+│   ├── application/        # Use cases, service interfaces
+│   └── infrastructure/     # Pure utilities, adapter interfaces
+│
+├── obsidian-plugin/        # ADAPTER: Obsidian-specific integration
+│   ├── presentation/       # React components, renderers
+│   └── infrastructure/     # ObsidianVaultAdapter, MetadataExtractor
+│
+├── cli/                    # ADAPTER: Command-line automation
+│   ├── executors/          # Command implementations
+│   └── infrastructure/     # NodeFsAdapter, PathResolver
+│
+└── test-utils/             # SHARED: Testing utilities
+    └── mocks/              # Shared mock factories
+```
+
+### Domain Ownership Rules
+
+**Package `exocortex` owns:**
+- Asset class definitions (`ems__Task`, `ems__Project`, etc.)
+- Status workflow definitions (`EffortStatus` enum)
+- Business rules (command visibility, status transitions)
+- Service interfaces (`IFileSystemAdapter`, `IMetadataService`)
+- Pure utilities (`DateFormatter`, `FrontmatterService`, `WikiLinkHelpers`)
+
+**Package `obsidian-plugin` owns:**
+- UI components (tables, renderers, modals)
+- Obsidian API integration
+- Plugin lifecycle (settings, commands, views)
+- Obsidian-specific metadata extraction
+
+**Package `cli` owns:**
+- Command-line interface design
+- Terminal output formatting
+- File system operations via Node.js
+- Batch processing workflows
+
+### Cross-Package Communication
+
+```typescript
+// exocortex defines the interface
+export interface IFileSystemAdapter {
+  exists(path: string): Promise<boolean>;
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+  create(path: string, content: string): Promise<void>;
+  delete(path: string): Promise<void>;
+  list(directory: string): Promise<string[]>;
+}
+
+// exocortex provides services that use the interface
+export class TaskCreationService {
+  constructor(private fs: IFileSystemAdapter) {}
+  // Business logic here
+}
+
+// obsidian-plugin implements the interface
+export class ObsidianVaultAdapter implements IFileSystemAdapter {
+  constructor(private vault: Vault) {}
+  // Obsidian-specific implementation
+}
+
+// cli implements the interface differently
+export class NodeFsAdapter implements IFileSystemAdapter {
+  // Node.js fs module implementation
+}
+```
+
+### Import Rules
+
+| From ↓ To → | exocortex | obsidian-plugin | cli | test-utils |
+|-------------|-----------|-----------------|-----|------------|
+| exocortex | ✅ | ❌ | ❌ | ❌ |
+| obsidian-plugin | ✅ | ✅ | ❌ | ❌ |
+| cli | ✅ | ❌ | ✅ | ❌ |
+| test-utils | ✅ | ✅ | ✅ | ✅ |
+
+**Key Rule**: `exocortex` NEVER imports from adapters (plugin/cli).
+
+### Shared Constants Pattern
+
+```typescript
+// packages/exocortex/src/domain/constants.ts
+export const AssetClass = {
+  Task: "ems__Task",
+  Project: "ems__Project",
+  Area: "ems__Area",
+  Concept: "ims__Concept",
+  Prototype: "ims__Prototype",
+} as const;
+
+// packages/obsidian-plugin/src/presentation/components/TaskTable.tsx
+import { AssetClass } from "exocortex";  // ✅ Correct
+
+// packages/cli/src/executors/TaskExecutor.ts
+import { AssetClass } from "exocortex";  // ✅ Correct
+```
+
+## Consequences
+
+### Positive
+
+- **Clear ownership**: Each package has defined responsibilities
+- **Independent evolution**: CLI can be released separately from plugin
+- **Testability**: Core logic tested without Obsidian
+- **Reduced coupling**: Changes in one adapter don't affect others
+- **Shared vocabulary**: Constants and types are single-sourced
+
+### Negative
+
+- **Complexity**: More packages to manage and version
+- **Build coordination**: Changes to core require rebuilding adapters
+- **Learning curve**: Developers must understand package boundaries
+
+### Mitigations
+
+1. **npm workspaces**: Handles cross-package dependencies automatically
+2. **TypeScript paths**: Simplified imports (`exocortex` vs `../../..`)
+3. **CI validation**: Tests run across all packages on PR
+4. **Documentation**: ARCHITECTURE.md explains domain boundaries
+
+## Alternatives Considered
+
+### Alternative 1: Single Package (Monolith)
+
+Keep everything in one package with folder separation.
+
+**Rejected because**:
+- CLI would pull in all Obsidian dependencies
+- No independent versioning possible
+- Harder to enforce layer boundaries
+
+### Alternative 2: Separate Repositories
+
+Split into `exocortex-core`, `exocortex-obsidian`, `exocortex-cli` repos.
+
+**Rejected because**:
+- Cross-repository changes are painful
+- Version synchronization complex
+- Development velocity suffers
+
+### Alternative 3: Feature-Based Packages
+
+One package per feature (tasks, projects, status, etc.).
+
+**Rejected because**:
+- Features are interconnected (tasks reference projects)
+- Would create circular dependencies
+- Too fine-grained for current team size
+
+## Related
+
+- **ADR-0008**: Clean Architecture (foundational decision)
+- **ADR-0006**: Pure Functions Separation (technical approach)
+- **Issue #122**: Core Extraction (implementation)
+- **Documentation**: ARCHITECTURE.md § Monorepo Organization
+
+---
+
+**Date**: 2026-02-20
+**Author**: AI Development Team
+**Related Issues**: #122 (Core Extraction), #2188 (ADR Documentation)

--- a/docs/adr/0010-testing-strategy.md
+++ b/docs/adr/0010-testing-strategy.md
@@ -1,0 +1,249 @@
+# ADR-0010: Testing Strategy
+
+## Status
+
+✅ **Accepted** (Implemented)
+
+## Context
+
+The Exocortex codebase requires a comprehensive testing strategy that:
+- Validates business logic independently from frameworks
+- Tests UI components with real browser rendering
+- Ensures end-to-end functionality in realistic environments
+- Maintains high coverage without sacrificing test reliability
+
+### Problem
+
+Testing Obsidian plugins presents unique challenges:
+1. **Obsidian API mocking**: Complex APIs that are hard to mock accurately
+2. **React component testing**: Need real browser for proper rendering
+3. **Plugin lifecycle**: Settings, commands, views have complex interactions
+4. **E2E testing**: Obsidian doesn't run easily in CI environments
+
+## Decision
+
+We adopt a **Test Pyramid Strategy** with four test levels:
+
+```
+                    ┌───────────┐
+                    │   E2E     │  1-5%
+                    │  (Docker) │  Smoke tests
+                    ├───────────┤
+                    │ Component │  15-20%
+                    │(Playwright)│  React UI
+                ┌───┴───────────┴───┐
+                │   Integration     │  20-25%
+                │ (UI + Mock Vault) │
+        ┌───────┴───────────────────┴───────┐
+        │           Unit Tests               │  55-60%
+        │    (Pure functions, Services)      │
+        └────────────────────────────────────┘
+```
+
+### Test Type Definitions
+
+**Unit Tests (Jest)**
+- Test pure functions and business logic in isolation
+- Mock all external dependencies
+- Fast execution (~1-5ms per test)
+- Location: `packages/*/tests/unit/`
+
+**Integration Tests (Jest + Mocks)**
+- Test service interactions with mocked infrastructure
+- Use `jest-environment-obsidian` for plugin-specific tests
+- Location: `packages/*/tests/ui/`
+
+**Component Tests (Playwright CT)**
+- Test React components with real browser rendering
+- Visual regression testing with screenshots
+- Location: `packages/obsidian-plugin/tests/component/`
+
+**E2E Tests (Playwright + Docker)**
+- Test full plugin in real Obsidian environment
+- Run in Docker for reproducibility
+- Location: `packages/obsidian-plugin/tests/e2e/`
+
+### Test Framework Selection
+
+```yaml
+Unit Tests:
+  Framework: Jest 30.x + ts-jest
+  Reason: Fast, well-integrated with TypeScript, good mocking
+
+Component Tests:
+  Framework: Playwright Component Testing
+  Reason: Real browser, visual regression, cross-browser support
+
+E2E Tests:
+  Framework: Playwright + Docker
+  Reason: Reproducible environment, Obsidian in container
+
+BDD:
+  Framework: Cucumber (Gherkin syntax)
+  Reason: Readable specs, stakeholder communication
+```
+
+### Coverage Requirements
+
+| Package | Target | Enforcement |
+|---------|--------|-------------|
+| exocortex (core) | 95% | CI blocks PR below threshold |
+| obsidian-plugin | 80% | CI blocks PR below threshold |
+| cli | 80% | CI blocks PR below threshold |
+| Overall | 80% | BDD coverage check |
+
+### Test File Organization
+
+```
+packages/exocortex/
+├── tests/
+│   ├── unit/
+│   │   ├── domain/           # Entity tests
+│   │   ├── application/      # Service tests
+│   │   └── infrastructure/   # Utility tests
+│   └── integration/          # Cross-service tests
+
+packages/obsidian-plugin/
+├── tests/
+│   ├── unit/
+│   │   ├── services/         # Plugin service tests
+│   │   └── helpers/          # Helper function tests
+│   ├── ui/                   # UI integration tests
+│   ├── component/            # Playwright component tests
+│   └── e2e/                  # End-to-end tests
+│       ├── specs/            # Test specifications
+│       └── fixtures/         # Test data
+
+packages/cli/
+├── tests/
+│   ├── unit/
+│   │   ├── executors/        # Command executor tests
+│   │   └── infrastructure/   # Adapter tests
+│   └── integration/          # CLI workflow tests
+```
+
+### Mocking Strategy
+
+**Pure Functions**: No mocks needed (ADR-0006)
+
+```typescript
+// Testing pure function - no mocks!
+test('DateFormatter formats timestamp correctly', () => {
+  const date = new Date('2025-10-26T14:30:00');
+  expect(DateFormatter.toLocalTimestamp(date)).toBe('2025-10-26T14:30:00');
+});
+```
+
+**Services with Adapters**: Mock the adapter interface
+
+```typescript
+// Testing service with mocked adapter
+describe('TaskCreationService', () => {
+  let service: TaskCreationService;
+  let mockFs: jest.Mocked<IFileSystemAdapter>;
+
+  beforeEach(() => {
+    mockFs = {
+      read: jest.fn(),
+      write: jest.fn(),
+      create: jest.fn(),
+      exists: jest.fn(),
+      delete: jest.fn(),
+      list: jest.fn(),
+    };
+    service = new TaskCreationService(mockFs);
+  });
+
+  it('creates task file with correct frontmatter', async () => {
+    await service.createTask('My Task');
+
+    expect(mockFs.create).toHaveBeenCalledWith(
+      expect.stringMatching(/^[0-9a-f-]{36}\.md$/),
+      expect.stringContaining('exo__Asset_label: My Task')
+    );
+  });
+});
+```
+
+**React Components**: Use test wrappers
+
+```typescript
+// Component test with mocked context
+test('TaskRow renders status icon', async ({ mount }) => {
+  const task = createMockTask({ status: 'Doing' });
+
+  const component = await mount(
+    <TaskRow task={task} onStatusChange={jest.fn()} />
+  );
+
+  await expect(component.locator('.status-icon')).toContainText('🔄');
+});
+```
+
+## Consequences
+
+### Positive
+
+- **Fast feedback**: Unit tests run in seconds
+- **Reliable UI testing**: Playwright provides stable component tests
+- **Realistic E2E**: Docker ensures consistent environment
+- **High coverage**: Pyramid ensures broad protection
+- **Maintainable**: Clear separation of test types
+
+### Negative
+
+- **Complex setup**: Multiple test frameworks to configure
+- **E2E overhead**: Docker setup required for full E2E
+- **Learning curve**: Team must understand when to use which test type
+
+### Mitigations
+
+1. **TESTING.md**: Comprehensive guide for all test types
+2. **TEST_TEMPLATES.md**: Copy-paste templates for common scenarios
+3. **CI enforcement**: Automated coverage checks prevent regression
+4. **Pre-commit hooks**: Run unit tests before push
+
+## Alternatives Considered
+
+### Alternative 1: Unit Tests Only
+
+Rely entirely on Jest unit tests with heavy mocking.
+
+**Rejected because**:
+- UI rendering bugs would slip through
+- Integration issues between components not caught
+- No visual regression protection
+
+### Alternative 2: E2E Tests Only
+
+Skip unit tests, focus on end-to-end testing.
+
+**Rejected because**:
+- Slow feedback loop (minutes vs seconds)
+- Flaky tests in CI
+- Hard to pinpoint failure location
+- Expensive to maintain
+
+### Alternative 3: Snapshot Testing
+
+Use Jest snapshots for component output.
+
+**Rejected because**:
+- Snapshots become noise (updated without review)
+- Don't catch visual regressions
+- Hard to maintain large snapshots
+
+Playwright visual snapshots are used instead for intentional visual regression testing.
+
+## Related
+
+- **ADR-0006**: Pure Functions Separation (enables mockless testing)
+- **ADR-0008**: Clean Architecture (enables layer-specific testing)
+- **Documentation**: TESTING.md, TEST_TEMPLATES.md, docs/TEST-PYRAMID.md
+- **CI**: `.github/workflows/ci.yml` enforces coverage thresholds
+
+---
+
+**Date**: 2026-02-20
+**Author**: AI Development Team
+**Related Issues**: #123 (Test Coverage), #2188 (ADR Documentation)

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,63 @@
+# ADR-XXXX: [Title]
+
+## Status
+
+[ Proposed | Accepted | Deprecated | Superseded by ADR-XXXX ]
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+### Problem
+
+Describe the specific problem being solved.
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+### Implementation
+
+Provide code examples or architecture diagrams if applicable.
+
+```typescript
+// Example code
+```
+
+## Consequences
+
+### Positive
+
+- Benefit 1
+- Benefit 2
+
+### Negative
+
+- Trade-off 1
+- Trade-off 2
+
+### Mitigations
+
+How we address the negative consequences.
+
+## Alternatives Considered
+
+### Alternative 1: [Name]
+
+**Rejected because**: [Reason]
+
+### Alternative 2: [Name]
+
+**Rejected because**: [Reason]
+
+## Related
+
+- **Issue**: #XXX
+- **ADR**: ADR-XXXX
+- **Documentation**: [Link]
+
+---
+
+**Date**: YYYY-MM-DD
+**Author**: @username
+**Related Issues**: #XXX


### PR DESCRIPTION
## Summary
- Add ADR template for creating new Architecture Decision Records
- Document Clean Architecture adoption (ADR-0008)
- Document domain separation strategy (ADR-0009)
- Document testing strategy (ADR-0010)
- Update README.md with link to ADR directory

## Changes
- `docs/adr/template.md`: Standard ADR template
- `docs/adr/0008-clean-architecture-adoption.md`: Clean Architecture with layer separation and DI
- `docs/adr/0009-domain-separation-strategy.md`: Monorepo structure and package boundaries
- `docs/adr/0010-testing-strategy.md`: Test pyramid, frameworks, coverage requirements
- `README.md`: Added link to ADR directory in AI Development Resources section

## Verification
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] All ADRs follow established format (consistent with existing ADRs 0001-0007)
- [x] README.md updated with link to ADR directory

## Acceptance Criteria
- [x] Create `docs/adr/` directory structure (already existed)
- [x] Create ADR template file: `docs/adr/template.md`
- [x] Write ADR 0008: Clean Architecture adoption
- [x] Write ADR 0009: Domain separation strategy
- [x] Write ADR 0010: Testing strategy
- [x] Update README.md with link to ADR directory

Closes #2188