### PR TITLE
feat(plugin): add Copy Label command for fleeting notes

### DIFF
--- a/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
+++ b/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
@@ -142,3 +142,17 @@ export function canCreateTaskForDailyNote(
 
   return true;
 }
+
+/**
+ * Can execute "Copy Label" command for fleeting notes
+ * Available for: ztlk__FleetingNote assets only
+ * Supports both string-based and UID-based identifiers
+ */
+export function canCopyFleetingNoteLabel(
+  context: CommandVisibilityContext,
+): boolean {
+  return (
+    hasClass(context.instanceClass, AssetClass.FLEETING_NOTE) ||
+    hasClass(context.instanceClass, AssetClass.FLEETING_NOTE_UID)
+  );
+}

--- a/packages/exocortex/src/domain/commands/visibility/index.ts
+++ b/packages/exocortex/src/domain/commands/visibility/index.ts
@@ -79,4 +79,5 @@ export {
   canCreateNarrowerConcept,
   canCreateSubclass,
   canCreateTaskForDailyNote,
+  canCopyFleetingNoteLabel,
 } from "./AssetVisibilityRules";

--- a/packages/exocortex/src/domain/constants/AssetClass.ts
+++ b/packages/exocortex/src/domain/constants/AssetClass.ts
@@ -17,4 +17,7 @@ export enum AssetClass {
   SESSION_END_EVENT = "ems__SessionEndEvent",
   PROTOTYPE = "exo__Prototype",
   CLASS = "exo__Class",
+  FLEETING_NOTE = "ztlk__FleetingNote",
+  /** UID-based identifier for ztlk__FleetingNote (Issue #2200) */
+  FLEETING_NOTE_UID = "fca0a931-a01f-48e4-b72a-4af206c94bc7",
 }

--- a/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
+++ b/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
@@ -49,6 +49,7 @@ import { RepairFolderCommand } from "./RepairFolderCommand";
 import { RenameToUidCommand } from "./RenameToUidCommand";
 import { VoteOnEffortCommand } from "./VoteOnEffortCommand";
 import { CopyLabelToAliasesCommand } from "./CopyLabelToAliasesCommand";
+import { CopyFleetingNoteLabelCommand } from "./CopyFleetingNoteLabelCommand";
 import { AddSupervisionCommand } from "./AddSupervisionCommand";
 import { ReloadLayoutCommand } from "./ReloadLayoutCommand";
 import { TogglePropertiesVisibilityCommand } from "./TogglePropertiesVisibilityCommand";
@@ -127,6 +128,7 @@ export class CommandRegistry {
       new RenameToUidCommand(renameToUidService),
       new VoteOnEffortCommand(effortVotingService),
       new CopyLabelToAliasesCommand(labelToAliasService),
+      new CopyFleetingNoteLabelCommand(app),
       new AddSupervisionCommand(app, supervisionCreationService, this.vaultAdapter),
       new ReloadLayoutCommand(reloadLayoutCallback),
       new TogglePropertiesVisibilityCommand(plugin),

--- a/packages/obsidian-plugin/src/application/commands/CopyFleetingNoteLabelCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CopyFleetingNoteLabelCommand.ts
@@ -1,0 +1,84 @@
+import { TFile, Notice, App } from "obsidian";
+import { ICommand } from "./ICommand";
+import {
+  CommandVisibilityContext,
+  canCopyFleetingNoteLabel,
+  LoggingService,
+} from "exocortex";
+
+/**
+ * Command to copy the first line of body (label) from a fleeting note to clipboard.
+ *
+ * The label is extracted from the note body (first non-empty line after frontmatter).
+ * This is useful for quickly referencing fleeting notes in other documents.
+ *
+ * Visibility: Only available for ztlk__FleetingNote assets.
+ */
+export class CopyFleetingNoteLabelCommand implements ICommand {
+  id = "copy-fleeting-note-label";
+  name = "Copy Label";
+
+  constructor(private app: App) {}
+
+  checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
+    if (!context || !canCopyFleetingNoteLabel(context)) return false;
+
+    if (!checking) {
+      void (async () => {
+        try {
+          await this.execute(file);
+        } catch (error) {
+          new Notice(`Failed to copy label: ${error instanceof Error ? error.message : String(error)}`);
+          LoggingService.error("Copy fleeting note label error", error instanceof Error ? error : undefined);
+        }
+      })();
+    }
+
+    return true;
+  };
+
+  private async execute(file: TFile): Promise<void> {
+    const content = await this.app.vault.read(file);
+    const label = this.extractLabelFromContent(content);
+
+    if (!label) {
+      new Notice("Label is empty");
+      return;
+    }
+
+    await navigator.clipboard.writeText(label);
+    new Notice("Label copied to clipboard");
+  }
+
+  /**
+   * Extracts the label (first non-empty line of body) from file content.
+   *
+   * @param content - Full file content including frontmatter
+   * @returns The trimmed first line of body, or null if empty
+   */
+  private extractLabelFromContent(content: string): string | null {
+    const lines = content.split("\n");
+
+    // Find body start after frontmatter
+    let bodyStartIndex = 0;
+    if (lines[0] === "---") {
+      // Find closing ---
+      for (let i = 1; i < lines.length; i++) {
+        if (lines[i] === "---") {
+          bodyStartIndex = i + 1;
+          break;
+        }
+      }
+    }
+
+    // Find first non-empty line in body
+    for (let i = bodyStartIndex; i < lines.length; i++) {
+      const trimmedLine = lines[i].trim();
+      if (trimmedLine) {
+        return trimmedLine;
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/CopyFleetingNoteLabelCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CopyFleetingNoteLabelCommand.test.ts
@@ -1,0 +1,228 @@
+import { flushPromises } from "./helpers/testHelpers";
+import { CopyFleetingNoteLabelCommand } from "../../src/application/commands/CopyFleetingNoteLabelCommand";
+import { TFile, Notice, App } from "obsidian";
+import { CommandVisibilityContext, LoggingService } from "exocortex";
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual("obsidian"),
+  Notice: jest.fn(),
+}));
+jest.mock("exocortex", () => ({
+  ...jest.requireActual("exocortex"),
+  canCopyFleetingNoteLabel: jest.fn(),
+  LoggingService: {
+    error: jest.fn(),
+  },
+}));
+
+describe("CopyFleetingNoteLabelCommand", () => {
+  let command: CopyFleetingNoteLabelCommand;
+  let mockApp: jest.Mocked<App>;
+  let mockFile: jest.Mocked<TFile>;
+  let mockContext: CommandVisibilityContext;
+  let originalClipboard: typeof navigator.clipboard;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Create mock app
+    mockApp = {
+      vault: {
+        read: jest.fn(),
+      },
+      workspace: {
+        getActiveFile: jest.fn(),
+      },
+    } as unknown as jest.Mocked<App>;
+
+    // Create mock file
+    mockFile = {
+      path: "01 Inbox/test-uuid.md",
+      basename: "test-uuid",
+    } as jest.Mocked<TFile>;
+
+    // Create mock context
+    mockContext = {
+      instanceClass: "[[ztlk__FleetingNote]]",
+      currentStatus: null,
+      metadata: {},
+      isArchived: false,
+      currentFolder: "01 Inbox",
+      expectedFolder: null,
+    };
+
+    // Mock clipboard API
+    originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+    });
+
+    // Create command instance
+    command = new CopyFleetingNoteLabelCommand(mockApp);
+  });
+
+  afterEach(() => {
+    // Restore original clipboard
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      configurable: true,
+    });
+  });
+
+  describe("id and name", () => {
+    it("should have correct id and name", () => {
+      expect(command.id).toBe("copy-fleeting-note-label");
+      expect(command.name).toBe("Copy Label");
+    });
+  });
+
+  describe("checkCallback", () => {
+    const mockCanCopyFleetingNoteLabel = require("exocortex").canCopyFleetingNoteLabel;
+
+    it("should return false when context is null", () => {
+      const result = command.checkCallback(true, mockFile, null);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when canCopyFleetingNoteLabel returns false", () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(false);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(false);
+    });
+
+    it("should return true when canCopyFleetingNoteLabel returns true and checking is true", () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      const result = command.checkCallback(true, mockFile, mockContext);
+      expect(result).toBe(true);
+      expect(mockApp.vault.read).not.toHaveBeenCalled();
+    });
+
+    it("should copy first line of body to clipboard when checking is false", async () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      mockApp.vault.read.mockResolvedValue("---\nexo__Instance_class: ztlk__FleetingNote\n---\n\nThis is the label to copy\nSecond line\nThird line");
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await flushPromises();
+
+      expect(mockApp.vault.read).toHaveBeenCalledWith(mockFile);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("This is the label to copy");
+      expect(Notice).toHaveBeenCalledWith("Label copied to clipboard");
+    });
+
+    it("should trim whitespace from first line", async () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      mockApp.vault.read.mockResolvedValue("---\nexo__Instance_class: ztlk__FleetingNote\n---\n\n  Label with spaces  \nSecond line");
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Label with spaces");
+      expect(Notice).toHaveBeenCalledWith("Label copied to clipboard");
+    });
+
+    it("should skip empty lines after frontmatter to find first content line", async () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      mockApp.vault.read.mockResolvedValue("---\nexo__Instance_class: ztlk__FleetingNote\n---\n\n\n\nActual label\nMore content");
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Actual label");
+      expect(Notice).toHaveBeenCalledWith("Label copied to clipboard");
+    });
+
+    it("should show notice when label is empty", async () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      mockApp.vault.read.mockResolvedValue("---\nexo__Instance_class: ztlk__FleetingNote\n---\n\n");
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+      expect(Notice).toHaveBeenCalledWith("Label is empty");
+    });
+
+    it("should show notice when file has only whitespace after frontmatter", async () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      mockApp.vault.read.mockResolvedValue("---\nexo__Instance_class: ztlk__FleetingNote\n---\n\n   \n   \n");
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+      expect(Notice).toHaveBeenCalledWith("Label is empty");
+    });
+
+    it("should handle errors and show notice", async () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      const error = new Error("Failed to read file");
+      mockApp.vault.read.mockRejectedValue(error);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      // Wait for async execution
+      await flushPromises();
+
+      expect(LoggingService.error).toHaveBeenCalledWith("Copy fleeting note label error", error);
+      expect(Notice).toHaveBeenCalledWith("Failed to copy label: Failed to read file");
+    });
+
+    it("should handle clipboard write errors", async () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      mockApp.vault.read.mockResolvedValue("---\nexo__Instance_class: ztlk__FleetingNote\n---\n\nMy label");
+
+      const clipboardError = new Error("Clipboard access denied");
+      (navigator.clipboard.writeText as jest.Mock).mockRejectedValue(clipboardError);
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      expect(LoggingService.error).toHaveBeenCalledWith("Copy fleeting note label error", clipboardError);
+      expect(Notice).toHaveBeenCalledWith("Failed to copy label: Clipboard access denied");
+    });
+
+    it("should handle file without frontmatter", async () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      mockApp.vault.read.mockResolvedValue("Just a plain file\nWith content");
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      // When no frontmatter, the first line is the label
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Just a plain file");
+      expect(Notice).toHaveBeenCalledWith("Label copied to clipboard");
+    });
+
+    it("should handle file with only frontmatter", async () => {
+      mockCanCopyFleetingNoteLabel.mockReturnValue(true);
+      mockApp.vault.read.mockResolvedValue("---\nexo__Instance_class: ztlk__FleetingNote\n---");
+
+      const result = command.checkCallback(false, mockFile, mockContext);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+      expect(Notice).toHaveBeenCalledWith("Label is empty");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/commands/CommandRegistry.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/CommandRegistry.test.ts
@@ -195,8 +195,8 @@ describe("CommandRegistry", () => {
       const registry = new CommandRegistry(mockApp, mockPlugin);
       const commands = registry.getAllCommands();
 
-      // 35 commands are registered based on source (including MarkReviewedCommand)
-      expect(commands.length).toBe(35);
+      // 36 commands are registered (including CopyFleetingNoteLabelCommand)
+      expect(commands.length).toBe(36);
     });
 
     it("should return same array on multiple calls", () => {

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.registration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.registration.test.ts
@@ -41,7 +41,7 @@ describe("CommandManager - registration", () => {
         ctx.commandManager.registerAllCommands(ctx.mockPlugin);
       }).not.toThrow();
 
-      expect(ctx.mockPlugin.addCommand).toHaveBeenCalledTimes(35);
+      expect(ctx.mockPlugin.addCommand).toHaveBeenCalledTimes(36);
     });
 
     it("should register commands with correct IDs", () => {

--- a/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.maintenance.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.maintenance.test.ts
@@ -4,6 +4,7 @@ import {
   canCleanProperties,
   canRepairFolder,
   canCopyLabelToAliases,
+  canCopyFleetingNoteLabel,
 } from "exocortex";
 
 describe("CommandVisibility - Maintenance Commands", () => {
@@ -433,6 +434,128 @@ describe("CommandVisibility - Maintenance Commands", () => {
         expectedFolder: null,
       };
       expect(canCopyLabelToAliases(context)).toBe(true);
+    });
+  });
+
+  describe("canCopyFleetingNoteLabel", () => {
+    it("should return true for ztlk__FleetingNote class", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ztlk__FleetingNote]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(true);
+    });
+
+    it("should return true for ztlk__FleetingNote without wiki-link brackets", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "ztlk__FleetingNote",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(true);
+    });
+
+    it("should return true for fleeting note UUID", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[fca0a931-a01f-48e4-b72a-4af206c94bc7]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(true);
+    });
+
+    it("should return true for fleeting note UUID without wiki-link brackets", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "fca0a931-a01f-48e4-b72a-4af206c94bc7",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(true);
+    });
+
+    it("should return true when fleeting note class is in array", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: ["[[exo__Asset]]", "[[ztlk__FleetingNote]]"],
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(true);
+    });
+
+    it("should return true when fleeting note UUID is in array", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: ["[[exo__Asset]]", "[[fca0a931-a01f-48e4-b72a-4af206c94bc7]]"],
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(true);
+    });
+
+    it("should return false for ems__Task class", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__Task]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(false);
+    });
+
+    it("should return false for ems__Project class", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: "[[ems__Project]]",
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(false);
+    });
+
+    it("should return false for null instanceClass", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: null,
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(false);
+    });
+
+    it("should return false for empty array instanceClass", () => {
+      const context: CommandVisibilityContext = {
+        instanceClass: [],
+        currentStatus: null,
+        metadata: {},
+        isArchived: false,
+        currentFolder: "",
+        expectedFolder: null,
+      };
+      expect(canCopyFleetingNoteLabel(context)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
Add a new command to copy the fleeting note label (first line of body) to clipboard. The command is visible only for assets with class `ztlk__FleetingNote` or UUID `fca0a931-a01f-48e4-b72a-4af206c94bc7`.

## Changes
- Add `FLEETING_NOTE` and `FLEETING_NOTE_UID` to `AssetClass` enum
- Add `canCopyFleetingNoteLabel` visibility rule to `AssetVisibilityRules.ts`
- Create `CopyFleetingNoteLabelCommand` implementing `ICommand` interface
- Register command in `CommandRegistry`
- Add 23 comprehensive unit tests

## User Story
**As a** Exocortex user working with fleeting notes  
**I want** to quickly copy the note's label to clipboard  
**So that** I can paste it into other notes, messages, or documents without manual selection

## Technical Details
- Label is extracted from the note body (first non-empty line after frontmatter)
- Uses `navigator.clipboard.writeText()` for cross-platform clipboard access
- Shows success/error notifications via Obsidian's Notice API
- Follows existing command patterns (CopyLabelToAliasesCommand)

## Testing
- [x] 10 visibility rule tests (canCopyFleetingNoteLabel)
- [x] 13 command tests (CopyFleetingNoteLabelCommand)
- [x] All existing tests pass
- [x] Build succeeds
- [x] Lint passes
- [x] Type check passes

Closes #2200