### PR TITLE
feat(plugin): add Copy Label button to UI for FleetingNote

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -123,6 +123,7 @@ export class ButtonGroupsBuilder {
 
     // Aggregate services for button builders
     this.services = {
+      app,
       taskCreationService,
       projectCreationService,
       areaCreationService,

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/ButtonBuilderTypes.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/ButtonBuilderTypes.ts
@@ -36,6 +36,7 @@ export interface ButtonBuilderContext {
  * Services container for button actions
  */
 export interface ButtonBuilderServices {
+  app: ObsidianApp;
   taskCreationService: TaskCreationService;
   projectCreationService: ProjectCreationService;
   areaCreationService: AreaCreationService;

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/MaintenanceButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/MaintenanceButtonGroupBuilder.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import { TFile, Notice } from "obsidian";
 import { ActionButton } from '@plugin/presentation/components/ActionButtonsGroup';
 import {
   canTrashEffort,
@@ -7,6 +7,7 @@ import {
   canRepairFolder,
   canRenameToUid,
   canCopyLabelToAliases,
+  canCopyFleetingNoteLabel,
   canConvertTaskToProject,
   canConvertProjectToTask,
   CommandVisibilityContext,
@@ -45,6 +46,7 @@ export class MaintenanceButtonGroupBuilder implements IButtonGroupBuilder {
       this.repairFolderButton(file, visibilityContext, expectedFolder, currentFolder, logger, refresh),
       this.renameToUidButton(file, metadata, visibilityContext, logger, refresh),
       this.copyLabelToAliasesButton(file, visibilityContext, logger, refresh),
+      this.copyFleetingNoteLabelButton(file, visibilityContext, logger),
       this.convertTaskToProjectButton(file, visibilityContext, logger, refresh),
       this.convertProjectToTaskButton(file, visibilityContext, logger, refresh),
     ];
@@ -180,6 +182,69 @@ export class MaintenanceButtonGroupBuilder implements IButtonGroupBuilder {
         logger.info(`Copied label to aliases: ${file.path}`);
       },
     };
+  }
+
+  private copyFleetingNoteLabelButton(
+    file: TFile,
+    context: CommandVisibilityContext,
+    logger: ILogger,
+  ): ActionButton {
+    return {
+      id: "copy-fleeting-note-label",
+      label: "Copy Label",
+      variant: "secondary",
+      visible: canCopyFleetingNoteLabel(context),
+      onClick: async () => {
+        try {
+          const content = await this.services.app.vault.read(file);
+          const label = this.extractLabelFromContent(content);
+
+          if (!label) {
+            new Notice("Label is empty");
+            return;
+          }
+
+          await navigator.clipboard.writeText(label);
+          new Notice("Label copied to clipboard");
+          logger.info(`Copied fleeting note label: ${file.path}`);
+        } catch (error) {
+          new Notice(`Failed to copy label: ${error instanceof Error ? error.message : String(error)}`);
+          logger.error(`Failed to copy fleeting note label: ${file.path}`, error instanceof Error ? error : undefined);
+        }
+      },
+    };
+  }
+
+  /**
+   * Extracts the label (first non-empty line of body) from file content.
+   *
+   * @param content - Full file content including frontmatter
+   * @returns The trimmed first line of body, or null if empty
+   */
+  private extractLabelFromContent(content: string): string | null {
+    const lines = content.split("\n");
+
+    // Find body start after frontmatter
+    let bodyStartIndex = 0;
+    if (lines[0] === "---") {
+      // Find closing ---
+      for (let i = 1; i < lines.length; i++) {
+        if (lines[i] === "---") {
+          bodyStartIndex = i + 1;
+          break;
+        }
+      }
+    }
+
+    // Find first non-empty line in body
+    for (let i = bodyStartIndex; i < lines.length; i++) {
+      const trimmedLine = lines[i].trim();
+      if (trimmedLine) {
+        return trimmedLine;
+      }
+    }
+
+    return null;
   }
 
   private convertTaskToProjectButton(

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
@@ -866,4 +866,65 @@ describe("ButtonGroupsBuilder - build", () => {
     );
     expect(createTaskButton?.visible).toBe(true);
   });
+
+  it("should show Copy Label button for FleetingNote", async () => {
+    const mockFile = {
+      path: "fleeting.md",
+      parent: { path: "FleetingNotes" },
+      basename: "fleeting",
+    } as TFile;
+    const metadata = {
+      exo__Instance_class: "[[ztlk__FleetingNote]]",
+    };
+
+    ctx.mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[ztlk__FleetingNote]]",
+    );
+    ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
+    ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
+    ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("FleetingNotes");
+
+    const groups = await ctx.builder.build(mockFile);
+
+    const maintenanceGroup = groups.find((g) => g.id === "maintenance");
+    const copyLabelButton = maintenanceGroup?.buttons.find(
+      (b) => b.id === "copy-fleeting-note-label",
+    );
+    expect(copyLabelButton).toBeDefined();
+    expect(copyLabelButton?.visible).toBe(true);
+  });
+
+  it("should NOT show Copy Label button for Task", async () => {
+    const mockFile = {
+      path: "task.md",
+      parent: { path: "Tasks" },
+      basename: "task",
+    } as TFile;
+    const metadata = {
+      exo__Instance_class: "[[ems__Task]]",
+      ems__Effort_status: "[[ems__EffortStatusBacklog]]",
+    };
+
+    ctx.mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[ems__Task]]",
+    );
+    ctx.mockMetadataExtractor.extractStatus.mockReturnValue(
+      "[[ems__EffortStatusBacklog]]",
+    );
+    ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
+    ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
+
+    const groups = await ctx.builder.build(mockFile);
+
+    const maintenanceGroup = groups.find((g) => g.id === "maintenance");
+    const copyLabelButton = maintenanceGroup?.buttons.find(
+      (b) => b.id === "copy-fleeting-note-label",
+    );
+    // Button may or may not exist, but if it exists it should not be visible
+    if (copyLabelButton) {
+      expect(copyLabelButton.visible).toBe(false);
+    }
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.fixtures.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.fixtures.ts
@@ -48,6 +48,9 @@ export function setupButtonGroupsBuilderTest(): ButtonGroupsBuilderTestContext {
       }),
       setActiveLeaf: jest.fn(),
     },
+    vault: {
+      read: jest.fn().mockResolvedValue("---\n---\nMock Label Content"),
+    },
   };
 
   const mockSettings = {


### PR DESCRIPTION
## Summary
- Add the missing UI button for the CopyFleetingNoteLabelCommand (introduced in PR #2201 but without the UI component)
- Button appears in MAINTENANCE section for FleetingNote assets
- Copies the first non-empty line after frontmatter to clipboard

## Changes
- Add `canCopyFleetingNoteLabel` to MaintenanceButtonGroupBuilder imports
- Add `copyFleetingNoteLabelButton` method to MaintenanceButtonGroupBuilder
- Add `app` to ButtonBuilderServices for file reading capability
- Add unit tests for Copy Label button visibility on FleetingNote

## Testing
- [x] Added unit tests for Copy Label button visibility
- [x] Verified button appears for FleetingNote assets
- [x] Verified button does NOT appear for Task assets
- [x] All existing tests pass

## Verification
- [x] `npm run build` — PASSED
- [x] `npm run lint` — PASSED
- [x] `npm run test:unit` — PASSED

## Acceptance Criteria
- [x] FleetingNote assets show "Copy Label" button in MAINTENANCE section
- [x] Other asset types do NOT show "Copy Label" button
- [x] Clicking button copies first line of body to clipboard
- [x] User sees success notification

Closes #2202