### PR TITLE
feat(sparql): Implement HAVING clause support for GROUP BY operations

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraOperation.ts
+++ b/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraOperation.ts
@@ -375,10 +375,29 @@ export interface ReducedOperation {
   input: AlgebraOperation;
 }
 
+/**
+ * GROUP BY operation with optional HAVING clause.
+ *
+ * SPARQL 1.1 GROUP BY groups solutions by the specified variables,
+ * then computes aggregate functions over each group.
+ *
+ * HAVING filters the grouped results based on aggregate conditions.
+ * It operates on the grouped solutions AFTER aggregation is computed.
+ *
+ * Example:
+ * ```sparql
+ * SELECT ?category (COUNT(?item) AS ?count)
+ * WHERE { ?item ex:category ?category }
+ * GROUP BY ?category
+ * HAVING (COUNT(?item) > 5)
+ * ```
+ */
 export interface GroupOperation {
   type: "group";
   variables: string[];
   aggregates: AggregateBinding[];
+  /** HAVING clause filter expressions. Applied after grouping and aggregation. */
+  having?: Expression[];
   input: AlgebraOperation;
 }
 

--- a/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraTranslator.ts
+++ b/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraTranslator.ts
@@ -99,11 +99,19 @@ export class AlgebraTranslator {
     const aggregates = this.extractAggregatesWithMapping(query.variables, aggregateVarMap);
     const groupVars = this.extractGroupVariables(query.group);
 
-    if (aggregates.length > 0 || groupVars.length > 0) {
+    // Extract and translate HAVING expressions, collecting any additional aggregates
+    const havingExpressions = this.extractHavingExpressions(
+      (query as any).having,
+      aggregates,
+      aggregateVarMap
+    );
+
+    if (aggregates.length > 0 || groupVars.length > 0 || havingExpressions.length > 0) {
       operation = {
         type: "group",
         variables: groupVars,
         aggregates: aggregates,
+        having: havingExpressions.length > 0 ? havingExpressions : undefined,
         input: operation,
       };
     }
@@ -388,6 +396,38 @@ export class AlgebraTranslator {
     return group
       .filter((g: any) => g.expression && g.expression.termType === "Variable")
       .map((g: any) => g.expression.value);
+  }
+
+  /**
+   * Extract and translate HAVING expressions.
+   *
+   * HAVING expressions can contain aggregate functions that may or may not
+   * appear in the SELECT clause. We need to:
+   * 1. Find any aggregate functions in HAVING
+   * 2. Create bindings for them (if not already in aggregates list)
+   * 3. Transform the HAVING expression to reference the computed aggregate variables
+   *
+   * @param having - The raw HAVING expressions from sparqljs
+   * @param aggregates - The aggregates array to add any new aggregates to
+   * @param aggregateVarMap - Map from sparqljs aggregate objects to variable names
+   * @returns The translated HAVING expressions
+   */
+  private extractHavingExpressions(
+    having: any[] | undefined,
+    aggregates: AggregateBinding[],
+    aggregateVarMap: Map<any, string>
+  ): Expression[] {
+    if (!having || having.length === 0) return [];
+
+    // First, collect any aggregates in HAVING that aren't already tracked
+    for (const expr of having) {
+      this.collectNestedAggregates(expr, aggregates, aggregateVarMap);
+    }
+
+    // Then transform HAVING expressions to reference aggregate variable bindings
+    return having.map((expr) =>
+      this.transformExpressionWithAggregateVars(expr, aggregateVarMap)
+    );
   }
 
   /**

--- a/packages/exocortex/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -420,8 +420,23 @@ export class QueryExecutor {
 
     // Use AggregateExecutor to compute grouped results
     const results = this.aggregateExecutor.execute(operation, inputSolutions);
-    for (const result of results) {
-      yield result;
+
+    // Apply HAVING filter if present
+    if (operation.having && operation.having.length > 0) {
+      for (const result of results) {
+        // All HAVING conditions must be true
+        const passesHaving = operation.having.every((expr) => {
+          const value = this.filterExecutor.evaluateExpression(expr as any, result);
+          return value === true;
+        });
+        if (passesHaving) {
+          yield result;
+        }
+      }
+    } else {
+      for (const result of results) {
+        yield result;
+      }
     }
   }
 

--- a/packages/exocortex/tests/compliance/sparql/aggregates.test.ts
+++ b/packages/exocortex/tests/compliance/sparql/aggregates.test.ts
@@ -9,7 +9,7 @@
  * - MIN: ✅ Implemented
  * - MAX: ✅ Implemented
  * - GROUP BY: ✅ Implemented
- * - HAVING: ⚠️ Partial (not correctly filtering)
+ * - HAVING: ✅ Implemented
  * - GROUP_CONCAT: ❌ Not tested
  * - SAMPLE: ❌ Not tested
  */
@@ -153,8 +153,7 @@ describe("SPARQL 1.1 Aggregates Compliance", () => {
   });
 
   describe("HAVING", () => {
-    // HAVING is not correctly filtering grouped results
-    it.skip("should filter grouped results", async () => {
+    it("should filter grouped results", async () => {
       const { store, executor } = createTestEnvironment();
       await loadTestData(store, TEST_DATA.numericData());
 
@@ -173,22 +172,21 @@ describe("SPARQL 1.1 Aggregates Compliance", () => {
       expect(results[0].category).toBe("B");
     });
 
-    it("should return all groups when HAVING is present (current behavior)", async () => {
+    it("should filter by aggregate count", async () => {
       const { store, executor } = createTestEnvironment();
       await loadTestData(store, TEST_DATA.numericData());
 
       const query = `
         ${buildPrefixes("ex")}
-        SELECT ?category (SUM(?value) AS ?total) WHERE {
-          ?item ex:category ?category .
-          ?item ex:value ?value
+        SELECT ?category (COUNT(?item) AS ?count) WHERE {
+          ?item ex:category ?category
         }
         GROUP BY ?category
-        HAVING (SUM(?value) > 50)
+        HAVING (COUNT(?item) >= 2)
       `;
 
       const results = await executeQuery(executor, query);
-      // Current implementation doesn't filter by HAVING
+      // Both A and B have at least 2 items
       expect(results.length).toBeGreaterThanOrEqual(1);
     });
   });

--- a/packages/exocortex/tests/sparql/compliance/aggregates.test.ts
+++ b/packages/exocortex/tests/sparql/compliance/aggregates.test.ts
@@ -593,8 +593,7 @@ describe("SPARQL 1.1 Compliance - Aggregate Functions", () => {
   });
 
   describe("HAVING Clause", () => {
-    // HAVING clause filtering not fully implemented - returns all groups
-    it.skip("should filter groups by aggregate condition", async () => {
+    it("should filter groups by aggregate condition", async () => {
       const query = `
         PREFIX ex: <http://example.org/>
         SELECT ?dept (COUNT(?emp) AS ?empCount) WHERE {
@@ -615,7 +614,7 @@ describe("SPARQL 1.1 Compliance - Aggregate Functions", () => {
       }
     });
 
-    it.skip("should filter groups by aggregate comparison", async () => {
+    it("should filter groups by aggregate comparison", async () => {
       const query = `
         PREFIX ex: <http://example.org/>
         SELECT ?dept (AVG(?salary) AS ?avgSalary) WHERE {


### PR DESCRIPTION
## Summary

This PR completes SPARQL 1.1 HAVING clause support, fixing the previously incomplete implementation.

### Changes

- **AlgebraOperation.ts**: Added `having` field to `GroupOperation` interface with documentation
- **AlgebraTranslator.ts**: Added `extractHavingExpressions()` to translate HAVING expressions and collect any aggregates referenced in HAVING
- **QueryExecutor.ts**: Added HAVING filter evaluation in `executeGroup()` after grouping

### Implementation Details

The HAVING clause is now properly implemented:
1. **Parse**: HAVING expressions are extracted from sparqljs AST (as `query.having`)
2. **Translate**: Aggregates in HAVING expressions get unique variable bindings, then expressions are transformed to reference these computed values
3. **Execute**: After GROUP BY produces results, HAVING filters are evaluated on each group

### Closes #2204

## SPARQL 1.1 Features Status

Based on analysis, the implementation status is:

| Feature | Status |
|---------|--------|
| GROUP BY with aggregates (COUNT, SUM, AVG, MIN, MAX) | ✅ Already implemented |
| HAVING clause | ✅ **Fixed in this PR** |
| Subqueries (nested SELECT) | ✅ Already implemented |
| Property paths (/, \|, ^, *, +, ?) | ✅ Already implemented |

### Test Plan

- [x] Unskipped and verified HAVING tests in `tests/sparql/compliance/aggregates.test.ts`
- [x] Updated HAVING tests in `tests/compliance/sparql/aggregates.test.ts`
- [x] All existing SPARQL tests pass
- [x] Build passes
- [x] Lint passes

### Examples

```sparql
# Count tasks by status, filter groups with more than 5 items
SELECT ?status (COUNT(?task) AS ?count)
WHERE { ?task ems:status ?status }
GROUP BY ?status
HAVING (COUNT(?task) > 5)

# Filter by aggregate comparison
SELECT ?dept (AVG(?salary) AS ?avgSalary)
WHERE { ?emp ex:department ?dept . ?emp ex:salary ?salary }
GROUP BY ?dept
HAVING (AVG(?salary) > 55000)

# Multiple HAVING conditions
SELECT ?category (COUNT(?item) AS ?count) (SUM(?value) AS ?total)
WHERE { ?item ex:category ?category . ?item ex:value ?value }
GROUP BY ?category
HAVING (COUNT(?item) >= 2 && SUM(?value) > 100)
```