### PR TITLE
fix(sparql): enable Unicode-aware REGEX and REPLACE matching

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/filters/BuiltInFunctions.ts
+++ b/packages/exocortex/src/infrastructure/sparql/filters/BuiltInFunctions.ts
@@ -341,9 +341,28 @@ export class BuiltInFunctions {
     return numericTypes.includes(datatype);
   }
 
+  /**
+   * SPARQL REGEX function with Unicode support.
+   *
+   * Per SPARQL 1.1 specification, REGEX is based on XPath/XQuery regex which
+   * uses XSD patterns that are Unicode-aware by default. To match this behavior
+   * in JavaScript, we always include the 'u' (Unicode) flag.
+   *
+   * This enables:
+   * - Case-insensitive matching for non-ASCII characters (Cyrillic, Greek, etc.)
+   * - Unicode character classes like \p{L} (any letter), \p{N} (any number)
+   *
+   * @param text - The text to match against
+   * @param pattern - The regex pattern (XPath/XSD regex syntax)
+   * @param flags - Optional flags: 's' (dotall), 'm' (multiline), 'i' (case-insensitive), 'x' (extended)
+   * @returns true if pattern matches text
+   */
   static regex(text: string, pattern: string, flags?: string): boolean {
     try {
-      const regex = new RegExp(pattern, flags);
+      // Always add 'u' flag for Unicode-aware matching (SPARQL 1.1 compliance)
+      // This enables proper Cyrillic/Unicode case-insensitive matching and \p{} classes
+      const unicodeFlags = flags ? (flags.includes("u") ? flags : flags + "u") : "u";
+      const regex = new RegExp(pattern, unicodeFlags);
       return regex.test(text);
     } catch (error) {
       throw new Error(`REGEX: invalid pattern '${pattern}': ${(error as Error).message}`);
@@ -545,12 +564,17 @@ export class BuiltInFunctions {
   }
 
   /**
-   * SPARQL 1.1 REPLACE function.
+   * SPARQL 1.1 REPLACE function with Unicode support.
    * https://www.w3.org/TR/sparql11-query/#func-replace
+   *
+   * Always includes 'u' flag for Unicode-aware matching (SPARQL 1.1 compliance).
    */
   static replace(str: string, pattern: string, replacement: string, flags?: string): string {
     try {
-      const regex = new RegExp(pattern, flags || "g");
+      // Always add 'u' flag for Unicode-aware matching, ensure 'g' flag is present for replace
+      const baseFlags = flags || "g";
+      const unicodeFlags = baseFlags.includes("u") ? baseFlags : baseFlags + "u";
+      const regex = new RegExp(pattern, unicodeFlags);
       return str.replace(regex, replacement);
     } catch (error) {
       throw new Error(`REPLACE: invalid pattern '${pattern}': ${(error as Error).message}`);

--- a/packages/exocortex/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/filters/BuiltInFunctions.test.ts
@@ -1157,6 +1157,50 @@ describe("BuiltInFunctions", () => {
     it("should throw for invalid regex", () => {
       expect(() => BuiltInFunctions.regex("test", "[invalid")).toThrow("REGEX: invalid pattern");
     });
+
+    // Issue #2207: Cyrillic and Unicode support
+    describe("Unicode/Cyrillic support (Issue #2207)", () => {
+      it("should support case-insensitive matching for Cyrillic text", () => {
+        // Lowercase pattern matching uppercase text
+        expect(BuiltInFunctions.regex("Проект", "проект", "i")).toBe(true);
+        // Uppercase pattern matching lowercase text
+        expect(BuiltInFunctions.regex("проект", "ПРОЕКТ", "i")).toBe(true);
+      });
+
+      it("should match Cyrillic text with all uppercase", () => {
+        expect(BuiltInFunctions.regex("ТЕКСТ", "текст", "i")).toBe(true);
+        expect(BuiltInFunctions.regex("текст", "ТЕКСТ", "i")).toBe(true);
+      });
+
+      it("should handle Cyrillic ё/Ё correctly", () => {
+        // ё and Ё are the same letter, different cases
+        expect(BuiltInFunctions.regex("Ёлка", "ёлка", "i")).toBe(true);
+        expect(BuiltInFunctions.regex("ёлка", "Ёлка", "i")).toBe(true);
+      });
+
+      it("should support Unicode character classes with u flag", () => {
+        // \p{L} matches any Unicode letter
+        expect(BuiltInFunctions.regex("Привет", "\\p{L}+")).toBe(true);
+        expect(BuiltInFunctions.regex("Hello", "\\p{L}+")).toBe(true);
+        expect(BuiltInFunctions.regex("123", "\\p{L}+")).toBe(false);
+      });
+
+      it("should support Unicode character classes with case-insensitive flag", () => {
+        // \p{L} with case-insensitive should work
+        expect(BuiltInFunctions.regex("ПРИВЕТ", "\\p{L}+", "i")).toBe(true);
+      });
+
+      it("should match Cyrillic patterns without flags", () => {
+        expect(BuiltInFunctions.regex("Привет мир", "мир")).toBe(true);
+        expect(BuiltInFunctions.regex("Привет мир", "Привет")).toBe(true);
+      });
+
+      it("should support Unicode in complex patterns", () => {
+        // Pattern with Cyrillic and special regex characters
+        expect(BuiltInFunctions.regex("Проект-2024", "Проект-\\d+")).toBe(true);
+        expect(BuiltInFunctions.regex("проект-2024", "проект-\\d+", "i")).toBe(true);
+      });
+    });
   });
 
   describe("Comparison", () => {
@@ -1428,6 +1472,23 @@ describe("BuiltInFunctions", () => {
 
     it("should throw for invalid regex", () => {
       expect(() => BuiltInFunctions.replace("test", "[invalid", "x")).toThrow("REPLACE: invalid pattern");
+    });
+
+    // Issue #2207: Unicode support for REPLACE
+    describe("Unicode/Cyrillic support (Issue #2207)", () => {
+      it("should support case-insensitive replacement for Cyrillic", () => {
+        expect(BuiltInFunctions.replace("Привет мир", "привет", "Здравствуй", "i")).toBe("Здравствуй мир");
+      });
+
+      it("should support Unicode character classes in patterns", () => {
+        // \p{L} matches any Unicode letter
+        expect(BuiltInFunctions.replace("Hello123World", "\\p{L}+", "X")).toBe("X123X");
+        expect(BuiltInFunctions.replace("Привет123Мир", "\\p{L}+", "X")).toBe("X123X");
+      });
+
+      it("should replace Cyrillic patterns correctly", () => {
+        expect(BuiltInFunctions.replace("Проект-2024-Проект", "Проект", "Задача")).toBe("Задача-2024-Задача");
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add 'u' (Unicode) flag to all REGEX and REPLACE operations for SPARQL 1.1 compliance
- Enables proper case-insensitive matching for Cyrillic, Greek, and other non-ASCII scripts
- Supports Unicode character classes like `\p{L}` (any letter), `\p{N}` (any number)

## Changes
- `BuiltInFunctions.regex()`: Always include 'u' flag for Unicode-aware matching
- `BuiltInFunctions.replace()`: Always include 'u' flag for Unicode-aware replacement
- Added comprehensive tests for Cyrillic/Unicode REGEX matching
- Added tests for Unicode REPLACE patterns

## Testing
- [x] Added 7 tests for REGEX Unicode/Cyrillic support
- [x] Added 3 tests for REPLACE Unicode/Cyrillic support
- [x] All existing REGEX and REPLACE tests pass (no regressions)
- [x] Build passes
- [x] Lint passes

## Acceptance Criteria (from Issue #2207)
- [x] Case-insensitive Cyrillic matching works: `FILTER REGEX(?x, "проект", "i")` matches "Проект"
- [x] Unicode character classes work: `\p{L}+` matches Cyrillic letters
- [x] Test cases for Cyrillic REGEX queries added

## Technical Details
Per SPARQL 1.1 specification, REGEX is based on XPath/XQuery regex which uses XSD patterns that are Unicode-aware by default. By always including the 'u' flag in JavaScript RegExp, we ensure compliance with this specification.

Fixes #2207