### PR TITLE
feat(cli): Add SPARQL debugging capabilities (--dry-run)

### DIFF
--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -4,6 +4,7 @@ import { resolve } from "path";
 import {
   InMemoryTripleStore,
   SPARQLParser,
+  SPARQLParseError,
   AlgebraTranslator,
   AlgebraOptimizer,
   AlgebraSerializer,
@@ -11,7 +12,6 @@ import {
   NoteToRDFConverter,
   Triple,
   type SolutionMapping,
-  type AlgebraOperation,
   type ConstructOperation,
 } from "exocortex";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
@@ -21,7 +21,8 @@ import { CsvFormatter } from "../formatters/CsvFormatter.js";
 import { TriplesFormatter } from "../formatters/TriplesFormatter.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError, InvalidArgumentsError } from "../utils/errors/index.js";
-import { ResponseBuilder, type QueryResult, type ConstructResult } from "../responses/index.js";
+import { ResponseBuilder, ErrorCode, type QueryResult, type ConstructResult } from "../responses/index.js";
+import { ExitCodes } from "../utils/ExitCodes.js";
 import { CacheManager } from "../cache/CacheManager.js";
 import { ProgressIndicator } from "../utils/ProgressIndicator.js";
 
@@ -30,6 +31,7 @@ export interface SparqlQueryOptions {
   format: "table" | "json" | "csv" | "ntriples";
   output?: OutputFormat;
   explain?: boolean;
+  dryRun?: boolean;
   stats?: boolean;
   noOptimize?: boolean;
   useCache?: boolean;
@@ -86,6 +88,7 @@ export function sparqlQueryCommand(): Command {
     .option("--format <type>", "Output format: table|json|csv|ntriples", "table")
     .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
     .option("--timeout <duration>", "Query timeout (e.g., 30s, 5000ms)", "10s")
+    .option("--dry-run", "Validate query syntax without executing (no vault loading)")
     .option("--explain", "Show optimized query plan")
     .option("--stats", "Show execution statistics")
     .option("--no-optimize", "Disable query optimization")
@@ -101,6 +104,12 @@ export function sparqlQueryCommand(): Command {
         const timeoutMs = parseTimeout(options.timeout || "10s");
 
         const queryString = loadQuery(queryArg);
+
+        // Dry-run mode: validate syntax only, no vault loading
+        if (options.dryRun) {
+          await executeDryRun(queryString, options, outputFormat);
+          return;
+        }
 
         const vaultPath = resolve(options.vault);
         if (!existsSync(vaultPath)) {
@@ -308,6 +317,110 @@ function loadQuery(queryArg: string): string {
   }
 
   return queryArg;
+}
+
+/**
+ * Execute dry-run mode: validate query syntax without loading vault or executing.
+ * This is useful for checking query syntax before running expensive operations.
+ */
+async function executeDryRun(
+  queryString: string,
+  options: SparqlQueryOptions,
+  outputFormat: OutputFormat
+): Promise<void> {
+  const parser = new SPARQLParser();
+
+  try {
+    // Parse query to validate syntax
+    const ast = parser.parse(queryString);
+
+    // Translate to algebra (validates query structure)
+    const translator = new AlgebraTranslator();
+    let algebra = translator.translate(ast);
+
+    // Optimize if requested (validates optimization rules)
+    if (!options.noOptimize && algebra.type !== "construct") {
+      const optimizer = new AlgebraOptimizer();
+      algebra = optimizer.optimize(algebra);
+    } else if (!options.noOptimize && algebra.type === "construct") {
+      const optimizer = new AlgebraOptimizer();
+      const constructOp = algebra as ConstructOperation;
+      algebra = {
+        ...constructOp,
+        where: optimizer.optimize(constructOp.where),
+      };
+    }
+
+    if (outputFormat === "json") {
+      // JSON response for MCP tools
+      const response = ResponseBuilder.success({
+        valid: true,
+        queryType: getQueryType(ast),
+        message: "Query syntax is valid",
+      });
+      console.log(JSON.stringify(response, null, 2));
+    } else {
+      // Text mode output
+      console.log(`✅ Query syntax is valid`);
+      console.log(`   Query type: ${getQueryType(ast)}`);
+
+      // Show query plan if --explain is also set
+      if (options.explain) {
+        console.log(`\n📊 Query Plan:`);
+        const serializer = new AlgebraSerializer();
+        if (algebra.type === "construct") {
+          const constructOp = algebra as ConstructOperation;
+          console.log("CONSTRUCT Template:");
+          console.log("  (template patterns)");
+          console.log("WHERE:");
+          console.log(serializer.toString(constructOp.where));
+        } else {
+          console.log(serializer.toString(algebra));
+        }
+      }
+    }
+  } catch (error) {
+    // Handle parse errors with detailed information
+    if (error instanceof SPARQLParseError) {
+      const locationInfo = error.line !== undefined
+        ? ` at line ${error.line}${error.column !== undefined ? `, column ${error.column}` : ""}`
+        : "";
+
+      if (outputFormat === "json") {
+        const response = ResponseBuilder.error(
+          ErrorCode.VALIDATION_INVALID_FORMAT,
+          error.message,
+          ExitCodes.INVALID_ARGUMENTS,
+          {
+            context: {
+              valid: false,
+              line: error.line,
+              column: error.column,
+            },
+          }
+        );
+        console.log(JSON.stringify(response, null, 2));
+      } else {
+        console.error(`❌ Syntax error${locationInfo}:`);
+        console.error(`   ${error.message}`);
+      }
+      process.exit(ExitCodes.INVALID_ARGUMENTS);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get the query type from a parsed AST.
+ */
+function getQueryType(ast: any): string {
+  if (ast.type === "update") {
+    return "UPDATE";
+  }
+  if ("queryType" in ast) {
+    return ast.queryType as string;
+  }
+  return "UNKNOWN";
 }
 
 function formatSelectResults(results: SolutionMapping[], format: string): void {

--- a/packages/cli/tests/unit/commands/sparql-query-debug.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-debug.test.ts
@@ -1,0 +1,270 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs";
+
+// Mock dependencies
+const mockTableFormatter = {
+  format: jest.fn().mockReturnValue("table output"),
+};
+const mockJsonFormatter = {
+  format: jest.fn().mockReturnValue('{"result": []}'),
+};
+
+jest.unstable_mockModule("../../../src/formatters/TableFormatter.js", () => ({
+  TableFormatter: jest.fn(() => mockTableFormatter),
+}));
+
+jest.unstable_mockModule("../../../src/formatters/JsonFormatter.js", () => ({
+  JsonFormatter: jest.fn(() => mockJsonFormatter),
+}));
+
+// Mock the heavy exocortex dependencies
+const mockParseFn = jest.fn().mockReturnValue({ type: "query", queryType: "SELECT" });
+
+jest.unstable_mockModule("exocortex", () => ({
+  InMemoryTripleStore: jest.fn(() => ({
+    addAll: jest.fn(),
+  })),
+  SPARQLParser: jest.fn(() => ({
+    parse: mockParseFn,
+  })),
+  SPARQLParseError: class SPARQLParseError extends Error {
+    public readonly line?: number;
+    public readonly column?: number;
+    constructor(message: string, line?: number, column?: number) {
+      super(message);
+      this.name = "SPARQLParseError";
+      this.line = line;
+      this.column = column;
+    }
+  },
+  AlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+  AlgebraOptimizer: jest.fn(() => ({
+    optimize: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+  AlgebraSerializer: jest.fn(() => ({
+    toString: jest.fn().mockReturnValue("BGP()"),
+  })),
+  QueryExecutor: jest.fn(() => ({
+    executeAll: jest.fn().mockResolvedValue([]),
+    isConstructQuery: jest.fn().mockReturnValue(false),
+  })),
+  NoteToRDFConverter: jest.fn(() => ({
+    convertVault: jest.fn().mockResolvedValue([]),
+  })),
+  SolutionMapping: class SolutionMapping extends Map {},
+  IRI: jest.fn(),
+  Literal: jest.fn(),
+  BlankNode: jest.fn(),
+  Triple: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../../src/adapters/FileSystemVaultAdapter.js", () => ({
+  FileSystemVaultAdapter: jest.fn(),
+}));
+
+// Mock CacheManager for --use-cache option
+jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
+  CacheManager: jest.fn(() => ({
+    loadOrBuild: jest.fn().mockResolvedValue({ triples: [], cacheHit: false, durationMs: 10 }),
+    buildCache: jest.fn().mockResolvedValue({ tripleCount: 0, durationMs: 10 }),
+    getCacheStats: jest.fn().mockResolvedValue(null),
+    invalidate: jest.fn().mockResolvedValue(undefined),
+    getCachePath: jest.fn().mockReturnValue("/mock/cache/path"),
+  })),
+}));
+
+// Mock ProgressIndicator
+jest.unstable_mockModule("../../../src/utils/ProgressIndicator.js", () => ({
+  ProgressIndicator: jest.fn(() => ({
+    start: jest.fn(),
+    stop: jest.fn(),
+  })),
+}));
+
+const { sparqlQueryCommand } = await import("../../../src/commands/sparql-query.js");
+
+describe("sparqlQueryCommand --dry-run flag", () => {
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let existsSyncSpy: jest.SpiedFunction<typeof fs.existsSync>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation((() => {}) as any);
+    existsSyncSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(process, "cwd").mockReturnValue("/test/vault");
+
+    // Reset parser mock to success state
+    mockParseFn.mockReturnValue({ type: "query", queryType: "SELECT" });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("command setup", () => {
+    it("should accept --dry-run option", () => {
+      const cmd = sparqlQueryCommand();
+      const options = cmd.options;
+      const dryRunOption = options.find(opt => opt.flags.includes("--dry-run"));
+      expect(dryRunOption).toBeDefined();
+    });
+
+    it("should have dry-run option with description mentioning validation", () => {
+      const cmd = sparqlQueryCommand();
+      const options = cmd.options;
+      const dryRunOption = options.find(opt => opt.flags.includes("--dry-run"));
+      expect(dryRunOption?.description).toMatch(/valid|syntax|check|parse/i);
+    });
+  });
+
+  describe("--dry-run execution", () => {
+    it("should validate syntax without loading vault when --dry-run is set", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", "/test/vault",
+        "--dry-run",
+      ]);
+
+      // Should show success message for valid query
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("valid"));
+      // Should NOT show "Loading vault" message (no vault loading in dry-run mode)
+      const loadingVaultCalls = consoleLogSpy.mock.calls.filter(
+        call => call[0]?.toString().includes("Loading vault")
+      );
+      expect(loadingVaultCalls.length).toBe(0);
+    });
+
+    it("should report syntax errors with line numbers when --dry-run is set", async () => {
+      // Make parser throw error with line/column info
+      const { SPARQLParseError } = await import("exocortex");
+      mockParseFn.mockImplementationOnce(() => {
+        throw new SPARQLParseError("Unexpected token", 3, 15);
+      });
+
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { INVALID }",
+        "--vault", "/test/vault",
+        "--dry-run",
+      ]);
+
+      // Should show error with line number
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/line.*3|3.*line/i)
+      );
+      // Should exit with non-zero code
+      expect(processExitSpy).toHaveBeenCalledWith(expect.any(Number));
+    });
+
+    it("should exit with code 0 for valid query in --dry-run mode", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", "/test/vault",
+        "--dry-run",
+      ]);
+
+      // Should not call process.exit with error code (0 is success, or no call at all)
+      const exitCalls = processExitSpy.mock.calls;
+      const errorExitCalls = exitCalls.filter(call => call[0] !== 0);
+      expect(errorExitCalls.length).toBe(0);
+    });
+
+    it("should exit with code 1 for invalid query in --dry-run mode", async () => {
+      const { SPARQLParseError } = await import("exocortex");
+      mockParseFn.mockImplementationOnce(() => {
+        throw new SPARQLParseError("Syntax error", 1, 1);
+      });
+
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "INVALID QUERY",
+        "--vault", "/test/vault",
+        "--dry-run",
+      ]);
+
+      // Should exit with non-zero code
+      expect(processExitSpy).toHaveBeenCalled();
+      const lastExitCall = processExitSpy.mock.calls[processExitSpy.mock.calls.length - 1];
+      expect(lastExitCall[0]).not.toBe(0);
+    });
+  });
+
+  describe("--dry-run with --explain combination", () => {
+    it("should show query plan without executing when both --dry-run and --explain are set", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", "/test/vault",
+        "--dry-run",
+        "--explain",
+      ]);
+
+      // Should show query plan
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Query Plan"));
+      // Should NOT load vault
+      const loadingVaultCalls = consoleLogSpy.mock.calls.filter(
+        call => call[0]?.toString().includes("Loading vault")
+      );
+      expect(loadingVaultCalls.length).toBe(0);
+    });
+  });
+});
+
+describe("sparqlQueryCommand enhanced error messages", () => {
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let existsSyncSpy: jest.SpiedFunction<typeof fs.existsSync>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation((() => {}) as any);
+    existsSyncSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(process, "cwd").mockReturnValue("/test/vault");
+
+    // Reset parser mock to success state
+    mockParseFn.mockReturnValue({ type: "query", queryType: "SELECT" });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("property name suggestions", () => {
+    it("should suggest correct property name for common typos", async () => {
+      // Simulate error with unknown property
+      const { SPARQLParseError } = await import("exocortex");
+      mockParseFn.mockImplementationOnce(() => {
+        throw new SPARQLParseError("Unknown prefix: ems__Task_status", 5, 10);
+      });
+
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ems:Task_status ?o }",
+        "--vault", "/test/vault",
+        "--dry-run",
+      ]);
+
+      // Error message should be shown
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/tests/unit/commands/sparql-query.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query.test.ts
@@ -25,6 +25,16 @@ jest.unstable_mockModule("exocortex", () => ({
   SPARQLParser: jest.fn(() => ({
     parse: jest.fn().mockReturnValue({ type: "query" }),
   })),
+  SPARQLParseError: class SPARQLParseError extends Error {
+    public readonly line?: number;
+    public readonly column?: number;
+    constructor(message: string, line?: number, column?: number) {
+      super(message);
+      this.name = "SPARQLParseError";
+      this.line = line;
+      this.column = column;
+    }
+  },
   AlgebraTranslator: jest.fn(() => ({
     translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
   })),


### PR DESCRIPTION
## Summary

Add `--dry-run` flag to the SPARQL query command for syntax validation without vault loading or query execution.

**Closes #2213**

## Changes

- Add `--dry-run` flag to `exocortex sparql query` command
- Validate SPARQL syntax using SPARQLParser
- Translate to algebra to verify query structure  
- Show query type (SELECT, CONSTRUCT, etc.)
- Combine with `--explain` to show query plan without execution
- Return structured JSON output in `--output json` mode
- Show line/column numbers for syntax errors

## Usage

```bash
# Validate syntax without execution
exocortex sparql query --dry-run "SELECT ?s WHERE { ?s ?p ?o }"

# Show query plan without execution
exocortex sparql query --dry-run --explain "SELECT ?s WHERE { ?s ?p ?o }"

# JSON output for MCP tools
exocortex sparql query --dry-run --output json "SELECT ?s WHERE { ?s ?p ?o }"
```

## Testing

- [x] Added unit tests for `--dry-run` flag (7 tests)
- [x] All existing tests pass
- [x] Build passes
- [x] Lint passes

## Acceptance Criteria

- [x] `--dry-run` validates SPARQL syntax without loading vault
- [x] Invalid queries show syntax errors with line numbers
- [x] Exit code 0 for valid queries, non-zero for invalid
- [x] Combined with `--explain` shows query plan