### PR TITLE
feat(cli): add SPARQL query templates library

### DIFF
--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -26,6 +26,7 @@ import { ExitCodes } from "../utils/ExitCodes.js";
 import { CacheManager } from "../cache/CacheManager.js";
 import { ProgressIndicator } from "../utils/ProgressIndicator.js";
 import { QueryAnalyzer } from "../utils/QueryAnalyzer.js";
+import { TemplateRegistry } from "../templates/TemplateRegistry.js";
 
 export interface SparqlQueryOptions {
   vault: string;
@@ -37,6 +38,8 @@ export interface SparqlQueryOptions {
   noOptimize?: boolean;
   useCache?: boolean;
   timeout?: string;
+  template?: string;
+  param?: string;
 }
 
 /**
@@ -107,7 +110,7 @@ export async function executeWithTimeout<T>(
 export function sparqlQueryCommand(): Command {
   return new Command("query")
     .description("Execute SPARQL query against Obsidian vault")
-    .argument("<query>", "SPARQL query string or path to .sparql file")
+    .argument("[query]", "SPARQL query string or path to .sparql file (optional if --template is used)")
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
     .option("--format <type>", "Output format: table|json|csv|ntriples", "table")
     .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
@@ -117,7 +120,9 @@ export function sparqlQueryCommand(): Command {
     .option("--stats", "Show execution statistics")
     .option("--no-optimize", "Disable query optimization")
     .option("--use-cache", "Use persistent cache (faster for repeated queries)")
-    .action(async (queryArg: string, options: SparqlQueryOptions) => {
+    .option("--template <name>", "Use a predefined query template")
+    .option("--param <params>", "Template parameters (format: key=value,key2=value2)")
+    .action(async (queryArg: string | undefined, options: SparqlQueryOptions) => {
       const outputFormat = (options.output || "text") as OutputFormat;
       ErrorHandler.setFormat(outputFormat);
 
@@ -127,7 +132,29 @@ export function sparqlQueryCommand(): Command {
         // Parse timeout
         const timeoutMs = parseTimeout(options.timeout || "30s");
 
-        const queryString = loadQuery(queryArg);
+        // Resolve query string from template or direct input
+        let queryString: string;
+        if (options.template) {
+          const registry = new TemplateRegistry();
+          const params = options.param ? registry.parseParamString(options.param) : {};
+          queryString = registry.applyTemplate(options.template, params);
+
+          if (outputFormat === "text") {
+            const template = registry.getTemplate(options.template);
+            console.log(`📋 Using template: ${options.template}`);
+            if (Object.keys(params).length > 0) {
+              console.log(`   Parameters: ${Object.entries(params).map(([k, v]) => `${k}=${v}`).join(", ")}`);
+            }
+            console.log();
+          }
+        } else if (queryArg) {
+          queryString = loadQuery(queryArg);
+        } else {
+          throw new InvalidArgumentsError(
+            "Either a query argument or --template flag is required.",
+            'exocortex sparql query "SELECT * WHERE { ?s ?p ?o }" or exocortex sparql query --template tasks-by-date --param date=2024-01-15'
+          );
+        }
 
         // Dry-run mode: validate syntax only, no vault loading
         if (options.dryRun) {

--- a/packages/cli/src/commands/sparql-templates.ts
+++ b/packages/cli/src/commands/sparql-templates.ts
@@ -1,0 +1,42 @@
+import { Command } from "commander";
+import { TemplateRegistry } from "../templates/TemplateRegistry.js";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { ResponseBuilder } from "../responses/index.js";
+
+export interface SparqlTemplatesOptions {
+  output?: OutputFormat;
+}
+
+/**
+ * Command to list available SPARQL query templates.
+ *
+ * Usage:
+ *   exocortex sparql templates
+ *   exocortex sparql templates --output json
+ */
+export function sparqlTemplatesCommand(): Command {
+  return new Command("templates")
+    .description("List available SPARQL query templates")
+    .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
+    .action(async (options: SparqlTemplatesOptions) => {
+      const outputFormat = (options.output || "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const registry = new TemplateRegistry();
+        const templates = registry.listTemplates();
+
+        if (outputFormat === "json") {
+          const response = ResponseBuilder.success({
+            templates,
+            count: templates.length,
+          });
+          console.log(JSON.stringify(response, null, 2));
+        } else {
+          console.log(registry.formatList("text"));
+        }
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import "reflect-metadata";
 import { Command } from "commander";
 import { sparqlQueryCommand } from "./commands/sparql-query.js";
 import { sparqlIndexCommand } from "./commands/sparql-index.js";
+import { sparqlTemplatesCommand } from "./commands/sparql-templates.js";
 import { commandCommand } from "./commands/command.js";
 import { watchCommand } from "./commands/watch.js";
 import { batchCommand } from "./commands/batch.js";
@@ -30,6 +31,7 @@ const sparqlCommand = program
 
 sparqlCommand.addCommand(sparqlQueryCommand());
 sparqlCommand.addCommand(sparqlIndexCommand());
+sparqlCommand.addCommand(sparqlTemplatesCommand());
 
 program.addCommand(commandCommand());
 program.addCommand(watchCommand());

--- a/packages/cli/src/templates/TemplateRegistry.ts
+++ b/packages/cli/src/templates/TemplateRegistry.ts
@@ -1,0 +1,379 @@
+/**
+ * SPARQL Query Templates Library
+ *
+ * Provides reusable SPARQL query templates with parameter substitution
+ * for common use cases, reducing repetitive queries and errors.
+ *
+ * @module templates/TemplateRegistry
+ */
+
+/**
+ * Custom error thrown when a template is not found.
+ */
+export class TemplateNotFoundError extends Error {
+  constructor(templateName: string) {
+    super(`Template not found: "${templateName}". Use --list-templates to see available templates.`);
+    this.name = "TemplateNotFoundError";
+  }
+}
+
+/**
+ * Custom error thrown when an invalid parameter is provided.
+ */
+export class InvalidParameterError extends Error {
+  constructor(paramName: string, templateName: string, validParams: string[]) {
+    super(
+      `Invalid parameter "${paramName}" for template "${templateName}". ` +
+      `Valid parameters: ${validParams.length > 0 ? validParams.join(", ") : "none"}`
+    );
+    this.name = "InvalidParameterError";
+  }
+}
+
+/**
+ * Custom error thrown when a required parameter is missing.
+ */
+export class MissingParameterError extends Error {
+  constructor(missingParams: string[], templateName: string) {
+    super(
+      `Missing required parameter(s) for template "${templateName}": ${missingParams.join(", ")}. ` +
+      `Use --param to provide values.`
+    );
+    this.name = "MissingParameterError";
+  }
+}
+
+/**
+ * Custom error thrown when parameter string format is invalid.
+ */
+export class InvalidParamFormatError extends Error {
+  constructor(paramString: string) {
+    super(
+      `Invalid parameter format: "${paramString}". ` +
+      `Use format: key=value or key1=value1,key2=value2`
+    );
+    this.name = "InvalidParamFormatError";
+  }
+}
+
+/**
+ * Template definition with metadata.
+ */
+export interface QueryTemplate {
+  /** Unique template name (e.g., "tasks-by-date") */
+  name: string;
+  /** Human-readable description */
+  description: string;
+  /** SPARQL query with {{param}} placeholders */
+  query: string;
+  /** List of parameter names used in the query */
+  parameters: string[];
+  /** Optional examples of parameter values */
+  examples?: Record<string, string>;
+}
+
+/**
+ * Validation result for parameter checking.
+ */
+export interface ParameterValidation {
+  valid: boolean;
+  missing: string[];
+  unknown: string[];
+}
+
+/**
+ * Built-in MVP templates for common SPARQL queries.
+ */
+const BUILTIN_TEMPLATES: QueryTemplate[] = [
+  {
+    name: "tasks-by-date",
+    description: "Find tasks scheduled for a specific date",
+    query: `PREFIX ems: <http://example.org/ems#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?task ?label ?status WHERE {
+  ?task a ems:Task ;
+        rdfs:label ?label .
+  OPTIONAL { ?task ems:Effort_status ?status }
+  ?task ems:Effort_plannedStartTimestamp ?start .
+  FILTER(STRSTARTS(STR(?start), "{{date}}"))
+}
+ORDER BY ?start`,
+    parameters: ["date"],
+    examples: { date: "2024-01-15" },
+  },
+  {
+    name: "tasks-by-status",
+    description: "Find tasks with a specific effort status",
+    query: `PREFIX ems: <http://example.org/ems#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?task ?label ?status WHERE {
+  ?task a ems:Task ;
+        rdfs:label ?label ;
+        ems:Effort_status ?statusNode .
+  ?statusNode rdfs:label ?status .
+  FILTER(STR(?status) = "{{status}}")
+}
+ORDER BY ?label`,
+    parameters: ["status"],
+    examples: { status: "Done" },
+  },
+  {
+    name: "projects-active",
+    description: "List all active projects (not completed)",
+    query: `PREFIX ems: <http://example.org/ems#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?project ?label ?status WHERE {
+  ?project a ems:Project ;
+           rdfs:label ?label .
+  OPTIONAL {
+    ?project ems:Effort_status ?statusNode .
+    ?statusNode rdfs:label ?status .
+  }
+  FILTER(!BOUND(?status) || ?status != "Done")
+}
+ORDER BY ?label`,
+    parameters: [],
+    examples: {},
+  },
+  {
+    name: "concepts-by-domain",
+    description: "Find concepts in a specific domain",
+    query: `PREFIX ims: <http://example.org/ims#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?concept ?label ?description WHERE {
+  ?concept a ims:Concept ;
+           rdfs:label ?label .
+  OPTIONAL { ?concept rdfs:comment ?description }
+  ?concept ims:Concept_domain ?domainNode .
+  ?domainNode rdfs:label ?domain .
+  FILTER(CONTAINS(LCASE(STR(?domain)), LCASE("{{domain}}")))
+}
+ORDER BY ?label`,
+    parameters: ["domain"],
+    examples: { domain: "Software Engineering" },
+  },
+  {
+    name: "sleep-analysis",
+    description: "Analyze sleep patterns from task records",
+    query: `PREFIX ems: <http://example.org/ems#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?task ?label ?start ?end WHERE {
+  ?task a ems:Task ;
+        rdfs:label ?label .
+  FILTER(CONTAINS(LCASE(STR(?label)), "sleep") || CONTAINS(LCASE(STR(?label)), "сон"))
+  OPTIONAL { ?task ems:Effort_startTimestamp ?start }
+  OPTIONAL { ?task ems:Effort_endTimestamp ?end }
+}
+ORDER BY DESC(?start)
+LIMIT 30`,
+    parameters: [],
+    examples: {},
+  },
+];
+
+/**
+ * Registry for SPARQL query templates with parameter substitution.
+ *
+ * Provides methods to list, retrieve, validate, and apply templates
+ * with safe parameter injection.
+ */
+export class TemplateRegistry {
+  private templates: Map<string, QueryTemplate>;
+
+  constructor() {
+    this.templates = new Map();
+    // Load built-in templates
+    for (const template of BUILTIN_TEMPLATES) {
+      this.templates.set(template.name, template);
+    }
+  }
+
+  /**
+   * List all available templates.
+   * @returns Array of template metadata
+   */
+  listTemplates(): QueryTemplate[] {
+    return Array.from(this.templates.values());
+  }
+
+  /**
+   * Get a template by name.
+   * @param name Template name
+   * @returns Template definition
+   * @throws TemplateNotFoundError if template doesn't exist
+   */
+  getTemplate(name: string): QueryTemplate {
+    const template = this.templates.get(name);
+    if (!template) {
+      throw new TemplateNotFoundError(name);
+    }
+    return template;
+  }
+
+  /**
+   * Apply parameter substitution to a template.
+   * @param name Template name
+   * @param params Parameter values to substitute
+   * @returns SPARQL query with substituted values
+   * @throws TemplateNotFoundError if template doesn't exist
+   * @throws MissingParameterError if required parameters are missing
+   * @throws InvalidParameterError if unknown parameters are provided
+   */
+  applyTemplate(name: string, params: Record<string, string>): string {
+    const template = this.getTemplate(name);
+    const validation = this.validateParameters(name, params);
+
+    if (!validation.valid) {
+      if (validation.missing.length > 0) {
+        throw new MissingParameterError(validation.missing, name);
+      }
+      if (validation.unknown.length > 0) {
+        throw new InvalidParameterError(validation.unknown[0], name, template.parameters);
+      }
+    }
+
+    let query = template.query;
+
+    // Substitute parameters with escaped values
+    for (const param of template.parameters) {
+      const value = params[param];
+      const escapedValue = this.escapeValue(value);
+      query = query.replace(new RegExp(`\\{\\{${param}\\}\\}`, "g"), escapedValue);
+    }
+
+    return query;
+  }
+
+  /**
+   * Validate parameters for a template without applying.
+   * @param name Template name
+   * @param params Parameters to validate
+   * @returns Validation result with missing/unknown params
+   */
+  validateParameters(name: string, params: Record<string, string>): ParameterValidation {
+    const template = this.getTemplate(name);
+    const providedKeys = Object.keys(params);
+    const requiredKeys = template.parameters;
+
+    const missing = requiredKeys.filter((key) => !(key in params) || params[key] === undefined);
+    const unknown = providedKeys.filter((key) => !requiredKeys.includes(key));
+
+    return {
+      valid: missing.length === 0 && unknown.length === 0,
+      missing,
+      unknown,
+    };
+  }
+
+  /**
+   * Parse a parameter string in format "key=value,key2=value2".
+   * @param paramString Parameter string to parse
+   * @returns Parsed key-value pairs
+   * @throws InvalidParamFormatError if format is invalid
+   */
+  parseParamString(paramString: string): Record<string, string> {
+    const trimmed = paramString.trim();
+    if (trimmed === "") {
+      return {};
+    }
+
+    const params: Record<string, string> = {};
+    const pairs = trimmed.split(",");
+
+    for (const pair of pairs) {
+      const eqIndex = pair.indexOf("=");
+      if (eqIndex === -1) {
+        throw new InvalidParamFormatError(paramString);
+      }
+
+      const key = pair.slice(0, eqIndex).trim();
+      const value = pair.slice(eqIndex + 1).trim();
+
+      if (key === "") {
+        throw new InvalidParamFormatError(paramString);
+      }
+
+      params[key] = value;
+    }
+
+    return params;
+  }
+
+  /**
+   * Escape a parameter value to prevent SPARQL injection.
+   * @param value Raw value to escape
+   * @returns Escaped value safe for SPARQL
+   */
+  private escapeValue(value: string): string {
+    // Escape quotes, backslashes, and other special characters
+    return value
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/'/g, "\\'")
+      .replace(/\n/g, "\\n")
+      .replace(/\r/g, "\\r")
+      .replace(/\t/g, "\\t");
+  }
+
+  /**
+   * Register a custom template.
+   * @param template Template definition to register
+   */
+  registerTemplate(template: QueryTemplate): void {
+    this.templates.set(template.name, template);
+  }
+
+  /**
+   * Check if a template exists.
+   * @param name Template name
+   * @returns True if template exists
+   */
+  hasTemplate(name: string): boolean {
+    return this.templates.has(name);
+  }
+
+  /**
+   * Format templates list for display.
+   * @param format Output format ("text" or "json")
+   * @returns Formatted string
+   */
+  formatList(format: "text" | "json" = "text"): string {
+    const templates = this.listTemplates();
+
+    if (format === "json") {
+      return JSON.stringify(templates, null, 2);
+    }
+
+    // Text format
+    const lines: string[] = [];
+    lines.push("Available SPARQL Templates:");
+    lines.push("=" .repeat(50));
+    lines.push("");
+
+    for (const template of templates) {
+      lines.push(`📋 ${template.name}`);
+      lines.push(`   ${template.description}`);
+      if (template.parameters.length > 0) {
+        lines.push(`   Parameters: ${template.parameters.join(", ")}`);
+        if (template.examples && Object.keys(template.examples).length > 0) {
+          const exampleStr = Object.entries(template.examples)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(", ");
+          lines.push(`   Example: --param "${exampleStr}"`);
+        }
+      } else {
+        lines.push("   Parameters: (none)");
+      }
+      lines.push("");
+    }
+
+    return lines.join("\n");
+  }
+}

--- a/packages/cli/tests/unit/commands/sparql-templates.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-templates.test.ts
@@ -1,0 +1,90 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import type { Command } from "commander";
+
+// Mock dependencies
+jest.unstable_mockModule("../../../src/templates/TemplateRegistry.js", () => ({
+  TemplateRegistry: jest.fn(() => ({
+    listTemplates: jest.fn().mockReturnValue([
+      {
+        name: "tasks-by-date",
+        description: "Find tasks scheduled for a specific date",
+        parameters: ["date"],
+        examples: { date: "2024-01-15" },
+      },
+      {
+        name: "projects-active",
+        description: "List all active projects",
+        parameters: [],
+        examples: {},
+      },
+    ]),
+    formatList: jest.fn().mockReturnValue(
+      "Available SPARQL Templates:\n" +
+      "==================================================\n\n" +
+      "📋 tasks-by-date\n" +
+      "   Find tasks scheduled for a specific date\n" +
+      "   Parameters: date\n\n" +
+      "📋 projects-active\n" +
+      "   List all active projects\n" +
+      "   Parameters: (none)\n"
+    ),
+  })),
+}));
+
+// Import after mocks
+const { sparqlTemplatesCommand } = await import("../../../src/commands/sparql-templates.js");
+
+describe("sparqlTemplatesCommand", () => {
+  let consoleSpy: jest.SpiedFunction<typeof console.log>;
+  let command: Command;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    command = sparqlTemplatesCommand();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  describe("command setup", () => {
+    it("should have correct name", () => {
+      expect(command.name()).toBe("templates");
+    });
+
+    it("should have description", () => {
+      expect(command.description()).toContain("SPARQL query templates");
+    });
+
+    it("should have --output option", () => {
+      const options = command.options;
+      const outputOption = options.find((opt) => opt.long === "--output");
+      expect(outputOption).toBeDefined();
+    });
+  });
+
+  describe("text output", () => {
+    it("should list templates in text format by default", async () => {
+      await command.parseAsync(["node", "test"]);
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const output = consoleSpy.mock.calls.join("\n");
+      expect(output).toContain("Available SPARQL Templates");
+      expect(output).toContain("tasks-by-date");
+    });
+  });
+
+  describe("json output", () => {
+    it("should list templates in JSON format", async () => {
+      await command.parseAsync(["node", "test", "--output", "json"]);
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const jsonOutput = consoleSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(jsonOutput);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.templates).toBeDefined();
+      expect(parsed.data.count).toBe(2);
+    });
+  });
+});

--- a/packages/cli/tests/unit/templates/TemplateRegistry.test.ts
+++ b/packages/cli/tests/unit/templates/TemplateRegistry.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  TemplateRegistry,
+  TemplateNotFoundError,
+  InvalidParameterError,
+  MissingParameterError,
+  InvalidParamFormatError,
+} from "../../../src/templates/TemplateRegistry.js";
+
+describe("TemplateRegistry", () => {
+  describe("listTemplates", () => {
+    it("should return all available templates", () => {
+      const registry = new TemplateRegistry();
+      const templates = registry.listTemplates();
+
+      expect(templates.length).toBeGreaterThan(0);
+      expect(templates[0]).toHaveProperty("name");
+      expect(templates[0]).toHaveProperty("description");
+      expect(templates[0]).toHaveProperty("parameters");
+    });
+
+    it("should include MVP templates", () => {
+      const registry = new TemplateRegistry();
+      const templates = registry.listTemplates();
+      const templateNames = templates.map((t) => t.name);
+
+      expect(templateNames).toContain("tasks-by-date");
+      expect(templateNames).toContain("tasks-by-status");
+      expect(templateNames).toContain("projects-active");
+      expect(templateNames).toContain("concepts-by-domain");
+      expect(templateNames).toContain("sleep-analysis");
+    });
+  });
+
+  describe("getTemplate", () => {
+    it("should return template by name", () => {
+      const registry = new TemplateRegistry();
+      const template = registry.getTemplate("tasks-by-date");
+
+      expect(template).toBeDefined();
+      expect(template.name).toBe("tasks-by-date");
+      expect(template.query).toContain("SELECT");
+      expect(template.parameters).toContain("date");
+    });
+
+    it("should throw TemplateNotFoundError for unknown template", () => {
+      const registry = new TemplateRegistry();
+
+      expect(() => registry.getTemplate("non-existent")).toThrow(TemplateNotFoundError);
+    });
+  });
+
+  describe("applyTemplate", () => {
+    it("should substitute single parameter", () => {
+      const registry = new TemplateRegistry();
+      const result = registry.applyTemplate("tasks-by-date", { date: "2024-01-15" });
+
+      expect(result).toContain("2024-01-15");
+      expect(result).not.toContain("{{date}}");
+      expect(result).toContain("SELECT");
+    });
+
+    it("should substitute multiple parameters", () => {
+      const registry = new TemplateRegistry();
+      const template = registry.getTemplate("tasks-by-status");
+
+      // Check that template has status parameter
+      expect(template.parameters).toContain("status");
+
+      const result = registry.applyTemplate("tasks-by-status", { status: "Done" });
+      expect(result).toContain("Done");
+      expect(result).not.toContain("{{status}}");
+    });
+
+    it("should throw MissingParameterError for required parameter not provided", () => {
+      const registry = new TemplateRegistry();
+
+      expect(() => registry.applyTemplate("tasks-by-date", {})).toThrow(MissingParameterError);
+    });
+
+    it("should throw InvalidParameterError for parameter not in template", () => {
+      const registry = new TemplateRegistry();
+
+      expect(() =>
+        registry.applyTemplate("tasks-by-date", {
+          date: "2024-01-15",
+          unknown: "value"
+        })
+      ).toThrow(InvalidParameterError);
+    });
+
+    it("should throw TemplateNotFoundError for unknown template", () => {
+      const registry = new TemplateRegistry();
+
+      expect(() =>
+        registry.applyTemplate("non-existent", { date: "2024-01-15" })
+      ).toThrow(TemplateNotFoundError);
+    });
+
+    it("should handle templates without parameters (projects-active)", () => {
+      const registry = new TemplateRegistry();
+      const result = registry.applyTemplate("projects-active", {});
+
+      expect(result).toContain("SELECT");
+      expect(result).not.toContain("{{");
+    });
+
+    it("should escape special SPARQL characters in parameter values", () => {
+      const registry = new TemplateRegistry();
+      // Test that quotes are properly escaped in parameter values
+      const result = registry.applyTemplate("concepts-by-domain", {
+        domain: "test\"domain"
+      });
+
+      // Should escape quotes to prevent SPARQL injection
+      expect(result).not.toContain('test"domain');
+      expect(result).toContain('test\\"domain');
+    });
+  });
+
+  describe("validateParameters", () => {
+    it("should validate required parameters are present", () => {
+      const registry = new TemplateRegistry();
+
+      const validation = registry.validateParameters("tasks-by-date", {});
+      expect(validation.valid).toBe(false);
+      expect(validation.missing).toContain("date");
+    });
+
+    it("should validate no unknown parameters", () => {
+      const registry = new TemplateRegistry();
+
+      const validation = registry.validateParameters("tasks-by-date", {
+        date: "2024-01-15",
+        unknown: "value"
+      });
+      expect(validation.valid).toBe(false);
+      expect(validation.unknown).toContain("unknown");
+    });
+
+    it("should return valid for correct parameters", () => {
+      const registry = new TemplateRegistry();
+
+      const validation = registry.validateParameters("tasks-by-date", {
+        date: "2024-01-15"
+      });
+      expect(validation.valid).toBe(true);
+      expect(validation.missing).toHaveLength(0);
+      expect(validation.unknown).toHaveLength(0);
+    });
+  });
+
+  describe("parseParamString", () => {
+    it("should parse single key=value", () => {
+      const registry = new TemplateRegistry();
+      const params = registry.parseParamString("date=2024-01-15");
+
+      expect(params).toEqual({ date: "2024-01-15" });
+    });
+
+    it("should parse multiple comma-separated params", () => {
+      const registry = new TemplateRegistry();
+      const params = registry.parseParamString("status=Done,limit=10");
+
+      expect(params).toEqual({ status: "Done", limit: "10" });
+    });
+
+    it("should handle values with equals sign", () => {
+      const registry = new TemplateRegistry();
+      const params = registry.parseParamString("filter=value=test");
+
+      expect(params).toEqual({ filter: "value=test" });
+    });
+
+    it("should trim whitespace", () => {
+      const registry = new TemplateRegistry();
+      const params = registry.parseParamString("  date = 2024-01-15  ");
+
+      expect(params).toEqual({ date: "2024-01-15" });
+    });
+
+    it("should return empty object for empty string", () => {
+      const registry = new TemplateRegistry();
+      const params = registry.parseParamString("");
+
+      expect(params).toEqual({});
+    });
+
+    it("should throw for invalid format", () => {
+      const registry = new TemplateRegistry();
+
+      expect(() => registry.parseParamString("invalid")).toThrow(InvalidParamFormatError);
+    });
+  });
+
+  describe("hasTemplate", () => {
+    it("should return true for existing template", () => {
+      const registry = new TemplateRegistry();
+      expect(registry.hasTemplate("tasks-by-date")).toBe(true);
+    });
+
+    it("should return false for non-existing template", () => {
+      const registry = new TemplateRegistry();
+      expect(registry.hasTemplate("non-existent")).toBe(false);
+    });
+  });
+
+  describe("registerTemplate", () => {
+    it("should register custom template", () => {
+      const registry = new TemplateRegistry();
+      registry.registerTemplate({
+        name: "custom-query",
+        description: "Custom test query",
+        query: "SELECT ?s WHERE { ?s ?p {{value}} }",
+        parameters: ["value"],
+      });
+
+      expect(registry.hasTemplate("custom-query")).toBe(true);
+      const template = registry.getTemplate("custom-query");
+      expect(template.description).toBe("Custom test query");
+    });
+  });
+
+  describe("formatList", () => {
+    it("should format as text", () => {
+      const registry = new TemplateRegistry();
+      const output = registry.formatList("text");
+
+      expect(output).toContain("Available SPARQL Templates");
+      expect(output).toContain("tasks-by-date");
+      expect(output).toContain("Parameters:");
+    });
+
+    it("should format as JSON", () => {
+      const registry = new TemplateRegistry();
+      const output = registry.formatList("json");
+
+      const parsed = JSON.parse(output);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0]).toHaveProperty("name");
+    });
+  });
+});
+
+describe("Template content verification", () => {
+  const registry = new TemplateRegistry();
+
+  describe("tasks-by-date template", () => {
+    it("should have valid SPARQL query", () => {
+      const template = registry.getTemplate("tasks-by-date");
+      expect(template.query).toMatch(/SELECT/i);
+      expect(template.query).toMatch(/WHERE/i);
+      expect(template.query).toContain("{{date}}");
+    });
+
+    it("should query for tasks with date filter", () => {
+      const template = registry.getTemplate("tasks-by-date");
+      expect(template.query).toMatch(/ems:Task/);
+    });
+  });
+
+  describe("tasks-by-status template", () => {
+    it("should have status parameter", () => {
+      const template = registry.getTemplate("tasks-by-status");
+      expect(template.parameters).toContain("status");
+    });
+
+    it("should filter by effort status", () => {
+      const template = registry.getTemplate("tasks-by-status");
+      expect(template.query).toMatch(/ems:Effort|ems:Task/);
+    });
+  });
+
+  describe("projects-active template", () => {
+    it("should have no required parameters", () => {
+      const template = registry.getTemplate("projects-active");
+      expect(template.parameters).toHaveLength(0);
+    });
+
+    it("should query for active projects", () => {
+      const template = registry.getTemplate("projects-active");
+      expect(template.query).toMatch(/ems:Project/);
+    });
+  });
+
+  describe("concepts-by-domain template", () => {
+    it("should have domain parameter", () => {
+      const template = registry.getTemplate("concepts-by-domain");
+      expect(template.parameters).toContain("domain");
+    });
+
+    it("should query for concepts", () => {
+      const template = registry.getTemplate("concepts-by-domain");
+      expect(template.query).toMatch(/ims:Concept/);
+    });
+  });
+
+  describe("sleep-analysis template", () => {
+    it("should have no required parameters for default behavior", () => {
+      const template = registry.getTemplate("sleep-analysis");
+      // Sleep analysis returns recent data by default
+      expect(template.parameters).toHaveLength(0);
+    });
+
+    it("should query for sleep-related data", () => {
+      const template = registry.getTemplate("sleep-analysis");
+      // Should query tasks or efforts related to sleep
+      expect(template.query).toMatch(/ems:|sleep/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add library of reusable SPARQL query templates with parameter substitution
- 5 MVP templates for common query patterns
- New `--template` and `--param` flags for `sparql query` command
- New `sparql templates` subcommand to list available templates

## Changes
- `TemplateRegistry` class with mustache-style `{{param}}` substitution
- Templates: tasks-by-date, tasks-by-status, projects-active, concepts-by-domain, sleep-analysis
- Parameter validation prevents injection and missing params errors
- 35+ unit tests for comprehensive coverage

## Usage Examples
```bash
# List available templates
exocortex sparql templates

# Use template with parameters
exocortex sparql query --template tasks-by-date --param date=2024-01-15

# Templates without parameters
exocortex sparql query --template projects-active

# JSON output for MCP tools
exocortex sparql templates --output json
```

## Testing
- [x] Added 35 unit tests for TemplateRegistry
- [x] Added tests for sparql-templates command
- [x] All existing tests pass
- [x] Build succeeds

## Verification
- [x] `npm run build` — PASSED
- [x] `npm run test:unit` — PASSED (821 tests)
- [x] `npm run lint` — PASSED
- [x] Manual testing of CLI commands — PASSED

## Acceptance Criteria
- [x] `--template` executes correct query
- [x] Parameters substituted safely with escaping
- [x] `sparql templates` shows all available templates
- [x] Templates cover common use cases (5 MVP templates)

Closes #2219