### PR TITLE
fix(obsidian-plugin): use single table with sticky header for virtualized layout

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
@@ -11,7 +11,7 @@
  * @module presentation/renderers
  * @since 1.0.0
  */
-import React, { useState, useMemo, useCallback, useRef, useLayoutEffect, useEffect } from "react";
+import React, { useState, useMemo, useCallback, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import type { TableLayout, LayoutColumn } from "../../domain/layout";
@@ -205,13 +205,6 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
 
   // Virtualization refs
   const parentRef = useRef<HTMLDivElement>(null);
-  const [isParentMounted, setIsParentMounted] = useState(false);
-
-  useLayoutEffect(() => {
-    if (parentRef.current && !isParentMounted) {
-      setIsParentMounted(true);
-    }
-  }, [isParentMounted]);
 
   // Handle sort toggle
   const handleSortToggle = useCallback(
@@ -281,59 +274,12 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
   const shouldVirtualize =
     options.virtualize && sortedRows.length > VIRTUALIZATION_THRESHOLD;
 
-  // Synchronize column widths between header and body tables in virtualized mode
-  // This fixes misalignment caused by scrollbar width difference (Issue #941, #2116)
-  const [scrollbarWidth, setScrollbarWidth] = useState(0);
-
-  // Track computed pixel widths for virtualized cells (Issue #2152)
-  // When rows have position: absolute, table-layout: fixed doesn't work
-  // We measure header cell widths and apply them explicitly to body cells
-  const headerTableRef = useRef<HTMLTableElement>(null);
-  const [computedColumnWidths, setComputedColumnWidths] = useState<number[]>([]);
-
-  // Measure scrollbar width and column widths when scroll container is mounted
-  const measureWidths = useCallback(() => {
-    if (!parentRef.current) return;
-
-    const scrollContainer = parentRef.current;
-    // Scrollbar width = total width - client width (visible content area)
-    const sbWidth = scrollContainer.offsetWidth - scrollContainer.clientWidth;
-    setScrollbarWidth(sbWidth);
-
-    // Measure header cell widths for virtualized row alignment (Issue #2152)
-    if (headerTableRef.current) {
-      const headerCells = headerTableRef.current.querySelectorAll("thead th");
-      const widths: number[] = [];
-      headerCells.forEach((cell) => {
-        // Use offsetWidth to get the actual rendered pixel width
-        widths.push((cell as HTMLElement).offsetWidth);
-      });
-      setComputedColumnWidths(widths);
-    }
-  }, []);
-
-  // Measure widths when virtualized mode is active and parent is mounted
-  useLayoutEffect(() => {
-    if (shouldVirtualize && isParentMounted) {
-      measureWidths();
-    }
-  }, [shouldVirtualize, isParentMounted, measureWidths]);
-
-  // Re-measure on window resize (scrollbar might appear/disappear, column widths change)
-  useEffect(() => {
-    if (!shouldVirtualize) return;
-
-    const handleResize = () => measureWidths();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, [shouldVirtualize, measureWidths]);
-
   const rowVirtualizer = useVirtualizer({
     count: shouldVirtualize ? sortedRows.length : 0,
     getScrollElement: () => parentRef.current,
     estimateSize: () => options.rowHeight || 35,
     overscan: 5,
-    enabled: shouldVirtualize && isParentMounted,
+    enabled: shouldVirtualize,
   });
 
   // Render column header
@@ -364,8 +310,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
   };
 
   // Render cell
-  // computedWidth is used in virtualized mode to apply measured pixel widths (Issue #2152)
-  const renderCell = (row: TableRow, column: LayoutColumn, columnIndex: number, useComputedWidth: boolean) => {
+  const renderCell = (row: TableRow, column: LayoutColumn) => {
     const value = row.values[column.uid];
     const CellRenderer = getCellRenderer(column.renderer);
     const isEditing =
@@ -373,17 +318,11 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
     const isClickable =
       options.editable && column.editable && !isEditing;
 
-    // In virtualized mode, use computed pixel widths to ensure alignment
-    // when rows have position: absolute (Issue #2152)
-    const cellWidth = useComputedWidth && computedColumnWidths[columnIndex]
-      ? `${computedColumnWidths[columnIndex]}px`
-      : parseColumnWidth(column.width);
-
     return (
       <td
         key={column.uid}
         className={`exo-layout-cell exo-layout-cell-${column.renderer || "text"} ${isEditing ? "exo-layout-cell-editing" : ""} ${isClickable ? "exo-layout-cell-editable" : ""}`}
-        style={{ width: cellWidth }}
+        style={{ width: parseColumnWidth(column.width) }}
         onClick={() => !isEditing && handleCellClick(row.id, column)}
       >
         <CellRenderer
@@ -421,8 +360,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
   };
 
   // Render row
-  // useComputedWidth is true for virtualized rows to apply measured pixel widths (Issue #2152)
-  const renderRow = (row: TableRow, _index: number, style?: React.CSSProperties, useComputedWidth = false) => {
+  const renderRow = (row: TableRow, _index: number, style?: React.CSSProperties) => {
     return (
       <tr
         key={row.id}
@@ -431,7 +369,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
         data-path={row.path}
         style={style}
       >
-        {columns.map((column, columnIndex) => renderCell(row, column, columnIndex, useComputedWidth))}
+        {columns.map((column) => renderCell(row, column))}
         {renderActionsCell(row)}
       </tr>
     );
@@ -501,7 +439,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
     );
   }
 
-  // Virtualized rendering
+  // Virtualized rendering - single table with sticky thead
   const virtualItems = rowVirtualizer.getVirtualItems();
   const virtualizerTotalSize = rowVirtualizer.getTotalSize();
   const totalSize =
@@ -511,66 +449,39 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
 
   return (
     <div className={`exo-layout-table-container exo-layout-virtualized ${className || ""}`}>
-      {/* Header wrapper with padding-right to account for scrollbar width (Issue #941, #2116) */}
-      <div
-        className="exo-layout-table-header-wrapper"
-        style={{
-          paddingRight: scrollbarWidth > 0 ? `${scrollbarWidth}px` : undefined,
-        }}
-      >
-        {/* Header table with ref for measuring column widths (Issue #2152) */}
-        <table ref={headerTableRef} className="exo-layout-table exo-layout-table-header-fixed">
-          {renderColGroup()}
-          {renderTableHeader()}
-        </table>
-      </div>
-
-      {/* Scrollable body */}
       <div
         ref={parentRef}
         className="exo-layout-virtual-scroll"
         style={{ height: "400px", overflow: "auto" }}
       >
-        <div
-          style={{
-            height: `${totalSize}px`,
-            width: "100%",
-            position: "relative",
-          }}
-        >
-          <table
-            className="exo-layout-table exo-layout-virtual-table"
+        <table className="exo-layout-table">
+          {renderColGroup()}
+          {renderTableHeader()}
+          <tbody
+            className="exo-layout-body"
             style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              width: "100%",
+              display: "block",
+              position: "relative",
+              height: `${totalSize}px`,
             }}
           >
-            {renderColGroup()}
-            <tbody className="exo-layout-body">
-              {virtualItems.length > 0 ? (
-                virtualItems.map((virtualRow) => {
-                  const row = sortedRows[virtualRow.index];
-                  // Pass useComputedWidth=true for virtualized rows (Issue #2152)
-                  // This ensures cells use measured pixel widths instead of
-                  // percentage/auto widths that don't work with position: absolute
-                  return renderRow(row, virtualRow.index, {
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    height: `${virtualRow.size}px`,
-                    transform: `translateY(${virtualRow.start}px)`,
-                  }, true);
-                })
-              ) : (
-                // Fallback: render all rows if virtualizer hasn't initialized
-                sortedRows.map((row, index) => renderRow(row, index))
-              )}
-            </tbody>
-          </table>
-        </div>
+            {virtualItems.length > 0 ? (
+              virtualItems.map((virtualRow) => {
+                const row = sortedRows[virtualRow.index];
+                return renderRow(row, virtualRow.index, {
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: `${virtualRow.size}px`,
+                  transform: `translateY(${virtualRow.start}px)`,
+                });
+              })
+            ) : (
+              sortedRows.map((row, index) => renderRow(row, index))
+            )}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -3246,17 +3246,14 @@
   flex-direction: column;
 }
 
-.exo-layout-table-header-fixed {
-  border-bottom: none;
+.exo-layout-virtualized .exo-layout-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 .exo-layout-virtual-scroll {
-  border-top: none;
   border-radius: 0 0 8px 8px;
-}
-
-.exo-layout-virtual-table {
-  border-top: none;
 }
 
 /* ============================================================================

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/TableLayoutRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/TableLayoutRenderer.test.tsx
@@ -449,7 +449,7 @@ describe("TableLayoutRenderer", () => {
       }));
     });
 
-    it("renders virtualized mode with proper structure for column width synchronization", () => {
+    it("renders virtualized mode with single table and sticky header", () => {
       // Mock virtualizer to return virtual items (simulating >50 rows)
       mockUseVirtualizer.mockImplementation(() => ({
         getVirtualItems: () => [
@@ -490,31 +490,28 @@ describe("TableLayoutRenderer", () => {
       // Check that virtualized mode is active
       expect(container.querySelector(".exo-layout-virtualized")).toBeInTheDocument();
 
-      // Verify the structure for width synchronization:
-      // 1. Header table exists with header-fixed class
-      const headerTable = container.querySelector(".exo-layout-table-header-fixed");
-      expect(headerTable).toBeInTheDocument();
+      // Single table with colgroup, thead, and tbody
+      const tables = container.querySelectorAll("table");
+      expect(tables.length).toBe(1);
 
-      // 2. Virtual table exists for body rows
-      const virtualTable = container.querySelector(".exo-layout-virtual-table");
-      expect(virtualTable).toBeInTheDocument();
+      const table = tables[0];
+      expect(table.querySelector("colgroup")).toBeInTheDocument();
+      expect(table.querySelector("thead")).toBeInTheDocument();
+      expect(table.querySelector("tbody")).toBeInTheDocument();
 
-      // 3. Both tables have colgroups with matching column count
-      const headerCols = headerTable?.querySelectorAll("colgroup col");
-      const bodyCols = virtualTable?.querySelectorAll("colgroup col");
-      expect(headerCols?.length).toBe(3);
-      expect(bodyCols?.length).toBe(3);
+      // Colgroup has correct column count
+      const cols = table.querySelectorAll("colgroup col");
+      expect(cols.length).toBe(3);
 
-      // 4. Body cells have width styles (fallback to column.width when computed widths unavailable)
-      const cells = virtualTable?.querySelectorAll("tbody tr:first-child td");
+      // Body cells have width styles from column definitions
+      const cells = table.querySelectorAll("tbody tr:first-child td");
       expect(cells?.length).toBe(3);
-      // In jsdom, computed widths are 0, so cells use column.width fallback
       expect(cells?.[0]).toHaveStyle({ width: "200px" });
       expect(cells?.[1]).toHaveStyle({ width: "100px" });
       expect(cells?.[2]).toHaveStyle({ width: "150px" });
     });
 
-    it("colgroup widths match between header and body tables in virtualized mode", () => {
+    it("uses single table with shared colgroup in virtualized mode", () => {
       mockUseVirtualizer.mockImplementation(() => ({
         getVirtualItems: () => [
           { index: 0, start: 0, size: 35, key: "0" },
@@ -548,21 +545,15 @@ describe("TableLayoutRenderer", () => {
         />
       );
 
-      // Both header table and body table should have matching colgroups
+      // Single table means one colgroup shared by header and body
       const colgroups = container.querySelectorAll("colgroup");
-      expect(colgroups.length).toBe(2); // One in header, one in body
+      expect(colgroups.length).toBe(1);
 
-      // Get col elements from both tables
-      const headerCols = colgroups[0]?.querySelectorAll("col");
-      const bodyCols = colgroups[1]?.querySelectorAll("col");
-
-      expect(headerCols?.length).toBe(bodyCols?.length);
-
-      // Widths should match
-      headerCols?.forEach((col, i) => {
-        const bodyCol = bodyCols?.[i];
-        expect(col.style.width).toBe(bodyCol?.style.width);
-      });
+      const cols = colgroups[0]?.querySelectorAll("col");
+      expect(cols?.length).toBe(3);
+      expect(cols?.[0]).toHaveStyle({ width: "40%" });
+      expect(cols?.[1]).toHaveStyle({ width: "30%" });
+      expect(cols?.[2]).toHaveStyle({ width: "30%" });
     });
 
     it("virtualized rows have position: absolute style applied", () => {
@@ -599,7 +590,7 @@ describe("TableLayoutRenderer", () => {
       );
 
       // Virtualized rows should have position: absolute
-      const virtualTableRows = container.querySelectorAll(".exo-layout-virtual-table tbody tr");
+      const virtualTableRows = container.querySelectorAll(".exo-layout-virtualized tbody tr");
       expect(virtualTableRows.length).toBe(2);
 
       virtualTableRows.forEach((row) => {
@@ -646,7 +637,7 @@ describe("TableLayoutRenderer", () => {
       fireEvent(window, new Event("resize"));
 
       // Cells should still have width styles after resize
-      const cells = container.querySelectorAll(".exo-layout-virtual-table tbody td");
+      const cells = container.querySelectorAll(".exo-layout-virtualized tbody td");
       expect(cells.length).toBeGreaterThanOrEqual(2);
       expect(cells[0]).toHaveStyle({ width: "200px" });
       expect(cells[1]).toHaveStyle({ width: "100px" });


### PR DESCRIPTION
## Summary
- Fixes column misalignment when tables have >50 rows by eliminating the split header/body two-table approach
- Uses a single `<table>` with `position: sticky` on `<thead>` instead of two separate `<table>` elements
- Removes ~100 lines of width-synchronization logic (`computedColumnWidths`, `scrollbarWidth`, `headerTableRef`, `measureWidths`, `isParentMounted`)

## Test plan
- [x] All 24 TableLayoutRenderer unit tests pass
- [x] Pre-commit hooks pass (ESLint, BDD coverage 100%)
- [ ] CI pipeline green (build-and-test + e2e-tests)