### PR TITLE
fix: use UUID for fleeting note class instead of name

### DIFF
--- a/packages/exocortex/src/services/FleetingNoteCreationService.ts
+++ b/packages/exocortex/src/services/FleetingNoteCreationService.ts
@@ -47,7 +47,7 @@ export class FleetingNoteCreationService {
       exo__Asset_isDefinedBy: '"[[!kitelev]]"',
       exo__Asset_uid: uid,
       exo__Asset_createdAt: timestamp,
-      exo__Instance_class: ['"[[ztlk__FleetingNote]]"'],
+      exo__Instance_class: ['"[[fca0a931-a01f-48e4-b72a-4af206c94bc7]]"'],
       exo__Asset_label: trimmedLabel,
       aliases: [trimmedLabel],
     };

--- a/packages/exocortex/src/services/SupervisionCreationService.ts
+++ b/packages/exocortex/src/services/SupervisionCreationService.ts
@@ -33,7 +33,7 @@ export class SupervisionCreationService {
       exo__Asset_isDefinedBy: '"[[!kitelev]]"',
       exo__Asset_uid: uid,
       exo__Asset_createdAt: timestamp,
-      exo__Instance_class: ['"[[ztlk__FleetingNote]]"'],
+      exo__Instance_class: ['"[[fca0a931-a01f-48e4-b72a-4af206c94bc7]]"'],
       ztlk__FleetingNote_type: '"[[CBT-Diary Record]]"',
     };
   }

--- a/packages/exocortex/tests/services/FleetingNoteCreationService.test.ts
+++ b/packages/exocortex/tests/services/FleetingNoteCreationService.test.ts
@@ -42,7 +42,7 @@ describe("FleetingNoteCreationService", () => {
       exo__Asset_isDefinedBy: '"[[!kitelev]]"',
       exo__Asset_uid: "test-uuid-123",
       exo__Asset_createdAt: mockTimestamp,
-      exo__Instance_class: ['"[[ztlk__FleetingNote]]"'],
+      exo__Instance_class: ['"[[fca0a931-a01f-48e4-b72a-4af206c94bc7]]"'],
       exo__Asset_label: "My note label",
       aliases: ["My note label"],
     });

--- a/packages/obsidian-plugin/tests/unit/SupervisionCreationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SupervisionCreationService.test.ts
@@ -23,7 +23,7 @@ describe("SupervisionCreationService", () => {
       expect(frontmatter.exo__Asset_uid).toBe(uid);
       expect(frontmatter.exo__Asset_createdAt).toBeDefined();
       expect(frontmatter.exo__Instance_class).toEqual([
-        '"[[ztlk__FleetingNote]]"',
+        '"[[fca0a931-a01f-48e4-b72a-4af206c94bc7]]"',
       ]);
       expect(frontmatter.ztlk__FleetingNote_type).toBe(
         '"[[CBT-Diary Record]]"',
@@ -178,7 +178,7 @@ describe("SupervisionCreationService", () => {
       expect(content).toContain("exo__Asset_uid:");
       expect(content).toContain("exo__Asset_createdAt:");
       expect(content).toContain(
-        'exo__Instance_class:\n  - "[[ztlk__FleetingNote]]"',
+        'exo__Instance_class:\n  - "[[fca0a931-a01f-48e4-b72a-4af206c94bc7]]"',
       );
       expect(content).toContain(
         'ztlk__FleetingNote_type: "[[CBT-Diary Record]]"',


### PR DESCRIPTION
Closes #2257

Replaces `ztlk__FleetingNote` with UUID `fca0a931-a01f-48e4-b72a-4af206c94bc7` in FleetingNoteCreationService and SupervisionCreationService (+ tests).