### PR TITLE
feat: inline button to remove redundant wikilink alias

### DIFF
--- a/packages/obsidian-plugin/src/presentation/editor-extensions/AliasIconViewPlugin.ts
+++ b/packages/obsidian-plugin/src/presentation/editor-extensions/AliasIconViewPlugin.ts
@@ -9,6 +9,8 @@ import { RangeSetBuilder, Extension } from "@codemirror/state";
 import { TFile } from "obsidian";
 import type { App, MetadataCache } from "obsidian";
 import { AliasIconWidget, type AliasIconClickResult } from "./AliasIconWidget";
+import { RedundantAliasRemoveWidget, type RedundantAliasRemoveClickResult } from "./RedundantAliasRemoveWidget";
+import { WikilinkLabelViewPlugin } from "./WikilinkLabelViewPlugin";
 
 /**
  * Represents a parsed wikilink with its position and extracted components.
@@ -44,6 +46,8 @@ export class AliasIconViewPlugin {
   private aliasService: IAliasService;
   private notifyUser: (message: string) => void;
   private pendingAliases: Set<string> = new Set();
+  private pendingRemovals: Set<string> = new Set();
+  private view: EditorView;
 
   constructor(
     view: EditorView,
@@ -56,6 +60,7 @@ export class AliasIconViewPlugin {
     this.metadataCache = metadataCache;
     this.aliasService = aliasService;
     this.notifyUser = notifyUser;
+    this.view = view;
     this.decorations = this.buildDecorations(view);
   }
 
@@ -75,7 +80,24 @@ export class AliasIconViewPlugin {
     this.pendingAliases.delete(this.getPendingKey(targetPath, alias));
   }
 
+  private getRemovalKey(from: number, to: number): string {
+    return `${from}|${to}`;
+  }
+
+  isRemovalPending(from: number, to: number): boolean {
+    return this.pendingRemovals.has(this.getRemovalKey(from, to));
+  }
+
+  markRemovalAsPending(from: number, to: number): void {
+    this.pendingRemovals.add(this.getRemovalKey(from, to));
+  }
+
+  unmarkRemovalAsPending(from: number, to: number): void {
+    this.pendingRemovals.delete(this.getRemovalKey(from, to));
+  }
+
   update(update: ViewUpdate): void {
+    this.view = update.view;
     if (update.docChanged || update.viewportChanged) {
       this.decorations = this.buildDecorations(update.view);
     }
@@ -96,26 +118,86 @@ export class AliasIconViewPlugin {
         continue;
       }
 
-      const existingAliases = this.aliasService.getAliases(targetFile);
+      // Check if alias equals exo__Asset_label (redundant alias)
+      const targetLabel = WikilinkLabelViewPlugin.resolveLabel(this.metadataCache, wikilink.targetPath);
 
-      // Check if alias is already in target's aliases or pending addition
-      if (!existingAliases.includes(wikilink.alias) && !this.isPending(targetFile.path, wikilink.alias)) {
-        const widget = new AliasIconWidget(
+      if (targetLabel && wikilink.alias === targetLabel && !this.isRemovalPending(wikilink.from, wikilink.to)) {
+        // Alias is redundant — show remove icon
+        const widget = new RedundantAliasRemoveWidget(
+          wikilink.from,
+          wikilink.to,
           targetFile.path,
           wikilink.alias,
-          (path: string, alias: string) => this.handleAddAlias(path, alias),
+          (from: number, to: number, _path: string, _alias: string) =>
+            this.handleRemoveRedundantAlias(from, to),
         );
 
         const decoration = Decoration.widget({
           widget,
-          side: 1, // Position after the wikilink
+          side: 1,
         });
 
         builder.add(wikilink.to, wikilink.to, decoration);
+      } else {
+        const existingAliases = this.aliasService.getAliases(targetFile);
+
+        // Check if alias is already in target's aliases or pending addition
+        if (!existingAliases.includes(wikilink.alias) && !this.isPending(targetFile.path, wikilink.alias)) {
+          const widget = new AliasIconWidget(
+            targetFile.path,
+            wikilink.alias,
+            (path: string, alias: string) => this.handleAddAlias(path, alias),
+          );
+
+          const decoration = Decoration.widget({
+            widget,
+            side: 1,
+          });
+
+          builder.add(wikilink.to, wikilink.to, decoration);
+        }
       }
     }
 
     return builder.finish();
+  }
+
+  /**
+   * Handle clicking the remove redundant alias icon.
+   * Transforms [[uuid|Label]] → [[uuid]] by editing the document.
+   */
+  private async handleRemoveRedundantAlias(
+    from: number,
+    to: number,
+  ): Promise<RedundantAliasRemoveClickResult> {
+    this.markRemovalAsPending(from, to);
+
+    try {
+      const currentText = this.view.state.doc.sliceString(from, to);
+
+      // Parse [[target|alias]] to extract target
+      const match = currentText.match(/^\[\[([^\]|]+)\|[^\]]+\]\]$/);
+      if (!match) {
+        this.unmarkRemovalAsPending(from, to);
+        return { success: false, error: "Could not parse wikilink" };
+      }
+
+      const target = match[1];
+      const newText = `[[${target}]]`;
+
+      this.view.dispatch({
+        changes: { from, to, insert: newText },
+      });
+
+      this.notifyUser("Removed redundant alias");
+      setTimeout(() => this.unmarkRemovalAsPending(from, to), 100);
+      return { success: true };
+    } catch (error) {
+      this.unmarkRemovalAsPending(from, to);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.notifyUser(`Failed to remove alias: ${errorMessage}`);
+      return { success: false, error: errorMessage };
+    }
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/editor-extensions/RedundantAliasRemoveWidget.ts
+++ b/packages/obsidian-plugin/src/presentation/editor-extensions/RedundantAliasRemoveWidget.ts
@@ -1,0 +1,106 @@
+import { WidgetType } from "@codemirror/view";
+import { setIcon } from "obsidian";
+
+/**
+ * Result type for the onClick callback to support optimistic UI.
+ */
+export interface RedundantAliasRemoveClickResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Widget that displays an icon to remove a redundant alias from a wikilink.
+ * Appears next to wikilinks where the alias equals the target's exo__Asset_label,
+ * since the plugin already renders the label automatically.
+ *
+ * Clicking transforms [[uuid|Label]] → [[uuid]].
+ *
+ * Implements optimistic UI: icon hides immediately on click, reappears on error.
+ */
+export class RedundantAliasRemoveWidget extends WidgetType {
+  private isProcessing = false;
+
+  constructor(
+    private readonly wikilinkFrom: number,
+    private readonly wikilinkTo: number,
+    private readonly targetPath: string,
+    private readonly alias: string,
+    private readonly onClick: (
+      wikilinkFrom: number,
+      wikilinkTo: number,
+      targetPath: string,
+      alias: string,
+    ) => Promise<RedundantAliasRemoveClickResult>,
+  ) {
+    super();
+  }
+
+  override toDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "exocortex-alias-remove-icon";
+    span.setAttribute("aria-label", `Remove redundant alias "${this.alias}"`);
+    span.setAttribute("data-target-path", this.targetPath);
+    span.setAttribute("data-alias", this.alias);
+
+    setIcon(span, "bookmark-minus");
+
+    span.addEventListener("mouseenter", () => {
+      span.classList.add("is-hovered");
+    });
+
+    span.addEventListener("mouseleave", () => {
+      span.classList.remove("is-hovered");
+    });
+
+    span.addEventListener("click", async (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.handleClick(span);
+    });
+
+    return span;
+  }
+
+  private async handleClick(element: HTMLElement): Promise<void> {
+    if (this.isProcessing) {
+      return;
+    }
+    this.isProcessing = true;
+
+    element.classList.add("is-hidden");
+
+    try {
+      const result = await this.onClick(
+        this.wikilinkFrom,
+        this.wikilinkTo,
+        this.targetPath,
+        this.alias,
+      );
+
+      if (!result.success) {
+        element.classList.remove("is-hidden");
+      }
+    } catch {
+      element.classList.remove("is-hidden");
+    } finally {
+      this.isProcessing = false;
+    }
+  }
+
+  override eq(other: WidgetType): boolean {
+    if (!(other instanceof RedundantAliasRemoveWidget)) {
+      return false;
+    }
+    return (
+      other.wikilinkFrom === this.wikilinkFrom &&
+      other.wikilinkTo === this.wikilinkTo &&
+      other.targetPath === this.targetPath &&
+      other.alias === this.alias
+    );
+  }
+
+  override ignoreEvent(): boolean {
+    return false;
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/editor-extensions/index.ts
+++ b/packages/obsidian-plugin/src/presentation/editor-extensions/index.ts
@@ -5,6 +5,10 @@ export {
   type IAliasService,
 } from "./AliasIconViewPlugin";
 export {
+  RedundantAliasRemoveWidget,
+  type RedundantAliasRemoveClickResult,
+} from "./RedundantAliasRemoveWidget";
+export {
   WikilinkLabelViewPlugin,
   createWikilinkLabelExtension,
   type WikilinkMatch,

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -3112,6 +3112,66 @@
 }
 
 /* ============================================================================
+   RedundantAliasRemoveWidget - Remove redundant wikilink aliases (Issue #2259)
+   ============================================================================ */
+
+.exocortex-alias-remove-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 2px;
+  cursor: pointer;
+  opacity: 0.6;
+  vertical-align: middle;
+  color: var(--text-muted);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.exocortex-alias-remove-icon:hover,
+.exocortex-alias-remove-icon.is-hovered {
+  opacity: 1;
+  transform: scale(1.1);
+  color: var(--text-warning);
+}
+
+.exocortex-alias-remove-icon.is-hidden {
+  display: none;
+}
+
+.exocortex-alias-remove-icon:active {
+  transform: scale(0.95);
+}
+
+.exocortex-alias-remove-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.theme-dark .exocortex-alias-remove-icon {
+  color: var(--text-muted);
+}
+
+@media (prefers-contrast: high) {
+  .exocortex-alias-remove-icon {
+    opacity: 1;
+    border: 1px solid currentColor;
+    border-radius: 2px;
+    padding: 1px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .exocortex-alias-remove-icon {
+    transition: none;
+  }
+
+  .exocortex-alias-remove-icon:hover,
+  .exocortex-alias-remove-icon.is-hovered {
+    transform: none;
+  }
+}
+
+/* ============================================================================
    TableLayoutRenderer - Layout-based Table Rendering (Issue #967)
    ============================================================================ */
 

--- a/packages/obsidian-plugin/tests/unit/RedundantAliasRemoveWidget.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RedundantAliasRemoveWidget.test.ts
@@ -1,0 +1,142 @@
+import { RedundantAliasRemoveWidget } from "../../src/presentation/editor-extensions/RedundantAliasRemoveWidget";
+
+// Uses global obsidian mock from tests/__mocks__/obsidian.ts
+
+describe("RedundantAliasRemoveWidget", () => {
+  const createMockOnClick = (result: { success: boolean; error?: string }) => {
+    return jest.fn().mockResolvedValue(result);
+  };
+
+  describe("constructor", () => {
+    it("should create widget with provided properties", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget = new RedundantAliasRemoveWidget(0, 30, "path/to/file.md", "My Label", onClick);
+
+      expect(widget).toBeInstanceOf(RedundantAliasRemoveWidget);
+    });
+  });
+
+  describe("toDOM", () => {
+    it("should create span element with correct class", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget = new RedundantAliasRemoveWidget(0, 30, "path/to/file.md", "My Label", onClick);
+
+      const element = widget.toDOM();
+
+      expect(element.tagName).toBe("SPAN");
+      expect(element.className).toBe("exocortex-alias-remove-icon");
+    });
+
+    it("should set aria-label for accessibility", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget = new RedundantAliasRemoveWidget(0, 30, "path/to/file.md", "My Label", onClick);
+
+      const element = widget.toDOM();
+
+      expect(element.getAttribute("aria-label")).toBe('Remove redundant alias "My Label"');
+    });
+
+    it("should set data attributes", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget = new RedundantAliasRemoveWidget(0, 30, "path/to/file.md", "My Label", onClick);
+
+      const element = widget.toDOM();
+
+      expect(element.getAttribute("data-target-path")).toBe("path/to/file.md");
+      expect(element.getAttribute("data-alias")).toBe("My Label");
+    });
+
+    it("should call setIcon with bookmark-minus", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget = new RedundantAliasRemoveWidget(0, 30, "path/to/file.md", "My Label", onClick);
+
+      const element = widget.toDOM();
+
+      expect(element.getAttribute("data-icon-set")).toBe("true");
+    });
+
+    it("should call onClick callback when clicked", async () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget = new RedundantAliasRemoveWidget(10, 40, "path/to/file.md", "My Label", onClick);
+
+      const element = widget.toDOM();
+      element.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(onClick).toHaveBeenCalledWith(10, 40, "path/to/file.md", "My Label");
+    });
+
+    it("should add is-hidden class on click (optimistic UI)", async () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget = new RedundantAliasRemoveWidget(0, 30, "path/to/file.md", "My Label", onClick);
+
+      const element = widget.toDOM();
+      element.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(element.classList.contains("is-hidden")).toBe(true);
+    });
+
+    it("should remove is-hidden class on failure", async () => {
+      const onClick = createMockOnClick({ success: false, error: "Failed" });
+      const widget = new RedundantAliasRemoveWidget(0, 30, "path/to/file.md", "My Label", onClick);
+
+      const element = widget.toDOM();
+      element.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(element.classList.contains("is-hidden")).toBe(false);
+    });
+
+    it("should add/remove hover class on mouseenter/mouseleave", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget = new RedundantAliasRemoveWidget(0, 30, "path/to/file.md", "My Label", onClick);
+
+      const element = widget.toDOM();
+
+      element.dispatchEvent(new MouseEvent("mouseenter"));
+      expect(element.classList.contains("is-hovered")).toBe(true);
+
+      element.dispatchEvent(new MouseEvent("mouseleave"));
+      expect(element.classList.contains("is-hovered")).toBe(false);
+    });
+  });
+
+  describe("eq", () => {
+    it("should return true for identical widgets", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget1 = new RedundantAliasRemoveWidget(0, 30, "path.md", "Label", onClick);
+      const widget2 = new RedundantAliasRemoveWidget(0, 30, "path.md", "Label", onClick);
+
+      expect(widget1.eq(widget2)).toBe(true);
+    });
+
+    it("should return false for different positions", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget1 = new RedundantAliasRemoveWidget(0, 30, "path.md", "Label", onClick);
+      const widget2 = new RedundantAliasRemoveWidget(5, 35, "path.md", "Label", onClick);
+
+      expect(widget1.eq(widget2)).toBe(false);
+    });
+
+    it("should return false for different target paths", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget1 = new RedundantAliasRemoveWidget(0, 30, "path1.md", "Label", onClick);
+      const widget2 = new RedundantAliasRemoveWidget(0, 30, "path2.md", "Label", onClick);
+
+      expect(widget1.eq(widget2)).toBe(false);
+    });
+  });
+
+  describe("ignoreEvent", () => {
+    it("should return false to allow event handling", () => {
+      const onClick = createMockOnClick({ success: true });
+      const widget = new RedundantAliasRemoveWidget(0, 30, "path.md", "Label", onClick);
+
+      expect(widget.ignoreEvent()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements #2259: adds an inline button (bookmark-minus icon) next to wikilinks where the alias is redundant — i.e., it equals the target's `exo__Asset_label`.

Since the plugin already renders `exo__Asset_label` instead of UUIDs, these aliases create visual and semantic duplication. Clicking the button transforms `[[uuid|Label]]` → `[[uuid]]`.

## Changes

- **RedundantAliasRemoveWidget** — new widget with optimistic UI (same pattern as AliasIconWidget)
- **AliasIconViewPlugin** — detects redundant aliases via `WikilinkLabelViewPlugin.resolveLabel()` and shows the remove button instead of add-alias button
- **CSS** — styles for `.exocortex-alias-remove-icon` (muted color, warning on hover)
- **Tests** — 13 unit tests for the new widget

Closes #2259