### PR TITLE
feat: support Create Instance for any exo__Prototype asset

### DIFF
--- a/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
+++ b/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
@@ -48,6 +48,12 @@ export function canCreateInstance(context: CommandVisibilityContext): boolean {
     return true;
   }
 
+  // Check if asset is an instance of exo__Prototype (Issue #2261)
+  // This covers any custom prototype class (e.g., ztlk__FleetingNotePrototype)
+  if (hasClass(context.instanceClass, AssetClass.PROTOTYPE)) {
+    return true;
+  }
+
   // Check if asset is a class definition that inherits from exo__Prototype
   return isPrototypeClass(context.instanceClass, context.metadata);
 }

--- a/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
@@ -6,6 +6,7 @@ import {
   TaskCreationService,
   WikiLinkHelpers,
   AssetClass,
+  DateFormatter,
   LoggingService,
 } from "exocortex";
 import { LabelInputModal, type LabelInputModalResult } from '@plugin/presentation/modals/LabelInputModal';
@@ -49,7 +50,11 @@ export class CreateInstanceCommand implements ICommand {
 
     const showTaskSize = sourceClass !== AssetClass.MEETING_PROTOTYPE;
 
-    const result = await this.showModal(showTaskSize);
+    // Generate default label: prototype label + current date (Issue #2261)
+    const baseLabel = String(metadata.exo__Asset_label || file.basename);
+    const defaultLabel = `${baseLabel} ${DateFormatter.toDateString(new Date())}`;
+
+    const result = await this.showModal(showTaskSize, defaultLabel);
 
     if (result.label === null) {
       return;
@@ -84,9 +89,9 @@ export class CreateInstanceCommand implements ICommand {
    * @param showTaskSize - Whether to show task size selector
    * @returns Promise resolving to the modal result
    */
-  private showModal(showTaskSize: boolean): Promise<LabelInputModalResult> {
+  private showModal(showTaskSize: boolean, defaultLabel: string = ""): Promise<LabelInputModalResult> {
     return new Promise<LabelInputModalResult>((resolve) => {
-      new LabelInputModal(this.app, resolve, "", showTaskSize).open();
+      new LabelInputModal(this.app, resolve, defaultLabel, showTaskSize).open();
     });
   }
 

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/CreationButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/CreationButtonGroupBuilder.ts
@@ -102,12 +102,9 @@ export class CreationButtonGroupBuilder implements IButtonGroupBuilder {
         onClick: async () => {
           const sourceClass = this.normalizeClass(instanceClass);
           const isMeeting = sourceClass === AssetClass.MEETING_PROTOTYPE;
-          // Support both string-based and UID-based TaskPrototype identifiers (Issue #2110)
-          const isTaskPrototype = sourceClass === AssetClass.TASK_PROTOTYPE ||
-            sourceClass === AssetClass.TASK_PROTOTYPE_UID;
-          const defaultValue = isMeeting || isTaskPrototype
-            ? this.generateDefaultLabel(metadata, file.basename)
-            : "";
+          // Generate default label for all prototypes (Issue #2261)
+          // Label = prototype's exo__Asset_label + current date
+          const defaultValue = this.generateDefaultLabel(metadata, file.basename);
           const result = await promptForLabel(app, defaultValue, !isMeeting);
           if (result.label === null) return;
           const created = await taskCreationService.createTask(

--- a/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
@@ -151,7 +151,7 @@ describe("CreateInstanceCommand", () => {
       expect(LabelInputModal).toHaveBeenCalledWith(
         mockApp,
         expect.any(Function),
-        "",
+        "test-file 2026-03-10",
         true
       );
       expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
@@ -267,7 +267,7 @@ describe("CreateInstanceCommand", () => {
       expect(LabelInputModal).toHaveBeenCalledWith(
         mockApp,
         expect.any(Function),
-        "",
+        "test-file 2026-03-10",
         false // showTaskSize should be false for MeetingPrototype
       );
     });

--- a/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.instance.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/visibility/CommandVisibility.instance.test.ts
@@ -217,6 +217,33 @@ describe("CommandVisibility - Instance/Subclass Commands", () => {
       expect(canCreateInstance(context)).toBe(true);
     });
 
+    // Instance of exo__Prototype (Issue #2261)
+    describe("assets with exo__Prototype in instanceClass", () => {
+      it("should return true for asset with exo__Prototype in instanceClass array", () => {
+        const context: CommandVisibilityContext = {
+          instanceClass: ["[[ztlk__FleetingNote]]", "[[exo__Prototype]]"],
+          currentStatus: null,
+          metadata: {},
+          isArchived: false,
+          currentFolder: "",
+          expectedFolder: null,
+        };
+        expect(canCreateInstance(context)).toBe(true);
+      });
+
+      it("should return true for asset with exo__Prototype as single instanceClass", () => {
+        const context: CommandVisibilityContext = {
+          instanceClass: "[[exo__Prototype]]",
+          currentStatus: null,
+          metadata: {},
+          isArchived: false,
+          currentFolder: "",
+          expectedFolder: null,
+        };
+        expect(canCreateInstance(context)).toBe(true);
+      });
+    });
+
     // Direct prototype inheritance via exo__Class_superClass
     describe("prototype inheritance via exo__Class_superClass", () => {
       it("should return true for class with exo__Class_superClass pointing to exo__Prototype", () => {


### PR DESCRIPTION
## Summary

Implements #2261: enables "Create Instance" command and layout button for **any** asset with `exo__Prototype` in its `exo__Instance_class`, not just known prototypes.

Previously, `canCreateInstance` only worked for hard-coded classes (`ems__TaskPrototype`, `ems__MeetingPrototype`, etc.) or `exo__Class` definitions inheriting from `exo__Prototype`. Custom prototypes like `ztlk__FleetingNotePrototype` (class `64e14e5e-ef94-4a4d-9658-6e7d32f808c0`) were not recognized.

## Changes

- **`canCreateInstance`** — added `hasClass(context.instanceClass, AssetClass.PROTOTYPE)` check
- **`CreateInstanceCommand`** — generates default label (`prototype label + date`) for all prototypes
- **`CreationButtonGroupBuilder`** — simplified default label logic (all prototypes get default label, not just TaskPrototype/MeetingPrototype)
- **Tests** — 2 new visibility tests + updated existing tests

## Behavior

1. Open any asset with `exo__Prototype` in `exo__Instance_class`
2. "Create Instance" button appears in layout + command palette
3. Modal opens with default label = `exo__Asset_label + current date`
4. Creates instance with `exo__Asset_prototype` pointing to the prototype

Closes #2261