### PR TITLE
fix: resolve UUID-based class refs for Create Instance (#2261)

### DIFF
--- a/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
+++ b/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
@@ -54,6 +54,12 @@ export function canCreateInstance(context: CommandVisibilityContext): boolean {
     return true;
   }
 
+  // Check if the asset's class (resolved by plugin) is a prototype (Issue #2261)
+  // This covers instances whose instanceClass is a UUID pointing to a prototype
+  if (context.classIsPrototype) {
+    return true;
+  }
+
   // Check if asset is a class definition that inherits from exo__Prototype
   return isPrototypeClass(context.instanceClass, context.metadata);
 }

--- a/packages/exocortex/src/domain/commands/visibility/types.ts
+++ b/packages/exocortex/src/domain/commands/visibility/types.ts
@@ -10,8 +10,10 @@
 export interface CommandVisibilityContext {
   instanceClass: string | string[] | null;
   currentStatus: string | string[] | null;
-  metadata: Record<string, any>;
+  metadata: Record<string, unknown>;
   isArchived: boolean;
   currentFolder: string;
   expectedFolder: string | null;
+  /** Whether the asset's class is an instance of exo__Prototype (Issue #2261) */
+  classIsPrototype?: boolean;
 }

--- a/packages/obsidian-plugin/src/application/services/CommandManager.ts
+++ b/packages/obsidian-plugin/src/application/services/CommandManager.ts
@@ -3,7 +3,7 @@ import { ExocortexPluginInterface } from '@plugin/types';
 import { CommandRegistry } from '@plugin/application/commands/CommandRegistry';
 import { MetadataExtractor } from "exocortex";
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
-import { CommandVisibilityContext } from "exocortex";
+import { CommandVisibilityContext, WikiLinkHelpers } from "exocortex";
 
 export class CommandManager {
   private commandRegistry: CommandRegistry | null = null;
@@ -59,6 +59,43 @@ export class CommandManager {
     return {
       ...context,
       expectedFolder: null,
+      classIsPrototype: this.resolveClassIsPrototype(context.instanceClass),
     };
+  }
+
+  /**
+   * Check if any of the asset's instance classes is a prototype (Issue #2261).
+   * Resolves UUID-based class references by looking up the class file's metadata.
+   */
+  private resolveClassIsPrototype(instanceClass: string | string[] | null): boolean {
+    if (!instanceClass) return false;
+    if (!this.app.metadataCache?.getFirstLinkpathDest) return false;
+
+    const classes = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
+
+    for (const cls of classes) {
+      const normalized = WikiLinkHelpers.normalize(cls);
+      if (!normalized) continue;
+
+      const classFile = this.app.metadataCache.getFirstLinkpathDest(normalized, "");
+      if (!classFile) continue;
+
+      const classCache = this.app.metadataCache.getFileCache(classFile);
+      const classMeta = classCache?.frontmatter;
+      if (!classMeta) continue;
+
+      const classInstanceClass = classMeta.exo__Instance_class;
+      if (!classInstanceClass) continue;
+
+      const classClasses = Array.isArray(classInstanceClass) ? classInstanceClass : [classInstanceClass];
+      for (const cc of classClasses) {
+        const normalizedCC = WikiLinkHelpers.normalize(cc);
+        if (normalizedCC === "exo__Prototype" || normalizedCC === "ebf717aa-4070-4b37-abde-10a700e354fc") {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 }

--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -4,6 +4,7 @@ import { ExocortexSettings } from '@plugin/domain/settings/ExocortexSettings';
 import { ButtonGroup } from '@plugin/presentation/components/ActionButtonsGroup';
 import {
   CommandVisibilityContext,
+  WikiLinkHelpers,
   TaskCreationService,
   ProjectCreationService,
   AreaCreationService,
@@ -170,6 +171,10 @@ export class ButtonGroupsBuilder {
       metadata,
     );
 
+    // Resolve whether the asset's class is a prototype (Issue #2261)
+    // This handles UUID-based instanceClass refs like [[64e14e5e-...|ztlk__FleetingNotePrototype]]
+    const classIsPrototype = this.resolveClassIsPrototype(instanceClass);
+
     const visibilityContext: CommandVisibilityContext = {
       instanceClass,
       currentStatus,
@@ -177,6 +182,7 @@ export class ButtonGroupsBuilder {
       isArchived,
       currentFolder,
       expectedFolder,
+      classIsPrototype,
     };
 
     const context: ButtonBuilderContext = {
@@ -202,4 +208,43 @@ export class ButtonGroupsBuilder {
 
     return groups;
   }
+
+  /**
+   * Check if any of the asset's instance classes is a prototype.
+   * Resolves UUID-based class references by looking up the class file's metadata.
+   */
+  private resolveClassIsPrototype(instanceClass: string | string[] | null): boolean {
+    if (!instanceClass) return false;
+    if (!this.app.metadataCache?.getFirstLinkpathDest) return false;
+
+    const classes = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
+
+    for (const cls of classes) {
+      const normalized = WikiLinkHelpers.normalize(cls);
+      if (!normalized) continue;
+
+      // Try to resolve the class file
+      const classFile = this.app.metadataCache.getFirstLinkpathDest(normalized, "");
+      if (!classFile) continue;
+
+      const classCache = this.app.metadataCache.getFileCache(classFile);
+      const classMeta = classCache?.frontmatter;
+      if (!classMeta) continue;
+
+      // Check if the class file has exo__Prototype in its instanceClass
+      const classInstanceClass = classMeta.exo__Instance_class;
+      if (!classInstanceClass) continue;
+
+      const classClasses = Array.isArray(classInstanceClass) ? classInstanceClass : [classInstanceClass];
+      for (const cc of classClasses) {
+        const normalizedCC = WikiLinkHelpers.normalize(cc);
+        if (normalizedCC === "exo__Prototype" || normalizedCC === "ebf717aa-4070-4b37-abde-10a700e354fc") {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
 }


### PR DESCRIPTION
## Problem

PR #2262 added `exo__Prototype` check to `canCreateInstance`, but only for assets that **are** prototypes themselves. Instances **of** custom prototypes (like fleeting notes created from `ztlk__FleetingNotePrototype`) have a UUID in `instanceClass` (e.g., `64e14e5e-ef94-4a4d-9658-6e7d32f808c0`), which doesn't match any known class name.

## Fix

Resolve the UUID reference to the actual class file via `MetadataCache`, then check if that class has `exo__Prototype` in **its** `instanceClass`.

## Changes

- `CommandVisibilityContext`: add optional `classIsPrototype` flag
- `canCreateInstance`: check `context.classIsPrototype`
- `ButtonGroupsBuilder`: resolve class file metadata via `MetadataCache.getFirstLinkpathDest`
- `CommandManager`: same resolution for command palette
- Null guards for test environments

Fixes #2261