### PR TITLE
feat: add inline copy button for exo__Asset_uid property (#2263)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/property-fields/TextPropertyField.ts
+++ b/packages/obsidian-plugin/src/presentation/components/property-fields/TextPropertyField.ts
@@ -1,4 +1,4 @@
-import { Setting } from "obsidian";
+import { Notice, Setting, setIcon } from "obsidian";
 import type { TextPropertyFieldProps, ValidationResult } from "./types";
 
 /**
@@ -78,7 +78,31 @@ export class TextPropertyField {
       }
     });
 
+    if (property.name === "exo__Asset_uid" && value) {
+      this.addCopyButton(setting, value);
+    }
+
     return setting;
+  }
+
+  private addCopyButton(setting: Setting, value: string): void {
+    const btn = setting.controlEl.createEl("button", {
+      cls: "clickable-icon",
+      attr: {
+        "aria-label": "Copy uid",
+      },
+    });
+    setIcon(btn, "copy");
+    btn.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(value);
+        setIcon(btn, "check");
+        new Notice("Uid copied to clipboard");
+        setTimeout(() => setIcon(btn, "copy"), 1500);
+      } catch {
+        new Notice("Failed to copy uid");
+      }
+    });
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/property-fields/TextPropertyField.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-fields/TextPropertyField.test.ts
@@ -3,6 +3,19 @@ import { TextPropertyField } from "../../../src/presentation/components/property
 
 // Helper to extend HTMLElement with Obsidian's methods
 function extendElement(el: HTMLElement): HTMLElement {
+  (el as any).createEl = (tag: string, options?: { cls?: string; text?: string; attr?: Record<string, string> }) => {
+    const child = document.createElement(tag);
+    if (options?.cls) child.className = options.cls;
+    if (options?.text) child.textContent = options.text;
+    if (options?.attr) {
+      for (const [key, val] of Object.entries(options.attr)) {
+        child.setAttribute(key, val);
+      }
+    }
+    extendElement(child);
+    el.appendChild(child);
+    return child;
+  };
   (el as any).createDiv = (options?: { cls?: string; text?: string }) => {
     const div = document.createElement("div");
     if (options?.cls) div.className = options.cls;
@@ -27,6 +40,10 @@ function extendElement(el: HTMLElement): HTMLElement {
 
 // Mock Obsidian's Setting class
 jest.mock("obsidian", () => ({
+  Notice: jest.fn(),
+  setIcon: jest.fn((el: HTMLElement, icon: string) => {
+    el.dataset.icon = icon;
+  }),
   Setting: class {
     settingEl = extendElement(document.createElement("div"));
     nameEl = extendElement(document.createElement("div"));
@@ -284,6 +301,134 @@ describe("TextPropertyField", () => {
       field.setValue("Updated");
       const input = containerEl.querySelector("input") as HTMLInputElement | null;
       expect(input!.value).toBe("Updated");
+    });
+  });
+
+  describe("copy UID button", () => {
+    const UID_VALUE = "fca0a931-a01f-48e4-b72a-4af206c94bc7";
+
+    beforeEach(() => {
+      Object.assign(navigator, {
+        clipboard: {
+          writeText: jest.fn().mockResolvedValue(undefined),
+        },
+      });
+    });
+
+    it("should render copy button for exo__Asset_uid property", () => {
+      new TextPropertyField(containerEl, {
+        property: {
+          uri: "exo:Asset_uid",
+          name: "exo__Asset_uid",
+          label: "UID",
+          fieldType: PropertyFieldType.Text,
+        },
+        value: UID_VALUE,
+        onChange: jest.fn(),
+      });
+
+      const btn = containerEl.querySelector("button.clickable-icon");
+      expect(btn).not.toBeNull();
+      expect(btn!.getAttribute("aria-label")).toBe("Copy uid");
+    });
+
+    it("should not render copy button for other text properties", () => {
+      new TextPropertyField(containerEl, {
+        property: {
+          uri: "exo:Asset_label",
+          name: "exo__Asset_label",
+          label: "Label",
+          fieldType: PropertyFieldType.Text,
+        },
+        value: "Some Label",
+        onChange: jest.fn(),
+      });
+
+      const btn = containerEl.querySelector("button.clickable-icon");
+      expect(btn).toBeNull();
+    });
+
+    it("should not render copy button when UID value is empty", () => {
+      new TextPropertyField(containerEl, {
+        property: {
+          uri: "exo:Asset_uid",
+          name: "exo__Asset_uid",
+          label: "UID",
+          fieldType: PropertyFieldType.Text,
+        },
+        value: "",
+        onChange: jest.fn(),
+      });
+
+      const btn = containerEl.querySelector("button.clickable-icon");
+      expect(btn).toBeNull();
+    });
+
+    it("should copy UID to clipboard on click", async () => {
+      new TextPropertyField(containerEl, {
+        property: {
+          uri: "exo:Asset_uid",
+          name: "exo__Asset_uid",
+          label: "UID",
+          fieldType: PropertyFieldType.Text,
+        },
+        value: UID_VALUE,
+        onChange: jest.fn(),
+      });
+
+      const btn = containerEl.querySelector("button.clickable-icon") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise(process.nextTick);
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(UID_VALUE);
+    });
+
+    it("should show Notice after successful copy", async () => {
+      const { Notice } = require("obsidian");
+
+      new TextPropertyField(containerEl, {
+        property: {
+          uri: "exo:Asset_uid",
+          name: "exo__Asset_uid",
+          label: "UID",
+          fieldType: PropertyFieldType.Text,
+        },
+        value: UID_VALUE,
+        onChange: jest.fn(),
+      });
+
+      const btn = containerEl.querySelector("button.clickable-icon") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise(process.nextTick);
+
+      expect(Notice).toHaveBeenCalledWith("Uid copied to clipboard");
+    });
+
+    it("should change icon to check after copy", async () => {
+      const { setIcon } = require("obsidian");
+
+      new TextPropertyField(containerEl, {
+        property: {
+          uri: "exo:Asset_uid",
+          name: "exo__Asset_uid",
+          label: "UID",
+          fieldType: PropertyFieldType.Text,
+        },
+        value: UID_VALUE,
+        onChange: jest.fn(),
+      });
+
+      const btn = containerEl.querySelector("button.clickable-icon") as HTMLButtonElement;
+      btn.click();
+
+      await new Promise(process.nextTick);
+
+      const calls = setIcon.mock.calls;
+      const checkCall = calls.find((c: any[]) => c[1] === "check");
+      expect(checkCall).toBeDefined();
+      expect(checkCall![0]).toBe(btn);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a copy-to-clipboard button next to the `exo__Asset_uid` value in layout property fields
- One-click UUID copying without manual text selection
- Visual feedback: icon changes to checkmark for 1.5s after copy
- `Notice` shown on success/failure

## Implementation
- Modified `TextPropertyField.ts` to detect `exo__Asset_uid` property and append a copy button
- Uses Obsidian's `setIcon` API for consistent theming (`copy` → `check` → `copy`)
- Uses `navigator.clipboard.writeText()` with error handling
- Button uses `clickable-icon` class for native Obsidian styling

## Test plan
- [x] 6 new unit tests covering:
  - Copy button renders for `exo__Asset_uid` only
  - No button for other text properties
  - No button when value is empty
  - Clipboard write with correct value
  - Notice shown after copy
  - Icon changes to check after copy
- [x] All 18 TextPropertyField tests pass
- [x] Pre-commit hooks pass (lint + tests + BDD 100%)

Closes #2263