### PR TITLE
fix: use dynamic date in CreateInstanceCommand tests

### DIFF
--- a/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
@@ -5,7 +5,8 @@ import {
   TaskCreationService,
   CommandVisibilityContext,
   LoggingService,
-  AssetClass
+  AssetClass,
+  DateFormatter
 } from "exocortex";
 import { LabelInputModal } from "../../src/presentation/modals/LabelInputModal";
 import { ObsidianVaultAdapter } from "../../src/adapters/ObsidianVaultAdapter";
@@ -151,7 +152,7 @@ describe("CreateInstanceCommand", () => {
       expect(LabelInputModal).toHaveBeenCalledWith(
         mockApp,
         expect.any(Function),
-        "test-file 2026-03-10",
+        `test-file ${DateFormatter.toDateString(new Date())}`,
         true
       );
       expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
@@ -267,7 +268,7 @@ describe("CreateInstanceCommand", () => {
       expect(LabelInputModal).toHaveBeenCalledWith(
         mockApp,
         expect.any(Function),
-        "test-file 2026-03-10",
+        `test-file ${DateFormatter.toDateString(new Date())}`,
         false // showTaskSize should be false for MeetingPrototype
       );
     });


### PR DESCRIPTION
## Summary
- Replace hardcoded date `2026-03-10` with `DateFormatter.toDateString(new Date())` in CreateInstanceCommand tests
- Prevents CI failures when the date changes (was blocking auto-release for PR #2265)

## Test plan
- [x] CreateInstanceCommand tests pass locally (12/12)
- [x] Pre-commit hooks pass