### PR TITLE
feat: show redundant wikilink-alias remove button in Properties block (#2267)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetPropertiesTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetPropertiesTable.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useMemo, useEffect } from "react";
-import { TFile } from "obsidian";
+import React, { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import { TFile, setIcon } from "obsidian";
 import { PropertyUpdateService } from '@plugin/application/services/PropertyUpdateService';
 import { PropertyValidationService } from '@plugin/application/services/PropertyValidationService';
 import { TextPropertyField } from "./properties/TextPropertyField";
@@ -21,16 +21,47 @@ export interface AssetPropertiesTableProps {
   metadata: Record<string, unknown>;
   onLinkClick?: (path: string, event: React.MouseEvent) => void;
   getAssetLabel?: (path: string) => string | null;
+  onRemoveRedundantAlias?: (file: TFile, propertyKey: string, target: string, alias: string) => Promise<void>;
   file?: TFile;
   propertyUpdateService?: PropertyUpdateService;
   propertyValidationService?: PropertyValidationService;
   editable?: boolean;
 }
 
+/**
+ * Helper component to render the bookmark-minus icon via Obsidian's setIcon.
+ */
+const AliasRemoveIcon: React.FC<{
+  alias: string;
+  onClick: () => void;
+}> = ({ alias, onClick }) => {
+  const spanRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (spanRef.current) {
+      setIcon(spanRef.current, "bookmark-minus");
+    }
+  }, []);
+
+  return (
+    <span
+      ref={spanRef}
+      className="exocortex-alias-remove-icon"
+      aria-label={`Remove redundant alias "${alias}"`}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onClick();
+      }}
+    />
+  );
+};
+
 export const AssetPropertiesTable: React.FC<AssetPropertiesTableProps> = ({
   metadata,
   onLinkClick,
   getAssetLabel,
+  onRemoveRedundantAlias,
   file,
   propertyUpdateService,
   propertyValidationService,
@@ -145,6 +176,25 @@ export const AssetPropertiesTable: React.FC<AssetPropertiesTableProps> = ({
     return "text";
   };
 
+  const [hiddenAliasIcons, setHiddenAliasIcons] = useState<Set<string>>(new Set());
+
+  const handleRemoveAlias = useCallback(async (propertyKey: string, target: string, alias: string) => {
+    if (!file || !onRemoveRedundantAlias) return;
+
+    const iconKey = `${propertyKey}:${target}`;
+    setHiddenAliasIcons(prev => new Set(prev).add(iconKey));
+
+    try {
+      await onRemoveRedundantAlias(file, propertyKey, target, alias);
+    } catch {
+      setHiddenAliasIcons(prev => {
+        const next = new Set(prev);
+        next.delete(iconKey);
+        return next;
+      });
+    }
+  }, [file, onRemoveRedundantAlias]);
+
   const handlePropertyUpdate = async (key: string, newValue: unknown) => {
     if (!file || !propertyUpdateService) return;
 
@@ -181,11 +231,11 @@ export const AssetPropertiesTable: React.FC<AssetPropertiesTableProps> = ({
       case "boolean":
       case "number":
       default:
-        return renderValue(value);
+        return renderValue(value, key);
     }
   };
 
-  const renderValue = (value: unknown): React.ReactNode => {
+  const renderValue = (value: unknown, propertyKey?: string): React.ReactNode => {
     if (value === null || value === undefined) {
       return "-";
     }
@@ -199,19 +249,31 @@ export const AssetPropertiesTable: React.FC<AssetPropertiesTableProps> = ({
         const parsed = parseWikiLink(value);
         const label = getAssetLabel?.(parsed.target);
         const displayText = parsed.alias || label || parsed.target;
+        const alias = parsed.alias;
+        const isRedundantAlias = alias != null && label != null && alias === label;
+        const iconKey = propertyKey ? `${propertyKey}:${parsed.target}` : "";
+        const iconHidden = hiddenAliasIcons.has(iconKey);
         return (
-          <a
-            data-href={parsed.target}
-            className="internal-link"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onLinkClick?.(parsed.target, e);
-            }}
-            style={{ cursor: "pointer" }}
-          >
-            {displayText}
-          </a>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: "2px" }}>
+            <a
+              data-href={parsed.target}
+              className="internal-link"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onLinkClick?.(parsed.target, e);
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              {displayText}
+            </a>
+            {isRedundantAlias && alias && onRemoveRedundantAlias && propertyKey && !iconHidden && (
+              <AliasRemoveIcon
+                alias={alias}
+                onClick={() => handleRemoveAlias(propertyKey, parsed.target, alias)}
+              />
+            )}
+          </span>
         );
       }
       return value;
@@ -222,7 +284,7 @@ export const AssetPropertiesTable: React.FC<AssetPropertiesTableProps> = ({
         <>
           {value.map((item, index) => (
             <React.Fragment key={index}>
-              {renderValue(item)}
+              {renderValue(item, propertyKey)}
               {index < value.length - 1 ? ", " : ""}
             </React.Fragment>
           ))}
@@ -363,7 +425,7 @@ export const AssetPropertiesTable: React.FC<AssetPropertiesTableProps> = ({
                 >
                   {editable && file && propertyUpdateService
                     ? renderEditableField(key, value)
-                    : renderValue(value)}
+                    : renderValue(value, key)}
                 </td>
               </tr>
             );

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/PropertiesRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/PropertiesRenderer.ts
@@ -85,6 +85,33 @@ export class PropertiesRenderer {
           },
           getAssetLabel: (path: string) =>
             this.metadataService.getAssetLabel(path),
+          onRemoveRedundantAlias: async (
+            targetFile: TFile,
+            propertyKey: string,
+            target: string,
+            alias: string,
+          ) => {
+            const currentValue = filteredMetadata[propertyKey];
+            const oldWikilink = `[[${target}|${alias}]]`;
+            const newWikilink = `[[${target}]]`;
+
+            if (Array.isArray(currentValue)) {
+              const updatedArray = currentValue.map((item: unknown) =>
+                item === oldWikilink ? newWikilink : item,
+              );
+              await this.propertyUpdateService.updateProperty(
+                targetFile,
+                propertyKey,
+                updatedArray,
+              );
+            } else {
+              await this.propertyUpdateService.updateProperty(
+                targetFile,
+                propertyKey,
+                newWikilink,
+              );
+            }
+          },
           file: file,
           propertyUpdateService: this.propertyUpdateService,
           editable: options?.editable ?? true,

--- a/packages/obsidian-plugin/tests/unit/AssetPropertiesTable.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/AssetPropertiesTable.test.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { render, act } from "@testing-library/react";
+import { AssetPropertiesTable } from "../../src/presentation/components/AssetPropertiesTable";
+import { createMockTFile } from "./helpers/testHelpers";
+
+// Uses the __mocks__/obsidian.ts mock via moduleNameMapper (no jest.mock needed)
+
+describe("AssetPropertiesTable - Redundant Alias Remove", () => {
+  const mockFile = createMockTFile("test/file.md");
+
+  function makeGetAssetLabel(mapping: Record<string, string>) {
+    return (path: string) => mapping[path] ?? null;
+  }
+
+  it("renders remove icon when alias equals getAssetLabel result", () => {
+    const onRemoveRedundantAlias = jest.fn();
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ parent: "[[some-uuid|My Label]]" }}
+        getAssetLabel={makeGetAssetLabel({ "some-uuid": "My Label" })}
+        file={mockFile}
+        onRemoveRedundantAlias={onRemoveRedundantAlias}
+      />,
+    );
+
+    const icon = container.querySelector(".exocortex-alias-remove-icon");
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("aria-label")).toBe(
+      'Remove redundant alias "My Label"',
+    );
+  });
+
+  it("does NOT render remove icon when alias differs from label", () => {
+    const onRemoveRedundantAlias = jest.fn();
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ parent: "[[some-uuid|Different Label]]" }}
+        getAssetLabel={makeGetAssetLabel({ "some-uuid": "My Label" })}
+        file={mockFile}
+        onRemoveRedundantAlias={onRemoveRedundantAlias}
+      />,
+    );
+
+    const icon = container.querySelector(".exocortex-alias-remove-icon");
+    expect(icon).toBeNull();
+  });
+
+  it("does NOT render remove icon when onRemoveRedundantAlias is not provided", () => {
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ parent: "[[some-uuid|My Label]]" }}
+        getAssetLabel={makeGetAssetLabel({ "some-uuid": "My Label" })}
+        file={mockFile}
+      />,
+    );
+
+    const icon = container.querySelector(".exocortex-alias-remove-icon");
+    expect(icon).toBeNull();
+  });
+
+  it("does NOT render remove icon when wikilink has no alias", () => {
+    const onRemoveRedundantAlias = jest.fn();
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ parent: "[[some-uuid]]" }}
+        getAssetLabel={makeGetAssetLabel({ "some-uuid": "My Label" })}
+        file={mockFile}
+        onRemoveRedundantAlias={onRemoveRedundantAlias}
+      />,
+    );
+
+    const icon = container.querySelector(".exocortex-alias-remove-icon");
+    expect(icon).toBeNull();
+  });
+
+  it("does NOT render remove icon when getAssetLabel returns null", () => {
+    const onRemoveRedundantAlias = jest.fn();
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ parent: "[[some-uuid|My Label]]" }}
+        getAssetLabel={makeGetAssetLabel({})}
+        file={mockFile}
+        onRemoveRedundantAlias={onRemoveRedundantAlias}
+      />,
+    );
+
+    const icon = container.querySelector(".exocortex-alias-remove-icon");
+    expect(icon).toBeNull();
+  });
+
+  it("calls onRemoveRedundantAlias with correct args on click", async () => {
+    const onRemoveRedundantAlias = jest.fn().mockResolvedValue(undefined);
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ parent: "[[some-uuid|My Label]]" }}
+        getAssetLabel={makeGetAssetLabel({ "some-uuid": "My Label" })}
+        file={mockFile}
+        onRemoveRedundantAlias={onRemoveRedundantAlias}
+      />,
+    );
+
+    const icon = container.querySelector(".exocortex-alias-remove-icon");
+    expect(icon).not.toBeNull();
+
+    await act(async () => {
+      icon!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onRemoveRedundantAlias).toHaveBeenCalledWith(
+      mockFile,
+      "parent",
+      "some-uuid",
+      "My Label",
+    );
+  });
+
+  it("works for array properties with wikilinks", () => {
+    const onRemoveRedundantAlias = jest.fn();
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{
+          tags: [
+            "[[uuid1|Label One]]",
+            "[[uuid2|Different]]",
+            "[[uuid3|Label Three]]",
+          ],
+        }}
+        getAssetLabel={makeGetAssetLabel({
+          uuid1: "Label One",
+          uuid2: "Actual Label",
+          uuid3: "Label Three",
+        })}
+        file={mockFile}
+        onRemoveRedundantAlias={onRemoveRedundantAlias}
+      />,
+    );
+
+    const icons = container.querySelectorAll(".exocortex-alias-remove-icon");
+    // uuid1 and uuid3 have redundant aliases, uuid2 does not
+    expect(icons).toHaveLength(2);
+  });
+
+  it("hides icon optimistically on click and shows on error", async () => {
+    const error = new Error("update failed");
+    const onRemoveRedundantAlias = jest.fn().mockRejectedValue(error);
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ parent: "[[some-uuid|My Label]]" }}
+        getAssetLabel={makeGetAssetLabel({ "some-uuid": "My Label" })}
+        file={mockFile}
+        onRemoveRedundantAlias={onRemoveRedundantAlias}
+      />,
+    );
+
+    const icon = container.querySelector(".exocortex-alias-remove-icon");
+    expect(icon).not.toBeNull();
+
+    // Click to trigger removal - wrap in act since it triggers state update
+    await act(async () => {
+      icon!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // Icon should be hidden (optimistic UI) then reappear after error
+    // After act completes, the rejected promise and re-render have happened
+    expect(
+      container.querySelector(".exocortex-alias-remove-icon"),
+    ).not.toBeNull();
+  });
+
+  it("uses setIcon with bookmark-minus", () => {
+    const onRemoveRedundantAlias = jest.fn();
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ parent: "[[some-uuid|My Label]]" }}
+        getAssetLabel={makeGetAssetLabel({ "some-uuid": "My Label" })}
+        file={mockFile}
+        onRemoveRedundantAlias={onRemoveRedundantAlias}
+      />,
+    );
+
+    const icon = container.querySelector(".exocortex-alias-remove-icon");
+    expect(icon).not.toBeNull();
+    // The __mocks__/obsidian.ts setIcon sets data-icon-name attribute
+    expect(icon?.getAttribute("data-icon-name")).toBe("bookmark-minus");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/PropertiesRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PropertiesRenderer.test.ts
@@ -96,6 +96,7 @@ describe("PropertiesRenderer", () => {
           metadata,
           onLinkClick: expect.any(Function),
           getAssetLabel: expect.any(Function),
+          onRemoveRedundantAlias: expect.any(Function),
         })
       );
     });
@@ -183,6 +184,56 @@ describe("PropertiesRenderer", () => {
 
         expect(mockMetadataService.getAssetLabel).toHaveBeenCalledWith("some/path.md");
         expect(result).toBe("Asset Label");
+      });
+    });
+
+    describe("onRemoveRedundantAlias callback", () => {
+      let onRemoveRedundantAlias: (file: any, key: string, target: string, alias: string) => Promise<void>;
+
+      beforeEach(async () => {
+        const metadata = createMockMetadata({
+          parent: "[[some-uuid|My Label]]",
+        });
+        mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
+
+        await renderer.render(mockElement, mockFile);
+
+        const createElementCall = (React.createElement as jest.Mock).mock.calls[0];
+        onRemoveRedundantAlias = createElementCall[1].onRemoveRedundantAlias;
+      });
+
+      it("should update single wikilink property to remove alias", async () => {
+        mockApp.fileManager.processFrontMatter.mockImplementation(
+          (_file: any, callback: (fm: any) => void) => {
+            const fm: Record<string, unknown> = {};
+            callback(fm);
+            expect(fm.parent).toBe("[[some-uuid]]");
+          },
+        );
+
+        await onRemoveRedundantAlias(mockFile, "parent", "some-uuid", "My Label");
+      });
+
+      it("should update array property to remove alias from matching element", async () => {
+        const metadata = createMockMetadata({
+          tags: ["[[uuid1|Label One]]", "[[uuid2|Keep This]]"],
+        });
+        mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
+
+        await renderer.render(mockElement, mockFile);
+
+        const createElementCall = (React.createElement as jest.Mock).mock.calls[1];
+        const callback = createElementCall[1].onRemoveRedundantAlias;
+
+        mockApp.fileManager.processFrontMatter.mockImplementation(
+          (_file: any, cb: (fm: any) => void) => {
+            const fm: Record<string, unknown> = {};
+            cb(fm);
+            expect(fm.tags).toEqual(["[[uuid1]]", "[[uuid2|Keep This]]"]);
+          },
+        );
+
+        await callback(mockFile, "tags", "uuid1", "Label One");
       });
     });
 


### PR DESCRIPTION
## Summary
Adds the redundant wikilink-alias remove button (bookmark-minus icon) to the Properties block rendered by `AssetPropertiesTable`, so users can remove redundant aliases not only in the editor (CodeMirror) but also in layout view.

## Changes
- **`AssetPropertiesTable.tsx`**: Added `onRemoveRedundantAlias` prop, `AliasRemoveIcon` component (uses Obsidian `setIcon` via ref), redundant alias detection in `renderValue()`, optimistic UI (hide icon on click, restore on error)
- **`PropertiesRenderer.ts`**: Passes `onRemoveRedundantAlias` callback that updates frontmatter via `PropertyUpdateService` (handles both single values and arrays)
- **`AssetPropertiesTable.test.tsx`**: New unit tests covering icon rendering, click behavior, absence when not needed
- **`PropertiesRenderer.test.ts`**: Tests for callback wiring

## Testing
- All 4536 tests pass (2 pre-existing date-related failures in CreateInstanceCommand)
- BDD coverage: 100% (222/222 scenarios)
- ESLint: clean

Closes #2267
Extends #2259