### PR TITLE
fix: add copy UID button to layout view (#2272)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetPropertiesTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetPropertiesTable.tsx
@@ -31,6 +31,42 @@ export interface AssetPropertiesTableProps {
 /**
  * Helper component to render the bookmark-minus icon via Obsidian's setIcon.
  */
+const CopyUidIcon: React.FC<{
+  value: string;
+}> = ({ value }) => {
+  const spanRef = useRef<HTMLSpanElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (spanRef.current) {
+      setIcon(spanRef.current, copied ? "check" : "copy");
+    }
+  }, [copied]);
+
+  const handleClick = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <span
+      ref={spanRef}
+      className="clickable-icon exo-copy-uid-btn"
+      aria-label="Copy uid"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        handleClick();
+      }}
+    />
+  );
+};
+
 const AliasRemoveIcon: React.FC<{
   alias: string;
   onClick: () => void;
@@ -245,6 +281,15 @@ export const AssetPropertiesTable: React.FC<AssetPropertiesTableProps> = ({
     }
 
     if (typeof value === "string") {
+      if (propertyKey === "exo__Asset_uid" && value) {
+        return (
+          <span style={{ display: "inline-flex", alignItems: "center", gap: "4px" }}>
+            {value}
+            <CopyUidIcon value={value} />
+          </span>
+        );
+      }
+
       if (isWikiLink(value)) {
         const parsed = parseWikiLink(value);
         const label = getAssetLabel?.(parsed.target);

--- a/packages/obsidian-plugin/tests/unit/AssetPropertiesTable.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/AssetPropertiesTable.test.tsx
@@ -5,6 +5,67 @@ import { createMockTFile } from "./helpers/testHelpers";
 
 // Uses the __mocks__/obsidian.ts mock via moduleNameMapper (no jest.mock needed)
 
+describe("AssetPropertiesTable - Copy UID button", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("renders copy button for exo__Asset_uid property", () => {
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ exo__Asset_uid: "fca0a931-a01f-48e4-b72a-4af206c94bc7" }}
+      />,
+    );
+
+    const btn = container.querySelector(".exo-copy-uid-btn");
+    expect(btn).not.toBeNull();
+    expect(btn?.getAttribute("aria-label")).toBe("Copy uid");
+  });
+
+  it("does not render copy button for other properties", () => {
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ exo__Asset_label: "Some Label" }}
+      />,
+    );
+
+    const btn = container.querySelector(".exo-copy-uid-btn");
+    expect(btn).toBeNull();
+  });
+
+  it("copies UID to clipboard on click", async () => {
+    const uid = "fca0a931-a01f-48e4-b72a-4af206c94bc7";
+    const { container } = render(
+      <AssetPropertiesTable metadata={{ exo__Asset_uid: uid }} />,
+    );
+
+    const btn = container.querySelector(".exo-copy-uid-btn");
+    expect(btn).not.toBeNull();
+
+    await act(async () => {
+      btn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(uid);
+  });
+
+  it("uses setIcon with copy icon", () => {
+    const { container } = render(
+      <AssetPropertiesTable
+        metadata={{ exo__Asset_uid: "test-uid" }}
+      />,
+    );
+
+    const btn = container.querySelector(".exo-copy-uid-btn");
+    expect(btn).not.toBeNull();
+    expect(btn?.getAttribute("data-icon-name")).toBe("copy");
+  });
+});
+
 describe("AssetPropertiesTable - Redundant Alias Remove", () => {
   const mockFile = createMockTFile("test/file.md");
 


### PR DESCRIPTION
## Summary
- Add copy-to-clipboard button next to `exo__Asset_uid` value in layout view (`AssetPropertiesTable.tsx`)
- PR #2265 added the button to `TextPropertyField.ts` (creation modal only) — this fix puts it in the correct component

## Implementation
- New `CopyUidIcon` React component using `setIcon` from Obsidian API
- Conditional rendering: only for `exo__Asset_uid` property
- Visual feedback: icon changes `copy` → `check` for 1.5s after click
- Uses `navigator.clipboard.writeText()` with error handling

## Test plan
- [x] 4 new unit tests: render, no-render for other props, clipboard write, icon check
- [x] All 13 AssetPropertiesTable tests pass
- [x] Pre-commit hooks pass (lint + tests + BDD 100%)

Closes #2272