### PR TITLE
fix: add UpdateExecutor mock to CLI SPARQL query tests

### DIFF
--- a/packages/cli/tests/unit/commands/sparql-query-debug.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-debug.test.ts
@@ -54,6 +54,10 @@ jest.unstable_mockModule("exocortex", () => ({
     convertVault: jest.fn().mockResolvedValue([]),
   })),
   SolutionMapping: class SolutionMapping extends Map {},
+  UpdateExecutor: jest.fn(() => ({
+    execute: jest.fn().mockResolvedValue({ insertedCount: 0, deletedCount: 0 }),
+  })),
+  UpdateExecutorError: class UpdateExecutorError extends Error {},
   IRI: jest.fn(),
   Literal: jest.fn(),
   BlankNode: jest.fn(),

--- a/packages/cli/tests/unit/commands/sparql-query.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query.test.ts
@@ -51,6 +51,10 @@ jest.unstable_mockModule("exocortex", () => ({
     convertVault: jest.fn().mockResolvedValue([]),
   })),
   SolutionMapping: class SolutionMapping extends Map {},
+  UpdateExecutor: jest.fn(() => ({
+    execute: jest.fn().mockResolvedValue({ insertedCount: 0, deletedCount: 0 }),
+  })),
+  UpdateExecutorError: class UpdateExecutorError extends Error {},
   IRI: jest.fn(),
   Literal: jest.fn(),
   BlankNode: jest.fn(),


### PR DESCRIPTION
## Summary
- Add missing `UpdateExecutor` and `UpdateExecutorError` mocks to CLI SPARQL query test files
- PR #2268 added `UpdateExecutor` import to `sparql-query.ts` but didn't update the ESM mocks in test files
- This was blocking auto-release on main (CI failure → Auto Release skipped)

## Test plan
- [x] Pre-commit hooks pass
- [x] CI should now pass for test-unit and test-coverage jobs