### PR TITLE
fix: use setup-node registry-url for npm auth, add whoami pre-check

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -121,6 +121,7 @@ jobs:
         with:
           node-version: "22"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Update package.json and manifest.json
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
@@ -274,10 +275,14 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Setup npm for publishing
+      - name: Verify npm auth
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          echo "🔑 Verifying npm authentication..."
+          npm whoami --registry https://registry.npmjs.org
+          echo "✅ npm auth verified"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update CLI package version
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'


### PR DESCRIPTION
## Changes

- Replace manual `.npmrc` creation with `setup-node` `registry-url` (GitHub Actions best practice)
- Add `npm whoami` pre-check to fail fast on expired/invalid tokens with clear error
- Remove redundant "Setup npm for publishing" step

## Context

Auto-release has been failing at npm publish since v15.30.0 (March 14) with `E404 Not Found`. Root cause was expired `NPM_TOKEN` (now renewed). This PR also hardens the workflow to catch auth issues earlier.

**Failed runs:** [#23088769364](https://github.com/kitelev/exocortex/actions/runs/23088769364), [#23354992666](https://github.com/kitelev/exocortex/actions/runs/23354992666)

Closes #2276