### PR TITLE
fix(test): add missing mocks for RDFS inference in sparql-index tests

### DIFF
--- a/packages/cli/tests/unit/commands/sparql-index.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-index.test.ts
@@ -8,6 +8,8 @@ const mockBuildCacheWithValidation = jest.fn();
 const mockGetCacheStats = jest.fn();
 const mockInvalidate = jest.fn();
 const mockGetCachePath = jest.fn();
+const mockLoadOrBuild = jest.fn();
+const mockSaveTriples = jest.fn();
 
 jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
   CacheManager: jest.fn(() => ({
@@ -15,6 +17,23 @@ jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
     getCacheStats: mockGetCacheStats,
     invalidate: mockInvalidate,
     getCachePath: mockGetCachePath,
+    loadOrBuild: mockLoadOrBuild,
+    saveTriples: mockSaveTriples,
+  })),
+}));
+
+// Mock exocortex RDFS inference
+const mockAddAll = jest.fn();
+const mockMatch = jest.fn();
+const mockMaterialize = jest.fn();
+
+jest.unstable_mockModule("exocortex", () => ({
+  InMemoryTripleStore: jest.fn(() => ({
+    addAll: mockAddAll,
+    match: mockMatch,
+  })),
+  RDFSInferenceEngine: jest.fn(() => ({
+    materialize: mockMaterialize,
   })),
 }));
 
@@ -54,6 +73,11 @@ describe("sparqlIndexCommand", () => {
       sizeBytes: 50000,
     });
     mockInvalidate.mockResolvedValue(undefined);
+    mockLoadOrBuild.mockResolvedValue({ triples: [] });
+    mockSaveTriples.mockResolvedValue(undefined);
+    mockAddAll.mockResolvedValue(undefined);
+    mockMatch.mockResolvedValue([]);
+    mockMaterialize.mockResolvedValue(0);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Changes

- Add `loadOrBuild` and `saveTriples` mocks to CacheManager mock
- Add `InMemoryTripleStore` and `RDFSInferenceEngine` mocks for `exocortex` module

## Context

PR #2271 (RDFS subClassOf inference) added a `cacheManager.loadOrBuild()` call in `sparql-index.ts` but didn't update the test mocks. This caused `test-unit` and `test-coverage` jobs to fail on `main`, which blocked auto-release.

Failing tests:
- `sparqlIndexCommand › index building › should build cache and output success message`
- `sparqlIndexCommand › index building › should show stats when --stats flag is provided`

Closes #2276