### PR TITLE
fix(cli): auto-inject Exocortex PREFIX declarations and resolve shorthand notation (#2284)

### DIFF
--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -15,6 +15,7 @@ import {
   type UpdateResult,
   type SolutionMapping,
   type ConstructOperation,
+  SPARQL_PREFIXES,
 } from "exocortex";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
 import { TableFormatter } from "../formatters/TableFormatter.js";
@@ -33,6 +34,7 @@ import { TemplateRegistry } from "../templates/TemplateRegistry.js";
 import { SPARQLErrorEnhancer } from "../utils/SPARQLErrorEnhancer.js";
 import { NTriplesFormatter } from "../utils/NTriplesFormatter.js";
 import { scanVaultNamespaces } from "../utils/VaultNamespaceScanner.js";
+import { injectExocortexPrefixes, transformShorthandNotation, filterOntologyPrefixes } from "../utils/QueryPrefixInjector.js";
 
 export interface SparqlQueryOptions {
   vault: string;
@@ -354,8 +356,15 @@ export function sparqlQueryCommand(): Command {
 
         const parser = new SPARQLParser();
 
+        // Transform shorthand notation: <exo__Property> → exo:Property
+        queryString = transformShorthandNotation(queryString);
+
+        // Auto-inject missing Exocortex PREFIX declarations
+        queryString = injectExocortexPrefixes(queryString);
+
         // Scan vault for namespace directories and auto-register prefixes
-        const vaultPrefixes = scanVaultNamespaces(vaultPath);
+        // Filter out ontology prefixes to avoid collision (exo/, ems/ dirs vs ontology IRIs)
+        const vaultPrefixes = filterOntologyPrefixes(scanVaultNamespaces(vaultPath));
         if (vaultPrefixes.size > 0) {
           parser.setVaultPrefixes(vaultPrefixes);
         }

--- a/packages/cli/src/utils/QueryPrefixInjector.ts
+++ b/packages/cli/src/utils/QueryPrefixInjector.ts
@@ -1,0 +1,101 @@
+import { SPARQL_PREFIXES } from "exocortex";
+
+/**
+ * Well-known Exocortex ontology prefixes that should NOT be treated as vault
+ * directory namespaces. These map to ontology IRIs, not vault file paths.
+ */
+const ONTOLOGY_PREFIXES = new Set([
+  "exo", "ems", "ims", "gtd", "period", "lit", "inbox",
+  "rdf", "rdfs", "owl", "xsd",
+]);
+
+/**
+ * Regex to match shorthand notation in angle brackets: <namespace__property>
+ * Captures: namespace (letters), property name (letters, digits, underscores)
+ */
+const SHORTHAND_PATTERN = /(<)([a-zA-Z][a-zA-Z0-9]*)__([a-zA-Z][a-zA-Z0-9_]*)(>)/g;
+
+/**
+ * Inject missing Exocortex PREFIX declarations into a SPARQL query.
+ *
+ * Parses the query for existing PREFIX declarations and adds any missing
+ * well-known prefixes (exo, ems, ims, etc.) from SPARQL_PREFIXES.
+ *
+ * @param query - The SPARQL query string
+ * @returns The query with missing PREFIX declarations prepended
+ */
+export function injectExocortexPrefixes(query: string): string {
+  // Find all already-declared prefixes
+  const declaredPrefixes = new Set<string>();
+  const prefixPattern = /PREFIX\s+(\w+)\s*:/gi;
+  let match: RegExpExecArray | null;
+  while ((match = prefixPattern.exec(query)) !== null) {
+    declaredPrefixes.add(match[1].toLowerCase());
+  }
+
+  // Parse SPARQL_PREFIXES into individual lines
+  const prefixLines = SPARQL_PREFIXES.split("\n").filter(line => line.trim().length > 0);
+
+  // Collect missing prefix declarations
+  const missingPrefixes: string[] = [];
+  for (const line of prefixLines) {
+    const lineMatch = /PREFIX\s+(\w+)\s*:/i.exec(line);
+    if (lineMatch && !declaredPrefixes.has(lineMatch[1].toLowerCase())) {
+      missingPrefixes.push(line);
+    }
+  }
+
+  if (missingPrefixes.length === 0) {
+    return query;
+  }
+
+  return missingPrefixes.join("\n") + "\n" + query;
+}
+
+/**
+ * Transform Exocortex shorthand notation to prefixed names.
+ *
+ * Converts `<namespace__property>` to `namespace:property` for known
+ * Exocortex ontology namespaces.
+ *
+ * Examples:
+ *   <exo__Instance_class> → exo:Instance_class
+ *   <ems__Meeting>        → ems:Meeting
+ *   <ems__Effort_status>  → ems:Effort_status
+ *
+ * Only transforms names where the namespace part matches a known
+ * Exocortex ontology prefix.
+ *
+ * @param query - The SPARQL query string
+ * @returns The query with shorthand notation replaced
+ */
+export function transformShorthandNotation(query: string): string {
+  return query.replace(SHORTHAND_PATTERN, (_match, _open, namespace, property, _close) => {
+    if (ONTOLOGY_PREFIXES.has(namespace.toLowerCase())) {
+      return `${namespace}:${property}`;
+    }
+    // Not a known ontology prefix — leave as-is
+    return _match;
+  });
+}
+
+/**
+ * Filter out ontology namespace prefixes from vault-scanned prefixes.
+ *
+ * Vault namespace scanning discovers directories like `exo/`, `ems/`, `ims/`
+ * and registers them as SPARQL prefixes. However, these names collide with
+ * Exocortex ontology namespaces that map to different IRIs.
+ *
+ * This function removes ontology prefix names from the vault prefix map
+ * so that ontology PREFIX declarations take priority.
+ *
+ * @param vaultPrefixes - Map from vault namespace scanning
+ * @returns Filtered map without ontology namespace collisions
+ */
+export function filterOntologyPrefixes(vaultPrefixes: Map<string, string>): Map<string, string> {
+  const filtered = new Map(vaultPrefixes);
+  for (const prefix of ONTOLOGY_PREFIXES) {
+    filtered.delete(prefix);
+  }
+  return filtered;
+}

--- a/packages/cli/tests/unit/commands/sparql-query-debug.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-debug.test.ts
@@ -62,6 +62,14 @@ jest.unstable_mockModule("exocortex", () => ({
   Literal: jest.fn(),
   BlankNode: jest.fn(),
   Triple: jest.fn(),
+  SPARQL_PREFIXES: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+PREFIX ims: <https://exocortex.my/ontology/ims#>
+PREFIX gtd: <https://exocortex.my/ontology/gtd#>
+PREFIX period: <https://exocortex.my/ontology/period#>
+PREFIX lit: <https://exocortex.my/ontology/lit#>
+PREFIX inbox: <https://exocortex.my/ontology/inbox#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>`,
 }));
 
 jest.unstable_mockModule("../../../src/adapters/FileSystemVaultAdapter.js", () => ({

--- a/packages/cli/tests/unit/commands/sparql-query.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query.test.ts
@@ -59,6 +59,14 @@ jest.unstable_mockModule("exocortex", () => ({
   Literal: jest.fn(),
   BlankNode: jest.fn(),
   Triple: jest.fn(),
+  SPARQL_PREFIXES: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+PREFIX ims: <https://exocortex.my/ontology/ims#>
+PREFIX gtd: <https://exocortex.my/ontology/gtd#>
+PREFIX period: <https://exocortex.my/ontology/period#>
+PREFIX lit: <https://exocortex.my/ontology/lit#>
+PREFIX inbox: <https://exocortex.my/ontology/inbox#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>`,
 }));
 
 jest.unstable_mockModule("../../../src/adapters/FileSystemVaultAdapter.js", () => ({

--- a/packages/cli/tests/unit/utils/QueryPrefixInjector.test.ts
+++ b/packages/cli/tests/unit/utils/QueryPrefixInjector.test.ts
@@ -1,0 +1,133 @@
+import { injectExocortexPrefixes, transformShorthandNotation, filterOntologyPrefixes } from "../../../src/utils/QueryPrefixInjector";
+
+describe("QueryPrefixInjector", () => {
+  describe("injectExocortexPrefixes", () => {
+    it("should inject all prefixes when none are declared", () => {
+      const query = "SELECT ?s WHERE { ?s exo:Instance_class ems:Task }";
+      const result = injectExocortexPrefixes(query);
+
+      expect(result).toContain("PREFIX exo: <https://exocortex.my/ontology/exo#>");
+      expect(result).toContain("PREFIX ems: <https://exocortex.my/ontology/ems#>");
+      expect(result).toContain("PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>");
+      expect(result).toContain(query); // original query preserved at end
+    });
+
+    it("should not duplicate already-declared prefixes", () => {
+      const query = "PREFIX exo: <https://exocortex.my/ontology/exo#>\nSELECT ?s WHERE { ?s exo:Instance_class ?o }";
+      const result = injectExocortexPrefixes(query);
+
+      // exo: should NOT appear in injected section (already declared)
+      const exoCount = (result.match(/PREFIX exo:/gi) || []).length;
+      expect(exoCount).toBe(1);
+
+      // Other prefixes should be injected
+      expect(result).toContain("PREFIX ems:");
+    });
+
+    it("should handle case-insensitive PREFIX matching", () => {
+      const query = "prefix EXO: <https://exocortex.my/ontology/exo#>\nSELECT ?s WHERE { ?s EXO:Instance_class ?o }";
+      const result = injectExocortexPrefixes(query);
+
+      const exoCount = (result.match(/PREFIX exo:/gi) || []).length;
+      expect(exoCount).toBe(1);
+    });
+
+    it("should return query unchanged when all prefixes are declared", () => {
+      const query = `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+PREFIX ims: <https://exocortex.my/ontology/ims#>
+PREFIX gtd: <https://exocortex.my/ontology/gtd#>
+PREFIX period: <https://exocortex.my/ontology/period#>
+PREFIX lit: <https://exocortex.my/ontology/lit#>
+PREFIX inbox: <https://exocortex.my/ontology/inbox#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+SELECT ?s WHERE { ?s exo:Instance_class ems:Task }`;
+      const result = injectExocortexPrefixes(query);
+      expect(result).toBe(query);
+    });
+  });
+
+  describe("transformShorthandNotation", () => {
+    it("should transform <exo__Instance_class> to exo:Instance_class", () => {
+      const query = "SELECT ?s WHERE { ?s <exo__Instance_class> <ems__Meeting> }";
+      const result = transformShorthandNotation(query);
+      expect(result).toBe("SELECT ?s WHERE { ?s exo:Instance_class ems:Meeting }");
+    });
+
+    it("should transform <ems__Effort_status> correctly", () => {
+      const query = "SELECT ?s ?status WHERE { ?s <ems__Effort_status> ?status }";
+      const result = transformShorthandNotation(query);
+      expect(result).toBe("SELECT ?s ?status WHERE { ?s ems:Effort_status ?status }");
+    });
+
+    it("should not transform unknown namespace shorthands", () => {
+      const query = "SELECT ?s WHERE { ?s <custom__property> ?o }";
+      const result = transformShorthandNotation(query);
+      expect(result).toBe("SELECT ?s WHERE { ?s <custom__property> ?o }");
+    });
+
+    it("should not transform full IRIs in angle brackets", () => {
+      const query = "SELECT ?s WHERE { ?s <https://example.org/property> ?o }";
+      const result = transformShorthandNotation(query);
+      expect(result).toBe(query);
+    });
+
+    it("should handle multiple shorthands in one query", () => {
+      const query = "SELECT ?s WHERE { ?s <exo__Instance_class> <ems__Task> . ?s <exo__Asset_label> ?l }";
+      const result = transformShorthandNotation(query);
+      expect(result).toBe("SELECT ?s WHERE { ?s exo:Instance_class ems:Task . ?s exo:Asset_label ?l }");
+    });
+
+    it("should not transform bare names without angle brackets", () => {
+      const query = "SELECT ?s WHERE { ?s exo__Instance_class ?o }";
+      const result = transformShorthandNotation(query);
+      // No angle brackets — no transformation
+      expect(result).toBe(query);
+    });
+  });
+
+  describe("filterOntologyPrefixes", () => {
+    it("should remove ontology prefixes from vault prefix map", () => {
+      const vaultPrefixes = new Map([
+        ["exo", "obsidian://vault/03%20Knowledge/exo/"],
+        ["ems", "obsidian://vault/03%20Knowledge/ems/"],
+        ["kitelev", "obsidian://vault/03%20Knowledge/kitelev/"],
+        ["concepts", "obsidian://vault/03%20Knowledge/concepts/"],
+      ]);
+
+      const filtered = filterOntologyPrefixes(vaultPrefixes);
+
+      expect(filtered.has("exo")).toBe(false);
+      expect(filtered.has("ems")).toBe(false);
+      expect(filtered.has("kitelev")).toBe(true);
+      expect(filtered.has("concepts")).toBe(true);
+      expect(filtered.size).toBe(2);
+    });
+
+    it("should not modify the original map", () => {
+      const vaultPrefixes = new Map([
+        ["exo", "obsidian://vault/03%20Knowledge/exo/"],
+      ]);
+
+      filterOntologyPrefixes(vaultPrefixes);
+      expect(vaultPrefixes.has("exo")).toBe(true);
+    });
+
+    it("should handle empty map", () => {
+      const filtered = filterOntologyPrefixes(new Map());
+      expect(filtered.size).toBe(0);
+    });
+
+    it("should filter all standard ontology prefixes", () => {
+      const allOntology = new Map([
+        ["exo", "a"], ["ems", "b"], ["ims", "c"],
+        ["gtd", "d"], ["period", "e"], ["lit", "f"],
+        ["inbox", "g"], ["rdf", "h"], ["rdfs", "i"],
+        ["owl", "j"], ["xsd", "k"],
+      ]);
+
+      const filtered = filterOntologyPrefixes(allOntology);
+      expect(filtered.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix CLI SPARQL queries that failed with "Cannot resolve relative IRI" when using Exocortex shorthand notation (`<exo__Instance_class>`) or prefixed names without explicit PREFIX declarations (`exo:Instance_class`)
- Root cause: vault namespace scanner registered directory-based prefixes (`exo/` → `obsidian://vault/...`) that **collided** with ontology namespaces (`exo:` → `https://exocortex.my/ontology/exo#`)
- Add `QueryPrefixInjector` utility with three transformations applied before query parsing

## Changes

### New: `QueryPrefixInjector.ts`
- `transformShorthandNotation()`: `<exo__Property>` → `exo:Property`
- `injectExocortexPrefixes()`: auto-inject missing well-known PREFIX declarations (exo, ems, ims, gtd, period, lit, inbox, xsd)
- `filterOntologyPrefixes()`: remove ontology namespace names from vault-scanned prefix map to prevent collision

### Modified: `sparql-query.ts`
- Import `SPARQL_PREFIXES` from `exocortex` and new utility functions
- Apply three-step query pre-processing before parser invocation

### Tests: 14 new unit tests
- `QueryPrefixInjector.test.ts`: covers all three functions with edge cases
- Updated exocortex module mocks in existing SPARQL query tests

## Test plan

- [x] 14 unit tests pass (QueryPrefixInjector)
- [x] 900 CLI unit tests pass (50 suites, 0 failures)
- [x] E2E: shorthand `<exo__Instance_class>` query returns results
- [x] E2E: prefixed `exo:Instance_class` query without PREFIX returns results
- [x] E2E: explicit PREFIX declarations still work correctly
- [x] Bundle verification: all symbols present in production build

Closes #2284