### PR TITLE
fix(cli): resolve class by label and parse body newlines (#2290)

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -191,8 +191,11 @@ export function createCommand(): Command {
         // Parse properties from --property flags
         const properties = parseProperties(options.property);
 
-        // Resolve body content
-        const body = await resolveBody(options);
+        // Resolve body content and parse escape sequences
+        let body = await resolveBody(options);
+        if (body) {
+          body = body.replace(/\\n/g, "\n");
+        }
 
         // Create services
         const fsAdapter = new NodeFsAdapter(vaultPath);

--- a/packages/cli/src/services/AssetCreationService.ts
+++ b/packages/cli/src/services/AssetCreationService.ts
@@ -160,7 +160,7 @@ export class AssetCreationService {
     fm["exo__Asset_label"] = params.label;
     fm["exo__Asset_createdAt"] = params.timestamp;
     fm["exo__Asset_createdBy"] = `"[[${params.createdBy}]]"`;
-    fm["exo__Instance_class"] = [`"[[${params.classShortName}]]"`];
+    fm["exo__Instance_class"] = [`"[[${params.classUuid}|${params.classShortName}]]"`];
 
     // Aliases
     const allAliases = [params.label];

--- a/packages/cli/src/services/ClassResolverService.ts
+++ b/packages/cli/src/services/ClassResolverService.ts
@@ -2,10 +2,15 @@ import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 
 /**
  * Error thrown when a class short name cannot be resolved in the vault.
+ * Includes available class names as suggestions when available.
  */
 export class ClassNotFoundError extends Error {
-  constructor(className: string) {
-    super(`Class '${className}' not found in vault`);
+  constructor(className: string, availableClasses?: string[]) {
+    let message = `Class '${className}' not found in vault`;
+    if (availableClasses && availableClasses.length > 0) {
+      message += `\nAvailable classes: ${availableClasses.join(", ")}`;
+    }
+    super(message);
     this.name = "ClassNotFoundError";
   }
 }
@@ -53,7 +58,10 @@ export class ClassResolverService {
     const uuid = index.get(classShortName);
 
     if (!uuid) {
-      throw new ClassNotFoundError(classShortName);
+      const availableClasses = Array.from(index.keys()).filter(
+        (name) => !this.isUUID(name),
+      );
+      throw new ClassNotFoundError(classShortName, availableClasses);
     }
 
     return uuid;
@@ -84,8 +92,10 @@ export class ClassResolverService {
    * Build the class name -> UUID index by scanning vault files.
    *
    * Scans all markdown files and looks for files where exo__Instance_class
-   * contains "ims__Class". For those files, the basename (without .md) is
-   * used as the short name and exo__Asset_uid as the UUID.
+   * contains "ims__Class" or "exo__Class". For those files:
+   * - exo__Asset_uid is used as the UUID (preferred)
+   * - If exo__Asset_uid is missing, the file basename is used if it is a valid UUID
+   * - The file basename and exo__Asset_label are used as lookup keys
    */
   private async buildIndex(vaultPath: string): Promise<Map<string, string>> {
     const index = new Map<string, string>();
@@ -100,23 +110,27 @@ export class ClassResolverService {
           continue;
         }
 
-        const uid = metadata.exo__Asset_uid;
+        // Determine UUID: prefer exo__Asset_uid, fallback to filename if it's a UUID
+        const basename = this.getBasename(file);
+        let uid = metadata.exo__Asset_uid;
+        if (!uid && this.isUUID(basename)) {
+          uid = basename;
+        }
         if (!uid) {
           continue;
         }
 
-        // Use the file basename (without .md) as the short name
-        const basename = this.getBasename(file);
+        const uidStr = String(uid);
 
-        // Also index by exo__Asset_label if available
-        const label = metadata.exo__Asset_label;
-
+        // Index by basename (for human-named files like ztlk__PermanentNote.md)
         if (basename) {
-          index.set(basename, String(uid));
+          index.set(basename, uidStr);
         }
 
+        // Index by exo__Asset_label (primary lookup key for UUID-named files)
+        const label = metadata.exo__Asset_label;
         if (label && typeof label === "string" && label !== basename) {
-          index.set(label, String(uid));
+          index.set(label, uidStr);
         }
       } catch {
         // Skip files that can't be read
@@ -129,6 +143,7 @@ export class ClassResolverService {
 
   /**
    * Check if a file's metadata indicates it is a class definition.
+   * Recognizes both `ims__Class` (legacy) and `exo__Class` (current) markers.
    */
   private isClassDefinition(metadata: Record<string, unknown>): boolean {
     const instanceClass = metadata.exo__Instance_class;
@@ -141,7 +156,7 @@ export class ClassResolverService {
 
     return classValues.some((value) => {
       const str = String(value);
-      return str.includes("ims__Class");
+      return str.includes("ims__Class") || str.includes("exo__Class");
     });
   }
 

--- a/packages/cli/tests/unit/services/AssetCreationService.test.ts
+++ b/packages/cli/tests/unit/services/AssetCreationService.test.ts
@@ -113,7 +113,7 @@ describe("AssetCreationService", () => {
       );
     });
 
-    it("should set correct frontmatter fields", async () => {
+    it("should set correct frontmatter fields with wikilink [[uuid|className]]", async () => {
       const result = await service.create({
         classShortName: "ztlk__PermanentNote",
         label: "Test Note",
@@ -123,7 +123,7 @@ describe("AssetCreationService", () => {
       expect(result.frontmatter).toMatchObject({
         exo__Asset_uid: "generated-uuid-1234-5678-9012-abcdef123456",
         exo__Asset_label: "Test Note",
-        exo__Instance_class: ['"[[ztlk__PermanentNote]]"'],
+        exo__Instance_class: ['"[[resolved-class-uuid|ztlk__PermanentNote]]"'],
       });
     });
 
@@ -307,6 +307,20 @@ describe("AssetCreationService", () => {
         expect.any(Object),
         "# Body content\n\nSome text here.",
       );
+    });
+
+    it("should use wikilink with UUID and label for exo__Instance_class", async () => {
+      mockClassResolver.resolve.mockResolvedValue("38b234f7-949a-4da0-bab0-c4ca559808d1");
+
+      const result = await service.create({
+        classShortName: "ztlk__PermanentNote",
+        label: "Test Note",
+        vault: "/vault",
+      });
+
+      expect(result.frontmatter.exo__Instance_class).toEqual([
+        '"[[38b234f7-949a-4da0-bab0-c4ca559808d1|ztlk__PermanentNote]]"',
+      ]);
     });
 
     it("should throw error for empty label", async () => {

--- a/packages/cli/tests/unit/services/ClassResolverService.test.ts
+++ b/packages/cli/tests/unit/services/ClassResolverService.test.ts
@@ -49,6 +49,22 @@ describe("ClassResolverService", () => {
       expect(uuid).toBe("abc-123-def-456");
     });
 
+    it("should resolve class by exo__Asset_label when file is named by UUID", async () => {
+      // Real-world scenario: class file named by UUID, label holds the class name
+      mockFsAdapter.getMarkdownFiles.mockResolvedValue([
+        "03 Knowledge/ztlk/38b234f7-949a-4da0-bab0-c4ca559808d1.md",
+      ]);
+      mockFsAdapter.getFileMetadata.mockResolvedValue({
+        exo__Instance_class: ['"[[exo__Class]]"'],
+        exo__Asset_uid: "38b234f7-949a-4da0-bab0-c4ca559808d1",
+        exo__Asset_label: "ztlk__PermanentNote",
+      });
+
+      const uuid = await resolver.resolve("/vault", "ztlk__PermanentNote");
+
+      expect(uuid).toBe("38b234f7-949a-4da0-bab0-c4ca559808d1");
+    });
+
     it("should resolve class by label", async () => {
       mockFsAdapter.getMarkdownFiles.mockResolvedValue([
         "03 Knowledge/classes/some-file.md",
@@ -64,7 +80,49 @@ describe("ClassResolverService", () => {
       expect(uuid).toBe("uuid-from-label");
     });
 
-    it("should throw ClassNotFoundError for unknown class", async () => {
+    it("should recognize exo__Class in exo__Instance_class (not just ims__Class)", async () => {
+      mockFsAdapter.getMarkdownFiles.mockResolvedValue([
+        "03 Knowledge/ztlk/some-uuid.md",
+      ]);
+      mockFsAdapter.getFileMetadata.mockResolvedValue({
+        exo__Instance_class: ['"[[exo__Class]]"'],
+        exo__Asset_uid: "exo-class-uuid",
+        exo__Asset_label: "ztlk__PermanentNote",
+      });
+
+      const uuid = await resolver.resolve("/vault", "ztlk__PermanentNote");
+
+      expect(uuid).toBe("exo-class-uuid");
+    });
+
+    it("should throw ClassNotFoundError with available class suggestions", async () => {
+      mockFsAdapter.getMarkdownFiles.mockResolvedValue([
+        "class1.md",
+        "class2.md",
+      ]);
+      mockFsAdapter.getFileMetadata
+        .mockResolvedValueOnce({
+          exo__Instance_class: ['"[[exo__Class]]"'],
+          exo__Asset_uid: "uuid-1",
+          exo__Asset_label: "ztlk__PermanentNote",
+        })
+        .mockResolvedValueOnce({
+          exo__Instance_class: ['"[[exo__Class]]"'],
+          exo__Asset_uid: "uuid-2",
+          exo__Asset_label: "ems__Task",
+        });
+
+      await expect(
+        resolver.resolve("/vault", "xyz__Unknown"),
+      ).rejects.toThrow(/xyz__Unknown/);
+
+      // Should include available class names as suggestions
+      await expect(
+        resolver.resolve("/vault", "xyz__Unknown"),
+      ).rejects.toThrow(/Available classes:/);
+    });
+
+    it("should throw ClassNotFoundError for unknown class with no available classes", async () => {
       mockFsAdapter.getMarkdownFiles.mockResolvedValue([]);
 
       await expect(
@@ -106,7 +164,7 @@ describe("ClassResolverService", () => {
       expect(mockFsAdapter.getMarkdownFiles).toHaveBeenCalledTimes(1);
     });
 
-    it("should skip files without exo__Instance_class containing ims__Class", async () => {
+    it("should skip files without exo__Instance_class containing class marker", async () => {
       mockFsAdapter.getMarkdownFiles.mockResolvedValue([
         "task.md",
         "class.md",
@@ -166,6 +224,21 @@ describe("ClassResolverService", () => {
 
       expect(uuid).toBe("string-class-uuid");
     });
+
+    it("should use UUID from filename when exo__Asset_uid is missing but filename is UUID", async () => {
+      mockFsAdapter.getMarkdownFiles.mockResolvedValue([
+        "03 Knowledge/ztlk/38b234f7-949a-4da0-bab0-c4ca559808d1.md",
+      ]);
+      mockFsAdapter.getFileMetadata.mockResolvedValue({
+        exo__Instance_class: ['"[[exo__Class]]"'],
+        // No exo__Asset_uid — but filename IS a UUID
+        exo__Asset_label: "ztlk__PermanentNote",
+      });
+
+      const uuid = await resolver.resolve("/vault", "ztlk__PermanentNote");
+
+      expect(uuid).toBe("38b234f7-949a-4da0-bab0-c4ca559808d1");
+    });
   });
 
   describe("listClasses()", () => {
@@ -187,6 +260,21 @@ describe("ClassResolverService", () => {
       const classes = await resolver.listClasses("/vault");
 
       expect(classes).toContain("ems__Task");
+      expect(classes).toContain("ztlk__PermanentNote");
+    });
+
+    it("should return classes with exo__Class instance type", async () => {
+      mockFsAdapter.getMarkdownFiles.mockResolvedValue([
+        "38b234f7-949a-4da0-bab0-c4ca559808d1.md",
+      ]);
+      mockFsAdapter.getFileMetadata.mockResolvedValue({
+        exo__Instance_class: ['"[[exo__Class]]"'],
+        exo__Asset_uid: "38b234f7-949a-4da0-bab0-c4ca559808d1",
+        exo__Asset_label: "ztlk__PermanentNote",
+      });
+
+      const classes = await resolver.listClasses("/vault");
+
       expect(classes).toContain("ztlk__PermanentNote");
     });
   });


### PR DESCRIPTION
## Summary
- Fix ClassResolverService to find class files named by UUID (e.g. `38b234f7-...md`) via `exo__Asset_label` scan
- Fix wikilink format in frontmatter to use `[[uuid|className]]` instead of `[[className]]`
- Parse `\n` escape sequences in `--body` argument as real newlines

## Changes
- **ClassResolverService**: Recognize `exo__Class` in `exo__Instance_class` (not just `ims__Class`)
- **ClassResolverService**: Use UUID from filename when `exo__Asset_uid` is missing but filename is a valid UUID
- **ClassNotFoundError**: Include available class names as suggestions in error message
- **AssetCreationService**: Format `exo__Instance_class` wikilink as `[[uuid|className]]`
- **create command**: Replace literal `\n` with actual newlines in `--body` text

## Testing
- [x] Added 4 new regression tests for ClassResolverService (exo__Class recognition, UUID-from-filename, label-based resolution, error suggestions)
- [x] Added 1 new test for AssetCreationService wikilink format
- [x] Updated existing test for frontmatter format
- [x] All 53 service tests pass
- [x] All 975 CLI unit tests pass

## Acceptance Criteria
- [x] `--class ztlk__PermanentNote` resolves to UUID `38b234f7-...` via `exo__Asset_label`
- [x] Wikilink in frontmatter: `[[38b234f7-...|ztlk__PermanentNote]]`
- [x] `--class 38b234f7-...` (UUID) works as before (pass-through)
- [x] `--class nonExistentClass` shows error with available class suggestions
- [x] `--body "Line1\n\nLine2"` produces real newlines in file

Fixes #2290, fixes #2288