### PR TITLE
fix(cli): quote wikilinks and use array format in --property (#2293)

### DIFF
--- a/packages/cli/src/services/AssetCreationService.ts
+++ b/packages/cli/src/services/AssetCreationService.ts
@@ -187,11 +187,33 @@ export class AssetCreationService {
         ) {
           continue;
         }
-        fm[key] = value;
+        fm[key] = this.formatPropertyValue(value);
       }
     }
 
     return fm;
+  }
+
+  /**
+   * Format a property value for frontmatter.
+   *
+   * Wikilink values (containing `[[`) are quoted and wrapped in a YAML array
+   * so Obsidian can parse them correctly. Plain values are left as scalars.
+   *
+   * @param value - The raw property value string
+   * @returns Formatted value: `string` for plain values, `string[]` for wikilinks
+   */
+  private formatPropertyValue(value: string): string | string[] {
+    if (!value.includes("[[")) {
+      return value;
+    }
+
+    // Quote the wikilink if not already quoted
+    const quoted =
+      value.startsWith('"') && value.endsWith('"') ? value : `"${value}"`;
+
+    // Wrap in array for YAML list format
+    return [quoted];
   }
 
   /**

--- a/packages/cli/tests/unit/services/AssetCreationService.test.ts
+++ b/packages/cli/tests/unit/services/AssetCreationService.test.ts
@@ -202,10 +202,72 @@ describe("AssetCreationService", () => {
         },
       });
 
-      expect(result.frontmatter["ztlk__Note_developedFrom"]).toBe(
-        "[[some-uuid|Label]]",
+      // Wikilink values should be quoted and wrapped in array
+      expect(result.frontmatter["ztlk__Note_developedFrom"]).toEqual(
+        ['"[[some-uuid|Label]]"'],
       );
+      // Plain values remain as scalar
       expect(result.frontmatter["custom_prop"]).toBe("custom_value");
+    });
+
+    describe("Issue #2293: wikilink property quoting", () => {
+      it("should quote wikilink values and wrap in array", async () => {
+        const result = await service.create({
+          classShortName: "ztlk__PermanentNote",
+          label: "Test Note",
+          vault: "/vault",
+          properties: {
+            "exo__Asset_relates": "[[some-uuid|My Asset]]",
+          },
+        });
+
+        expect(result.frontmatter["exo__Asset_relates"]).toEqual(
+          ['"[[some-uuid|My Asset]]"'],
+        );
+      });
+
+      it("should not quote plain text values", async () => {
+        const result = await service.create({
+          classShortName: "ztlk__PermanentNote",
+          label: "Test Note",
+          vault: "/vault",
+          properties: {
+            "custom_prop": "plain text value",
+          },
+        });
+
+        expect(result.frontmatter["custom_prop"]).toBe("plain text value");
+      });
+
+      it("should handle wikilink without label", async () => {
+        const result = await service.create({
+          classShortName: "ztlk__PermanentNote",
+          label: "Test Note",
+          vault: "/vault",
+          properties: {
+            "exo__Asset_relates": "[[some-uuid]]",
+          },
+        });
+
+        expect(result.frontmatter["exo__Asset_relates"]).toEqual(
+          ['"[[some-uuid]]"'],
+        );
+      });
+
+      it("should not double-quote already quoted wikilinks", async () => {
+        const result = await service.create({
+          classShortName: "ztlk__PermanentNote",
+          label: "Test Note",
+          vault: "/vault",
+          properties: {
+            "exo__Asset_relates": '"[[some-uuid|Label]]"',
+          },
+        });
+
+        expect(result.frontmatter["exo__Asset_relates"]).toEqual(
+          ['"[[some-uuid|Label]]"'],
+        );
+      });
     });
 
     it("should not override system properties via --property", async () => {


### PR DESCRIPTION
## Summary
- Wikilink property values (`[[uuid|Label]]`) are now quoted and wrapped in YAML array format
- Plain text property values remain as unquoted scalars
- Prevents YAML parse errors from unquoted `|` characters in wikilinks

## Changes
- `AssetCreationService.ts`: Added `formatPropertyValue()` method that detects wikilinks, quotes them, and wraps in array
- `AssetCreationService.test.ts`: Added 4 regression tests for Issue #2293 (wikilink quoting, plain text, no-label wikilinks, already-quoted wikilinks)

## Before/After
```yaml
# Before (broken)
exo__Asset_relates: [[uuid|Label]]

# After (correct)
exo__Asset_relates:
  - "[[uuid|Label]]"
```

## Testing
- [x] Added 4 regression tests for Issue #2293
- [x] All 28 AssetCreationService tests pass
- [x] All 957 CLI unit tests pass (53 suites)
- [x] Zero regressions

## Acceptance Criteria
- [x] `--property "key=[[uuid|Label]]"` writes quoted value `"[[uuid|Label]]"`
- [x] Wikilink properties use array format (`- "[[...]]"`)
- [x] `--property "key=plain text"` keeps scalar format without quotes
- [x] Already-quoted wikilinks are not double-quoted

Fixes #2293