### PR TITLE
fix(cli): add auto-prefix injection to ask command (#2299)

### DIFF
--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -11,6 +11,8 @@ import {
   QueryExecutor,
 } from "exocortex";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
+import { injectExocortexPrefixes, transformShorthandNotation, filterOntologyPrefixes } from "../utils/QueryPrefixInjector.js";
+import { scanVaultNamespaces } from "../utils/VaultNamespaceScanner.js";
 import { TableFormatter } from "../formatters/TableFormatter.js";
 import { JsonFormatter } from "../formatters/JsonFormatter.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
@@ -133,8 +135,16 @@ export function askCommand(): Command {
         }
 
         // Parse and execute SPARQL
+        let sparqlQuery = conversionResult.query;
+        sparqlQuery = transformShorthandNotation(sparqlQuery);
+        sparqlQuery = injectExocortexPrefixes(sparqlQuery);
+
         const parser = new SPARQLParser();
-        const ast = parser.parse(conversionResult.query);
+        const vaultPrefixes = filterOntologyPrefixes(scanVaultNamespaces(vaultPath));
+        if (vaultPrefixes.size > 0) {
+          parser.setVaultPrefixes(vaultPrefixes);
+        }
+        const ast = parser.parse(sparqlQuery);
 
         const translator = new AlgebraTranslator();
         let algebra = translator.translate(ast);

--- a/packages/cli/tests/unit/commands/ask.test.ts
+++ b/packages/cli/tests/unit/commands/ask.test.ts
@@ -54,6 +54,9 @@ jest.unstable_mockModule("exocortex", () => ({
       { getVariables: () => ["s"], toJSON: () => ({ s: "http://example.org/test" }) },
     ]),
   })),
+  SPARQL_PREFIXES: `PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>`,
 }));
 
 jest.unstable_mockModule("../../../src/adapters/FileSystemVaultAdapter.js", () => ({


### PR DESCRIPTION
## Summary

- Apply same auto-prefix injection to `ask` command as `sparql query` (#2285)
- Prevents "Cannot resolve relative IRI" when NLToSPARQLService generates queries with bare namespace names
- 2 files changed, 14 insertions

## Test plan

- [x] 53/53 CLI unit test suites pass
- [x] E2E: `ask` command works with auto-injected prefixes
- [x] Build succeeds

Closes #2299