### PR TITLE
fix: text-based fallback for UID copy button in Properties block

### DIFF
--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesUidCopyPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesUidCopyPatch.ts
@@ -85,13 +85,48 @@ export class PropertiesUidCopyPatch {
     const metadataContainer = container.querySelector<HTMLElement>(".metadata-container");
     if (!metadataContainer) return;
 
-    const uidProperties = metadataContainer.querySelectorAll<HTMLElement>(
-      `.metadata-property[data-property-key="${PROPERTY_KEY}"]`
-    );
-
-    for (const propertyEl of Array.from(uidProperties)) {
+    const uidProperties = this.findUidProperties(metadataContainer);
+    for (const propertyEl of uidProperties) {
       this.addCopyButton(propertyEl);
     }
+  }
+
+  private findUidProperties(metadataContainer: HTMLElement): HTMLElement[] {
+    const results: HTMLElement[] = [];
+
+    const byDataAttr = metadataContainer.querySelectorAll<HTMLElement>(
+      `.metadata-property[data-property-key="${PROPERTY_KEY}"]`
+    );
+    if (byDataAttr.length > 0) {
+      return Array.from(byDataAttr);
+    }
+
+    const allProperties = metadataContainer.querySelectorAll<HTMLElement>(".metadata-property");
+    for (const prop of Array.from(allProperties)) {
+      const keyEl = prop.querySelector<HTMLElement>(".metadata-property-key");
+      if (!keyEl) continue;
+      const keyText = this.extractKeyText(keyEl);
+      if (keyText === PROPERTY_KEY) {
+        results.push(prop);
+      }
+    }
+
+    return results;
+  }
+
+  private isUidProperty(el: HTMLElement): boolean {
+    if (el.getAttribute("data-property-key") === PROPERTY_KEY) return true;
+    const keyEl = el.querySelector<HTMLElement>(".metadata-property-key");
+    if (!keyEl) return false;
+    return this.extractKeyText(keyEl) === PROPERTY_KEY;
+  }
+
+  private extractKeyText(keyEl: HTMLElement): string {
+    const input = keyEl.querySelector<HTMLInputElement>("input");
+    if (input?.value?.trim()) {
+      return input.value.trim();
+    }
+    return (keyEl.textContent || "").trim().replace(/\u200B/g, "");
   }
 
   private addCopyButton(propertyEl: HTMLElement): void {
@@ -167,17 +202,15 @@ export class PropertiesUidCopyPatch {
             this.patchPropertiesBlock(node.parentElement || node);
           } else if (node.querySelector?.(".metadata-container")) {
             this.patchPropertiesBlock(node);
-          } else if (
-            node.classList?.contains("metadata-property") &&
-            node.getAttribute("data-property-key") === PROPERTY_KEY
-          ) {
-            this.addCopyButton(node);
+          } else if (node.classList?.contains("metadata-property")) {
+            if (this.isUidProperty(node)) {
+              this.addCopyButton(node);
+            }
           } else {
-            const uidProps = node.querySelectorAll?.<HTMLElement>(
-              `.metadata-property[data-property-key="${PROPERTY_KEY}"]`
-            );
-            if (uidProps?.length) {
-              for (const prop of Array.from(uidProps)) {
+            const mc = node.querySelector?.(".metadata-container") as HTMLElement | null;
+            if (mc) {
+              const uidProps = this.findUidProperties(mc);
+              for (const prop of uidProps) {
                 this.addCopyButton(prop);
               }
             }

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesUidCopyPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesUidCopyPatch.test.ts
@@ -187,6 +187,55 @@ describe("PropertiesUidCopyPatch", () => {
       expect(buttons.length).toBe(1);
     });
 
+    it("should find uid property by key text when data-property-key is absent", () => {
+      const property = document.createElement("div");
+      property.className = "metadata-property";
+
+      const keyEl = document.createElement("div");
+      keyEl.className = "metadata-property-key";
+      const keyInput = document.createElement("input");
+      keyInput.value = "exo__Asset_uid";
+      keyEl.appendChild(keyInput);
+      property.appendChild(keyEl);
+
+      const valueEl = document.createElement("div");
+      valueEl.className = "metadata-property-value";
+      const valInput = document.createElement("input");
+      valInput.type = "text";
+      valInput.value = "fallback-uid-123";
+      valueEl.appendChild(valInput);
+      property.appendChild(valueEl);
+
+      mockMetadataContainer.appendChild(property);
+
+      patch.enable();
+
+      const button = property.querySelector(".exo-uid-copy-btn");
+      expect(button).toBeTruthy();
+    });
+
+    it("should find uid property by key text content (no input)", () => {
+      const property = document.createElement("div");
+      property.className = "metadata-property";
+
+      const keyEl = document.createElement("div");
+      keyEl.className = "metadata-property-key";
+      keyEl.textContent = "exo__Asset_uid";
+      property.appendChild(keyEl);
+
+      const valueEl = document.createElement("div");
+      valueEl.className = "metadata-property-value";
+      valueEl.textContent = "text-uid-456";
+      property.appendChild(valueEl);
+
+      mockMetadataContainer.appendChild(property);
+
+      patch.enable();
+
+      const button = property.querySelector(".exo-uid-copy-btn");
+      expect(button).toBeTruthy();
+    });
+
     it("should not add button when value is empty", () => {
       const uidProp = createUidProperty("");
       mockMetadataContainer.appendChild(uidProp);


### PR DESCRIPTION
## Summary

Fixes UID copy button not appearing on mobile Obsidian (and potentially other platforms) where `data-property-key` attribute is absent from `.metadata-property` DOM elements.

**Root cause**: Original implementation relied solely on `data-property-key="exo__Asset_uid"` CSS selector. Mobile Obsidian does not set this attribute.

**Fix**: Added text-based fallback that:
1. First tries `data-property-key` selector (fast path, desktop)
2. Falls back to iterating `.metadata-property` elements and matching key text content (input value or textContent)
3. Strips zero-width spaces from text comparison

### Files Changed
- `PropertiesUidCopyPatch.ts` — added `findUidProperties()`, `isUidProperty()`, `extractKeyText()` fallback methods
- `PropertiesUidCopyPatch.test.ts` — 2 new tests for text-based fallback (19 total)

## Related Issues
- Follow-up fix for #2320 / PR #2323

## Test plan
- [x] 19 unit tests passing
- [x] TypeScript clean
- [x] BDD coverage 100%