### PR TITLE
feat(cli): archive --verify integrity check (#2311)

### DIFF
--- a/packages/cli/src/commands/archive.ts
+++ b/packages/cli/src/commands/archive.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { ClassResolverService } from "../services/ClassResolverService.js";
 import { ArchiveService } from "../services/ArchiveService.js";
+import { ArchiveVerifyService } from "../services/ArchiveVerifyService.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 
@@ -13,11 +14,12 @@ import { VaultNotFoundError } from "../utils/errors/index.js";
 interface ArchiveCommandOptions {
   vault: string;
   archiveVault: string;
-  class: string;
-  year: string;
+  class?: string;
+  year?: string;
   dryRun?: boolean;
   noReferenced?: boolean;
   json?: boolean;
+  verify?: boolean;
 }
 
 /**
@@ -25,6 +27,9 @@ interface ArchiveCommandOptions {
  *
  * Transfers archived assets from the active vault to a separate archive vault,
  * ensuring zero broken links by checking references before moving.
+ *
+ * When `--verify` is passed, runs integrity verification instead of archival:
+ * checks for broken cross-vault links, missing ontologies, and vault statistics.
  *
  * @returns Commander Command instance configured for asset archival
  *
@@ -42,6 +47,11 @@ interface ArchiveCommandOptions {
  *   --vault /path/to/active-vault \
  *   --archive-vault /path/to/archive-vault \
  *   --class ems__Task --year 2025
+ *
+ * # Verify archive integrity
+ * exocortex archive --verify \
+ *   --vault /path/to/active-vault \
+ *   --archive-vault /path/to/archive-vault
  * ```
  */
 export function archiveCommand(): Command {
@@ -51,11 +61,11 @@ export function archiveCommand(): Command {
     )
     .requiredOption("--vault <path>", "Path to the active vault")
     .requiredOption("--archive-vault <path>", "Path to the archive vault")
-    .requiredOption(
+    .option(
       "--class <names>",
       "Comma-separated class short names or UUIDs (e.g. ems__Task,ems__Meeting)",
     )
-    .requiredOption(
+    .option(
       "--year <year>",
       "Filter by resolution/end timestamp year (e.g. 2025)",
     )
@@ -65,6 +75,11 @@ export function archiveCommand(): Command {
       "Skip assets referenced by non-archived (default: true)",
     )
     .option("--json", "Output in JSON format (default: true)", true)
+    .option(
+      "--verify",
+      "Verify archive integrity instead of archiving (read-only)",
+      false,
+    )
     .action(async (options: ArchiveCommandOptions) => {
       try {
         // Validate vault paths
@@ -76,6 +91,30 @@ export function archiveCommand(): Command {
         const archiveVaultPath = resolve(options.archiveVault);
         if (!existsSync(archiveVaultPath)) {
           throw new VaultNotFoundError(archiveVaultPath);
+        }
+
+        // Branch: verify mode
+        if (options.verify) {
+          const activeFs = new NodeFsAdapter(vaultPath);
+          const archiveFs = new NodeFsAdapter(archiveVaultPath);
+          const verifyService = new ArchiveVerifyService(activeFs, archiveFs);
+
+          const result = await verifyService.verify();
+
+          process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+          process.exit(result.ok ? 0 : 1);
+        }
+
+        // Archive mode: validate required options
+        if (!options.class) {
+          throw new Error(
+            "--class is required for archive operation. Use --verify for integrity check.",
+          );
+        }
+        if (!options.year) {
+          throw new Error(
+            "--year is required for archive operation. Use --verify for integrity check.",
+          );
         }
 
         // Parse year

--- a/packages/cli/src/services/ArchiveVerifyService.ts
+++ b/packages/cli/src/services/ArchiveVerifyService.ts
@@ -1,0 +1,223 @@
+import path from "path";
+import yaml from "js-yaml";
+import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+
+/**
+ * Result of the archive verification operation.
+ *
+ * JSON-serializable output for CI integration.
+ * Exit code 0 when `ok === true`, exit code 1 otherwise.
+ */
+export interface ArchiveVerifyResult {
+  /** Number of broken cross-vault links detected */
+  broken_links: number;
+  /** Details of each broken link */
+  broken_link_details: BrokenLinkDetail[];
+  /** Archive ontologies expected but missing */
+  missing_ontologies: string[];
+  /** Vault statistics */
+  stats: VaultStats;
+  /** Overall health: true when broken_links === 0 && missing_ontologies.length === 0 */
+  ok: boolean;
+}
+
+/**
+ * Detail of a single broken cross-vault link.
+ */
+export interface BrokenLinkDetail {
+  /** UUID of the archived asset being referenced */
+  uuid: string;
+  /** Relative path in the active vault that references the archived UUID */
+  referenced_from: string;
+}
+
+/**
+ * Vault statistics.
+ */
+export interface VaultStats {
+  /** Number of markdown files in the active vault */
+  active_files: number;
+  /** Number of markdown files in the archive vault */
+  archive_files: number;
+}
+
+/**
+ * Service that verifies archive integrity after archival.
+ *
+ * Checks:
+ * 1. No broken links from active (non-archived) assets to archive UUIDs
+ * 2. All archive ontologies (`!<name>_archive.md`) exist in archive vault
+ * 3. File count statistics for both vaults
+ *
+ * Algorithm:
+ * 1. Collect all UUID filenames from archive vault → archiveUUIDs set
+ * 2. Scan active vault: for each non-archived file, extract all UUID references
+ * 3. For each reference that matches an archive UUID → broken link
+ * 4. Collect unique `exo__Asset_isDefinedBy` from archive files → expected ontologies
+ * 5. Check existence of each `!<name>_archive.md` in archive vault
+ * 6. Count files in both vaults
+ */
+export class ArchiveVerifyService {
+  constructor(
+    private readonly activeFs: NodeFsAdapter,
+    private readonly archiveFs: NodeFsAdapter,
+  ) {}
+
+  /**
+   * Execute the archive verification.
+   */
+  async verify(): Promise<ArchiveVerifyResult> {
+    // Step 1: Get all markdown files in both vaults
+    const activeFiles = await this.activeFs.getMarkdownFiles();
+    const archiveFiles = await this.archiveFs.getMarkdownFiles();
+
+    // Step 2: Build archive UUID set from archive vault filenames
+    const archiveUUIDs = new Set<string>();
+    for (const file of archiveFiles) {
+      const basename = path.basename(file, ".md");
+      if (this.isUUID(basename)) {
+        archiveUUIDs.add(basename.toLowerCase());
+      }
+    }
+
+    // Step 3: Scan active vault for broken links
+    const brokenLinkDetails: BrokenLinkDetail[] = [];
+    const uuidPattern =
+      /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+    for (const file of activeFiles) {
+      try {
+        const content = await this.activeFs.readFile(file);
+        const metadata = this.extractFrontmatter(content);
+
+        // Skip archived files in active vault (they are pending move)
+        if (metadata.archived === true) {
+          continue;
+        }
+
+        // Extract all UUID references from the entire file content
+        const matches = content.match(uuidPattern);
+        if (matches) {
+          const seenInFile = new Set<string>();
+          for (const match of matches) {
+            const lower = match.toLowerCase();
+            if (archiveUUIDs.has(lower) && !seenInFile.has(lower)) {
+              seenInFile.add(lower);
+              brokenLinkDetails.push({
+                uuid: lower,
+                referenced_from: file,
+              });
+            }
+          }
+        }
+      } catch {
+        // Skip unreadable files
+        continue;
+      }
+    }
+
+    // Step 4: Check archive ontologies
+    const missingOntologies = await this.checkArchiveOntologies(archiveFiles);
+
+    // Step 5: Build result
+    const ok =
+      brokenLinkDetails.length === 0 && missingOntologies.length === 0;
+
+    return {
+      broken_links: brokenLinkDetails.length,
+      broken_link_details: brokenLinkDetails,
+      missing_ontologies: missingOntologies,
+      stats: {
+        active_files: activeFiles.length,
+        archive_files: archiveFiles.length,
+      },
+      ok,
+    };
+  }
+
+  /**
+   * Check that for each unique isDefinedBy in archive vault,
+   * the corresponding archive ontology file exists.
+   *
+   * For example, if archive files reference `[[!ems|EMS Ontology]]`,
+   * then `!ems_archive.md` must exist in the archive vault.
+   */
+  private async checkArchiveOntologies(
+    archiveFiles: string[],
+  ): Promise<string[]> {
+    const ontologyTargets = new Set<string>();
+
+    for (const file of archiveFiles) {
+      // Skip ontology files themselves
+      const basename = path.basename(file, ".md");
+      if (basename.startsWith("!")) {
+        continue;
+      }
+
+      try {
+        const content = await this.archiveFs.readFile(file);
+        const metadata = this.extractFrontmatter(content);
+        const isDefinedBy = metadata.exo__Asset_isDefinedBy;
+        if (isDefinedBy) {
+          const target = this.extractWikilinkTarget(String(isDefinedBy));
+          if (target && target.startsWith("!")) {
+            // If it already ends with _archive, extract the base name
+            const baseName = target.endsWith("_archive")
+              ? target
+              : target + "_archive";
+            ontologyTargets.add(baseName);
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    const missing: string[] = [];
+    for (const ontologyName of ontologyTargets) {
+      const ontologyPath = ontologyName + ".md";
+      const exists = await this.archiveFs.fileExists(ontologyPath);
+      if (!exists) {
+        missing.push(ontologyName);
+      }
+    }
+
+    return missing.sort();
+  }
+
+  /**
+   * Extract wikilink target from a wikilink string.
+   * "[[!ems_archive|EMS Ontology (Archive)]]" -> "!ems_archive"
+   * "[[!ems|EMS Ontology]]" -> "!ems"
+   */
+  private extractWikilinkTarget(wikilink: string): string | null {
+    const match = wikilink.match(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/);
+    return match ? match[1] : null;
+  }
+
+  /**
+   * Extract frontmatter from markdown content.
+   */
+  private extractFrontmatter(content: string): Record<string, unknown> {
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) return {};
+
+    try {
+      const parsed = yaml.load(match[1]);
+      return typeof parsed === "object" && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Check if a string is a UUID v4.
+   */
+  private isUUID(value: string): boolean {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      value,
+    );
+  }
+}

--- a/packages/cli/tests/unit/commands/archive.test.ts
+++ b/packages/cli/tests/unit/commands/archive.test.ts
@@ -2,12 +2,13 @@ import { jest } from "@jest/globals";
 import { Command } from "commander";
 
 /**
- * Issue #2306: Tests for archive CLI command registration
+ * Issue #2306 + #2311: Tests for archive CLI command registration
  *
  * Acceptance criteria:
  * - Command is registered with correct name and description
- * - Required options: --vault, --archive-vault, --class, --year
- * - Optional options: --dry-run, --no-referenced, --json
+ * - Required options: --vault, --archive-vault
+ * - Optional options: --class, --year, --dry-run, --no-referenced, --json, --verify
+ * - --class and --year are validated at runtime (required for archive, not for verify)
  */
 describe("Issue #2306: archive command", () => {
   let archiveCommandFn: () => Command;
@@ -46,22 +47,20 @@ describe("Issue #2306: archive command", () => {
     expect(option!.mandatory).toBe(true);
   });
 
-  it("should have required option --class", () => {
+  it("should have option --class (validated at runtime)", () => {
     const cmd = archiveCommandFn();
     const option = cmd.options.find(
       (opt) => opt.long === "--class",
     );
     expect(option).toBeDefined();
-    expect(option!.mandatory).toBe(true);
   });
 
-  it("should have required option --year", () => {
+  it("should have option --year (validated at runtime)", () => {
     const cmd = archiveCommandFn();
     const option = cmd.options.find(
       (opt) => opt.long === "--year",
     );
     expect(option).toBeDefined();
-    expect(option!.mandatory).toBe(true);
   });
 
   it("should have optional --dry-run flag", () => {
@@ -79,5 +78,14 @@ describe("Issue #2306: archive command", () => {
       (opt) => opt.long === "--json",
     );
     expect(option).toBeDefined();
+  });
+
+  it("should have optional --verify flag", () => {
+    const cmd = archiveCommandFn();
+    const option = cmd.options.find(
+      (opt) => opt.long === "--verify",
+    );
+    expect(option).toBeDefined();
+    expect(option!.mandatory).toBeFalsy();
   });
 });

--- a/packages/cli/tests/unit/services/ArchiveVerifyService.test.ts
+++ b/packages/cli/tests/unit/services/ArchiveVerifyService.test.ts
@@ -1,0 +1,593 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+/**
+ * Issue #2311: Tests for ArchiveVerifyService
+ *
+ * Acceptance criteria:
+ * - `archive --verify` when broken links exist -> report with UUID and referencing files
+ * - `archive --verify` when all clean -> {broken_links: 0} and exit code 0
+ * - Missing archive ontology -> missing_ontologies contains its name
+ * - Read-only operation (no writes to either vault)
+ * - Correct file count statistics
+ */
+
+// Quotes string values that contain special YAML characters
+function yamlQuote(val) {
+  const s = String(val);
+  if (/[\[\]{|}:#>,]/.test(s) || s !== s.trim()) {
+    return `"${s.replace(/"/g, '\\"')}"`;
+  }
+  return s;
+}
+
+// Helper to build markdown file with frontmatter (no TS annotations for jest compatibility)
+function buildMd(frontmatter, body) {
+  if (body === undefined) body = "";
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      for (const item of value) {
+        lines.push(`  - ${yamlQuote(item)}`);
+      }
+    } else if (typeof value === "boolean") {
+      lines.push(`${key}: ${value}`);
+    } else {
+      lines.push(`${key}: ${yamlQuote(value)}`);
+    }
+  }
+  lines.push("---");
+  if (body) {
+    lines.push("");
+    lines.push(body);
+  }
+  return lines.join("\n");
+}
+
+// UUID constants
+const ARCHIVE_UUID_1 = "aa000001-1111-2222-3333-444455556666";
+const ARCHIVE_UUID_2 = "aa000002-1111-2222-3333-444455556666";
+const ACTIVE_UUID_1 = "bb000001-1111-2222-3333-444455556666";
+const ACTIVE_UUID_2 = "bb000002-1111-2222-3333-444455556666";
+
+// Mock adapters
+const mockActiveFs = {
+  getMarkdownFiles: jest.fn(),
+  readFile: jest.fn(),
+  getFileMetadata: jest.fn(),
+  fileExists: jest.fn(),
+  writeFile: jest.fn(),
+  deleteFile: jest.fn(),
+  createFile: jest.fn(),
+  updateFile: jest.fn(),
+  renameFile: jest.fn(),
+  createDirectory: jest.fn(),
+  directoryExists: jest.fn(),
+  findFilesByMetadata: jest.fn(),
+  findFileByUID: jest.fn(),
+};
+
+const mockArchiveFs = {
+  getMarkdownFiles: jest.fn(),
+  readFile: jest.fn(),
+  getFileMetadata: jest.fn(),
+  fileExists: jest.fn(),
+  writeFile: jest.fn(),
+  deleteFile: jest.fn(),
+  createFile: jest.fn(),
+  updateFile: jest.fn(),
+  renameFile: jest.fn(),
+  createDirectory: jest.fn(),
+  directoryExists: jest.fn(),
+  findFilesByMetadata: jest.fn(),
+  findFileByUID: jest.fn(),
+};
+
+// Dynamic import for ESM compatibility
+const { ArchiveVerifyService } = await import(
+  "../../../src/services/ArchiveVerifyService.js"
+);
+
+describe("Issue #2311: ArchiveVerifyService", () => {
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ArchiveVerifyService(mockActiveFs, mockArchiveFs);
+  });
+
+  describe("clean archive — no broken links", () => {
+    it("should return ok: true and broken_links: 0 when no active file references archive UUIDs", async () => {
+      // Active vault: 2 files, no references to archive UUIDs
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ACTIVE_UUID_1}.md`,
+        `${ACTIVE_UUID_2}.md`,
+      ]);
+      mockActiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ACTIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Instance_class: "ems__Task",
+            exo__Asset_uid: ACTIVE_UUID_1,
+          });
+        }
+        if (p === `${ACTIVE_UUID_2}.md`) {
+          return buildMd(
+            {
+              exo__Instance_class: "ems__Task",
+              exo__Asset_uid: ACTIVE_UUID_2,
+            },
+            `References [[${ACTIVE_UUID_1}|Other active task]]`,
+          );
+        }
+        throw new Error("File not found");
+      });
+
+      // Archive vault: 2 files with ontology
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(true);
+      expect(result.broken_links).toBe(0);
+      expect(result.broken_link_details).toEqual([]);
+      expect(result.missing_ontologies).toEqual([]);
+    });
+
+    it("should return correct vault stats", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([
+        "file1.md",
+        "file2.md",
+        "file3.md",
+      ]);
+      mockActiveFs.readFile.mockResolvedValue(
+        buildMd({ exo__Instance_class: "ems__Task" }),
+      );
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        `${ARCHIVE_UUID_2}.md`,
+      ]);
+      mockArchiveFs.readFile.mockResolvedValue(
+        buildMd({ exo__Asset_isDefinedBy: "[[!ems_archive|EMS]]" }),
+      );
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      const result = await service.verify();
+
+      expect(result.stats.active_files).toBe(3);
+      expect(result.stats.archive_files).toBe(2);
+    });
+  });
+
+  describe("broken links detected", () => {
+    it("should detect broken link when active file references archive UUID", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ACTIVE_UUID_1}.md`,
+      ]);
+      mockActiveFs.readFile.mockResolvedValue(
+        buildMd(
+          {
+            exo__Instance_class: "ems__Task",
+            exo__Asset_uid: ACTIVE_UUID_1,
+          },
+          `Depends on [[${ARCHIVE_UUID_1}|Old archived task]]`,
+        ),
+      );
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(false);
+      expect(result.broken_links).toBe(1);
+      expect(result.broken_link_details).toEqual([
+        {
+          uuid: ARCHIVE_UUID_1,
+          referenced_from: `${ACTIVE_UUID_1}.md`,
+        },
+      ]);
+    });
+
+    it("should detect multiple broken links from different files", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ACTIVE_UUID_1}.md`,
+        `${ACTIVE_UUID_2}.md`,
+      ]);
+      mockActiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ACTIVE_UUID_1}.md`) {
+          return buildMd(
+            {
+              exo__Instance_class: "ems__Task",
+              exo__Asset_uid: ACTIVE_UUID_1,
+            },
+            `Links to [[${ARCHIVE_UUID_1}]]`,
+          );
+        }
+        if (p === `${ACTIVE_UUID_2}.md`) {
+          return buildMd(
+            {
+              exo__Instance_class: "ems__Task",
+              exo__Asset_uid: ACTIVE_UUID_2,
+            },
+            `Links to [[${ARCHIVE_UUID_2}]]`,
+          );
+        }
+        throw new Error("File not found");
+      });
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        `${ARCHIVE_UUID_2}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (
+          p === `${ARCHIVE_UUID_1}.md` ||
+          p === `${ARCHIVE_UUID_2}.md`
+        ) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(false);
+      expect(result.broken_links).toBe(2);
+      expect(result.broken_link_details).toHaveLength(2);
+    });
+
+    it("should not count the same UUID twice from the same file", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ACTIVE_UUID_1}.md`,
+      ]);
+      mockActiveFs.readFile.mockResolvedValue(
+        buildMd(
+          {
+            exo__Instance_class: "ems__Task",
+            exo__Asset_uid: ACTIVE_UUID_1,
+          },
+          `First ref [[${ARCHIVE_UUID_1}]] and second ref [[${ARCHIVE_UUID_1}|again]]`,
+        ),
+      );
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      const result = await service.verify();
+
+      expect(result.broken_links).toBe(1);
+    });
+
+    it("should skip archived files in active vault when checking for broken links", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ACTIVE_UUID_1}.md`,
+      ]);
+      mockActiveFs.readFile.mockResolvedValue(
+        buildMd(
+          {
+            exo__Instance_class: "ems__Task",
+            exo__Asset_uid: ACTIVE_UUID_1,
+            archived: true,
+          },
+          `Links to [[${ARCHIVE_UUID_1}]]`,
+        ),
+      );
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(true);
+      expect(result.broken_links).toBe(0);
+    });
+  });
+
+  describe("missing archive ontologies", () => {
+    it("should detect missing archive ontology", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([]);
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(false);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(false);
+      expect(result.missing_ontologies).toEqual(["!ems_archive"]);
+    });
+
+    it("should detect missing ontology when archive file references non-archive ontology name", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([]);
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems|EMS Ontology]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(false);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(false);
+      expect(result.missing_ontologies).toEqual(["!ems_archive"]);
+    });
+
+    it("should not report existing archive ontology as missing", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([]);
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      const result = await service.verify();
+
+      expect(result.missing_ontologies).toEqual([]);
+    });
+
+    it("should handle multiple ontologies, reporting only missing ones", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([]);
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        `${ARCHIVE_UUID_2}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        if (p === `${ARCHIVE_UUID_2}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ims|IMS Ontology]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockImplementation(async (p) => {
+        if (p === "!ems_archive.md") return true;
+        if (p === "!ims_archive.md") return false;
+        return false;
+      });
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(false);
+      expect(result.missing_ontologies).toEqual(["!ims_archive"]);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty vaults gracefully", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([]);
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([]);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(true);
+      expect(result.broken_links).toBe(0);
+      expect(result.broken_link_details).toEqual([]);
+      expect(result.missing_ontologies).toEqual([]);
+      expect(result.stats).toEqual({ active_files: 0, archive_files: 0 });
+    });
+
+    it("should handle unreadable files without crashing", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([
+        "unreadable.md",
+        `${ACTIVE_UUID_1}.md`,
+      ]);
+      mockActiveFs.readFile.mockImplementation(async (p) => {
+        if (p === "unreadable.md") throw new Error("EACCES");
+        if (p === `${ACTIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Instance_class: "ems__Task",
+            exo__Asset_uid: ACTIVE_UUID_1,
+          });
+        }
+        throw new Error("File not found");
+      });
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([]);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(true);
+      expect(result.stats.active_files).toBe(2);
+    });
+
+    it("should handle files without frontmatter", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue(["plain.md"]);
+      mockActiveFs.readFile.mockResolvedValue(
+        "# Just a plain markdown file\nNo frontmatter here.",
+      );
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("should not count non-UUID filenames in archive vault", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ACTIVE_UUID_1}.md`,
+      ]);
+      mockActiveFs.readFile.mockResolvedValue(
+        buildMd(
+          {
+            exo__Instance_class: "ems__Task",
+          },
+          "References [[some-note|My Note]]",
+        ),
+      );
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        "some-note.md",
+        `${ARCHIVE_UUID_1}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      const result = await service.verify();
+
+      expect(result.ok).toBe(true);
+      expect(result.broken_links).toBe(0);
+    });
+  });
+
+  describe("read-only guarantee", () => {
+    it("should never call writeFile or deleteFile on either vault", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ACTIVE_UUID_1}.md`,
+      ]);
+      mockActiveFs.readFile.mockResolvedValue(
+        buildMd(
+          {
+            exo__Instance_class: "ems__Task",
+          },
+          `Broken ref [[${ARCHIVE_UUID_1}]]`,
+        ),
+      );
+
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        `${ARCHIVE_UUID_1}.md`,
+        "!ems_archive.md",
+      ]);
+      mockArchiveFs.readFile.mockImplementation(async (p) => {
+        if (p === `${ARCHIVE_UUID_1}.md`) {
+          return buildMd({
+            exo__Asset_isDefinedBy: "[[!ems_archive|EMS (Archive)]]",
+          });
+        }
+        throw new Error("File not found");
+      });
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+
+      await service.verify();
+
+      expect(mockActiveFs.writeFile).not.toHaveBeenCalled();
+      expect(mockActiveFs.deleteFile).not.toHaveBeenCalled();
+      expect(mockArchiveFs.writeFile).not.toHaveBeenCalled();
+      expect(mockArchiveFs.deleteFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("JSON output structure", () => {
+    it("should return result with all required fields", async () => {
+      mockActiveFs.getMarkdownFiles.mockResolvedValue([]);
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([]);
+
+      const result = await service.verify();
+
+      expect(result).toHaveProperty("broken_links");
+      expect(result).toHaveProperty("broken_link_details");
+      expect(result).toHaveProperty("missing_ontologies");
+      expect(result).toHaveProperty("stats");
+      expect(result).toHaveProperty("ok");
+      expect(result.stats).toHaveProperty("active_files");
+      expect(result.stats).toHaveProperty("archive_files");
+
+      // Verify JSON serialization works
+      const json = JSON.stringify(result);
+      const parsed = JSON.parse(json);
+      expect(parsed).toEqual(result);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ArchiveVerifyService` for post-archival integrity verification
- Add `--verify` flag to the `archive` CLI command
- Check broken cross-vault links, missing ontologies, vault statistics

## Changes
- **New file**: `packages/cli/src/services/ArchiveVerifyService.ts` — service with `verify()` method that checks:
  1. Broken links: active (non-archived) assets referencing UUIDs in archive vault
  2. Missing ontologies: expected `!<name>_archive.md` files in archive vault
  3. Statistics: file counts for both vaults
- **Modified**: `packages/cli/src/commands/archive.ts` — added `--verify` flag; `--class` and `--year` changed from `requiredOption` to `option` (validated at runtime for archive mode, not needed for verify)
- **New test**: `packages/cli/tests/unit/services/ArchiveVerifyService.test.ts` — 16 unit tests
- **Updated test**: `packages/cli/tests/unit/commands/archive.test.ts` — 9 tests (updated for optional --class/--year, added --verify flag test)

## Usage
```bash
# Verify archive integrity (read-only)
npx @kitelev/exocortex-cli archive --verify \
  --vault /path/to/active \
  --archive-vault /path/to/archive

# Output (JSON):
# {"broken_links": 0, "broken_link_details": [], "missing_ontologies": [], "stats": {"active_files": 9159, "archive_files": 2735}, "ok": true}
# Exit code: 0 (clean) or 1 (issues found)
```

## Testing
- [x] 16 unit tests for ArchiveVerifyService (broken links, missing ontologies, edge cases, read-only guarantee, JSON structure)
- [x] 9 command registration tests (updated for --verify flag)
- [x] All existing 1039 CLI tests pass (only pre-existing sparql-exo003 integration failures)
- [x] All 4454 obsidian-plugin tests pass

## Acceptance Criteria
- [x] `archive --verify` when broken links exist -> report with UUID and referencing files
- [x] `archive --verify` when all clean -> `{broken_links: 0}` and exit code 0
- [x] Missing archive ontology -> `missing_ontologies` contains its name
- [x] `--dry-run` not applicable (verify is inherently read-only)
- [x] Read-only operation (no writes to either vault)
- [x] Machine-readable JSON output for CI integration

Closes #2311