### PR TITLE
feat: dynamic display name rules via exoob__PrintNameRule (#2326)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -34,6 +34,7 @@ import { PropertiesLinkPatch } from "./presentation/properties/PropertiesLinkPat
 import { PropertiesUidCopyPatch } from "./presentation/properties/PropertiesUidCopyPatch";
 import { BodyLinkPatch } from "./presentation/body/BodyLinkPatch";
 import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
+import { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService";
 
 /**
  * Exocortex Plugin - Automatic layout rendering
@@ -61,6 +62,7 @@ export default class ExocortexPlugin extends Plugin {
    */
   api!: ExocortexAPI;
   settings!: ExocortexSettings;
+  printNameRuleService!: PrintNameRuleService;
   private timerManager!: TimerManager;
   // MutationObserver to detect when layout is removed by Obsidian re-renders (e.g., when processing embeds)
   private layoutPersistenceObserver: MutationObserver | null = null;
@@ -82,6 +84,15 @@ export default class ExocortexPlugin extends Plugin {
       this.timerManager = new TimerManager();
 
       await this.loadSettings();
+
+      this.printNameRuleService = new PrintNameRuleService(this.app);
+      this.printNameRuleService.initialize();
+
+      this.registerEvent(
+        this.app.metadataCache.on("changed", () => {
+          this.printNameRuleService.refresh();
+        })
+      );
 
       this.vaultAdapter = new ObsidianVaultAdapter(
         this.app.vault,

--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
@@ -1,77 +1,51 @@
-/**
- * DisplayNameResolver - Resolves display names with per-class template support
- *
- * This service:
- * - Determines the appropriate template based on asset class
- * - Uses DisplayNameTemplateEngine for template rendering
- * - Falls back to default template if no class-specific template exists
- *
- * Resolution algorithm:
- * 1. Extract exo__Instance_class from metadata
- * 2. Look up class-specific template in classTemplates
- * 3. Fall back to defaultTemplate if not found
- * 4. Render template with metadata using DisplayNameTemplateEngine
- */
 import { DisplayNameTemplateEngine } from "./DisplayNameTemplateEngine";
+import type { MetadataResolver } from "./DisplayNameTemplateEngine";
+import type { PrintNameRuleService } from "./PrintNameRuleService";
 import type { DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
 
-/**
- * Context for display name resolution
- */
 export interface DisplayNameContext {
-  /** Frontmatter metadata */
   metadata: Record<string, unknown>;
-  /** Original filename without extension */
   basename: string;
-  /** File creation date (optional) */
   createdDate?: Date;
 }
 
 export class DisplayNameResolver {
-  constructor(private readonly settings: DisplayNameSettings) {}
+  constructor(
+    private readonly settings: DisplayNameSettings,
+    private readonly ruleService?: PrintNameRuleService | null,
+    private readonly metadataResolver?: MetadataResolver | null,
+  ) {}
 
-  /**
-   * Resolve display name for an asset
-   *
-   * @param context - Display name context containing metadata and file info
-   * @returns Resolved display name, or null if template produces empty result
-   */
   resolve(context: DisplayNameContext): string | null {
     const { metadata, basename, createdDate } = context;
 
-    // Extract asset class
     const assetClass = this.extractAssetClass(metadata);
-
-    // Get appropriate template for this class
     const template = this.getTemplateForClass(assetClass);
-
-    // Render using template engine
     const engine = new DisplayNameTemplateEngine(template);
 
-    return engine.render(metadata, basename, createdDate);
+    return engine.render(
+      metadata,
+      basename,
+      createdDate,
+      this.metadataResolver ?? undefined,
+    );
   }
 
-  /**
-   * Get the template for a specific asset class
-   *
-   * @param assetClass - The asset class (e.g., "ems__Task")
-   * @returns The template string to use
-   */
   getTemplateForClass(assetClass: string | null): string {
+    if (assetClass && this.ruleService) {
+      const dynamicRule = this.ruleService.getTemplateForClass(assetClass);
+      if (dynamicRule) {
+        return dynamicRule.template;
+      }
+    }
+
     if (assetClass && this.settings.classTemplates[assetClass]) {
       return this.settings.classTemplates[assetClass];
     }
+
     return this.settings.defaultTemplate;
   }
 
-  /**
-   * Extract asset class from metadata
-   *
-   * Handles various formats:
-   * - String: "ems__Task"
-   * - Wikilink: "[[ems__Task]]"
-   * - Array: ["ems__Task"]
-   */
   private extractAssetClass(metadata: Record<string, unknown>): string | null {
     const instanceClass = metadata.exo__Instance_class;
 
@@ -79,13 +53,11 @@ export class DisplayNameResolver {
       return null;
     }
 
-    // Handle array - take first element
     if (Array.isArray(instanceClass)) {
       if (instanceClass.length === 0) return null;
       return this.cleanClassValue(instanceClass[0]);
     }
 
-    // Handle string
     if (typeof instanceClass === "string") {
       return this.cleanClassValue(instanceClass);
     }
@@ -93,39 +65,26 @@ export class DisplayNameResolver {
     return null;
   }
 
-  /**
-   * Clean class value by removing wikilink syntax and trimming
-   */
   private cleanClassValue(value: unknown): string | null {
     if (typeof value !== "string") return null;
 
     const cleaned = value
-      .replace(/^\[\[|\]\]$/g, "") // Remove wikilink brackets
-      .replace(/^"|"$/g, "") // Remove quotes
+      .replace(/^\[\[|\]\]$/g, "")
+      .replace(/^"|"$/g, "")
       .trim();
 
     return cleaned || null;
   }
 
-  /**
-   * Get list of all configured class templates
-   */
   getConfiguredClasses(): string[] {
     return Object.keys(this.settings.classTemplates);
   }
 
-  /**
-   * Check if per-class templates are enabled
-   * (i.e., if there are any class-specific templates configured)
-   */
   hasClassTemplates(): boolean {
     return Object.keys(this.settings.classTemplates).length > 0;
   }
 }
 
-/**
- * Create a DisplayNameResolver with default settings
- */
 export async function createDefaultResolver(): Promise<DisplayNameResolver> {
   const { DEFAULT_DISPLAY_NAME_SETTINGS } = await import("@plugin/domain/settings/ExocortexSettings");
   return new DisplayNameResolver(DEFAULT_DISPLAY_NAME_SETTINGS);

--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
@@ -17,6 +17,8 @@
  * - "[{{exo__Instance_class}}] {{exo__Asset_label}}" - Class prefix
  * - "{{_basename}} - {{exo__Asset_label}}" - Filename with label
  */
+export type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
+
 export class DisplayNameTemplateEngine {
   private static readonly PLACEHOLDER_PATTERN = /\{\{([^}]+)\}\}/g;
   private static readonly WIKILINK_PATTERN = /^\[\[|\]\]$/g;
@@ -34,7 +36,8 @@ export class DisplayNameTemplateEngine {
   render(
     metadata: Record<string, unknown>,
     basename: string,
-    createdDate?: Date
+    createdDate?: Date,
+    metadataResolver?: MetadataResolver
   ): string | null {
     if (!this.template || this.template.trim() === "") {
       return null;
@@ -44,7 +47,7 @@ export class DisplayNameTemplateEngine {
       DisplayNameTemplateEngine.PLACEHOLDER_PATTERN,
       (_, key: string) => {
         const trimmedKey = key.trim();
-        return this.resolveValue(trimmedKey, metadata, basename, createdDate);
+        return this.resolveValue(trimmedKey, metadata, basename, createdDate, metadataResolver);
       }
     );
 
@@ -111,7 +114,8 @@ export class DisplayNameTemplateEngine {
     key: string,
     metadata: Record<string, unknown>,
     basename: string,
-    createdDate?: Date
+    createdDate?: Date,
+    metadataResolver?: MetadataResolver
   ): string {
     // Handle special variables
     if (key === "_basename") {
@@ -125,15 +129,19 @@ export class DisplayNameTemplateEngine {
       return "";
     }
 
-    // Handle dot notation for nested fields
-    const value = this.getNestedValue(metadata, key);
+    // Handle dot notation for nested fields (with cross-asset resolution)
+    const value = this.getNestedValue(metadata, key, metadataResolver);
     return this.formatValue(value);
   }
 
   /**
    * Get nested value from object using dot notation
    */
-  private getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  private getNestedValue(
+    obj: Record<string, unknown>,
+    path: string,
+    metadataResolver?: MetadataResolver
+  ): unknown {
     const parts = path.split(".");
     let current: unknown = obj;
 
@@ -143,6 +151,13 @@ export class DisplayNameTemplateEngine {
       }
 
       if (typeof current !== "object") {
+        if (typeof current === "string" && metadataResolver && this.isWikilink(current)) {
+          const resolved = metadataResolver(current);
+          if (resolved) {
+            current = (resolved as Record<string, unknown>)[part];
+            continue;
+          }
+        }
         return undefined;
       }
 
@@ -150,6 +165,10 @@ export class DisplayNameTemplateEngine {
     }
 
     return current;
+  }
+
+  private isWikilink(value: string): boolean {
+    return value.startsWith("[[") && value.endsWith("]]");
   }
 
   /**

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -1,0 +1,174 @@
+import { TFile } from "obsidian";
+import type { App } from "obsidian";
+
+export interface PrintNameRule {
+  className: string;
+  template: string;
+  priority: number;
+  sourceFile: string;
+}
+
+type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
+
+export class PrintNameRuleService {
+  private rules: Map<string, PrintNameRule[]> = new Map();
+  private classHierarchy: Map<string, string[]> = new Map();
+  private initialized = false;
+
+  constructor(private readonly app: App) {}
+
+  initialize(): void {
+    this.scanVault();
+    this.initialized = true;
+  }
+
+  getTemplateForClass(className: string): { template: string; priority: number } | null {
+    if (!this.initialized) return null;
+
+    const directRules = this.rules.get(className);
+    if (directRules && directRules.length > 0) {
+      return { template: directRules[0].template, priority: directRules[0].priority };
+    }
+
+    const ancestors = this.getAncestorClasses(className);
+    for (const ancestor of ancestors) {
+      const ancestorRules = this.rules.get(ancestor);
+      if (ancestorRules && ancestorRules.length > 0) {
+        return { template: ancestorRules[0].template, priority: ancestorRules[0].priority };
+      }
+    }
+
+    return null;
+  }
+
+  createMetadataResolver(): MetadataResolver {
+    return (wikilinkTarget: string): Record<string, unknown> | null => {
+      const cleaned = wikilinkTarget
+        .replace(/^\[\[|\]\]$/g, "")
+        .replace(/^"|"$/g, "")
+        .trim();
+
+      if (!cleaned) return null;
+
+      let file = this.app.metadataCache.getFirstLinkpathDest(cleaned, "");
+      if (!file && !cleaned.endsWith(".md")) {
+        file = this.app.metadataCache.getFirstLinkpathDest(cleaned + ".md", "");
+      }
+
+      if (!(file instanceof TFile)) {
+        return null;
+      }
+
+      const cache = this.app.metadataCache.getFileCache(file);
+      return cache?.frontmatter ? { ...cache.frontmatter } : null;
+    };
+  }
+
+  refresh(): void {
+    this.scanVault();
+  }
+
+  private scanVault(): void {
+    this.rules.clear();
+    this.classHierarchy.clear();
+
+    const files = this.app.vault.getMarkdownFiles();
+
+    for (const file of files) {
+      const cache = this.app.metadataCache.getFileCache(file);
+      const fm = cache?.frontmatter;
+      if (!fm) continue;
+
+      const instanceClass = this.cleanClassValue(fm.exo__Instance_class);
+
+      if (instanceClass === "exoob__PrintNameRule") {
+        this.processRuleAsset(fm, file.path);
+      }
+
+      const superClass = this.cleanClassValue(fm.exo__Class_superClass);
+      if (superClass && instanceClass) {
+        const cleanedChild = this.cleanClassValue(fm.exo__Asset_label) || instanceClass;
+
+        const existing = this.classHierarchy.get(cleanedChild);
+        if (existing) {
+          existing.push(superClass);
+        } else {
+          this.classHierarchy.set(cleanedChild, [superClass]);
+        }
+      }
+    }
+  }
+
+  private processRuleAsset(fm: Record<string, unknown>, path: string): void {
+    const ruleClass = this.cleanClassValue(fm.exoob__PrintNameRule_class);
+    const template = fm.exoob__PrintNameRule_template;
+    const priority = fm.exoob__Rule_priority;
+
+    if (!ruleClass || typeof template !== "string" || !template.trim()) {
+      return;
+    }
+
+    const rule: PrintNameRule = {
+      className: ruleClass,
+      template: template.trim(),
+      priority: typeof priority === "number" ? priority : 0,
+      sourceFile: path,
+    };
+
+    const existing = this.rules.get(ruleClass);
+    if (existing) {
+      existing.push(rule);
+      existing.sort((a, b) => b.priority - a.priority);
+    } else {
+      this.rules.set(ruleClass, [rule]);
+    }
+  }
+
+  private getAncestorClasses(className: string): string[] {
+    const ancestors: string[] = [];
+    const visited = new Set<string>();
+    const queue = [className];
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current || visited.has(current)) continue;
+      visited.add(current);
+
+      const parents = this.classHierarchy.get(current);
+      if (parents) {
+        for (const parent of parents) {
+          if (!visited.has(parent)) {
+            ancestors.push(parent);
+            queue.push(parent);
+          }
+        }
+      }
+    }
+
+    return ancestors;
+  }
+
+  private cleanClassValue(value: unknown): string | null {
+    if (!value) return null;
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) return null;
+      return this.cleanClassValue(value[0]);
+    }
+
+    if (typeof value !== "string") return null;
+
+    return value
+      .replace(/^\[\[|\]\]$/g, "")
+      .replace(/^"|"$/g, "")
+      .trim() || null;
+  }
+
+  getRulesCount(): number {
+    let count = 0;
+    for (const rules of this.rules.values()) {
+      count += rules.length;
+    }
+    return count;
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/body/BodyLinkPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/body/BodyLinkPatch.ts
@@ -1,6 +1,7 @@
 import { TFile, Plugin, CachedMetadata } from "obsidian";
 import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
 import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+import type { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
 import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
 
 /**
@@ -22,6 +23,7 @@ import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/sett
 
 interface PluginWithSettings extends Plugin {
   settings: ExocortexSettings;
+  printNameRuleService?: PrintNameRuleService;
 }
 
 export class BodyLinkPatch {
@@ -58,7 +60,9 @@ export class BodyLinkPatch {
    * Create a DisplayNameResolver with current settings
    */
   private createResolver(): DisplayNameResolver {
-    return new DisplayNameResolver(this.getDisplayNameSettings());
+    const ruleService = this.plugin.printNameRuleService ?? null;
+    const metadataResolver = ruleService?.createMetadataResolver() ?? null;
+    return new DisplayNameResolver(this.getDisplayNameSettings(), ruleService, metadataResolver);
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/graph-view/GraphViewPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/graph-view/GraphViewPatch.ts
@@ -1,6 +1,7 @@
 import { TFile, WorkspaceLeaf, Plugin, CachedMetadata } from "obsidian";
 import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
 import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+import type { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
 import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
 import { FunctionReplacer } from "@plugin/infrastructure/utils/FunctionReplacer";
 
@@ -31,6 +32,7 @@ import { FunctionReplacer } from "@plugin/infrastructure/utils/FunctionReplacer"
 // Plugin interface to access settings
 interface PluginWithSettings extends Plugin {
   settings: ExocortexSettings;
+  printNameRuleService?: PrintNameRuleService;
 }
 
 // Obsidian internal types for graph nodes (not exposed in public API)
@@ -100,7 +102,9 @@ export class GraphViewPatch {
    * Create a DisplayNameResolver with current settings
    */
   private createResolver(): DisplayNameResolver {
-    return new DisplayNameResolver(this.getDisplayNameSettings());
+    const ruleService = this.plugin.printNameRuleService ?? null;
+    const metadataResolver = ruleService?.createMetadataResolver() ?? null;
+    return new DisplayNameResolver(this.getDisplayNameSettings(), ruleService, metadataResolver);
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
@@ -1,6 +1,7 @@
 import { TFile, Plugin, CachedMetadata } from "obsidian";
 import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
 import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+import type { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
 import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
 
 /**
@@ -20,6 +21,7 @@ import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/sett
 
 interface PluginWithSettings extends Plugin {
   settings: ExocortexSettings;
+  printNameRuleService?: PrintNameRuleService;
 }
 
 export class PropertiesLinkPatch {
@@ -56,7 +58,9 @@ export class PropertiesLinkPatch {
    * Create a DisplayNameResolver with current settings
    */
   private createResolver(): DisplayNameResolver {
-    return new DisplayNameResolver(this.getDisplayNameSettings());
+    const ruleService = this.plugin.printNameRuleService ?? null;
+    const metadataResolver = ruleService?.createMetadataResolver() ?? null;
+    return new DisplayNameResolver(this.getDisplayNameSettings(), ruleService, metadataResolver);
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/tab-titles/TabTitlePatch.ts
+++ b/packages/obsidian-plugin/src/presentation/tab-titles/TabTitlePatch.ts
@@ -1,6 +1,7 @@
 import { TFile, WorkspaceLeaf, Plugin, CachedMetadata, MarkdownView } from "obsidian";
 import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
 import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+import type { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
 import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
 
 /**
@@ -19,6 +20,7 @@ import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/sett
 // Plugin interface to access settings
 interface PluginWithSettings extends Plugin {
   settings: ExocortexSettings;
+  printNameRuleService?: PrintNameRuleService;
 }
 
 export class TabTitlePatch {
@@ -56,7 +58,9 @@ export class TabTitlePatch {
    * Create a DisplayNameResolver with current settings
    */
   private createResolver(): DisplayNameResolver {
-    return new DisplayNameResolver(this.getDisplayNameSettings());
+    const ruleService = this.plugin.printNameRuleService ?? null;
+    const metadataResolver = ruleService?.createMetadataResolver() ?? null;
+    return new DisplayNameResolver(this.getDisplayNameSettings(), ruleService, metadataResolver);
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -108,6 +108,7 @@ describe("ExocortexPlugin", () => {
     mockVault = {
       on: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
       getName: jest.fn().mockReturnValue("Test Vault"),
+      getMarkdownFiles: jest.fn().mockReturnValue([]),
     };
 
     // Setup mock app
@@ -201,8 +202,8 @@ describe("ExocortexPlugin", () => {
         "sparql",
         expect.any(Function)
       );
-      // 10 - 4 semantic search file events (create, modify, delete, rename) = 6 (Issue #2318)
-      expect(plugin.registerEvent).toHaveBeenCalledTimes(6);
+      // 10 - 4 semantic search file events (create, modify, delete, rename) = 6 + 1 PrintNameRuleService refresh = 7
+      expect(plugin.registerEvent).toHaveBeenCalledTimes(7);
       expect(mockLogger.info).toHaveBeenCalledWith("Exocortex Plugin loaded successfully");
     });
 
@@ -1126,13 +1127,10 @@ describe("ExocortexPlugin", () => {
       // Arrange
       const mockFile = { path: "test.md" } as TFile;
 
-      // Find all changed handlers - the plugin's handler is the one that triggers handleMetadataChange
-      // which in turn calls taskTrackingService.handleFileChange
       const changedCalls = mockMetadataCache.on.mock.calls.filter(
-        call => call[0] === "changed"
+        (call: unknown[]) => call[0] === "changed"
       );
-      // The plugin's changed handler is the second one (ExocortexAPI registers first)
-      const changedHandler = changedCalls.length > 1 ? changedCalls[1]?.[1] : changedCalls[0]?.[1];
+      const changedHandler = changedCalls[changedCalls.length - 1]?.[1];
 
       mockMetadataCache.getFileCache.mockReturnValue({
         frontmatter: { test: "data" },

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
@@ -182,6 +182,100 @@ describe("DisplayNameResolver", () => {
     });
   });
 
+  describe("with PrintNameRuleService", () => {
+    it("should use dynamic rule template over settings template", () => {
+      const mockRuleService = {
+        getTemplateForClass: jest.fn().mockReturnValue({
+          template: "{{exo__Asset_label}} (DynamicRule)",
+          priority: 100,
+        }),
+        createMetadataResolver: jest.fn().mockReturnValue(null),
+      };
+
+      const resolver = new DisplayNameResolver(
+        defaultSettings,
+        mockRuleService as any,
+      );
+
+      const result = resolver.resolve({
+        metadata: {
+          exo__Asset_label: "My Task",
+          exo__Instance_class: "ems__Task",
+        },
+        basename: "my-task",
+      });
+
+      expect(result).toBe("My Task (DynamicRule)");
+      expect(mockRuleService.getTemplateForClass).toHaveBeenCalledWith("ems__Task");
+    });
+
+    it("should fall back to settings when no dynamic rule exists", () => {
+      const mockRuleService = {
+        getTemplateForClass: jest.fn().mockReturnValue(null),
+        createMetadataResolver: jest.fn().mockReturnValue(null),
+      };
+
+      const resolver = new DisplayNameResolver(
+        defaultSettings,
+        mockRuleService as any,
+      );
+
+      const result = resolver.resolve({
+        metadata: {
+          exo__Asset_label: "Morning routine",
+          exo__Instance_class: "ems__TaskPrototype",
+        },
+        basename: "morning-routine",
+      });
+
+      expect(result).toBe("Morning routine (TaskPrototype)");
+    });
+
+    it("should work without rule service (backwards compatible)", () => {
+      const resolver = new DisplayNameResolver(defaultSettings);
+
+      const result = resolver.resolve({
+        metadata: {
+          exo__Asset_label: "Fix bug",
+          exo__Instance_class: "ems__Task",
+        },
+        basename: "fix-bug",
+      });
+
+      expect(result).toBe("Fix bug");
+    });
+
+    it("should pass metadata resolver to template engine for cross-asset resolution", () => {
+      const mockMetadataResolver = jest.fn().mockReturnValue({
+        exo__Asset_label: "Parent Project",
+      });
+      const mockRuleService = {
+        getTemplateForClass: jest.fn().mockReturnValue({
+          template: "{{exo__Asset_label}} / {{ems__Effort_project.exo__Asset_label}}",
+          priority: 50,
+        }),
+        createMetadataResolver: jest.fn().mockReturnValue(mockMetadataResolver),
+      };
+
+      const resolver = new DisplayNameResolver(
+        defaultSettings,
+        mockRuleService as any,
+        mockMetadataResolver,
+      );
+
+      const result = resolver.resolve({
+        metadata: {
+          exo__Asset_label: "Sub Task",
+          exo__Instance_class: "ems__Task",
+          ems__Effort_project: "[[project-uuid]]",
+        },
+        basename: "sub-task",
+      });
+
+      expect(result).toBe("Sub Task / Parent Project");
+    });
+  });
+
   describe("DEFAULT_DISPLAY_NAME_SETTINGS", () => {
     it("should have default template with class suffix for all asset types", () => {
       // Default template now includes class suffix for consistent display across all asset types

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameTemplateEngine.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameTemplateEngine.test.ts
@@ -482,4 +482,72 @@ describe("DisplayNameTemplateEngine", () => {
       expect(result).toBe("function() {}");
     });
   });
+
+  describe("cross-asset resolution via metadataResolver", () => {
+    it("should resolve wikilink property to related asset metadata", () => {
+      const resolver = jest.fn().mockReturnValue({
+        exo__Asset_label: "Parent Project",
+        exo__Instance_class: "ems__Project",
+      });
+
+      const engine = new DisplayNameTemplateEngine(
+        "{{exo__Asset_label}} / {{ems__Effort_project.exo__Asset_label}}"
+      );
+      const result = engine.render(
+        {
+          exo__Asset_label: "My Task",
+          ems__Effort_project: "[[project-uuid]]",
+        },
+        "my-task",
+        undefined,
+        resolver,
+      );
+
+      expect(result).toBe("My Task / Parent Project");
+      expect(resolver).toHaveBeenCalledWith("[[project-uuid]]");
+    });
+
+    it("should return empty string when wikilink target not found", () => {
+      const resolver = jest.fn().mockReturnValue(null);
+
+      const engine = new DisplayNameTemplateEngine(
+        "{{exo__Asset_label}} ({{ems__Effort_project.exo__Asset_label}})"
+      );
+      const result = engine.render(
+        {
+          exo__Asset_label: "My Task",
+          ems__Effort_project: "[[nonexistent]]",
+        },
+        "my-task",
+        undefined,
+        resolver,
+      );
+
+      expect(result).toBe("My Task");
+    });
+
+    it("should work without metadataResolver (backwards compatible)", () => {
+      const engine = new DisplayNameTemplateEngine(
+        "{{exo__Asset_label}} ({{ems__Effort_project.exo__Asset_label}})"
+      );
+      const result = engine.render(
+        {
+          exo__Asset_label: "My Task",
+          ems__Effort_project: "[[project-uuid]]",
+        },
+        "my-task",
+      );
+
+      expect(result).toBe("My Task");
+    });
+
+    it("should handle non-wikilink dot notation normally", () => {
+      const engine = new DisplayNameTemplateEngine("{{custom.priority}}");
+      const result = engine.render(
+        { custom: { priority: "high" } },
+        "my-file",
+      );
+      expect(result).toBe("high");
+    });
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -1,0 +1,333 @@
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+
+function createMockApp(files: Array<{ path: string; frontmatter: Record<string, unknown> }>): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    tfile.basename = f.path.replace(".md", "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+
+  return {
+    vault: {
+      getMarkdownFiles: jest.fn().mockReturnValue(mockFiles),
+    },
+    metadataCache: {
+      getFileCache: jest.fn().mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const cleanPath = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find(f => f.path === cleanPath) ?? null;
+      }),
+    },
+  } as unknown as App;
+}
+
+describe("PrintNameRuleService", () => {
+  describe("basic rule resolution", () => {
+    it("should find rule for exact class match", () => {
+      const app = createMockApp([
+        {
+          path: "rule1.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__TaskPrototype]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}} (TP)",
+            exoob__Rule_priority: 100,
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      const result = service.getTemplateForClass("ems__TaskPrototype");
+      expect(result).not.toBeNull();
+      expect(result!.template).toBe("{{exo__Asset_label}} (TP)");
+      expect(result!.priority).toBe(100);
+    });
+
+    it("should return null when no rule exists for class", () => {
+      const app = createMockApp([]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      expect(service.getTemplateForClass("ems__Task")).toBeNull();
+    });
+
+    it("should return null when not initialized", () => {
+      const app = createMockApp([]);
+      const service = new PrintNameRuleService(app);
+
+      expect(service.getTemplateForClass("ems__Task")).toBeNull();
+    });
+  });
+
+  describe("priority resolution", () => {
+    it("should use highest priority rule when multiple rules for same class", () => {
+      const app = createMockApp([
+        {
+          path: "rule1.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__Task]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}} (low)",
+            exoob__Rule_priority: 10,
+          },
+        },
+        {
+          path: "rule2.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__Task]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}} (high)",
+            exoob__Rule_priority: 100,
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      const result = service.getTemplateForClass("ems__Task");
+      expect(result!.template).toBe("{{exo__Asset_label}} (high)");
+      expect(result!.priority).toBe(100);
+    });
+
+    it("should default priority to 0 when not specified", () => {
+      const app = createMockApp([
+        {
+          path: "rule1.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__Task]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      const result = service.getTemplateForClass("ems__Task");
+      expect(result!.priority).toBe(0);
+    });
+  });
+
+  describe("class hierarchy inheritance", () => {
+    it("should inherit rule from parent class", () => {
+      const app = createMockApp([
+        {
+          path: "effort-class.md",
+          frontmatter: {
+            exo__Instance_class: "exo__Class",
+            exo__Asset_label: "ems__Task",
+            exo__Class_superClass: "[[ems__Effort]]",
+          },
+        },
+        {
+          path: "rule1.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__Effort]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}} (Effort)",
+            exoob__Rule_priority: 50,
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      const result = service.getTemplateForClass("ems__Task");
+      expect(result).not.toBeNull();
+      expect(result!.template).toBe("{{exo__Asset_label}} (Effort)");
+    });
+
+    it("should prefer direct class rule over inherited rule", () => {
+      const app = createMockApp([
+        {
+          path: "task-class.md",
+          frontmatter: {
+            exo__Instance_class: "exo__Class",
+            exo__Asset_label: "ems__Task",
+            exo__Class_superClass: "[[ems__Effort]]",
+          },
+        },
+        {
+          path: "effort-rule.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__Effort]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}} (Effort)",
+            exoob__Rule_priority: 50,
+          },
+        },
+        {
+          path: "task-rule.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__Task]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}} (Task)",
+            exoob__Rule_priority: 10,
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      const result = service.getTemplateForClass("ems__Task");
+      expect(result!.template).toBe("{{exo__Asset_label}} (Task)");
+    });
+  });
+
+  describe("wikilink class value cleaning", () => {
+    it("should handle class without wikilink brackets", () => {
+      const app = createMockApp([
+        {
+          path: "rule1.md",
+          frontmatter: {
+            exo__Instance_class: "exoob__PrintNameRule",
+            exoob__PrintNameRule_class: "ems__Task",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
+            exoob__Rule_priority: 10,
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      expect(service.getTemplateForClass("ems__Task")).not.toBeNull();
+    });
+
+    it("should handle class with wikilink brackets", () => {
+      const app = createMockApp([
+        {
+          path: "rule1.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__Task]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
+            exoob__Rule_priority: 10,
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      expect(service.getTemplateForClass("ems__Task")).not.toBeNull();
+    });
+  });
+
+  describe("invalid rules", () => {
+    it("should skip rules without template", () => {
+      const app = createMockApp([
+        {
+          path: "rule1.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__Task]]",
+            exoob__Rule_priority: 10,
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      expect(service.getTemplateForClass("ems__Task")).toBeNull();
+    });
+
+    it("should skip rules without class", () => {
+      const app = createMockApp([
+        {
+          path: "rule1.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
+            exoob__Rule_priority: 10,
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      expect(service.getRulesCount()).toBe(0);
+    });
+  });
+
+  describe("refresh", () => {
+    it("should reload rules on refresh", () => {
+      const app = createMockApp([]);
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      expect(service.getRulesCount()).toBe(0);
+
+      const newFiles = [
+        {
+          path: "rule1.md",
+          frontmatter: {
+            exo__Instance_class: "[[exoob__PrintNameRule]]",
+            exoob__PrintNameRule_class: "[[ems__Task]]",
+            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
+            exoob__Rule_priority: 10,
+          },
+        },
+      ];
+      const newMockFile = { path: "rule1.md", basename: "rule1", extension: "md" } as TFile;
+      (app.vault.getMarkdownFiles as jest.Mock).mockReturnValue([newMockFile]);
+      (app.metadataCache.getFileCache as jest.Mock).mockImplementation((file: TFile) => {
+        if (file.path === "rule1.md") {
+          return { frontmatter: newFiles[0].frontmatter };
+        }
+        return null;
+      });
+
+      service.refresh();
+
+      expect(service.getRulesCount()).toBe(1);
+    });
+  });
+
+  describe("metadataResolver", () => {
+    it("should resolve wikilink to metadata", () => {
+      const app = createMockApp([
+        {
+          path: "project.md",
+          frontmatter: {
+            exo__Asset_label: "My Project",
+            exo__Instance_class: "ems__Project",
+          },
+        },
+      ]);
+
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      const resolver = service.createMetadataResolver();
+      const metadata = resolver("[[project]]");
+      expect(metadata).not.toBeNull();
+      expect(metadata!.exo__Asset_label).toBe("My Project");
+    });
+
+    it("should return null for non-existent targets", () => {
+      const app = createMockApp([]);
+      const service = new PrintNameRuleService(app);
+      service.initialize();
+
+      const resolver = service.createMetadataResolver();
+      expect(resolver("[[nonexistent]]")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds data-driven display name rules: vault assets of class `exoob__PrintNameRule` define per-class display templates with priority resolution and class hierarchy inheritance.

- **PrintNameRuleService** scans vault for `exoob__PrintNameRule` assets, caches rules by class, supports inheritance via `exo__Class_superClass`
- **DisplayNameResolver** now checks dynamic rules (highest priority) before falling back to settings-based templates
- **DisplayNameTemplateEngine** supports cross-asset property resolution: `{{ems__Effort_project.exo__Asset_label}}` follows wikilinks to related assets
- All 6 rendering locations updated: Properties, Body, TabTitles, GraphView, FileExplorer, LivePreview

### Example rule asset:
```yaml
exo__Instance_class: "[[exoob__PrintNameRule]]"
exoob__PrintNameRule_class: "[[ems__TaskPrototype]]"
exoob__PrintNameRule_template: "{{exo__Asset_label}} (TPrototype)"
exoob__Rule_priority: 100
```

Closes #2326

## Test plan

- [x] 20+ new unit tests for PrintNameRuleService (priority, inheritance, wikilink cleaning, refresh, metadataResolver)
- [x] 4 new tests for DisplayNameResolver with PrintNameRuleService integration
- [x] 4 new tests for cross-asset template resolution in DisplayNameTemplateEngine
- [x] Updated ExocortexPlugin tests for new event handler count
- [x] All 4476 obsidian-plugin tests pass
- [x] All 5819 core tests pass
- [x] TypeScript clean compilation (0 errors)
- [x] ESLint clean (0 errors, 0 warnings)
- [x] BDD coverage 100%