### PR TITLE
feat(cli): add --also flag for cross-vault SPARQL queries (#2313)

### DIFF
--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -38,6 +38,7 @@ import { injectExocortexPrefixes, transformShorthandNotation, filterOntologyPref
 
 export interface SparqlQueryOptions {
   vault: string;
+  also?: string[];
   format: "table" | "json" | "csv" | "ntriples";
   output?: OutputFormat;
   explain?: boolean;
@@ -216,11 +217,20 @@ export async function executeWithTimeout<T>(
   return Promise.race([queryPromise, timeoutPromise]);
 }
 
+/**
+ * Commander.js accumulator for repeatable --also flag.
+ * Each --also <path> adds a vault path to the array.
+ */
+function collectAlso(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}
+
 export function sparqlQueryCommand(): Command {
   return new Command("query")
     .description("Execute SPARQL query against Obsidian vault")
     .argument("[query]", "SPARQL query string or path to .sparql file (optional if --template is used)")
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--also <path>", "Additional vault to include in query (repeatable)", collectAlso, [])
     .option("--format <type>", "Output format: table|json|csv|ntriples", "table")
     .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
     .option("--timeout <duration>", "Query timeout (e.g., 30s, 5000ms)", "30s")
@@ -344,13 +354,33 @@ export function sparqlQueryCommand(): Command {
           triples = await converter.convertVault();
         }
 
+        // Load additional vaults if --also specified
+        const alsoVaults = options.also || [];
+        for (const alsoPath of alsoVaults) {
+          const resolvedAlsoPath = resolve(alsoPath);
+          if (!existsSync(resolvedAlsoPath)) {
+            throw new VaultNotFoundError(resolvedAlsoPath);
+          }
+          if (outputFormat === "text") {
+            console.log(`📦 Loading additional vault: ${resolvedAlsoPath}...`);
+          }
+          const alsoAdapter = new FileSystemVaultAdapter(resolvedAlsoPath);
+          const alsoConverter = new NoteToRDFConverter(alsoAdapter);
+          const alsoTriples = await alsoConverter.convertVault();
+          triples = triples.concat(alsoTriples);
+          if (outputFormat === "text") {
+            console.log(`   ➕ Added ${alsoTriples.length} triples from ${resolvedAlsoPath}`);
+          }
+        }
+
         const tripleStore = new InMemoryTripleStore();
         await tripleStore.addAll(triples);
 
         const loadDuration = Date.now() - loadStartTime;
         if (outputFormat === "text") {
           const cacheStatus = cacheHit ? " (from cache)" : "";
-          console.log(`✅ Loaded ${triples.length} triples in ${loadDuration}ms${cacheStatus}\n`);
+          const alsoStatus = alsoVaults.length > 0 ? ` (${alsoVaults.length + 1} vaults)` : "";
+          console.log(`✅ Loaded ${triples.length} triples in ${loadDuration}ms${cacheStatus}${alsoStatus}\n`);
           console.log(`🔍 Parsing SPARQL query...`);
         }
 
@@ -365,6 +395,15 @@ export function sparqlQueryCommand(): Command {
         // Scan vault for namespace directories and auto-register prefixes
         // Filter out ontology prefixes to avoid collision (exo/, ems/ dirs vs ontology IRIs)
         const vaultPrefixes = filterOntologyPrefixes(scanVaultNamespaces(vaultPath));
+        // Also scan additional vaults for namespace directories
+        for (const alsoPath of alsoVaults) {
+          const alsoPrefixes = filterOntologyPrefixes(scanVaultNamespaces(resolve(alsoPath)));
+          for (const [prefix, uri] of alsoPrefixes) {
+            if (!vaultPrefixes.has(prefix)) {
+              vaultPrefixes.set(prefix, uri);
+            }
+          }
+        }
         if (vaultPrefixes.size > 0) {
           parser.setVaultPrefixes(vaultPrefixes);
         }

--- a/packages/cli/tests/unit/commands/sparql-query-also.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-also.test.ts
@@ -1,0 +1,212 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// ── Shared mock state ──────────────────────────────────────────────────
+const mockAddAll = jest.fn();
+const mockConvertVault = jest.fn().mockResolvedValue([]);
+
+jest.unstable_mockModule("../../../src/formatters/TableFormatter.js", () => ({
+  TableFormatter: jest.fn(() => ({ format: jest.fn().mockReturnValue("") })),
+}));
+jest.unstable_mockModule("../../../src/formatters/JsonFormatter.js", () => ({
+  JsonFormatter: jest.fn(() => ({ format: jest.fn().mockReturnValue("{}") })),
+}));
+jest.unstable_mockModule("../../../src/formatters/CsvFormatter.js", () => ({
+  CsvFormatter: jest.fn(() => ({ format: jest.fn().mockReturnValue("") })),
+}));
+jest.unstable_mockModule("../../../src/formatters/TriplesFormatter.js", () => ({
+  TriplesFormatter: jest.fn(() => ({
+    formatTable: jest.fn().mockReturnValue(""),
+    formatJson: jest.fn().mockReturnValue("[]"),
+    formatNTriples: jest.fn().mockReturnValue(""),
+  })),
+}));
+
+jest.unstable_mockModule("exocortex", () => ({
+  InMemoryTripleStore: jest.fn(() => ({ addAll: mockAddAll })),
+  SPARQLParser: jest.fn(() => ({
+    parse: jest.fn().mockReturnValue({ type: "query" }),
+    setVaultPrefixes: jest.fn(),
+  })),
+  SPARQLParseError: class extends Error {
+    constructor(m: string) { super(m); this.name = "SPARQLParseError"; }
+  },
+  AlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+  AlgebraOptimizer: jest.fn(() => ({
+    optimize: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+  AlgebraSerializer: jest.fn(() => ({
+    toString: jest.fn().mockReturnValue("BGP()"),
+  })),
+  QueryExecutor: jest.fn(() => ({
+    executeAll: jest.fn().mockResolvedValue([]),
+    isConstructQuery: jest.fn().mockReturnValue(false),
+    setTimeout: jest.fn(),
+  })),
+  NoteToRDFConverter: jest.fn(() => ({ convertVault: mockConvertVault })),
+  SolutionMapping: class extends Map {},
+  UpdateExecutor: jest.fn(() => ({
+    execute: jest.fn().mockResolvedValue([]),
+  })),
+  UpdateExecutorError: class extends Error {},
+  IRI: jest.fn(),
+  Literal: jest.fn(),
+  BlankNode: jest.fn(),
+  Triple: jest.fn(),
+  SPARQL_PREFIXES: "PREFIX exo: <https://exocortex.my/ontology/exo#>",
+}));
+
+jest.unstable_mockModule("../../../src/adapters/FileSystemVaultAdapter.js", () => ({
+  FileSystemVaultAdapter: jest.fn(),
+}));
+jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
+  CacheManager: jest.fn(() => ({
+    loadOrBuild: jest.fn().mockResolvedValue({ triples: [], cacheHit: false }),
+  })),
+}));
+jest.unstable_mockModule("../../../src/cache/QueryResultCache.js", () => ({
+  QueryResultCache: jest.fn(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+jest.unstable_mockModule("../../../src/utils/VaultNamespaceScanner.js", () => ({
+  scanVaultNamespaces: jest.fn().mockReturnValue(new Map()),
+}));
+jest.unstable_mockModule("../../../src/utils/QueryPrefixInjector.js", () => ({
+  injectExocortexPrefixes: jest.fn((q: string) => q),
+  transformShorthandNotation: jest.fn((q: string) => q),
+  filterOntologyPrefixes: jest.fn((m: Map<string, string>) => m),
+}));
+
+const { sparqlQueryCommand } = await import("../../../src/commands/sparql-query.js");
+
+// Create real temp directories for vault paths
+const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "exo-test-"));
+const primaryVault = path.join(tmpBase, "vault");
+const archiveVault = path.join(tmpBase, "archive");
+const archiveVault2 = path.join(tmpBase, "archive2");
+fs.mkdirSync(primaryVault);
+fs.mkdirSync(archiveVault);
+fs.mkdirSync(archiveVault2);
+
+describe("sparqlQueryCommand --also flag", () => {
+  beforeEach(() => {
+    mockAddAll.mockClear();
+    mockConvertVault.mockClear();
+    mockConvertVault.mockResolvedValue([
+      { subject: "s1", predicate: "p1", object: "o1" },
+      { subject: "s2", predicate: "p2", object: "o2" },
+    ]);
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(process, "exit").mockImplementation((() => {}) as never);
+  });
+
+  describe("command setup", () => {
+    it("should have --also option registered", () => {
+      const cmd = sparqlQueryCommand();
+      const opt = cmd.options.find((o: { long?: string }) => o.long === "--also");
+      expect(opt).toBeDefined();
+    });
+
+    it("--also description should mention repeatable", () => {
+      const cmd = sparqlQueryCommand();
+      const opt = cmd.options.find((o: { long?: string }) => o.long === "--also");
+      expect(opt?.description).toContain("repeatable");
+    });
+  });
+
+  describe("backward compatibility (no --also)", () => {
+    it("should call convertVault once for primary vault only", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", primaryVault,
+        "--no-cache",
+      ]);
+
+      expect(mockConvertVault).toHaveBeenCalledTimes(1);
+      expect(mockAddAll).toHaveBeenCalledTimes(1);
+      expect(mockAddAll.mock.calls[0][0]).toHaveLength(2);
+    });
+  });
+
+  describe("single --also vault", () => {
+    it("should call convertVault twice and merge triples", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", primaryVault,
+        "--also", archiveVault,
+        "--no-cache",
+      ]);
+
+      expect(mockConvertVault).toHaveBeenCalledTimes(2);
+      expect(mockAddAll).toHaveBeenCalledTimes(1);
+      expect(mockAddAll.mock.calls[0][0]).toHaveLength(4);
+    });
+
+    it("should log additional vault loading message", async () => {
+      const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", primaryVault,
+        "--also", archiveVault,
+        "--no-cache",
+      ]);
+
+      const logs = logSpy.mock.calls.map(c => String(c[0]));
+      expect(logs.some(m => m.includes("additional vault"))).toBe(true);
+      expect(logs.some(m => m.includes("2 vaults"))).toBe(true);
+      logSpy.mockRestore();
+    });
+  });
+
+  describe("multiple --also vaults", () => {
+    it("should call convertVault three times and merge all triples", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", primaryVault,
+        "--also", archiveVault,
+        "--also", archiveVault2,
+        "--no-cache",
+      ]);
+
+      expect(mockConvertVault).toHaveBeenCalledTimes(3);
+      expect(mockAddAll).toHaveBeenCalledTimes(1);
+      expect(mockAddAll.mock.calls[0][0]).toHaveLength(6);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should error when --also vault path does not exist", async () => {
+      const exitSpy = jest.spyOn(process, "exit").mockImplementation((() => {}) as never);
+      const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", primaryVault,
+        "--also", "/nonexistent/path/vault-missing-12345",
+        "--no-cache",
+      ]);
+
+      expect(exitSpy).toHaveBeenCalled();
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add repeatable `--also <path>` flag to `sparql query` for cross-vault data federation
- Triples from additional vaults are merged into default graph before query execution
- Namespace prefixes from additional vaults are auto-discovered
- Backward compatible: without `--also`, behavior is identical to previous version

## Usage Examples
```bash
# Query archive vault directly
npx @kitelev/exocortex-cli sparql query \
  --vault /path/to/archive-vault \
  "SELECT * WHERE { ?s a ems:Task }"

# Union: active + archive
npx @kitelev/exocortex-cli sparql query \
  --vault /path/to/active-vault \
  --also /path/to/archive-vault \
  "SELECT (COUNT(?s) AS ?total) WHERE { ?s a ems:Task }"

# Multiple additional vaults
npx @kitelev/exocortex-cli sparql query \
  --vault /path/to/vault-2026 \
  --also /path/to/vault-2025 \
  --also /path/to/vault-2024 \
  "SELECT ?year (COUNT(?task) AS ?count) WHERE { ... }"
```

## Implementation
- `SparqlQueryOptions.also?: string[]` — new optional field
- Commander.js accumulator (`collectAlso`) for repeatable `--also` flags
- After primary vault loading, each `--also` vault is loaded via `NoteToRDFConverter` and triples are concatenated
- Namespace scanning extended to additional vaults
- Error handling: `VaultNotFoundError` for invalid `--also` paths

## Test Plan
- [x] 7 unit tests (command setup, backward compat, single/multiple --also, error handling)
- [x] CLI unit tests: 59 suites, 1036 passed
- [ ] CI pipeline

Closes #2313