### PR TITLE
feat(cli): add unarchive command — restore asset from archive to active vault (#2312)

### DIFF
--- a/packages/cli/src/commands/unarchive.ts
+++ b/packages/cli/src/commands/unarchive.ts
@@ -1,0 +1,116 @@
+import { Command } from "commander";
+import { resolve } from "path";
+import { existsSync } from "fs";
+import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+import { UnarchiveService } from "../services/UnarchiveService.js";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+
+/**
+ * Options parsed from CLI flags for the unarchive command.
+ */
+interface UnarchiveCommandOptions {
+  uuid: string;
+  vault: string;
+  archiveVault: string;
+  dryRun?: boolean;
+}
+
+/**
+ * Creates the 'unarchive' subcommand for restoring an asset from the archive vault
+ * back to the active vault.
+ *
+ * This is the symmetric reverse of the 'archive' command:
+ * - Finds asset by UUID in the archive vault
+ * - Updates exo__Asset_isDefinedBy from archive ontology to active ontology
+ * - Moves file to active vault inbox (03 Knowledge/inbox/)
+ * - Preserves archived: true in frontmatter
+ *
+ * @returns Commander Command instance configured for asset unarchival
+ *
+ * @example
+ * ```bash
+ * # Restore asset from archive
+ * exocortex unarchive \
+ *   --uuid ca0d0001-1111-2222-3333-444455556666 \
+ *   --vault /path/to/active-vault \
+ *   --archive-vault /path/to/archive-vault
+ *
+ * # Dry run (preview without restoring)
+ * exocortex unarchive --dry-run \
+ *   --uuid ca0d0001-1111-2222-3333-444455556666 \
+ *   --vault /path/to/active-vault \
+ *   --archive-vault /path/to/archive-vault
+ * ```
+ */
+export function unarchiveCommand(): Command {
+  return new Command("unarchive")
+    .description(
+      "Restore asset from archive vault to active vault (reverse of archive)",
+    )
+    .requiredOption("--uuid <uuid>", "UUID of the asset to restore")
+    .requiredOption("--vault <path>", "Path to the active vault")
+    .requiredOption("--archive-vault <path>", "Path to the archive vault")
+    .option("--dry-run", "Preview without writing files", false)
+    .action(async (options: UnarchiveCommandOptions) => {
+      try {
+        // Validate vault paths
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const archiveVaultPath = resolve(options.archiveVault);
+        if (!existsSync(archiveVaultPath)) {
+          throw new VaultNotFoundError(archiveVaultPath);
+        }
+
+        // Validate UUID format
+        const uuidPattern =
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!uuidPattern.test(options.uuid)) {
+          throw new Error(
+            `Invalid UUID format: ${options.uuid}. Expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`,
+          );
+        }
+
+        // Create services
+        const activeFs = new NodeFsAdapter(vaultPath);
+        const archiveFs = new NodeFsAdapter(archiveVaultPath);
+        const unarchiveService = new UnarchiveService(activeFs, archiveFs);
+
+        // Execute unarchive
+        const result = await unarchiveService.unarchive({
+          uuid: options.uuid,
+          vaultPath,
+          archiveVaultPath,
+          dryRun: options.dryRun || false,
+        });
+
+        if (!result.success) {
+          process.stdout.write(
+            JSON.stringify({ error: result.error }) + "\n",
+          );
+          process.exit(1);
+        }
+
+        // Output result
+        if (options.dryRun) {
+          process.stderr.write("--- DRY RUN PREVIEW ---\n");
+          process.stderr.write(`Would restore: ${result.uuid}\n`);
+          process.stderr.write(`Target: ${result.movedTo}\n`);
+          if (result.isDefinedBy) {
+            process.stderr.write(
+              `isDefinedBy: ${result.isDefinedBy}\n`,
+            );
+          }
+          process.stderr.write("--- END PREVIEW ---\n");
+        }
+
+        process.stdout.write(JSON.stringify(result) + "\n");
+        process.exit(0);
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import { validateCommand } from "./commands/validate.js";
 import { classesCommand } from "./commands/classes.js";
 import { createCommand } from "./commands/create.js";
 import { archiveCommand } from "./commands/archive.js";
+import { unarchiveCommand } from "./commands/unarchive.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -46,5 +47,6 @@ program.addCommand(validateCommand());
 program.addCommand(classesCommand());
 program.addCommand(createCommand());
 program.addCommand(archiveCommand());
+program.addCommand(unarchiveCommand());
 
 program.parse();

--- a/packages/cli/src/services/UnarchiveService.ts
+++ b/packages/cli/src/services/UnarchiveService.ts
@@ -1,0 +1,188 @@
+import path from "path";
+import yaml from "js-yaml";
+import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+
+/**
+ * Options for the unarchive operation
+ */
+export interface UnarchiveOptions {
+  /** UUID of asset to restore */
+  uuid: string;
+  /** Path to the active vault */
+  vaultPath: string;
+  /** Path to the archive vault */
+  archiveVaultPath: string;
+  /** If true, preview without writing */
+  dryRun: boolean;
+}
+
+/**
+ * Result of the unarchive operation
+ */
+export interface UnarchiveResult {
+  success: boolean;
+  uuid: string;
+  movedTo?: string;
+  isDefinedBy?: string;
+  error?: string;
+}
+
+/**
+ * Service that restores a single asset from the archive vault back to the active vault.
+ *
+ * This is the symmetric reverse of ArchiveService.transferFile():
+ * - Finds asset by UUID in archive vault
+ * - Updates exo__Asset_isDefinedBy from archive ontology to active ontology
+ * - Moves file to active vault inbox (03 Knowledge/inbox/)
+ * - Preserves archived: true in frontmatter (user decides whether to remove it)
+ */
+export class UnarchiveService {
+  constructor(
+    private readonly activeFs: NodeFsAdapter,
+    private readonly archiveFs: NodeFsAdapter,
+  ) {}
+
+  /**
+   * Execute the unarchive operation for a single asset.
+   */
+  async unarchive(options: UnarchiveOptions): Promise<UnarchiveResult> {
+    const { uuid, dryRun } = options;
+
+    // Step 1: Find asset in archive vault by UUID
+    const assetFile = await this.findAssetByUUID(uuid);
+    if (!assetFile) {
+      return {
+        success: false,
+        uuid,
+        error: `UUID ${uuid} not found in archive vault`,
+      };
+    }
+
+    // Step 2: Read content and extract frontmatter
+    const content = await this.archiveFs.readFile(assetFile);
+    const metadata = this.extractFrontmatter(content);
+
+    // Step 3: Resolve active ontology URI from archive ontology
+    const isDefinedBy = metadata.exo__Asset_isDefinedBy;
+    const activeOntologyWikilink = isDefinedBy
+      ? this.resolveActiveOntology(String(isDefinedBy))
+      : null;
+
+    // Step 4: Determine target path in active vault
+    const targetPath = path.join("03 Knowledge", "inbox", path.basename(assetFile));
+
+    // Dry-run: return preview without making changes
+    if (dryRun) {
+      return {
+        success: true,
+        uuid,
+        movedTo: targetPath,
+        isDefinedBy: activeOntologyWikilink || undefined,
+      };
+    }
+
+    // Step 5: Update isDefinedBy in content
+    let updatedContent = content;
+    if (isDefinedBy && activeOntologyWikilink) {
+      updatedContent = updatedContent.replace(
+        String(isDefinedBy),
+        activeOntologyWikilink,
+      );
+    }
+
+    // Step 6: Write file to active vault inbox
+    await this.activeFs.writeFile(targetPath, updatedContent);
+
+    // Step 7: Delete from archive vault
+    await this.archiveFs.deleteFile(assetFile);
+
+    return {
+      success: true,
+      uuid,
+      movedTo: targetPath,
+      isDefinedBy: activeOntologyWikilink || undefined,
+    };
+  }
+
+  /**
+   * Find asset file by UUID in the archive vault.
+   *
+   * Search order:
+   * 1. Direct filename match: <uuid>.md
+   * 2. Scan all files for exo__Asset_uid match in frontmatter
+   */
+  private async findAssetByUUID(uuid: string): Promise<string | null> {
+    // Fast path: check if file with UUID name exists
+    const directPath = uuid + ".md";
+    const exists = await this.archiveFs.fileExists(directPath);
+    if (exists) {
+      return directPath;
+    }
+
+    // Slow path: scan archive vault for matching exo__Asset_uid
+    const allFiles = await this.archiveFs.getMarkdownFiles();
+    for (const file of allFiles) {
+      try {
+        const content = await this.archiveFs.readFile(file);
+        const metadata = this.extractFrontmatter(content);
+        const uid = metadata.exo__Asset_uid;
+        if (uid && String(uid).toLowerCase() === uuid.toLowerCase()) {
+          return file;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolve the active ontology wikilink from an archive ontology wikilink.
+   *
+   * Reverse of ArchiveService.getArchiveOntologyName():
+   * "[[!ems_archive|EMS Ontology (Archive)]]" → "[[!ems|EMS Ontology]]"
+   * "[[!ems_archive]]" → "[[!ems]]"
+   */
+  private resolveActiveOntology(archiveWikilink: string): string | null {
+    const match = archiveWikilink.match(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/);
+    if (!match) return null;
+
+    const target = match[1]; // e.g. "!ems_archive"
+    const label = match[2]; // e.g. "EMS Ontology (Archive)" or undefined
+
+    // Check if this is actually an archive ontology reference
+    if (!target.endsWith("_archive")) {
+      // Already pointing to active ontology, return as-is
+      return archiveWikilink;
+    }
+
+    // Strip _archive suffix
+    const activeTarget = target.replace(/_archive$/, "");
+
+    // Strip " (Archive)" suffix from label if present
+    if (label) {
+      const activeLabel = label.replace(/\s*\(Archive\)$/, "");
+      return `[[${activeTarget}|${activeLabel}]]`;
+    }
+
+    return `[[${activeTarget}]]`;
+  }
+
+  /**
+   * Extract frontmatter from markdown content.
+   */
+  private extractFrontmatter(content: string): Record<string, unknown> {
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) return {};
+
+    try {
+      const parsed = yaml.load(match[1]);
+      return typeof parsed === "object" && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+}

--- a/packages/cli/tests/unit/services/UnarchiveService.test.ts
+++ b/packages/cli/tests/unit/services/UnarchiveService.test.ts
@@ -1,0 +1,367 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+/**
+ * Issue #2312: Tests for UnarchiveService
+ *
+ * Acceptance criteria:
+ * - Given UUID in archive vault Then file moved to active vault with updated isDefinedBy
+ * - Given UUID not in archive vault Then error message, success: false
+ * - Given --dry-run Then preview JSON without moving files
+ * - Given unarchive Then file lands in 03 Knowledge/inbox/
+ * - Given unarchive Then archived: true preserved in frontmatter
+ * - Given asset with _archive ontology Then isDefinedBy updated to active ontology
+ * - Given asset found by exo__Asset_uid (not filename) Then correctly restored
+ */
+
+// Helper to build markdown file with frontmatter (no TS annotations)
+function yamlQuote(val) {
+  const s = String(val);
+  if (/[\[\]{|}:#>,]/.test(s) || s !== s.trim()) {
+    return `"${s.replace(/"/g, '\\"')}"`;
+  }
+  return s;
+}
+
+function buildMd(frontmatter, body) {
+  if (body === undefined) body = "";
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      for (const item of value) {
+        lines.push(`  - ${yamlQuote(item)}`);
+      }
+    } else if (typeof value === "boolean") {
+      lines.push(`${key}: ${value}`);
+    } else {
+      lines.push(`${key}: ${yamlQuote(value)}`);
+    }
+  }
+  lines.push("---");
+  if (body) {
+    lines.push("");
+    lines.push(body);
+  }
+  return lines.join("\n");
+}
+
+// UUID constants for tests
+const TASK_CLASS_UUID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const CANDIDATE_UUID = "ca0d0001-1111-2222-3333-444455556666";
+const NONEXISTENT_UUID = "deadbeef-0000-0000-0000-000000000000";
+
+// Build archived task in archive vault (with archive ontology)
+function buildArchivedInArchive(uuid) {
+  return buildMd({
+    exo__Instance_class: TASK_CLASS_UUID,
+    exo__Asset_uid: uuid,
+    exo__Asset_label: `Task ${uuid.substring(0, 8)}`,
+    exo__Asset_isDefinedBy: "[[!ems_archive|EMS Ontology (Archive)]]",
+    archived: true,
+    ems__Effort_resolutionTimestamp: "2025-06-15T10:00:00",
+  });
+}
+
+// Build archived task without _archive ontology (edge case)
+function buildArchivedWithActiveOntology(uuid) {
+  return buildMd({
+    exo__Instance_class: TASK_CLASS_UUID,
+    exo__Asset_uid: uuid,
+    exo__Asset_label: `Task ${uuid.substring(0, 8)}`,
+    exo__Asset_isDefinedBy: "[[!ems|EMS Ontology]]",
+    archived: true,
+  });
+}
+
+// Mock adapters
+const mockActiveFs = {
+  getMarkdownFiles: jest.fn(),
+  readFile: jest.fn(),
+  fileExists: jest.fn(),
+  writeFile: jest.fn(),
+  deleteFile: jest.fn(),
+  getFileMetadata: jest.fn(),
+  createFile: jest.fn(),
+  updateFile: jest.fn(),
+  renameFile: jest.fn(),
+  createDirectory: jest.fn(),
+  directoryExists: jest.fn(),
+  findFilesByMetadata: jest.fn(),
+  findFileByUID: jest.fn(),
+};
+
+const mockArchiveFs = {
+  getMarkdownFiles: jest.fn(),
+  readFile: jest.fn(),
+  fileExists: jest.fn(),
+  writeFile: jest.fn(),
+  deleteFile: jest.fn(),
+  getFileMetadata: jest.fn(),
+  createFile: jest.fn(),
+  updateFile: jest.fn(),
+  renameFile: jest.fn(),
+  createDirectory: jest.fn(),
+  directoryExists: jest.fn(),
+  findFilesByMetadata: jest.fn(),
+  findFileByUID: jest.fn(),
+};
+
+// Import the service (no module mocking needed — we pass adapters directly)
+const { UnarchiveService } = await import(
+  "../../../src/services/UnarchiveService.js"
+);
+
+describe("UnarchiveService", () => {
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new UnarchiveService(mockActiveFs, mockArchiveFs);
+  });
+
+  describe("successful unarchive", () => {
+    it("should find asset by UUID filename and move to active vault inbox", async () => {
+      const content = buildArchivedInArchive(CANDIDATE_UUID);
+
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+      mockActiveFs.writeFile.mockResolvedValue(undefined);
+      mockArchiveFs.deleteFile.mockResolvedValue(undefined);
+
+      const result = await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.uuid).toBe(CANDIDATE_UUID);
+      expect(result.movedTo).toBe(`03 Knowledge/inbox/${CANDIDATE_UUID}.md`);
+      expect(result.isDefinedBy).toBe("[[!ems|EMS Ontology]]");
+    });
+
+    it("should update exo__Asset_isDefinedBy from archive to active ontology", async () => {
+      const content = buildArchivedInArchive(CANDIDATE_UUID);
+
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+      mockActiveFs.writeFile.mockResolvedValue(undefined);
+      mockArchiveFs.deleteFile.mockResolvedValue(undefined);
+
+      await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      // Verify the written content has updated isDefinedBy
+      const writtenContent = mockActiveFs.writeFile.mock.calls[0][1];
+      expect(writtenContent).toContain("[[!ems|EMS Ontology]]");
+      expect(writtenContent).not.toContain("_archive");
+    });
+
+    it("should preserve archived: true in frontmatter after unarchive", async () => {
+      const content = buildArchivedInArchive(CANDIDATE_UUID);
+
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+      mockActiveFs.writeFile.mockResolvedValue(undefined);
+      mockArchiveFs.deleteFile.mockResolvedValue(undefined);
+
+      await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      const writtenContent = mockActiveFs.writeFile.mock.calls[0][1];
+      expect(writtenContent).toContain("archived: true");
+    });
+
+    it("should delete file from archive vault after moving", async () => {
+      const content = buildArchivedInArchive(CANDIDATE_UUID);
+
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+      mockActiveFs.writeFile.mockResolvedValue(undefined);
+      mockArchiveFs.deleteFile.mockResolvedValue(undefined);
+
+      await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      expect(mockArchiveFs.deleteFile).toHaveBeenCalledWith(
+        `${CANDIDATE_UUID}.md`,
+      );
+    });
+
+    it("should find asset by exo__Asset_uid when filename does not match UUID", async () => {
+      const content = buildArchivedInArchive(CANDIDATE_UUID);
+
+      // Direct filename check returns false
+      mockArchiveFs.fileExists.mockResolvedValue(false);
+      // Scan finds the file by UID
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([
+        "some/nested/old-name.md",
+      ]);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+      mockActiveFs.writeFile.mockResolvedValue(undefined);
+      mockArchiveFs.deleteFile.mockResolvedValue(undefined);
+
+      const result = await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.movedTo).toBe("03 Knowledge/inbox/old-name.md");
+    });
+  });
+
+  describe("UUID not found", () => {
+    it("should return error when UUID not found in archive vault", async () => {
+      mockArchiveFs.fileExists.mockResolvedValue(false);
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([]);
+
+      const result = await service.unarchive({
+        uuid: NONEXISTENT_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(NONEXISTENT_UUID);
+      expect(result.error).toContain("not found in archive vault");
+    });
+
+    it("should not write or delete any files when UUID not found", async () => {
+      mockArchiveFs.fileExists.mockResolvedValue(false);
+      mockArchiveFs.getMarkdownFiles.mockResolvedValue([]);
+
+      await service.unarchive({
+        uuid: NONEXISTENT_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      expect(mockActiveFs.writeFile).not.toHaveBeenCalled();
+      expect(mockArchiveFs.deleteFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dry-run mode", () => {
+    it("should return preview without moving files", async () => {
+      const content = buildArchivedInArchive(CANDIDATE_UUID);
+
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+
+      const result = await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.uuid).toBe(CANDIDATE_UUID);
+      expect(result.movedTo).toBe(`03 Knowledge/inbox/${CANDIDATE_UUID}.md`);
+      expect(result.isDefinedBy).toBe("[[!ems|EMS Ontology]]");
+    });
+
+    it("should not write or delete any files in dry-run mode", async () => {
+      const content = buildArchivedInArchive(CANDIDATE_UUID);
+
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+
+      await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: true,
+      });
+
+      expect(mockActiveFs.writeFile).not.toHaveBeenCalled();
+      expect(mockArchiveFs.deleteFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ontology handling edge cases", () => {
+    it("should handle asset already pointing to active ontology", async () => {
+      const content = buildArchivedWithActiveOntology(CANDIDATE_UUID);
+
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+      mockActiveFs.writeFile.mockResolvedValue(undefined);
+      mockArchiveFs.deleteFile.mockResolvedValue(undefined);
+
+      const result = await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.isDefinedBy).toBe("[[!ems|EMS Ontology]]");
+    });
+
+    it("should handle wikilink without label", async () => {
+      const content = buildMd({
+        exo__Instance_class: TASK_CLASS_UUID,
+        exo__Asset_uid: CANDIDATE_UUID,
+        exo__Asset_isDefinedBy: "[[!ems_archive]]",
+        archived: true,
+      });
+
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+      mockActiveFs.writeFile.mockResolvedValue(undefined);
+      mockArchiveFs.deleteFile.mockResolvedValue(undefined);
+
+      const result = await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.isDefinedBy).toBe("[[!ems]]");
+    });
+
+    it("should handle asset without isDefinedBy property", async () => {
+      const content = buildMd({
+        exo__Instance_class: TASK_CLASS_UUID,
+        exo__Asset_uid: CANDIDATE_UUID,
+        archived: true,
+      });
+
+      mockArchiveFs.fileExists.mockResolvedValue(true);
+      mockArchiveFs.readFile.mockResolvedValue(content);
+      mockActiveFs.writeFile.mockResolvedValue(undefined);
+      mockArchiveFs.deleteFile.mockResolvedValue(undefined);
+
+      const result = await service.unarchive({
+        uuid: CANDIDATE_UUID,
+        vaultPath: "/active",
+        archiveVaultPath: "/archive",
+        dryRun: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.isDefinedBy).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `unarchive` CLI command — symmetric reverse of `archive`
- Finds asset by UUID in archive vault (direct filename match + frontmatter scan fallback)
- Updates `exo__Asset_isDefinedBy` from archive ontology (`[[!ems_archive|...]]`) to active ontology (`[[!ems|...]]`)
- Moves file to active vault inbox (`03 Knowledge/inbox/`)
- Preserves `archived: true` in frontmatter (user decides whether to remove)
- `--dry-run` mode for preview without side effects
- JSON output for machine-readable results

## Files Changed
- **New:** `packages/cli/src/services/UnarchiveService.ts` — core business logic
- **New:** `packages/cli/src/commands/unarchive.ts` — CLI command registration
- **Modified:** `packages/cli/src/index.ts` — register unarchive command
- **New:** `packages/cli/tests/unit/services/UnarchiveService.test.ts` — 12 unit tests

## Test plan
- [x] 12 unit tests pass (success, error, dry-run, edge cases)
- [x] Existing 1070 tests unaffected
- [x] Build succeeds
- [x] TypeScript compiles without new errors

Closes #2312