### PR TITLE
feat(cli): add archive --stats flag for vault statistics (#2340)

### DIFF
--- a/packages/cli/src/commands/archive.ts
+++ b/packages/cli/src/commands/archive.ts
@@ -6,6 +6,7 @@ import { ClassResolverService } from "../services/ClassResolverService.js";
 import { ArchiveService } from "../services/ArchiveService.js";
 import { ArchiveVerifyService } from "../services/ArchiveVerifyService.js";
 import { ArchiveCascadeService } from "../services/ArchiveCascadeService.js";
+import { ArchiveStatsService } from "../services/ArchiveStatsService.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 
@@ -22,6 +23,7 @@ interface ArchiveCommandOptions {
   json?: boolean;
   verify?: boolean;
   cascade?: boolean;
+  stats?: boolean;
 }
 
 /**
@@ -97,6 +99,11 @@ export function archiveCommand(): Command {
       "Iteratively resolve archived-to-archived chains (no --class/--year needed)",
       false,
     )
+    .option(
+      "--stats",
+      "Print archive vault statistics by class and year (read-only)",
+      false,
+    )
     .action(async (options: ArchiveCommandOptions) => {
       try {
         // Validate vault paths
@@ -108,6 +115,18 @@ export function archiveCommand(): Command {
         const archiveVaultPath = resolve(options.archiveVault);
         if (!existsSync(archiveVaultPath)) {
           throw new VaultNotFoundError(archiveVaultPath);
+        }
+
+        // Branch: stats mode
+        if (options.stats) {
+          const archiveFs = new NodeFsAdapter(archiveVaultPath);
+          const statsService = new ArchiveStatsService(archiveFs);
+
+          const result = await statsService.collect();
+
+          process.stderr.write(formatStatsSummary(result));
+          process.stdout.write(JSON.stringify(result) + "\n");
+          process.exit(0);
         }
 
         // Branch: verify mode
@@ -242,4 +261,34 @@ export function archiveCommand(): Command {
         ErrorHandler.handle(error as Error);
       }
     });
+}
+
+/**
+ * Format archive stats as a human-readable summary for stderr.
+ */
+function formatStatsSummary(stats: import("../services/ArchiveStatsService.js").ArchiveStats): string {
+  const lines: string[] = ["--- ARCHIVE STATS ---"];
+
+  lines.push(`Total assets: ${stats.total}`);
+
+  if (Object.keys(stats.by_class).length > 0) {
+    lines.push("");
+    lines.push("By class:");
+    const sorted = Object.entries(stats.by_class).sort((a, b) => b[1] - a[1]);
+    for (const [cls, count] of sorted) {
+      lines.push(`  ${cls}: ${count}`);
+    }
+  }
+
+  if (Object.keys(stats.by_year).length > 0) {
+    lines.push("");
+    lines.push("By year:");
+    const sorted = Object.entries(stats.by_year).sort((a, b) => a[0].localeCompare(b[0]));
+    for (const [year, count] of sorted) {
+      lines.push(`  ${year}: ${count}`);
+    }
+  }
+
+  lines.push("--- END STATS ---");
+  return lines.join("\n") + "\n";
 }

--- a/packages/cli/src/services/ArchiveStatsService.ts
+++ b/packages/cli/src/services/ArchiveStatsService.ts
@@ -1,0 +1,141 @@
+import yaml from "js-yaml";
+import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+
+/**
+ * Statistics aggregation result for an archive vault.
+ */
+export interface ArchiveStats {
+  /** Total number of archived assets */
+  total: number;
+  /** Count of assets per ontological class */
+  by_class: Record<string, number>;
+  /** Count of assets per year (derived from timestamps) */
+  by_year: Record<string, number>;
+  /** Cross-tabulation: count per class per year */
+  cross: Record<string, Record<string, number>>;
+}
+
+/**
+ * Aggregates statistics from an archive vault by scanning all markdown files
+ * and collecting counts by ontological class and by year.
+ *
+ * Year is derived from `ems__Effort_resolutionTimestamp` with fallback to
+ * `ems__Effort_endTimestamp`. Missing timestamps produce year key `"unknown"`.
+ *
+ * Class is derived from `exo__Instance_class`. Missing class produces
+ * class key `"unknown"`.
+ *
+ * Runs in a single O(n) pass over files.
+ *
+ * @example
+ * ```typescript
+ * const service = new ArchiveStatsService(new NodeFsAdapter(archivePath));
+ * const stats = await service.collect();
+ * console.log(stats.total, stats.by_class, stats.by_year);
+ * ```
+ */
+export class ArchiveStatsService {
+  constructor(private readonly fs: NodeFsAdapter) {}
+
+  /**
+   * Collect archive vault statistics.
+   *
+   * @returns Aggregated statistics with total, by_class, by_year, and cross-tabulation
+   */
+  async collect(): Promise<ArchiveStats> {
+    const files = await this.fs.getMarkdownFiles();
+    const stats: ArchiveStats = {
+      total: 0,
+      by_class: {},
+      by_year: {},
+      cross: {},
+    };
+
+    for (const file of files) {
+      try {
+        const content = await this.fs.readFile(file);
+        const fm = this.extractFrontmatter(content);
+
+        stats.total++;
+
+        const cls = this.extractClass(fm);
+        stats.by_class[cls] = (stats.by_class[cls] ?? 0) + 1;
+
+        const year = this.extractYear(fm);
+        stats.by_year[year] = (stats.by_year[year] ?? 0) + 1;
+
+        if (!stats.cross[cls]) stats.cross[cls] = {};
+        stats.cross[cls][year] = (stats.cross[cls][year] ?? 0) + 1;
+      } catch {
+        // Skip unreadable files
+        continue;
+      }
+    }
+
+    return stats;
+  }
+
+  /**
+   * Extract the class short name from frontmatter.
+   *
+   * Handles both string and array forms of exo__Instance_class.
+   * Extracts the label from wikilink format: `"[[uuid|ClassName]]"` → `"ClassName"`.
+   */
+  private extractClass(fm: Record<string, unknown>): string {
+    const raw = fm.exo__Instance_class;
+    if (!raw) return "unknown";
+
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    const str = String(value).replace(/^"|"$/g, "");
+
+    // Extract label from wikilink: [[uuid|Label]] → Label
+    const wikilinkMatch = str.match(/\[\[[^\]|]+\|([^\]]+)\]\]/);
+    if (wikilinkMatch) return wikilinkMatch[1];
+
+    // Extract plain wikilink: [[ClassName]] → ClassName
+    const plainMatch = str.match(/\[\[([^\]]+)\]\]/);
+    if (plainMatch) return plainMatch[1];
+
+    return str || "unknown";
+  }
+
+  /**
+   * Extract year from timestamps.
+   *
+   * Priority: ems__Effort_resolutionTimestamp > ems__Effort_endTimestamp.
+   * Falls back to "unknown" if neither is present.
+   */
+  private extractYear(fm: Record<string, unknown>): string {
+    const ts =
+      fm.ems__Effort_resolutionTimestamp ?? fm.ems__Effort_endTimestamp;
+
+    if (!ts) return "unknown";
+
+    // js-yaml may parse ISO timestamps as Date objects
+    if (ts instanceof Date) {
+      const year = ts.getFullYear();
+      return isNaN(year) ? "unknown" : year.toString();
+    }
+
+    const str = String(ts);
+    const yearMatch = str.match(/^(\d{4})/);
+    return yearMatch ? yearMatch[1] : "unknown";
+  }
+
+  /**
+   * Extract frontmatter from markdown content.
+   */
+  private extractFrontmatter(content: string): Record<string, unknown> {
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) return {};
+
+    try {
+      const parsed = yaml.load(match[1]);
+      return typeof parsed === "object" && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+}

--- a/packages/cli/tests/unit/services/ArchiveStatsService.test.ts
+++ b/packages/cli/tests/unit/services/ArchiveStatsService.test.ts
@@ -1,0 +1,252 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+const mockFsAdapter = {
+  getMarkdownFiles: jest.fn<() => Promise<string[]>>(),
+  readFile: jest.fn<(path: string) => Promise<string>>(),
+  fileExists: jest.fn(),
+  createFile: jest.fn(),
+  updateFile: jest.fn(),
+  writeFile: jest.fn(),
+  deleteFile: jest.fn(),
+  renameFile: jest.fn(),
+  createDirectory: jest.fn(),
+  directoryExists: jest.fn(),
+  getFileMetadata: jest.fn(),
+  findFilesByMetadata: jest.fn(),
+  findFileByUID: jest.fn(),
+};
+
+jest.unstable_mockModule("../../../src/adapters/NodeFsAdapter.js", () => ({
+  NodeFsAdapter: jest.fn(() => mockFsAdapter),
+}));
+
+const { ArchiveStatsService } = await import(
+  "../../../src/services/ArchiveStatsService.js"
+);
+
+/**
+ * Helper to create markdown file content with frontmatter.
+ */
+function makeMd(fm: Record<string, unknown>): string {
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(fm)) {
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      for (const item of value) {
+        lines.push(`  - ${item}`);
+      }
+    } else {
+      lines.push(`${key}: ${value}`);
+    }
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+describe("ArchiveStatsService", () => {
+  let service: InstanceType<typeof ArchiveStatsService>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ArchiveStatsService(mockFsAdapter as any);
+  });
+
+  it("should return zeros for empty vault", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue([]);
+
+    const stats = await service.collect();
+
+    expect(stats.total).toBe(0);
+    expect(stats.by_class).toEqual({});
+    expect(stats.by_year).toEqual({});
+    expect(stats.cross).toEqual({});
+  });
+
+  it("should count total files correctly", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue([
+      "a.md",
+      "b.md",
+      "c.md",
+    ]);
+    mockFsAdapter.readFile.mockResolvedValue(
+      makeMd({ exo__Instance_class: '"[[uuid|ems__Task]]"' }),
+    );
+
+    const stats = await service.collect();
+
+    expect(stats.total).toBe(3);
+  });
+
+  it("should aggregate by class correctly", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue([
+      "a.md",
+      "b.md",
+      "c.md",
+    ]);
+    mockFsAdapter.readFile
+      .mockResolvedValueOnce(
+        makeMd({ exo__Instance_class: '"[[uuid1|ems__Task]]"' }),
+      )
+      .mockResolvedValueOnce(
+        makeMd({ exo__Instance_class: '"[[uuid2|ems__Meeting]]"' }),
+      )
+      .mockResolvedValueOnce(
+        makeMd({ exo__Instance_class: '"[[uuid1|ems__Task]]"' }),
+      );
+
+    const stats = await service.collect();
+
+    expect(stats.by_class).toEqual({
+      ems__Task: 2,
+      ems__Meeting: 1,
+    });
+  });
+
+  it("should use resolutionTimestamp for year when present", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue(["a.md"]);
+    mockFsAdapter.readFile.mockResolvedValue(
+      makeMd({
+        exo__Instance_class: '"[[uuid|ems__Task]]"',
+        ems__Effort_resolutionTimestamp: "2025-06-15T10:00:00",
+        ems__Effort_endTimestamp: "2024-12-31T23:59:59",
+      }),
+    );
+
+    const stats = await service.collect();
+
+    expect(stats.by_year).toEqual({ "2025": 1 });
+  });
+
+  it("should fall back to endTimestamp when resolutionTimestamp is absent", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue(["a.md"]);
+    mockFsAdapter.readFile.mockResolvedValue(
+      makeMd({
+        exo__Instance_class: '"[[uuid|ems__Task]]"',
+        ems__Effort_endTimestamp: "2024-03-20T15:30:00",
+      }),
+    );
+
+    const stats = await service.collect();
+
+    expect(stats.by_year).toEqual({ "2024": 1 });
+  });
+
+  it("should assign year 'unknown' when both timestamps are absent", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue(["a.md"]);
+    mockFsAdapter.readFile.mockResolvedValue(
+      makeMd({ exo__Instance_class: '"[[uuid|ems__Task]]"' }),
+    );
+
+    const stats = await service.collect();
+
+    expect(stats.by_year).toEqual({ unknown: 1 });
+  });
+
+  it("should assign class 'unknown' when exo__Instance_class is absent", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue(["a.md"]);
+    mockFsAdapter.readFile.mockResolvedValue(
+      makeMd({ exo__Asset_label: "Some Asset" }),
+    );
+
+    const stats = await service.collect();
+
+    expect(stats.by_class).toEqual({ unknown: 1 });
+  });
+
+  it("should build correct cross-tabulation", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue([
+      "a.md",
+      "b.md",
+      "c.md",
+    ]);
+    mockFsAdapter.readFile
+      .mockResolvedValueOnce(
+        makeMd({
+          exo__Instance_class: '"[[u|ems__Task]]"',
+          ems__Effort_endTimestamp: "2025-01-01T00:00:00",
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeMd({
+          exo__Instance_class: '"[[u|ems__Task]]"',
+          ems__Effort_endTimestamp: "2025-06-15T00:00:00",
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeMd({
+          exo__Instance_class: '"[[u|ems__Meeting]]"',
+          ems__Effort_endTimestamp: "2025-03-20T00:00:00",
+        }),
+      );
+
+    const stats = await service.collect();
+
+    expect(stats.cross).toEqual({
+      ems__Task: { "2025": 2 },
+      ems__Meeting: { "2025": 1 },
+    });
+  });
+
+  it("should handle exo__Instance_class as array", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue(["a.md"]);
+    mockFsAdapter.readFile.mockResolvedValue(
+      makeMd({
+        exo__Instance_class: ['"[[uuid|ems__Project]]"'],
+      }),
+    );
+
+    const stats = await service.collect();
+
+    expect(stats.by_class).toEqual({ ems__Project: 1 });
+  });
+
+  it("should handle plain class name without wikilink", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue(["a.md"]);
+    mockFsAdapter.readFile.mockResolvedValue(
+      makeMd({ exo__Instance_class: "ems__Task" }),
+    );
+
+    const stats = await service.collect();
+
+    expect(stats.by_class).toEqual({ ems__Task: 1 });
+  });
+
+  it("should handle class as plain wikilink without label", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue(["a.md"]);
+    mockFsAdapter.readFile.mockResolvedValue(
+      makeMd({ exo__Instance_class: '"[[ems__Task]]"' }),
+    );
+
+    const stats = await service.collect();
+
+    expect(stats.by_class).toEqual({ ems__Task: 1 });
+  });
+
+  it("should skip unreadable files without crashing", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue([
+      "good.md",
+      "broken.md",
+    ]);
+    mockFsAdapter.readFile
+      .mockResolvedValueOnce(
+        makeMd({ exo__Instance_class: '"[[u|ems__Task]]"' }),
+      )
+      .mockRejectedValueOnce(new Error("EPERM: permission denied"));
+
+    const stats = await service.collect();
+
+    expect(stats.total).toBe(1);
+    expect(stats.by_class).toEqual({ ems__Task: 1 });
+  });
+
+  it("should handle files without frontmatter", async () => {
+    mockFsAdapter.getMarkdownFiles.mockResolvedValue(["no-fm.md"]);
+    mockFsAdapter.readFile.mockResolvedValue("# Just a heading\n\nNo frontmatter here.");
+
+    const stats = await service.collect();
+
+    expect(stats.total).toBe(1);
+    expect(stats.by_class).toEqual({ unknown: 1 });
+    expect(stats.by_year).toEqual({ unknown: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ArchiveStatsService` — pure aggregation service scanning archive vault
- Add `--stats` flag to `archive` command as early-return dispatch branch
- Outputs JSON `{total, by_class, by_year, cross}` to stdout, summary to stderr
- 13 unit tests covering all edge cases

## Key decisions
- Year derived from `ems__Effort_resolutionTimestamp` > `ems__Effort_endTimestamp` > `"unknown"`
- Handles `js-yaml` parsing timestamps as Date objects (not just strings)
- Class extracted from wikilink format `[[uuid|ClassName]]` with fallbacks
- Single O(n) pass over files, no write operations

## Test plan
- [x] 13 unit tests pass (empty vault, class aggregation, year fallback, cross-tab, error resilience)
- [x] All 1097 CLI unit tests pass (no regressions)
- [ ] CI pipeline green

Closes #2340