### PR TITLE
feat: expand Archgate — Tier 2 rules + complete ADR migration

### DIFF
--- a/.archgate/adrs/ARCH-003-status-workflow.md
+++ b/.archgate/adrs/ARCH-003-status-workflow.md
@@ -1,0 +1,14 @@
+---
+id: ARCH-003
+title: Status Workflow Design
+domain: architecture
+rules: false
+---
+
+# Status Workflow Design
+
+10-state workflow for effort lifecycle: Draft → Backlog → Analysis → Todo → Doing → Done (plus Review, Blocked, Cancelled, Archived). Explicit transitions only.
+
+## References
+
+- [ADR-0003: Status Workflow Design](../../docs/adr/0003-status-workflow-design.md)

--- a/.archgate/adrs/ARCH-004-react-interactive-tables.md
+++ b/.archgate/adrs/ARCH-004-react-interactive-tables.md
@@ -1,0 +1,14 @@
+---
+id: ARCH-004
+title: React for Interactive Tables
+domain: frontend
+rules: false
+---
+
+# React for Interactive Tables
+
+React components over vanilla DOM for complex UIs — sorting, filtering, column visibility toggles.
+
+## References
+
+- [ADR-0004: React for Interactive Tables](../../docs/adr/0004-react-for-interactive-tables.md)

--- a/.archgate/adrs/ARCH-005-effort-voting.md
+++ b/.archgate/adrs/ARCH-005-effort-voting.md
@@ -1,0 +1,14 @@
+---
+id: ARCH-005
+title: Effort Voting System
+domain: architecture
+rules: false
+---
+
+# Effort Voting System
+
+Priority voting via effort signals (votes, reactions) for task prioritization.
+
+## References
+
+- [ADR-0005: Effort Voting System](../../docs/adr/0005-effort-voting-system.md)

--- a/.archgate/adrs/ARCH-007-command-visibility.md
+++ b/.archgate/adrs/ARCH-007-command-visibility.md
@@ -1,0 +1,14 @@
+---
+id: ARCH-007
+title: Command Visibility Strategy
+domain: architecture
+rules: false
+---
+
+# Command Visibility Strategy
+
+Rule-based command visibility tied to asset state — commands appear only when applicable.
+
+## References
+
+- [ADR-0007: Command Visibility Strategy](../../docs/adr/0007-command-visibility-strategy.md)

--- a/.archgate/adrs/QUAL-001-code-quality.md
+++ b/.archgate/adrs/QUAL-001-code-quality.md
@@ -1,0 +1,37 @@
+---
+id: QUAL-001
+title: Code Quality Standards
+domain: backend
+rules: true
+files: ["packages/exocortex/src/**/*.ts"]
+---
+
+# Code Quality Standards
+
+## Context
+
+With multiple AI agents working in parallel, code quality standards must be automatically enforced. Manual code review cannot catch all violations consistently.
+
+## Decision
+
+### DI Injectable Services
+
+All service classes in the core package must use `@injectable()` decorator for DI container management.
+
+### No Console in Core
+
+Core package (`packages/exocortex`) should use structured logging via `ILogger` interface, not direct `console.*` calls. Exceptions: benchmarks, infrastructure logging services.
+
+## Do's and Don'ts
+
+### Do
+
+- Use `@injectable()` on all service classes
+- Use `ILogger` interface for logging in services
+- Keep console usage in infrastructure/CLI adapters only
+
+### Don't
+
+- Create service classes without DI decorators
+- Use `console.log` for debugging in production code
+- Mix logging approaches within same layer

--- a/.archgate/adrs/QUAL-001-code-quality.rules.ts
+++ b/.archgate/adrs/QUAL-001-code-quality.rules.ts
@@ -1,0 +1,79 @@
+/// <reference path="../rules.d.ts" />
+
+// Files where console usage is expected/acceptable
+const CONSOLE_EXCLUDED = [
+  "benchmarks/", // Performance benchmarks
+  "LoggingService.ts", // Logging infrastructure
+  "ApplicationErrorHandler.ts", // Error boundary
+  "TypeRegistry.ts", // DI container registration
+];
+
+export default {
+  rules: {
+    "injectable-services": {
+      description:
+        "Service classes in core package should use @injectable() for DI",
+      severity: "warning",
+      async check(ctx) {
+        const serviceFiles = await ctx.glob(
+          "packages/exocortex/src/services/*.ts",
+        );
+
+        for (const file of serviceFiles) {
+          // Skip index/barrel files
+          if (file.endsWith("index.ts")) continue;
+
+          const content = await ctx.readFile(file);
+
+          // Check if file has a class definition
+          const hasClass = /export\s+class\s+\w+/.test(content);
+          if (!hasClass) continue;
+
+          // Check if it has @injectable()
+          const hasInjectable = /@injectable\(\)/.test(content);
+          if (!hasInjectable) {
+            const classMatch = content.match(
+              /export\s+class\s+(\w+)/,
+            );
+            const className = classMatch ? classMatch[1] : "Unknown";
+
+            ctx.report.warning({
+              message: `Service class ${className} is missing @injectable() decorator`,
+              file,
+              line: 1,
+              fix: `Add @injectable() decorator from tsyringe: import { injectable } from 'tsyringe'; @injectable() export class ${className}`,
+            });
+          }
+        }
+      },
+    },
+
+    "no-console-in-core-services": {
+      description:
+        "Core services should use ILogger, not direct console.* calls",
+      severity: "warning",
+      async check(ctx) {
+        const coreFiles = await ctx.glob(
+          "packages/exocortex/src/services/**/*.ts",
+        );
+
+        for (const file of coreFiles) {
+          if (CONSOLE_EXCLUDED.some((exc) => file.includes(exc))) continue;
+
+          const hits = await ctx.grep(
+            file,
+            /console\.(log|warn|error|info|debug)\(/,
+          );
+          for (const hit of hits) {
+            ctx.report.warning({
+              message: "Core service uses console.* instead of ILogger",
+              file: hit.file,
+              line: hit.line,
+              fix: "Inject ILogger via DI and use this.logger.info/warn/error()",
+            });
+          }
+        }
+      },
+    },
+  },
+} satisfies RuleSet;


### PR DESCRIPTION
## Summary

Expands Archgate governance with Tier 2 quality rules and completes migration of all 10 original ADRs.

## Changes

### New Rules (QUAL-001)

| Rule | Severity | Findings |
|------|----------|----------|
| `injectable-services` | warning | 4 services missing `@injectable()` |
| `no-console-in-core-services` | warning | 10 console.* calls in core services |

Both rules are **warnings** — they annotate PRs but don't block CI. This gives visibility without breaking workflow.

### Complete ADR Migration

All 10 original ADRs from `docs/adr/` are now mirrored in `.archgate/adrs/`:
- ARCH-003: Status Workflow Design
- ARCH-004: React for Interactive Tables
- ARCH-005: Effort Voting System
- ARCH-007: Command Visibility Strategy

### Current Archgate Totals

- **11 ADRs** (4 with executable rules, 7 documentation-only)
- **9 rules** across 4 rule files
- **0 errors** on current codebase
- **14 warnings** identifying real quality issues

## Test plan

- [x] `archgate check` passes (9/9 rules, 0 errors, 14 warnings)
- [x] Warning-only rules don't block CI (severity: warning)
- [ ] CI `archgate` job passes