### PR TITLE
test(cli): add validate command registration tests (#2346)

### DIFF
--- a/packages/cli/tests/unit/commands/validate.test.ts
+++ b/packages/cli/tests/unit/commands/validate.test.ts
@@ -1,54 +1,97 @@
 import { jest } from "@jest/globals";
+import { Command } from "commander";
+
+// Mock CacheManager (transitively depends on exocortex, fs-extra)
+jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
+  CacheManager: jest.fn(() => ({
+    validateVault: jest.fn(() => []),
+  })),
+}));
+
+// Mock exocortex (CacheManager dependency)
+jest.unstable_mockModule("exocortex", () => ({
+  NoteToRDFConverter: jest.fn(),
+  Triple: jest.fn(),
+  IRI: jest.fn(),
+  Literal: jest.fn(),
+  BlankNode: jest.fn(),
+}));
+
+// Mock fs-extra (CacheManager dependency)
+jest.unstable_mockModule("fs-extra", () => ({
+  default: {
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    pathExists: jest.fn(),
+    ensureDir: jest.fn(),
+    stat: jest.fn(),
+    rename: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+const { validateCommand } = await import("../../../src/commands/validate.js");
 
 /**
- * Issue #2205: Tests for exocortex validate command
+ * Issue #2346: Tests for validate CLI command registration
  *
- * Acceptance criteria:
- * - `exocortex validate` command to check vault health
- * - Reports all files with IRI issues
- * - Returns exit code 0 for healthy vault, 1 for issues found
+ * Validates that the Commander.js command is correctly configured with
+ * all required/optional options and proper defaults.
  */
-describe("Issue #2205: validate command", () => {
-  const mockValidateVault = jest.fn();
-  const mockConsoleLog = jest.spyOn(console, "log").mockImplementation();
-  const mockConsoleError = jest.spyOn(console, "error").mockImplementation();
-
-  beforeEach(() => {
-    jest.clearAllMocks();
+describe("Issue #2346: validate command", () => {
+  it("should create a command with name 'validate'", () => {
+    const cmd = validateCommand();
+    expect(cmd).toBeInstanceOf(Command);
+    expect(cmd.name()).toBe("validate");
   });
 
-  afterAll(() => {
-    mockConsoleLog.mockRestore();
-    mockConsoleError.mockRestore();
+  it("should have a description mentioning IRI or vault validation", () => {
+    const cmd = validateCommand();
+    expect(cmd.description()).toBeTruthy();
+    expect(cmd.description().toLowerCase()).toMatch(/iri|valid|check|vault/);
   });
 
-  describe("text output format", () => {
-    it("should report no issues for healthy vault", async () => {
-      // This test verifies the validate command exists and works
-      // Will be implemented alongside the command
-      expect(true).toBe(true);
-    });
-
-    it("should list each file with IRI issues", async () => {
-      // This test verifies detailed file listing
-      expect(true).toBe(true);
-    });
-
-    it("should show summary at end", async () => {
-      // This test verifies summary statistics
-      expect(true).toBe(true);
-    });
+  it("should have optional --vault option with default value", () => {
+    const cmd = validateCommand();
+    const option = cmd.options.find(
+      (opt) => opt.long === "--vault",
+    );
+    expect(option).toBeDefined();
+    expect(option!.mandatory).toBeFalsy();
+    expect(option!.defaultValue).toBeDefined();
   });
 
-  describe("json output format", () => {
-    it("should return structured JSON with issues array", async () => {
-      // This test verifies JSON output format
-      expect(true).toBe(true);
-    });
+  it("should have optional --output option with default 'text'", () => {
+    const cmd = validateCommand();
+    const option = cmd.options.find(
+      (opt) => opt.long === "--output",
+    );
+    expect(option).toBeDefined();
+    expect(option!.mandatory).toBeFalsy();
+    expect(option!.defaultValue).toBe("text");
+  });
 
-    it("should include metadata in JSON response", async () => {
-      // This test verifies JSON metadata
-      expect(true).toBe(true);
-    });
+  it("should register exactly 2 options", () => {
+    const cmd = validateCommand();
+    expect(cmd.options).toHaveLength(2);
+  });
+
+  it("should have --vault option that accepts a path argument", () => {
+    const cmd = validateCommand();
+    const option = cmd.options.find(
+      (opt) => opt.long === "--vault",
+    );
+    expect(option).toBeDefined();
+    // Commander uses '<path>' for required argument on optional option
+    expect(option!.flags).toContain("<path>");
+  });
+
+  it("should have --output option that accepts a type argument", () => {
+    const cmd = validateCommand();
+    const option = cmd.options.find(
+      (opt) => opt.long === "--output",
+    );
+    expect(option).toBeDefined();
+    expect(option!.flags).toContain("<type>");
   });
 });


### PR DESCRIPTION
## Summary
- Replace placeholder tests in `validate.test.ts` with 7 proper command registration tests
- Mock ESM dependencies (`CacheManager`, `exocortex`, `fs-extra`) using `jest.unstable_mockModule()`
- Test command name, description, option count, defaults, and argument types

## Testing
- [x] All 7 new tests pass locally
- [x] Full CLI unit suite passes (65 suites, 1099 tests, 0 failures)
- [x] No regressions

Closes #2346