### PR TITLE
fix(cli): remove unused --json flag from archive command (#2351)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -496,7 +496,6 @@ npx @kitelev/exocortex-cli archive --dry-run \
 - `--year <year>` - Filter by resolution/end timestamp year (e.g. `2025`) **[required for archive mode]**
 - `--dry-run` - Preview without writing files
 - `--no-referenced` - Skip assets that are still referenced by active (non-archived) files **(default behavior)**. Pass `--referenced` to include them anyway.
-- `--json` - Output in JSON format (default: true)
 
 **Exit codes:**
 

--- a/packages/cli/src/commands/archive.ts
+++ b/packages/cli/src/commands/archive.ts
@@ -20,7 +20,6 @@ interface ArchiveCommandOptions {
   year?: string;
   dryRun?: boolean;
   noReferenced?: boolean;
-  json?: boolean;
   verify?: boolean;
   cascade?: boolean;
   stats?: boolean;
@@ -88,7 +87,6 @@ export function archiveCommand(): Command {
       "--no-referenced",
       "Skip assets referenced by non-archived (default: true)",
     )
-    .option("--json", "Output in JSON format (default: true)", true)
     .option(
       "--verify",
       "Verify archive integrity instead of archiving (read-only)",

--- a/packages/cli/tests/unit/commands/archive.test.ts
+++ b/packages/cli/tests/unit/commands/archive.test.ts
@@ -7,7 +7,7 @@ import { Command } from "commander";
  * Acceptance criteria:
  * - Command is registered with correct name and description
  * - Required options: --vault, --archive-vault
- * - Optional options: --class, --year, --dry-run, --no-referenced, --json, --verify, --cascade
+ * - Optional options: --class, --year, --dry-run, --no-referenced, --verify, --cascade
  * - --class and --year are validated at runtime (required for archive, not for verify/cascade)
  */
 describe("Issue #2306: archive command", () => {
@@ -72,14 +72,6 @@ describe("Issue #2306: archive command", () => {
     expect(option!.mandatory).toBeFalsy();
   });
 
-  it("should have optional --json flag", () => {
-    const cmd = archiveCommandFn();
-    const option = cmd.options.find(
-      (opt) => opt.long === "--json",
-    );
-    expect(option).toBeDefined();
-  });
-
   it("should have optional --verify flag", () => {
     const cmd = archiveCommandFn();
     const option = cmd.options.find(
@@ -120,9 +112,9 @@ describe("Issue #2345: archive command dispatch branch tests", () => {
     expect(option).toBeDefined();
   });
 
-  it("should register exactly 10 options total", () => {
+  it("should register exactly 9 options total", () => {
     const cmd = archiveCommandFn();
-    expect(cmd.options).toHaveLength(10);
+    expect(cmd.options).toHaveLength(9);
   });
 
   it("should have --stats as non-mandatory option", () => {
@@ -161,15 +153,6 @@ describe("Issue #2345: archive command dispatch branch tests", () => {
     );
     expect(option).toBeDefined();
     expect(option!.mandatory).toBeFalsy();
-  });
-
-  it("should have --json default value of true", () => {
-    const cmd = archiveCommandFn();
-    const option = cmd.options.find(
-      (opt) => opt.long === "--json",
-    );
-    expect(option).toBeDefined();
-    expect(option!.defaultValue).toBe(true);
   });
 
   it("should have a description mentioning 'archive'", () => {


### PR DESCRIPTION
## Summary
- Remove unused `--json` flag from archive command definition
- Remove `json?: boolean` from `ArchiveCommandOptions` interface
- Remove `--json` from README documentation
- Update tests: remove `--json` tests, fix option count from 10 to 9
- Output remains JSON (was always hardcoded, flag was never checked)

Closes #2351

## Test plan
- [x] `archive.test.ts` passes (16/16 tests)
- [x] No references to `options.json` in archive action handler
- [x] Option count updated from 10 to 9