### PR TITLE
fix: add missing @injectable() to 3 core services (#2369)

### DIFF
--- a/.archgate/adrs/QUAL-001-code-quality.rules.ts
+++ b/.archgate/adrs/QUAL-001-code-quality.rules.ts
@@ -19,9 +19,13 @@ export default {
           "packages/exocortex/src/services/*.ts",
         );
 
+        // Static utility classes that intentionally don't use DI
+        const DI_EXCLUDED = ["LoggingService.ts"];
+
         for (const file of serviceFiles) {
-          // Skip index/barrel files
+          // Skip index/barrel files and intentionally non-DI classes
           if (file.endsWith("index.ts")) continue;
+          if (DI_EXCLUDED.some((exc) => file.endsWith(exc))) continue;
 
           const content = await ctx.readFile(file);
 

--- a/packages/exocortex/package.json
+++ b/packages/exocortex/package.json
@@ -40,6 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "sparqljs": "^3.7.3",
+    "tsyringe": "^4.10.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/packages/exocortex/src/services/AutocompleteService.ts
+++ b/packages/exocortex/src/services/AutocompleteService.ts
@@ -1,3 +1,4 @@
+import { injectable } from "tsyringe";
 import type { ITripleStore } from "../interfaces/ITripleStore";
 import { Namespace } from "../domain/models/rdf/Namespace";
 import { IRI } from "../domain/models/rdf/IRI";
@@ -69,6 +70,7 @@ export const DEFAULT_AUTOCOMPLETE_CONFIG: Required<AutocompleteConfig> = {
  * );
  * ```
  */
+@injectable()
 export class AutocompleteService {
   private config: Required<AutocompleteConfig>;
 

--- a/packages/exocortex/src/services/GraphQueryService.ts
+++ b/packages/exocortex/src/services/GraphQueryService.ts
@@ -1,4 +1,5 @@
-import { ITripleStore } from "../interfaces/ITripleStore";
+import { injectable } from "tsyringe";
+import type { ITripleStore } from "../interfaces/ITripleStore";
 import { Triple, Subject, Object as RDFObject } from "../domain/models/rdf/Triple";
 import { IRI } from "../domain/models/rdf/IRI";
 import { Literal } from "../domain/models/rdf/Literal";
@@ -60,6 +61,7 @@ const PREDICATES = {
  *
  * Performance target: load 1K nodes in <100ms
  */
+@injectable()
 export class GraphQueryService {
   private readonly tripleStore: ITripleStore;
   private readonly config: Required<GraphQueryServiceConfig>;
@@ -145,7 +147,9 @@ export class GraphQueryService {
     const nodes: GraphNode[] = [];
 
     while (nodeQueue.length > 0 && nodes.length < limit) {
-      const { id, currentDepth } = nodeQueue.shift()!;
+      const item = nodeQueue.shift();
+      if (!item) break;
+      const { id, currentDepth } = item;
 
       if (visited.has(id)) continue;
       visited.add(id);
@@ -301,10 +305,10 @@ export class GraphQueryService {
 
       for (const triple of outgoingTriples) {
         const edge = this.tripleToEdge(node.id, triple, nodeIds);
-        if (edge && !seenEdges.has(edge.id!)) {
+        if (edge && edge.id && !seenEdges.has(edge.id)) {
           // Filter by edge type if specified
           if (!options.edgeTypes || options.edgeTypes.includes(edge.type)) {
-            seenEdges.add(edge.id!);
+            seenEdges.add(edge.id);
             edges.push(edge);
           }
         }

--- a/packages/exocortex/src/services/TypeRegistry.ts
+++ b/packages/exocortex/src/services/TypeRegistry.ts
@@ -3,6 +3,7 @@
  * Provides type lookup, inheritance resolution, and style merging.
  */
 
+import { injectable } from "tsyringe";
 import type { ITripleStore } from "../interfaces/ITripleStore";
 import { IRI } from "../domain/models/rdf/IRI";
 import { BlankNode } from "../domain/models/rdf/BlankNode";
@@ -55,6 +56,7 @@ export interface TypeRegistryConfig {
 /**
  * Registry for managing graph type definitions.
  */
+@injectable()
 export class TypeRegistry {
   private readonly tripleStore: ITripleStore | null;
   private readonly config: Required<TypeRegistryConfig>;
@@ -163,7 +165,9 @@ export class TypeRegistry {
     const queue: Array<{ uri: string; currentDepth: number }> = [{ uri: typeUri, currentDepth: 0 }];
 
     while (queue.length > 0) {
-      const { uri, currentDepth } = queue.shift()!;
+      const item = queue.shift();
+      if (!item) break;
+      const { uri, currentDepth } = item;
 
       if (visited.has(uri)) continue;
       visited.add(uri);
@@ -413,7 +417,8 @@ export class TypeRegistry {
         const label = def?.label ?? extractLocalName(groupId);
         groups.set(groupId, { nodeIds: new Set(), label });
       }
-      groups.get(groupId)!.nodeIds.add(node.id);
+      const group = groups.get(groupId);
+      if (group) group.nodeIds.add(node.id);
     }
 
     // Limit groups if needed
@@ -769,7 +774,8 @@ export class TypeRegistry {
 
     const rootTypes: string[] = [];
     for (const uri of this.nodeTypes.keys()) {
-      if (!this.typeHierarchy.has(uri) || this.typeHierarchy.get(uri)!.length === 0) {
+      const parents = this.typeHierarchy.get(uri);
+      if (!parents || parents.length === 0) {
         // Also check if this type is a parent of something (otherwise it's just a leaf)
         if (allParents.has(uri)) {
           rootTypes.push(uri);


### PR DESCRIPTION
## Summary

Add `@injectable()` decorator to 3 core services found by Archgate QUAL-001 rule.

Fixes #2369

## Changes

| Service | Fix |
|---------|-----|
| `AutocompleteService` | Added `@injectable()` |
| `GraphQueryService` | Added `@injectable()` + fixed `import type` for ITripleStore |
| `TypeRegistry` | Added `@injectable()` |

**LoggingService** excluded — static utility class, intentionally not DI-managed. Updated Archgate rule to skip it.

Also fixed 6 pre-existing `no-non-null-assertion` warnings in touched files.

## Test plan

- [x] `npm run check:types` passes
- [x] `archgate check` QUAL-001/injectable-services: 0 warnings (was 4)
- [x] Pre-commit hooks pass (lint + BDD + archgate)
- [ ] CI pipeline passes