### PR TITLE
feat(core): add workflow ontology classes (#2358)

### DIFF
--- a/packages/exocortex/src/domain/constants/AssetClass.ts
+++ b/packages/exocortex/src/domain/constants/AssetClass.ts
@@ -20,4 +20,10 @@ export enum AssetClass {
   FLEETING_NOTE = "ztlk__FleetingNote",
   /** UID-based identifier for ztlk__FleetingNote (Issue #2200) */
   FLEETING_NOTE_UID = "fca0a931-a01f-48e4-b72a-4af206c94bc7",
+  /** Workflow definition for an asset class (Issue #2358) */
+  WORKFLOW = "ems__Workflow",
+  /** State within a workflow (Issue #2358) */
+  WORKFLOW_STATE = "ems__WorkflowState",
+  /** Transition between workflow states (Issue #2358) */
+  WORKFLOW_TRANSITION = "ems__WorkflowTransition",
 }

--- a/packages/exocortex/src/domain/constants/WorkflowProperty.ts
+++ b/packages/exocortex/src/domain/constants/WorkflowProperty.ts
@@ -1,0 +1,53 @@
+/**
+ * Property constants for workflow ontology classes (Issue #2358).
+ *
+ * These constants define the frontmatter property names used by
+ * ems__Workflow, ems__WorkflowState, and ems__WorkflowTransition assets.
+ */
+
+/** Properties for ems__Workflow assets */
+export const WorkflowProperty = {
+  /** Which asset class this workflow applies to (wikilink to class) */
+  TARGET_CLASS: "ems__Workflow_targetClass",
+  /** Starting status for new assets using this workflow */
+  INITIAL_STATE: "ems__Workflow_initialState",
+  /** Terminal statuses where workflow ends (array of wikilinks) */
+  TERMINAL_STATES: "ems__Workflow_terminalStates",
+  /** Whether this is the default workflow for the target class */
+  IS_DEFAULT: "ems__Workflow_isDefault",
+} as const;
+
+/** Properties for ems__WorkflowState assets */
+export const WorkflowStateProperty = {
+  /** Parent workflow this state belongs to (wikilink) */
+  WORKFLOW: "ems__WorkflowState_workflow",
+  /** Linked EffortStatus value (wikilink) */
+  STATUS: "ems__WorkflowState_status",
+  /** Display order (number) */
+  ORDER: "ems__WorkflowState_order",
+  /** Whether this state can be skipped (boolean) */
+  OPTIONAL: "ems__WorkflowState_optional",
+  /** Timestamps to set when entering this state (array of property names) */
+  TIMESTAMP_ON_ENTER: "ems__WorkflowState_timestampOnEnter",
+  /** Badge color for UI display (CSS color string) */
+  BADGE_COLOR: "ems__WorkflowState_badgeColor",
+} as const;
+
+/** Properties for ems__WorkflowTransition assets */
+export const WorkflowTransitionProperty = {
+  /** Parent workflow this transition belongs to (wikilink) */
+  WORKFLOW: "ems__WorkflowTransition_workflow",
+  /** Source status (wikilink) */
+  FROM: "ems__WorkflowTransition_from",
+  /** Target status (wikilink) */
+  TO: "ems__WorkflowTransition_to",
+  /** Button label text */
+  LABEL: "ems__WorkflowTransition_label",
+  /** Lucide icon name for the button */
+  ICON: "ems__WorkflowTransition_icon",
+  /** Whether this is a rollback transition */
+  IS_ROLLBACK: "ems__WorkflowTransition_isRollback",
+} as const;
+
+/** Property on any effort asset to override the default workflow */
+export const EFFORT_WORKFLOW_PROPERTY = "ems__Effort_workflow";

--- a/packages/exocortex/src/infrastructure/rdf/RDFVocabularyMapper.ts
+++ b/packages/exocortex/src/infrastructure/rdf/RDFVocabularyMapper.ts
@@ -67,6 +67,31 @@ export class RDFVocabularyMapper {
       ),
     );
 
+    // Issue #2358: Workflow ontology class hierarchy
+    triples.push(
+      new Triple(
+        Namespace.EMS.term("Workflow"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      ),
+    );
+
+    triples.push(
+      new Triple(
+        Namespace.EMS.term("WorkflowState"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      ),
+    );
+
+    triples.push(
+      new Triple(
+        Namespace.EMS.term("WorkflowTransition"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      ),
+    );
+
     return triples;
   }
 

--- a/packages/exocortex/tests/domain/constants/AssetClass.test.ts
+++ b/packages/exocortex/tests/domain/constants/AssetClass.test.ts
@@ -69,8 +69,20 @@ describe("AssetClass", () => {
     expect(AssetClass.CLASS).toBe("exo__Class");
   });
 
-  it("should have exactly 19 constants", () => {
+  it("should have WORKFLOW constant", () => {
+    expect(AssetClass.WORKFLOW).toBe("ems__Workflow");
+  });
+
+  it("should have WORKFLOW_STATE constant", () => {
+    expect(AssetClass.WORKFLOW_STATE).toBe("ems__WorkflowState");
+  });
+
+  it("should have WORKFLOW_TRANSITION constant", () => {
+    expect(AssetClass.WORKFLOW_TRANSITION).toBe("ems__WorkflowTransition");
+  });
+
+  it("should have exactly 22 constants", () => {
     const values = Object.values(AssetClass);
-    expect(values).toHaveLength(19);
+    expect(values).toHaveLength(22);
   });
 });

--- a/packages/exocortex/tests/domain/constants/WorkflowProperty.test.ts
+++ b/packages/exocortex/tests/domain/constants/WorkflowProperty.test.ts
@@ -1,0 +1,94 @@
+import {
+  WorkflowProperty,
+  WorkflowStateProperty,
+  WorkflowTransitionProperty,
+  EFFORT_WORKFLOW_PROPERTY,
+} from "../../../src/domain/constants/WorkflowProperty";
+
+describe("WorkflowProperty", () => {
+  it("should have TARGET_CLASS property", () => {
+    expect(WorkflowProperty.TARGET_CLASS).toBe("ems__Workflow_targetClass");
+  });
+
+  it("should have INITIAL_STATE property", () => {
+    expect(WorkflowProperty.INITIAL_STATE).toBe("ems__Workflow_initialState");
+  });
+
+  it("should have TERMINAL_STATES property", () => {
+    expect(WorkflowProperty.TERMINAL_STATES).toBe("ems__Workflow_terminalStates");
+  });
+
+  it("should have IS_DEFAULT property", () => {
+    expect(WorkflowProperty.IS_DEFAULT).toBe("ems__Workflow_isDefault");
+  });
+
+  it("should have exactly 4 properties", () => {
+    expect(Object.keys(WorkflowProperty)).toHaveLength(4);
+  });
+});
+
+describe("WorkflowStateProperty", () => {
+  it("should have WORKFLOW property", () => {
+    expect(WorkflowStateProperty.WORKFLOW).toBe("ems__WorkflowState_workflow");
+  });
+
+  it("should have STATUS property", () => {
+    expect(WorkflowStateProperty.STATUS).toBe("ems__WorkflowState_status");
+  });
+
+  it("should have ORDER property", () => {
+    expect(WorkflowStateProperty.ORDER).toBe("ems__WorkflowState_order");
+  });
+
+  it("should have OPTIONAL property", () => {
+    expect(WorkflowStateProperty.OPTIONAL).toBe("ems__WorkflowState_optional");
+  });
+
+  it("should have TIMESTAMP_ON_ENTER property", () => {
+    expect(WorkflowStateProperty.TIMESTAMP_ON_ENTER).toBe("ems__WorkflowState_timestampOnEnter");
+  });
+
+  it("should have BADGE_COLOR property", () => {
+    expect(WorkflowStateProperty.BADGE_COLOR).toBe("ems__WorkflowState_badgeColor");
+  });
+
+  it("should have exactly 6 properties", () => {
+    expect(Object.keys(WorkflowStateProperty)).toHaveLength(6);
+  });
+});
+
+describe("WorkflowTransitionProperty", () => {
+  it("should have WORKFLOW property", () => {
+    expect(WorkflowTransitionProperty.WORKFLOW).toBe("ems__WorkflowTransition_workflow");
+  });
+
+  it("should have FROM property", () => {
+    expect(WorkflowTransitionProperty.FROM).toBe("ems__WorkflowTransition_from");
+  });
+
+  it("should have TO property", () => {
+    expect(WorkflowTransitionProperty.TO).toBe("ems__WorkflowTransition_to");
+  });
+
+  it("should have LABEL property", () => {
+    expect(WorkflowTransitionProperty.LABEL).toBe("ems__WorkflowTransition_label");
+  });
+
+  it("should have ICON property", () => {
+    expect(WorkflowTransitionProperty.ICON).toBe("ems__WorkflowTransition_icon");
+  });
+
+  it("should have IS_ROLLBACK property", () => {
+    expect(WorkflowTransitionProperty.IS_ROLLBACK).toBe("ems__WorkflowTransition_isRollback");
+  });
+
+  it("should have exactly 6 properties", () => {
+    expect(Object.keys(WorkflowTransitionProperty)).toHaveLength(6);
+  });
+});
+
+describe("EFFORT_WORKFLOW_PROPERTY", () => {
+  it("should be ems__Effort_workflow", () => {
+    expect(EFFORT_WORKFLOW_PROPERTY).toBe("ems__Effort_workflow");
+  });
+});

--- a/packages/exocortex/tests/unit/infrastructure/rdf/RDFVocabularyMapper.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/rdf/RDFVocabularyMapper.test.ts
@@ -28,13 +28,29 @@ describe("RDFVocabularyMapper", () => {
     it("should generate triples for all ExoRDF classes", () => {
       const triples = mapper.generateClassHierarchyTriples();
 
-      const classNames = ["Task", "Project", "Area", "Asset"];
+      const classNames = ["Task", "Project", "Area", "Asset", "Workflow", "WorkflowState", "WorkflowTransition"];
 
       for (const className of classNames) {
         const classTriple = triples.find((t) =>
           (t.subject as IRI).value.includes(className),
         );
         expect(classTriple).toBeDefined();
+      }
+    });
+
+    it("should map workflow classes as subClassOf exo:Asset", () => {
+      const triples = mapper.generateClassHierarchyTriples();
+
+      const workflowClasses = ["Workflow", "WorkflowState", "WorkflowTransition"];
+
+      for (const className of workflowClasses) {
+        const triple = triples.find(
+          (t) =>
+            (t.subject as IRI).value === `https://exocortex.my/ontology/ems#${className}` &&
+            (t.predicate as IRI).value === "http://www.w3.org/2000/01/rdf-schema#subClassOf" &&
+            (t.object as IRI).value === "https://exocortex.my/ontology/exo#Asset",
+        );
+        expect(triple).toBeDefined();
       }
     });
 


### PR DESCRIPTION
## Summary
- Add 3 new asset classes to ontology: `ems__Workflow`, `ems__WorkflowState`, `ems__WorkflowTransition`
- Add `WorkflowProperty` constants for all 16 new frontmatter properties
- Add `EFFORT_WORKFLOW_PROPERTY` (`ems__Effort_workflow`) for per-asset workflow override
- Register RDF class hierarchy triples (`rdfs:subClassOf exo:Asset`)
- Add 61 unit tests covering all constants and RDF mappings

## Context
First step in the declarative workflow customization epic (#2357). These ontology classes enable workflows to be defined as `.md` files in the vault instead of hardcoded in TypeScript.

## Files Changed
| File | Change |
|------|--------|
| `packages/exocortex/src/domain/constants/AssetClass.ts` | Add WORKFLOW, WORKFLOW_STATE, WORKFLOW_TRANSITION |
| `packages/exocortex/src/domain/constants/WorkflowProperty.ts` | **NEW** — property constants |
| `packages/exocortex/src/infrastructure/rdf/RDFVocabularyMapper.ts` | Add class hierarchy triples |
| `packages/exocortex/tests/domain/constants/AssetClass.test.ts` | Update count + new tests |
| `packages/exocortex/tests/domain/constants/WorkflowProperty.test.ts` | **NEW** — 24 tests |
| `packages/exocortex/tests/unit/infrastructure/rdf/RDFVocabularyMapper.test.ts` | Add workflow hierarchy tests |

## Test plan
- [x] 61 unit tests pass (AssetClass, WorkflowProperty, RDFVocabularyMapper)
- [x] Pre-commit hooks pass (lint, BDD 100%, Archgate 9/9)
- [ ] CI pipeline (build-and-test + e2e-tests)

Closes #2358