### PR TITLE
fix: replace console.* with ILogger in 3 core services (#2370)

### DIFF
--- a/.archgate/adrs/QUAL-001-code-quality.rules.ts
+++ b/.archgate/adrs/QUAL-001-code-quality.rules.ts
@@ -69,6 +69,10 @@ export default {
             /console\.(log|warn|error|info|debug)\(/,
           );
           for (const hit of hits) {
+            // Skip console calls inside JSDoc/comment blocks (code examples)
+            const trimmed = hit.content.trim();
+            if (trimmed.startsWith("*") || trimmed.startsWith("//")) continue;
+
             ctx.report.warning({
               message: "Core service uses console.* instead of ILogger",
               file: hit.file,

--- a/packages/exocortex/src/services/GraphQueryService.ts
+++ b/packages/exocortex/src/services/GraphQueryService.ts
@@ -1,5 +1,6 @@
 import { injectable } from "tsyringe";
 import type { ITripleStore } from "../interfaces/ITripleStore";
+import type { ILogger } from "../interfaces/ILogger";
 import { Triple, Subject, Object as RDFObject } from "../domain/models/rdf/Triple";
 import { IRI } from "../domain/models/rdf/IRI";
 import { Literal } from "../domain/models/rdf/Literal";
@@ -68,9 +69,11 @@ export class GraphQueryService {
   private readonly subscribers: Set<GraphChangeCallback> = new Set();
   private nodeCache: Map<string, GraphNodeData> = new Map();
   private lastCacheUpdate: number = 0;
+  private readonly logger?: ILogger;
 
-  constructor(tripleStore: ITripleStore, config: GraphQueryServiceConfig = {}) {
+  constructor(tripleStore: ITripleStore, config: GraphQueryServiceConfig = {}, logger?: ILogger) {
     this.tripleStore = tripleStore;
+    this.logger = logger;
     this.config = {
       defaultLimit: config.defaultLimit ?? 100,
       maxLimit: config.maxLimit ?? 10000,
@@ -94,7 +97,7 @@ export class GraphQueryService {
 
     const loadTime = Date.now() - startTime;
     if (loadTime > 100 && nodes.length > 0) {
-      console.debug(`GraphQueryService: loaded ${nodes.length} nodes in ${loadTime}ms (${(loadTime / nodes.length).toFixed(2)}ms/node)`);
+      this.logger?.debug(`GraphQueryService: loaded ${nodes.length} nodes in ${loadTime}ms (${(loadTime / nodes.length).toFixed(2)}ms/node)`);
     }
 
     return {
@@ -224,7 +227,7 @@ export class GraphQueryService {
       try {
         callback(event);
       } catch (error) {
-        console.error("GraphQueryService: error in subscriber callback", error);
+        this.logger?.error("GraphQueryService: error in subscriber callback", error instanceof Error ? error : new Error(String(error)));
       }
     }
     // Invalidate cache on changes

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -1,5 +1,6 @@
 import { injectable, inject } from "tsyringe";
 import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import type { ILogger } from "../interfaces/ILogger";
 import { Triple } from "../domain/models/rdf/Triple";
 import { IRI } from "../domain/models/rdf/IRI";
 import { Literal } from "../domain/models/rdf/Literal";
@@ -39,6 +40,7 @@ export class NoteToRDFConverter {
 
   constructor(
     @inject(DI_TOKENS.IVaultAdapter) private readonly vault: IVaultAdapter,
+    @inject(DI_TOKENS.ILogger) private readonly logger: ILogger,
   ) {
     this.vocabularyMapper = new RDFVocabularyMapper();
   }
@@ -499,8 +501,7 @@ export class NoteToRDFConverter {
         });
 
         // Issue #684: Skip files with invalid IRIs instead of crashing
-        console.warn(`⚠️ Skipping file with invalid IRI: ${file.path}`);
-        console.warn(`   Reason: ${reason}`);
+        this.logger.warn(`Skipping file with invalid IRI: ${file.path}`, { reason });
       }
     }
 
@@ -608,7 +609,7 @@ export class NoteToRDFConverter {
    * @returns Array of RDF objects (IRI or Literal). UUID wikilinks return [IRI, Literal].
    */
   private async valueToRDFObject(
-    value: any,
+    value: unknown,
     sourceFile: IFile
   ): Promise<(IRI | Literal)[]> {
     if (typeof value === "string") {
@@ -734,7 +735,7 @@ export class NoteToRDFConverter {
    * valueToClassURI("[[SomeNote]]")   // → Literal("[[SomeNote]]") (not a class reference)
    * ```
    */
-  private valueToClassURI(value: any): IRI | Literal {
+  private valueToClassURI(value: unknown): IRI | Literal {
     if (typeof value !== "string") {
       return new Literal(String(value));
     }

--- a/packages/exocortex/src/services/URIConstructionService.ts
+++ b/packages/exocortex/src/services/URIConstructionService.ts
@@ -1,5 +1,6 @@
 import { injectable, inject } from "tsyringe";
 import type { IFileSystemAdapter } from "../interfaces/IFileSystemAdapter";
+import type { ILogger } from "../interfaces/ILogger";
 import { DI_TOKENS } from "../interfaces/tokens";
 
 export interface URIConstructionOptions {
@@ -9,7 +10,7 @@ export interface URIConstructionOptions {
 
 export interface AssetMetadata {
   path: string;
-  frontmatter?: Record<string, any>;
+  frontmatter?: Record<string, unknown>;
 }
 
 @injectable()
@@ -19,6 +20,7 @@ export class URIConstructionService {
 
   constructor(
     @inject(DI_TOKENS.IFileSystemAdapter) private readonly fileSystem: IFileSystemAdapter,
+    @inject(DI_TOKENS.ILogger) private readonly logger: ILogger,
   ) {}
 
   configure(options?: URIConstructionOptions): void {
@@ -36,9 +38,7 @@ export class URIConstructionService {
       if (this.strictValidation) {
         throw new Error(`Asset missing exo__Asset_uid: ${asset.path}`);
       }
-      console.warn(
-        `Asset ${asset.path} missing UID, using filename fallback`,
-      );
+      this.logger.warn(`Asset ${asset.path} missing UID, using filename fallback`);
       return this.constructFallbackURI(asset);
     }
 
@@ -82,9 +82,7 @@ export class URIConstructionService {
     }
 
     if (!fileExists) {
-      console.warn(
-        `Ontology file not found: ${ontologyPath}, using default`,
-      );
+      this.logger.warn(`Ontology file not found: ${ontologyPath}, using default`);
       return this.defaultOntologyURL;
     }
 

--- a/packages/obsidian-plugin/src/application/processors/SPARQLCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/SPARQLCodeBlockProcessor.ts
@@ -379,7 +379,7 @@ export class SPARQLCodeBlockProcessor {
         this.plugin.app.metadataCache,
         this.plugin.app
       );
-      const converter = new NoteToRDFConverter(vaultAdapter);
+      const converter = new NoteToRDFConverter(vaultAdapter, LoggerFactory.create("NoteToRDFConverter"));
       const triples = await converter.convertVault();
 
       this.tripleStore = new InMemoryTripleStore();

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -33,7 +33,7 @@ export class VaultRDFIndexer {
       app.metadataCache,
       app
     );
-    this.converter = new NoteToRDFConverter(this.vaultAdapter);
+    this.converter = new NoteToRDFConverter(this.vaultAdapter, logger || LoggerFactory.create("NoteToRDFConverter"));
 
     const defaultLogger = LoggerFactory.create("VaultRDFIndexer");
     this.logger = logger || {


### PR DESCRIPTION
## Summary

Replace 6 direct `console.*` calls with structured `ILogger` in core services, as found by Archgate QUAL-001 rule.

Fixes #2370

## Changes

| Service | Before | After |
|---------|--------|-------|
| `GraphQueryService` | `console.debug`, `console.error` | `this.logger?.debug`, `this.logger?.error` |
| `NoteToRDFConverter` | 2x `console.warn` | `this.logger.warn` with context |
| `URIConstructionService` | 2x `console.warn` | `this.logger.warn` |

Call sites updated:
- `SPARQLCodeBlockProcessor` — pass `LoggerFactory.create()` to converter
- `VaultRDFIndexer` — pass logger to converter

Archgate rule updated to skip JSDoc code examples (4 false positives eliminated).

## Result

Archgate QUAL-001: **0 errors, 0 warnings** (was 14 warnings before #2369 + #2370)

## Test plan

- [x] `npm run check:types` passes
- [x] `archgate check` — 9/9 pass, 0 warnings
- [x] Pre-commit hooks pass
- [ ] CI pipeline passes