### PR TITLE
feat: add Tier 3 Archgate rules — React, errors, imports

### DIFF
--- a/.archgate/adrs/ERROR-001-error-handling.md
+++ b/.archgate/adrs/ERROR-001-error-handling.md
@@ -1,0 +1,31 @@
+---
+id: ERROR-001
+title: Error Handling Standards
+domain: backend
+rules: true
+files: ["packages/*/src/**/*.ts"]
+---
+
+# Error Handling Standards
+
+## Context
+
+Swallowed errors (empty catch blocks) hide bugs and make debugging impossible. All errors must be logged or rethrown.
+
+## Decision
+
+- No empty catch blocks — every catch must log, rethrow, or explicitly handle
+- Error parameters should be properly typed
+
+## Do's and Don'ts
+
+### Do
+
+- Log errors: `catch(e) { this.logger.error("...", e); }`
+- Rethrow: `catch(e) { throw new ServiceError("...", e); }`
+- Handle explicitly: `catch(e) { return fallbackValue; }`
+
+### Don't
+
+- Swallow errors: `catch(e) { }` or `catch { }`
+- Ignore without comment: `catch(e) { /* TODO */ }`

--- a/.archgate/adrs/ERROR-001-error-handling.rules.ts
+++ b/.archgate/adrs/ERROR-001-error-handling.rules.ts
@@ -1,0 +1,35 @@
+/// <reference path="../rules.d.ts" />
+export default {
+  rules: {
+    "no-empty-catch": {
+      description:
+        "Catch blocks must not be completely empty — log, rethrow, or handle explicitly",
+      severity: "warning",
+      async check(ctx) {
+        // Only check production source, not tests or benchmarks
+        const patterns = [
+          "packages/*/src/**/*.ts",
+          "packages/*/src/**/*.tsx",
+        ];
+
+        for (const pattern of patterns) {
+          const hits = await ctx.grepFiles(
+            /catch\s*(\([^)]*\))?\s*\{\s*\}/,
+            pattern,
+          );
+          for (const hit of hits) {
+            // Skip test files
+            if (hit.file.includes("/tests/") || hit.file.includes(".test.") || hit.file.includes(".spec.")) continue;
+
+            ctx.report.warning({
+              message: "Empty catch block — errors should be logged, rethrown, or explicitly handled",
+              file: hit.file,
+              line: hit.line,
+              fix: "Add: logger.error(...), throw, or return fallback value",
+            });
+          }
+        }
+      },
+    },
+  },
+} satisfies RuleSet;

--- a/.archgate/adrs/IMPORT-001-obsidian-containment.md
+++ b/.archgate/adrs/IMPORT-001-obsidian-containment.md
@@ -1,0 +1,34 @@
+---
+id: IMPORT-001
+title: Obsidian API Containment
+domain: frontend
+rules: true
+files:
+  [
+    "packages/obsidian-plugin/src/**/*.ts",
+    "packages/obsidian-plugin/src/**/*.tsx",
+  ]
+---
+
+# Obsidian API Containment
+
+## Context
+
+Obsidian API imports must be contained in presentation and infrastructure layers. Application and domain layers in the plugin package must remain framework-agnostic.
+
+This complements ARCH-008 (which protects packages/exocortex) by protecting layers within the obsidian-plugin package itself.
+
+## Decision
+
+- `import from "obsidian"` allowed ONLY in:
+  - `packages/obsidian-plugin/src/presentation/` (UI components, modals, renderers)
+  - `packages/obsidian-plugin/src/infrastructure/` (adapters)
+  - `packages/obsidian-plugin/src/main.ts` (plugin entry point)
+- Forbidden in:
+  - `packages/obsidian-plugin/src/application/` (use cases)
+  - `packages/obsidian-plugin/src/domain/` (business rules)
+
+## References
+
+- [ADR-0008: Clean Architecture](../../docs/adr/0008-clean-architecture-adoption.md)
+- ARCH-008 Archgate rules (core package protection)

--- a/.archgate/adrs/IMPORT-001-obsidian-containment.rules.ts
+++ b/.archgate/adrs/IMPORT-001-obsidian-containment.rules.ts
@@ -1,0 +1,61 @@
+/// <reference path="../rules.d.ts" />
+export default {
+  rules: {
+    "no-obsidian-in-plugin-application": {
+      description:
+        "Plugin application layer should minimize obsidian runtime imports — prefer DI interfaces",
+      severity: "warning",
+      async check(ctx) {
+        const appFiles = await ctx.glob(
+          "packages/obsidian-plugin/src/application/**/*.ts",
+        );
+
+        for (const file of appFiles) {
+          const hits = await ctx.grep(file, /from\s+['"]obsidian['"]/);
+          for (const hit of hits) {
+            const content = await ctx.readFile(hit.file);
+            const line = content.split("\n")[hit.line - 1] || "";
+            // Allow type-only imports (no runtime dependency)
+            if (line.includes("import type")) continue;
+
+            ctx.report.warning({
+              message:
+                "Plugin application layer imports obsidian runtime. Consider using DI interfaces.",
+              file: hit.file,
+              line: hit.line,
+              fix: "Use interface from exocortex package or import type instead of runtime import",
+            });
+          }
+        }
+      },
+    },
+
+    "no-obsidian-in-plugin-domain": {
+      description:
+        "Plugin domain layer must not import obsidian runtime",
+      severity: "warning",
+      async check(ctx) {
+        const domainFiles = await ctx.glob(
+          "packages/obsidian-plugin/src/domain/**/*.ts",
+        );
+
+        for (const file of domainFiles) {
+          const hits = await ctx.grep(file, /from\s+['"]obsidian['"]/);
+          for (const hit of hits) {
+            const content = await ctx.readFile(hit.file);
+            const line = content.split("\n")[hit.line - 1] || "";
+            if (line.includes("import type")) continue;
+
+            ctx.report.warning({
+              message:
+                "Plugin domain layer imports obsidian runtime. Domain must be framework-agnostic.",
+              file: hit.file,
+              line: hit.line,
+              fix: "Move obsidian dependency to infrastructure adapter. Domain must be pure.",
+            });
+          }
+        }
+      },
+    },
+  },
+} satisfies RuleSet;

--- a/.archgate/adrs/REACT-001-component-standards.md
+++ b/.archgate/adrs/REACT-001-component-standards.md
@@ -1,0 +1,34 @@
+---
+id: REACT-001
+title: React Component Standards
+domain: frontend
+rules: true
+files: ["packages/obsidian-plugin/src/presentation/**/*.tsx"]
+---
+
+# React Component Standards
+
+## Context
+
+Exocortex uses React 19 for interactive UI. With multiple AI agents generating code, component conventions must be enforced automatically.
+
+## Decision
+
+- All React components must be **functional** (no class components except ErrorBoundary)
+- ErrorBoundary is the only justified exception (React API requires class for error boundaries)
+
+## Do's and Don'ts
+
+### Do
+
+- Use functional components with hooks
+- Use React.FC<Props> for typing
+
+### Don't
+
+- Create class components (use functional + hooks instead)
+- Use class-based lifecycle methods
+
+## References
+
+- [ADR-0004: React for Interactive Tables](../../docs/adr/0004-react-for-interactive-tables.md)

--- a/.archgate/adrs/REACT-001-component-standards.rules.ts
+++ b/.archgate/adrs/REACT-001-component-standards.rules.ts
@@ -1,0 +1,27 @@
+/// <reference path="../rules.d.ts" />
+export default {
+  rules: {
+    "no-class-components": {
+      description:
+        "React components must be functional — no class components except ErrorBoundary",
+      severity: "error",
+      async check(ctx) {
+        const hits = await ctx.grepFiles(
+          /class\s+\w+\s+extends\s+(React\.)?(Component|PureComponent)/,
+          "packages/obsidian-plugin/src/presentation/**/*.tsx",
+        );
+        for (const hit of hits) {
+          if (hit.file.includes("ErrorBoundary")) continue;
+
+          ctx.report.violation({
+            message:
+              "Class component detected. Use functional component with hooks instead.",
+            file: hit.file,
+            line: hit.line,
+            fix: "Convert to functional component: const MyComponent: React.FC<Props> = (props) => { ... }",
+          });
+        }
+      },
+    },
+  },
+} satisfies RuleSet;


### PR DESCRIPTION
## Summary

Add Tier 3 Archgate rules for React component standards, error handling, and Obsidian API containment.

## New Rules (4)

| ADR | Rule | Severity | Findings |
|-----|------|----------|----------|
| REACT-001 | `no-class-components` | error | 0 (clean) |
| ERROR-001 | `no-empty-catch` | warning | 0 (clean) |
| IMPORT-001 | `no-obsidian-in-plugin-application` | warning | 46 (arch debt) |
| IMPORT-001 | `no-obsidian-in-plugin-domain` | warning | 1 (PrintNameRuleService) |

## Design Decisions

- **REACT-001** as `error`: class components are never acceptable (except ErrorBoundary)
- **IMPORT-001** as `warning`: 46 obsidian imports in application layer is architectural debt, not a blocking issue. Visibility through annotations enables gradual migration.
- **ERROR-001** uses simple regex `catch { }` instead of AST — catches empty catch blocks without false positives on multiline handlers

## Archgate Totals

- **14 ADRs**, **13 rules** across 7 rule files
- **0 errors**, **48 warnings** on current codebase

## Test plan

- [x] `archgate check` — 13/13 pass, 0 errors
- [x] Pre-commit hooks pass (lint + BDD + archgate)
- [ ] CI pipeline passes