### PR TITLE
feat(core): add default workflow templates (#2363)

### DIFF
--- a/packages/exocortex/src/domain/defaults/DefaultWorkflows.ts
+++ b/packages/exocortex/src/domain/defaults/DefaultWorkflows.ts
@@ -1,0 +1,164 @@
+import { v4 as uuidv4 } from "uuid";
+import { AssetClass } from "../constants/AssetClass";
+import { EffortStatus } from "../constants/EffortStatus";
+import type { WorkflowDefinition } from "../models/WorkflowDefinition";
+import {
+  WorkflowProperty,
+  WorkflowStateProperty,
+  WorkflowTransitionProperty,
+} from "../constants/WorkflowProperty";
+import { MetadataHelpers } from "../../utilities/MetadataHelpers";
+
+/**
+ * Default workflow definition for ems__Project assets.
+ *
+ * States: Draft -> Backlog -> Analysis -> ToDo -> Doing -> Done | Trashed
+ * Issue #2363
+ */
+export const PROJECT_DEFAULT_WORKFLOW: WorkflowDefinition = {
+  id: "a1b2c3d4-1111-4000-a000-000000000001",
+  name: "Project Default Workflow",
+  targetClass: AssetClass.PROJECT,
+  initialState: EffortStatus.DRAFT,
+  terminalStates: [EffortStatus.DONE, EffortStatus.TRASHED],
+  isDefault: true,
+  states: [
+    { status: EffortStatus.DRAFT, order: 1, optional: false, timestampOnEnter: [] },
+    { status: EffortStatus.BACKLOG, order: 2, optional: false, timestampOnEnter: [] },
+    { status: EffortStatus.ANALYSIS, order: 3, optional: true, timestampOnEnter: [] },
+    { status: EffortStatus.TODO, order: 4, optional: true, timestampOnEnter: [] },
+    { status: EffortStatus.DOING, order: 5, optional: false, timestampOnEnter: ["ems__Effort_startTimestamp"] },
+    { status: EffortStatus.DONE, order: 6, optional: false, timestampOnEnter: ["ems__Effort_endTimestamp", "ems__Effort_resolutionTimestamp"] },
+    { status: EffortStatus.TRASHED, order: 7, optional: false, timestampOnEnter: ["ems__Effort_resolutionTimestamp"] },
+  ],
+  transitions: [
+    { from: EffortStatus.DRAFT, to: EffortStatus.BACKLOG, label: "\u2192 Backlog", isRollback: false },
+    { from: EffortStatus.BACKLOG, to: EffortStatus.ANALYSIS, label: "\u2192 Analysis", isRollback: false },
+    { from: EffortStatus.ANALYSIS, to: EffortStatus.TODO, label: "\u2192 ToDo", isRollback: false },
+    { from: EffortStatus.TODO, to: EffortStatus.DOING, label: "\u25B6 Start", isRollback: false },
+    { from: EffortStatus.DOING, to: EffortStatus.DONE, label: "\u2713 Done", isRollback: false },
+    { from: EffortStatus.BACKLOG, to: EffortStatus.DRAFT, label: "\u2190 Draft", isRollback: true },
+    { from: EffortStatus.ANALYSIS, to: EffortStatus.BACKLOG, label: "\u2190 Backlog", isRollback: true },
+    { from: EffortStatus.TODO, to: EffortStatus.ANALYSIS, label: "\u2190 Analysis", isRollback: true },
+    { from: EffortStatus.DOING, to: EffortStatus.TODO, label: "\u2190 ToDo", isRollback: true },
+    { from: EffortStatus.DONE, to: EffortStatus.DOING, label: "\u2190 Doing", isRollback: true },
+  ],
+};
+
+/**
+ * Default workflow definition for ems__Task assets.
+ *
+ * States: Draft -> Backlog -> Doing -> Done | Trashed
+ * Issue #2363
+ */
+export const TASK_DEFAULT_WORKFLOW: WorkflowDefinition = {
+  id: "a1b2c3d4-2222-4000-a000-000000000002",
+  name: "Task Default Workflow",
+  targetClass: AssetClass.TASK,
+  initialState: EffortStatus.DRAFT,
+  terminalStates: [EffortStatus.DONE, EffortStatus.TRASHED],
+  isDefault: true,
+  states: [
+    { status: EffortStatus.DRAFT, order: 1, optional: false, timestampOnEnter: [] },
+    { status: EffortStatus.BACKLOG, order: 2, optional: false, timestampOnEnter: [] },
+    { status: EffortStatus.DOING, order: 3, optional: false, timestampOnEnter: ["ems__Effort_startTimestamp"] },
+    { status: EffortStatus.DONE, order: 4, optional: false, timestampOnEnter: ["ems__Effort_endTimestamp", "ems__Effort_resolutionTimestamp"] },
+    { status: EffortStatus.TRASHED, order: 5, optional: false, timestampOnEnter: ["ems__Effort_resolutionTimestamp"] },
+  ],
+  transitions: [
+    { from: EffortStatus.DRAFT, to: EffortStatus.BACKLOG, label: "\u2192 Backlog", isRollback: false },
+    { from: EffortStatus.BACKLOG, to: EffortStatus.DOING, label: "\u25B6 Start", isRollback: false },
+    { from: EffortStatus.DOING, to: EffortStatus.DONE, label: "\u2713 Done", isRollback: false },
+    { from: EffortStatus.BACKLOG, to: EffortStatus.DRAFT, label: "\u2190 Draft", isRollback: true },
+    { from: EffortStatus.DOING, to: EffortStatus.BACKLOG, label: "\u2190 Backlog", isRollback: true },
+    { from: EffortStatus.DONE, to: EffortStatus.DOING, label: "\u2190 Doing", isRollback: true },
+  ],
+};
+
+/**
+ * Generates .md asset files for a complete workflow definition.
+ *
+ * Returns one file for the workflow itself, one per state, and one per transition.
+ * Each file contains YAML frontmatter with proper ontology properties.
+ *
+ * @param workflow - The workflow definition to serialize
+ * @returns Array of { filename, content } entries ready to be written to vault
+ *
+ * Issue #2363
+ */
+export function buildWorkflowAssetContent(
+  workflow: WorkflowDefinition,
+): Array<{ filename: string; content: string }> {
+  const now = new Date().toISOString();
+  const files: Array<{ filename: string; content: string }> = [];
+
+  // 1. Workflow file
+  const workflowUid = workflow.id;
+  const workflowFrontmatter: Record<string, unknown> = {
+    exo__Asset_uid: workflowUid,
+    exo__Asset_label: `"${workflow.name}"`,
+    exo__Asset_createdAt: now,
+    exo__Instance_class: AssetClass.WORKFLOW,
+    [WorkflowProperty.TARGET_CLASS]: `"[[${workflow.targetClass}]]"`,
+    [WorkflowProperty.INITIAL_STATE]: `"[[${workflow.initialState}]]"`,
+    [WorkflowProperty.TERMINAL_STATES]: workflow.terminalStates.map(
+      (s) => `"[[${s}]]"`,
+    ),
+    [WorkflowProperty.IS_DEFAULT]: workflow.isDefault,
+  };
+  files.push({
+    filename: `${workflowUid}.md`,
+    content: MetadataHelpers.buildFileContent(workflowFrontmatter),
+  });
+
+  // 2. State files
+  for (const state of workflow.states) {
+    const stateUid = uuidv4();
+    const stateFrontmatter: Record<string, unknown> = {
+      exo__Asset_uid: stateUid,
+      exo__Asset_label: `"${workflow.name} - ${state.status}"`,
+      exo__Asset_createdAt: now,
+      exo__Instance_class: AssetClass.WORKFLOW_STATE,
+      [WorkflowStateProperty.WORKFLOW]: `"[[${workflowUid}]]"`,
+      [WorkflowStateProperty.STATUS]: `"[[${state.status}]]"`,
+      [WorkflowStateProperty.ORDER]: state.order,
+      [WorkflowStateProperty.OPTIONAL]: state.optional,
+    };
+    if (state.timestampOnEnter.length > 0) {
+      stateFrontmatter[WorkflowStateProperty.TIMESTAMP_ON_ENTER] =
+        state.timestampOnEnter;
+    }
+    if (state.badgeColor) {
+      stateFrontmatter[WorkflowStateProperty.BADGE_COLOR] = `"${state.badgeColor}"`;
+    }
+    files.push({
+      filename: `${stateUid}.md`,
+      content: MetadataHelpers.buildFileContent(stateFrontmatter),
+    });
+  }
+
+  // 3. Transition files
+  for (const transition of workflow.transitions) {
+    const transUid = uuidv4();
+    const transFrontmatter: Record<string, unknown> = {
+      exo__Asset_uid: transUid,
+      exo__Asset_label: `"${workflow.name} - ${transition.label}"`,
+      exo__Asset_createdAt: now,
+      exo__Instance_class: AssetClass.WORKFLOW_TRANSITION,
+      [WorkflowTransitionProperty.WORKFLOW]: `"[[${workflowUid}]]"`,
+      [WorkflowTransitionProperty.FROM]: `"[[${transition.from}]]"`,
+      [WorkflowTransitionProperty.TO]: `"[[${transition.to}]]"`,
+      [WorkflowTransitionProperty.LABEL]: `"${transition.label}"`,
+      [WorkflowTransitionProperty.IS_ROLLBACK]: transition.isRollback,
+    };
+    if (transition.icon) {
+      transFrontmatter[WorkflowTransitionProperty.ICON] = `"${transition.icon}"`;
+    }
+    files.push({
+      filename: `${transUid}.md`,
+      content: MetadataHelpers.buildFileContent(transFrontmatter),
+    });
+  }
+
+  return files;
+}

--- a/packages/exocortex/tests/domain/defaults/DefaultWorkflows.test.ts
+++ b/packages/exocortex/tests/domain/defaults/DefaultWorkflows.test.ts
@@ -1,0 +1,234 @@
+import { AssetClass } from "../../../src/domain/constants/AssetClass";
+import { EffortStatus } from "../../../src/domain/constants/EffortStatus";
+import {
+  PROJECT_DEFAULT_WORKFLOW,
+  TASK_DEFAULT_WORKFLOW,
+  buildWorkflowAssetContent,
+} from "../../../src/domain/defaults/DefaultWorkflows";
+
+describe("DefaultWorkflows", () => {
+  describe("PROJECT_DEFAULT_WORKFLOW", () => {
+    it("should have correct targetClass", () => {
+      expect(PROJECT_DEFAULT_WORKFLOW.targetClass).toBe(AssetClass.PROJECT);
+    });
+
+    it("should have 7 states", () => {
+      expect(PROJECT_DEFAULT_WORKFLOW.states).toHaveLength(7);
+    });
+
+    it("should have 10 transitions", () => {
+      expect(PROJECT_DEFAULT_WORKFLOW.transitions).toHaveLength(10);
+    });
+
+    it("should have DRAFT as initial state", () => {
+      expect(PROJECT_DEFAULT_WORKFLOW.initialState).toBe(EffortStatus.DRAFT);
+    });
+
+    it("should have DONE and TRASHED as terminal states", () => {
+      expect(PROJECT_DEFAULT_WORKFLOW.terminalStates).toEqual([
+        EffortStatus.DONE,
+        EffortStatus.TRASHED,
+      ]);
+    });
+
+    it("should be marked as default", () => {
+      expect(PROJECT_DEFAULT_WORKFLOW.isDefault).toBe(true);
+    });
+
+    it("should have states in correct order", () => {
+      const orders = PROJECT_DEFAULT_WORKFLOW.states.map((s) => s.order);
+      expect(orders).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    });
+
+    it("should have Analysis and ToDo as optional states", () => {
+      const optionalStates = PROJECT_DEFAULT_WORKFLOW.states
+        .filter((s) => s.optional)
+        .map((s) => s.status);
+      expect(optionalStates).toEqual([EffortStatus.ANALYSIS, EffortStatus.TODO]);
+    });
+
+    it("should set startTimestamp when entering DOING", () => {
+      const doingState = PROJECT_DEFAULT_WORKFLOW.states.find(
+        (s) => s.status === EffortStatus.DOING,
+      );
+      expect(doingState?.timestampOnEnter).toContain("ems__Effort_startTimestamp");
+    });
+
+    it("should set endTimestamp and resolutionTimestamp when entering DONE", () => {
+      const doneState = PROJECT_DEFAULT_WORKFLOW.states.find(
+        (s) => s.status === EffortStatus.DONE,
+      );
+      expect(doneState?.timestampOnEnter).toContain("ems__Effort_endTimestamp");
+      expect(doneState?.timestampOnEnter).toContain("ems__Effort_resolutionTimestamp");
+    });
+
+    it("should have 5 forward and 5 rollback transitions", () => {
+      const forward = PROJECT_DEFAULT_WORKFLOW.transitions.filter((t) => !t.isRollback);
+      const rollback = PROJECT_DEFAULT_WORKFLOW.transitions.filter((t) => t.isRollback);
+      expect(forward).toHaveLength(5);
+      expect(rollback).toHaveLength(5);
+    });
+  });
+
+  describe("TASK_DEFAULT_WORKFLOW", () => {
+    it("should have correct targetClass", () => {
+      expect(TASK_DEFAULT_WORKFLOW.targetClass).toBe(AssetClass.TASK);
+    });
+
+    it("should have 5 states", () => {
+      expect(TASK_DEFAULT_WORKFLOW.states).toHaveLength(5);
+    });
+
+    it("should have 6 transitions", () => {
+      expect(TASK_DEFAULT_WORKFLOW.transitions).toHaveLength(6);
+    });
+
+    it("should have DRAFT as initial state", () => {
+      expect(TASK_DEFAULT_WORKFLOW.initialState).toBe(EffortStatus.DRAFT);
+    });
+
+    it("should have DONE and TRASHED as terminal states", () => {
+      expect(TASK_DEFAULT_WORKFLOW.terminalStates).toEqual([
+        EffortStatus.DONE,
+        EffortStatus.TRASHED,
+      ]);
+    });
+
+    it("should be marked as default", () => {
+      expect(TASK_DEFAULT_WORKFLOW.isDefault).toBe(true);
+    });
+
+    it("should have states in correct order", () => {
+      const orders = TASK_DEFAULT_WORKFLOW.states.map((s) => s.order);
+      expect(orders).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("should have no optional states", () => {
+      const optionalStates = TASK_DEFAULT_WORKFLOW.states.filter((s) => s.optional);
+      expect(optionalStates).toHaveLength(0);
+    });
+
+    it("should have 3 forward and 3 rollback transitions", () => {
+      const forward = TASK_DEFAULT_WORKFLOW.transitions.filter((t) => !t.isRollback);
+      const rollback = TASK_DEFAULT_WORKFLOW.transitions.filter((t) => t.isRollback);
+      expect(forward).toHaveLength(3);
+      expect(rollback).toHaveLength(3);
+    });
+  });
+
+  describe("buildWorkflowAssetContent", () => {
+    it("should generate correct number of files for project workflow", () => {
+      const files = buildWorkflowAssetContent(PROJECT_DEFAULT_WORKFLOW);
+      // 1 workflow + 7 states + 10 transitions = 18
+      expect(files).toHaveLength(18);
+    });
+
+    it("should generate correct number of files for task workflow", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      // 1 workflow + 5 states + 6 transitions = 12
+      expect(files).toHaveLength(12);
+    });
+
+    it("should generate files with .md extension", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      for (const file of files) {
+        expect(file.filename).toMatch(/\.md$/);
+      }
+    });
+
+    it("should generate files with valid YAML frontmatter format", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      for (const file of files) {
+        expect(file.content).toMatch(/^---\n/);
+        expect(file.content).toMatch(/\n---\n/);
+      }
+    });
+
+    it("should include exo__Asset_uid in every file", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      for (const file of files) {
+        expect(file.content).toContain("exo__Asset_uid:");
+      }
+    });
+
+    it("should include exo__Asset_label in every file", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      for (const file of files) {
+        expect(file.content).toContain("exo__Asset_label:");
+      }
+    });
+
+    it("should include exo__Instance_class in every file", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      for (const file of files) {
+        expect(file.content).toContain("exo__Instance_class:");
+      }
+    });
+
+    it("should reference correct targetClass in workflow file", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      const workflowFile = files[0];
+      expect(workflowFile.content).toContain(AssetClass.TASK);
+    });
+
+    it("should reference correct targetClass for project workflow", () => {
+      const files = buildWorkflowAssetContent(PROJECT_DEFAULT_WORKFLOW);
+      const workflowFile = files[0];
+      expect(workflowFile.content).toContain(AssetClass.PROJECT);
+    });
+
+    it("should set workflow file as ems__Workflow class", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      const workflowFile = files[0];
+      expect(workflowFile.content).toContain(`exo__Instance_class: ${AssetClass.WORKFLOW}`);
+    });
+
+    it("should set state files as ems__WorkflowState class", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      // States are files[1] through files[5] (5 states)
+      for (let i = 1; i <= 5; i++) {
+        expect(files[i].content).toContain(
+          `exo__Instance_class: ${AssetClass.WORKFLOW_STATE}`,
+        );
+      }
+    });
+
+    it("should set transition files as ems__WorkflowTransition class", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      // Transitions are files[6] through files[11] (6 transitions)
+      for (let i = 6; i <= 11; i++) {
+        expect(files[i].content).toContain(
+          `exo__Instance_class: ${AssetClass.WORKFLOW_TRANSITION}`,
+        );
+      }
+    });
+
+    it("should generate unique UIDs for state and transition files", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      const uids = files.map((f) => f.filename.replace(".md", ""));
+      const uniqueUids = new Set(uids);
+      expect(uniqueUids.size).toBe(uids.length);
+    });
+
+    it("should include exo__Asset_createdAt in every file", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      for (const file of files) {
+        expect(file.content).toContain("exo__Asset_createdAt:");
+      }
+    });
+
+    it("should include isDefault property in workflow file", () => {
+      const files = buildWorkflowAssetContent(PROJECT_DEFAULT_WORKFLOW);
+      const workflowFile = files[0];
+      expect(workflowFile.content).toContain("ems__Workflow_isDefault: true");
+    });
+
+    it("should include timestampOnEnter for states that have it", () => {
+      const files = buildWorkflowAssetContent(TASK_DEFAULT_WORKFLOW);
+      // DOING state (index 3 in states, file index 3) has timestampOnEnter
+      const doingStateFile = files[3];
+      expect(doingStateFile.content).toContain("ems__WorkflowState_timestampOnEnter:");
+      expect(doingStateFile.content).toContain("ems__Effort_startTimestamp");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `PROJECT_DEFAULT_WORKFLOW` and `TASK_DEFAULT_WORKFLOW` constants with real UUIDs (replacing hardcoded fallbacks in WorkflowResolver)
- Add `buildWorkflowAssetContent()` function that generates .md vault files with proper YAML frontmatter for a complete workflow (workflow + states + transitions)
- 36 unit tests covering workflow structure, file generation, and frontmatter validity

Closes #2363