### PR TITLE
feat(cli): add workflow list/show/validate CLI commands (#2365)

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,0 +1,454 @@
+import { Command } from "commander";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { resolve, join } from "path";
+import {
+  FrontmatterService,
+  WorkflowEngine,
+  AssetClass,
+  EffortStatus,
+  type WorkflowDefinition,
+  type WorkflowStateDefinition,
+  type WorkflowTransitionDefinition,
+} from "exocortex";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+import { ResponseBuilder } from "../responses/index.js";
+
+export interface WorkflowCommandOptions {
+  vault: string;
+  output?: OutputFormat;
+}
+
+interface WorkflowFileInfo {
+  filePath: string;
+  uid: string;
+  label: string;
+  targetClass: string;
+  isDefault: boolean;
+  stateCount: number;
+  transitionCount: number;
+}
+
+/**
+ * Creates the 'workflow' command group for listing, showing, and validating
+ * custom workflow definitions in the vault.
+ *
+ * Issue #2365
+ */
+export function workflowCommand(): Command {
+  const workflow = new Command("workflow")
+    .description("Manage custom workflow definitions");
+
+  workflow
+    .command("list")
+    .description("List all workflow definitions in the vault")
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--output <type>", "Response format: text|json", "text")
+    .action(async (options: WorkflowCommandOptions) => {
+      const outputFormat = (options.output || "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const workflows = scanWorkflows(vaultPath);
+
+        if (outputFormat === "json") {
+          const response = ResponseBuilder.success({
+            workflows,
+            totalWorkflows: workflows.length,
+          });
+          console.log(JSON.stringify(response, null, 2));
+        } else {
+          if (workflows.length === 0) {
+            console.log("No workflows found in vault.");
+            return;
+          }
+
+          console.log(`\n📋 Found ${workflows.length} workflow(s):\n`);
+
+          const maxName = Math.max(...workflows.map(w => w.label.length), 4);
+          const maxClass = Math.max(...workflows.map(w => w.targetClass.length), 12);
+
+          console.log("┌" + "─".repeat(maxName + 2) + "┬" + "─".repeat(maxClass + 2) + "┬" + "─".repeat(8) + "┬" + "─".repeat(13) + "┬" + "─".repeat(9) + "┐");
+          console.log("│ " + "Name".padEnd(maxName) + " │ " + "Target Class".padEnd(maxClass) + " │ " + "States".padEnd(6) + " │ " + "Transitions".padEnd(11) + " │ " + "Default".padEnd(7) + " │");
+          console.log("├" + "─".repeat(maxName + 2) + "┼" + "─".repeat(maxClass + 2) + "┼" + "─".repeat(8) + "┼" + "─".repeat(13) + "┼" + "─".repeat(9) + "┤");
+
+          for (const w of workflows) {
+            console.log(
+              "│ " + w.label.padEnd(maxName) +
+              " │ " + w.targetClass.padEnd(maxClass) +
+              " │ " + w.stateCount.toString().padStart(6) +
+              " │ " + w.transitionCount.toString().padStart(11) +
+              " │ " + (w.isDefault ? "  yes  " : "   no  ") + " │"
+            );
+          }
+
+          console.log("└" + "─".repeat(maxName + 2) + "┴" + "─".repeat(maxClass + 2) + "┴" + "─".repeat(8) + "┴" + "─".repeat(13) + "┴" + "─".repeat(9) + "┘");
+        }
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+
+  workflow
+    .command("show")
+    .description("Show details of a workflow definition")
+    .argument("<uid>", "UID of the workflow asset")
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--output <type>", "Response format: text|json", "text")
+    .action(async (uid: string, options: WorkflowCommandOptions) => {
+      const outputFormat = (options.output || "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const definition = loadWorkflowByUid(vaultPath, uid);
+        if (!definition) {
+          if (outputFormat === "json") {
+            const response = ResponseBuilder.success({
+              error: `Workflow with UID "${uid}" not found`,
+            });
+            console.log(JSON.stringify(response, null, 2));
+          } else {
+            console.log(`❌ Workflow with UID "${uid}" not found.`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (outputFormat === "json") {
+          const response = ResponseBuilder.success(definition);
+          console.log(JSON.stringify(response, null, 2));
+        } else {
+          console.log(`\n📋 Workflow: ${definition.name}\n`);
+          console.log(`   ID: ${definition.id}`);
+          console.log(`   Target class: ${definition.targetClass}`);
+          console.log(`   Initial state: ${definition.initialState}`);
+          console.log(`   Terminal states: ${definition.terminalStates.join(", ")}`);
+          console.log(`   Default: ${definition.isDefault ? "yes" : "no"}`);
+
+          console.log(`\n   States (${definition.states.length}):`);
+          for (const s of definition.states) {
+            const optStr = s.optional ? " (optional)" : "";
+            const tsStr = s.timestampOnEnter.length > 0
+              ? ` [timestamps: ${s.timestampOnEnter.join(", ")}]`
+              : "";
+            console.log(`     ${s.order}. ${s.status}${optStr}${tsStr}`);
+          }
+
+          console.log(`\n   Transitions (${definition.transitions.length}):`);
+          for (const t of definition.transitions) {
+            const rollback = t.isRollback ? " (rollback)" : "";
+            console.log(`     ${t.label}: ${t.from} → ${t.to}${rollback}`);
+          }
+        }
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+
+  workflow
+    .command("validate")
+    .description("Validate a workflow definition")
+    .argument("<uid>", "UID of the workflow asset")
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--output <type>", "Response format: text|json", "text")
+    .action(async (uid: string, options: WorkflowCommandOptions) => {
+      const outputFormat = (options.output || "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const definition = loadWorkflowByUid(vaultPath, uid);
+        if (!definition) {
+          if (outputFormat === "json") {
+            const response = ResponseBuilder.success({
+              error: `Workflow with UID "${uid}" not found`,
+            });
+            console.log(JSON.stringify(response, null, 2));
+          } else {
+            console.log(`❌ Workflow with UID "${uid}" not found.`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        const engine = new WorkflowEngine(definition);
+        const result = engine.validate();
+
+        if (outputFormat === "json") {
+          const response = ResponseBuilder.success({
+            workflow: definition.name,
+            uid: definition.id,
+            ...result,
+          });
+          console.log(JSON.stringify(response, null, 2));
+        } else {
+          if (result.valid) {
+            console.log(`✅ Workflow "${definition.name}" is valid.`);
+          } else {
+            console.log(`❌ Workflow "${definition.name}" has ${result.errors.length} error(s):\n`);
+            for (const err of result.errors) {
+              console.log(`   • ${err}`);
+            }
+            process.exitCode = 1;
+          }
+        }
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+
+  return workflow;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+const frontmatterService = new FrontmatterService();
+
+/**
+ * Scan vault for workflow definition files.
+ * Recursively finds .md files with exo__Instance_class containing ems__Workflow.
+ */
+function scanWorkflows(vaultPath: string): WorkflowFileInfo[] {
+  const workflows: WorkflowFileInfo[] = [];
+  scanDirectory(vaultPath, vaultPath, workflows);
+  return workflows;
+}
+
+function scanDirectory(
+  dir: string,
+  vaultRoot: string,
+  results: WorkflowFileInfo[],
+): void {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      // Skip hidden directories and node_modules
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+      scanDirectory(fullPath, vaultRoot, results);
+    } else if (entry.name.endsWith(".md")) {
+      const info = tryParseWorkflowFile(fullPath);
+      if (info) {
+        results.push(info);
+      }
+    }
+  }
+}
+
+function tryParseWorkflowFile(filePath: string): WorkflowFileInfo | null {
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    const parsed = frontmatterService.parse(content);
+    if (!parsed.exists) return null;
+
+    const fm = parseYamlFrontmatter(parsed.content);
+    const instanceClass = fm["exo__Instance_class"];
+
+    if (!instanceClass) return null;
+
+    // Check if it's a workflow - can be string or array
+    const isWorkflow = Array.isArray(instanceClass)
+      ? instanceClass.some((c: string) => c.includes("ems__Workflow") && !c.includes("WorkflowState") && !c.includes("WorkflowTransition"))
+      : typeof instanceClass === "string" && instanceClass.includes("ems__Workflow") && !instanceClass.includes("WorkflowState") && !instanceClass.includes("WorkflowTransition");
+
+    if (!isWorkflow) return null;
+
+    const uid = fm["exo__Asset_uid"] ?? "";
+    const label = fm["exo__Asset_label"] ?? extractLabelFromFilename(filePath);
+    const targetClass = normalizeWikilink(fm["ems__Workflow_targetClass"] ?? "ems__Task");
+    const isDefault = fm["ems__Workflow_isDefault"] === true || fm["ems__Workflow_isDefault"] === "true";
+
+    // Count states and transitions by scanning files that reference this workflow
+    // For simplicity, count from the YAML list properties if they exist
+    const states = Array.isArray(fm["ems__Workflow_states"]) ? fm["ems__Workflow_states"].length : 0;
+    const transitions = Array.isArray(fm["ems__Workflow_transitions"]) ? fm["ems__Workflow_transitions"].length : 0;
+
+    return {
+      filePath,
+      uid,
+      label,
+      targetClass,
+      isDefault,
+      stateCount: states,
+      transitionCount: transitions,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load a full WorkflowDefinition by scanning vault for a workflow with matching UID.
+ */
+function loadWorkflowByUid(
+  vaultPath: string,
+  uid: string,
+): WorkflowDefinition | null {
+  const workflows = scanWorkflows(vaultPath);
+  const found = workflows.find(w => w.uid === uid);
+  if (!found) return null;
+
+  try {
+    const content = readFileSync(found.filePath, "utf-8");
+    const parsed = frontmatterService.parse(content);
+    if (!parsed.exists) return null;
+
+    const fm = parseYamlFrontmatter(parsed.content);
+
+    const targetClass = normalizeWikilink(fm["ems__Workflow_targetClass"] ?? "ems__Task") as AssetClass;
+    const initialStateRaw = normalizeWikilink(fm["ems__Workflow_initialState"] ?? "ems__EffortStatusDraft");
+    const initialState = resolveEffortStatus(initialStateRaw) ?? EffortStatus.DRAFT;
+
+    const terminalStatesRaw: string[] = Array.isArray(fm["ems__Workflow_terminalStates"])
+      ? fm["ems__Workflow_terminalStates"].map((s: string) => normalizeWikilink(s))
+      : [];
+    const terminalStates = terminalStatesRaw
+      .map(resolveEffortStatus)
+      .filter((s): s is EffortStatus => s !== null);
+
+    const isDefault = fm["ems__Workflow_isDefault"] === true || fm["ems__Workflow_isDefault"] === "true";
+
+    // Build states from inline YAML or linked files
+    const statesRaw: any[] = Array.isArray(fm["ems__Workflow_states"]) ? fm["ems__Workflow_states"] : [];
+    const states: WorkflowStateDefinition[] = statesRaw.map((s: any, idx: number) => {
+      if (typeof s === "string") {
+        const status = resolveEffortStatus(normalizeWikilink(s));
+        return {
+          status: status ?? EffortStatus.DRAFT,
+          order: idx + 1,
+          optional: false,
+          timestampOnEnter: [],
+        };
+      }
+      return {
+        status: resolveEffortStatus(normalizeWikilink(s.status ?? "")) ?? EffortStatus.DRAFT,
+        order: s.order ?? idx + 1,
+        optional: s.optional === true || s.optional === "true",
+        timestampOnEnter: Array.isArray(s.timestampOnEnter) ? s.timestampOnEnter : [],
+        badgeColor: s.badgeColor,
+      };
+    });
+
+    const transitionsRaw: any[] = Array.isArray(fm["ems__Workflow_transitions"]) ? fm["ems__Workflow_transitions"] : [];
+    const transitions: WorkflowTransitionDefinition[] = transitionsRaw
+      .map((t: any) => {
+        const from = resolveEffortStatus(normalizeWikilink(t.from ?? ""));
+        const to = resolveEffortStatus(normalizeWikilink(t.to ?? ""));
+        if (!from || !to) return null;
+        return {
+          from,
+          to,
+          label: t.label ?? `${from} → ${to}`,
+          icon: t.icon,
+          isRollback: t.isRollback === true || t.isRollback === "true",
+        };
+      })
+      .filter((t): t is WorkflowTransitionDefinition => t !== null);
+
+    return {
+      id: uid,
+      name: found.label,
+      targetClass,
+      states,
+      transitions,
+      initialState,
+      terminalStates: terminalStates.length > 0
+        ? terminalStates
+        : [EffortStatus.DONE, EffortStatus.TRASHED],
+      isDefault,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Simple YAML frontmatter parser for key-value pairs.
+ * Handles basic YAML: strings, booleans, arrays.
+ */
+function parseYamlFrontmatter(content: string): Record<string, any> {
+  const result: Record<string, any> = {};
+  const lines = content.split("\n");
+  let currentKey = "";
+  let currentArray: string[] | null = null;
+
+  for (const line of lines) {
+    // Array item
+    if (line.match(/^\s+-\s+/) && currentKey) {
+      const value = line.replace(/^\s+-\s+/, "").trim();
+      if (!currentArray) {
+        currentArray = [];
+      }
+      currentArray.push(value);
+      result[currentKey] = currentArray;
+      continue;
+    }
+
+    // Key-value pair
+    const kvMatch = line.match(/^([a-zA-Z0-9_]+):\s*(.*)/);
+    if (kvMatch) {
+      // Save previous array
+      currentKey = kvMatch[1];
+      currentArray = null;
+      let value: any = kvMatch[2].trim();
+
+      // Remove quotes
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+
+      // Boolean conversion
+      if (value === "true") value = true;
+      else if (value === "false") value = false;
+
+      // Empty value means possible array follows
+      if (value === "") {
+        result[currentKey] = [];
+        currentArray = result[currentKey] as string[];
+        continue;
+      }
+
+      result[currentKey] = value;
+    }
+  }
+
+  return result;
+}
+
+function normalizeWikilink(value: string): string {
+  if (typeof value !== "string") return "";
+  return value.replace(/["'[\]]/g, "").trim();
+}
+
+function extractLabelFromFilename(filePath: string): string {
+  const parts = filePath.split("/");
+  const filename = parts[parts.length - 1];
+  return filename.replace(/\.md$/, "");
+}
+
+function resolveEffortStatus(raw: string): EffortStatus | null {
+  return Object.values(EffortStatus).includes(raw as EffortStatus)
+    ? (raw as EffortStatus)
+    : null;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import { classesCommand } from "./commands/classes.js";
 import { createCommand } from "./commands/create.js";
 import { archiveCommand } from "./commands/archive.js";
 import { unarchiveCommand } from "./commands/unarchive.js";
+import { workflowCommand } from "./commands/workflow.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -48,5 +49,6 @@ program.addCommand(classesCommand());
 program.addCommand(createCommand());
 program.addCommand(archiveCommand());
 program.addCommand(unarchiveCommand());
+program.addCommand(workflowCommand());
 
 program.parse();

--- a/packages/cli/tests/unit/commands/workflow.test.ts
+++ b/packages/cli/tests/unit/commands/workflow.test.ts
@@ -1,0 +1,331 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { Command } from "commander";
+
+// Mock fs module
+const mockReaddirSync = jest.fn();
+const mockReadFileSync = jest.fn();
+const mockExistsSync = jest.fn();
+
+jest.unstable_mockModule("fs", () => ({
+  existsSync: mockExistsSync,
+  readdirSync: mockReaddirSync,
+  readFileSync: mockReadFileSync,
+}));
+
+// Mock exocortex
+const mockValidate = jest.fn();
+jest.unstable_mockModule("exocortex", () => ({
+  FrontmatterService: jest.fn(() => ({
+    parse: jest.fn((content) => {
+      const match = content.match(/^---\n([\s\S]*?)\n---/);
+      if (!match) return { exists: false, content: "", originalContent: content };
+      return { exists: true, content: match[1], originalContent: content };
+    }),
+  })),
+  WorkflowEngine: jest.fn(() => ({
+    validate: mockValidate,
+  })),
+  AssetClass: {
+    TASK: "ems__Task",
+    PROJECT: "ems__Project",
+    WORKFLOW: "ems__Workflow",
+  },
+  EffortStatus: {
+    DRAFT: "ems__EffortStatusDraft",
+    BACKLOG: "ems__EffortStatusBacklog",
+    DOING: "ems__EffortStatusDoing",
+    DONE: "ems__EffortStatusDone",
+    TRASHED: "ems__EffortStatusTrashed",
+  },
+}));
+
+const { workflowCommand } = await import("../../../src/commands/workflow.js");
+
+/**
+ * Issue #2365: Tests for workflow CLI command registration and behavior
+ */
+describe("Issue #2365: workflow command", () => {
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue([]);
+    mockReadFileSync.mockReturnValue("");
+    mockValidate.mockReturnValue({ valid: true, errors: [] });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  describe("command registration", () => {
+    it("should create a command with name 'workflow'", () => {
+      const cmd = workflowCommand();
+      expect(cmd).toBeInstanceOf(Command);
+      expect(cmd.name()).toBe("workflow");
+    });
+
+    it("should have a description", () => {
+      const cmd = workflowCommand();
+      expect(cmd.description()).toBeTruthy();
+    });
+
+    it("should register 'list' subcommand", () => {
+      const cmd = workflowCommand();
+      const listCmd = cmd.commands.find((c) => c.name() === "list");
+      expect(listCmd).toBeDefined();
+      expect(listCmd.description()).toBeTruthy();
+    });
+
+    it("should register 'show' subcommand", () => {
+      const cmd = workflowCommand();
+      const showCmd = cmd.commands.find((c) => c.name() === "show");
+      expect(showCmd).toBeDefined();
+    });
+
+    it("should register 'validate' subcommand", () => {
+      const cmd = workflowCommand();
+      const validateCmd = cmd.commands.find((c) => c.name() === "validate");
+      expect(validateCmd).toBeDefined();
+    });
+
+    it("should have 3 subcommands total", () => {
+      const cmd = workflowCommand();
+      expect(cmd.commands).toHaveLength(3);
+    });
+
+    it("list subcommand should have --vault option with default", () => {
+      const cmd = workflowCommand();
+      const listCmd = cmd.commands.find((c) => c.name() === "list");
+      const vaultOpt = listCmd.options.find((o) => o.long === "--vault");
+      expect(vaultOpt).toBeDefined();
+      expect(vaultOpt.defaultValue).toBeDefined();
+    });
+
+    it("list subcommand should have --output option with default 'text'", () => {
+      const cmd = workflowCommand();
+      const listCmd = cmd.commands.find((c) => c.name() === "list");
+      const outputOpt = listCmd.options.find((o) => o.long === "--output");
+      expect(outputOpt).toBeDefined();
+      expect(outputOpt.defaultValue).toBe("text");
+    });
+
+    it("show subcommand should accept uid argument", () => {
+      const cmd = workflowCommand();
+      const showCmd = cmd.commands.find((c) => c.name() === "show");
+      expect(showCmd.registeredArguments).toBeDefined();
+      expect(showCmd.registeredArguments.length).toBeGreaterThan(0);
+    });
+
+    it("validate subcommand should accept uid argument", () => {
+      const cmd = workflowCommand();
+      const validateCmd = cmd.commands.find((c) => c.name() === "validate");
+      expect(validateCmd.registeredArguments).toBeDefined();
+      expect(validateCmd.registeredArguments.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("list execution", () => {
+    it("should print 'No workflows found' for empty vault", async () => {
+      mockReaddirSync.mockReturnValue([]);
+
+      const cmd = workflowCommand();
+      const listCmd = cmd.commands.find((c) => c.name() === "list");
+
+      await listCmd.parseAsync(["node", "test", "--vault", "/tmp/test-vault"], { from: "node" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith("No workflows found in vault.");
+    });
+
+    it("should print table when workflows exist", async () => {
+      mockReaddirSync.mockImplementation((dir, opts) => {
+        if (dir.includes("test-vault")) {
+          return [
+            { name: "workflow.md", isDirectory: () => false },
+          ];
+        }
+        return [];
+      });
+
+      mockReadFileSync.mockReturnValue(
+        "---\nexo__Instance_class: ems__Workflow\nexo__Asset_uid: test-uid-123\nexo__Asset_label: Task Workflow\nems__Workflow_targetClass: ems__Task\nems__Workflow_isDefault: true\n---\n"
+      );
+
+      const cmd = workflowCommand();
+      const listCmd = cmd.commands.find((c) => c.name() === "list");
+
+      await listCmd.parseAsync(["node", "test", "--vault", "/tmp/test-vault"], { from: "node" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Found 1 workflow(s)")
+      );
+    });
+
+    it("should output JSON when --output json is specified", async () => {
+      mockReaddirSync.mockReturnValue([]);
+
+      const cmd = workflowCommand();
+      const listCmd = cmd.commands.find((c) => c.name() === "list");
+
+      await listCmd.parseAsync(["node", "test", "--vault", "/tmp/test-vault", "--output", "json"], { from: "node" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"totalWorkflows"')
+      );
+    });
+  });
+
+  describe("show execution", () => {
+    it("should print 'not found' for unknown UID", async () => {
+      mockReaddirSync.mockReturnValue([]);
+
+      const cmd = workflowCommand();
+      const showCmd = cmd.commands.find((c) => c.name() === "show");
+
+      await showCmd.parseAsync(["node", "test", "nonexistent-uid", "--vault", "/tmp/test-vault"], { from: "node" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("not found")
+      );
+    });
+
+    it("should print workflow details for valid UID", async () => {
+      mockReaddirSync.mockImplementation((dir, opts) => {
+        if (dir.includes("test-vault")) {
+          return [
+            { name: "workflow.md", isDirectory: () => false },
+          ];
+        }
+        return [];
+      });
+
+      const workflowContent = [
+        "---",
+        "exo__Instance_class: ems__Workflow",
+        "exo__Asset_uid: found-uid-456",
+        "exo__Asset_label: My Workflow",
+        "ems__Workflow_targetClass: ems__Task",
+        "ems__Workflow_initialState: ems__EffortStatusDraft",
+        "ems__Workflow_isDefault: true",
+        "ems__Workflow_terminalStates:",
+        "  - ems__EffortStatusDone",
+        "  - ems__EffortStatusTrashed",
+        "ems__Workflow_states:",
+        "  - ems__EffortStatusDraft",
+        "  - ems__EffortStatusDoing",
+        "  - ems__EffortStatusDone",
+        "ems__Workflow_transitions:",
+        "---",
+        "",
+      ].join("\n");
+
+      mockReadFileSync.mockReturnValue(workflowContent);
+
+      const cmd = workflowCommand();
+      const showCmd = cmd.commands.find((c) => c.name() === "show");
+
+      await showCmd.parseAsync(["node", "test", "found-uid-456", "--vault", "/tmp/test-vault"], { from: "node" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("My Workflow")
+      );
+    });
+  });
+
+  describe("validate execution", () => {
+    it("should print 'not found' for unknown UID", async () => {
+      mockReaddirSync.mockReturnValue([]);
+
+      const cmd = workflowCommand();
+      const validateCmd = cmd.commands.find((c) => c.name() === "validate");
+
+      await validateCmd.parseAsync(["node", "test", "nonexistent-uid", "--vault", "/tmp/test-vault"], { from: "node" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("not found")
+      );
+    });
+
+    it("should print valid result for correct workflow", async () => {
+      mockReaddirSync.mockImplementation((dir, opts) => {
+        if (dir.includes("test-vault")) {
+          return [
+            { name: "workflow.md", isDirectory: () => false },
+          ];
+        }
+        return [];
+      });
+
+      const workflowContent = [
+        "---",
+        "exo__Instance_class: ems__Workflow",
+        "exo__Asset_uid: valid-uid-789",
+        "exo__Asset_label: Valid Workflow",
+        "ems__Workflow_targetClass: ems__Task",
+        "ems__Workflow_initialState: ems__EffortStatusDraft",
+        "ems__Workflow_isDefault: true",
+        "ems__Workflow_states:",
+        "  - ems__EffortStatusDraft",
+        "  - ems__EffortStatusDone",
+        "ems__Workflow_transitions:",
+        "---",
+        "",
+      ].join("\n");
+
+      mockReadFileSync.mockReturnValue(workflowContent);
+      mockValidate.mockReturnValue({ valid: true, errors: [] });
+
+      const cmd = workflowCommand();
+      const validateCmd = cmd.commands.find((c) => c.name() === "validate");
+
+      await validateCmd.parseAsync(["node", "test", "valid-uid-789", "--vault", "/tmp/test-vault"], { from: "node" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("is valid")
+      );
+    });
+
+    it("should print errors for invalid workflow", async () => {
+      mockReaddirSync.mockImplementation((dir, opts) => {
+        if (dir.includes("test-vault")) {
+          return [
+            { name: "workflow.md", isDirectory: () => false },
+          ];
+        }
+        return [];
+      });
+
+      const workflowContent = [
+        "---",
+        "exo__Instance_class: ems__Workflow",
+        "exo__Asset_uid: invalid-uid-000",
+        "exo__Asset_label: Bad Workflow",
+        "ems__Workflow_targetClass: ems__Task",
+        "ems__Workflow_initialState: ems__EffortStatusDraft",
+        "ems__Workflow_isDefault: false",
+        "ems__Workflow_states:",
+        "  - ems__EffortStatusDraft",
+        "ems__Workflow_transitions:",
+        "---",
+        "",
+      ].join("\n");
+
+      mockReadFileSync.mockReturnValue(workflowContent);
+      mockValidate.mockReturnValue({
+        valid: false,
+        errors: ["State has no outgoing forward transitions"],
+      });
+
+      const cmd = workflowCommand();
+      const validateCmd = cmd.commands.find((c) => c.name() === "validate");
+
+      await validateCmd.parseAsync(["node", "test", "invalid-uid-000", "--vault", "/tmp/test-vault"], { from: "node" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("error(s)")
+      );
+    });
+  });
+});

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -36,6 +36,13 @@ export {
 export { ClassCreationService } from "./services/ClassCreationService";
 export { ConceptCreationService } from "./services/ConceptCreationService";
 export { EffortStatusWorkflow } from "./services/EffortStatusWorkflow";
+export { WorkflowEngine } from "./services/WorkflowEngine";
+export type { WorkflowValidationResult } from "./services/WorkflowEngine";
+export type {
+  WorkflowDefinition,
+  WorkflowStateDefinition,
+  WorkflowTransitionDefinition,
+} from "./domain/models/WorkflowDefinition";
 export { EffortVotingService } from "./services/EffortVotingService";
 export { FolderRepairService } from "./services/FolderRepairService";
 export { LabelToAliasService } from "./services/LabelToAliasService";


### PR DESCRIPTION
## Summary

Adds CLI commands to manage custom workflow definitions stored as vault assets:

- `exocortex workflow list` -- scans vault for `ems__Workflow` files and displays a formatted table
- `exocortex workflow show <uid>` -- shows detailed workflow info (states, transitions, terminal states)
- `exocortex workflow validate <uid>` -- validates workflow structure using `WorkflowEngine.validate()`

All commands support `--vault` and `--output json` flags.

Also exports `WorkflowEngine`, `WorkflowDefinition`, `WorkflowStateDefinition`, `WorkflowTransitionDefinition`, and `WorkflowValidationResult` from `@exocortex/core` package.

## Files Changed

- `packages/cli/src/commands/workflow.ts` -- new workflow command group (list/show/validate)
- `packages/cli/src/index.ts` -- register workflow command
- `packages/exocortex/src/index.ts` -- export WorkflowEngine and WorkflowDefinition types
- `packages/cli/tests/unit/commands/workflow.test.ts` -- 18 unit tests

## Test Plan

- [x] 18 unit tests pass (registration, list/show/validate execution, JSON output, edge cases)
- [x] No new TypeScript errors introduced
- [ ] CI pipeline

Closes #2365