### PR TITLE
fix(docs): mark semantic-search docs as not implemented

### DIFF
--- a/docs/semantic-search/BENCHMARK-FRAMEWORK.md
+++ b/docs/semantic-search/BENCHMARK-FRAMEWORK.md
@@ -1,3 +1,5 @@
+> **Status: Not Implemented** — This feature was designed but not yet implemented. Documentation kept for future reference.
+
 # Embedding Quality Benchmark Framework
 
 This document defines the methodology for evaluating embedding model quality in Exocortex's semantic search system.

--- a/docs/semantic-search/EMBEDDING-MODEL-SELECTION.md
+++ b/docs/semantic-search/EMBEDDING-MODEL-SELECTION.md
@@ -1,3 +1,5 @@
+> **Status: Not Implemented** — This feature was designed but not yet implemented. Documentation kept for future reference.
+
 # Embedding Model Selection for Semantic Search
 
 This document provides a comprehensive analysis of embedding models for Exocortex's semantic search functionality, including performance benchmarks, privacy considerations, and our final recommendation.

--- a/docs/semantic-search/README.md
+++ b/docs/semantic-search/README.md
@@ -1,3 +1,5 @@
+> **Status: Not Implemented** — This feature was designed but not yet implemented. Documentation kept for future reference.
+
 # Semantic Search Documentation
 
 This directory contains documentation for Exocortex's semantic search functionality.


### PR DESCRIPTION
## Summary

- Added deprecation notice to all 3 files in `docs/semantic-search/` marking them as **not implemented** design documents
- Files affected: `README.md`, `BENCHMARK-FRAMEWORK.md`, `EMBEDDING-MODEL-SELECTION.md`
- No references to semantic-search found in the main `README.md`, so no label changes needed

Closes #2399