### PR TITLE
fix(docs): fix architecture diagram claims in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Exocortex is a **monorepo** with five packages sharing Clean Architecture core:
 │   ┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐ │
 │   │  Obsidian Plugin │    │       CLI        │    │   Your App       │ │
 │   │  (@exocortex/    │    │  (@kitelev/      │    │   (REST API      │ │
-│   │  obsidian-plugin)│    │  exocortex-cli)  │    │   coming soon)   │ │
+│   │  obsidian-plugin)│    │  exocortex-cli)  │    │   planned)       │ │
 │   └────────┬─────────┘    └────────┬─────────┘    └────────┬─────────┘ │
 │            │                       │                        │           │
 │            └───────────────────────┼────────────────────────┘           │
@@ -216,7 +216,7 @@ Exocortex is a **monorepo** with five packages sharing Clean Architecture core:
 │                       │                         │                       │
 │                       │  • Domain models        │                       │
 │                       │  • SPARQL engine        │                       │
-│                       │  • Inference rules      │                       │
+│                       │  • RDFS inference       │                       │
 │                       │  • Storage adapters     │                       │
 │                       └─────────────────────────┘                       │
 │                                                                         │
@@ -245,8 +245,8 @@ Exocortex is a **monorepo** with five packages sharing Clean Architecture core:
 ├─────────────────────────────────────────────────────────────────────────┤
 │                      Infrastructure Layer                               │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────────┐                 │
-│  │   Markdown  │  │    SPARQL   │  │   N-Triples     │                 │
-│  │   Parser    │  │   Engine    │  │   Storage       │                 │
+│  │   Markdown  │  │    SPARQL   │  │   RDF           │                 │
+│  │   Parser    │  │   Engine    │  │   Serializers   │                 │
 │  └─────────────┘  └─────────────┘  └─────────────────┘                 │
 └─────────────────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
## Summary
- Change "coming soon" to "planned" for REST API in system diagram (#2400)
- Clarify "Inference rules" as "RDFS inference" in Core Library box (#2401)
- Replace "N-Triples Storage" with "RDF Serializers" in Infrastructure Layer (#2403)

## Test plan
- [x] ASCII art alignment verified (line lengths match surrounding lines)
- [x] Documentation-only change, no code affected

Closes #2400, Closes #2401, Closes #2403