### PR TITLE
feat(archgate): add DOC-001 documentation consistency rule

### DIFF
--- a/.archgate/adrs/DOC-001-documentation-consistency.md
+++ b/.archgate/adrs/DOC-001-documentation-consistency.md
@@ -1,0 +1,52 @@
+---
+id: DOC-001
+title: Documentation Consistency
+domain: documentation
+rules: true
+files: ["**/*.md", "packages/*/src/**/*.ts"]
+---
+
+# Documentation Consistency
+
+## Context
+
+AI-driven development at high velocity (10+ PRs/day) creates "documentation debt" — features are added, refactored, or removed faster than docs are updated. This leads to phantom features documented in README/ARCHITECTURE that no longer exist in code.
+
+**Incident (2026-03-23)**: Deep audit found 9 phantom features in README.md including non-existent 3D Graph Visualization, broken Core Library API example, and references to unimplemented modules (PTMS, Simulacrum). Fixed in PRs #2393-#2410.
+
+## Decision
+
+### Feature-to-Doc Traceability
+
+When source files defining a feature are created, modified, or deleted, all `.md` documentation files must be checked for references to that feature.
+
+### What Counts as a Feature Change
+
+- **Created**: New command, renderer, service, or module added
+- **Renamed**: File or export renamed
+- **Deleted**: File removed or feature deprecated
+- **Moved**: File relocated to different path
+
+### Documentation Files to Check
+
+- `README.md` — User-facing features, packages table, examples
+- `ARCHITECTURE.md` — Components, services, layers
+- `VISION.md` — Implementation status column
+- `docs/` — Feature-specific guides
+- `CLAUDE.md` — Agent instructions with file paths and metrics
+
+## Do's and Don'ts
+
+### Do
+
+- Update README.md when adding/removing user-facing features
+- Update ARCHITECTURE.md when component counts change (commands, services, renderers, modals)
+- Mark removed feature docs with deprecation notice instead of silent deletion
+- Keep VISION.md status column current when features move from Planned → Implemented
+
+### Don't
+
+- Claim features exist in README that have no source code
+- Leave docs for removed features without deprecation notice
+- Reference file paths in .md files without verifying they exist
+- Use "coming soon" for features with no planned implementation work

--- a/.archgate/adrs/DOC-001-documentation-consistency.rules.ts
+++ b/.archgate/adrs/DOC-001-documentation-consistency.rules.ts
@@ -1,0 +1,145 @@
+/// <reference path="../rules.d.ts" />
+
+/**
+ * DOC-001: Documentation Consistency
+ *
+ * Detects phantom references in .md files — paths, classes, and exports
+ * that are documented but don't exist in the codebase.
+ */
+
+// Key documentation files to scan
+const DOC_FILES = [
+  "README.md",
+  "ARCHITECTURE.md",
+  "VISION.md",
+];
+
+// Paths that are intentionally external or planned
+const PATH_ALLOWLIST = [
+  "docs/", // docs may reference planned features
+  "http", // URLs
+  ".github/", // CI configs always exist
+];
+
+export default {
+  rules: {
+    "no-phantom-source-paths": {
+      description:
+        "Documentation must not reference source file paths that don't exist",
+      severity: "warning",
+      async check(ctx) {
+        for (const docFile of DOC_FILES) {
+          const exists = (await ctx.glob(docFile)).length > 0;
+          if (!exists) continue;
+
+          const content = await ctx.readFile(docFile);
+          const lines = content.split("\n");
+
+          for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+
+            // Match patterns like `packages/*/src/**/*.ts` or `src/path/File.ts`
+            const pathMatches = line.match(
+              /(?:packages\/[\w-]+\/(?:src|tests)\/[\w/./-]+\.tsx?)/g,
+            );
+            if (!pathMatches) continue;
+
+            for (const refPath of pathMatches) {
+              // Skip if in code block comment or allowlisted
+              if (PATH_ALLOWLIST.some((a) => refPath.includes(a))) continue;
+              // Skip glob patterns with wildcards
+              if (refPath.includes("*")) continue;
+
+              const found = await ctx.glob(refPath);
+              if (found.length === 0) {
+                ctx.report.warning({
+                  message: `Documentation references non-existent path: ${refPath}`,
+                  file: docFile,
+                  line: i + 1,
+                  fix: `Verify the path exists or update the reference. File may have been moved or deleted.`,
+                });
+              }
+            }
+          }
+        }
+      },
+    },
+
+    "no-stale-package-description": {
+      description:
+        "README package table must list all workspace packages",
+      severity: "warning",
+      async check(ctx) {
+        const readmeFiles = await ctx.glob("README.md");
+        if (readmeFiles.length === 0) return;
+
+        const readme = await ctx.readFile("README.md");
+
+        // Find all actual workspace packages
+        const packageDirs = await ctx.glob("packages/*/package.json");
+        const packageNames = packageDirs.map((p) => {
+          const parts = p.split("/");
+          return parts[parts.indexOf("packages") + 1];
+        });
+
+        // Check each package is mentioned in README
+        for (const pkg of packageNames) {
+          // Search for package name in various forms
+          const patterns = [
+            pkg, // e.g. "exocortex", "cli", "obsidian-plugin"
+            `packages/${pkg}`, // e.g. "packages/cli"
+          ];
+
+          const found = patterns.some((p) => readme.includes(p));
+          if (!found) {
+            ctx.report.warning({
+              message: `Package "${pkg}" exists in packages/ but is not mentioned in README.md`,
+              file: "README.md",
+              line: 1,
+              fix: `Add package to the Packages table in README.md`,
+            });
+          }
+        }
+      },
+    },
+
+    "no-coming-soon-without-issue": {
+      description:
+        'Features marked "coming soon" should have a linked GitHub issue',
+      severity: "warning",
+      async check(ctx) {
+        for (const docFile of DOC_FILES) {
+          const exists = (await ctx.glob(docFile)).length > 0;
+          if (!exists) continue;
+
+          const content = await ctx.readFile(docFile);
+          const lines = content.split("\n");
+
+          for (let i = 0; i < lines.length; i++) {
+            const line = lines[i].toLowerCase();
+            if (
+              line.includes("coming soon") ||
+              line.includes("coming shortly")
+            ) {
+              // Check if there's a GitHub issue reference nearby (within 3 lines)
+              const context = lines
+                .slice(Math.max(0, i - 1), i + 3)
+                .join(" ");
+              const hasIssueRef =
+                /#\d+/.test(context) || /github\.com.*issues/.test(context);
+
+              if (!hasIssueRef) {
+                ctx.report.warning({
+                  message: `"Coming soon" without linked issue — use "planned" instead or link to a GitHub issue`,
+                  file: docFile,
+                  line: i + 1,
+                  fix: `Replace "coming soon" with "planned" or add a GitHub issue reference: (#123)`,
+                });
+              }
+            }
+          }
+        }
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Adds automated Archgate rule DOC-001 to prevent phantom features in documentation — the exact problem discovered and manually fixed in this session's audit (PRs #2393-#2410).

### Three automated checks:
- **no-phantom-source-paths** — warns when README/ARCHITECTURE reference source file paths that don't exist
- **no-stale-package-description** — warns when a workspace package exists but isn't in README
- **no-coming-soon-without-issue** — warns when "coming soon" used without linked GitHub issue

### Motivation
2026-03-23 audit found 9 phantom features. This rule automates detection going forward.

## Test plan
- [ ] CI passes (Archgate 13/13 pass verified locally)