### PR TITLE
fix(core): add type guards for unknown frontmatter values in URIConstructionService

### DIFF
--- a/packages/exocortex/src/services/URIConstructionService.ts
+++ b/packages/exocortex/src/services/URIConstructionService.ts
@@ -67,7 +67,7 @@ export class URIConstructionService {
   private async resolveOntologyURL(asset: AssetMetadata): Promise<string> {
     const isDefinedBy = asset.frontmatter?.exo__Asset_isDefinedBy;
 
-    if (!isDefinedBy) {
+    if (!isDefinedBy || typeof isDefinedBy !== "string") {
       return this.defaultOntologyURL;
     }
 
@@ -94,7 +94,8 @@ export class URIConstructionService {
   }
 
   private extractUID(asset: AssetMetadata): string | null {
-    return asset.frontmatter?.exo__Asset_uid || null;
+    const uid = asset.frontmatter?.exo__Asset_uid;
+    return typeof uid === "string" ? uid : null;
   }
 
   private extractWikiLink(wikiLink: string): string {


### PR DESCRIPTION
## Summary
- Fix 2 TypeScript errors in `URIConstructionService.ts` that broke CI on main since PR #2376
- `frontmatter` is `Record<string, unknown>`, but values were used as `string` without type guards
- Added `typeof` checks instead of `as string` assertions for runtime safety

## Root Cause
PR #2376 replaced `console.*` with `ILogger` — the TypeScript errors in this file went unnoticed because unit tests pass (they don't run `tsc`), but `build` and `typecheck` CI jobs fail.

**Impact**: All 14+ commits after PR #2376 had failing CI → Auto Release skipped every time → no releases since `v15.0.1`.

## Changes
- **Line 70**: Added `typeof isDefinedBy !== "string"` guard before passing to `extractWikiLink()`
- **Line 97**: Replaced `uid || null` with `typeof uid === "string" ? uid : null` for correct narrowing

## Test plan
- [x] `tsc --noEmit --skipLibCheck` passes (0 errors)
- [x] All 212 plugin unit test suites pass
- [x] All 69/70 CLI test suites pass (1 pre-existing integration failure)
- [x] Pre-commit hooks pass (lint, BDD 100%, archgate)