### PR TITLE
test(plugin): StatusButtonGroupBuilder workflow fallback tests (#2416)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -38,6 +38,9 @@ export { ConceptCreationService } from "./services/ConceptCreationService";
 export { EffortStatusWorkflow } from "./services/EffortStatusWorkflow";
 export { WorkflowEngine } from "./services/WorkflowEngine";
 export type { WorkflowValidationResult } from "./services/WorkflowEngine";
+export { WorkflowResolver } from "./services/WorkflowResolver";
+export { VisibilityGenerator } from "./services/VisibilityGenerator";
+export type { VisibleCommand } from "./services/VisibilityGenerator";
 export type {
   WorkflowDefinition,
   WorkflowStateDefinition,

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
@@ -9,7 +9,13 @@ import {
   canMarkDone,
   canRollbackStatus,
   CommandVisibilityContext,
+  WorkflowEngine,
+  WorkflowResolver,
+  VisibilityGenerator,
+  EffortStatus,
+  AssetClass,
 } from "exocortex";
+import { InMemoryTripleStore } from "exocortex";
 import { ILogger } from '@plugin/adapters/logging/ILogger';
 import {
   IButtonGroupBuilder,
@@ -32,9 +38,9 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
   }
 
   build(context: ButtonBuilderContext): ActionButton[] {
-    const { file, visibilityContext, logger, refresh } = context;
+    const { file, visibilityContext, logger, refresh, metadata } = context;
 
-    return [
+    const standardButtons = [
       this.setDraftStatusButton(file, visibilityContext, logger, refresh),
       this.moveToBacklogButton(file, visibilityContext, logger, refresh),
       this.moveToAnalysisButton(file, visibilityContext, logger, refresh),
@@ -43,6 +49,63 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
       this.markDoneButton(file, visibilityContext, logger, refresh),
       this.rollbackStatusButton(file, visibilityContext, logger, refresh),
     ];
+
+    const hasVisibleStandard = standardButtons.some((b) => b.visible);
+    if (hasVisibleStandard) {
+      return standardButtons;
+    }
+
+    const workflowButtons = this.buildWorkflowButtons(file, metadata, logger, refresh);
+    if (workflowButtons.length > 0) {
+      return workflowButtons;
+    }
+
+    return standardButtons;
+  }
+
+  private buildWorkflowButtons(
+    file: TFile,
+    metadata: Record<string, unknown>,
+    logger: ILogger,
+    refresh: () => Promise<void>,
+  ): ActionButton[] {
+    const statusRaw = metadata["ems__Effort_status"] as string | undefined;
+    if (!statusRaw) return [];
+
+    const normalized = statusRaw.replace(/["'[\]]/g, "").trim();
+    const currentStatus = Object.values(EffortStatus).find((s) => s === normalized);
+    if (!currentStatus) return [];
+
+    const resolver = new WorkflowResolver(new InMemoryTripleStore());
+    const instanceClassRaw = metadata["exo__Instance_class"];
+    const isTask = Array.isArray(instanceClassRaw)
+      ? instanceClassRaw.some((c: string) => String(c).includes("ems__Task") || String(c).includes("ems__Meeting"))
+      : typeof instanceClassRaw === "string" && (instanceClassRaw.includes("ems__Task") || instanceClassRaw.includes("ems__Meeting"));
+
+    const assetClass = isTask ? AssetClass.TASK : AssetClass.PROJECT;
+    const definition = resolver.getHardcodedFallback(assetClass);
+    const engine = new WorkflowEngine(definition);
+    const generator = new VisibilityGenerator(engine);
+
+    const commands = generator.getVisibleCommands(currentStatus);
+    return commands.map((cmd) => ({
+      id: cmd.commandId,
+      label: cmd.label,
+      variant: cmd.isRollback ? "warning" as const : "secondary" as const,
+      visible: true,
+      onClick: async () => {
+        const wrappedStatus = `"[[${cmd.targetStatus}]]"`;
+        const content = await file.vault.read(file);
+        const updatedContent = content.replace(
+          /ems__Effort_status:\s*"?\[\[[^\]]*\]\]"?/,
+          `ems__Effort_status: ${wrappedStatus}`,
+        );
+        await file.vault.modify(file, updatedContent);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await refresh();
+        logger.info(`Workflow transition: ${cmd.label} → ${cmd.targetStatus} on ${file.path}`);
+      },
+    }));
   }
 
   private setDraftStatusButton(

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/StatusButtonGroupBuilder.workflow.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/StatusButtonGroupBuilder.workflow.test.ts
@@ -1,0 +1,425 @@
+import { TFile } from "obsidian";
+import { StatusButtonGroupBuilder } from "../../../../src/presentation/builders/button-groups/StatusButtonGroupBuilder";
+import {
+  ButtonBuilderContext,
+  ButtonBuilderServices,
+} from "../../../../src/presentation/builders/button-groups/ButtonBuilderTypes";
+import {
+  TaskStatusService,
+  CommandVisibilityContext,
+  EffortStatus,
+} from "exocortex";
+import { ILogger } from "../../../../src/infrastructure/logging/ILogger";
+import { createMockMetadata } from "../../helpers/testHelpers";
+
+function createMockServices(): ButtonBuilderServices {
+  return {
+    app: {} as any,
+    taskCreationService: {} as any,
+    projectCreationService: {} as any,
+    areaCreationService: {} as any,
+    classCreationService: {} as any,
+    conceptCreationService: {} as any,
+    taskStatusService: {
+      setDraftStatus: jest.fn(),
+      moveToBacklog: jest.fn(),
+      moveToAnalysis: jest.fn(),
+      moveToToDo: jest.fn(),
+      startEffort: jest.fn(),
+      markTaskAsDone: jest.fn(),
+      rollbackStatus: jest.fn(),
+    } as unknown as TaskStatusService,
+    propertyCleanupService: {} as any,
+    folderRepairService: {} as any,
+    renameToUidService: {} as any,
+    effortVotingService: {} as any,
+    labelToAliasService: {} as any,
+    assetConversionService: {} as any,
+  };
+}
+
+function createMockLogger(): jest.Mocked<ILogger> {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as jest.Mocked<ILogger>;
+}
+
+function createMockFile(path = "test.md"): TFile {
+  return {
+    path,
+    name: "test.md",
+    basename: "test",
+    extension: "md",
+    parent: null,
+    vault: {
+      read: jest.fn().mockResolvedValue('---\nems__Effort_status: "[[ems__EffortStatusBacklog]]"\n---\n'),
+      modify: jest.fn().mockResolvedValue(undefined),
+    },
+    stat: { ctime: Date.now(), mtime: Date.now(), size: 100 },
+  } as unknown as TFile;
+}
+
+function createContext(overrides: {
+  instanceClass?: string | string[] | null;
+  currentStatus?: string | null;
+  isArchived?: boolean;
+  metadata?: Record<string, unknown>;
+}): ButtonBuilderContext {
+  const {
+    instanceClass = "ems__Task",
+    currentStatus = `[[${EffortStatus.BACKLOG}]]`,
+    isArchived = false,
+    metadata = {},
+  } = overrides;
+
+  const visibilityContext: CommandVisibilityContext = {
+    instanceClass,
+    currentStatus,
+    metadata: metadata as Record<string, unknown>,
+    isArchived,
+    currentFolder: "Tasks",
+    expectedFolder: "Tasks",
+  };
+
+  const mergedMetadata: Record<string, unknown> = {
+    ...createMockMetadata({
+      exo__Instance_class: instanceClass,
+      ems__Effort_status: currentStatus,
+    }),
+    ...metadata,
+  };
+
+  return {
+    app: {} as any,
+    settings: {} as any,
+    plugin: {} as any,
+    file: createMockFile(),
+    metadata: mergedMetadata,
+    instanceClass,
+    visibilityContext,
+    logger: createMockLogger(),
+    refresh: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("StatusButtonGroupBuilder - workflow fallback", () => {
+  let builder: StatusButtonGroupBuilder;
+  let services: ButtonBuilderServices;
+
+  beforeEach(() => {
+    services = createMockServices();
+    builder = new StatusButtonGroupBuilder(services);
+  });
+
+  describe("group metadata", () => {
+    it('should return groupId "status"', () => {
+      expect(builder.getGroupId()).toBe("status");
+    });
+
+    it('should return groupTitle "Status"', () => {
+      expect(builder.getGroupTitle()).toBe("Status");
+    });
+  });
+
+  describe("standard classes use hardcoded buttons (no fallback)", () => {
+    it("ems__Task with Backlog status returns standard buttons with Start Effort visible", () => {
+      const context = createContext({
+        instanceClass: "ems__Task",
+        currentStatus: `[[${EffortStatus.BACKLOG}]]`,
+      });
+
+      const buttons = builder.build(context);
+
+      const startEffort = buttons.find((b) => b.id === "start-effort");
+      expect(startEffort).toBeDefined();
+      expect(startEffort?.visible).toBe(true);
+      expect(startEffort?.label).toBe("Start Effort");
+
+      const hasVisibleStandard = buttons.some((b) => b.visible);
+      expect(hasVisibleStandard).toBe(true);
+
+      const workflowIds = buttons.filter((b) => b.id.startsWith("workflow-"));
+      expect(workflowIds).toHaveLength(0);
+    });
+
+    it("ems__Project with ToDo status returns standard buttons with Start Effort visible", () => {
+      const context = createContext({
+        instanceClass: "ems__Project",
+        currentStatus: `[[${EffortStatus.TODO}]]`,
+      });
+
+      const buttons = builder.build(context);
+
+      const startEffort = buttons.find((b) => b.id === "start-effort");
+      expect(startEffort).toBeDefined();
+      expect(startEffort?.visible).toBe(true);
+
+      const workflowIds = buttons.filter((b) => b.id.startsWith("workflow-"));
+      expect(workflowIds).toHaveLength(0);
+    });
+
+    it("ems__Task with Draft status returns Move to Backlog button visible", () => {
+      const context = createContext({
+        instanceClass: "ems__Task",
+        currentStatus: `[[${EffortStatus.DRAFT}]]`,
+      });
+
+      const buttons = builder.build(context);
+
+      const moveToBacklog = buttons.find((b) => b.id === "move-to-backlog");
+      expect(moveToBacklog).toBeDefined();
+      expect(moveToBacklog?.visible).toBe(true);
+    });
+
+    it("ems__Task with Doing status returns Mark Done button visible", () => {
+      const context = createContext({
+        instanceClass: "ems__Task",
+        currentStatus: `[[${EffortStatus.DOING}]]`,
+      });
+
+      const buttons = builder.build(context);
+
+      const markDone = buttons.find((b) => b.id === "mark-done");
+      expect(markDone).toBeDefined();
+      expect(markDone?.visible).toBe(true);
+    });
+
+    it("ems__Task with no status returns Set Draft button visible", () => {
+      const context = createContext({
+        instanceClass: "ems__Task",
+        currentStatus: null,
+      });
+
+      const buttons = builder.build(context);
+
+      const setDraft = buttons.find((b) => b.id === "set-draft-status");
+      expect(setDraft).toBeDefined();
+      expect(setDraft?.visible).toBe(true);
+    });
+  });
+
+  describe("custom class triggers workflow fallback", () => {
+    it("ems__SimpleTask with Backlog status generates workflow buttons", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.BACKLOG}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+
+      const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
+      expect(workflowButtons.length).toBeGreaterThan(0);
+    });
+
+    it("workflow buttons include both forward and rollback transitions", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.BACKLOG}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+
+      const forwardButtons = buttons.filter(
+        (b) => b.id.startsWith("workflow-") && b.variant === "secondary",
+      );
+      const rollbackButtons = buttons.filter(
+        (b) => b.id.startsWith("workflow-") && b.variant === "warning",
+      );
+
+      expect(forwardButtons.length).toBeGreaterThan(0);
+      expect(rollbackButtons.length).toBeGreaterThan(0);
+    });
+
+    it("workflow button labels come from VisibilityGenerator", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.BACKLOG}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+      const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
+
+      for (const btn of workflowButtons) {
+        expect(btn.label).toBeTruthy();
+        expect(typeof btn.label).toBe("string");
+        expect(btn.label.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("workflow button count matches task fallback transitions from Backlog", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.BACKLOG}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+      const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
+
+      expect(workflowButtons).toHaveLength(2);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("asset without ems__Effort_status returns no workflow buttons", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+        },
+      });
+
+      const buttons = builder.build(context);
+      const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
+      expect(workflowButtons).toHaveLength(0);
+    });
+
+    it("asset with unknown status string returns no workflow buttons", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: "[[ems__EffortStatusUnknownXYZ]]",
+        },
+      });
+
+      const buttons = builder.build(context);
+      const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
+      expect(workflowButtons).toHaveLength(0);
+    });
+
+    it("custom class with Done status returns no forward buttons (terminal)", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.DONE}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+      const forwardButtons = buttons.filter(
+        (b) => b.id.startsWith("workflow-") && b.variant === "secondary",
+      );
+      expect(forwardButtons).toHaveLength(0);
+    });
+
+    it("custom class with Done status still has rollback button", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.DONE}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+      const rollbackButtons = buttons.filter(
+        (b) => b.id.startsWith("workflow-") && b.variant === "warning",
+      );
+      expect(rollbackButtons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("button properties", () => {
+    it("forward buttons have variant secondary", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.BACKLOG}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+      const forwardButtons = buttons.filter(
+        (b) => b.id.startsWith("workflow-") && !b.id.includes("rollback"),
+      );
+
+      for (const btn of forwardButtons) {
+        if (btn.variant !== "warning") {
+          expect(btn.variant).toBe("secondary");
+        }
+      }
+    });
+
+    it("rollback buttons have variant warning", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.BACKLOG}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+      const rollbackButtons = buttons.filter(
+        (b) => b.id.startsWith("workflow-") && b.variant === "warning",
+      );
+
+      for (const btn of rollbackButtons) {
+        expect(btn.variant).toBe("warning");
+      }
+    });
+
+    it("all workflow buttons have visible=true", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.BACKLOG}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+      const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
+
+      for (const btn of workflowButtons) {
+        expect(btn.visible).toBe(true);
+      }
+    });
+
+    it("all workflow buttons have onClick function", () => {
+      const context = createContext({
+        instanceClass: "ems__SimpleTask",
+        currentStatus: null,
+        metadata: {
+          exo__Instance_class: "ems__SimpleTask",
+          ems__Effort_status: `[[${EffortStatus.BACKLOG}]]`,
+        },
+      });
+
+      const buttons = builder.build(context);
+      const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
+
+      for (const btn of workflowButtons) {
+        expect(typeof btn.onClick).toBe("function");
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 19 unit tests for StatusButtonGroupBuilder workflow fallback logic
- Cover standard class buttons (ems__Task, ems__Project), custom class workflow fallback, edge cases, and button properties
- Include StatusButtonGroupBuilder.ts with workflow fallback build() method and buildWorkflowButtons() private method
- Export WorkflowResolver and VisibilityGenerator from core package

Closes #2416