### PR TITLE
feat(plugin): wire ITripleStore into StatusButtonGroupBuilder (#2419)

### DIFF
--- a/packages/exocortex/src/services/WorkflowResolver.ts
+++ b/packages/exocortex/src/services/WorkflowResolver.ts
@@ -198,6 +198,10 @@ export class WorkflowResolver {
     // Load transitions
     const transitions = await this.loadTransitions(workflowSubject);
 
+    if (states.length === 0 && transitions.length === 0) {
+      return null;
+    }
+
     return {
       id,
       name,

--- a/packages/exocortex/tests/unit/services/WorkflowResolver.nullReturn.test.ts
+++ b/packages/exocortex/tests/unit/services/WorkflowResolver.nullReturn.test.ts
@@ -1,0 +1,97 @@
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { WorkflowResolver } from "../../../src/services/WorkflowResolver";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import { AssetClass } from "../../../src/domain/constants/AssetClass";
+import { EffortStatus } from "../../../src/domain/constants/EffortStatus";
+
+describe("WorkflowResolver - null return for empty workflow data", () => {
+  let store: InMemoryTripleStore;
+  let resolver: WorkflowResolver;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    resolver = new WorkflowResolver(store);
+  });
+
+  describe("loadWorkflowBySubject returns null", () => {
+    it("should return null when workflow IRI has no states and no transitions", async () => {
+      const workflowIRI = new IRI("obsidian://vault/empty-workflow.md");
+
+      await store.addAll([
+        new Triple(workflowIRI, Namespace.RDF.term("type"), Namespace.EMS.term("Workflow")),
+        new Triple(workflowIRI, Namespace.EXO.term("Asset_uid"), new Literal("empty-workflow")),
+        new Triple(workflowIRI, Namespace.EXO.term("Asset_label"), new Literal("Empty Workflow")),
+        new Triple(workflowIRI, Namespace.EMS.term("Workflow_targetClass"), Namespace.EMS.term("Task")),
+        new Triple(workflowIRI, Namespace.EMS.term("Workflow_isDefault"), new Literal("true")),
+        new Triple(workflowIRI, Namespace.EMS.term("Workflow_initialState"), new Literal(EffortStatus.DRAFT)),
+      ]);
+
+      const result = await resolver.resolveForClass(AssetClass.TASK);
+
+      expect(result.id).toBe("hardcoded-task-default");
+      expect(result.name).toContain("hardcoded");
+    });
+  });
+
+  describe("resolveForAsset falls back to class default", () => {
+    it("should fall back to hardcoded when asset-specific workflow has no states/transitions", async () => {
+      const assetIRI = new IRI("obsidian://vault/my-task.md");
+      const workflowIRI = new IRI("obsidian://vault/empty-workflow.md");
+
+      await store.addAll([
+        new Triple(assetIRI, Namespace.EMS.term("Effort_workflow"), workflowIRI),
+        new Triple(workflowIRI, Namespace.RDF.term("type"), Namespace.EMS.term("Workflow")),
+        new Triple(workflowIRI, Namespace.EXO.term("Asset_uid"), new Literal("empty-workflow")),
+        new Triple(workflowIRI, Namespace.EXO.term("Asset_label"), new Literal("Empty Workflow")),
+        new Triple(workflowIRI, Namespace.EMS.term("Workflow_targetClass"), Namespace.EMS.term("Task")),
+        new Triple(workflowIRI, Namespace.EMS.term("Workflow_isDefault"), new Literal("false")),
+      ]);
+
+      const result = await resolver.resolveForAsset(assetIRI, AssetClass.TASK);
+
+      expect(result.id).toBe("hardcoded-task-default");
+    });
+  });
+
+  describe("resolveForClass with populated workflow", () => {
+    it("should return vault workflow when states and transitions exist", async () => {
+      const workflowIRI = new IRI("obsidian://vault/real-workflow.md");
+
+      await store.addAll([
+        new Triple(workflowIRI, Namespace.RDF.term("type"), Namespace.EMS.term("Workflow")),
+        new Triple(workflowIRI, Namespace.EXO.term("Asset_uid"), new Literal("real-workflow")),
+        new Triple(workflowIRI, Namespace.EXO.term("Asset_label"), new Literal("Real Workflow")),
+        new Triple(workflowIRI, Namespace.EMS.term("Workflow_targetClass"), Namespace.EMS.term("Task")),
+        new Triple(workflowIRI, Namespace.EMS.term("Workflow_isDefault"), new Literal("true")),
+        new Triple(workflowIRI, Namespace.EMS.term("Workflow_initialState"), new Literal(EffortStatus.DRAFT)),
+      ]);
+
+      const stateIRI = new IRI("obsidian://vault/state-draft.md");
+      await store.addAll([
+        new Triple(stateIRI, Namespace.RDF.term("type"), Namespace.EMS.term("WorkflowState")),
+        new Triple(stateIRI, Namespace.EMS.term("WorkflowState_workflow"), workflowIRI),
+        new Triple(stateIRI, Namespace.EMS.term("WorkflowState_status"), new Literal(EffortStatus.DRAFT)),
+        new Triple(stateIRI, Namespace.EMS.term("WorkflowState_order"), new Literal("1")),
+      ]);
+
+      const transIRI = new IRI("obsidian://vault/trans-draft-backlog.md");
+      await store.addAll([
+        new Triple(transIRI, Namespace.RDF.term("type"), Namespace.EMS.term("WorkflowTransition")),
+        new Triple(transIRI, Namespace.EMS.term("WorkflowTransition_workflow"), workflowIRI),
+        new Triple(transIRI, Namespace.EMS.term("WorkflowTransition_from"), new Literal(EffortStatus.DRAFT)),
+        new Triple(transIRI, Namespace.EMS.term("WorkflowTransition_to"), new Literal(EffortStatus.BACKLOG)),
+        new Triple(transIRI, Namespace.EMS.term("WorkflowTransition_label"), new Literal("Move to Backlog")),
+      ]);
+
+      const result = await resolver.resolveForClass(AssetClass.TASK);
+
+      expect(result.id).toBe("real-workflow");
+      expect(result.name).toBe("Real Workflow");
+      expect(result.states).toHaveLength(1);
+      expect(result.transitions).toHaveLength(1);
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/services/WorkflowResolver.perProject.test.ts
+++ b/packages/exocortex/tests/unit/services/WorkflowResolver.perProject.test.ts
@@ -199,22 +199,20 @@ describe("WorkflowResolver — per-project workflow override (ems__Effort_workfl
     expect(workflow.isDefault).toBe(false);
   });
 
-  it("should return a degraded workflow when ems__Effort_workflow points to non-existent workflow subject", async () => {
-    // When the workflow IRI exists as a reference but has no triples in the store,
-    // loadWorkflowBySubject still constructs a minimal WorkflowDefinition with defaults.
-    // This is by design: the IRI is valid, it just has no states/transitions loaded.
+  it("should fall back to class default when ems__Effort_workflow points to non-existent workflow subject", async () => {
+    // When the workflow IRI exists as a reference but has no states/transitions in the store,
+    // loadWorkflowBySubject returns null, causing resolveForAsset to fall back to
+    // the class default (hardcoded fallback).
     const assetSubject = new IRI("obsidian://vault/my-project.md");
     const nonExistentWorkflow = new IRI("obsidian://vault/does-not-exist.md");
     await setAssetWorkflow(store, assetSubject, nonExistentWorkflow);
 
     const workflow = await resolver.resolveForAsset(assetSubject, AssetClass.PROJECT);
 
-    // Uses the IRI value as id (no uid triple found), and "Unknown Workflow" as name
-    expect(workflow.id).toBe("obsidian://vault/does-not-exist.md");
-    expect(workflow.name).toBe("Unknown Workflow");
-    expect(workflow.states).toHaveLength(0);
-    expect(workflow.transitions).toHaveLength(0);
-    // Terminal states default to [DONE, TRASHED] when none specified
+    expect(workflow.id).toBe("hardcoded-project-default");
+    expect(workflow.name).toContain("hardcoded");
+    expect(workflow.states.length).toBeGreaterThan(0);
+    expect(workflow.transitions.length).toBeGreaterThan(0);
     expect(workflow.terminalStates).toContain(EffortStatus.DONE);
     expect(workflow.terminalStates).toContain(EffortStatus.TRASHED);
   });

--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -20,6 +20,7 @@ import {
   MetadataExtractor,
   CriticalityZoneService,
 } from "exocortex";
+import type { ITripleStore } from "exocortex";
 import {
   ButtonBuilderContext,
   ButtonBuilderServices,
@@ -74,6 +75,8 @@ export interface ButtonGroupsBuilderConfig {
   metadataExtractor: MetadataExtractor;
   /** Logger instance */
   logger: ILogger;
+  /** Triple store for workflow resolution (optional, falls back to empty store) */
+  tripleStore?: ITripleStore;
   /** Callback to refresh the view */
   refresh: () => Promise<void>;
 }
@@ -115,6 +118,7 @@ export class ButtonGroupsBuilder {
       labelToAliasService,
       assetConversionService,
       criticalityZoneService,
+      tripleStore,
       metadataExtractor,
       logger,
       refresh,
@@ -142,6 +146,7 @@ export class ButtonGroupsBuilder {
       effortVotingService,
       labelToAliasService,
       assetConversionService,
+      tripleStore,
     };
 
     // Initialize specialized builders

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/ButtonBuilderTypes.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/ButtonBuilderTypes.ts
@@ -15,6 +15,7 @@ import { RenameToUidService } from "exocortex";
 import { EffortVotingService } from "exocortex";
 import { LabelToAliasService } from "exocortex";
 import { AssetConversionService } from "exocortex";
+import type { ITripleStore } from "exocortex";
 import { ObsidianApp, ExocortexPluginInterface, MetadataRecord } from '@plugin/types';
 
 /**
@@ -49,6 +50,7 @@ export interface ButtonBuilderServices {
   effortVotingService: EffortVotingService;
   labelToAliasService: LabelToAliasService;
   assetConversionService: AssetConversionService;
+  tripleStore?: ITripleStore;
 }
 
 /**

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
@@ -76,7 +76,8 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
     const currentStatus = Object.values(EffortStatus).find((s) => s === normalized);
     if (!currentStatus) return [];
 
-    const resolver = new WorkflowResolver(new InMemoryTripleStore());
+    const store = this.services.tripleStore ?? new InMemoryTripleStore();
+    const resolver = new WorkflowResolver(store);
     const instanceClassRaw = metadata["exo__Instance_class"];
     const isTask = Array.isArray(instanceClassRaw)
       ? instanceClassRaw.some((c: string) => String(c).includes("ems__Task") || String(c).includes("ems__Meeting"))

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -116,6 +116,8 @@ export class UniversalLayoutRenderer {
       this.app, this.settings, this.reactRenderer, this.backlinksCacheManager,
       this.metadataService, this.plugin, () => this.refresh(), this.vaultAdapter);
 
+    const tripleStore = this.resolveTripleStore();
+
     this.buttonGroupsBuilder = new ButtonGroupsBuilder({
       app: this.app,
       settings: this.settings,
@@ -133,6 +135,7 @@ export class UniversalLayoutRenderer {
       labelToAliasService: services.labelToAlias,
       assetConversionService: services.assetConversion,
       criticalityZoneService: services.criticalityZone,
+      tripleStore,
       metadataExtractor: this.metadataExtractor,
       logger: this.logger,
       refresh: () => this.refresh(),
@@ -153,6 +156,17 @@ export class UniversalLayoutRenderer {
       sectionStateManager: this.sectionStateManager,
       eventListenerManager: this.eventListenerManager,
     });
+  }
+
+  private resolveTripleStore() {
+    const pluginAny = this.plugin as unknown as Record<string, unknown>;
+    if (
+      pluginAny.sparql &&
+      typeof (pluginAny.sparql as Record<string, unknown>).getTripleStore === "function"
+    ) {
+      return (pluginAny.sparql as { getTripleStore(): import("exocortex").ITripleStore }).getTripleStore();
+    }
+    return undefined;
   }
 
   private resolveServices() {


### PR DESCRIPTION
## Summary

Connect `WorkflowResolver` to the plugin's real `ITripleStore` so workflow buttons can eventually be generated from vault workflow assets instead of always using hardcoded fallbacks.

### Changes

- **ButtonBuilderTypes.ts**: Add optional `tripleStore?: ITripleStore` to `ButtonBuilderServices`
- **StatusButtonGroupBuilder.ts**: Use injected triple store (`this.services.tripleStore`) instead of creating a new empty `InMemoryTripleStore()`
- **ButtonGroupsBuilder.ts**: Add `tripleStore` to config interface and pass through to services
- **UniversalLayoutRenderer.ts**: Resolve triple store from plugin's `SPARQLApi.getTripleStore()` and pass to `ButtonGroupsBuilder`
- **WorkflowResolver.ts**: Fix `loadWorkflowBySubject()` to return `null` when workflow has no states and no transitions (previously returned a degraded definition that masked missing data)
- **Tests**: 3 new unit tests for null-return behavior, 1 existing test updated

### Why

The `buildWorkflowButtons()` method was creating `new InMemoryTripleStore()` (empty), meaning custom workflow `.md` files in the vault were always ignored. Now the real triple store is passed through, and when the build method becomes async in a future PR, vault-based workflow resolution will work automatically.

### Note

The `build()` method is still synchronous and uses `getHardcodedFallback()`. The async `resolveForClass()` cannot be called from sync code. This PR wires the plumbing so a future async refactor will "just work".

Closes #2419