### PR TITLE
fix(plugin): set timestamps on workflow button transitions (#2421)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
@@ -96,12 +96,32 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
       visible: true,
       onClick: async () => {
         const wrappedStatus = `"[[${cmd.targetStatus}]]"`;
-        const content = await file.vault.read(file);
-        const updatedContent = content.replace(
+        let content = await file.vault.read(file);
+        content = content.replace(
           /ems__Effort_status:\s*"?\[\[[^\]]*\]\]"?/,
           `ems__Effort_status: ${wrappedStatus}`,
         );
-        await file.vault.modify(file, updatedContent);
+
+        const targetState = definition.states.find(
+          (s: { status: string }) => s.status === cmd.targetStatus,
+        );
+        if (targetState && targetState.timestampOnEnter.length > 0) {
+          const now = new Date();
+          const ts = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}T${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}:${String(now.getSeconds()).padStart(2, "0")}`;
+          for (const prop of targetState.timestampOnEnter) {
+            const propRegex = new RegExp(`${prop}:\\s*.*`);
+            if (propRegex.test(content)) {
+              content = content.replace(propRegex, `${prop}: ${ts}`);
+            } else {
+              content = content.replace(
+                /ems__Effort_status:/,
+                `${prop}: ${ts}\nems__Effort_status:`,
+              );
+            }
+          }
+        }
+
+        await file.vault.modify(file, content);
         await new Promise((resolve) => setTimeout(resolve, 100));
         await refresh();
         logger.info(`Workflow transition: ${cmd.label} → ${cmd.targetStatus} on ${file.path}`);


### PR DESCRIPTION
## Summary
Workflow buttons now set timestamps from `WorkflowStateDefinition.timestampOnEnter` when clicked.

**Before**: clicking "✓ Complete" only changed status, no timestamps
**After**: clicking "✓ Complete" sets `ems__Effort_endTimestamp` + `ems__Effort_resolutionTimestamp`

## How it works
1. On button click, finds target `WorkflowStateDefinition` by status
2. Reads `timestampOnEnter[]` array (e.g., `["ems__Effort_startTimestamp"]`)
3. For each property: updates existing or inserts before `ems__Effort_status`
4. Timestamp format: ISO 8601 local time (`YYYY-MM-DDTHH:MM:SS`)

Closes #2421