### PR TITLE
fix(plugin): resolve workflow from triple store for custom asset classes

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -205,7 +205,7 @@ export class ButtonGroupsBuilder {
     // Build groups from all builders, filtering out empty ones
     const groups: ButtonGroup[] = [];
     for (const builder of this.builders) {
-      const group = createButtonGroupIfVisible(builder, context);
+      const group = await createButtonGroupIfVisible(builder, context);
       if (group) {
         groups.push(group);
       }

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/ButtonBuilderTypes.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/ButtonBuilderTypes.ts
@@ -57,7 +57,7 @@ export interface ButtonBuilderServices {
  * Interface for button group builders
  */
 export interface IButtonGroupBuilder {
-  build(context: ButtonBuilderContext): ActionButton[];
+  build(context: ButtonBuilderContext): ActionButton[] | Promise<ActionButton[]>;
   getGroupId(): string;
   getGroupTitle(): string;
 }
@@ -65,11 +65,11 @@ export interface IButtonGroupBuilder {
 /**
  * Helper to create button group if it has visible buttons
  */
-export function createButtonGroupIfVisible(
+export async function createButtonGroupIfVisible(
   builder: IButtonGroupBuilder,
   context: ButtonBuilderContext,
-): ButtonGroup | null {
-  const buttons = builder.build(context);
+): Promise<ButtonGroup | null> {
+  const buttons = await builder.build(context);
   if (buttons.some((btn) => btn.visible)) {
     return {
       id: builder.getGroupId(),

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
@@ -14,8 +14,8 @@ import {
   VisibilityGenerator,
   EffortStatus,
   AssetClass,
+  InMemoryTripleStore,
 } from "exocortex";
-import { InMemoryTripleStore } from "exocortex";
 import { ILogger } from '@plugin/adapters/logging/ILogger';
 import {
   IButtonGroupBuilder,
@@ -37,7 +37,7 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
     return "Status";
   }
 
-  build(context: ButtonBuilderContext): ActionButton[] {
+  async build(context: ButtonBuilderContext): Promise<ActionButton[]> {
     const { file, visibilityContext, logger, refresh, metadata } = context;
 
     const standardButtons = [
@@ -55,7 +55,7 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
       return standardButtons;
     }
 
-    const workflowButtons = this.buildWorkflowButtons(file, metadata, logger, refresh);
+    const workflowButtons = await this.buildWorkflowButtons(file, metadata, logger, refresh);
     if (workflowButtons.length > 0) {
       return workflowButtons;
     }
@@ -63,12 +63,12 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
     return standardButtons;
   }
 
-  private buildWorkflowButtons(
+  private async buildWorkflowButtons(
     file: TFile,
     metadata: Record<string, unknown>,
     logger: ILogger,
     refresh: () => Promise<void>,
-  ): ActionButton[] {
+  ): Promise<ActionButton[]> {
     const statusRaw = metadata["ems__Effort_status"] as string | undefined;
     if (!statusRaw) return [];
 
@@ -79,12 +79,33 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
     const store = this.services.tripleStore ?? new InMemoryTripleStore();
     const resolver = new WorkflowResolver(store);
     const instanceClassRaw = metadata["exo__Instance_class"];
-    const isTask = Array.isArray(instanceClassRaw)
-      ? instanceClassRaw.some((c: string) => String(c).includes("ems__Task") || String(c).includes("ems__Meeting"))
-      : typeof instanceClassRaw === "string" && (instanceClassRaw.includes("ems__Task") || instanceClassRaw.includes("ems__Meeting"));
 
-    const assetClass = isTask ? AssetClass.TASK : AssetClass.PROJECT;
-    const definition = resolver.getHardcodedFallback(assetClass);
+    const rawClass = Array.isArray(instanceClassRaw)
+      ? (instanceClassRaw[0] as string ?? "")
+      : (typeof instanceClassRaw === "string" ? instanceClassRaw : "");
+    const normalizedClass = rawClass.replace(/["'[\]]/g, "").trim() as AssetClass;
+
+    const isKnownTask = normalizedClass === AssetClass.TASK || normalizedClass === AssetClass.MEETING;
+    const isKnownProject = normalizedClass === AssetClass.PROJECT;
+    const fallbackClass = isKnownTask ? AssetClass.TASK : AssetClass.PROJECT;
+
+    let definition;
+    if (!isKnownTask && !isKnownProject) {
+      try {
+        const storeCount = await store.count();
+        if (storeCount > 0) {
+          definition = await resolver.resolveForClass(normalizedClass);
+          if (definition.states.length === 0 && definition.transitions.length === 0) {
+            definition = null;
+          }
+        }
+      } catch {
+        // Fall through to hardcoded
+      }
+    }
+    if (!definition) {
+      definition = resolver.getHardcodedFallback(fallbackClass);
+    }
     const engine = new WorkflowEngine(definition);
     const generator = new VisibilityGenerator(engine);
 

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/StatusButtonGroupBuilder.workflow.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/StatusButtonGroupBuilder.workflow.test.ts
@@ -125,13 +125,13 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
   });
 
   describe("standard classes use hardcoded buttons (no fallback)", () => {
-    it("ems__Task with Backlog status returns standard buttons with Start Effort visible", () => {
+    it("ems__Task with Backlog status returns standard buttons with Start Effort visible", async () => {
       const context = createContext({
         instanceClass: "ems__Task",
         currentStatus: `[[${EffortStatus.BACKLOG}]]`,
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
 
       const startEffort = buttons.find((b) => b.id === "start-effort");
       expect(startEffort).toBeDefined();
@@ -145,13 +145,13 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
       expect(workflowIds).toHaveLength(0);
     });
 
-    it("ems__Project with ToDo status returns standard buttons with Start Effort visible", () => {
+    it("ems__Project with ToDo status returns standard buttons with Start Effort visible", async () => {
       const context = createContext({
         instanceClass: "ems__Project",
         currentStatus: `[[${EffortStatus.TODO}]]`,
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
 
       const startEffort = buttons.find((b) => b.id === "start-effort");
       expect(startEffort).toBeDefined();
@@ -161,39 +161,39 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
       expect(workflowIds).toHaveLength(0);
     });
 
-    it("ems__Task with Draft status returns Move to Backlog button visible", () => {
+    it("ems__Task with Draft status returns Move to Backlog button visible", async () => {
       const context = createContext({
         instanceClass: "ems__Task",
         currentStatus: `[[${EffortStatus.DRAFT}]]`,
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
 
       const moveToBacklog = buttons.find((b) => b.id === "move-to-backlog");
       expect(moveToBacklog).toBeDefined();
       expect(moveToBacklog?.visible).toBe(true);
     });
 
-    it("ems__Task with Doing status returns Mark Done button visible", () => {
+    it("ems__Task with Doing status returns Mark Done button visible", async () => {
       const context = createContext({
         instanceClass: "ems__Task",
         currentStatus: `[[${EffortStatus.DOING}]]`,
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
 
       const markDone = buttons.find((b) => b.id === "mark-done");
       expect(markDone).toBeDefined();
       expect(markDone?.visible).toBe(true);
     });
 
-    it("ems__Task with no status returns Set Draft button visible", () => {
+    it("ems__Task with no status returns Set Draft button visible", async () => {
       const context = createContext({
         instanceClass: "ems__Task",
         currentStatus: null,
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
 
       const setDraft = buttons.find((b) => b.id === "set-draft-status");
       expect(setDraft).toBeDefined();
@@ -202,7 +202,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
   });
 
   describe("custom class triggers workflow fallback", () => {
-    it("ems__SimpleTask with Backlog status generates workflow buttons", () => {
+    it("ems__SimpleTask with Backlog status generates workflow buttons", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -212,13 +212,13 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
 
       const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
       expect(workflowButtons.length).toBeGreaterThan(0);
     });
 
-    it("workflow buttons include both forward and rollback transitions", () => {
+    it("workflow buttons include both forward and rollback transitions", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -228,7 +228,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
 
       const forwardButtons = buttons.filter(
         (b) => b.id.startsWith("workflow-") && b.variant === "secondary",
@@ -241,7 +241,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
       expect(rollbackButtons.length).toBeGreaterThan(0);
     });
 
-    it("workflow button labels come from VisibilityGenerator", () => {
+    it("workflow button labels come from VisibilityGenerator", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -251,7 +251,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
 
       for (const btn of workflowButtons) {
@@ -261,7 +261,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
       }
     });
 
-    it("workflow button count matches task fallback transitions from Backlog", () => {
+    it("workflow button count matches task fallback transitions from Backlog", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -271,7 +271,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
 
       expect(workflowButtons).toHaveLength(2);
@@ -279,7 +279,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
   });
 
   describe("edge cases", () => {
-    it("asset without ems__Effort_status returns no workflow buttons", () => {
+    it("asset without ems__Effort_status returns no workflow buttons", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -288,12 +288,12 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
       expect(workflowButtons).toHaveLength(0);
     });
 
-    it("asset with unknown status string returns no workflow buttons", () => {
+    it("asset with unknown status string returns no workflow buttons", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -303,12 +303,12 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
       expect(workflowButtons).toHaveLength(0);
     });
 
-    it("custom class with Done status returns no forward buttons (terminal)", () => {
+    it("custom class with Done status returns no forward buttons (terminal)", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -318,14 +318,14 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const forwardButtons = buttons.filter(
         (b) => b.id.startsWith("workflow-") && b.variant === "secondary",
       );
       expect(forwardButtons).toHaveLength(0);
     });
 
-    it("custom class with Done status still has rollback button", () => {
+    it("custom class with Done status still has rollback button", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -335,7 +335,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const rollbackButtons = buttons.filter(
         (b) => b.id.startsWith("workflow-") && b.variant === "warning",
       );
@@ -344,7 +344,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
   });
 
   describe("button properties", () => {
-    it("forward buttons have variant secondary", () => {
+    it("forward buttons have variant secondary", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -354,7 +354,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const forwardButtons = buttons.filter(
         (b) => b.id.startsWith("workflow-") && !b.id.includes("rollback"),
       );
@@ -366,7 +366,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
       }
     });
 
-    it("rollback buttons have variant warning", () => {
+    it("rollback buttons have variant warning", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -376,7 +376,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const rollbackButtons = buttons.filter(
         (b) => b.id.startsWith("workflow-") && b.variant === "warning",
       );
@@ -386,7 +386,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
       }
     });
 
-    it("all workflow buttons have visible=true", () => {
+    it("all workflow buttons have visible=true", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -396,7 +396,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
 
       for (const btn of workflowButtons) {
@@ -404,7 +404,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
       }
     });
 
-    it("all workflow buttons have onClick function", () => {
+    it("all workflow buttons have onClick function", async () => {
       const context = createContext({
         instanceClass: "ems__SimpleTask",
         currentStatus: null,
@@ -414,7 +414,7 @@ describe("StatusButtonGroupBuilder - workflow fallback", () => {
         },
       });
 
-      const buttons = builder.build(context);
+      const buttons = await builder.build(context);
       const workflowButtons = buttons.filter((b) => b.id.startsWith("workflow-"));
 
       for (const btn of workflowButtons) {


### PR DESCRIPTION
## Problem
Custom asset classes like `ems__SimpleTask` always got hardcoded Project workflow buttons ("→ Analysis", "← Draft") instead of their actual vault-defined workflow ("✓ Complete").

**Root cause**: `buildWorkflowButtons()` always called `resolver.getHardcodedFallback(PROJECT)` — never queried the triple store.

## Fix
- For custom classes (not Task/Meeting/Project), query triple store via `resolveForClass()` using the actual class name from metadata
- Make `IButtonGroupBuilder.build()` support async (returns `Promise<ActionButton[]>`)
- Make `createButtonGroupIfVisible()` async
- Update 17 tests for async build

**Before**: `ems__SimpleTask` → hardcoded Project workflow → "→ Analysis" button
**After**: `ems__SimpleTask` → triple store → SimpleTask Workflow → "✓ Complete" button

## Test plan
- [x] 146 tests pass (17 updated for async)
- [x] Pre-commit: lint ✅, BDD 100% ✅, Archgate 13/13 ✅
- [ ] CI pipeline
- [ ] Manual: ems__SimpleTask "Купить молоко" shows "✓ Complete" button