### PR TITLE
feat(core): exocmd domain models and ontology constants

### DIFF
--- a/packages/exocortex/src/domain/constants/AssetClass.ts
+++ b/packages/exocortex/src/domain/constants/AssetClass.ts
@@ -26,4 +26,12 @@ export enum AssetClass {
   WORKFLOW_STATE = "ems__WorkflowState",
   /** Transition between workflow states (Issue #2358) */
   WORKFLOW_TRANSITION = "ems__WorkflowTransition",
+  /** Dynamic command definition (RFC-009, Issue #2427) */
+  COMMAND = "exocmd__Command",
+  /** Precondition for command visibility (RFC-009, Issue #2427) */
+  PRECONDITION = "exocmd__Precondition",
+  /** Grounding action for command execution (RFC-009, Issue #2427) */
+  GROUNDING = "exocmd__Grounding",
+  /** Binding of command to asset context (RFC-009, Issue #2427) */
+  COMMAND_BINDING = "exocmd__CommandBinding",
 }

--- a/packages/exocortex/src/domain/constants/CommandProperty.ts
+++ b/packages/exocortex/src/domain/constants/CommandProperty.ts
@@ -1,0 +1,63 @@
+/**
+ * Property constants for dynamic command ontology classes (RFC-009 Section 4.5).
+ *
+ * These constants define the frontmatter property names used by
+ * exocmd__Command, exocmd__Precondition, exocmd__Grounding,
+ * and exocmd__CommandBinding assets.
+ */
+
+/** Properties for exocmd__Command assets */
+export const CommandProperty = {
+  /** Lucide icon name for the command button */
+  ICON: "exocmd__Command_icon",
+  /** Reference to a Precondition asset (wikilink) */
+  PRECONDITION: "exocmd__Command_precondition",
+  /** Reference to a Grounding asset (wikilink) */
+  GROUNDING: "exocmd__Command_grounding",
+  /** Text shown in confirmation dialog before execution */
+  CONFIRM_MESSAGE: "exocmd__Command_confirmMessage",
+  /** Text shown after successful execution */
+  SUCCESS_MESSAGE: "exocmd__Command_successMessage",
+  /** Category for grouping: "maintenance", "status", "planning" */
+  CATEGORY: "exocmd__Command_category",
+} as const;
+
+/** Properties for exocmd__Precondition assets */
+export const PreconditionProperty = {
+  /** SPARQL ASK query that determines command visibility */
+  SPARQL_ASK: "exocmd__Precondition_sparqlAsk",
+} as const;
+
+/** Properties for exocmd__Grounding assets */
+export const GroundingProperty = {
+  /** Grounding type: sparql_update | property_delete | property_set | composite | service_call */
+  TYPE: "exocmd__Grounding_type",
+  /** SPARQL UPDATE query (for sparql_update type) */
+  SPARQL_UPDATE: "exocmd__Grounding_sparqlUpdate",
+  /** Frontmatter property name to modify (for property_delete / property_set) */
+  TARGET_PROPERTY: "exocmd__Grounding_targetProperty",
+  /** Value to set (for property_set type) */
+  TARGET_VALUE: "exocmd__Grounding_targetValue",
+  /** Ordered array of Grounding asset references (for composite type) */
+  STEPS: "exocmd__Grounding_steps",
+} as const;
+
+/** Properties for exocmd__CommandBinding assets */
+export const CommandBindingProperty = {
+  /** Reference to the Command asset (wikilink) */
+  COMMAND: "exocmd__CommandBinding_command",
+  /** Apply to all assets of this class (wikilink) */
+  TARGET_CLASS: "exocmd__CommandBinding_targetClass",
+  /** Apply to all instances of this prototype (wikilink) */
+  TARGET_PROTOTYPE: "exocmd__CommandBinding_targetPrototype",
+  /** Apply to a specific asset (wikilink) */
+  TARGET_ASSET: "exocmd__CommandBinding_targetAsset",
+  /** Where to render: "column" | "inline" | "hover" | "contextMenu" */
+  POSITION: "exocmd__CommandBinding_position",
+  /** Sort order among buttons (default: 100) */
+  ORDER: "exocmd__CommandBinding_order",
+  /** Button group name for grouping related commands */
+  GROUP: "exocmd__CommandBinding_group",
+  /** Override command-level precondition for this binding (wikilink) */
+  PRECONDITION: "exocmd__CommandBinding_precondition",
+} as const;

--- a/packages/exocortex/src/domain/constants/GroundingType.ts
+++ b/packages/exocortex/src/domain/constants/GroundingType.ts
@@ -1,0 +1,17 @@
+/**
+ * Types of grounding actions for dynamic commands (RFC-009 Section 4.2.3).
+ *
+ * Determines how a command modifies the target asset when executed.
+ */
+export enum GroundingType {
+  /** Full SPARQL UPDATE query (maximum flexibility) */
+  SPARQL_UPDATE = "sparql_update",
+  /** Remove a single frontmatter property */
+  PROPERTY_DELETE = "property_delete",
+  /** Set a single frontmatter property to a value */
+  PROPERTY_SET = "property_set",
+  /** Sequential execution of multiple grounding steps */
+  COMPOSITE = "composite",
+  /** Delegate to a registered service by ID */
+  SERVICE_CALL = "service_call",
+}

--- a/packages/exocortex/src/domain/constants/index.ts
+++ b/packages/exocortex/src/domain/constants/index.ts
@@ -1,2 +1,9 @@
 export { AssetClass } from "./AssetClass";
 export { EffortStatus } from "./EffortStatus";
+export { GroundingType } from "./GroundingType";
+export {
+  CommandProperty,
+  PreconditionProperty,
+  GroundingProperty,
+  CommandBindingProperty,
+} from "./CommandProperty";

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -1,0 +1,175 @@
+import { GroundingType } from "../constants/GroundingType";
+
+/**
+ * Domain model for a dynamic command (RFC-009 Section 4.2.1).
+ *
+ * Represents WHAT to do and WHEN it is available.
+ * Immutable after construction.
+ */
+export interface CommandDefinition {
+  /** Asset UID of the command */
+  readonly id: string;
+  /** Human-readable label (e.g., "Remove start timestamp") */
+  readonly name: string;
+  /** Lucide icon name (e.g., "clock-x") */
+  readonly icon?: string;
+  /** Precondition that determines when the command is available */
+  readonly precondition?: PreconditionDefinition;
+  /** Action to execute when the command is invoked */
+  readonly grounding: GroundingDefinition;
+  /** Text shown in confirmation dialog */
+  readonly confirmMessage?: string;
+  /** Text shown after successful execution */
+  readonly successMessage?: string;
+  /** Category for grouping (e.g., "maintenance", "status") */
+  readonly category?: string;
+}
+
+/**
+ * Domain model for a precondition (RFC-009 Section 4.2.2).
+ *
+ * Determines WHEN a command button should be visible.
+ * Uses SPARQL ASK query evaluated against the target asset.
+ *
+ * Variables in SPARQL:
+ * - `$target` replaced with IRI of the current asset
+ * - `$now` replaced with current timestamp (ISO 8601)
+ * - `$user` replaced with IRI of the current user
+ */
+export interface PreconditionDefinition {
+  /** Asset UID of the precondition */
+  readonly id: string;
+  /** Human-readable description (e.g., "Asset has startTimestamp") */
+  readonly label: string;
+  /** SPARQL ASK query */
+  readonly sparqlAsk: string;
+}
+
+/**
+ * Domain model for a grounding action (RFC-009 Section 4.2.3).
+ *
+ * Defines WHAT happens when a command is executed.
+ */
+export interface GroundingDefinition {
+  /** Asset UID of the grounding */
+  readonly id: string;
+  /** Human-readable description (e.g., "Delete startTimestamp") */
+  readonly label: string;
+  /** Type of grounding action */
+  readonly type: GroundingType;
+  /** Frontmatter property name (for property_delete / property_set) */
+  readonly targetProperty?: string;
+  /** Value to set (for property_set) */
+  readonly targetValue?: string;
+  /** SPARQL UPDATE query (for sparql_update) */
+  readonly sparqlUpdate?: string;
+  /** Ordered sub-steps (for composite type) */
+  readonly steps?: readonly GroundingDefinition[];
+}
+
+/**
+ * Domain model for a command binding (RFC-009 Section 4.2.4).
+ *
+ * Binds a command to a context: WHO sees the button.
+ *
+ * Resolution priority (specific → general):
+ * 1. targetAsset — only for a specific asset
+ * 2. targetPrototype — for all instances of a prototype
+ * 3. targetClass — for all assets of a class
+ *
+ * At least one of targetClass, targetPrototype, targetAsset is required.
+ */
+export interface CommandBindingDefinition {
+  /** Asset UID of the binding */
+  readonly id: string;
+  /** Human-readable description */
+  readonly label: string;
+  /** Reference to the Command asset (UID) */
+  readonly commandRef: string;
+  /** Apply to all assets of this class */
+  readonly targetClass?: string;
+  /** Apply to all instances of this prototype */
+  readonly targetPrototype?: string;
+  /** Apply to a specific asset */
+  readonly targetAsset?: string;
+  /** Where to render the button */
+  readonly position?: string;
+  /** Sort order (default: 100) */
+  readonly order?: number;
+  /** Button group name */
+  readonly group?: string;
+  /** Binding-level precondition overriding command-level precondition */
+  readonly precondition?: PreconditionDefinition;
+}
+
+// -- Type Guards --
+
+/**
+ * Checks if frontmatter represents an exocmd__Command asset.
+ * Uses exact class matching (not CONTAINS) to avoid false positives.
+ */
+export function isCommandFrontmatter(
+  frontmatter: Record<string, unknown>,
+): boolean {
+  return hasInstanceClass(frontmatter, "exocmd__Command");
+}
+
+/**
+ * Checks if frontmatter represents an exocmd__Precondition asset.
+ */
+export function isPreconditionFrontmatter(
+  frontmatter: Record<string, unknown>,
+): boolean {
+  return hasInstanceClass(frontmatter, "exocmd__Precondition");
+}
+
+/**
+ * Checks if frontmatter represents an exocmd__Grounding asset.
+ */
+export function isGroundingFrontmatter(
+  frontmatter: Record<string, unknown>,
+): boolean {
+  return hasInstanceClass(frontmatter, "exocmd__Grounding");
+}
+
+/**
+ * Checks if frontmatter represents an exocmd__CommandBinding asset.
+ */
+export function isCommandBindingFrontmatter(
+  frontmatter: Record<string, unknown>,
+): boolean {
+  return hasInstanceClass(frontmatter, "exocmd__CommandBinding");
+}
+
+/**
+ * Shared helper: checks if frontmatter's exo__Instance_class contains a specific class.
+ * Handles both single string and array formats, with wikilink extraction.
+ */
+function hasInstanceClass(
+  frontmatter: Record<string, unknown>,
+  className: string,
+): boolean {
+  const instanceClass = frontmatter["exo__Instance_class"];
+  if (instanceClass == null) {
+    return false;
+  }
+
+  const classes = Array.isArray(instanceClass)
+    ? instanceClass
+    : [instanceClass];
+
+  for (const cls of classes) {
+    if (typeof cls !== "string") continue;
+
+    // Extract class name from wikilink: [[exocmd__Command]] → exocmd__Command
+    // Also handles [[uuid|Label]] format: extract the first part before |
+    const match = cls.match(/\[\[([^|\]]+)/);
+    const extracted = match ? match[1] : cls;
+
+    if (extracted === className) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/exocortex/src/domain/models/rdf/Namespace.ts
+++ b/packages/exocortex/src/domain/models/rdf/Namespace.ts
@@ -59,4 +59,6 @@ export class Namespace {
   static readonly EXO = new Namespace("exo", "https://exocortex.my/ontology/exo#");
 
   static readonly EMS = new Namespace("ems", "https://exocortex.my/ontology/ems#");
+
+  static readonly EXOCMD = new Namespace("exocmd", "https://exocortex.my/ontology/exocmd#");
 }

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -1,6 +1,25 @@
 // Domain exports
 export * from "./domain/constants/AssetClass";
 export * from "./domain/constants/EffortStatus";
+export { GroundingType } from "./domain/constants/GroundingType";
+export {
+  CommandProperty,
+  PreconditionProperty,
+  GroundingProperty,
+  CommandBindingProperty,
+} from "./domain/constants/CommandProperty";
+export type {
+  CommandDefinition,
+  PreconditionDefinition,
+  GroundingDefinition,
+  CommandBindingDefinition,
+} from "./domain/models/CommandDefinition";
+export {
+  isCommandFrontmatter,
+  isPreconditionFrontmatter,
+  isGroundingFrontmatter,
+  isCommandBindingFrontmatter,
+} from "./domain/models/CommandDefinition";
 export * from "./domain/models/GraphNode";
 export * from "./domain/models/GraphData";
 export * from "./domain/models/GraphEdge";

--- a/packages/exocortex/src/infrastructure/rdf/RDFVocabularyMapper.ts
+++ b/packages/exocortex/src/infrastructure/rdf/RDFVocabularyMapper.ts
@@ -92,6 +92,39 @@ export class RDFVocabularyMapper {
       ),
     );
 
+    // RFC-009: Dynamic Command System class hierarchy (Issue #2427)
+    triples.push(
+      new Triple(
+        Namespace.EXOCMD.term("Command"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      ),
+    );
+
+    triples.push(
+      new Triple(
+        Namespace.EXOCMD.term("Precondition"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      ),
+    );
+
+    triples.push(
+      new Triple(
+        Namespace.EXOCMD.term("Grounding"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      ),
+    );
+
+    triples.push(
+      new Triple(
+        Namespace.EXOCMD.term("CommandBinding"),
+        Namespace.RDFS.term("subClassOf"),
+        Namespace.EXO.term("Asset"),
+      ),
+    );
+
     return triples;
   }
 
@@ -163,10 +196,15 @@ export class RDFVocabularyMapper {
     if (value instanceof IRI) {
       objectIRI = value;
     } else {
-      const classMatch = value.match(/^(ems|exo)__(.+)$/);
+      const classMatch = value.match(/^(ems|exo|exocmd)__(.+)$/);
       if (classMatch) {
         const [, nsPrefix, className] = classMatch;
-        const namespace = nsPrefix === "ems" ? Namespace.EMS : Namespace.EXO;
+        const namespace =
+          nsPrefix === "ems"
+            ? Namespace.EMS
+            : nsPrefix === "exocmd"
+              ? Namespace.EXOCMD
+              : Namespace.EXO;
         objectIRI = namespace.term(className);
       } else {
         objectIRI = new IRI(value);

--- a/packages/exocortex/tests/domain/constants/AssetClass.test.ts
+++ b/packages/exocortex/tests/domain/constants/AssetClass.test.ts
@@ -81,8 +81,24 @@ describe("AssetClass", () => {
     expect(AssetClass.WORKFLOW_TRANSITION).toBe("ems__WorkflowTransition");
   });
 
-  it("should have exactly 22 constants", () => {
+  it("should have COMMAND constant (RFC-009)", () => {
+    expect(AssetClass.COMMAND).toBe("exocmd__Command");
+  });
+
+  it("should have PRECONDITION constant (RFC-009)", () => {
+    expect(AssetClass.PRECONDITION).toBe("exocmd__Precondition");
+  });
+
+  it("should have GROUNDING constant (RFC-009)", () => {
+    expect(AssetClass.GROUNDING).toBe("exocmd__Grounding");
+  });
+
+  it("should have COMMAND_BINDING constant (RFC-009)", () => {
+    expect(AssetClass.COMMAND_BINDING).toBe("exocmd__CommandBinding");
+  });
+
+  it("should have exactly 26 constants", () => {
     const values = Object.values(AssetClass);
-    expect(values).toHaveLength(22);
+    expect(values).toHaveLength(26);
   });
 });

--- a/packages/exocortex/tests/unit/domain/constants/CommandConstants.test.ts
+++ b/packages/exocortex/tests/unit/domain/constants/CommandConstants.test.ts
@@ -1,0 +1,81 @@
+import { GroundingType } from "../../../../src/domain/constants/GroundingType";
+import {
+  CommandProperty,
+  PreconditionProperty,
+  GroundingProperty,
+  CommandBindingProperty,
+} from "../../../../src/domain/constants/CommandProperty";
+import { AssetClass } from "../../../../src/domain/constants/AssetClass";
+
+describe("GroundingType", () => {
+  it("should have all 5 RFC types", () => {
+    expect(GroundingType.SPARQL_UPDATE).toBe("sparql_update");
+    expect(GroundingType.PROPERTY_DELETE).toBe("property_delete");
+    expect(GroundingType.PROPERTY_SET).toBe("property_set");
+    expect(GroundingType.COMPOSITE).toBe("composite");
+    expect(GroundingType.SERVICE_CALL).toBe("service_call");
+  });
+
+  it("should have exactly 5 values", () => {
+    const values = Object.values(GroundingType);
+    expect(values).toHaveLength(5);
+  });
+});
+
+describe("CommandProperty", () => {
+  it("should have correct exocmd__Command_* property names", () => {
+    expect(CommandProperty.ICON).toBe("exocmd__Command_icon");
+    expect(CommandProperty.PRECONDITION).toBe("exocmd__Command_precondition");
+    expect(CommandProperty.GROUNDING).toBe("exocmd__Command_grounding");
+    expect(CommandProperty.CONFIRM_MESSAGE).toBe("exocmd__Command_confirmMessage");
+    expect(CommandProperty.SUCCESS_MESSAGE).toBe("exocmd__Command_successMessage");
+    expect(CommandProperty.CATEGORY).toBe("exocmd__Command_category");
+  });
+});
+
+describe("PreconditionProperty", () => {
+  it("should have correct exocmd__Precondition_* property names", () => {
+    expect(PreconditionProperty.SPARQL_ASK).toBe("exocmd__Precondition_sparqlAsk");
+  });
+});
+
+describe("GroundingProperty", () => {
+  it("should have correct exocmd__Grounding_* property names", () => {
+    expect(GroundingProperty.TYPE).toBe("exocmd__Grounding_type");
+    expect(GroundingProperty.SPARQL_UPDATE).toBe("exocmd__Grounding_sparqlUpdate");
+    expect(GroundingProperty.TARGET_PROPERTY).toBe("exocmd__Grounding_targetProperty");
+    expect(GroundingProperty.TARGET_VALUE).toBe("exocmd__Grounding_targetValue");
+    expect(GroundingProperty.STEPS).toBe("exocmd__Grounding_steps");
+  });
+});
+
+describe("CommandBindingProperty", () => {
+  it("should have correct exocmd__CommandBinding_* property names", () => {
+    expect(CommandBindingProperty.COMMAND).toBe("exocmd__CommandBinding_command");
+    expect(CommandBindingProperty.TARGET_CLASS).toBe("exocmd__CommandBinding_targetClass");
+    expect(CommandBindingProperty.TARGET_PROTOTYPE).toBe("exocmd__CommandBinding_targetPrototype");
+    expect(CommandBindingProperty.TARGET_ASSET).toBe("exocmd__CommandBinding_targetAsset");
+    expect(CommandBindingProperty.POSITION).toBe("exocmd__CommandBinding_position");
+    expect(CommandBindingProperty.ORDER).toBe("exocmd__CommandBinding_order");
+    expect(CommandBindingProperty.GROUP).toBe("exocmd__CommandBinding_group");
+    expect(CommandBindingProperty.PRECONDITION).toBe("exocmd__CommandBinding_precondition");
+  });
+});
+
+describe("AssetClass exocmd extensions", () => {
+  it("should have COMMAND asset class", () => {
+    expect(AssetClass.COMMAND).toBe("exocmd__Command");
+  });
+
+  it("should have PRECONDITION asset class", () => {
+    expect(AssetClass.PRECONDITION).toBe("exocmd__Precondition");
+  });
+
+  it("should have GROUNDING asset class", () => {
+    expect(AssetClass.GROUNDING).toBe("exocmd__Grounding");
+  });
+
+  it("should have COMMAND_BINDING asset class", () => {
+    expect(AssetClass.COMMAND_BINDING).toBe("exocmd__CommandBinding");
+  });
+});

--- a/packages/exocortex/tests/unit/domain/models/CommandDefinition.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/CommandDefinition.test.ts
@@ -1,0 +1,335 @@
+import {
+  isCommandFrontmatter,
+  isPreconditionFrontmatter,
+  isGroundingFrontmatter,
+  isCommandBindingFrontmatter,
+} from "../../../../src/domain/models/CommandDefinition";
+import { GroundingType } from "../../../../src/domain/constants/GroundingType";
+
+describe("CommandDefinition", () => {
+  describe("domain model structure", () => {
+    it("should represent minimal command with required fields", () => {
+      const cmd = {
+        id: "cmd-remove-start",
+        name: "Remove start timestamp",
+        grounding: {
+          id: "gnd-remove-start",
+          label: "Delete startTimestamp",
+          type: GroundingType.PROPERTY_DELETE,
+          targetProperty: "ems__Effort_startTimestamp",
+        },
+      };
+
+      expect(cmd.id).toBe("cmd-remove-start");
+      expect(cmd.grounding.type).toBe("property_delete");
+    });
+
+    it("should represent full command with all optional fields", () => {
+      const cmd = {
+        id: "cmd-remove-start",
+        name: "Remove start timestamp",
+        icon: "clock-x",
+        precondition: {
+          id: "pre-has-start",
+          label: "Has start timestamp",
+          sparqlAsk: "ASK { $target ems:Effort_startTimestamp ?ts }",
+        },
+        grounding: {
+          id: "gnd-remove-start",
+          label: "Delete startTimestamp",
+          type: GroundingType.PROPERTY_DELETE,
+          targetProperty: "ems__Effort_startTimestamp",
+        },
+        confirmMessage: "Remove start timestamp?",
+        successMessage: "Start timestamp removed",
+        category: "maintenance",
+      };
+
+      expect(cmd.icon).toBe("clock-x");
+      expect(cmd.precondition.sparqlAsk).toContain("ASK");
+      expect(cmd.category).toBe("maintenance");
+    });
+  });
+
+  describe("PreconditionDefinition", () => {
+    it("should represent SPARQL ASK precondition", () => {
+      const pre = {
+        id: "pre-has-start",
+        label: "Asset has startTimestamp",
+        sparqlAsk:
+          "PREFIX ems: <https://exocortex.my/ontology/ems#> ASK { $target ems:Effort_startTimestamp ?ts . }",
+      };
+
+      expect(pre.sparqlAsk).toContain("ASK");
+    });
+  });
+
+  describe("GroundingDefinition variants", () => {
+    it("should represent property_delete grounding", () => {
+      const gnd = {
+        id: "gnd-remove-start",
+        label: "Delete startTimestamp",
+        type: GroundingType.PROPERTY_DELETE,
+        targetProperty: "ems__Effort_startTimestamp",
+      };
+
+      expect(gnd.type).toBe(GroundingType.PROPERTY_DELETE);
+      expect(gnd.targetProperty).toBe("ems__Effort_startTimestamp");
+    });
+
+    it("should represent property_set grounding", () => {
+      const gnd = {
+        id: "gnd-set-status",
+        label: "Set status to Doing",
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__Effort_status",
+        targetValue: '"[[ems__EffortStatusDoing]]"',
+      };
+
+      expect(gnd.type).toBe(GroundingType.PROPERTY_SET);
+      expect(gnd.targetValue).toContain("EffortStatusDoing");
+    });
+
+    it("should represent sparql_update grounding", () => {
+      const gnd = {
+        id: "gnd-sparql",
+        label: "SPARQL update",
+        type: GroundingType.SPARQL_UPDATE,
+        sparqlUpdate:
+          "DELETE { $target ems:Effort_startTimestamp ?ts } WHERE { $target ems:Effort_startTimestamp ?ts }",
+      };
+
+      expect(gnd.type).toBe(GroundingType.SPARQL_UPDATE);
+      expect(gnd.sparqlUpdate).toContain("DELETE");
+    });
+
+    it("should represent composite grounding with steps", () => {
+      const step1 = {
+        id: "gnd-set-status",
+        label: "Set status",
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__Effort_status",
+        targetValue: '"[[ems__EffortStatusDoing]]"',
+      };
+
+      const step2 = {
+        id: "gnd-set-start",
+        label: "Set start timestamp",
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__Effort_startTimestamp",
+        targetValue: "$now",
+      };
+
+      const composite = {
+        id: "gnd-composite",
+        label: "Start effort",
+        type: GroundingType.COMPOSITE,
+        steps: [step1, step2],
+      };
+
+      expect(composite.type).toBe(GroundingType.COMPOSITE);
+      expect(composite.steps).toHaveLength(2);
+    });
+
+    it("should represent service_call grounding", () => {
+      const gnd = {
+        id: "gnd-service",
+        label: "Call service",
+        type: GroundingType.SERVICE_CALL,
+      };
+
+      expect(gnd.type).toBe(GroundingType.SERVICE_CALL);
+    });
+  });
+
+  describe("CommandBindingDefinition", () => {
+    it("should represent binding with targetClass", () => {
+      const binding = {
+        id: "bind-remove-start-tasks",
+        label: "Remove start for all tasks",
+        commandRef: "cmd-remove-start",
+        targetClass: "ems__Task",
+      };
+
+      expect(binding.targetClass).toBe("ems__Task");
+    });
+
+    it("should represent binding with targetPrototype and display options", () => {
+      const binding = {
+        id: "bind-remove-start-pokurit",
+        label: "Remove start for Pokurit",
+        commandRef: "cmd-remove-start",
+        targetPrototype: "a717a21b-a960-4795-9caa-04aeaba730ee",
+        position: "inline",
+        order: 50,
+        group: "maintenance",
+      };
+
+      expect(binding.targetPrototype).toBe("a717a21b-a960-4795-9caa-04aeaba730ee");
+      expect(binding.position).toBe("inline");
+      expect(binding.order).toBe(50);
+    });
+
+    it("should represent binding with targetAsset", () => {
+      const binding = {
+        id: "bind-specific",
+        label: "Binding for specific asset",
+        commandRef: "cmd-remove-start",
+        targetAsset: "some-asset-uid",
+      };
+
+      expect(binding.targetAsset).toBe("some-asset-uid");
+    });
+
+    it("should represent binding with overriding precondition", () => {
+      const binding = {
+        id: "bind-with-pre",
+        label: "Binding with custom precondition",
+        commandRef: "cmd-start",
+        targetClass: "ems__Task",
+        precondition: {
+          id: "pre-task-backlog",
+          label: "Task is in Backlog",
+          sparqlAsk: "ASK { $target ems:Effort_status ems:EffortStatusBacklog }",
+        },
+      };
+
+      expect(binding.precondition).toBeDefined();
+      expect(binding.precondition.sparqlAsk).toContain("Backlog");
+    });
+  });
+
+  describe("type guards", () => {
+    describe("isCommandFrontmatter", () => {
+      it("should return true for valid command frontmatter (array class)", () => {
+        const fm = {
+          exo__Instance_class: ["[[exocmd__Command]]"],
+          exo__Asset_uid: "cmd-test",
+          exo__Asset_label: "Test Command",
+        };
+
+        expect(isCommandFrontmatter(fm)).toBe(true);
+      });
+
+      it("should return true for plain string class (no wikilink)", () => {
+        const fm = {
+          exo__Instance_class: "exocmd__Command",
+        };
+
+        expect(isCommandFrontmatter(fm)).toBe(true);
+      });
+
+      it("should return true for wikilink with label", () => {
+        const fm = {
+          exo__Instance_class: ["[[exocmd__Command|Dynamic Command]]"],
+        };
+
+        expect(isCommandFrontmatter(fm)).toBe(true);
+      });
+
+      it("should return false for different class", () => {
+        const fm = {
+          exo__Instance_class: ["[[ems__Task]]"],
+        };
+
+        expect(isCommandFrontmatter(fm)).toBe(false);
+      });
+
+      it("should return false for missing exo__Instance_class", () => {
+        const fm = {
+          exo__Asset_uid: "test",
+        };
+
+        expect(isCommandFrontmatter(fm)).toBe(false);
+      });
+
+      it("should return false for null instance class", () => {
+        const fm = {
+          exo__Instance_class: null,
+        };
+
+        expect(isCommandFrontmatter(fm)).toBe(false);
+      });
+
+      it("should return false for non-string array items", () => {
+        const fm = {
+          exo__Instance_class: [123, true],
+        };
+
+        expect(isCommandFrontmatter(fm)).toBe(false);
+      });
+    });
+
+    describe("isPreconditionFrontmatter", () => {
+      it("should return true for valid precondition frontmatter", () => {
+        const fm = {
+          exo__Instance_class: ["[[exocmd__Precondition]]"],
+        };
+
+        expect(isPreconditionFrontmatter(fm)).toBe(true);
+      });
+
+      it("should return false for command frontmatter", () => {
+        const fm = {
+          exo__Instance_class: ["[[exocmd__Command]]"],
+        };
+
+        expect(isPreconditionFrontmatter(fm)).toBe(false);
+      });
+    });
+
+    describe("isGroundingFrontmatter", () => {
+      it("should return true for valid grounding frontmatter", () => {
+        const fm = {
+          exo__Instance_class: ["[[exocmd__Grounding]]"],
+        };
+
+        expect(isGroundingFrontmatter(fm)).toBe(true);
+      });
+
+      it("should return false for empty frontmatter", () => {
+        expect(isGroundingFrontmatter({})).toBe(false);
+      });
+    });
+
+    describe("isCommandBindingFrontmatter", () => {
+      it("should return true for valid binding frontmatter", () => {
+        const fm = {
+          exo__Instance_class: ["[[exocmd__CommandBinding]]"],
+        };
+
+        expect(isCommandBindingFrontmatter(fm)).toBe(true);
+      });
+
+      it("should return false for grounding frontmatter", () => {
+        const fm = {
+          exo__Instance_class: ["[[exocmd__Grounding]]"],
+        };
+
+        expect(isCommandBindingFrontmatter(fm)).toBe(false);
+      });
+    });
+
+    describe("exact class matching (no false positives)", () => {
+      it("should not match CommandBinding when checking for Command", () => {
+        const fm = {
+          exo__Instance_class: ["[[exocmd__CommandBinding]]"],
+        };
+
+        expect(isCommandFrontmatter(fm)).toBe(false);
+      });
+
+      it("should handle multi-class frontmatter correctly", () => {
+        const fm = {
+          exo__Instance_class: [
+            "[[exo__Asset]]",
+            "[[exocmd__Command]]",
+          ],
+        };
+
+        expect(isCommandFrontmatter(fm)).toBe(true);
+        expect(isPreconditionFrontmatter(fm)).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/infrastructure/rdf/RDFVocabularyMapper.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/rdf/RDFVocabularyMapper.test.ts
@@ -260,6 +260,66 @@ describe("RDFVocabularyMapper", () => {
     });
   });
 
+  describe("exocmd class hierarchy (RFC-009, Issue #2427)", () => {
+    it("should map exocmd classes as subClassOf exo:Asset", () => {
+      const triples = mapper.generateClassHierarchyTriples();
+
+      const exocmdClasses = ["Command", "Precondition", "Grounding", "CommandBinding"];
+
+      for (const className of exocmdClasses) {
+        const triple = triples.find(
+          (t) =>
+            (t.subject as IRI).value === `https://exocortex.my/ontology/exocmd#${className}` &&
+            (t.predicate as IRI).value === "http://www.w3.org/2000/01/rdf-schema#subClassOf" &&
+            (t.object as IRI).value === "https://exocortex.my/ontology/exo#Asset",
+        );
+        expect(triple).toBeDefined();
+      }
+    });
+  });
+
+  describe("exocmd namespace in generateMappedTriple (RFC-009)", () => {
+    it("should resolve exocmd__ class references to EXOCMD namespace IRI", () => {
+      const subjectIRI = new IRI("https://exocortex.my/ontology/test/asset-1");
+
+      const triple = mapper.generateMappedTriple(
+        subjectIRI,
+        "exo__Instance_class",
+        "exocmd__Command",
+      );
+
+      expect(triple).toBeDefined();
+      expect((triple!.object as IRI).value).toBe(
+        "https://exocortex.my/ontology/exocmd#Command",
+      );
+    });
+
+    it("should resolve exocmd__Precondition to EXOCMD namespace", () => {
+      const subjectIRI = new IRI("https://exocortex.my/ontology/test/asset-2");
+
+      const triple = mapper.generateMappedTriple(
+        subjectIRI,
+        "exo__Instance_class",
+        "exocmd__Precondition",
+      );
+
+      expect(triple).toBeDefined();
+      expect((triple!.object as IRI).value).toBe(
+        "https://exocortex.my/ontology/exocmd#Precondition",
+      );
+    });
+
+    it("should still resolve ems__ and exo__ prefixes correctly", () => {
+      const subjectIRI = new IRI("https://exocortex.my/ontology/test/asset-3");
+
+      const emsTriple = mapper.generateMappedTriple(subjectIRI, "exo__Instance_class", "ems__Task");
+      expect((emsTriple!.object as IRI).value).toBe("https://exocortex.my/ontology/ems#Task");
+
+      const exoTriple = mapper.generateMappedTriple(subjectIRI, "exo__Instance_class", "exo__Asset");
+      expect((exoTriple!.object as IRI).value).toBe("https://exocortex.my/ontology/exo#Asset");
+    });
+  });
+
   describe("hasMappingFor", () => {
     it("should return true for mapped properties", () => {
       expect(mapper.hasMappingFor("exo__Instance_class")).toBe(true);


### PR DESCRIPTION
## Summary
Closes #2427

Foundation for the Dynamic Command System (RFC-009). Defines the domain layer that all subsequent services (CommandResolver, GroundingExecutor, etc.) depend on.

### New files
- `CommandDefinition.ts` — 4 readonly interfaces: CommandDefinition, PreconditionDefinition, GroundingDefinition, CommandBindingDefinition
- `GroundingType.ts` — string enum with 5 types (sparql_update, property_delete, property_set, composite, service_call)
- `CommandProperty.ts` — all `exocmd__*` frontmatter property name constants

### Modified files
- `AssetClass.ts` — 4 new constants: COMMAND, PRECONDITION, GROUNDING, COMMAND_BINDING
- `Namespace.ts` — EXOCMD namespace (`https://exocortex.my/ontology/exocmd#`)
- `RDFVocabularyMapper.ts` — exocmd class hierarchy triples + `exocmd__` prefix in generateMappedTriple()
- `index.ts` — exports for all new types

### Key design decisions
- **Binding-level precondition**: CommandBindingDefinition supports optional `precondition` that overrides command-level precondition (per Issue comment)
- **Exact class matching**: Type guards use `===` comparison, not CONTAINS, to avoid `exocmd__CommandBinding` matching `exocmd__Command`
- **GroundingType.SERVICE_CALL**: Added beyond RFC §4.2.3 for future extensibility

## Test plan
- [x] 42 new unit tests (CommandDefinition, CommandConstants, RDFVocabularyMapper extensions)
- [x] Existing AssetClass test updated (22 → 26 constants)
- [x] All 1149 unit tests pass
- [x] BDD coverage 100%
- [x] Archgate compliance pass
- [x] TypeScript strict mode: zero errors