### PR TITLE
refactor(core): add @injectable() to 4 workflow services

### DIFF
--- a/packages/exocortex/src/services/KanbanColumnProvider.ts
+++ b/packages/exocortex/src/services/KanbanColumnProvider.ts
@@ -1,3 +1,4 @@
+import { injectable } from "tsyringe";
 import type { WorkflowDefinition } from "../domain/models/WorkflowDefinition";
 import { EffortStatus } from "../domain/constants/EffortStatus";
 
@@ -19,6 +20,7 @@ export interface KanbanColumn {
  *
  * Issue #2367
  */
+@injectable()
 export class KanbanColumnProvider {
   /**
    * Generate ordered columns from a WorkflowDefinition.

--- a/packages/exocortex/src/services/VisibilityGenerator.ts
+++ b/packages/exocortex/src/services/VisibilityGenerator.ts
@@ -1,3 +1,4 @@
+import { injectable } from "tsyringe";
 import { WorkflowEngine } from "./WorkflowEngine";
 import { EffortStatus } from "../domain/constants/EffortStatus";
 import type { WorkflowTransitionDefinition } from "../domain/models/WorkflowDefinition";
@@ -10,6 +11,7 @@ export interface VisibleCommand {
   readonly isRollback: boolean;
 }
 
+@injectable()
 export class VisibilityGenerator {
   constructor(private readonly engine: WorkflowEngine) {}
 

--- a/packages/exocortex/src/services/WorkflowEngine.ts
+++ b/packages/exocortex/src/services/WorkflowEngine.ts
@@ -1,3 +1,4 @@
+import { injectable } from "tsyringe";
 import { EffortStatus } from "../domain/constants/EffortStatus";
 import type {
   WorkflowDefinition,
@@ -20,6 +21,7 @@ export interface WorkflowValidationResult {
  *
  * Issue #2360
  */
+@injectable()
 export class WorkflowEngine {
   constructor(private readonly definition: WorkflowDefinition) {}
 

--- a/packages/exocortex/src/services/WorkflowResolver.ts
+++ b/packages/exocortex/src/services/WorkflowResolver.ts
@@ -1,3 +1,4 @@
+import { injectable } from "tsyringe";
 import type { ITripleStore } from "../interfaces/ITripleStore";
 import type { Triple, Object as RDFObject } from "../domain/models/rdf/Triple";
 import { IRI } from "../domain/models/rdf/IRI";
@@ -21,6 +22,7 @@ import type {
  *
  * Issue #2359
  */
+@injectable()
 export class WorkflowResolver {
   private readonly cache = new Map<string, WorkflowDefinition>();
 


### PR DESCRIPTION
## Summary

- Add missing `@injectable()` decorator to 4 core services flagged by archgate QUAL-001
- KanbanColumnProvider, VisibilityGenerator, WorkflowEngine, WorkflowResolver

## Context

These services work fine via `new` but lack the `@injectable()` decorator required by the archgate `injectable-services` rule. Adding the decorator is a no-op for current usage (all instantiated via `new`) but makes them DI-ready.

## Test plan

- [x] TypeScript type check clean
- [ ] CI pipeline green (archgate warnings should drop from 4 to 0)