### PR TITLE
feat(core): GroundingExecutor for command action execution

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -50,6 +50,13 @@ export {
   type EvalContext,
   type HostFunction,
 } from "./services/PreconditionEvaluator";
+export {
+  GroundingExecutor,
+  ServiceRegistry,
+  type ExecutionResult,
+  type UserInput,
+  type IGroundingService,
+} from "./services/GroundingExecutor";
 export { TaskCreationService } from "./services/TaskCreationService";
 export { ProjectCreationService } from "./services/ProjectCreationService";
 export { TaskStatusService } from "./services/TaskStatusService";

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -1,0 +1,350 @@
+import { injectable } from "tsyringe";
+import type { IFileSystemReader } from "../interfaces/IFileSystemAdapter";
+import type { IFileSystemWriter } from "../interfaces/IFileSystemAdapter";
+import type { GroundingDefinition } from "../domain/models/CommandDefinition";
+import { GroundingType } from "../domain/constants/GroundingType";
+import { FrontmatterService } from "../utilities/FrontmatterService";
+
+/**
+ * Result of executing a grounding action.
+ */
+export interface ExecutionResult {
+  readonly success: boolean;
+  readonly error?: string;
+}
+
+/**
+ * Input parameters collected from the user (for service_call groundings).
+ * UI layer collects these via modals; CLI via interactive prompts or --arg flags.
+ */
+export type UserInput = Record<string, unknown>;
+
+/**
+ * A named service that can be invoked by service_call groundings.
+ */
+export interface IGroundingService {
+  execute(targetIRI: string, userInput?: UserInput): Promise<void>;
+}
+
+/**
+ * Registry for named services callable from vault-defined groundings.
+ *
+ * Services are registered by ID (e.g., "TaskStatusService") and invoked
+ * when a service_call grounding references them.
+ */
+export class ServiceRegistry {
+  private readonly services = new Map<string, IGroundingService>();
+
+  register(serviceId: string, service: IGroundingService): void {
+    this.services.set(serviceId, service);
+  }
+
+  get(serviceId: string): IGroundingService | undefined {
+    return this.services.get(serviceId);
+  }
+
+  has(serviceId: string): boolean {
+    return this.services.has(serviceId);
+  }
+
+  getRegisteredIds(): string[] {
+    return Array.from(this.services.keys());
+  }
+}
+
+/** Maximum depth for composite grounding to prevent infinite recursion */
+const MAX_COMPOSITE_DEPTH = 20;
+
+/**
+ * Executes grounding actions for dynamic commands (RFC-009 §5.4).
+ *
+ * The "write side" of the Dynamic Command System. Once a precondition passes,
+ * GroundingExecutor applies the actual change to the target asset.
+ *
+ * Supported grounding types:
+ * - `property_set` — set a frontmatter property to a value
+ * - `property_delete` — remove a frontmatter property
+ * - `composite` — execute multiple groundings sequentially with rollback
+ * - `service_call` — delegate to a registered TypeScript service
+ * - `sparql_update` — stub (NotImplementedError), pending UpdateExecutor support
+ *
+ * Variable substitution in targetValue:
+ * - `$now` → current ISO 8601 timestamp
+ * - `$today` → current date (YYYY-MM-DD)
+ * - `$target` → IRI of the target asset
+ *
+ * Issue #2430
+ */
+@injectable()
+export class GroundingExecutor {
+  private readonly frontmatterService: FrontmatterService;
+  private readonly fileReader: IFileSystemReader;
+  private readonly fileWriter: IFileSystemWriter;
+  private readonly serviceRegistry: ServiceRegistry;
+
+  constructor(
+    fileReader: IFileSystemReader,
+    fileWriter: IFileSystemWriter,
+    serviceRegistry: ServiceRegistry,
+  ) {
+    this.frontmatterService = new FrontmatterService();
+    this.fileReader = fileReader;
+    this.fileWriter = fileWriter;
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  /**
+   * Execute a grounding action on the target asset.
+   *
+   * @param grounding - The grounding definition to execute
+   * @param targetIRI - IRI of the target asset
+   * @param targetFilePath - File path of the target asset in the vault
+   * @param userInput - Optional user input for service_call groundings
+   * @returns ExecutionResult indicating success or failure
+   */
+  async execute(
+    grounding: GroundingDefinition,
+    targetIRI: string,
+    targetFilePath: string,
+    userInput?: UserInput,
+  ): Promise<ExecutionResult> {
+    try {
+      switch (grounding.type) {
+        case GroundingType.PROPERTY_SET:
+          return await this.executePropertySet(
+            grounding,
+            targetIRI,
+            targetFilePath,
+          );
+
+        case GroundingType.PROPERTY_DELETE:
+          return await this.executePropertyDelete(
+            grounding,
+            targetFilePath,
+          );
+
+        case GroundingType.COMPOSITE:
+          return await this.executeComposite(
+            grounding,
+            targetIRI,
+            targetFilePath,
+            userInput,
+            0,
+          );
+
+        case GroundingType.SERVICE_CALL:
+          return await this.executeServiceCall(
+            grounding,
+            targetIRI,
+            userInput,
+          );
+
+        case GroundingType.SPARQL_UPDATE:
+          return {
+            success: false,
+            error:
+              "sparql_update grounding not yet implemented. Use property_set/property_delete instead.",
+          };
+
+        default:
+          return {
+            success: false,
+            error: `Unknown grounding type: ${(grounding as GroundingDefinition).type}`,
+          };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  // -- Private: Grounding Type Implementations --
+
+  private async executePropertySet(
+    grounding: GroundingDefinition,
+    targetIRI: string,
+    filePath: string,
+  ): Promise<ExecutionResult> {
+    if (!grounding.targetProperty) {
+      return { success: false, error: "property_set requires targetProperty" };
+    }
+    if (grounding.targetValue === undefined) {
+      return { success: false, error: "property_set requires targetValue" };
+    }
+
+    const substitutedValue = this.substituteVariables(
+      grounding.targetValue,
+      targetIRI,
+    );
+
+    const content = await this.fileReader.readFile(filePath);
+    const updated = this.frontmatterService.updateProperty(
+      content,
+      grounding.targetProperty,
+      substitutedValue,
+    );
+    await this.fileWriter.updateFile(filePath, updated);
+
+    return { success: true };
+  }
+
+  private async executePropertyDelete(
+    grounding: GroundingDefinition,
+    filePath: string,
+  ): Promise<ExecutionResult> {
+    if (!grounding.targetProperty) {
+      return {
+        success: false,
+        error: "property_delete requires targetProperty",
+      };
+    }
+
+    const content = await this.fileReader.readFile(filePath);
+    const updated = this.frontmatterService.removeProperty(
+      content,
+      grounding.targetProperty,
+    );
+    await this.fileWriter.updateFile(filePath, updated);
+
+    return { success: true };
+  }
+
+  private async executeComposite(
+    grounding: GroundingDefinition,
+    targetIRI: string,
+    filePath: string,
+    userInput: UserInput | undefined,
+    depth: number,
+  ): Promise<ExecutionResult> {
+    if (depth >= MAX_COMPOSITE_DEPTH) {
+      return {
+        success: false,
+        error: `Composite grounding exceeded maximum depth of ${MAX_COMPOSITE_DEPTH}`,
+      };
+    }
+
+    const steps = grounding.steps ?? [];
+    if (steps.length === 0) {
+      return { success: true };
+    }
+
+    // Capture state before execution for rollback
+    let originalContent: string | undefined;
+    try {
+      originalContent = await this.fileReader.readFile(filePath);
+    } catch {
+      // File might not exist for service_call-only composites
+    }
+
+    const completedSteps: number[] = [];
+
+    try {
+      for (let i = 0; i < steps.length; i++) {
+        const step = steps[i];
+        const result = await this.executeStep(
+          step,
+          targetIRI,
+          filePath,
+          userInput,
+          depth + 1,
+        );
+        if (!result.success) {
+          // Rollback completed steps by restoring original file content
+          await this.rollback(originalContent, filePath, completedSteps);
+          return {
+            success: false,
+            error: `Composite step ${i} failed: ${result.error}`,
+          };
+        }
+        completedSteps.push(i);
+      }
+
+      return { success: true };
+    } catch (error) {
+      await this.rollback(originalContent, filePath, completedSteps);
+      return {
+        success: false,
+        error: `Composite execution failed: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  private async executeServiceCall(
+    grounding: GroundingDefinition,
+    targetIRI: string,
+    userInput?: UserInput,
+  ): Promise<ExecutionResult> {
+    // service_call uses targetProperty as serviceId (repurposed field)
+    const serviceId = grounding.targetProperty;
+    if (!serviceId) {
+      return { success: false, error: "service_call requires targetProperty as serviceId" };
+    }
+
+    const service = this.serviceRegistry.get(serviceId);
+    if (!service) {
+      return {
+        success: false,
+        error: `Service not found: "${serviceId}". Registered services: ${this.serviceRegistry.getRegisteredIds().join(", ") || "none"}`,
+      };
+    }
+
+    await service.execute(targetIRI, userInput);
+    return { success: true };
+  }
+
+  private async executeStep(
+    step: GroundingDefinition,
+    targetIRI: string,
+    filePath: string,
+    userInput: UserInput | undefined,
+    depth: number,
+  ): Promise<ExecutionResult> {
+    // For composite steps, use recursive execute with depth tracking
+    if (step.type === GroundingType.COMPOSITE) {
+      return this.executeComposite(step, targetIRI, filePath, userInput, depth);
+    }
+    return this.execute(step, targetIRI, filePath, userInput);
+  }
+
+  // -- Private: Rollback --
+
+  private async rollback(
+    originalContent: string | undefined,
+    filePath: string,
+    _completedSteps: number[],
+  ): Promise<void> {
+    if (originalContent === undefined) return;
+
+    try {
+      await this.fileWriter.updateFile(filePath, originalContent);
+    } catch (rollbackError) {
+      // Log rollback failure but do not throw — prevents masking the original error
+      console.error(
+        `[GroundingExecutor] Rollback failed for ${filePath}:`,
+        rollbackError,
+      );
+    }
+  }
+
+  // -- Private: Variable Substitution --
+
+  /**
+   * Substitute custom variables in grounding values.
+   * Same variables as PreconditionEvaluator for consistency.
+   *
+   * - $target → targetIRI (no angle brackets — this is a value, not SPARQL)
+   * - $now → current ISO 8601 timestamp
+   * - $today → current date (YYYY-MM-DD)
+   */
+  substituteVariables(value: string, targetIRI: string): string {
+    const now = new Date().toISOString();
+    const today = now.slice(0, 10);
+
+    return value
+      .replace(/\$target/g, targetIRI)
+      .replace(/\$now/g, now)
+      .replace(/\$today/g, today);
+  }
+}

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -1,0 +1,508 @@
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+
+// -- Mocks --
+
+function createMockReader(content?: string) {
+  const defaultContent = content || "---\nfoo: bar\n---\nBody";
+  return {
+    readFile: jest.fn().mockResolvedValue(defaultContent),
+    fileExists: jest.fn().mockResolvedValue(true),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+}
+
+function createMockWriter() {
+  return {
+    createFile: jest.fn().mockResolvedValue(""),
+    updateFile: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    deleteFile: jest.fn().mockResolvedValue(undefined),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeGrounding(overrides: Record<string, unknown>): GroundingDefinition {
+  return {
+    id: "gnd-test",
+    label: "Test Grounding",
+    ...overrides,
+  } as unknown as GroundingDefinition;
+}
+
+// -- Tests --
+
+describe("GroundingExecutor", () => {
+  const TARGET_IRI = "https://exocortex.my/assets/test-asset-123";
+  const FILE_PATH = "/vault/test-asset.md";
+
+  let reader: ReturnType<typeof createMockReader>;
+  let writer: ReturnType<typeof createMockWriter>;
+  let registry: ServiceRegistry;
+  let executor: GroundingExecutor;
+
+  beforeEach(() => {
+    reader = createMockReader();
+    writer = createMockWriter();
+    registry = new ServiceRegistry();
+    executor = new GroundingExecutor(reader, writer, registry);
+  });
+
+  // -- property_set --
+
+  describe("property_set", () => {
+    it("should update frontmatter property to new value", async () => {
+      reader.readFile.mockResolvedValue("---\nems__status: Backlog\n---\nBody");
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__status",
+        targetValue: "Done",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      expect(writer.updateFile).toHaveBeenCalledTimes(1);
+      const writtenContent = writer.updateFile.mock.calls[0][1];
+      expect(writtenContent).toContain("ems__status: Done");
+    });
+
+    it("should substitute $now with ISO timestamp", async () => {
+      reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__Effort_startTimestamp",
+        targetValue: "$now",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const writtenContent = writer.updateFile.mock.calls[0][1];
+      expect(writtenContent).toMatch(
+        /ems__Effort_startTimestamp: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+      );
+    });
+
+    it("should substitute $today with YYYY-MM-DD", async () => {
+      reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "due_date",
+        targetValue: "$today",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const writtenContent = writer.updateFile.mock.calls[0][1];
+      expect(writtenContent).toMatch(/due_date: \d{4}-\d{2}-\d{2}$/m);
+    });
+
+    it("should substitute $target with IRI", async () => {
+      reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "linked_from",
+        targetValue: "$target",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const writtenContent = writer.updateFile.mock.calls[0][1];
+      expect(writtenContent).toContain("linked_from: " + TARGET_IRI);
+    });
+
+    it("should fail when targetProperty is missing", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetValue: "value",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("targetProperty");
+    });
+
+    it("should fail when targetValue is undefined", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "prop",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("targetValue");
+    });
+  });
+
+  // -- property_delete --
+
+  describe("property_delete", () => {
+    it("should remove frontmatter property", async () => {
+      reader.readFile.mockResolvedValue(
+        "---\nfoo: bar\nems__Effort_startTimestamp: 2026-01-01\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_DELETE,
+        targetProperty: "ems__Effort_startTimestamp",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const writtenContent = writer.updateFile.mock.calls[0][1];
+      expect(writtenContent).not.toContain("ems__Effort_startTimestamp");
+      expect(writtenContent).toContain("foo: bar");
+    });
+
+    it("should succeed when property does not exist (no-op)", async () => {
+      reader.readFile.mockResolvedValue("---\nfoo: bar\n---\nBody");
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_DELETE,
+        targetProperty: "nonexistent_property",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should fail when targetProperty is missing", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_DELETE,
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("targetProperty");
+    });
+  });
+
+  // -- composite --
+
+  describe("composite", () => {
+    it("should execute all steps in sequence", async () => {
+      reader.readFile.mockResolvedValue("---\nstatus: Backlog\n---\nBody");
+
+      const grounding = makeGrounding({
+        type: GroundingType.COMPOSITE,
+        steps: [
+          makeGrounding({
+            type: GroundingType.PROPERTY_SET,
+            targetProperty: "status",
+            targetValue: "Doing",
+          }),
+          makeGrounding({
+            type: GroundingType.PROPERTY_SET,
+            targetProperty: "ems__Effort_startTimestamp",
+            targetValue: "$now",
+          }),
+        ],
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      // readFile called: once for original snapshot + once per property_set step
+      expect(reader.readFile).toHaveBeenCalledTimes(3);
+      expect(writer.updateFile).toHaveBeenCalledTimes(2);
+    });
+
+    it("should rollback on step failure", async () => {
+      const originalContent = "---\nstatus: Backlog\n---\nBody";
+      reader.readFile.mockResolvedValue(originalContent);
+
+      const grounding = makeGrounding({
+        type: GroundingType.COMPOSITE,
+        steps: [
+          makeGrounding({
+            type: GroundingType.PROPERTY_SET,
+            targetProperty: "status",
+            targetValue: "Doing",
+          }),
+          makeGrounding({
+            type: GroundingType.PROPERTY_SET,
+            // Missing targetProperty → will fail
+            targetValue: "broken",
+          }),
+        ],
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Composite step 1 failed");
+      // Rollback writes original content back
+      const lastUpdateCall = writer.updateFile.mock.calls[writer.updateFile.mock.calls.length - 1];
+      expect(lastUpdateCall[1]).toBe(originalContent);
+    });
+
+    it("should succeed with empty steps array", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.COMPOSITE,
+        steps: [],
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should succeed with undefined steps", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.COMPOSITE,
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should prevent infinite recursion with depth limit", async () => {
+      reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+      // Create deeply nested composite (depth > MAX_COMPOSITE_DEPTH)
+      let innermost = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "foo",
+        targetValue: "bar",
+      });
+
+      for (let i = 0; i < 25; i++) {
+        innermost = makeGrounding({
+          type: GroundingType.COMPOSITE,
+          steps: [innermost],
+        });
+      }
+
+      const result = await executor.execute(innermost, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("maximum depth");
+    });
+  });
+
+  // -- service_call --
+
+  describe("service_call", () => {
+    it("should call registered service with correct args", async () => {
+      const mockService = {
+        execute: jest.fn().mockResolvedValue(undefined),
+      };
+      registry.register("TaskStatusService", mockService);
+
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "TaskStatusService",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, undefined);
+    });
+
+    it("should pass userInput to service", async () => {
+      const mockService = {
+        execute: jest.fn().mockResolvedValue(undefined),
+      };
+      registry.register("AreaCreationService", mockService);
+
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "AreaCreationService",
+      });
+
+      const userInput = { label: "New Area", size: "medium" };
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        userInput,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, userInput);
+    });
+
+    it("should fail for unknown serviceId", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "NonExistentService",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Service not found");
+      expect(result.error).toContain("NonExistentService");
+    });
+
+    it("should fail when serviceId (targetProperty) is missing", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("targetProperty");
+    });
+
+    it("should capture service execution errors", async () => {
+      const mockService = {
+        execute: jest.fn().mockRejectedValue(new Error("Service crashed")),
+      };
+      registry.register("CrashingService", mockService);
+
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "CrashingService",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Service crashed");
+    });
+  });
+
+  // -- sparql_update --
+
+  describe("sparql_update", () => {
+    it("should return error (not implemented)", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.SPARQL_UPDATE,
+        sparqlUpdate: "DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not yet implemented");
+    });
+  });
+
+  // -- ExecutionResult --
+
+  describe("ExecutionResult", () => {
+    it("should return success=true on successful execution", async () => {
+      reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_DELETE,
+        targetProperty: "foo",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("should return success=false + error on failure", async () => {
+      reader.readFile.mockRejectedValue(new Error("File not found"));
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_DELETE,
+        targetProperty: "foo",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("File not found");
+    });
+  });
+
+  // -- ServiceRegistry --
+
+  describe("ServiceRegistry", () => {
+    it("should register and retrieve a service", () => {
+      const mockService = { execute: jest.fn() };
+
+      registry.register("TestService", mockService);
+
+      expect(registry.has("TestService")).toBe(true);
+      expect(registry.get("TestService")).toBe(mockService);
+    });
+
+    it("should return undefined for unregistered service", () => {
+      expect(registry.has("Unknown")).toBe(false);
+      expect(registry.get("Unknown")).toBeUndefined();
+    });
+
+    it("should list registered service IDs", () => {
+      const s1 = { execute: jest.fn() };
+      const s2 = { execute: jest.fn() };
+
+      registry.register("ServiceA", s1);
+      registry.register("ServiceB", s2);
+
+      const ids = registry.getRegisteredIds();
+      expect(ids).toContain("ServiceA");
+      expect(ids).toContain("ServiceB");
+      expect(ids).toHaveLength(2);
+    });
+  });
+
+  // -- Variable Substitution --
+
+  describe("substituteVariables", () => {
+    it("should replace $target with IRI (no angle brackets)", () => {
+      const result = executor.substituteVariables(
+        "linked to $target",
+        TARGET_IRI,
+      );
+      expect(result).toBe("linked to " + TARGET_IRI);
+    });
+
+    it("should replace $now with ISO timestamp", () => {
+      const result = executor.substituteVariables("started at $now", TARGET_IRI);
+      expect(result).toMatch(/started at \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it("should replace $today with YYYY-MM-DD", () => {
+      const result = executor.substituteVariables(
+        "due $today",
+        TARGET_IRI,
+      );
+      expect(result).toMatch(/due \d{4}-\d{2}-\d{2}$/);
+    });
+
+    it("should handle multiple variables in one string", () => {
+      const result = executor.substituteVariables(
+        "$target modified on $today at $now",
+        TARGET_IRI,
+      );
+      expect(result).toContain(TARGET_IRI);
+      expect(result).toMatch(/\d{4}-\d{2}-\d{2}/);
+      expect(result).not.toContain("$target");
+      expect(result).not.toContain("$today");
+      expect(result).not.toContain("$now");
+    });
+
+    it("should return unchanged string when no variables present", () => {
+      const result = executor.substituteVariables(
+        "plain value",
+        TARGET_IRI,
+      );
+      expect(result).toBe("plain value");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement GroundingExecutor — the "write side" of the Dynamic Command System (RFC-009 §5.4)
- Supports 4 grounding types: `property_set`, `property_delete`, `composite`, `service_call`
- `sparql_update` stubbed (NotImplementedError) pending UpdateExecutor support
- ServiceRegistry for named TypeScript service invocation from vault-defined groundings
- Variable substitution ($now, $today, $target) in property values
- Composite transactional rollback on step failure

## Test plan
- [x] 30 unit tests covering all grounding types, error paths, rollback, and variable substitution
- [x] TypeScript compilation (zero errors)
- [x] ESLint clean (zero warnings on new files)
- [x] BDD coverage 100%
- [x] Archgate 13/13 passed

## Files changed
- `packages/exocortex/src/services/GroundingExecutor.ts` (new)
- `packages/exocortex/tests/unit/services/GroundingExecutor.test.ts` (new)
- `packages/exocortex/src/index.ts` (exports added)

Closes #2430