### PR TITLE
feat(core): WorkflowCommandAdapter — workflow transitions as commands

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -73,6 +73,7 @@ export type { WorkflowValidationResult } from "./services/WorkflowEngine";
 export { WorkflowResolver } from "./services/WorkflowResolver";
 export { VisibilityGenerator } from "./services/VisibilityGenerator";
 export type { VisibleCommand } from "./services/VisibilityGenerator";
+export { WorkflowCommandAdapter } from "./services/WorkflowCommandAdapter";
 export type {
   WorkflowDefinition,
   WorkflowStateDefinition,

--- a/packages/exocortex/src/services/WorkflowCommandAdapter.ts
+++ b/packages/exocortex/src/services/WorkflowCommandAdapter.ts
@@ -1,0 +1,177 @@
+import { injectable } from "tsyringe";
+import { EffortStatus } from "../domain/constants/EffortStatus";
+import { GroundingType } from "../domain/constants/GroundingType";
+import type {
+  CommandDefinition,
+  GroundingDefinition,
+  PreconditionDefinition,
+} from "../domain/models/CommandDefinition";
+import type {
+  WorkflowDefinition,
+  WorkflowTransitionDefinition,
+} from "../domain/models/WorkflowDefinition";
+import { WorkflowEngine } from "./WorkflowEngine";
+
+/**
+ * Converts WorkflowTransitionDefinitions into CommandDefinitions,
+ * bridging the workflow engine with the dynamic command system (RFC-009 §3).
+ *
+ * Pure domain adapter — no I/O, no vault access, no side effects.
+ * Wraps WorkflowEngine for transition queries and adds command semantics.
+ *
+ * Issue #2431
+ */
+@injectable()
+export class WorkflowCommandAdapter {
+  private readonly engine: WorkflowEngine;
+
+  constructor(private readonly workflow: WorkflowDefinition) {
+    this.engine = new WorkflowEngine(workflow);
+  }
+
+  /**
+   * Convert all transitions from the current status into CommandDefinitions.
+   *
+   * For each matching transition (where `from === currentStatus`):
+   * - Generates deterministic ID: `workflow-{fromShort}-to-{toShort}`
+   * - Uses transition label and icon
+   * - Builds precondition: status check for `from` state
+   * - Builds composite grounding: set status + set timestamps (from timestampOnEnter)
+   * - Sets category: `isRollback ? 'rollback' : 'workflow'`
+   */
+  adaptTransitions(currentStatus: EffortStatus): CommandDefinition[] {
+    const transitions = this.engine.getAllTransitions(currentStatus);
+    return transitions.map((t) => this.transitionToCommand(t));
+  }
+
+  /**
+   * Convert only forward (non-rollback) transitions to commands.
+   */
+  adaptForwardTransitions(currentStatus: EffortStatus): CommandDefinition[] {
+    const transitions = this.engine.getAvailableTransitions(currentStatus);
+    return transitions.map((t) => this.transitionToCommand(t));
+  }
+
+  /**
+   * Convert only rollback transitions to commands.
+   */
+  adaptRollbackTransitions(currentStatus: EffortStatus): CommandDefinition[] {
+    const transitions = this.engine.getRollbackTransitions(currentStatus);
+    return transitions.map((t) => this.transitionToCommand(t));
+  }
+
+  /**
+   * Get the underlying WorkflowEngine for direct queries.
+   */
+  getEngine(): WorkflowEngine {
+    return this.engine;
+  }
+
+  /**
+   * Get the underlying WorkflowDefinition.
+   */
+  getWorkflow(): WorkflowDefinition {
+    return this.workflow;
+  }
+
+  private transitionToCommand(
+    transition: WorkflowTransitionDefinition,
+  ): CommandDefinition {
+    const commandId = this.generateCommandId(transition);
+    const precondition = this.buildPrecondition(transition);
+    const grounding = this.buildGrounding(transition);
+    const category = transition.isRollback ? "rollback" : "workflow";
+
+    return {
+      id: commandId,
+      name: transition.label,
+      icon: transition.icon,
+      precondition,
+      grounding,
+      category,
+      confirmMessage: transition.isRollback
+        ? `Rollback to ${this.shortStatus(transition.to)}?`
+        : undefined,
+      successMessage: `Status changed to ${this.shortStatus(transition.to)}`,
+    };
+  }
+
+  /**
+   * Generate a deterministic command ID from transition endpoints.
+   * Format: `workflow-{fromShort}-to-{toShort}`
+   * Matches VisibilityGenerator's pattern.
+   */
+  private generateCommandId(
+    transition: WorkflowTransitionDefinition,
+  ): string {
+    const fromShort = this.shortStatus(transition.from);
+    const toShort = this.shortStatus(transition.to);
+    return `workflow-${fromShort}-to-${toShort}`;
+  }
+
+  /**
+   * Build a precondition that checks if the asset is in the expected `from` state.
+   */
+  private buildPrecondition(
+    transition: WorkflowTransitionDefinition,
+  ): PreconditionDefinition {
+    return {
+      id: `precond-${this.generateCommandId(transition)}`,
+      label: `Asset status is ${this.shortStatus(transition.from)}`,
+      sparqlAsk: `ASK { $target ems:Effort_status "${transition.from}" }`,
+    };
+  }
+
+  /**
+   * Build a composite grounding:
+   * 1. Set status property to target state
+   * 2. Set each timestamp from `timestampOnEnter` of the target state
+   */
+  private buildGrounding(
+    transition: WorkflowTransitionDefinition,
+  ): GroundingDefinition {
+    const steps: GroundingDefinition[] = [];
+
+    // Step 1: Set the status to the target state
+    steps.push({
+      id: `gnd-status-${this.shortStatus(transition.to)}`,
+      label: `Set status to ${this.shortStatus(transition.to)}`,
+      type: GroundingType.PROPERTY_SET,
+      targetProperty: "ems__Effort_status",
+      targetValue: transition.to,
+    });
+
+    // Step 2: Set timestamps defined in timestampOnEnter for the target state
+    const timestamps = this.engine.getTimestampsForStatus(transition.to);
+    for (const tsProperty of timestamps) {
+      steps.push({
+        id: `gnd-ts-${tsProperty}`,
+        label: `Set ${tsProperty}`,
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: tsProperty,
+        targetValue: "$now",
+      });
+    }
+
+    // If only one step, return it directly (no need for composite wrapper)
+    if (steps.length === 1) {
+      return steps[0];
+    }
+
+    // Composite grounding wrapping all steps
+    return {
+      id: `gnd-composite-${this.generateCommandId(transition)}`,
+      label: `Transition to ${this.shortStatus(transition.to)}`,
+      type: GroundingType.COMPOSITE,
+      steps,
+    };
+  }
+
+  /**
+   * Extract short status name from full EffortStatus enum value.
+   * e.g., "ems__EffortStatusDoing" → "doing"
+   */
+  private shortStatus(status: EffortStatus): string {
+    return status.replace("ems__EffortStatus", "").toLowerCase();
+  }
+}

--- a/packages/exocortex/tests/unit/services/WorkflowCommandAdapter.test.ts
+++ b/packages/exocortex/tests/unit/services/WorkflowCommandAdapter.test.ts
@@ -1,0 +1,312 @@
+import { WorkflowCommandAdapter } from "../../../src/services/WorkflowCommandAdapter";
+import { EffortStatus } from "../../../src/domain/constants/EffortStatus";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import type { WorkflowDefinition } from "../../../src/domain/models/WorkflowDefinition";
+import { AssetClass } from "../../../src/domain/constants/AssetClass";
+
+// -- Test Fixtures --
+
+function createMinimalWorkflow(
+  overrides?: Partial<WorkflowDefinition>,
+): WorkflowDefinition {
+  return {
+    id: "wf-test",
+    name: "Test Workflow",
+    targetClass: AssetClass.TASK,
+    initialState: EffortStatus.BACKLOG,
+    terminalStates: [EffortStatus.DONE, EffortStatus.TRASHED],
+    isDefault: true,
+    states: [
+      { status: EffortStatus.BACKLOG, order: 0, optional: false, timestampOnEnter: [] },
+      { status: EffortStatus.TODO, order: 1, optional: false, timestampOnEnter: [] },
+      {
+        status: EffortStatus.DOING,
+        order: 2,
+        optional: false,
+        timestampOnEnter: ["ems__Effort_startTimestamp"],
+      },
+      {
+        status: EffortStatus.DONE,
+        order: 3,
+        optional: false,
+        timestampOnEnter: ["ems__Effort_endTimestamp"],
+      },
+      { status: EffortStatus.TRASHED, order: 4, optional: false, timestampOnEnter: [] },
+    ],
+    transitions: [
+      { from: EffortStatus.BACKLOG, to: EffortStatus.TODO, label: "→ Todo", isRollback: false },
+      { from: EffortStatus.TODO, to: EffortStatus.DOING, label: "▶ Start", icon: "play", isRollback: false },
+      { from: EffortStatus.DOING, to: EffortStatus.DONE, label: "✓ Done", icon: "check", isRollback: false },
+      { from: EffortStatus.DOING, to: EffortStatus.TODO, label: "← Back", icon: "undo", isRollback: true },
+      { from: EffortStatus.BACKLOG, to: EffortStatus.TRASHED, label: "🗑 Trash", icon: "trash", isRollback: false },
+    ],
+    ...overrides,
+  };
+}
+
+// -- Tests --
+
+describe("WorkflowCommandAdapter", () => {
+  let adapter: WorkflowCommandAdapter;
+  let workflow: WorkflowDefinition;
+
+  beforeEach(() => {
+    workflow = createMinimalWorkflow();
+    adapter = new WorkflowCommandAdapter(workflow);
+  });
+
+  // -- adaptTransitions --
+
+  describe("adaptTransitions", () => {
+    it("should return all transitions from current status as commands", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.BACKLOG);
+
+      expect(commands).toHaveLength(2); // Todo + Trash
+    });
+
+    it("should return empty array for terminal states", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.DONE);
+
+      expect(commands).toHaveLength(0);
+    });
+
+    it("should include both forward and rollback transitions", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.DOING);
+
+      expect(commands).toHaveLength(2); // Done + Back
+      const categories = commands.map((c) => c.category);
+      expect(categories).toContain("workflow");
+      expect(categories).toContain("rollback");
+    });
+
+    it("should generate deterministic command IDs", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.BACKLOG);
+
+      expect(commands[0].id).toBe("workflow-backlog-to-todo");
+      expect(commands[1].id).toBe("workflow-backlog-to-trashed");
+    });
+
+    it("should preserve transition label as command name", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+
+      expect(commands[0].name).toBe("▶ Start");
+    });
+
+    it("should preserve transition icon", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+
+      expect(commands[0].icon).toBe("play");
+    });
+
+    it("should handle transitions without icon", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.BACKLOG);
+      const todoCmd = commands.find((c) => c.id === "workflow-backlog-to-todo");
+
+      expect(todoCmd?.icon).toBeUndefined();
+    });
+  });
+
+  // -- Preconditions --
+
+  describe("preconditions", () => {
+    it("should build precondition with SPARQL ASK checking from-status", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const precondition = commands[0].precondition;
+
+      expect(precondition).toBeDefined();
+      expect(precondition!.id).toBe("precond-workflow-todo-to-doing");
+      expect(precondition!.sparqlAsk).toContain(EffortStatus.TODO);
+      expect(precondition!.sparqlAsk).toContain("$target");
+    });
+
+    it("should include human-readable label in precondition", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+
+      expect(commands[0].precondition!.label).toContain("todo");
+    });
+  });
+
+  // -- Grounding --
+
+  describe("grounding", () => {
+    it("should build composite grounding with status + timestamps", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const startCmd = commands[0]; // Todo → Doing
+
+      // Doing has timestampOnEnter: ["ems__Effort_startTimestamp"]
+      expect(startCmd.grounding.type).toBe(GroundingType.COMPOSITE);
+      expect(startCmd.grounding.steps).toHaveLength(2);
+    });
+
+    it("should set status property as first grounding step", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const steps = commands[0].grounding.steps!;
+
+      expect(steps[0].type).toBe(GroundingType.PROPERTY_SET);
+      expect(steps[0].targetProperty).toBe("ems__Effort_status");
+      expect(steps[0].targetValue).toBe(EffortStatus.DOING);
+    });
+
+    it("should set timestamps as subsequent grounding steps", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const steps = commands[0].grounding.steps!;
+
+      expect(steps[1].type).toBe(GroundingType.PROPERTY_SET);
+      expect(steps[1].targetProperty).toBe("ems__Effort_startTimestamp");
+      expect(steps[1].targetValue).toBe("$now");
+    });
+
+    it("should return simple grounding when no timestamps", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.BACKLOG);
+      const todoCmd = commands.find((c) => c.id === "workflow-backlog-to-todo");
+
+      // Todo has no timestampOnEnter → single property_set, not composite
+      expect(todoCmd!.grounding.type).toBe(GroundingType.PROPERTY_SET);
+      expect(todoCmd!.grounding.targetProperty).toBe("ems__Effort_status");
+      expect(todoCmd!.grounding.targetValue).toBe(EffortStatus.TODO);
+      expect(todoCmd!.grounding.steps).toBeUndefined();
+    });
+
+    it("should handle multiple timestamps on enter", () => {
+      const multiTimestampWorkflow = createMinimalWorkflow({
+        states: [
+          { status: EffortStatus.BACKLOG, order: 0, optional: false, timestampOnEnter: [] },
+          {
+            status: EffortStatus.DOING,
+            order: 1,
+            optional: false,
+            timestampOnEnter: [
+              "ems__Effort_startTimestamp",
+              "ems__Effort_plannedStartTimestamp",
+            ],
+          },
+          { status: EffortStatus.DONE, order: 2, optional: false, timestampOnEnter: [] },
+        ],
+        transitions: [
+          { from: EffortStatus.BACKLOG, to: EffortStatus.DOING, label: "Start", isRollback: false },
+          { from: EffortStatus.DOING, to: EffortStatus.DONE, label: "Done", isRollback: false },
+        ],
+      });
+
+      const multiAdapter = new WorkflowCommandAdapter(multiTimestampWorkflow);
+      const commands = multiAdapter.adaptTransitions(EffortStatus.BACKLOG);
+      const steps = commands[0].grounding.steps!;
+
+      expect(steps).toHaveLength(3); // status + 2 timestamps
+      expect(steps[0].targetProperty).toBe("ems__Effort_status");
+      expect(steps[1].targetProperty).toBe("ems__Effort_startTimestamp");
+      expect(steps[2].targetProperty).toBe("ems__Effort_plannedStartTimestamp");
+    });
+  });
+
+  // -- Category --
+
+  describe("category", () => {
+    it("should set category to 'workflow' for forward transitions", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+
+      expect(commands[0].category).toBe("workflow");
+    });
+
+    it("should set category to 'rollback' for rollback transitions", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.DOING);
+      const rollbackCmd = commands.find((c) => c.category === "rollback");
+
+      expect(rollbackCmd).toBeDefined();
+      expect(rollbackCmd!.id).toBe("workflow-doing-to-todo");
+    });
+  });
+
+  // -- Confirm/Success Messages --
+
+  describe("messages", () => {
+    it("should set confirmMessage for rollback transitions", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.DOING);
+      const rollbackCmd = commands.find((c) => c.category === "rollback");
+
+      expect(rollbackCmd!.confirmMessage).toContain("Rollback");
+      expect(rollbackCmd!.confirmMessage).toContain("todo");
+    });
+
+    it("should not set confirmMessage for forward transitions", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+
+      expect(commands[0].confirmMessage).toBeUndefined();
+    });
+
+    it("should set successMessage for all transitions", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+
+      expect(commands[0].successMessage).toContain("doing");
+    });
+  });
+
+  // -- adaptForwardTransitions / adaptRollbackTransitions --
+
+  describe("adaptForwardTransitions", () => {
+    it("should return only forward transitions", () => {
+      const commands = adapter.adaptForwardTransitions(EffortStatus.DOING);
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0].category).toBe("workflow");
+      expect(commands[0].id).toBe("workflow-doing-to-done");
+    });
+  });
+
+  describe("adaptRollbackTransitions", () => {
+    it("should return only rollback transitions", () => {
+      const commands = adapter.adaptRollbackTransitions(EffortStatus.DOING);
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0].category).toBe("rollback");
+      expect(commands[0].id).toBe("workflow-doing-to-todo");
+    });
+
+    it("should return empty when no rollback available", () => {
+      const commands = adapter.adaptRollbackTransitions(EffortStatus.BACKLOG);
+
+      expect(commands).toHaveLength(0);
+    });
+  });
+
+  // -- Accessor methods --
+
+  describe("getEngine", () => {
+    it("should expose the underlying WorkflowEngine", () => {
+      const engine = adapter.getEngine();
+
+      expect(engine.canTransition(EffortStatus.BACKLOG, EffortStatus.TODO)).toBe(true);
+    });
+  });
+
+  describe("getWorkflow", () => {
+    it("should return the original workflow definition", () => {
+      expect(adapter.getWorkflow()).toBe(workflow);
+    });
+  });
+
+  // -- Edge Cases --
+
+  describe("edge cases", () => {
+    it("should handle status with no outgoing transitions", () => {
+      const commands = adapter.adaptTransitions(EffortStatus.TRASHED);
+
+      expect(commands).toHaveLength(0);
+    });
+
+    it("should produce consistent IDs across multiple calls", () => {
+      const first = adapter.adaptTransitions(EffortStatus.BACKLOG);
+      const second = adapter.adaptTransitions(EffortStatus.BACKLOG);
+
+      expect(first.map((c) => c.id)).toEqual(second.map((c) => c.id));
+    });
+
+    it("should match VisibilityGenerator command ID format", () => {
+      // VisibilityGenerator uses: workflow-{fromShort}-to-{toShort}
+      // where fromShort = t.from.replace("ems__EffortStatus", "").toLowerCase()
+      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+
+      expect(commands[0].id).toMatch(/^workflow-[a-z]+-to-[a-z]+$/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2431

Adds `WorkflowCommandAdapter` service to `@exocortex/core` that converts `WorkflowTransitionDefinition` into `CommandDefinition`, unifying the workflow engine with the dynamic command system (RFC-009 §3).

### Key design decisions

- **Wraps WorkflowEngine** — adapter delegates transition queries to the engine, does NOT replace it
- **Deterministic command IDs** — `workflow-{from}-to-{to}` format matching `VisibilityGenerator`
- **Composite grounding** — status set + timestampOnEnter properties via `property_set` (not `sparql_update` which is a Phase 1 stub)
- **Simple grounding optimization** — when no timestamps needed, returns single `property_set` instead of composite wrapper
- **Category tagging** — `isRollback ? 'rollback' : 'workflow'` for UI grouping

### Files changed

- `packages/exocortex/src/services/WorkflowCommandAdapter.ts` — new service (~160 lines)
- `packages/exocortex/src/index.ts` — export added
- `packages/exocortex/tests/unit/services/WorkflowCommandAdapter.test.ts` — 27 unit tests

### Test plan

- [x] 27 unit tests covering all transitions, preconditions, grounding, categories, messages, edge cases
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] ESLint passes
- [x] BDD coverage 100%
- [x] Archgate compliance passes
- [ ] CI pipeline green