### PR TITLE
chore(cleanup): replace direct console.* with LoggingService and remove debug statements

### DIFF
--- a/packages/exocortex/src/application/errors/ApplicationErrorHandler.ts
+++ b/packages/exocortex/src/application/errors/ApplicationErrorHandler.ts
@@ -2,6 +2,7 @@ import type { ILogger } from "../../interfaces/ILogger";
 import type { INotificationService } from "../../interfaces/INotificationService";
 import { ApplicationError } from "../../domain/errors/ApplicationError";
 import { ErrorCode } from "../../domain/errors/ErrorCode";
+import { LoggingService } from "../../services/LoggingService";
 
 /**
  * Telemetry hook for monitoring errors
@@ -102,7 +103,7 @@ export class ApplicationErrorHandler {
       }
     }
 
-    throw lastError!;
+    throw lastError as ApplicationError;
   }
 
   /**
@@ -192,7 +193,7 @@ export class ApplicationErrorHandler {
           hookMethod.apply(hook, args);
         }
       } catch (error) {
-        console.error("Error in telemetry hook:", error);
+        LoggingService.error("Error in telemetry hook", error instanceof Error ? error : new Error(String(error)));
       }
     }
   }

--- a/packages/exocortex/src/infrastructure/sparql/cache/IncrementalIndexer.ts
+++ b/packages/exocortex/src/infrastructure/sparql/cache/IncrementalIndexer.ts
@@ -1,3 +1,5 @@
+import { LoggingService } from "../../../services/LoggingService";
+
 /**
  * IncrementalIndexer - Tracks file modification times for smart cache invalidation
  *
@@ -214,7 +216,7 @@ export class IncrementalIndexer {
         try {
           callback(changesToInvalidate);
         } catch (error) {
-          console.error("IncrementalIndexer: Error in invalidation callback:", error);
+          LoggingService.error("IncrementalIndexer: Error in invalidation callback", error instanceof Error ? error : new Error(String(error)));
         }
       }
     }

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -4,6 +4,7 @@ import type { IFileSystemWriter } from "../interfaces/IFileSystemAdapter";
 import type { GroundingDefinition } from "../domain/models/CommandDefinition";
 import { GroundingType } from "../domain/constants/GroundingType";
 import { FrontmatterService } from "../utilities/FrontmatterService";
+import { LoggingService } from "./LoggingService";
 
 /**
  * Result of executing a grounding action.
@@ -321,9 +322,9 @@ export class GroundingExecutor {
       await this.fileWriter.updateFile(filePath, originalContent);
     } catch (rollbackError) {
       // Log rollback failure but do not throw — prevents masking the original error
-      console.error(
-        `[GroundingExecutor] Rollback failed for ${filePath}:`,
-        rollbackError,
+      LoggingService.error(
+        `[GroundingExecutor] Rollback failed for ${filePath}`,
+        rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)),
       );
     }
   }

--- a/packages/exocortex/src/services/TypeRegistry.ts
+++ b/packages/exocortex/src/services/TypeRegistry.ts
@@ -8,6 +8,7 @@ import type { ITripleStore } from "../interfaces/ITripleStore";
 import { IRI } from "../domain/models/rdf/IRI";
 import { BlankNode } from "../domain/models/rdf/BlankNode";
 import { Literal } from "../domain/models/rdf/Literal";
+import { LoggingService } from "./LoggingService";
 import type { Subject, Object as RDFObject } from "../domain/models/rdf/Triple";
 import {
   NodeTypeDefinition,
@@ -791,7 +792,7 @@ export class TypeRegistry {
       try {
         callback(event);
       } catch (error) {
-        console.error("TypeRegistry: error in subscriber callback", error);
+        LoggingService.error("TypeRegistry: error in subscriber callback", error instanceof Error ? error : new Error(String(error)));
       }
     }
   }

--- a/packages/exocortex/tests/unit/application/errors/ApplicationErrorHandler.test.ts
+++ b/packages/exocortex/tests/unit/application/errors/ApplicationErrorHandler.test.ts
@@ -7,6 +7,7 @@ import {
   NetworkError,
   ValidationError,
 } from "../../../../src/domain/errors/index";
+import { LoggingService } from "../../../../src/services/LoggingService";
 
 describe("ApplicationErrorHandler", () => {
   let handler: ApplicationErrorHandler;
@@ -205,20 +206,20 @@ describe("ApplicationErrorHandler", () => {
       };
       handler.registerTelemetryHook(badHook);
 
-      const consoleErrorSpy = jest
-        .spyOn(console, "error")
+      const loggingErrorSpy = jest
+        .spyOn(LoggingService, "error")
         .mockImplementation(() => {});
 
       const error = new ValidationError("Test");
       const result = handler.handle(error);
 
       expect(result).toBeDefined();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "Error in telemetry hook:",
+      expect(loggingErrorSpy).toHaveBeenCalledWith(
+        "Error in telemetry hook",
         expect.any(Error),
       );
 
-      consoleErrorSpy.mockRestore();
+      loggingErrorSpy.mockRestore();
     });
 
     it("should merge context from executeWithRetry", async () => {

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/StatusButtonGroupBuilder.ts
@@ -42,10 +42,8 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
 
     // For custom (non-standard) asset classes, use workflow-driven buttons directly
     const isCustom = this.isCustomAssetClass(metadata);
-    console.debug("[Exocortex Workflow] build() called, isCustom:", isCustom, "class:", metadata["exo__Instance_class"]);
     if (isCustom) {
       const workflowButtons = await this.buildWorkflowButtons(file, metadata, logger, refresh);
-      console.debug("[Exocortex Workflow] workflowButtons:", workflowButtons.length);
       if (workflowButtons.length > 0) {
         return workflowButtons;
       }
@@ -84,19 +82,13 @@ export class StatusButtonGroupBuilder implements IButtonGroupBuilder {
     refresh: () => Promise<void>,
   ): Promise<ActionButton[]> {
     const statusRaw = metadata["ems__Effort_status"] as string | undefined;
-    console.debug("[Exocortex Workflow] buildWorkflowButtons statusRaw:", statusRaw);
     if (!statusRaw) return [];
 
     const normalized = statusRaw.replace(/["'[\]]/g, "").trim();
     const currentStatus = Object.values(EffortStatus).find((s) => s === normalized);
-    console.debug("[Exocortex Workflow] normalized:", normalized, "currentStatus:", currentStatus);
     if (!currentStatus) return [];
 
-    const hasTripleStore = !!this.services.tripleStore;
-    console.debug("[Exocortex Workflow] hasTripleStore:", hasTripleStore);
     const store = this.services.tripleStore ?? new InMemoryTripleStore();
-    const storeCount = await store.count();
-    console.debug("[Exocortex Workflow] storeCount:", storeCount);
     const resolver = new WorkflowResolver(store);
     const instanceClassRaw = metadata["exo__Instance_class"];
 


### PR DESCRIPTION
## Summary

- Replace 4 direct `console.error` calls in core services with `LoggingService.error()`:
  - `TypeRegistry.ts` — subscriber callback errors
  - `GroundingExecutor.ts` — rollback failure logging
  - `ApplicationErrorHandler.ts` — telemetry hook errors + fix non-null assertion lint warning
  - `IncrementalIndexer.ts` — invalidation callback errors
- Remove 6 leftover `console.debug` statements from `StatusButtonGroupBuilder.ts` (plugin)
- Update test to spy on `LoggingService` instead of `console`

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — zero errors
- [x] Core tests: 180 suites, 6116 passed
- [x] Archgate: `no-console-in-core-services` now 0 violations (was 1)

Closes #2453