### PR TITLE
test(cli): fix integration tests and measure coverage (#2460)

### DIFF
--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -12,8 +12,8 @@ if [ "$CI" = "true" ]; then
     npx jest --clearCache || true
 fi
 
-# Set memory limits
-export NODE_OPTIONS="--max-old-space-size=4096"
+# Set memory limits and ESM support for CLI tests (jest workers inherit NODE_OPTIONS)
+export NODE_OPTIONS="--max-old-space-size=4096 --experimental-vm-modules"
 
 # Run obsidian-plugin tests (with coverage if COVERAGE=true)
 echo "📦 Running obsidian-plugin tests..."


### PR DESCRIPTION
## Summary

- Fix 43 failing CLI test suites caused by missing `--experimental-vm-modules` in `NODE_OPTIONS`
- Root cause: `test-ci-batched.sh` set `NODE_OPTIONS="--max-old-space-size=4096"` which **overwrote** the ESM flag needed by jest worker processes to parse top-level `await` in `jest.unstable_mockModule()` pattern
- Fix: append `--experimental-vm-modules` to `NODE_OPTIONS` so jest workers inherit it

## Results

| Metric | Before | After | Threshold |
|--------|--------|-------|-----------|
| Passing suites | 28/71 | **71/71** | - |
| Statements | unmeasurable | **70.68%** | 65% |
| Branches | unmeasurable | **60.63%** | 60% |
| Functions | unmeasurable | **82.39%** | 70% |
| Lines | unmeasurable | **71.11%** | 65% |

## Root Cause Analysis

The CLI test files use `jest.unstable_mockModule()` + top-level `await import()` pattern for ESM-compatible mocking. This requires Node.js `--experimental-vm-modules` flag. The `test-ci-batched.sh` script passed this flag to the main `node` process (`node --experimental-vm-modules ./node_modules/jest/bin/jest.js`), but also set `NODE_OPTIONS="--max-old-space-size=4096"` without the ESM flag. Jest spawns worker child processes that inherit `NODE_OPTIONS` but not parent CLI flags, so workers could not parse the top-level `await` syntax.

## Test plan
- [x] All 71 CLI test suites pass locally
- [x] All 217 obsidian-plugin test suites pass (no regression from `--experimental-vm-modules` in NODE_OPTIONS)
- [x] Coverage above all thresholds
- [x] TypeScript type check clean
- [ ] CI pipeline green

Closes #2460