### PR TITLE
fix(plugin): fix IRI encoding mismatch in VaultRDFIndexer

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -192,7 +192,7 @@ export class VaultRDFIndexer {
   }
 
   private async removeFileTriples(filePath: string): Promise<void> {
-    const fileIRI = new IRI(`obsidian://vault/${encodeURIComponent(filePath)}`);
+    const fileIRI = new IRI(`obsidian://vault/${encodeURI(filePath)}`);
     const triples = await this.tripleStore.match(fileIRI);
     await this.tripleStore.removeAll(triples);
   }

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.test.ts
@@ -1,6 +1,6 @@
 import { VaultRDFIndexer } from "../../../src/infrastructure/VaultRDFIndexer";
 import type { App, TFile, EventRef } from "obsidian";
-import { InMemoryTripleStore, NoteToRDFConverter, ApplicationErrorHandler } from "exocortex";
+import { InMemoryTripleStore, NoteToRDFConverter, ApplicationErrorHandler, IRI } from "exocortex";
 import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
 
 jest.mock("exocortex");
@@ -196,6 +196,49 @@ describe("VaultRDFIndexer", () => {
       indexer.dispose();
 
       expect(mockApp.vault.offref).toHaveBeenCalledTimes(eventRefCount);
+    });
+  });
+
+  describe("Issue #2488: IRI encoding consistency", () => {
+    let iriConstructorCalls: string[];
+
+    beforeEach(async () => {
+      iriConstructorCalls = [];
+      (IRI as unknown as jest.Mock).mockImplementation((value: string) => {
+        iriConstructorCalls.push(value);
+        return { value };
+      });
+      await indexer.initialize();
+    });
+
+    it("should use encodeURI for subdirectory file paths in removeFileTriples (modify scenario)", async () => {
+      const subdirPath = "My Folder/My Note.md";
+      const mockFile = { path: subdirPath, extension: "md" } as TFile;
+
+      mockTripleStore.match.mockResolvedValue([]);
+      mockConverter.convertNote.mockResolvedValue([]);
+
+      await indexer.updateFile(mockFile);
+
+      const removeIRI = iriConstructorCalls.find(v => v.includes("My%20Folder"));
+      expect(removeIRI).toBeDefined();
+      expect(removeIRI).toBe(`obsidian://vault/My%20Folder/My%20Note.md`);
+      expect(removeIRI).not.toContain("My%20Folder%2FMy%20Note.md");
+    });
+
+    it("should use encodeURI for subdirectory file paths in removeFileTriples (delete scenario)", async () => {
+      const subdirPath = "03 Knowledge/kitelev/some-note.md";
+      const mockFile = { path: subdirPath } as TFile;
+
+      mockTripleStore.match.mockResolvedValue([{ subject: {}, predicate: {}, object: {} }]);
+      mockTripleStore.removeAll.mockResolvedValue(1);
+
+      await indexer.removeFile(mockFile);
+
+      const removeIRI = iriConstructorCalls.find(v => v.includes("03%20Knowledge"));
+      expect(removeIRI).toBeDefined();
+      expect(removeIRI).toBe(`obsidian://vault/03%20Knowledge/kitelev/some-note.md`);
+      expect(removeIRI).not.toContain("%2F");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Changed `encodeURIComponent` to `encodeURI` in `removeFileTriples()` to match `NoteToRDFConverter.notePathToIRI()`
- `encodeURIComponent` encoded `/` as `%2F`, producing different IRIs than `encodeURI` for subdirectory paths
- This caused stale triples: removal never matched the IRI used during conversion

## Changes
- `VaultRDFIndexer.ts` line 195: `encodeURIComponent` -> `encodeURI`
- Added 2 regression tests verifying correct IRI encoding for subdirectory files

## Testing
- [x] Regression test: modify file in subdirectory -> old triples removed (IRI matches)
- [x] Regression test: delete file in subdirectory -> all triples removed (IRI matches)
- [x] All 21 VaultRDFIndexer tests pass
- [x] TypeScript compilation passes (`tsc --noEmit --skipLibCheck`)
- [x] Pre-commit hooks pass (lint, BDD 100%, archgate)

## Acceptance Criteria
- [x] `removeFileTriples()` uses `encodeURI()` matching `notePathToIRI()`
- [x] Unit test: modify file in subdirectory -> old triples removed, new triples present
- [x] Unit test: delete file in subdirectory -> all triples removed

Closes #2488