### PR TITLE
feat(plugin): wire RDFSInferenceEngine into VaultRDFIndexer

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -3,6 +3,7 @@ import {
   InMemoryTripleStore,
   NoteToRDFConverter,
   ApplicationErrorHandler,
+  RDFSInferenceEngine,
   NetworkError,
   ServiceError,
   type ILogger,
@@ -69,6 +70,7 @@ export class VaultRDFIndexer {
         { context: "VaultRDFIndexer.initialize", operation: "convertVault" }
       );
       await this.tripleStore.addAll(triples);
+      await this.runInference();
 
       this.registerEventListeners();
 
@@ -169,6 +171,7 @@ export class VaultRDFIndexer {
         await this.removeFileTriples(file.path);
         const triples = await this.converter.convertNote(file as IFile);
         await this.tripleStore.addAll(triples);
+        await this.runInference();
       },
       { context: "VaultRDFIndexer.updateFile", filePath: file.path }
     );
@@ -203,9 +206,15 @@ export class VaultRDFIndexer {
         await this.tripleStore.clear();
         const triples = await this.converter.convertVault();
         await this.tripleStore.addAll(triples);
+        await this.runInference();
       },
       { context: "VaultRDFIndexer.refresh", operation: "refresh" }
     );
+  }
+
+  private async runInference(): Promise<void> {
+    const engine = new RDFSInferenceEngine();
+    await engine.materialize(this.tripleStore);
   }
 
   getTripleStore(): InMemoryTripleStore {

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.test.ts
@@ -1,6 +1,6 @@
 import { VaultRDFIndexer } from "../../../src/infrastructure/VaultRDFIndexer";
 import type { App, TFile, EventRef } from "obsidian";
-import { InMemoryTripleStore, NoteToRDFConverter, ApplicationErrorHandler, IRI } from "exocortex";
+import { InMemoryTripleStore, NoteToRDFConverter, ApplicationErrorHandler, IRI, RDFSInferenceEngine } from "exocortex";
 import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
 
 jest.mock("exocortex");
@@ -239,6 +239,44 @@ describe("VaultRDFIndexer", () => {
       expect(removeIRI).toBeDefined();
       expect(removeIRI).toBe(`obsidian://vault/03%20Knowledge/kitelev/some-note.md`);
       expect(removeIRI).not.toContain("%2F");
+    });
+  });
+
+  describe("Issue #2490: RDFS inference materialization", () => {
+    let mockMaterialize: jest.Mock;
+
+    beforeEach(() => {
+      mockMaterialize = jest.fn().mockResolvedValue(0);
+      (RDFSInferenceEngine as jest.MockedClass<typeof RDFSInferenceEngine>).mockImplementation(() => ({
+        materialize: mockMaterialize,
+      } as any));
+    });
+
+    it("should run RDFS inference after initialize addAll", async () => {
+      await indexer.initialize();
+
+      expect(mockMaterialize).toHaveBeenCalledWith(mockTripleStore);
+    });
+
+    it("should run RDFS inference after updateFile re-converts a note", async () => {
+      await indexer.initialize();
+      mockMaterialize.mockClear();
+
+      const mockFile = { path: "test.md", extension: "md" } as TFile;
+      mockConverter.convertNote.mockResolvedValue([]);
+
+      await indexer.updateFile(mockFile);
+
+      expect(mockMaterialize).toHaveBeenCalledWith(mockTripleStore);
+    });
+
+    it("should run RDFS inference after refresh addAll", async () => {
+      await indexer.initialize();
+      mockMaterialize.mockClear();
+
+      await indexer.refresh();
+
+      expect(mockMaterialize).toHaveBeenCalledWith(mockTripleStore);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Wired `RDFSInferenceEngine.materialize()` into VaultRDFIndexer's `initialize()`, `updateFile()`, and `refresh()` methods
- Previously, RDFS inference only ran in the CLI (`sparql-index.ts`), meaning the plugin never materialized subClassOf triples
- Now queries like `?s rdf:type ems:Asset` correctly return `ems:Task` instances via subClassOf inference

## Changes
- `VaultRDFIndexer.ts`: Import `RDFSInferenceEngine`, add private `runInference()` method, call it after every `addAll(triples)`
- 3 new unit tests verifying inference runs in `initialize()`, `updateFile()`, and `refresh()`

## Testing
- [x] Test: inference runs after `initialize()` calls `addAll(triples)`
- [x] Test: inference runs after `updateFile()` re-converts a note
- [x] Test: inference runs after `refresh()` calls `addAll(triples)`
- [x] All 22 VaultRDFIndexer tests pass
- [x] TypeScript compilation passes (`tsc --noEmit --skipLibCheck`)
- [x] Pre-commit hooks pass (lint, BDD 100%, archgate)

## Acceptance Criteria
- [x] `initialize()` calls `RDFSInferenceEngine.materialize()` after `addAll(triples)`
- [x] `updateFile()` re-runs inference after re-converting changed file
- [x] `refresh()` runs inference after `addAll(triples)`
- [x] Tests verify inference is called with the tripleStore

Closes #2490