### PR TITLE
feat(core): extend EvalContext with fileBasename and currentFolder (#2495)

### DIFF
--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -41,8 +41,10 @@ export interface PreconditionDefinition {
   readonly id: string;
   /** Human-readable description (e.g., "Asset has startTimestamp") */
   readonly label: string;
-  /** SPARQL ASK query */
-  readonly sparqlAsk: string;
+  /** SPARQL ASK query (evaluated against triple store) */
+  readonly sparqlAsk?: string;
+  /** Host function name (evaluated via registered TypeScript function) */
+  readonly hostFunction?: string;
 }
 
 /**

--- a/packages/exocortex/src/services/PreconditionEvaluator.ts
+++ b/packages/exocortex/src/services/PreconditionEvaluator.ts
@@ -11,6 +11,8 @@ import type { AskOperation } from "../infrastructure/sparql/algebra/AlgebraOpera
  */
 export interface EvalContext {
   readonly targetIRI: string;
+  readonly fileBasename?: string;
+  readonly currentFolder?: string;
   readonly [key: string]: unknown;
 }
 
@@ -56,7 +58,7 @@ export class PreconditionEvaluator {
   async evaluate(
     precondition: PreconditionDefinition | undefined,
     targetIRI: string,
-    _context?: EvalContext,
+    context?: EvalContext,
   ): Promise<boolean> {
     // No precondition = always available
     if (!precondition) return true;
@@ -64,6 +66,15 @@ export class PreconditionEvaluator {
     // SPARQL ASK evaluation
     if (precondition.sparqlAsk) {
       return this.evaluateSparqlAsk(precondition.sparqlAsk, targetIRI);
+    }
+
+    // Host function evaluation
+    if (precondition.hostFunction) {
+      return this.evaluateHostFunction(
+        precondition.hostFunction,
+        targetIRI,
+        context,
+      );
     }
 
     return true;
@@ -106,6 +117,21 @@ export class PreconditionEvaluator {
       return null;
     }
     return algebra as AskOperation;
+  }
+
+  private evaluateHostFunction(
+    name: string,
+    targetIRI: string,
+    context?: EvalContext,
+  ): boolean {
+    const fn = this.hostFunctions.get(name);
+    if (!fn) return true;
+
+    const evalContext: EvalContext = context
+      ? { ...context, targetIRI }
+      : { targetIRI };
+
+    return fn(evalContext);
   }
 
   private async evaluateSparqlAsk(

--- a/packages/exocortex/tests/unit/services/PreconditionEvaluator.test.ts
+++ b/packages/exocortex/tests/unit/services/PreconditionEvaluator.test.ts
@@ -172,6 +172,82 @@ describe("PreconditionEvaluator", () => {
     });
   });
 
+  describe("Issue #2495: EvalContext with fileBasename and currentFolder", () => {
+    it("should pass fileBasename and currentFolder to host function via context", async () => {
+      let receivedContext: import("../../../src/services/PreconditionEvaluator").EvalContext | undefined;
+
+      evaluator.registerHostFunction("checkFile", (ctx) => {
+        receivedContext = ctx;
+        return true;
+      });
+
+      const precondition = {
+        id: "pre-check-file",
+        label: "Check file",
+        hostFunction: "checkFile",
+      };
+
+      const context = {
+        targetIRI: ASSET_IRI,
+        fileBasename: "my-task.md",
+        currentFolder: "03 Knowledge/projects",
+      };
+
+      await evaluator.evaluate(precondition, ASSET_IRI, context);
+
+      expect(receivedContext).toBeDefined();
+      expect(receivedContext!.targetIRI).toBe(ASSET_IRI);
+      expect(receivedContext!.fileBasename).toBe("my-task.md");
+      expect(receivedContext!.currentFolder).toBe("03 Knowledge/projects");
+    });
+
+    it("should work when fileBasename and currentFolder are omitted", async () => {
+      let receivedContext: import("../../../src/services/PreconditionEvaluator").EvalContext | undefined;
+
+      evaluator.registerHostFunction("checkMinimal", (ctx) => {
+        receivedContext = ctx;
+        return true;
+      });
+
+      const precondition = {
+        id: "pre-minimal",
+        label: "Minimal check",
+        hostFunction: "checkMinimal",
+      };
+
+      await evaluator.evaluate(precondition, ASSET_IRI);
+
+      expect(receivedContext).toBeDefined();
+      expect(receivedContext!.targetIRI).toBe(ASSET_IRI);
+      expect(receivedContext!.fileBasename).toBeUndefined();
+      expect(receivedContext!.currentFolder).toBeUndefined();
+    });
+
+    it("should return host function result for hostFunction precondition", async () => {
+      evaluator.registerHostFunction("alwaysFalse", () => false);
+
+      const precondition = {
+        id: "pre-false",
+        label: "Always false",
+        hostFunction: "alwaysFalse",
+      };
+
+      const result = await evaluator.evaluate(precondition, ASSET_IRI);
+      expect(result).toBe(false);
+    });
+
+    it("should return true when hostFunction is not registered", async () => {
+      const precondition = {
+        id: "pre-unknown",
+        label: "Unknown function",
+        hostFunction: "nonExistentFn",
+      };
+
+      const result = await evaluator.evaluate(precondition, ASSET_IRI);
+      expect(result).toBe(true);
+    });
+  });
+
   describe("precondition with sparqlAsk returning true for complex query", () => {
     it("should handle multi-pattern ASK query", async () => {
       const subject = new IRI(ASSET_IRI);

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -6,6 +6,7 @@ import type {
   PreconditionEvaluator,
   GroundingExecutor,
   UserInput,
+  EvalContext,
 } from "exocortex";
 import { ILogger } from '@plugin/adapters/logging/ILogger';
 import {
@@ -85,12 +86,19 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
 
     if (resolved.length === 0) return [];
 
+    const evalContext: EvalContext = {
+      targetIRI: subjectIRI,
+      fileBasename: file.basename,
+      currentFolder: file.parent?.path,
+    };
+
     const availabilityChecks = await Promise.all(
       resolved.map(async (rc) => {
         try {
           const available = await this.config.preconditionEvaluator.evaluate(
             rc.command.precondition,
             subjectIRI,
+            evalContext,
           );
           return { rc, available };
         } catch {


### PR DESCRIPTION
## Summary
- Extend `EvalContext` interface with optional `fileBasename` and `currentFolder` properties
- Add `hostFunction` field to `PreconditionDefinition` for non-SPARQL preconditions
- Implement host function evaluation path in `PreconditionEvaluator.evaluate()`
- Pass file context from `DynamicCommandButtonGroupBuilder` to `evaluate()` calls

## Testing
- [x] 4 new unit tests for host function evaluation with file context
- [x] All 19 PreconditionEvaluator tests pass
- [x] Full core test suite (6691 tests) passes
- [x] TypeScript typecheck clean

## Acceptance Criteria
- [x] `EvalContext` interface gains `fileBasename?: string` and `currentFolder?: string`
- [x] `DynamicCommandButtonGroupBuilder` passes file info to `evaluate()` context
- [x] Unit test: host_function receives fileBasename and currentFolder
- [x] Existing tests remain green

Fixes #2495