### PR TITLE
perf(core): add compiled SPARQL ASK cache in PreconditionEvaluator (#2496)

### DIFF
--- a/packages/exocortex/src/services/PreconditionEvaluator.ts
+++ b/packages/exocortex/src/services/PreconditionEvaluator.ts
@@ -39,6 +39,7 @@ export type HostFunction = (context: EvalContext) => boolean;
 export class PreconditionEvaluator {
   private readonly hostFunctions = new Map<string, HostFunction>();
   private readonly tripleStore: ITripleStore;
+  private readonly askCache = new Map<string, AskOperation>();
 
   constructor(tripleStore: ITripleStore) {
     this.tripleStore = tripleStore;
@@ -82,34 +83,55 @@ export class PreconditionEvaluator {
     return this.hostFunctions.has(name);
   }
 
+  invalidateCache(): void {
+    this.askCache.clear();
+  }
+
   // -- Private --
+
+  private static readonly SENTINEL_IRI = "urn:exocortex:cache-sentinel:target";
+
+  private compileAsk(sparqlAsk: string): AskOperation | null {
+    const processedQuery = this.substituteVariables(
+      sparqlAsk,
+      PreconditionEvaluator.SENTINEL_IRI,
+    );
+    const parser = new SPARQLParser();
+    const parsed = parser.parse(processedQuery);
+    const translator = new AlgebraTranslator();
+    const algebra = translator.translate(parsed);
+
+    const executor = new QueryExecutor(this.tripleStore);
+    if (!executor.isAskQuery(algebra)) {
+      return null;
+    }
+    return algebra as AskOperation;
+  }
 
   private async evaluateSparqlAsk(
     sparqlAsk: string,
     targetIRI: string,
   ): Promise<boolean> {
     try {
-      // Step 1: Variable substitution (text preprocessing BEFORE parser)
-      const processedQuery = this.substituteVariables(sparqlAsk, targetIRI);
+      let compiled = this.askCache.get(sparqlAsk);
 
-      // Step 2: Parse SPARQL ASK query
-      const parser = new SPARQLParser();
-      const parsed = parser.parse(processedQuery);
-
-      // Step 3: Translate to algebra
-      const translator = new AlgebraTranslator();
-      const algebra = translator.translate(parsed);
-
-      // Step 4: Verify it's an ASK operation
-      const executor = new QueryExecutor(this.tripleStore);
-      if (!executor.isAskQuery(algebra)) {
-        return false;
+      if (compiled === undefined) {
+        const result = this.compileAsk(sparqlAsk);
+        if (!result) return false;
+        compiled = result;
+        this.askCache.set(sparqlAsk, compiled);
       }
 
-      // Step 5: Execute ASK
-      return await executor.executeAsk(algebra as AskOperation);
+      const instantiated = JSON.parse(
+        JSON.stringify(compiled).replaceAll(
+          PreconditionEvaluator.SENTINEL_IRI,
+          targetIRI,
+        ),
+      ) as AskOperation;
+
+      const executor = new QueryExecutor(this.tripleStore);
+      return await executor.executeAsk(instantiated);
     } catch {
-      // Fail closed: SPARQL errors → command not available
       return false;
     }
   }

--- a/packages/exocortex/tests/unit/services/PreconditionEvaluator.test.ts
+++ b/packages/exocortex/tests/unit/services/PreconditionEvaluator.test.ts
@@ -236,4 +236,128 @@ describe("PreconditionEvaluator", () => {
       expect(result).toBe(false);
     });
   });
+
+  describe("Issue #2496: compiled SPARQL ASK cache", () => {
+    const ASK_QUERY = `
+      PREFIX ems: <https://exocortex.my/ontology/ems#>
+      ASK { $target ems:Effort_startTimestamp ?ts }
+    `;
+
+    beforeEach(async () => {
+      const subject = new IRI(ASSET_IRI);
+      await store.add(
+        new Triple(
+          subject,
+          Namespace.EMS.term("Effort_startTimestamp"),
+          new Literal("2026-03-30T10:00:00"),
+        ),
+      );
+    });
+
+    it("should cache parsed algebra and skip parse on second call", async () => {
+      const SPARQLParserModule = await import("../../../src/infrastructure/sparql/SPARQLParser");
+      const parseSpy = jest.spyOn(SPARQLParserModule.SPARQLParser.prototype, "parse");
+
+      const precondition = {
+        id: "pre-cached",
+        label: "Cached ASK",
+        sparqlAsk: ASK_QUERY,
+      };
+
+      const result1 = await evaluator.evaluate(precondition, ASSET_IRI);
+      expect(result1).toBe(true);
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+
+      const result2 = await evaluator.evaluate(precondition, ASSET_IRI);
+      expect(result2).toBe(true);
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+
+      parseSpy.mockRestore();
+    });
+
+    it("should invalidate cache when invalidateCache is called", async () => {
+      const SPARQLParserModule = await import("../../../src/infrastructure/sparql/SPARQLParser");
+      const parseSpy = jest.spyOn(SPARQLParserModule.SPARQLParser.prototype, "parse");
+
+      const precondition = {
+        id: "pre-inv",
+        label: "Invalidatable",
+        sparqlAsk: ASK_QUERY,
+      };
+
+      await evaluator.evaluate(precondition, ASSET_IRI);
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+
+      evaluator.invalidateCache();
+
+      await evaluator.evaluate(precondition, ASSET_IRI);
+      expect(parseSpy).toHaveBeenCalledTimes(2);
+
+      parseSpy.mockRestore();
+    });
+
+    it("should work correctly with different targetIRIs on same query", async () => {
+      const OTHER_IRI = "https://exocortex.my/ontology/ems/other-asset-456";
+      const otherSubject = new IRI(OTHER_IRI);
+      await store.add(
+        new Triple(
+          otherSubject,
+          Namespace.EMS.term("Effort_startTimestamp"),
+          new Literal("2026-04-01T09:00:00"),
+        ),
+      );
+
+      const precondition = {
+        id: "pre-multi",
+        label: "Multi-target",
+        sparqlAsk: ASK_QUERY,
+      };
+
+      const result1 = await evaluator.evaluate(precondition, ASSET_IRI);
+      expect(result1).toBe(true);
+
+      const result2 = await evaluator.evaluate(precondition, OTHER_IRI);
+      expect(result2).toBe(true);
+    });
+
+    it("benchmark: 27 cached ASK queries should complete in < 50ms on 10K triples", async () => {
+      const TRIPLE_COUNT = 10000;
+      const QUERY_COUNT = 27;
+
+      for (let i = 0; i < TRIPLE_COUNT; i++) {
+        const iri = new IRI(`https://exocortex.my/ontology/ems/asset-${i}`);
+        await store.add(
+          new Triple(
+            iri,
+            Namespace.EMS.term("Effort_startTimestamp"),
+            new Literal(`2026-01-01T${String(i % 24).padStart(2, "0")}:00:00`),
+          ),
+        );
+      }
+
+      const queries: { id: string; label: string; sparqlAsk: string }[] = [];
+      for (let i = 0; i < QUERY_COUNT; i++) {
+        queries.push({
+          id: `bench-${i}`,
+          label: `Benchmark ${i}`,
+          sparqlAsk: `
+            PREFIX ems: <https://exocortex.my/ontology/ems#>
+            ASK { $target ems:Effort_startTimestamp ?ts }
+          `,
+        });
+      }
+
+      for (const q of queries) {
+        await evaluator.evaluate(q, ASSET_IRI);
+      }
+
+      const start = performance.now();
+      for (const q of queries) {
+        await evaluator.evaluate(q, ASSET_IRI);
+      }
+      const elapsed = performance.now() - start;
+
+      expect(elapsed).toBeLessThan(50);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add compiled SPARQL ASK query cache (`Map<string, AskOperation>`) keyed on raw sparqlAsk string
- First call: parse + translate + cache. Subsequent calls: retrieve from cache + execute only
- Cache invalidation via `invalidateCache()` method
- Uses sentinel IRI pattern: parse with placeholder, deep-clone + replace on each execution

## Changes
- `PreconditionEvaluator.ts`: Added `askCache` field, `compileAsk()` method, `invalidateCache()` method
- Refactored `evaluateSparqlAsk()` to check cache before parsing
- Import cleanup (removed unused `AlgebraOperation` type)

## Testing
- [x] Cache hit test: second evaluate() with same query skips parse (SPARQLParser.parse spy)
- [x] Cache invalidation test: invalidateCache() forces re-parse
- [x] Multi-target test: same query works with different targetIRIs
- [x] Benchmark: 27 cached ASK queries on 10K triples < 50ms
- [x] All 19 PreconditionEvaluator tests pass
- [x] TypeScript typecheck clean

## Acceptance Criteria
- [x] Cache: `Map<string, AskOperation>` keyed on sparqlAsk string
- [x] First call: parse + translate + cache
- [x] Subsequent calls: retrieve from cache + execute only
- [x] Cache invalidation on `invalidateCache()` call
- [x] Unit test: second evaluate() with same query skips parse
- [x] Benchmark: 27 cached ASK queries < 50ms on 10K triples

Fixes #2496