### PR TITLE
feat(plugin): wire CommandResolver, PreconditionEvaluator, GroundingExecutor in DI (#2492)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -16,7 +16,13 @@ import {
   DEFAULT_SETTINGS,
 } from "./domain/settings/ExocortexSettings";
 import { ExocortexSettingTab } from "./presentation/settings/ExocortexSettingTab";
-import { TaskStatusService } from "exocortex";
+import {
+  TaskStatusService,
+  CommandResolver,
+  PreconditionEvaluator,
+  GroundingExecutor,
+  ServiceRegistry,
+} from "exocortex";
 import { ObsidianVaultAdapter } from "./adapters/ObsidianVaultAdapter";
 import { TaskTrackingService } from "./application/services/TaskTrackingService";
 import { AliasSyncService } from "./application/services/AliasSyncService";
@@ -35,6 +41,7 @@ import { PropertiesUidCopyPatch } from "./presentation/properties/PropertiesUidC
 import { BodyLinkPatch } from "./presentation/body/BodyLinkPatch";
 import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
 import { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService";
+import { ObsidianFileSystemAdapter } from "./adapters/ObsidianFileSystemAdapter";
 
 /**
  * Exocortex Plugin - Automatic layout rendering
@@ -63,6 +70,10 @@ export default class ExocortexPlugin extends Plugin {
   api!: ExocortexAPI;
   settings!: ExocortexSettings;
   printNameRuleService!: PrintNameRuleService;
+  commandResolver!: CommandResolver;
+  preconditionEvaluator!: PreconditionEvaluator;
+  groundingExecutor!: GroundingExecutor;
+  serviceRegistry!: ServiceRegistry;
   private timerManager!: TimerManager;
   // MutationObserver to detect when layout is removed by Obsidian re-renders (e.g., when processing embeds)
   private layoutPersistenceObserver: MutationObserver | null = null;
@@ -127,6 +138,15 @@ export default class ExocortexPlugin extends Plugin {
       this.layoutProcessor = new LayoutCodeBlockProcessor(this);
       this.sparql = new SPARQLApi(this);
       this.api = new ExocortexAPI(this);
+
+      // RFC-009: Wire Dynamic Command System services
+      // Construct manually (not via tsyringe) because they need the live triple store
+      const tripleStore = this.sparql.getTripleStore();
+      this.commandResolver = new CommandResolver(tripleStore);
+      this.preconditionEvaluator = new PreconditionEvaluator(tripleStore);
+      this.serviceRegistry = new ServiceRegistry();
+      const obsidianFs = new ObsidianFileSystemAdapter(this.app.vault);
+      this.groundingExecutor = new GroundingExecutor(obsidianFs, obsidianFs, this.serviceRegistry);
 
       // Register the alias icon editor extension for Live Preview mode
       this.registerEditorExtension(

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -1499,4 +1499,49 @@ describe("ExocortexPlugin", () => {
       );
     });
   });
+
+  describe("RFC-009 service wiring", () => {
+    it("should construct CommandResolver with tripleStore after onload", async () => {
+      // Act
+      await plugin.onload();
+
+      // Assert
+      expect(plugin.commandResolver).toBeDefined();
+    });
+
+    it("should construct PreconditionEvaluator with tripleStore after onload", async () => {
+      // Act
+      await plugin.onload();
+
+      // Assert
+      expect(plugin.preconditionEvaluator).toBeDefined();
+    });
+
+    it("should construct GroundingExecutor with ObsidianFileSystemAdapter and ServiceRegistry after onload", async () => {
+      // Act
+      await plugin.onload();
+
+      // Assert
+      expect(plugin.groundingExecutor).toBeDefined();
+    });
+
+    it("should create ServiceRegistry instance after onload", async () => {
+      // Act
+      await plugin.onload();
+
+      // Assert
+      expect(plugin.serviceRegistry).toBeDefined();
+    });
+
+    it("should make all three RFC-009 services accessible from plugin instance", async () => {
+      // Act
+      await plugin.onload();
+
+      // Assert
+      expect(plugin.commandResolver).toBeDefined();
+      expect(plugin.preconditionEvaluator).toBeDefined();
+      expect(plugin.groundingExecutor).toBeDefined();
+      expect(plugin.serviceRegistry).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Wire RFC-009 Dynamic Command System services into `ExocortexPlugin.onload()`
- Manually construct `CommandResolver`, `PreconditionEvaluator`, `GroundingExecutor`, and `ServiceRegistry` after `this.sparql` is created (triple store available)
- All four services are accessible as public fields on the plugin instance

## Changes
- `ExocortexPlugin.ts`: Add imports for RFC-009 services + `ObsidianFileSystemAdapter`, declare public fields, construct after `SPARQLApi` initialization
- `ExocortexPlugin.test.ts`: Add 5 tests verifying all RFC-009 services are constructed and accessible after `onload()`

## Testing
- [x] 5 new unit tests for RFC-009 service wiring
- [x] All 62 ExocortexPlugin tests pass
- [x] All 4627 plugin tests pass (218 suites)
- [x] All 6688 core tests pass (207 suites)
- [x] TypeScript compilation clean (`tsc --noEmit --skipLibCheck`)
- [x] ESLint clean (zero warnings)
- [x] BDD coverage 100% (222/222)
- [x] Archgate 13/13 ADR rules pass

## Acceptance Criteria
- [x] `CommandResolver` constructed with `tripleStore` from `SPARQLApi`
- [x] `PreconditionEvaluator` constructed with same `tripleStore`
- [x] `GroundingExecutor` constructed with `ObsidianFileSystemAdapter` + `ServiceRegistry`
- [x] `ServiceRegistry` instance created (initially empty)
- [x] All three services accessible from plugin instance

Fixes #2492