### PR TITLE
feat(plugin): pass RFC-009 services to UniversalLayoutRenderer (#2493)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -115,6 +115,7 @@ export default class ExocortexPlugin extends Plugin {
         this.settings,
         this,
         this.vaultAdapter,
+        this.resolveRfc009Services(),
       );
       this.taskStatusService = container.resolve(TaskStatusService);
       this.taskTrackingService = new TaskTrackingService(
@@ -817,6 +818,18 @@ export default class ExocortexPlugin extends Plugin {
         `Failed to handle metadata change for ${file.path}`,
         error as Error,
       );
+    }
+  }
+
+  private resolveRfc009Services() {
+    try {
+      return {
+        commandResolver: container.resolve(CommandResolver),
+        preconditionEvaluator: container.resolve(PreconditionEvaluator),
+        groundingExecutor: container.resolve(GroundingExecutor),
+      };
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -11,6 +11,7 @@ import { ProjectCreationService, AreaCreationService, ClassCreationService } fro
 import { ConceptCreationService, TaskStatusService, PropertyCleanupService } from "exocortex";
 import { FolderRepairService, RenameToUidService, EffortVotingService } from "exocortex";
 import { LabelToAliasService, AssetConversionService, CriticalityZoneService } from "exocortex";
+import { CommandResolver, PreconditionEvaluator, GroundingExecutor } from "exocortex";
 import { BacklinksCacheManager } from '@plugin/adapters/caching/BacklinksCacheManager';
 import { EventListenerManager } from '@plugin/adapters/events/EventListenerManager';
 import { ButtonGroupsBuilder } from '@plugin/presentation/builders/ButtonGroupsBuilder';
@@ -58,6 +59,10 @@ export class UniversalLayoutRenderer {
   private dailyNavRenderer: DailyNavigationRenderer;
   private incrementalUpdateHandler!: IncrementalUpdateHandler;
 
+  private commandResolver?: CommandResolver;
+  private preconditionEvaluator?: PreconditionEvaluator;
+  private groundingExecutor?: GroundingExecutor;
+
   private dependencyResolver: PropertyDependencyResolver;
   private deltaDetector: FrontmatterDeltaDetector;
   // Use LRU cache with max 500 entries and 5-minute TTL to prevent unbounded growth
@@ -70,11 +75,24 @@ export class UniversalLayoutRenderer {
   private currentFilePath: string | null = null;
   private currentConfig: UniversalLayoutConfig = {};
 
-  constructor(app: ObsidianApp, settings: ExocortexSettings, plugin: ExocortexPluginInterface, vaultAdapter: IVaultAdapter) {
+  constructor(
+    app: ObsidianApp,
+    settings: ExocortexSettings,
+    plugin: ExocortexPluginInterface,
+    vaultAdapter: IVaultAdapter,
+    rfc009Services?: {
+      commandResolver?: CommandResolver;
+      preconditionEvaluator?: PreconditionEvaluator;
+      groundingExecutor?: GroundingExecutor;
+    },
+  ) {
     this.app = app;
     this.settings = settings;
     this.plugin = plugin;
     this.vaultAdapter = vaultAdapter;
+    this.commandResolver = rfc009Services?.commandResolver;
+    this.preconditionEvaluator = rfc009Services?.preconditionEvaluator;
+    this.groundingExecutor = rfc009Services?.groundingExecutor;
     this.logger = LoggerFactory.create("UniversalLayoutRenderer");
 
     // Create ReactRenderer with ErrorBoundary enabled for graceful error handling.
@@ -135,6 +153,9 @@ export class UniversalLayoutRenderer {
       labelToAliasService: services.labelToAlias,
       assetConversionService: services.assetConversion,
       criticalityZoneService: services.criticalityZone,
+      commandResolver: this.commandResolver,
+      preconditionEvaluator: this.preconditionEvaluator,
+      groundingExecutor: this.groundingExecutor,
       tripleStore,
       metadataExtractor: this.metadataExtractor,
       logger: this.logger,

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -191,7 +191,11 @@ describe("ExocortexPlugin", () => {
       expect(mockLogger.info).toHaveBeenCalledWith("Loading Exocortex Plugin");
       expect(plugin.loadData).toHaveBeenCalled();
       expect(ObsidianVaultAdapter).toHaveBeenCalledWith(mockVault, mockMetadataCache, mockApp);
-      expect(UniversalLayoutRenderer).toHaveBeenCalledWith(mockApp, plugin.settings, plugin, plugin.vaultAdapter);
+      const rendererCall = (UniversalLayoutRenderer as jest.Mock).mock.calls[0];
+      expect(rendererCall[0]).toBe(mockApp);
+      expect(rendererCall[1]).toEqual(plugin.settings);
+      expect(rendererCall[2]).toBe(plugin);
+      expect(rendererCall[3]).toBe(plugin.vaultAdapter);
       // TaskStatusService is now resolved from DI container, not instantiated directly
       expect(TaskTrackingService).toHaveBeenCalledWith(mockApp, mockVault, mockMetadataCache);
       expect(SPARQLCodeBlockProcessor).toHaveBeenCalledWith(plugin);

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.dynamicCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.dynamicCommands.test.ts
@@ -1,0 +1,153 @@
+import {
+  ButtonGroupsBuilder,
+  ButtonGroupsBuilderConfig,
+} from "../../../../src/presentation/builders/ButtonGroupsBuilder";
+import { TFile } from "obsidian";
+import { ExocortexSettings } from "../../../../src/domain/settings/ExocortexSettings";
+import {
+  TaskCreationService,
+  ProjectCreationService,
+  AreaCreationService,
+  ClassCreationService,
+  ConceptCreationService,
+  TaskStatusService,
+  PropertyCleanupService,
+  FolderRepairService,
+  RenameToUidService,
+  EffortVotingService,
+  LabelToAliasService,
+  AssetConversionService,
+  MetadataExtractor,
+  CriticalityZoneService,
+  CommandResolver,
+  PreconditionEvaluator,
+  GroundingExecutor,
+} from "exocortex";
+import { ILogger } from "../../../../src/infrastructure/logging/ILogger";
+
+function createMinimalConfig(
+  overrides?: Partial<ButtonGroupsBuilderConfig>,
+): ButtonGroupsBuilderConfig {
+  const mockApp = {
+    workspace: { getLeaf: jest.fn().mockReturnValue({ openFile: jest.fn() }) },
+    vault: { read: jest.fn().mockResolvedValue("---\n---\n") },
+  } as any;
+
+  return {
+    app: mockApp,
+    settings: {} as ExocortexSettings,
+    plugin: { saveSettings: jest.fn() } as any,
+    taskCreationService: { createTask: jest.fn() } as any,
+    projectCreationService: { createProject: jest.fn() } as any,
+    areaCreationService: { createChildArea: jest.fn() } as any,
+    classCreationService: { createSubclass: jest.fn() } as any,
+    conceptCreationService: { createNarrowerConcept: jest.fn() } as any,
+    taskStatusService: {} as any,
+    propertyCleanupService: { cleanEmptyProperties: jest.fn() } as any,
+    folderRepairService: { getExpectedFolder: jest.fn(), repairFolder: jest.fn() } as any,
+    renameToUidService: { renameToUid: jest.fn() } as any,
+    effortVotingService: { incrementEffortVotes: jest.fn() } as any,
+    labelToAliasService: { copyLabelToAliases: jest.fn() } as any,
+    assetConversionService: { convertTaskToProject: jest.fn() } as any,
+    criticalityZoneService: { setZoneToday: jest.fn() } as any,
+    metadataExtractor: {
+      extractMetadata: jest.fn(),
+      extractInstanceClass: jest.fn(),
+      extractStatus: jest.fn(),
+      extractIsArchived: jest.fn(),
+    } as any,
+    logger: { info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() } as any,
+    refresh: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ButtonGroupsBuilder - dynamic commands (RFC-009)", () => {
+  it("should NOT include dynamic-commands builder when services are omitted", async () => {
+    const config = createMinimalConfig();
+    const builder = new ButtonGroupsBuilder(config);
+
+    const mockFile = { path: "test.md", parent: { path: "folder" }, basename: "test" } as TFile;
+    config.metadataExtractor.extractMetadata = jest.fn().mockReturnValue({
+      exo__Instance_class: "[[ems__Task]]",
+    });
+    config.metadataExtractor.extractInstanceClass = jest.fn().mockReturnValue("[[ems__Task]]");
+    config.metadataExtractor.extractStatus = jest.fn().mockReturnValue(null);
+    config.metadataExtractor.extractIsArchived = jest.fn().mockReturnValue(false);
+    (config.folderRepairService.getExpectedFolder as jest.Mock).mockResolvedValue(null);
+
+    const groups = await builder.build(mockFile);
+    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    expect(dynamicGroup).toBeUndefined();
+  });
+
+  it("should include dynamic-commands builder when RFC-009 services are provided", async () => {
+    const mockCommandResolver = {
+      resolveForAsset: jest.fn().mockResolvedValue([
+        {
+          command: {
+            commandIRI: "urn:cmd:test",
+            label: "Test Command",
+            precondition: { type: "always_true" },
+            grounding: { type: "set_frontmatter_value", property: "status", value: "done" },
+          },
+          binding: {
+            order: 0,
+            group: "default",
+          },
+        },
+      ]),
+    };
+
+    const mockPreconditionEvaluator = {
+      evaluate: jest.fn().mockResolvedValue(true),
+    };
+
+    const mockGroundingExecutor = {
+      execute: jest.fn().mockResolvedValue({ success: true }),
+    };
+
+    const config = createMinimalConfig({
+      commandResolver: mockCommandResolver as unknown as CommandResolver,
+      preconditionEvaluator: mockPreconditionEvaluator as unknown as PreconditionEvaluator,
+      groundingExecutor: mockGroundingExecutor as unknown as GroundingExecutor,
+    });
+
+    const builder = new ButtonGroupsBuilder(config);
+
+    const mockFile = { path: "test.md", parent: { path: "folder" }, basename: "test" } as TFile;
+    config.metadataExtractor.extractMetadata = jest.fn().mockReturnValue({
+      exo__Instance_class: "[[ems__Task]]",
+      exo__Asset_uid: "urn:uuid:12345",
+    });
+    config.metadataExtractor.extractInstanceClass = jest.fn().mockReturnValue("[[ems__Task]]");
+    config.metadataExtractor.extractStatus = jest.fn().mockReturnValue(null);
+    config.metadataExtractor.extractIsArchived = jest.fn().mockReturnValue(false);
+    (config.folderRepairService.getExpectedFolder as jest.Mock).mockResolvedValue(null);
+
+    const groups = await builder.build(mockFile);
+    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    expect(dynamicGroup).toBeDefined();
+    expect(dynamicGroup!.title).toBe("Commands");
+  });
+
+  it("should NOT include dynamic-commands builder when only partial services provided", async () => {
+    const config = createMinimalConfig({
+      commandResolver: { resolveForAsset: jest.fn() } as unknown as CommandResolver,
+    });
+    const builder = new ButtonGroupsBuilder(config);
+
+    const mockFile = { path: "test.md", parent: { path: "folder" }, basename: "test" } as TFile;
+    config.metadataExtractor.extractMetadata = jest.fn().mockReturnValue({
+      exo__Instance_class: "[[ems__Task]]",
+    });
+    config.metadataExtractor.extractInstanceClass = jest.fn().mockReturnValue("[[ems__Task]]");
+    config.metadataExtractor.extractStatus = jest.fn().mockReturnValue(null);
+    config.metadataExtractor.extractIsArchived = jest.fn().mockReturnValue(false);
+    (config.folderRepairService.getExpectedFolder as jest.Mock).mockResolvedValue(null);
+
+    const groups = await builder.build(mockFile);
+    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    expect(dynamicGroup).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Thread `CommandResolver`, `PreconditionEvaluator`, and `GroundingExecutor` from `ExocortexPlugin` through `UniversalLayoutRenderer` to `ButtonGroupsBuilder`
- `DynamicCommandButtonGroupBuilder` is now activated when all three RFC-009 services are available in the DI container
- Graceful degradation: if services cannot be resolved (e.g., missing DI registrations), the renderer works as before without dynamic commands

## Changes
- `UniversalLayoutRenderer` constructor accepts optional `rfc009Services` parameter
- Services are stored and threaded to `ButtonGroupsBuilder` config in `initializeRenderers()`
- `ExocortexPlugin.resolveRfc009Services()` resolves the three services from DI container with try/catch fallback
- Updated `ExocortexPlugin.test.ts` assertion to account for the new constructor argument
- Added `ButtonGroupsBuilder.dynamicCommands.test.ts` with 3 tests verifying builder inclusion/exclusion

## Testing
- [x] TypeScript type check passes (`tsc --noEmit --skipLibCheck`)
- [x] All unit tests pass (4624 plugin + 1167 CLI + all core)
- [x] BDD coverage 100%
- [x] Archgate compliance passes (13/13 rules)
- [x] New test: dynamic-commands builder included when all 3 services provided
- [x] New test: dynamic-commands builder excluded when services omitted
- [x] New test: dynamic-commands builder excluded when only partial services provided

## Acceptance Criteria
- [x] `UniversalLayoutRenderer` constructor accepts optional RFC-009 services
- [x] Services threaded through to `ButtonGroupsBuilder` config in `initializeRenderers()`
- [x] `DynamicCommandButtonGroupBuilder` appears in `this.builders` when services provided
- [x] Unit test: builder list includes dynamic builder when services injected

Fixes #2493