### PR TITLE
feat(core): implement NonInheritablePropertyRegistry (#2500)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -213,6 +213,7 @@ export { NullLogger } from "./infrastructure/NullLogger";
 export { InMemoryTripleStore } from "./infrastructure/rdf/InMemoryTripleStore";
 export { RDFVocabularyMapper } from "./infrastructure/rdf/RDFVocabularyMapper";
 export { RDFSInferenceEngine } from "./infrastructure/rdf/RDFSInferenceEngine";
+export { NonInheritablePropertyRegistry } from "./services/NonInheritablePropertyRegistry";
 export { NoteToRDFConverter } from "./services/NoteToRDFConverter";
 
 // SPARQL Engine exports

--- a/packages/exocortex/src/services/NonInheritablePropertyRegistry.ts
+++ b/packages/exocortex/src/services/NonInheritablePropertyRegistry.ts
@@ -1,0 +1,191 @@
+import { ITripleStore } from "../interfaces/ITripleStore";
+import { IRI } from "../domain/models/rdf/IRI";
+import { Literal } from "../domain/models/rdf/Literal";
+import { Namespace } from "../domain/models/rdf/Namespace";
+
+/**
+ * Registry of properties that must NOT be inherited through prototype chain resolution.
+ *
+ * Loads the set from the triple store by querying for properties marked with
+ * exo__NonInheritableProperty class, then provides O(1) lookup by predicate IRI.
+ *
+ * Used by PrototypeChainMaterializer to skip excluded properties during inheritance.
+ */
+export class NonInheritablePropertyRegistry {
+  private readonly nonInheritableIRIs: Set<string> = new Set();
+  private initialized = false;
+
+  /**
+   * Load non-inheritable property set from triple store.
+   *
+   * Queries for: ?property exo:Instance_class exo:NonInheritableProperty
+   * Then maps each property's Asset_label to its predicate IRI.
+   *
+   * Safe default: if query fails or returns no results, all properties are inheritable.
+   */
+  async initialize(store: ITripleStore): Promise<void> {
+    this.nonInheritableIRIs.clear();
+
+    try {
+      const allPredicates = await store.predicates();
+
+      const instanceClassPredicate = allPredicates.find((p) =>
+        p.value.includes("Instance_class"),
+      );
+
+      if (!instanceClassPredicate) {
+        this.initialized = true;
+        return;
+      }
+
+      // Find the NonInheritableProperty class IRI in the store
+      const nonInheritableClassIRI = await this.findNonInheritableClassIRI(
+        store,
+        allPredicates,
+      );
+
+      if (!nonInheritableClassIRI) {
+        this.initialized = true;
+        return;
+      }
+
+      // Find all properties marked as NonInheritableProperty
+      const markedProperties = await store.match(
+        undefined,
+        instanceClassPredicate,
+        nonInheritableClassIRI,
+      );
+
+      if (markedProperties.length === 0) {
+        this.initialized = true;
+        return;
+      }
+
+      // For each marked property, get its Asset_label and convert to predicate IRI
+      const labelPredicate = allPredicates.find((p) =>
+        p.value.includes("Asset_label"),
+      );
+
+      if (!labelPredicate) {
+        this.initialized = true;
+        return;
+      }
+
+      for (const triple of markedProperties) {
+        const labelTriples = await store.match(
+          triple.subject,
+          labelPredicate,
+          undefined,
+        );
+
+        for (const labelTriple of labelTriples) {
+          if (labelTriple.object instanceof Literal) {
+            const propertyKey = labelTriple.object.value;
+            const predicateIRI = this.propertyKeyToIRI(propertyKey);
+            if (predicateIRI) {
+              this.nonInheritableIRIs.add(predicateIRI);
+            }
+          }
+        }
+      }
+    } catch {
+      // Safe default: empty set = all properties inheritable
+    }
+
+    this.initialized = true;
+  }
+
+  /**
+   * Check if a property predicate IRI is non-inheritable.
+   * Returns false (safe default) if not initialized or property not found.
+   */
+  isNonInheritable(propertyIRI: string): boolean {
+    return this.nonInheritableIRIs.has(propertyIRI);
+  }
+
+  /**
+   * Get the count of registered non-inheritable properties.
+   */
+  get size(): number {
+    return this.nonInheritableIRIs.size;
+  }
+
+  /**
+   * Check if the registry has been initialized.
+   */
+  get isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
+   * Find the IRI used for exo__NonInheritableProperty class in the store.
+   * Uses Asset_label matching since the class IRI varies by vault path.
+   */
+  private async findNonInheritableClassIRI(
+    store: ITripleStore,
+    allPredicates: IRI[],
+  ): Promise<IRI | null> {
+    const labelPredicate = allPredicates.find((p) =>
+      p.value.includes("Asset_label"),
+    );
+
+    if (!labelPredicate) {
+      return null;
+    }
+
+    // Search for assets labeled "exo__NonInheritableProperty"
+    const labelTriples = await store.match(
+      undefined,
+      labelPredicate,
+      new Literal("exo__NonInheritableProperty"),
+    );
+
+    if (labelTriples.length > 0 && labelTriples[0].subject instanceof IRI) {
+      return labelTriples[0].subject as IRI;
+    }
+
+    // Fallback: look for IRI containing "NonInheritableProperty"
+    const instanceClassPredicate = allPredicates.find((p) =>
+      p.value.includes("Instance_class"),
+    );
+
+    if (instanceClassPredicate) {
+      const allClassTriples = await store.match(
+        undefined,
+        instanceClassPredicate,
+        undefined,
+      );
+
+      for (const t of allClassTriples) {
+        if (
+          t.object instanceof IRI &&
+          t.object.value.includes("NonInheritableProperty")
+        ) {
+          return t.object as IRI;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Convert a property key (e.g. "ems__Effort_startTimestamp") to its predicate IRI.
+   * Follows the same convention as NoteToRDFConverter.propertyKeyToIRI().
+   */
+  private propertyKeyToIRI(key: string): string | null {
+    if (key.startsWith("exo__")) {
+      return Namespace.EXO.term(key.substring(5)).value;
+    }
+
+    if (key.startsWith("ems__")) {
+      return Namespace.EMS.term(key.substring(5)).value;
+    }
+
+    if (key.startsWith("exocmd__")) {
+      return Namespace.EXOCMD.term(key.substring(8)).value;
+    }
+
+    return null;
+  }
+}

--- a/packages/exocortex/tests/unit/services/NonInheritablePropertyRegistry.test.ts
+++ b/packages/exocortex/tests/unit/services/NonInheritablePropertyRegistry.test.ts
@@ -1,0 +1,366 @@
+import { NonInheritablePropertyRegistry } from "../../../src/services/NonInheritablePropertyRegistry";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+describe("NonInheritablePropertyRegistry", () => {
+  let registry: NonInheritablePropertyRegistry;
+  let store: InMemoryTripleStore;
+
+  // Predicates
+  const instanceClass = new IRI(
+    "https://exocortex.my/ontology/exo#Instance_class",
+  );
+  const assetLabel = new IRI(
+    "https://exocortex.my/ontology/exo#Asset_label",
+  );
+
+  // NonInheritableProperty class (as it appears in vault — obsidian IRI)
+  const nonInheritableClassIRI = new IRI(
+    "obsidian://vault/03%20Knowledge/exo/exo__NonInheritableProperty.md",
+  );
+
+  // Property definition subjects (vault file IRIs)
+  const startTimestampDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_startTimestamp.md",
+  );
+  const endTimestampDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_endTimestamp.md",
+  );
+  const plannedStartDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_plannedStartTimestamp.md",
+  );
+  const plannedEndDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_plannedEndTimestamp.md",
+  );
+  const prototypeDef = new IRI(
+    "obsidian://vault/03%20Knowledge/exo/exo__Asset_prototype.md",
+  );
+  const uidDef = new IRI(
+    "obsidian://vault/03%20Knowledge/exo/exo__Asset_uid.md",
+  );
+  const labelDef = new IRI(
+    "obsidian://vault/03%20Knowledge/exo/exo__Asset_label.md",
+  );
+  const statusDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_status.md",
+  );
+  const resultDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_result.md",
+  );
+  const blockedByDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_blockedBy.md",
+  );
+  const scheduledDateDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_scheduledDate.md",
+  );
+  const dueDateDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_dueDate.md",
+  );
+
+  // Inheritable property (not marked)
+  const areaDef = new IRI(
+    "obsidian://vault/03%20Knowledge/ems/ems__Effort_area.md",
+  );
+
+  const ALL_NONINHERITABLE_DEFS = [
+    { def: startTimestampDef, label: "ems__Effort_startTimestamp" },
+    { def: endTimestampDef, label: "ems__Effort_endTimestamp" },
+    { def: plannedStartDef, label: "ems__Effort_plannedStartTimestamp" },
+    { def: plannedEndDef, label: "ems__Effort_plannedEndTimestamp" },
+    { def: prototypeDef, label: "exo__Asset_prototype" },
+    { def: uidDef, label: "exo__Asset_uid" },
+    { def: labelDef, label: "exo__Asset_label" },
+    { def: statusDef, label: "ems__Effort_status" },
+    { def: resultDef, label: "ems__Effort_result" },
+    { def: blockedByDef, label: "ems__Effort_blockedBy" },
+    { def: scheduledDateDef, label: "ems__Effort_scheduledDate" },
+    { def: dueDateDef, label: "ems__Effort_dueDate" },
+  ];
+
+  async function populateStoreWith12Properties(): Promise<void> {
+    // Add NonInheritableProperty class label
+    await store.add(
+      new Triple(
+        nonInheritableClassIRI,
+        assetLabel,
+        new Literal("exo__NonInheritableProperty"),
+      ),
+    );
+
+    // Mark all 12 properties
+    for (const { def, label } of ALL_NONINHERITABLE_DEFS) {
+      await store.add(
+        new Triple(def, instanceClass, nonInheritableClassIRI),
+      );
+      await store.add(
+        new Triple(def, assetLabel, new Literal(label)),
+      );
+    }
+
+    // Add an inheritable property (not marked as NonInheritableProperty)
+    await store.add(
+      new Triple(areaDef, assetLabel, new Literal("ems__Effort_area")),
+    );
+  }
+
+  beforeEach(() => {
+    registry = new NonInheritablePropertyRegistry();
+    store = new InMemoryTripleStore();
+  });
+
+  describe("initialize", () => {
+    it("should handle empty store gracefully", async () => {
+      await registry.initialize(store);
+
+      expect(registry.isInitialized).toBe(true);
+      expect(registry.size).toBe(0);
+    });
+
+    it("should load all 12 non-inheritable properties", async () => {
+      await populateStoreWith12Properties();
+
+      await registry.initialize(store);
+
+      expect(registry.isInitialized).toBe(true);
+      expect(registry.size).toBe(12);
+    });
+
+    it("should handle store without Instance_class predicate", async () => {
+      await store.add(
+        new Triple(
+          new IRI("http://example.com/something"),
+          assetLabel,
+          new Literal("test"),
+        ),
+      );
+
+      await registry.initialize(store);
+
+      expect(registry.isInitialized).toBe(true);
+      expect(registry.size).toBe(0);
+    });
+
+    it("should handle store without NonInheritableProperty class", async () => {
+      // Add Instance_class triples but without NonInheritableProperty
+      await store.add(
+        new Triple(
+          startTimestampDef,
+          instanceClass,
+          new IRI("https://exocortex.my/ontology/exo#TimestampProperty"),
+        ),
+      );
+
+      await registry.initialize(store);
+
+      expect(registry.isInitialized).toBe(true);
+      expect(registry.size).toBe(0);
+    });
+
+    it("should clear previous state on re-initialize", async () => {
+      await populateStoreWith12Properties();
+      await registry.initialize(store);
+      expect(registry.size).toBe(12);
+
+      // Re-initialize with empty store
+      const emptyStore = new InMemoryTripleStore();
+      await registry.initialize(emptyStore);
+
+      expect(registry.size).toBe(0);
+    });
+  });
+
+  describe("isNonInheritable", () => {
+    beforeEach(async () => {
+      await populateStoreWith12Properties();
+      await registry.initialize(store);
+    });
+
+    it("should return true for all 12 marked properties", () => {
+      // EMS properties
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_startTimestamp").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_endTimestamp").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_plannedStartTimestamp").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_plannedEndTimestamp").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_status").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_result").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_blockedBy").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_scheduledDate").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_dueDate").value,
+        ),
+      ).toBe(true);
+
+      // EXO properties
+      expect(
+        registry.isNonInheritable(
+          Namespace.EXO.term("Asset_prototype").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EXO.term("Asset_uid").value,
+        ),
+      ).toBe(true);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EXO.term("Asset_label").value,
+        ),
+      ).toBe(true);
+    });
+
+    it("should return false for unmarked properties", () => {
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_area").value,
+        ),
+      ).toBe(false);
+
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_timeEstimateMinutes").value,
+        ),
+      ).toBe(false);
+
+      expect(
+        registry.isNonInheritable(
+          Namespace.EXO.term("Asset_description").value,
+        ),
+      ).toBe(false);
+    });
+
+    it("should return false before initialization", () => {
+      const uninitializedRegistry = new NonInheritablePropertyRegistry();
+
+      expect(
+        uninitializedRegistry.isNonInheritable(
+          Namespace.EMS.term("Effort_startTimestamp").value,
+        ),
+      ).toBe(false);
+    });
+
+    it("should return false for unknown IRI strings", () => {
+      expect(
+        registry.isNonInheritable("http://completely/unknown/property"),
+      ).toBe(false);
+
+      expect(registry.isNonInheritable("")).toBe(false);
+    });
+  });
+
+  describe("fallback IRI detection", () => {
+    it("should find NonInheritableProperty by IRI pattern when label not found", async () => {
+      // Setup: NonInheritableProperty class referenced by IRI containing the name
+      // (no Asset_label triple for the class itself)
+      const niClassByIRI = new IRI(
+        "https://exocortex.my/ontology/exo#NonInheritableProperty",
+      );
+
+      await store.add(
+        new Triple(startTimestampDef, instanceClass, niClassByIRI),
+      );
+      await store.add(
+        new Triple(
+          startTimestampDef,
+          assetLabel,
+          new Literal("ems__Effort_startTimestamp"),
+        ),
+      );
+
+      await registry.initialize(store);
+
+      expect(registry.size).toBe(1);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EMS.term("Effort_startTimestamp").value,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should skip properties with non-Exocortex labels", async () => {
+      await store.add(
+        new Triple(
+          nonInheritableClassIRI,
+          assetLabel,
+          new Literal("exo__NonInheritableProperty"),
+        ),
+      );
+
+      const unknownDef = new IRI("obsidian://vault/unknown.md");
+      await store.add(
+        new Triple(unknownDef, instanceClass, nonInheritableClassIRI),
+      );
+      await store.add(
+        new Triple(unknownDef, assetLabel, new Literal("someUnknownPrefix__Prop")),
+      );
+
+      await registry.initialize(store);
+
+      expect(registry.size).toBe(0);
+    });
+
+    it("should handle exocmd__ namespace properties", async () => {
+      await store.add(
+        new Triple(
+          nonInheritableClassIRI,
+          assetLabel,
+          new Literal("exo__NonInheritableProperty"),
+        ),
+      );
+
+      const exocmdDef = new IRI("obsidian://vault/exocmd_prop.md");
+      await store.add(
+        new Triple(exocmdDef, instanceClass, nonInheritableClassIRI),
+      );
+      await store.add(
+        new Triple(exocmdDef, assetLabel, new Literal("exocmd__Grounding_type")),
+      );
+
+      await registry.initialize(store);
+
+      expect(registry.size).toBe(1);
+      expect(
+        registry.isNonInheritable(
+          Namespace.EXOCMD.term("Grounding_type").value,
+        ),
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `NonInheritablePropertyRegistry` in `packages/exocortex/src/services/`
- Loads non-inheritable property markers from triple store via `exo:Instance_class = exo:NonInheritableProperty`
- Converts `Asset_label` → predicate IRI using same convention as `NoteToRDFConverter.propertyKeyToIRI()`
- O(1) lookup via `Set<string>` for `PrototypeChainMaterializer` (#2501)
- Safe default: returns false if SPARQL fails or no properties found
- Exported from `@exocortex/core` index

## Test plan
- [x] 12 unit tests covering all acceptance criteria
- [x] TypeScript check: zero errors
- [x] Pre-commit hooks: lint, BDD 100%, archgate pass

Closes #2500