### PR TITLE
feat(core): implement PrototypeChainMaterializer (#2501)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -214,6 +214,7 @@ export { InMemoryTripleStore } from "./infrastructure/rdf/InMemoryTripleStore";
 export { RDFVocabularyMapper } from "./infrastructure/rdf/RDFVocabularyMapper";
 export { RDFSInferenceEngine } from "./infrastructure/rdf/RDFSInferenceEngine";
 export { NonInheritablePropertyRegistry } from "./services/NonInheritablePropertyRegistry";
+export { PrototypeChainMaterializer, INFERRED_GRAPH } from "./services/PrototypeChainMaterializer";
 export { NoteToRDFConverter } from "./services/NoteToRDFConverter";
 
 // SPARQL Engine exports

--- a/packages/exocortex/src/services/PrototypeChainMaterializer.ts
+++ b/packages/exocortex/src/services/PrototypeChainMaterializer.ts
@@ -1,0 +1,135 @@
+import { ITripleStore } from "../interfaces/ITripleStore";
+import { Triple, type Subject } from "../domain/models/rdf/Triple";
+import { IRI } from "../domain/models/rdf/IRI";
+import { NonInheritablePropertyRegistry } from "./NonInheritablePropertyRegistry";
+
+/**
+ * Named graph IRI for materialized (inherited) triples.
+ * Used to distinguish own vs inherited properties in Phase 6 (ExoQL OWN()).
+ */
+export const INFERRED_GRAPH = new IRI("https://exocortex.my/ontology/exo#inferred");
+
+/**
+ * Single-hop prototype chain materializer.
+ *
+ * For each instance with an exo__Asset_prototype link, copies all inheritable
+ * properties from the prototype that the instance doesn't already own.
+ *
+ * Materialized triples are added to both the default graph (for match() visibility)
+ * and the `exo:inferred` named graph (for own/inherited distinction).
+ *
+ * Follows the RDFSInferenceEngine pattern: post-index pass over the triple store.
+ */
+export class PrototypeChainMaterializer {
+  private readonly registry: NonInheritablePropertyRegistry;
+
+  constructor(registry: NonInheritablePropertyRegistry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Materialize inherited properties from prototypes into instances.
+   *
+   * @param store - The triple store to read from and write materialized triples into
+   * @returns Number of new materialized triples added
+   */
+  async materialize(store: ITripleStore): Promise<number> {
+    const allPredicates = await store.predicates();
+
+    // Find the prototype predicate (exo:Asset_prototype)
+    const prototypePredicate = allPredicates.find((p) =>
+      p.value.includes("Asset_prototype"),
+    );
+
+    if (!prototypePredicate) {
+      return 0;
+    }
+
+    // Find all instance → prototype links
+    const prototypeTriples = await store.match(
+      undefined,
+      prototypePredicate,
+      undefined,
+    );
+
+    if (prototypeTriples.length === 0) {
+      return 0;
+    }
+
+    // Build map: instance → prototype (single-hop only)
+    // Cycle detection: skip if instance equals prototype
+    const instanceToPrototype = new Map<string, { instance: Subject; prototype: Subject }>();
+    for (const triple of prototypeTriples) {
+      if (triple.subject instanceof IRI && triple.object instanceof IRI) {
+        const instanceIRI = triple.subject.value;
+        const prototypeIRI = triple.object.value;
+
+        // Cycle detection
+        if (instanceIRI === prototypeIRI) {
+          continue;
+        }
+
+        instanceToPrototype.set(instanceIRI, {
+          instance: triple.subject,
+          prototype: triple.object as IRI,
+        });
+      }
+    }
+
+    if (instanceToPrototype.size === 0) {
+      return 0;
+    }
+
+    let materializedCount = 0;
+
+    for (const { instance, prototype } of instanceToPrototype.values()) {
+      // Get all triples of the prototype
+      const prototypeTriples = await store.match(prototype, undefined, undefined);
+
+      if (prototypeTriples.length === 0) {
+        continue;
+      }
+
+      // Get predicates the instance already owns
+      const ownTriples = await store.match(instance, undefined, undefined);
+      const ownPredicates = new Set<string>();
+      for (const t of ownTriples) {
+        ownPredicates.add(t.predicate.value);
+      }
+
+      // Materialize inheritable properties
+      for (const protoTriple of prototypeTriples) {
+        const predicateIRI = protoTriple.predicate.value;
+
+        // Skip non-inheritable properties
+        if (this.registry.isNonInheritable(predicateIRI)) {
+          continue;
+        }
+
+        // Skip if instance already has this property (own takes priority)
+        if (ownPredicates.has(predicateIRI)) {
+          continue;
+        }
+
+        // Materialize: create triple with instance as subject
+        const materializedTriple = new Triple(
+          instance,
+          protoTriple.predicate,
+          protoTriple.object,
+        );
+
+        // Add to default graph (for match() visibility)
+        await store.add(materializedTriple);
+
+        // Add to named graph (for own/inherited distinction)
+        if (store.addToGraph) {
+          await store.addToGraph(materializedTriple, INFERRED_GRAPH);
+        }
+
+        materializedCount++;
+      }
+    }
+
+    return materializedCount;
+  }
+}

--- a/packages/exocortex/tests/unit/services/PrototypeChainMaterializer.test.ts
+++ b/packages/exocortex/tests/unit/services/PrototypeChainMaterializer.test.ts
@@ -1,0 +1,231 @@
+import { PrototypeChainMaterializer, INFERRED_GRAPH } from "../../../src/services/PrototypeChainMaterializer";
+import { NonInheritablePropertyRegistry } from "../../../src/services/NonInheritablePropertyRegistry";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+describe("PrototypeChainMaterializer", () => {
+  let materializer: PrototypeChainMaterializer;
+  let registry: NonInheritablePropertyRegistry;
+  let store: InMemoryTripleStore;
+
+  // Predicates
+  const prototype = Namespace.EXO.term("Asset_prototype");
+  const instanceClass = Namespace.EXO.term("Instance_class");
+  const assetLabel = Namespace.EXO.term("Asset_label");
+  const assetUid = Namespace.EXO.term("Asset_uid");
+  const effortArea = Namespace.EMS.term("Effort_area");
+  const effortTimeEstimate = Namespace.EMS.term("Effort_timeEstimateMinutes");
+  const effortStatus = Namespace.EMS.term("Effort_status");
+  const effortStartTimestamp = Namespace.EMS.term("Effort_startTimestamp");
+
+  // Subjects
+  const breakfastProto = new IRI("obsidian://vault/Breakfast.md");
+  const breakfastInstance = new IRI("obsidian://vault/Breakfast-2026-04-05.md");
+  const morningProto = new IRI("obsidian://vault/MorningRoutine.md");
+  const cycleA = new IRI("obsidian://vault/CycleA.md");
+  const cycleB = new IRI("obsidian://vault/CycleB.md");
+
+  // NonInheritableProperty class (for registry setup)
+  const nonInheritableClassIRI = new IRI(
+    "obsidian://vault/exo__NonInheritableProperty.md",
+  );
+
+  // Values
+  const healthArea = new IRI("obsidian://vault/Health.md");
+  const backlogStatus = new IRI("obsidian://vault/Backlog.md");
+  const taskClass = new IRI("https://exocortex.my/ontology/ems#Task");
+
+  async function setupRegistry(nonInheritableProps: string[]): Promise<void> {
+    const registryStore = new InMemoryTripleStore();
+
+    // Add NonInheritableProperty class label
+    await registryStore.add(
+      new Triple(nonInheritableClassIRI, assetLabel, new Literal("exo__NonInheritableProperty")),
+    );
+
+    for (const propLabel of nonInheritableProps) {
+      const defIRI = new IRI(`obsidian://vault/${propLabel}.md`);
+      await registryStore.add(new Triple(defIRI, instanceClass, nonInheritableClassIRI));
+      await registryStore.add(new Triple(defIRI, assetLabel, new Literal(propLabel)));
+    }
+
+    await registry.initialize(registryStore);
+  }
+
+  beforeEach(async () => {
+    registry = new NonInheritablePropertyRegistry();
+    store = new InMemoryTripleStore();
+
+    // Setup registry with standard non-inheritable properties
+    await setupRegistry([
+      "exo__Asset_uid",
+      "exo__Asset_label",
+      "exo__Asset_prototype",
+      "ems__Effort_status",
+      "ems__Effort_startTimestamp",
+    ]);
+
+    materializer = new PrototypeChainMaterializer(registry);
+  });
+
+  describe("no prototype", () => {
+    it("should return 0 for empty store", async () => {
+      const count = await materializer.materialize(store);
+      expect(count).toBe(0);
+    });
+
+    it("should return 0 when no Asset_prototype triples exist", async () => {
+      await store.add(new Triple(breakfastInstance, assetLabel, new Literal("Breakfast")));
+
+      const count = await materializer.materialize(store);
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("single prototype", () => {
+    it("should materialize inheritable properties from prototype", async () => {
+      // Prototype has: area (inheritable), timeEstimate (inheritable), label (non-inheritable)
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+      await store.add(new Triple(breakfastProto, effortTimeEstimate, new Literal("15")));
+      await store.add(new Triple(breakfastProto, assetLabel, new Literal("Breakfast")));
+      await store.add(new Triple(breakfastProto, assetUid, new Literal("proto-uid")));
+
+      // Instance links to prototype, has its own label
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastInstance, assetLabel, new Literal("Breakfast 2026-04-05")));
+      await store.add(new Triple(breakfastInstance, assetUid, new Literal("instance-uid")));
+
+      const count = await materializer.materialize(store);
+
+      // Should materialize: area + timeEstimate (2 inheritable props)
+      // Should NOT materialize: label, uid (non-inheritable)
+      expect(count).toBe(2);
+
+      // Verify materialized triples in default graph
+      const areaTriples = await store.match(breakfastInstance, effortArea, undefined);
+      expect(areaTriples.length).toBe(1);
+      expect(areaTriples[0].object).toEqual(healthArea);
+
+      const timeTriples = await store.match(breakfastInstance, effortTimeEstimate, undefined);
+      expect(timeTriples.length).toBe(1);
+      expect((timeTriples[0].object as Literal).value).toBe("15");
+
+      // Verify non-inheritable label stays original
+      const labelTriples = await store.match(breakfastInstance, assetLabel, undefined);
+      expect(labelTriples.length).toBe(1);
+      expect((labelTriples[0].object as Literal).value).toBe("Breakfast 2026-04-05");
+    });
+
+    it("should not overwrite existing own properties", async () => {
+      // Prototype has area = Health
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+
+      // Instance has its own area override
+      const vacationArea = new IRI("obsidian://vault/Vacation.md");
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastInstance, effortArea, vacationArea));
+
+      const count = await materializer.materialize(store);
+
+      // Nothing materialized — instance already has area
+      expect(count).toBe(0);
+
+      // Own value preserved
+      const areaTriples = await store.match(breakfastInstance, effortArea, undefined);
+      expect(areaTriples.length).toBe(1);
+      expect(areaTriples[0].object).toEqual(vacationArea);
+    });
+
+    it("should add materialized triples to named graph", async () => {
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+
+      await materializer.materialize(store);
+
+      // Verify in named graph
+      const namedGraphTriples = await store.matchInGraph!(
+        breakfastInstance,
+        effortArea,
+        undefined,
+        INFERRED_GRAPH,
+      );
+      expect(namedGraphTriples.length).toBe(1);
+      expect(namedGraphTriples[0].object).toEqual(healthArea);
+    });
+  });
+
+  describe("non-inheritable properties", () => {
+    it("should skip all non-inheritable properties", async () => {
+      // Prototype has mix of inheritable and non-inheritable
+      await store.add(new Triple(breakfastProto, assetLabel, new Literal("Breakfast")));
+      await store.add(new Triple(breakfastProto, assetUid, new Literal("proto-uid")));
+      await store.add(new Triple(breakfastProto, effortStatus, backlogStatus));
+      await store.add(new Triple(breakfastProto, effortStartTimestamp, new Literal("2026-04-01")));
+      await store.add(new Triple(breakfastProto, prototype, morningProto));
+
+      // Instance with only prototype link
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+
+      const count = await materializer.materialize(store);
+
+      // All 5 prototype properties are non-inheritable → 0 materialized
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("cycle detection", () => {
+    it("should handle self-referencing prototype", async () => {
+      // A has prototype → A (self-cycle)
+      await store.add(new Triple(cycleA, prototype, cycleA));
+      await store.add(new Triple(cycleA, effortArea, healthArea));
+
+      const count = await materializer.materialize(store);
+
+      // Self-cycle is skipped
+      expect(count).toBe(0);
+    });
+
+    it("should handle A → B → A cycle (single-hop only processes A→B)", async () => {
+      // A → B, B → A
+      await store.add(new Triple(cycleA, prototype, cycleB));
+      await store.add(new Triple(cycleB, prototype, cycleA));
+
+      // B has an inheritable property
+      await store.add(new Triple(cycleB, effortArea, healthArea));
+      // A has an inheritable property
+      await store.add(new Triple(cycleA, effortTimeEstimate, new Literal("30")));
+
+      const count = await materializer.materialize(store);
+
+      // Single-hop: A inherits area from B, B inherits timeEstimate from A
+      expect(count).toBe(2);
+    });
+  });
+
+  describe("multiple instances sharing prototype", () => {
+    it("should materialize for each instance independently", async () => {
+      const instance2 = new IRI("obsidian://vault/Breakfast-2026-04-06.md");
+
+      // Prototype has area
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+
+      // Two instances link to same prototype
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(instance2, prototype, breakfastProto));
+
+      const count = await materializer.materialize(store);
+
+      // 1 property × 2 instances = 2
+      expect(count).toBe(2);
+
+      const area1 = await store.match(breakfastInstance, effortArea, undefined);
+      expect(area1.length).toBe(1);
+
+      const area2 = await store.match(instance2, effortArea, undefined);
+      expect(area2.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Single-hop prototype chain materializer following `RDFSInferenceEngine` pattern
- Traverses `exo__Asset_prototype` links, copies inheritable properties to instances
- Skips non-inheritable properties via `NonInheritablePropertyRegistry` (#2500)
- Dual write: default graph (for `match()`) + `exo:inferred` named graph (for OWN/INHERITED Phase 6)
- Cycle detection (self-reference + A→B→A)
- Exported `INFERRED_GRAPH` constant

## Test plan
- [x] 9 unit tests: empty store, single prototype, own property override, non-inheritable skip, cycle detection, multiple instances
- [x] TypeScript: zero errors
- [x] Pre-commit: lint, BDD 100%, archgate pass

Closes #2501