### PR TITLE
feat(cli): integrate PrototypeChainMaterializer in sparql-index.ts (#2502)

### DIFF
--- a/packages/cli/src/commands/sparql-index.ts
+++ b/packages/cli/src/commands/sparql-index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { existsSync } from "fs";
 import { resolve } from "path";
-import { InMemoryTripleStore, RDFSInferenceEngine } from "exocortex";
+import { InMemoryTripleStore, RDFSInferenceEngine, NonInheritablePropertyRegistry, PrototypeChainMaterializer } from "exocortex";
 import { CacheManager } from "../cache/CacheManager.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
@@ -80,6 +80,13 @@ export function sparqlIndexCommand(): Command {
           const engine = new RDFSInferenceEngine();
           inferredCount = await engine.materialize(tripleStore);
 
+          // Prototype chain materialization (after RDFS inference)
+          const registry = new NonInheritablePropertyRegistry();
+          await registry.initialize(tripleStore);
+          const protoMaterializer = new PrototypeChainMaterializer(registry);
+          const protoInferredCount = await protoMaterializer.materialize(tripleStore);
+          inferredCount += protoInferredCount;
+
           if (inferredCount > 0) {
             const allTriples = await tripleStore.match();
             await cacheManager.saveTriples(allTriples);
@@ -87,7 +94,7 @@ export function sparqlIndexCommand(): Command {
           }
 
           if (outputFormat === "text" && inferredCount > 0) {
-            console.log(`🧠 Materialized ${inferredCount} inferred Instance_class triples`);
+            console.log(`🧠 Materialized ${inferredCount} inferred triples (RDFS + prototype chain)`);
           }
         }
 

--- a/packages/cli/tests/unit/commands/sparql-index.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-index.test.ts
@@ -22,10 +22,12 @@ jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
   })),
 }));
 
-// Mock exocortex RDFS inference
+// Mock exocortex RDFS inference + prototype chain
 const mockAddAll = jest.fn();
 const mockMatch = jest.fn();
 const mockMaterialize = jest.fn();
+const mockRegistryInitialize = jest.fn();
+const mockProtoMaterialize = jest.fn();
 
 jest.unstable_mockModule("exocortex", () => ({
   InMemoryTripleStore: jest.fn(() => ({
@@ -34,6 +36,12 @@ jest.unstable_mockModule("exocortex", () => ({
   })),
   RDFSInferenceEngine: jest.fn(() => ({
     materialize: mockMaterialize,
+  })),
+  NonInheritablePropertyRegistry: jest.fn(() => ({
+    initialize: mockRegistryInitialize,
+  })),
+  PrototypeChainMaterializer: jest.fn(() => ({
+    materialize: mockProtoMaterialize,
   })),
 }));
 
@@ -78,6 +86,8 @@ describe("sparqlIndexCommand", () => {
     mockAddAll.mockResolvedValue(undefined);
     mockMatch.mockResolvedValue([]);
     mockMaterialize.mockResolvedValue(0);
+    mockRegistryInitialize.mockResolvedValue(undefined);
+    mockProtoMaterialize.mockResolvedValue(0);
   });
 
   afterEach(async () => {
@@ -150,6 +160,64 @@ describe("sparqlIndexCommand", () => {
 
       expect(mockInvalidate).toHaveBeenCalled();
       expect(mockBuildCacheWithValidation).toHaveBeenCalled();
+    });
+  });
+
+  describe("prototype chain materialization", () => {
+    it("should run PrototypeChainMaterializer after RDFS inference", async () => {
+      const cmd = sparqlIndexCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--vault", vaultPath,
+      ]);
+
+      expect(mockRegistryInitialize).toHaveBeenCalled();
+      expect(mockProtoMaterialize).toHaveBeenCalled();
+    });
+
+    it("should save triples when prototype chain materializes new triples", async () => {
+      mockProtoMaterialize.mockResolvedValue(5);
+      mockMatch.mockResolvedValue([{ subject: "s", predicate: "p", object: "o" }]);
+
+      const cmd = sparqlIndexCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--vault", vaultPath,
+      ]);
+
+      expect(mockSaveTriples).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Materialized 5 inferred triples")
+      );
+    });
+
+    it("should combine RDFS and prototype chain inferred counts", async () => {
+      mockMaterialize.mockResolvedValue(10);
+      mockProtoMaterialize.mockResolvedValue(3);
+      mockMatch.mockResolvedValue([]);
+
+      const cmd = sparqlIndexCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--vault", vaultPath,
+      ]);
+
+      expect(mockSaveTriples).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Materialized 13 inferred triples")
+      );
+    });
+
+    it("should not run prototype chain when --no-inference is set", async () => {
+      const cmd = sparqlIndexCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "--vault", vaultPath,
+        "--no-inference",
+      ]);
+
+      expect(mockRegistryInitialize).not.toHaveBeenCalled();
+      expect(mockProtoMaterialize).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Closes #2502

## Summary
- Wire `PrototypeChainMaterializer` into the CLI `sparql index` pipeline after `RDFSInferenceEngine`
- Initialize `NonInheritablePropertyRegistry` from the triple store, then run prototype chain materialization
- Combined inferred count (RDFS + prototype) is saved back to cache
- 4 new unit tests covering: execution order, triple saving, combined counts, --no-inference flag

## Files changed
- `packages/cli/src/commands/sparql-index.ts` — added prototype chain materialization step
- `packages/cli/tests/unit/commands/sparql-index.test.ts` — added mocks and 4 tests

## Test plan
- [x] All 11 sparql-index tests pass (4 new + 7 existing)
- [x] Full CLI suite: 72 suites, 1171 tests pass
- [x] TypeScript typecheck passes (`tsc --noEmit --skipLibCheck`)