### PR TITLE
refactor(plugin): remove 7 hardcoded label fallback implementations (#2505)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/body/BodyLinkPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/body/BodyLinkPatch.ts
@@ -388,43 +388,7 @@ export class BodyLinkPatch {
     frontmatter: Record<string, unknown>,
     _file: TFile
   ): Record<string, unknown> {
-    const metadata = { ...frontmatter };
-
-    // If label is missing, try to get from prototype
-    if (!metadata.exo__Asset_label) {
-      const prototypeRef = metadata.exo__Asset_prototype;
-      if (prototypeRef) {
-        const prototypePath =
-          typeof prototypeRef === "string"
-            ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
-            : null;
-
-        if (prototypePath) {
-          let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-            prototypePath,
-            ""
-          );
-
-          if (!prototypeFile && !prototypePath.endsWith(".md")) {
-            prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-              prototypePath + ".md",
-              ""
-            );
-          }
-
-          if (prototypeFile instanceof TFile) {
-            const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
-            const prototypeMetadata = prototypeCache?.frontmatter;
-
-            if (prototypeMetadata?.exo__Asset_label) {
-              metadata.exo__Asset_label = prototypeMetadata.exo__Asset_label;
-            }
-          }
-        }
-      }
-    }
-
-    return metadata;
+    return { ...frontmatter };
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/editor-extensions/WikilinkLabelViewPlugin.ts
+++ b/packages/obsidian-plugin/src/presentation/editor-extensions/WikilinkLabelViewPlugin.ts
@@ -189,25 +189,6 @@ export class WikilinkLabelViewPlugin {
 
     const metadata = { ...frontmatter };
 
-    if (!metadata.exo__Asset_label) {
-      const prototypeRef = metadata.exo__Asset_prototype;
-      if (prototypeRef && typeof prototypeRef === "string") {
-        const prototypePath = prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim();
-        if (prototypePath) {
-          let protoFile = this.metadataCache.getFirstLinkpathDest(prototypePath, "");
-          if (!protoFile && !prototypePath.endsWith(".md")) {
-            protoFile = this.metadataCache.getFirstLinkpathDest(prototypePath + ".md", "");
-          }
-          if (protoFile instanceof TFile) {
-            const protoCache = this.metadataCache.getFileCache(protoFile);
-            if (protoCache?.frontmatter?.exo__Asset_label) {
-              metadata.exo__Asset_label = protoCache.frontmatter.exo__Asset_label;
-            }
-          }
-        }
-      }
-    }
-
     if (this.printNameRuleService) {
       const displaySettings = this.settings.displayNameSettings || {
         defaultTemplate: "{{exo__Asset_label}}",
@@ -353,43 +334,6 @@ export class WikilinkLabelViewPlugin {
     const label = metadata.exo__Asset_label;
     if (label && typeof label === "string" && label.trim() !== "") {
       return label;
-    }
-
-    // Try to get label from prototype
-    const prototypeRef = metadata.exo__Asset_prototype;
-    if (prototypeRef) {
-      const prototypePath =
-        typeof prototypeRef === "string"
-          ? prototypeRef.replace(/^\[\[|\]\]$/g, "").trim()
-          : null;
-
-      if (prototypePath) {
-        let prototypeFile = metadataCache.getFirstLinkpathDest(
-          prototypePath,
-          "",
-        );
-
-        if (!prototypeFile && !prototypePath.endsWith(".md")) {
-          prototypeFile = metadataCache.getFirstLinkpathDest(
-            prototypePath + ".md",
-            "",
-          );
-        }
-
-        if (prototypeFile instanceof TFile) {
-          const prototypeCache = metadataCache.getFileCache(prototypeFile);
-          const prototypeMetadata = prototypeCache?.frontmatter;
-          const prototypeLabel = prototypeMetadata?.exo__Asset_label;
-
-          if (
-            prototypeLabel &&
-            typeof prototypeLabel === "string" &&
-            prototypeLabel.trim() !== ""
-          ) {
-            return prototypeLabel;
-          }
-        }
-      }
     }
 
     return null;

--- a/packages/obsidian-plugin/src/presentation/graph-view/GraphViewPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/graph-view/GraphViewPatch.ts
@@ -429,92 +429,16 @@ export class GraphViewPatch {
       return label.trim();
     }
 
-    // Fallback: try prototype label if available
-    const prototypeRef = frontmatter.exo__Asset_prototype;
-    if (prototypeRef) {
-      const prototypePath =
-        typeof prototypeRef === "string"
-          ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
-          : null;
-
-      if (prototypePath) {
-        let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-          prototypePath,
-          ""
-        );
-
-        // Try with .md extension if not found
-        if (!prototypeFile && !prototypePath.endsWith(".md")) {
-          prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-            prototypePath + ".md",
-            ""
-          );
-        }
-
-        if (prototypeFile instanceof TFile) {
-          const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
-          const prototypeMetadata = prototypeCache?.frontmatter;
-
-          if (prototypeMetadata) {
-            const prototypeLabel = prototypeMetadata.exo__Asset_label;
-            if (
-              prototypeLabel &&
-              typeof prototypeLabel === "string" &&
-              prototypeLabel.trim() !== ""
-            ) {
-              return prototypeLabel.trim();
-            }
-          }
-        }
-      }
-    }
-
     return null;
   }
 
   /**
-   * Build metadata object for template rendering, merging frontmatter with prototype data
+   * Build metadata object for template rendering
    */
   private buildTemplateMetadata(
     frontmatter: Record<string, unknown>,
     _file: TFile
   ): Record<string, unknown> {
-    const metadata = { ...frontmatter };
-
-    // If label is missing, try to get from prototype
-    if (!metadata.exo__Asset_label) {
-      const prototypeRef = metadata.exo__Asset_prototype;
-      if (prototypeRef) {
-        const prototypePath =
-          typeof prototypeRef === "string"
-            ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
-            : null;
-
-        if (prototypePath) {
-          let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-            prototypePath,
-            ""
-          );
-
-          if (!prototypeFile && !prototypePath.endsWith(".md")) {
-            prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-              prototypePath + ".md",
-              ""
-            );
-          }
-
-          if (prototypeFile instanceof TFile) {
-            const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
-            const prototypeMetadata = prototypeCache?.frontmatter;
-
-            if (prototypeMetadata?.exo__Asset_label) {
-              metadata.exo__Asset_label = prototypeMetadata.exo__Asset_label;
-            }
-          }
-        }
-      }
-    }
-
-    return metadata;
+    return { ...frontmatter };
   }
 }

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
@@ -378,43 +378,7 @@ export class PropertiesLinkPatch {
     frontmatter: Record<string, unknown>,
     _file: TFile
   ): Record<string, unknown> {
-    const metadata = { ...frontmatter };
-
-    // If label is missing, try to get from prototype
-    if (!metadata.exo__Asset_label) {
-      const prototypeRef = metadata.exo__Asset_prototype;
-      if (prototypeRef) {
-        const prototypePath =
-          typeof prototypeRef === "string"
-            ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
-            : null;
-
-        if (prototypePath) {
-          let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-            prototypePath,
-            ""
-          );
-
-          if (!prototypeFile && !prototypePath.endsWith(".md")) {
-            prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-              prototypePath + ".md",
-              ""
-            );
-          }
-
-          if (prototypeFile instanceof TFile) {
-            const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
-            const prototypeMetadata = prototypeCache?.frontmatter;
-
-            if (prototypeMetadata?.exo__Asset_label) {
-              metadata.exo__Asset_label = prototypeMetadata.exo__Asset_label;
-            }
-          }
-        }
-      }
-    }
-
-    return metadata;
+    return { ...frontmatter };
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
@@ -24,35 +24,6 @@ export class AssetMetadataService {
       return label;
     }
 
-    const prototypeRef = metadata.exo__Asset_prototype;
-    if (prototypeRef) {
-      const prototypePath =
-        typeof prototypeRef === "string"
-          ? prototypeRef.replace(/^\[\[|\]\]$/g, "").trim()
-          : null;
-
-      if (prototypePath) {
-        const prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-          prototypePath,
-          "",
-        );
-        if (prototypeFile instanceof TFile) {
-          const prototypeCache =
-            this.app.metadataCache.getFileCache(prototypeFile);
-          const prototypeMetadata = prototypeCache?.frontmatter || {};
-          const prototypeLabel = prototypeMetadata.exo__Asset_label;
-
-          if (
-            prototypeLabel &&
-            typeof prototypeLabel === "string" &&
-            prototypeLabel.trim() !== ""
-          ) {
-            return prototypeLabel;
-          }
-        }
-      }
-    }
-
     return null;
   }
 

--- a/packages/obsidian-plugin/src/presentation/tab-titles/TabTitlePatch.ts
+++ b/packages/obsidian-plugin/src/presentation/tab-titles/TabTitlePatch.ts
@@ -208,46 +208,6 @@ export class TabTitlePatch {
       return label.trim();
     }
 
-    // Fallback: try prototype label if available
-    const prototypeRef = frontmatter.exo__Asset_prototype;
-    if (prototypeRef) {
-      const prototypePath =
-        typeof prototypeRef === "string"
-          ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
-          : null;
-
-      if (prototypePath) {
-        let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-          prototypePath,
-          ""
-        );
-
-        // Try with .md extension if not found
-        if (!prototypeFile && !prototypePath.endsWith(".md")) {
-          prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-            prototypePath + ".md",
-            ""
-          );
-        }
-
-        if (prototypeFile instanceof TFile) {
-          const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
-          const prototypeMetadata = prototypeCache?.frontmatter;
-
-          if (prototypeMetadata) {
-            const prototypeLabel = prototypeMetadata.exo__Asset_label;
-            if (
-              prototypeLabel &&
-              typeof prototypeLabel === "string" &&
-              prototypeLabel.trim() !== ""
-            ) {
-              return prototypeLabel.trim();
-            }
-          }
-        }
-      }
-    }
-
     return null;
   }
 
@@ -258,43 +218,7 @@ export class TabTitlePatch {
     frontmatter: Record<string, unknown>,
     _file: TFile
   ): Record<string, unknown> {
-    const metadata = { ...frontmatter };
-
-    // If label is missing, try to get from prototype
-    if (!metadata.exo__Asset_label) {
-      const prototypeRef = metadata.exo__Asset_prototype;
-      if (prototypeRef) {
-        const prototypePath =
-          typeof prototypeRef === "string"
-            ? prototypeRef.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim()
-            : null;
-
-        if (prototypePath) {
-          let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-            prototypePath,
-            ""
-          );
-
-          if (!prototypeFile && !prototypePath.endsWith(".md")) {
-            prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-              prototypePath + ".md",
-              ""
-            );
-          }
-
-          if (prototypeFile instanceof TFile) {
-            const prototypeCache = this.app.metadataCache.getFileCache(prototypeFile);
-            const prototypeMetadata = prototypeCache?.frontmatter;
-
-            if (prototypeMetadata?.exo__Asset_label) {
-              metadata.exo__Asset_label = prototypeMetadata.exo__Asset_label;
-            }
-          }
-        }
-      }
-    }
-
-    return metadata;
+    return { ...frontmatter };
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/utils/WikilinkLabelResolver.ts
+++ b/packages/obsidian-plugin/src/presentation/utils/WikilinkLabelResolver.ts
@@ -103,36 +103,6 @@ export class WikilinkLabelResolver {
       return label;
     }
 
-    // Try to get label from prototype
-    const prototypeRef = metadata.exo__Asset_prototype;
-    if (prototypeRef) {
-      const prototypePath =
-        typeof prototypeRef === "string"
-          ? prototypeRef.replace(/^\[\[|\]\]$/g, "").trim()
-          : null;
-
-      if (prototypePath) {
-        const prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-          prototypePath,
-          "",
-        );
-        if (prototypeFile instanceof TFile) {
-          const prototypeCache =
-            this.app.metadataCache.getFileCache(prototypeFile);
-          const prototypeMetadata = prototypeCache?.frontmatter || {};
-          const prototypeLabel = prototypeMetadata.exo__Asset_label;
-
-          if (
-            prototypeLabel &&
-            typeof prototypeLabel === "string" &&
-            prototypeLabel.trim() !== ""
-          ) {
-            return prototypeLabel;
-          }
-        }
-      }
-    }
-
     return null;
   }
 

--- a/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
+++ b/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
@@ -1540,21 +1540,19 @@ describe("UniversalLayoutRenderer UI Integration", () => {
     });
   });
 
-  describe("Prototype Label Fallback", () => {
-    it("should display prototype label when asset has exo__Asset_prototype", async () => {
+  describe("Materialized Prototype Label", () => {
+    it("should display materialized label from prototype on instance", async () => {
       const currentFile = new TFile("current.md");
 
       const taskFile = new TFile("tasks/Task-123.md");
       (taskFile as any).stat = { ctime: Date.now(), mtime: Date.now() };
-
-      const prototypeFile = new TFile("prototypes/TaskPrototype.md");
 
       // Mock workspace and vault
       (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue(
         currentFile,
       );
 
-      // Mock cache for current file
+      // Mock cache for current file - label is materialized on instance by PrototypeChainMaterializer
       (mockApp.metadataCache.getFileCache as jest.Mock).mockImplementation(
         (file: TFile) => {
           if (file.path === "current.md") {
@@ -1565,13 +1563,6 @@ describe("UniversalLayoutRenderer UI Integration", () => {
               frontmatter: {
                 exo__Instance_class: "ems__Task",
                 exo__Asset_prototype: "[[TaskPrototype]]",
-                // No exo__Asset_label on task itself
-              },
-            };
-          }
-          if (file.path === "prototypes/TaskPrototype.md") {
-            return {
-              frontmatter: {
                 exo__Asset_label: "Marketing Campaign Template",
               },
             };
@@ -1585,20 +1576,16 @@ describe("UniversalLayoutRenderer UI Integration", () => {
         (path: string) => {
           if (path === "current.md") return currentFile;
           if (path === "tasks/Task-123.md") return taskFile;
-          if (path === "TaskPrototype.md") return prototypeFile;
-          if (path === "prototypes/TaskPrototype.md") return prototypeFile;
           return null;
         },
       );
 
-      // Mock metadataCache.getFirstLinkpathDest (used by new label resolution logic)
+      // Mock metadataCache.getFirstLinkpathDest
       (
         mockApp.metadataCache.getFirstLinkpathDest as jest.Mock
       ).mockImplementation((path: string) => {
         if (path === "tasks/Task-123.md" || path === "tasks/Task-123")
           return taskFile;
-        if (path === "TaskPrototype" || path === "TaskPrototype.md")
-          return prototypeFile;
         return null;
       });
 
@@ -1611,16 +1598,16 @@ describe("UniversalLayoutRenderer UI Integration", () => {
       await renderer.render("", domContainer, {} as MarkdownPostProcessorContext);
       await waitForReact();
 
-      // Check that prototype label is displayed (not filename)
+      // Check that materialized label is displayed (not filename)
       const assetLinks = domContainer.querySelectorAll("a.internal-link");
-      let foundPrototypeLabel = false;
+      let foundMaterializedLabel = false;
       assetLinks.forEach((link) => {
         if (link.textContent === "Marketing Campaign Template") {
-          foundPrototypeLabel = true;
+          foundMaterializedLabel = true;
         }
       });
 
-      expect(foundPrototypeLabel).toBe(true);
+      expect(foundMaterializedLabel).toBe(true);
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/AssetMetadataService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AssetMetadataService.test.ts
@@ -38,27 +38,33 @@ describe("AssetMetadataService", () => {
       expect(result).toBeNull();
     });
 
-    it("should fallback to prototype label", () => {
+    it("should return materialized label from prototype (via PrototypeChainMaterializer)", () => {
       const mockFile = new TFile();
-      const mockPrototypeFile = new TFile();
-      mockApp.metadataCache.getFirstLinkpathDest
-        .mockReturnValueOnce(mockFile)
-        .mockReturnValueOnce(mockPrototypeFile);
-      mockApp.metadataCache.getFileCache
-        .mockReturnValueOnce({
-          frontmatter: {
-            exo__Asset_prototype: "[[prototype-path]]",
-          },
-        })
-        .mockReturnValueOnce({
-          frontmatter: {
-            exo__Asset_label: "Prototype Label",
-          },
-        });
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_prototype: "[[prototype-path]]",
+          exo__Asset_label: "Prototype Label",
+        },
+      });
 
       const result = service.getAssetLabel("test-path");
 
       expect(result).toBe("Prototype Label");
+    });
+
+    it("should return null when instance has no label and no materialized label", () => {
+      const mockFile = new TFile();
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_prototype: "[[prototype-path]]",
+        },
+      });
+
+      const result = service.getAssetLabel("test-path");
+
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/presentation/body/BodyLinkPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/body/BodyLinkPatch.test.ts
@@ -200,32 +200,23 @@ describe("BodyLinkPatch", () => {
       );
     });
 
-    it("should fallback to prototype label when asset has no label", () => {
+    it("should display materialized label inherited from prototype", () => {
       const mockFile = new TFile();
-      const mockPrototypeFile = new TFile();
       Object.defineProperty(mockFile, "extension", { value: "md" });
       Object.defineProperty(mockFile, "basename", { value: "test-file" });
       Object.defineProperty(mockFile, "stat", {
         value: { ctime: Date.now() },
       });
-      Object.defineProperty(mockPrototypeFile, "extension", { value: "md" });
 
-      mockApp.metadataCache.getFirstLinkpathDest
-        .mockReturnValueOnce(mockFile) // First call: resolve link path
-        .mockReturnValueOnce(mockPrototypeFile); // Second call: resolve prototype
+      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
 
-      mockApp.metadataCache.getFileCache
-        .mockReturnValueOnce({
-          frontmatter: {
-            exo__Asset_prototype: "[[prototype-path]]",
-            exo__Instance_class: "ems__Task",
-          },
-        })
-        .mockReturnValueOnce({
-          frontmatter: {
-            exo__Asset_label: "Prototype Label",
-          },
-        });
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_prototype: "[[prototype-path]]",
+          exo__Asset_label: "Prototype Label",
+          exo__Instance_class: "ems__Task",
+        },
+      });
 
       patch.enable();
 

--- a/packages/obsidian-plugin/tests/unit/presentation/graph-view/GraphViewPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/graph-view/GraphViewPatch.test.ts
@@ -205,33 +205,18 @@ describe("GraphViewPatch", () => {
       expect(mockNode.getDisplayText()).toBe("Test Label");
     });
 
-    it("should fallback to prototype label", () => {
+    it("should display materialized label inherited from prototype", () => {
       const mockFile = new TFile();
-      const mockPrototypeFile = new TFile();
       Object.defineProperty(mockFile, "extension", { value: "md" });
       Object.defineProperty(mockFile, "basename", { value: "test-file" });
-      Object.defineProperty(mockPrototypeFile, "extension", { value: "md" });
       mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
 
-      // Use mockImplementation to handle multiple calls with different returns
-      mockApp.metadataCache.getFileCache.mockImplementation((file: TFile) => {
-        if (file === mockFile) {
-          return {
-            frontmatter: {
-              exo__Asset_prototype: "[[prototype-path]]",
-            },
-          };
-        }
-        if (file === mockPrototypeFile) {
-          return {
-            frontmatter: {
-              exo__Asset_label: "Prototype Label",
-            },
-          };
-        }
-        return null;
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_prototype: "[[prototype-path]]",
+          exo__Asset_label: "Prototype Label",
+        },
       });
-      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockPrototypeFile);
 
       patch.enable();
 

--- a/packages/obsidian-plugin/tests/unit/presentation/tab-titles/TabTitlePatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/tab-titles/TabTitlePatch.test.ts
@@ -148,26 +148,18 @@ describe("TabTitlePatch", () => {
       expect(mockWorkspaceLeaf.getDisplayText()).toBe("Test Label");
     });
 
-    it("should fallback to prototype label", () => {
+    it("should display materialized label inherited from prototype", () => {
       const mockFile = new TFile();
-      const mockPrototypeFile = new TFile();
       Object.defineProperty(mockFile, "extension", { value: "md" });
       Object.defineProperty(mockFile, "basename", { value: "test-file" });
-      Object.defineProperty(mockPrototypeFile, "extension", { value: "md" });
       mockMarkdownView.file = mockFile;
 
-      mockApp.metadataCache.getFileCache
-        .mockReturnValueOnce({
-          frontmatter: {
-            exo__Asset_prototype: "[[prototype-path]]",
-          },
-        })
-        .mockReturnValueOnce({
-          frontmatter: {
-            exo__Asset_label: "Prototype Label",
-          },
-        });
-      mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(mockPrototypeFile);
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_prototype: "[[prototype-path]]",
+          exo__Asset_label: "Prototype Label",
+        },
+      });
 
       patch.enable();
 

--- a/packages/obsidian-plugin/tests/unit/presentation/utils/WikilinkLabelResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/utils/WikilinkLabelResolver.test.ts
@@ -109,18 +109,27 @@ describe("WikilinkLabelResolver", () => {
       expect(resolver.getAssetLabel("test-file")).toBeNull();
     });
 
-    it("returns label from prototype when direct label not found", () => {
+    it("returns materialized label inherited from prototype", () => {
       const mockApp = createMockApp({
         "task-instance": {
           exo__Asset_prototype: "[[task-prototype]]",
-        },
-        "task-prototype": {
           exo__Asset_label: "Task Template",
         },
       });
 
       const resolver = new WikilinkLabelResolver(mockApp);
       expect(resolver.getAssetLabel("task-instance")).toBe("Task Template");
+    });
+
+    it("returns null when instance has no label (even with prototype)", () => {
+      const mockApp = createMockApp({
+        "task-instance": {
+          exo__Asset_prototype: "[[task-prototype]]",
+        },
+      });
+
+      const resolver = new WikilinkLabelResolver(mockApp);
+      expect(resolver.getAssetLabel("task-instance")).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Removed 7 hardcoded prototype label fallback implementations across the plugin
- PrototypeChainMaterializer now materializes inherited labels into the triple store, making manual prototype lookups redundant
- Net result: 439 lines deleted, 70 lines added (13 files changed)

## Fallbacks removed

| Location | Method | Type |
|----------|--------|------|
| AssetMetadataService | `getAssetLabel()` | Direct prototype lookup |
| WikilinkLabelResolver | `getAssetLabel()` | Direct prototype lookup |
| TabTitlePatch | `getAssetLabel()` + `buildTemplateMetadata()` | Both patterns |
| GraphViewPatch | `getAssetLabel()` + `buildTemplateMetadata()` | Both patterns |
| WikilinkLabelViewPlugin | `resolveLabel()` + `resolveForDecoration()` | Both patterns |
| PropertiesLinkPatch | `buildTemplateMetadata()` | Metadata enrichment |
| BodyLinkPatch | `buildTemplateMetadata()` | Metadata enrichment |

## Test plan
- [x] All 4636 plugin tests pass (219 suites, 9 skipped as before)
- [x] TypeScript compiles cleanly (`tsc --noEmit --skipLibCheck`)
- [x] BDD coverage 100% (222/222 scenarios)
- [x] Archgate ADR compliance passes (13/13 rules)
- [x] ESLint passes with zero warnings
- [x] Tests updated: prototype label tests now simulate materialized labels (label on instance frontmatter)
- [ ] CI pipeline

Closes #2505