### PR TITLE
refactor(core): remove 3-tier area fallback in AssetMetadataService (#2506)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
@@ -117,35 +117,6 @@ export class AssetMetadataService {
       }
     }
 
-    const prototypeRef = metadata.exo__Asset_prototype;
-    const prototypePath = this.extractFirstValue(prototypeRef);
-
-    if (prototypePath && !visited.has(prototypePath)) {
-      visited.add(prototypePath);
-      let prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-        prototypePath,
-        "",
-      );
-
-      if (!prototypeFile && !prototypePath.endsWith(".md")) {
-        prototypeFile = this.app.metadataCache.getFirstLinkpathDest(
-          prototypePath + ".md",
-          "",
-        );
-      }
-
-      if (prototypeFile instanceof TFile) {
-        const prototypeCache =
-          this.app.metadataCache.getFileCache(prototypeFile);
-        const prototypeMetadata = prototypeCache?.frontmatter || {};
-
-        const resolvedArea = this.getEffortArea(prototypeMetadata, visited);
-        if (resolvedArea) {
-          return resolvedArea;
-        }
-      }
-    }
-
     return null;
   }
 

--- a/packages/obsidian-plugin/tests/unit/AssetMetadataService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AssetMetadataService.test.ts
@@ -102,7 +102,18 @@ describe("AssetMetadataService", () => {
       expect(result).toBeNull();
     });
 
-    it("should resolve area from prototype", () => {
+    it("should return materialized area from prototype via triple store", () => {
+      const metadata = {
+        exo__Asset_prototype: "[[prototype-path]]",
+        ems__Effort_area: "materialized-prototype-area",
+      };
+
+      const result = service.getEffortArea(metadata);
+
+      expect(result).toBe("materialized-prototype-area");
+    });
+
+    it("should not traverse prototype for area (materializer handles inheritance)", () => {
       const mockPrototypeFile = new TFile();
       mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(
         mockPrototypeFile,
@@ -119,7 +130,18 @@ describe("AssetMetadataService", () => {
 
       const result = service.getEffortArea(metadata);
 
-      expect(result).toBe("prototype-area");
+      expect(result).toBeNull();
+      expect(mockApp.metadataCache.getFirstLinkpathDest).not.toHaveBeenCalled();
+    });
+
+    it("should return null when neither instance nor prototype has area", () => {
+      const metadata = {
+        exo__Asset_prototype: "[[prototype-path]]",
+      };
+
+      const result = service.getEffortArea(metadata);
+
+      expect(result).toBeNull();
     });
 
     it("should resolve area from parent effort", () => {
@@ -142,17 +164,13 @@ describe("AssetMetadataService", () => {
       expect(result).toBe("parent-area");
     });
 
-    it("should inherit area from parent when prototype has no area", () => {
-      const mockPrototypeFile = new TFile();
+    it("should resolve area from parent when prototype present but no materialized area", () => {
       const mockParentFile = new TFile();
 
       mockApp.metadataCache.getFirstLinkpathDest.mockImplementation(
         (linkpath: string) => {
           if (linkpath === "parent-effort") {
             return mockParentFile;
-          }
-          if (linkpath === "prototype-path") {
-            return mockPrototypeFile;
           }
           return null;
         },
@@ -163,55 +181,6 @@ describe("AssetMetadataService", () => {
           return {
             frontmatter: {
               ems__Effort_area: "parent-area",
-            },
-          };
-        }
-        if (file === mockPrototypeFile) {
-          return {
-            frontmatter: {},
-          };
-        }
-        return null;
-      });
-
-      const metadata = {
-        exo__Asset_prototype: "[[prototype-path]]",
-        ems__Effort_parent: "[[parent-effort]]",
-      };
-
-      const result = service.getEffortArea(metadata);
-
-      expect(result).toBe("parent-area");
-    });
-
-    it("should prefer parent area over prototype area when both are present", () => {
-      const mockPrototypeFile = new TFile();
-      const mockParentFile = new TFile();
-
-      mockApp.metadataCache.getFirstLinkpathDest.mockImplementation(
-        (linkpath: string) => {
-          if (linkpath === "parent-effort") {
-            return mockParentFile;
-          }
-          if (linkpath === "prototype-path") {
-            return mockPrototypeFile;
-          }
-          return null;
-        },
-      );
-
-      mockApp.metadataCache.getFileCache.mockImplementation((file: TFile) => {
-        if (file === mockParentFile) {
-          return {
-            frontmatter: {
-              ems__Effort_area: "parent-area",
-            },
-          };
-        }
-        if (file === mockPrototypeFile) {
-          return {
-            frontmatter: {
-              ems__Effort_area: "prototype-area",
             },
           };
         }
@@ -256,36 +225,6 @@ describe("AssetMetadataService", () => {
       const result = service.getEffortArea(metadata);
 
       expect(result).toBe("parent-area");
-    });
-
-    it("should resolve prototype area with .md extension fallback", () => {
-      const mockPrototypeFile = new TFile();
-
-      mockApp.metadataCache.getFirstLinkpathDest.mockImplementation(
-        (linkpath: string) => {
-          if (linkpath === "prototype-effort") {
-            return null;
-          }
-          if (linkpath === "prototype-effort.md") {
-            return mockPrototypeFile;
-          }
-          return null;
-        },
-      );
-
-      mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          ems__Effort_area: "prototype-area",
-        },
-      });
-
-      const metadata = {
-        exo__Asset_prototype: "[[prototype-effort]]",
-      };
-
-      const result = service.getEffortArea(metadata);
-
-      expect(result).toBe("prototype-area");
     });
 
     it("should not add .md extension if path already ends with .md", () => {


### PR DESCRIPTION
## Summary
- Removed prototype chain traversal from `AssetMetadataService.getEffortArea()` — PrototypeChainMaterializer now materializes inherited properties into the triple store, making manual prototype lookup redundant
- Kept direct area lookup (own/materialized value) and parent hierarchy traversal
- Updated unit tests: replaced prototype-traversal tests with materialization-aware tests

## Test plan
- [x] 20 AssetMetadataService unit tests pass (3 new, 3 removed)
- [x] 4638 plugin tests pass, 0 failures
- [x] TypeScript compiles cleanly
- [x] BDD coverage 100%, archgate pass

Closes #2506