### PR TITLE
feat(core): add SPARQL-based label template syntax for dynamic button labels (#2515)

### DIFF
--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -11,6 +11,17 @@ export interface CommandDefinition {
   readonly id: string;
   /** Human-readable label (e.g., "Remove start timestamp") */
   readonly name: string;
+  /**
+   * SPARQL-based label template with `{sparql}` placeholders.
+   * Each `{...}` block is executed as a SPARQL SELECT query;
+   * the first binding of the first result row replaces the placeholder.
+   *
+   * Example: `"Vote ({SELECT (COUNT(?v) AS ?n) WHERE { $target exo:vote ?v }})"` → `"Vote (3)"`
+   *
+   * Variable substitution (same as PreconditionEvaluator):
+   * - `$target` → `<targetIRI>`
+   */
+  readonly labelTemplate?: string;
   /** Lucide icon name (e.g., "clock-x") */
   readonly icon?: string;
   /** Precondition that determines when the command is available */

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -4,6 +4,9 @@ import { IRI } from "../domain/models/rdf/IRI";
 import { Literal } from "../domain/models/rdf/Literal";
 import { Namespace } from "../domain/models/rdf/Namespace";
 import { GroundingType } from "../domain/constants/GroundingType";
+import { SPARQLParser } from "../infrastructure/sparql/SPARQLParser";
+import { AlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
+import { QueryExecutor } from "../infrastructure/sparql/executors/QueryExecutor";
 import type {
   CommandDefinition,
   PreconditionDefinition,
@@ -100,6 +103,7 @@ export class CommandResolver {
 
     // Load command properties
     const name = await this.getLiteralValue(subject, Namespace.EXO.term("Asset_label")) ?? "Unknown Command";
+    const labelTemplate = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Command_labelTemplate"));
     const icon = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Command_icon"));
     const confirmMessage = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Command_confirmMessage"));
     const successMessage = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Command_successMessage"));
@@ -115,6 +119,7 @@ export class CommandResolver {
     return {
       id: commandUID,
       name,
+      labelTemplate: labelTemplate ?? undefined,
       icon: icon ?? undefined,
       precondition: precondition ?? undefined,
       grounding,
@@ -168,7 +173,107 @@ export class CommandResolver {
     this.cache.clear();
   }
 
+  /**
+   * Resolve a dynamic label for a command bound to a specific target asset.
+   *
+   * If the command has a `labelTemplate`, each `{...}` placeholder is executed
+   * as a SPARQL SELECT query (with `$target` substituted for the target IRI).
+   * The first binding value of the first result row replaces the placeholder.
+   * On error or empty result, the placeholder is replaced with an empty string.
+   *
+   * If the command has no `labelTemplate`, returns the static `name`.
+   *
+   * @param command - The command definition (may have labelTemplate)
+   * @param targetIRI - IRI of the current asset (substituted for $target)
+   * @returns The resolved label string
+   */
+  async resolveLabel(
+    command: CommandDefinition,
+    targetIRI: string,
+  ): Promise<string> {
+    if (!command.labelTemplate) {
+      return command.name;
+    }
+
+    let result = command.labelTemplate;
+    const placeholders = this.extractPlaceholders(command.labelTemplate);
+
+    for (const { full, body } of placeholders) {
+      const resolved = await this.evaluateSelectSnippet(body, targetIRI);
+      result = result.replace(full, resolved);
+    }
+
+    return result;
+  }
+
   // -- Private helpers --
+
+  /**
+   * Extract top-level `{...}` placeholders from a label template,
+   * correctly handling nested braces in SPARQL WHERE clauses.
+   *
+   * Returns array of { full: "{...}", body: "..." } for each placeholder.
+   */
+  private extractPlaceholders(template: string): Array<{ full: string; body: string }> {
+    const results: Array<{ full: string; body: string }> = [];
+    let i = 0;
+
+    while (i < template.length) {
+      if (template[i] === "{") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < template.length && depth > 0) {
+          if (template[j] === "{") depth++;
+          else if (template[j] === "}") depth--;
+          j++;
+        }
+        if (depth === 0) {
+          const full = template.slice(i, j);
+          const body = template.slice(i + 1, j - 1);
+          results.push({ full, body });
+        }
+        i = j;
+      } else {
+        i++;
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Execute a SPARQL SELECT snippet and return the first binding value
+   * of the first result row, or empty string on failure / no results.
+   */
+  private async evaluateSelectSnippet(
+    sparqlBody: string,
+    targetIRI: string,
+  ): Promise<string> {
+    try {
+      const query = sparqlBody.replace(/\$target/g, `<${targetIRI}>`);
+      const parser = new SPARQLParser();
+      const parsed = parser.parse(query);
+      const translator = new AlgebraTranslator();
+      const algebra = translator.translate(parsed);
+      const executor = new QueryExecutor(this.tripleStore);
+      const solutions = await executor.executeAll(algebra);
+
+      if (solutions.length === 0) return "";
+
+      // Return the first binding value of the first solution
+      const firstSolution = solutions[0];
+      const vars = firstSolution.variables();
+      if (vars.length === 0) return "";
+
+      const value = firstSolution.get(vars[0]);
+      if (!value) return "";
+      if (value instanceof Literal) return value.value;
+      if (value instanceof IRI) return value.value;
+      return String(value);
+    } catch {
+      return "";
+    }
+  }
 
   private async loadBindingDefinition(subject: IRI): Promise<CommandBindingDefinition | null> {
     const uid = await this.getLiteralValue(subject, Namespace.EXO.term("Asset_uid"));

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -12,6 +12,7 @@ async function addCommandAsset(
   opts: {
     uid: string;
     label: string;
+    labelTemplate?: string;
     icon?: string;
     preconditionRef?: string;
     groundingRef: string;
@@ -29,6 +30,9 @@ async function addCommandAsset(
     new Triple(subject, Namespace.EXOCMD.term("Command_grounding"), new IRI(`obsidian://vault/${opts.groundingRef}.md`)),
   ];
 
+  if (opts.labelTemplate) {
+    triples.push(new Triple(subject, Namespace.EXOCMD.term("Command_labelTemplate"), new Literal(opts.labelTemplate)));
+  }
   if (opts.icon) {
     triples.push(new Triple(subject, Namespace.EXOCMD.term("Command_icon"), new Literal(opts.icon)));
   }
@@ -572,6 +576,108 @@ describe("CommandResolver", () => {
 
       expect(resolved[0].command.name).toBe("B"); // order 50
       expect(resolved[1].command.name).toBe("A"); // order 100 (default)
+    });
+  });
+
+  describe("resolveLabel", () => {
+    it("should return static name when no labelTemplate is set", async () => {
+      await addGroundingAsset(store, { uid: "gnd-1", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, { uid: "cmd-static", label: "Static Label", groundingRef: "gnd-1" });
+
+      const cmd = await resolver.loadCommand("cmd-static");
+      expect(cmd).not.toBeNull();
+
+      const label = await resolver.resolveLabel(cmd!, "urn:test:asset-1");
+      expect(label).toBe("Static Label");
+    });
+
+    it("should return template as-is when template has no placeholders", async () => {
+      await addGroundingAsset(store, { uid: "gnd-2", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, {
+        uid: "cmd-no-placeholder",
+        label: "Fallback",
+        labelTemplate: "Plain text label",
+        groundingRef: "gnd-2",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-no-placeholder");
+      expect(cmd).not.toBeNull();
+
+      const label = await resolver.resolveLabel(cmd!, "urn:test:asset-1");
+      expect(label).toBe("Plain text label");
+    });
+
+    it("should substitute SPARQL placeholder with query result", async () => {
+      // Set up vote triples for the target asset
+      const targetIRI = "obsidian://vault/task-42.md";
+      const targetSubject = new IRI(targetIRI);
+
+      await store.addAll([
+        new Triple(targetSubject, Namespace.EXO.term("vote"), new Literal("user-a")),
+        new Triple(targetSubject, Namespace.EXO.term("vote"), new Literal("user-b")),
+        new Triple(targetSubject, Namespace.EXO.term("vote"), new Literal("user-c")),
+      ]);
+
+      await addGroundingAsset(store, { uid: "gnd-3", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, {
+        uid: "cmd-vote",
+        label: "Vote",
+        labelTemplate: "Vote ({SELECT (COUNT(?v) AS ?n) WHERE { $target <https://exocortex.my/ontology/exo#vote> ?v }})",
+        groundingRef: "gnd-3",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-vote");
+      expect(cmd).not.toBeNull();
+
+      const label = await resolver.resolveLabel(cmd!, targetIRI);
+      expect(label).toBe("Vote (3)");
+    });
+
+    it("should replace placeholder with empty string when query returns no results", async () => {
+      await addGroundingAsset(store, { uid: "gnd-4", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, {
+        uid: "cmd-empty",
+        label: "Items",
+        labelTemplate: "Items ({SELECT (COUNT(?x) AS ?n) WHERE { $target <https://exocortex.my/ontology/exo#item> ?x }})",
+        groundingRef: "gnd-4",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-empty");
+      expect(cmd).not.toBeNull();
+
+      // No item triples in store → COUNT returns 0
+      const label = await resolver.resolveLabel(cmd!, "urn:test:no-items");
+      expect(label).toBe("Items (0)");
+    });
+
+    it("should replace placeholder with empty string on invalid SPARQL", async () => {
+      await addGroundingAsset(store, { uid: "gnd-5", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, {
+        uid: "cmd-bad-sparql",
+        label: "Bad",
+        labelTemplate: "Status ({INVALID SPARQL HERE})",
+        groundingRef: "gnd-5",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-bad-sparql");
+      expect(cmd).not.toBeNull();
+
+      const label = await resolver.resolveLabel(cmd!, "urn:test:asset");
+      expect(label).toBe("Status ()");
+    });
+
+    it("should load labelTemplate from triple store", async () => {
+      await addGroundingAsset(store, { uid: "gnd-6", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, {
+        uid: "cmd-with-tpl",
+        label: "Fallback Name",
+        labelTemplate: "Dynamic ({SELECT ?x WHERE { ?s ?p ?o }})",
+        groundingRef: "gnd-6",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-with-tpl");
+      expect(cmd).not.toBeNull();
+      expect(cmd!.labelTemplate).toBe("Dynamic ({SELECT ?x WHERE { ?s ?p ?o }})");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `exocmd__Command_labelTemplate` property to `CommandDefinition` interface
- Add `resolveLabel(command, targetIRI)` method to `CommandResolver` that evaluates `{SPARQL}` placeholders against the triple store
- Handle nested braces in SPARQL WHERE clauses via balanced-brace extraction
- Gracefully return empty string on SPARQL parse/execution errors or no results
- Falls back to static `name` when no template is set

## Example
```
labelTemplate: "Vote ({SELECT (COUNT(?v) AS ?n) WHERE { $target exo:vote ?v }})"
→ "Vote (3)"
```

## Test plan
- [x] 6 new unit tests for `resolveLabel` (29 total for CommandResolver)
  - No labelTemplate → returns static name
  - Template with no placeholders → returns as-is
  - Template with SPARQL placeholder → executes query, substitutes result
  - Empty query result → placeholder replaced with empty string (COUNT returns 0)
  - Invalid SPARQL → placeholder replaced with empty string
  - labelTemplate loaded from triple store correctly
- [x] All 6748 existing tests pass
- [x] TypeScript typecheck clean
- [x] ESLint clean
- [x] BDD coverage 100%
- [x] Archgate compliance pass

Closes #2515