### PR TITLE
refactor(core): simplify CommandRegistry — remove static command registrations (#2517)

### DIFF
--- a/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
+++ b/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
@@ -1,147 +1,37 @@
-import { App } from "obsidian";
-import { container } from "tsyringe";
 import { ICommand } from "./ICommand";
-import { ExocortexPluginInterface } from '@plugin/types';
-import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
-import {
-  TaskCreationService,
-  ProjectCreationService,
-  AreaCreationService,
-  TaskStatusService,
-  PropertyCleanupService,
-  FolderRepairService,
-  SupervisionCreationService,
-  RenameToUidService,
-  EffortVotingService,
-  LabelToAliasService,
-  AssetConversionService,
-  FleetingNoteCreationService,
-  GenericAssetCreationService,
-  DI_TOKENS,
-  registerCoreServices,
-} from "exocortex";
-import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
-import { SPARQLQueryService } from '@plugin/application/services/SPARQLQueryService';
-import { OntologySchemaService } from '@plugin/application/services/OntologySchemaService';
-import { ClassDiscoveryService } from '@plugin/application/services/ClassDiscoveryService';
+import { CommandResolver, ResolvedCommand } from "exocortex";
 
-import { CreateTaskCommand } from "./CreateTaskCommand";
-import { CreateProjectCommand } from "./CreateProjectCommand";
-import { CreateAreaCommand } from "./CreateAreaCommand";
-import { CreateInstanceCommand } from "./CreateInstanceCommand";
-import { CreateFleetingNoteCommand } from "./CreateFleetingNoteCommand";
-import { CreateRelatedTaskCommand } from "./CreateRelatedTaskCommand";
-import { SetDraftStatusCommand } from "./SetDraftStatusCommand";
-import { MoveToBacklogCommand } from "./MoveToBacklogCommand";
-import { MoveToAnalysisCommand } from "./MoveToAnalysisCommand";
-import { MoveToToDoCommand } from "./MoveToToDoCommand";
-import { StartEffortCommand } from "./StartEffortCommand";
-import { PlanOnTodayCommand } from "./PlanOnTodayCommand";
-import { PlanForEveningCommand } from "./PlanForEveningCommand";
-import { ShiftDayBackwardCommand } from "./ShiftDayBackwardCommand";
-import { ShiftDayForwardCommand } from "./ShiftDayForwardCommand";
-import { MarkDoneCommand } from "./MarkDoneCommand";
-import { MarkReviewedCommand } from "./MarkReviewedCommand";
-import { TrashEffortCommand } from "./TrashEffortCommand";
-import { ArchiveTaskCommand } from "./ArchiveTaskCommand";
-import { CleanPropertiesCommand } from "./CleanPropertiesCommand";
-import { RepairFolderCommand } from "./RepairFolderCommand";
-import { RenameToUidCommand } from "./RenameToUidCommand";
-import { VoteOnEffortCommand } from "./VoteOnEffortCommand";
-import { CopyLabelToAliasesCommand } from "./CopyLabelToAliasesCommand";
-import { CopyFleetingNoteLabelCommand } from "./CopyFleetingNoteLabelCommand";
-import { AddSupervisionCommand } from "./AddSupervisionCommand";
-import { ReloadLayoutCommand } from "./ReloadLayoutCommand";
-
-import { ToggleLayoutVisibilityCommand } from "./ToggleLayoutVisibilityCommand";
-import { ToggleArchivedAssetsCommand } from "./ToggleArchivedAssetsCommand";
-import { ConvertTaskToProjectCommand } from "./ConvertTaskToProjectCommand";
-import { ConvertProjectToTaskCommand } from "./ConvertProjectToTaskCommand";
-import { OpenQueryBuilderCommand } from "./OpenQueryBuilderCommand";
-import { EditPropertiesCommand } from "./EditPropertiesCommand";
-import { CreateAssetCommand } from "./CreateAssetCommand";
-
+/**
+ * Thin registry that provides global (UI-only) commands and delegates
+ * asset-specific command resolution to CommandResolver (RFC-009 §5.3).
+ *
+ * All per-asset commands (status transitions, creation, voting, etc.)
+ * are defined as vault command assets and resolved via SPARQL.
+ * Only global commands that require plugin/app UI dependencies remain.
+ */
 export class CommandRegistry {
-  private commands: ICommand[] = [];
-  private vaultAdapter: ObsidianVaultAdapter;
+  private commandResolver: CommandResolver | null = null;
 
-  constructor(
-    app: App,
-    plugin: ExocortexPluginInterface,
-    reloadLayoutCallback?: () => void,
-  ) {
-    this.vaultAdapter = new ObsidianVaultAdapter(app.vault, app.metadataCache, app);
+  constructor(private readonly globalCommands: ICommand[]) {}
 
-    // Create logger for services
-    const logger = LoggerFactory.create("CommandRegistry");
-
-    // Register infrastructure dependencies with DI container
-    container.register(DI_TOKENS.IVaultAdapter, { useValue: this.vaultAdapter });
-    container.register(DI_TOKENS.ILogger, { useValue: logger });
-
-    // Register all core services
-    registerCoreServices();
-
-    // Resolve services from DI container
-    const taskCreationService = container.resolve(TaskCreationService);
-    const projectCreationService = container.resolve(ProjectCreationService);
-    const areaCreationService = container.resolve(AreaCreationService);
-    const taskStatusService = container.resolve(TaskStatusService);
-    const propertyCleanupService = container.resolve(PropertyCleanupService);
-    const folderRepairService = container.resolve(FolderRepairService);
-    const supervisionCreationService = container.resolve(SupervisionCreationService);
-    const renameToUidService = container.resolve(RenameToUidService);
-    const effortVotingService = container.resolve(EffortVotingService);
-    const labelToAliasService = container.resolve(LabelToAliasService);
-    const assetConversionService = container.resolve(AssetConversionService);
-    const fleetingNoteCreationService = container.resolve(FleetingNoteCreationService);
-    const genericAssetCreationService = container.resolve(GenericAssetCreationService);
-
-    // Create ontology schema service for dynamic forms
-    const sparqlQueryService = new SPARQLQueryService(app, logger);
-    const ontologySchemaService = new OntologySchemaService(sparqlQueryService);
-    const classDiscoveryService = new ClassDiscoveryService(sparqlQueryService);
-
-    this.commands = [
-      new CreateTaskCommand(app, taskCreationService, this.vaultAdapter),
-      new CreateProjectCommand(app, projectCreationService, this.vaultAdapter),
-      new CreateAreaCommand(app, areaCreationService, this.vaultAdapter),
-      new CreateInstanceCommand(app, taskCreationService, this.vaultAdapter),
-      new CreateFleetingNoteCommand(app, fleetingNoteCreationService, this.vaultAdapter),
-      new CreateRelatedTaskCommand(app, taskCreationService, this.vaultAdapter),
-      new SetDraftStatusCommand(taskStatusService),
-      new MoveToBacklogCommand(taskStatusService),
-      new MoveToAnalysisCommand(taskStatusService),
-      new MoveToToDoCommand(taskStatusService),
-      new StartEffortCommand(taskStatusService),
-      new PlanOnTodayCommand(taskStatusService),
-      new PlanForEveningCommand(taskStatusService),
-      new ShiftDayBackwardCommand(taskStatusService),
-      new ShiftDayForwardCommand(taskStatusService),
-      new MarkDoneCommand(taskStatusService),
-      new MarkReviewedCommand(taskStatusService),
-      new TrashEffortCommand(app, taskStatusService),
-      new ArchiveTaskCommand(taskStatusService),
-      new CleanPropertiesCommand(propertyCleanupService),
-      new RepairFolderCommand(app, folderRepairService),
-      new RenameToUidCommand(renameToUidService),
-      new VoteOnEffortCommand(effortVotingService),
-      new CopyLabelToAliasesCommand(labelToAliasService),
-      new CopyFleetingNoteLabelCommand(app),
-      new AddSupervisionCommand(app, supervisionCreationService, this.vaultAdapter),
-      new ReloadLayoutCommand(reloadLayoutCallback),
-
-      new ToggleLayoutVisibilityCommand(plugin),
-      new ToggleArchivedAssetsCommand(plugin),
-      new ConvertTaskToProjectCommand(assetConversionService),
-      new ConvertProjectToTaskCommand(assetConversionService),
-      new OpenQueryBuilderCommand(app, plugin),
-      new EditPropertiesCommand(app, plugin),
-      new CreateAssetCommand(app, genericAssetCreationService, this.vaultAdapter, classDiscoveryService, ontologySchemaService),
-    ];
+  getGlobalCommands(): ICommand[] {
+    return this.globalCommands;
   }
 
   getAllCommands(): ICommand[] {
-    return this.commands;
+    return this.globalCommands;
+  }
+
+  async getCommandsForAsset(
+    subjectIRI: string,
+    assetClass: string,
+    prototypeIRI?: string,
+  ): Promise<ResolvedCommand[]> {
+    if (!this.commandResolver) return [];
+    return this.commandResolver.resolveForAsset(subjectIRI, assetClass, prototypeIRI);
+  }
+
+  setCommandResolver(resolver: CommandResolver): void {
+    this.commandResolver = resolver;
   }
 }

--- a/packages/obsidian-plugin/src/application/services/CommandManager.ts
+++ b/packages/obsidian-plugin/src/application/services/CommandManager.ts
@@ -1,9 +1,29 @@
 import { App, TFile } from "obsidian";
+import { container } from "tsyringe";
 import { ExocortexPluginInterface } from '@plugin/types';
 import { CommandRegistry } from '@plugin/application/commands/CommandRegistry';
-import { MetadataExtractor } from "exocortex";
+import {
+  MetadataExtractor,
+  CommandVisibilityContext,
+  WikiLinkHelpers,
+  FleetingNoteCreationService,
+  GenericAssetCreationService,
+  DI_TOKENS,
+  registerCoreServices,
+} from "exocortex";
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
-import { CommandVisibilityContext, WikiLinkHelpers } from "exocortex";
+import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
+import { SPARQLQueryService } from '@plugin/application/services/SPARQLQueryService';
+import { OntologySchemaService } from '@plugin/application/services/OntologySchemaService';
+import { ClassDiscoveryService } from '@plugin/application/services/ClassDiscoveryService';
+
+import { ReloadLayoutCommand } from '@plugin/application/commands/ReloadLayoutCommand';
+import { ToggleLayoutVisibilityCommand } from '@plugin/application/commands/ToggleLayoutVisibilityCommand';
+import { ToggleArchivedAssetsCommand } from '@plugin/application/commands/ToggleArchivedAssetsCommand';
+import { OpenQueryBuilderCommand } from '@plugin/application/commands/OpenQueryBuilderCommand';
+import { EditPropertiesCommand } from '@plugin/application/commands/EditPropertiesCommand';
+import { CreateAssetCommand } from '@plugin/application/commands/CreateAssetCommand';
+import { CreateFleetingNoteCommand } from '@plugin/application/commands/CreateFleetingNoteCommand';
 
 export class CommandManager {
   private commandRegistry: CommandRegistry | null = null;
@@ -17,15 +37,35 @@ export class CommandManager {
       app,
     );
     this.metadataExtractor = new MetadataExtractor(this.vaultAdapter);
-    // CommandRegistry is lazily initialized in registerAllCommands()
-    // to avoid needing a placeholder plugin instance
   }
 
   registerAllCommands(
     plugin: ExocortexPluginInterface,
     reloadLayoutCallback?: () => void,
   ): void {
-    this.commandRegistry = new CommandRegistry(this.app, plugin, reloadLayoutCallback);
+    const logger = LoggerFactory.create("CommandManager");
+
+    container.register(DI_TOKENS.IVaultAdapter, { useValue: this.vaultAdapter });
+    container.register(DI_TOKENS.ILogger, { useValue: logger });
+    registerCoreServices();
+
+    const fleetingNoteCreationService = container.resolve(FleetingNoteCreationService);
+    const genericAssetCreationService = container.resolve(GenericAssetCreationService);
+    const sparqlQueryService = new SPARQLQueryService(this.app, logger);
+    const ontologySchemaService = new OntologySchemaService(sparqlQueryService);
+    const classDiscoveryService = new ClassDiscoveryService(sparqlQueryService);
+
+    const globalCommands = [
+      new ReloadLayoutCommand(reloadLayoutCallback),
+      new ToggleLayoutVisibilityCommand(plugin),
+      new ToggleArchivedAssetsCommand(plugin),
+      new OpenQueryBuilderCommand(this.app, plugin),
+      new EditPropertiesCommand(this.app, plugin),
+      new CreateAssetCommand(this.app, genericAssetCreationService, this.vaultAdapter, classDiscoveryService, ontologySchemaService),
+      new CreateFleetingNoteCommand(this.app, fleetingNoteCreationService, this.vaultAdapter),
+    ];
+
+    this.commandRegistry = new CommandRegistry(globalCommands);
 
     const commands = this.commandRegistry.getAllCommands();
 
@@ -63,10 +103,6 @@ export class CommandManager {
     };
   }
 
-  /**
-   * Check if any of the asset's instance classes is a prototype (Issue #2261).
-   * Resolves UUID-based class references by looking up the class file's metadata.
-   */
   private resolveClassIsPrototype(instanceClass: string | string[] | null): boolean {
     if (!instanceClass) return false;
     if (!this.app.metadataCache?.getFirstLinkpathDest) return false;

--- a/packages/obsidian-plugin/tests/unit/commands-index.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands-index.test.ts
@@ -49,8 +49,7 @@ describe("Commands Index Exports", () => {
     });
   });
 
-  it("should export exactly 27 command classes and 1 registry", () => {
-    // Filter out type exports (which don't appear at runtime)
+  it("should export command classes and registry", () => {
     const exports = Object.keys(commandsIndex);
     const commandClasses = exports.filter((key) => key.endsWith("Command"));
     const registryClasses = exports.filter((key) => key.endsWith("Registry"));

--- a/packages/obsidian-plugin/tests/unit/commands/CommandRegistry.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/CommandRegistry.test.ts
@@ -1,236 +1,89 @@
 import "reflect-metadata";
-import { container } from "tsyringe";
 import { CommandRegistry } from "../../../src/application/commands/CommandRegistry";
-import { App } from "obsidian";
-import { ExocortexPluginInterface } from "../../../src/types";
-
-// Mock exocortex
-jest.mock("exocortex", () => ({
-  TaskCreationService: jest.fn(),
-  ProjectCreationService: jest.fn(),
-  AreaCreationService: jest.fn(),
-  TaskStatusService: jest.fn(),
-  PropertyCleanupService: jest.fn(),
-  FolderRepairService: jest.fn(),
-  SupervisionCreationService: jest.fn(),
-  RenameToUidService: jest.fn(),
-  EffortVotingService: jest.fn(),
-  LabelToAliasService: jest.fn(),
-  AssetConversionService: jest.fn(),
-  FleetingNoteCreationService: jest.fn(),
-  GenericAssetCreationService: jest.fn(),
-  DI_TOKENS: {
-    IVaultAdapter: Symbol("IVaultAdapter"),
-    ILogger: Symbol("ILogger"),
-  },
-  registerCoreServices: jest.fn(),
-}));
-
-// Mock LoggerFactory
-jest.mock("../../../src/adapters/logging/LoggerFactory", () => ({
-  LoggerFactory: {
-    create: jest.fn().mockReturnValue({
-      debug: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    }),
-  },
-}));
-
-// Mock ObsidianVaultAdapter
-jest.mock("../../../src/adapters/ObsidianVaultAdapter", () => ({
-  ObsidianVaultAdapter: jest.fn().mockImplementation(() => ({
-    read: jest.fn(),
-    write: jest.fn(),
-  })),
-}));
-
-// Mock command classes to avoid complex dependencies
-jest.mock("../../../src/application/commands/CreateTaskCommand");
-jest.mock("../../../src/application/commands/CreateProjectCommand");
-jest.mock("../../../src/application/commands/CreateAreaCommand");
-jest.mock("../../../src/application/commands/CreateInstanceCommand");
-jest.mock("../../../src/application/commands/CreateFleetingNoteCommand");
-jest.mock("../../../src/application/commands/CreateRelatedTaskCommand");
-jest.mock("../../../src/application/commands/SetDraftStatusCommand");
-jest.mock("../../../src/application/commands/MoveToBacklogCommand");
-jest.mock("../../../src/application/commands/MoveToAnalysisCommand");
-jest.mock("../../../src/application/commands/MoveToToDoCommand");
-jest.mock("../../../src/application/commands/StartEffortCommand");
-jest.mock("../../../src/application/commands/PlanOnTodayCommand");
-jest.mock("../../../src/application/commands/PlanForEveningCommand");
-jest.mock("../../../src/application/commands/ShiftDayBackwardCommand");
-jest.mock("../../../src/application/commands/ShiftDayForwardCommand");
-jest.mock("../../../src/application/commands/MarkDoneCommand");
-jest.mock("../../../src/application/commands/TrashEffortCommand");
-jest.mock("../../../src/application/commands/ArchiveTaskCommand");
-jest.mock("../../../src/application/commands/CleanPropertiesCommand");
-jest.mock("../../../src/application/commands/RepairFolderCommand");
-jest.mock("../../../src/application/commands/RenameToUidCommand");
-jest.mock("../../../src/application/commands/VoteOnEffortCommand");
-jest.mock("../../../src/application/commands/CopyLabelToAliasesCommand");
-jest.mock("../../../src/application/commands/AddSupervisionCommand");
-jest.mock("../../../src/application/commands/ReloadLayoutCommand");
-
-jest.mock("../../../src/application/commands/ToggleLayoutVisibilityCommand");
-jest.mock("../../../src/application/commands/ToggleArchivedAssetsCommand");
-jest.mock("../../../src/application/commands/ConvertTaskToProjectCommand");
-jest.mock("../../../src/application/commands/ConvertProjectToTaskCommand");
-jest.mock("../../../src/application/commands/OpenQueryBuilderCommand");
-jest.mock("../../../src/application/commands/EditPropertiesCommand");
-jest.mock("../../../src/application/commands/CreateAssetCommand");
-
-// Mock SPARQLQueryService and OntologySchemaService
-jest.mock("../../../src/application/services/SPARQLQueryService", () => ({
-  SPARQLQueryService: jest.fn().mockImplementation(() => ({
-    initialize: jest.fn(),
-    query: jest.fn(),
-    refresh: jest.fn(),
-    dispose: jest.fn(),
-  })),
-}));
-
-jest.mock("../../../src/application/services/OntologySchemaService", () => ({
-  OntologySchemaService: jest.fn().mockImplementation(() => ({
-    getClassProperties: jest.fn(),
-    getClassHierarchy: jest.fn(),
-    isDeprecatedProperty: jest.fn(),
-    getDefaultProperties: jest.fn(),
-  })),
-}));
-
-jest.mock("../../../src/application/services/ClassDiscoveryService", () => ({
-  ClassDiscoveryService: jest.fn().mockImplementation(() => ({
-    discoverClasses: jest.fn().mockResolvedValue([]),
-    getCreatableClasses: jest.fn().mockResolvedValue([]),
-    getDefaultClasses: jest.fn().mockReturnValue([]),
-  })),
-}));
+import { ICommand } from "../../../src/application/commands/ICommand";
 
 describe("CommandRegistry", () => {
-  let mockApp: App;
-  let mockPlugin: ExocortexPluginInterface;
-  let mockReloadLayoutCallback: jest.Mock;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    container.clearInstances();
-
-    // Create mock container.resolve
-    const mockServices = {
-      taskCreationService: {},
-      projectCreationService: {},
-      areaCreationService: {},
-      taskStatusService: {},
-      propertyCleanupService: {},
-      folderRepairService: {},
-      supervisionCreationService: {},
-      renameToUidService: {},
-      effortVotingService: {},
-      labelToAliasService: {},
-      assetConversionService: {},
-      fleetingNoteCreationService: {},
-    };
-
-    jest.spyOn(container, "resolve").mockImplementation(() => mockServices as any);
-    jest.spyOn(container, "register").mockImplementation(() => container as any);
-
-    mockApp = {
-      vault: {
-        getMarkdownFiles: jest.fn().mockReturnValue([]),
-        getName: jest.fn().mockReturnValue("Test Vault"),
-      },
-      metadataCache: {
-        getFileCache: jest.fn(),
-      },
-    } as unknown as App;
-
-    mockPlugin = {
-      settings: {
-        currentOntology: null,
-        showLayoutSection: true,
-      },
-      saveSettings: jest.fn(),
-      refreshLayout: jest.fn(),
-    } as unknown as ExocortexPluginInterface;
-
-    mockReloadLayoutCallback = jest.fn();
-  });
-
-  afterEach(() => {
-    container.clearInstances();
+  const createMockCommand = (id: string): ICommand => ({
+    id,
+    name: `Mock ${id}`,
+    callback: jest.fn(),
   });
 
   describe("constructor", () => {
-    it("should create instance without reloadLayoutCallback", () => {
-      const registry = new CommandRegistry(mockApp, mockPlugin);
-
+    it("should create instance with empty commands array", () => {
+      const registry = new CommandRegistry([]);
       expect(registry).toBeInstanceOf(CommandRegistry);
     });
 
-    it("should create instance with reloadLayoutCallback", () => {
-      const registry = new CommandRegistry(mockApp, mockPlugin, mockReloadLayoutCallback);
-
+    it("should create instance with global commands", () => {
+      const commands = [createMockCommand("cmd1"), createMockCommand("cmd2")];
+      const registry = new CommandRegistry(commands);
       expect(registry).toBeInstanceOf(CommandRegistry);
-    });
-
-    it("should register IVaultAdapter with DI container", () => {
-      new CommandRegistry(mockApp, mockPlugin);
-
-      expect(container.register).toHaveBeenCalled();
     });
   });
 
   describe("getAllCommands", () => {
-    it("should return array of commands", () => {
-      const registry = new CommandRegistry(mockApp, mockPlugin);
-      const commands = registry.getAllCommands();
+    it("should return global commands", () => {
+      const commands = [createMockCommand("cmd1"), createMockCommand("cmd2")];
+      const registry = new CommandRegistry(commands);
 
-      expect(Array.isArray(commands)).toBe(true);
-    });
-
-    it("should return correct number of commands", () => {
-      const registry = new CommandRegistry(mockApp, mockPlugin);
-      const commands = registry.getAllCommands();
-
-      // 36 commands are registered (including CopyFleetingNoteLabelCommand)
-      expect(commands.length).toBe(34);
+      expect(registry.getAllCommands()).toEqual(commands);
     });
 
     it("should return same array on multiple calls", () => {
-      const registry = new CommandRegistry(mockApp, mockPlugin);
-      const commands1 = registry.getAllCommands();
-      const commands2 = registry.getAllCommands();
+      const commands = [createMockCommand("cmd1")];
+      const registry = new CommandRegistry(commands);
 
-      expect(commands1).toBe(commands2);
+      expect(registry.getAllCommands()).toBe(registry.getAllCommands());
     });
   });
 
-  describe("command types", () => {
-    it("should include creation commands", () => {
-      const registry = new CommandRegistry(mockApp, mockPlugin);
-      const commands = registry.getAllCommands();
+  describe("getGlobalCommands", () => {
+    it("should return same commands as getAllCommands", () => {
+      const commands = [createMockCommand("cmd1")];
+      const registry = new CommandRegistry(commands);
 
-      // All command classes are mocked, so we can't check exact types
-      // but we can verify count
-      expect(commands.length).toBeGreaterThan(0);
+      expect(registry.getGlobalCommands()).toBe(registry.getAllCommands());
+    });
+  });
+
+  describe("getCommandsForAsset", () => {
+    it("should return empty array when no CommandResolver is set", async () => {
+      const registry = new CommandRegistry([]);
+      const result = await registry.getCommandsForAsset("iri", "class");
+      expect(result).toEqual([]);
     });
 
-    it("should include status commands", () => {
-      const registry = new CommandRegistry(mockApp, mockPlugin);
-      const commands = registry.getAllCommands();
+    it("should delegate to CommandResolver when set", async () => {
+      const registry = new CommandRegistry([]);
+      const mockResolved = [
+        { command: { id: "cmd1", name: "Command 1" }, binding: { id: "b1" } },
+      ];
+      const mockResolver = {
+        resolveForAsset: jest.fn().mockResolvedValue(mockResolved),
+        invalidateCache: jest.fn(),
+      };
 
-      // Commands exist
-      expect(commands.length).toBeGreaterThanOrEqual(10);
+      registry.setCommandResolver(mockResolver as any);
+      const result = await registry.getCommandsForAsset("iri", "class", "proto");
+
+      expect(mockResolver.resolveForAsset).toHaveBeenCalledWith("iri", "class", "proto");
+      expect(result).toBe(mockResolved);
     });
+  });
 
-    it("should include toggle commands", () => {
-      const registry = new CommandRegistry(mockApp, mockPlugin);
-      const commands = registry.getAllCommands();
+  describe("setCommandResolver", () => {
+    it("should enable vault-driven command resolution", async () => {
+      const registry = new CommandRegistry([]);
+      const mockResolver = {
+        resolveForAsset: jest.fn().mockResolvedValue([]),
+        invalidateCache: jest.fn(),
+      };
 
-      // Toggle commands included
-      expect(commands.length).toBeGreaterThanOrEqual(20);
+      registry.setCommandResolver(mockResolver as any);
+      await registry.getCommandsForAsset("iri", "class");
+
+      expect(mockResolver.resolveForAsset).toHaveBeenCalled();
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.createCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.createCommands.test.ts
@@ -3,156 +3,55 @@ import {
   CommandManagerTestContext,
 } from "./CommandManager.fixtures";
 
-describe("CommandManager - create commands", () => {
+describe("CommandManager - create commands (vault-driven)", () => {
   let ctx: CommandManagerTestContext;
 
   beforeEach(() => {
     ctx = setupCommandManagerTest();
   });
 
-  describe("Create Task Command", () => {
+  describe("Global create commands", () => {
     beforeEach(() => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
     });
 
-    it("should be visible for Area class", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Area]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-task");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
+    it("should register create-fleeting-note as global command", () => {
+      const command = ctx.registeredCommands.get("create-fleeting-note");
+      expect(command).toBeDefined();
+      expect(typeof command.callback).toBe("function");
     });
 
-    it("should be visible for Project class", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Project]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-task");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for Task class", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-task");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-
-    it("should be visible even for archived Area", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Area]]",
-          exo__Asset_isArchived: true,
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-task");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
+    it("should register create-asset as global command", () => {
+      const command = ctx.registeredCommands.get("create-asset");
+      expect(command).toBeDefined();
+      expect(typeof command.callback).toBe("function");
     });
   });
 
-  describe("Create Project Command", () => {
-    beforeEach(() => {
+  describe("Per-asset create commands are now vault-driven", () => {
+    it("should NOT register create-task statically (moved to vault)", () => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
+      expect(ctx.registeredCommands.has("create-task")).toBe(false);
     });
 
-    it("should be visible for Area class", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Area]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-project");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should be visible for Project class", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Project]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-project");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-  });
-
-  describe("Create Instance Command", () => {
-    beforeEach(() => {
+    it("should NOT register create-project statically (moved to vault)", () => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
+      expect(ctx.registeredCommands.has("create-project")).toBe(false);
     });
 
-    it("should be visible for Task Prototype class", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__TaskPrototype]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-instance");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for Task class", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-instance");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Create Related Task Command", () => {
-    beforeEach(() => {
+    it("should NOT register create-area statically (moved to vault)", () => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
+      expect(ctx.registeredCommands.has("create-area")).toBe(false);
     });
 
-    it("should be visible for Task class", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-related-task");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
+    it("should NOT register create-instance statically (moved to vault)", () => {
+      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
+      expect(ctx.registeredCommands.has("create-instance")).toBe(false);
     });
 
-    it("should not be visible for archived Task", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          exo__Asset_isArchived: true,
-        },
-      });
-
-      const command = ctx.registeredCommands.get("create-related-task");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
+    it("should NOT register create-related-task statically (moved to vault)", () => {
+      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
+      expect(ctx.registeredCommands.has("create-related-task")).toBe(false);
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.errorHandling.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.errorHandling.test.ts
@@ -1,383 +1,53 @@
 import {
   setupCommandManagerTest,
   CommandManagerTestContext,
-  TFile,
   Notice,
-  flushPromises,
 } from "./CommandManager.fixtures";
 
-describe("CommandManager - error handling", () => {
+describe("CommandManager - error handling (global commands)", () => {
   let ctx: CommandManagerTestContext;
 
   beforeEach(() => {
     ctx = setupCommandManagerTest();
   });
 
-  describe("Command Execution - Error Handling", () => {
+  describe("Reload Layout without callback", () => {
+    it("should show failure notice when callback is not set", () => {
+      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
+
+      const command = ctx.registeredCommands.get("reload-layout");
+      command.callback();
+
+      expect(Notice).toHaveBeenCalledWith("Failed to reload layout");
+    });
+  });
+
+  describe("Global commands handle errors gracefully", () => {
     beforeEach(() => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
     });
 
-    it("should handle errors in set draft status execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
+    it("should handle toggle-layout-visibility when saveSettings rejects", async () => {
+      ctx.mockPlugin.saveSettings.mockRejectedValueOnce(new Error("Save failed"));
+      const command = ctx.registeredCommands.get("toggle-layout-visibility");
 
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("set-draft-status");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to set draft status"),
-      );
+      await expect(command.callback()).rejects.toThrow("Save failed");
     });
 
-    it("should handle errors in move to backlog execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDraft",
-        },
-      });
+    it("should handle toggle-archived-assets when saveSettings rejects", async () => {
+      ctx.mockPlugin.saveSettings.mockRejectedValueOnce(new Error("Save failed"));
+      const command = ctx.registeredCommands.get("toggle-archived-assets-visibility");
 
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("move-to-backlog");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to move to backlog"),
-      );
+      await expect(command.callback()).rejects.toThrow("Save failed");
     });
-
-    it("should handle errors in move to analysis execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Project]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("move-to-analysis");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to move to analysis"),
-      );
-    });
-
-    it("should handle errors in move to todo execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Project]]",
-          ems__Effort_status: "ems__EffortStatusAnalysis",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("move-to-todo");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to move to todo"),
-      );
-    });
-
-    it("should handle errors in start effort execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("start-effort");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to start effort"),
-      );
-    });
-
-    it("should handle errors in plan on today execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusToDo",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("plan-on-today");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to plan on today"),
-      );
-    });
-
-    it("should handle errors in plan for evening execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("plan-for-evening");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to plan for evening"),
-      );
-    });
-
-    it("should handle errors in shift day backward execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_plannedStartTimestamp: "2025-01-20T00:00:00",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("shift-day-backward");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to shift day backward"),
-      );
-    });
-
-    it("should handle errors in shift day forward execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_plannedStartTimestamp: "2025-01-20T00:00:00",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("shift-day-forward");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to shift day forward"),
-      );
-    });
-
-    it("should handle errors in mark done execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDoing",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("mark-done");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to mark as done"),
-      );
-    });
-
-    // Skip: TrashEffortCommand requires modal which uses path alias (@plugin/...)
-    // that Jest's moduleNameMapper doesn't resolve correctly for mock paths.
-    // The command is fully tested in TrashEffortCommand.test.ts
-    it.skip("should handle errors in trash effort execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("trash-effort");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to trash effort"),
-      );
-    });
-
-    it("should handle errors in archive task execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDone",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("archive-task");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to archive task"),
-      );
-    });
-
-    it("should handle errors in clean properties execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          empty_prop: "",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("clean-properties");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to clean properties"),
-      );
-    });
-
-    it("should handle errors in repair folder execution", async () => {
-      ctx.mockFile = {
-        basename: "test-file",
-        path: "wrong-folder/test-file.md",
-        parent: { path: "wrong-folder" },
-      } as unknown as TFile;
-      ctx.mockApp.workspace.getActiveFile.mockReturnValue(ctx.mockFile);
-
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_isDefinedBy: "[[test-area]]",
-        },
-      });
-
-      const mockArea = {
-        path: "correct-folder/test-area.md",
-        parent: { path: "correct-folder" },
-      };
-      ctx.mockApp.metadataCache.getFirstLinkpathDest = jest
-        .fn()
-        .mockReturnValue(mockArea);
-
-      ctx.mockApp.vault.rename = jest
-        .fn()
-        .mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("repair-folder");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to repair folder"),
-      );
-    });
-
-    it("should handle errors in rename to uid execution", async () => {
-      ctx.mockFile = {
-        basename: "wrong-name",
-        path: "test/wrong-name.md",
-        parent: { path: "test" },
-      } as unknown as TFile;
-      ctx.mockApp.workspace.getActiveFile.mockReturnValue(ctx.mockFile);
-
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_uid: "correct-uid",
-        },
-      });
-
-      ctx.mockApp.fileManager.renameFile = jest
-        .fn()
-        .mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("rename-to-uid");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to rename"),
-      );
-    });
-
-    it("should handle errors in vote on effort execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("vote-on-effort");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to vote"),
-      );
-    });
-
-    it("should handle errors in copy label to aliases execution", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_label: "Test Label",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockRejectedValue(new Error("Vault error"));
-
-      const command = ctx.registeredCommands.get("copy-label-to-aliases");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to copy label"),
-      );
+  });
+
+  describe("Per-asset error handling is now vault-driven", () => {
+    it("should not have per-asset commands to test error handling on", () => {
+      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
+      expect(ctx.registeredCommands.has("start-effort")).toBe(false);
+      expect(ctx.registeredCommands.has("mark-done")).toBe(false);
+      expect(ctx.registeredCommands.has("trash-effort")).toBe(false);
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.maintenanceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.maintenanceCommands.test.ts
@@ -1,244 +1,49 @@
 import {
   setupCommandManagerTest,
   CommandManagerTestContext,
-  TFile,
 } from "./CommandManager.fixtures";
 
-describe("CommandManager - maintenance commands", () => {
+describe("CommandManager - maintenance commands (vault-driven)", () => {
   let ctx: CommandManagerTestContext;
 
   beforeEach(() => {
     ctx = setupCommandManagerTest();
   });
 
-  describe("Archive Task Command", () => {
+  const vaultDrivenMaintenanceCommands = [
+    "clean-properties",
+    "repair-folder",
+    "rename-to-uid",
+    "vote-on-effort",
+    "copy-label-to-aliases",
+    "add-supervision",
+  ];
+
+  describe("Maintenance commands are now vault-driven via CommandResolver", () => {
     beforeEach(() => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
     });
 
-    it("should be visible for Task with Done status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDone",
-        },
+    vaultDrivenMaintenanceCommands.forEach((commandId) => {
+      it(`should NOT register ${commandId} statically (moved to vault)`, () => {
+        expect(ctx.registeredCommands.has(commandId)).toBe(false);
       });
-
-      const command = ctx.registeredCommands.get("archive-task");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for archived Task", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDone",
-          exo__Asset_isArchived: true,
-        },
-      });
-
-      const command = ctx.registeredCommands.get("archive-task");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
     });
   });
 
-  describe("Clean Properties Command", () => {
+  describe("Global maintenance commands still registered", () => {
     beforeEach(() => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
     });
 
-    it("should be visible for file with empty properties", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          empty_prop: "",
-          null_prop: null,
-        },
-      });
-
-      const command = ctx.registeredCommands.get("clean-properties");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
+    it("should register edit-properties as global command", () => {
+      const command = ctx.registeredCommands.get("edit-properties");
+      expect(command).toBeDefined();
     });
 
-    it("should not be visible for file without empty properties", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("clean-properties");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-
-    it("should not be visible for file without frontmatter", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: null,
-      });
-
-      const command = ctx.registeredCommands.get("clean-properties");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Repair Folder Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for file with isDefinedBy property", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_isDefinedBy: "[[ems__Area]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("repair-folder");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for file without isDefinedBy property", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {},
-      });
-
-      const command = ctx.registeredCommands.get("repair-folder");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Rename To UID Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible when filename differs from UID", () => {
-      ctx.mockFile = {
-        basename: "wrong-name",
-        path: "test/wrong-name.md",
-        parent: { path: "test" },
-      } as unknown as TFile;
-      ctx.mockApp.workspace.getActiveFile.mockReturnValue(ctx.mockFile);
-
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_uid: "correct-uid",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("rename-to-uid");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible when filename matches UID", () => {
-      ctx.mockFile = {
-        basename: "matching-uid",
-        path: "test/matching-uid.md",
-        parent: { path: "test" },
-      } as unknown as TFile;
-      ctx.mockApp.workspace.getActiveFile.mockReturnValue(ctx.mockFile);
-
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_uid: "matching-uid",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("rename-to-uid");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Vote On Effort Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for non-archived Task", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("vote-on-effort");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for archived Task", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          exo__Asset_isArchived: true,
-        },
-      });
-
-      const command = ctx.registeredCommands.get("vote-on-effort");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Copy Label To Aliases Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for file with label", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_label: "Test Label",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("copy-label-to-aliases");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for file without label", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {},
-      });
-
-      const command = ctx.registeredCommands.get("copy-label-to-aliases");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-
-    it("should not be visible for file with empty label", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_label: "",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("copy-label-to-aliases");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-
-    it("should be visible when label not in aliases", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_label: "Test Label",
-          aliases: ["Other Alias"],
-        },
-      });
-
-      const command = ctx.registeredCommands.get("copy-label-to-aliases");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
+    it("should register open-sparql-query-builder as global command", () => {
+      const command = ctx.registeredCommands.get("open-sparql-query-builder");
+      expect(command).toBeDefined();
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.registration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.registration.test.ts
@@ -41,10 +41,10 @@ describe("CommandManager - registration", () => {
         ctx.commandManager.registerAllCommands(ctx.mockPlugin);
       }).not.toThrow();
 
-      expect(ctx.mockPlugin.addCommand).toHaveBeenCalledTimes(34);
+      expect(ctx.mockPlugin.addCommand).toHaveBeenCalledTimes(7);
     });
 
-    it("should register commands with correct IDs", () => {
+    it("should register global commands with correct IDs", () => {
       const registeredCommandIds: string[] = [];
       ctx.mockPlugin.addCommand = jest.fn((command: any) => {
         registeredCommandIds.push(command.id);
@@ -52,74 +52,13 @@ describe("CommandManager - registration", () => {
 
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
 
-      expect(registeredCommandIds).toContain("create-task");
-      expect(registeredCommandIds).toContain("create-project");
-      expect(registeredCommandIds).toContain("create-area");
-      expect(registeredCommandIds).toContain("create-instance");
-      expect(registeredCommandIds).toContain("create-fleeting-note");
-      expect(registeredCommandIds).toContain("create-related-task");
-      expect(registeredCommandIds).toContain("set-draft-status");
-      expect(registeredCommandIds).toContain("move-to-backlog");
-      expect(registeredCommandIds).toContain("move-to-analysis");
-      expect(registeredCommandIds).toContain("move-to-todo");
-      expect(registeredCommandIds).toContain("start-effort");
-      expect(registeredCommandIds).toContain("plan-on-today");
-      expect(registeredCommandIds).toContain("plan-for-evening");
-      expect(registeredCommandIds).toContain("shift-day-backward");
-      expect(registeredCommandIds).toContain("shift-day-forward");
-      expect(registeredCommandIds).toContain("mark-done");
-      expect(registeredCommandIds).toContain("trash-effort");
-      expect(registeredCommandIds).toContain("archive-task");
-      expect(registeredCommandIds).toContain("clean-properties");
-      expect(registeredCommandIds).toContain("repair-folder");
-      expect(registeredCommandIds).toContain("rename-to-uid");
-      expect(registeredCommandIds).toContain("vote-on-effort");
-      expect(registeredCommandIds).toContain("copy-label-to-aliases");
       expect(registeredCommandIds).toContain("reload-layout");
-      expect(registeredCommandIds).toContain("add-supervision");
       expect(registeredCommandIds).toContain("toggle-layout-visibility");
-      expect(registeredCommandIds).toContain(
-        "toggle-archived-assets-visibility",
-      );
+      expect(registeredCommandIds).toContain("toggle-archived-assets-visibility");
       expect(registeredCommandIds).toContain("open-sparql-query-builder");
-    });
-
-    it("should register commands with correct names", () => {
-      const registeredNames: string[] = [];
-      ctx.mockPlugin.addCommand = jest.fn((command: any) => {
-        registeredNames.push(command.name);
-      });
-
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-
-      expect(registeredNames).toContain("Create task");
-      expect(registeredNames).toContain("Create project");
-      expect(registeredNames).toContain("Create area");
-      expect(registeredNames).toContain("Create instance");
-      expect(registeredNames).toContain("Create fleeting note");
-      expect(registeredNames).toContain("Create related task");
-      expect(registeredNames).toContain("Set draft status");
-      expect(registeredNames).toContain("Move to backlog");
-      expect(registeredNames).toContain("Move to analysis");
-      expect(registeredNames).toContain("Move to to-do");
-      expect(registeredNames).toContain("Start effort");
-      expect(registeredNames).toContain("Plan on today");
-      expect(registeredNames).toContain("Plan for evening (19:00)");
-      expect(registeredNames).toContain("Shift day backward");
-      expect(registeredNames).toContain("Shift day forward");
-      expect(registeredNames).toContain("Mark as done");
-      expect(registeredNames).toContain("Trash");
-      expect(registeredNames).toContain("Archive task");
-      expect(registeredNames).toContain("Clean empty properties");
-      expect(registeredNames).toContain("Repair folder");
-      expect(registeredNames).toContain("Rename to uid");
-      expect(registeredNames).toContain("Vote on effort");
-      expect(registeredNames).toContain("Copy label to aliases");
-      expect(registeredNames).toContain("Reload layout");
-      expect(registeredNames).toContain("Add supervision");
-      expect(registeredNames).toContain("Toggle layout visibility");
-      expect(registeredNames).toContain("Toggle archived assets visibility");
-      expect(registeredNames).toContain("open sparql query builder");
+      expect(registeredCommandIds).toContain("edit-properties");
+      expect(registeredCommandIds).toContain("create-asset");
+      expect(registeredCommandIds).toContain("create-fleeting-note");
     });
 
     it("should register commands with checkCallback or callback function", () => {
@@ -147,47 +86,6 @@ describe("CommandManager - registration", () => {
 
       reloadCommand.callback();
       expect(mockCallback).toHaveBeenCalled();
-    });
-  });
-
-  describe("Command Visibility - No Active File", () => {
-    beforeEach(() => {
-      ctx.mockApp.workspace.getActiveFile.mockReturnValue(null);
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    const checkCallbackCommands = [
-      "create-task",
-      "create-project",
-      "create-area",
-      "create-instance",
-      "create-related-task",
-      "set-draft-status",
-      "move-to-backlog",
-      "move-to-analysis",
-      "move-to-todo",
-      "start-effort",
-      "plan-on-today",
-      "plan-for-evening",
-      "shift-day-backward",
-      "shift-day-forward",
-      "mark-done",
-      "trash-effort",
-      "archive-task",
-      "clean-properties",
-      "repair-folder",
-      "rename-to-uid",
-      "vote-on-effort",
-      "copy-label-to-aliases",
-    ];
-
-    checkCallbackCommands.forEach((commandId) => {
-      it(`should return false for ${commandId} when no active file`, () => {
-        const command = ctx.registeredCommands.get(commandId);
-        expect(command).toBeDefined();
-        const result = command.checkCallback(true);
-        expect(result).toBe(false);
-      });
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.statusCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.statusCommands.test.ts
@@ -3,294 +3,38 @@ import {
   CommandManagerTestContext,
 } from "./CommandManager.fixtures";
 
-describe("CommandManager - status commands", () => {
+describe("CommandManager - status commands (vault-driven)", () => {
   let ctx: CommandManagerTestContext;
 
   beforeEach(() => {
     ctx = setupCommandManagerTest();
   });
 
-  describe("Set Draft Status Command", () => {
+  const vaultDrivenStatusCommands = [
+    "set-draft-status",
+    "move-to-backlog",
+    "move-to-analysis",
+    "move-to-todo",
+    "start-effort",
+    "plan-on-today",
+    "plan-for-evening",
+    "shift-day-backward",
+    "shift-day-forward",
+    "mark-done",
+    "mark-reviewed",
+    "trash-effort",
+    "archive-task",
+  ];
+
+  describe("Status commands are now vault-driven via CommandResolver", () => {
     beforeEach(() => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
     });
 
-    it("should be visible for Task without status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
+    vaultDrivenStatusCommands.forEach((commandId) => {
+      it(`should NOT register ${commandId} statically (moved to vault)`, () => {
+        expect(ctx.registeredCommands.has(commandId)).toBe(false);
       });
-
-      const command = ctx.registeredCommands.get("set-draft-status");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for Task with Draft status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDraft",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("set-draft-status");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Move To Backlog Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Task with Draft status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDraft",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("move-to-backlog");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for Task with Backlog status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("move-to-backlog");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Move To Analysis Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Project with Backlog status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Project]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("move-to-analysis");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-  });
-
-  describe("Move To ToDo Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Project with Analysis status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Project]]",
-          ems__Effort_status: "ems__EffortStatusAnalysis",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("move-to-todo");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-  });
-
-  describe("Start Effort Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Task with Backlog status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("start-effort");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for Task with In Progress status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDoing",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("start-effort");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Plan On Today Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Task with ToDo status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusToDo",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("plan-on-today");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-  });
-
-  describe("Plan For Evening Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Task with Backlog status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("plan-for-evening");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-  });
-
-  describe("Shift Day Backward Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Task with effort day", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_plannedStartTimestamp: "2025-01-20T00:00:00",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("shift-day-backward");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for Task without effort day", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("shift-day-backward");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Shift Day Forward Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Task with effort day", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_plannedStartTimestamp: "2025-01-20T00:00:00",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("shift-day-forward");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-  });
-
-  describe("Mark Done Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Task with In Progress status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDoing",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("mark-done");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for Task with Done status", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDone",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("mark-done");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
-    });
-  });
-
-  describe("Trash Effort Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be visible for Task not trashed", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("trash-effort");
-      const result = command.checkCallback(true);
-      expect(result).toBe(true);
-    });
-
-    it("should not be visible for trashed Task", () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusTrashed",
-        },
-      });
-
-      const command = ctx.registeredCommands.get("trash-effort");
-      const result = command.checkCallback(true);
-      expect(result).toBe(false);
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.successPaths.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.successPaths.test.ts
@@ -1,389 +1,62 @@
 import {
   setupCommandManagerTest,
   CommandManagerTestContext,
-  TFile,
   Notice,
-  flushPromises,
 } from "./CommandManager.fixtures";
 
-describe("CommandManager - success paths", () => {
+describe("CommandManager - success paths (global commands)", () => {
   let ctx: CommandManagerTestContext;
 
   beforeEach(() => {
     ctx = setupCommandManagerTest();
   });
 
-  describe("Command Execution - Repair Folder Special Cases", () => {
+  describe("Global command execution", () => {
     beforeEach(() => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
     });
 
-    it("should handle repair folder when no expected folder found", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_isDefinedBy: "[[ems__NonExistent]]",
-        },
-      });
+    it("should execute reload-layout successfully", () => {
+      const mockCallback = jest.fn();
+      ctx.commandManager.registerAllCommands(ctx.mockPlugin, mockCallback);
 
-      ctx.mockApp.metadataCache.getFirstLinkpathDest = jest
-        .fn()
-        .mockReturnValue(null);
+      const command = ctx.registeredCommands.get("reload-layout");
+      command.callback();
 
-      const command = ctx.registeredCommands.get("repair-folder");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith("No expected folder found");
+      expect(mockCallback).toHaveBeenCalled();
+      expect(Notice).toHaveBeenCalledWith("Layout reloaded");
     });
 
-    it("should handle repair folder when already in correct folder", async () => {
-      ctx.mockFile = {
-        basename: "test-file",
-        path: "correct-folder/test-file.md",
-        parent: { path: "correct-folder" },
-      } as unknown as TFile;
-      ctx.mockApp.workspace.getActiveFile.mockReturnValue(ctx.mockFile);
+    it("should execute toggle-layout-visibility successfully", async () => {
+      const command = ctx.registeredCommands.get("toggle-layout-visibility");
+      await command.callback();
 
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_isDefinedBy: "[[test-area]]",
-        },
-      });
+      expect(ctx.mockPlugin.saveSettings).toHaveBeenCalled();
+      expect(ctx.mockPlugin.refreshLayout).toHaveBeenCalled();
+    });
 
-      const mockArea = {
-        path: "correct-folder/test-area.md",
-        parent: { path: "correct-folder" },
-      };
-      ctx.mockApp.metadataCache.getFirstLinkpathDest = jest
-        .fn()
-        .mockReturnValue(mockArea);
+    it("should execute toggle-archived-assets-visibility successfully", async () => {
+      const command = ctx.registeredCommands.get("toggle-archived-assets-visibility");
+      await command.callback();
 
-      const command = ctx.registeredCommands.get("repair-folder");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith("Asset is already in correct folder");
+      expect(ctx.mockPlugin.saveSettings).toHaveBeenCalled();
+      expect(ctx.mockPlugin.refreshLayout).toHaveBeenCalled();
     });
   });
 
-  describe("Command Execution - Success Paths", () => {
-    beforeEach(() => {
+  describe("Per-asset success paths are now vault-driven", () => {
+    it("should have no per-asset commands registered statically", () => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-      jest.clearAllMocks();
-    });
 
-    it("should execute set draft status successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
+      const perAssetIds = [
+        "create-task", "create-project", "create-area",
+        "set-draft-status", "move-to-backlog", "start-effort",
+        "mark-done", "trash-effort",
+      ];
+
+      perAssetIds.forEach((id) => {
+        expect(ctx.registeredCommands.has(id)).toBe(false);
       });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("set-draft-status");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Draft status"),
-      );
-    });
-
-    it("should execute move to backlog successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDraft",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("move-to-backlog");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(expect.stringContaining("Backlog"));
-    });
-
-    it("should execute move to analysis successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Project]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("move-to-analysis");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(expect.stringContaining("Analysis"));
-    });
-
-    it("should execute move to todo successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Project]]",
-          ems__Effort_status: "ems__EffortStatusAnalysis",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("move-to-todo");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(expect.stringContaining("ToDo"));
-    });
-
-    it("should execute start effort successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("start-effort");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Started effort"),
-      );
-    });
-
-    it("should execute plan on today successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusToDo",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("plan-on-today");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Planned on today"),
-      );
-    });
-
-    it("should execute plan for evening successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusBacklog",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("plan-for-evening");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Planned for evening"),
-      );
-    });
-
-    it("should execute shift day backward successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_plannedStartTimestamp: "2025-01-20T00:00:00",
-        },
-      });
-
-      ctx.mockApp.vault.read.mockResolvedValue(
-        "---\nems__Effort_plannedStartTimestamp: 2025-01-20T00:00:00\n---",
-      );
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("shift-day-backward");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Day shifted backward"),
-      );
-    });
-
-    it("should execute shift day forward successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_plannedStartTimestamp: "2025-01-20T00:00:00",
-        },
-      });
-
-      ctx.mockApp.vault.read.mockResolvedValue(
-        "---\nems__Effort_plannedStartTimestamp: 2025-01-20T00:00:00\n---",
-      );
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("shift-day-forward");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Day shifted forward"),
-      );
-    });
-
-    it("should execute mark done successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDoing",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("mark-done");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Marked as done"),
-      );
-    });
-
-    // Skip: TrashEffortCommand requires modal which uses path alias (@plugin/...)
-    // that Jest's moduleNameMapper doesn't resolve correctly for mock paths.
-    // The command is fully tested in TrashEffortCommand.test.ts
-    it.skip("should execute trash effort successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("trash-effort");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(Notice).toHaveBeenCalledWith(expect.stringContaining("Trashed"));
-    });
-
-    it("should execute archive task successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_status: "ems__EffortStatusDone",
-        },
-      });
-
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("archive-task");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(expect.stringContaining("Archived"));
-    });
-
-    it("should execute clean properties successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          empty_prop: "",
-        },
-      });
-
-      ctx.mockApp.vault.read.mockResolvedValue('---\nempty_prop: ""\n---');
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("clean-properties");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Cleaned empty properties"),
-      );
-    });
-
-    it("should execute vote on effort successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Instance_class: "[[ems__Task]]",
-          ems__Effort_votes: 5,
-        },
-      });
-
-      ctx.mockApp.vault.read.mockResolvedValue("---\nems__Effort_votes: 5\n---");
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("vote-on-effort");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(expect.stringContaining("Voted"));
-    });
-
-    it("should execute copy label to aliases successfully", async () => {
-      ctx.mockApp.metadataCache.getFileCache.mockReturnValue({
-        frontmatter: {
-          exo__Asset_label: "Test Label",
-        },
-      });
-
-      ctx.mockApp.vault.read.mockResolvedValue(
-        "---\nexo__Asset_label: Test Label\n---",
-      );
-      ctx.mockApp.vault.modify.mockResolvedValue(undefined);
-
-      const command = ctx.registeredCommands.get("copy-label-to-aliases");
-      await command.checkCallback(false);
-
-      await flushPromises();
-
-      expect(ctx.mockApp.vault.modify).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Label copied to aliases"),
-      );
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.toggleCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.toggleCommands.test.ts
@@ -43,18 +43,6 @@ describe("CommandManager - toggle commands", () => {
     });
   });
 
-  describe("Add Supervision Command", () => {
-    beforeEach(() => {
-      ctx.commandManager.registerAllCommands(ctx.mockPlugin);
-    });
-
-    it("should be always available", () => {
-      const command = ctx.registeredCommands.get("add-supervision");
-      expect(command).toBeDefined();
-      expect(typeof command.callback).toBe("function");
-    });
-  });
-
   describe("Toggle Layout Visibility Command", () => {
     beforeEach(() => {
       ctx.commandManager.registerAllCommands(ctx.mockPlugin);


### PR DESCRIPTION
## Summary
- Remove all 27 per-asset static command registrations from CommandRegistry, keeping only 7 global UI commands
- CommandRegistry reduced from 147 LOC to 37 LOC (75% reduction)
- New `getCommandsForAsset()` method delegates entirely to `CommandResolver.resolveForAsset()`
- DI bootstrap and global command construction moved to CommandManager
- Tests updated: 218 suites passing, 4553 tests passing

## Changes
- `CommandRegistry.ts` — now a thin facade accepting pre-built ICommand[] and delegating to CommandResolver
- `CommandManager.ts` — owns DI setup and global command instantiation
- 7 test files updated to verify vault-driven command path

## Test plan
- [x] All 218 obsidian-plugin test suites pass
- [x] All 6800 core tests pass
- [x] TypeScript typecheck clean
- [x] BDD coverage 100%
- [x] Archgate compliance pass
- [x] LOC reduction: 75% (147 → 37)

Closes #2517