### PR TITLE
feat(plugin): exoql code block processor alias (#2519)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -191,6 +191,11 @@ export default class ExocortexPlugin extends Plugin {
       );
 
       this.registerMarkdownCodeBlockProcessor(
+        "exoql",
+        (source, el, ctx) => this.sparqlProcessor.process(source, el, ctx)
+      );
+
+      this.registerMarkdownCodeBlockProcessor(
         "exo-layout",
         (source, el, ctx) => this.layoutProcessor.process(source, el, ctx)
       );

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -206,6 +206,10 @@ describe("ExocortexPlugin", () => {
         "sparql",
         expect.any(Function)
       );
+      expect(plugin.registerMarkdownCodeBlockProcessor).toHaveBeenCalledWith(
+        "exoql",
+        expect.any(Function)
+      );
       // 10 - 4 semantic search file events (create, modify, delete, rename) = 6 + 1 PrintNameRuleService refresh = 7
       expect(plugin.registerEvent).toHaveBeenCalledTimes(7);
       expect(mockLogger.info).toHaveBeenCalledWith("Exocortex Plugin loaded successfully");
@@ -1233,6 +1237,34 @@ describe("ExocortexPlugin", () => {
       const processorFn = processorCall[1];
 
       // Test that it calls the SPARQL processor
+      const source = "SELECT * WHERE { ?s ?p ?o }";
+      const el = document.createElement("div");
+      const ctx = {} as any;
+
+      // Act
+      processorFn(source, el, ctx);
+
+      // Assert
+      expect(mockSparqlProcessor.process).toHaveBeenCalledWith(source, el, ctx);
+    });
+
+    it("should register exoql code block processor as alias for SPARQL", async () => {
+      // Arrange
+      await plugin.onload();
+
+      // Assert
+      expect(plugin.registerMarkdownCodeBlockProcessor).toHaveBeenCalledWith(
+        "exoql",
+        expect.any(Function)
+      );
+
+      // Find the exoql processor call
+      const calls = (plugin.registerMarkdownCodeBlockProcessor as jest.Mock).mock.calls;
+      const exoqlCall = calls.find((c: any[]) => c[0] === "exoql");
+      expect(exoqlCall).toBeDefined();
+      const processorFn = exoqlCall![1];
+
+      // Test that it calls the same SPARQL processor
       const source = "SELECT * WHERE { ?s ?p ?o }";
       const el = document.createElement("div");
       const ctx = {} as any;


### PR DESCRIPTION
## Summary
- Register `exoql` as a code block processor alias alongside the existing `sparql` processor
- Both ` ```sparql ` and ` ```exoql ` code blocks now invoke the same SPARQL query handler

## Test plan
- [x] Added test verifying `exoql` processor registration in `ExocortexPlugin.test.ts`
- [x] Added test verifying `exoql` delegates to the same `SPARQLCodeBlockProcessor.process()`
- [x] Updated initialization test to assert both `sparql` and `exoql` registrations
- [x] TypeScript typecheck passes
- [x] All 63 ExocortexPlugin tests pass

Closes #2519