### PR TITLE
feat(core): ExoQL public API namespace with clean re-exports

### DIFF
--- a/packages/exocortex/src/exoql/index.ts
+++ b/packages/exocortex/src/exoql/index.ts
@@ -1,0 +1,110 @@
+import type { ITripleStore } from "../interfaces/ITripleStore";
+import type { Triple } from "../domain/models/rdf/Triple";
+import { SPARQLParser } from "../infrastructure/sparql/SPARQLParser";
+import { AlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
+import {
+  QueryExecutor,
+  type QueryExecutorConfig,
+} from "../infrastructure/sparql/executors/QueryExecutor";
+import type { SolutionMapping } from "../infrastructure/sparql/SolutionMapping";
+import type {
+  AskOperation,
+  ConstructOperation,
+} from "../infrastructure/sparql/algebra/AlgebraOperation";
+
+/**
+ * ExoQL  public facade for executing SPARQL queries against a triple store.
+ *
+ * Thin wrapper over the internal SPARQLParser  AlgebraTranslator  QueryExecutor
+ * pipeline, providing a concise three-method API:
+ *
+ * - `query(sparql, store)`      SELECT  SolutionMapping[]
+ * - `ask(sparql, store)`        ASK     boolean
+ * - `construct(sparql, store)`  CONSTRUCT  Triple[]
+ *
+ * All methods accept a raw SPARQL string and an ITripleStore instance.
+ */
+export class ExoQL {
+  /**
+   * Execute a SELECT query and return all solution mappings.
+   *
+   * @param sparql  SPARQL SELECT query string
+   * @param store   Triple store to query against
+   * @param config  Optional QueryExecutor configuration
+   * @returns Array of solution mappings (variable bindings)
+   */
+  static async query(
+    sparql: string,
+    store: ITripleStore,
+    config?: QueryExecutorConfig,
+  ): Promise<SolutionMapping[]> {
+    const { algebra, executor } = ExoQL.prepare(sparql, store, config);
+    return executor.executeAll(algebra);
+  }
+
+  /**
+   * Execute an ASK query and return a boolean result.
+   *
+   * @param sparql  SPARQL ASK query string
+   * @param store   Triple store to query against
+   * @param config  Optional QueryExecutor configuration
+   * @returns true if the pattern has at least one match, false otherwise
+   */
+  static async ask(
+    sparql: string,
+    store: ITripleStore,
+    config?: QueryExecutorConfig,
+  ): Promise<boolean> {
+    const { algebra, executor } = ExoQL.prepare(sparql, store, config);
+    if (!executor.isAskQuery(algebra)) {
+      throw new ExoQLError("ExoQL.ask() requires an ASK query");
+    }
+    return executor.executeAsk(algebra as AskOperation);
+  }
+
+  /**
+   * Execute a CONSTRUCT query and return generated triples.
+   *
+   * @param sparql  SPARQL CONSTRUCT query string
+   * @param store   Triple store to query against
+   * @param config  Optional QueryExecutor configuration
+   * @returns Array of RDF triples produced by the CONSTRUCT template
+   */
+  static async construct(
+    sparql: string,
+    store: ITripleStore,
+    config?: QueryExecutorConfig,
+  ): Promise<Triple[]> {
+    const { algebra, executor } = ExoQL.prepare(sparql, store, config);
+    if (!executor.isConstructQuery(algebra)) {
+      throw new ExoQLError("ExoQL.construct() requires a CONSTRUCT query");
+    }
+    return executor.executeConstruct(algebra as ConstructOperation);
+  }
+
+  /**
+   * Internal: parse SPARQL, translate to algebra, create executor.
+   */
+  private static prepare(
+    sparql: string,
+    store: ITripleStore,
+    config?: QueryExecutorConfig,
+  ) {
+    const parser = new SPARQLParser();
+    const translator = new AlgebraTranslator();
+    const ast = parser.parse(sparql);
+    const algebra = translator.translate(ast);
+    const executor = new QueryExecutor(store, config);
+    return { algebra, executor };
+  }
+}
+
+/**
+ * Error thrown by ExoQL when the query type does not match the method called.
+ */
+export class ExoQLError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExoQLError";
+  }
+}

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -388,6 +388,9 @@ export type {
   LoaderState,
 } from "./infrastructure/memory";
 
+// ExoQL public API
+export { ExoQL, ExoQLError } from "./exoql";
+
 // Error exports
 export * from "./domain/errors";
 export * from "./application/errors";

--- a/packages/exocortex/tests/unit/exoql/ExoQL.test.ts
+++ b/packages/exocortex/tests/unit/exoql/ExoQL.test.ts
@@ -1,0 +1,214 @@
+import { ExoQL, ExoQLError } from "../../../src/exoql";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+
+describe("ExoQL", () => {
+  let store: InMemoryTripleStore;
+
+  const RDF_TYPE = new IRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+  const EX = (local: string) => new IRI(`http://example.org/${local}`);
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+  });
+
+  // ---------------------------------------------------------------
+  // ExoQL.query  (SELECT)
+  // ---------------------------------------------------------------
+  describe("query()", () => {
+    it("returns solution mappings for a basic SELECT", async () => {
+      await store.add(new Triple(EX("task1"), RDF_TYPE, EX("Task")));
+      await store.add(new Triple(EX("task2"), RDF_TYPE, EX("Task")));
+
+      const results = await ExoQL.query(
+        `SELECT ?s WHERE { ?s <${RDF_TYPE.value}> <${EX("Task").value}> }`,
+        store,
+      );
+
+      expect(results).toHaveLength(2);
+      const uris = results.map((r) => (r.get("s") as IRI).value).sort();
+      expect(uris).toEqual([
+        "http://example.org/task1",
+        "http://example.org/task2",
+      ]);
+    });
+
+    it("returns empty array when no matches", async () => {
+      const results = await ExoQL.query(
+        `SELECT ?s WHERE { ?s <${RDF_TYPE.value}> <${EX("Task").value}> }`,
+        store,
+      );
+      expect(results).toEqual([]);
+    });
+
+    it("supports FILTER in SELECT queries", async () => {
+      await store.add(
+        new Triple(EX("task1"), EX("label"), new Literal("Alpha")),
+      );
+      await store.add(
+        new Triple(EX("task2"), EX("label"), new Literal("Beta")),
+      );
+
+      const results = await ExoQL.query(
+        `SELECT ?s ?label WHERE {
+           ?s <${EX("label").value}> ?label .
+           FILTER(?label = "Alpha")
+         }`,
+        store,
+      );
+
+      expect(results).toHaveLength(1);
+      expect((results[0].get("s") as IRI).value).toBe(
+        "http://example.org/task1",
+      );
+    });
+
+    it("supports LIMIT and OFFSET", async () => {
+      for (let i = 1; i <= 5; i++) {
+        await store.add(new Triple(EX(`item${i}`), RDF_TYPE, EX("Item")));
+      }
+
+      const results = await ExoQL.query(
+        `SELECT ?s WHERE { ?s <${RDF_TYPE.value}> <${EX("Item").value}> } LIMIT 2`,
+        store,
+      );
+
+      expect(results).toHaveLength(2);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // ExoQL.ask  (ASK)
+  // ---------------------------------------------------------------
+  describe("ask()", () => {
+    it("returns true when pattern matches", async () => {
+      await store.add(new Triple(EX("task1"), RDF_TYPE, EX("Task")));
+
+      const result = await ExoQL.ask(
+        `ASK WHERE { ?s <${RDF_TYPE.value}> <${EX("Task").value}> }`,
+        store,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when pattern does not match", async () => {
+      const result = await ExoQL.ask(
+        `ASK WHERE { ?s <${RDF_TYPE.value}> <${EX("Task").value}> }`,
+        store,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("throws ExoQLError when called with a SELECT query", async () => {
+      await expect(
+        ExoQL.ask(
+          `SELECT ?s WHERE { ?s <${RDF_TYPE.value}> <${EX("Task").value}> }`,
+          store,
+        ),
+      ).rejects.toThrow(ExoQLError);
+    });
+
+    it("throws ExoQLError with descriptive message for wrong query type", async () => {
+      await expect(
+        ExoQL.ask(
+          `SELECT ?s WHERE { ?s <${RDF_TYPE.value}> <${EX("Task").value}> }`,
+          store,
+        ),
+      ).rejects.toThrow("ExoQL.ask() requires an ASK query");
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // ExoQL.construct  (CONSTRUCT)
+  // ---------------------------------------------------------------
+  describe("construct()", () => {
+    it("returns constructed triples", async () => {
+      await store.add(new Triple(EX("task1"), RDF_TYPE, EX("Task")));
+      await store.add(
+        new Triple(EX("task1"), EX("label"), new Literal("My Task")),
+      );
+
+      const triples = await ExoQL.construct(
+        `CONSTRUCT {
+           ?s <${EX("type").value}> "task" .
+         } WHERE {
+           ?s <${RDF_TYPE.value}> <${EX("Task").value}> .
+         }`,
+        store,
+      );
+
+      expect(triples).toHaveLength(1);
+      expect((triples[0].subject as IRI).value).toBe(
+        "http://example.org/task1",
+      );
+      expect((triples[0].predicate as IRI).value).toBe(
+        "http://example.org/type",
+      );
+    });
+
+    it("returns empty array when WHERE clause has no matches", async () => {
+      const triples = await ExoQL.construct(
+        `CONSTRUCT {
+           ?s <${EX("type").value}> "task" .
+         } WHERE {
+           ?s <${RDF_TYPE.value}> <${EX("Task").value}> .
+         }`,
+        store,
+      );
+
+      expect(triples).toEqual([]);
+    });
+
+    it("throws ExoQLError when called with a SELECT query", async () => {
+      await expect(
+        ExoQL.construct(
+          `SELECT ?s WHERE { ?s <${RDF_TYPE.value}> <${EX("Task").value}> }`,
+          store,
+        ),
+      ).rejects.toThrow(ExoQLError);
+    });
+
+    it("throws ExoQLError with descriptive message for wrong query type", async () => {
+      await expect(
+        ExoQL.construct(
+          `SELECT ?s WHERE { ?s <${RDF_TYPE.value}> <${EX("Task").value}> }`,
+          store,
+        ),
+      ).rejects.toThrow("ExoQL.construct() requires a CONSTRUCT query");
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Error class
+  // ---------------------------------------------------------------
+  describe("ExoQLError", () => {
+    it("has correct name property", () => {
+      const err = new ExoQLError("test");
+      expect(err.name).toBe("ExoQLError");
+    });
+
+    it("is instanceof Error", () => {
+      const err = new ExoQLError("test");
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Re-export verification
+  // ---------------------------------------------------------------
+  describe("re-exports from main index", () => {
+    it("ExoQL is exported from @exocortex/core index", async () => {
+      const mod = await import("../../../src/index");
+      expect(mod.ExoQL).toBe(ExoQL);
+    });
+
+    it("ExoQLError is exported from @exocortex/core index", async () => {
+      const mod = await import("../../../src/index");
+      expect(mod.ExoQLError).toBe(ExoQLError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ExoQL` static class as a thin public facade over the internal SPARQL execution pipeline (`SPARQLParser` -> `AlgebraTranslator` -> `QueryExecutor`)
- Three static methods: `query()` (SELECT), `ask()` (ASK), `construct()` (CONSTRUCT)
- Exported from `@exocortex/core` main entry point alongside `ExoQLError`

## Files Changed (3)

- `packages/exocortex/src/exoql/index.ts` — new ExoQL class + ExoQLError
- `packages/exocortex/src/index.ts` — re-export ExoQL and ExoQLError
- `packages/exocortex/tests/unit/exoql/ExoQL.test.ts` — 16 tests

## Test Plan

- [x] 16 unit tests covering all 3 methods, error cases, and re-export verification
- [x] Build passes with no TypeScript errors
- [x] All pre-commit checks pass (lint, archgate, BDD coverage 100%)

Closes #2521