### PR TITLE
feat(core): own/inherited distinction via hybrid named graphs (#2522)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -215,6 +215,7 @@ export { RDFVocabularyMapper } from "./infrastructure/rdf/RDFVocabularyMapper";
 export { RDFSInferenceEngine } from "./infrastructure/rdf/RDFSInferenceEngine";
 export { NonInheritablePropertyRegistry } from "./services/NonInheritablePropertyRegistry";
 export { PrototypeChainMaterializer, INFERRED_GRAPH } from "./services/PrototypeChainMaterializer";
+export { SourceAnnotator, SOURCE_VARIABLE, type TripleSource } from "./services/SourceAnnotator";
 export { NoteToRDFConverter } from "./services/NoteToRDFConverter";
 
 // SPARQL Engine exports

--- a/packages/exocortex/src/services/SourceAnnotator.ts
+++ b/packages/exocortex/src/services/SourceAnnotator.ts
@@ -1,0 +1,202 @@
+import type { ITripleStore } from "../interfaces/ITripleStore";
+import type { Subject, Predicate, Object as RDFObject } from "../domain/models/rdf/Triple";
+import { Literal } from "../domain/models/rdf/Literal";
+import { IRI } from "../domain/models/rdf/IRI";
+import { SolutionMapping } from "../infrastructure/sparql/SolutionMapping";
+import { INFERRED_GRAPH } from "./PrototypeChainMaterializer";
+
+/**
+ * Source type for triple provenance: own (asserted directly) or inherited (materialized from prototype).
+ */
+export type TripleSource = "own" | "inherited";
+
+/**
+ * The variable name used to annotate solution mappings with source information.
+ */
+export const SOURCE_VARIABLE = "_source";
+
+/**
+ * Annotates SPARQL query results with own/inherited provenance.
+ *
+ * For each solution mapping, checks whether the triple (identified by subject,
+ * predicate, and object bindings) exists in the `exo:inferred` named graph.
+ * If it does, the triple was materialized from a prototype chain and is "inherited".
+ * Otherwise, it was directly asserted and is "own".
+ *
+ * Usage:
+ * ```typescript
+ * const annotator = new SourceAnnotator(tripleStore);
+ * const annotated = await annotator.annotate(solutions, "s", "p", "o");
+ * // Each solution now has a "_source" binding: "own" or "inherited"
+ * ```
+ *
+ * Designed for ExoQL results where users need to distinguish between
+ * properties defined on an asset vs inherited from its prototype.
+ */
+export class SourceAnnotator {
+  constructor(private readonly tripleStore: ITripleStore) {}
+
+  /**
+   * Annotate solution mappings with `_source` binding.
+   *
+   * For each solution, extracts the subject, predicate, and object from the
+   * specified variable names, then checks the `exo:inferred` named graph
+   * to determine provenance.
+   *
+   * @param solutions - Array of solution mappings from query execution
+   * @param subjectVar - Variable name for the subject (without '?' prefix)
+   * @param predicateVar - Variable name for the predicate (without '?' prefix)
+   * @param objectVar - Variable name for the object (without '?' prefix)
+   * @returns New array of annotated solution mappings with `_source` binding
+   */
+  async annotate(
+    solutions: SolutionMapping[],
+    subjectVar: string,
+    predicateVar: string,
+    objectVar: string,
+  ): Promise<SolutionMapping[]> {
+    if (!this.tripleStore.matchInGraph) {
+      // Triple store doesn't support named graphs - all triples are "own"
+      return solutions.map((sol) => {
+        const clone = sol.clone();
+        clone.set(SOURCE_VARIABLE, new Literal("own"));
+        return clone;
+      });
+    }
+
+    const annotated: SolutionMapping[] = [];
+
+    for (const solution of solutions) {
+      const subject = solution.get(subjectVar);
+      const predicate = solution.get(predicateVar);
+      const object = solution.get(objectVar);
+
+      const clone = solution.clone();
+
+      if (!subject || !predicate || !object) {
+        // Missing bindings - cannot determine source, default to "own"
+        clone.set(SOURCE_VARIABLE, new Literal("own"));
+      } else {
+        const source = await this.determineSource(
+          subject as Subject,
+          predicate as Predicate,
+          object as RDFObject,
+        );
+        clone.set(SOURCE_VARIABLE, new Literal(source));
+      }
+
+      annotated.push(clone);
+    }
+
+    return annotated;
+  }
+
+  /**
+   * Annotate a single solution mapping with `_source` binding.
+   *
+   * @param solution - A solution mapping from query execution
+   * @param subjectVar - Variable name for the subject
+   * @param predicateVar - Variable name for the predicate
+   * @param objectVar - Variable name for the object
+   * @returns New annotated solution mapping with `_source` binding
+   */
+  async annotateSingle(
+    solution: SolutionMapping,
+    subjectVar: string,
+    predicateVar: string,
+    objectVar: string,
+  ): Promise<SolutionMapping> {
+    const results = await this.annotate([solution], subjectVar, predicateVar, objectVar);
+    return results[0];
+  }
+
+  /**
+   * Determine whether a specific triple is "own" or "inherited".
+   *
+   * Checks if the triple exists in the `exo:inferred` named graph.
+   * If it does, the triple was materialized from a prototype and is "inherited".
+   * If not, it was directly asserted and is "own".
+   *
+   * @param subject - The triple's subject
+   * @param predicate - The triple's predicate
+   * @param object - The triple's object
+   * @returns "own" or "inherited"
+   */
+  async determineSource(
+    subject: Subject,
+    predicate: Predicate,
+    object: RDFObject,
+  ): Promise<TripleSource> {
+    if (!this.tripleStore.matchInGraph) {
+      return "own";
+    }
+
+    const inferredMatches = await this.tripleStore.matchInGraph(
+      subject,
+      predicate,
+      object,
+      INFERRED_GRAPH,
+    );
+
+    return inferredMatches.length > 0 ? "inherited" : "own";
+  }
+
+  /**
+   * Batch-annotate solutions using a subject-based approach.
+   *
+   * For queries where only the subject is known (not predicate/object),
+   * checks if ANY triple for that subject exists in the inferred graph.
+   * This is useful for queries like `SELECT ?s WHERE { ?s a ems:Task }`.
+   *
+   * @param solutions - Array of solution mappings
+   * @param subjectVar - Variable name for the subject
+   * @returns New array with `_source` binding: "own" if subject has no
+   *          inferred triples, "inherited" if ALL its triples are inferred,
+   *          "mixed" if it has both own and inferred triples
+   */
+  async annotateBySubject(
+    solutions: SolutionMapping[],
+    subjectVar: string,
+  ): Promise<SolutionMapping[]> {
+    if (!this.tripleStore.matchInGraph) {
+      return solutions.map((sol) => {
+        const clone = sol.clone();
+        clone.set(SOURCE_VARIABLE, new Literal("own"));
+        return clone;
+      });
+    }
+
+    const annotated: SolutionMapping[] = [];
+
+    // Cache: subject IRI -> source determination
+    const cache = new Map<string, TripleSource>();
+
+    for (const solution of solutions) {
+      const subject = solution.get(subjectVar);
+      const clone = solution.clone();
+
+      if (!subject || !(subject instanceof IRI)) {
+        clone.set(SOURCE_VARIABLE, new Literal("own"));
+      } else {
+        const cacheKey = subject.value;
+
+        if (!cache.has(cacheKey)) {
+          const inferredTriples = await this.tripleStore.matchInGraph(
+            subject,
+            undefined,
+            undefined,
+            INFERRED_GRAPH,
+          );
+          cache.set(cacheKey, inferredTriples.length > 0 ? "inherited" : "own");
+        }
+
+        const cachedSource = cache.get(cacheKey) ?? "own";
+        clone.set(SOURCE_VARIABLE, new Literal(cachedSource));
+      }
+
+      annotated.push(clone);
+    }
+
+    return annotated;
+  }
+}

--- a/packages/exocortex/tests/unit/services/SourceAnnotator.test.ts
+++ b/packages/exocortex/tests/unit/services/SourceAnnotator.test.ts
@@ -1,0 +1,388 @@
+import { SourceAnnotator, SOURCE_VARIABLE } from "../../../src/services/SourceAnnotator";
+import { INFERRED_GRAPH } from "../../../src/services/PrototypeChainMaterializer";
+import { PrototypeChainMaterializer } from "../../../src/services/PrototypeChainMaterializer";
+import { NonInheritablePropertyRegistry } from "../../../src/services/NonInheritablePropertyRegistry";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { SolutionMapping } from "../../../src/infrastructure/sparql/SolutionMapping";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+describe("SourceAnnotator", () => {
+  let store: InMemoryTripleStore;
+  let annotator: SourceAnnotator;
+
+  // Predicates
+  const prototype = Namespace.EXO.term("Asset_prototype");
+  const assetLabel = Namespace.EXO.term("Asset_label");
+  const assetUid = Namespace.EXO.term("Asset_uid");
+  const effortArea = Namespace.EMS.term("Effort_area");
+  const effortTimeEstimate = Namespace.EMS.term("Effort_timeEstimateMinutes");
+
+  // Subjects
+  const breakfastProto = new IRI("obsidian://vault/Breakfast.md");
+  const breakfastInstance = new IRI("obsidian://vault/Breakfast-2026-04-05.md");
+
+  // Objects
+  const healthArea = new IRI("obsidian://vault/Health.md");
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    annotator = new SourceAnnotator(store);
+  });
+
+  describe("annotate", () => {
+    it("should return 'own' for directly asserted triples", async () => {
+      // Add a triple only to default graph (own)
+      await store.add(new Triple(breakfastInstance, effortArea, healthArea));
+
+      const solution = new SolutionMapping();
+      solution.set("s", breakfastInstance);
+      solution.set("p", effortArea);
+      solution.set("o", healthArea);
+
+      const results = await annotator.annotate([solution], "s", "p", "o");
+
+      expect(results).toHaveLength(1);
+      const source = results[0].get(SOURCE_VARIABLE);
+      expect(source).toBeInstanceOf(Literal);
+      expect((source as Literal).value).toBe("own");
+    });
+
+    it("should return 'inherited' for materialized triples", async () => {
+      // Add triple to both default and inferred graph (materialized)
+      const triple = new Triple(breakfastInstance, effortArea, healthArea);
+      await store.add(triple);
+      await store.addToGraph(triple, INFERRED_GRAPH);
+
+      const solution = new SolutionMapping();
+      solution.set("s", breakfastInstance);
+      solution.set("p", effortArea);
+      solution.set("o", healthArea);
+
+      const results = await annotator.annotate([solution], "s", "p", "o");
+
+      expect(results).toHaveLength(1);
+      const source = results[0].get(SOURCE_VARIABLE);
+      expect(source).toBeInstanceOf(Literal);
+      expect((source as Literal).value).toBe("inherited");
+    });
+
+    it("should handle multiple solutions with mixed sources", async () => {
+      // Own triple
+      await store.add(new Triple(breakfastInstance, assetLabel, new Literal("Breakfast")));
+
+      // Inherited triple
+      const inheritedTriple = new Triple(breakfastInstance, effortArea, healthArea);
+      await store.add(inheritedTriple);
+      await store.addToGraph(inheritedTriple, INFERRED_GRAPH);
+
+      const ownSolution = new SolutionMapping();
+      ownSolution.set("s", breakfastInstance);
+      ownSolution.set("p", assetLabel);
+      ownSolution.set("o", new Literal("Breakfast"));
+
+      const inheritedSolution = new SolutionMapping();
+      inheritedSolution.set("s", breakfastInstance);
+      inheritedSolution.set("p", effortArea);
+      inheritedSolution.set("o", healthArea);
+
+      const results = await annotator.annotate(
+        [ownSolution, inheritedSolution],
+        "s", "p", "o",
+      );
+
+      expect(results).toHaveLength(2);
+      expect((results[0].get(SOURCE_VARIABLE) as Literal).value).toBe("own");
+      expect((results[1].get(SOURCE_VARIABLE) as Literal).value).toBe("inherited");
+    });
+
+    it("should default to 'own' when bindings are missing", async () => {
+      const solution = new SolutionMapping();
+      solution.set("s", breakfastInstance);
+      // Missing "p" and "o"
+
+      const results = await annotator.annotate([solution], "s", "p", "o");
+
+      expect(results).toHaveLength(1);
+      expect((results[0].get(SOURCE_VARIABLE) as Literal).value).toBe("own");
+    });
+
+    it("should preserve existing bindings in annotated results", async () => {
+      await store.add(new Triple(breakfastInstance, effortArea, healthArea));
+
+      const solution = new SolutionMapping();
+      solution.set("s", breakfastInstance);
+      solution.set("p", effortArea);
+      solution.set("o", healthArea);
+      solution.set("extra", new Literal("keep-me"));
+
+      const results = await annotator.annotate([solution], "s", "p", "o");
+
+      expect(results[0].get("s")).toEqual(breakfastInstance);
+      expect(results[0].get("p")).toEqual(effortArea);
+      expect(results[0].get("o")).toEqual(healthArea);
+      expect(results[0].get("extra")).toEqual(new Literal("keep-me"));
+      expect(results[0].has(SOURCE_VARIABLE)).toBe(true);
+    });
+
+    it("should not mutate original solution mappings", async () => {
+      await store.add(new Triple(breakfastInstance, effortArea, healthArea));
+
+      const solution = new SolutionMapping();
+      solution.set("s", breakfastInstance);
+      solution.set("p", effortArea);
+      solution.set("o", healthArea);
+
+      await annotator.annotate([solution], "s", "p", "o");
+
+      // Original should NOT have _source
+      expect(solution.has(SOURCE_VARIABLE)).toBe(false);
+    });
+
+    it("should handle empty solutions array", async () => {
+      const results = await annotator.annotate([], "s", "p", "o");
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("annotateSingle", () => {
+    it("should annotate a single solution mapping", async () => {
+      await store.add(new Triple(breakfastInstance, effortArea, healthArea));
+
+      const solution = new SolutionMapping();
+      solution.set("s", breakfastInstance);
+      solution.set("p", effortArea);
+      solution.set("o", healthArea);
+
+      const result = await annotator.annotateSingle(solution, "s", "p", "o");
+
+      expect((result.get(SOURCE_VARIABLE) as Literal).value).toBe("own");
+    });
+  });
+
+  describe("determineSource", () => {
+    it("should return 'own' when triple is not in inferred graph", async () => {
+      await store.add(new Triple(breakfastInstance, effortArea, healthArea));
+
+      const source = await annotator.determineSource(
+        breakfastInstance,
+        effortArea,
+        healthArea,
+      );
+
+      expect(source).toBe("own");
+    });
+
+    it("should return 'inherited' when triple is in inferred graph", async () => {
+      const triple = new Triple(breakfastInstance, effortArea, healthArea);
+      await store.add(triple);
+      await store.addToGraph(triple, INFERRED_GRAPH);
+
+      const source = await annotator.determineSource(
+        breakfastInstance,
+        effortArea,
+        healthArea,
+      );
+
+      expect(source).toBe("inherited");
+    });
+  });
+
+  describe("annotateBySubject", () => {
+    it("should return 'own' for subjects with no inferred triples", async () => {
+      await store.add(new Triple(breakfastInstance, assetLabel, new Literal("Breakfast")));
+
+      const solution = new SolutionMapping();
+      solution.set("s", breakfastInstance);
+
+      const results = await annotator.annotateBySubject([solution], "s");
+
+      expect(results).toHaveLength(1);
+      expect((results[0].get(SOURCE_VARIABLE) as Literal).value).toBe("own");
+    });
+
+    it("should return 'inherited' for subjects with inferred triples", async () => {
+      const triple = new Triple(breakfastInstance, effortArea, healthArea);
+      await store.add(triple);
+      await store.addToGraph(triple, INFERRED_GRAPH);
+
+      const solution = new SolutionMapping();
+      solution.set("s", breakfastInstance);
+
+      const results = await annotator.annotateBySubject([solution], "s");
+
+      expect(results).toHaveLength(1);
+      expect((results[0].get(SOURCE_VARIABLE) as Literal).value).toBe("inherited");
+    });
+
+    it("should cache subject lookups for performance", async () => {
+      await store.add(new Triple(breakfastInstance, assetLabel, new Literal("Breakfast")));
+
+      const sol1 = new SolutionMapping();
+      sol1.set("s", breakfastInstance);
+      const sol2 = new SolutionMapping();
+      sol2.set("s", breakfastInstance);
+
+      // Spy on matchInGraph
+      const spy = jest.spyOn(store, "matchInGraph");
+
+      await annotator.annotateBySubject([sol1, sol2], "s");
+
+      // Should only call matchInGraph once due to caching
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should default to 'own' for non-IRI subjects", async () => {
+      const solution = new SolutionMapping();
+      solution.set("s", new Literal("not-an-iri"));
+
+      const results = await annotator.annotateBySubject([solution], "s");
+
+      expect((results[0].get(SOURCE_VARIABLE) as Literal).value).toBe("own");
+    });
+  });
+
+  describe("integration with PrototypeChainMaterializer", () => {
+    let materializer: PrototypeChainMaterializer;
+    let registry: NonInheritablePropertyRegistry;
+
+    const nonInheritableClassIRI = new IRI("obsidian://vault/exo__NonInheritableProperty.md");
+    const instanceClass = Namespace.EXO.term("Instance_class");
+
+    beforeEach(async () => {
+      registry = new NonInheritablePropertyRegistry();
+
+      // Setup registry with standard non-inheritable properties
+      const registryStore = new InMemoryTripleStore();
+      await registryStore.add(
+        new Triple(nonInheritableClassIRI, assetLabel, new Literal("exo__NonInheritableProperty")),
+      );
+      for (const propLabel of ["exo__Asset_uid", "exo__Asset_label", "exo__Asset_prototype"]) {
+        const defIRI = new IRI(`obsidian://vault/${propLabel}.md`);
+        await registryStore.add(new Triple(defIRI, instanceClass, nonInheritableClassIRI));
+        await registryStore.add(new Triple(defIRI, assetLabel, new Literal(propLabel)));
+      }
+      await registry.initialize(registryStore);
+
+      materializer = new PrototypeChainMaterializer(registry);
+    });
+
+    it("should correctly distinguish own vs inherited after materialization", async () => {
+      // Setup prototype with inheritable property
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+      await store.add(new Triple(breakfastProto, effortTimeEstimate, new Literal("15")));
+      await store.add(new Triple(breakfastProto, assetLabel, new Literal("Breakfast Proto")));
+
+      // Setup instance with prototype link and own label
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastInstance, assetLabel, new Literal("Breakfast Instance")));
+      await store.add(new Triple(breakfastInstance, assetUid, new Literal("uid-123")));
+
+      // Materialize
+      const materialized = await materializer.materialize(store);
+      expect(materialized).toBe(2); // area + timeEstimate
+
+      // Now annotate: own label should be "own", inherited area should be "inherited"
+      const ownSolution = new SolutionMapping();
+      ownSolution.set("s", breakfastInstance);
+      ownSolution.set("p", assetLabel);
+      ownSolution.set("o", new Literal("Breakfast Instance"));
+
+      const inheritedAreaSolution = new SolutionMapping();
+      inheritedAreaSolution.set("s", breakfastInstance);
+      inheritedAreaSolution.set("p", effortArea);
+      inheritedAreaSolution.set("o", healthArea);
+
+      const inheritedTimeSolution = new SolutionMapping();
+      inheritedTimeSolution.set("s", breakfastInstance);
+      inheritedTimeSolution.set("p", effortTimeEstimate);
+      inheritedTimeSolution.set("o", new Literal("15"));
+
+      const results = await annotator.annotate(
+        [ownSolution, inheritedAreaSolution, inheritedTimeSolution],
+        "s", "p", "o",
+      );
+
+      expect(results).toHaveLength(3);
+      expect((results[0].get(SOURCE_VARIABLE) as Literal).value).toBe("own");
+      expect((results[1].get(SOURCE_VARIABLE) as Literal).value).toBe("inherited");
+      expect((results[2].get(SOURCE_VARIABLE) as Literal).value).toBe("inherited");
+    });
+
+    it("should return 'own' for properties that override prototype", async () => {
+      // Prototype has area
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+
+      // Instance overrides with its own area
+      const fitnessArea = new IRI("obsidian://vault/Fitness.md");
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastInstance, effortArea, fitnessArea));
+
+      // Materialize (should not materialize area since instance already has it)
+      const materialized = await materializer.materialize(store);
+      expect(materialized).toBe(0);
+
+      // Annotate
+      const solution = new SolutionMapping();
+      solution.set("s", breakfastInstance);
+      solution.set("p", effortArea);
+      solution.set("o", fitnessArea);
+
+      const results = await annotator.annotate([solution], "s", "p", "o");
+
+      expect((results[0].get(SOURCE_VARIABLE) as Literal).value).toBe("own");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle Literal objects in triple matching", async () => {
+      const literalObj = new Literal("hello");
+      const triple = new Triple(breakfastInstance, assetLabel, literalObj);
+      await store.add(triple);
+      await store.addToGraph(triple, INFERRED_GRAPH);
+
+      const source = await annotator.determineSource(
+        breakfastInstance,
+        assetLabel,
+        literalObj,
+      );
+
+      expect(source).toBe("inherited");
+    });
+
+    it("should handle typed literals correctly", async () => {
+      const xsdInt = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+      const typedLiteral = new Literal("42", xsdInt);
+      const triple = new Triple(breakfastInstance, effortTimeEstimate, typedLiteral);
+      await store.add(triple);
+
+      const source = await annotator.determineSource(
+        breakfastInstance,
+        effortTimeEstimate,
+        typedLiteral,
+      );
+
+      expect(source).toBe("own");
+    });
+
+    it("should return 'own' when triple exists only in default graph", async () => {
+      await store.add(new Triple(breakfastInstance, effortArea, healthArea));
+
+      // Add a DIFFERENT triple to inferred graph (not the same one)
+      await store.addToGraph(
+        new Triple(breakfastInstance, assetLabel, new Literal("other")),
+        INFERRED_GRAPH,
+      );
+
+      const source = await annotator.determineSource(
+        breakfastInstance,
+        effortArea,
+        healthArea,
+      );
+
+      expect(source).toBe("own");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `SourceAnnotator` service that determines triple provenance (own vs inherited) by checking the `exo:inferred` named graph
- Supports three annotation modes: per-triple (`annotate`), per-subject (`annotateBySubject`), and single-row (`annotateSingle`)
- Includes subject-based caching for batch performance
- Exports `SourceAnnotator`, `SOURCE_VARIABLE`, and `TripleSource` type from `@exocortex/core`

Closes #2522

## Test plan
- [x] 19 unit tests covering all annotation modes
- [x] Integration test with PrototypeChainMaterializer (own property = "own", inherited = "inherited")
- [x] Edge cases: missing bindings, non-IRI subjects, typed literals, empty input
- [x] Immutability: original solution mappings not mutated
- [x] Cache correctness: single matchInGraph call for repeated subjects
- [x] Full core test suite passes (213 suites, 6767 tests)
- [x] Typecheck clean, lint clean, archgate pass