### PR TITLE
feat(core): ExoQL OWN() filter function — query only own properties (#2523)

### DIFF
--- a/packages/exocortex/src/exoql/index.ts
+++ b/packages/exocortex/src/exoql/index.ts
@@ -1,5 +1,5 @@
 import type { ITripleStore } from "../interfaces/ITripleStore";
-import type { Triple } from "../domain/models/rdf/Triple";
+import type { Triple, Subject, Predicate, Object as RDFObject } from "../domain/models/rdf/Triple";
 import { SPARQLParser } from "../infrastructure/sparql/SPARQLParser";
 import { AlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
 import {
@@ -11,6 +11,8 @@ import type {
   AskOperation,
   ConstructOperation,
 } from "../infrastructure/sparql/algebra/AlgebraOperation";
+import { SourceAnnotator, SOURCE_VARIABLE } from "../services/SourceAnnotator";
+import { Literal } from "../domain/models/rdf/Literal";
 
 /**
  * ExoQL  public facade for executing SPARQL queries against a triple store.
@@ -83,6 +85,89 @@ export class ExoQL {
   }
 
   /**
+   * Execute a SELECT query and return only "own" (non-inherited) results.
+   *
+   * Uses the SourceAnnotator to check each solution mapping against the
+   * `exo:inferred` named graph. Triples that exist in the inferred graph
+   * were materialized from a prototype chain and are filtered out.
+   *
+   * The query MUST bind `?s` (subject), `?p` (predicate), and `?o` (object)
+   * variables, or custom variable names can be specified via `OwnFilterConfig`.
+   *
+   * @param sparql  SPARQL SELECT query string
+   * @param store   Triple store to query against
+   * @param ownConfig  Optional configuration for variable name mapping
+   * @param config  Optional QueryExecutor configuration
+   * @returns Array of solution mappings for own (non-inherited) triples only
+   *
+   * @example
+   * ```typescript
+   * // Default: expects ?s ?p ?o variables
+   * const own = await ExoQL.queryOwn(
+   *   `SELECT ?s ?p ?o WHERE { ?s ?p ?o }`,
+   *   store,
+   * );
+   *
+   * // Custom variable names
+   * const own = await ExoQL.queryOwn(
+   *   `SELECT ?subject ?predicate ?value WHERE { ?subject ?predicate ?value }`,
+   *   store,
+   *   { subjectVar: "subject", predicateVar: "predicate", objectVar: "value" },
+   * );
+   * ```
+   */
+  static async queryOwn(
+    sparql: string,
+    store: ITripleStore,
+    ownConfig?: OwnFilterConfig,
+    config?: QueryExecutorConfig,
+  ): Promise<SolutionMapping[]> {
+    const solutions = await ExoQL.query(sparql, store, config);
+
+    if (solutions.length === 0) {
+      return [];
+    }
+
+    const subjectVar = ownConfig?.subjectVar ?? "s";
+    const predicateVar = ownConfig?.predicateVar ?? "p";
+    const objectVar = ownConfig?.objectVar ?? "o";
+
+    const annotator = new SourceAnnotator(store);
+    const annotated = await annotator.annotate(
+      solutions,
+      subjectVar,
+      predicateVar,
+      objectVar,
+    );
+
+    return annotated.filter((sol) => {
+      const source = sol.get(SOURCE_VARIABLE);
+      return source instanceof Literal && source.value === "own";
+    });
+  }
+
+  /**
+   * Check whether a specific triple is "own" (directly asserted) or "inherited"
+   * (materialized from a prototype chain via the `exo:inferred` named graph).
+   *
+   * @param subject   The triple's subject
+   * @param predicate The triple's predicate
+   * @param object    The triple's object
+   * @param store     Triple store to check against
+   * @returns `true` if the triple is own, `false` if inherited
+   */
+  static async isOwn(
+    subject: Subject,
+    predicate: Predicate,
+    object: RDFObject,
+    store: ITripleStore,
+  ): Promise<boolean> {
+    const annotator = new SourceAnnotator(store);
+    const source = await annotator.determineSource(subject, predicate, object);
+    return source === "own";
+  }
+
+  /**
    * Internal: parse SPARQL, translate to algebra, create executor.
    */
   private static prepare(
@@ -97,6 +182,21 @@ export class ExoQL {
     const executor = new QueryExecutor(store, config);
     return { algebra, executor };
   }
+}
+
+/**
+ * Configuration for OWN() filtering variable name mapping.
+ *
+ * By default, `queryOwn()` expects the query to bind `?s`, `?p`, and `?o`.
+ * Use this to specify custom variable names when the query uses different names.
+ */
+export interface OwnFilterConfig {
+  /** Variable name for the subject (without '?' prefix). Default: "s" */
+  subjectVar?: string;
+  /** Variable name for the predicate (without '?' prefix). Default: "p" */
+  predicateVar?: string;
+  /** Variable name for the object (without '?' prefix). Default: "o" */
+  objectVar?: string;
 }
 
 /**

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -390,7 +390,7 @@ export type {
 } from "./infrastructure/memory";
 
 // ExoQL public API
-export { ExoQL, ExoQLError } from "./exoql";
+export { ExoQL, ExoQLError, type OwnFilterConfig } from "./exoql";
 
 // Error exports
 export * from "./domain/errors";

--- a/packages/exocortex/tests/unit/exoql/ExoQLOwn.test.ts
+++ b/packages/exocortex/tests/unit/exoql/ExoQLOwn.test.ts
@@ -1,0 +1,227 @@
+import { ExoQL } from "../../../src/exoql";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { INFERRED_GRAPH } from "../../../src/services/PrototypeChainMaterializer";
+
+describe("ExoQL OWN() filter", () => {
+  let store: InMemoryTripleStore;
+
+  const EX = (local: string) => new IRI(`http://example.org/${local}`);
+  const RDF_TYPE = new IRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+  });
+
+  // ---------------------------------------------------------------
+  // ExoQL.queryOwn()
+  // ---------------------------------------------------------------
+  describe("queryOwn()", () => {
+    it("returns only own triples, filtering out inherited ones", async () => {
+      // Own triple: directly asserted in default graph
+      const ownTriple = new Triple(EX("task1"), EX("name"), new Literal("My Task"));
+      await store.add(ownTriple);
+
+      // Inherited triple: exists in both default and inferred graph
+      const inheritedTriple = new Triple(EX("task1"), EX("status"), EX("Active"));
+      await store.add(inheritedTriple);
+      await store.addToGraph!(inheritedTriple, INFERRED_GRAPH);
+
+      const results = await ExoQL.queryOwn(
+        `SELECT ?s ?p ?o WHERE { ?s ?p ?o }`,
+        store,
+      );
+
+      // Only the own triple should be returned
+      expect(results).toHaveLength(1);
+      expect((results[0].get("p") as IRI).value).toBe("http://example.org/name");
+    });
+
+    it("returns all triples when none are inherited", async () => {
+      await store.add(new Triple(EX("task1"), EX("name"), new Literal("Task 1")));
+      await store.add(new Triple(EX("task2"), EX("name"), new Literal("Task 2")));
+
+      const results = await ExoQL.queryOwn(
+        `SELECT ?s ?p ?o WHERE { ?s ?p ?o }`,
+        store,
+      );
+
+      expect(results).toHaveLength(2);
+    });
+
+    it("returns empty array when all triples are inherited", async () => {
+      const triple1 = new Triple(EX("task1"), EX("status"), EX("Active"));
+      const triple2 = new Triple(EX("task1"), EX("priority"), new Literal("High"));
+
+      await store.add(triple1);
+      await store.addToGraph!(triple1, INFERRED_GRAPH);
+      await store.add(triple2);
+      await store.addToGraph!(triple2, INFERRED_GRAPH);
+
+      const results = await ExoQL.queryOwn(
+        `SELECT ?s ?p ?o WHERE { ?s ?p ?o }`,
+        store,
+      );
+
+      expect(results).toHaveLength(0);
+    });
+
+    it("returns empty array when store is empty", async () => {
+      const results = await ExoQL.queryOwn(
+        `SELECT ?s ?p ?o WHERE { ?s ?p ?o }`,
+        store,
+      );
+
+      expect(results).toEqual([]);
+    });
+
+    it("supports custom variable names via OwnFilterConfig", async () => {
+      const ownTriple = new Triple(EX("task1"), EX("name"), new Literal("Own"));
+      await store.add(ownTriple);
+
+      const inheritedTriple = new Triple(EX("task1"), EX("status"), EX("Inherited"));
+      await store.add(inheritedTriple);
+      await store.addToGraph!(inheritedTriple, INFERRED_GRAPH);
+
+      const results = await ExoQL.queryOwn(
+        `SELECT ?subject ?predicate ?object WHERE { ?subject ?predicate ?object }`,
+        store,
+        { subjectVar: "subject", predicateVar: "predicate", objectVar: "object" },
+      );
+
+      expect(results).toHaveLength(1);
+      expect((results[0].get("predicate") as IRI).value).toBe("http://example.org/name");
+    });
+
+    it("works with FILTER in the underlying query", async () => {
+      const ownTriple = new Triple(EX("task1"), RDF_TYPE, EX("Task"));
+      await store.add(ownTriple);
+
+      const inheritedTriple = new Triple(EX("task1"), EX("status"), EX("Active"));
+      await store.add(inheritedTriple);
+      await store.addToGraph!(inheritedTriple, INFERRED_GRAPH);
+
+      // Also add another own triple that doesn't match the filter
+      await store.add(new Triple(EX("task1"), EX("label"), new Literal("Label")));
+
+      const results = await ExoQL.queryOwn(
+        `SELECT ?s ?p ?o WHERE {
+           ?s ?p ?o .
+           FILTER(?p = <${RDF_TYPE.value}>)
+         }`,
+        store,
+      );
+
+      // Only the rdf:type triple is own AND matches the filter
+      expect(results).toHaveLength(1);
+      expect((results[0].get("p") as IRI).value).toBe(RDF_TYPE.value);
+    });
+
+    it("handles mixed own and inherited triples for multiple subjects", async () => {
+      // task1: has own name, inherited status
+      const t1Own = new Triple(EX("task1"), EX("name"), new Literal("Task 1"));
+      await store.add(t1Own);
+
+      const t1Inherited = new Triple(EX("task1"), EX("status"), EX("Active"));
+      await store.add(t1Inherited);
+      await store.addToGraph!(t1Inherited, INFERRED_GRAPH);
+
+      // task2: has own name, own priority
+      await store.add(new Triple(EX("task2"), EX("name"), new Literal("Task 2")));
+      await store.add(new Triple(EX("task2"), EX("priority"), new Literal("High")));
+
+      const results = await ExoQL.queryOwn(
+        `SELECT ?s ?p ?o WHERE { ?s ?p ?o }`,
+        store,
+      );
+
+      // task1: 1 own, task2: 2 own = 3 total
+      expect(results).toHaveLength(3);
+      const predicates = results.map((r) => (r.get("p") as IRI).value).sort();
+      expect(predicates).toEqual([
+        "http://example.org/name",
+        "http://example.org/name",
+        "http://example.org/priority",
+      ]);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // ExoQL.isOwn()
+  // ---------------------------------------------------------------
+  describe("isOwn()", () => {
+    it("returns true for a directly asserted triple", async () => {
+      const triple = new Triple(EX("task1"), EX("name"), new Literal("My Task"));
+      await store.add(triple);
+
+      const result = await ExoQL.isOwn(
+        EX("task1"),
+        EX("name"),
+        new Literal("My Task"),
+        store,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false for an inherited triple", async () => {
+      const triple = new Triple(EX("task1"), EX("status"), EX("Active"));
+      await store.add(triple);
+      await store.addToGraph!(triple, INFERRED_GRAPH);
+
+      const result = await ExoQL.isOwn(
+        EX("task1"),
+        EX("status"),
+        EX("Active"),
+        store,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when store does not support named graphs", async () => {
+      // Create a minimal store without matchInGraph
+      const basicStore = {
+        add: store.add.bind(store),
+        remove: store.remove.bind(store),
+        has: store.has.bind(store),
+        match: store.match.bind(store),
+        addAll: store.addAll.bind(store),
+        removeAll: store.removeAll.bind(store),
+        clear: store.clear.bind(store),
+        count: store.count.bind(store),
+        subjects: store.subjects.bind(store),
+        predicates: store.predicates.bind(store),
+        objects: store.objects.bind(store),
+        beginTransaction: store.beginTransaction.bind(store),
+        // matchInGraph intentionally omitted
+      };
+
+      await basicStore.add(new Triple(EX("task1"), EX("name"), new Literal("Task")));
+
+      const result = await ExoQL.isOwn(
+        EX("task1"),
+        EX("name"),
+        new Literal("Task"),
+        basicStore,
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Re-export verification
+  // ---------------------------------------------------------------
+  describe("re-exports from main index", () => {
+    it("OwnFilterConfig type is exported from @exocortex/core index", async () => {
+      // Type-only exports cannot be verified at runtime,
+      // but we can verify the module compiles with the import
+      const mod = await import("../../../src/index");
+      expect(mod.ExoQL.queryOwn).toBeDefined();
+      expect(mod.ExoQL.isOwn).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ExoQL.queryOwn()` method that executes a SELECT query and post-filters results to return only "own" (non-inherited) triples using `SourceAnnotator` + `exo:inferred` named graph
- Add `ExoQL.isOwn()` static helper to check if a specific triple is own or inherited
- Export `OwnFilterConfig` interface for custom variable name mapping (`?s/?p/?o` defaults, configurable)

Closes #2523

## Test plan
- [x] 11 tests covering: own-only filtering, all-own passthrough, all-inherited exclusion, empty store, custom variable names, FILTER interop, multi-subject mixed scenarios, isOwn() for own/inherited/no-named-graph-support, re-export verification
- [x] TypeScript typecheck passes
- [x] All pre-commit hooks pass (lint, BDD 100%, archgate)