### PR TITLE
feat(plugin): React DynamicFormModal supporting all InputSchemaField types (#2525)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -1,4 +1,4 @@
-import { Notice } from "obsidian";
+import { App, Notice } from "obsidian";
 import { ActionButton } from '@plugin/presentation/components/ActionButtonsGroup';
 import type {
   CommandResolver,
@@ -13,6 +13,7 @@ import {
   IButtonGroupBuilder,
   ButtonBuilderContext,
 } from "./ButtonBuilderTypes";
+import { DynamicFormModal } from "@plugin/presentation/modals/DynamicFormModal";
 
 /**
  * Configuration for DynamicCommandButtonGroupBuilder.
@@ -84,7 +85,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
   }
 
   async build(context: ButtonBuilderContext): Promise<ActionButton[]> {
-    const { file, metadata, logger, refresh } = context;
+    const { app, file, metadata, logger, refresh } = context;
 
     const subjectIRI = this.extractSubjectIRI(metadata) ?? file.path;
     if (!subjectIRI) return [];
@@ -135,7 +136,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     if (visibleCommands.length === 0) return [];
 
     return visibleCommands.map(({ rc }) =>
-      this.createButton(rc, subjectIRI, file.path, logger, refresh),
+      this.createButton(rc, subjectIRI, file.path, app as App, logger, refresh),
     );
   }
 
@@ -143,6 +144,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     rc: ResolvedCommand,
     targetIRI: string,
     filePath: string,
+    app: App,
     logger: ILogger,
     refresh: () => Promise<void>,
   ): ActionButton {
@@ -155,7 +157,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
       variant,
       visible: true,
       onClick: async () => {
-        await this.handleClick(rc, targetIRI, filePath, logger, refresh);
+        await this.handleClick(rc, targetIRI, filePath, app, logger, refresh);
       },
     };
   }
@@ -164,6 +166,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     rc: ResolvedCommand,
     targetIRI: string,
     filePath: string,
+    app: App,
     logger: ILogger,
     refresh: () => Promise<void>,
   ): Promise<void> {
@@ -177,7 +180,8 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     let userInput: UserInput | undefined;
     const inputSchema = this.extractInputSchema(rc);
     if (inputSchema && inputSchema.length > 0) {
-      const collected = await this.showInputModal(inputSchema);
+      const modal = new DynamicFormModal(app, inputSchema);
+      const collected = await modal.waitForResult();
       if (collected === null) return;
       userInput = collected;
     }
@@ -235,114 +239,6 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
         typeof (field as Record<string, unknown>)["type"] === "string",
     );
   }
-
-  /* eslint-disable obsidianmd/no-static-styles-assignment */
-  private async showInputModal(
-    schema: InputSchemaField[],
-  ): Promise<UserInput | null> {
-    return new Promise((resolve) => {
-      const container = document.createElement("div");
-      container.className = "exocortex-input-modal-overlay";
-      container.style.cssText =
-        "position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);z-index:9999;display:flex;align-items:center;justify-content:center;";
-
-      const modal = document.createElement("div");
-      modal.className = "exocortex-input-modal";
-      modal.style.cssText =
-        "background:var(--background-primary);padding:20px;border-radius:8px;min-width:300px;max-width:500px;";
-
-      const title = document.createElement("h3");
-      title.textContent = "Input required";
-      modal.appendChild(title);
-
-      const inputs: Map<string, HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement> = new Map();
-
-      for (const field of schema) {
-        const label = document.createElement("label");
-        label.style.cssText = "display:block;margin:8px 0 4px;";
-        label.textContent = field.label ?? field.name;
-        modal.appendChild(label);
-
-        if (field.type === "enum" && field.options) {
-          const select = document.createElement("select");
-          select.style.cssText = "width:100%;padding:4px;";
-          for (const opt of field.options) {
-            const option = document.createElement("option");
-            if (typeof opt === "string") {
-              option.value = opt;
-              option.textContent = opt;
-            } else {
-              option.value = opt.value;
-              option.textContent = opt.label;
-            }
-            select.appendChild(option);
-          }
-          if (field.defaultValue) select.value = field.defaultValue;
-          modal.appendChild(select);
-          inputs.set(field.name, select);
-        } else if (field.type === "date") {
-          const input = document.createElement("input");
-          input.type = "date";
-          input.style.cssText = "width:100%;padding:4px;";
-          if (field.defaultValue) input.value = field.defaultValue;
-          modal.appendChild(input);
-          inputs.set(field.name, input);
-        } else if (field.type === "multiline") {
-          const textarea = document.createElement("textarea");
-          textarea.rows = field.rows ?? 4;
-          textarea.style.cssText = "width:100%;padding:4px;resize:vertical;";
-          if (field.defaultValue) textarea.value = field.defaultValue;
-          modal.appendChild(textarea);
-          inputs.set(field.name, textarea);
-        } else if (field.type === "assetRef") {
-          const input = document.createElement("input");
-          input.type = "text";
-          input.placeholder = "Asset reference...";
-          input.style.cssText = "width:100%;padding:4px;";
-          if (field.defaultValue) input.value = field.defaultValue;
-          modal.appendChild(input);
-          inputs.set(field.name, input);
-        } else {
-          const input = document.createElement("input");
-          input.type = "text";
-          input.style.cssText = "width:100%;padding:4px;";
-          if (field.defaultValue) input.value = field.defaultValue;
-          modal.appendChild(input);
-          inputs.set(field.name, input);
-        }
-      }
-
-      const buttonContainer = document.createElement("div");
-      buttonContainer.style.cssText =
-        "display:flex;justify-content:flex-end;gap:8px;margin-top:16px;";
-
-      const cancelBtn = document.createElement("button");
-      cancelBtn.textContent = "Cancel";
-      cancelBtn.addEventListener("click", () => {
-        container.remove();
-        resolve(null);
-      });
-      buttonContainer.appendChild(cancelBtn);
-
-      const okBtn = document.createElement("button");
-      okBtn.textContent = "OK";
-      okBtn.className = "mod-cta";
-      okBtn.addEventListener("click", () => {
-        const result: UserInput = {};
-        for (const [name, el] of inputs) {
-          result[name] = el.value;
-        }
-        container.remove();
-        resolve(result);
-      });
-      buttonContainer.appendChild(okBtn);
-
-      modal.appendChild(buttonContainer);
-      container.appendChild(modal);
-      document.body.appendChild(container);
-    });
-  }
-  /* eslint-enable obsidianmd/no-static-styles-assignment */
 
   private extractSubjectIRI(metadata: Record<string, unknown>): string | undefined {
     const uid = metadata["exo__Asset_uid"];

--- a/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
@@ -1,0 +1,165 @@
+import React, { useState, useCallback, useMemo } from "react";
+import type {
+  InputSchemaField,
+  EnumOption,
+} from "@plugin/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+
+export interface DynamicFormProps {
+  readonly schema: InputSchemaField[];
+  readonly onSubmit: (values: Record<string, string>) => void;
+  readonly onCancel: () => void;
+}
+
+interface FieldError {
+  readonly name: string;
+  readonly message: string;
+}
+
+function normalizeEnumOption(opt: string | EnumOption): EnumOption {
+  return typeof opt === "string" ? { value: opt, label: opt } : opt;
+}
+
+export const DynamicForm: React.FC<DynamicFormProps> = ({
+  schema,
+  onSubmit,
+  onCancel,
+}) => {
+  const initialValues = useMemo(() => {
+    const values: Record<string, string> = {};
+    for (const field of schema) {
+      values[field.name] = field.defaultValue ?? "";
+    }
+    return values;
+  }, [schema]);
+
+  const [values, setValues] = useState<Record<string, string>>(initialValues);
+  const [errors, setErrors] = useState<FieldError[]>([]);
+
+  const handleChange = useCallback((name: string, value: string) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+    setErrors((prev) => prev.filter((e) => e.name !== name));
+  }, []);
+
+  const validate = useCallback((): boolean => {
+    const newErrors: FieldError[] = [];
+    for (const field of schema) {
+      if (field.required && !values[field.name]?.trim()) {
+        newErrors.push({
+          name: field.name,
+          message: `${field.label ?? field.name} is required`,
+        });
+      }
+    }
+    setErrors(newErrors);
+    return newErrors.length === 0;
+  }, [schema, values]);
+
+  const handleSubmit = useCallback(() => {
+    if (validate()) {
+      onSubmit(values);
+    }
+  }, [validate, values, onSubmit]);
+
+  const getFieldError = useCallback(
+    (name: string): string | undefined =>
+      errors.find((e) => e.name === name)?.message,
+    [errors],
+  );
+
+  return (
+    <div className="dynamic-form">
+      {schema.map((field) => (
+        <div key={field.name} className="dynamic-form-field">
+          <label className="dynamic-form-label">
+            {field.label ?? field.name}
+            {field.required && <span className="dynamic-form-required"> *</span>}
+          </label>
+          {renderField(field, values[field.name] ?? "", handleChange)}
+          {getFieldError(field.name) && (
+            <div className="dynamic-form-error">{getFieldError(field.name)}</div>
+          )}
+        </div>
+      ))}
+      <div className="modal-button-container">
+        <button className="mod-cta" onClick={handleSubmit}>
+          OK
+        </button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+};
+
+function renderField(
+  field: InputSchemaField,
+  value: string,
+  onChange: (name: string, value: string) => void,
+): React.ReactElement {
+  switch (field.type) {
+    case "date":
+      return (
+        <input
+          type="date"
+          className="dynamic-form-input"
+          value={value}
+          onChange={(e) => onChange(field.name, e.target.value)}
+          data-testid={`field-${field.name}`}
+        />
+      );
+
+    case "enum":
+      return (
+        <select
+          className="dynamic-form-input dropdown"
+          value={value}
+          onChange={(e) => onChange(field.name, e.target.value)}
+          data-testid={`field-${field.name}`}
+        >
+          {!field.required && <option value="">-- select --</option>}
+          {(field.options ?? []).map((opt) => {
+            const normalized = normalizeEnumOption(opt);
+            return (
+              <option key={normalized.value} value={normalized.value}>
+                {normalized.label}
+              </option>
+            );
+          })}
+        </select>
+      );
+
+    case "multiline":
+      return (
+        <textarea
+          className="dynamic-form-input"
+          rows={field.rows ?? 4}
+          value={value}
+          onChange={(e) => onChange(field.name, e.target.value)}
+          data-testid={`field-${field.name}`}
+        />
+      );
+
+    case "assetRef":
+      return (
+        <input
+          type="text"
+          className="dynamic-form-input"
+          placeholder="asset reference..."
+          value={value}
+          onChange={(e) => onChange(field.name, e.target.value)}
+          data-testid={`field-${field.name}`}
+        />
+      );
+
+    case "text":
+    default:
+      return (
+        <input
+          type="text"
+          className="dynamic-form-input"
+          value={value}
+          onChange={(e) => onChange(field.name, e.target.value)}
+          data-testid={`field-${field.name}`}
+        />
+      );
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/modals/DynamicFormModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/DynamicFormModal.ts
@@ -1,0 +1,73 @@
+import { Modal, App } from "obsidian";
+import React from "react";
+import type { InputSchemaField } from "@plugin/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+import { ReactRenderer } from "@plugin/presentation/utils/ReactRenderer";
+import { DynamicForm } from "@plugin/presentation/components/dynamic-form/DynamicForm";
+import { ErrorBoundary } from "@plugin/presentation/components/ErrorBoundary";
+
+export type UserInput = Record<string, string>;
+
+export class DynamicFormModal extends Modal {
+  private readonly schema: InputSchemaField[];
+  private readonly reactRenderer: ReactRenderer;
+  private resolvePromise: ((value: UserInput | null) => void) | null = null;
+
+  constructor(app: App, schema: InputSchemaField[]) {
+    super(app);
+    this.schema = schema;
+    this.reactRenderer = new ReactRenderer();
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("dynamic-form-modal");
+
+    const titleEl = contentEl.createEl("h3", { cls: "dynamic-form-modal-title" });
+    titleEl.textContent = "Input required";
+
+    const container = contentEl.createEl("div", { cls: "dynamic-form-container" });
+
+    this.reactRenderer.render(
+      container,
+      React.createElement(
+        ErrorBoundary,
+        {
+          children: React.createElement(DynamicForm, {
+            schema: this.schema,
+            onSubmit: (values: UserInput) => {
+              this.resolvePromise?.(values);
+              this.resolvePromise = null;
+              this.close();
+            },
+            onCancel: () => {
+              this.resolvePromise?.(null);
+              this.resolvePromise = null;
+              this.close();
+            },
+          }),
+          onError: (error: Error) => {
+            console.error("[Exocortex DynamicFormModal] Render error:", error);
+          },
+        },
+      ),
+    );
+  }
+
+  override onClose(): void {
+    const { contentEl } = this;
+    this.reactRenderer.cleanup();
+    contentEl.empty();
+    if (this.resolvePromise) {
+      this.resolvePromise(null);
+      this.resolvePromise = null;
+    }
+  }
+
+  waitForResult(): Promise<UserInput | null> {
+    return new Promise((resolve) => {
+      this.resolvePromise = resolve;
+      this.open();
+    });
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
@@ -1,0 +1,282 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DynamicForm, DynamicFormProps } from "../../../../src/presentation/components/dynamic-form/DynamicForm";
+import type { InputSchemaField } from "../../../../src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+
+function renderForm(
+  schema: InputSchemaField[],
+  overrides: Partial<DynamicFormProps> = {},
+) {
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+  const result = render(
+    <DynamicForm
+      schema={schema}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+      {...overrides}
+    />,
+  );
+  return { ...result, onSubmit, onCancel };
+}
+
+describe("DynamicForm", () => {
+  describe("text field", () => {
+    it("should render a text input", () => {
+      renderForm([{ name: "title", type: "text", label: "Title" }]);
+      expect(screen.getByText("Title")).toBeInTheDocument();
+      expect(screen.getByTestId("field-title")).toBeInTheDocument();
+      expect(screen.getByTestId("field-title").tagName).toBe("INPUT");
+    });
+
+    it("should use name as label when label is omitted", () => {
+      renderForm([{ name: "myField", type: "text" }]);
+      expect(screen.getByText("myField")).toBeInTheDocument();
+    });
+
+    it("should populate default value", () => {
+      renderForm([{ name: "title", type: "text", defaultValue: "hello" }]);
+      expect(screen.getByTestId("field-title")).toHaveValue("hello");
+    });
+
+    it("should update value on change", () => {
+      const { onSubmit } = renderForm([{ name: "title", type: "text" }]);
+      const input = screen.getByTestId("field-title");
+      fireEvent.change(input, { target: { value: "new value" } });
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).toHaveBeenCalledWith({ title: "new value" });
+    });
+  });
+
+  describe("date field", () => {
+    it("should render a date input", () => {
+      renderForm([{ name: "dueDate", type: "date", label: "Due date" }]);
+      const input = screen.getByTestId("field-dueDate");
+      expect(input.tagName).toBe("INPUT");
+      expect(input).toHaveAttribute("type", "date");
+    });
+
+    it("should populate default date value", () => {
+      renderForm([{ name: "dueDate", type: "date", defaultValue: "2026-04-05" }]);
+      expect(screen.getByTestId("field-dueDate")).toHaveValue("2026-04-05");
+    });
+  });
+
+  describe("enum field", () => {
+    it("should render a select dropdown with string options", () => {
+      renderForm([{
+        name: "priority",
+        type: "enum",
+        label: "Priority",
+        options: ["low", "medium", "high"],
+      }]);
+      const select = screen.getByTestId("field-priority");
+      expect(select.tagName).toBe("SELECT");
+      expect(screen.getByText("low")).toBeInTheDocument();
+      expect(screen.getByText("medium")).toBeInTheDocument();
+      expect(screen.getByText("high")).toBeInTheDocument();
+    });
+
+    it("should render value/label option pairs", () => {
+      renderForm([{
+        name: "status",
+        type: "enum",
+        options: [
+          { value: "active", label: "Active status" },
+          { value: "archived", label: "Archived status" },
+        ],
+      }]);
+      expect(screen.getByText("Active status")).toBeInTheDocument();
+      expect(screen.getByText("Archived status")).toBeInTheDocument();
+    });
+
+    it("should render mixed string and object options", () => {
+      renderForm([{
+        name: "status",
+        type: "enum",
+        options: [
+          "simple",
+          { value: "complex", label: "Complex option" },
+        ],
+      }]);
+      expect(screen.getByText("simple")).toBeInTheDocument();
+      expect(screen.getByText("Complex option")).toBeInTheDocument();
+    });
+
+    it("should include placeholder option when not required", () => {
+      renderForm([{
+        name: "priority",
+        type: "enum",
+        options: ["low", "high"],
+      }]);
+      expect(screen.getByText("-- select --")).toBeInTheDocument();
+    });
+
+    it("should not include placeholder when required", () => {
+      renderForm([{
+        name: "priority",
+        type: "enum",
+        required: true,
+        options: ["low", "high"],
+      }]);
+      expect(screen.queryByText("-- select --")).not.toBeInTheDocument();
+    });
+
+    it("should apply default value to select", () => {
+      renderForm([{
+        name: "priority",
+        type: "enum",
+        options: ["low", "medium", "high"],
+        defaultValue: "medium",
+      }]);
+      expect(screen.getByTestId("field-priority")).toHaveValue("medium");
+    });
+  });
+
+  describe("multiline field", () => {
+    it("should render a textarea", () => {
+      renderForm([{ name: "description", type: "multiline", label: "Description" }]);
+      const textarea = screen.getByTestId("field-description");
+      expect(textarea.tagName).toBe("TEXTAREA");
+    });
+
+    it("should use default 4 rows", () => {
+      renderForm([{ name: "notes", type: "multiline" }]);
+      expect(screen.getByTestId("field-notes")).toHaveAttribute("rows", "4");
+    });
+
+    it("should use custom rows count", () => {
+      renderForm([{ name: "notes", type: "multiline", rows: 8 }]);
+      expect(screen.getByTestId("field-notes")).toHaveAttribute("rows", "8");
+    });
+
+    it("should populate default value", () => {
+      renderForm([{ name: "notes", type: "multiline", defaultValue: "initial text" }]);
+      expect(screen.getByTestId("field-notes")).toHaveValue("initial text");
+    });
+  });
+
+  describe("assetRef field", () => {
+    it("should render a text input with placeholder", () => {
+      renderForm([{ name: "parent", type: "assetRef", label: "Parent asset" }]);
+      const input = screen.getByTestId("field-parent");
+      expect(input.tagName).toBe("INPUT");
+      expect(input).toHaveAttribute("placeholder", "asset reference...");
+    });
+
+    it("should populate default value", () => {
+      renderForm([{
+        name: "parent",
+        type: "assetRef",
+        defaultValue: "uuid-1234",
+      }]);
+      expect(screen.getByTestId("field-parent")).toHaveValue("uuid-1234");
+    });
+  });
+
+  describe("validation", () => {
+    it("should show error for empty required text field", () => {
+      renderForm([{ name: "title", type: "text", label: "Title", required: true }]);
+      fireEvent.click(screen.getByText("OK"));
+      expect(screen.getByText("Title is required")).toBeInTheDocument();
+    });
+
+    it("should show error for empty required enum field", () => {
+      renderForm([{
+        name: "priority",
+        type: "enum",
+        label: "Priority",
+        required: true,
+        options: ["low", "high"],
+      }]);
+      fireEvent.click(screen.getByText("OK"));
+      expect(screen.getByText("Priority is required")).toBeInTheDocument();
+    });
+
+    it("should not submit when validation fails", () => {
+      const { onSubmit } = renderForm([
+        { name: "title", type: "text", required: true },
+      ]);
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("should clear error when field is filled", () => {
+      renderForm([{ name: "title", type: "text", label: "Title", required: true }]);
+      fireEvent.click(screen.getByText("OK"));
+      expect(screen.getByText("Title is required")).toBeInTheDocument();
+
+      fireEvent.change(screen.getByTestId("field-title"), {
+        target: { value: "filled" },
+      });
+      expect(screen.queryByText("Title is required")).not.toBeInTheDocument();
+    });
+
+    it("should use field name in error when label is absent", () => {
+      renderForm([{ name: "myField", type: "text", required: true }]);
+      fireEvent.click(screen.getByText("OK"));
+      expect(screen.getByText("myField is required")).toBeInTheDocument();
+    });
+
+    it("should show required indicator", () => {
+      renderForm([{ name: "title", type: "text", required: true }]);
+      expect(screen.getByText("*")).toBeInTheDocument();
+    });
+
+    it("should not show required indicator for optional fields", () => {
+      renderForm([{ name: "title", type: "text" }]);
+      expect(screen.queryByText("*")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("form submission", () => {
+    it("should submit all field values", () => {
+      const { onSubmit } = renderForm([
+        { name: "title", type: "text", defaultValue: "My title" },
+        { name: "dueDate", type: "date", defaultValue: "2026-04-05" },
+        { name: "notes", type: "multiline", defaultValue: "Some notes" },
+      ]);
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).toHaveBeenCalledWith({
+        title: "My title",
+        dueDate: "2026-04-05",
+        notes: "Some notes",
+      });
+    });
+
+    it("should call onCancel when cancel clicked", () => {
+      const { onCancel } = renderForm([{ name: "title", type: "text" }]);
+      fireEvent.click(screen.getByText("Cancel"));
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe("multiple fields", () => {
+    it("should render all field types together", () => {
+      renderForm([
+        { name: "title", type: "text", label: "Title" },
+        { name: "dueDate", type: "date", label: "Due date" },
+        { name: "priority", type: "enum", label: "Priority", options: ["low", "high"] },
+        { name: "notes", type: "multiline", label: "Notes" },
+        { name: "parent", type: "assetRef", label: "Parent" },
+      ]);
+
+      expect(screen.getByTestId("field-title")).toBeInTheDocument();
+      expect(screen.getByTestId("field-dueDate")).toBeInTheDocument();
+      expect(screen.getByTestId("field-priority")).toBeInTheDocument();
+      expect(screen.getByTestId("field-notes")).toBeInTheDocument();
+      expect(screen.getByTestId("field-parent")).toBeInTheDocument();
+    });
+
+    it("should validate all required fields at once", () => {
+      renderForm([
+        { name: "title", type: "text", label: "Title", required: true },
+        { name: "priority", type: "enum", label: "Priority", required: true, options: ["low"] },
+      ]);
+      fireEvent.click(screen.getByText("OK"));
+      expect(screen.getByText("Title is required")).toBeInTheDocument();
+      expect(screen.getByText("Priority is required")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/DynamicFormModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/DynamicFormModal.test.ts
@@ -1,0 +1,178 @@
+import { DynamicFormModal, UserInput } from "../../../../src/presentation/modals/DynamicFormModal";
+import type { InputSchemaField } from "../../../../src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+import { ReactRenderer } from "@plugin/presentation/utils/ReactRenderer";
+
+jest.mock("obsidian", () => ({
+  Modal: class MockModal {
+    app: unknown;
+    contentEl = {
+      empty: jest.fn(),
+      addClass: jest.fn(),
+      createEl: jest.fn().mockReturnValue(document.createElement("div")),
+    };
+
+    constructor(app: unknown) {
+      this.app = app;
+    }
+
+    open = jest.fn();
+    close = jest.fn();
+  },
+  App: jest.fn(),
+}));
+
+jest.mock("../../../../src/presentation/utils/ReactRenderer");
+jest.mock("../../../../src/presentation/components/dynamic-form/DynamicForm");
+jest.mock("../../../../src/presentation/components/ErrorBoundary");
+
+describe("DynamicFormModal", () => {
+  const mockApp = {} as any;
+  const schema: InputSchemaField[] = [
+    { name: "title", type: "text", label: "Title", required: true },
+    { name: "priority", type: "enum", options: ["low", "high"] },
+  ];
+
+  let mockRender: jest.Mock;
+  let mockCleanup: jest.Mock;
+
+  beforeEach(() => {
+    mockRender = jest.fn();
+    mockCleanup = jest.fn();
+    (ReactRenderer as jest.Mock).mockImplementation(() => ({
+      render: mockRender,
+      cleanup: mockCleanup,
+    }));
+  });
+
+  it("should construct with app and schema", () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+    expect(modal).toBeDefined();
+  });
+
+  it("should set up contentEl on open", () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+    modal.onOpen();
+    expect(modal.contentEl.empty).toHaveBeenCalled();
+    expect(modal.contentEl.addClass).toHaveBeenCalledWith("dynamic-form-modal");
+  });
+
+  it("should create title element on open", () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+    modal.onOpen();
+    expect(modal.contentEl.createEl).toHaveBeenCalledWith("h3", {
+      cls: "dynamic-form-modal-title",
+    });
+  });
+
+  it("should create form container on open", () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+    modal.onOpen();
+    expect(modal.contentEl.createEl).toHaveBeenCalledWith("div", {
+      cls: "dynamic-form-container",
+    });
+  });
+
+  it("should render React component via ReactRenderer on open", () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+    modal.onOpen();
+    expect(mockRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("should clean up on close", () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+    modal.onOpen();
+    modal.onClose();
+    expect(mockCleanup).toHaveBeenCalled();
+    expect(modal.contentEl.empty).toHaveBeenCalled();
+  });
+
+  it("should resolve null on close if waitForResult is pending", async () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+
+    const resultPromise = modal.waitForResult();
+    expect(modal.open).toHaveBeenCalled();
+
+    modal.onClose();
+    const result = await resultPromise;
+    expect(result).toBeNull();
+  });
+
+  it("should resolve with values when onSubmit is called", async () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+
+    const resultPromise = modal.waitForResult();
+
+    modal.onOpen();
+    const renderCall = mockRender.mock.calls[0];
+    const reactElement = renderCall[1];
+
+    const errorBoundaryProps = reactElement.props;
+    const formElement = errorBoundaryProps.children;
+    const formProps = formElement.props;
+
+    const values: UserInput = { title: "Test", priority: "high" };
+    formProps.onSubmit(values);
+
+    const result = await resultPromise;
+    expect(result).toEqual(values);
+  });
+
+  it("should resolve null when onCancel is called", async () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+
+    const resultPromise = modal.waitForResult();
+
+    modal.onOpen();
+    const renderCall = mockRender.mock.calls[0];
+    const reactElement = renderCall[1];
+
+    const errorBoundaryProps = reactElement.props;
+    const formElement = errorBoundaryProps.children;
+    const formProps = formElement.props;
+
+    formProps.onCancel();
+
+    const result = await resultPromise;
+    expect(result).toBeNull();
+  });
+
+  it("should accept all five field types in schema", () => {
+    const fullSchema: InputSchemaField[] = [
+      { name: "text1", type: "text" },
+      { name: "date1", type: "date" },
+      { name: "enum1", type: "enum", options: ["a", "b"] },
+      { name: "multi1", type: "multiline" },
+      { name: "ref1", type: "assetRef" },
+    ];
+    const modal = new DynamicFormModal(mockApp, fullSchema);
+    expect(modal).toBeDefined();
+    modal.onOpen();
+    expect(mockRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pass schema to DynamicForm component", () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+    modal.onOpen();
+
+    const renderCall = mockRender.mock.calls[0];
+    const reactElement = renderCall[1];
+    const formElement = reactElement.props.children;
+    expect(formElement.props.schema).toBe(schema);
+  });
+
+  it("should not resolve twice on close after submit", async () => {
+    const modal = new DynamicFormModal(mockApp, schema);
+    const resultPromise = modal.waitForResult();
+
+    modal.onOpen();
+    const renderCall = mockRender.mock.calls[0];
+    const formProps = renderCall[1].props.children.props;
+
+    formProps.onSubmit({ title: "done", priority: "low" });
+
+    modal.onClose();
+
+    const result = await resultPromise;
+    expect(result).toEqual({ title: "done", priority: "low" });
+  });
+});


### PR DESCRIPTION
## Summary
- Created `DynamicForm` React component supporting all 5 `InputSchemaField` types: text, date, enum, multiline, assetRef
- Created `DynamicFormModal` Obsidian Modal wrapper using `ReactRenderer` + `ErrorBoundary`
- Replaced inline DOM-based `showInputModal` in `DynamicCommandButtonGroupBuilder` with the new modal
- Added required field validation with error messages and required indicators

## Details
- `DynamicForm.tsx` — stateless React form component with per-field rendering
- `DynamicFormModal.ts` — Obsidian Modal that hosts the React form and exposes `waitForResult()` promise API
- Enum fields support string options, {value, label} pairs, mixed options, and optional placeholder
- AssetRef fields render as text inputs with placeholder (SPARQL-backed search to be added later)

## Test plan
- [x] 29 tests for DynamicForm component (all field types, validation, submission, cancel)
- [x] 12 tests for DynamicFormModal (lifecycle, promise resolution, submit/cancel callbacks)
- [x] All 51 existing DynamicCommandButtonGroupBuilder tests pass unchanged
- [x] Full test suite passes (`npm run test:all`)
- [x] TypeScript clean (`npm run check:types`)

Closes #2525