### PR TITLE
feat(core): implement PropertySchemaResolver (#2528)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -106,6 +106,13 @@ export {
 } from "./services/DynamicFrontmatterGenerator";
 export { AlgorithmExtractor } from "./services/AlgorithmExtractor";
 export { PlanningService } from "./services/PlanningService";
+export {
+  PropertySchemaResolver,
+  type PropertySchema,
+  type PropertySchemaOption,
+  type PropertySchemaValidation,
+  type ISPARQLQueryable,
+} from "./services/PropertySchemaResolver";
 export { AssetConversionService } from "./services/AssetConversionService";
 export { SessionEventService } from "./services/SessionEventService";
 export { URIConstructionService } from "./services/URIConstructionService";

--- a/packages/exocortex/src/services/PropertySchemaResolver.ts
+++ b/packages/exocortex/src/services/PropertySchemaResolver.ts
@@ -1,0 +1,305 @@
+import type { ILogger } from "../interfaces/ILogger";
+import { PropertyFieldType, rangeToFieldType } from "../domain/types/PropertyFieldType";
+import { extractPropertyLabel } from "../domain/types/PropertyDefinition";
+
+export interface PropertySchema {
+  type: PropertyFieldType;
+  label: string;
+  options?: PropertySchemaOption[];
+  validation?: PropertySchemaValidation;
+}
+
+export interface PropertySchemaOption {
+  value: string;
+  label: string;
+}
+
+export interface PropertySchemaValidation {
+  required?: boolean;
+  minValue?: number;
+  maxValue?: number;
+  maxLength?: number;
+  pattern?: string;
+}
+
+export interface PropertySchemaBinding {
+  type?: string;
+  label?: string;
+  rangeType?: string;
+  description?: string;
+  required?: string;
+  minValue?: string;
+  maxValue?: string;
+  maxLength?: string;
+  pattern?: string;
+  optionValue?: string;
+  optionLabel?: string;
+}
+
+export interface ISPARQLQueryable {
+  query(sparql: string): Promise<Map<string, unknown>[]>;
+}
+
+export class PropertySchemaResolver {
+  private cache = new Map<string, PropertySchema>();
+  private allSchemasLoaded = false;
+
+  constructor(
+    private readonly sparqlService: ISPARQLQueryable,
+    private readonly logger?: ILogger,
+  ) {}
+
+  async getSchema(propertyIRI: string): Promise<PropertySchema | null> {
+    const normalizedIRI = this.normalizeIRI(propertyIRI);
+
+    const cached = this.cache.get(normalizedIRI);
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const schema = await this.loadSchemaFromStore(normalizedIRI);
+      if (schema) {
+        this.cache.set(normalizedIRI, schema);
+      }
+      return schema;
+    } catch (error) {
+      this.logger?.warn(`Failed to load schema for ${propertyIRI}`, { error: String(error) });
+      return null;
+    }
+  }
+
+  async getAllSchemas(): Promise<Map<string, PropertySchema>> {
+    if (this.allSchemasLoaded) {
+      return new Map(this.cache);
+    }
+
+    try {
+      const schemas = await this.loadAllSchemasFromStore();
+      for (const [iri, schema] of schemas) {
+        this.cache.set(iri, schema);
+      }
+      this.allSchemasLoaded = true;
+      return new Map(this.cache);
+    } catch (error) {
+      this.logger?.warn("Failed to load all schemas", { error: String(error) });
+      return new Map(this.cache);
+    }
+  }
+
+  invalidateCache(): void {
+    this.cache.clear();
+    this.allSchemasLoaded = false;
+  }
+
+  private async loadSchemaFromStore(propertyIRI: string): Promise<PropertySchema | null> {
+    const fullIRI = this.toFullIRI(propertyIRI);
+
+    const query = `
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+      PREFIX exo: <https://exocortex.my/ontology/exo#>
+      PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+      SELECT ?type ?label ?rangeType ?description ?required ?minValue ?maxValue ?maxLength ?pattern ?optionValue ?optionLabel WHERE {
+        <${fullIRI}> rdfs:range ?rangeType .
+        OPTIONAL { <${fullIRI}> rdfs:label ?label . }
+        OPTIONAL { <${fullIRI}> rdfs:comment ?description . }
+        OPTIONAL { <${fullIRI}> exo:schema_required ?required . }
+        OPTIONAL { <${fullIRI}> exo:schema_minValue ?minValue . }
+        OPTIONAL { <${fullIRI}> exo:schema_maxValue ?maxValue . }
+        OPTIONAL { <${fullIRI}> exo:schema_maxLength ?maxLength . }
+        OPTIONAL { <${fullIRI}> exo:schema_pattern ?pattern . }
+        OPTIONAL {
+          ?rangeType owl:oneOf ?list .
+          ?list rdfs:member ?optionValue .
+          OPTIONAL { ?optionValue rdfs:label ?optionLabel . }
+        }
+      }
+    `;
+
+    const results = await this.sparqlService.query(query);
+    if (results.length === 0) {
+      return null;
+    }
+
+    return this.buildSchemaFromBindings(propertyIRI, results);
+  }
+
+  private async loadAllSchemasFromStore(): Promise<Map<string, PropertySchema>> {
+    const query = `
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX exo: <https://exocortex.my/ontology/exo#>
+      PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+      SELECT ?property ?rangeType ?label ?description ?required ?minValue ?maxValue ?maxLength ?pattern ?optionValue ?optionLabel WHERE {
+        ?property rdf:type owl:DatatypeProperty .
+        OPTIONAL { ?property rdfs:range ?rangeType . }
+        OPTIONAL { ?property rdfs:label ?label . }
+        OPTIONAL { ?property rdfs:comment ?description . }
+        OPTIONAL { ?property exo:schema_required ?required . }
+        OPTIONAL { ?property exo:schema_minValue ?minValue . }
+        OPTIONAL { ?property exo:schema_maxValue ?maxValue . }
+        OPTIONAL { ?property exo:schema_maxLength ?maxLength . }
+        OPTIONAL { ?property exo:schema_pattern ?pattern . }
+        OPTIONAL {
+          ?rangeType owl:oneOf ?list .
+          ?list rdfs:member ?optionValue .
+          OPTIONAL { ?optionValue rdfs:label ?optionLabel . }
+        }
+      }
+    `;
+
+    const results = await this.sparqlService.query(query);
+    const grouped = new Map<string, Map<string, unknown>[]>();
+
+    for (const binding of results) {
+      const propertyUri = binding.get("property");
+      if (!propertyUri) continue;
+
+      const iri = this.fromFullIRI(String(propertyUri));
+      const existing = grouped.get(iri);
+      if (existing) {
+        existing.push(binding);
+      } else {
+        grouped.set(iri, [binding]);
+      }
+    }
+
+    const schemas = new Map<string, PropertySchema>();
+    for (const [iri, bindings] of grouped) {
+      const schema = this.buildSchemaFromBindings(iri, bindings);
+      if (schema) {
+        schemas.set(iri, schema);
+      }
+    }
+
+    return schemas;
+  }
+
+  private buildSchemaFromBindings(
+    propertyIRI: string,
+    bindings: Map<string, unknown>[],
+  ): PropertySchema | null {
+    if (bindings.length === 0) return null;
+
+    const first = bindings[0];
+    const rangeType = this.getBindingValue(first, "rangeType");
+    const label = this.getBindingValue(first, "label") || extractPropertyLabel(propertyIRI);
+    const fieldType = rangeType ? rangeToFieldType(rangeType) : PropertyFieldType.Text;
+
+    const options = this.extractOptions(bindings);
+
+    const validation = this.extractValidation(first);
+
+    const schema: PropertySchema = {
+      type: fieldType,
+      label,
+    };
+
+    if (options.length > 0) {
+      schema.options = options;
+    }
+
+    if (validation) {
+      schema.validation = validation;
+    }
+
+    return schema;
+  }
+
+  private extractOptions(bindings: Map<string, unknown>[]): PropertySchemaOption[] {
+    const options: PropertySchemaOption[] = [];
+    const seen = new Set<string>();
+
+    for (const binding of bindings) {
+      const optionValue = this.getBindingValue(binding, "optionValue");
+      if (optionValue && !seen.has(optionValue)) {
+        seen.add(optionValue);
+        const optionLabel = this.getBindingValue(binding, "optionLabel") || optionValue;
+        options.push({ value: optionValue, label: optionLabel });
+      }
+    }
+
+    return options;
+  }
+
+  private extractValidation(binding: Map<string, unknown>): PropertySchemaValidation | undefined {
+    const required = this.getBindingValue(binding, "required");
+    const minValue = this.getBindingValue(binding, "minValue");
+    const maxValue = this.getBindingValue(binding, "maxValue");
+    const maxLength = this.getBindingValue(binding, "maxLength");
+    const pattern = this.getBindingValue(binding, "pattern");
+
+    const hasValidation = required || minValue || maxValue || maxLength || pattern;
+    if (!hasValidation) return undefined;
+
+    const validation: PropertySchemaValidation = {};
+
+    if (required === "true") {
+      validation.required = true;
+    }
+    if (minValue !== undefined) {
+      const num = Number(minValue);
+      if (!isNaN(num)) validation.minValue = num;
+    }
+    if (maxValue !== undefined) {
+      const num = Number(maxValue);
+      if (!isNaN(num)) validation.maxValue = num;
+    }
+    if (maxLength !== undefined) {
+      const num = Number(maxLength);
+      if (!isNaN(num)) validation.maxLength = num;
+    }
+    if (pattern) {
+      validation.pattern = pattern;
+    }
+
+    return validation;
+  }
+
+  private getBindingValue(binding: Map<string, unknown>, key: string): string | undefined {
+    const value = binding.get(key);
+    if (value === undefined || value === null) return undefined;
+    return String(value);
+  }
+
+  private normalizeIRI(iri: string): string {
+    if (iri.startsWith("http://") || iri.startsWith("https://")) {
+      return this.fromFullIRI(iri);
+    }
+    return iri;
+  }
+
+  private toFullIRI(propertyName: string): string {
+    if (propertyName.startsWith("http://") || propertyName.startsWith("https://")) {
+      return propertyName;
+    }
+
+    const match = propertyName.match(/^([a-z]+)__(.+)$/);
+    if (match) {
+      const [, prefix, localName] = match;
+      switch (prefix) {
+        case "ems":
+          return `https://exocortex.my/ontology/ems#${localName}`;
+        case "exo":
+          return `https://exocortex.my/ontology/exo#${localName}`;
+        default:
+          return `https://exocortex.my/ontology/${prefix}#${localName}`;
+      }
+    }
+
+    return propertyName;
+  }
+
+  private fromFullIRI(iri: string): string {
+    const match = iri.match(/https:\/\/exocortex\.my\/ontology\/([a-z]+)#(.+)$/);
+    if (match) {
+      const [, prefix, localName] = match;
+      return `${prefix}__${localName}`;
+    }
+    return iri;
+  }
+}

--- a/packages/exocortex/tests/services/PropertySchemaResolver.test.ts
+++ b/packages/exocortex/tests/services/PropertySchemaResolver.test.ts
@@ -1,0 +1,470 @@
+import {
+  PropertySchemaResolver,
+  type ISPARQLQueryable,
+  type PropertySchema,
+} from "../../src/services/PropertySchemaResolver";
+import { PropertyFieldType } from "../../src/domain/types/PropertyFieldType";
+
+describe("PropertySchemaResolver", () => {
+  let mockSparqlService: jest.Mocked<ISPARQLQueryable>;
+  let resolver: PropertySchemaResolver;
+
+  beforeEach(() => {
+    mockSparqlService = {
+      query: jest.fn(),
+    };
+    resolver = new PropertySchemaResolver(mockSparqlService);
+  });
+
+  describe("getSchema", () => {
+    it("should return schema for a text property", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+          ["description", "Display label for the asset"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_label");
+
+      expect(schema).not.toBeNull();
+      expect(schema!.type).toBe(PropertyFieldType.Text);
+      expect(schema!.label).toBe("Label");
+    });
+
+    it("should return schema for an enum property with options", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "https://exocortex.my/ontology/ems#EffortStatus"],
+          ["label", "Status"],
+          ["optionValue", "[[ems__EffortStatusBacklog]]"],
+          ["optionLabel", "Backlog"],
+        ]),
+        new Map<string, unknown>([
+          ["rangeType", "https://exocortex.my/ontology/ems#EffortStatus"],
+          ["label", "Status"],
+          ["optionValue", "[[ems__EffortStatusDoing]]"],
+          ["optionLabel", "Doing"],
+        ]),
+        new Map<string, unknown>([
+          ["rangeType", "https://exocortex.my/ontology/ems#EffortStatus"],
+          ["label", "Status"],
+          ["optionValue", "[[ems__EffortStatusDone]]"],
+          ["optionLabel", "Done"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("ems__Effort_status");
+
+      expect(schema).not.toBeNull();
+      expect(schema!.type).toBe(PropertyFieldType.StatusSelect);
+      expect(schema!.label).toBe("Status");
+      expect(schema!.options).toHaveLength(3);
+      expect(schema!.options).toEqual([
+        { value: "[[ems__EffortStatusBacklog]]", label: "Backlog" },
+        { value: "[[ems__EffortStatusDoing]]", label: "Doing" },
+        { value: "[[ems__EffortStatusDone]]", label: "Done" },
+      ]);
+    });
+
+    it("should return null for unknown property", async () => {
+      mockSparqlService.query.mockResolvedValue([]);
+
+      const schema = await resolver.getSchema("exo__NonExistent_prop");
+
+      expect(schema).toBeNull();
+    });
+
+    it("should return null on query error", async () => {
+      mockSparqlService.query.mockRejectedValue(new Error("Query failed"));
+
+      const schema = await resolver.getSchema("exo__Asset_label");
+
+      expect(schema).toBeNull();
+    });
+
+    it("should cache schema after first load", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      await resolver.getSchema("exo__Asset_label");
+      await resolver.getSchema("exo__Asset_label");
+
+      expect(mockSparqlService.query).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return cached schema on second call", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#integer"],
+          ["label", "Votes"],
+        ]),
+      ]);
+
+      const first = await resolver.getSchema("ems__Effort_votes");
+      const second = await resolver.getSchema("ems__Effort_votes");
+
+      expect(first).toEqual(second);
+      expect(first!.type).toBe(PropertyFieldType.Number);
+    });
+
+    it("should extract label from property name when not provided", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#dateTime"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_createdAt");
+
+      expect(schema!.label).toBe("Created At");
+    });
+
+    it("should map dateTime range to DateTime field type", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#dateTime"],
+          ["label", "Created at"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_createdAt");
+
+      expect(schema!.type).toBe(PropertyFieldType.DateTime);
+    });
+
+    it("should map boolean range to Boolean field type", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#boolean"],
+          ["label", "Archived"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_isArchived");
+
+      expect(schema!.type).toBe(PropertyFieldType.Boolean);
+    });
+
+    it("should include validation when present", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#integer"],
+          ["label", "Votes"],
+          ["required", "true"],
+          ["minValue", "0"],
+          ["maxValue", "100"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("ems__Effort_votes");
+
+      expect(schema!.validation).toEqual({
+        required: true,
+        minValue: 0,
+        maxValue: 100,
+      });
+    });
+
+    it("should not include validation when no constraints present", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_label");
+
+      expect(schema!.validation).toBeUndefined();
+    });
+
+    it("should normalize full IRI to prefixed form for cache key", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      await resolver.getSchema("https://exocortex.my/ontology/exo#Asset_label");
+      await resolver.getSchema("exo__Asset_label");
+
+      expect(mockSparqlService.query).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle size-select type", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "https://exocortex.my/ontology/ems#TaskSize"],
+          ["label", "Size"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("ems__Task_size");
+
+      expect(schema!.type).toBe(PropertyFieldType.SizeSelect);
+    });
+
+    it("should deduplicate options by value", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "https://exocortex.my/ontology/ems#EffortStatus"],
+          ["label", "Status"],
+          ["optionValue", "Backlog"],
+          ["optionLabel", "Backlog"],
+        ]),
+        new Map<string, unknown>([
+          ["rangeType", "https://exocortex.my/ontology/ems#EffortStatus"],
+          ["label", "Status"],
+          ["optionValue", "Backlog"],
+          ["optionLabel", "Backlog Duplicate"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("ems__Effort_status");
+
+      expect(schema!.options).toHaveLength(1);
+      expect(schema!.options![0].label).toBe("Backlog");
+    });
+
+    it("should use option value as label when label not provided", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "https://exocortex.my/ontology/ems#EffortStatus"],
+          ["label", "Status"],
+          ["optionValue", "SomeValue"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("ems__Effort_status");
+
+      expect(schema!.options![0]).toEqual({ value: "SomeValue", label: "SomeValue" });
+    });
+
+    it("should include pattern in validation", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "UID"],
+          ["pattern", "^[a-f0-9-]+$"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_uid");
+
+      expect(schema!.validation).toEqual({
+        pattern: "^[a-f0-9-]+$",
+      });
+    });
+
+    it("should include maxLength in validation", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Short Name"],
+          ["maxLength", "50"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_shortName");
+
+      expect(schema!.validation).toEqual({
+        maxLength: 50,
+      });
+    });
+
+    it("should default to Text type when rangeType missing", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["label", "Something"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_something");
+
+      expect(schema!.type).toBe(PropertyFieldType.Text);
+    });
+  });
+
+  describe("getAllSchemas", () => {
+    it("should return all schemas from store", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["property", "https://exocortex.my/ontology/exo#Asset_label"],
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+        new Map<string, unknown>([
+          ["property", "https://exocortex.my/ontology/ems#Effort_votes"],
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#integer"],
+          ["label", "Votes"],
+        ]),
+      ]);
+
+      const schemas = await resolver.getAllSchemas();
+
+      expect(schemas.size).toBe(2);
+      expect(schemas.get("exo__Asset_label")!.type).toBe(PropertyFieldType.Text);
+      expect(schemas.get("ems__Effort_votes")!.type).toBe(PropertyFieldType.Number);
+    });
+
+    it("should cache all schemas after first load", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["property", "https://exocortex.my/ontology/exo#Asset_label"],
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      await resolver.getAllSchemas();
+      await resolver.getAllSchemas();
+
+      expect(mockSparqlService.query).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return empty map on query error", async () => {
+      mockSparqlService.query.mockRejectedValue(new Error("Query failed"));
+
+      const schemas = await resolver.getAllSchemas();
+
+      expect(schemas.size).toBe(0);
+    });
+
+    it("should skip bindings without property URI", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Orphan"],
+        ]),
+        new Map<string, unknown>([
+          ["property", "https://exocortex.my/ontology/exo#Asset_label"],
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      const schemas = await resolver.getAllSchemas();
+
+      expect(schemas.size).toBe(1);
+      expect(schemas.has("exo__Asset_label")).toBe(true);
+    });
+
+    it("should populate cache so getSchema uses cached value", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["property", "https://exocortex.my/ontology/exo#Asset_label"],
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      await resolver.getAllSchemas();
+      const schema = await resolver.getSchema("exo__Asset_label");
+
+      expect(mockSparqlService.query).toHaveBeenCalledTimes(1);
+      expect(schema!.type).toBe(PropertyFieldType.Text);
+    });
+  });
+
+  describe("invalidateCache", () => {
+    it("should clear cached schemas", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      await resolver.getSchema("exo__Asset_label");
+      resolver.invalidateCache();
+      await resolver.getSchema("exo__Asset_label");
+
+      expect(mockSparqlService.query).toHaveBeenCalledTimes(2);
+    });
+
+    it("should force getAllSchemas to reload", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["property", "https://exocortex.my/ontology/exo#Asset_label"],
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      await resolver.getAllSchemas();
+      resolver.invalidateCache();
+      await resolver.getAllSchemas();
+
+      expect(mockSparqlService.query).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("IRI conversion", () => {
+    it("should convert prefixed property name to full IRI in query", async () => {
+      mockSparqlService.query.mockResolvedValue([]);
+
+      await resolver.getSchema("ems__Effort_status");
+
+      expect(mockSparqlService.query).toHaveBeenCalledWith(
+        expect.stringContaining("<https://exocortex.my/ontology/ems#Effort_status>"),
+      );
+    });
+
+    it("should handle full IRI as input", async () => {
+      mockSparqlService.query.mockResolvedValue([]);
+
+      await resolver.getSchema("https://exocortex.my/ontology/exo#Asset_label");
+
+      expect(mockSparqlService.query).toHaveBeenCalledWith(
+        expect.stringContaining("<https://exocortex.my/ontology/exo#Asset_label>"),
+      );
+    });
+
+    it("should handle custom namespace prefix", async () => {
+      mockSparqlService.query.mockResolvedValue([]);
+
+      await resolver.getSchema("custom__MyProperty");
+
+      expect(mockSparqlService.query).toHaveBeenCalledWith(
+        expect.stringContaining("<https://exocortex.my/ontology/custom#MyProperty>"),
+      );
+    });
+  });
+
+  describe("with logger", () => {
+    it("should log warning on getSchema error", async () => {
+      const mockLogger = { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() };
+      const loggedResolver = new PropertySchemaResolver(mockSparqlService, mockLogger as any);
+
+      mockSparqlService.query.mockRejectedValue(new Error("Connection lost"));
+
+      await loggedResolver.getSchema("exo__Asset_label");
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to load schema"),
+        expect.objectContaining({ error: expect.stringContaining("Connection lost") }),
+      );
+    });
+
+    it("should log warning on getAllSchemas error", async () => {
+      const mockLogger = { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() };
+      const loggedResolver = new PropertySchemaResolver(mockSparqlService, mockLogger as any);
+
+      mockSparqlService.query.mockRejectedValue(new Error("Connection lost"));
+
+      await loggedResolver.getAllSchemas();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to load all schemas"),
+        expect.objectContaining({ error: expect.stringContaining("Connection lost") }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `PropertySchemaResolver` in `packages/exocortex/src/services/` that loads property schemas from triple store via SPARQL queries
- Wraps `ISPARQLQueryable` interface with in-memory caching and `invalidateCache()` for vault update scenarios
- Exports `PropertySchema`, `PropertySchemaOption`, `PropertySchemaValidation`, and `ISPARQLQueryable` types from core package

## Test plan
- [x] 30 unit tests covering: text property, enum with options, unknown returns null, caching, cache invalidation, validation constraints, IRI conversion, logger integration
- [x] TypeScript typecheck passes
- [x] All 6882 core tests pass
- [x] All 4478 plugin tests pass
- [x] ESLint, BDD coverage (100%), and archgate all green

Closes #2528