### PR TITLE
refactor(core): internal ExoQL rename — SPARQLParser -> ExoQLParser (#2538)

### DIFF
--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -5,10 +5,10 @@ import {
   InMemoryTripleStore,
   NoteToRDFConverter,
   NLToSPARQLService,
-  SPARQLParser,
-  AlgebraTranslator,
+  ExoQLParser,
+  ExoQLAlgebraTranslator,
   AlgebraOptimizer,
-  QueryExecutor,
+  ExoQLQueryExecutor,
 } from "exocortex";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
 import { injectExocortexPrefixes, transformShorthandNotation, filterOntologyPrefixes } from "../utils/QueryPrefixInjector.js";
@@ -139,21 +139,21 @@ export function askCommand(): Command {
         sparqlQuery = transformShorthandNotation(sparqlQuery);
         sparqlQuery = injectExocortexPrefixes(sparqlQuery);
 
-        const parser = new SPARQLParser();
+        const parser = new ExoQLParser();
         const vaultPrefixes = filterOntologyPrefixes(scanVaultNamespaces(vaultPath));
         if (vaultPrefixes.size > 0) {
           parser.setVaultPrefixes(vaultPrefixes);
         }
         const ast = parser.parse(sparqlQuery);
 
-        const translator = new AlgebraTranslator();
+        const translator = new ExoQLAlgebraTranslator();
         let algebra = translator.translate(ast);
 
         const optimizer = new AlgebraOptimizer();
         algebra = optimizer.optimize(algebra);
 
         const execStartTime = Date.now();
-        const executor = new QueryExecutor(tripleStore);
+        const executor = new ExoQLQueryExecutor(tripleStore);
         const results = await executor.executeAll(algebra);
         const execDuration = Date.now() - execStartTime;
         const totalDuration = Date.now() - startTime;

--- a/packages/cli/src/commands/classes.ts
+++ b/packages/cli/src/commands/classes.ts
@@ -3,10 +3,10 @@ import { existsSync } from "fs";
 import { resolve } from "path";
 import {
   InMemoryTripleStore,
-  SPARQLParser,
-  AlgebraTranslator,
+  ExoQLParser,
+  ExoQLAlgebraTranslator,
   AlgebraOptimizer,
-  QueryExecutor,
+  ExoQLQueryExecutor,
   NoteToRDFConverter,
   Triple,
   IRI,
@@ -119,14 +119,14 @@ async function listAllClasses(
     ORDER BY DESC(?count)
   `;
 
-  const parser = new SPARQLParser();
+  const parser = new ExoQLParser();
   const ast = parser.parse(query);
-  const translator = new AlgebraTranslator();
+  const translator = new ExoQLAlgebraTranslator();
   let algebra = translator.translate(ast);
   const optimizer = new AlgebraOptimizer();
   algebra = optimizer.optimize(algebra);
 
-  const executor = new QueryExecutor(tripleStore);
+  const executor = new ExoQLQueryExecutor(tripleStore);
   const results = await executor.executeAll(algebra);
 
   const classes: { name: string; count: number }[] = results.map((result) => {
@@ -182,14 +182,14 @@ async function showClassDetails(
     }
   `;
 
-  const parser = new SPARQLParser();
+  const parser = new ExoQLParser();
   let ast = parser.parse(countQuery);
-  let translator = new AlgebraTranslator();
+  let translator = new ExoQLAlgebraTranslator();
   let algebra = translator.translate(ast);
   let optimizer = new AlgebraOptimizer();
   algebra = optimizer.optimize(algebra);
 
-  const executor = new QueryExecutor(tripleStore);
+  const executor = new ExoQLQueryExecutor(tripleStore);
   const countResults = await executor.executeAll(algebra);
   const instanceCount = countResults.length > 0
     ? parseInt(countResults[0].get("count")?.toString() || "0", 10)
@@ -210,7 +210,7 @@ async function showClassDetails(
   `;
 
   ast = parser.parse(propsQuery);
-  translator = new AlgebraTranslator();
+  translator = new ExoQLAlgebraTranslator();
   algebra = translator.translate(ast);
   optimizer = new AlgebraOptimizer();
   algebra = optimizer.optimize(algebra);

--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -3,12 +3,12 @@ import { readFileSync, existsSync } from "fs";
 import { resolve } from "path";
 import {
   InMemoryTripleStore,
-  SPARQLParser,
+  ExoQLParser,
   SPARQLParseError,
-  AlgebraTranslator,
+  ExoQLAlgebraTranslator,
   AlgebraOptimizer,
   AlgebraSerializer,
-  QueryExecutor,
+  ExoQLQueryExecutor,
   NoteToRDFConverter,
   Triple,
   UpdateExecutor,
@@ -389,7 +389,7 @@ export function sparqlQueryCommand(): Command {
           console.log(`🔍 Parsing SPARQL query...`);
         }
 
-        const parser = new SPARQLParser();
+        const parser = new ExoQLParser();
 
         // Transform shorthand notation: <exo__Property> → exo:Property
         queryString = transformShorthandNotation(queryString);
@@ -463,7 +463,7 @@ export function sparqlQueryCommand(): Command {
         if (outputFormat === "text") {
           console.log(`🔄 Translating to algebra...`);
         }
-        const translator = new AlgebraTranslator();
+        const translator = new ExoQLAlgebraTranslator();
         let algebra = translator.translate(ast);
 
         // Optimization is only applicable to non-CONSTRUCT queries
@@ -497,7 +497,7 @@ export function sparqlQueryCommand(): Command {
         }
 
         const execStartTime = Date.now();
-        const executor = new QueryExecutor(tripleStore);
+        const executor = new ExoQLQueryExecutor(tripleStore);
 
         // Set query timeout if the executor supports it
         if (typeof executor.setTimeout === "function") {
@@ -757,7 +757,7 @@ async function executeDryRun(
   }
 
   // Simple validation without full analysis
-  const parser = new SPARQLParser();
+  const parser = new ExoQLParser();
 
   try {
     // Parse query to validate syntax
@@ -766,7 +766,7 @@ async function executeDryRun(
     // UPDATE queries don't go through algebra translation
     if (ast.type !== "update") {
       // Translate to algebra (validates query structure)
-      const translator = new AlgebraTranslator();
+      const translator = new ExoQLAlgebraTranslator();
       let algebra = translator.translate(ast);
 
       // Optimize if requested (validates optimization rules)

--- a/packages/cli/src/utils/QueryAnalyzer.ts
+++ b/packages/cli/src/utils/QueryAnalyzer.ts
@@ -1,7 +1,7 @@
 import {
-  SPARQLParser,
+  ExoQLParser,
   SPARQLParseError,
-  AlgebraTranslator,
+  ExoQLAlgebraTranslator,
   AlgebraOptimizer,
   AlgebraSerializer,
 } from "exocortex";
@@ -68,14 +68,14 @@ export interface QueryAnalyzerOptions {
  * Provides helpful error messages with suggestions for syntax errors.
  */
 export class QueryAnalyzer {
-  private readonly parser: SPARQLParser;
-  private readonly translator: AlgebraTranslator;
+  private readonly parser: ExoQLParser;
+  private readonly translator: ExoQLAlgebraTranslator;
   private readonly optimizer: AlgebraOptimizer;
   private readonly serializer: AlgebraSerializer;
 
   constructor() {
-    this.parser = new SPARQLParser();
-    this.translator = new AlgebraTranslator();
+    this.parser = new ExoQLParser();
+    this.translator = new ExoQLAlgebraTranslator();
     this.optimizer = new AlgebraOptimizer();
     this.serializer = new AlgebraSerializer();
   }

--- a/packages/cli/tests/unit/commands/ask.test.ts
+++ b/packages/cli/tests/unit/commands/ask.test.ts
@@ -40,14 +40,25 @@ jest.unstable_mockModule("exocortex", () => ({
     convertVault: jest.fn().mockResolvedValue([]),
   })),
   NLToSPARQLService: jest.fn(() => mockNLToSPARQLService),
+  ExoQLParser: jest.fn(() => ({
+    parse: jest.fn().mockReturnValue({ type: "query" }),
+  })),
   SPARQLParser: jest.fn(() => ({
     parse: jest.fn().mockReturnValue({ type: "query" }),
+  })),
+  ExoQLAlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
   })),
   AlgebraTranslator: jest.fn(() => ({
     translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
   })),
   AlgebraOptimizer: jest.fn(() => ({
     optimize: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+  ExoQLQueryExecutor: jest.fn(() => ({
+    executeAll: jest.fn().mockResolvedValue([
+      { getVariables: () => ["s"], toJSON: () => ({ s: "http://example.org/test" }) },
+    ]),
   })),
   QueryExecutor: jest.fn(() => ({
     executeAll: jest.fn().mockResolvedValue([

--- a/packages/cli/tests/unit/commands/classes.test.ts
+++ b/packages/cli/tests/unit/commands/classes.test.ts
@@ -10,15 +10,27 @@ jest.unstable_mockModule("exocortex", () => ({
   NoteToRDFConverter: jest.fn(() => ({
     convertVault: jest.fn().mockResolvedValue([]),
   })),
+  ExoQLParser: jest.fn(() => ({
+    parse: jest.fn().mockReturnValue({ type: "query", queryType: "SELECT" }),
+  })),
+
   SPARQLParser: jest.fn(() => ({
     parse: jest.fn().mockReturnValue({ type: "query" }),
   })),
+  ExoQLAlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+
   AlgebraTranslator: jest.fn(() => ({
     translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
   })),
   AlgebraOptimizer: jest.fn(() => ({
     optimize: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
   })),
+  ExoQLQueryExecutor: jest.fn(() => ({
+    executeAll: jest.fn().mockResolvedValue([]),
+  })),
+
   QueryExecutor: jest.fn(() => ({
     executeAll: jest.fn().mockResolvedValue([]),
     isConstructQuery: jest.fn().mockReturnValue(false),

--- a/packages/cli/tests/unit/commands/sparql-query-also.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-also.test.ts
@@ -26,6 +26,10 @@ jest.unstable_mockModule("../../../src/formatters/TriplesFormatter.js", () => ({
 
 jest.unstable_mockModule("exocortex", () => ({
   InMemoryTripleStore: jest.fn(() => ({ addAll: mockAddAll })),
+  ExoQLParser: jest.fn(() => ({
+    parse: jest.fn().mockReturnValue({ type: "query", queryType: "SELECT" }),
+  })),
+
   SPARQLParser: jest.fn(() => ({
     parse: jest.fn().mockReturnValue({ type: "query" }),
     setVaultPrefixes: jest.fn(),
@@ -33,6 +37,10 @@ jest.unstable_mockModule("exocortex", () => ({
   SPARQLParseError: class extends Error {
     constructor(m: string) { super(m); this.name = "SPARQLParseError"; }
   },
+  ExoQLAlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+
   AlgebraTranslator: jest.fn(() => ({
     translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
   })),
@@ -42,6 +50,10 @@ jest.unstable_mockModule("exocortex", () => ({
   AlgebraSerializer: jest.fn(() => ({
     toString: jest.fn().mockReturnValue("BGP()"),
   })),
+  ExoQLQueryExecutor: jest.fn(() => ({
+    executeAll: jest.fn().mockResolvedValue([]),
+  })),
+
   QueryExecutor: jest.fn(() => ({
     executeAll: jest.fn().mockResolvedValue([]),
     isConstructQuery: jest.fn().mockReturnValue(false),

--- a/packages/cli/tests/unit/commands/sparql-query-debug.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-debug.test.ts
@@ -24,6 +24,9 @@ jest.unstable_mockModule("exocortex", () => ({
   InMemoryTripleStore: jest.fn(() => ({
     addAll: jest.fn(),
   })),
+  ExoQLParser: jest.fn(() => ({
+    parse: mockParseFn,
+  })),
   SPARQLParser: jest.fn(() => ({
     parse: mockParseFn,
   })),
@@ -37,6 +40,10 @@ jest.unstable_mockModule("exocortex", () => ({
       this.column = column;
     }
   },
+  ExoQLAlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+
   AlgebraTranslator: jest.fn(() => ({
     translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
   })),
@@ -46,6 +53,10 @@ jest.unstable_mockModule("exocortex", () => ({
   AlgebraSerializer: jest.fn(() => ({
     toString: jest.fn().mockReturnValue("BGP()"),
   })),
+  ExoQLQueryExecutor: jest.fn(() => ({
+    executeAll: jest.fn().mockResolvedValue([]),
+  })),
+
   QueryExecutor: jest.fn(() => ({
     executeAll: jest.fn().mockResolvedValue([]),
     isConstructQuery: jest.fn().mockReturnValue(false),

--- a/packages/cli/tests/unit/commands/sparql-query.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query.test.ts
@@ -22,6 +22,10 @@ jest.unstable_mockModule("exocortex", () => ({
   InMemoryTripleStore: jest.fn(() => ({
     addAll: jest.fn(),
   })),
+  ExoQLParser: jest.fn(() => ({
+    parse: jest.fn().mockReturnValue({ type: "query", queryType: "SELECT" }),
+  })),
+
   SPARQLParser: jest.fn(() => ({
     parse: jest.fn().mockReturnValue({ type: "query" }),
   })),
@@ -35,6 +39,10 @@ jest.unstable_mockModule("exocortex", () => ({
       this.column = column;
     }
   },
+  ExoQLAlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+
   AlgebraTranslator: jest.fn(() => ({
     translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
   })),
@@ -44,6 +52,10 @@ jest.unstable_mockModule("exocortex", () => ({
   AlgebraSerializer: jest.fn(() => ({
     toString: jest.fn().mockReturnValue("BGP()"),
   })),
+  ExoQLQueryExecutor: jest.fn(() => ({
+    executeAll: jest.fn().mockResolvedValue([]),
+  })),
+
   QueryExecutor: jest.fn(() => ({
     executeAll: jest.fn().mockResolvedValue([]),
   })),

--- a/packages/cli/tests/unit/utils/QueryAnalyzer.test.ts
+++ b/packages/cli/tests/unit/utils/QueryAnalyzer.test.ts
@@ -14,10 +14,17 @@ const mockParseError = class SPARQLParseError extends Error {
 };
 
 jest.unstable_mockModule("exocortex", () => ({
+  ExoQLParser: jest.fn(() => ({
+    parse: mockParseFn,
+  })),
   SPARQLParser: jest.fn(() => ({
     parse: mockParseFn,
   })),
   SPARQLParseError: mockParseError,
+  ExoQLAlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+
   AlgebraTranslator: jest.fn(() => ({
     translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
   })),

--- a/packages/exocortex/src/exoql/index.ts
+++ b/packages/exocortex/src/exoql/index.ts
@@ -1,9 +1,9 @@
 import type { ITripleStore } from "../interfaces/ITripleStore";
 import type { Triple, Subject, Predicate, Object as RDFObject } from "../domain/models/rdf/Triple";
-import { SPARQLParser } from "../infrastructure/sparql/SPARQLParser";
-import { AlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
+import { ExoQLParser } from "../infrastructure/sparql/SPARQLParser";
+import { ExoQLAlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
 import {
-  QueryExecutor,
+  ExoQLQueryExecutor,
   type QueryExecutorConfig,
 } from "../infrastructure/sparql/executors/QueryExecutor";
 import type { SolutionMapping } from "../infrastructure/sparql/SolutionMapping";
@@ -17,7 +17,7 @@ import { Literal } from "../domain/models/rdf/Literal";
 /**
  * ExoQL  public facade for executing SPARQL queries against a triple store.
  *
- * Thin wrapper over the internal SPARQLParser  AlgebraTranslator  QueryExecutor
+ * Thin wrapper over the internal ExoQLParser → ExoQLAlgebraTranslator → ExoQLQueryExecutor
  * pipeline, providing a concise three-method API:
  *
  * - `query(sparql, store)`      SELECT  SolutionMapping[]
@@ -175,11 +175,11 @@ export class ExoQL {
     store: ITripleStore,
     config?: QueryExecutorConfig,
   ) {
-    const parser = new SPARQLParser();
-    const translator = new AlgebraTranslator();
+    const parser = new ExoQLParser();
+    const translator = new ExoQLAlgebraTranslator();
     const ast = parser.parse(sparql);
     const algebra = translator.translate(ast);
-    const executor = new QueryExecutor(store, config);
+    const executor = new ExoQLQueryExecutor(store, config);
     return { algebra, executor };
   }
 }

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -226,9 +226,9 @@ export { SourceAnnotator, SOURCE_VARIABLE, type TripleSource } from "./services/
 export { NoteToRDFConverter } from "./services/NoteToRDFConverter";
 
 // SPARQL Engine exports
-export { SPARQLParser, SPARQLParseError, type SPARQLQuery, type SelectQuery, type ConstructQuery, type Update, type UpdateOperation, type ExtendedDescribeQuery, type ParseResult } from "./infrastructure/sparql/SPARQLParser";
+export { ExoQLParser, SPARQLParser, SPARQLParseError, type SPARQLQuery, type SelectQuery, type ConstructQuery, type Update, type UpdateOperation, type ExtendedDescribeQuery, type ParseResult } from "./infrastructure/sparql/SPARQLParser";
 export { DescribeOptionsTransformer, DescribeOptionsTransformerError, type DescribeOptions, type DescribeTransformResult } from "./infrastructure/sparql/DescribeOptionsTransformer";
-export { AlgebraTranslator } from "./infrastructure/sparql/algebra/AlgebraTranslator";
+export { ExoQLAlgebraTranslator, AlgebraTranslator } from "./infrastructure/sparql/algebra/AlgebraTranslator";
 export { AlgebraOptimizer } from "./infrastructure/sparql/algebra/AlgebraOptimizer";
 export { AlgebraSerializer } from "./infrastructure/sparql/algebra/AlgebraSerializer";
 export type {
@@ -244,7 +244,7 @@ export { OptionalExecutor } from "./infrastructure/sparql/executors/OptionalExec
 export { UnionExecutor } from "./infrastructure/sparql/executors/UnionExecutor";
 export { ConstructExecutor } from "./infrastructure/sparql/executors/ConstructExecutor";
 export { DescribeExecutor, type DescribeExecutorOptions } from "./infrastructure/sparql/executors/DescribeExecutor";
-export { QueryExecutor } from "./infrastructure/sparql/executors/QueryExecutor";
+export { ExoQLQueryExecutor, QueryExecutor } from "./infrastructure/sparql/executors/QueryExecutor";
 export { UpdateExecutor, UpdateExecutorError, type UpdateResult } from "./infrastructure/sparql/executors/UpdateExecutor";
 export { SolutionMapping } from "./infrastructure/sparql/SolutionMapping";
 export { BuiltInFunctions } from "./infrastructure/sparql/filters/BuiltInFunctions";

--- a/packages/exocortex/src/infrastructure/sparql/SPARQLParser.ts
+++ b/packages/exocortex/src/infrastructure/sparql/SPARQLParser.ts
@@ -70,7 +70,7 @@ export interface SPARQLParserOptions {
   vocabularyResolver?: VocabularyResolver;
 }
 
-export class SPARQLParser {
+export class ExoQLParser {
   private readonly parser: InstanceType<typeof sparqljs.Parser>;
   private readonly generator: InstanceType<typeof sparqljs.Generator>;
   private readonly caseWhenTransformer: CaseWhenTransformer;
@@ -463,3 +463,6 @@ export class SPARQLParser {
     }
   }
 }
+
+/** @deprecated Use ExoQLParser instead. Will be removed in a future release. */
+export { ExoQLParser as SPARQLParser };

--- a/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraTranslator.ts
+++ b/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraTranslator.ts
@@ -32,7 +32,7 @@ export type DirectionMappings = Map<string, "ltr" | "rtl">;
  *
  * Public API is unchanged: callers use `translate()` and `setDirectionMappings()`.
  */
-export class AlgebraTranslator {
+export class ExoQLAlgebraTranslator {
   private readonly tripleTranslator: TripleTranslator;
   private readonly expressionTranslator: ExpressionTranslator;
   private readonly patternTranslator: PatternTranslator;
@@ -241,3 +241,6 @@ export class AlgebraTranslator {
     };
   }
 }
+
+/** @deprecated Use ExoQLAlgebraTranslator instead. Will be removed in a future release. */
+export { ExoQLAlgebraTranslator as AlgebraTranslator };

--- a/packages/exocortex/src/infrastructure/sparql/algebra/index.ts
+++ b/packages/exocortex/src/infrastructure/sparql/algebra/index.ts
@@ -1,4 +1,4 @@
-export { AlgebraTranslator, AlgebraTranslatorError } from "./AlgebraTranslator";
+export { ExoQLAlgebraTranslator, AlgebraTranslator, AlgebraTranslatorError } from "./AlgebraTranslator";
 export type { DirectionMappings } from "./AlgebraTranslator";
 export { ExpressionTranslator } from "./ExpressionTranslator";
 export { PatternTranslator } from "./PatternTranslator";

--- a/packages/exocortex/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -59,7 +59,7 @@ export interface QueryExecutorConfig {
   serviceConfig?: ServiceExecutorConfig;
 }
 
-export class QueryExecutor {
+export class ExoQLQueryExecutor {
   private readonly tripleStore: ITripleStore;
   private readonly bgpExecutor: BGPExecutor;
   private readonly filterExecutor: FilterExecutor;
@@ -720,7 +720,7 @@ export class QueryExecutor {
   private async *executeGraph(operation: GraphOperation): AsyncIterableIterator<SolutionMapping> {
     // Create a pattern executor that respects graph context
     const executePatternInGraph = async function* (
-      this: QueryExecutor,
+      this: ExoQLQueryExecutor,
       pattern: AlgebraOperation,
       graphContext?: IRI
     ): AsyncIterableIterator<SolutionMapping> {
@@ -969,3 +969,6 @@ export class QueryExecutor {
     return false; // No solutions found
   }
 }
+
+/** @deprecated Use ExoQLQueryExecutor instead. Will be removed in a future release. */
+export { ExoQLQueryExecutor as QueryExecutor };

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -4,9 +4,9 @@ import { IRI } from "../domain/models/rdf/IRI";
 import { Literal } from "../domain/models/rdf/Literal";
 import { Namespace } from "../domain/models/rdf/Namespace";
 import { GroundingType } from "../domain/constants/GroundingType";
-import { SPARQLParser } from "../infrastructure/sparql/SPARQLParser";
-import { AlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
-import { QueryExecutor } from "../infrastructure/sparql/executors/QueryExecutor";
+import { ExoQLParser } from "../infrastructure/sparql/SPARQLParser";
+import { ExoQLAlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
+import { ExoQLQueryExecutor } from "../infrastructure/sparql/executors/QueryExecutor";
 import type {
   CommandDefinition,
   PreconditionDefinition,
@@ -251,11 +251,11 @@ export class CommandResolver {
   ): Promise<string> {
     try {
       const query = sparqlBody.replace(/\$target/g, `<${targetIRI}>`);
-      const parser = new SPARQLParser();
+      const parser = new ExoQLParser();
       const parsed = parser.parse(query);
-      const translator = new AlgebraTranslator();
+      const translator = new ExoQLAlgebraTranslator();
       const algebra = translator.translate(parsed);
-      const executor = new QueryExecutor(this.tripleStore);
+      const executor = new ExoQLQueryExecutor(this.tripleStore);
       const solutions = await executor.executeAll(algebra);
 
       if (solutions.length === 0) return "";

--- a/packages/exocortex/src/services/PreconditionEvaluator.ts
+++ b/packages/exocortex/src/services/PreconditionEvaluator.ts
@@ -1,9 +1,9 @@
 import { injectable } from "tsyringe";
 import type { ITripleStore } from "../interfaces/ITripleStore";
 import type { PreconditionDefinition } from "../domain/models/CommandDefinition";
-import { SPARQLParser } from "../infrastructure/sparql/SPARQLParser";
-import { AlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
-import { QueryExecutor } from "../infrastructure/sparql/executors/QueryExecutor";
+import { ExoQLParser } from "../infrastructure/sparql/SPARQLParser";
+import { ExoQLAlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
+import { ExoQLQueryExecutor } from "../infrastructure/sparql/executors/QueryExecutor";
 import type { AskOperation } from "../infrastructure/sparql/algebra/AlgebraOperation";
 
 /**
@@ -107,12 +107,12 @@ export class PreconditionEvaluator {
       sparqlAsk,
       PreconditionEvaluator.SENTINEL_IRI,
     );
-    const parser = new SPARQLParser();
+    const parser = new ExoQLParser();
     const parsed = parser.parse(processedQuery);
-    const translator = new AlgebraTranslator();
+    const translator = new ExoQLAlgebraTranslator();
     const algebra = translator.translate(parsed);
 
-    const executor = new QueryExecutor(this.tripleStore);
+    const executor = new ExoQLQueryExecutor(this.tripleStore);
     if (!executor.isAskQuery(algebra)) {
       return null;
     }
@@ -155,7 +155,7 @@ export class PreconditionEvaluator {
         ),
       ) as AskOperation;
 
-      const executor = new QueryExecutor(this.tripleStore);
+      const executor = new ExoQLQueryExecutor(this.tripleStore);
       return await executor.executeAsk(instantiated);
     } catch {
       return false;

--- a/packages/obsidian-plugin/src/application/processors/SPARQLCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/SPARQLCodeBlockProcessor.ts
@@ -2,9 +2,9 @@ import React from "react";
 import { MarkdownPostProcessorContext, EventRef, Notice, MarkdownRenderChild } from "obsidian";
 import {
   InMemoryTripleStore,
-  SPARQLParser,
+  ExoQLParser,
   SPARQLParseError,
-  AlgebraTranslator,
+  ExoQLAlgebraTranslator,
   AlgebraOptimizer,
   BGPExecutor,
   ConstructExecutor,
@@ -405,10 +405,10 @@ export class SPARQLCodeBlockProcessor {
       throw new Error("Triple store not initialized");
     }
 
-    const parser = new SPARQLParser();
+    const parser = new ExoQLParser();
     const ast: SPARQLQuery = parser.parse(queryString);
 
-    const translator = new AlgebraTranslator();
+    const translator = new ExoQLAlgebraTranslator();
     let algebra = translator.translate(ast);
 
     const optimizer = new AlgebraOptimizer();

--- a/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
+++ b/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
@@ -1,7 +1,7 @@
 import { App, TFile } from "obsidian";
 import {
-  SPARQLParser,
-  AlgebraTranslator,
+  ExoQLParser,
+  ExoQLAlgebraTranslator,
   AlgebraOptimizer,
   BGPExecutor,
   type SPARQLQuery,
@@ -19,8 +19,8 @@ import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
 
 export class SPARQLQueryService {
   private indexer: VaultRDFIndexer;
-  private parser: SPARQLParser;
-  private translator: AlgebraTranslator;
+  private parser: ExoQLParser;
+  private translator: ExoQLAlgebraTranslator;
   private optimizer: AlgebraOptimizer;
   private executor: BGPExecutor | null = null;
   private isInitialized = false;
@@ -55,8 +55,8 @@ export class SPARQLQueryService {
     );
 
     this.indexer = new VaultRDFIndexer(app, this.logger, notifier);
-    this.parser = new SPARQLParser();
-    this.translator = new AlgebraTranslator();
+    this.parser = new ExoQLParser();
+    this.translator = new ExoQLAlgebraTranslator();
     this.optimizer = new AlgebraOptimizer();
   }
 


### PR DESCRIPTION
## Summary
- Renames `SPARQLParser` → `ExoQLParser`, `AlgebraTranslator` → `ExoQLAlgebraTranslator`, `QueryExecutor` → `ExoQLQueryExecutor` across all packages
- Old names kept as deprecated re-exports for backward compatibility (one release cycle)
- All internal imports updated in core, CLI, and obsidian-plugin packages
- Test mocks updated to provide both old and new names

## Test plan
- [x] Core package: 215 suites, 6852 tests pass
- [x] CLI package: 74 suites, 1212 tests pass
- [x] Plugin unit tests: 214 suites, 4478 tests pass
- [x] Plugin component tests: 539 tests pass
- [x] TypeScript typecheck clean
- [x] BDD coverage: 100%
- [x] Archgate: all 13 rules pass

Closes #2538