### PR TITLE
refactor(plugin): CreateInstance uses InstantiationRuleResolver (#2536)

### DIFF
--- a/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
@@ -2,23 +2,27 @@ import { App, TFile } from "obsidian";
 import {
   CommandVisibilityContext,
   canCreateInstance,
-  TaskCreationService,
   WikiLinkHelpers,
-  AssetClass,
   DateFormatter,
+  GenericAssetCreationService,
+  type InstantiationRule,
+  type InstantiationRuleResolver,
   type IFile,
 } from "exocortex";
 import { showLabelInputModal, type LabelInputModalResult } from '@plugin/presentation/modals/modalSchemas';
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
 import { BaseContextAssetCreationCommand } from "./base/BaseContextAssetCreationCommand";
+import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
 
 export class CreateInstanceCommand extends BaseContextAssetCreationCommand {
   readonly id = "create-instance";
   readonly name = "Create instance";
+  private readonly logger = LoggerFactory.create("CreateInstanceCommand");
 
   constructor(
     app: App,
-    private taskCreationService: TaskCreationService,
+    private readonly ruleResolver: InstantiationRuleResolver,
+    private readonly genericAssetCreationService: GenericAssetCreationService,
     vaultAdapter: ObsidianVaultAdapter,
   ) {
     super(app, vaultAdapter);
@@ -38,20 +42,13 @@ export class CreateInstanceCommand extends BaseContextAssetCreationCommand {
 
   protected override showModal(
     file: TFile,
-    context: CommandVisibilityContext,
+    _context: CommandVisibilityContext,
     metadata: Record<string, unknown>,
   ): Promise<LabelInputModalResult> {
-    const instanceClass = context.instanceClass;
-    const classes = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
-    const firstClass = classes[0] || "";
-    const sourceClass = WikiLinkHelpers.normalize(firstClass);
-
-    const showTaskSize = sourceClass !== AssetClass.MEETING_PROTOTYPE;
-
     const baseLabel = String(metadata.exo__Asset_label || file.basename);
     const defaultLabel = `${baseLabel} ${DateFormatter.toDateString(new Date())}`;
 
-    return showLabelInputModal(this.app, defaultLabel, showTaskSize);
+    return showLabelInputModal(this.app, defaultLabel, true);
   }
 
   protected async createAsset(
@@ -65,12 +62,83 @@ export class CreateInstanceCommand extends BaseContextAssetCreationCommand {
     const firstClass = classes[0] || "";
     const sourceClass = WikiLinkHelpers.normalize(firstClass);
 
-    return this.taskCreationService.createTask(
-      file,
-      metadata,
-      sourceClass,
-      modalResult.label as string,
-      modalResult.taskSize,
-    );
+    const rule = await this.ruleResolver.getRule(sourceClass);
+
+    if (rule) {
+      return this.createFromRule(file, metadata, sourceClass, modalResult, rule);
+    }
+
+    this.logger.warn(`No instantiation rule for ${sourceClass}, using generic fallback`);
+    return this.createFallback(file, metadata, sourceClass, modalResult);
+  }
+
+  private async createFromRule(
+    file: TFile,
+    metadata: Record<string, unknown>,
+    sourceClass: string,
+    modalResult: LabelInputModalResult,
+    rule: InstantiationRule,
+  ): Promise<IFile> {
+    const propertyValues: Record<string, unknown> = {};
+
+    if (rule.prototypeUID) {
+      propertyValues["exo__Asset_prototype"] = `"[[${rule.prototypeUID}]]"`;
+    }
+
+    if (modalResult.taskSize) {
+      propertyValues["ems__Effort_taskSize"] = modalResult.taskSize;
+    }
+
+    for (const psr of rule.propertySetRules) {
+      if (psr.valueType === "wikilink") {
+        propertyValues[psr.property] = `"[[${psr.value}]]"`;
+      } else {
+        propertyValues[psr.property] = psr.value;
+      }
+    }
+
+    const folderPath = rule.defaultFolder || file.parent?.path || "";
+
+    return this.genericAssetCreationService.createAsset({
+      className: sourceClass,
+      label: modalResult.label || undefined,
+      folderPath,
+      propertyValues,
+      parentFile: this.toIFile(file),
+      parentMetadata: metadata,
+    });
+  }
+
+  private async createFallback(
+    file: TFile,
+    metadata: Record<string, unknown>,
+    sourceClass: string,
+    modalResult: LabelInputModalResult,
+  ): Promise<IFile> {
+    const propertyValues: Record<string, unknown> = {};
+
+    if (modalResult.taskSize) {
+      propertyValues["ems__Effort_taskSize"] = modalResult.taskSize;
+    }
+
+    const folderPath = file.parent?.path || "";
+
+    return this.genericAssetCreationService.createAsset({
+      className: sourceClass,
+      label: modalResult.label || undefined,
+      folderPath,
+      propertyValues,
+      parentFile: this.toIFile(file),
+      parentMetadata: metadata,
+    });
+  }
+
+  private toIFile(tfile: TFile): IFile {
+    return {
+      path: tfile.path,
+      basename: tfile.basename,
+      name: tfile.name,
+      parent: tfile.parent ? { path: tfile.parent.path, name: tfile.parent.name } : null,
+    } as IFile;
   }
 }

--- a/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
@@ -2,11 +2,12 @@ import { flushPromises, waitForCondition } from "./helpers/testHelpers";
 import { CreateInstanceCommand } from "../../src/application/commands/CreateInstanceCommand";
 import { App, TFile, Notice, WorkspaceLeaf } from "obsidian";
 import {
-  TaskCreationService,
+  GenericAssetCreationService,
   CommandVisibilityContext,
   LoggingService,
-  AssetClass,
-  DateFormatter
+  DateFormatter,
+  type InstantiationRuleResolver,
+  type InstantiationRule,
 } from "exocortex";
 import { showLabelInputModal } from "../../src/presentation/modals/modalSchemas";
 import { ObsidianVaultAdapter } from "../../src/adapters/ObsidianVaultAdapter";
@@ -27,15 +28,13 @@ jest.mock("exocortex", () => ({
   WikiLinkHelpers: {
     normalize: jest.fn(),
   },
-  AssetClass: {
-    MEETING_PROTOTYPE: "MeetingPrototype",
-  },
 }));
 
 describe("CreateInstanceCommand", () => {
   let command: CreateInstanceCommand;
   let mockApp: jest.Mocked<App>;
-  let mockTaskCreationService: jest.Mocked<TaskCreationService>;
+  let mockRuleResolver: jest.Mocked<InstantiationRuleResolver>;
+  let mockGenericAssetCreationService: jest.Mocked<GenericAssetCreationService>;
   let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
@@ -45,22 +44,18 @@ describe("CreateInstanceCommand", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Setup WikiLinkHelpers mock
     const { WikiLinkHelpers } = require("exocortex");
     WikiLinkHelpers.normalize.mockImplementation((str: string) => str);
 
-    // Create mock leaf
     mockLeaf = {
       openFile: jest.fn(),
     } as unknown as jest.Mocked<WorkspaceLeaf>;
 
-    // Create mock TFile for created file
     mockTFile = {
       path: "new-instance.md",
       basename: "new-instance",
     } as jest.Mocked<TFile>;
 
-    // Create mock app
     mockApp = {
       workspace: {
         getLeaf: jest.fn().mockReturnValue(mockLeaf),
@@ -76,22 +71,26 @@ describe("CreateInstanceCommand", () => {
       },
     } as unknown as jest.Mocked<App>;
 
-    // Create mock services
-    mockTaskCreationService = {
-      createTask: jest.fn(),
-    } as unknown as jest.Mocked<TaskCreationService>;
+    mockRuleResolver = {
+      getRule: jest.fn().mockResolvedValue(null),
+      invalidateCache: jest.fn(),
+    } as unknown as jest.Mocked<InstantiationRuleResolver>;
+
+    mockGenericAssetCreationService = {
+      createAsset: jest.fn(),
+    } as unknown as jest.Mocked<GenericAssetCreationService>;
 
     mockVaultAdapter = {
       toTFile: jest.fn().mockReturnValue(mockTFile),
     } as unknown as jest.Mocked<ObsidianVaultAdapter>;
 
-    // Create mock file
     mockFile = {
       path: "test-file.md",
       basename: "test-file",
-    } as jest.Mocked<TFile>;
+      name: "test-file.md",
+      parent: { path: "parent-folder", name: "parent-folder" },
+    } as unknown as jest.Mocked<TFile>;
 
-    // Create mock context
     mockContext = {
       instanceClass: "Task",
       status: "Active",
@@ -99,8 +98,12 @@ describe("CreateInstanceCommand", () => {
       isDraft: false,
     };
 
-    // Create command instance
-    command = new CreateInstanceCommand(mockApp, mockTaskCreationService, mockVaultAdapter);
+    command = new CreateInstanceCommand(
+      mockApp,
+      mockRuleResolver,
+      mockGenericAssetCreationService,
+      mockVaultAdapter,
+    );
   });
 
   describe("id and name", () => {
@@ -116,213 +119,390 @@ describe("CreateInstanceCommand", () => {
     it("should return false when context is null", () => {
       const result = command.checkCallback(true, mockFile, null);
       expect(result).toBe(false);
-      expect(mockTaskCreationService.createTask).not.toHaveBeenCalled();
+      expect(mockGenericAssetCreationService.createAsset).not.toHaveBeenCalled();
     });
 
     it("should return false when canCreateInstance returns false", () => {
       mockCanCreateInstance.mockReturnValue(false);
       const result = command.checkCallback(true, mockFile, mockContext);
       expect(result).toBe(false);
-      expect(mockTaskCreationService.createTask).not.toHaveBeenCalled();
+      expect(mockGenericAssetCreationService.createAsset).not.toHaveBeenCalled();
     });
 
     it("should return true when canCreateInstance returns true and checking is true", () => {
       mockCanCreateInstance.mockReturnValue(true);
       const result = command.checkCallback(true, mockFile, mockContext);
       expect(result).toBe(true);
-      expect(mockTaskCreationService.createTask).not.toHaveBeenCalled();
-    });
-
-    it("should execute command when checking is false and canCreateInstance returns true", async () => {
-      mockCanCreateInstance.mockReturnValue(true);
-      const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
-
-      // Mock modal to return label and task size
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test Instance", taskSize: "medium", openInNewTab: false });
-
-      const result = command.checkCallback(false, mockFile, mockContext);
-      expect(result).toBe(true);
-
-      // Wait for async execution
-      await flushPromises();
-
-      expect(mockShowLabelInputModal).toHaveBeenCalledWith(mockApp,
-        `test-file ${DateFormatter.toDateString(new Date())}`,
-        true
-      );
-      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
-        mockFile,
-        { key: "value" },
-        "Task",
-        "Test Instance",
-        "medium"
-      );
-      expect(mockVaultAdapter.toTFile).toHaveBeenCalledWith(createdFile);
-      expect(mockLeaf.openFile).toHaveBeenCalledWith(mockTFile);
-      expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, { focus: true });
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+      expect(mockGenericAssetCreationService.createAsset).not.toHaveBeenCalled();
     });
 
     it("should handle modal cancellation", async () => {
       mockCanCreateInstance.mockReturnValue(true);
-
-      // Mock modal to return null (cancelled)
       mockShowLabelInputModal.mockResolvedValue({ label: null, taskSize: null, openInNewTab: false });
 
       const result = command.checkCallback(false, mockFile, mockContext);
       expect(result).toBe(true);
 
-      // Wait for async execution
       await flushPromises();
 
       expect(mockShowLabelInputModal).toHaveBeenCalled();
-      expect(mockTaskCreationService.createTask).not.toHaveBeenCalled();
+      expect(mockGenericAssetCreationService.createAsset).not.toHaveBeenCalled();
       expect(Notice).not.toHaveBeenCalled();
     });
+  });
+
+  describe("rule-based creation", () => {
+    const mockCanCreateInstance = require("exocortex").canCreateInstance;
+
+    it("should create asset using resolved InstantiationRule", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const rule: InstantiationRule = {
+        prototypeUID: "proto-uid-123",
+        defaultFolder: "02 Areas/tasks",
+        propertySetRules: [
+          { property: "ems__Effort_status", value: "753a44d5-846c-4b82-9196-4fd9a4d48777", valueType: "wikilink" },
+        ],
+      };
+      mockRuleResolver.getRule.mockResolvedValue(rule);
+      const createdFile = { basename: "new-instance", path: "02 Areas/tasks/new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "My Task", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(mockRuleResolver.getRule).toHaveBeenCalledWith("Task");
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          className: "Task",
+          label: "My Task",
+          folderPath: "02 Areas/tasks",
+          propertyValues: expect.objectContaining({
+            "exo__Asset_prototype": '"[[proto-uid-123]]"',
+            "ems__Effort_status": '"[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"',
+          }),
+        }),
+      );
+      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+    });
+
+    it("should include taskSize in propertyValues when provided", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const rule: InstantiationRule = {
+        prototypeUID: "proto-uid-123",
+        defaultFolder: "tasks",
+        propertySetRules: [],
+      };
+      mockRuleResolver.getRule.mockResolvedValue(rule);
+      const createdFile = { basename: "new-instance", path: "tasks/new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "My Task", taskSize: '"[[ems__TaskSize_S]]"', openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          propertyValues: expect.objectContaining({
+            "ems__Effort_taskSize": '"[[ems__TaskSize_S]]"',
+          }),
+        }),
+      );
+    });
+
+    it("should handle rule with multiple propertySetRules", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const rule: InstantiationRule = {
+        prototypeUID: "proto-uid",
+        defaultFolder: "tasks",
+        propertySetRules: [
+          { property: "ems__Effort_status", value: "backlog-uid", valueType: "wikilink" },
+          { property: "exo__Asset_isDefinedBy", value: "ontology-uid", valueType: "wikilink" },
+          { property: "ems__Effort_priority", value: "3", valueType: "literal" },
+        ],
+      };
+      mockRuleResolver.getRule.mockResolvedValue(rule);
+      const createdFile = { basename: "new-instance", path: "tasks/new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "Task", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          propertyValues: expect.objectContaining({
+            "ems__Effort_status": '"[[backlog-uid]]"',
+            "exo__Asset_isDefinedBy": '"[[ontology-uid]]"',
+            "ems__Effort_priority": "3",
+          }),
+        }),
+      );
+    });
+
+    it("should handle rule with null prototypeUID", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const rule: InstantiationRule = {
+        prototypeUID: null,
+        defaultFolder: "tasks",
+        propertySetRules: [],
+      };
+      mockRuleResolver.getRule.mockResolvedValue(rule);
+      const createdFile = { basename: "new-instance", path: "tasks/new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "Task", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      const callArgs = mockGenericAssetCreationService.createAsset.mock.calls[0][0];
+      expect(callArgs.propertyValues).not.toHaveProperty("exo__Asset_prototype");
+    });
+
+    it("should fall back to parent folder when rule has null defaultFolder", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const rule: InstantiationRule = {
+        prototypeUID: "proto-uid",
+        defaultFolder: null,
+        propertySetRules: [],
+      };
+      mockRuleResolver.getRule.mockResolvedValue(rule);
+      const createdFile = { basename: "new-instance", path: "parent-folder/new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "Task", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          folderPath: "parent-folder",
+        }),
+      );
+    });
+  });
+
+  describe("fallback creation (no rule found)", () => {
+    const mockCanCreateInstance = require("exocortex").canCreateInstance;
+
+    it("should use generic fallback when no rule exists", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      mockRuleResolver.getRule.mockResolvedValue(null);
+      const createdFile = { basename: "new-instance", path: "parent-folder/new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test Instance", taskSize: '"[[ems__TaskSize_M]]"', openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(mockRuleResolver.getRule).toHaveBeenCalledWith("Task");
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          className: "Task",
+          label: "Test Instance",
+          folderPath: "parent-folder",
+          propertyValues: expect.objectContaining({
+            "ems__Effort_taskSize": '"[[ems__TaskSize_M]]"',
+          }),
+        }),
+      );
+      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+    });
+
+    it("should handle fallback with empty label", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      mockRuleResolver.getRule.mockResolvedValue(null);
+      const createdFile = { basename: "new-instance", path: "parent-folder/new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          label: undefined,
+        }),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    const mockCanCreateInstance = require("exocortex").canCreateInstance;
 
     it("should handle service error and show error notice", async () => {
       mockCanCreateInstance.mockReturnValue(true);
-      const error = new Error("Failed to create task");
-      mockTaskCreationService.createTask.mockRejectedValue(error);
+      const error = new Error("Failed to create asset");
+      mockGenericAssetCreationService.createAsset.mockRejectedValue(error);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       const result = command.checkCallback(false, mockFile, mockContext);
       expect(result).toBe(true);
 
-      // Wait for async execution
       await flushPromises();
 
-      expect(mockTaskCreationService.createTask).toHaveBeenCalled();
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalled();
       expect(LoggingService.error).toHaveBeenCalledWith("Create instance error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to create instance: Failed to create task");
+      expect(Notice).toHaveBeenCalledWith("Failed to create instance: Failed to create asset");
     });
 
-    it("should handle array instanceClass", async () => {
+    it("should handle ruleResolver error gracefully", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      mockRuleResolver.getRule.mockRejectedValue(new Error("Triple store unavailable"));
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(Notice).toHaveBeenCalledWith("Failed to create instance: Triple store unavailable");
+    });
+  });
+
+  describe("array instanceClass", () => {
+    const mockCanCreateInstance = require("exocortex").canCreateInstance;
+
+    it("should handle array instanceClass and use first element", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const arrayContext = {
         ...mockContext,
         instanceClass: ["Task", "Project"],
       };
-      const createdFile = { basename: "new-task", path: "new-task.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockRuleResolver.getRule.mockResolvedValue(null);
+      const createdFile = { basename: "new-task", path: "parent-folder/new-task.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "My Task", taskSize: "large", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "My Task", taskSize: null, openInNewTab: false });
 
-      const result = command.checkCallback(false, mockFile, arrayContext);
-      expect(result).toBe(true);
-
-      // Wait for async execution
+      command.checkCallback(false, mockFile, arrayContext);
       await flushPromises();
 
-      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
-        mockFile,
-        { key: "value" },
-        "Task", // First class in array
-        "My Task",
-        "large"
+      expect(mockRuleResolver.getRule).toHaveBeenCalledWith("Task");
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalledWith(
+        expect.objectContaining({ className: "Task" }),
       );
       expect(Notice).toHaveBeenCalledWith("Instance created: new-task");
     });
 
-    it("should not show task size for MeetingPrototype", async () => {
+    it("should handle empty instanceClass array", async () => {
       mockCanCreateInstance.mockReturnValue(true);
-      const meetingContext = {
-        ...mockContext,
-        instanceClass: AssetClass.MEETING_PROTOTYPE,
-      };
-      const createdFile = { basename: "new-meeting", path: "new-meeting.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      const emptyContext = { ...mockContext, instanceClass: [] };
+      mockRuleResolver.getRule.mockResolvedValue(null);
+      const createdFile = { basename: "new-instance", path: "parent-folder/new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Meeting", taskSize: null, openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
-      const result = command.checkCallback(false, mockFile, meetingContext);
-      expect(result).toBe(true);
-
-      // Wait for async execution
+      command.checkCallback(false, mockFile, emptyContext);
       await flushPromises();
 
-      expect(mockShowLabelInputModal).toHaveBeenCalledWith(mockApp,
-        `test-file ${DateFormatter.toDateString(new Date())}`,
-        false // showTaskSize should be false for MeetingPrototype
+      expect(mockRuleResolver.getRule).toHaveBeenCalledWith("");
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalledWith(
+        expect.objectContaining({ className: "" }),
+      );
+    });
+  });
+
+  describe("modal defaults", () => {
+    const mockCanCreateInstance = require("exocortex").canCreateInstance;
+
+    it("should pass default label based on file label and date", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
+        frontmatter: { exo__Asset_label: "My Prototype" },
+      });
+      mockRuleResolver.getRule.mockResolvedValue(null);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(mockShowLabelInputModal).toHaveBeenCalledWith(
+        mockApp,
+        `My Prototype ${DateFormatter.toDateString(new Date())}`,
+        true,
       );
     });
 
+    it("should use file basename when no label in metadata", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
+        frontmatter: {},
+      });
+      mockRuleResolver.getRule.mockResolvedValue(null);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      expect(mockShowLabelInputModal).toHaveBeenCalledWith(
+        mockApp,
+        `test-file ${DateFormatter.toDateString(new Date())}`,
+        true,
+      );
+    });
+  });
+
+  describe("file activation wait", () => {
+    const mockCanCreateInstance = require("exocortex").canCreateInstance;
+
     it("should wait for file to become active via polling", async () => {
       mockCanCreateInstance.mockReturnValue(true);
+      mockRuleResolver.getRule.mockResolvedValue(null);
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
-      // File becomes active after 3 polling attempts
       let attempts = 0;
       mockApp.workspace.getActiveFile = jest.fn(() => {
         attempts++;
         return attempts >= 3 ? mockTFile : null;
       });
 
-      const result = command.checkCallback(false, mockFile, mockContext);
-      expect(result).toBe(true);
+      command.checkCallback(false, mockFile, mockContext);
 
-      // Wait for polling to complete
       await waitForCondition(
         () => (Notice as jest.Mock).mock.calls.some(call => call[0] === "Instance created: new-instance"),
-        { timeout: 3000 }
+        { timeout: 3000 },
       );
 
       expect((mockApp.workspace.getActiveFile as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(3);
       expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
     });
+  });
 
-    it("should handle missing frontmatter metadata", async () => {
-      mockCanCreateInstance.mockReturnValue(true);
-      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({});
-      const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
-
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "medium", openInNewTab: false });
-
-      const result = command.checkCallback(false, mockFile, mockContext);
-      expect(result).toBe(true);
-
-      // Wait for async execution
-      await flushPromises();
-
-      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
-        mockFile,
-        {}, // Empty metadata
-        "Task", // sourceClass still comes from context.instanceClass
-        "Test",
-        "medium"
-      );
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
-    });
+  describe("null metadata handling", () => {
+    const mockCanCreateInstance = require("exocortex").canCreateInstance;
 
     it("should handle null cache from metadataCache", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue(null);
+      mockRuleResolver.getRule.mockResolvedValue(null);
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
-      const result = command.checkCallback(false, mockFile, mockContext);
-      expect(result).toBe(true);
-
-      // Wait for async execution
+      command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
-        mockFile,
-        {}, // Empty metadata
-        "Task", // sourceClass still comes from context.instanceClass
-        "Test",
-        "small"
-      );
+      expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalled();
       expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
     });
-
   });
 });

--- a/packages/obsidian-plugin/tests/unit/error-handling.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling.test.ts
@@ -20,11 +20,12 @@ import { flushPromises } from "./helpers/testHelpers";
 import { CreateInstanceCommand } from "../../src/application/commands/CreateInstanceCommand";
 import { App, TFile, Notice, WorkspaceLeaf, TFolder, Vault, MetadataCache, FileManager, Plugin } from "obsidian";
 import {
-  TaskCreationService,
+  GenericAssetCreationService,
   CommandVisibilityContext,
   LoggingService,
   IFile,
   IVaultContext,
+  type InstantiationRuleResolver,
 } from "exocortex";
 import { showLabelInputModal } from "../../src/presentation/modals/modalSchemas";
 import { ObsidianVaultAdapter } from "../../src/adapters/ObsidianVaultAdapter";
@@ -64,7 +65,8 @@ describe("Error Handling - Negative Tests", () => {
   describe("1. CreateInstanceCommand - toTFile conversion failure", () => {
     let command: CreateInstanceCommand;
     let mockApp: jest.Mocked<App>;
-    let mockTaskCreationService: jest.Mocked<TaskCreationService>;
+    let mockRuleResolver: jest.Mocked<InstantiationRuleResolver>;
+    let mockGenericAssetCreationService: jest.Mocked<GenericAssetCreationService>;
     let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
     let mockFile: jest.Mocked<TFile>;
     let mockContext: CommandVisibilityContext;
@@ -93,9 +95,14 @@ describe("Error Handling - Negative Tests", () => {
         },
       } as unknown as jest.Mocked<App>;
 
-      mockTaskCreationService = {
-        createTask: jest.fn(),
-      } as unknown as jest.Mocked<TaskCreationService>;
+      mockRuleResolver = {
+        getRule: jest.fn().mockResolvedValue(null),
+        invalidateCache: jest.fn(),
+      } as unknown as jest.Mocked<InstantiationRuleResolver>;
+
+      mockGenericAssetCreationService = {
+        createAsset: jest.fn(),
+      } as unknown as jest.Mocked<GenericAssetCreationService>;
 
       // Return null from toTFile to trigger error
       mockVaultAdapter = {
@@ -105,7 +112,9 @@ describe("Error Handling - Negative Tests", () => {
       mockFile = {
         path: "test-file.md",
         basename: "test-file",
-      } as jest.Mocked<TFile>;
+        name: "test-file.md",
+        parent: { path: "parent-folder", name: "parent-folder" },
+      } as unknown as jest.Mocked<TFile>;
 
       mockContext = {
         instanceClass: "Task",
@@ -114,7 +123,7 @@ describe("Error Handling - Negative Tests", () => {
         isDraft: false,
       };
 
-      command = new CreateInstanceCommand(mockApp, mockTaskCreationService, mockVaultAdapter);
+      command = new CreateInstanceCommand(mockApp, mockRuleResolver, mockGenericAssetCreationService, mockVaultAdapter);
     });
 
     it("should show error notice when toTFile returns null", async () => {
@@ -122,9 +131,9 @@ describe("Error Handling - Negative Tests", () => {
       mockCanCreateInstance.mockReturnValue(true);
 
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
 

--- a/packages/obsidian-plugin/tests/unit/error-handling/CreateInstanceCommand.error.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/CreateInstanceCommand.error.test.ts
@@ -1,23 +1,11 @@
-/**
- * CreateInstanceCommand Error Handling Tests
- *
- * Tests error scenarios for:
- * - Modal failures and cancellations
- * - Task creation service failures
- * - File conversion errors
- * - Workspace operation errors
- * - Non-Error throwable handling
- *
- * Issue: #788 - Add negative tests for error handling
- */
-
 import { flushPromises } from "../helpers/testHelpers";
 import { CreateInstanceCommand } from "../../../src/application/commands/CreateInstanceCommand";
 import { App, TFile, Notice, WorkspaceLeaf } from "obsidian";
 import {
-  TaskCreationService,
+  GenericAssetCreationService,
   CommandVisibilityContext,
   LoggingService,
+  type InstantiationRuleResolver,
 } from "exocortex";
 import { showLabelInputModal } from "../../../src/presentation/modals/modalSchemas";
 import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
@@ -38,17 +26,14 @@ jest.mock("exocortex", () => ({
   WikiLinkHelpers: {
     normalize: jest.fn(),
   },
-  AssetClass: {
-    MEETING_PROTOTYPE: "MeetingPrototype",
-  },
 }));
 
 describe("CreateInstanceCommand Error Handling", () => {
   let command: CreateInstanceCommand;
   let mockApp: jest.Mocked<App>;
-  let mockTaskCreationService: jest.Mocked<TaskCreationService>;
+  let mockRuleResolver: jest.Mocked<InstantiationRuleResolver>;
+  let mockGenericAssetCreationService: jest.Mocked<GenericAssetCreationService>;
   let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
-  let mockPlugin: jest.Mocked<ExocortexPluginInterface>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
   let mockLeaf: jest.Mocked<WorkspaceLeaf>;
@@ -84,22 +69,25 @@ describe("CreateInstanceCommand Error Handling", () => {
       },
     } as unknown as jest.Mocked<App>;
 
-    mockTaskCreationService = {
-      createTask: jest.fn(),
-    } as unknown as jest.Mocked<TaskCreationService>;
+    mockRuleResolver = {
+      getRule: jest.fn().mockResolvedValue(null),
+      invalidateCache: jest.fn(),
+    } as unknown as jest.Mocked<InstantiationRuleResolver>;
+
+    mockGenericAssetCreationService = {
+      createAsset: jest.fn(),
+    } as unknown as jest.Mocked<GenericAssetCreationService>;
 
     mockVaultAdapter = {
       toTFile: jest.fn().mockReturnValue(mockTFile),
     } as unknown as jest.Mocked<ObsidianVaultAdapter>;
 
-    mockPlugin = {
-      settings: {},
-    } as unknown as jest.Mocked<ExocortexPluginInterface>;
-
     mockFile = {
       path: "test-file.md",
       basename: "test-file",
-    } as jest.Mocked<TFile>;
+      name: "test-file.md",
+      parent: { path: "parent-folder", name: "parent-folder" },
+    } as unknown as jest.Mocked<TFile>;
 
     mockContext = {
       instanceClass: "Task",
@@ -110,9 +98,9 @@ describe("CreateInstanceCommand Error Handling", () => {
 
     command = new CreateInstanceCommand(
       mockApp,
-      mockTaskCreationService,
+      mockRuleResolver,
+      mockGenericAssetCreationService,
       mockVaultAdapter,
-      mockPlugin
     );
   });
 
@@ -121,8 +109,6 @@ describe("CreateInstanceCommand Error Handling", () => {
 
     it("should handle modal throwing an error during open", async () => {
       mockCanCreateInstance.mockReturnValue(true);
-
-      // Mock modal to throw an error
       mockShowLabelInputModal.mockRejectedValue(new Error("Modal initialization failed"));
 
       const result = command.checkCallback(false, mockFile, mockContext);
@@ -132,17 +118,15 @@ describe("CreateInstanceCommand Error Handling", () => {
 
       expect(LoggingService.error).toHaveBeenCalledWith(
         "Create instance error",
-        expect.any(Error)
+        expect.any(Error),
       );
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: Modal initialization failed"
+        "Failed to create instance: Modal initialization failed",
       );
     });
 
     it("should handle modal callback never being called (modal hangs)", async () => {
       mockCanCreateInstance.mockReturnValue(true);
-
-      // Mock modal that never resolves (simulating hung modal)
       mockShowLabelInputModal.mockReturnValue(new Promise(() => {}));
 
       const result = command.checkCallback(false, mockFile, mockContext);
@@ -150,114 +134,110 @@ describe("CreateInstanceCommand Error Handling", () => {
 
       await flushPromises();
 
-      // Modal never called callback, so createTask should not be called
-      expect(mockTaskCreationService.createTask).not.toHaveBeenCalled();
+      expect(mockGenericAssetCreationService.createAsset).not.toHaveBeenCalled();
     });
-
   });
 
-  describe("Task Creation Service Error Handling", () => {
+  describe("Asset Creation Service Error Handling", () => {
     const mockCanCreateInstance = require("exocortex").canCreateInstance;
 
-    it("should handle network error during task creation", async () => {
+    it("should handle network error during asset creation", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const networkError = new Error("Network request failed: ETIMEDOUT");
-      mockTaskCreationService.createTask.mockRejectedValue(networkError);
+      mockGenericAssetCreationService.createAsset.mockRejectedValue(networkError);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: Network request failed: ETIMEDOUT"
+        "Failed to create instance: Network request failed: ETIMEDOUT",
       );
       expect(LoggingService.error).toHaveBeenCalledWith(
         "Create instance error",
-        networkError
+        networkError,
       );
     });
 
-    it("should handle permission denied error during task creation", async () => {
+    it("should handle permission denied error during asset creation", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const permissionError = new Error("EACCES: permission denied");
-      mockTaskCreationService.createTask.mockRejectedValue(permissionError);
+      mockGenericAssetCreationService.createAsset.mockRejectedValue(permissionError);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: EACCES: permission denied"
+        "Failed to create instance: EACCES: permission denied",
       );
     });
 
-    it("should handle disk full error during task creation", async () => {
+    it("should handle disk full error during asset creation", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const diskFullError = new Error("ENOSPC: no space left on device");
-      mockTaskCreationService.createTask.mockRejectedValue(diskFullError);
+      mockGenericAssetCreationService.createAsset.mockRejectedValue(diskFullError);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: ENOSPC: no space left on device"
+        "Failed to create instance: ENOSPC: no space left on device",
       );
     });
 
     it("should handle file already exists error", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const existsError = new Error("File already exists: task.md");
-      mockTaskCreationService.createTask.mockRejectedValue(existsError);
+      mockGenericAssetCreationService.createAsset.mockRejectedValue(existsError);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: File already exists: task.md"
+        "Failed to create instance: File already exists: task.md",
       );
     });
 
     it("should handle undefined error object", async () => {
       mockCanCreateInstance.mockReturnValue(true);
-      mockTaskCreationService.createTask.mockRejectedValue(undefined);
+      mockGenericAssetCreationService.createAsset.mockRejectedValue(undefined);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: undefined"
+        "Failed to create instance: undefined",
       );
     });
 
     it("should handle non-Error throwable (string)", async () => {
       mockCanCreateInstance.mockReturnValue(true);
-      mockTaskCreationService.createTask.mockRejectedValue(
-        "String error message"
-      );
+      mockGenericAssetCreationService.createAsset.mockRejectedValue("String error message");
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: String error message"
+        "Failed to create instance: String error message",
       );
     });
 
     it("should handle non-Error throwable (number)", async () => {
       mockCanCreateInstance.mockReturnValue(true);
-      mockTaskCreationService.createTask.mockRejectedValue(404);
+      mockGenericAssetCreationService.createAsset.mockRejectedValue(404);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
@@ -272,34 +252,34 @@ describe("CreateInstanceCommand Error Handling", () => {
     it("should throw error when toTFile returns null", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
       mockVaultAdapter.toTFile.mockReturnValue(null as any);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to create instance:")
+        expect.stringContaining("Failed to create instance:"),
       );
     });
 
     it("should handle toTFile throwing an error", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
       mockVaultAdapter.toTFile.mockImplementation(() => {
         throw new Error("File not found in vault cache");
       });
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: File not found in vault cache"
+        "Failed to create instance: File not found in vault cache",
       );
     });
   });
@@ -310,155 +290,51 @@ describe("CreateInstanceCommand Error Handling", () => {
     it("should handle openFile failure", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
       mockLeaf.openFile.mockRejectedValue(new Error("Cannot open file"));
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: Cannot open file"
+        "Failed to create instance: Cannot open file",
       );
     });
 
     it("should handle getLeaf returning null", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
       (mockApp.workspace.getLeaf as jest.Mock).mockReturnValue(null);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      // Should fail when trying to call openFile on null leaf
       expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to create instance:")
+        expect.stringContaining("Failed to create instance:"),
       );
     });
 
     it("should handle setActiveLeaf error", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
       (mockApp.workspace.setActiveLeaf as jest.Mock).mockImplementation(() => {
         throw new Error("Workspace state invalid");
       });
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: Workspace state invalid"
+        "Failed to create instance: Workspace state invalid",
       );
-    });
-  });
-
-  describe("Context and Input Validation Errors", () => {
-    const mockCanCreateInstance = require("exocortex").canCreateInstance;
-
-    it("should handle empty instanceClass array", async () => {
-      mockCanCreateInstance.mockReturnValue(true);
-      const emptyContext = {
-        ...mockContext,
-        instanceClass: [],
-      };
-      const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
-
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
-
-      command.checkCallback(false, mockFile, emptyContext);
-      await flushPromises();
-
-      // Should call createTask with empty string for sourceClass
-      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
-        mockFile,
-        { key: "value" },
-        "",
-        "Test",
-        "small"
-      );
-    });
-
-    it("should handle undefined instanceClass", async () => {
-      mockCanCreateInstance.mockReturnValue(true);
-      const undefinedContext = {
-        ...mockContext,
-        instanceClass: undefined as any,
-      };
-      const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
-
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
-
-      command.checkCallback(false, mockFile, undefinedContext);
-      await flushPromises();
-
-      // Should handle undefined gracefully
-      expect(mockTaskCreationService.createTask).toHaveBeenCalledWith(
-        mockFile,
-        { key: "value" },
-        "",
-        "Test",
-        "small"
-      );
-    });
-
-  });
-
-  describe("Timeout and Long-Running Operation Handling", () => {
-    const mockCanCreateInstance = require("exocortex").canCreateInstance;
-
-    it("should handle file never becoming active (timeout scenario)", async () => {
-      mockCanCreateInstance.mockReturnValue(true);
-      const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
-
-      // File never becomes active (returns different file)
-      const differentFile = {
-        path: "different-file.md",
-        basename: "different-file",
-      } as jest.Mocked<TFile>;
-      (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue(
-        differentFile
-      );
-
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
-
-      command.checkCallback(false, mockFile, mockContext);
-      await flushPromises();
-
-      // Wait for polling timeout to complete (20 attempts * 100ms = 2 seconds)
-      await new Promise((resolve) => setTimeout(resolve, 2500));
-
-      // Should still show success notice even if file didn't become active
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
-    });
-
-    it("should handle getActiveFile returning null consistently", async () => {
-      mockCanCreateInstance.mockReturnValue(true);
-      const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
-
-      (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue(null);
-
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
-
-      command.checkCallback(false, mockFile, mockContext);
-      await flushPromises();
-
-      // Wait for polling timeout to complete (20 attempts * 100ms = 2 seconds)
-      await new Promise((resolve) => setTimeout(resolve, 2500));
-
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
-      // Polling-based approach calls getActiveFile repeatedly
-      expect(mockApp.workspace.getActiveFile).toHaveBeenCalled();
     });
   });
 
@@ -468,26 +344,68 @@ describe("CreateInstanceCommand Error Handling", () => {
     it("should handle error when opening in new tab", async () => {
       mockCanCreateInstance.mockReturnValue(true);
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
 
-      // Make getLeaf("tab") fail
       (mockApp.workspace.getLeaf as jest.Mock).mockImplementation(
         (option: string | boolean) => {
           if (option === "tab") {
             throw new Error("Cannot create new tab");
           }
           return mockLeaf;
-        }
+        },
       );
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: true });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: true });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
       expect(Notice).toHaveBeenCalledWith(
-        "Failed to create instance: Cannot create new tab"
+        "Failed to create instance: Cannot create new tab",
       );
+    });
+  });
+
+  describe("Timeout and Long-Running Operation Handling", () => {
+    const mockCanCreateInstance = require("exocortex").canCreateInstance;
+
+    it("should handle file never becoming active (timeout scenario)", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      const differentFile = {
+        path: "different-file.md",
+        basename: "different-file",
+      } as jest.Mocked<TFile>;
+      (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue(differentFile);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      await new Promise((resolve) => setTimeout(resolve, 2500));
+
+      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+    });
+
+    it("should handle getActiveFile returning null consistently", async () => {
+      mockCanCreateInstance.mockReturnValue(true);
+      const createdFile = { basename: "new-instance", path: "new-instance.md" };
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
+
+      (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue(null);
+
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
+
+      command.checkCallback(false, mockFile, mockContext);
+      await flushPromises();
+
+      await new Promise((resolve) => setTimeout(resolve, 2500));
+
+      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+      expect(mockApp.workspace.getActiveFile).toHaveBeenCalled();
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/error-handling/error-scenarios.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/error-scenarios.test.ts
@@ -23,10 +23,11 @@ import { SPARQLQueryService } from "../../../src/application/services/SPARQLQuer
 import { SPARQLCodeBlockProcessor } from "../../../src/application/processors/SPARQLCodeBlockProcessor";
 import { App, TFile, Notice, WorkspaceLeaf, Vault, MetadataCache, FileManager } from "obsidian";
 import {
-  TaskCreationService,
+  GenericAssetCreationService,
   CommandVisibilityContext,
   LoggingService,
   IFile,
+  type InstantiationRuleResolver,
 } from "exocortex";
 import { showLabelInputModal } from "../../../src/presentation/modals/modalSchemas";
 import type ExocortexPlugin from "../../../src/ExocortexPlugin";
@@ -57,7 +58,8 @@ jest.mock("../../../src/application/services/SPARQLQueryService");
 describe("CreateInstanceCommand Error Handling", () => {
   let command: CreateInstanceCommand;
   let mockApp: jest.Mocked<App>;
-  let mockTaskCreationService: jest.Mocked<TaskCreationService>;
+  let mockRuleResolver: jest.Mocked<InstantiationRuleResolver>;
+  let mockGenericAssetCreationService: jest.Mocked<GenericAssetCreationService>;
   let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
@@ -86,9 +88,14 @@ describe("CreateInstanceCommand Error Handling", () => {
       },
     } as unknown as jest.Mocked<App>;
 
-    mockTaskCreationService = {
-      createTask: jest.fn(),
-    } as unknown as jest.Mocked<TaskCreationService>;
+    mockRuleResolver = {
+      getRule: jest.fn().mockResolvedValue(null),
+      invalidateCache: jest.fn(),
+    } as unknown as jest.Mocked<InstantiationRuleResolver>;
+
+    mockGenericAssetCreationService = {
+      createAsset: jest.fn(),
+    } as unknown as jest.Mocked<GenericAssetCreationService>;
 
     mockVaultAdapter = {
       toTFile: jest.fn(),
@@ -97,7 +104,9 @@ describe("CreateInstanceCommand Error Handling", () => {
     mockFile = {
       path: "test-file.md",
       basename: "test-file",
-    } as jest.Mocked<TFile>;
+      name: "test-file.md",
+      parent: { path: "parent-folder", name: "parent-folder" },
+    } as unknown as jest.Mocked<TFile>;
 
     mockContext = {
       instanceClass: "Task",
@@ -106,18 +115,18 @@ describe("CreateInstanceCommand Error Handling", () => {
       isDraft: false,
     };
 
-    command = new CreateInstanceCommand(mockApp, mockTaskCreationService, mockVaultAdapter);
+    command = new CreateInstanceCommand(mockApp, mockRuleResolver, mockGenericAssetCreationService, mockVaultAdapter);
   });
 
   describe("Scenario 1: toTFile returns null (file conversion failure)", () => {
-    it("should throw error when toTFile returns null after task creation", async () => {
+    it("should throw error when toTFile returns null after asset creation", async () => {
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
 
       // toTFile returns null - simulating file conversion failure
       mockVaultAdapter.toTFile.mockReturnValue(null as any);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test Instance", taskSize: "medium", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test Instance", taskSize: null, openInNewTab: false });
 
       const result = command.checkCallback(false, mockFile, mockContext);
       expect(result).toBe(true);
@@ -135,10 +144,10 @@ describe("CreateInstanceCommand Error Handling", () => {
 
     it("should include file path in error message when toTFile fails", async () => {
       const createdFile = { basename: "new-instance", path: "path/to/new-instance.md" };
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
       mockVaultAdapter.toTFile.mockReturnValue(null as any);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
@@ -149,12 +158,12 @@ describe("CreateInstanceCommand Error Handling", () => {
     });
   });
 
-  describe("Scenario 2: TaskCreationService throws various errors", () => {
-    it("should handle permission denied error from task creation", async () => {
+  describe("Scenario 2: GenericAssetCreationService throws various errors", () => {
+    it("should handle permission denied error from asset creation", async () => {
       const permissionError = new Error("Permission denied: Cannot write to directory");
-      mockTaskCreationService.createTask.mockRejectedValue(permissionError);
+      mockGenericAssetCreationService.createAsset.mockRejectedValue(permissionError);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
@@ -165,9 +174,9 @@ describe("CreateInstanceCommand Error Handling", () => {
 
     it("should handle file already exists error", async () => {
       const existsError = new Error("File already exists: task-name.md");
-      mockTaskCreationService.createTask.mockRejectedValue(existsError);
+      mockGenericAssetCreationService.createAsset.mockRejectedValue(existsError);
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
@@ -176,9 +185,9 @@ describe("CreateInstanceCommand Error Handling", () => {
     });
 
     it("should handle non-Error thrown values", async () => {
-      mockTaskCreationService.createTask.mockRejectedValue("String error message");
+      mockGenericAssetCreationService.createAsset.mockRejectedValue("String error message");
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
@@ -192,11 +201,11 @@ describe("CreateInstanceCommand Error Handling", () => {
       const createdFile = { basename: "new-instance", path: "new-instance.md" };
       const mockTFile = { path: "new-instance.md", basename: "new-instance" } as TFile;
 
-      mockTaskCreationService.createTask.mockResolvedValue(createdFile as any);
+      mockGenericAssetCreationService.createAsset.mockResolvedValue(createdFile as any);
       mockVaultAdapter.toTFile.mockReturnValue(mockTFile);
       mockLeaf.openFile.mockRejectedValue(new Error("Failed to open file"));
 
-      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: "small", openInNewTab: false });
+      mockShowLabelInputModal.mockResolvedValue({ label: "Test", taskSize: null, openInNewTab: false });
 
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();


### PR DESCRIPTION
## Summary
- Replaced `TaskCreationService` dependency with `InstantiationRuleResolver` + `GenericAssetCreationService` in `CreateInstanceCommand`
- Command now resolves creation rules (prototype UID, default folder, property-set rules) from vault assets via the resolver
- Falls back to generic creation when no instantiation rule exists for the target class
- Updated all 4 test files (main, error, error-scenarios, error-handling) to match new constructor and behavior

## Test plan
- [x] 20 unit tests in `CreateInstanceCommand.test.ts` (rule-based creation, fallback, error handling, array instanceClass, modal defaults)
- [x] 17 error handling tests in `CreateInstanceCommand.error.test.ts`
- [x] 86 tests in `error-scenarios.test.ts` and `error-handling.test.ts`
- [x] TypeScript typecheck passes
- [x] Full test suite: 483 passed
- [x] BDD coverage: 100%
- [x] Archgate: 13/13 rules pass

Closes #2536