### PR TITLE
chore: verify vault commands + fix host_function precondition loading (#2582)

### DIFF
--- a/packages/cli/src/commands/dynamic-command.ts
+++ b/packages/cli/src/commands/dynamic-command.ts
@@ -564,18 +564,11 @@ function validateCommands(vaultPath: string): ValidationIssue[] {
             commandIssues.push(`Grounding "${groundingUid}" (property_set) missing targetValue`);
           }
 
-          // service_call: targetProperty holds the serviceId — must be a known service
+          // service_call: serviceId from dedicated property or fallback to targetProperty
           if (gType === GroundingType.SERVICE_CALL) {
-            const serviceId = gfm["exocmd__Grounding_targetProperty"];
+            const serviceId = gfm["exocmd__Grounding_serviceId"] ?? gfm["exocmd__Grounding_targetProperty"];
             if (!serviceId) {
-              commandIssues.push(`Grounding "${groundingUid}" (service_call) missing targetProperty (serviceId)`);
-            } else {
-              const knownIds: readonly string[] = CLI_STUB_SERVICE_IDS;
-              if (!knownIds.includes(String(serviceId))) {
-                commandIssues.push(
-                  `Grounding "${groundingUid}" references unknown service "${serviceId}". Known services: ${knownIds.join(", ")}`,
-                );
-              }
+              commandIssues.push(`Grounding "${groundingUid}" (service_call) missing serviceId and targetProperty`);
             }
           }
         }
@@ -592,10 +585,11 @@ function validateCommands(vaultPath: string): ValidationIssue[] {
       } else if (!hasClass(preconditionFile.fm, "exocmd__Precondition")) {
         commandIssues.push(`Precondition reference "${preconditionUid}" is not an exocmd__Precondition asset`);
       } else {
-        // Validate SPARQL ASK
+        // Validate precondition has either sparqlAsk or hostFunction
         const sparqlAsk = preconditionFile.fm["exocmd__Precondition_sparqlAsk"];
-        if (!sparqlAsk) {
-          commandIssues.push(`Precondition "${preconditionUid}" missing sparqlAsk`);
+        const hostFunction = preconditionFile.fm["exocmd__Precondition_hostFunction"];
+        if (!sparqlAsk && !hostFunction) {
+          commandIssues.push(`Precondition "${preconditionUid}" missing both sparqlAsk and hostFunction`);
         }
       }
     }
@@ -743,7 +737,10 @@ function hasClass(fm: Record<string, any>, className: string): boolean {
 
 function normalizeWikilink(value: string): string {
   if (typeof value !== "string") return "";
-  return value.replace(/["'[\]]/g, "").trim();
+  // Remove quotes and brackets, then strip "|Label" suffix (wikilink alias)
+  const stripped = value.replace(/["'[\]]/g, "").trim();
+  const pipeIdx = stripped.indexOf("|");
+  return pipeIdx >= 0 ? stripped.substring(0, pipeIdx).trim() : stripped;
 }
 
 function extractLabelFromFilename(filePath: string): string {

--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -374,7 +374,7 @@ describe("dynamic-command CLI", () => {
       consoleSpy.mockRestore();
     });
 
-    it("should report unknown service in service_call grounding", async () => {
+    it("should accept service_call with serviceId from dedicated property", async () => {
       const commandFm = [
         "exo__Instance_class: exocmd__Command",
         "exo__Asset_uid: cmd-svc",
@@ -385,9 +385,15 @@ describe("dynamic-command CLI", () => {
       const groundingFm = [
         "exo__Instance_class: exocmd__Grounding",
         "exo__Asset_uid: gnd-svc",
-        "exo__Asset_label: Call Unknown",
+        "exo__Asset_label: Call Plugin Service",
         "exocmd__Grounding_type: service_call",
-        "exocmd__Grounding_targetProperty: nonExistentService",
+        "exocmd__Grounding_serviceId: cleanProperties",
+      ].join("\n");
+
+      const bindingFm = [
+        "exo__Instance_class: exocmd__CommandBinding",
+        "exo__Asset_uid: bind-svc",
+        "exocmd__CommandBinding_command: [[cmd-svc]]",
       ].join("\n");
 
       mockReaddirSync.mockImplementation((dir: string) => {
@@ -395,6 +401,7 @@ describe("dynamic-command CLI", () => {
           return [
             { name: "cmd-svc.md", isDirectory: () => false },
             { name: "gnd-svc.md", isDirectory: () => false },
+            { name: "bind-svc.md", isDirectory: () => false },
           ];
         }
         return [];
@@ -403,6 +410,7 @@ describe("dynamic-command CLI", () => {
       mockReadFileSync.mockImplementation((path: string) => {
         if (path.endsWith("cmd-svc.md")) return `---\n${commandFm}\n---\n`;
         if (path.endsWith("gnd-svc.md")) return `---\n${groundingFm}\n---\n`;
+        if (path.endsWith("bind-svc.md")) return `---\n${bindingFm}\n---\n`;
         return "";
       });
 
@@ -413,8 +421,8 @@ describe("dynamic-command CLI", () => {
       await valCmd.parseAsync(["--vault", "/vault"], { from: "user" });
 
       const output = consoleSpy.mock.calls.map((c: any) => c[0]).join("\n");
-      expect(output).toContain("unknown service");
-      expect(output).toContain("nonExistentService");
+      expect(output).toContain("valid");
+      expect(output).not.toContain("missing serviceId");
 
       consoleSpy.mockRestore();
     });
@@ -510,7 +518,7 @@ describe("dynamic-command CLI", () => {
       await valCmd.parseAsync(["--vault", "/vault"], { from: "user" });
 
       const output = consoleSpy.mock.calls.map((c: any) => c[0]).join("\n");
-      expect(output).toContain("missing targetProperty (serviceId)");
+      expect(output).toContain("missing serviceId and targetProperty");
 
       consoleSpy.mockRestore();
     });

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -385,10 +385,19 @@ export class CommandResolver {
     const uid = await this.getLiteralValue(preconditionSubject, Namespace.EXO.term("Asset_uid"));
     const label = await this.getLiteralValue(preconditionSubject, Namespace.EXO.term("Asset_label")) ?? "";
     const sparqlAsk = await this.getLiteralValue(preconditionSubject, Namespace.EXOCMD.term("Precondition_sparqlAsk"));
+    const hostFunction = await this.getLiteralValue(preconditionSubject, Namespace.EXOCMD.term("Precondition_hostFunction"));
 
-    if (!uid || !sparqlAsk) return null;
+    if (!uid) return null;
 
-    return { id: uid, label, sparqlAsk };
+    // A precondition must have either sparqlAsk or hostFunction
+    if (!sparqlAsk && !hostFunction) return null;
+
+    return {
+      id: uid,
+      label,
+      ...(sparqlAsk && { sparqlAsk }),
+      ...(hostFunction && { hostFunction }),
+    };
   }
 
   private async loadLinkedGrounding(

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -55,16 +55,24 @@ async function addCommandAsset(
 
 async function addPreconditionAsset(
   store: InMemoryTripleStore,
-  opts: { uid: string; label: string; sparqlAsk: string },
+  opts: { uid: string; label: string; sparqlAsk?: string; hostFunction?: string },
 ): Promise<IRI> {
   const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
 
-  await store.addAll([
+  const triples: Triple[] = [
     new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Precondition")),
     new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
     new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(opts.label)),
-    new Triple(subject, Namespace.EXOCMD.term("Precondition_sparqlAsk"), new Literal(opts.sparqlAsk)),
-  ]);
+  ];
+
+  if (opts.sparqlAsk) {
+    triples.push(new Triple(subject, Namespace.EXOCMD.term("Precondition_sparqlAsk"), new Literal(opts.sparqlAsk)));
+  }
+  if (opts.hostFunction) {
+    triples.push(new Triple(subject, Namespace.EXOCMD.term("Precondition_hostFunction"), new Literal(opts.hostFunction)));
+  }
+
+  await store.addAll(triples);
   return subject;
 }
 
@@ -268,6 +276,66 @@ describe("CommandResolver", () => {
 
       const cmd = await resolver.loadCommand("cmd-no-grounding");
       expect(cmd).toBeNull();
+    });
+
+    it("should load precondition with hostFunction instead of sparqlAsk", async () => {
+      await addPreconditionAsset(store, {
+        uid: "pre-host-fn",
+        label: "Has obsolete properties",
+        hostFunction: "hasObsoleteProperties",
+      });
+
+      await addGroundingAsset(store, {
+        uid: "gnd-clean",
+        label: "Clean properties",
+        type: "property_delete",
+        targetProperty: "deprecated_prop",
+      });
+
+      await addCommandAsset(store, {
+        uid: "cmd-clean",
+        label: "Clean Properties",
+        preconditionRef: "pre-host-fn",
+        groundingRef: "gnd-clean",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-clean");
+
+      expect(cmd).not.toBeNull();
+      expect(cmd!.precondition).toBeDefined();
+      expect(cmd!.precondition!.id).toBe("pre-host-fn");
+      expect(cmd!.precondition!.hostFunction).toBe("hasObsoleteProperties");
+      expect(cmd!.precondition!.sparqlAsk).toBeUndefined();
+    });
+
+    it("should load precondition with both sparqlAsk and hostFunction", async () => {
+      await addPreconditionAsset(store, {
+        uid: "pre-both",
+        label: "Dual precondition",
+        sparqlAsk: "ASK { $target ?p ?o }",
+        hostFunction: "customCheck",
+      });
+
+      await addGroundingAsset(store, {
+        uid: "gnd-dual",
+        label: "Dual",
+        type: "property_delete",
+        targetProperty: "some_prop",
+      });
+
+      await addCommandAsset(store, {
+        uid: "cmd-dual",
+        label: "Dual Command",
+        preconditionRef: "pre-both",
+        groundingRef: "gnd-dual",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-dual");
+
+      expect(cmd).not.toBeNull();
+      expect(cmd!.precondition).toBeDefined();
+      expect(cmd!.precondition!.sparqlAsk).toBe("ASK { $target ?p ?o }");
+      expect(cmd!.precondition!.hostFunction).toBe("customCheck");
     });
 
     it("should handle command without precondition gracefully", async () => {


### PR DESCRIPTION
## Summary
- **Fix CommandResolver** (`loadLinkedPreconditionFromProperty`): now reads `Precondition_hostFunction` from the triple store, not just `sparqlAsk`. Commands with host function preconditions (like "Clean Properties", "Repair Folder", "Rename to UID") are now loaded correctly.
- **Fix CLI `dyncommand validate`**: `normalizeWikilink` now strips `|Label` suffix from wikilink aliases (`[[uuid|Label]]` → `uuid`). Previously reported false "not found" errors for all 30 vault commands.
- **Fix CLI `dyncommand validate`**: `service_call` grounding validation now reads `serviceId` from the dedicated `Grounding_serviceId` property (with fallback to `targetProperty`). Removed overly strict unknown-service check (services may be plugin-only).
- **2 new unit tests** for hostFunction precondition loading in CommandResolver.

## Verification Results
- `dyncommand list`: **30 commands** found (7 status + 3 criticality + 4 planning + 4 maintenance + 5 maintenance-complex + 7 creation)
- `dyncommand validate`: **16 commands fully valid** with bindings; 14 commands have "no binding" warnings (expected — bindings will be added in a follow-up)
- All tests pass: exocortex 6767/6767, CLI 1187/1187, plugin 53/53

## Test plan
- [x] Unit tests for hostFunction precondition loading (2 new tests)
- [x] CLI `dyncommand list` shows 30 commands
- [x] CLI `dyncommand validate` passes structural validation (no false positives)
- [x] Full test suite passes across all packages

Closes #2582