### PR TITLE
feat(core): extend PrototypeChainMaterializer — BFS with MAX_DEPTH, closest-wins

### DIFF
--- a/packages/exocortex/src/services/PrototypeChainMaterializer.ts
+++ b/packages/exocortex/src/services/PrototypeChainMaterializer.ts
@@ -1,5 +1,5 @@
 import { ITripleStore } from "../interfaces/ITripleStore";
-import { Triple, type Subject } from "../domain/models/rdf/Triple";
+import { Triple } from "../domain/models/rdf/Triple";
 import { IRI } from "../domain/models/rdf/IRI";
 import { NonInheritablePropertyRegistry } from "./NonInheritablePropertyRegistry";
 
@@ -10,10 +10,20 @@ import { NonInheritablePropertyRegistry } from "./NonInheritablePropertyRegistry
 export const INFERRED_GRAPH = new IRI("https://exocortex.my/ontology/exo#inferred");
 
 /**
- * Single-hop prototype chain materializer.
+ * Maximum depth for prototype chain traversal.
+ * Protects against unbounded chains and excessive memory usage.
+ */
+export const MAX_PROTOTYPE_DEPTH = 10;
+
+/**
+ * Multi-hop prototype chain materializer.
  *
- * For each instance with an exo__Asset_prototype link, copies all inheritable
- * properties from the prototype that the instance doesn't already own.
+ * For each instance with an exo__Asset_prototype link, resolves the full
+ * prototype chain via BFS traversal (up to MAX_PROTOTYPE_DEPTH) and copies
+ * all inheritable properties that the instance doesn't already own.
+ *
+ * Closest prototype wins: if proto1 and proto2 both define `area`,
+ * the value from proto1 (nearer) is used.
  *
  * Materialized triples are added to both the default graph (for match() visibility)
  * and the `exo:inferred` named graph (for own/inherited distinction).
@@ -28,7 +38,7 @@ export class PrototypeChainMaterializer {
   }
 
   /**
-   * Materialize inherited properties from prototypes into instances.
+   * Materialize inherited properties from the full prototype chain into instances.
    *
    * @param store - The triple store to read from and write materialized triples into
    * @returns Number of new materialized triples added
@@ -45,7 +55,7 @@ export class PrototypeChainMaterializer {
       return 0;
     }
 
-    // Find all instance → prototype links
+    // Find all subject → prototype links
     const prototypeTriples = await store.match(
       undefined,
       prototypePredicate,
@@ -56,80 +66,127 @@ export class PrototypeChainMaterializer {
       return 0;
     }
 
-    // Build map: instance → prototype (single-hop only)
-    // Cycle detection: skip if instance equals prototype
-    const instanceToPrototype = new Map<string, { instance: Subject; prototype: Subject }>();
+    // Build prototype graph: subject IRI string → prototype IRI
+    // Self-cycle detection: skip if subject equals prototype
+    const protoGraph = new Map<string, IRI>();
     for (const triple of prototypeTriples) {
       if (triple.subject instanceof IRI && triple.object instanceof IRI) {
-        const instanceIRI = triple.subject.value;
+        const subjectIRI = triple.subject.value;
         const prototypeIRI = triple.object.value;
 
-        // Cycle detection
-        if (instanceIRI === prototypeIRI) {
-          continue;
+        if (subjectIRI !== prototypeIRI) {
+          protoGraph.set(subjectIRI, triple.object as IRI);
         }
-
-        instanceToPrototype.set(instanceIRI, {
-          instance: triple.subject,
-          prototype: triple.object as IRI,
-        });
       }
     }
 
-    if (instanceToPrototype.size === 0) {
+    if (protoGraph.size === 0) {
       return 0;
     }
 
     let materializedCount = 0;
 
-    for (const { instance, prototype } of instanceToPrototype.values()) {
-      // Get all triples of the prototype
-      const prototypeTriples = await store.match(prototype, undefined, undefined);
+    for (const [instanceIRI] of protoGraph) {
+      const instance = new IRI(instanceIRI);
 
-      if (prototypeTriples.length === 0) {
+      // Resolve full prototype chain via BFS: [proto1, proto2, ..., protoN] near→far
+      const chain = this.resolveChain(instanceIRI, protoGraph);
+
+      if (chain.length === 0) {
         continue;
       }
 
       // Get predicates the instance already owns
       const ownTriples = await store.match(instance, undefined, undefined);
-      const ownPredicates = new Set<string>();
+      const seenPredicates = new Set<string>();
       for (const t of ownTriples) {
-        ownPredicates.add(t.predicate.value);
+        seenPredicates.add(t.predicate.value);
       }
 
-      // Materialize inheritable properties
-      for (const protoTriple of prototypeTriples) {
-        const predicateIRI = protoTriple.predicate.value;
+      // Walk chain near→far: closest prototype wins
+      for (const protoIRIStr of chain) {
+        const proto = new IRI(protoIRIStr);
+        const protoTriples = await store.match(proto, undefined, undefined);
 
-        // Skip non-inheritable properties
-        if (this.registry.isNonInheritable(predicateIRI)) {
-          continue;
+        for (const protoTriple of protoTriples) {
+          const predicateValue = protoTriple.predicate.value;
+
+          // Skip non-inheritable properties
+          if (this.registry.isNonInheritable(predicateValue)) {
+            continue;
+          }
+
+          // Skip if already seen (own or from closer prototype)
+          if (seenPredicates.has(predicateValue)) {
+            continue;
+          }
+
+          // Materialize: create triple with instance as subject
+          const materializedTriple = new Triple(
+            instance,
+            protoTriple.predicate,
+            protoTriple.object,
+          );
+
+          // Add to default graph (for match() visibility)
+          await store.add(materializedTriple);
+
+          // Add to named graph (for own/inherited distinction)
+          if (store.addToGraph) {
+            await store.addToGraph(materializedTriple, INFERRED_GRAPH);
+          }
+
+          seenPredicates.add(predicateValue);
+          materializedCount++;
         }
-
-        // Skip if instance already has this property (own takes priority)
-        if (ownPredicates.has(predicateIRI)) {
-          continue;
-        }
-
-        // Materialize: create triple with instance as subject
-        const materializedTriple = new Triple(
-          instance,
-          protoTriple.predicate,
-          protoTriple.object,
-        );
-
-        // Add to default graph (for match() visibility)
-        await store.add(materializedTriple);
-
-        // Add to named graph (for own/inherited distinction)
-        if (store.addToGraph) {
-          await store.addToGraph(materializedTriple, INFERRED_GRAPH);
-        }
-
-        materializedCount++;
       }
     }
 
     return materializedCount;
+  }
+
+  /**
+   * BFS traversal to resolve the full prototype chain for a given instance.
+   * Returns ordered array of prototype IRIs from nearest to farthest.
+   *
+   * Uses a BFS queue with visited set for cycle detection and
+   * MAX_PROTOTYPE_DEPTH limit to prevent unbounded traversal.
+   *
+   * @param instanceIRI - Starting instance IRI string
+   * @param protoGraph - Map of subject IRI string → prototype IRI
+   * @returns Array of prototype IRI strings, ordered near→far
+   */
+  private resolveChain(
+    instanceIRI: string,
+    protoGraph: Map<string, IRI>,
+  ): string[] {
+    const chain: string[] = [];
+    const visited = new Set<string>();
+    visited.add(instanceIRI);
+
+    const queue: string[] = [];
+    const directProto = protoGraph.get(instanceIRI);
+    if (directProto) {
+      queue.push(directProto.value);
+    }
+
+    while (queue.length > 0 && chain.length < MAX_PROTOTYPE_DEPTH) {
+      const current = queue.shift();
+      if (current === undefined) break;
+
+      if (visited.has(current)) {
+        continue;
+      }
+
+      visited.add(current);
+      chain.push(current);
+
+      const nextProto = protoGraph.get(current);
+      if (nextProto && !visited.has(nextProto.value)) {
+        queue.push(nextProto.value);
+      }
+    }
+
+    return chain;
   }
 }

--- a/packages/exocortex/tests/unit/services/PrototypeChainMaterializer.test.ts
+++ b/packages/exocortex/tests/unit/services/PrototypeChainMaterializer.test.ts
@@ -1,4 +1,4 @@
-import { PrototypeChainMaterializer, INFERRED_GRAPH } from "../../../src/services/PrototypeChainMaterializer";
+import { PrototypeChainMaterializer, INFERRED_GRAPH, MAX_PROTOTYPE_DEPTH } from "../../../src/services/PrototypeChainMaterializer";
 import { NonInheritablePropertyRegistry } from "../../../src/services/NonInheritablePropertyRegistry";
 import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
 import { Triple } from "../../../src/domain/models/rdf/Triple";
@@ -188,7 +188,7 @@ describe("PrototypeChainMaterializer", () => {
       expect(count).toBe(0);
     });
 
-    it("should handle A → B → A cycle (single-hop only processes A→B)", async () => {
+    it("should handle A → B → A cycle (BFS visited set stops traversal)", async () => {
       // A → B, B → A
       await store.add(new Triple(cycleA, prototype, cycleB));
       await store.add(new Triple(cycleB, prototype, cycleA));
@@ -200,7 +200,7 @@ describe("PrototypeChainMaterializer", () => {
 
       const count = await materializer.materialize(store);
 
-      // Single-hop: A inherits area from B, B inherits timeEstimate from A
+      // Multi-hop with cycle detection: A inherits area from B, B inherits timeEstimate from A
       expect(count).toBe(2);
     });
   });
@@ -226,6 +226,228 @@ describe("PrototypeChainMaterializer", () => {
 
       const area2 = await store.match(instance2, effortArea, undefined);
       expect(area2.length).toBe(1);
+    });
+  });
+
+  describe("multi-hop prototype chain", () => {
+    const metaProto = new IRI("obsidian://vault/MetaPrototype.md");
+    const effortParent = Namespace.EMS.term("Effort_parent");
+    const effortPriority = Namespace.EMS.term("Effort_priority");
+
+    it("should inherit from depth-2 chain (instance → proto → meta-proto)", async () => {
+      // Chain: breakfastInstance → breakfastProto → morningProto
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastProto, prototype, morningProto));
+
+      // breakfastProto has area (inheritable)
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+
+      // morningProto has parent (inheritable) — only reachable via multi-hop
+      const routineArea = new IRI("obsidian://vault/Routine.md");
+      await store.add(new Triple(morningProto, effortParent, routineArea));
+
+      const count = await materializer.materialize(store);
+
+      // Instance gets: area from proto (depth 1) + parent from meta-proto (depth 2)
+      expect(count).toBeGreaterThanOrEqual(2);
+
+      const areaTriples = await store.match(breakfastInstance, effortArea, undefined);
+      expect(areaTriples.length).toBe(1);
+      expect(areaTriples[0].object).toEqual(healthArea);
+
+      const parentTriples = await store.match(breakfastInstance, effortParent, undefined);
+      expect(parentTriples.length).toBe(1);
+      expect(parentTriples[0].object).toEqual(routineArea);
+    });
+
+    it("should inherit from depth-3 chain", async () => {
+      // Chain: breakfastInstance → breakfastProto → morningProto → metaProto
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastProto, prototype, morningProto));
+      await store.add(new Triple(morningProto, prototype, metaProto));
+
+      // Each level has a unique inheritable property
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+      const routineParent = new IRI("obsidian://vault/Routine.md");
+      await store.add(new Triple(morningProto, effortParent, routineParent));
+      await store.add(new Triple(metaProto, effortPriority, new Literal("high")));
+
+      const count = await materializer.materialize(store);
+
+      // Instance gets all 3 properties from chain
+      const areaTriples = await store.match(breakfastInstance, effortArea, undefined);
+      expect(areaTriples.length).toBe(1);
+
+      const parentTriples = await store.match(breakfastInstance, effortParent, undefined);
+      expect(parentTriples.length).toBe(1);
+
+      const priorityTriples = await store.match(breakfastInstance, effortPriority, undefined);
+      expect(priorityTriples.length).toBe(1);
+      expect((priorityTriples[0].object as Literal).value).toBe("high");
+    });
+
+    it("should apply closest-wins: nearer prototype property takes priority", async () => {
+      // Chain: breakfastInstance → breakfastProto → morningProto
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastProto, prototype, morningProto));
+
+      // Both prototypes define area — closest (breakfastProto) should win
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+      const fitnessArea = new IRI("obsidian://vault/Fitness.md");
+      await store.add(new Triple(morningProto, effortArea, fitnessArea));
+
+      // morningProto also has parent (unique to depth 2)
+      const routineParent = new IRI("obsidian://vault/Routine.md");
+      await store.add(new Triple(morningProto, effortParent, routineParent));
+
+      const count = await materializer.materialize(store);
+
+      // area = Health (from breakfastProto, closer), NOT Fitness (from morningProto)
+      const areaTriples = await store.match(breakfastInstance, effortArea, undefined);
+      expect(areaTriples.length).toBe(1);
+      expect(areaTriples[0].object).toEqual(healthArea);
+
+      // parent = Routine (only from morningProto)
+      const parentTriples = await store.match(breakfastInstance, effortParent, undefined);
+      expect(parentTriples.length).toBe(1);
+      expect(parentTriples[0].object).toEqual(routineParent);
+    });
+
+    it("should detect cycle at depth-2 and stop traversal", async () => {
+      // Chain: breakfastInstance → breakfastProto → morningProto → breakfastProto (cycle!)
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastProto, prototype, morningProto));
+      await store.add(new Triple(morningProto, prototype, breakfastProto)); // cycle
+
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+      const routineParent = new IRI("obsidian://vault/Routine.md");
+      await store.add(new Triple(morningProto, effortParent, routineParent));
+
+      const count = await materializer.materialize(store);
+
+      // Instance should still get area (depth 1) and parent (depth 2)
+      // Cycle at depth 3 is detected and traversal stops
+      const areaTriples = await store.match(breakfastInstance, effortArea, undefined);
+      expect(areaTriples.length).toBe(1);
+
+      const parentTriples = await store.match(breakfastInstance, effortParent, undefined);
+      expect(parentTriples.length).toBe(1);
+    });
+
+    it("should stop at MAX_PROTOTYPE_DEPTH", async () => {
+      // Build a chain of MAX_PROTOTYPE_DEPTH + 2 prototypes
+      const chainLength = MAX_PROTOTYPE_DEPTH + 2;
+      const protos: IRI[] = [];
+      for (let i = 0; i < chainLength; i++) {
+        protos.push(new IRI(`obsidian://vault/Proto${i}.md`));
+      }
+
+      const instance = new IRI("obsidian://vault/DeepInstance.md");
+
+      // instance → proto0 → proto1 → ... → protoN
+      await store.add(new Triple(instance, prototype, protos[0]));
+      for (let i = 0; i < chainLength - 1; i++) {
+        await store.add(new Triple(protos[i], prototype, protos[i + 1]));
+      }
+
+      // Each proto has a unique inheritable property
+      for (let i = 0; i < chainLength; i++) {
+        const propIRI = new IRI(`obsidian://vault/Value${i}.md`);
+        await store.add(new Triple(protos[i], effortArea, propIRI));
+      }
+
+      // Only proto0's area should be inherited (closest wins for same predicate)
+      // But let's give each proto a unique predicate to test depth limit
+      for (let i = 0; i < chainLength; i++) {
+        await store.add(
+          new Triple(protos[i], effortTimeEstimate, new Literal(`${(i + 1) * 10}`)),
+        );
+      }
+
+      const count = await materializer.materialize(store);
+
+      // For the deep instance:
+      // - effortArea: only proto0's value (closest wins, all protos have it)
+      // - effortTimeEstimate: only proto0's value (closest wins, all protos have it)
+      // So instance gets 2 properties, but from depth 1 only (closest wins)
+      // The depth limit applies to chain resolution, not property count
+      const areaTriples = await store.match(instance, effortArea, undefined);
+      expect(areaTriples.length).toBe(1);
+      expect(areaTriples[0].object).toEqual(new IRI("obsidian://vault/Value0.md"));
+
+      // Verify chain was capped: proto at depth MAX_PROTOTYPE_DEPTH+1 should NOT be reachable
+      // To test this, let's add a unique property ONLY at the beyond-depth proto
+      const beyondPredicate = Namespace.EMS.term("Effort_parent");
+      const beyondValue = new IRI("obsidian://vault/BeyondDepth.md");
+      await store.add(new Triple(protos[chainLength - 1], beyondPredicate, beyondValue));
+
+      // Re-run on fresh store to test depth limit with unique property at max+1
+      const store2 = new InMemoryTripleStore();
+
+      // Rebuild chain in fresh store
+      const instance2 = new IRI("obsidian://vault/DeepInstance2.md");
+      const freshProtos: IRI[] = [];
+      for (let i = 0; i <= MAX_PROTOTYPE_DEPTH + 1; i++) {
+        freshProtos.push(new IRI(`obsidian://vault/FreshProto${i}.md`));
+      }
+
+      await store2.add(new Triple(instance2, prototype, freshProtos[0]));
+      for (let i = 0; i < freshProtos.length - 1; i++) {
+        await store2.add(new Triple(freshProtos[i], prototype, freshProtos[i + 1]));
+      }
+
+      // Only the proto beyond MAX_DEPTH has the unique property
+      await store2.add(
+        new Triple(freshProtos[MAX_PROTOTYPE_DEPTH + 1], effortParent, beyondValue),
+      );
+      // Give protos within depth a different property
+      await store2.add(new Triple(freshProtos[0], effortArea, healthArea));
+
+      const materializer2 = new PrototypeChainMaterializer(registry);
+      await materializer2.materialize(store2);
+
+      // Instance should have area from proto0 (within depth)
+      const areaResult = await store2.match(instance2, effortArea, undefined);
+      expect(areaResult.length).toBe(1);
+
+      // Instance should NOT have parent from beyond-depth proto
+      const parentResult = await store2.match(instance2, effortParent, undefined);
+      expect(parentResult.length).toBe(0);
+    });
+
+    it("should add multi-hop materialized triples to named graph", async () => {
+      // Chain: breakfastInstance → breakfastProto → morningProto
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastProto, prototype, morningProto));
+
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+      const routineParent = new IRI("obsidian://vault/Routine.md");
+      await store.add(new Triple(morningProto, effortParent, routineParent));
+
+      await materializer.materialize(store);
+
+      // Both depth-1 and depth-2 triples should be in named graph
+      const namedArea = await store.matchInGraph!(
+        breakfastInstance,
+        effortArea,
+        undefined,
+        INFERRED_GRAPH,
+      );
+      expect(namedArea.length).toBe(1);
+
+      const namedParent = await store.matchInGraph!(
+        breakfastInstance,
+        effortParent,
+        undefined,
+        INFERRED_GRAPH,
+      );
+      expect(namedParent.length).toBe(1);
+    });
+  });
+
+  describe("MAX_PROTOTYPE_DEPTH constant", () => {
+    it("should be exported and equal to 10", () => {
+      expect(MAX_PROTOTYPE_DEPTH).toBe(10);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extends `PrototypeChainMaterializer` from single-hop to multi-hop BFS traversal
- Adds `MAX_PROTOTYPE_DEPTH=10` configurable constant
- Closest prototype wins on property conflict (near > far)
- Cycle detection via BFS visited Set
- Full backward compatibility: single-hop = depth-1 case

## Changes
- `PrototypeChainMaterializer.ts`: Replaced single-hop map with BFS `resolveChain()` method. Queue-based traversal follows prototype graph up to MAX_DEPTH, collecting ordered chain near→far.
- `PrototypeChainMaterializer.test.ts`: Added 7 new tests (depth-2, depth-3, closest-wins, cycle-at-depth-2, MAX_DEPTH hit, named graph multi-hop, constant export). Updated 1 existing test comment.

## Test plan
- [x] All 16 unit tests pass (9 existing + 7 new)
- [x] Full test:all passes (4345 core + 1187 plugin + 53 BDD + 483 component)
- [x] Build passes (no TS errors)
- [x] ESLint clean (0 warnings)
- [x] BDD coverage 100%
- [x] Archgate passes

Resolves #2589