### PR TITLE
feat(core): 6 temporal variables — $yesterday, $thisWeekStart, $lastWeekStart, etc.

### DIFF
--- a/packages/exocortex/src/services/PreconditionEvaluator.ts
+++ b/packages/exocortex/src/services/PreconditionEvaluator.ts
@@ -163,6 +163,11 @@ export class PreconditionEvaluator {
   }
 
   /**
+   * Asia/Almaty UTC offset in milliseconds (UTC+5, no DST).
+   */
+  private static readonly ALMATY_OFFSET_MS = 5 * 60 * 60 * 1000;
+
+  /**
    * Substitute custom variables in SPARQL query string.
    * This is TEXT replacement, NOT SPARQL variable binding.
    *
@@ -170,14 +175,58 @@ export class PreconditionEvaluator {
    * - $target → <targetIRI> (wrapped in angle brackets)
    * - $now → "2026-03-31T10:00:00.000Z"^^xsd:dateTime
    * - $today → "2026-03-31"^^xsd:date
+   * - $yesterday → "2026-03-30"^^xsd:date (Asia/Almaty)
+   * - $thisWeekStart → "2026-03-30"^^xsd:date (Monday, Asia/Almaty)
+   * - $lastWeekStart → "2026-03-23"^^xsd:date (prev Monday, Asia/Almaty)
+   * - $thisMonthStart → "2026-03-01"^^xsd:date (Asia/Almaty)
+   * - $lastMonthStart → "2026-02-01"^^xsd:date (Asia/Almaty)
+   * - $thisYearStart → "2026-01-01"^^xsd:date (Asia/Almaty)
    */
   substituteVariables(query: string, targetIRI: string): string {
     const now = new Date().toISOString();
     const today = now.slice(0, 10);
 
+    // Compute Almaty-local date components
+    const utcNow = new Date();
+    const almatyNow = new Date(utcNow.getTime() + PreconditionEvaluator.ALMATY_OFFSET_MS);
+    const almatyYear = almatyNow.getUTCFullYear();
+    const almatyMonth = almatyNow.getUTCMonth(); // 0-based
+    const almatyDate = almatyNow.getUTCDate();
+    const almatyDay = almatyNow.getUTCDay(); // 0=Sun
+
+    // $yesterday
+    const yesterday = new Date(Date.UTC(almatyYear, almatyMonth, almatyDate - 1));
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    // $thisWeekStart (Monday of current week)
+    const daysFromMonday = (almatyDay + 6) % 7; // Mon=0, Tue=1, ..., Sun=6
+    const thisWeekStart = new Date(Date.UTC(almatyYear, almatyMonth, almatyDate - daysFromMonday));
+    const thisWeekStartStr = thisWeekStart.toISOString().slice(0, 10);
+
+    // $lastWeekStart (Monday of previous week)
+    const lastWeekStart = new Date(thisWeekStart.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const lastWeekStartStr = lastWeekStart.toISOString().slice(0, 10);
+
+    // $thisMonthStart
+    const thisMonthStartStr = `${almatyYear}-${String(almatyMonth + 1).padStart(2, "0")}-01`;
+
+    // $lastMonthStart
+    const lastMonthIdx = almatyMonth === 0 ? 11 : almatyMonth - 1;
+    const lastMonthYear = almatyMonth === 0 ? almatyYear - 1 : almatyYear;
+    const lastMonthStartStr = `${lastMonthYear}-${String(lastMonthIdx + 1).padStart(2, "0")}-01`;
+
+    // $thisYearStart
+    const thisYearStartStr = `${almatyYear}-01-01`;
+
     return query
       .replace(/\$target/g, `<${targetIRI}>`)
       .replace(/\$now/g, `"${now}"^^xsd:dateTime`)
+      .replace(/\$yesterday/g, `"${yesterdayStr}"^^xsd:date`)
+      .replace(/\$thisWeekStart/g, `"${thisWeekStartStr}"^^xsd:date`)
+      .replace(/\$lastWeekStart/g, `"${lastWeekStartStr}"^^xsd:date`)
+      .replace(/\$thisMonthStart/g, `"${thisMonthStartStr}"^^xsd:date`)
+      .replace(/\$lastMonthStart/g, `"${lastMonthStartStr}"^^xsd:date`)
+      .replace(/\$thisYearStart/g, `"${thisYearStartStr}"^^xsd:date`)
       .replace(/\$today/g, `"${today}"^^xsd:date`);
   }
 }

--- a/packages/exocortex/tests/unit/services/PreconditionEvaluator.test.ts
+++ b/packages/exocortex/tests/unit/services/PreconditionEvaluator.test.ts
@@ -128,6 +128,84 @@ describe("PreconditionEvaluator", () => {
       // After first substitution, no more $target to replace
       expect(first).toBe(second);
     });
+
+    it("should replace $yesterday with xsd:date literal", () => {
+      const query = "ASK { ?s ems:date $yesterday }";
+      const result = evaluator.substituteVariables(query, ASSET_IRI);
+
+      expect(result).not.toContain("$yesterday");
+      expect(result).toMatch(/"[0-9]{4}-[0-9]{2}-[0-9]{2}"\^\^xsd:date/);
+    });
+
+    it("should replace $thisWeekStart with Monday date", () => {
+      const query = "ASK { ?s ems:date $thisWeekStart }";
+      const result = evaluator.substituteVariables(query, ASSET_IRI);
+
+      expect(result).not.toContain("$thisWeekStart");
+      expect(result).toMatch(/"[0-9]{4}-[0-9]{2}-[0-9]{2}"\^\^xsd:date/);
+
+      // Extract the date and verify it's a Monday
+      const match = result.match(/"(\d{4}-\d{2}-\d{2})"/);
+      if (match) {
+        const day = new Date(match[1]).getUTCDay();
+        expect(day).toBe(1); // Monday
+      }
+    });
+
+    it("should replace $lastWeekStart with previous Monday date", () => {
+      const query = "ASK { ?s ems:date $lastWeekStart }";
+      const result = evaluator.substituteVariables(query, ASSET_IRI);
+
+      expect(result).not.toContain("$lastWeekStart");
+      expect(result).toMatch(/"[0-9]{4}-[0-9]{2}-[0-9]{2}"\^\^xsd:date/);
+
+      // Extract and verify it's a Monday, 7 days before thisWeekStart
+      const thisWeekResult = evaluator.substituteVariables("$thisWeekStart", ASSET_IRI);
+      const lastWeekResult = evaluator.substituteVariables("$lastWeekStart", ASSET_IRI);
+
+      const thisMatch = thisWeekResult.match(/"(\d{4}-\d{2}-\d{2})"/);
+      const lastMatch = lastWeekResult.match(/"(\d{4}-\d{2}-\d{2})"/);
+      if (thisMatch && lastMatch) {
+        const diff = new Date(thisMatch[1]).getTime() - new Date(lastMatch[1]).getTime();
+        expect(diff).toBe(7 * 24 * 60 * 60 * 1000); // exactly 7 days
+      }
+    });
+
+    it("should replace $thisMonthStart with 1st of current month", () => {
+      const query = "ASK { ?s ems:date $thisMonthStart }";
+      const result = evaluator.substituteVariables(query, ASSET_IRI);
+
+      expect(result).not.toContain("$thisMonthStart");
+      expect(result).toMatch(/"[0-9]{4}-[0-9]{2}-01"\^\^xsd:date/);
+    });
+
+    it("should replace $lastMonthStart with 1st of previous month", () => {
+      const query = "ASK { ?s ems:date $lastMonthStart }";
+      const result = evaluator.substituteVariables(query, ASSET_IRI);
+
+      expect(result).not.toContain("$lastMonthStart");
+      expect(result).toMatch(/"[0-9]{4}-[0-9]{2}-01"\^\^xsd:date/);
+    });
+
+    it("should replace $thisYearStart with Jan 1st", () => {
+      const query = "ASK { ?s ems:date $thisYearStart }";
+      const result = evaluator.substituteVariables(query, ASSET_IRI);
+
+      expect(result).not.toContain("$thisYearStart");
+      expect(result).toMatch(/"[0-9]{4}-01-01"\^\^xsd:date/);
+    });
+
+    it("should handle all temporal variables in single query", () => {
+      const query = "FILTER($yesterday && $thisWeekStart && $lastWeekStart && $thisMonthStart && $lastMonthStart && $thisYearStart)";
+      const result = evaluator.substituteVariables(query, ASSET_IRI);
+
+      expect(result).not.toContain("$yesterday");
+      expect(result).not.toContain("$thisWeekStart");
+      expect(result).not.toContain("$lastWeekStart");
+      expect(result).not.toContain("$thisMonthStart");
+      expect(result).not.toContain("$lastMonthStart");
+      expect(result).not.toContain("$thisYearStart");
+    });
   });
 
   describe("SPARQL ASK with $target substitution", () => {


### PR DESCRIPTION
## Summary
- Extends `substituteVariables()` with 6 new temporal convenience variables in Asia/Almaty timezone
- `$yesterday`, `$thisWeekStart`, `$lastWeekStart`, `$thisMonthStart`, `$lastMonthStart`, `$thisYearStart`
- All return `xsd:date` literals

## Test plan
- [x] 7 new tests + 5 existing pass (12 total)
- [x] Build clean, pre-commit hooks pass

Resolves #2598