### PR TITLE
feat(core): 6 temporal built-in functions — DAYS_BETWEEN, MINUTES_BETWEEN, AGE_DAYS, etc.

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/filters/FunctionRegistry.ts
+++ b/packages/exocortex/src/infrastructure/sparql/filters/FunctionRegistry.ts
@@ -565,3 +565,68 @@ functionHandlers.set("triple", (args, ctx) => {
 
 // COALESCE and IF are NOT in this registry because they need lazy evaluation
 // (evaluating arguments only when needed). They remain in FilterExecutor.
+
+// =============================================================================
+// RFC-013 Temporal Functions
+// =============================================================================
+
+// DAYS_BETWEEN(a, b) → integer: days between two dateTimes
+functionHandlers.set("days_between", (args, ctx) => {
+  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+  return Math.floor((d2.getTime() - d1.getTime()) / (24 * 60 * 60 * 1000));
+});
+
+// MINUTES_BETWEEN(a, b) → integer: minutes between two dateTimes
+functionHandlers.set("minutes_between", (args, ctx) => {
+  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+  return Math.floor((d2.getTime() - d1.getTime()) / (60 * 1000));
+});
+
+// HOURS_BETWEEN(a, b) → decimal: hours between two dateTimes
+functionHandlers.set("hours_between", (args, ctx) => {
+  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+  return (d2.getTime() - d1.getTime()) / (60 * 60 * 1000);
+});
+
+// AGE_DAYS(dateTime) → integer: days from dateTime to NOW()
+functionHandlers.set("age_days", (args, ctx) => {
+  const dateStr = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const d = new Date(dateStr);
+  const now = new Date();
+  return Math.floor((now.getTime() - d.getTime()) / (24 * 60 * 60 * 1000));
+});
+
+// WEEK_NUMBER(dateTime) → integer: ISO week number
+functionHandlers.set("week_number", (args, ctx) => {
+  const dateStr = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const d = new Date(dateStr);
+  // ISO 8601 week number calculation
+  const tmp = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  tmp.setUTCDate(tmp.getUTCDate() + 4 - (tmp.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
+  return Math.ceil(((tmp.getTime() - yearStart.getTime()) / (24 * 60 * 60 * 1000) + 1) / 7);
+});
+
+// FORMAT_DATE(dateTime, pattern) → string: format date with pattern
+// Supported patterns: YYYY, MM, DD, HH, mm, ss
+functionHandlers.set("format_date", (args, ctx) => {
+  const dateStr = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const pattern = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const d = new Date(dateStr);
+  return pattern
+    .replace("YYYY", String(d.getFullYear()))
+    .replace("MM", String(d.getMonth() + 1).padStart(2, "0"))
+    .replace("DD", String(d.getDate()).padStart(2, "0"))
+    .replace("HH", String(d.getHours()).padStart(2, "0"))
+    .replace("mm", String(d.getMinutes()).padStart(2, "0"))
+    .replace("ss", String(d.getSeconds()).padStart(2, "0"));
+});

--- a/packages/exocortex/tests/unit/sparql/temporal-functions.test.ts
+++ b/packages/exocortex/tests/unit/sparql/temporal-functions.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for RFC-013 temporal built-in functions.
+ *
+ * Issue #2597: 6 temporal built-in functions — DAYS_BETWEEN, MINUTES_BETWEEN, etc.
+ *
+ * Custom functions use IRI syntax: exo:days_between(?a, ?b)
+ */
+
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { SPARQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+import { ExoQLAlgebraTranslator } from "../../../src/infrastructure/sparql/algebra/AlgebraTranslator";
+import { ExoQLQueryExecutor } from "../../../src/infrastructure/sparql/executors/QueryExecutor";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+describe("RFC-013 Temporal Functions", () => {
+  let store: InMemoryTripleStore;
+  let parser: SPARQLParser;
+  let translator: ExoQLAlgebraTranslator;
+
+  const task = new IRI("urn:exo:task-1");
+
+  const PREFIXES = `
+    PREFIX ems: <https://exocortex.my/ontology/ems#>
+    PREFIX exo: <https://exocortex.my/ontology/exo#>
+  `;
+
+  async function queryValue(sparql: string, variable: string): Promise<string | undefined> {
+    const ast = parser.parse(sparql);
+    const algebra = translator.translate(ast);
+    const executor = new ExoQLQueryExecutor(store);
+    const solutions = await executor.executeAll(algebra);
+    if (solutions.length === 0) return undefined;
+    const val = solutions[0].get(variable);
+    if (val instanceof Literal) return val.value;
+    if (typeof val === "number") return String(val);
+    if (typeof val === "string") return val;
+    return undefined;
+  }
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    parser = new SPARQLParser();
+    translator = new ExoQLAlgebraTranslator();
+
+    await store.addAll([
+      new Triple(task, Namespace.EMS.term("Effort_startTimestamp"), new Literal("2026-01-15T10:00:00Z")),
+      new Triple(task, Namespace.EMS.term("Effort_endTimestamp"), new Literal("2026-01-15T12:30:00Z")),
+      new Triple(task, Namespace.EXO.term("Asset_createdAt"), new Literal("2026-01-01T00:00:00Z")),
+      new Triple(task, Namespace.EMS.term("Effort_plannedEndTimestamp"), new Literal("2026-01-25T10:00:00Z")),
+    ]);
+  });
+
+  describe("exo:days_between(a, b)", () => {
+    it("should return days between two dateTimes (same day = 0)", async () => {
+      const result = await queryValue(`${PREFIXES}
+        SELECT (exo:days_between(?start, ?end) AS ?days) WHERE {
+          <urn:exo:task-1> ems:Effort_startTimestamp ?start .
+          <urn:exo:task-1> ems:Effort_endTimestamp ?end .
+        }
+      `, "days");
+
+      expect(result).toBe("0");
+    });
+
+    it("should return 10 for 10-day gap", async () => {
+      const result = await queryValue(`${PREFIXES}
+        SELECT (exo:days_between(?start, ?end) AS ?days) WHERE {
+          <urn:exo:task-1> ems:Effort_startTimestamp ?start .
+          <urn:exo:task-1> ems:Effort_plannedEndTimestamp ?end .
+        }
+      `, "days");
+
+      expect(result).toBe("10");
+    });
+  });
+
+  describe("exo:minutes_between(a, b)", () => {
+    it("should return 150 for 2h30m gap", async () => {
+      const result = await queryValue(`${PREFIXES}
+        SELECT (exo:minutes_between(?start, ?end) AS ?mins) WHERE {
+          <urn:exo:task-1> ems:Effort_startTimestamp ?start .
+          <urn:exo:task-1> ems:Effort_endTimestamp ?end .
+        }
+      `, "mins");
+
+      expect(result).toBe("150");
+    });
+  });
+
+  describe("exo:hours_between(a, b)", () => {
+    it("should return 2.5 for 2h30m gap", async () => {
+      const result = await queryValue(`${PREFIXES}
+        SELECT (exo:hours_between(?start, ?end) AS ?hours) WHERE {
+          <urn:exo:task-1> ems:Effort_startTimestamp ?start .
+          <urn:exo:task-1> ems:Effort_endTimestamp ?end .
+        }
+      `, "hours");
+
+      expect(Number(result)).toBe(2.5);
+    });
+  });
+
+  describe("exo:age_days(dateTime)", () => {
+    it("should return positive age in days", async () => {
+      const result = await queryValue(`${PREFIXES}
+        SELECT (exo:age_days(?created) AS ?age) WHERE {
+          <urn:exo:task-1> exo:Asset_createdAt ?created .
+        }
+      `, "age");
+
+      expect(Number(result)).toBeGreaterThan(0);
+    });
+  });
+
+  describe("exo:week_number(dateTime)", () => {
+    it("should return ISO week 3 for 2026-01-15", async () => {
+      const result = await queryValue(`${PREFIXES}
+        SELECT (exo:week_number(?start) AS ?week) WHERE {
+          <urn:exo:task-1> ems:Effort_startTimestamp ?start .
+        }
+      `, "week");
+
+      expect(result).toBe("3");
+    });
+  });
+
+  describe("exo:format_date(dateTime, pattern)", () => {
+    it("should format date with YYYY-MM-DD pattern", async () => {
+      const result = await queryValue(`${PREFIXES}
+        SELECT (exo:format_date(?start, "YYYY-MM-DD") AS ?formatted) WHERE {
+          <urn:exo:task-1> ems:Effort_startTimestamp ?start .
+        }
+      `, "formatted");
+
+      expect(result).toBe("2026-01-15");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 6 new temporal functions in FunctionRegistry: `exo:days_between`, `exo:minutes_between`, `exo:hours_between`, `exo:age_days`, `exo:week_number`, `exo:format_date`
- All callable via IRI syntax in ExoQL queries (e.g., `exo:days_between(?start, ?end)`)
- 7 unit tests covering all functions

## Test plan
- [x] 7 temporal function tests pass
- [x] Build clean, pre-commit hooks pass

Resolves #2597