### PR TITLE
ci: CLI npm auto-publish pipeline on merge to main

### DIFF
--- a/packages/cli/tests/unit/npm-publish-verify.test.ts
+++ b/packages/cli/tests/unit/npm-publish-verify.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+describe("CLI npm publish verification (#2601)", () => {
+  const cliRoot = path.resolve(__dirname, "../..");
+  const cliPkgPath = path.join(cliRoot, "package.json");
+  const workflowPath = path.resolve(
+    cliRoot,
+    "../../.github/workflows/npm-publish-cli.yml",
+  );
+
+  let pkg: Record<string, unknown>;
+
+  beforeAll(() => {
+    pkg = JSON.parse(fs.readFileSync(cliPkgPath, "utf8"));
+  });
+
+  it("should have correct scoped package name", () => {
+    expect(pkg.name).toBe("@kitelev/exocortex-cli");
+  });
+
+  it("should have main entry point", () => {
+    expect(pkg.main).toBe("dist/index.js");
+  });
+
+  it("should have bin entry for CLI executable", () => {
+    const bin = pkg.bin as Record<string, string>;
+    expect(bin["exocortex-cli"]).toBe("./dist/index.js");
+  });
+
+  it("should have build script", () => {
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts.build).toBeDefined();
+  });
+
+  it("should have prepublishOnly script that cleans and builds", () => {
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts.prepublishOnly).toContain("clean");
+    expect(scripts.prepublishOnly).toContain("build");
+  });
+
+  it("should have npm-publish-cli workflow", () => {
+    expect(fs.existsSync(workflowPath)).toBe(true);
+  });
+
+  it("workflow should trigger on release event", () => {
+    const workflow = fs.readFileSync(workflowPath, "utf8");
+    expect(workflow).toContain("on:");
+    expect(workflow).toContain("release:");
+    expect(workflow).toContain("types: [published]");
+  });
+
+  it("workflow should publish @kitelev/exocortex-cli", () => {
+    const workflow = fs.readFileSync(workflowPath, "utf8");
+    expect(workflow).toContain("npm publish --access public");
+    expect(workflow).toContain("@kitelev/exocortex-cli");
+  });
+});

--- a/packages/cli/tests/unit/npm-publish-verify.test.ts
+++ b/packages/cli/tests/unit/npm-publish-verify.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect } from "@jest/globals";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const cliRoot = path.resolve(testDir, "../..");
+const monorepoRoot = path.resolve(cliRoot, "../..");
 
 describe("CLI npm publish verification (#2601)", () => {
-  const cliRoot = path.resolve(__dirname, "../..");
   const cliPkgPath = path.join(cliRoot, "package.json");
   const workflowPath = path.resolve(
-    cliRoot,
-    "../../.github/workflows/npm-publish-cli.yml",
+    monorepoRoot,
+    ".github/workflows/npm-publish-cli.yml",
   );
 
   let pkg: Record<string, unknown>;


### PR DESCRIPTION
## Summary

- Verifies the existing `npm-publish-cli.yml` workflow satisfies Issue #2601 requirements
- Adds 8 verification tests confirming: correct package name (`@kitelev/exocortex-cli`), entry points, build scripts, workflow trigger (`release: published`), and npm publish command
- Pipeline: push to main → Auto Release → release event → `npm-publish-cli.yml` → `npm publish --access public`

## Test plan

- [x] All 8 tests in `packages/cli/tests/unit/npm-publish-verify.test.ts` pass locally
- [ ] CI checks pass (build, typecheck, test-unit, test-coverage, test-bdd, archgate, e2e-tests, test-component)

Resolves #2601.