### PR TITLE
chore: CLI version sync with plugin monorepo version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitelev/exocortex-cli",
-  "version": "0.1.0",
+  "version": "15.55.5",
   "description": "CLI tool for Exocortex knowledge management system - SPARQL queries, task management, and more",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Syncs CLI package.json from 0.1.0 to 15.55.5 (monorepo root version)
- Auto-release workflow already bumps CLI version + publishes on every release

Resolves #2602