### PR TITLE
refactor: eliminate obsidian runtime imports from application layer

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -32,6 +32,7 @@ import { LayoutCodeBlockProcessor } from "./application/processors/LayoutCodeBlo
 import { SPARQLApi } from "./application/api/SPARQLApi";
 import { ExocortexAPI } from "./application/api/ExocortexAPI";
 import { PluginContainer } from "./infrastructure/di/PluginContainer";
+import { ObsidianNotificationService } from "./infrastructure/di/ObsidianNotificationService";
 import { createAliasIconExtension, createWikilinkLabelExtension } from "./presentation/editor-extensions";
 import { TimerManager } from "./infrastructure/timer";
 import { LRUCache } from "./infrastructure/cache";
@@ -136,7 +137,8 @@ export default class ExocortexPlugin extends Plugin {
         maxEntries: 1000,
         ttl: 5 * 60 * 1000, // 5 minutes
       });
-      this.sparqlProcessor = new SPARQLCodeBlockProcessor(this);
+      const notifier = new ObsidianNotificationService();
+      this.sparqlProcessor = new SPARQLCodeBlockProcessor(this, notifier);
       this.layoutProcessor = new LayoutCodeBlockProcessor(this);
       this.sparql = new SPARQLApi(this);
       this.api = new ExocortexAPI(this);

--- a/packages/obsidian-plugin/src/application/api/ExocortexAPI.ts
+++ b/packages/obsidian-plugin/src/application/api/ExocortexAPI.ts
@@ -1,4 +1,5 @@
-import { TFile, EventRef } from "obsidian";
+import { TFile } from "obsidian";
+import type { EventRef } from "obsidian";
 import type ExocortexPlugin from '@plugin/ExocortexPlugin';
 import { AssetMetadataService } from '@plugin/presentation/renderers/layout/helpers/AssetMetadataService';
 import { BacklinksCacheManager } from '@plugin/adapters/caching/BacklinksCacheManager';

--- a/packages/obsidian-plugin/src/application/commands/AddSupervisionCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/AddSupervisionCommand.ts
@@ -1,6 +1,6 @@
-import { App, Notice } from "obsidian";
+import type { App } from "obsidian";
 import { ICommand } from "./ICommand";
-import { SupervisionCreationService, LoggingService } from "exocortex";
+import { SupervisionCreationService, LoggingService, type INotificationService } from "exocortex";
 import { showSupervisionModal } from '@plugin/presentation/modals/modalSchemas';
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
 import { CommandHelpers } from "./helpers/CommandHelpers";
@@ -13,6 +13,7 @@ export class AddSupervisionCommand implements ICommand {
     private app: App,
     private supervisionCreationService: SupervisionCreationService,
     private vaultAdapter: ObsidianVaultAdapter,
+    private notifier: INotificationService,
   ) {}
 
   callback = async (): Promise<void> => {
@@ -28,10 +29,10 @@ export class AddSupervisionCommand implements ICommand {
       const tfile = this.vaultAdapter.toTFile(createdFile);
       await CommandHelpers.openFileInNewTab(this.app, tfile);
 
-      new Notice(`Supervision created: ${createdFile.basename}`);
+      this.notifier.success(`Supervision created: ${createdFile.basename}`);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      new Notice(`Failed to create supervision: ${errorMessage}`);
+      this.notifier.error(`Failed to create supervision: ${errorMessage}`);
       LoggingService.error("Add supervision error", error instanceof Error ? error : new Error(String(error)));
     }
   };

--- a/packages/obsidian-plugin/src/application/commands/ArchiveTaskCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/ArchiveTaskCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canArchiveTask,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class ArchiveTaskCommand implements ICommand {
   id = "archive-task";
   name = "Archive task";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canArchiveTask(context)) return false;
@@ -21,7 +25,7 @@ export class ArchiveTaskCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to archive task: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to archive task: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Archive task error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class ArchiveTaskCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.archiveTask(file);
-    new Notice(`Archived: ${file.basename}`);
+    this.notifier.success(`Archived: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/CleanPropertiesCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CleanPropertiesCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canCleanProperties,
   PropertyCleanupService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class CleanPropertiesCommand implements ICommand {
   id = "clean-properties";
   name = "Clean empty properties";
 
-  constructor(private propertyCleanupService: PropertyCleanupService) {}
+  constructor(
+    private propertyCleanupService: PropertyCleanupService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canCleanProperties(context)) return false;
@@ -21,7 +25,7 @@ export class CleanPropertiesCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to clean properties: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to clean properties: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Clean properties error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class CleanPropertiesCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.propertyCleanupService.cleanEmptyProperties(file);
-    new Notice(`Cleaned empty properties: ${file.basename}`);
+    this.notifier.success(`Cleaned empty properties: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/ConvertProjectToTaskCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/ConvertProjectToTaskCommand.ts
@@ -1,10 +1,11 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canConvertProjectToTask,
   AssetConversionService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class ConvertProjectToTaskCommand implements ICommand {
@@ -13,6 +14,7 @@ export class ConvertProjectToTaskCommand implements ICommand {
 
   constructor(
     private conversionService: AssetConversionService,
+    private notifier: INotificationService,
   ) {}
 
   checkCallback = (
@@ -27,7 +29,7 @@ export class ConvertProjectToTaskCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to convert Project to Task: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to convert Project to Task: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Convert Project to Task error", error instanceof Error ? error : undefined);
         }
       })();
@@ -38,6 +40,6 @@ export class ConvertProjectToTaskCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.conversionService.convertProjectToTask(file);
-    new Notice(`Converted to Task: ${file.basename}`);
+    this.notifier.success(`Converted to Task: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/ConvertTaskToProjectCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/ConvertTaskToProjectCommand.ts
@@ -1,10 +1,11 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canConvertTaskToProject,
   AssetConversionService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class ConvertTaskToProjectCommand implements ICommand {
@@ -13,6 +14,7 @@ export class ConvertTaskToProjectCommand implements ICommand {
 
   constructor(
     private conversionService: AssetConversionService,
+    private notifier: INotificationService,
   ) {}
 
   checkCallback = (
@@ -27,7 +29,7 @@ export class ConvertTaskToProjectCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to convert Task to Project: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to convert Task to Project: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Convert Task to Project error", error instanceof Error ? error : undefined);
         }
       })();
@@ -38,6 +40,6 @@ export class ConvertTaskToProjectCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.conversionService.convertTaskToProject(file);
-    new Notice(`Converted to Project: ${file.basename}`);
+    this.notifier.success(`Converted to Project: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/CopyFleetingNoteLabelCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CopyFleetingNoteLabelCommand.ts
@@ -1,9 +1,10 @@
-import { TFile, Notice, App } from "obsidian";
+import type { TFile, App } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canCopyFleetingNoteLabel,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 /**
@@ -18,7 +19,10 @@ export class CopyFleetingNoteLabelCommand implements ICommand {
   id = "copy-fleeting-note-label";
   name = "Copy Label";
 
-  constructor(private app: App) {}
+  constructor(
+    private app: App,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canCopyFleetingNoteLabel(context)) return false;
@@ -28,7 +32,7 @@ export class CopyFleetingNoteLabelCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to copy label: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to copy label: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Copy fleeting note label error", error instanceof Error ? error : undefined);
         }
       })();
@@ -42,12 +46,12 @@ export class CopyFleetingNoteLabelCommand implements ICommand {
     const label = this.extractLabelFromContent(content);
 
     if (!label) {
-      new Notice("Label is empty");
+      this.notifier.warn("Label is empty");
       return;
     }
 
     await navigator.clipboard.writeText(label);
-    new Notice("Label copied to clipboard");
+    this.notifier.success("Label copied to clipboard");
   }
 
   /**

--- a/packages/obsidian-plugin/src/application/commands/CopyLabelToAliasesCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CopyLabelToAliasesCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canCopyLabelToAliases,
   LabelToAliasService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class CopyLabelToAliasesCommand implements ICommand {
   id = "copy-label-to-aliases";
   name = "Copy label to aliases";
 
-  constructor(private labelToAliasService: LabelToAliasService) {}
+  constructor(
+    private labelToAliasService: LabelToAliasService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canCopyLabelToAliases(context)) return false;
@@ -21,7 +25,7 @@ export class CopyLabelToAliasesCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to copy label: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to copy label: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Copy label to aliases error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class CopyLabelToAliasesCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.labelToAliasService.copyLabelToAliases(file);
-    new Notice("Label copied to aliases");
+    this.notifier.success("Label copied to aliases");
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/CreateAreaCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateAreaCommand.ts
@@ -1,9 +1,10 @@
-import { App, TFile } from "obsidian";
+import type { App, TFile } from "obsidian";
 import {
   CommandVisibilityContext,
   canCreateChildArea,
   AreaCreationService,
   type IFile,
+  type INotificationService,
 } from "exocortex";
 import type { LabelInputModalResult } from '@plugin/presentation/modals/modalSchemas';
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
@@ -17,8 +18,9 @@ export class CreateAreaCommand extends BaseContextAssetCreationCommand {
     app: App,
     private areaCreationService: AreaCreationService,
     vaultAdapter: ObsidianVaultAdapter,
+    notifier: INotificationService,
   ) {
-    super(app, vaultAdapter);
+    super(app, vaultAdapter, notifier);
   }
 
   protected canCreate(context: CommandVisibilityContext): boolean {

--- a/packages/obsidian-plugin/src/application/commands/CreateAssetCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateAssetCommand.ts
@@ -1,9 +1,10 @@
-import { App, Notice } from "obsidian";
+import type { App } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   GenericAssetCreationService,
   LoggingService,
   type AssetPropertyDefinition,
+  type INotificationService,
 } from "exocortex";
 import {
   showClassSelectionModal,
@@ -54,6 +55,7 @@ export class CreateAssetCommand implements ICommand {
     private genericAssetCreationService: GenericAssetCreationService,
     private vaultAdapter: ObsidianVaultAdapter,
     private classDiscoveryService: ClassDiscoveryService,
+    private notifier: INotificationService,
     private schemaService?: OntologySchemaService,
   ) {}
 
@@ -106,9 +108,9 @@ export class CreateAssetCommand implements ICommand {
       await leaf.openFile(tfile);
       this.app.workspace.setActiveLeaf(leaf, { focus: true });
 
-      new Notice(`${selectedClass.label} created: ${createdFile.basename}`);
+      this.notifier.success(`${selectedClass.label} created: ${createdFile.basename}`);
     } catch (error) {
-      new Notice(`Failed to create asset: ${error instanceof Error ? error.message : String(error)}`);
+      this.notifier.error(`Failed to create asset: ${error instanceof Error ? error.message : String(error)}`);
       LoggingService.error("Create asset error", error instanceof Error ? error : undefined);
     }
   };

--- a/packages/obsidian-plugin/src/application/commands/CreateFleetingNoteCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateFleetingNoteCommand.ts
@@ -1,7 +1,8 @@
-import { App, Notice } from "obsidian";
+import type { App } from "obsidian";
 import {
   FleetingNoteCreationService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 import { ICommand } from "./ICommand";
 import { showFleetingNoteModal } from '@plugin/presentation/modals/modalSchemas';
@@ -16,6 +17,7 @@ export class CreateFleetingNoteCommand implements ICommand {
     private app: App,
     private fleetingNoteCreationService: FleetingNoteCreationService,
     private vaultAdapter: ObsidianVaultAdapter,
+    private notifier: INotificationService,
   ) {}
 
   callback = async (): Promise<void> => {
@@ -33,10 +35,10 @@ export class CreateFleetingNoteCommand implements ICommand {
       const tfile = this.vaultAdapter.toTFile(createdFile);
       await CommandHelpers.openFileInNewTab(this.app, tfile);
 
-      new Notice(`Fleeting note created: ${createdFile.basename}`);
+      this.notifier.success(`Fleeting note created: ${createdFile.basename}`);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      new Notice(`Failed to create fleeting note: ${errorMessage}`);
+      this.notifier.error(`Failed to create fleeting note: ${errorMessage}`);
       LoggingService.error("Create fleeting note error", error instanceof Error ? error : new Error(String(error)));
     }
   };

--- a/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateInstanceCommand.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from "obsidian";
+import type { App, TFile } from "obsidian";
 import {
   CommandVisibilityContext,
   canCreateInstance,
@@ -8,6 +8,7 @@ import {
   type InstantiationRule,
   type InstantiationRuleResolver,
   type IFile,
+  type INotificationService,
 } from "exocortex";
 import { showLabelInputModal, type LabelInputModalResult } from '@plugin/presentation/modals/modalSchemas';
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
@@ -24,8 +25,9 @@ export class CreateInstanceCommand extends BaseContextAssetCreationCommand {
     private readonly ruleResolver: InstantiationRuleResolver,
     private readonly genericAssetCreationService: GenericAssetCreationService,
     vaultAdapter: ObsidianVaultAdapter,
+    notifier: INotificationService,
   ) {
-    super(app, vaultAdapter);
+    super(app, vaultAdapter, notifier);
   }
 
   protected canCreate(context: CommandVisibilityContext): boolean {

--- a/packages/obsidian-plugin/src/application/commands/EditPropertiesCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/EditPropertiesCommand.ts
@@ -1,8 +1,8 @@
-import { App, TFile, Notice } from "obsidian";
+import type { App, TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import { ExocortexPluginInterface } from '@plugin/types';
 import { PropertyEditorModal } from '@plugin/presentation/modals/PropertyEditorModal';
-import type { CommandVisibilityContext } from "exocortex";
+import type { CommandVisibilityContext, INotificationService } from "exocortex";
 
 export class EditPropertiesCommand implements ICommand {
   id = "edit-properties";
@@ -11,6 +11,7 @@ export class EditPropertiesCommand implements ICommand {
   constructor(
     private app: App,
     private plugin: ExocortexPluginInterface,
+    private notifier: INotificationService,
   ) {}
 
   checkCallback = (
@@ -34,7 +35,7 @@ export class EditPropertiesCommand implements ICommand {
       );
       modal.open();
     } else {
-      new Notice("This file has no frontmatter properties to edit");
+      this.notifier.info("This file has no frontmatter properties to edit");
     }
   };
 }

--- a/packages/obsidian-plugin/src/application/commands/ICommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/ICommand.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import type { TFile } from "obsidian";
 import { CommandVisibilityContext } from "exocortex";
 
 export interface ICommand {

--- a/packages/obsidian-plugin/src/application/commands/MarkDoneCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/MarkDoneCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canMarkDone,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class MarkDoneCommand implements ICommand {
   id = "mark-done";
   name = "Mark as done";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canMarkDone(context)) return false;
@@ -21,7 +25,7 @@ export class MarkDoneCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to mark as done: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to mark as done: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Mark done error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class MarkDoneCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.markTaskAsDone(file);
-    new Notice(`Marked as done: ${file.basename}`);
+    this.notifier.success(`Marked as done: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/MarkReviewedCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/MarkReviewedCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canMarkReviewed,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class MarkReviewedCommand implements ICommand {
   id = "mark-reviewed";
   name = "Mark as reviewed";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canMarkReviewed(context)) return false;
@@ -21,7 +25,7 @@ export class MarkReviewedCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to mark as reviewed: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to mark as reviewed: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Mark reviewed error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class MarkReviewedCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.markAsReviewed(file);
-    new Notice(`Marked as reviewed: ${file.basename}`);
+    this.notifier.success(`Marked as reviewed: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/MoveToAnalysisCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/MoveToAnalysisCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canMoveToAnalysis,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class MoveToAnalysisCommand implements ICommand {
   id = "move-to-analysis";
   name = "Move to analysis";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canMoveToAnalysis(context)) return false;
@@ -21,7 +25,7 @@ export class MoveToAnalysisCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to move to analysis: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to move to analysis: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Move to analysis error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class MoveToAnalysisCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.moveToAnalysis(file);
-    new Notice(`Moved to Analysis: ${file.basename}`);
+    this.notifier.success(`Moved to Analysis: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/MoveToBacklogCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/MoveToBacklogCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canMoveToBacklog,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class MoveToBacklogCommand implements ICommand {
   id = "move-to-backlog";
   name = "Move to backlog";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canMoveToBacklog(context)) return false;
@@ -21,7 +25,7 @@ export class MoveToBacklogCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to move to backlog: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to move to backlog: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Move to backlog error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class MoveToBacklogCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.moveToBacklog(file);
-    new Notice(`Moved to Backlog: ${file.basename}`);
+    this.notifier.success(`Moved to Backlog: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/MoveToToDoCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/MoveToToDoCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canMoveToToDo,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class MoveToToDoCommand implements ICommand {
   id = "move-to-todo";
   name = "Move to to-do";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canMoveToToDo(context)) return false;
@@ -21,7 +25,7 @@ export class MoveToToDoCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to move to todo: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to move to todo: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Move to todo error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class MoveToToDoCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.moveToToDo(file);
-    new Notice(`Moved to ToDo: ${file.basename}`);
+    this.notifier.success(`Moved to ToDo: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/OpenQueryBuilderCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/OpenQueryBuilderCommand.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from "obsidian";
+import type { App, Plugin } from "obsidian";
 import { ICommand } from "./ICommand";
 import { SPARQLQueryBuilderModal } from '@plugin/presentation/modals/SPARQLQueryBuilderModal';
 

--- a/packages/obsidian-plugin/src/application/commands/PlanForEveningCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/PlanForEveningCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canPlanForEvening,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class PlanForEveningCommand implements ICommand {
   id = "plan-for-evening";
   name = "Plan for evening (19:00)";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canPlanForEvening(context)) return false;
@@ -21,7 +25,7 @@ export class PlanForEveningCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to plan for evening: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to plan for evening: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Plan for evening error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class PlanForEveningCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.planForEvening(file);
-    new Notice(`Planned for evening (19:00): ${file.basename}`);
+    this.notifier.success(`Planned for evening (19:00): ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/PlanOnTodayCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/PlanOnTodayCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canPlanOnToday,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class PlanOnTodayCommand implements ICommand {
   id = "plan-on-today";
   name = "Plan on today";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canPlanOnToday(context)) return false;
@@ -21,7 +25,7 @@ export class PlanOnTodayCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to plan on today: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to plan on today: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Plan on today error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class PlanOnTodayCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.planOnToday(file);
-    new Notice(`Planned on today: ${file.basename}`);
+    this.notifier.success(`Planned on today: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/ReloadLayoutCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/ReloadLayoutCommand.ts
@@ -1,18 +1,21 @@
-import { Notice } from "obsidian";
 import { ICommand } from "./ICommand";
+import type { INotificationService } from "exocortex";
 
 export class ReloadLayoutCommand implements ICommand {
   id = "reload-layout";
   name = "Reload layout";
 
-  constructor(private reloadLayoutCallback?: () => void) {}
+  constructor(
+    private reloadLayoutCallback: (() => void) | undefined,
+    private notifier: INotificationService,
+  ) {}
 
   callback = (): void => {
     if (this.reloadLayoutCallback) {
       this.reloadLayoutCallback();
-      new Notice("Layout reloaded");
+      this.notifier.success("Layout reloaded");
     } else {
-      new Notice("Failed to reload layout");
+      this.notifier.error("Failed to reload layout");
     }
   };
 }

--- a/packages/obsidian-plugin/src/application/commands/RenameToUidCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/RenameToUidCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canRenameToUid,
   RenameToUidService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class RenameToUidCommand implements ICommand {
   id = "rename-to-uid";
   name = "Rename to uid";
 
-  constructor(private renameToUidService: RenameToUidService) {}
+  constructor(
+    private renameToUidService: RenameToUidService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canRenameToUid(context, file.basename)) return false;
@@ -21,7 +25,7 @@ export class RenameToUidCommand implements ICommand {
         try {
           await this.execute(file, context.metadata);
         } catch (error) {
-          new Notice(`Failed to rename: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to rename: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Rename to UID error", error instanceof Error ? error : undefined);
         }
       })();
@@ -36,6 +40,6 @@ export class RenameToUidCommand implements ICommand {
 
     await this.renameToUidService.renameToUid(file, metadata);
 
-    new Notice(`Renamed "${oldName}" to "${uid}"`);
+    this.notifier.success(`Renamed "${oldName}" to "${uid}"`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/RepairFolderCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/RepairFolderCommand.ts
@@ -1,6 +1,6 @@
-import { App, TFile, Notice } from "obsidian";
+import type { App, TFile } from "obsidian";
 import { ICommand } from "./ICommand";
-import { FolderRepairService, LoggingService } from "exocortex";
+import { FolderRepairService, LoggingService, type INotificationService } from "exocortex";
 
 export class RepairFolderCommand implements ICommand {
   id = "repair-folder";
@@ -9,6 +9,7 @@ export class RepairFolderCommand implements ICommand {
   constructor(
     private app: App,
     private folderRepairService: FolderRepairService,
+    private notifier: INotificationService,
   ) {}
 
   checkCallback = (checking: boolean, file: TFile): boolean => {
@@ -22,7 +23,7 @@ export class RepairFolderCommand implements ICommand {
         try {
           await this.execute(file, metadata);
         } catch (error) {
-          new Notice(`Failed to repair folder: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to repair folder: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Repair folder error", error instanceof Error ? error : undefined);
         }
       })();
@@ -35,17 +36,17 @@ export class RepairFolderCommand implements ICommand {
     const expectedFolder = await this.folderRepairService.getExpectedFolder(file, metadata);
 
     if (!expectedFolder) {
-      new Notice("No expected folder found");
+      this.notifier.warn("No expected folder found");
       return;
     }
 
     const currentFolder = file.parent?.path || "";
     if (currentFolder === expectedFolder) {
-      new Notice("Asset is already in correct folder");
+      this.notifier.info("Asset is already in correct folder");
       return;
     }
 
     await this.folderRepairService.repairFolder(file, expectedFolder);
-    new Notice(`Moved to ${expectedFolder}`);
+    this.notifier.success(`Moved to ${expectedFolder}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/SetDraftStatusCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/SetDraftStatusCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canSetDraftStatus,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class SetDraftStatusCommand implements ICommand {
   id = "set-draft-status";
   name = "Set draft status";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canSetDraftStatus(context)) return false;
@@ -21,7 +25,7 @@ export class SetDraftStatusCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to set draft status: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to set draft status: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Set draft status error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class SetDraftStatusCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.setDraftStatus(file);
-    new Notice(`Set Draft status: ${file.basename}`);
+    this.notifier.success(`Set Draft status: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/ShiftDayBackwardCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/ShiftDayBackwardCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canShiftDayBackward,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class ShiftDayBackwardCommand implements ICommand {
   id = "shift-day-backward";
   name = "Shift day backward";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canShiftDayBackward(context)) return false;
@@ -21,7 +25,7 @@ export class ShiftDayBackwardCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to shift day backward: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to shift day backward: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Shift day backward error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class ShiftDayBackwardCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.shiftDayBackward(file);
-    new Notice(`Day shifted backward: ${file.basename}`);
+    this.notifier.success(`Day shifted backward: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/ShiftDayForwardCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/ShiftDayForwardCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canShiftDayForward,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class ShiftDayForwardCommand implements ICommand {
   id = "shift-day-forward";
   name = "Shift day forward";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canShiftDayForward(context)) return false;
@@ -21,7 +25,7 @@ export class ShiftDayForwardCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to shift day forward: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to shift day forward: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Shift day forward error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class ShiftDayForwardCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.shiftDayForward(file);
-    new Notice(`Day shifted forward: ${file.basename}`);
+    this.notifier.success(`Day shifted forward: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/StartEffortCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/StartEffortCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canStartEffort,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class StartEffortCommand implements ICommand {
   id = "start-effort";
   name = "Start effort";
 
-  constructor(private taskStatusService: TaskStatusService) {}
+  constructor(
+    private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canStartEffort(context)) return false;
@@ -21,7 +25,7 @@ export class StartEffortCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to start effort: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to start effort: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Start effort error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class StartEffortCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     await this.taskStatusService.startEffort(file);
-    new Notice(`Started effort: ${file.basename}`);
+    this.notifier.success(`Started effort: ${file.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/ToggleArchivedAssetsCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/ToggleArchivedAssetsCommand.ts
@@ -1,18 +1,21 @@
-import { Notice } from "obsidian";
 import { ICommand } from "./ICommand";
 import { ExocortexPluginInterface } from '@plugin/types';
+import type { INotificationService } from "exocortex";
 
 export class ToggleArchivedAssetsCommand implements ICommand {
   id = "toggle-archived-assets-visibility";
   name = "Toggle archived assets visibility";
 
-  constructor(private plugin: ExocortexPluginInterface) {}
+  constructor(
+    private plugin: ExocortexPluginInterface,
+    private notifier: INotificationService,
+  ) {}
 
   callback = async (): Promise<void> => {
     this.plugin.settings.showArchivedAssets = !this.plugin.settings.showArchivedAssets;
     await this.plugin.saveSettings();
     this.plugin.refreshLayout?.();
-    new Notice(
+    this.notifier.info(
       `Archived assets ${this.plugin.settings.showArchivedAssets ? "shown" : "hidden"}`,
     );
   };

--- a/packages/obsidian-plugin/src/application/commands/ToggleLayoutVisibilityCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/ToggleLayoutVisibilityCommand.ts
@@ -1,17 +1,20 @@
-import { Notice } from "obsidian";
 import { ICommand } from "./ICommand";
 import { ExocortexPluginInterface } from '@plugin/types';
+import type { INotificationService } from "exocortex";
 
 export class ToggleLayoutVisibilityCommand implements ICommand {
   id = "toggle-layout-visibility";
   name = "Toggle layout visibility";
 
-  constructor(private plugin: ExocortexPluginInterface) {}
+  constructor(
+    private plugin: ExocortexPluginInterface,
+    private notifier: INotificationService,
+  ) {}
 
   callback = async (): Promise<void> => {
     this.plugin.settings.layoutVisible = !this.plugin.settings.layoutVisible;
     await this.plugin.saveSettings();
     this.plugin.refreshLayout?.();
-    new Notice(`Layout ${this.plugin.settings.layoutVisible ? "shown" : "hidden"}`);
+    this.notifier.info(`Layout ${this.plugin.settings.layoutVisible ? "shown" : "hidden"}`);
   };
 }

--- a/packages/obsidian-plugin/src/application/commands/TrashEffortCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/TrashEffortCommand.ts
@@ -1,10 +1,12 @@
-import { App, TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
+import type { App } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canTrashEffort,
   TaskStatusService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 import {
   showTrashReasonModal,
@@ -18,6 +20,7 @@ export class TrashEffortCommand implements ICommand {
   constructor(
     private app: App,
     private taskStatusService: TaskStatusService,
+    private notifier: INotificationService,
   ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
@@ -28,7 +31,7 @@ export class TrashEffortCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to trash effort: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to trash effort: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Trash effort error", error instanceof Error ? error : undefined);
         }
       })();
@@ -45,7 +48,7 @@ export class TrashEffortCommand implements ICommand {
     }
 
     await this.taskStatusService.trashEffort(file, result.reason);
-    new Notice(`Trashed: ${file.basename}`);
+    this.notifier.success(`Trashed: ${file.basename}`);
   }
 
   private showModal(): Promise<TrashReasonModalResult> {

--- a/packages/obsidian-plugin/src/application/commands/VoteOnEffortCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/VoteOnEffortCommand.ts
@@ -1,17 +1,21 @@
-import { TFile, Notice } from "obsidian";
+import type { TFile } from "obsidian";
 import { ICommand } from "./ICommand";
 import {
   CommandVisibilityContext,
   canVoteOnEffort,
   EffortVotingService,
   LoggingService,
+  type INotificationService,
 } from "exocortex";
 
 export class VoteOnEffortCommand implements ICommand {
   id = "vote-on-effort";
   name = "Vote on effort";
 
-  constructor(private effortVotingService: EffortVotingService) {}
+  constructor(
+    private effortVotingService: EffortVotingService,
+    private notifier: INotificationService,
+  ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
     if (!context || !canVoteOnEffort(context)) return false;
@@ -21,7 +25,7 @@ export class VoteOnEffortCommand implements ICommand {
         try {
           await this.execute(file);
         } catch (error) {
-          new Notice(`Failed to vote: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to vote: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error("Vote on effort error", error instanceof Error ? error : undefined);
         }
       })();
@@ -32,6 +36,6 @@ export class VoteOnEffortCommand implements ICommand {
 
   private async execute(file: TFile): Promise<void> {
     const newVoteCount = await this.effortVotingService.incrementEffortVotes(file);
-    new Notice(`Voted! New vote count: ${newVoteCount}`);
+    this.notifier.success(`Voted! New vote count: ${newVoteCount}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/base/BaseContextAssetCreationCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/base/BaseContextAssetCreationCommand.ts
@@ -1,29 +1,15 @@
-import { App, TFile, Notice } from "obsidian";
+import type { App, TFile } from "obsidian";
 import { ICommand } from "../ICommand";
 import {
   CommandVisibilityContext,
   LoggingService,
   type IFile,
+  type INotificationService,
 } from "exocortex";
 import { showLabelInputModal, type LabelInputModalResult } from '@plugin/presentation/modals/modalSchemas';
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
 import { CommandHelpers } from "../helpers/CommandHelpers";
 
-/**
- * Base class for asset creation commands that operate within a file context.
- *
- * Implements the Template Method pattern to eliminate duplicated boilerplate
- * across CreateInstanceCommand and other context-aware creation commands.
- *
- * Subclasses override:
- * - canCreate(): visibility check for the command
- * - getAssetTypeName(): human-readable name for notices
- * - getErrorLogPrefix(): prefix for error logging
- * - createAsset(): the actual creation service call
- *
- * Optionally override:
- * - showModal(): to customize the modal (e.g., default label, hide task size)
- */
 export abstract class BaseContextAssetCreationCommand implements ICommand {
   abstract readonly id: string;
   abstract readonly name: string;
@@ -31,6 +17,7 @@ export abstract class BaseContextAssetCreationCommand implements ICommand {
   constructor(
     protected readonly app: App,
     protected readonly vaultAdapter: ObsidianVaultAdapter,
+    protected readonly notifier: INotificationService,
   ) {}
 
   checkCallback = (checking: boolean, file: TFile, context: CommandVisibilityContext | null): boolean => {
@@ -41,7 +28,7 @@ export abstract class BaseContextAssetCreationCommand implements ICommand {
         try {
           await this.execute(file, context);
         } catch (error) {
-          new Notice(`Failed to create ${this.getAssetTypeName().toLowerCase()}: ${error instanceof Error ? error.message : String(error)}`);
+          this.notifier.error(`Failed to create ${this.getAssetTypeName().toLowerCase()}: ${error instanceof Error ? error.message : String(error)}`);
           LoggingService.error(this.getErrorLogPrefix(), error instanceof Error ? error : undefined);
         }
       })();
@@ -96,6 +83,6 @@ export abstract class BaseContextAssetCreationCommand implements ICommand {
 
     await CommandHelpers.waitForFileActivation(this.app, tfile.path);
 
-    new Notice(`${this.getAssetTypeName()} created: ${createdFile.basename}`);
+    this.notifier.success(`${this.getAssetTypeName()} created: ${createdFile.basename}`);
   }
 }

--- a/packages/obsidian-plugin/src/application/commands/helpers/CommandHelpers.ts
+++ b/packages/obsidian-plugin/src/application/commands/helpers/CommandHelpers.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import type { TFile } from "obsidian";
 import { ObsidianApp } from '@plugin/types';
 
 /**

--- a/packages/obsidian-plugin/src/application/layout/LayoutService.ts
+++ b/packages/obsidian-plugin/src/application/layout/LayoutService.ts
@@ -13,7 +13,8 @@
  * @since 1.0.0
  */
 
-import { TFile, type App } from "obsidian";
+import { TFile } from "obsidian";
+import type { App } from "obsidian";
 import type {
   IVaultAdapter,
   IFile,

--- a/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
@@ -17,11 +17,8 @@
  */
 
 import React from "react";
-import {
-  MarkdownPostProcessorContext,
-  MarkdownRenderChild,
-  type EventRef,
-} from "obsidian";
+import type { MarkdownPostProcessorContext, EventRef } from "obsidian";
+import { MarkdownRenderChild } from "obsidian";
 import type ExocortexPlugin from "@plugin/ExocortexPlugin";
 import { LayoutService } from "../layout";
 import type { LayoutRenderResult } from "../layout";

--- a/packages/obsidian-plugin/src/application/processors/SPARQLCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/SPARQLCodeBlockProcessor.ts
@@ -1,5 +1,6 @@
 import React from "react";
-import { MarkdownPostProcessorContext, EventRef, Notice, MarkdownRenderChild } from "obsidian";
+import type { MarkdownPostProcessorContext, EventRef } from "obsidian";
+import { MarkdownRenderChild } from "obsidian";
 import {
   InMemoryTripleStore,
   ExoQLParser,
@@ -15,6 +16,7 @@ import {
   type AlgebraOperation,
   type ConstructOperation,
   type AlgebraTriple,
+  type INotificationService,
 } from "exocortex";
 import type ExocortexPlugin from '@plugin/ExocortexPlugin';
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
@@ -84,9 +86,11 @@ export class SPARQLCodeBlockProcessor {
   private readonly CLEANUP_INTERVAL_MS = 60 * 1000;
   private cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
   private readonly logger = LoggerFactory.create("SPARQLCodeBlockProcessor");
+  private readonly notifier: INotificationService;
 
-  constructor(plugin: ExocortexPlugin) {
+  constructor(plugin: ExocortexPlugin, notifier: INotificationService) {
     this.plugin = plugin;
+    this.notifier = notifier;
     this.startCleanupInterval();
   }
 
@@ -213,7 +217,7 @@ export class SPARQLCodeBlockProcessor {
         error: errorObj,
         context: { queryPreview: source.substring(0, 100) },
       });
-      new Notice(`SPARQL query error: ${errorObj.message}`, 5000);
+      this.notifier.error(`SPARQL query error: ${errorObj.message}`);
 
       container.innerHTML = "";
       this.renderError(errorObj, container, source);
@@ -262,7 +266,7 @@ export class SPARQLCodeBlockProcessor {
         error: errorObj,
         context: { queryPreview: source.substring(0, 100) },
       });
-      new Notice(`SPARQL query refresh error: ${errorObj.message}`, 5000);
+      this.notifier.error(`SPARQL query refresh error: ${errorObj.message}`);
 
       container.innerHTML = "";
       this.renderError(errorObj, container, source);
@@ -393,7 +397,7 @@ export class SPARQLCodeBlockProcessor {
         errorCode: ErrorCodes.STORE_INITIALIZATION,
         error: errorObj,
       });
-      new Notice(`Failed to load triple store: ${errorObj.message}`, 5000);
+      this.notifier.error(`Failed to load triple store: ${errorObj.message}`);
       throw errorObj;
     } finally {
       this.isLoading = false;

--- a/packages/obsidian-plugin/src/application/services/AliasSyncService.ts
+++ b/packages/obsidian-plugin/src/application/services/AliasSyncService.ts
@@ -1,4 +1,4 @@
-import { TFile, MetadataCache, App } from "obsidian";
+import type { TFile, MetadataCache, App } from "obsidian";
 import {
   ApplicationErrorHandler,
   NetworkError,

--- a/packages/obsidian-plugin/src/application/services/CommandManager.ts
+++ b/packages/obsidian-plugin/src/application/services/CommandManager.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from "obsidian";
+import type { App, TFile } from "obsidian";
 import { container } from "tsyringe";
 import { ExocortexPluginInterface } from '@plugin/types';
 import { CommandRegistry } from '@plugin/application/commands/CommandRegistry';
@@ -10,9 +10,11 @@ import {
   GenericAssetCreationService,
   DI_TOKENS,
   registerCoreServices,
+  type INotificationService,
 } from "exocortex";
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
 import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
+import { ObsidianNotificationService } from '@plugin/infrastructure/di/ObsidianNotificationService';
 import { SPARQLQueryService } from '@plugin/application/services/SPARQLQueryService';
 import { OntologySchemaService } from '@plugin/application/services/OntologySchemaService';
 import { ClassDiscoveryService } from '@plugin/application/services/ClassDiscoveryService';
@@ -49,6 +51,8 @@ export class CommandManager {
     container.register(DI_TOKENS.ILogger, { useValue: logger });
     registerCoreServices();
 
+    const notifier: INotificationService = new ObsidianNotificationService();
+
     const fleetingNoteCreationService = container.resolve(FleetingNoteCreationService);
     const genericAssetCreationService = container.resolve(GenericAssetCreationService);
     const sparqlQueryService = new SPARQLQueryService(this.app, logger);
@@ -56,13 +60,13 @@ export class CommandManager {
     const classDiscoveryService = new ClassDiscoveryService(sparqlQueryService);
 
     const globalCommands = [
-      new ReloadLayoutCommand(reloadLayoutCallback),
-      new ToggleLayoutVisibilityCommand(plugin),
-      new ToggleArchivedAssetsCommand(plugin),
+      new ReloadLayoutCommand(reloadLayoutCallback, notifier),
+      new ToggleLayoutVisibilityCommand(plugin, notifier),
+      new ToggleArchivedAssetsCommand(plugin, notifier),
       new OpenQueryBuilderCommand(this.app, plugin),
-      new EditPropertiesCommand(this.app, plugin),
-      new CreateAssetCommand(this.app, genericAssetCreationService, this.vaultAdapter, classDiscoveryService, ontologySchemaService),
-      new CreateFleetingNoteCommand(this.app, fleetingNoteCreationService, this.vaultAdapter),
+      new EditPropertiesCommand(this.app, plugin, notifier),
+      new CreateAssetCommand(this.app, genericAssetCreationService, this.vaultAdapter, classDiscoveryService, notifier, ontologySchemaService),
+      new CreateFleetingNoteCommand(this.app, fleetingNoteCreationService, this.vaultAdapter, notifier),
     ];
 
     this.commandRegistry = new CommandRegistry(globalCommands);

--- a/packages/obsidian-plugin/src/application/services/PropertyUpdateService.ts
+++ b/packages/obsidian-plugin/src/application/services/PropertyUpdateService.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from "obsidian";
+import type { App, TFile } from "obsidian";
 import { ILogger } from '@plugin/adapters/logging/ILogger';
 import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
 import {

--- a/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
+++ b/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from "obsidian";
+import type { App, TFile } from "obsidian";
 import {
   ExoQLParser,
   ExoQLAlgebraTranslator,

--- a/packages/obsidian-plugin/src/application/services/TaskTrackingService.ts
+++ b/packages/obsidian-plugin/src/application/services/TaskTrackingService.ts
@@ -1,4 +1,5 @@
-import { App, MetadataCache, TFile, Vault, Platform } from "obsidian";
+import type { App, MetadataCache, TFile, Vault } from "obsidian";
+import { Platform } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import { ILogger } from '@plugin/adapters/logging/ILogger';
 import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';

--- a/packages/obsidian-plugin/tests/unit/AddSupervisionCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AddSupervisionCommand.test.ts
@@ -21,6 +21,7 @@ const mockShowSupervisionModal = showSupervisionModal as jest.MockedFunction<typ
 
 describe("AddSupervisionCommand", () => {
   let command: AddSupervisionCommand;
+  let mockNotifier: any;
   let mockApp: jest.Mocked<App>;
   let mockSupervisionCreationService: jest.Mocked<SupervisionCreationService>;
   let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
@@ -51,7 +52,8 @@ describe("AddSupervisionCommand", () => {
       .spyOn(CommandHelpers, "openFileInNewTab")
       .mockResolvedValue(undefined);
 
-    command = new AddSupervisionCommand(mockApp, mockSupervisionCreationService, mockVaultAdapter);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new AddSupervisionCommand(mockApp, mockSupervisionCreationService, mockVaultAdapter, mockNotifier);
   });
 
   afterEach(() => {
@@ -87,7 +89,7 @@ describe("AddSupervisionCommand", () => {
       expect(mockSupervisionCreationService.createSupervision).toHaveBeenCalledWith(formData);
       expect(mockVaultAdapter.toTFile).toHaveBeenCalledWith(createdFile);
       expect(openFileSpy).toHaveBeenCalledWith(mockApp, mockTFile);
-      expect(Notice).toHaveBeenCalledWith("Supervision created: test-supervision");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Supervision created: test-supervision");
     });
 
     it("should handle modal cancellation", async () => {
@@ -97,7 +99,7 @@ describe("AddSupervisionCommand", () => {
 
       expect(mockShowSupervisionModal).toHaveBeenCalled();
       expect(mockSupervisionCreationService.createSupervision).not.toHaveBeenCalled();
-      expect(Notice).not.toHaveBeenCalled();
+      expect(mockNotifier.success).not.toHaveBeenCalled();
     });
 
     it("should handle service error and show error notice", async () => {
@@ -119,7 +121,7 @@ describe("AddSupervisionCommand", () => {
 
       expect(mockSupervisionCreationService.createSupervision).toHaveBeenCalledWith(formData);
       expect(LoggingService.error).toHaveBeenCalledWith("Add supervision error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to create supervision: Failed to create file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to create supervision: Failed to create file");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ArchiveTaskCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ArchiveTaskCommand.test.ts
@@ -20,6 +20,7 @@ describe("ArchiveTaskCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("ArchiveTaskCommand", () => {
     };
 
     // Create command instance
-    command = new ArchiveTaskCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new ArchiveTaskCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("ArchiveTaskCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.archiveTask).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Archived: test-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Archived: test-task");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("ArchiveTaskCommand", () => {
 
       expect(mockTaskStatusService.archiveTask).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Archive task error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to archive task: Failed to archive");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to archive task: Failed to archive");
     });
 
     it("should handle already archived context", () => {
@@ -130,7 +132,7 @@ describe("ArchiveTaskCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.archiveTask).toHaveBeenCalledWith(longFile);
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.success).toHaveBeenCalledWith(
         "Archived: very-long-task-name-that-exceeds-normal-length-expectations"
       );
     });
@@ -173,7 +175,7 @@ describe("ArchiveTaskCommand", () => {
       // Since error is not an Error instance, undefined is passed to LoggingService.error
       expect(LoggingService.error).toHaveBeenCalledWith("Archive task error", undefined);
       // Since error is not an Error instance, String(error) is used which calls toString()
-      expect(Notice).toHaveBeenCalledWith("Failed to archive task: Custom error string");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to archive task: Custom error string");
     });
 
     it("should handle multiple concurrent archive operations", async () => {
@@ -193,12 +195,12 @@ describe("ArchiveTaskCommand", () => {
       files.forEach(file => command.checkCallback(false, file, mockContext));
 
       // Wait for all async executions
-      await waitForCondition(() => (Notice as jest.Mock).mock.calls.length >= 3);
+      await waitForCondition(() => mockNotifier.success.mock.calls.length >= 3);
 
       expect(mockTaskStatusService.archiveTask).toHaveBeenCalledTimes(3);
       files.forEach((file, index) => {
         expect(mockTaskStatusService.archiveTask).toHaveBeenNthCalledWith(index + 1, file);
-        expect(Notice).toHaveBeenCalledWith(`Archived: ${file.basename}`);
+        expect(mockNotifier.success).toHaveBeenCalledWith(`Archived: ${file.basename}`);
       });
     });
   });

--- a/packages/obsidian-plugin/tests/unit/CleanPropertiesCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CleanPropertiesCommand.test.ts
@@ -20,6 +20,7 @@ describe("CleanPropertiesCommand", () => {
   let mockPropertyCleanupService: jest.Mocked<PropertyCleanupService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("CleanPropertiesCommand", () => {
     };
 
     // Create command instance
-    command = new CleanPropertiesCommand(mockPropertyCleanupService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new CleanPropertiesCommand(mockPropertyCleanupService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("CleanPropertiesCommand", () => {
       await flushPromises();
 
       expect(mockPropertyCleanupService.cleanEmptyProperties).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Cleaned empty properties: test-file");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Cleaned empty properties: test-file");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("CleanPropertiesCommand", () => {
 
       expect(mockPropertyCleanupService.cleanEmptyProperties).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Clean properties error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to clean properties: Failed to clean");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to clean properties: Failed to clean");
     });
 
     it("should handle files with special characters", async () => {
@@ -123,7 +125,7 @@ describe("CleanPropertiesCommand", () => {
       await flushPromises();
 
       expect(mockPropertyCleanupService.cleanEmptyProperties).toHaveBeenCalledWith(specialFile);
-      expect(Notice).toHaveBeenCalledWith("Cleaned empty properties: [IMPORTANT] File (2024)");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Cleaned empty properties: [IMPORTANT] File (2024)");
     });
 
     it("should handle file system errors", async () => {
@@ -139,7 +141,7 @@ describe("CleanPropertiesCommand", () => {
 
       expect(mockPropertyCleanupService.cleanEmptyProperties).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Clean properties error", fsError);
-      expect(Notice).toHaveBeenCalledWith("Failed to clean properties: File locked");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to clean properties: File locked");
     });
 
     it("should handle archived context", () => {
@@ -168,7 +170,7 @@ describe("CleanPropertiesCommand", () => {
       expect(mockPropertyCleanupService.cleanEmptyProperties).toHaveBeenCalledTimes(3);
       files.forEach((file, index) => {
         expect(mockPropertyCleanupService.cleanEmptyProperties).toHaveBeenNthCalledWith(index + 1, file);
-        expect(Notice).toHaveBeenCalledWith(`Cleaned empty properties: ${file.basename}`);
+        expect(mockNotifier.success).toHaveBeenCalledWith(`Cleaned empty properties: ${file.basename}`);
       });
     });
   });

--- a/packages/obsidian-plugin/tests/unit/ConvertProjectToTaskCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ConvertProjectToTaskCommand.test.ts
@@ -25,8 +25,10 @@ describe("ConvertProjectToTaskCommand", () => {
       parent: null,
     } as TFile;
 
+    const mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
     command = new ConvertProjectToTaskCommand(
       mockConversionService,
+      mockNotifier,
     );
   });
 

--- a/packages/obsidian-plugin/tests/unit/ConvertTaskToProjectCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ConvertTaskToProjectCommand.test.ts
@@ -25,8 +25,10 @@ describe("ConvertTaskToProjectCommand", () => {
       parent: null,
     } as TFile;
 
+    const mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
     command = new ConvertTaskToProjectCommand(
       mockConversionService,
+      mockNotifier,
     );
   });
 

--- a/packages/obsidian-plugin/tests/unit/CopyFleetingNoteLabelCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CopyFleetingNoteLabelCommand.test.ts
@@ -17,6 +17,7 @@ jest.mock("exocortex", () => ({
 
 describe("CopyFleetingNoteLabelCommand", () => {
   let command: CopyFleetingNoteLabelCommand;
+  let mockNotifier: any;
   let mockApp: jest.Mocked<App>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
@@ -61,7 +62,8 @@ describe("CopyFleetingNoteLabelCommand", () => {
     });
 
     // Create command instance
-    command = new CopyFleetingNoteLabelCommand(mockApp);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new CopyFleetingNoteLabelCommand(mockApp, mockNotifier);
   });
 
   afterEach(() => {
@@ -112,7 +114,7 @@ describe("CopyFleetingNoteLabelCommand", () => {
 
       expect(mockApp.vault.read).toHaveBeenCalledWith(mockFile);
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith("This is the label to copy");
-      expect(Notice).toHaveBeenCalledWith("Label copied to clipboard");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Label copied to clipboard");
     });
 
     it("should trim whitespace from first line", async () => {
@@ -125,7 +127,7 @@ describe("CopyFleetingNoteLabelCommand", () => {
       await flushPromises();
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Label with spaces");
-      expect(Notice).toHaveBeenCalledWith("Label copied to clipboard");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Label copied to clipboard");
     });
 
     it("should skip empty lines after frontmatter to find first content line", async () => {
@@ -138,7 +140,7 @@ describe("CopyFleetingNoteLabelCommand", () => {
       await flushPromises();
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Actual label");
-      expect(Notice).toHaveBeenCalledWith("Label copied to clipboard");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Label copied to clipboard");
     });
 
     it("should show notice when label is empty", async () => {
@@ -151,7 +153,7 @@ describe("CopyFleetingNoteLabelCommand", () => {
       await flushPromises();
 
       expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Label is empty");
+      expect(mockNotifier.warn).toHaveBeenCalledWith("Label is empty");
     });
 
     it("should show notice when file has only whitespace after frontmatter", async () => {
@@ -164,7 +166,7 @@ describe("CopyFleetingNoteLabelCommand", () => {
       await flushPromises();
 
       expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Label is empty");
+      expect(mockNotifier.warn).toHaveBeenCalledWith("Label is empty");
     });
 
     it("should handle errors and show notice", async () => {
@@ -179,7 +181,7 @@ describe("CopyFleetingNoteLabelCommand", () => {
       await flushPromises();
 
       expect(LoggingService.error).toHaveBeenCalledWith("Copy fleeting note label error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to copy label: Failed to read file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to copy label: Failed to read file");
     });
 
     it("should handle clipboard write errors", async () => {
@@ -195,7 +197,7 @@ describe("CopyFleetingNoteLabelCommand", () => {
       await flushPromises();
 
       expect(LoggingService.error).toHaveBeenCalledWith("Copy fleeting note label error", clipboardError);
-      expect(Notice).toHaveBeenCalledWith("Failed to copy label: Clipboard access denied");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to copy label: Clipboard access denied");
     });
 
     it("should handle file without frontmatter", async () => {
@@ -209,7 +211,7 @@ describe("CopyFleetingNoteLabelCommand", () => {
 
       // When no frontmatter, the first line is the label
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Just a plain file");
-      expect(Notice).toHaveBeenCalledWith("Label copied to clipboard");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Label copied to clipboard");
     });
 
     it("should handle file with only frontmatter", async () => {
@@ -222,7 +224,7 @@ describe("CopyFleetingNoteLabelCommand", () => {
       await flushPromises();
 
       expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Label is empty");
+      expect(mockNotifier.warn).toHaveBeenCalledWith("Label is empty");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/CopyLabelToAliasesCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CopyLabelToAliasesCommand.test.ts
@@ -20,6 +20,7 @@ describe("CopyLabelToAliasesCommand", () => {
   let mockLabelToAliasService: jest.Mocked<LabelToAliasService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("CopyLabelToAliasesCommand", () => {
     };
 
     // Create command instance
-    command = new CopyLabelToAliasesCommand(mockLabelToAliasService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new CopyLabelToAliasesCommand(mockLabelToAliasService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("CopyLabelToAliasesCommand", () => {
       await flushPromises();
 
       expect(mockLabelToAliasService.copyLabelToAliases).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Label copied to aliases");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Label copied to aliases");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("CopyLabelToAliasesCommand", () => {
 
       expect(mockLabelToAliasService.copyLabelToAliases).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Copy label to aliases error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to copy label: Failed to copy");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to copy label: Failed to copy");
     });
 
     it("should handle files with special characters", async () => {
@@ -123,7 +125,7 @@ describe("CopyLabelToAliasesCommand", () => {
       await flushPromises();
 
       expect(mockLabelToAliasService.copyLabelToAliases).toHaveBeenCalledWith(specialFile);
-      expect(Notice).toHaveBeenCalledWith("Label copied to aliases");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Label copied to aliases");
     });
 
     it("should handle file system errors", async () => {
@@ -139,7 +141,7 @@ describe("CopyLabelToAliasesCommand", () => {
 
       expect(mockLabelToAliasService.copyLabelToAliases).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Copy label to aliases error", fsError);
-      expect(Notice).toHaveBeenCalledWith("Failed to copy label: File locked");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to copy label: File locked");
     });
 
     it("should handle permission denied error", async () => {
@@ -155,7 +157,7 @@ describe("CopyLabelToAliasesCommand", () => {
 
       expect(mockLabelToAliasService.copyLabelToAliases).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Copy label to aliases error", permError);
-      expect(Notice).toHaveBeenCalledWith("Failed to copy label: Permission denied: cannot write to file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to copy label: Permission denied: cannot write to file");
     });
 
     it("should handle multiple concurrent copy operations", async () => {
@@ -178,8 +180,8 @@ describe("CopyLabelToAliasesCommand", () => {
       files.forEach((file, index) => {
         expect(mockLabelToAliasService.copyLabelToAliases).toHaveBeenNthCalledWith(index + 1, file);
       });
-      expect(Notice).toHaveBeenCalledTimes(3);
-      expect(Notice).toHaveBeenCalledWith("Label copied to aliases");
+      expect(mockNotifier.success).toHaveBeenCalledTimes(3);
+      expect(mockNotifier.success).toHaveBeenCalledWith("Label copied to aliases");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/CreateAreaCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CreateAreaCommand.test.ts
@@ -26,6 +26,7 @@ jest.mock("exocortex", () => ({
 
 describe("CreateAreaCommand", () => {
   let command: CreateAreaCommand;
+  let mockNotifier: any;
   let mockApp: jest.Mocked<App>;
   let mockAreaCreationService: jest.Mocked<AreaCreationService>;
   let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
@@ -86,7 +87,8 @@ describe("CreateAreaCommand", () => {
     };
 
     // Create command instance
-    command = new CreateAreaCommand(mockApp, mockAreaCreationService, mockVaultAdapter);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new CreateAreaCommand(mockApp, mockAreaCreationService, mockVaultAdapter, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -141,7 +143,7 @@ describe("CreateAreaCommand", () => {
       expect(mockVaultAdapter.toTFile).toHaveBeenCalledWith(createdFile);
       expect(mockLeaf.openFile).toHaveBeenCalledWith(mockTFile);
       expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, { focus: true });
-      expect(Notice).toHaveBeenCalledWith("Area created: new-area");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Area created: new-area");
     });
 
     it("should handle modal cancellation", async () => {
@@ -157,7 +159,7 @@ describe("CreateAreaCommand", () => {
 
       expect(mockShowLabelInputModal).toHaveBeenCalled();
       expect(mockAreaCreationService.createChildArea).not.toHaveBeenCalled();
-      expect(Notice).not.toHaveBeenCalled();
+      expect(mockNotifier.success).not.toHaveBeenCalled();
     });
 
     it("should handle service error and show error notice", async () => {
@@ -174,7 +176,7 @@ describe("CreateAreaCommand", () => {
 
       expect(mockAreaCreationService.createChildArea).toHaveBeenCalled();
       expect(LoggingService.error).toHaveBeenCalledWith("Create area error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to create area: Failed to create area");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to create area: Failed to create area");
     });
 
     it("should wait for file to become active", async () => {
@@ -197,7 +199,7 @@ describe("CreateAreaCommand", () => {
       await waitForCondition(() => (mockApp.workspace.getActiveFile as jest.Mock).mock.calls.length >= 3);
 
       expect(mockApp.workspace.getActiveFile).toHaveBeenCalledTimes(3);
-      expect(Notice).toHaveBeenCalledWith("Area created: new-area");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Area created: new-area");
     });
 
     it("should handle missing frontmatter metadata", async () => {
@@ -218,7 +220,7 @@ describe("CreateAreaCommand", () => {
         {}, // Empty metadata
         "Test"
       );
-      expect(Notice).toHaveBeenCalledWith("Area created: new-area");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Area created: new-area");
     });
 
     it("should handle null cache from metadataCache", async () => {
@@ -239,7 +241,7 @@ describe("CreateAreaCommand", () => {
         {}, // Empty metadata
         "Test"
       );
-      expect(Notice).toHaveBeenCalledWith("Area created: new-area");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Area created: new-area");
     });
 
     it("should timeout after max attempts waiting for file", async () => {
@@ -257,13 +259,13 @@ describe("CreateAreaCommand", () => {
 
       // Wait for polling loop to complete (20 attempts × 100ms = 2000ms + buffer)
       await waitForCondition(
-        () => (Notice as jest.Mock).mock.calls.length > 0,
+        () => mockNotifier.success.mock.calls.length > 0,
         { timeout: 5000, interval: 100 }
       );
 
       // Should still complete successfully even if file doesn't become active
       expect(mockApp.workspace.getActiveFile).toHaveBeenCalledTimes(20); // max attempts
-      expect(Notice).toHaveBeenCalledWith("Area created: new-area");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Area created: new-area");
     });
 
     it("should open file in new tab when openInNewTab is true", async () => {
@@ -280,7 +282,7 @@ describe("CreateAreaCommand", () => {
       await flushPromises();
 
       expect(mockApp.workspace.getLeaf).toHaveBeenCalledWith("tab");
-      expect(Notice).toHaveBeenCalledWith("Area created: new-area");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Area created: new-area");
     });
 
     it("should open file in current tab when openInNewTab is false", async () => {
@@ -297,7 +299,7 @@ describe("CreateAreaCommand", () => {
       await flushPromises();
 
       expect(mockApp.workspace.getLeaf).toHaveBeenCalledWith(false);
-      expect(Notice).toHaveBeenCalledWith("Area created: new-area");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Area created: new-area");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/CreateFleetingNoteCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CreateFleetingNoteCommand.test.ts
@@ -26,6 +26,7 @@ const mockShowFleetingNoteModal = showFleetingNoteModal as jest.MockedFunction<t
 
 describe("CreateFleetingNoteCommand", () => {
   let command: CreateFleetingNoteCommand;
+  let mockNotifier: any;
   let mockApp: jest.Mocked<App>;
   let mockFleetingNoteCreationService: jest.Mocked<FleetingNoteCreationService>;
   let mockVaultAdapter: jest.Mocked<ObsidianVaultAdapter>;
@@ -56,10 +57,12 @@ describe("CreateFleetingNoteCommand", () => {
       .spyOn(CommandHelpers, "openFileInNewTab")
       .mockResolvedValue(undefined);
 
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
     command = new CreateFleetingNoteCommand(
       mockApp,
       mockFleetingNoteCreationService,
       mockVaultAdapter,
+      mockNotifier,
     );
   });
 
@@ -89,7 +92,7 @@ describe("CreateFleetingNoteCommand", () => {
     expect(mockFleetingNoteCreationService.createFleetingNote).toHaveBeenCalledWith("Test note");
     expect(mockVaultAdapter.toTFile).toHaveBeenCalledWith(createdFile);
     expect(openFileSpy).toHaveBeenCalledWith(mockApp, mockTFile);
-    expect(Notice).toHaveBeenCalledWith("Fleeting note created: test");
+    expect(mockNotifier.success).toHaveBeenCalledWith("Fleeting note created: test");
   });
 
   it("does nothing when modal is cancelled", async () => {
@@ -99,7 +102,7 @@ describe("CreateFleetingNoteCommand", () => {
 
     expect(mockFleetingNoteCreationService.createFleetingNote).not.toHaveBeenCalled();
     expect(openFileSpy).not.toHaveBeenCalled();
-    expect(Notice).not.toHaveBeenCalled();
+    expect(mockNotifier.success).not.toHaveBeenCalled();
   });
 
   it("handles service errors gracefully", async () => {
@@ -111,6 +114,6 @@ describe("CreateFleetingNoteCommand", () => {
     await command.callback();
 
     expect(LoggingService.error).toHaveBeenCalledWith("Create fleeting note error", error);
-    expect(Notice).toHaveBeenCalledWith("Failed to create fleeting note: Vault failure");
+    expect(mockNotifier.error).toHaveBeenCalledWith("Failed to create fleeting note: Vault failure");
   });
 });

--- a/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/CreateInstanceCommand.test.ts
@@ -40,6 +40,7 @@ describe("CreateInstanceCommand", () => {
   let mockContext: CommandVisibilityContext;
   let mockLeaf: jest.Mocked<WorkspaceLeaf>;
   let mockTFile: jest.Mocked<TFile>;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -98,11 +99,13 @@ describe("CreateInstanceCommand", () => {
       isDraft: false,
     };
 
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
     command = new CreateInstanceCommand(
       mockApp,
       mockRuleResolver,
       mockGenericAssetCreationService,
       mockVaultAdapter,
+      mockNotifier,
     );
   });
 
@@ -147,7 +150,7 @@ describe("CreateInstanceCommand", () => {
 
       expect(mockShowLabelInputModal).toHaveBeenCalled();
       expect(mockGenericAssetCreationService.createAsset).not.toHaveBeenCalled();
-      expect(Notice).not.toHaveBeenCalled();
+      expect(mockNotifier.success).not.toHaveBeenCalled();
     });
   });
 
@@ -184,7 +187,7 @@ describe("CreateInstanceCommand", () => {
           }),
         }),
       );
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Instance created: new-instance");
     });
 
     it("should include taskSize in propertyValues when provided", async () => {
@@ -312,7 +315,7 @@ describe("CreateInstanceCommand", () => {
           }),
         }),
       );
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Instance created: new-instance");
     });
 
     it("should handle fallback with empty label", async () => {
@@ -351,7 +354,7 @@ describe("CreateInstanceCommand", () => {
 
       expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalled();
       expect(LoggingService.error).toHaveBeenCalledWith("Create instance error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to create instance: Failed to create asset");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to create instance: Failed to create asset");
     });
 
     it("should handle ruleResolver error gracefully", async () => {
@@ -363,7 +366,7 @@ describe("CreateInstanceCommand", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to create instance: Triple store unavailable");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to create instance: Triple store unavailable");
     });
   });
 
@@ -389,7 +392,7 @@ describe("CreateInstanceCommand", () => {
       expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalledWith(
         expect.objectContaining({ className: "Task" }),
       );
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Instance created: new-task");
     });
 
     it("should handle empty instanceClass array", async () => {
@@ -477,12 +480,12 @@ describe("CreateInstanceCommand", () => {
       command.checkCallback(false, mockFile, mockContext);
 
       await waitForCondition(
-        () => (Notice as jest.Mock).mock.calls.some(call => call[0] === "Instance created: new-instance"),
+        () => mockNotifier.success.mock.calls.some((call: string[]) => call[0] === "Instance created: new-instance"),
         { timeout: 3000 },
       );
 
       expect((mockApp.workspace.getActiveFile as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(3);
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Instance created: new-instance");
     });
   });
 
@@ -502,7 +505,7 @@ describe("CreateInstanceCommand", () => {
       await flushPromises();
 
       expect(mockGenericAssetCreationService.createAsset).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Instance created: new-instance");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/EditPropertiesCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/EditPropertiesCommand.test.ts
@@ -33,6 +33,7 @@ import type { CommandVisibilityContext } from "exocortex";
 
 describe("EditPropertiesCommand", () => {
   let command: EditPropertiesCommand;
+  let mockNotifier: any;
   let mockApp: App;
   let mockPlugin: ExocortexPluginInterface;
   let mockFile: TFile;
@@ -60,7 +61,8 @@ describe("EditPropertiesCommand", () => {
 
     mockContext = null;
 
-    command = new EditPropertiesCommand(mockApp, mockPlugin);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new EditPropertiesCommand(mockApp, mockPlugin, mockNotifier);
   });
 
   describe("properties", () => {
@@ -137,7 +139,7 @@ describe("EditPropertiesCommand", () => {
 
       command.checkCallback(false, mockFile, mockContext);
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.info).toHaveBeenCalledWith(
         "This file has no frontmatter properties to edit"
       );
       expect(PropertyEditorModal).not.toHaveBeenCalled();
@@ -148,7 +150,7 @@ describe("EditPropertiesCommand", () => {
 
       command.checkCallback(false, mockFile, mockContext);
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.info).toHaveBeenCalledWith(
         "This file has no frontmatter properties to edit"
       );
     });

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -198,7 +198,7 @@ describe("ExocortexPlugin", () => {
       expect(rendererCall[3]).toBe(plugin.vaultAdapter);
       // TaskStatusService is now resolved from DI container, not instantiated directly
       expect(TaskTrackingService).toHaveBeenCalledWith(mockApp, mockVault, mockMetadataCache);
-      expect(SPARQLCodeBlockProcessor).toHaveBeenCalledWith(plugin);
+      expect(SPARQLCodeBlockProcessor).toHaveBeenCalledWith(plugin, expect.any(Object));
       expect(CommandManager).toHaveBeenCalledWith(mockApp);
       expect(mockCommandManager.registerAllCommands).toHaveBeenCalled();
       expect(plugin.addSettingTab).toHaveBeenCalled();

--- a/packages/obsidian-plugin/tests/unit/MarkDoneCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/MarkDoneCommand.test.ts
@@ -20,6 +20,7 @@ describe("MarkDoneCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("MarkDoneCommand", () => {
     };
 
     // Create command instance
-    command = new MarkDoneCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new MarkDoneCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("MarkDoneCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Marked as done: test-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as done: test-task");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("MarkDoneCommand", () => {
 
       expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Mark done error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to mark as done: Failed to mark done");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to mark as done: Failed to mark done");
     });
 
     it("should handle different context statuses", () => {
@@ -143,7 +145,7 @@ describe("MarkDoneCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(specialFile);
-      expect(Notice).toHaveBeenCalledWith("Marked as done: task-with-special-chars!@#$");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as done: task-with-special-chars!@#$");
     });
 
     it("should handle concurrent executions", async () => {
@@ -163,15 +165,15 @@ describe("MarkDoneCommand", () => {
       command.checkCallback(false, file3, mockContext);
 
       // Wait for all async executions
-      await waitForCondition(() => (Notice as jest.Mock).mock.calls.length >= 3);
+      await waitForCondition(() => mockNotifier.success.mock.calls.length >= 3);
 
       expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledTimes(3);
       expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(file1);
       expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(file2);
       expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(file3);
-      expect(Notice).toHaveBeenCalledWith("Marked as done: task1");
-      expect(Notice).toHaveBeenCalledWith("Marked as done: task2");
-      expect(Notice).toHaveBeenCalledWith("Marked as done: task3");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as done: task1");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as done: task2");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as done: task3");
     });
 
     it("should handle service returning undefined", async () => {
@@ -185,7 +187,7 @@ describe("MarkDoneCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.markTaskAsDone).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Marked as done: test-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as done: test-task");
       expect(LoggingService.error).not.toHaveBeenCalled();
     });
 
@@ -204,7 +206,7 @@ describe("MarkDoneCommand", () => {
       // Since error is not an Error instance, undefined is passed to LoggingService.error
       expect(LoggingService.error).toHaveBeenCalledWith("Mark done error", undefined);
       // Since error is not an Error instance, String(error) is used which calls toString()
-      expect(Notice).toHaveBeenCalledWith("Failed to mark as done: Custom error");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to mark as done: Custom error");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/MarkReviewedCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/MarkReviewedCommand.test.ts
@@ -20,6 +20,7 @@ describe("MarkReviewedCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("MarkReviewedCommand", () => {
     };
 
     // Create command instance
-    command = new MarkReviewedCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new MarkReviewedCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("MarkReviewedCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.markAsReviewed).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Marked as reviewed: test-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as reviewed: test-task");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("MarkReviewedCommand", () => {
 
       expect(mockTaskStatusService.markAsReviewed).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Mark reviewed error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to mark as reviewed: Failed to mark reviewed");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to mark as reviewed: Failed to mark reviewed");
     });
 
     it("should work with Project class", () => {
@@ -131,7 +133,7 @@ describe("MarkReviewedCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.markAsReviewed).toHaveBeenCalledWith(specialFile);
-      expect(Notice).toHaveBeenCalledWith("Marked as reviewed: task-with-special-chars!@#$");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as reviewed: task-with-special-chars!@#$");
     });
 
     it("should handle concurrent executions", async () => {
@@ -151,15 +153,15 @@ describe("MarkReviewedCommand", () => {
       command.checkCallback(false, file3, mockContext);
 
       // Wait for all async executions
-      await waitForCondition(() => (Notice as jest.Mock).mock.calls.length >= 3);
+      await waitForCondition(() => mockNotifier.success.mock.calls.length >= 3);
 
       expect(mockTaskStatusService.markAsReviewed).toHaveBeenCalledTimes(3);
       expect(mockTaskStatusService.markAsReviewed).toHaveBeenCalledWith(file1);
       expect(mockTaskStatusService.markAsReviewed).toHaveBeenCalledWith(file2);
       expect(mockTaskStatusService.markAsReviewed).toHaveBeenCalledWith(file3);
-      expect(Notice).toHaveBeenCalledWith("Marked as reviewed: task1");
-      expect(Notice).toHaveBeenCalledWith("Marked as reviewed: task2");
-      expect(Notice).toHaveBeenCalledWith("Marked as reviewed: task3");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as reviewed: task1");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as reviewed: task2");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as reviewed: task3");
     });
 
     it("should handle service returning undefined", async () => {
@@ -173,7 +175,7 @@ describe("MarkReviewedCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.markAsReviewed).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Marked as reviewed: test-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Marked as reviewed: test-task");
       expect(LoggingService.error).not.toHaveBeenCalled();
     });
 
@@ -192,7 +194,7 @@ describe("MarkReviewedCommand", () => {
       // Since error is not an Error instance, undefined is passed to LoggingService.error
       expect(LoggingService.error).toHaveBeenCalledWith("Mark reviewed error", undefined);
       // Since error is not an Error instance, String(error) is used which calls toString()
-      expect(Notice).toHaveBeenCalledWith("Failed to mark as reviewed: Custom error");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to mark as reviewed: Custom error");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/MoveToAnalysisCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/MoveToAnalysisCommand.test.ts
@@ -20,6 +20,7 @@ describe("MoveToAnalysisCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("MoveToAnalysisCommand", () => {
     };
 
     // Create command instance
-    command = new MoveToAnalysisCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new MoveToAnalysisCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("MoveToAnalysisCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.moveToAnalysis).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Moved to Analysis: test-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to Analysis: test-task");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("MoveToAnalysisCommand", () => {
 
       expect(mockTaskStatusService.moveToAnalysis).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Move to analysis error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to move to analysis: Failed to move to analysis");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to move to analysis: Failed to move to analysis");
     });
 
     it("should handle Analysis status context", () => {
@@ -130,7 +132,7 @@ describe("MoveToAnalysisCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.moveToAnalysis).toHaveBeenCalledWith(underscoreFile);
-      expect(Notice).toHaveBeenCalledWith("Moved to Analysis: important_analysis_task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to Analysis: important_analysis_task");
     });
 
     it("should handle database errors", async () => {
@@ -146,7 +148,7 @@ describe("MoveToAnalysisCommand", () => {
 
       expect(mockTaskStatusService.moveToAnalysis).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Move to analysis error", dbError);
-      expect(Notice).toHaveBeenCalledWith("Failed to move to analysis: Database connection failed");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to move to analysis: Database connection failed");
     });
 
     it("should handle archived context", () => {

--- a/packages/obsidian-plugin/tests/unit/MoveToBacklogCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/MoveToBacklogCommand.test.ts
@@ -20,6 +20,7 @@ describe("MoveToBacklogCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("MoveToBacklogCommand", () => {
     };
 
     // Create command instance
-    command = new MoveToBacklogCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new MoveToBacklogCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("MoveToBacklogCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.moveToBacklog).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Moved to Backlog: test-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to Backlog: test-task");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("MoveToBacklogCommand", () => {
 
       expect(mockTaskStatusService.moveToBacklog).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Move to backlog error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to move to backlog: Failed to move");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to move to backlog: Failed to move");
     });
 
     it("should handle Backlog status context", () => {
@@ -130,7 +132,7 @@ describe("MoveToBacklogCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.moveToBacklog).toHaveBeenCalledWith(dashedFile);
-      expect(Notice).toHaveBeenCalledWith("Moved to Backlog: my-important-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to Backlog: my-important-task");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/MoveToToDoCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/MoveToToDoCommand.test.ts
@@ -20,6 +20,7 @@ describe("MoveToToDoCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("MoveToToDoCommand", () => {
     };
 
     // Create command instance
-    command = new MoveToToDoCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new MoveToToDoCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("MoveToToDoCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.moveToToDo).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Moved to ToDo: test-task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to ToDo: test-task");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("MoveToToDoCommand", () => {
 
       expect(mockTaskStatusService.moveToToDo).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Move to todo error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to move to todo: Failed to move to todo");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to move to todo: Failed to move to todo");
     });
 
     it("should handle ToDo status context", () => {
@@ -130,7 +132,7 @@ describe("MoveToToDoCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.moveToToDo).toHaveBeenCalledWith(numberedFile);
-      expect(Notice).toHaveBeenCalledWith("Moved to ToDo: task-123");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to ToDo: task-123");
     });
 
     it("should handle permission errors", async () => {
@@ -146,7 +148,7 @@ describe("MoveToToDoCommand", () => {
 
       expect(mockTaskStatusService.moveToToDo).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Move to todo error", permissionError);
-      expect(Notice).toHaveBeenCalledWith("Failed to move to todo: Permission denied");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to move to todo: Permission denied");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/PlanForEveningCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PlanForEveningCommand.test.ts
@@ -20,6 +20,7 @@ describe("PlanForEveningCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("PlanForEveningCommand", () => {
     };
 
     // Create command instance
-    command = new PlanForEveningCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new PlanForEveningCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("PlanForEveningCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.planForEvening).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Planned for evening (19:00): test-file");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Planned for evening (19:00): test-file");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("PlanForEveningCommand", () => {
 
       expect(mockTaskStatusService.planForEvening).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Plan for evening error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to plan for evening: Failed to plan");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to plan for evening: Failed to plan");
     });
 
     it("should handle files with special characters", async () => {
@@ -123,7 +125,7 @@ describe("PlanForEveningCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.planForEvening).toHaveBeenCalledWith(specialFile);
-      expect(Notice).toHaveBeenCalledWith("Planned for evening (19:00): [EVENING] Task (2024)");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Planned for evening (19:00): [EVENING] Task (2024)");
     });
 
     it("should handle file system errors", async () => {
@@ -139,7 +141,7 @@ describe("PlanForEveningCommand", () => {
 
       expect(mockTaskStatusService.planForEvening).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Plan for evening error", fsError);
-      expect(Notice).toHaveBeenCalledWith("Failed to plan for evening: File locked");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to plan for evening: File locked");
     });
 
     it("should handle permission denied error", async () => {
@@ -155,7 +157,7 @@ describe("PlanForEveningCommand", () => {
 
       expect(mockTaskStatusService.planForEvening).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Plan for evening error", permError);
-      expect(Notice).toHaveBeenCalledWith("Failed to plan for evening: Permission denied: cannot write to file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to plan for evening: Permission denied: cannot write to file");
     });
 
     it("should handle multiple concurrent planning operations", async () => {
@@ -177,7 +179,7 @@ describe("PlanForEveningCommand", () => {
       expect(mockTaskStatusService.planForEvening).toHaveBeenCalledTimes(3);
       files.forEach((file, index) => {
         expect(mockTaskStatusService.planForEvening).toHaveBeenNthCalledWith(index + 1, file);
-        expect(Notice).toHaveBeenCalledWith(`Planned for evening (19:00): ${file.basename}`);
+        expect(mockNotifier.success).toHaveBeenCalledWith(`Planned for evening (19:00): ${file.basename}`);
       });
     });
   });

--- a/packages/obsidian-plugin/tests/unit/PlanOnTodayCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PlanOnTodayCommand.test.ts
@@ -20,6 +20,7 @@ describe("PlanOnTodayCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("PlanOnTodayCommand", () => {
     };
 
     // Create command instance
-    command = new PlanOnTodayCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new PlanOnTodayCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("PlanOnTodayCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.planOnToday).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Planned on today: test-file");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Planned on today: test-file");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("PlanOnTodayCommand", () => {
 
       expect(mockTaskStatusService.planOnToday).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Plan on today error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to plan on today: Failed to plan");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to plan on today: Failed to plan");
     });
 
     it("should handle files with special characters", async () => {
@@ -123,7 +125,7 @@ describe("PlanOnTodayCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.planOnToday).toHaveBeenCalledWith(specialFile);
-      expect(Notice).toHaveBeenCalledWith("Planned on today: [TODAY] Task (2024)");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Planned on today: [TODAY] Task (2024)");
     });
 
     it("should handle file system errors", async () => {
@@ -139,7 +141,7 @@ describe("PlanOnTodayCommand", () => {
 
       expect(mockTaskStatusService.planOnToday).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Plan on today error", fsError);
-      expect(Notice).toHaveBeenCalledWith("Failed to plan on today: File locked");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to plan on today: File locked");
     });
 
     it("should handle permission denied error", async () => {
@@ -155,7 +157,7 @@ describe("PlanOnTodayCommand", () => {
 
       expect(mockTaskStatusService.planOnToday).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Plan on today error", permError);
-      expect(Notice).toHaveBeenCalledWith("Failed to plan on today: Permission denied: cannot write to file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to plan on today: Permission denied: cannot write to file");
     });
 
     it("should handle multiple concurrent planning operations", async () => {
@@ -177,7 +179,7 @@ describe("PlanOnTodayCommand", () => {
       expect(mockTaskStatusService.planOnToday).toHaveBeenCalledTimes(3);
       files.forEach((file, index) => {
         expect(mockTaskStatusService.planOnToday).toHaveBeenNthCalledWith(index + 1, file);
-        expect(Notice).toHaveBeenCalledWith(`Planned on today: ${file.basename}`);
+        expect(mockNotifier.success).toHaveBeenCalledWith(`Planned on today: ${file.basename}`);
       });
     });
 
@@ -194,7 +196,7 @@ describe("PlanOnTodayCommand", () => {
 
       expect(mockTaskStatusService.planOnToday).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Plan on today error", alreadyPlannedError);
-      expect(Notice).toHaveBeenCalledWith("Failed to plan on today: Task already planned for today");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to plan on today: Task already planned for today");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ReloadLayoutCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ReloadLayoutCommand.test.ts
@@ -1,24 +1,20 @@
 import { flushPromises } from "./helpers/testHelpers";
 import { ReloadLayoutCommand } from "../../src/application/commands/ReloadLayoutCommand";
-import { Notice } from "obsidian";
-
-jest.mock("obsidian", () => ({
-  ...jest.requireActual("obsidian"),
-  Notice: jest.fn(),
-}));
 
 describe("ReloadLayoutCommand", () => {
   let command: ReloadLayoutCommand;
   let mockReloadLayoutCallback: jest.Mock;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockReloadLayoutCallback = jest.fn();
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
   });
 
   describe("id and name", () => {
     it("should have correct id and name", () => {
-      command = new ReloadLayoutCommand(mockReloadLayoutCallback);
+      command = new ReloadLayoutCommand(mockReloadLayoutCallback, mockNotifier);
       expect(command.id).toBe("reload-layout");
       expect(command.name).toBe("Reload layout");
     });
@@ -26,79 +22,79 @@ describe("ReloadLayoutCommand", () => {
 
   describe("callback", () => {
     it("should call reloadLayoutCallback and show success notice", () => {
-      command = new ReloadLayoutCommand(mockReloadLayoutCallback);
+      command = new ReloadLayoutCommand(mockReloadLayoutCallback, mockNotifier);
 
       command.callback();
 
       expect(mockReloadLayoutCallback).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Layout reloaded");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Layout reloaded");
     });
 
     it("should show failure notice when reloadLayoutCallback is undefined", () => {
-      command = new ReloadLayoutCommand(undefined);
+      command = new ReloadLayoutCommand(undefined, mockNotifier);
 
       command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to reload layout");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to reload layout");
     });
 
     it("should show failure notice when reloadLayoutCallback is null", () => {
-      command = new ReloadLayoutCommand(null as any);
+      command = new ReloadLayoutCommand(null as any, mockNotifier);
 
       command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to reload layout");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to reload layout");
     });
 
     it("should handle multiple calls correctly", () => {
-      command = new ReloadLayoutCommand(mockReloadLayoutCallback);
+      command = new ReloadLayoutCommand(mockReloadLayoutCallback, mockNotifier);
 
       command.callback();
       command.callback();
       command.callback();
 
       expect(mockReloadLayoutCallback).toHaveBeenCalledTimes(3);
-      expect(Notice).toHaveBeenCalledTimes(3);
-      expect(Notice).toHaveBeenCalledWith("Layout reloaded");
+      expect(mockNotifier.success).toHaveBeenCalledTimes(3);
+      expect(mockNotifier.success).toHaveBeenCalledWith("Layout reloaded");
     });
 
     it("should handle callback that throws error", () => {
       const errorCallback = jest.fn(() => {
         throw new Error("Reload failed");
       });
-      command = new ReloadLayoutCommand(errorCallback);
+      command = new ReloadLayoutCommand(errorCallback, mockNotifier);
 
       expect(() => command.callback()).toThrow("Reload failed");
       expect(errorCallback).toHaveBeenCalled();
-      expect(Notice).not.toHaveBeenCalled();
+      expect(mockNotifier.success).not.toHaveBeenCalled();
     });
 
     it("should work with async callback", () => {
       const asyncCallback = jest.fn(async () => {
         await flushPromises();
       });
-      command = new ReloadLayoutCommand(asyncCallback);
+      command = new ReloadLayoutCommand(asyncCallback, mockNotifier);
 
       command.callback();
 
       expect(asyncCallback).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Layout reloaded");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Layout reloaded");
     });
 
     it("should show failure notice when callback is empty string", () => {
-      command = new ReloadLayoutCommand("" as any);
+      command = new ReloadLayoutCommand("" as any, mockNotifier);
 
       command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to reload layout");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to reload layout");
     });
 
     it("should show failure notice when callback is false", () => {
-      command = new ReloadLayoutCommand(false as any);
+      command = new ReloadLayoutCommand(false as any, mockNotifier);
 
       command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to reload layout");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to reload layout");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/RenameToUidCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RenameToUidCommand.test.ts
@@ -20,6 +20,7 @@ describe("RenameToUidCommand", () => {
   let mockRenameToUidService: jest.Mocked<RenameToUidService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -47,7 +48,8 @@ describe("RenameToUidCommand", () => {
     };
 
     // Create command instance
-    command = new RenameToUidCommand(mockRenameToUidService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new RenameToUidCommand(mockRenameToUidService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -97,7 +99,7 @@ describe("RenameToUidCommand", () => {
       await flushPromises();
 
       expect(mockRenameToUidService.renameToUid).toHaveBeenCalledWith(mockFile, mockContext.metadata);
-      expect(Notice).toHaveBeenCalledWith('Renamed "test-file" to "asset-12345"');
+      expect(mockNotifier.success).toHaveBeenCalledWith('Renamed "test-file" to "asset-12345"');
     });
 
     it("should handle errors and show notice", async () => {
@@ -113,7 +115,7 @@ describe("RenameToUidCommand", () => {
 
       expect(mockRenameToUidService.renameToUid).toHaveBeenCalledWith(mockFile, mockContext.metadata);
       expect(LoggingService.error).toHaveBeenCalledWith("Rename to UID error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to rename: Rename failed");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to rename: Rename failed");
     });
 
     it("should handle missing UID in metadata", async () => {
@@ -132,7 +134,7 @@ describe("RenameToUidCommand", () => {
       await flushPromises();
 
       expect(mockRenameToUidService.renameToUid).toHaveBeenCalledWith(mockFile, contextWithoutUid.metadata);
-      expect(Notice).toHaveBeenCalledWith('Renamed "test-file" to "undefined"');
+      expect(mockNotifier.success).toHaveBeenCalledWith('Renamed "test-file" to "undefined"');
     });
 
     it("should handle files with special characters in name", async () => {
@@ -151,7 +153,7 @@ describe("RenameToUidCommand", () => {
       await flushPromises();
 
       expect(mockRenameToUidService.renameToUid).toHaveBeenCalledWith(specialFile, mockContext.metadata);
-      expect(Notice).toHaveBeenCalledWith('Renamed "[IMPORTANT] File (2024)" to "asset-12345"');
+      expect(mockNotifier.success).toHaveBeenCalledWith('Renamed "[IMPORTANT] File (2024)" to "asset-12345"');
     });
 
     it("should handle file already named as UID", async () => {
@@ -170,7 +172,7 @@ describe("RenameToUidCommand", () => {
       await flushPromises();
 
       expect(mockRenameToUidService.renameToUid).toHaveBeenCalledWith(uidFile, mockContext.metadata);
-      expect(Notice).toHaveBeenCalledWith('Renamed "asset-12345" to "asset-12345"');
+      expect(mockNotifier.success).toHaveBeenCalledWith('Renamed "asset-12345" to "asset-12345"');
     });
 
     it("should handle permission denied error", async () => {
@@ -186,7 +188,7 @@ describe("RenameToUidCommand", () => {
 
       expect(mockRenameToUidService.renameToUid).toHaveBeenCalledWith(mockFile, mockContext.metadata);
       expect(LoggingService.error).toHaveBeenCalledWith("Rename to UID error", permError);
-      expect(Notice).toHaveBeenCalledWith("Failed to rename: Permission denied: cannot rename file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to rename: Permission denied: cannot rename file");
     });
 
     it("should handle context with complex metadata", async () => {
@@ -210,7 +212,7 @@ describe("RenameToUidCommand", () => {
       await flushPromises();
 
       expect(mockRenameToUidService.renameToUid).toHaveBeenCalledWith(mockFile, complexContext.metadata);
-      expect(Notice).toHaveBeenCalledWith('Renamed "test-file" to "complex-uid-98765"');
+      expect(mockNotifier.success).toHaveBeenCalledWith('Renamed "test-file" to "complex-uid-98765"');
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/RepairFolderCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RepairFolderCommand.test.ts
@@ -16,6 +16,7 @@ jest.mock("exocortex", () => ({
 
 describe("RepairFolderCommand", () => {
   let command: RepairFolderCommand;
+  let mockNotifier: any;
   let mockApp: jest.Mocked<App>;
   let mockFolderRepairService: jest.Mocked<FolderRepairService>;
   let mockFile: jest.Mocked<TFile>;
@@ -46,7 +47,8 @@ describe("RepairFolderCommand", () => {
     } as jest.Mocked<TFile>;
 
     // Create command instance
-    command = new RepairFolderCommand(mockApp, mockFolderRepairService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new RepairFolderCommand(mockApp, mockFolderRepairService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -111,7 +113,7 @@ describe("RepairFolderCommand", () => {
         { exo__Asset_isDefinedBy: "Asset" }
       );
       expect(mockFolderRepairService.repairFolder).toHaveBeenCalledWith(mockFile, "expected/folder");
-      expect(Notice).toHaveBeenCalledWith("Moved to expected/folder");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to expected/folder");
     });
 
     it("should show notice when no expected folder found", async () => {
@@ -128,7 +130,7 @@ describe("RepairFolderCommand", () => {
 
       expect(mockFolderRepairService.getExpectedFolder).toHaveBeenCalled();
       expect(mockFolderRepairService.repairFolder).not.toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("No expected folder found");
+      expect(mockNotifier.warn).toHaveBeenCalledWith("No expected folder found");
     });
 
     it("should show notice when asset is already in correct folder", async () => {
@@ -145,7 +147,7 @@ describe("RepairFolderCommand", () => {
 
       expect(mockFolderRepairService.getExpectedFolder).toHaveBeenCalled();
       expect(mockFolderRepairService.repairFolder).not.toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Asset is already in correct folder");
+      expect(mockNotifier.info).toHaveBeenCalledWith("Asset is already in correct folder");
     });
 
     it("should handle file with no parent folder", async () => {
@@ -168,7 +170,7 @@ describe("RepairFolderCommand", () => {
       await flushPromises();
 
       expect(mockFolderRepairService.repairFolder).toHaveBeenCalledWith(rootFile, "expected/folder");
-      expect(Notice).toHaveBeenCalledWith("Moved to expected/folder");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to expected/folder");
     });
 
     it("should handle errors and show error notice", async () => {
@@ -185,7 +187,7 @@ describe("RepairFolderCommand", () => {
       await flushPromises();
 
       expect(LoggingService.error).toHaveBeenCalledWith("Repair folder error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to repair folder: Failed to repair");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to repair folder: Failed to repair");
     });
 
     it("should handle repair folder service errors", async () => {
@@ -203,7 +205,7 @@ describe("RepairFolderCommand", () => {
       await flushPromises();
 
       expect(LoggingService.error).toHaveBeenCalledWith("Repair folder error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to repair folder: Move failed");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to repair folder: Move failed");
     });
 
     it("should handle empty expected folder path", async () => {
@@ -220,7 +222,7 @@ describe("RepairFolderCommand", () => {
 
       expect(mockFolderRepairService.getExpectedFolder).toHaveBeenCalled();
       expect(mockFolderRepairService.repairFolder).not.toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("No expected folder found");
+      expect(mockNotifier.warn).toHaveBeenCalledWith("No expected folder found");
     });
 
     it("should handle complex metadata", async () => {
@@ -248,7 +250,7 @@ describe("RepairFolderCommand", () => {
         complexMetadata
       );
       expect(mockFolderRepairService.repairFolder).toHaveBeenCalledWith(mockFile, "complex/expected/folder");
-      expect(Notice).toHaveBeenCalledWith("Moved to complex/expected/folder");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to complex/expected/folder");
     });
 
     it("should handle permission denied error", async () => {
@@ -266,7 +268,7 @@ describe("RepairFolderCommand", () => {
       await flushPromises();
 
       expect(LoggingService.error).toHaveBeenCalledWith("Repair folder error", permError);
-      expect(Notice).toHaveBeenCalledWith("Failed to repair folder: Permission denied: cannot move file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to repair folder: Permission denied: cannot move file");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/SetDraftStatusCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SetDraftStatusCommand.test.ts
@@ -20,6 +20,7 @@ describe("SetDraftStatusCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("SetDraftStatusCommand", () => {
     };
 
     // Create command instance
-    command = new SetDraftStatusCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new SetDraftStatusCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -87,7 +89,7 @@ describe("SetDraftStatusCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.setDraftStatus).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Set Draft status: test-draft");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Set Draft status: test-draft");
     });
 
     it("should handle errors and show notice", async () => {
@@ -102,7 +104,7 @@ describe("SetDraftStatusCommand", () => {
 
       expect(mockTaskStatusService.setDraftStatus).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Set draft status error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to set draft status: Failed to set draft");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to set draft status: Failed to set draft");
     });
 
     it("should handle already draft context", () => {
@@ -127,7 +129,7 @@ describe("SetDraftStatusCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.setDraftStatus).toHaveBeenCalledWith(spaceFile);
-      expect(Notice).toHaveBeenCalledWith("Set Draft status: my draft task");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Set Draft status: my draft task");
     });
 
     it("should handle network errors", async () => {
@@ -143,7 +145,7 @@ describe("SetDraftStatusCommand", () => {
 
       expect(mockTaskStatusService.setDraftStatus).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Set draft status error", networkError);
-      expect(Notice).toHaveBeenCalledWith("Failed to set draft status: Network timeout");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to set draft status: Network timeout");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ShiftDayBackwardCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ShiftDayBackwardCommand.test.ts
@@ -20,6 +20,7 @@ describe("ShiftDayBackwardCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("ShiftDayBackwardCommand", () => {
     };
 
     // Create command instance
-    command = new ShiftDayBackwardCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new ShiftDayBackwardCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("ShiftDayBackwardCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.shiftDayBackward).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Day shifted backward: test-file");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Day shifted backward: test-file");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("ShiftDayBackwardCommand", () => {
 
       expect(mockTaskStatusService.shiftDayBackward).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Shift day backward error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to shift day backward: Failed to shift");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to shift day backward: Failed to shift");
     });
 
     it("should handle files with special characters", async () => {
@@ -123,7 +125,7 @@ describe("ShiftDayBackwardCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.shiftDayBackward).toHaveBeenCalledWith(specialFile);
-      expect(Notice).toHaveBeenCalledWith("Day shifted backward: [DATE] Task (2024-01-01)");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Day shifted backward: [DATE] Task (2024-01-01)");
     });
 
     it("should handle date boundary errors", async () => {
@@ -139,7 +141,7 @@ describe("ShiftDayBackwardCommand", () => {
 
       expect(mockTaskStatusService.shiftDayBackward).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Shift day backward error", boundaryError);
-      expect(Notice).toHaveBeenCalledWith("Failed to shift day backward: Cannot shift before minimum date");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to shift day backward: Cannot shift before minimum date");
     });
 
     it("should handle invalid date format errors", async () => {
@@ -155,7 +157,7 @@ describe("ShiftDayBackwardCommand", () => {
 
       expect(mockTaskStatusService.shiftDayBackward).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Shift day backward error", formatError);
-      expect(Notice).toHaveBeenCalledWith("Failed to shift day backward: Invalid date format in file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to shift day backward: Invalid date format in file");
     });
 
     it("should handle multiple concurrent shift operations", async () => {
@@ -177,7 +179,7 @@ describe("ShiftDayBackwardCommand", () => {
       expect(mockTaskStatusService.shiftDayBackward).toHaveBeenCalledTimes(3);
       files.forEach((file, index) => {
         expect(mockTaskStatusService.shiftDayBackward).toHaveBeenNthCalledWith(index + 1, file);
-        expect(Notice).toHaveBeenCalledWith(`Day shifted backward: ${file.basename}`);
+        expect(mockNotifier.success).toHaveBeenCalledWith(`Day shifted backward: ${file.basename}`);
       });
     });
 
@@ -194,7 +196,7 @@ describe("ShiftDayBackwardCommand", () => {
 
       expect(mockTaskStatusService.shiftDayBackward).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Shift day backward error", fsError);
-      expect(Notice).toHaveBeenCalledWith("Failed to shift day backward: File locked");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to shift day backward: File locked");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ShiftDayForwardCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ShiftDayForwardCommand.test.ts
@@ -20,6 +20,7 @@ describe("ShiftDayForwardCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("ShiftDayForwardCommand", () => {
     };
 
     // Create command instance
-    command = new ShiftDayForwardCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new ShiftDayForwardCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("ShiftDayForwardCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.shiftDayForward).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Day shifted forward: test-file");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Day shifted forward: test-file");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("ShiftDayForwardCommand", () => {
 
       expect(mockTaskStatusService.shiftDayForward).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Shift day forward error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to shift day forward: Failed to shift");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to shift day forward: Failed to shift");
     });
 
     it("should handle files with special characters", async () => {
@@ -123,7 +125,7 @@ describe("ShiftDayForwardCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.shiftDayForward).toHaveBeenCalledWith(specialFile);
-      expect(Notice).toHaveBeenCalledWith("Day shifted forward: [DATE] Task (2024-12-31)");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Day shifted forward: [DATE] Task (2024-12-31)");
     });
 
     it("should handle date boundary errors", async () => {
@@ -139,7 +141,7 @@ describe("ShiftDayForwardCommand", () => {
 
       expect(mockTaskStatusService.shiftDayForward).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Shift day forward error", boundaryError);
-      expect(Notice).toHaveBeenCalledWith("Failed to shift day forward: Cannot shift beyond maximum date");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to shift day forward: Cannot shift beyond maximum date");
     });
 
     it("should handle invalid date format errors", async () => {
@@ -155,7 +157,7 @@ describe("ShiftDayForwardCommand", () => {
 
       expect(mockTaskStatusService.shiftDayForward).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Shift day forward error", formatError);
-      expect(Notice).toHaveBeenCalledWith("Failed to shift day forward: Invalid date format in file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to shift day forward: Invalid date format in file");
     });
 
     it("should handle multiple concurrent shift operations", async () => {
@@ -177,7 +179,7 @@ describe("ShiftDayForwardCommand", () => {
       expect(mockTaskStatusService.shiftDayForward).toHaveBeenCalledTimes(3);
       files.forEach((file, index) => {
         expect(mockTaskStatusService.shiftDayForward).toHaveBeenNthCalledWith(index + 1, file);
-        expect(Notice).toHaveBeenCalledWith(`Day shifted forward: ${file.basename}`);
+        expect(mockNotifier.success).toHaveBeenCalledWith(`Day shifted forward: ${file.basename}`);
       });
     });
 
@@ -194,7 +196,7 @@ describe("ShiftDayForwardCommand", () => {
 
       expect(mockTaskStatusService.shiftDayForward).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Shift day forward error", fsError);
-      expect(Notice).toHaveBeenCalledWith("Failed to shift day forward: File locked");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to shift day forward: File locked");
     });
 
     it("should handle leap year boundary", async () => {
@@ -213,7 +215,7 @@ describe("ShiftDayForwardCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.shiftDayForward).toHaveBeenCalledWith(leapYearFile);
-      expect(Notice).toHaveBeenCalledWith("Day shifted forward: leap-year-task-2024-02-29");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Day shifted forward: leap-year-task-2024-02-29");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/StartEffortCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/StartEffortCommand.test.ts
@@ -20,6 +20,7 @@ describe("StartEffortCommand", () => {
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("StartEffortCommand", () => {
     };
 
     // Create command instance
-    command = new StartEffortCommand(mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new StartEffortCommand(mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -88,7 +90,7 @@ describe("StartEffortCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.startEffort).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Started effort: test-effort");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Started effort: test-effort");
     });
 
     it("should handle errors and show notice", async () => {
@@ -104,7 +106,7 @@ describe("StartEffortCommand", () => {
 
       expect(mockTaskStatusService.startEffort).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Start effort error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to start effort: Failed to start");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to start effort: Failed to start");
     });
 
     it("should handle already started effort", () => {
@@ -130,7 +132,7 @@ describe("StartEffortCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.startEffort).toHaveBeenCalledWith(unicodeFile);
-      expect(Notice).toHaveBeenCalledWith("Started effort: 努力-测试");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Started effort: 努力-测试");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ToggleArchivedAssetsCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ToggleArchivedAssetsCommand.test.ts
@@ -9,6 +9,7 @@ jest.mock("obsidian", () => ({
 
 describe("ToggleArchivedAssetsCommand", () => {
   let command: ToggleArchivedAssetsCommand;
+  let mockNotifier: any;
   let mockPlugin: jest.Mocked<ExocortexPluginInterface>;
 
   beforeEach(() => {
@@ -24,7 +25,8 @@ describe("ToggleArchivedAssetsCommand", () => {
     } as unknown as jest.Mocked<ExocortexPluginInterface>;
 
     // Create command instance
-    command = new ToggleArchivedAssetsCommand(mockPlugin);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new ToggleArchivedAssetsCommand(mockPlugin, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -44,7 +46,7 @@ describe("ToggleArchivedAssetsCommand", () => {
       expect(mockPlugin.settings.showArchivedAssets).toBe(true);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
       expect(mockPlugin.refreshLayout).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Archived assets shown");
+      expect(mockNotifier.info).toHaveBeenCalledWith("Archived assets shown");
     });
 
     it("should toggle showArchivedAssets from true to false", async () => {
@@ -56,7 +58,7 @@ describe("ToggleArchivedAssetsCommand", () => {
       expect(mockPlugin.settings.showArchivedAssets).toBe(false);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
       expect(mockPlugin.refreshLayout).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Archived assets hidden");
+      expect(mockNotifier.info).toHaveBeenCalledWith("Archived assets hidden");
     });
 
     it("should handle multiple toggles correctly", async () => {
@@ -66,17 +68,17 @@ describe("ToggleArchivedAssetsCommand", () => {
       // First toggle (false -> true)
       await command.callback();
       expect(mockPlugin.settings.showArchivedAssets).toBe(true);
-      expect(Notice).toHaveBeenNthCalledWith(1, "Archived assets shown");
+      expect(mockNotifier.info).toHaveBeenNthCalledWith(1, "Archived assets shown");
 
       // Second toggle (true -> false)
       await command.callback();
       expect(mockPlugin.settings.showArchivedAssets).toBe(false);
-      expect(Notice).toHaveBeenNthCalledWith(2, "Archived assets hidden");
+      expect(mockNotifier.info).toHaveBeenNthCalledWith(2, "Archived assets hidden");
 
       // Third toggle (false -> true)
       await command.callback();
       expect(mockPlugin.settings.showArchivedAssets).toBe(true);
-      expect(Notice).toHaveBeenNthCalledWith(3, "Archived assets shown");
+      expect(mockNotifier.info).toHaveBeenNthCalledWith(3, "Archived assets shown");
 
       expect(mockPlugin.saveSettings).toHaveBeenCalledTimes(3);
       expect(mockPlugin.refreshLayout).toHaveBeenCalledTimes(3);
@@ -105,7 +107,7 @@ describe("ToggleArchivedAssetsCommand", () => {
 
       expect(mockPlugin.settings.showArchivedAssets).toBe(true);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Archived assets shown");
+      expect(mockNotifier.info).toHaveBeenCalledWith("Archived assets shown");
       // Should not throw even if refreshLayout is undefined
     });
 
@@ -114,12 +116,12 @@ describe("ToggleArchivedAssetsCommand", () => {
       mockPlugin.saveSettings.mockResolvedValue();
 
       // First command instance
-      const command1 = new ToggleArchivedAssetsCommand(mockPlugin);
+      const command1 = new ToggleArchivedAssetsCommand(mockPlugin, mockNotifier);
       await command1.callback();
       expect(mockPlugin.settings.showArchivedAssets).toBe(true);
 
       // Second command instance should see the updated state
-      const command2 = new ToggleArchivedAssetsCommand(mockPlugin);
+      const command2 = new ToggleArchivedAssetsCommand(mockPlugin, mockNotifier);
       await command2.callback();
       expect(mockPlugin.settings.showArchivedAssets).toBe(false);
     });
@@ -144,7 +146,7 @@ describe("ToggleArchivedAssetsCommand", () => {
 
       expect(mockPlugin.settings.showArchivedAssets).toBe(true);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Archived assets shown");
+      expect(mockNotifier.info).toHaveBeenCalledWith("Archived assets shown");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ToggleLayoutVisibilityCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ToggleLayoutVisibilityCommand.test.ts
@@ -9,6 +9,7 @@ jest.mock("obsidian", () => ({
 
 describe("ToggleLayoutVisibilityCommand", () => {
   let command: ToggleLayoutVisibilityCommand;
+  let mockNotifier: any;
   let mockPlugin: jest.Mocked<ExocortexPluginInterface>;
 
   beforeEach(() => {
@@ -24,7 +25,8 @@ describe("ToggleLayoutVisibilityCommand", () => {
     } as unknown as jest.Mocked<ExocortexPluginInterface>;
 
     // Create command instance
-    command = new ToggleLayoutVisibilityCommand(mockPlugin);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new ToggleLayoutVisibilityCommand(mockPlugin, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -44,7 +46,7 @@ describe("ToggleLayoutVisibilityCommand", () => {
       expect(mockPlugin.settings.layoutVisible).toBe(true);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
       expect(mockPlugin.refreshLayout).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Layout shown");
+      expect(mockNotifier.info).toHaveBeenCalledWith("Layout shown");
     });
 
     it("should toggle layoutVisible from true to false", async () => {
@@ -56,7 +58,7 @@ describe("ToggleLayoutVisibilityCommand", () => {
       expect(mockPlugin.settings.layoutVisible).toBe(false);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
       expect(mockPlugin.refreshLayout).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Layout hidden");
+      expect(mockNotifier.info).toHaveBeenCalledWith("Layout hidden");
     });
 
     it("should handle multiple toggles correctly", async () => {
@@ -66,17 +68,17 @@ describe("ToggleLayoutVisibilityCommand", () => {
       // First toggle (false -> true)
       await command.callback();
       expect(mockPlugin.settings.layoutVisible).toBe(true);
-      expect(Notice).toHaveBeenNthCalledWith(1, "Layout shown");
+      expect(mockNotifier.info).toHaveBeenNthCalledWith(1, "Layout shown");
 
       // Second toggle (true -> false)
       await command.callback();
       expect(mockPlugin.settings.layoutVisible).toBe(false);
-      expect(Notice).toHaveBeenNthCalledWith(2, "Layout hidden");
+      expect(mockNotifier.info).toHaveBeenNthCalledWith(2, "Layout hidden");
 
       // Third toggle (false -> true)
       await command.callback();
       expect(mockPlugin.settings.layoutVisible).toBe(true);
-      expect(Notice).toHaveBeenNthCalledWith(3, "Layout shown");
+      expect(mockNotifier.info).toHaveBeenNthCalledWith(3, "Layout shown");
 
       expect(mockPlugin.saveSettings).toHaveBeenCalledTimes(3);
       expect(mockPlugin.refreshLayout).toHaveBeenCalledTimes(3);
@@ -105,7 +107,7 @@ describe("ToggleLayoutVisibilityCommand", () => {
 
       expect(mockPlugin.settings.layoutVisible).toBe(false);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Layout hidden");
+      expect(mockNotifier.info).toHaveBeenCalledWith("Layout hidden");
       // Should not throw even if refreshLayout is undefined
     });
 
@@ -125,12 +127,12 @@ describe("ToggleLayoutVisibilityCommand", () => {
       mockPlugin.saveSettings.mockResolvedValue();
 
       // First command instance
-      const command1 = new ToggleLayoutVisibilityCommand(mockPlugin);
+      const command1 = new ToggleLayoutVisibilityCommand(mockPlugin, mockNotifier);
       await command1.callback();
       expect(mockPlugin.settings.layoutVisible).toBe(false);
 
       // Second command instance should see the updated state
-      const command2 = new ToggleLayoutVisibilityCommand(mockPlugin);
+      const command2 = new ToggleLayoutVisibilityCommand(mockPlugin, mockNotifier);
       await command2.callback();
       expect(mockPlugin.settings.layoutVisible).toBe(true);
     });

--- a/packages/obsidian-plugin/tests/unit/TrashEffortCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/TrashEffortCommand.test.ts
@@ -22,6 +22,7 @@ const mockShowTrashReasonModal = showTrashReasonModal as jest.MockedFunction<typ
 
 describe("TrashEffortCommand", () => {
   let command: TrashEffortCommand;
+  let mockNotifier: any;
   let mockApp: jest.Mocked<App>;
   let mockTaskStatusService: jest.Mocked<TaskStatusService>;
   let mockFile: jest.Mocked<TFile>;
@@ -50,7 +51,8 @@ describe("TrashEffortCommand", () => {
       isDraft: false,
     };
 
-    command = new TrashEffortCommand(mockApp, mockTaskStatusService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new TrashEffortCommand(mockApp, mockTaskStatusService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -94,7 +96,7 @@ describe("TrashEffortCommand", () => {
 
       expect(mockShowTrashReasonModal).toHaveBeenCalledWith(mockApp);
       expect(mockTaskStatusService.trashEffort).toHaveBeenCalledWith(mockFile, null);
-      expect(Notice).toHaveBeenCalledWith("Trashed: test-effort");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Trashed: test-effort");
     });
 
     it("should pass reason to trashEffort when user provides reason", async () => {
@@ -108,7 +110,7 @@ describe("TrashEffortCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.trashEffort).toHaveBeenCalledWith(mockFile, "No longer needed");
-      expect(Notice).toHaveBeenCalledWith("Trashed: test-effort");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Trashed: test-effort");
     });
 
     it("should not execute when user cancels modal", async () => {
@@ -123,7 +125,7 @@ describe("TrashEffortCommand", () => {
 
       expect(mockShowTrashReasonModal).toHaveBeenCalledWith(mockApp);
       expect(mockTaskStatusService.trashEffort).not.toHaveBeenCalled();
-      expect(Notice).not.toHaveBeenCalled();
+      expect(mockNotifier.success).not.toHaveBeenCalled();
     });
 
     it("should handle errors and show notice", async () => {
@@ -138,7 +140,7 @@ describe("TrashEffortCommand", () => {
 
       expect(mockTaskStatusService.trashEffort).toHaveBeenCalledWith(mockFile, null);
       expect(LoggingService.error).toHaveBeenCalledWith("Trash effort error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to trash effort: Failed to move to trash");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to trash effort: Failed to move to trash");
     });
 
     it("should handle already trashed effort", () => {
@@ -163,7 +165,7 @@ describe("TrashEffortCommand", () => {
       await flushPromises();
 
       expect(mockTaskStatusService.trashEffort).toHaveBeenCalledWith(specialFile, null);
-      expect(Notice).toHaveBeenCalledWith("Trashed: [URGENT] Important Effort");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Trashed: [URGENT] Important Effort");
     });
 
     it("should handle permission denied errors", async () => {
@@ -178,7 +180,7 @@ describe("TrashEffortCommand", () => {
 
       expect(mockTaskStatusService.trashEffort).toHaveBeenCalledWith(mockFile, null);
       expect(LoggingService.error).toHaveBeenCalledWith("Trash effort error", permError);
-      expect(Notice).toHaveBeenCalledWith("Failed to trash effort: Permission denied: cannot delete file");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to trash effort: Permission denied: cannot delete file");
     });
 
     it("should handle non-Effort context", () => {

--- a/packages/obsidian-plugin/tests/unit/VoteOnEffortCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/VoteOnEffortCommand.test.ts
@@ -20,6 +20,7 @@ describe("VoteOnEffortCommand", () => {
   let mockEffortVotingService: jest.Mocked<EffortVotingService>;
   let mockFile: jest.Mocked<TFile>;
   let mockContext: CommandVisibilityContext;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,7 +45,8 @@ describe("VoteOnEffortCommand", () => {
     };
 
     // Create command instance
-    command = new VoteOnEffortCommand(mockEffortVotingService);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new VoteOnEffortCommand(mockEffortVotingService, mockNotifier);
   });
 
   describe("id and name", () => {
@@ -87,7 +89,7 @@ describe("VoteOnEffortCommand", () => {
       await flushPromises();
 
       expect(mockEffortVotingService.incrementEffortVotes).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Voted! New vote count: 5");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Voted! New vote count: 5");
     });
 
     it("should handle first vote correctly", async () => {
@@ -100,7 +102,7 @@ describe("VoteOnEffortCommand", () => {
       await flushPromises();
 
       expect(mockEffortVotingService.incrementEffortVotes).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Voted! New vote count: 1");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Voted! New vote count: 1");
     });
 
     it("should handle large vote counts", async () => {
@@ -113,7 +115,7 @@ describe("VoteOnEffortCommand", () => {
       await flushPromises();
 
       expect(mockEffortVotingService.incrementEffortVotes).toHaveBeenCalledWith(mockFile);
-      expect(Notice).toHaveBeenCalledWith("Voted! New vote count: 9999");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Voted! New vote count: 9999");
     });
 
     it("should handle errors and show notice", async () => {
@@ -128,7 +130,7 @@ describe("VoteOnEffortCommand", () => {
 
       expect(mockEffortVotingService.incrementEffortVotes).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Vote on effort error", error);
-      expect(Notice).toHaveBeenCalledWith("Failed to vote: Failed to record vote");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to vote: Failed to record vote");
     });
 
     it("should handle concurrent votes", async () => {
@@ -147,8 +149,8 @@ describe("VoteOnEffortCommand", () => {
       await flushPromises();
 
       expect(mockEffortVotingService.incrementEffortVotes).toHaveBeenCalledTimes(3);
-      expect(Notice).toHaveBeenCalledTimes(3);
-      expect(Notice).toHaveBeenCalledWith("Voted! New vote count: 10");
+      expect(mockNotifier.success).toHaveBeenCalledTimes(3);
+      expect(mockNotifier.success).toHaveBeenCalledWith("Voted! New vote count: 10");
     });
 
     it("should handle file system errors", async () => {
@@ -163,7 +165,7 @@ describe("VoteOnEffortCommand", () => {
 
       expect(mockEffortVotingService.incrementEffortVotes).toHaveBeenCalledWith(mockFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Vote on effort error", fsError);
-      expect(Notice).toHaveBeenCalledWith("Failed to vote: File is read-only");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to vote: File is read-only");
     });
 
     it("should handle non-Effort context", () => {

--- a/packages/obsidian-plugin/tests/unit/application/processors/SPARQLCodeBlockProcessor.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/processors/SPARQLCodeBlockProcessor.test.ts
@@ -22,7 +22,7 @@ describe("SPARQLCodeBlockProcessor", () => {
 
     mockEl = document.createElement("div");
 
-    processor = new SPARQLCodeBlockProcessor(mockPlugin);
+    processor = new SPARQLCodeBlockProcessor(mockPlugin, { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() } as any);
   });
 
   afterEach(() => {
@@ -522,7 +522,7 @@ describe("SPARQLCodeBlockProcessor", () => {
       const clearIntervalSpy = jest.spyOn(global, "clearInterval");
 
       // The constructor starts the interval
-      const newProcessor = new SPARQLCodeBlockProcessor(mockPlugin);
+      const newProcessor = new SPARQLCodeBlockProcessor(mockPlugin, { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() } as any);
       const intervalId = (newProcessor as any).cleanupIntervalId;
 
       expect(intervalId).not.toBeNull();
@@ -537,7 +537,7 @@ describe("SPARQLCodeBlockProcessor", () => {
     });
 
     it("should run periodic cleanup at specified interval", () => {
-      const newProcessor = new SPARQLCodeBlockProcessor(mockPlugin);
+      const newProcessor = new SPARQLCodeBlockProcessor(mockPlugin, { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() } as any);
       const cleanupSpy = jest.spyOn(newProcessor as any, "cleanupStaleQueries");
 
       // Fast forward by cleanup interval

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.errorHandling.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.errorHandling.test.ts
@@ -18,7 +18,7 @@ describe("CommandManager - error handling (global commands)", () => {
       const command = ctx.registeredCommands.get("reload-layout");
       command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to reload layout");
+      expect(Notice).toHaveBeenCalledWith("✗ Failed to reload layout", expect.any(Number));
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.successPaths.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.successPaths.test.ts
@@ -24,7 +24,7 @@ describe("CommandManager - success paths (global commands)", () => {
       command.callback();
 
       expect(mockCallback).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Layout reloaded");
+      expect(Notice).toHaveBeenCalledWith("✓ Layout reloaded", expect.any(Number));
     });
 
     it("should execute toggle-layout-visibility successfully", async () => {

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.toggleCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.toggleCommands.test.ts
@@ -30,7 +30,7 @@ describe("CommandManager - toggle commands", () => {
       command.callback();
 
       expect(mockCallback).toHaveBeenCalled();
-      expect(Notice).toHaveBeenCalledWith("Layout reloaded");
+      expect(Notice).toHaveBeenCalledWith("✓ Layout reloaded", expect.any(Number));
     });
 
     it("should show failure notice when callback not set", () => {
@@ -39,7 +39,7 @@ describe("CommandManager - toggle commands", () => {
       const command = ctx.registeredCommands.get("reload-layout");
       command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to reload layout");
+      expect(Notice).toHaveBeenCalledWith("✗ Failed to reload layout", expect.any(Number));
     });
   });
 
@@ -84,7 +84,7 @@ describe("CommandManager - toggle commands", () => {
       const command = ctx.registeredCommands.get("toggle-layout-visibility");
       await command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Layout shown");
+      expect(Notice).toHaveBeenCalledWith("Layout shown", expect.any(Number));
     });
 
     it("should show notice when toggled to hidden", async () => {
@@ -92,7 +92,7 @@ describe("CommandManager - toggle commands", () => {
       const command = ctx.registeredCommands.get("toggle-layout-visibility");
       await command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Layout hidden");
+      expect(Notice).toHaveBeenCalledWith("Layout hidden", expect.any(Number));
     });
   });
 
@@ -147,7 +147,7 @@ describe("CommandManager - toggle commands", () => {
       );
       await command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Archived assets shown");
+      expect(Notice).toHaveBeenCalledWith("Archived assets shown", expect.any(Number));
     });
 
     it("should show notice when toggled to hidden", async () => {
@@ -157,7 +157,7 @@ describe("CommandManager - toggle commands", () => {
       );
       await command.callback();
 
-      expect(Notice).toHaveBeenCalledWith("Archived assets hidden");
+      expect(Notice).toHaveBeenCalledWith("Archived assets hidden", expect.any(Number));
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/error-handling.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling.test.ts
@@ -63,6 +63,7 @@ jest.mock("exocortex", () => ({
 
 describe("Error Handling - Negative Tests", () => {
   describe("1. CreateInstanceCommand - toTFile conversion failure", () => {
+  let mockNotifier: any;
     let command: CreateInstanceCommand;
     let mockApp: jest.Mocked<App>;
     let mockRuleResolver: jest.Mocked<InstantiationRuleResolver>;
@@ -123,7 +124,8 @@ describe("Error Handling - Negative Tests", () => {
         isDraft: false,
       };
 
-      command = new CreateInstanceCommand(mockApp, mockRuleResolver, mockGenericAssetCreationService, mockVaultAdapter);
+      mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+      command = new CreateInstanceCommand(mockApp, mockRuleResolver, mockGenericAssetCreationService, mockVaultAdapter, mockNotifier);
     });
 
     it("should show error notice when toTFile returns null", async () => {
@@ -141,7 +143,7 @@ describe("Error Handling - Negative Tests", () => {
 
       expect(mockVaultAdapter.toTFile).toHaveBeenCalledWith(createdFile);
       expect(LoggingService.error).toHaveBeenCalledWith("Create instance error", expect.any(Error));
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         expect.stringContaining("Failed to create instance")
       );
     });

--- a/packages/obsidian-plugin/tests/unit/error-handling/CreateInstanceCommand.error.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/CreateInstanceCommand.error.test.ts
@@ -39,6 +39,7 @@ describe("CreateInstanceCommand Error Handling", () => {
   let mockLeaf: jest.Mocked<WorkspaceLeaf>;
   let mockTFile: jest.Mocked<TFile>;
 
+  let mockNotifier: any;
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -96,11 +97,13 @@ describe("CreateInstanceCommand Error Handling", () => {
       isDraft: false,
     };
 
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
     command = new CreateInstanceCommand(
       mockApp,
       mockRuleResolver,
       mockGenericAssetCreationService,
       mockVaultAdapter,
+      mockNotifier,
     );
   });
 
@@ -120,7 +123,7 @@ describe("CreateInstanceCommand Error Handling", () => {
         "Create instance error",
         expect.any(Error),
       );
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: Modal initialization failed",
       );
     });
@@ -151,7 +154,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: Network request failed: ETIMEDOUT",
       );
       expect(LoggingService.error).toHaveBeenCalledWith(
@@ -170,7 +173,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: EACCES: permission denied",
       );
     });
@@ -185,7 +188,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: ENOSPC: no space left on device",
       );
     });
@@ -200,7 +203,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: File already exists: task.md",
       );
     });
@@ -214,7 +217,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: undefined",
       );
     });
@@ -228,7 +231,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: String error message",
       );
     });
@@ -242,7 +245,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to create instance: 404");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to create instance: 404");
     });
   });
 
@@ -260,7 +263,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         expect.stringContaining("Failed to create instance:"),
       );
     });
@@ -278,7 +281,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: File not found in vault cache",
       );
     });
@@ -298,7 +301,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: Cannot open file",
       );
     });
@@ -314,7 +317,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         expect.stringContaining("Failed to create instance:"),
       );
     });
@@ -332,7 +335,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: Workspace state invalid",
       );
     });
@@ -360,7 +363,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         "Failed to create instance: Cannot create new tab",
       );
     });
@@ -387,7 +390,7 @@ describe("CreateInstanceCommand Error Handling", () => {
 
       await new Promise((resolve) => setTimeout(resolve, 2500));
 
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Instance created: new-instance");
     });
 
     it("should handle getActiveFile returning null consistently", async () => {
@@ -404,7 +407,7 @@ describe("CreateInstanceCommand Error Handling", () => {
 
       await new Promise((resolve) => setTimeout(resolve, 2500));
 
-      expect(Notice).toHaveBeenCalledWith("Instance created: new-instance");
+      expect(mockNotifier.success).toHaveBeenCalledWith("Instance created: new-instance");
       expect(mockApp.workspace.getActiveFile).toHaveBeenCalled();
     });
   });

--- a/packages/obsidian-plugin/tests/unit/error-handling/SPARQLCodeBlockProcessor.error.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/SPARQLCodeBlockProcessor.error.test.ts
@@ -59,7 +59,14 @@ describe("SPARQLCodeBlockProcessor Error Handling", () => {
 
     mockEl = document.createElement("div");
 
-    processor = new SPARQLCodeBlockProcessor(mockPlugin);
+    const mockNotifier = {
+      info: jest.fn(),
+      success: jest.fn(),
+      error: jest.fn((msg: string) => { mockNotice(msg, 5000); }),
+      warn: jest.fn(),
+      confirm: jest.fn(),
+    };
+    processor = new SPARQLCodeBlockProcessor(mockPlugin, mockNotifier as any);
   });
 
   describe("Invalid Query Syntax Errors", () => {

--- a/packages/obsidian-plugin/tests/unit/error-handling/error-scenarios.test.ts
+++ b/packages/obsidian-plugin/tests/unit/error-handling/error-scenarios.test.ts
@@ -57,6 +57,7 @@ jest.mock("../../../src/application/services/SPARQLQueryService");
  */
 describe("CreateInstanceCommand Error Handling", () => {
   let command: CreateInstanceCommand;
+  let mockNotifier: any;
   let mockApp: jest.Mocked<App>;
   let mockRuleResolver: jest.Mocked<InstantiationRuleResolver>;
   let mockGenericAssetCreationService: jest.Mocked<GenericAssetCreationService>;
@@ -115,7 +116,8 @@ describe("CreateInstanceCommand Error Handling", () => {
       isDraft: false,
     };
 
-    command = new CreateInstanceCommand(mockApp, mockRuleResolver, mockGenericAssetCreationService, mockVaultAdapter);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+      command = new CreateInstanceCommand(mockApp, mockRuleResolver, mockGenericAssetCreationService, mockVaultAdapter, mockNotifier);
   });
 
   describe("Scenario 1: toTFile returns null (file conversion failure)", () => {
@@ -137,7 +139,7 @@ describe("CreateInstanceCommand Error Handling", () => {
         "Create instance error",
         expect.any(Error)
       );
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         expect.stringContaining("Failed to create instance:")
       );
     });
@@ -152,7 +154,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.error).toHaveBeenCalledWith(
         expect.stringContaining("path/to/new-instance.md")
       );
     });
@@ -169,7 +171,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       await flushPromises();
 
       expect(LoggingService.error).toHaveBeenCalledWith("Create instance error", permissionError);
-      expect(Notice).toHaveBeenCalledWith("Failed to create instance: Permission denied: Cannot write to directory");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to create instance: Permission denied: Cannot write to directory");
     });
 
     it("should handle file already exists error", async () => {
@@ -181,7 +183,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to create instance: File already exists: task-name.md");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to create instance: File already exists: task-name.md");
     });
 
     it("should handle non-Error thrown values", async () => {
@@ -192,7 +194,7 @@ describe("CreateInstanceCommand Error Handling", () => {
       command.checkCallback(false, mockFile, mockContext);
       await flushPromises();
 
-      expect(Notice).toHaveBeenCalledWith("Failed to create instance: String error message");
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to create instance: String error message");
     });
   });
 
@@ -233,7 +235,7 @@ describe("SPARQLCodeBlockProcessor Error Handling", () => {
       } as App,
     } as ExocortexPlugin;
 
-    processor = new SPARQLCodeBlockProcessor(mockPlugin);
+    processor = new SPARQLCodeBlockProcessor(mockPlugin, { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() } as any);
   });
 
   afterEach(() => {

--- a/packages/obsidian-plugin/tests/unit/property-editor/EditPropertiesCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/EditPropertiesCommand.test.ts
@@ -16,6 +16,7 @@ describe("EditPropertiesCommand", () => {
   let mockApp: App;
   let mockPlugin: any;
   let command: EditPropertiesCommand;
+  let mockNotifier: { info: jest.Mock; success: jest.Mock; error: jest.Mock; warn: jest.Mock; confirm: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -30,7 +31,8 @@ describe("EditPropertiesCommand", () => {
       refreshLayout: jest.fn(),
     };
 
-    command = new EditPropertiesCommand(mockApp, mockPlugin);
+    mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
+    command = new EditPropertiesCommand(mockApp, mockPlugin, mockNotifier);
   });
 
   describe("command properties", () => {
@@ -114,7 +116,7 @@ describe("EditPropertiesCommand", () => {
 
       command.checkCallback(false, mockFile, null);
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.info).toHaveBeenCalledWith(
         "This file has no frontmatter properties to edit",
       );
     });
@@ -128,7 +130,7 @@ describe("EditPropertiesCommand", () => {
 
       command.checkCallback(false, mockFile, null);
 
-      expect(Notice).toHaveBeenCalledWith(
+      expect(mockNotifier.info).toHaveBeenCalledWith(
         "This file has no frontmatter properties to edit",
       );
     });


### PR DESCRIPTION
## Summary

- Converts 38 of 43 application-layer files to use `import type` for obsidian types (TFile, App, MetadataCache, etc.)
- Replaces `new Notice()` calls with injected `INotificationService` in 28 command files
- Adds `notifier: INotificationService` parameter to all command constructors
- Updates `CommandManager` to create and inject `ObsidianNotificationService`
- Updates `SPARQLCodeBlockProcessor` to accept notifier via constructor
- Updates all 30 affected test files to use `mockNotifier` pattern

**Archgate IMPORT-001 violations: 43 -> 5**

Remaining 5 are irreducible runtime dependencies:
- `TFile` — `instanceof` checks in LayoutService, ExocortexAPI
- `MarkdownRenderChild` — `extends` in both code block processors
- `Platform` — runtime property access in TaskTrackingService

## Test plan

- [x] Build passes with no TypeScript errors
- [x] All 209 test suites pass (4345 tests)
- [x] Core package tests pass (6898 tests)
- [x] BDD coverage: 100%
- [x] Archgate: 13 rules pass, 5 IMPORT-001 warnings (was 43)
- [x] ESLint: 0 warnings