### PR TITLE
feat(core): ontology-driven readOnly flag for property schemas

### DIFF
--- a/packages/exocortex/src/services/PropertySchemaResolver.ts
+++ b/packages/exocortex/src/services/PropertySchemaResolver.ts
@@ -6,6 +6,7 @@ import { extractPropertyLabel } from "../domain/types/PropertyDefinition";
 export interface PropertySchema {
   type: PropertyFieldType;
   label: string;
+  readOnly?: boolean;
   options?: PropertySchemaOption[];
   validation?: PropertySchemaValidation;
 }
@@ -29,6 +30,7 @@ export interface PropertySchemaBinding {
   rangeType?: string;
   description?: string;
   required?: string;
+  readOnly?: string;
   minValue?: string;
   maxValue?: string;
   maxLength?: string;
@@ -103,11 +105,12 @@ export class PropertySchemaResolver {
       PREFIX exo: <https://exocortex.my/ontology/exo#>
       PREFIX ems: <https://exocortex.my/ontology/ems#>
 
-      SELECT ?type ?label ?rangeType ?description ?required ?minValue ?maxValue ?maxLength ?pattern ?optionValue ?optionLabel WHERE {
+      SELECT ?type ?label ?rangeType ?description ?required ?readOnly ?minValue ?maxValue ?maxLength ?pattern ?optionValue ?optionLabel WHERE {
         <${fullIRI}> rdfs:range ?rangeType .
         OPTIONAL { <${fullIRI}> rdfs:label ?label . }
         OPTIONAL { <${fullIRI}> rdfs:comment ?description . }
         OPTIONAL { <${fullIRI}> exo:schema_required ?required . }
+        OPTIONAL { <${fullIRI}> exo:schema_readOnly ?readOnly . }
         OPTIONAL { <${fullIRI}> exo:schema_minValue ?minValue . }
         OPTIONAL { <${fullIRI}> exo:schema_maxValue ?maxValue . }
         OPTIONAL { <${fullIRI}> exo:schema_maxLength ?maxLength . }
@@ -136,12 +139,13 @@ export class PropertySchemaResolver {
       PREFIX exo: <https://exocortex.my/ontology/exo#>
       PREFIX ems: <https://exocortex.my/ontology/ems#>
 
-      SELECT ?property ?rangeType ?label ?description ?required ?minValue ?maxValue ?maxLength ?pattern ?optionValue ?optionLabel WHERE {
+      SELECT ?property ?rangeType ?label ?description ?required ?readOnly ?minValue ?maxValue ?maxLength ?pattern ?optionValue ?optionLabel WHERE {
         ?property rdf:type owl:DatatypeProperty .
         OPTIONAL { ?property rdfs:range ?rangeType . }
         OPTIONAL { ?property rdfs:label ?label . }
         OPTIONAL { ?property rdfs:comment ?description . }
         OPTIONAL { ?property exo:schema_required ?required . }
+        OPTIONAL { ?property exo:schema_readOnly ?readOnly . }
         OPTIONAL { ?property exo:schema_minValue ?minValue . }
         OPTIONAL { ?property exo:schema_maxValue ?maxValue . }
         OPTIONAL { ?property exo:schema_maxLength ?maxLength . }
@@ -192,6 +196,7 @@ export class PropertySchemaResolver {
     const label = this.getBindingValue(first, "label") || extractPropertyLabel(propertyIRI);
     const fieldType = rangeType ? rangeToFieldType(rangeType) : PropertyFieldType.Text;
 
+    const readOnly = this.getBindingValue(first, "readOnly");
     const options = this.extractOptions(bindings);
 
     const validation = this.extractValidation(first);
@@ -200,6 +205,10 @@ export class PropertySchemaResolver {
       type: fieldType,
       label,
     };
+
+    if (readOnly === "true") {
+      schema.readOnly = true;
+    }
 
     if (options.length > 0) {
       schema.options = options;

--- a/packages/exocortex/tests/services/PropertySchemaResolver.test.ts
+++ b/packages/exocortex/tests/services/PropertySchemaResolver.test.ts
@@ -279,6 +279,50 @@ describe("PropertySchemaResolver", () => {
       });
     });
 
+    it("should set readOnly flag when ontology marks property as readOnly", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "UID"],
+          ["readOnly", "true"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_uid");
+
+      expect(schema).not.toBeNull();
+      expect(schema!.readOnly).toBe(true);
+    });
+
+    it("should not set readOnly flag when ontology does not mark property", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_label");
+
+      expect(schema).not.toBeNull();
+      expect(schema!.readOnly).toBeUndefined();
+    });
+
+    it("should not set readOnly when value is 'false'", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Name"],
+          ["readOnly", "false"],
+        ]),
+      ]);
+
+      const schema = await resolver.getSchema("exo__Asset_name");
+
+      expect(schema).not.toBeNull();
+      expect(schema!.readOnly).toBeUndefined();
+    });
+
     it("should default to Text type when rangeType missing", async () => {
       mockSparqlService.query.mockResolvedValue([
         new Map<string, unknown>([
@@ -312,6 +356,27 @@ describe("PropertySchemaResolver", () => {
       expect(schemas.size).toBe(2);
       expect(schemas.get("exo__Asset_label")!.type).toBe(PropertyFieldType.Text);
       expect(schemas.get("ems__Effort_votes")!.type).toBe(PropertyFieldType.Number);
+    });
+
+    it("should preserve readOnly flag in getAllSchemas results", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["property", "https://exocortex.my/ontology/exo#Asset_uid"],
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "UID"],
+          ["readOnly", "true"],
+        ]),
+        new Map<string, unknown>([
+          ["property", "https://exocortex.my/ontology/exo#Asset_label"],
+          ["rangeType", "http://www.w3.org/2001/XMLSchema#string"],
+          ["label", "Label"],
+        ]),
+      ]);
+
+      const schemas = await resolver.getAllSchemas();
+
+      expect(schemas.get("exo__Asset_uid")!.readOnly).toBe(true);
+      expect(schemas.get("exo__Asset_label")!.readOnly).toBeUndefined();
     });
 
     it("should cache all schemas after first load", async () => {
@@ -414,6 +479,16 @@ describe("PropertySchemaResolver", () => {
 
       expect(mockSparqlService.query).toHaveBeenCalledWith(
         expect.stringContaining("<https://exocortex.my/ontology/ems#Effort_status>"),
+      );
+    });
+
+    it("should include schema_readOnly in single-property query", async () => {
+      mockSparqlService.query.mockResolvedValue([]);
+
+      await resolver.getSchema("exo__Asset_uid");
+
+      expect(mockSparqlService.query).toHaveBeenCalledWith(
+        expect.stringContaining("exo:schema_readOnly"),
       );
     });
 

--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemaService.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemaService.ts
@@ -45,13 +45,7 @@ function coreSchemaToDefinition(
     definition.max = schema.validation.maxValue;
   }
 
-  const readOnlyProperties = new Set([
-    "exo__Asset_uid",
-    "exo__Asset_createdAt",
-    "ems__Effort_startTimestamp",
-    "ems__Effort_endTimestamp",
-  ]);
-  if (readOnlyProperties.has(propertyIRI)) {
+  if (schema.readOnly) {
     definition.readOnly = true;
   }
 

--- a/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
@@ -66,11 +66,13 @@ function buildTestSchemas(): Map<string, PropertySchema> {
   schemas.set("exo__Asset_uid", {
     type: "text" as any,
     label: "UID",
+    readOnly: true,
     validation: { required: true },
   });
   schemas.set("exo__Asset_createdAt", {
     type: "timestamp" as any,
     label: "Created at",
+    readOnly: true,
     validation: { required: true },
   });
   schemas.set("exo__Asset_isArchived", {
@@ -102,10 +104,12 @@ function buildTestSchemas(): Map<string, PropertySchema> {
   schemas.set("ems__Effort_startTimestamp", {
     type: "timestamp" as any,
     label: "Started at",
+    readOnly: true,
   });
   schemas.set("ems__Effort_endTimestamp", {
     type: "timestamp" as any,
     label: "Ended at",
+    readOnly: true,
   });
   schemas.set("ems__Task_size", {
     type: "size-select" as any,
@@ -405,6 +409,31 @@ describe("PropertySchemas", () => {
       const editable = getEditableProperties(schema);
       expect(editable.some((p) => p.name === "ems__Effort_startTimestamp")).toBe(false);
       expect(editable.some((p) => p.name === "ems__Effort_endTimestamp")).toBe(false);
+    });
+
+    it("should propagate readOnly from core schema, not hardcoded list", async () => {
+      const schemas = buildTestSchemas();
+      schemas.set("ems__Effort_day", {
+        type: "wikilink" as any,
+        label: "Planned day",
+        readOnly: true,
+      });
+      const resolver = createMockResolver(schemas);
+      initPropertySchemaService(resolver, createMockHierarchyResolver());
+
+      const schema = await getPropertySchemaForClass("ems__Task");
+      const day = schema.find((p) => p.name === "ems__Effort_day");
+      expect(day?.readOnly).toBe(true);
+    });
+
+    it("should not mark property as readOnly when core schema has no readOnly flag", async () => {
+      const schemas = buildTestSchemas();
+      const resolver = createMockResolver(schemas);
+      initPropertySchemaService(resolver, createMockHierarchyResolver());
+
+      const schema = await getPropertySchemaForClass("ems__Task");
+      const status = schema.find((p) => p.name === "ems__Effort_status");
+      expect(status?.readOnly).toBeUndefined();
     });
 
     it("should include editable properties", async () => {


### PR DESCRIPTION
## Summary

- Add `readOnly?: boolean` field to `PropertySchema` interface in core package
- Extend `PropertySchemaResolver` SPARQL queries to load `exo:schema_readOnly` from vault ontology
- Replace hardcoded `readOnlyProperties` Set in `PropertySchemaService.coreSchemaToDefinition()` with ontology-driven `schema.readOnly` flag
- Add 6 new tests verifying readOnly loading and propagation across core and plugin packages

## Why

The hardcoded `readOnlyProperties` Set violated the ontology-driven design principle: adding or removing read-only properties required code changes instead of ontology updates. Now the readOnly flag is declared in vault property definitions alongside other schema metadata (`schema_required`, `schema_minValue`, etc.) and loaded dynamically.

## Files changed

| File | Change |
|------|--------|
| `packages/exocortex/src/services/PropertySchemaResolver.ts` | Added `readOnly` to `PropertySchema`, `PropertySchemaBinding`; extended SPARQL queries with `exo:schema_readOnly`; parse readOnly in `buildSchemaFromBindings` |
| `packages/obsidian-plugin/src/domain/property-editor/PropertySchemaService.ts` | Removed hardcoded `readOnlyProperties` Set; use `schema.readOnly` |
| `packages/exocortex/tests/services/PropertySchemaResolver.test.ts` | 4 new tests for readOnly flag loading |
| `packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts` | 2 new tests for readOnly propagation; updated mock schemas |

## Test plan

- [x] Core: readOnly loaded when ontology marks `exo:schema_readOnly "true"`
- [x] Core: readOnly undefined when not present in ontology
- [x] Core: readOnly undefined when value is "false"
- [x] Core: readOnly preserved through `getAllSchemas` path
- [x] Core: SPARQL query includes `schema_readOnly` variable
- [x] Plugin: readOnly propagated from core schema to definition
- [x] Plugin: non-readOnly property remains editable
- [x] Plugin: existing getEditableProperties tests pass (uid, createdAt, timestamps filtered)
- [x] All 1220 unit + 53 UI + 483 component tests pass
- [x] TypeScript strict compilation clean
- [x] BDD coverage 100%
- [x] Architecture gate pass

Closes #2624