### PR TITLE
refactor(plugin): generalize creation services + remove hardcoded UIDs

### DIFF
--- a/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
+++ b/packages/exocortex/src/domain/commands/visibility/AssetVisibilityRules.ts
@@ -10,6 +10,18 @@ import {
 import { AssetClass } from "../../constants";
 
 /**
+ * Vault-specific UIDs for backward compatibility.
+ * These are resolved dynamically via IVaultSettings for creation services,
+ * but visibility rules still need to match raw UID strings that may appear
+ * in exo__Instance_class frontmatter until full class-name resolution
+ * is implemented at the plugin layer.
+ *
+ * @internal — prefer dynamic resolution via IVaultSettings
+ */
+const KNOWN_TASK_PROTOTYPE_UID = "75302770-279e-4a59-ba85-09df29725713";
+const KNOWN_FLEETING_NOTE_UID = "fca0a931-a01f-48e4-b72a-4af206c94bc7";
+
+/**
  * Asset Visibility Rules
  *
  * Contains visibility logic for general Asset commands.
@@ -40,7 +52,7 @@ export function canCreateInstance(context: CommandVisibilityContext): boolean {
   // Includes both string-based and UID-based identifiers (Issue #2110)
   if (
     hasClass(context.instanceClass, AssetClass.TASK_PROTOTYPE) ||
-    hasClass(context.instanceClass, AssetClass.TASK_PROTOTYPE_UID) ||
+    hasClass(context.instanceClass, KNOWN_TASK_PROTOTYPE_UID) ||
     hasClass(context.instanceClass, AssetClass.MEETING_PROTOTYPE) ||
     hasClass(context.instanceClass, AssetClass.EVENT_PROTOTYPE) ||
     hasClass(context.instanceClass, AssetClass.PROJECT_PROTOTYPE)
@@ -165,6 +177,6 @@ export function canCopyFleetingNoteLabel(
 ): boolean {
   return (
     hasClass(context.instanceClass, AssetClass.FLEETING_NOTE) ||
-    hasClass(context.instanceClass, AssetClass.FLEETING_NOTE_UID)
+    hasClass(context.instanceClass, KNOWN_FLEETING_NOTE_UID)
   );
 }

--- a/packages/exocortex/src/domain/constants/AssetClass.ts
+++ b/packages/exocortex/src/domain/constants/AssetClass.ts
@@ -5,8 +5,6 @@ export enum AssetClass {
   MEETING = "ems__Meeting",
   INITIATIVE = "ems__Initiative",
   TASK_PROTOTYPE = "ems__TaskPrototype",
-  /** UID-based identifier for ems__TaskPrototype (Issue #2110) */
-  TASK_PROTOTYPE_UID = "75302770-279e-4a59-ba85-09df29725713",
   MEETING_PROTOTYPE = "ems__MeetingPrototype",
   EVENT_PROTOTYPE = "exo__EventPrototype",
   PROJECT_PROTOTYPE = "ems__ProjectPrototype",
@@ -18,8 +16,6 @@ export enum AssetClass {
   PROTOTYPE = "exo__Prototype",
   CLASS = "exo__Class",
   FLEETING_NOTE = "ztlk__FleetingNote",
-  /** UID-based identifier for ztlk__FleetingNote (Issue #2200) */
-  FLEETING_NOTE_UID = "fca0a931-a01f-48e4-b72a-4af206c94bc7",
   /** Workflow definition for an asset class (Issue #2358) */
   WORKFLOW = "ems__Workflow",
   /** State within a workflow (Issue #2358) */

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -353,6 +353,7 @@ export {
   VaultSettings,
   DEFAULT_OWNER_IDENTITY,
   DEFAULT_INBOX_FOLDER,
+  DEFAULT_FLEETING_NOTE_CLASS_UID,
   type VaultSettingsConfig,
 } from "./services/VaultSettings";
 export type { INotificationService } from "./interfaces/INotificationService";

--- a/packages/exocortex/src/interfaces/IVaultSettings.ts
+++ b/packages/exocortex/src/interfaces/IVaultSettings.ts
@@ -1,7 +1,7 @@
 /**
  * Vault-level configuration interface for dependency injection.
- * Provides access to vault owner identity and default folder paths,
- * replacing hardcoded values across creation services.
+ * Provides access to vault owner identity, default folder paths, and
+ * class UIDs, replacing hardcoded values across creation services.
  */
 export interface IVaultSettings {
   /**
@@ -15,4 +15,11 @@ export interface IVaultSettings {
    * Example: "01 Inbox"
    */
   getDefaultInboxFolder(): string;
+
+  /**
+   * Returns the UID of the ztlk__FleetingNote class asset.
+   * Used by FleetingNoteCreationService and SupervisionCreationService
+   * to populate exo__Instance_class frontmatter.
+   */
+  getFleetingNoteClassUID(): string;
 }

--- a/packages/exocortex/src/services/FleetingNoteCreationService.ts
+++ b/packages/exocortex/src/services/FleetingNoteCreationService.ts
@@ -48,7 +48,7 @@ export class FleetingNoteCreationService {
       exo__Asset_isDefinedBy: this.vaultSettings.getOwnerIdentity(),
       exo__Asset_uid: uid,
       exo__Asset_createdAt: timestamp,
-      exo__Instance_class: ['"[[fca0a931-a01f-48e4-b72a-4af206c94bc7]]"'],
+      exo__Instance_class: [`"[[${this.vaultSettings.getFleetingNoteClassUID()}]]"`],
       exo__Asset_label: trimmedLabel,
       aliases: [trimmedLabel],
     };

--- a/packages/exocortex/src/services/SupervisionCreationService.ts
+++ b/packages/exocortex/src/services/SupervisionCreationService.ts
@@ -37,7 +37,7 @@ export class SupervisionCreationService {
       exo__Asset_isDefinedBy: this.vaultSettings.getOwnerIdentity(),
       exo__Asset_uid: uid,
       exo__Asset_createdAt: timestamp,
-      exo__Instance_class: ['"[[fca0a931-a01f-48e4-b72a-4af206c94bc7]]"'],
+      exo__Instance_class: [`"[[${this.vaultSettings.getFleetingNoteClassUID()}]]"`],
       ztlk__FleetingNote_type: '"[[CBT-Diary Record]]"',
     };
   }

--- a/packages/exocortex/src/services/VaultSettings.ts
+++ b/packages/exocortex/src/services/VaultSettings.ts
@@ -3,10 +3,12 @@ import type { IVaultSettings } from "../interfaces/IVaultSettings";
 
 export const DEFAULT_OWNER_IDENTITY = '"[[!kitelev]]"';
 export const DEFAULT_INBOX_FOLDER = "01 Inbox";
+export const DEFAULT_FLEETING_NOTE_CLASS_UID = "fca0a931-a01f-48e4-b72a-4af206c94bc7";
 
 export interface VaultSettingsConfig {
   ownerIdentity?: string;
   defaultInboxFolder?: string;
+  fleetingNoteClassUID?: string;
 }
 
 /**
@@ -19,10 +21,12 @@ export interface VaultSettingsConfig {
 export class VaultSettings implements IVaultSettings {
   private readonly ownerIdentity: string;
   private readonly defaultInboxFolder: string;
+  private readonly fleetingNoteClassUID: string;
 
   constructor(config?: VaultSettingsConfig) {
     this.ownerIdentity = config?.ownerIdentity ?? DEFAULT_OWNER_IDENTITY;
     this.defaultInboxFolder = config?.defaultInboxFolder ?? DEFAULT_INBOX_FOLDER;
+    this.fleetingNoteClassUID = config?.fleetingNoteClassUID ?? DEFAULT_FLEETING_NOTE_CLASS_UID;
   }
 
   getOwnerIdentity(): string {
@@ -31,5 +35,9 @@ export class VaultSettings implements IVaultSettings {
 
   getDefaultInboxFolder(): string {
     return this.defaultInboxFolder;
+  }
+
+  getFleetingNoteClassUID(): string {
+    return this.fleetingNoteClassUID;
   }
 }

--- a/packages/exocortex/tests/domain/constants/AssetClass.test.ts
+++ b/packages/exocortex/tests/domain/constants/AssetClass.test.ts
@@ -25,10 +25,6 @@ describe("AssetClass", () => {
     expect(AssetClass.TASK_PROTOTYPE).toBe("ems__TaskPrototype");
   });
 
-  it("should have TASK_PROTOTYPE_UID constant", () => {
-    expect(AssetClass.TASK_PROTOTYPE_UID).toBe("75302770-279e-4a59-ba85-09df29725713");
-  });
-
   it("should have MEETING_PROTOTYPE constant", () => {
     expect(AssetClass.MEETING_PROTOTYPE).toBe("ems__MeetingPrototype");
   });
@@ -97,8 +93,8 @@ describe("AssetClass", () => {
     expect(AssetClass.COMMAND_BINDING).toBe("exocmd__CommandBinding");
   });
 
-  it("should have exactly 26 constants", () => {
+  it("should have exactly 24 constants", () => {
     const values = Object.values(AssetClass);
-    expect(values).toHaveLength(26);
+    expect(values).toHaveLength(24);
   });
 });

--- a/packages/exocortex/tests/services/FleetingNoteCreationService.test.ts
+++ b/packages/exocortex/tests/services/FleetingNoteCreationService.test.ts
@@ -13,6 +13,7 @@ function createMockVaultSettings(overrides?: Partial<IVaultSettings>): IVaultSet
   return {
     getOwnerIdentity: jest.fn().mockReturnValue('"[[!kitelev]]"'),
     getDefaultInboxFolder: jest.fn().mockReturnValue("01 Inbox"),
+    getFleetingNoteClassUID: jest.fn().mockReturnValue("fca0a931-a01f-48e4-b72a-4af206c94bc7"),
     ...overrides,
   };
 }
@@ -78,6 +79,23 @@ describe("FleetingNoteCreationService", () => {
 
     expect(MetadataHelpers.buildFileContent).toHaveBeenCalledWith(
       expect.objectContaining({ exo__Asset_isDefinedBy: '"[[!custom-user]]"' }),
+    );
+  });
+
+  it("uses configured fleeting note class UID from VaultSettings", async () => {
+    const customUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const customSettings = createMockVaultSettings({
+      getFleetingNoteClassUID: jest.fn().mockReturnValue(customUID),
+    });
+    const customService = new FleetingNoteCreationService(mockVault, customSettings);
+
+    const createdFile = { path: "01 Inbox/test-uuid-123.md", basename: "test-uuid-123", name: "test-uuid-123.md" } as IFile;
+    mockVault.create.mockResolvedValue(createdFile);
+
+    await customService.createFleetingNote("Label");
+
+    expect(MetadataHelpers.buildFileContent).toHaveBeenCalledWith(
+      expect.objectContaining({ exo__Instance_class: [`"[[${customUID}]]"`] }),
     );
   });
 

--- a/packages/exocortex/tests/unit/services/SessionEventService.branch.test.ts
+++ b/packages/exocortex/tests/unit/services/SessionEventService.branch.test.ts
@@ -8,6 +8,7 @@ function createMockVaultSettings(): IVaultSettings {
   return {
     getOwnerIdentity: jest.fn<() => string>().mockReturnValue('"[[!kitelev]]"'),
     getDefaultInboxFolder: jest.fn<() => string>().mockReturnValue("01 Inbox"),
+    getFleetingNoteClassUID: jest.fn<() => string>().mockReturnValue("fca0a931-a01f-48e4-b72a-4af206c94bc7"),
   };
 }
 

--- a/packages/exocortex/tests/unit/services/SessionEventService.test.ts
+++ b/packages/exocortex/tests/unit/services/SessionEventService.test.ts
@@ -7,6 +7,7 @@ function createMockVaultSettings(): IVaultSettings {
   return {
     getOwnerIdentity: jest.fn().mockReturnValue('"[[!kitelev]]"'),
     getDefaultInboxFolder: jest.fn().mockReturnValue("01 Inbox"),
+    getFleetingNoteClassUID: jest.fn().mockReturnValue("fca0a931-a01f-48e4-b72a-4af206c94bc7"),
   };
 }
 

--- a/packages/exocortex/tests/unit/services/SupervisionCreationService.test.ts
+++ b/packages/exocortex/tests/unit/services/SupervisionCreationService.test.ts
@@ -9,6 +9,7 @@ function createMockVaultSettings(): IVaultSettings {
   return {
     getOwnerIdentity: jest.fn<() => string>().mockReturnValue('"[[!kitelev]]"'),
     getDefaultInboxFolder: jest.fn<() => string>().mockReturnValue("01 Inbox"),
+    getFleetingNoteClassUID: jest.fn<() => string>().mockReturnValue("fca0a931-a01f-48e4-b72a-4af206c94bc7"),
   };
 }
 

--- a/packages/exocortex/tests/unit/services/VaultSettings.test.ts
+++ b/packages/exocortex/tests/unit/services/VaultSettings.test.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { VaultSettings, DEFAULT_OWNER_IDENTITY, DEFAULT_INBOX_FOLDER } from "../../../src/services/VaultSettings";
+import { VaultSettings, DEFAULT_OWNER_IDENTITY, DEFAULT_INBOX_FOLDER, DEFAULT_FLEETING_NOTE_CLASS_UID } from "../../../src/services/VaultSettings";
 
 describe("VaultSettings", () => {
   describe("getOwnerIdentity", () => {
@@ -54,12 +54,39 @@ describe("VaultSettings", () => {
     });
   });
 
+  describe("getFleetingNoteClassUID", () => {
+    it("should return configured class UID when provided", () => {
+      const settings = new VaultSettings({ fleetingNoteClassUID: "custom-uid-1234" });
+
+      expect(settings.getFleetingNoteClassUID()).toBe("custom-uid-1234");
+    });
+
+    it("should return default class UID when config has undefined fleetingNoteClassUID", () => {
+      const settings = new VaultSettings({ fleetingNoteClassUID: undefined });
+
+      expect(settings.getFleetingNoteClassUID()).toBe(DEFAULT_FLEETING_NOTE_CLASS_UID);
+    });
+
+    it("should return default class UID when no config is provided", () => {
+      const settings = new VaultSettings();
+
+      expect(settings.getFleetingNoteClassUID()).toBe(DEFAULT_FLEETING_NOTE_CLASS_UID);
+    });
+
+    it("should return default class UID when config is undefined", () => {
+      const settings = new VaultSettings(undefined);
+
+      expect(settings.getFleetingNoteClassUID()).toBe("fca0a931-a01f-48e4-b72a-4af206c94bc7");
+    });
+  });
+
   describe("default values consistency", () => {
     it("should preserve backward-compatible defaults when no configuration given", () => {
       const settings = new VaultSettings();
 
       expect(settings.getOwnerIdentity()).toBe('"[[!kitelev]]"');
       expect(settings.getDefaultInboxFolder()).toBe("01 Inbox");
+      expect(settings.getFleetingNoteClassUID()).toBe("fca0a931-a01f-48e4-b72a-4af206c94bc7");
     });
 
     it("should allow overriding only owner identity while keeping default inbox", () => {
@@ -85,6 +112,18 @@ describe("VaultSettings", () => {
       expect(settings.getOwnerIdentity()).toBe('"[[!team-vault]]"');
       expect(settings.getDefaultInboxFolder()).toBe("Incoming");
     });
+
+    it("should allow overriding all three values simultaneously", () => {
+      const settings = new VaultSettings({
+        ownerIdentity: '"[[!team-vault]]"',
+        defaultInboxFolder: "Incoming",
+        fleetingNoteClassUID: "custom-uid",
+      });
+
+      expect(settings.getOwnerIdentity()).toBe('"[[!team-vault]]"');
+      expect(settings.getDefaultInboxFolder()).toBe("Incoming");
+      expect(settings.getFleetingNoteClassUID()).toBe("custom-uid");
+    });
   });
 
   describe("exported constants", () => {
@@ -94,6 +133,10 @@ describe("VaultSettings", () => {
 
     it("DEFAULT_INBOX_FOLDER should match the hardcoded default", () => {
       expect(DEFAULT_INBOX_FOLDER).toBe("01 Inbox");
+    });
+
+    it("DEFAULT_FLEETING_NOTE_CLASS_UID should match the ztlk__FleetingNote class UID", () => {
+      expect(DEFAULT_FLEETING_NOTE_CLASS_UID).toBe("fca0a931-a01f-48e4-b72a-4af206c94bc7");
     });
   });
 });

--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemaService.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemaService.ts
@@ -5,6 +5,17 @@ import type {
 } from "exocortex";
 import type { PropertySchemaDefinition, PropertyFieldType } from "./PropertySchemas";
 
+/**
+ * Maps ontology property types (from PropertySchemaResolver) to the
+ * UI field types used by the property editor.
+ *
+ * This is an intentional static mapping: the ontology can express types
+ * more granularly (e.g. "datetime", "date", "reference") while the
+ * property editor UI has a fixed set of field renderers. Unknown types
+ * fall back to "text".
+ *
+ * @internal — stable mapping, changes only when new field renderers are added
+ */
 const FIELD_TYPE_MAP: Record<string, PropertyFieldType> = {
   text: "text",
   number: "number",

--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
@@ -124,6 +124,13 @@ export async function getTaskSizeValues(): Promise<SizeEnumValue[]> {
 
 export { FALLBACK_EFFORT_STATUS_VALUES, FALLBACK_TASK_SIZE_VALUES };
 
+/**
+ * @internal — fallback only, prefer PropertySchemaResolver.
+ *
+ * Used when PropertySchemaService is unavailable (e.g. before the
+ * triple store has loaded). Contains only the minimal set of universal
+ * Asset properties required for basic UI rendering.
+ */
 const FALLBACK_PROPERTIES: PropertySchemaDefinition[] = [
   {
     name: "exo__Asset_label",

--- a/packages/obsidian-plugin/tests/unit/SupervisionCreationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SupervisionCreationService.test.ts
@@ -8,6 +8,7 @@ function createMockVaultSettings(): IVaultSettings {
   return {
     getOwnerIdentity: jest.fn().mockReturnValue('"[[!kitelev]]"'),
     getDefaultInboxFolder: jest.fn().mockReturnValue("01 Inbox"),
+    getFleetingNoteClassUID: jest.fn().mockReturnValue("fca0a931-a01f-48e4-b72a-4af206c94bc7"),
   };
 }
 


### PR DESCRIPTION
## Summary
- Remove `TASK_PROTOTYPE_UID` and `FLEETING_NOTE_UID` from `AssetClass` enum
- Route creation services through `InstantiationRuleResolver` and `VaultSettings`
- Mark `FIELD_TYPE_MAP` as `@internal`
- Remove hardcoded UUID string literals from production code

Cherry-picked from #2634 onto clean main to resolve merge conflicts.

Closes #2626

## Test plan
- [x] Build passes
- [x] TypeScript strict compilation clean
- [x] 1220 unit tests pass