### PR TITLE
test(core): verify property_set handles YAML arrays of wikilinks (#2637)

### DIFF
--- a/packages/exocortex/src/utilities/FrontmatterService.ts
+++ b/packages/exocortex/src/utilities/FrontmatterService.ts
@@ -126,30 +126,31 @@ export class FrontmatterService {
    */
   updateProperty(content: string, property: string, value: unknown): string {
     const parsed = this.parse(content);
+    const serialized = this.serializeValue(property, value);
 
     // No frontmatter exists - create new block
     if (!parsed.exists) {
-      return this.createFrontmatter(content, { [property]: value });
+      return `---\n${serialized}\n---\n${content}`;
     }
 
     // Frontmatter exists - update or add property
     let updatedFrontmatter = parsed.content;
 
-    // Property already exists - replace value
+    // Property already exists - replace value (including multi-line array items)
     if (this.hasProperty(updatedFrontmatter, property)) {
       const propertyRegex = new RegExp(
-        `${this.escapeRegex(property)}:.*$`,
+        `${this.escapeRegex(property)}:.*(?:\n {2}- .*)*`,
         "m",
       );
       updatedFrontmatter = updatedFrontmatter.replace(
         propertyRegex,
-        `${property}: ${value}`,
+        serialized,
       );
     } else {
       // Property doesn't exist - append to frontmatter
       // Add newline separator only if frontmatter is not empty
       const separator = updatedFrontmatter.length > 0 ? "\n" : "";
-      updatedFrontmatter += `${separator}${property}: ${value}`;
+      updatedFrontmatter += `${separator}${serialized}`;
     }
 
     // Replace frontmatter block in original content
@@ -250,7 +251,7 @@ export class FrontmatterService {
    */
   createFrontmatter(content: string, properties: Record<string, unknown>): string {
     const frontmatterLines = Object.entries(properties).map(
-      ([key, value]) => `${key}: ${value}`,
+      ([key, value]) => this.serializeValue(key, value),
     );
 
     const frontmatterBlock = `---\n${frontmatterLines.join("\n")}\n---`;
@@ -297,6 +298,21 @@ export class FrontmatterService {
    * @returns Escaped string safe for use in RegExp
    * @private
    */
+  /**
+   * Serialize a property key-value pair to YAML string.
+   * Arrays are serialized as multi-line YAML lists.
+   */
+  private serializeValue(property: string, value: unknown): string {
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        return `${property}:`;
+      }
+      const items = value.map((v) => `  - ${v}`).join("\n");
+      return `${property}:\n${items}`;
+    }
+    return `${property}: ${String(value)}`;
+  }
+
   private escapeRegex(str: string): string {
     return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   }

--- a/packages/exocortex/tests/utilities/FrontmatterService.test.ts
+++ b/packages/exocortex/tests/utilities/FrontmatterService.test.ts
@@ -578,4 +578,104 @@ Body`;
       expect(result).toBe(`---\nfoo: bar\ndescription: ${longValue}\n---\nBody`);
     });
   });
+
+  describe("updateProperty with arrays of wikilinks (RFC-016 #2637)", () => {
+    it("should serialize array of wikilinks as YAML list", () => {
+      const content = "---\nfoo: bar\n---\nBody";
+      const newValue = [
+        '"[[uuid1|ems__Task]]"',
+        '"[[uuid2|gtd__NextAction]]"',
+      ];
+
+      const result = service.updateProperty(content, "exo__Instance_class", newValue);
+
+      expect(result).toContain("uuid1");
+      expect(result).toContain("uuid2");
+      expect(result).toContain("ems__Task");
+      expect(result).toContain("gtd__NextAction");
+      // Should be valid YAML list format
+      expect(result).toContain('  - "[[uuid1|ems__Task]]"');
+      expect(result).toContain('  - "[[uuid2|gtd__NextAction]]"');
+    });
+
+    it("should replace existing array property with new array", () => {
+      const content = `---
+exo__Instance_class:
+  - "[[ems__Task]]"
+  - "[[gtd__InboxItem]]"
+foo: bar
+---
+Body`;
+
+      const newValue = [
+        '"[[uuid1|ems__Task]]"',
+        '"[[uuid2|gtd__NextAction]]"',
+      ];
+
+      const result = service.updateProperty(content, "exo__Instance_class", newValue);
+
+      expect(result).toContain("uuid1");
+      expect(result).toContain("uuid2");
+      expect(result).not.toContain("gtd__InboxItem");
+      expect(result).toContain("foo: bar");
+    });
+
+    it("should handle single-element array", () => {
+      const content = "---\nfoo: bar\n---\nBody";
+      const newValue = ['"[[uuid1|ems__Task]]"'];
+
+      const result = service.updateProperty(content, "exo__Instance_class", newValue);
+
+      expect(result).toContain('  - "[[uuid1|ems__Task]]"');
+    });
+
+    it("should handle empty array", () => {
+      const content = "---\nfoo: bar\n---\nBody";
+      const newValue: string[] = [];
+
+      const result = service.updateProperty(content, "exo__Instance_class", newValue);
+
+      // Empty array should produce empty YAML array
+      expect(result).toContain("exo__Instance_class:");
+    });
+
+    it("should produce round-trip parseable YAML for arrays", () => {
+      const content = "---\nfoo: bar\n---\nBody";
+      const newValue = [
+        '"[[uuid1|ems__Task]]"',
+        '"[[uuid2|gtd__NextAction]]"',
+      ];
+
+      const result = service.updateProperty(content, "exo__Instance_class", newValue);
+
+      // Verify the result is parseable - extract frontmatter and check structure
+      const parsed = service.parse(result);
+      expect(parsed.exists).toBe(true);
+      expect(parsed.content).toContain("exo__Instance_class:");
+      expect(parsed.content).toContain('  - "[[uuid1|ems__Task]]"');
+      expect(parsed.content).toContain('  - "[[uuid2|gtd__NextAction]]"');
+    });
+
+    it("should replace existing single-value property with array", () => {
+      const content = '---\nexo__Instance_class: "[[ems__Task]]"\nfoo: bar\n---\nBody';
+      const newValue = [
+        '"[[uuid1|ems__Task]]"',
+        '"[[uuid2|gtd__NextAction]]"',
+      ];
+
+      const result = service.updateProperty(content, "exo__Instance_class", newValue);
+
+      expect(result).toContain('  - "[[uuid1|ems__Task]]"');
+      expect(result).toContain('  - "[[uuid2|gtd__NextAction]]"');
+      expect(result).toContain("foo: bar");
+    });
+
+    it("should not affect non-array updateProperty behavior", () => {
+      // Regression: ensure scalar values still work
+      const content = "---\nfoo: bar\n---\nBody";
+      const result = service.updateProperty(content, "status", '"[[StatusDone]]"');
+
+      expect(result).toBe('---\nfoo: bar\nstatus: "[[StatusDone]]"\n---\nBody');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add array serialization support to `FrontmatterService.updateProperty` — arrays are now serialized as multi-line YAML lists (`  - item`) instead of `Array.toString()`
- Add `serializeValue` private method for consistent YAML serialization of scalar and array values
- Update `createFrontmatter` to use the same serialization logic
- Fix regex in `updateProperty` to match and replace existing multi-line array properties (including `  - ` continuation lines)

## Test plan

- [x] 7 new tests covering: array of wikilinks, replace existing array, single-element array, empty array, round-trip parsing, replace scalar with array, regression for scalar values
- [x] All 77 FrontmatterService tests pass
- [x] All 1220 unit tests pass (0 regressions)
- [x] TypeScript typecheck clean
- [x] ESLint clean
- [x] BDD coverage 100%
- [x] Archgate compliance pass

Closes #2637