### PR TITLE
feat(core): multi-valued property merge in PrototypeChainMaterializer (#2639)

### DIFF
--- a/packages/cli/src/commands/sparql-index.ts
+++ b/packages/cli/src/commands/sparql-index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { existsSync } from "fs";
 import { resolve } from "path";
-import { InMemoryTripleStore, RDFSInferenceEngine, NonInheritablePropertyRegistry, PrototypeChainMaterializer } from "exocortex";
+import { InMemoryTripleStore, RDFSInferenceEngine, NonInheritablePropertyRegistry, PropertyCardinalityRegistry, PrototypeChainMaterializer } from "exocortex";
 import { CacheManager } from "../cache/CacheManager.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
@@ -83,7 +83,9 @@ export function sparqlIndexCommand(): Command {
           // Prototype chain materialization (after RDFS inference)
           const registry = new NonInheritablePropertyRegistry();
           await registry.initialize(tripleStore);
-          const protoMaterializer = new PrototypeChainMaterializer(registry);
+          const cardinalityRegistry = new PropertyCardinalityRegistry();
+          await cardinalityRegistry.initialize(tripleStore);
+          const protoMaterializer = new PrototypeChainMaterializer(registry, cardinalityRegistry);
           const protoInferredCount = await protoMaterializer.materialize(tripleStore);
           inferredCount += protoInferredCount;
 

--- a/packages/cli/tests/unit/commands/sparql-index.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-index.test.ts
@@ -29,6 +29,8 @@ const mockMaterialize = jest.fn();
 const mockRegistryInitialize = jest.fn();
 const mockProtoMaterialize = jest.fn();
 
+const mockCardinalityRegistryInitialize = jest.fn();
+
 jest.unstable_mockModule("exocortex", () => ({
   InMemoryTripleStore: jest.fn(() => ({
     addAll: mockAddAll,
@@ -39,6 +41,9 @@ jest.unstable_mockModule("exocortex", () => ({
   })),
   NonInheritablePropertyRegistry: jest.fn(() => ({
     initialize: mockRegistryInitialize,
+  })),
+  PropertyCardinalityRegistry: jest.fn(() => ({
+    initialize: mockCardinalityRegistryInitialize,
   })),
   PrototypeChainMaterializer: jest.fn(() => ({
     materialize: mockProtoMaterialize,

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -225,6 +225,7 @@ export { InMemoryTripleStore } from "./infrastructure/rdf/InMemoryTripleStore";
 export { RDFVocabularyMapper } from "./infrastructure/rdf/RDFVocabularyMapper";
 export { RDFSInferenceEngine } from "./infrastructure/rdf/RDFSInferenceEngine";
 export { NonInheritablePropertyRegistry } from "./services/NonInheritablePropertyRegistry";
+export { PropertyCardinalityRegistry } from "./services/PropertyCardinalityRegistry";
 export { PrototypeChainMaterializer, INFERRED_GRAPH } from "./services/PrototypeChainMaterializer";
 export { SourceAnnotator, SOURCE_VARIABLE, type TripleSource } from "./services/SourceAnnotator";
 export { NoteToRDFConverter } from "./services/NoteToRDFConverter";

--- a/packages/exocortex/src/services/PropertyCardinalityRegistry.ts
+++ b/packages/exocortex/src/services/PropertyCardinalityRegistry.ts
@@ -1,0 +1,194 @@
+import { injectable } from "tsyringe";
+import { ITripleStore } from "../interfaces/ITripleStore";
+import { IRI } from "../domain/models/rdf/IRI";
+import { Literal } from "../domain/models/rdf/Literal";
+import { Namespace } from "../domain/models/rdf/Namespace";
+
+/**
+ * Registry of multi-valued properties for prototype chain merge semantics.
+ *
+ * Loads from triple store by querying for properties marked with
+ * exo__Property_cardinality: exo__PropertyCardinalityMultiple,
+ * then provides O(1) lookup by predicate IRI.
+ *
+ * Used by PrototypeChainMaterializer to APPEND (not skip) inherited values
+ * for multi-valued properties like exo__Instance_class.
+ */
+@injectable()
+export class PropertyCardinalityRegistry {
+  private readonly multiValuedIRIs: Set<string> = new Set();
+  private initialized = false;
+
+  /**
+   * Load multi-valued property set from triple store.
+   *
+   * Queries for: ?property exo:Property_cardinality exo:PropertyCardinalityMultiple
+   * Then maps each property's Asset_label to its predicate IRI.
+   *
+   * Safe default: if query fails or returns no results, all properties are single-valued.
+   */
+  async initialize(store: ITripleStore): Promise<void> {
+    this.multiValuedIRIs.clear();
+
+    try {
+      const allPredicates = await store.predicates();
+
+      const cardinalityPredicate = allPredicates.find((p) =>
+        p.value.includes("Property_cardinality"),
+      );
+
+      if (!cardinalityPredicate) {
+        this.initialized = true;
+        return;
+      }
+
+      // Find the PropertyCardinalityMultiple class IRI in the store
+      const multipleClassIRI = await this.findMultipleCardinalityIRI(
+        store,
+        allPredicates,
+      );
+
+      if (!multipleClassIRI) {
+        this.initialized = true;
+        return;
+      }
+
+      // Find all properties marked as multi-valued
+      const markedProperties = await store.match(
+        undefined,
+        cardinalityPredicate,
+        multipleClassIRI,
+      );
+
+      if (markedProperties.length === 0) {
+        this.initialized = true;
+        return;
+      }
+
+      // For each marked property, get its Asset_label and convert to predicate IRI
+      const labelPredicate = allPredicates.find((p) =>
+        p.value.includes("Asset_label"),
+      );
+
+      if (!labelPredicate) {
+        this.initialized = true;
+        return;
+      }
+
+      for (const triple of markedProperties) {
+        const labelTriples = await store.match(
+          triple.subject,
+          labelPredicate,
+          undefined,
+        );
+
+        for (const labelTriple of labelTriples) {
+          if (labelTriple.object instanceof Literal) {
+            const propertyKey = labelTriple.object.value;
+            const predicateIRI = this.propertyKeyToIRI(propertyKey);
+            if (predicateIRI) {
+              this.multiValuedIRIs.add(predicateIRI);
+            }
+          }
+        }
+      }
+    } catch {
+      // Safe default: empty set = all properties single-valued (skip behavior)
+    }
+
+    this.initialized = true;
+  }
+
+  /**
+   * Check if a property predicate IRI is multi-valued.
+   * Returns false (safe default) if not initialized or property not found.
+   */
+  isMultiValued(propertyIRI: string): boolean {
+    return this.multiValuedIRIs.has(propertyIRI);
+  }
+
+  /**
+   * Get the count of registered multi-valued properties.
+   */
+  get size(): number {
+    return this.multiValuedIRIs.size;
+  }
+
+  /**
+   * Check if the registry has been initialized.
+   */
+  get isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
+   * Find the IRI used for exo__PropertyCardinalityMultiple class in the store.
+   * Uses Asset_label matching since the class IRI varies by vault path.
+   */
+  private async findMultipleCardinalityIRI(
+    store: ITripleStore,
+    allPredicates: IRI[],
+  ): Promise<IRI | null> {
+    const labelPredicate = allPredicates.find((p) =>
+      p.value.includes("Asset_label"),
+    );
+
+    if (!labelPredicate) {
+      return null;
+    }
+
+    // Search for assets labeled "exo__PropertyCardinalityMultiple"
+    const labelTriples = await store.match(
+      undefined,
+      labelPredicate,
+      new Literal("exo__PropertyCardinalityMultiple"),
+    );
+
+    if (labelTriples.length > 0 && labelTriples[0].subject instanceof IRI) {
+      return labelTriples[0].subject as IRI;
+    }
+
+    // Fallback: look for IRI containing "PropertyCardinalityMultiple"
+    const instanceClassPredicate = allPredicates.find((p) =>
+      p.value.includes("Instance_class"),
+    );
+
+    if (instanceClassPredicate) {
+      const allClassTriples = await store.match(
+        undefined,
+        instanceClassPredicate,
+        undefined,
+      );
+
+      for (const t of allClassTriples) {
+        if (
+          t.object instanceof IRI &&
+          t.object.value.includes("PropertyCardinalityMultiple")
+        ) {
+          return t.object as IRI;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Convert a property key (e.g. "exo__Instance_class") to its predicate IRI.
+   */
+  private propertyKeyToIRI(key: string): string | null {
+    if (key.startsWith("exo__")) {
+      return Namespace.EXO.term(key.substring(5)).value;
+    }
+
+    if (key.startsWith("ems__")) {
+      return Namespace.EMS.term(key.substring(5)).value;
+    }
+
+    if (key.startsWith("exocmd__")) {
+      return Namespace.EXOCMD.term(key.substring(8)).value;
+    }
+
+    return null;
+  }
+}

--- a/packages/exocortex/src/services/PrototypeChainMaterializer.ts
+++ b/packages/exocortex/src/services/PrototypeChainMaterializer.ts
@@ -3,6 +3,7 @@ import { ITripleStore } from "../interfaces/ITripleStore";
 import { Triple } from "../domain/models/rdf/Triple";
 import { IRI } from "../domain/models/rdf/IRI";
 import { NonInheritablePropertyRegistry } from "./NonInheritablePropertyRegistry";
+import { PropertyCardinalityRegistry } from "./PropertyCardinalityRegistry";
 
 /**
  * Named graph IRI for materialized (inherited) triples.
@@ -48,9 +49,14 @@ export const MAX_PROTOTYPE_DEPTH = 10;
 @injectable()
 export class PrototypeChainMaterializer {
   private readonly registry: NonInheritablePropertyRegistry;
+  private readonly cardinalityRegistry: PropertyCardinalityRegistry | null;
 
-  constructor(registry: NonInheritablePropertyRegistry) {
+  constructor(
+    registry: NonInheritablePropertyRegistry,
+    cardinalityRegistry?: PropertyCardinalityRegistry,
+  ) {
     this.registry = registry;
+    this.cardinalityRegistry = cardinalityRegistry ?? null;
   }
 
   /**
@@ -115,8 +121,20 @@ export class PrototypeChainMaterializer {
       // Get predicates the instance already owns
       const ownTriples = await store.match(instance, undefined, undefined);
       const seenPredicates = new Set<string>();
+      // Track seen values for multi-valued predicates to avoid duplicates
+      const seenValues = new Map<string, Set<string>>();
       for (const t of ownTriples) {
         seenPredicates.add(t.predicate.value);
+        // For multi-valued predicates, track individual values
+        if (this.isMultiValued(t.predicate.value)) {
+          const objectValue = t.object instanceof IRI ? t.object.value : String(t.object);
+          let valueSet = seenValues.get(t.predicate.value);
+          if (!valueSet) {
+            valueSet = new Set();
+            seenValues.set(t.predicate.value, valueSet);
+          }
+          valueSet.add(objectValue);
+        }
       }
 
       // Walk chain near→far: closest prototype wins
@@ -146,14 +164,48 @@ export class PrototypeChainMaterializer {
             continue;
           }
 
-          // Skip if already seen (own or from closer prototype)
-          if (seenPredicates.has(predicateValue)) {
-            continue;
-          }
-
           // Skip properties that the prototype itself inherited (materialized)
           // They'll be handled at the correct depth from their original source
           if (protoInheritedPredicates.has(predicateValue)) {
+            continue;
+          }
+
+          // Multi-valued predicate: APPEND instead of skip
+          if (seenPredicates.has(predicateValue) && this.isMultiValued(predicateValue)) {
+            const objectValue = protoTriple.object instanceof IRI
+              ? protoTriple.object.value
+              : String(protoTriple.object);
+
+            // Skip duplicate values
+            const valueset = seenValues.get(predicateValue);
+            if (valueset?.has(objectValue)) {
+              continue;
+            }
+
+            // Append new value
+            let appendSet = seenValues.get(predicateValue);
+            if (!appendSet) {
+              appendSet = new Set();
+              seenValues.set(predicateValue, appendSet);
+            }
+            appendSet.add(objectValue);
+
+            const materializedTriple = new Triple(
+              instance,
+              protoTriple.predicate,
+              protoTriple.object,
+            );
+            await store.add(materializedTriple);
+            if (store.addToGraph) {
+              await store.addToGraph(materializedTriple, INFERRED_GRAPH);
+              await store.addToGraph(materializedTriple, inferredGraphForDepth(depth));
+            }
+            materializedCount++;
+            continue;
+          }
+
+          // Single-valued: skip if already seen (own or from closer prototype)
+          if (seenPredicates.has(predicateValue)) {
             continue;
           }
 
@@ -180,6 +232,17 @@ export class PrototypeChainMaterializer {
     }
 
     return materializedCount;
+  }
+
+  /**
+   * Check if a predicate is multi-valued via the cardinality registry.
+   * Returns false if no registry is configured (backward-compatible default).
+   */
+  private isMultiValued(predicateIRI: string): boolean {
+    if (!this.cardinalityRegistry) {
+      return false;
+    }
+    return this.cardinalityRegistry.isMultiValued(predicateIRI);
   }
 
   /**

--- a/packages/exocortex/tests/unit/services/PropertyCardinalityRegistry.test.ts
+++ b/packages/exocortex/tests/unit/services/PropertyCardinalityRegistry.test.ts
@@ -1,0 +1,108 @@
+import { PropertyCardinalityRegistry } from "../../../src/services/PropertyCardinalityRegistry";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+describe("PropertyCardinalityRegistry", () => {
+  let registry: PropertyCardinalityRegistry;
+  let store: InMemoryTripleStore;
+
+  const instanceClass = Namespace.EXO.term("Instance_class");
+  const assetLabel = Namespace.EXO.term("Asset_label");
+  const propertyCardinality = Namespace.EXO.term("Property_cardinality");
+
+  const multipleCardinalityClassIRI = new IRI(
+    "obsidian://vault/exo__PropertyCardinalityMultiple.md",
+  );
+  const propertyCardinalityClassIRI = new IRI(
+    "obsidian://vault/exo__PropertyCardinality.md",
+  );
+
+  async function setupStore(multiValuedProps: string[]): Promise<void> {
+    // Define PropertyCardinalityMultiple class
+    await store.add(
+      new Triple(
+        multipleCardinalityClassIRI,
+        assetLabel,
+        new Literal("exo__PropertyCardinalityMultiple"),
+      ),
+    );
+    await store.add(
+      new Triple(
+        multipleCardinalityClassIRI,
+        instanceClass,
+        propertyCardinalityClassIRI,
+      ),
+    );
+
+    // Define each multi-valued property
+    for (const propLabel of multiValuedProps) {
+      const defIRI = new IRI(`obsidian://vault/${propLabel}.md`);
+      await store.add(
+        new Triple(defIRI, propertyCardinality, multipleCardinalityClassIRI),
+      );
+      await store.add(new Triple(defIRI, assetLabel, new Literal(propLabel)));
+    }
+  }
+
+  beforeEach(() => {
+    registry = new PropertyCardinalityRegistry();
+    store = new InMemoryTripleStore();
+  });
+
+  it("should identify exo__Instance_class as multi-valued", async () => {
+    await setupStore(["exo__Instance_class"]);
+    await registry.initialize(store);
+
+    const iri = Namespace.EXO.term("Instance_class").value;
+    expect(registry.isMultiValued(iri)).toBe(true);
+  });
+
+  it("should return false for unlisted property", async () => {
+    await setupStore(["exo__Instance_class"]);
+    await registry.initialize(store);
+
+    const iri = Namespace.EXO.term("Asset_label").value;
+    expect(registry.isMultiValued(iri)).toBe(false);
+  });
+
+  it("should handle multiple multi-valued properties", async () => {
+    await setupStore(["exo__Instance_class", "ems__Effort_prototype"]);
+    await registry.initialize(store);
+
+    expect(registry.isMultiValued(Namespace.EXO.term("Instance_class").value)).toBe(true);
+    expect(registry.isMultiValued(Namespace.EMS.term("Effort_prototype").value)).toBe(true);
+    expect(registry.size).toBe(2);
+  });
+
+  it("should return false when not initialized", () => {
+    const iri = Namespace.EXO.term("Instance_class").value;
+    expect(registry.isMultiValued(iri)).toBe(false);
+  });
+
+  it("should handle empty store", async () => {
+    await registry.initialize(store);
+
+    expect(registry.isMultiValued(Namespace.EXO.term("Instance_class").value)).toBe(false);
+    expect(registry.isInitialized).toBe(true);
+    expect(registry.size).toBe(0);
+  });
+
+  it("should handle store without cardinality predicate", async () => {
+    // Only add some triples, but no Property_cardinality
+    await store.add(
+      new Triple(
+        new IRI("obsidian://vault/test.md"),
+        assetLabel,
+        new Literal("test"),
+      ),
+    );
+
+    await registry.initialize(store);
+
+    expect(registry.isMultiValued(Namespace.EXO.term("Instance_class").value)).toBe(false);
+    expect(registry.isInitialized).toBe(true);
+  });
+});

--- a/packages/exocortex/tests/unit/services/PrototypeChainMaterializer.test.ts
+++ b/packages/exocortex/tests/unit/services/PrototypeChainMaterializer.test.ts
@@ -1,5 +1,6 @@
 import { PrototypeChainMaterializer, INFERRED_GRAPH, MAX_PROTOTYPE_DEPTH } from "../../../src/services/PrototypeChainMaterializer";
 import { NonInheritablePropertyRegistry } from "../../../src/services/NonInheritablePropertyRegistry";
+import { PropertyCardinalityRegistry } from "../../../src/services/PropertyCardinalityRegistry";
 import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
 import { Triple } from "../../../src/domain/models/rdf/Triple";
 import { IRI } from "../../../src/domain/models/rdf/IRI";
@@ -455,117 +456,152 @@ describe("PrototypeChainMaterializer", () => {
     const gtdReviewClass = new IRI("https://exocortex.my/ontology/gtd#Review");
 
     it("should inherit single Instance_class value when instance has NO own Instance_class", async () => {
-      // Prototype has one class: ems__Task
       await store.add(new Triple(breakfastProto, instanceClass, taskClass));
       await store.add(new Triple(breakfastProto, effortArea, healthArea));
-
-      // Instance links to prototype, has NO own Instance_class
       await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
 
       const count = await materializer.materialize(store);
 
-      // Instance_class is inheritable → class should be inherited
       const classTriples = await store.match(breakfastInstance, instanceClass, undefined);
       expect(classTriples.length).toBe(1);
       expect((classTriples[0].object as IRI).value).toBe(taskClass.value);
 
-      // Area should also be inherited
       const areaTriples = await store.match(breakfastInstance, effortArea, undefined);
       expect(areaTriples.length).toBe(1);
     });
 
-    // TODO: Phase 2 (RFC-016 #2639) will fix multi-valued merge.
-    // Currently, seenPredicates marks the predicate as "done" after the first
-    // inherited triple, so only 1 of N values from the same predicate is inherited.
-    it.skip("should inherit ALL Instance_class values when prototype has multiple classes (Phase 2 — #2639)", async () => {
-      // Prototype has two classes: ems__Task and gtd__Review
+    it("should skip multi-valued merge when no cardinality registry provided (backward compat)", async () => {
+      // Without cardinality registry: old behavior — only first value inherited
       await store.add(new Triple(breakfastProto, instanceClass, taskClass));
       await store.add(new Triple(breakfastProto, instanceClass, gtdReviewClass));
-
-      // Instance has NO own Instance_class
       await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
 
       await materializer.materialize(store);
 
-      // After Phase 2: instance should have BOTH classes
-      const classTriples = await store.match(breakfastInstance, instanceClass, undefined);
-      expect(classTriples.length).toBe(2);
-
-      const classValues = classTriples.map(t => (t.object as IRI).value);
-      expect(classValues).toContain(taskClass.value);
-      expect(classValues).toContain(gtdReviewClass.value);
-    });
-
-    // TODO: Phase 2 (RFC-016 #2639) will fix this.
-    // Currently, if instance has ANY own value for a predicate, the entire
-    // predicate is skipped during inheritance — even for multi-valued properties.
-    it.skip("should append inherited Instance_class values when instance has OWN partial class (Phase 2 — #2639)", async () => {
-      // Prototype has two classes: ems__Task and gtd__Review
-      await store.add(new Triple(breakfastProto, instanceClass, taskClass));
-      await store.add(new Triple(breakfastProto, instanceClass, gtdReviewClass));
-
-      // Instance has OWN Instance_class: [ems__Task] only
-      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
-      await store.add(new Triple(breakfastInstance, instanceClass, taskClass));
-
-      await materializer.materialize(store);
-
-      // After Phase 2: instance should have BOTH ems__Task (own) AND gtd__Review (inherited)
-      const classTriples = await store.match(breakfastInstance, instanceClass, undefined);
-      expect(classTriples.length).toBe(2);
-
-      const classValues = classTriples.map(t => (t.object as IRI).value);
-      expect(classValues).toContain(taskClass.value);
-      expect(classValues).toContain(gtdReviewClass.value);
-    });
-
-    it("should verify current skip: only first of multiple prototype classes is inherited", async () => {
-      // Documents CURRENT behavior — seenPredicates marks predicate after first triple
-      await store.add(new Triple(breakfastProto, instanceClass, taskClass));
-      await store.add(new Triple(breakfastProto, instanceClass, gtdReviewClass));
-
-      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
-
-      await materializer.materialize(store);
-
-      // Current: only 1 class inherited (first one processed), second is skipped
       const classTriples = await store.match(breakfastInstance, instanceClass, undefined);
       expect(classTriples.length).toBe(1);
     });
 
-    it("should verify current skip: own Instance_class blocks ALL prototype classes", async () => {
-      // Documents CURRENT behavior — own predicate blocks all inheritance
+    it("should skip own Instance_class blocking when no cardinality registry provided", async () => {
       await store.add(new Triple(breakfastProto, instanceClass, taskClass));
       await store.add(new Triple(breakfastProto, instanceClass, gtdReviewClass));
-
       await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
       await store.add(new Triple(breakfastInstance, instanceClass, taskClass));
 
       await materializer.materialize(store);
 
-      // Current: seenPredicates has Instance_class from own → ALL inherited skipped
       const classTriples = await store.match(breakfastInstance, instanceClass, undefined);
       expect(classTriples.length).toBe(1);
       expect((classTriples[0].object as IRI).value).toBe(taskClass.value);
     });
 
     it("should inherit Instance_class through depth-2 chain when instance has no own class", async () => {
-      // Chain: breakfastInstance → breakfastProto → morningProto
       await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
       await store.add(new Triple(breakfastProto, prototype, morningProto));
-
-      // morningProto (grandparent) has single Instance_class
       await store.add(new Triple(morningProto, instanceClass, gtdReviewClass));
-
-      // breakfastProto (parent) has area
       await store.add(new Triple(breakfastProto, effortArea, healthArea));
 
-      const count = await materializer.materialize(store);
+      await materializer.materialize(store);
 
-      // Instance should inherit Instance_class from grandparent (single value passes)
       const classTriples = await store.match(breakfastInstance, instanceClass, undefined);
       expect(classTriples.length).toBe(1);
       expect((classTriples[0].object as IRI).value).toBe(gtdReviewClass.value);
+    });
+  });
+
+  describe("multi-valued property merge (RFC-016 #2639)", () => {
+    const gtdReviewClass = new IRI("https://exocortex.my/ontology/gtd#Review");
+    const propertyCardinality = Namespace.EXO.term("Property_cardinality");
+    const multipleCardinalityClassIRI = new IRI("obsidian://vault/exo__PropertyCardinalityMultiple.md");
+
+    let materializerWithCardinality: PrototypeChainMaterializer;
+
+    async function setupCardinalityRegistry(): Promise<PropertyCardinalityRegistry> {
+      const cardStore = new InMemoryTripleStore();
+
+      // Define PropertyCardinalityMultiple class
+      await cardStore.add(
+        new Triple(multipleCardinalityClassIRI, assetLabel, new Literal("exo__PropertyCardinalityMultiple")),
+      );
+
+      // Mark exo__Instance_class as multi-valued
+      const instanceClassDef = new IRI("obsidian://vault/exo__Instance_class.md");
+      await cardStore.add(
+        new Triple(instanceClassDef, propertyCardinality, multipleCardinalityClassIRI),
+      );
+      await cardStore.add(
+        new Triple(instanceClassDef, assetLabel, new Literal("exo__Instance_class")),
+      );
+
+      const cardRegistry = new PropertyCardinalityRegistry();
+      await cardRegistry.initialize(cardStore);
+      return cardRegistry;
+    }
+
+    beforeEach(async () => {
+      const cardRegistry = await setupCardinalityRegistry();
+      materializerWithCardinality = new PrototypeChainMaterializer(registry, cardRegistry);
+    });
+
+    it("should inherit ALL Instance_class values when prototype has multiple classes", async () => {
+      await store.add(new Triple(breakfastProto, instanceClass, taskClass));
+      await store.add(new Triple(breakfastProto, instanceClass, gtdReviewClass));
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+
+      await materializerWithCardinality.materialize(store);
+
+      const classTriples = await store.match(breakfastInstance, instanceClass, undefined);
+      expect(classTriples.length).toBe(2);
+
+      const classValues = classTriples.map(t => (t.object as IRI).value);
+      expect(classValues).toContain(taskClass.value);
+      expect(classValues).toContain(gtdReviewClass.value);
+    });
+
+    it("should append inherited Instance_class values when instance has OWN partial class", async () => {
+      await store.add(new Triple(breakfastProto, instanceClass, taskClass));
+      await store.add(new Triple(breakfastProto, instanceClass, gtdReviewClass));
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastInstance, instanceClass, taskClass));
+
+      await materializerWithCardinality.materialize(store);
+
+      const classTriples = await store.match(breakfastInstance, instanceClass, undefined);
+      expect(classTriples.length).toBe(2);
+
+      const classValues = classTriples.map(t => (t.object as IRI).value);
+      expect(classValues).toContain(taskClass.value);
+      expect(classValues).toContain(gtdReviewClass.value);
+    });
+
+    it("should NOT duplicate values already owned by instance", async () => {
+      // Prototype has [ems__Task, gtd__Review], instance has [ems__Task]
+      await store.add(new Triple(breakfastProto, instanceClass, taskClass));
+      await store.add(new Triple(breakfastProto, instanceClass, gtdReviewClass));
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastInstance, instanceClass, taskClass));
+
+      await materializerWithCardinality.materialize(store);
+
+      // ems__Task should appear exactly once (own), gtd__Review once (inherited)
+      const classTriples = await store.match(breakfastInstance, instanceClass, undefined);
+      const taskValues = classTriples.filter(t => (t.object as IRI).value === taskClass.value);
+      expect(taskValues.length).toBe(1);
+    });
+
+    it("should preserve single-valued skip for non-multi-valued properties", async () => {
+      // effortArea is NOT multi-valued, should still use skip semantics
+      await store.add(new Triple(breakfastProto, effortArea, healthArea));
+      const vacationArea = new IRI("obsidian://vault/Vacation.md");
+      await store.add(new Triple(breakfastInstance, prototype, breakfastProto));
+      await store.add(new Triple(breakfastInstance, effortArea, vacationArea));
+
+      await materializerWithCardinality.materialize(store);
+
+      // Own value preserved, prototype value skipped
+      const areaTriples = await store.match(breakfastInstance, effortArea, undefined);
+      expect(areaTriples.length).toBe(1);
+      expect(areaTriples[0].object).toEqual(vacationArea);
     });
   });
 });

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -5,6 +5,7 @@ import {
   ApplicationErrorHandler,
   RDFSInferenceEngine,
   NonInheritablePropertyRegistry,
+  PropertyCardinalityRegistry,
   PrototypeChainMaterializer,
   INFERRED_GRAPH,
   Namespace,
@@ -238,7 +239,9 @@ export class VaultRDFIndexer {
 
     const registry = new NonInheritablePropertyRegistry();
     await registry.initialize(this.tripleStore);
-    const materializer = new PrototypeChainMaterializer(registry);
+    const cardinalityRegistry = new PropertyCardinalityRegistry();
+    await cardinalityRegistry.initialize(this.tripleStore);
+    const materializer = new PrototypeChainMaterializer(registry, cardinalityRegistry);
     await materializer.materialize(this.tripleStore);
   }
 


### PR DESCRIPTION
## Summary

- New `PropertyCardinalityRegistry` — identifies multi-valued properties (exo__PropertyCardinalityMultiple) from triple store, O(1) lookup
- Modified `PrototypeChainMaterializer` skip logic: APPEND inherited values for multi-valued predicates, SKIP for single-valued (backward compat)
- Value-level deduplication prevents duplicate triples in materialized result
- Optional constructor parameter — existing callers work unchanged (no cardinality registry = old behavior)
- Production callers updated: VaultRDFIndexer (plugin), sparql-index (CLI)

## Key behavioral change

Before: `exo__Instance_class` with own `[ems__Task]` + prototype `[ems__Task, gtd__Review]` → only `[ems__Task]` (gtd__Review lost)

After: → `[ems__Task, gtd__Review]` (gtd__Review appended from prototype)

Single-valued properties (status, label) → unchanged skip behavior.

## Test plan

- [x] 7 new PropertyCardinalityRegistry tests (multi-valued detection, empty store, missing predicate)
- [x] 4 new multi-valued merge tests (inherit all, append, no duplicates, single-valued preserved)
- [x] 4 backward-compat tests (no registry = old skip behavior)
- [x] All existing PrototypeChainMaterializer tests pass unchanged
- [x] CLI mock updated for new export
- [x] TypeScript typecheck clean, ESLint clean
- [x] BDD 100%, Archgate pass

Closes #2639