### PR TITLE
feat(core): add CREATE_INSTANCE to GroundingType and GroundingDefinition (#2642)

### DIFF
--- a/packages/exocortex/src/domain/constants/GroundingType.ts
+++ b/packages/exocortex/src/domain/constants/GroundingType.ts
@@ -14,4 +14,6 @@ export enum GroundingType {
   COMPOSITE = "composite",
   /** Delegate to a registered service by ID */
   SERVICE_CALL = "service_call",
+  /** Create a new instance file from a prototype (RFC-016) */
+  CREATE_INSTANCE = "create_instance",
 }

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -78,6 +78,12 @@ export interface GroundingDefinition {
   readonly sparqlUpdate?: string;
   /** Ordered sub-steps (for composite type) */
   readonly steps?: readonly GroundingDefinition[];
+  /** Class to instantiate (for create_instance, e.g., "gtd__InboxItem") */
+  readonly targetClass?: string;
+  /** Prototype asset IRI or UUID (for create_instance) */
+  readonly targetPrototype?: string;
+  /** Vault-relative folder path (for create_instance, e.g., "01 Inbox") */
+  readonly targetFolder?: string;
 }
 
 /**

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -446,6 +446,9 @@ export class CommandResolver {
     const targetProperty = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetProperty"));
     const targetValue = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetValue"));
     const sparqlUpdate = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_sparqlUpdate"));
+    const targetClass = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetClass"));
+    const targetPrototype = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetPrototype"));
+    const targetFolder = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetFolder"));
 
     // Load composite steps if applicable
     let steps: GroundingDefinition[] | undefined;
@@ -461,6 +464,9 @@ export class CommandResolver {
       targetValue: targetValue ?? undefined,
       sparqlUpdate: sparqlUpdate ?? undefined,
       steps,
+      targetClass: targetClass ?? undefined,
+      targetPrototype: targetPrototype ?? undefined,
+      targetFolder: targetFolder ?? undefined,
     };
   }
 

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -140,6 +140,12 @@ export class GroundingExecutor {
             userInput,
           );
 
+        case GroundingType.CREATE_INSTANCE:
+          return {
+            success: false,
+            error: "create_instance grounding not yet implemented. See RFC-016 Issue #2643.",
+          };
+
         case GroundingType.SPARQL_UPDATE:
           return {
             success: false,


### PR DESCRIPTION
## Summary

- New `GroundingType.CREATE_INSTANCE = "create_instance"` enum value
- New `GroundingDefinition` fields: `targetClass`, `targetPrototype`, `targetFolder`
- Stub case in `GroundingExecutor` (returns not-implemented error pending #2643)
- RDF parsing in `CommandResolver` for `exocmd__Grounding_targetClass/targetPrototype/targetFolder`

No executor implementation — only type and model definitions.

## Test plan

- [x] All 1220 unit tests pass (0 regressions)
- [x] TypeScript typecheck clean, ESLint clean
- [x] BDD 100%, Archgate pass

Closes #2642