### PR TITLE
feat(core): implement executeCreateInstance in GroundingExecutor (#2643)

### DIFF
--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -141,10 +141,7 @@ export class GroundingExecutor {
           );
 
         case GroundingType.CREATE_INSTANCE:
-          return {
-            success: false,
-            error: "create_instance grounding not yet implemented. See RFC-016 Issue #2643.",
-          };
+          return await this.executeCreateInstance(grounding, userInput);
 
         case GroundingType.SPARQL_UPDATE:
           return {
@@ -298,6 +295,38 @@ export class GroundingExecutor {
     }
 
     await service.execute(targetIRI, userInput);
+    return { success: true };
+  }
+
+  private async executeCreateInstance(
+    grounding: GroundingDefinition,
+    userInput?: UserInput,
+  ): Promise<ExecutionResult> {
+    if (!grounding.targetFolder) {
+      return { success: false, error: "create_instance requires targetFolder" };
+    }
+
+    const uid = globalThis.crypto.randomUUID();
+    const label = (userInput?.label as string) ?? "Untitled";
+
+    const properties: Record<string, unknown> = {
+      exo__Asset_uid: uid,
+      exo__Asset_label: label,
+    };
+
+    if (grounding.targetClass) {
+      properties.exo__Instance_class = `"[[${grounding.targetClass}]]"`;
+    }
+
+    if (grounding.targetPrototype) {
+      properties.exo__Asset_prototype = `"[[${grounding.targetPrototype}]]"`;
+    }
+
+    const content = this.frontmatterService.createFrontmatter("", properties);
+    const filePath = `${grounding.targetFolder}/${uid}.md`;
+
+    await this.fileWriter.createFile(filePath, content);
+
     return { success: true };
   }
 

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -505,4 +505,85 @@ describe("GroundingExecutor", () => {
       expect(result).toBe("plain value");
     });
   });
+
+  // -- create_instance (RFC-016 #2643) --
+
+  describe("create_instance", () => {
+    it("should create file with correct frontmatter", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "gtd__InboxItem",
+        targetPrototype: "proto-uuid-123",
+        targetFolder: "01 Inbox",
+      });
+      const userInput = { label: "Buy milk" };
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, userInput);
+
+      expect(result.success).toBe(true);
+      expect(writer.createFile).toHaveBeenCalledTimes(1);
+
+      const [path, content] = writer.createFile.mock.calls[0];
+      expect(path).toMatch(/^01 Inbox\/[a-f0-9-]+\.md$/);
+      expect(content).toContain("exo__Asset_uid:");
+      expect(content).toContain("exo__Asset_label: Buy milk");
+      expect(content).toContain("gtd__InboxItem");
+      expect(content).toContain("proto-uuid-123");
+    });
+
+    it("should generate valid UUID in filename", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "tasks",
+      });
+
+      await executor.execute(grounding, TARGET_IRI, FILE_PATH, { label: "Test" });
+
+      const [path] = writer.createFile.mock.calls[0];
+      const filename = path.split("/").pop()?.replace(".md", "");
+      expect(filename).toMatch(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/);
+    });
+
+    it("should fail when targetFolder is missing", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, { label: "Test" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("targetFolder");
+    });
+
+    it("should work without targetPrototype", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, { label: "No proto" });
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain("exo__Asset_label: No proto");
+      expect(content).not.toContain("exo__Asset_prototype");
+    });
+
+    it("should use 'Untitled' as default label when no user input", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain("exo__Asset_label: Untitled");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Implement `executeCreateInstance()` in `GroundingExecutor`
- Generates UUID, builds frontmatter (uid, label, Instance_class, Asset_prototype)
- Creates file at `targetFolder/<uuid>.md` via `IFileSystemWriter.createFile`
- 5 new unit tests covering: frontmatter content, UUID format, missing targetFolder, optional prototype, default label

## Test plan

- [x] 5 new create_instance tests pass
- [x] All existing GroundingExecutor tests pass (35 total)
- [x] All 1220 unit tests pass (0 regressions)
- [x] TypeScript typecheck clean, ESLint clean

Closes #2643