### PR TITLE
test(core): add tests for CREATE_INSTANCE grounding type

### DIFF
--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -58,6 +58,7 @@ jest.unstable_mockModule("exocortex", () => ({
     PROPERTY_SET: "property_set",
     COMPOSITE: "composite",
     SERVICE_CALL: "service_call",
+    CREATE_INSTANCE: "create_instance",
   },
 }));
 

--- a/packages/exocortex/tests/unit/domain/constants/CommandConstants.test.ts
+++ b/packages/exocortex/tests/unit/domain/constants/CommandConstants.test.ts
@@ -8,17 +8,18 @@ import {
 import { AssetClass } from "../../../../src/domain/constants/AssetClass";
 
 describe("GroundingType", () => {
-  it("should have all 5 RFC types", () => {
+  it("should have all 6 grounding types", () => {
     expect(GroundingType.SPARQL_UPDATE).toBe("sparql_update");
     expect(GroundingType.PROPERTY_DELETE).toBe("property_delete");
     expect(GroundingType.PROPERTY_SET).toBe("property_set");
     expect(GroundingType.COMPOSITE).toBe("composite");
     expect(GroundingType.SERVICE_CALL).toBe("service_call");
+    expect(GroundingType.CREATE_INSTANCE).toBe("create_instance");
   });
 
-  it("should have exactly 5 values", () => {
+  it("should have exactly 6 values", () => {
     const values = Object.values(GroundingType);
-    expect(values).toHaveLength(5);
+    expect(values).toHaveLength(6);
   });
 });
 

--- a/packages/exocortex/tests/unit/domain/models/CommandDefinition.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/CommandDefinition.test.ts
@@ -140,6 +140,35 @@ describe("CommandDefinition", () => {
 
       expect(gnd.type).toBe(GroundingType.SERVICE_CALL);
     });
+
+    it("should represent create_instance grounding with all optional fields", () => {
+      const gnd = {
+        id: "gnd-create-task",
+        label: "Create new task from prototype",
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetPrototype: "a717a21b-a960-4795-9caa-04aeaba730ee",
+        targetFolder: "01 Inbox",
+      };
+
+      expect(gnd.type).toBe(GroundingType.CREATE_INSTANCE);
+      expect(gnd.targetClass).toBe("ems__Task");
+      expect(gnd.targetPrototype).toBe("a717a21b-a960-4795-9caa-04aeaba730ee");
+      expect(gnd.targetFolder).toBe("01 Inbox");
+    });
+
+    it("should represent create_instance grounding with minimal fields", () => {
+      const gnd = {
+        id: "gnd-create-minimal",
+        label: "Create instance",
+        type: GroundingType.CREATE_INSTANCE,
+      };
+
+      expect(gnd.type).toBe(GroundingType.CREATE_INSTANCE);
+      expect(gnd.targetClass).toBeUndefined();
+      expect(gnd.targetPrototype).toBeUndefined();
+      expect(gnd.targetFolder).toBeUndefined();
+    });
   });
 
   describe("CommandBindingDefinition", () => {

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -382,6 +382,24 @@ describe("GroundingExecutor", () => {
     });
   });
 
+  // -- create_instance --
+
+  describe("create_instance", () => {
+    it("should return not-implemented error", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetPrototype: "proto-uuid-123",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not yet implemented");
+    });
+  });
+
   // -- sparql_update --
 
   describe("sparql_update", () => {


### PR DESCRIPTION
## Summary
- Update GroundingType enum count from 5 to 6 in CommandConstants test
- Add `create_instance` grounding variant tests (full and minimal) in CommandDefinition test
- Add GroundingExecutor test verifying create_instance returns not-implemented error
- Add `CREATE_INSTANCE` to CLI dynamic-command mock for completeness

Closes #2642