### PR TITLE
feat(plugin): wire create_instance grounding in Obsidian plugin adapter

### DIFF
--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -1,4 +1,5 @@
 import { injectable } from "tsyringe";
+import { v4 as uuidv4 } from "uuid";
 import type { IFileSystemReader } from "../interfaces/IFileSystemAdapter";
 import type { IFileSystemWriter } from "../interfaces/IFileSystemAdapter";
 import type { GroundingDefinition } from "../domain/models/CommandDefinition";
@@ -141,7 +142,11 @@ export class GroundingExecutor {
           );
 
         case GroundingType.CREATE_INSTANCE:
-          return await this.executeCreateInstance(grounding, userInput);
+          return await this.executeCreateInstance(
+            grounding,
+            targetIRI,
+            userInput,
+          );
 
         case GroundingType.SPARQL_UPDATE:
           return {
@@ -300,26 +305,44 @@ export class GroundingExecutor {
 
   private async executeCreateInstance(
     grounding: GroundingDefinition,
+    targetIRI: string,
     userInput?: UserInput,
   ): Promise<ExecutionResult> {
     if (!grounding.targetFolder) {
       return { success: false, error: "create_instance requires targetFolder" };
     }
 
-    const uid = globalThis.crypto.randomUUID();
+    const uid = uuidv4();
     const label = (userInput?.label as string) ?? "Untitled";
 
     const properties: Record<string, unknown> = {
       exo__Asset_uid: uid,
+      exo__Asset_createdAt: new Date().toISOString(),
       exo__Asset_label: label,
     };
 
+    if (label !== "Untitled") {
+      properties.aliases = [label];
+    }
+
     if (grounding.targetClass) {
-      properties.exo__Instance_class = `"[[${grounding.targetClass}]]"`;
+      properties.exo__Instance_class = [`"[[${grounding.targetClass}]]"`];
     }
 
     if (grounding.targetPrototype) {
       properties.exo__Asset_prototype = `"[[${grounding.targetPrototype}]]"`;
+    }
+
+    if (targetIRI) {
+      properties.exo__Asset_source = `"[[${targetIRI}]]"`;
+    }
+
+    if (userInput) {
+      for (const [key, value] of Object.entries(userInput)) {
+        if (key === "label") continue;
+        if (value === null || value === undefined) continue;
+        properties[key] = value;
+      }
     }
 
     const content = this.frontmatterService.createFrontmatter("", properties);

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -506,7 +506,7 @@ describe("GroundingExecutor", () => {
     });
   });
 
-  // -- create_instance (RFC-016 #2643) --
+  // -- create_instance (RFC-016 #2643, #2645) --
 
   describe("create_instance", () => {
     it("should create file with correct frontmatter", async () => {
@@ -586,6 +586,122 @@ describe("GroundingExecutor", () => {
       expect(content).toContain("exo__Asset_label: Untitled");
     });
 
+    it("should include exo__Asset_createdAt timestamp", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toMatch(/exo__Asset_createdAt: \d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("should include exo__Instance_class as YAML array", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain('exo__Instance_class:\n  - "[[ems__Task]]"');
+    });
+
+    it("should include exo__Asset_source linking to target asset", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(`"[[${TARGET_IRI}]]"`);
+    });
+
+    it("should add aliases when label is provided", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, { label: "My task" });
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain("aliases:\n  - My task");
+    });
+
+    it("should not add aliases for default 'Untitled' label", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).not.toContain("aliases:");
+    });
+
+    it("should pass additional userInput fields to frontmatter", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const userInput = { label: "Task", ems__Effort_status: '"[[Backlog]]"' };
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, userInput);
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain('ems__Effort_status: "[[Backlog]]"');
+    });
+
+    it("should skip null/undefined userInput values", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const userInput = { label: "Task", nullProp: null, undefProp: undefined };
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, userInput);
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).not.toContain("nullProp");
+      expect(content).not.toContain("undefProp");
+    });
+
+    it("should handle file system errors gracefully", async () => {
+      writer.createFile.mockRejectedValue(new Error("Disk full"));
+
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Disk full");
+    });
+
     // Integration test: full frontmatter verification (RFC-016 #2644)
     it("should create file with complete and correct frontmatter structure", async () => {
       const grounding = makeGrounding({
@@ -608,9 +724,11 @@ describe("GroundingExecutor", () => {
       // Verify frontmatter has all required fields
       expect(content).toMatch(/^---\n/);
       expect(content).toContain("exo__Asset_uid:");
+      expect(content).toContain("exo__Asset_createdAt:");
       expect(content).toContain("exo__Asset_label: Купить молоко");
       expect(content).toContain("gtd__InboxItem");
       expect(content).toContain("proto-daily-review-uuid");
+      expect(content).toContain(`"[[${TARGET_IRI}]]"`);
 
       // Verify UUID in path matches UUID in frontmatter
       const pathUuid = path.split("/").pop()?.replace(".md", "");


### PR DESCRIPTION
## Summary

- Enhance `executeCreateInstance` in core `GroundingExecutor` to match codebase conventions
- Replace `globalThis.crypto.randomUUID()` with `uuid` v4 (consistent with all other creation services)
- Add `exo__Asset_createdAt` timestamp to new instances
- Use YAML array format for `exo__Instance_class` (matches `GenericAssetCreationService` pattern)
- Link back to source asset via `exo__Asset_source` wikilink
- Pass additional `userInput` fields to frontmatter (not just `label`)
- Add `aliases` when label is provided (matching asset creation conventions)
- Add 8 new unit tests covering all enhanced behaviors

## Test plan

- [x] All 45 `GroundingExecutor` tests pass (30 existing + 15 `create_instance`)
- [x] Full unit suite: 1220 tests, 75 suites passing
- [x] TypeScript compilation clean (`tsc -noEmit`)
- [x] ESLint clean, BDD 100%, Archgate 13/13
- [x] Plugin-level `DynamicCommandButtonGroupBuilder` tests unaffected (24 pass)

Closes #2645