### PR TITLE
fix: handle pipe in normalizeWikilink for CommandResolver (#2688)

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -595,6 +595,8 @@ export class CommandResolver {
   }
 
   private normalizeWikilink(value: string): string {
-    return value.replace(/["'[\]]/g, "").trim();
+    const cleaned = value.replace(/["'[\]]/g, "").trim();
+    const pipeIndex = cleaned.indexOf("|");
+    return pipeIndex >= 0 ? cleaned.substring(0, pipeIndex) : cleaned;
   }
 }

--- a/packages/obsidian-plugin/tests/e2e/specs/dynamic-command-buttons-render.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/dynamic-command-buttons-render.spec.ts
@@ -42,12 +42,7 @@ test.describe("Dynamic Command Button Rendering & Functionality", () => {
     fs.writeFileSync(FIXTURE_PATH, fixtureOriginal, "utf-8");
   });
 
-  // FIXME(#2670): CommandResolver returns 0 commands despite 3 CommandBinding rdf:type
-  // triples in store. Likely value format mismatch in getLinkedValue/matchesReference:
-  // NoteToRDFConverter stores targetClass as IRI, CommandResolver expects Literal.
-  // Triple store: 317 triples, 37 rdf:type, 3 CommandBinding, 66 exocmd. All correct.
-  // Needs integration test: CommandResolver + real vault-converted triples.
-  test.fixme("renders button from RDF config and executes grounding on click", async () => {
+  test("renders button from RDF config and executes grounding on click", async () => {
     const page = await launcher.getWindow();
 
     // ── Step 1: Wait for plugin + force triple store init + diagnostics ──

--- a/packages/obsidian-plugin/tests/e2e/specs/dynamic-command-buttons-render.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/dynamic-command-buttons-render.spec.ts
@@ -73,13 +73,18 @@ test.describe("Dynamic Command Button Rendering & Functionality", () => {
       });
     }, { timeout: 10000 }).toBe("dynamic-cmd-test-with-ts.md");
 
+    // Force layout refresh — triple store was populated in Step 1,
+    // but layout may have rendered before init completed
+    await page.evaluate(() => {
+      const plugin = (window as any).app?.plugins?.plugins?.exocortex;
+      plugin?.refreshLayout?.();
+    });
+
     await page
       .locator(".exocortex-buttons-section, .exocortex-action-buttons-container")
       .first()
       .waitFor({ state: "visible", timeout: 20000 })
-      .catch(() => {
-        // Timeout is expected if no buttons section renders for this file type
-      });
+      .catch(() => {});
 
     const removeTimestampButton = page.locator(
       'button.exocortex-action-button:has-text("Remove Start Timestamp")'

--- a/packages/obsidian-plugin/tests/e2e/specs/dynamic-command-buttons-render.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/dynamic-command-buttons-render.spec.ts
@@ -45,112 +45,22 @@ test.describe("Dynamic Command Button Rendering & Functionality", () => {
   test("renders button from RDF config and executes grounding on click", async () => {
     const page = await launcher.getWindow();
 
-    // ── Step 1: Wait for plugin + force triple store init + diagnostics ──
+    // ── Step 1: Wait for plugin + force triple store init ──
 
-    const diag = await page.evaluate(async () => {
+    await page.evaluate(async () => {
       const app = (window as any).app;
       for (let i = 0; i < 20; i++) {
         if (app?.plugins?.plugins?.exocortex) break;
         await new Promise((r) => setTimeout(r, 500));
       }
       const plugin = app?.plugins?.plugins?.exocortex;
-      if (!plugin) return { error: "plugin not loaded" };
+      if (!plugin) return;
 
-      const hasSparql = !!plugin.sparql;
-      const hasResolver = !!plugin.commandResolver;
-      const hasGrounding = !!plugin.groundingExecutor;
-
-      let tripleStoreSize = -1;
-      let initError: string | null = null;
-      let queryResult: string | null = null;
-
-      // Try to force-initialize SPARQL via internal queryService
-      try {
-        const qs = (plugin.sparql as any)?.queryService;
-        if (qs && !qs.isInitialized) {
-          await qs.initialize();
-          initError = "OK";
-        } else if (qs?.isInitialized) {
-          initError = "already initialized";
-        } else {
-          initError = "no queryService found";
-        }
-      } catch (e: any) {
-        initError = `INIT ERROR: ${e.message} | cause: ${e.details?.originalError ?? "none"} | STACK: ${(e.stack || "").substring(0, 400)}`;
+      const qs = (plugin.sparql as any)?.queryService;
+      if (qs && !qs.isInitialized) {
+        await qs.initialize().catch(() => {});
       }
-
-      // Try direct triple store access (match() is async!)
-      let tsInfo: any = null;
-      try {
-        const ts = plugin.sparql?.getTripleStore?.();
-        const matchAll = await ts?.match?.(undefined, undefined, undefined);
-        const allTriples = Array.isArray(matchAll) ? matchAll : [];
-        tripleStoreSize = allTriples.length;
-        const bindingTriples = allTriples.filter((t: any) =>
-          String(t?.object?.value ?? "").includes("CommandBinding") ||
-          String(t?.predicate?.value ?? "").includes("CommandBinding")
-        );
-        const rdfTypeTriples = allTriples.filter((t: any) =>
-          String(t?.predicate?.value ?? "").includes("rdf-syntax-ns#type") ||
-          String(t?.predicate?.value ?? "").includes("/type")
-        );
-        const exocmdTriples = allTriples.filter((t: any) =>
-          String(t?.predicate?.value ?? "").includes("exocmd") ||
-          String(t?.object?.value ?? "").includes("exocmd")
-        );
-        const cmdBindingType = rdfTypeTriples.filter((t: any) =>
-          String(t?.object?.value ?? "").includes("CommandBinding")
-        );
-        const allRdfTypes = rdfTypeTriples.map((t: any) => String(t?.object?.value ?? "").split("#").pop()).filter(Boolean);
-        tsInfo = {
-          total: allTriples.length,
-          bindings: bindingTriples.length,
-          rdfTypeCount: rdfTypeTriples.length,
-          cmdBindingTypeCount: cmdBindingType.length,
-          allRdfTypeClasses: [...new Set(allRdfTypes)],
-          cmdBindingSample: cmdBindingType.slice(0, 2).map((t: any) => `s=${t?.subject?.value?.slice(-40)} o=${t?.object?.value}`),
-          exocmdCount: exocmdTriples.length,
-        };
-      } catch (e: any) {
-        tsInfo = `TS ERROR: ${e.message}`;
-      }
-
-      // Try simplest query
-      try {
-        const sparql = plugin.sparql;
-        if (sparql?.query) {
-          const r = await sparql.query("ASK { ?s ?p ?o }");
-          queryResult = JSON.stringify(r);
-        }
-      } catch (e: any) {
-        queryResult = `QUERY ERROR: ${e.message}`;
-      }
-
-
-      let resolverResult: string | null = null;
-      try {
-        if (plugin.commandResolver?.resolveForAsset) {
-          const cmds = await plugin.commandResolver.resolveForAsset(
-            "e2e-task-with-start-timestamp", "ems__Task", undefined
-          );
-          resolverResult = `found ${cmds.length} commands: ${cmds.map((c: any) => c.command?.name).join(", ")}`;
-        }
-      } catch (e: any) {
-        resolverResult = `ERROR: ${e.message}`;
-      }
-
-      const allButtons = document.querySelectorAll("button");
-      const exoButtons = document.querySelectorAll(".exocortex-action-button");
-
-      return {
-        hasSparql, hasResolver, hasGrounding,
-        tripleStoreSize, initError, tsInfo, queryResult, resolverResult,
-        allButtonsCount: allButtons.length,
-        exoButtonsCount: exoButtons.length,
-      };
     });
-
-    console.log("[DIAG] Step 1 results:", JSON.stringify(diag, null, 2));
 
     // ── Step 2: Open task WITH startTimestamp → button MUST appear ──
 


### PR DESCRIPTION
## Summary
normalizeWikilink stripped brackets but preserved pipe: `[[uid|Name]]` → `uid|Name` instead of `uid`. This caused getLinkedUID/findSubjectByUID to fail matching against Asset_uid, so CommandResolver returned 0 commands despite 3 CommandBinding rdf:type triples in store.

One-line fix: extract text before first `|`.

## Test plan
- [x] TypeScript, build, 1220 unit tests pass
- [ ] E2E: `resolverResult: "found N commands"` (was "found 0")
- [ ] E2E: button "Remove Start Timestamp" visible

Closes #2688