### PR TITLE
docs: fix Instance_class format in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Every piece of knowledge is a Markdown file with YAML frontmatter:
 ```yaml
 ---
 exo__Asset_uid: 965fd5c2-808e-4c7e-8242-e2e5d85bd996
-exo__Instance_class: ims__Concept
+exo__Instance_class:
+  - "[[ims__Concept]]"
 exo__Asset_label: "Exocortex"
 exo__Asset_relates:
   - "[[PKM]]"

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -64,7 +64,8 @@ The plugin detects new files automatically — no restart needed.
 
 ```yaml
 ---
-exo__Instance_class: ems__Area
+exo__Instance_class:
+  - "[[ems__Area]]"
 exo__Asset_label: Test Area
 ---
 ```
@@ -96,7 +97,8 @@ Areas represent broad domains of work (e.g., "Development", "Marketing", "Person
 
 ```yaml
 ---
-exo__Instance_class: ems__Area
+exo__Instance_class:
+  - "[[ems__Area]]"
 exo__Asset_label: Development
 ---
 # Development
@@ -130,7 +132,8 @@ Projects represent specific initiatives within an area.
 
 ```yaml
 ---
-exo__Instance_class: ems__Project
+exo__Instance_class:
+  - "[[ems__Project]]"
 exo__Asset_label: Build API Server
 ems__Effort_area: "[[Development]]"
 ems__Effort_status: "[[ems__EffortStatusBacklog]]"
@@ -184,7 +187,8 @@ Create `Set up Express server.md`:
 
 ```yaml
 ---
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 exo__Asset_label: Set up Express server
 ems__Effort_area: "[[Development]]"
 ems__Effort_parent: "[[Build API Server]]"
@@ -213,7 +217,8 @@ Daily notes show all tasks scheduled for a specific date.
 
 ```yaml
 ---
-exo__Instance_class: pn__DailyNote
+exo__Instance_class:
+  - "[[pn__DailyNote]]"
 exo__Asset_label: "2025-11-10"
 pn__Day_date: "2025-11-10"
 ---

--- a/docs/ONTOLOGY_EXTENSION.md
+++ b/docs/ONTOLOGY_EXTENSION.md
@@ -27,7 +27,8 @@ Ontology definitions are stored in markdown notes with frontmatter. The plugin r
 
 ```yaml
 ---
-exo__Instance_class: exo__Ontology
+exo__Instance_class:
+  - "[[exo__Ontology]]"
 exo__Ontology_url: "https://exocortex.my/ontology/ems#"
 ---
 ```
@@ -105,7 +106,8 @@ In markdown frontmatter format:
 
 ```yaml
 ---
-exo__Instance_class: rdf__Property
+exo__Instance_class:
+  - "[[rdf__Property]]"
 exo__Asset_label: "Task Priority"
 rdf__Property_domain: "[[ems__Task]]"
 rdf__Property_range: xsd:integer
@@ -208,7 +210,8 @@ To use your custom class with Exocortex commands, instances must use the class n
 
 ```yaml
 ---
-exo__Instance_class: myns__Sprint
+exo__Instance_class:
+  - "[[myns__Sprint]]"
 exo__Asset_label: "Sprint 42"
 myns__Sprint_velocity: 21
 myns__Sprint_goal: "Complete user authentication"
@@ -272,7 +275,8 @@ myns__Task_customField: "value"
 
 ```yaml
 ---
-exo__Instance_class: rdfs__Class
+exo__Instance_class:
+  - "[[rdfs__Class]]"
 exo__Asset_label: "Team"
 rdfs__subClassOf: "[[exo__Asset]]"
 rdfs__comment: "A group of people working together"
@@ -287,7 +291,8 @@ Represents a team that can be assigned to projects and tasks.
 
 ```yaml
 ---
-exo__Instance_class: rdf__Property
+exo__Instance_class:
+  - "[[rdf__Property]]"
 exo__Asset_label: "Team"
 rdf__Property_domain: "[[ems__Effort]]"
 rdf__Property_range: "[[myns__Team]]"
@@ -304,7 +309,8 @@ Assigns a team to any effort (task, project, meeting, etc.).
 
 ```yaml
 ---
-exo__Instance_class: myns__Team
+exo__Instance_class:
+  - "[[myns__Team]]"
 exo__Asset_label: "Frontend Team"
 myns__Team_memberCount: 5
 ---
@@ -318,7 +324,8 @@ The team responsible for UI development.
 
 ```yaml
 ---
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 exo__Asset_label: "Implement login form"
 ems__Effort_team: "[[Frontend Team]]"
 ems__Effort_status: "[[ems__EffortStatusToDo]]"
@@ -333,7 +340,7 @@ Before expecting your property to appear in modals:
 - [ ] Property has `rdfs:range` with recognized type
 - [ ] Property has `rdfs:label` for display name
 - [ ] Property is NOT marked `owl:deprecated true`
-- [ ] Ontology file has `exo__Instance_class: exo__Ontology`
+- [ ] Ontology file has `exo__Instance_class` with `"[[exo__Ontology]]"`
 - [ ] Default ontology is set in plugin settings
 
 ## Troubleshooting

--- a/docs/Plugin-Commands.md
+++ b/docs/Plugin-Commands.md
@@ -39,7 +39,8 @@ Commands for creating new assets.
 **Result**: Creates `tasks/task-[uid].md` with:
 ```yaml
 ---
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 exo__Asset_label: [Label]
 ems__Effort_area: "[[Area]]"
 ems__Effort_project: "[[Project]]"
@@ -89,7 +90,8 @@ ems__Effort_status: "[[ems__EffortStatusToDo]]"
 **Result**: Creates `projects/project-[uid].md` with:
 ```yaml
 ---
-exo__Instance_class: ems__Project
+exo__Instance_class:
+  - "[[ems__Project]]"
 exo__Asset_label: [Label]
 ems__Effort_area: "[[Area]]"
 ems__Effort_status: "[[ems__EffortStatusBacklog]]"
@@ -155,7 +157,8 @@ ems__Effort_status: "[[ems__EffortStatusBacklog]]"
 **Result**: Creates specialized fleeting note in `01 Inbox/` with:
 ```yaml
 ---
-exo__Instance_class: ztlk__FleetingNote
+exo__Instance_class:
+  - "[[ztlk__FleetingNote]]"
 ztlk__FleetingNote_type: "[[CBT-Diary Record]]"
 ---
 
@@ -502,7 +505,8 @@ aliases:
 
 **Updates**:
 ```yaml
-exo__Instance_class: ems__Project
+exo__Instance_class:
+  - "[[ems__Project]]"
 # Removes task-specific properties
 # Keeps area, status, label
 ```
@@ -521,7 +525,8 @@ exo__Instance_class: ems__Project
 
 **Updates**:
 ```yaml
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 # Adds task-specific properties if needed
 ```
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -17,7 +17,8 @@
 
 3. **Verify Frontmatter**: Must include `exo__Instance_class`
    ```yaml
-   exo__Instance_class: ems__Task
+   exo__Instance_class:
+     - "[[ems__Task]]"
    ```
 
 4. **Reload Layout**: Cmd/Ctrl + P → "Reload Layout"
@@ -67,7 +68,7 @@
    pn__Day_date: "2025-11-10"
    ```
 
-2. **Check Note Class**: Daily note must have `exo__Instance_class: pn__DailyNote`
+2. **Check Note Class**: Daily note must have `exo__Instance_class` with `"[[pn__DailyNote]]"`
 
 3. **Check Archive Status**: Toggle "Show Archived" if task is archived
 

--- a/docs/rdf/ExoRDF-Mapping.md
+++ b/docs/rdf/ExoRDF-Mapping.md
@@ -165,7 +165,8 @@ For each asset, the triple store generates **both** ExoRDF and RDF/RDFS triples:
 
 **Input** (Obsidian frontmatter):
 ```yaml
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 ```
 
 **Output** (RDF triples):
@@ -233,7 +234,8 @@ function constructAssetURI(asset: AssetMetadata): string {
 ```yaml
 exo__Asset_uid: 550e8400-e29b-41d4-a716-446655440000
 exo__Asset_isDefinedBy: "[[Ontology/EMS]]"
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 ```
 
 **Ontology frontmatter** (`Ontology/EMS.md`):
@@ -265,7 +267,8 @@ URI: https://exocortex.my/ontology/ems/550e8400-e29b-41d4-a716-446655440000
 ```yaml
 ---
 exo__Asset_uid: 550e8400-e29b-41d4-a716-446655440000
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 exo__Asset_label: Review PR #365
 exo__Asset_isDefinedBy: "[[Ontology/EMS]]"
 ems__Effort_status: "[[ems__EffortStatusInProgress]]"
@@ -301,7 +304,8 @@ ems__Task_size: M
 ```yaml
 ---
 exo__Asset_uid: 7c9e6679-7425-40de-944b-e07fc1f90ae7
-exo__Instance_class: ems__Project
+exo__Instance_class:
+  - "[[ems__Project]]"
 exo__Asset_label: Implement SPARQL Engine
 exo__Asset_isDefinedBy: "[[Ontology/EMS]]"
 ---
@@ -311,7 +315,8 @@ exo__Asset_isDefinedBy: "[[Ontology/EMS]]"
 ```yaml
 ---
 exo__Asset_uid: 3b241101-e2bb-4255-8caf-4136c566a964
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 ems__Effort_parent: "[[Implement SPARQL Engine]]"
 ---
 ```

--- a/docs/workflows/Area-Organization.md
+++ b/docs/workflows/Area-Organization.md
@@ -22,7 +22,8 @@ Areas represent broad domains of work:
 
 ```yaml
 ---
-exo__Instance_class: ems__Area
+exo__Instance_class:
+  - "[[ems__Area]]"
 exo__Asset_label: Development
 ---
 
@@ -35,7 +36,8 @@ All software engineering efforts.
 
 ```yaml
 ---
-exo__Instance_class: ems__Area
+exo__Instance_class:
+  - "[[ems__Area]]"
 exo__Asset_label: Frontend Development
 ems__Area_parent: "[[Development]]"
 ---
@@ -178,7 +180,8 @@ Product Line B (Area)
 
 ```yaml
 ---
-exo__Instance_class: ems__Area
+exo__Instance_class:
+  - "[[ems__Area]]"
 exo__Asset_label: [Area Name]
 ems__Area_parent: "[[Parent Area]]"  # optional
 ---

--- a/docs/workflows/Daily-Planning.md
+++ b/docs/workflows/Daily-Planning.md
@@ -12,7 +12,8 @@ Daily notes use `pn__DailyNote` class with date property:
 
 ```yaml
 ---
-exo__Instance_class: pn__DailyNote
+exo__Instance_class:
+  - "[[pn__DailyNote]]"
 exo__Asset_label: "2025-11-10"
 pn__Day_date: "2025-11-10"  # ISO format: YYYY-MM-DD
 ---
@@ -211,7 +212,8 @@ For appointments/deadlines:
 
 ```yaml
 ---
-exo__Instance_class: pn__DailyNote
+exo__Instance_class:
+  - "[[pn__DailyNote]]"
 exo__Asset_label: "YYYY-MM-DD"
 pn__Day_date: "YYYY-MM-DD"
 ---

--- a/docs/workflows/Project-Workflow.md
+++ b/docs/workflows/Project-Workflow.md
@@ -29,7 +29,8 @@ Result: `projects/project-build-api.md` created with:
 
 ```yaml
 ---
-exo__Instance_class: ems__Project
+exo__Instance_class:
+  - "[[ems__Project]]"
 exo__Asset_label: Build API Server
 ems__Effort_area: "[[Development]]"
 ems__Effort_status: "[[ems__EffortStatusBacklog]]"
@@ -44,7 +45,8 @@ REST API for mobile app.
 
 ```yaml
 ---
-exo__Instance_class: ems__Project
+exo__Instance_class:
+  - "[[ems__Project]]"
 exo__Asset_label: [Project Name]
 ems__Effort_area: "[[Area Name]]"
 ems__Effort_status: "[[ems__EffortStatusBacklog]]"
@@ -320,7 +322,8 @@ Clone for next quarter, update dates.
 ### Essential Properties
 
 ```yaml
-exo__Instance_class: ems__Project
+exo__Instance_class:
+  - "[[ems__Project]]"
 exo__Asset_label: [Name]
 ems__Effort_area: "[[Area]]"
 ems__Effort_status: "[[ems__EffortStatusBacklog]]"

--- a/docs/workflows/Task-Workflow.md
+++ b/docs/workflows/Task-Workflow.md
@@ -65,7 +65,8 @@ Create `tasks/task-build-endpoint.md`:
 
 ```yaml
 ---
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 exo__Asset_label: Build /users endpoint
 ems__Effort_area: "[[Development]]"
 ems__Effort_project: "[[Build API Server]]"
@@ -89,7 +90,8 @@ For sub-tasks, use `ems__Effort_parent`:
 
 ```yaml
 ---
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 exo__Asset_label: Write endpoint tests
 ems__Effort_area: "[[Development]]"
 ems__Effort_project: "[[Build API Server]]"
@@ -461,7 +463,8 @@ Common paths:
 Essential task frontmatter:
 ```yaml
 ---
-exo__Instance_class: ems__Task
+exo__Instance_class:
+  - "[[ems__Task]]"
 exo__Asset_label: [Task Name]
 ems__Effort_area: "[[Area Name]]"
 ems__Effort_project: "[[Project Name]]"
@@ -477,7 +480,7 @@ ems__Effort_scheduled_start_date: "YYYY-MM-DD"
 | Problem | Solution |
 |---------|----------|
 | Task not in daily note | Check `ems__Effort_scheduled_start_date` matches daily note's `pn__Day_date` |
-| Buttons don't appear | Verify `exo__Instance_class: ems__Task` |
+| Buttons don't appear | Verify `exo__Instance_class` contains `"[[ems__Task]]"` |
 | Status won't change | Check for typos in status wiki-link |
 | Task disappeared | Check if accidentally archived (`exo__Asset_archived: true`) |
 


### PR DESCRIPTION
## Summary
- Fixed `exo__Instance_class` in README "Asset — The Unit of Knowledge" example to use wikilink array format (`- "[[ims__Concept]]"`) instead of plain string (`ims__Concept`)
- This matches the actual format used by the system for class references

## Test plan
- [ ] Verify README renders correctly on GitHub