### PR TITLE
docs: fix starter-kit link and property name mismatches

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -51,10 +51,11 @@ BRAT will automatically keep the plugin updated with new releases.
 
 The plugin needs ontology files in your vault to enable buttons and commands. Download and extract the Starter Kit:
 
-1. Go to the [latest GitHub Release](https://github.com/kitelev/exocortex/releases/latest)
+1. Go to the [Starter Kit Release](https://github.com/kitelev/exocortex-starter-kit/releases/latest)
 2. Download `exocortex-starter-kit.zip`
 3. Extract the ZIP into your vault (any folder works — the plugin scans the entire vault)
    - Recommended: extract into a folder like `Knowledge/` or at the vault root
+   - The ZIP contains `exocmd/` (command definitions) and `pn/` (DailyNote properties)
 
 The plugin detects new files automatically — no restart needed.
 
@@ -220,7 +221,7 @@ Daily notes show all tasks scheduled for a specific date.
 exo__Instance_class:
   - "[[pn__DailyNote]]"
 exo__Asset_label: "2025-11-10"
-pn__Day_date: "2025-11-10"
+pn__DailyNote_day: "2025-11-10"
 ---
 # 2025-11-10
 
@@ -350,7 +351,7 @@ Discover all commands:
 | `ems__Effort_parent`                | Parent project/task | `"[[Build API Server]]"`                                  |
 | `ems__Effort_status`                | Workflow status     | `"[[ems__EffortStatusToDo]]"`                             |
 | `ems__Effort_plannedStartTimestamp` | Planned start date  | `"2025-11-10"`                                            |
-| `pn__Day_date`                      | Daily note date     | `"2025-11-10"`                                            |
+| `pn__DailyNote_day`                 | Daily note date     | `"2025-11-10"`                                            |
 
 ### Common Commands
 
@@ -365,13 +366,13 @@ Discover all commands:
 
 ### Troubleshooting
 
-| Problem                  | Solution                                                                                |
-| ------------------------ | --------------------------------------------------------------------------------------- |
-| Layout doesn't appear    | Switch to Reading Mode (Ctrl/Cmd + E)                                                   |
-| No buttons visible       | Verify Starter Kit is installed (exocmd/ folder exists in vault)                        |
-| Buttons don't work       | Check console for errors (Ctrl/Cmd + Shift + I)                                         |
-| Wiki-links not resolving | Verify target note exists with correct `exo__Asset_label`                               |
-| Daily tasks not showing  | Check task has `ems__Effort_plannedStartTimestamp` matching daily note's `pn__Day_date` |
+| Problem                  | Solution                                                                                     |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| Layout doesn't appear    | Switch to Reading Mode (Ctrl/Cmd + E)                                                        |
+| No buttons visible       | Verify Starter Kit is installed (exocmd/ folder exists in vault)                             |
+| Buttons don't work       | Check console for errors (Ctrl/Cmd + Shift + I)                                              |
+| Wiki-links not resolving | Verify target note exists with correct `exo__Asset_label`                                    |
+| Daily tasks not showing  | Check task has `ems__Effort_plannedStartTimestamp` matching daily note's `pn__DailyNote_day` |
 
 ---
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -16,6 +16,7 @@
 2. **Check Plugin Enabled**: Settings → Community plugins → Exocortex (ON)
 
 3. **Verify Frontmatter**: Must include `exo__Instance_class`
+
    ```yaml
    exo__Instance_class:
      - "[[ems__Task]]"
@@ -59,13 +60,14 @@
 
 **Solutions**:
 
-1. **Check Date Match**: Task's `ems__Effort_scheduled_start_date` must match daily note's `pn__Day_date`
+1. **Check Date Match**: Task's `ems__Effort_plannedStartTimestamp` must match daily note's `pn__DailyNote_day`
+
    ```yaml
    # Task
-   ems__Effort_scheduled_start_date: "2025-11-10"
+   ems__Effort_plannedStartTimestamp: "2025-11-10"
 
    # Daily Note
-   pn__Day_date: "2025-11-10"
+   pn__DailyNote_day: "2025-11-10"
    ```
 
 2. **Check Note Class**: Daily note must have `exo__Instance_class` with `"[[pn__DailyNote]]"`
@@ -83,6 +85,7 @@
 **Solutions**:
 
 1. **Check Status Format**: Must be wiki-link format
+
    ```yaml
    ems__Effort_status: "[[ems__EffortStatusToDo]]"  # Correct
    ems__Effort_status: "ToDo"  # Wrong
@@ -149,6 +152,7 @@
    - Use Cmd/Ctrl + G (local graph) or "Open graph view" command
 
 3. **Check Label Property**: Notes must have `exo__Asset_label` in frontmatter
+
    ```yaml
    exo__Asset_label: "My Project"
    ```
@@ -168,9 +172,10 @@
 **Problem**: Wikilinks inside markdown tables display raw UUIDs while links in regular paragraphs show labels.
 
 **Example**:
+
 ```markdown
-| Link | Shows UUID? |
-|------|-------------|
+| Link          | Shows UUID?   |
+| ------------- | ------------- |
 | [[uuid-here]] | ❌ Shows UUID |
 
 But [[uuid-here]] in text shows label correctly ✅
@@ -209,12 +214,14 @@ But [[uuid-here]] in text shows label correctly ✅
 **Solutions**:
 
 1. **Clean Install**:
+
    ```bash
    rm -rf node_modules package-lock.json
    npm install
    ```
 
 2. **Check Node Version**: Requires Node.js 18+
+
    ```bash
    node --version  # Should be v18+
    ```
@@ -233,6 +240,7 @@ But [[uuid-here]] in text shows label correctly ✅
 ---
 
 **See also:**
+
 - [Getting Started Guide](Getting-Started.md)
 - [Plugin Commands](Plugin-Commands.md)
 - [SPARQL Troubleshooting](sparql/User-Guide.md#troubleshooting)

--- a/docs/workflows/Daily-Planning.md
+++ b/docs/workflows/Daily-Planning.md
@@ -15,9 +15,8 @@ Daily notes use `pn__DailyNote` class with date property:
 exo__Instance_class:
   - "[[pn__DailyNote]]"
 exo__Asset_label: "2025-11-10"
-pn__Day_date: "2025-11-10"  # ISO format: YYYY-MM-DD
+pn__DailyNote_day: "2025-11-10" # ISO format: YYYY-MM-DD
 ---
-
 # 2025-11-10
 
 Today's focus: [Add notes here]
@@ -35,8 +34,9 @@ Today's focus: [Add notes here]
 2. Click **"Plan on Today"** button
 
 Updates task frontmatter:
+
 ```yaml
-ems__Effort_scheduled_start_date: "2025-11-10"
+ems__Effort_plannedStartTimestamp: "2025-11-10"
 ```
 
 ### Viewing Daily Tasks
@@ -44,6 +44,7 @@ ems__Effort_scheduled_start_date: "2025-11-10"
 Open daily note in Reading Mode:
 
 **Daily Tasks Section shows:**
+
 - All tasks scheduled for this date
 - Grouped by area
 - Sorted by project
@@ -58,6 +59,7 @@ Set focus to show only specific area's tasks:
 3. Daily Tasks section filters to that area only
 
 Clear focus:
+
 1. Click **"Set Focus Area"** again
 2. Select "(No focus)" option
 
@@ -68,12 +70,14 @@ Clear focus:
 ### Using Arrow Buttons
 
 From daily note or task note:
+
 - **◀ Shift Day Backward**: Reschedule to previous day
 - **▶ Shift Day Forward**: Reschedule to next day
 
 ### Bulk Rescheduling
 
 To move multiple tasks:
+
 1. Open each task from daily note
 2. Click shift buttons
 3. Tasks move to new date
@@ -88,7 +92,7 @@ Schedule tasks for specific time:
 2. Task scheduled to today at 18:00
 
 ```yaml
-ems__Effort_scheduled_start_date: "2025-11-10"
+ems__Effort_plannedStartTimestamp: "2025-11-10"
 ems__Session_scheduled_start_time: "18:00"
 ```
 
@@ -133,11 +137,13 @@ ems__Session_scheduled_start_time: "18:00"
 **Healthy daily load: 4-8 tasks**
 
 Too many (>10):
+
 - Overcommitted
 - Reschedule lower priority
 - Break tasks into smaller units
 
 Too few (<3):
+
 - Add more tasks from backlog
 - May need better task breakdown
 
@@ -149,14 +155,17 @@ Add time blocks in daily note content:
 ## Schedule
 
 **Morning (9:00-12:00)**
+
 - [[Build /users endpoint]]
 - [[Write API tests]]
 
 **Afternoon (13:00-17:00)**
+
 - [[Deploy to staging]]
 - [[Code review]]
 
 **Evening (18:00-20:00)**
+
 - [[Update documentation]]
 ```
 
@@ -177,6 +186,7 @@ Daily notes can show/hide archived tasks:
 ### Pattern 1: Weekly Planning
 
 Sunday evening:
+
 ```markdown
 1. Create daily notes for week (Mon-Fri)
 2. Review backlog tasks
@@ -187,6 +197,7 @@ Sunday evening:
 ### Pattern 2: Sprint Planning
 
 Start of sprint:
+
 ```markdown
 1. Create daily notes for sprint duration
 2. Distribute sprint tasks across days
@@ -197,6 +208,7 @@ Start of sprint:
 ### Pattern 3: Time-Specific Work
 
 For appointments/deadlines:
+
 ```markdown
 1. Use "Plan for Evening" for time-specific work
 2. Add time notes in task content:
@@ -215,7 +227,7 @@ For appointments/deadlines:
 exo__Instance_class:
   - "[[pn__DailyNote]]"
 exo__Asset_label: "YYYY-MM-DD"
-pn__Day_date: "YYYY-MM-DD"
+pn__DailyNote_day: "YYYY-MM-DD"
 ---
 
 # YYYY-MM-DD
@@ -229,12 +241,12 @@ pn__Day_date: "YYYY-MM-DD"
 
 ### Common Commands
 
-| Action | Command |
-|--------|---------|
-| Plan task | "Plan on Today" button |
-| Shift forward | ▶ button |
-| Shift backward | ◀ button |
-| Set focus area | "Set Focus Area" button |
+| Action          | Command                         |
+| --------------- | ------------------------------- |
+| Plan task       | "Plan on Today" button          |
+| Shift forward   | ▶ button                        |
+| Shift backward  | ◀ button                        |
+| Set focus area  | "Set Focus Area" button         |
 | Toggle archived | "Toggle Archived Assets" button |
 
 ---

--- a/docs/workflows/Project-Workflow.md
+++ b/docs/workflows/Project-Workflow.md
@@ -35,7 +35,6 @@ exo__Asset_label: Build API Server
 ems__Effort_area: "[[Development]]"
 ems__Effort_status: "[[ems__EffortStatusBacklog]]"
 ---
-
 # Build API Server
 
 REST API for mobile app.
@@ -77,6 +76,7 @@ Draft → Backlog → Analysis → ToDo → Doing → Done
 ```
 
 Same as tasks, but:
+
 - **Backlog**: Awaiting resource allocation
 - **Analysis**: Defining scope, tasks, timeline
 - **ToDo**: Ready to start (tasks created)
@@ -85,14 +85,14 @@ Same as tasks, but:
 
 ### Typical Duration
 
-| Status | Duration | Percentage Complete |
-|--------|----------|---------------------|
-| Draft | 1-7 days | 0% |
-| Backlog | Weeks to months | 0% |
-| Analysis | 1-5 days | 0-10% |
-| ToDo | Days to weeks | 10-20% |
-| Doing | Weeks to months | 20-95% |
-| Done | Permanent | 100% |
+| Status   | Duration        | Percentage Complete |
+| -------- | --------------- | ------------------- |
+| Draft    | 1-7 days        | 0%                  |
+| Backlog  | Weeks to months | 0%                  |
+| Analysis | 1-5 days        | 0-10%               |
+| ToDo     | Days to weeks   | 10-20%              |
+| Doing    | Weeks to months | 20-95%              |
+| Done     | Permanent       | 100%                |
 
 ---
 
@@ -109,10 +109,12 @@ Same as tasks, but:
 **Good project = 5-15 tasks**
 
 Too few tasks (<3):
+
 - May not need project structure
 - Consider converting to single task
 
 Too many tasks (>20):
+
 - Break into milestones
 - Create multiple projects
 - Group related tasks
@@ -140,6 +142,7 @@ Build API Server (Project)
 Exocortex doesn't auto-calculate progress. Track manually:
 
 **Option 1: Checklist in content**
+
 ```markdown
 ## Progress
 
@@ -153,11 +156,13 @@ Exocortex doesn't auto-calculate progress. Track manually:
 ```
 
 **Option 2: Add progress property**
+
 ```yaml
 ems__Effort_progress_percentage: 40
 ```
 
 **Option 3: Count completed tasks**
+
 - 3 / 8 tasks done = 37.5% complete
 
 ### Project Dashboard
@@ -165,12 +170,14 @@ ems__Effort_progress_percentage: 40
 View project status from project note:
 
 **Asset Relations section shows:**
+
 - All child tasks
 - Status of each task
 - Vote counts
 - Scheduled dates
 
 **Sort by status** to see:
+
 - What's done
 - What's in progress
 - What's blocked
@@ -180,10 +187,11 @@ View project status from project note:
 Schedule entire project to daily note:
 
 ```yaml
-ems__Effort_scheduled_start_date: "2025-11-10"
+ems__Effort_plannedStartTimestamp: "2025-11-10"
 ```
 
 **Daily Projects section shows:**
+
 - Project and all its tasks
 - Task statuses
 - Quick access to start tasks
@@ -195,6 +203,7 @@ ems__Effort_scheduled_start_date: "2025-11-10"
 ### Completion Criteria
 
 Project is done when:
+
 - [ ] All tasks completed or archived
 - [ ] Deliverables met
 - [ ] Documentation updated
@@ -214,11 +223,13 @@ Project is done when:
 **Tasks**: 8 completed, 2 archived (out of scope)
 
 ### Outcomes
+
 - API deployed to production
 - 95% test coverage
 - Documentation published
 
 ### Lessons Learned
+
 - Authentication took longer than expected
 - Should have split user/post endpoints into separate stories
 ```
@@ -236,11 +247,13 @@ Project is done when:
 ### Project Naming
 
 **Good:**
+
 - "Build Mobile App"
 - "Migrate to Kubernetes"
 - "Launch Marketing Campaign Q4"
 
 **Bad:**
+
 - "Project 1" (not descriptive)
 - "Do stuff" (vague)
 - "Fix things" (use task instead)
@@ -248,12 +261,14 @@ Project is done when:
 ### Project Scope
 
 **Clear scope indicators:**
+
 - Specific objective
 - Defined deliverables
 - Measurable success criteria
 - Time-bounded (even if flexible)
 
 **Scope creep warning signs:**
+
 - Tasks keep getting added
 - No clear completion criteria
 - "One more feature" syndrome
@@ -328,18 +343,18 @@ exo__Asset_label: [Name]
 ems__Effort_area: "[[Area]]"
 ems__Effort_status: "[[ems__EffortStatusBacklog]]"
 ems__Effort_votes: 0
-ems__Effort_scheduled_start_date: "YYYY-MM-DD"  # optional
+ems__Effort_plannedStartTimestamp: "YYYY-MM-DD" # optional
 ```
 
 ### Common Commands
 
-| Action | Command/Button |
-|--------|----------------|
+| Action         | Command/Button                      |
+| -------------- | ----------------------------------- |
 | Create project | Area note → "Create Project" button |
-| Create task | Project note → "Create Task" button |
-| Change status | Status buttons or Command Palette |
-| Vote | "Vote" button |
-| Schedule | "Plan on Today" button |
+| Create task    | Project note → "Create Task" button |
+| Change status  | Status buttons or Command Palette   |
+| Vote           | "Vote" button                       |
+| Schedule       | "Plan on Today" button              |
 
 ---
 

--- a/docs/workflows/Task-Workflow.md
+++ b/docs/workflows/Task-Workflow.md
@@ -29,14 +29,14 @@ Archive                                   Archive
 
 ### Status Descriptions
 
-| Status | Purpose | Typical Duration | Next Actions |
-|--------|---------|------------------|--------------|
-| **Draft** | Initial idea, not committed | Hours to days | Move to Backlog or Archive |
-| **Backlog** | Committed work, awaiting analysis | Days to weeks | Move to Analysis |
-| **Analysis** | Being planned and scoped | Hours to days | Move to ToDo |
-| **ToDo** | Ready to start, prioritized | Days to weeks | Plan on specific day, Start Effort |
-| **Doing** | Actively working | Hours to days | Mark Done |
-| **Done** | Completed | Permanent | Archive (optional) |
+| Status       | Purpose                           | Typical Duration | Next Actions                       |
+| ------------ | --------------------------------- | ---------------- | ---------------------------------- |
+| **Draft**    | Initial idea, not committed       | Hours to days    | Move to Backlog or Archive         |
+| **Backlog**  | Committed work, awaiting analysis | Days to weeks    | Move to Analysis                   |
+| **Analysis** | Being planned and scoped          | Hours to days    | Move to ToDo                       |
+| **ToDo**     | Ready to start, prioritized       | Days to weeks    | Plan on specific day, Start Effort |
+| **Doing**    | Actively working                  | Hours to days    | Mark Done                          |
+| **Done**     | Completed                         | Permanent        | Archive (optional)                 |
 
 ---
 
@@ -101,6 +101,7 @@ ems__Effort_status: "[[ems__EffortStatusToDo]]"
 ```
 
 **Use cases for sub-tasks:**
+
 - Breaking large tasks into steps
 - Dependencies between tasks
 - Tracking sub-components
@@ -113,20 +114,21 @@ ems__Effort_status: "[[ems__EffortStatusToDo]]"
 
 Buttons appear contextually based on current status:
 
-| Current Status | Available Buttons |
-|----------------|-------------------|
-| Draft | Set Draft Status, Move to Backlog, Archive |
-| Backlog | Move to Analysis, Archive |
-| Analysis | Move to ToDo, Move to Backlog |
-| ToDo | Start Effort (→ Doing), Move to Analysis |
-| Doing | Mark Done, Move to ToDo |
-| Done | Archive |
+| Current Status | Available Buttons                          |
+| -------------- | ------------------------------------------ |
+| Draft          | Set Draft Status, Move to Backlog, Archive |
+| Backlog        | Move to Analysis, Archive                  |
+| Analysis       | Move to ToDo, Move to Backlog              |
+| ToDo           | Start Effort (→ Doing), Move to Analysis   |
+| Doing          | Mark Done, Move to ToDo                    |
+| Done           | Archive                                    |
 
 **Click button → Status updates automatically → Timestamp recorded**
 
 ### Using Command Palette
 
 Cmd/Ctrl + P → Type status command:
+
 - "Set Draft Status"
 - "Move to Backlog"
 - "Move to Analysis"
@@ -159,6 +161,7 @@ ems__Effort_status_changes:
 ```
 
 **Use timestamps to:**
+
 - Analyze time-in-status
 - Track work duration
 - Generate velocity metrics
@@ -173,8 +176,9 @@ ems__Effort_status_changes:
 2. Click **"Plan on Today"** button
 
 Result:
+
 ```yaml
-ems__Effort_scheduled_start_date: "2025-11-10"
+ems__Effort_plannedStartTimestamp: "2025-11-10"
 ```
 
 Task now appears in `2025-11-10.md` daily note's **Daily Tasks** section.
@@ -184,14 +188,16 @@ Task now appears in `2025-11-10.md` daily note's **Daily Tasks** section.
 1. Click **"Plan for Evening"** button
 
 Result:
+
 ```yaml
-ems__Effort_scheduled_start_date: "2025-11-10"
+ems__Effort_plannedStartTimestamp: "2025-11-10"
 ems__Session_scheduled_start_time: "18:00"
 ```
 
 ### Shifting Days
 
 Use arrow buttons to reschedule:
+
 - **◀ Shift Day Backward**: Moves task to previous day
 - **▶ Shift Day Forward**: Moves task to next day
 
@@ -213,6 +219,7 @@ Use arrow buttons to reschedule:
 2. Click **"Start Effort"** button
 
 Changes:
+
 ```yaml
 ems__Effort_status: "[[ems__EffortStatusDoing]]"
 ems__Effort_started_on: "2025-11-10T09:30:00Z"
@@ -228,10 +235,12 @@ Add progress notes in the task content:
 ## Progress Log
 
 ### 2025-11-10 09:30
+
 - Set up Express router
 - Implemented GET /users
 
 ### 2025-11-10 11:00
+
 - Implemented POST /users
 - Added validation
 ```
@@ -239,12 +248,14 @@ Add progress notes in the task content:
 ### Pausing Work
 
 If you need to pause:
+
 1. Click "Move to ToDo" (returns to ready-to-start state)
 2. Add note in content explaining why paused
 
 ### Switching Tasks
 
 No special action needed:
+
 - Start new task (click "Start Effort" on different task)
 - Both tasks show as "Doing" until completed
 - Use timestamps to track actual work time
@@ -259,6 +270,7 @@ No special action needed:
 2. Click **"Mark Done"** button
 
 Changes:
+
 ```yaml
 ems__Effort_status: "[[ems__EffortStatusDone]]"
 ems__Effort_completed_on: "2025-11-10T14:15:00Z"
@@ -267,6 +279,7 @@ ems__Effort_completed_on: "2025-11-10T14:15:00Z"
 ### Verification Checklist
 
 Before marking done:
+
 - [ ] All acceptance criteria met
 - [ ] Sub-tasks completed (if any)
 - [ ] Documentation updated
@@ -275,6 +288,7 @@ Before marking done:
 ### Post-Completion
 
 After marking done:
+
 - Task still appears in relations
 - Task appears in daily note (if scheduled)
 - Use "Archive" to hide from active views (optional)
@@ -286,6 +300,7 @@ After marking done:
 ### When to Archive
 
 Archive tasks that are:
+
 - Completed and no longer need visibility
 - Cancelled/abandoned efforts
 - Duplicates or mistakes
@@ -296,11 +311,13 @@ Archive tasks that are:
 2. Click **"Archive"** button
 
 Changes:
+
 ```yaml
 exo__Asset_archived: true
 ```
 
 Archived tasks:
+
 - Hidden from daily note by default (toggle with "Show Archived")
 - Hidden from relations (unless explicitly shown)
 - Still searchable in Obsidian
@@ -308,6 +325,7 @@ Archived tasks:
 ### Trashing a Task
 
 For permanent removal:
+
 1. Click **"Trash"** button
 2. Confirm deletion
 3. Task moved to Obsidian trash
@@ -317,6 +335,7 @@ For permanent removal:
 ### Bulk Cleanup
 
 Use "Clean Properties" command to:
+
 - Remove empty properties
 - Format inconsistent values
 - Fix malformed wiki-links
@@ -328,11 +347,13 @@ Use "Clean Properties" command to:
 ### Task Naming
 
 **Good names:**
+
 - "Build /users REST endpoint"
 - "Fix login redirect bug"
 - "Write getting-started documentation"
 
 **Bad names:**
+
 - "Task 1" (not descriptive)
 - "Do the thing" (vague)
 - "Fix bug" (which bug?)
@@ -342,22 +363,26 @@ Use "Clean Properties" command to:
 **Ideal task duration: 2-6 hours**
 
 Too large (>8 hours):
+
 - Break into sub-tasks
 - Convert to project if multi-day
 
 Too small (<30 minutes):
+
 - Combine with related tasks
 - Consider checklist instead
 
 ### Status Discipline
 
 **Do:**
+
 - ✅ Move tasks through statuses consistently
 - ✅ Use buttons/commands (not manual edits)
 - ✅ Keep tasks in appropriate status
 - ✅ Archive completed tasks regularly
 
 **Don't:**
+
 - ❌ Skip Analysis for complex tasks
 - ❌ Leave tasks in "Doing" overnight
 - ❌ Keep hundreds of "Done" tasks unarchived
@@ -366,12 +391,14 @@ Too small (<30 minutes):
 ### Daily Planning
 
 **Morning routine:**
+
 1. Open today's daily note
 2. Review planned tasks
 3. Adjust priorities (vote/re-order)
 4. Start first task
 
 **Evening routine:**
+
 1. Mark completed tasks as "Done"
 2. Reschedule incomplete tasks (◀ / ▶)
 3. Archive finished tasks
@@ -380,11 +407,13 @@ Too small (<30 minutes):
 ### Sub-Task Management
 
 **When to use sub-tasks:**
+
 - Task > 8 hours effort
 - Clear sequential dependencies
 - Different skill sets required
 
 **When NOT to use:**
+
 - Simple checklists (use markdown lists instead)
 - Parallel work (create separate tasks)
 - Micro-management (trust yourself!)
@@ -396,6 +425,7 @@ Too small (<30 minutes):
 ### Pattern 1: Backlog Grooming
 
 Weekly review of backlog:
+
 ```markdown
 1. Open area note
 2. Review all "Backlog" tasks in relations
@@ -407,6 +437,7 @@ Weekly review of backlog:
 ### Pattern 2: Sprint Planning
 
 Plan tasks for week/sprint:
+
 ```markdown
 1. Filter tasks by "ToDo" status
 2. Vote to prioritize
@@ -418,6 +449,7 @@ Plan tasks for week/sprint:
 ### Pattern 3: Blocked Task
 
 Handle dependencies:
+
 ```markdown
 1. Move task to "Analysis"
 2. Add blocking reason in content:
@@ -429,6 +461,7 @@ Handle dependencies:
 ### Pattern 4: Recurring Tasks
 
 For weekly/monthly tasks:
+
 ```markdown
 1. Create template task
 2. Clone task for each occurrence
@@ -442,12 +475,12 @@ For weekly/monthly tasks:
 
 ### Keyboard Shortcuts
 
-| Action | Shortcut |
-|--------|----------|
-| Command palette | Cmd/Ctrl + P |
-| Switch to Reading Mode | Cmd/Ctrl + E |
-| Quick switcher | Cmd/Ctrl + O |
-| Search | Cmd/Ctrl + Shift + F |
+| Action                 | Shortcut             |
+| ---------------------- | -------------------- |
+| Command palette        | Cmd/Ctrl + P         |
+| Switch to Reading Mode | Cmd/Ctrl + E         |
+| Quick switcher         | Cmd/Ctrl + O         |
+| Search                 | Cmd/Ctrl + Shift + F |
 
 ### Status Transitions
 
@@ -461,6 +494,7 @@ Common paths:
 ### Property Quick Copy
 
 Essential task frontmatter:
+
 ```yaml
 ---
 exo__Instance_class:
@@ -469,7 +503,7 @@ exo__Asset_label: [Task Name]
 ems__Effort_area: "[[Area Name]]"
 ems__Effort_project: "[[Project Name]]"
 ems__Effort_status: "[[ems__EffortStatusToDo]]"
-ems__Effort_scheduled_start_date: "YYYY-MM-DD"
+ems__Effort_plannedStartTimestamp: "YYYY-MM-DD"
 ---
 ```
 
@@ -477,12 +511,12 @@ ems__Effort_scheduled_start_date: "YYYY-MM-DD"
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| Task not in daily note | Check `ems__Effort_scheduled_start_date` matches daily note's `pn__Day_date` |
-| Buttons don't appear | Verify `exo__Instance_class` contains `"[[ems__Task]]"` |
-| Status won't change | Check for typos in status wiki-link |
-| Task disappeared | Check if accidentally archived (`exo__Asset_archived: true`) |
+| Problem                | Solution                                                                           |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| Task not in daily note | Check `ems__Effort_plannedStartTimestamp` matches daily note's `pn__DailyNote_day` |
+| Buttons don't appear   | Verify `exo__Instance_class` contains `"[[ems__Task]]"`                            |
+| Status won't change    | Check for typos in status wiki-link                                                |
+| Task disappeared       | Check if accidentally archived (`exo__Asset_archived: true`)                       |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix starter-kit download link: `exocortex/releases/latest` → `exocortex-starter-kit/releases/latest`
- Replace `pn__Day_date` → `pn__DailyNote_day` across all docs (5 occurrences in 4 files)
- Replace `ems__Effort_scheduled_start_date` → `ems__Effort_plannedStartTimestamp` across all docs (10 occurrences in 4 files)
- Add description of zip contents to Getting-Started.md Step 2

Starter-kit release v1.0.0 created: https://github.com/kitelev/exocortex-starter-kit/releases/tag/v1.0.0

Closes #2708
Closes #2709

## Test plan
- [x] `npm run test:all` passes (unit + BDD 100% + archgate + component)
- [x] `grep -r 'pn__Day_date' docs/` → 0 results
- [x] `grep -r 'ems__Effort_scheduled_start_date' docs/` → 0 results
- [x] `grep -r 'exocortex/releases/latest' docs/` → 0 results (old link removed)
- [x] Starter-kit release v1.0.0 exists with `exocortex-starter-kit.zip` asset