### PR TITLE
feat: log Notice messages to developer console

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/di/ObsidianNotificationService.ts
+++ b/packages/obsidian-plugin/src/infrastructure/di/ObsidianNotificationService.ts
@@ -5,18 +5,22 @@ export class ObsidianNotificationService implements INotificationService {
   private readonly DEFAULT_DURATION = 4000;
 
   info(message: string, duration?: number): void {
+    console.debug("[Exocortex] info:", message);
     new Notice(message, duration || this.DEFAULT_DURATION);
   }
 
   success(message: string, duration?: number): void {
+    console.debug("[Exocortex] success:", message);
     new Notice(`✓ ${message}`, duration || this.DEFAULT_DURATION);
   }
 
   error(message: string, duration?: number): void {
+    console.error("[Exocortex] error:", message);
     new Notice(`✗ ${message}`, duration || this.DEFAULT_DURATION);
   }
 
   warn(message: string, duration?: number): void {
+    console.warn("[Exocortex] warn:", message);
     new Notice(`⚠ ${message}`, duration || this.DEFAULT_DURATION);
   }
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianNotificationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianNotificationService.test.ts
@@ -10,7 +10,14 @@ describe("ObsidianNotificationService", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(console, "debug").mockImplementation();
+    jest.spyOn(console, "error").mockImplementation();
+    jest.spyOn(console, "warn").mockImplementation();
     service = new ObsidianNotificationService();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe("info", () => {
@@ -18,6 +25,12 @@ describe("ObsidianNotificationService", () => {
       service.info("Information message");
 
       expect(Notice).toHaveBeenCalledWith("Information message", 4000);
+    });
+
+    it("should log to console", () => {
+      service.info("Information message");
+
+      expect(console.debug).toHaveBeenCalledWith("[Exocortex] info:", "Information message");
     });
 
     it("should use custom duration when provided", () => {
@@ -40,6 +53,12 @@ describe("ObsidianNotificationService", () => {
       expect(Notice).toHaveBeenCalledWith("✓ Operation completed", 4000);
     });
 
+    it("should log to console", () => {
+      service.success("Operation completed");
+
+      expect(console.debug).toHaveBeenCalledWith("[Exocortex] success:", "Operation completed");
+    });
+
     it("should use custom duration when provided", () => {
       service.success("Operation completed", 3000);
 
@@ -54,6 +73,12 @@ describe("ObsidianNotificationService", () => {
       expect(Notice).toHaveBeenCalledWith("✗ An error occurred", 4000);
     });
 
+    it("should log to console.error", () => {
+      service.error("An error occurred");
+
+      expect(console.error).toHaveBeenCalledWith("[Exocortex] error:", "An error occurred");
+    });
+
     it("should use custom duration when provided", () => {
       service.error("An error occurred", 8000);
 
@@ -66,6 +91,12 @@ describe("ObsidianNotificationService", () => {
       service.warn("Warning message");
 
       expect(Notice).toHaveBeenCalledWith("⚠ Warning message", 4000);
+    });
+
+    it("should log to console.warn", () => {
+      service.warn("Warning message");
+
+      expect(console.warn).toHaveBeenCalledWith("[Exocortex] warn:", "Warning message");
     });
 
     it("should use custom duration when provided", () => {


### PR DESCRIPTION
## Summary
- Add console logging to `ObsidianNotificationService` so all Notice messages persist in dev tools
- `info`/`success` → `console.debug`, `error` → `console.error`, `warn` → `console.warn`
- All messages prefixed with `[Exocortex]` for easy filtering

Closes #2721

## Test plan
- [x] Unit tests for all 4 methods verify console output
- [x] BDD coverage 100%
- [x] Archgate pass