### PR TITLE
fix: reverse-map IRI to Obsidian property names in grounding executor

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -443,8 +443,8 @@ export class CommandResolver {
     const type = this.resolveGroundingType(typeStr);
     if (!type) return null;
 
-    const targetProperty = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetProperty"));
-    const targetValue = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetValue"));
+    const targetProperty = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetProperty"));
+    const targetValue = await this.getObsidianWikilinkValue(subject, Namespace.EXOCMD.term("Grounding_targetValue"));
     const sparqlUpdate = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_sparqlUpdate"));
     const targetClass = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetClass"));
     const targetPrototype = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetPrototype"));
@@ -579,18 +579,59 @@ export class CommandResolver {
     const obj = triples[0].object;
     if (obj instanceof Literal) return this.normalizeWikilink(obj.value);
     if (obj instanceof IRI) {
-      // Extract local name from IRI (e.g., ems#Task → ems__Task)
-      const hash = obj.value.lastIndexOf("#");
-      if (hash >= 0) {
-        const ns = obj.value.substring(0, hash + 1);
-        const local = obj.value.substring(hash + 1);
-        // Reverse namespace resolution
-        if (ns === Namespace.EMS.iri.value) return `ems__${local}`;
-        if (ns === Namespace.EXO.iri.value) return `exo__${local}`;
-        if (ns === Namespace.EXOCMD.iri.value) return `exocmd__${local}`;
-      }
-      return obj.value;
+      return this.iriToObsidianName(obj.value) ?? obj.value;
     }
+    return null;
+  }
+
+  /**
+   * Reverse-map an IRI to Obsidian-style property name (e.g., ems__Effort_status).
+   * Falls back to getLiteralValue for Literal objects.
+   */
+  private async getObsidianName(subject: IRI, predicate: IRI): Promise<string | null> {
+    const triples = await this.tripleStore.match(subject, predicate, undefined);
+    if (triples.length === 0) return null;
+
+    const obj = triples[0].object;
+    if (obj instanceof Literal) return obj.value;
+    if (obj instanceof IRI) return this.iriToObsidianName(obj.value) ?? obj.value;
+    return null;
+  }
+
+  /**
+   * Read a grounding target value, converting IRIs back to wikilink format.
+   * Literal values are returned as-is (they already contain wikilink syntax).
+   */
+  private async getObsidianWikilinkValue(subject: IRI, predicate: IRI): Promise<string | null> {
+    const triples = await this.tripleStore.match(subject, predicate, undefined);
+    if (triples.length === 0) return null;
+
+    const obj = triples[0].object;
+    if (obj instanceof Literal) return obj.value;
+    if (obj instanceof IRI) {
+      const name = this.iriToObsidianName(obj.value);
+      return name ? `"[[${name}]]"` : obj.value;
+    }
+    return null;
+  }
+
+  private iriToObsidianName(iri: string): string | null {
+    const hash = iri.lastIndexOf("#");
+    if (hash >= 0) {
+      const ns = iri.substring(0, hash + 1);
+      const local = iri.substring(hash + 1);
+      if (ns === Namespace.EMS.iri.value) return `ems__${local}`;
+      if (ns === Namespace.EXO.iri.value) return `exo__${local}`;
+      if (ns === Namespace.EXOCMD.iri.value) return `exocmd__${local}`;
+      if (ns === Namespace.IMS.iri.value) return `ims__${local}`;
+      if (ns === Namespace.ZTLK.iri.value) return `ztlk__${local}`;
+      if (ns === Namespace.PTMS.iri.value) return `ptms__${local}`;
+      if (ns === Namespace.LIT.iri.value) return `lit__${local}`;
+      if (ns === Namespace.INBOX.iri.value) return `inbox__${local}`;
+    }
+    // Handle obsidian:// vault URLs (e.g., obsidian://vault/ems/ems__EffortStatusDoing.md)
+    const obsMatch = iri.match(/\/([^/]+)\.md$/);
+    if (obsMatch) return obsMatch[1];
     return null;
   }
 

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -260,6 +260,33 @@ describe("CommandResolver", () => {
       expect(cmd!.grounding.targetProperty).toBe("ems__Effort_status");
     });
 
+    it("should reverse-map IRI targetProperty and targetValue to Obsidian names", async () => {
+      // Simulate what happens when the triple store resolves vault references to IRIs
+      const groundingSubject = new IRI(`obsidian://vault/gnd-iri.md`);
+      await store.addAll([
+        new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-iri")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("IRI Grounding")),
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("property_set")),
+        // targetProperty stored as IRI instead of Literal
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_targetProperty"), Namespace.EMS.term("Effort_status")),
+        // targetValue stored as IRI instead of Literal
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_targetValue"), Namespace.EMS.term("EffortStatusDoing")),
+      ]);
+
+      await addCommandAsset(store, {
+        uid: "cmd-iri-test",
+        label: "IRI Test",
+        groundingRef: "gnd-iri",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-iri-test");
+
+      expect(cmd!.grounding).toBeDefined();
+      expect(cmd!.grounding.targetProperty).toBe("ems__Effort_status");
+      expect(cmd!.grounding.targetValue).toBe("\"[[ems__EffortStatusDoing]]\"");
+    });
+
     it("should return null for missing UID", async () => {
       const cmd = await resolver.loadCommand("non-existent");
       expect(cmd).toBeNull();


### PR DESCRIPTION
## Summary
- `CommandResolver.loadGroundingDefinition()` used `getLiteralValue()` for targetProperty/targetValue which returned raw IRIs when the triple store resolved vault references
- New `getObsidianName()` and `getObsidianWikilinkValue()` reverse-map IRIs back to Obsidian-style names
- Extracted `iriToObsidianName()` helper covering all 8 ontology namespaces + obsidian:// URLs
- Refactored `getLinkedValue()` to use the shared helper (DRY)

Closes #2725

## Test plan
- [x] New test: IRI targetProperty/targetValue reverse-mapped correctly
- [x] All 32 CommandResolver tests pass
- [x] BDD 100%, archgate pass
- [ ] E2E: click "Set Status Doing" button → frontmatter shows `ems__Effort_status: "[[ems__EffortStatusDoing]]"`