### PR TITLE
fix: FileLogChannel does not create log file on cold start

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -105,6 +105,7 @@ export default class ExocortexPlugin extends Plugin {
       // Initialize notification service and log channel routing
       this.notifier = new ObsidianNotificationService();
       this.fileLogChannel = new FileLogChannel(this.app.vault.adapter);
+      await this.fileLogChannel.ensureFileExists();
       this.configureLogChannels();
 
       this.printNameRuleService = new PrintNameRuleService(this.app);

--- a/packages/obsidian-plugin/src/adapters/logging/FileLogChannel.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/FileLogChannel.ts
@@ -9,8 +9,29 @@ const LOG_FILE_NAME = "exocortex-logs.txt";
 export class FileLogChannel {
   private buffer: string[] = [];
   private flushScheduled = false;
+  private fileReady = false;
 
   constructor(private readonly adapter: DataAdapter) {}
+
+  /**
+   * Ensure the log file exists on disk. Must be called once at startup
+   * before any log lines are flushed.
+   *
+   * Obsidian's DataAdapter.append() silently no-ops when the target file
+   * does not exist (resolves without error), so we cannot rely on a
+   * catch-and-create fallback inside flush().
+   */
+  async ensureFileExists(): Promise<void> {
+    try {
+      const exists = await this.adapter.exists(LOG_FILE_NAME);
+      if (!exists) {
+        await this.adapter.write(LOG_FILE_NAME, "");
+      }
+      this.fileReady = true;
+    } catch {
+      // Best-effort — flush() will retry via write() if needed
+    }
+  }
 
   append(level: string, context: string, message: string): void {
     const timestamp = new Date().toISOString();
@@ -31,12 +52,17 @@ export class FileLogChannel {
     this.buffer = [];
     this.flushScheduled = false;
     if (!lines) return;
-    // Fire-and-forget — logging should never block the caller
-    void this.adapter.append(LOG_FILE_NAME, lines).catch(() => {
-      // If file doesn't exist yet, create it then append
-      void this.adapter.write(LOG_FILE_NAME, lines).catch(() => {
-        // Silently fail — we can't log a logging failure
+
+    if (this.fileReady) {
+      void this.adapter.append(LOG_FILE_NAME, lines).catch(() => {
+        // Silently fail — file may have been deleted mid-session
       });
-    });
+    } else {
+      // File was not pre-created (ensureFileExists failed or was not called).
+      // Write creates the file; subsequent flushes will use append.
+      void this.adapter.write(LOG_FILE_NAME, lines)
+        .then(() => { this.fileReady = true; })
+        .catch(() => { /* Silently fail */ });
+    }
   }
 }

--- a/packages/obsidian-plugin/tests/unit/FileLogChannel.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FileLogChannel.test.ts
@@ -2,84 +2,126 @@ import { FileLogChannel } from "../../src/adapters/logging/FileLogChannel";
 
 describe("FileLogChannel", () => {
   let channel: FileLogChannel;
-  let mockAdapter: { append: jest.Mock; write: jest.Mock };
+  let mockAdapter: { append: jest.Mock; write: jest.Mock; exists: jest.Mock };
 
   beforeEach(() => {
     mockAdapter = {
       append: jest.fn().mockResolvedValue(undefined),
       write: jest.fn().mockResolvedValue(undefined),
+      exists: jest.fn().mockResolvedValue(false),
     };
     channel = new FileLogChannel(mockAdapter as any);
   });
 
-  it("should append log lines to the log file via adapter", async () => {
-    channel.append("info", "TestCtx", "Hello world");
+  describe("ensureFileExists", () => {
+    it("should create the log file when it does not exist", async () => {
+      mockAdapter.exists.mockResolvedValue(false);
 
-    // Wait for microtask flush
-    await flushMicrotasks();
+      await channel.ensureFileExists();
 
-    expect(mockAdapter.append).toHaveBeenCalledTimes(1);
-    const writtenLine = mockAdapter.append.mock.calls[0][1] as string;
-    expect(writtenLine).toContain("[INFO]");
-    expect(writtenLine).toContain("[TestCtx]");
-    expect(writtenLine).toContain("Hello world");
-    expect(writtenLine).toMatch(/^\[\d{4}-\d{2}-\d{2}T/);
-    expect(writtenLine).toEndWith("\n");
-    expect(mockAdapter.append.mock.calls[0][0]).toBe("exocortex-logs.txt");
+      expect(mockAdapter.exists).toHaveBeenCalledWith("exocortex-logs.txt");
+      expect(mockAdapter.write).toHaveBeenCalledWith("exocortex-logs.txt", "");
+    });
+
+    it("should not overwrite the log file when it already exists", async () => {
+      mockAdapter.exists.mockResolvedValue(true);
+
+      await channel.ensureFileExists();
+
+      expect(mockAdapter.exists).toHaveBeenCalledWith("exocortex-logs.txt");
+      expect(mockAdapter.write).not.toHaveBeenCalled();
+    });
+
+    it("should not throw when exists check fails", async () => {
+      mockAdapter.exists.mockRejectedValue(new Error("EPERM"));
+
+      await expect(channel.ensureFileExists()).resolves.toBeUndefined();
+    });
   });
 
-  it("should batch multiple appends in the same tick", async () => {
-    channel.append("debug", "A", "Line 1");
-    channel.append("warn", "B", "Line 2");
-    channel.append("error", "C", "Line 3");
+  describe("flush after ensureFileExists", () => {
+    beforeEach(async () => {
+      mockAdapter.exists.mockResolvedValue(false);
+      await channel.ensureFileExists();
+      mockAdapter.write.mockClear();
+    });
 
-    await flushMicrotasks();
+    it("should append log lines via adapter.append", async () => {
+      channel.append("info", "TestCtx", "Hello world");
 
-    expect(mockAdapter.append).toHaveBeenCalledTimes(1);
-    const combined = mockAdapter.append.mock.calls[0][1] as string;
-    expect(combined).toContain("[DEBUG]");
-    expect(combined).toContain("[WARN]");
-    expect(combined).toContain("[ERROR]");
-    expect(combined.split("\n").filter(Boolean)).toHaveLength(3);
+      await flushMicrotasks();
+
+      expect(mockAdapter.append).toHaveBeenCalledTimes(1);
+      const writtenLine = mockAdapter.append.mock.calls[0][1] as string;
+      expect(writtenLine).toContain("[INFO]");
+      expect(writtenLine).toContain("[TestCtx]");
+      expect(writtenLine).toContain("Hello world");
+      expect(writtenLine).toMatch(/^\[\d{4}-\d{2}-\d{2}T/);
+      expect(writtenLine).toEndWith("\n");
+      expect(mockAdapter.append.mock.calls[0][0]).toBe("exocortex-logs.txt");
+    });
+
+    it("should batch multiple appends in the same tick", async () => {
+      channel.append("debug", "A", "Line 1");
+      channel.append("warn", "B", "Line 2");
+      channel.append("error", "C", "Line 3");
+
+      await flushMicrotasks();
+
+      expect(mockAdapter.append).toHaveBeenCalledTimes(1);
+      const combined = mockAdapter.append.mock.calls[0][1] as string;
+      expect(combined).toContain("[DEBUG]");
+      expect(combined).toContain("[WARN]");
+      expect(combined).toContain("[ERROR]");
+      expect(combined.split("\n").filter(Boolean)).toHaveLength(3);
+    });
+
+    it("should format log lines with ISO timestamp", async () => {
+      channel.append("warn", "MyService", "Something happened");
+
+      await flushMicrotasks();
+
+      const line = mockAdapter.append.mock.calls[0][1] as string;
+      const isoMatch = line.match(/^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\]/);
+      expect(isoMatch).not.toBeNull();
+    });
   });
 
-  it("should fallback to write when append fails (file does not exist)", async () => {
-    mockAdapter.append.mockRejectedValueOnce(new Error("ENOENT"));
+  describe("flush without ensureFileExists (fallback path)", () => {
+    it("should use write to create the file on first flush", async () => {
+      channel.append("info", "Ctx", "First write");
 
-    channel.append("info", "Ctx", "First write");
+      await flushMicrotasks();
 
-    await flushMicrotasks();
-    // Allow error handler promise to resolve
-    await flushMicrotasks();
+      expect(mockAdapter.write).toHaveBeenCalledTimes(1);
+      const writtenLine = mockAdapter.write.mock.calls[0][1] as string;
+      expect(writtenLine).toContain("First write");
+    });
 
-    expect(mockAdapter.write).toHaveBeenCalledTimes(1);
-    const writtenLine = mockAdapter.write.mock.calls[0][1] as string;
-    expect(writtenLine).toContain("First write");
-  });
+    it("should switch to append after successful write", async () => {
+      channel.append("info", "Ctx", "First");
+      await flushMicrotasks();
+      // Let the write promise resolve and set fileReady
+      await flushMicrotasks();
 
-  it("should silently handle write failure", async () => {
-    mockAdapter.append.mockRejectedValueOnce(new Error("ENOENT"));
-    mockAdapter.write.mockRejectedValueOnce(new Error("EPERM"));
+      mockAdapter.write.mockClear();
+      channel.append("info", "Ctx", "Second");
+      await flushMicrotasks();
 
-    // Should not throw
-    channel.append("error", "Ctx", "Fail silently");
+      expect(mockAdapter.append).toHaveBeenCalledTimes(1);
+      expect(mockAdapter.write).not.toHaveBeenCalled();
+    });
 
-    await flushMicrotasks();
-    await flushMicrotasks();
+    it("should silently handle write failure", async () => {
+      mockAdapter.write.mockRejectedValueOnce(new Error("EPERM"));
 
-    expect(mockAdapter.append).toHaveBeenCalledTimes(1);
-    expect(mockAdapter.write).toHaveBeenCalledTimes(1);
-  });
+      channel.append("error", "Ctx", "Fail silently");
 
-  it("should format log lines with ISO timestamp", async () => {
-    channel.append("warn", "MyService", "Something happened");
+      await flushMicrotasks();
+      await flushMicrotasks();
 
-    await flushMicrotasks();
-
-    const line = mockAdapter.append.mock.calls[0][1] as string;
-    // ISO 8601 format check
-    const isoMatch = line.match(/^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\]/);
-    expect(isoMatch).not.toBeNull();
+      expect(mockAdapter.write).toHaveBeenCalledTimes(1);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- FileLogChannel relied on `DataAdapter.append()` rejecting when the target file doesn't exist, but Obsidian's append silently no-ops (resolves without error) for missing files
- Added `ensureFileExists()` that creates `exocortex-logs.txt` at startup if it doesn't exist
- Added fallback `write()` path in `flush()` when `ensureFileExists()` was not called or failed
- Updated tests: 9 cases covering init, fallback, and batching paths

Closes #2729

## Test plan

- [x] Unit tests pass (9 FileLogChannel tests)
- [x] Full test suite passes (1244 tests)
- [x] Build succeeds
- [x] TypeScript type-check passes
- [x] BDD coverage 100%, archgate passes
- [ ] Manual: enable file logging in settings → reload Obsidian → verify `exocortex-logs.txt` created