### PR TITLE
fix: normalize IRI property names and values in FrontmatterService

### DIFF
--- a/packages/exocortex/src/utilities/FrontmatterService.ts
+++ b/packages/exocortex/src/utilities/FrontmatterService.ts
@@ -125,6 +125,10 @@ export class FrontmatterService {
    * ```
    */
   updateProperty(content: string, property: string, value: unknown): string {
+    property = FrontmatterService.normalizeIRI(property);
+    if (typeof value === "string") {
+      value = FrontmatterService.normalizeIRIValue(value);
+    }
     const parsed = this.parse(content);
     const serialized = this.serializeValue(property, value);
 
@@ -231,6 +235,51 @@ export class FrontmatterService {
    */
   hasProperty(frontmatterContent: string, property: string): boolean {
     return frontmatterContent.includes(`${property}:`);
+  }
+
+  /** Namespace IRI → Obsidian property name prefix map */
+  private static readonly IRI_PREFIX_MAP: Record<string, string> = {
+    "https://exocortex.my/ontology/ems#": "ems__",
+    "https://exocortex.my/ontology/exo#": "exo__",
+    "https://exocortex.my/ontology/exocmd#": "exocmd__",
+    "https://exocortex.my/ontology/ims#": "ims__",
+    "https://exocortex.my/ontology/ztlk#": "ztlk__",
+    "https://exocortex.my/ontology/ptms#": "ptms__",
+    "https://exocortex.my/ontology/lit#": "lit__",
+    "https://exocortex.my/ontology/inbox#": "inbox__",
+  };
+
+  /**
+   * Reverse-map a full IRI property name to Obsidian-style name.
+   * E.g. "https://exocortex.my/ontology/ems#Effort_status" → "ems__Effort_status"
+   * Non-IRI values pass through unchanged.
+   */
+  static normalizeIRI(property: string): string {
+    const hash = property.lastIndexOf("#");
+    if (hash < 0) return property;
+    const ns = property.substring(0, hash + 1);
+    const local = property.substring(hash + 1);
+    const prefix = FrontmatterService.IRI_PREFIX_MAP[ns];
+    return prefix ? prefix + local : property;
+  }
+
+  /**
+   * Reverse-map an IRI value to wikilink format.
+   * E.g. "obsidian://vault/ems/ems__EffortStatusDoing.md" → "\"[[ems__EffortStatusDoing]]\""
+   * Non-IRI and non-obsidian:// values pass through unchanged.
+   */
+  static normalizeIRIValue(value: string): string {
+    // Handle obsidian:// vault URLs
+    const obsMatch = value.match(/^obsidian:\/\/vault\/.*\/([^/]+)\.md$/);
+    if (obsMatch) {
+      return `"[[${obsMatch[1]}]]"`;
+    }
+    // Handle full ontology IRIs as values
+    const normalized = FrontmatterService.normalizeIRI(value);
+    if (normalized !== value) {
+      return `"[[${normalized}]]"`;
+    }
+    return value;
   }
 
   /**

--- a/packages/exocortex/tests/utilities/FrontmatterService.test.ts
+++ b/packages/exocortex/tests/utilities/FrontmatterService.test.ts
@@ -678,4 +678,51 @@ Body`;
       expect(result).toBe('---\nfoo: bar\nstatus: "[[StatusDone]]"\n---\nBody');
     });
   });
+
+  describe("IRI normalization", () => {
+    it("should normalize IRI property name to Obsidian-style", () => {
+      expect(FrontmatterService.normalizeIRI("https://exocortex.my/ontology/ems#Effort_status"))
+        .toBe("ems__Effort_status");
+    });
+
+    it("should normalize all known namespace IRIs", () => {
+      expect(FrontmatterService.normalizeIRI("https://exocortex.my/ontology/exo#Asset_label")).toBe("exo__Asset_label");
+      expect(FrontmatterService.normalizeIRI("https://exocortex.my/ontology/exocmd#Command_icon")).toBe("exocmd__Command_icon");
+      expect(FrontmatterService.normalizeIRI("https://exocortex.my/ontology/ims#Concept_domain")).toBe("ims__Concept_domain");
+      expect(FrontmatterService.normalizeIRI("https://exocortex.my/ontology/ztlk#FleetingNote")).toBe("ztlk__FleetingNote");
+    });
+
+    it("should pass through non-IRI property names", () => {
+      expect(FrontmatterService.normalizeIRI("ems__Effort_status")).toBe("ems__Effort_status");
+      expect(FrontmatterService.normalizeIRI("foo_bar")).toBe("foo_bar");
+    });
+
+    it("should normalize obsidian:// vault URL to wikilink", () => {
+      expect(FrontmatterService.normalizeIRIValue("obsidian://vault/ems/ems__EffortStatusDoing.md"))
+        .toBe('"[[ems__EffortStatusDoing]]"');
+    });
+
+    it("should normalize ontology IRI value to wikilink", () => {
+      expect(FrontmatterService.normalizeIRIValue("https://exocortex.my/ontology/ems#EffortStatusDoing"))
+        .toBe('"[[ems__EffortStatusDoing]]"');
+    });
+
+    it("should pass through normal values", () => {
+      expect(FrontmatterService.normalizeIRIValue('"[[ems__EffortStatusDoing]]"')).toBe('"[[ems__EffortStatusDoing]]"');
+      expect(FrontmatterService.normalizeIRIValue("2025-11-10")).toBe("2025-11-10");
+    });
+
+    it("should update property correctly when given IRI key and value", () => {
+      const content = '---\nems__Effort_status: "[[ems__EffortStatusToDo]]"\n---\nBody';
+      const result = service.updateProperty(
+        content,
+        "https://exocortex.my/ontology/ems#Effort_status",
+        "obsidian://vault/ems/ems__EffortStatusDoing.md",
+      );
+
+      expect(result).toContain('ems__Effort_status: "[[ems__EffortStatusDoing]]"');
+      expect(result).not.toContain("https://");
+      expect(result).not.toContain("obsidian://");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Defensive fix at the write point: `FrontmatterService.updateProperty()` now normalizes IRI property names and values before writing to frontmatter.

- IRI key: `https://exocortex.my/ontology/ems#Effort_status` → `ems__Effort_status`
- IRI value: `obsidian://vault/ems/ems__EffortStatusDoing.md` → `"[[ems__EffortStatusDoing]]"`
- Covers all 8 ontology namespaces (ems, exo, exocmd, ims, ztlk, ptms, lit, inbox)

Closes #2725

## Root cause

`NoteToRDFConverter.isClassReference()` treats any `ems__` prefixed string as a class reference and expands it to a full IRI in the triple store. When grounding definitions are read back and executed through any code path, the IRI propagates to `FrontmatterService` which fails to match the existing Obsidian-style property name — adding a duplicate IRI key instead of updating the existing property.

## Test plan

- [x] 7 new unit tests for `normalizeIRI`, `normalizeIRIValue`, and end-to-end `updateProperty` with IRI inputs
- [x] All 84 FrontmatterService tests pass
- [x] Full test suite (4628 tests) passes
- [x] BDD 100%, archgate pass
- [x] Node.js verification script confirms IRI→Obsidian normalization
- [ ] E2E: "Set Status Doing" button writes `ems__Effort_status: "[[ems__EffortStatusDoing]]"` (no IRI)