### PR TITLE
fix: resolve UUID Instance_class to exo__Asset_label for layout rendering

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/helpers/AssetMetadataService.ts
@@ -93,15 +93,27 @@ export class AssetMetadataService {
 
   extractInstanceClass(metadata: MetadataRecord): string {
     const instanceClass = metadata.exo__Instance_class || "";
-    if (Array.isArray(instanceClass)) {
-      const firstClass = instanceClass[0] || "";
-      return String(firstClass)
-        .replace(/^\[\[|\]\]$/g, "")
-        .trim();
+    const raw = Array.isArray(instanceClass)
+      ? String(instanceClass[0] || "")
+      : String(instanceClass);
+
+    // Strip wikilink brackets: [[target|alias]] → target|alias, or [[target]] → target
+    const stripped = raw.replace(/^\[\[|\]\]$/g, "").trim();
+    if (!stripped) return "";
+
+    // Extract link target (before |) — may be UUID or human-readable name
+    const linkTarget = stripped.includes("|")
+      ? stripped.split("|")[0].trim()
+      : stripped;
+
+    // If linkTarget looks like a UUID, resolve to exo__Asset_label via metadata cache
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(linkTarget)) {
+      const label = this.getAssetLabel(linkTarget);
+      if (label) return label;
     }
-    return String(instanceClass)
-      .replace(/^\[\[|\]\]$/g, "")
-      .trim();
+
+    // Fallback: return as-is (backward compatible with [[ems__Area]] format)
+    return linkTarget;
   }
 
   /**


### PR DESCRIPTION
## Summary

`extractInstanceClass()` now handles `[[UUID|alias]]` wikilinks from UUID-ified starter-kit. When the link target is a UUID, resolves it to `exo__Asset_label` via Obsidian metadata cache. Falls back to raw value for backward compatibility with `[[ems__Area]]` format.

**Phase 0** of RFC: Eliminate hardcoded AssetClass (`[[78cb7050-e05c-41c9-afdc-c152a9664632]]`)

## Problem

After starter-kit PR #9 (UUID rename), `exo__Instance_class` contains `[[82c74542-...|ems__Area]]` instead of `[[ems__Area]]`. The old `extractInstanceClass()` stripped brackets but didn't handle `UUID|alias` format, returning `82c74542-...|ems__Area` which failed comparison with `AssetClass.AREA = "ems__Area"`. Result: layout didn't render.

## Test plan
- [x] Build passes, BDD 100%, archgate clean
- [ ] E2E: Test Area with `[[UUID|ems__Area]]` renders layout with COMMANDS