### PR TITLE
fix: use ExoQLQueryExecutor to support ASK queries in triple store init

### DIFF
--- a/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
+++ b/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
@@ -3,11 +3,10 @@ import {
   ExoQLParser,
   ExoQLAlgebraTranslator,
   AlgebraOptimizer,
-  BGPExecutor,
+  ExoQLQueryExecutor,
   type SPARQLQuery,
   type SolutionMapping,
   type AlgebraOperation,
-  type BGPOperation,
   ValidationError,
   ServiceError,
   ApplicationErrorHandler,
@@ -22,7 +21,7 @@ export class SPARQLQueryService {
   private parser: ExoQLParser;
   private translator: ExoQLAlgebraTranslator;
   private optimizer: AlgebraOptimizer;
-  private executor: BGPExecutor | null = null;
+  private executor: ExoQLQueryExecutor | null = null;
   private isInitialized = false;
   private errorHandler: ApplicationErrorHandler;
   private logger: ILogger;
@@ -72,7 +71,7 @@ export class SPARQLQueryService {
       );
 
       const tripleStore = this.indexer.getTripleStore();
-      this.executor = new BGPExecutor(tripleStore);
+      this.executor = new ExoQLQueryExecutor(tripleStore);
 
       this.isInitialized = true;
     } catch (error) {
@@ -110,13 +109,13 @@ export class SPARQLQueryService {
       let algebra: AlgebraOperation = this.translator.translate(ast);
       algebra = this.optimizer.optimize(algebra);
 
-      const resultIterator = this.executor.execute(algebra as BGPOperation);
-      const results: SolutionMapping[] = [];
-      for await (const mapping of resultIterator) {
-        results.push(mapping);
+      // ASK queries return boolean, not solution mappings
+      if (this.executor.isAskQuery(algebra)) {
+        await this.executor.executeAsk(algebra);
+        return [];
       }
 
-      return results;
+      return await this.executor.executeAll(algebra);
     } catch (error) {
       if (error instanceof ServiceError) {
         this.errorHandler.handle(error);


### PR DESCRIPTION
## Summary

- **Root cause**: `SPARQLQueryService` used `BGPExecutor` directly, which only handles BGP operations. When the plugin sends `ASK { ?s ?p ?o }` on startup to eagerly initialize the triple store, `BGPExecutor.execute()` receives an `AskOperation` (which has `where`, not `triples`), causing `TypeError: Cannot read properties of undefined (reading 'length')` — surfaced as "Failed to eagerly initialize triple store" Notice.
- **Fix**: Replace `BGPExecutor` with `ExoQLQueryExecutor` which properly handles all SPARQL operation types (ASK, SELECT, CONSTRUCT, FILTER, JOIN, UNION, etc.) via its switch-based `execute()` method. ASK queries are detected via `isAskQuery()` and executed via `executeAsk()` before reaching the generic `execute()` path.
- **Bonus**: This also fixes a latent issue where SELECT queries with FILTER, JOIN, OPTIONAL, UNION were force-cast to `BGPOperation` and would fail silently.

## Test plan

- [x] `SPARQLQueryService.test.ts` — 14 tests pass
- [x] `SPARQLQueryService.error.test.ts` — 26 tests pass
- [x] Full unit test suite — 1244 tests pass
- [x] Build succeeds
- [x] ESLint clean
- [x] BDD 100%
- [x] Archgate clean

Fixes #2736