### PR TITLE
feat: enable file logging by default for all log levels

### DIFF
--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -47,10 +47,10 @@ export type LogLevel = "debug" | "info" | "warn" | "error";
 export type LogChannelsSettings = Record<LogLevel, LogChannelConfig>;
 
 export const DEFAULT_LOG_CHANNELS: LogChannelsSettings = {
-  debug: { notice: false, console: true, file: false },
-  info: { notice: false, console: true, file: false },
-  warn: { notice: true, console: true, file: false },
-  error: { notice: true, console: true, file: false },
+  debug: { notice: false, console: true, file: true },
+  info: { notice: false, console: true, file: true },
+  warn: { notice: true, console: true, file: true },
+  error: { notice: true, console: true, file: true },
 };
 
 export interface ExocortexSettings {

--- a/packages/obsidian-plugin/tests/unit/LogChannelSettings.test.ts
+++ b/packages/obsidian-plugin/tests/unit/LogChannelSettings.test.ts
@@ -13,26 +13,26 @@ describe("LogChannelSettings", () => {
       expect(DEFAULT_LOG_CHANNELS).toHaveProperty("error");
     });
 
-    it("should default debug to console only", () => {
-      expect(DEFAULT_LOG_CHANNELS.debug).toEqual({ notice: false, console: true, file: false });
+    it("should default debug to console + file", () => {
+      expect(DEFAULT_LOG_CHANNELS.debug).toEqual({ notice: false, console: true, file: true });
     });
 
-    it("should default info to console only", () => {
-      expect(DEFAULT_LOG_CHANNELS.info).toEqual({ notice: false, console: true, file: false });
+    it("should default info to console + file", () => {
+      expect(DEFAULT_LOG_CHANNELS.info).toEqual({ notice: false, console: true, file: true });
     });
 
-    it("should default warn to notice + console", () => {
-      expect(DEFAULT_LOG_CHANNELS.warn).toEqual({ notice: true, console: true, file: false });
+    it("should default warn to notice + console + file", () => {
+      expect(DEFAULT_LOG_CHANNELS.warn).toEqual({ notice: true, console: true, file: true });
     });
 
-    it("should default error to notice + console", () => {
-      expect(DEFAULT_LOG_CHANNELS.error).toEqual({ notice: true, console: true, file: false });
+    it("should default error to notice + console + file", () => {
+      expect(DEFAULT_LOG_CHANNELS.error).toEqual({ notice: true, console: true, file: true });
     });
 
-    it("should not enable file channel by default for any level", () => {
+    it("should enable file channel by default for all levels", () => {
       const levels = Object.keys(DEFAULT_LOG_CHANNELS) as (keyof LogChannelsSettings)[];
       for (const level of levels) {
-        expect(DEFAULT_LOG_CHANNELS[level].file).toBe(false);
+        expect(DEFAULT_LOG_CHANNELS[level].file).toBe(true);
       }
     });
   });


### PR DESCRIPTION
## Summary

- Enable `file: true` for all log levels in `DEFAULT_LOG_CHANNELS`
- Update tests to match new defaults

## Motivation

Fresh installs produce no `exocortex-logs.txt` → impossible to debug startup failures like #2736. Users following Getting Started Guide have zero diagnostics.

Existing users with saved `data.json` are not affected — their persisted config takes precedence over defaults.

## Test plan

- [x] Unit tests updated and passing
- [x] Build passes
- [x] BDD 100%, archgate passes

Closes #2737