### PR TITLE
fix: CommandResolver.matchesReference handles UUID|alias format

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -346,7 +346,24 @@ export class CommandResolver {
     // Normalize both sides: remove wikilink brackets, quotes, extract UID
     const normalized = this.normalizeWikilink(bindingValue);
     const normalizedTarget = this.normalizeWikilink(target);
-    return normalized === normalizedTarget;
+    if (normalized === normalizedTarget) return true;
+
+    // Cross-match aliases: when one side is UUID|alias and the other is just alias,
+    // the UUID part won't match the alias. Try matching against the alias part too.
+    // Issue #2740
+    const targetAlias = this.extractAlias(target);
+    if (targetAlias && normalized === targetAlias) return true;
+
+    const bindingAlias = this.extractAlias(bindingValue);
+    if (bindingAlias && bindingAlias === normalizedTarget) return true;
+
+    return false;
+  }
+
+  private extractAlias(value: string): string | null {
+    const cleaned = value.replace(/["'[\]]/g, "").trim();
+    const pipeIndex = cleaned.indexOf("|");
+    return pipeIndex >= 0 ? cleaned.substring(pipeIndex + 1).trim() : null;
   }
 
   private getBindingPriority(binding: CommandBindingDefinition): number {

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -498,6 +498,35 @@ describe("CommandResolver", () => {
 
       expect(bindings).toHaveLength(0);
     });
+
+    it("should match when assetClass is UUID|alias and binding targetClass is alias", async () => {
+      await addBindingAsset(store, {
+        uid: "bind-1",
+        label: "For tasks",
+        commandRef: "cmd-1",
+        targetClass: "ems__Task",
+      });
+
+      // Simulates extractAssetClass output from [[UUID|ems__Task]] wikilink format
+      const bindings = await resolver.findBindings("1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task");
+
+      expect(bindings).toHaveLength(1);
+      expect(bindings[0].targetClass).toBe("ems__Task");
+    });
+
+    it("should match when both sides use UUID|alias format with same alias", async () => {
+      await addBindingAsset(store, {
+        uid: "bind-1",
+        label: "For tasks",
+        commandRef: "cmd-1",
+        targetClass: "ems__Task",
+      });
+
+      // Both UUID|alias formats should match as long as alias is the same
+      const bindings = await resolver.findBindings("different-uuid|ems__Task");
+
+      expect(bindings).toHaveLength(1);
+    });
   });
 
   describe("resolveForAsset", () => {
@@ -511,6 +540,21 @@ describe("CommandResolver", () => {
       expect(resolved).toHaveLength(1);
       expect(resolved[0].command.name).toBe("Command 1");
       expect(resolved[0].binding.targetClass).toBe("ems__Task");
+    });
+
+    it("should resolve commands when assetClass uses UUID|alias format", async () => {
+      await addGroundingAsset(store, { uid: "gnd-1", label: "G1", type: "property_delete", targetProperty: "test" });
+      await addCommandAsset(store, { uid: "cmd-1", label: "Command 1", groundingRef: "gnd-1" });
+      await addBindingAsset(store, { uid: "bind-1", label: "B1", commandRef: "cmd-1", targetClass: "ems__Task" });
+
+      // UUID|alias format from [[UUID|ems__Task]] wikilink
+      const resolved = await resolver.resolveForAsset(
+        "asset-123",
+        "1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task",
+      );
+
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0].command.name).toBe("Command 1");
     });
 
     it("should return empty array when no bindings match", async () => {


### PR DESCRIPTION
## Summary

- Fix command buttons not rendering when `exo__Instance_class` uses `[[UUID|alias]]` wikilink format
- `matchesReference()` now cross-matches aliases via new `extractAlias()` helper
- Added 3 tests covering UUID|alias matching scenarios

## Root Cause

`extractAssetClass()` strips `[]""` from `[[UUID|alias]]` → `UUID|alias`. Then `normalizeWikilink()` takes only the UUID part. Binding's `targetClass` is plain `"ems__Task"`. UUID ≠ alias → no match → no buttons.

## Test plan

- [x] 3 new unit tests for UUID|alias matching
- [x] 35/35 CommandResolver tests pass
- [x] 24/24 DynamicCommandButtonGroupBuilder tests pass
- [x] TypeScript type check clean
- [x] BDD 100%, Archgate 13/13
- [ ] CI full suite

Closes #2740