### PR TITLE
fix: valueToClassURI handles [[UUID|alias]] wikilink format (#2742)

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -731,6 +731,15 @@ export class NoteToRDFConverter {
     return linkpath.includes("|") ? linkpath.split("|")[0] : linkpath;
   }
 
+  // Issue #2742: Extract alias from [[UUID|alias]] wikilink format
+  private extractWikilinkAlias(value: string): string | null {
+    const match = value.match(/^\[\[([^\]]+)\]\]$/);
+    if (!match) return null;
+    const linkpath = match[1];
+    const pipeIndex = linkpath.indexOf("|");
+    return pipeIndex >= 0 ? linkpath.substring(pipeIndex + 1).trim() : null;
+  }
+
   /**
    * Converts a value for exo__Instance_class to a namespace URI.
    *
@@ -761,6 +770,15 @@ export class NoteToRDFConverter {
     const classIRI = this.expandClassValue(classRef);
     if (classIRI) {
       return classIRI;
+    }
+
+    // Issue #2742: If UUID didn't expand, try alias from [[UUID|alias]] format
+    const alias = this.extractWikilinkAlias(cleanValue);
+    if (alias) {
+      const aliasIRI = this.expandClassValue(alias);
+      if (aliasIRI) {
+        return aliasIRI;
+      }
     }
 
     // Not a class reference - return as literal (preserves original wiki-link format)

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -636,6 +636,106 @@ describe("NoteToRDFConverter", () => {
         expect((domainTriple!.object as IRI).value).toBe(Namespace.EMS.term("Effort").value);
       });
     });
+
+    // Issue #2742: [[UUID|alias]] format should generate rdf:type triple via alias
+    describe("UUID|alias wikilink format for Instance_class (Issue #2742)", () => {
+      const file: IFile = {
+        path: "test.md",
+        basename: "test",
+        name: "test.md",
+        parent: null,
+      };
+
+      it("should generate rdf:type triple from [[UUID|ems__Task]] format", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task]]"],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const typeTriple = triples.find((t) =>
+          (t.predicate as IRI).value === Namespace.RDF.term("type").value
+        );
+
+        expect(typeTriple).toBeDefined();
+        expect(typeTriple!.object).toBeInstanceOf(IRI);
+        expect((typeTriple!.object as IRI).value).toBe(Namespace.EMS.term("Task").value);
+      });
+
+      it("should generate rdf:type triple from [[UUID|exocmd__CommandBinding]] format", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[3677039a-a5a8-4402-9a07-f8f18fe384ad|exocmd__CommandBinding]]"],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const typeTriple = triples.find((t) =>
+          (t.predicate as IRI).value === Namespace.RDF.term("type").value
+        );
+
+        expect(typeTriple).toBeDefined();
+        expect(typeTriple!.object).toBeInstanceOf(IRI);
+        expect((typeTriple!.object as IRI).value).toBe(Namespace.EXOCMD.term("CommandBinding").value);
+      });
+
+      it("should generate Instance_class IRI from [[UUID|ems__Task]] format", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task]]"],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const classTriple = triples.find((t) =>
+          (t.predicate as IRI).value.includes("Instance_class")
+        );
+
+        expect(classTriple).toBeDefined();
+        expect(classTriple!.object).toBeInstanceOf(IRI);
+        expect((classTriple!.object as IRI).value).toBe(Namespace.EMS.term("Task").value);
+      });
+
+      it("should still work with [[alias-only]] format (no UUID)", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[ems__Task]]"],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const typeTriple = triples.find((t) =>
+          (t.predicate as IRI).value === Namespace.RDF.term("type").value
+        );
+
+        expect(typeTriple).toBeDefined();
+        expect(typeTriple!.object).toBeInstanceOf(IRI);
+        expect((typeTriple!.object as IRI).value).toBe(Namespace.EMS.term("Task").value);
+      });
+
+      it("should still work with bare class name (no wikilink)", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["ems__Task"],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const typeTriple = triples.find((t) =>
+          (t.predicate as IRI).value === Namespace.RDF.term("type").value
+        );
+
+        expect(typeTriple).toBeDefined();
+        expect(typeTriple!.object).toBeInstanceOf(IRI);
+        expect((typeTriple!.object as IRI).value).toBe(Namespace.EMS.term("Task").value);
+      });
+    });
   });
 
   // Issue #666: Asset_fileName predicate for SPARQL queries by filename


### PR DESCRIPTION
## Summary

- Fixes #2742 — `NoteToRDFConverter.valueToClassURI()` now handles `[[UUID|alias]]` wikilink format
- `extractWikilink()` returns UUID from `[[UUID|alias]]`, but `expandClassValue()` can't convert UUID to namespace IRI → `rdf:type` triple was not created
- Added `extractWikilinkAlias()` fallback: if UUID doesn't expand, try the alias part
- This is the root cause fix for command buttons not rendering in starter kit vault

## Test plan

- [x] `[[UUID|ems__Task]]` → `rdf:type ems:Task` triple created
- [x] `[[UUID|exocmd__CommandBinding]]` → `rdf:type exocmd:CommandBinding` triple created
- [x] `[[UUID|ems__Task]]` → `Instance_class` IRI correct
- [x] `[[ems__Task]]` (alias-only) — still works
- [x] `ems__Task` (bare) — still works
- [x] All 135 NoteToRDFConverter tests pass (0 regressions)
- [x] Full test suite: 1269 tests pass