### PR TITLE
fix: valueToClassURI falls back to alias for [[UUID|alias]] Instance_class

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -732,6 +732,24 @@ export class NoteToRDFConverter {
   }
 
   /**
+   * Extracts the alias (display name) from a [[target|alias]] wikilink.
+   *
+   * Issue #2742: When [[UUID|ems__Task]] format is used, extractWikilink returns
+   * the UUID which can't be expanded to a class IRI. This method extracts the alias
+   * part so it can be tried as a fallback.
+   *
+   * @param value - The raw wikilink string (e.g., "[[UUID|ems__Task]]")
+   * @returns The alias part, or null if no alias present
+   */
+  private extractWikilinkAlias(value: string): string | null {
+    const match = value.match(/^\[\[([^\]]+)\]\]$/);
+    if (!match) return null;
+    const linkpath = match[1];
+    if (!linkpath.includes("|")) return null;
+    return linkpath.split("|")[1];
+  }
+
+  /**
    * Converts a value for exo__Instance_class to a namespace URI.
    *
    * Issue #663: Always stores class references as namespace URIs (not file URIs),
@@ -761,6 +779,16 @@ export class NoteToRDFConverter {
     const classIRI = this.expandClassValue(classRef);
     if (classIRI) {
       return classIRI;
+    }
+
+    // Issue #2742: For [[UUID|alias]] format, extractWikilink returns the UUID
+    // which doesn't expand to a class IRI. Try the alias part as fallback.
+    const alias = this.extractWikilinkAlias(cleanValue);
+    if (alias) {
+      const aliasIRI = this.expandClassValue(alias);
+      if (aliasIRI) {
+        return aliasIRI;
+      }
     }
 
     // Not a class reference - return as literal (preserves original wiki-link format)

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -571,6 +571,69 @@ describe("NoteToRDFConverter", () => {
         expect(values).toContain(Namespace.EMS.term("Effort").value);
       });
 
+      // Issue #2742: [[UUID|alias]] format should expand alias to class IRI
+      it("should expand UUID|alias Instance_class to namespace URI via alias (Issue #2742)", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[3677039a-a5a8-4402-9a07-f8f18fe384ad|exocmd__CommandBinding]]"],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const classTriples = triples.filter((t) =>
+          (t.predicate as IRI).value.includes("Instance_class")
+        );
+
+        expect(classTriples.length).toBe(1);
+        expect(classTriples[0].object).toBeInstanceOf(IRI);
+        expect((classTriples[0].object as IRI).value).toBe(
+          Namespace.EXOCMD.term("CommandBinding").value
+        );
+      });
+
+      it("should generate rdf:type triple for UUID|alias Instance_class (Issue #2742)", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task]]"],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const typeTriple = triples.find((t) =>
+          (t.predicate as IRI).value === Namespace.RDF.term("type").value
+        );
+
+        expect(typeTriple).toBeDefined();
+        expect(typeTriple!.object).toBeInstanceOf(IRI);
+        expect((typeTriple!.object as IRI).value).toBe(
+          Namespace.EMS.term("Task").value
+        );
+      });
+
+      it("should handle multiple UUID|alias Instance_class values (Issue #2742)", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: [
+            "[[aaa-bbb|ems__Task]]",
+            "[[ccc-ddd|ems__Effort]]",
+          ],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const typeTriples = triples.filter((t) =>
+          (t.predicate as IRI).value === Namespace.RDF.term("type").value
+        );
+
+        expect(typeTriples.length).toBe(2);
+        const values = typeTriples.map((t) => (t.object as IRI).value);
+        expect(values).toContain(Namespace.EMS.term("Task").value);
+        expect(values).toContain(Namespace.EMS.term("Effort").value);
+      });
+
       it("should still use file URI when wiki-link target file exists", async () => {
         const frontmatter: IFrontmatter = {
           exo__Property_domain: "[[ems__Effort]]",


### PR DESCRIPTION
## Summary

- Fixes #2742: `extractWikilink()` discards alias from `[[UUID|alias]]`, breaking `rdf:type` generation
- Added `extractWikilinkAlias()` helper to extract the alias part from wikilinks
- `valueToClassURI()` now tries alias as fallback when UUID doesn't expand to a class IRI
- This enables `rdf:type` triples for starter kit assets using `[[UUID|alias]]` format

## Root cause

`extractWikilink("[[UUID|ems__Task]]")` returns `"UUID"` → `expandClassValue("UUID")` returns `null` → `valueToClassURI` returns `Literal` → `rdf:type` triple not created (requires `IRI`).

## Fix

When `expandClassValue(uuid)` fails, try `expandClassValue(alias)` as fallback.

## Test plan

- [x] `[[UUID|ems__Task]]` generates `rdf:type ems:Task` triple
- [x] `[[UUID|exocmd__CommandBinding]]` generates correct namespace IRI
- [x] Multiple `[[UUID|alias]]` values all generate `rdf:type` triples
- [x] Existing `[[ems__Task]]` (alias-only) continues to work
- [x] Existing bare `ems__Task` continues to work
- [x] All 122 NoteToRDFConverter tests pass
- [x] Full test suite passes (537 passed, 2 unrelated perf flakes)