### PR TITLE
fix: valueToClassURI resolves [[UUID]] wikilinks via vault lookup (#2745)

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -781,6 +781,24 @@ export class NoteToRDFConverter {
       }
     }
 
+    // Issue #2745: If UUID-only wikilink, look up file in vault and resolve via basename/label
+    if (this.isUUID(classRef)) {
+      const resolvedFile = this.vault.getFirstLinkpathDest(classRef, "");
+      if (resolvedFile) {
+        const basenameIRI = this.expandClassValue(resolvedFile.basename);
+        if (basenameIRI) return basenameIRI;
+
+        const fm = this.vault.getFrontmatter(resolvedFile);
+        if (fm) {
+          const label = fm["exo__Asset_label"];
+          if (typeof label === "string") {
+            const labelIRI = this.expandClassValue(label);
+            if (labelIRI) return labelIRI;
+          }
+        }
+      }
+    }
+
     // Not a class reference - return as literal (preserves original wiki-link format)
     return new Literal(cleanValue);
   }

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -736,6 +736,149 @@ describe("NoteToRDFConverter", () => {
         expect((typeTriple!.object as IRI).value).toBe(Namespace.EMS.term("Task").value);
       });
     });
+
+    // Issue #2745: [[UUID]] (UUID-only wikilink) should resolve rdf:type via vault lookup
+    describe("UUID-only wikilink format for Instance_class (Issue #2745)", () => {
+      const file: IFile = {
+        path: "exocmd/status/binding.md",
+        basename: "binding",
+        name: "binding.md",
+        parent: null,
+      };
+
+      const classDefFile: IFile = {
+        path: "exocmd/3677039a-a5a8-4402-9a07-f8f18fe384ad.md",
+        basename: "3677039a-a5a8-4402-9a07-f8f18fe384ad",
+        name: "3677039a-a5a8-4402-9a07-f8f18fe384ad.md",
+        parent: null,
+      };
+
+      it("should generate rdf:type triple from [[UUID]] when class def file has exo__Asset_label", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[3677039a-a5a8-4402-9a07-f8f18fe384ad]]"],
+        };
+
+        mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+          if (f.path === file.path) return frontmatter;
+          if (f.path === classDefFile.path) return { exo__Asset_label: "exocmd__CommandBinding" };
+          return null;
+        });
+
+        mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+          if (linkpath === "3677039a-a5a8-4402-9a07-f8f18fe384ad") return classDefFile;
+          return null;
+        });
+
+        const triples = await converter.convertNote(file);
+
+        const typeTriple = triples.find((t) =>
+          (t.predicate as IRI).value === Namespace.RDF.term("type").value
+        );
+
+        expect(typeTriple).toBeDefined();
+        expect(typeTriple!.object).toBeInstanceOf(IRI);
+        expect((typeTriple!.object as IRI).value).toBe(Namespace.EXOCMD.term("CommandBinding").value);
+      });
+
+      it("should generate rdf:type triple from [[UUID]] when class def basename is a class name", async () => {
+        const namedClassFile: IFile = {
+          path: "exocmd/exocmd__CommandGrounding.md",
+          basename: "exocmd__CommandGrounding",
+          name: "exocmd__CommandGrounding.md",
+          parent: null,
+        };
+
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[11579feb-2e42-491c-af59-b89b1129a539]]"],
+        };
+
+        mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+          if (f.path === file.path) return frontmatter;
+          return null;
+        });
+
+        mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+          if (linkpath === "11579feb-2e42-491c-af59-b89b1129a539") return namedClassFile;
+          return null;
+        });
+
+        const triples = await converter.convertNote(file);
+
+        const typeTriple = triples.find((t) =>
+          (t.predicate as IRI).value === Namespace.RDF.term("type").value
+        );
+
+        expect(typeTriple).toBeDefined();
+        expect(typeTriple!.object).toBeInstanceOf(IRI);
+        expect((typeTriple!.object as IRI).value).toBe(Namespace.EXOCMD.term("CommandGrounding").value);
+      });
+
+      it("should return Literal when [[UUID]] file not found in vault", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]]"],
+        };
+
+        mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+          if (f.path === file.path) return frontmatter;
+          return null;
+        });
+
+        mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+        const triples = await converter.convertNote(file);
+
+        const classTriple = triples.find((t) =>
+          (t.predicate as IRI).value.includes("Instance_class")
+        );
+
+        expect(classTriple).toBeDefined();
+        expect(classTriple!.object).toBeInstanceOf(Literal);
+      });
+
+      it("should return Literal when [[UUID]] file has no label and UUID basename", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[3677039a-a5a8-4402-9a07-f8f18fe384ad]]"],
+        };
+
+        mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+          if (f.path === file.path) return frontmatter;
+          if (f.path === classDefFile.path) return { exo__Class_description: "Some class" };
+          return null;
+        });
+
+        mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+          if (linkpath === "3677039a-a5a8-4402-9a07-f8f18fe384ad") return classDefFile;
+          return null;
+        });
+
+        const triples = await converter.convertNote(file);
+
+        const classTriple = triples.find((t) =>
+          (t.predicate as IRI).value.includes("Instance_class")
+        );
+
+        expect(classTriple).toBeDefined();
+        expect(classTriple!.object).toBeInstanceOf(Literal);
+      });
+
+      it("should still work with [[UUID|alias]] format after vault lookup added (regression #2742)", async () => {
+        const frontmatter: IFrontmatter = {
+          exo__Instance_class: ["[[3677039a-a5a8-4402-9a07-f8f18fe384ad|exocmd__CommandBinding]]"],
+        };
+
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const typeTriple = triples.find((t) =>
+          (t.predicate as IRI).value === Namespace.RDF.term("type").value
+        );
+
+        expect(typeTriple).toBeDefined();
+        expect(typeTriple!.object).toBeInstanceOf(IRI);
+        expect((typeTriple!.object as IRI).value).toBe(Namespace.EXOCMD.term("CommandBinding").value);
+      });
+    });
   });
 
   // Issue #666: Asset_fileName predicate for SPARQL queries by filename


### PR DESCRIPTION
## Summary

- Fixes #2745 — `valueToClassURI()` now resolves `[[UUID]]` (UUID-only) wikilinks to proper `rdf:type` triples via vault lookup
- When a UUID wikilink doesn't have an alias, the converter looks up the referenced file and resolves the class name from file basename or `exo__Asset_label` frontmatter property
- This is the final fix in the chain (#2740 → #2741 → #2742 → #2743 → **#2745**) that enables command buttons to render in starter kit vaults

## Changes

### Code (`NoteToRDFConverter.ts`)
- Added vault lookup fallback in `valueToClassURI()` after the alias extraction step (#2742)
- Lookup order: basename → `exo__Asset_label` → literal fallback

### Tests (`NoteToRDFConverter.test.ts`)
- 5 new tests covering UUID-only wikilink resolution:
  - Resolve via `exo__Asset_label` (primary path for exocmd class defs)
  - Resolve via basename (when file is named with class prefix)
  - Graceful fallback when file not found
  - Graceful fallback when file has no label and UUID basename
  - Regression test for `[[UUID|alias]]` format (#2742)

### Data (starter kit — separate commit in kitelev/exocortex-starter-kit)
- Added `exo__Asset_label` to 4 class definition files:
  - `exocmd__CommandBinding`, `exocmd__CommandGrounding`, `exocmd__Command`, `exocmd__Precondition`

## Test plan
- [x] All 129 NoteToRDFConverter tests pass
- [x] BDD coverage: 100% (222/222 scenarios)
- [x] Archgate: 13/13 rules pass
- [x] ESLint: clean
- [ ] CI pipeline (automated)
- [ ] E2E: command buttons visible in starter kit vault (post-merge)

Closes #2745