### PR TITLE
fix: resolve UUID wikilink alias in grounding targetValue

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -655,12 +655,31 @@ export class CommandResolver {
     if (triples.length === 0) return null;
 
     const obj = triples[0].object;
-    if (obj instanceof Literal) return obj.value;
+    if (obj instanceof Literal) return this.resolveWikilinkAlias(obj.value);
     if (obj instanceof IRI) {
       const name = this.iriToObsidianName(obj.value);
       return name ? `"[[${name}]]"` : obj.value;
     }
     return null;
+  }
+
+  /**
+   * Resolve UUID-only wikilinks to include alias from the triple store.
+   * Converts "[[UUID]]" to "[[UUID|label]]" when the asset exists.
+   * Already-aliased values ("[[UUID|alias]]") pass through unchanged.
+   */
+  private async resolveWikilinkAlias(value: string): Promise<string> {
+    const match = value.match(/\[\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]\]/);
+    if (!match) return value;
+
+    const uuid = match[1];
+    const assetSubject = await this.findSubjectByUID(uuid);
+    if (!assetSubject) return value;
+
+    const label = await this.getLiteralValue(assetSubject, Namespace.EXO.term("Asset_label"));
+    if (!label) return value;
+
+    return value.replace(`[[${uuid}]]`, `[[${uuid}|${label}]]`);
   }
 
   private iriToObsidianName(iri: string): string | null {

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -287,6 +287,101 @@ describe("CommandResolver", () => {
       expect(cmd!.grounding.targetValue).toBe("\"[[ems__EffortStatusDoing]]\"");
     });
 
+    it("should resolve UUID wikilink alias in targetValue from triple store", async () => {
+      // Status asset in the triple store (simulates ems__EffortStatusDoing)
+      const statusUUID = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+      const statusSubject = new IRI(`obsidian://vault/${statusUUID}.md`);
+      await store.addAll([
+        new Triple(statusSubject, Namespace.EXO.term("Asset_uid"), new Literal(statusUUID)),
+        new Triple(statusSubject, Namespace.EXO.term("Asset_label"), new Literal("ems__EffortStatusDoing")),
+      ]);
+
+      // Grounding with UUID-only targetValue (as stored in starter kit)
+      await addGroundingAsset(store, {
+        uid: "gnd-uuid-alias",
+        label: "Set Status Doing",
+        type: "property_set",
+        targetProperty: "ems__Effort_status",
+        targetValue: `"[[${statusUUID}]]"`,
+      });
+
+      await addCommandAsset(store, {
+        uid: "cmd-uuid-alias",
+        label: "Set Status Doing",
+        groundingRef: "gnd-uuid-alias",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-uuid-alias");
+
+      expect(cmd!.grounding).toBeDefined();
+      expect(cmd!.grounding.targetValue).toBe(`"[[${statusUUID}|ems__EffortStatusDoing]]"`);
+    });
+
+    it("should preserve targetValue when UUID is not found in store", async () => {
+      const unknownUUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+      await addGroundingAsset(store, {
+        uid: "gnd-unknown-uuid",
+        label: "Unknown Status",
+        type: "property_set",
+        targetProperty: "ems__Effort_status",
+        targetValue: `"[[${unknownUUID}]]"`,
+      });
+
+      await addCommandAsset(store, {
+        uid: "cmd-unknown-uuid",
+        label: "Unknown Status",
+        groundingRef: "gnd-unknown-uuid",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-unknown-uuid");
+
+      expect(cmd!.grounding).toBeDefined();
+      expect(cmd!.grounding.targetValue).toBe(`"[[${unknownUUID}]]"`);
+    });
+
+    it("should not modify targetValue with existing alias", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-with-alias",
+        label: "Already Aliased",
+        type: "property_set",
+        targetProperty: "ems__Effort_status",
+        targetValue: '"[[027e78f4-6e16-4b36-b8fb-5510507d5745|ems__EffortStatusDoing]]"',
+      });
+
+      await addCommandAsset(store, {
+        uid: "cmd-with-alias",
+        label: "Already Aliased",
+        groundingRef: "gnd-with-alias",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-with-alias");
+
+      expect(cmd!.grounding).toBeDefined();
+      expect(cmd!.grounding.targetValue).toBe('"[[027e78f4-6e16-4b36-b8fb-5510507d5745|ems__EffortStatusDoing]]"');
+    });
+
+    it("should not modify non-wikilink targetValue", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-plain",
+        label: "Plain Value",
+        type: "property_set",
+        targetProperty: "ems__Effort_status",
+        targetValue: "$today",
+      });
+
+      await addCommandAsset(store, {
+        uid: "cmd-plain",
+        label: "Plain Value",
+        groundingRef: "gnd-plain",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-plain");
+
+      expect(cmd!.grounding).toBeDefined();
+      expect(cmd!.grounding.targetValue).toBe("$today");
+    });
+
     it("should return null for missing UID", async () => {
       const cmd = await resolver.loadCommand("non-existent");
       expect(cmd).toBeNull();


### PR DESCRIPTION
## Summary

- Command buttons (e.g., "Set Status Doing") now write `[[UUID|label]]` instead of `[[UUID]]` when setting property values
- `CommandResolver.getObsidianWikilinkValue()` resolves UUID-only wikilinks by looking up `Asset_label` in the triple store
- Fixes UUID leak in Obsidian UI where status showed `ems__EffortStatusDoing (8619c4fc-...)` instead of human-readable name

## Changes

- `CommandResolver.ts`: Added `resolveWikilinkAlias()` private method that converts `[[UUID]]` → `[[UUID|label]]` using `findSubjectByUID` + `getLiteralValue`
- `CommandResolver.test.ts`: 4 new tests covering alias resolution, unknown UUID fallback, pre-existing alias preservation, non-wikilink passthrough

## Test plan

- [x] 4 new unit tests pass (alias resolution, unknown UUID, existing alias, non-wikilink)
- [x] Full CommandResolver test suite: 39/39 pass
- [x] `npm run test:all` passes (3 pre-existing component test timeouts unrelated)
- [x] TypeScript typecheck clean
- [x] BDD coverage 100%, Archgate clean
- [ ] E2E: verify command button click writes correct format in Obsidian