### PR TITLE
fix: implement actual projection in executeProject to fix DISTINCT

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -349,9 +349,19 @@ export class ExoQLQueryExecutor {
   }
 
   private async *executeProject(operation: ProjectOperation): AsyncIterableIterator<SolutionMapping> {
-    // Project passes through to input, variable filtering happens at result formatting
+    const { SolutionMapping: SM } = await import("../SolutionMapping");
+    const projectedVars = new Set(operation.variables);
     for await (const solution of this.execute(operation.input)) {
-      yield solution;
+      const projected = new SM();
+      for (const variable of solution.variables()) {
+        if (projectedVars.has(variable)) {
+          const value = solution.get(variable);
+          if (value !== undefined) {
+            projected.set(variable, value);
+          }
+        }
+      }
+      yield projected;
     }
   }
 

--- a/packages/exocortex/tests/compliance/sparql/solution-modifiers.test.ts
+++ b/packages/exocortex/tests/compliance/sparql/solution-modifiers.test.ts
@@ -2,7 +2,7 @@
  * SPARQL 1.1 Solution Modifiers Compliance Tests
  *
  * Coverage Status:
- * - DISTINCT: ⚠️ Partial (not correctly deduplicating)
+ * - DISTINCT: ✅ Implemented (projection-based deduplication)
  * - REDUCED: ✅ Implemented
  * - ORDER BY: ✅ Implemented
  * - ORDER BY DESC: ✅ Implemented
@@ -23,8 +23,7 @@ import {
 
 describe("SPARQL 1.1 Solution Modifiers Compliance", () => {
   describe("DISTINCT", () => {
-    // DISTINCT is not correctly deduplicating results
-    it.skip("should remove duplicate solutions", async () => {
+    it("should remove duplicate solutions", async () => {
       const { store, executor } = createTestEnvironment();
       await loadTestData(store, TEST_DATA.numericData());
 
@@ -42,7 +41,7 @@ describe("SPARQL 1.1 Solution Modifiers Compliance", () => {
       expect(categories).toContain("B");
     });
 
-    it("should return results with DISTINCT (current behavior: not deduplicating)", async () => {
+    it("should deduplicate results correctly", async () => {
       const { store, executor } = createTestEnvironment();
       await loadTestData(store, TEST_DATA.numericData());
 
@@ -54,8 +53,7 @@ describe("SPARQL 1.1 Solution Modifiers Compliance", () => {
       `;
 
       const results = await executeQuery(executor, query);
-      // Current implementation returns 5 (not deduped) instead of 2
-      expect(results.length).toBeGreaterThanOrEqual(2);
+      expect(results.length).toBe(2);
       const categories = results.map((r) => r.category);
       expect(categories).toContain("A");
       expect(categories).toContain("B");

--- a/packages/exocortex/tests/sparql/compliance/solution-modifiers.test.ts
+++ b/packages/exocortex/tests/sparql/compliance/solution-modifiers.test.ts
@@ -348,8 +348,7 @@ describe("SPARQL 1.1 Compliance - Solution Modifiers", () => {
   });
 
   describe("DISTINCT", () => {
-    // DISTINCT not removing duplicates - returns all rows
-    it.skip("should remove duplicate solutions", async () => {
+    it("should remove duplicate solutions", async () => {
       const query = `
         PREFIX ex: <http://example.org/>
         SELECT DISTINCT ?department WHERE {
@@ -366,7 +365,7 @@ describe("SPARQL 1.1 Compliance - Solution Modifiers", () => {
       expect(departments).toEqual(["Engineering", "HR", "Sales"]);
     });
 
-    it.skip("should remove duplicates from multiple variables", async () => {
+    it("should remove duplicates from multiple variables", async () => {
       const query = `
         PREFIX ex: <http://example.org/>
         SELECT DISTINCT ?age ?score WHERE {
@@ -386,7 +385,7 @@ describe("SPARQL 1.1 Compliance - Solution Modifiers", () => {
       expect(uniquePairs.size).toBe(results.length);
     });
 
-    it.skip("should work with ORDER BY", async () => {
+    it("should work with ORDER BY", async () => {
       const query = `
         PREFIX ex: <http://example.org/>
         SELECT DISTINCT ?department WHERE {
@@ -401,6 +400,56 @@ describe("SPARQL 1.1 Compliance - Solution Modifiers", () => {
 
       const departments = results.map((r) => getValue(r.get("department")));
       expect(departments).toEqual(["Engineering", "HR", "Sales"]);
+    });
+
+    it("should preserve results with unbound OPTIONAL variables (#2747)", async () => {
+      // Add a person without a nickname (OPTIONAL field)
+      await store.add(
+        new Triple(
+          new IRI(`${EX}frank`),
+          RDF_TYPE,
+          new IRI(`${EX}Person`)
+        )
+      );
+      await store.add(
+        new Triple(
+          new IRI(`${EX}frank`),
+          new IRI(`${EX}name`),
+          new Literal("Frank")
+        )
+      );
+      // Frank has NO nickname — OPTIONAL will leave ?nickname unbound
+
+      // Alice gets a nickname
+      await store.add(
+        new Triple(
+          new IRI(`${EX}alice`),
+          new IRI(`${EX}nickname`),
+          new Literal("Ali")
+        )
+      );
+
+      const query = `
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?name ?nickname WHERE {
+          ?person ex:name ?name .
+          OPTIONAL { ?person ex:nickname ?nickname }
+        }
+      `;
+
+      const parsed = parser.parse(query);
+      const algebra = translator.translate(parsed);
+      const results = await executor.executeAll(algebra);
+
+      const names = results.map((r) => getValue(r.get("name"))).sort();
+      // All 6 people should appear (5 original + Frank)
+      expect(names).toEqual(["Alice", "Bob", "Carol", "Dan", "Eve", "Frank"]);
+
+      // Alice should have nickname, Frank should not
+      const alice = results.find((r) => getValue(r.get("name")) === "Alice");
+      expect(getValue(alice?.get("nickname"))).toBe("Ali");
+      const frank = results.find((r) => getValue(r.get("name")) === "Frank");
+      expect(frank?.get("nickname")).toBeUndefined();
     });
   });
 
@@ -590,8 +639,7 @@ describe("SPARQL 1.1 Compliance - Solution Modifiers", () => {
       expect(getValue(page3[0].get("name"))).toBe("Eve");
     });
 
-    // DISTINCT not removing duplicates - OFFSET operates on all rows
-    it.skip("should work with DISTINCT", async () => {
+    it("should work with DISTINCT", async () => {
       const query = `
         PREFIX ex: <http://example.org/>
         SELECT DISTINCT ?department WHERE {
@@ -703,8 +751,7 @@ describe("SPARQL 1.1 Compliance - Solution Modifiers", () => {
   });
 
   describe("Combined Modifiers", () => {
-    // DISTINCT not removing duplicates - returns all rows
-    it.skip("should apply DISTINCT before ORDER BY", async () => {
+    it("should apply DISTINCT before ORDER BY", async () => {
       const query = `
         PREFIX ex: <http://example.org/>
         SELECT DISTINCT ?department WHERE {


### PR DESCRIPTION
## Summary
- `executeProject` was a no-op (pass-through), so DISTINCT never worked correctly — non-projected variables like `?person` made every row unique
- Now `executeProject` strips non-projected variables from solutions before DISTINCT sees them
- Un-skipped 7 DISTINCT tests that were marked as broken, added new test for DISTINCT + OPTIONAL (#2747)

## Test plan
- [x] All existing DISTINCT tests un-skipped and passing (7 tests)
- [x] New test: DISTINCT with OPTIONAL unbound variables (#2747)
- [x] `npm run build` green
- [x] Pre-commit hooks (lint, archgate, BDD 100%) passing
- [x] No regressions in sparql-critical-paths integration tests

Closes #2747