### PR TITLE
fix: resolve wikilink aliases and UUID labels in display name templates

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
@@ -131,7 +131,7 @@ export class DisplayNameTemplateEngine {
 
     // Handle dot notation for nested fields (with cross-asset resolution)
     const value = this.getNestedValue(metadata, key, metadataResolver);
-    return this.formatValue(value);
+    return this.formatValue(value, metadataResolver);
   }
 
   /**
@@ -172,16 +172,53 @@ export class DisplayNameTemplateEngine {
   }
 
   /**
-   * Format a value for display
+   * Format a string value, handling wikilink syntax:
+   * - [[target|alias]] → alias
+   * - [[target]] with metadataResolver → resolved exo__Asset_label
+   * - [[target]] without resolver → target (stripped brackets)
    */
-  private formatValue(value: unknown): string {
+  private formatWikilinkValue(value: string, metadataResolver?: MetadataResolver): string {
+    // Match wikilink pattern: [[target]] or [[target|alias]]
+    const match = value.match(/^\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]$/);
+    if (!match) {
+      // Not a wikilink — strip any partial bracket syntax
+      return value.replace(DisplayNameTemplateEngine.WIKILINK_PATTERN, "").trim();
+    }
+
+    const target = match[1].trim();
+    const alias = match[2]?.trim();
+
+    // If alias exists, use it directly
+    if (alias) {
+      return alias;
+    }
+
+    // Try to resolve label via metadataResolver
+    if (metadataResolver) {
+      const resolved = metadataResolver(value);
+      if (resolved) {
+        const label = resolved.exo__Asset_label;
+        if (typeof label === "string" && label.trim()) {
+          return label.trim();
+        }
+      }
+    }
+
+    // Fallback: return target without brackets
+    return target;
+  }
+
+  /**
+   * Format a value for display.
+   * Parses wikilinks to extract alias or resolve label via metadataResolver.
+   */
+  private formatValue(value: unknown, metadataResolver?: MetadataResolver): string {
     if (value === null || value === undefined) {
       return "";
     }
 
     if (typeof value === "string") {
-      // Strip wikilink syntax
-      return value.replace(DisplayNameTemplateEngine.WIKILINK_PATTERN, "").trim();
+      return this.formatWikilinkValue(value, metadataResolver);
     }
 
     if (Array.isArray(value)) {
@@ -189,7 +226,7 @@ export class DisplayNameTemplateEngine {
       if (value.length === 0) {
         return "";
       }
-      return this.formatValue(value[0]);
+      return this.formatValue(value[0], metadataResolver);
     }
 
     if (typeof value === "object") {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameTemplateEngine.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameTemplateEngine.test.ts
@@ -99,6 +99,48 @@ describe("DisplayNameTemplateEngine", () => {
       expect(result).toBe("My Task");
     });
 
+    it("should extract alias from wikilink with pipe syntax", () => {
+      const engine = new DisplayNameTemplateEngine("{{exo__Instance_class}}");
+      const result = engine.render(
+        { exo__Instance_class: ["[[8619c4fc-64f1-4869-b17e-e34186cacca9|exo__Class]]"] },
+        "status-doing"
+      );
+      expect(result).toBe("exo__Class");
+    });
+
+    it("should resolve UUID wikilink via metadataResolver", () => {
+      const resolver = jest.fn().mockReturnValue({
+        exo__Asset_label: "exo__Class",
+      });
+      const engine = new DisplayNameTemplateEngine(
+        "{{exo__Asset_label}} ({{exo__Instance_class}})"
+      );
+      const result = engine.render(
+        {
+          exo__Asset_label: "ems__EffortStatusDoing",
+          exo__Instance_class: ["[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"],
+        },
+        "status-doing",
+        undefined,
+        resolver
+      );
+      expect(result).toBe("ems__EffortStatusDoing (exo__Class)");
+      expect(resolver).toHaveBeenCalledWith("[[8619c4fc-64f1-4869-b17e-e34186cacca9]]");
+    });
+
+    it("should show UUID when metadataResolver returns null for UUID wikilink", () => {
+      const resolver = jest.fn().mockReturnValue(null);
+      const engine = new DisplayNameTemplateEngine("{{exo__Instance_class}}");
+      const result = engine.render(
+        { exo__Instance_class: ["[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"] },
+        "status",
+        undefined,
+        resolver
+      );
+      // Fallback to UUID when resolver can't find it
+      expect(result).toBe("8619c4fc-64f1-4869-b17e-e34186cacca9");
+    });
+
     it("should handle array values by using first element", () => {
       const engine = new DisplayNameTemplateEngine("{{exo__Instance_class}}");
       const result = engine.render(


### PR DESCRIPTION
## Summary

- `DisplayNameTemplateEngine.formatValue()` now properly parses wikilinks instead of naively stripping brackets
- `[[target|alias]]` → returns alias (previously showed `target|alias` with pipe)
- `[[UUID]]` → resolves `exo__Asset_label` via metadataResolver (previously showed raw UUID)
- Fixes UUID metaclass leak in Properties panel where status assets showed `ems__EffortStatusDoing (8619c4fc-...)` instead of `ems__EffortStatusDoing (exo__Class)`

## Root cause

Default display name template is `{{exo__Asset_label}} ({{exo__Instance_class}})`. Status assets like `ems__EffortStatusDoing` have `exo__Instance_class: ["[[8619c4fc-...]]"]` (UUID without alias). The old `formatValue()` just stripped `[[` and `]]`, leaving the raw UUID visible.

## Test plan

- [x] 3 new unit tests: alias extraction, UUID resolution via metadataResolver, fallback
- [x] Full DisplayNameTemplateEngine suite: 62/62 pass
- [x] All display-name tests: 102/102 pass  
- [x] TypeScript typecheck clean
- [x] BDD coverage 100%, Archgate clean