### PR TITLE
docs: fix Getting Started Guide text issues

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -166,7 +166,7 @@ REST API for the mobile app.
 
 ### What You'll See
 
-- **Action Buttons**: Move between statuses, vote, create tasks
+- **Action Buttons**: Create tasks, set planned dates, convert to task
 - **Asset Relations**: This project will appear in the Development area's relations
 
 ---
@@ -297,7 +297,7 @@ The Exocortex layout renders automatically in Reading Mode based on the note's `
 - **Daily Projects**: All projects scheduled for this date
 - **Focus Area Filter**: Show only tasks from specific area
 
-**ems**Project / ems**Task**
+**ems\_\_Project** / **ems\_\_Task**
 
 - Standard layout (Properties + Buttons + Relations)
 


### PR DESCRIPTION
## Summary

- Fix broken markdown on line 300: `**ems**Project / ems**Task**` → `**ems\_\_Project** / **ems\_\_Task**` (double underscores eaten by bold formatting)
- Fix inaccurate Project buttons description: status transition buttons are only bound to `ems__Task` (confirmed via starter kit command bindings), not `ems__Project`

## Context

Found during E2E verification of the Getting Started Guide before sharing with first Exocortex follower.

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify Project button description matches actual UI behavior