### PR TITLE
docs: improve Getting Started positioning for first followers

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,6 +1,6 @@
 # Getting Started with Exocortex
 
-**Set up Exocortex for task management in Obsidian. Requires: Obsidian desktop, basic terminal knowledge.**
+**Set up Exocortex — an ontology-driven knowledge management plugin for Obsidian. Requires: Obsidian desktop, basic terminal knowledge.**
 
 ---
 
@@ -19,15 +19,20 @@
 
 ## What is Exocortex?
 
-Exocortex transforms Obsidian into a powerful task management system with:
+Exocortex is an Obsidian plugin that lets you **define custom entity types, their properties, and UI — all as data, not code**. Think of it as Notion databases, but with an ontology layer and fully offline.
 
-- **Automatic layouts** that appear below your note's metadata
+You describe your entities (tasks, projects, areas, or any custom type) in YAML frontmatter, and the plugin automatically generates layouts, action buttons, and workflows based on those definitions. No server, no vendor lock-in — your data lives as Markdown files in your git repository.
+
+### What You Get
+
+- **Automatic layouts** that render below your note's metadata in Reading Mode
 - **Hierarchical organization** (Areas → Projects → Tasks)
+- **Dynamic action buttons** that appear based on entity type and state
 - **Daily planning** with focused task lists
 - **Effort tracking** from idea to completion
 - **Collaborative voting** for prioritization
 
-**The key insight**: Instead of manually maintaining task lists, you define relationships in frontmatter, and Exocortex automatically displays relevant information based on context.
+**The key insight**: You define relationships in frontmatter, and Exocortex automatically displays relevant information based on context. Create a new entity type — and the UI adapts without changing any code.
 
 ---
 


### PR DESCRIPTION
## Summary
- Rewrites "What is Exocortex?" section to lead with the core value proposition: define entity types, properties, and UI as data, not code
- Adds "Notion databases but with ontology and offline" framing for easier onboarding of first followers
- Updates subtitle from "task management" to "ontology-driven knowledge management" to reflect broader capabilities
- Adds "Dynamic action buttons" to feature list and "What You Get" subheading

## Context
Based on a competitive analysis of 15+ systems (Jira, Notion, Salesforce, Semantic MediaWiki, Fresnel, SHACL, NocoBase, etc.), Exocortex occupies a unique niche: file-based + RDF-native + UI generation + offline-first + personal KM. The previous intro undersold this by framing it as "task management".

## Test plan
- [ ] Verify Getting Started guide renders correctly on GitHub
- [ ] Verify no broken markdown or links