### PR TITLE
docs: add Everything as Knowledge positioning to README and VISION

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,41 @@
 
 ---
 
+## Why Exocortex
+
+Most tools separate data from configuration: you write content in one place and configure UI, workflows, and schemas in another. Exocortex takes a different approach — **Everything as Knowledge**.
+
+Your entities, their properties, UI layouts, workflows, and commands are all described as semantic data in the same Markdown files, in the same vault. Create a new entity type — and the UI adapts automatically. Define a workflow transition — and buttons appear. No code changes, no server, no vendor lock-in.
+
+This is an evolution of the "as Code" paradigm (Infrastructure as Code, Docs as Code):
+
+| As Code | As Knowledge (Exocortex) |
+|---------|--------------------------|
+| **Workflow as Code** — CI/CD pipelines | **Workflow as Knowledge** — status transitions as RDF data, UI buttons generated automatically |
+| **Layout as Code** — JSON/CSS config | **Layout as Knowledge** — columns, filters, sorting described semantically |
+| **Schema as Code** — JSON Schema, Prisma | **Schema as Knowledge** — OWL classes and properties as files in your vault |
+
+**"As Code" describes desired system state. "As Knowledge" describes what things mean and how they relate.**
+
+Compared to existing tools:
+
+| | Exocortex | Notion | Jira | Semantic MediaWiki | Protégé |
+|---|:---:|:---:|:---:|:---:|:---:|
+| RDF/Semantic | ✅ | — | — | ✅ | ✅ |
+| File-based (git-friendly) | ✅ | — | — | — | ✅ |
+| UI from ontology | ✅ | ✅ | ~ | ~ | ✅ |
+| Offline-first | ✅ | ~ | — | — | ✅ |
+| For knowledge workers | ✅ | ✅ | ✅ | ~ | �� |
+| Action layer (commands) | ✅ | ~ | ✅ | — | — |
+
+---
+
 ## What It Does
 
 - **Semantic knowledge graph** — every piece of knowledge is an Asset with UUID, class, properties, and relationships stored as RDF triples
 - **SPARQL queries** — ask complex questions across your entire knowledge base
 - **Modular ontologies** — IMS (concepts, notes, people), EMS (tasks, projects, meetings), ZTLK (zettelkasten)
-- **Vault-driven architecture** — commands, workflows, property schemas, and prototype chains defined as vault assets, not hardcoded
+- **Everything as Knowledge** — commands, workflows, property schemas, and layouts defined as vault assets, not hardcoded
 - **Ontology plugins** — extend the system with installable ontology packages (e.g. [GTD + Jedi Techniques](https://github.com/kitelev/gtd-jedi))
 - **Local-first** — all data stays on your device, no cloud required
 

--- a/VISION.md
+++ b/VISION.md
@@ -12,6 +12,30 @@
 
 > "Life is the goal. Awareness is the methodology. Exocortex is the instrument."
 
+### Everything as Knowledge
+
+Exocortex follows the principle of **"Everything as Knowledge"** — an evolution of the "as Code" paradigm. While Infrastructure as Code and Docs as Code describe desired system states in machine-executable files, Exocortex goes further: entities, UI layouts, workflows, commands, and even the schema itself are all **semantic data** in the same format and the same storage.
+
+| Layer | Traditional Approach | Exocortex |
+|-------|---------------------|-----------|
+| Schema | Hardcoded in app or config files | OWL classes and properties as Markdown files in your vault |
+| Workflows | Code (event handlers, scripts) | RDF data: `ems__WorkflowTransition` with states, preconditions, grounding |
+| UI Layouts | JSON/CSS configuration | `pn__Layout` — columns, filters, sorting as semantic data |
+| Commands | Compiled into the plugin | `exocmd__Command` + SPARQL-based preconditions + declarative grounding |
+| Content | Markdown files | Same Markdown files — content and metadata in one place |
+
+This approach gives four advantages over "as Code":
+1. **Composability through a graph** — everything is connected via queryable RDF triples, not just file imports
+2. **Schema = data** — the meta-level lives in the same space as user data; add a file to create a new entity type
+3. **Accessibility** — requires domain expertise, not programming skills
+4. **Foundation for reasoning** — SPARQL queries today, OWL inference potential tomorrow
+
+### Historical Context
+
+Exocortex builds on ideas from the Semantic Web community. [Fresnel](https://www.w3.org/2005/04/fresnel-info/) (W3C, 2005) introduced Lenses and Formats for rendering RDF data, but lacked an action layer. [SHACL](https://www.w3.org/TR/shacl/) describes constraints and UI hints for RDF shapes. Exocortex combines these concepts with an action layer (dynamic commands, workflow state machines), file-based storage (Markdown + YAML frontmatter), and an offline-first runtime (Obsidian).
+
+**Formula:** Exocortex = Fresnel display layer + action layer (RFC-009) + file-based RDF store + Obsidian runtime.
+
 ### The Path to Übermensch
 
 Exocortex is an instrument for becoming **Übermensch** (Nietzsche):


### PR DESCRIPTION
## Summary
- Adds "Why Exocortex" section to README with the "Everything as Knowledge" paradigm and comparison table (vs Notion, Jira, Semantic MediaWiki, Protégé)
- Adds "Everything as Knowledge" and "Historical Context" sections to VISION.md with the Fresnel → SHACL → Exocortex lineage
- Renames "Vault-driven architecture" to "Everything as Knowledge" in README feature list

## Context
Based on a competitive analysis of 15+ systems with dynamic configuration. Exocortex occupies a unique niche: file-based + RDF-native + UI generation + offline-first + personal KM. The "as Knowledge" framing differentiates from "as Code" (IaC, Docs as Code) by emphasizing semantic data over machine-executable definitions.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] VISION.md renders correctly on GitHub
- [ ] No broken links or markdown issues