### PR TITLE
fix: render Area tree widgets for UUID-alias class wikilinks

### DIFF
--- a/packages/exocortex/src/services/AreaHierarchyBuilder.ts
+++ b/packages/exocortex/src/services/AreaHierarchyBuilder.ts
@@ -3,6 +3,7 @@ import { AreaNode, AreaNodeData } from "../domain/models/AreaNode";
 import { AssetClass } from "../domain/constants";
 import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
 import { DI_TOKENS } from "../interfaces/tokens";
+import { WikiLinkHelpers } from "../utilities/WikiLinkHelpers";
 
 export interface AssetRelation {
   path: string;
@@ -48,14 +49,9 @@ export class AreaHierarchyBuilder {
   private extractInstanceClass(metadata: Record<string, unknown>): string {
     const instanceClass = metadata.exo__Instance_class || "";
     if (Array.isArray(instanceClass)) {
-      return this.cleanWikiLink(String(instanceClass[0] || ""));
+      return WikiLinkHelpers.normalize(String(instanceClass[0] || ""));
     }
-    return this.cleanWikiLink(String(instanceClass));
-  }
-
-  private cleanWikiLink(value: string): string {
-    if (typeof value !== "string") return "";
-    return value.replace(/^\[\[|\]\]$/g, "").trim();
+    return WikiLinkHelpers.normalize(String(instanceClass));
   }
 
   private collectAllAreasFromVault(): Map<string, AreaNodeData> {
@@ -99,10 +95,10 @@ export class AreaHierarchyBuilder {
 
     if (Array.isArray(parentProperty)) {
       const firstParent = parentProperty[0] || "";
-      return this.cleanWikiLink(firstParent);
+      return WikiLinkHelpers.normalize(String(firstParent));
     }
 
-    return this.cleanWikiLink(String(parentProperty));
+    return WikiLinkHelpers.normalize(String(parentProperty));
   }
 
   private isArchived(metadata: Record<string, unknown>): boolean {

--- a/packages/exocortex/src/utilities/WikiLinkHelpers.ts
+++ b/packages/exocortex/src/utilities/WikiLinkHelpers.ts
@@ -1,9 +1,34 @@
 export class WikiLinkHelpers {
   private static readonly WIKI_LINK_PATTERN = /\[\[|\]\]/g;
+  private static readonly UUID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+  /**
+   * Normalize a wikilink value to its canonical identifier.
+   *
+   * Handles three frontmatter forms:
+   * - `"[[ems__Area]]"` → `"ems__Area"` (plain wikilink, target is canonical)
+   * - `"[[UUID|ems__Area]]"` → `"ems__Area"` (UUID-alias: target is an opaque
+   *   pointer, alias carries the canonical class/label name — see issue #2764)
+   * - `"[[Some Note|Display]]"` → `"Some Note"` (non-UUID target: target is
+   *   the canonical file basename, display alias is ignored)
+   */
   static normalize(value: string | null | undefined): string {
     if (!value) return "";
-    return value.replace(this.WIKI_LINK_PATTERN, "").trim();
+    const stripped = value.replace(this.WIKI_LINK_PATTERN, "").trim();
+    if (!stripped) return "";
+
+    const pipeIndex = stripped.indexOf("|");
+    if (pipeIndex === -1) return stripped;
+
+    const target = stripped.substring(0, pipeIndex).trim();
+    const alias = stripped.substring(pipeIndex + 1).trim();
+
+    if (this.UUID_PATTERN.test(target)) {
+      return alias || target;
+    }
+
+    return target;
   }
 
   static normalizeArray(

--- a/packages/exocortex/tests/unit/services/AreaHierarchyBuilder.test.ts
+++ b/packages/exocortex/tests/unit/services/AreaHierarchyBuilder.test.ts
@@ -120,6 +120,52 @@ describe("AreaHierarchyBuilder", () => {
       expect(result!.children).toEqual([]);
     });
 
+    it("should build hierarchy when exo__Instance_class uses UUID-alias form (issue #2764)", () => {
+      // Regression for #2764: starter-kit-style frontmatter uses
+      // "[[UUID|ems__Area]]" instead of "[[ems__Area]]" and the widget
+      // would previously render nothing because the class comparison
+      // stripped only brackets and left the "UUID|ems__Area" literal.
+      const file = createMockFile({
+        path: "areas/test-area-uuid.md",
+        basename: "test-area-uuid",
+      });
+      mockVault.getAbstractFileByPath.mockReturnValue(file);
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Instance_class:
+          "[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]",
+        exo__Asset_label: "Test Area UUID",
+      });
+      mockVault.getAllFiles.mockReturnValue([file]);
+
+      const result = builder.buildHierarchy("areas/test-area-uuid.md", []);
+
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe("areas/test-area-uuid.md");
+      expect(result!.label).toBe("Test Area UUID");
+      expect(result!.depth).toBe(0);
+      expect(result!.children).toEqual([]);
+    });
+
+    it("should build hierarchy when exo__Instance_class is an array with UUID-alias form (issue #2764)", () => {
+      const file = createMockFile({
+        path: "areas/array-area.md",
+        basename: "array-area",
+      });
+      mockVault.getAbstractFileByPath.mockReturnValue(file);
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Instance_class: [
+          "[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]",
+        ],
+        exo__Asset_label: "Array Area",
+      });
+      mockVault.getAllFiles.mockReturnValue([file]);
+
+      const result = builder.buildHierarchy("areas/array-area.md", []);
+
+      expect(result).not.toBeNull();
+      expect(result!.label).toBe("Array Area");
+    });
+
     it("should build hierarchy with parent-child relationships", () => {
       const parentFile = createMockFile({
         path: "areas/parent.md",

--- a/packages/exocortex/tests/utilities/WikiLinkHelpers.test.ts
+++ b/packages/exocortex/tests/utilities/WikiLinkHelpers.test.ts
@@ -33,6 +33,55 @@ describe("WikiLinkHelpers", () => {
     it("should handle value with only brackets", () => {
       expect(WikiLinkHelpers.normalize("[[]]")).toBe("");
     });
+
+    describe("UUID-alias wikilinks (issue #2764)", () => {
+      it("should prefer alias when target is a UUID", () => {
+        expect(
+          WikiLinkHelpers.normalize("[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]"),
+        ).toBe("ems__Area");
+      });
+
+      it("should handle UUID-alias with uppercase hex", () => {
+        expect(
+          WikiLinkHelpers.normalize("[[82C74542-1B14-4217-B852-D84730484B25|ems__Project]]"),
+        ).toBe("ems__Project");
+      });
+
+      it("should fall back to UUID when alias is empty", () => {
+        expect(
+          WikiLinkHelpers.normalize("[[82c74542-1b14-4217-b852-d84730484b25|]]"),
+        ).toBe("82c74542-1b14-4217-b852-d84730484b25");
+      });
+
+      it("should prefer target (not alias) when target is non-UUID", () => {
+        // For non-UUID targets, the target is the canonical file basename
+        // and the alias is just display text — keep the target.
+        expect(WikiLinkHelpers.normalize("[[Some Note|Display Label]]")).toBe(
+          "Some Note",
+        );
+      });
+
+      it("should keep working for plain class wikilinks without alias", () => {
+        expect(WikiLinkHelpers.normalize("[[ems__Area]]")).toBe("ems__Area");
+      });
+
+      it("should handle UUID-alias where alias contains special chars", () => {
+        expect(
+          WikiLinkHelpers.normalize("[[82c74542-1b14-4217-b852-d84730484b25|ems__Class Name]]"),
+        ).toBe("ems__Class Name");
+      });
+
+      it("should reject malformed UUID targets (fall through to target)", () => {
+        // "not-a-uuid" doesn't match the UUID pattern, so target (non-UUID branch) is returned
+        expect(WikiLinkHelpers.normalize("[[not-a-uuid|alias]]")).toBe("not-a-uuid");
+      });
+
+      it("should treat a UUID target with multi-pipe alias correctly", () => {
+        expect(
+          WikiLinkHelpers.normalize("[[82c74542-1b14-4217-b852-d84730484b25|label|extra]]"),
+        ).toBe("label|extra");
+      });
+    });
   });
 
   describe("normalizeArray", () => {

--- a/packages/obsidian-plugin/tests/unit/AreaHierarchyBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AreaHierarchyBuilder.test.ts
@@ -70,6 +70,92 @@ describe("AreaHierarchyBuilder", () => {
       expect(result?.depth).toBe(0);
     });
 
+    it("should build hierarchy when exo__Instance_class uses UUID-alias wikilink (issue #2764)", () => {
+      // Regression for #2764: starter-kit-style frontmatter uses
+      // `[[UUID|ems__Area]]` instead of `[[ems__Area]]`. Before the fix,
+      // AreaHierarchyBuilder's internal wikilink normalization returned
+      // the literal `UUID|ems__Area` substring and the !== AREA check
+      // failed, so the widget rendered nothing.
+      const currentAreaPath = "areas/test-area-uuid.md";
+      const uuidAreaFile = {
+        basename: "test-area-uuid",
+        path: currentAreaPath,
+        stat: { ctime: 0, mtime: 0 },
+      };
+
+      mockVaultAdapter.getAbstractFileByPath.mockReturnValue(uuidAreaFile);
+      mockVaultAdapter.getAllFiles.mockReturnValue([uuidAreaFile]);
+      mockVaultAdapter.getFrontmatter.mockReturnValue({
+        exo__Instance_class: [
+          "[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]",
+        ],
+        exo__Asset_label: "Test Area UUID",
+      });
+
+      const result = builder.buildHierarchy(currentAreaPath, []);
+
+      expect(result).not.toBeNull();
+      expect(result?.path).toBe(currentAreaPath);
+      expect(result?.label).toBe("Test Area UUID");
+      expect(result?.children).toHaveLength(0);
+      expect(result?.depth).toBe(0);
+    });
+
+    it("should recognize UUID-alias Area in collectAllAreasFromVault iteration (issue #2764)", () => {
+      // Second regression path: even if the current file is a classic
+      // `[[ems__Area]]`, any OTHER Area in the vault that uses the
+      // UUID-alias form must still be recognized so parent/child linking
+      // works across mixed-form Areas.
+      const rootPath = "areas/root-classic.md";
+      const childPath = "areas/child-uuid.md";
+
+      const rootFile = {
+        basename: "root-classic",
+        path: rootPath,
+        stat: { ctime: 0, mtime: 0 },
+      };
+      const childFile = {
+        basename: "child-uuid",
+        path: childPath,
+        stat: { ctime: 0, mtime: 0 },
+      };
+
+      mockVaultAdapter.getAbstractFileByPath.mockImplementation(
+        (path: string) => {
+          if (path === rootPath) return rootFile;
+          if (path === childPath) return childFile;
+          return null;
+        },
+      );
+      mockVaultAdapter.getAllFiles.mockReturnValue([rootFile, childFile]);
+      mockVaultAdapter.getFrontmatter.mockImplementation((file: any) => {
+        if (file.path === rootPath) {
+          return {
+            exo__Instance_class: ["[[ems__Area]]"],
+            exo__Asset_label: "Classic Root",
+          };
+        }
+        if (file.path === childPath) {
+          return {
+            exo__Instance_class: [
+              "[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]",
+            ],
+            exo__Asset_label: "UUID Child",
+            ems__Area_parent: "[[root-classic]]",
+          };
+        }
+        return null;
+      });
+
+      const result = builder.buildHierarchy(rootPath, []);
+
+      expect(result).not.toBeNull();
+      expect(result?.path).toBe(rootPath);
+      expect(result?.children).toHaveLength(1);
+      expect(result?.children[0]?.path).toBe(childPath);
+      expect(result?.children[0]?.label).toBe("UUID Child");
+    });
+
     it("should build two-level hierarchy with parent-child relationship", () => {
       const rootPath = "areas/root.md";
       const childPath = "areas/child.md";

--- a/packages/obsidian-plugin/tests/unit/utilities/WikiLinkHelpers.uuid-alias.test.ts
+++ b/packages/obsidian-plugin/tests/unit/utilities/WikiLinkHelpers.uuid-alias.test.ts
@@ -1,0 +1,102 @@
+import { WikiLinkHelpers } from "exocortex";
+
+describe("WikiLinkHelpers.normalize — UUID-alias wikilinks (issue #2764)", () => {
+  it("should prefer alias when target is a UUID", () => {
+    expect(
+      WikiLinkHelpers.normalize(
+        "[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]",
+      ),
+    ).toBe("ems__Area");
+  });
+
+  it("should handle uppercase UUID targets", () => {
+    expect(
+      WikiLinkHelpers.normalize(
+        "[[82C74542-1B14-4217-B852-D84730484B25|ems__Project]]",
+      ),
+    ).toBe("ems__Project");
+  });
+
+  it("should fall back to UUID when alias is empty", () => {
+    expect(
+      WikiLinkHelpers.normalize(
+        "[[82c74542-1b14-4217-b852-d84730484b25|]]",
+      ),
+    ).toBe("82c74542-1b14-4217-b852-d84730484b25");
+  });
+
+  it("should prefer target (not alias) when target is non-UUID", () => {
+    // For non-UUID targets, the target is the canonical file basename
+    // and the alias is display-only — keep the target.
+    expect(WikiLinkHelpers.normalize("[[Some Note|Display Label]]")).toBe(
+      "Some Note",
+    );
+  });
+
+  it("should keep working for plain class wikilinks without alias", () => {
+    expect(WikiLinkHelpers.normalize("[[ems__Area]]")).toBe("ems__Area");
+  });
+
+  it("should handle UUID-alias where alias contains spaces", () => {
+    expect(
+      WikiLinkHelpers.normalize(
+        "[[82c74542-1b14-4217-b852-d84730484b25|Custom Class Name]]",
+      ),
+    ).toBe("Custom Class Name");
+  });
+
+  it("should not match a malformed UUID target", () => {
+    // `not-a-uuid` fails the UUID regex, so the target wins (non-UUID branch).
+    expect(WikiLinkHelpers.normalize("[[not-a-uuid|alias]]")).toBe(
+      "not-a-uuid",
+    );
+  });
+
+  it("should treat a UUID target with multi-pipe alias as alias-wins", () => {
+    expect(
+      WikiLinkHelpers.normalize(
+        "[[82c74542-1b14-4217-b852-d84730484b25|label|extra]]",
+      ),
+    ).toBe("label|extra");
+  });
+
+  it("should keep normalizing null and undefined to empty string", () => {
+    expect(WikiLinkHelpers.normalize(null)).toBe("");
+    expect(WikiLinkHelpers.normalize(undefined)).toBe("");
+  });
+
+  it("should keep normalizing empty bracket-only string to empty", () => {
+    expect(WikiLinkHelpers.normalize("[[]]")).toBe("");
+  });
+});
+
+describe("WikiLinkHelpers.equals — UUID-alias wikilinks (issue #2764)", () => {
+  it("should equate UUID-alias form with plain form", () => {
+    expect(
+      WikiLinkHelpers.equals(
+        "[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]",
+        "[[ems__Area]]",
+      ),
+    ).toBe(true);
+  });
+
+  it("should equate UUID-alias form with bare class name", () => {
+    expect(
+      WikiLinkHelpers.equals(
+        "[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]",
+        "ems__Area",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("WikiLinkHelpers.includes — UUID-alias wikilinks (issue #2764)", () => {
+  it("should find UUID-alias form when searching for plain class", () => {
+    expect(
+      WikiLinkHelpers.includes(
+        ["[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]"],
+        "ems__Area",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2764. When `exo__Instance_class` uses the starter-kit UUID-alias form `[[<uuid>|ems__Area]]`, Area Tree and Asset Relations widgets silently failed to render. Properties and COMMANDS kept working because they go through `AssetMetadataService.extractInstanceClass` on the plugin side, which already normalises UUID-alias. The widget path, however, dispatches through `AreaHierarchyBuilder` in `@exocortex/core`, which used its own private `cleanWikiLink` that only stripped `[[` / `]]` and left the literal `"<uuid>|ems__Area"` in place. The `instanceClass !== AssetClass.AREA` check therefore always failed.

## Root cause

`AreaHierarchyBuilder.extractInstanceClass` → `cleanWikiLink` is a duplicate of `WikiLinkHelpers.normalize`, which is itself too dumb for UUID-alias wikilinks. Both helpers just stripped brackets. There is no single canonical normaliser in `@exocortex/core`, so the smart path that `NoteToRDFConverter.valueToClassURI` uses (for RDF triples) never applies to the widget's control flow.

## Fix

1. **Teach `WikiLinkHelpers.normalize` the UUID-alias rule** in `packages/exocortex/src/utilities/WikiLinkHelpers.ts`:
   - `[[ems__Area]]` → `ems__Area` (unchanged)
   - `[[<uuid>|ems__Area]]` → `ems__Area` (**new**: UUID targets are opaque pointers, alias carries the canonical class/label)
   - `[[Some Note|Display]]` → `Some Note` (unchanged: non-UUID target is a file basename, alias is display-only)
   - `[[<uuid>|]]` → `<uuid>` (empty alias → fall back to UUID)
2. **Drop the duplicate `cleanWikiLink`** in `AreaHierarchyBuilder` and route both `extractInstanceClass` and `extractParentPath` through the shared `WikiLinkHelpers.normalize`.

Because `WikiLinkHelpers.normalize` is also used by `hasClass` in the command visibility rules (`packages/exocortex/src/domain/commands/visibility/helpers.ts`), the same fix also aligns command visibility with command-binding for UUID-alias values. No call site was observed failing beforehand, but the semantics are now consistent across both paths.

## Tests

### New

- `packages/obsidian-plugin/tests/unit/utilities/WikiLinkHelpers.uuid-alias.test.ts` — 12 cases covering `normalize`, `equals`, and `includes` with UUID-alias, plain class, non-UUID alias, multi-pipe alias, empty alias, uppercase UUID, and null/undefined inputs.
- `packages/obsidian-plugin/tests/unit/AreaHierarchyBuilder.test.ts` — two regression cases:
  - current file's `exo__Instance_class` uses UUID-alias → widget must still render the root node
  - current file uses classic form, but a **child** Area uses UUID-alias → `collectAllAreasFromVault` iteration must still recognise the child and link it into the tree

### Mirror (core package)

Parallel cases added in `packages/exocortex/tests/` for local core-package runs. CI's `test:unit` script routes core-package tests through the obsidian-plugin jest config, which is where the primary regression coverage lives.

## Verified locally

- `npx jest --config packages/obsidian-plugin/jest.config.js` → **4,423 tests passing, 0 failures** (was 4,399 before; +24 new tests)
- `npm run check:types` → clean
- `npm run lint` → 0 errors (2 pre-existing warnings unrelated)
- Pre-commit hook: eslint + lint-staged jest (related tests) + BDD coverage 100% + archgate 13/13 → all green

## Pre-existing issues observed (not addressed here)

Running `packages/exocortex/jest.config.js` directly surfaces 6 failing tests in `MetadataExtractor`, `QueryExecutor.branch`, `subquery-acceptance`, `FrontmatterService.error`, and a `CommandDefinition` TS error. None of these are run by the CI `test:unit` script (`scripts/test-ci-batched.sh` only configures obsidian-plugin and cli jest configs). They are orthogonal to this fix and should be triaged separately.

## Test plan

- [ ] CI green (build, typecheck, test-unit, test-coverage, test-bdd, archgate, test-component, e2e-tests, performance-tests)
- [ ] Auto Release succeeds
- [ ] Re-test the fix in `regression-test-vault-latest` — the `Test Area UUID.md` file (with `[[UUID|ems__Area]]` frontmatter) should now render **Area tree** and **Asset Relations** after the BRAT auto-update