### PR TITLE
fix: resolve raw vocabulary labels in Asset Relations table (#2765)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -1,6 +1,17 @@
 import React, { useState, useMemo, useRef, useLayoutEffect, useCallback, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function humanizePropertyName(raw: string): string {
+  if (!raw) return raw;
+  if (UUID_REGEX.test(raw)) return raw;
+  if (!raw.includes("__")) return raw;
+  const withoutPrefix = raw.replace(/^[a-z]+__/, "");
+  const spaced = withoutPrefix.replace(/_/g, " ");
+  return spaced.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 export interface AssetRelation {
   path: string;
   title: string;
@@ -146,7 +157,9 @@ const SingleTable: React.FC<SingleTableProps> = ({
     if (typeof value === "string" && isWikiLink(value)) {
       const parsed = parseWikiLink(value);
       const label = getAssetLabel?.(parsed.target);
-      const displayText = parsed.alias || label || parsed.target;
+      const displayText = parsed.alias
+        ? humanizePropertyName(parsed.alias)
+        : label || humanizePropertyName(parsed.target);
 
       return (
         <a
@@ -301,27 +314,34 @@ const SingleTable: React.FC<SingleTableProps> = ({
       return "-";
     }
 
-    return instanceClasses.map((instanceClass, index) => (
-      <React.Fragment key={`${instanceClass.target}-${index}`}>
-        {instanceClass.target !== "-" ? (
-          <a
-            data-href={instanceClass.target}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onAssetClick?.(instanceClass.target, e);
-            }}
-            className="internal-link"
-            style={{ cursor: "pointer" }}
-          >
-            {instanceClass.alias || instanceClass.target}
-          </a>
-        ) : (
-          "-"
-        )}
-        {index < instanceClasses.length - 1 ? ", " : ""}
-      </React.Fragment>
-    ));
+    return instanceClasses.map((instanceClass, index) => {
+      const alias = instanceClass.alias;
+      const target = instanceClass.target;
+      const resolvedLabel = alias
+        ? humanizePropertyName(alias)
+        : getAssetLabel?.(target) || humanizePropertyName(target);
+      return (
+        <React.Fragment key={`${target}-${index}`}>
+          {target !== "-" ? (
+            <a
+              data-href={target}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onAssetClick?.(target, e);
+              }}
+              className="internal-link"
+              style={{ cursor: "pointer" }}
+            >
+              {resolvedLabel}
+            </a>
+          ) : (
+            "-"
+          )}
+          {index < instanceClasses.length - 1 ? ", " : ""}
+        </React.Fragment>
+      );
+    });
   };
 
   const renderRow = (relation: AssetRelation, index: number, style?: React.CSSProperties) => {
@@ -392,7 +412,7 @@ const SingleTable: React.FC<SingleTableProps> = ({
           onClick={() => handleSort("exo__Instance_class")}
           className="sortable"
         >
-          exo__Instance_class{" "}
+          {humanizePropertyName("exo__Instance_class")}{" "}
           {sortState.column === "exo__Instance_class" &&
             (sortState.order === "asc" ? "↑" : "↓")}
         </th>
@@ -403,7 +423,7 @@ const SingleTable: React.FC<SingleTableProps> = ({
             className="sortable"
             style={{ cursor: "pointer" }}
           >
-            {prop}{" "}
+            {humanizePropertyName(prop)}{" "}
             {sortState.column === prop &&
               (sortState.order === "asc" ? "↑" : "↓")}
           </th>
@@ -577,7 +597,7 @@ export const AssetRelationsTable: React.FC<AssetRelationsTableProps> = ({
                 >
                   {isCollapsed ? "▶" : "▼"}
                 </button>
-                <h3 className="group-header">{groupName}</h3>
+                <h3 className="group-header">{humanizePropertyName(groupName)}</h3>
               </div>
               <div
                 className="relation-group-content"

--- a/packages/obsidian-plugin/tests/component/AssetRelationsTable.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/AssetRelationsTable.spec.tsx
@@ -171,36 +171,35 @@ test.describe("AssetRelationsTable Component", () => {
     await expect(component.locator("tbody tr")).toHaveCount(0);
   });
 
-  test("should display exo__Instance_class column", async ({ mount }) => {
+  test("should display Instance Class column with humanized header", async ({ mount }) => {
     const component = await mount(
       <AssetRelationsTable relations={mockRelations} />,
     );
 
-    // Check Instance Class column exists
+    // Column header is humanized from raw IRI "exo__Instance_class" → "Instance Class"
     await expect(
-      component.locator('th:has-text("exo__Instance_class")'),
+      component.locator('th:has-text("Instance Class")'),
     ).toBeVisible();
 
-    // Check Instance Class values are displayed (wiki syntax removed)
-    await expect(component.locator("text=ems__Task")).toBeVisible();
-    await expect(component.locator("text=ems__Project")).toBeVisible();
+    // Cell values are humanized from raw class IRIs
+    await expect(component.locator("text=Task").first()).toBeVisible();
+    await expect(component.locator("text=Project").first()).toBeVisible();
   });
 
-  test("should sort by exo__Instance_class", async ({ mount }) => {
+  test("should sort by Instance Class column", async ({ mount }) => {
     const component = await mount(
       <AssetRelationsTable relations={mockRelations} />,
     );
 
-    // Click exo__Instance_class column
-    await component.locator('th:has-text("exo__Instance_class")').click();
+    // Click humanized column header
+    await component.locator('th:has-text("Instance Class")').click();
 
-    // Check sort indicator
     await expect(
-      component.locator('th:has-text("exo__Instance_class")'),
+      component.locator('th:has-text("Instance Class")'),
     ).toContainText("↑");
   });
 
-  test("should display multiple exo__Instance_class values as comma-separated links", async ({
+  test("should display multiple instance classes as humanized comma-separated links", async ({
     mount,
   }) => {
     const relationsWithMultipleClasses: AssetRelation[] = [
@@ -221,12 +220,12 @@ test.describe("AssetRelationsTable Component", () => {
       <AssetRelationsTable relations={relationsWithMultipleClasses} />,
     );
 
-    // All three classes should be visible
-    await expect(component.locator("text=exo__Prototype")).toBeVisible();
-    await expect(component.locator("text=inbox__Stuff")).toBeVisible();
-    await expect(component.locator("text=ems__Task")).toBeVisible();
+    // All three classes render their humanized display label
+    await expect(component.locator("text=Prototype")).toBeVisible();
+    await expect(component.locator("text=Stuff")).toBeVisible();
+    await expect(component.locator("text=Task").first()).toBeVisible();
 
-    // Each class should be a clickable link
+    // Each class should be a clickable link (data-href keeps the raw target)
     const instanceClassCell = component.locator(".instance-class").first();
     const links = instanceClassCell.locator("a.internal-link");
     await expect(links).toHaveCount(3);
@@ -260,16 +259,16 @@ test.describe("AssetRelationsTable Component", () => {
       />,
     );
 
-    // Click on first class link
-    await component.locator('a:has-text("exo__Prototype")').click();
+    // Click on first class link (displayed as humanized "Prototype", underlying target "exo__Prototype")
+    await component.locator('a:has-text("Prototype")').click();
     expect(clickedPaths).toContain("exo__Prototype");
 
     // Click on second class link
-    await component.locator('a:has-text("inbox__Stuff")').click();
+    await component.locator('a:has-text("Stuff")').click();
     expect(clickedPaths).toContain("inbox__Stuff");
   });
 
-  test("should display single exo__Instance_class value without comma", async ({
+  test("should display single instance class value without comma", async ({
     mount,
   }) => {
     const relationsWithSingleClass: AssetRelation[] = [
@@ -290,7 +289,8 @@ test.describe("AssetRelationsTable Component", () => {
       <AssetRelationsTable relations={relationsWithSingleClass} />,
     );
 
-    await expect(component.locator("text=ems__Task")).toBeVisible();
+    // Rendered as humanized "Task"
+    await expect(component.locator("text=Task").first()).toBeVisible();
 
     // Should have exactly one link in instance-class cell
     const instanceClassCell = component.locator(".instance-class").first();
@@ -696,7 +696,7 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
       />,
     );
 
-    await expect(component.locator('th:has-text("ems__Effort_votes")')).toBeVisible();
+    await expect(component.locator('th:has-text("Effort Votes")')).toBeVisible();
     await expect(component.locator("text=5")).toBeVisible();
     await expect(component.locator("text=3")).toBeVisible();
     await expect(
@@ -718,7 +718,7 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
     );
 
     await expect(
-      component.locator('th:has-text("ems__Effort_votes")'),
+      component.locator('th:has-text("Effort Votes")'),
     ).not.toBeVisible();
     await expect(
       component.locator("button.exocortex-toggle-effort-votes"),
@@ -763,7 +763,7 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
 
     await expect(component.locator(".relation-group")).toBeVisible();
     await expect(
-      component.locator('th:has-text("ems__Effort_status")'),
+      component.locator('th:has-text("Effort Status")'),
     ).toBeVisible();
   });
 
@@ -1005,13 +1005,13 @@ test.describe("AssetRelationsTableWithToggle Component", () => {
       />,
     );
 
-    await component.locator('thead th:has-text("ems__Effort_votes")').click();
+    await component.locator('thead th:has-text("Effort Votes")').click();
 
     const firstRow = component.locator("tbody tr").first();
     const firstValue = await firstRow.locator("td").nth(2).textContent();
     expect(firstValue).toBe("3");
 
-    await expect(component.locator('thead th:has-text("ems__Effort_votes")')).toContainText("↑");
+    await expect(component.locator('thead th:has-text("Effort Votes")')).toContainText("↑");
   });
 
   test("should sort by wiki link dynamic property", async ({ mount }) => {

--- a/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
+++ b/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
@@ -295,7 +295,10 @@ describe("UniversalLayoutRenderer UI Integration", () => {
 
       const headerTexts = Array.from(headers).map((h) => h.textContent?.trim());
       expect(headerTexts.some((text) => text?.startsWith("Name"))).toBeTruthy();
-      expect(headerTexts).toContain("exo__Instance_class");
+      // Column header is humanized from raw IRI "exo__Instance_class" → "Instance Class"
+      expect(
+        headerTexts.some((text) => text?.startsWith("Instance Class")),
+      ).toBeTruthy();
     });
 
     it("should render clickable Instance Class links", async () => {
@@ -342,11 +345,16 @@ describe("UniversalLayoutRenderer UI Integration", () => {
       );
       expect(instanceClassLinks?.length).toBeGreaterThan(0);
 
-      // Verify link text (wiki syntax removed)
+      // Link text is humanized from raw IRI "ems__Task" → "Task";
+      // underlying data-href still points to the raw target for navigation.
       const linkText = instanceClassLinks?.[0]?.textContent?.trim();
-      expect(linkText).toBe("ems__Task");
+      expect(linkText).toBe("Task");
       expect(linkText).not.toContain("[[");
       expect(linkText).not.toContain("]]");
+      expect(linkText).not.toContain("__");
+      expect(instanceClassLinks?.[0]?.getAttribute("data-href")).toBe(
+        "ems__Task",
+      );
     });
 
     it("should handle grouped relations rendering", async () => {

--- a/packages/obsidian-plugin/tests/unit/utilities/humanizePropertyName.test.ts
+++ b/packages/obsidian-plugin/tests/unit/utilities/humanizePropertyName.test.ts
@@ -1,0 +1,71 @@
+import { humanizePropertyName } from "../../../src/presentation/components/AssetRelationsTable";
+
+describe("humanizePropertyName", () => {
+  describe("prefix stripping", () => {
+    it("strips exo__ prefix and humanizes", () => {
+      expect(humanizePropertyName("exo__Instance_class")).toBe("Instance Class");
+    });
+
+    it("strips ems__ prefix and humanizes multi-word names", () => {
+      expect(humanizePropertyName("ems__Effort_status")).toBe("Effort Status");
+    });
+
+    it("strips ims__ prefix", () => {
+      expect(humanizePropertyName("ims__Concept_broader")).toBe("Concept Broader");
+    });
+
+    it("strips ztlk__ prefix", () => {
+      expect(humanizePropertyName("ztlk__FleetingNote_body")).toBe("FleetingNote Body");
+    });
+
+    it("handles class names (no field suffix)", () => {
+      expect(humanizePropertyName("ems__Task")).toBe("Task");
+      expect(humanizePropertyName("ems__Area")).toBe("Area");
+      expect(humanizePropertyName("ems__Project")).toBe("Project");
+    });
+  });
+
+  describe("no-prefix passthrough", () => {
+    it("passes through human-readable strings unchanged", () => {
+      expect(humanizePropertyName("Body Links")).toBe("Body Links");
+    });
+
+    it("passes through plain lowercase words unchanged (assumed already friendly)", () => {
+      expect(humanizePropertyName("title")).toBe("title");
+    });
+
+    it("passes through camelCase custom property names unchanged", () => {
+      expect(humanizePropertyName("assignedTo")).toBe("assignedTo");
+    });
+
+    it("passes through snake_case without IRI-prefix unchanged", () => {
+      expect(humanizePropertyName("created_at")).toBe("created_at");
+    });
+  });
+
+  describe("UUID guard", () => {
+    it("passes through UUIDs unchanged (no humanization garbage)", () => {
+      const uuid = "82c74542-1b14-4217-b852-d84730484b25";
+      expect(humanizePropertyName(uuid)).toBe(uuid);
+    });
+
+    it("passes through uppercase UUIDs", () => {
+      const uuid = "82C74542-1B14-4217-B852-D84730484B25";
+      expect(humanizePropertyName(uuid)).toBe(uuid);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty string unchanged", () => {
+      expect(humanizePropertyName("")).toBe("");
+    });
+
+    it("handles single-word property without underscore", () => {
+      expect(humanizePropertyName("exo__Label")).toBe("Label");
+    });
+
+    it("preserves alphanumeric class names like ems__EffortStatusBacklog", () => {
+      expect(humanizePropertyName("ems__EffortStatusBacklog")).toBe("EffortStatusBacklog");
+    });
+  });
+});


### PR DESCRIPTION
Partial fix for #2765 (Getting Started Guide accuracy audit).

## Summary

- Column headers, group headers, and instance-class cells in the Asset Relations widget no longer leak raw IRI-style property names and class identifiers.
- Adds a small pure helper `humanizePropertyName` exported from `AssetRelationsTable.tsx`, with 14 unit tests covering prefix stripping, UUID guard, and non-IRI passthrough.
- Updated existing component-test assertions that relied on the raw vocabulary.

## Before / After (regression-test-vault-latest → Test Area.md → Asset Relations)

| Location | Before | After |
|---|---|---|
| Group header | `ems__Effort_area` | `Effort Area` |
| Column: Instance class | `exo__Instance_class` | `Instance Class` |
| Column: Effort status | `ems__Effort_status` | `Effort Status` |
| Cell: class IRI | `ems__Project` | `Project` |
| Cell: alias-is-IRI `[[UUID\|ems__Area]]` | `ems__Area` | `Area` |
| Cell: status wikilink | `ems__EffortStatusBacklog` | `EffortStatusBacklog` (prefix stripped) |

## humanizePropertyName rule

```
humanizePropertyName(raw):
  if empty        → passthrough
  if UUID         → passthrough (no transformation garbage)
  if no "__"      → passthrough (already friendly: "Body Links", "assignedTo", "property1")
  otherwise       → strip lowercase "prefix__", replace "_" with " ", title-case each word
```

This preserves every existing component test that asserts custom property names like `assignedTo`, `property1`, or `Body Links` unchanged, while fixing the vocab leak for `exo__`, `ems__`, `ims__`, `ztlk__`, `inbox__`, and `exocmd__` namespaces.

Full word-boundary splitting of PascalCase class names (e.g., `EffortStatusBacklog` → `Effort Status Backlog`) is intentionally out of scope — the backing class file's `exo__Asset_label`, when present, should take precedence, and we already resolve via `getAssetLabel` before falling back to humanization.

## Residual #2765 items (follow-up PRs)

- [ ] Properties column truncation on narrow layouts (#2766)
- [ ] Daily note date label rendering (#2766)
- [ ] Daily Projects day-property (`ems__Effort_day` vs `ems__Effort_plannedStartTimestamp`) mismatch (#2765/#2766)
- [ ] Area tree empty-state wording ("No areas to display" → clearer copy)

## Test plan

- [x] 14 new unit tests in `tests/unit/utilities/humanizePropertyName.test.ts` — all pass
- [x] 6 existing Playwright component tests updated to expect humanized headers/cells
- [x] Full obsidian-plugin Jest suite green (`4,427 passed`, 3 skipped; 212/213 suites; remaining suite is a flaky SIGSEGV worker unrelated to the change, passes in isolation)
- [x] `npm run check:types` clean
- [x] `npm run lint` clean (0 errors, 2 pre-existing warnings)
- [x] BDD coverage 100% (222/222), Archgate 13/13 pass
- [x] Visually re-verified in `regression-test-vault-latest` on `Test Area.md` (screenshot evidence captured during development)
- [ ] CI green on all 8 required checks
- [ ] Auto Release publishes new patch version
- [ ] Visual re-verification after merge with released plugin version