### PR TITLE
refactor: remove ems__Effort_day orphan from plugin types and stale docs (#2765)

### DIFF
--- a/docs/PROPERTY_SCHEMA.md
+++ b/docs/PROPERTY_SCHEMA.md
@@ -411,17 +411,17 @@ ems__Effort_votes: 5
 
 ### ems\_\_Effort_day
 
-**Planned day for effort execution**
+**User-facing day tag for SPARQL search**
 
-| Attribute     | Value                                            |
-| ------------- | ------------------------------------------------ |
-| **Type**      | String (WikiLink to date)                        |
-| **Required**  | No                                               |
-| **Format**    | `"[[YYYY-MM-DD]]"`                               |
-| **Purpose**   | Schedule task for specific day                   |
-| **Generated** | By "Plan on Today" or "Plan for Evening" command |
-| **Mutable**   | ✅ Yes (can reschedule)                          |
-| **Used For**  | Daily task aggregation view                      |
+| Attribute     | Value                                                |
+| ------------- | ---------------------------------------------------- |
+| **Type**      | String (WikiLink to date)                            |
+| **Required**  | No                                                   |
+| **Format**    | `"[[YYYY-MM-DD]]"`                                   |
+| **Purpose**   | Optional user-managed tag for SPARQL day queries     |
+| **Generated** | Manually by user or via SPARQL/Dataview queries      |
+| **Mutable**   | ✅ Yes                                               |
+| **Used For**  | SPARQL filtering only (not read by plugin renderers) |
 
 **Example**:
 
@@ -429,12 +429,11 @@ ems__Effort_votes: 5
 ems__Effort_day: "[[2025-10-26]]"
 ```
 
-**Commands that set this**:
+**Notes**:
 
-- "Plan on Today" → Sets to today's date
-- "Plan for Evening" → Sets to today + adds plannedStartTimestamp
-- "Shift Day Forward" → Adds 1 day
-- "Shift Day Backward" → Subtracts 1 day
+- Plugin daily-note aggregation filters tasks by `ems__Effort_startTimestamp`, `ems__Effort_endTimestamp`, `ems__Effort_plannedStartTimestamp`, and `ems__Effort_plannedEndTimestamp` — NOT by `ems__Effort_day`.
+- Planning commands (`Plan on Today`, `Plan for Evening`, `Shift Day Forward/Backward`) update `ems__Effort_plannedStartTimestamp`, not `ems__Effort_day`.
+- This property remains part of the public `ems:` SPARQL vocabulary (see `cli/docs/ONTOLOGY_REFERENCE.md`) — set it manually if you need day-tagging for custom queries.
 
 ---
 

--- a/docs/Plugin-Commands.md
+++ b/docs/Plugin-Commands.md
@@ -293,7 +293,7 @@ Commands for scheduling and organizing efforts.
 **Updates**:
 
 ```yaml
-ems__Effort_day: "[[2025-11-10]]" # Wiki-link to today's date
+ems__Effort_plannedStartTimestamp: "2025-11-10T00:00:00" # Today at start of day (local time)
 ```
 
 **Visibility**: Available on efforts (tasks/projects).
@@ -306,13 +306,12 @@ ems__Effort_day: "[[2025-11-10]]" # Wiki-link to today's date
 **Button**: "Plan for Evening"
 **Keyboard**: Cmd/Ctrl + P → "Plan for Evening"
 
-**Purpose**: Schedule effort for today's evening (18:00).
+**Purpose**: Schedule effort for today's evening (19:00).
 
 **Updates**:
 
 ```yaml
-ems__Effort_day: "[[2025-11-10]]"
-ems__Effort_plannedStartTimestamp: "2025-11-10T19:00:00.000Z" # ISO 8601 timestamp
+ems__Effort_plannedStartTimestamp: "2025-11-10T19:00:00" # Today at 19:00 (local time)
 ```
 
 **Visibility**: Available on efforts.
@@ -327,9 +326,9 @@ ems__Effort_plannedStartTimestamp: "2025-11-10T19:00:00.000Z" # ISO 8601 timesta
 
 **Purpose**: Reschedule effort to next day.
 
-**Updates**: Increments `ems__Effort_day` by 1 day.
+**Updates**: Adds 1 day to `ems__Effort_plannedStartTimestamp` (keeps 00:00:00 local time).
 
-**Example**: 2025-11-10 → 2025-11-11
+**Example**: `2025-11-10T00:00:00` → `2025-11-11T00:00:00`
 
 **Visibility**: Available on scheduled efforts.
 
@@ -343,9 +342,9 @@ ems__Effort_plannedStartTimestamp: "2025-11-10T19:00:00.000Z" # ISO 8601 timesta
 
 **Purpose**: Reschedule effort to previous day.
 
-**Updates**: Decrements `ems__Effort_day` by 1 day.
+**Updates**: Subtracts 1 day from `ems__Effort_plannedStartTimestamp` (keeps 00:00:00 local time).
 
-**Example**: 2025-11-10 → 2025-11-09
+**Example**: `2025-11-10T00:00:00` → `2025-11-09T00:00:00`
 
 **Visibility**: Available on scheduled efforts.
 
@@ -770,12 +769,12 @@ Commands appear contextually based on note type and state:
 
 ### By Properties
 
-| Property           | Required Commands          |
-| ------------------ | -------------------------- |
-| `ems__Effort_day`  | Shift Day Forward/Backward |
-| `exo__Asset_label` | Copy Label to Aliases      |
-| UID property       | Rename to UID              |
-| Not archived       | Archive Task               |
+| Property                            | Required Commands          |
+| ----------------------------------- | -------------------------- |
+| `ems__Effort_plannedStartTimestamp` | Shift Day Forward/Backward |
+| `exo__Asset_label`                  | Copy Label to Aliases      |
+| UID property                        | Rename to UID              |
+| Not archived                        | Archive Task               |
 
 ---
 

--- a/packages/obsidian-plugin/src/application/services/PropertyDependencyResolver.ts
+++ b/packages/obsidian-plugin/src/application/services/PropertyDependencyResolver.ts
@@ -29,9 +29,6 @@ export class PropertyDependencyResolver {
     "ems__Effort_votes": [
       LayoutSection.DAILY_TASKS,
     ],
-    "ems__Effort_day": [
-      LayoutSection.DAILY_TASKS,
-    ],
     "ems__Effort_area": [
       LayoutSection.DAILY_TASKS,
     ],

--- a/packages/obsidian-plugin/src/types/index.ts
+++ b/packages/obsidian-plugin/src/types/index.ts
@@ -20,7 +20,6 @@ export interface AssetMetadata {
   ems__Effort_status?: string | string[];
   ems__Effort_votes?: number;
   exo__Asset_prototype?: string;
-  ems__Effort_day?: string;
   ems__Effort_startTimestamp?: string | number;
   ems__Effort_plannedStartTimestamp?: string | number;
   ems__Effort_endTimestamp?: string | number;

--- a/packages/obsidian-plugin/tests/unit/PropertyDependencyResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PropertyDependencyResolver.test.ts
@@ -60,13 +60,6 @@ describe("PropertyDependencyResolver", () => {
       expect(sections).toHaveLength(1);
     });
 
-    it("should map ems__Effort_day to Daily Tasks", () => {
-      const sections = resolver.getAffectedSections(["ems__Effort_day"]);
-
-      expect(sections).toContain(LayoutSection.DAILY_TASKS);
-      expect(sections).toHaveLength(1);
-    });
-
     it("should map ems__Effort_area to Daily Tasks", () => {
       const sections = resolver.getAffectedSections(["ems__Effort_area"]);
 


### PR DESCRIPTION
## Summary

Follow-up to #2770. Removes the `ems__Effort_day` dead-code residuals from `packages/obsidian-plugin` and fixes stale documentation that misrepresented plugin command behavior.

## Context

The `ems__Effort_day` field was declared in `AssetMetadata` and listed as a `DAILY_TASKS` re-render trigger in `PropertyDependencyResolver`, but:

- **No renderer reads it.** `DailyTasksRenderer` delegates filtering to `DailyNoteHelpers.isEffortInDay()`, which only checks `ems__Effort_startTimestamp`, `ems__Effort_endTimestamp`, `ems__Effort_plannedStartTimestamp`, and `ems__Effort_plannedEndTimestamp`.
- **No plugin command writes it.** `TaskStatusService.planOnToday`, `planForEvening`, and `shiftDay` all update `ems__Effort_plannedStartTimestamp`.
- **No Starter Kit exocmd writes it.** `Plan on Today` / `Plan for Evening` use `service_call` grounding to the services above — verified by grep against `/Users/kitelev/Developer/exocortex-starter-kit`.

The property remains part of the public `ems:` SPARQL vocabulary (see `packages/cli/docs/ONTOLOGY_REFERENCE.md`), so users can still set it manually for custom Dataview / SPARQL queries.

## Changes

**Plugin code**:
- Remove `ems__Effort_day?: string` from `AssetMetadata` interface (indexer `[key: string]: unknown` still covers test fixture usage).
- Remove `ems__Effort_day` entry from `PropertyDependencyResolver.PROPERTY_DEPENDENCIES`.
- Remove matching assertion in `PropertyDependencyResolver.test.ts`.

**Docs fixes** (previously lied about what plugin commands do):
- `docs/Plugin-Commands.md`: `Plan on Today`, `Plan for Evening`, `Shift Day Forward/Backward` sections now describe the actual behavior (`ems__Effort_plannedStartTimestamp`), with accurate formats.
- `docs/PROPERTY_SCHEMA.md`: `ems__Effort_day` rewritten from "command-managed" to "user-managed SPARQL tag" with explicit note that plugin commands don't touch it.

## Out of scope

- BDD self-simulation in `specs/step_definitions/common.steps.ts` / `daily-tasks.steps.ts` that still references `ems__Effort_day` — deferred; those are world.ts helpers for scenario setup, not plugin code.
- Test fixtures with `ems__Effort_day: "[[...]]"` (~40 files) — retained as harmless noise data; removing them is massive churn for zero benefit.
- `packages/test-utils/src/factories/project.factory.ts` `DailyProject` factory — unrelated, deferred.

## Test plan

- [x] `npm test` (unit + UI + component): 537 passed, 2 flaky playwright context timeouts retried → all pass.
- [x] BDD coverage: 100% (214/214).
- [x] Archgate: all 13 rules pass.
- [ ] CI 8 required checks on PR.
- [ ] Auto Release publishes new patch version.