### PR TITLE
refactor: remove orphan DailyProject factory from test-utils (#2765)

### DIFF
--- a/packages/test-utils/src/factories/project.factory.ts
+++ b/packages/test-utils/src/factories/project.factory.ts
@@ -7,25 +7,14 @@
  *
  * // Project with specific status
  * const doingProject = ProjectFactory.doing();
- *
- * // DailyProject for React components
- * const dailyProject = ProjectFactory.createDailyProject();
  */
 
 import type {
   ProjectFixture,
-  DailyProject,
-  EffortStatus,
-  EffortStatusName,
   FileInfo,
   Metadata,
 } from "../types";
-import {
-  STATUS_MAP,
-  normalizeStatus,
-  isDoneStatus,
-  isTrashedStatus,
-} from "../helpers/status.helpers";
+import { normalizeStatus } from "../helpers/status.helpers";
 
 let projectCounter = 0;
 
@@ -177,97 +166,6 @@ export const ProjectFactory = {
    */
   inArea(area: string, overrides: Partial<ProjectFixture> = {}): ProjectFixture {
     return ProjectFactory.create({ area, ...overrides });
-  },
-
-  // DailyProject factory methods for React component tests
-
-  /**
-   * Create a DailyProject for React component tests.
-   */
-  createDailyProject(overrides: Partial<DailyProject> = {}): DailyProject {
-    const id = generateId();
-    const basename = overrides.file?.basename ?? id;
-    const path = overrides.path ?? overrides.file?.path ?? `projects/${basename}.md`;
-    const status = overrides.status ?? "ems__EffortStatusDraft";
-    const normalizedStatus = status.startsWith("ems__")
-      ? status
-      : STATUS_MAP[status as EffortStatusName] ?? "ems__EffortStatusDraft";
-
-    return {
-      file: {
-        path,
-        basename,
-        ...overrides.file,
-      },
-      path,
-      title: overrides.title ?? basename,
-      label: overrides.label ?? `Test Project ${projectCounter}`,
-      startTime: overrides.startTime ?? "",
-      endTime: overrides.endTime ?? "",
-      startTimestamp: overrides.startTimestamp ?? null,
-      endTimestamp: overrides.endTimestamp ?? null,
-      status: normalizedStatus,
-      metadata: overrides.metadata ?? {},
-      isDone: overrides.isDone ?? isDoneStatus(normalizedStatus as EffortStatus),
-      isTrashed: overrides.isTrashed ?? isTrashedStatus(normalizedStatus as EffortStatus),
-      isBlocked: overrides.isBlocked ?? false,
-    };
-  },
-
-  /**
-   * Create multiple DailyProjects for React component tests.
-   */
-  createManyDailyProjects(
-    count: number,
-    overrides: Partial<DailyProject> = {}
-  ): DailyProject[] {
-    return Array.from({ length: count }, () =>
-      ProjectFactory.createDailyProject(overrides)
-    );
-  },
-
-  // DailyProject convenience methods
-
-  /**
-   * Create a DailyProject with Doing status.
-   */
-  dailyProjectDoing(overrides: Partial<DailyProject> = {}): DailyProject {
-    return ProjectFactory.createDailyProject({
-      status: "ems__EffortStatusDoing",
-      ...overrides,
-    });
-  },
-
-  /**
-   * Create a DailyProject with Done status.
-   */
-  dailyProjectDone(overrides: Partial<DailyProject> = {}): DailyProject {
-    return ProjectFactory.createDailyProject({
-      status: "ems__EffortStatusDone",
-      isDone: true,
-      ...overrides,
-    });
-  },
-
-  /**
-   * Create a DailyProject with Trashed status.
-   */
-  dailyProjectTrashed(overrides: Partial<DailyProject> = {}): DailyProject {
-    return ProjectFactory.createDailyProject({
-      status: "ems__EffortStatusTrashed",
-      isTrashed: true,
-      ...overrides,
-    });
-  },
-
-  /**
-   * Create a blocked DailyProject.
-   */
-  dailyProjectBlocked(overrides: Partial<DailyProject> = {}): DailyProject {
-    return ProjectFactory.createDailyProject({
-      isBlocked: true,
-      ...overrides,
-    });
   },
 
   // Metadata conversion

--- a/packages/test-utils/src/types.ts
+++ b/packages/test-utils/src/types.ts
@@ -117,7 +117,7 @@ export interface MeetingFixture extends TaskFixture {
 /**
  * Concept fixture for unit tests.
  */
-export interface ConceptFixture extends BaseFixture {}
+export type ConceptFixture = BaseFixture;
 
 /**
  * DailyTask interface matching the React component interface.
@@ -139,25 +139,6 @@ export interface DailyTask {
   isMeeting: boolean;
   isBlocked: boolean;
   isEmptySlot?: boolean;
-}
-
-/**
- * DailyProject interface matching the React component interface.
- */
-export interface DailyProject {
-  file: FileInfo;
-  path: string;
-  title: string;
-  label: string;
-  startTime: string;
-  endTime: string;
-  startTimestamp: string | number | null;
-  endTimestamp: string | number | null;
-  status: string;
-  metadata: Record<string, unknown>;
-  isDone: boolean;
-  isTrashed: boolean;
-  isBlocked: boolean;
 }
 
 /**

--- a/packages/test-utils/tests/factories.test.ts
+++ b/packages/test-utils/tests/factories.test.ts
@@ -231,16 +231,6 @@ describe("ProjectFactory", () => {
     expect(project.status).toBe("ems__EffortStatusDoing");
   });
 
-  it("should create DailyProject", () => {
-    const dailyProject = ProjectFactory.createDailyProject();
-
-    expect(dailyProject.file).toBeDefined();
-    expect(dailyProject.status).toBe("ems__EffortStatusDraft");
-    expect(dailyProject.isDone).toBe(false);
-    expect(dailyProject.isTrashed).toBe(false);
-    expect(dailyProject.isBlocked).toBe(false);
-  });
-
   it("should convert project to metadata", () => {
     const project = ProjectFactory.create({ label: "My Project", area: "work" });
     const metadata = ProjectFactory.toMetadata(project);


### PR DESCRIPTION
Final residual of the Daily Projects / `ems__Effort_day` dead-code arc (#2167 → #2770 → #2771 → #2772 → this PR).

The `DailyProject` interface and factory methods in `packages/test-utils/` have been orphan since commit `4a1b01d3` (#2167, 2026-02-19) when `DailyProjectsRenderer.ts` was removed. No React component, runtime code, or other test imports `DailyProject` — grep verified zero consumers outside `packages/test-utils/` itself.

## Summary

- Delete `DailyProject` interface from `packages/test-utils/src/types.ts`
- Delete 6 `DailyProject` factory methods from `packages/test-utils/src/factories/project.factory.ts` (`createDailyProject`, `createManyDailyProjects`, `dailyProjectDoing/Done/Trashed/Blocked`)
- Delete connected-component orphan imports (`DailyProject`, `EffortStatus`, `EffortStatusName`, `STATUS_MAP`, `isDoneStatus`, `isTrashedStatus`)
- Delete single `DailyProject` test case from `packages/test-utils/tests/factories.test.ts`
- Convert empty `ConceptFixture` interface to type alias (lint-staged blocked the commit on a pre-existing `@typescript-eslint/no-empty-object-type` in the same file)

133 deletions, 2 insertions. Pure cleanup.

## Out of scope

- Remaining #2765 residuals (UI polish items — Properties column, date label, PascalCase splitting) — separate walkthrough PRs
- #2766 first-run UX polish — separate issue

## Test plan

- [x] `npm run check:types` — TS strict clean, no cascade orphans remain
- [x] `npm test` (unit + ui + component) — all green: test-unit batched ✅, test-ui jest 53 passed ✅, test-component playwright 539 passed ✅
- [ ] CI green (8 required checks)
- [ ] Auto Release publishes new patch