### PR TITLE
fix(area-tree): differentiate empty state copy for new vs filtered (#2766)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AreaHierarchyTree.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AreaHierarchyTree.tsx
@@ -235,6 +235,15 @@ export const AreaHierarchyTreeWithToggle: React.FC<AreaHierarchyTreeWithTogglePr
   }, [tree, showArchived]);
 
   if (!filteredTree.children || filteredTree.children.length === 0) {
+    // Distinguish "no sub-areas exist at all" (new top-level area, normal state)
+    // from "sub-areas exist but the current filter hid them all" (action needed).
+    // Issue #2766 item 4: the previous "No areas to display" message read as a
+    // bug to first-time users opening their first top-level area.
+    const hasAnyChildren = !!tree?.children && tree.children.length > 0;
+    const emptyMessage = hasAnyChildren
+      ? "No sub-areas match the current filter."
+      : "Sub-areas you create here will appear in this tree.";
+
     return (
       <div className="exocortex-area-tree-wrapper">
         <div className="exocortex-area-tree-controls">
@@ -253,7 +262,7 @@ export const AreaHierarchyTreeWithToggle: React.FC<AreaHierarchyTreeWithTogglePr
         </div>
         <div className="exocortex-area-tree">
           <h3>Area Hierarchy</h3>
-          <p className="exocortex-no-areas">No areas to display</p>
+          <p className="exocortex-no-areas">{emptyMessage}</p>
         </div>
       </div>
     );

--- a/packages/obsidian-plugin/tests/unit/presentation/components/AreaHierarchyTree.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/AreaHierarchyTree.test.tsx
@@ -274,7 +274,7 @@ describe("AreaHierarchyTreeWithToggle", () => {
       expect(screen.getByText("Child 2")).toBeInTheDocument();
     });
 
-    it("should show 'No areas to display' when all areas are filtered out", () => {
+    it("should show filter empty-state message when all areas are filtered out", () => {
       const allArchivedTree: AreaNode = {
         path: "root",
         title: "Root",
@@ -299,7 +299,10 @@ describe("AreaHierarchyTreeWithToggle", () => {
       });
       render(<AreaHierarchyTreeWithToggle {...props} />);
 
-      expect(screen.getByText("No areas to display")).toBeInTheDocument();
+      // Children exist but the active filter hides them — distinct message.
+      expect(
+        screen.getByText("No sub-areas match the current filter.")
+      ).toBeInTheDocument();
     });
 
     it("should also filter out children of archived areas", () => {
@@ -312,14 +315,17 @@ describe("AreaHierarchyTreeWithToggle", () => {
   });
 
   describe("empty tree handling", () => {
-    it("should handle tree with no children", () => {
+    it("should show top-level-area empty-state message when tree has no children", () => {
       const props = createProps({
         tree: createMockTree({ children: [] }),
         showArchived: false,
       });
       render(<AreaHierarchyTreeWithToggle {...props} />);
 
-      expect(screen.getByText("No areas to display")).toBeInTheDocument();
+      // First-time / top-level-area state — friendly explanation, not a bug.
+      expect(
+        screen.getByText("Sub-areas you create here will appear in this tree.")
+      ).toBeInTheDocument();
     });
 
     it("should still show toggle button when tree is empty", () => {


### PR DESCRIPTION
## Summary

**Closes (one item from)**: #2766 — first-run UX polish, item 4.

When a brand-new top-level Area is opened, the Area Tree widget renders the message **"No areas to display"**. For a first-time user this reads as a bug — they just created the area and the tree appears empty. The current copy was contributed back when the same code path also caught "tree filtered to nothing" cases, so a generic message was the safe choice.

This PR distinguishes the two cases by inspecting the **pre-filter** `tree.children` rather than `filteredTree.children`:

| Case | Old copy | New copy |
| --- | --- | --- |
| New top-level area, no children | "No areas to display" | "Sub-areas you create here will appear in this tree." |
| Tree had children but filter hid them all | "No areas to display" | "No sub-areas match the current filter." |

The Show/Hide Archived toggle still renders in both branches, so a user that hit the filter case can recover in one click.

## Test plan

- [x] Updated 2 existing tests in `AreaHierarchyTree.test.tsx`:
  - "should show 'No areas to display' when all areas are filtered out" → "should show filter empty-state message when all areas are filtered out"
  - "should handle tree with no children" → "should show top-level-area empty-state message when tree has no children"
- [x] All 21 tests in the suite pass (`npx jest .../AreaHierarchyTree.test.tsx`)
- [x] `npm run test:all` (unit + component + bdd:check + archgate) — green
- [ ] CI green (8 mandatory checks)
- [ ] Auto Release publishes new patch version
- [ ] Verified in fresh `/e2e-getting-started` walkthrough on the new release

Refs: #2766 (item 4)