### PR TITLE
fix(daily-tasks): suppress time portion for date-only timestamps (#2766)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/DailyTasksTable.tsx
@@ -1,3 +1,3 @@
 export type { DailyTask, DailyTasksTableProps, DailyTasksTableWithToggleProps, WikiLink } from './daily-tasks';
 export { DailyTasksTable, DailyTasksTableWithToggle, DailyTasksTableRow } from './daily-tasks';
-export { calculateTimeFromTimestamps, periodsOverlap, isContextTask, parseWikiLink, formatTimeEstimate, getDisplayName, getEffortAreaDisplayText, formatTimeDisplay, createEmptySlot, calculateEmptySlots } from './daily-tasks';
+export { calculateTimeFromTimestamps, periodsOverlap, isContextTask, parseWikiLink, formatTimeEstimate, getDisplayName, getEffortAreaDisplayText, formatTimeDisplay, isDateOnlyTimestamp, createEmptySlot, calculateEmptySlots } from './daily-tasks';

--- a/packages/obsidian-plugin/src/presentation/components/daily-tasks/helpers.ts
+++ b/packages/obsidian-plugin/src/presentation/components/daily-tasks/helpers.ts
@@ -187,12 +187,41 @@ export const getEffortAreaDisplayText = (
   }
 };
 
+const DATE_ONLY_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Detects "date only" string timestamps that have no time component.
+ *
+ * Such values get parsed by `new Date()` as UTC midnight, which then renders
+ * as the wrong wall-clock hour in any non-UTC timezone — e.g. `"2025-11-10"`
+ * displays as `05:00` for a viewer in `Asia/Almaty` (UTC+5).
+ *
+ * Issue #2766 item 6: callers should suppress the time portion when this
+ * helper returns true so the daily layout does not leak the local timezone
+ * offset of whoever happens to be viewing the vault.
+ */
+export const isDateOnlyTimestamp = (
+  value: unknown,
+): value is string =>
+  typeof value === "string" && DATE_ONLY_TIMESTAMP_REGEX.test(value);
+
 export const formatTimeDisplay = (
   timestamp: string | number | null | undefined,
   fallbackFormatted: string,
   showFullDateInEffortTimes: boolean,
 ): string => {
   if (!timestamp) return fallbackFormatted || "-";
+
+  // Date-only strings have no real time component. Computing one via
+  // `new Date(...).getHours()` would expose the viewer's timezone offset,
+  // so suppress it (Issue #2766 item 6).
+  if (isDateOnlyTimestamp(timestamp)) {
+    if (showFullDateInEffortTimes) {
+      // Pure-string slice avoids any Date / TZ involvement: "YYYY-MM-DD" → "MM-DD".
+      return timestamp.slice(5);
+    }
+    return fallbackFormatted || "-";
+  }
 
   const date = new Date(timestamp);
   if (isNaN(date.getTime())) return fallbackFormatted || "-";

--- a/packages/obsidian-plugin/src/presentation/components/daily-tasks/index.ts
+++ b/packages/obsidian-plugin/src/presentation/components/daily-tasks/index.ts
@@ -13,6 +13,7 @@ export {
   getDisplayName,
   getEffortAreaDisplayText,
   formatTimeDisplay,
+  isDateOnlyTimestamp,
   createEmptySlot,
   calculateEmptySlots,
 } from './helpers';

--- a/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
@@ -6,6 +6,7 @@ import { ReactRenderer } from '@plugin/presentation/utils/ReactRenderer';
 import {
   DailyTask,
   DailyTasksTableWithToggle,
+  isDateOnlyTimestamp,
 } from '@plugin/presentation/components/DailyTasksTable';
 import { AssetClass, EffortStatus, IVaultAdapter, IFile } from "exocortex";
 import { MetadataExtractor } from "exocortex";
@@ -200,6 +201,10 @@ export class DailyTasksRenderer {
           timestamp: string | number | null | undefined,
         ): string => {
           if (!timestamp) return "";
+          // Date-only strings ("2025-11-10") have no time component; deriving
+          // hours from `new Date(...)` would expose the viewer's timezone offset
+          // (Issue #2766 item 6 — would render as "05:00" in Asia/Almaty).
+          if (isDateOnlyTimestamp(timestamp)) return "";
           const date = new Date(timestamp);
           if (isNaN(date.getTime())) return "";
           return date.toLocaleTimeString("en-US", {

--- a/packages/obsidian-plugin/tests/unit/presentation/components/DailyTasksTable.dateOnlyTimestamp.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/DailyTasksTable.dateOnlyTimestamp.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for date-only timestamp handling in DailyTasksTable helpers.
+ *
+ * Issue #2766 item 6: Daily Note Tasks table renders date-only timestamps
+ * (like `"2025-11-10"`) as a wall-clock hour by feeding them to `new Date()`,
+ * which parses them as UTC midnight. In any non-UTC timezone the result is
+ * the local timezone offset (e.g. `"05:00"` in `Asia/Almaty` / UTC+5).
+ *
+ * The fix introduces `isDateOnlyTimestamp` and teaches `formatTimeDisplay`
+ * to suppress the time portion when the underlying value has no time.
+ */
+
+import {
+  isDateOnlyTimestamp,
+  formatTimeDisplay,
+} from '@plugin/presentation/components/DailyTasksTable';
+
+describe('Issue #2766 item 6: date-only timestamp handling', () => {
+  describe('isDateOnlyTimestamp', () => {
+    it.each([
+      '2025-11-10',
+      '2025-01-01',
+      '1999-12-31',
+      '2099-06-15',
+    ])('returns true for ISO date-only string %s', (value) => {
+      expect(isDateOnlyTimestamp(value)).toBe(true);
+    });
+
+    it.each([
+      '2025-11-10T00:00:00',
+      '2025-11-10T05:30:00+05:00',
+      '2025-11-10 12:00',
+      '2025/11/10',
+      'Mon Nov 10 2025',
+      '',
+    ])('returns false for non-date-only string %s', (value) => {
+      expect(isDateOnlyTimestamp(value)).toBe(false);
+    });
+
+    it.each([null, undefined, 0, 1731196800000, true, {}, []])(
+      'returns false for non-string value %p',
+      (value) => {
+        expect(isDateOnlyTimestamp(value)).toBe(false);
+      },
+    );
+
+    it('rejects partial / malformed date strings', () => {
+      expect(isDateOnlyTimestamp('2025-11')).toBe(false);
+      expect(isDateOnlyTimestamp('2025-1-10')).toBe(false);
+      expect(isDateOnlyTimestamp('25-11-10')).toBe(false);
+      expect(isDateOnlyTimestamp('2025-11-10extra')).toBe(false);
+    });
+  });
+
+  describe('formatTimeDisplay with date-only timestamps', () => {
+    it('returns the fallback (not a locale-shifted time) when showFullDateInEffortTimes=false', () => {
+      // The fallback is empty (the upstream renderer should set startTime=""
+      // for date-only values), so the cell renders "-" instead of leaking
+      // a UTC→local hour.
+      expect(formatTimeDisplay('2025-11-10', '', false)).toBe('-');
+    });
+
+    it('uses string slicing (not Date arithmetic) when showFullDateInEffortTimes=true', () => {
+      // String slicing is timezone-independent — "2025-11-10" → "11-10".
+      // Crucially: NO trailing " 05:00" (or any other locale-derived hour).
+      expect(formatTimeDisplay('2025-11-10', '', true)).toBe('11-10');
+      expect(formatTimeDisplay('2025-01-01', '', true)).toBe('01-01');
+    });
+
+    it('does NOT leak local hours for date-only timestamps in any showFullDateInEffortTimes mode', () => {
+      // Regression guard for #2766 #6.
+      expect(formatTimeDisplay('2025-11-10', '', true)).not.toMatch(/\d{2}:\d{2}/);
+      expect(formatTimeDisplay('2025-11-10', '', false)).not.toMatch(/\d{2}:\d{2}/);
+    });
+  });
+
+  describe('formatTimeDisplay with timestamps that DO have a time component', () => {
+    it('still renders ISO datetime hours when showFullDateInEffortTimes=true', () => {
+      // ISO without timezone parses as local — keep existing behaviour.
+      const result = formatTimeDisplay('2025-11-10T14:30:00', '14:30', true);
+      // We don't assert exact output (depends on local TZ in CI), only that
+      // some "MM-DD HH:MM" pattern survives — i.e. real timestamps are NOT
+      // accidentally suppressed by the new date-only branch.
+      expect(result).toMatch(/^\d{2}-\d{2} \d{2}:\d{2}$/);
+    });
+
+    it('falls back to fallbackFormatted when showFullDateInEffortTimes=false', () => {
+      expect(formatTimeDisplay('2025-11-10T14:30:00', '14:30', false)).toBe('14:30');
+    });
+
+    it('returns "-" for null timestamps with empty fallback', () => {
+      expect(formatTimeDisplay(null, '', false)).toBe('-');
+      expect(formatTimeDisplay(undefined, '', false)).toBe('-');
+    });
+
+    it('returns fallback for invalid timestamp strings', () => {
+      expect(formatTimeDisplay('not-a-date', 'fallback', false)).toBe('fallback');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**Closes (one item from)**: #2766 — first-run UX polish, item 6.

The Daily Note Tasks table renders date-only timestamps (e.g. `"2025-11-10"` from `ems__Effort_plannedStartTimestamp`) as a wall-clock hour by feeding them to `new Date()`, which parses date-only strings as UTC midnight. In any non-UTC timezone the result is the local timezone offset — `"2025-11-10"` displays as `"05:00"` for a viewer in `Asia/Almaty` (UTC+5).

The walkthrough exposing this in #2766 was on UTC+5, so any developer outside that timezone could not reproduce the bug locally.

## Two affected render paths

1. **`DailyTasksRenderer.formatTime`** builds the cached `task.startTime` / `task.endTime` strings via `date.toLocaleTimeString()`. For a date-only frontmatter value this leaks UTC→local hours.
2. **`helpers.formatTimeDisplay`** is the per-row formatter consumed by `DailyTasksTableRow`. With `showFullDateInEffortTimes=true` it builds `${month}-${day} ${hours}:${minutes}` from `date.getHours()` — same leak.

The audit was prompted by the advisor in STEP C of the session — the first instinct was to fix only `DailyTasksRenderer`. Reading `daily-tasks/helpers.ts` revealed that fixing only the renderer would still leave the toggled "show full date" path broken.

## Fix

Add a small typed helper:

```ts
export const isDateOnlyTimestamp = (value: unknown): value is string =>
  typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
```

Both render paths now branch on it:

- **`DailyTasksRenderer.formatTime`** returns `""` for date-only inputs, so `task.startTime` is empty for date-only frontmatter values.
- **`helpers.formatTimeDisplay`**:
  - With `showFullDateInEffortTimes=false`, falls back to `fallbackFormatted` (which is now `""` for date-only values) — cell renders `"-"`.
  - With `showFullDateInEffortTimes=true`, returns `timestamp.slice(5)` — pure string slice, no `Date` involvement, no TZ shift. So `"2025-11-10"` renders as `"11-10"` (no `05:00` hours appended).

ISO-with-time strings (`"2025-11-10T14:30:00"`, etc.) are unaffected — the new branch only triggers for the strict date-only regex.

`isDateOnlyTimestamp` is exported from `daily-tasks/index.ts` and re-exported via the existing `DailyTasksTable.tsx` barrel so the renderer's import keeps the established `@plugin/.../DailyTasksTable` path.

## Test plan

- [x] New test file `DailyTasksTable.dateOnlyTimestamp.test.ts` with **25 cases**:
  - `isDateOnlyTimestamp` exhaustive coverage: 4 valid date-only strings, 6 non-date-only strings, 7 non-string values, 4 malformed/partial date strings.
  - `formatTimeDisplay` with date-only timestamps in both `showFullDateInEffortTimes` modes.
  - **Explicit regression guard**: assertion that no `\d{2}:\d{2}` pattern leaks into the output for date-only inputs.
  - `formatTimeDisplay` with ISO-with-time timestamps to confirm the pre-existing render path still works.
- [x] All 25 new tests pass.
- [x] `npm run test:all` (unit + component + bdd:check + archgate) — green.
- [x] Locale-independent: the regression is reproduced via timezone-free string slicing, so the test suite is safe to run in any TZ (no `TZ=Asia/Almaty` env var required).
- [ ] CI green (8 mandatory checks)
- [ ] Auto Release publishes new patch version
- [ ] Verified in fresh `/e2e-getting-started` walkthrough on the new release

Refs: #2766 (item 6)