### PR TITLE
fix: createAsset grounding writes exo__Asset_createdAt (#2777)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -103,11 +103,13 @@ export function populateServiceRegistry(
       if (!folder && folder !== "") throw new Error("createAsset requires userInput.folder");
 
       const uid = crypto.randomUUID();
+      const createdAt = DateFormatter.toISOTimestamp(new Date());
       const fileName = `${uid}.md`;
       const filePath = `${folder}/${fileName}`;
       const frontmatter = [
         "---",
         `exo__Asset_uid: ${uid}`,
+        `exo__Asset_createdAt: ${createdAt}`,
         `exo__Asset_label: ${label}`,
         `exo__Asset_prototype: "[[${prototypeUID}]]"`,
         "---",

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -212,6 +212,19 @@ describe("ServiceRegistryPopulator", () => {
       );
     });
 
+    it("should include exo__Asset_createdAt with ISO-8601 timestamp", async () => {
+      const service = registry.get("createAsset")!;
+      await service.execute("", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Timestamped Task",
+        folder: "01 Areas/Tasks",
+      });
+
+      const createCall = (deps.fileSystemAdapter.createFile as jest.Mock).mock.calls[0];
+      const frontmatter = createCall[1] as string;
+      expect(frontmatter).toMatch(/exo__Asset_createdAt: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
     it("should throw when prototypeUID is missing", async () => {
       const service = registry.get("createAsset")!;
       await expect(


### PR DESCRIPTION
## Summary

- Adds `exo__Asset_createdAt: <ISO-8601>` to the hardcoded frontmatter in the `createAsset` grounding service handler (`ServiceRegistryPopulator.ts:105-119`).
- Mirrors the shape that `GenericAssetCreationService.createAsset` emits at line 119 — the generic path already writes `createdAt`, but the hardcoded `service_call` handler was stripping it.
- Unit test asserts `exo__Asset_createdAt` is present in the frontmatter with an ISO-8601 timestamp.

## Why

Discovered during journey #1 (`create-child-task-from-parent`) triage on 2026-04-13:
- Every `Create Task` button (the `dec97198` command) bound to Project/Area flows through `createAsset` → writes only `uid`/`label`/`prototype`.
- Downstream audits and SPARQL filters that rely on `createdAt` returned zero results for tasks created this way.
- The bug is isolated to the grounding service layer — the core service was always correct.

## Test plan

- [x] `npx jest …/ServiceRegistryPopulator.test.ts` passes (43 tests, includes new `should include exo__Asset_createdAt with ISO-8601 timestamp`).
- [x] `npm run test:all` passes locally (unit + component; Docker e2e skipped — runs in CI).
- [x] Pre-commit lint-staged + archgate green.
- [ ] CI 8-check gate (pending).

Closes #2777.