### PR TITLE
feat(createRelatedTask): auto-open + status default + Area parent detection

### DIFF
--- a/packages/exocortex/src/services/GenericAssetCreationService.ts
+++ b/packages/exocortex/src/services/GenericAssetCreationService.ts
@@ -116,6 +116,7 @@ export class GenericAssetCreationService {
 
     // Set required system properties
     frontmatter["exo__Asset_uid"] = uid;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
     frontmatter["exo__Asset_createdAt"] = DateFormatter.toLocalTimestamp(now);
     frontmatter["exo__Instance_class"] = [this.formatWikilink(config.className)];
 
@@ -168,9 +169,14 @@ export class GenericAssetCreationService {
     const parentMetadata = config.parentMetadata || {};
     const parentName = config.parentFile?.basename;
 
-    // For tasks created from projects/areas, inherit the parent reference
+    // For tasks created from projects/areas, inherit the parent reference.
+    // When the parent asset is an ems__Area, the task should link via
+    // ems__Effort_area instead of ems__Effort_parent (parent-property semantics).
     if (config.className === "ems__Task" || config.className.startsWith("ems__Task")) {
-      frontmatter["ems__Effort_parent"] = parentName
+      const parentClass = parentMetadata.exo__Instance_class;
+      const isAreaParent = this.isAreaClass(parentClass);
+      const parentPropertyName = isAreaParent ? "ems__Effort_area" : "ems__Effort_parent";
+      frontmatter[parentPropertyName] = parentName
         ? this.formatWikilink(parentName)
         : null;
     }
@@ -289,6 +295,7 @@ export class GenericAssetCreationService {
       return value;
     }
     if (value instanceof Date) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
       return DateFormatter.toLocalTimestamp(value);
     }
     if (typeof value === "string") {
@@ -341,6 +348,7 @@ export class GenericAssetCreationService {
    */
   private formatTimestamp(value: unknown): string {
     if (value instanceof Date) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
       return DateFormatter.toLocalTimestamp(value);
     }
 
@@ -356,6 +364,7 @@ export class GenericAssetCreationService {
       // Try to parse as date
       const date = new Date(value);
       if (!isNaN(date.getTime())) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
         return DateFormatter.toLocalTimestamp(date);
       }
       return value;
@@ -364,6 +373,7 @@ export class GenericAssetCreationService {
     if (typeof value === "number") {
       const date = new Date(value);
       if (!isNaN(date.getTime())) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
         return DateFormatter.toLocalTimestamp(date);
       }
     }

--- a/packages/exocortex/tests/unit/services/GenericAssetCreationService.test.ts
+++ b/packages/exocortex/tests/unit/services/GenericAssetCreationService.test.ts
@@ -832,6 +832,46 @@ describe("GenericAssetCreationService", () => {
         expect(content).toContain('ems__Effort_parent: "[[project]]"');
       });
 
+      it("should set ems__Effort_area for ems__Task with an ems__Area parent", async () => {
+        const parentFile: IFile = {
+          path: "areas/development.md",
+          basename: "development",
+          name: "development.md",
+          parent: { path: "areas" } as IFolder,
+        };
+        const config = {
+          className: "ems__Task",
+          parentFile,
+          parentMetadata: {
+            exo__Instance_class: ["[[ems__Area]]"],
+          },
+        };
+        await service.createAsset(config);
+        const content = mockVault.create.mock.calls[0][1];
+        expect(content).toContain('ems__Effort_area: "[[development]]"');
+        expect(content).not.toContain("ems__Effort_parent:");
+      });
+
+      it("should set ems__Effort_area to null when Area parent has no basename", async () => {
+        const parentFile: IFile = {
+          path: "areas/",
+          basename: "",
+          name: "",
+          parent: { path: "areas" } as IFolder,
+        };
+        const config = {
+          className: "ems__Task",
+          parentFile,
+          parentMetadata: {
+            exo__Instance_class: ["[[ems__Area]]"],
+          },
+        };
+        await service.createAsset(config);
+        const content = mockVault.create.mock.calls[0][1];
+        expect(content).toContain("ems__Effort_area: null");
+        expect(content).not.toContain("ems__Effort_parent:");
+      });
+
       it("should set ems__Project_area for project with area parent", async () => {
         const parentFile: IFile = {
           path: "areas/my-area.md",

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -257,18 +257,35 @@ export function populateServiceRegistry(
         const label = userInput?.label as string | undefined;
         if (!label) throw new Error("createRelatedTask requires userInput.label");
         const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        const frontmatter = vaultAdapter.getFrontmatter(iFile);
+        const parentMetadata = (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
         const folderPath = iFile.parent?.path || "";
-        await genericAssetCreationService.createAsset({
+
+        const propertyValues: Record<string, unknown> = {
+          "ems__Effort_status": '"[[ems__EffortStatusDraft]]"',
+        };
+
+        // Optional declarative override: starter-kit bindings may pass
+        // `parentProperty` via Grounding_targetValue to force a specific parent
+        // link. When absent, GenericAssetCreationService auto-detects
+        // ems__Effort_area vs ems__Effort_parent from the parent's Instance_class.
+        const explicitParentProperty = userInput?.parentProperty as string | undefined;
+        if (explicitParentProperty && iFile.basename) {
+          propertyValues[explicitParentProperty] = `"[[${iFile.basename}]]"`;
+        }
+
+        const createdFile = await genericAssetCreationService.createAsset({
           className: "ems__Task",
           label,
           folderPath,
-          propertyValues: {
-            "ems__Effort_parent": iFile.basename ? `"[[${iFile.basename}]]"` : undefined,
-          },
+          propertyValues,
           parentFile: iFile,
-          parentMetadata: (frontmatter as Record<string, unknown>) ?? {},
+          parentMetadata,
         });
+
+        const tfile = vaultAdapter.toTFile(createdFile);
+        const leaf = app.workspace.getLeaf("tab");
+        await leaf.openFile(tfile);
+        app.workspace.setActiveLeaf(leaf, { focus: true });
       }),
     );
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -39,6 +39,10 @@ function createMockDeps(withVaultAdapter = false): ServiceRegistryDeps {
       workspace: {
         getActiveFile: jest.fn().mockReturnValue({ path: "active.md" }),
         openLinkText: jest.fn().mockResolvedValue(undefined),
+        getLeaf: jest.fn().mockReturnValue({
+          openFile: jest.fn().mockResolvedValue(undefined),
+        }),
+        setActiveLeaf: jest.fn(),
       },
     } as any,
     fileSystemAdapter: {
@@ -66,6 +70,11 @@ function createMockDeps(withVaultAdapter = false): ServiceRegistryDeps {
       modify: jest.fn().mockResolvedValue(undefined),
       create: jest.fn().mockResolvedValue(mockIFile),
       createFolder: jest.fn().mockResolvedValue(undefined),
+      toTFile: jest.fn().mockReturnValue({
+        path: mockIFile.path,
+        basename: mockIFile.basename,
+        name: mockIFile.name,
+      }),
     } as any;
   }
 
@@ -534,6 +543,41 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
         expect.stringContaining("folder/"),
         expect.stringContaining("ems__Task"),
       );
+    });
+
+    it("should set ems__Effort_status to Draft by default", async () => {
+      const service = registry.get("createRelatedTask")!;
+      await service.execute("test-uid-123", { label: "Subtask" });
+
+      const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
+      const content = createCall[1] as string;
+      expect(content).toContain('ems__Effort_status: "[[ems__EffortStatusDraft]]"');
+    });
+
+    it("should open the created task in a new tab leaf", async () => {
+      const service = registry.get("createRelatedTask")!;
+      await service.execute("test-uid-123", { label: "Subtask" });
+
+      expect(deps.app.workspace.getLeaf).toHaveBeenCalledWith("tab");
+      expect(deps.vaultAdapter!.toTFile).toHaveBeenCalled();
+      const leafMock = (deps.app.workspace.getLeaf as jest.Mock).mock.results[0].value;
+      expect(leafMock.openFile).toHaveBeenCalled();
+      expect(deps.app.workspace.setActiveLeaf).toHaveBeenCalledWith(
+        leafMock,
+        { focus: true },
+      );
+    });
+
+    it("should honor explicit parentProperty override from userInput", async () => {
+      const service = registry.get("createRelatedTask")!;
+      await service.execute("test-uid-123", {
+        label: "Area subtask",
+        parentProperty: "ems__Effort_area",
+      });
+
+      const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
+      const content = createCall[1] as string;
+      expect(content).toContain('ems__Effort_area: "[[test-uid-123]]"');
     });
 
     it("should throw when label is missing", async () => {


### PR DESCRIPTION
## Summary

Upgrades the `createRelatedTask` grounding service so the starter-kit can wire a parent-aware **Create Child Task** button to `ems__Project` / `ems__Area`. Three atomic changes:

1. **Core auto-detect (`GenericAssetCreationService.inheritParentContext`)** — when creating an `ems__Task` from a parent whose `exo__Instance_class` includes `ems__Area`, write `ems__Effort_area: [[parent]]` instead of `ems__Effort_parent: [[parent]]`. Non-Area parents keep the existing behavior.
2. **Handler Draft status** — default `ems__Effort_status: \"[[ems__EffortStatusDraft]]\"` for all tasks created through `createRelatedTask`, matching journey #1's acceptance criteria.
3. **Handler auto-open** — capture the returned `IFile` and call `vaultAdapter.toTFile() + workspace.getLeaf(\"tab\").openFile(tfile)`, mirroring the existing `CreateAssetCommand` pattern.
4. **Optional `userInput.parentProperty` override** — starter-kit bindings can pass `{parentProperty: \"ems__Effort_area\"}` via `Grounding_targetValue` for declarative control; absent → class-based auto-detection wins.

## Why

Journey #1 (`create-child-task-from-parent`, triaged 2026-04-13) requires tasks to open in a new leaf with Draft status and a parent reference that respects Project vs Area semantics. Without these changes the starter-kit companion PR (kitelev/exocortex-starter-kit#16) cannot close the gap.

## Test plan

- [x] 2 new core tests: Task-from-Area → `ems__Effort_area` with and without parent basename.
- [x] 3 new handler tests: Draft status default, auto-open leaf wiring, explicit `parentProperty` override.
- [x] `npm run test:all` passes locally (539 component + full unit).
- [x] Pre-commit lint-staged + archgate green.
- [ ] CI 8-check gate (pending).

## Notes

- Pre-existing `toLocalTimestamp` deprecation warnings in `GenericAssetCreationService.ts` (5 lines) are annotated with `eslint-disable-next-line` + intent comments; behavior unchanged, follow-up cleanup possible.
- Pairs with [kitelev/exocortex-starter-kit#16](https://github.com/kitelev/exocortex-starter-kit/issues/16).