### PR TITLE
fix(plugin): reindex triple store after metadataCache resolves (#2780)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -88,6 +88,9 @@ export default class ExocortexPlugin extends Plugin {
   private graphViewPatch!: GraphViewPatch;
   private fileLogChannel!: FileLogChannel;
   private notifier!: ObsidianNotificationService;
+  // Issue #2780: tracked so the post-resolve reindex can await it before
+  // calling refresh(), avoiding a concurrent clear()/convertVault() race.
+  private eagerInitPromise: Promise<void> | null = null;
 
   override async onload(): Promise<void> {
     try {
@@ -220,9 +223,52 @@ export default class ExocortexPlugin extends Plugin {
         (source, el, ctx) => this.layoutProcessor.process(source, el, ctx)
       );
 
+      // Issue #2780: Re-index triple store once metadataCache has fully resolved.
+      //
+      // onLayoutReady (below) triggers an eager store init so buttons render
+      // fast on first paint — but at that point Obsidian's metadataCache may
+      // still be parsing files, so `getFrontmatter(file)` returns null for
+      // any file whose YAML hasn't been parsed yet. NoteToRDFConverter silently
+      // skips those files, leaving them with 0 triples in the store.
+      //
+      // For non-preconditioned commands this is invisible (binding triples come
+      // from starter-kit files that are parsed early), but preconditioned
+      // commands run SPARQL ASKs like `$target ems:Effort_status ?s` against
+      // the TARGET file's triples — and when those are missing, the ASK returns
+      // false, fail-closed → every preconditioned command is silently hidden.
+      // A later mutation to the file triggers `VaultRDFIndexer.updateFile`,
+      // which re-runs convertNote with warm metadata and fills in the missing
+      // triples — that's why clicking any mutating command on the file magically
+      // "wakes up" the hidden commands.
+      //
+      // `metadataCache.on("resolved")` is Obsidian's signal that the initial
+      // vault parse is complete. Once it fires, we await the eager-init promise
+      // (so the two paths serialize — `refresh()` calls clear()+convertVault()
+      // and we don't want that interleaved with an in-flight init) and then do
+      // a full reindex. The one-shot flag keeps this to a single refresh per
+      // plugin load; per-file mutations still go through `vault.on("modify")`.
+      let postResolveReindexDone = false;
       this.registerEvent(
         this.app.metadataCache.on("resolved", () => {
           this.layoutRenderer.invalidateBacklinksCache();
+
+          if (postResolveReindexDone) return;
+          postResolveReindexDone = true;
+
+          const initPromise = this.eagerInitPromise ?? Promise.resolve();
+          void initPromise
+            .then(() => this.sparql.refresh())
+            .then(() => {
+              this.commandResolver.invalidateCache();
+              this.preconditionEvaluator.invalidateCache();
+              this.autoRenderLayout();
+            })
+            .catch((err) => {
+              this.logger.error(
+                "Failed to reindex triple store after metadataCache resolved",
+                err,
+              );
+            });
         }),
       );
 
@@ -272,12 +318,21 @@ export default class ExocortexPlugin extends Plugin {
       // onLayoutReady fires after Obsidian finishes mounting vault files.
       // Without this, VaultRDFIndexer.initialize() finds 0 files → 0 triples
       // → CommandResolver finds no bindings → dynamic buttons don't render.
-      this.app.workspace.onLayoutReady(() => {
-        void this.sparql.query("ASK { ?s ?p ?o }").then(() => {
-          this.commandResolver.invalidateCache();
-          this.autoRenderLayout();
-        }).catch((err) => {
-          this.logger.error("Failed to eagerly initialize triple store", err);
+      //
+      // NB: At this point metadataCache is typically NOT fully resolved yet.
+      // The `metadataCache.on("resolved")` handler above awaits this promise
+      // and then refreshes the store to pick up any files that were skipped
+      // because their frontmatter wasn't parsed in time. See issue #2780.
+      this.eagerInitPromise = new Promise<void>((resolve) => {
+        this.app.workspace.onLayoutReady(() => {
+          void this.sparql.query("ASK { ?s ?p ?o }").then(() => {
+            this.commandResolver.invalidateCache();
+            this.autoRenderLayout();
+          }).catch((err) => {
+            this.logger.error("Failed to eagerly initialize triple store", err);
+          }).finally(() => {
+            resolve();
+          });
         });
       });
 

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -1581,4 +1581,126 @@ describe("ExocortexPlugin", () => {
       expect(plugin.serviceRegistry).toBeDefined();
     });
   });
+
+  describe("Issue #2780: post-resolve reindex (cold-open precondition fix)", () => {
+    // Regression for #2780: preconditioned commands never rendered on cold
+    // file-open. Root cause: `onLayoutReady` fires before `metadataCache`
+    // has finished parsing every file, so the first `convertVault()` sees
+    // null frontmatter for racing files and ingests zero triples for them.
+    // Preconditions like `$target ems:Effort_status ?s` then return false
+    // (empty store) → commands hidden. Any subsequent frontmatter mutation
+    // re-runs `convertNote` with warm metadata and restores the commands.
+    //
+    // Fix: register a one-shot `metadataCache.on("resolved")` handler that
+    // awaits the eager-init promise and then calls `sparql.refresh()` to
+    // reindex the vault with guaranteed-warm metadata. These tests pin that
+    // contract so the race can't silently come back.
+    let resolvedHandler: (() => void) | undefined;
+    let refreshSpy: jest.SpyInstance;
+    let querySpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      resolvedHandler = undefined;
+      mockMetadataCache.on.mockImplementation((event: string, cb: () => void) => {
+        if (event === "resolved") {
+          resolvedHandler = cb;
+        }
+        return { unsubscribe: jest.fn() };
+      });
+
+      // Spy on the real SPARQLApi prototype so the plugin's internal
+      // `new SPARQLApi(this)` call picks up the stubs.
+      const sparqlApiModule = await import("../../src/application/api/SPARQLApi");
+      refreshSpy = jest
+        .spyOn(sparqlApiModule.SPARQLApi.prototype, "refresh")
+        .mockResolvedValue(undefined);
+      querySpy = jest
+        .spyOn(sparqlApiModule.SPARQLApi.prototype, "query")
+        .mockResolvedValue({ bindings: [], count: 0 });
+    });
+
+    afterEach(() => {
+      refreshSpy?.mockRestore();
+      querySpy?.mockRestore();
+    });
+
+    it("registers a metadataCache 'resolved' handler that refreshes the store and invalidates both caches", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      expect(resolvedHandler).toBeDefined();
+      // eager init ran once (triggered by onLayoutReady mock calling cb inline)
+      expect(querySpy).toHaveBeenCalledWith("ASK { ?s ?p ?o }");
+
+      const commandResolverSpy = jest.spyOn(plugin.commandResolver, "invalidateCache");
+      const preconditionEvaluatorSpy = jest.spyOn(
+        plugin.preconditionEvaluator,
+        "invalidateCache",
+      );
+
+      // Before firing, refresh has never been called.
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      resolvedHandler!();
+      await flushPromises();
+
+      // Backlinks cache still invalidated (kept from pre-fix behavior)
+      expect(mockLayoutRenderer.invalidateBacklinksCache).toHaveBeenCalled();
+      // New post-resolve behavior: refresh + invalidate BOTH command caches
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(commandResolverSpy).toHaveBeenCalled();
+      expect(preconditionEvaluatorSpy).toHaveBeenCalled();
+    });
+
+    it("re-index is one-shot: subsequent 'resolved' events do not trigger another refresh", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      resolvedHandler!();
+      await flushPromises();
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+      // Obsidian can fire "resolved" again on per-file re-resolve; we must
+      // NOT tear down and rebuild the triple store every time.
+      resolvedHandler!();
+      resolvedHandler!();
+      await flushPromises();
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("awaits the eager-init promise before calling refresh to avoid a concurrent clear/convertVault race", async () => {
+      // Hold eager init open until the test explicitly releases it.
+      let releaseEagerInit: () => void = () => {};
+      const eagerInitGate = new Promise<void>((r) => {
+        releaseEagerInit = () => r();
+      });
+      querySpy.mockImplementation(async () => {
+        await eagerInitGate;
+        return { bindings: [], count: 0 };
+      });
+
+      // onLayoutReady fires synchronously via our mock and schedules eager init.
+      await plugin.onload();
+      // Let microtasks settle so the resolved handler is wired up.
+      await flushPromises();
+
+      // Fire resolved while eager init is still pending.
+      resolvedHandler!();
+      await flushPromises();
+
+      // Serialization contract: refresh must NOT have started yet — it's
+      // chained after the eager-init promise, so clear()+convertVault()
+      // from `refresh()` can't race with the in-flight eager init.
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      // Unblock eager init and let the chained refresh run.
+      releaseEagerInit();
+      await flushPromises();
+      await flushPromises();
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2780. On cold file-open, every precondition-filtered command was silently hidden until the user mutated the file's frontmatter — then all 19 "hidden" commands suddenly appeared. Now they render on first paint.

## Root cause

`ExocortexPlugin.onLayoutReady` eagerly calls `convertVault()` to populate the triple store for fast first render. The problem: **`onLayoutReady` fires before Obsidian's `metadataCache` has finished parsing every file**. For any file whose YAML isn't parsed yet, `getFrontmatter(file)` returns `null` → `NoteToRDFConverter.convertNote` skips it → zero triples for that file.

For non-preconditioned commands this is invisible because their bindings come from starter-kit files (parsed early). But preconditioned commands run `ASK { \$target ems:Effort_status ?s ... }` against the **target file's** triples — and when those are missing the ASK returns false, fail-closed → every preconditioned command is silently hidden. A later frontmatter mutation on the file triggers `VaultRDFIndexer.updateFile` which re-runs `convertNote` with warm metadata and backfills the triples — that's why clicking any mutating command "unlocks" the COMMANDS panel.

## Fix

One-shot `metadataCache.on("resolved")` handler merged into the existing resolved handler in `ExocortexPlugin`:

1. Awaits `eagerInitPromise` (the existing `onLayoutReady` init) — this serializes the two paths so `refresh()`'s `clear() + convertVault()` can't race with an in-flight eager init
2. Calls `sparql.refresh()` — reindexes with metadataCache guaranteed-warm
3. Invalidates **both** `commandResolver` and `preconditionEvaluator` caches
4. Triggers `autoRenderLayout()` so the currently-open file picks up the freshly indexed triples without user input
5. One-shot flag prevents the heavy refresh from re-running on subsequent per-file `resolved` events

No changes in `packages/exocortex` — this is a plugin-layer event-ordering bug, the evaluator is correct.

## Test plan

Three new regression cases in `packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts` under `describe("Issue #2780: post-resolve reindex (cold-open precondition fix)")`:

- [x] `"resolved"` fires → `refresh()` + both `invalidateCache` + backlinks cache invalidation — **fails on main, passes on branch**
- [x] One-shot: subsequent `"resolved"` events do not trigger another refresh — **fails on main, passes on branch**
- [x] Serialization: resolved handler awaits eager init before calling refresh (verified by holding the eager init promise open, firing resolved, asserting refresh not yet called, then releasing and asserting refresh called) — **fails on main, passes on branch**
- [x] \`npm run test:all\` green locally (539 passed, 31 skipped; Docker E2E skipped — runs in CI)
- [ ] Manual cold-open verification in test vault after Obsidian restart: \`Implement Feature.md\` (\`ems__Task\`, \`ems__Effort_status: [[ems__EffortStatusBacklog]]\`), Reading Mode → all 34 commands visible immediately (including \`Set Status Doing\`, \`Move to ToDo\`, \`Set Draft Status\`, etc.) — will run post-merge
- [ ] 8 CI checks green
- [ ] Auto Release succeeds