### PR TITLE
fix(#2782 v2): replace dual-storage with namespace URI for class-like enum wikilinks

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -642,15 +642,18 @@ export class NoteToRDFConverter {
             const uuidLiteral = new Literal(linkpath);
 
             // Issue #2782: when the target file represents a class-like enum
-            // member (status/criticality/etc.), also emit its namespace URI so
-            // starter-kit preconditions of the form
-            //   FILTER(?s != <ems:EffortStatusDoing>)
-            // keep working after `Set Status X` mutates the frontmatter into
-            // [[UUID]] form. Mirrors the basename → label detection used by
-            // valueToClassURI for Instance_class (Issue #2745).
+            // member (status/criticality/etc.), REPLACE the dual-storage pair
+            // with the namespace URI alone. Additive emission (v15.90.25)
+            // does not work for starter-kit preconditions of the form
+            //   ASK { ?s != <ems:EffortStatusDoing> }
+            // because ASK is existential — any non-matching binding (file IRI
+            // or UUID literal) makes the FILTER pass and the gate returns TRUE.
+            // Class-like enum targets are never queried by raw UUID literal
+            // (#2102 dual storage exists for exo__Asset_prototype only) so the
+            // replace is safe. Mirrors valueToClassURI's Issue #2745 lookup.
             const basenameClassIRI = this.expandClassValue(targetFile.basename);
             if (basenameClassIRI) {
-              return [fileIRI, uuidLiteral, basenameClassIRI];
+              return [basenameClassIRI];
             }
             const targetFm = this.vault.getFrontmatter(targetFile);
             if (targetFm) {
@@ -658,7 +661,7 @@ export class NoteToRDFConverter {
               if (typeof label === "string") {
                 const labelClassIRI = this.expandClassValue(label);
                 if (labelClassIRI) {
-                  return [fileIRI, uuidLiteral, labelClassIRI];
+                  return [labelClassIRI];
                 }
               }
             }

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -900,7 +900,7 @@ describe("NoteToRDFConverter", () => {
         parent: null,
       };
 
-      it("should also emit namespace URI when [[UUID]] resolves to a class-like enum file (via exo__Asset_label)", async () => {
+      it("should REPLACE dual-storage with namespace URI alone when [[UUID]] resolves to a class-like enum (via exo__Asset_label)", async () => {
         const taskFrontmatter: IFrontmatter = {
           ems__Effort_status: "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]",
         };
@@ -923,17 +923,16 @@ describe("NoteToRDFConverter", () => {
           (t) => (t.predicate as IRI).value === Namespace.EMS.term("Effort_status").value
         );
 
-        const objectValues = statusTriples.map((t) => (t.object as IRI | Literal).value);
-
-        // Existing dual-storage triples preserved
-        expect(objectValues).toContain("027e78f4-6e16-4b36-b8fb-5510507d5745");
-        expect(objectValues.some((v) => v.includes("027e78f4-6e16-4b36-b8fb-5510507d5745.md"))).toBe(true);
-
-        // NEW (#2782): namespace URI for the resolved class member
-        expect(objectValues).toContain(Namespace.EMS.term("EffortStatusDoing").value);
+        // Replace, not additive: ASK is existential, so file IRI + UUID literal
+        // bindings would defeat FILTER(?s != <ns:URI>) preconditions.
+        expect(statusTriples).toHaveLength(1);
+        expect(statusTriples[0].object).toBeInstanceOf(IRI);
+        expect((statusTriples[0].object as IRI).value).toBe(
+          Namespace.EMS.term("EffortStatusDoing").value
+        );
       });
 
-      it("should also emit namespace URI when [[UUID]] resolves via class-named basename", async () => {
+      it("should REPLACE with namespace URI when [[UUID]] resolves via class-named basename", async () => {
         const namedEnumFile: IFile = {
           path: "ems/ems__EffortStatusBacklog.md",
           basename: "ems__EffortStatusBacklog",
@@ -960,9 +959,12 @@ describe("NoteToRDFConverter", () => {
         const statusTriples = triples.filter(
           (t) => (t.predicate as IRI).value === Namespace.EMS.term("Effort_status").value
         );
-        const objectValues = statusTriples.map((t) => (t.object as IRI | Literal).value);
 
-        expect(objectValues).toContain(Namespace.EMS.term("EffortStatusBacklog").value);
+        expect(statusTriples).toHaveLength(1);
+        expect(statusTriples[0].object).toBeInstanceOf(IRI);
+        expect((statusTriples[0].object as IRI).value).toBe(
+          Namespace.EMS.term("EffortStatusBacklog").value
+        );
       });
 
       it("should NOT emit namespace URI when [[UUID]] target is not a class-like enum", async () => {


### PR DESCRIPTION
## Summary

Follow-up to v15.90.25 (#2783). The additive fix shipped in PR #2783 is fundamentally broken for ASK preconditions of the form

```sparql
ASK { $target ems:Effort_status ?s . FILTER(?s != <ems:EffortStatusDoing>) }
```

ASK is **existential** — if any binding satisfies the FILTER, ASK returns TRUE. The additive approach emitted three triples for `[[UUID]]` enum wikilinks (file IRI + UUID literal + namespace URI), so the file-IRI and UUID-literal bindings always made the FILTER pass even when the namespace URI matched. Result: post-#2783 v15.90.25 still showed the stale Set Status Doing button after a click.

## Live verification

Reproduced + fixed in real Obsidian (test vault, Implement Feature.md):
- v15.90.25 (additive): after Set Status Doing click + restart → Set Status Backlog appears ✓ but Set Status Doing still visible ✗
- This PR (replace): after Set Status Doing click + restart → Set Status Backlog appears ✓ AND Set Status Doing hidden ✓

## Fix

Switched to **REPLACE** for class-like enum targets. For UUID wikilinks resolving to a file whose basename or `exo__Asset_label` is a class reference, return `[classIRI]` alone instead of `[fileIRI, uuidLiteral, classIRI]`. Issue #2102 dual storage rationale (raw UUID literal SPARQL queries) only applies to `exo__Asset_prototype`; status enum members are never queried by raw UUID.

## Tests

- Two positive regression tests now assert `statusTriples.length === 1` with namespace URI as the sole object
- Negative regression test unchanged: ordinary UUID-named target preserves `[fileIRI, uuidLiteral]`
- Full `NoteToRDFConverter` suite: 132/132 ✓
- Full `npm test` (unit + UI + component): 539 ✓

## Test plan
- [x] `npx jest packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts` — 132/132
- [x] `npm test` — all green
- [x] Live reproduction in test vault — Set Status Doing button correctly toggles after restart
- [ ] CI: 8 mandatory checks
- [ ] `/user-journey start-effort-backlog-to-doing` Scenario A + B + C

## Out of scope (separate follow-up)

In-session post-click cache invalidation: the layout doesn't refresh until Obsidian restart even after the converter emits the correct triples. That's a separate hot-mutation path issue, distinct from #2782's converter ingestion bug. Will file a follow-up.

Refs #2782.