### PR TITLE
fix: hot-mutation cache invalidation re-renders layout in-session (#2785)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -272,9 +272,23 @@ export default class ExocortexPlugin extends Plugin {
         }),
       );
 
+      // Issue #2785: hot-mutation cache invalidation.
+      //
+      // After an inline-button command writes frontmatter (e.g. `Set Status Doing`),
+      // `metadataCache.on("changed")` fires with guaranteed-fresh frontmatter —
+      // this is the right event to drive a re-index. `vault.on("modify")` alone
+      // is insufficient because it can fire before metadataCache has re-parsed
+      // the file, causing a re-index against stale values, and even when it
+      // doesn't race, nothing triggers `autoRenderLayout` after the mutation —
+      // so the COMMANDS panel stays stale until Obsidian restart.
+      //
+      // Fix: schedule a debounced, per-file re-index that swaps the file's
+      // triples → invalidates the command caches → re-renders active layouts.
+      // Symmetric to #2780 but for incremental mutations rather than cold start.
       this.registerEvent(
         this.app.metadataCache.on("changed", (file) => {
           this.handleMetadataChange(file);
+          this.scheduleHotReindex(file);
         }),
       );
 
@@ -941,6 +955,47 @@ export default class ExocortexPlugin extends Plugin {
     }
   }
 
+
+  /**
+   * Issue #2785: schedule a debounced, per-file re-index after a frontmatter mutation.
+   *
+   * Called from the `metadataCache.on("changed")` subscriber — at that point
+   * Obsidian has already re-parsed the file, so `sparql.reindexFile(file)`
+   * converts it against fresh metadata. After the re-index completes we
+   * invalidate the command/precondition caches and trigger `autoRenderLayout`
+   * so active leaves pick up the new button visibility without an Obsidian
+   * restart.
+   *
+   * Debouncing key is per-file (`hot-reindex:<path>`) so a burst of changes
+   * to the same file collapses to one re-index, while concurrent edits to
+   * different files each run their own re-index.
+   *
+   * Non-markdown files are ignored (binary / config assets).
+   */
+  private scheduleHotReindex(file: TFile): void {
+    if (file.extension !== "md") return;
+
+    const timerName = `hot-reindex:${file.path}`;
+    this.timerManager.setTimeout(
+      timerName,
+      () => {
+        void (async () => {
+          try {
+            await this.sparql.reindexFile(file);
+            this.commandResolver.invalidateCache();
+            this.preconditionEvaluator.invalidateCache();
+            this.autoRenderLayout();
+          } catch (err) {
+            this.logger.error(
+              `Failed to hot-reindex ${file.path} after metadata change`,
+              err as Error,
+            );
+          }
+        })();
+      },
+      150,
+    );
+  }
 
   private removeAutoRenderedLayouts(): void {
     document

--- a/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
+++ b/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
@@ -1,3 +1,4 @@
+import type { TFile } from "obsidian";
 import type { InMemoryTripleStore, SolutionMapping, Triple } from "exocortex";
 import { SPARQLQueryService } from '@plugin/application/services/SPARQLQueryService';
 import type ExocortexPlugin from '@plugin/ExocortexPlugin';
@@ -267,6 +268,30 @@ export class SPARQLApi {
    */
   async refresh(): Promise<void> {
     await this.queryService.refresh();
+  }
+
+  /**
+   * Re-indexes triples for a single file.
+   *
+   * Removes existing triples owned by `file` from the triple store and
+   * re-converts the file's frontmatter + body into fresh triples. Unlike
+   * {@link refresh}, this operation is O(1 file) rather than O(all files),
+   * making it cheap enough to call on every incremental frontmatter mutation.
+   *
+   * Intended use: call from a `metadataCache.on("changed")` handler after
+   * Obsidian has parsed the latest frontmatter. Issue #2785 (hot-mutation
+   * cache invalidation gap) requires this entry point because
+   * `metadataCache.on("changed")` is the only event that fires with
+   * guaranteed-fresh metadata — `vault.on("modify")` may fire before the
+   * cache has re-parsed the file, producing a re-index with stale values.
+   *
+   * @param file - The file whose triples need to be re-indexed
+   * @returns Promise that resolves when re-indexing is complete
+   *
+   * @see Issue #2785
+   */
+  async reindexFile(file: TFile): Promise<void> {
+    await this.queryService.updateFile(file);
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -1703,4 +1703,202 @@ describe("ExocortexPlugin", () => {
       expect(refreshSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("Issue #2785: hot-mutation cache invalidation (post-click layout refresh)", () => {
+    // Regression for #2785: after clicking an inline-button command like
+    // "Set Status Doing", the frontmatter writes correctly and Obsidian's
+    // Properties widget repaints, but the Exocortex COMMANDS panel stays
+    // stale — the clicked button remains visible until Obsidian restart.
+    //
+    // Root cause: VaultRDFIndexer's own `vault.on("modify")` listener may
+    // re-index with stale metadata (Obsidian hasn't finished re-parsing the
+    // file by the time the modify event fires), AND nothing triggers
+    // `autoRenderLayout()` after the mutation. #2780 only handled the
+    // cold-start race — this describe block pins the hot-mutation contract.
+    //
+    // Fix: `metadataCache.on("changed")` handler schedules a per-file
+    // debounced re-index via `sparql.reindexFile(file)` → invalidates the
+    // command resolver cache → re-renders the layout. `metadataCache.changed`
+    // is the right event because it fires with guaranteed-fresh frontmatter.
+
+    let changedHandlers: Array<(file: TFile) => void> = [];
+    let reindexFileSpy: jest.SpyInstance;
+    let querySpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      changedHandlers = [];
+      mockMetadataCache.on.mockImplementation(
+        (event: string, cb: (file: TFile) => void) => {
+          if (event === "changed") {
+            changedHandlers.push(cb);
+          }
+          return { unsubscribe: jest.fn() };
+        },
+      );
+
+      const sparqlApiModule = await import("../../src/application/api/SPARQLApi");
+      reindexFileSpy = jest
+        .spyOn(sparqlApiModule.SPARQLApi.prototype, "reindexFile")
+        .mockResolvedValue(undefined);
+      querySpy = jest
+        .spyOn(sparqlApiModule.SPARQLApi.prototype, "query")
+        .mockResolvedValue({ bindings: [], count: 0 });
+    });
+
+    afterEach(() => {
+      reindexFileSpy?.mockRestore();
+      querySpy?.mockRestore();
+    });
+
+    const getLastChangedHandler = (): ((file: TFile) => void) => {
+      expect(changedHandlers.length).toBeGreaterThan(0);
+      return changedHandlers[changedHandlers.length - 1]!;
+    };
+
+    it("re-indexes the changed file via sparql.reindexFile when metadataCache fires 'changed'", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      const mockFile = { path: "Implement Feature.md", extension: "md" } as TFile;
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          "ems__Effort_status": "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]",
+        },
+      });
+
+      const handler = getLastChangedHandler();
+      handler(mockFile);
+
+      await waitForCondition(
+        () => reindexFileSpy.mock.calls.length > 0,
+        { timeout: 1500, message: "reindexFile was never called" },
+      );
+
+      expect(reindexFileSpy).toHaveBeenCalledWith(mockFile);
+      expect(reindexFileSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("invalidates commandResolver cache after re-indexing the file", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      const commandResolverSpy = jest.spyOn(
+        plugin.commandResolver,
+        "invalidateCache",
+      );
+      const preconditionEvaluatorSpy = jest.spyOn(
+        plugin.preconditionEvaluator,
+        "invalidateCache",
+      );
+
+      const mockFile = { path: "Implement Feature.md", extension: "md" } as TFile;
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: { "ems__Effort_status": "[[ems__EffortStatusDoing]]" },
+      });
+
+      const handler = getLastChangedHandler();
+      handler(mockFile);
+
+      await waitForCondition(
+        () => commandResolverSpy.mock.calls.length > 0,
+        { timeout: 1500, message: "commandResolver.invalidateCache never called" },
+      );
+
+      expect(commandResolverSpy).toHaveBeenCalled();
+      expect(preconditionEvaluatorSpy).toHaveBeenCalled();
+    });
+
+    it("triggers autoRenderLayout after re-indexing so the COMMANDS panel repaints without Obsidian restart", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      const autoRenderLayoutSpy = jest
+        .spyOn(plugin as any, "autoRenderLayout")
+        .mockImplementation(() => {});
+
+      const mockFile = { path: "Implement Feature.md", extension: "md" } as TFile;
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: { "ems__Effort_status": "[[ems__EffortStatusDoing]]" },
+      });
+
+      const handler = getLastChangedHandler();
+      handler(mockFile);
+
+      await waitForCondition(
+        () => autoRenderLayoutSpy.mock.calls.length > 0,
+        { timeout: 1500, message: "autoRenderLayout never called post-mutation" },
+      );
+
+      expect(autoRenderLayoutSpy).toHaveBeenCalled();
+    });
+
+    it("debounces rapid changes: 5 'changed' events for the same file within the debounce window produce a single reindex", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      const mockFile = { path: "Implement Feature.md", extension: "md" } as TFile;
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: { "ems__Effort_status": "[[ems__EffortStatusDoing]]" },
+      });
+
+      const handler = getLastChangedHandler();
+      for (let i = 0; i < 5; i++) {
+        handler(mockFile);
+      }
+
+      await waitForCondition(
+        () => reindexFileSpy.mock.calls.length >= 1,
+        { timeout: 1500, message: "reindexFile was never called" },
+      );
+      // Wait an extra tick to catch any non-debounced follow-ups.
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(reindexFileSpy).toHaveBeenCalledTimes(1);
+      expect(reindexFileSpy).toHaveBeenCalledWith(mockFile);
+    });
+
+    it("debounces per-file: two different files both get re-indexed", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      const fileA = { path: "A.md", extension: "md" } as TFile;
+      const fileB = { path: "B.md", extension: "md" } as TFile;
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: { "ems__Effort_status": "[[ems__EffortStatusDoing]]" },
+      });
+
+      const handler = getLastChangedHandler();
+      handler(fileA);
+      handler(fileB);
+      handler(fileA); // duplicate of A should still debounce to 1
+
+      await waitForCondition(
+        () => reindexFileSpy.mock.calls.length >= 2,
+        { timeout: 1500, message: "reindexFile not called for both files" },
+      );
+      // Extra wait to catch over-firing.
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(reindexFileSpy).toHaveBeenCalledTimes(2);
+      const reindexedPaths = reindexFileSpy.mock.calls
+        .map((c: any[]) => (c[0] as TFile).path)
+        .sort();
+      expect(reindexedPaths).toEqual(["A.md", "B.md"]);
+    });
+
+    it("ignores non-markdown files (extension !== 'md')", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      const imageFile = { path: "cover.png", extension: "png" } as TFile;
+
+      const handler = getLastChangedHandler();
+      handler(imageFile);
+
+      // Give the debounce ample time to fire if it were going to.
+      await new Promise((r) => setTimeout(r, 400));
+
+      expect(reindexFileSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/api/SPARQLApi.test.ts
+++ b/packages/obsidian-plugin/tests/unit/api/SPARQLApi.test.ts
@@ -1,7 +1,7 @@
 import { SPARQLApi } from "../../../src/application/api/SPARQLApi";
 import { SPARQLQueryService } from "../../../src/application/services/SPARQLQueryService";
 import type ExocortexPlugin from "../../../src/ExocortexPlugin";
-import type { App } from "obsidian";
+import type { App, TFile } from "obsidian";
 
 jest.mock("../../../src/application/services/SPARQLQueryService");
 
@@ -20,6 +20,7 @@ describe("SPARQLApi", () => {
     mockQueryService = {
       query: jest.fn(),
       refresh: jest.fn(),
+      updateFile: jest.fn(),
       dispose: jest.fn(),
       getTripleStore: jest.fn().mockReturnValue({}),
     } as any;
@@ -83,6 +84,25 @@ describe("SPARQLApi", () => {
       await api.refresh();
 
       expect(mockQueryService.refresh).toHaveBeenCalled();
+    });
+  });
+
+  describe("reindexFile (Issue #2785)", () => {
+    it("should delegate to queryService.updateFile for the given file", async () => {
+      const file = { path: "Implement Feature.md", extension: "md" } as TFile;
+
+      await api.reindexFile(file);
+
+      expect(mockQueryService.updateFile).toHaveBeenCalledWith(file);
+      expect(mockQueryService.updateFile).toHaveBeenCalledTimes(1);
+    });
+
+    it("should propagate errors from queryService.updateFile", async () => {
+      const file = { path: "Broken.md", extension: "md" } as TFile;
+      const error = new Error("convert failed");
+      mockQueryService.updateFile.mockRejectedValue(error);
+
+      await expect(api.reindexFile(file)).rejects.toThrow("convert failed");
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #2785 — after clicking inline-button commands like `Set Status Doing`, the COMMANDS panel previously stayed stale until Obsidian restart even though the frontmatter wrote correctly. This PR pipes a per-file, debounced re-index from `metadataCache.on("changed")` so the layout repaints with fresh button visibility in the same session.

- New `SPARQLApi.reindexFile(file)` thin wrapper around the existing `SPARQLQueryService.updateFile` → `VaultRDFIndexer.updateFile` path
- New `ExocortexPlugin.scheduleHotReindex(file)` private method using `TimerManager.setTimeout` with key `hot-reindex:<path>` (150ms debounce, automatic per-file deduping)
- Wired into the existing `metadataCache.on("changed")` subscriber so `metadataCache.changed` (which fires with guaranteed-fresh frontmatter) is the entry point — `vault.modify` can race the cache and is intentionally untouched
- After re-index: `commandResolver.invalidateCache()` + `preconditionEvaluator.invalidateCache()` + `autoRenderLayout()` so the COMMANDS panel repaints

## Why this design

Symmetric to the #2780 cold-start fix (which uses `metadataCache.on("resolved")` for full-vault re-index after Obsidian finishes parsing). #2785 is the incremental-mutation counterpart. Per-file scope is mandatory — `sparql.refresh()` would re-convert every vault file on every keystroke. Per-file `TimerManager` named timers give debouncing for free without locking the global timeline.

## Test plan

- [x] **6 regression tests** in `ExocortexPlugin.test.ts → describe("Issue #2785")`
  - re-indexes the changed file via `sparql.reindexFile`
  - invalidates `commandResolver` + `preconditionEvaluator`
  - triggers `autoRenderLayout`
  - debounces 5 rapid changes for the same file → 1 reindex
  - debounces per-file: 2 different files → 2 reindexes
  - ignores non-markdown files
- [x] **2 unit tests** for `SPARQLApi.reindexFile` (delegate + error propagation)
- [x] `npm run test:unit` — 1244 passed, 25 skipped, 0 failed
- [x] `npm run test:component` — 539 passed, 31 skipped, 0 failed
- [x] `npm run check:types` — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings)
- [x] **Live UI verification** on `getting-started-test-vault`:
  - Cold-opened `Lifecycle Test Task` (Backlog)
  - Clicked `Set Status Doing` → status updated to `ems__EffortStatusDoing` AND `Set Status Doing` button disappeared, `Set Status Backlog` button appeared **without restarting Obsidian**
  - Clicked `Set Status Backlog` → reverse round trip also works in-session

## Out of scope

- The `vault.on("modify")` re-index path inside `VaultRDFIndexer` is unchanged — it still handles create/delete/rename correctly and harmlessly double-indexes on frontmatter mutations (the `metadataCache.changed` path runs after with fresh metadata and wins).
- Journey #2 Scenario B and journey #3 full-lifecycle re-runs land in the next session (the live verification on Lifecycle Test Task already proves the fix).