### PR TITLE
feat(beta): Dataview prereq doc + $nowLocal grounding variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,24 @@ Your entities, their properties, UI layouts, workflows, and commands are all des
 
 This is an evolution of the "as Code" paradigm (Infrastructure as Code, Docs as Code):
 
-| As Code | As Knowledge (Exocortex) |
-|---------|--------------------------|
-| **Workflow as Code** — CI/CD pipelines | **Workflow as Knowledge** — status transitions as RDF data, UI buttons generated automatically |
-| **Layout as Code** — JSON/CSS config | **Layout as Knowledge** — columns, filters, sorting described semantically |
-| **Schema as Code** — JSON Schema, Prisma | **Schema as Knowledge** — OWL classes and properties as files in your vault |
+| As Code                                  | As Knowledge (Exocortex)                                                                       |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Workflow as Code** — CI/CD pipelines   | **Workflow as Knowledge** — status transitions as RDF data, UI buttons generated automatically |
+| **Layout as Code** — JSON/CSS config     | **Layout as Knowledge** — columns, filters, sorting described semantically                     |
+| **Schema as Code** — JSON Schema, Prisma | **Schema as Knowledge** — OWL classes and properties as files in your vault                    |
 
 **"As Code" describes desired system state. "As Knowledge" describes what things mean and how they relate.**
 
 Compared to existing tools:
 
-| | Exocortex | Notion | Jira | Semantic MediaWiki | Protégé |
-|---|:---:|:---:|:---:|:---:|:---:|
-| RDF/Semantic | ✅ | — | — | ✅ | ✅ |
-| File-based (git-friendly) | ✅ | — | — | — | ✅ |
-| UI from ontology | ✅ | ✅ | ~ | ~ | ✅ |
-| Offline-first | ✅ | ~ | — | — | ✅ |
-| For knowledge workers | ✅ | ✅ | ✅ | ~ | �� |
-| Action layer (commands) | ✅ | ~ | ✅ | — | — |
+|                           | Exocortex | Notion | Jira | Semantic MediaWiki | Protégé |
+| ------------------------- | :-------: | :----: | :--: | :----------------: | :-----: |
+| RDF/Semantic              |    ✅     |   —    |  —   |         ✅         |   ✅    |
+| File-based (git-friendly) |    ✅     |   —    |  —   |         —          |   ✅    |
+| UI from ontology          |    ✅     |   ✅   |  ~   |         ~          |   ✅    |
+| Offline-first             |    ✅     |   ~    |  —   |         —          |   ✅    |
+| For knowledge workers     |    ✅     |   ✅   |  ✅  |         ~          |   ��    |
+| Action layer (commands)   |    ✅     |   ~    |  ✅  |         —          |    —    |
 
 ---
 
@@ -56,6 +56,13 @@ Compared to existing tools:
 
 Best for: Visual knowledge management, daily planning, interactive exploration.
 
+**Prerequisites:**
+
+- **Obsidian** 1.4+
+- **[Dataview](https://github.com/blacksmithgu/obsidian-dataview)** community plugin — required for the Daily Tasks widget on daily notes. Install via Community plugins browser (search "Dataview") and enable it before installing Exocortex.
+
+**Install Exocortex via BRAT:**
+
 1. Install [BRAT](https://github.com/TfTHacker/obsidian42-brat) plugin from Obsidian Community Plugins
 2. Open BRAT settings → **Add Beta Plugin**
 3. Enter repository: `kitelev/exocortex`
@@ -65,7 +72,7 @@ BRAT will automatically keep the plugin updated with new releases.
 
 > **Next:** Follow the **[Getting Started Guide](./docs/Getting-Started.md)** to install the Starter Kit and create your first Area, Project, and Task.
 >
-> **Note:** Layouts appear in **Reading Mode** (Ctrl/Cmd + E).
+> **Note:** Layouts appear in **Reading Mode** (Ctrl/Cmd + E). Without Dataview the plugin still renders action buttons, status panels, and Asset Relations — only the Daily Tasks widget on daily notes depends on it.
 
 ### Option 2: CLI
 

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -5,6 +5,7 @@ import type { IFileSystemWriter } from "../interfaces/IFileSystemAdapter";
 import type { GroundingDefinition } from "../domain/models/CommandDefinition";
 import { GroundingType } from "../domain/constants/GroundingType";
 import { FrontmatterService } from "../utilities/FrontmatterService";
+import { DateFormatter } from "../utilities/DateFormatter";
 import { LoggingService } from "./LoggingService";
 
 /**
@@ -407,15 +408,22 @@ export class GroundingExecutor {
    * Same variables as PreconditionEvaluator for consistency.
    *
    * - $target → targetIRI (no angle brackets — this is a value, not SPARQL)
-   * - $now → current ISO 8601 timestamp
+   * - $now → current ISO 8601 UTC timestamp (with milliseconds and Z suffix)
+   * - $nowLocal → current local timestamp (YYYY-MM-DDTHH:mm:ss, no ms, no tz) —
+   *   matches the format written by `TaskStatusService.startEffort/markTaskAsDone`,
+   *   so composite groundings can chain status + timestamp writes consistently
+   *   with palette commands.
    * - $today → current date (YYYY-MM-DD)
    */
   substituteVariables(value: string, targetIRI: string): string {
-    const now = new Date().toISOString();
+    const date = new Date();
+    const now = date.toISOString();
+    const nowLocal = DateFormatter.toLocalTimestamp(date);
     const today = now.slice(0, 10);
 
     return value
       .replace(/\$target/g, targetIRI)
+      .replace(/\$nowLocal/g, nowLocal)
       .replace(/\$now/g, now)
       .replace(/\$today/g, today);
   }

--- a/packages/exocortex/src/utilities/DateFormatter.ts
+++ b/packages/exocortex/src/utilities/DateFormatter.ts
@@ -69,13 +69,23 @@ export class DateFormatter {
    *
    * Format: `YYYY-MM-DDTHH:MM:SS`
    *
-   * @deprecated Use `toISOTimestamp()` for effort timestamps to enable SPARQL filtering.
-   * This method is kept for backward compatibility with display-only timestamps.
+   * Canonical format for effort and asset lifecycle timestamps across the
+   * codebase. Examples:
    *
-   * Used for frontmatter properties like:
-   * - `ems__Effort_created`
-   * - `ems__Effort_modified`
-   * - `ems__Effort_archived`
+   * - `ems__Effort_startTimestamp` / `endTimestamp` / `resolutionTimestamp`
+   *   (written by `TaskStatusService.startEffort` / `markTaskAsDone`)
+   * - `ems__Effort_plannedStartTimestamp` / `plannedEndTimestamp`
+   *   (written by `TaskStatusService.planForEvening` and friends)
+   * - `exo__Asset_createdAt` (written by `GenericAssetCreationService` /
+   *   `AreaCreationService` and other `*CreationService` classes)
+   *
+   * Starter-kit composite groundings produce the same shape via the
+   * `$nowLocal` variable in `GroundingExecutor.substituteVariables`, so palette
+   * commands and inline status buttons stay format-aligned.
+   *
+   * `toISOTimestamp` (UTC with `Z` suffix) is reserved for places that need
+   * explicit UTC anchoring or lexicographic ordering — it is NOT a drop-in
+   * replacement for the local-time format above.
    *
    * @param date - Date object to format
    * @returns ISO 8601 local timestamp string

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -560,6 +560,29 @@ describe("GroundingExecutor", () => {
       expect(result).toMatch(/started at \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
     });
 
+    it("should replace $nowLocal with local timestamp (no ms, no tz suffix)", () => {
+      const result = executor.substituteVariables(
+        "started at $nowLocal",
+        TARGET_IRI,
+      );
+      expect(result).toMatch(/^started at \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+      expect(result).not.toContain(".");
+      expect(result).not.toContain("Z");
+    });
+
+    it("should replace $nowLocal before $now to avoid prefix collision", () => {
+      const result = executor.substituteVariables(
+        "$nowLocal then $now",
+        TARGET_IRI,
+      );
+      expect(result).not.toContain("$now");
+      expect(result).not.toContain("$nowLocal");
+      expect(result).not.toContain("Local");
+      expect(result).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} then \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+    });
+
     it("should replace $today with YYYY-MM-DD", () => {
       const result = executor.substituteVariables(
         "due $today",


### PR DESCRIPTION
## Summary

Two paired changes that unblock the **starter-kit composite groundings** (separate PR) which will let inline `Set Status Doing` / `Set Status Done` buttons set both status AND timestamps in one click — matching the palette `Start Effort` / `Mark Done` semantics.

### 1. README Prerequisites doc (Dataview hard dep)

The Daily Tasks widget on `pn__DailyNote` notes silently does not render without the Dataview community plugin. Component test `AssetRelationsTable` already encodes this as an intentional hard requirement (`should NOT render Tasks table when Dataview is not available`). Beta users would otherwise install Exocortex, open a daily note, see no tasks, and either file a bug or churn.

Adds a **Prerequisites** block under Quick Start naming Dataview explicitly. Also clarifies that the rest of the plugin (action buttons, status panels, Asset Relations) renders without Dataview — so the dependency is scoped, not blanket.

### 2. `$nowLocal` grounding substitution variable

`GroundingExecutor.substituteVariables` already supports `$now` (UTC ISO with milliseconds + `Z`) and `$today` (`YYYY-MM-DD`). It does **not** offer the canonical local-time format (`YYYY-MM-DDTHH:mm:ss`, no ms, no tz) used by **every** effort timestamp writer in the codebase:

- `TaskStatusService.startEffort` / `markTaskAsDone` / `planForEvening` (palette path)
- `GenericAssetCreationService.exo__Asset_createdAt`
- `AreaCreationService` / `ConceptCreationService` / `FleetingNoteCreationService` (every \*CreationService)

All call `DateFormatter.toLocalTimestamp(new Date())`. So composite groundings authored with `$now` would write a **different** timestamp format than the palette, creating two formats in the same effort field depending on which UI path the user clicked. For beta that's a data consistency bug.

This PR adds `$nowLocal` → `DateFormatter.toLocalTimestamp(new Date())`, ordered to substitute before `$now` (since `$now` is a strict prefix — naive ordering would corrupt `$nowLocal` → `…Local`). Two new tests cover the format shape and the prefix-collision ordering.

### 3. `DateFormatter.toLocalTimestamp` JSDoc cleanup

The function was tagged `@deprecated` with guidance to use `toISOTimestamp`. That guidance was aspirational and never adopted — every effort-timestamp writer uses `toLocalTimestamp`, and `toISOTimestamp` produces an entirely different format (UTC with `Z`) that's not interchangeable. The deprecation also tripped `@typescript-eslint/no-deprecated` for the new `$nowLocal` use site.

Removes the misleading `@deprecated` tag, enumerates the canonical use sites in the JSDoc, and notes the new `$nowLocal` grounding variable as the alignment hook.

## Test plan

- [x] `npx jest --config packages/exocortex/jest.config.js --testPathPatterns GroundingExecutor` → 51 tests pass (49 existing + 2 new)
- [x] `./scripts/test-ci-batched.sh` (test:unit CI gate) → 1244 tests pass
- [x] `npm run check:types` → clean
- [x] `npm run lint` → 0 errors, 2 pre-existing warnings (not my code)
- [x] BDD coverage 100% across 12 features, archgate 13/13 pass (pre-commit hook)
- [x] `git push` → branch up

## Follow-up (separate starter-kit PR)

Composite `Set Status Doing` / `Set Status Done` groundings using `$nowLocal` for chained status + `Effort_startTimestamp` / `endTimestamp` writes. Will land after this PR releases.