### PR TITLE
feat(grounding): add createRelatedProject service for parent-aware Project creation

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -290,6 +290,65 @@ export function populateServiceRegistry(
     );
 
     registry.register(
+      "createRelatedProject",
+      wrapService(async (targetIRI: string, userInput?: UserInput) => {
+        const label = userInput?.label as string | undefined;
+        if (!label) throw new Error("createRelatedProject requires userInput.label");
+        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
+        const parentMetadata = (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
+        const folderPath = iFile.parent?.path || "";
+
+        // Mirror createRelatedTask but scoped to ems__Project. Uses the same
+        // ems__Effort_* parent-property convention so AssetRelations rendering
+        // works uniformly with sibling Task/Meeting efforts. When the parent
+        // is an ems__Area, write ems__Effort_area; when the parent is another
+        // Project or Task, write ems__Effort_parent. The core
+        // GenericAssetCreationService.inheritParentContext currently only
+        // auto-inherits for ems__Task, so this handler does the area vs parent
+        // detection explicitly via userInput.parentProperty and falls back to
+        // the auto-detected form.
+        const propertyValues: Record<string, unknown> = {
+          "ems__Effort_status": '"[[ems__EffortStatusDraft]]"',
+        };
+
+        if (iFile.basename) {
+          const explicitParentProperty = userInput?.parentProperty as string | undefined;
+          if (explicitParentProperty) {
+            propertyValues[explicitParentProperty] = `"[[${iFile.basename}]]"`;
+          } else {
+            const parentClass = parentMetadata["exo__Instance_class"];
+            const parentClasses = Array.isArray(parentClass)
+              ? parentClass
+              : parentClass != null
+                ? [parentClass]
+                : [];
+            const isAreaParent = parentClasses.some((cls) =>
+              String(cls).includes("Area"),
+            );
+            const parentPropertyName = isAreaParent
+              ? "ems__Effort_area"
+              : "ems__Effort_parent";
+            propertyValues[parentPropertyName] = `"[[${iFile.basename}]]"`;
+          }
+        }
+
+        const createdFile = await genericAssetCreationService.createAsset({
+          className: "ems__Project",
+          label,
+          folderPath,
+          propertyValues,
+          parentFile: iFile,
+          parentMetadata,
+        });
+
+        const tfile = vaultAdapter.toTFile(createdFile);
+        const leaf = app.workspace.getLeaf("tab");
+        await leaf.openFile(tfile);
+        app.workspace.setActiveLeaf(leaf, { focus: true });
+      }),
+    );
+
+    registry.register(
       "createTaskForDailyNote",
       wrapService(async (targetIRI: string, userInput?: UserInput) => {
         const label = userInput?.label as string | undefined;

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -123,6 +123,7 @@ describe("ServiceRegistryPopulator", () => {
       "incrementVotes",
       "copyLabelToAliases",
       "createRelatedTask",
+      "createRelatedProject",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -425,6 +426,7 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       "incrementVotes",
       "copyLabelToAliases",
       "createRelatedTask",
+      "createRelatedProject",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -584,6 +586,92 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       const service = registry.get("createRelatedTask")!;
       await expect(service.execute("test-uid-123", {})).rejects.toThrow(
         "createRelatedTask requires userInput.label",
+      );
+    });
+  });
+
+  describe("createRelatedProject", () => {
+    it("should create a related project asset", async () => {
+      const service = registry.get("createRelatedProject")!;
+      await service.execute("test-uid-123", { label: "New Project" });
+
+      expect(deps.vaultAdapter!.create).toHaveBeenCalledWith(
+        expect.stringContaining("folder/"),
+        expect.stringContaining("ems__Project"),
+      );
+    });
+
+    it("should set ems__Effort_status to Draft by default", async () => {
+      const service = registry.get("createRelatedProject")!;
+      await service.execute("test-uid-123", { label: "New Project" });
+
+      const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
+      const content = createCall[1] as string;
+      expect(content).toContain('ems__Effort_status: "[[ems__EffortStatusDraft]]"');
+    });
+
+    it("should write ems__Effort_area when parent is an Area", async () => {
+      (deps.vaultAdapter!.getFrontmatter as jest.Mock).mockReturnValueOnce({
+        exo__Asset_uid: "test-uid-123",
+        exo__Asset_label: "Research",
+        exo__Instance_class: ["[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]"],
+      });
+
+      const service = registry.get("createRelatedProject")!;
+      await service.execute("test-uid-123", { label: "Thesis" });
+
+      const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
+      const content = createCall[1] as string;
+      expect(content).toContain('ems__Effort_area: "[[test-uid-123]]"');
+      expect(content).not.toContain("ems__Effort_parent");
+    });
+
+    it("should write ems__Effort_parent when parent is not an Area", async () => {
+      (deps.vaultAdapter!.getFrontmatter as jest.Mock).mockReturnValueOnce({
+        exo__Asset_uid: "test-uid-123",
+        exo__Asset_label: "Parent Project",
+        exo__Instance_class: ["[[ems__Project]]"],
+      });
+
+      const service = registry.get("createRelatedProject")!;
+      await service.execute("test-uid-123", { label: "Sub Project" });
+
+      const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
+      const content = createCall[1] as string;
+      expect(content).toContain('ems__Effort_parent: "[[test-uid-123]]"');
+      expect(content).not.toContain("ems__Effort_area");
+    });
+
+    it("should honor explicit parentProperty override from userInput", async () => {
+      const service = registry.get("createRelatedProject")!;
+      await service.execute("test-uid-123", {
+        label: "Override Project",
+        parentProperty: "ems__Effort_parent",
+      });
+
+      const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
+      const content = createCall[1] as string;
+      expect(content).toContain('ems__Effort_parent: "[[test-uid-123]]"');
+    });
+
+    it("should open the created project in a new tab leaf", async () => {
+      const service = registry.get("createRelatedProject")!;
+      await service.execute("test-uid-123", { label: "Visible Project" });
+
+      expect(deps.app.workspace.getLeaf).toHaveBeenCalledWith("tab");
+      expect(deps.vaultAdapter!.toTFile).toHaveBeenCalled();
+      const leafMock = (deps.app.workspace.getLeaf as jest.Mock).mock.results[0].value;
+      expect(leafMock.openFile).toHaveBeenCalled();
+      expect(deps.app.workspace.setActiveLeaf).toHaveBeenCalledWith(
+        leafMock,
+        { focus: true },
+      );
+    });
+
+    it("should throw when label is missing", async () => {
+      const service = registry.get("createRelatedProject")!;
+      await expect(service.execute("test-uid-123", {})).rejects.toThrow(
+        "createRelatedProject requires userInput.label",
       );
     });
   });


### PR DESCRIPTION
## Summary

Adds a new \`createRelatedProject\` service handler symmetric with \`createRelatedTask\`, scoped to the \`ems__Project\` class. It mirrors the parent-inheritance discipline so inline "Create Project" buttons on Areas / Projects produce efforts whose \`ems__Effort_area\` / \`ems__Effort_parent\` link points back at the triggering note without manual frontmatter editing.

## Why

The generic \`createAsset\` handler writes prototype-only frontmatter (\`uid + createdAt + label + prototype\`) and never inherits parent context, so clicking \`Create Project\` on a Research Area produces an orphaned Project with no \`ems__Effort_area\`. Journey #5 (create-area-project-task-hierarchy) surfaced this gap during live re-run on plugin v15.91.0 after starter-kit PR #20 rewrote the spec to use the dedicated \`Create Project\` command instead of the old manual class-flip flow.

Rather than extending \`createAsset\` with optional parent inheritance — which would change behavior for all existing callers — this adds a dedicated handler that is easy to reason about and symmetric with \`createRelatedTask\`.

## Behavior

- Reads parent note metadata via \`vaultAdapter.getFrontmatter\`
- When the parent's \`exo__Instance_class\` contains an \"Area\" class, the new Project gets \`ems__Effort_area: [[<parent basename>]]\`
- Otherwise (Project or Task parent) the new Project gets \`ems__Effort_parent: [[<parent basename>]]\`
- Honors \`userInput.parentProperty\` override for starter-kit bindings that want to force a specific link, matching \`createRelatedTask\`'s override contract
- Defaults \`ems__Effort_status\` to \`[[ems__EffortStatusDraft]]\`
- Delegates materialization to \`GenericAssetCreationService.createAsset\` which handles folder creation, \`exo__Asset_uid\`, \`exo__Instance_class\`, labels, aliases
- Opens the new Project in a new tab leaf (same UX as \`createRelatedTask\`)

## Test coverage

6 new unit tests in \`ServiceRegistryPopulator.test.ts\`:

- Service registered under the canonical name
- Default Draft status is written
- Area parent → \`ems__Effort_area\`
- Non-Area parent → \`ems__Effort_parent\`
- Explicit \`parentProperty\` override honored
- New file opens in a new tab leaf
- Missing label throws with the canonical error message

All 53 \`ServiceRegistryPopulator\` tests pass, CI test-unit gate green (1244 tests), typecheck clean, BDD coverage 100% across 12 features, archgate 13/13.

## Follow-up

Starter-kit PR to re-point the \`Create Project\` grounding (\`8748f8b0-...\`) from \`createAsset\` to \`createRelatedProject\`. Will land after this PR releases.