### PR TITLE
fix: widen auto-release feat-scope regex to match hyphenated scopes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -60,7 +60,7 @@ jobs:
             echo "Detected BREAKING CHANGE → major bump"
             echo "type=major" >> $GITHUB_OUTPUT
           # Check for feat:
-          elif echo "$COMMITS" | grep -qE "^feat(\([a-z]+\))?:"; then
+          elif echo "$COMMITS" | grep -qE "^feat(\([a-z0-9-]+\))?:"; then
             echo "Detected feat: → minor bump"
             echo "type=minor" >> $GITHUB_OUTPUT
           # Everything else is patch


### PR DESCRIPTION
## Summary
- Widens Auto Release workflow's feat-bump regex from `[a-z]+` to `[a-z0-9-]+` inside the scope group
- Same dormant bug that starter-kit v1.7.0 already fixed
- Prior regex rejected commits like `feat(ux-polish):` → patch bump instead of minor (observed on v15.92.1)

## Motivation
Commit `feat(ux-polish): Enter-to-submit...` from #2789 should have bumped minor → v15.93.0 but landed as v15.92.1 patch. Confirms same regex bug as starter-kit had.

## Expected behavior after merge
- This PR uses `fix:` prefix → patch bump → v15.92.2
- Next PR with `feat(commands-grouping):` will bump minor → v15.93.0, proving the fix inline

## Test plan
- [ ] Auto Release workflow runs on merge, bumps patch → v15.92.2
- [ ] Follow-up feat(hyphen-scope): PR correctly bumps minor