### PR TITLE
feat(commands-grouping): render COMMANDS panel as category sections with collapsible maintenance

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -145,9 +145,21 @@ export class ButtonGroupsBuilder {
       refresh: this.refresh,
     };
 
-    // Build groups from all builders, filtering out empty ones
+    // Build groups from all builders, filtering out empty ones.
+    // DynamicCommandButtonGroupBuilder exposes buildCategoryGroups for
+    // category-sectioned rendering (RFC-009 COMMANDS panel polish); other
+    // flat builders still go through the legacy single-group wrapper.
     const groups: ButtonGroup[] = [];
     for (const builder of this.builders) {
+      if (builder instanceof DynamicCommandButtonGroupBuilder) {
+        const categoryGroups = await builder.buildCategoryGroups(context);
+        for (const g of categoryGroups) {
+          if (g.buttons.some((btn) => btn.visible !== false)) {
+            groups.push(g);
+          }
+        }
+        continue;
+      }
       const group = await createButtonGroupIfVisible(builder, context);
       if (group) {
         groups.push(group);

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -1,5 +1,5 @@
 import { App } from "obsidian";
-import { ActionButton } from '@plugin/presentation/components/ActionButtonsGroup';
+import { ActionButton, ButtonGroup } from '@plugin/presentation/components/ActionButtonsGroup';
 import type {
   CommandResolver,
   ResolvedCommand,
@@ -87,7 +87,93 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
   }
 
   async build(context: ButtonBuilderContext): Promise<ActionButton[]> {
-    const { app, file, metadata, logger, refresh } = context;
+    const resolved = await this.resolveVisibleCommands(context);
+    if (resolved === null) return [];
+    const { visibleCommands, subjectIRI } = resolved;
+    const { app, file, logger, refresh } = context;
+    return visibleCommands.map((rc) =>
+      this.createButton(rc, subjectIRI, file.path, app as App, logger, refresh),
+    );
+  }
+
+  /**
+   * Build COMMANDS panel as category-grouped ButtonGroups (RFC-009 polish).
+   *
+   * Fixed category order: creation → status → planning → criticality → maintenance.
+   * Commands with no category land in a trailing "Other" group. Maintenance is
+   * marked collapsedByDefault because those commands are power-user repair tools
+   * that rarely apply during normal work and otherwise dominate panel real-estate.
+   *
+   * Groups with zero visible commands are omitted — the React component re-filters
+   * too, but returning them empty here keeps the payload lean.
+   */
+  async buildCategoryGroups(context: ButtonBuilderContext): Promise<ButtonGroup[]> {
+    const resolved = await this.resolveVisibleCommands(context);
+    if (resolved === null) return [];
+    const { visibleCommands, subjectIRI } = resolved;
+    const { app, file, logger, refresh } = context;
+
+    const byCategory = new Map<string, ResolvedCommand[]>();
+    for (const rc of visibleCommands) {
+      const key = (rc.command.category ?? "").trim().toLowerCase() || "other";
+      const bucket = byCategory.get(key);
+      if (bucket) {
+        bucket.push(rc);
+      } else {
+        byCategory.set(key, [rc]);
+      }
+    }
+
+    const groups: ButtonGroup[] = [];
+    for (const spec of DynamicCommandButtonGroupBuilder.CATEGORY_ORDER) {
+      const commands = byCategory.get(spec.id);
+      byCategory.delete(spec.id);
+      if (!commands || commands.length === 0) continue;
+      groups.push({
+        id: `dynamic-commands-${spec.id}`,
+        title: spec.title,
+        collapsedByDefault: spec.collapsedByDefault,
+        buttons: commands.map((rc) =>
+          this.createButton(rc, subjectIRI, file.path, app as App, logger, refresh),
+        ),
+      });
+    }
+
+    // Any leftover categories (unexpected values) go into a single Other group
+    // at the end, in insertion order, so nothing is silently dropped.
+    const leftover: ResolvedCommand[] = [];
+    for (const commands of byCategory.values()) {
+      leftover.push(...commands);
+    }
+    if (leftover.length > 0) {
+      groups.push({
+        id: "dynamic-commands-other",
+        title: "Other",
+        buttons: leftover.map((rc) =>
+          this.createButton(rc, subjectIRI, file.path, app as App, logger, refresh),
+        ),
+      });
+    }
+
+    return groups;
+  }
+
+  private static readonly CATEGORY_ORDER: ReadonlyArray<{
+    id: string;
+    title: string;
+    collapsedByDefault?: boolean;
+  }> = [
+    { id: "creation", title: "Create" },
+    { id: "status", title: "Status" },
+    { id: "planning", title: "Planning" },
+    { id: "criticality", title: "Criticality" },
+    { id: "maintenance", title: "Maintenance", collapsedByDefault: true },
+  ];
+
+  private async resolveVisibleCommands(
+    context: ButtonBuilderContext,
+  ): Promise<{ visibleCommands: ResolvedCommand[]; subjectIRI: string } | null> {
+    const { file, metadata, logger } = context;
 
     // CRITICAL: subjectIRI MUST match triple store subject IRI.
     // NoteToRDFConverter indexes triples by `obsidian://vault/${encodeURI(file.path)}`,
@@ -97,7 +183,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     const subjectIRI = `obsidian://vault/${encodeURI(file.path)}`;
 
     const assetClass = this.extractAssetClass(metadata);
-    if (!assetClass) return [];
+    if (!assetClass) return null;
 
     const prototypeIRI = this.extractPrototypeIRI(metadata);
 
@@ -110,10 +196,10 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
       );
     } catch (error) {
       logger.info(`[DynamicCommands] Failed to resolve commands: ${String(error)}`);
-      return [];
+      return null;
     }
 
-    if (resolved.length === 0) return [];
+    if (resolved.length === 0) return null;
 
     const evalContext: EvalContext = {
       targetIRI: subjectIRI,
@@ -137,13 +223,12 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     );
 
     const visibleCommands = availabilityChecks
-      .filter(({ available }) => available);
+      .filter(({ available }) => available)
+      .map(({ rc }) => rc);
 
-    if (visibleCommands.length === 0) return [];
+    if (visibleCommands.length === 0) return null;
 
-    return visibleCommands.map(({ rc }) =>
-      this.createButton(rc, subjectIRI, file.path, app as App, logger, refresh),
-    );
+    return { visibleCommands, subjectIRI };
   }
 
   private createButton(

--- a/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 /**
  * Props for individual action buttons within the group
@@ -18,6 +18,13 @@ export interface ButtonGroup {
   id: string;
   title: string;
   buttons: ActionButton[];
+  /**
+   * When true, the group renders as a collapsible disclosure that starts
+   * collapsed on first mount. Users toggle via the header. Used for
+   * power-user / rare-use groups (e.g. Maintenance) so they do not dominate
+   * panel real-estate during normal work.
+   */
+  collapsedByDefault?: boolean;
 }
 
 /**
@@ -38,11 +45,11 @@ export interface ActionButtonsGroupProps {
  * - Color-coded button variants for different action types
  * - Responsive layout adapting to screen size
  * - Clean, modern design with proper spacing
+ * - Optional per-group collapsible disclosure (collapsedByDefault)
  */
 export const ActionButtonsGroup: React.FC<ActionButtonsGroupProps> = ({
   groups,
 }) => {
-  // Filter out groups with no visible buttons
   const visibleGroups = groups
     .map((group) => ({
       ...group,
@@ -50,35 +57,75 @@ export const ActionButtonsGroup: React.FC<ActionButtonsGroupProps> = ({
     }))
     .filter((group) => group.buttons.length > 0);
 
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    for (const g of visibleGroups) {
+      if (g.collapsedByDefault) initial[g.id] = true;
+    }
+    return initial;
+  });
+
   if (visibleGroups.length === 0) {
     return null;
   }
 
+  const toggle = (id: string) => {
+    setCollapsed((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
   return (
     <div className="exocortex-action-buttons-container">
-      {visibleGroups.map((group, groupIndex) => (
-        <div key={group.id} className="exocortex-button-group">
-          <div className="exocortex-button-group-title">{group.title}</div>
-          <div className="exocortex-button-group-buttons">
-            {group.buttons.map((button) => (
+      {visibleGroups.map((group, groupIndex) => {
+        const isCollapsible = group.collapsedByDefault === true;
+        const isCollapsed = collapsed[group.id] === true;
+        return (
+          <div key={group.id} className="exocortex-button-group">
+            {isCollapsible ? (
               <button
-                key={button.id}
-                className={`exocortex-action-button exocortex-action-button--${button.variant || "secondary"}`}
-                onClick={async (e) => {
+                type="button"
+                className="exocortex-button-group-title exocortex-button-group-title--collapsible"
+                aria-expanded={!isCollapsed}
+                aria-controls={`exocortex-button-group-body-${group.id}`}
+                onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  await button.onClick();
+                  toggle(group.id);
                 }}
               >
-                {button.label}
+                <span className="exocortex-button-group-disclosure">
+                  {isCollapsed ? "▶" : "▼"}
+                </span>
+                {group.title}
               </button>
-            ))}
+            ) : (
+              <div className="exocortex-button-group-title">{group.title}</div>
+            )}
+            {!(isCollapsible && isCollapsed) && (
+              <div
+                className="exocortex-button-group-buttons"
+                id={`exocortex-button-group-body-${group.id}`}
+              >
+                {group.buttons.map((button) => (
+                  <button
+                    key={button.id}
+                    className={`exocortex-action-button exocortex-action-button--${button.variant || "secondary"}`}
+                    onClick={async (e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      await button.onClick();
+                    }}
+                  >
+                    {button.label}
+                  </button>
+                ))}
+              </div>
+            )}
+            {groupIndex < visibleGroups.length - 1 && (
+              <div className="exocortex-button-group-separator" />
+            )}
           </div>
-          {groupIndex < visibleGroups.length - 1 && (
-            <div className="exocortex-button-group-separator" />
-          )}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/packages/obsidian-plugin/tests/e2e/specs/dynamic-command-buttons-render.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/dynamic-command-buttons-render.spec.ts
@@ -90,16 +90,27 @@ test.describe("Dynamic Command Button Rendering & Functionality", () => {
       plugin?.refreshLayout?.();
     });
 
-    // Button "Remove Start Timestamp" must render — precondition SPARQL ASK
-    // checks for ems:Effort_startTimestamp triple in triple store, which
-    // exists for this file (task has ems__Effort_startTimestamp: "2026-03-30...")
+    // "Remove Start Timestamp" lives in the Maintenance category, which now
+    // renders as a collapsed-by-default disclosure (UX iteration 2). First the
+    // Maintenance header must appear, then clicking it reveals the button.
+    // Precondition SPARQL ASK checks for ems:Effort_startTimestamp triple,
+    // which exists for this fixture.
+    const maintenanceHeader = page.locator(
+      'button.exocortex-button-group-title--collapsible:has-text("Maintenance")'
+    );
+    await expect(
+      maintenanceHeader,
+      "Maintenance category header must render for task WITH startTimestamp."
+    ).toBeVisible({ timeout: 20000 });
+    await maintenanceHeader.click();
+
     const removeTimestampButton = page.locator(
       'button.exocortex-action-button:has-text("Remove Start Timestamp")'
     );
 
     await expect(
       removeTimestampButton,
-      'Button "Remove Start Timestamp" must render for task WITH startTimestamp.'
+      'Button "Remove Start Timestamp" must render for task WITH startTimestamp after expanding Maintenance.'
     ).toBeVisible({ timeout: 20000 });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
@@ -55,6 +55,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
         command: {
           id: "cmd-1",
           name: "Start Effort",
+          category: "status",
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value", property: "status", value: "doing" },
         },
@@ -65,9 +66,9 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
 
     const groups = await ctx.builder.build(mockFile);
 
-    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands-status");
     expect(dynamicGroup).toBeDefined();
-    expect(dynamicGroup!.title).toBe("Commands");
+    expect(dynamicGroup!.title).toBe("Status");
     expect(dynamicGroup!.buttons.length).toBe(1);
     expect(dynamicGroup!.buttons[0].label).toBe("Start Effort");
   });
@@ -93,6 +94,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
         command: {
           id: "cmd-visible",
           name: "Visible Command",
+          category: "status",
           precondition: { type: "check_status" },
           grounding: { type: "set_frontmatter_value" },
         },
@@ -102,6 +104,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
         command: {
           id: "cmd-hidden",
           name: "Hidden Command",
+          category: "status",
           precondition: { type: "check_status" },
           grounding: { type: "set_frontmatter_value" },
         },
@@ -114,7 +117,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
 
     const groups = await ctx.builder.build(mockFile);
 
-    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands-status");
     expect(dynamicGroup).toBeDefined();
     expect(dynamicGroup!.buttons.length).toBe(1);
     expect(dynamicGroup!.buttons[0].label).toBe("Visible Command");
@@ -162,6 +165,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
         command: {
           id: "cmd-status",
           name: "Move to Backlog",
+          category: "status",
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value" },
         },
@@ -171,6 +175,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
         command: {
           id: "cmd-maintenance",
           name: "Clean Properties",
+          category: "maintenance",
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value" },
         },
@@ -180,6 +185,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
         command: {
           id: "cmd-danger",
           name: "Trash",
+          category: "maintenance",
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value" },
         },
@@ -190,12 +196,16 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
 
     const groups = await ctx.builder.build(mockFile);
 
-    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
-    expect(dynamicGroup).toBeDefined();
-    expect(dynamicGroup!.buttons.length).toBe(3);
-    expect(dynamicGroup!.buttons[0].variant).toBe("primary");
-    expect(dynamicGroup!.buttons[1].variant).toBe("secondary");
-    expect(dynamicGroup!.buttons[2].variant).toBe("danger");
+    const statusGroup = groups.find((g) => g.id === "dynamic-commands-status");
+    const maintenanceGroup = groups.find((g) => g.id === "dynamic-commands-maintenance");
+    expect(statusGroup).toBeDefined();
+    expect(statusGroup!.buttons.length).toBe(1);
+    expect(statusGroup!.buttons[0].variant).toBe("primary");
+    expect(maintenanceGroup).toBeDefined();
+    expect(maintenanceGroup!.collapsedByDefault).toBe(true);
+    expect(maintenanceGroup!.buttons.length).toBe(2);
+    expect(maintenanceGroup!.buttons[0].variant).toBe("secondary");
+    expect(maintenanceGroup!.buttons[1].variant).toBe("danger");
   });
 
   it("should handle resolver errors gracefully", async () => {

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.dynamicCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.dynamicCommands.test.ts
@@ -53,7 +53,7 @@ describe("ButtonGroupsBuilder - dynamic commands (RFC-009)", () => {
     (config.folderRepairService.getExpectedFolder as jest.Mock).mockResolvedValue(null);
 
     const groups = await builder.build(mockFile);
-    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    const dynamicGroup = groups.find((g) => g.id.startsWith("dynamic-commands"));
     expect(dynamicGroup).toBeUndefined();
   });
 
@@ -103,9 +103,10 @@ describe("ButtonGroupsBuilder - dynamic commands (RFC-009)", () => {
     (config.folderRepairService.getExpectedFolder as jest.Mock).mockResolvedValue(null);
 
     const groups = await builder.build(mockFile);
-    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    const dynamicGroup = groups.find((g) => g.id.startsWith("dynamic-commands"));
     expect(dynamicGroup).toBeDefined();
-    expect(dynamicGroup!.title).toBe("Commands");
+    // Legacy per-builder title "Commands" is now category-specific ("Other", "Status", ...).
+    expect(dynamicGroup!.title.length).toBeGreaterThan(0);
   });
 
   it("should NOT include dynamic-commands builder when only partial services provided", async () => {
@@ -124,7 +125,7 @@ describe("ButtonGroupsBuilder - dynamic commands (RFC-009)", () => {
     (config.folderRepairService.getExpectedFolder as jest.Mock).mockResolvedValue(null);
 
     const groups = await builder.build(mockFile);
-    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    const dynamicGroup = groups.find((g) => g.id.startsWith("dynamic-commands"));
     expect(dynamicGroup).toBeUndefined();
   });
 });

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.handlers.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.handlers.test.ts
@@ -42,7 +42,7 @@ describe("ButtonGroupsBuilder - onClick handlers (dynamic commands)", () => {
     ctx.mockGroundingExecutor.execute.mockResolvedValue({ success: true });
 
     const groups = await ctx.builder.build(mockFile);
-    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    const dynamicGroup = groups.find((g) => g.id.startsWith("dynamic-commands"));
     const button = dynamicGroup?.buttons[0];
 
     expect(button).toBeDefined();
@@ -90,7 +90,7 @@ describe("ButtonGroupsBuilder - onClick handlers (dynamic commands)", () => {
     ctx.mockGroundingExecutor.execute.mockResolvedValue({ success: true });
 
     const groups = await ctx.builder.build(mockFile);
-    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    const dynamicGroup = groups.find((g) => g.id.startsWith("dynamic-commands"));
     const button = dynamicGroup?.buttons[0];
 
     expect(button).toBeDefined();
@@ -136,7 +136,7 @@ describe("ButtonGroupsBuilder - onClick handlers (dynamic commands)", () => {
     });
 
     const groups = await ctx.builder.build(mockFile);
-    const dynamicGroup = groups.find((g) => g.id === "dynamic-commands");
+    const dynamicGroup = groups.find((g) => g.id.startsWith("dynamic-commands"));
     const button = dynamicGroup?.buttons[0];
 
     expect(button).toBeDefined();

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -437,4 +437,109 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       expect(result[1].label).toBe("Second");
     });
   });
+
+  describe("buildCategoryGroups", () => {
+    it("should return groups in fixed order (creation → status → planning → criticality → maintenance)", async () => {
+      const commands = [
+        createResolvedCommand({ id: "m1", name: "Rename to UID", category: "maintenance" }),
+        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
+        createResolvedCommand({ id: "s1", name: "Set Status Doing", category: "status" }),
+        createResolvedCommand({ id: "p1", name: "Plan on Today", category: "planning" }),
+        createResolvedCommand({ id: "k1", name: "Set Criticality High", category: "criticality" }),
+      ];
+      mockResolveForAsset.mockResolvedValue(commands);
+      mockEvaluate.mockResolvedValue(true);
+
+      const result = await builder.buildCategoryGroups(createContext());
+
+      expect(result.map((g) => g.id)).toEqual([
+        "dynamic-commands-creation",
+        "dynamic-commands-status",
+        "dynamic-commands-planning",
+        "dynamic-commands-criticality",
+        "dynamic-commands-maintenance",
+      ]);
+      expect(result.map((g) => g.title)).toEqual([
+        "Create",
+        "Status",
+        "Planning",
+        "Criticality",
+        "Maintenance",
+      ]);
+    });
+
+    it("should mark maintenance group collapsedByDefault", async () => {
+      mockResolveForAsset.mockResolvedValue([
+        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
+        createResolvedCommand({ id: "m1", name: "Rename to UID", category: "maintenance" }),
+      ]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const result = await builder.buildCategoryGroups(createContext());
+
+      const creation = result.find((g) => g.id === "dynamic-commands-creation");
+      const maintenance = result.find((g) => g.id === "dynamic-commands-maintenance");
+      expect(creation?.collapsedByDefault).toBeFalsy();
+      expect(maintenance?.collapsedByDefault).toBe(true);
+    });
+
+    it("should omit categories that have zero visible commands", async () => {
+      mockResolveForAsset.mockResolvedValue([
+        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
+        createResolvedCommand({ id: "s1", name: "Set Status Doing", category: "status" }),
+      ]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const result = await builder.buildCategoryGroups(createContext());
+
+      expect(result.map((g) => g.id)).toEqual([
+        "dynamic-commands-creation",
+        "dynamic-commands-status",
+      ]);
+      expect(result.find((g) => g.id === "dynamic-commands-maintenance")).toBeUndefined();
+    });
+
+    it("should drop categories where preconditions filter out every command", async () => {
+      mockResolveForAsset.mockResolvedValue([
+        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
+        createResolvedCommand({ id: "m1", name: "Rename to UID", category: "maintenance" }),
+      ]);
+      mockEvaluate
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      const result = await builder.buildCategoryGroups(createContext());
+
+      expect(result.map((g) => g.id)).toEqual(["dynamic-commands-creation"]);
+    });
+
+    it("should route commands without category into Other group at the end", async () => {
+      mockResolveForAsset.mockResolvedValue([
+        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
+        createResolvedCommand({ id: "u1", name: "Uncategorized" }),
+      ]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const result = await builder.buildCategoryGroups(createContext());
+
+      expect(result.map((g) => g.id)).toEqual([
+        "dynamic-commands-creation",
+        "dynamic-commands-other",
+      ]);
+      const other = result.find((g) => g.id === "dynamic-commands-other");
+      expect(other?.buttons.map((b) => b.label)).toEqual(["Uncategorized"]);
+    });
+
+    it("should return [] when no commands resolved", async () => {
+      mockResolveForAsset.mockResolvedValue([]);
+      const result = await builder.buildCategoryGroups(createContext());
+      expect(result).toEqual([]);
+    });
+
+    it("should return [] when resolver throws", async () => {
+      mockResolveForAsset.mockRejectedValue(new Error("boom"));
+      const result = await builder.buildCategoryGroups(createContext());
+      expect(result).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Groups dynamic command buttons by `exocmd__Command_category` in fixed order: Create → Status → Planning → Criticality → Maintenance
- Maintenance group renders collapsed-by-default (power-user repair commands)
- Adds `collapsedByDefault` flag to `ButtonGroup` + collapsible disclosure in `ActionButtonsGroup`
- Unknown categories land in trailing "Other" fallback — nothing silently dropped
- **Pure rendering change** — zero RDF schema changes, zero command deletions

## Motivation
A Task in Backlog matches ~30 commands after precondition filtering. Rendering them in one flat "Commands" block makes the panel a wall of buttons and hides what the user actually wants to do next. Option A from the UX discovery session (2026-04-13) — the smallest surgical change that gives 80% of the clarity.

## Implementation
- `ButtonGroup` gains optional `collapsedByDefault?: boolean`
- `ActionButtonsGroup` renders collapsible groups as accessible `aria-expanded` disclosure with ▶/▼ affordance (React `useState`)
- `DynamicCommandButtonGroupBuilder` exposes new `buildCategoryGroups()` that partitions visible commands by category into ButtonGroups
- `ButtonGroupsBuilder` prefers `buildCategoryGroups()` via \`instanceof\` for the dynamic builder; flat-builders still go through legacy wrapper
- 7 new unit tests on the builder + updates to existing ButtonGroupsBuilder suite (hardcoded `"dynamic-commands"` id → category-specific ids)

## Note on commit scope
Commit message uses `feat(commands-grouping):` with a hyphenated scope. This is intentional — it sanity-tests #2790's regex widening. Expected bump: **minor** → v15.93.0. If it lands as patch, the regex fix regressed.

## Test plan
- [x] Unit tests green locally (44 button-group tests)
- [x] Typecheck clean
- [ ] CI green (8 checks)
- [ ] Auto Release bumps minor → v15.93.0
- [ ] Live-verify in Obsidian after BRAT update (follow-up STEP)