### PR TITLE
feat(gtd-capture): add ribbon button for one-click fleeting-note capture

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -206,6 +206,13 @@ export default class ExocortexPlugin extends Plugin {
         this.autoRenderLayout(),
       );
 
+      // GTD Capture: one-click fleeting note to inbox.
+      // Delegates to the existing `create-fleeting-note` command so the
+      // ribbon and command palette share a single implementation.
+      this.addRibbonIcon("inbox", "Capture to inbox (fleeting note)", () => {
+        void this.commandManager.executeCommand("create-fleeting-note");
+      });
+
       this.addSettingTab(new ExocortexSettingTab(this.app, this));
 
       this.registerMarkdownCodeBlockProcessor(

--- a/packages/obsidian-plugin/src/application/services/CommandManager.ts
+++ b/packages/obsidian-plugin/src/application/services/CommandManager.ts
@@ -97,6 +97,36 @@ export class CommandManager {
     }
   }
 
+  /**
+   * Invoke a registered global command by its id.
+   *
+   * Used by surfaces like the ribbon icon that want to trigger the same flow
+   * as the command palette without duplicating handler code. Fire-and-forget:
+   * returns once the handler has been invoked, not once it has finished.
+   */
+  executeCommand(id: string): boolean {
+    if (!this.commandRegistry) return false;
+    const command = this.commandRegistry
+      .getAllCommands()
+      .find((c) => c.id === id);
+    if (!command) return false;
+
+    if (command.callback) {
+      void command.callback();
+      return true;
+    }
+
+    if (command.checkCallback) {
+      const file = this.app.workspace.getActiveFile();
+      if (!file) return false;
+      const context = this.getContext(file);
+      command.checkCallback(false, file, context);
+      return true;
+    }
+
+    return false;
+  }
+
   private getContext(file: TFile): CommandVisibilityContext | null {
     const context = this.metadataExtractor.extractCommandVisibilityContext(file);
 

--- a/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.executeCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.executeCommand.test.ts
@@ -1,0 +1,31 @@
+import {
+  setupCommandManagerTest,
+  CommandManagerTestContext,
+  CommandManager,
+} from "./CommandManager.fixtures";
+
+describe("CommandManager - executeCommand", () => {
+  let ctx: CommandManagerTestContext;
+
+  beforeEach(() => {
+    ctx = setupCommandManagerTest();
+    ctx.commandManager.registerAllCommands(ctx.mockPlugin);
+  });
+
+  it("returns true for a registered global command id", () => {
+    expect(ctx.registeredCommands.get("create-fleeting-note")).toBeDefined();
+    const result = ctx.commandManager.executeCommand("create-fleeting-note");
+    expect(result).toBe(true);
+  });
+
+  it("returns false for an unknown command id", () => {
+    const result = ctx.commandManager.executeCommand("does-not-exist");
+    expect(result).toBe(false);
+  });
+
+  it("returns false when commands have not been registered yet", () => {
+    const fresh = new CommandManager({} as never);
+    const result = fresh.executeCommand("create-fleeting-note");
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a left-sidebar ribbon icon (📥) that invokes the existing `create-fleeting-note` command, giving users a one-click path from any Obsidian view into their inbox.
- Adds `CommandManager.executeCommand(id)` so the ribbon and the command palette share a single registered implementation instead of duplicating the fleeting-note flow.
- No behavior change for existing users — the underlying command is already registered and reachable from the palette.

Part of the GTD Capture phase from the 2026-04-13 UX discovery (Part 2 Scenario 1). Discovery doc lives in `Developer/exocortex-ux-discovery-2026-04-13.md` alongside the rest of the beta-arc tail work.

## Test plan
- [x] `npx jest --config packages/obsidian-plugin/jest.config.js tests/unit/commands/manager/CommandManager.executeCommand.test.ts` — 3/3 pass
- [x] `npm test` — 539 pass / 31 skipped, no regressions
- [x] `npm run build` — typecheck + esbuild green
- [ ] CI: 8 mandatory checks