### PR TITLE
feat(fleeting-note): auto-create inbox folder if missing

### DIFF
--- a/packages/exocortex/src/services/FleetingNoteCreationService.ts
+++ b/packages/exocortex/src/services/FleetingNoteCreationService.ts
@@ -30,16 +30,26 @@ export class FleetingNoteCreationService {
     const frontmatter = this.generateFrontmatter(uid, label);
     const fileContent = MetadataHelpers.buildFileContent(frontmatter);
 
-    const filePath = `${this.vaultSettings.getDefaultInboxFolder()}/${fileName}`;
+    const inboxFolder = this.vaultSettings.getDefaultInboxFolder();
+    const filePath = `${inboxFolder}/${fileName}`;
+
+    await this.ensureFolderExists(inboxFolder);
 
     const createdFile = await this.vault.create(filePath, fileContent);
 
     return createdFile;
   }
 
+  private async ensureFolderExists(folderPath: string): Promise<void> {
+    const exists = await this.vault.exists(folderPath);
+    if (!exists) {
+      await this.vault.createFolder(folderPath);
+    }
+  }
+
   private generateFrontmatter(uid: string, label: string): Record<string, unknown> {
     const now = new Date();
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- display-only timestamp, not for SPARQL filtering
+     
     const timestamp = DateFormatter.toLocalTimestamp(now);
 
     const trimmedLabel = label.trim();

--- a/packages/exocortex/src/services/SupervisionCreationService.ts
+++ b/packages/exocortex/src/services/SupervisionCreationService.ts
@@ -23,14 +23,23 @@ export class SupervisionCreationService {
     const inboxFolder = this.vaultSettings.getDefaultInboxFolder();
     const filePath = `${inboxFolder}/${fileName}`;
 
+    await this.ensureFolderExists(inboxFolder);
+
     const createdFile = await this.vault.create(filePath, fileContent);
 
     return createdFile;
   }
 
+  private async ensureFolderExists(folderPath: string): Promise<void> {
+    const exists = await this.vault.exists(folderPath);
+    if (!exists) {
+      await this.vault.createFolder(folderPath);
+    }
+  }
+
   generateFrontmatter(uid: string): Record<string, unknown> {
     const now = new Date();
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- display-only timestamp, not for SPARQL filtering
+     
     const timestamp = DateFormatter.toLocalTimestamp(now);
 
     return {

--- a/packages/exocortex/tests/services/FleetingNoteCreationService.test.ts
+++ b/packages/exocortex/tests/services/FleetingNoteCreationService.test.ts
@@ -27,6 +27,8 @@ describe("FleetingNoteCreationService", () => {
   beforeEach(() => {
     mockVault = {
       create: jest.fn(),
+      exists: jest.fn().mockResolvedValue(true),
+      createFolder: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<IVaultAdapter>;
 
     mockVaultSettings = createMockVaultSettings();
@@ -121,5 +123,45 @@ describe("FleetingNoteCreationService", () => {
     mockVault.create.mockRejectedValue(error);
 
     await expect(service.createFleetingNote("Label")).rejects.toThrow(error);
+  });
+
+  it("skips folder creation when inbox folder already exists", async () => {
+    (mockVault.exists as jest.Mock).mockResolvedValue(true);
+    mockVault.create.mockResolvedValue({ path: "01 Inbox/test-uuid-123.md" } as IFile);
+
+    await service.createFleetingNote("Label");
+
+    expect(mockVault.exists).toHaveBeenCalledWith("01 Inbox");
+    expect(mockVault.createFolder).not.toHaveBeenCalled();
+    expect(mockVault.create).toHaveBeenCalled();
+  });
+
+  it("auto-creates inbox folder when missing before writing the note", async () => {
+    (mockVault.exists as jest.Mock).mockResolvedValue(false);
+    mockVault.create.mockResolvedValue({ path: "01 Inbox/test-uuid-123.md" } as IFile);
+
+    await service.createFleetingNote("Label");
+
+    expect(mockVault.exists).toHaveBeenCalledWith("01 Inbox");
+    expect(mockVault.createFolder).toHaveBeenCalledWith("01 Inbox");
+    expect(mockVault.create).toHaveBeenCalledWith(
+      "01 Inbox/test-uuid-123.md",
+      expect.any(String),
+    );
+
+    const existsOrder = (mockVault.exists as jest.Mock).mock.invocationCallOrder[0];
+    const createFolderOrder = (mockVault.createFolder as jest.Mock).mock.invocationCallOrder[0];
+    const createOrder = (mockVault.create as jest.Mock).mock.invocationCallOrder[0];
+    expect(existsOrder).toBeLessThan(createFolderOrder);
+    expect(createFolderOrder).toBeLessThan(createOrder);
+  });
+
+  it("propagates createFolder errors and does not attempt to write the note", async () => {
+    (mockVault.exists as jest.Mock).mockResolvedValue(false);
+    const error = new Error("createFolder failed");
+    (mockVault.createFolder as jest.Mock).mockRejectedValue(error);
+
+    await expect(service.createFleetingNote("Label")).rejects.toThrow(error);
+    expect(mockVault.create).not.toHaveBeenCalled();
   });
 });

--- a/packages/exocortex/tests/unit/services/SupervisionCreationService.test.ts
+++ b/packages/exocortex/tests/unit/services/SupervisionCreationService.test.ts
@@ -21,6 +21,8 @@ describe("SupervisionCreationService", () => {
   beforeEach(() => {
     mockVault = {
       create: jest.fn<(path: string, content: string) => Promise<IFile>>(),
+      exists: jest.fn<(path: string) => Promise<boolean>>().mockResolvedValue(true),
+      createFolder: jest.fn<(path: string) => Promise<void>>().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<IVaultAdapter>;
 
     mockVault.create.mockResolvedValue({ path: "01 Inbox/test.md", basename: "test" } as IFile);
@@ -122,6 +124,47 @@ describe("SupervisionCreationService", () => {
       expect(body).toContain("- Поведение: Test behavior");
       expect(body).toContain("- Краткосрочные последствия поведения: Short term");
       expect(body).toContain("- Долгосрочные последствия поведения: Long term");
+    });
+  });
+
+  describe("inbox folder auto-creation", () => {
+    const formData: SupervisionFormData = {
+      situation: "s",
+      emotions: "e",
+      thoughts: "t",
+      behavior: "b",
+      shortTermConsequences: "short",
+      longTermConsequences: "long",
+      desiredBehavior: "desired",
+    };
+
+    it("skips createFolder when inbox folder already exists", async () => {
+      jest.mocked(mockVault.exists).mockResolvedValue(true);
+
+      await service.createSupervision(formData);
+
+      expect(mockVault.exists).toHaveBeenCalledWith("01 Inbox");
+      expect(mockVault.createFolder).not.toHaveBeenCalled();
+      expect(mockVault.create).toHaveBeenCalled();
+    });
+
+    it("auto-creates inbox folder when missing before writing the file", async () => {
+      jest.mocked(mockVault.exists).mockResolvedValue(false);
+
+      await service.createSupervision(formData);
+
+      expect(mockVault.createFolder).toHaveBeenCalledWith("01 Inbox");
+      const createFolderOrder = (mockVault.createFolder as jest.Mock).mock.invocationCallOrder[0];
+      const createOrder = (mockVault.create as jest.Mock).mock.invocationCallOrder[0];
+      expect(createFolderOrder).toBeLessThan(createOrder);
+    });
+
+    it("propagates createFolder errors without writing the file", async () => {
+      jest.mocked(mockVault.exists).mockResolvedValue(false);
+      jest.mocked(mockVault.createFolder).mockRejectedValue(new Error("boom"));
+
+      await expect(service.createSupervision(formData)).rejects.toThrow("boom");
+      expect(mockVault.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/SupervisionCreationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SupervisionCreationService.test.ts
@@ -20,6 +20,8 @@ describe("SupervisionCreationService", () => {
   beforeEach(() => {
     mockVault = {
       create: jest.fn().mockResolvedValue({ path: "01 Inbox/test-uuid.md" }),
+      exists: jest.fn().mockResolvedValue(true),
+      createFolder: jest.fn().mockResolvedValue(undefined),
     };
     mockVaultSettings = createMockVaultSettings();
     service = new SupervisionCreationService(mockVault, mockVaultSettings);


### PR DESCRIPTION
## Summary
- Fix silent fail of `Capture to inbox` ribbon (v15.94.0) and Supervision creation on fresh vaults
- Both `FleetingNoteCreationService` and `SupervisionCreationService` now auto-create `01 Inbox/` via `vault.createFolder()` when missing
- No `IVaultAdapter` interface change — `exists()` and `createFolder()` already present

## Context
On fresh install, `vault.create("01 Inbox/<uuid>.md")` rejects when parent folder absent. Error was routed to Notice toast only, not logged — users saw modal dismiss with no file written. Discovered during live-verify 2026-04-14 (Phase 1 of beta publish gate).

Hybrid approach: plugin safety net here + starter-kit `.gitkeep` (separate PR) for discoverability.

## Test plan
- [x] `FleetingNoteCreationService.test.ts` — exists=true skip, exists=false autocreate ordered before write, createFolder error propagation
- [x] `SupervisionCreationService.test.ts` (both core and obsidian-plugin) — same three scenarios
- [x] `npm run test:unit` — 1244 passed
- [x] `npm run test:all` — unit + component pass locally; E2E runs in CI
- [ ] Fresh vault live-verify (post-merge with new release)