### PR TITLE
feat(properties): readable predicate labels via PropertiesLabelPatch

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -41,6 +41,7 @@ import { LRUCache } from "./infrastructure/cache";
 import { TabTitlePatch } from "./presentation/tab-titles/TabTitlePatch";
 import { PropertiesLinkPatch } from "./presentation/properties/PropertiesLinkPatch";
 import { PropertiesUidCopyPatch } from "./presentation/properties/PropertiesUidCopyPatch";
+import { PropertiesLabelPatch } from "./presentation/properties/PropertiesLabelPatch";
 import { BodyLinkPatch } from "./presentation/body/BodyLinkPatch";
 import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
 import { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService";
@@ -85,6 +86,7 @@ export default class ExocortexPlugin extends Plugin {
   private propertiesLinkPatch!: PropertiesLinkPatch;
   private bodyLinkPatch!: BodyLinkPatch;
   private propertiesUidCopyPatch!: PropertiesUidCopyPatch;
+  private propertiesLabelPatch!: PropertiesLabelPatch;
   private graphViewPatch!: GraphViewPatch;
   private fileLogChannel!: FileLogChannel;
   private notifier!: ObsidianNotificationService;
@@ -381,6 +383,14 @@ export default class ExocortexPlugin extends Plugin {
         this.propertiesUidCopyPatch.enable();
       }, 500);
 
+      // Initialize Properties readable-label patch (always enabled)
+      // Replaces raw predicate names (e.g. ems__Effort_area) with human-readable
+      // labels resolved from property definition assets' exo__Asset_label.
+      this.propertiesLabelPatch = new PropertiesLabelPatch(this);
+      this.timerManager.setTimeout("properties-label-patch", () => {
+        this.propertiesLabelPatch.enable();
+      }, 500);
+
       // Initialize Body link patch
       this.bodyLinkPatch = new BodyLinkPatch(this);
       if (this.settings.showLabelsInBody) {
@@ -462,6 +472,11 @@ export default class ExocortexPlugin extends Plugin {
     // Cleanup Properties UID copy button patch
     if (this.propertiesUidCopyPatch) {
       this.propertiesUidCopyPatch.cleanup();
+    }
+
+    // Cleanup Properties readable-label patch
+    if (this.propertiesLabelPatch) {
+      this.propertiesLabelPatch.cleanup();
     }
 
     // Cleanup Body link patch

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
@@ -1,0 +1,323 @@
+import { Plugin, TFile } from "obsidian";
+
+/**
+ * PropertiesLabelPatch - Patches Obsidian's Properties block to show human-readable
+ * predicate labels (e.g. "Effort Area" instead of `ems__Effort_area`) and makes
+ * them clickable to open the predicate definition asset.
+ *
+ * Resolution strategy (resolvePredicate):
+ *  1. Filename match — a file whose basename equals the raw predicate name
+ *  2. Aliases match — a file whose frontmatter `aliases` contains the raw predicate
+ *
+ * Both paths require the matched file to have a non-empty `exo__Asset_label` that
+ * differs from the raw predicate; that label is what replaces the key text. If no
+ * definition asset is found, the predicate row is left untouched (Scenario C fallback).
+ *
+ * Reading Mode only. Live Preview is explicitly out of scope for first iteration.
+ * Follows the MutationObserver + layout-change re-patch pattern established by
+ * PropertiesLinkPatch / PropertiesUidCopyPatch.
+ */
+
+const PATCHED_ATTR = "data-exo-label-patched";
+const ORIGINAL_KEY_ATTR = "data-exo-original-key";
+const CLICKABLE_CLASS = "exo-label-clickable";
+
+interface ResolvedPredicate {
+  label: string;
+  file: TFile;
+}
+
+interface PatchRecord {
+  propertyEl: HTMLElement;
+  keyEl: HTMLElement;
+  input: HTMLInputElement | null;
+  originalKey: string;
+  originalText: string | null;
+  textNode: Text | null;
+  clickHandler: (e: MouseEvent) => void;
+}
+
+export class PropertiesLabelPatch {
+  private app: Plugin["app"];
+  private plugin: Plugin;
+  private observer: MutationObserver | null = null;
+  private enabled = false;
+  private resolveCache: Map<string, ResolvedPredicate | null> = new Map();
+  private indexBuilt = false;
+  private patched: PatchRecord[] = [];
+
+  constructor(plugin: Plugin) {
+    this.plugin = plugin;
+    this.app = plugin.app;
+  }
+
+  enable(): void {
+    if (this.enabled) return;
+    this.enabled = true;
+
+    this.buildIndex();
+    this.patchAllPropertiesBlocks();
+    this.setupObserver();
+
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("changed", () => {
+        this.invalidateIndex();
+        this.patchAllPropertiesBlocks();
+      })
+    );
+
+    this.plugin.registerEvent(
+      this.app.workspace.on("layout-change", () => {
+        setTimeout(() => this.patchAllPropertiesBlocks(), 100);
+      })
+    );
+
+    this.plugin.registerEvent(
+      this.app.workspace.on("active-leaf-change", () => {
+        setTimeout(() => this.patchAllPropertiesBlocks(), 100);
+      })
+    );
+  }
+
+  disable(): void {
+    if (!this.enabled) return;
+    this.enabled = false;
+
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+
+    this.restoreAll();
+  }
+
+  cleanup(): void {
+    this.disable();
+  }
+
+  private invalidateIndex(): void {
+    this.indexBuilt = false;
+    this.resolveCache.clear();
+  }
+
+  private buildIndex(): void {
+    if (this.indexBuilt) return;
+    this.resolveCache.clear();
+
+    let files: TFile[] = [];
+    if (typeof this.app.vault.getMarkdownFiles === "function") {
+      const result = this.app.vault.getMarkdownFiles();
+      if (Array.isArray(result)) {
+        files = result;
+      }
+    }
+
+    for (const file of files) {
+      const cache = this.app.metadataCache.getFileCache(file);
+      const fm = cache?.frontmatter;
+      if (!fm) continue;
+
+      const rawLabel = fm["exo__Asset_label"];
+      if (typeof rawLabel !== "string") continue;
+      const label = rawLabel.trim();
+      if (!label) continue;
+
+      const keys = new Set<string>();
+      keys.add(file.basename);
+      const aliases = fm["aliases"];
+      if (Array.isArray(aliases)) {
+        for (const a of aliases) {
+          if (typeof a === "string" && a.trim().length > 0) {
+            keys.add(a.trim());
+          }
+        }
+      }
+
+      for (const key of keys) {
+        if (key === label) continue;
+        if (!this.resolveCache.has(key)) {
+          this.resolveCache.set(key, { label, file });
+        }
+      }
+    }
+
+    this.indexBuilt = true;
+  }
+
+  private resolvePredicate(predicate: string): ResolvedPredicate | null {
+    if (!this.indexBuilt) this.buildIndex();
+    const cached = this.resolveCache.get(predicate);
+    return cached ?? null;
+  }
+
+  private patchAllPropertiesBlocks(): void {
+    if (!this.enabled) return;
+
+    if (typeof this.app.workspace.getLeavesOfType === "function") {
+      const leaves = this.app.workspace.getLeavesOfType("markdown");
+      if (Array.isArray(leaves)) {
+        for (const leaf of leaves) {
+          const container = leaf.view.containerEl;
+          this.patchPropertiesBlock(container);
+        }
+      }
+    }
+  }
+
+  private patchPropertiesBlock(container: HTMLElement): void {
+    const metadataContainer = container.querySelector<HTMLElement>(".metadata-container");
+    if (!metadataContainer) return;
+
+    const properties = metadataContainer.querySelectorAll<HTMLElement>(".metadata-property");
+    for (const prop of Array.from(properties)) {
+      this.patchProperty(prop);
+    }
+  }
+
+  private patchProperty(propertyEl: HTMLElement): void {
+    if (propertyEl.getAttribute(PATCHED_ATTR) === "true") return;
+
+    const predicate = this.extractPredicate(propertyEl);
+    if (!predicate) return;
+
+    const resolved = this.resolvePredicate(predicate);
+    if (!resolved) return;
+
+    const keyEl = propertyEl.querySelector<HTMLElement>(".metadata-property-key");
+    if (!keyEl) return;
+
+    const input = keyEl.querySelector<HTMLInputElement>("input");
+    let originalText: string | null = null;
+    let textNode: Text | null = null;
+
+    if (input) {
+      input.setAttribute(ORIGINAL_KEY_ATTR, input.value);
+      input.value = resolved.label;
+    } else {
+      textNode = this.findPredicateTextNode(keyEl, predicate);
+      if (textNode) {
+        originalText = textNode.textContent ?? null;
+        textNode.textContent = resolved.label;
+      } else {
+        // Nothing to replace — skip patch to avoid corrupting DOM
+        return;
+      }
+    }
+
+    const clickHandler = (e: MouseEvent): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.openDefinition(resolved.file);
+    };
+    keyEl.addEventListener("click", clickHandler);
+    keyEl.classList.add(CLICKABLE_CLASS);
+    keyEl.setAttribute(
+      "aria-label",
+      `Open definition: ${resolved.label} (${predicate})`
+    );
+
+    propertyEl.setAttribute(PATCHED_ATTR, "true");
+    this.patched.push({
+      propertyEl,
+      keyEl,
+      input,
+      originalKey: predicate,
+      originalText,
+      textNode,
+      clickHandler,
+    });
+  }
+
+  private extractPredicate(propertyEl: HTMLElement): string | null {
+    const attr = propertyEl.getAttribute("data-property-key");
+    if (attr && attr.trim().length > 0) return attr.trim();
+
+    const keyEl = propertyEl.querySelector<HTMLElement>(".metadata-property-key");
+    if (!keyEl) return null;
+
+    const input = keyEl.querySelector<HTMLInputElement>("input");
+    if (input?.value?.trim()) {
+      const val = input.value.trim();
+      return val.length > 0 ? val : null;
+    }
+
+    const text = (keyEl.textContent || "").trim().replace(/\u200B/g, "");
+    return text.length > 0 ? text : null;
+  }
+
+  private findPredicateTextNode(keyEl: HTMLElement, predicate: string): Text | null {
+    const walker = document.createTreeWalker(keyEl, NodeFilter.SHOW_TEXT, null);
+    let node: Node | null = walker.nextNode();
+    while (node) {
+      const text = (node.textContent || "").trim().replace(/\u200B/g, "");
+      if (text === predicate) return node as Text;
+      node = walker.nextNode();
+    }
+    return null;
+  }
+
+  private openDefinition(file: TFile): void {
+    const leaf = this.app.workspace.getLeaf("tab");
+    if (leaf && typeof (leaf as { openFile?: (f: TFile) => Promise<void> }).openFile === "function") {
+      void (leaf as { openFile: (f: TFile) => Promise<void> }).openFile(file);
+    }
+  }
+
+  private setupObserver(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+
+    this.observer = new MutationObserver((mutations) => {
+      if (!this.enabled) return;
+
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (!(node instanceof HTMLElement)) continue;
+
+          if (node.classList?.contains("metadata-container")) {
+            this.patchPropertiesBlock(node.parentElement || node);
+          } else if (node.querySelector?.(".metadata-container")) {
+            this.patchPropertiesBlock(node);
+          } else if (node.classList?.contains("metadata-property")) {
+            this.patchProperty(node);
+          } else {
+            const mc = node.querySelector?.(".metadata-container") as HTMLElement | null;
+            if (mc) {
+              const props = mc.querySelectorAll<HTMLElement>(".metadata-property");
+              for (const prop of Array.from(props)) {
+                this.patchProperty(prop);
+              }
+            }
+          }
+        }
+      }
+    });
+
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  private restoreAll(): void {
+    for (const record of this.patched) {
+      try {
+        if (record.input) {
+          const original = record.input.getAttribute(ORIGINAL_KEY_ATTR) ?? record.originalKey;
+          record.input.value = original;
+          record.input.removeAttribute(ORIGINAL_KEY_ATTR);
+        } else if (record.textNode && record.originalText !== null) {
+          record.textNode.textContent = record.originalText;
+        }
+        record.keyEl.removeEventListener("click", record.clickHandler);
+        record.keyEl.classList.remove(CLICKABLE_CLASS);
+        record.keyEl.removeAttribute("aria-label");
+        record.propertyEl.removeAttribute(PATCHED_ATTR);
+      } catch {
+        // Best-effort restore; ignore individual failures
+      }
+    }
+    this.patched = [];
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
@@ -1,0 +1,411 @@
+import { PropertiesLabelPatch } from "../../../../src/presentation/properties/PropertiesLabelPatch";
+
+jest.mock("obsidian", () => ({
+  Plugin: class {},
+  TFile: class {},
+  Notice: jest.fn(),
+}));
+
+interface FakeFile {
+  path: string;
+  basename: string;
+  extension: string;
+}
+
+interface FakeLeaf {
+  openFile: jest.Mock;
+}
+
+describe("PropertiesLabelPatch", () => {
+  let patch: PropertiesLabelPatch;
+  let mockPlugin: any;
+  let mockApp: any;
+  let mockContainer: HTMLElement;
+  let mockMetadataContainer: HTMLElement;
+  let mockWorkspaceLeaf: any;
+  let openedFiles: FakeFile[];
+  let openFileMock: jest.Mock;
+
+  const FILE_EFFORT_AREA: FakeFile = {
+    path: "exo/properties/ems__Effort_area.md",
+    basename: "ems__Effort_area",
+    extension: "md",
+  };
+  const FILE_EFFORT_STATUS: FakeFile = {
+    path: "exo/properties/ems__Effort_status.md",
+    basename: "ems__Effort_status",
+    extension: "md",
+  };
+  const FILE_ASSET_LABEL: FakeFile = {
+    path: "exo/properties/exo__Asset_label.md",
+    basename: "exo__Asset_label",
+    extension: "md",
+  };
+
+  const FRONTMATTERS: Record<string, any> = {
+    [FILE_EFFORT_AREA.path]: {
+      exo__Asset_label: "Effort Area",
+      aliases: ["ems__Effort_area"],
+      exo__Instance_class: "[[exo__ObjectProperty]]",
+    },
+    [FILE_EFFORT_STATUS.path]: {
+      exo__Asset_label: "Effort Status",
+      aliases: ["ems__Effort_status"],
+      exo__Instance_class: "[[exo__ObjectProperty]]",
+    },
+    [FILE_ASSET_LABEL.path]: {
+      exo__Asset_label: "Label",
+      aliases: ["exo__Asset_label"],
+      exo__Instance_class: "[[exo__StringProperty]]",
+    },
+  };
+
+  function createPropertyRow(key: string, valueText: string): HTMLElement {
+    const propertyEl = document.createElement("div");
+    propertyEl.className = "metadata-property";
+    propertyEl.setAttribute("data-property-key", key);
+
+    const keyEl = document.createElement("div");
+    keyEl.className = "metadata-property-key";
+    const keyInput = document.createElement("input");
+    keyInput.type = "text";
+    keyInput.value = key;
+    keyEl.appendChild(keyInput);
+    propertyEl.appendChild(keyEl);
+
+    const valueEl = document.createElement("div");
+    valueEl.className = "metadata-property-value";
+    valueEl.textContent = valueText;
+    propertyEl.appendChild(valueEl);
+
+    return propertyEl;
+  }
+
+  function createPropertyRowTextKey(key: string, valueText: string): HTMLElement {
+    const propertyEl = document.createElement("div");
+    propertyEl.className = "metadata-property";
+
+    const keyEl = document.createElement("div");
+    keyEl.className = "metadata-property-key";
+    keyEl.textContent = key;
+    propertyEl.appendChild(keyEl);
+
+    const valueEl = document.createElement("div");
+    valueEl.className = "metadata-property-value";
+    valueEl.textContent = valueText;
+    propertyEl.appendChild(valueEl);
+
+    return propertyEl;
+  }
+
+  beforeEach(() => {
+    openedFiles = [];
+    openFileMock = jest.fn().mockImplementation((file: FakeFile) => {
+      openedFiles.push(file);
+      return Promise.resolve();
+    });
+
+    mockMetadataContainer = document.createElement("div");
+    mockMetadataContainer.className = "metadata-container";
+
+    mockContainer = document.createElement("div");
+    mockContainer.appendChild(mockMetadataContainer);
+    document.body.appendChild(mockContainer);
+
+    mockWorkspaceLeaf = {
+      view: { containerEl: mockContainer },
+    };
+
+    const fakeLeaf: FakeLeaf = { openFile: openFileMock };
+
+    mockApp = {
+      workspace: {
+        getLeavesOfType: jest.fn().mockReturnValue([mockWorkspaceLeaf]),
+        getLeaf: jest.fn().mockReturnValue(fakeLeaf),
+        on: jest.fn().mockReturnValue({ id: "test" }),
+      },
+      metadataCache: {
+        on: jest.fn().mockReturnValue({ id: "test" }),
+        getFileCache: jest.fn().mockImplementation((file: FakeFile) => {
+          const fm = FRONTMATTERS[file.path];
+          return fm ? { frontmatter: fm } : null;
+        }),
+      },
+      vault: {
+        getMarkdownFiles: jest
+          .fn()
+          .mockReturnValue([FILE_EFFORT_AREA, FILE_EFFORT_STATUS, FILE_ASSET_LABEL]),
+      },
+    };
+
+    mockPlugin = {
+      app: mockApp,
+      registerEvent: jest.fn(),
+    };
+
+    patch = new PropertiesLabelPatch(mockPlugin);
+  });
+
+  afterEach(() => {
+    patch.cleanup();
+    jest.clearAllMocks();
+    if (mockContainer.parentNode) {
+      mockContainer.parentNode.removeChild(mockContainer);
+    }
+  });
+
+  describe("enable", () => {
+    it("registers layout-change, active-leaf-change, metadataCache changed events", () => {
+      patch.enable();
+
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        "layout-change",
+        expect.any(Function)
+      );
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        "active-leaf-change",
+        expect.any(Function)
+      );
+      expect(mockApp.metadataCache.on).toHaveBeenCalledWith(
+        "changed",
+        expect.any(Function)
+      );
+    });
+
+    it("is idempotent (double-enable registers events only once)", () => {
+      patch.enable();
+      const callCount = mockPlugin.registerEvent.mock.calls.length;
+      patch.enable();
+      expect(mockPlugin.registerEvent).toHaveBeenCalledTimes(callCount);
+    });
+  });
+
+  describe("Scenario A: known predicates get readable labels", () => {
+    it("replaces raw predicate with readable label for ems__Effort_area", () => {
+      const row = createPropertyRow("ems__Effort_area", "Development");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const input = row.querySelector<HTMLInputElement>(
+        ".metadata-property-key input"
+      )!;
+      expect(input.value).toBe("Effort Area");
+      expect(input.getAttribute("data-exo-original-key")).toBe("ems__Effort_area");
+    });
+
+    it("replaces raw predicate for ems__Effort_status", () => {
+      const row = createPropertyRow("ems__Effort_status", "Doing");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const input = row.querySelector<HTMLInputElement>(
+        ".metadata-property-key input"
+      )!;
+      expect(input.value).toBe("Effort Status");
+    });
+
+    it("replaces raw predicate for exo__Asset_label", () => {
+      const row = createPropertyRow("exo__Asset_label", "Build API");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const input = row.querySelector<HTMLInputElement>(
+        ".metadata-property-key input"
+      )!;
+      expect(input.value).toBe("Label");
+    });
+
+    it("adds clickable affordance (class + aria-label) to the key element", () => {
+      const row = createPropertyRow("ems__Effort_area", "Development");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
+      expect(keyEl.classList.contains("exo-label-clickable")).toBe(true);
+      expect(keyEl.getAttribute("aria-label")).toContain("Effort Area");
+      expect(keyEl.getAttribute("aria-label")).toContain("ems__Effort_area");
+    });
+
+    it("marks the property row as patched to avoid double-patching", () => {
+      const row = createPropertyRow("ems__Effort_area", "Development");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+      const input = row.querySelector<HTMLInputElement>(
+        ".metadata-property-key input"
+      )!;
+      expect(input.value).toBe("Effort Area");
+
+      // Invoke layout-change callback to re-run patchAll
+      const layoutCb = mockApp.workspace.on.mock.calls.find(
+        (c: any[]) => c[0] === "layout-change"
+      )?.[1];
+      if (layoutCb) layoutCb();
+
+      // Still "Effort Area", not "Effort Area" → (label of "Effort Area")
+      expect(input.value).toBe("Effort Area");
+    });
+
+    it("patches property row that uses text content instead of input for key", () => {
+      const row = createPropertyRowTextKey("ems__Effort_area", "Development");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
+      expect(keyEl.textContent).toBe("Effort Area");
+      expect(keyEl.classList.contains("exo-label-clickable")).toBe(true);
+    });
+  });
+
+  describe("Scenario B: clicking readable label opens definition", () => {
+    it("click on patched key element calls openFile for the definition asset", () => {
+      const row = createPropertyRow("ems__Effort_status", "Doing");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
+      keyEl.click();
+
+      expect(mockApp.workspace.getLeaf).toHaveBeenCalledWith("tab");
+      expect(openFileMock).toHaveBeenCalledTimes(1);
+      expect(openedFiles[0]).toBe(FILE_EFFORT_STATUS);
+    });
+  });
+
+  describe("Scenario C: unknown predicate fallback", () => {
+    it("does NOT modify input value for predicate with no definition asset", () => {
+      const row = createPropertyRow("vendor__Custom_field", "whatever");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const input = row.querySelector<HTMLInputElement>(
+        ".metadata-property-key input"
+      )!;
+      expect(input.value).toBe("vendor__Custom_field");
+      expect(input.getAttribute("data-exo-original-key")).toBeNull();
+    });
+
+    it("does NOT attach clickable class for unknown predicate", () => {
+      const row = createPropertyRow("vendor__Custom_field", "whatever");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
+      expect(keyEl.classList.contains("exo-label-clickable")).toBe(false);
+    });
+
+    it("does NOT emit errors when only unknown predicates are present", () => {
+      const row = createPropertyRow("vendor__Custom_field", "whatever");
+      mockMetadataContainer.appendChild(row);
+
+      const errSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      expect(() => patch.enable()).not.toThrow();
+      expect(errSpy).not.toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+  });
+
+  describe("disable / cleanup", () => {
+    it("restores original input.value on disable", () => {
+      const row = createPropertyRow("ems__Effort_area", "Development");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+      const input = row.querySelector<HTMLInputElement>(
+        ".metadata-property-key input"
+      )!;
+      expect(input.value).toBe("Effort Area");
+
+      patch.disable();
+
+      expect(input.value).toBe("ems__Effort_area");
+      expect(input.getAttribute("data-exo-original-key")).toBeNull();
+    });
+
+    it("restores original text content on disable when no input is present", () => {
+      const row = createPropertyRowTextKey("ems__Effort_area", "Development");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
+      expect(keyEl.textContent).toBe("Effort Area");
+
+      patch.disable();
+
+      expect(keyEl.textContent).toBe("ems__Effort_area");
+    });
+
+    it("removes clickable class and aria-label on disable", () => {
+      const row = createPropertyRow("ems__Effort_area", "Development");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
+      expect(keyEl.classList.contains("exo-label-clickable")).toBe(true);
+
+      patch.disable();
+      expect(keyEl.classList.contains("exo-label-clickable")).toBe(false);
+      expect(keyEl.getAttribute("aria-label")).toBeNull();
+    });
+
+    it("click handler no longer fires after disable", () => {
+      const row = createPropertyRow("ems__Effort_status", "Doing");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+      patch.disable();
+
+      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
+      keyEl.click();
+      expect(openFileMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dynamic DOM (MutationObserver)", () => {
+    it("patches a property row that is added after enable()", async () => {
+      patch.enable();
+
+      const row = createPropertyRow("ems__Effort_area", "Development");
+      mockMetadataContainer.appendChild(row);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const input = row.querySelector<HTMLInputElement>(
+        ".metadata-property-key input"
+      )!;
+      expect(input.value).toBe("Effort Area");
+    });
+  });
+
+  describe("index invalidation", () => {
+    it("re-patches on metadataCache changed event", () => {
+      const row = createPropertyRow("ems__Effort_area", "Development");
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+      const input = row.querySelector<HTMLInputElement>(
+        ".metadata-property-key input"
+      )!;
+      expect(input.value).toBe("Effort Area");
+
+      const changedCb = mockApp.metadataCache.on.mock.calls.find(
+        (c: any[]) => c[0] === "changed"
+      )?.[1];
+      expect(typeof changedCb).toBe("function");
+
+      // Fire the callback — index should rebuild, existing patched rows remain
+      changedCb();
+
+      // Still patched (idempotent on patched rows)
+      expect(input.value).toBe("Effort Area");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `PropertiesLabelPatch` — a new DOM patch that replaces raw predicate names in Obsidian's native Properties block (e.g. `ems__Effort_area`) with human-readable labels (`Effort Area`) resolved from property definition assets' `exo__Asset_label`. Clicking a patched label opens the definition asset in a new leaf.

Phase 3 of beta-readiness — ships the plugin half of kitelev/exocortex-starter-kit#27 together with the test-coverage acceptance gate #2793.

## How it works

1. On `enable()`, walks `vault.getMarkdownFiles()` once and builds a reverse index `basename|alias → {label, file}` from any file that has a non-empty `exo__Asset_label`.
2. Iterates each `.metadata-property` in every open markdown view's `.metadata-container`, resolves its `data-property-key` (or falls back to key input / text content) against the index.
3. For a hit, replaces the key's display text with the resolved label, attaches a click handler that `workspace.getLeaf("tab").openFile(...)` on the definition asset, and marks the row patched so re-patches are idempotent.
4. Unknown predicates are left untouched — Scenario C of the journey.
5. A `MutationObserver` on `document.body` catches dynamically-added metadata rows; layout / active-leaf / metadataCache `changed` events trigger re-patches; metadata changes also invalidate the index.
6. `disable()` restores every patched row (input value, text content, click handler, aria-label, clickable class).

Pattern parallels existing `PropertiesLinkPatch` and `PropertiesUidCopyPatch`; wired into `ExocortexPlugin.onload()` with the same `timerManager.setTimeout(..., 500)` delay and cleaned up in `onunload()`.

## Test plan

- [x] 18 new unit tests in `tests/unit/presentation/properties/PropertiesLabelPatch.test.ts`:
  - Scenario A (3 predicates × readable label replacement, clickable affordance, patched flag, text-content fallback)
  - Scenario B (click → `openFile` called with the correct `TFile`)
  - Scenario C (unknown predicate → unchanged input value, no click class, no console errors)
  - `disable()` / `cleanup()` restoration (input, text content, click handler, class, aria-label)
  - MutationObserver picks up dynamically-added rows
  - metadataCache `changed` callback invalidates index without breaking existing patches
- [x] Full `npm run test:all` green locally (4517 unit tests passed, 539 component tests passed). E2E runs in CI only.
- [x] archgate / BDD coverage checks green.

## Closes

- Closes #2793 (test coverage acceptance gate)
- Refs kitelev/exocortex-starter-kit#27 (feature requirement + starter-kit property defs in companion PR)

## Non-goals for this PR

- Live Preview support (first iteration is Reading Mode only; documented in issue #27)
- Shipping property definition assets — that is the starter-kit PR
- i18n / translated labels