### PR TITLE
fix(properties): span overlay — avoid frontmatter key mutation

### DIFF
--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
@@ -19,7 +19,8 @@ import { Plugin, TFile } from "obsidian";
  */
 
 const PATCHED_ATTR = "data-exo-label-patched";
-const ORIGINAL_KEY_ATTR = "data-exo-original-key";
+const DISPLAY_SPAN_CLASS = "exo-label-display";
+const HIDDEN_INPUT_CLASS = "exo-label-hidden-input";
 const CLICKABLE_CLASS = "exo-label-clickable";
 
 interface ResolvedPredicate {
@@ -31,9 +32,9 @@ interface PatchRecord {
   propertyEl: HTMLElement;
   keyEl: HTMLElement;
   input: HTMLInputElement | null;
-  originalKey: string;
-  originalText: string | null;
+  displaySpan: HTMLSpanElement;
   textNode: Text | null;
+  originalTextContent: string | null;
   clickHandler: (e: MouseEvent) => void;
 }
 
@@ -186,21 +187,41 @@ export class PropertiesLabelPatch {
     const keyEl = propertyEl.querySelector<HTMLElement>(".metadata-property-key");
     if (!keyEl) return;
 
+    // CRITICAL: we MUST NOT mutate `input.value`. Obsidian's native Properties
+    // block treats the input as the canonical frontmatter-key editor — writing
+    // to `input.value` and then clicking on the field persists the new value as
+    // a rename of the frontmatter key, which corrupts the asset. Instead we
+    // keep the original input intact, hide it, and insert a sibling span that
+    // displays the readable label and owns the click handler.
     const input = keyEl.querySelector<HTMLInputElement>("input");
-    let originalText: string | null = null;
+    const displaySpan = document.createElement("span");
+    displaySpan.className = `${DISPLAY_SPAN_CLASS} ${CLICKABLE_CLASS}`;
+    displaySpan.textContent = resolved.label;
+    displaySpan.setAttribute("role", "link");
+    displaySpan.setAttribute("tabindex", "0");
+    displaySpan.setAttribute(
+      "aria-label",
+      `Open definition: ${resolved.label} (${predicate})`
+    );
+    displaySpan.setAttribute("data-exo-predicate", predicate);
+
     let textNode: Text | null = null;
+    let originalTextContent: string | null = null;
 
     if (input) {
-      input.setAttribute(ORIGINAL_KEY_ATTR, input.value);
-      input.value = resolved.label;
+      input.classList.add(HIDDEN_INPUT_CLASS);
+      input.parentNode?.insertBefore(displaySpan, input);
     } else {
       textNode = this.findPredicateTextNode(keyEl, predicate);
       if (textNode) {
-        originalText = textNode.textContent ?? null;
-        textNode.textContent = resolved.label;
+        originalTextContent = textNode.textContent ?? null;
+        textNode.textContent = "";
+        textNode.parentNode?.insertBefore(displaySpan, textNode.nextSibling);
       } else {
-        // Nothing to replace — skip patch to avoid corrupting DOM
-        return;
+        // Nothing recognizable to replace — append the display span as a
+        // best-effort fallback (the key DOM is non-standard), so the user
+        // still sees the readable label and click target.
+        keyEl.appendChild(displaySpan);
       }
     }
 
@@ -209,40 +230,40 @@ export class PropertiesLabelPatch {
       e.stopPropagation();
       this.openDefinition(resolved.file);
     };
-    keyEl.addEventListener("click", clickHandler);
-    keyEl.classList.add(CLICKABLE_CLASS);
-    keyEl.setAttribute(
-      "aria-label",
-      `Open definition: ${resolved.label} (${predicate})`
-    );
+    displaySpan.addEventListener("click", clickHandler);
 
+    keyEl.classList.add(CLICKABLE_CLASS);
     propertyEl.setAttribute(PATCHED_ATTR, "true");
     this.patched.push({
       propertyEl,
       keyEl,
       input,
-      originalKey: predicate,
-      originalText,
+      displaySpan,
       textNode,
+      originalTextContent,
       clickHandler,
     });
   }
 
   private extractPredicate(propertyEl: HTMLElement): string | null {
+    // Obsidian's `data-property-key` attribute is lowercased (e.g. `exo__asset_uid`),
+    // but the index is keyed on the original-case predicate from frontmatter
+    // (e.g. `exo__Asset_uid`). The `<input>` inside `.metadata-property-key` holds
+    // the original-case value, so always prefer it when present.
+    const keyEl = propertyEl.querySelector<HTMLElement>(".metadata-property-key");
+    if (keyEl) {
+      const input = keyEl.querySelector<HTMLInputElement>("input");
+      if (input?.value?.trim()) {
+        return input.value.trim();
+      }
+      const text = (keyEl.textContent || "").trim().replace(/\u200B/g, "");
+      if (text.length > 0) return text;
+    }
+
     const attr = propertyEl.getAttribute("data-property-key");
     if (attr && attr.trim().length > 0) return attr.trim();
 
-    const keyEl = propertyEl.querySelector<HTMLElement>(".metadata-property-key");
-    if (!keyEl) return null;
-
-    const input = keyEl.querySelector<HTMLInputElement>("input");
-    if (input?.value?.trim()) {
-      const val = input.value.trim();
-      return val.length > 0 ? val : null;
-    }
-
-    const text = (keyEl.textContent || "").trim().replace(/\u200B/g, "");
-    return text.length > 0 ? text : null;
+    return null;
   }
 
   private findPredicateTextNode(keyEl: HTMLElement, predicate: string): Text | null {
@@ -303,16 +324,16 @@ export class PropertiesLabelPatch {
   private restoreAll(): void {
     for (const record of this.patched) {
       try {
+        record.displaySpan.removeEventListener("click", record.clickHandler);
+        record.displaySpan.remove();
+
         if (record.input) {
-          const original = record.input.getAttribute(ORIGINAL_KEY_ATTR) ?? record.originalKey;
-          record.input.value = original;
-          record.input.removeAttribute(ORIGINAL_KEY_ATTR);
-        } else if (record.textNode && record.originalText !== null) {
-          record.textNode.textContent = record.originalText;
+          record.input.classList.remove(HIDDEN_INPUT_CLASS);
+        } else if (record.textNode && record.originalTextContent !== null) {
+          record.textNode.textContent = record.originalTextContent;
         }
-        record.keyEl.removeEventListener("click", record.clickHandler);
+
         record.keyEl.classList.remove(CLICKABLE_CLASS);
-        record.keyEl.removeAttribute("aria-label");
         record.propertyEl.removeAttribute(PATCHED_ATTR);
       } catch {
         // Best-effort restore; ignore individual failures

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -5946,3 +5946,17 @@
   font-size: 0.7em;
   color: var(--text-faint);
 }
+
+/* PropertiesLabelPatch — span overlay + hidden input */
+.metadata-property-key input.exo-label-hidden-input {
+  display: none !important;
+}
+
+.metadata-property-key .exo-label-display {
+  cursor: pointer;
+  color: var(--text-accent);
+}
+
+.metadata-property-key .exo-label-display:hover {
+  text-decoration: underline;
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
@@ -27,18 +27,23 @@ describe("PropertiesLabelPatch", () => {
   let openFileMock: jest.Mock;
 
   const FILE_EFFORT_AREA: FakeFile = {
-    path: "exo/properties/ems__Effort_area.md",
-    basename: "ems__Effort_area",
+    path: "ems/ab1b5cc2.md",
+    basename: "ab1b5cc2",
     extension: "md",
   };
   const FILE_EFFORT_STATUS: FakeFile = {
-    path: "exo/properties/ems__Effort_status.md",
-    basename: "ems__Effort_status",
+    path: "ems/64594641.md",
+    basename: "64594641",
     extension: "md",
   };
   const FILE_ASSET_LABEL: FakeFile = {
-    path: "exo/properties/exo__Asset_label.md",
-    basename: "exo__Asset_label",
+    path: "exo/3d1e4212.md",
+    basename: "3d1e4212",
+    extension: "md",
+  };
+  const FILE_EFFORT_AREA_FALLBACK: FakeFile = {
+    path: "exo/properties/ems__Effort_area.md",
+    basename: "ems__Effort_area",
     extension: "md",
   };
 
@@ -46,42 +51,46 @@ describe("PropertiesLabelPatch", () => {
     [FILE_EFFORT_AREA.path]: {
       exo__Asset_label: "Effort Area",
       aliases: ["ems__Effort_area"],
-      exo__Instance_class: "[[exo__ObjectProperty]]",
     },
     [FILE_EFFORT_STATUS.path]: {
       exo__Asset_label: "Effort Status",
       aliases: ["ems__Effort_status"],
-      exo__Instance_class: "[[exo__ObjectProperty]]",
     },
     [FILE_ASSET_LABEL.path]: {
       exo__Asset_label: "Label",
       aliases: ["exo__Asset_label"],
-      exo__Instance_class: "[[exo__StringProperty]]",
+    },
+    [FILE_EFFORT_AREA_FALLBACK.path]: {
+      exo__Asset_label: "Effort Area Fallback",
     },
   };
 
-  function createPropertyRow(key: string, valueText: string): HTMLElement {
+  function createPropertyRow(options: {
+    lowercaseAttr?: boolean;
+    inputValue: string;
+  }): HTMLElement {
+    const { lowercaseAttr = true, inputValue } = options;
     const propertyEl = document.createElement("div");
     propertyEl.className = "metadata-property";
-    propertyEl.setAttribute("data-property-key", key);
+    const attrValue = lowercaseAttr ? inputValue.toLowerCase() : inputValue;
+    propertyEl.setAttribute("data-property-key", attrValue);
 
     const keyEl = document.createElement("div");
     keyEl.className = "metadata-property-key";
     const keyInput = document.createElement("input");
     keyInput.type = "text";
-    keyInput.value = key;
+    keyInput.value = inputValue;
     keyEl.appendChild(keyInput);
     propertyEl.appendChild(keyEl);
 
     const valueEl = document.createElement("div");
     valueEl.className = "metadata-property-value";
-    valueEl.textContent = valueText;
     propertyEl.appendChild(valueEl);
 
     return propertyEl;
   }
 
-  function createPropertyRowTextKey(key: string, valueText: string): HTMLElement {
+  function createPropertyRowTextKey(key: string): HTMLElement {
     const propertyEl = document.createElement("div");
     propertyEl.className = "metadata-property";
 
@@ -92,7 +101,6 @@ describe("PropertiesLabelPatch", () => {
 
     const valueEl = document.createElement("div");
     valueEl.className = "metadata-property-value";
-    valueEl.textContent = valueText;
     propertyEl.appendChild(valueEl);
 
     return propertyEl;
@@ -134,7 +142,12 @@ describe("PropertiesLabelPatch", () => {
       vault: {
         getMarkdownFiles: jest
           .fn()
-          .mockReturnValue([FILE_EFFORT_AREA, FILE_EFFORT_STATUS, FILE_ASSET_LABEL]),
+          .mockReturnValue([
+            FILE_EFFORT_AREA,
+            FILE_EFFORT_STATUS,
+            FILE_ASSET_LABEL,
+            FILE_EFFORT_AREA_FALLBACK,
+          ]),
       },
     };
 
@@ -180,9 +193,9 @@ describe("PropertiesLabelPatch", () => {
     });
   });
 
-  describe("Scenario A: known predicates get readable labels", () => {
-    it("replaces raw predicate with readable label for ems__Effort_area", () => {
-      const row = createPropertyRow("ems__Effort_area", "Development");
+  describe("Scenario A: known predicates get readable labels via span overlay", () => {
+    it("inserts a display span with the readable label while leaving input.value UNCHANGED", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_area" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
@@ -190,55 +203,72 @@ describe("PropertiesLabelPatch", () => {
       const input = row.querySelector<HTMLInputElement>(
         ".metadata-property-key input"
       )!;
-      expect(input.value).toBe("Effort Area");
-      expect(input.getAttribute("data-exo-original-key")).toBe("ems__Effort_area");
+      // CRITICAL regression guard: input.value MUST stay as the raw predicate.
+      // Mutating input.value causes Obsidian to persist a rename of the
+      // frontmatter key, which corrupts the asset (observed live 2026-04-14).
+      expect(input.value).toBe("ems__Effort_area");
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      expect(span).toBeTruthy();
+      expect(span.textContent).toBe("Effort Area");
+      expect(input.classList.contains("exo-label-hidden-input")).toBe(true);
     });
 
-    it("replaces raw predicate for ems__Effort_status", () => {
-      const row = createPropertyRow("ems__Effort_status", "Doing");
+    it("resolves original-case predicate from input.value when data-property-key is lowercased", () => {
+      // Regression guard: Obsidian lowercases data-property-key
+      // (e.g. `ems__effort_area`), but input.value holds original case.
+      const row = createPropertyRow({
+        inputValue: "ems__Effort_area",
+        lowercaseAttr: true,
+      });
+      expect(row.getAttribute("data-property-key")).toBe("ems__effort_area");
+
+      mockMetadataContainer.appendChild(row);
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      expect(span.textContent).toBe("Effort Area");
+    });
+
+    it("replaces all 3 canonical predicates independently", () => {
+      const rowStatus = createPropertyRow({ inputValue: "ems__Effort_status" });
+      const rowArea = createPropertyRow({ inputValue: "ems__Effort_area" });
+      const rowLabel = createPropertyRow({ inputValue: "exo__Asset_label" });
+      mockMetadataContainer.appendChild(rowStatus);
+      mockMetadataContainer.appendChild(rowArea);
+      mockMetadataContainer.appendChild(rowLabel);
+
+      patch.enable();
+
+      expect(
+        rowStatus.querySelector<HTMLSpanElement>(".exo-label-display")?.textContent
+      ).toBe("Effort Status");
+      expect(
+        rowArea.querySelector<HTMLSpanElement>(".exo-label-display")?.textContent
+      ).toBe("Effort Area");
+      expect(
+        rowLabel.querySelector<HTMLSpanElement>(".exo-label-display")?.textContent
+      ).toBe("Label");
+    });
+
+    it("adds aria-label and role=link affordance for accessibility", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_area" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
 
-      const input = row.querySelector<HTMLInputElement>(
-        ".metadata-property-key input"
-      )!;
-      expect(input.value).toBe("Effort Status");
-    });
-
-    it("replaces raw predicate for exo__Asset_label", () => {
-      const row = createPropertyRow("exo__Asset_label", "Build API");
-      mockMetadataContainer.appendChild(row);
-
-      patch.enable();
-
-      const input = row.querySelector<HTMLInputElement>(
-        ".metadata-property-key input"
-      )!;
-      expect(input.value).toBe("Label");
-    });
-
-    it("adds clickable affordance (class + aria-label) to the key element", () => {
-      const row = createPropertyRow("ems__Effort_area", "Development");
-      mockMetadataContainer.appendChild(row);
-
-      patch.enable();
-
-      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
-      expect(keyEl.classList.contains("exo-label-clickable")).toBe(true);
-      expect(keyEl.getAttribute("aria-label")).toContain("Effort Area");
-      expect(keyEl.getAttribute("aria-label")).toContain("ems__Effort_area");
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      expect(span.getAttribute("role")).toBe("link");
+      expect(span.getAttribute("tabindex")).toBe("0");
+      expect(span.getAttribute("aria-label")).toContain("Effort Area");
+      expect(span.getAttribute("aria-label")).toContain("ems__Effort_area");
     });
 
     it("marks the property row as patched to avoid double-patching", () => {
-      const row = createPropertyRow("ems__Effort_area", "Development");
+      const row = createPropertyRow({ inputValue: "ems__Effort_area" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
-      const input = row.querySelector<HTMLInputElement>(
-        ".metadata-property-key input"
-      )!;
-      expect(input.value).toBe("Effort Area");
 
       // Invoke layout-change callback to re-run patchAll
       const layoutCb = mockApp.workspace.on.mock.calls.find(
@@ -246,41 +276,71 @@ describe("PropertiesLabelPatch", () => {
       )?.[1];
       if (layoutCb) layoutCb();
 
-      // Still "Effort Area", not "Effort Area" → (label of "Effort Area")
-      expect(input.value).toBe("Effort Area");
+      // Still exactly one span, not two
+      const spans = row.querySelectorAll(".exo-label-display");
+      expect(spans.length).toBe(1);
     });
 
     it("patches property row that uses text content instead of input for key", () => {
-      const row = createPropertyRowTextKey("ems__Effort_area", "Development");
+      const row = createPropertyRowTextKey("ems__Effort_area");
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
 
-      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
-      expect(keyEl.textContent).toBe("Effort Area");
-      expect(keyEl.classList.contains("exo-label-clickable")).toBe(true);
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      expect(span.textContent).toBe("Effort Area");
     });
   });
 
   describe("Scenario B: clicking readable label opens definition", () => {
-    it("click on patched key element calls openFile for the definition asset", () => {
-      const row = createPropertyRow("ems__Effort_status", "Doing");
+    it("click on display span calls openFile for the definition asset", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_status" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
 
-      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
-      keyEl.click();
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      span.click();
 
       expect(mockApp.workspace.getLeaf).toHaveBeenCalledWith("tab");
       expect(openFileMock).toHaveBeenCalledTimes(1);
       expect(openedFiles[0]).toBe(FILE_EFFORT_STATUS);
     });
+
+    it("click event does NOT propagate to the input (no frontmatter corruption)", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_status" });
+      mockMetadataContainer.appendChild(row);
+
+      const inputFocusSpy = jest.fn();
+      const input = row.querySelector<HTMLInputElement>(
+        ".metadata-property-key input"
+      )!;
+      input.addEventListener("focus", inputFocusSpy);
+      input.addEventListener("click", inputFocusSpy);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      span.click();
+
+      expect(inputFocusSpy).not.toHaveBeenCalled();
+      expect(input.value).toBe("ems__Effort_status");
+    });
   });
 
   describe("Scenario C: unknown predicate fallback", () => {
-    it("does NOT modify input value for predicate with no definition asset", () => {
-      const row = createPropertyRow("vendor__Custom_field", "whatever");
+    it("does NOT create a display span for unknown predicate", () => {
+      const row = createPropertyRow({ inputValue: "vendor__Custom_field" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display");
+      expect(span).toBeNull();
+    });
+
+    it("leaves the input intact for unknown predicate", () => {
+      const row = createPropertyRow({ inputValue: "vendor__Custom_field" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
@@ -289,21 +349,11 @@ describe("PropertiesLabelPatch", () => {
         ".metadata-property-key input"
       )!;
       expect(input.value).toBe("vendor__Custom_field");
-      expect(input.getAttribute("data-exo-original-key")).toBeNull();
-    });
-
-    it("does NOT attach clickable class for unknown predicate", () => {
-      const row = createPropertyRow("vendor__Custom_field", "whatever");
-      mockMetadataContainer.appendChild(row);
-
-      patch.enable();
-
-      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
-      expect(keyEl.classList.contains("exo-label-clickable")).toBe(false);
+      expect(input.classList.contains("exo-label-hidden-input")).toBe(false);
     });
 
     it("does NOT emit errors when only unknown predicates are present", () => {
-      const row = createPropertyRow("vendor__Custom_field", "whatever");
+      const row = createPropertyRow({ inputValue: "vendor__Custom_field" });
       mockMetadataContainer.appendChild(row);
 
       const errSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
@@ -314,37 +364,26 @@ describe("PropertiesLabelPatch", () => {
   });
 
   describe("disable / cleanup", () => {
-    it("restores original input.value on disable", () => {
-      const row = createPropertyRow("ems__Effort_area", "Development");
+    it("removes display span on disable and restores input visibility", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_area" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
       const input = row.querySelector<HTMLInputElement>(
         ".metadata-property-key input"
       )!;
-      expect(input.value).toBe("Effort Area");
+      expect(input.classList.contains("exo-label-hidden-input")).toBe(true);
+      expect(row.querySelector(".exo-label-display")).toBeTruthy();
 
       patch.disable();
 
+      expect(row.querySelector(".exo-label-display")).toBeNull();
+      expect(input.classList.contains("exo-label-hidden-input")).toBe(false);
       expect(input.value).toBe("ems__Effort_area");
-      expect(input.getAttribute("data-exo-original-key")).toBeNull();
     });
 
-    it("restores original text content on disable when no input is present", () => {
-      const row = createPropertyRowTextKey("ems__Effort_area", "Development");
-      mockMetadataContainer.appendChild(row);
-
-      patch.enable();
-      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
-      expect(keyEl.textContent).toBe("Effort Area");
-
-      patch.disable();
-
-      expect(keyEl.textContent).toBe("ems__Effort_area");
-    });
-
-    it("removes clickable class and aria-label on disable", () => {
-      const row = createPropertyRow("ems__Effort_area", "Development");
+    it("removes clickable class from key element on disable", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_area" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
@@ -353,18 +392,17 @@ describe("PropertiesLabelPatch", () => {
 
       patch.disable();
       expect(keyEl.classList.contains("exo-label-clickable")).toBe(false);
-      expect(keyEl.getAttribute("aria-label")).toBeNull();
     });
 
     it("click handler no longer fires after disable", () => {
-      const row = createPropertyRow("ems__Effort_status", "Doing");
+      const row = createPropertyRow({ inputValue: "ems__Effort_status" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
       patch.disable();
 
-      const keyEl = row.querySelector<HTMLElement>(".metadata-property-key")!;
-      keyEl.click();
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display");
+      expect(span).toBeNull();
       expect(openFileMock).not.toHaveBeenCalled();
     });
   });
@@ -373,39 +411,35 @@ describe("PropertiesLabelPatch", () => {
     it("patches a property row that is added after enable()", async () => {
       patch.enable();
 
-      const row = createPropertyRow("ems__Effort_area", "Development");
+      const row = createPropertyRow({ inputValue: "ems__Effort_area" });
       mockMetadataContainer.appendChild(row);
 
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      const input = row.querySelector<HTMLInputElement>(
-        ".metadata-property-key input"
-      )!;
-      expect(input.value).toBe("Effort Area");
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display");
+      expect(span?.textContent).toBe("Effort Area");
     });
   });
 
   describe("index invalidation", () => {
     it("re-patches on metadataCache changed event", () => {
-      const row = createPropertyRow("ems__Effort_area", "Development");
+      const row = createPropertyRow({ inputValue: "ems__Effort_area" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
-      const input = row.querySelector<HTMLInputElement>(
-        ".metadata-property-key input"
-      )!;
-      expect(input.value).toBe("Effort Area");
+      const spanBefore = row.querySelector<HTMLSpanElement>(".exo-label-display");
+      expect(spanBefore?.textContent).toBe("Effort Area");
 
       const changedCb = mockApp.metadataCache.on.mock.calls.find(
         (c: any[]) => c[0] === "changed"
       )?.[1];
       expect(typeof changedCb).toBe("function");
 
-      // Fire the callback — index should rebuild, existing patched rows remain
       changedCb();
 
-      // Still patched (idempotent on patched rows)
-      expect(input.value).toBe("Effort Area");
+      // Still exactly one span (idempotent on patched rows)
+      const spansAfter = row.querySelectorAll(".exo-label-display");
+      expect(spansAfter.length).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2795 (plugin half of starter-kit#27). Live-verify against `getting-started-test-vault` on `Build API Server.md` found two bugs that the unit suite missed, both rooted in Obsidian's native Properties block DOM.

### Bug 1 — Case mismatch on predicate lookup

Obsidian **lowercases** the `data-property-key` attribute on `.metadata-property` (e.g. `ems__effort_area`), but the raw-case frontmatter key lives in the `<input>` inside `.metadata-property-key`. Since the index is keyed on the raw frontmatter case (`ems__Effort_area`), reading the attribute first meant every lookup missed. Fix: flip the order in `extractPredicate()` — always prefer `input.value`, fall back to the attribute.

### Bug 2 (critical) — Frontmatter corruption via `input.value = label`

The initial implementation set `input.value = resolved.label` to make the label visible. Clicking on the key row then caused Obsidian to persist that input as a **rename of the frontmatter key**, turning `ems__Effort_status:` into `Effort Status:` on `Build API Server.md`. This is data corruption, not a rendering bug.

Fix: never mutate `input.value`. Instead:
1. Hide the input via a new `.exo-label-hidden-input` CSS class (`display: none !important`).
2. Insert a sibling `<span.exo-label-display>` into `.metadata-property-key` carrying the readable label.
3. Attach the click handler to the span only — `e.stopPropagation()` guarantees no focus reaches the input.
4. `disable()` removes the class and the span; `input.value` is never touched.

`styles.css` gains three small rules for the display span and hidden input.

## Test plan

- [x] 18 unit tests rewritten against the span-overlay model, including two new regression guards:
  - `input.value` remains equal to the raw predicate at all times (guards against bug 2).
  - Click event does NOT propagate to the input (guards against bug 2 via focus/click).
  - Lowercased `data-property-key` attribute still resolves correctly (guards against bug 1).
- [x] `npm run build` green.
- [x] Full plugin unit suite green (4514 tests passing).
- [x] Live-verify **PASS** on plugin built locally from this branch + starter-kit v1.11.0:
  - Scenario A: Properties block on `Build API Server.md` shows **UID / Label / Class / Effort Status / Effort Area** (all 5 predicates).
  - Scenario B: click on "Effort Status" opens `ems/64594641-63c9-4ec6-ab32-cfd191a6ccc6.md` in a new tab. Aria-label tooltip reads "Open definition: Effort Status (ems__Effort_status)".
  - Scenario C: `Unknown Predicate Test.md` with `vendor__Custom_field` renders the raw predicate untouched, no crash.
  - `Build API Server.md` frontmatter verified intact after click-and-navigate (no rename regression).
  - `exocortex-logs.txt`: 0 `[ERROR]` entries post-run.

## Refs

- Refs kitelev/exocortex-starter-kit#27 (feature requirement + starter-kit property defs)
- Refs #2793 (test coverage gate — now with regression guards for the two bugs above)
- Follow-up to #2795 (initial PropertiesLabelPatch)