### PR TITLE
fix(properties): subscribe to metadataCache resolved to fix Finding 4 (fresh-vault empty index)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
@@ -67,6 +67,20 @@ export class PropertiesLabelPatch {
       })
     );
 
+    // Obsidian fires "resolved" once the initial vault parse finishes. On a
+    // fresh-vault/tarball install this arrives AFTER enable() runs — plugin
+    // starts 500ms post-load, but metadata parsing can still be in flight —
+    // so without this listener the index built at enable() sees null
+    // frontmatters for every property def file and readable labels never
+    // appear. Subscribing here makes the feature work on the supported
+    // starter-kit install path. Finding 4, UX audit 2026-04-14.
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("resolved", () => {
+        this.invalidateIndex();
+        this.patchAllPropertiesBlocks();
+      })
+    );
+
     this.plugin.registerEvent(
       this.app.workspace.on("layout-change", () => {
         setTimeout(() => this.patchAllPropertiesBlocks(), 100);

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
@@ -441,5 +441,61 @@ describe("PropertiesLabelPatch", () => {
       const spansAfter = row.querySelectorAll(".exo-label-display");
       expect(spansAfter.length).toBe(1);
     });
+
+    it("registers metadataCache resolved event listener", () => {
+      patch.enable();
+      expect(mockApp.metadataCache.on).toHaveBeenCalledWith(
+        "resolved",
+        expect.any(Function)
+      );
+    });
+
+    // REGRESSION: Finding 4 from UX audit 2026-04-14.
+    // Scenario: fresh vault + starter-kit tarball install. Plugin enables 500ms
+    // after onload, but Obsidian's metadataCache has NOT finished the initial
+    // vault parse. buildIndex() runs against a cache where getFileCache returns
+    // null for every def file. Index is empty. Then Obsidian fires "resolved"
+    // ONCE — PropertiesLabelPatch was NOT listening → index stays empty forever
+    // → Properties block shows raw `ems__Effort_a...` instead of "Effort Area"
+    // for every user who installs via the supported tarball path.
+    //
+    // Fix: subscribe to metadataCache.on("resolved") → invalidate + re-patch.
+    // Without the fix this test FAILS: span is null because resolvePredicate
+    // returned null at enable() time and there was no signal to retry.
+    it("recovers when metadataCache is empty at enable() and resolves later (Finding 4)", () => {
+      // Arrange: metadataCache is not yet resolved — every getFileCache call
+      // returns null (Obsidian's actual behavior during fresh vault startup).
+      const lateFrontmatters: Record<string, any> = { ...FRONTMATTERS };
+      let metadataResolved = false;
+      mockApp.metadataCache.getFileCache = jest
+        .fn()
+        .mockImplementation((file: FakeFile) => {
+          if (!metadataResolved) return null;
+          const fm = lateFrontmatters[file.path];
+          return fm ? { frontmatter: fm } : null;
+        });
+
+      const row = createPropertyRow({ inputValue: "ems__Effort_area" });
+      mockMetadataContainer.appendChild(row);
+
+      // Act 1: plugin enables before cache is resolved — no patch possible.
+      patch.enable();
+
+      expect(
+        row.querySelector<HTMLSpanElement>(".exo-label-display")
+      ).toBeNull();
+
+      // Act 2: Obsidian finishes its initial parse and fires "resolved".
+      metadataResolved = true;
+      const resolvedCb = mockApp.metadataCache.on.mock.calls.find(
+        (c: any[]) => c[0] === "resolved"
+      )?.[1];
+      expect(typeof resolvedCb).toBe("function");
+      resolvedCb();
+
+      // Assert: the row now carries the readable label.
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display");
+      expect(span?.textContent).toBe("Effort Area");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the blocker **Finding 4** from the 2026-04-14 UX audit: on the supported `starter-kit v1.12.0` tarball install path, `PropertiesLabelPatch` silently shows raw predicates (`ems__Effort_a...`) instead of readable labels.

## Root cause

On a fresh vault + tarball install, `PropertiesLabelPatch.enable()` runs 500 ms after `onload`, but Obsidian's `metadataCache` has NOT finished the initial vault parse yet. `buildIndex()` scans every markdown file but `getFileCache()` returns `null` for property definition files → reverse index is empty → `resolvePredicate` returns `null` forever → Properties block shows raw predicate names.

Previously the only signals rebuilding the index were:
- `metadataCache.on("changed")` — fires only for subsequent file edits, NOT during initial parse
- `layout-change` / `active-leaf-change` — re-run `patchAllPropertiesBlocks` but with the same empty cache

Obsidian fires `metadataCache.on("resolved")` exactly once when the initial parse completes; nothing was listening. Same class of race as #2785 for the layout renderer.

Note: the audit's stated hypothesis ("filename-only lookup, no aliases support") was wrong — the code already indexes both `file.basename` AND `fm.aliases`. The actual failure mode is a timing race.

## Fix

Subscribe to `metadataCache.on("resolved")` in `enable()`:

```ts
this.plugin.registerEvent(
  this.app.metadataCache.on("resolved", () => {
    this.invalidateIndex();
    this.patchAllPropertiesBlocks();
  })
);
```

## Regression test

New test `recovers when metadataCache is empty at enable() and resolves later (Finding 4)`:
1. `getFileCache` returns `null` for every file until a flag flips
2. `enable()` — no patch applied (empty index)
3. `metadataCache.on("resolved")` callback fires → flag flips → re-patch
4. Assert the `Effort Area` span appears

Without the fix, step 3 fails at `expect(typeof resolvedCb).toBe("function")` — no listener registered. With the fix the span resolves correctly.

Full unit suite for `packages/obsidian-plugin/tests/unit/presentation/properties/` — **64 passed**.

## Test plan

- [x] Unit tests green locally
- [ ] CI green
- [ ] Auto Release publishes new version
- [ ] Live reproduce on fresh vault after merge (Finding 4 observer action — tracked in next-session-prompt-fix-ux-blockers-2026-04-14.md)