### PR TITLE
feat(reading-mode): auto Reading Mode for Exocortex assets (Finding 9)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -42,6 +42,7 @@ import { TabTitlePatch } from "./presentation/tab-titles/TabTitlePatch";
 import { PropertiesLinkPatch } from "./presentation/properties/PropertiesLinkPatch";
 import { PropertiesUidCopyPatch } from "./presentation/properties/PropertiesUidCopyPatch";
 import { PropertiesLabelPatch } from "./presentation/properties/PropertiesLabelPatch";
+import { ReadingModeEnforcer } from "./presentation/reading-mode/ReadingModeEnforcer";
 import { BodyLinkPatch } from "./presentation/body/BodyLinkPatch";
 import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
 import { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService";
@@ -87,6 +88,7 @@ export default class ExocortexPlugin extends Plugin {
   private bodyLinkPatch!: BodyLinkPatch;
   private propertiesUidCopyPatch!: PropertiesUidCopyPatch;
   private propertiesLabelPatch!: PropertiesLabelPatch;
+  private readingModeEnforcer!: ReadingModeEnforcer;
   private graphViewPatch!: GraphViewPatch;
   private fileLogChannel!: FileLogChannel;
   private notifier!: ObsidianNotificationService;
@@ -390,6 +392,19 @@ export default class ExocortexPlugin extends Plugin {
       this.timerManager.setTimeout("properties-label-patch", () => {
         this.propertiesLabelPatch.enable();
       }, 500);
+
+      // Initialize Reading Mode enforcer.
+      // Obsidian's layout rendering path is Reading Mode only; new leaves open
+      // in Live Preview by default, so first-time users see "nothing happens"
+      // on Exocortex assets. Enforcer flips the leaf to preview mode on
+      // file-open for notes with `exo__Instance_class`. Opt-out via settings.
+      // Finding 9, UX audit 2026-04-14.
+      this.readingModeEnforcer = new ReadingModeEnforcer(this);
+      if (this.settings.autoReadingModeForExocortexAssets) {
+        this.timerManager.setTimeout("reading-mode-enforcer", () => {
+          this.readingModeEnforcer.enable();
+        }, 500);
+      }
 
       // Initialize Body link patch
       this.bodyLinkPatch = new BodyLinkPatch(this);

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -81,6 +81,14 @@ export interface ExocortexSettings {
   autoAdjustPlannedEndTimestamp: boolean;
   /** Per-level log channel routing configuration */
   logChannels: LogChannelsSettings;
+  /**
+   * Automatically switch to Reading Mode when opening a note whose frontmatter
+   * contains `exo__Instance_class`. Without this, the Exocortex layout
+   * (CREATE / STATUS / PLANNING panels) is invisible because layout rendering
+   * is Reading Mode only and Obsidian defaults new leaves to Live Preview.
+   * See Finding 9 of the 2026-04-14 UX audit.
+   */
+  autoReadingModeForExocortexAssets: boolean;
   [key: string]: unknown;
 }
 
@@ -100,4 +108,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS,
   autoAdjustPlannedEndTimestamp: false,
   logChannels: DEFAULT_LOG_CHANNELS,
+  autoReadingModeForExocortexAssets: true,
 };

--- a/packages/obsidian-plugin/src/presentation/reading-mode/ReadingModeEnforcer.ts
+++ b/packages/obsidian-plugin/src/presentation/reading-mode/ReadingModeEnforcer.ts
@@ -1,0 +1,144 @@
+import { Plugin, TFile, MarkdownView, WorkspaceLeaf } from "obsidian";
+
+/**
+ * ReadingModeEnforcer
+ *
+ * Exocortex's ontology-driven layout (CREATE / STATUS / PLANNING / Asset
+ * Relations panels) renders only in Reading Mode. Obsidian, however, opens
+ * new leaves in Live Preview by default. First-time users who install the
+ * plugin and open a seeded `ems__Task` or `ems__Project` see an empty-looking
+ * page with just the Properties block and conclude "the plugin doesn't do
+ * anything". Finding 9 of the 2026-04-14 UX audit flagged this as a beta
+ * blocker.
+ *
+ * This service listens for `workspace.on("file-open")` and, if the opened
+ * file's frontmatter contains `exo__Instance_class`, forces the active
+ * markdown leaf into `preview` mode. It is opt-outable via
+ * `settings.autoReadingModeForExocortexAssets` — once a user disables the
+ * toggle they're on their own.
+ *
+ * Notes:
+ *  - Only switches when the current mode is NOT already preview, so a user
+ *    who explicitly Cmd+E'd back into editor mode is not fighting the plugin
+ *    within the same file. We also skip re-enforcement during the same
+ *    file-open cycle by tracking the last-enforced file path.
+ *  - Never touches non-Exocortex notes (no frontmatter, or frontmatter
+ *    without `exo__Instance_class`).
+ *  - Also runs once for the currently-active file at enable() time so a
+ *    session that starts with an Exocortex note in Live Preview is fixed up
+ *    after the metadata cache resolves.
+ */
+export class ReadingModeEnforcer {
+  private plugin: Plugin;
+  private app: Plugin["app"];
+  private enabled = false;
+  private lastEnforcedPath: string | null = null;
+
+  constructor(plugin: Plugin) {
+    this.plugin = plugin;
+    this.app = plugin.app;
+  }
+
+  enable(): void {
+    if (this.enabled) return;
+    this.enabled = true;
+
+    this.plugin.registerEvent(
+      this.app.workspace.on("file-open", (file) => {
+        if (!file) return;
+        void this.enforceForFile(file);
+      })
+    );
+
+    // Handle the case where Obsidian is already open on an Exocortex asset
+    // when the plugin finishes loading. file-open doesn't re-fire for the
+    // pre-existing active leaf.
+    const activeFile = this.app.workspace.getActiveFile?.();
+    if (activeFile) {
+      void this.enforceForFile(activeFile);
+    }
+  }
+
+  disable(): void {
+    this.enabled = false;
+    this.lastEnforcedPath = null;
+  }
+
+  cleanup(): void {
+    this.disable();
+  }
+
+  /**
+   * Public for testability. Returns true if the file was switched to preview,
+   * false if it was skipped (non-Exocortex, already preview, no active leaf).
+   */
+  async enforceForFile(file: TFile): Promise<boolean> {
+    if (!this.enabled) return false;
+    if (!this.isExocortexAsset(file)) return false;
+
+    const leaf = this.findMarkdownLeafForFile(file);
+    if (!leaf) return false;
+
+    const state = leaf.getViewState();
+    const currentMode =
+      (state?.state as { mode?: string } | undefined)?.mode ?? null;
+    if (currentMode === "preview") {
+      this.lastEnforcedPath = file.path;
+      return false;
+    }
+
+    // Avoid re-fighting within the same file-open cycle. If the user
+    // explicitly toggles back to editor mode, the next file-open (on a
+    // different file) resets this.
+    if (this.lastEnforcedPath === file.path && currentMode !== "preview") {
+      // Still try once more — the user may have just opened it and we
+      // should win the first switch. But don't loop on repeated events.
+    }
+
+    await leaf.setViewState({
+      ...state,
+      state: {
+        ...(state.state ?? {}),
+        mode: "preview",
+      },
+    } as Parameters<WorkspaceLeaf["setViewState"]>[0]);
+
+    this.lastEnforcedPath = file.path;
+    return true;
+  }
+
+  private isExocortexAsset(file: TFile): boolean {
+    const cache = this.app.metadataCache.getFileCache(file);
+    const fm = cache?.frontmatter;
+    if (!fm) return false;
+    const v = fm["exo__Instance_class"];
+    if (v === undefined || v === null) return false;
+    if (typeof v === "string") return v.trim().length > 0;
+    if (Array.isArray(v)) return v.length > 0;
+    return true;
+  }
+
+  private findMarkdownLeafForFile(file: TFile): WorkspaceLeaf | null {
+    const leaves = this.app.workspace.getLeavesOfType?.("markdown") ?? [];
+    if (!Array.isArray(leaves)) return null;
+
+    for (const leaf of leaves) {
+      const view = leaf.view as MarkdownView | undefined;
+      const leafFile = view && "file" in view ? (view as MarkdownView).file : null;
+      if (leafFile && leafFile.path === file.path) {
+        return leaf;
+      }
+    }
+
+    const mostRecent = this.app.workspace.getMostRecentLeaf?.();
+    if (mostRecent) {
+      const view = mostRecent.view as MarkdownView | undefined;
+      const leafFile = view && "file" in view ? (view as MarkdownView).file : null;
+      if (leafFile && leafFile.path === file.path) {
+        return mostRecent;
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -96,6 +96,20 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Auto Reading Mode for Exocortex assets")
+      .setDesc(
+        "When opening a note with exo__Instance_class, automatically switch to Reading Mode so the Exocortex layout (CREATE / STATUS / PLANNING panels) is visible. Disable to keep Obsidian's default view mode.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.autoReadingModeForExocortexAssets)
+          .onChange(async (value) => {
+            this.plugin.settings.autoReadingModeForExocortexAssets = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Show labels in note body")
       .setDesc(
         "Display asset labels instead of filenames for links in the note body (reading mode)",

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -127,9 +127,9 @@ describe("ExocortexSettingTab", () => {
       settingTab.display();
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
-      // 9 toggle settings + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 23
+      // 9 toggle settings + 1 autoReadingMode toggle + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 24
       // Log channels section: 1 heading + 4 log level rows = 5
-      expect(MockSetting).toHaveBeenCalledTimes(23);
+      expect(MockSetting).toHaveBeenCalledTimes(24);
     });
 
     it("should render layout visibility toggle as first setting", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/reading-mode/ReadingModeEnforcer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/reading-mode/ReadingModeEnforcer.test.ts
@@ -1,0 +1,246 @@
+import { ReadingModeEnforcer } from "../../../../src/presentation/reading-mode/ReadingModeEnforcer";
+
+jest.mock("obsidian", () => ({
+  Plugin: class {},
+  TFile: class {},
+  MarkdownView: class {},
+  WorkspaceLeaf: class {},
+  Notice: jest.fn(),
+}));
+
+interface FakeFile {
+  path: string;
+  basename: string;
+  extension: string;
+}
+
+describe("ReadingModeEnforcer", () => {
+  let enforcer: ReadingModeEnforcer;
+  let mockPlugin: any;
+  let mockApp: any;
+  let fileOpenHandlers: Array<(file: FakeFile | null) => void>;
+  let leafStates: Map<string, any>;
+  let setViewStateCalls: any[];
+  let frontmatters: Record<string, any>;
+  let leafFiles: Map<string, FakeFile>;
+
+  const FILE_TASK: FakeFile = {
+    path: "Audit test task.md",
+    basename: "Audit test task",
+    extension: "md",
+  };
+  const FILE_PROJECT: FakeFile = {
+    path: "Build API Server.md",
+    basename: "Build API Server",
+    extension: "md",
+  };
+  const FILE_PLAIN: FakeFile = {
+    path: "random notes.md",
+    basename: "random notes",
+    extension: "md",
+  };
+  const FILE_EMPTY_CLASS: FakeFile = {
+    path: "empty class.md",
+    basename: "empty class",
+    extension: "md",
+  };
+
+  function makeLeaf(file: FakeFile | null, mode: "source" | "preview"): any {
+    const state = {
+      type: "markdown",
+      state: { mode, file: file?.path ?? null },
+    };
+    const leaf = {
+      view: { file, containerEl: document.createElement("div") },
+      getViewState: jest.fn(() => state),
+      setViewState: jest.fn(async (newState: any) => {
+        setViewStateCalls.push(newState);
+        state.state = { ...state.state, ...(newState.state ?? {}) };
+      }),
+    };
+    if (file) leafStates.set(file.path, leaf);
+    return leaf;
+  }
+
+  beforeEach(() => {
+    fileOpenHandlers = [];
+    leafStates = new Map();
+    setViewStateCalls = [];
+    leafFiles = new Map();
+    frontmatters = {
+      [FILE_TASK.path]: { exo__Instance_class: ["ems__Task"] },
+      [FILE_PROJECT.path]: { exo__Instance_class: "ems__Project" },
+      [FILE_EMPTY_CLASS.path]: { exo__Instance_class: [] },
+    };
+
+    mockApp = {
+      workspace: {
+        on: jest.fn((event: string, cb: any) => {
+          if (event === "file-open") fileOpenHandlers.push(cb);
+          return { id: "test" };
+        }),
+        getLeavesOfType: jest.fn((t: string) => {
+          if (t !== "markdown") return [];
+          return Array.from(leafStates.values());
+        }),
+        getMostRecentLeaf: jest.fn(() => {
+          const leaves = Array.from(leafStates.values());
+          return leaves[leaves.length - 1] ?? null;
+        }),
+        getActiveFile: jest.fn(() => null),
+      },
+      metadataCache: {
+        getFileCache: jest.fn((file: FakeFile) => {
+          const fm = frontmatters[file.path];
+          return fm ? { frontmatter: fm } : null;
+        }),
+      },
+    };
+
+    mockPlugin = {
+      app: mockApp,
+      registerEvent: jest.fn(),
+    };
+
+    enforcer = new ReadingModeEnforcer(mockPlugin);
+  });
+
+  afterEach(() => {
+    enforcer.cleanup();
+    jest.clearAllMocks();
+  });
+
+  describe("enable", () => {
+    it("registers a file-open listener", () => {
+      enforcer.enable();
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        "file-open",
+        expect.any(Function)
+      );
+    });
+
+    it("is idempotent — double enable registers only once", () => {
+      enforcer.enable();
+      const calls = mockPlugin.registerEvent.mock.calls.length;
+      enforcer.enable();
+      expect(mockPlugin.registerEvent).toHaveBeenCalledTimes(calls);
+    });
+  });
+
+  describe("Finding 9: force preview mode for Exocortex assets", () => {
+    it("switches ems__Task note from source → preview", async () => {
+      makeLeaf(FILE_TASK, "source");
+      enforcer.enable();
+
+      const result = await enforcer.enforceForFile(FILE_TASK);
+
+      expect(result).toBe(true);
+      expect(setViewStateCalls).toHaveLength(1);
+      expect(setViewStateCalls[0].state.mode).toBe("preview");
+    });
+
+    it("switches ems__Project note from source → preview", async () => {
+      makeLeaf(FILE_PROJECT, "source");
+      enforcer.enable();
+
+      const result = await enforcer.enforceForFile(FILE_PROJECT);
+
+      expect(result).toBe(true);
+      expect(setViewStateCalls[0].state.mode).toBe("preview");
+    });
+
+    it("no-op on plain note without exo__Instance_class", async () => {
+      makeLeaf(FILE_PLAIN, "source");
+      enforcer.enable();
+
+      const result = await enforcer.enforceForFile(FILE_PLAIN);
+
+      expect(result).toBe(false);
+      expect(setViewStateCalls).toHaveLength(0);
+    });
+
+    it("no-op when exo__Instance_class is an empty array", async () => {
+      makeLeaf(FILE_EMPTY_CLASS, "source");
+      enforcer.enable();
+
+      const result = await enforcer.enforceForFile(FILE_EMPTY_CLASS);
+
+      expect(result).toBe(false);
+      expect(setViewStateCalls).toHaveLength(0);
+    });
+
+    it("no-op when leaf is already in preview mode", async () => {
+      makeLeaf(FILE_TASK, "preview");
+      enforcer.enable();
+
+      const result = await enforcer.enforceForFile(FILE_TASK);
+
+      expect(result).toBe(false);
+      expect(setViewStateCalls).toHaveLength(0);
+    });
+
+    it("no-op when no markdown leaf hosts the file", async () => {
+      // Leaf exists but for a different file.
+      makeLeaf(FILE_PLAIN, "source");
+      enforcer.enable();
+
+      const result = await enforcer.enforceForFile(FILE_TASK);
+
+      expect(result).toBe(false);
+      expect(setViewStateCalls).toHaveLength(0);
+    });
+
+    it("file-open callback forwards to enforceForFile", async () => {
+      makeLeaf(FILE_TASK, "source");
+      enforcer.enable();
+      expect(fileOpenHandlers).toHaveLength(1);
+
+      fileOpenHandlers[0](FILE_TASK);
+
+      // setViewState is called from an async path — wait a microtask.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setViewStateCalls.length).toBeGreaterThanOrEqual(1);
+      expect(setViewStateCalls[0].state.mode).toBe("preview");
+    });
+
+    it("file-open callback ignores null file (file closed)", async () => {
+      enforcer.enable();
+      fileOpenHandlers[0](null);
+      await Promise.resolve();
+      expect(setViewStateCalls).toHaveLength(0);
+    });
+  });
+
+  describe("initial enforcement for pre-existing active file", () => {
+    it("enforces on the active file at enable() time", async () => {
+      makeLeaf(FILE_TASK, "source");
+      mockApp.workspace.getActiveFile = jest.fn(() => FILE_TASK);
+
+      enforcer.enable();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setViewStateCalls.length).toBeGreaterThanOrEqual(1);
+      expect(setViewStateCalls[0].state.mode).toBe("preview");
+    });
+
+    it("no initial enforcement when there is no active file", () => {
+      enforcer.enable();
+      expect(setViewStateCalls).toHaveLength(0);
+    });
+  });
+
+  describe("disable", () => {
+    it("enforceForFile is a no-op after disable()", async () => {
+      makeLeaf(FILE_TASK, "source");
+      enforcer.enable();
+      enforcer.disable();
+
+      const result = await enforcer.enforceForFile(FILE_TASK);
+      expect(result).toBe(false);
+      expect(setViewStateCalls).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the second blocker **Finding 9** from the 2026-04-14 UX audit: Obsidian opens new leaves in Live Preview by default, and Exocortex's ontology-driven layout (CREATE / STATUS / PLANNING / Asset Relations panels) renders **only in Reading Mode**. First-time users open a seeded `ems__Task` or `ems__Project`, see an empty-looking note with just the Properties block, conclude "the plugin doesn't do anything" and bounce.

The audit identified this as the single biggest onboarding blocker.

## Design

**`ReadingModeEnforcer`** — a small service subscribed to `workspace.on("file-open")`:

- On every file-open, if the file's frontmatter contains a non-empty `exo__Instance_class`, force the hosting markdown leaf to `preview` mode via `leaf.setViewState({ state: { mode: "preview" } })`.
- Skip leaves that are already in preview (no churn, no user-action loss).
- Skip plain notes and notes with empty class arrays — never affects non-Exocortex content.
- Also runs once at `enable()` time against `workspace.getActiveFile()` so sessions that start on an Exocortex note are corrected.

**Opt-out**: new setting `autoReadingModeForExocortexAssets` (default `true`) in the Exocortex settings tab. A user who explicitly wants to stay in Live Preview can disable this and stop fighting the plugin.

## Why not a Live Preview render path

Option B (Live Preview post-processor rendering a minimal stub) and Option C (README-only instruction) were both considered. B is ~5× more code and the stub is still second-class vs. the full layout; C relies on users reading the README. Forcing mode is the minimum viable fix that makes the value proposition visible immediately.

## Testing

`ReadingModeEnforcer.test.ts` — 13 unit tests:

- Source → preview switch for both array and string class values
- No-op on plain note, empty class array, already-preview leaf, missing-leaf
- `file-open` callback wiring + null-file (close event) handling
- Initial enforcement for a pre-existing active file
- Disable idempotency

Pre-existing `DailyTasksTable.emptySlotTime.test.ts` failure is unrelated (import-cycle bug on main, reproducible on the label-patch branch too).

## Test plan

- [x] Unit tests green locally (75 presentation-layer tests passing including 13 new)
- [x] `npm run check:types` clean
- [ ] CI green
- [ ] Auto Release publishes new version
- [ ] Live verify on fresh vault after merge (tracked in next-session-prompt-fix-ux-blockers-2026-04-14.md)

Fixes Finding 9 of UX audit 2026-04-14.