### PR TITLE
feat(creation): Finding 8 — inject label as # heading into asset body

### DIFF
--- a/packages/exocortex/src/utilities/MetadataHelpers.ts
+++ b/packages/exocortex/src/utilities/MetadataHelpers.ts
@@ -151,7 +151,15 @@ export class MetadataHelpers {
       })
       .join("\n");
 
-    const body = bodyContent ? `\n${bodyContent}\n` : "\n";
+    let effectiveBody = bodyContent;
+    if (effectiveBody === undefined) {
+      const label = frontmatter["exo__Asset_label"];
+      if (typeof label === "string" && label.trim() !== "") {
+        effectiveBody = `# ${label}`;
+      }
+    }
+
+    const body = effectiveBody ? `\n${effectiveBody}\n` : "\n";
     return `---\n${frontmatterLines}\n---\n${body}`;
   }
 }

--- a/packages/exocortex/tests/utilities/MetadataHelpers.test.ts
+++ b/packages/exocortex/tests/utilities/MetadataHelpers.test.ts
@@ -660,6 +660,39 @@ describe("MetadataHelpers", () => {
 
       expect(result).toBe("---\ntitle: Doc\n---\n\nLine 1\nLine 2\nLine 3\n");
     });
+
+    it("should inject label as H1 heading when frontmatter has exo__Asset_label and body is omitted", () => {
+      const frontmatter = {
+        exo__Asset_uid: "abc-123",
+        exo__Asset_label: "Audit test task",
+      };
+      const result = MetadataHelpers.buildFileContent(frontmatter);
+
+      expect(result).toBe(
+        "---\nexo__Asset_uid: abc-123\nexo__Asset_label: Audit test task\n---\n\n# Audit test task\n",
+      );
+    });
+
+    it("should NOT inject label heading when explicit body is provided", () => {
+      const frontmatter = {
+        exo__Asset_label: "Explicit body task",
+      };
+      const body = "Custom body content";
+      const result = MetadataHelpers.buildFileContent(frontmatter, body);
+
+      expect(result).toBe(
+        "---\nexo__Asset_label: Explicit body task\n---\n\nCustom body content\n",
+      );
+    });
+
+    it("should NOT inject heading when exo__Asset_label is empty string", () => {
+      const frontmatter = {
+        exo__Asset_label: "",
+      };
+      const result = MetadataHelpers.buildFileContent(frontmatter);
+
+      expect(result).toBe("---\nexo__Asset_label: \n---\n\n");
+    });
   });
 
   describe("containsReference - mutation killing", () => {


### PR DESCRIPTION
## Summary
- `MetadataHelpers.buildFileContent` now emits `# <label>` as the body when frontmatter carries a non-empty `exo__Asset_label` and no explicit body was supplied.
- Result: newly-created assets open with a human-readable inline title in Obsidian instead of the UUID filename.
- Change is a single chokepoint — all six creation services that route through `buildFileContent` (Generic, Area, Concept, Class, FleetingNote, SessionEvent) pick it up without further edits.

## Context
UX audit 2026-04-14 Finding 8. Obsidian's inline title feature reads the first H1 from the file body (`# Something`) and only falls back to the filename when no H1 exists. Because every creation service left the body empty, users saw a UUID as the title after Create Task / Create Project / Create Note / etc. — even though they had just typed a meaningful label.

## Scope notes
- Does **not** touch `SupervisionCreationService` (has its own `buildFileContent` overload that already supplies an explicit body).
- Does **not** touch `DailyReviewService` (generates its own content from scratch).
- Does **not** alter `bodyContent` callers — explicit bodies still win.
- Preserves the existing empty-frontmatter / no-label behavior (no heading injected when label is absent or empty string).

## Verification
New tests in `MetadataHelpers.test.ts`:

- `should inject label as H1 heading when frontmatter has exo__Asset_label and body is omitted`
- `should NOT inject label heading when explicit body is provided`
- `should NOT inject heading when exo__Asset_label is empty string`

All 11 buildFileContent tests green; 390/390 tests pass in `packages/exocortex/tests/services` (the 2 unrelated pre-existing ESM-export syntax failures in `DynamicFrontmatterGenerator.test.ts` / `DailyReviewService.test.ts` are not touched by this PR).

## Test plan
- [x] Unit test for label injection (H1 heading case)
- [x] Unit test for explicit-body override
- [x] Unit test for empty-label no-op
- [x] Typecheck `packages/exocortex`
- [ ] Post-merge: open a freshly-created Task in starter-kit vault, confirm inline title reads the label, not UUID