### PR TITLE
fix(ui): match font-size of relabeled property keys with native Obsidian keys

### DIFF
--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -5955,6 +5955,10 @@
 .metadata-property-key .exo-label-display {
   cursor: pointer;
   color: var(--text-accent);
+  font-size: var(--metadata-label-font-size, var(--font-ui-small));
+  font-weight: var(--metadata-label-font-weight, var(--font-medium));
+  font-family: inherit;
+  line-height: var(--line-height-tight);
 }
 
 .metadata-property-key .exo-label-display:hover {

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
@@ -498,4 +498,28 @@ describe("PropertiesLabelPatch", () => {
       expect(span?.textContent).toBe("Effort Area");
     });
   });
+
+  describe("stylesheet: font-size parity with native property keys", () => {
+    it("applies metadata-label font variables to .exo-label-display", () => {
+      const fs = require("fs");
+      const path = require("path");
+      const stylesPath = path.resolve(
+        __dirname,
+        "../../../../styles.css"
+      );
+      const css = fs.readFileSync(stylesPath, "utf8");
+
+      // Extract the .metadata-property-key .exo-label-display rule block.
+      const match = css.match(
+        /\.metadata-property-key \.exo-label-display\s*\{([^}]*)\}/
+      );
+      expect(match).toBeTruthy();
+      const block = match![1];
+
+      // Must inherit Obsidian's metadata-label font sizing so that the patched
+      // property key renders at the same size as native Properties keys.
+      expect(block).toMatch(/font-size:\s*var\(--metadata-label-font-size/);
+      expect(block).toMatch(/font-weight:\s*var\(--metadata-label-font-weight/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- PropertiesLabelPatch-span inherits Obsidian's `--metadata-label-font-size` / `--metadata-label-font-weight` so relabeled property keys render at the same visual size as native Obsidian property keys in the Properties section.
- Added a stylesheet assertion in `PropertiesLabelPatch.test.ts` to lock the CSS rule against regression.

Closes #2800

## Test plan
- [x] `npx jest ... PropertiesLabelPatch.test.ts` → 21/21 pass
- [x] `npm run test:all` → unit + component (539 passed) + BDD 100% + archgate pass
- [ ] Visual check in Obsidian — manual confirmation on next plugin reload