### PR TITLE
fix(ui): align .exo-label-display box with native property key metrics

### DIFF
--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -5955,10 +5955,15 @@
 .metadata-property-key .exo-label-display {
   cursor: pointer;
   color: var(--text-accent);
+  /* match native .metadata-property-key input metrics */
+  font: inherit;
   font-size: var(--metadata-label-font-size, var(--font-ui-small));
-  font-weight: var(--metadata-label-font-weight, var(--font-medium));
-  font-family: inherit;
-  line-height: var(--line-height-tight);
+  /* vertical centering: span must occupy the same box as the hidden input */
+  display: inline-flex;
+  align-items: center;
+  height: var(--input-height);
+  padding: var(--size-4-1) var(--size-4-2);
+  box-sizing: border-box;
 }
 
 .metadata-property-key .exo-label-display:hover {

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
@@ -499,8 +499,8 @@ describe("PropertiesLabelPatch", () => {
     });
   });
 
-  describe("stylesheet: font-size parity with native property keys", () => {
-    it("applies metadata-label font variables to .exo-label-display", () => {
+  describe("stylesheet: .exo-label-display matches native input metrics", () => {
+    it("occupies the same geometric box as native .metadata-property-key input", () => {
       const fs = require("fs");
       const path = require("path");
       const stylesPath = path.resolve(
@@ -516,10 +516,27 @@ describe("PropertiesLabelPatch", () => {
       expect(match).toBeTruthy();
       const block = match![1];
 
-      // Must inherit Obsidian's metadata-label font sizing so that the patched
-      // property key renders at the same size as native Properties keys.
+      // font: inherit + explicit font-size overrides weight/line-height/family
+      // so the span picks up native metrics instead of forcing --font-medium /
+      // --line-height-tight (which caused the v15.98.1 vertical misalignment).
+      expect(block).toMatch(/font:\s*inherit/);
       expect(block).toMatch(/font-size:\s*var\(--metadata-label-font-size/);
-      expect(block).toMatch(/font-weight:\s*var\(--metadata-label-font-weight/);
+
+      // The span must occupy the same box as the hidden input so baselines
+      // align with native Properties keys.
+      expect(block).toMatch(/display:\s*inline-flex/);
+      expect(block).toMatch(/align-items:\s*center/);
+      expect(block).toMatch(/height:\s*var\(--input-height/);
+      expect(block).toMatch(/padding:\s*var\(--size-4-1\) var\(--size-4-2/);
+      expect(block).toMatch(/box-sizing:\s*border-box/);
+
+      // Regression gates (v15.98.1 post-mortem): explicit font-weight and
+      // line-height broke vertical alignment because native uses --font-normal
+      // and normal line-height. Must NOT be re-introduced.
+      expect(block).not.toMatch(
+        /font-weight:\s*var\(--metadata-label-font-weight/
+      );
+      expect(block).not.toMatch(/line-height:\s*var\(--line-height-tight/);
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up regression from v15.98.1 (PR #2801, issue #2800). After that release the relabeled Properties keys (Defined By / UID / Class / Label) were visually shifted **up** from the row baseline and rendered slightly bolder than native keys like `aliases`.

Root cause: v15.98.1 forced `font-weight: var(--metadata-label-font-weight)` (= 500) and `line-height: var(--line-height-tight)` onto a naked inline span, while native `.metadata-property-key input` uses `--font-normal` (= 400) plus its own input-height/padding. The span never matched the native box.

## Fix

Replaced the `.metadata-property-key .exo-label-display` rule with a box-matching variant:

```css
font: inherit;
font-size: var(--metadata-label-font-size, var(--font-ui-small));
display: inline-flex;
align-items: center;
height: var(--input-height);
padding: var(--size-4-1) var(--size-4-2);
box-sizing: border-box;
```

- `font: inherit` picks up native `font-weight`/`line-height`/`font-family` instead of overriding them.
- Explicit `font-size` override preserves the v15.98.1 intent (match `--metadata-label-font-size`).
- `inline-flex` + `height` + `padding` makes the span occupy the same geometric box as the hidden `input.exo-label-hidden-input`, fixing vertical centering.

## Tests

`PropertiesLabelPatch.test.ts` now asserts the full new shape via fs+regex on the CSS block:

- positive: `font: inherit`, `font-size: var(--metadata-label-font-size`, `display: inline-flex`, `align-items: center`, `height: var(--input-height`, `padding: var(--size-4-1) var(--size-4-2`, `box-sizing: border-box`
- negative (regression gates): block must **NOT** contain `font-weight: var(--metadata-label-font-weight` or `line-height: var(--line-height-tight`

All 21 tests in the suite pass; `npm run test:all` (unit + component) green.

## Test plan

- [x] `PropertiesLabelPatch.test.ts` passes (21/21)
- [x] `npm run test:all` unit + component green
- [ ] Visual verification in Obsidian (pending user review — computer-control not exercised to avoid disrupting the active vault-2025 / Obsidian Sync session). Expected: `Defined By`, `UID`, `Class`, `Label` keys sit on the same baseline as `aliases`, with matching weight.

## Linked issues

Follow-up of #2800 / #2801.