### PR TITLE
fix(ui): File Explorer sidebar shows exo__Asset_label instead of UUID (#2802)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -42,6 +42,7 @@ import { TabTitlePatch } from "./presentation/tab-titles/TabTitlePatch";
 import { PropertiesLinkPatch } from "./presentation/properties/PropertiesLinkPatch";
 import { PropertiesUidCopyPatch } from "./presentation/properties/PropertiesUidCopyPatch";
 import { PropertiesLabelPatch } from "./presentation/properties/PropertiesLabelPatch";
+import { FileExplorerLabelPatch } from "./presentation/fileexplorer/FileExplorerLabelPatch";
 import { ReadingModeEnforcer } from "./presentation/reading-mode/ReadingModeEnforcer";
 import { BodyLinkPatch } from "./presentation/body/BodyLinkPatch";
 import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
@@ -88,6 +89,7 @@ export default class ExocortexPlugin extends Plugin {
   private bodyLinkPatch!: BodyLinkPatch;
   private propertiesUidCopyPatch!: PropertiesUidCopyPatch;
   private propertiesLabelPatch!: PropertiesLabelPatch;
+  private fileExplorerLabelPatch!: FileExplorerLabelPatch;
   private readingModeEnforcer!: ReadingModeEnforcer;
   private graphViewPatch!: GraphViewPatch;
   private fileLogChannel!: FileLogChannel;
@@ -393,6 +395,16 @@ export default class ExocortexPlugin extends Plugin {
         this.propertiesLabelPatch.enable();
       }, 500);
 
+      // Initialize File Explorer readable-label patch (always enabled).
+      // Replaces UUID filenames in the sidebar with `exo__Asset_label`.
+      // Finding: Ваня Холькин UX audit 2026-04-12 09:32 — «Структура уродская»;
+      // File Explorer still showed bare UUIDs after v15.98.0 fixed inline title.
+      // Issue #2802.
+      this.fileExplorerLabelPatch = new FileExplorerLabelPatch(this);
+      this.timerManager.setTimeout("file-explorer-label-patch", () => {
+        this.fileExplorerLabelPatch.enable();
+      }, 500);
+
       // Initialize Reading Mode enforcer.
       // Obsidian's layout rendering path is Reading Mode only; new leaves open
       // in Live Preview by default, so first-time users see "nothing happens"
@@ -492,6 +504,11 @@ export default class ExocortexPlugin extends Plugin {
     // Cleanup Properties readable-label patch
     if (this.propertiesLabelPatch) {
       this.propertiesLabelPatch.cleanup();
+    }
+
+    // Cleanup File Explorer readable-label patch
+    if (this.fileExplorerLabelPatch) {
+      this.fileExplorerLabelPatch.cleanup();
     }
 
     // Cleanup Body link patch

--- a/packages/obsidian-plugin/src/presentation/fileexplorer/FileExplorerLabelPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/fileexplorer/FileExplorerLabelPatch.ts
@@ -1,0 +1,185 @@
+import { Plugin, TFile } from "obsidian";
+
+/**
+ * FileExplorerLabelPatch — replaces UUID filenames in Obsidian's File Explorer
+ * sidebar with human-readable `exo__Asset_label` values.
+ *
+ * Strategy: span overlay. The original `.nav-file-title-content` text node is
+ * hidden via a CSS class and a sibling `<span class="exo-file-explorer-label">`
+ * is appended with the resolved label. We never mutate the original text node
+ * directly — Obsidian re-renders the file explorer row on rename/refresh, and
+ * our MutationObserver re-applies the overlay on every such re-render.
+ *
+ * Trigger: frontmatter has both `exo__Instance_class` AND a non-empty
+ * `exo__Asset_label`. Without `exo__Instance_class` we leave the row alone so
+ * non-Exocortex notes render normally.
+ *
+ * Registered after PropertiesLabelPatch in ExocortexPlugin.onload() with the
+ * same 500ms delay, and listens to `metadataCache.on("resolved")` to cover the
+ * fresh-vault / starter-kit-tarball install path where metadata parsing is
+ * still in flight when the plugin enables (Finding 4, UX audit 2026-04-14).
+ *
+ * Issue #2802. Source: Ваня Холькин vault asset
+ * `37a88fda-74f3-4b26-bc93-8ebdac701c70`, 09:32 2026-04-12.
+ */
+
+const PATCHED_ATTR = "data-exo-fe-label-patched";
+const OVERLAY_SPAN_CLASS = "exo-file-explorer-label";
+const HIDDEN_TEXT_CLASS = "exo-file-explorer-label-hidden";
+
+interface PatchRecord {
+  contentEl: HTMLElement;
+  overlay: HTMLSpanElement;
+}
+
+export class FileExplorerLabelPatch {
+  private app: Plugin["app"];
+  private plugin: Plugin;
+  private observer: MutationObserver | null = null;
+  private enabled = false;
+  private patched: PatchRecord[] = [];
+
+  constructor(plugin: Plugin) {
+    this.plugin = plugin;
+    this.app = plugin.app;
+  }
+
+  enable(): void {
+    if (this.enabled) return;
+    this.enabled = true;
+
+    this.patchAll();
+    this.setupObserver();
+
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("changed", () => {
+        this.patchAll();
+      })
+    );
+
+    // Fresh vault / starter-kit tarball: metadataCache finishes after plugin
+    // enables; without this listener getFileCache returns null for every file
+    // and labels never appear. See PropertiesLabelPatch for background.
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("resolved", () => {
+        this.restoreAll();
+        this.patchAll();
+      })
+    );
+
+    this.plugin.registerEvent(
+      this.app.workspace.on("layout-change", () => {
+        setTimeout(() => this.patchAll(), 100);
+      })
+    );
+  }
+
+  disable(): void {
+    if (!this.enabled) return;
+    this.enabled = false;
+
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+
+    this.restoreAll();
+  }
+
+  cleanup(): void {
+    this.disable();
+  }
+
+  private patchAll(): void {
+    if (!this.enabled) return;
+    const titles = document.getElementsByClassName("nav-file-title");
+    for (const title of Array.from(titles)) {
+      if (title instanceof HTMLElement) this.patchTitle(title);
+    }
+  }
+
+  private patchTitle(titleEl: HTMLElement): void {
+    const contentEl = titleEl.querySelector<HTMLElement>(".nav-file-title-content");
+    if (!contentEl) return;
+    if (contentEl.getAttribute(PATCHED_ATTR) === "true") return;
+
+    const dataPath = titleEl.getAttribute("data-path");
+    if (!dataPath) return;
+
+    const abstractFile = this.app.vault.getAbstractFileByPath(dataPath);
+    if (!abstractFile || !(abstractFile instanceof TFile)) return;
+
+    const cache = this.app.metadataCache.getFileCache(abstractFile);
+    const fm = cache?.frontmatter;
+    if (!fm) return;
+
+    const instanceClass = fm["exo__Instance_class"];
+    if (instanceClass === undefined || instanceClass === null) return;
+    if (Array.isArray(instanceClass) && instanceClass.length === 0) return;
+
+    const rawLabel = fm["exo__Asset_label"];
+    if (typeof rawLabel !== "string") return;
+    const label = rawLabel.trim();
+    if (!label) return;
+
+    // Avoid overlay if the label already equals what's visible — nothing to
+    // improve and we'd just create a visual duplicate.
+    const currentText = (contentEl.textContent || "").trim();
+    if (currentText === label) return;
+
+    contentEl.classList.add(HIDDEN_TEXT_CLASS);
+
+    const overlay = document.createElement("span");
+    overlay.className = OVERLAY_SPAN_CLASS;
+    overlay.textContent = label;
+    overlay.setAttribute("data-exo-source-path", dataPath);
+
+    contentEl.appendChild(overlay);
+    contentEl.setAttribute(PATCHED_ATTR, "true");
+
+    this.patched.push({ contentEl, overlay });
+  }
+
+  private setupObserver(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+
+    this.observer = new MutationObserver((mutations) => {
+      if (!this.enabled) return;
+
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (!(node instanceof HTMLElement)) continue;
+
+          if (node.classList?.contains("nav-file-title")) {
+            this.patchTitle(node);
+          } else {
+            const titles = node.getElementsByClassName("nav-file-title");
+            for (const title of Array.from(titles)) {
+              if (title instanceof HTMLElement) this.patchTitle(title);
+            }
+          }
+        }
+      }
+    });
+
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  private restoreAll(): void {
+    for (const record of this.patched) {
+      try {
+        record.overlay.remove();
+        record.contentEl.classList.remove(HIDDEN_TEXT_CLASS);
+        record.contentEl.removeAttribute(PATCHED_ATTR);
+      } catch {
+        // Best-effort restore
+      }
+    }
+    this.patched = [];
+  }
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -5969,3 +5969,17 @@
 .metadata-property-key .exo-label-display:hover {
   text-decoration: underline;
 }
+
+/* FileExplorerLabelPatch — span overlay for UUID-named Exocortex assets (#2802) */
+.nav-file-title-content.exo-file-explorer-label-hidden {
+  font-size: 0 !important;
+  line-height: 0 !important;
+}
+
+.nav-file-title-content .exo-file-explorer-label {
+  font-size: var(--nav-item-size, var(--font-ui-small));
+  font-weight: var(--nav-item-weight, inherit);
+  font-family: inherit;
+  line-height: var(--line-height-tight);
+  color: inherit;
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerLabelPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerLabelPatch.test.ts
@@ -1,0 +1,362 @@
+jest.mock("obsidian", () => {
+  class FakeTFileCtor {
+    path: string;
+    basename: string;
+    extension: string;
+    constructor(path: string) {
+      this.path = path;
+      const name = path.split("/").pop() || path;
+      this.basename = name.replace(/\.md$/, "");
+      this.extension = "md";
+    }
+  }
+  return {
+    Plugin: class {},
+    TFile: FakeTFileCtor,
+    Notice: jest.fn(),
+  };
+});
+
+import { FileExplorerLabelPatch } from "../../../../src/presentation/fileexplorer/FileExplorerLabelPatch";
+import { TFile as ObsidianTFile } from "obsidian";
+
+const FakeTFileCtor = ObsidianTFile as unknown as new (path: string) => {
+  path: string;
+  basename: string;
+  extension: string;
+};
+
+describe("FileExplorerLabelPatch", () => {
+  let patch: FileExplorerLabelPatch;
+  let mockPlugin: any;
+  let mockApp: any;
+  let navContainer: HTMLElement;
+
+  const FILE_TASK_UUID =
+    "37a88fda-74f3-4b26-bc93-8ebdac701c70";
+  const FILE_TASK_PATH = `03 Knowledge/${FILE_TASK_UUID}.md`;
+  const FILE_PROJECT_UUID = "ab1b5cc2-0000-0000-0000-000000000000";
+  const FILE_PROJECT_PATH = `03 Knowledge/${FILE_PROJECT_UUID}.md`;
+  const FILE_NON_EXOCORTEX_PATH = "03 Knowledge/Random note.md";
+
+  const FRONTMATTERS: Record<string, any> = {
+    [FILE_TASK_PATH]: {
+      exo__Instance_class: ["[[1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task]]"],
+      exo__Asset_label: "Купить молоко",
+    },
+    [FILE_PROJECT_PATH]: {
+      exo__Instance_class: ["[[7db5eeff-718a-49b0-8d2b-39b084a356e3|ems__Project]]"],
+      exo__Asset_label: "Сайт перестройки",
+    },
+    [FILE_NON_EXOCORTEX_PATH]: {
+      // No exo__Instance_class — should NOT be patched
+      tags: ["misc"],
+    },
+  };
+
+  const FILES_BY_PATH: Record<string, FakeTFileCtor> = {
+    [FILE_TASK_PATH]: new FakeTFileCtor(FILE_TASK_PATH),
+    [FILE_PROJECT_PATH]: new FakeTFileCtor(FILE_PROJECT_PATH),
+    [FILE_NON_EXOCORTEX_PATH]: new FakeTFileCtor(FILE_NON_EXOCORTEX_PATH),
+  };
+
+  function createNavFileTitle(path: string, visibleText?: string): HTMLElement {
+    const basename = (path.split("/").pop() || path).replace(/\.md$/, "");
+    const titleEl = document.createElement("div");
+    titleEl.className = "nav-file-title";
+    titleEl.setAttribute("data-path", path);
+
+    const contentEl = document.createElement("div");
+    contentEl.className = "nav-file-title-content";
+    contentEl.textContent = visibleText ?? basename;
+    titleEl.appendChild(contentEl);
+
+    return titleEl;
+  }
+
+  beforeEach(() => {
+    navContainer = document.createElement("div");
+    navContainer.className = "nav-files-container";
+    document.body.appendChild(navContainer);
+
+    mockApp = {
+      workspace: {
+        on: jest.fn().mockReturnValue({ id: "test" }),
+      },
+      metadataCache: {
+        on: jest.fn().mockReturnValue({ id: "test" }),
+        getFileCache: jest.fn().mockImplementation((file: FakeTFileCtor) => {
+          const fm = FRONTMATTERS[file.path];
+          return fm ? { frontmatter: fm } : null;
+        }),
+      },
+      vault: {
+        getAbstractFileByPath: jest.fn().mockImplementation((path: string) => {
+          return FILES_BY_PATH[path] ?? null;
+        }),
+      },
+    };
+
+    mockPlugin = {
+      app: mockApp,
+      registerEvent: jest.fn(),
+    };
+
+    patch = new FileExplorerLabelPatch(mockPlugin);
+  });
+
+  afterEach(() => {
+    patch.cleanup();
+    jest.clearAllMocks();
+    if (navContainer.parentNode) {
+      navContainer.parentNode.removeChild(navContainer);
+    }
+  });
+
+  describe("enable", () => {
+    it("registers layout-change, metadataCache changed + resolved events", () => {
+      patch.enable();
+
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        "layout-change",
+        expect.any(Function)
+      );
+      expect(mockApp.metadataCache.on).toHaveBeenCalledWith(
+        "changed",
+        expect.any(Function)
+      );
+      expect(mockApp.metadataCache.on).toHaveBeenCalledWith(
+        "resolved",
+        expect.any(Function)
+      );
+    });
+
+    it("is idempotent (double-enable registers events only once)", () => {
+      patch.enable();
+      const callCount = mockPlugin.registerEvent.mock.calls.length;
+      patch.enable();
+      expect(mockPlugin.registerEvent).toHaveBeenCalledTimes(callCount);
+    });
+  });
+
+  describe("Scenario A: Exocortex assets get readable label overlay", () => {
+    it("injects overlay span with exo__Asset_label for UUID filename", () => {
+      const titleEl = createNavFileTitle(FILE_TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      const overlay = titleEl.querySelector<HTMLSpanElement>(
+        ".exo-file-explorer-label"
+      );
+      expect(overlay).toBeTruthy();
+      expect(overlay?.textContent).toBe("Купить молоко");
+    });
+
+    it("hides original text by adding .exo-file-explorer-label-hidden class", () => {
+      const titleEl = createNavFileTitle(FILE_TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      const contentEl = titleEl.querySelector<HTMLElement>(
+        ".nav-file-title-content"
+      )!;
+      expect(
+        contentEl.classList.contains("exo-file-explorer-label-hidden")
+      ).toBe(true);
+    });
+
+    it("marks patched nodes to avoid double-overlay", () => {
+      const titleEl = createNavFileTitle(FILE_TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+      // Trigger a second full scan via metadataCache changed
+      const changedCb = mockApp.metadataCache.on.mock.calls.find(
+        (c: any[]) => c[0] === "changed"
+      )?.[1];
+      if (changedCb) changedCb();
+
+      const overlays = titleEl.querySelectorAll(".exo-file-explorer-label");
+      expect(overlays.length).toBe(1);
+    });
+
+    it("patches multiple Exocortex assets independently", () => {
+      const taskEl = createNavFileTitle(FILE_TASK_PATH);
+      const projectEl = createNavFileTitle(FILE_PROJECT_PATH);
+      navContainer.appendChild(taskEl);
+      navContainer.appendChild(projectEl);
+
+      patch.enable();
+
+      expect(
+        taskEl.querySelector<HTMLSpanElement>(".exo-file-explorer-label")
+          ?.textContent
+      ).toBe("Купить молоко");
+      expect(
+        projectEl.querySelector<HTMLSpanElement>(".exo-file-explorer-label")
+          ?.textContent
+      ).toBe("Сайт перестройки");
+    });
+  });
+
+  describe("Scenario B: non-Exocortex files left untouched", () => {
+    it("does NOT inject overlay for file without exo__Instance_class", () => {
+      const titleEl = createNavFileTitle(FILE_NON_EXOCORTEX_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      const overlay = titleEl.querySelector(".exo-file-explorer-label");
+      expect(overlay).toBeNull();
+      const contentEl = titleEl.querySelector<HTMLElement>(
+        ".nav-file-title-content"
+      )!;
+      expect(
+        contentEl.classList.contains("exo-file-explorer-label-hidden")
+      ).toBe(false);
+    });
+
+    it("does NOT inject overlay when label equals visible text", () => {
+      // Simulate file whose basename already matches label — no improvement possible
+      const path = "03 Knowledge/Already Readable.md";
+      FILES_BY_PATH[path] = new FakeTFileCtor(path);
+      FRONTMATTERS[path] = {
+        exo__Instance_class: ["[[ems__Task]]"],
+        exo__Asset_label: "Already Readable",
+      };
+      const titleEl = createNavFileTitle(path);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-label")).toBeNull();
+      delete FILES_BY_PATH[path];
+      delete FRONTMATTERS[path];
+    });
+  });
+
+  describe("Scenario C: no-frontmatter / no-label edge cases", () => {
+    it("does nothing when metadataCache returns null", () => {
+      const orphanPath = "03 Knowledge/orphan-uuid.md";
+      FILES_BY_PATH[orphanPath] = new FakeTFileCtor(orphanPath);
+      const titleEl = createNavFileTitle(orphanPath);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-label")).toBeNull();
+      delete FILES_BY_PATH[orphanPath];
+    });
+
+    it("does nothing when data-path attribute is missing", () => {
+      const titleEl = document.createElement("div");
+      titleEl.className = "nav-file-title";
+      const contentEl = document.createElement("div");
+      contentEl.className = "nav-file-title-content";
+      contentEl.textContent = "noop";
+      titleEl.appendChild(contentEl);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-label")).toBeNull();
+    });
+  });
+
+  describe("disable / cleanup", () => {
+    it("removes overlay span on disable and restores hidden class", () => {
+      const titleEl = createNavFileTitle(FILE_TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+      const contentEl = titleEl.querySelector<HTMLElement>(
+        ".nav-file-title-content"
+      )!;
+      expect(
+        contentEl.classList.contains("exo-file-explorer-label-hidden")
+      ).toBe(true);
+      expect(titleEl.querySelector(".exo-file-explorer-label")).toBeTruthy();
+
+      patch.disable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-label")).toBeNull();
+      expect(
+        contentEl.classList.contains("exo-file-explorer-label-hidden")
+      ).toBe(false);
+      expect((contentEl.textContent || "").trim()).toBe(FILE_TASK_UUID);
+    });
+  });
+
+  describe("dynamic DOM (MutationObserver)", () => {
+    it("patches a nav-file-title added after enable()", async () => {
+      patch.enable();
+
+      const titleEl = createNavFileTitle(FILE_TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const overlay = titleEl.querySelector<HTMLSpanElement>(
+        ".exo-file-explorer-label"
+      );
+      expect(overlay?.textContent).toBe("Купить молоко");
+    });
+  });
+
+  describe("Finding 4 regression: empty metadataCache at enable() + resolved later", () => {
+    it("recovers when metadataCache is empty at enable() and fires resolved later", () => {
+      let metadataResolved = false;
+      mockApp.metadataCache.getFileCache = jest
+        .fn()
+        .mockImplementation((file: FakeTFileCtor) => {
+          if (!metadataResolved) return null;
+          const fm = FRONTMATTERS[file.path];
+          return fm ? { frontmatter: fm } : null;
+        });
+
+      const titleEl = createNavFileTitle(FILE_TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-label")).toBeNull();
+
+      metadataResolved = true;
+      const resolvedCb = mockApp.metadataCache.on.mock.calls.find(
+        (c: any[]) => c[0] === "resolved"
+      )?.[1];
+      expect(typeof resolvedCb).toBe("function");
+      resolvedCb();
+
+      const overlay = titleEl.querySelector<HTMLSpanElement>(
+        ".exo-file-explorer-label"
+      );
+      expect(overlay?.textContent).toBe("Купить молоко");
+    });
+  });
+
+  describe("stylesheet: overlay + hidden class rules present", () => {
+    it("styles.css contains .exo-file-explorer-label-hidden font-size:0 rule", () => {
+      const fs = require("fs");
+      const path = require("path");
+      const stylesPath = path.resolve(
+        __dirname,
+        "../../../../styles.css"
+      );
+      const css = fs.readFileSync(stylesPath, "utf8");
+
+      const hiddenMatch = css.match(
+        /\.nav-file-title-content\.exo-file-explorer-label-hidden\s*\{([^}]*)\}/
+      );
+      expect(hiddenMatch).toBeTruthy();
+      expect(hiddenMatch![1]).toMatch(/font-size:\s*0/);
+
+      const overlayMatch = css.match(
+        /\.nav-file-title-content \.exo-file-explorer-label\s*\{([^}]*)\}/
+      );
+      expect(overlayMatch).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `FileExplorerLabelPatch` — a span-overlay decorator that replaces raw UUID filenames in Obsidian's File Explorer sidebar with `exo__Asset_label` for Exocortex assets.
- Triggers only when frontmatter has both `exo__Instance_class` AND a non-empty `exo__Asset_label`. Non-Exocortex notes render normally.
- Mirrors `PropertiesLabelPatch`: span overlay + hidden-text CSS class (no text-node mutation), `MutationObserver`, `metadataCache.on("resolved")` listener for the fresh-vault / starter-kit-tarball install path.

Closes #2802.

Source: Ваня Холькин vault asset `37a88fda-74f3-4b26-bc93-8ebdac701c70`, 09:32 2026-04-12 — «Структура уродская, мне не нравится ))». v15.98.0 fixed the inline title (H1 body injection); this PR closes the remaining File Explorer sidebar gap.

## Implementation notes

- Registration point: after `PropertiesLabelPatch` in `ExocortexPlugin.onload()` with the same 500ms `timerManager` delay; cleanup wired in `onunload()`.
- Path → file lookup via `app.vault.getAbstractFileByPath(data-path)` → `metadataCache.getFileCache(file)` — no per-mutation full-vault scan.
- Overlay hidden via `.exo-file-explorer-label-hidden` (`font-size: 0 !important`) so it doesn't affect flow; label span inherits `--nav-item-size`.
- Idempotent: `data-exo-fe-label-patched` attr prevents double-overlay on repeated `patchAll()` calls.

## Test plan

- [x] New unit test: `packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerLabelPatch.test.ts` — 14 tests covering enable/disable lifecycle, span overlay, non-Exocortex passthrough, UUID-alt-basename identity skip, MutationObserver dynamic add, Finding 4 regression (empty cache → resolved later), stylesheet assertions via `fs.readFileSync` + regex.
- [x] `npm run test:unit` green locally.
- [x] `npm run build` green locally.
- [ ] CI 8 checks green.
- [ ] Autorelease ships ≥ v15.99.0.