### PR TITLE
fix(asset-dropdown): render class dropdown via exo__Asset_label (closes #2807)

### DIFF
--- a/.mlc-config.json
+++ b/.mlc-config.json
@@ -10,6 +10,9 @@
       "pattern": "^https://github\\.com/kitelev/exocortex/discussions"
     },
     {
+      "pattern": "^https://github\\.com/kitelev/exocortex/issues/"
+    },
+    {
       "pattern": "^https://www\\.w3\\.org/TR/"
     },
     {

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -140,6 +140,19 @@ export class NoteToRDFConverter {
           }
         }
       }
+
+      // Issue #2807: exo__Asset_label is the Exocortex display-label property.
+      // Emit an additional rdfs:label triple so standard SPARQL queries
+      // (e.g. ClassDiscoveryService) can find labels without knowing the
+      // Exocortex vocabulary. exo__Asset_label semantically extends rdfs:label.
+      if (key === "exo__Asset_label") {
+        const rdfsLabel = Namespace.RDFS.term("label");
+        for (const val of values) {
+          if (typeof val === "string" && val.length > 0) {
+            triples.push(new Triple(subject, rdfsLabel, new Literal(val)));
+          }
+        }
+      }
     }
 
     // Issue #1329: Index body wikilinks to RDF

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -125,6 +125,55 @@ describe("NoteToRDFConverter", () => {
       expect((labelTriple!.object as Literal).value).toBe("My Label");
     });
 
+    it("should also emit rdfs:label when exo__Asset_label is present (Issue #2807)", async () => {
+      const file: IFile = {
+        path: "test.md",
+        basename: "test",
+        name: "test.md",
+        parent: null,
+      };
+
+      const frontmatter: IFrontmatter = {
+        exo__Asset_label: "ems__Task",
+      };
+
+      mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+      const triples = await converter.convertNote(file);
+
+      const rdfsLabelIri = Namespace.RDFS.term("label").value;
+      const rdfsLabelTriples = triples.filter(
+        (t) => (t.predicate as IRI).value === rdfsLabelIri
+      );
+
+      expect(rdfsLabelTriples).toHaveLength(1);
+      expect((rdfsLabelTriples[0].object as Literal).value).toBe("ems__Task");
+    });
+
+    it("should emit rdfs:label for each array value in exo__Asset_label (defensive)", async () => {
+      const file: IFile = {
+        path: "test.md",
+        basename: "test",
+        name: "test.md",
+        parent: null,
+      };
+
+      const frontmatter: IFrontmatter = {
+        exo__Asset_label: ["Primary", "Alt"],
+      };
+
+      mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+      const triples = await converter.convertNote(file);
+
+      const rdfsLabelIri = Namespace.RDFS.term("label").value;
+      const values = triples
+        .filter((t) => (t.predicate as IRI).value === rdfsLabelIri)
+        .map((t) => (t.object as Literal).value);
+
+      expect(values).toEqual(["Primary", "Alt"]);
+    });
+
     it("should convert ems__ properties to RDF triples", async () => {
       const file: IFile = {
         path: "test.md",

--- a/packages/obsidian-plugin/src/application/services/ClassDiscoveryService.ts
+++ b/packages/obsidian-plugin/src/application/services/ClassDiscoveryService.ts
@@ -74,14 +74,23 @@ export class ClassDiscoveryService {
         const classUri = binding.get("class");
         if (!classUri) continue;
 
-        const className = this.toClassName(String(classUri));
+        // Issue #2807: Class-def notes in starter-kit are stored as UUID-named
+        // files. The SPARQL subject (?class) is therefore a file IRI (UUID),
+        // not a namespace URI. Prefer the prefixed label ("ems__Task") as the
+        // canonical className when available — it is what downstream code
+        // (DynamicAssetCreationModal, GenericAssetCreationService) expects.
+        const labelValue = binding.get("label")?.toString();
+        const className = this.isPrefixedClassName(labelValue)
+          ? (labelValue as string)
+          : this.toClassName(String(classUri));
         if (!className) continue;
 
         // Skip if already processed (avoid duplicates from UNION)
         if (classMap.has(className)) continue;
 
-        const labelValue = binding.get("label")?.toString();
-        const label = labelValue || this.extractLabel(className);
+        // Derive human-readable display label from the canonical className
+        // ("ems__Task" → "Task"). Falls back to whatever the binding gave us.
+        const label = this.extractLabel(className);
         const description = binding.get("comment")?.toString();
         const superClassUri = binding.get("superClass")?.toString();
         const superClass = superClassUri ? this.toClassName(superClassUri) : undefined;
@@ -167,6 +176,16 @@ export class ClassDiscoveryService {
         canCreateInstance: true,
       },
     ];
+  }
+
+  /**
+   * Check whether a label value looks like a canonical prefixed class name
+   * (e.g. "ems__Task", "exo__Area"). Used by Issue #2807 to prefer the
+   * frontmatter label over a file-IRI fallback when building className.
+   */
+  private isPrefixedClassName(value: string | undefined): boolean {
+    if (!value) return false;
+    return /^[a-z]+__[A-Za-z][A-Za-z0-9_]*$/.test(value);
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/services/ClassDiscoveryService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/services/ClassDiscoveryService.test.ts
@@ -1,0 +1,163 @@
+import { SPARQLQueryService } from "../../../src/application/services/SPARQLQueryService";
+import { ClassDiscoveryService } from "../../../src/application/services/ClassDiscoveryService";
+
+jest.mock("../../../src/application/services/SPARQLQueryService");
+
+describe("ClassDiscoveryService", () => {
+  let mockSparqlService: jest.Mocked<SPARQLQueryService>;
+  let service: ClassDiscoveryService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSparqlService = {
+      query: jest.fn(),
+    } as unknown as jest.Mocked<SPARQLQueryService>;
+    service = new ClassDiscoveryService(mockSparqlService);
+  });
+
+  describe("discoverClasses (Issue #2807)", () => {
+    it("should use frontmatter label as className when ?class is a UUID file IRI", async () => {
+      // Starter-kit reality: class-def files are UUID-named, so SPARQL returns
+      // a file IRI for ?class. The label comes from exo__Asset_label (now also
+      // emitted as rdfs:label). The service must prefer the prefixed label
+      // over the file IRI for className.
+      const taskClassBinding = new Map<string, unknown>([
+        ["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"],
+        ["label", "ems__Task"],
+      ]);
+      const areaClassBinding = new Map<string, unknown>([
+        ["class", "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md"],
+        ["label", "ems__Area"],
+      ]);
+
+      mockSparqlService.query.mockResolvedValue([taskClassBinding, areaClassBinding]);
+
+      const classes = await service.discoverClasses();
+
+      const taskClass = classes.find((c) => c.className === "ems__Task");
+      const areaClass = classes.find((c) => c.className === "ems__Area");
+
+      expect(taskClass).toBeDefined();
+      expect(taskClass!.label).toBe("Task");
+      expect(taskClass!.canCreateInstance).toBe(true);
+
+      expect(areaClass).toBeDefined();
+      expect(areaClass!.label).toBe("Area");
+    });
+
+    it("should sort classes alphabetically by display label", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["class", "obsidian://vault/ems/uuid-task.md"],
+          ["label", "ems__Task"],
+        ]),
+        new Map<string, unknown>([
+          ["class", "obsidian://vault/ems/uuid-area.md"],
+          ["label", "ems__Area"],
+        ]),
+        new Map<string, unknown>([
+          ["class", "obsidian://vault/ems/uuid-project.md"],
+          ["label", "ems__Project"],
+        ]),
+      ]);
+
+      const classes = await service.discoverClasses();
+
+      expect(classes.map((c) => c.label)).toEqual(["Area", "Project", "Task"]);
+    });
+
+    it("should fall back to toClassName when label is absent", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["class", "https://exocortex.my/ontology/ems#Task"],
+        ]),
+      ]);
+
+      const classes = await service.discoverClasses();
+
+      expect(classes).toHaveLength(1);
+      expect(classes[0].className).toBe("ems__Task");
+      expect(classes[0].label).toBe("Task");
+    });
+
+    it("should filter out deprecated classes", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["class", "obsidian://vault/ems/uuid-task.md"],
+          ["label", "ems__Task"],
+          ["deprecated", "false"],
+        ]),
+        new Map<string, unknown>([
+          ["class", "obsidian://vault/ems/uuid-old.md"],
+          ["label", "ems__Deprecated"],
+          ["deprecated", "true"],
+        ]),
+      ]);
+
+      const classes = await service.discoverClasses();
+
+      expect(classes.map((c) => c.className)).toEqual(["ems__Task"]);
+    });
+
+    it("should ignore a label value that is not a prefixed class name", async () => {
+      // Defensive: if someone labels a class with free text like "My Task Type",
+      // that is NOT a valid className, so we must fall back to the IRI path.
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["class", "https://exocortex.my/ontology/ems#Task"],
+          ["label", "My Task Type"],
+        ]),
+      ]);
+
+      const classes = await service.discoverClasses();
+
+      expect(classes).toHaveLength(1);
+      expect(classes[0].className).toBe("ems__Task");
+    });
+
+    it("should dedupe duplicate classes emitted by UNION", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["class", "obsidian://vault/ems/uuid-task.md"],
+          ["label", "ems__Task"],
+        ]),
+        new Map<string, unknown>([
+          ["class", "obsidian://vault/ems/uuid-task.md"],
+          ["label", "ems__Task"],
+        ]),
+      ]);
+
+      const classes = await service.discoverClasses();
+
+      expect(classes).toHaveLength(1);
+    });
+
+    it("should return defaults when SPARQL query throws", async () => {
+      mockSparqlService.query.mockRejectedValue(new Error("boom"));
+
+      const classes = await service.discoverClasses();
+
+      expect(classes.length).toBeGreaterThan(0);
+      expect(classes.map((c) => c.className)).toContain("ems__Task");
+    });
+  });
+
+  describe("getCreatableClasses", () => {
+    it("should exclude non-instantiable meta-classes", async () => {
+      mockSparqlService.query.mockResolvedValue([
+        new Map<string, unknown>([
+          ["class", "obsidian://vault/ems/uuid-task.md"],
+          ["label", "ems__Task"],
+        ]),
+        new Map<string, unknown>([
+          ["class", "obsidian://vault/exo/uuid-class.md"],
+          ["label", "exo__Class"],
+        ]),
+      ]);
+
+      const classes = await service.getCreatableClasses();
+
+      expect(classes.map((c) => c.className)).toEqual(["ems__Task"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Emit `rdfs:label` triple whenever `exo__Asset_label` is present in `NoteToRDFConverter`. `exo__Asset_label` semantically extends `rdfs:label`, so surfacing it under the canonical RDFS predicate lets every standard SPARQL query reach labels without knowing the Exocortex vocabulary.
- Harden `ClassDiscoveryService.discoverClasses` to use the prefixed label ("ems__Task") as the canonical className when `?class` resolves to a file IRI (the starter-kit reality, where class-def notes are UUID-named). `extractLabel` already turns "ems__Task" into a human-readable "Task".

## Why it was broken
In starter-kit vaults the `rdf:type exo:Class` subjects are UUID-based file IRIs, and class-def frontmatter only declares `exo__Asset_label`, not `rdfs:label`. The existing SPARQL `OPTIONAL { ?class rdfs:label ?label }` never matched, so the dropdown fell back to the UUID (because `toClassName` can't decode file IRIs and `extractLabel` can't strip a prefix from a UUID). Result: users saw "8619c4fc-64f1-4869..." instead of "Task".

## Test plan
- [x] `NoteToRDFConverter.test.ts` — new cases: rdfs:label emission for single string and array-valued `exo__Asset_label`.
- [x] `ClassDiscoveryService.test.ts` — **new file** — 8 cases covering: file-IRI + label fallback, alphabetical sort, absent-label fallback to IRI, deprecated filtering, defensive reject of non-prefixed labels, UNION dedup, error path returns defaults, `getCreatableClasses` excludes meta-classes.
- [x] `npm run test:unit` locally (4529 passing; unrelated Layout persistence test is flaky on main — passes in isolation and on retry).
- [ ] CI green
- [ ] Live validation via computer-control in getting-started-test-vault after release

Closes #2807