### PR TITLE
fix(inline-title): render exo__Asset_label as inline H1 (closes #2806)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -39,6 +39,7 @@ import { createAliasIconExtension, createWikilinkLabelExtension } from "./presen
 import { TimerManager } from "./infrastructure/timer";
 import { LRUCache } from "./infrastructure/cache";
 import { TabTitlePatch } from "./presentation/tab-titles/TabTitlePatch";
+import { InlineTitlePatch } from "./presentation/tab-titles/InlineTitlePatch";
 import { PropertiesLinkPatch } from "./presentation/properties/PropertiesLinkPatch";
 import { PropertiesUidCopyPatch } from "./presentation/properties/PropertiesUidCopyPatch";
 import { PropertiesLabelPatch } from "./presentation/properties/PropertiesLabelPatch";
@@ -85,6 +86,7 @@ export default class ExocortexPlugin extends Plugin {
   // MutationObserver to detect when layout is removed by Obsidian re-renders (e.g., when processing embeds)
   private layoutPersistenceObserver: MutationObserver | null = null;
   private tabTitlePatch!: TabTitlePatch;
+  private inlineTitlePatch!: InlineTitlePatch;
   private propertiesLinkPatch!: PropertiesLinkPatch;
   private bodyLinkPatch!: BodyLinkPatch;
   private propertiesUidCopyPatch!: PropertiesUidCopyPatch;
@@ -372,6 +374,15 @@ export default class ExocortexPlugin extends Plugin {
         }, 500);
       }
 
+      // Initialize Inline Title label patch (Issue #2806)
+      // Reuses the tab-title label toggle so both headers stay in sync.
+      this.inlineTitlePatch = new InlineTitlePatch(this);
+      if (this.settings.showLabelsInTabTitles) {
+        this.timerManager.setTimeout("inline-title-patch", () => {
+          this.inlineTitlePatch.enable();
+        }, 500);
+      }
+
       // Initialize Properties link patch
       this.propertiesLinkPatch = new PropertiesLinkPatch(this);
       if (this.settings.showLabelsInProperties) {
@@ -491,6 +502,11 @@ export default class ExocortexPlugin extends Plugin {
       this.tabTitlePatch.cleanup();
     }
 
+    // Cleanup Inline Title patch
+    if (this.inlineTitlePatch) {
+      this.inlineTitlePatch.cleanup();
+    }
+
     // Cleanup Properties link patch
     if (this.propertiesLinkPatch) {
       this.propertiesLinkPatch.cleanup();
@@ -587,8 +603,10 @@ export default class ExocortexPlugin extends Plugin {
   toggleTabTitleLabels(enabled: boolean): void {
     if (enabled) {
       this.tabTitlePatch.enable();
+      this.inlineTitlePatch?.enable();
     } else {
       this.tabTitlePatch.disable();
+      this.inlineTitlePatch?.disable();
     }
   }
 
@@ -638,6 +656,12 @@ export default class ExocortexPlugin extends Plugin {
     if (this.settings.showLabelsInTabTitles && this.tabTitlePatch) {
       this.tabTitlePatch.disable();
       this.tabTitlePatch.enable();
+    }
+
+    // Re-apply inline title labels with new template (Issue #2806)
+    if (this.settings.showLabelsInTabTitles && this.inlineTitlePatch) {
+      this.inlineTitlePatch.disable();
+      this.inlineTitlePatch.enable();
     }
 
     // Re-apply properties link labels with new template

--- a/packages/obsidian-plugin/src/presentation/tab-titles/InlineTitlePatch.ts
+++ b/packages/obsidian-plugin/src/presentation/tab-titles/InlineTitlePatch.ts
@@ -1,0 +1,231 @@
+import { TFile, WorkspaceLeaf, Plugin, CachedMetadata, MarkdownView } from "obsidian";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+import type { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
+
+/**
+ * InlineTitlePatch — rewrites the inline title (the big H1 Obsidian shows above
+ * the note body in Reading Mode and Live Preview) to display `exo__Asset_label`
+ * instead of the raw filename.
+ *
+ * For class-definition notes in the starter-kit (UUID-named files) this turns
+ * a header like "1b20a8f0-d745-4e93-91db-4531b3df120e" into "ems__Task". See
+ * issue #2806.
+ *
+ * Strategy:
+ * - Reuses `DisplayNameResolver` + `PrintNameRuleService` (same stack as
+ *   `TabTitlePatch`) so tab titles and inline titles stay in sync.
+ * - Hooks `active-leaf-change`, `layout-change`, and `metadataCache.changed`
+ *   to re-apply the label whenever Obsidian re-renders.
+ * - A per-leaf `MutationObserver` re-applies the label if Obsidian itself
+ *   writes into the `.inline-title` element (it does this on file open).
+ * - `disable()` restores the original text and disconnects all observers.
+ */
+interface PluginWithSettings extends Plugin {
+  settings: ExocortexSettings;
+  printNameRuleService?: PrintNameRuleService;
+}
+
+interface PatchedLeafState {
+  originalText: string | null;
+  observer: MutationObserver | null;
+}
+
+export class InlineTitlePatch {
+  private app: Plugin["app"];
+  private plugin: PluginWithSettings;
+  private enabled = false;
+  private patchedLeaves: WeakMap<WorkspaceLeaf, PatchedLeafState> = new WeakMap();
+  private metadataChangeHandler: (file: TFile, data: string, cache: CachedMetadata) => void;
+
+  constructor(plugin: Plugin) {
+    this.plugin = plugin as PluginWithSettings;
+    this.app = plugin.app;
+    this.metadataChangeHandler = this.handleMetadataChange.bind(this);
+  }
+
+  private getDisplayNameSettings(): DisplayNameSettings {
+    if (this.plugin.settings?.displayNameSettings) {
+      return this.plugin.settings.displayNameSettings;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional backwards compatibility
+    const template = this.plugin.settings?.displayNameTemplate || DEFAULT_DISPLAY_NAME_TEMPLATE;
+    return {
+      defaultTemplate: template,
+      classTemplates: {},
+    };
+  }
+
+  private createResolver(): DisplayNameResolver {
+    const ruleService = this.plugin.printNameRuleService ?? null;
+    const metadataResolver = ruleService?.createMetadataResolver() ?? null;
+    return new DisplayNameResolver(this.getDisplayNameSettings(), ruleService, metadataResolver);
+  }
+
+  enable(): void {
+    if (this.enabled) return;
+    this.enabled = true;
+
+    this.refreshAllLeaves();
+
+    this.plugin.registerEvent(
+      this.app.workspace.on("active-leaf-change", () => this.refreshAllLeaves())
+    );
+    this.plugin.registerEvent(
+      this.app.workspace.on("layout-change", () => this.refreshAllLeaves())
+    );
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("changed", this.metadataChangeHandler)
+    );
+  }
+
+  disable(): void {
+    if (!this.enabled) return;
+    this.enabled = false;
+    this.restoreAllLeaves();
+  }
+
+  cleanup(): void {
+    this.disable();
+  }
+
+  private refreshAllLeaves(): void {
+    if (!this.enabled) return;
+    if (typeof this.app.workspace.iterateAllLeaves !== "function") return;
+
+    this.app.workspace.iterateAllLeaves((leaf) => {
+      if (leaf.view instanceof MarkdownView) {
+        this.applyLabelToLeaf(leaf);
+      }
+    });
+  }
+
+  private findInlineTitleEls(leaf: WorkspaceLeaf): HTMLElement[] {
+    const view = leaf.view;
+    if (!(view instanceof MarkdownView)) return [];
+    const container = (view as unknown as { containerEl?: HTMLElement }).containerEl;
+    if (!container || typeof container.getElementsByClassName !== "function") return [];
+    const nodes = container.getElementsByClassName("inline-title");
+    const result: HTMLElement[] = [];
+    for (let i = 0; i < nodes.length; i += 1) {
+      const el = nodes.item(i);
+      if (el instanceof HTMLElement) result.push(el);
+    }
+    return result;
+  }
+
+  private applyLabelToLeaf(leaf: WorkspaceLeaf): void {
+    const view = leaf.view;
+    if (!(view instanceof MarkdownView)) return;
+    const file = view.file;
+    if (!file || !(file instanceof TFile) || file.extension !== "md") return;
+
+    const label = this.getAssetLabel(file);
+    if (!label) {
+      // No override for this file — leave Obsidian default intact.
+      return;
+    }
+
+    const inlineTitles = this.findInlineTitleEls(leaf);
+    if (inlineTitles.length === 0) return;
+
+    // Remember the original basename the first time we touch this leaf so
+    // disable() can restore it cleanly.
+    if (!this.patchedLeaves.has(leaf)) {
+      this.patchedLeaves.set(leaf, {
+        originalText: inlineTitles[0].textContent,
+        observer: null,
+      });
+    }
+
+    for (const el of inlineTitles) {
+      if (el.textContent !== label) {
+        el.textContent = label;
+      }
+    }
+
+    this.ensureObserver(leaf);
+  }
+
+  private ensureObserver(leaf: WorkspaceLeaf): void {
+    const state = this.patchedLeaves.get(leaf);
+    if (!state) return;
+    if (state.observer) return;
+    const view = leaf.view;
+    if (!(view instanceof MarkdownView)) return;
+    const container = (view as unknown as { containerEl?: HTMLElement }).containerEl;
+    if (!container || typeof MutationObserver === "undefined") return;
+
+    const observer = new MutationObserver(() => {
+      if (!this.enabled) return;
+      const file = view.file;
+      if (!file) return;
+      const currentLabel = this.getAssetLabel(file);
+      if (!currentLabel) return;
+      for (const el of this.findInlineTitleEls(leaf)) {
+        if (el.textContent !== currentLabel) {
+          el.textContent = currentLabel;
+        }
+      }
+    });
+    observer.observe(container, { childList: true, subtree: true, characterData: true });
+    state.observer = observer;
+  }
+
+  private getAssetLabel(file: TFile): string | null {
+    const cache = this.app.metadataCache.getFileCache(file);
+    const frontmatter = cache?.frontmatter;
+    if (!frontmatter) return null;
+
+    const metadata = { ...frontmatter };
+    const createdDate = file.stat?.ctime ? new Date(file.stat.ctime) : undefined;
+
+    const resolver = this.createResolver();
+    const displayName = resolver.resolve({
+      metadata,
+      basename: file.basename,
+      createdDate,
+    });
+    if (displayName) return displayName;
+
+    const label = frontmatter.exo__Asset_label;
+    if (label && typeof label === "string" && label.trim() !== "") {
+      return label.trim();
+    }
+    return null;
+  }
+
+  private handleMetadataChange(file: TFile): void {
+    if (!this.enabled) return;
+    if (file.extension !== "md") return;
+    if (typeof this.app.workspace.iterateAllLeaves !== "function") return;
+
+    this.app.workspace.iterateAllLeaves((leaf) => {
+      const view = leaf.view;
+      if (view instanceof MarkdownView && view.file?.path === file.path) {
+        this.applyLabelToLeaf(leaf);
+      }
+    });
+  }
+
+  private restoreAllLeaves(): void {
+    if (typeof this.app.workspace.iterateAllLeaves !== "function") return;
+
+    this.app.workspace.iterateAllLeaves((leaf) => {
+      const state = this.patchedLeaves.get(leaf);
+      if (!state) return;
+      if (state.observer) {
+        state.observer.disconnect();
+        state.observer = null;
+      }
+      for (const el of this.findInlineTitleEls(leaf)) {
+        if (state.originalText !== null) {
+          el.textContent = state.originalText;
+        }
+      }
+    });
+
+    this.patchedLeaves = new WeakMap();
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/tab-titles/InlineTitlePatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/tab-titles/InlineTitlePatch.test.ts
@@ -1,0 +1,170 @@
+import { InlineTitlePatch } from "../../../../src/presentation/tab-titles/InlineTitlePatch";
+import { TFile, WorkspaceLeaf, Plugin, MarkdownView } from "obsidian";
+
+describe("InlineTitlePatch (Issue #2806)", () => {
+  let patch: InlineTitlePatch;
+  let mockPlugin: any;
+  let mockApp: any;
+  let mockWorkspaceLeaf: any;
+  let mockMarkdownView: any;
+  let inlineTitleEl: HTMLElement;
+  let containerEl: HTMLElement;
+
+  beforeEach(() => {
+    containerEl = document.createElement("div");
+    inlineTitleEl = document.createElement("div");
+    inlineTitleEl.className = "inline-title";
+    inlineTitleEl.textContent = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+    containerEl.appendChild(inlineTitleEl);
+
+    mockMarkdownView = {
+      file: null,
+      containerEl,
+    };
+    Object.setPrototypeOf(mockMarkdownView, MarkdownView.prototype);
+
+    mockWorkspaceLeaf = {
+      view: mockMarkdownView,
+    };
+
+    mockApp = {
+      workspace: {
+        iterateAllLeaves: jest.fn((callback: (leaf: WorkspaceLeaf) => void) => {
+          callback(mockWorkspaceLeaf);
+        }),
+        on: jest.fn().mockReturnValue({ id: "test" }),
+      },
+      metadataCache: {
+        getFileCache: jest.fn(),
+        on: jest.fn().mockReturnValue({ id: "test" }),
+      },
+    };
+
+    mockPlugin = {
+      app: mockApp,
+      registerEvent: jest.fn(),
+      settings: {},
+    };
+
+    patch = new InlineTitlePatch(mockPlugin);
+  });
+
+  afterEach(() => {
+    patch.cleanup();
+    jest.clearAllMocks();
+  });
+
+  describe("enable", () => {
+    it("should register workspace and metadata events", () => {
+      patch.enable();
+
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        "active-leaf-change",
+        expect.any(Function)
+      );
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        "layout-change",
+        expect.any(Function)
+      );
+      expect(mockApp.metadataCache.on).toHaveBeenCalledWith(
+        "changed",
+        expect.any(Function)
+      );
+    });
+
+    it("should replace inline title with exo__Asset_label", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", {
+        value: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+      });
+      mockMarkdownView.file = mockFile;
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_label: "ems__Task",
+        },
+      });
+
+      patch.enable();
+
+      expect(inlineTitleEl.textContent).toBe("ems__Task");
+    });
+
+    it("should not touch inline title when frontmatter has no label", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "Untitled" });
+      mockMarkdownView.file = mockFile;
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({ frontmatter: {} });
+
+      patch.enable();
+
+      expect(inlineTitleEl.textContent).toBe(
+        "1b20a8f0-d745-4e93-91db-4531b3df120e"
+      );
+    });
+
+    it("should not double-enable", () => {
+      patch.enable();
+      patch.enable();
+
+      expect(mockPlugin.registerEvent).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("disable", () => {
+    it("should restore original inline title text", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "md" });
+      Object.defineProperty(mockFile, "basename", { value: "1b20a8f0" });
+      mockMarkdownView.file = mockFile;
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "Test" },
+      });
+
+      patch.enable();
+      expect(inlineTitleEl.textContent).toBe("Test");
+
+      patch.disable();
+      expect(inlineTitleEl.textContent).toBe(
+        "1b20a8f0-d745-4e93-91db-4531b3df120e"
+      );
+    });
+
+    it("should not throw when disabling without enabling", () => {
+      expect(() => patch.disable()).not.toThrow();
+    });
+  });
+
+  describe("non-markdown views", () => {
+    it("should ignore non-MarkdownView leaves", () => {
+      const nonMdLeaf = { view: {} } as WorkspaceLeaf;
+      mockApp.workspace.iterateAllLeaves = jest.fn(
+        (cb: (leaf: WorkspaceLeaf) => void) => cb(nonMdLeaf)
+      );
+
+      expect(() => patch.enable()).not.toThrow();
+    });
+  });
+
+  describe("files without extension md", () => {
+    it("should skip non-md files", () => {
+      const mockFile = new TFile();
+      Object.defineProperty(mockFile, "extension", { value: "canvas" });
+      Object.defineProperty(mockFile, "basename", { value: "my-canvas" });
+      mockMarkdownView.file = mockFile;
+
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { exo__Asset_label: "Should Not Apply" },
+      });
+
+      patch.enable();
+      expect(inlineTitleEl.textContent).toBe(
+        "1b20a8f0-d745-4e93-91db-4531b3df120e"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `InlineTitlePatch` rewrites Obsidian's `.inline-title` element (the big H1 shown above the note body in Reading Mode and Live Preview) to display `exo__Asset_label` instead of the raw basename.
- Mirrors `TabTitlePatch` architecture and reuses `DisplayNameResolver` / `PrintNameRuleService`, so tab and inline titles honour the same per-class display templates.
- Gated by the existing `showLabelsInTabTitles` setting — one toggle keeps both headers in sync, no new user-facing setting.

## Why it was broken
Class-definition notes in the starter-kit are UUID-named files, so the inline title rendered the raw UUID ("1b20a8f0-d745-4e93-91db-4531b3df120e"). The tab title was already patched, but the inline header inside the reading view wasn't, giving a schizophrenic experience where the tab said "Task" and the body said the UUID.

## Implementation notes
- Workspace events (`active-leaf-change`, `layout-change`) + `metadataCache.changed` re-apply labels on re-render.
- A per-leaf `MutationObserver` re-applies the label when Obsidian itself writes into `.inline-title` on file open.
- `disable()` restores the original basename text and disconnects observers; `WeakMap` stores per-leaf state so GC handles leaf teardown.
- `getElementsByClassName` + `instanceof HTMLElement` is used instead of `querySelectorAll` (repo ESLint rule).

## Test plan
- [x] `InlineTitlePatch.test.ts` (new) — 8 cases: event registration, happy-path label replacement, frontmatter absence, non-markdown views, non-md extensions, disable restores original, double-enable guard.
- [x] `npm run test:unit` locally green (77 suites, 1244 passing).
- [ ] CI green
- [ ] Live validation via computer-control after release

Closes #2806