### PR TITLE
fix(relations): resolve Asset Relations for UUID-referenced files (#2811)

### DIFF
--- a/packages/obsidian-plugin/src/adapters/caching/BacklinksCacheManager.ts
+++ b/packages/obsidian-plugin/src/adapters/caching/BacklinksCacheManager.ts
@@ -131,16 +131,50 @@ export class BacklinksCacheManager {
     for (const sourcePath in resolvedLinks) {
       const links = resolvedLinks[sourcePath];
       for (const targetPath in links) {
-        const existingBacklinks = this.backlinksCache.get(targetPath);
-        if (!existingBacklinks) {
-          this.backlinksCache.set(targetPath, new Set([sourcePath]));
-        } else {
-          existingBacklinks.add(sourcePath);
-        }
+        this.addBacklink(targetPath, sourcePath);
       }
     }
 
+    // Resolve unresolved links via UID→path mapping.
+    // When files use human-readable filenames but wikilinks reference by UUID
+    // (e.g. [[uuid|alias]]), Obsidian can't resolve the link → 0 backlinks.
+    // Build a UID→path index and use unresolvedLinks to recover these backlinks.
+    this.resolveUidBacklinks();
+
     this.cacheValid = true;
+  }
+
+  private resolveUidBacklinks(): void {
+    const uidToPath = new Map<string, string>();
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const cache = this.app.metadataCache.getFileCache(file);
+      const uid = cache?.frontmatter?.exo__Asset_uid;
+      if (uid && typeof uid === "string") {
+        uidToPath.set(uid, file.path);
+      }
+    }
+
+    if (uidToPath.size === 0) return;
+
+    const unresolvedLinks = this.app.metadataCache.unresolvedLinks;
+    for (const sourcePath in unresolvedLinks) {
+      const links = unresolvedLinks[sourcePath];
+      for (const linkTarget in links) {
+        const resolvedPath = uidToPath.get(linkTarget);
+        if (resolvedPath) {
+          this.addBacklink(resolvedPath, sourcePath);
+        }
+      }
+    }
+  }
+
+  private addBacklink(targetPath: string, sourcePath: string): void {
+    const existing = this.backlinksCache.get(targetPath);
+    if (!existing) {
+      this.backlinksCache.set(targetPath, new Set([sourcePath]));
+    } else {
+      existing.add(sourcePath);
+    }
   }
 
   invalidate(): void {

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -47,8 +47,19 @@ export class RelationsRenderer {
 
         const isArchived = MetadataHelpers.isAssetArchived(metadata);
 
-        const referencingProperties =
+        // Match by basename first; also match by UID for files where
+        // the filename doesn't equal the UUID (e.g. human-readable names).
+        let referencingProperties =
           MetadataHelpers.findAllReferencingProperties(metadata, file.basename);
+
+        if (referencingProperties.length === 0) {
+          const targetFm = this.vaultAdapter.getFrontmatter(file as unknown as IFile);
+          const uid = targetFm?.exo__Asset_uid;
+          if (uid && typeof uid === "string") {
+            referencingProperties =
+              MetadataHelpers.findAllReferencingProperties(metadata, uid);
+          }
+        }
 
         const enrichedMetadata = { ...metadata };
         const resolvedLabel = this.metadataService.getAssetLabel(sourcePath);

--- a/packages/obsidian-plugin/tests/unit/BacklinksCacheManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/BacklinksCacheManager.test.ts
@@ -37,8 +37,11 @@ describe("BacklinksCacheManager", () => {
     mockApp = {
       metadataCache: {
         resolvedLinks: mockResolvedLinks,
+        unresolvedLinks: {},
+        getFileCache: jest.fn().mockReturnValue({ frontmatter: {} }),
       },
       vault: {
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
         on: jest.fn((eventType: string, handler: (file: any, oldPath?: string) => void) => {
           if (!mockEventHandlers.has(eventType)) {
             mockEventHandlers.set(eventType, []);
@@ -329,6 +332,138 @@ describe("BacklinksCacheManager", () => {
       expect(cacheManager.isValid()).toBe(false);
       cacheManager.buildCache();
       expect(cacheManager.isValid()).toBe(true);
+    });
+  });
+
+  describe("UID-based backlink resolution", () => {
+    it("should resolve unresolved links via UID→path mapping", () => {
+      // Area file has human-readable name but UID in frontmatter
+      const areaFile = Object.assign(Object.create(TFile.prototype), {
+        path: "01 Inbox/Hello Area.md",
+        basename: "Hello Area",
+        extension: "md",
+      });
+
+      // Project file references Area by UUID in frontmatter
+      const projectFile = Object.assign(Object.create(TFile.prototype), {
+        path: "01 Inbox/Build my first project.md",
+        basename: "Build my first project",
+        extension: "md",
+      });
+
+      (mockApp.vault as any).getMarkdownFiles = jest.fn().mockReturnValue([areaFile, projectFile]);
+      (mockApp.metadataCache as any).getFileCache = jest.fn().mockImplementation((file: TFile) => {
+        if (file.path === areaFile.path) {
+          return { frontmatter: { exo__Asset_uid: "723b5de3-3047-41d9-a3dc-ea96ba28a5f1" } };
+        }
+        if (file.path === projectFile.path) {
+          return { frontmatter: { exo__Asset_uid: "00d0631d-56c7-4e4b-b98a-fc0b908e6bc9" } };
+        }
+        return { frontmatter: {} };
+      });
+
+      // Project links to Area by UUID → unresolved because file is "Hello Area.md"
+      (mockApp.metadataCache as any).unresolvedLinks = {
+        "01 Inbox/Build my first project.md": {
+          "723b5de3-3047-41d9-a3dc-ea96ba28a5f1": 1,
+        },
+      };
+
+      // No resolved links between these files
+      mockApp.metadataCache.resolvedLinks = {};
+
+      cacheManager.buildCache();
+
+      const areaBacklinks = cacheManager.getBacklinks("01 Inbox/Hello Area.md");
+      expect(areaBacklinks).toBeDefined();
+      expect(areaBacklinks?.has("01 Inbox/Build my first project.md")).toBe(true);
+    });
+
+    it("should combine resolved and UID-based backlinks", () => {
+      const targetFile = Object.assign(Object.create(TFile.prototype), {
+        path: "01 Inbox/Target.md",
+        basename: "Target",
+        extension: "md",
+      });
+
+      (mockApp.vault as any).getMarkdownFiles = jest.fn().mockReturnValue([targetFile]);
+      (mockApp.metadataCache as any).getFileCache = jest.fn().mockReturnValue({
+        frontmatter: { exo__Asset_uid: "uid-123" },
+      });
+      (mockApp.metadataCache as any).unresolvedLinks = {
+        "source-by-uid.md": { "uid-123": 1 },
+      };
+
+      mockApp.metadataCache.resolvedLinks = {
+        "source-by-name.md": { "01 Inbox/Target.md": 1 },
+      };
+
+      cacheManager.buildCache();
+
+      const backlinks = cacheManager.getBacklinks("01 Inbox/Target.md");
+      expect(backlinks).toBeDefined();
+      expect(backlinks?.size).toBe(2);
+      expect(backlinks?.has("source-by-name.md")).toBe(true);
+      expect(backlinks?.has("source-by-uid.md")).toBe(true);
+    });
+
+    it("should not fail when vault has no files with UIDs", () => {
+      (mockApp.vault as any).getMarkdownFiles = jest.fn().mockReturnValue([]);
+      (mockApp.metadataCache as any).getFileCache = jest.fn().mockReturnValue({ frontmatter: {} });
+      (mockApp.metadataCache as any).unresolvedLinks = {
+        "source.md": { "non-existent-uid": 1 },
+      };
+      mockApp.metadataCache.resolvedLinks = {};
+
+      expect(() => cacheManager.buildCache()).not.toThrow();
+      expect(cacheManager.isValid()).toBe(true);
+    });
+
+    it("should skip files without exo__Asset_uid", () => {
+      const fileNoUid = Object.assign(Object.create(TFile.prototype), {
+        path: "no-uid.md",
+        basename: "no-uid",
+        extension: "md",
+      });
+
+      (mockApp.vault as any).getMarkdownFiles = jest.fn().mockReturnValue([fileNoUid]);
+      (mockApp.metadataCache as any).getFileCache = jest.fn().mockReturnValue({
+        frontmatter: { some_property: "value" },
+      });
+      (mockApp.metadataCache as any).unresolvedLinks = {
+        "source.md": { "some-uid": 1 },
+      };
+      mockApp.metadataCache.resolvedLinks = {};
+
+      cacheManager.buildCache();
+
+      expect(cacheManager.getBacklinks("no-uid.md")).toBeUndefined();
+    });
+
+    it("should not duplicate backlinks from UID resolution", () => {
+      const targetFile = Object.assign(Object.create(TFile.prototype), {
+        path: "target.md",
+        basename: "target",
+        extension: "md",
+      });
+
+      (mockApp.vault as any).getMarkdownFiles = jest.fn().mockReturnValue([targetFile]);
+      (mockApp.metadataCache as any).getFileCache = jest.fn().mockReturnValue({
+        frontmatter: { exo__Asset_uid: "uid-123" },
+      });
+      (mockApp.metadataCache as any).unresolvedLinks = {
+        "source.md": { "uid-123": 1 },
+      };
+
+      // source.md also has a resolved link to target.md
+      mockApp.metadataCache.resolvedLinks = {
+        "source.md": { "target.md": 1 },
+      };
+
+      cacheManager.buildCache();
+
+      const backlinks = cacheManager.getBacklinks("target.md");
+      expect(backlinks?.size).toBe(1); // No duplicates
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -376,6 +376,93 @@ describe("RelationsRenderer", () => {
       });
     });
 
+    describe("when referencing by UID (human-readable filenames)", () => {
+      let sourceFile: any;
+      let sourceMetadata: any;
+
+      beforeEach(() => {
+        sourceFile = createTestTFile("source/project.md");
+        sourceMetadata = createMockMetadata({
+          ems__Effort_parent: "[[uid-of-area|Hello Area]]",
+        });
+
+        mockBacklinksCacheManager.getBacklinks.mockReturnValue([sourceFile.path]);
+        mockVaultAdapter.getAbstractFileByPath.mockReturnValue(sourceFile);
+        mockVaultAdapter.getFrontmatter.mockImplementation((file: any) => {
+          if (file.path === mockFile.path || file === mockFile) {
+            return { exo__Asset_uid: "uid-of-target" };
+          }
+          return sourceMetadata;
+        });
+        MetadataHelpers.isAssetArchived.mockReturnValue(false);
+        BlockerHelpers.isEffortBlocked.mockReturnValue(false);
+        mockMetadataService.getAssetLabel.mockReturnValue(null);
+      });
+
+      it("should match by UID when basename match fails", async () => {
+        // First call with basename returns nothing
+        MetadataHelpers.findAllReferencingProperties.mockReturnValueOnce([]);
+        // Second call with UID returns property
+        MetadataHelpers.findAllReferencingProperties.mockReturnValueOnce(["ems__Effort_parent"]);
+
+        const result = await renderer.getAssetRelations(mockFile, {});
+
+        expect(MetadataHelpers.findAllReferencingProperties).toHaveBeenCalledTimes(2);
+        expect(MetadataHelpers.findAllReferencingProperties).toHaveBeenCalledWith(
+          expect.anything(), "target-file"
+        );
+        expect(MetadataHelpers.findAllReferencingProperties).toHaveBeenCalledWith(
+          expect.anything(), "uid-of-target"
+        );
+        expect(result).toHaveLength(1);
+        expect(result[0].propertyName).toBe("ems__Effort_parent");
+        expect(result[0].isBodyLink).toBe(false);
+      });
+
+      it("should not check UID when basename match succeeds", async () => {
+        MetadataHelpers.findAllReferencingProperties.mockReturnValue(["ems__Effort_parent"]);
+
+        await renderer.getAssetRelations(mockFile, {});
+
+        // Should only be called once (with basename)
+        expect(MetadataHelpers.findAllReferencingProperties).toHaveBeenCalledTimes(1);
+      });
+
+      it("should create body link when neither basename nor UID match", async () => {
+        mockVaultAdapter.getFrontmatter.mockImplementation((file: any) => {
+          if (file.path === mockFile.path || file === mockFile) {
+            return { exo__Asset_uid: "uid-of-target" };
+          }
+          return sourceMetadata;
+        });
+
+        MetadataHelpers.findAllReferencingProperties.mockReturnValue([]);
+
+        const result = await renderer.getAssetRelations(mockFile, {});
+
+        expect(result).toHaveLength(1);
+        expect(result[0].isBodyLink).toBe(true);
+      });
+
+      it("should handle target file with no UID gracefully", async () => {
+        mockVaultAdapter.getFrontmatter.mockImplementation((file: any) => {
+          if (file.path === mockFile.path || file === mockFile) {
+            return {}; // No UID
+          }
+          return sourceMetadata;
+        });
+
+        MetadataHelpers.findAllReferencingProperties.mockReturnValue([]);
+
+        const result = await renderer.getAssetRelations(mockFile, {});
+
+        // Should create body link, only called once (no UID fallback)
+        expect(MetadataHelpers.findAllReferencingProperties).toHaveBeenCalledTimes(1);
+        expect(result).toHaveLength(1);
+        expect(result[0].isBodyLink).toBe(true);
+      });
+    });
+
     describe("when multiple backlinks exist", () => {
       it("should process all backlinks", async () => {
         const file1 = createTestTFile("source/file1.md");


### PR DESCRIPTION
## Summary

- **BacklinksCacheManager**: now resolves unresolved wikilinks via UID→path mapping. When files use human-readable filenames but are referenced by `[[UUID|alias]]` in frontmatter, Obsidian puts these in `unresolvedLinks` instead of `resolvedLinks`. The cache now builds a UID→path index and recovers these as proper backlinks.
- **RelationsRenderer**: falls back to matching by `exo__Asset_uid` when `findAllReferencingProperties(metadata, file.basename)` returns nothing, so property-based relation grouping works for UUID-referenced files.

Closes #2811

## Root Cause

Seed files in the Getting Started vault use human-readable filenames (`Hello Area.md`, `Build my first project.md`) but wikilinks reference by UUID (`[[723b5de3-...|Hello Area]]`). Obsidian can't resolve UUID to a file with a different basename → `metadataCache.resolvedLinks` is empty → `BacklinksCacheManager` returns 0 backlinks → Asset Relations panel is absent.

## Test plan

- [x] 66 BacklinksCacheManager unit tests pass (5 new for UID resolution)
- [x] 60 RelationsRenderer unit tests pass (4 new for UID fallback)
- [x] `npm run test:all` passes (unit + component + BDD + archgate)
- [ ] Live-verify in Obsidian: Area shows child Project, Project shows parent Area + child Tasks