### PR TITLE
feat(plugin): RFC-024 Phase 0 — built-in defaults + changelog modal

### DIFF
--- a/.archgate/adrs/DOC-001-documentation-consistency.rules.ts
+++ b/.archgate/adrs/DOC-001-documentation-consistency.rules.ts
@@ -142,4 +142,4 @@ export default {
       },
     },
   },
-};
+} satisfies RuleSet;

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -35,7 +35,14 @@ import { SPARQLApi } from "./application/api/SPARQLApi";
 import { ExocortexAPI } from "./application/api/ExocortexAPI";
 import { PluginContainer } from "./infrastructure/di/PluginContainer";
 import { ObsidianNotificationService } from "./infrastructure/di/ObsidianNotificationService";
-import { createAliasIconExtension, createWikilinkLabelExtension } from "./presentation/editor-extensions";
+import {
+  createAliasIconExtension,
+  createWikilinkLabelExtension,
+} from "./presentation/editor-extensions";
+import {
+  ChangelogModal,
+  shouldShowChangelog,
+} from "./presentation/modals/ChangelogModal";
 import { TimerManager } from "./infrastructure/timer";
 import { LRUCache } from "./infrastructure/cache";
 import { TabTitlePatch } from "./presentation/tab-titles/TabTitlePatch";
@@ -125,7 +132,7 @@ export default class ExocortexPlugin extends Plugin {
       this.registerEvent(
         this.app.metadataCache.on("changed", () => {
           this.printNameRuleService.refresh();
-        })
+        }),
       );
 
       this.vaultAdapter = new ObsidianVaultAdapter(
@@ -147,7 +154,11 @@ export default class ExocortexPlugin extends Plugin {
       this.preconditionEvaluator = new PreconditionEvaluator(tripleStore);
       this.serviceRegistry = new ServiceRegistry();
       const obsidianFs = new ObsidianFileSystemAdapter(this.app.vault);
-      this.groundingExecutor = new GroundingExecutor(obsidianFs, obsidianFs, this.serviceRegistry);
+      this.groundingExecutor = new GroundingExecutor(
+        obsidianFs,
+        obsidianFs,
+        this.serviceRegistry,
+      );
 
       populateServiceRegistry(this.serviceRegistry, {
         app: this.app,
@@ -172,11 +183,11 @@ export default class ExocortexPlugin extends Plugin {
       this.taskTrackingService = new TaskTrackingService(
         this.app,
         this.app.vault,
-        this.app.metadataCache
+        this.app.metadataCache,
       );
       this.aliasSyncService = new AliasSyncService(
         this.app.metadataCache,
-        this.app
+        this.app,
       );
       this.wikilinkAliasService = new WikilinkAliasService(
         this.app,
@@ -223,19 +234,16 @@ export default class ExocortexPlugin extends Plugin {
 
       this.addSettingTab(new ExocortexSettingTab(this.app, this));
 
-      this.registerMarkdownCodeBlockProcessor(
-        "sparql",
-        (source, el, ctx) => this.sparqlProcessor.process(source, el, ctx)
+      this.registerMarkdownCodeBlockProcessor("sparql", (source, el, ctx) =>
+        this.sparqlProcessor.process(source, el, ctx),
       );
 
-      this.registerMarkdownCodeBlockProcessor(
-        "exoql",
-        (source, el, ctx) => this.sparqlProcessor.process(source, el, ctx)
+      this.registerMarkdownCodeBlockProcessor("exoql", (source, el, ctx) =>
+        this.sparqlProcessor.process(source, el, ctx),
       );
 
-      this.registerMarkdownCodeBlockProcessor(
-        "exo-layout",
-        (source, el, ctx) => this.layoutProcessor.process(source, el, ctx)
+      this.registerMarkdownCodeBlockProcessor("exo-layout", (source, el, ctx) =>
+        this.layoutProcessor.process(source, el, ctx),
       );
 
       // Issue #2780: Re-index triple store once metadataCache has fully resolved.
@@ -320,27 +328,43 @@ export default class ExocortexPlugin extends Plugin {
       this.registerEvent(
         this.app.workspace.on("file-open", (file) => {
           if (file) {
-            this.timerManager.setTimeout("auto-layout-file-open", () => this.autoRenderLayout(), 150);
+            this.timerManager.setTimeout(
+              "auto-layout-file-open",
+              () => this.autoRenderLayout(),
+              150,
+            );
           }
         }),
       );
 
       this.registerEvent(
         this.app.workspace.on("active-leaf-change", () => {
-          this.timerManager.setTimeout("auto-layout-leaf-change", () => this.autoRenderLayout(), 150);
+          this.timerManager.setTimeout(
+            "auto-layout-leaf-change",
+            () => this.autoRenderLayout(),
+            150,
+          );
         }),
       );
 
       this.registerEvent(
         this.app.workspace.on("layout-change", () => {
-          this.timerManager.setTimeout("auto-layout-change", () => this.autoRenderLayout(), 150);
+          this.timerManager.setTimeout(
+            "auto-layout-change",
+            () => this.autoRenderLayout(),
+            150,
+          );
         }),
       );
 
       // Initial render
       const activeFile = this.app.workspace.getActiveFile();
       if (activeFile) {
-        this.timerManager.setTimeout("auto-layout-initial", () => this.autoRenderLayout(), 150);
+        this.timerManager.setTimeout(
+          "auto-layout-initial",
+          () => this.autoRenderLayout(),
+          150,
+        );
       }
 
       // RFC-009: Eagerly initialize triple store after vault is ready.
@@ -354,14 +378,21 @@ export default class ExocortexPlugin extends Plugin {
       // because their frontmatter wasn't parsed in time. See issue #2780.
       this.eagerInitPromise = new Promise<void>((resolve) => {
         this.app.workspace.onLayoutReady(() => {
-          void this.sparql.query("ASK { ?s ?p ?o }").then(() => {
-            this.commandResolver.invalidateCache();
-            this.autoRenderLayout();
-          }).catch((err) => {
-            this.logger.error("Failed to eagerly initialize triple store", err);
-          }).finally(() => {
-            resolve();
-          });
+          void this.sparql
+            .query("ASK { ?s ?p ?o }")
+            .then(() => {
+              this.commandResolver.invalidateCache();
+              this.autoRenderLayout();
+            })
+            .catch((err) => {
+              this.logger.error(
+                "Failed to eagerly initialize triple store",
+                err,
+              );
+            })
+            .finally(() => {
+              resolve();
+            });
         });
       });
 
@@ -369,42 +400,62 @@ export default class ExocortexPlugin extends Plugin {
       this.tabTitlePatch = new TabTitlePatch(this);
       if (this.settings.showLabelsInTabTitles) {
         // Delay enabling to ensure workspace is fully loaded
-        this.timerManager.setTimeout("tab-title-patch", () => {
-          this.tabTitlePatch.enable();
-        }, 500);
+        this.timerManager.setTimeout(
+          "tab-title-patch",
+          () => {
+            this.tabTitlePatch.enable();
+          },
+          500,
+        );
       }
 
       // Initialize Inline Title label patch (Issue #2806)
       // Reuses the tab-title label toggle so both headers stay in sync.
       this.inlineTitlePatch = new InlineTitlePatch(this);
       if (this.settings.showLabelsInTabTitles) {
-        this.timerManager.setTimeout("inline-title-patch", () => {
-          this.inlineTitlePatch.enable();
-        }, 500);
+        this.timerManager.setTimeout(
+          "inline-title-patch",
+          () => {
+            this.inlineTitlePatch.enable();
+          },
+          500,
+        );
       }
 
       // Initialize Properties link patch
       this.propertiesLinkPatch = new PropertiesLinkPatch(this);
       if (this.settings.showLabelsInProperties) {
         // Delay enabling to ensure Properties block is fully loaded
-        this.timerManager.setTimeout("properties-link-patch", () => {
-          this.propertiesLinkPatch.enable();
-        }, 500);
+        this.timerManager.setTimeout(
+          "properties-link-patch",
+          () => {
+            this.propertiesLinkPatch.enable();
+          },
+          500,
+        );
       }
 
       // Initialize Properties UID copy button patch (always enabled)
       this.propertiesUidCopyPatch = new PropertiesUidCopyPatch(this, notifier);
-      this.timerManager.setTimeout("properties-uid-copy-patch", () => {
-        this.propertiesUidCopyPatch.enable();
-      }, 500);
+      this.timerManager.setTimeout(
+        "properties-uid-copy-patch",
+        () => {
+          this.propertiesUidCopyPatch.enable();
+        },
+        500,
+      );
 
       // Initialize Properties readable-label patch (always enabled)
       // Replaces raw predicate names (e.g. ems__Effort_area) with human-readable
       // labels resolved from property definition assets' exo__Asset_label.
       this.propertiesLabelPatch = new PropertiesLabelPatch(this);
-      this.timerManager.setTimeout("properties-label-patch", () => {
-        this.propertiesLabelPatch.enable();
-      }, 500);
+      this.timerManager.setTimeout(
+        "properties-label-patch",
+        () => {
+          this.propertiesLabelPatch.enable();
+        },
+        500,
+      );
 
       // Initialize File Explorer readable-label patch (always enabled).
       // Replaces UUID filenames in the sidebar with `exo__Asset_label`.
@@ -412,9 +463,13 @@ export default class ExocortexPlugin extends Plugin {
       // File Explorer still showed bare UUIDs after v15.98.0 fixed inline title.
       // Issue #2802.
       this.fileExplorerLabelPatch = new FileExplorerLabelPatch(this);
-      this.timerManager.setTimeout("file-explorer-label-patch", () => {
-        this.fileExplorerLabelPatch.enable();
-      }, 500);
+      this.timerManager.setTimeout(
+        "file-explorer-label-patch",
+        () => {
+          this.fileExplorerLabelPatch.enable();
+        },
+        500,
+      );
 
       // Initialize Reading Mode enforcer.
       // Obsidian's layout rendering path is Reading Mode only; new leaves open
@@ -424,27 +479,66 @@ export default class ExocortexPlugin extends Plugin {
       // Finding 9, UX audit 2026-04-14.
       this.readingModeEnforcer = new ReadingModeEnforcer(this);
       if (this.settings.autoReadingModeForExocortexAssets) {
-        this.timerManager.setTimeout("reading-mode-enforcer", () => {
-          this.readingModeEnforcer.enable();
-        }, 500);
+        this.timerManager.setTimeout(
+          "reading-mode-enforcer",
+          () => {
+            this.readingModeEnforcer.enable();
+          },
+          500,
+        );
       }
 
       // Initialize Body link patch
       this.bodyLinkPatch = new BodyLinkPatch(this);
       if (this.settings.showLabelsInBody) {
         // Delay enabling to ensure markdown body is fully loaded
-        this.timerManager.setTimeout("body-link-patch", () => {
-          this.bodyLinkPatch.enable();
-        }, 500);
+        this.timerManager.setTimeout(
+          "body-link-patch",
+          () => {
+            this.bodyLinkPatch.enable();
+          },
+          500,
+        );
       }
 
       // Initialize Graph View label patch
       this.graphViewPatch = new GraphViewPatch(this);
       if (this.settings.showLabelsInGraphView) {
         // Delay enabling to ensure Graph View is fully loaded
-        this.timerManager.setTimeout("graph-view-patch", () => {
-          this.graphViewPatch.enable();
-        }, 500);
+        this.timerManager.setTimeout(
+          "graph-view-patch",
+          () => {
+            this.graphViewPatch.enable();
+          },
+          500,
+        );
+      }
+
+      // RFC-024 Phase 0: first-launch-after-upgrade changelog modal.
+      // Delayed 500ms so Obsidian's own modal stack has settled and the
+      // workspace is interactive before we surface a dialog.
+      const currentVersion = this.manifest.version;
+      if (
+        shouldShowChangelog(
+          this.settings.lastShownChangelogVersion,
+          currentVersion,
+        )
+      ) {
+        this.timerManager.setTimeout(
+          "rfc024-changelog-modal",
+          () => {
+            const modal = new ChangelogModal(
+              this.app,
+              currentVersion,
+              (version) => {
+                this.settings.lastShownChangelogVersion = version;
+                void this.saveSettings();
+              },
+            );
+            modal.open();
+          },
+          500,
+        );
       }
 
       this.logger.info("Exocortex Plugin loaded successfully");
@@ -556,7 +650,9 @@ export default class ExocortexPlugin extends Plugin {
    * Called on init and whenever log channel settings change.
    */
   configureLogChannels(): void {
-    const hasFileEnabled = Object.values(this.settings.logChannels).some(c => c.file);
+    const hasFileEnabled = Object.values(this.settings.logChannels).some(
+      (c) => c.file,
+    );
     Logger.configure({
       channels: this.settings.logChannels,
       fileChannel: hasFileEnabled ? this.fileLogChannel : null,
@@ -745,7 +841,11 @@ export default class ExocortexPlugin extends Plugin {
     // Render layout
     void (async () => {
       try {
-        await this.layoutRenderer.render("", layoutContainer, {} as MarkdownPostProcessorContext);
+        await this.layoutRenderer.render(
+          "",
+          layoutContainer,
+          {} as MarkdownPostProcessorContext,
+        );
       } catch (error) {
         this.logger.error("Failed to auto-render layout", error);
       }
@@ -784,8 +884,12 @@ export default class ExocortexPlugin extends Plugin {
       }
 
       // Check current state of layout and metadata
-      const layoutExists = viewContainer.querySelector(".exocortex-auto-layout");
-      const currentMetadataContainer = viewContainer.querySelector(".metadata-container");
+      const layoutExists = viewContainer.querySelector(
+        ".exocortex-auto-layout",
+      );
+      const currentMetadataContainer = viewContainer.querySelector(
+        ".metadata-container",
+      );
 
       // If layout exists, nothing to do
       if (layoutExists) {
@@ -818,8 +922,12 @@ export default class ExocortexPlugin extends Plugin {
           return;
         }
 
-        const layoutStillMissing = !viewContainer.querySelector(".exocortex-auto-layout");
-        const metadataStillExists = viewContainer.querySelector(".metadata-container");
+        const layoutStillMissing = !viewContainer.querySelector(
+          ".exocortex-auto-layout",
+        );
+        const metadataStillExists = viewContainer.querySelector(
+          ".metadata-container",
+        );
 
         if (layoutStillMissing && metadataStillExists) {
           isReRendering = true;
@@ -834,19 +942,33 @@ export default class ExocortexPlugin extends Plugin {
           `;
 
           // Insert after metadata container
-          metadataStillExists.insertAdjacentElement("afterend", newLayoutContainer);
+          metadataStillExists.insertAdjacentElement(
+            "afterend",
+            newLayoutContainer,
+          );
 
           // Render layout
           void (async () => {
             try {
-              await this.layoutRenderer.render("", newLayoutContainer, {} as MarkdownPostProcessorContext);
+              await this.layoutRenderer.render(
+                "",
+                newLayoutContainer,
+                {} as MarkdownPostProcessorContext,
+              );
             } catch (error) {
-              this.logger.error("Failed to re-render layout after embed processing", error);
+              this.logger.error(
+                "Failed to re-render layout after embed processing",
+                error,
+              );
             } finally {
               // Reset flag after a short delay to allow for DOM stabilization
-              this.timerManager.setTimeout(null, () => {
-                isReRendering = false;
-              }, 100);
+              this.timerManager.setTimeout(
+                null,
+                () => {
+                  isReRendering = false;
+                },
+                100,
+              );
             }
           })();
         }
@@ -922,9 +1044,7 @@ export default class ExocortexPlugin extends Plugin {
             `Skipping plannedEndTimestamp adjustment - autoAdjustPlannedEndTimestamp is disabled`,
           );
         } else {
-          const currentDate = new Date(
-            String(currentPlannedStartTimestamp),
-          );
+          const currentDate = new Date(String(currentPlannedStartTimestamp));
           const previousDate = previousPlannedStartTimestamp
             ? new Date(String(previousPlannedStartTimestamp))
             : null;
@@ -937,39 +1057,49 @@ export default class ExocortexPlugin extends Plugin {
             const deltaMs = currentDate.getTime() - previousDate.getTime();
 
             // Issue #2095: Idempotency check for Obsidian Sync
-          // When synced from another device, plannedEndTimestamp may already be shifted.
-          // Check if the current plannedEndTimestamp equals the expected value to avoid double-shift.
-          const currentPlannedEndTimestamp =
-            metadata.ems__Effort_plannedEndTimestamp;
-          const previousPlannedEndTimestamp =
-            cachedMetadata.ems__Effort_plannedEndTimestamp;
+            // When synced from another device, plannedEndTimestamp may already be shifted.
+            // Check if the current plannedEndTimestamp equals the expected value to avoid double-shift.
+            const currentPlannedEndTimestamp =
+              metadata.ems__Effort_plannedEndTimestamp;
+            const previousPlannedEndTimestamp =
+              cachedMetadata.ems__Effort_plannedEndTimestamp;
 
-          if (currentPlannedEndTimestamp && previousPlannedEndTimestamp) {
-            const currentEndDate = new Date(
-              String(currentPlannedEndTimestamp),
-            );
-            const previousEndDate = new Date(
-              String(previousPlannedEndTimestamp),
-            );
+            if (currentPlannedEndTimestamp && previousPlannedEndTimestamp) {
+              const currentEndDate = new Date(
+                String(currentPlannedEndTimestamp),
+              );
+              const previousEndDate = new Date(
+                String(previousPlannedEndTimestamp),
+              );
 
-            if (
-              !isNaN(currentEndDate.getTime()) &&
-              !isNaN(previousEndDate.getTime())
-            ) {
-              const expectedEndTimestamp =
-                previousEndDate.getTime() + deltaMs;
-              const actualEndTimestamp = currentEndDate.getTime();
+              if (
+                !isNaN(currentEndDate.getTime()) &&
+                !isNaN(previousEndDate.getTime())
+              ) {
+                const expectedEndTimestamp =
+                  previousEndDate.getTime() + deltaMs;
+                const actualEndTimestamp = currentEndDate.getTime();
 
-              // If plannedEndTimestamp is already at expected value, skip the shift
-              // This happens when syncing from another device that already applied the shift
-              if (actualEndTimestamp === expectedEndTimestamp) {
-                this.logger.info(
-                  `Skipping plannedEndTimestamp shift - already at expected value (sync from another device)`,
-                );
-                // Update cache for plannedEndTimestamp to reflect synced value
-                cachedMetadata.ems__Effort_plannedEndTimestamp =
-                  currentPlannedEndTimestamp;
+                // If plannedEndTimestamp is already at expected value, skip the shift
+                // This happens when syncing from another device that already applied the shift
+                if (actualEndTimestamp === expectedEndTimestamp) {
+                  this.logger.info(
+                    `Skipping plannedEndTimestamp shift - already at expected value (sync from another device)`,
+                  );
+                  // Update cache for plannedEndTimestamp to reflect synced value
+                  cachedMetadata.ems__Effort_plannedEndTimestamp =
+                    currentPlannedEndTimestamp;
+                } else {
+                  await this.taskStatusService.shiftPlannedEndTimestamp(
+                    file,
+                    deltaMs,
+                  );
+                  this.logger.info(
+                    `Shifted ems__Effort_plannedEndTimestamp by ${deltaMs}ms`,
+                  );
+                }
               } else {
+                // Dates are invalid, proceed with shift
                 await this.taskStatusService.shiftPlannedEndTimestamp(
                   file,
                   deltaMs,
@@ -979,7 +1109,7 @@ export default class ExocortexPlugin extends Plugin {
                 );
               }
             } else {
-              // Dates are invalid, proceed with shift
+              // No plannedEndTimestamp to check, proceed with shift
               await this.taskStatusService.shiftPlannedEndTimestamp(
                 file,
                 deltaMs,
@@ -988,17 +1118,7 @@ export default class ExocortexPlugin extends Plugin {
                 `Shifted ems__Effort_plannedEndTimestamp by ${deltaMs}ms`,
               );
             }
-          } else {
-            // No plannedEndTimestamp to check, proceed with shift
-            await this.taskStatusService.shiftPlannedEndTimestamp(
-              file,
-              deltaMs,
-            );
-            this.logger.info(
-              `Shifted ems__Effort_plannedEndTimestamp by ${deltaMs}ms`,
-            );
           }
-        }
         }
       }
 
@@ -1019,9 +1139,7 @@ export default class ExocortexPlugin extends Plugin {
           currentAssetLabel,
         );
 
-        this.logger.info(
-          `Auto-synced aliases for exo__Asset_label change`,
-        );
+        this.logger.info(`Auto-synced aliases for exo__Asset_label change`);
       }
 
       this.metadataCache.set(file.path, { ...metadata });
@@ -1032,7 +1150,6 @@ export default class ExocortexPlugin extends Plugin {
       );
     }
   }
-
 
   /**
    * Issue #2785: schedule a debounced, per-file re-index after a frontmatter mutation.

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -515,10 +515,16 @@ export default class ExocortexPlugin extends Plugin {
       }
 
       // RFC-024 Phase 0: first-launch-after-upgrade changelog modal.
+      // Fresh installs have no prior behaviour to contrast, so we silently seed
+      // `lastShownChangelogVersion` and skip the modal (avoids onboarding noise
+      // and unblocks E2E test vaults that boot from an empty data.json).
       // Delayed 500ms so Obsidian's own modal stack has settled and the
       // workspace is interactive before we surface a dialog.
       const currentVersion = this.manifest.version;
-      if (
+      if (this.isFreshInstall) {
+        this.settings.lastShownChangelogVersion = currentVersion;
+        void this.saveSettings();
+      } else if (
         shouldShowChangelog(
           this.settings.lastShownChangelogVersion,
           currentVersion,
@@ -637,8 +643,18 @@ export default class ExocortexPlugin extends Plugin {
     this.logger?.info("Exocortex Plugin unloaded");
   }
 
+  /**
+   * True when the plugin data file did not exist at startup — i.e. this is a
+   * brand-new install with no prior user state. Used to suppress the RFC-024
+   * Phase 0 changelog modal for users who never had pre-recoloring behaviour
+   * (nothing to inform them about).
+   */
+  private isFreshInstall = false;
+
   async loadSettings(): Promise<void> {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    const rawData = await this.loadData();
+    this.isFreshInstall = rawData == null;
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, rawData);
     // Ensure logChannels exists for users upgrading from older versions
     if (!this.settings.logChannels) {
       this.settings.logChannels = DEFAULT_LOG_CHANNELS;

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -20,16 +20,17 @@ export const DEFAULT_DISPLAY_NAME_SETTINGS: DisplayNameSettings = {
   defaultTemplate: "{{exo__Asset_label}} ({{exo__Instance_class}})",
 
   classTemplates: {
-    "ems__TaskPrototype": "{{exo__Asset_label}} (TaskPrototype)",
+    ems__TaskPrototype: "{{exo__Asset_label}} (TaskPrototype)",
     // UID-based identifier for ems__TaskPrototype (Issue #2110)
-    "75302770-279e-4a59-ba85-09df29725713": "{{exo__Asset_label}} (TaskPrototype)",
-    "ems__Task": "{{exo__Asset_label}}",
-    "ems__Project": "{{exo__Asset_label}}",
-    "ems__Area": "{{exo__Asset_label}}",
-    "ems__MeetingPrototype": "{{exo__Asset_label}} (MeetingPrototype)",
-    "ems__Meeting": "{{exo__Asset_label}}",
+    "75302770-279e-4a59-ba85-09df29725713":
+      "{{exo__Asset_label}} (TaskPrototype)",
+    ems__Task: "{{exo__Asset_label}}",
+    ems__Project: "{{exo__Asset_label}}",
+    ems__Area: "{{exo__Asset_label}}",
+    ems__MeetingPrototype: "{{exo__Asset_label}} (MeetingPrototype)",
+    ems__Meeting: "{{exo__Asset_label}}",
     // DailyNote uses the basename (date) as its display name since it typically doesn't have a label
-    "pn__DailyNote": "{{_basename}}",
+    pn__DailyNote: "{{_basename}}",
   },
 };
 
@@ -89,6 +90,12 @@ export interface ExocortexSettings {
    * See Finding 9 of the 2026-04-14 UX audit.
    */
   autoReadingModeForExocortexAssets: boolean;
+  /**
+   * Plugin version that last displayed the RFC-024 changelog modal.
+   * Used to show the modal exactly once per upgrade. Undefined on fresh
+   * installs (which will see the modal on first load).
+   */
+  lastShownChangelogVersion?: string;
   [key: string]: unknown;
 }
 

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -1,5 +1,8 @@
 import { App } from "obsidian";
-import { ActionButton, ButtonGroup } from '@plugin/presentation/components/ActionButtonsGroup';
+import {
+  ActionButton,
+  ButtonGroup,
+} from "@plugin/presentation/components/ActionButtonsGroup";
 import type {
   CommandResolver,
   ResolvedCommand,
@@ -9,12 +12,13 @@ import type {
   EvalContext,
   INotificationService,
 } from "exocortex";
-import { ILogger } from '@plugin/adapters/logging/ILogger';
+import { ILogger } from "@plugin/adapters/logging/ILogger";
 import {
   IButtonGroupBuilder,
   ButtonBuilderContext,
 } from "./ButtonBuilderTypes";
 import { DynamicFormModal } from "@plugin/presentation/modals/DynamicFormModal";
+import { resolveVariantForGroup } from "./categoryDefaultVariants";
 
 /**
  * Configuration for DynamicCommandButtonGroupBuilder.
@@ -107,7 +111,9 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
    * Groups with zero visible commands are omitted — the React component re-filters
    * too, but returning them empty here keeps the payload lean.
    */
-  async buildCategoryGroups(context: ButtonBuilderContext): Promise<ButtonGroup[]> {
+  async buildCategoryGroups(
+    context: ButtonBuilderContext,
+  ): Promise<ButtonGroup[]> {
     const resolved = await this.resolveVisibleCommands(context);
     if (resolved === null) return [];
     const { visibleCommands, subjectIRI } = resolved;
@@ -134,7 +140,14 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
         title: spec.title,
         collapsedByDefault: spec.collapsedByDefault,
         buttons: commands.map((rc) =>
-          this.createButton(rc, subjectIRI, file.path, app as App, logger, refresh),
+          this.createButton(
+            rc,
+            subjectIRI,
+            file.path,
+            app as App,
+            logger,
+            refresh,
+          ),
         ),
       });
     }
@@ -150,7 +163,14 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
         id: "dynamic-commands-other",
         title: "Other",
         buttons: leftover.map((rc) =>
-          this.createButton(rc, subjectIRI, file.path, app as App, logger, refresh),
+          this.createButton(
+            rc,
+            subjectIRI,
+            file.path,
+            app as App,
+            logger,
+            refresh,
+          ),
         ),
       });
     }
@@ -172,7 +192,10 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
 
   private async resolveVisibleCommands(
     context: ButtonBuilderContext,
-  ): Promise<{ visibleCommands: ResolvedCommand[]; subjectIRI: string } | null> {
+  ): Promise<{
+    visibleCommands: ResolvedCommand[];
+    subjectIRI: string;
+  } | null> {
     const { file, metadata, logger } = context;
 
     // CRITICAL: subjectIRI MUST match triple store subject IRI.
@@ -195,7 +218,9 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
         prototypeIRI,
       );
     } catch (error) {
-      logger.info(`[DynamicCommands] Failed to resolve commands: ${String(error)}`);
+      logger.info(
+        `[DynamicCommands] Failed to resolve commands: ${String(error)}`,
+      );
       return null;
     }
 
@@ -240,7 +265,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     refresh: () => Promise<void>,
   ): ActionButton {
     const { command, binding } = rc;
-    const variant = this.resolveVariant(binding.group);
+    const variant = resolveVariantForGroup(binding.group);
 
     return {
       id: `dynamic-cmd-${command.id}`,
@@ -290,23 +315,17 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
       }
       await new Promise((resolve) => setTimeout(resolve, 100));
       await refresh();
-      logger.info(`[DynamicCommands] Executed "${command.name}" on ${filePath}`);
+      logger.info(
+        `[DynamicCommands] Executed "${command.name}" on ${filePath}`,
+      );
     } else {
-      this.config.notificationService.error(`Command failed: ${result.error ?? "unknown error"}`);
-      logger.info(`[DynamicCommands] Failed "${command.name}": ${result.error}`);
+      this.config.notificationService.error(
+        `Command failed: ${result.error ?? "unknown error"}`,
+      );
+      logger.info(
+        `[DynamicCommands] Failed "${command.name}": ${result.error}`,
+      );
     }
-  }
-
-  private resolveVariant(
-    group?: string,
-  ): "primary" | "secondary" | "success" | "warning" | "danger" {
-    if (!group) return "secondary";
-    const lower = group.toLowerCase();
-    if (lower === "danger" || lower === "destructive") return "danger";
-    if (lower === "warning") return "warning";
-    if (lower === "success") return "success";
-    if (lower === "primary") return "primary";
-    return "secondary";
   }
 
   private async showConfirmation(message: string): Promise<boolean> {
@@ -319,7 +338,9 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
 
   private extractInputSchema(rc: ResolvedCommand): InputSchemaField[] | null {
     const grounding = rc.command.grounding;
-    const raw = (grounding as unknown as Record<string, unknown>)["inputSchema"];
+    const raw = (grounding as unknown as Record<string, unknown>)[
+      "inputSchema"
+    ];
     if (!raw || !Array.isArray(raw)) return null;
 
     return raw.filter(
@@ -331,7 +352,9 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     );
   }
 
-  private extractAssetClass(metadata: Record<string, unknown>): string | undefined {
+  private extractAssetClass(
+    metadata: Record<string, unknown>,
+  ): string | undefined {
     const raw = metadata["exo__Instance_class"];
     if (typeof raw === "string") {
       return raw.replace(/["'[\]]/g, "").trim();
@@ -345,7 +368,9 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     return undefined;
   }
 
-  private extractPrototypeIRI(metadata: Record<string, unknown>): string | undefined {
+  private extractPrototypeIRI(
+    metadata: Record<string, unknown>,
+  ): string | undefined {
     const raw = metadata["exo__Asset_prototype"];
     if (typeof raw === "string") {
       return raw.replace(/["'[\]]/g, "").trim();

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/categoryDefaultVariants.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/categoryDefaultVariants.ts
@@ -1,0 +1,37 @@
+import type { ActionButtonVariant } from "@plugin/presentation/components/ActionButtonsGroup";
+
+/**
+ * Built-in default variant map per command-binding group (RFC-024 Phase 0).
+ *
+ * Keys are values of `exocmd__CommandBinding_group` (or the `binding.group` field
+ * on the domain model). Forward-looking sub-category keys (`status/done`,
+ * `status/blocked`, `status/cancelled`) are included per RFC-024 §4 acceptance
+ * criteria — they are inert today because starter-kit bindings use flat `status`
+ * category, but will activate when sub-category granularity is introduced.
+ *
+ * Rationale: prior implementation hardcoded a 5-case switch in
+ * `DynamicCommandButtonGroupBuilder.resolveVariant`; this map is
+ * independently testable and removes rollout coupling to starter-kit migration
+ * (every installation receives the correct default colors on plugin upgrade).
+ */
+export const categoryDefaultVariant: Readonly<
+  Record<string, ActionButtonVariant>
+> = Object.freeze({
+  creation: "primary",
+  "status/done": "success",
+  "status/blocked": "warning",
+  "status/cancelled": "danger",
+  criticality: "warning",
+  maintenance: "muted",
+});
+
+/**
+ * Resolves the default button variant for a command binding's `group` string.
+ * Falls back to `"secondary"` for unknown, empty, or missing groups.
+ */
+export function resolveVariantForGroup(
+  group: string | undefined,
+): ActionButtonVariant {
+  if (!group) return "secondary";
+  return categoryDefaultVariant[group] ?? "secondary";
+}

--- a/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
@@ -1,13 +1,26 @@
 import React, { useState } from "react";
 
 /**
+ * Semantic variants for action buttons. The `muted` variant (RFC-024 Phase 0)
+ * is reserved for power-user / maintenance commands that should recede
+ * visually so primary actions stay prominent.
+ */
+export type ActionButtonVariant =
+  | "primary"
+  | "secondary"
+  | "success"
+  | "warning"
+  | "danger"
+  | "muted";
+
+/**
  * Props for individual action buttons within the group
  */
 export interface ActionButton {
   id: string;
   label: string;
   onClick: () => void | Promise<void>;
-  variant?: "primary" | "secondary" | "success" | "warning" | "danger";
+  variant?: ActionButtonVariant;
   visible?: boolean;
 }
 

--- a/packages/obsidian-plugin/src/presentation/modals/ChangelogModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/ChangelogModal.ts
@@ -1,0 +1,92 @@
+import { App, Modal } from "obsidian";
+
+/**
+ * Returns `true` when the changelog modal should be displayed for the given
+ * plugin version. Fresh installs (lastShown undefined/empty) always show,
+ * and any version mismatch (upgrade or downgrade) also triggers display.
+ * Equal versions suppress the modal so it appears at most once per version.
+ */
+export function shouldShowChangelog(
+  lastShownVersion: string | undefined,
+  currentVersion: string,
+): boolean {
+  if (!lastShownVersion) return true;
+  return lastShownVersion !== currentVersion;
+}
+
+/**
+ * First-launch-after-upgrade changelog modal (RFC-024 Phase 0).
+ *
+ * Informs the user about the new built-in button recoloring so the visual
+ * change is not silent. Dismissed state is persisted by the caller via the
+ * `onDismiss` callback — the modal itself owns no durable state.
+ */
+export class ChangelogModal extends Modal {
+  constructor(
+    app: App,
+    private readonly version: string,
+    private readonly onDismiss: (version: string) => void,
+  ) {
+    super(app);
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("exocortex-changelog-modal");
+
+    contentEl.createEl("h2", {
+      text: `Exocortex ${this.version} — what changed`,
+    });
+
+    contentEl.createEl("p", {
+      cls: "exocortex-changelog-intro",
+      text:
+        "Command buttons now use semantic default colors out of the box — " +
+        "no vault changes required. Creation actions are prominent, " +
+        "maintenance commands recede, and status/criticality actions keep " +
+        "their intent clear at a glance.",
+    });
+
+    const list = contentEl.createEl("ul", {
+      cls: "exocortex-changelog-list",
+    });
+    list.createEl("li", { text: "Creation → primary" });
+    list.createEl("li", { text: "Criticality → warning" });
+    list.createEl("li", { text: "Maintenance → muted" });
+    list.createEl("li", {
+      text: "Status sub-actions (done / blocked / cancelled) remap as sub-categories roll out",
+    });
+
+    contentEl.createEl("p", {
+      cls: "exocortex-changelog-customize",
+      text:
+        "Customize in your vault by setting `exocmd__CommandBinding_variant` " +
+        "on individual bindings. Explicit binding variants always win over " +
+        "these defaults.",
+    });
+
+    const buttonContainer = contentEl.createDiv({
+      cls: "modal-button-container",
+    });
+    const dismissButton = buttonContainer.createEl("button", {
+      text: "Got it",
+      cls: "mod-cta",
+    });
+    dismissButton.addEventListener("click", () => this.dismiss());
+  }
+
+  override onClose(): void {
+    this.contentEl.empty();
+  }
+
+  /**
+   * User-facing dismiss handler: persists the current version via the
+   * injected callback and closes the modal. Exposed for unit testability
+   * (`dismissButton.click` is routed here).
+   */
+  dismiss(): void {
+    this.onDismiss(this.version);
+    this.close();
+  }
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -1177,6 +1177,19 @@
   box-shadow: 0 2px 12px rgba(244, 67, 54, 0.3);
 }
 
+/* Muted variant - Power-user / maintenance commands (RFC-024 Phase 0) */
+.exocortex-action-button--muted {
+  background-color: var(--background-primary);
+  color: var(--text-muted);
+  border-color: var(--background-modifier-border);
+}
+
+.exocortex-action-button--muted:hover {
+  background-color: var(--background-modifier-hover);
+  color: var(--text-normal);
+  border-color: var(--text-muted);
+}
+
 /* Dark theme adjustments */
 .theme-dark .exocortex-action-buttons-container {
   background-color: var(--background-primary);

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
@@ -23,7 +23,9 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     };
 
     ctx.mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
-    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue("[[ems__Task]]");
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[ems__Task]]",
+    );
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue(null);
@@ -46,7 +48,9 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     };
 
     ctx.mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
-    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue("[[ems__Task]]");
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[ems__Task]]",
+    );
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
@@ -57,7 +61,11 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
           name: "Start Effort",
           category: "status",
           precondition: { type: "always_true" },
-          grounding: { type: "set_frontmatter_value", property: "status", value: "doing" },
+          grounding: {
+            type: "set_frontmatter_value",
+            property: "status",
+            value: "doing",
+          },
         },
         binding: { order: 0, group: "primary" },
       },
@@ -85,7 +93,9 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     };
 
     ctx.mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
-    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue("[[ems__Task]]");
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[ems__Task]]",
+    );
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
@@ -134,7 +144,9 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     };
 
     ctx.mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
-    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue("[[ems__Task]]");
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[ems__Task]]",
+    );
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
@@ -156,20 +168,22 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     };
 
     ctx.mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
-    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue("[[ems__Task]]");
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[ems__Task]]",
+    );
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
     ctx.mockCommandResolver.resolveForAsset.mockResolvedValue([
       {
         command: {
-          id: "cmd-status",
-          name: "Move to Backlog",
+          id: "cmd-creation",
+          name: "Create Task",
           category: "status",
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value" },
         },
-        binding: { order: 0, group: "primary" },
+        binding: { order: 0, group: "creation" },
       },
       {
         command: {
@@ -179,33 +193,37 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value" },
         },
-        binding: { order: 1, group: "secondary" },
+        binding: { order: 1, group: "maintenance" },
       },
       {
         command: {
-          id: "cmd-danger",
+          id: "cmd-unknown",
           name: "Trash",
           category: "maintenance",
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value" },
         },
-        binding: { order: 2, group: "danger" },
+        binding: { order: 2, group: "legacy-unknown" },
       },
     ]);
     ctx.mockPreconditionEvaluator.evaluate.mockResolvedValue(true);
 
     const groups = await ctx.builder.build(mockFile);
 
+    // RFC-024 Phase 0: category-driven default variants.
+    // `creation` → primary, `maintenance` → muted, unknown group → secondary.
     const statusGroup = groups.find((g) => g.id === "dynamic-commands-status");
-    const maintenanceGroup = groups.find((g) => g.id === "dynamic-commands-maintenance");
+    const maintenanceGroup = groups.find(
+      (g) => g.id === "dynamic-commands-maintenance",
+    );
     expect(statusGroup).toBeDefined();
     expect(statusGroup!.buttons.length).toBe(1);
     expect(statusGroup!.buttons[0].variant).toBe("primary");
     expect(maintenanceGroup).toBeDefined();
     expect(maintenanceGroup!.collapsedByDefault).toBe(true);
     expect(maintenanceGroup!.buttons.length).toBe(2);
-    expect(maintenanceGroup!.buttons[0].variant).toBe("secondary");
-    expect(maintenanceGroup!.buttons[1].variant).toBe("danger");
+    expect(maintenanceGroup!.buttons[0].variant).toBe("muted");
+    expect(maintenanceGroup!.buttons[1].variant).toBe("secondary");
   });
 
   it("should handle resolver errors gracefully", async () => {
@@ -220,11 +238,15 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     };
 
     ctx.mockMetadataExtractor.extractMetadata.mockReturnValue(metadata);
-    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue("[[ems__Task]]");
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[ems__Task]]",
+    );
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
-    ctx.mockCommandResolver.resolveForAsset.mockRejectedValue(new Error("Resolver failed"));
+    ctx.mockCommandResolver.resolveForAsset.mockRejectedValue(
+      new Error("Resolver failed"),
+    );
 
     const groups = await ctx.builder.build(mockFile);
 

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -1,7 +1,5 @@
 import { DynamicCommandButtonGroupBuilder } from "../../../../src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
-import {
-  GroundingType,
-} from "exocortex";
+import { GroundingType } from "exocortex";
 
 const mockResolveForAsset = jest.fn();
 const mockEvaluate = jest.fn();
@@ -26,7 +24,9 @@ const mockGroundingExecutor = {
   substituteVariables: jest.fn(),
 };
 
-function createGrounding(overrides?: Partial<GroundingDefinition>): GroundingDefinition {
+function createGrounding(
+  overrides?: Partial<GroundingDefinition>,
+): GroundingDefinition {
   return {
     id: "grounding-1",
     label: "Test grounding",
@@ -37,7 +37,9 @@ function createGrounding(overrides?: Partial<GroundingDefinition>): GroundingDef
   };
 }
 
-function createCommand(overrides?: Partial<CommandDefinition>): CommandDefinition {
+function createCommand(
+  overrides?: Partial<CommandDefinition>,
+): CommandDefinition {
   return {
     id: "cmd-1",
     name: "Test command",
@@ -46,7 +48,9 @@ function createCommand(overrides?: Partial<CommandDefinition>): CommandDefinitio
   };
 }
 
-function createBinding(overrides?: Partial<CommandBindingDefinition>): CommandBindingDefinition {
+function createBinding(
+  overrides?: Partial<CommandBindingDefinition>,
+): CommandBindingDefinition {
   return {
     id: "binding-1",
     label: "Test binding",
@@ -66,12 +70,17 @@ function createResolvedCommand(
   };
 }
 
-function createContext(metadataOverrides?: Record<string, unknown>): ButtonBuilderContext {
+function createContext(
+  metadataOverrides?: Record<string, unknown>,
+): ButtonBuilderContext {
   return {
     app: {} as ButtonBuilderContext["app"],
     settings: {} as ButtonBuilderContext["settings"],
     plugin: {} as ButtonBuilderContext["plugin"],
-    file: { path: "test/file.md", parent: { path: "test" } } as ButtonBuilderContext["file"],
+    file: {
+      path: "test/file.md",
+      parent: { path: "test" },
+    } as ButtonBuilderContext["file"],
     metadata: {
       exo__Asset_uid: "obsidian://vault/test/file.md",
       exo__Instance_class: ["[[ems__Task]]"],
@@ -87,7 +96,12 @@ function createContext(metadataOverrides?: Record<string, unknown>): ButtonBuild
       expectedFolder: "test",
       classIsPrototype: false,
     },
-    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() } as unknown as ButtonBuilderContext["logger"],
+    logger: {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as ButtonBuilderContext["logger"],
     refresh: jest.fn().mockResolvedValue(undefined),
   };
 }
@@ -106,7 +120,11 @@ describe("DynamicCommandButtonGroupBuilder", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     builder = new DynamicCommandButtonGroupBuilder({
-      commandResolver: mockCommandResolver as unknown as Parameters<typeof DynamicCommandButtonGroupBuilder.prototype.build>[0] extends never ? never : any,
+      commandResolver: mockCommandResolver as unknown as Parameters<
+        typeof DynamicCommandButtonGroupBuilder.prototype.build
+      >[0] extends never
+        ? never
+        : any,
       preconditionEvaluator: mockPreconditionEvaluator as unknown as any,
       groundingExecutor: mockGroundingExecutor as unknown as any,
       notificationService: mockNotificationService as any,
@@ -132,7 +150,11 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       const result = await builder.build(context);
       expect(result).toEqual([]);
       // subjectIRI is always constructed from file.path as obsidian://vault/ IRI
-      expect(mockResolveForAsset).toHaveBeenCalledWith("obsidian://vault/test/file.md", "ems__Task", undefined);
+      expect(mockResolveForAsset).toHaveBeenCalledWith(
+        "obsidian://vault/test/file.md",
+        "ems__Task",
+        undefined,
+      );
     });
 
     it("should return empty array when no instance class in metadata", async () => {
@@ -173,9 +195,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       const rc1 = createResolvedCommand({ id: "cmd-pass", name: "Passing" });
       const rc2 = createResolvedCommand({ id: "cmd-fail", name: "Failing" });
       mockResolveForAsset.mockResolvedValue([rc1, rc2]);
-      mockEvaluate
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false);
+      mockEvaluate.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
       const context = createContext();
       const result = await builder.build(context);
@@ -251,10 +271,11 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       );
     });
 
-    it("should resolve variant from binding group", async () => {
+    it("should resolve variant from binding group via categoryDefaultVariant map", async () => {
+      // RFC-024 Phase 0: `creation` group maps to `primary` by built-in defaults
       const rc = createResolvedCommand(
-        { name: "Danger action" },
-        { group: "danger" },
+        { name: "Create action" },
+        { group: "creation" },
       );
       mockResolveForAsset.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
@@ -262,13 +283,41 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       const context = createContext();
       const result = await builder.build(context);
 
-      expect(result[0].variant).toBe("danger");
+      expect(result[0].variant).toBe("primary");
+    });
+
+    it("should map maintenance group to muted variant (RFC-024 Phase 0)", async () => {
+      const rc = createResolvedCommand(
+        { name: "Rebuild index" },
+        { group: "maintenance" },
+      );
+      mockResolveForAsset.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].variant).toBe("muted");
     });
 
     it("should default variant to secondary when no group", async () => {
       const rc = createResolvedCommand(
         { name: "Default action" },
         { group: undefined },
+      );
+      mockResolveForAsset.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].variant).toBe("secondary");
+    });
+
+    it("should default variant to secondary for unknown group", async () => {
+      const rc = createResolvedCommand(
+        { name: "Future action" },
+        { group: "future-uncategorized" },
       );
       mockResolveForAsset.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
@@ -345,7 +394,9 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
       await result[0].onClick();
 
-      expect(mockNotificationService.error).toHaveBeenCalledWith("Command failed: Something went wrong");
+      expect(mockNotificationService.error).toHaveBeenCalledWith(
+        "Command failed: Something went wrong",
+      );
     });
 
     it("should show confirmation dialog when confirmMessage is set", async () => {
@@ -425,8 +476,14 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should preserve command order from resolver", async () => {
-      const rc1 = createResolvedCommand({ id: "c1", name: "First" }, { order: 1 });
-      const rc2 = createResolvedCommand({ id: "c2", name: "Second" }, { order: 2 });
+      const rc1 = createResolvedCommand(
+        { id: "c1", name: "First" },
+        { order: 1 },
+      );
+      const rc2 = createResolvedCommand(
+        { id: "c2", name: "Second" },
+        { order: 2 },
+      );
       mockResolveForAsset.mockResolvedValue([rc1, rc2]);
       mockEvaluate.mockResolvedValue(true);
 
@@ -441,11 +498,31 @@ describe("DynamicCommandButtonGroupBuilder", () => {
   describe("buildCategoryGroups", () => {
     it("should return groups in fixed order (creation → status → planning → criticality → maintenance)", async () => {
       const commands = [
-        createResolvedCommand({ id: "m1", name: "Rename to UID", category: "maintenance" }),
-        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
-        createResolvedCommand({ id: "s1", name: "Set Status Doing", category: "status" }),
-        createResolvedCommand({ id: "p1", name: "Plan on Today", category: "planning" }),
-        createResolvedCommand({ id: "k1", name: "Set Criticality High", category: "criticality" }),
+        createResolvedCommand({
+          id: "m1",
+          name: "Rename to UID",
+          category: "maintenance",
+        }),
+        createResolvedCommand({
+          id: "c1",
+          name: "Create Task",
+          category: "creation",
+        }),
+        createResolvedCommand({
+          id: "s1",
+          name: "Set Status Doing",
+          category: "status",
+        }),
+        createResolvedCommand({
+          id: "p1",
+          name: "Plan on Today",
+          category: "planning",
+        }),
+        createResolvedCommand({
+          id: "k1",
+          name: "Set Criticality High",
+          category: "criticality",
+        }),
       ];
       mockResolveForAsset.mockResolvedValue(commands);
       mockEvaluate.mockResolvedValue(true);
@@ -470,23 +547,41 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
     it("should mark maintenance group collapsedByDefault", async () => {
       mockResolveForAsset.mockResolvedValue([
-        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
-        createResolvedCommand({ id: "m1", name: "Rename to UID", category: "maintenance" }),
+        createResolvedCommand({
+          id: "c1",
+          name: "Create Task",
+          category: "creation",
+        }),
+        createResolvedCommand({
+          id: "m1",
+          name: "Rename to UID",
+          category: "maintenance",
+        }),
       ]);
       mockEvaluate.mockResolvedValue(true);
 
       const result = await builder.buildCategoryGroups(createContext());
 
       const creation = result.find((g) => g.id === "dynamic-commands-creation");
-      const maintenance = result.find((g) => g.id === "dynamic-commands-maintenance");
+      const maintenance = result.find(
+        (g) => g.id === "dynamic-commands-maintenance",
+      );
       expect(creation?.collapsedByDefault).toBeFalsy();
       expect(maintenance?.collapsedByDefault).toBe(true);
     });
 
     it("should omit categories that have zero visible commands", async () => {
       mockResolveForAsset.mockResolvedValue([
-        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
-        createResolvedCommand({ id: "s1", name: "Set Status Doing", category: "status" }),
+        createResolvedCommand({
+          id: "c1",
+          name: "Create Task",
+          category: "creation",
+        }),
+        createResolvedCommand({
+          id: "s1",
+          name: "Set Status Doing",
+          category: "status",
+        }),
       ]);
       mockEvaluate.mockResolvedValue(true);
 
@@ -496,17 +591,25 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         "dynamic-commands-creation",
         "dynamic-commands-status",
       ]);
-      expect(result.find((g) => g.id === "dynamic-commands-maintenance")).toBeUndefined();
+      expect(
+        result.find((g) => g.id === "dynamic-commands-maintenance"),
+      ).toBeUndefined();
     });
 
     it("should drop categories where preconditions filter out every command", async () => {
       mockResolveForAsset.mockResolvedValue([
-        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
-        createResolvedCommand({ id: "m1", name: "Rename to UID", category: "maintenance" }),
+        createResolvedCommand({
+          id: "c1",
+          name: "Create Task",
+          category: "creation",
+        }),
+        createResolvedCommand({
+          id: "m1",
+          name: "Rename to UID",
+          category: "maintenance",
+        }),
       ]);
-      mockEvaluate
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false);
+      mockEvaluate.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
       const result = await builder.buildCategoryGroups(createContext());
 
@@ -515,7 +618,11 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
     it("should route commands without category into Other group at the end", async () => {
       mockResolveForAsset.mockResolvedValue([
-        createResolvedCommand({ id: "c1", name: "Create Task", category: "creation" }),
+        createResolvedCommand({
+          id: "c1",
+          name: "Create Task",
+          category: "creation",
+        }),
         createResolvedCommand({ id: "u1", name: "Uncategorized" }),
       ]);
       mockEvaluate.mockResolvedValue(true);

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/categoryDefaultVariants.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/categoryDefaultVariants.test.ts
@@ -1,0 +1,72 @@
+import {
+  categoryDefaultVariant,
+  resolveVariantForGroup,
+} from "../../../../src/presentation/builders/button-groups/categoryDefaultVariants";
+
+describe("categoryDefaultVariant map (RFC-024 Phase 0)", () => {
+  it("maps creation to primary", () => {
+    expect(categoryDefaultVariant["creation"]).toBe("primary");
+  });
+
+  it("maps status/done to success", () => {
+    expect(categoryDefaultVariant["status/done"]).toBe("success");
+  });
+
+  it("maps status/blocked to warning", () => {
+    expect(categoryDefaultVariant["status/blocked"]).toBe("warning");
+  });
+
+  it("maps status/cancelled to danger", () => {
+    expect(categoryDefaultVariant["status/cancelled"]).toBe("danger");
+  });
+
+  it("maps criticality to warning", () => {
+    expect(categoryDefaultVariant["criticality"]).toBe("warning");
+  });
+
+  it("maps maintenance to muted", () => {
+    expect(categoryDefaultVariant["maintenance"]).toBe("muted");
+  });
+
+  it("does not define status bare (falls through to secondary)", () => {
+    expect(categoryDefaultVariant["status"]).toBeUndefined();
+  });
+
+  it("does not define planning (falls through to secondary)", () => {
+    expect(categoryDefaultVariant["planning"]).toBeUndefined();
+  });
+});
+
+describe("resolveVariantForGroup (RFC-024 Phase 0)", () => {
+  it("returns secondary for undefined group", () => {
+    expect(resolveVariantForGroup(undefined)).toBe("secondary");
+  });
+
+  it("returns secondary for empty string group", () => {
+    expect(resolveVariantForGroup("")).toBe("secondary");
+  });
+
+  it("returns primary for creation group", () => {
+    expect(resolveVariantForGroup("creation")).toBe("primary");
+  });
+
+  it("returns warning for criticality group", () => {
+    expect(resolveVariantForGroup("criticality")).toBe("warning");
+  });
+
+  it("returns muted for maintenance group", () => {
+    expect(resolveVariantForGroup("maintenance")).toBe("muted");
+  });
+
+  it("returns secondary for unknown group", () => {
+    expect(resolveVariantForGroup("unknown-future-category")).toBe("secondary");
+  });
+
+  it("returns secondary for bare status group (sub-category required for color)", () => {
+    expect(resolveVariantForGroup("status")).toBe("secondary");
+  });
+
+  it("returns secondary for planning group", () => {
+    expect(resolveVariantForGroup("planning")).toBe("secondary");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/ChangelogModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/ChangelogModal.test.ts
@@ -1,0 +1,105 @@
+import {
+  ChangelogModal,
+  shouldShowChangelog,
+} from "../../../../src/presentation/modals/ChangelogModal";
+
+jest.mock("obsidian", () => ({
+  Modal: class MockModal {
+    app: unknown;
+    contentEl: {
+      empty: jest.Mock;
+      addClass: jest.Mock;
+      createEl: jest.Mock;
+      createDiv: jest.Mock;
+    };
+
+    constructor(app: unknown) {
+      this.app = app;
+      const el = {
+        empty: jest.fn(),
+        addClass: jest.fn(),
+        createEl: jest.fn().mockReturnValue({
+          addEventListener: jest.fn(),
+          createEl: jest.fn(),
+          createDiv: jest.fn(),
+          createSpan: jest.fn(),
+          addClass: jest.fn(),
+          setAttribute: jest.fn(),
+          appendChild: jest.fn(),
+        }),
+        createDiv: jest.fn().mockReturnValue({
+          addEventListener: jest.fn(),
+          createEl: jest.fn().mockReturnValue({
+            addEventListener: jest.fn(),
+            createEl: jest.fn(),
+          }),
+        }),
+      };
+      this.contentEl = el;
+    }
+
+    open = jest.fn();
+    close = jest.fn();
+  },
+  App: jest.fn(),
+}));
+
+describe("shouldShowChangelog (RFC-024 Phase 0)", () => {
+  it("returns true when lastShownChangelogVersion is undefined (fresh install)", () => {
+    expect(shouldShowChangelog(undefined, "15.99.0")).toBe(true);
+  });
+
+  it("returns true when lastShownChangelogVersion differs from current", () => {
+    expect(shouldShowChangelog("15.98.5", "15.99.0")).toBe(true);
+  });
+
+  it("returns false when lastShownChangelogVersion equals current", () => {
+    expect(shouldShowChangelog("15.99.0", "15.99.0")).toBe(false);
+  });
+
+  it("returns true when lastShown is older patch", () => {
+    expect(shouldShowChangelog("15.99.0", "15.99.1")).toBe(true);
+  });
+
+  it("returns true on empty-string lastShown", () => {
+    expect(shouldShowChangelog("", "15.99.0")).toBe(true);
+  });
+});
+
+describe("ChangelogModal (RFC-024 Phase 0)", () => {
+  const mockApp = {} as any;
+
+  it("constructs with app, version, and dismiss callback", () => {
+    const onDismiss = jest.fn();
+    const modal = new ChangelogModal(mockApp, "15.99.0", onDismiss);
+    expect(modal).toBeDefined();
+  });
+
+  it("renders header, body, and dismiss button on open", () => {
+    const onDismiss = jest.fn();
+    const modal = new ChangelogModal(mockApp, "15.99.0", onDismiss);
+    modal.onOpen();
+    expect(modal.contentEl.empty).toHaveBeenCalled();
+    expect(modal.contentEl.addClass).toHaveBeenCalledWith(
+      "exocortex-changelog-modal",
+    );
+    expect(modal.contentEl.createEl).toHaveBeenCalledWith(
+      "h2",
+      expect.objectContaining({ text: expect.any(String) }),
+    );
+  });
+
+  it("invokes onDismiss callback and closes when user dismisses", () => {
+    const onDismiss = jest.fn();
+    const modal = new ChangelogModal(mockApp, "15.99.0", onDismiss);
+    modal.dismiss();
+    expect(onDismiss).toHaveBeenCalledWith("15.99.0");
+    expect(modal.close).toHaveBeenCalled();
+  });
+
+  it("empties content on close", () => {
+    const modal = new ChangelogModal(mockApp, "15.99.0", jest.fn());
+    modal.onClose();
+    expect(modal.contentEl.empty).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements RFC-024 Phase 0 (#2833):
- Replaces hardcoded `resolveVariant` switch in `DynamicCommandButtonGroupBuilder` with a data-driven `categoryDefaultVariant` map exported from a new module (`categoryDefaultVariants.ts`).
- Adds first-launch-after-upgrade `ChangelogModal` gated by a new `lastShownChangelogVersion` plugin setting — shown at most once per version.
- Introduces the new `muted` button variant (TS union + CSS class using Obsidian theme vars) required by RFC-024 §4 for `maintenance` actions.

Rollout no longer depends on a starter-kit migration PR: every installation receives the intended default button colors out of the box on upgrade, and users are informed about the change.

## Behaviour change (intentional)

| binding.group  | before    | after      |
|----------------|-----------|------------|
| creation       | secondary | primary    |
| criticality    | secondary | warning    |
| maintenance    | secondary | muted      |
| danger/warning/success/primary literal | matched directly | → secondary (variant name ≠ category) |
| unknown/empty  | secondary | secondary  |

Explicit binding variant overrides (Phase 2 `exocmd__CommandBinding_variant`) remain additive.

## Scope guarded

- **Not touched:** WCAG recalibration of existing `success`/`warning`/`danger` foregrounds, `exo__Layout` extension, `obsmd__CommandBindingStyle` meta-class — all Phase 1 / Phase 2 (#2834). The `muted` addition is a whitelist extension, explicitly sanctioned by RFC-024 §3 («whitelist'ы расширяются, никогда не удаляются»).
- **Forward-compat map entries:** `status/done`, `status/blocked`, `status/cancelled` shipped per AC2 but inert today (starter-kit bindings use flat `status`). They activate when sub-category granularity is introduced.

## Test plan

- [x] Unit tests for 9 variant resolution cases (`categoryDefaultVariants.test.ts`, 16 assertions)
- [x] Unit tests for `ChangelogModal` show/hide logic + dismiss wiring (9 assertions)
- [x] Existing `DynamicCommandButtonGroupBuilder` test updated to assert new map contract (`creation`→`primary`, `maintenance`→`muted`, unknown→`secondary`)
- [x] Existing `ButtonGroupsBuilder.build.test.ts` updated to match new default variants
- [x] `npm run check:types` green
- [x] `npm test` (unit + UI + component = 539 passed / 31 skipped) green locally
- [ ] CI 8 checks + Auto Release

Closes #2833
Part of RFC-024 FINAL v1 (Beta GA milestone #73, vault UUID `83d5a78e-8ba1-436d-b97f-6cf1cf5add74`)