### PR TITLE
fix(sparql): strip `#` line comments before CASE WHEN scan (closes #2835)

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/CaseWhenTransformer.ts
+++ b/packages/exocortex/src/infrastructure/sparql/CaseWhenTransformer.ts
@@ -39,9 +39,11 @@ export class CaseWhenTransformer {
    * @throws CaseWhenTransformerError if CASE WHEN syntax is malformed
    */
   transform(query: string): string {
-    // Keep transforming until no more CASE expressions are found
-    // (handles nested CASE expressions)
-    let result = query;
+    // Strip SPARQL `#` line comments first so that keywords like
+    // CASE/WHEN/THEN/ELSE/END living inside a comment do not confuse the
+    // scanner. Comment characters are replaced with equivalent whitespace so
+    // positions in downstream error messages still line up with the input.
+    let result = this.stripLineComments(query);
     let transformed: string;
     let iterationCount = 0;
     const maxIterations = 100; // Prevent infinite loops
@@ -57,6 +59,63 @@ export class CaseWhenTransformer {
       }
     } while (result !== transformed);
 
+    return result;
+  }
+
+  /**
+   * Replace SPARQL `#` line comments with equivalent-length whitespace.
+   * Strings and `<...>` IRIs are copied through untouched so that a `#`
+   * inside them is not treated as the start of a comment.
+   */
+  private stripLineComments(query: string): string {
+    let result = "";
+    let i = 0;
+    while (i < query.length) {
+      const char = query[i];
+
+      if (char === "'" || char === '"') {
+        const quote = char;
+        result += char;
+        i++;
+        while (i < query.length && query[i] !== quote) {
+          if (query[i] === "\\" && i + 1 < query.length) {
+            result += query[i] + query[i + 1];
+            i += 2;
+            continue;
+          }
+          result += query[i];
+          i++;
+        }
+        if (i < query.length) {
+          result += query[i];
+          i++;
+        }
+        continue;
+      }
+
+      if (char === "<") {
+        const end = query.indexOf(">", i);
+        // IRIrefs in SPARQL cannot contain newlines — if we don't find `>`
+        // on the same line, treat `<` as an ordinary character.
+        const nextNewline = query.indexOf("\n", i);
+        if (end !== -1 && (nextNewline === -1 || end < nextNewline)) {
+          result += query.substring(i, end + 1);
+          i = end + 1;
+          continue;
+        }
+      }
+
+      if (char === "#") {
+        const newline = query.indexOf("\n", i);
+        const end = newline === -1 ? query.length : newline;
+        result += " ".repeat(end - i);
+        i = end;
+        continue;
+      }
+
+      result += char;
+      i++;
+    }
     return result;
   }
 
@@ -358,7 +417,7 @@ export class CaseWhenTransformer {
    */
   private extractElseClause(caseExpr: string): string | null {
     // Remove CASE and END keywords
-    let content = caseExpr.replace(/^\s*CASE\s+/i, "").replace(/\s*END\s*$/i, "");
+    const content = caseExpr.replace(/^\s*CASE\s+/i, "").replace(/\s*END\s*$/i, "");
 
     // Find ELSE position at top level
     const elsePositions = this.findKeywordPositions(content, "ELSE");

--- a/packages/obsidian-plugin/tests/unit/infrastructure/sparql/CaseWhenTransformer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/sparql/CaseWhenTransformer.test.ts
@@ -241,4 +241,52 @@ describe("CaseWhenTransformer", () => {
       expect(result).toBe(`IF(BOUND(?x), ?x, ?default)`);
     });
   });
+
+  describe("SPARQL `#` line comments (bug #2835)", () => {
+    it("should ignore CASE keyword inside a line comment", () => {
+      const input = `# Test: CASE WHEN status is done THEN mark finished
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+SELECT ?s WHERE { ?s ems:Effort_status ?o } LIMIT 1`;
+      expect(() => transformer.transform(input)).not.toThrow();
+      const result = transformer.transform(input);
+      expect(result).toContain("SELECT ?s");
+      expect(result).not.toContain("IF(");
+    });
+
+    it("should ignore WHEN/THEN/ELSE/END keywords inside a trailing comment", () => {
+      const input = `SELECT ?s WHERE { ?s ?p ?o } # WHEN the query runs we take every END`;
+      expect(() => transformer.transform(input)).not.toThrow();
+    });
+
+    it("should not treat `#` inside an IRI as a comment start", () => {
+      const input = `PREFIX ems: <https://exocortex.my/ontology/ems#> # CASE study of CASE WHEN END
+SELECT ?s WHERE { ?s ems:Effort_status ?o }`;
+      expect(() => transformer.transform(input)).not.toThrow();
+    });
+
+    it("should not treat `#` inside a double-quoted string as a comment start", () => {
+      const input = `CASE WHEN ?label = "# CASE study" THEN "hit" ELSE "miss" END`;
+      const result = transformer.transform(input);
+      expect(result).toBe(`IF(?label = "# CASE study", "hit", "miss")`);
+    });
+
+    it("should not treat `#` inside a single-quoted string as a comment start", () => {
+      const input = `CASE WHEN ?label = '# END of line' THEN 'yes' ELSE 'no' END`;
+      const result = transformer.transform(input);
+      expect(result).toBe(`IF(?label = '# END of line', 'yes', 'no')`);
+    });
+
+    it("should transform a valid CASE WHEN even when a sibling comment mentions CASE", () => {
+      const input = `# header: use CASE WHEN for branching
+SELECT (CASE WHEN ?x > 10 THEN "high" ELSE "low" END AS ?level) WHERE { ?s :v ?x }`;
+      const result = transformer.transform(input);
+      expect(result).toContain(`IF(?x > 10, "high", "low")`);
+      expect(result).not.toContain("CASE WHEN ?x");
+    });
+
+    it("should handle a comment-only query without error", () => {
+      const input = `# just a CASE WHEN END comment with no SPARQL content`;
+      expect(() => transformer.transform(input)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`CaseWhenTransformer` walked the raw SPARQL query to find CASE/WHEN/END tokens and did not recognise `#` line comments. A comment whose body contained any of those keywords produced `CASE WHEN transformation error: Unclosed CASE expression at position N`, making it impossible to annotate `.rq` files (discovered writing regression invariants for `kitelev/exocortex-starter-kit`).

## Fix

Added `stripLineComments()` that replaces each `#...\n` with equivalent-length whitespace before the CASE scanning loop. Positions in downstream error messages stay aligned with the input. Strings (`"..."`, `'...'`) and IRIrefs (`<...>`) are copied through untouched so a `#` inside them (e.g. the fragment in `<http://example.org/ont#foo>`) is not treated as a comment start.

## Tests

7 new cases in `CaseWhenTransformer.test.ts` under `describe("SPARQL \`#\` line comments (bug #2835)")`:
- Issue repro verbatim
- `<...#foo>` IRI fragment + comment on same line
- `"# not a comment"` and `'# END of line'` string literals
- Trailing `#` comment after valid SPARQL
- Sibling comment mentioning CASE alongside a real `CASE WHEN`
- Comment-only query

All 36 tests green locally. End-to-end verified via locally-built CLI (`packages/cli/dist/index.js`) against the exact repro from the issue.

## Closes

Closes #2835