### PR TITLE
feat(eslint): block Node.js built-ins in plugin/core src (no-restricted-imports)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,6 +57,29 @@ export default tseslint.config(
         selector: 'NewExpression[callee.name="Notice"]',
         message: 'Use INotificationService instead of direct new Notice(). Only ObsidianNotificationService may call new Notice().',
       }],
+
+      // Block Node.js built-ins in plugin/core src for mobile compatibility.
+      // manifest.json sets "isDesktopOnly": false → plugin targets mobile
+      // Obsidian (WKWebView/WebView without a Node.js runtime). Importing
+      // fs/child_process/os/path would crash the plugin on mobile load.
+      // Tests and scripts may use Node APIs (see overrides below).
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: [
+              'fs', 'fs/*',
+              'node:fs', 'node:fs/*',
+              'child_process',
+              'node:child_process',
+              'os',
+              'node:os',
+              'path', 'path/*',
+              'node:path', 'node:path/*',
+            ],
+            message: 'Node.js built-ins (fs/child_process/os/path) are forbidden in plugin/core src — plugin is mobile-compatible (manifest isDesktopOnly=false) and would crash on Obsidian mobile (WebView without Node runtime). Use Obsidian Vault/FileSystemAdapter APIs instead.',
+          },
+        ],
+      }],
     },
   },
   {
@@ -70,6 +93,7 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
+      'no-restricted-imports': 'off',
     },
   },
   {


### PR DESCRIPTION
## Summary
- Adds `no-restricted-imports` rule to `eslint.config.mjs` blocking `fs`, `child_process`, `os`, `path` (+ `node:` prefix aliases + sub-paths like `fs/promises`, `path/posix`) in all src/ files.
- Test override extends `'no-restricted-imports': 'off'` so tests retain Node APIs.
- Rationale comment in config explains mobile compatibility constraint.

## Rationale
`packages/obsidian-plugin/manifest.json` sets `"isDesktopOnly": false` → the plugin targets mobile Obsidian, which runs inside a WKWebView/WebView without a Node.js runtime. Any `fs`/`child_process`/`os`/`path` import at src level would throw on mobile load and crash the plugin.

This is a **preventive guardrail** — the current codebase is already free of such imports (grep-clean baseline across `packages/obsidian-plugin/src` and `packages/exocortex/src`). The rule defends against future regressions.

## Test case (temporary file, not committed)

Created `packages/obsidian-plugin/src/tmp-test.ts` with:
```ts
import fs from 'fs';
import { readFile } from 'node:fs/promises';
import { exec } from 'child_process';
import os from 'node:os';
import path from 'path';
```

`npx eslint packages/obsidian-plugin/src/tmp-test.ts` output (5 violations, exit 1):
```
  1:1  error  'fs' import is restricted from being used by a pattern. Node.js built-ins (fs/child_process/os/path) are forbidden in plugin/core src — plugin is mobile-compatible (manifest isDesktopOnly=false) and would crash on Obsidian mobile (WebView without Node runtime). Use Obsidian Vault/FileSystemAdapter APIs instead  no-restricted-imports
  2:1  error  'node:fs/promises' import is restricted from being used by a pattern. ...  no-restricted-imports
  3:1  error  'child_process' import is restricted from being used by a pattern. ...     no-restricted-imports
  4:1  error  'node:os' import is restricted from being used by a pattern. ...           no-restricted-imports
  5:1  error  'path' import is restricted from being used by a pattern. ...              no-restricted-imports

✖ 10 problems (10 errors, 0 warnings)
```
(5 x `no-restricted-imports` + 5 x `import/no-nodejs-modules` from the already-present `obsidianmd/platform` preset — my rule supplies the project-specific rationale message.)

File deleted before commit.

## Baseline
`npm run lint` before my change: 4 problems (2 errors, 2 warnings) — all pre-existing (`obsidianmd/ui/sentence-case` in `ExocortexSettingTab.ts` + `@typescript-eslint/no-non-null-assertion` warnings).
`npm run lint` after my change: identical 4 problems. Zero new violations introduced by `no-restricted-imports`.

## Acceptance Criteria (Task e628db29)
- [x] Rule added to `eslint.config.mjs`
- [x] `npm run lint` introduces zero new violations on current code (preventive, baseline grep-clean)
- [x] Test case verified: temporary `import fs from 'fs'` → ESLint blocks with clear error message (output pasted above, file not committed)
- [x] Documentation comment in config explains rationale (mobile compatibility, manifest `isDesktopOnly=false`)

## Parent project
`246cc520-239a-4be8-ae35-a924dea1bba1` — Exocortex lightweight test mitigations (RFC-025 v6 replacement)

## Test plan
- [x] `npm run lint` passes with same baseline as main
- [x] Temporary Node import triggers the rule with custom message
- [x] Tests remain unaffected (`no-restricted-imports: off` in test override)