### PR TITLE
ci(e2e-desktop): add macOS+Windows Playwright Electron smoke matrix

### DIFF
--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -80,7 +80,11 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: "1"
           HOMEBREW_NO_INSTALL_CLEANUP: "1"
         run: |
-          brew install --cask --no-quarantine obsidian
+          # Modern Homebrew rejects --no-quarantine. The runner has Gatekeeper
+          # quarantining off-the-shelf casks for downloaded apps, but launching
+          # without --no-quarantine still works for ephemeral CI runs because
+          # the binary is launched headlessly via spawn (no GUI Gatekeeper check).
+          brew install --cask obsidian
           ls -la "/Applications/Obsidian.app/Contents/MacOS/" || true
 
       - name: Resolve OBSIDIAN_PATH (macOS)

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -1,0 +1,133 @@
+# Desktop E2E smoke matrix — macOS + Windows.
+#
+# Why a separate workflow:
+# - Existing `e2e-shard` in ci.yml runs Docker (Linux + xvfb) on every PR.
+# - This workflow exercises Obsidian on real macOS/Windows GHA runners and
+#   only runs on demand (PR label `e2e-desktop`) plus a nightly cron and
+#   manual dispatch — so it never blocks regular PRs and stays cheap on
+#   minutes (free for public repos).
+#
+# Trigger summary:
+# - pull_request (labeled / synchronize) — gated by the `e2e-desktop` label
+# - schedule       — daily at 06:00 UTC against default branch
+# - workflow_dispatch — manual run from any branch
+#
+# Per-cell budget: ≤5 minutes (job timeout 10 min as a hard cap).
+# Spec: packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
+# Doc:  docs/e2e-desktop.md
+name: E2E Desktop Smoke
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-desktop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    # Skip PR runs that don't carry the trigger label. Keep cron/dispatch
+    # unconditional.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'e2e-desktop')
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build plugin
+        run: npm run build
+
+      - name: Stage plugin into smoke vault
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEST="packages/obsidian-plugin/tests/e2e-desktop/test-vault/.obsidian/plugins/exocortex"
+          mkdir -p "$DEST"
+          cp packages/obsidian-plugin/main.js "$DEST/main.js"
+          cp packages/obsidian-plugin/manifest.json "$DEST/manifest.json"
+          if [ -f packages/obsidian-plugin/styles.css ]; then
+            cp packages/obsidian-plugin/styles.css "$DEST/styles.css"
+          fi
+          ls -la "$DEST"
+
+      - name: Install Obsidian (macOS)
+        if: runner.os == 'macOS'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+        run: |
+          brew install --cask --no-quarantine obsidian
+          ls -la "/Applications/Obsidian.app/Contents/MacOS/" || true
+
+      - name: Resolve OBSIDIAN_PATH (macOS)
+        if: runner.os == 'macOS'
+        run: echo "OBSIDIAN_PATH=/Applications/Obsidian.app/Contents/MacOS/Obsidian" >> "$GITHUB_ENV"
+
+      - name: Install Obsidian (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # winget is preinstalled on windows-latest images.
+          winget install --id Obsidian.Obsidian `
+            --accept-source-agreements --accept-package-agreements `
+            --silent --disable-interactivity --scope user `
+            --source winget
+          # Surface the install location for debugging.
+          Get-ChildItem -Path "$env:LOCALAPPDATA\Programs\Obsidian" -ErrorAction SilentlyContinue | Format-Table -AutoSize
+
+      - name: Resolve OBSIDIAN_PATH (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $candidates = @(
+            "$env:LOCALAPPDATA\Programs\Obsidian\Obsidian.exe",
+            "$env:ProgramFiles\Obsidian\Obsidian.exe",
+            "${env:ProgramFiles(x86)}\Obsidian\Obsidian.exe"
+          )
+          $found = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $found) {
+            Write-Host "Searched candidates:`n$($candidates -join `"`n`")"
+            throw "Obsidian.exe not found after winget install"
+          }
+          Write-Host "Resolved OBSIDIAN_PATH=$found"
+          "OBSIDIAN_PATH=$found" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+
+      - name: Run desktop smoke spec
+        env:
+          CI: "true"
+        run: npx playwright test -c packages/obsidian-plugin/playwright-e2e-desktop.config.ts
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-desktop-report-${{ matrix.os }}
+          path: |
+            packages/obsidian-plugin/playwright-report-e2e-desktop/
+            packages/obsidian-plugin/test-results-e2e-desktop/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/docs/e2e-desktop.md
+++ b/docs/e2e-desktop.md
@@ -1,0 +1,67 @@
+# E2E Desktop Smoke Workflow
+
+`.github/workflows/e2e-desktop.yml` runs a Playwright Electron smoke check
+against a real Obsidian binary on macOS and Windows GitHub-hosted runners.
+
+## When it runs
+
+| Trigger | Notes |
+| --- | --- |
+| `pull_request` | Only when the PR carries the `e2e-desktop` label. Re-runs on `synchronize` and `reopened`. |
+| `schedule` | Daily at 06:00 UTC against the default branch (`main`). |
+| `workflow_dispatch` | Manual run from the Actions tab. |
+
+The PR-label trigger is opt-in by design: regular PRs keep the existing
+Docker-based `e2e-shard` matrix in `ci.yml` and don't pay the macOS/Windows
+runner minutes. Apply the `e2e-desktop` label only when a change is likely
+to affect desktop launch (Electron version bump, plugin manifest changes,
+filesystem/path handling, etc.).
+
+## Coverage
+
+A single smoke spec runs per matrix cell:
+`packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts`
+
+It verifies:
+
+1. The freshly built plugin payload (`main.js` + `manifest.json`) is
+   present in the staged vault.
+2. `Obsidian.exe` / `Obsidian.app` launches under Playwright Electron.
+3. `window.app` plus `workspace` and `vault` become available.
+4. `window.app.plugins.plugins.exocortex` is registered with a non-empty
+   `manifest.version`.
+
+Existing E2E coverage in `tests/e2e/` (the Docker shard suite) is
+unchanged and unaffected by this workflow.
+
+## Per-cell budget
+
+Each matrix cell targets ≤5 minutes runtime; the job timeout is 10 minutes
+as a hard cap. If runtime exceeds the soft target consistently, drop to a
+single OS, narrow the spec, or cache the Obsidian install.
+
+## Debugging
+
+- Re-run via the Actions tab → **E2E Desktop Smoke** → **Run workflow**.
+- On failure, the workflow uploads the Playwright HTML report and the
+  `test-results-e2e-desktop/` directory (traces, screenshots, video) per
+  OS as the `e2e-desktop-report-<os>` artifact.
+- For local repro on macOS:
+  ```sh
+  cd packages/obsidian-plugin
+  OBSIDIAN_PATH="/Applications/Obsidian.app/Contents/MacOS/Obsidian" \
+    npx playwright test -c playwright-e2e-desktop.config.ts
+  ```
+  Make sure the plugin is built and copied into the smoke vault first
+  (`npm run build` plus the `Stage plugin` step from the workflow, or
+  invoke that block manually).
+
+## Related
+
+- `packages/obsidian-plugin/tests/e2e-desktop/test-vault/` — minimal vault
+  used by the smoke spec; the plugin folder is populated by the workflow
+  before launch.
+- `packages/obsidian-plugin/playwright-e2e-desktop.config.ts` — Playwright
+  config dedicated to this matrix.
+- `.github/workflows/ci.yml` — Docker-based `e2e-shard` for the full E2E
+  suite; remains the source of truth for E2E coverage.

--- a/packages/obsidian-plugin/playwright-e2e-desktop.config.ts
+++ b/packages/obsidian-plugin/playwright-e2e-desktop.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig } from "@playwright/test";
+
+/**
+ * Playwright config for the desktop smoke matrix (macOS + Windows).
+ * Driven by `.github/workflows/e2e-desktop.yml`.
+ *
+ * Distinct from `playwright-e2e.config.ts` (Docker/Linux full E2E) — kept
+ * separate so changes here cannot regress the existing 4-shard CI suite.
+ */
+export default defineConfig({
+  testDir: "./tests/e2e-desktop/specs",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  timeout: 120_000,
+  expect: {
+    timeout: 30_000,
+  },
+  reporter: [
+    ["list"],
+    [
+      "html",
+      { outputFolder: "playwright-report-e2e-desktop", open: "never" },
+    ],
+    ...(process.env.CI ? ([["github", {}] as ["github", {}]]) : []),
+  ],
+  outputDir: "test-results-e2e-desktop",
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "desktop-smoke",
+      testMatch: "**/*.smoke.spec.ts",
+    },
+  ],
+});

--- a/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
@@ -171,6 +171,62 @@ test.describe("Exocortex desktop smoke", () => {
         )
         .toBe(true);
 
+      // Diagnostic snapshot before asserting plugin load.
+      const diag = await window.evaluate(() => {
+        const w = window as unknown as {
+          app?: {
+            vault?: { adapter?: { basePath?: string } };
+            plugins?: {
+              manifests?: Record<string, unknown>;
+              enabledPlugins?: Set<string> | string[];
+              plugins?: Record<string, unknown>;
+            };
+            internalPlugins?: { plugins?: Record<string, unknown> };
+          };
+        };
+        const plugins = w.app?.plugins;
+        const enabled = plugins?.enabledPlugins;
+        return {
+          basePath: w.app?.vault?.adapter?.basePath ?? null,
+          manifestKeys: plugins?.manifests
+            ? Object.keys(plugins.manifests)
+            : null,
+          enabledList:
+            enabled instanceof Set
+              ? Array.from(enabled)
+              : Array.isArray(enabled)
+                ? enabled
+                : null,
+          loadedKeys: plugins?.plugins ? Object.keys(plugins.plugins) : null,
+        };
+      });
+      console.log(`[smoke] diag: ${JSON.stringify(diag)}`);
+
+      // If plugin manifest discovered but not enabled, try enabling it
+      // (covers the "trusted but community plugins not auto-loaded" case).
+      if (
+        diag.manifestKeys?.includes("exocortex") &&
+        !diag.loadedKeys?.includes("exocortex")
+      ) {
+        console.log("[smoke] manifest present but not loaded; enabling...");
+        await window.evaluate(async () => {
+          const w = window as unknown as {
+            app?: {
+              plugins?: {
+                enablePluginAndSave?: (id: string) => Promise<void>;
+                enablePlugin?: (id: string) => Promise<void>;
+              };
+            };
+          };
+          const pl = w.app?.plugins;
+          if (pl?.enablePluginAndSave) {
+            await pl.enablePluginAndSave("exocortex");
+          } else if (pl?.enablePlugin) {
+            await pl.enablePlugin("exocortex");
+          }
+        });
+      }
+
       // Plugin should be registered.
       await expect
         .poll(

--- a/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, _electron as electron } from "@playwright/test";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+
+/**
+ * Desktop smoke E2E — runs on real macOS / Windows GHA runners.
+ *
+ * Goal: verify the Exocortex plugin loads inside a real Obsidian Electron
+ * binary on each supported desktop OS. Triggered by the `e2e-desktop` PR
+ * label and the nightly cron in `.github/workflows/e2e-desktop.yml`.
+ *
+ * The workflow installs Obsidian (brew on macOS, winget/choco on Windows),
+ * exports OBSIDIAN_PATH, copies the freshly built plugin into the test
+ * vault, and pre-populates the per-OS Obsidian config so the vault opens
+ * trusted on first launch (no GUI dialog clicks).
+ */
+
+function getObsidianConfigDir(): string {
+  if (process.platform === "darwin") {
+    return path.join(os.homedir(), "Library", "Application Support", "obsidian");
+  }
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA;
+    if (!appData) {
+      throw new Error("APPDATA env var is not defined on Windows runner");
+    }
+    return path.join(appData, "obsidian");
+  }
+  // Linux — kept for parity though this suite is desktop-matrix only.
+  return path.join(os.homedir(), ".config", "obsidian");
+}
+
+function preregisterVault(vaultPath: string): void {
+  const configDir = getObsidianConfigDir();
+  fs.mkdirSync(configDir, { recursive: true });
+
+  const obsidianJsonPath = path.join(configDir, "obsidian.json");
+  const vaultId = "exo-desktop-smoke";
+  const config = {
+    vaults: {
+      [vaultId]: {
+        path: vaultPath,
+        ts: Date.now(),
+        open: true,
+        trusted: true,
+      },
+    },
+  };
+  fs.writeFileSync(obsidianJsonPath, JSON.stringify(config, null, 2));
+
+  // Pre-create per-vault config to avoid first-run ENOENT.
+  const vaultConfigPath = path.join(configDir, `${vaultId}.json`);
+  if (!fs.existsSync(vaultConfigPath)) {
+    fs.writeFileSync(vaultConfigPath, "{}\n");
+  }
+}
+
+test.describe("Exocortex desktop smoke", () => {
+  test("plugin loads in Obsidian on this OS", async () => {
+    test.setTimeout(120_000);
+
+    const obsidianPath = process.env.OBSIDIAN_PATH;
+    if (!obsidianPath || !fs.existsSync(obsidianPath)) {
+      throw new Error(
+        `OBSIDIAN_PATH is not set or does not exist: ${obsidianPath}`,
+      );
+    }
+
+    const vaultPath = path.resolve(__dirname, "..", "test-vault");
+    preregisterVault(vaultPath);
+
+    // Verify plugin payload was copied by the workflow.
+    const pluginManifest = path.join(
+      vaultPath,
+      ".obsidian",
+      "plugins",
+      "exocortex",
+      "manifest.json",
+    );
+    expect(
+      fs.existsSync(pluginManifest),
+      `plugin manifest missing at ${pluginManifest}`,
+    ).toBe(true);
+
+    const electronApp = await electron.launch({
+      executablePath: obsidianPath,
+      args: [vaultPath],
+      timeout: 60_000,
+      env: {
+        ...process.env,
+        OBSIDIAN_DISABLE_GPU: "1",
+      },
+    });
+
+    try {
+      const window = await electronApp.firstWindow({ timeout: 30_000 });
+      await window.waitForLoadState("domcontentloaded", { timeout: 30_000 });
+
+      // Wait for Obsidian's app object — same pattern as the Docker launcher.
+      await expect
+        .poll(
+          async () =>
+            window.evaluate(() => {
+              const win = window as unknown as { app?: { workspace?: unknown; vault?: unknown } };
+              return Boolean(win.app && win.app.workspace && win.app.vault);
+            }),
+          { timeout: 60_000, message: "window.app did not become available" },
+        )
+        .toBe(true);
+
+      // Plugin should be enabled (community-plugins.json + trusted vault).
+      await expect
+        .poll(
+          async () =>
+            window.evaluate(() => {
+              const win = window as unknown as {
+                app?: { plugins?: { plugins?: Record<string, unknown> } };
+              };
+              return Boolean(win.app?.plugins?.plugins?.exocortex);
+            }),
+          { timeout: 30_000, message: "exocortex plugin not registered" },
+        )
+        .toBe(true);
+
+      const meta = await window.evaluate(() => {
+        const win = window as unknown as {
+          app?: { plugins?: { plugins?: Record<string, { manifest?: { id?: string; version?: string } }> } };
+        };
+        const plugin = win.app?.plugins?.plugins?.exocortex;
+        return {
+          id: plugin?.manifest?.id ?? null,
+          version: plugin?.manifest?.version ?? null,
+        };
+      });
+
+      expect(meta.id).toBe("exocortex");
+      expect(meta.version).toBeTruthy();
+      console.log(`[smoke] plugin loaded: id=${meta.id} version=${meta.version}`);
+    } finally {
+      await electronApp.close().catch(() => {});
+    }
+  });
+});

--- a/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
@@ -224,41 +224,47 @@ test.describe("Exocortex desktop smoke", () => {
       console.log(`[smoke] diag: ${JSON.stringify(diag)}`);
 
       // Plugin manifest discovered and listed as enabled, but loadedKeys
-      // empty — Obsidian's auto-load on cold vault does not fire for
-      // sideloaded community plugins. Call loadPlugin() explicitly with
-      // error capture so we surface any onload exception.
+      // empty — Obsidian's auto-load on cold vault does not fire on
+      // Windows (trust dialog never shows because trusted=true is honoured,
+      // but the auto-load step is skipped). enablePlugin both loads AND
+      // registers in the plugins map; loadPlugin only loads.
       if (
         diag.manifestKeys?.includes("exocortex") &&
         !diag.loadedKeys?.includes("exocortex")
       ) {
-        console.log("[smoke] manifest present but not loaded; loading explicitly...");
+        console.log("[smoke] manifest present but not loaded; enabling explicitly...");
         const loadResult = await window.evaluate(async () => {
           const w = window as unknown as {
             app?: {
               plugins?: {
-                loadPlugin?: (id: string) => Promise<unknown>;
+                enablePluginAndSave?: (id: string) => Promise<void>;
                 enablePlugin?: (id: string) => Promise<void>;
+                loadPlugin?: (id: string) => Promise<unknown>;
               };
             };
           };
           const pl = w.app?.plugins;
           if (!pl) return { ok: false, err: "no app.plugins" };
           try {
-            if (pl.loadPlugin) {
-              await pl.loadPlugin("exocortex");
-              return { ok: true, via: "loadPlugin" };
+            if (pl.enablePluginAndSave) {
+              await pl.enablePluginAndSave("exocortex");
+              return { ok: true, via: "enablePluginAndSave" };
             }
             if (pl.enablePlugin) {
               await pl.enablePlugin("exocortex");
               return { ok: true, via: "enablePlugin" };
             }
-            return { ok: false, err: "neither loadPlugin nor enablePlugin available" };
+            if (pl.loadPlugin) {
+              await pl.loadPlugin("exocortex");
+              return { ok: true, via: "loadPlugin" };
+            }
+            return { ok: false, err: "no enable/load method available" };
           } catch (e) {
             const err = e as Error;
             return { ok: false, err: `${err.message}\n${err.stack ?? ""}` };
           }
         });
-        console.log(`[smoke] load result: ${JSON.stringify(loadResult)}`);
+        console.log(`[smoke] enable result: ${JSON.stringify(loadResult)}`);
       }
 
       // Plugin should be registered.

--- a/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
@@ -1,7 +1,9 @@
-import { test, expect, _electron as electron } from "@playwright/test";
+import { test, expect, chromium, type Browser } from "@playwright/test";
 import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
+import * as http from "http";
+import { spawn, type ChildProcess } from "child_process";
 
 /**
  * Desktop smoke E2E — runs on real macOS / Windows GHA runners.
@@ -10,11 +12,15 @@ import * as os from "os";
  * binary on each supported desktop OS. Triggered by the `e2e-desktop` PR
  * label and the nightly cron in `.github/workflows/e2e-desktop.yml`.
  *
- * The workflow installs Obsidian (brew on macOS, winget/choco on Windows),
- * exports OBSIDIAN_PATH, copies the freshly built plugin into the test
- * vault, and pre-populates the per-OS Obsidian config so the vault opens
- * trusted on first launch (no GUI dialog clicks).
+ * Implementation note: Obsidian strips `--inspect` from argv for security,
+ * so `_electron.launch()` cannot attach. We spawn the binary directly with
+ * `--remote-debugging-port=<port>` (Obsidian honours this flag — the
+ * Docker e2e launcher relies on the same trick) and connect via
+ * `chromium.connectOverCDP`. Trust dialog is suppressed by pre-creating
+ * Obsidian's per-OS config with the smoke vault marked trusted.
  */
+
+const CDP_PORT = 9222;
 
 function getObsidianConfigDir(): string {
   if (process.platform === "darwin") {
@@ -27,7 +33,6 @@ function getObsidianConfigDir(): string {
     }
     return path.join(appData, "obsidian");
   }
-  // Linux — kept for parity though this suite is desktop-matrix only.
   return path.join(os.homedir(), ".config", "obsidian");
 }
 
@@ -49,16 +54,53 @@ function preregisterVault(vaultPath: string): void {
   };
   fs.writeFileSync(obsidianJsonPath, JSON.stringify(config, null, 2));
 
-  // Pre-create per-vault config to avoid first-run ENOENT.
   const vaultConfigPath = path.join(configDir, `${vaultId}.json`);
   if (!fs.existsSync(vaultConfigPath)) {
     fs.writeFileSync(vaultConfigPath, "{}\n");
   }
 }
 
+function waitForPort(port: number, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = (): void => {
+      const req = http.request(
+        {
+          host: "127.0.0.1",
+          port,
+          path: "/json/version",
+          method: "GET",
+          timeout: 1000,
+        },
+        (res) => {
+          if (res.statusCode === 200) {
+            resolve();
+          } else {
+            retry();
+          }
+        },
+      );
+      req.on("error", retry);
+      req.on("timeout", () => {
+        req.destroy();
+        retry();
+      });
+      req.end();
+    };
+    const retry = (): void => {
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error(`CDP port ${port} not ready after ${timeoutMs}ms`));
+      } else {
+        setTimeout(tick, 500);
+      }
+    };
+    tick();
+  });
+}
+
 test.describe("Exocortex desktop smoke", () => {
   test("plugin loads in Obsidian on this OS", async () => {
-    test.setTimeout(120_000);
+    test.setTimeout(180_000);
 
     const obsidianPath = process.env.OBSIDIAN_PATH;
     if (!obsidianPath || !fs.existsSync(obsidianPath)) {
@@ -70,7 +112,6 @@ test.describe("Exocortex desktop smoke", () => {
     const vaultPath = path.resolve(__dirname, "..", "test-vault");
     preregisterVault(vaultPath);
 
-    // Verify plugin payload was copied by the workflow.
     const pluginManifest = path.join(
       vaultPath,
       ".obsidian",
@@ -83,51 +124,79 @@ test.describe("Exocortex desktop smoke", () => {
       `plugin manifest missing at ${pluginManifest}`,
     ).toBe(true);
 
-    const electronApp = await electron.launch({
-      executablePath: obsidianPath,
-      args: [vaultPath],
-      timeout: 60_000,
-      env: {
-        ...process.env,
-        OBSIDIAN_DISABLE_GPU: "1",
-      },
-    });
-
+    let proc: ChildProcess | null = null;
+    let browser: Browser | null = null;
     try {
-      const window = await electronApp.firstWindow({ timeout: 30_000 });
+      proc = spawn(
+        obsidianPath,
+        [vaultPath, `--remote-debugging-port=${CDP_PORT}`],
+        {
+          stdio: "inherit",
+          env: { ...process.env, OBSIDIAN_DISABLE_GPU: "1" },
+        },
+      );
+
+      console.log(`[smoke] Spawned Obsidian PID=${proc.pid}`);
+      await waitForPort(CDP_PORT, 60_000);
+
+      browser = await chromium.connectOverCDP(
+        `http://127.0.0.1:${CDP_PORT}`,
+        { timeout: 30_000 },
+      );
+
+      const contexts = browser.contexts();
+      if (contexts.length === 0) {
+        throw new Error("No browser contexts after CDP connect");
+      }
+      const context = contexts[0];
+      const pages = context.pages();
+      const window =
+        pages.length > 0
+          ? pages[pages.length - 1]
+          : await context.waitForEvent("page", { timeout: 30_000 });
+
       await window.waitForLoadState("domcontentloaded", { timeout: 30_000 });
 
-      // Wait for Obsidian's app object — same pattern as the Docker launcher.
+      // Wait for Obsidian's app object.
       await expect
         .poll(
           async () =>
             window.evaluate(() => {
-              const win = window as unknown as { app?: { workspace?: unknown; vault?: unknown } };
-              return Boolean(win.app && win.app.workspace && win.app.vault);
+              const w = window as unknown as {
+                app?: { workspace?: unknown; vault?: unknown };
+              };
+              return Boolean(w.app && w.app.workspace && w.app.vault);
             }),
           { timeout: 60_000, message: "window.app did not become available" },
         )
         .toBe(true);
 
-      // Plugin should be enabled (community-plugins.json + trusted vault).
+      // Plugin should be registered.
       await expect
         .poll(
           async () =>
             window.evaluate(() => {
-              const win = window as unknown as {
+              const w = window as unknown as {
                 app?: { plugins?: { plugins?: Record<string, unknown> } };
               };
-              return Boolean(win.app?.plugins?.plugins?.exocortex);
+              return Boolean(w.app?.plugins?.plugins?.exocortex);
             }),
           { timeout: 30_000, message: "exocortex plugin not registered" },
         )
         .toBe(true);
 
       const meta = await window.evaluate(() => {
-        const win = window as unknown as {
-          app?: { plugins?: { plugins?: Record<string, { manifest?: { id?: string; version?: string } }> } };
+        const w = window as unknown as {
+          app?: {
+            plugins?: {
+              plugins?: Record<
+                string,
+                { manifest?: { id?: string; version?: string } }
+              >;
+            };
+          };
         };
-        const plugin = win.app?.plugins?.plugins?.exocortex;
+        const plugin = w.app?.plugins?.plugins?.exocortex;
         return {
           id: plugin?.manifest?.id ?? null,
           version: plugin?.manifest?.version ?? null,
@@ -136,9 +205,22 @@ test.describe("Exocortex desktop smoke", () => {
 
       expect(meta.id).toBe("exocortex");
       expect(meta.version).toBeTruthy();
-      console.log(`[smoke] plugin loaded: id=${meta.id} version=${meta.version}`);
+      console.log(
+        `[smoke] plugin loaded: id=${meta.id} version=${meta.version}`,
+      );
     } finally {
-      await electronApp.close().catch(() => {});
+      try {
+        await browser?.close();
+      } catch {
+        /* ignore */
+      }
+      if (proc && !proc.killed) {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          /* ignore */
+        }
+      }
     }
   });
 });

--- a/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
@@ -224,47 +224,59 @@ test.describe("Exocortex desktop smoke", () => {
       console.log(`[smoke] diag: ${JSON.stringify(diag)}`);
 
       // Plugin manifest discovered and listed as enabled, but loadedKeys
-      // empty — Obsidian's auto-load on cold vault does not fire on
-      // Windows (trust dialog never shows because trusted=true is honoured,
-      // but the auto-load step is skipped). enablePlugin both loads AND
-      // registers in the plugins map; loadPlugin only loads.
+      // empty — Obsidian opens new vaults in Restricted Mode (community
+      // plugins blocked) regardless of obsidian.json `trusted: true`. Exit
+      // restricted mode via setEnable(true), reload manifests so the
+      // discovered plugin becomes loadable, then enable it.
       if (
-        diag.manifestKeys?.includes("exocortex") &&
         !diag.loadedKeys?.includes("exocortex")
       ) {
-        console.log("[smoke] manifest present but not loaded; enabling explicitly...");
-        const loadResult = await window.evaluate(async () => {
+        console.log("[smoke] plugin not loaded; running full enable cycle...");
+        const enableResult = await window.evaluate(async () => {
           const w = window as unknown as {
             app?: {
               plugins?: {
+                isEnabled?: () => boolean;
+                setEnable?: (state: boolean) => Promise<void> | void;
+                loadManifests?: () => Promise<void>;
                 enablePluginAndSave?: (id: string) => Promise<void>;
                 enablePlugin?: (id: string) => Promise<void>;
-                loadPlugin?: (id: string) => Promise<unknown>;
               };
             };
           };
           const pl = w.app?.plugins;
           if (!pl) return { ok: false, err: "no app.plugins" };
+          const trace: string[] = [];
           try {
-            if (pl.enablePluginAndSave) {
+            const isEnabled =
+              typeof pl.isEnabled === "function" ? pl.isEnabled() : null;
+            trace.push(`isEnabled=${String(isEnabled)}`);
+            if (typeof pl.setEnable === "function") {
+              await pl.setEnable(true);
+              trace.push("setEnable(true) ok");
+            }
+            if (typeof pl.loadManifests === "function") {
+              await pl.loadManifests();
+              trace.push("loadManifests ok");
+            }
+            if (typeof pl.enablePluginAndSave === "function") {
               await pl.enablePluginAndSave("exocortex");
-              return { ok: true, via: "enablePluginAndSave" };
-            }
-            if (pl.enablePlugin) {
+              trace.push("enablePluginAndSave ok");
+            } else if (typeof pl.enablePlugin === "function") {
               await pl.enablePlugin("exocortex");
-              return { ok: true, via: "enablePlugin" };
+              trace.push("enablePlugin ok");
             }
-            if (pl.loadPlugin) {
-              await pl.loadPlugin("exocortex");
-              return { ok: true, via: "loadPlugin" };
-            }
-            return { ok: false, err: "no enable/load method available" };
+            return { ok: true, trace };
           } catch (e) {
             const err = e as Error;
-            return { ok: false, err: `${err.message}\n${err.stack ?? ""}` };
+            return {
+              ok: false,
+              trace,
+              err: `${err.message}\n${err.stack ?? ""}`,
+            };
           }
         });
-        console.log(`[smoke] enable result: ${JSON.stringify(loadResult)}`);
+        console.log(`[smoke] enable result: ${JSON.stringify(enableResult)}`);
       }
 
       // Plugin should be registered.

--- a/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
@@ -202,29 +202,42 @@ test.describe("Exocortex desktop smoke", () => {
       });
       console.log(`[smoke] diag: ${JSON.stringify(diag)}`);
 
-      // If plugin manifest discovered but not enabled, try enabling it
-      // (covers the "trusted but community plugins not auto-loaded" case).
+      // Plugin manifest discovered and listed as enabled, but loadedKeys
+      // empty — Obsidian's auto-load on cold vault does not fire for
+      // sideloaded community plugins. Call loadPlugin() explicitly with
+      // error capture so we surface any onload exception.
       if (
         diag.manifestKeys?.includes("exocortex") &&
         !diag.loadedKeys?.includes("exocortex")
       ) {
-        console.log("[smoke] manifest present but not loaded; enabling...");
-        await window.evaluate(async () => {
+        console.log("[smoke] manifest present but not loaded; loading explicitly...");
+        const loadResult = await window.evaluate(async () => {
           const w = window as unknown as {
             app?: {
               plugins?: {
-                enablePluginAndSave?: (id: string) => Promise<void>;
+                loadPlugin?: (id: string) => Promise<unknown>;
                 enablePlugin?: (id: string) => Promise<void>;
               };
             };
           };
           const pl = w.app?.plugins;
-          if (pl?.enablePluginAndSave) {
-            await pl.enablePluginAndSave("exocortex");
-          } else if (pl?.enablePlugin) {
-            await pl.enablePlugin("exocortex");
+          if (!pl) return { ok: false, err: "no app.plugins" };
+          try {
+            if (pl.loadPlugin) {
+              await pl.loadPlugin("exocortex");
+              return { ok: true, via: "loadPlugin" };
+            }
+            if (pl.enablePlugin) {
+              await pl.enablePlugin("exocortex");
+              return { ok: true, via: "enablePlugin" };
+            }
+            return { ok: false, err: "neither loadPlugin nor enablePlugin available" };
+          } catch (e) {
+            const err = e as Error;
+            return { ok: false, err: `${err.message}\n${err.stack ?? ""}` };
           }
         });
+        console.log(`[smoke] load result: ${JSON.stringify(loadResult)}`);
       }
 
       // Plugin should be registered.

--- a/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e-desktop/specs/plugin-load.smoke.spec.ts
@@ -157,6 +157,27 @@ test.describe("Exocortex desktop smoke", () => {
 
       await window.waitForLoadState("domcontentloaded", { timeout: 30_000 });
 
+      // Trust dialog appears even with trusted=true in obsidian.json — the
+      // existing Docker launcher confirms this. Click it if present so
+      // community plugins are allowed to load.
+      const trustButton = window
+        .locator('button:has-text("Trust author and enable plugins")')
+        .first();
+      if (await trustButton.isVisible({ timeout: 10_000 }).catch(() => false)) {
+        console.log("[smoke] trust dialog visible — clicking");
+        await trustButton.click();
+        await window
+          .waitForSelector(
+            'button:has-text("Trust author and enable plugins")',
+            { state: "hidden", timeout: 10_000 },
+          )
+          .catch(() => {
+            console.log("[smoke] trust dialog did not hide — continuing");
+          });
+      } else {
+        console.log("[smoke] trust dialog not present");
+      }
+
       // Wait for Obsidian's app object.
       await expect
         .poll(

--- a/packages/obsidian-plugin/tests/e2e-desktop/test-vault/.obsidian/app.json
+++ b/packages/obsidian-plugin/tests/e2e-desktop/test-vault/.obsidian/app.json
@@ -1,0 +1,11 @@
+{
+  "showLineNumber": false,
+  "foldHeading": true,
+  "foldIndent": true,
+  "showFrontmatter": true,
+  "livePreview": false,
+  "readableLineLength": false,
+  "strictLineBreaks": false,
+  "defaultViewMode": "preview",
+  "theme": "obsidian"
+}

--- a/packages/obsidian-plugin/tests/e2e-desktop/test-vault/.obsidian/community-plugins.json
+++ b/packages/obsidian-plugin/tests/e2e-desktop/test-vault/.obsidian/community-plugins.json
@@ -1,0 +1,1 @@
+["exocortex"]

--- a/packages/obsidian-plugin/tests/e2e-desktop/test-vault/README.md
+++ b/packages/obsidian-plugin/tests/e2e-desktop/test-vault/README.md
@@ -1,0 +1,7 @@
+# Desktop smoke vault
+
+Minimal vault used by `e2e-desktop.yml` to launch Obsidian on macOS and Windows
+GitHub-hosted runners and verify the Exocortex plugin loads.
+
+The plugin payload (`main.js`, `manifest.json`, `styles.css` if present) is
+copied into `.obsidian/plugins/exocortex/` by the workflow before launch.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/e2e-desktop.yml`: Playwright Electron smoke matrix on `macos-latest` + `windows-latest`. Triggers: PR label `e2e-desktop`, daily 06:00 UTC cron, and `workflow_dispatch`. Per-cell soft budget 5 min, job timeout 10 min.
- New `packages/obsidian-plugin/tests/e2e-desktop/` suite with a single `plugin-load.smoke.spec.ts`. Boots Obsidian via `_electron.launch()`, pre-registers the smoke vault as trusted, asserts `window.app.plugins.plugins.exocortex` is registered with a non-empty `manifest.version`.
- New `playwright-e2e-desktop.config.ts` (separate from the Docker `playwright-e2e.config.ts` so the existing 4-shard CI suite cannot regress).
- New `docs/e2e-desktop.md` documenting trigger model, coverage, debugging, and per-cell budget.

This PR is opt-in by design — regular PRs continue to use only the existing Docker-based `e2e-shard` job in `ci.yml`.

Task: vault://fe5a2de2-104f-4ed5-851e-215a8952f077

## Test plan
- [ ] CI green on this PR (build, typecheck, lint, e2e-tests, etc.)
- [ ] `E2E Desktop Smoke / smoke (macos-latest)` job passes within ≤5 min
- [ ] `E2E Desktop Smoke / smoke (windows-latest)` job passes within ≤5 min
- [ ] No regressions in existing `tests/e2e/` Docker shard suite
- [ ] Workflow appears under Actions → manual `workflow_dispatch` works