### PR TITLE
fix(grounding): quote inherited isDefinedBy + unify Project area via ems__Effort_area (#2850)

### DIFF
--- a/packages/exocortex/src/services/GenericAssetCreationService.ts
+++ b/packages/exocortex/src/services/GenericAssetCreationService.ts
@@ -116,7 +116,7 @@ export class GenericAssetCreationService {
 
     // Set required system properties
     frontmatter["exo__Asset_uid"] = uid;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
+     
     frontmatter["exo__Asset_createdAt"] = DateFormatter.toLocalTimestamp(now);
     frontmatter["exo__Instance_class"] = [this.formatWikilink(config.className)];
 
@@ -181,20 +181,28 @@ export class GenericAssetCreationService {
         : null;
     }
 
-    // For projects created from areas, inherit the area
+    // For projects created from areas/projects/tasks, inherit the parent via
+    // the unified ems__Effort_* convention (same as Task). When the parent is
+    // an Area, write ems__Effort_area; otherwise ems__Effort_parent. This
+    // replaces the legacy ems__Project_area emission (issue #2850) — downstream
+    // code only consumes the ems__Effort_* properties.
     if (config.className === "ems__Project" || config.className.startsWith("ems__Project")) {
-      // If parent is an area, set it as area reference
       const parentClass = parentMetadata.exo__Instance_class;
-      if (this.isAreaClass(parentClass)) {
-        frontmatter["ems__Project_area"] = parentName
-          ? this.formatWikilink(parentName)
-          : null;
-      }
+      const isAreaParent = this.isAreaClass(parentClass);
+      const parentPropertyName = isAreaParent ? "ems__Effort_area" : "ems__Effort_parent";
+      frontmatter[parentPropertyName] = parentName
+        ? this.formatWikilink(parentName)
+        : null;
     }
 
-    // Inherit isDefinedBy if available
+    // Inherit isDefinedBy if available. Re-quote via formatWikilink so that
+    // namespace-prefixed wikilinks like `[[!foo]]` — which lose their outer
+    // YAML quotes when Obsidian metadataCache parses the parent — are not
+    // re-emitted as unquoted YAML tag directives (issue #2850).
     if (parentMetadata.exo__Asset_isDefinedBy) {
-      frontmatter["exo__Asset_isDefinedBy"] = parentMetadata.exo__Asset_isDefinedBy;
+      const inherited = parentMetadata.exo__Asset_isDefinedBy;
+      frontmatter["exo__Asset_isDefinedBy"] =
+        typeof inherited === "string" ? this.formatWikilink(inherited) : inherited;
     }
   }
 
@@ -295,7 +303,7 @@ export class GenericAssetCreationService {
       return value;
     }
     if (value instanceof Date) {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
+       
       return DateFormatter.toLocalTimestamp(value);
     }
     if (typeof value === "string") {
@@ -348,7 +356,7 @@ export class GenericAssetCreationService {
    */
   private formatTimestamp(value: unknown): string {
     if (value instanceof Date) {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
+       
       return DateFormatter.toLocalTimestamp(value);
     }
 
@@ -364,7 +372,7 @@ export class GenericAssetCreationService {
       // Try to parse as date
       const date = new Date(value);
       if (!isNaN(date.getTime())) {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
+         
         return DateFormatter.toLocalTimestamp(date);
       }
       return value;
@@ -373,7 +381,7 @@ export class GenericAssetCreationService {
     if (typeof value === "number") {
       const date = new Date(value);
       if (!isNaN(date.getTime())) {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-existing local-timestamp call, unchanged by this PR
+         
         return DateFormatter.toLocalTimestamp(date);
       }
     }

--- a/packages/exocortex/tests/integration/asset-creation/asset-creation-flow.test.ts
+++ b/packages/exocortex/tests/integration/asset-creation/asset-creation-flow.test.ts
@@ -257,9 +257,10 @@ describe("Asset Creation Flow (Integration)", () => {
       // Act
       const projectFile = await service.createAsset(projectConfig);
 
-      // Assert: Project has parent reference
+      // Assert: Project has parent reference via unified ems__Effort_* convention (issue #2850)
       const storedFile = vault.getStoredFiles().get(projectFile.path);
-      expect(storedFile!.content).toContain("ems__Project_area:");
+      expect(storedFile!.content).toContain("ems__Effort_area:");
+      expect(storedFile!.content).not.toContain("ems__Project_area");
     });
   });
 

--- a/packages/exocortex/tests/unit/services/GenericAssetCreationService.test.ts
+++ b/packages/exocortex/tests/unit/services/GenericAssetCreationService.test.ts
@@ -872,7 +872,7 @@ describe("GenericAssetCreationService", () => {
         expect(content).not.toContain("ems__Effort_parent:");
       });
 
-      it("should set ems__Project_area for project with area parent", async () => {
+      it("should set ems__Effort_area for project with area parent (issue #2850)", async () => {
         const parentFile: IFile = {
           path: "areas/my-area.md",
           basename: "my-area",
@@ -888,10 +888,12 @@ describe("GenericAssetCreationService", () => {
         };
         await service.createAsset(config);
         const content = mockVault.create.mock.calls[0][1];
-        expect(content).toContain('ems__Project_area: "[[my-area]]"');
+        expect(content).toContain('ems__Effort_area: "[[my-area]]"');
+        // Legacy property must not appear (was the duplicate in issue #2850).
+        expect(content).not.toContain("ems__Project_area");
       });
 
-      it("should set ems__Project_area to null when parent has no basename", async () => {
+      it("should set ems__Effort_area to null when parent has no basename", async () => {
         const parentFile: IFile = {
           path: "areas/",
           basename: "",
@@ -907,10 +909,10 @@ describe("GenericAssetCreationService", () => {
         };
         await service.createAsset(config);
         const content = mockVault.create.mock.calls[0][1];
-        expect(content).toContain("ems__Project_area: null");
+        expect(content).toContain("ems__Effort_area: null");
       });
 
-      it("should not set ems__Project_area when parent is not area class", async () => {
+      it("should set ems__Effort_parent when project parent is not an area (issue #2850)", async () => {
         const parentFile: IFile = {
           path: "projects/parent.md",
           basename: "parent",
@@ -926,6 +928,8 @@ describe("GenericAssetCreationService", () => {
         };
         await service.createAsset(config);
         const content = mockVault.create.mock.calls[0][1];
+        expect(content).toContain('ems__Effort_parent: "[[parent]]"');
+        expect(content).not.toContain("ems__Effort_area");
         expect(content).not.toContain("ems__Project_area");
       });
 
@@ -945,10 +949,10 @@ describe("GenericAssetCreationService", () => {
         };
         await service.createAsset(config);
         const content = mockVault.create.mock.calls[0][1];
-        expect(content).toContain('ems__Project_area: "[[area]]"');
+        expect(content).toContain('ems__Effort_area: "[[area]]"');
       });
 
-      it("should inherit exo__Asset_isDefinedBy from parent", async () => {
+      it("should inherit exo__Asset_isDefinedBy from parent (already-quoted value)", async () => {
         const parentFile: IFile = {
           path: "projects/project.md",
           basename: "project",
@@ -965,6 +969,31 @@ describe("GenericAssetCreationService", () => {
         await service.createAsset(config);
         const content = mockVault.create.mock.calls[0][1];
         expect(content).toContain('exo__Asset_isDefinedBy: "[[my-ontology]]"');
+      });
+
+      it("should re-quote inherited exo__Asset_isDefinedBy when metadataCache stripped outer quotes (issue #2850)", async () => {
+        // Obsidian metadataCache parses `"[[foo]]"` from YAML and returns the
+        // inner string `[[foo]]` — inherited unwrapped value must be re-quoted
+        // by the writer so YAML doesn't re-interpret `[[!foo]]` as a tag.
+        const parentFile: IFile = {
+          path: "areas/area.md",
+          basename: "area",
+          name: "area.md",
+          parent: { path: "areas" } as IFolder,
+        };
+        const config = {
+          className: "ems__Project",
+          parentFile,
+          parentMetadata: {
+            exo__Instance_class: ["[[ems__Area]]"],
+            exo__Asset_isDefinedBy: "[[!toos_areas]]",
+          },
+        };
+        await service.createAsset(config);
+        const content = mockVault.create.mock.calls[0][1];
+        expect(content).toContain('exo__Asset_isDefinedBy: "[[!toos_areas]]"');
+        // Unquoted `[[!foo]]` would cause YAMLWarning + empty wikilink.
+        expect(content).not.toMatch(/exo__Asset_isDefinedBy:\s*\[\[!/);
       });
 
       it("should not inherit when parentMetadata has no exo__Asset_isDefinedBy", async () => {
@@ -986,7 +1015,7 @@ describe("GenericAssetCreationService", () => {
     });
 
     describe("isAreaClass edge cases", () => {
-      it("should return false for null instanceClass", async () => {
+      it("should treat null instanceClass as non-area and emit ems__Effort_parent", async () => {
         const parentFile: IFile = {
           path: "projects/project.md",
           basename: "project",
@@ -1002,6 +1031,7 @@ describe("GenericAssetCreationService", () => {
         };
         await service.createAsset(config);
         const content = mockVault.create.mock.calls[0][1];
+        expect(content).toContain('ems__Effort_parent: "[[project]]"');
         expect(content).not.toContain("ems__Project_area");
       });
 
@@ -1021,7 +1051,7 @@ describe("GenericAssetCreationService", () => {
         };
         await service.createAsset(config);
         const content = mockVault.create.mock.calls[0][1];
-        expect(content).toContain('ems__Project_area: "[[area]]"');
+        expect(content).toContain('ems__Effort_area: "[[area]]"');
       });
     });
 

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -85,7 +85,15 @@ export function populateServiceRegistry(
   registry.register(
     "createAsset",
     wrapService(async (targetIRI: string, userInput?: UserInput) => {
-      const prototypeUID = userInput?.prototypeUID as string | undefined;
+      // Accept both `prototypeUID` and `prototype` — starter-kit groundings
+      // prior to 2026-04-13 wired "Create Project" with `{"prototype":"..."}`
+      // (natural JSON key), which diverged from the service contract. The UI
+      // click-through silently failed because the 4 s red Notice fades fast
+      // while the direct console call suggested the plugin was correct. See
+      // #2850 Bug 3.
+      const prototypeUID =
+        (userInput?.prototypeUID as string | undefined) ??
+        (userInput?.prototype as string | undefined);
       const label = userInput?.label as string | undefined;
       let folder = userInput?.folder as string | undefined;
       if (!prototypeUID) throw new Error("createAsset requires userInput.prototypeUID");

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -241,6 +241,28 @@ describe("ServiceRegistryPopulator", () => {
         service.execute("", { label: "x", folder: "y" }),
       ).rejects.toThrow("userInput.prototypeUID");
     });
+
+    // Regression #2850 Bug 3: `Create Project` grounding in the vault was
+    // authored with `{"prototype":"..."}` (matching the natural JSON key
+    // name) while the service expected `prototypeUID`. The mismatch caused
+    // the UI click-through to fail with a brief 4 s red Notice and no file
+    // created — user reported as "silent fail". Accept `prototype` as an
+    // alias so outdated starter-kit groundings keep working.
+    it("should accept 'prototype' as alias for 'prototypeUID'", async () => {
+      const service = registry.get("createAsset")!;
+      await service.execute("", {
+        prototype: "ems__ProjectPrototype",
+        label: "Aliased Project",
+        folder: "01 Areas",
+      });
+
+      expect(deps.fileSystemAdapter.createFile).toHaveBeenCalledWith(
+        expect.stringMatching(/^01 Areas\/[a-f0-9-]+\.md$/),
+        expect.stringContaining(
+          'exo__Asset_prototype: "[[ems__ProjectPrototype]]"',
+        ),
+      );
+    });
   });
 
   describe("openFile", () => {

--- a/packages/obsidian-plugin/tests/unit/integration/asset-creation-flow.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/asset-creation-flow.test.ts
@@ -261,9 +261,10 @@ describe("Asset Creation Flow (Integration)", () => {
       // Act
       const projectFile = await service.createAsset(projectConfig);
 
-      // Assert: Project has parent reference
+      // Assert: Project has parent reference via unified ems__Effort_* convention (issue #2850)
       const storedFile = vault.getStoredFiles().get(projectFile.path);
-      expect(storedFile!.content).toContain("ems__Project_area:");
+      expect(storedFile!.content).toContain("ems__Effort_area:");
+      expect(storedFile!.content).not.toContain("ems__Project_area");
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #2850 — Create Project (and any createAsset inheriting from Area with namespace-prefixed `isDefinedBy`) produced corrupt frontmatter:

```yaml
exo__Asset_isDefinedBy: [[!toos_areas]]   # unquoted → YAML tag warning → empty wikilink
ems__Project_area: "[[area-uuid]]"        # legacy, duplicate of ems__Effort_area
ems__Effort_area: "[[area-uuid]]"         # correct, written by handler
```

## Fix

`packages/exocortex/src/services/GenericAssetCreationService.ts#inheritParentContext`:
- Route inherited `exo__Asset_isDefinedBy` through `formatWikilink()` so that strings returned unwrapped by Obsidian's `metadataCache` (e.g. `[[!toos_areas]]`) are re-quoted on write.
- Drop the legacy `ems__Project_area` emission. Projects now inherit parent via the unified `ems__Effort_*` convention (mirrors existing Task logic): `ems__Effort_area` for Area parents, `ems__Effort_parent` otherwise. No src code reads `ems__Project_area`.

## Verification

Live sanity on vault v15.101.0 + fresh main.js from this branch:

```yaml
# new project in area with "[[!toos_areas]]" isDefinedBy
exo__Asset_uid: 0260327e-...
exo__Instance_class: ["[[ems__Project]]"]
exo__Asset_label: Direct Post-Fix 2026-04-18
ems__Effort_area: "[[ecd46905-...]]"      # ← only one area property
exo__Asset_isDefinedBy: "[[!toos_areas]]" # ← quoted, no YAML tag warning
ems__Effort_status: "[[ems__EffortStatusDraft]]"
```

Console-clean, no YAMLWarning.

## Tests

- **New unit test** (`GenericAssetCreationService.test.ts`): reproduces `[[!foo]]` inheritance, asserts quoted re-emission + `not.toMatch(/isDefinedBy:\s*\[\[!/)`.
- **Updated** 5 existing tests to assert `ems__Effort_area` instead of `ems__Project_area`, plus explicit `not.toContain("ems__Project_area")`.
- **Non-area parent path** now asserts `ems__Effort_parent` (was: asserted absence of any area property).

All 97 tests in `GenericAssetCreationService.test.ts` + `asset-creation-flow.test.ts` pass.

## Test plan

- [x] Unit tests pass locally
- [x] Integration tests pass locally
- [x] Live verification in vault-2025 (v15.101.0 + fresh main.js)
- [ ] CI 8 checks
- [ ] Auto Release