### PR TITLE
fix(a11y): raise danger button variant to WCAG AAA (closes #2847)

### DIFF
--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -1140,7 +1140,7 @@
   --exo-intent-warning-bg: rgba(191, 54, 12, 0.12);
   --exo-intent-warning-border: rgba(191, 54, 12, 0.3);
 
-  --exo-intent-danger-fg: var(--text-error, #b71c1c);
+  --exo-intent-danger-fg: var(--text-error, #7f1d1d);
   --exo-intent-danger-bg: rgba(183, 28, 28, 0.12);
   --exo-intent-danger-border: rgba(183, 28, 28, 0.3);
 
@@ -1161,7 +1161,7 @@
   --exo-intent-warning-bg: rgba(255, 183, 77, 0.18);
   --exo-intent-warning-border: rgba(255, 183, 77, 0.35);
 
-  --exo-intent-danger-fg: var(--text-error, #ef9a9a);
+  --exo-intent-danger-fg: var(--text-error, #ffcdd2);
   --exo-intent-danger-bg: rgba(239, 154, 154, 0.18);
   --exo-intent-danger-border: rgba(239, 154, 154, 0.35);
 

--- a/packages/obsidian-plugin/tests/unit/styles/accessibility-contrast-matrix.test.ts
+++ b/packages/obsidian-plugin/tests/unit/styles/accessibility-contrast-matrix.test.ts
@@ -103,11 +103,11 @@ const VARIANT_PALETTE = {
   },
   danger: {
     light: {
-      fg: hexToRGB("#b71c1c"),
+      fg: hexToRGB("#7f1d1d"),
       bg: blendRGBA([183, 28, 28, 0.12], THEME_BASE.light),
     },
     dark: {
-      fg: hexToRGB("#ef9a9a"),
+      fg: hexToRGB("#ffcdd2"),
       bg: blendRGBA([239, 154, 154, 0.18], THEME_BASE.dark),
     },
   },
@@ -149,14 +149,12 @@ describe("WCAG AA contrast matrix (RFC-024 Phase 1 CI gate)", () => {
       },
     );
 
-    // RFC-024 §8 lists AAA (>=7:1) as an aspirational target for `danger`,
-    // not a merge gate. The shipped palette lands at ~5.6:1 light / ~5.5:1
-    // dark — comfortably AA but below AAA. Tightening to AAA would require
-    // a darker/lighter foreground that harms perceived "danger-ness".
-    // The test below is skipped so the intent is visible in source without
-    // gating merges. Re-enable if the palette is ever recalibrated.
-    it.skip.each(THEMES)(
-      "danger variant reaches AAA (>=7:1) in %s mode (aspirational)",
+    // Recalibrated to AAA per issue #2847 (RFC-024 Phase 4 AC2):
+    // foreground darkened in light mode (`#b71c1c` → `#7f1d1d`, Tailwind red-900)
+    // and lightened in dark mode (`#ef9a9a` → `#ffcdd2`, Material Red 100) against
+    // the same tinted backgrounds. Ratios: light ≈ 8.18:1, dark ≈ 8.35:1.
+    it.each(THEMES)(
+      "danger variant reaches AAA (>=7:1) in %s mode",
       (theme) => {
         const { fg, bg } = VARIANT_PALETTE.danger[theme];
         expect(contrastRatio(fg, bg)).toBeGreaterThanOrEqual(7);
@@ -173,7 +171,7 @@ describe("WCAG AA contrast matrix (RFC-024 Phase 1 CI gate)", () => {
       ["--exo-intent-secondary-fg", "#1d1d1d"],
       ["--exo-intent-success-fg", "#1b5e20"],
       ["--exo-intent-warning-fg", "#bf360c"],
-      ["--exo-intent-danger-fg", "#b71c1c"],
+      ["--exo-intent-danger-fg", "#7f1d1d"],
       ["--exo-intent-muted-fg", "#666666"],
     ])("styles.css defines %s with fallback %s", (token, expectedHex) => {
       const pattern = new RegExp(


### PR DESCRIPTION
## Summary

Recalibrates the `--exo-intent-danger-fg` fallback so the `.exocortex-action-button--danger` variant meets WCAG AAA (≥ 7:1) in both light and dark themes, closing RFC-024 Phase 4 AC2 (#2847).

| theme | fg before | fg after           | ratio before | ratio after |
|-------|-----------|--------------------|--------------|-------------|
| light | `#b71c1c` | `#7f1d1d` (Tailwind red-900) | 5.36:1 | **8.18:1** |
| dark  | `#ef9a9a` | `#ffcdd2` (Material Red 100) | 5.46:1 | **8.35:1** |

- Backgrounds (`rgba(183,28,28,0.12)` / `rgba(239,154,154,0.18)`) and borders unchanged — the button still reads as a red tinted destructive action, just with higher-contrast text.
- Scope limited to `packages/obsidian-plugin/styles.css` per issue note. No layout / ThemeResolver / React changes.

## Acceptance Criteria (AC)

- [x] `danger` contrast ≥ 7:1 in light theme — **8.18:1**
- [x] `danger` contrast ≥ 7:1 in dark theme — **8.35:1**
- [x] No regression on other 5 variants — AA matrix still passes (min: `muted` light 4.66:1)
- [x] `accessibility-contrast-matrix.test.ts` — `it.skip.each(...)` on danger AAA removed, both assertions pass (24/24 tests)
- [ ] Visual smoke in Obsidian with action row in both themes — deferred to parent orchestrator / manual follow-up (AC #4 not unit-testable)

## Test Plan

```
npx jest --config packages/obsidian-plugin/jest.config.js \
  packages/obsidian-plugin/tests/unit/styles/accessibility-contrast-matrix.test.ts --runInBand
# Tests: 24 passed, 24 total  (was 22 passed + 2 skipped)
npm run check:types           # OK
```

Visual verification (button row × 6 variants × 2 themes) deferred to parent orchestrator before Done promotion.

## Notes

- Chose Option (a) from issue body (darker/lighter foreground) over Option (b) (full Layer 2 token recalibration). The single-value change keeps the visual identity of the variant and confines the diff to 2 CSS values + the test palette.
- Tailwind red-900 / Material Red 100 were picked for recognisability — both are well-established "error/destructive" palette entries.

Closes #2847