### PR TITLE
feat(core): export CommandBindingStyleProperty + CommandVariant/LabelClass/StyleSource unions (RFC-024 Phase 2)

### DIFF
--- a/packages/exocortex/src/domain/constants/CommandBindingStyleEnums.ts
+++ b/packages/exocortex/src/domain/constants/CommandBindingStyleEnums.ts
@@ -1,0 +1,100 @@
+/**
+ * Enum value unions for `exocmd__CommandBindingStyle` properties (RFC-024 §4 Phase 2).
+ *
+ * These unions are the canonical source for allowed values. They are mirrored
+ * by the starter-kit ontology property definitions (see `exocmd/` in
+ * `exocortex-starter-kit`) and consumed by the plugin's UI layer
+ * (`ActionButtonsGroup.tsx` etc.) to consolidate duplicate literals.
+ *
+ * Invariants:
+ * - **Non-breaking schema (RFC-024 §3):** whitelists extend, never shrink.
+ *   Renames require an explicit migration asset.
+ * - **Coerce → warn → fallback:** invalid inbound values are lowercased/trimmed
+ *   and matched against the whitelist; misses fall back to vendor defaults and
+ *   log a warning capped at 200 chars — never crash (RFC-024 §5).
+ */
+
+/**
+ * Semantic button variant. Matches `ActionButtonVariant` in the Obsidian plugin;
+ * the plugin's copy is the UI-layer alias and must stay in sync with this union.
+ *
+ * - `primary` — dominant action (≤1 per panel)
+ * - `secondary` — default, neutral emphasis
+ * - `success` — positive outcome (e.g. status → Done)
+ * - `warning` — caution (e.g. status → Blocked)
+ * - `danger` — destructive / status → Cancelled
+ * - `muted` — power-user / maintenance, visually receded
+ */
+export type CommandVariant =
+  | "primary"
+  | "secondary"
+  | "success"
+  | "warning"
+  | "danger"
+  | "muted";
+
+/** Frozen whitelist of {@link CommandVariant} values for runtime validation. */
+export const COMMAND_VARIANT_VALUES: readonly CommandVariant[] = Object.freeze([
+  "primary",
+  "secondary",
+  "success",
+  "warning",
+  "danger",
+  "muted",
+]);
+
+/**
+ * Typographic modifier applied to the button label.
+ *
+ * - `muted` — lower contrast (pairs well with `muted` variant)
+ * - `bold` — stronger weight
+ * - `uppercase` — ALL-CAPS rendering
+ * - `compact` — tighter size / padding
+ */
+export type LabelClass = "muted" | "bold" | "uppercase" | "compact";
+
+/** Frozen whitelist of {@link LabelClass} values. */
+export const LABEL_CLASS_VALUES: readonly LabelClass[] = Object.freeze([
+  "muted",
+  "bold",
+  "uppercase",
+  "compact",
+]);
+
+/**
+ * Governance marker for a CommandBindingStyle asset (RFC-024 §3, §5).
+ *
+ * - `vendor` — shipped preset (starter-kit example or plugin default)
+ * - `user` — user override; wins over vendor per precedence matrix
+ */
+export type StyleSource = "vendor" | "user";
+
+/** Frozen whitelist of {@link StyleSource} values. */
+export const STYLE_SOURCE_VALUES: readonly StyleSource[] = Object.freeze([
+  "vendor",
+  "user",
+]);
+
+/** Narrowing guard for {@link CommandVariant}. Does not coerce — caller coerces. */
+export function isCommandVariant(value: unknown): value is CommandVariant {
+  return (
+    typeof value === "string" &&
+    (COMMAND_VARIANT_VALUES as readonly string[]).includes(value)
+  );
+}
+
+/** Narrowing guard for {@link LabelClass}. Does not coerce. */
+export function isLabelClass(value: unknown): value is LabelClass {
+  return (
+    typeof value === "string" &&
+    (LABEL_CLASS_VALUES as readonly string[]).includes(value)
+  );
+}
+
+/** Narrowing guard for {@link StyleSource}. Does not coerce. */
+export function isStyleSource(value: unknown): value is StyleSource {
+  return (
+    typeof value === "string" &&
+    (STYLE_SOURCE_VALUES as readonly string[]).includes(value)
+  );
+}

--- a/packages/exocortex/src/domain/constants/CommandProperty.ts
+++ b/packages/exocortex/src/domain/constants/CommandProperty.ts
@@ -60,4 +60,33 @@ export const CommandBindingProperty = {
   GROUP: "exocmd__CommandBinding_group",
   /** Override command-level precondition for this binding (wikilink) */
   PRECONDITION: "exocmd__CommandBinding_precondition",
+  /** Optional reference to exocmd__CommandBindingStyle asset (wikilink, RFC-024 §4 Phase 2) */
+  STYLE: "exocmd__CommandBinding_style",
+  /** Inline shorthand variant literal (RFC-024 §4 Phase 2). Explicit style reference wins over inline. */
+  VARIANT: "exocmd__CommandBinding_variant",
+} as const;
+
+/**
+ * Properties for exocmd__CommandBindingStyle assets (RFC-024 §4 Phase 2).
+ *
+ * Single source для button-level visual properties. Style can be referenced via
+ * `exocmd__CommandBinding_style` (preferred, reusable) or inlined via the
+ * shorthand `exocmd__CommandBinding_variant`. Enum values (`VARIANT`, `LABEL_CLASS`,
+ * `SOURCE`) are mirrored by TS unions in `./CommandBindingStyleEnums`.
+ */
+export const CommandBindingStyleProperty = {
+  /** Semantic variant literal (see {@link CommandVariant}) */
+  VARIANT: "exocmd__CommandBindingStyle_variant",
+  /** Boolean literal ("true" | "false"). Default true — render existing Command_icon */
+  SHOW_ICON: "exocmd__CommandBindingStyle_showIcon",
+  /** Typographic modifier literal (see {@link LabelClass}) */
+  LABEL_CLASS: "exocmd__CommandBindingStyle_labelClass",
+  /** Literal text for aria-label accessibility attribute */
+  ARIA_LABEL: "exocmd__CommandBindingStyle_ariaLabel",
+  /** Literal text for title attribute (Obsidian tooltip convention) */
+  TOOLTIP: "exocmd__CommandBindingStyle_tooltip",
+  /** Chord string (e.g. "Mod+Shift+D"). Registered with exo-cmd- namespace */
+  KEYBOARD_SHORTCUT: "exocmd__CommandBindingStyle_keyboardShortcut",
+  /** Governance marker (see {@link StyleSource}). User wins over vendor (RFC-024 §5) */
+  SOURCE: "exocmd__CommandBindingStyle_source",
 } as const;

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -18,7 +18,19 @@ export {
   PreconditionProperty,
   GroundingProperty,
   CommandBindingProperty,
+  CommandBindingStyleProperty,
 } from "./domain/constants/CommandProperty";
+export {
+  type CommandVariant,
+  type LabelClass,
+  type StyleSource,
+  COMMAND_VARIANT_VALUES,
+  LABEL_CLASS_VALUES,
+  STYLE_SOURCE_VALUES,
+  isCommandVariant,
+  isLabelClass,
+  isStyleSource,
+} from "./domain/constants/CommandBindingStyleEnums";
 export type {
   CommandDefinition,
   PreconditionDefinition,

--- a/packages/exocortex/tests/unit/domain/constants/CommandBindingStyleContract.test.ts
+++ b/packages/exocortex/tests/unit/domain/constants/CommandBindingStyleContract.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Contract test for `exocmd__CommandBindingStyle` schema (RFC-024 §4 Phase 2).
+ *
+ * Enforces the two-way binding between ontology-side property aliases
+ * (frontmatter keys written to the vault) and TS-side enum unions that
+ * the plugin compares against at runtime. Divergence = silent coerce-to-
+ * fallback at runtime, which is exactly what the RFC's non-breaking-schema
+ * invariant (§3) forbids.
+ */
+
+import {
+  CommandBindingProperty,
+  CommandBindingStyleProperty,
+} from "../../../../src/domain/constants/CommandProperty";
+import {
+  type CommandVariant,
+  type LabelClass,
+  type StyleSource,
+  COMMAND_VARIANT_VALUES,
+  LABEL_CLASS_VALUES,
+  STYLE_SOURCE_VALUES,
+  isCommandVariant,
+  isLabelClass,
+  isStyleSource,
+} from "../../../../src/domain/constants/CommandBindingStyleEnums";
+
+describe("CommandBindingStyleProperty — ontology property aliases", () => {
+  it("has exactly the 7 RFC-024 §4 Phase 2 properties", () => {
+    const keys = Object.keys(CommandBindingStyleProperty).sort();
+    expect(keys).toEqual([
+      "ARIA_LABEL",
+      "KEYBOARD_SHORTCUT",
+      "LABEL_CLASS",
+      "SHOW_ICON",
+      "SOURCE",
+      "TOOLTIP",
+      "VARIANT",
+    ]);
+  });
+
+  it("aliases follow exocmd__CommandBindingStyle_* naming", () => {
+    for (const alias of Object.values(CommandBindingStyleProperty)) {
+      expect(alias).toMatch(/^exocmd__CommandBindingStyle_[a-z][A-Za-z]+$/);
+    }
+  });
+
+  it("aliases are all distinct", () => {
+    const values = Object.values(CommandBindingStyleProperty);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("field-for-field RFC §4 mapping is preserved", () => {
+    expect(CommandBindingStyleProperty.VARIANT).toBe(
+      "exocmd__CommandBindingStyle_variant",
+    );
+    expect(CommandBindingStyleProperty.SHOW_ICON).toBe(
+      "exocmd__CommandBindingStyle_showIcon",
+    );
+    expect(CommandBindingStyleProperty.LABEL_CLASS).toBe(
+      "exocmd__CommandBindingStyle_labelClass",
+    );
+    expect(CommandBindingStyleProperty.ARIA_LABEL).toBe(
+      "exocmd__CommandBindingStyle_ariaLabel",
+    );
+    expect(CommandBindingStyleProperty.TOOLTIP).toBe(
+      "exocmd__CommandBindingStyle_tooltip",
+    );
+    expect(CommandBindingStyleProperty.KEYBOARD_SHORTCUT).toBe(
+      "exocmd__CommandBindingStyle_keyboardShortcut",
+    );
+    expect(CommandBindingStyleProperty.SOURCE).toBe(
+      "exocmd__CommandBindingStyle_source",
+    );
+  });
+});
+
+describe("CommandBindingProperty — style wiring", () => {
+  it("exposes STYLE wikilink reference (RFC-024 §4 Phase 2)", () => {
+    expect(CommandBindingProperty.STYLE).toBe("exocmd__CommandBinding_style");
+  });
+
+  it("exposes VARIANT inline shorthand (RFC-024 §4 Phase 2)", () => {
+    expect(CommandBindingProperty.VARIANT).toBe(
+      "exocmd__CommandBinding_variant",
+    );
+  });
+});
+
+describe("CommandVariant union ↔ whitelist", () => {
+  it("whitelist enumerates exactly the 6 union members", () => {
+    expect([...COMMAND_VARIANT_VALUES].sort()).toEqual([
+      "danger",
+      "muted",
+      "primary",
+      "secondary",
+      "success",
+      "warning",
+    ]);
+  });
+
+  it.each(COMMAND_VARIANT_VALUES)("isCommandVariant accepts '%s'", (value) => {
+    expect(isCommandVariant(value)).toBe(true);
+    // Compile-time assignability — if this errored the union drifted from whitelist
+    const variant: CommandVariant = value;
+    expect(variant).toBe(value);
+  });
+
+  it.each(["Primary", "PRIMARY", " primary", "primary ", "info", "", null, 1])(
+    "isCommandVariant rejects invalid input %p",
+    (value) => {
+      expect(isCommandVariant(value)).toBe(false);
+    },
+  );
+
+  it("whitelist is frozen (non-breaking schema invariant)", () => {
+    expect(Object.isFrozen(COMMAND_VARIANT_VALUES)).toBe(true);
+  });
+});
+
+describe("LabelClass union ↔ whitelist", () => {
+  it("whitelist enumerates exactly the 4 RFC §4 union members", () => {
+    expect([...LABEL_CLASS_VALUES].sort()).toEqual([
+      "bold",
+      "compact",
+      "muted",
+      "uppercase",
+    ]);
+  });
+
+  it.each(LABEL_CLASS_VALUES)("isLabelClass accepts '%s'", (value) => {
+    expect(isLabelClass(value)).toBe(true);
+    const labelClass: LabelClass = value;
+    expect(labelClass).toBe(value);
+  });
+
+  it.each(["Bold", "italic", "", null, undefined])(
+    "isLabelClass rejects invalid input %p",
+    (value) => {
+      expect(isLabelClass(value)).toBe(false);
+    },
+  );
+
+  it("whitelist is frozen", () => {
+    expect(Object.isFrozen(LABEL_CLASS_VALUES)).toBe(true);
+  });
+});
+
+describe("StyleSource union ↔ whitelist", () => {
+  it("whitelist enumerates vendor+user", () => {
+    expect([...STYLE_SOURCE_VALUES].sort()).toEqual(["user", "vendor"]);
+  });
+
+  it.each(STYLE_SOURCE_VALUES)("isStyleSource accepts '%s'", (value) => {
+    expect(isStyleSource(value)).toBe(true);
+    const src: StyleSource = value;
+    expect(src).toBe(value);
+  });
+
+  it.each(["User", "system", "default", "", null])(
+    "isStyleSource rejects invalid input %p",
+    (value) => {
+      expect(isStyleSource(value)).toBe(false);
+    },
+  );
+
+  it("whitelist is frozen", () => {
+    expect(Object.isFrozen(STYLE_SOURCE_VALUES)).toBe(true);
+  });
+});
+
+describe("Schema ↔ union field alignment", () => {
+  /**
+   * Every enum-valued Style property has a matching TS union. Divergence
+   * (a property without a union or a union without a property) means the
+   * plugin's runtime coercion cannot round-trip through the ontology.
+   */
+  it("VARIANT property pairs with CommandVariant union", () => {
+    expect(CommandBindingStyleProperty.VARIANT.endsWith("_variant")).toBe(true);
+    expect(COMMAND_VARIANT_VALUES.length).toBeGreaterThan(0);
+  });
+
+  it("LABEL_CLASS property pairs with LabelClass union", () => {
+    expect(
+      CommandBindingStyleProperty.LABEL_CLASS.endsWith("_labelClass"),
+    ).toBe(true);
+    expect(LABEL_CLASS_VALUES.length).toBeGreaterThan(0);
+  });
+
+  it("SOURCE property pairs with StyleSource union", () => {
+    expect(CommandBindingStyleProperty.SOURCE.endsWith("_source")).toBe(true);
+    expect(STYLE_SOURCE_VALUES.length).toBeGreaterThan(0);
+  });
+
+  it("CommandBinding.VARIANT shorthand literal type matches CommandVariant", () => {
+    // The inline shorthand property accepts exactly the CommandVariant whitelist.
+    for (const v of COMMAND_VARIANT_VALUES) {
+      expect(isCommandVariant(v)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Type-side half of RFC-024 §4 Phase 2 meta-class introduction. Exports frontmatter property constants + TS enum unions for the new `exocmd__CommandBindingStyle` ontology class.

- **New** `CommandBindingStyleProperty` — 7 frontmatter keys (variant, showIcon, labelClass, ariaLabel, tooltip, keyboardShortcut, source)
- **Extended** `CommandBindingProperty` — `.STYLE` (wikilink reference) and `.VARIANT` (inline shorthand) for binding↔style wiring
- **New** `CommandBindingStyleEnums.ts` — `CommandVariant` (6 values matching existing `ActionButtonVariant`), `LabelClass` (4 values per RFC §4), `StyleSource` (`vendor`/`user`) + frozen whitelists + narrowing guards
- **Contract test** — `CommandBindingStyleContract.test.ts` (27 assertions) enforces binding property ↔ TS type alignment, whitelist freezing (non-breaking-schema invariant, RFC §3), and coerce-safe narrowing (no crash on invalid input, RFC §5)

All symbols re-exported from `packages/exocortex/src/index.ts`.

**No behaviour change** — this PR only adds type exports. CommandResolver wiring, `ActionButtonVariant` alias consolidation, and starter-kit binding migration are separate Phase 5 tasks.

## Companion PR (ontology side)

- kitelev/exocortex-starter-kit#80 — class definition + 9 property assets

## Scope

- RFC-024 §4 Phase 2 (meta-class commit; avoids flat→nested migration)
- Task UUID: `80dc32bb-ba83-4f49-ab12-cc2cca6d69eb`
- Project: `c28b28a9-4101-47fb-ac3b-bdd70bb8bf8b` (RFC-024 Visual Customization)

## Test plan

- [x] Core package: `jest tests/unit/domain/constants/*.test.ts` → **56/56 green** (new contract suite 27 assertions + existing CommandConstants 29 assertions)
- [x] Core package: `tsc --noEmit` clean
- [x] Core package: `npm run build -w packages/exocortex` green
- [x] Pre-commit hooks: archgate ✅, BDD coverage ✅, ADR rules ✅
- [ ] CI: build / typecheck / test-unit / test-coverage / test-bdd / archgate / e2e / test-component