### PR TITLE
feat(layout): add exo__Layout_commandPanel inline parser (RFC-024 Phase 3)

### DIFF
--- a/packages/obsidian-plugin/src/domain/layout/CommandPanel.ts
+++ b/packages/obsidian-plugin/src/domain/layout/CommandPanel.ts
@@ -1,0 +1,244 @@
+/**
+ * CommandPanel Domain Model — RFC-024 Phase 3 (Context Panels).
+ *
+ * Inline structure attached to `exo__Layout` via the optional
+ * `exo__Layout_commandPanel` slot. Lets a layout define which command
+ * buttons render above/next to its target-class view without introducing
+ * a parallel class `exocmd__CommandPanel`.
+ *
+ * Four fields (all optional; absence is backward-compatible):
+ * - `includeGroups` — OR-merge of command group ids to include
+ * - `excludeCommands` — UUIDs of specific bindings/commands to exclude
+ * - `layout`         — rendering mode: inline | stacked | dropdown
+ * - `featuredBinding`— UUID of a binding promoted to `primary` variant
+ *
+ * Precedence rules (RFC-024 §4 Phase 3):
+ *   1. Multiple layouts for one class: sort by `exo__Layout_order` ASC
+ *      (resolved outside this module — PanelResolver scope)
+ *   2. `excludeCommands` trumps `includeGroups`
+ *   3. `featuredBinding` overrides binding.style.variant → `primary`
+ *   4. Binding-level style.variant > class-level default > plugin fallback
+ *
+ * Rules 2 and 3 are enforceable from the parsed structure alone and are
+ * exposed here as pure helpers {@link applyCommandPanelFilter} and
+ * {@link isFeaturedBinding}. Rule 1 belongs to a downstream resolver.
+ *
+ * @module domain/layout
+ * @since RFC-024 Phase 3
+ */
+
+/**
+ * Rendering mode for the command panel.
+ * Distinct from `ActionPosition` (LayoutActions) — this is panel layout
+ * (orientation), not action placement relative to rows.
+ */
+export type CommandPanelMode = "inline" | "stacked" | "dropdown";
+
+/**
+ * Parsed `exo__Layout_commandPanel` inline structure.
+ *
+ * All fields are optional: an empty object `{}` is a valid panel spec
+ * meaning "render every applicable command with default layout".
+ */
+export interface CommandPanel {
+  /**
+   * Command-group ids whose bindings should be included (OR-merged).
+   * Example: `["creation", "status"]` includes every binding tagged with
+   * either group. Empty / missing means "no group filter — include all".
+   */
+  includeGroups?: string[];
+
+  /**
+   * UUIDs of command-bindings to exclude. Trumps `includeGroups`.
+   * Values in frontmatter are wikilinks (`[[uuid]]`) that are normalised
+   * to bare UUID strings for easier downstream comparison.
+   */
+  excludeCommands?: string[];
+
+  /**
+   * Rendering mode for the panel.
+   */
+  layout?: CommandPanelMode;
+
+  /**
+   * UUID of the binding that should be promoted to the `primary` variant
+   * (fixes the "N primary buttons" UX anti-pattern). Stored as a bare
+   * UUID string regardless of the wikilink form used in frontmatter.
+   */
+  featuredBinding?: string;
+}
+
+/**
+ * Type guard for {@link CommandPanelMode}.
+ */
+export function isValidCommandPanelMode(
+  value: unknown,
+): value is CommandPanelMode {
+  return value === "inline" || value === "stacked" || value === "dropdown";
+}
+
+/**
+ * Strip the wikilink wrapper and alias from a value, returning the bare
+ * link target (typically a UUID).
+ *
+ * - `"[[uuid]]"`             → `"uuid"`
+ * - `"[[uuid|alias]]"`       → `"uuid"`
+ * - `"[[path/to/file]]"`     → `"path/to/file"`
+ * - `"uuid"` (already bare)  → `"uuid"`
+ * - non-string / empty       → `null`
+ */
+export function normalizeBindingRef(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const match = trimmed.match(/^\[\[([^\]|#]+)(?:[|#][^\]]*)?\]\]$/);
+  const ref = (match ? match[1] : trimmed).trim();
+  return ref.length > 0 ? ref : null;
+}
+
+/**
+ * Create a {@link CommandPanel} from an inline frontmatter object.
+ *
+ * Permissive: unknown / invalid fields are dropped (never thrown). If
+ * every field is absent / invalid, returns `null` so callers can omit
+ * the slot entirely — preserving the non-breaking invariant for layouts
+ * that never defined a command panel.
+ *
+ * @param raw - The inline object parsed from YAML (`exo__Layout_commandPanel`).
+ * @returns A populated panel or `null` when nothing parses.
+ */
+export function createCommandPanelFromFrontmatter(
+  raw: unknown,
+): CommandPanel | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+
+  const record = raw as Record<string, unknown>;
+  const panel: CommandPanel = {};
+
+  const includeGroupsRaw = record["includeGroups"];
+  const includeGroups = normalizeStringArray(includeGroupsRaw);
+  if (includeGroups && includeGroups.length > 0) {
+    panel.includeGroups = includeGroups;
+  }
+
+  const excludeCommandsRaw = record["excludeCommands"];
+  const excludeCommands = normalizeRefArray(excludeCommandsRaw);
+  if (excludeCommands && excludeCommands.length > 0) {
+    panel.excludeCommands = excludeCommands;
+  }
+
+  const layoutRaw = record["layout"];
+  if (isValidCommandPanelMode(layoutRaw)) {
+    panel.layout = layoutRaw;
+  } else if (typeof layoutRaw === "string" && layoutRaw.trim().length > 0) {
+    console.warn(
+      `[CommandPanel] exo__Layout_commandPanel.layout must be ` +
+        `"inline" | "stacked" | "dropdown". Received ${JSON.stringify(
+          layoutRaw,
+        )} — dropping field.`,
+    );
+  }
+
+  const featuredRaw = record["featuredBinding"];
+  if (featuredRaw !== undefined && featuredRaw !== null) {
+    const featuredRef = Array.isArray(featuredRaw)
+      ? normalizeBindingRef(featuredRaw[0])
+      : normalizeBindingRef(featuredRaw);
+    if (featuredRef) {
+      panel.featuredBinding = featuredRef;
+    }
+  }
+
+  return Object.keys(panel).length > 0 ? panel : null;
+}
+
+/**
+ * Precedence rule #2 (explicit, RFC-024 §5).
+ *
+ * Given a set of candidate commands and a panel spec, return the subset
+ * that survives exclusion. `excludeCommands` trumps `includeGroups` —
+ * i.e. an excluded command is dropped even when its group is included.
+ * Group membership is supplied by the caller since command assets live
+ * outside this domain module.
+ *
+ * @param candidates - Candidate commands (each with uid + optional group).
+ * @param panel - Parsed command panel spec.
+ * @returns Commands that pass both include-by-group and exclude-by-uid.
+ */
+export function applyCommandPanelFilter<
+  T extends { uid: string; group?: string },
+>(candidates: readonly T[], panel: CommandPanel | undefined): T[] {
+  if (!panel) {
+    return [...candidates];
+  }
+
+  const include = panel.includeGroups;
+  const exclude = new Set(panel.excludeCommands ?? []);
+
+  return candidates.filter((candidate) => {
+    if (exclude.has(candidate.uid)) {
+      return false;
+    }
+    if (include && include.length > 0) {
+      if (!candidate.group || !include.includes(candidate.group)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+/**
+ * Precedence rule #3 (explicit, RFC-024 §5).
+ *
+ * @param panel - Parsed command panel spec.
+ * @param bindingUid - UUID of the binding whose variant is being resolved.
+ * @returns `true` if this binding is the panel's featured binding and
+ *          therefore overrides its own `style.variant` to `primary`.
+ */
+export function isFeaturedBinding(
+  panel: CommandPanel | undefined,
+  bindingUid: string,
+): boolean {
+  return (
+    panel?.featuredBinding !== undefined && panel.featuredBinding === bindingUid
+  );
+}
+
+function normalizeStringArray(value: unknown): string[] | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const source = Array.isArray(value) ? value : [value];
+  const out: string[] = [];
+  for (const entry of source) {
+    if (typeof entry === "string") {
+      const trimmed = entry.trim();
+      if (trimmed.length > 0) {
+        out.push(trimmed);
+      }
+    }
+  }
+  return out;
+}
+
+function normalizeRefArray(value: unknown): string[] | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const source = Array.isArray(value) ? value : [value];
+  const out: string[] = [];
+  for (const entry of source) {
+    const ref = normalizeBindingRef(entry);
+    if (ref) {
+      out.push(ref);
+    }
+  }
+  return out;
+}

--- a/packages/obsidian-plugin/src/domain/layout/Layout.ts
+++ b/packages/obsidian-plugin/src/domain/layout/Layout.ts
@@ -3,6 +3,7 @@ import type { LayoutFilter } from "./LayoutFilter";
 import type { LayoutSort } from "./LayoutSort";
 import type { LayoutGroup } from "./LayoutGroup";
 import type { LayoutActions } from "./LayoutActions";
+import type { CommandPanel } from "./CommandPanel";
 
 /**
  * Layout type enumeration.
@@ -152,6 +153,15 @@ export interface BaseLayout {
    * Maps to exo__Layout_labelTypography.
    */
   labelTypography?: LabelTypography;
+
+  /**
+   * Optional per-class command panel configuration (RFC-024 Phase 3).
+   * Inline structure parsed from `exo__Layout_commandPanel` that
+   * controls which command bindings render next to this layout and how.
+   * Absence means "no panel override" — consumer falls back to the
+   * plugin-wide default button set.
+   */
+  commandPanel?: CommandPanel;
 }
 
 /**

--- a/packages/obsidian-plugin/src/domain/layout/index.ts
+++ b/packages/obsidian-plugin/src/domain/layout/index.ts
@@ -115,3 +115,14 @@ export {
   isPreconditionFrontmatter,
   isSparqlGroundingFrontmatter,
 } from "./LayoutActions";
+
+// CommandPanel types (RFC-024 Phase 3)
+export {
+  type CommandPanelMode,
+  type CommandPanel,
+  isValidCommandPanelMode,
+  normalizeBindingRef,
+  createCommandPanelFromFrontmatter,
+  applyCommandPanelFilter,
+  isFeaturedBinding,
+} from "./CommandPanel";

--- a/packages/obsidian-plugin/src/infrastructure/layout/LayoutParser.ts
+++ b/packages/obsidian-plugin/src/infrastructure/layout/LayoutParser.ts
@@ -24,6 +24,7 @@ import {
   type LayoutActions,
   type LabelTypography,
   type CommandRef,
+  type CommandPanel,
   LayoutType,
   getLayoutTypeFromInstanceClass,
   isLayoutFrontmatter,
@@ -33,6 +34,7 @@ import {
   createLayoutGroupFromFrontmatter,
   createLayoutActionsFromFrontmatter,
   createCommandRefFromFrontmatter,
+  createCommandPanelFromFrontmatter,
   isLayoutActionsFrontmatter,
   isCommandFrontmatter,
   isValidCalendarView,
@@ -335,7 +337,12 @@ export class LayoutParser {
     }
 
     const visualSlots = this.parseVisualSlots(frontmatter);
-    return { ...layout, ...visualSlots } as Layout;
+    const commandPanel = this.parseCommandPanel(frontmatter);
+    return {
+      ...layout,
+      ...visualSlots,
+      ...(commandPanel ? { commandPanel } : {}),
+    } as Layout;
   }
 
   /**
@@ -371,6 +378,24 @@ export class LayoutParser {
     }
 
     return slots;
+  }
+
+  /**
+   * Parse RFC-024 Phase 3 `exo__Layout_commandPanel` inline structure.
+   *
+   * Returns `undefined` when the slot is absent or contains no valid
+   * fields, keeping the layout backward-compatible with vaults that
+   * never defined a command panel.
+   */
+  private parseCommandPanel(
+    frontmatter: IFrontmatter,
+  ): CommandPanel | undefined {
+    const raw = frontmatter["exo__Layout_commandPanel"];
+    if (raw === undefined || raw === null) {
+      return undefined;
+    }
+    const panel = createCommandPanelFromFrontmatter(raw);
+    return panel ?? undefined;
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/domain/layout/CommandPanel.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/layout/CommandPanel.test.ts
@@ -1,0 +1,229 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  applyCommandPanelFilter,
+  createCommandPanelFromFrontmatter,
+  isFeaturedBinding,
+  isValidCommandPanelMode,
+  normalizeBindingRef,
+  type CommandPanel,
+} from "../../../../src/domain/layout";
+
+describe("CommandPanel — RFC-024 Phase 3 domain model", () => {
+  let warnSpy: jest.SpiedFunction<typeof console.warn>;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe("isValidCommandPanelMode", () => {
+    it.each(["inline", "stacked", "dropdown"])(
+      "accepts canonical mode %s",
+      (mode) => {
+        expect(isValidCommandPanelMode(mode)).toBe(true);
+      },
+    );
+
+    it.each([
+      ["unknown string", "grid"],
+      ["empty string", ""],
+      ["number", 1],
+      ["null", null],
+      ["undefined", undefined],
+      ["object", {}],
+    ])("rejects %s", (_label, value) => {
+      expect(isValidCommandPanelMode(value)).toBe(false);
+    });
+  });
+
+  describe("normalizeBindingRef", () => {
+    it.each([
+      ["bare wikilink", "[[abc-123]]", "abc-123"],
+      ["wikilink with alias", "[[abc-123|My Binding]]", "abc-123"],
+      ["wikilink with heading", "[[abc-123#section]]", "abc-123"],
+      ["bare uuid", "abc-123", "abc-123"],
+      ["wikilink with path", "[[path/to/file]]", "path/to/file"],
+      ["whitespace padded wikilink", "  [[abc-123]]  ", "abc-123"],
+    ])("extracts ref from %s", (_label, input, expected) => {
+      expect(normalizeBindingRef(input)).toBe(expected);
+    });
+
+    it.each([
+      ["empty string", ""],
+      ["null", null],
+      ["number", 42],
+      ["whitespace only", "   "],
+    ])("returns null for %s", (_label, input) => {
+      expect(normalizeBindingRef(input)).toBeNull();
+    });
+  });
+
+  describe("createCommandPanelFromFrontmatter", () => {
+    it("returns null when raw is missing", () => {
+      expect(createCommandPanelFromFrontmatter(undefined)).toBeNull();
+      expect(createCommandPanelFromFrontmatter(null)).toBeNull();
+    });
+
+    it("returns null when raw is not an object", () => {
+      expect(createCommandPanelFromFrontmatter("inline")).toBeNull();
+      expect(createCommandPanelFromFrontmatter(42)).toBeNull();
+      expect(createCommandPanelFromFrontmatter([])).toBeNull();
+    });
+
+    it("returns null when no valid field is present", () => {
+      const panel = createCommandPanelFromFrontmatter({
+        includeGroups: [],
+        excludeCommands: null,
+        layout: "grid",
+        featuredBinding: "",
+      });
+      expect(panel).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("must be"));
+    });
+
+    it("parses all four fields from a fully-populated inline structure", () => {
+      const panel = createCommandPanelFromFrontmatter({
+        includeGroups: ["creation", "status"],
+        excludeCommands: ["[[cmd-uuid-1]]", "[[cmd-uuid-2|exclude me]]"],
+        layout: "stacked",
+        featuredBinding: "[[bind-uuid-xyz]]",
+      });
+
+      expect(panel).toEqual({
+        includeGroups: ["creation", "status"],
+        excludeCommands: ["cmd-uuid-1", "cmd-uuid-2"],
+        layout: "stacked",
+        featuredBinding: "bind-uuid-xyz",
+      });
+    });
+
+    it("coerces single-string includeGroups into an array", () => {
+      const panel = createCommandPanelFromFrontmatter({
+        includeGroups: "creation",
+      });
+      expect(panel?.includeGroups).toEqual(["creation"]);
+    });
+
+    it("drops non-string entries in includeGroups", () => {
+      const panel = createCommandPanelFromFrontmatter({
+        includeGroups: ["creation", null, 42, "status", "  "],
+      });
+      expect(panel?.includeGroups).toEqual(["creation", "status"]);
+    });
+
+    it("accepts excludeCommands passed as a single wikilink", () => {
+      const panel = createCommandPanelFromFrontmatter({
+        excludeCommands: "[[cmd-uuid-1]]",
+      });
+      expect(panel?.excludeCommands).toEqual(["cmd-uuid-1"]);
+    });
+
+    it("accepts featuredBinding passed as a single-element array", () => {
+      const panel = createCommandPanelFromFrontmatter({
+        featuredBinding: ["[[bind-uuid-xyz]]"],
+      });
+      expect(panel?.featuredBinding).toBe("bind-uuid-xyz");
+    });
+
+    it("warns and drops invalid layout values", () => {
+      const panel = createCommandPanelFromFrontmatter({
+        includeGroups: ["creation"],
+        layout: "grid",
+      });
+      expect(panel).toEqual({ includeGroups: ["creation"] });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("grid"));
+    });
+
+    it("silently drops missing layout without warning", () => {
+      const panel = createCommandPanelFromFrontmatter({
+        includeGroups: ["creation"],
+      });
+      expect(panel).toEqual({ includeGroups: ["creation"] });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("applyCommandPanelFilter — precedence rule #2", () => {
+    const candidates = [
+      { uid: "a", group: "creation" },
+      { uid: "b", group: "creation" },
+      { uid: "c", group: "status" },
+      { uid: "d", group: "misc" },
+      { uid: "e" },
+    ];
+
+    it("returns a copy of candidates when panel is undefined", () => {
+      const result = applyCommandPanelFilter(candidates, undefined);
+      expect(result).toEqual(candidates);
+      expect(result).not.toBe(candidates);
+    });
+
+    it("returns a copy of candidates when panel is an empty object", () => {
+      const result = applyCommandPanelFilter(candidates, {});
+      expect(result).toEqual(candidates);
+    });
+
+    it("filters by includeGroups (OR-merge)", () => {
+      const panel: CommandPanel = {
+        includeGroups: ["creation", "status"],
+      };
+      expect(
+        applyCommandPanelFilter(candidates, panel).map((c) => c.uid),
+      ).toEqual(["a", "b", "c"]);
+    });
+
+    it("excludes commands explicitly listed in excludeCommands", () => {
+      const panel: CommandPanel = { excludeCommands: ["b", "d"] };
+      expect(
+        applyCommandPanelFilter(candidates, panel).map((c) => c.uid),
+      ).toEqual(["a", "c", "e"]);
+    });
+
+    it("excludeCommands trumps includeGroups when they overlap", () => {
+      const panel: CommandPanel = {
+        includeGroups: ["creation", "status"],
+        excludeCommands: ["a", "c"],
+      };
+      expect(
+        applyCommandPanelFilter(candidates, panel).map((c) => c.uid),
+      ).toEqual(["b"]);
+    });
+
+    it("drops ungrouped commands when includeGroups is active", () => {
+      const panel: CommandPanel = { includeGroups: ["creation"] };
+      expect(
+        applyCommandPanelFilter(candidates, panel).map((c) => c.uid),
+      ).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("isFeaturedBinding — precedence rule #3", () => {
+    const panel: CommandPanel = { featuredBinding: "bind-xyz" };
+
+    it("returns true for the featured binding uid", () => {
+      expect(isFeaturedBinding(panel, "bind-xyz")).toBe(true);
+    });
+
+    it("returns false for any other uid", () => {
+      expect(isFeaturedBinding(panel, "bind-abc")).toBe(false);
+    });
+
+    it("returns false when panel is undefined", () => {
+      expect(isFeaturedBinding(undefined, "bind-xyz")).toBe(false);
+    });
+
+    it("returns false when panel has no featuredBinding", () => {
+      expect(isFeaturedBinding({}, "bind-xyz")).toBe(false);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/layout/LayoutParser.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/layout/LayoutParser.test.ts
@@ -986,4 +986,76 @@ describe("LayoutParser", () => {
       expect(layout!.labelTypography).toBeUndefined();
     });
   });
+
+  describe("RFC-024 Phase 3 commandPanel slot", () => {
+    const baseLayoutFrontmatter: IFrontmatter = {
+      exo__Asset_uid: "layout-cmdpanel-001",
+      exo__Asset_label: "Tasks Layout",
+      exo__Instance_class: ["[[exo__TableLayout]]"],
+      exo__Layout_targetClass: "[[ems__Task]]",
+    };
+
+    it("parses the inline commandPanel with all four fields", async () => {
+      const frontmatter: IFrontmatter = {
+        ...baseLayoutFrontmatter,
+        exo__Layout_commandPanel: {
+          includeGroups: ["creation", "status"],
+          excludeCommands: ["[[cmd-uuid-1]]", "[[cmd-uuid-2|alias]]"],
+          layout: "stacked",
+          featuredBinding: "[[bind-uuid-xyz]]",
+        },
+      };
+
+      const layout = await parser.parseLayoutFromFrontmatter(frontmatter);
+
+      expect(layout).not.toBeNull();
+      expect(layout!.commandPanel).toEqual({
+        includeGroups: ["creation", "status"],
+        excludeCommands: ["cmd-uuid-1", "cmd-uuid-2"],
+        layout: "stacked",
+        featuredBinding: "bind-uuid-xyz",
+      });
+    });
+
+    it("is non-breaking: omits commandPanel when absent from frontmatter", async () => {
+      const layout = await parser.parseLayoutFromFrontmatter(
+        baseLayoutFrontmatter,
+      );
+
+      expect(layout).not.toBeNull();
+      expect(layout!.commandPanel).toBeUndefined();
+      expect(layout!.uid).toBe("layout-cmdpanel-001");
+      expect(layout!.type).toBe(LayoutType.Table);
+    });
+
+    it("omits commandPanel when the slot contains no valid fields", async () => {
+      const warnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      try {
+        const frontmatter: IFrontmatter = {
+          ...baseLayoutFrontmatter,
+          exo__Layout_commandPanel: { layout: "grid" },
+        };
+
+        const layout = await parser.parseLayoutFromFrontmatter(frontmatter);
+
+        expect(layout).not.toBeNull();
+        expect(layout!.commandPanel).toBeUndefined();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("keeps partial commandPanel structures (layout-only)", async () => {
+      const frontmatter: IFrontmatter = {
+        ...baseLayoutFrontmatter,
+        exo__Layout_commandPanel: { layout: "dropdown" },
+      };
+
+      const layout = await parser.parseLayoutFromFrontmatter(frontmatter);
+
+      expect(layout!.commandPanel).toEqual({ layout: "dropdown" });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- RFC-024 Phase 3 (Context Panels) T6.1 — inline `exo__Layout_commandPanel` parser in `LayoutParser`.
- Adds 4 fields: `includeGroups` (OR-merge), `excludeCommands` (exclusion list), `layout` (`inline`/`stacked`/`dropdown`), `featuredBinding` (UUID promoted to primary).
- Pure helpers `applyCommandPanelFilter` + `isFeaturedBinding` enforce precedence rules #2 and #3 from RFC §5 without touching the resolver.
- Rule #1 (`exo__Layout_order` ASC) stays with the future `PanelResolver` (T6.2+) — out of scope here.

## Why non-breaking
- `commandPanel?: CommandPanel` is optional on `BaseLayout`.
- Parser returns `undefined` when `exo__Layout_commandPanel` is absent — tested explicitly.
- Invalid `layout` values are dropped with a `console.warn` (mirrors `isValidAccentColor` pattern).

## Files
- `packages/obsidian-plugin/src/domain/layout/CommandPanel.ts` (new) — types + pure helpers.
- `packages/obsidian-plugin/src/domain/layout/Layout.ts` — `commandPanel?` slot.
- `packages/obsidian-plugin/src/domain/layout/index.ts` — barrel export.
- `packages/obsidian-plugin/src/infrastructure/layout/LayoutParser.ts` — `parseCommandPanel`.
- `packages/obsidian-plugin/tests/unit/domain/layout/CommandPanel.test.ts` (new) — 27 domain cases.
- `packages/obsidian-plugin/tests/unit/infrastructure/layout/LayoutParser.test.ts` — 4 integration cases.

## Test plan
- [x] `npx jest packages/obsidian-plugin/tests/unit/domain/layout/ --runInBand` → 195/195 pass
- [x] `npx jest packages/obsidian-plugin/tests/unit/infrastructure/layout/LayoutParser.test.ts --runInBand` → 56/56 pass (incl. 4 new commandPanel cases)
- [x] `npm run test:unit` → 1278 passed, 25 skipped
- [x] `npm run check:types` → clean
- [x] `npx eslint` on touched files → clean
- [x] Pre-commit archgate → 13/13 rules pass

## Related
- RFC-024 §4 Phase 3
- Parent: Phase 6 Context Panels (vault task 7a52ab1f-71c5-45e6-ad0e-8f54d69c0c12)
- Task: vault UUID 5da12459-5dd0-43b3-bb89-e7f8e470c512

## Acceptance criteria
- [x] Parser handles all 4 fields
- [x] Non-breaking для layouts без commandPanel
- [x] Tests cover precedence rules (exclude > include, featured overrides variant)