### PR TITLE
fix(convert): Convert commands fail through updateProperty dispatch (RFC-028 Finding 5 completion)

### DIFF
--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -325,6 +325,24 @@ export class GroundingExecutor {
       return await this.executeConvertToTask(filePath);
     }
 
+    // RFC-028 Finding 5 completion: production vault + starter-kit groundings
+    // `abdbdf09` (Convert to task) and `e8c1d18a` (Convert to project) ship
+    // with `serviceId = "updateProperty"` + `targetValue = "ems__Task|Project"`.
+    // The grounding schema overloads `targetProperty` as serviceId for
+    // service_call, so at dispatch time we can detect the class-flip intent
+    // from (serviceId=updateProperty, targetValue=ems__Task|ems__Project).
+    // Link-to-parent (30b9e8d8) uses the same serviceId but carries NO
+    // targetValue (driven via inputSchema+userInput) and so flows past this
+    // short-circuit into the registered updateProperty service below.
+    if (serviceId === "updateProperty") {
+      if (grounding.targetValue === "ems__Task") {
+        return await this.executeConvertToTask(filePath);
+      }
+      if (grounding.targetValue === "ems__Project") {
+        return await this.executeConvertToProject(filePath);
+      }
+    }
+
     const service = this.serviceRegistry.get(serviceId);
     if (!service) {
       return {
@@ -356,6 +374,17 @@ export class GroundingExecutor {
       content,
       "exo__Instance_class",
       `["[[ems__Task]]"]`,
+    );
+    await this.fileWriter.updateFile(filePath, updated);
+    return { success: true };
+  }
+
+  private async executeConvertToProject(filePath: string): Promise<ExecutionResult> {
+    const content = await this.fileReader.readFile(filePath);
+    const updated = this.frontmatterService.updateProperty(
+      content,
+      "exo__Instance_class",
+      `["[[ems__Project]]"]`,
     );
     await this.fileWriter.updateFile(filePath, updated);
     return { success: true };

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -1189,3 +1189,239 @@ describe("Convert to Task grounding — end-to-end wiring (Finding 5)", () => {
     expect(written).toContain('exo__Asset_label: "Audit Project"');
   });
 });
+
+// =============================================================================
+// RFC-028 Finding 5 completion — production-shape dispatch for Convert commands
+// =============================================================================
+//
+// The fix shipped in PR #2860 short-circuits on `serviceId === "convertToTask"`,
+// which is the shape used by unit-test fixtures. But the real vault + starter-kit
+// grounding `abdbdf09` ("Convert to task") ships with `serviceId = "updateProperty"`
+// + `targetProperty = "exo__Instance_class"` + `targetValue = "ems__Task"`.
+//
+// The CommandResolver parser overrides `targetProperty` with `Grounding_serviceId`
+// for service_call groundings, so at executor time the definition looks like:
+//   { type: service_call, targetProperty: "updateProperty", targetValue: "ems__Task" }
+//
+// That shape DOES NOT match the short-circuit, falls through to
+// `serviceRegistry.get("updateProperty")`, which requires `userInput.property`
+// → runtime error "updateProperty requires userInput.property" (seen live in
+// vault v15.105.4 verification, Task 2f7c7e56).
+//
+// Scope: extend dispatch to cover BOTH Convert groundings without touching the
+// vault data layer. Convert to Project grounding `e8c1d18a` follows the same
+// pattern with `targetValue = "ems__Project"` and is wired to `b1b6978e` via
+// binding `148aaf8c` (targetClass: ems__Task) — active UI surface.
+// =============================================================================
+
+describe("Convert commands — production-shape dispatch (Finding 5 completion)", () => {
+  const TARGET_IRI = "https://exocortex.my/assets/convert-under-test";
+  const FILE_PATH = "/vault/convert-under-test.md";
+
+  function createConvertReader(sourceClass: "ems__Project" | "ems__Task") {
+    const content = [
+      "---",
+      "exo__Asset_uid: convert-under-test",
+      'exo__Asset_label: "Audit Asset"',
+      "exo__Instance_class:",
+      `  - "[[${sourceClass}]]"`,
+      'ems__Effort_area: "[[area-uuid]]"',
+      'ems__Effort_status: "[[ems__EffortStatusDraft]]"',
+      "---",
+      "",
+      "Body",
+    ].join("\n");
+    return {
+      readFile: jest.fn().mockResolvedValue(content),
+      fileExists: jest.fn().mockResolvedValue(true),
+      getMarkdownFiles: jest.fn().mockResolvedValue([]),
+    };
+  }
+
+  function createWriter() {
+    return {
+      createFile: jest.fn().mockResolvedValue(""),
+      updateFile: jest.fn().mockResolvedValue(undefined),
+      writeFile: jest.fn().mockResolvedValue(undefined),
+      deleteFile: jest.fn().mockResolvedValue(undefined),
+      renameFile: jest.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  function makeSvcCall(overrides: Record<string, unknown>): GroundingDefinition {
+    return {
+      id: "gnd-prod-shape",
+      label: "Prod-shape service_call",
+      type: GroundingType.SERVICE_CALL,
+      ...overrides,
+    } as unknown as GroundingDefinition;
+  }
+
+  let reader: ReturnType<typeof createConvertReader>;
+  let writer: ReturnType<typeof createWriter>;
+  let registry: ServiceRegistry;
+  let executor: GroundingExecutor;
+
+  describe("Convert to Task (production grounding shape)", () => {
+    beforeEach(() => {
+      reader = createConvertReader("ems__Project");
+      writer = createWriter();
+      registry = new ServiceRegistry();
+      executor = new GroundingExecutor(reader, writer, registry);
+    });
+
+    it("flips class to ems__Task when serviceId=updateProperty + targetValue=ems__Task", async () => {
+      // Arrange: grounding matches parsed shape of vault file abdbdf09
+      // after CommandResolver's serviceId-overrides-targetProperty step.
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "ems__Task",
+      });
+
+      // Act
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(writer.updateFile).toHaveBeenCalledTimes(1);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(/exo__Instance_class:\s*\[?\s*"\[\[ems__Task\]\]"/);
+      expect(written).not.toMatch(/exo__Instance_class:[\s\S]*?ems__Project/);
+    });
+
+    it("preserves other frontmatter properties (area, status, label)", async () => {
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "ems__Task",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toContain('ems__Effort_area: "[[area-uuid]]"');
+      expect(written).toContain(
+        'ems__Effort_status: "[[ems__EffortStatusDraft]]"',
+      );
+      expect(written).toContain('exo__Asset_label: "Audit Asset"');
+    });
+  });
+
+  describe("Convert to Project (production grounding shape)", () => {
+    beforeEach(() => {
+      reader = createConvertReader("ems__Task");
+      writer = createWriter();
+      registry = new ServiceRegistry();
+      executor = new GroundingExecutor(reader, writer, registry);
+    });
+
+    it("flips class to ems__Project when serviceId=updateProperty + targetValue=ems__Project", async () => {
+      // Arrange: grounding matches parsed shape of vault file e8c1d18a
+      // ("Convert to project"), mirror of Convert-to-Task path.
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "ems__Project",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      expect(writer.updateFile).toHaveBeenCalledTimes(1);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(
+        /exo__Instance_class:\s*\[?\s*"\[\[ems__Project\]\]"/,
+      );
+      expect(written).not.toMatch(/exo__Instance_class:[\s\S]*?ems__Task/);
+    });
+
+    it("preserves other frontmatter properties after Task→Project flip", async () => {
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "ems__Project",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toContain('ems__Effort_area: "[[area-uuid]]"');
+      expect(written).toContain('exo__Asset_label: "Audit Asset"');
+    });
+  });
+
+  describe("Link-to-parent (non-regression: updateProperty with userInput must not short-circuit)", () => {
+    beforeEach(() => {
+      reader = createConvertReader("ems__Task");
+      writer = createWriter();
+      registry = new ServiceRegistry();
+      executor = new GroundingExecutor(reader, writer, registry);
+    });
+
+    it("dispatches to registered updateProperty service when targetProperty !== exo__Instance_class", async () => {
+      // Arrange: grounding mirrors vault file 30b9e8d8 ("Link to parent").
+      // After parser override, targetProperty ends up as serviceId="updateProperty",
+      // BUT real distinguishing signal is the presence of userInput + absence of
+      // class-flip targetValue. Register a mock updateProperty service and assert
+      // it is invoked (i.e. the composite short-circuit did NOT swallow this).
+      const mockService = { execute: jest.fn().mockResolvedValue(undefined) };
+      registry.register("updateProperty", mockService);
+
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        // targetValue absent — Link-to-parent drives the new parent via userInput
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+        property: "ems__Effort_parent",
+        value: "[[parent-uuid]]",
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockService.execute).toHaveBeenCalledTimes(1);
+      // Writer should NOT have been called by a Convert short-circuit
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+
+    it("also non-regresses when targetValue is a non-class-flip string", async () => {
+      // Defensive: even if a future grounding supplies a targetValue that is
+      // neither "ems__Task" nor "ems__Project", dispatch must still reach
+      // the registered service (not short-circuit).
+      const mockService = { execute: jest.fn().mockResolvedValue(undefined) };
+      registry.register("updateProperty", mockService);
+
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "some-other-value",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+        property: "any__prop",
+        value: "x",
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockService.execute).toHaveBeenCalledTimes(1);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR #2860 shipped the `executeConvertToTask` short-circuit in `GroundingExecutor.executeServiceCall`, keyed on `serviceId === "convertToTask"`. That shape matches the unit-test fixture but NOT the production vault + starter-kit grounding `abdbdf09` ("Convert to task"), which ships with:

```yaml
exocmd__Grounding_type: "service_call"
exocmd__Grounding_serviceId: "updateProperty"
exocmd__Grounding_targetProperty: "exo__Instance_class"
exocmd__Grounding_targetValue: "ems__Task"
```

`CommandResolver` overrides `targetProperty` with `Grounding_serviceId` for `service_call` — so at dispatch the short-circuit sees `serviceId === "updateProperty"` and falls through to the registered `updateProperty` service, which requires `userInput.property` and fails with a generic Notice: **`Command failed: updateProperty requires userInput.property`**.

Verified live in v15.105.4 against vault `1b305799` (Audit Test Project 2026-04-19) — class was NOT flipped; error Notice surfaced to the user.

The same failure mode applies to grounding `e8c1d18a` ("Convert to project"), which is wired via `b1b6978e` + binding `148aaf8c` (targetClass: `ems__Task`) — active UI surface.

## Fix

Extend the composite short-circuit in `executeServiceCall` to also detect the production grounding shape:

- `serviceId === "updateProperty"` + `targetValue === "ems__Task"` → `executeConvertToTask(filePath)`
- `serviceId === "updateProperty"` + `targetValue === "ems__Project"` → `executeConvertToProject(filePath)` (new, mirror of existing convert handler)

Link-to-parent grounding `30b9e8d8` shares the same `serviceId` but has no `targetValue` (driven via `inputSchema` + `userInput`), so it flows past the new short-circuit into the registered service exactly as before. A non-regression test locks this.

- No vault / starter-kit data changes required.
- Existing `serviceId === "convertToTask"` branch preserved so the PR #2860 unit-test path still works.

## Test plan

- [x] New `describe("Convert commands — production-shape dispatch (Finding 5 completion)")` in `GroundingExecutor.test.ts`:
  - [x] Production-shape Convert to Task — class flips + metadata preserved
  - [x] Production-shape Convert to Project — class flips + metadata preserved
  - [x] Link-to-parent non-regression — dispatch reaches the registered `updateProperty` service, writer NOT called
  - [x] Defensive non-regression — non-class-flip `targetValue` still reaches the registered service
- [x] All 66 `GroundingExecutor.test.ts` tests green
- [x] `npm run test` green across exocortex / obsidian-plugin / cli packages
- [x] `npm run test:component` green (539 component tests)
- [x] BDD coverage 100 % (193/193)
- [x] Archgate clean (13/13)
- [ ] CI (triggered on push): build / typecheck / test-unit / test-coverage / test-bdd / archgate / e2e-tests / test-component
- [ ] Post-merge: install v15.105.5, reload Obsidian, click Convert to Task on an `ems__Project` — class flips to `ems__Task`, frontmatter preserved.

## Not fixed here (follow-up)

The underlying design wart — the grounding schema overloading `targetProperty` as serviceId for `service_call` and losing the original `Grounding_targetProperty` field in the parsed `GroundingDefinition` — is paved over for the class-flip case but remains. The next `service_call` grounding with non-trivial dispatch logic will hit the same shape of bug. Flagged for a future refactor (add a first-class `serviceId` field on `GroundingDefinition`, stop overwriting `targetProperty` in the parser).

Refs: Task `2f7c7e56-46d1-4da0-91b7-fc3b4c478da9`, parent `2e7bc5d4` (Triad C Fix Finding 5)