### PR TITLE
fix(convert): match wrapped wikilink targetValue (RFC-028 Finding 5 follow-up)

### DIFF
--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -17,6 +17,26 @@ export interface ExecutionResult {
 }
 
 /**
+ * Extract a class token (e.g. "ems__Task") from a `Grounding_targetValue`
+ * string as parsed by CommandResolver.getObsidianWikilinkValue. The parser
+ * emits either the plain literal ("ems__Task") or the wrapped wikilink form
+ * (`"[[ems__Task]]"`), depending on whether the underlying RDF triple stored
+ * the value as a Literal or an IRI. Returns the inner class token for either
+ * shape; returns undefined for absent/empty/unrecognised values.
+ *
+ * Kept module-local (not exported) — it only exists to bridge the parser's
+ * polymorphic output to the service_call composite short-circuit.
+ */
+function extractClassFromTargetValue(
+  value: string | undefined,
+): string | undefined {
+  if (!value) return undefined;
+  const wrapped = value.match(/^"?\[\[([^\]|]+)(?:\|[^\]]*)?\]\]"?$/);
+  if (wrapped) return wrapped[1];
+  return value;
+}
+
+/**
  * Input parameters collected from the user (for service_call groundings).
  * UI layer collects these via modals; CLI via interactive prompts or --arg flags.
  */
@@ -327,18 +347,30 @@ export class GroundingExecutor {
 
     // RFC-028 Finding 5 completion: production vault + starter-kit groundings
     // `abdbdf09` (Convert to task) and `e8c1d18a` (Convert to project) ship
-    // with `serviceId = "updateProperty"` + `targetValue = "ems__Task|Project"`.
-    // The grounding schema overloads `targetProperty` as serviceId for
-    // service_call, so at dispatch time we can detect the class-flip intent
-    // from (serviceId=updateProperty, targetValue=ems__Task|ems__Project).
+    // with `serviceId = "updateProperty"` + `targetValue` ∈ {"ems__Task",
+    // "ems__Project"}.  The grounding schema overloads `targetProperty` as
+    // serviceId for service_call, so at dispatch time we can detect the
+    // class-flip intent from (serviceId=updateProperty, targetValue=class).
+    //
+    // IMPORTANT: the CommandResolver reads `Grounding_targetValue` via
+    // `getObsidianWikilinkValue`, which returns different shapes depending on
+    // how the underlying RDF triple is stored:
+    //   - plain string literal `"ems__Task"` → stays `"ems__Task"` (CLI tests
+    //     and some vaults; also matches PR #2860 unit-test fixtures).
+    //   - IRI (`ems#Task`) → wrapped as `"[[ems__Task]]"` (vault production
+    //     state observed 2026-04-19T14:37Z via exocortex-cli triple dump on
+    //     grounding `abdbdf09`).
+    // Match both shapes so whichever the parser produces dispatches correctly.
+    //
     // Link-to-parent (30b9e8d8) uses the same serviceId but carries NO
     // targetValue (driven via inputSchema+userInput) and so flows past this
     // short-circuit into the registered updateProperty service below.
     if (serviceId === "updateProperty") {
-      if (grounding.targetValue === "ems__Task") {
+      const targetClass = extractClassFromTargetValue(grounding.targetValue);
+      if (targetClass === "ems__Task") {
         return await this.executeConvertToTask(filePath);
       }
-      if (grounding.targetValue === "ems__Project") {
+      if (targetClass === "ems__Project") {
         return await this.executeConvertToProject(filePath);
       }
     }

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -1424,4 +1424,131 @@ describe("Convert commands — production-shape dispatch (Finding 5 completion)"
       expect(writer.updateFile).not.toHaveBeenCalled();
     });
   });
+
+  describe("Wrapped wikilink targetValue (real vault shape — Finding 5 follow-up)", () => {
+    // Background: CommandResolver.getObsidianWikilinkValue returns a Literal
+    // string as-is ("ems__Task") OR wraps an IRI back into wikilink form
+    // ("[[ems__Task]]" with literal quotes). The vault grounding abdbdf09
+    // stores targetValue as `ems__Task` in YAML, but depending on how the
+    // Turtle parser resolves it in the triple store, the parsed
+    // GroundingDefinition.targetValue may arrive as `"[[ems__Task]]"` instead
+    // of the plain `ems__Task` string. v15.105.5 shipped the composite
+    // short-circuit checking only the plain string — live UI confirmed the
+    // wrapped form is what reaches the executor in production, so the
+    // Convert to Task button still failed with "updateProperty requires
+    // userInput.property". This suite locks in both shapes.
+
+    beforeEach(() => {
+      reader = createConvertReader("ems__Project");
+      writer = createWriter();
+      registry = new ServiceRegistry();
+      executor = new GroundingExecutor(reader, writer, registry);
+    });
+
+    it("flips class to ems__Task when targetValue is wrapped as \"[[ems__Task]]\"", async () => {
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: '"[[ems__Task]]"',
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      expect(writer.updateFile).toHaveBeenCalledTimes(1);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(/exo__Instance_class:\s*\[?\s*"\[\[ems__Task\]\]"/);
+      expect(written).not.toMatch(/exo__Instance_class:[\s\S]*?ems__Project/);
+    });
+
+    it("flips class to ems__Task when targetValue is unquoted [[ems__Task]]", async () => {
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "[[ems__Task]]",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(/exo__Instance_class:\s*\[?\s*"\[\[ems__Task\]\]"/);
+    });
+
+    it("flips class to ems__Project when targetValue is wrapped as \"[[ems__Project]]\"", async () => {
+      const projectReader = createConvertReader("ems__Task");
+      const projectWriter = createWriter();
+      const projectExec = new GroundingExecutor(
+        projectReader,
+        projectWriter,
+        new ServiceRegistry(),
+      );
+
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: '"[[ems__Project]]"',
+      });
+
+      const result = await projectExec.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      const written = projectWriter.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(
+        /exo__Instance_class:\s*\[?\s*"\[\[ems__Project\]\]"/,
+      );
+    });
+
+    it("handles wikilink with alias \"[[ems__Task|Task]]\" — extracts ems__Task target", async () => {
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: '"[[ems__Task|Task]]"',
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(/exo__Instance_class:\s*\[?\s*"\[\[ems__Task\]\]"/);
+    });
+
+    it("does NOT short-circuit when targetValue wraps an unrelated class", async () => {
+      // Defensive: a wrapped wikilink that is NOT ems__Task/ems__Project
+      // must still reach the registered service (via the extractor returning
+      // the inner token, which fails both matches).
+      const mockService = { execute: jest.fn().mockResolvedValue(undefined) };
+      registry.register("updateProperty", mockService);
+
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: '"[[some__OtherClass]]"',
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+        property: "x",
+        value: "y",
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockService.execute).toHaveBeenCalledTimes(1);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

v15.105.5 (PR #2861) shipped the composite short-circuit for Convert to Task / Convert to Project keyed on the exact string `grounding.targetValue === "ems__Task"` / `"ems__Project"`. Live UI verification against vault grounding `abdbdf09` still failed with **`Command failed: updateProperty requires userInput.property`** — class did NOT flip. Logs confirmed (`exocortex-logs.txt`):

```
[DynamicCommands] Failed "Convert to Task": updateProperty requires userInput.property
```

Root cause (verified via `exocortex-cli` triple dump on `abdbdf09` in the actual vault):

```
?p = exocmd:Grounding_targetValue
?o = https://exocortex.my/ontology/ems#Task   ← IRI, not a Literal
```

The RDF triple stores `Grounding_targetValue` as an IRI. `CommandResolver.getObsidianWikilinkValue` then wraps IRIs back into Obsidian wikilink form with literal quotes: `"[[ems__Task]]"`. So at dispatch time `grounding.targetValue === '"[[ems__Task]]"'`, not the plain `"ems__Task"` the v15.105.5 branch checks.

Unit-test fixtures in PR #2860 and PR #2861 both passed `"ems__Task"` as a plain string directly into the `GroundingDefinition`, so the parser roundtrip was never exercised and this mismatch slipped through both. The advisor flagged parser-shape verification before the earlier attempt; production data revealed the parser emits the wrapped form.

## Fix

- Added a module-local helper `extractClassFromTargetValue` that strips optional outer quotes, `[[...]]`, and an optional alias suffix (`[[UUID|label]]`). Returns the inner class token for either the plain Literal shape (`"ems__Task"`) or the wrapped IRI shape (`'"[[ems__Task]]"'`).
- Composite short-circuit now compares the extracted token against `"ems__Task"` / `"ems__Project"`, covering both parser outputs in one branch.

Non-regression preserved: Link-to-parent (`30b9e8d8`) has no `targetValue` → helper returns `undefined` → short-circuit does not fire → registered service path as before.

## Test plan

- [x] New `describe("Wrapped wikilink targetValue (real vault shape — Finding 5 follow-up)")` in `GroundingExecutor.test.ts`:
  - [x] Wrapped `\"[[ems__Task]]\"` → class flips to Task
  - [x] Unquoted `[[ems__Task]]` → class flips to Task
  - [x] Wrapped `\"[[ems__Project]]\"` → class flips to Project
  - [x] Aliased `\"[[ems__Task|Task]]\"` → extracts `ems__Task`
  - [x] Defensive: wrapped but unrelated class → reaches registered service (non-regression)
- [x] All 71 `GroundingExecutor.test.ts` tests green (66 + 5 new)
- [x] Monorepo unit tests green (4703 + 1278 + 82 + 53)
- [x] BDD 100 % (193/193), archgate 13/13, build clean
- [ ] CI (triggered on push): build / typecheck / test-unit / test-coverage / test-bdd / archgate / e2e-tests / test-component
- [ ] Post-merge: install v15.105.6, reload, click Convert to Task on an `ems__Project` — class flips to `ems__Task`, frontmatter preserved.

## Follow-up note

The design wart flagged in PR #2861's description — `targetProperty` doubling as serviceId for `service_call`, and `targetValue` polymorphism between Literal and IRI — is still there. This PR broadens the bandage to cover the IRI-wrapped shape; it does NOT remove the wart. The principled fix would be a separate `serviceId` field on `GroundingDefinition` and a unified parse path that always returns the class token for class-flip groundings.

Refs: Task `2f7c7e56-46d1-4da0-91b7-fc3b4c478da9` (Triad C.3 verify), v15.105.5 live failure on vault `1b305799`, PR #2861 (v15.105.5).