### PR TITLE
fix(cli): dyncommand list/validate now resolves UUID-wikilink class refs

### DIFF
--- a/packages/cli/src/commands/dynamic-command.ts
+++ b/packages/cli/src/commands/dynamic-command.ts
@@ -430,8 +430,10 @@ function scanCommands(vaultPath: string): CommandFileInfo[] {
   const allFiles: Array<{ filePath: string; fm: Record<string, any> }> = [];
   collectParsedFiles(vaultPath, allFiles);
 
+  const classLabelByUid = buildClassLabelIndex(allFiles);
+
   for (const { filePath, fm } of allFiles) {
-    if (!hasClass(fm, "exocmd__Command")) continue;
+    if (!hasClass(fm, "exocmd__Command", classLabelByUid)) continue;
 
     const uid = fm["exo__Asset_uid"] ?? "";
     const label = fm["exo__Asset_label"] ?? extractLabelFromFilename(filePath);
@@ -445,7 +447,7 @@ function scanCommands(vaultPath: string): CommandFileInfo[] {
     if (groundingRef) {
       const groundingUid = normalizeWikilink(String(groundingRef));
       const groundingFile = allFiles.find(f =>
-        f.fm["exo__Asset_uid"] === groundingUid && hasClass(f.fm, "exocmd__Grounding"),
+        f.fm["exo__Asset_uid"] === groundingUid && hasClass(f.fm, "exocmd__Grounding", classLabelByUid),
       );
       if (groundingFile) {
         groundingType = groundingFile.fm["exocmd__Grounding_type"];
@@ -505,6 +507,8 @@ function validateCommands(vaultPath: string): ValidationIssue[] {
   const allFiles: Array<{ filePath: string; fm: Record<string, any> }> = [];
   collectParsedFiles(vaultPath, allFiles);
 
+  const classLabelByUid = buildClassLabelIndex(allFiles);
+
   // Build lookup maps
   const uidMap = new Map<string, { filePath: string; fm: Record<string, any> }>();
   for (const file of allFiles) {
@@ -514,7 +518,7 @@ function validateCommands(vaultPath: string): ValidationIssue[] {
 
   // Validate each command
   for (const { filePath, fm } of allFiles) {
-    if (!hasClass(fm, "exocmd__Command")) continue;
+    if (!hasClass(fm, "exocmd__Command", classLabelByUid)) continue;
 
     const uid = fm["exo__Asset_uid"] ?? "";
     const label = fm["exo__Asset_label"] ?? extractLabelFromFilename(filePath);
@@ -539,7 +543,7 @@ function validateCommands(vaultPath: string): ValidationIssue[] {
       const groundingFile = uidMap.get(groundingUid);
       if (!groundingFile) {
         commandIssues.push(`Grounding reference "${groundingUid}" not found in vault`);
-      } else if (!hasClass(groundingFile.fm, "exocmd__Grounding")) {
+      } else if (!hasClass(groundingFile.fm, "exocmd__Grounding", classLabelByUid)) {
         commandIssues.push(`Grounding reference "${groundingUid}" is not an exocmd__Grounding asset`);
       } else {
         // Validate grounding definition
@@ -582,7 +586,7 @@ function validateCommands(vaultPath: string): ValidationIssue[] {
       const preconditionFile = uidMap.get(preconditionUid);
       if (!preconditionFile) {
         commandIssues.push(`Precondition reference "${preconditionUid}" not found in vault`);
-      } else if (!hasClass(preconditionFile.fm, "exocmd__Precondition")) {
+      } else if (!hasClass(preconditionFile.fm, "exocmd__Precondition", classLabelByUid)) {
         commandIssues.push(`Precondition reference "${preconditionUid}" is not an exocmd__Precondition asset`);
       } else {
         // Validate precondition has either sparqlAsk or hostFunction
@@ -596,7 +600,7 @@ function validateCommands(vaultPath: string): ValidationIssue[] {
 
     // Check bindings exist for this command
     const hasBinding = allFiles.some(f => {
-      if (!hasClass(f.fm, "exocmd__CommandBinding")) return false;
+      if (!hasClass(f.fm, "exocmd__CommandBinding", classLabelByUid)) return false;
       const cmdRef = normalizeWikilink(String(f.fm["exocmd__CommandBinding_command"] ?? ""));
       return cmdRef === uid;
     });
@@ -721,7 +725,27 @@ function parseYamlFrontmatter(content: string): Record<string, any> {
   return result;
 }
 
-function hasClass(fm: Record<string, any>, className: string): boolean {
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function buildClassLabelIndex(
+  files: Array<{ filePath: string; fm: Record<string, any> }>,
+): Map<string, string> {
+  const idx = new Map<string, string>();
+  for (const { fm } of files) {
+    const uid = fm["exo__Asset_uid"];
+    const label = fm["exo__Asset_label"];
+    if (typeof uid === "string" && typeof label === "string") {
+      idx.set(uid, label);
+    }
+  }
+  return idx;
+}
+
+function hasClass(
+  fm: Record<string, any>,
+  className: string,
+  classLabelByUid?: Map<string, string>,
+): boolean {
   const instanceClass = fm["exo__Instance_class"];
   if (!instanceClass) return false;
 
@@ -731,6 +755,13 @@ function hasClass(fm: Record<string, any>, className: string): boolean {
     const match = cls.match(/\[\[([^|\]]+)/);
     const extracted = match ? match[1] : cls;
     if (extracted === className) return true;
+    // Issue #2863: starter-kit uses UUID-named class definition files
+    // (exo__Instance_class: "[[<uuid>]]"), so the wikilink target is a UUID,
+    // not the class name. Resolve UUID → exo__Asset_label via reverse index.
+    if (classLabelByUid && UUID_RE.test(extracted)) {
+      const resolved = classLabelByUid.get(extracted);
+      if (resolved === className) return true;
+    }
   }
   return false;
 }

--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -274,6 +274,106 @@ describe("dynamic-command CLI", () => {
 
       consoleSpy.mockRestore();
     });
+
+    it("should find commands with plain class-name wikilink (regression)", async () => {
+      const commandFm = [
+        'exo__Instance_class: "[[exocmd__Command]]"',
+        "exo__Asset_uid: cmd-plain-wikilink",
+        "exo__Asset_label: Plain Wikilink Command",
+        "exocmd__Command_grounding: [[gnd-plain]]",
+      ].join("\n");
+
+      mockReaddirSync.mockImplementation((dir: string) => {
+        if (dir.endsWith("/vault")) {
+          return [{ name: "cmd.md", isDirectory: () => false }];
+        }
+        return [];
+      });
+
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("cmd.md")) return `---\n${commandFm}\n---\n`;
+        return "";
+      });
+
+      const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+      const cmd = dynamicCommandCommand();
+      const listCmd = cmd.commands.find((c: any) => c.name() === "list");
+      await listCmd.parseAsync(["--vault", "/vault", "--output", "json"], { from: "user" });
+
+      const output = consoleSpy.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toMatch(/"totalCommands":\s*1/);
+      expect(output).toContain("cmd-plain-wikilink");
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should find commands referencing class via UUID-wikilink (#2863)", async () => {
+      // Class definition file: UUID filename, exo__Asset_label = "exocmd__Command"
+      const classFm = [
+        "exo__Asset_uid: 790e5b16-251d-4556-96ac-e5c7f1429b2e",
+        'exo__Asset_label: "exocmd__Command"',
+      ].join("\n");
+
+      // Command file: exo__Instance_class is UUID-wikilink pointing to the class
+      const commandFm = [
+        "exo__Instance_class:",
+        '  - "[[790e5b16-251d-4556-96ac-e5c7f1429b2e]]"',
+        "exo__Asset_uid: cmd-uuid-wikilink",
+        "exo__Asset_label: UUID Wikilink Command",
+        "exocmd__Command_grounding: [[gnd-uuid]]",
+      ].join("\n");
+
+      // Grounding class definition: UUID filename, label = "exocmd__Grounding"
+      const groundingClassFm = [
+        "exo__Asset_uid: 11579feb-2e42-491c-af59-b89b1129a539",
+        'exo__Asset_label: "exocmd__Grounding"',
+      ].join("\n");
+
+      // Grounding instance: UUID-wikilink class ref
+      const groundingFm = [
+        "exo__Instance_class:",
+        '  - "[[11579feb-2e42-491c-af59-b89b1129a539]]"',
+        "exo__Asset_uid: gnd-uuid",
+        "exo__Asset_label: UUID Grounding",
+        'exocmd__Grounding_type: "property_set"',
+      ].join("\n");
+
+      mockReaddirSync.mockImplementation((dir: string) => {
+        if (dir.endsWith("/vault")) {
+          return [
+            { name: "class.md", isDirectory: () => false },
+            { name: "cmd.md", isDirectory: () => false },
+            { name: "gnd-class.md", isDirectory: () => false },
+            { name: "gnd.md", isDirectory: () => false },
+          ];
+        }
+        return [];
+      });
+
+      mockReadFileSync.mockImplementation((path: string) => {
+        // More specific matches MUST come before generic ones
+        if (path.endsWith("/gnd-class.md")) return `---\n${groundingClassFm}\n---\n`;
+        if (path.endsWith("/class.md")) return `---\n${classFm}\n---\n`;
+        if (path.endsWith("/cmd.md")) return `---\n${commandFm}\n---\n`;
+        if (path.endsWith("/gnd.md")) return `---\n${groundingFm}\n---\n`;
+        return "";
+      });
+
+      const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+      const cmd = dynamicCommandCommand();
+      const listCmd = cmd.commands.find((c: any) => c.name() === "list");
+      await listCmd.parseAsync(["--vault", "/vault", "--output", "json"], { from: "user" });
+
+      const output = consoleSpy.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toMatch(/"totalCommands":\s*1/);
+      expect(output).toContain("cmd-uuid-wikilink");
+      // Grounding type must resolve via UUID-wikilink reverse lookup too
+      expect(output).toContain("property_set");
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe("show action", () => {


### PR DESCRIPTION
## Summary

- `hasClass` previously string-matched the wikilink target against the class name, so starter-kit vaults with UUID-named class definition files (`exo__Instance_class: "[[<uuid>]]"`) were skipped — `dyncommand list` returned 0 on a vault with 48+ valid commands.
- Fix: build a UUID → `exo__Asset_label` reverse index from all collected files; when the wikilink target is a UUID, resolve its label and compare against the class name.
- Bare strings and plain class-name wikilinks continue to match as before; applied uniformly to every `hasClass` call site in `scanCommands` and `validateCommands`.

## Evidence

- Before: `npx @kitelev/exocortex-cli@15.105.0 dyncommand list --vault <starter-kit>` → `totalCommands: 0`.
- After (local build): same command → `totalCommands: 44`.
- Unit tests: `packages/cli/tests/unit/commands/dynamic-command.test.ts` — 2 new cases pinning plain-wikilink (regression) and UUID-wikilink (the bug); suite now 21 passed.

## Test plan

- [x] Unit: `npm test -- --testPathPatterns=dynamic-command` → 21 passed
- [x] Unit: full CLI suite `npm test` (80 suites, 1280 passed)
- [x] Typecheck: `npm run check:types` clean
- [x] Smoke: local CLI against `exocortex-starter-kit` → 44 commands discovered (was 0)
- [ ] CI 8 checks green
- [ ] Post-merge: `@kitelev/exocortex-cli@latest dyncommand list --vault <starter-kit>` → totalCommands > 0

Closes #2863.