### PR TITLE
feat(cli): port createRelatedTask + exec --input flag (closes #2865)

### DIFF
--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -219,8 +219,12 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
   }
 
   private createFileObject(filePath: string): IFile {
-    const basename = path.basename(filePath);
-    const name = path.basename(filePath, path.extname(filePath));
+    // Match Obsidian TFile semantics: `basename` is the name WITHOUT extension
+    // and `name` is the full filename. Shared services in `packages/exocortex`
+    // (GenericAssetCreationService.inheritParentContext, NoteToRDFConverter,
+    // AreaHierarchyBuilder, AssetConversionService) rely on this contract.
+    const name = path.basename(filePath);
+    const basename = path.basename(filePath, path.extname(filePath));
     const parentPath = path.dirname(filePath);
 
     return {

--- a/packages/cli/src/commands/dynamic-command.ts
+++ b/packages/cli/src/commands/dynamic-command.ts
@@ -10,6 +10,7 @@ import {
   GroundingExecutor,
   ServiceRegistry,
   GroundingType,
+  GenericAssetCreationService,
   type GroundingDefinition,
   type CommandBindingDefinition,
 } from "exocortex";
@@ -26,6 +27,7 @@ export interface DynCommandOptions {
   output?: OutputFormat;
   target?: string;
   dryRun?: boolean;
+  input?: string;
 }
 
 interface CommandFileInfo {
@@ -234,6 +236,7 @@ export function dynamicCommandCommand(): Command {
     .option("--target <filepath>", "Path to target asset file (relative to vault)")
     .option("--output <type>", "Response format: text|json", "text")
     .option("--dry-run", "Preview changes without modifying files")
+    .option("--input <json>", "JSON userInput for service_call groundings, e.g. '{\"label\":\"Task name\"}'")
     .action(async (uid: string, options: DynCommandOptions) => {
       const outputFormat = (options.output || "text") as OutputFormat;
       ErrorHandler.setFormat(outputFormat);
@@ -328,7 +331,12 @@ export function dynamicCommandCommand(): Command {
 
         // Execute grounding
         const serviceRegistry = new ServiceRegistry();
-        populateCliServiceRegistry(serviceRegistry);
+        const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
+        const genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+        populateCliServiceRegistry(serviceRegistry, {
+          vaultAdapter,
+          genericAssetCreationService,
+        });
         const nodeFsAdapter = new NodeFsAdapter(vaultPath);
         const groundingExecutor = new GroundingExecutor(
           nodeFsAdapter,
@@ -336,10 +344,27 @@ export function dynamicCommandCommand(): Command {
           serviceRegistry,
         );
 
+        let userInput: Record<string, unknown> | undefined;
+        if (options.input) {
+          try {
+            const parsed = JSON.parse(options.input);
+            if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+              throw new Error("must be a JSON object");
+            }
+            userInput = parsed as Record<string, unknown>;
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error(`❌ --input: invalid JSON object (${msg})`);
+            process.exitCode = ExitCodes.INVALID_ARGUMENTS;
+            return;
+          }
+        }
+
         const result = await groundingExecutor.execute(
           command.grounding,
           targetIRI,
           options.target,
+          userInput,
         );
 
         if (outputFormat === "json") {

--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -1,4 +1,11 @@
-import { ServiceRegistry, type IGroundingService } from "exocortex";
+import {
+  ServiceRegistry,
+  type IGroundingService,
+  type IVaultAdapter,
+  type IFile,
+  type UserInput,
+  GenericAssetCreationService,
+} from "exocortex";
 
 /**
  * The 10 well-known service IDs the plugin registers via
@@ -48,6 +55,73 @@ function notImplementedService(serviceId: string): IGroundingService {
 }
 
 /**
+ * Optional dependencies that unlock real CLI-side service implementations.
+ *
+ * `dyncommand validate` and unit tests call `populateCliServiceRegistry`
+ * without deps and receive only fail-loud stubs. `dyncommand exec` supplies
+ * the adapters + shared services so ported handlers (e.g. createRelatedTask,
+ * #2865) can run against a real vault on disk.
+ */
+export interface CliServiceRegistryDeps {
+  vaultAdapter: IVaultAdapter;
+  genericAssetCreationService: GenericAssetCreationService;
+}
+
+function resolveTargetFile(vaultAdapter: IVaultAdapter, targetIRI: string): IFile {
+  const candidate = vaultAdapter.getAbstractFileByPath(`${targetIRI}.md`);
+  if (!candidate || !("basename" in candidate)) {
+    throw new Error(`Cannot resolve target file for IRI: ${targetIRI}`);
+  }
+  return candidate as IFile;
+}
+
+/**
+ * CLI-side implementation of the `createRelatedTask` service (#2865).
+ *
+ * Mirrors the plugin handler in
+ * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`
+ * minus workspace/leaf side-effects — the CLI just writes the new `.md` file
+ * and returns. Parent-context inheritance (ems__Effort_area vs ems__Effort_parent)
+ * is delegated to `GenericAssetCreationService.inheritParentContext`.
+ */
+export function createCreateRelatedTaskService(
+  vaultAdapter: IVaultAdapter,
+  genericAssetCreationService: GenericAssetCreationService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
+      const label = userInput?.label as string | undefined;
+      if (!label) {
+        throw new Error("createRelatedTask requires userInput.label");
+      }
+
+      const parentFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const parentMetadata =
+        (vaultAdapter.getFrontmatter(parentFile) as Record<string, unknown>) ?? {};
+      const folderPath = parentFile.parent?.path || "";
+
+      const propertyValues: Record<string, unknown> = {
+        ems__Effort_status: '"[[ems__EffortStatusDraft]]"',
+      };
+
+      const explicitParentProperty = userInput?.parentProperty as string | undefined;
+      if (explicitParentProperty && parentFile.basename) {
+        propertyValues[explicitParentProperty] = `"[[${parentFile.basename}]]"`;
+      }
+
+      await genericAssetCreationService.createAsset({
+        className: "ems__Task",
+        label,
+        folderPath,
+        propertyValues,
+        parentFile,
+        parentMetadata,
+      });
+    },
+  };
+}
+
+/**
  * Populate a ServiceRegistry with fail-loud stubs for all well-known services.
  *
  * Pre-#2864 the stubs resolved silently, so `dyncommand exec` on service_call
@@ -55,9 +129,27 @@ function notImplementedService(serviceId: string): IGroundingService {
  * that path would pass while production behavior diverged. Post-fix each stub
  * throws `CliServiceNotImplementedError`, surfaced by `GroundingExecutor` as
  * `{success:false, error}`, which the CLI prints and returns non-zero exit.
+ *
+ * When `deps` is provided, real service implementations (starting with
+ * `createRelatedTask`, #2865) are registered on top of the stubs. This keeps
+ * `dyncommand validate` behavior stable (no deps required) while letting
+ * `dyncommand exec` run real handlers against a vault on disk.
  */
-export function populateCliServiceRegistry(registry: ServiceRegistry): void {
+export function populateCliServiceRegistry(
+  registry: ServiceRegistry,
+  deps?: CliServiceRegistryDeps,
+): void {
   for (const id of CLI_STUB_SERVICE_IDS) {
     registry.register(id, notImplementedService(id));
+  }
+
+  if (deps) {
+    registry.register(
+      "createRelatedTask",
+      createCreateRelatedTaskService(
+        deps.vaultAdapter,
+        deps.genericAssetCreationService,
+      ),
+    );
   }
 }

--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -52,6 +52,9 @@ jest.unstable_mockModule("exocortex", () => ({
     has: jest.fn(),
     getRegisteredIds: jest.fn().mockReturnValue([]),
   })),
+  GenericAssetCreationService: jest.fn(() => ({
+    createAsset: jest.fn().mockResolvedValue({ path: "", basename: "", name: "" }),
+  })),
   GroundingType: {
     SPARQL_UPDATE: "sparql_update",
     PROPERTY_DELETE: "property_delete",

--- a/packages/cli/tests/unit/services/createRelatedTask.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedTask.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import yaml from "js-yaml";
+import {
+  GenericAssetCreationService,
+  ServiceRegistry,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
+import {
+  createCreateRelatedTaskService,
+  populateCliServiceRegistry,
+  CliServiceNotImplementedError,
+} from "../../../src/services/CliServiceRegistryPopulator.js";
+
+type Frontmatter = Record<string, unknown>;
+
+function readFrontmatter(filePath: string): Frontmatter {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter in ${filePath}`);
+  return yaml.load(match[1]) as Frontmatter;
+}
+
+function writeAsset(vaultRoot: string, relPath: string, frontmatter: Frontmatter): string {
+  const fullPath = path.join(vaultRoot, relPath);
+  fs.ensureDirSync(path.dirname(fullPath));
+  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n`, "utf-8");
+  return fullPath;
+}
+
+function newCreatedFile(vaultRoot: string, folder: string, excludeBasenames: Set<string>): string {
+  const dir = path.join(vaultRoot, folder);
+  const entries = fs.readdirSync(dir).filter((e) => e.endsWith(".md"));
+  const created = entries.find((e) => !excludeBasenames.has(path.basename(e, ".md")));
+  if (!created) {
+    throw new Error(`No new .md file found in ${dir}. Existing: ${entries.join(", ")}`);
+  }
+  return path.join(dir, created);
+}
+
+describe("createRelatedTask (CLI)", () => {
+  let vaultRoot: string;
+  let vaultAdapter: FileSystemVaultAdapter;
+  let genericAssetCreationService: GenericAssetCreationService;
+  let service: ReturnType<typeof createCreateRelatedTaskService>;
+
+  beforeEach(() => {
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-createrelatedtask-"));
+    vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
+    genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    service = createCreateRelatedTaskService(vaultAdapter, genericAssetCreationService);
+  });
+
+  afterEach(() => {
+    fs.removeSync(vaultRoot);
+  });
+
+  it("inherits ems__Effort_area when parent is ems__Area", async () => {
+    writeAsset(vaultRoot, "areas/Area1.md", {
+      exo__Asset_uid: "area-uid-1",
+      exo__Asset_label: "Area 1",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+    const before = new Set(["Area1"]);
+
+    await service.execute("areas/Area1", { label: "New Task from Area" });
+
+    const createdPath = newCreatedFile(vaultRoot, "areas", before);
+    const fm = readFrontmatter(createdPath);
+
+    expect(fm.exo__Instance_class).toEqual(["[[ems__Task]]"]);
+    expect(fm.exo__Asset_label).toBe("New Task from Area");
+    expect(fm.ems__Effort_area).toBe("[[Area1]]");
+    expect(fm.ems__Effort_parent).toBeUndefined();
+    expect(fm.ems__Effort_status).toBe("[[ems__EffortStatusDraft]]");
+  });
+
+  it("inherits ems__Effort_parent when parent is ems__Project", async () => {
+    writeAsset(vaultRoot, "projects/Project1.md", {
+      exo__Asset_uid: "proj-uid-1",
+      exo__Asset_label: "Project 1",
+      exo__Instance_class: ["[[ems__Project]]"],
+    });
+    const before = new Set(["Project1"]);
+
+    await service.execute("projects/Project1", { label: "New Task from Project" });
+
+    const createdPath = newCreatedFile(vaultRoot, "projects", before);
+    const fm = readFrontmatter(createdPath);
+
+    expect(fm.exo__Instance_class).toEqual(["[[ems__Task]]"]);
+    expect(fm.ems__Effort_parent).toBe("[[Project1]]");
+    expect(fm.ems__Effort_area).toBeUndefined();
+  });
+
+  it("writes explicit parentProperty in addition to auto-detected inheritance", async () => {
+    writeAsset(vaultRoot, "areas/Area2.md", {
+      exo__Asset_uid: "area-uid-2",
+      exo__Asset_label: "Area 2",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+    const before = new Set(["Area2"]);
+
+    await service.execute("areas/Area2", {
+      label: "Custom",
+      parentProperty: "ems__Effort_customParent",
+    });
+
+    const createdPath = newCreatedFile(vaultRoot, "areas", before);
+    const fm = readFrontmatter(createdPath);
+
+    expect(fm.ems__Effort_customParent).toBe("[[Area2]]");
+    expect(fm.ems__Effort_area).toBe("[[Area2]]");
+  });
+
+  it("rejects when label is missing", async () => {
+    writeAsset(vaultRoot, "areas/Area3.md", {
+      exo__Asset_uid: "area-uid-3",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+
+    await expect(service.execute("areas/Area3", {})).rejects.toThrow(/label/i);
+  });
+
+  it("rejects when target file does not exist", async () => {
+    await expect(
+      service.execute("areas/DoesNotExist", { label: "x" }),
+    ).rejects.toThrow();
+  });
+
+  it("registry integration: populateCliServiceRegistry with deps registers real createRelatedTask (no throw-stub)", async () => {
+    writeAsset(vaultRoot, "areas/Area4.md", {
+      exo__Asset_uid: "area-uid-4",
+      exo__Asset_label: "Area 4",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+    const before = new Set(["Area4"]);
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+    });
+
+    const registered = registry.get("createRelatedTask");
+    expect(registered).toBeDefined();
+
+    await expect(
+      registered!.execute("areas/Area4", { label: "Registered Task" }),
+    ).resolves.toBeUndefined();
+
+    const createdPath = newCreatedFile(vaultRoot, "areas", before);
+    const fm = readFrontmatter(createdPath);
+    expect(fm.exo__Asset_label).toBe("Registered Task");
+    expect(fm.ems__Effort_area).toBe("[[Area4]]");
+  });
+
+  it("registry integration: createRelatedTask is NOT a CliServiceNotImplementedError stub when deps provided (#2864 regression guard)", async () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+    });
+    const registered = registry.get("createRelatedTask");
+    expect(registered).toBeDefined();
+
+    writeAsset(vaultRoot, "areas/Area5.md", {
+      exo__Asset_uid: "area-uid-5",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+
+    try {
+      await registered!.execute("areas/Area5", { label: "Guard Task" });
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(CliServiceNotImplementedError);
+    }
+  });
+
+  it("registry integration: when deps are NOT provided, createRelatedTask is absent (backwards-compat)", () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry);
+    expect(registry.has("createRelatedTask")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2865 — first real service port after the meta-gap closures #2863 (v15.105.7) and #2864 (v15.105.8). Previously `dyncommand exec` on starter-kit's `Create Child Task` command flowed into a CLI fail-loud stub (post-#2864); now it creates a real `ems__Task` with parent context inherited from the target file via the shared `GenericAssetCreationService`.

## Scope

1. **CLI service impl** — `CreateRelatedTaskService` mirrors the plugin handler in `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts:341` minus Obsidian workspace side-effects. Parent-context inheritance (ems__Area → `ems__Effort_area`, ems__Project/Task → `ems__Effort_parent`) is delegated to shared `GenericAssetCreationService.inheritParentContext`.

2. **Registry deps** — `populateCliServiceRegistry(registry, deps?)` now accepts optional adapters. `dyncommand validate` still runs without deps (fail-loud stubs only); `dyncommand exec` wires the real implementation.

3. **`--input <json>` on `dyncommand exec`** — without it `userInput.label` could not reach the service, so the DoD (`creates ems__Task with ems__Effort_area/parent inherited`) was mechanically unreachable. Flag parses as JSON object and flows through `GroundingExecutor.execute`.

## Bundled adjacent fix

`FileSystemVaultAdapter.createFileObject` had `basename`/`name` semantics inverted: shared `exocortex` services (`NoteToRDFConverter`, `GenericAssetCreationService.inheritParentContext`, `AreaHierarchyBuilder`, `AssetConversionService`) read `file.basename` as the name *without* extension per Obsidian `TFile` contract. Before the swap the CLI adapter returned `"Area1.md"` for `basename`, causing inherited wikilinks to emit `[[Area1.md]]`. Audit confirmed no CLI caller consumed the inverted shape (all internal callers use `path.basename(..., ".md")` directly; no tests asserted the swap).

## Tests

8 new unit tests in `packages/cli/tests/unit/services/createRelatedTask.test.ts`:

- Area parent → `ems__Effort_area` inherited, no `ems__Effort_parent`
- Project parent → `ems__Effort_parent` inherited, no `ems__Effort_area`
- Explicit `parentProperty` coexists with auto-detected inheritance (additive)
- Missing `label` → rejects with `/label/`
- Target file missing → rejects
- Registry integration with deps → real service registered, not stub
- Registry integration with deps → not a `CliServiceNotImplementedError`
- Registry integration without deps → `createRelatedTask` absent (backwards-compat)

Full CLI suite: **1267 tests passing**, coverage 70.78/61.23/82.52/71.1 (thresholds 65/60/70/65). Typecheck clean.

## Smoke on starter-kit

```
# Area parent (Hello Area)
$ node dist/index.js dyncommand exec 2adf3655-0ab9-4578-ad2e-223108729db8 \
    --target "01 Inbox/723b5de3-3047-41d9-a3dc-ea96ba28a5f1.md" \
    --vault <starter-kit> \
    --input '{"label":"Smoke-Area-Task"}' --output json
# → ems__Effort_area: "[[723b5de3-3047-41d9-a3dc-ea96ba28a5f1]]"

# Project parent (Build my first project)
$ node dist/index.js dyncommand exec 2adf3655-0ab9-4578-ad2e-223108729db8 \
    --target "01 Inbox/00d0631d-56c7-4e4b-b98a-fc0b908e6bc9.md" \
    --vault <starter-kit> \
    --input '{"label":"Smoke-Project-Task"}' --output json
# → ems__Effort_parent: "[[00d0631d-56c7-4e4b-b98a-fc0b908e6bc9]]"
```

Both produced valid `ems__Task` assets with the correct parent-property shape. Artifacts removed post-smoke.

## Test plan

- [x] Failing tests written first (TDD Step 1)
- [x] Minimal impl → tests green (TDD Step 2)
- [x] Full CLI suite green locally (1267/1267)
- [x] Typecheck clean
- [x] Coverage thresholds met
- [x] Smoke on starter-kit: Area parent → ems__Effort_area
- [x] Smoke on starter-kit: Project parent → ems__Effort_parent
- [ ] CI all 8 required checks green
- [ ] Auto Release succeeds, new `@kitelev/exocortex-cli` version published