### PR TITLE
feat(cli): createRelatedProject service port (closes #2866)

### DIFF
--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -122,6 +122,53 @@ export function createCreateRelatedTaskService(
 }
 
 /**
+ * CLI-side implementation of the `createRelatedProject` service (#2866).
+ *
+ * Mirrors the plugin handler in
+ * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`
+ * minus workspace/leaf side-effects. Parent-context inheritance
+ * (ems__Effort_area vs ems__Effort_parent) is delegated to
+ * `GenericAssetCreationService.inheritParentContext`, which covers the
+ * `ems__Project` branch symmetrically with `ems__Task`.
+ */
+export function createCreateRelatedProjectService(
+  vaultAdapter: IVaultAdapter,
+  genericAssetCreationService: GenericAssetCreationService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
+      const label = userInput?.label as string | undefined;
+      if (!label) {
+        throw new Error("createRelatedProject requires userInput.label");
+      }
+
+      const parentFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const parentMetadata =
+        (vaultAdapter.getFrontmatter(parentFile) as Record<string, unknown>) ?? {};
+      const folderPath = parentFile.parent?.path || "";
+
+      const propertyValues: Record<string, unknown> = {
+        ems__Effort_status: '"[[ems__EffortStatusDraft]]"',
+      };
+
+      const explicitParentProperty = userInput?.parentProperty as string | undefined;
+      if (explicitParentProperty && parentFile.basename) {
+        propertyValues[explicitParentProperty] = `"[[${parentFile.basename}]]"`;
+      }
+
+      await genericAssetCreationService.createAsset({
+        className: "ems__Project",
+        label,
+        folderPath,
+        propertyValues,
+        parentFile,
+        parentMetadata,
+      });
+    },
+  };
+}
+
+/**
  * Populate a ServiceRegistry with fail-loud stubs for all well-known services.
  *
  * Pre-#2864 the stubs resolved silently, so `dyncommand exec` on service_call
@@ -147,6 +194,13 @@ export function populateCliServiceRegistry(
     registry.register(
       "createRelatedTask",
       createCreateRelatedTaskService(
+        deps.vaultAdapter,
+        deps.genericAssetCreationService,
+      ),
+    );
+    registry.register(
+      "createRelatedProject",
+      createCreateRelatedProjectService(
         deps.vaultAdapter,
         deps.genericAssetCreationService,
       ),

--- a/packages/cli/tests/unit/services/createRelatedProject.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedProject.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import yaml from "js-yaml";
+import {
+  GenericAssetCreationService,
+  ServiceRegistry,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
+import {
+  createCreateRelatedProjectService,
+  populateCliServiceRegistry,
+  CliServiceNotImplementedError,
+} from "../../../src/services/CliServiceRegistryPopulator.js";
+
+type Frontmatter = Record<string, unknown>;
+
+function readFrontmatter(filePath: string): Frontmatter {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter in ${filePath}`);
+  return yaml.load(match[1]) as Frontmatter;
+}
+
+function writeAsset(vaultRoot: string, relPath: string, frontmatter: Frontmatter): string {
+  const fullPath = path.join(vaultRoot, relPath);
+  fs.ensureDirSync(path.dirname(fullPath));
+  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n`, "utf-8");
+  return fullPath;
+}
+
+function newCreatedFile(vaultRoot: string, folder: string, excludeBasenames: Set<string>): string {
+  const dir = path.join(vaultRoot, folder);
+  const entries = fs.readdirSync(dir).filter((e) => e.endsWith(".md"));
+  const created = entries.find((e) => !excludeBasenames.has(path.basename(e, ".md")));
+  if (!created) {
+    throw new Error(`No new .md file found in ${dir}. Existing: ${entries.join(", ")}`);
+  }
+  return path.join(dir, created);
+}
+
+describe("createRelatedProject (CLI)", () => {
+  let vaultRoot: string;
+  let vaultAdapter: FileSystemVaultAdapter;
+  let genericAssetCreationService: GenericAssetCreationService;
+  let service: ReturnType<typeof createCreateRelatedProjectService>;
+
+  beforeEach(() => {
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-createrelatedproject-"));
+    vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
+    genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    service = createCreateRelatedProjectService(vaultAdapter, genericAssetCreationService);
+  });
+
+  afterEach(() => {
+    fs.removeSync(vaultRoot);
+  });
+
+  it("inherits ems__Effort_area when parent is ems__Area", async () => {
+    writeAsset(vaultRoot, "areas/Area1.md", {
+      exo__Asset_uid: "area-uid-1",
+      exo__Asset_label: "Area 1",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+    const before = new Set(["Area1"]);
+
+    await service.execute("areas/Area1", { label: "New Project from Area" });
+
+    const createdPath = newCreatedFile(vaultRoot, "areas", before);
+    const fm = readFrontmatter(createdPath);
+
+    expect(fm.exo__Instance_class).toEqual(["[[ems__Project]]"]);
+    expect(fm.exo__Asset_label).toBe("New Project from Area");
+    expect(fm.ems__Effort_area).toBe("[[Area1]]");
+    expect(fm.ems__Effort_parent).toBeUndefined();
+    expect(fm.ems__Effort_status).toBe("[[ems__EffortStatusDraft]]");
+  });
+
+  it("inherits ems__Effort_parent when parent is ems__Project", async () => {
+    writeAsset(vaultRoot, "projects/Project1.md", {
+      exo__Asset_uid: "proj-uid-1",
+      exo__Asset_label: "Project 1",
+      exo__Instance_class: ["[[ems__Project]]"],
+    });
+    const before = new Set(["Project1"]);
+
+    await service.execute("projects/Project1", { label: "Sub Project from Project" });
+
+    const createdPath = newCreatedFile(vaultRoot, "projects", before);
+    const fm = readFrontmatter(createdPath);
+
+    expect(fm.exo__Instance_class).toEqual(["[[ems__Project]]"]);
+    expect(fm.ems__Effort_parent).toBe("[[Project1]]");
+    expect(fm.ems__Effort_area).toBeUndefined();
+  });
+
+  it("inherits ems__Effort_parent when parent is ems__Task", async () => {
+    writeAsset(vaultRoot, "tasks/Task1.md", {
+      exo__Asset_uid: "task-uid-1",
+      exo__Asset_label: "Task 1",
+      exo__Instance_class: ["[[ems__Task]]"],
+    });
+    const before = new Set(["Task1"]);
+
+    await service.execute("tasks/Task1", { label: "Project from Task" });
+
+    const createdPath = newCreatedFile(vaultRoot, "tasks", before);
+    const fm = readFrontmatter(createdPath);
+
+    expect(fm.exo__Instance_class).toEqual(["[[ems__Project]]"]);
+    expect(fm.ems__Effort_parent).toBe("[[Task1]]");
+    expect(fm.ems__Effort_area).toBeUndefined();
+  });
+
+  it("writes explicit parentProperty in addition to auto-detected inheritance", async () => {
+    writeAsset(vaultRoot, "areas/Area2.md", {
+      exo__Asset_uid: "area-uid-2",
+      exo__Asset_label: "Area 2",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+    const before = new Set(["Area2"]);
+
+    await service.execute("areas/Area2", {
+      label: "Custom Project",
+      parentProperty: "ems__Effort_customParent",
+    });
+
+    const createdPath = newCreatedFile(vaultRoot, "areas", before);
+    const fm = readFrontmatter(createdPath);
+
+    expect(fm.ems__Effort_customParent).toBe("[[Area2]]");
+    expect(fm.ems__Effort_area).toBe("[[Area2]]");
+  });
+
+  it("rejects when label is missing", async () => {
+    writeAsset(vaultRoot, "areas/Area3.md", {
+      exo__Asset_uid: "area-uid-3",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+
+    await expect(service.execute("areas/Area3", {})).rejects.toThrow(/label/i);
+  });
+
+  it("rejects when target file does not exist", async () => {
+    await expect(
+      service.execute("areas/DoesNotExist", { label: "x" }),
+    ).rejects.toThrow();
+  });
+
+  it("registry integration: populateCliServiceRegistry with deps registers real createRelatedProject (no throw-stub)", async () => {
+    writeAsset(vaultRoot, "areas/Area4.md", {
+      exo__Asset_uid: "area-uid-4",
+      exo__Asset_label: "Area 4",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+    const before = new Set(["Area4"]);
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+    });
+
+    const registered = registry.get("createRelatedProject");
+    expect(registered).toBeDefined();
+
+    await expect(
+      registered!.execute("areas/Area4", { label: "Registered Project" }),
+    ).resolves.toBeUndefined();
+
+    const createdPath = newCreatedFile(vaultRoot, "areas", before);
+    const fm = readFrontmatter(createdPath);
+    expect(fm.exo__Asset_label).toBe("Registered Project");
+    expect(fm.ems__Effort_area).toBe("[[Area4]]");
+  });
+
+  it("registry integration: createRelatedProject is NOT a CliServiceNotImplementedError stub when deps provided (#2866 regression guard)", async () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+    });
+    const registered = registry.get("createRelatedProject");
+    expect(registered).toBeDefined();
+
+    writeAsset(vaultRoot, "areas/Area5.md", {
+      exo__Asset_uid: "area-uid-5",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+
+    try {
+      await registered!.execute("areas/Area5", { label: "Guard Project" });
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(CliServiceNotImplementedError);
+    }
+  });
+
+  it("registry integration: when deps are NOT provided, createRelatedProject is absent (backwards-compat)", () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry);
+    expect(registry.has("createRelatedProject")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Port the `createRelatedProject` service-handler from the Obsidian plugin
into the CLI, closing the second CLI-parity gap after #2865
(createRelatedTask, v15.106.0).

`dyncommand exec` on a `service_call` grounding bound to
`createRelatedProject` (e.g. the starter-kit `Create Project` command
`3520c214-...` → grounding `8748f8b0-...`) now creates a real
`ems__Project` `.md` file with parent context inherited from the
triggering note — mirroring the plugin UI exactly.

## Scope

- `createCreateRelatedProjectService` factory added to
  `packages/cli/src/services/CliServiceRegistryPopulator.ts`, mirroring
  `createCreateRelatedTaskService` minus Obsidian workspace side-effects
  (no `openFile`, no `setActiveLeaf`).
- Parent-context inheritance is delegated to the shared
  `GenericAssetCreationService.inheritParentContext`, which already
  handles the `ems__Project` branch (lines 189-196) symmetrically with
  `ems__Task` — Area parent → `ems__Effort_area`, Project/Task parent →
  `ems__Effort_parent`.
- `populateCliServiceRegistry` now registers `createRelatedProject` when
  deps are provided; without deps the service remains absent
  (backwards-compat with the `dyncommand validate` flow that only needs
  fail-loud stubs).
- **No changes** to `dynamic-command.ts` — the #2865 deps wiring
  (`vaultAdapter` + `genericAssetCreationService`) already supplies
  everything the new factory needs.
- **No changes** to shared services — `GenericAssetCreationService`
  Project branch has been in place since #2850.

## Tests

9 new unit tests in `packages/cli/tests/unit/services/createRelatedProject.test.ts`
covering:

- Area parent → `ems__Effort_area` inherited, no `ems__Effort_parent`.
- Project parent → `ems__Effort_parent` inherited, no `ems__Effort_area`.
- Task parent → `ems__Effort_parent` (Project under Task treated as
  sibling effort).
- Explicit `parentProperty` override coexists with auto-detection.
- Missing-label rejection (`/label/i`).
- Target-not-found rejection.
- Registry integration with deps: real impl registered, executes end-to-end.
- Regression guard: real impl is NOT a `CliServiceNotImplementedError` stub.
- Backwards-compat: without deps, `registry.has("createRelatedProject") === false`.

Coverage (local full CLI suite, fresh `jest --coverage`):

- `CliServiceRegistryPopulator.ts`: 100% statements / 84.61% branches /
  100% functions / 100% lines.
- All files: 70.86 / 61.31 / 82.58 / 71.19 — all thresholds met
  (65/60/70/65).
- 1276 tests passing, 0 failing.

## Smoke on starter-kit

```bash
node dist/index.js dyncommand exec 3520c214-abe4-4ada-9a2d-04516b957ba2 \
  --target "01 Inbox/723b5de3-...-Area.md" \
  --vault /path/to/exocortex-starter-kit \
  --input '{"label":"Smoke-Area-Project"}' \
  --output json
# → success, created .md with ems__Effort_area: "[[723b5de3-...]]"

node dist/index.js dyncommand exec 3520c214-abe4-4ada-9a2d-04516b957ba2 \
  --target "01 Inbox/00d0631d-...-Project.md" \
  --vault /path/to/exocortex-starter-kit \
  --input '{"label":"Smoke-Project-Project"}' \
  --output json
# → success, created .md with ems__Effort_parent: "[[00d0631d-...]]"
```

Both smoke artifacts cleaned up after verification.

## Test plan

- [x] 9/9 unit tests pass (RED → GREEN via TDD)
- [x] Full CLI suite (1276 tests, 79 suites) passes
- [x] Typecheck green (`npm run check:types`)
- [x] Coverage thresholds met (65/60/70/65)
- [x] Smoke on starter-kit: Area parent → `ems__Effort_area`
- [x] Smoke on starter-kit: Project parent → `ems__Effort_parent`
- [ ] 8 CI checks pass on PR
- [ ] Auto Release publishes new `@kitelev/exocortex-cli` version

Closes #2866