### PR TITLE
feat: archiveAsset service port (closes #2867)

### DIFF
--- a/packages/cli/src/commands/dynamic-command.ts
+++ b/packages/cli/src/commands/dynamic-command.ts
@@ -11,6 +11,7 @@ import {
   ServiceRegistry,
   GroundingType,
   GenericAssetCreationService,
+  ArchiveAssetService,
   type GroundingDefinition,
   type CommandBindingDefinition,
 } from "exocortex";
@@ -333,9 +334,11 @@ export function dynamicCommandCommand(): Command {
         const serviceRegistry = new ServiceRegistry();
         const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
         const genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+        const archiveAssetService = new ArchiveAssetService(vaultAdapter);
         populateCliServiceRegistry(serviceRegistry, {
           vaultAdapter,
           genericAssetCreationService,
+          archiveAssetService,
         });
         const nodeFsAdapter = new NodeFsAdapter(vaultPath);
         const groundingExecutor = new GroundingExecutor(

--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -5,6 +5,7 @@ import {
   type IFile,
   type UserInput,
   GenericAssetCreationService,
+  ArchiveAssetService,
 } from "exocortex";
 
 /**
@@ -65,6 +66,7 @@ function notImplementedService(serviceId: string): IGroundingService {
 export interface CliServiceRegistryDeps {
   vaultAdapter: IVaultAdapter;
   genericAssetCreationService: GenericAssetCreationService;
+  archiveAssetService: ArchiveAssetService;
 }
 
 function resolveTargetFile(vaultAdapter: IVaultAdapter, targetIRI: string): IFile {
@@ -169,6 +171,28 @@ export function createCreateRelatedProjectService(
 }
 
 /**
+ * CLI-side implementation of the `archiveAsset` service (#2867).
+ *
+ * Mirrors the plugin handler in
+ * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
+ * Archive semantic is in-place frontmatter mutation (`archived: true` +
+ * remove `aliases`) delegated to the shared `ArchiveAssetService`. No
+ * file move; batch cross-vault archival remains the domain of the
+ * separate `cli archive` command (`ArchiveService`).
+ */
+export function createArchiveAssetService(
+  vaultAdapter: IVaultAdapter,
+  archiveAssetService: ArchiveAssetService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      await archiveAssetService.archiveAsset(targetFile);
+    },
+  };
+}
+
+/**
  * Populate a ServiceRegistry with fail-loud stubs for all well-known services.
  *
  * Pre-#2864 the stubs resolved silently, so `dyncommand exec` on service_call
@@ -203,6 +227,13 @@ export function populateCliServiceRegistry(
       createCreateRelatedProjectService(
         deps.vaultAdapter,
         deps.genericAssetCreationService,
+      ),
+    );
+    registry.register(
+      "archiveAsset",
+      createArchiveAssetService(
+        deps.vaultAdapter,
+        deps.archiveAssetService,
       ),
     );
   }

--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -55,6 +55,9 @@ jest.unstable_mockModule("exocortex", () => ({
   GenericAssetCreationService: jest.fn(() => ({
     createAsset: jest.fn().mockResolvedValue({ path: "", basename: "", name: "" }),
   })),
+  ArchiveAssetService: jest.fn(() => ({
+    archiveAsset: jest.fn().mockResolvedValue(undefined),
+  })),
   GroundingType: {
     SPARQL_UPDATE: "sparql_update",
     PROPERTY_DELETE: "property_delete",

--- a/packages/cli/tests/unit/services/archiveAsset.test.ts
+++ b/packages/cli/tests/unit/services/archiveAsset.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import yaml from "js-yaml";
+import {
+  ArchiveAssetService,
+  GenericAssetCreationService,
+  ServiceRegistry,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
+import {
+  createArchiveAssetService,
+  populateCliServiceRegistry,
+  CliServiceNotImplementedError,
+} from "../../../src/services/CliServiceRegistryPopulator.js";
+
+type Frontmatter = Record<string, unknown>;
+
+function readFrontmatter(filePath: string): Frontmatter {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter in ${filePath}`);
+  return yaml.load(match[1]) as Frontmatter;
+}
+
+function writeAsset(
+  vaultRoot: string,
+  relPath: string,
+  frontmatter: Frontmatter,
+  body = "",
+): string {
+  const fullPath = path.join(vaultRoot, relPath);
+  fs.ensureDirSync(path.dirname(fullPath));
+  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n${body}`, "utf-8");
+  return fullPath;
+}
+
+describe("archiveAsset (CLI)", () => {
+  let vaultRoot: string;
+  let vaultAdapter: FileSystemVaultAdapter;
+  let archiveAssetService: ArchiveAssetService;
+  let genericAssetCreationService: GenericAssetCreationService;
+  let service: ReturnType<typeof createArchiveAssetService>;
+
+  beforeEach(() => {
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-archiveasset-"));
+    vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
+    archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    service = createArchiveAssetService(vaultAdapter, archiveAssetService);
+  });
+
+  afterEach(() => {
+    fs.removeSync(vaultRoot);
+  });
+
+  it("sets archived: true on a Done task", async () => {
+    writeAsset(vaultRoot, "tasks/DoneTask.md", {
+      exo__Asset_uid: "task-1",
+      exo__Asset_label: "Done Task",
+      ems__Effort_status: "[[ems__EffortStatusDone]]",
+    });
+
+    await service.execute("tasks/DoneTask");
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/DoneTask.md"));
+    expect(fm.archived).toBe(true);
+  });
+
+  it("removes aliases when archiving", async () => {
+    writeAsset(vaultRoot, "tasks/WithAliases.md", {
+      exo__Asset_uid: "task-2",
+      exo__Asset_label: "With Aliases",
+      ems__Effort_status: "[[ems__EffortStatusDone]]",
+      aliases: ["With Aliases", "Alt Name"],
+    });
+
+    await service.execute("tasks/WithAliases");
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/WithAliases.md"));
+    expect(fm.archived).toBe(true);
+    expect(fm.aliases).toBeUndefined();
+  });
+
+  it("is idempotent when already archived", async () => {
+    writeAsset(vaultRoot, "tasks/Already.md", {
+      exo__Asset_uid: "task-3",
+      exo__Asset_label: "Already",
+      archived: true,
+    });
+    const before = fs.readFileSync(
+      path.join(vaultRoot, "tasks/Already.md"),
+      "utf-8",
+    );
+
+    await service.execute("tasks/Already");
+
+    const after = fs.readFileSync(
+      path.join(vaultRoot, "tasks/Already.md"),
+      "utf-8",
+    );
+    expect(after).toBe(before);
+  });
+
+  it("preserves file body content", async () => {
+    writeAsset(
+      vaultRoot,
+      "tasks/WithBody.md",
+      {
+        exo__Asset_uid: "task-4",
+        exo__Asset_label: "With Body",
+      },
+      "## Notes\n- bullet one\n- bullet two\n",
+    );
+
+    await service.execute("tasks/WithBody");
+
+    const content = fs.readFileSync(
+      path.join(vaultRoot, "tasks/WithBody.md"),
+      "utf-8",
+    );
+    expect(content).toContain("## Notes\n- bullet one\n- bullet two\n");
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/WithBody.md"));
+    expect(fm.archived).toBe(true);
+  });
+
+  it("rejects when target file does not exist", async () => {
+    await expect(service.execute("tasks/Missing")).rejects.toThrow();
+  });
+
+  it("registry integration: populateCliServiceRegistry with deps registers real archiveAsset (no throw-stub)", async () => {
+    writeAsset(vaultRoot, "tasks/Registered.md", {
+      exo__Asset_uid: "task-5",
+      exo__Asset_label: "Registered",
+    });
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+    });
+
+    const registered = registry.get("archiveAsset");
+    expect(registered).toBeDefined();
+    await expect(registered!.execute("tasks/Registered")).resolves.toBeUndefined();
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/Registered.md"));
+    expect(fm.archived).toBe(true);
+  });
+
+  it("registry integration: archiveAsset is NOT a CliServiceNotImplementedError stub when deps provided (#2867 regression guard)", async () => {
+    writeAsset(vaultRoot, "tasks/Guard.md", {
+      exo__Asset_uid: "task-6",
+      exo__Asset_label: "Guard",
+    });
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+    });
+    const registered = registry.get("archiveAsset");
+    expect(registered).toBeDefined();
+
+    try {
+      await registered!.execute("tasks/Guard");
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(CliServiceNotImplementedError);
+    }
+  });
+
+  it("registry integration: when deps are NOT provided, archiveAsset is absent (backwards-compat)", () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry);
+    expect(registry.has("archiveAsset")).toBe(false);
+  });
+});

--- a/packages/cli/tests/unit/services/createRelatedProject.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedProject.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import os from "os";
 import yaml from "js-yaml";
 import {
+  ArchiveAssetService,
   GenericAssetCreationService,
   ServiceRegistry,
 } from "exocortex";
@@ -45,12 +46,14 @@ describe("createRelatedProject (CLI)", () => {
   let vaultRoot: string;
   let vaultAdapter: FileSystemVaultAdapter;
   let genericAssetCreationService: GenericAssetCreationService;
+  let archiveAssetService: ArchiveAssetService;
   let service: ReturnType<typeof createCreateRelatedProjectService>;
 
   beforeEach(() => {
     vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-createrelatedproject-"));
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    archiveAssetService = new ArchiveAssetService(vaultAdapter);
     service = createCreateRelatedProjectService(vaultAdapter, genericAssetCreationService);
   });
 
@@ -161,6 +164,7 @@ describe("createRelatedProject (CLI)", () => {
     populateCliServiceRegistry(registry, {
       vaultAdapter,
       genericAssetCreationService,
+      archiveAssetService,
     });
 
     const registered = registry.get("createRelatedProject");
@@ -181,6 +185,7 @@ describe("createRelatedProject (CLI)", () => {
     populateCliServiceRegistry(registry, {
       vaultAdapter,
       genericAssetCreationService,
+      archiveAssetService,
     });
     const registered = registry.get("createRelatedProject");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/createRelatedTask.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedTask.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import os from "os";
 import yaml from "js-yaml";
 import {
+  ArchiveAssetService,
   GenericAssetCreationService,
   ServiceRegistry,
 } from "exocortex";
@@ -45,12 +46,14 @@ describe("createRelatedTask (CLI)", () => {
   let vaultRoot: string;
   let vaultAdapter: FileSystemVaultAdapter;
   let genericAssetCreationService: GenericAssetCreationService;
+  let archiveAssetService: ArchiveAssetService;
   let service: ReturnType<typeof createCreateRelatedTaskService>;
 
   beforeEach(() => {
     vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-createrelatedtask-"));
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    archiveAssetService = new ArchiveAssetService(vaultAdapter);
     service = createCreateRelatedTaskService(vaultAdapter, genericAssetCreationService);
   });
 
@@ -143,6 +146,7 @@ describe("createRelatedTask (CLI)", () => {
     populateCliServiceRegistry(registry, {
       vaultAdapter,
       genericAssetCreationService,
+      archiveAssetService,
     });
 
     const registered = registry.get("createRelatedTask");
@@ -163,6 +167,7 @@ describe("createRelatedTask (CLI)", () => {
     populateCliServiceRegistry(registry, {
       vaultAdapter,
       genericAssetCreationService,
+      archiveAssetService,
     });
     const registered = registry.get("createRelatedTask");
     expect(registered).toBeDefined();

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -137,6 +137,7 @@ export {
   type GenericAssetCreationConfig,
   type AssetPropertyDefinition,
 } from "./services/GenericAssetCreationService";
+export { ArchiveAssetService } from "./services/ArchiveAssetService";
 export type {
   URIConstructionOptions,
   AssetMetadata,

--- a/packages/exocortex/src/services/ArchiveAssetService.ts
+++ b/packages/exocortex/src/services/ArchiveAssetService.ts
@@ -1,0 +1,37 @@
+import { injectable, inject } from "tsyringe";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
+import { FrontmatterService } from "../utilities/FrontmatterService";
+
+/**
+ * Archive an Exocortex asset by marking it `archived: true` (top-level
+ * frontmatter) and removing `aliases`. Idempotent: a second call on an
+ * already-archived asset without aliases is a no-op.
+ *
+ * This is the shared (plugin + CLI) implementation behind the
+ * `archiveAsset` grounding service (Issue #2867). Semantics mirror the
+ * legacy `cli archive` subcommand's `executeArchive`
+ * (StatusCommandExecutor): in-place frontmatter mutation, no physical
+ * file move. Batch cross-vault archival remains the separate domain of
+ * `ArchiveService` / `cli archive`.
+ */
+@injectable()
+export class ArchiveAssetService {
+  private readonly frontmatterService = new FrontmatterService();
+
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
+
+  async archiveAsset(file: IFile): Promise<void> {
+    const content = await this.vault.read(file);
+    let updated = this.frontmatterService.updateProperty(
+      content,
+      "archived",
+      "true",
+    );
+    updated = this.frontmatterService.removeProperty(updated, "aliases");
+    if (updated === content) return;
+    await this.vault.modify(file, updated);
+  }
+}

--- a/packages/exocortex/tests/services/ArchiveAssetService.test.ts
+++ b/packages/exocortex/tests/services/ArchiveAssetService.test.ts
@@ -1,0 +1,129 @@
+import { ArchiveAssetService } from "../../src/services/ArchiveAssetService";
+import { IVaultAdapter, IFile } from "../../src/interfaces/IVaultAdapter";
+
+describe("ArchiveAssetService", () => {
+  let service: ArchiveAssetService;
+  let mockVault: jest.Mocked<IVaultAdapter>;
+  let mockFile: IFile;
+
+  beforeEach(() => {
+    mockVault = {
+      read: jest.fn(),
+      modify: jest.fn(),
+    } as unknown as jest.Mocked<IVaultAdapter>;
+
+    mockFile = {
+      path: "03 Knowledge/kitelev/05dc6377.md",
+      name: "05dc6377.md",
+      basename: "05dc6377",
+    } as IFile;
+
+    service = new ArchiveAssetService(mockVault);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sets archived: true on a Done task without prior archived property", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377
+exo__Asset_label: Done Task
+ems__Effort_status: "[[ems__EffortStatusDone]]"
+---
+
+Body.
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.archiveAsset(mockFile);
+
+    expect(mockVault.modify).toHaveBeenCalledTimes(1);
+    const [, written] = mockVault.modify.mock.calls[0];
+    expect(written).toMatch(/\narchived: true\n/);
+  });
+
+  it("removes aliases property when archiving", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377
+exo__Asset_label: Done Task
+ems__Effort_status: "[[ems__EffortStatusDone]]"
+aliases:
+  - "Done Task"
+  - "Another alias"
+---
+
+Body.
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.archiveAsset(mockFile);
+
+    const [, written] = mockVault.modify.mock.calls[0];
+    expect(written).toMatch(/\narchived: true\n/);
+    expect(written).not.toMatch(/\naliases:/);
+    expect(written).not.toMatch(/- "Done Task"/);
+  });
+
+  it("is a no-op when asset is already archived with no aliases (idempotent)", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377
+exo__Asset_label: Done Task
+archived: true
+---
+
+Body.
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.archiveAsset(mockFile);
+
+    expect(mockVault.modify).not.toHaveBeenCalled();
+  });
+
+  it("still removes aliases when archived is already true (partial state)", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377
+exo__Asset_label: Done Task
+archived: true
+aliases:
+  - "Stale alias"
+---
+
+Body.
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.archiveAsset(mockFile);
+
+    expect(mockVault.modify).toHaveBeenCalledTimes(1);
+    const [, written] = mockVault.modify.mock.calls[0];
+    expect(written).toMatch(/\narchived: true\n/);
+    expect(written).not.toMatch(/\naliases:/);
+  });
+
+  it("preserves body content unchanged", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377
+exo__Asset_label: Done Task
+---
+
+## Algorithm
+- [x] step one
+- [x] step two
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.archiveAsset(mockFile);
+
+    const [, written] = mockVault.modify.mock.calls[0];
+    expect(written).toMatch(/## Algorithm\n- \[x\] step one\n- \[x\] step two\n/);
+  });
+
+  it("propagates read errors", async () => {
+    mockVault.read.mockRejectedValue(new Error("File not found"));
+
+    await expect(service.archiveAsset(mockFile)).rejects.toThrow("File not found");
+    expect(mockVault.modify).not.toHaveBeenCalled();
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -8,6 +8,7 @@ import {
   EffortStatusWorkflow,
   StatusTimestampService,
   GenericAssetCreationService,
+  ArchiveAssetService,
   DateFormatter,
   type IGroundingService,
   type UserInput,
@@ -281,6 +282,7 @@ export function populateServiceRegistry(
     const effortVotingService = new EffortVotingService(vaultAdapter);
     const labelToAliasService = new LabelToAliasService(vaultAdapter);
     const genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    const archiveAssetService = new ArchiveAssetService(vaultAdapter);
 
     registry.register(
       "rollbackStatus",
@@ -432,6 +434,14 @@ export function populateServiceRegistry(
         const leaf = app.workspace.getLeaf("tab");
         await leaf.openFile(tfile);
         app.workspace.setActiveLeaf(leaf, { focus: true });
+      }),
+    );
+
+    registry.register(
+      "archiveAsset",
+      wrapService(async (targetIRI: string) => {
+        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
+        await archiveAssetService.archiveAsset(iFile);
       }),
     );
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -124,6 +124,7 @@ describe("ServiceRegistryPopulator", () => {
       "copyLabelToAliases",
       "createRelatedTask",
       "createRelatedProject",
+      "archiveAsset",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -449,6 +450,7 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       "copyLabelToAliases",
       "createRelatedTask",
       "createRelatedProject",
+      "archiveAsset",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -694,6 +696,58 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       const service = registry.get("createRelatedProject")!;
       await expect(service.execute("test-uid-123", {})).rejects.toThrow(
         "createRelatedProject requires userInput.label",
+      );
+    });
+  });
+
+  describe("archiveAsset", () => {
+    beforeEach(() => {
+      (deps.vaultAdapter!.read as jest.Mock).mockResolvedValue(
+        "---\nexo__Asset_uid: test-uid-123\nexo__Asset_label: Done Task\nems__Effort_status: \"[[ems__EffortStatusDone]]\"\n---\nBody",
+      );
+    });
+
+    it("should set archived: true on target asset", async () => {
+      const service = registry.get("archiveAsset")!;
+      await service.execute("test-uid-123");
+
+      expect(deps.vaultAdapter!.read).toHaveBeenCalledWith(mockIFile);
+      expect(deps.vaultAdapter!.modify).toHaveBeenCalledWith(
+        mockIFile,
+        expect.stringMatching(/\narchived: true\n/),
+      );
+    });
+
+    it("should remove aliases when archiving", async () => {
+      (deps.vaultAdapter!.read as jest.Mock).mockResolvedValue(
+        "---\nexo__Asset_uid: test-uid-123\nexo__Asset_label: Done Task\naliases:\n  - \"Done Task\"\n---\nBody",
+      );
+      const service = registry.get("archiveAsset")!;
+      await service.execute("test-uid-123");
+
+      const modifyCall = (deps.vaultAdapter!.modify as jest.Mock).mock.calls[0];
+      const written = modifyCall[1] as string;
+      expect(written).toMatch(/\narchived: true\n/);
+      expect(written).not.toMatch(/\naliases:/);
+    });
+
+    it("should be a no-op when asset is already archived with no aliases", async () => {
+      (deps.vaultAdapter!.read as jest.Mock).mockResolvedValue(
+        "---\nexo__Asset_uid: test-uid-123\narchived: true\n---\nBody",
+      );
+      const service = registry.get("archiveAsset")!;
+      await service.execute("test-uid-123");
+
+      expect(deps.vaultAdapter!.modify).not.toHaveBeenCalled();
+    });
+
+    it("should throw when target IRI cannot be resolved", async () => {
+      (deps.app.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: { exo__Asset_uid: "different-uid" },
+      });
+      const service = registry.get("archiveAsset")!;
+      await expect(service.execute("nonexistent-iri")).rejects.toThrow(
+        "No file found for IRI",
       );
     });
   });


### PR DESCRIPTION
## Summary

- Close the **archiveAsset** CLI-parity gap (#2867) and the plugin-side dead-ref reported alongside it. Before this change, the starter-kit "Archive Completed" button was a silent no-op: the grounding (`eb3bb751`) referenced `serviceId: archiveAsset`, but that service was never registered in either `ServiceRegistryPopulator` (plugin) or `CliServiceRegistryPopulator` (CLI).
- New shared `ArchiveAssetService` in `packages/exocortex/src/services/`, DI via `IVaultAdapter`. Registered by plugin + CLI via a single codepath. Follows the #2865/#2866 pattern.

## Semantic choice — Option A (in-place mark)

Archive = **set top-level `archived: true` + remove `aliases`**. No physical file move. Idempotent.

| Signal | Evidence |
| --- | --- |
| Vault convention | 3418 assets in `vault-2025` use top-level `archived: true`, zero `archive/` folders |
| Reference impl | `StatusCommandExecutor.executeArchive` (legacy `cli archive-asset` subcommand) does exactly this |
| Docs-rot caveat | Grounding + command-binding body text in starter-kit say "moves to archive folder AND marks archived" — mark-only has always been the actual behavior; body text is aspirational, not spec |
| Separate concern | Cross-vault batch file-move remains the domain of `ArchiveService` / `cli archive` (unchanged) |

Follow-up (separate issue, not scope here): update starter-kit body text of the `Archive Completed` command and `Archive asset via service` grounding to say "marks archived" instead of "moves to archive folder".

## Changes

| Layer | File | Change |
| --- | --- | --- |
| Shared | `packages/exocortex/src/services/ArchiveAssetService.ts` | **new** — IVaultAdapter DI, `archiveAsset(file)` |
| Shared | `packages/exocortex/src/index.ts` | export `ArchiveAssetService` |
| Plugin | `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts` | instantiate + register `archiveAsset` handler when `vaultAdapter` provided |
| CLI | `packages/cli/src/services/CliServiceRegistryPopulator.ts` | `createArchiveAssetService` factory + required `deps.archiveAssetService` (matches #2865/#2866 shape) |
| CLI | `packages/cli/src/commands/dynamic-command.ts` | instantiate `ArchiveAssetService` in `dyncommand exec` wiring |

## Tests (TDD Step 1 → Step 2, outcome-based)

- `packages/exocortex/tests/services/ArchiveAssetService.test.ts` — 6 new unit tests (mock IVaultAdapter): happy path, aliases removal, idempotency (archived+no-aliases → no-op), partial-state cleanup (archived+aliases → still writes), body preservation, read-error propagation.
- `packages/cli/tests/unit/services/archiveAsset.test.ts` — 8 new integration tests (tmp-dir + real `FileSystemVaultAdapter`): frontmatter mutation end-to-end, idempotency, target-missing rejection, registry integration (#2867 regression guard), backwards-compat path without deps.
- `packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts` — +4 plugin-side tests (registration, semantic parity with CLI).
- Dep-shape updates to `createRelatedTask.test.ts` / `createRelatedProject.test.ts` / `dynamic-command.test.ts` mock.

### Coverage (CLI)

- **All files**: Stmts 70.94 / Branches 61.38 / Funcs 82.79 / Lines 71.27 — above thresholds (65/60/70/65).
- `CliServiceRegistryPopulator.ts`: Stmts 100 / Branches 85.71 / Funcs 100 / Lines 100.

## Local smoke

- **CLI** (`dyncommand exec` via tmp starter-kit vault + minimal no-precondition command → archiveAsset grounding):
  ```json
  {"success": true, "data": {"command": "Smoke Archive (No Precondition)", "preconditionPassed": true, "executed": true, "success": true}}
  ```
  Target file mutated: `archived: true` added, `aliases` removed. Exit 0.
- **Plugin smoke via `Archive Completed`** command end-to-end is blocked by the orthogonal CLI SPARQL status-IRI divergence (file IRI vs ns URI, per `reference_cli_status_iri_vault_divergence` — known and out-of-scope here). Unit + integration tests cover the handler path; plugin UI click-through to be manually verified post-merge on real vault.

## Test plan

- [ ] CI: 8 mandatory checks (build, typecheck, test-unit, test-coverage, test-bdd, archgate, e2e-tests, test-component) all green
- [ ] Auto Release publishes new CLI + plugin version to npm
- [ ] Manual: in `vault-2025` / `exocortex-starter-kit`, open a Done-status `ems__Task`, click "Archive Completed" → file frontmatter has `archived: true` and no `aliases` block
- [ ] Manual: click "Archive Completed" a second time — file unchanged (idempotent)

Closes #2867