### PR TITLE
feat(cli): port planForEvening service (closes #2868)

### DIFF
--- a/packages/cli/src/commands/dynamic-command.ts
+++ b/packages/cli/src/commands/dynamic-command.ts
@@ -12,6 +12,9 @@ import {
   GroundingType,
   GenericAssetCreationService,
   ArchiveAssetService,
+  EffortStatusWorkflow,
+  StatusTimestampService,
+  TaskStatusService,
   type GroundingDefinition,
   type CommandBindingDefinition,
 } from "exocortex";
@@ -335,10 +338,16 @@ export function dynamicCommandCommand(): Command {
         const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
         const genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
         const archiveAssetService = new ArchiveAssetService(vaultAdapter);
+        const taskStatusService = new TaskStatusService(
+          vaultAdapter,
+          new EffortStatusWorkflow(),
+          new StatusTimestampService(vaultAdapter),
+        );
         populateCliServiceRegistry(serviceRegistry, {
           vaultAdapter,
           genericAssetCreationService,
           archiveAssetService,
+          taskStatusService,
         });
         const nodeFsAdapter = new NodeFsAdapter(vaultPath);
         const groundingExecutor = new GroundingExecutor(

--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -6,6 +6,7 @@ import {
   type UserInput,
   GenericAssetCreationService,
   ArchiveAssetService,
+  TaskStatusService,
 } from "exocortex";
 
 /**
@@ -67,6 +68,7 @@ export interface CliServiceRegistryDeps {
   vaultAdapter: IVaultAdapter;
   genericAssetCreationService: GenericAssetCreationService;
   archiveAssetService: ArchiveAssetService;
+  taskStatusService: TaskStatusService;
 }
 
 function resolveTargetFile(vaultAdapter: IVaultAdapter, targetIRI: string): IFile {
@@ -193,6 +195,27 @@ export function createArchiveAssetService(
 }
 
 /**
+ * CLI-side implementation of the `planForEvening` service (#2868).
+ *
+ * Mirrors the plugin handler in
+ * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
+ * Sets `ems__Effort_plannedStartTimestamp` to today at 19:00:00 local time
+ * (no ms, no tz) via the shared `TaskStatusService.planForEvening`, which
+ * is already storage-agnostic via `IVaultAdapter`.
+ */
+export function createPlanForEveningService(
+  vaultAdapter: IVaultAdapter,
+  taskStatusService: TaskStatusService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      await taskStatusService.planForEvening(targetFile);
+    },
+  };
+}
+
+/**
  * Populate a ServiceRegistry with fail-loud stubs for all well-known services.
  *
  * Pre-#2864 the stubs resolved silently, so `dyncommand exec` on service_call
@@ -234,6 +257,13 @@ export function populateCliServiceRegistry(
       createArchiveAssetService(
         deps.vaultAdapter,
         deps.archiveAssetService,
+      ),
+    );
+    registry.register(
+      "planForEvening",
+      createPlanForEveningService(
+        deps.vaultAdapter,
+        deps.taskStatusService,
       ),
     );
   }

--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -58,6 +58,11 @@ jest.unstable_mockModule("exocortex", () => ({
   ArchiveAssetService: jest.fn(() => ({
     archiveAsset: jest.fn().mockResolvedValue(undefined),
   })),
+  TaskStatusService: jest.fn(() => ({
+    planForEvening: jest.fn().mockResolvedValue(undefined),
+  })),
+  EffortStatusWorkflow: jest.fn(() => ({})),
+  StatusTimestampService: jest.fn(() => ({})),
   GroundingType: {
     SPARQL_UPDATE: "sparql_update",
     PROPERTY_DELETE: "property_delete",

--- a/packages/cli/tests/unit/services/archiveAsset.test.ts
+++ b/packages/cli/tests/unit/services/archiveAsset.test.ts
@@ -5,8 +5,11 @@ import os from "os";
 import yaml from "js-yaml";
 import {
   ArchiveAssetService,
+  EffortStatusWorkflow,
   GenericAssetCreationService,
   ServiceRegistry,
+  StatusTimestampService,
+  TaskStatusService,
 } from "exocortex";
 import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
 import {
@@ -42,6 +45,7 @@ describe("archiveAsset (CLI)", () => {
   let vaultAdapter: FileSystemVaultAdapter;
   let archiveAssetService: ArchiveAssetService;
   let genericAssetCreationService: GenericAssetCreationService;
+  let taskStatusService: TaskStatusService;
   let service: ReturnType<typeof createArchiveAssetService>;
 
   beforeEach(() => {
@@ -49,6 +53,11 @@ describe("archiveAsset (CLI)", () => {
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    taskStatusService = new TaskStatusService(
+      vaultAdapter,
+      new EffortStatusWorkflow(),
+      new StatusTimestampService(vaultAdapter),
+    );
     service = createArchiveAssetService(vaultAdapter, archiveAssetService);
   });
 
@@ -141,6 +150,7 @@ describe("archiveAsset (CLI)", () => {
       vaultAdapter,
       genericAssetCreationService,
       archiveAssetService,
+      taskStatusService,
     });
 
     const registered = registry.get("archiveAsset");
@@ -162,6 +172,7 @@ describe("archiveAsset (CLI)", () => {
       vaultAdapter,
       genericAssetCreationService,
       archiveAssetService,
+      taskStatusService,
     });
     const registered = registry.get("archiveAsset");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/createRelatedProject.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedProject.test.ts
@@ -5,8 +5,11 @@ import os from "os";
 import yaml from "js-yaml";
 import {
   ArchiveAssetService,
+  EffortStatusWorkflow,
   GenericAssetCreationService,
   ServiceRegistry,
+  StatusTimestampService,
+  TaskStatusService,
 } from "exocortex";
 import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
 import {
@@ -47,6 +50,7 @@ describe("createRelatedProject (CLI)", () => {
   let vaultAdapter: FileSystemVaultAdapter;
   let genericAssetCreationService: GenericAssetCreationService;
   let archiveAssetService: ArchiveAssetService;
+  let taskStatusService: TaskStatusService;
   let service: ReturnType<typeof createCreateRelatedProjectService>;
 
   beforeEach(() => {
@@ -54,6 +58,11 @@ describe("createRelatedProject (CLI)", () => {
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    taskStatusService = new TaskStatusService(
+      vaultAdapter,
+      new EffortStatusWorkflow(),
+      new StatusTimestampService(vaultAdapter),
+    );
     service = createCreateRelatedProjectService(vaultAdapter, genericAssetCreationService);
   });
 
@@ -165,6 +174,7 @@ describe("createRelatedProject (CLI)", () => {
       vaultAdapter,
       genericAssetCreationService,
       archiveAssetService,
+      taskStatusService,
     });
 
     const registered = registry.get("createRelatedProject");
@@ -186,6 +196,7 @@ describe("createRelatedProject (CLI)", () => {
       vaultAdapter,
       genericAssetCreationService,
       archiveAssetService,
+      taskStatusService,
     });
     const registered = registry.get("createRelatedProject");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/createRelatedTask.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedTask.test.ts
@@ -5,8 +5,11 @@ import os from "os";
 import yaml from "js-yaml";
 import {
   ArchiveAssetService,
+  EffortStatusWorkflow,
   GenericAssetCreationService,
   ServiceRegistry,
+  StatusTimestampService,
+  TaskStatusService,
 } from "exocortex";
 import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
 import {
@@ -47,6 +50,7 @@ describe("createRelatedTask (CLI)", () => {
   let vaultAdapter: FileSystemVaultAdapter;
   let genericAssetCreationService: GenericAssetCreationService;
   let archiveAssetService: ArchiveAssetService;
+  let taskStatusService: TaskStatusService;
   let service: ReturnType<typeof createCreateRelatedTaskService>;
 
   beforeEach(() => {
@@ -54,6 +58,11 @@ describe("createRelatedTask (CLI)", () => {
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    taskStatusService = new TaskStatusService(
+      vaultAdapter,
+      new EffortStatusWorkflow(),
+      new StatusTimestampService(vaultAdapter),
+    );
     service = createCreateRelatedTaskService(vaultAdapter, genericAssetCreationService);
   });
 
@@ -147,6 +156,7 @@ describe("createRelatedTask (CLI)", () => {
       vaultAdapter,
       genericAssetCreationService,
       archiveAssetService,
+      taskStatusService,
     });
 
     const registered = registry.get("createRelatedTask");
@@ -168,6 +178,7 @@ describe("createRelatedTask (CLI)", () => {
       vaultAdapter,
       genericAssetCreationService,
       archiveAssetService,
+      taskStatusService,
     });
     const registered = registry.get("createRelatedTask");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/planForEvening.test.ts
+++ b/packages/cli/tests/unit/services/planForEvening.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import yaml from "js-yaml";
+import {
+  ArchiveAssetService,
+  EffortStatusWorkflow,
+  GenericAssetCreationService,
+  ServiceRegistry,
+  StatusTimestampService,
+  TaskStatusService,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
+import {
+  createPlanForEveningService,
+  populateCliServiceRegistry,
+  CliServiceNotImplementedError,
+} from "../../../src/services/CliServiceRegistryPopulator.js";
+
+type Frontmatter = Record<string, unknown>;
+
+function readFrontmatter(filePath: string): Frontmatter {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter in ${filePath}`);
+  return yaml.load(match[1]) as Frontmatter;
+}
+
+/**
+ * Returns the raw YAML string value for a frontmatter key — bypasses
+ * js-yaml's implicit timestamp coercion so assertions can verify the
+ * exact on-disk format (`YYYY-MM-DDTHH:MM:SS` with no ms/tz).
+ */
+function readRawProperty(filePath: string, key: string): string | null {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return null;
+  const lineRe = new RegExp(`^${key}:\\s*(.*)$`, "m");
+  const line = fmMatch[1].match(lineRe);
+  if (!line) return null;
+  return line[1].trim();
+}
+
+function writeAsset(
+  vaultRoot: string,
+  relPath: string,
+  frontmatter: Frontmatter,
+  body = "",
+): string {
+  const fullPath = path.join(vaultRoot, relPath);
+  fs.ensureDirSync(path.dirname(fullPath));
+  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n${body}`, "utf-8");
+  return fullPath;
+}
+
+function todayYYYYMMDD(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+describe("planForEvening (CLI)", () => {
+  let vaultRoot: string;
+  let vaultAdapter: FileSystemVaultAdapter;
+  let archiveAssetService: ArchiveAssetService;
+  let genericAssetCreationService: GenericAssetCreationService;
+  let workflow: EffortStatusWorkflow;
+  let timestampService: StatusTimestampService;
+  let taskStatusService: TaskStatusService;
+  let service: ReturnType<typeof createPlanForEveningService>;
+
+  beforeEach(() => {
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-planforevening-"));
+    vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
+    archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    workflow = new EffortStatusWorkflow();
+    timestampService = new StatusTimestampService(vaultAdapter);
+    taskStatusService = new TaskStatusService(
+      vaultAdapter,
+      workflow,
+      timestampService,
+    );
+    service = createPlanForEveningService(vaultAdapter, taskStatusService);
+  });
+
+  afterEach(() => {
+    fs.removeSync(vaultRoot);
+  });
+
+  it("sets ems__Effort_plannedStartTimestamp to <TODAY>T19:00:00 on a Backlog task", async () => {
+    writeAsset(vaultRoot, "tasks/Backlog.md", {
+      exo__Asset_uid: "task-1",
+      exo__Asset_label: "Backlog Task",
+      ems__Effort_status: "[[ems__EffortStatusBacklog]]",
+    });
+
+    await service.execute("tasks/Backlog");
+
+    const raw = readRawProperty(
+      path.join(vaultRoot, "tasks/Backlog.md"),
+      "ems__Effort_plannedStartTimestamp",
+    );
+    expect(raw).toBe(`${todayYYYYMMDD()}T19:00:00`);
+  });
+
+  it("timestamp matches /^\\d{4}-\\d{2}-\\d{2}T19:00:00$/ format (no ms, no Z, no tz)", async () => {
+    writeAsset(vaultRoot, "tasks/FormatCheck.md", {
+      exo__Asset_uid: "task-2",
+      exo__Asset_label: "Format Check",
+    });
+
+    await service.execute("tasks/FormatCheck");
+
+    const raw = readRawProperty(
+      path.join(vaultRoot, "tasks/FormatCheck.md"),
+      "ems__Effort_plannedStartTimestamp",
+    );
+    expect(raw).toMatch(/^\d{4}-\d{2}-\d{2}T19:00:00$/);
+  });
+
+  it("preserves unrelated frontmatter keys", async () => {
+    writeAsset(vaultRoot, "tasks/Preserve.md", {
+      exo__Asset_uid: "task-3",
+      exo__Asset_label: "Preserve Me",
+      exo__Instance_class: ["[[ems__Task]]"],
+      ems__Effort_status: "[[ems__EffortStatusBacklog]]",
+      aliases: ["PM"],
+    });
+
+    await service.execute("tasks/Preserve");
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/Preserve.md"));
+    expect(fm.exo__Asset_uid).toBe("task-3");
+    expect(fm.exo__Asset_label).toBe("Preserve Me");
+    expect(fm.exo__Instance_class).toEqual(["[[ems__Task]]"]);
+    expect(fm.ems__Effort_status).toBe("[[ems__EffortStatusBacklog]]");
+    expect(fm.aliases).toEqual(["PM"]);
+  });
+
+  it("overwrites existing plannedStartTimestamp with new 19:00 value", async () => {
+    writeAsset(vaultRoot, "tasks/Overwrite.md", {
+      exo__Asset_uid: "task-4",
+      exo__Asset_label: "Overwrite",
+      ems__Effort_plannedStartTimestamp: "2025-01-01T08:00:00",
+    });
+
+    await service.execute("tasks/Overwrite");
+
+    const raw = readRawProperty(
+      path.join(vaultRoot, "tasks/Overwrite.md"),
+      "ems__Effort_plannedStartTimestamp",
+    );
+    expect(raw).toMatch(/^\d{4}-\d{2}-\d{2}T19:00:00$/);
+    expect(raw).not.toBe("2025-01-01T08:00:00");
+  });
+
+  it("preserves file body content", async () => {
+    writeAsset(
+      vaultRoot,
+      "tasks/WithBody.md",
+      {
+        exo__Asset_uid: "task-5",
+        exo__Asset_label: "With Body",
+      },
+      "## Notes\n- alpha\n- beta\n",
+    );
+
+    await service.execute("tasks/WithBody");
+
+    const content = fs.readFileSync(
+      path.join(vaultRoot, "tasks/WithBody.md"),
+      "utf-8",
+    );
+    expect(content).toContain("## Notes\n- alpha\n- beta\n");
+  });
+
+  it("rejects when target file does not exist", async () => {
+    await expect(service.execute("tasks/Missing")).rejects.toThrow();
+  });
+
+  it("registry integration: populateCliServiceRegistry with deps registers real planForEvening (no throw-stub)", async () => {
+    writeAsset(vaultRoot, "tasks/Registered.md", {
+      exo__Asset_uid: "task-6",
+      exo__Asset_label: "Registered",
+    });
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+      taskStatusService,
+    });
+
+    const registered = registry.get("planForEvening");
+    expect(registered).toBeDefined();
+    await expect(registered!.execute("tasks/Registered")).resolves.toBeUndefined();
+
+    const raw = readRawProperty(
+      path.join(vaultRoot, "tasks/Registered.md"),
+      "ems__Effort_plannedStartTimestamp",
+    );
+    expect(raw).toMatch(/^\d{4}-\d{2}-\d{2}T19:00:00$/);
+  });
+
+  it("registry integration: planForEvening is NOT a CliServiceNotImplementedError stub when deps provided (#2868 regression guard)", async () => {
+    writeAsset(vaultRoot, "tasks/Guard.md", {
+      exo__Asset_uid: "task-7",
+      exo__Asset_label: "Guard",
+    });
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+      taskStatusService,
+    });
+    const registered = registry.get("planForEvening");
+    expect(registered).toBeDefined();
+
+    try {
+      await registered!.execute("tasks/Guard");
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(CliServiceNotImplementedError);
+    }
+  });
+
+  it("registry integration: when deps are NOT provided, planForEvening is absent (backwards-compat)", () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry);
+    expect(registry.has("planForEvening")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2868 — port the `planForEvening` service to the CLI so that the starter-kit **"Plan for Evening (19:00)"** command actually schedules tasks when invoked via `npx @kitelev/exocortex-cli dyncommand exec` instead of failing with the fail-loud `CliServiceNotImplementedError` stub from #2864.

- **No new shared service.** `TaskStatusService.planForEvening` is already storage-agnostic via `IVaultAdapter`; this PR just wires it through on the CLI side.
- CLI: `createPlanForEveningService` factory + required `taskStatusService` dep in `CliServiceRegistryPopulator`, plus `dynamic-command.ts` exec action instantiates `EffortStatusWorkflow` + `StatusTimestampService` + `TaskStatusService` and passes them through.
- Plugin: no change (already wired at `ServiceRegistryPopulator.ts:302-307`).

Follows the same shape as #2865 / #2866 / #2877.

## Semantic

Writes `ems__Effort_plannedStartTimestamp: <TODAY>T19:00:00` to frontmatter via `DateFormatter.toLocalTimestamp(<Date with 19:00:00 local>)` — no ms, no `Z`, no tz offset, matching the rest of the vault's timestamp convention.

## Test plan

- [x] 9 new tests in `packages/cli/tests/unit/services/planForEvening.test.ts` (integration against tmp-dir `FileSystemVaultAdapter`):
  - Happy path on backlog task
  - Timestamp matches `/^\d{4}-\d{2}-\d{2}T19:00:00$/`
  - Preserves unrelated frontmatter keys
  - Overwrites existing `plannedStartTimestamp`
  - Preserves file body
  - Rejects missing target
  - Registry integration (`populateCliServiceRegistry` with deps)
  - #2868 regression guard (handler is NOT a `CliServiceNotImplementedError` stub)
  - Backwards-compat (no deps → handler absent)
- [x] `createRelatedTask` / `createRelatedProject` / `archiveAsset` / `dynamic-command` test suites updated to pass the new required `taskStatusService` dep.
- [x] `npm run check:types` — clean.
- [x] CLI coverage: **70.95 / 61.35 / 82.85 / 71.27** vs CLI floor 65/60/70/65.
- [x] Local smoke against a tmp starter-kit vault: `dyncommand exec f3c916ab-... --target "01 Inbox/BacklogTask.md" --output json` returns `{success:true, message:"Scheduled for evening"}`, exit 0, and frontmatter now contains `ems__Effort_plannedStartTimestamp: 2026-04-19T19:00:00`.

## Out of scope

Related `TaskStatusService` methods (`planOnToday`, `rollbackStatus`, `shiftDay`) are intentionally not bundled in this PR — surgical parity pattern from #2865 / #2866 / #2867. File follow-up issues if the CLI-UI parity audit flags them.