### PR TITLE
feat: cleanProperties service (plugin + CLI) (closes #2869)

### DIFF
--- a/packages/cli/src/commands/dynamic-command.ts
+++ b/packages/cli/src/commands/dynamic-command.ts
@@ -12,6 +12,7 @@ import {
   GroundingType,
   GenericAssetCreationService,
   ArchiveAssetService,
+  PropertyCleanupService,
   EffortStatusWorkflow,
   StatusTimestampService,
   TaskStatusService,
@@ -338,6 +339,7 @@ export function dynamicCommandCommand(): Command {
         const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
         const genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
         const archiveAssetService = new ArchiveAssetService(vaultAdapter);
+        const propertyCleanupService = new PropertyCleanupService(vaultAdapter);
         const taskStatusService = new TaskStatusService(
           vaultAdapter,
           new EffortStatusWorkflow(),
@@ -348,6 +350,7 @@ export function dynamicCommandCommand(): Command {
           genericAssetCreationService,
           archiveAssetService,
           taskStatusService,
+          propertyCleanupService,
         });
         const nodeFsAdapter = new NodeFsAdapter(vaultPath);
         const groundingExecutor = new GroundingExecutor(

--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -6,6 +6,7 @@ import {
   type UserInput,
   GenericAssetCreationService,
   ArchiveAssetService,
+  PropertyCleanupService,
   TaskStatusService,
 } from "exocortex";
 
@@ -69,6 +70,7 @@ export interface CliServiceRegistryDeps {
   genericAssetCreationService: GenericAssetCreationService;
   archiveAssetService: ArchiveAssetService;
   taskStatusService: TaskStatusService;
+  propertyCleanupService: PropertyCleanupService;
 }
 
 function resolveTargetFile(vaultAdapter: IVaultAdapter, targetIRI: string): IFile {
@@ -195,6 +197,28 @@ export function createArchiveAssetService(
 }
 
 /**
+ * CLI-side implementation of the `cleanProperties` service (#2869).
+ *
+ * Mirrors the plugin handler in
+ * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
+ * Delegates to the shared `PropertyCleanupService` which strips frontmatter
+ * entries whose values are empty (`""`, `null`, `undefined`, `[]`, `{}`).
+ * Storage-agnostic via `IVaultAdapter`, so the plugin and CLI paths stay
+ * byte-identical for the same input.
+ */
+export function createCleanPropertiesService(
+  vaultAdapter: IVaultAdapter,
+  propertyCleanupService: PropertyCleanupService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      await propertyCleanupService.cleanEmptyProperties(targetFile);
+    },
+  };
+}
+
+/**
  * CLI-side implementation of the `planForEvening` service (#2868).
  *
  * Mirrors the plugin handler in
@@ -264,6 +288,13 @@ export function populateCliServiceRegistry(
       createPlanForEveningService(
         deps.vaultAdapter,
         deps.taskStatusService,
+      ),
+    );
+    registry.register(
+      "cleanProperties",
+      createCleanPropertiesService(
+        deps.vaultAdapter,
+        deps.propertyCleanupService,
       ),
     );
   }

--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -58,6 +58,9 @@ jest.unstable_mockModule("exocortex", () => ({
   ArchiveAssetService: jest.fn(() => ({
     archiveAsset: jest.fn().mockResolvedValue(undefined),
   })),
+  PropertyCleanupService: jest.fn(() => ({
+    cleanEmptyProperties: jest.fn().mockResolvedValue(undefined),
+  })),
   TaskStatusService: jest.fn(() => ({
     planForEvening: jest.fn().mockResolvedValue(undefined),
   })),

--- a/packages/cli/tests/unit/services/archiveAsset.test.ts
+++ b/packages/cli/tests/unit/services/archiveAsset.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   GenericAssetCreationService,
+  PropertyCleanupService,
   ServiceRegistry,
   StatusTimestampService,
   TaskStatusService,
@@ -45,6 +46,7 @@ describe("archiveAsset (CLI)", () => {
   let vaultAdapter: FileSystemVaultAdapter;
   let archiveAssetService: ArchiveAssetService;
   let genericAssetCreationService: GenericAssetCreationService;
+  let propertyCleanupService: PropertyCleanupService;
   let taskStatusService: TaskStatusService;
   let service: ReturnType<typeof createArchiveAssetService>;
 
@@ -53,6 +55,7 @@ describe("archiveAsset (CLI)", () => {
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -151,6 +154,7 @@ describe("archiveAsset (CLI)", () => {
       genericAssetCreationService,
       archiveAssetService,
       taskStatusService,
+      propertyCleanupService,
     });
 
     const registered = registry.get("archiveAsset");
@@ -173,6 +177,7 @@ describe("archiveAsset (CLI)", () => {
       genericAssetCreationService,
       archiveAssetService,
       taskStatusService,
+      propertyCleanupService,
     });
     const registered = registry.get("archiveAsset");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/cleanProperties.test.ts
+++ b/packages/cli/tests/unit/services/cleanProperties.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import yaml from "js-yaml";
+import {
+  ArchiveAssetService,
+  EffortStatusWorkflow,
+  GenericAssetCreationService,
+  PropertyCleanupService,
+  ServiceRegistry,
+  StatusTimestampService,
+  TaskStatusService,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
+import {
+  createCleanPropertiesService,
+  populateCliServiceRegistry,
+  CliServiceNotImplementedError,
+} from "../../../src/services/CliServiceRegistryPopulator.js";
+
+type Frontmatter = Record<string, unknown>;
+
+function readFrontmatter(filePath: string): Frontmatter {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter in ${filePath}`);
+  return yaml.load(match[1]) as Frontmatter;
+}
+
+function writeRaw(vaultRoot: string, relPath: string, content: string): string {
+  const fullPath = path.join(vaultRoot, relPath);
+  fs.ensureDirSync(path.dirname(fullPath));
+  fs.writeFileSync(fullPath, content, "utf-8");
+  return fullPath;
+}
+
+describe("cleanProperties (CLI)", () => {
+  let vaultRoot: string;
+  let vaultAdapter: FileSystemVaultAdapter;
+  let propertyCleanupService: PropertyCleanupService;
+  let archiveAssetService: ArchiveAssetService;
+  let genericAssetCreationService: GenericAssetCreationService;
+  let taskStatusService: TaskStatusService;
+  let service: ReturnType<typeof createCleanPropertiesService>;
+
+  beforeEach(() => {
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-cleanproperties-"));
+    vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
+    propertyCleanupService = new PropertyCleanupService(vaultAdapter);
+    archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    taskStatusService = new TaskStatusService(
+      vaultAdapter,
+      new EffortStatusWorkflow(),
+      new StatusTimestampService(vaultAdapter),
+    );
+    service = createCleanPropertiesService(vaultAdapter, propertyCleanupService);
+  });
+
+  afterEach(() => {
+    fs.removeSync(vaultRoot);
+  });
+
+  it('removes empty string properties ("")', async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Empty.md",
+      '---\nexo__Asset_uid: task-1\nexo__Asset_label: "With Empty"\nems__Effort_plannedStartTimestamp: ""\n---\nBody\n',
+    );
+
+    await service.execute("tasks/Empty");
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/Empty.md"));
+    expect(fm.exo__Asset_uid).toBe("task-1");
+    expect(fm.ems__Effort_plannedStartTimestamp).toBeUndefined();
+  });
+
+  it("removes null-valued properties", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Null.md",
+      "---\nexo__Asset_uid: task-2\nexo__Asset_label: With Null\nobsolete_field: null\n---\nBody\n",
+    );
+
+    await service.execute("tasks/Null");
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/Null.md"));
+    expect(fm.obsolete_field).toBeUndefined();
+    expect(fm.exo__Asset_label).toBe("With Null");
+  });
+
+  it("removes empty list properties ([])", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/EmptyList.md",
+      "---\nexo__Asset_uid: task-3\nexo__Asset_label: Empty List\ntags: []\n---\nBody\n",
+    );
+
+    await service.execute("tasks/EmptyList");
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/EmptyList.md"));
+    expect(fm.tags).toBeUndefined();
+  });
+
+  it("keeps non-empty properties untouched", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Mixed.md",
+      '---\nexo__Asset_uid: task-4\nexo__Asset_label: Mixed\nems__Effort_plannedStartTimestamp: ""\nems__Effort_status: "[[ems__EffortStatusDoing]]"\n---\nBody\n',
+    );
+
+    await service.execute("tasks/Mixed");
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/Mixed.md"));
+    expect(fm.ems__Effort_plannedStartTimestamp).toBeUndefined();
+    expect(fm.ems__Effort_status).toBe("[[ems__EffortStatusDoing]]");
+    expect(fm.exo__Asset_label).toBe("Mixed");
+  });
+
+  it("preserves file body content", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/WithBody.md",
+      '---\nexo__Asset_uid: task-5\nempty_prop: ""\n---\n## Notes\n- bullet one\n- bullet two\n',
+    );
+
+    await service.execute("tasks/WithBody");
+
+    const content = fs.readFileSync(
+      path.join(vaultRoot, "tasks/WithBody.md"),
+      "utf-8",
+    );
+    expect(content).toContain("## Notes\n- bullet one\n- bullet two\n");
+    expect(content).not.toMatch(/empty_prop:\s*""/);
+  });
+
+  it("rejects when target file does not exist", async () => {
+    await expect(service.execute("tasks/Missing")).rejects.toThrow();
+  });
+
+  it("registry integration: populateCliServiceRegistry with deps registers real cleanProperties (no throw-stub)", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Registered.md",
+      '---\nexo__Asset_uid: task-6\nexo__Asset_label: Registered\nempty: ""\n---\nBody\n',
+    );
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+      taskStatusService,
+      propertyCleanupService,
+    });
+
+    const registered = registry.get("cleanProperties");
+    expect(registered).toBeDefined();
+    await expect(registered!.execute("tasks/Registered")).resolves.toBeUndefined();
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/Registered.md"));
+    expect(fm.empty).toBeUndefined();
+    expect(fm.exo__Asset_label).toBe("Registered");
+  });
+
+  it("registry integration: cleanProperties is NOT a CliServiceNotImplementedError stub when deps provided (#2869 regression guard)", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Guard.md",
+      '---\nexo__Asset_uid: task-7\nexo__Asset_label: Guard\n---\nBody\n',
+    );
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+      taskStatusService,
+      propertyCleanupService,
+    });
+    const registered = registry.get("cleanProperties");
+    expect(registered).toBeDefined();
+
+    try {
+      await registered!.execute("tasks/Guard");
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(CliServiceNotImplementedError);
+    }
+  });
+
+  it("registry integration: when deps are NOT provided, cleanProperties is absent (backwards-compat)", () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry);
+    expect(registry.has("cleanProperties")).toBe(false);
+  });
+});

--- a/packages/cli/tests/unit/services/createRelatedProject.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedProject.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   GenericAssetCreationService,
+  PropertyCleanupService,
   ServiceRegistry,
   StatusTimestampService,
   TaskStatusService,
@@ -50,6 +51,7 @@ describe("createRelatedProject (CLI)", () => {
   let vaultAdapter: FileSystemVaultAdapter;
   let genericAssetCreationService: GenericAssetCreationService;
   let archiveAssetService: ArchiveAssetService;
+  let propertyCleanupService: PropertyCleanupService;
   let taskStatusService: TaskStatusService;
   let service: ReturnType<typeof createCreateRelatedProjectService>;
 
@@ -58,6 +60,7 @@ describe("createRelatedProject (CLI)", () => {
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -175,6 +178,7 @@ describe("createRelatedProject (CLI)", () => {
       genericAssetCreationService,
       archiveAssetService,
       taskStatusService,
+      propertyCleanupService,
     });
 
     const registered = registry.get("createRelatedProject");
@@ -197,6 +201,7 @@ describe("createRelatedProject (CLI)", () => {
       genericAssetCreationService,
       archiveAssetService,
       taskStatusService,
+      propertyCleanupService,
     });
     const registered = registry.get("createRelatedProject");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/createRelatedTask.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedTask.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   GenericAssetCreationService,
+  PropertyCleanupService,
   ServiceRegistry,
   StatusTimestampService,
   TaskStatusService,
@@ -50,6 +51,7 @@ describe("createRelatedTask (CLI)", () => {
   let vaultAdapter: FileSystemVaultAdapter;
   let genericAssetCreationService: GenericAssetCreationService;
   let archiveAssetService: ArchiveAssetService;
+  let propertyCleanupService: PropertyCleanupService;
   let taskStatusService: TaskStatusService;
   let service: ReturnType<typeof createCreateRelatedTaskService>;
 
@@ -58,6 +60,7 @@ describe("createRelatedTask (CLI)", () => {
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -157,6 +160,7 @@ describe("createRelatedTask (CLI)", () => {
       genericAssetCreationService,
       archiveAssetService,
       taskStatusService,
+      propertyCleanupService,
     });
 
     const registered = registry.get("createRelatedTask");
@@ -179,6 +183,7 @@ describe("createRelatedTask (CLI)", () => {
       genericAssetCreationService,
       archiveAssetService,
       taskStatusService,
+      propertyCleanupService,
     });
     const registered = registry.get("createRelatedTask");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/planForEvening.test.ts
+++ b/packages/cli/tests/unit/services/planForEvening.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   GenericAssetCreationService,
+  PropertyCleanupService,
   ServiceRegistry,
   StatusTimestampService,
   TaskStatusService,
@@ -68,6 +69,7 @@ describe("planForEvening (CLI)", () => {
   let vaultAdapter: FileSystemVaultAdapter;
   let archiveAssetService: ArchiveAssetService;
   let genericAssetCreationService: GenericAssetCreationService;
+  let propertyCleanupService: PropertyCleanupService;
   let workflow: EffortStatusWorkflow;
   let timestampService: StatusTimestampService;
   let taskStatusService: TaskStatusService;
@@ -78,6 +80,7 @@ describe("planForEvening (CLI)", () => {
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     workflow = new EffortStatusWorkflow();
     timestampService = new StatusTimestampService(vaultAdapter);
     taskStatusService = new TaskStatusService(
@@ -195,6 +198,7 @@ describe("planForEvening (CLI)", () => {
       genericAssetCreationService,
       archiveAssetService,
       taskStatusService,
+      propertyCleanupService,
     });
 
     const registered = registry.get("planForEvening");
@@ -220,6 +224,7 @@ describe("planForEvening (CLI)", () => {
       genericAssetCreationService,
       archiveAssetService,
       taskStatusService,
+      propertyCleanupService,
     });
     const registered = registry.get("planForEvening");
     expect(registered).toBeDefined();

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -9,6 +9,7 @@ import {
   StatusTimestampService,
   GenericAssetCreationService,
   ArchiveAssetService,
+  PropertyCleanupService,
   DateFormatter,
   type IGroundingService,
   type UserInput,
@@ -283,6 +284,7 @@ export function populateServiceRegistry(
     const labelToAliasService = new LabelToAliasService(vaultAdapter);
     const genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     const archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    const propertyCleanupService = new PropertyCleanupService(vaultAdapter);
 
     registry.register(
       "rollbackStatus",
@@ -442,6 +444,14 @@ export function populateServiceRegistry(
       wrapService(async (targetIRI: string) => {
         const iFile = resolveIFile(app, targetIRI, vaultAdapter);
         await archiveAssetService.archiveAsset(iFile);
+      }),
+    );
+
+    registry.register(
+      "cleanProperties",
+      wrapService(async (targetIRI: string) => {
+        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
+        await propertyCleanupService.cleanEmptyProperties(iFile);
       }),
     );
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -125,6 +125,7 @@ describe("ServiceRegistryPopulator", () => {
       "createRelatedTask",
       "createRelatedProject",
       "archiveAsset",
+      "cleanProperties",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -451,6 +452,7 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       "createRelatedTask",
       "createRelatedProject",
       "archiveAsset",
+      "cleanProperties",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -746,6 +748,39 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
         frontmatter: { exo__Asset_uid: "different-uid" },
       });
       const service = registry.get("archiveAsset")!;
+      await expect(service.execute("nonexistent-iri")).rejects.toThrow(
+        "No file found for IRI",
+      );
+    });
+  });
+
+  describe("cleanProperties", () => {
+    beforeEach(() => {
+      (deps.vaultAdapter!.read as jest.Mock).mockResolvedValue(
+        "---\nexo__Asset_uid: test-uid-123\nexo__Asset_label: Test Asset\nems__Effort_plannedStartTimestamp: \"\"\nobsolete_prop: null\nempty_list: []\n---\nBody",
+      );
+    });
+
+    it("should strip empty properties from frontmatter via PropertyCleanupService", async () => {
+      const service = registry.get("cleanProperties")!;
+      await service.execute("test-uid-123");
+
+      expect(deps.vaultAdapter!.read).toHaveBeenCalledWith(mockIFile);
+      const modifyCall = (deps.vaultAdapter!.modify as jest.Mock).mock.calls[0];
+      expect(modifyCall).toBeDefined();
+      const written = modifyCall[1] as string;
+      expect(written).not.toMatch(/ems__Effort_plannedStartTimestamp:\s*""/);
+      expect(written).not.toMatch(/obsolete_prop:\s*null/);
+      expect(written).not.toMatch(/empty_list:\s*\[\]/);
+      expect(written).toContain("exo__Asset_uid: test-uid-123");
+      expect(written).toContain("exo__Asset_label: Test Asset");
+    });
+
+    it("should throw when target IRI cannot be resolved", async () => {
+      (deps.app.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: { exo__Asset_uid: "different-uid" },
+      });
+      const service = registry.get("cleanProperties")!;
       await expect(service.execute("nonexistent-iri")).rejects.toThrow(
         "No file found for IRI",
       );


### PR DESCRIPTION
## Summary

- Close CLI-parity gap #2869: `cleanProperties` grounding service was referenced by starter-kit (command 0da175e1 + grounding de7914fb) but never registered in plugin or CLI populators.
- Option A (implement end-to-end) — the shared `PropertyCleanupService` already existed (`packages/exocortex/src/services/PropertyCleanupService.ts`) with storage-agnostic `IVaultAdapter` DI; wiring it through was the missing piece.
- Plugin: register `cleanProperties` handler inside the `vaultAdapter` block of `ServiceRegistryPopulator`, mirroring `archiveAsset` (#2867).
- CLI: add `createCleanPropertiesService` factory to `CliServiceRegistryPopulator`, add `propertyCleanupService` to required deps, thread it through `dynamic-command.ts` exec action.

## Semantic

`cleanProperties(file)` strips frontmatter entries whose values are empty: `""`, `null`, `undefined`, `[]`, `{}`, `"null"`, `"undefined"`, quoted empty strings, and empty list properties. Idempotent, body-preserving, byte-identical between plugin/CLI paths (both call the same shared service).

## Smoke

Synthetic grounding + task with `empty_prop: ""`, `null_prop: null`, `empty_list: []`, `real_prop: "keep me"`, `ems__Effort_status: "[[ems__EffortStatusDoing]]"` → `dyncommand exec cmd-clean --target tasks/task-smoke.md` → empty properties removed, non-empty kept, body preserved. ✅

## Precondition note

Starter-kit command 0da175e1 references precondition host function `hasObsoleteProperties`, not registered anywhere. `PreconditionEvaluator.evaluateHostFunction` defaults to `true` (permissive) for unknown host functions (line 128), so button visibility isn't blocked. Out of scope for this fix.

## Test plan

- [x] Plugin unit: `ServiceRegistryPopulator.test.ts` — 64/64 pass (2 new cases for cleanProperties).
- [x] CLI unit: `cleanProperties.test.ts` — 9/9 pass (semantic + registry integration + backwards-compat guard).
- [x] CLI unit: `archiveAsset`/`createRelatedTask`/`createRelatedProject`/`planForEvening` tests updated for new required dep — all green.
- [x] CLI unit: `dynamic-command.test.ts` — 21/21 pass (ESM mock factory declares new export).
- [x] Full `CI=true npm run test:unit` — obsidian-plugin 4709 passed, CLI 1302 passed, exocortex regression 82 passed.
- [x] `npm run check:types` clean.
- [x] CLI smoke against synthetic grounding on tmp vault — cleanup correct, body preserved.
- [ ] CI (build, typecheck, test-unit, test-coverage, test-bdd, archgate, e2e-tests, test-component) — pending.