### PR TITLE
feat: fixMissingLabel service (plugin + CLI) (closes #2870)

### DIFF
--- a/packages/cli/src/commands/dynamic-command.ts
+++ b/packages/cli/src/commands/dynamic-command.ts
@@ -12,6 +12,7 @@ import {
   GroundingType,
   GenericAssetCreationService,
   ArchiveAssetService,
+  FixMissingLabelService,
   PropertyCleanupService,
   EffortStatusWorkflow,
   StatusTimestampService,
@@ -340,6 +341,7 @@ export function dynamicCommandCommand(): Command {
         const genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
         const archiveAssetService = new ArchiveAssetService(vaultAdapter);
         const propertyCleanupService = new PropertyCleanupService(vaultAdapter);
+        const fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
         const taskStatusService = new TaskStatusService(
           vaultAdapter,
           new EffortStatusWorkflow(),
@@ -351,6 +353,7 @@ export function dynamicCommandCommand(): Command {
           archiveAssetService,
           taskStatusService,
           propertyCleanupService,
+          fixMissingLabelService,
         });
         const nodeFsAdapter = new NodeFsAdapter(vaultPath);
         const groundingExecutor = new GroundingExecutor(

--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -6,6 +6,7 @@ import {
   type UserInput,
   GenericAssetCreationService,
   ArchiveAssetService,
+  FixMissingLabelService,
   PropertyCleanupService,
   TaskStatusService,
 } from "exocortex";
@@ -71,6 +72,7 @@ export interface CliServiceRegistryDeps {
   archiveAssetService: ArchiveAssetService;
   taskStatusService: TaskStatusService;
   propertyCleanupService: PropertyCleanupService;
+  fixMissingLabelService: FixMissingLabelService;
 }
 
 function resolveTargetFile(vaultAdapter: IVaultAdapter, targetIRI: string): IFile {
@@ -219,6 +221,28 @@ export function createCleanPropertiesService(
 }
 
 /**
+ * CLI-side implementation of the `fixMissingLabel` service (#2870).
+ *
+ * Mirrors the plugin handler in
+ * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
+ * Delegates to the shared `FixMissingLabelService` which sets
+ * `exo__Asset_label` to `file.basename` when the property is missing or
+ * empty. Idempotent: a no-op when the label is already set. Storage-agnostic
+ * via `IVaultAdapter`, so plugin and CLI stay byte-identical.
+ */
+export function createFixMissingLabelService(
+  vaultAdapter: IVaultAdapter,
+  fixMissingLabelService: FixMissingLabelService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      await fixMissingLabelService.fixMissingLabel(targetFile);
+    },
+  };
+}
+
+/**
  * CLI-side implementation of the `planForEvening` service (#2868).
  *
  * Mirrors the plugin handler in
@@ -295,6 +319,13 @@ export function populateCliServiceRegistry(
       createCleanPropertiesService(
         deps.vaultAdapter,
         deps.propertyCleanupService,
+      ),
+    );
+    registry.register(
+      "fixMissingLabel",
+      createFixMissingLabelService(
+        deps.vaultAdapter,
+        deps.fixMissingLabelService,
       ),
     );
   }

--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -61,6 +61,9 @@ jest.unstable_mockModule("exocortex", () => ({
   PropertyCleanupService: jest.fn(() => ({
     cleanEmptyProperties: jest.fn().mockResolvedValue(undefined),
   })),
+  FixMissingLabelService: jest.fn(() => ({
+    fixMissingLabel: jest.fn().mockResolvedValue(undefined),
+  })),
   TaskStatusService: jest.fn(() => ({
     planForEvening: jest.fn().mockResolvedValue(undefined),
   })),

--- a/packages/cli/tests/unit/services/cleanProperties.test.ts
+++ b/packages/cli/tests/unit/services/cleanProperties.test.ts
@@ -6,6 +6,7 @@ import yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
+  FixMissingLabelService,
   GenericAssetCreationService,
   PropertyCleanupService,
   ServiceRegistry,
@@ -42,6 +43,7 @@ describe("cleanProperties (CLI)", () => {
   let archiveAssetService: ArchiveAssetService;
   let genericAssetCreationService: GenericAssetCreationService;
   let taskStatusService: TaskStatusService;
+  let fixMissingLabelService: FixMissingLabelService;
   let service: ReturnType<typeof createCleanPropertiesService>;
 
   beforeEach(() => {
@@ -50,6 +52,7 @@ describe("cleanProperties (CLI)", () => {
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -153,6 +156,7 @@ describe("cleanProperties (CLI)", () => {
       archiveAssetService,
       taskStatusService,
       propertyCleanupService,
+      fixMissingLabelService,
     });
 
     const registered = registry.get("cleanProperties");
@@ -178,6 +182,7 @@ describe("cleanProperties (CLI)", () => {
       archiveAssetService,
       taskStatusService,
       propertyCleanupService,
+      fixMissingLabelService,
     });
     const registered = registry.get("cleanProperties");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/createRelatedProject.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedProject.test.ts
@@ -6,6 +6,7 @@ import yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
+  FixMissingLabelService,
   GenericAssetCreationService,
   PropertyCleanupService,
   ServiceRegistry,
@@ -53,6 +54,7 @@ describe("createRelatedProject (CLI)", () => {
   let archiveAssetService: ArchiveAssetService;
   let propertyCleanupService: PropertyCleanupService;
   let taskStatusService: TaskStatusService;
+  let fixMissingLabelService: FixMissingLabelService;
   let service: ReturnType<typeof createCreateRelatedProjectService>;
 
   beforeEach(() => {
@@ -61,6 +63,7 @@ describe("createRelatedProject (CLI)", () => {
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
+    fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -179,6 +182,7 @@ describe("createRelatedProject (CLI)", () => {
       archiveAssetService,
       taskStatusService,
       propertyCleanupService,
+      fixMissingLabelService,
     });
 
     const registered = registry.get("createRelatedProject");
@@ -202,6 +206,7 @@ describe("createRelatedProject (CLI)", () => {
       archiveAssetService,
       taskStatusService,
       propertyCleanupService,
+      fixMissingLabelService,
     });
     const registered = registry.get("createRelatedProject");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/createRelatedTask.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedTask.test.ts
@@ -6,6 +6,7 @@ import yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
+  FixMissingLabelService,
   GenericAssetCreationService,
   PropertyCleanupService,
   ServiceRegistry,
@@ -53,6 +54,7 @@ describe("createRelatedTask (CLI)", () => {
   let archiveAssetService: ArchiveAssetService;
   let propertyCleanupService: PropertyCleanupService;
   let taskStatusService: TaskStatusService;
+  let fixMissingLabelService: FixMissingLabelService;
   let service: ReturnType<typeof createCreateRelatedTaskService>;
 
   beforeEach(() => {
@@ -61,6 +63,7 @@ describe("createRelatedTask (CLI)", () => {
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
+    fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -161,6 +164,7 @@ describe("createRelatedTask (CLI)", () => {
       archiveAssetService,
       taskStatusService,
       propertyCleanupService,
+      fixMissingLabelService,
     });
 
     const registered = registry.get("createRelatedTask");
@@ -184,6 +188,7 @@ describe("createRelatedTask (CLI)", () => {
       archiveAssetService,
       taskStatusService,
       propertyCleanupService,
+      fixMissingLabelService,
     });
     const registered = registry.get("createRelatedTask");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/fixMissingLabel.test.ts
+++ b/packages/cli/tests/unit/services/fixMissingLabel.test.ts
@@ -15,7 +15,7 @@ import {
 } from "exocortex";
 import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
 import {
-  createArchiveAssetService,
+  createFixMissingLabelService,
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
@@ -29,105 +29,95 @@ function readFrontmatter(filePath: string): Frontmatter {
   return yaml.load(match[1]) as Frontmatter;
 }
 
-function writeAsset(
-  vaultRoot: string,
-  relPath: string,
-  frontmatter: Frontmatter,
-  body = "",
-): string {
+function writeRaw(vaultRoot: string, relPath: string, content: string): string {
   const fullPath = path.join(vaultRoot, relPath);
   fs.ensureDirSync(path.dirname(fullPath));
-  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
-  fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n${body}`, "utf-8");
+  fs.writeFileSync(fullPath, content, "utf-8");
   return fullPath;
 }
 
-describe("archiveAsset (CLI)", () => {
+describe("fixMissingLabel (CLI)", () => {
   let vaultRoot: string;
   let vaultAdapter: FileSystemVaultAdapter;
+  let fixMissingLabelService: FixMissingLabelService;
   let archiveAssetService: ArchiveAssetService;
   let genericAssetCreationService: GenericAssetCreationService;
   let propertyCleanupService: PropertyCleanupService;
-  let fixMissingLabelService: FixMissingLabelService;
   let taskStatusService: TaskStatusService;
-  let service: ReturnType<typeof createArchiveAssetService>;
+  let service: ReturnType<typeof createFixMissingLabelService>;
 
   beforeEach(() => {
-    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-archiveasset-"));
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-fixmissinglabel-"));
     vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
+    fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
-    fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
       new StatusTimestampService(vaultAdapter),
     );
-    service = createArchiveAssetService(vaultAdapter, archiveAssetService);
+    service = createFixMissingLabelService(vaultAdapter, fixMissingLabelService);
   });
 
   afterEach(() => {
     fs.removeSync(vaultRoot);
   });
 
-  it("sets archived: true on a Done task", async () => {
-    writeAsset(vaultRoot, "tasks/DoneTask.md", {
-      exo__Asset_uid: "task-1",
-      exo__Asset_label: "Done Task",
-      ems__Effort_status: "[[ems__EffortStatusDone]]",
-    });
+  it("adds exo__Asset_label derived from basename when missing", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/7de4ab12-label.md",
+      "---\nexo__Asset_uid: 7de4ab12-label\n---\nBody\n",
+    );
 
-    await service.execute("tasks/DoneTask");
+    await service.execute("tasks/7de4ab12-label");
 
-    const fm = readFrontmatter(path.join(vaultRoot, "tasks/DoneTask.md"));
-    expect(fm.archived).toBe(true);
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/7de4ab12-label.md"));
+    expect(fm.exo__Asset_label).toBe("7de4ab12-label");
+    expect(fm.exo__Asset_uid).toBe("7de4ab12-label");
   });
 
-  it("removes aliases when archiving", async () => {
-    writeAsset(vaultRoot, "tasks/WithAliases.md", {
-      exo__Asset_uid: "task-2",
-      exo__Asset_label: "With Aliases",
-      ems__Effort_status: "[[ems__EffortStatusDone]]",
-      aliases: ["With Aliases", "Alt Name"],
-    });
+  it("sets exo__Asset_label when value is empty string", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Empty.md",
+      '---\nexo__Asset_uid: 7de4ab12\nexo__Asset_label: ""\n---\nBody\n',
+    );
 
-    await service.execute("tasks/WithAliases");
+    await service.execute("tasks/Empty");
 
-    const fm = readFrontmatter(path.join(vaultRoot, "tasks/WithAliases.md"));
-    expect(fm.archived).toBe(true);
-    expect(fm.aliases).toBeUndefined();
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/Empty.md"));
+    expect(fm.exo__Asset_label).toBe("Empty");
   });
 
-  it("is idempotent when already archived", async () => {
-    writeAsset(vaultRoot, "tasks/Already.md", {
-      exo__Asset_uid: "task-3",
-      exo__Asset_label: "Already",
-      archived: true,
-    });
-    const before = fs.readFileSync(
-      path.join(vaultRoot, "tasks/Already.md"),
+  it("is a no-op when label already set to non-empty value", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Labeled.md",
+      '---\nexo__Asset_uid: 7de4ab12\nexo__Asset_label: "Already Has Label"\n---\nBody\n',
+    );
+
+    const originalContent = fs.readFileSync(
+      path.join(vaultRoot, "tasks/Labeled.md"),
       "utf-8",
     );
 
-    await service.execute("tasks/Already");
+    await service.execute("tasks/Labeled");
 
-    const after = fs.readFileSync(
-      path.join(vaultRoot, "tasks/Already.md"),
+    const unchanged = fs.readFileSync(
+      path.join(vaultRoot, "tasks/Labeled.md"),
       "utf-8",
     );
-    expect(after).toBe(before);
+    expect(unchanged).toBe(originalContent);
   });
 
   it("preserves file body content", async () => {
-    writeAsset(
+    writeRaw(
       vaultRoot,
       "tasks/WithBody.md",
-      {
-        exo__Asset_uid: "task-4",
-        exo__Asset_label: "With Body",
-      },
-      "## Notes\n- bullet one\n- bullet two\n",
+      "---\nexo__Asset_uid: task-5\n---\n## Notes\n- bullet one\n- bullet two\n",
     );
 
     await service.execute("tasks/WithBody");
@@ -137,19 +127,18 @@ describe("archiveAsset (CLI)", () => {
       "utf-8",
     );
     expect(content).toContain("## Notes\n- bullet one\n- bullet two\n");
-    const fm = readFrontmatter(path.join(vaultRoot, "tasks/WithBody.md"));
-    expect(fm.archived).toBe(true);
   });
 
   it("rejects when target file does not exist", async () => {
     await expect(service.execute("tasks/Missing")).rejects.toThrow();
   });
 
-  it("registry integration: populateCliServiceRegistry with deps registers real archiveAsset (no throw-stub)", async () => {
-    writeAsset(vaultRoot, "tasks/Registered.md", {
-      exo__Asset_uid: "task-5",
-      exo__Asset_label: "Registered",
-    });
+  it("registry integration: populateCliServiceRegistry with deps registers real fixMissingLabel (no throw-stub)", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Registered.md",
+      "---\nexo__Asset_uid: task-6\n---\nBody\n",
+    );
 
     const registry = new ServiceRegistry();
     populateCliServiceRegistry(registry, {
@@ -161,19 +150,20 @@ describe("archiveAsset (CLI)", () => {
       fixMissingLabelService,
     });
 
-    const registered = registry.get("archiveAsset");
+    const registered = registry.get("fixMissingLabel");
     expect(registered).toBeDefined();
     await expect(registered!.execute("tasks/Registered")).resolves.toBeUndefined();
 
     const fm = readFrontmatter(path.join(vaultRoot, "tasks/Registered.md"));
-    expect(fm.archived).toBe(true);
+    expect(fm.exo__Asset_label).toBe("Registered");
   });
 
-  it("registry integration: archiveAsset is NOT a CliServiceNotImplementedError stub when deps provided (#2867 regression guard)", async () => {
-    writeAsset(vaultRoot, "tasks/Guard.md", {
-      exo__Asset_uid: "task-6",
-      exo__Asset_label: "Guard",
-    });
+  it("registry integration: fixMissingLabel is NOT a CliServiceNotImplementedError stub when deps provided (#2870 regression guard)", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Guard.md",
+      "---\nexo__Asset_uid: task-7\n---\nBody\n",
+    );
 
     const registry = new ServiceRegistry();
     populateCliServiceRegistry(registry, {
@@ -184,7 +174,7 @@ describe("archiveAsset (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
     });
-    const registered = registry.get("archiveAsset");
+    const registered = registry.get("fixMissingLabel");
     expect(registered).toBeDefined();
 
     try {
@@ -194,9 +184,9 @@ describe("archiveAsset (CLI)", () => {
     }
   });
 
-  it("registry integration: when deps are NOT provided, archiveAsset is absent (backwards-compat)", () => {
+  it("registry integration: when deps are NOT provided, fixMissingLabel is absent (backwards-compat)", () => {
     const registry = new ServiceRegistry();
     populateCliServiceRegistry(registry);
-    expect(registry.has("archiveAsset")).toBe(false);
+    expect(registry.has("fixMissingLabel")).toBe(false);
   });
 });

--- a/packages/cli/tests/unit/services/planForEvening.test.ts
+++ b/packages/cli/tests/unit/services/planForEvening.test.ts
@@ -6,6 +6,7 @@ import yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
+  FixMissingLabelService,
   GenericAssetCreationService,
   PropertyCleanupService,
   ServiceRegistry,
@@ -73,6 +74,7 @@ describe("planForEvening (CLI)", () => {
   let workflow: EffortStatusWorkflow;
   let timestampService: StatusTimestampService;
   let taskStatusService: TaskStatusService;
+  let fixMissingLabelService: FixMissingLabelService;
   let service: ReturnType<typeof createPlanForEveningService>;
 
   beforeEach(() => {
@@ -81,6 +83,7 @@ describe("planForEvening (CLI)", () => {
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
+    fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     workflow = new EffortStatusWorkflow();
     timestampService = new StatusTimestampService(vaultAdapter);
     taskStatusService = new TaskStatusService(
@@ -199,6 +202,7 @@ describe("planForEvening (CLI)", () => {
       archiveAssetService,
       taskStatusService,
       propertyCleanupService,
+      fixMissingLabelService,
     });
 
     const registered = registry.get("planForEvening");
@@ -225,6 +229,7 @@ describe("planForEvening (CLI)", () => {
       archiveAssetService,
       taskStatusService,
       propertyCleanupService,
+      fixMissingLabelService,
     });
     const registered = registry.get("planForEvening");
     expect(registered).toBeDefined();

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -138,6 +138,7 @@ export {
   type AssetPropertyDefinition,
 } from "./services/GenericAssetCreationService";
 export { ArchiveAssetService } from "./services/ArchiveAssetService";
+export { FixMissingLabelService } from "./services/FixMissingLabelService";
 export type {
   URIConstructionOptions,
   AssetMetadata,

--- a/packages/exocortex/src/services/FixMissingLabelService.ts
+++ b/packages/exocortex/src/services/FixMissingLabelService.ts
@@ -1,0 +1,52 @@
+import { injectable, inject } from "tsyringe";
+import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { DI_TOKENS } from "../interfaces/tokens";
+import { FrontmatterService } from "../utilities/FrontmatterService";
+
+/**
+ * Repair missing `exo__Asset_label` by deriving the label from the file's
+ * basename. Idempotent: when the asset already has a non-empty label the
+ * service is a no-op.
+ *
+ * This is the shared (plugin + CLI) implementation behind the
+ * `fixMissingLabel` grounding service (Issue #2870). The starter-kit
+ * "Fix Missing Label" command is gated on a SPARQL ASK precondition that
+ * matches assets with a UID but no `exo__Asset_label`, so in practice the
+ * service is only invoked when a repair is required — but the handler
+ * still checks defensively and skips when the value is already present.
+ *
+ * `file.basename` is used verbatim per the Obsidian TFile contract
+ * (no extension) — see memory `feedback_file_basename_obsidian_tfile_contract`.
+ */
+@injectable()
+export class FixMissingLabelService {
+  private readonly frontmatterService = new FrontmatterService();
+
+  constructor(
+    @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+  ) {}
+
+  async fixMissingLabel(file: IFile): Promise<void> {
+    const content = await this.vault.read(file);
+    if (this.hasNonEmptyLabel(content)) return;
+    const updated = this.frontmatterService.updateProperty(
+      content,
+      "exo__Asset_label",
+      file.basename,
+    );
+    if (updated === content) return;
+    await this.vault.modify(file, updated);
+  }
+
+  private hasNonEmptyLabel(content: string): boolean {
+    const parsed = this.frontmatterService.parse(content);
+    if (!parsed.exists) return false;
+    const match = parsed.content.match(
+      /^exo__Asset_label:\s*(.*)$/m,
+    );
+    if (!match) return false;
+    const raw = match[1].trim();
+    if (raw === "" || raw === '""' || raw === "''") return false;
+    return true;
+  }
+}

--- a/packages/exocortex/tests/services/FixMissingLabelService.test.ts
+++ b/packages/exocortex/tests/services/FixMissingLabelService.test.ts
@@ -1,0 +1,138 @@
+import { FixMissingLabelService } from "../../src/services/FixMissingLabelService";
+import { IVaultAdapter, IFile } from "../../src/interfaces/IVaultAdapter";
+
+describe("FixMissingLabelService", () => {
+  let service: FixMissingLabelService;
+  let mockVault: jest.Mocked<IVaultAdapter>;
+  let mockFile: IFile;
+
+  beforeEach(() => {
+    mockVault = {
+      read: jest.fn(),
+      modify: jest.fn(),
+    } as unknown as jest.Mocked<IVaultAdapter>;
+
+    mockFile = {
+      path: "03 Knowledge/kitelev/05dc6377-abc.md",
+      name: "05dc6377-abc.md",
+      basename: "05dc6377-abc",
+    } as IFile;
+
+    service = new FixMissingLabelService(mockVault);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("adds exo__Asset_label = basename when property is absent", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377-abc
+---
+
+Body.
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.fixMissingLabel(mockFile);
+
+    expect(mockVault.modify).toHaveBeenCalledTimes(1);
+    const [, written] = mockVault.modify.mock.calls[0];
+    expect(written).toMatch(/\nexo__Asset_label: 05dc6377-abc\n/);
+    expect(written).toContain("exo__Asset_uid: 05dc6377-abc");
+  });
+
+  it("sets exo__Asset_label to basename when value is empty string", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377-abc
+exo__Asset_label: ""
+---
+
+Body.
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.fixMissingLabel(mockFile);
+
+    expect(mockVault.modify).toHaveBeenCalledTimes(1);
+    const [, written] = mockVault.modify.mock.calls[0];
+    expect(written).toMatch(/\nexo__Asset_label: 05dc6377-abc\n/);
+    expect(written).not.toMatch(/exo__Asset_label:\s*""/);
+  });
+
+  it("sets exo__Asset_label to basename when value is whitespace-only", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377-abc
+exo__Asset_label:
+---
+
+Body.
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.fixMissingLabel(mockFile);
+
+    expect(mockVault.modify).toHaveBeenCalledTimes(1);
+    const [, written] = mockVault.modify.mock.calls[0];
+    expect(written).toMatch(/\nexo__Asset_label: 05dc6377-abc\n/);
+  });
+
+  it("is a no-op when exo__Asset_label is already set to a non-empty value", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377-abc
+exo__Asset_label: "Existing Label"
+---
+
+Body.
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.fixMissingLabel(mockFile);
+
+    expect(mockVault.modify).not.toHaveBeenCalled();
+  });
+
+  it("preserves body content unchanged", async () => {
+    const original = `---
+exo__Asset_uid: 05dc6377-abc
+---
+
+## Notes
+- point one
+- point two
+`;
+    mockVault.read.mockResolvedValue(original);
+
+    await service.fixMissingLabel(mockFile);
+
+    const [, written] = mockVault.modify.mock.calls[0];
+    expect(written).toMatch(/## Notes\n- point one\n- point two\n/);
+  });
+
+  it("propagates read errors", async () => {
+    mockVault.read.mockRejectedValue(new Error("File not found"));
+
+    await expect(service.fixMissingLabel(mockFile)).rejects.toThrow(
+      "File not found",
+    );
+    expect(mockVault.modify).not.toHaveBeenCalled();
+  });
+
+  it("uses file.basename verbatim (no .md stripping — Obsidian TFile contract)", async () => {
+    const original = `---
+exo__Asset_uid: some-uid
+---
+`;
+    mockVault.read.mockResolvedValue(original);
+    const fileNoExt: IFile = {
+      path: "folder/Human Readable Name.md",
+      name: "Human Readable Name.md",
+      basename: "Human Readable Name",
+    } as IFile;
+
+    await service.fixMissingLabel(fileNoExt);
+
+    const [, written] = mockVault.modify.mock.calls[0];
+    expect(written).toMatch(/exo__Asset_label: Human Readable Name\n/);
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -9,6 +9,7 @@ import {
   StatusTimestampService,
   GenericAssetCreationService,
   ArchiveAssetService,
+  FixMissingLabelService,
   PropertyCleanupService,
   DateFormatter,
   type IGroundingService,
@@ -285,6 +286,7 @@ export function populateServiceRegistry(
     const genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     const archiveAssetService = new ArchiveAssetService(vaultAdapter);
     const propertyCleanupService = new PropertyCleanupService(vaultAdapter);
+    const fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
 
     registry.register(
       "rollbackStatus",
@@ -452,6 +454,14 @@ export function populateServiceRegistry(
       wrapService(async (targetIRI: string) => {
         const iFile = resolveIFile(app, targetIRI, vaultAdapter);
         await propertyCleanupService.cleanEmptyProperties(iFile);
+      }),
+    );
+
+    registry.register(
+      "fixMissingLabel",
+      wrapService(async (targetIRI: string) => {
+        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
+        await fixMissingLabelService.fixMissingLabel(iFile);
       }),
     );
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -126,6 +126,7 @@ describe("ServiceRegistryPopulator", () => {
       "createRelatedProject",
       "archiveAsset",
       "cleanProperties",
+      "fixMissingLabel",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -453,6 +454,7 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       "createRelatedProject",
       "archiveAsset",
       "cleanProperties",
+      "fixMissingLabel",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -781,6 +783,45 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
         frontmatter: { exo__Asset_uid: "different-uid" },
       });
       const service = registry.get("cleanProperties")!;
+      await expect(service.execute("nonexistent-iri")).rejects.toThrow(
+        "No file found for IRI",
+      );
+    });
+  });
+
+  describe("fixMissingLabel", () => {
+    it("sets exo__Asset_label to file.basename when the label is missing", async () => {
+      (deps.vaultAdapter!.read as jest.Mock).mockResolvedValue(
+        "---\nexo__Asset_uid: test-uid-123\n---\nBody",
+      );
+
+      const service = registry.get("fixMissingLabel")!;
+      await service.execute("test-uid-123");
+
+      expect(deps.vaultAdapter!.read).toHaveBeenCalledWith(mockIFile);
+      const modifyCall = (deps.vaultAdapter!.modify as jest.Mock).mock.calls[0];
+      expect(modifyCall).toBeDefined();
+      const written = modifyCall[1] as string;
+      expect(written).toContain("exo__Asset_label: test-uid-123");
+      expect(written).toContain("exo__Asset_uid: test-uid-123");
+    });
+
+    it("is a no-op when the asset already has a label", async () => {
+      (deps.vaultAdapter!.read as jest.Mock).mockResolvedValue(
+        "---\nexo__Asset_uid: test-uid-123\nexo__Asset_label: Existing\n---\nBody",
+      );
+
+      const service = registry.get("fixMissingLabel")!;
+      await service.execute("test-uid-123");
+
+      expect(deps.vaultAdapter!.modify).not.toHaveBeenCalled();
+    });
+
+    it("throws when target IRI cannot be resolved", async () => {
+      (deps.app.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: { exo__Asset_uid: "different-uid" },
+      });
+      const service = registry.get("fixMissingLabel")!;
       await expect(service.execute("nonexistent-iri")).rejects.toThrow(
         "No file found for IRI",
       );


### PR DESCRIPTION
## Summary

Closes #2870 — the CLI-parity gap for the starter-kit **Fix Missing Label** command. Before this change, the button (00bad8ce) bound to `exo__Asset` instances referenced `serviceId: fixMissingLabel` via grounding cd98b4de, but no registry (plugin or CLI) knew about it. Clicks failed silently in Obsidian; `dyncommand exec` threw `CliServiceNotImplementedError` after #2864.

**Option A — implement end-to-end:**
- New shared `FixMissingLabelService` (storage-agnostic via `IVaultAdapter`).
- Plugin: `ServiceRegistryPopulator` registers handler inside the `if (vaultAdapter)` block.
- CLI: `createFixMissingLabelService` factory + `CliServiceRegistryDeps.fixMissingLabelService` + `dynamic-command.ts` exec wiring.

**Semantic:** if `exo__Asset_label` is missing / empty string / whitespace-only → set to `file.basename`. Non-empty labels are preserved (idempotent no-op).

## Test plan

- [x] `FixMissingLabelService` unit tests — 7 cases (missing/empty/whitespace label, idempotent, body preservation, error propagation, basename contract).
- [x] Plugin `ServiceRegistryPopulator` tests — 3 new cases + vault-dependent-IDs list update.
- [x] CLI `fixMissingLabel.test.ts` — 8 cases (semantic + registry integration + backwards-compat + regression guard).
- [x] CLI sibling tests (archiveAsset, cleanProperties, createRelatedTask, createRelatedProject, planForEvening) updated to pass the new required dep.
- [x] CLI `dynamic-command.test.ts` ESM mock factory — declares new `FixMissingLabelService` export.
- [x] `npm run test:unit` green (plugin + CLI + exocortex grounding regression batches).
- [x] `npm run build` green.
- [x] Local smoke — `dyncommand exec` on a label-less asset sets `exo__Asset_label = <basename>` and is idempotent on re-run.