### PR TITLE
feat: repairFolder service (plugin + CLI) (closes #2872)

### DIFF
--- a/packages/cli/src/commands/dynamic-command.ts
+++ b/packages/cli/src/commands/dynamic-command.ts
@@ -13,6 +13,7 @@ import {
   GenericAssetCreationService,
   ArchiveAssetService,
   FixMissingLabelService,
+  FolderRepairService,
   PropertyCleanupService,
   RenameToUidService,
   EffortStatusWorkflow,
@@ -344,6 +345,7 @@ export function dynamicCommandCommand(): Command {
         const propertyCleanupService = new PropertyCleanupService(vaultAdapter);
         const fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
         const renameToUidService = new RenameToUidService(vaultAdapter);
+        const folderRepairService = new FolderRepairService(vaultAdapter);
         const taskStatusService = new TaskStatusService(
           vaultAdapter,
           new EffortStatusWorkflow(),
@@ -357,6 +359,7 @@ export function dynamicCommandCommand(): Command {
           propertyCleanupService,
           fixMissingLabelService,
           renameToUidService,
+          folderRepairService,
         });
         const nodeFsAdapter = new NodeFsAdapter(vaultPath);
         const groundingExecutor = new GroundingExecutor(

--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -7,6 +7,7 @@ import {
   GenericAssetCreationService,
   ArchiveAssetService,
   FixMissingLabelService,
+  FolderRepairService,
   PropertyCleanupService,
   RenameToUidService,
   TaskStatusService,
@@ -75,6 +76,7 @@ export interface CliServiceRegistryDeps {
   propertyCleanupService: PropertyCleanupService;
   fixMissingLabelService: FixMissingLabelService;
   renameToUidService: RenameToUidService;
+  folderRepairService: FolderRepairService;
 }
 
 function resolveTargetFile(vaultAdapter: IVaultAdapter, targetIRI: string): IFile {
@@ -275,6 +277,51 @@ export function createRenameToUidService(
 }
 
 /**
+ * CLI-side implementation of the `repairFolder` service (#2872).
+ *
+ * Mirrors the plugin handler in
+ * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
+ * Delegates to the shared `FolderRepairService`: derives the expected folder
+ * from `exo__Asset_isDefinedBy` and moves the target file there. Idempotent —
+ * a no-op when the asset is already in the expected folder. Throws when the
+ * expected folder cannot be derived (missing `exo__Asset_isDefinedBy` or the
+ * referenced asset is not in the vault) so the CLI exits non-zero and dyncommand
+ * groundings surface the failure instead of silently no-op'ing (#2864 pattern).
+ *
+ * Storage-agnostic via `IVaultAdapter`, so plugin and CLI stay byte-identical
+ * for the same input. The separate hardcoded `cli command repair-folder`
+ * subcommand (`FolderRepairExecutor`) remains for batch/scripting workflows
+ * and is not touched by this wiring.
+ */
+export function createRepairFolderService(
+  vaultAdapter: IVaultAdapter,
+  folderRepairService: FolderRepairService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const metadata =
+        (vaultAdapter.getFrontmatter(targetFile) as Record<string, unknown>) ??
+        {};
+      const expectedFolder = await folderRepairService.getExpectedFolder(
+        targetFile,
+        metadata,
+      );
+      if (expectedFolder === null) {
+        throw new Error(
+          "repairFolder: cannot determine expected folder (missing exo__Asset_isDefinedBy or referenced asset not found)",
+        );
+      }
+      const currentFolder = targetFile.parent?.path ?? "";
+      if (currentFolder === expectedFolder) {
+        return;
+      }
+      await folderRepairService.repairFolder(targetFile, expectedFolder);
+    },
+  };
+}
+
+/**
  * CLI-side implementation of the `planForEvening` service (#2868).
  *
  * Mirrors the plugin handler in
@@ -358,6 +405,13 @@ export function populateCliServiceRegistry(
       createRenameToUidService(
         deps.vaultAdapter,
         deps.renameToUidService,
+      ),
+    );
+    registry.register(
+      "repairFolder",
+      createRepairFolderService(
+        deps.vaultAdapter,
+        deps.folderRepairService,
       ),
     );
     registry.register(

--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -67,6 +67,10 @@ jest.unstable_mockModule("exocortex", () => ({
   RenameToUidService: jest.fn(() => ({
     renameToUid: jest.fn().mockResolvedValue(undefined),
   })),
+  FolderRepairService: jest.fn(() => ({
+    getExpectedFolder: jest.fn().mockResolvedValue(null),
+    repairFolder: jest.fn().mockResolvedValue(undefined),
+  })),
   TaskStatusService: jest.fn(() => ({
     planForEvening: jest.fn().mockResolvedValue(undefined),
   })),

--- a/packages/cli/tests/unit/services/archiveAsset.test.ts
+++ b/packages/cli/tests/unit/services/archiveAsset.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   FixMissingLabelService,
+  FolderRepairService,
   GenericAssetCreationService,
   PropertyCleanupService,
   RenameToUidService,
@@ -51,6 +52,7 @@ describe("archiveAsset (CLI)", () => {
   let propertyCleanupService: PropertyCleanupService;
   let fixMissingLabelService: FixMissingLabelService;
   let renameToUidService: RenameToUidService;
+  let folderRepairService: FolderRepairService;
   let taskStatusService: TaskStatusService;
   let service: ReturnType<typeof createArchiveAssetService>;
 
@@ -62,6 +64,7 @@ describe("archiveAsset (CLI)", () => {
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     renameToUidService = new RenameToUidService(vaultAdapter);
+    folderRepairService = new FolderRepairService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -163,6 +166,7 @@ describe("archiveAsset (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
 
     const registered = registry.get("archiveAsset");
@@ -188,6 +192,7 @@ describe("archiveAsset (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
     const registered = registry.get("archiveAsset");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/cleanProperties.test.ts
+++ b/packages/cli/tests/unit/services/cleanProperties.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   FixMissingLabelService,
+  FolderRepairService,
   GenericAssetCreationService,
   PropertyCleanupService,
   RenameToUidService,
@@ -46,6 +47,7 @@ describe("cleanProperties (CLI)", () => {
   let taskStatusService: TaskStatusService;
   let fixMissingLabelService: FixMissingLabelService;
   let renameToUidService: RenameToUidService;
+  let folderRepairService: FolderRepairService;
   let service: ReturnType<typeof createCleanPropertiesService>;
 
   beforeEach(() => {
@@ -56,6 +58,7 @@ describe("cleanProperties (CLI)", () => {
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     renameToUidService = new RenameToUidService(vaultAdapter);
+    folderRepairService = new FolderRepairService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -161,6 +164,7 @@ describe("cleanProperties (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
 
     const registered = registry.get("cleanProperties");
@@ -188,6 +192,7 @@ describe("cleanProperties (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
     const registered = registry.get("cleanProperties");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/createRelatedProject.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedProject.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   FixMissingLabelService,
+  FolderRepairService,
   GenericAssetCreationService,
   PropertyCleanupService,
   RenameToUidService,
@@ -57,6 +58,7 @@ describe("createRelatedProject (CLI)", () => {
   let taskStatusService: TaskStatusService;
   let fixMissingLabelService: FixMissingLabelService;
   let renameToUidService: RenameToUidService;
+  let folderRepairService: FolderRepairService;
   let service: ReturnType<typeof createCreateRelatedProjectService>;
 
   beforeEach(() => {
@@ -67,6 +69,7 @@ describe("createRelatedProject (CLI)", () => {
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     renameToUidService = new RenameToUidService(vaultAdapter);
+    folderRepairService = new FolderRepairService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -187,6 +190,7 @@ describe("createRelatedProject (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
 
     const registered = registry.get("createRelatedProject");
@@ -212,6 +216,7 @@ describe("createRelatedProject (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
     const registered = registry.get("createRelatedProject");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/createRelatedTask.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedTask.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   FixMissingLabelService,
+  FolderRepairService,
   GenericAssetCreationService,
   PropertyCleanupService,
   RenameToUidService,
@@ -57,6 +58,7 @@ describe("createRelatedTask (CLI)", () => {
   let taskStatusService: TaskStatusService;
   let fixMissingLabelService: FixMissingLabelService;
   let renameToUidService: RenameToUidService;
+  let folderRepairService: FolderRepairService;
   let service: ReturnType<typeof createCreateRelatedTaskService>;
 
   beforeEach(() => {
@@ -67,6 +69,7 @@ describe("createRelatedTask (CLI)", () => {
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     renameToUidService = new RenameToUidService(vaultAdapter);
+    folderRepairService = new FolderRepairService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -169,6 +172,7 @@ describe("createRelatedTask (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
 
     const registered = registry.get("createRelatedTask");
@@ -194,6 +198,7 @@ describe("createRelatedTask (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
     const registered = registry.get("createRelatedTask");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/fixMissingLabel.test.ts
+++ b/packages/cli/tests/unit/services/fixMissingLabel.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   FixMissingLabelService,
+  FolderRepairService,
   GenericAssetCreationService,
   PropertyCleanupService,
   RenameToUidService,
@@ -46,6 +47,7 @@ describe("fixMissingLabel (CLI)", () => {
   let propertyCleanupService: PropertyCleanupService;
   let taskStatusService: TaskStatusService;
   let renameToUidService: RenameToUidService;
+  let folderRepairService: FolderRepairService;
   let service: ReturnType<typeof createFixMissingLabelService>;
 
   beforeEach(() => {
@@ -56,6 +58,7 @@ describe("fixMissingLabel (CLI)", () => {
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     renameToUidService = new RenameToUidService(vaultAdapter);
+    folderRepairService = new FolderRepairService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -152,6 +155,7 @@ describe("fixMissingLabel (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
 
     const registered = registry.get("fixMissingLabel");
@@ -178,6 +182,7 @@ describe("fixMissingLabel (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
     const registered = registry.get("fixMissingLabel");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/planForEvening.test.ts
+++ b/packages/cli/tests/unit/services/planForEvening.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   FixMissingLabelService,
+  FolderRepairService,
   GenericAssetCreationService,
   PropertyCleanupService,
   RenameToUidService,
@@ -77,6 +78,7 @@ describe("planForEvening (CLI)", () => {
   let taskStatusService: TaskStatusService;
   let fixMissingLabelService: FixMissingLabelService;
   let renameToUidService: RenameToUidService;
+  let folderRepairService: FolderRepairService;
   let service: ReturnType<typeof createPlanForEveningService>;
 
   beforeEach(() => {
@@ -87,6 +89,7 @@ describe("planForEvening (CLI)", () => {
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     renameToUidService = new RenameToUidService(vaultAdapter);
+    folderRepairService = new FolderRepairService(vaultAdapter);
     workflow = new EffortStatusWorkflow();
     timestampService = new StatusTimestampService(vaultAdapter);
     taskStatusService = new TaskStatusService(
@@ -207,6 +210,7 @@ describe("planForEvening (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
 
     const registered = registry.get("planForEvening");
@@ -235,6 +239,7 @@ describe("planForEvening (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
     const registered = registry.get("planForEvening");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/renameToUid.test.ts
+++ b/packages/cli/tests/unit/services/renameToUid.test.ts
@@ -7,6 +7,7 @@ import {
   ArchiveAssetService,
   EffortStatusWorkflow,
   FixMissingLabelService,
+  FolderRepairService,
   GenericAssetCreationService,
   PropertyCleanupService,
   RenameToUidService,
@@ -46,6 +47,7 @@ describe("renameToUid (CLI)", () => {
   let genericAssetCreationService: GenericAssetCreationService;
   let propertyCleanupService: PropertyCleanupService;
   let taskStatusService: TaskStatusService;
+  let folderRepairService: FolderRepairService;
   let service: ReturnType<typeof createRenameToUidService>;
 
   beforeEach(() => {
@@ -56,6 +58,7 @@ describe("renameToUid (CLI)", () => {
     archiveAssetService = new ArchiveAssetService(vaultAdapter);
     genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     propertyCleanupService = new PropertyCleanupService(vaultAdapter);
+    folderRepairService = new FolderRepairService(vaultAdapter);
     taskStatusService = new TaskStatusService(
       vaultAdapter,
       new EffortStatusWorkflow(),
@@ -150,6 +153,7 @@ describe("renameToUid (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
 
     const registered = registry.get("renameToUid");
@@ -175,6 +179,7 @@ describe("renameToUid (CLI)", () => {
       propertyCleanupService,
       fixMissingLabelService,
       renameToUidService,
+      folderRepairService,
     });
     const registered = registry.get("renameToUid");
     expect(registered).toBeDefined();

--- a/packages/cli/tests/unit/services/repairFolder.test.ts
+++ b/packages/cli/tests/unit/services/repairFolder.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import yaml from "js-yaml";
+import {
+  ArchiveAssetService,
+  EffortStatusWorkflow,
+  FixMissingLabelService,
+  FolderRepairService,
+  GenericAssetCreationService,
+  PropertyCleanupService,
+  RenameToUidService,
+  ServiceRegistry,
+  StatusTimestampService,
+  TaskStatusService,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
+import {
+  createRepairFolderService,
+  populateCliServiceRegistry,
+  CliServiceNotImplementedError,
+} from "../../../src/services/CliServiceRegistryPopulator.js";
+
+type Frontmatter = Record<string, unknown>;
+
+function readFrontmatter(filePath: string): Frontmatter {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter in ${filePath}`);
+  return yaml.load(match[1]) as Frontmatter;
+}
+
+function writeRaw(vaultRoot: string, relPath: string, content: string): string {
+  const fullPath = path.join(vaultRoot, relPath);
+  fs.ensureDirSync(path.dirname(fullPath));
+  fs.writeFileSync(fullPath, content, "utf-8");
+  return fullPath;
+}
+
+describe("repairFolder (CLI)", () => {
+  let vaultRoot: string;
+  let vaultAdapter: FileSystemVaultAdapter;
+  let folderRepairService: FolderRepairService;
+  let renameToUidService: RenameToUidService;
+  let fixMissingLabelService: FixMissingLabelService;
+  let archiveAssetService: ArchiveAssetService;
+  let genericAssetCreationService: GenericAssetCreationService;
+  let propertyCleanupService: PropertyCleanupService;
+  let taskStatusService: TaskStatusService;
+  let service: ReturnType<typeof createRepairFolderService>;
+
+  beforeEach(() => {
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-repairfolder-"));
+    vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
+    folderRepairService = new FolderRepairService(vaultAdapter);
+    renameToUidService = new RenameToUidService(vaultAdapter);
+    fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
+    archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    propertyCleanupService = new PropertyCleanupService(vaultAdapter);
+    taskStatusService = new TaskStatusService(
+      vaultAdapter,
+      new EffortStatusWorkflow(),
+      new StatusTimestampService(vaultAdapter),
+    );
+    service = createRepairFolderService(vaultAdapter, folderRepairService);
+  });
+
+  afterEach(() => {
+    fs.removeSync(vaultRoot);
+  });
+
+  // CLI FileSystemVaultAdapter.getFirstLinkpathDest only resolves non-UUID
+  // linkpaths relative to the source file's directory. For cross-folder
+  // resolution we use UUID-named referent files so the adapter's lazy UUID
+  // index picks them up from anywhere in the vault.
+  const AREA_REFERENT = "60967c6a-4e8a-4ee3-8922-db98b981e4f4";
+  const MISSING_REFERENT = "00000000-0000-0000-0000-ffffffffffff";
+
+  it("moves a misplaced asset into the folder of its isDefinedBy referent", async () => {
+    writeRaw(
+      vaultRoot,
+      `01 Areas/${AREA_REFERENT}.md`,
+      `---\nexo__Asset_uid: ${AREA_REFERENT}\nexo__Asset_label: Areas\n---\nBody\n`,
+    );
+    writeRaw(
+      vaultRoot,
+      "02 Misplaced/target-uid.md",
+      `---\nexo__Asset_uid: target-uid\nexo__Asset_label: Target\nexo__Asset_isDefinedBy: "[[${AREA_REFERENT}]]"\n---\nBody\n`,
+    );
+
+    await service.execute("02 Misplaced/target-uid");
+
+    expect(fs.existsSync(path.join(vaultRoot, "01 Areas/target-uid.md"))).toBe(true);
+    expect(fs.existsSync(path.join(vaultRoot, "02 Misplaced/target-uid.md"))).toBe(false);
+  });
+
+  it("is a no-op when asset is already in the expected folder (idempotent)", async () => {
+    writeRaw(
+      vaultRoot,
+      `01 Areas/${AREA_REFERENT}.md`,
+      `---\nexo__Asset_uid: ${AREA_REFERENT}\nexo__Asset_label: Areas\n---\nBody\n`,
+    );
+    writeRaw(
+      vaultRoot,
+      "01 Areas/already-correct.md",
+      `---\nexo__Asset_uid: already-correct\nexo__Asset_label: Correct\nexo__Asset_isDefinedBy: "[[${AREA_REFERENT}]]"\n---\nBody\n`,
+    );
+
+    await expect(service.execute("01 Areas/already-correct")).resolves.toBeUndefined();
+
+    expect(fs.existsSync(path.join(vaultRoot, "01 Areas/already-correct.md"))).toBe(true);
+    const fm = readFrontmatter(path.join(vaultRoot, "01 Areas/already-correct.md"));
+    expect(fm.exo__Asset_uid).toBe("already-correct");
+  });
+
+  it("throws when exo__Asset_isDefinedBy is missing (no expected folder derivable)", async () => {
+    writeRaw(
+      vaultRoot,
+      "02 Misplaced/no-isdefined.md",
+      "---\nexo__Asset_uid: no-isdefined\nexo__Asset_label: NoIsDefined\n---\nBody\n",
+    );
+
+    await expect(service.execute("02 Misplaced/no-isdefined")).rejects.toThrow(
+      /expected folder|isDefinedBy/i,
+    );
+  });
+
+  it("throws when the isDefinedBy referent cannot be located in the vault", async () => {
+    writeRaw(
+      vaultRoot,
+      "02 Misplaced/orphan.md",
+      `---\nexo__Asset_uid: orphan\nexo__Asset_label: Orphan\nexo__Asset_isDefinedBy: "[[${MISSING_REFERENT}]]"\n---\nBody\n`,
+    );
+
+    await expect(service.execute("02 Misplaced/orphan")).rejects.toThrow(
+      /expected folder|isDefinedBy/i,
+    );
+  });
+
+  it("throws when the target file does not exist", async () => {
+    await expect(service.execute("02 Misplaced/does-not-exist")).rejects.toThrow();
+  });
+
+  it("registry integration: populateCliServiceRegistry with deps registers real repairFolder (no throw-stub)", async () => {
+    writeRaw(
+      vaultRoot,
+      `01 Areas/${AREA_REFERENT}.md`,
+      `---\nexo__Asset_uid: ${AREA_REFERENT}\nexo__Asset_label: Areas\n---\nBody\n`,
+    );
+    writeRaw(
+      vaultRoot,
+      "02 Misplaced/registered-uid.md",
+      `---\nexo__Asset_uid: registered-uid\nexo__Asset_label: Registered\nexo__Asset_isDefinedBy: "[[${AREA_REFERENT}]]"\n---\nBody\n`,
+    );
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+      taskStatusService,
+      propertyCleanupService,
+      fixMissingLabelService,
+      renameToUidService,
+      folderRepairService,
+    });
+
+    const registered = registry.get("repairFolder");
+    expect(registered).toBeDefined();
+    await expect(
+      registered!.execute("02 Misplaced/registered-uid"),
+    ).resolves.toBeUndefined();
+
+    expect(fs.existsSync(path.join(vaultRoot, "01 Areas/registered-uid.md"))).toBe(true);
+  });
+
+  it("registry integration: repairFolder is NOT a CliServiceNotImplementedError stub when deps provided (#2872 regression guard)", async () => {
+    writeRaw(
+      vaultRoot,
+      `01 Areas/${AREA_REFERENT}.md`,
+      `---\nexo__Asset_uid: ${AREA_REFERENT}\nexo__Asset_label: Areas\n---\nBody\n`,
+    );
+    writeRaw(
+      vaultRoot,
+      "02 Misplaced/guard.md",
+      `---\nexo__Asset_uid: guard\nexo__Asset_label: Guard\nexo__Asset_isDefinedBy: "[[${AREA_REFERENT}]]"\n---\nBody\n`,
+    );
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+      taskStatusService,
+      propertyCleanupService,
+      fixMissingLabelService,
+      renameToUidService,
+      folderRepairService,
+    });
+    const registered = registry.get("repairFolder");
+    expect(registered).toBeDefined();
+
+    try {
+      await registered!.execute("02 Misplaced/guard");
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(CliServiceNotImplementedError);
+    }
+  });
+
+  it("registry integration: when deps are NOT provided, repairFolder is absent (backwards-compat)", () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry);
+    expect(registry.has("repairFolder")).toBe(false);
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -10,6 +10,7 @@ import {
   GenericAssetCreationService,
   ArchiveAssetService,
   FixMissingLabelService,
+  FolderRepairService,
   PropertyCleanupService,
   RenameToUidService,
   DateFormatter,
@@ -289,6 +290,7 @@ export function populateServiceRegistry(
     const propertyCleanupService = new PropertyCleanupService(vaultAdapter);
     const fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     const renameToUidService = new RenameToUidService(vaultAdapter);
+    const folderRepairService = new FolderRepairService(vaultAdapter);
 
     registry.register(
       "rollbackStatus",
@@ -474,6 +476,29 @@ export function populateServiceRegistry(
         const metadata =
           (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
         await renameToUidService.renameToUid(iFile, metadata);
+      }),
+    );
+
+    registry.register(
+      "repairFolder",
+      wrapService(async (targetIRI: string) => {
+        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
+        const metadata =
+          (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
+        const expectedFolder = await folderRepairService.getExpectedFolder(
+          iFile,
+          metadata,
+        );
+        if (expectedFolder === null) {
+          throw new Error(
+            "repairFolder: cannot determine expected folder (missing exo__Asset_isDefinedBy or referenced asset not found)",
+          );
+        }
+        const currentFolder = iFile.parent?.path ?? "";
+        if (currentFolder === expectedFolder) {
+          return;
+        }
+        await folderRepairService.repairFolder(iFile, expectedFolder);
       }),
     );
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -136,6 +136,7 @@ describe("ServiceRegistryPopulator", () => {
       "cleanProperties",
       "fixMissingLabel",
       "renameToUid",
+      "repairFolder",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -465,6 +466,7 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       "cleanProperties",
       "fixMissingLabel",
       "renameToUid",
+      "repairFolder",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -901,6 +903,101 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       const service = registry.get("createTaskForDailyNote")!;
       await expect(service.execute("test-uid-123", {})).rejects.toThrow(
         "createTaskForDailyNote requires userInput.label",
+      );
+    });
+  });
+
+  describe("repairFolder", () => {
+    const REFERENCED_PATH = "01 Areas/!toos_areas.md";
+    const REFERENCED_FILE = {
+      path: REFERENCED_PATH,
+      basename: "!toos_areas",
+      name: "!toos_areas.md",
+      parent: { path: "01 Areas", name: "01 Areas" },
+    };
+
+    beforeEach(() => {
+      (deps.vaultAdapter!.getFrontmatter as jest.Mock).mockReturnValue({
+        exo__Asset_uid: "test-uid-123",
+        exo__Asset_label: "Test Asset",
+        exo__Asset_isDefinedBy: "[[!toos_areas]]",
+      });
+
+      const adapter = deps.vaultAdapter! as unknown as {
+        getFirstLinkpathDest?: jest.Mock;
+        getAbstractFileByPath: jest.Mock;
+      };
+      adapter.getFirstLinkpathDest = jest
+        .fn()
+        .mockImplementation((reference: string) => {
+          if (reference === "!toos_areas") return REFERENCED_FILE;
+          return null;
+        });
+      adapter.getAbstractFileByPath = jest
+        .fn()
+        .mockImplementation((path: string) => {
+          if (path === mockIFile.path) return mockIFile;
+          if (path === REFERENCED_PATH) return REFERENCED_FILE;
+          return null;
+        });
+    });
+
+    it("moves the target file to the folder of its isDefinedBy referent", async () => {
+      const service = registry.get("repairFolder")!;
+      await service.execute("test-uid-123");
+
+      expect(deps.vaultAdapter!.rename).toHaveBeenCalledWith(
+        mockIFile,
+        "01 Areas/test-uid-123.md",
+      );
+    });
+
+    it("is a no-op when the target is already in the expected folder", async () => {
+      const sameFolderReferenced = {
+        ...REFERENCED_FILE,
+        parent: { path: mockIFile.parent.path, name: mockIFile.parent.name },
+      };
+      (
+        deps.vaultAdapter! as unknown as { getFirstLinkpathDest: jest.Mock }
+      ).getFirstLinkpathDest.mockReturnValue(sameFolderReferenced);
+
+      const service = registry.get("repairFolder")!;
+      await service.execute("test-uid-123");
+
+      expect(deps.vaultAdapter!.rename).not.toHaveBeenCalled();
+    });
+
+    it("throws when exo__Asset_isDefinedBy is missing (no expected folder derivable)", async () => {
+      (deps.vaultAdapter!.getFrontmatter as jest.Mock).mockReturnValueOnce({
+        exo__Asset_uid: "test-uid-123",
+        exo__Asset_label: "Test Asset",
+      });
+
+      const service = registry.get("repairFolder")!;
+      await expect(service.execute("test-uid-123")).rejects.toThrow(
+        /expected folder|isDefinedBy/i,
+      );
+    });
+
+    it("throws when the isDefinedBy referent cannot be located", async () => {
+      (
+        deps.vaultAdapter! as unknown as { getFirstLinkpathDest: jest.Mock }
+      ).getFirstLinkpathDest.mockReturnValue(null);
+
+      const service = registry.get("repairFolder")!;
+      await expect(service.execute("test-uid-123")).rejects.toThrow(
+        /expected folder|isDefinedBy/i,
+      );
+    });
+
+    it("throws when the target IRI cannot be resolved", async () => {
+      (deps.app.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: { exo__Asset_uid: "different-uid" },
+      });
+
+      const service = registry.get("repairFolder")!;
+      await expect(service.execute("nonexistent-iri")).rejects.toThrow(
+        "No file found for IRI",
       );
     });
   });


### PR DESCRIPTION
## Summary

Wire the existing shared `FolderRepairService` as a `repairFolder`
dyncommand `service_call` handler in both the Obsidian plugin and CLI
registries. Starter-kit grounding `e7189a73-…` / command `ad65f560-…`
("Repair Folder") now resolve to a real implementation on both surfaces
instead of silently no-op'ing or throwing `CliServiceNotImplementedError`.

Pattern: wire-only fix, mirrors #2869 cleanProperties (v15.110.0),
#2870 fixMissingLabel (v15.111.0), and #2871 renameToUid (v15.112.0).

## Behavior

The service derives the expected folder from `exo__Asset_isDefinedBy`,
moves the file there via `FolderRepairService.repairFolder`, is
idempotent (no-op when already in the correct folder), and throws when
the expected folder cannot be derived (missing `exo__Asset_isDefinedBy`
or unresolvable referent).

## Scope notes

- CLI hardcoded `CommandExecutor.executeRepairFolder` subcommand
  (`packages/cli/src/executors/commands/FolderRepairExecutor.ts`) is
  **intentionally NOT refactored** in this PR. Its logic diverges from
  the shared service (filename-based cross-vault fallback, dry-run
  mode, explicit `process.exit` codes) — merging requires behaviour
  coordination and is tracked separately. The `cli command repair-folder`
  subcommand continues to work.

## Test plan

- [x] New CLI test suite `repairFolder.test.ts` (8 tests): factory
  (move / idempotent / missing-isDefinedBy / missing-referent /
  nonexistent target) + registry integration + regression guard +
  backwards-compat.
- [x] Plugin `ServiceRegistryPopulator.test.ts` extended with 5
  `repairFolder` describe cases.
- [x] Sibling CLI service tests updated to include `folderRepairService`
  in deps (7 files).
- [x] `CI=true npx jest` CLI package: 85 suites / 1327 tests pass.
- [x] Plugin narrow suite: 76 tests pass.
- [x] `npm run check:types` pass.
- [x] `npm run lint` — no new warnings/errors in touched files.

Closes #2872