### PR TITLE
test(cli): Phase 1 command-catalog helper + self-test + unit tests (RFC §12)

### DIFF
--- a/packages/cli/tests/integration/starter-kit/test-helpers/command-catalog.self.test.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/command-catalog.self.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Inline integration guard for `loadCommandCatalog()` — fires the instant the
+ * loader regresses into a silent-zero state (substring filter, wrong fixture
+ * path, yaml library change, etc.). Without this guard, jest would report
+ * "0 tests passed" when the parametrized grounding suite below it finds
+ * nothing to iterate — identical failure shape to issue #2863.
+ *
+ * Filename ends `.self.test.ts` (not `.self-test.ts`) so jest's `testMatch`
+ * (`<rootDir>/tests/**\/*.test.ts`) actually runs it. If the loader ever
+ * returns `[]` for any reason, these assertions fail loudly.
+ */
+import { describe, it, expect } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import {
+  loadCommandCatalog,
+  EXOCMD_COMMAND_CLASS_UUID,
+} from "./command-catalog.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES_ROOT = path.resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "starter-kit-fixtures",
+);
+
+const SUBMODULE_HYDRATED =
+  fs.existsSync(FIXTURES_ROOT) &&
+  fs.existsSync(path.join(FIXTURES_ROOT, "exocmd"));
+
+const describeOrSkip = SUBMODULE_HYDRATED ? describe : describe.skip;
+
+describeOrSkip("command-catalog loader (self-test)", () => {
+  const catalog = loadCommandCatalog();
+
+  // RFC v4 §4.0 authoritative count is 44. We assert >= 40 to absorb
+  // ±planned UX-RFC churn (duplicate-removal P0-1 brings it to 43; adding
+  // the 9th stub never reaches the catalog since filter is class-UUID).
+  it("discovers >= 40 Command instances from the starter-kit submodule", () => {
+    expect(catalog.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it("every entry resolves to the Command class UUID", () => {
+    expect(catalog.length).toBeGreaterThan(0);
+    for (const entry of catalog) {
+      expect(entry.classUuid).toBe(EXOCMD_COMMAND_CLASS_UUID);
+    }
+  });
+
+  it("every entry has a UUID-shaped `uid` and a non-empty label", () => {
+    const uuidRe =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    for (const entry of catalog) {
+      expect(entry.uid).toMatch(uuidRe);
+      expect(entry.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every entry's fixture file exists and contains the class UUID wikilink", () => {
+    const wikilink = `[[${EXOCMD_COMMAND_CLASS_UUID}]]`;
+    for (const entry of catalog) {
+      expect(fs.existsSync(entry.path)).toBe(true);
+      const content = fs.readFileSync(entry.path, "utf8");
+      expect(content).toContain(wikilink);
+    }
+  });
+
+  it("no duplicate UIDs in the catalog", () => {
+    const uids = catalog.map((c) => c.uid);
+    expect(new Set(uids).size).toBe(uids.length);
+  });
+});

--- a/packages/cli/tests/integration/starter-kit/test-helpers/command-catalog.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/command-catalog.ts
@@ -1,0 +1,278 @@
+/**
+ * Command catalog loader — Phase 1 integration helper.
+ *
+ * Scans starter-kit fixtures for `exocmd__Command` instances and returns a
+ * parametrization catalog for the test suite. Discovery contract:
+ *
+ *   - Filter by class UUID `790e5b16-251d-4556-96ac-e5c7f1429b2e`
+ *     (`exocmd__Command` class definition). Accept three wikilink forms:
+ *       1. `[[790e5b16-251d-4556-96ac-e5c7f1429b2e]]` — canonical UUID
+ *       2. `[[exocmd__Command]]` — resolved class label (legacy)
+ *       3. `"exocmd__Command"` — bare label (legacy; not currently emitted)
+ *
+ *     A substring match on `"exocmd__Command"` is forbidden — it silently
+ *     returns `[]` on UUID-wikilink assets (issue #2863 / PR #2873 class of
+ *     bug — see memory `feedback_cli_dyncommand_list_uuid_wikilink`).
+ *
+ *   - Exclude property-definition stubs: the 8 ontology assets under
+ *     `exocmd/` whose `exo__Instance_class` points to `exo__Property` /
+ *     `exo__ObjectProperty` (RFC v4 §4.0a). The class-UUID filter above
+ *     rejects these naturally (their `exo__Instance_class` is NOT
+ *     `[[790e5b16-...]]`).
+ *
+ *   - A reverse index `Map<classLabel, classUuid>` is built once at load
+ *     time by scanning every `.md` file under the fixture root for assets
+ *     that themselves declare `exo__Instance_class: [[8619c4fc-...]]`
+ *     (the `exo__Class` meta-class UUID). Used to resolve legacy label
+ *     wikilinks to their UUID.
+ *
+ * Phase 1 is the first helper shipped under this convention. RFC v4 §12
+ * gate requires a matching unit test at
+ * `tests/unit/test-helpers/command-catalog.test.ts` and an inline
+ * integration guard at
+ * `tests/integration/starter-kit/test-helpers/command-catalog.self.test.ts`.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import yaml from "js-yaml";
+
+/** `exocmd__Command` class UUID — RFC v4 header constant. */
+export const EXOCMD_COMMAND_CLASS_UUID =
+  "790e5b16-251d-4556-96ac-e5c7f1429b2e";
+
+/** `exo__Class` meta-class UUID — used to find class-definition files. */
+export const EXO_CLASS_META_UUID = "8619c4fc-64f1-4869-b17e-e34186cacca9";
+
+const COMMAND_CLASS_WIKILINK_UUID = `[[${EXOCMD_COMMAND_CLASS_UUID}]]`;
+const COMMAND_CLASS_WIKILINK_LABEL = "[[exocmd__Command]]";
+const COMMAND_CLASS_BARE_LABEL = "exocmd__Command";
+const EXO_CLASS_WIKILINK_UUID = `[[${EXO_CLASS_META_UUID}]]`;
+const EXO_CLASS_WIKILINK_LABEL = "[[exo__Class]]";
+
+/**
+ * Resolved Command instance. `raw` retains the full parsed frontmatter for
+ * downstream helpers (extract-target-class, predict-mutation) that need more
+ * than the top-level fields this contract exposes.
+ */
+export interface CommandCatalogEntry {
+  /** `exo__Asset_uid` — UUID of the command instance. */
+  uid: string;
+  /** `exo__Asset_label` — human-readable command name. */
+  label: string;
+  /** Absolute path to the fixture `.md` file. */
+  path: string;
+  /** Class UUID that matched (always `EXOCMD_COMMAND_CLASS_UUID`). */
+  classUuid: string;
+  /** `exocmd__Command_icon` if declared. */
+  icon?: string;
+  /** `exocmd__Command_category` if declared (e.g. `"creation"`, `"status"`). */
+  category?: string;
+  /** `exocmd__Command_grounding` wikilink if declared. */
+  grounding?: string;
+  /** `exocmd__Command_precondition` wikilink if declared. */
+  precondition?: string;
+  /** `exocmd__Command_targetClass` wikilink if declared (Phase 1 addendum). */
+  targetClass?: string;
+  /** Raw parsed frontmatter — ground truth for downstream helpers. */
+  raw: Record<string, unknown>;
+}
+
+export interface LoadOptions {
+  /** Override fixture root (default: `<worktree>/packages/starter-kit-fixtures`). */
+  fixturesRoot?: string;
+  /** DI hook for test isolation — list `.md` files under the fixture root. */
+  listMarkdownFiles?: (root: string) => string[];
+  /** DI hook — read a file as UTF-8 text. */
+  readFile?: (filePath: string) => string;
+  /** DI hook — called with `{ path, reason }` when an entry is skipped. */
+  onSkip?: (event: { path: string; reason: string; cause?: unknown }) => void;
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+/**
+ * Resolve the default fixtures root via `import.meta.url` — stable regardless
+ * of the jest cwd (phase0-benchmark uses cwd and is brittle).
+ *
+ * File location: `<repo>/packages/cli/tests/integration/starter-kit/test-helpers/command-catalog.ts`
+ * Target:        `<repo>/packages/starter-kit-fixtures`
+ */
+function defaultFixturesRoot(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "..", "..", "..", "..", "..", "starter-kit-fixtures");
+}
+
+function defaultListMarkdownFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".git")) {
+        continue;
+      }
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        out.push(full);
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+function defaultReadFile(filePath: string): string {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function extractFrontmatter(raw: string): Record<string, unknown> | null {
+  const match = FRONTMATTER_RE.exec(raw);
+  if (!match) return null;
+  const parsed = yaml.load(match[1]);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function toArray(value: unknown): unknown[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Does any value in `classField` match the `exocmd__Command` class?
+ * Accepts UUID wikilink, label wikilink, or bare label.
+ */
+function matchesCommandClass(classField: unknown, labelToUuid: Map<string, string>): boolean {
+  for (const raw of toArray(classField)) {
+    if (typeof raw !== "string") continue;
+    if (raw === COMMAND_CLASS_WIKILINK_UUID) return true;
+    if (raw === COMMAND_CLASS_WIKILINK_LABEL) return true;
+    if (raw === COMMAND_CLASS_BARE_LABEL) return true;
+    // Defence in depth: if a legacy fixture uses some other label wikilink
+    // that the reverse index resolves to the Command UUID, accept it.
+    const labelMatch = /^\[\[([^\]|]+)(?:\|[^\]]+)?\]\]$/.exec(raw);
+    if (labelMatch) {
+      const resolved = labelToUuid.get(labelMatch[1]);
+      if (resolved === EXOCMD_COMMAND_CLASS_UUID) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Is this asset an instance of `exo__Class` (i.e. a class definition)?
+ * Used to build the reverse index on first scan.
+ */
+function isClassDefinition(classField: unknown): boolean {
+  for (const raw of toArray(classField)) {
+    if (typeof raw !== "string") continue;
+    if (raw === EXO_CLASS_WIKILINK_UUID) return true;
+    if (raw === EXO_CLASS_WIKILINK_LABEL) return true;
+    if (raw === "exo__Class") return true;
+  }
+  return false;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Build a `Map<classLabel, classUuid>` reverse index by scanning every parsed
+ * frontmatter for assets whose `exo__Instance_class` is `exo__Class`. When
+ * two class definitions share a label, the first seen wins (deterministic
+ * under a sorted `files` input).
+ */
+export function buildClassLabelToUuid(
+  parsed: Array<{ path: string; fm: Record<string, unknown> }>,
+): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const { fm } of parsed) {
+    if (!isClassDefinition(fm["exo__Instance_class"])) continue;
+    const label = asString(fm["exo__Asset_label"]);
+    const uid = asString(fm["exo__Asset_uid"]);
+    if (!label || !uid) continue;
+    if (!index.has(label)) {
+      index.set(label, uid);
+    }
+  }
+  return index;
+}
+
+/**
+ * Load the command catalog from the starter-kit fixtures. Deterministically
+ * sorted by UID so parametrized test output is stable across machines.
+ */
+export function loadCommandCatalog(options: LoadOptions = {}): CommandCatalogEntry[] {
+  const fixturesRoot = options.fixturesRoot ?? defaultFixturesRoot();
+  const listFiles = options.listMarkdownFiles ?? defaultListMarkdownFiles;
+  const readFile = options.readFile ?? defaultReadFile;
+  const onSkip = options.onSkip ?? (() => {});
+
+  const files = listFiles(fixturesRoot).slice().sort();
+  const parsed: Array<{ path: string; fm: Record<string, unknown> }> = [];
+
+  for (const filePath of files) {
+    let raw: string;
+    try {
+      raw = readFile(filePath);
+    } catch (cause) {
+      onSkip({ path: filePath, reason: "read_error", cause });
+      continue;
+    }
+    let fm: Record<string, unknown> | null;
+    try {
+      fm = extractFrontmatter(raw);
+    } catch (cause) {
+      onSkip({ path: filePath, reason: "yaml_parse_error", cause });
+      continue;
+    }
+    if (!fm) {
+      onSkip({ path: filePath, reason: "no_frontmatter" });
+      continue;
+    }
+    parsed.push({ path: filePath, fm });
+  }
+
+  const labelToUuid = buildClassLabelToUuid(parsed);
+
+  const entries: CommandCatalogEntry[] = [];
+  for (const { path: filePath, fm } of parsed) {
+    if (!matchesCommandClass(fm["exo__Instance_class"], labelToUuid)) {
+      continue;
+    }
+    const uid = asString(fm["exo__Asset_uid"]);
+    const label = asString(fm["exo__Asset_label"]);
+    if (!uid || !label) {
+      onSkip({
+        path: filePath,
+        reason: uid ? "missing_label" : "missing_uid",
+      });
+      continue;
+    }
+    entries.push({
+      uid,
+      label,
+      path: filePath,
+      classUuid: EXOCMD_COMMAND_CLASS_UUID,
+      icon: asString(fm["exocmd__Command_icon"]),
+      category: asString(fm["exocmd__Command_category"]),
+      grounding: asString(fm["exocmd__Command_grounding"]),
+      precondition: asString(fm["exocmd__Command_precondition"]),
+      targetClass: asString(fm["exocmd__Command_targetClass"]),
+      raw: fm,
+    });
+  }
+
+  entries.sort((a, b) => a.uid.localeCompare(b.uid));
+  return entries;
+}

--- a/packages/cli/tests/unit/test-helpers/command-catalog.test.ts
+++ b/packages/cli/tests/unit/test-helpers/command-catalog.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Unit tests for the integration-layer `command-catalog.ts` helper.
+ *
+ * RFC v4 §12 PR-readiness gate: every helper under
+ * `tests/integration/**\/test-helpers/` MUST have a matching unit test under
+ * `tests/unit/**\/test-helpers/`. This is the pair for
+ * `tests/integration/starter-kit/test-helpers/command-catalog.ts`.
+ *
+ * Strategy: dependency injection via `LoadOptions` (in-memory file list +
+ * reader). Avoids `jest.unstable_mockModule` — see memory
+ * `feedback_jest_esm_mock_named_exports` for the named-export trap.
+ */
+import { describe, it, expect, jest } from "@jest/globals";
+import * as fsNode from "fs";
+import {
+  loadCommandCatalog,
+  buildClassLabelToUuid,
+  EXOCMD_COMMAND_CLASS_UUID,
+  EXO_CLASS_META_UUID,
+} from "../../integration/starter-kit/test-helpers/command-catalog.js";
+
+// ---------------------------------------------------------------------------
+// Fixture factory — builds in-memory frontmatter so every test case is
+// self-describing and no submodule access is required.
+// ---------------------------------------------------------------------------
+
+interface InMemoryFixture {
+  [path: string]: string;
+}
+
+function fm(body: Record<string, unknown>): string {
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(body)) {
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      for (const v of value) {
+        lines.push(`  - "${String(v).replace(/"/g, '\\"')}"`);
+      }
+    } else if (typeof value === "string") {
+      lines.push(`${key}: "${value.replace(/"/g, '\\"')}"`);
+    } else {
+      lines.push(`${key}: ${String(value)}`);
+    }
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+function commandFrontmatter(
+  uid: string,
+  label: string,
+  classRef: string,
+  extras: Record<string, unknown> = {},
+): string {
+  return fm({
+    exo__Asset_uid: uid,
+    exo__Asset_label: label,
+    exo__Instance_class: [classRef],
+    ...extras,
+  });
+}
+
+function makeOptions(files: InMemoryFixture) {
+  return {
+    fixturesRoot: "/mock-fixtures",
+    listMarkdownFiles: () => Object.keys(files),
+    readFile: (p: string) => {
+      if (!(p in files)) {
+        throw new Error(`ENOENT: mock has no entry for ${p}`);
+      }
+      return files[p];
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildClassLabelToUuid
+// ---------------------------------------------------------------------------
+
+describe("buildClassLabelToUuid", () => {
+  it("indexes class definitions by label → uid", () => {
+    const parsed = [
+      {
+        path: "/a.md",
+        fm: {
+          exo__Asset_label: "exocmd__Command",
+          exo__Asset_uid: EXOCMD_COMMAND_CLASS_UUID,
+          exo__Instance_class: [`[[${EXO_CLASS_META_UUID}]]`],
+        },
+      },
+      {
+        path: "/b.md",
+        fm: {
+          exo__Asset_label: "ems__Task",
+          exo__Asset_uid: "task-uid",
+          exo__Instance_class: [`[[${EXO_CLASS_META_UUID}]]`],
+        },
+      },
+    ];
+    const index = buildClassLabelToUuid(parsed);
+    expect(index.get("exocmd__Command")).toBe(EXOCMD_COMMAND_CLASS_UUID);
+    expect(index.get("ems__Task")).toBe("task-uid");
+    expect(index.size).toBe(2);
+  });
+
+  it("accepts `[[exo__Class]]` label wikilink and bare `exo__Class`", () => {
+    const parsed = [
+      {
+        path: "/a.md",
+        fm: {
+          exo__Asset_label: "A",
+          exo__Asset_uid: "a",
+          exo__Instance_class: "[[exo__Class]]",
+        },
+      },
+      {
+        path: "/b.md",
+        fm: {
+          exo__Asset_label: "B",
+          exo__Asset_uid: "b",
+          exo__Instance_class: "exo__Class",
+        },
+      },
+    ];
+    const index = buildClassLabelToUuid(parsed);
+    expect(index.get("A")).toBe("a");
+    expect(index.get("B")).toBe("b");
+  });
+
+  it("keeps the first-seen uid when a label collides (deterministic)", () => {
+    const parsed = [
+      {
+        path: "/a.md",
+        fm: {
+          exo__Asset_label: "Dup",
+          exo__Asset_uid: "first",
+          exo__Instance_class: [`[[${EXO_CLASS_META_UUID}]]`],
+        },
+      },
+      {
+        path: "/b.md",
+        fm: {
+          exo__Asset_label: "Dup",
+          exo__Asset_uid: "second",
+          exo__Instance_class: [`[[${EXO_CLASS_META_UUID}]]`],
+        },
+      },
+    ];
+    expect(buildClassLabelToUuid(parsed).get("Dup")).toBe("first");
+  });
+
+  it("ignores non-class assets", () => {
+    const parsed = [
+      {
+        path: "/a.md",
+        fm: {
+          exo__Asset_label: "NotAClass",
+          exo__Asset_uid: "x",
+          exo__Instance_class: [`[[${EXOCMD_COMMAND_CLASS_UUID}]]`],
+        },
+      },
+    ];
+    expect(buildClassLabelToUuid(parsed).size).toBe(0);
+  });
+
+  it("skips class defs missing label or uid", () => {
+    const parsed = [
+      {
+        path: "/a.md",
+        fm: {
+          exo__Asset_label: "Only label",
+          exo__Instance_class: [`[[${EXO_CLASS_META_UUID}]]`],
+        },
+      },
+      {
+        path: "/b.md",
+        fm: {
+          exo__Asset_uid: "only-uid",
+          exo__Instance_class: [`[[${EXO_CLASS_META_UUID}]]`],
+        },
+      },
+    ];
+    expect(buildClassLabelToUuid(parsed).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadCommandCatalog — happy paths
+// ---------------------------------------------------------------------------
+
+describe("loadCommandCatalog — UUID wikilink filter", () => {
+  it("returns Commands referenced by canonical class UUID wikilink", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/exocmd/cmd-a.md": commandFrontmatter(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "Command A",
+        `[[${EXOCMD_COMMAND_CLASS_UUID}]]`,
+        { exocmd__Command_icon: "star", exocmd__Command_category: "creation" },
+      ),
+      "/mock-fixtures/exocmd/cmd-b.md": commandFrontmatter(
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        "Command B",
+        `[[${EXOCMD_COMMAND_CLASS_UUID}]]`,
+      ),
+    };
+    const catalog = loadCommandCatalog(makeOptions(files));
+    expect(catalog.length).toBe(2);
+    expect(catalog.map((c) => c.uid)).toEqual([
+      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    ]);
+    expect(catalog[0].icon).toBe("star");
+    expect(catalog[0].category).toBe("creation");
+  });
+
+  it("returns Commands referenced by resolved label wikilink", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/ontology.md": fm({
+        exo__Asset_uid: EXOCMD_COMMAND_CLASS_UUID,
+        exo__Asset_label: "exocmd__Command",
+        exo__Instance_class: [`[[${EXO_CLASS_META_UUID}]]`],
+      }),
+      "/mock-fixtures/exocmd/cmd-label.md": commandFrontmatter(
+        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        "Label-form command",
+        "[[exocmd__Command]]",
+      ),
+    };
+    const catalog = loadCommandCatalog(makeOptions(files));
+    expect(catalog.map((c) => c.uid)).toEqual([
+      "cccccccc-cccc-cccc-cccc-cccccccccccc",
+    ]);
+  });
+
+  it("returns Commands referenced by bare label string", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/exocmd/cmd.md": commandFrontmatter(
+        "dddddddd-dddd-dddd-dddd-dddddddddddd",
+        "Bare-label command",
+        "exocmd__Command",
+      ),
+    };
+    const catalog = loadCommandCatalog(makeOptions(files));
+    expect(catalog.length).toBe(1);
+  });
+
+  it("resolves arbitrary legacy class label via reverse index", () => {
+    // Simulate a future-legacy shape: an older class label that still
+    // points to the Command class UUID in the ontology table.
+    const files: InMemoryFixture = {
+      "/mock-fixtures/ontology.md": fm({
+        exo__Asset_uid: EXOCMD_COMMAND_CLASS_UUID,
+        exo__Asset_label: "LegacyCommandLabel",
+        exo__Instance_class: [`[[${EXO_CLASS_META_UUID}]]`],
+      }),
+      "/mock-fixtures/exocmd/cmd.md": commandFrontmatter(
+        "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+        "Legacy label command",
+        "[[LegacyCommandLabel]]",
+      ),
+    };
+    const catalog = loadCommandCatalog(makeOptions(files));
+    expect(catalog.length).toBe(1);
+  });
+
+  it("handles a single-value (non-array) `exo__Instance_class`", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/exocmd/cmd.md": fm({
+        exo__Asset_uid: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        exo__Asset_label: "Scalar class",
+        exo__Instance_class: `[[${EXOCMD_COMMAND_CLASS_UUID}]]`,
+      }),
+    };
+    const catalog = loadCommandCatalog(makeOptions(files));
+    expect(catalog.length).toBe(1);
+  });
+
+  it("sorts the catalog deterministically by uid", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/exocmd/zzz.md": commandFrontmatter(
+        "22222222-2222-2222-2222-222222222222",
+        "Z",
+        `[[${EXOCMD_COMMAND_CLASS_UUID}]]`,
+      ),
+      "/mock-fixtures/exocmd/aaa.md": commandFrontmatter(
+        "11111111-1111-1111-1111-111111111111",
+        "A",
+        `[[${EXOCMD_COMMAND_CLASS_UUID}]]`,
+      ),
+    };
+    const catalog = loadCommandCatalog(makeOptions(files));
+    expect(catalog.map((c) => c.uid)).toEqual([
+      "11111111-1111-1111-1111-111111111111",
+      "22222222-2222-2222-2222-222222222222",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadCommandCatalog — exclusions
+// ---------------------------------------------------------------------------
+
+describe("loadCommandCatalog — exclusions", () => {
+  it("returns [] for an empty fixture set (does not crash)", () => {
+    expect(loadCommandCatalog(makeOptions({}))).toEqual([]);
+  });
+
+  it("excludes property-definition stubs that only reference Command via domain", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/exocmd/prop.md": fm({
+        exo__Asset_uid: "025fafe0-a42b-4b39-b917-ae8c3b2b1f59",
+        exo__Asset_label: "exocmd__Command_confirmMessage",
+        exo__Instance_class: ["[[30d63ce4-e574-456c-8de8-2bf1a53688c1]]"],
+        exo__Property_domain: `[[${EXOCMD_COMMAND_CLASS_UUID}]]`,
+      }),
+      "/mock-fixtures/exocmd/real-cmd.md": commandFrontmatter(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "Real",
+        `[[${EXOCMD_COMMAND_CLASS_UUID}]]`,
+      ),
+    };
+    const catalog = loadCommandCatalog(makeOptions(files));
+    expect(catalog.map((c) => c.label)).toEqual(["Real"]);
+  });
+
+  it("excludes non-Command classes (e.g. inbox__Asset)", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/inbox/asset.md": commandFrontmatter(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "Inbox asset",
+        "[[inbox__Asset]]",
+      ),
+    };
+    expect(loadCommandCatalog(makeOptions(files))).toEqual([]);
+  });
+
+  it("skips files with no frontmatter and notifies onSkip", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/body-only.md": "# Heading\n\nNo frontmatter here.\n",
+    };
+    const onSkip = jest.fn();
+    const catalog = loadCommandCatalog({ ...makeOptions(files), onSkip });
+    expect(catalog).toEqual([]);
+    expect(onSkip).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "no_frontmatter" }),
+    );
+  });
+
+  it("skips malformed YAML without crashing", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/broken.md":
+        "---\nexo__Asset_uid: x\n  bad: indent: here\n---\n",
+      "/mock-fixtures/ok.md": commandFrontmatter(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "Survivor",
+        `[[${EXOCMD_COMMAND_CLASS_UUID}]]`,
+      ),
+    };
+    const onSkip = jest.fn();
+    const catalog = loadCommandCatalog({ ...makeOptions(files), onSkip });
+    expect(catalog.map((c) => c.label)).toEqual(["Survivor"]);
+    expect(onSkip).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "yaml_parse_error" }),
+    );
+  });
+
+  it("skips read errors and notifies onSkip", () => {
+    const onSkip = jest.fn();
+    const catalog = loadCommandCatalog({
+      fixturesRoot: "/mock-fixtures",
+      listMarkdownFiles: () => ["/mock-fixtures/vanished.md"],
+      readFile: () => {
+        throw new Error("ENOENT");
+      },
+      onSkip,
+    });
+    expect(catalog).toEqual([]);
+    expect(onSkip).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "read_error" }),
+    );
+  });
+
+  it("skips entries missing uid or label", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/no-uid.md": fm({
+        exo__Asset_label: "No UID",
+        exo__Instance_class: [`[[${EXOCMD_COMMAND_CLASS_UUID}]]`],
+      }),
+      "/mock-fixtures/no-label.md": fm({
+        exo__Asset_uid: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        exo__Instance_class: [`[[${EXOCMD_COMMAND_CLASS_UUID}]]`],
+      }),
+    };
+    const onSkip = jest.fn();
+    const catalog = loadCommandCatalog({ ...makeOptions(files), onSkip });
+    expect(catalog).toEqual([]);
+    const reasons = onSkip.mock.calls.map(
+      (c) => (c[0] as { reason: string }).reason,
+    );
+    expect(reasons).toContain("missing_uid");
+    expect(reasons).toContain("missing_label");
+  });
+
+  it("exposes `raw` frontmatter so downstream helpers can read custom keys", () => {
+    const files: InMemoryFixture = {
+      "/mock-fixtures/exocmd/cmd.md": commandFrontmatter(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "Custom",
+        `[[${EXOCMD_COMMAND_CLASS_UUID}]]`,
+        { custom__Field: "custom-value" },
+      ),
+    };
+    const [entry] = loadCommandCatalog(makeOptions(files));
+    expect(entry.raw["custom__Field"]).toBe("custom-value");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default resolution paths — light smoke (full path coverage comes from the
+// integration self-test hitting the real submodule).
+// ---------------------------------------------------------------------------
+
+describe("loadCommandCatalog — defaults", () => {
+  it("uses defaultListMarkdownFiles when `listMarkdownFiles` omitted", () => {
+    // The default walker reads from disk; point it at an empty tmp dir via
+    // fixturesRoot to exercise the directory-walk branch without touching
+    // the submodule.
+    const tmp = "/tmp/command-catalog-empty-" + Date.now();
+    fsNode.mkdirSync(tmp, { recursive: true });
+    try {
+      const catalog = loadCommandCatalog({ fixturesRoot: tmp });
+      expect(catalog).toEqual([]);
+    } finally {
+      fsNode.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("default walker skips non-existent roots without throwing", () => {
+    const catalog = loadCommandCatalog({
+      fixturesRoot: "/definitely-does-not-exist-" + Date.now(),
+    });
+    expect(catalog).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

First helper shipped in RFC-CI-Tests Phase 1 (parent task `58b1d922-…`). Introduces `loadCommandCatalog()` + its RFC §12 gate unit tests + its integration-layer self-test against the real submodule.

- `packages/cli/tests/integration/starter-kit/test-helpers/command-catalog.ts` — class-UUID-based discovery (RFC §3.3 corrected); accepts UUID wikilink, label wikilink, bare label, and arbitrary legacy labels resolved via reverse ontology index. Pure DI helper — no hidden singletons.
- `…/test-helpers/command-catalog.self.test.ts` — inline integration guard asserting catalog size ≥ 40 against the real submodule and that every entry's fixture actually contains the Command class-UUID wikilink (defends against the issue #2863 class of regression — silent-zero from substring-filter).
- `packages/cli/tests/unit/test-helpers/command-catalog.test.ts` — RFC §12 PR-readiness gate. Uses DI (`LoadOptions`) to avoid `jest.unstable_mockModule` pitfalls (memory `feedback_jest_esm_mock_named_exports`).

### Verification

- Catalog size against live submodule: **44 Commands** (matches RFC v4 §4.0 authoritative SPARQL count).
- Helper coverage measured locally via `jest --coverage --collectCoverageFrom=tests/integration/starter-kit/test-helpers/command-catalog.ts`:

| Metric | Value | §9.1 target |
|---|---|---|
| Statements | **96.22%** | — |
| Branches | **93.05%** | ≥ 80% |
| Functions | **100%** | — |
| Lines | **98.91%** | — |

- `npm test` in `packages/cli`: 1375 passed / 40 skipped / 0 failed.

### RFC §12 gate checklist

- [x] Every helper added under `tests/integration/**/test-helpers/` has a matching unit test in `tests/unit/**/test-helpers/`.
- [x] Helper coverage ≥ 80% branches (93.05%).
- [x] Self-test asserts ≥ 40 discovered Commands.
- [x] `collectCoverageFrom` untouched — helper sits in `tests/`, default `src/**/*.ts` globus excludes it, so no drag on the 65% CI floor.

### §12.4 path-convention drift

RFC v4 flagged `tests/integration/**/test-helpers/` vs §9.1's `tests/integration/starter-kit/` drift as a Phase 1 follow-up. This PR **adopts the §12 convention**: `tests/integration/starter-kit/test-helpers/` + `tests/unit/test-helpers/`. Non-blocking RFC minor revision TODO for §9.1 text alignment.

### Filename divergence from RFC §3.3 snippet

The RFC illustrative snippet uses `command-catalog.self-test.ts`. That filename does **not** match jest's `testMatch: ["<rootDir>/tests/**/*.test.ts"]` — it would be silently ignored, turning the self-test itself into the silent-zero class of bug it is trying to prevent. This PR ships `command-catalog.self.test.ts` instead. Will flag in Phase 1 retrospective for an RFC minor update.

## Test plan

- [x] Unit suite (`packages/cli/tests/unit/test-helpers/command-catalog.test.ts`) — 21 tests, all edge cases covered
- [x] Integration self-test against real submodule (`…/command-catalog.self.test.ts`) — 5 tests, all green
- [x] Full CLI test suite (`npm test -w @kitelev/exocortex-cli`) — 1375 green
- [x] Helper coverage ≥ 80% branches (93.05% measured)
- [ ] Pre-merge CI green (8 mandatory checks)
- [ ] Auto Release succeeds post-merge

## Related

- Parent project: `9b4f1f59-d771-4c1b-b8e4-feb06984c06c` (RFC-CI-Tests Phase 1)
- RFC v4: `/Users/kitelev/Developer/rfc-ci-button-testing-2026-04-20.md`
- Fixture access wiring (PR #2886): `docs/fixture-access.md`
- Downstream tasks depending on this catalog: `6208967d` (YAML contract-test), `97e3f5ab` (5-cmd pilot + CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)