### PR TITLE
test(cli): YAML contract test + baseline snapshot (RFC Phase 1 Complement 2)

### DIFF
--- a/packages/cli/tests/integration/starter-kit/exocmd-contract.baseline.json
+++ b/packages/cli/tests/integration/starter-kit/exocmd-contract.baseline.json
@@ -1,0 +1,39 @@
+{
+  "_doc": [
+    "Known violators frozen at task 6208967d commit (baseline ratchet).",
+    "New violations must fail the contract — add the offending UUID here AND",
+    "open an issue tracking the fix. Fixes update the baseline (remove the UUID).",
+    "",
+    "RFC v4 §7.4 duplicate-removal P0-1 will shrink AC3 to []; UX RFC P1-3/P1-4",
+    "will shrink AC4/AC5. Until then the list below is the lock.",
+    "",
+    "To clear/update a baseline: remove resolved UUIDs, commit message MUST",
+    "reference the resolving PR so reviewers can verify the shrink.",
+    ""
+  ],
+  "AC3_duplicateCategoryLabel": {
+    "rationale": "RFC §7.4 P0-1 schedules removal of one of the two `Remove Start Timestamp` commands. `a7d3573a-...` is the canonical RFC-009 reference example (full confirmMessage+successMessage, top-level `exocmd/`); `9f33ecdd-...` is the later-added stub under `exocmd/maintenance/`. The suite flags the whole dup group; when P0-1 removes one entry the group collapses and this array becomes `[]`.",
+    "entries": [
+      "9f33ecdd-8bf2-47b3-b042-d03760b0b383",
+      "a7d3573a-bb3a-4068-9792-d715e4b104b2"
+    ]
+  },
+  "AC4_confirmMessageOnNonDestructive": {
+    "rationale": "UX RFC P1-3 removes 3 confirmMessages. Pending merge; current violators frozen. Convert to Task/Project are excluded — `isDestructive` classifies `creation` + /^Convert /i as destructive per UX RFC P1-3 canonical list (Delete, Convert class, Archive, Rename-to-UID).",
+    "entries": [
+      "843d3fda-6ed4-49d1-bee7-304514c36a4b",
+      "22a7ceb9-5d76-49d3-8d15-b3796e3d7531",
+      "6bc86da6-4e58-4441-bc9b-20d2097451df",
+      "91beb9e5-87bd-4ded-ac05-47f8e6473e40",
+      "c29ea05e-f23b-4fde-b5c9-822b31e713bf"
+    ]
+  },
+  "AC5_missingSuccessMessage": {
+    "rationale": "UX RFC P1-4 adds 2 successMessages. Pending merge; current missing frozen.",
+    "entries": [
+      "652c85ea-c22d-4183-b718-bdf58a94c102",
+      "9f33ecdd-8bf2-47b3-b042-d03760b0b383",
+      "fcae3280-9e24-445c-93aa-9bc9df7e3dea"
+    ]
+  }
+}

--- a/packages/cli/tests/integration/starter-kit/exocmd-contract.test.ts
+++ b/packages/cli/tests/integration/starter-kit/exocmd-contract.test.ts
@@ -1,0 +1,423 @@
+/**
+ * RFC-CI-Tests Phase 1 Complement 2 — YAML contract test.
+ *
+ * Static-guard suite. Reads the pinned `starter-kit-fixtures` submodule and
+ * asserts 8 invariants over the `exocmd__*` assets (Command, Binding,
+ * Grounding, Precondition). No subprocess, no runtime — pure fs + yaml.
+ *
+ * Placement note (RFC §7.3 divergence — user-approved):
+ * ----------------------------------------------------
+ * RFC v4 §7.3 literally specifies
+ *   `packages/obsidian-plugin/tests/unit/infrastructure/exocmd-contract.test.ts`
+ * but the catalog helper shipped in 58b1d922 (PR #2887) lives in
+ *   `packages/cli/tests/integration/starter-kit/test-helpers/command-catalog.ts`
+ * and it uses ESM-only features (`import.meta.url`, `.js` extension imports).
+ * Plugin jest runs in CommonJS ts-jest jsdom — it cannot import the catalog
+ * helper without duplicating the loader (which would reintroduce the silent-
+ * zero class of bug this contract is designed to prevent). Orchestrator
+ * approved placement in CLI package as symmetric with 58b1d922 + path-drift
+ * flag V4-2 resolution path. RFC v5 footnote pending.
+ *
+ * Baseline-lock / ratchet strategy:
+ * ---------------------------------
+ * Three ACs (3/4/5) have known non-zero violators in the fixtures today, each
+ * scheduled for resolution by UX RFC Phase 0/P1-3/P1-4. Hard-failing them now
+ * would block every Phase 1 PR. Instead:
+ *   - The baseline file `./exocmd-contract.baseline.json` freezes the exact
+ *     set of violator UUIDs.
+ *   - New violations fail the contract (added UUIDs).
+ *   - Fixes update the baseline (removed UUIDs). PR template captures this.
+ *
+ * Any baseline drift — extra violators, removed violators, or the same violator
+ * count with different UUIDs — must show up as a diff. Never silently.
+ */
+import { describe, it, expect } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import yaml from "js-yaml";
+import {
+  EXOCMD_COMMAND_CLASS_UUID,
+  EXO_CLASS_META_UUID,
+  loadCommandCatalog,
+  type CommandCatalogEntry,
+} from "./test-helpers/command-catalog.js";
+
+/* ------------------------------------------------------------------------- */
+/* Class UUIDs — single source of truth inside the suite.                    */
+/* ------------------------------------------------------------------------- */
+
+const EXOCMD_BINDING_CLASS_UUID = "3677039a-a5a8-4402-9a07-f8f18fe384ad";
+const EXOCMD_GROUNDING_CLASS_UUID = "11579feb-2e42-491c-af59-b89b1129a539";
+const EXOCMD_PRECONDITION_CLASS_UUID = "15d119b5-9636-431e-9e91-1f140107d059";
+
+/* ------------------------------------------------------------------------- */
+/* Fixture discovery — same walk pattern as command-catalog.ts               */
+/* ------------------------------------------------------------------------- */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES_ROOT = path.resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "starter-kit-fixtures",
+);
+const SUBMODULE_HYDRATED =
+  fs.existsSync(FIXTURES_ROOT) && fs.existsSync(path.join(FIXTURES_ROOT, "exocmd"));
+
+const FM_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+const UUID_ANY_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface ParsedAsset {
+  path: string;
+  fm: Record<string, unknown>;
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (e.name === "node_modules" || e.name.startsWith(".git")) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full, out);
+    else if (e.isFile() && e.name.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+function parseFm(raw: string): Record<string, unknown> | null {
+  const m = FM_RE.exec(raw);
+  if (!m) return null;
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(m[1]);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function toArray(value: unknown): unknown[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function extractWikilinkUid(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const m = /^\[\[([^\]|]+)(?:\|[^\]]+)?\]\]$/.exec(raw);
+  return m ? m[1] : undefined;
+}
+
+function hasClassUuid(fm: Record<string, unknown>, targetUuid: string): boolean {
+  for (const raw of toArray(fm["exo__Instance_class"])) {
+    if (extractWikilinkUid(raw) === targetUuid) return true;
+  }
+  return false;
+}
+
+function loadAllAssets(): ParsedAsset[] {
+  const out: ParsedAsset[] = [];
+  if (!SUBMODULE_HYDRATED) return out;
+  for (const filePath of walk(FIXTURES_ROOT).sort()) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    const fm = parseFm(raw);
+    if (fm) out.push({ path: filePath, fm });
+  }
+  return out;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Baseline snapshot                                                         */
+/* ------------------------------------------------------------------------- */
+
+interface BaselineBlock {
+  rationale: string;
+  entries: string[];
+}
+interface Baseline {
+  AC3_duplicateCategoryLabel: BaselineBlock;
+  AC4_confirmMessageOnNonDestructive: BaselineBlock;
+  AC5_missingSuccessMessage: BaselineBlock;
+}
+
+function loadBaseline(): Baseline {
+  const text = fs.readFileSync(
+    path.join(HERE, "exocmd-contract.baseline.json"),
+    "utf8",
+  );
+  return JSON.parse(text) as Baseline;
+}
+
+/* ------------------------------------------------------------------------- */
+/* AC4 destructive policy                                                    */
+/*                                                                           */
+/* Per UX RFC P1-3: destructive operations are Archive, Convert-class,       */
+/* Remove/Delete, Rename-to-UID. Policy check uses an explicit predicate     */
+/* (category + label prefix) so it survives category renames (criticality    */
+/* → zone, UX RFC P0-2). Baseline covers Phase 1 entry state; any command    */
+/* added with a new destructive-shaped label and *no* confirmMessage is a    */
+/* policy violation the maintainer resolves by either adding the message or  */
+/* adjusting the predicate.                                                  */
+/* ------------------------------------------------------------------------- */
+function isDestructive(category: string | undefined, label: string): boolean {
+  if (!category) return false;
+  if (category === "maintenance" || category === "maintenance-complex") {
+    // Maintenance is broadly destructive; the confirm requirement is the
+    // default here. Per-label exceptions live in the baseline.
+    return true;
+  }
+  if (category === "creation" && /^Convert /i.test(label)) {
+    // Convert to Task / Convert to Project re-classify the asset — destructive
+    // by effect, even though the category is creation.
+    return true;
+  }
+  return false;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Suite                                                                     */
+/* ------------------------------------------------------------------------- */
+
+const describeOrSkip = SUBMODULE_HYDRATED ? describe : describe.skip;
+
+describeOrSkip("exocmd contract (YAML static guard, RFC Phase 1 Complement 2)", () => {
+  const allAssets = loadAllAssets();
+  const commandCatalog: CommandCatalogEntry[] = loadCommandCatalog();
+
+  const bindings = allAssets.filter(({ fm }) =>
+    hasClassUuid(fm, EXOCMD_BINDING_CLASS_UUID),
+  );
+  const groundings = allAssets.filter(({ fm }) =>
+    hasClassUuid(fm, EXOCMD_GROUNDING_CLASS_UUID),
+  );
+  const preconditions = allAssets.filter(({ fm }) =>
+    hasClassUuid(fm, EXOCMD_PRECONDITION_CLASS_UUID),
+  );
+  const classDefs = allAssets.filter(({ fm }) =>
+    hasClassUuid(fm, EXO_CLASS_META_UUID),
+  );
+
+  const commandByUid = new Map<string, CommandCatalogEntry>();
+  for (const c of commandCatalog) commandByUid.set(c.uid, c);
+
+  const groundingUids = new Set<string>();
+  for (const { fm } of groundings) {
+    const uid = asString(fm["exo__Asset_uid"]);
+    if (uid) groundingUids.add(uid);
+  }
+
+  const classUids = new Set<string>();
+  for (const { fm } of classDefs) {
+    const uid = asString(fm["exo__Asset_uid"]);
+    if (uid) classUids.add(uid);
+  }
+
+  const baseline = loadBaseline();
+
+  /* Silent-zero guard for the suite itself — if discovery is broken, every
+   * describe below would vacuously pass. This mirrors the command-catalog
+   * self-test spirit for the other classes too. */
+  it("discovery finds a non-trivial number of each asset kind", () => {
+    expect(commandCatalog.length).toBeGreaterThanOrEqual(40);
+    expect(bindings.length).toBeGreaterThanOrEqual(40);
+    expect(groundings.length).toBeGreaterThanOrEqual(40);
+    expect(preconditions.length).toBeGreaterThanOrEqual(20);
+    expect(classDefs.length).toBeGreaterThanOrEqual(20);
+  });
+
+  describe("AC1: every Command has ≥ 1 Binding", () => {
+    it("no orphan commands", () => {
+      const bindingsByCmd = new Map<string, string[]>();
+      for (const { fm, path: bp } of bindings) {
+        const cmdUid = extractWikilinkUid(fm["exocmd__CommandBinding_command"]);
+        if (!cmdUid) continue;
+        const list = bindingsByCmd.get(cmdUid) ?? [];
+        list.push(bp);
+        bindingsByCmd.set(cmdUid, list);
+      }
+      const orphans = commandCatalog
+        .filter((c) => !bindingsByCmd.has(c.uid))
+        .map((c) => `${c.uid} "${c.label}"`);
+      expect(orphans).toEqual([]);
+    });
+  });
+
+  describe("AC2: every Binding → existing Command, and that Command has a resolvable Grounding", () => {
+    it("no dangling binding references and every bound command has a grounding present in the fixtures", () => {
+      const violations: string[] = [];
+      for (const { fm, path: bp } of bindings) {
+        const cmdRef = fm["exocmd__CommandBinding_command"];
+        const cmdUid = extractWikilinkUid(cmdRef);
+        const rel = path.relative(FIXTURES_ROOT, bp);
+        if (!cmdUid) {
+          violations.push(`binding ${rel}: malformed command ref ${JSON.stringify(cmdRef)}`);
+          continue;
+        }
+        const cmd = commandByUid.get(cmdUid);
+        if (!cmd) {
+          violations.push(`binding ${rel}: command [[${cmdUid}]] not in catalog`);
+          continue;
+        }
+        const groundingRef = cmd.raw["exocmd__Command_grounding"];
+        if (!groundingRef) {
+          violations.push(
+            `binding ${rel} → command "${cmd.label}" (${cmd.uid}): missing exocmd__Command_grounding`,
+          );
+          continue;
+        }
+        const groundingUid = extractWikilinkUid(groundingRef);
+        if (!groundingUid) {
+          violations.push(
+            `binding ${rel} → command "${cmd.label}" (${cmd.uid}): malformed grounding ref ${JSON.stringify(groundingRef)}`,
+          );
+          continue;
+        }
+        if (!groundingUids.has(groundingUid)) {
+          violations.push(
+            `binding ${rel} → command "${cmd.label}" (${cmd.uid}): grounding [[${groundingUid}]] not found in fixtures`,
+          );
+        }
+      }
+      expect(violations).toEqual([]);
+    });
+  });
+
+  describe("AC3: no duplicate (category, label) tuples across Commands", () => {
+    it("known dup baseline — locked until RFC §7.4 P0-1 removes the dup", () => {
+      /* Return *every* UID that participates in a `(category, label)` collision
+       * (not just "second" per scan order). Consequence: when RFC §7.4 P0-1
+       * deletes one of the two `Remove Start Timestamp` fixtures, the group
+       * size drops to 1 and the array collapses to `[]` — the baseline then
+       * just needs its entries cleared. If the test instead flagged "second",
+       * deleting the canonical one would leave the other in the baseline
+       * forever as a phantom violation. */
+      const byKey = new Map<string, CommandCatalogEntry[]>();
+      for (const c of commandCatalog) {
+        const key = `${c.category ?? "(none)"}|${c.label}`;
+        const list = byKey.get(key) ?? [];
+        list.push(c);
+        byKey.set(key, list);
+      }
+      const dupUids: string[] = [];
+      for (const group of byKey.values()) {
+        if (group.length > 1) {
+          for (const c of group) dupUids.push(c.uid);
+        }
+      }
+      dupUids.sort();
+      const expected = [...baseline.AC3_duplicateCategoryLabel.entries].sort();
+      expect(dupUids).toEqual(expected);
+    });
+  });
+
+  describe("AC4: confirmMessage only on destructive categories (UX RFC P1-3)", () => {
+    it("violator set matches baseline exactly", () => {
+      const violators: string[] = [];
+      for (const c of commandCatalog) {
+        const confirm = c.raw["exocmd__Command_confirmMessage"];
+        if (confirm === undefined || confirm === null || confirm === "") continue;
+        if (!isDestructive(c.category, c.label)) {
+          violators.push(c.uid);
+        }
+      }
+      violators.sort();
+      const expected = [...baseline.AC4_confirmMessageOnNonDestructive.entries].sort();
+      expect(violators).toEqual(expected);
+    });
+  });
+
+  describe("AC5: successMessage required on every Command (UX RFC P1-4)", () => {
+    it("missing set matches baseline exactly", () => {
+      const missing: string[] = [];
+      for (const c of commandCatalog) {
+        const msg = c.raw["exocmd__Command_successMessage"];
+        if (msg === undefined || msg === null || msg === "") missing.push(c.uid);
+      }
+      missing.sort();
+      const expected = [...baseline.AC5_missingSuccessMessage.entries].sort();
+      expect(missing).toEqual(expected);
+    });
+  });
+
+  describe("AC6: every Command's exo__Asset_uid is a valid UUID-v4", () => {
+    it("no non-UUID or non-v4 command uids", () => {
+      const bad: Array<{ uid: string; why: string }> = [];
+      for (const c of commandCatalog) {
+        if (!UUID_ANY_RE.test(c.uid)) {
+          bad.push({ uid: c.uid, why: "not UUID-shaped" });
+          continue;
+        }
+        if (!UUID_V4_RE.test(c.uid)) {
+          bad.push({ uid: c.uid, why: "not v4 (version digit ≠ 4 or variant ≠ 8-b)" });
+        }
+      }
+      expect(bad).toEqual([]);
+    });
+  });
+
+  describe("AC7: every referenced class UUID resolves to an ontology class definition", () => {
+    it("no dangling exo__Instance_class wikilinks across Commands / Bindings / Groundings / Preconditions", () => {
+      const violations: string[] = [];
+      const check = (asset: ParsedAsset, kind: string): void => {
+        for (const raw of toArray(asset.fm["exo__Instance_class"])) {
+          const uid = extractWikilinkUid(raw);
+          if (!uid) continue;
+          if (!classUids.has(uid)) {
+            violations.push(
+              `${kind} ${path.relative(FIXTURES_ROOT, asset.path)}: class [[${uid}]] not found`,
+            );
+          }
+        }
+      };
+      for (const c of commandCatalog) {
+        check({ path: c.path, fm: c.raw }, "Command");
+      }
+      for (const b of bindings) check(b, "Binding");
+      for (const g of groundings) check(g, "Grounding");
+      for (const p of preconditions) check(p, "Precondition");
+      expect(violations).toEqual([]);
+    });
+  });
+
+  describe("AC8: class-UUID self-guard (every Command declares exo__Instance_class as [[790e5b16-…]])", () => {
+    const canonicalWikilink = `[[${EXOCMD_COMMAND_CLASS_UUID}]]`;
+
+    it("frontmatter literal includes the canonical UUID wikilink", () => {
+      const missing: Array<{ uid: string; classField: unknown }> = [];
+      for (const c of commandCatalog) {
+        const classField = c.raw["exo__Instance_class"];
+        const found = toArray(classField).some((v) => v === canonicalWikilink);
+        if (!found) missing.push({ uid: c.uid, classField });
+      }
+      expect(missing).toEqual([]);
+    });
+
+    it("fixture file byte-level contains the canonical UUID wikilink", () => {
+      const missing: string[] = [];
+      for (const c of commandCatalog) {
+        const raw = fs.readFileSync(c.path, "utf8");
+        if (!raw.includes(canonicalWikilink)) missing.push(c.uid);
+      }
+      expect(missing).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

RFC-CI-Tests Phase 1 Complement 2 — static-guard **YAML contract test** over the pinned `starter-kit-fixtures` submodule. Parent task `6208967d-2744-4e81-8b9c-5aaea6c488ad`, project `9b4f1f59`.

Asserts 8 invariants over `exocmd__Command` / `CommandBinding` / `CommandGrounding` / `Precondition` assets. Reuses `loadCommandCatalog()` from #2887; inlines fs-walk / yaml-parse for the three non-Command classes.

## Test placement — RFC §7.3 divergence (orchestrator-approved)

RFC v4 §7.3 literally specifies `packages/obsidian-plugin/tests/unit/infrastructure/exocmd-contract.test.ts`. The catalog helper from 58b1d922 is **ESM-only** (`import.meta.url`, `.js`-extension imports); plugin package runs **CommonJS ts-jest** and cannot import the helper without duplicating the loader — which would reintroduce the silent-zero class of bug this contract is designed to prevent.

Orchestrator approved placement under `packages/cli/tests/integration/starter-kit/`, symmetric with #2887 and §12.4 path-drift resolution. **RFC v5 footnote pending** for §7.3 path text alignment.

## Baseline-ratchet strategy (ACs 3 / 4 / 5)

Three ACs have known non-zero violators today; each is scheduled for fix by an UX-RFC phase (§7.4 P0-1 dedup, P1-3 confirm trim, P1-4 successMessage completion). Hard-failing would block every Phase 1 PR.

`packages/cli/tests/integration/starter-kit/exocmd-contract.baseline.json` freezes the exact violator UUID sets. Protocol:

| Change in fixtures | Baseline reaction |
|---|---|
| New violator appears | Test FAILS — add the UUID AND open a fix issue, OR fix immediately |
| Violator fixed | Test FAILS — remove the UUID from the baseline in the same PR that ships the fix |
| Violator renamed / category changed | Test FAILS — baseline UUID + actual divergence shown in jest diff output |

AC3 flags the **whole dup group** (not just "second by scan order") so that when P0-1 removes either of the two `Remove Start Timestamp` files the group collapses and the array becomes `[]` — no phantom leftover violation.

## Current baseline snapshot

| AC | Lock | Violators | Rationale |
|---|---|---|---|
| AC1 orphan commands | **hard (0)** | — | Every Command has ≥ 1 Binding |
| AC2 binding/grounding integrity | **hard (0)** | — | No dangling refs |
| **AC3 dup (category, label)** | ratchet | `9f33ecdd`, `a7d3573a` (both `Remove Start Timestamp`) | RFC §7.4 P0-1 removes one |
| **AC4 confirm on non-destructive** | ratchet | `843d3fda`, `22a7ceb9`, `6bc86da6`, `91beb9e5`, `c29ea05e` | UX RFC P1-3 removes 3 confirmMessages. Convert to Task/Project excluded per `isDestructive` (UX RFC P1-3 canonical: Delete / Convert / Archive / Rename-to-UID). **Refined from 11 → 9 → 5** after applying the isDestructive predicate. |
| **AC5 missing successMessage** | ratchet | `652c85ea`, `9f33ecdd`, `fcae3280` | UX RFC P1-4 adds successMessages |
| AC6 UUID-v4 shape | **hard (0)** | — | All 44 Command uids are v4 |
| AC7 unresolvable class refs | **hard (0)** | — | Across Commands / Bindings / Groundings / Preconditions |
| AC8 class-UUID self-guard | **hard (0)** | — | Frontmatter literal + byte-level `[[790e5b16-...]]` |

## Verification

### Suite locally

```
  exocmd contract (YAML static guard, RFC Phase 1 Complement 2)
    ✓ discovery finds a non-trivial number of each asset kind
    AC1 ✓ no orphan commands
    AC2 ✓ no dangling binding refs and every bound command has a resolvable grounding
    AC3 ✓ known dup baseline — locked until §7.4 P0-1 removes the dup
    AC4 ✓ violator set matches baseline exactly
    AC5 ✓ missing set matches baseline exactly
    AC6 ✓ no non-UUID or non-v4 command uids
    AC7 ✓ no dangling exo__Instance_class wikilinks across four kinds
    AC8 ✓ frontmatter literal includes the canonical UUID wikilink
    AC8 ✓ fixture file byte-level contains the canonical UUID wikilink
```

- **Runtime**: 0.40s (10 assertions). RFC §7.3 aspires to "~200ms total" — measured 400ms includes ~250ms jest ESM startup on macOS. On the Linux CI container the delta should narrow. **Flagged for Phase 1 retrospective** — investigate if runtime remains above 200ms on CI.
- **Full CLI suite**: 1385 green (was 1375) + 40 skipped + 0 failed.
- **Adversarial detection proof**: initial run RED on AC3 / AC4 due to baseline mismatch (different dup sort, isDestructive refinement) — confirms tests actually compare against expected snapshot rather than accepting whatever is there.

## RFC §12 PR Readiness Gate

- [x] No new helper code shipped under `tests/integration/**/test-helpers/` in this PR — gate is **non-applicable**. Inline fs/yaml utilities live in the contract test file itself; `isDestructive()` is 12 LOC and test-specific.
- [x] Coverage delta: test-only PR, no production code added — `packages/cli/` coverage unchanged.
- [x] `collectCoverageFrom` untouched — test file lives in `tests/`, default `src/**/*.ts` excludes it.

## Starter-kit inconsistencies found

1. **AC3** — 2 commands share `(maintenance, "Remove Start Timestamp")`. Known; RFC §7.4 P0-1 scheduled removal.
2. **AC4** — 5 commands have `confirmMessage` on non-destructive labels (Link to Parent; Set/Remove Scheduled Date; Set Planned Start/End). 3 are scheduled for removal by UX RFC P1-3.
3. **AC5** — 3 commands missing `successMessage` (Set Result; both `Remove Start Timestamp` files, one of which is the AC3 dup; Remove End Timestamp). UX RFC P1-4 planned fix.
4. **No new inconsistencies** beyond what the RFCs already scheduled.

## Test plan

- [x] Suite green locally (10/10 assertions)
- [x] Full CLI `npm test` green (1385 passed)
- [x] Typecheck passes
- [x] Adversarial verification: initial AC3/AC4 red → green after baseline fit
- [ ] Pre-merge CI green (8 mandatory checks)
- [ ] Auto Release succeeds post-merge

## Related

- Parent project: `9b4f1f59-d771-4c1b-b8e4-feb06984c06c` (RFC-CI-Tests Phase 1)
- Task: `6208967d-2744-4e81-8b9c-5aaea6c488ad`
- RFC v4: `/Users/kitelev/Developer/rfc-ci-button-testing-2026-04-20.md` §7.3 (Complement 2), §12 (PR Readiness Gate), §7.4 P0-1 (scheduled AC3 resolution)
- Catalog helper (this PR reuses): #2887
- Submodule wiring: #2886