### PR TITLE
test(cli): Phase 1 helpers bundle (RFC §7.1a + §12 gate)

### DIFF
--- a/packages/cli/tests/integration/starter-kit/test-helpers/execute-command.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/execute-command.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration harness wrapper — dispatches a grounding against a fixture file
+ * through the real `GroundingExecutor` (RFC v4 §7.1 primary approach).
+ *
+ * Wires the three Phase 1 helpers together:
+ *
+ *   fixture-factory → creates the tmp `.md` host asset
+ *   user-input-factory → synthesises `--input` JSON when the grounding schema
+ *                        declares one
+ *   execute-command (this file) → instantiates `GroundingExecutor` with node-fs
+ *                                 adapters and calls `.execute(...)`
+ *
+ * Mirrors the CLI dispatch path: `@kitelev/exocortex-cli command <uid>
+ * <file> --input ...` delegates to the same `GroundingExecutor`, so the test
+ * covers what a user sees when clicking an inline button in Obsidian.
+ *
+ * No CLI subprocess is spawned here (per Phase 0 note on `dd3bdaaa` — subprocess
+ * harness is deferred tech debt, ticket #2883). Real async fs, no mocks.
+ */
+import * as fs from "fs";
+import * as fsp from "fs/promises";
+import { GroundingExecutor, GroundingType, ServiceRegistry } from "exocortex";
+import type {
+  GroundingDefinition,
+  IFileSystemReader,
+  IFileSystemWriter,
+} from "exocortex";
+import type { GroundingData } from "./extract-target-class.js";
+
+// ---------------------------------------------------------------------------
+// Minimal node-fs adapters — only the methods GroundingExecutor exercises.
+// ---------------------------------------------------------------------------
+
+export class NodeFileSystemReader implements IFileSystemReader {
+  async readFile(filePath: string): Promise<string> {
+    return fsp.readFile(filePath, "utf8");
+  }
+
+  async fileExists(filePath: string): Promise<boolean> {
+    try {
+      await fsp.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getMarkdownFiles(rootPath?: string): Promise<string[]> {
+    const root = rootPath ?? ".";
+    const out: string[] = [];
+    const walk = async (dir: string): Promise<void> => {
+      let entries: fs.Dirent[];
+      try {
+        entries = await fsp.readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        const full = `${dir}/${entry.name}`;
+        if (entry.isDirectory()) await walk(full);
+        else if (entry.isFile() && entry.name.endsWith(".md")) out.push(full);
+      }
+    };
+    await walk(root);
+    return out;
+  }
+}
+
+export class NodeFileSystemWriter implements IFileSystemWriter {
+  async createFile(filePath: string, content: string): Promise<string> {
+    await fsp.writeFile(filePath, content, { encoding: "utf8", flag: "wx" });
+    return filePath;
+  }
+  async updateFile(filePath: string, content: string): Promise<void> {
+    await fsp.writeFile(filePath, content, "utf8");
+  }
+  async writeFile(filePath: string, content: string): Promise<void> {
+    await fsp.writeFile(filePath, content, "utf8");
+  }
+  async deleteFile(filePath: string): Promise<void> {
+    await fsp.unlink(filePath);
+  }
+  async renameFile(oldPath: string, newPath: string): Promise<void> {
+    await fsp.rename(oldPath, newPath);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GroundingData → GroundingDefinition
+// ---------------------------------------------------------------------------
+
+const TYPE_LOOKUP: ReadonlyMap<string, GroundingType> = new Map([
+  ["property_set", GroundingType.PROPERTY_SET],
+  ["property_delete", GroundingType.PROPERTY_DELETE],
+  ["composite", GroundingType.COMPOSITE],
+  ["service_call", GroundingType.SERVICE_CALL],
+  ["create_instance", GroundingType.CREATE_INSTANCE],
+  ["sparql_update", GroundingType.SPARQL_UPDATE],
+]);
+
+/**
+ * Convert a parsed `GroundingData` (produced by `loadStarterKitContext`) into
+ * the `GroundingDefinition` shape the real `GroundingExecutor` expects.
+ *
+ * The executor's service_call dispatcher reads `targetProperty` as the
+ * `serviceId` (executor:331). Vault groundings store this under a different
+ * YAML key (`exocmd__Grounding_serviceId`), so when the raw grounding lacks
+ * `targetProperty` but has `serviceId`, we copy the latter into the former so
+ * the executor can find it.
+ */
+export function toGroundingDefinition(
+  data: GroundingData,
+): GroundingDefinition {
+  const type = TYPE_LOOKUP.get(data.type ?? "") ?? GroundingType.PROPERTY_SET;
+  const targetProperty =
+    type === GroundingType.SERVICE_CALL
+      ? data.targetProperty ?? data.serviceId
+      : data.targetProperty;
+  const steps = data.steps?.map(toGroundingDefinition);
+  return {
+    id: data.uid,
+    label: data.label,
+    type,
+    targetProperty,
+    targetValue: data.targetValue,
+    targetClass: data.targetClass,
+    steps,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// executeCommandHarness — end-to-end dispatch
+// ---------------------------------------------------------------------------
+
+export interface ExecuteOptions {
+  readonly grounding: GroundingData;
+  readonly filePath: string;
+  readonly targetIRI: string;
+  readonly userInput?: Record<string, unknown>;
+  readonly serviceRegistry?: ServiceRegistry;
+}
+
+export interface ExecuteHarnessResult {
+  readonly success: boolean;
+  readonly error?: string;
+}
+
+/**
+ * Dispatch a grounding via the real `GroundingExecutor` and return the raw
+ * `ExecutionResult`. Caller reads the file afterwards to diff `before` vs
+ * `after` frontmatter.
+ */
+export async function executeCommandHarness(
+  opts: ExecuteOptions,
+): Promise<ExecuteHarnessResult> {
+  const executor = new GroundingExecutor(
+    new NodeFileSystemReader(),
+    new NodeFileSystemWriter(),
+    opts.serviceRegistry ?? new ServiceRegistry(),
+  );
+  const definition = toGroundingDefinition(opts.grounding);
+  return executor.execute(
+    definition,
+    opts.targetIRI,
+    opts.filePath,
+    opts.userInput,
+  );
+}

--- a/packages/cli/tests/integration/starter-kit/test-helpers/extract-target-class.self.test.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/extract-target-class.self.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Integration self-test for `extract-target-class` — runs the RFC v4 §7.1a
+ * ladder against the live `starter-kit-fixtures` submodule and pins the
+ * Strategy-distribution aggregate against the Phase 0 post-Option-C baseline
+ * (`/Users/kitelev/Developer/phase1-post-migration-ladder-2026-04-20.md`).
+ *
+ * The unit suite (`tests/unit/test-helpers/extract-target-class.test.ts`)
+ * covers per-branch logic with synthetic data. This self-test is the canary:
+ * if ladder drift, Option-C migration rollback, or fixture churn ever changes
+ * the gate math, the test goes red immediately.
+ */
+import { describe, it, expect } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { loadCommandCatalog } from "./command-catalog.js";
+import {
+  extractTargetClassFromCommand,
+  loadStarterKitContext,
+  type ResolutionStrategy,
+} from "./extract-target-class.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES_ROOT = path.resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "starter-kit-fixtures",
+);
+
+const SUBMODULE_HYDRATED =
+  fs.existsSync(FIXTURES_ROOT) &&
+  fs.existsSync(path.join(FIXTURES_ROOT, "exocmd"));
+
+const describeOrSkip = SUBMODULE_HYDRATED ? describe : describe.skip;
+
+describeOrSkip("extract-target-class ladder (self-test)", () => {
+  const catalog = loadCommandCatalog();
+  const ctx = loadStarterKitContext();
+  const results = catalog.map((cmd) => ({
+    cmd,
+    result: extractTargetClassFromCommand(cmd, ctx),
+  }));
+  const counts = new Map<ResolutionStrategy, number>([
+    ["S1", 0],
+    ["S2", 0],
+    ["S3", 0],
+    ["S4", 0],
+    ["S5", 0],
+  ]);
+  for (const { result } of results) {
+    counts.set(result.strategy, (counts.get(result.strategy) ?? 0) + 1);
+  }
+
+  it("classifies every Command into a strategy", () => {
+    expect(catalog.length).toBeGreaterThanOrEqual(40);
+    expect(results).toHaveLength(catalog.length);
+  });
+
+  it("S1 count matches Option-C migration anchor (8 creation commands)", () => {
+    // Creation commands migrated in Phase 1 reconcile (starter-kit PR #81).
+    // Floor at 7 to absorb ±1 fixture churn without turning red prematurely.
+    expect(counts.get("S1")).toBeGreaterThanOrEqual(7);
+  });
+
+  it("S5 fallback ratio ≤ 30% (RFC §7.1a gate)", () => {
+    const s5 = counts.get("S5") ?? 0;
+    const ratio = s5 / catalog.length;
+    expect(ratio).toBeLessThanOrEqual(0.3);
+  });
+
+  it("all non-S5 results are NOT dispatchOnly; S5 results ARE", () => {
+    for (const { result } of results) {
+      if (result.strategy === "S5") expect(result.dispatchOnly).toBe(true);
+      else expect(result.dispatchOnly).toBe(false);
+    }
+  });
+
+  it("every resolved targetClass is a non-empty string", () => {
+    for (const { result } of results) {
+      expect(typeof result.targetClass).toBe("string");
+      expect(result.targetClass.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/cli/tests/integration/starter-kit/test-helpers/extract-target-class.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/extract-target-class.ts
@@ -1,0 +1,476 @@
+/**
+ * `extractTargetClassFromCommand` — RFC v4 §7.1a 5-strategy resolution ladder.
+ *
+ * Pure classifier over the starter-kit submodule: given a parametrized
+ * `CommandCatalogEntry` plus a pre-scanned `StarterKitContext` (preconditions,
+ * groundings, and class-label reverse index), returns the host class on which
+ * a test fixture should be materialised. Mirrors the Python classifier used in
+ * the Phase 0 report so the Strategy distribution held across implementations
+ * is load-bearing — any drift surfaces in the aggregate assertions below.
+ *
+ *   S1 — Explicit `exocmd__Command_targetClass`                          (8 cmds)
+ *   S2 — Precondition SPARQL `$target <ns:Class_prop>` / `rdf:type`    (19 cmds)
+ *   S3 — Grounding `targetProperty` RDFS:domain heuristic               (5 cmds)
+ *   S4 — Grounding `targetValue` class-flip pivot                       (2 cmds)
+ *   S5 — Fallback `ems__Task` (dispatch-only)                         (≤10 cmds)
+ *
+ * Aggregate gate (RFC §7.1a): S5 ratio ≤ 30% of the 44-Command catalog. At
+ * 2026-04-20 the post-Option-C ratio is 22.7% (10/44). The companion
+ * `loadStarterKitContext` loader scans the submodule once and builds the
+ * maps every downstream helper needs — keeping the ladder itself a pure
+ * function over pre-resolved data.
+ *
+ * RFC v4 §12 gate: matching unit test lives at
+ * `packages/cli/tests/unit/test-helpers/extract-target-class.test.ts`.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import yaml from "js-yaml";
+import type { CommandCatalogEntry } from "./command-catalog.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ResolutionStrategy = "S1" | "S2" | "S3" | "S4" | "S5";
+
+export interface ExtractTargetClassResult {
+  /** Selected host class label (e.g. `"ems__Task"`). */
+  readonly targetClass: string;
+  /** Which ladder step selected the class. */
+  readonly strategy: ResolutionStrategy;
+  /** Short free-form reason (classifier note — for debug output / audits). */
+  readonly reason: string;
+  /**
+   * True when the strategy cannot anchor a frontmatter-mutation assertion —
+   * test harness should downgrade to P-dispatch only. Currently means `S5`.
+   */
+  readonly dispatchOnly: boolean;
+}
+
+export interface PreconditionData {
+  readonly uid: string;
+  readonly label: string;
+  readonly sparqlAsk?: string;
+  readonly hostFunction?: string;
+}
+
+export interface GroundingData {
+  readonly uid: string;
+  readonly label: string;
+  /** `property_set` | `property_delete` | `composite` | `service_call` | `create_instance` | `sparql_update`. */
+  readonly type?: string;
+  readonly targetProperty?: string;
+  readonly targetValue?: string;
+  readonly serviceId?: string;
+  readonly inputSchema?: string;
+  readonly targetClass?: string;
+  /** Resolved step groundings (flattened from `exocmd__Grounding_steps` wikilinks). */
+  readonly steps?: readonly GroundingData[];
+  readonly raw: Record<string, unknown>;
+}
+
+export interface StarterKitContext {
+  readonly preconditions: ReadonlyMap<string, PreconditionData>;
+  readonly groundings: ReadonlyMap<string, GroundingData>;
+  /** `classUuid → classLabel` — used to resolve UUID-wikilinks back to labels. */
+  readonly classLabelByUuid: ReadonlyMap<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Context loader — one pass over the submodule
+// ---------------------------------------------------------------------------
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+const EXO_CLASS_UID = "8619c4fc-64f1-4869-b17e-e34186cacca9";
+const PRECONDITION_CLASS_UID = "15d119b5-9636-431e-9e91-1f140107d059";
+const GROUNDING_CLASS_UID = "11579feb-2e42-491c-af59-b89b1129a539";
+
+export interface LoadContextOptions {
+  readonly fixturesRoot?: string;
+  readonly listMarkdownFiles?: (root: string) => string[];
+  readonly readFile?: (filePath: string) => string;
+}
+
+function defaultFixturesRoot(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(
+    here,
+    "..",
+    "..",
+    "..",
+    "..",
+    "..",
+    "starter-kit-fixtures",
+  );
+}
+
+function defaultList(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".git")) {
+        continue;
+      }
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith(".md")) out.push(full);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+function readFrontmatter(raw: string): Record<string, unknown> | null {
+  const match = FRONTMATTER_RE.exec(raw);
+  if (!match) return null;
+  try {
+    const parsed = yaml.load(match[1]);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function toArray(value: unknown): unknown[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Strip Obsidian wikilink wrapper; accept `[[X]]`, `"[[X]]"`, `[[X|alias]]`, or `X`. */
+function unwrapWikilink(raw: string): string {
+  const match = raw.match(/^"?\[\[([^\]|]+)(?:\|[^\]]*)?\]\]"?$/);
+  return match ? match[1] : raw;
+}
+
+function hasInstanceClass(fm: Record<string, unknown>, uid: string): boolean {
+  for (const raw of toArray(fm["exo__Instance_class"])) {
+    if (typeof raw !== "string") continue;
+    if (raw === `[[${uid}]]` || raw === `"[[${uid}]]"`) return true;
+  }
+  return false;
+}
+
+/**
+ * Scan the starter-kit fixture tree and build the `StarterKitContext`
+ * consumed by `extractTargetClassFromCommand` (and indirectly by
+ * `execute-command.ts`). One O(n) walk over the submodule.
+ */
+export function loadStarterKitContext(
+  options: LoadContextOptions = {},
+): StarterKitContext {
+  const root = options.fixturesRoot ?? defaultFixturesRoot();
+  const listFiles = options.listMarkdownFiles ?? defaultList;
+  const readFile = options.readFile ?? ((p) => fs.readFileSync(p, "utf8"));
+
+  const preconditions = new Map<string, PreconditionData>();
+  const groundings = new Map<string, GroundingData>();
+  const classLabelByUuid = new Map<string, string>();
+  const groundingFM: Array<{ uid: string; fm: Record<string, unknown> }> = [];
+
+  for (const filePath of listFiles(root).slice().sort()) {
+    let raw: string;
+    try {
+      raw = readFile(filePath);
+    } catch {
+      continue;
+    }
+    const fm = readFrontmatter(raw);
+    if (!fm) continue;
+    const uid = asString(fm["exo__Asset_uid"]);
+    const label = asString(fm["exo__Asset_label"]) ?? "";
+    if (!uid) continue;
+
+    if (hasInstanceClass(fm, EXO_CLASS_UID) && label) {
+      if (!classLabelByUuid.has(uid)) classLabelByUuid.set(uid, label);
+    }
+    if (hasInstanceClass(fm, PRECONDITION_CLASS_UID)) {
+      preconditions.set(uid, {
+        uid,
+        label,
+        sparqlAsk: asString(fm["exocmd__Precondition_sparqlAsk"]),
+        hostFunction: asString(fm["exocmd__Precondition_hostFunction"]),
+      });
+    }
+    if (hasInstanceClass(fm, GROUNDING_CLASS_UID)) {
+      groundingFM.push({ uid, fm });
+    }
+  }
+
+  // Second pass: groundings reference other groundings via `_steps`. Resolve
+  // once the uid → frontmatter map is complete.
+  const groundingFMMap = new Map(groundingFM.map(({ uid, fm }) => [uid, fm]));
+  for (const { uid, fm } of groundingFM) {
+    groundings.set(uid, buildGroundingData(uid, fm, groundingFMMap));
+  }
+
+  return { preconditions, groundings, classLabelByUuid };
+}
+
+function buildGroundingData(
+  uid: string,
+  fm: Record<string, unknown>,
+  fmMap: Map<string, Record<string, unknown>>,
+): GroundingData {
+  const label = asString(fm["exo__Asset_label"]) ?? "";
+  const stepsRaw = toArray(fm["exocmd__Grounding_steps"]);
+  const steps: GroundingData[] = [];
+  for (const stepWl of stepsRaw) {
+    if (typeof stepWl !== "string") continue;
+    const stepUid = unwrapWikilink(stepWl);
+    const stepFm = fmMap.get(stepUid);
+    if (stepFm) steps.push(buildGroundingData(stepUid, stepFm, fmMap));
+  }
+  return {
+    uid,
+    label,
+    type: asString(fm["exocmd__Grounding_type"]),
+    targetProperty: asString(fm["exocmd__Grounding_targetProperty"]),
+    targetValue: asString(fm["exocmd__Grounding_targetValue"]),
+    serviceId: asString(fm["exocmd__Grounding_serviceId"]),
+    inputSchema: asString(fm["exocmd__Grounding_inputSchema"]),
+    targetClass: asString(fm["exocmd__Grounding_targetClass"]),
+    steps: steps.length > 0 ? steps : undefined,
+    raw: fm,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ladder
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve class from a wikilink value that may be either a UUID ref or a
+ * class label. Returns the class label for both shapes, or undefined if the
+ * UUID does not resolve.
+ */
+function resolveClassFromWikilink(
+  value: string,
+  classLabelByUuid: ReadonlyMap<string, string>,
+): string | undefined {
+  const inner = unwrapWikilink(value);
+  // UUID → resolve via reverse index
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(inner)) {
+    return classLabelByUuid.get(inner);
+  }
+  // Label (e.g. "ems__Task")
+  return inner;
+}
+
+/**
+ * Extract `ns__Class` from a SPARQL property-prefix token `ns:Class_prop` or
+ * `rdf:type <ns#Class>`. Used by Strategy 2 to infer host class from the
+ * precondition SPARQL.
+ */
+export function extractClassFromSparql(
+  sparqlAsk: string,
+): { class: string; reason: string } | undefined {
+  const body = sparqlAsk.replace(/\s+/g, " ");
+  // Prefer explicit `$target rdf:type <ns#Class>` if present.
+  const rdfType = body.match(
+    /\$target\s+(?:a|rdf:type)\s+<[^>]*[#\/](\w+)>/,
+  );
+  if (rdfType) {
+    return {
+      class: rdfType[1].replace(/__+/g, "__"),
+      reason: `precond rdf:type match (${rdfType[1]})`,
+    };
+  }
+  // Property-prefix form: $target ns:Class_prop <value>. Excludes
+  // exo:Instance_class (class-flip hint belongs to S4).
+  const propRe =
+    /\$target\s+([A-Za-z][\w-]*):([A-Za-z][\w-]*)_([A-Za-z][\w-]*)/g;
+  const seen = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = propRe.exec(body)) !== null) {
+    const [, ns, klass, prop] = m;
+    if (ns === "exo" && klass === "Instance" && prop === "class") continue;
+    const label = `${ns}__${klass}`;
+    seen.add(label);
+  }
+  if (seen.size === 1) {
+    const [label] = seen;
+    return { class: label, reason: `precond property-prefix (${label})` };
+  }
+  return undefined;
+}
+
+/**
+ * Extract the single class label from a set of grounding `targetProperty`
+ * IRIs (S3 heuristic). Accepts property labels in `ns__Class_prop` form.
+ */
+function extractClassFromTargetProperty(
+  targetProperties: readonly string[],
+): { class: string; reason: string } | undefined {
+  const classes = new Set<string>();
+  for (const prop of targetProperties) {
+    const match = prop.match(/^([A-Za-z][\w-]*)__([A-Za-z][\w-]*)_/);
+    if (!match) continue;
+    classes.add(`${match[1]}__${match[2]}`);
+  }
+  if (classes.size === 1) {
+    const [label] = classes;
+    return {
+      class: label,
+      reason: `grounding targetProperty domain (${label})`,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Collect `targetProperty` tokens from a grounding and its composite children,
+ * plus nested `"property"` keys inside JSON `targetValue` blocks (e.g. the
+ * `Set Planned Start` family).
+ */
+function collectTargetProperties(grounding: GroundingData): string[] {
+  const out: string[] = [];
+  const visit = (g: GroundingData): void => {
+    if (g.targetProperty) out.push(g.targetProperty);
+    if (g.targetValue) {
+      try {
+        const parsed = JSON.parse(g.targetValue);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          const prop = (parsed as { property?: unknown }).property;
+          if (typeof prop === "string") out.push(prop);
+        }
+      } catch {
+        /* ignore — plain wikilink / literal targetValue */
+      }
+    }
+    for (const step of g.steps ?? []) visit(step);
+  };
+  visit(grounding);
+  return out;
+}
+
+/**
+ * Determine if the grounding encodes a Convert class-flip (S4). Returns the
+ * "pre-flip" host class (i.e. the source fixture class that the button
+ * converts AWAY from).
+ */
+function classFlipPreFlip(
+  grounding: GroundingData,
+  classLabelByUuid: ReadonlyMap<string, string>,
+): { class: string; reason: string } | undefined {
+  // Only serviceId=updateProperty with a class targetValue counts as a
+  // class-flip in the current executor (see GroundingExecutor:368-376).
+  if (
+    grounding.type !== "service_call" ||
+    grounding.targetProperty !== "updateProperty" ||
+    !grounding.targetValue
+  ) {
+    return undefined;
+  }
+  // Class-flip targetValues are wrapped wikilinks (`[[X]]` / `"[[X]]"`).
+  // JSON-object targetValues (e.g. `{"property":"ems__Effort_..."}`) belong
+  // to S3 property-domain heuristic, not S4.
+  if (!/^"?\[\[/.test(grounding.targetValue.trim())) {
+    return undefined;
+  }
+  const dest = resolveClassFromWikilink(
+    grounding.targetValue,
+    classLabelByUuid,
+  );
+  if (!dest) return undefined;
+  // Symmetric mapping: Convert-to-Task fixture starts as ems__Project, and
+  // vice-versa. Anything else falls back to ems__Effort (broadest pre-flip).
+  let pre: string;
+  if (dest === "ems__Task") pre = "ems__Project";
+  else if (dest === "ems__Project") pre = "ems__Task";
+  else pre = "ems__Effort";
+  return { class: pre, reason: `class-flip dest=${dest}; fixture pre-flip=${pre}` };
+}
+
+/**
+ * Apply the RFC §7.1a ladder to a single Command, returning the chosen host
+ * class + strategy + reason. Pure function over the pre-resolved context.
+ */
+export function extractTargetClassFromCommand(
+  cmd: CommandCatalogEntry,
+  ctx: StarterKitContext,
+): ExtractTargetClassResult {
+  // --- S1: explicit frontmatter declaration -------------------------------
+  if (cmd.targetClass) {
+    const cls = resolveClassFromWikilink(cmd.targetClass, ctx.classLabelByUuid);
+    if (cls) {
+      return {
+        targetClass: cls,
+        strategy: "S1",
+        reason: `explicit exocmd__Command_targetClass=${cls}`,
+        dispatchOnly: false,
+      };
+    }
+  }
+
+  // --- S2: precondition SPARQL inspection ---------------------------------
+  if (cmd.precondition) {
+    const uid = unwrapWikilink(cmd.precondition);
+    const pre = ctx.preconditions.get(uid);
+    if (pre?.sparqlAsk) {
+      const hit = extractClassFromSparql(pre.sparqlAsk);
+      if (hit) {
+        return {
+          targetClass: hit.class,
+          strategy: "S2",
+          reason: hit.reason,
+          dispatchOnly: false,
+        };
+      }
+    }
+  }
+
+  // --- S3 / S4 require grounding resolution -------------------------------
+  const groundingUid = cmd.grounding ? unwrapWikilink(cmd.grounding) : undefined;
+  const grounding = groundingUid ? ctx.groundings.get(groundingUid) : undefined;
+
+  // --- S4: class-flip pivot (checked before S3 so convert commands beat
+  //         property-heuristic) ------------------------------------------
+  if (grounding) {
+    const flip = classFlipPreFlip(grounding, ctx.classLabelByUuid);
+    if (flip) {
+      return {
+        targetClass: flip.class,
+        strategy: "S4",
+        reason: flip.reason,
+        dispatchOnly: false,
+      };
+    }
+  }
+
+  // --- S3: grounding targetProperty RDFS:domain heuristic -----------------
+  if (grounding) {
+    const props = collectTargetProperties(grounding);
+    const hit = extractClassFromTargetProperty(props);
+    if (hit) {
+      return {
+        targetClass: hit.class,
+        strategy: "S3",
+        reason: hit.reason,
+        dispatchOnly: false,
+      };
+    }
+  }
+
+  // --- S5: fallback -------------------------------------------------------
+  return {
+    targetClass: "ems__Task",
+    strategy: "S5",
+    reason: "fallback (no ladder match)",
+    dispatchOnly: true,
+  };
+}

--- a/packages/cli/tests/integration/starter-kit/test-helpers/fixture-factory.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/fixture-factory.ts
@@ -1,0 +1,181 @@
+/**
+ * Fixture factory — Phase 1 integration helper (RFC v4 §7.1a foundation).
+ *
+ * Materialises synthetic vault assets (`ems__Task`, `ems__Project`, `ems__Area`,
+ * and arbitrary host classes) inside an isolated tmp directory so parametrized
+ * integration tests over the 44-Command catalog each get a fresh host asset to
+ * dispatch the Grounding against.
+ *
+ * Contract highlights:
+ *
+ *  - **Deterministic UUIDs.** A seed string (e.g. a command UID plus a test-case
+ *    discriminator) maps through SHA-1 to a stable UUIDv5-shaped identifier.
+ *    Running the same test twice produces the same file UID — no flaky snapshot
+ *    diff, no leaked random tmp names.
+ *  - **Isolated tmp root per factory call** (`makeFixtureRoot`). Tests cleanup
+ *    via `cleanupFixtureRoot(root)` in `afterEach`. Roots are created under
+ *    `<os.tmpdir>/exocortex-fixture-<suffix>` so parallel jest workers never
+ *    collide.
+ *  - **Stable `targetIRI` convention** — `obsidian://vault/<basename>` without
+ *    the `.md` suffix, mirroring how `GroundingExecutor.execute` consumers
+ *    address the file from the real plugin (memory `reference_cli_status_iri_vault_divergence`
+ *    observes the IRI shape divergence — we commit to the vault-2025 shape here).
+ *  - **No updateProperty CLI stub shipped** (per Phase 0 `dd3bdaaa` note): read-back
+ *    happens via direct `fs.readFileSync` in tests, not via CLI subprocess.
+ *
+ * RFC v4 §12 gate: matching unit test lives at
+ * `packages/cli/tests/unit/test-helpers/fixture-factory.test.ts`.
+ */
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+export interface FixtureAsset {
+  /** Deterministic UUID of the host asset. */
+  readonly uid: string;
+  /** Human-readable label. */
+  readonly label: string;
+  /** Absolute path of the materialised `.md` file on disk. */
+  readonly path: string;
+  /** Class label set as `exo__Instance_class` (e.g. "ems__Task"). */
+  readonly className: string;
+  /** Stable Obsidian-style IRI (`obsidian://vault/<basename>`). */
+  readonly targetIRI: string;
+}
+
+export interface BuildFixtureOptions {
+  /**
+   * Class label to stamp as `exo__Instance_class` (e.g. "ems__Task").
+   * For classes whose resolution is via UUID wikilink, pass the UUID string —
+   * the factory wraps it as `[[<value>]]` verbatim.
+   */
+  readonly className: string;
+  /**
+   * Seed string used to derive the deterministic UUID. Typical value is the
+   * command UID under test + an optional discriminator (e.g. `"precondition-unmet"`).
+   * Two distinct seeds always produce two distinct UIDs; identical seeds produce
+   * identical UIDs across runs.
+   */
+  readonly seed: string;
+  /** Optional human-readable label. Falls back to `"Fixture for <seed>"`. */
+  readonly label?: string;
+  /** Additional frontmatter keys merged on top of the skeleton. */
+  readonly extraFrontmatter?: Record<string, unknown>;
+  /**
+   * Tmp root under which the `.md` file is written. Must already exist —
+   * use `makeFixtureRoot()` to allocate one. Required so callers cannot
+   * accidentally leak files into the repo root.
+   */
+  readonly root: string;
+}
+
+const UUID_NAMESPACE = "exocortex-fixture-factory-v1";
+
+/**
+ * Deterministic UUIDv5-shaped identifier from a seed string.
+ *
+ * Pure SHA-1 of (namespace + "::" + seed), truncated to 16 bytes, with RFC 4122
+ * version/variant nibbles patched. Matches the UUIDv5 textual shape so any
+ * downstream tooling that validates UUID format accepts the output.
+ */
+export function uuidFromSeed(seed: string): string {
+  const hash = crypto
+    .createHash("sha1")
+    .update(UUID_NAMESPACE + "::" + seed)
+    .digest();
+  const bytes = Buffer.from(hash.subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+  const hex = bytes.toString("hex");
+  return (
+    hex.slice(0, 8) +
+    "-" +
+    hex.slice(8, 12) +
+    "-" +
+    hex.slice(12, 16) +
+    "-" +
+    hex.slice(16, 20) +
+    "-" +
+    hex.slice(20, 32)
+  );
+}
+
+/**
+ * Allocate a fresh, empty tmp directory for a test case. Safe for parallel
+ * jest workers (suffix is process-unique).
+ */
+export function makeFixtureRoot(prefix = "exocortex-fixture-"): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** Recursively remove a fixture root. No-op if the path does not exist. */
+export function cleanupFixtureRoot(root: string): void {
+  if (!root) return;
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+function yamlScalar(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "boolean" || typeof value === "number") {
+    return String(value);
+  }
+  const str = String(value);
+  return `"${str.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function renderFrontmatter(fm: Record<string, unknown>): string {
+  const lines: string[] = ["---"];
+  for (const [key, value] of Object.entries(fm)) {
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      for (const item of value) lines.push(`  - ${yamlScalar(item)}`);
+    } else if (value && typeof value === "object") {
+      // Rare path — encode as inline JSON so downstream YAML parsers still
+      // succeed. Callers who need richer structure should pass YAML strings.
+      lines.push(`${key}: ${JSON.stringify(value)}`);
+    } else {
+      lines.push(`${key}: ${yamlScalar(value)}`);
+    }
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+/**
+ * Create a synthetic host asset inside `opts.root`. Returns the materialised
+ * `FixtureAsset` record. Throws if `opts.root` is missing or the file would
+ * overwrite an existing one (deterministic UUID collision).
+ */
+export function buildFixture(opts: BuildFixtureOptions): FixtureAsset {
+  if (!opts.root || !fs.existsSync(opts.root)) {
+    throw new Error(
+      `fixture-factory: root does not exist (did you call makeFixtureRoot()?): ${opts.root}`,
+    );
+  }
+  const uid = uuidFromSeed(opts.seed);
+  const label = opts.label ?? `Fixture for ${opts.seed}`;
+  const basename = uid;
+  const filePath = path.join(opts.root, `${basename}.md`);
+  if (fs.existsSync(filePath)) {
+    throw new Error(
+      `fixture-factory: refusing to overwrite existing fixture (seed collision?): ${filePath}`,
+    );
+  }
+  const frontmatter: Record<string, unknown> = {
+    exo__Asset_uid: uid,
+    exo__Asset_label: label,
+    exo__Instance_class: [`[[${opts.className}]]`],
+    aliases: [label],
+    ...(opts.extraFrontmatter ?? {}),
+  };
+  const content = renderFrontmatter(frontmatter) + `# ${label}\n`;
+  fs.writeFileSync(filePath, content, "utf8");
+  return {
+    uid,
+    label,
+    path: filePath,
+    className: opts.className,
+    targetIRI: `obsidian://vault/${basename}`,
+  };
+}

--- a/packages/cli/tests/integration/starter-kit/test-helpers/predict-mutation.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/predict-mutation.ts
@@ -1,0 +1,333 @@
+/**
+ * Grounding → expected frontmatter-diff predictor (RFC v4 §7.1 contract).
+ *
+ * Port of the Phase 0 prototype `/tmp/phase0-predictor-test/predictor.mjs` with
+ * TypeScript types layered on. Pure function: no file I/O, no mutation. Given a
+ * parsed `GroundingDefinition`, the host's `targetIRI`, and the optional
+ * `userInput`, it returns the frontmatter delta the real `GroundingExecutor`
+ * would write — so the integration harness can compare `before` vs `after`
+ * without coupling to dispatch mechanics.
+ *
+ * Per-command special-case branch count (RFC §7.1b gate ≤5):
+ *   1. `service_call.serviceId === "convertToTask"`              → executor:344
+ *   2. `service_call.serviceId === "updateProperty"` + targetCls `ems__Task`
+ *                                                                 → executor:370
+ *   3. `service_call.serviceId === "updateProperty"` + targetCls `ems__Project`
+ *                                                                 → executor:373
+ *
+ * Total: **3 / 5** — 2 branches of headroom preserved for future class-flip
+ * shortcuts (e.g. `ems__Area` if the ontology ever grows another pivot class).
+ *
+ * RFC v4 §12 gate: matching unit test lives at
+ * `packages/cli/tests/unit/test-helpers/predict-mutation.test.ts`.
+ */
+import type { GroundingDefinition } from "exocortex";
+import { GroundingType } from "exocortex";
+
+export interface PredictedMutation {
+  /**
+   * Expected frontmatter diff: `{ [property]: expected-string-value }`.
+   * A sentinel `"__DELETE__"` value marks property_delete semantics — callers
+   * strip such keys from the "after" snapshot before comparing.
+   */
+  readonly frontmatterDiff: Readonly<Record<string, string>>;
+  /**
+   * Regex matchers for nondeterministic fields (`$nowLocal` substitutions).
+   * Callers should prefer these over literal equality on the corresponding
+   * property key.
+   */
+  readonly timestampRegexes?: Readonly<Record<string, RegExp>>;
+  /**
+   * File-creation side effect (`create_instance` grounding). Present instead
+   * of — not in addition to — a frontmatter diff on the host asset.
+   */
+  readonly fileCreation?: {
+    readonly targetFolder: string;
+    readonly targetClass?: string;
+    readonly targetPrototype?: string;
+  };
+  /**
+   * True when the grounding is dispatch-only (generic `service_call`). The
+   * caller should assert dispatch success without attempting to match a
+   * mutation diff.
+   */
+  readonly unpredictable?: true;
+  /** Human-readable reason when `unpredictable === true`. */
+  readonly reason?: string;
+}
+
+export interface PredictorUserInput {
+  readonly value?: unknown;
+}
+
+export interface PredictorContext {
+  /**
+   * Injection hook for the `$nowLocal` timestamp format. Tests pin a fixed
+   * date to make regex matchers stable; production callers let this default
+   * to the real clock.
+   */
+  readonly now?: Date;
+}
+
+const TIMESTAMP_ANY_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/;
+
+/**
+ * Match `GroundingExecutor.substituteVariables` verbatim (executor.ts:527-549).
+ * Kept as a local function so predictor/executor drift surfaces as a one-line
+ * diff during review.
+ */
+export function substituteVariables(
+  value: string,
+  targetIRI: string,
+  userInput: PredictorUserInput | undefined,
+  now: Date,
+): string {
+  const nowIso = now.toISOString();
+  const nowLocal = toLocalTimestamp(now);
+  const today = nowIso.slice(0, 10);
+
+  let result = value
+    .replace(/\$target/g, targetIRI)
+    .replace(/\$nowLocal/g, nowLocal)
+    .replace(/\$now/g, nowIso)
+    .replace(/\$today/g, today);
+
+  if (userInput?.value !== undefined && userInput.value !== null) {
+    const inputStr = String(userInput.value);
+    result = result
+      .replace(/\$input\b/g, inputStr)
+      .replace(/\$value\b/g, inputStr);
+  }
+  return result;
+}
+
+/** Mirrors `DateFormatter.toLocalTimestamp` (YYYY-MM-DDTHH:mm:ss, no ms, no tz). */
+function toLocalTimestamp(d: Date): string {
+  const p = (n: number): string => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T` +
+    `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+  );
+}
+
+/**
+ * Extract a class token (e.g. `ems__Task`) from a `Grounding_targetValue`.
+ * Accepts both the wrapped wikilink form (`"[[ems__Task]]"`) that the vault
+ * RDF pipeline emits AND the plain literal form (`ems__Task`) that some CLI
+ * fixtures use. Mirrors executor:30-37.
+ */
+export function extractClassFromTargetValue(
+  value: string | undefined,
+): string | undefined {
+  if (!value) return undefined;
+  const wrapped = value.match(/^"?\[\[([^\]|]+)(?:\|[^\]]*)?\]\]"?$/);
+  if (wrapped) return wrapped[1];
+  return value;
+}
+
+const containsInputPlaceholder = (value: string): boolean =>
+  /\$(input|value)\b/.test(value);
+
+/**
+ * Predict the frontmatter mutation for a single grounding dispatch.
+ *
+ * The caller is expected to pre-parse the grounding tree (via
+ * `loadResolutionContext` / the command-catalog helpers) so this function is
+ * deterministic and side-effect free.
+ */
+export function predictMutationForGrounding(
+  grounding: GroundingDefinition,
+  targetIRI: string,
+  userInput?: PredictorUserInput,
+  context: PredictorContext = {},
+): PredictedMutation {
+  const now = context.now ?? new Date();
+  return predictGrounding(grounding, targetIRI, userInput, now);
+}
+
+function predictGrounding(
+  g: GroundingDefinition,
+  targetIRI: string,
+  userInput: PredictorUserInput | undefined,
+  now: Date,
+): PredictedMutation {
+  switch (g.type) {
+    case GroundingType.PROPERTY_SET:
+      return predictPropertySet(g, targetIRI, userInput, now);
+    case GroundingType.PROPERTY_DELETE:
+      return predictPropertyDelete(g);
+    case GroundingType.COMPOSITE:
+      return predictComposite(g, targetIRI, userInput, now);
+    case GroundingType.SERVICE_CALL:
+      return predictServiceCall(g);
+    case GroundingType.CREATE_INSTANCE:
+      return predictCreateInstance(g);
+    case GroundingType.SPARQL_UPDATE:
+      return {
+        frontmatterDiff: {},
+        unpredictable: true,
+        reason: "sparql_update is not implemented in GroundingExecutor",
+      };
+    default:
+      return {
+        frontmatterDiff: {},
+        unpredictable: true,
+        reason: `Unknown grounding type: ${String(g.type)}`,
+      };
+  }
+}
+
+function predictPropertySet(
+  g: GroundingDefinition,
+  targetIRI: string,
+  userInput: PredictorUserInput | undefined,
+  now: Date,
+): PredictedMutation {
+  if (!g.targetProperty || g.targetValue === undefined) {
+    return {
+      frontmatterDiff: {},
+      unpredictable: true,
+      reason: "property_set grounding missing targetProperty or targetValue",
+    };
+  }
+  if (
+    containsInputPlaceholder(g.targetValue) &&
+    (userInput === undefined ||
+      userInput.value === undefined ||
+      userInput.value === null)
+  ) {
+    return {
+      frontmatterDiff: {},
+      unpredictable: true,
+      reason:
+        "property_set targetValue contains $input/$value but userInput.value is missing",
+    };
+  }
+  const hasNowLocal = /\$nowLocal/.test(g.targetValue);
+  const substituted = substituteVariables(g.targetValue, targetIRI, userInput, now);
+  const diff: Record<string, string> = { [g.targetProperty]: substituted };
+  if (hasNowLocal) {
+    return {
+      frontmatterDiff: diff,
+      timestampRegexes: { [g.targetProperty]: TIMESTAMP_ANY_RE },
+    };
+  }
+  return { frontmatterDiff: diff };
+}
+
+function predictPropertyDelete(g: GroundingDefinition): PredictedMutation {
+  if (!g.targetProperty) {
+    return {
+      frontmatterDiff: {},
+      unpredictable: true,
+      reason: "property_delete grounding missing targetProperty",
+    };
+  }
+  return { frontmatterDiff: { [g.targetProperty]: "__DELETE__" } };
+}
+
+function predictComposite(
+  g: GroundingDefinition,
+  targetIRI: string,
+  userInput: PredictorUserInput | undefined,
+  now: Date,
+): PredictedMutation {
+  const steps = g.steps ?? [];
+  const merged: Record<string, string> = {};
+  const regexes: Record<string, RegExp> = {};
+  for (const step of steps) {
+    const stepResult = predictGrounding(step, targetIRI, userInput, now);
+    if (stepResult.unpredictable) return stepResult;
+    Object.assign(merged, stepResult.frontmatterDiff);
+    if (stepResult.timestampRegexes) {
+      Object.assign(regexes, stepResult.timestampRegexes);
+    }
+  }
+  return Object.keys(regexes).length === 0
+    ? { frontmatterDiff: merged }
+    : { frontmatterDiff: merged, timestampRegexes: regexes };
+}
+
+function predictServiceCall(g: GroundingDefinition): PredictedMutation {
+  // For service_call, executor:331 repurposes `targetProperty` as `serviceId`.
+  const serviceId = g.targetProperty;
+  if (!serviceId) {
+    return {
+      frontmatterDiff: {},
+      unpredictable: true,
+      reason: "service_call grounding missing serviceId (targetProperty)",
+    };
+  }
+  // Branch 1 — convertToTask direct alias.
+  if (serviceId === "convertToTask") {
+    return {
+      frontmatterDiff: { exo__Instance_class: `["[[ems__Task]]"]` },
+    };
+  }
+  if (serviceId === "updateProperty") {
+    const cls = extractClassFromTargetValue(g.targetValue);
+    // Branch 2 — updateProperty + ems__Task class-flip.
+    if (cls === "ems__Task") {
+      return {
+        frontmatterDiff: { exo__Instance_class: `["[[ems__Task]]"]` },
+      };
+    }
+    // Branch 3 — updateProperty + ems__Project class-flip.
+    if (cls === "ems__Project") {
+      return {
+        frontmatterDiff: { exo__Instance_class: `["[[ems__Project]]"]` },
+      };
+    }
+  }
+  return {
+    frontmatterDiff: {},
+    unpredictable: true,
+    reason: `service_call "${serviceId}" is dispatch-only; predictor is silent by design`,
+  };
+}
+
+function predictCreateInstance(g: GroundingDefinition): PredictedMutation {
+  if (!g.targetFolder) {
+    return {
+      frontmatterDiff: {},
+      unpredictable: true,
+      reason: "create_instance grounding missing targetFolder",
+    };
+  }
+  return {
+    frontmatterDiff: {},
+    fileCreation: {
+      targetFolder: g.targetFolder,
+      targetClass: g.targetClass,
+      targetPrototype: g.targetPrototype,
+    },
+  };
+}
+
+/**
+ * Convenience assertion helper — flattens a `PredictedMutation` + a raw
+ * `after` frontmatter into a `{ matches: boolean; failures: string[] }` for
+ * parametrized test output. Not a jest matcher (kept stdout-friendly).
+ */
+export function matchMutation(
+  predicted: PredictedMutation,
+  afterFrontmatter: Record<string, unknown>,
+): { matches: boolean; failures: string[] } {
+  const failures: string[] = [];
+  for (const [key, expected] of Object.entries(predicted.frontmatterDiff)) {
+    const actual = afterFrontmatter[key];
+    const regex = predicted.timestampRegexes?.[key];
+    if (regex) {
+      if (typeof actual !== "string" || !regex.test(actual)) {
+        failures.push(`${key}: actual=${JSON.stringify(actual)} does not match ${regex}`);
+      }
+    } else if (expected === "__DELETE__") {
+      if (key in afterFrontmatter) {
+        failures.push(`${key}: expected to be deleted but present as ${JSON.stringify(actual)}`);
+      }
+    } else if (actual !== expected) {
+      failures.push(`${key}: expected=${JSON.stringify(expected)} actual=${JSON.stringify(actual)}`);
+    }
+  }
+  return { matches: failures.length === 0, failures };
+}

--- a/packages/cli/tests/integration/starter-kit/test-helpers/user-input-factory.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/user-input-factory.ts
@@ -1,0 +1,201 @@
+/**
+ * User-input factory — Phase 1 integration helper (RFC v4 §7.1a contract).
+ *
+ * Synthesises `--input '<JSON>'` payloads for starter-kit commands whose
+ * `exocmd__Grounding_inputSchema` declares a JSON Schema object. The factory
+ * is deliberately narrow: it maps the 5 conceptual field types documented in
+ * memory `reference_inputschema_field_mapping` (text / date / enum / multiline
+ * / assetRef) to deterministic fixture values, so the same parametrized test
+ * case emits the same `--input` payload across runs.
+ *
+ * Field name contract: downstream `GroundingExecutor.substituteVariables`
+ * substitutes `$input` / `$value` with `userInput.value`. Schemas with the
+ * field `value` are passed through; schemas with the field `label` (used by
+ * `create_instance` groundings) are also passed through under that name.
+ * Any other property name is flagged as unsupported — we don't silently
+ * rename fields.
+ *
+ * RFC v4 §12 gate: matching unit test lives at
+ * `packages/cli/tests/unit/test-helpers/user-input-factory.test.ts`.
+ */
+
+/** Conceptual field-type families recognised by the factory. */
+export type FieldType =
+  | "text"
+  | "multiline"
+  | "date"
+  | "enum"
+  | "assetRef";
+
+/** JSON-Schema shape (narrow subset the starter-kit actually uses). */
+export interface JsonSchemaField {
+  readonly type?: string;
+  readonly format?: string;
+  readonly enum?: readonly unknown[];
+  readonly title?: string;
+  /** Non-standard marker for multi-line input (mirrors plugin convention). */
+  readonly multiline?: boolean;
+}
+
+export interface JsonSchemaObject {
+  readonly type?: "object";
+  readonly properties?: Readonly<Record<string, JsonSchemaField>>;
+  readonly required?: readonly string[];
+}
+
+/** Result emitted by `buildUserInputForSchema`. */
+export interface UserInputResult {
+  /** JSON object suitable for `dyncommand exec --input`. */
+  readonly payload: Record<string, unknown>;
+  /** Conceptual type recognised for the payload field. */
+  readonly fieldType: FieldType;
+  /** Payload property name (`value` for $input/$value substitution). */
+  readonly fieldName: string;
+}
+
+/** Deterministic constants per RFC §7.1a § "buildUserInputFor contract". */
+export const DEFAULT_DATE = "2026-04-20";
+export const DEFAULT_TEXT_PREFIX = "test-input-";
+export const DEFAULT_MULTILINE_PREFIX = "test-multiline-";
+
+/**
+ * Classify a JSON-schema field into one of the 5 conceptual families.
+ *
+ * Algorithm:
+ *   - `enum` present                               → `enum`
+ *   - `format === "asset-reference"` or `"assetRef"` → `assetRef`
+ *   - `format === "date"` or `"date-time"`         → `date`
+ *   - `format === "textarea"` or `multiline === true` → `multiline`
+ *   - otherwise (incl. `type === "string"` bare)  → `text`
+ */
+export function classifyField(field: JsonSchemaField | undefined): FieldType {
+  if (!field) return "text";
+  if (Array.isArray(field.enum) && field.enum.length > 0) return "enum";
+  const fmt = field.format?.toLowerCase();
+  if (fmt === "asset-reference" || fmt === "assetref") return "assetRef";
+  if (fmt === "date" || fmt === "date-time") return "date";
+  if (fmt === "textarea" || field.multiline === true) return "multiline";
+  return "text";
+}
+
+/**
+ * Synthesise a deterministic value for a single field.
+ *
+ * `seed` is incorporated into text-like results so parametrized tests over
+ * distinct commands emit distinct payloads. `assetRefSeedUuid` is the UUID
+ * of a pre-created seed fixture the caller will have materialised via
+ * `fixture-factory` — reused as the `[[<uuid>]]` value.
+ */
+export function synthesiseFieldValue(
+  fieldType: FieldType,
+  field: JsonSchemaField | undefined,
+  seed: string,
+  assetRefSeedUuid?: string,
+): unknown {
+  switch (fieldType) {
+    case "enum": {
+      const first = field?.enum?.[0];
+      if (first === undefined) {
+        throw new Error(
+          "user-input-factory: classified as enum but schema has no options",
+        );
+      }
+      return first;
+    }
+    case "date":
+      return DEFAULT_DATE;
+    case "multiline":
+      return `${DEFAULT_MULTILINE_PREFIX}${seed}`;
+    case "assetRef":
+      if (!assetRefSeedUuid) {
+        throw new Error(
+          "user-input-factory: assetRef field requires `assetRefSeedUuid`",
+        );
+      }
+      return `[[${assetRefSeedUuid}]]`;
+    case "text":
+    default:
+      return `${DEFAULT_TEXT_PREFIX}${seed}`;
+  }
+}
+
+export interface BuildUserInputOptions {
+  readonly seed: string;
+  /** UUID of a pre-materialised asset fixture used for `assetRef` fields. */
+  readonly assetRefSeedUuid?: string;
+}
+
+/**
+ * Build a deterministic `{ [fieldName]: value }` payload from a JSON schema.
+ * Returns `undefined` when the schema has no properties (the command does
+ * not require userInput — `--input` flag should be omitted entirely).
+ *
+ * Throws on unsupported shapes rather than guessing — silent fallback is the
+ * class of bug that caused the CLI parity sprint's `userInput` silent-fail
+ * memories.
+ */
+export function buildUserInputForSchema(
+  schema: JsonSchemaObject | undefined,
+  opts: BuildUserInputOptions,
+): UserInputResult | undefined {
+  if (!schema || !schema.properties) return undefined;
+  const entries = Object.entries(schema.properties);
+  if (entries.length === 0) return undefined;
+  if (entries.length > 1) {
+    throw new Error(
+      `user-input-factory: multi-field schemas unsupported (${entries.length} fields); starter-kit commands use single-field inputs`,
+    );
+  }
+  const [fieldName, field] = entries[0];
+  if (fieldName !== "value" && fieldName !== "label") {
+    throw new Error(
+      `user-input-factory: unsupported field name "${fieldName}" — only "value" (for $input/$value substitution) and "label" (for create_instance) are recognised`,
+    );
+  }
+  const fieldType = classifyField(field);
+  const payload: Record<string, unknown> = {
+    [fieldName]: synthesiseFieldValue(
+      fieldType,
+      field,
+      opts.seed,
+      opts.assetRefSeedUuid,
+    ),
+  };
+  return { payload, fieldName, fieldType };
+}
+
+/**
+ * Parse the inline `exocmd__Grounding_inputSchema` frontmatter string into a
+ * `JsonSchemaObject`. Starter-kit stores schemas as inline JSON strings in the
+ * grounding frontmatter. Returns `undefined` when the field is absent or
+ * malformed (so tests skip `--input` gracefully instead of crashing).
+ */
+export function parseInputSchemaFromGroundingRaw(
+  raw: unknown,
+): JsonSchemaObject | undefined {
+  if (typeof raw !== "string" || raw.trim().length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as JsonSchemaObject;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Convenience: given a grounding frontmatter record + build options, resolve
+ * the inputSchema and synthesise the payload in one call. Production call
+ * sites use this; unit tests exercise `buildUserInputForSchema` directly.
+ */
+export function buildUserInputForGroundingFrontmatter(
+  groundingFrontmatter: Record<string, unknown> | undefined,
+  opts: BuildUserInputOptions,
+): UserInputResult | undefined {
+  const schema = parseInputSchemaFromGroundingRaw(
+    groundingFrontmatter?.["exocmd__Grounding_inputSchema"],
+  );
+  return buildUserInputForSchema(schema, opts);
+}

--- a/packages/cli/tests/unit/test-helpers/execute-command.test.ts
+++ b/packages/cli/tests/unit/test-helpers/execute-command.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for the integration-layer `execute-command.ts` wrapper.
+ *
+ * Covers the node-fs adapters + `toGroundingDefinition` transformer. The
+ * end-to-end `executeCommandHarness` path is covered by the parametrized
+ * integration suite (to be added in Phase 1 follow-up tasks); this suite
+ * keeps the transformer honest without touching the submodule.
+ */
+import { describe, it, expect } from "@jest/globals";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { GroundingType, ServiceRegistry } from "exocortex";
+import {
+  NodeFileSystemReader,
+  NodeFileSystemWriter,
+  executeCommandHarness,
+  toGroundingDefinition,
+} from "../../integration/starter-kit/test-helpers/execute-command.js";
+import type { GroundingData } from "../../integration/starter-kit/test-helpers/extract-target-class.js";
+
+// ---------------------------------------------------------------------------
+// toGroundingDefinition
+// ---------------------------------------------------------------------------
+
+describe("toGroundingDefinition", () => {
+  it("maps property_set", () => {
+    const out = toGroundingDefinition({
+      uid: "g-1",
+      label: "Set Status",
+      type: "property_set",
+      targetProperty: "ems__Effort_status",
+      targetValue: `"[[ems__EffortStatusDoing]]"`,
+      raw: {},
+    });
+    expect(out).toMatchObject({
+      id: "g-1",
+      label: "Set Status",
+      type: GroundingType.PROPERTY_SET,
+      targetProperty: "ems__Effort_status",
+      targetValue: `"[[ems__EffortStatusDoing]]"`,
+    });
+  });
+
+  it("maps property_delete", () => {
+    const out = toGroundingDefinition({
+      uid: "g-2",
+      label: "Delete",
+      type: "property_delete",
+      targetProperty: "ems__Effort_endTimestamp",
+      raw: {},
+    });
+    expect(out.type).toBe(GroundingType.PROPERTY_DELETE);
+  });
+
+  it("maps service_call and copies serviceId into targetProperty", () => {
+    const out = toGroundingDefinition({
+      uid: "g-3",
+      label: "Convert",
+      type: "service_call",
+      serviceId: "updateProperty",
+      targetValue: `"[[ems__Task]]"`,
+      raw: {},
+    });
+    expect(out.type).toBe(GroundingType.SERVICE_CALL);
+    expect(out.targetProperty).toBe("updateProperty");
+    expect(out.targetValue).toBe(`"[[ems__Task]]"`);
+  });
+
+  it("does NOT overwrite explicit targetProperty on service_call", () => {
+    const out = toGroundingDefinition({
+      uid: "g-3b",
+      label: "Convert",
+      type: "service_call",
+      targetProperty: "updateProperty",
+      serviceId: "different-value",
+      targetValue: `"[[ems__Task]]"`,
+      raw: {},
+    });
+    expect(out.targetProperty).toBe("updateProperty");
+  });
+
+  it("maps composite and recurses into steps", () => {
+    const data: GroundingData = {
+      uid: "g-4",
+      label: "Transition",
+      type: "composite",
+      steps: [
+        {
+          uid: "s-1",
+          label: "Set status",
+          type: "property_set",
+          targetProperty: "ems__Effort_status",
+          targetValue: `"[[ems__EffortStatusDoing]]"`,
+          raw: {},
+        },
+        {
+          uid: "s-2",
+          label: "Set timestamp",
+          type: "property_set",
+          targetProperty: "ems__Effort_startTimestamp",
+          targetValue: "$nowLocal",
+          raw: {},
+        },
+      ],
+      raw: {},
+    };
+    const out = toGroundingDefinition(data);
+    expect(out.type).toBe(GroundingType.COMPOSITE);
+    expect(out.steps).toHaveLength(2);
+    expect(out.steps?.[0].type).toBe(GroundingType.PROPERTY_SET);
+    expect(out.steps?.[1].targetValue).toBe("$nowLocal");
+  });
+
+  it("defaults to PROPERTY_SET for unknown types (executor will reject)", () => {
+    const out = toGroundingDefinition({
+      uid: "g-5",
+      label: "Unknown",
+      type: "nonsense",
+      raw: {},
+    });
+    expect(out.type).toBe(GroundingType.PROPERTY_SET);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NodeFileSystemReader / NodeFileSystemWriter
+// ---------------------------------------------------------------------------
+
+describe("NodeFileSystemReader / NodeFileSystemWriter", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "execute-command-unit-"));
+  afterAll(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  const reader = new NodeFileSystemReader();
+  const writer = new NodeFileSystemWriter();
+
+  it("readFile round-trips writeFile", async () => {
+    const file = path.join(tmp, "a.md");
+    await writer.writeFile(file, "hello");
+    expect(await reader.readFile(file)).toBe("hello");
+  });
+
+  it("fileExists returns true/false", async () => {
+    const existing = path.join(tmp, "b.md");
+    await writer.writeFile(existing, "x");
+    expect(await reader.fileExists(existing)).toBe(true);
+    expect(await reader.fileExists(path.join(tmp, "missing.md"))).toBe(false);
+  });
+
+  it("updateFile overwrites existing content", async () => {
+    const file = path.join(tmp, "c.md");
+    await writer.writeFile(file, "before");
+    await writer.updateFile(file, "after");
+    expect(await reader.readFile(file)).toBe("after");
+  });
+
+  it("createFile fails when file already exists", async () => {
+    const file = path.join(tmp, "d.md");
+    await writer.createFile(file, "v1");
+    await expect(writer.createFile(file, "v2")).rejects.toThrow();
+  });
+
+  it("deleteFile + renameFile behave as expected", async () => {
+    const a = path.join(tmp, "rename-a.md");
+    const b = path.join(tmp, "rename-b.md");
+    await writer.writeFile(a, "content");
+    await writer.renameFile(a, b);
+    expect(await reader.fileExists(a)).toBe(false);
+    expect(await reader.fileExists(b)).toBe(true);
+    await writer.deleteFile(b);
+    expect(await reader.fileExists(b)).toBe(false);
+  });
+
+  it("getMarkdownFiles walks subdirectories and filters .md", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "md-walk-"));
+    try {
+      fs.mkdirSync(path.join(root, "sub"));
+      fs.writeFileSync(path.join(root, "a.md"), "");
+      fs.writeFileSync(path.join(root, "b.txt"), "");
+      fs.writeFileSync(path.join(root, "sub", "c.md"), "");
+      const files = await reader.getMarkdownFiles(root);
+      const rel = files.map((p) => path.relative(root, p)).sort();
+      expect(rel).toEqual(["a.md", "sub/c.md"]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeCommandHarness — smoke via real GroundingExecutor
+// ---------------------------------------------------------------------------
+
+describe("executeCommandHarness (real GroundingExecutor end-to-end)", () => {
+  it("dispatches a property_set grounding and mutates the target file", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "execute-smoke-"));
+    try {
+      const filePath = path.join(tmp, "host.md");
+      fs.writeFileSync(
+        filePath,
+        [
+          "---",
+          `exo__Asset_uid: host-uid`,
+          `exo__Asset_label: "Host"`,
+          `exo__Instance_class:`,
+          `  - "[[ems__Task]]"`,
+          "---",
+          "",
+          "# Host",
+          "",
+        ].join("\n"),
+      );
+      const result = await executeCommandHarness({
+        grounding: {
+          uid: "g-smoke",
+          label: "Set Status",
+          type: "property_set",
+          targetProperty: "ems__Effort_status",
+          targetValue: `"[[ems__EffortStatusDoing]]"`,
+          raw: {},
+        },
+        filePath,
+        targetIRI: "obsidian://vault/host",
+      });
+      expect(result.success).toBe(true);
+      const after = fs.readFileSync(filePath, "utf8");
+      expect(after).toContain("ems__Effort_status");
+      expect(after).toContain("ems__EffortStatusDoing");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts a custom ServiceRegistry", async () => {
+    const registry = new ServiceRegistry();
+    expect(registry.getRegisteredIds()).toEqual([]);
+    // Harness must accept and forward the registry — no crash on generic
+    // service_call with unknown serviceId (error surfaces as result.success=false).
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "execute-registry-"));
+    try {
+      const filePath = path.join(tmp, "h.md");
+      fs.writeFileSync(filePath, "---\n---\n");
+      const result = await executeCommandHarness({
+        grounding: {
+          uid: "g-sc",
+          label: "Unknown service",
+          type: "service_call",
+          serviceId: "notRegistered",
+          raw: {},
+        },
+        filePath,
+        targetIRI: "obsidian://vault/h",
+        serviceRegistry: registry,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Service not found/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/tests/unit/test-helpers/extract-target-class.test.ts
+++ b/packages/cli/tests/unit/test-helpers/extract-target-class.test.ts
@@ -1,0 +1,546 @@
+/**
+ * Unit tests for the integration-layer `extract-target-class.ts` helper.
+ *
+ * Covers the 5-strategy ladder (RFC v4 §7.1a) with in-memory fixtures so the
+ * test suite runs without touching the starter-kit submodule. The companion
+ * integration self-test (TBD) asserts the aggregate distribution against the
+ * real 44-Command catalog.
+ */
+import { describe, it, expect } from "@jest/globals";
+import type { CommandCatalogEntry } from "../../integration/starter-kit/test-helpers/command-catalog.js";
+import {
+  extractClassFromSparql,
+  extractTargetClassFromCommand,
+  loadStarterKitContext,
+  type StarterKitContext,
+  type PreconditionData,
+  type GroundingData,
+} from "../../integration/starter-kit/test-helpers/extract-target-class.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function ctx(
+  overrides: Partial<{
+    preconditions: Iterable<readonly [string, PreconditionData]>;
+    groundings: Iterable<readonly [string, GroundingData]>;
+    classLabelByUuid: Iterable<readonly [string, string]>;
+  }> = {},
+): StarterKitContext {
+  return {
+    preconditions: new Map(overrides.preconditions ?? []),
+    groundings: new Map(overrides.groundings ?? []),
+    classLabelByUuid: new Map(overrides.classLabelByUuid ?? []),
+  };
+}
+
+function cmd(overrides: Partial<CommandCatalogEntry>): CommandCatalogEntry {
+  return {
+    uid: overrides.uid ?? "00000000-0000-0000-0000-000000000000",
+    label: overrides.label ?? "Test Command",
+    path: overrides.path ?? "/fixtures/cmd.md",
+    classUuid: overrides.classUuid ?? "790e5b16-251d-4556-96ac-e5c7f1429b2e",
+    icon: overrides.icon,
+    category: overrides.category,
+    grounding: overrides.grounding,
+    precondition: overrides.precondition,
+    targetClass: overrides.targetClass,
+    raw: overrides.raw ?? {},
+  };
+}
+
+function grounding(overrides: Partial<GroundingData>): GroundingData {
+  return {
+    uid: overrides.uid ?? "g-1",
+    label: overrides.label ?? "g",
+    type: overrides.type,
+    targetProperty: overrides.targetProperty,
+    targetValue: overrides.targetValue,
+    serviceId: overrides.serviceId,
+    inputSchema: overrides.inputSchema,
+    targetClass: overrides.targetClass,
+    steps: overrides.steps,
+    raw: overrides.raw ?? {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// extractClassFromSparql — Strategy 2 helper
+// ---------------------------------------------------------------------------
+
+describe("extractClassFromSparql", () => {
+  it("detects $target rdf:type <ns#Class>", () => {
+    const hit = extractClassFromSparql(
+      "ASK { $target rdf:type <https://exocortex.my/ontology/ems#Task> . }",
+    );
+    expect(hit?.class).toBe("Task");
+    expect(hit?.reason).toMatch(/rdf:type/);
+  });
+
+  it("detects $target a <ns#Class> (shorthand)", () => {
+    const hit = extractClassFromSparql(
+      "ASK { $target a <https://exocortex.my/ontology/ems#Task> }",
+    );
+    expect(hit?.class).toBe("Task");
+  });
+
+  it("extracts ns__Class from a single property-prefix pattern", () => {
+    const hit = extractClassFromSparql(
+      "ASK { FILTER NOT EXISTS { $target ems:Effort_status ?x . } }",
+    );
+    expect(hit?.class).toBe("ems__Effort");
+    expect(hit?.reason).toMatch(/property-prefix/);
+  });
+
+  it("ignores exo:Instance_class (belongs to S4 pivot)", () => {
+    const hit = extractClassFromSparql(
+      "ASK { $target exo:Instance_class ?x }",
+    );
+    expect(hit).toBeUndefined();
+  });
+
+  it("returns undefined when multiple distinct classes are mentioned", () => {
+    const hit = extractClassFromSparql(
+      "ASK { $target ems:Task_zone ?z . $target ems:Effort_status ?s . }",
+    );
+    expect(hit).toBeUndefined();
+  });
+
+  it("detects Task_zone (criticality family)", () => {
+    const hit = extractClassFromSparql(
+      "ASK { FILTER NOT EXISTS { $target ems:Task_zone ?z . } }",
+    );
+    expect(hit?.class).toBe("ems__Task");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strategy 1 — explicit exocmd__Command_targetClass
+// ---------------------------------------------------------------------------
+
+describe("extractTargetClassFromCommand — Strategy 1 (explicit targetClass)", () => {
+  it("returns the class for a literal wikilink", () => {
+    const result = extractTargetClassFromCommand(
+      cmd({ targetClass: "[[ems__Project]]" }),
+      ctx(),
+    );
+    expect(result.strategy).toBe("S1");
+    expect(result.targetClass).toBe("ems__Project");
+    expect(result.dispatchOnly).toBe(false);
+  });
+
+  it("resolves a UUID-form wikilink via classLabelByUuid", () => {
+    const CLS_UUID = "11111111-1111-4111-8111-111111111111";
+    const result = extractTargetClassFromCommand(
+      cmd({ targetClass: `[[${CLS_UUID}|ems__Project]]` }),
+      ctx({ classLabelByUuid: [[CLS_UUID, "ems__Project"]] }),
+    );
+    expect(result.strategy).toBe("S1");
+    expect(result.targetClass).toBe("ems__Project");
+  });
+
+  it("falls through to later strategies when targetClass UUID is unknown", () => {
+    const result = extractTargetClassFromCommand(
+      cmd({ targetClass: "[[22222222-2222-4222-8222-222222222222]]" }),
+      ctx(), // no reverse index entry
+    );
+    // No precondition/grounding → S5 fallback.
+    expect(result.strategy).toBe("S5");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strategy 2 — precondition SPARQL inspection
+// ---------------------------------------------------------------------------
+
+describe("extractTargetClassFromCommand — Strategy 2 (precondition SPARQL)", () => {
+  it("extracts class from Effort_status precondition", () => {
+    const P_UID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const result = extractTargetClassFromCommand(
+      cmd({ precondition: `[[${P_UID}|Not in Doing]]` }),
+      ctx({
+        preconditions: [
+          [
+            P_UID,
+            {
+              uid: P_UID,
+              label: "Not in Doing",
+              sparqlAsk:
+                "ASK { FILTER NOT EXISTS { $target ems:Effort_status ?x } }",
+            },
+          ],
+        ],
+      }),
+    );
+    expect(result.strategy).toBe("S2");
+    expect(result.targetClass).toBe("ems__Effort");
+  });
+
+  it("falls through when precondition has no sparqlAsk (host function)", () => {
+    const P_UID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const result = extractTargetClassFromCommand(
+      cmd({ precondition: `[[${P_UID}]]` }),
+      ctx({
+        preconditions: [
+          [
+            P_UID,
+            {
+              uid: P_UID,
+              label: "Rename",
+              hostFunction: "hasNonUidFilename",
+            },
+          ],
+        ],
+      }),
+    );
+    expect(result.strategy).toBe("S5");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strategy 3 — grounding targetProperty domain heuristic
+// ---------------------------------------------------------------------------
+
+describe("extractTargetClassFromCommand — Strategy 3 (targetProperty domain)", () => {
+  it("infers ems__Effort from `ems__Effort_plannedStartTimestamp` grounding", () => {
+    const G_UID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const result = extractTargetClassFromCommand(
+      cmd({ grounding: `[[${G_UID}]]` }),
+      ctx({
+        groundings: [
+          [
+            G_UID,
+            grounding({
+              uid: G_UID,
+              type: "service_call",
+              targetProperty: "updateProperty",
+              targetValue:
+                '{"property":"ems__Effort_plannedStartTimestamp"}',
+            }),
+          ],
+        ],
+      }),
+    );
+    expect(result.strategy).toBe("S3");
+    expect(result.targetClass).toBe("ems__Effort");
+  });
+
+  it("infers from composite steps targetProperty pool", () => {
+    const G_UID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    const result = extractTargetClassFromCommand(
+      cmd({ grounding: `[[${G_UID}]]` }),
+      ctx({
+        groundings: [
+          [
+            G_UID,
+            grounding({
+              uid: G_UID,
+              type: "composite",
+              steps: [
+                grounding({
+                  uid: "s-1",
+                  type: "property_set",
+                  targetProperty: "ems__Effort_scheduledDate",
+                }),
+                grounding({
+                  uid: "s-2",
+                  type: "property_set",
+                  targetProperty: "ems__Effort_status",
+                }),
+              ],
+            }),
+          ],
+        ],
+      }),
+    );
+    expect(result.strategy).toBe("S3");
+    expect(result.targetClass).toBe("ems__Effort");
+  });
+
+  it("returns undefined when composite spans multiple classes (falls through)", () => {
+    const G_UID = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+    const result = extractTargetClassFromCommand(
+      cmd({ grounding: `[[${G_UID}]]` }),
+      ctx({
+        groundings: [
+          [
+            G_UID,
+            grounding({
+              uid: G_UID,
+              type: "composite",
+              steps: [
+                grounding({
+                  uid: "s-1",
+                  type: "property_set",
+                  targetProperty: "ems__Effort_status",
+                }),
+                grounding({
+                  uid: "s-2",
+                  type: "property_set",
+                  targetProperty: "exo__Asset_uid",
+                }),
+              ],
+            }),
+          ],
+        ],
+      }),
+    );
+    expect(result.strategy).toBe("S5");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strategy 4 — class-flip pivot (Convert commands)
+// ---------------------------------------------------------------------------
+
+describe("extractTargetClassFromCommand — Strategy 4 (class-flip)", () => {
+  it("Convert to Task → fixture pre-flip is ems__Project", () => {
+    const G_UID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+    const result = extractTargetClassFromCommand(
+      cmd({ grounding: `[[${G_UID}]]` }),
+      ctx({
+        groundings: [
+          [
+            G_UID,
+            grounding({
+              uid: G_UID,
+              type: "service_call",
+              targetProperty: "updateProperty",
+              targetValue: `"[[ems__Task]]"`,
+            }),
+          ],
+        ],
+      }),
+    );
+    expect(result.strategy).toBe("S4");
+    expect(result.targetClass).toBe("ems__Project");
+  });
+
+  it("Convert to Project → fixture pre-flip is ems__Task", () => {
+    const G_UID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    const result = extractTargetClassFromCommand(
+      cmd({ grounding: `[[${G_UID}]]` }),
+      ctx({
+        groundings: [
+          [
+            G_UID,
+            grounding({
+              uid: G_UID,
+              type: "service_call",
+              targetProperty: "updateProperty",
+              targetValue: `"[[ems__Project]]"`,
+            }),
+          ],
+        ],
+      }),
+    );
+    expect(result.strategy).toBe("S4");
+    expect(result.targetClass).toBe("ems__Task");
+  });
+
+  it("resolves UUID-wikilink targetValue via classLabelByUuid", () => {
+    const G_UID = "11111111-2222-4333-8444-555555555555";
+    const TASK_UID = "df7e579d-02d4-4f3a-971f-3d1d785b689b";
+    const result = extractTargetClassFromCommand(
+      cmd({ grounding: `[[${G_UID}]]` }),
+      ctx({
+        groundings: [
+          [
+            G_UID,
+            grounding({
+              uid: G_UID,
+              type: "service_call",
+              targetProperty: "updateProperty",
+              targetValue: `[[${TASK_UID}]]`,
+            }),
+          ],
+        ],
+        classLabelByUuid: [[TASK_UID, "ems__Task"]],
+      }),
+    );
+    expect(result.strategy).toBe("S4");
+    expect(result.targetClass).toBe("ems__Project");
+  });
+
+  it("other-class flip falls back to ems__Effort (broadest pre-flip)", () => {
+    const G_UID = "22222222-3333-4444-8555-666666666666";
+    const result = extractTargetClassFromCommand(
+      cmd({ grounding: `[[${G_UID}]]` }),
+      ctx({
+        groundings: [
+          [
+            G_UID,
+            grounding({
+              uid: G_UID,
+              type: "service_call",
+              targetProperty: "updateProperty",
+              targetValue: `"[[ems__Area]]"`,
+            }),
+          ],
+        ],
+      }),
+    );
+    expect(result.strategy).toBe("S4");
+    expect(result.targetClass).toBe("ems__Effort");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strategy 5 — fallback
+// ---------------------------------------------------------------------------
+
+describe("extractTargetClassFromCommand — Strategy 5 (fallback)", () => {
+  it("returns ems__Task + dispatchOnly=true when nothing resolves", () => {
+    const result = extractTargetClassFromCommand(cmd({}), ctx());
+    expect(result.strategy).toBe("S5");
+    expect(result.targetClass).toBe("ems__Task");
+    expect(result.dispatchOnly).toBe(true);
+  });
+
+  it("returns fallback when grounding resolves but has no property hints", () => {
+    const G_UID = "aaaabbbb-cccc-4ddd-8eee-ffff00000000";
+    const result = extractTargetClassFromCommand(
+      cmd({ grounding: `[[${G_UID}]]` }),
+      ctx({
+        groundings: [
+          [
+            G_UID,
+            grounding({
+              uid: G_UID,
+              type: "service_call",
+              serviceId: "cleanProperties",
+            }),
+          ],
+        ],
+      }),
+    );
+    expect(result.strategy).toBe("S5");
+    expect(result.dispatchOnly).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadStarterKitContext — DI paths
+// ---------------------------------------------------------------------------
+
+describe("loadStarterKitContext", () => {
+  it("returns empty maps for an empty fixture set", () => {
+    const result = loadStarterKitContext({
+      fixturesRoot: "/none",
+      listMarkdownFiles: () => [],
+      readFile: () => "",
+    });
+    expect(result.preconditions.size).toBe(0);
+    expect(result.groundings.size).toBe(0);
+    expect(result.classLabelByUuid.size).toBe(0);
+  });
+
+  it("indexes a class definition via exo__Class UUID", () => {
+    const CLS_UID = "8619c4fc-64f1-4869-b17e-e34186cacca9";
+    const THIS_UID = "99999999-9999-4999-8999-999999999999";
+    const files = {
+      "/mock/cls.md": [
+        "---",
+        `exo__Asset_uid: ${THIS_UID}`,
+        `exo__Asset_label: "ems__Project"`,
+        `exo__Instance_class:`,
+        `  - "[[${CLS_UID}]]"`,
+        "---",
+      ].join("\n"),
+    };
+    const ctxOut = loadStarterKitContext({
+      fixturesRoot: "/mock",
+      listMarkdownFiles: () => Object.keys(files),
+      readFile: (p) => files[p as keyof typeof files],
+    });
+    expect(ctxOut.classLabelByUuid.get(THIS_UID)).toBe("ems__Project");
+  });
+
+  it("indexes a precondition asset with sparqlAsk", () => {
+    const PRE_CLS = "15d119b5-9636-431e-9e91-1f140107d059";
+    const THIS_UID = "88888888-8888-4888-8888-888888888888";
+    const files = {
+      "/mock/pre.md": [
+        "---",
+        `exo__Asset_uid: ${THIS_UID}`,
+        `exo__Asset_label: "Not in Done"`,
+        `exo__Instance_class:`,
+        `  - "[[${PRE_CLS}]]"`,
+        `exocmd__Precondition_sparqlAsk: "ASK { $target ems:Effort_status ?s }"`,
+        "---",
+      ].join("\n"),
+    };
+    const ctxOut = loadStarterKitContext({
+      fixturesRoot: "/mock",
+      listMarkdownFiles: () => Object.keys(files),
+      readFile: (p) => files[p as keyof typeof files],
+    });
+    const pre = ctxOut.preconditions.get(THIS_UID);
+    expect(pre?.sparqlAsk).toMatch(/ems:Effort_status/);
+    expect(pre?.label).toBe("Not in Done");
+  });
+
+  it("resolves composite grounding steps across files", () => {
+    const G_CLS = "11579feb-2e42-491c-af59-b89b1129a539";
+    const PARENT = "cafe0000-0000-4000-8000-aaaa00000000";
+    const STEP_A = "cafe0000-0000-4000-8000-aaaa00000001";
+    const files = {
+      "/mock/parent.md": [
+        "---",
+        `exo__Asset_uid: ${PARENT}`,
+        `exo__Asset_label: "Composite"`,
+        `exo__Instance_class:`,
+        `  - "[[${G_CLS}]]"`,
+        `exocmd__Grounding_type: composite`,
+        `exocmd__Grounding_steps:`,
+        `  - "[[${STEP_A}|Step A]]"`,
+        "---",
+      ].join("\n"),
+      "/mock/step-a.md": [
+        "---",
+        `exo__Asset_uid: ${STEP_A}`,
+        `exo__Asset_label: "Step A"`,
+        `exo__Instance_class:`,
+        `  - "[[${G_CLS}]]"`,
+        `exocmd__Grounding_type: property_set`,
+        `exocmd__Grounding_targetProperty: "ems__Effort_status"`,
+        "---",
+      ].join("\n"),
+    };
+    const ctxOut = loadStarterKitContext({
+      fixturesRoot: "/mock",
+      listMarkdownFiles: () => Object.keys(files),
+      readFile: (p) => files[p as keyof typeof files],
+    });
+    const parent = ctxOut.groundings.get(PARENT);
+    expect(parent?.type).toBe("composite");
+    expect(parent?.steps).toHaveLength(1);
+    expect(parent?.steps?.[0]?.targetProperty).toBe("ems__Effort_status");
+  });
+
+  it("skips files that fail to read or parse without throwing", () => {
+    const PRE_CLS = "15d119b5-9636-431e-9e91-1f140107d059";
+    const files = {
+      "/mock/broken.md": "---\nbad: yaml: here\n---",
+      "/mock/ok.md": [
+        "---",
+        `exo__Asset_uid: 77777777-7777-4777-8777-777777777777`,
+        `exo__Asset_label: "OK"`,
+        `exo__Instance_class:`,
+        `  - "[[${PRE_CLS}]]"`,
+        `exocmd__Precondition_sparqlAsk: "ASK { $target rdf:type <http://x#Y> }"`,
+        "---",
+      ].join("\n"),
+    };
+    const ctxOut = loadStarterKitContext({
+      fixturesRoot: "/mock",
+      listMarkdownFiles: () => Object.keys(files),
+      readFile: (p) => {
+        if (!(p in files)) throw new Error("missing");
+        return files[p as keyof typeof files];
+      },
+    });
+    expect(ctxOut.preconditions.size).toBe(1);
+  });
+});

--- a/packages/cli/tests/unit/test-helpers/fixture-factory.test.ts
+++ b/packages/cli/tests/unit/test-helpers/fixture-factory.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the integration-layer `fixture-factory.ts` helper.
+ *
+ * RFC v4 §12 PR-readiness gate pairs `tests/integration/**\/test-helpers/` with
+ * `tests/unit/**\/test-helpers/`. This suite keeps the factory's contract
+ * self-enforcing without relying on the starter-kit submodule or jest plumbing.
+ */
+import { describe, it, expect } from "@jest/globals";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  buildFixture,
+  cleanupFixtureRoot,
+  makeFixtureRoot,
+  uuidFromSeed,
+} from "../../integration/starter-kit/test-helpers/fixture-factory.js";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("uuidFromSeed", () => {
+  it("produces a UUIDv5-shaped identifier", () => {
+    const uid = uuidFromSeed("some-seed");
+    expect(uid).toMatch(UUID_RE);
+  });
+
+  it("is deterministic across invocations", () => {
+    expect(uuidFromSeed("cmd-a::case-1")).toBe(uuidFromSeed("cmd-a::case-1"));
+  });
+
+  it("produces distinct UIDs for distinct seeds", () => {
+    const a = uuidFromSeed("cmd-a::case-1");
+    const b = uuidFromSeed("cmd-a::case-2");
+    const c = uuidFromSeed("cmd-b::case-1");
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  it("treats empty string as a valid seed (still UUID-shaped)", () => {
+    expect(uuidFromSeed("")).toMatch(UUID_RE);
+  });
+});
+
+describe("makeFixtureRoot / cleanupFixtureRoot", () => {
+  it("creates a fresh empty directory under os.tmpdir()", () => {
+    const root = makeFixtureRoot();
+    try {
+      expect(fs.existsSync(root)).toBe(true);
+      expect(fs.readdirSync(root)).toEqual([]);
+      expect(root.startsWith(os.tmpdir())).toBe(true);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("allocates distinct roots on repeated calls (parallel-safe)", () => {
+    const a = makeFixtureRoot();
+    const b = makeFixtureRoot();
+    try {
+      expect(a).not.toBe(b);
+    } finally {
+      cleanupFixtureRoot(a);
+      cleanupFixtureRoot(b);
+    }
+  });
+
+  it("respects a custom prefix", () => {
+    const root = makeFixtureRoot("unit-fixture-prefix-");
+    try {
+      expect(path.basename(root)).toMatch(/^unit-fixture-prefix-/);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("cleanupFixtureRoot is idempotent / no-op on missing paths", () => {
+    const root = makeFixtureRoot();
+    cleanupFixtureRoot(root);
+    expect(() => cleanupFixtureRoot(root)).not.toThrow();
+    expect(() => cleanupFixtureRoot("")).not.toThrow();
+  });
+});
+
+describe("buildFixture", () => {
+  it("materialises a .md file with the deterministic UID as basename", () => {
+    const root = makeFixtureRoot();
+    try {
+      const asset = buildFixture({
+        className: "ems__Task",
+        seed: "deterministic-seed-1",
+        root,
+      });
+      expect(asset.uid).toMatch(UUID_RE);
+      expect(asset.path).toBe(path.join(root, `${asset.uid}.md`));
+      expect(fs.existsSync(asset.path)).toBe(true);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("emits valid frontmatter with class wikilink and alias", () => {
+    const root = makeFixtureRoot();
+    try {
+      const asset = buildFixture({
+        className: "ems__Project",
+        seed: "seed-project",
+        label: "My Fixture Project",
+        root,
+      });
+      const content = fs.readFileSync(asset.path, "utf8");
+      expect(content).toMatch(/^---\n/);
+      expect(content).toContain(`exo__Asset_uid: "${asset.uid}"`);
+      expect(content).toContain(`exo__Asset_label: "My Fixture Project"`);
+      expect(content).toContain(`- "[[ems__Project]]"`);
+      expect(content).toContain(`- "My Fixture Project"`);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("falls back to `Fixture for <seed>` label when label omitted", () => {
+    const root = makeFixtureRoot();
+    try {
+      const asset = buildFixture({
+        className: "ems__Task",
+        seed: "labelless",
+        root,
+      });
+      expect(asset.label).toBe("Fixture for labelless");
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("merges extraFrontmatter on top of the skeleton", () => {
+    const root = makeFixtureRoot();
+    try {
+      const asset = buildFixture({
+        className: "ems__Task",
+        seed: "extras",
+        root,
+        extraFrontmatter: {
+          ems__Effort_status: `"[[ems__EffortStatusBacklog]]"`,
+          tags: ["fixture", "smoke"],
+        },
+      });
+      const content = fs.readFileSync(asset.path, "utf8");
+      expect(content).toContain("ems__Effort_status");
+      expect(content).toContain("ems__EffortStatusBacklog");
+      expect(content).toContain("tags:");
+      expect(content).toContain(`- "fixture"`);
+      expect(content).toContain(`- "smoke"`);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("emits a stable Obsidian-style targetIRI", () => {
+    const root = makeFixtureRoot();
+    try {
+      const asset = buildFixture({
+        className: "ems__Task",
+        seed: "iri-shape",
+        root,
+      });
+      expect(asset.targetIRI).toBe(`obsidian://vault/${asset.uid}`);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("refuses to overwrite an existing fixture (seed collision)", () => {
+    const root = makeFixtureRoot();
+    try {
+      buildFixture({ className: "ems__Task", seed: "collide", root });
+      expect(() =>
+        buildFixture({ className: "ems__Task", seed: "collide", root }),
+      ).toThrow(/refusing to overwrite/);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("throws when root is missing or unset", () => {
+    expect(() =>
+      buildFixture({
+        className: "ems__Task",
+        seed: "no-root",
+        root: "",
+      }),
+    ).toThrow(/root does not exist/);
+
+    const fake = path.join(os.tmpdir(), `never-made-${Date.now()}`);
+    expect(() =>
+      buildFixture({ className: "ems__Task", seed: "fake-root", root: fake }),
+    ).toThrow(/root does not exist/);
+  });
+
+  it("encodes object-valued frontmatter as inline JSON", () => {
+    const root = makeFixtureRoot();
+    try {
+      const asset = buildFixture({
+        className: "ems__Task",
+        seed: "json-object",
+        root,
+        extraFrontmatter: {
+          custom__Nested: { property: "value", other: 1 },
+        },
+      });
+      const content = fs.readFileSync(asset.path, "utf8");
+      expect(content).toContain(
+        `custom__Nested: {"property":"value","other":1}`,
+      );
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+
+  it("round-trips the body heading with the asset label", () => {
+    const root = makeFixtureRoot();
+    try {
+      const asset = buildFixture({
+        className: "ems__Task",
+        seed: "body",
+        label: "Body Heading Sample",
+        root,
+      });
+      const content = fs.readFileSync(asset.path, "utf8");
+      expect(content.endsWith("# Body Heading Sample\n")).toBe(true);
+    } finally {
+      cleanupFixtureRoot(root);
+    }
+  });
+});

--- a/packages/cli/tests/unit/test-helpers/predict-mutation.test.ts
+++ b/packages/cli/tests/unit/test-helpers/predict-mutation.test.ts
@@ -1,0 +1,547 @@
+/**
+ * Unit tests for the integration-layer `predict-mutation.ts` helper.
+ *
+ * RFC v4 §7.1b branch-count gate: the predictor must stay within 5 per-command
+ * special-case branches. A dedicated test case (`"audit: per-command branch
+ * count"`) fails if a reviewer adds a 6th branch without reopening the RFC.
+ */
+import { describe, it, expect } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { GroundingType } from "exocortex";
+import type { GroundingDefinition } from "exocortex";
+import {
+  extractClassFromTargetValue,
+  matchMutation,
+  predictMutationForGrounding,
+  substituteVariables,
+} from "../../integration/starter-kit/test-helpers/predict-mutation.js";
+
+const FIXED_NOW = new Date("2026-04-20T15:30:00.000Z");
+const TARGET_IRI = "obsidian://vault/fixture-test";
+
+function grounding(
+  overrides: Partial<GroundingDefinition> & { type: GroundingType },
+): GroundingDefinition {
+  return {
+    id: overrides.id ?? "00000000-0000-0000-0000-000000000000",
+    label: overrides.label ?? "test-grounding",
+    type: overrides.type,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// substituteVariables
+// ---------------------------------------------------------------------------
+
+describe("substituteVariables", () => {
+  it("replaces $target with the passed IRI", () => {
+    const out = substituteVariables("$target", TARGET_IRI, undefined, FIXED_NOW);
+    expect(out).toBe(TARGET_IRI);
+  });
+
+  it("replaces $nowLocal with YYYY-MM-DDTHH:mm:ss (no ms, no tz)", () => {
+    const out = substituteVariables("$nowLocal", TARGET_IRI, undefined, FIXED_NOW);
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+    expect(out.endsWith("Z")).toBe(false);
+    expect(out.includes(".")).toBe(false);
+  });
+
+  it("replaces $now with full ISO 8601 Z timestamp", () => {
+    const out = substituteVariables("$now", TARGET_IRI, undefined, FIXED_NOW);
+    expect(out).toBe("2026-04-20T15:30:00.000Z");
+  });
+
+  it("replaces $today with YYYY-MM-DD", () => {
+    const out = substituteVariables("$today", TARGET_IRI, undefined, FIXED_NOW);
+    expect(out).toBe("2026-04-20");
+  });
+
+  it("replaces $input and $value when userInput.value is defined", () => {
+    const input = substituteVariables(
+      "$input",
+      TARGET_IRI,
+      { value: "hello" },
+      FIXED_NOW,
+    );
+    const value = substituteVariables(
+      "$value",
+      TARGET_IRI,
+      { value: 42 },
+      FIXED_NOW,
+    );
+    expect(input).toBe("hello");
+    expect(value).toBe("42");
+  });
+
+  it("leaves $input / $value untouched when userInput is missing", () => {
+    expect(
+      substituteVariables("$input", TARGET_IRI, undefined, FIXED_NOW),
+    ).toBe("$input");
+    expect(
+      substituteVariables("$value", TARGET_IRI, { value: null }, FIXED_NOW),
+    ).toBe("$value");
+  });
+
+  it("applies multiple substitutions in a single value", () => {
+    const out = substituteVariables(
+      "$target-$today",
+      TARGET_IRI,
+      undefined,
+      FIXED_NOW,
+    );
+    expect(out).toBe(`${TARGET_IRI}-2026-04-20`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractClassFromTargetValue — Literal-vs-IRI edge case
+// ---------------------------------------------------------------------------
+
+describe("extractClassFromTargetValue", () => {
+  it.each([
+    [`"[[ems__Task]]"`, "ems__Task"],
+    [`[[ems__Task]]`, "ems__Task"],
+    [`[[ems__Task|Task alias]]`, "ems__Task"],
+    [`ems__Task`, "ems__Task"],
+    [undefined, undefined],
+    ["", undefined],
+  ])("%p → %p", (input, expected) => {
+    expect(extractClassFromTargetValue(input)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// property_set / property_delete
+// ---------------------------------------------------------------------------
+
+describe("predictMutationForGrounding — property_set", () => {
+  it("predicts a simple literal value", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__Effort_status",
+        targetValue: `"[[ems__EffortStatusDoing]]"`,
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.frontmatterDiff).toEqual({
+      ems__Effort_status: `"[[ems__EffortStatusDoing]]"`,
+    });
+    expect(result.timestampRegexes).toBeUndefined();
+    expect(result.unpredictable).toBeUndefined();
+  });
+
+  it("emits a timestamp regex when targetValue uses $nowLocal", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__Effort_startTimestamp",
+        targetValue: "$nowLocal",
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.timestampRegexes?.ems__Effort_startTimestamp?.test(
+      "2026-04-20T20:30:00",
+    )).toBe(true);
+    expect(
+      result.timestampRegexes?.ems__Effort_startTimestamp?.test(
+        "not-a-timestamp",
+      ),
+    ).toBe(false);
+  });
+
+  it("substitutes $input when userInput.value provided", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__Effort_result",
+        targetValue: "$input",
+      }),
+      TARGET_IRI,
+      { value: "outcome text" },
+      { now: FIXED_NOW },
+    );
+    expect(result.frontmatterDiff.ems__Effort_result).toBe("outcome text");
+  });
+
+  it("flags unpredictable when $input placeholder present but userInput missing", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__Effort_result",
+        targetValue: "$input",
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.unpredictable).toBe(true);
+    expect(result.reason).toMatch(/\$input\/\$value/);
+  });
+
+  it("flags unpredictable on missing targetProperty/targetValue", () => {
+    const a = predictMutationForGrounding(
+      grounding({ type: GroundingType.PROPERTY_SET, targetValue: "x" }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    const b = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "ems__Effort_result",
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(a.unpredictable).toBe(true);
+    expect(b.unpredictable).toBe(true);
+  });
+});
+
+describe("predictMutationForGrounding — property_delete", () => {
+  it("emits a __DELETE__ sentinel for property_delete", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.PROPERTY_DELETE,
+        targetProperty: "ems__Effort_startTimestamp",
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.frontmatterDiff.ems__Effort_startTimestamp).toBe("__DELETE__");
+  });
+
+  it("flags unpredictable on missing targetProperty", () => {
+    const result = predictMutationForGrounding(
+      grounding({ type: GroundingType.PROPERTY_DELETE }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.unpredictable).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composite
+// ---------------------------------------------------------------------------
+
+describe("predictMutationForGrounding — composite", () => {
+  it("merges child frontmatter diffs (Set Status Doing shape)", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.COMPOSITE,
+        steps: [
+          grounding({
+            id: "step-1",
+            type: GroundingType.PROPERTY_SET,
+            targetProperty: "ems__Effort_status",
+            targetValue: `"[[ems__EffortStatusDoing]]"`,
+          }),
+          grounding({
+            id: "step-2",
+            type: GroundingType.PROPERTY_SET,
+            targetProperty: "ems__Effort_startTimestamp",
+            targetValue: "$nowLocal",
+          }),
+        ],
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.frontmatterDiff.ems__Effort_status).toBe(
+      `"[[ems__EffortStatusDoing]]"`,
+    );
+    expect(result.timestampRegexes?.ems__Effort_startTimestamp).toBeDefined();
+    expect(result.unpredictable).toBeUndefined();
+  });
+
+  it("propagates unpredictable from any failing step", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.COMPOSITE,
+        steps: [
+          grounding({
+            id: "ok",
+            type: GroundingType.PROPERTY_SET,
+            targetProperty: "a",
+            targetValue: "1",
+          }),
+          grounding({
+            id: "bad",
+            type: GroundingType.PROPERTY_SET,
+            targetProperty: "b",
+            // Missing targetValue
+          }),
+        ],
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.unpredictable).toBe(true);
+  });
+
+  it("handles empty composite as a no-op diff", () => {
+    const result = predictMutationForGrounding(
+      grounding({ type: GroundingType.COMPOSITE, steps: [] }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.frontmatterDiff).toEqual({});
+    expect(result.unpredictable).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// service_call — per-command class-flip branches (RFC §7.1b gate ≤5)
+// ---------------------------------------------------------------------------
+
+describe("predictMutationForGrounding — service_call class-flip branches", () => {
+  it("branch 1: serviceId=convertToTask → ems__Task class-flip", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "convertToTask",
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.frontmatterDiff.exo__Instance_class).toBe(
+      `["[[ems__Task]]"]`,
+    );
+  });
+
+  it("branch 2: serviceId=updateProperty + targetValue=ems__Task (wrapped)", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "updateProperty",
+        targetValue: `"[[ems__Task]]"`,
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.frontmatterDiff.exo__Instance_class).toBe(
+      `["[[ems__Task]]"]`,
+    );
+  });
+
+  it("branch 3: serviceId=updateProperty + targetValue=ems__Project", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "updateProperty",
+        targetValue: `[[ems__Project]]`,
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.frontmatterDiff.exo__Instance_class).toBe(
+      `["[[ems__Project]]"]`,
+    );
+  });
+
+  it("updateProperty + unknown class falls through to dispatch-only", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "updateProperty",
+        targetValue: `"[[ems__Area]]"`,
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.unpredictable).toBe(true);
+  });
+
+  it("generic service_call is dispatch-only (unpredictable)", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "cleanProperties",
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.unpredictable).toBe(true);
+  });
+
+  it("service_call without serviceId is unpredictable", () => {
+    const result = predictMutationForGrounding(
+      grounding({ type: GroundingType.SERVICE_CALL }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.unpredictable).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create_instance / sparql_update
+// ---------------------------------------------------------------------------
+
+describe("predictMutationForGrounding — create_instance / sparql_update", () => {
+  it("returns a fileCreation side-effect descriptor", () => {
+    const result = predictMutationForGrounding(
+      grounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetFolder: "01 Inbox",
+        targetClass: "ems__Task",
+        targetPrototype: "prototype-uuid",
+      }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.fileCreation).toEqual({
+      targetFolder: "01 Inbox",
+      targetClass: "ems__Task",
+      targetPrototype: "prototype-uuid",
+    });
+    expect(result.frontmatterDiff).toEqual({});
+  });
+
+  it("create_instance without targetFolder is unpredictable", () => {
+    const result = predictMutationForGrounding(
+      grounding({ type: GroundingType.CREATE_INSTANCE }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.unpredictable).toBe(true);
+  });
+
+  it("sparql_update is explicitly flagged unpredictable", () => {
+    const result = predictMutationForGrounding(
+      grounding({ type: GroundingType.SPARQL_UPDATE }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.unpredictable).toBe(true);
+    expect(result.reason).toMatch(/sparql_update/);
+  });
+
+  it("unknown grounding types are unpredictable (not a throw)", () => {
+    const result = predictMutationForGrounding(
+      grounding({ type: "nonsense" as GroundingType }),
+      TARGET_IRI,
+      undefined,
+      { now: FIXED_NOW },
+    );
+    expect(result.unpredictable).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchMutation — stdout-friendly diff helper
+// ---------------------------------------------------------------------------
+
+describe("matchMutation", () => {
+  it("reports matches=true when every predicted key equals the after-frontmatter", () => {
+    const predicted = {
+      frontmatterDiff: {
+        ems__Effort_status: `"[[ems__EffortStatusDoing]]"`,
+      },
+    };
+    const { matches, failures } = matchMutation(predicted, {
+      ems__Effort_status: `"[[ems__EffortStatusDoing]]"`,
+      aliases: ["unrelated"],
+    });
+    expect(matches).toBe(true);
+    expect(failures).toEqual([]);
+  });
+
+  it("reports failures with property name + both values", () => {
+    const predicted = {
+      frontmatterDiff: {
+        ems__Effort_status: `"[[ems__EffortStatusDoing]]"`,
+      },
+    };
+    const { matches, failures } = matchMutation(predicted, {
+      ems__Effort_status: `"[[ems__EffortStatusBacklog]]"`,
+    });
+    expect(matches).toBe(false);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatch(/ems__Effort_status/);
+    expect(failures[0]).toMatch(/Backlog/);
+  });
+
+  it("applies regex matchers for timestamp fields", () => {
+    const predicted = {
+      frontmatterDiff: { ems__Effort_startTimestamp: "ignored-base" },
+      timestampRegexes: {
+        ems__Effort_startTimestamp: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/,
+      },
+    };
+    const ok = matchMutation(predicted, {
+      ems__Effort_startTimestamp: "2026-04-20T15:30:00",
+    });
+    const bad = matchMutation(predicted, {
+      ems__Effort_startTimestamp: "garbage",
+    });
+    expect(ok.matches).toBe(true);
+    expect(bad.matches).toBe(false);
+  });
+
+  it("treats __DELETE__ expectation as 'key must be absent'", () => {
+    const predicted = {
+      frontmatterDiff: { ems__Effort_startTimestamp: "__DELETE__" },
+    };
+    const gone = matchMutation(predicted, { ems__Effort_status: "x" });
+    const still = matchMutation(predicted, {
+      ems__Effort_startTimestamp: "still-here",
+    });
+    expect(gone.matches).toBe(true);
+    expect(still.matches).toBe(false);
+    expect(still.failures[0]).toMatch(/expected to be deleted/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Branch-count audit — RFC §7.1b gate (≤ 5 per-command branches)
+// ---------------------------------------------------------------------------
+
+describe("audit: per-command branch count (RFC §7.1b)", () => {
+  it("service_call helper stays within 5 per-command special-case branches", () => {
+    const HERE = path.dirname(fileURLToPath(import.meta.url));
+    const source = fs.readFileSync(
+      path.resolve(
+        HERE,
+        "..",
+        "..",
+        "integration",
+        "starter-kit",
+        "test-helpers",
+        "predict-mutation.ts",
+      ),
+      "utf8",
+    );
+    // Count the 3 documented class-flip branches by matching the annotated
+    // `// Branch N — ...` comments. The annotation is load-bearing: any
+    // future reviewer adding a 4th/5th class-flip MUST attach the numbered
+    // comment; a 6th will fail this assertion loudly.
+    const branches = (source.match(/\/\/ Branch \d+ — /g) ?? []).length;
+    expect(branches).toBeLessThanOrEqual(5);
+    expect(branches).toBeGreaterThanOrEqual(3); // current baseline
+  });
+});

--- a/packages/cli/tests/unit/test-helpers/user-input-factory.test.ts
+++ b/packages/cli/tests/unit/test-helpers/user-input-factory.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Unit tests for the integration-layer `user-input-factory.ts` helper.
+ *
+ * RFC v4 §7.1a "5 field types" coverage: a dedicated describe block asserts
+ * every conceptual type (text / multiline / date / enum / assetRef) is
+ * classified and synthesised correctly.
+ */
+import { describe, it, expect } from "@jest/globals";
+import {
+  DEFAULT_DATE,
+  DEFAULT_MULTILINE_PREFIX,
+  DEFAULT_TEXT_PREFIX,
+  buildUserInputForGroundingFrontmatter,
+  buildUserInputForSchema,
+  classifyField,
+  parseInputSchemaFromGroundingRaw,
+  synthesiseFieldValue,
+} from "../../integration/starter-kit/test-helpers/user-input-factory.js";
+
+// ---------------------------------------------------------------------------
+// classifyField — five conceptual field types
+// ---------------------------------------------------------------------------
+
+describe("classifyField — 5 field type coverage (RFC §7.1a)", () => {
+  it.each<[object, string]>([
+    [{ type: "string" }, "text"],
+    [{ type: "string", title: "Project name" }, "text"],
+    [{ type: "string", format: "date" }, "date"],
+    [{ type: "string", format: "date-time" }, "date"],
+    [{ type: "string", format: "asset-reference" }, "assetRef"],
+    [{ type: "string", format: "assetRef" }, "assetRef"],
+    [{ type: "string", format: "textarea" }, "multiline"],
+    [{ type: "string", multiline: true }, "multiline"],
+    [{ type: "string", enum: ["a", "b"] }, "enum"],
+  ])("%j → %s", (field, expected) => {
+    expect(classifyField(field)).toBe(expected);
+  });
+
+  it("defaults to `text` for undefined field", () => {
+    expect(classifyField(undefined)).toBe("text");
+  });
+
+  it("empty enum array is NOT classified as enum", () => {
+    expect(classifyField({ enum: [] })).toBe("text");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// synthesiseFieldValue — deterministic, seeded
+// ---------------------------------------------------------------------------
+
+describe("synthesiseFieldValue — deterministic per field type", () => {
+  it("text → prefixed seed", () => {
+    expect(synthesiseFieldValue("text", undefined, "abc")).toBe(
+      `${DEFAULT_TEXT_PREFIX}abc`,
+    );
+  });
+
+  it("multiline → prefixed seed (distinct from text prefix)", () => {
+    const value = synthesiseFieldValue("multiline", undefined, "xyz");
+    expect(value).toBe(`${DEFAULT_MULTILINE_PREFIX}xyz`);
+    expect(value).not.toBe(synthesiseFieldValue("text", undefined, "xyz"));
+  });
+
+  it("date → fixed DEFAULT_DATE (2026-04-20)", () => {
+    expect(synthesiseFieldValue("date", undefined, "ignored")).toBe(
+      DEFAULT_DATE,
+    );
+  });
+
+  it("enum → first option from schema", () => {
+    expect(
+      synthesiseFieldValue("enum", { enum: ["Red", "Green"] }, "seed"),
+    ).toBe("Red");
+  });
+
+  it("enum without options throws", () => {
+    expect(() => synthesiseFieldValue("enum", {}, "seed")).toThrow(
+      /no options/,
+    );
+  });
+
+  it("assetRef → [[<seed-uuid>]]", () => {
+    expect(
+      synthesiseFieldValue(
+        "assetRef",
+        {},
+        "any-seed",
+        "00000000-0000-4000-8000-000000000000",
+      ),
+    ).toBe(`[[00000000-0000-4000-8000-000000000000]]`);
+  });
+
+  it("assetRef without seed UUID throws", () => {
+    expect(() => synthesiseFieldValue("assetRef", {}, "seed")).toThrow(
+      /assetRef field requires/,
+    );
+  });
+
+  it("text value is reproducible for same seed", () => {
+    const a = synthesiseFieldValue("text", undefined, "same");
+    const b = synthesiseFieldValue("text", undefined, "same");
+    expect(a).toBe(b);
+  });
+
+  it("text values differ across seeds", () => {
+    const a = synthesiseFieldValue("text", undefined, "alpha");
+    const b = synthesiseFieldValue("text", undefined, "beta");
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildUserInputForSchema — end-to-end
+// ---------------------------------------------------------------------------
+
+describe("buildUserInputForSchema — $value substitution contract", () => {
+  it("emits {value: ...} for text schema with property name `value`", () => {
+    const result = buildUserInputForSchema(
+      {
+        type: "object",
+        properties: { value: { type: "string", title: "Result" } },
+        required: ["value"],
+      },
+      { seed: "set-result" },
+    );
+    expect(result).toEqual({
+      payload: { value: `${DEFAULT_TEXT_PREFIX}set-result` },
+      fieldName: "value",
+      fieldType: "text",
+    });
+  });
+
+  it("emits {label: ...} for schemas that drive create_instance", () => {
+    const result = buildUserInputForSchema(
+      {
+        type: "object",
+        properties: { label: { type: "string", title: "Task name" } },
+        required: ["label"],
+      },
+      { seed: "create-task" },
+    );
+    expect(result?.fieldName).toBe("label");
+    expect(result?.payload).toEqual({
+      label: `${DEFAULT_TEXT_PREFIX}create-task`,
+    });
+  });
+
+  it("emits {value: DEFAULT_DATE} for date fields", () => {
+    const result = buildUserInputForSchema(
+      {
+        type: "object",
+        properties: {
+          value: { type: "string", title: "Scheduled date", format: "date" },
+        },
+      },
+      { seed: "scheduled-date" },
+    );
+    expect(result?.payload.value).toBe(DEFAULT_DATE);
+    expect(result?.fieldType).toBe("date");
+  });
+
+  it("emits {value: [[<uuid>]]} for asset-reference fields", () => {
+    const seedUuid = "cafebabe-1111-4222-8333-dead00000000";
+    const result = buildUserInputForSchema(
+      {
+        type: "object",
+        properties: {
+          value: {
+            type: "string",
+            title: "Parent",
+            format: "asset-reference",
+          },
+        },
+      },
+      { seed: "link-parent", assetRefSeedUuid: seedUuid },
+    );
+    expect(result?.fieldType).toBe("assetRef");
+    expect(result?.payload.value).toBe(`[[${seedUuid}]]`);
+  });
+
+  it("picks the first enum option", () => {
+    const result = buildUserInputForSchema(
+      {
+        type: "object",
+        properties: {
+          value: {
+            type: "string",
+            title: "Priority",
+            enum: ["High", "Medium", "Low"],
+          },
+        },
+      },
+      { seed: "priority" },
+    );
+    expect(result?.fieldType).toBe("enum");
+    expect(result?.payload.value).toBe("High");
+  });
+
+  it("returns undefined when the schema has no properties", () => {
+    expect(
+      buildUserInputForSchema({ type: "object", properties: {} }, {
+        seed: "x",
+      }),
+    ).toBeUndefined();
+    expect(buildUserInputForSchema(undefined, { seed: "x" })).toBeUndefined();
+  });
+
+  it("throws on unsupported multi-field schemas", () => {
+    expect(() =>
+      buildUserInputForSchema(
+        {
+          type: "object",
+          properties: {
+            value: { type: "string" },
+            extra: { type: "string" },
+          },
+        },
+        { seed: "multi" },
+      ),
+    ).toThrow(/multi-field schemas unsupported/);
+  });
+
+  it("throws on unsupported field names (not `value` or `label`)", () => {
+    expect(() =>
+      buildUserInputForSchema(
+        {
+          type: "object",
+          properties: { notValue: { type: "string" } },
+        },
+        { seed: "wrong-name" },
+      ),
+    ).toThrow(/unsupported field name/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseInputSchemaFromGroundingRaw — inline JSON tolerance
+// ---------------------------------------------------------------------------
+
+describe("parseInputSchemaFromGroundingRaw", () => {
+  it("parses starter-kit inline JSON shape", () => {
+    const raw =
+      '{"type":"object","properties":{"value":{"type":"string","title":"Planned start (date)"}},"required":["value"]}';
+    const schema = parseInputSchemaFromGroundingRaw(raw);
+    expect(schema?.properties?.value?.title).toBe("Planned start (date)");
+  });
+
+  it("returns undefined for missing / non-string input", () => {
+    expect(parseInputSchemaFromGroundingRaw(undefined)).toBeUndefined();
+    expect(parseInputSchemaFromGroundingRaw(42)).toBeUndefined();
+    expect(parseInputSchemaFromGroundingRaw("")).toBeUndefined();
+  });
+
+  it("returns undefined for malformed JSON (no throw)", () => {
+    expect(parseInputSchemaFromGroundingRaw("{not json")).toBeUndefined();
+  });
+
+  it("rejects array / primitive JSON roots (must be object)", () => {
+    expect(parseInputSchemaFromGroundingRaw("[1,2,3]")).toBeUndefined();
+    expect(parseInputSchemaFromGroundingRaw('"scalar"')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildUserInputForGroundingFrontmatter — production entrypoint
+// ---------------------------------------------------------------------------
+
+describe("buildUserInputForGroundingFrontmatter", () => {
+  it("resolves inputSchema from grounding frontmatter and synthesises payload", () => {
+    const fm = {
+      exocmd__Grounding_type: "service_call",
+      exocmd__Grounding_serviceId: "updateProperty",
+      exocmd__Grounding_inputSchema:
+        '{"type":"object","properties":{"value":{"type":"string","title":"Result"}},"required":["value"]}',
+    };
+    const result = buildUserInputForGroundingFrontmatter(fm, {
+      seed: "set-result",
+    });
+    expect(result?.payload).toEqual({
+      value: `${DEFAULT_TEXT_PREFIX}set-result`,
+    });
+  });
+
+  it("returns undefined when grounding has no inputSchema", () => {
+    const fm = {
+      exocmd__Grounding_type: "property_set",
+      exocmd__Grounding_targetProperty: "ems__Effort_status",
+    };
+    const result = buildUserInputForGroundingFrontmatter(fm, {
+      seed: "set-status",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for undefined grounding frontmatter (command without grounding)", () => {
+    expect(
+      buildUserInputForGroundingFrontmatter(undefined, { seed: "x" }),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Ships 5 Phase 1 integration test helpers under `packages/cli/tests/integration/starter-kit/test-helpers/` that the RFC v4 §7.1 CLI harness needs to dispatch and assert every starter-kit Command.
- Each helper has a matching unit test under `packages/cli/tests/unit/test-helpers/` — satisfies RFC §12 PR-readiness gate (helpers self-covered, no statements.pct regression projected).
- Integration self-test for the 5-strategy ladder against the real 44-Command catalog pins the Phase 0 post-Option-C distribution anchors.

## Helpers

| File | LOC | Role |
|---|---:|---|
| `fixture-factory.ts` | 170 | Synthesises tmp `.md` host assets with deterministic UUIDv5-shaped UIDs; `afterEach` cleanup; stable `obsidian://vault/<uid>` targetIRI. |
| `predict-mutation.ts` | 240 | Pure port of the Phase 0 `predictor.mjs`; mirrors `GroundingExecutor.substituteVariables` verbatim; **3 per-command class-flip branches (RFC §7.1b gate ≤ 5).** |
| `user-input-factory.ts` | 170 | Deterministic `$value` payload synthesis for the 5 field types (text / multiline / date / enum / assetRef). |
| `extract-target-class.ts` | 330 | RFC §7.1a 5-strategy resolution ladder (S1 explicit → S5 fallback); paired `loadStarterKitContext` loader scans the submodule once. |
| `execute-command.ts` | 180 | Node-fs adapters + GroundingData→GroundingDefinition transformer + `executeCommandHarness` (real `GroundingExecutor` end-to-end, no CLI subprocess). |

## Unit coverage (per RFC §9.1 / §12)

| Helper | Stmt | Branch |
|---|---:|---:|
| `fixture-factory.ts` | 95.0% | 92.6% |
| `predict-mutation.ts` | 100.0% | 95.3% |
| `user-input-factory.ts` | 100.0% | 100.0% |
| `extract-target-class.ts` | 84.8% | 77.2% |
| `execute-command.ts` | 97.0% | 88.9% |
| **Aggregate (incl. command-catalog)** | **91.15%** | **85.15%** |

All metrics above the RFC §9.1 65% statements floor. No coverage delta regression expected on `packages/cli/`.

## RFC §12 gate (path convention)

Helpers live at `tests/integration/starter-kit/test-helpers/`; unit tests at `tests/unit/test-helpers/` — matches §12 glob and existing `command-catalog.test.ts` precedent. V4-2 drift resolved toward §12 convention (task-file AC literal path `tests/unit/services/test-helpers/` intentionally diverged; flagged for RFC minor).

## Tests

- [x] 150 unit tests (6 suites) pass locally
- [x] Integration self-test `extract-target-class.self.test.ts` — S1 ≥ 7, S5 ratio ≤ 30%, dispatchOnly ⟺ S5
- [x] `npm run test:unit` passes end-to-end (1497 tests, 0 failures)
- [x] Root `tsc -noEmit -skipLibCheck` clean
- [x] Pre-commit hooks (archgate / BDD / lint) green

## Task

- Task: `c2e0c599-d0cb-4740-b0d0-c455e47beac0`
- Parent project: `9b4f1f59` (CI Test Coverage for Starter-Kit Dynamic Commands — RFC v4)
- Prior Phase 1 tasks already merged: `1894db7c` (Option C migration), `27260d2d` (submodule wired), `58b1d922` (command-catalog), `6208967d` (YAML contract).

## Deferred (out of scope)

- Parametrized integration dispatch suite over all 44 Commands (separate task `97e3f5ab`, 5-command pilot).
- `#2883` CLI `targetIRI` path vs `obsidian://vault/` divergence (jest-only defer).
- `updateProperty` CLI stub — not needed; read-back is direct `fs.readFileSync` per Phase 0 `dd3bdaaa` note.