### PR TITLE
ci: dedupe test-unit ↔ test-coverage jest invocations (Phase 2 speedup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,9 +134,16 @@ jobs:
       - name: Run ADR compliance checks
         run: archgate check --ci
 
+  # test-unit runs ONLY UI tests (jest-environment-obsidian).
+  # Phase 2 (CI speedup, task 761ca21e 2026-04-21):
+  #   Previously also ran test:unit (= test-ci-batched.sh) duplicating test-coverage.
+  #   That duplicate jest invocation was removed here. test-coverage remains the
+  #   single full-suite jest runner with --coverage.
+  # Phase 4 (planned, task f235881d): drop this job after the main branch
+  # protection rule is updated to no longer require "test-unit" as a status check.
   test-unit:
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 4
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
@@ -155,10 +162,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run unit and UI tests only (component tests have separate job)
+      - name: Run UI tests (jest-environment-obsidian)
         run: |
           export NODE_OPTIONS="--max-old-space-size=4096"
-          npm run test:unit && npm run test:ui
+          npm run test:ui
 
       - name: Track Flaky Tests
         if: always()


### PR DESCRIPTION
## Summary

Phase 2 of the _Exocortex CI Pipeline Speedup ≤2min_ project (task `761ca21e-cc2e-41d9-9038-720e907ceb29`, parent `e5939fb2`).

`test-unit` and `test-coverage` were running two distinct jest invocations of the same suite:

| Job | Previous behaviour | New behaviour |
|---|---|---|
| `test-unit` | `npm run test:unit && npm run test:ui` = `scripts/test-ci-batched.sh` + `jest.ui.config.js` | `npm run test:ui` only |
| `test-coverage` | `scripts/test-ci-batched.sh` with `COVERAGE=true` | _unchanged_ |

`test-ci-batched.sh` was the duplicated work — both jobs invoked it on every CI run. That duplicate invocation is removed from `test-unit`. `test-coverage` remains the single full-suite jest runner with `--coverage`, and its lcov artifact path (`packages/obsidian-plugin/coverage/`) + artifact name (`coverage-reports`) are unchanged. Downstream consumers (`test-pyramid` `needs: [test-unit, test-coverage]`, codecov upload) are untouched.

## Savings: compute-minutes, NOT wall-clock

Both jobs run in parallel (no `needs:` between them), so before this change wall-clock = `max(test-unit≈176s, test-coverage≈194s) = 194s`. After this change, `test-unit` drops to the UI suite only (~30–40s locally: 53 tests in 3.6s plus container + `npm ci` overhead), and `test-coverage` is unchanged. Wall-clock on the critical path remains ~194s — the gain is in runner-minutes, roughly −140s per CI run.

Genuine wall-clock reduction on the critical path is scoped separately to the sharding task (`9346c5be`, Phase 2 e2e-shard rebalance) and to later phases of the speedup project.

## Branch protection + sibling coordination

`gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks` confirms the 8 required contexts include `test-unit`. Removing the job outright would block every subsequent PR until the protection rule is updated. The job is therefore preserved as a thin UI-only stub; it still reports as `test-unit`, still satisfies the required check, and the container+setup steps are identical so the job remains a valid status context.

The sibling admin project `9b4f1f59-d771-4c1b-b8e4-feb06984c06c` owns branch-protection alignment. Phase 4 of this project (task `f235881d`) will drop the `test-unit` job entirely once that sibling work has removed `test-unit` from the required-checks list on `main`.

## Verification

- [x] Local `npm run test:ui` passes: **53/53 green** in ~3.6 s.
- [x] `git diff .github/workflows/ci.yml` is 10+/3− — only the `test-unit` step name, command, comment block, and `timeout-minutes: 7 → 4` changed.
- [x] `test-coverage` job body unchanged — coverage thresholds, artifact uploads (`coverage-reports`), `coverage-summary.md` generation untouched.
- [x] `test-pyramid needs: [test-unit, test-coverage]` unchanged.
- [x] Flaky report artifact (`flaky-test-report-unit`) preserved — still uploaded from the (now slimmer) `test-unit` job.
- [ ] Pre-merge CI — both required checks (`test-unit`, `test-coverage`) green.
- [ ] Post-merge: Auto Release fires, version bumps, 2 consecutive main CI runs green (R3 mitigation).

## Test plan

- [ ] Pre-merge CI passes on all 8 required contexts (`build`, `typecheck`, `test-unit`, `test-coverage`, `test-bdd`, `archgate`, `e2e-tests`, `test-component`).
- [ ] After merge: `gh run list --workflow "Auto Release" --limit 1` = `success`, new patch version published (`gh release list --limit 1`).
- [ ] Coverage delta ≤ 1pp compared to pre-change baseline — `coverage-reports` artifact inspection.
- [ ] Second main-CI run (triggered by any subsequent merge) stays green.