### PR TITLE
docs: testing convention for RFC-CI-Tests L1/L2/L3 layers (Phase 4/1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -578,6 +578,31 @@ jest.mock("../../src/presentation/modals/AreaSelectionModal", () => ({
 }));
 ```
 
+### RFC-CI-Tests L1/L2/L3 Testing Convention (Phase 4, 2026-04-21)
+
+Starter-kit dynamic commands (`exocmd__Command`) are covered in three test layers. New commands MUST be added to every applicable layer before merge. Source of truth: RFC v5 at `/Users/kitelev/Developer/rfc-ci-button-testing-2026-04-20.md`.
+
+| Layer | Runner | Location | Scope |
+| ----- | ------ | -------- | ----- |
+| **L1 — Unit** | Jest (ts-jest) | `packages/cli/tests/unit/**` | Helpers (`command-catalog`, `extract-target-class`, `predict-mutation`, `fixture-factory`, `user-input-factory`, `execute-command`) + per-command outcome assertions with mocked boundaries. |
+| **L2 — Integration** | Jest + real `GroundingExecutor` | `packages/cli/tests/integration/starter-kit/**` | 41 active starter-kit commands through `CommandResolver` / `PreconditionEvaluator` / `GroundingExecutor` against fixture vaults. Parametrized catalogue + YAML contract invariants. |
+| **L3 — E2E** | Playwright + Docker Obsidian | `packages/obsidian-plugin/tests/e2e/specs/**` | Smoke subset (RFC §7.4.3) exercising the real plugin UI, sharded across `e2e-shard-1..4`. |
+
+**Layer authoring rules:**
+
+- New helper → L1 unit test under `packages/cli/tests/unit/test-helpers/` (threshold-neutrality — RFC v5 §9.1).
+- New `exocmd__Command` or grounding change → L2 parametrized entry + L1 unit cases for any new dispatch branches.
+- New user-visible button flow → L3 smoke spec (or extend existing spec) covering golden path with `expandGroupIfCollapsed("Maintenance")` helper where applicable.
+
+**Runtime-verify gate:** new E2E specs MUST run green in CI (not only local) before the hosting task flips to Review; skipping this gate caused attribution drift flagged in Phase 2 retrospective.
+
+**Required CI checks (branch-protected per Phase 4 amendment 2026-04-21):**
+`test-unit`, `test-coverage`, `e2e-shard-1`, `e2e-shard-2`, `e2e-shard-3`, `e2e-shard-4`, `archgate`, `test-component`, `typecheck`, `lint`.
+
+**Rollback playbook:** `docs/ROLLBACK_RFC_CI_TESTS.md` — per-trigger mitigation (flaky quarantine / smoke budget trim / submodule → npm migration / admin nuclear rollback).
+
+**Cross-project narrative (2026-04-21):** Phase 4 stability rests on Phase 3 EXIT (PR #2895) and was measurably helped by the parallel CI Speedup project (PR #2900 — `test-unit` ↔ `test-coverage` jest dedupe); both contributed to the 5/5 consecutive green main-PR counter required before branch-protection amendment.
+
 ### GitHub Branch Protection Best Practices
 
 **⚠️ CRITICAL: NEVER use aggregator jobs for branch protection!**

--- a/packages/obsidian-plugin/CLAUDE.md
+++ b/packages/obsidian-plugin/CLAUDE.md
@@ -39,6 +39,30 @@ npm run test:all   # MUST pass: unit + component + e2e + BDD ≥80%
 
 ---
 
+## Testing Conventions — RFC-CI-Tests L1/L2/L3 (Phase 4)
+
+Starter-kit dynamic commands (`exocmd__Command`) are covered in three layers. New commands MUST add tests on every applicable layer before merge. Source of truth: `/Users/kitelev/Developer/rfc-ci-button-testing-2026-04-20.md` (RFC v5).
+
+| Layer | Runner | Location | Purpose |
+| ----- | ------ | -------- | ------- |
+| **L1 — Unit** | Jest (ts-jest) | `packages/cli/tests/unit/**` | Helpers (`command-catalog`, `extract-target-class`, `predict-mutation`, `fixture-factory`, `user-input-factory`, `execute-command`) + per-command outcome assertions with mocked boundaries. |
+| **L2 — Integration** | Jest + real `GroundingExecutor` | `packages/cli/tests/integration/starter-kit/**` | Exercise the 41 active starter-kit commands end-to-end through `CommandResolver` / `PreconditionEvaluator` / `GroundingExecutor` against fixture vaults. Parametrized catalogue + YAML contract test. |
+| **L3 — E2E** | Playwright + Docker Obsidian | `packages/obsidian-plugin/tests/e2e/specs/**` | Smoke subset (RFC §7.4.3) exercising the real plugin in Obsidian UI against fixture assets. Distributed across `e2e-shard-1..4`. |
+
+**When to touch which layer:**
+
+- New helper → L1 unit test in `packages/cli/tests/unit/test-helpers/`.
+- New `exocmd__Command` or new grounding → L2 parametrized entry (+ contract invariants if structural) + L1 unit cases for any new dispatch branches.
+- New button flow users actually click → L3 smoke spec (or extend existing smoke spec) covering the golden path.
+
+**Required CI checks (branch-protected):** `test-unit`, `test-coverage`, `e2e-shard-1..4`, `archgate`, `test-component`, `typecheck`, `lint` (RFC v5 §8 Phase 4 amendment, 2026-04-21).
+
+**Rollback:** if a layer becomes destabilising (flaky >5%, budget overage, submodule friction), follow the per-trigger mitigation in `docs/ROLLBACK_RFC_CI_TESTS.md` before disabling a check.
+
+**Cross-project note (2026-04-21):** Phase 4 stability was established on top of Phase 3 EXIT (PR #2895) and benefited from the CI Speedup project (PR #2900 — `test-unit` ↔ `test-coverage` jest dedupe); both were counted toward the 5/5 pre-cutover green window.
+
+---
+
 ## Architecture
 
 ```
@@ -110,3 +134,5 @@ See ../../PATTERNS.md for Docker E2E setup, debugging, and critical lessons.
 - `../../TROUBLESHOOTING.md` — Common issues and fixes
 - `ARCHITECTURE.md` — Detailed architecture docs
 - `docs/PROPERTY_SCHEMA.md` — Frontmatter vocabulary
+- `../../docs/ROLLBACK_RFC_CI_TESTS.md` — Per-trigger mitigation paths for RFC-CI-Tests suite
+- `/Users/kitelev/Developer/rfc-ci-button-testing-2026-04-20.md` — RFC v5 source of truth (starter-kit L1/L2/L3 coverage)


### PR DESCRIPTION
## Summary

Documents the three-layer coverage model (L1 unit / L2 integration / L3 E2E) established across RFC-CI-Tests Phases 1–3 and now entering Phase 4 enforcement.

Edits `packages/obsidian-plugin/CLAUDE.md` and `AGENTS.md` to add:

- Layer table (L1 unit / L2 integration / L3 E2E) with runner, location, and scope.
- Authoring rules (which layer to touch for new helpers / commands / user flows).
- Runtime-verify gate (E2E specs must be CI-green before Review flip).
- Required CI checks list (per Phase 4 amendment, 2026-04-21).
- Rollback pointer to `docs/ROLLBACK_RFC_CI_TESTS.md`.
- Cross-project narrative — Phase 4 stability rests on Phase 3 EXIT (PR #2895) and was helped by the CI Speedup project (PR #2900 `test-unit` ↔ `test-coverage` jest dedupe), both feeding the 5/5 green-window counter.

Ships separately from the Phase 4 branch-protection enforcement PR so docs land before the admin-coordinated protection change.

**Source of truth:** `/Users/kitelev/Developer/rfc-ci-button-testing-2026-04-20.md` (RFC v5 §8 Phase 4).

## Scope

- `AGENTS.md` — new "RFC-CI-Tests L1/L2/L3 Testing Convention (Phase 4, 2026-04-21)" section above the existing GitHub Branch Protection Best Practices block.
- `packages/obsidian-plugin/CLAUDE.md` — new "Testing Conventions — RFC-CI-Tests L1/L2/L3 (Phase 4)" section after Test Requirements; two extra Key Resources entries (rollback doc + RFC).

No code / CI / test changes — pure documentation.

## Linked tasks

- Child task: `70b28b93-f05a-40aa-be94-f31d385f1a33` (Phase 4 coordination).
- Parent project: `9b4f1f59-d771-4c1b-b8e4-feb06984c06c` (CI Test Coverage for Starter-Kit Dynamic Commands — RFC v2).

## Test plan

- [x] CI pipeline (all 8 currently-required checks green)
- [x] Auto Release fires a patch bump on merge (`docs(...)` → conventional-commit patch regex)
- [x] `packages/obsidian-plugin/CLAUDE.md` + `AGENTS.md` render correctly on GitHub (tables, code fences, cross-links)
- [ ] Phase 4 branch-protection amendment PR references this docs PR in its body

🤖 Generated with [Claude Code](https://claude.com/claude-code)