### PR TITLE
test(e2e): Phase 1 fixture consolidation — 9 specs beforeEach→beforeAll

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/alias-sync-on-label-change.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/alias-sync-on-label-change.spec.ts
@@ -2,17 +2,21 @@ import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
 import * as path from "path";
 
+test.describe.configure({ mode: "parallel" });
+
 test.describe("Alias Sync on Label Change", () => {
   let launcher: ObsidianLauncher;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     const vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
   });
 
-  test.afterEach(async () => {
-    await launcher.close();
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
   });
 
   test("should sync alias when exo__Asset_label changes", async () => {

--- a/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
@@ -2,17 +2,21 @@ import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
 import * as path from "path";
 
+test.describe.configure({ mode: "parallel" });
+
 test.describe("DailyNote Archive Filter", () => {
   let launcher: ObsidianLauncher;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     const vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
   });
 
-  test.afterEach(async () => {
-    await launcher.close();
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
   });
 
   test("should toggle archived tasks visibility with button click", async () => {

--- a/packages/obsidian-plugin/tests/e2e/specs/daily-navigation.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-navigation.spec.ts
@@ -2,17 +2,21 @@ import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
 import * as path from "path";
 
+test.describe.configure({ mode: "parallel" });
+
 test.describe("Daily Note Navigation", () => {
   let launcher: ObsidianLauncher;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     const vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
   });
 
-  test.afterEach(async () => {
-    await launcher.close();
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
   });
 
   test("should display navigation links at the top of DailyNote layout", async () => {

--- a/packages/obsidian-plugin/tests/e2e/specs/daily-note-tasks.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-note-tasks.spec.ts
@@ -2,17 +2,21 @@ import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
 import * as path from "path";
 
+test.describe.configure({ mode: "parallel" });
+
 test.describe("DailyNote Tasks Table", () => {
   let launcher: ObsidianLauncher;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     const vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
   });
 
-  test.afterEach(async () => {
-    await launcher.close();
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
   });
 
   test("should display only tasks for the current day", async () => {

--- a/packages/obsidian-plugin/tests/e2e/specs/dynamic-commands.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/dynamic-commands.spec.ts
@@ -18,17 +18,21 @@ import * as path from "path";
  *
  * Issue #2435
  */
+test.describe.configure({ mode: "parallel" });
+
 test.describe("Dynamic Command System E2E", () => {
   let launcher: ObsidianLauncher;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     const vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
   });
 
-  test.afterEach(async () => {
-    await launcher.close();
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
   });
 
   test("should load exocortex plugin with vault containing command files", async () => {

--- a/packages/obsidian-plugin/tests/e2e/specs/layout-overflow-styling.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/layout-overflow-styling.spec.ts
@@ -16,18 +16,22 @@ import * as path from "path";
  * `ems__Effort_area: "[[development]]"`. This guarantees that
  * .exocortex-assets-relations and .exocortex-relations-table render.
  */
+test.describe.configure({ mode: "parallel" });
+
 test.describe("Layout Overflow and Styling Consistency", () => {
   let launcher: ObsidianLauncher;
   let vaultPath: string;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
   });
 
-  test.afterEach(async () => {
-    await launcher.close();
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
   });
 
   test("should not have horizontal overflow in asset relations section", async () => {

--- a/packages/obsidian-plugin/tests/e2e/specs/table-column-alignment.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/table-column-alignment.spec.ts
@@ -13,17 +13,21 @@ import * as path from "path";
  * 2. Column widths are consistent between header and body
  * 3. The Name column has non-zero width (doesn't collapse)
  */
+test.describe.configure({ mode: "parallel" });
+
 test.describe("Table Column Alignment (#594)", () => {
   let launcher: ObsidianLauncher;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     const vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
   });
 
-  test.afterEach(async () => {
-    await launcher.close();
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
   });
 
   test("should align header columns with data columns", async () => {

--- a/packages/obsidian-plugin/tests/e2e/specs/table-virtualization-large-datasets.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/table-virtualization-large-datasets.spec.ts
@@ -18,18 +18,22 @@ import * as path from "path";
  *
  * VIRTUALIZATION_THRESHOLD = 50 (defined in AssetRelationsTable.tsx)
  */
+test.describe.configure({ mode: "parallel" });
+
 test.describe("Table Virtualization for Large Datasets", () => {
   let launcher: ObsidianLauncher;
   let vaultPath: string;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
   });
 
-  test.afterEach(async () => {
-    await launcher.close();
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
   });
 
   test("should render virtual table rows for >50 items (Issue #549)", async () => {

--- a/packages/obsidian-plugin/tests/e2e/specs/vault-commands-smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/vault-commands-smoke.spec.ts
@@ -25,17 +25,21 @@ import * as path from "path";
  * - Tasks/dynamic-cmd-test-with-ts.md    (Task with status Doing)
  * - exoql-test-page.md (ExoQL code block)
  */
+test.describe.configure({ mode: "parallel" });
+
 test.describe("Vault Commands Smoke Tests", () => {
   let launcher: ObsidianLauncher;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     const vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
   });
 
-  test.afterEach(async () => {
-    await launcher.close();
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
   });
 
   test("should render vault command buttons on a Task note", async () => {


### PR DESCRIPTION
## Summary

Converts `test.beforeEach(launcher.launch)` → `test.beforeAll` in 9 E2E specs, amortizing Obsidian launch (~3.5s) across tests within each `describe` block.

Part of CI Speedup Phase 1 (RFC `rfc-ci-speedup-2026-04-21.md`, task UUID `5a752e7b-e688-4f5a-98a4-b9ed8a15eeaa`). Scope is audit-corrected from RFC §4's 13-spec list down to 9 — the 9 specs that actually had the `beforeEach(launch)` antipattern per `ci-speedup-phase1-audit-2026-04-21.md` §5.

## Scope

**Category A — fixture + event-wait both** (event-wait deferred to sibling task `335e392a`; no `waitForTimeout` edits in this PR):

1. `daily-navigation.spec.ts` — 6 tests
2. `daily-archive-filter.spec.ts` — 2 tests
3. `daily-note-tasks.spec.ts` — 4 tests
4. `table-column-alignment.spec.ts` — 5 tests

**Category B — fixture only:**

5. `dynamic-commands.spec.ts` — 5 tests
6. `vault-commands-smoke.spec.ts` — 7 tests
7. `layout-overflow-styling.spec.ts` — 6 tests
8. `table-virtualization-large-datasets.spec.ts` — 5 tests
9. `alias-sync-on-label-change.spec.ts` — 2 tests

Each spec also receives `test.describe.configure({ mode: "parallel" })` for consistency with `starter-kit-smoke.spec.ts` (RFC v5 §7.2 meta-hint). Under current `playwright-e2e.config.ts` (`workers: 1`, `fullyParallel: false`) this is cosmetic — documents intent without changing scheduler behavior.

## Projected savings

Per audit §5.2: ~115s aggregate wall-time reduction (33 saved launches × ~3.5s each), split across 4 shards.

| Spec | Saved launches | Savings (s) |
|---|---:|---:|
| vault-commands-smoke | 6 | 21 |
| daily-navigation | 5 | 17.5 |
| layout-overflow-styling | 5 | 17.5 |
| dynamic-commands | 4 | 14 |
| table-column-alignment | 4 | 14 |
| table-virtualization-large-datasets | 4 | 14 |
| daily-note-tasks | 3 | 10.5 |
| daily-archive-filter | 1 | 3.5 |
| alias-sync-on-label-change | 1 | 3.5 |

## Risk assessment (R1 — state leak)

`ObsidianLauncher.openFile()` uses `app.workspace.getLeaf(true)` which forces new-leaf creation (verified in `utils/obsidian-launcher.ts:430` with existing comment: *"Force new leaf creation to avoid workspace state issues in shared fixtures"*). Cross-test state from the workspace layer is already isolated by design.

File-on-disk mutations from earlier tests (e.g. `vault-commands-smoke` test 4 flipping status Backlog→Doing) already persist across tests under `beforeEach` — `beforeEach(launch)` restarts Obsidian but does not reset fixture files. `beforeAll` is therefore semantically identical for file-state.

Two specs mutate files but use disjoint fixture paths per test (`alias-sync-on-label-change`) or perform idempotent toggles (`daily-note-tasks` Effort Area column toggle) — verified by reading each spec end-to-end before editing.

## Reference patterns

- `starter-kit-smoke.spec.ts` (RFC-CI-Tests Phase 3 baseline, 7 tests, 1.3s avg — best-in-class)
- `area-tree-collapsible.spec.ts` (6 tests, 1.3s avg)

## Test plan

- [ ] All 4 e2e-shard-1..4 pass in PR CI
- [ ] Post-merge main CI green + Auto Release fires
- [ ] Measured per-shard wall-time reduction vs main baseline (`/tmp/baseline-e2e-shards.json`)
- [ ] No new flake (retry counts unchanged in CI log)

## Orchestrator context

- Parent project: `e5939fb2-0e1f-418c-93a1-619faaf9f6b3` (Exocortex CI Pipeline Speedup ≤2min)
- Sibling task (file-orthogonal): `9346c5be` (jest --shard rollout)
- Child session: `claude-child-5a752e7b-1776766473`