### PR TITLE
ci: parallelize test-coverage via jest --shard=X/4 matrix (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,78 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-  test-coverage:
+  # Phase 2 CI speedup (task 9346c5be, 2026-04-21):
+  # test-coverage was previously a single 190s job running three jest invocations
+  # serially (obsidian-plugin full suite + CLI + exocortex regression).
+  # Split into parallel matrix (obsidian-plugin 1/4..4/4) + sibling jobs (CLI,
+  # exocortex-regression), with the branch-protected `test-coverage` name
+  # repurposed as the aggregator (mirrors the e2e-shard → e2e-tests pattern).
+  # Per-shard coverage-final.json is merged via scripts/merge-coverage.js.
+  test-coverage-shard:
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 4
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run obsidian-plugin tests (shard ${{ matrix.shard }}/4)
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+          CI: "true"
+          FLAKY_REPORT_FILE: "flaky-report-shard-${{ matrix.shard }}.json"
+        run: |
+          # Empty --coverageThreshold overrides jest.config.js thresholds so a
+          # partial shard doesn't falsely fail the gate; aggregator applies
+          # thresholds on merged coverage.
+          node ./node_modules/jest/bin/jest.js \
+            --config packages/obsidian-plugin/jest.config.js \
+            --shard=${{ matrix.shard }}/4 \
+            --coverage \
+            --coverageReporters=json \
+            --coverageReporters=lcov \
+            --coverageThreshold='{}' \
+            --maxWorkers=2 \
+            --forceExit
+
+      - name: Upload shard coverage
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-shard-${{ matrix.shard }}
+          path: packages/obsidian-plugin/coverage/coverage-final.json
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload shard flaky report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: flaky-report-shard-${{ matrix.shard }}
+          path: flaky-report-shard-${{ matrix.shard }}.json
+          retention-days: 30
+          if-no-files-found: ignore
+
+  test-coverage-cli:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
@@ -220,67 +289,18 @@ jobs:
       - name: Install jq for coverage parsing
         run: apt-get update && apt-get install -y jq
 
-      - name: Run unit tests with coverage
+      - name: Run CLI tests with coverage
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096 --experimental-vm-modules"
+          CI: "true"
         run: |
-          export NODE_OPTIONS="--max-old-space-size=4096"
-          export COVERAGE=true
-          ./scripts/test-ci-batched.sh || exit 1
-
-      - name: Check coverage thresholds (obsidian-plugin)
-        run: |
-          echo "=============================================="
-          echo "Verifying obsidian-plugin coverage thresholds"
-          echo "=============================================="
-
-          # Check if coverage report exists
-          COVERAGE_FILE="packages/obsidian-plugin/coverage/coverage-summary.json"
-          if [ ! -f "$COVERAGE_FILE" ]; then
-            echo "❌ Coverage report not found at $COVERAGE_FILE"
-            echo "This means the test-ci-batched.sh script did not collect coverage."
-            exit 1
-          fi
-
-          # Extract coverage percentages from JSON
-          STATEMENTS=$(cat "$COVERAGE_FILE" | jq -r '.total.statements.pct')
-          BRANCHES=$(cat "$COVERAGE_FILE" | jq -r '.total.branches.pct')
-          FUNCTIONS=$(cat "$COVERAGE_FILE" | jq -r '.total.functions.pct')
-          LINES=$(cat "$COVERAGE_FILE" | jq -r '.total.lines.pct')
-
-          echo "📊 obsidian-plugin Coverage Report:"
-          echo "  Statements: ${STATEMENTS}% (required: 75.5%)"
-          echo "  Branches:   ${BRANCHES}% (required: 63%)"
-          echo "  Functions:  ${FUNCTIONS}% (required: 69%)"
-          echo "  Lines:      ${LINES}% (required: 76%)"
-
-          # Check if coverage meets thresholds using awk for floating point comparison
-          # Updated thresholds after graph visualization removal (Issue #2083)
-          # statements: lowered from 76 to 75.5 due to marginal failure (75.94% vs 76%) after PR #1338
-          FAILED=0
-          if [ $(echo "$STATEMENTS < 75.5" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
-            echo "❌ Statement coverage ${STATEMENTS}% is below 75.5% threshold"
-            FAILED=1
-          fi
-
-          if [ $(echo "$BRANCHES < 63" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
-            echo "❌ Branch coverage ${BRANCHES}% is below 63% threshold"
-            FAILED=1
-          fi
-
-          if [ $(echo "$FUNCTIONS < 69" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
-            echo "❌ Function coverage ${FUNCTIONS}% is below 69% threshold"
-            FAILED=1
-          fi
-
-          if [ $(echo "$LINES < 76" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
-            echo "❌ Line coverage ${LINES}% is below 76% threshold"
-            FAILED=1
-          fi
-
-          if [ $FAILED -eq 1 ]; then
-            exit 1
-          fi
-
-          echo "✅ obsidian-plugin coverage thresholds met!"
+          node --experimental-vm-modules ./node_modules/jest/bin/jest.js \
+            --config packages/cli/jest.config.js \
+            --coverage \
+            --coverageReporters=lcov \
+            --coverageReporters=json-summary \
+            --coverageReporters=text-summary \
+            --forceExit
 
       - name: Check coverage thresholds (cli)
         run: |
@@ -288,7 +308,6 @@ jobs:
           echo "Verifying CLI package coverage thresholds"
           echo "=============================================="
 
-          # Check if CLI coverage report exists
           CLI_COVERAGE_FILE="packages/cli/coverage/coverage-summary.json"
           if [ ! -f "$CLI_COVERAGE_FILE" ]; then
             echo "⚠️ CLI coverage report not found at $CLI_COVERAGE_FILE"
@@ -296,7 +315,6 @@ jobs:
             exit 0
           fi
 
-          # Extract coverage percentages from JSON
           STATEMENTS=$(cat "$CLI_COVERAGE_FILE" | jq -r '.total.statements.pct')
           BRANCHES=$(cat "$CLI_COVERAGE_FILE" | jq -r '.total.branches.pct')
           FUNCTIONS=$(cat "$CLI_COVERAGE_FILE" | jq -r '.total.functions.pct')
@@ -308,7 +326,6 @@ jobs:
           echo "  Functions:  ${FUNCTIONS}% (required: 70%)"
           echo "  Lines:      ${LINES}% (required: 65%)"
 
-          # Check if coverage meets thresholds
           FAILED=0
           if [ $(echo "$STATEMENTS < 65" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
             echo "❌ CLI Statement coverage ${STATEMENTS}% is below 65% threshold"
@@ -335,9 +352,148 @@ jobs:
           fi
 
           echo "✅ CLI coverage thresholds met!"
+
+      - name: Upload CLI coverage
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-cli
+          path: packages/cli/coverage/
+          retention-days: 1
+          if-no-files-found: ignore
+
+  test-coverage-exocortex:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run exocortex grounding regression tests
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+          CI: "true"
+        run: |
+          node ./node_modules/jest/bin/jest.js \
+            --config packages/exocortex/jest.config.js \
+            --testPathPatterns='services/(GroundingExecutor|AssetConversionService)\.test\.ts' \
+            --forceExit
+
+  test-coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    needs: [test-coverage-shard, test-coverage-cli, test-coverage-exocortex]
+    if: always()
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
+
+    steps:
+      - name: Verify upstream jobs succeeded
+        run: |
+          if [ "${{ needs.test-coverage-shard.result }}" != "success" ]; then
+            echo "❌ test-coverage-shard failed"
+            exit 1
+          fi
+          if [ "${{ needs.test-coverage-cli.result }}" != "success" ]; then
+            echo "❌ test-coverage-cli failed"
+            exit 1
+          fi
+          if [ "${{ needs.test-coverage-exocortex.result }}" != "success" ]; then
+            echo "❌ test-coverage-exocortex failed"
+            exit 1
+          fi
+          echo "✅ All upstream coverage jobs passed"
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install jq for coverage parsing
+        run: apt-get update && apt-get install -y jq
+
+      - name: Download obsidian-plugin shard coverage
+        uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-shard-*
+          path: coverage-shards
+
+      - name: Merge obsidian-plugin coverage
+        run: |
+          mkdir -p packages/obsidian-plugin/coverage
+          node scripts/merge-coverage.js coverage-shards packages/obsidian-plugin/coverage
+
+      - name: Check coverage thresholds (obsidian-plugin)
+        run: |
           echo "=============================================="
-          echo "✅ All package coverage thresholds passed!"
+          echo "Verifying obsidian-plugin coverage thresholds"
           echo "=============================================="
+
+          COVERAGE_FILE="packages/obsidian-plugin/coverage/coverage-summary.json"
+          if [ ! -f "$COVERAGE_FILE" ]; then
+            echo "❌ Coverage report not found at $COVERAGE_FILE"
+            echo "The merge step did not produce a summary."
+            exit 1
+          fi
+
+          STATEMENTS=$(cat "$COVERAGE_FILE" | jq -r '.total.statements.pct')
+          BRANCHES=$(cat "$COVERAGE_FILE" | jq -r '.total.branches.pct')
+          FUNCTIONS=$(cat "$COVERAGE_FILE" | jq -r '.total.functions.pct')
+          LINES=$(cat "$COVERAGE_FILE" | jq -r '.total.lines.pct')
+
+          echo "📊 obsidian-plugin Coverage Report (merged across shards):"
+          echo "  Statements: ${STATEMENTS}% (required: 75.5%)"
+          echo "  Branches:   ${BRANCHES}% (required: 63%)"
+          echo "  Functions:  ${FUNCTIONS}% (required: 69%)"
+          echo "  Lines:      ${LINES}% (required: 76%)"
+
+          FAILED=0
+          if [ $(echo "$STATEMENTS < 75.5" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
+            echo "❌ Statement coverage ${STATEMENTS}% is below 75.5% threshold"
+            FAILED=1
+          fi
+
+          if [ $(echo "$BRANCHES < 63" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
+            echo "❌ Branch coverage ${BRANCHES}% is below 63% threshold"
+            FAILED=1
+          fi
+
+          if [ $(echo "$FUNCTIONS < 69" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
+            echo "❌ Function coverage ${FUNCTIONS}% is below 69% threshold"
+            FAILED=1
+          fi
+
+          if [ $(echo "$LINES < 76" | awk '{print ($1 < $3) ? 1 : 0}') -eq 1 ]; then
+            echo "❌ Line coverage ${LINES}% is below 76% threshold"
+            FAILED=1
+          fi
+
+          if [ $FAILED -eq 1 ]; then
+            exit 1
+          fi
+
+          echo "✅ obsidian-plugin coverage thresholds met!"
 
       - name: Generate coverage summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,10 +204,11 @@ jobs:
   # repurposed as the aggregator (mirrors the e2e-shard → e2e-tests pattern).
   # Per-shard coverage-final.json is merged via scripts/merge-coverage.js.
   test-coverage-shard:
+    # Runs on bare ubuntu-latest — jest uses jsdom testEnvironment, no browser
+    # or Playwright binaries are needed. Skipping the playwright container
+    # saves ~25s of container init per shard leg.
     runs-on: ubuntu-latest
     timeout-minutes: 4
-    container:
-      image: mcr.microsoft.com/playwright:v1.57.0-jammy
     strategy:
       fail-fast: false
       matrix:
@@ -266,10 +267,9 @@ jobs:
           if-no-files-found: ignore
 
   test-coverage-cli:
+    # Bare ubuntu-latest — CLI jest is node-only; no browser/playwright needed.
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    container:
-      image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
     steps:
       - name: Checkout
@@ -285,9 +285,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Install jq for coverage parsing
-        run: apt-get update && apt-get install -y jq
 
       - name: Run CLI tests with coverage
         env:
@@ -363,10 +360,9 @@ jobs:
           if-no-files-found: ignore
 
   test-coverage-exocortex:
+    # Bare ubuntu-latest — narrow node-only regression suite, no browser needed.
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    container:
-      image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
     steps:
       - name: Checkout
@@ -394,12 +390,12 @@ jobs:
             --forceExit
 
   test-coverage:
+    # Bare ubuntu-latest aggregator — only runs istanbul merge + threshold
+    # checks in pure Node. jq is preinstalled on ubuntu-latest.
     runs-on: ubuntu-latest
     timeout-minutes: 3
     needs: [test-coverage-shard, test-coverage-cli, test-coverage-exocortex]
     if: always()
-    container:
-      image: mcr.microsoft.com/playwright:v1.57.0-jammy
 
     steps:
       - name: Verify upstream jobs succeeded
@@ -429,9 +425,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Install jq for coverage parsing
-        run: apt-get update && apt-get install -y jq
 
       - name: Download obsidian-plugin shard coverage
         uses: actions/download-artifact@v7

--- a/packages/obsidian-plugin/jest.config.js
+++ b/packages/obsidian-plugin/jest.config.js
@@ -93,7 +93,7 @@ module.exports = {
           [
             "<rootDir>/../test-utils/reporters/flaky-reporter.js",
             {
-              outputFile: "flaky-report.json",
+              outputFile: process.env.FLAKY_REPORT_FILE || "flaky-report.json",
               failOnFlaky: false,
               verbose: true,
             },

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+// Merges per-shard coverage-final.json files into a single obsidian-plugin
+// coverage report. Used by the sharded test-coverage GHA job (Phase 2 CI speedup).
+//
+// Usage:
+//   node scripts/merge-coverage.js <shard-inputs-dir> <output-coverage-dir>
+//
+// <shard-inputs-dir> contains subdirectories like `coverage-shard-1/`, each
+// holding a `coverage-final.json` produced by `jest --coverage --shard=X/N`.
+// <output-coverage-dir> is the final `packages/obsidian-plugin/coverage/`
+// path expected by the coverage-reports artifact consumer.
+//
+// Outputs: lcov.info, coverage-summary.json, coverage-final.json, lcov-report/.
+
+const fs = require("fs");
+const path = require("path");
+const libCoverage = require("istanbul-lib-coverage");
+const libReport = require("istanbul-lib-report");
+const reports = require("istanbul-reports");
+
+function walkJsonFiles(dir) {
+  const out = [];
+  const stack = [dir];
+  while (stack.length) {
+    const current = stack.pop();
+    if (!fs.existsSync(current)) continue;
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && entry.name === "coverage-final.json") {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+function main() {
+  const [, , inputsDirArg, outputDirArg] = process.argv;
+  if (!inputsDirArg || !outputDirArg) {
+    console.error(
+      "Usage: node scripts/merge-coverage.js <inputs-dir> <output-dir>",
+    );
+    process.exit(2);
+  }
+  const inputsDir = path.resolve(inputsDirArg);
+  const outputDir = path.resolve(outputDirArg);
+  const files = walkJsonFiles(inputsDir);
+  if (files.length === 0) {
+    console.error(`No coverage-final.json files found under ${inputsDir}`);
+    process.exit(1);
+  }
+  console.log(`Merging ${files.length} coverage-final.json file(s):`);
+  const map = libCoverage.createCoverageMap({});
+  for (const f of files) {
+    console.log(`  - ${path.relative(inputsDir, f)}`);
+    const raw = JSON.parse(fs.readFileSync(f, "utf8"));
+    map.merge(raw);
+  }
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(outputDir, "coverage-final.json"),
+    JSON.stringify(map.toJSON()),
+  );
+  const context = libReport.createContext({
+    dir: outputDir,
+    coverageMap: map,
+    defaultSummarizer: "nested",
+  });
+  for (const reporter of ["lcov", "json-summary", "text-summary"]) {
+    reports.create(reporter, {}).execute(context);
+  }
+  console.log(`Merged coverage written to ${outputDir}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Phase 2 of the CI Pipeline Speedup project (orchestrator ems__Project `e5939fb2`). Task `9346c5be-c297-4d56-95c5-0ae6019346f9` — primary wall-clock lever for the Phase 2 ≤120s jest-critical-path gate.

Split the monolithic `test-coverage` job (**192s** on main post-#2901) into parallel matrix + sibling jobs, mirroring the proven `e2e-shard → e2e-tests` pattern.

### New job topology

| Job | Parallelism | Notes |
|---|---|---|
| `test-coverage-shard (1..4)` | matrix | obsidian-plugin jest `--shard=X/4 --coverage --coverageThreshold='{}'` + `--maxWorkers=2`; partial lcov uploaded per shard |
| `test-coverage-cli` | parallel | CLI jest with own coverage + own thresholds (65/60/70/65) |
| `test-coverage-exocortex` | parallel | narrow `services/(GroundingExecutor\|AssetConversionService)` regression suite |
| `test-coverage` (**branch-protected name retained**) | aggregator | downloads 4 shard `coverage-final.json`, merges via `scripts/merge-coverage.js`, applies obsidian-plugin thresholds, uploads `coverage-reports` |

### Coverage delta validation (local 4-shard merge vs main baseline run `24716320497`)

| Metric | Baseline (main) | Merged shards | Δ |
|---|---|---|---|
| Statements | 81.15% | 81.14% | 0.01pp |
| Branches | 70.15% | 70.09% | 0.06pp |
| Functions | 74.87% | 74.87% | 0.00pp |
| Lines | 82.15% | 82.14% | 0.01pp |

All deltas ≪ 1pp AC. Rounding artefacts only; no real coverage regression.

### Wall-clock projection

- Pre: `test-coverage` = 192s (single job).
- Post: worst shard (~50s in CI) + aggregator (~30-35s: npm ci cached + downloads + istanbul merge + threshold + upload) ≈ **~85s critical path**.
- Parallel siblings (`test-coverage-cli`, `test-coverage-exocortex`) ≤55s each → do not extend critical path.

Actual numbers will be captured on this PR's first green run.

### Branch-protection contract

Required check `test-coverage` literal name **retained** (aggregator). New names (`test-coverage-shard`, `test-coverage-cli`, `test-coverage-exocortex`) are non-required; sibling Phase 4 project task `f235881d` (9b4f1f59) will add them to branch protection after stabilization.

### Files changed

- `.github/workflows/ci.yml` — job restructure (~280 LOC diff)
- `packages/obsidian-plugin/jest.config.js` — flaky-reporter `outputFile` now env-parameterized (`FLAKY_REPORT_FILE`) to avoid cross-shard collisions
- `scripts/merge-coverage.js` (**new**) — istanbul-lib-coverage-based lcov merger; ~70 LOC, zero extra deps (istanbul-lib-* already transitive via jest)

### Risks & mitigations (from RFC-CI-Speedup §Risk)

- **R2 (test isolation across shards)**: `--maxWorkers=2` bounded per shard; `--forceExit` retained; `resetMocks/clearMocks/restoreMocks: true` already in config. Coverage delta 0.0–0.1pp empirically validates no isolation breakage.
- **R3 (downstream codecov/artifact consumer break)**: `coverage-reports` artifact path/name/contents unchanged. `test-pyramid` job still passes via same artifact.
- **R5 (shard imbalance widening wall-clock)**: local jest default alphabetical sharding gave 14s/6s/10s/3s. Worst-leg still 3x faster than current 55-60s. Acceptable for Phase 2 exit; Phase 4 candidate for custom testSequencer if critical.

## Test plan

- [ ] CI: all 4 `test-coverage-shard` matrix legs green
- [ ] CI: `test-coverage-cli` + `test-coverage-exocortex` green
- [ ] CI: aggregator `test-coverage` green with merged lcov + thresholds applied
- [ ] Coverage delta measured from merged aggregator artifact vs baseline — ≤1pp all four metrics
- [ ] `test-pyramid` job downloads `coverage-reports` artifact and passes (downstream contract)
- [ ] Full critical-path wall-clock recorded in PR description post-merge
- [ ] 2 consecutive green PR runs before merge (per `feedback_e2e_spec_runtime_verify_gap`)