### PR TITLE
test(e2e): replace 18 blind sleeps with event-based waits

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/area-tree-collapsible.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/area-tree-collapsible.spec.ts
@@ -19,10 +19,6 @@ test.describe("Area Tree Collapsible Functionality", () => {
     await launcher.openFile("Areas/development.md");
     await launcher.waitForModalsToClose(10000);
 
-    // Additional wait for plugin to fully render after modals close
-    const window = await launcher.getWindow();
-    await window.waitForTimeout(5000);
-
     await launcher.waitForElement(".exocortex-area-tree", 60000);
 
     const areaTree = launcher.page.locator(".exocortex-area-tree");

--- a/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
@@ -25,14 +25,13 @@ test.describe("DailyNote Archive Filter", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
-    await window.waitForTimeout(5000);
-
-    await launcher.waitForElement(".exocortex-daily-tasks-section", 60000);
 
     const toggleButton = window.locator(
       ".exocortex-daily-tasks-section .exocortex-toggle-archived",
     );
-    await expect(toggleButton).toBeVisible({ timeout: 10000 });
+    await expect(toggleButton).toContainText("Show Archived", {
+      timeout: 30000,
+    });
 
     const initialButtonText = await toggleButton.textContent();
     expect(initialButtonText).toContain("Show Archived");
@@ -51,7 +50,7 @@ test.describe("DailyNote Archive Filter", () => {
     expect(tableContent).not.toContain("Archived Task");
 
     await toggleButton.click();
-    await window.waitForTimeout(2000);
+    await expect(toggleButton).toContainText("Hide Archived", { timeout: 5000 });
 
     const updatedButtonText = await toggleButton.textContent();
     expect(updatedButtonText).toContain("Hide Archived");
@@ -65,7 +64,7 @@ test.describe("DailyNote Archive Filter", () => {
     expect(updatedTableContent).toContain("Archived Task");
 
     await toggleButton.click();
-    await window.waitForTimeout(2000);
+    await expect(toggleButton).toContainText("Show Archived", { timeout: 5000 });
 
     const finalButtonText = await toggleButton.textContent();
     expect(finalButtonText).toContain("Show Archived");
@@ -84,34 +83,32 @@ test.describe("DailyNote Archive Filter", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
-    await window.waitForTimeout(5000);
-
-    await launcher.waitForElement(".exocortex-daily-tasks-section", 60000);
 
     const toggleButton = window.locator(
       ".exocortex-daily-tasks-section .exocortex-toggle-archived",
     );
-    await expect(toggleButton).toBeVisible({ timeout: 10000 });
+    await expect(toggleButton).toContainText("Show Archived", {
+      timeout: 30000,
+    });
 
     await toggleButton.click();
-    await window.waitForTimeout(2000);
+    await expect(toggleButton).toContainText("Hide Archived", { timeout: 5000 });
 
     let buttonText = await toggleButton.textContent();
     expect(buttonText).toContain("Hide Archived");
 
     await launcher.openFile("Daily Notes/2025-10-17.md");
-    await window.waitForTimeout(2000);
+    await launcher.waitForModalsToClose(10000);
 
     await launcher.openFile("Daily Notes/2025-10-18.md");
     await launcher.waitForModalsToClose(10000);
-    await window.waitForTimeout(5000);
-
-    await launcher.waitForElement(".exocortex-daily-tasks-section", 60000);
 
     const toggleButtonAfterRefresh = window.locator(
       ".exocortex-daily-tasks-section .exocortex-toggle-archived",
     );
-    await expect(toggleButtonAfterRefresh).toBeVisible({ timeout: 10000 });
+    await expect(toggleButtonAfterRefresh).toContainText("Hide Archived", {
+      timeout: 30000,
+    });
 
     buttonText = await toggleButtonAfterRefresh.textContent();
     expect(buttonText).toContain("Hide Archived");

--- a/packages/obsidian-plugin/tests/e2e/specs/daily-navigation.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-navigation.spec.ts
@@ -25,12 +25,12 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
-    await window.waitForTimeout(5000);
-
-    await launcher.waitForElement(".exocortex-daily-navigation", 60000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
-    await expect(navContainer).toBeVisible({ timeout: 10000 });
+    await expect(navContainer.locator(".exocortex-nav-prev a")).toContainText(
+      "2025-10-15",
+      { timeout: 30000 },
+    );
 
     const prevLink = navContainer.locator(".exocortex-nav-prev a");
     await expect(prevLink).toBeVisible();
@@ -49,11 +49,13 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
-    await window.waitForTimeout(5000);
-
-    await launcher.waitForElement(".exocortex-daily-navigation", 60000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
+    await expect(navContainer.locator(".exocortex-nav-prev a")).toContainText(
+      "2025-10-15",
+      { timeout: 30000 },
+    );
+
     const propertiesSection = window.locator(".exocortex-properties-section");
 
     const navVisible = await navContainer.isVisible();
@@ -76,9 +78,12 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
-    await window.waitForTimeout(5000);
 
     await launcher.waitForElement(".exocortex-layout-rendered", 60000);
+    // Layout signals render complete; if nav would appear, it would be here by now.
+    await expect(window.locator(".exocortex-layout-rendered")).toBeVisible({
+      timeout: 5000,
+    });
 
     const navContainer = window.locator(".exocortex-daily-navigation");
     const isVisible = await navContainer.isVisible().catch(() => false);
@@ -92,12 +97,12 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
-    await window.waitForTimeout(5000);
-
-    await launcher.waitForElement(".exocortex-daily-navigation", 60000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
-    await expect(navContainer).toBeVisible({ timeout: 10000 });
+    await expect(navContainer.locator(".exocortex-nav-prev a")).toContainText(
+      "2025-10-15",
+      { timeout: 30000 },
+    );
 
     const prevLink = navContainer.locator(".exocortex-nav-prev a");
     const nextLink = navContainer.locator(".exocortex-nav-next a");
@@ -120,12 +125,12 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
-    await window.waitForTimeout(5000);
-
-    await launcher.waitForElement(".exocortex-daily-navigation", 60000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
-    await expect(navContainer).toBeVisible({ timeout: 10000 });
+    await expect(navContainer.locator(".exocortex-nav-prev a")).toContainText(
+      "2025-10-15",
+      { timeout: 30000 },
+    );
 
     const prevLink = navContainer.locator(".exocortex-nav-prev a");
     const nextLink = navContainer.locator(".exocortex-nav-next a");
@@ -146,12 +151,11 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
-    await window.waitForTimeout(5000);
-
-    await launcher.waitForElement(".exocortex-daily-navigation", 60000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
-    await expect(navContainer).toBeVisible({ timeout: 10000 });
+    await expect(
+      navContainer.locator(".exocortex-nav-prev .exocortex-nav-disabled"),
+    ).toContainText("2025-10-14", { timeout: 30000 });
 
     const prevDisabled = navContainer.locator(
       ".exocortex-nav-prev .exocortex-nav-disabled",

--- a/packages/obsidian-plugin/tests/e2e/specs/daily-note-tasks.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-note-tasks.spec.ts
@@ -26,9 +26,6 @@ test.describe("DailyNote Tasks Table", () => {
 
     await launcher.waitForModalsToClose(10000);
 
-    // Additional wait for plugin to fully render after modals close
-    await window.waitForTimeout(5000);
-
     await launcher.waitForElement(".exocortex-daily-tasks-section", 60000);
 
     const tasksTable = window
@@ -125,9 +122,9 @@ test.describe("DailyNote Tasks Table", () => {
       expect(initialHeaderCount).toBe(5);
 
       await toggleButton.click();
-      await window.waitForTimeout(1000);
 
       headers = tasksTable.locator("thead th");
+      await expect(headers).toHaveCount(4, { timeout: 5000 });
       let headerCount = await headers.count();
       expect(headerCount).toBe(4);
 
@@ -143,9 +140,9 @@ test.describe("DailyNote Tasks Table", () => {
     expect(headerTexts).not.toContain("Effort Area");
 
     await toggleButton.click();
-    await window.waitForTimeout(1000);
 
     headers = tasksTable.locator("thead th");
+    await expect(headers).toHaveCount(5, { timeout: 5000 });
     headerCount = await headers.count();
     expect(headerCount).toBe(5);
 

--- a/packages/obsidian-plugin/tests/e2e/specs/table-column-alignment.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/table-column-alignment.spec.ts
@@ -37,9 +37,6 @@ test.describe("Table Column Alignment (#594)", () => {
 
     await launcher.waitForModalsToClose(10000);
 
-    // Additional wait for plugin to fully render after modals close
-    await window.waitForTimeout(5000);
-
     await launcher.waitForElement(".exocortex-daily-tasks-section", 60000);
 
     const tasksTable = window


### PR DESCRIPTION
## Summary

Phase 1 Priority 2 per CI speedup audit (task 335e392a). Replaces 18 `waitForTimeout()` calls across 5 E2E specs with semantic event-based Playwright waits.

## Changes per spec

| Spec | Sites | Approach |
|---|---:|---|
| daily-navigation | 6 | Content-specific `toContainText(date)` on `.exocortex-nav-prev` — avoids stale DOM after shared-launcher `beforeAll` refactor (#2902) |
| daily-archive-filter | 7 | Toggle button `toContainText("Show/Hide Archived")` waits + content-specific initial render |
| daily-note-tasks | 3 | Remove redundant padding before `waitForElement`; post-click sleep → `toHaveCount(N)` wait |
| table-column-alignment | 1 | Remove redundant padding; `waitForElement` already event-wait |
| area-tree-collapsible | 1 | Remove redundant padding; `waitForElement` already event-wait |
| **Total** | **18** | Aggregate sleep: 70s → 0s |

## Why content-specific in daily-navigation/daily-archive-filter

After PR #2902 (beforeEach→beforeAll), launcher persists across tests. Simple `waitForSelector(".exocortex-daily-navigation")` could return immediately on stale DOM from previous test. Content-specific waits (e.g. `toContainText("2025-10-15")`) ensure current test's file has rendered, not a sibling's leftovers.

## Projected savings

Shard-2 is the bottleneck (206s post-Phase-1 vs 180s gate). daily-navigation + daily-archive-filter are concentrated there.
- Aggregate: ~50s saved
- Shard-2: ~39s saved → projected ≈167s (below 180s gate ✓)

## Test plan
- [ ] All 4 e2e shards green pre-merge
- [ ] No new flake (retry counts monitored)
- [ ] Post-merge main CI + Auto Release succeed
- [ ] Shard-2 wall-clock measured post-merge < 180s