### PR TITLE
perf(ci): parallelize Playwright CT with 2 workers

### DIFF
--- a/packages/obsidian-plugin/playwright-ct.config.ts
+++ b/packages/obsidian-plugin/playwright-ct.config.ts
@@ -34,7 +34,8 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
 
   // Workers for parallel execution
-  workers: process.env.CI ? 1 : undefined,
+  // ctPort is auto-incremented per-worker (3100, 3101), so 2 workers do not collide
+  workers: process.env.CI ? 2 : undefined,
 
   // Reporter configuration
   reporter: [


### PR DESCRIPTION
## Summary

- Bump `workers: process.env.CI ? 1 : undefined` → `workers: process.env.CI ? 2 : undefined` in `packages/obsidian-plugin/playwright-ct.config.ts`.
- Playwright CT auto-increments `ctPort` per worker (3100, 3101) — no dev server collision.
- `fullyParallel: true` already enabled; fixtures isolated via per-test `mount()`.

## Why

Part of **Exocortex CI Pipeline Speedup ≤2min** (`ems__Project e5939fb2`), **Phase 2 exit gate**: Jest/Playwright CT critical path ≤120s.

Post-PR#2903 (`9346c5be` jest --shard for test-coverage):
- **test-coverage:** 82.5s avg ✓
- **test-component:** ~190s ❌ (dominant, unchanged)

Projected impact: ~50% reduction (test workload is CPU-bound Vite bundling + browser rendering, both parallel-friendly).

## Risks mitigations

| Risk | Mitigation |
|------|-----------|
| Port collision | Playwright CT auto-increments `ctPort` per worker |
| Cross-worker state leak | `grep` verified: no `test.describe.serial`, no shared `beforeAll`, no `fs.writeFile`, no global mutation |
| OOM | Container is stock `playwright:v1.57.0-jammy` on ubuntu-latest (4 vCPU / 16GB); 2 workers × 4GB = 8GB — well under |
| Flake spike | Existing `retries: 2` budget preserved; monitoring retry counts post-merge |

## Test plan

- [ ] CI: `test-component` green (target ≤100s, cap ≤120s)
- [ ] No new flaky test reports (`flaky-report-playwright.json` `totalFlaky` unchanged)
- [ ] 2+ consecutive green PR runs before merge
- [ ] Post-merge main CI: `test-component` ≤120s confirmed with n≥2 measurements