### PR TITLE
perf(ci): extract shared setup into composite action with node_modules cache

### DIFF
--- a/.github/actions/setup-node-pnpm/README.md
+++ b/.github/actions/setup-node-pnpm/README.md
@@ -1,0 +1,92 @@
+# `setup-node-pnpm` composite action
+
+Shared setup for every Node-based job in `ci.yml`. Centralises repeated boilerplate (checkout, `setup-node`, `npm ci`, optional build) and adds a `node_modules` cache that skips `npm ci` on exact-lockfile hits.
+
+> The directory name retains the historical `setup-node-pnpm` label introduced in the Phase 3 project brief. This repository uses `npm` (not `pnpm`) — the action name is a naming legacy only.
+
+## Inputs
+
+| Input             | Default    | Description                                                                                                                                                                                                  |
+| ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `node-version`    | `"22"`     | Node.js major version to install via `actions/setup-node@v4`.                                                                                                                                                |
+| `run-build`       | `"false"`  | When `"true"`, runs `npm run build` after dependency install. Required for `build`, `test-component`, `performance-tests`.                                                                                   |
+| `cache-key-extra` | `""`       | Suffix appended to the `node_modules` cache key. Use this to segregate caches produced inside different container images (e.g. `playwright-jammy`) so the restore step never unpacks native modules compiled against a different glibc / ABI. |
+
+All inputs are strings — GitHub composite actions do not support boolean inputs.
+
+## Checkout is the caller's responsibility
+
+Local composite actions (referenced via `uses: ./.github/actions/<name>`) require the calling job to have already run `actions/checkout` — the runner needs `action.yml` on disk before it can resolve the reference. Each job therefore performs its own `actions/checkout@v6` step with the appropriate `submodules` mode before invoking this action. Submodule handling is deliberately kept in the job definition so recursive-vs-shallow decisions remain visible and reviewable at the call site.
+
+## Steps performed
+
+1. `actions/setup-node@v4` with `cache: "npm"` (primes `~/.npm` download cache).
+2. `actions/cache@v4` over the root `node_modules` and every workspace's `node_modules`, keyed on `package-lock.json` hash + OS + Node version + optional discriminator.
+3. Conditional `npm ci --prefer-offline --no-audit --no-fund` on cache miss.
+4. On cache hit: a sanity check that verifies `node_modules/.package-lock.json` exists, falling back to `npm ci` if the restored tree looks corrupted.
+5. Conditional `npm run build` when `run-build: "true"`.
+
+## Example usage
+
+```yaml
+jobs:
+  my-job:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
+        with:
+          run-build: "true"
+          cache-key-extra: "playwright-jammy"
+
+      - name: Run tests
+        run: npm run test:something
+```
+
+## Cache key strategy
+
+```
+<runner.os>-nm-node<node-version>-<hashFiles(package-lock.json)>[-<cache-key-extra>]
+```
+
+**Exact-match only** — no `restore-keys`. A partial match would risk unpacking a stale dependency tree that doesn't match the current lockfile; skipping `npm ci` in that state would leave the job with subtly wrong modules. When the lockfile changes, the cache misses and `npm ci` runs fresh; the new tree is then persisted for subsequent runs with the same lockfile.
+
+The optional `cache-key-extra` input lets container-based jobs isolate their cache from host-runner jobs that share the same lockfile. For example, both `test-unit` (playwright container) and `test-coverage-shard` (bare `ubuntu-latest`) see the same `hashFiles('package-lock.json')`, but they should not share a `node_modules` cache because native modules (`better-sqlite3`, etc.) may have been compiled against different glibc versions. Containerised jobs pass `cache-key-extra: "playwright-jammy"`; bare-runner jobs omit the input.
+
+## Why no `pnpm`?
+
+The action name was fixed by the Phase 3 project brief (§4 naming). The repository itself runs on `npm` workspaces with `packages/starter-kit-fixtures` negated via `package.json`'s `workspaces` field. The action is named after its brief role — "the shared setup we'd reach for regardless of package manager" — rather than the tool it invokes.
+
+## Jobs that use this action
+
+As of this PR (Phase 3 task `44b3219a`):
+
+| Job                       | checkout submodules | run-build | cache-key-extra      |
+| ------------------------- | ------------------- | --------- | -------------------- |
+| `build`                   | none                | `"true"`  |                      |
+| `typecheck`               | none                |           |                      |
+| `lint`                    | none                |           |                      |
+| `test-unit`               | `recursive`         |           | `"playwright-jammy"` |
+| `test-coverage-shard`     | `recursive`         |           |                      |
+| `test-coverage-cli`       | `recursive`         |           |                      |
+| `test-coverage-exocortex` | `recursive`         |           |                      |
+| `test-coverage`           | none                |           |                      |
+| `test-bdd`                | none                |           |                      |
+| `test-component`          | none                | `"true"`  | `"playwright-jammy"` |
+| `test-pyramid`            | none                |           |                      |
+| `performance-tests`       | none                | `"true"`  | `"playwright-jammy"` |
+
+Jobs that deliberately do **not** use the composite:
+
+- `docs-link-check` — uses a third-party link-check action, not Node.
+- `docs-property-validation` — `setup-node` only, no `npm ci` required.
+- `archgate` — has its own `~/.archgate` cache and uses `npm install -g`, not `npm ci`.
+- `e2e-shard` — no Node setup in the runner; tests run inside a pre-built Docker image.
+- `e2e-tests` — minimal `setup-node` + a one-off `npm install -D @playwright/test`, no full lockfile install.

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,67 @@
+name: Setup Node & Install Dependencies
+description: >
+  Shared setup used by every Node-based job in ci.yml — Node install,
+  cached node_modules restore, conditional `npm ci`, and an optional
+  `npm run build`. The caller is responsible for running
+  `actions/checkout` beforehand (local composite actions require the repo
+  to be on disk before the action can be resolved).
+inputs:
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: "22"
+  run-build:
+    description: Run `npm run build` after dependency install
+    required: false
+    default: "false"
+  cache-key-extra:
+    description: >
+      Extra discriminator appended to the node_modules cache key. Use this to
+      segregate caches produced inside different container images so the
+      restore step never unpacks artifacts built against a different glibc /
+      native module ABI.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: "npm"
+
+    - name: Cache node_modules
+      id: nm-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          packages/cli/node_modules
+          packages/exocortex/node_modules
+          packages/obsidian-plugin/node_modules
+          packages/test-utils/node_modules
+        key: ${{ runner.os }}-nm-node${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}${{ inputs.cache-key-extra != '' && format('-{0}', inputs.cache-key-extra) || '' }}
+
+    - name: Install dependencies
+      if: steps.nm-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm ci --prefer-offline --no-audit --no-fund
+
+    - name: Verify dependencies (cache hit path)
+      if: steps.nm-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        echo "node_modules restored from cache — skipping npm ci"
+        # Sanity check — if the restored tree is incomplete (e.g. cache
+        # corruption), fall back to a fresh install so the job doesn't fail
+        # later with a cryptic "Cannot find module" error.
+        if [ ! -d node_modules ] || [ ! -f node_modules/.package-lock.json ]; then
+          echo "node_modules looks incomplete — running npm ci as fallback"
+          npm ci --prefer-offline --no-audit --no-fund
+        fi
+
+    - name: Build packages
+      if: inputs.run-build == 'true'
+      shell: bash
+      run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node & install deps (+ build)
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
+          run-build: "true"
 
       - name: Upload built plugin
         uses: actions/upload-artifact@v6
@@ -50,14 +43,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Type check
         run: npm run check:types
@@ -70,14 +57,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Lint
         run: npm run lint
@@ -153,14 +134,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+          cache-key-extra: "playwright-jammy"
 
       - name: Run UI tests (jest-environment-obsidian)
         run: |
@@ -220,14 +197,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Run obsidian-plugin tests (shard ${{ matrix.shard }}/4)
         env:
@@ -277,14 +248,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Run CLI tests with coverage
         env:
@@ -370,14 +335,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Run exocortex grounding regression tests
         env:
@@ -417,14 +376,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Download obsidian-plugin shard coverage
         uses: actions/download-artifact@v7
@@ -519,14 +472,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Run BDD Tests
         run: npm run bdd:test
@@ -568,17 +515,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node & install deps (+ build)
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build packages
-        run: npm run build
+          run-build: "true"
+          cache-key-extra: "playwright-jammy"
 
       - name: Run component tests (excluding visual)
         run: |
@@ -677,14 +618,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Download coverage reports
         uses: actions/download-artifact@v7
@@ -863,22 +798,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node & install deps (+ build)
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+          run-build: "true"
+          cache-key-extra: "playwright-jammy"
 
       - name: Run unit-level performance tests
         run: |
           export NODE_OPTIONS="--max-old-space-size=4096"
           npm run test:perf
-
-      - name: Build packages (required for component tests)
-        run: npm run build
 
       - name: Run component rendering performance tests
         run: |


### PR DESCRIPTION
## Summary

Centralises `checkout + actions/setup-node + npm ci + (optional) build` into one local composite action (`.github/actions/setup-node-pnpm/`) used by 12 CI jobs. Adds a `node_modules` cache keyed on `package-lock.json` hash so repeat runs on unchanged dependencies skip `npm ci` entirely (measured at ~10s on recent main).

**Phase 3 orchestrated project** — task `44b3219a` under ems__Project `e5939fb2` (CI speedup ≤2min).

## What changes

- **New**: `.github/actions/setup-node-pnpm/action.yml` (composite) + `README.md` (usage docs).
- **ci.yml**: 12 jobs refactored to call the composite. Each job retains its own `actions/checkout@v6` (local composite actions require the repo on disk before they can be resolved). Net diff: +30 / -101 lines.
- **No job renames** → branch protection (`test-unit`, `test-coverage`, `test-component`, `test-bdd`, `build`, `typecheck`, `archgate`, `e2e-tests`) is unaffected.

Jobs touched: `build` (run-build), `typecheck`, `lint`, `test-unit` (+playwright-jammy cache key), `test-coverage-shard`, `test-coverage-cli`, `test-coverage-exocortex`, `test-coverage`, `test-bdd`, `test-component` (run-build + playwright-jammy), `test-pyramid`, `performance-tests` (run-build + playwright-jammy).

Jobs deliberately untouched: `docs-link-check`, `docs-property-validation`, `archgate`, `e2e-shard`, `e2e-tests` (each documented in README).

## Baseline vs projection (honest)

Real step-level timing on main commit 2ba9ceb0 (run 24738789283), `test-component`:

| Step | Time |
| ---- | ---- |
| Initialize containers | 25s |
| Checkout | 1s |
| Setup Node.js | 3s |
| **Install dependencies (`npm ci`)** | **10s** ← cache target |
| Build packages | 21s |
| Component tests (non-visual) | 63s |
| Visual regression tests | 18s |
| Upload / flaky / cleanup | ~10s |
| **Total** | **151s** |

The original Phase 3 spec projected `npm ci: 30s → 5-10s` (save ~25s), but current `npm ci` is already **only 10s** thanks to `actions/setup-node@v4`'s built-in npm-download cache. So the realistic saving from `node_modules` caching is **~8s per job**, not 25s.

Post-composite `test-component` projection:

- Cache miss (PR run 1): ~151s (unchanged — `npm ci` still runs).
- Cache hit (PR run 2+): ~143s (`npm ci` 10s → cache restore ~2s).

**Phase 2 exit gate (`test-component` ≤120s) is NOT expected to close on this PR alone** — the floor is ~23s above target. Container init (25s) and build step (21s) are the remaining large levers; both need follow-up work outside the scope of a composite-setup PR.

What this PR buys:

- ~8s per job on cache-hit runs.
- DRY setup — future CI tweaks land in one file.
- Cache-hit skip path + sanity fallback on corruption.
- Documented conventions for when to use / not use composite.

## Test plan

- [ ] First PR run (cache miss): verify all 12 jobs succeed, `Install dependencies` step still runs.
- [ ] Second PR run (cache hit): verify `Install dependencies` step is skipped (the "Verify dependencies (cache hit path)" echoes the skip message); measure wall-clock delta on `test-component`, `test-coverage-shard`, `test-bdd`.
- [ ] Verify `test-unit` and `test-component` (container jobs) use the `playwright-jammy` cache key (check cache hits don't collide with bare-runner caches).
- [ ] Verify no job regresses vs. baseline.
- [ ] `gh pr view --json statusCheckRollup` shows all 8 branch-protected checks green.
- [ ] Post-merge main CI: `Auto Release` fires (ping orchestrator if cancelled per `feedback_automerge_main_ci_race_blocks_release`).