### PR TITLE
test: validate docs-only PR skips e2e (dummy — do not merge)

### DIFF
--- a/docs/phase3-filter-validation.md
+++ b/docs/phase3-filter-validation.md
@@ -1,0 +1,6 @@
+# Phase 3 Path-Filter Validation (dummy)
+
+Dummy documentation file used to validate that docs-only PRs
+correctly skip the gated e2e jobs in PR [#2908](https://github.com/kitelev/exocortex/pull/2908).
+
+This file will be removed — do not rely on it.


### PR DESCRIPTION
## Purpose (DO NOT MERGE)

Dummy PR to empirically validate that the path-filter gate in parent PR [#2908](https://github.com/kitelev/exocortex/pull/2908) correctly **skips** the heavy e2e jobs on a pure docs change.

**Base = `ci-speedup/phase3-path-filter`** (not main) so the filter is active in the workflow being run.

## Expected outcome

- `detect-changes`: `code=false`
- `test-component`, `e2e-shard (1..4)`, `performance-tests`: all `skipped`
- Required checks: `skipped` should satisfy branch protection (validates advisor hypothesis)
- PR mergeable status: mergeable

## Non-expected outcome (would indicate filter bug)

- Any of the gated jobs run to completion
- PR reports blocked-by-required-checks

Closing without merge once status verified.