### PR TITLE
test: R4 mitigation — docs + stray .spec.ts must trigger e2e (dummy — do not merge)

### DIFF
--- a/docs/phase3-filter-validation.md
+++ b/docs/phase3-filter-validation.md
@@ -1,0 +1,10 @@
+# Phase 3 Path-Filter Validation — docs + spec rename (dummy)
+
+Dummy documentation file + a misplaced `.spec.ts` file simulating the
+R4 failure scenario (docs PR that inadvertently includes a spec
+rename/addition).
+
+R4 mitigation in PR [#2908](https://github.com/kitelev/exocortex/pull/2908)
+should detect this and still trigger the gated e2e jobs.
+
+Will be removed — do not rely on it.

--- a/docs/phase3-rename.spec.ts
+++ b/docs/phase3-rename.spec.ts
@@ -1,0 +1,5 @@
+// Dummy spec file in docs/ simulating R4 scenario for PR #2908.
+// The path-filter must detect this and force e2e to run.
+// Not collected by any jest/playwright config — safe to keep for the
+// duration of the validation PR, will be deleted with the PR closure.
+export const DUMMY = "phase3-rename-r4-validation";


### PR DESCRIPTION
## Purpose (DO NOT MERGE)

R4 mitigation validation for PR [#2908](https://github.com/kitelev/exocortex/pull/2908).

Simulates the failure scenario: a docs-only PR that inadvertently includes a `.spec.ts` file (rename, migration, copy). The restrictive regex must catch this and **force** e2e to run even though the predominant change is docs.

**Base = `ci-speedup/phase3-path-filter`** so the filter is active.

## Expected outcome

- `detect-changes`: `code=true` (because `**/*.spec.{ts,tsx,js,jsx}` glob matches `docs/phase3-rename.spec.ts`)
- `test-component`, `e2e-shard (1..4)`, `performance-tests`: all run normally

## Non-expected outcome (would indicate R4 regression)

- Any of the gated jobs show `skipped` — indicates the spec-file glob in the filter is broken

Closing without merge once status verified.