### PR TITLE
test: validate docs-only PR skips gated e2e jobs (dummy — DO NOT MERGE)

### DIFF
--- a/docs/phase3-filter-validation.md
+++ b/docs/phase3-filter-validation.md
@@ -1,0 +1,7 @@
+# Phase 3 Path-Filter Validation — docs-only (dummy)
+
+Dummy documentation file used to validate that docs-only PRs
+correctly skip the gated e2e jobs merged in
+PR [#2908](https://github.com/kitelev/exocortex/pull/2908).
+
+Will be closed without merge once the filter behavior is verified.


### PR DESCRIPTION
Dummy PR validating that after #2908 merged, docs-only PRs trigger `code=false` in `detect-changes` and the heavy e2e jobs are `skipped`. Will be closed without merge.