### PR TITLE
test: R4 mitigation — docs + stray .spec.ts must trigger e2e (dummy — DO NOT MERGE)

### DIFF
--- a/docs/phase3-filter-validation.md
+++ b/docs/phase3-filter-validation.md
@@ -1,0 +1,10 @@
+# Phase 3 Path-Filter Validation — R4 scenario (dummy)
+
+Dummy documentation file + a misplaced `.spec.ts` file simulating the
+R4 failure scenario (docs PR that inadvertently includes a spec
+rename / addition) for PR [#2908](https://github.com/kitelev/exocortex/pull/2908).
+
+The restrictive regex in the filter should detect the spec file and
+force the gated e2e jobs to run despite the predominantly docs diff.
+
+Will be closed without merge once R4 behavior is verified.

--- a/docs/phase3-rename.spec.ts
+++ b/docs/phase3-rename.spec.ts
@@ -1,0 +1,5 @@
+// Dummy spec file in docs/ simulating R4 scenario for PR #2908.
+// Path-filter must detect this and force e2e to run.
+// Not collected by any jest/playwright config — safe during the
+// validation PR, removed when the PR is closed.
+export const DUMMY = "phase3-rename-r4-validation";


### PR DESCRIPTION
Dummy PR validating that after #2908 merged, a docs PR that also includes a `.spec.ts` file triggers `code=true` (R4 mitigation). Heavy jobs must RUN. Will be closed without merge.