### PR TITLE
test: post-fix R4 — docs + .spec.ts triggers e2e (dummy — DO NOT MERGE)

### DIFF
--- a/docs/phase3-filter-validation.md
+++ b/docs/phase3-filter-validation.md
@@ -1,0 +1,10 @@
+# Phase 3 Path-Filter Validation — R4 scenario (post-fix dummy)
+
+Docs edit + misplaced `.spec.ts` simulating the R4 failure scenario
+(docs PR that inadvertently includes a spec file) for the post-fix
+state after PR #2913.
+
+Expected: `**/*.spec.{ts,tsx,js,jsx}` glob matches, `code=true`, all
+gated e2e jobs run full tests.
+
+Will be closed without merge.

--- a/docs/phase3-rename.spec.ts
+++ b/docs/phase3-rename.spec.ts
@@ -1,0 +1,5 @@
+// Dummy spec file in docs/ simulating R4 scenario post-fix.
+// Path-filter must detect this and force e2e to run.
+// Not collected by any jest/playwright config — safe during the
+// validation PR, removed when the PR is closed.
+export const DUMMY = "phase3-rename-r4-post-fix-validation";


### PR DESCRIPTION
Post-fix R4 validation of PR #2913. Expected: `detect-changes.code=true` via `**/*.spec.{ts,tsx,js,jsx}` glob, all 4 shards run full e2e. Close without merge.