### PR TITLE
docs(ci): update required checks + timing blurb (Phase 4 cutover, f235881d)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -596,8 +596,9 @@ Starter-kit dynamic commands (`exocmd__Command`) are covered in three test layer
 
 **Runtime-verify gate:** new E2E specs MUST run green in CI (not only local) before the hosting task flips to Review; skipping this gate caused attribution drift flagged in Phase 2 retrospective.
 
-**Required CI checks (branch-protected per Phase 4 amendment 2026-04-21):**
-`test-unit`, `test-coverage`, `e2e-shard-1`, `e2e-shard-2`, `e2e-shard-3`, `e2e-shard-4`, `archgate`, `test-component`, `typecheck`, `lint`.
+**Required CI checks (branch-protected, 11 contexts as of Phase 4 cutover 2026-04-22):**
+`archgate`, `detect-changes`, `e2e-shard (1)`, `e2e-shard (2)`, `e2e-shard (3)`, `e2e-shard (4)`, `lint`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`.
+Matrix contexts use the parenthesised form `<job> (<shard>)` — hyphenated names like `e2e-shard-1` silently resolve to no required check. `test-unit` was dropped from required contexts in f235881d (Phase 4 cutover) now that it is a deduplicated stub; `detect-changes` was added so path-filter infrastructure always runs.
 
 **Rollback playbook:** `docs/ROLLBACK_RFC_CI_TESTS.md` — per-trigger mitigation (flaky quarantine / smoke budget trim / submodule → npm migration / admin nuclear rollback).
 
@@ -628,22 +629,40 @@ build-and-test:
 **✅ CORRECT - Require individual jobs:**
 
 ```bash
-# Configure branch protection via GitHub API
+# Configure branch protection via GitHub API.
+# Current exocortex required set (11 contexts) as of Phase 4 cutover 2026-04-22.
 gh api repos/OWNER/REPO/branches/main/protection/required_status_checks -X PATCH --input - <<EOF
 {
   "strict": true,
-  "checks": [
-    {"context": "build", "app_id": 15368},
-    {"context": "typecheck", "app_id": 15368},
-    {"context": "test-unit", "app_id": 15368},
-    {"context": "test-coverage", "app_id": 15368},
-    {"context": "test-bdd", "app_id": 15368},
-    {"context": "test-component", "app_id": 15368},
-    {"context": "e2e-tests", "app_id": 15368}
+  "contexts": [
+    "archgate",
+    "detect-changes",
+    "e2e-shard (1)",
+    "e2e-shard (2)",
+    "e2e-shard (3)",
+    "e2e-shard (4)",
+    "lint",
+    "test-bdd",
+    "test-component",
+    "test-coverage",
+    "typecheck"
   ]
 }
 EOF
 ```
+
+**Matrix-job check-run names use parenthesised form `<job> (<shard>)` with
+literal space and parens** (e.g. `e2e-shard (1)`). Hyphenated names like
+`e2e-shard-1` silently resolve to no required check — always verify names on
+a live PR via `gh pr view <PR> --json statusCheckRollup` before composing a
+PATCH payload.
+
+**Path-filtered jobs** (`test-component`, `e2e-shard (1..4)`): on docs-only
+PRs the `detect-changes` job emits `code=false`, and downstream jobs either
+skip via job-level `if:` (singletons — reported as skipped=success) or
+short-circuit via `env.RUN_E2E` gates at step level (matrix jobs must NOT
+use job-level `if:` or the parenthesised `(N)` contexts collapse to a single
+base name).
 
 **Why this matters:**
 - Individual job requirements provide **real protection**
@@ -726,10 +745,12 @@ refactor: simplify RDF store queries
    ```
 
 ### Task NOT Complete Until:
-- ✅ CI pipeline passes (build-and-test + e2e-tests)
+- ✅ All 11 required CI checks pass (see "GitHub Branch Protection Best Practices" above for the current list). Critical-path target after Phase 3: **~236s avg ±50s**, gate relaxed to **≤220s** per Decision B (RFC v2 relax, 2026-04-22). Original ≤135s target was infeasible given setup-floor dominance.
 - ✅ PR merged to main
 - ✅ Auto-release workflow creates GitHub release
 - ✅ Worktree cleaned up
+
+**Rollback reference:** `docs/ROLLBACK_CI_SPEEDUP.md` documents per-phase revert procedure for any of the Phase 1–3 speedup changes if a regression is detected post-merge.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ infrastructure/  → Obsidian API adapters, file system
 
 - **Tests:** 564 test files, ~11K+ individual test cases (parametrized). Run `npm run test:all` for exact count.
 - **Coverage thresholds**: statements 75.5%, branches 63%, BDD ≥80%
-- **CI checks**: build, typecheck, test-unit, test-coverage, test-bdd, archgate, e2e-tests, test-component
+- **Required CI checks (11, post-Phase 4 2026-04-22)**: archgate · detect-changes · e2e-shard (1..4) · lint · test-bdd · test-component · test-coverage · typecheck. Source of truth: `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`.
+- **CI pipeline target**: post-Phase 3 baseline is ~236s avg ±50s (N=3 on main). Gate relaxed to **≤220s** per Decision B (RFC v2 relax, 2026-04-22); original ≤135s target was infeasible given setup-floor dominance. See `docs/ROLLBACK_CI_SPEEDUP.md` for per-phase revert procedure.
 
 ## TypeScript Tooling
 
@@ -62,7 +63,7 @@ npm run test:all                                    # Test first
 git commit -am "feat: user-facing description"
 git push origin feature/my-feature
 gh pr create --title "feat: description" --body "..."
-gh pr merge --auto --squash                         # Wait for 8 CI checks
+gh pr merge --auto --squash                         # Wait for 11 required CI checks
 ```
 
 **Task is NOT complete until**: CI green + PR merged + Auto Release succeeds + post-mortem written.


### PR DESCRIPTION
## Summary

Phase 4 cutover companion PR for **f235881d** (Exocortex CI Pipeline Speedup ≤2min project, parent `e5939fb2`). Updates CLAUDE.md + AGENTS.md to reflect the live branch-protection required checks and the relaxed critical-path gate.

## What changed

**Branch protection (applied before PR, not in this diff):**
- **Removed** `test-unit` from required contexts — it was stubbed to a deduplicated `test:ui` runner in Phase 2 PR #2900 (task 761ca21e); the Phase 4 drop was deferred to this task per the `test-unit` job comment in `ci.yml`.
- **Added** `detect-changes` — introduced in Phase 3 PR #2908; required now so path-filter infrastructure (`code`, `force-e2e`) always runs.

Current required set (11): `archgate`, `detect-changes`, `e2e-shard (1..4)`, `lint`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`.

**This PR (docs only):**
- `CLAUDE.md` — replaced stale single-line "CI checks" summary with the current 11-check list and the post-Phase 3 timing blurb.
- `AGENTS.md` — fixed three stale blocks:
  1. RFC-CI-Tests Phase 4 required-checks list (was using hyphenated `e2e-shard-1` form and omitted `test-bdd` + `detect-changes`).
  2. `GitHub Branch Protection Best Practices` example payload (was 7-check list from PR #305 era).
  3. `Task NOT Complete Until` referenced non-existent `build-and-test` aggregator.

CI timing expectation: **~236s avg ±50s** (N=3 post-merge main runs), gate relaxed to **≤220s** per Decision B (RFC v2 relax). Original ≤135s target was infeasible — setup floor (`npm ci` + build ~62s) dominates, and remaining critical-path jobs (`test-component` 144-151s, `e2e-shard` 143-253s) include container init that cannot be trivially parallelised.

Rollback procedure: `docs/ROLLBACK_CI_SPEEDUP.md` (merged in PR #2916).

## Test plan

- [x] Branch-protection PATCH verified via `gh api .../required_status_checks` — 11 contexts returned, `test-unit` absent, `detect-changes` present.
- [x] Backup of pre-change required_status_checks saved to `/tmp/branch-protection-backup-*.json` for audit.
- [ ] PR CI green on all 11 required checks (including `detect-changes` as new gate).
- [ ] Post-merge auto-release succeeds → new version tag published.