### PR TITLE
perf(ci): pre-build Docker CI base image to GHCR (Phase 5)

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,82 @@
+name: CI Docker Image
+
+# Builds and publishes the pre-built CI base image to GHCR. The image
+# contains the Playwright runtime, Obsidian binary, xvfb, and node_modules
+# installed from the current lock file. It is consumed by e2e-shard jobs
+# in ci.yml via `--build-arg BASE_IMAGE=ghcr.io/kitelev/exocortex-ci:<tag>`
+# (Phase 5 CI Speedup, task d7d18dd6).
+#
+# Triggers:
+#   - push on main touching the lock file or Dockerfile.ci  → publish
+#   - workflow_dispatch                                      → manual rebuild
+#
+# PRs cannot publish to GHCR (GITHUB_TOKEN from fork PRs lacks packages:write
+# scope, and writing from untrusted PR content would be a security issue).
+# The e2e-shard job handles cache-miss by falling back to a local
+# Dockerfile.ci build, so PRs that change the lock file still work — they
+# simply do not benefit from the speedup until they land on main.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "package-lock.json"
+      - "packages/obsidian-plugin/Dockerfile.ci"
+      - ".github/workflows/ci-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ci-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tag
+        id: tag
+        # Hash the inputs that determine image contents:
+        #   - package-lock.json     (drives npm ci)
+        #   - Dockerfile.ci         (drives apt install / obsidian download)
+        # Any change in either invalidates the tag and republishes. Truncated
+        # to 16 hex chars for readability — collision space 2^64 is adequate
+        # given the small number of distinct tags we ever produce.
+        run: |
+          HASH=$(cat \
+            package-lock.json \
+            packages/obsidian-plugin/Dockerfile.ci \
+            | sha256sum | cut -c1-16)
+          echo "tag=$HASH" >> "$GITHUB_OUTPUT"
+          echo "::notice::ci-image tag = $HASH"
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packages/obsidian-plugin/Dockerfile.ci
+          push: true
+          tags: |
+            ghcr.io/kitelev/exocortex-ci:${{ steps.tag.outputs.tag }}
+            ghcr.io/kitelev/exocortex-ci:latest
+          cache-from: type=gha,scope=ci-image
+          cache-to: type=gha,scope=ci-image,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  # e2e-shard jobs pull the pre-built base image from GHCR (Phase 5
+  # CI Speedup, task d7d18dd6). Read-only — publish happens in
+  # ci-image.yml on push-to-main only.
+  packages: read
 
 jobs:
   # Detect whether PR touches code that requires e2e/browser testing.
@@ -770,20 +774,77 @@ jobs:
           name: plugin-build
           path: .
 
+      # Phase 5 CI Speedup (task d7d18dd6): use the `docker` driver (local
+      # Docker daemon) so that both the GHCR-pulled base image and the
+      # locally-built fallback base are visible to the FROM in Dockerfile.e2e.
+      # The default `docker-container` driver runs in an isolated namespace
+      # and cannot resolve locally-tagged images at FROM-time.
+      # Trade-off: loses BuildKit `type=gha` intermediate-layer caching for
+      # the Dockerfile.e2e build; acceptable because that build is now a
+      # thin app layer (~5s) once the heavy base is cache-hit via GHCR.
       - name: Set up Docker Buildx
         if: env.RUN_E2E == 'true'
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+
+      # Phase 5: pull pre-built base image from GHCR when possible. The
+      # base contains xvfb + Obsidian + node_modules, so Dockerfile.e2e
+      # only needs to COPY plugin artifacts (~5s instead of ~80s cold).
+      - name: Log in to GHCR
+        if: env.RUN_E2E == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve base image (pull from GHCR or build locally)
+        if: env.RUN_E2E == 'true'
+        id: base
+        run: |
+          set -euo pipefail
+          HASH=$(cat \
+            package-lock.json \
+            packages/obsidian-plugin/Dockerfile.ci \
+            | sha256sum | cut -c1-16)
+          TAGGED="ghcr.io/kitelev/exocortex-ci:${HASH}"
+          LATEST="ghcr.io/kitelev/exocortex-ci:latest"
+
+          # Prefer the exact-hash tag (deterministic). Fall back to :latest
+          # which lags by one main-merge but still saves the npm ci cost.
+          # Final fallback is a local Dockerfile.ci build (bootstrap / first
+          # run on a new lock file; adds ~60s but preserves correctness).
+          if docker pull "$TAGGED" 2>/dev/null; then
+            echo "::notice::Pulled pre-built base $TAGGED (hash match)"
+            echo "image=$TAGGED" >> "$GITHUB_OUTPUT"
+          elif docker pull "$LATEST" 2>/dev/null; then
+            echo "::warning::Hash-tagged base $TAGGED not in GHCR — using $LATEST (lock file may have changed; speedup still partial)"
+            echo "image=$LATEST" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::No pre-built base in GHCR — building locally from Dockerfile.ci (bootstrap / cache cold)"
+            docker build \
+              -t exocortex-ci-base:local \
+              -f packages/obsidian-plugin/Dockerfile.ci \
+              .
+            echo "image=exocortex-ci-base:local" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build E2E Docker image
         if: env.RUN_E2E == 'true'
+        # With the `docker` driver (see setup-buildx step above) the legacy
+        # builder is used, which does not support type=gha registry cache.
+        # That's acceptable here because the Dockerfile.e2e build is now a
+        # thin app layer (~5s); heavy caching happens at the base-image
+        # level in GHCR instead.
         uses: docker/build-push-action@v5
         with:
           context: .
           file: packages/obsidian-plugin/Dockerfile.e2e
           load: true
           tags: exocortex-e2e:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            BASE_IMAGE=${{ steps.base.outputs.image }}
 
       - name: Run E2E tests (shard ${{ matrix.shard }}/4)
         if: env.RUN_E2E == 'true'

--- a/packages/obsidian-plugin/Dockerfile.ci
+++ b/packages/obsidian-plugin/Dockerfile.ci
@@ -1,0 +1,66 @@
+# Pre-built CI base image — Playwright + Obsidian + xvfb + node_modules.
+#
+# Published to ghcr.io/kitelev/exocortex-ci by .github/workflows/ci-image.yml
+# on any change to package-lock.json or this Dockerfile. Consumed by
+# Dockerfile.e2e via `--build-arg BASE_IMAGE=ghcr.io/kitelev/exocortex-ci:<tag>`.
+#
+# Phase 5 CI Speedup (task d7d18dd6): amortises the ~60s npm ci cost that
+# was being paid by every e2e-shard on every PR. Only rebuilt on lock-file
+# churn (rare), so steady-state cache-hit rate is high.
+FROM mcr.microsoft.com/playwright:v1.55.1-jammy
+
+# xvfb + window manager + Obsidian runtime deps (matches Dockerfile.e2e
+# Stage 1 verbatim so the two image layers stay binary-compatible).
+RUN apt-get update && apt-get install -y \
+    xvfb \
+    x11-utils \
+    fluxbox \
+    libgbm1 \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    libgtk-3-0 \
+    libgdk-pixbuf2.0-0 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxi6 \
+    libxrandr2 \
+    libxtst6 \
+    wget \
+    unzip \
+    squashfs-tools \
+    zlib1g \
+    libfuse2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Obsidian binary (cached until version changes).
+WORKDIR /opt
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+        OBSIDIAN_FILE="obsidian-1.9.14-arm64.tar.gz"; \
+        OBSIDIAN_DIR="obsidian-1.9.14-arm64"; \
+    else \
+        OBSIDIAN_FILE="obsidian-1.9.14.tar.gz"; \
+        OBSIDIAN_DIR="obsidian-1.9.14"; \
+    fi && \
+    wget -q https://github.com/obsidianmd/obsidian-releases/releases/download/v1.9.14/$OBSIDIAN_FILE \
+    && tar -xzf $OBSIDIAN_FILE \
+    && mv $OBSIDIAN_DIR obsidian \
+    && rm $OBSIDIAN_FILE
+
+WORKDIR /app
+
+# Copy manifests for every published workspace (starter-kit-fixtures is
+# excluded from `workspaces` in root package.json, so no package.json is
+# required for it).
+COPY package*.json ./
+COPY packages/exocortex/package*.json ./packages/exocortex/
+COPY packages/obsidian-plugin/package*.json ./packages/obsidian-plugin/
+COPY packages/cli/package*.json ./packages/cli/
+COPY packages/test-utils/package*.json ./packages/test-utils/
+RUN npm ci --prefer-offline --no-audit --no-fund
+
+ENV DISPLAY=:99
+ENV OBSIDIAN_PATH=/opt/obsidian/obsidian
+ENV OBSIDIAN_VAULT=/app/packages/obsidian-plugin/tests/e2e/test-vault

--- a/packages/obsidian-plugin/Dockerfile.e2e
+++ b/packages/obsidian-plugin/Dockerfile.e2e
@@ -1,61 +1,21 @@
-# Stage 1: Base image with Obsidian (cached for long time)
-FROM mcr.microsoft.com/playwright:v1.55.1-jammy AS obsidian-base
-
-# Install xvfb, window manager, and dependencies for headless Obsidian
-RUN apt-get update && apt-get install -y \
-    xvfb \
-    x11-utils \
-    fluxbox \
-    libgbm1 \
-    libnss3 \
-    libxss1 \
-    libasound2 \
-    libgtk-3-0 \
-    libgdk-pixbuf2.0-0 \
-    libxcomposite1 \
-    libxcursor1 \
-    libxdamage1 \
-    libxi6 \
-    libxrandr2 \
-    libxtst6 \
-    wget \
-    unzip \
-    squashfs-tools \
-    zlib1g \
-    libfuse2 \
-    && rm -rf /var/lib/apt/lists/*
-
-# Download and extract Obsidian (cached until version changes)
-WORKDIR /opt
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
-        OBSIDIAN_FILE="obsidian-1.9.14-arm64.tar.gz"; \
-        OBSIDIAN_DIR="obsidian-1.9.14-arm64"; \
-    else \
-        OBSIDIAN_FILE="obsidian-1.9.14.tar.gz"; \
-        OBSIDIAN_DIR="obsidian-1.9.14"; \
-    fi && \
-    wget -q https://github.com/obsidianmd/obsidian-releases/releases/download/v1.9.14/$OBSIDIAN_FILE \
-    && tar -xzf $OBSIDIAN_FILE \
-    && mv $OBSIDIAN_DIR obsidian \
-    && rm $OBSIDIAN_FILE
-
-# Stage 2: Dependencies (cached until package.json changes)
-FROM obsidian-base AS dependencies
+# E2E test image — thin app layer on top of a pre-built base.
+#
+# Phase 5 CI Speedup (task d7d18dd6): the heavy Stage 1 (obsidian + xvfb)
+# and Stage 2 (npm ci) work has been extracted into Dockerfile.ci and
+# published to ghcr.io/kitelev/exocortex-ci. This file now only adds the
+# app-specific layer (plugin artifacts + test fixtures), which is fast.
+#
+# BASE_IMAGE defaults to a local tag. CI passes either
+# `--build-arg BASE_IMAGE=ghcr.io/kitelev/exocortex-ci:<hash>` (cache-hit)
+# or `--build-arg BASE_IMAGE=exocortex-ci-base:local` after falling back
+# to a local Dockerfile.ci build (cache-miss / bootstrap). `docker build`
+# outside CI needs the base image available locally under the same tag.
+ARG BASE_IMAGE=exocortex-ci-base:local
+FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
-# Copy package files from root and all workspaces
-COPY package*.json ./
-COPY packages/exocortex/package*.json ./packages/exocortex/
-COPY packages/obsidian-plugin/package*.json ./packages/obsidian-plugin/
-COPY packages/cli/package*.json ./packages/cli/
-RUN npm ci --prefer-offline --no-audit
-
-# Stage 3: Application (rebuilt on code changes)
-FROM dependencies AS app
-
-# Copy entrypoint first (rarely changes)
+# Copy entrypoint first (rarely changes so it stays in a stable layer).
 COPY packages/obsidian-plugin/docker-entrypoint-e2e.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
@@ -79,7 +39,9 @@ RUN mkdir -p packages/obsidian-plugin/tests/e2e/test-vault/.obsidian/plugins/exo
     && echo "=== Plugin files installed: ===" \
     && ls -lh packages/obsidian-plugin/tests/e2e/test-vault/.obsidian/plugins/exocortex/
 
-# Environment variables
+# Environment variables (also inherited from Dockerfile.ci base, but set
+# explicitly here so a bootstrap build from a fallback base without them
+# still produces a runnable image).
 ENV DISPLAY=:99
 ENV OBSIDIAN_PATH=/opt/obsidian/obsidian
 ENV OBSIDIAN_VAULT=/app/packages/obsidian-plugin/tests/e2e/test-vault


### PR DESCRIPTION
## Summary

Phase 5 of the [≤2min CI Speedup project](https://github.com/kitelev/exocortex/issues?q=label%3Aci-speedup) (task `d7d18dd6-5c1e-4472-9627-929dcf91b96b`, parent `e5939fb2-0e1f-418c-93a1-619faaf9f6b3`).

Extracts the heavy stages of `Dockerfile.e2e` (Obsidian + xvfb + `npm ci`) into a new `Dockerfile.ci`, published to `ghcr.io/kitelev/exocortex-ci` by a dedicated workflow. `e2e-shard` now `docker pull`s the pre-built base instead of rebuilding it per shard, amortising the ~60s `npm ci` cost across all PRs.

## What changed

| File | Purpose |
|---|---|
| `packages/obsidian-plugin/Dockerfile.ci` (new) | Heavy base: Playwright + xvfb + Obsidian binary + `node_modules` from lock file |
| `packages/obsidian-plugin/Dockerfile.e2e` | Now thin: `ARG BASE_IMAGE` + app layer (plugin artifacts + test fixtures) |
| `.github/workflows/ci-image.yml` (new) | Builds `Dockerfile.ci` + pushes to GHCR on push-to-main when `package-lock.json` or `Dockerfile.ci` changes |
| `.github/workflows/ci.yml` | `e2e-shard` pulls `ghcr.io/kitelev/exocortex-ci:<hash>` → `:latest` → local `Dockerfile.ci` build as fallback |

## Bootstrap

First merge to `main` fires `ci-image.yml` and publishes the initial image. Until then (and on PRs that change `package-lock.json`), `e2e-shard` falls back to a local `Dockerfile.ci` build — same cost as the current baseline, no regression.

## Scope

**Narrowed from original AC per meta decision 2026-04-22.** Only `e2e-shard` touches the pre-built image. Non-e2e jobs (`lint`, `typecheck`, `test-bdd`, `test-coverage-shard`, `test-component`) intentionally keep bare-ubuntu runners — container overhead (~25s init) is a net regression on short jobs per `feedback_playwright_container_unneeded_jsdom_jest`.

## Gate (relaxed)

`≤180s avg on N=5 consecutive post-merge main runs`. Relaxed from the original `≤160s / N=3` given the documented ±50s runner-variance envelope (see `docs/CI_SPEEDUP_PHASE3_EXIT_ANALYSIS.md` §6).

## Expected savings

Pareto §2 of Phase 3 exit analysis: e2e-shard Docker build = 47% of critical path (~81s avg, ~101s worst). With a cache-hit GHCR pull, the Dockerfile.e2e build drops to ~5-10s (thin COPY layer only). Projected critical path: ~236s → ~160-180s avg.

## Test plan

- [ ] CI pipeline green on this PR (baseline measurement; first run will hit GHCR-miss and fall back to local build — acceptable)
- [ ] `ci-image.yml` fires on merge-to-main and publishes `ghcr.io/kitelev/exocortex-ci:<hash>`
- [ ] Next PR after merge: `e2e-shard` pulls the pre-built base (check step log for `Pulled pre-built base … (hash match)` notice)
- [ ] Post-merge N=5 main CI runs: critical path ≤180s avg
- [ ] Coverage delta 0.00pp vs baseline

## Related

- RFC: `/Users/kitelev/Developer/rfc-ci-speedup-2026-04-21.md` §4 Phase 3 (H3 hypothesis, now narrowed to Phase 5 scope)
- Phase 3 exit: `docs/CI_SPEEDUP_PHASE3_EXIT_ANALYSIS.md` §3-5 (Decision B)
- Rollback doc: `docs/ROLLBACK_CI_SPEEDUP.md` (Phase 5 section to be appended post-merge)