### PR TITLE
feat(ci): increase e2e shards 4→6 (D0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
   # Phase 2 CI speedup (task 9346c5be, 2026-04-21):
   # test-coverage was previously a single 190s job running three jest invocations
   # serially (obsidian-plugin full suite + CLI + exocortex regression).
-  # Split into parallel matrix (obsidian-plugin 1/4..4/4) + sibling jobs (CLI,
+  # Split into parallel matrix (obsidian-plugin 1/6..6/6) + sibling jobs (CLI,
   # exocortex-regression), with the branch-protected `test-coverage` name
   # repurposed as the aggregator (mirrors the e2e-shard → e2e-tests pattern).
   # Per-shard coverage-final.json is merged via scripts/merge-coverage.js.
@@ -255,7 +255,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
 
     steps:
       - name: Checkout
@@ -266,7 +266,7 @@ jobs:
       - name: Setup Node & install deps
         uses: ./.github/actions/setup-node-pnpm
 
-      - name: Run obsidian-plugin tests (shard ${{ matrix.shard }}/4)
+      - name: Run obsidian-plugin tests (shard ${{ matrix.shard }}/6)
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
           CI: "true"
@@ -277,7 +277,7 @@ jobs:
           # thresholds on merged coverage.
           node ./node_modules/jest/bin/jest.js \
             --config packages/obsidian-plugin/jest.config.js \
-            --shard=${{ matrix.shard }}/4 \
+            --shard=${{ matrix.shard }}/6 \
             --coverage \
             --coverageReporters=json \
             --coverageReporters=lcov \
@@ -739,7 +739,7 @@ jobs:
     needs: [build, detect-changes]
     # NOTE: no job-level `if:` here — matrix-job skip collapses to a single
     # base `e2e-shard` check-run, dropping the branch-protected parenthesised
-    # `e2e-shard (1..4)` required check names. Instead, the job always starts,
+    # `e2e-shard (1..6)` required check names. Instead, the job always starts,
     # then each step is gated on `env.RUN_E2E`. On docs-only PRs the runner
     # exits in ~15-30s after skipping every heavy step, registering an
     # individual `e2e-shard (N)` check-run with conclusion `success` — which
@@ -749,16 +749,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
 
     steps:
       - name: Announce gating decision
         run: |
           echo "RUN_E2E=${RUN_E2E}"
           if [ "$RUN_E2E" = "true" ]; then
-            echo "::notice::Running e2e shard ${{ matrix.shard }}/4 (code change detected)"
+            echo "::notice::Running e2e shard ${{ matrix.shard }}/6 (code change detected)"
           else
-            echo "::notice::Skipping e2e shard ${{ matrix.shard }}/4 (docs-only PR — detect-changes gate)"
+            echo "::notice::Skipping e2e shard ${{ matrix.shard }}/6 (docs-only PR — detect-changes gate)"
           fi
 
       - name: Checkout
@@ -846,7 +846,7 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.image }}
 
-      - name: Run E2E tests (shard ${{ matrix.shard }}/4)
+      - name: Run E2E tests (shard ${{ matrix.shard }}/6)
         if: env.RUN_E2E == 'true'
         run: |
           mkdir -p test-results-e2e playwright-report-e2e blob-report
@@ -855,7 +855,7 @@ jobs:
             -v $PWD/playwright-report-e2e:/app/playwright-report-e2e \
             -v $PWD/blob-report:/app/packages/obsidian-plugin/blob-report \
             -e CI=true \
-            exocortex-e2e npx playwright test -c packages/obsidian-plugin/playwright-e2e.config.ts --shard=${{ matrix.shard }}/4
+            exocortex-e2e npx playwright test -c packages/obsidian-plugin/playwright-e2e.config.ts --shard=${{ matrix.shard }}/6
 
       - name: Upload blob report for shard ${{ matrix.shard }}
         if: always() && env.RUN_E2E == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -586,7 +586,7 @@ Starter-kit dynamic commands (`exocmd__Command`) are covered in three test layer
 | ----- | ------ | -------- | ----- |
 | **L1 — Unit** | Jest (ts-jest) | `packages/cli/tests/unit/**` | Helpers (`command-catalog`, `extract-target-class`, `predict-mutation`, `fixture-factory`, `user-input-factory`, `execute-command`) + per-command outcome assertions with mocked boundaries. |
 | **L2 — Integration** | Jest + real `GroundingExecutor` | `packages/cli/tests/integration/starter-kit/**` | 41 active starter-kit commands through `CommandResolver` / `PreconditionEvaluator` / `GroundingExecutor` against fixture vaults. Parametrized catalogue + YAML contract invariants. |
-| **L3 — E2E** | Playwright + Docker Obsidian | `packages/obsidian-plugin/tests/e2e/specs/**` | Smoke subset (RFC §7.4.3) exercising the real plugin UI, sharded across `e2e-shard-1..4`. |
+| **L3 — E2E** | Playwright + Docker Obsidian | `packages/obsidian-plugin/tests/e2e/specs/**` | Smoke subset (RFC §7.4.3) exercising the real plugin UI, sharded across `e2e-shard-1..6`. |
 
 **Layer authoring rules:**
 
@@ -596,8 +596,8 @@ Starter-kit dynamic commands (`exocmd__Command`) are covered in three test layer
 
 **Runtime-verify gate:** new E2E specs MUST run green in CI (not only local) before the hosting task flips to Review; skipping this gate caused attribution drift flagged in Phase 2 retrospective.
 
-**Required CI checks (branch-protected, 11 contexts as of Phase 4 cutover 2026-04-22):**
-`archgate`, `detect-changes`, `e2e-shard (1)`, `e2e-shard (2)`, `e2e-shard (3)`, `e2e-shard (4)`, `lint`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`.
+**Required CI checks (branch-protected, 13 contexts post CI Path 2 D0 2026-04-22):**
+`archgate`, `detect-changes`, `e2e-shard (1)`, `e2e-shard (2)`, `e2e-shard (3)`, `e2e-shard (4)`, `e2e-shard (5)`, `e2e-shard (6)`, `lint`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`.
 Matrix contexts use the parenthesised form `<job> (<shard>)` — hyphenated names like `e2e-shard-1` silently resolve to no required check. `test-unit` was dropped from required contexts in f235881d (Phase 4 cutover) now that it is a deduplicated stub; `detect-changes` was added so path-filter infrastructure always runs.
 
 **Rollback playbook:** `docs/ROLLBACK_RFC_CI_TESTS.md` — per-trigger mitigation (flaky quarantine / smoke budget trim / submodule → npm migration / admin nuclear rollback).
@@ -630,7 +630,7 @@ build-and-test:
 
 ```bash
 # Configure branch protection via GitHub API.
-# Current exocortex required set (11 contexts) as of Phase 4 cutover 2026-04-22.
+# Current exocortex required set (13 contexts) post CI Path 2 D0 2026-04-22.
 gh api repos/OWNER/REPO/branches/main/protection/required_status_checks -X PATCH --input - <<EOF
 {
   "strict": true,
@@ -641,6 +641,8 @@ gh api repos/OWNER/REPO/branches/main/protection/required_status_checks -X PATCH
     "e2e-shard (2)",
     "e2e-shard (3)",
     "e2e-shard (4)",
+    "e2e-shard (5)",
+    "e2e-shard (6)",
     "lint",
     "test-bdd",
     "test-component",
@@ -657,7 +659,7 @@ literal space and parens** (e.g. `e2e-shard (1)`). Hyphenated names like
 a live PR via `gh pr view <PR> --json statusCheckRollup` before composing a
 PATCH payload.
 
-**Path-filtered jobs** (`test-component`, `e2e-shard (1..4)`): on docs-only
+**Path-filtered jobs** (`test-component`, `e2e-shard (1..6)`): on docs-only
 PRs the `detect-changes` job emits `code=false`, and downstream jobs either
 skip via job-level `if:` (singletons — reported as skipped=success) or
 short-circuit via `env.RUN_E2E` gates at step level (matrix jobs must NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ infrastructure/  → Obsidian API adapters, file system
 
 - **Tests:** 564 test files, ~11K+ individual test cases (parametrized). Run `npm run test:all` for exact count.
 - **Coverage thresholds**: statements 75.5%, branches 63%, BDD ≥80%
-- **Required CI checks (11, post-Phase 4 2026-04-22)**: archgate · detect-changes · e2e-shard (1..4) · lint · test-bdd · test-component · test-coverage · typecheck. Source of truth: `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`.
+- **Required CI checks (13, post CI Path 2 D0 2026-04-22)**: archgate · detect-changes · e2e-shard (1..6) · lint · test-bdd · test-component · test-coverage · typecheck. Source of truth: `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`.
 - **CI pipeline target**: post-Phase 3 baseline is ~236s avg ±50s (N=3 on main). Gate relaxed to **≤220s** per Decision B (RFC v2 relax, 2026-04-22); original ≤135s target was infeasible given setup-floor dominance. See `docs/ROLLBACK_CI_SPEEDUP.md` for per-phase revert procedure.
 
 ## TypeScript Tooling


### PR DESCRIPTION
## Summary

CI Path 2 D0 (XS): увеличить количество e2e шардов с 4 до 6 для снижения критического пути.

- `ci.yml`: `e2e-shard` и `test-coverage-shard` matrix `[1..4]` → `[1..6]`; `--shard=N/4` → `N/6`
- `AGENTS.md` + `CLAUDE.md`: required CI checks 11 → 13 contexts (добавляются `e2e-shard (5)` + `e2e-shard (6)`)

## Motivation

Post-Phase 5 Phase 2a baseline (см. vault 473184ea, N=2): 176s avg ±32s. Shard 4 исторически самый тяжёлый (144s vs 83s у shard 1) — `--shard=N/4` делит по числу тестов, не по времени. 6-way split снижает тестов/шард на −33%.

**Projected savings:** critical path 144s → 95-110s (overhead ~25s параллелен, не влияет).
**Stoimost:** +2 runner-minute/run (~\$0.004/run on GitHub-hosted).

## Branch-protection coordination

Matrix `(5)` и `(6)` check names появятся в этом PR **before merge**. Workflow:

1. PR opens → CI runs → verify `gh pr view --json statusCheckRollup` shows `e2e-shard (5)` + `(6)` в parenthesised form
2. PATCH `branch-protection/required_status_checks` с augmented context list (11 → 13) **pre-merge**
3. Merge via `gh pr merge --auto --squash`

## Test plan

- [ ] CI green: 6 e2e-shard checks + aggregator `e2e-tests` (aggregator uses `needs.e2e-shard.result` which is job-level singular — works без изменений)
- [ ] Parenthesised form verified via `statusCheckRollup`
- [ ] branch-protection PATCH applied atomically pre-merge
- [ ] N=3 post-merge main CI runs измерены → critical path avg vs 176s baseline