### PR TITLE
feat(ci): D1 weighted shard rebalance (6 configs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,13 @@ jobs:
         run: npm run lint
         continue-on-error: true
 
+      # D1 CI Path 2 (task e0f6e6fd): guard against shard-assignment drift.
+      # Playwright shard configs are hand-maintained lists; this step fails
+      # the lint job if a new *.spec.ts lands without being added to exactly
+      # one shard (or if a shard references a deleted/renamed spec).
+      - name: Validate e2e shard assignments
+        run: node scripts/validate-shard-assignments.mjs
+
   docs-link-check:
     runs-on: ubuntu-latest
     timeout-minutes: 3
@@ -846,6 +853,14 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.image }}
 
+      # D1 CI Path 2 (task e0f6e6fd): per-shard weighted configs replace
+      # Playwright's default `--shard=N/M` split. Each playwright.shard-N.config.ts
+      # extends playwright-e2e.config.ts and sets an explicit testMatch drawn
+      # from packages/obsidian-plugin/playwright-shard-assignments.json — LPT
+      # bin-packed by Phase 2a per-spec median timing (asset 473184ea) so that
+      # max-minus-min shard variance stays ≤15s. The lint job runs
+      # scripts/validate-shard-assignments.mjs to guard against drift when
+      # new *.spec.ts files land.
       - name: Run E2E tests (shard ${{ matrix.shard }}/6)
         if: env.RUN_E2E == 'true'
         run: |
@@ -855,7 +870,7 @@ jobs:
             -v $PWD/playwright-report-e2e:/app/playwright-report-e2e \
             -v $PWD/blob-report:/app/packages/obsidian-plugin/blob-report \
             -e CI=true \
-            exocortex-e2e npx playwright test -c packages/obsidian-plugin/playwright-e2e.config.ts --shard=${{ matrix.shard }}/6
+            exocortex-e2e npx playwright test -c packages/obsidian-plugin/playwright.shard-${{ matrix.shard }}.config.ts
 
       - name: Upload blob report for shard ${{ matrix.shard }}
         if: always() && env.RUN_E2E == 'true'

--- a/packages/obsidian-plugin/Dockerfile.e2e
+++ b/packages/obsidian-plugin/Dockerfile.e2e
@@ -26,6 +26,17 @@ COPY manifest.json ./packages/obsidian-plugin/
 COPY packages/obsidian-plugin/tests/e2e/ ./packages/obsidian-plugin/tests/e2e/
 COPY packages/obsidian-plugin/playwright-e2e.config.ts ./packages/obsidian-plugin/
 COPY packages/obsidian-plugin/playwright-no-flaky-reporter.ts ./packages/obsidian-plugin/
+# D1 CI Path 2 (task e0f6e6fd): per-shard configs + factory + LPT assignments JSON.
+# The CI runner invokes `npx playwright test -c packages/obsidian-plugin/playwright.shard-N.config.ts`,
+# so each of these files must exist inside the image (matching the /app/packages/obsidian-plugin path).
+COPY packages/obsidian-plugin/playwright-shard-config-factory.ts ./packages/obsidian-plugin/
+COPY packages/obsidian-plugin/playwright-shard-assignments.json ./packages/obsidian-plugin/
+COPY packages/obsidian-plugin/playwright.shard-1.config.ts ./packages/obsidian-plugin/
+COPY packages/obsidian-plugin/playwright.shard-2.config.ts ./packages/obsidian-plugin/
+COPY packages/obsidian-plugin/playwright.shard-3.config.ts ./packages/obsidian-plugin/
+COPY packages/obsidian-plugin/playwright.shard-4.config.ts ./packages/obsidian-plugin/
+COPY packages/obsidian-plugin/playwright.shard-5.config.ts ./packages/obsidian-plugin/
+COPY packages/obsidian-plugin/playwright.shard-6.config.ts ./packages/obsidian-plugin/
 
 # Create test vault and install pre-built plugin
 RUN mkdir -p packages/obsidian-plugin/tests/e2e/test-vault/.obsidian/plugins/exocortex \

--- a/packages/obsidian-plugin/playwright-shard-assignments.json
+++ b/packages/obsidian-plugin/playwright-shard-assignments.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "D1 weighted shard assignment (CI Path 2, task e0f6e6fd). LPT bin-pack by per-spec median ms from Phase 2a baseline (473184ea, N=2). Spec filenames relative to testDir packages/obsidian-plugin/tests/e2e/specs. Validator scripts/validate-shard-assignments.mjs. When adding a new spec, extend exactly one shard array.",
+  "_generated_from": {
+    "phase_2a_baseline": "473184ea-c0da-49dd-bfe4-4c1d63421001",
+    "method": "greedy LPT (longest processing time) bin-packing, ties broken by current shard load ascending"
+  },
+  "shards": [
+    ["dynamic-commands.spec.ts"],
+    ["effort-timestamps-auto-sync.spec.ts", "daily-archive-filter.spec.ts"],
+    [
+      "dynamic-command-buttons-render.spec.ts",
+      "alias-sync-on-label-change.spec.ts"
+    ],
+    [
+      "starter-kit-smoke.spec.ts",
+      "layout-overflow-styling.spec.ts",
+      "brat-installation-compatibility.spec.ts"
+    ],
+    [
+      "area-tree-collapsible.spec.ts",
+      "vault-commands-smoke.spec.ts",
+      "table-virtualization-large-datasets.spec.ts"
+    ],
+    [
+      "daily-navigation.spec.ts",
+      "table-column-alignment.spec.ts",
+      "daily-note-tasks.spec.ts"
+    ]
+  ],
+  "_projected_weights_ms": {
+    "shard_1": 10432,
+    "shard_2": 6922,
+    "shard_3": 6894,
+    "shard_4": 5397,
+    "shard_5": 6341,
+    "shard_6": 6113,
+    "max_minus_min_ms": 5035
+  }
+}

--- a/packages/obsidian-plugin/playwright-shard-config-factory.ts
+++ b/packages/obsidian-plugin/playwright-shard-config-factory.ts
@@ -1,0 +1,21 @@
+import { defineConfig, type PlaywrightTestConfig } from "@playwright/test";
+import baseConfig from "./playwright-e2e.config";
+import shardData from "./playwright-shard-assignments.json";
+
+export function buildShardConfig(shardIndex: number): PlaywrightTestConfig {
+  const specs = shardData.shards[shardIndex - 1];
+  if (!specs || !Array.isArray(specs) || specs.length === 0) {
+    throw new Error(
+      `Invalid shard index ${shardIndex}: expected 1..${shardData.shards.length}`,
+    );
+  }
+  return defineConfig({
+    ...baseConfig,
+    projects: [
+      {
+        name: `e2e-shard-${shardIndex}`,
+        testMatch: specs,
+      },
+    ],
+  });
+}

--- a/packages/obsidian-plugin/playwright.shard-1.config.ts
+++ b/packages/obsidian-plugin/playwright.shard-1.config.ts
@@ -1,0 +1,3 @@
+import { buildShardConfig } from "./playwright-shard-config-factory";
+
+export default buildShardConfig(1);

--- a/packages/obsidian-plugin/playwright.shard-2.config.ts
+++ b/packages/obsidian-plugin/playwright.shard-2.config.ts
@@ -1,0 +1,3 @@
+import { buildShardConfig } from "./playwright-shard-config-factory";
+
+export default buildShardConfig(2);

--- a/packages/obsidian-plugin/playwright.shard-3.config.ts
+++ b/packages/obsidian-plugin/playwright.shard-3.config.ts
@@ -1,0 +1,3 @@
+import { buildShardConfig } from "./playwright-shard-config-factory";
+
+export default buildShardConfig(3);

--- a/packages/obsidian-plugin/playwright.shard-4.config.ts
+++ b/packages/obsidian-plugin/playwright.shard-4.config.ts
@@ -1,0 +1,3 @@
+import { buildShardConfig } from "./playwright-shard-config-factory";
+
+export default buildShardConfig(4);

--- a/packages/obsidian-plugin/playwright.shard-5.config.ts
+++ b/packages/obsidian-plugin/playwright.shard-5.config.ts
@@ -1,0 +1,3 @@
+import { buildShardConfig } from "./playwright-shard-config-factory";
+
+export default buildShardConfig(5);

--- a/packages/obsidian-plugin/playwright.shard-6.config.ts
+++ b/packages/obsidian-plugin/playwright.shard-6.config.ts
@@ -1,0 +1,3 @@
+import { buildShardConfig } from "./playwright-shard-config-factory";
+
+export default buildShardConfig(6);

--- a/scripts/validate-shard-assignments.mjs
+++ b/scripts/validate-shard-assignments.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// D1 shard drift guard (CI Path 2, task e0f6e6fd).
+// Asserts that the 6 playwright.shard-N.config.ts files, via
+// playwright-shard-assignments.json, cover every *.spec.ts on disk
+// exactly once — no missing, no extra, no duplicates. Exits 1 on drift.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const PLUGIN_DIR = path.join(repoRoot, "packages", "obsidian-plugin");
+const ASSIGNMENTS_PATH = path.join(PLUGIN_DIR, "playwright-shard-assignments.json");
+const SPECS_DIR = path.join(PLUGIN_DIR, "tests", "e2e", "specs");
+const SHARD_COUNT = 6;
+
+function fail(msg) {
+  console.error(`[shard-drift] ❌ ${msg}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(ASSIGNMENTS_PATH)) {
+  fail(`Missing assignments file: ${ASSIGNMENTS_PATH}`);
+}
+if (!fs.existsSync(SPECS_DIR)) {
+  fail(`Missing specs dir: ${SPECS_DIR}`);
+}
+
+const data = JSON.parse(fs.readFileSync(ASSIGNMENTS_PATH, "utf8"));
+if (!data || !Array.isArray(data.shards)) {
+  fail(`${ASSIGNMENTS_PATH} must export { shards: string[][] }`);
+}
+const shards = data.shards;
+if (shards.length !== SHARD_COUNT) {
+  fail(`Expected ${SHARD_COUNT} shards, got ${shards.length}`);
+}
+for (let i = 0; i < SHARD_COUNT; i++) {
+  const cfg = path.join(PLUGIN_DIR, `playwright.shard-${i + 1}.config.ts`);
+  if (!fs.existsSync(cfg)) {
+    fail(`Missing shard config: ${cfg}`);
+  }
+  if (!Array.isArray(shards[i])) {
+    fail(`shards[${i}] is not an array`);
+  }
+  if (shards[i].length === 0) {
+    fail(`shards[${i}] is empty — each shard must have ≥1 spec`);
+  }
+}
+
+const assignments = shards.flat();
+const assignmentsSet = new Set(assignments);
+if (assignmentsSet.size !== assignments.length) {
+  const counts = new Map();
+  for (const a of assignments) counts.set(a, (counts.get(a) ?? 0) + 1);
+  const dupes = [...counts].filter(([, c]) => c > 1).map(([f]) => f);
+  fail(`Duplicate spec assignments across shards: ${dupes.join(", ")}`);
+}
+
+const filesOnDisk = fs
+  .readdirSync(SPECS_DIR)
+  .filter((f) => f.endsWith(".spec.ts"))
+  .sort();
+const onDiskSet = new Set(filesOnDisk);
+
+const missing = filesOnDisk.filter((f) => !assignmentsSet.has(f));
+if (missing.length > 0) {
+  fail(
+    `Spec files on disk NOT assigned to any shard (add to playwright-shard-assignments.json):\n  ${missing.join("\n  ")}`,
+  );
+}
+
+const extra = assignments.filter((a) => !onDiskSet.has(a));
+if (extra.length > 0) {
+  fail(
+    `Shard assignments reference files that don't exist on disk:\n  ${extra.join("\n  ")}`,
+  );
+}
+
+console.log(
+  `[shard-drift] ✅ ${filesOnDisk.length} *.spec.ts files balanced across ${SHARD_COUNT} shards, no drift.`,
+);
+for (let i = 0; i < shards.length; i++) {
+  console.log(`  shard ${i + 1} (${shards[i].length}): ${shards[i].join(", ")}`);
+}


### PR DESCRIPTION
## Summary

- Replace Playwright default `--shard=N/M` (which splits test cases by alphabetical hash, ignoring execution time) with 6 explicit per-shard configs that partition `*.spec.ts` files via LPT bin-packing on Phase 2a per-spec median timing.
- Add `scripts/validate-shard-assignments.mjs` + lint step — CI fails if a new `*.spec.ts` lands without shard assignment, or if a shard references a missing/duplicated spec.
- No branch-protection change required: matrix `[1..6]` and the six parenthesised check names `e2e-shard (1..6)` stay the same.

## Why

Post-D0 (PR #2921, SHA `54aae8af`) observed wall-clock shard distribution was `80/91/91/91/92/113s` — 33s spread driven by Playwright splitting test cases by name-hash while ignoring spec weight. Phase 2a baseline (asset `473184ea`, N=2) shows `shard 3 (default)` carried 23.2s of test time (dynamic-commands + both render specs + effort-timestamps-auto-sync) while `shard 2 (default)` carried 3.5s.

## Weighted LPT distribution (spec-weight level)

| Shard | Specs | Weight (ms) |
|-------|-------|-------------|
| 1 | dynamic-commands | 10432 |
| 2 | effort-timestamps-auto-sync, daily-archive-filter | 6922 |
| 3 | dynamic-command-buttons-render, alias-sync-on-label-change | 6894 |
| 4 | starter-kit-smoke, layout-overflow-styling, brat-installation-compatibility | 5397 |
| 5 | area-tree-collapsible, vault-commands-smoke, table-virtualization-large-datasets | 6341 |
| 6 | daily-navigation, table-column-alignment, daily-note-tasks | 6113 |

**max − min = 5.0s** (test time only, excluding constant setup floor).

## Caveat — variance gate & D2 dependency

Task acceptance requires shard variance ≤15s on N=3 post-merge. Phase 2a baseline explicitly documents `starter-kit-smoke.spec.ts` as a **recurring attempt-1 flake** adding ~20s retry overhead per run — this sits on shard 4 under D1 (and would sit elsewhere wherever we placed it — redistribution does not eliminate per-run retry cost). Until **D2** (task eb… retries:0 + flakiness fixes) lands, wall-clock variance for shard 4 will include that ~20s overhead and may exceed the ≤15s gate in isolation. D1 validates the weighted-LPT **distribution** at the spec-weight level (5.0s spread); D2 is the phase that drives wall-clock variance inside ≤15s deterministically.

## Design notes

- **Variant A** (explicit `testMatch` per-shard config) — **not** Variant B (`--grep`), which breaks Playwright's blob-report sharding infrastructure. Matches RFC §D1 recommendation.
- 6 thin configs (`playwright.shard-{1..6}.config.ts`, 3 lines each) delegate to `playwright-shard-config-factory.ts` which reads the single source of truth `playwright-shard-assignments.json`.
- `test-coverage-shard` job is **unchanged** — it uses `jest --shard=N/6`, which is jest's own sharding (not Playwright) and continues to split the unit test pool evenly by count.
- When adding a new `*.spec.ts`, append its filename to exactly one shard in `playwright-shard-assignments.json`; the lint job blocks drift.

## Test plan

- [x] `node scripts/validate-shard-assignments.mjs` passes locally — 14 specs across 6 shards, no drift.
- [x] `npx playwright test -c packages/obsidian-plugin/playwright.shard-N.config.ts --list` resolves the expected spec set for N ∈ {1..6} (5+3+3+19+18+15 = 63 tests across 14 files).
- [x] `npm run check:types` clean.
- [x] `npm run lint` / `npm run bdd:check` / archgate all green (pre-commit hook).
- [ ] All 11 required CI checks green on PR.
- [ ] Post-merge N=3 shard variance measurement documented (expected ≤15s post-D2; boundary-risk pre-D2).

Ref: task `e0f6e6fd-f822-462a-9bed-f74a6dc7f332` (CI Path 2 project `45990c97-c06f-48e6-bfe5-73ae852cd23c`), RFC `27652db8`, baseline `473184ea`.