### PR TITLE
docs: fix outdated developer API examples

### DIFF
--- a/docs/Plugin-Development-Guide.md
+++ b/docs/Plugin-Development-Guide.md
@@ -88,20 +88,29 @@ export function canExecuteMyCustomCommand(metadata: Record<string, any>): boolea
 
 ### 1. Create Renderer Class
 
+Renderers are standalone classes that accept dependencies via constructor and expose
+a `render` method. There is no `BaseRenderer` base class to extend.
+
 `src/presentation/renderers/layout/MyCustomRenderer.ts`:
 
 ```typescript
-import { BaseRenderer } from './BaseRenderer';
+import { App } from 'obsidian';
+import { IVaultAdapter } from 'exocortex';
 
-export class MyCustomRenderer extends BaseRenderer {
+export class MyCustomRenderer {
+  constructor(
+    private app: App,
+    private vault: IVaultAdapter,
+  ) {}
+
   async render(
     container: HTMLElement,
-    metadata: Record<string, any>
+    metadata: Record<string, unknown>
   ): Promise<void> {
     const section = container.createDiv({ cls: 'my-custom-section' });
     section.createEl('h3', { text: 'My Custom Section' });
 
-    // Render logic
+    // Render logic using this.app, this.vault, metadata
   }
 }
 ```
@@ -111,8 +120,8 @@ export class MyCustomRenderer extends BaseRenderer {
 `src/presentation/renderers/layout/UniversalLayoutRenderer.ts`:
 
 ```typescript
-private renderCustomSection(container: HTMLElement): void {
-  const renderer = new MyCustomRenderer(this.app, this.plugin);
+private async renderCustomSection(container: HTMLElement): Promise<void> {
+  const renderer = new MyCustomRenderer(this.app, this.vault);
   await renderer.render(container, this.metadata);
 }
 ```

--- a/docs/api/Core-API.md
+++ b/docs/api/Core-API.md
@@ -10,7 +10,7 @@ The `exocortex` package provides storage-independent business logic:
 
 ```typescript
 import {
-  TaskCreationService,
+  GenericAssetCreationService,
   EffortStatusWorkflow,
   RDFSerializer
 } from 'exocortex';
@@ -25,47 +25,52 @@ import {
 
 ## Services
 
-### Task Creation Service
+### Generic Asset Creation Service
 
 ```typescript
-import { TaskCreationService } from 'exocortex';
+import { GenericAssetCreationService } from 'exocortex';
 
-class TaskCreationService {
-  createTask(params: {
-    label: string;
-    area: string;
-    project?: string;
-    status?: string;
-  }): Promise<{ path: string; frontmatter: Record<string, any> }>;
+class GenericAssetCreationService {
+  constructor(vault: IVaultAdapter) {}
+
+  createAsset(
+    config: {
+      className: string;
+      label?: string;
+      folderPath?: string;
+      propertyValues?: Record<string, unknown>;
+      parentFile?: IFile;
+      parentMetadata?: Record<string, unknown>;
+    },
+    propertyDefinitions?: AssetPropertyDefinition[]
+  ): Promise<IFile>;
 }
 ```
 
-**Example**:
+**Example — creating a task**:
 ```typescript
-const service = new TaskCreationService(vaultAdapter);
+const service = container.resolve(GenericAssetCreationService);
 
-const task = await service.createTask({
+const file = await service.createAsset({
+  className: "ems__Task",
   label: "Build API endpoint",
-  area: "[[Development]]",
-  project: "[[API Server]]",
-  status: "[[ems__EffortStatusToDo]]"
+  propertyValues: {
+    ems__Effort_status: "[[ems__EffortStatusToDo]]"
+  }
 });
 
-// Result: { path: "tasks/task-abc123.md", frontmatter: {...} }
+// Result: IFile { path: "tasks/<uuid>.md", basename: "<uuid>", ... }
 ```
 
-### Project Creation Service
-
+**Example — creating a project**:
 ```typescript
-import { ProjectCreationService } from 'exocortex';
-
-class ProjectCreationService {
-  createProject(params: {
-    label: string;
-    area: string;
-    status?: string;
-  }): Promise<{ path: string; frontmatter: Record<string, any> }>;
-}
+const file = await service.createAsset({
+  className: "ems__Project",
+  label: "API Server",
+  propertyValues: {
+    ems__Effort_status: "[[ems__EffortStatusBacklog]]"
+  }
+});
 ```
 
 ### Effort Status Workflow


### PR DESCRIPTION
Closes #2928
Closes #2929

- docs/api/Core-API.md: replace removed TaskCreationService/ProjectCreationService with GenericAssetCreationService
- docs/Plugin-Development-Guide.md: remove non-existent BaseRenderer, replace with standalone renderer pattern