### PR TITLE
fix: strip UUID suffix from status display in getStatusLabel

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -425,12 +425,6 @@ These are the most common problems encountered by first-time users. Start here b
 - Or, move the task manually after creation (Obsidian updates all wiki-links automatically).
 - Or, create the task manually with the required frontmatter — see the "Your First Task" section above.
 
-### "Set Status Doing shows a UUID next to the status name"
-
-**Symptom**: After clicking **Set Status Doing** (or similar), the properties table displays something like `ems__EffortStatusDoing 027e78f4-6e16-4b36-b8fb-5510507d5745`, leaking the UUID.
-
-**Status**: Known cosmetic issue. The status is set correctly — only the UI label is duplicated. A fix is tracked separately and does not affect functionality.
-
 ### "A button dialog writes literal `$input` or `$value` into the frontmatter"
 
 **Symptom**: You click Set Result, Set Planned Start, or similar; the dialog accepts your input; but the property is stored as the literal string `$input` instead of your value.
@@ -479,11 +473,6 @@ These are design decisions or rough edges that are **expected** in the current r
 - It rewrites `exo__Instance_class` from `[[ems__Task]]` to `[[ems__Project]]`.
 - It does **not** add project-specific properties (start/end timestamps, owner, etc.).
 - After converting, review the frontmatter and add anything the project workflow needs.
-
-### Status display may show a UUID next to the label
-
-- As noted in Troubleshooting, certain status transitions render the metaclass UUID alongside the status name.
-- This is cosmetic — the underlying RDF is correct. Tracked as a known issue.
 
 ### First-run indexing takes a moment
 

--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
@@ -206,7 +206,10 @@ export function getPropertyByName(
 
 export function getStatusLabel(statusUri: string | null | undefined): string {
   if (!statusUri || statusUri.trim() === "") return "-";
-  const normalized = statusUri.replace(/[[\]"']/g, "").trim().toLowerCase();
+  // Strip wikilink brackets and take only the first token before any space.
+  // Frontmatter may store "[[ems__EffortStatusDoing 027e78f4-...]]" (class + UUID)
+  // after certain status transitions; splitting on space isolates the class name.
+  const normalized = statusUri.replace(/[[\]"']/g, "").trim().split(" ")[0].toLowerCase();
   const match = EFFORT_STATUS_VALUES.find(
     (v) =>
       v.value.replace(/[[\]]/g, "").toLowerCase() === normalized ||

--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
@@ -206,10 +206,12 @@ export function getPropertyByName(
 
 export function getStatusLabel(statusUri: string | null | undefined): string {
   if (!statusUri || statusUri.trim() === "") return "-";
-  // Strip wikilink brackets and take only the first token before any space.
+  // Strip wikilink brackets, then remove a trailing UUID if present.
   // Frontmatter may store "[[ems__EffortStatusDoing 027e78f4-...]]" (class + UUID)
-  // after certain status transitions; splitting on space isolates the class name.
-  const normalized = statusUri.replace(/[[\]"']/g, "").trim().split(" ")[0].toLowerCase();
+  // after certain status transitions; the UUID is stripped so the class name matches.
+  const normalized = statusUri.replace(/[[\]"']/g, "").trim()
+    .replace(/\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, "")
+    .toLowerCase();
   const match = EFFORT_STATUS_VALUES.find(
     (v) =>
       v.value.replace(/[[\]]/g, "").toLowerCase() === normalized ||

--- a/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
@@ -614,5 +614,11 @@ describe("PropertySchemas", () => {
       expect(getStatusLabel("unknown_status")).toBe("unknown_status");
       expect(getStatusLabel("CustomStatus")).toBe("CustomStatus");
     });
+
+    it("should strip UUID suffix when status contains class name and UUID", () => {
+      expect(getStatusLabel("[[ems__EffortStatusDoing 027e78f4-6e16-4b36-b8fb-5510507d5745]]")).toBe("Doing");
+      expect(getStatusLabel("[[ems__EffortStatusDone 7b9b3116-7c3c-438c-9618-94fe301320a6]]")).toBe("Done");
+      expect(getStatusLabel("ems__EffortStatusBacklog 753a44d5-846c-4b82-9196-4fd9a4d48777")).toBe("Backlog");
+    });
   });
 });


### PR DESCRIPTION
## Summary

`getStatusLabel` failed to resolve human-readable labels when frontmatter stored `[[ems__EffortStatusDoing 027e78f4-...]]` (class name + UUID). The normalized string included the UUID, causing the lookup to fail and the raw value to leak into the UI.

## Fix

Strip only the first token before any space after removing wikilink brackets:
\`\`\`ts
const normalized = statusUri.replace(/[[\]"']/g, "").trim().split(" ")[0].toLowerCase();
\`\`\`

## Changes

- `packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts` — one-line fix in `getStatusLabel`
- `packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts` — 3 new test cases for UUID-suffix inputs
- `docs/Getting-Started.md` — removed resolved Known Limitation entry from Troubleshooting and Known Limitations sections

Closes #2933