### PR TITLE
fix(docs): rewrap ADR-0011 prose to unblock Auto Release

### DIFF
--- a/docs/adr/0011-relation-column-set-repository.md
+++ b/docs/adr/0011-relation-column-set-repository.md
@@ -8,7 +8,7 @@ Accepted
 
 RFC be70f741-a8e3-4826-aab1-d3f950068861 ("RDF-configurable columns for UniversalLayout backlinks table", v2) introduces `ui__RelationColumnSet` — the first Exocortex ontology class whose instances are **automatically discovered and bound** to a runtime component without a vault-authored layout file pointing at them.
 
-Prior examples (`exo__TableLayout`, `exo__Layout`) are always referenced explicitly — either via codeblock `source` attribute or via `exo__Class_layout` on the class asset. `RelationColumnSetRepository` is different: it scans every file in the vault, matches by `exo__Instance_class`, indexes by `(normalizedClass, normalizedProperty)`, and later (Phase 2 resolver + Phase 3 renderer integration) answers "which columns should the auto-backlinks table render for rows of class X referenced via property Y?"
+Prior examples (`exo__TableLayout`, `exo__Layout`) are always referenced explicitly — either via codeblock `source` attribute or via a class-level layout property on the class asset. `RelationColumnSetRepository` is different: it scans every file in the vault, matches by `exo__Instance_class`, indexes by `(normalizedClass, normalizedProperty)`, and later (Phase 2 resolver + Phase 3 renderer integration) answers "which columns should the auto-backlinks table render for rows of class X referenced via property Y?"
 
 ### Problem
 


### PR DESCRIPTION
## Summary

- **Hotfix for PR #2935** (RFC be70f741 Phase 1). The merged PR introduced `docs/adr/0011-relation-column-set-repository.md` with a prose mention of \`exo__Class_layout\` (used only as an illustrative class-level layout property). The `docs-property-validation` CI job treats any identifier matching \`(exo|ems|…)__\w+_\w+\` as a property-name claim and fails because no source file emits it.
- Post-merge main CI failed on this single job, which in turn **skipped Auto Release** → no version was published for PR #2935.
- This PR rewraps the prose to refer to "a class-level layout property" in free English, removing the regex match. No semantic change to the ADR.

## Test plan

- [x] `node scripts/validate-docs-properties.js` runs locally — **0 missing** (was: 1 missing).
- [x] Pre-commit archgate + BDD pass.
- [ ] CI green.
- [ ] Auto Release succeeds → new version published.

## Related

- Unblocks: #2935 — "feat(layout): RelationColumnSetRepository + domain model (RFC be70f741 Phase 1)"
- Task: 6533ca08-5e9a-435d-9d3a-be69b872eba9
- Project: 489e297d-069f-4144-a538-dce81da18d0f

🤖 Generated with Claude Code