### PR TITLE
feat: Phase 2 RelationColumnSetResolver + priority ladder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,14 +411,18 @@ jobs:
       - name: Setup Node & install deps
         uses: ./.github/actions/setup-node-pnpm
 
-      - name: Run exocortex grounding regression tests
+      - name: Run exocortex grounding + RFC regression tests
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
           CI: "true"
+        # Allow-list pattern kept in sync with scripts/test-ci-batched.sh.
+        # Additions:
+        # - RFC be70f741 Phase 2: application/services/RelationColumnSetResolver(.property)?.test.ts
+        #   + performance/RelationColumnSetResolverPerformance.test.ts (p95 <1ms gate).
         run: |
           node ./node_modules/jest/bin/jest.js \
             --config packages/exocortex/jest.config.js \
-            --testPathPatterns='services/(GroundingExecutor|AssetConversionService)\.test\.ts' \
+            --testPathPatterns='(services/(GroundingExecutor|AssetConversionService)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test)\.ts' \
             --forceExit
 
   test-coverage:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8688,6 +8688,46 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -17234,6 +17274,7 @@
         "@types/sparqljs": "^3.1.12",
         "@types/uuid": "^10.0.0",
         "eslint": "^9.38.0",
+        "fast-check": "^3.23.2",
         "jest": "^30.0.0",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3"

--- a/packages/exocortex/package.json
+++ b/packages/exocortex/package.json
@@ -50,6 +50,7 @@
     "@types/sparqljs": "^3.1.12",
     "@types/uuid": "^10.0.0",
     "eslint": "^9.38.0",
+    "fast-check": "^3.23.2",
     "jest": "^30.0.0",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3"

--- a/packages/exocortex/src/application/services/RelationColumnSetResolver.ts
+++ b/packages/exocortex/src/application/services/RelationColumnSetResolver.ts
@@ -1,0 +1,187 @@
+/**
+ * RelationColumnSetResolver — 4-tier priority ladder for `ui__RelationColumnSet`.
+ *
+ * Phase 2 of RFC be70f741-a8e3-4826-aab1-d3f950068861.
+ *
+ * Inputs
+ * - Row classes in the order declared on the row asset (`exo__Instance_class`
+ *   is always an array — see `AssetRelationsTable.tsx` `getInstanceClasses`).
+ * - Referencing property (raw or wikilink form) — the backlinks group key.
+ *
+ * Algorithm (per RFC §"Priority ladder")
+ * - Iterate `rowClasses` in declaration order.  For each class, evaluate the
+ *   tiers top-down; first tier with ≥1 match wins for that class, and the
+ *   overall resolve returns it — we never look at subsequent classes once a
+ *   prior class has a match.
+ *   - Tier 1: exact — `targetClasses.includes(cls) && referencingProperty === prop`.
+ *   - Tier 2: class-only — `targetClasses.includes(cls) && config.referencingProperty === null`.
+ *   - Tier 3: property-only — `config.targetClasses === null && referencingProperty === prop`.
+ *   - Tier 4: null — caller falls back to legacy hardcoded map.
+ * - Tie-breaker within a tier (RFC v2 architect M3 fix):
+ *   `priority DESC → exo__Asset_uid ASC (localeCompare)`.
+ * - `log.warn` fires once per resolve when ≥2 matches share the winning tier
+ *   AND priority — the debugging aid cited in RFC v2 R2 mitigation.
+ *
+ * Determinism
+ * - Given a stable snapshot (`getAll()` returns the same array contents) and
+ *   stable inputs, `resolve` returns the same asset; property-based test in
+ *   `tests/application/services/RelationColumnSetResolver.property.test.ts`
+ *   asserts this invariant over N=500 fast-check runs.
+ *
+ * Performance
+ * - `resolve()` p95 < 1 ms on 100 configs per RFC M4 benchmark.  See
+ *   `tests/performance/RelationColumnSetResolverPerformance.test.ts`.
+ *
+ * @module application/services
+ * @since 15.x (RFC be70f741 Phase 2)
+ */
+
+import { normalizeRef, type RelationColumnSet } from "../../domain/layout/RelationColumnSet";
+
+export interface RelationColumnSetResolverLogger {
+  warn(message: string): void;
+}
+
+const NOOP_LOGGER: RelationColumnSetResolverLogger = {
+  warn: () => {},
+};
+
+export interface RelationColumnSetResolverOptions {
+  readonly logger?: RelationColumnSetResolverLogger;
+}
+
+export type RelationColumnSetProvider = () => readonly RelationColumnSet[];
+
+export class RelationColumnSetResolver {
+  private readonly provider: RelationColumnSetProvider;
+  private readonly logger: RelationColumnSetResolverLogger;
+
+  constructor(
+    provider: RelationColumnSetProvider,
+    options: RelationColumnSetResolverOptions = {},
+  ) {
+    this.provider = provider;
+    this.logger = options.logger ?? NOOP_LOGGER;
+  }
+
+  /**
+   * Resolve the column set for a row-asset + referencing-property pair.
+   *
+   * @param rowClasses  `exo__Instance_class` of the row asset.  Array order is
+   *                    honored — first class with a match wins.
+   * @param referencingProperty  Backlinks group key.  May be `null`/empty; in
+   *                             that case only Tier 2 (class-only) can match.
+   * @returns The winning config, or `null` if no tier matches for any class.
+   */
+  resolve(
+    rowClasses: readonly string[] | null | undefined,
+    referencingProperty: string | null | undefined,
+  ): RelationColumnSet | null {
+    if (!rowClasses || rowClasses.length === 0) {
+      return null;
+    }
+
+    const prop =
+      referencingProperty != null ? normalizeRef(referencingProperty) : null;
+    const all = this.provider();
+    if (all.length === 0) {
+      return null;
+    }
+
+    for (const rawCls of rowClasses) {
+      const cls = normalizeRef(rawCls);
+      if (cls === null) {
+        continue;
+      }
+
+      if (prop !== null) {
+        const tier1 = this.filterTier1(all, cls, prop);
+        if (tier1.length > 0) {
+          return this.tiebreak(tier1, 1);
+        }
+      }
+
+      const tier2 = this.filterTier2(all, cls);
+      if (tier2.length > 0) {
+        return this.tiebreak(tier2, 2);
+      }
+
+      if (prop !== null) {
+        const tier3 = this.filterTier3(all, prop);
+        if (tier3.length > 0) {
+          return this.tiebreak(tier3, 3);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private filterTier1(
+    all: readonly RelationColumnSet[],
+    cls: string,
+    prop: string,
+  ): RelationColumnSet[] {
+    const out: RelationColumnSet[] = [];
+    for (const cs of all) {
+      if (cs.targetClasses === null) continue;
+      if (cs.referencingProperty !== prop) continue;
+      if (!cs.targetClasses.includes(cls)) continue;
+      out.push(cs);
+    }
+    return out;
+  }
+
+  private filterTier2(
+    all: readonly RelationColumnSet[],
+    cls: string,
+  ): RelationColumnSet[] {
+    const out: RelationColumnSet[] = [];
+    for (const cs of all) {
+      if (cs.targetClasses === null) continue;
+      if (cs.referencingProperty !== null) continue;
+      if (!cs.targetClasses.includes(cls)) continue;
+      out.push(cs);
+    }
+    return out;
+  }
+
+  private filterTier3(
+    all: readonly RelationColumnSet[],
+    prop: string,
+  ): RelationColumnSet[] {
+    const out: RelationColumnSet[] = [];
+    for (const cs of all) {
+      if (cs.targetClasses !== null) continue;
+      if (cs.referencingProperty !== prop) continue;
+      out.push(cs);
+    }
+    return out;
+  }
+
+  private tiebreak(
+    matches: RelationColumnSet[],
+    tier: 1 | 2 | 3,
+  ): RelationColumnSet {
+    const sorted = matches.slice().sort((a, b) => {
+      const priorityDelta = b.priority - a.priority;
+      if (priorityDelta !== 0) return priorityDelta;
+      return a.uid.localeCompare(b.uid);
+    });
+    const winner = sorted[0];
+    if (sorted.length > 1) {
+      const winningPriority = winner.priority;
+      const tied = sorted.filter((cs) => cs.priority === winningPriority);
+      if (tied.length > 1) {
+        const losers = tied
+          .slice(1)
+          .map((cs) => cs.uid)
+          .join(", ");
+        this.logger.warn(
+          `RelationColumnSetResolver: tier=${tier} priority=${winningPriority} collision — selected ${winner.uid}; tied losers: ${losers}`,
+        );
+      }
+    }
+    return winner;
+  }
+}

--- a/packages/exocortex/src/application/services/index.ts
+++ b/packages/exocortex/src/application/services/index.ts
@@ -1,0 +1,6 @@
+export {
+  RelationColumnSetResolver,
+  type RelationColumnSetProvider,
+  type RelationColumnSetResolverLogger,
+  type RelationColumnSetResolverOptions,
+} from "./RelationColumnSetResolver";

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -438,6 +438,14 @@ export {
   type RelationColumnSet,
 } from "./domain/layout";
 
+// RelationColumnSetResolver (RFC be70f741 Phase 2)
+export {
+  RelationColumnSetResolver,
+  type RelationColumnSetProvider,
+  type RelationColumnSetResolverLogger,
+  type RelationColumnSetResolverOptions,
+} from "./application/services";
+
 // Error exports
 export * from "./domain/errors";
 export * from "./application/errors";

--- a/packages/exocortex/tests/application/services/RelationColumnSetResolver.property.test.ts
+++ b/packages/exocortex/tests/application/services/RelationColumnSetResolver.property.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Property-based determinism invariant for RelationColumnSetResolver.
+ *
+ * RFC be70f741 Phase 2 §"Unit-тесты (обязательные)" demands N≥500 runs of the
+ * determinism invariant: `resolve(a, b)` yields the same answer given the same
+ * snapshot and inputs, regardless of snapshot ORDER.  Ordering of configs
+ * inside the snapshot MUST NOT change the resolver verdict — the tiebreaker
+ * (`priority DESC → uid ASC`) fully orders matches.
+ *
+ * Seeds are explicit so failures reproduce locally with the same counterexample
+ * shrinks the CI run produced.
+ */
+
+import * as fc from "fast-check";
+import { RelationColumnSetResolver } from "../../../src/application/services/RelationColumnSetResolver";
+import type { RelationColumnSet } from "../../../src/domain/layout/RelationColumnSet";
+
+const NUM_RUNS = 500;
+const SEED = 0xc0ffee;
+
+const classPool = ["C1", "C2", "C3", "C4", "C5"];
+const propertyPool = ["P1", "P2", "P3", "P4", "P5"];
+
+const classArrayArb = fc
+  .subarray(classPool, { minLength: 1, maxLength: 3 })
+  .map((arr) => [...arr]); // fast-check `subarray` returns readonly — clone to plain array
+
+const configArb = fc
+  .record({
+    uid: fc.uuid(),
+    label: fc.string({ minLength: 1, maxLength: 10 }),
+    targetClasses: fc.option(classArrayArb, { nil: null }),
+    referencingProperty: fc.option(fc.constantFrom(...propertyPool), {
+      nil: null,
+    }),
+    columns: fc
+      .array(fc.constantFrom("exo__Asset_label", "exo__Asset_createdAt"), {
+        minLength: 1,
+        maxLength: 3,
+      })
+      .map((arr) => [...arr]),
+    priority: fc.integer({ min: 0, max: 10 }),
+    sourcePath: fc.string({ minLength: 1, maxLength: 20 }).map((s) => `${s}.md`),
+  })
+  .filter(
+    // RFC v2 asset-level validation: at least one of (targetClass, referencingProperty).
+    (cs) => cs.targetClasses !== null || cs.referencingProperty !== null,
+  )
+  .map(
+    (cs): RelationColumnSet => ({
+      uid: cs.uid,
+      label: cs.label,
+      targetClasses: cs.targetClasses,
+      referencingProperty: cs.referencingProperty,
+      columns: cs.columns,
+      priority: cs.priority,
+      sourcePath: cs.sourcePath,
+    }),
+  );
+
+const uniqueByUid = (list: RelationColumnSet[]): RelationColumnSet[] => {
+  const seen = new Set<string>();
+  const out: RelationColumnSet[] = [];
+  for (const cs of list) {
+    if (seen.has(cs.uid)) continue;
+    seen.add(cs.uid);
+    out.push(cs);
+  }
+  return out;
+};
+
+describe("RelationColumnSetResolver — property-based invariants", () => {
+  it("determinism: repeated resolve with identical inputs + snapshot yields identical output", () => {
+    fc.assert(
+      fc.property(
+        fc.array(configArb, { minLength: 0, maxLength: 15 }).map(uniqueByUid),
+        classArrayArb,
+        fc.option(fc.constantFrom(...propertyPool), { nil: null }),
+        (snapshot, rowClasses, prop) => {
+          const resolver = new RelationColumnSetResolver(() => snapshot);
+          const first = resolver.resolve(rowClasses, prop);
+          const second = resolver.resolve(rowClasses, prop);
+          // Reference equality is the strongest determinism check — the
+          // tiebreaker is stable so the same object must be chosen.
+          return first === second;
+        },
+      ),
+      { numRuns: NUM_RUNS, seed: SEED },
+    );
+  });
+
+  it("order-independence: shuffling snapshot does NOT change the resolved asset (by uid)", () => {
+    fc.assert(
+      fc.property(
+        fc.array(configArb, { minLength: 0, maxLength: 15 }).map(uniqueByUid),
+        classArrayArb,
+        fc.option(fc.constantFrom(...propertyPool), { nil: null }),
+        fc.integer({ min: 0, max: 2 ** 31 - 1 }),
+        (snapshot, rowClasses, prop, shuffleSeed) => {
+          const baseline = new RelationColumnSetResolver(() => snapshot);
+          const baselineResult = baseline.resolve(rowClasses, prop);
+
+          // Deterministic shuffle driven by `shuffleSeed`.
+          const shuffled = snapshot
+            .map((cs, idx): [number, RelationColumnSet] => [
+              // xor-shift-ish mixing — stable per `shuffleSeed`.
+              (shuffleSeed ^ (idx * 2654435761)) >>> 0,
+              cs,
+            ])
+            .sort((a, b) => a[0] - b[0])
+            .map(([, cs]) => cs);
+
+          const shuffledResolver = new RelationColumnSetResolver(() => shuffled);
+          const shuffledResult = shuffledResolver.resolve(rowClasses, prop);
+
+          if (baselineResult === null && shuffledResult === null) return true;
+          if (baselineResult === null || shuffledResult === null) return false;
+          return baselineResult.uid === shuffledResult.uid;
+        },
+      ),
+      { numRuns: NUM_RUNS, seed: SEED + 1 },
+    );
+  });
+
+  it("null-safety: empty/degenerate inputs never throw and always return null", () => {
+    fc.assert(
+      fc.property(
+        fc.array(configArb, { minLength: 0, maxLength: 5 }).map(uniqueByUid),
+        (snapshot) => {
+          const resolver = new RelationColumnSetResolver(() => snapshot);
+          resolver.resolve([], "P");
+          resolver.resolve(null, "P");
+          resolver.resolve(undefined, "P");
+          resolver.resolve(["C"], null);
+          resolver.resolve(["C"], undefined);
+          resolver.resolve(["C"], "");
+          return true; // if we got here — no throws.
+        },
+      ),
+      { numRuns: NUM_RUNS, seed: SEED + 2 },
+    );
+  });
+});

--- a/packages/exocortex/tests/application/services/RelationColumnSetResolver.test.ts
+++ b/packages/exocortex/tests/application/services/RelationColumnSetResolver.test.ts
@@ -1,0 +1,509 @@
+/**
+ * RelationColumnSetResolver unit tests.
+ *
+ * Phase 2 of RFC be70f741-a8e3-4826-aab1-d3f950068861.
+ *
+ * Coverage plan (RFC §"Unit-тесты (обязательные)")
+ * - Base matrix: 4 tiers × {single-match, 2-match collision, 0-match} = 12 cases.
+ * - Tiebreaker: priority > (DESC), priority = + uid < (ASC).
+ * - Normalization roundtrip — all wikilink forms exercised via `resolve`.
+ * - Multi-class ladder: 3 classes, collision on tier-2 → first class wins.
+ * - Empty rowClasses / empty property → null.
+ * - Multi-class array в config.targetClasses — expand в N tuples via `.includes`.
+ * - Property-based determinism invariant lives in the sibling `.property.test.ts`.
+ */
+
+import { RelationColumnSetResolver } from "../../../src/application/services/RelationColumnSetResolver";
+import type { RelationColumnSet } from "../../../src/domain/layout/RelationColumnSet";
+
+function mk(overrides: Partial<RelationColumnSet> = {}): RelationColumnSet {
+  return {
+    uid: overrides.uid ?? "uid-default",
+    label: overrides.label ?? "default",
+    targetClasses: overrides.targetClasses ?? null,
+    referencingProperty: overrides.referencingProperty ?? null,
+    columns: overrides.columns ?? ["exo__Asset_label"],
+    priority: overrides.priority ?? 0,
+    sourcePath: overrides.sourcePath ?? "mock.md",
+  };
+}
+
+function warnSpy() {
+  const messages: string[] = [];
+  return {
+    logger: { warn: (msg: string) => messages.push(msg) },
+    messages,
+  };
+}
+
+describe("RelationColumnSetResolver — base 4×3 matrix", () => {
+  // ── Tier 1: exact (targetClass + referencingProperty both match) ──
+  describe("Tier 1 — exact match", () => {
+    it("single-match: unique (class, property) pair wins", () => {
+      const expected = mk({
+        uid: "t1-single",
+        targetClasses: ["period__Week"],
+        referencingProperty: "ems__WeeklyObjective__week",
+      });
+      const resolver = new RelationColumnSetResolver(() => [expected]);
+      expect(
+        resolver.resolve(["period__Week"], "ems__WeeklyObjective__week"),
+      ).toBe(expected);
+    });
+
+    it("2-match collision: higher priority wins + logs.warn not fired for distinct priorities", () => {
+      const low = mk({
+        uid: "aaa",
+        targetClasses: ["C"],
+        referencingProperty: "P",
+        priority: 1,
+      });
+      const high = mk({
+        uid: "zzz",
+        targetClasses: ["C"],
+        referencingProperty: "P",
+        priority: 5,
+      });
+      const spy = warnSpy();
+      const resolver = new RelationColumnSetResolver(() => [low, high], {
+        logger: spy.logger,
+      });
+      expect(resolver.resolve(["C"], "P")).toBe(high);
+      expect(spy.messages).toHaveLength(0);
+    });
+
+    it("0-match: class alone without property falls through to tier 2/3/null", () => {
+      const config = mk({
+        uid: "t1-miss",
+        targetClasses: ["Other"],
+        referencingProperty: "P",
+      });
+      const resolver = new RelationColumnSetResolver(() => [config]);
+      expect(resolver.resolve(["C"], "P")).toBeNull();
+    });
+  });
+
+  // ── Tier 2: class-only (targetClass match, config.referencingProperty === null) ──
+  describe("Tier 2 — class-only", () => {
+    it("single-match: class match + config has no referencingProperty", () => {
+      const expected = mk({
+        uid: "t2-single",
+        targetClasses: ["ems__Task"],
+        referencingProperty: null,
+      });
+      const resolver = new RelationColumnSetResolver(() => [expected]);
+      expect(resolver.resolve(["ems__Task"], "any_property")).toBe(expected);
+    });
+
+    it("2-match collision: equal priority → uid ASC + warn fires", () => {
+      const low = mk({
+        uid: "zzz",
+        targetClasses: ["C"],
+        referencingProperty: null,
+        priority: 3,
+      });
+      const high = mk({
+        uid: "aaa",
+        targetClasses: ["C"],
+        referencingProperty: null,
+        priority: 3,
+      });
+      const spy = warnSpy();
+      const resolver = new RelationColumnSetResolver(() => [low, high], {
+        logger: spy.logger,
+      });
+      expect(resolver.resolve(["C"], "P")).toBe(high);
+      expect(spy.messages).toHaveLength(1);
+      expect(spy.messages[0]).toMatch(/tier=2/);
+      expect(spy.messages[0]).toMatch(/aaa/);
+      expect(spy.messages[0]).toMatch(/zzz/);
+    });
+
+    it("0-match: config class differs", () => {
+      const config = mk({
+        uid: "t2-miss",
+        targetClasses: ["Other"],
+        referencingProperty: null,
+      });
+      const resolver = new RelationColumnSetResolver(() => [config]);
+      expect(resolver.resolve(["C"], "P")).toBeNull();
+    });
+  });
+
+  // ── Tier 3: property-only (config.targetClasses === null, referencingProperty match) ──
+  describe("Tier 3 — property-only", () => {
+    it("single-match: property match + config has no targetClass", () => {
+      const expected = mk({
+        uid: "t3-single",
+        targetClasses: null,
+        referencingProperty: "ems__Effort_status",
+      });
+      const resolver = new RelationColumnSetResolver(() => [expected]);
+      expect(resolver.resolve(["any_class"], "ems__Effort_status")).toBe(
+        expected,
+      );
+    });
+
+    it("2-match collision: priority DESC decisive; uid ASC used only on ties", () => {
+      const low = mk({
+        uid: "m-mid",
+        targetClasses: null,
+        referencingProperty: "P",
+        priority: 7,
+      });
+      const high = mk({
+        uid: "z-top",
+        targetClasses: null,
+        referencingProperty: "P",
+        priority: 10,
+      });
+      const resolver = new RelationColumnSetResolver(() => [low, high]);
+      expect(resolver.resolve(["C"], "P")).toBe(high);
+    });
+
+    it("0-match: config property differs", () => {
+      const config = mk({
+        uid: "t3-miss",
+        targetClasses: null,
+        referencingProperty: "Other",
+      });
+      const resolver = new RelationColumnSetResolver(() => [config]);
+      expect(resolver.resolve(["C"], "P")).toBeNull();
+    });
+  });
+
+  // ── Tier 4: fallback to null ──
+  describe("Tier 4 — null fallback", () => {
+    it("single (empty snapshot) → null", () => {
+      const resolver = new RelationColumnSetResolver(() => []);
+      expect(resolver.resolve(["C"], "P")).toBeNull();
+    });
+
+    it("2-match collision cannot exist at tier 4 — resolver returns null when no earlier tier matches", () => {
+      const unrelated = [
+        mk({ targetClasses: ["Other"], referencingProperty: "P1" }),
+        mk({ targetClasses: ["Other"], referencingProperty: "P2" }),
+      ];
+      const resolver = new RelationColumnSetResolver(() => unrelated);
+      expect(resolver.resolve(["C"], "P")).toBeNull();
+    });
+
+    it("0-match (neither class nor property known)", () => {
+      const resolver = new RelationColumnSetResolver(() => [
+        mk({ targetClasses: ["X"], referencingProperty: "Y" }),
+      ]);
+      expect(resolver.resolve(["C"], "P")).toBeNull();
+    });
+  });
+});
+
+describe("RelationColumnSetResolver — tier precedence", () => {
+  it("Tier 1 wins over Tier 2 for same class", () => {
+    const tier1 = mk({
+      uid: "t1",
+      targetClasses: ["C"],
+      referencingProperty: "P",
+      priority: 0,
+    });
+    const tier2 = mk({
+      uid: "t2",
+      targetClasses: ["C"],
+      referencingProperty: null,
+      priority: 999,
+    });
+    const resolver = new RelationColumnSetResolver(() => [tier2, tier1]);
+    expect(resolver.resolve(["C"], "P")).toBe(tier1);
+  });
+
+  it("Tier 2 wins over Tier 3 for same class", () => {
+    const tier2 = mk({
+      uid: "t2",
+      targetClasses: ["C"],
+      referencingProperty: null,
+      priority: 0,
+    });
+    const tier3 = mk({
+      uid: "t3",
+      targetClasses: null,
+      referencingProperty: "P",
+      priority: 999,
+    });
+    const resolver = new RelationColumnSetResolver(() => [tier3, tier2]);
+    expect(resolver.resolve(["C"], "P")).toBe(tier2);
+  });
+
+  it("Tier 3 matches when no class config exists for the rowClass", () => {
+    const tier3 = mk({
+      uid: "t3",
+      targetClasses: null,
+      referencingProperty: "P",
+      priority: 0,
+    });
+    const unrelated = mk({
+      uid: "u",
+      targetClasses: ["Other"],
+      referencingProperty: "P",
+      priority: 999,
+    });
+    const resolver = new RelationColumnSetResolver(() => [unrelated, tier3]);
+    expect(resolver.resolve(["C"], "P")).toBe(tier3);
+  });
+});
+
+describe("RelationColumnSetResolver — tiebreaker", () => {
+  it("priority DESC: 10 > 5 > 0", () => {
+    const p0 = mk({ uid: "a", targetClasses: ["C"], referencingProperty: "P", priority: 0 });
+    const p5 = mk({ uid: "b", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const p10 = mk({ uid: "c", targetClasses: ["C"], referencingProperty: "P", priority: 10 });
+    const resolver = new RelationColumnSetResolver(() => [p5, p0, p10]);
+    expect(resolver.resolve(["C"], "P")).toBe(p10);
+  });
+
+  it("priority equal → uid ASC (localeCompare)", () => {
+    const aUid = mk({ uid: "aaa", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const zUid = mk({ uid: "zzz", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const mUid = mk({ uid: "mmm", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const resolver = new RelationColumnSetResolver(() => [zUid, mUid, aUid]);
+    expect(resolver.resolve(["C"], "P")).toBe(aUid);
+  });
+
+  it("priority 0 loses to priority 1 (no defensive fallback needed)", () => {
+    const zero = mk({ uid: "a", targetClasses: ["C"], referencingProperty: "P", priority: 0 });
+    const higher = mk({ uid: "b", targetClasses: ["C"], referencingProperty: "P", priority: 1 });
+    const resolver = new RelationColumnSetResolver(() => [zero, higher]);
+    expect(resolver.resolve(["C"], "P")).toBe(higher);
+  });
+
+  it("log.warn fires once per resolve when winning tier has priority tie", () => {
+    const a = mk({ uid: "a", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const b = mk({ uid: "b", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const c = mk({ uid: "c", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const spy = warnSpy();
+    const resolver = new RelationColumnSetResolver(() => [a, b, c], {
+      logger: spy.logger,
+    });
+    expect(resolver.resolve(["C"], "P")).toBe(a);
+    expect(spy.messages).toHaveLength(1);
+    expect(spy.messages[0]).toContain("tier=1");
+    expect(spy.messages[0]).toContain("priority=5");
+  });
+
+  it("log.warn silent when winning priority unique but lower-priority match also exists", () => {
+    const low = mk({ uid: "a", targetClasses: ["C"], referencingProperty: "P", priority: 1 });
+    const winner = mk({ uid: "b", targetClasses: ["C"], referencingProperty: "P", priority: 9 });
+    const spy = warnSpy();
+    const resolver = new RelationColumnSetResolver(() => [low, winner], {
+      logger: spy.logger,
+    });
+    expect(resolver.resolve(["C"], "P")).toBe(winner);
+    expect(spy.messages).toHaveLength(0);
+  });
+});
+
+describe("RelationColumnSetResolver — normalization roundtrip", () => {
+  // The resolver delegates to `normalizeRef` from domain/layout.  These cases
+  // assert that ALL wikilink forms accepted by `normalizeRef` flow through
+  // `resolve` correctly, covering the RFC-mandated normalization gate at the
+  // service boundary.
+  it("raw identifier matches wikilink-form config", () => {
+    const config = mk({
+      targetClasses: ["ems__Task"],
+      referencingProperty: "ems__Effort_status",
+    });
+    const resolver = new RelationColumnSetResolver(() => [config]);
+    expect(
+      resolver.resolve(["[[ems__Task]]"], "[[ems__Effort_status]]"),
+    ).toBe(config);
+  });
+
+  it("wikilink with alias — alias after `|` is dropped", () => {
+    const config = mk({
+      targetClasses: ["uuid-123"],
+      referencingProperty: "prop-uuid",
+    });
+    const resolver = new RelationColumnSetResolver(() => [config]);
+    expect(
+      resolver.resolve(
+        ["[[uuid-123|Display Name]]"],
+        "[[prop-uuid|Friendly]]",
+      ),
+    ).toBe(config);
+  });
+
+  it("whitespace trimmed consistently both sides", () => {
+    const config = mk({ targetClasses: ["C"], referencingProperty: "P" });
+    const resolver = new RelationColumnSetResolver(() => [config]);
+    expect(resolver.resolve(["  C  "], "  P  ")).toBe(config);
+  });
+
+  it("empty string rowClass entry skipped; next entry used", () => {
+    const config = mk({ targetClasses: ["C"], referencingProperty: "P" });
+    const resolver = new RelationColumnSetResolver(() => [config]);
+    expect(resolver.resolve(["", "C"], "P")).toBe(config);
+  });
+
+  it("non-string rowClass entry skipped", () => {
+    const config = mk({ targetClasses: ["C"], referencingProperty: "P" });
+    const resolver = new RelationColumnSetResolver(() => [config]);
+    // Cast through unknown — mimics lax frontmatter inputs
+    const rowClasses = [null as unknown as string, "C"];
+    expect(resolver.resolve(rowClasses, "P")).toBe(config);
+  });
+
+  it("wikilink with internal brackets drops the unmatched trailing part via trim", () => {
+    // `normalizeRef` expects matched `[[...]]`. A malformed `[[C` is not a
+    // wikilink match → treated as raw, resulting in literal `[[C` which will
+    // not match config `C`.
+    const config = mk({ targetClasses: ["C"], referencingProperty: "P" });
+    const resolver = new RelationColumnSetResolver(() => [config]);
+    expect(resolver.resolve(["[[C"], "P")).toBeNull();
+  });
+
+  it("null rowClass element skipped gracefully (type-cast)", () => {
+    const config = mk({ targetClasses: ["C"], referencingProperty: "P" });
+    const resolver = new RelationColumnSetResolver(() => [config]);
+    const rowClasses = [undefined as unknown as string, "C"];
+    expect(resolver.resolve(rowClasses, "P")).toBe(config);
+  });
+});
+
+describe("RelationColumnSetResolver — multi-class rowClasses", () => {
+  it("3 classes: first class hits tier 1 → wins", () => {
+    const forFirst = mk({
+      uid: "first",
+      targetClasses: ["Cls1"],
+      referencingProperty: "P",
+    });
+    const forSecond = mk({
+      uid: "second",
+      targetClasses: ["Cls2"],
+      referencingProperty: "P",
+    });
+    const resolver = new RelationColumnSetResolver(() => [forFirst, forSecond]);
+    expect(resolver.resolve(["Cls1", "Cls2", "Cls3"], "P")).toBe(forFirst);
+  });
+
+  it("3 classes: first class has NO match → fall through to second class", () => {
+    const secondOnly = mk({
+      uid: "second",
+      targetClasses: ["Cls2"],
+      referencingProperty: "P",
+    });
+    const resolver = new RelationColumnSetResolver(() => [secondOnly]);
+    expect(resolver.resolve(["Cls1", "Cls2", "Cls3"], "P")).toBe(secondOnly);
+  });
+
+  it("3 classes: collision on tier-2 for first class → first class wins, later classes untouched", () => {
+    const t2First = mk({
+      uid: "aaa",
+      targetClasses: ["Cls1"],
+      referencingProperty: null,
+      priority: 3,
+    });
+    const t1Second = mk({
+      uid: "zzz",
+      targetClasses: ["Cls2"],
+      referencingProperty: "P",
+      priority: 999,
+    });
+    const resolver = new RelationColumnSetResolver(() => [t2First, t1Second]);
+    // Tier 2 match on Cls1 short-circuits — Cls2's tier-1 never evaluated.
+    expect(resolver.resolve(["Cls1", "Cls2"], "P")).toBe(t2First);
+  });
+
+  it("config.targetClasses is multi-value array — each class is a hit candidate", () => {
+    const multi = mk({
+      uid: "multi",
+      targetClasses: ["Cls1", "Cls2", "Cls3"],
+      referencingProperty: "P",
+    });
+    const resolver = new RelationColumnSetResolver(() => [multi]);
+    expect(resolver.resolve(["Cls2"], "P")).toBe(multi);
+    expect(resolver.resolve(["Cls3"], "P")).toBe(multi);
+    expect(resolver.resolve(["NotInSet"], "P")).toBeNull();
+  });
+});
+
+describe("RelationColumnSetResolver — empty / degenerate inputs", () => {
+  it("rowClasses empty array → null", () => {
+    const resolver = new RelationColumnSetResolver(() => [
+      mk({ targetClasses: ["C"], referencingProperty: "P" }),
+    ]);
+    expect(resolver.resolve([], "P")).toBeNull();
+  });
+
+  it("rowClasses is null → null", () => {
+    const resolver = new RelationColumnSetResolver(() => [
+      mk({ targetClasses: ["C"], referencingProperty: "P" }),
+    ]);
+    expect(resolver.resolve(null, "P")).toBeNull();
+  });
+
+  it("rowClasses is undefined → null", () => {
+    const resolver = new RelationColumnSetResolver(() => [
+      mk({ targetClasses: ["C"], referencingProperty: "P" }),
+    ]);
+    expect(resolver.resolve(undefined, "P")).toBeNull();
+  });
+
+  it("referencingProperty is empty string → normalizeRef returns null → only tier 2 possible", () => {
+    const tier2 = mk({
+      targetClasses: ["C"],
+      referencingProperty: null,
+      uid: "t2",
+    });
+    const tier1 = mk({
+      targetClasses: ["C"],
+      referencingProperty: "P",
+      uid: "t1",
+    });
+    const resolver = new RelationColumnSetResolver(() => [tier1, tier2]);
+    expect(resolver.resolve(["C"], "")).toBe(tier2);
+  });
+
+  it("referencingProperty is null → only tier 2 possible", () => {
+    const tier2 = mk({ targetClasses: ["C"], referencingProperty: null });
+    const resolver = new RelationColumnSetResolver(() => [tier2]);
+    expect(resolver.resolve(["C"], null)).toBe(tier2);
+  });
+
+  it("referencingProperty is undefined → only tier 2 possible", () => {
+    const tier2 = mk({ targetClasses: ["C"], referencingProperty: null });
+    const resolver = new RelationColumnSetResolver(() => [tier2]);
+    expect(resolver.resolve(["C"], undefined)).toBe(tier2);
+  });
+
+  it("snapshot empty → null for any inputs", () => {
+    const resolver = new RelationColumnSetResolver(() => []);
+    expect(resolver.resolve(["C"], "P")).toBeNull();
+  });
+
+  it("provider returns same snapshot on repeated resolve calls (stability)", () => {
+    const config = mk({ targetClasses: ["C"], referencingProperty: "P" });
+    let callCount = 0;
+    const resolver = new RelationColumnSetResolver(() => {
+      callCount += 1;
+      return [config];
+    });
+    resolver.resolve(["C"], "P");
+    resolver.resolve(["C"], "P");
+    expect(callCount).toBe(2);
+  });
+});
+
+describe("RelationColumnSetResolver — logger default (no options)", () => {
+  it("omitting logger does not throw on collision", () => {
+    const a = mk({ uid: "a", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const b = mk({ uid: "b", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const resolver = new RelationColumnSetResolver(() => [a, b]);
+    expect(() => resolver.resolve(["C"], "P")).not.toThrow();
+    expect(resolver.resolve(["C"], "P")).toBe(a);
+  });
+
+  it("explicit empty-object options uses noop logger", () => {
+    const a = mk({ uid: "a", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const b = mk({ uid: "b", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
+    const resolver = new RelationColumnSetResolver(() => [a, b], {});
+    expect(resolver.resolve(["C"], "P")).toBe(a);
+  });
+});

--- a/packages/exocortex/tests/performance/RelationColumnSetResolverPerformance.test.ts
+++ b/packages/exocortex/tests/performance/RelationColumnSetResolverPerformance.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Performance gate for RelationColumnSetResolver.
+ *
+ * RFC be70f741 Phase 2 §Acceptance Criteria: `resolve()` p95 < 1 ms on 100
+ * configs.  This test is the gate; failing this test blocks Phase 2 Done.
+ *
+ * Measurement
+ * - 100 synthetic configs spread evenly across tier-1 / tier-2 / tier-3 shapes.
+ * - 500 warmup + 5000 measured iterations (enough for stable p95 even on
+ *   noisy CI runners).
+ * - `process.hrtime.bigint()` for monotonic ns precision.
+ * - p95 = sorted[ceil(0.95 * n) - 1].
+ *
+ * Guardrail
+ * - Gate `p95 < 1_000_000` ns (= 1 ms).  The median is expected well below
+ *   100 µs on a modern runner; the 10× headroom absorbs CI jitter.
+ */
+
+import { RelationColumnSetResolver } from "../../src/application/services/RelationColumnSetResolver";
+import type { RelationColumnSet } from "../../src/domain/layout/RelationColumnSet";
+
+const WARMUP_ITERATIONS = 500;
+const MEASURED_ITERATIONS = 5000;
+const P95_BUDGET_NS = 1_000_000; // 1 ms
+
+function buildFixture(): RelationColumnSet[] {
+  const out: RelationColumnSet[] = [];
+  // Tier 1 candidates: 40 configs with (class, property) pairs.
+  for (let i = 0; i < 40; i += 1) {
+    out.push({
+      uid: `tier1-${String(i).padStart(3, "0")}`,
+      label: `tier1-${i}`,
+      targetClasses: [`Cls${i % 10}`],
+      referencingProperty: `Prop${i % 10}`,
+      columns: ["exo__Asset_label"],
+      priority: i % 3,
+      sourcePath: `tier1-${i}.md`,
+    });
+  }
+  // Tier 2 candidates: 30 class-only configs.
+  for (let i = 0; i < 30; i += 1) {
+    out.push({
+      uid: `tier2-${String(i).padStart(3, "0")}`,
+      label: `tier2-${i}`,
+      targetClasses: [`Cls${i % 10}`],
+      referencingProperty: null,
+      columns: ["exo__Asset_label"],
+      priority: i % 4,
+      sourcePath: `tier2-${i}.md`,
+    });
+  }
+  // Tier 3 candidates: 30 property-only configs.
+  for (let i = 0; i < 30; i += 1) {
+    out.push({
+      uid: `tier3-${String(i).padStart(3, "0")}`,
+      label: `tier3-${i}`,
+      targetClasses: null,
+      referencingProperty: `Prop${i % 10}`,
+      columns: ["exo__Asset_label"],
+      priority: i % 5,
+      sourcePath: `tier3-${i}.md`,
+    });
+  }
+  return out;
+}
+
+function percentile(sorted: readonly bigint[], p: number): bigint {
+  const rank = Math.ceil(p * sorted.length);
+  const idx = Math.min(Math.max(rank - 1, 0), sorted.length - 1);
+  return sorted[idx];
+}
+
+describe("RelationColumnSetResolver — performance gate", () => {
+  it("resolve() p95 < 1 ms on 100 configs", () => {
+    const configs = buildFixture();
+    expect(configs).toHaveLength(100);
+
+    const resolver = new RelationColumnSetResolver(() => configs);
+
+    // Representative rowClass × property inputs covering all tiers.
+    const queries: Array<[readonly string[], string]> = [
+      [["Cls0"], "Prop0"], // tier 1 hit
+      [["Cls5"], "Prop5"], // tier 1 hit
+      [["Cls9"], "PropMiss"], // tier 2 hit (class-only)
+      [["ClsMiss"], "Prop0"], // tier 3 hit
+      [["ClsMiss"], "PropMiss"], // tier 4 miss
+      [["Cls0", "Cls1"], "Prop0"], // multi-class
+    ];
+
+    // Warmup — JIT stabilisation.
+    for (let i = 0; i < WARMUP_ITERATIONS; i += 1) {
+      const [cls, prop] = queries[i % queries.length];
+      resolver.resolve(cls, prop);
+    }
+
+    const samples: bigint[] = new Array(MEASURED_ITERATIONS);
+    for (let i = 0; i < MEASURED_ITERATIONS; i += 1) {
+      const [cls, prop] = queries[i % queries.length];
+      const t0 = process.hrtime.bigint();
+      resolver.resolve(cls, prop);
+      const t1 = process.hrtime.bigint();
+      samples[i] = t1 - t0;
+    }
+
+    samples.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const p50 = percentile(samples, 0.5);
+    const p95 = percentile(samples, 0.95);
+    const p99 = percentile(samples, 0.99);
+    const maxSample = samples[samples.length - 1];
+
+    // Log for visibility in CI summary; noise-free enough to keep in the test.
+    // eslint-disable-next-line no-console
+    console.log(
+      `[RelationColumnSetResolver perf] p50=${p50}ns p95=${p95}ns p99=${p99}ns max=${maxSample}ns (n=${MEASURED_ITERATIONS}, configs=${configs.length})`,
+    );
+
+    expect(Number(p95)).toBeLessThan(P95_BUDGET_NS);
+  });
+});

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -82,20 +82,23 @@ else
     fi
 fi
 
-# Run exocortex regression tests (narrow scope: two files only).
+# Run exocortex regression tests (narrow scope: allow-listed files only).
 # The packages/exocortex/jest.config.js root-level config is otherwise unreachable
 # from CI because obsidian-plugin/jest.config.js's `testMatch` with `<rootDir>/../exocortex/...`
 # does not actually discover external roots without a `roots` entry. This narrow
-# invocation pulls in only the files targeted by RFC-028 Findings 3+4 / Finding 5
-# regression suites so those TDD steps can produce CI-verified RED→GREEN proof.
+# invocation pulls in only the files targeted by specific RFC regression /
+# Phase-N green-gates so those TDD steps can produce CI-verified RED→GREEN proof.
 # Pre-existing failures in the wider exocortex package (performance tests,
 # QueryExecutor.branch, MetadataExtractor, etc.) are intentionally excluded —
 # tracked as a separate follow-up (CI gap audit).
 #
-# RFC-028 Finding 5 (3.C.1) extends the pattern with AssetConversionService.test.ts
-# so the Project→Task conversion regression lock is also observable in CI.
-echo "📦 Running exocortex grounding regression tests..."
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=services/(GroundingExecutor|AssetConversionService)\.test\.ts --forceExit"
+# Allow-list additions:
+# - RFC-028 Findings 3+4: services/GroundingExecutor.test.ts
+# - RFC-028 Finding 5 (3.C.1): services/AssetConversionService.test.ts
+# - RFC be70f741 Phase 2: application/services/RelationColumnSetResolver(.property)?.test.ts
+#   + performance/RelationColumnSetResolverPerformance.test.ts (p95 <1ms gate)
+echo "📦 Running exocortex grounding + RFC regression tests..."
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
## Summary
- RFC be70f741 Phase 2 deliverable — `RelationColumnSetResolver` with 4-tier priority ladder over `RelationColumnSet` snapshot from Phase 1 repository.
- Tiebreaker: `priority DESC → exo__Asset_uid ASC` (RFC v2 architect M3 fix). `log.warn` on every equal-priority collision.
- Behaviour-neutral — no consumer until Phase 3 integrates into `RelationsRenderer.ts:160-163`.

## Related
- Task [6cc11990-4ba8-4aa5-bf9f-78dc5da904c0](../blob/main/vault-2025/..)
- Project `489e297d-069f-4144-a538-dce81da18d0f`
- RFC `be70f741-a8e3-4826-aab1-d3f950068861`

## Test plan
- [x] 41 unit tests — base 4×3 matrix, tier precedence, tiebreaker, normalization roundtrip, multi-class, degenerate inputs.
- [x] 3 property-based tests (fast-check, N=500 runs each, explicit seed=0xc0ffee) — determinism, order-independence, null-safety.
- [x] Performance gate `tests/performance/RelationColumnSetResolverPerformance.test.ts` — p95 < 1 ms on 100 configs (measured locally p95 ≈ 5 µs).
- [x] Coverage: 100% statements, 100% branches on `RelationColumnSetResolver.ts` (file-level).
- [x] `npx tsc --noEmit --skipLibCheck` clean.
- [x] `scripts/test-ci-batched.sh` full run passes locally.
- [x] CI allow-list (`scripts/test-ci-batched.sh`) extended so the 3 new suites run in main CI.