### PR TITLE
feat: Phase 4 cache invalidation tests + docs + adapter leak fix (RFC be70f741)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17312,12 +17312,14 @@
         "@playwright/experimental-ct-react": "^1.55.1",
         "@playwright/test": "^1.55.1",
         "@testing-library/jest-dom": "^6.9.1",
+        "@types/js-yaml": "^4.0.0",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "esbuild-plugin-tsc": "^0.5.0",
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.2.0",
-        "jest-environment-obsidian": "^0.0.1"
+        "jest-environment-obsidian": "^0.0.1",
+        "js-yaml": "^4.1.0"
       }
     },
     "packages/obsidian-plugin/node_modules/@codemirror/state": {

--- a/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
+++ b/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
@@ -1,0 +1,130 @@
+# `ui__RelationColumnSet` — RDF-configurable backlinks columns
+
+`ui__RelationColumnSet` lets you declare, directly in the vault, which
+properties should appear as columns in the UniversalLayout auto-backlinks
+table for a given (rowClass, referencingProperty) pair. Previously this map
+was hardcoded in `RelationsRenderer.ts`; now it is driven by RDF, so new
+semantic cases can be shipped without touching plugin source.
+
+The resolver is wired automatically on plugin load and is gated by the
+`enableRelationColumnSetResolver` setting (default `true`). When the flag is
+off, or no matching config exists, the renderer transparently falls back to
+the original hardcoded map — the feature is purely additive and opt-in per
+(rowClass, referencingProperty) pair.
+
+## Copy-pasteable example
+
+Create a new note anywhere in the vault (e.g.
+`03 Knowledge/ui/weekly-objective-week.md`) with the following frontmatter to
+show `exo__Asset_createdAt` and `exo__Asset_label` as columns whenever
+`ems__WeeklyObjective` backlinks to an open `period__Week` via
+`ems__WeeklyObjective__week`:
+
+```yaml
+---
+exo__Asset_uid: 3f41c77a-7e42-4b45-9e87-0d4b6dc3f451
+exo__Asset_label: "WeeklyObjective columns for Week"
+exo__Instance_class:
+  - "[[ui__RelationColumnSet]]"
+ui__RelationColumnSet_label: "WeeklyObjective ← Week"
+ui__RelationColumnSet_targetClass:
+  - "[[ems__WeeklyObjective]]"
+ui__RelationColumnSet_referencingProperty: "[[ems__WeeklyObjective__week]]"
+ui__RelationColumnSet_columns:
+  - "[[exo__Asset_createdAt]]"
+  - "[[exo__Asset_label]]"
+ui__RelationColumnSet_priority: 0
+---
+```
+
+The columns render in the declared order, left-to-right. Only the ontology
+class wikilink in `exo__Instance_class` is mandatory for discovery; every
+`ui__RelationColumnSet_*` field is validated on parse with a `log.warn` on
+malformed input — invalid assets are skipped, never thrown.
+
+## Priority ladder
+
+The resolver matches one config per (rowClass, referencingProperty) pair.
+When more than one config could match, the ladder below fires in order and
+the first tier with at least one match wins.
+
+| Tier                  | Condition                                                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| **1 — Exact**         | `targetClass` contains the row-class AND `referencingProperty` equals the backlinks group key. |
+| **2 — Class only**    | `targetClass` contains the row-class AND the config omits `referencingProperty`.               |
+| **3 — Property only** | The config omits `targetClass` AND `referencingProperty` equals the backlinks group key.       |
+| **4 — Default**       | Nothing matched — the renderer falls back to its legacy hardcoded map.                         |
+
+**Tiebreaker within a tier** — `priority DESC → exo__Asset_uid ASC`. Ties on
+both fields are impossible because `exo__Asset_uid` is globally unique; the
+uid-sort guarantees deterministic output across vaults and across machines.
+When two configs share the same tier and priority, the resolver emits a
+`log.warn` with both uids so the collision is visible in the console.
+
+Declaration order of classes in `exo__Instance_class` matters: the resolver
+walks classes in that order, and the first class to produce a non-null match
+wins. This lets you declare a specific class (`ems__WeeklyObjective`) ahead
+of a more generic one (`ems__Effort`) on the row asset and get the
+specific-first behaviour without writing priority arithmetic.
+
+## Coexistence with `exo__TableLayout`
+
+`exo__TableLayout` and `ui__RelationColumnSet` operate on different data
+sources:
+
+- `exo__TableLayout` renders a user-declared list of assets (explicit
+  `rows:` or a SPARQL-like query), and each layout defines its own columns.
+- `ui__RelationColumnSet` only customises the **auto-backlinks table**
+  produced by `UniversalLayout` — the one grouped by referencing property.
+
+Both renderers are live simultaneously on the same note without interference.
+You can put an `exo__TableLayout` codeblock inside a note whose class is
+targeted by a `ui__RelationColumnSet`, and each table uses its own column
+definition. The RelationsRenderer integration point is
+`RelationsRenderer.ts:buildGroupSpecificProperties` — it only consults the
+resolver; it never touches `exo__TableLayout` code paths.
+
+## Feature flag
+
+`ExocortexSettings.enableRelationColumnSetResolver` gates consumption of the
+resolver by the renderer. It does **not** gate the repository itself — the
+index is always warm so toggling the flag at runtime is immediate (no reload
+needed). Defaults:
+
+- `true` on new installs.
+- Toggling to `false` reverts the auto-backlinks table to the legacy
+  hardcoded map for every group — useful for bisecting a regression or
+  comparing behaviour.
+
+The flag lives under the "RFC be70f741 Phase 1 — enable the
+RelationColumnSetRepository" description in `ExocortexSettings.ts:100-110`.
+
+## Troubleshooting
+
+`log.warn` messages emitted by the pipeline, listed in the order they can
+appear:
+
+- `RelationColumnSet <uid>: at least one of targetClass / referencingProperty required (<path>)` —
+  the config has neither. Add at least one of the two fields.
+- `RelationColumnSet <uid>: columns array must contain at least one entry (<path>)` —
+  `ui__RelationColumnSet_columns` was empty or absent; declare at least one
+  column wikilink.
+- `RelationColumnSet: exo__Asset_uid missing at <path>` — every vault asset
+  needs a UUID; regenerate it or paste one from an existing working config.
+- `RelationColumnSetRepository: duplicate exo__Asset_uid <uid> (<path>); keeping first-seen` —
+  two files share a UUID. The repository keeps the first-seen asset and
+  skips duplicates on subsequent rebuilds; change one uid to resolve.
+- `RelationColumnSetResolver: tier-<N> collision on <cls> / <prop> (uids: [<a>, <b>, …])` —
+  multiple matching configs share the same tier and priority. The resolver
+  still picks one deterministically (uid ASC), but the warning lets you
+  either split the configs or raise the priority on the intended winner.
+
+If the auto-backlinks table does not reflect a newly-added config, check:
+
+1. `enableRelationColumnSetResolver` is `true` in settings.
+2. `exo__Instance_class` contains `[[ui__RelationColumnSet]]` or the
+   canonical UID `[[97fc9862-c886-4d86-9a60-e0cf9d778575]]`.
+3. The console does not show any of the `log.warn` messages above for the
+   file's path.
+4. The open note's row-class is listed in `ui__RelationColumnSet_targetClass`
+   (exact wikilink match after normalisation).

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -34,11 +34,13 @@
     "@playwright/experimental-ct-react": "^1.55.1",
     "@playwright/test": "^1.55.1",
     "@testing-library/jest-dom": "^6.9.1",
+    "@types/js-yaml": "^4.0.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "esbuild-plugin-tsc": "^0.5.0",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.2.0",
-    "jest-environment-obsidian": "^0.0.1"
+    "jest-environment-obsidian": "^0.0.1",
+    "js-yaml": "^4.1.0"
   }
 }

--- a/packages/obsidian-plugin/src/infrastructure/repositories/ObsidianRelationColumnSetAdapter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/repositories/ObsidianRelationColumnSetAdapter.ts
@@ -8,7 +8,7 @@
  */
 
 import { TFile } from "obsidian";
-import type { App, EventRef } from "obsidian";
+import type { App } from "obsidian";
 
 import type {
   RelationColumnSetEventHandler,
@@ -35,20 +35,27 @@ export class ObsidianRelationColumnSetAdapter
     event: "changed" | "deleted" | "renamed",
     handler: RelationColumnSetEventHandler,
   ): () => void {
-    let eventRef: EventRef;
+    // Each event belongs to a different `Events` instance (metadataCache for
+    // changed/deleted, vault for rename).  Capturing the correct offref target
+    // here avoids a listener leak on plugin unload → load cycles — the
+    // `eventRef` returned by `vault.on('rename', …)` is NOT registered in
+    // `metadataCache`, so routing all offrefs through `metadataCache.offref`
+    // would silently no-op for rename.
     if (event === "changed") {
-      eventRef = this.app.metadataCache.on("changed", (file) => {
+      const eventRef = this.app.metadataCache.on("changed", (file) => {
         if (file instanceof TFile) handler({ path: file.path });
       });
-    } else if (event === "deleted") {
-      eventRef = this.app.metadataCache.on("deleted", (file) => {
-        if (file instanceof TFile) handler({ path: file.path });
-      });
-    } else {
-      eventRef = this.app.vault.on("rename", (file, _oldPath) => {
-        if (file instanceof TFile) handler({ path: file.path });
-      });
+      return () => this.app.metadataCache.offref(eventRef);
     }
-    return () => this.app.metadataCache.offref(eventRef);
+    if (event === "deleted") {
+      const eventRef = this.app.metadataCache.on("deleted", (file) => {
+        if (file instanceof TFile) handler({ path: file.path });
+      });
+      return () => this.app.metadataCache.offref(eventRef);
+    }
+    const eventRef = this.app.vault.on("rename", (file, _oldPath) => {
+      if (file instanceof TFile) handler({ path: file.path });
+    });
+    return () => this.app.vault.offref(eventRef);
   }
 }

--- a/packages/obsidian-plugin/tests/component/docs-example-renders.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/docs-example-renders.spec.tsx
@@ -1,0 +1,108 @@
+/**
+ * RFC be70f741 Phase 4 — docs example CI gate (M5 usability).
+ *
+ * Reads `docs/RELATION_COLUMN_SET.md`, extracts the ```yaml fenced block,
+ * parses it through the same pipeline production uses
+ * (`createRelationColumnSetFromFrontmatter` → `RelationColumnSetResolver`),
+ * and mounts `AssetRelationsTable` with the resolver-derived columns.  If
+ * anyone edits the docs in a way that silently breaks the copy-pasteable
+ * example, this test fails in CI — the RFC M5 "falsifiable usability"
+ * guarantee.
+ */
+
+import { test, expect } from "@playwright/experimental-ct-react";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as yaml from "js-yaml";
+import React from "react";
+
+import {
+  createRelationColumnSetFromFrontmatter,
+  type RelationColumnSet,
+} from "../../../exocortex/src/domain/layout/RelationColumnSet";
+import { RelationColumnSetResolver } from "../../../exocortex/src/application/services/RelationColumnSetResolver";
+
+import { AssetRelationsTable } from "../../src/presentation/components/AssetRelationsTable";
+import { happyPathRelations } from "./fixtures/relation-column-set";
+
+const DOCS_PATH = path.resolve(__dirname, "../../docs/RELATION_COLUMN_SET.md");
+const YAML_FENCE = /```yaml\n([\s\S]+?)\n```/;
+const ROW_CLASSES = ["[[ems__WeeklyObjective]]"];
+const GROUP_PROP = "[[ems__WeeklyObjective__week]]";
+
+function loadDocsConfig(): RelationColumnSet {
+  const md = fs.readFileSync(DOCS_PATH, "utf8");
+  const match = md.match(YAML_FENCE);
+  if (!match) {
+    throw new Error(
+      `docs-example-renders: no \`\`\`yaml\\n…\\n\`\`\` block found in ${DOCS_PATH}`,
+    );
+  }
+  // The docs block is wrapped in Obsidian-style `---` fences inside the YAML
+  // code block (for copy-paste fidelity).  js-yaml treats each `---` as a
+  // document separator, so strip the leading/trailing fences before parsing.
+  const stripped = match[1].replace(/^---\s*\n/, "").replace(/\n---\s*$/, "");
+  const frontmatter = yaml.load(stripped) as Record<string, unknown>;
+  const parsed = createRelationColumnSetFromFrontmatter(frontmatter, {
+    sourcePath: DOCS_PATH,
+    warn: (msg) => {
+      // Surface any parse warning as a hard failure — the docs example must
+      // validate cleanly under exactly the rules the runtime enforces.
+      throw new Error(`docs-example-renders: parse warning: ${msg}`);
+    },
+  });
+  if (!parsed) {
+    throw new Error(
+      `docs-example-renders: createRelationColumnSetFromFrontmatter returned null for docs YAML`,
+    );
+  }
+  return parsed;
+}
+
+test.describe("docs/RELATION_COLUMN_SET.md example renders", () => {
+  test("resolver picks docs-example config for WeeklyObjective → Week + AssetRelationsTable shows its columns", async ({
+    mount,
+  }) => {
+    const docsConfig = loadDocsConfig();
+
+    expect(docsConfig.targetClasses).toEqual(["ems__WeeklyObjective"]);
+    expect(docsConfig.referencingProperty).toBe("ems__WeeklyObjective__week");
+    expect(docsConfig.columns).toEqual([
+      "[[exo__Asset_createdAt]]",
+      "[[exo__Asset_label]]",
+    ]);
+
+    const resolver = new RelationColumnSetResolver(() => [docsConfig]);
+    const resolved = resolver.resolve(ROW_CLASSES, GROUP_PROP);
+    expect(resolved?.uid).toBe(docsConfig.uid);
+
+    // Strip wikilink wrapping — AssetRelationsTable expects bare property
+    // names for column header lookup (the renderer does the same transform
+    // in `buildGroupSpecificProperties`).
+    const columnPropertyNames = resolved!.columns.map((col) => {
+      const m = col.match(/^\[\[([^|\]]+)(?:\|[^\]]+)?\]\]$/);
+      return m ? m[1] : col;
+    });
+    const groupSpecificProperties = {
+      ems__WeeklyObjective__week: columnPropertyNames,
+    };
+
+    const component = await mount(
+      <AssetRelationsTable
+        relations={happyPathRelations}
+        groupByProperty={true}
+        groupSpecificProperties={groupSpecificProperties}
+      />,
+    );
+
+    await expect(
+      component.getByRole("columnheader", { name: /Createdat/i }),
+    ).toBeVisible();
+    await expect(
+      component.getByRole("columnheader", { name: /Label/i }),
+    ).toBeVisible();
+    await expect(component.locator("tbody tr")).toHaveCount(
+      happyPathRelations.length,
+    );
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/repositories/ObsidianRelationColumnSetAdapter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/repositories/ObsidianRelationColumnSetAdapter.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Adapter unit-tests for RFC be70f741 Phase 4 — verify that each event's
+ * `offref` is routed to the same `Events` instance that `on` was registered
+ * against.  Historically rename was subscribed via `vault.on(…)` but its
+ * unsubscribe called `metadataCache.offref(eventRef)`, which silently no-op'd
+ * because the `eventRef` did not belong to `metadataCache`'s listener list.
+ * Result: listener leak per plugin unload→load cycle.  The fix picks the
+ * correct Events target per event kind — these tests pin that contract.
+ */
+
+import { TFile } from "obsidian";
+
+import { ObsidianRelationColumnSetAdapter } from "../../../../src/infrastructure/repositories/ObsidianRelationColumnSetAdapter";
+
+interface FakeEvents {
+  on: jest.Mock<unknown, [string, (...args: unknown[]) => void]>;
+  offref: jest.Mock<void, [unknown]>;
+  trigger: (event: string, ...args: unknown[]) => number;
+}
+
+function makeEvents(): FakeEvents {
+  const listeners = new Map<
+    string,
+    Array<{ ref: unknown; handler: (...args: unknown[]) => void }>
+  >();
+  const on = jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+    const ref = { event, handler };
+    const bucket = listeners.get(event) ?? [];
+    bucket.push({ ref, handler });
+    listeners.set(event, bucket);
+    return ref;
+  });
+  const offref = jest.fn((ref: unknown) => {
+    for (const bucket of listeners.values()) {
+      const idx = bucket.findIndex((e) => e.ref === ref);
+      if (idx >= 0) {
+        bucket.splice(idx, 1);
+        return;
+      }
+    }
+  });
+  return {
+    on,
+    offref,
+    trigger: (event, ...args) => {
+      const bucket = listeners.get(event) ?? [];
+      for (const entry of bucket) entry.handler(...args);
+      return bucket.length;
+    },
+  };
+}
+
+function makeApp(): {
+  app: {
+    vault: FakeEvents & {
+      getMarkdownFiles: jest.Mock;
+      getAbstractFileByPath: jest.Mock;
+    };
+    metadataCache: FakeEvents & { getFileCache: jest.Mock };
+  };
+  vaultEvents: FakeEvents;
+  metaEvents: FakeEvents;
+} {
+  const vaultEvents = makeEvents();
+  const metaEvents = makeEvents();
+  const vault = {
+    ...vaultEvents,
+    getMarkdownFiles: jest.fn(() => []),
+    getAbstractFileByPath: jest.fn(() => null),
+  };
+  const metadataCache = {
+    ...metaEvents,
+    getFileCache: jest.fn(() => null),
+  };
+  return {
+    app: { vault, metadataCache } as never,
+    vaultEvents,
+    metaEvents,
+  };
+}
+
+describe("ObsidianRelationColumnSetAdapter — subscribe/unsubscribe symmetry", () => {
+  test("changed subscribes to metadataCache and offrefs metadataCache", () => {
+    const { app, metaEvents, vaultEvents } = makeApp();
+    const adapter = new ObsidianRelationColumnSetAdapter(app as never);
+
+    const unsub = adapter.on("changed", () => {});
+
+    expect(metaEvents.on).toHaveBeenCalledTimes(1);
+    expect(metaEvents.on.mock.calls[0][0]).toBe("changed");
+    expect(vaultEvents.on).not.toHaveBeenCalled();
+
+    unsub();
+    expect(metaEvents.offref).toHaveBeenCalledTimes(1);
+    expect(vaultEvents.offref).not.toHaveBeenCalled();
+  });
+
+  test("deleted subscribes to metadataCache and offrefs metadataCache", () => {
+    const { app, metaEvents, vaultEvents } = makeApp();
+    const adapter = new ObsidianRelationColumnSetAdapter(app as never);
+
+    const unsub = adapter.on("deleted", () => {});
+
+    expect(metaEvents.on).toHaveBeenCalledTimes(1);
+    expect(metaEvents.on.mock.calls[0][0]).toBe("deleted");
+    expect(vaultEvents.on).not.toHaveBeenCalled();
+
+    unsub();
+    expect(metaEvents.offref).toHaveBeenCalledTimes(1);
+    expect(vaultEvents.offref).not.toHaveBeenCalled();
+  });
+
+  test("renamed subscribes to vault and offrefs vault (phase 4 leak fix)", () => {
+    const { app, metaEvents, vaultEvents } = makeApp();
+    const adapter = new ObsidianRelationColumnSetAdapter(app as never);
+
+    const unsub = adapter.on("renamed", () => {});
+
+    expect(vaultEvents.on).toHaveBeenCalledTimes(1);
+    expect(vaultEvents.on.mock.calls[0][0]).toBe("rename");
+    expect(metaEvents.on).not.toHaveBeenCalled();
+
+    unsub();
+    expect(vaultEvents.offref).toHaveBeenCalledTimes(1);
+    expect(metaEvents.offref).not.toHaveBeenCalled();
+  });
+
+  test("rename unsubscribe actually removes the handler (not a silent no-op)", () => {
+    const { app, vaultEvents } = makeApp();
+    const adapter = new ObsidianRelationColumnSetAdapter(app as never);
+    const handler = jest.fn();
+
+    const unsub = adapter.on("renamed", handler);
+
+    // Fire a matching event with a TFile payload → handler invoked.
+    const file = new TFile("a.md");
+    expect(vaultEvents.trigger("rename", file, "old.md")).toBe(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unsub();
+
+    // After unsubscribe the bucket must be empty — if offref routed to the
+    // wrong Events instance this assertion would have fired (handler called
+    // twice because the listener was never removed).
+    expect(vaultEvents.trigger("rename", file, "old.md")).toBe(0);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("handler ignores non-TFile payloads", () => {
+    const { app, metaEvents } = makeApp();
+    const adapter = new ObsidianRelationColumnSetAdapter(app as never);
+    const handler = jest.fn();
+
+    adapter.on("changed", handler);
+    // TFolder-like object — handler must NOT fire.
+    metaEvents.trigger("changed", { isFolder: true });
+    expect(handler).not.toHaveBeenCalled();
+
+    const file = new TFile("a.md");
+    metaEvents.trigger("changed", file);
+    expect(handler).toHaveBeenCalledWith({ path: "a.md" });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/integration/cache-invalidation.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/cache-invalidation.integration.test.ts
@@ -1,0 +1,294 @@
+/**
+ * RFC be70f741 Phase 4 — end-to-end cache invalidation integration.
+ *
+ * Scope: wire a live `RelationColumnSetRepository` to a live
+ * `RelationColumnSetResolver` through the same provider the production
+ * `ExocortexPlugin.onload` installs (`() => repo.getSnapshot().all`), and
+ * prove the five Phase 4 scenarios propagate from metadataCache event →
+ * debounce → rebuild → resolver result:
+ *
+ *   1. Add a new `ui__RelationColumnSet` config → resolver returns columns.
+ *   2. Modify an existing config → resolver reflects the new columns.
+ *   3. Delete a config → resolver returns `null` (renderer falls back to
+ *      the legacy hardcoded map).
+ *   4. Rename a config's vault path (uid unchanged) → asset remains
+ *      resolvable — end-to-end exercise of the Phase 4 adapter-fix
+ *      (`vault.on('rename')` ↔ `vault.offref`).
+ *   5. Batch-write three configs within the debounce window → exactly one
+ *      rebuild runs (150 ms trailing coalescing).
+ */
+
+import { RelationColumnSetResolver } from "exocortex";
+import {
+  RelationColumnSetRepository,
+  type RelationColumnSetEventHandler,
+  type RelationColumnSetVaultAdapter,
+} from "../../../src/infrastructure/repositories/RelationColumnSetRepository";
+
+// ── Test doubles ─────────────────────────────────────────────────────────────
+
+type FrontmatterMap = Record<string, Record<string, unknown>>;
+
+interface FakeAdapter extends RelationColumnSetVaultAdapter {
+  setFrontmatter(path: string, fm: Record<string, unknown>): void;
+  removeFrontmatter(path: string): void;
+  renameFrontmatter(oldPath: string, newPath: string): void;
+  fire(event: "changed" | "deleted" | "renamed", path: string): void;
+}
+
+function makeAdapter(initial: FrontmatterMap = {}): FakeAdapter {
+  const store: FrontmatterMap = { ...initial };
+  const listeners: Record<
+    "changed" | "deleted" | "renamed",
+    Set<RelationColumnSetEventHandler>
+  > = { changed: new Set(), deleted: new Set(), renamed: new Set() };
+
+  return {
+    getAllMarkdownPaths: () => Object.keys(store),
+    getFrontmatter: (path) => store[path] ?? null,
+    on(event, handler) {
+      listeners[event].add(handler);
+      return () => listeners[event].delete(handler);
+    },
+    setFrontmatter(path, fm) {
+      store[path] = fm;
+    },
+    removeFrontmatter(path) {
+      delete store[path];
+    },
+    renameFrontmatter(oldPath, newPath) {
+      if (store[oldPath]) {
+        store[newPath] = store[oldPath];
+        delete store[oldPath];
+      }
+    },
+    fire(event, path) {
+      for (const handler of listeners[event]) handler({ path });
+    },
+  };
+}
+
+interface FakeTimer {
+  readonly options: {
+    setTimer: (cb: () => void, ms: number) => unknown;
+    clearTimer: (handle: unknown) => void;
+  };
+  advance(ms: number): void;
+  readonly pending: () => number;
+}
+
+function makeTimer(): FakeTimer {
+  interface Entry {
+    id: number;
+    fireAt: number;
+    cb: () => void;
+  }
+  let now = 0;
+  let nextId = 1;
+  let entries: Entry[] = [];
+  return {
+    options: {
+      setTimer: (cb, ms) => {
+        const entry: Entry = { id: nextId++, fireAt: now + ms, cb };
+        entries.push(entry);
+        return entry.id;
+      },
+      clearTimer: (handle) => {
+        entries = entries.filter((e) => e.id !== handle);
+      },
+    },
+    advance(ms) {
+      now += ms;
+      const due = entries.filter((e) => e.fireAt <= now);
+      entries = entries.filter((e) => e.fireAt > now);
+      for (const e of due) e.cb();
+    },
+    pending: () => entries.length,
+  };
+}
+
+// ── Fixture helpers ──────────────────────────────────────────────────────────
+
+const CLASS_WIKILINK = "[[97fc9862-c886-4d86-9a60-e0cf9d778575|ui__RelationColumnSet]]";
+
+function weeklyObjectiveConfig(
+  uid: string,
+  columns: readonly string[] = ["[[exo__Asset_createdAt]]", "[[exo__Asset_label]]"],
+  priority = 0,
+): Record<string, unknown> {
+  return {
+    exo__Asset_uid: uid,
+    exo__Instance_class: [CLASS_WIKILINK],
+    ui__RelationColumnSet_targetClass: ["[[ems__WeeklyObjective]]"],
+    ui__RelationColumnSet_referencingProperty: "[[ems__WeeklyObjective__week]]",
+    ui__RelationColumnSet_columns: columns,
+    ui__RelationColumnSet_priority: priority,
+  };
+}
+
+interface Wired {
+  adapter: FakeAdapter;
+  timer: FakeTimer;
+  repo: RelationColumnSetRepository;
+  resolver: RelationColumnSetResolver;
+  warnings: string[];
+}
+
+function wire(initial: FrontmatterMap = {}): Wired {
+  const adapter = makeAdapter(initial);
+  const timer = makeTimer();
+  const warnings: string[] = [];
+  const logger = { warn: (m: string) => warnings.push(m) };
+  const repo = new RelationColumnSetRepository(adapter, {
+    logger,
+    ...timer.options,
+  });
+  repo.initialize();
+  // Mirror production wiring: provider closes over `repo.getSnapshot().all`
+  // so the resolver always sees the freshest published snapshot after each
+  // atomic swap (double-buffering guarantees existing readers are unaffected).
+  const resolver = new RelationColumnSetResolver(
+    () => repo.getSnapshot().all,
+    { logger },
+  );
+  return { adapter, timer, repo, resolver, warnings };
+}
+
+const ROW_CLASSES = ["[[ems__WeeklyObjective]]"];
+const GROUP_PROP = "[[ems__WeeklyObjective__week]]";
+
+// ── Scenarios ────────────────────────────────────────────────────────────────
+
+describe("Phase 4 cache invalidation — add/modify/delete/rename/batch", () => {
+  test("S1: add new ui__RelationColumnSet config → columns flow to resolver", () => {
+    const { adapter, timer, resolver } = wire();
+
+    // Baseline — empty vault, resolver reports no match (renderer falls back).
+    expect(resolver.resolve(ROW_CLASSES, GROUP_PROP)).toBeNull();
+
+    // User drops a config file into the vault.
+    adapter.setFrontmatter("configs/weekly.md", weeklyObjectiveConfig("wo-1"));
+    adapter.fire("changed", "configs/weekly.md");
+
+    // Before the debounce elapses, the snapshot is still the baseline.
+    expect(resolver.resolve(ROW_CLASSES, GROUP_PROP)).toBeNull();
+
+    // After 150 ms the rebuild runs and publishes the new snapshot.
+    timer.advance(150);
+
+    const resolved = resolver.resolve(ROW_CLASSES, GROUP_PROP);
+    expect(resolved).not.toBeNull();
+    expect(resolved?.uid).toBe("wo-1");
+    // Columns are preserved verbatim (the resolver's consumer — the renderer —
+    // treats them as opaque refs and does the final lookup downstream).
+    expect(resolved?.columns).toEqual([
+      "[[exo__Asset_createdAt]]",
+      "[[exo__Asset_label]]",
+    ]);
+  });
+
+  test("S2: modify existing config → resolver reflects new columns", () => {
+    const { adapter, timer, resolver } = wire({
+      "configs/weekly.md": weeklyObjectiveConfig("wo-1"),
+    });
+
+    const before = resolver.resolve(ROW_CLASSES, GROUP_PROP);
+    expect(before?.columns).toEqual([
+      "[[exo__Asset_createdAt]]",
+      "[[exo__Asset_label]]",
+    ]);
+
+    // User reorders columns — uid stays, columns change.
+    adapter.setFrontmatter(
+      "configs/weekly.md",
+      weeklyObjectiveConfig("wo-1", [
+        "[[exo__Asset_label]]",
+        "[[ems__Effort_status]]",
+      ]),
+    );
+    adapter.fire("changed", "configs/weekly.md");
+    timer.advance(150);
+
+    const after = resolver.resolve(ROW_CLASSES, GROUP_PROP);
+    expect(after?.uid).toBe("wo-1");
+    expect(after?.columns).toEqual([
+      "[[exo__Asset_label]]",
+      "[[ems__Effort_status]]",
+    ]);
+  });
+
+  test("S3: delete config → resolver returns null (legacy fallback path)", () => {
+    const { adapter, timer, resolver } = wire({
+      "configs/weekly.md": weeklyObjectiveConfig("wo-1"),
+    });
+
+    expect(resolver.resolve(ROW_CLASSES, GROUP_PROP)?.uid).toBe("wo-1");
+
+    adapter.removeFrontmatter("configs/weekly.md");
+    adapter.fire("deleted", "configs/weekly.md");
+    timer.advance(150);
+
+    expect(resolver.resolve(ROW_CLASSES, GROUP_PROP)).toBeNull();
+  });
+
+  test("S4: rename — asset stays resolvable, sourcePath tracks the new path", () => {
+    const { adapter, timer, repo, resolver } = wire({
+      "configs/weekly.md": weeklyObjectiveConfig("wo-1"),
+    });
+
+    expect(repo.getSnapshot().byUid.get("wo-1")?.sourcePath).toBe(
+      "configs/weekly.md",
+    );
+
+    adapter.renameFrontmatter("configs/weekly.md", "configs/renamed.md");
+    adapter.fire("renamed", "configs/renamed.md");
+    timer.advance(150);
+
+    // Snapshot still has the uid (index is uid-keyed, not path-keyed) and the
+    // new path is reflected in sourcePath.
+    const after = repo.getSnapshot().byUid.get("wo-1");
+    expect(after).toBeDefined();
+    expect(after?.sourcePath).toBe("configs/renamed.md");
+
+    // Resolver still routes rowClass+property to the same config.
+    expect(resolver.resolve(ROW_CLASSES, GROUP_PROP)?.uid).toBe("wo-1");
+  });
+
+  test("S5: batch write 3 files within debounce window → exactly 1 rebuild", () => {
+    const { adapter, timer, repo, resolver } = wire();
+
+    const defaultCols = [
+      "[[exo__Asset_createdAt]]",
+      "[[exo__Asset_label]]",
+    ];
+    adapter.setFrontmatter("configs/a.md", weeklyObjectiveConfig("a", defaultCols, 0));
+    adapter.fire("changed", "configs/a.md");
+    adapter.setFrontmatter("configs/b.md", weeklyObjectiveConfig("b", defaultCols, 2));
+    adapter.fire("changed", "configs/b.md");
+    adapter.setFrontmatter("configs/c.md", weeklyObjectiveConfig("c", defaultCols, 1));
+    adapter.fire("changed", "configs/c.md");
+
+    // Three event bursts yield a single pending timer (each fresh event
+    // cancels the previous trailing timer — classic debounce trailing edge).
+    expect(timer.pending()).toBe(1);
+
+    // Halfway through the window — still pending, snapshot unchanged.
+    timer.advance(100);
+    expect(timer.pending()).toBe(1);
+    expect(resolver.resolve(ROW_CLASSES, GROUP_PROP)).toBeNull();
+
+    // Past the trailing edge — rebuild fires once and publishes all three.
+    timer.advance(60);
+    expect(timer.pending()).toBe(0);
+
+    // All three configs must be indexed in the same snapshot → proof that a
+    // single rebuild absorbed the burst.
+    const uids = [...repo.getSnapshot().byUid.keys()].sort();
+    expect(uids).toEqual(["a", "b", "c"]);
+
+    // Tier-1 collision on {a, b, c}; deterministic tiebreaker
+    // `priority DESC → uid ASC` picks the highest-priority match — `b`.
+    const picked = resolver.resolve(ROW_CLASSES, GROUP_PROP);
+    expect(picked?.uid).toBe("b");
+  });
+});


### PR DESCRIPTION
## Summary
Closes RFC be70f741 Phase 4 — integration coverage for cache invalidation, user-facing docs, and a silent listener-leak fix in the Obsidian adapter. No production behaviour regression: Phase 1 already wired up `changed`/`deleted`/`renamed` subscriptions + 150 ms debounce + double-buffering; this PR adds the tests, the docs, and a one-line scope-expanded leak fix.

## Adapter listener-leak fix (scope expansion, approved by orchestrator)
`ObsidianRelationColumnSetAdapter` routed every `offref` call through `metadataCache.offref(eventRef)` — but the rename branch subscribed via `vault.on('rename', …)`. `vault.on` and `metadataCache.on` are separate `Events` instances, so `metadataCache.offref` silently no-op'd the vault-side listener, leaking a handler on every plugin unload→load cycle. Each branch now calls the matching `<target>.offref(eventRef)`.

Covered by 5 unit tests in `ObsidianRelationColumnSetAdapter.test.ts` with realistic `TFile` payloads catching event-shape drift between mock and Obsidian API (per orchestrator requirement).

## Integration coverage (cache-invalidation.integration.test.ts)
5 end-to-end scenarios walking event → debounce → rebuild → resolver:

1. **Add** new `ui__RelationColumnSet` config → resolver returns the columns.
2. **Modify** existing config → resolver reflects the new columns.
3. **Delete** config → resolver returns `null` (renderer falls back to legacy map).
4. **Rename** (path change, uid unchanged) → `sourcePath` tracks new path. End-to-end exercise of the adapter fix (`vault.on('rename')` ↔ `vault.offref`).
5. **Batch write** 3 configs inside 150 ms window → exactly **1** rebuild fires (debounce trailing-edge coalescing).

## Docs + CI gate (M5 falsifiable usability)
- `docs/RELATION_COLUMN_SET.md` — 2-paragraph overview + copy-pasteable YAML example + 4-tier priority ladder + coexistence rules with `exo__TableLayout` + feature-flag description + troubleshooting for every `log.warn` path.
- `tests/component/docs-example-renders.spec.tsx` — parses the docs YAML through the production pipeline (`createRelationColumnSetFromFrontmatter` → `RelationColumnSetResolver`) and mounts `AssetRelationsTable` with the resolver-derived columns. Any silent break in the docs example fails CI.

## Hot-reload verification substitution (per orchestrator)
Live-vault computer-control verification was blocked by `v15.105.6` plugin lag in `/Users/kitelev/vault-2025` (Phase 1 first shipped in `v15.117.0`). Integration scenarios 1 + 5 exercise the exact `metadataCache.on → debounce → rebuild → snapshot` path; live-vault sanity-check deferred to the next vault plugin auto-update cycle — documented as non-blocking follow-up.

## Starter-kit fixture
Shipping in parallel via `kitelev/exocortex-starter-kit#84` (MERGED) — MVG fixture `Task ← Project` (uses classes every starter-kit user has). Docs here use `WeeklyObjective ← Week` for conceptual clarity per RFC motivating case.

## Tests
| Suite | Result |
| --- | --- |
| `npm run test:unit` | 127/127 green (exocortex regression subset + CLI + obsidian-plugin) |
| `npm run test:ui` | 53/53 green |
| `npm run test:component` | 547 passed (1 pre-existing flake on `RenderingPerformance.spec.tsx` — isolated retry green, CI retries=2) |
| `npm run check:types` | green |

## Checklist
- [x] Integration scenarios 1-5 green
- [x] Adapter subscribe/unsubscribe symmetry unit tests (5/5) with TFile payload
- [x] `docs/RELATION_COLUMN_SET.md` copy-pasteable example
- [x] `docs-example-renders.spec.tsx` green locally
- [x] Starter-kit fixture merged (#84)
- [x] Hot-reload AC substituted with integration Scenario 1+5 evidence (per orchestrator)
- [ ] Auto Release publishes v15.120.0 (post-merge verification)

## Test plan
- [ ] All 13 required CI checks green
- [ ] Auto Release workflow publishes a new version
- [ ] Post-merge sanity: `gh run list --workflow "Auto Release" --limit 1` shows success

## Related
- Parent project: `489e297d-069f-4144-a538-dce81da18d0f`
- Task: `c5bc00f3-fd60-48c4-8a24-c27f9f7a841f`
- RFC: `be70f741-a8e3-4826-aab1-d3f950068861`
- Starter-kit PR: kitelev/exocortex-starter-kit#84 (MERGED)