### PR TITLE
fix(relcolset): consolidate normalizers on WikiLinkHelpers.normalize (closes #2941, #2942)

### DIFF
--- a/packages/exocortex/src/domain/layout/RelationColumnSet.ts
+++ b/packages/exocortex/src/domain/layout/RelationColumnSet.ts
@@ -13,6 +13,8 @@
  * @since 15.x (RFC be70f741-a8e3-4826-aab1-d3f950068861 Phase 1)
  */
 
+import { WikiLinkHelpers } from "../../utilities/WikiLinkHelpers";
+
 export interface RelationColumnSet {
   readonly uid: string;
   readonly label: string;
@@ -23,19 +25,30 @@ export interface RelationColumnSet {
   readonly sourcePath: string;
 }
 
+/**
+ * Normalize a wikilink or raw identifier to its canonical string form, or
+ * `null` when the input cannot be normalized.
+ *
+ * Delegates to {@link WikiLinkHelpers.normalize} so the resolver + repository
+ * share the SAME wikilink semantics as every other `@exocortex/core` consumer
+ * (issue #2941 — prior asymmetric "before-pipe wins" behaviour caused
+ * `ui__RelationColumnSet` match failures for starter-kit-style
+ * `[[uuid|alias]]` frontmatter).
+ *
+ * Behaviour (via `WikiLinkHelpers.normalize`):
+ * - `"[[ems__Area]]"` → `"ems__Area"`
+ * - `"[[UUID|ems__Area]]"` → `"ems__Area"` (UUID target ⇒ alias wins)
+ * - `"[[Some Note|Display]]"` → `"Some Note"` (non-UUID target ⇒ target wins)
+ *
+ * Preserves the `string | null` contract of the original function: returns
+ * `null` for non-string inputs, empty strings, and wikilinks whose inner text
+ * collapses to empty (e.g. `"[[|alias]]"`).
+ */
 export function normalizeRef(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
   }
-  const trimmed = value.trim();
-  if (trimmed.length === 0) {
-    return null;
-  }
-  const wikilinkMatch = trimmed.match(/^\[\[([^\]]+)\]\]$/);
-  const inner = wikilinkMatch ? wikilinkMatch[1] : trimmed;
-  const aliasSeparator = inner.indexOf("|");
-  const bare = aliasSeparator >= 0 ? inner.slice(0, aliasSeparator) : inner;
-  const normalized = bare.trim();
+  const normalized = WikiLinkHelpers.normalize(value);
   return normalized.length > 0 ? normalized : null;
 }
 
@@ -103,8 +116,20 @@ export function createRelationColumnSetFromFrontmatter(
     return null;
   }
 
+  // Normalize column entries through the shared wikilink normalizer so
+  // downstream consumers (`AssetRelationsTable`, `RelationsRenderer`) receive
+  // bare property names even when the frontmatter uses starter-kit-style
+  // wikilink forms (`[[exo__Asset_createdAt]]`, `[[UUID|exo__Asset_label]]`).
+  // Issue #2942 — raw wikilinks were previously passed through as literal
+  // React metadata keys, yielding undefined column values.
   const columnsRaw = toStringArray(frontmatter["ui__RelationColumnSet_columns"]);
-  const columns = columnsRaw.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+  const columns: string[] = [];
+  for (const entry of columnsRaw) {
+    const normalized = WikiLinkHelpers.normalize(entry);
+    if (normalized.length > 0) {
+      columns.push(normalized);
+    }
+  }
   if (columns.length === 0) {
     warn(
       `RelationColumnSet ${uid}: columns array must contain at least one entry (${sourcePath})`,

--- a/packages/exocortex/tests/application/services/RelationColumnSetResolver.test.ts
+++ b/packages/exocortex/tests/application/services/RelationColumnSetResolver.test.ts
@@ -350,13 +350,13 @@ describe("RelationColumnSetResolver — normalization roundtrip", () => {
     expect(resolver.resolve(rowClasses, "P")).toBe(config);
   });
 
-  it("wikilink with internal brackets drops the unmatched trailing part via trim", () => {
-    // `normalizeRef` expects matched `[[...]]`. A malformed `[[C` is not a
-    // wikilink match → treated as raw, resulting in literal `[[C` which will
-    // not match config `C`.
+  it("malformed half-wikilink is tolerated — outer brackets stripped (delegates to WikiLinkHelpers)", () => {
+    // After issue #2941 consolidation, `normalizeRef` delegates to
+    // `WikiLinkHelpers.normalize`, which permissively strips any `[[` / `]]`
+    // substrings.  `"[[C"` therefore collapses to `"C"` and matches config `C`.
     const config = mk({ targetClasses: ["C"], referencingProperty: "P" });
     const resolver = new RelationColumnSetResolver(() => [config]);
-    expect(resolver.resolve(["[[C"], "P")).toBeNull();
+    expect(resolver.resolve(["[[C"], "P")).toBe(config);
   });
 
   it("null rowClass element skipped gracefully (type-cast)", () => {
@@ -505,5 +505,59 @@ describe("RelationColumnSetResolver — logger default (no options)", () => {
     const b = mk({ uid: "b", targetClasses: ["C"], referencingProperty: "P", priority: 5 });
     const resolver = new RelationColumnSetResolver(() => [a, b], {});
     expect(resolver.resolve(["C"], "P")).toBe(a);
+  });
+});
+
+describe("RelationColumnSetResolver — wikilink pipe-order matrix (issue #2941)", () => {
+  // Config-side `targetClasses` / `referencingProperty` are already normalized
+  // by `createRelationColumnSetFromFrontmatter` before reaching the resolver.
+  // Row-side inputs (`exo__Instance_class`, backlink property) arrive RAW from
+  // Obsidian's `metadataCache`, so the resolver MUST normalize them through
+  // the same `WikiLinkHelpers.normalize` semantics — issue #2941 fix.
+  const TARGET_CLASS = "ems__WeeklyObjective";
+  const PROPERTY = "ems__WeeklyObjective__week";
+  const UUID_CLS = "5bc8d83d-34e4-4c2d-86e4-0c7dd30a2a12";
+  const UUID_PROP = "8f3b9e12-4a7c-4f2e-9b1a-3c4d5e6f7a8b";
+
+  const classForms: readonly { readonly label: string; readonly input: string }[] = [
+    { label: "bare", input: TARGET_CLASS },
+    { label: "[[name]]", input: `[[${TARGET_CLASS}]]` },
+    { label: "[[name|uuid]] (basename-first)", input: `[[${TARGET_CLASS}|${UUID_CLS}]]` },
+    { label: "[[uuid|name]] (starter-kit pipe order)", input: `[[${UUID_CLS}|${TARGET_CLASS}]]` },
+  ];
+
+  const propertyForms: readonly { readonly label: string; readonly input: string }[] = [
+    { label: "bare", input: PROPERTY },
+    { label: "[[name]]", input: `[[${PROPERTY}]]` },
+    { label: "[[name|uuid]] (basename-first)", input: `[[${PROPERTY}|${UUID_PROP}]]` },
+    { label: "[[uuid|name]] (starter-kit pipe order)", input: `[[${UUID_PROP}|${PROPERTY}]]` },
+  ];
+
+  for (const cls of classForms) {
+    for (const prop of propertyForms) {
+      it(`row class=${cls.label} × property=${prop.label} → Tier-1 match`, () => {
+        const config = mk({
+          uid: "matrix",
+          targetClasses: [TARGET_CLASS],
+          referencingProperty: PROPERTY,
+        });
+        const resolver = new RelationColumnSetResolver(() => [config]);
+        expect(resolver.resolve([cls.input], prop.input)).toBe(config);
+      });
+    }
+  }
+
+  // Symmetric: config frontmatter in starter-kit pipe order matches plain row.
+  it("config parsed from starter-kit-style `[[uuid|name]]` matches bare row", () => {
+    // Simulate what `createRelationColumnSetFromFrontmatter` produces after
+    // normalization: bare `TARGET_CLASS` in `targetClasses`.  (The resolver
+    // itself receives already-normalized config strings by contract.)
+    const config = mk({
+      uid: "sym",
+      targetClasses: [TARGET_CLASS],
+      referencingProperty: PROPERTY,
+    });
+    const resolver = new RelationColumnSetResolver(() => [config]);
+    expect(resolver.resolve([TARGET_CLASS], PROPERTY)).toBe(config);
   });
 });

--- a/packages/exocortex/tests/domain/layout/RelationColumnSet.test.ts
+++ b/packages/exocortex/tests/domain/layout/RelationColumnSet.test.ts
@@ -24,8 +24,27 @@ describe("normalizeRef", () => {
     expect(normalizeRef("[[foo]]")).toBe("foo");
   });
 
-  test("strips alias after pipe", () => {
+  test("non-UUID target — target wins (alias is display-only)", () => {
+    // `uuid` here is a literal identifier string, NOT a UUID pattern.
     expect(normalizeRef("[[uuid|Display Name]]")).toBe("uuid");
+    expect(normalizeRef("[[Some Note|Display Label]]")).toBe("Some Note");
+  });
+
+  test("UUID target — alias wins (starter-kit `[[UUID|className]]` form)", () => {
+    // Post issue #2941: wikilinks where the target matches the UUID regex
+    // now normalize to the alias (the canonical class identifier), matching
+    // `WikiLinkHelpers.normalize` semantics across the rest of `@exocortex/core`.
+    expect(
+      normalizeRef("[[82c74542-1b14-4217-b852-d84730484b25|ems__Area]]"),
+    ).toBe("ems__Area");
+    expect(
+      normalizeRef("[[1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task]]"),
+    ).toBe("ems__Task");
+    expect(
+      normalizeRef(
+        "[[97fc9862-c886-4d86-9a60-e0cf9d778575|ui__RelationColumnSet]]",
+      ),
+    ).toBe("ui__RelationColumnSet");
   });
 
   test("preserves raw identifier when no wikilink", () => {
@@ -59,6 +78,41 @@ describe("normalizeRef", () => {
   });
 });
 
+describe("normalizeRef — 4×3 pipe-order matrix (issue #2941)", () => {
+  // Every frontmatter form produced by vault-2025 / starter-kit MUST collapse
+  // to the same canonical identifier regardless of pipe order.  Matrix: 4
+  // wikilink forms × 3 role fields (targetClass / referencingProperty /
+  // column entry) = 12 equivalence assertions.
+  const UUID = "97fc9862-c886-4d86-9a60-e0cf9d778575";
+
+  interface MatrixCase {
+    readonly form: "bare" | "[[name]]" | "[[name|uuid]]" | "[[uuid|name]]";
+    readonly input: string;
+  }
+
+  const roles: readonly ({ readonly name: string; readonly canonical: string })[] = [
+    { name: "targetClass — ems__WeeklyObjective", canonical: "ems__WeeklyObjective" },
+    { name: "referencingProperty — ems__WeeklyObjective__week", canonical: "ems__WeeklyObjective__week" },
+    { name: "column entry — exo__Asset_createdAt", canonical: "exo__Asset_createdAt" },
+  ];
+
+  for (const role of roles) {
+    const cases: readonly MatrixCase[] = [
+      { form: "bare", input: role.canonical },
+      { form: "[[name]]", input: `[[${role.canonical}]]` },
+      // basename-first: non-UUID target wins; alias `UUID` is display-only.
+      { form: "[[name|uuid]]", input: `[[${role.canonical}|${UUID}]]` },
+      // starter-kit pipe order: UUID target ⇒ alias (canonical name) wins.
+      { form: "[[uuid|name]]", input: `[[${UUID}|${role.canonical}]]` },
+    ];
+    for (const c of cases) {
+      test(`${role.name} in ${c.form} form → "${role.canonical}"`, () => {
+        expect(normalizeRef(c.input)).toBe(role.canonical);
+      });
+    }
+  }
+});
+
 describe("createRelationColumnSetFromFrontmatter — happy path", () => {
   test("parses a fully-populated asset", () => {
     const { warn, messages } = makeWarn();
@@ -78,12 +132,14 @@ describe("createRelationColumnSetFromFrontmatter — happy path", () => {
     );
 
     expect(result).not.toBeNull();
+    // `columns` MUST be bare property names (issue #2942): raw wikilinks were
+    // previously passed as-is, so React used `"[[prop]]"` as a metadata key.
     expect(result).toEqual({
       uid: "6533ca08-uid",
       label: "Week → WeeklyObjective",
       targetClasses: ["ems__WeeklyObjective"],
       referencingProperty: "ems__WeeklyObjective__week",
-      columns: ["[[exo__Asset_createdAt]]", "[[exo__Asset_label]]"],
+      columns: ["exo__Asset_createdAt", "exo__Asset_label"],
       priority: 10,
       sourcePath: SOURCE_PATH,
     });
@@ -195,6 +251,69 @@ describe("createRelationColumnSetFromFrontmatter — happy path", () => {
     );
     expect(result?.targetClasses).toEqual(["X"]);
     expect(result?.referencingProperty).toBeNull();
+  });
+});
+
+describe("createRelationColumnSetFromFrontmatter — column normalization (issue #2942)", () => {
+  const UUID = "5bc8d83d-34e4-4c2d-86e4-0c7dd30a2a12";
+
+  test("mixed column forms all collapse to bare property names", () => {
+    const { warn } = makeWarn();
+    const result = createRelationColumnSetFromFrontmatter(
+      {
+        exo__Asset_uid: "cols-mixed",
+        ui__RelationColumnSet_targetClass: ["[[ems__Task]]"],
+        ui__RelationColumnSet_columns: [
+          "[[exo__Asset_createdAt]]", // plain wikilink
+          "[[exo__Asset_label]]", // plain wikilink
+          "exo__Asset_uid", // bare property name
+          `[[${UUID}|exo__Effort_status]]`, // starter-kit: UUID target ⇒ alias
+          "[[ems__Task_priority|human label]]", // non-UUID target ⇒ target
+        ],
+      },
+      { sourcePath: SOURCE_PATH, warn },
+    );
+    expect(result?.columns).toEqual([
+      "exo__Asset_createdAt",
+      "exo__Asset_label",
+      "exo__Asset_uid",
+      "exo__Effort_status",
+      "ems__Task_priority",
+    ]);
+  });
+
+  test("empty/blank column entries are dropped after normalization", () => {
+    const { warn, messages } = makeWarn();
+    const result = createRelationColumnSetFromFrontmatter(
+      {
+        exo__Asset_uid: "cols-filtered",
+        ui__RelationColumnSet_targetClass: ["[[ems__Task]]"],
+        ui__RelationColumnSet_columns: [
+          "",
+          "   ",
+          "[[]]",
+          "[[|only-alias]]",
+          "exo__Asset_label",
+        ],
+      },
+      { sourcePath: SOURCE_PATH, warn },
+    );
+    expect(result?.columns).toEqual(["exo__Asset_label"]);
+    expect(messages).toHaveLength(0);
+  });
+
+  test("all columns degenerate to empty → reject with warn", () => {
+    const { warn, messages } = makeWarn();
+    const result = createRelationColumnSetFromFrontmatter(
+      {
+        exo__Asset_uid: "cols-all-blank",
+        ui__RelationColumnSet_targetClass: ["[[ems__Task]]"],
+        ui__RelationColumnSet_columns: ["[[]]", "[[|x]]", "   "],
+      },
+      { sourcePath: SOURCE_PATH, warn },
+    );
+    expect(result).toBeNull();
+    expect(messages[0]).toMatch(/columns array/);
   });
 });
 

--- a/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
+++ b/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
@@ -42,6 +42,31 @@ class wikilink in `exo__Instance_class` is mandatory for discovery; every
 `ui__RelationColumnSet_*` field is validated on parse with a `log.warn` on
 malformed input — invalid assets are skipped, never thrown.
 
+### Wikilink forms — canonical normalization
+
+Every wikilink field (`ui__RelationColumnSet_targetClass`,
+`ui__RelationColumnSet_referencingProperty`, each entry in
+`ui__RelationColumnSet_columns`) is normalized through
+`WikiLinkHelpers.normalize` before it reaches the resolver. All four
+frontmatter forms below are therefore equivalent:
+
+- `ems__WeeklyObjective` (bare identifier — valid for matching but Obsidian
+  won't autocomplete it)
+- `[[ems__WeeklyObjective]]` (plain wikilink — recommended for the
+  copy-pasteable example above)
+- `[[ems__WeeklyObjective|Weekly Objective]]` (non-UUID target ⇒ target
+  wins, alias is display-only)
+- `[[97fc9862-c886-4d86-9a60-e0cf9d778575|ems__WeeklyObjective]]` (starter-kit
+  convention — UUID target ⇒ alias wins, starter-kit assets use this form)
+
+Row-side `exo__Instance_class` values from the vault are normalized under
+the same rules, so a `ui__RelationColumnSet` config parsed in any form
+above matches a row in any form above — no pipe-order mirroring needed.
+
+The `columns` array receives the same normalization: every entry is reduced
+to a bare property name before the React renderer looks it up against the
+row frontmatter (e.g. `[[exo__Asset_createdAt]]` → `exo__Asset_createdAt`).
+
 ## Priority ladder
 
 The resolver matches one config per (rowClass, referencingProperty) pair.

--- a/packages/obsidian-plugin/tests/component/docs-example-renders.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/docs-example-renders.spec.tsx
@@ -67,24 +67,19 @@ test.describe("docs/RELATION_COLUMN_SET.md example renders", () => {
 
     expect(docsConfig.targetClasses).toEqual(["ems__WeeklyObjective"]);
     expect(docsConfig.referencingProperty).toBe("ems__WeeklyObjective__week");
+    // Post issue #2942: columns are normalized to bare property names during
+    // parse, so the renderer can index frontmatter directly with no transform.
     expect(docsConfig.columns).toEqual([
-      "[[exo__Asset_createdAt]]",
-      "[[exo__Asset_label]]",
+      "exo__Asset_createdAt",
+      "exo__Asset_label",
     ]);
 
     const resolver = new RelationColumnSetResolver(() => [docsConfig]);
     const resolved = resolver.resolve(ROW_CLASSES, GROUP_PROP);
     expect(resolved?.uid).toBe(docsConfig.uid);
 
-    // Strip wikilink wrapping — AssetRelationsTable expects bare property
-    // names for column header lookup (the renderer does the same transform
-    // in `buildGroupSpecificProperties`).
-    const columnPropertyNames = resolved!.columns.map((col) => {
-      const m = col.match(/^\[\[([^|\]]+)(?:\|[^\]]+)?\]\]$/);
-      return m ? m[1] : col;
-    });
     const groupSpecificProperties = {
-      ems__WeeklyObjective__week: columnPropertyNames,
+      ems__WeeklyObjective__week: [...resolved!.columns],
     };
 
     const component = await mount(

--- a/packages/obsidian-plugin/tests/unit/infrastructure/repositories/RelationColumnSetRepository.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/repositories/RelationColumnSetRepository.test.ts
@@ -148,6 +148,34 @@ describe("RelationColumnSetRepository — initial scan", () => {
     expect(adapter.listenerCount("deleted")).toBe(1);
     expect(adapter.listenerCount("renamed")).toBe(1);
   });
+
+  test("snapshot columns normalized via WikiLinkHelpers (issue #2942)", () => {
+    // Post issue #2942 fix: columns produced by
+    // `createRelationColumnSetFromFrontmatter` MUST be bare property names so
+    // React's `metadata[column]` lookup succeeds.  Wikilink + UUID-alias +
+    // mixed-form inputs all collapse to the canonical identifier.
+    const UUID = "5bc8d83d-34e4-4c2d-86e4-0c7dd30a2a12";
+    const adapter = makeAdapter({
+      "cols.md": validConfig("uid-cols", {
+        ui__RelationColumnSet_columns: [
+          "[[exo__Asset_createdAt]]",
+          "[[exo__Asset_label]]",
+          "exo__Asset_uid",
+          `[[${UUID}|exo__Effort_status]]`,
+        ],
+      }),
+    });
+    const repo = new RelationColumnSetRepository(adapter, makeTimer());
+    repo.initialize();
+
+    const entry = repo.getSnapshot().byUid.get("uid-cols");
+    expect(entry?.columns).toEqual([
+      "exo__Asset_createdAt",
+      "exo__Asset_label",
+      "exo__Asset_uid",
+      "exo__Effort_status",
+    ]);
+  });
 });
 
 describe("RelationColumnSetRepository — event debouncing", () => {

--- a/packages/obsidian-plugin/tests/unit/integration/cache-invalidation.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/cache-invalidation.integration.test.ts
@@ -179,11 +179,11 @@ describe("Phase 4 cache invalidation — add/modify/delete/rename/batch", () => 
     const resolved = resolver.resolve(ROW_CLASSES, GROUP_PROP);
     expect(resolved).not.toBeNull();
     expect(resolved?.uid).toBe("wo-1");
-    // Columns are preserved verbatim (the resolver's consumer — the renderer —
-    // treats them as opaque refs and does the final lookup downstream).
+    // Columns normalize to bare property names (post #2942) so React's
+    // `metadata[column]` lookup on the row frontmatter succeeds.
     expect(resolved?.columns).toEqual([
-      "[[exo__Asset_createdAt]]",
-      "[[exo__Asset_label]]",
+      "exo__Asset_createdAt",
+      "exo__Asset_label",
     ]);
   });
 
@@ -194,8 +194,8 @@ describe("Phase 4 cache invalidation — add/modify/delete/rename/batch", () => 
 
     const before = resolver.resolve(ROW_CLASSES, GROUP_PROP);
     expect(before?.columns).toEqual([
-      "[[exo__Asset_createdAt]]",
-      "[[exo__Asset_label]]",
+      "exo__Asset_createdAt",
+      "exo__Asset_label",
     ]);
 
     // User reorders columns — uid stays, columns change.
@@ -212,8 +212,8 @@ describe("Phase 4 cache invalidation — add/modify/delete/rename/batch", () => 
     const after = resolver.resolve(ROW_CLASSES, GROUP_PROP);
     expect(after?.uid).toBe("wo-1");
     expect(after?.columns).toEqual([
-      "[[exo__Asset_label]]",
-      "[[ems__Effort_status]]",
+      "exo__Asset_label",
+      "ems__Effort_status",
     ]);
   });
 


### PR DESCRIPTION
## Summary

Consolidates `ui__RelationColumnSet` wikilink normalization on the shared
`WikiLinkHelpers.normalize` so the resolver + repository match rows regardless
of pipe order and React receives bare property names for the columns array.

One PR bundles both P0 defects — the shared root cause is a Phase 2 child
Claude that rolled its own `normalizeRef` in
`packages/exocortex/src/domain/layout/RelationColumnSet.ts` instead of
delegating to `WikiLinkHelpers.normalize`. That rolled normalizer always
returned the before-pipe portion, which diverges from
`WikiLinkHelpers.normalize` semantics established by PR #2768 / v15.90.13
(UUID target ⇒ alias wins; non-UUID target ⇒ target wins). Starter-kit vaults
use `[[UUID|className]]` on the row while the config used
`[[className|UUID]]`, so match silently failed and columns were passed through
verbatim.

Closes #2941
Closes #2942

### Clarification on the issue-body wording

Issue #2941's acceptance criteria literally say "grep for `function xi`
returns 0 hits". In the shipped codebase the local normalizer is named
`normalizeRef`, not `xi` — `function xi` already returns 0 hits today. The
AC is paraphrased from an earlier draft; this PR fixes the intent (the
asymmetric normalizer) rather than the literal identifier.

## Changes

- `packages/exocortex/src/domain/layout/RelationColumnSet.ts`
  - `normalizeRef` now delegates to `WikiLinkHelpers.normalize`, preserving
    the `string | null` contract (option A — no call-site churn, no
    breaking change to the `normalizeRelationColumnSetRef` re-export).
  - `createRelationColumnSetFromFrontmatter` runs every column entry through
    `WikiLinkHelpers.normalize` so `snapshot.columns` holds bare property
    names (fixes #2942).
- Tests
  - `packages/exocortex/tests/domain/layout/RelationColumnSet.test.ts`
    - 4-form × 3-role matrix (12 cases) for `normalizeRef`: every
      wikilink form produced by the vault collapses to the canonical
      identifier for every role field.
    - Explicit UUID-alias coverage for starter-kit frontmatter shape
      `[[97fc9862-…|ui__RelationColumnSet]]` → `ui__RelationColumnSet`.
    - Mixed-form column normalization + "all columns degenerate to empty →
      rejected" path. Updated the one existing fixture that pinned raw
      `[[prop]]` wikilinks into `snapshot.columns`.
  - `packages/exocortex/tests/application/services/RelationColumnSetResolver.test.ts`
    - 4×4 matrix (16 cases) covering all row-side class × property pipe-order
      combinations — every permutation produces a Tier-1 match.
    - Updated the malformed-wikilink test: after consolidation, `[[C`
      (half-bracket) permissively collapses to `C` (delegated to
      `WikiLinkHelpers.normalize`'s global strip) and matches config `C`
      instead of returning null.
  - `packages/obsidian-plugin/tests/unit/infrastructure/repositories/RelationColumnSetRepository.test.ts`
    - Snapshot-level assertion: mixed wikilink + UUID-alias + bare
      column entries all normalize inside the repository's snapshot.
- `packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md` — documents the
  four equivalent wikilink forms and the canonical-column-name guarantee.

## Test plan

- [x] `npx jest … RelationColumnSet` (obsidian-plugin config) — 37 passed
- [x] `npx jest … RelationColumnSet` (exocortex config) — 121 passed (+
  performance p95 <1 ms still green)
- [x] `./scripts/test-ci-batched.sh` — exit 0 (obsidian-plugin + CLI +
  exocortex narrow allow-list all passed)
- [x] `npm run check:types` — exit 0
- [x] `npm run lint` — exit 0 (pre-existing warnings/errors in unrelated
  files; no regressions from this diff)
- [ ] CI — 13 required checks + post-merge Auto Release
- [ ] Live-test — create `ui__RelationColumnSet` config in vault-2025 with
  starter-kit `[[UUID|className]]` pipe order; confirm columns render
  without manual pipe-flip