### PR TITLE
feat(ontology): bootstrap ui__RelationColumnSet ontology on plugin load (#2943)

### DIFF
--- a/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
+++ b/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
@@ -12,6 +12,25 @@ off, or no matching config exists, the renderer transparently falls back to
 the original hardcoded map — the feature is purely additive and opt-in per
 (rowClass, referencingProperty) pair.
 
+## Initial setup — zero-friction ontology bootstrap
+
+The plugin installs the 7 required ontology assets (`!ui` ontology root,
+`ui__RelationColumnSet` class, and 5 `ui__RelationColumnSet_*` properties)
+automatically on `onload`, so a fresh personal vault does not need any
+manual copy from `kitelev/exocortex-starter-kit`. Target folder:
+`_exocortex-ui-ontology/` — one UUID-named file per asset, following the
+starter-kit convention.
+
+Bootstrap is idempotent — files already present at the target path are
+skipped, so upgrading the plugin (or opening a vault where the ontology was
+pre-installed) does not create duplicates, overwrite customisation, or log
+warnings on subsequent loads. If you moved the 7 files to a different
+folder in your vault, the plugin will still install a fresh copy at
+`_exocortex-ui-ontology/`; delete whichever copy you prefer to keep one
+canonical location (duplicate `exo__Asset_uid` values are flagged by
+`RelationColumnSetRepository: duplicate exo__Asset_uid` warnings — see
+Troubleshooting below).
+
 ## Copy-pasteable example
 
 Create a new note anywhere in the vault (e.g.

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -64,6 +64,8 @@ import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
 import { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService";
 import { ObsidianFileSystemAdapter } from "./adapters/ObsidianFileSystemAdapter";
 import { populateServiceRegistry } from "./infrastructure/services/ServiceRegistryPopulator";
+import { UiOntologyBootstrapper } from "./infrastructure/ontology/UiOntologyBootstrapper";
+import { ObsidianUiOntologyBootstrapperVault } from "./infrastructure/ontology/ObsidianUiOntologyBootstrapperVault";
 
 /**
  * Exocortex Plugin - Automatic layout rendering
@@ -176,6 +178,34 @@ export default class ExocortexPlugin extends Plugin {
         sparqlApi: this.sparql,
         vaultAdapter: this.vaultAdapter,
       });
+
+      // Issue #2943 — install the `ui__RelationColumnSet` ontology (7 files)
+      // into the vault before the repository initialises, so the snapshot
+      // can pick up the class + property assets on first rebuild. Idempotent:
+      // skips any file already present at the target path. Errors on
+      // individual writes are logged but do not abort plugin load.
+      try {
+        const bootstrapResult = await new UiOntologyBootstrapper(
+          new ObsidianUiOntologyBootstrapperVault(this.app.vault),
+        ).bootstrap();
+        if (bootstrapResult.created.length > 0) {
+          this.logger.info("UiOntologyBootstrapper", {
+            message: `installed ${bootstrapResult.created.length} ontology file(s)`,
+            created: bootstrapResult.created,
+          });
+        }
+        if (bootstrapResult.errors.length > 0) {
+          for (const err of bootstrapResult.errors) {
+            this.logger.warn("UiOntologyBootstrapper", {
+              message: `failed to install ${err.path}: ${err.error.message}`,
+            });
+          }
+        }
+      } catch (err) {
+        this.logger.warn("UiOntologyBootstrapper", {
+          message: `bootstrap failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
 
       // RFC be70f741 Phase 3 — wire RelationColumnSetRepository + Resolver so
       // `UniversalLayoutRenderer` → `RelationsRenderer` can consult the index

--- a/packages/obsidian-plugin/src/infrastructure/ontology/ObsidianUiOntologyBootstrapperVault.ts
+++ b/packages/obsidian-plugin/src/infrastructure/ontology/ObsidianUiOntologyBootstrapperVault.ts
@@ -1,0 +1,32 @@
+import type { Vault } from "obsidian";
+import type { UiOntologyBootstrapperVault } from "./UiOntologyBootstrapper";
+
+/**
+ * Obsidian-concrete `UiOntologyBootstrapperVault` adapter — translates the
+ * minimal bootstrapper API to `Vault` primitives.
+ *
+ * `fileExists` is a fast path-level check against `getAbstractFileByPath`.
+ * It does NOT scan the whole vault for a file with the same
+ * `exo__Asset_uid`; if a user manually copied the 7 files to a non-default
+ * folder, calling bootstrap still installs them at `_exocortex-ui-ontology/`.
+ * Rationale: scanning by UID requires a resolved `metadataCache`, and
+ * bootstrap runs early in `onload` before resolution.
+ */
+export class ObsidianUiOntologyBootstrapperVault
+  implements UiOntologyBootstrapperVault
+{
+  constructor(private readonly vault: Vault) {}
+
+  fileExists(path: string): boolean {
+    return this.vault.getAbstractFileByPath(path) !== null;
+  }
+
+  async createFile(path: string, content: string): Promise<void> {
+    await this.vault.create(path, content);
+  }
+
+  async ensureFolder(path: string): Promise<void> {
+    if (this.vault.getAbstractFileByPath(path) !== null) return;
+    await this.vault.createFolder(path);
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/ontology/UiOntologyBootstrapper.ts
+++ b/packages/obsidian-plugin/src/infrastructure/ontology/UiOntologyBootstrapper.ts
@@ -1,0 +1,221 @@
+/**
+ * UiOntologyBootstrapper — installs the `ui__RelationColumnSet` ontology
+ * (7 files) into a personal vault on plugin load.
+ *
+ * Closes #2943. Keeps vaults without starter-kit copies functional for
+ * `ui__RelationColumnSet` configs — the feature would otherwise require a
+ * manual 7-file copy from `kitelev/exocortex-starter-kit`.
+ *
+ * Idempotency: skip each file already present at its target path. The second
+ * call after the first is a no-op. Errors on individual writes do not abort
+ * the run; each failure is collected in `result.errors` and the remaining
+ * files are still installed.
+ */
+
+export interface UiOntologyBootstrapperVault {
+  fileExists(path: string): boolean;
+  createFile(path: string, content: string): Promise<void>;
+  ensureFolder(path: string): Promise<void>;
+}
+
+export interface UiOntologyFile {
+  readonly uid: string;
+  readonly filename: string;
+  readonly content: string;
+}
+
+export interface UiOntologyBootstrapResult {
+  readonly created: string[];
+  readonly skipped: string[];
+  readonly errors: Array<{ path: string; error: Error }>;
+}
+
+export interface UiOntologyBootstrapperOptions {
+  /** Vault-relative folder where the 7 ontology files will be installed. */
+  targetFolder?: string;
+}
+
+const DEFAULT_TARGET_FOLDER = "_exocortex-ui-ontology";
+
+const UI_ROOT_FILE: UiOntologyFile = {
+  uid: "3ee15e1b-3725-4497-9946-df0b67b63f29",
+  filename: "3ee15e1b-3725-4497-9946-df0b67b63f29.md",
+  content: `---
+exo__Asset_uid: 3ee15e1b-3725-4497-9946-df0b67b63f29
+exo__Instance_class:
+  - "[[829b9b3b-6fc3-4276-be6a-27d3398c012e|exo__Ontology]]"
+exo__Asset_label: UI Ontology
+aliases:
+  - UI Ontology
+  - "!ui"
+---
+`,
+};
+
+const CLASS_FILE: UiOntologyFile = {
+  uid: "97fc9862-c886-4d86-9a60-e0cf9d778575",
+  filename: "97fc9862-c886-4d86-9a60-e0cf9d778575.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[3ee15e1b-3725-4497-9946-df0b67b63f29|!ui]]"
+exo__Asset_uid: 97fc9862-c886-4d86-9a60-e0cf9d778575
+exo__Instance_class:
+  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9|exo__Class]]"
+exo__Asset_label: ui__RelationColumnSet
+aliases:
+  - ui__RelationColumnSet
+exo__Class_description: |
+  Ordered set of columns that UniversalLayout should render for one specific
+  combination of (row-asset class, referencing property) in the auto-backlinks
+  table. Resolver matches via tiered priority ladder:
+  (targetClass AND referencingProperty) > (targetClass only) > (referencingProperty only) > default.
+  Tiebreaker: ui__RelationColumnSet_priority DESC → exo__Asset_uid ASC.
+---
+`,
+};
+
+const LABEL_PROPERTY_FILE: UiOntologyFile = {
+  uid: "3382b5cd-5d4d-4aaa-b55f-d6af85c4ee13",
+  filename: "3382b5cd-5d4d-4aaa-b55f-d6af85c4ee13.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[3ee15e1b-3725-4497-9946-df0b67b63f29|!ui]]"
+exo__Asset_uid: 3382b5cd-5d4d-4aaa-b55f-d6af85c4ee13
+exo__Instance_class:
+  - "[[30d63ce4-e574-456c-8de8-2bf1a53688c1|exo__StringProperty]]"
+exo__Asset_label: "ui__RelationColumnSet_label"
+rdfs__label: "Relation Column Set Label"
+exo__Property_domain: "[[97fc9862-c886-4d86-9a60-e0cf9d778575|ui__RelationColumnSet]]"
+exo__Asset_description: "Optional human-readable label used for debugging and logs. Defaults to basename when absent."
+---
+`,
+};
+
+const PRIORITY_PROPERTY_FILE: UiOntologyFile = {
+  uid: "7ca5816a-f95a-40bf-ba94-c00081ce3b9f",
+  filename: "7ca5816a-f95a-40bf-ba94-c00081ce3b9f.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[3ee15e1b-3725-4497-9946-df0b67b63f29|!ui]]"
+exo__Asset_uid: 7ca5816a-f95a-40bf-ba94-c00081ce3b9f
+exo__Instance_class:
+  - "[[81c5d3c0-e2f2-4f7d-a19d-de91f414340e|exo__NumberProperty]]"
+exo__Asset_label: "ui__RelationColumnSet_priority"
+rdfs__label: "Relation Column Set Priority"
+exo__Property_domain: "[[97fc9862-c886-4d86-9a60-e0cf9d778575|ui__RelationColumnSet]]"
+exo__Asset_description: "Numeric tiebreaker for configs matching on the same tier. Default 0 when absent. Sort order: priority DESC → exo__Asset_uid ASC."
+---
+`,
+};
+
+const TARGET_CLASS_PROPERTY_FILE: UiOntologyFile = {
+  uid: "d0aa1baa-be37-4258-b3e7-9f6e5fd63722",
+  filename: "d0aa1baa-be37-4258-b3e7-9f6e5fd63722.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[3ee15e1b-3725-4497-9946-df0b67b63f29|!ui]]"
+exo__Asset_uid: d0aa1baa-be37-4258-b3e7-9f6e5fd63722
+exo__Instance_class:
+  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"
+exo__Asset_label: "ui__RelationColumnSet_targetClass"
+rdfs__label: "Relation Column Set Target Class"
+exo__Property_domain: "[[97fc9862-c886-4d86-9a60-e0cf9d778575|ui__RelationColumnSet]]"
+exo__Property_range: "[[8619c4fc-64f1-4869-b17e-e34186cacca9|exo__Class]]"
+exo__Asset_description: "Optional class (or array of classes) of row-assets this column set applies to. Multi-class rows — resolver walks declaration-order; first non-null match wins."
+---
+`,
+};
+
+const REFERENCING_PROPERTY_FILE: UiOntologyFile = {
+  uid: "d0aa8c6a-dcc4-4c73-883a-9bd5c27a3a31",
+  filename: "d0aa8c6a-dcc4-4c73-883a-9bd5c27a3a31.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[3ee15e1b-3725-4497-9946-df0b67b63f29|!ui]]"
+exo__Asset_uid: d0aa8c6a-dcc4-4c73-883a-9bd5c27a3a31
+exo__Instance_class:
+  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"
+exo__Asset_label: "ui__RelationColumnSet_referencingProperty"
+rdfs__label: "Relation Column Set Referencing Property"
+exo__Property_domain: "[[97fc9862-c886-4d86-9a60-e0cf9d778575|ui__RelationColumnSet]]"
+exo__Property_range: "[[38277bfa-d7f9-4a75-b856-b23276ab0db3|exo__Property]]"
+exo__Asset_description: "Optional name of the referencing-property group this column set applies to. Normalisation rule: stored as wikilink [[name]], resolver compares normalized (bare identifier) form against raw property name from RelationsRenderer."
+---
+`,
+};
+
+const COLUMNS_PROPERTY_FILE: UiOntologyFile = {
+  uid: "dc6da098-db18-4e75-8758-6a7779289d8a",
+  filename: "dc6da098-db18-4e75-8758-6a7779289d8a.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[3ee15e1b-3725-4497-9946-df0b67b63f29|!ui]]"
+exo__Asset_uid: dc6da098-db18-4e75-8758-6a7779289d8a
+exo__Instance_class:
+  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"
+exo__Asset_label: "ui__RelationColumnSet_columns"
+rdfs__label: "Relation Column Set Columns"
+exo__Property_domain: "[[97fc9862-c886-4d86-9a60-e0cf9d778575|ui__RelationColumnSet]]"
+exo__Asset_description: "Ordered list of wikilink-references to exo__LayoutColumn assets. Order in frontmatter array IS the render order. Range is exo__LayoutColumn (TypeScript-level concept; no canonical class asset in ontology yet — canonicalisation deferred to Phase 3+ per ADR)."
+---
+`,
+};
+
+/**
+ * Static manifest of the 7 ontology files bundled with the plugin.
+ *
+ * Source-of-truth: `kitelev/exocortex-starter-kit` `ui/` directory
+ * (snapshot from PR #86, 2026-04-24 — snake_case labels per Task 3 fix).
+ *
+ * The `7e2d4e3e-...` MVG fixture (Task ← Project example) is intentionally
+ * NOT bundled — it is example data, not ontology. Users create their own
+ * `ui__RelationColumnSet` configs once the ontology is installed.
+ */
+export const UI_ONTOLOGY_FILES: readonly UiOntologyFile[] = [
+  UI_ROOT_FILE,
+  CLASS_FILE,
+  LABEL_PROPERTY_FILE,
+  PRIORITY_PROPERTY_FILE,
+  TARGET_CLASS_PROPERTY_FILE,
+  REFERENCING_PROPERTY_FILE,
+  COLUMNS_PROPERTY_FILE,
+];
+
+export class UiOntologyBootstrapper {
+  private readonly targetFolder: string;
+
+  constructor(
+    private readonly vault: UiOntologyBootstrapperVault,
+    options: UiOntologyBootstrapperOptions = {},
+  ) {
+    this.targetFolder = options.targetFolder ?? DEFAULT_TARGET_FOLDER;
+  }
+
+  async bootstrap(): Promise<UiOntologyBootstrapResult> {
+    const created: string[] = [];
+    const skipped: string[] = [];
+    const errors: Array<{ path: string; error: Error }> = [];
+
+    const pending: Array<{ path: string; content: string }> = [];
+    for (const file of UI_ONTOLOGY_FILES) {
+      const path = `${this.targetFolder}/${file.filename}`;
+      if (this.vault.fileExists(path)) {
+        skipped.push(path);
+      } else {
+        pending.push({ path, content: file.content });
+      }
+    }
+
+    if (pending.length > 0) {
+      await this.vault.ensureFolder(this.targetFolder);
+    }
+
+    for (const entry of pending) {
+      try {
+        await this.vault.createFile(entry.path, entry.content);
+        created.push(entry.path);
+      } catch (error) {
+        errors.push({
+          path: entry.path,
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+      }
+    }
+
+    return { created, skipped, errors };
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/infrastructure/ontology/UiOntologyBootstrapper.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/ontology/UiOntologyBootstrapper.test.ts
@@ -1,0 +1,256 @@
+import {
+  UI_ONTOLOGY_FILES,
+  UiOntologyBootstrapper,
+  type UiOntologyBootstrapperVault,
+} from "../../../../src/infrastructure/ontology/UiOntologyBootstrapper";
+
+interface FakeVault extends UiOntologyBootstrapperVault {
+  files: Map<string, string>;
+  folders: Set<string>;
+  createdPaths: string[];
+  ensuredFolders: string[];
+}
+
+function makeVault(existingPaths: Iterable<string> = []): FakeVault {
+  const files = new Map<string, string>();
+  const folders = new Set<string>();
+  const createdPaths: string[] = [];
+  const ensuredFolders: string[] = [];
+
+  for (const path of existingPaths) {
+    files.set(path, "existing-stub");
+  }
+
+  return {
+    files,
+    folders,
+    createdPaths,
+    ensuredFolders,
+    fileExists(path) {
+      return files.has(path);
+    },
+    async createFile(path, content) {
+      if (files.has(path)) {
+        throw new Error(`duplicate create for ${path}`);
+      }
+      files.set(path, content);
+      createdPaths.push(path);
+    },
+    async ensureFolder(path) {
+      folders.add(path);
+      ensuredFolders.push(path);
+    },
+  };
+}
+
+const TARGET_FOLDER = "_exocortex-ui-ontology";
+
+const BUNDLED_UIDS = [
+  "3ee15e1b-3725-4497-9946-df0b67b63f29", // !ui ontology root
+  "97fc9862-c886-4d86-9a60-e0cf9d778575", // ui__RelationColumnSet class
+  "3382b5cd-5d4d-4aaa-b55f-d6af85c4ee13", // _label
+  "7ca5816a-f95a-40bf-ba94-c00081ce3b9f", // _priority
+  "d0aa1baa-be37-4258-b3e7-9f6e5fd63722", // _targetClass
+  "d0aa8c6a-dcc4-4c73-883a-9bd5c27a3a31", // _referencingProperty
+  "dc6da098-db18-4e75-8758-6a7779289d8a", // _columns
+] as const;
+
+const FIXTURE_UID = "7e2d4e3e-1e9d-461a-8baa-4792949919cd"; // MVG fixture — NOT bundled
+
+describe("UiOntologyBootstrapper", () => {
+  describe("UI_ONTOLOGY_FILES static manifest", () => {
+    it("bundles exactly 7 ontology files", () => {
+      expect(UI_ONTOLOGY_FILES).toHaveLength(7);
+    });
+
+    it("covers all 7 canonical UUIDs", () => {
+      const uids = UI_ONTOLOGY_FILES.map((f) => f.uid).sort();
+      expect(uids).toEqual([...BUNDLED_UIDS].sort());
+    });
+
+    it("does NOT bundle the Task←Project MVG fixture (example data, not ontology)", () => {
+      const uids = UI_ONTOLOGY_FILES.map((f) => f.uid);
+      expect(uids).not.toContain(FIXTURE_UID);
+    });
+
+    it("each file has a UUID basename and a non-empty markdown body", () => {
+      for (const file of UI_ONTOLOGY_FILES) {
+        expect(file.uid).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        );
+        expect(file.filename).toBe(`${file.uid}.md`);
+        expect(file.content.length).toBeGreaterThan(0);
+        expect(file.content).toContain(`exo__Asset_uid: ${file.uid}`);
+      }
+    });
+
+    it("each file references the !ui ontology root (except the root itself)", () => {
+      const ROOT = "3ee15e1b-3725-4497-9946-df0b67b63f29";
+      for (const file of UI_ONTOLOGY_FILES) {
+        if (file.uid === ROOT) continue;
+        expect(file.content).toContain(
+          `exo__Asset_isDefinedBy: "[[${ROOT}|!ui]]"`,
+        );
+      }
+    });
+
+    it("property files use snake_case exo__Asset_label matching Task 3 convention", () => {
+      // Regression guard for feedback_starter_kit_ontology_label_snake_case.md
+      const propertyUids = new Set([
+        "3382b5cd-5d4d-4aaa-b55f-d6af85c4ee13",
+        "7ca5816a-f95a-40bf-ba94-c00081ce3b9f",
+        "d0aa1baa-be37-4258-b3e7-9f6e5fd63722",
+        "d0aa8c6a-dcc4-4c73-883a-9bd5c27a3a31",
+        "dc6da098-db18-4e75-8758-6a7779289d8a",
+      ]);
+      for (const file of UI_ONTOLOGY_FILES) {
+        if (!propertyUids.has(file.uid)) continue;
+        expect(file.content).toMatch(
+          /exo__Asset_label: "ui__RelationColumnSet_[a-zA-Z]+"/,
+        );
+      }
+    });
+  });
+
+  describe("bootstrap() — empty vault", () => {
+    it("creates target folder + all 7 files when vault is empty", async () => {
+      const vault = makeVault();
+      const bootstrapper = new UiOntologyBootstrapper(vault);
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(7);
+      expect(result.skipped).toHaveLength(0);
+      expect(vault.ensuredFolders).toContain(TARGET_FOLDER);
+      expect(vault.createdPaths).toHaveLength(7);
+      for (const uid of BUNDLED_UIDS) {
+        expect(vault.files.has(`${TARGET_FOLDER}/${uid}.md`)).toBe(true);
+      }
+    });
+
+    it("written file content matches the bundled manifest verbatim", async () => {
+      const vault = makeVault();
+      const bootstrapper = new UiOntologyBootstrapper(vault);
+
+      await bootstrapper.bootstrap();
+
+      for (const file of UI_ONTOLOGY_FILES) {
+        const stored = vault.files.get(`${TARGET_FOLDER}/${file.filename}`);
+        expect(stored).toBe(file.content);
+      }
+    });
+  });
+
+  describe("bootstrap() — idempotency", () => {
+    it("is a no-op when all 7 files already exist at target path", async () => {
+      const preExisting = BUNDLED_UIDS.map(
+        (uid) => `${TARGET_FOLDER}/${uid}.md`,
+      );
+      const vault = makeVault(preExisting);
+      const bootstrapper = new UiOntologyBootstrapper(vault);
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(0);
+      expect(result.skipped).toHaveLength(7);
+      expect(vault.createdPaths).toHaveLength(0);
+    });
+
+    it("second bootstrap call after first is a no-op (re-run safety)", async () => {
+      const vault = makeVault();
+      const bootstrapper = new UiOntologyBootstrapper(vault);
+
+      const first = await bootstrapper.bootstrap();
+      expect(first.created).toHaveLength(7);
+
+      const second = await bootstrapper.bootstrap();
+      expect(second.created).toHaveLength(0);
+      expect(second.skipped).toHaveLength(7);
+      expect(vault.files.size).toBe(7);
+    });
+
+    it("creates only the missing subset when vault has partial install", async () => {
+      const preExisting = [
+        `${TARGET_FOLDER}/3ee15e1b-3725-4497-9946-df0b67b63f29.md`,
+        `${TARGET_FOLDER}/97fc9862-c886-4d86-9a60-e0cf9d778575.md`,
+      ];
+      const vault = makeVault(preExisting);
+      const bootstrapper = new UiOntologyBootstrapper(vault);
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.skipped).toHaveLength(2);
+      expect(result.created).toHaveLength(5);
+      expect(vault.files.size).toBe(7);
+    });
+  });
+
+  describe("bootstrap() — folder handling", () => {
+    it("ensures the target folder before any file write", async () => {
+      const vault = makeVault();
+      const calls: string[] = [];
+      vault.ensureFolder = async (path) => {
+        calls.push(`folder:${path}`);
+      };
+      vault.createFile = async (path, _content) => {
+        calls.push(`file:${path}`);
+        vault.files.set(path, _content);
+      };
+      const bootstrapper = new UiOntologyBootstrapper(vault);
+
+      await bootstrapper.bootstrap();
+
+      expect(calls[0]).toBe(`folder:${TARGET_FOLDER}`);
+      expect(calls.slice(1).every((c) => c.startsWith("file:"))).toBe(true);
+    });
+
+    it("does not ensure folder when nothing needs to be created", async () => {
+      const preExisting = BUNDLED_UIDS.map(
+        (uid) => `${TARGET_FOLDER}/${uid}.md`,
+      );
+      const vault = makeVault(preExisting);
+      const bootstrapper = new UiOntologyBootstrapper(vault);
+
+      await bootstrapper.bootstrap();
+
+      expect(vault.ensuredFolders).toHaveLength(0);
+    });
+  });
+
+  describe("bootstrap() — resilience", () => {
+    it("continues installing remaining files if one write throws", async () => {
+      const vault = makeVault();
+      let attempts = 0;
+      vault.createFile = async (path, content) => {
+        attempts++;
+        if (attempts === 2) throw new Error("disk full simulation");
+        vault.files.set(path, content);
+        vault.createdPaths.push(path);
+      };
+      const bootstrapper = new UiOntologyBootstrapper(vault);
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(6);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].error.message).toBe("disk full simulation");
+    });
+  });
+
+  describe("bootstrap() — configurable target folder", () => {
+    it("installs into a custom folder when one is provided", async () => {
+      const vault = makeVault();
+      const bootstrapper = new UiOntologyBootstrapper(vault, {
+        targetFolder: "ontologies/ui",
+      });
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(7);
+      expect(vault.ensuredFolders).toContain("ontologies/ui");
+      for (const uid of BUNDLED_UIDS) {
+        expect(vault.files.has(`ontologies/ui/${uid}.md`)).toBe(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2943. Installs the 7 `ui__RelationColumnSet` ontology assets into `_exocortex-ui-ontology/` on plugin `onload`, so a fresh personal vault can create `ui__RelationColumnSet` configs without a manual copy from `kitelev/exocortex-starter-kit`.

Task 2 of project `6788f2d4-592a-44c3-96de-1dcd35683552` (RFC be70f741 defect remediation). Task 1 (normalizers #2941/#2942 → v15.120.1) and Task 3 (starter-kit snake_case labels → v1.30.1) are already shipped.

## Option decision — **Option B** (plugin bundle + onLoad idempotent install)

| Option | Verdict | Rationale |
|---|---|---|
| **A** — pull-up to `kitelev/exocortex-public-ontologies` | ⛔ BLOCKED | That repo's `scripts/validate.py` requires `metadata: anchor\|statement\|namespace\|blank_node` on every file (see `_prefixes.yaml` + Validation Rules in its `CLAUDE.md`). `exo__Asset_*` frontmatter does not declare `metadata` → would fail validation. No sibling `exocortex-core-ontologies` repo exists. |
| **B** — plugin bundle + `onLoad` idempotent install | ✅ **Chosen** | Self-contained in a single repo, zero user action, idempotent on upgrade, matches the code example in the issue body. Survives the vault format invariants check (7 files match starter-kit post-#86 snake_case labels). |
| **C** — CLI-driven `npx install-ui-ontology` | ❌ Fails AC | Violates zero-friction AC ("Given empty vault When user creates config Then ontology available"). Requires the user to know about and run a CLI command before the feature works. |

Decision was verified via advisor + empirical format-compat check on `exocortex-public-ontologies`.

## What changed

- `packages/obsidian-plugin/src/infrastructure/ontology/UiOntologyBootstrapper.ts` — static manifest of the 7 ontology files + `bootstrap()` method. Adapter interface decouples the core logic from Obsidian's `Vault` for unit testing.
- `packages/obsidian-plugin/src/infrastructure/ontology/ObsidianUiOntologyBootstrapperVault.ts` — concrete `Vault` adapter (fast path-level `getAbstractFileByPath` check, no `metadataCache` dependency so bootstrap can run early in `onload`).
- `packages/obsidian-plugin/src/ExocortexPlugin.ts` — wires bootstrap **before** `RelationColumnSetRepository.initialize()` so the repository picks up the installed ontology on first rebuild. Errors on individual file writes are logged but do not abort plugin load.
- `packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md` — new "Initial setup — zero-friction ontology bootstrap" section documenting the install location and idempotency contract.
- `packages/obsidian-plugin/tests/unit/infrastructure/ontology/UiOntologyBootstrapper.test.ts` — 15 unit tests covering empty-vault install, idempotency (second call no-op, partial-install subset), folder handling (not created when nothing to install, created before first write), write-error resilience, and manifest invariants (7 files, canonical UUIDs, no MVG fixture, snake_case labels matching Task 3 convention).

## Idempotency contract

Path-level: files already present at `_exocortex-ui-ontology/<uid>.md` are skipped.

- Second `bootstrap()` call after the first — no-op
- Plugin upgrade in a vault with existing ontology files — no overwrite
- Partially-installed vault — only missing subset is created
- Write error on one file — remaining files still install; error collected in `result.errors`

## MVG fixture

The Task ← Project MVG fixture (`7e2d4e3e-1e9d-461a-8baa-4792949919cd`) from the starter-kit is intentionally NOT bundled. It is example data, not ontology. Users create their own `ui__RelationColumnSet` configs once the ontology is installed. This is covered by a dedicated regression test.

## Acceptance criteria

- [x] Option decision documented (this PR body)
- [x] Closes #2943
- [x] Empty-vault scenario — tested (creates all 7 files)
- [x] Existing-vault idempotency — tested (no overwrite, no duplicates)
- [x] Docs updated — "Initial setup" section added to `RELATION_COLUMN_SET.md`; no "copy 7 files" instruction exists anywhere in the repo (verified via `git grep`)
- [ ] `npm run test:all` green — CI checks below
- [ ] Live-test after release (v15.122.0+): delete the 7 files from `vault-2025`, re-open the vault, verify bootstrap recreates them

## Test plan

- Unit: `tests/unit/infrastructure/ontology/UiOntologyBootstrapper.test.ts` — 15/15 green locally
- Integration: CI `test-coverage` + `test-component` + `e2e-shard (1..4)` jobs
- Regression: `RelationColumnSet.phase1-AC.test.ts` + `RelationColumnSetRepository.test.ts` + `RelationsRenderer.relation-column-set.test.ts` — 52/52 green locally

## Post-mortem follow-ups (tracked, not in this PR)

- Follow-up: consider scanning by `exo__Asset_uid` across the vault (via resolved `metadataCache`) as a secondary idempotency check for users who moved the 7 files to a custom folder. Currently they would get a duplicate copy at `_exocortex-ui-ontology/`; hook `validate-wikilinks.sh` + `RelationColumnSetRepository: duplicate exo__Asset_uid` warning make it visible.
- Follow-up (unrelated, noted in Task 3 post-mortem): `kitelev/exocortex-starter-kit` `auto-release.yml` (lines 107/124) doesn't package `ui/` → in-repo files are not shipped in the release zip. Orthogonal to this PR; does not affect plugin-based bootstrap.