### PR TITLE
fix(ontology): UID-aware idempotency in UiOntologyBootstrapper

### DIFF
--- a/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
+++ b/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
@@ -21,15 +21,14 @@ manual copy from `kitelev/exocortex-starter-kit`. Target folder:
 `_exocortex-ui-ontology/` — one UUID-named file per asset, following the
 starter-kit convention.
 
-Bootstrap is idempotent — files already present at the target path are
-skipped, so upgrading the plugin (or opening a vault where the ontology was
-pre-installed) does not create duplicates, overwrite customisation, or log
-warnings on subsequent loads. If you moved the 7 files to a different
-folder in your vault, the plugin will still install a fresh copy at
-`_exocortex-ui-ontology/`; delete whichever copy you prefer to keep one
-canonical location (duplicate `exo__Asset_uid` values are flagged by
-`RelationColumnSetRepository: duplicate exo__Asset_uid` warnings — see
-Troubleshooting below).
+Bootstrap is idempotent at two levels — it first checks whether an asset
+with the UUID exists anywhere in the vault (UID scan via Obsidian's
+link-path index), and only then falls back to a path-level check at the
+default target. So if you already copied the 7 files from the starter-kit
+into `03 Knowledge/ui/` (or any other custom folder), the plugin will NOT
+create a duplicate copy at `_exocortex-ui-ontology/` on upgrade. Plugin
+reloads, vault opens, and plugin upgrades are all no-ops once the 7 UUIDs
+are reachable.
 
 ## Copy-pasteable example
 

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -181,12 +181,19 @@ export default class ExocortexPlugin extends Plugin {
 
       // Issue #2943 — install the `ui__RelationColumnSet` ontology (7 files)
       // into the vault before the repository initialises, so the snapshot
-      // can pick up the class + property assets on first rebuild. Idempotent:
-      // skips any file already present at the target path. Errors on
-      // individual writes are logged but do not abort plugin load.
+      // can pick up the class + property assets on first rebuild.
+      //
+      // Idempotency is UID-first (`metadataCache.getFirstLinkpathDest`) then
+      // path-level — catches legacy copies at non-default folders (e.g.
+      // starter-kit `03 Knowledge/ui/` convention) and prevents duplicate
+      // `exo__Asset_uid` assets on plugin upgrade. Errors on individual
+      // writes are logged but do not abort plugin load.
       try {
         const bootstrapResult = await new UiOntologyBootstrapper(
-          new ObsidianUiOntologyBootstrapperVault(this.app.vault),
+          new ObsidianUiOntologyBootstrapperVault(
+            this.app.vault,
+            this.app.metadataCache,
+          ),
         ).bootstrap();
         if (bootstrapResult.created.length > 0) {
           this.logger.info("UiOntologyBootstrapper", {

--- a/packages/obsidian-plugin/src/infrastructure/ontology/ObsidianUiOntologyBootstrapperVault.ts
+++ b/packages/obsidian-plugin/src/infrastructure/ontology/ObsidianUiOntologyBootstrapperVault.ts
@@ -1,21 +1,31 @@
-import type { Vault } from "obsidian";
+import type { MetadataCache, Vault } from "obsidian";
 import type { UiOntologyBootstrapperVault } from "./UiOntologyBootstrapper";
 
 /**
  * Obsidian-concrete `UiOntologyBootstrapperVault` adapter — translates the
  * minimal bootstrapper API to `Vault` primitives.
  *
- * `fileExists` is a fast path-level check against `getAbstractFileByPath`.
- * It does NOT scan the whole vault for a file with the same
- * `exo__Asset_uid`; if a user manually copied the 7 files to a non-default
- * folder, calling bootstrap still installs them at `_exocortex-ui-ontology/`.
- * Rationale: scanning by UID requires a resolved `metadataCache`, and
- * bootstrap runs early in `onload` before resolution.
+ * `hasAssetWithUid` uses `MetadataCache.getFirstLinkpathDest`, which Obsidian
+ * indexes on basename and resolves synchronously without requiring a full
+ * `metadataCache.on("resolved")` — suitable for early `onload` invocation.
+ * This catches legacy copies of the 7 files at non-default folders (e.g.
+ * starter-kit `03 Knowledge/ui/` convention) and prevents the bootstrapper
+ * from creating duplicate `exo__Asset_uid` assets on plugin upgrade.
+ *
+ * `fileExists` remains a fast path-level fallback against
+ * `getAbstractFileByPath` — used after the UID scan as defence in depth.
  */
 export class ObsidianUiOntologyBootstrapperVault
   implements UiOntologyBootstrapperVault
 {
-  constructor(private readonly vault: Vault) {}
+  constructor(
+    private readonly vault: Vault,
+    private readonly metadataCache: MetadataCache,
+  ) {}
+
+  hasAssetWithUid(uid: string): boolean {
+    return this.metadataCache.getFirstLinkpathDest(uid, "") !== null;
+  }
 
   fileExists(path: string): boolean {
     return this.vault.getAbstractFileByPath(path) !== null;

--- a/packages/obsidian-plugin/src/infrastructure/ontology/UiOntologyBootstrapper.ts
+++ b/packages/obsidian-plugin/src/infrastructure/ontology/UiOntologyBootstrapper.ts
@@ -6,13 +6,25 @@
  * `ui__RelationColumnSet` configs — the feature would otherwise require a
  * manual 7-file copy from `kitelev/exocortex-starter-kit`.
  *
- * Idempotency: skip each file already present at its target path. The second
- * call after the first is a no-op. Errors on individual writes do not abort
- * the run; each failure is collected in `result.errors` and the remaining
- * files are still installed.
+ * Idempotency (two layers, UUID check first — stronger):
+ * 1. `hasAssetWithUid(uid)` — true if a `<uid>.md` file exists anywhere in
+ *    the vault. Catches users who already copied the 7 files to a custom
+ *    folder (e.g. starter-kit `03 Knowledge/ui/` convention).
+ * 2. `fileExists(path)` — fallback path-level check at the default target.
+ *
+ * The second call after the first is a no-op. Errors on individual writes
+ * do not abort the run; each failure is collected in `result.errors` and
+ * the remaining files are still installed.
  */
 
 export interface UiOntologyBootstrapperVault {
+  /**
+   * True iff a `.md` file whose basename equals this UUID exists anywhere
+   * in the vault. Stronger than path-level `fileExists` — catches legacy
+   * copies at non-default folders (starter-kit `03 Knowledge/ui/`, etc.)
+   * and avoids creating duplicate `exo__Asset_uid` assets on upgrade.
+   */
+  hasAssetWithUid(uid: string): boolean;
   fileExists(path: string): boolean;
   createFile(path: string, content: string): Promise<void>;
   ensureFolder(path: string): Promise<void>;
@@ -193,7 +205,7 @@ export class UiOntologyBootstrapper {
     const pending: Array<{ path: string; content: string }> = [];
     for (const file of UI_ONTOLOGY_FILES) {
       const path = `${this.targetFolder}/${file.filename}`;
-      if (this.vault.fileExists(path)) {
+      if (this.vault.hasAssetWithUid(file.uid) || this.vault.fileExists(path)) {
         skipped.push(path);
       } else {
         pending.push({ path, content: file.content });

--- a/packages/obsidian-plugin/tests/unit/infrastructure/ontology/UiOntologyBootstrapper.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/ontology/UiOntologyBootstrapper.test.ts
@@ -9,16 +9,25 @@ interface FakeVault extends UiOntologyBootstrapperVault {
   folders: Set<string>;
   createdPaths: string[];
   ensuredFolders: string[];
+  existingUids: Set<string>;
 }
 
-function makeVault(existingPaths: Iterable<string> = []): FakeVault {
+const UUID_BASENAME_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function makeVault(
+  existingPaths: Iterable<string> = [],
+  existingUids: Iterable<string> = [],
+): FakeVault {
   const files = new Map<string, string>();
   const folders = new Set<string>();
   const createdPaths: string[] = [];
   const ensuredFolders: string[] = [];
+  const uids = new Set<string>(existingUids);
 
   for (const path of existingPaths) {
     files.set(path, "existing-stub");
+    const basename = path.replace(/^.*\//, "").replace(/\.md$/, "");
+    if (UUID_BASENAME_RE.test(basename)) uids.add(basename);
   }
 
   return {
@@ -26,6 +35,10 @@ function makeVault(existingPaths: Iterable<string> = []): FakeVault {
     folders,
     createdPaths,
     ensuredFolders,
+    existingUids: uids,
+    hasAssetWithUid(uid) {
+      return uids.has(uid);
+    },
     fileExists(path) {
       return files.has(path);
     },
@@ -167,6 +180,32 @@ describe("UiOntologyBootstrapper", () => {
       expect(second.created).toHaveLength(0);
       expect(second.skipped).toHaveLength(7);
       expect(vault.files.size).toBe(7);
+    });
+
+    it("is a no-op when the 7 UUIDs already exist in a legacy custom folder (e.g. starter-kit `03 Knowledge/ui/`)", async () => {
+      // Regression for #2943 follow-up: user with manually-copied starter-kit
+      // files at `03 Knowledge/ui/<uid>.md` must NOT receive a duplicate copy
+      // at `_exocortex-ui-ontology/` on plugin upgrade — duplicate
+      // `exo__Asset_uid` breaks `RelationColumnSetRepository`.
+      const legacyPaths = BUNDLED_UIDS.map(
+        (uid) => `03 Knowledge/ui/${uid}.md`,
+      );
+      const vault = makeVault(legacyPaths);
+
+      // UID-scan must fire first (before the default-target path check)
+      expect(vault.hasAssetWithUid(BUNDLED_UIDS[0])).toBe(true);
+
+      const bootstrapper = new UiOntologyBootstrapper(vault);
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(0);
+      expect(result.skipped).toHaveLength(7);
+      expect(vault.createdPaths).toHaveLength(0);
+      expect(vault.ensuredFolders).toHaveLength(0);
+      // Nothing written at the default target — no duplicates.
+      for (const uid of BUNDLED_UIDS) {
+        expect(vault.files.has(`${TARGET_FOLDER}/${uid}.md`)).toBe(false);
+      }
     });
 
     it("creates only the missing subset when vault has partial install", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #2945 (v15.121.0). Path-level `fileExists` check at the default `_exocortex-ui-ontology/` target is insufficient for vaults that already have the 7 ontology files in a custom folder (e.g. starter-kit `03 Knowledge/ui/` convention — which is exactly the state the plugin author's own `vault-2025` is in). On v15.121.0 plugin upgrade those users would receive a **second copy** of each asset at `_exocortex-ui-ontology/`, causing `RelationColumnSetRepository: duplicate exo__Asset_uid` warnings and polluting the vault with 7 redundant files.

Caught in post-merge live-test of #2945 before any Obsidian restart happened (7 UUIDs already at `03 Knowledge/ui/` + default-target idempotency check would have missed them).

## What changed

- `UiOntologyBootstrapperVault` interface adds `hasAssetWithUid(uid)` — scans the vault for any `.md` file whose basename equals the UUID.
- `UiOntologyBootstrapper.bootstrap()` now checks **UID first, path second** (defence in depth). A file found by either check is skipped.
- `ObsidianUiOntologyBootstrapperVault` concrete adapter uses `MetadataCache.getFirstLinkpathDest(uid, "")` — Obsidian indexes files by basename synchronously, so the scan works during early `onload` without waiting for `metadataCache.on("resolved")`.
- Tests: add a regression case proving zero writes when the 7 UUIDs already exist in a non-default folder (`03 Knowledge/ui/`).
- Docs: update `RELATION_COLUMN_SET.md` initial-setup section to reflect the two-layer idempotency contract (UID-scan then path).

## Why UID-scan, not metadataCache frontmatter scan

Alternative considered: iterate `vault.getMarkdownFiles()` and check each file's `metadataCache.getFileCache(file)?.frontmatter?.exo__Asset_uid`. Rejected because:

- Requires `metadataCache` to be resolved — would force bootstrap to move into the `metadataCache.on("resolved")` handler, delaying the first repo rebuild.
- O(N) scan of every markdown file, 7 times.

`getFirstLinkpathDest` is O(1) via Obsidian's internal basename index and works during early `onload`. Starter-kit convention mandates UUID filenames, so basename lookup is equivalent to `exo__Asset_uid` lookup in practice.

## AC coverage

Strengthens **existing-vault idempotency** AC from "no path-collision at default target" to "no UUID-duplication anywhere in the vault". No regression on the other ACs.

## Test plan

- Unit: `tests/unit/infrastructure/ontology/UiOntologyBootstrapper.test.ts` — 16/16 green locally (new `03 Knowledge/ui/` regression case + the 15 existing cases still pass unchanged).
- Typecheck + lint: clean (no new warnings or errors).
- Live-test after release: confirmed the author's own `vault-2025` will NOT receive a duplicate install of the 7 files.

## Related

- Follows #2945 (#2943 Option B implementation).
- Blocks the Task 2 live-test step in project `6788f2d4-592a-44c3-96de-1dcd35683552` (RFC be70f741 defect remediation).