### PR TITLE
test(e2e): eliminate 9 waitForTimeout sites in archived-button.spec.ts (RFC 3cc77ba2 Phase 1.1a)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/archived-button.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/archived-button.spec.ts
@@ -11,7 +11,9 @@ test.describe("Show Archived Button in pn__DailyNote", () => {
     const dailyNoteLink = page.locator('a[href*="2025-10-18"]').first();
     if (await dailyNoteLink.isVisible()) {
       await dailyNoteLink.click();
-      await page.waitForTimeout(1000);
+      await expect(page.locator(".exocortex-assets-relations")).toBeVisible({
+        timeout: 10000,
+      });
     }
   });
 
@@ -21,21 +23,19 @@ test.describe("Show Archived Button in pn__DailyNote", () => {
 
     const showArchivedButton = page.locator("button.exocortex-toggle-archived");
     await expect(showArchivedButton).toBeVisible();
-
-    const buttonText = await showArchivedButton.textContent();
-    expect(buttonText).toContain("Show Archived");
+    await expect(showArchivedButton).toContainText("Show Archived");
   });
 
   test("should hide archived assets by default", async ({ page }) => {
     const relationsSection = page.locator(".exocortex-assets-relations");
     await expect(relationsSection).toBeVisible({ timeout: 10000 });
 
-    await page.waitForTimeout(1000);
+    await expect(
+      page.locator(".exocortex-relation-table tbody tr").first(),
+    ).toBeVisible({ timeout: 5000 });
 
     const archivedTaskRow = page.locator('text="Archived Task"');
-    const isVisible = await archivedTaskRow.isVisible().catch(() => false);
-
-    expect(isVisible).toBe(false);
+    await expect(archivedTaskRow).toBeHidden();
   });
 
   test("should show archived assets when Show Archived button is clicked", async ({ page }) => {
@@ -48,10 +48,7 @@ test.describe("Show Archived Button in pn__DailyNote", () => {
     const rowsBeforeClick = await page.locator(".exocortex-relation-table tbody tr").count();
 
     await showArchivedButton.click();
-    await page.waitForTimeout(500);
-
-    const buttonTextAfter = await showArchivedButton.textContent();
-    expect(buttonTextAfter).toContain("Hide Archived");
+    await expect(showArchivedButton).toContainText("Hide Archived", { timeout: 5000 });
 
     const archivedTaskRow = page.locator('text="Archived Task"');
     await expect(archivedTaskRow).toBeVisible({ timeout: 5000 });
@@ -68,7 +65,6 @@ test.describe("Show Archived Button in pn__DailyNote", () => {
     await expect(showArchivedButton).toBeVisible();
 
     await showArchivedButton.click();
-    await page.waitForTimeout(500);
 
     const archivedTaskRow = page.locator('text="Archived Task"');
     await expect(archivedTaskRow).toBeVisible({ timeout: 5000 });
@@ -76,13 +72,8 @@ test.describe("Show Archived Button in pn__DailyNote", () => {
     const rowsWithArchived = await page.locator(".exocortex-relation-table tbody tr").count();
 
     await showArchivedButton.click();
-    await page.waitForTimeout(500);
-
-    const buttonText = await showArchivedButton.textContent();
-    expect(buttonText).toContain("Show Archived");
-
-    const isVisible = await archivedTaskRow.isVisible().catch(() => false);
-    expect(isVisible).toBe(false);
+    await expect(showArchivedButton).toContainText("Show Archived", { timeout: 5000 });
+    await expect(archivedTaskRow).toBeHidden();
 
     const rowsWithoutArchived = await page.locator(".exocortex-relation-table tbody tr").count();
     expect(rowsWithoutArchived).toBeLessThan(rowsWithArchived);
@@ -96,22 +87,20 @@ test.describe("Show Archived Button in pn__DailyNote", () => {
     await expect(showArchivedButton).toBeVisible();
 
     await showArchivedButton.click();
-    await page.waitForTimeout(500);
 
     const archivedTaskRow = page.locator('text="Archived Task"');
     await expect(archivedTaskRow).toBeVisible({ timeout: 5000 });
 
     await page.reload();
     await page.waitForSelector(".exocortex-assets-relations", { timeout: 10000 });
-    await page.waitForTimeout(1000);
 
     const archivedTaskAfterReload = page.locator('text="Archived Task"');
-    const isVisibleAfterReload = await archivedTaskAfterReload.isVisible({ timeout: 5000 }).catch(() => false);
+    await expect(archivedTaskAfterReload).toBeVisible({ timeout: 5000 });
 
-    expect(isVisibleAfterReload).toBe(true);
-
-    const buttonTextAfterReload = await page.locator("button.exocortex-toggle-archived").textContent();
-    expect(buttonTextAfterReload).toContain("Hide Archived");
+    await expect(page.locator("button.exocortex-toggle-archived")).toContainText(
+      "Hide Archived",
+      { timeout: 5000 },
+    );
   });
 
   test("should only filter archived assets, not other assets", async ({ page }) => {
@@ -124,10 +113,14 @@ test.describe("Show Archived Button in pn__DailyNote", () => {
     const nonArchivedRowsInitial = await page.locator(".exocortex-relation-table tbody tr").count();
 
     await showArchivedButton.click();
-    await page.waitForTimeout(500);
+    await expect
+      .poll(
+        async () => page.locator(".exocortex-relation-table tbody tr").count(),
+        { timeout: 5000 },
+      )
+      .toBeGreaterThan(nonArchivedRowsInitial);
 
     const allRowsAfterShow = await page.locator(".exocortex-relation-table tbody tr").count();
-
     const archivedCount = allRowsAfterShow - nonArchivedRowsInitial;
     expect(archivedCount).toBeGreaterThan(0);
 
@@ -146,7 +139,6 @@ test.describe("Show Archived Button in pn__DailyNote", () => {
     const rowsBeforeClick = await page.locator(".exocortex-relation-table tbody tr").count();
 
     await showArchivedButton.click();
-    await page.waitForTimeout(500);
 
     const newFormatTask = page.locator('text="Archived Task"').first();
     await expect(newFormatTask).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
## Summary

- Replace 9 `page.waitForTimeout()` calls in `archived-button.spec.ts` with structured Playwright web-first assertions (`toBeVisible/toBeHidden/toContainText`, `expect.poll`).
- Addresses Category A timing-flake sites per RFC 3cc77ba2 v2 §Phase 1.1a (lines 14/33/51/71/79/99/106/127/149).
- First of 5 PRs in RFC Phase 1; paired with forthcoming PR 1.1b which adds the `no-waitForTimeout-in-e2e` lint rule.

## RFC context

- RFC: `3cc77ba2-2ef7-4677-a198-ab490d6461f6` v2
- Parent Task: `d7856ad7-53d7-42fb-a806-fcb3ec6f5e97` (Phase 1 Quick Wins)
- Project: `3c163173-4c47-47b6-819f-154118082507` (Flaky tests stabilisation)
- Phase 0 artefacts (all green):
  - Survey N=3 Category B — ship-as-fix go/no-go met
  - Launcher audit — legitimate-throttle verdict, no reorder
  - FLAKY_THRESHOLD baseline = 0 per-shard

## Per-site changes

| Line | Before | After | Rationale |
| ---- | ------ | ----- | --------- |
| 14 (beforeEach) | `waitForTimeout(1000)` after daily-note click | `expect('.exocortex-assets-relations').toBeVisible({timeout: 10000})` | Structured wait for relations panel instead of blind sleep. |
| 33 | `waitForTimeout(1000)` + `isVisible` probe | wait for first table row visible, then `toBeHidden` | Distinguish "not rendered" from "rendered but filtered". |
| 51 | `waitForTimeout(500)` + `textContent+toContain` | `toContainText("Hide Archived", {timeout})` | Web-first assertion retries. |
| 71 | `waitForTimeout(500)` before `toBeVisible({timeout})` | drop — next `toBeVisible({timeout: 5000})` already retries | Redundant. |
| 79 | `waitForTimeout(500)` + `textContent+toContain`+`isVisible` | `toContainText("Show Archived", {timeout})` + `toBeHidden()` | Web-first both checks. |
| 99 | `waitForTimeout(500)` before `toBeVisible({timeout})` | drop | Redundant. |
| 106 | `waitForTimeout(1000)` post-reload | drop — `toBeVisible({timeout})` on reload probe covers | Subsequent assertion already retries. |
| 127 | `waitForTimeout(500)` + `count()` | `expect.poll(count).toBeGreaterThan(initialCount, {timeout: 5000})` | Structured polling for row-count delta. |
| 149 | `waitForTimeout(500)` before `toBeVisible({timeout})` | drop | Redundant. |

Also replaces three `textContent()+expect(...).toContain(...)` sites with web-first `toContainText()` to retain retry semantics previously provided by the sleep.

## Test plan

- [ ] 13 required CI checks pass (archgate · detect-changes · e2e-shard 1..6 · lint · test-bdd · test-component · test-coverage · typecheck)
- [ ] `e2e-shard` containing `archived-button.spec.ts` passes on first attempt (no retries)
- [ ] Post-merge main CI green, Auto Release publishes new tag

## RFC acceptance criteria touched

- [x] 0 `waitForTimeout` in `archived-button.spec.ts` (9 → 0)
- [ ] Lint rule enforces zero — **deferred to PR 1.1b** (this PR is intentionally lint-less)

Authored via claude-in-chrome session `claude-child-d7856ad7-phase1-1-1a` under orchestrator `claude-orch-flaky-tests-2026-04-24`.