### PR TITLE
test(e2e): add no-waitForTimeout lint rule + eliminate 3 remaining sites (RFC 3cc77ba2 Phase 1.1b)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -96,6 +96,34 @@ export default tseslint.config(
       'no-restricted-imports': 'off',
     },
   },
+  // E2E spec timing-flake guard (RFC 3cc77ba2 v2 §Phase 1.1).
+  // Blocks `page.waitForTimeout()`, `setTimeout()`, `new Promise(r => setTimeout(r, N))`
+  // (the inner setTimeout is caught) and `setInterval()` in E2E specs.
+  // Launcher (`tests/e2e/utils/obsidian-launcher.ts:190`) is exempt because the
+  // glob is `*.spec.ts` only; launcher is infrastructure `.ts`, not a spec.
+  {
+    files: ['packages/obsidian-plugin/tests/e2e/**/*.spec.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'CallExpression[callee.property.name="waitForTimeout"]',
+          message:
+            'waitForTimeout creates Category A timing flakes (RFC 3cc77ba2 v2 §Phase 1.1). Use expect(locator).toBeVisible({timeout}), expect.poll(() => condition, {timeout}), or page.waitForFunction() instead.',
+        },
+        {
+          selector: 'CallExpression[callee.name="setTimeout"]',
+          message:
+            'setTimeout (including inside `new Promise(r => setTimeout(r, N))`) creates Category A timing flakes. Use Playwright web-first assertions with explicit timeouts.',
+        },
+        {
+          selector: 'CallExpression[callee.name="setInterval"]',
+          message:
+            'setInterval creates Category A timing flakes. Use expect.poll({intervals, timeout}) instead.',
+        },
+      ],
+    },
+  },
   {
     ignores: [
       'node_modules/',

--- a/packages/obsidian-plugin/tests/e2e/button-styles.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/button-styles.spec.ts
@@ -93,7 +93,18 @@ test.describe("Button CSS Styles Tests", () => {
     });
 
     await firstButton.hover();
-    await page.waitForTimeout(200);
+
+    // Structured poll: wait for hover-transform to diverge from initial,
+    // replaces blind 200ms sleep.
+    await expect
+      .poll(
+        async () =>
+          firstButton.evaluate(
+            (el) => window.getComputedStyle(el).transform,
+          ),
+        { timeout: 2000 },
+      )
+      .not.toBe(initialTransform);
 
     const hoverTransform = await firstButton.evaluate((el) => {
       return window.getComputedStyle(el).transform;

--- a/packages/obsidian-plugin/tests/e2e/layout-visual.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/layout-visual.spec.ts
@@ -202,11 +202,16 @@ test.describe("Layout Visual Tests", () => {
 
     if (isVisible) {
       await page.setViewportSize({ width: 1920, height: 1080 });
-      await page.waitForTimeout(100);
+      // Wait for browser to propagate viewport change, replaces blind sleep.
+      await page.waitForFunction(() => window.innerWidth === 1920, undefined, {
+        timeout: 2000,
+      });
       const wideBox = await container.boundingBox();
 
       await page.setViewportSize({ width: 1280, height: 720 });
-      await page.waitForTimeout(100);
+      await page.waitForFunction(() => window.innerWidth === 1280, undefined, {
+        timeout: 2000,
+      });
       const narrowBox = await container.boundingBox();
 
       if (wideBox && narrowBox) {


### PR DESCRIPTION
## Summary

- Eliminates last 3 `waitForTimeout` sites in E2E specs (`button-styles:96`, `layout-visual:205`, `layout-visual:209`).
- Adds file-scoped ESLint rule `no-restricted-syntax` that blocks `waitForTimeout`, `setTimeout`, and `setInterval` in `packages/obsidian-plugin/tests/e2e/**/*.spec.ts` — enforcing Category A zero-flake invariant going forward.
- Second of 5 PRs in RFC Phase 1, paired with PR #2947 (1.1a) — combined these two PRs drop E2E `waitForTimeout` from 13 → 0.

## RFC context

- RFC: `3cc77ba2-2ef7-4677-a198-ab490d6461f6` v2
- Parent Task: `d7856ad7-53d7-42fb-a806-fcb3ec6f5e97` (Phase 1 Quick Wins)
- Phase 0.2 launcher audit (`legitimate-throttle, NO reorder` verdict) justifies the launcher carve-out via glob: lint targets only `*.spec.ts`, launcher is `utils/obsidian-launcher.ts` infrastructure.

## Per-site changes

| File:Line | Before | After | Rationale |
| --------- | ------ | ----- | --------- |
| button-styles.spec.ts:96 | waitForTimeout(200) after .hover() | expect.poll(transform).not.toBe(initialTransform, {timeout:2000}) | Structured wait for hover-transform divergence. |
| layout-visual.spec.ts:205 | waitForTimeout(100) after setViewportSize({w:1920}) | page.waitForFunction(() => window.innerWidth === 1920, {timeout:2000}) | Browser-confirmed viewport propagation. |
| layout-visual.spec.ts:209 | waitForTimeout(100) after setViewportSize({w:1280}) | page.waitForFunction(() => window.innerWidth === 1280, {timeout:2000}) | Same. |

## Lint rule additions (eslint.config.mjs)

New block targeting packages/obsidian-plugin/tests/e2e/**/*.spec.ts blocks:
- CallExpression[callee.property.name="waitForTimeout"] — page/this.window.waitForTimeout
- CallExpression[callee.name="setTimeout"] — global + inner of new Promise(r => setTimeout(r, N))
- CallExpression[callee.name="setInterval"]

## Launcher exemption — by file:line per Phase 0.2 audit

tests/e2e/utils/obsidian-launcher.ts:190 is exempt because the glob is *.spec.ts only; launcher is infrastructure .ts, not a spec. Phase 0.2 audit verdict: legitimate-throttle (paired with deterministic predicate hasApp && hasWorkspace && hasVault, bounded by maxPolls=60, observable via logs). 79/79 sampled invocations logged "App object found after 0 polls" — migration yields no correctness gain.

## Test plan

- [ ] 13 required CI checks pass (archgate · detect-changes · e2e-shard 1..6 · lint · test-bdd · test-component · test-coverage · typecheck)
- [ ] Lint step blocks regressions of waitForTimeout/setTimeout/setInterval in specs
- [ ] Post-merge main CI green, Auto Release publishes new tag
- [ ] Combined with PR #2947 merged: total waitForTimeout in E2E specs = 0

## RFC acceptance criteria touched

- [x] 0 waitForTimeout in tests/e2e/**/*.spec.ts (lint enforced)
- [x] Launcher exemption by file glob (audit-backed; line 190 not reachable by glob)
- [x] Equivalents (setTimeout, setInterval, new Promise(r => setTimeout)) also blocked