### PR TITLE
test(e2e): cold-start helper + P99 observability + effort-timestamps-auto-sync refactor (RFC 3cc77ba2 Phase 1.2+2.1a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -868,12 +868,14 @@ jobs:
       - name: Run E2E tests (shard ${{ matrix.shard }}/6)
         if: env.RUN_E2E == 'true'
         run: |
-          mkdir -p test-results-e2e playwright-report-e2e blob-report
+          mkdir -p test-results-e2e playwright-report-e2e blob-report plugin-wait-ms
           docker run --init --rm \
             -v $PWD/test-results-e2e:/app/test-results \
             -v $PWD/playwright-report-e2e:/app/playwright-report-e2e \
             -v $PWD/blob-report:/app/packages/obsidian-plugin/blob-report \
+            -v $PWD/plugin-wait-ms:/app/plugin-wait-ms \
             -e CI=true \
+            -e PLUGIN_WAIT_MS_LOG=/app/plugin-wait-ms/shard-${{ matrix.shard }}.jsonl \
             exocortex-e2e npx playwright test -c packages/obsidian-plugin/playwright.shard-${{ matrix.shard }}.config.ts
 
       - name: Upload blob report for shard ${{ matrix.shard }}
@@ -893,6 +895,48 @@ jobs:
           path: test-results-e2e/
           retention-days: 7
           if-no-files-found: ignore
+
+      # RFC 3cc77ba2 v2 §Phase 1.2: PLUGIN_WAIT_MS observability. Helper
+      # `tests/e2e/utils/waitForExocortexPlugin.ts` writes per-invocation
+      # timings as JSONL when `PLUGIN_WAIT_MS_LOG` is set. We upload the
+      # artifact unconditionally and then run a post-hoc P99 gate
+      # (fail when P99 > 15000 ms) per shard. Empty log is benign: the
+      # gate only fires on observed samples.
+      - name: Upload PLUGIN_WAIT_MS log for shard ${{ matrix.shard }}
+        if: always() && env.RUN_E2E == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: plugin-wait-ms-shard-${{ matrix.shard }}
+          path: plugin-wait-ms/shard-${{ matrix.shard }}.jsonl
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Enforce PLUGIN_WAIT_MS P99 gate (shard ${{ matrix.shard }})
+        if: always() && env.RUN_E2E == 'true'
+        run: |
+          LOG="plugin-wait-ms/shard-${{ matrix.shard }}.jsonl"
+          if [ ! -s "$LOG" ]; then
+            echo "::notice::No PLUGIN_WAIT_MS samples for shard ${{ matrix.shard }} — gate skipped"
+            exit 0
+          fi
+          # Compute P99 across samples; for N<100 we floor to index
+          # `floor(N * 0.99)` which is functionally the max for small N.
+          P99=$(jq -s '
+            map(.ms) | sort_by(.) as $xs |
+            if length == 0 then 0
+            else $xs[(length - 1) | floor | if . < 0 then 0 else . end]
+            end' "$LOG" | head -1)
+          N=$(wc -l < "$LOG" | tr -d ' ')
+          echo "::notice::shard=${{ matrix.shard }} N=$N P99_PLUGIN_WAIT_MS=${P99}ms (gate: ≤15000)"
+          if [ -z "$P99" ] || [ "$P99" = "null" ]; then
+            echo "::warning::Unable to compute P99 (N=$N) — gate skipped"
+            exit 0
+          fi
+          if [ "$P99" -gt 15000 ]; then
+            echo "::error::P99 PLUGIN_WAIT_MS=${P99}ms exceeds 15000ms gate on shard ${{ matrix.shard }} (N=$N samples)"
+            exit 1
+          fi
+          echo "✅ P99 PLUGIN_WAIT_MS gate passed: ${P99}ms ≤ 15000ms"
 
   # Merge E2E test reports from all shards
   # Named "e2e-tests" to satisfy branch protection rule

--- a/packages/obsidian-plugin/tests/e2e/specs/effort-timestamps-auto-sync.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/effort-timestamps-auto-sync.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
+import { waitForExocortexPluginViaPlaywright } from "../utils/waitForExocortexPlugin";
 import * as path from "path";
 
 test.describe("Effort Timestamps Auto-Sync", () => {
@@ -17,37 +18,30 @@ test.describe("Effort Timestamps Auto-Sync", () => {
 
   test("should sync resolutionTimestamp when endTimestamp changes", async () => {
     await launcher.openFile("Tasks/timestamp-sync-task.md");
-
     const window = await launcher.getWindow();
+
+    // Playwright-level cold-start wait (RFC 3cc77ba2 v2 §Phase 1.2). Emits
+    // PLUGIN_WAIT_MS metric consumed by the CI P99 aggregator.
+    await waitForExocortexPluginViaPlaywright(window, {
+      specName: "effort-timestamps-auto-sync",
+    });
 
     // Use local ISO 8601 timestamp format (no Z suffix)
     const inputTimestamp = "2025-10-21T15:30:00";
-    // Expected output format after sync (ISO 8601 local time, no Z suffix)
     const expectedTimestamp = "2025-10-21T15:30:00";
 
-    const syncResult = await window.evaluate(async (newTimestamp) => {
+    // Trigger mutation once — plugin is already loaded, no inner wait needed.
+    const triggerResult = await window.evaluate(async (newTimestamp) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const app = (window as any).app;
-      if (!app || !app.vault) {
+      if (!app?.vault) {
         return { success: false, error: "App not available" };
       }
-
-      // Wait for exocortex plugin to be loaded
-      const maxPluginWait = 10;
-      for (let i = 0; i < maxPluginWait; i++) {
-        if (app.plugins?.plugins?.exocortex) {
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+      const plugin = app.plugins?.plugins?.exocortex;
+      if (!plugin) {
+        return { success: false, error: "Plugin not loaded at mutation time" };
       }
 
-      if (!app.plugins?.plugins?.exocortex) {
-        return {
-          success: false,
-          error: "Exocortex plugin not loaded after 10 seconds",
-        };
-      }
-
-      const plugin = app.plugins.plugins.exocortex;
       const file = app.vault.getAbstractFileByPath(
         "Tasks/timestamp-sync-task.md",
       );
@@ -55,10 +49,13 @@ test.describe("Effort Timestamps Auto-Sync", () => {
         return { success: false, error: "File not found" };
       }
 
-      // Change the frontmatter
-      await app.fileManager.processFrontMatter(file, (frontmatter: any) => {
-        frontmatter.ems__Effort_endTimestamp = newTimestamp;
-      });
+      await app.fileManager.processFrontMatter(
+        file,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (frontmatter: any) => {
+          frontmatter.ems__Effort_endTimestamp = newTimestamp;
+        },
+      );
 
       // In E2E Docker environment, metadata change events don't fire reliably,
       // so we manually trigger the sync to test the functionality.
@@ -68,75 +65,38 @@ test.describe("Effort Timestamps Auto-Sync", () => {
         await plugin.taskStatusService.syncEffortEndTimestamp(file, parsedDate);
       }
 
-      const maxRetries = 10;
-      const retryDelay = 500;
-
-      for (let i = 0; i < maxRetries; i++) {
-        await new Promise((resolve) => setTimeout(resolve, retryDelay));
-
-        const updatedContent = await app.vault.read(file);
-        const frontmatterMatch = updatedContent.match(/^---\n([\s\S]*?)\n---/);
-
-        if (!frontmatterMatch) {
-          continue;
-        }
-
-        const frontmatterText = frontmatterMatch[1];
-        const endMatch = frontmatterText.match(
-          /ems__Effort_endTimestamp:\s*(.+)$/m,
-        );
-        const resolutionMatch = frontmatterText.match(
-          /ems__Effort_resolutionTimestamp:\s*(.+)$/m,
-        );
-
-        const endTimestamp = endMatch ? endMatch[1].trim() : null;
-        const resolutionTimestamp = resolutionMatch
-          ? resolutionMatch[1].trim()
-          : null;
-
-        if (
-          endTimestamp === newTimestamp &&
-          resolutionTimestamp === newTimestamp
-        ) {
-          return {
-            success: true,
-            endTimestamp,
-            resolutionTimestamp,
-            retriesNeeded: i + 1,
-          };
-        }
-      }
-
-      const finalContent = await app.vault.read(file);
-      const finalMatch = finalContent.match(/^---\n([\s\S]*?)\n---/);
-
-      if (!finalMatch) {
-        return { success: false, error: "No frontmatter found after retries" };
-      }
-
-      const finalText = finalMatch[1];
-      const finalEndMatch = finalText.match(
-        /ems__Effort_endTimestamp:\s*(.+)$/m,
-      );
-      const finalResolutionMatch = finalText.match(
-        /ems__Effort_resolutionTimestamp:\s*(.+)$/m,
-      );
-
-      return {
-        success: false,
-        error: "Timestamps did not sync within timeout",
-        endTimestamp: finalEndMatch ? finalEndMatch[1].trim() : null,
-        resolutionTimestamp: finalResolutionMatch
-          ? finalResolutionMatch[1].trim()
-          : null,
-        expectedTimestamp: newTimestamp,
-      };
+      return { success: true };
     }, inputTimestamp);
 
-    console.log("[E2E Test] Sync result:", syncResult);
+    expect(triggerResult.success).toBe(true);
 
-    expect(syncResult.success).toBe(true);
-    expect(syncResult.endTimestamp).toBe(expectedTimestamp);
-    expect(syncResult.resolutionTimestamp).toBe(expectedTimestamp);
+    // Replace 10-retry / 500ms sleep-loop with structured `expect.poll`.
+    await expect
+      .poll(
+        async () =>
+          window.evaluate(async () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const app = (window as any).app;
+            const file = app.vault.getAbstractFileByPath(
+              "Tasks/timestamp-sync-task.md",
+            );
+            if (!file) return { end: null, resolution: null };
+            const content = await app.vault.read(file);
+            const match = content.match(/^---\n([\s\S]*?)\n---/);
+            if (!match) return { end: null, resolution: null };
+            const endMatch = match[1].match(
+              /ems__Effort_endTimestamp:\s*(.+)$/m,
+            );
+            const resMatch = match[1].match(
+              /ems__Effort_resolutionTimestamp:\s*(.+)$/m,
+            );
+            return {
+              end: endMatch ? endMatch[1].trim() : null,
+              resolution: resMatch ? resMatch[1].trim() : null,
+            };
+          }),
+        { timeout: 10_000, intervals: [200, 500, 500, 1000, 1000, 2000] },
+      )
+      .toEqual({ end: expectedTimestamp, resolution: expectedTimestamp });
   });
 });

--- a/packages/obsidian-plugin/tests/e2e/utils/waitForExocortexPlugin.ts
+++ b/packages/obsidian-plugin/tests/e2e/utils/waitForExocortexPlugin.ts
@@ -1,0 +1,115 @@
+import type { Page } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Default cold-start wait ceiling (RFC 3cc77ba2 v2 §Phase 1.2):
+ * - 30s guardrail against pathological Docker cold-starts (P99 measured ~11s).
+ * - 15s paired P99 gate is applied post-hoc by the CI aggregator, not inline.
+ */
+export const PLUGIN_WAIT_TIMEOUT_MS_DEFAULT = 30_000;
+
+export interface WaitForExocortexPluginOptions {
+  /** Wait ceiling in milliseconds. Default: {@link PLUGIN_WAIT_TIMEOUT_MS_DEFAULT}. */
+  timeoutMs?: number;
+  /** Test/spec identifier recorded in the PLUGIN_WAIT_MS log. */
+  specName?: string;
+}
+
+/**
+ * Playwright-level wait for the Exocortex plugin to register on
+ * `window.app.plugins.plugins.exocortex`. Replaces the in-spec
+ * `maxPluginWait = 10` for-loops that were classified as Category B
+ * environment flakes in RFC 3cc77ba2 v2 §Category B.
+ *
+ * Emits a `[PLUGIN_WAIT_MS] ms=N spec=X context=playwright` log line to stdout
+ * for CI stdout scrapers. If the `PLUGIN_WAIT_MS_LOG` env var is set (CI only),
+ * also appends a JSONL record to that path for per-shard aggregation.
+ */
+export async function waitForExocortexPluginViaPlaywright(
+  page: Page,
+  opts: WaitForExocortexPluginOptions = {},
+): Promise<number> {
+  const timeoutMs = opts.timeoutMs ?? PLUGIN_WAIT_TIMEOUT_MS_DEFAULT;
+  const specName = opts.specName ?? "unknown";
+  const start = Date.now();
+
+  await page.waitForFunction(
+    () => {
+      const w = window as unknown as {
+        app?: { plugins?: { plugins?: { exocortex?: unknown } } };
+      };
+      return Boolean(w.app?.plugins?.plugins?.exocortex);
+    },
+    undefined,
+    { timeout: timeoutMs },
+  );
+
+  const elapsed = Date.now() - start;
+  emitPluginWaitMs({ ms: elapsed, spec: specName, context: "playwright" });
+  return elapsed;
+}
+
+/**
+ * Browser-context plugin-wait snippet, exported as a string so it can be
+ * inlined via `page.evaluate(new Function(\`return ${evaluateWaitForPlugin}\`)())`.
+ *
+ * Use this when a test MUST poll for the plugin from inside `page.evaluate()`
+ * (e.g. to read the plugin reference that does not survive serialisation).
+ * Prefer {@link waitForExocortexPluginViaPlaywright} when the plugin reference
+ * is not needed downstream of the evaluate boundary.
+ *
+ * The function body is self-contained (no external refs) to survive
+ * stringification. Uses a structured polling loop paired with a deterministic
+ * predicate, bounded by `timeoutMs`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const evaluateWaitForPlugin = (async function (
+  timeoutMs = 30000,
+): Promise<unknown | null> {
+  const start = Date.now();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as unknown as { app?: any };
+  while (Date.now() - start < timeoutMs) {
+    const plugin = w.app?.plugins?.plugins?.exocortex;
+    if (plugin) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[PLUGIN_WAIT_MS] ms=${Date.now() - start} context=browser`,
+      );
+      return plugin;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  return null;
+}).toString();
+
+/**
+ * CI metric emission. Writes to `PLUGIN_WAIT_MS_LOG` (if set) as JSONL, and
+ * always logs to stdout. Silent no-op on write failure — observability is
+ * advisory, not test-blocking.
+ */
+function emitPluginWaitMs(record: {
+  ms: number;
+  spec: string;
+  context: "playwright" | "browser";
+}): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `[PLUGIN_WAIT_MS] ms=${record.ms} spec=${record.spec} context=${record.context}`,
+  );
+
+  const logPath = process.env.PLUGIN_WAIT_MS_LOG;
+  if (!logPath || logPath.length === 0) return;
+
+  try {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.appendFileSync(
+      logPath,
+      JSON.stringify({ ...record, ts: Date.now() }) + "\n",
+      "utf8",
+    );
+  } catch {
+    // Observability is best-effort; do not fail tests on metric emission errors.
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `tests/e2e/utils/waitForExocortexPlugin.ts` with two implementations (Playwright-context + browser-context) per RFC 3cc77ba2 v2 §Phase 1.2 (Planner B2 resolution).
- Refactors `effort-timestamps-auto-sync.spec.ts` to use the helper instead of inline `maxPluginWait=10` loop (Category B) and replaces `maxRetries=10` sleep-poll with `expect.poll()` (Category C).
- Wires `PLUGIN_WAIT_MS` JSONL log → GitHub Actions artifact → per-shard P99 gate (>15000 ms fails).
- Third of 5 PRs in RFC Phase 1; paired with PR 1.2b (alias-sync bundled per-file).

## RFC context

- RFC: `3cc77ba2-2ef7-4677-a198-ab490d6461f6` v2
- Parent Task: `d7856ad7-53d7-42fb-a806-fcb3ec6f5e97` (Phase 1 Quick Wins)
- Phase 0.1 survey: N=3 "plugin not loaded" occurrences, all in `effort-timestamps-auto-sync.spec.ts` + `alias-sync-on-label-change.spec.ts` — **Category B ship-as-fix** go/no-go met.
- Phase 0.2 launcher audit: launcher NOT root cause; spec-level `maxPluginWait=10` is. This PR replaces that loop.

## Helper design

Two implementations per context (Planner B2 — helper API unsable inside `page.evaluate` otherwise):

- **Playwright-context** — `waitForExocortexPluginViaPlaywright(page, { timeoutMs, specName })`
  - `page.waitForFunction(() => (window as any).app?.plugins?.plugins?.exocortex, {timeout})`
  - 30s guardrail (P99 is currently ~11s per Phase 0.2 measurement; 30s = 3× headroom, not target)
  - Measures wall-clock and emits stdout + JSONL (when `PLUGIN_WAIT_MS_LOG` env var is set)
- **Browser-context** — `evaluateWaitForPlugin` (stringified async function)
  - Self-contained (no external refs) — survives `.toString()` + inline into `page.evaluate`
  - Structured 200ms polling, bounded by passed timeout
  - Only exported for specs that cannot lift the wait to Playwright-level (rare)

The inner `setTimeout` in `evaluateWaitForPlugin` is in a helper file (`utils/*.ts`), not a spec — the Phase 1.1b lint rule glob is `*.spec.ts` only, so no lint drift.

## effort-timestamps-auto-sync.spec.ts refactor

Before → After:

| Section | Before | After |
| ------- | ------ | ----- |
| Plugin wait (lines 35-48) | `for (i=0; i<10; i++) { if plugin return; await setTimeout(1000); }` — 10s budget | single `await waitForExocortexPluginViaPlaywright(window, {specName})` — 30s guardrail + P99 metric |
| Frontmatter sync poll (lines 74-108) | `for (i=0; i<10; i++) { await setTimeout(500); read+regex-match; if pass return; }` — 5s worst-case | `expect.poll(() => readFrontmatter()).toEqual({end, resolution}, {timeout: 10000, intervals: [200,500,500,1000,1000,2000]})` |

Behaviour unchanged: same mutation, same expected end-state. `retriesNeeded` return field removed (was diagnostic, never asserted on).

## CI observability

- Docker-run step mounts `$PWD/plugin-wait-ms:/app/plugin-wait-ms` and sets `PLUGIN_WAIT_MS_LOG=/app/plugin-wait-ms/shard-${matrix.shard}.jsonl`.
- Post-run: `Upload PLUGIN_WAIT_MS log` artifact (30-day retention) + `Enforce P99 gate` step.
- Gate logic: `jq -s 'map(.ms)|sort_by(.)|.[(length-1)]'` over the JSONL, then compared to 15000 ms. Empty log → notice, gate skipped (not failure).
- Single-sample per shard degenerates P99 to max; acceptable for first-run, becomes meaningful once aggregated over multiple runs.

## Test plan

- [ ] 13 required CI checks pass (archgate · detect-changes · e2e-shard 1..6 · lint · test-bdd · test-component · test-coverage · typecheck)
- [ ] New steps appear in Actions: `Upload PLUGIN_WAIT_MS log for shard N` + `Enforce PLUGIN_WAIT_MS P99 gate`
- [ ] `plugin-wait-ms-shard-N` artifact retained 30 days
- [ ] P99 gate passes on current baseline (~10-11s observed; well under 15s)
- [ ] Post-merge main CI green, Auto Release publishes new tag

## RFC acceptance criteria touched

- [x] 0 `maxPluginWait` inline loops in `effort-timestamps-auto-sync.spec.ts` (helper replaces)
- [x] P99 `PLUGIN_WAIT_MS` metric published (per-shard JSONL artifact)
- [x] Gate fails at P99 > 15s per shard