### PR TITLE
ci(flaky): activate per-shard flaky-reporter fail-mode + docs/FLAKY_POLICY (RFC 3cc77ba2 Phase 1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,34 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
+      # RFC 3cc77ba2 v2 §Phase 1.3: fail-mode flaky gate per shard.
+      # Threshold resolution (most → least specific):
+      #   1. Per-shard override: `vars.FLAKY_THRESHOLD_SHARD_{N}`
+      #   2. Global default:     `vars.FLAKY_THRESHOLD` (covers all 6 shards)
+      #   3. Hardcoded fallback: `0` (Phase 0.3 baseline — 158 reports, 0 flakes)
+      # Governance: raise → 2-reviewer approval + quarantine entry with
+      # expiresAt ≤30d (see docs/FLAKY_POLICY.md). Lowering: 1 reviewer.
+      - name: Enforce FLAKY_THRESHOLD per shard
+        if: always()
+        env:
+          FLAKY_THRESHOLD: ${{ vars[format('FLAKY_THRESHOLD_SHARD_{0}', matrix.shard)] || vars.FLAKY_THRESHOLD || '0' }}
+        run: |
+          REPORT="flaky-report-shard-${{ matrix.shard }}.json"
+          if [ ! -f "$REPORT" ]; then
+            echo "::notice::No flaky-report for shard ${{ matrix.shard }} — gate skipped (jest retries disabled or run aborted)"
+            exit 0
+          fi
+          THRESHOLD="${FLAKY_THRESHOLD:-0}"
+          FLAKY=$(jq -r '.totalFlaky // 0' "$REPORT")
+          TOTAL=$(jq -r '.summary.totalTests // 0' "$REPORT")
+          echo "::notice::shard=${{ matrix.shard }} totalFlaky=${FLAKY} totalTests=${TOTAL} threshold=${THRESHOLD}"
+          if [ "$FLAKY" -gt "$THRESHOLD" ]; then
+            echo "::error::Flaky tests detected on shard ${{ matrix.shard }} (${FLAKY} > ${THRESHOLD}). Fix or quarantine per docs/FLAKY_POLICY.md. Raising FLAKY_THRESHOLD requires 2-reviewer approval + tests/quarantine.ts entry (expiresAt ≤30d)."
+            jq '.flakyTests // []' "$REPORT"
+            exit 1
+          fi
+          echo "✅ FLAKY_THRESHOLD gate passed: ${FLAKY} ≤ ${THRESHOLD}"
+
   test-coverage-cli:
     # Bare ubuntu-latest — CLI jest is node-only; no browser/playwright needed.
     runs-on: ubuntu-latest

--- a/docs/FLAKY_POLICY.md
+++ b/docs/FLAKY_POLICY.md
@@ -1,0 +1,143 @@
+# Flaky Test Policy
+
+This policy governs how the Exocortex CI pipeline detects, reports, and
+gates on flaky tests. It is the operational realisation of RFC
+`3cc77ba2-2ef7-4677-a198-ab490d6461f6` v2, §Phase 1.3.
+
+## Definitions
+
+| Term | Definition |
+| ---- | ---------- |
+| **Flaky test** | A test that, within a single CI job run, failed at least once but passed on a retry (Jest `invocations > 1 && status == "passed"`). |
+| **`FLAKY_THRESHOLD`** | Maximum tolerated `totalFlaky` count per shard per run. Starts at `0` and is raised only via governance below. |
+| **Quarantine** | A deliberate skip or tolerated-failure recorded in `tests/quarantine.ts` with an `expiresAt ≤ 30d`, pointing to a tracking issue. |
+
+## Gate behaviour
+
+The `test-coverage-shard` job uploads `flaky-report-shard-${N}.json` per
+shard and then evaluates the gate. The resolution order is most →
+least specific:
+
+1. **Per-shard override:** `vars.FLAKY_THRESHOLD_SHARD_{N}` where `N` ∈
+   {1,2,3,4,5,6}. Use this to raise only one shard.
+2. **Global default:** `vars.FLAKY_THRESHOLD`. Applies to all 6 shards.
+3. **Hardcoded fallback:** `0`. Matches the Phase 0.3 empirical baseline
+   (158 reports across 50 runs, `totalFlaky = 0` in all).
+
+Gate result:
+
+- `totalFlaky ≤ threshold` → PASS (`✅`).
+- `totalFlaky > threshold` → FAIL with `::error::` + `jq .flakyTests`
+  spill of the offending tests.
+- `flaky-report-shard-{N}.json` missing → PASS-skip with `::notice::`.
+  Expected when Jest retries are disabled for the shard.
+
+## Governance
+
+### Raising the threshold (`0 → N` or `N → M > N`)
+
+1. **2-reviewer approval** on the PR that changes the repository variable
+   or flat file defining the threshold.
+2. **Quarantine entry required** — one entry per newly tolerated flake in
+   `tests/quarantine.ts` with:
+   - `file` — path to the flaky spec.
+   - `testName` — exact `test(...)` title.
+   - `reason` — one-line plain-English cause.
+   - `issueLink` — GitHub issue tracking the root cause fix.
+   - `owner` — GitHub username / team owning the fix.
+   - `expiresAt` — ISO date ≤ 30 days from the raise commit date.
+3. **PR description** must name the quarantine entry and the issue being
+   tracked, and must quote the `flaky-report` evidence (test name and
+   retry count).
+
+### Lowering the threshold (`N → 0` or `N → M < N`)
+
+- **1 reviewer** — tightening is low-risk.
+- Remove the corresponding quarantine entry if the flake is fixed (if not,
+  keep it; the quarantine entry and the threshold are independent levers).
+
+### Measurement window reset (QA M3)
+
+Any change to `retries`, `timeout`, `quarantine`, or `FLAKY_THRESHOLD`
+**resets** the rolling window used in RFC metrics. Re-establish a new
+baseline with `N = 50` runs before claiming the policy is re-stable.
+
+## Operational runbook
+
+### Adjust the global threshold
+
+```bash
+# Raise the global threshold (applies to all 6 shards).
+gh variable set FLAKY_THRESHOLD --body '1' --repo kitelev/exocortex
+
+# Un-raise.
+gh variable set FLAKY_THRESHOLD --body '0' --repo kitelev/exocortex
+```
+
+### Adjust one shard only
+
+```bash
+# Raise shard 3 only, global stays at 0.
+gh variable set FLAKY_THRESHOLD_SHARD_3 --body '1' --repo kitelev/exocortex
+
+# Remove the shard-3 override (falls back to global).
+gh variable delete FLAKY_THRESHOLD_SHARD_3 --repo kitelev/exocortex
+```
+
+### Inspect the current values
+
+```bash
+gh variable list --repo kitelev/exocortex | grep -i flaky
+```
+
+### Local reproduction
+
+```bash
+# Download the shard artifact and inspect.
+gh run view <run-id> --log-failed --repo kitelev/exocortex
+gh api "repos/kitelev/exocortex/actions/artifacts/<artifact-id>/zip" > flaky.zip
+unzip flaky.zip && jq . flaky-report-shard-*.json
+```
+
+## Phase-0 baseline reference
+
+- Sample: 50 most-recent main CI runs as of 2026-04-24
+  (`2026-04-19 → 2026-04-24`).
+- Artefacts: 135 post-restructure + 23 pre-restructure = 158 reports.
+- `totalFlaky = 0` in every single report (CT retry-validated; Jest
+  retry-blind).
+- Conclusion: `FLAKY_THRESHOLD = 0` per-shard is the correct default.
+  Full methodology: `/Users/kitelev/Developer/phase0-flaky-threshold-baseline.md`.
+
+## Rationale — why per-shard over aggregate
+
+Per Architect M2 + Planner Q1 (RFC v2):
+
+- Aggregate `FLAKY_THRESHOLD` applied to `sum(shards)` masks single-shard
+  regressions. `[1, 1, 1, 1, 1, 0]` vs threshold `3` (aggregate 5) fails;
+  but `[5, 0, 0, 0, 0, 0]` vs threshold `3` (aggregate 5) also fails —
+  yet only the latter is the genuine single-shard regression.
+- Per-shard gives early-warning surface, at the cost of 6 independent
+  thresholds. We keep them identical by default (all `0`) so the
+  operational cost stays near zero.
+
+## Relationship with other tools
+
+- **`tests/quarantine.ts`** — the *what* to skip. Entries require
+  `expiresAt ≤ 30d`. Independent of `FLAKY_THRESHOLD` — quarantine
+  removes a failing test from the run, threshold controls tolerance for
+  any remaining retry-passes.
+- **`FLAKY_REPORT_FILE` (Jest reporter)** — the *evidence*. Generated by
+  `packages/test-utils/src/reporters/flaky-reporter.ts`. Requires
+  `jest.retryTimes()` configured somewhere in the tree; without retries,
+  `invocations` never exceeds 1 and the reporter is blind.
+- **CT retries (`playwright-ct.config.ts:retries:2`)** — the current only
+  reporter-valid retry surface. Jest/E2E are retry-disabled at time of
+  policy adoption; the gate is therefore defensive against future
+  `retries:N>0` activation (Phase 3.1 of the RFC).
+
+## Change log
+
+| Date | Author | Change |
+| ---- | ------ | ------ |
+| 2026-04-24 | ExoAssistant (RFC 3cc77ba2 Phase 1.3 author) | Initial policy. Threshold = 0 per-shard; governance described above. |


### PR DESCRIPTION
## Summary

Activates the fail-mode branch of the `flaky-reporter` infrastructure (generator-only/warn-only until now). Gates each of the 6 test-coverage shards on `totalFlaky ≤ FLAKY_THRESHOLD` with per-shard override support. Adds a governance policy doc (`docs/FLAKY_POLICY.md`) covering threshold changes, quarantine, and measurement-window reset rules.

## RFC context

- RFC: `3cc77ba2-2ef7-4677-a198-ab490d6461f6` v2 (Phase 1.3, final of 5 PRs in Phase 1)
- Parent Task: `d7856ad7-53d7-42fb-a806-fcb3ec6f5e97`
- Phase 0.3 artefact: `/Users/kitelev/Developer/phase0-flaky-threshold-baseline.md` — empirical baseline `totalFlaky = 0` across 158 reports / 50 runs; initial threshold = 0 per-shard is safe.

## CI change

New step in `test-coverage-shard` job after `Upload shard flaky report`:

| Field | Value |
| ----- | ----- |
| `FLAKY_THRESHOLD` env | `vars[format('FLAKY_THRESHOLD_SHARD_{0}', matrix.shard)] \|\| vars.FLAKY_THRESHOLD \|\| '0'` |
| Fail condition | `totalFlaky > threshold` |
| Skip condition | report missing (jest retries disabled) |
| Error output | `::error::` + `jq .flakyTests` of offenders |

Threshold resolution (most → least specific):

1. Per-shard: `vars.FLAKY_THRESHOLD_SHARD_{N}` for N ∈ {1..6}
2. Global default: `vars.FLAKY_THRESHOLD`
3. Fallback: `0`

## Policy docs

`docs/FLAKY_POLICY.md` new, covers:

- **Governance** — raise (`0 → N`) = 2-reviewer + `tests/quarantine.ts` entry with `expiresAt ≤30d`, `issueLink`, `owner`; lower = 1-reviewer.
- **Measurement window reset (QA M3)** — any `retries`/`timeout`/`quarantine`/`FLAKY_THRESHOLD` change resets the rolling baseline; N=50 runs required before re-stable.
- **Runbook** — `gh variable set/delete/list FLAKY_THRESHOLD[_SHARD_N]` usage.
- **Phase-0 baseline reference** — methodology and conclusion.
- **Per-shard vs aggregate rationale** — per Architect M2 + Planner Q1.
- **Relationship map** — how `FLAKY_THRESHOLD`, `tests/quarantine.ts`, `flaky-reporter`, and CT vs Jest retries interact.

## Risk — currently low

- Jest has no `jest.retryTimes()` configured anywhere → reporter is blind, `totalFlaky = 0` mechanically → gate is defensive-only until Phase 3.1 activates retries.
- Playwright E2E retries = 0 (D2 decision 2026-04-22) → not reported.
- Playwright CT has retries=2 but its flaky-report artifact `flaky-test-report-component` uses a different name; this PR does not gate on it (out-of-scope, its warn-only log continues unchanged).

Worst case if a real Jest retry is ever added without this PR: flaky tests silently pass. With this PR: same flake surfaces as `::error::` on first retry-pass.

## Test plan

- [ ] 13 required CI checks pass (archgate · detect-changes · e2e-shard 1..6 · lint · test-bdd · test-component · test-coverage · typecheck)
- [ ] New `Enforce FLAKY_THRESHOLD per shard` step visible in CI job log
- [ ] With current `FLAKY_THRESHOLD` unset (fallback = 0) and baseline 0 flakes, gate passes silently with `✅ FLAKY_THRESHOLD gate passed: 0 ≤ 0`
- [ ] Post-merge main CI green, Auto Release publishes new tag
- [ ] `docs/FLAKY_POLICY.md` rendered correctly on GitHub (markdown preview)

## RFC acceptance criteria touched

- [x] flaky-reporter active in fail-mode per shard
- [x] `docs/FLAKY_POLICY.md` created, governance documented
- [x] `FLAKY_THRESHOLD` is a GitHub repository variable (runtime override)
- [x] Initial threshold = 0 per-shard (Phase 0.3 baseline)