### PR TITLE
feat(e2e): data-flake detector for fixture drift (RFC 3cc77ba2 Phase 2.2 step 1)

### DIFF
--- a/packages/obsidian-plugin/playwright-e2e.config.ts
+++ b/packages/obsidian-plugin/playwright-e2e.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
     ["list"],
     ...(process.env.CI ? [["github", {}] as ["github", {}]] : []),
     ["./playwright-no-flaky-reporter.ts"],
+    // RFC 3cc77ba2 Phase 2.2 step 1 — data-flake detector (Category F).
+    // Warn-only: snapshots tests/e2e/test-vault/ before/after each test and writes
+    // test-results/fixture-drift.json for CI artifact pickup. Never fails the run.
+    ["./tests/e2e/reporters/fixture-drift-reporter.ts"],
   ],
 
   // Output directory for test artifacts (videos, screenshots, traces)

--- a/packages/obsidian-plugin/tests/e2e/reporters/fixture-drift-reporter.ts
+++ b/packages/obsidian-plugin/tests/e2e/reporters/fixture-drift-reporter.ts
@@ -1,0 +1,151 @@
+import type {
+  FullConfig,
+  Reporter,
+  TestCase,
+  TestResult,
+} from "@playwright/test/reporter";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  diffSnapshots,
+  snapshotVault,
+  type VaultDrift,
+  type VaultSnapshot,
+} from "../utils/vault-hash";
+
+interface DriftEntry {
+  spec: string;
+  test: string;
+  status: TestResult["status"];
+  durationMs: number;
+  drifted: boolean;
+  drift: VaultDrift;
+  beforeTakenAt: string;
+  afterTakenAt: string;
+}
+
+interface DriftReport {
+  generatedAt: string;
+  vaultPath: string;
+  totalTests: number;
+  totalDrifted: number;
+  entries: DriftEntry[];
+}
+
+const DEFAULT_VAULT_REL =
+  "packages/obsidian-plugin/tests/e2e/test-vault";
+
+function resolveVaultPath(configRootDir: string): string | null {
+  const envOverride = process.env.FIXTURE_DRIFT_VAULT_PATH;
+  if (envOverride && fs.existsSync(envOverride)) return envOverride;
+
+  const candidateRoots = [
+    configRootDir,
+    path.resolve(configRootDir, ".."),
+    path.resolve(configRootDir, "..", ".."),
+    process.cwd(),
+    path.resolve(process.cwd(), ".."),
+  ];
+  for (const root of candidateRoots) {
+    const candidate = path.join(root, DEFAULT_VAULT_REL);
+    if (fs.existsSync(candidate)) return candidate;
+    const direct = path.join(root, "tests/e2e/test-vault");
+    if (fs.existsSync(direct)) return direct;
+  }
+  return null;
+}
+
+function resolveOutputPath(configRootDir: string): string {
+  const envOverride = process.env.FIXTURE_DRIFT_OUTPUT;
+  if (envOverride) return envOverride;
+  // test-results/ is Playwright's outputDir and is the volume mount in Docker CI
+  // (-v $PWD/test-results-e2e:/app/test-results) so writing here ensures artifact pickup.
+  const dir = path.join(configRootDir, "test-results");
+  return path.join(dir, "fixture-drift.json");
+}
+
+export default class FixtureDriftReporter implements Reporter {
+  private vaultPath: string | null = null;
+  private rootDir: string = process.cwd();
+  private beforeByTestId = new Map<string, VaultSnapshot>();
+  private entries: DriftEntry[] = [];
+  private disabled = false;
+
+  onBegin(config: FullConfig): void {
+    this.rootDir = config.rootDir || process.cwd();
+    this.vaultPath = resolveVaultPath(this.rootDir);
+    if (!this.vaultPath) {
+      this.disabled = true;
+      console.warn(
+        "[fixture-drift-reporter] vault path not resolved — reporter disabled",
+      );
+    }
+  }
+
+  onTestBegin(test: TestCase): void {
+    if (this.disabled || !this.vaultPath) return;
+    try {
+      const snapshot = snapshotVault(this.vaultPath);
+      this.beforeByTestId.set(test.id, snapshot);
+    } catch (err) {
+      console.warn(
+        `[fixture-drift-reporter] snapshot-before failed for ${test.title}:`,
+        err,
+      );
+    }
+  }
+
+  onTestEnd(test: TestCase, result: TestResult): void {
+    if (this.disabled || !this.vaultPath) return;
+    const before = this.beforeByTestId.get(test.id);
+    this.beforeByTestId.delete(test.id);
+    if (!before) return;
+    try {
+      const after = snapshotVault(this.vaultPath);
+      const drift = diffSnapshots(before, after);
+      this.entries.push({
+        spec: path.relative(this.rootDir, test.location.file),
+        test: test.title,
+        status: result.status,
+        durationMs: result.duration,
+        drifted: drift.totalChanged > 0,
+        drift,
+        beforeTakenAt: before.takenAt,
+        afterTakenAt: after.takenAt,
+      });
+    } catch (err) {
+      console.warn(
+        `[fixture-drift-reporter] snapshot-after failed for ${test.title}:`,
+        err,
+      );
+    }
+  }
+
+  onEnd(): void {
+    if (this.disabled || !this.vaultPath) return;
+    const report: DriftReport = {
+      generatedAt: new Date().toISOString(),
+      vaultPath: this.vaultPath,
+      totalTests: this.entries.length,
+      totalDrifted: this.entries.filter((e) => e.drifted).length,
+      entries: this.entries,
+    };
+    const outPath = resolveOutputPath(this.rootDir);
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, JSON.stringify(report, null, 2), "utf-8");
+    // Warn-only console summary; does NOT fail the run (Phase 2.2 step 1 = detection only).
+    if (report.totalDrifted > 0) {
+      console.warn(
+        `[fixture-drift-reporter] ${report.totalDrifted}/${report.totalTests} test(s) left fixture in drifted state — see ${path.relative(this.rootDir, outPath)}`,
+      );
+    } else {
+      console.log(
+        `[fixture-drift-reporter] 0/${report.totalTests} fixture drift — report: ${path.relative(this.rootDir, outPath)}`,
+      );
+    }
+  }
+
+  printsToStdio(): boolean {
+    return false;
+  }
+}

--- a/packages/obsidian-plugin/tests/e2e/utils/vault-hash.ts
+++ b/packages/obsidian-plugin/tests/e2e/utils/vault-hash.ts
@@ -1,0 +1,103 @@
+import { createHash } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+
+export interface VaultFileSnapshot {
+  relPath: string;
+  sha256: string;
+  size: number;
+}
+
+export interface VaultSnapshot {
+  takenAt: string;
+  vaultPath: string;
+  files: VaultFileSnapshot[];
+}
+
+export interface VaultDrift {
+  added: string[];
+  removed: string[];
+  modified: string[];
+  totalChanged: number;
+}
+
+const DEFAULT_IGNORED_SEGMENTS = new Set<string>([
+  ".obsidian",
+  ".trash",
+  ".git",
+]);
+
+function collectFiles(
+  root: string,
+  ignored: Set<string>,
+  current: string,
+  out: string[],
+): void {
+  const entries = fs.readdirSync(path.join(root, current), {
+    withFileTypes: true,
+  });
+  for (const entry of entries) {
+    if (ignored.has(entry.name)) continue;
+    const rel = current ? path.posix.join(current, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      collectFiles(root, ignored, rel, out);
+    } else if (entry.isFile()) {
+      out.push(rel);
+    }
+  }
+}
+
+export function snapshotVault(
+  vaultPath: string,
+  ignored: Set<string> = DEFAULT_IGNORED_SEGMENTS,
+): VaultSnapshot {
+  const files: VaultFileSnapshot[] = [];
+  const relPaths: string[] = [];
+  collectFiles(vaultPath, ignored, "", relPaths);
+  relPaths.sort();
+  for (const relPath of relPaths) {
+    const abs = path.join(vaultPath, relPath);
+    const stat = fs.statSync(abs);
+    const buf = fs.readFileSync(abs);
+    const sha256 = createHash("sha256").update(buf).digest("hex");
+    files.push({ relPath, sha256, size: stat.size });
+  }
+  return {
+    takenAt: new Date().toISOString(),
+    vaultPath,
+    files,
+  };
+}
+
+export function diffSnapshots(
+  before: VaultSnapshot,
+  after: VaultSnapshot,
+): VaultDrift {
+  const beforeMap = new Map(before.files.map((f) => [f.relPath, f.sha256]));
+  const afterMap = new Map(after.files.map((f) => [f.relPath, f.sha256]));
+  const added: string[] = [];
+  const removed: string[] = [];
+  const modified: string[] = [];
+  for (const [rel, sha] of afterMap) {
+    const prev = beforeMap.get(rel);
+    if (prev === undefined) {
+      added.push(rel);
+    } else if (prev !== sha) {
+      modified.push(rel);
+    }
+  }
+  for (const rel of beforeMap.keys()) {
+    if (!afterMap.has(rel)) {
+      removed.push(rel);
+    }
+  }
+  added.sort();
+  removed.sort();
+  modified.sort();
+  return {
+    added,
+    removed,
+    modified,
+    totalChanged: added.length + removed.length + modified.length,
+  };
+}

--- a/packages/obsidian-plugin/tests/unit/utilities/vault-hash.test.ts
+++ b/packages/obsidian-plugin/tests/unit/utilities/vault-hash.test.ts
@@ -1,0 +1,121 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  diffSnapshots,
+  snapshotVault,
+} from "../../e2e/utils/vault-hash";
+
+describe("vault-hash utility (Phase 2.2 data-flake detector)", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vault-hash-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function writeFile(relPath: string, content: string): void {
+    const abs = path.join(tmpRoot, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, "utf-8");
+  }
+
+  it("returns empty files list for empty vault", () => {
+    const snap = snapshotVault(tmpRoot);
+    expect(snap.files).toEqual([]);
+    expect(snap.vaultPath).toBe(tmpRoot);
+  });
+
+  it("produces stable hashes sorted by relPath", () => {
+    writeFile("z.md", "z-content");
+    writeFile("a.md", "a-content");
+    writeFile("dir/b.md", "b-content");
+
+    const snap = snapshotVault(tmpRoot);
+    expect(snap.files.map((f) => f.relPath)).toEqual([
+      "a.md",
+      "dir/b.md",
+      "z.md",
+    ]);
+    for (const file of snap.files) {
+      expect(file.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(file.size).toBeGreaterThan(0);
+    }
+  });
+
+  it("ignores .obsidian directory by default", () => {
+    writeFile(".obsidian/workspace.json", '{"foo":"bar"}');
+    writeFile("Tasks/task-1.md", "task body");
+
+    const snap = snapshotVault(tmpRoot);
+    expect(snap.files).toHaveLength(1);
+    expect(snap.files[0].relPath).toBe("Tasks/task-1.md");
+  });
+
+  it("diffSnapshots detects added files", () => {
+    writeFile("a.md", "a");
+    const before = snapshotVault(tmpRoot);
+    writeFile("b.md", "b");
+    const after = snapshotVault(tmpRoot);
+    const drift = diffSnapshots(before, after);
+    expect(drift.added).toEqual(["b.md"]);
+    expect(drift.removed).toEqual([]);
+    expect(drift.modified).toEqual([]);
+    expect(drift.totalChanged).toBe(1);
+  });
+
+  it("diffSnapshots detects removed files", () => {
+    writeFile("a.md", "a");
+    writeFile("b.md", "b");
+    const before = snapshotVault(tmpRoot);
+    fs.unlinkSync(path.join(tmpRoot, "b.md"));
+    const after = snapshotVault(tmpRoot);
+    const drift = diffSnapshots(before, after);
+    expect(drift.added).toEqual([]);
+    expect(drift.removed).toEqual(["b.md"]);
+    expect(drift.modified).toEqual([]);
+    expect(drift.totalChanged).toBe(1);
+  });
+
+  it("diffSnapshots detects modified files by content hash", () => {
+    writeFile("a.md", "before");
+    const before = snapshotVault(tmpRoot);
+    writeFile("a.md", "after");
+    const after = snapshotVault(tmpRoot);
+    const drift = diffSnapshots(before, after);
+    expect(drift.added).toEqual([]);
+    expect(drift.removed).toEqual([]);
+    expect(drift.modified).toEqual(["a.md"]);
+    expect(drift.totalChanged).toBe(1);
+  });
+
+  it("diffSnapshots reports no drift when vault is untouched", () => {
+    writeFile("Tasks/timestamp-sync-task.md", "# task");
+    writeFile("Projects/p.md", "# project");
+    const before = snapshotVault(tmpRoot);
+    const after = snapshotVault(tmpRoot);
+    const drift = diffSnapshots(before, after);
+    expect(drift.totalChanged).toBe(0);
+    expect(drift.added).toEqual([]);
+    expect(drift.removed).toEqual([]);
+    expect(drift.modified).toEqual([]);
+  });
+
+  it("diffSnapshots handles multi-category drift (Category F canonical case)", () => {
+    writeFile("Tasks/t1.md", "original");
+    writeFile("Tasks/t2.md", "stable");
+    const before = snapshotVault(tmpRoot);
+    writeFile("Tasks/t1.md", "mutated by processFrontMatter");
+    fs.unlinkSync(path.join(tmpRoot, "Tasks/t2.md"));
+    writeFile("Tasks/t3.md", "created by test");
+    const after = snapshotVault(tmpRoot);
+    const drift = diffSnapshots(before, after);
+    expect(drift.modified).toEqual(["Tasks/t1.md"]);
+    expect(drift.removed).toEqual(["Tasks/t2.md"]);
+    expect(drift.added).toEqual(["Tasks/t3.md"]);
+    expect(drift.totalChanged).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a warn-only Playwright reporter that SHA-256-hashes `tests/e2e/test-vault/` before and after each test and writes `test-results/fixture-drift.json` for CI artifact pickup. Implements **Phase 2.2 step 1** of RFC `3cc77ba2-2ef7-4677-a198-ab490d6461f6` (v2) — detection infrastructure that the later decision gate (Option A/B/C, Phase 2.2 step 3) will consume.

### Why a reporter, not per-spec hooks

- Zero spec changes (15 specs untouched)
- Works via `onTestBegin` / `onTestEnd`, so snapshots bracket `test.afterEach` (launcher.close() and any manual fixture restore finish before the after-snapshot)
- Reporter is inherited automatically by all 6 shard configs via `...baseConfig` spread in `playwright-shard-config-factory.ts`
- `Dockerfile.e2e` already `COPY packages/obsidian-plugin/tests/e2e/` wholesale, so no Docker change

### Baseline audit findings (bakes into Phase 2.2 decision data)

Audited all 15 E2E specs for fixture mutation and rollback:

| Spec | Mutation vector | Rollback? |
|---|---|---|
| `dynamic-command-buttons-render.spec.ts` | `fs.writeFileSync(FIXTURE_PATH, ...)` | ✅ `afterEach` restores `fixtureOriginal` |
| `effort-timestamps-auto-sync.spec.ts` | `app.fileManager.processFrontMatter(file, ...)` via `page.evaluate` | ❌ canonical Category F data flake |
| 13 others | `launcher.close()` only | Indeterminate — reporter will tell us |

The mutation vector everyone missed in the v1 discussion is `app.fileManager.processFrontMatter()` invoked inside `page.evaluate()` — it bypasses `fs.writeFileSync` grep entirely and is what `effort-timestamps-auto-sync` uses.

### What the reporter emits

`test-results/fixture-drift.json`:
```jsonc
{
  "generatedAt": "2026-04-24T...",
  "vaultPath": "/.../tests/e2e/test-vault",
  "totalTests": N,
  "totalDrifted": M,
  "entries": [
    {
      "spec": "packages/obsidian-plugin/tests/e2e/specs/effort-timestamps-auto-sync.spec.ts",
      "test": "should sync resolutionTimestamp ...",
      "status": "passed",
      "durationMs": 42000,
      "drifted": true,
      "drift": { "added": [], "removed": [], "modified": ["Tasks/timestamp-sync-task.md"], "totalChanged": 1 },
      "beforeTakenAt": "...",
      "afterTakenAt": "..."
    }
  ]
}
```

In CI the Docker run mounts `$PWD/test-results-e2e:/app/test-results`, so this file is uploaded as part of the existing `e2e-test-artifacts-<shard>` artifact — no workflow change.

### Scope guard (explicit)

- **Warn-only**. Never fails the run (Phase 2.2 step 1 is detection, not fix).
- `.obsidian/`, `.trash/`, `.git/` excluded from hashing to eliminate false positives from Obsidian config writes.
- Reporter no-ops if it can't resolve the vault path (`FIXTURE_DRIFT_VAULT_PATH` env override available).

### Non-goals (explicit, for future phases)

- Does NOT decide Option A/B/C — that's step 3, after N=20 measurement across ≥3 CI invocations (RFC v2 M8 cold/warm cache mix requirement)
- Does NOT fail CI on drift — enforcement comes after the isolation decision
- Does NOT cover Docker-build cache variance (Phase 2.3, optional)

## Test plan

- [x] 8 unit tests for `vault-hash.ts` — empty vault, stable ordering, `.obsidian` exclusion, added/removed/modified detection, multi-category drift (Category F canonical case)
- [x] `tsc --noEmit` clean on `packages/obsidian-plugin`
- [x] Lint: only pre-existing errors in `ExocortexSettingTab.ts` (unchanged by this PR; lint job is `continue-on-error: true`)
- [ ] 13 required CI checks green
- [ ] First CI run produces `fixture-drift.json` entry per test — confirm `effort-timestamps-auto-sync.spec.ts` flags as drifted, `dynamic-command-buttons-render.spec.ts` flags as clean (baseline validation of detector correctness)

Refs: RFC `3cc77ba2-2ef7-4677-a198-ab490d6461f6` v2 §Phase 2.2, task `1e13509c-cc5e-4ef1-a334-af7b3d67cbd9` step 1.