### PR TITLE
fix(ci): route fixture-drift.json to mounted path (RFC 3cc77ba2 Phase 2.2 hotfix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -904,6 +904,7 @@ jobs:
             -v $PWD/plugin-wait-ms:/app/plugin-wait-ms \
             -e CI=true \
             -e PLUGIN_WAIT_MS_LOG=/app/plugin-wait-ms/shard-${{ matrix.shard }}.jsonl \
+            -e FIXTURE_DRIFT_OUTPUT=/app/test-results/fixture-drift.json \
             exocortex-e2e npx playwright test -c packages/obsidian-plugin/playwright.shard-${{ matrix.shard }}.config.ts
 
       - name: Upload blob report for shard ${{ matrix.shard }}


### PR DESCRIPTION
## Summary

- Fixes PR #2952 regression: `fixture-drift.json` written to unmounted path inside Docker container, so `e2e-test-artifacts-<shard>` never picks it up.
- Single-line addition: `-e FIXTURE_DRIFT_OUTPUT=/app/test-results/fixture-drift.json` in the `docker run` invocation. The reporter already honours this env var (`fixture-drift-reporter.ts:39`).

## Root cause

`FixtureDriftReporter` writes to `path.join(config.rootDir, "test-results", "fixture-drift.json")`. Inside the e2e Docker container, `config.rootDir` resolves to `/app/packages/obsidian-plugin`, so the JSON lands in `/app/packages/obsidian-plugin/test-results/fixture-drift.json`. The CI Docker volume mount (`ci.yml:901`) is `-v \$PWD/test-results-e2e:/app/test-results` — only `/app/test-results/` is mapped to the host. Result: reporter runs correctly, console warn fires (`[fixture-drift-reporter] 3/5 test(s) left fixture in drifted state` on shard 1 of merge commit `3e2da42d`), but the file is stranded inside the container and `Upload E2E test artifacts` reports `No files were found with the provided path: test-results-e2e/`.

Evidence: merge-commit run [24902858757](https://github.com/kitelev/exocortex/actions/runs/24902858757) — shard 1 log shows both the reporter warn AND the empty-upload message.

## Why env var, not reporter code change

- `FIXTURE_DRIFT_OUTPUT` env var is already implemented by the reporter (takes priority over default path, parent dir created via `mkdirSync({recursive:true})`).
- Zero reporter code changes → zero new unit tests required.
- Keeps the reporter path logic generic (it works correctly in local non-Docker runs where `config.rootDir` == process cwd).

## Impact

Unblocks RFC 3cc77ba2 Phase 2.2 step 2 (N=20 measurement) which depends on `fixture-drift.json` being available in the CI artefact bundle.

## Test plan

- [x] Diff is a single-line env var addition
- [x] Local syntax check: YAML valid, env var name matches reporter's `process.env.FIXTURE_DRIFT_OUTPUT`
- [ ] CI: all 13 required checks pass on this PR
- [ ] Post-merge verification (session 3): download `e2e-test-artifacts-1` from the merge run, confirm `fixture-drift.json` present with `effort-timestamps-auto-sync.spec.ts` → `drifted: true` and `"Tasks/timestamp-sync-task.md"` in `modified[]`