### PR TITLE
docs(e2e): shared fixture invariant + Option C decision (RFC 3cc77ba2 Phase 2.2)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/README.md
+++ b/packages/obsidian-plugin/tests/e2e/specs/README.md
@@ -1,0 +1,43 @@
+# E2E specs — shared fixture invariant & ordering contract
+
+Author: RFC `3cc77ba2` Phase 2.2 — Option C (docs + ordering contract).
+Decision record: `/Users/kitelev/vault-2025/03 Knowledge/inbox/1e13509c-cc5e-4ef1-a334-af7b3d67cbd9.md` (session 3, 2026-04-25).
+
+## Shared fixture invariant
+
+Specs in this directory execute against a **shared** vault under `tests/e2e/test-vault/`. The vault is mounted read-write into the Docker Obsidian container and **is not restored** between tests or between specs unless the test does so explicitly.
+
+Consequences:
+
+- A test that mutates a fixture file (via `fs.writeFileSync`, `app.fileManager.processFrontMatter`, or plugin-triggered writes) leaves the fixture in a drifted state for every subsequent test in the same shard.
+- Plugin logging emits to `test-vault/exocortex-logs.txt`. That file is almost always in the modified set of `fixture-drift.json`; it is ambient output and can be ignored for isolation purposes.
+- Specs do **not** declare or rely on a cross-spec ordering contract. Parallel/shuffled execution must still pass. Any spec that requires a specific neighbour state must set that state itself in `beforeAll`/`beforeEach` rather than depend on the order Playwright happens to choose.
+
+## Fixture drift detector
+
+The Playwright reporter `../reporters/fixture-drift-reporter.ts` hashes every non-ignored file in `test-vault/` before and after each test. A test that leaves any non-ignored file changed is recorded in `test-results/fixture-drift.json` (inside the container → surfaced to `e2e-test-artifacts-<shard>` via the `FIXTURE_DRIFT_OUTPUT` env var passed from CI, see `.github/workflows/ci.yml`). The reporter is **warn-only** — drift never fails CI. It exists as an early-warning signal so that future classes of flake can be classified quickly.
+
+At the time of the Phase 2.2 decision (2026-04-25, run `24904690787`) the detector reported 54/64 tests drift. Most drift is ambient (`exocortex-logs.txt`) or locally-contained plugin writes; one canonical spec (`effort-timestamps-auto-sync.spec.ts`, Category F in the RFC audit) mutates `Tasks/timestamp-sync-task.md` with no rollback. Left as-is per Option C.
+
+## When to add a per-spec cleanup
+
+The N=19 post-D0 variance audit that informed Option C showed:
+
+- test-step wall-clock variance ≤ 5 s excluding the D0 transition run — below the RFC v2 `> 15 s → Option B` threshold;
+- e2e retry rate 21 % (4/19) driven by **selector timeout / browser-closed / assertion / infra-timeout** modes — **not** by drift-correlated specs.
+
+If a retry in CI turns out to be caused by drift (a failed test explicitly reads a file another test mutated), add spec-local cleanup rather than rolling out a global hook. The reference pattern is `dynamic-command-buttons-render.spec.ts` (lines 32–43): `fs.readFileSync` snapshot in `beforeEach`, `fs.writeFileSync` restore in `afterEach`. Keep the scope to the one file the spec mutates.
+
+If drift-correlated retries become systemic (≥ 3 specs across ≥ 2 shards), escalate to Option A (`afterEach` whitelist driven by `fixture-drift.json`) and re-open RFC 3cc77ba2 Phase 2.2.
+
+## Docker cache (RFC Phase 2.3) — skipped
+
+Phase 2.3 (Docker buildx `--cache-from=type=gha`) was marked optional in RFC v2 and is **not** pursued. Rationale: `feedback_ci_runner_variance_dwarfs_measurement.md` established that runner scheduling variance dominates image-level variance in this repository; delta < 5 % baseline is expected, below the RFC skip criterion.
+
+## Running a single spec locally
+
+```
+npm run test:e2e -- packages/obsidian-plugin/tests/e2e/specs/<name>.spec.ts
+```
+
+Tests run inside Docker only. Never invoke Playwright against a host-side Obsidian — see `PATTERNS.md` § Docker E2E.

--- a/scripts/phase2-2-measurement.sh
+++ b/scripts/phase2-2-measurement.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# phase2-2-measurement.sh — collect per-shard test-step timing from main CI runs
+#
+# Related: RFC 3cc77ba2 Phase 2.2 decision (Option C, 2026-04-25). This script
+# captures the inputs that fed the decision so a future session can re-measure
+# cheaply if drift-correlated retries appear and Option A/B revisit is needed.
+#
+# Usage:
+#   scripts/phase2-2-measurement.sh [NUM_RUNS] [OUTPUT_DIR]
+#     NUM_RUNS   : how many recent successful main CI runs to sample (default 20)
+#     OUTPUT_DIR : where per-run / aggregate JSON is written (default $PWD/phase2-measurement)
+#
+# Requires: gh (authenticated against kitelev/exocortex), jq, python3.
+#
+# Notes:
+# - Only post-D0 runs are 6-shard; if you reach back that far the Python
+#   aggregator will drop runs missing shards.
+# - run_attempt=2 jobs are treated as retries and excluded from the "clean"
+#   variance aggregate; they are reported separately as flake signal.
+# - Output format matches phase2-2-test-step-variance-2026-04-25.json.
+
+set -euo pipefail
+
+NUM_RUNS="${1:-20}"
+OUTPUT_DIR="${2:-$PWD/phase2-measurement}"
+REPO="${REPO:-kitelev/exocortex}"
+WORKFLOW="${WORKFLOW:-CI}"
+BRANCH="${BRANCH:-main}"
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "→ listing last $NUM_RUNS successful $BRANCH runs of workflow $WORKFLOW"
+mapfile -t RUN_IDS < <(
+  gh run list --repo "$REPO" --workflow="$WORKFLOW" --branch="$BRANCH" \
+    --status=success --limit "$NUM_RUNS" --json databaseId --jq '.[].databaseId'
+)
+
+if [[ ${#RUN_IDS[@]} -eq 0 ]]; then
+  echo "no successful runs found" >&2
+  exit 1
+fi
+
+echo "→ collecting step-level timing for ${#RUN_IDS[@]} runs"
+for rid in "${RUN_IDS[@]}"; do
+  out="$OUTPUT_DIR/steps-${rid}.json"
+  if [[ -s "$out" ]]; then
+    continue
+  fi
+  gh api "repos/$REPO/actions/runs/${rid}/jobs?per_page=100" \
+    --jq '[.jobs[] | select(.name | contains("e2e-shard")) | {name, run_attempt, steps: [.steps[] | select(.name | startswith("Run E2E tests")) | {name, started_at, completed_at}]}]' \
+    > "$out"
+done
+
+echo "→ aggregating"
+python3 - "$OUTPUT_DIR" "${RUN_IDS[@]}" <<'PY'
+import json, statistics as S, sys
+from datetime import datetime
+from pathlib import Path
+
+base = Path(sys.argv[1])
+ids = sys.argv[2:]
+
+def parse(s): return datetime.strptime(s.replace("Z", ""), "%Y-%m-%dT%H:%M:%S")
+
+clean, retried = [], []
+for rid in ids:
+    f = base / f"steps-{rid}.json"
+    if not f.exists(): continue
+    data = json.loads(f.read_text())
+    if any(j.get("run_attempt", 1) == 2 for j in data):
+        retried.append(rid); continue
+    row = {"run_id": rid}
+    for job in data:
+        if job.get("run_attempt", 1) != 1: continue
+        steps = job.get("steps") or []
+        if not steps: continue
+        s = steps[0]
+        row[job["name"]] = int((parse(s["completed_at"]) - parse(s["started_at"])).total_seconds())
+    clean.append(row)
+
+per_shard = {f"e2e-shard ({i})": [] for i in range(1, 7)}
+for row in clean:
+    for i in range(1, 7):
+        v = row.get(f"e2e-shard ({i})")
+        if v is not None:
+            per_shard[f"e2e-shard ({i})"].append(v)
+
+stats = {}
+for name, vals in per_shard.items():
+    if not vals: continue
+    n = len(vals)
+    stats[name] = {
+        "n": n, "min": min(vals), "max": max(vals), "range": max(vals) - min(vals),
+        "avg": round(S.mean(vals), 1), "median": S.median(vals),
+        "stdev": round(S.stdev(vals), 1) if n > 1 else 0,
+    }
+
+max_range = max((s["range"] for s in stats.values()), default=0)
+decision = "B" if max_range > 15 else "A" if max_range < 5 else "C"
+
+report = {
+    "generated_at": datetime.utcnow().isoformat() + "Z",
+    "N_total": len(ids), "N_clean": len(clean), "N_retried": len(retried),
+    "retry_rate_pct": round(len(retried) / max(len(ids), 1) * 100, 1),
+    "per_shard_stats": stats,
+    "max_range_s": max_range,
+    "rfc_v2_decision_candidate": f"Option {decision}",
+    "clean_runs": clean,
+    "retried_runs": retried,
+}
+out = base / "phase2-2-variance.json"
+out.write_text(json.dumps(report, indent=2))
+print(f"clean={len(clean)} retried={len(retried)} max_range={max_range}s => Option {decision}")
+print(f"saved: {out}")
+PY


### PR DESCRIPTION
## Summary

- Documents the shared-fixture invariant for E2E specs and the upgrade criteria for escalating to Option A/B if drift-correlated retries appear.
- Adds `scripts/phase2-2-measurement.sh` so future sessions can reproduce the variance audit that informed the decision.
- Formalises RFC 3cc77ba2 Phase 2.2 as **Option C** (docs + ordering contract) and marks Phase 2.3 skipped per the RFC skip criterion.

## Why Option C

N=19 post-D0 measurement (2026-04-22 → 2026-04-24, sampled 2026-04-25):

| Metric | Value | Decision matrix |
| --- | --- | --- |
| Test-step wall-clock variance (max per-shard range, excl. D0 transition) | **5 s** | RFC v2 `< 5 s → A, 5–15 s → C, > 15 s → B` |
| e2e retry rate (attempt 1 → attempt 2) | **4 / 19 = 21 %** | flake signal, resolved below |
| Fixture drift rate | **84 %** (1 post-hotfix observation) | scope signal, not retry driver |

Failure-mode correlation audit (the tiebreaker):

- `starter-kit-smoke.spec.ts` — `waitForSelector` timeout 30 s (Obsidian UI race)
- `daily-note-tasks.spec.ts` — `Target page, context or browser has been closed`
- `dynamic-commands.spec.ts` — `expect().toBe()` equality mismatch
- `actions/download-artifact@v7` `ETIMEDOUT` on one job

0 of 4 failures correlated with drift-tagged specs (e.g. `effort-timestamps-auto-sync.spec.ts`). These are Phase 3 (retry policy / selector stability) territory, not fixture isolation. Option A would implement `afterEach` cleanup without reducing retry rate; Option B would pay multi-week cost against an unrelated root cause.

Option C keeps the warn-only detector (`fixture-drift-reporter.ts`) live as an early-warning signal: if drift-correlated retries appear on ≥ 3 specs / ≥ 2 shards, the README directs the next session back into RFC 3cc77ba2 Phase 2.2 for an Option A revisit.

Full data and advisor gate trail in the task body (`/Users/kitelev/vault-2025/03 Knowledge/inbox/1e13509c-cc5e-4ef1-a334-af7b3d67cbd9.md`).

## Test plan

- [ ] archgate, lint, typecheck, test-bdd, test-component, test-coverage pass (docs-only + scripts/, no runtime impact)
- [ ] e2e-shard (1..6) pass (README is not loaded by Playwright)
- [ ] `bash -n scripts/phase2-2-measurement.sh` syntax-checked locally