### PR TITLE
feat(layout): exo__Layout Phase 3 — docs + docs-example CT + E2E smoke

### DIFF
--- a/packages/obsidian-plugin/docs/EXO_LAYOUT.md
+++ b/packages/obsidian-plugin/docs/EXO_LAYOUT.md
@@ -1,0 +1,228 @@
+# `exo__Layout` — RDF-configurable layout blocks (zero codeblock)
+
+`exo__Layout` lets you declare, directly in the vault, the entire body
+structure of a note whose class you own. Instead of writing a
+`dataviewjs` / `exo-layout` codeblock inside every `period__Week` note (or
+every `ems__Project`, or every `ems__Area`), you publish **one** Layout
+asset that targets the class, reference a handful of **Block** assets, and
+the plugin renders the declared blocks in the declared order on every
+note of that class — no per-note plumbing required.
+
+Layouts and blocks live as regular vault files with `exo__Layout` or an
+`exo__*Block` subclass in `exo__Instance_class`. The plugin's
+`ExoLayoutRepository` indexes them at load (single vault scan, 150 ms
+debounce, double-buffered snapshot reads) and `UniversalLayoutRenderer`
+consults the `LayoutSelector` on every note render. If a Layout is
+selected, the default Asset Relations table is replaced by the declared
+blocks; if no Layout matches, everything falls back to the legacy
+Asset Relations rendering — the feature is purely additive.
+
+## Feature flag
+
+`ExocortexSettings.enableExoLayoutRenderer` gates consumption of the
+resolver by the renderer. Defaults:
+
+- `true` on new installs.
+- Toggling to `false` reverts every note to the legacy Asset Relations
+  rendering, even if a matching Layout exists — useful for bisecting a
+  regression or A/B-ing the new experience against the legacy one.
+
+The toggle is live in the Settings tab; no plugin reload required.
+
+## Quickstart — `period__Week` with backlinks columns for `ems__WeeklyObjective`
+
+The motivating scenario: you want every `period__Week` note to show a
+single table of its backlinking `ems__WeeklyObjective` rows, with exactly
+two columns (`exo__Asset_createdAt` and `exo__Asset_label`) — **not** the
+default `Name` + `Instance Class` columns produced by Asset Relations, and
+**not** wrapped in the default "Asset Relations" heading.
+
+Create **two files anywhere in your vault** (folder and basename are
+irrelevant — discovery is by `exo__Instance_class`):
+
+### File 1 — the Layout asset
+
+```yaml
+---
+exo__Asset_uid: 0b8af5f8-7a9f-4f24-9e80-3d8de32f8b3b
+exo__Asset_label: "period__Week layout"
+exo__Instance_class:
+  - "[[exo__Layout]]"
+exo__Layout_targetClass: "[[period__Week]]"
+exo__Layout_blocks:
+  - "[[c1c9b3cd-7f42-4f5a-9a0a-9d3e0f9c6b11]]"
+exo__Layout_priority: 0
+exo__Layout_coexistsWithDefault: false
+---
+```
+
+### File 2 — the `exo__BacklinksTableBlock` referenced by the Layout
+
+```yaml
+---
+exo__Asset_uid: c1c9b3cd-7f42-4f5a-9a0a-9d3e0f9c6b11
+exo__Asset_label: "Weekly Objectives (for period__Week)"
+exo__Instance_class:
+  - "[[exo__BacklinksTableBlock]]"
+exo__LayoutBlock_title: "Weekly Objectives"
+exo__BacklinksTableBlock_rowClass: "[[ems__WeeklyObjective]]"
+exo__BacklinksTableBlock_referencingProperty: "[[ems__WeeklyObjective__week]]"
+exo__BacklinksTableBlock_columns:
+  - "[[exo__Asset_createdAt]]"
+  - "[[exo__Asset_label]]"
+exo__BacklinksTableBlock_sortOrder: "asc"
+---
+```
+
+Open any `period__Week` note. You should see a single `<h3>Weekly
+Objectives</h3>` followed by a two-column table with each
+`ems__WeeklyObjective` whose `ems__WeeklyObjective__week` points to the
+open week. Nothing else — no `Name`, no `Instance Class`, no "Asset
+Relations" heading.
+
+The columns render in the declared order, left-to-right. Every
+`exo__*Block_*` field is validated on parse with a `log.warn` on malformed
+input — invalid blocks are skipped by the layout render loop without
+throwing, so one typo never brings the whole page down.
+
+## Block types reference (MVP)
+
+Two block kinds ship in this MVP. Their discriminator is the
+`exo__Instance_class` wikilink on the block asset itself.
+
+### `exo__PropertiesBlock`
+
+Renders the open note's own frontmatter as a two-column properties table.
+
+| Field                           | Required | Notes                                                       |
+| ------------------------------- | -------- | ----------------------------------------------------------- |
+| `exo__Asset_uid`                | yes      | Block uid referenced from `exo__Layout_blocks`.             |
+| `exo__Instance_class`           | yes      | Must contain `[[exo__PropertiesBlock]]` (plain or UUID).    |
+| `exo__LayoutBlock_title`        | no       | `<h3>` shown above the table. Falls back to `exo__Asset_label`, then to the block file basename. |
+| `exo__LayoutBlock_collapsed`    | no       | Reserved for a future "collapsed by default" UX — not yet consulted by the renderer. |
+
+### `exo__BacklinksTableBlock`
+
+Renders a filtered, sorted table of backlinks — the block equivalent of
+the default Asset Relations section, but scoped to a single
+`(rowClass, referencingProperty)` pair and with explicit columns.
+
+| Field                                                 | Required | Notes                                                                                       |
+| ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `exo__Asset_uid`                                      | yes      | Block uid.                                                                                  |
+| `exo__Instance_class`                                 | yes      | Must contain `[[exo__BacklinksTableBlock]]`.                                                |
+| `exo__BacklinksTableBlock_rowClass`                   | yes      | Wikilink; only backlinks whose `exo__Instance_class` matches are included.                  |
+| `exo__BacklinksTableBlock_referencingProperty`        | yes      | Wikilink; only backlinks whose referencing frontmatter property equals this are included.   |
+| `exo__BacklinksTableBlock_columns`                    | yes      | Array of wikilinks or bare identifiers. Each is normalised to a property name before rendering. |
+| `exo__BacklinksTableBlock_sortBy`                     | no       | Column to sort by; defaults to `exo__Asset_label`.                                          |
+| `exo__BacklinksTableBlock_sortOrder`                  | no       | `"asc"` (default) or `"desc"`.                                                              |
+| `exo__BacklinksTableBlock_limit`                      | no       | Positive integer cap on visible rows; omit for unlimited.                                   |
+| `exo__BacklinksTableBlock_showArchived`               | no       | `false` by default; set `true` to include rows with `archived: true`.                       |
+
+### Wikilink forms — canonical normalization
+
+Every wikilink field is normalised through `WikiLinkHelpers.normalize`
+before the resolver or the renderer touches it. All four frontmatter
+forms below are equivalent:
+
+- `exo__BacklinksTableBlock` (bare identifier)
+- `[[exo__BacklinksTableBlock]]` (plain wikilink — recommended)
+- `[[exo__BacklinksTableBlock|Backlinks table]]` (non-UUID target ⇒
+  target wins, alias display-only)
+- `[[2e868956-d81e-43fd-9817-1addde9cb311|exo__BacklinksTableBlock]]`
+  (starter-kit convention — UUID target ⇒ alias wins)
+
+Row-side `exo__Instance_class` values are normalised under the same
+rules, so a block parsed in any form matches a row in any form — no
+pipe-order mirroring needed. The `columns` array receives the same
+normalization: every entry is reduced to a bare property name before
+the React renderer looks it up against the row frontmatter (e.g.
+`[[exo__Asset_createdAt]]` → `exo__Asset_createdAt`).
+
+## Priority ladder
+
+When more than one Layout asset targets the same class, the resolver
+picks a single winner.
+
+| Step | Rule                                                                                      |
+| ---- | ----------------------------------------------------------------------------------------- |
+| 1    | Walk `exo__Instance_class` of the open note in declaration order; stop at the first match. |
+| 2    | Among matches for the winning class, pick the highest `exo__Layout_priority`.             |
+| 3    | Tiebreaker — `exo__Asset_uid` ascending.                                                  |
+| 4    | Nothing matched — fall back to the default Asset Relations rendering.                     |
+
+Declaration order of classes in `exo__Instance_class` matters: the
+selector walks classes in that order, and the first class to produce a
+non-null match wins. This lets you declare a specific class
+(`ems__Daily`) ahead of a more generic one (`ems__Effort`) on a note and
+get the specific-first behaviour without writing priority arithmetic.
+
+## Coexistence with the default Asset Relations table
+
+`exo__Layout_coexistsWithDefault` decides whether the plugin still emits
+the legacy Asset Relations section **in addition** to the Layout blocks.
+
+- `false` (default) — the Layout replaces Asset Relations entirely. Use
+  this when your Layout already contains a
+  `exo__BacklinksTableBlock` (or several) and the default heading +
+  grouped table would be redundant.
+- `true` — the Layout blocks render first, and the default Asset
+  Relations section appears below them. Use this when the Layout only
+  adds new blocks (e.g. a `PropertiesBlock` for pinned metadata) and
+  you still want the class-wide Asset Relations table below.
+
+## Coexistence with `ui__RelationColumnSet`
+
+Both features live side-by-side and never fight:
+
+- `exo__Layout` (this page) owns the **body structure** of a note —
+  which blocks render, in what order, with what columns.
+- `ui__RelationColumnSet` (see `RELATION_COLUMN_SET.md`) customises the
+  **column map of the default Asset Relations table**, which only
+  renders when `coexistsWithDefault: true` **or** when no Layout
+  matches the open note's class at all.
+
+So if a note has both a matching Layout and matching RelationColumnSet
+configs:
+
+- `coexistsWithDefault: false` → Layout wins; RelationColumnSet is not
+  consulted (Asset Relations not rendered at all).
+- `coexistsWithDefault: true` → Layout blocks render first, then the
+  default Asset Relations table renders below with columns picked by
+  RelationColumnSet's resolver (same ladder as always).
+
+## Troubleshooting
+
+`log.warn` messages emitted by the pipeline, listed in the order they
+can appear:
+
+- `Layout: exo__Asset_uid missing at <path>` — every Layout needs a
+  UUID. Regenerate one or paste from an existing working asset.
+- `Layout <uid>: exo__Layout_targetClass required (<path>)` — add the
+  class wikilink you want this Layout to render for.
+- `Layout <uid>: exo__Layout_blocks must contain at least one block (<path>)` —
+  the blocks array was empty or absent. Reference at least one block
+  asset; bare identifiers and wikilinks both work.
+- `LayoutBlock: exo__Asset_uid missing at <path>` — same rule as Layout.
+- `BacklinksTableBlock <uid>: rowClass and referencingProperty required (<path>)` —
+  both fields are mandatory for the block filter to match anything.
+- `LayoutBlock <uid>: unknown block class at <path> — expected exo__PropertiesBlock or exo__BacklinksTableBlock` —
+  the block asset's `exo__Instance_class` is neither MVP variant;
+  extend the plugin or fix the class reference.
+- `ExoLayoutRenderer: block "<ref>" not found (layout=<uid>, file=<path>)` —
+  the layout references a block that the repository never indexed. The
+  other blocks still render; fix the reference or the block asset.
+- `ExoLayoutRepository: duplicate exo__Asset_uid <uid> (<path>); keeping first-seen` —
+  two files share a UUID. Change one of them.
+
+If an open note renders the default Asset Relations table when you
+expected a Layout, check:
+
+1. `enableExoLayoutRenderer` is `true` in Settings → Exocortex.
+2. The note's `exo__Instance_class` contains the class targeted by the
+   Layout (exact wikilink match after normalisation).
+3. The console does not show any `log.warn` for the Layout or its
+   blocks — a single parse failure blanks the whole Layout (the
+   selector returns `null`).
+4. The Layout file itself is inside the vault (the repository subscribes
+   to `vault` events, not `metadataCache`-synthesised ones).

--- a/packages/obsidian-plugin/playwright-shard-assignments.json
+++ b/packages/obsidian-plugin/playwright-shard-assignments.json
@@ -15,7 +15,8 @@
     [
       "starter-kit-smoke.spec.ts",
       "layout-overflow-styling.spec.ts",
-      "brat-installation-compatibility.spec.ts"
+      "brat-installation-compatibility.spec.ts",
+      "exo-layout-smoke.spec.ts"
     ],
     [
       "area-tree-collapsible.spec.ts",

--- a/packages/obsidian-plugin/tests/component/exo-layout-docs-renders.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/exo-layout-docs-renders.spec.tsx
@@ -1,0 +1,170 @@
+/**
+ * RFC exo__Layout Phase 3 — docs example CI gate (M5 usability).
+ *
+ * Parallel to `docs-example-renders.spec.tsx` (RelationColumnSet gate): reads
+ * `docs/EXO_LAYOUT.md`, extracts the two ```yaml fenced blocks (Layout +
+ * BacklinksTableBlock) from the Quickstart section, parses each through the
+ * production factories (`createLayoutFromFrontmatter` /
+ * `createLayoutBlockFromFrontmatter`), and mounts `BacklinksTableBlockView`
+ * with the parsed block's columns.  If someone edits the docs in a way that
+ * silently breaks the copy-pasteable example, this test fails in CI — the
+ * RFC M5 "falsifiable usability" guarantee extended to Layout.
+ */
+
+import { test, expect } from "@playwright/experimental-ct-react";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as yaml from "js-yaml";
+import React from "react";
+
+import {
+  createLayoutFromFrontmatter,
+  createLayoutBlockFromFrontmatter,
+  isBacklinksTableBlock,
+  type Layout,
+  type LayoutBlock,
+} from "../../../exocortex/src/domain/layout";
+
+import { BacklinksTableBlockView } from "../../src/presentation/components/LayoutBlocks";
+import type { AssetRelation } from "../../src/presentation/renderers/layout/types";
+
+const DOCS_PATH = path.resolve(__dirname, "../../docs/EXO_LAYOUT.md");
+const YAML_FENCE = /```yaml\n([\s\S]+?)\n```/g;
+
+function stripObsidianFences(raw: string): string {
+  // The docs YAML blocks are wrapped in Obsidian-style `---` fences for
+  // copy-paste fidelity.  js-yaml treats each `---` as a document separator,
+  // so strip the leading/trailing fences before parsing.
+  return raw.replace(/^---\s*\n/, "").replace(/\n---\s*$/, "");
+}
+
+function loadDocsYamlBlocks(): Record<string, unknown>[] {
+  const md = fs.readFileSync(DOCS_PATH, "utf8");
+  const blocks: Record<string, unknown>[] = [];
+  for (const match of md.matchAll(YAML_FENCE)) {
+    const parsed = yaml.load(stripObsidianFences(match[1])) as Record<
+      string,
+      unknown
+    >;
+    blocks.push(parsed);
+  }
+  if (blocks.length < 2) {
+    throw new Error(
+      `exo-layout-docs-renders: expected ≥2 \`\`\`yaml blocks in ${DOCS_PATH}, found ${blocks.length}`,
+    );
+  }
+  return blocks;
+}
+
+const WEEK_CREATED = new Date("2026-03-01T00:00:00Z").getTime();
+
+const weeklyObjectiveRows: AssetRelation[] = [
+  {
+    path: "Objectives/wo-1.md",
+    title: "Ship RFC exo__Layout Phase 3",
+    propertyName: "ems__WeeklyObjective__week",
+    isBodyLink: false,
+    created: WEEK_CREATED + 10 * 60_000,
+    modified: WEEK_CREATED + 60 * 60_000,
+    metadata: {
+      exo__Instance_class: ["[[ems__WeeklyObjective]]"],
+      exo__Asset_label: "Ship RFC exo__Layout Phase 3",
+      exo__Asset_createdAt: "2026-03-01T00:10:00+0500",
+    },
+    file: { path: "Objectives/wo-1.md", basename: "wo-1" },
+  } as AssetRelation,
+  {
+    path: "Objectives/wo-2.md",
+    title: "Close defect remediation follow-up",
+    propertyName: "ems__WeeklyObjective__week",
+    isBodyLink: false,
+    created: WEEK_CREATED + 20 * 60_000,
+    modified: WEEK_CREATED + 30 * 60_000,
+    metadata: {
+      exo__Instance_class: ["[[ems__WeeklyObjective]]"],
+      exo__Asset_label: "Close defect remediation follow-up",
+      exo__Asset_createdAt: "2026-03-01T00:20:00+0500",
+    },
+    file: { path: "Objectives/wo-2.md", basename: "wo-2" },
+  } as AssetRelation,
+];
+
+test.describe("docs/EXO_LAYOUT.md example renders", () => {
+  test("Quickstart YAML parses into a valid Layout + BacklinksTableBlock; BacklinksTableBlockView renders exactly the declared columns", async ({
+    mount,
+  }) => {
+    const [layoutFm, blockFm] = loadDocsYamlBlocks();
+
+    const layout = createLayoutFromFrontmatter(layoutFm, {
+      sourcePath: DOCS_PATH,
+      warn: (msg) => {
+        throw new Error(`docs Layout parse warning: ${msg}`);
+      },
+    });
+    if (layout === null) {
+      throw new Error(
+        `docs Layout parse returned null for first YAML block in ${DOCS_PATH}`,
+      );
+    }
+    expect(layout.targetClass).toBe("period__Week");
+    expect(layout.coexistsWithDefault).toBe(false);
+    expect(layout.blocks.length).toBe(1);
+
+    const block: LayoutBlock | null = createLayoutBlockFromFrontmatter(blockFm, {
+      sourcePath: DOCS_PATH,
+      warn: (msg) => {
+        throw new Error(`docs LayoutBlock parse warning: ${msg}`);
+      },
+    });
+    if (block === null || !isBacklinksTableBlock(block)) {
+      throw new Error(
+        `docs Quickstart second YAML block must be an exo__BacklinksTableBlock`,
+      );
+    }
+
+    // The Layout references the block by uid (post-normalisation).
+    expect(layout.blocks[0]).toBe(block.uid);
+
+    // Post-parse columns are normalised to bare property names so the renderer
+    // can index frontmatter directly without further transform.
+    expect(block.columns).toEqual([
+      "exo__Asset_createdAt",
+      "exo__Asset_label",
+    ]);
+    expect(block.rowClass).toBe("ems__WeeklyObjective");
+    expect(block.referencingProperty).toBe("ems__WeeklyObjective__week");
+
+    const component = await mount(
+      <BacklinksTableBlockView
+        title={block.title}
+        columns={[...block.columns]}
+        rows={weeklyObjectiveRows}
+      />,
+    );
+
+    const headers = component.getByRole("columnheader");
+    await expect(headers).toHaveCount(2);
+    await expect(
+      component.getByRole("columnheader", { name: "exo__Asset_createdAt" }),
+    ).toBeVisible();
+    await expect(
+      component.getByRole("columnheader", { name: "exo__Asset_label" }),
+    ).toBeVisible();
+
+    // Must NOT contain the default Asset Relations columns.
+    await expect(
+      component.getByRole("columnheader", { name: /^Name$/i }),
+    ).toHaveCount(0);
+    await expect(
+      component.getByRole("columnheader", { name: /Instance Class/i }),
+    ).toHaveCount(0);
+
+    // Row count matches fixture; columns render the declared frontmatter values.
+    await expect(component.locator("tbody tr")).toHaveCount(
+      weeklyObjectiveRows.length,
+    );
+    await expect(
+      component.getByText("Ship RFC exo__Layout Phase 3"),
+    ).toBeVisible();
+  });
+});

--- a/packages/obsidian-plugin/tests/e2e/specs/exo-layout-smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/exo-layout-smoke.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "@playwright/test";
+import { ObsidianLauncher } from "../utils/obsidian-launcher";
+
+/**
+ * RFC exo__Layout Phase 3 — L3 E2E smoke.
+ *
+ * MVG (RFC v1 §"Мотивирующий кейс пользователя"): open an `exo__DemoClass`
+ * asset, observe the declared `exo__Layout` render a single
+ * `exo__BacklinksTableBlock` with exactly the two configured columns
+ * (`exo__Asset_createdAt`, `exo__Asset_label`) — NOT the default Name +
+ * Instance Class Asset Relations table, and NOT wrapped in the legacy
+ * "Asset Relations" heading (because `coexistsWithDefault: false`).
+ *
+ * Budget ≤25s (RFC v1 §Phase 3 exit-criteria). Shard 3 hosts this spec
+ * alongside the RelationColumnSet smoke because both drive the same
+ * UniversalLayout pipeline with minimal interaction (no modals, no input).
+ */
+test.describe("ExoLayout — Phase 3 smoke", () => {
+  let launcher: ObsidianLauncher;
+
+  test.beforeAll(async () => {
+    launcher = new ObsidianLauncher();
+    await launcher.launch();
+  });
+
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
+  });
+
+  test(
+    "exo__DemoClass note renders declared BacklinksTableBlock with 2 columns and NO default Asset Relations wrapper",
+    { timeout: 25_000 },
+    async () => {
+      await launcher.openFile("exolayout/demo-target.md");
+      await launcher.waitForModalsToClose(10_000);
+
+      // The ExoLayoutRenderer emits `.exocortex-exo-layout` as the block
+      // container; one child `.exocortex-exo-layout-block` per resolved block.
+      await launcher.waitForElement(".exocortex-exo-layout", 15_000);
+
+      const layoutRoot = launcher.page.locator(".exocortex-exo-layout");
+      await expect(layoutRoot).toBeVisible();
+
+      const blocks = layoutRoot.locator(".exocortex-exo-layout-block");
+      await expect(blocks).toHaveCount(1);
+
+      // The block title comes from `exo__LayoutBlock_title` in the fixture.
+      await expect(
+        layoutRoot.locator(
+          ".exocortex-layout-block-title:has-text(\"Demo Rows\")",
+        ),
+      ).toBeVisible();
+
+      // Exactly TWO columnheaders rendered by BacklinksTableBlockView —
+      // NOT the legacy Name + Instance Class pair.
+      const headers = layoutRoot.getByRole("columnheader");
+      await expect(headers).toHaveCount(2);
+      await expect(
+        layoutRoot.getByRole("columnheader", { name: "exo__Asset_createdAt" }),
+      ).toBeVisible();
+      await expect(
+        layoutRoot.getByRole("columnheader", { name: "exo__Asset_label" }),
+      ).toBeVisible();
+
+      // 3 exo__DemoRow fixture rows referencing demo-target.
+      const rows = layoutRoot.locator(
+        ".exocortex-layout-block-backlinks-table tbody tr",
+      );
+      await expect(rows).toHaveCount(3);
+
+      // coexistsWithDefault=false ⇒ UniversalLayout returns early and the
+      // legacy grouped Asset Relations table is NOT mounted.
+      await expect(
+        launcher.page.locator(".exocortex-assets-relations"),
+      ).toHaveCount(0);
+      await expect(
+        launcher.page.locator(".exocortex-relations-grouped"),
+      ).toHaveCount(0);
+    },
+  );
+});

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/block-demo-backlinks.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/block-demo-backlinks.md
@@ -1,0 +1,18 @@
+---
+exo__Instance_class: "[[exo__BacklinksTableBlock]]"
+exo__Asset_uid: fixture-exolayout-demo-block
+exo__Asset_label: "Demo rows (fixture)"
+exo__LayoutBlock_title: "Demo Rows"
+exo__BacklinksTableBlock_rowClass: "[[exo__DemoRow]]"
+exo__BacklinksTableBlock_referencingProperty: "[[exo__DemoRow__target]]"
+exo__BacklinksTableBlock_columns:
+  - "[[exo__Asset_createdAt]]"
+  - "[[exo__Asset_label]]"
+exo__BacklinksTableBlock_sortOrder: "asc"
+---
+
+# Demo rows block
+
+Phase 3 E2E smoke fixture — declares a backlinks table with exactly two
+columns (`exo__Asset_createdAt`, `exo__Asset_label`) for `exo__DemoRow`
+assets referencing the open note via `exo__DemoRow__target`.

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/demo-row-1.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/demo-row-1.md
@@ -1,0 +1,9 @@
+---
+exo__Instance_class: "[[exo__DemoRow]]"
+exo__Asset_uid: fixture-exolayout-row-1
+exo__Asset_label: "Demo row one"
+exo__Asset_createdAt: "2026-04-25T09:00:00+0500"
+exo__DemoRow__target: "[[demo-target]]"
+---
+
+# Demo row one

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/demo-row-2.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/demo-row-2.md
@@ -1,0 +1,9 @@
+---
+exo__Instance_class: "[[exo__DemoRow]]"
+exo__Asset_uid: fixture-exolayout-row-2
+exo__Asset_label: "Demo row two"
+exo__Asset_createdAt: "2026-04-25T10:00:00+0500"
+exo__DemoRow__target: "[[demo-target]]"
+---
+
+# Demo row two

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/demo-row-3.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/demo-row-3.md
@@ -1,0 +1,9 @@
+---
+exo__Instance_class: "[[exo__DemoRow]]"
+exo__Asset_uid: fixture-exolayout-row-3
+exo__Asset_label: "Demo row three"
+exo__Asset_createdAt: "2026-04-25T11:00:00+0500"
+exo__DemoRow__target: "[[demo-target]]"
+---
+
+# Demo row three

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/demo-target.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/demo-target.md
@@ -1,0 +1,12 @@
+---
+exo__Instance_class: "[[exo__DemoClass]]"
+exo__Asset_uid: fixture-exolayout-target
+exo__Asset_label: "Demo target (fixture)"
+exo__Asset_createdAt: "2026-04-25T00:00:00+0500"
+---
+
+# Demo target
+
+Phase 3 E2E smoke fixture — opened by `exo-layout-smoke.spec.ts`. Three
+`exo__DemoRow` assets reference this note through `exo__DemoRow__target`;
+the matching layout declares that they render as a two-column table.

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/layout-demo-class.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/layout-demo-class.md
@@ -1,0 +1,17 @@
+---
+exo__Instance_class: "[[exo__Layout]]"
+exo__Asset_uid: fixture-exolayout-demo-class
+exo__Asset_label: "exo__DemoClass layout (fixture)"
+exo__Layout_targetClass: "[[exo__DemoClass]]"
+exo__Layout_blocks:
+  - "[[fixture-exolayout-demo-block]]"
+exo__Layout_priority: 0
+exo__Layout_coexistsWithDefault: false
+---
+
+# exo__DemoClass layout
+
+Phase 3 E2E smoke fixture — declares the block order for `exo__DemoClass`
+notes. Consumed by `exo-layout-smoke.spec.ts`. The block asset below declares
+a two-column backlinks table; the default Asset Relations section is
+suppressed because `coexistsWithDefault: false`.


### PR DESCRIPTION
## Summary

Ships the user-facing surface of RFC `6628d78a-78a9-473c-ace3-e9b6d28750d1` Phase 3 on top of the Phase 2 runtime merged in #2953 (`v15.123.0`). Task `f9d59980-8967-49fa-91a0-bc16e7f35be4` Parts A/B/C.

- **Part A — E2E smoke** (\`tests/e2e/specs/exo-layout-smoke.spec.ts\`): opens a self-contained `exolayout/demo-target.md` fixture, asserts the `ExoLayoutRenderer` produces exactly one `.exocortex-exo-layout-block` with 2 columnheaders (`exo__Asset_createdAt`, `exo__Asset_label`) + 3 fixture rows, and that the legacy `.exocortex-assets-relations` wrapper is absent (because `coexistsWithDefault: false`). Test budget ≤25s.
- **Part A — test-vault fixture** (\`tests/e2e/test-vault/exolayout/\`): 6 fixture files (Layout asset + BacklinksTableBlock asset + open target + 3 `exo__DemoRow` rows). Auto-included by the wholesale `COPY packages/obsidian-plugin/tests/e2e/` in `Dockerfile.e2e`.
- **Part A — shard assignment** (\`playwright-shard-assignments.json\`): added the new spec to shard 4 (lowest projected weight per the D1 drift guard). `scripts/validate-shard-assignments.mjs` green.
- **Part B — Docs** (\`docs/EXO_LAYOUT.md\`): full user guide. Overview, Feature flag, Quickstart with copy-pasteable YAML for `period__Week` + `ems__WeeklyObjective` (the RFC motivating scenario), block types reference, wikilink normalisation, priority ladder, coexistence with the default Asset Relations table + `ui__RelationColumnSet`, full `log.warn` troubleshooting catalogue.
- **Part C — Docs-example CI gate** (\`tests/component/exo-layout-docs-renders.spec.tsx\`): parallel to the existing `RelationColumnSet` gate. Parses both \`\`\`yaml fences from the docs through the production factories (\`createLayoutFromFrontmatter\` / \`createLayoutBlockFromFrontmatter\`), asserts they produce the expected Layout + BacklinksTableBlock with `uid` cross-reference, and mounts `BacklinksTableBlockView` to verify the rendered columns match the RFC M5 "falsifiable usability" guarantee.

## Test plan

- [x] Docs YAML parses via the production factories (verified locally with a Node one-liner pre-push).
- [x] \`scripts/validate-shard-assignments.mjs\` green (16 specs balanced across 6 shards, shard 4 now owns 4 specs).
- [ ] CI green (13 required checks).
- [ ] Post-merge Auto Release green.
- [ ] Live test in user's vault-2025 via computer-control (replacing existing `46635050` `ui__RelationColumnSet` config with the new `exo__Layout` for `period__Week`).

## Not included

- **Task Part D** — starter-kit MVG fixture ships in [kitelev/exocortex-starter-kit#88](https://github.com/kitelev/exocortex-starter-kit/pull/88) (already merged). Plugin docs link to the starter-kit fixture; the plugin PR is independent of the starter-kit release.

## Refs

- RFC `6628d78a-78a9-473c-ace3-e9b6d28750d1`
- Task `f9d59980-8967-49fa-91a0-bc16e7f35be4`
- Phase 2 runtime: #2953 (\`ca5596a0\`, v15.123.0)
- Starter-kit Part D: kitelev/exocortex-starter-kit#88