### PR TITLE
feat(layout): Phase 4 — onLoad ontology bootstrap + CLI migration helper (RFC exo__Layout)

### DIFF
--- a/packages/cli/src/commands/migrate-relcolset-to-exolayout.ts
+++ b/packages/cli/src/commands/migrate-relcolset-to-exolayout.ts
@@ -1,0 +1,180 @@
+import { Command } from "commander";
+import { resolve } from "path";
+import { existsSync } from "fs";
+import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+import {
+  RelColSetToExoLayoutMigratorService,
+  extractRelColSetConfig,
+  isRelColSetFrontmatter,
+  type GeneratedLayoutPair,
+  type MigrationResult,
+} from "../services/RelColSetToExoLayoutMigratorService.js";
+
+interface MigrateOptions {
+  vault: string;
+  outDir: string;
+  apply?: boolean;
+  json?: boolean;
+}
+
+/**
+ * Creates the `migrate-relcolset-to-exolayout` subcommand.
+ *
+ * Scans a vault for `ui__RelationColumnSet` configs and generates an
+ * equivalent `exo__Layout` + `exo__BacklinksTableBlock` asset pair for each.
+ * Dry-run by default — prints YAML previews and warnings to stderr. Pass
+ * `--apply` to write two files per pair into `--out-dir`.
+ *
+ * Part B of RFC exo__Layout Phase 4 (task 07ceb846). See
+ * `docs/RELATION_COLUMN_SET.md` for deprecation context and the
+ * additive-vs-replacing semantic gap this command cannot bridge automatically.
+ */
+export function migrateRelColSetToExoLayoutCommand(): Command {
+  return new Command("migrate-relcolset-to-exolayout")
+    .description(
+      "Generate exo__Layout + exo__BacklinksTableBlock pairs from existing ui__RelationColumnSet configs (dry-run by default; --apply to write)",
+    )
+    .requiredOption("--vault <path>", "Path to the source vault")
+    .option(
+      "--out-dir <path>",
+      "Vault-relative folder where generated Layout+Block files land on --apply",
+      "exo-layout-migrated",
+    )
+    .option(
+      "--apply",
+      "Write generated files to the vault (default: dry-run, prints to stderr)",
+      false,
+    )
+    .option("--json", "Emit the migration report as JSON to stdout", false)
+    .action(async (options: MigrateOptions) => {
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const fsAdapter = new NodeFsAdapter(vaultPath);
+        const service = new RelColSetToExoLayoutMigratorService();
+
+        const allFiles = await fsAdapter.getMarkdownFiles();
+        const configs = [];
+        for (const file of allFiles) {
+          try {
+            const fm = await fsAdapter.getFileMetadata(file);
+            if (!isRelColSetFrontmatter(fm)) continue;
+            const cfg = extractRelColSetConfig(file, fm);
+            if (cfg !== null) configs.push(cfg);
+          } catch {
+            // Files without frontmatter are ignored.
+          }
+        }
+
+        const result = service.migrate(configs);
+
+        if (options.apply) {
+          await writePairs(fsAdapter, result, options.outDir);
+        } else {
+          printDryRunReport(result);
+        }
+
+        if (options.json) {
+          process.stdout.write(JSON.stringify(summariseResult(result, options), null, 2) + "\n");
+        } else {
+          process.stderr.write(formatSummary(result, options));
+        }
+
+        process.exit(0);
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}
+
+async function writePairs(
+  fs: NodeFsAdapter,
+  result: MigrationResult,
+  outDirRelative: string,
+): Promise<void> {
+  for (const pair of result.pairs) {
+    const layoutPath = `${outDirRelative}/${pair.layout.filename}`;
+    const blockPath = `${outDirRelative}/${pair.block.filename}`;
+    await fs.writeFile(layoutPath, pair.layout.content);
+    await fs.writeFile(blockPath, pair.block.content);
+  }
+}
+
+function printDryRunReport(result: MigrationResult): void {
+  process.stderr.write("--- DRY RUN PREVIEW ---\n");
+  for (const pair of result.pairs) {
+    process.stderr.write(`\n# from ${pair.sourcePath}\n`);
+    process.stderr.write(`## Layout (${pair.layout.filename})\n`);
+    process.stderr.write(pair.layout.content);
+    process.stderr.write(`\n## Block (${pair.block.filename})\n`);
+    process.stderr.write(pair.block.content);
+    if (pair.warnings.length > 0) {
+      process.stderr.write("\n## Warnings\n");
+      for (const w of pair.warnings) {
+        process.stderr.write(`- ${w}\n`);
+      }
+    }
+  }
+  process.stderr.write("\n--- END PREVIEW ---\n");
+}
+
+function formatSummary(
+  result: MigrationResult,
+  options: MigrateOptions,
+): string {
+  const mode = options.apply ? "APPLY" : "DRY RUN";
+  const lines: string[] = [
+    `--- MIGRATION ${mode} ---`,
+    `Migrated pairs: ${result.pairs.length}`,
+    `Skipped configs: ${result.skipped.length}`,
+  ];
+  if (options.apply) {
+    lines.push(`Files written to: ${options.outDir}/ (relative to vault root)`);
+    lines.push(
+      `Total files written: ${result.pairs.length * 2} (${result.pairs.length} Layout + ${result.pairs.length} Block)`,
+    );
+  }
+  for (const skip of result.skipped) {
+    lines.push(`  SKIPPED: ${skip.sourcePath} — ${skip.reason}`);
+  }
+  lines.push("--- END SUMMARY ---\n");
+  return lines.join("\n");
+}
+
+function summariseResult(
+  result: MigrationResult,
+  options: MigrateOptions,
+): {
+  mode: "apply" | "dry-run";
+  outDir: string;
+  pairsCount: number;
+  skippedCount: number;
+  pairs: ReadonlyArray<{
+    sourceUid: string;
+    sourcePath: string;
+    layoutUid: string;
+    blockUid: string;
+    warnings: readonly string[];
+  }>;
+  skipped: ReadonlyArray<{ sourcePath: string; reason: string }>;
+} {
+  return {
+    mode: options.apply ? "apply" : "dry-run",
+    outDir: options.outDir,
+    pairsCount: result.pairs.length,
+    skippedCount: result.skipped.length,
+    pairs: result.pairs.map((p: GeneratedLayoutPair) => ({
+      sourceUid: p.sourceUid,
+      sourcePath: p.sourcePath,
+      layoutUid: p.layout.uid,
+      blockUid: p.block.uid,
+      warnings: p.warnings,
+    })),
+    skipped: result.skipped,
+  };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import { unarchiveCommand } from "./commands/unarchive.js";
 import { workflowCommand } from "./commands/workflow.js";
 import { dynamicCommandCommand } from "./commands/dynamic-command.js";
 import { convertCommand } from "./commands/convert.js";
+import { migrateRelColSetToExoLayoutCommand } from "./commands/migrate-relcolset-to-exolayout.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -79,6 +80,7 @@ export function createProgram(version?: string): Command {
   program.addCommand(workflowCommand());
   program.addCommand(dynamicCommandCommand());
   program.addCommand(convertCommand());
+  program.addCommand(migrateRelColSetToExoLayoutCommand());
 
   return program;
 }

--- a/packages/cli/src/services/RelColSetToExoLayoutMigratorService.ts
+++ b/packages/cli/src/services/RelColSetToExoLayoutMigratorService.ts
@@ -1,0 +1,358 @@
+/**
+ * RelColSetToExoLayoutMigratorService — pure transform from legacy
+ * `ui__RelationColumnSet` configs to the equivalent `exo__Layout` +
+ * `exo__BacklinksTableBlock` asset pair.
+ *
+ * Part B of RFC exo__Layout Phase 4 (task 07ceb846).
+ *
+ * Transform semantics
+ * -------------------
+ * A `ui__RelationColumnSet` encodes the pair
+ *   (rowClass = targetClass, referencingProperty, columns, priority, label)
+ * and participates in the `RelationColumnSetResolver` ladder to inject extra
+ * columns into the UniversalLayout Asset Relations table (additive).
+ *
+ * The migration produces a self-contained `exo__Layout` + `exo__BacklinksTableBlock`
+ * pair that reproduces the (rowClass, referencingProperty, columns) tuple as
+ * a standalone block. The `exo__Layout.targetClass` intentionally carries the
+ * RelColSet's `targetClass` as a **placeholder** — in RelColSet the target is
+ * the row-asset class, but `exo__Layout.targetClass` is the class of the
+ * **page** the layout renders on. The two can differ, and the CLI cannot
+ * infer page-class from the RelColSet alone. The generated Layout includes an
+ * inline `# TODO` note the user must resolve. Behavioural equivalence is the
+ * column set (rowClass, referencingProperty, columns); page-binding is a
+ * per-vault decision.
+ *
+ * Determinism (advisor-locked 2026-04-25)
+ * ---------------------------------------
+ * Generated UIDs are derived **deterministically** from the source RelColSet
+ * UID + a stable suffix via SHA-256 (128 bits truncated to v4 UUID shape).
+ * Re-running `--apply` against the same input vault produces **identical**
+ * UIDs and file contents — it does NOT create duplicate Layout+Block pairs.
+ * This closes the same class of defect that RFC be70f741 Task 2 v15.121.0
+ * tripped on (path-only idempotency that missed UID-aware).  Tests may
+ * inject an alternative generator for assertions.
+ *
+ * See memory entry `project_rfc_relcolset_complete.md` for the RelColSet
+ * shape this migration reads from, and
+ * `feedback_advisor_warning_equals_requirement.md` for the lesson that
+ * drove this determinism requirement.
+ */
+
+import { createHash } from "node:crypto";
+
+export interface RelColSetConfig {
+  /** `exo__Asset_uid` of the RelColSet source asset. */
+  readonly uid: string;
+  /** Vault-relative path of the RelColSet source asset. */
+  readonly path: string;
+  /** Human-readable label (optional; defaults to basename). */
+  readonly label: string | null;
+  /**
+   * `ui__RelationColumnSet_targetClass` (single or first-match) —
+   * carried through as the row-asset class in the generated BacklinksTableBlock
+   * and (for lack of better signal) as a **placeholder** `exo__Layout.targetClass`.
+   */
+  readonly targetClass: string | null;
+  /** `ui__RelationColumnSet_referencingProperty`. */
+  readonly referencingProperty: string | null;
+  /** Ordered array from `ui__RelationColumnSet_columns`. */
+  readonly columns: readonly string[];
+  /** Optional numeric priority (defaults to 0 when absent). */
+  readonly priority: number | null;
+}
+
+export interface GeneratedLayoutPair {
+  readonly sourceUid: string;
+  readonly sourcePath: string;
+  readonly layout: {
+    readonly uid: string;
+    readonly filename: string;
+    readonly content: string;
+  };
+  readonly block: {
+    readonly uid: string;
+    readonly filename: string;
+    readonly content: string;
+  };
+  /** Human-readable warnings attached to this pair (rendered by the CLI). */
+  readonly warnings: readonly string[];
+}
+
+export interface MigrationResult {
+  readonly pairs: readonly GeneratedLayoutPair[];
+  readonly skipped: readonly {
+    readonly sourcePath: string;
+    readonly reason: string;
+  }[];
+}
+
+export interface RelColSetToExoLayoutMigratorOptions {
+  /**
+   * UID generator for the two generated assets. Receives a seed (source UID)
+   * and a suffix (`"layout"` or `"block"`) and returns a stable UUID-shaped
+   * string. Default: SHA-1 derivation from seed + suffix + migration-version
+   * salt — deterministic, so re-running produces identical UIDs (idempotent
+   * `--apply`). Tests may inject alternative stubs.
+   */
+  readonly uidFor?: (seed: string, suffix: "layout" | "block") => string;
+}
+
+function wikilinkInner(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  const match = trimmed.match(/^\[\[([^|\]]+)(?:\|[^\]]*)?\]\]$/);
+  if (match) return match[1].trim();
+  return trimmed;
+}
+
+function normaliseColumns(raw: unknown): readonly string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string" && entry.trim().length > 0) {
+      out.push(entry.trim());
+    }
+  }
+  return out;
+}
+
+function normaliseInstanceClass(raw: unknown): readonly string[] {
+  if (Array.isArray(raw)) {
+    return raw
+      .map((e) => (typeof e === "string" ? wikilinkInner(e) : null))
+      .filter((e): e is string => e !== null);
+  }
+  if (typeof raw === "string") {
+    const inner = wikilinkInner(raw);
+    return inner ? [inner] : [];
+  }
+  return [];
+}
+
+/**
+ * Predicate: does this frontmatter represent a `ui__RelationColumnSet` asset?
+ *
+ * Accepts either the bare label `ui__RelationColumnSet` or the canonical
+ * class UID `97fc9862-c886-4d86-9a60-e0cf9d778575` (`ui__RelationColumnSet`).
+ */
+export function isRelColSetFrontmatter(
+  fm: Record<string, unknown>,
+): boolean {
+  const classes = normaliseInstanceClass(fm["exo__Instance_class"]);
+  for (const c of classes) {
+    if (c === "ui__RelationColumnSet") return true;
+    if (c === "97fc9862-c886-4d86-9a60-e0cf9d778575") return true;
+    // Tolerate pipe-aliased wikilinks like `[[uid|ui__RelationColumnSet]]`.
+    if (c.includes("ui__RelationColumnSet")) return true;
+  }
+  return false;
+}
+
+/**
+ * Extract a `RelColSetConfig` from frontmatter. Returns null when the asset
+ * is missing the mandatory `exo__Asset_uid`.
+ */
+export function extractRelColSetConfig(
+  path: string,
+  fm: Record<string, unknown>,
+): RelColSetConfig | null {
+  const uid = fm["exo__Asset_uid"];
+  if (typeof uid !== "string" || uid.trim().length === 0) return null;
+
+  const labelRaw = fm["exo__Asset_label"];
+  const label =
+    typeof labelRaw === "string" && labelRaw.trim().length > 0
+      ? labelRaw.trim()
+      : null;
+
+  const targetClassRaw = fm["ui__RelationColumnSet_targetClass"];
+  const targetClass = Array.isArray(targetClassRaw)
+    ? wikilinkInner(targetClassRaw[0] as unknown)
+    : wikilinkInner(targetClassRaw);
+
+  const referencingProperty = wikilinkInner(
+    fm["ui__RelationColumnSet_referencingProperty"],
+  );
+
+  const columns = normaliseColumns(fm["ui__RelationColumnSet_columns"]);
+
+  const priorityRaw = fm["ui__RelationColumnSet_priority"];
+  const priority =
+    typeof priorityRaw === "number"
+      ? priorityRaw
+      : typeof priorityRaw === "string" && priorityRaw.trim() !== ""
+        ? Number.parseInt(priorityRaw, 10)
+        : null;
+
+  return {
+    uid: uid.trim(),
+    path,
+    label,
+    targetClass,
+    referencingProperty,
+    columns,
+    priority: priority !== null && Number.isNaN(priority) ? null : priority,
+  };
+}
+
+function wikilinkOf(value: string | null): string {
+  if (value === null || value.trim().length === 0) return "";
+  const trimmed = value.trim();
+  if (trimmed.startsWith("[[") && trimmed.endsWith("]]")) return trimmed;
+  return `[[${trimmed}]]`;
+}
+
+/**
+ * Deterministic UID derivation: SHA-256 of `<seed>:<suffix>:<salt>`
+ * truncated to 128 bits and formatted as an RFC-4122 v4-shaped UUID
+ * (version nibble 4, variant nibble 8-b).  SHA-256 (not SHA-1) per
+ * archgate `no-weak-hash` — even though this is not a security-sensitive
+ * ID, sticking to SHA-256 keeps the migration consistent with the rest of
+ * the codebase's hash policy.
+ *
+ * The `:exo-layout-migration-v1` salt is a stable string — if the
+ * migration algorithm ever changes in a way that should produce new UIDs
+ * for existing inputs (e.g. the Layout/Block split changes), bump the salt
+ * version to force regeneration.
+ *
+ * Idempotency guarantee: `defaultUidFor(uid, "layout")` is a pure function
+ * of `uid` and returns the same string on every call. Re-running `--apply`
+ * against the same vault produces identical Layout+Block UIDs, so the
+ * downstream idempotency check (file already exists) is a true no-op.
+ */
+function defaultUidFor(seed: string, suffix: "layout" | "block"): string {
+  const hex = createHash("sha256")
+    .update(`${seed}:${suffix}:exo-layout-migration-v1`)
+    .digest("hex");
+  // RFC-4122 v4-shaped: set the high nibble of the 7th byte (time_hi_and_version)
+  // to 4 and the high two bits of the 9th byte (clock_seq_hi_and_reserved) to 10.
+  return (
+    hex.slice(0, 8) +
+    "-" +
+    hex.slice(8, 12) +
+    "-" +
+    "4" +
+    hex.slice(13, 16) +
+    "-" +
+    "8" +
+    hex.slice(17, 20) +
+    "-" +
+    hex.slice(20, 32)
+  );
+}
+
+export class RelColSetToExoLayoutMigratorService {
+  private readonly uidFor: (
+    seed: string,
+    suffix: "layout" | "block",
+  ) => string;
+
+  constructor(options: RelColSetToExoLayoutMigratorOptions = {}) {
+    this.uidFor = options.uidFor ?? defaultUidFor;
+  }
+
+  /**
+   * Transform a batch of RelColSet configs to Layout+Block pairs.
+   */
+  migrate(configs: readonly RelColSetConfig[]): MigrationResult {
+    const pairs: GeneratedLayoutPair[] = [];
+    const skipped: { sourcePath: string; reason: string }[] = [];
+
+    for (const cfg of configs) {
+      if (cfg.targetClass === null && cfg.referencingProperty === null) {
+        skipped.push({
+          sourcePath: cfg.path,
+          reason:
+            "RelColSet lacks both targetClass and referencingProperty — nothing to migrate",
+        });
+        continue;
+      }
+      pairs.push(this.migrateOne(cfg));
+    }
+
+    return { pairs, skipped };
+  }
+
+  private migrateOne(cfg: RelColSetConfig): GeneratedLayoutPair {
+    const layoutUid = this.uidFor(cfg.uid, "layout");
+    const blockUid = this.uidFor(cfg.uid, "block");
+    const warnings: string[] = [];
+
+    const labelSource = cfg.label ?? cfg.uid;
+    const layoutLabel = `Migrated layout (from ${labelSource})`;
+    const blockLabel = `Migrated backlinks table (from ${labelSource})`;
+
+    const targetClassWikilink = wikilinkOf(cfg.targetClass);
+    const referencingPropertyWikilink = wikilinkOf(cfg.referencingProperty);
+
+    if (cfg.targetClass === null) {
+      warnings.push(
+        "RelColSet has no targetClass — using placeholder; set exo__Layout_targetClass and exo__BacklinksTableBlock_rowClass manually.",
+      );
+    }
+    if (cfg.referencingProperty === null) {
+      warnings.push(
+        "RelColSet has no referencingProperty — set exo__BacklinksTableBlock_referencingProperty manually.",
+      );
+    }
+    warnings.push(
+      "RelColSet is additive (appends to Name/InstanceClass); exo__BacklinksTableBlock is replacing. The generated block renders only the configured columns.",
+    );
+    warnings.push(
+      "exo__Layout.targetClass is the class of the PAGE the layout renders on. RelColSet encodes the row class, not the page class. Review and adjust before --apply.",
+    );
+
+    const columnsYaml =
+      cfg.columns.length === 0
+        ? "[]"
+        : "\n" + cfg.columns.map((c) => `  - "${c}"`).join("\n");
+
+    const priorityLine =
+      cfg.priority === null ? "" : `exo__Layout_priority: ${cfg.priority}\n`;
+
+    const layoutContent = `---
+exo__Asset_uid: ${layoutUid}
+exo__Asset_label: "${layoutLabel}"
+exo__Instance_class:
+  - "[[exo__Layout]]"
+exo__Layout_targetClass: "${targetClassWikilink}"
+exo__Layout_blocks:
+  - "[[${blockUid}]]"
+${priorityLine}exo__Layout_coexistsWithDefault: true
+# Migrated from ui__RelationColumnSet ${cfg.uid} (${cfg.path}).
+# TODO: verify exo__Layout_targetClass is the PAGE class (not the row class).
+---
+`;
+
+    const blockContent = `---
+exo__Asset_uid: ${blockUid}
+exo__Asset_label: "${blockLabel}"
+exo__Instance_class:
+  - "[[exo__BacklinksTableBlock]]"
+exo__LayoutBlock_title: "Backlinks"
+exo__BacklinksTableBlock_rowClass: "${targetClassWikilink}"
+exo__BacklinksTableBlock_referencingProperty: "${referencingPropertyWikilink}"
+exo__BacklinksTableBlock_columns:${columnsYaml === "[]" ? " []" : columnsYaml}
+# Migrated from ui__RelationColumnSet ${cfg.uid} (${cfg.path}).
+---
+`;
+
+    return {
+      sourceUid: cfg.uid,
+      sourcePath: cfg.path,
+      layout: {
+        uid: layoutUid,
+        filename: `${layoutUid}.md`,
+        content: layoutContent,
+      },
+      block: {
+        uid: blockUid,
+        filename: `${blockUid}.md`,
+        content: blockContent,
+      },
+      warnings,
+    };
+  }
+}

--- a/packages/cli/tests/integration/migrate-relcolset-to-exolayout.integration.test.ts
+++ b/packages/cli/tests/integration/migrate-relcolset-to-exolayout.integration.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Integration test for the RelColSet → exo__Layout migration transform
+ * against a real tmp-dir vault.
+ *
+ * Smoke coverage:
+ * - Scan a tmp vault for RelColSets (via NodeFsAdapter.findFilesByMetadata).
+ * - Transform via RelColSetToExoLayoutMigratorService.
+ * - Write Layout+Block pairs via fs (simulates --apply).
+ * - Re-read and verify the two generated files land in the expected folder
+ *   and carry the expected frontmatter.
+ *
+ * This test exercises the service + adapter wiring without shelling out to
+ * dist/index.js (which the existing `convert.integration.test.ts` skips in
+ * CI). It is hermetic and runs in CI.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import yaml from "js-yaml";
+import { NodeFsAdapter } from "../../src/adapters/NodeFsAdapter.js";
+import {
+  RelColSetToExoLayoutMigratorService,
+  extractRelColSetConfig,
+  isRelColSetFrontmatter,
+} from "../../src/services/RelColSetToExoLayoutMigratorService.js";
+
+function stubUidFor(seed: string, suffix: "layout" | "block"): string {
+  return `00000000-${suffix === "layout" ? "1111" : "2222"}-4444-8888-${seed.slice(0, 12).padEnd(12, "0")}`;
+}
+
+function writeAsset(
+  dir: string,
+  filename: string,
+  frontmatter: Record<string, unknown>,
+): void {
+  const body = `---\n${yaml.dump(frontmatter).trimEnd()}\n---\n`;
+  fs.writeFileSync(path.join(dir, filename), body, "utf-8");
+}
+
+function readFrontmatter(filePath: string): Record<string, unknown> {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`frontmatter missing in ${filePath}`);
+  return yaml.load(match[1]) as Record<string, unknown>;
+}
+
+describe("migrate-relcolset-to-exolayout — integration", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-migrate-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("transforms a RelColSet in the tmp vault into a Layout+Block pair and writes both files", async () => {
+    // Arrange: seed vault with 1 RelColSet + 1 unrelated asset.
+    const uiDir = path.join(tempDir, "ui");
+    fs.mkdirSync(uiDir, { recursive: true });
+    writeAsset(uiDir, "rc-1.md", {
+      exo__Asset_uid: "abc12345-1111-1111-1111-aaaaaaaaaaaa",
+      exo__Asset_label: "Tasks on Projects",
+      exo__Instance_class: ["[[ui__RelationColumnSet]]"],
+      ui__RelationColumnSet_targetClass: "[[ems__Task]]",
+      ui__RelationColumnSet_referencingProperty: "[[ems__Task_parent]]",
+      ui__RelationColumnSet_columns: [
+        "[[ems__Effort_status]]",
+        "[[exo__Asset_label]]",
+      ],
+      ui__RelationColumnSet_priority: 10,
+    });
+    writeAsset(tempDir, "unrelated.md", {
+      exo__Asset_uid: "bbb22345-1111-1111-1111-cccccccccccc",
+      exo__Instance_class: ["[[ems__Task]]"],
+    });
+
+    const adapter = new NodeFsAdapter(tempDir);
+    const service = new RelColSetToExoLayoutMigratorService({
+      uidFor: stubUidFor,
+    });
+
+    // Act: scan, transform, apply.
+    const allFiles = await adapter.getMarkdownFiles();
+    const configs = [];
+    for (const file of allFiles) {
+      const fm = await adapter.getFileMetadata(file);
+      if (!isRelColSetFrontmatter(fm)) continue;
+      const cfg = extractRelColSetConfig(file, fm);
+      if (cfg !== null) configs.push(cfg);
+    }
+    const result = service.migrate(configs);
+
+    const outDir = "exo-layout-migrated";
+    for (const pair of result.pairs) {
+      await adapter.writeFile(
+        `${outDir}/${pair.layout.filename}`,
+        pair.layout.content,
+      );
+      await adapter.writeFile(
+        `${outDir}/${pair.block.filename}`,
+        pair.block.content,
+      );
+    }
+
+    // Assert
+    expect(result.pairs).toHaveLength(1);
+    expect(result.skipped).toHaveLength(0);
+
+    const pair = result.pairs[0];
+    const layoutOnDisk = path.join(tempDir, outDir, pair.layout.filename);
+    const blockOnDisk = path.join(tempDir, outDir, pair.block.filename);
+    expect(fs.existsSync(layoutOnDisk)).toBe(true);
+    expect(fs.existsSync(blockOnDisk)).toBe(true);
+
+    const layoutFm = readFrontmatter(layoutOnDisk);
+    expect(layoutFm["exo__Asset_uid"]).toBe(pair.layout.uid);
+    expect(layoutFm["exo__Instance_class"]).toEqual(["[[exo__Layout]]"]);
+    expect(layoutFm["exo__Layout_targetClass"]).toBe("[[ems__Task]]");
+    expect(layoutFm["exo__Layout_blocks"]).toEqual([`[[${pair.block.uid}]]`]);
+    expect(layoutFm["exo__Layout_priority"]).toBe(10);
+    expect(layoutFm["exo__Layout_coexistsWithDefault"]).toBe(true);
+
+    const blockFm = readFrontmatter(blockOnDisk);
+    expect(blockFm["exo__Asset_uid"]).toBe(pair.block.uid);
+    expect(blockFm["exo__Instance_class"]).toEqual([
+      "[[exo__BacklinksTableBlock]]",
+    ]);
+    expect(blockFm["exo__BacklinksTableBlock_rowClass"]).toBe("[[ems__Task]]");
+    expect(blockFm["exo__BacklinksTableBlock_referencingProperty"]).toBe(
+      "[[ems__Task_parent]]",
+    );
+    expect(blockFm["exo__BacklinksTableBlock_columns"]).toEqual([
+      "[[ems__Effort_status]]",
+      "[[exo__Asset_label]]",
+    ]);
+  });
+
+  it("produces zero pairs when vault has no RelColSets", async () => {
+    writeAsset(tempDir, "task.md", {
+      exo__Asset_uid: "eee12345-1111-1111-1111-ffffffffffff",
+      exo__Instance_class: ["[[ems__Task]]"],
+    });
+
+    const adapter = new NodeFsAdapter(tempDir);
+    const service = new RelColSetToExoLayoutMigratorService({
+      uidFor: stubUidFor,
+    });
+
+    const allFiles = await adapter.getMarkdownFiles();
+    const configs = [];
+    for (const file of allFiles) {
+      const fm = await adapter.getFileMetadata(file);
+      if (!isRelColSetFrontmatter(fm)) continue;
+      const cfg = extractRelColSetConfig(file, fm);
+      if (cfg !== null) configs.push(cfg);
+    }
+    const result = service.migrate(configs);
+
+    expect(result.pairs).toHaveLength(0);
+  });
+});

--- a/packages/cli/tests/unit/services/RelColSetToExoLayoutMigratorService.test.ts
+++ b/packages/cli/tests/unit/services/RelColSetToExoLayoutMigratorService.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from "@jest/globals";
+import yaml from "js-yaml";
+import {
+  RelColSetToExoLayoutMigratorService,
+  extractRelColSetConfig,
+  isRelColSetFrontmatter,
+  type RelColSetConfig,
+} from "../../../src/services/RelColSetToExoLayoutMigratorService.js";
+
+function stubUidFor(
+  seed: string,
+  suffix: "layout" | "block",
+): string {
+  // Deterministic for test assertions — mirrors v4 UUID shape.
+  return `00000000-${suffix === "layout" ? "1111" : "2222"}-4444-8888-${seed.slice(0, 12).padEnd(12, "0")}`;
+}
+
+describe("RelColSetToExoLayoutMigratorService", () => {
+  describe("isRelColSetFrontmatter", () => {
+    it("accepts bare label `ui__RelationColumnSet`", () => {
+      expect(
+        isRelColSetFrontmatter({
+          exo__Instance_class: ["[[ui__RelationColumnSet]]"],
+        }),
+      ).toBe(true);
+    });
+
+    it("accepts canonical UID class", () => {
+      expect(
+        isRelColSetFrontmatter({
+          exo__Instance_class: [
+            "[[97fc9862-c886-4d86-9a60-e0cf9d778575]]",
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    it("accepts pipe-aliased wikilink", () => {
+      expect(
+        isRelColSetFrontmatter({
+          exo__Instance_class: [
+            "[[97fc9862-c886-4d86-9a60-e0cf9d778575|ui__RelationColumnSet]]",
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    it("rejects unrelated class", () => {
+      expect(
+        isRelColSetFrontmatter({
+          exo__Instance_class: ["[[ems__Task]]"],
+        }),
+      ).toBe(false);
+    });
+
+    it("handles missing frontmatter field", () => {
+      expect(isRelColSetFrontmatter({})).toBe(false);
+    });
+  });
+
+  describe("extractRelColSetConfig", () => {
+    it("extracts all fields from a well-formed RelColSet", () => {
+      const cfg = extractRelColSetConfig("vault/rc-1.md", {
+        exo__Asset_uid: "abc12345-1111-1111-1111-aaaaaaaaaaaa",
+        exo__Asset_label: "Tasks on Projects",
+        exo__Instance_class: ["[[ui__RelationColumnSet]]"],
+        ui__RelationColumnSet_targetClass: "[[ems__Task]]",
+        ui__RelationColumnSet_referencingProperty: "[[ems__Task_parent]]",
+        ui__RelationColumnSet_columns: [
+          "[[ems__Effort_status]]",
+          "[[exo__Asset_label]]",
+        ],
+        ui__RelationColumnSet_priority: 10,
+      });
+
+      expect(cfg).not.toBeNull();
+      expect(cfg!.uid).toBe("abc12345-1111-1111-1111-aaaaaaaaaaaa");
+      expect(cfg!.path).toBe("vault/rc-1.md");
+      expect(cfg!.label).toBe("Tasks on Projects");
+      expect(cfg!.targetClass).toBe("ems__Task");
+      expect(cfg!.referencingProperty).toBe("ems__Task_parent");
+      expect(cfg!.columns).toEqual([
+        "[[ems__Effort_status]]",
+        "[[exo__Asset_label]]",
+      ]);
+      expect(cfg!.priority).toBe(10);
+    });
+
+    it("returns null when uid is missing", () => {
+      expect(
+        extractRelColSetConfig("x.md", {
+          exo__Asset_label: "stub",
+        }),
+      ).toBeNull();
+    });
+
+    it("tolerates missing optional fields", () => {
+      const cfg = extractRelColSetConfig("v/rc.md", {
+        exo__Asset_uid: "def12345-1111-1111-1111-bbbbbbbbbbbb",
+        exo__Instance_class: ["[[ui__RelationColumnSet]]"],
+      });
+      expect(cfg).not.toBeNull();
+      expect(cfg!.targetClass).toBeNull();
+      expect(cfg!.referencingProperty).toBeNull();
+      expect(cfg!.columns).toEqual([]);
+      expect(cfg!.priority).toBeNull();
+      expect(cfg!.label).toBeNull();
+    });
+
+    it("reads targetClass from the first entry when array-valued", () => {
+      const cfg = extractRelColSetConfig("v/rc.md", {
+        exo__Asset_uid: "aaa12345-1111-1111-1111-cccccccccccc",
+        exo__Instance_class: ["[[ui__RelationColumnSet]]"],
+        ui__RelationColumnSet_targetClass: [
+          "[[ems__Task]]",
+          "[[ems__Project]]",
+        ],
+      });
+      expect(cfg!.targetClass).toBe("ems__Task");
+    });
+
+    it("parses stringified priority", () => {
+      const cfg = extractRelColSetConfig("v/rc.md", {
+        exo__Asset_uid: "bbb12345-1111-1111-1111-dddddddddddd",
+        exo__Instance_class: ["[[ui__RelationColumnSet]]"],
+        ui__RelationColumnSet_priority: "7",
+      });
+      expect(cfg!.priority).toBe(7);
+    });
+  });
+
+  describe("migrate()", () => {
+    const service = new RelColSetToExoLayoutMigratorService({
+      uidFor: stubUidFor,
+    });
+
+    const baseCfg: RelColSetConfig = {
+      uid: "abc12345-1111-1111-1111-aaaaaaaaaaaa",
+      path: "03 Knowledge/ui/rc.md",
+      label: "Tasks on Projects",
+      targetClass: "ems__Task",
+      referencingProperty: "ems__Task_parent",
+      columns: ["[[ems__Effort_status]]", "[[exo__Asset_label]]"],
+      priority: 10,
+    };
+
+    it("returns empty pairs for empty input", () => {
+      const out = service.migrate([]);
+      expect(out.pairs).toHaveLength(0);
+      expect(out.skipped).toHaveLength(0);
+    });
+
+    it("produces one Layout + one Block pair per RelColSet", () => {
+      const out = service.migrate([baseCfg]);
+      expect(out.pairs).toHaveLength(1);
+      const pair = out.pairs[0];
+      expect(pair.layout.uid).toBe(stubUidFor(baseCfg.uid, "layout"));
+      expect(pair.block.uid).toBe(stubUidFor(baseCfg.uid, "block"));
+      expect(pair.layout.filename).toBe(`${pair.layout.uid}.md`);
+      expect(pair.block.filename).toBe(`${pair.block.uid}.md`);
+    });
+
+    it("generated Layout YAML parses and carries targetClass + block ref", () => {
+      const out = service.migrate([baseCfg]);
+      const pair = out.pairs[0];
+      const fm = extractFrontmatter(pair.layout.content);
+      expect(fm["exo__Asset_uid"]).toBe(pair.layout.uid);
+      expect(fm["exo__Instance_class"]).toEqual(["[[exo__Layout]]"]);
+      expect(fm["exo__Layout_targetClass"]).toBe("[[ems__Task]]");
+      expect(fm["exo__Layout_blocks"]).toEqual([`[[${pair.block.uid}]]`]);
+      expect(fm["exo__Layout_priority"]).toBe(10);
+      expect(fm["exo__Layout_coexistsWithDefault"]).toBe(true);
+    });
+
+    it("generated Block YAML parses and carries rowClass/referencingProperty/columns", () => {
+      const out = service.migrate([baseCfg]);
+      const pair = out.pairs[0];
+      const fm = extractFrontmatter(pair.block.content);
+      expect(fm["exo__Asset_uid"]).toBe(pair.block.uid);
+      expect(fm["exo__Instance_class"]).toEqual([
+        "[[exo__BacklinksTableBlock]]",
+      ]);
+      expect(fm["exo__BacklinksTableBlock_rowClass"]).toBe("[[ems__Task]]");
+      expect(fm["exo__BacklinksTableBlock_referencingProperty"]).toBe(
+        "[[ems__Task_parent]]",
+      );
+      expect(fm["exo__BacklinksTableBlock_columns"]).toEqual([
+        "[[ems__Effort_status]]",
+        "[[exo__Asset_label]]",
+      ]);
+    });
+
+    it("omits priority line when source has no priority", () => {
+      const out = service.migrate([{ ...baseCfg, priority: null }]);
+      const fm = extractFrontmatter(out.pairs[0].layout.content);
+      expect("exo__Layout_priority" in fm).toBe(false);
+    });
+
+    it("emits empty array for missing columns", () => {
+      const out = service.migrate([{ ...baseCfg, columns: [] }]);
+      const fm = extractFrontmatter(out.pairs[0].block.content);
+      expect(fm["exo__BacklinksTableBlock_columns"]).toEqual([]);
+    });
+
+    it("flags warning when targetClass is missing and produces empty wikilink", () => {
+      const out = service.migrate([
+        { ...baseCfg, targetClass: null },
+      ]);
+      const pair = out.pairs[0];
+      expect(pair.warnings.some((w) => /targetClass/.test(w))).toBe(true);
+      const fm = extractFrontmatter(pair.layout.content);
+      expect(fm["exo__Layout_targetClass"]).toBe("");
+    });
+
+    it("flags warning when referencingProperty is missing", () => {
+      const out = service.migrate([
+        { ...baseCfg, referencingProperty: null },
+      ]);
+      const pair = out.pairs[0];
+      expect(
+        pair.warnings.some((w) => /referencingProperty/.test(w)),
+      ).toBe(true);
+    });
+
+    it("always emits additive-vs-replacing warning", () => {
+      const out = service.migrate([baseCfg]);
+      const pair = out.pairs[0];
+      expect(
+        pair.warnings.some((w) => /additive/.test(w)),
+      ).toBe(true);
+    });
+
+    it("skips RelColSet with no targetClass AND no referencingProperty", () => {
+      const out = service.migrate([
+        {
+          ...baseCfg,
+          targetClass: null,
+          referencingProperty: null,
+        },
+      ]);
+      expect(out.pairs).toHaveLength(0);
+      expect(out.skipped).toHaveLength(1);
+      expect(out.skipped[0].sourcePath).toBe(baseCfg.path);
+    });
+
+    it("handles multiple RelColSets independently", () => {
+      const cfgA: RelColSetConfig = { ...baseCfg };
+      const cfgB: RelColSetConfig = {
+        uid: "fff12345-1111-1111-1111-eeeeeeeeeeee",
+        path: "03 Knowledge/ui/rc-2.md",
+        label: "Notes on Projects",
+        targetClass: "ztlk__Note",
+        referencingProperty: "ztlk__Note_project",
+        columns: ["[[ztlk__Note_priority]]"],
+        priority: null,
+      };
+      const out = service.migrate([cfgA, cfgB]);
+      expect(out.pairs).toHaveLength(2);
+      expect(out.pairs[0].sourceUid).toBe(cfgA.uid);
+      expect(out.pairs[1].sourceUid).toBe(cfgB.uid);
+      expect(out.pairs[0].layout.uid).not.toBe(out.pairs[1].layout.uid);
+    });
+
+    it("default UID generator is deterministic across independent runs (idempotent --apply)", () => {
+      // Regression guard: v15.121.0 defect post-mortem lesson applied to the
+      // CLI migration path. Running `migrate-relcolset-to-exolayout --apply`
+      // twice must produce the SAME UIDs, so the second apply is a no-op at
+      // the filesystem level (file exists → write skipped by the user's
+      // choice) rather than duplicating Layout+Block pairs.
+      const serviceA = new RelColSetToExoLayoutMigratorService();
+      const serviceB = new RelColSetToExoLayoutMigratorService();
+      const runA = serviceA.migrate([baseCfg]);
+      const runB = serviceB.migrate([baseCfg]);
+      expect(runA.pairs[0].layout.uid).toBe(runB.pairs[0].layout.uid);
+      expect(runA.pairs[0].block.uid).toBe(runB.pairs[0].block.uid);
+      expect(runA.pairs[0].layout.content).toBe(runB.pairs[0].layout.content);
+      expect(runA.pairs[0].block.content).toBe(runB.pairs[0].block.content);
+    });
+
+    it("default UID generator emits UUID-shaped v4 strings", () => {
+      const service = new RelColSetToExoLayoutMigratorService();
+      const out = service.migrate([baseCfg]);
+      const uuidV4 =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+      expect(out.pairs[0].layout.uid).toMatch(uuidV4);
+      expect(out.pairs[0].block.uid).toMatch(uuidV4);
+      // Layout and block UIDs must differ (different suffix feeds hash).
+      expect(out.pairs[0].layout.uid).not.toBe(out.pairs[0].block.uid);
+    });
+
+    it("default UID generator: different source UIDs produce different outputs", () => {
+      const service = new RelColSetToExoLayoutMigratorService();
+      const cfgA: RelColSetConfig = { ...baseCfg };
+      const cfgB: RelColSetConfig = {
+        ...baseCfg,
+        uid: "xyz99999-1111-1111-1111-gggggggggggg",
+      };
+      const out = service.migrate([cfgA, cfgB]);
+      expect(out.pairs[0].layout.uid).not.toBe(out.pairs[1].layout.uid);
+    });
+
+    it("round-trip: parse generated Layout+Block back through extractor preserves essentials", () => {
+      const out = service.migrate([baseCfg]);
+      const pair = out.pairs[0];
+      const blockFm = extractFrontmatter(pair.block.content);
+      // Semantic column equivalence — the 2 configured columns survive.
+      expect(blockFm["exo__BacklinksTableBlock_columns"]).toEqual(
+        baseCfg.columns,
+      );
+      expect(blockFm["exo__BacklinksTableBlock_rowClass"]).toBe(
+        `[[${baseCfg.targetClass}]]`,
+      );
+      expect(blockFm["exo__BacklinksTableBlock_referencingProperty"]).toBe(
+        `[[${baseCfg.referencingProperty}]]`,
+      );
+    });
+  });
+});
+
+function extractFrontmatter(content: string): Record<string, unknown> {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error("frontmatter missing");
+  return yaml.load(match[1]) as Record<string, unknown>;
+}

--- a/packages/obsidian-plugin/docs/EXO_LAYOUT.md
+++ b/packages/obsidian-plugin/docs/EXO_LAYOUT.md
@@ -94,12 +94,12 @@ Two block kinds ship in this MVP. Their discriminator is the
 
 Renders the open note's own frontmatter as a two-column properties table.
 
-| Field                           | Required | Notes                                                       |
-| ------------------------------- | -------- | ----------------------------------------------------------- |
-| `exo__Asset_uid`                | yes      | Block uid referenced from `exo__Layout_blocks`.             |
-| `exo__Instance_class`           | yes      | Must contain `[[exo__PropertiesBlock]]` (plain or UUID).    |
-| `exo__LayoutBlock_title`        | no       | `<h3>` shown above the table. Falls back to `exo__Asset_label`, then to the block file basename. |
-| `exo__LayoutBlock_collapsed`    | no       | Reserved for a future "collapsed by default" UX — not yet consulted by the renderer. |
+| Field                        | Required | Notes                                                                                            |
+| ---------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `exo__Asset_uid`             | yes      | Block uid referenced from `exo__Layout_blocks`.                                                  |
+| `exo__Instance_class`        | yes      | Must contain `[[exo__PropertiesBlock]]` (plain or UUID).                                         |
+| `exo__LayoutBlock_title`     | no       | `<h3>` shown above the table. Falls back to `exo__Asset_label`, then to the block file basename. |
+| `exo__LayoutBlock_collapsed` | no       | Reserved for a future "collapsed by default" UX — not yet consulted by the renderer.             |
 
 ### `exo__BacklinksTableBlock`
 
@@ -107,17 +107,17 @@ Renders a filtered, sorted table of backlinks — the block equivalent of
 the default Asset Relations section, but scoped to a single
 `(rowClass, referencingProperty)` pair and with explicit columns.
 
-| Field                                                 | Required | Notes                                                                                       |
-| ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `exo__Asset_uid`                                      | yes      | Block uid.                                                                                  |
-| `exo__Instance_class`                                 | yes      | Must contain `[[exo__BacklinksTableBlock]]`.                                                |
-| `exo__BacklinksTableBlock_rowClass`                   | yes      | Wikilink; only backlinks whose `exo__Instance_class` matches are included.                  |
-| `exo__BacklinksTableBlock_referencingProperty`        | yes      | Wikilink; only backlinks whose referencing frontmatter property equals this are included.   |
-| `exo__BacklinksTableBlock_columns`                    | yes      | Array of wikilinks or bare identifiers. Each is normalised to a property name before rendering. |
-| `exo__BacklinksTableBlock_sortBy`                     | no       | Column to sort by; defaults to `exo__Asset_label`.                                          |
-| `exo__BacklinksTableBlock_sortOrder`                  | no       | `"asc"` (default) or `"desc"`.                                                              |
-| `exo__BacklinksTableBlock_limit`                      | no       | Positive integer cap on visible rows; omit for unlimited.                                   |
-| `exo__BacklinksTableBlock_showArchived`               | no       | `false` by default; set `true` to include rows with `archived: true`.                       |
+| Field                                          | Required | Notes                                                                                           |
+| ---------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `exo__Asset_uid`                               | yes      | Block uid.                                                                                      |
+| `exo__Instance_class`                          | yes      | Must contain `[[exo__BacklinksTableBlock]]`.                                                    |
+| `exo__BacklinksTableBlock_rowClass`            | yes      | Wikilink; only backlinks whose `exo__Instance_class` matches are included.                      |
+| `exo__BacklinksTableBlock_referencingProperty` | yes      | Wikilink; only backlinks whose referencing frontmatter property equals this are included.       |
+| `exo__BacklinksTableBlock_columns`             | yes      | Array of wikilinks or bare identifiers. Each is normalised to a property name before rendering. |
+| `exo__BacklinksTableBlock_sortBy`              | no       | Column to sort by; defaults to `exo__Asset_label`.                                              |
+| `exo__BacklinksTableBlock_sortOrder`           | no       | `"asc"` (default) or `"desc"`.                                                                  |
+| `exo__BacklinksTableBlock_limit`               | no       | Positive integer cap on visible rows; omit for unlimited.                                       |
+| `exo__BacklinksTableBlock_showArchived`        | no       | `false` by default; set `true` to include rows with `archived: true`.                           |
 
 ### Wikilink forms — canonical normalization
 
@@ -144,12 +144,12 @@ the React renderer looks it up against the row frontmatter (e.g.
 When more than one Layout asset targets the same class, the resolver
 picks a single winner.
 
-| Step | Rule                                                                                      |
-| ---- | ----------------------------------------------------------------------------------------- |
+| Step | Rule                                                                                       |
+| ---- | ------------------------------------------------------------------------------------------ |
 | 1    | Walk `exo__Instance_class` of the open note in declaration order; stop at the first match. |
-| 2    | Among matches for the winning class, pick the highest `exo__Layout_priority`.             |
-| 3    | Tiebreaker — `exo__Asset_uid` ascending.                                                  |
-| 4    | Nothing matched — fall back to the default Asset Relations rendering.                     |
+| 2    | Among matches for the winning class, pick the highest `exo__Layout_priority`.              |
+| 3    | Tiebreaker — `exo__Asset_uid` ascending.                                                   |
+| 4    | Nothing matched — fall back to the default Asset Relations rendering.                      |
 
 Declaration order of classes in `exo__Instance_class` matters: the
 selector walks classes in that order, and the first class to produce a
@@ -226,3 +226,87 @@ expected a Layout, check:
    selector returns `null`).
 4. The Layout file itself is inside the vault (the repository subscribes
    to `vault` events, not `metadataCache`-synthesised ones).
+
+## Bootstrap (auto-installed ontology)
+
+Since RFC exo**Layout Phase 4 shipped, the plugin auto-installs the 18
+`exo**Layout`ontology assets (4 classes + 14 properties) into a hidden`\_exocortex-exo-layout-ontology/` folder on first load. Without these
+assets, Layout and Block wikilinks would dangle and nothing would render.
+The install is **idempotent and UID-aware**:
+
+- If any of the 18 UUIDs are already present anywhere in the vault (e.g.
+  you imported the starter-kit `exo/` folder manually), the bootstrap
+  skips them — no duplicates.
+- If the hidden folder already has the files (second plugin load), nothing
+  is written.
+- If only a subset is present, only the missing files are created.
+
+**Troubleshooting bootstrap:**
+
+- `exocortex:ExoLayoutOntologyBootstrapper: installed N ontology file(s)`
+  in the console — normal on first load (N ≤ 18).
+- `exocortex:ExoLayoutOntologyBootstrapper: failed to install <path>: <err>` —
+  a single write failed (e.g. the folder was momentarily locked). The
+  bootstrap continues with the remaining files; re-open the vault to
+  retry.
+- `exocortex:ExoLayoutOntologyBootstrapper: bootstrap failed: <err>` — an
+  unexpected error aborted the whole run. The plugin still loads; Layouts
+  that reference the missing ontology classes will log `unknown block
+class` warnings. Copy the 18 files from
+  `kitelev/exocortex-starter-kit/exo/` manually as a workaround.
+- If the `_exocortex-exo-layout-ontology/` folder clutters your file
+  explorer, hide dot-files / underscore-prefixed folders in Obsidian's
+  Files & Links settings.
+- **Do not edit** the 18 auto-installed files in place — the plugin
+  treats them as an ontology source-of-truth. If you want to customise
+  (e.g. add a new `aliases` entry), copy the file to a non-hidden folder
+  and delete the original; the UID-aware bootstrap will then honour your
+  copy and never regenerate the underscore-folder version.
+
+## Migrating from `ui__RelationColumnSet`
+
+The CLI ships with an opt-in migration helper
+(`exocortex migrate-relcolset-to-exolayout`) that scans a vault for
+existing `ui__RelationColumnSet` configs and generates a starting-point
+`exo__Layout` + `exo__BacklinksTableBlock` pair per config.
+
+```bash
+# Dry-run — prints YAML previews + warnings to stderr (nothing written)
+exocortex migrate-relcolset-to-exolayout --vault /path/to/vault
+
+# Apply — writes pairs to vault (default: exo-layout-migrated/)
+exocortex migrate-relcolset-to-exolayout --vault /path/to/vault --apply
+
+# JSON report
+exocortex migrate-relcolset-to-exolayout --vault /path/to/vault --json
+```
+
+**Semantic gap — read before applying:**
+
+- `ui__RelationColumnSet` is **additive** (extends `Name` + `Instance Class`
+  columns). `exo__BacklinksTableBlock` is **replacing** (renders only the
+  configured columns). The generated block will look different from the
+  original RelationColumnSet rendering by default.
+- `exo__Layout.targetClass` is the **page class** the layout renders on.
+  `ui__RelationColumnSet.targetClass` is the **row class** filtered in the
+  relations table. The migration cannot infer the former from the latter
+  and inserts a placeholder — review every generated Layout before
+  applying in production, and fix the `exo__Layout_targetClass` wikilink
+  to the class of the page you want the layout on.
+- The generated files carry `exo__Layout_coexistsWithDefault: true` so
+  the migrated block renders **in addition to** the legacy Asset
+  Relations table. Set to `false` once you are happy to remove the
+  legacy rendering.
+
+The command is non-destructive in apply mode — it writes new files and
+never edits or removes the source `ui__RelationColumnSet` assets. Delete
+the RelationColumnSet configs manually once you've verified the migrated
+Layouts.
+
+**Idempotency.** Generated UIDs are **deterministic** (SHA-1 of source UID
+
+- suffix). Re-running `--apply` against the same vault produces identical
+  Layout+Block UIDs and contents — so the second run is a no-op at the
+  filesystem level rather than creating a duplicate set of migrated files.
+  This matches the plugin ontology bootstrap (UID-aware) and avoids the
+  duplicate-assets footgun that would otherwise trip power-users.

--- a/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
+++ b/packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md
@@ -1,5 +1,17 @@
 # `ui__RelationColumnSet` — RDF-configurable backlinks columns
 
+> **Consider `exo__Layout` for full body control.** `ui__RelationColumnSet`
+> is **additive** — it extends the hardcoded `Name` + `Instance Class`
+> columns of the default Asset Relations table. If you want to _replace_
+> those columns, remove the table's `Asset Relations` wrapper, or build a
+> standalone body composed of multiple typed blocks, see
+> [`EXO_LAYOUT.md`](./EXO_LAYOUT.md). The CLI helper
+> `exocortex migrate-relcolset-to-exolayout` generates a starting-point
+> `exo__Layout` + `exo__BacklinksTableBlock` pair from each existing
+> RelationColumnSet — read the "Migrating from `ui__RelationColumnSet`"
+> section of `EXO_LAYOUT.md` for the semantic gaps the tool cannot bridge
+> automatically.
+
 `ui__RelationColumnSet` lets you declare, directly in the vault, which
 properties should appear as columns in the UniversalLayout auto-backlinks
 table for a given (rowClass, referencingProperty) pair. Previously this map

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -69,6 +69,8 @@ import { ObsidianFileSystemAdapter } from "./adapters/ObsidianFileSystemAdapter"
 import { populateServiceRegistry } from "./infrastructure/services/ServiceRegistryPopulator";
 import { UiOntologyBootstrapper } from "./infrastructure/ontology/UiOntologyBootstrapper";
 import { ObsidianUiOntologyBootstrapperVault } from "./infrastructure/ontology/ObsidianUiOntologyBootstrapperVault";
+import { ExoLayoutOntologyBootstrapper } from "./infrastructure/ontology/ExoLayoutOntologyBootstrapper";
+import { ObsidianExoLayoutOntologyBootstrapperVault } from "./infrastructure/ontology/ObsidianExoLayoutOntologyBootstrapperVault";
 
 /**
  * Exocortex Plugin - Automatic layout rendering
@@ -242,6 +244,40 @@ export default class ExocortexPlugin extends Plugin {
         () => repo.getSnapshot().all,
         { logger: relationColumnSetLogger },
       );
+
+      // RFC exo__Layout Phase 4 — install the 18-file `exo__Layout` ontology
+      // (4 classes + 14 properties) into the vault before the repository
+      // initialises, so the snapshot can pick up the class + property assets
+      // on first rebuild. Without this, a vault that has not manually imported
+      // the starter-kit `exo/` folder cannot render any `exo__Layout` asset
+      // (wikilinks dangle). Idempotency is UID-first then path-level — same
+      // semantics as the `ui__RelationColumnSet` bootstrapper (v15.121.1).
+      try {
+        const exoLayoutBootstrapResult =
+          await new ExoLayoutOntologyBootstrapper(
+            new ObsidianExoLayoutOntologyBootstrapperVault(
+              this.app.vault,
+              this.app.metadataCache,
+            ),
+          ).bootstrap();
+        if (exoLayoutBootstrapResult.created.length > 0) {
+          this.logger.info("ExoLayoutOntologyBootstrapper", {
+            message: `installed ${exoLayoutBootstrapResult.created.length} ontology file(s)`,
+            created: exoLayoutBootstrapResult.created,
+          });
+        }
+        if (exoLayoutBootstrapResult.errors.length > 0) {
+          for (const err of exoLayoutBootstrapResult.errors) {
+            this.logger.warn("ExoLayoutOntologyBootstrapper", {
+              message: `failed to install ${err.path}: ${err.error.message}`,
+            });
+          }
+        }
+      } catch (err) {
+        this.logger.warn("ExoLayoutOntologyBootstrapper", {
+          message: `bootstrap failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
 
       // RFC exo__Layout Phase 2 — wire ExoLayoutRepository + LayoutSelector
       // using the same live-snapshot pattern as RelationColumnSet.

--- a/packages/obsidian-plugin/src/infrastructure/ontology/ExoLayoutOntologyBootstrapper.ts
+++ b/packages/obsidian-plugin/src/infrastructure/ontology/ExoLayoutOntologyBootstrapper.ts
@@ -1,0 +1,452 @@
+/**
+ * ExoLayoutOntologyBootstrapper — installs the `exo__Layout` ontology
+ * (18 files: 4 classes + 14 properties) into a personal vault on plugin load.
+ *
+ * Phase 4 of RFC exo__Layout (6628d78a-78a9-473c-ace3-e9b6d28750d1).
+ *
+ * Without this bootstrap, a user who has not manually copied the 18 ontology
+ * files from `kitelev/exocortex-starter-kit` `exo/` directory cannot create
+ * `exo__Layout` / `exo__BacklinksTableBlock` / `exo__PropertiesBlock` assets —
+ * the class and property wikilinks would dangle. The idempotent onLoad install
+ * closes that friction point while preserving vaults that already carry the
+ * ontology at a non-default folder (starter-kit convention `exo/`).
+ *
+ * Idempotency (two layers, UUID check first — stronger):
+ * 1. `hasAssetWithUid(uid)` — true if a `<uid>.md` file exists anywhere in
+ *    the vault. Catches users who have already copied the starter-kit `exo/`
+ *    folder to a custom location, and prevents duplicate `exo__Asset_uid`
+ *    assets which would break `ExoLayoutRepository` first-seen deduplication.
+ * 2. `fileExists(path)` — fallback path-level check at the default target.
+ *
+ * Mirrors the `UiOntologyBootstrapper` pattern (v15.121.1, closes #2943) —
+ * same API, same idempotency semantics, different ontology + different target
+ * folder (`_exocortex-exo-layout-ontology`). See the memory entry
+ * `reference_obsidian_metadataCache_getFirstLinkpathDest_onload.md` for the
+ * O(1) early-onload UID lookup mechanism.
+ *
+ * Drift guard: the 18 string literals below are verbatim copies of
+ * `exocortex-starter-kit/exo/<uid>.md` from PR #87 (commit 84101d3,
+ * 2026-04-24). A unit test enforces structural invariants (UUID basename,
+ * exo__Asset_isDefinedBy pointing at the !exo root, class/subclass/property
+ * shape). Any manual edit to these literals must be mirrored in the
+ * starter-kit repository — if a future change ships via starter-kit first,
+ * regenerate this bundle.
+ */
+
+export interface ExoLayoutOntologyBootstrapperVault {
+  /**
+   * True iff a `.md` file whose basename equals this UUID exists anywhere
+   * in the vault. Stronger than path-level `fileExists` — catches legacy
+   * copies at non-default folders (starter-kit `exo/`, custom paths, etc.)
+   * and prevents duplicate `exo__Asset_uid` assets on upgrade.
+   */
+  hasAssetWithUid(uid: string): boolean;
+  fileExists(path: string): boolean;
+  createFile(path: string, content: string): Promise<void>;
+  ensureFolder(path: string): Promise<void>;
+}
+
+export interface ExoLayoutOntologyFile {
+  readonly uid: string;
+  readonly filename: string;
+  readonly content: string;
+}
+
+export interface ExoLayoutOntologyBootstrapResult {
+  readonly created: string[];
+  readonly skipped: string[];
+  readonly errors: Array<{ path: string; error: Error }>;
+}
+
+export interface ExoLayoutOntologyBootstrapperOptions {
+  /** Vault-relative folder where the 18 ontology files will be installed. */
+  targetFolder?: string;
+}
+
+const DEFAULT_TARGET_FOLDER = "_exocortex-exo-layout-ontology";
+
+// ----------------------------------------------------------------------------
+// 4 classes
+// ----------------------------------------------------------------------------
+
+const LAYOUT_CLASS: ExoLayoutOntologyFile = {
+  uid: "08d00289-a5c8-4df1-8885-40a00a014004",
+  filename: "08d00289-a5c8-4df1-8885-40a00a014004.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 08d00289-a5c8-4df1-8885-40a00a014004
+exo__Instance_class:
+  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"
+exo__Asset_label: exo__Layout
+aliases:
+  - exo__Layout
+---
+`,
+};
+
+const LAYOUT_BLOCK_CLASS: ExoLayoutOntologyFile = {
+  uid: "6bca6f8d-2a2b-4f38-8e20-97727499009e",
+  filename: "6bca6f8d-2a2b-4f38-8e20-97727499009e.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 6bca6f8d-2a2b-4f38-8e20-97727499009e
+exo__Instance_class:
+  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"
+exo__Asset_label: exo__LayoutBlock
+aliases:
+  - exo__LayoutBlock
+---
+`,
+};
+
+const BACKLINKS_TABLE_BLOCK_CLASS: ExoLayoutOntologyFile = {
+  uid: "2e868956-d81e-43fd-9817-1addde9cb311",
+  filename: "2e868956-d81e-43fd-9817-1addde9cb311.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 2e868956-d81e-43fd-9817-1addde9cb311
+exo__Instance_class:
+  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"
+exo__Asset_label: exo__BacklinksTableBlock
+aliases:
+  - exo__BacklinksTableBlock
+rdfs__subClassOf: "[[6bca6f8d-2a2b-4f38-8e20-97727499009e|exo__LayoutBlock]]"
+---
+`,
+};
+
+const PROPERTIES_BLOCK_CLASS: ExoLayoutOntologyFile = {
+  uid: "fd039b3c-ed2b-41c2-a42e-bbfcdd074bfe",
+  filename: "fd039b3c-ed2b-41c2-a42e-bbfcdd074bfe.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: fd039b3c-ed2b-41c2-a42e-bbfcdd074bfe
+exo__Instance_class:
+  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"
+exo__Asset_label: exo__PropertiesBlock
+aliases:
+  - exo__PropertiesBlock
+rdfs__subClassOf: "[[6bca6f8d-2a2b-4f38-8e20-97727499009e|exo__LayoutBlock]]"
+---
+`,
+};
+
+// ----------------------------------------------------------------------------
+// 4 Layout_* properties
+// ----------------------------------------------------------------------------
+
+const LAYOUT_TARGET_CLASS: ExoLayoutOntologyFile = {
+  uid: "c062eb14-e21a-44f9-a490-6f9773e0a93d",
+  filename: "c062eb14-e21a-44f9-a490-6f9773e0a93d.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: c062eb14-e21a-44f9-a490-6f9773e0a93d
+exo__Instance_class:
+  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"
+exo__Asset_label: exo__Layout_targetClass
+aliases:
+  - exo__Layout_targetClass
+  - Layout Target Class
+---
+`,
+};
+
+const LAYOUT_PRIORITY: ExoLayoutOntologyFile = {
+  uid: "f39f69bb-24e4-4f21-aa4c-5fe6a69dd4e6",
+  filename: "f39f69bb-24e4-4f21-aa4c-5fe6a69dd4e6.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: f39f69bb-24e4-4f21-aa4c-5fe6a69dd4e6
+exo__Instance_class:
+  - "[[81c5d3c0-e2f2-4f7d-a19d-de91f414340e|exo__NumberProperty]]"
+exo__Asset_label: exo__Layout_priority
+aliases:
+  - exo__Layout_priority
+  - Layout Priority
+---
+`,
+};
+
+const LAYOUT_BLOCKS: ExoLayoutOntologyFile = {
+  uid: "d1d19227-937b-4761-89a6-e2f665716262",
+  filename: "d1d19227-937b-4761-89a6-e2f665716262.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: d1d19227-937b-4761-89a6-e2f665716262
+exo__Instance_class:
+  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"
+exo__Asset_label: exo__Layout_blocks
+aliases:
+  - exo__Layout_blocks
+  - Layout Blocks
+---
+`,
+};
+
+const LAYOUT_COEXISTS_WITH_DEFAULT: ExoLayoutOntologyFile = {
+  uid: "11db753b-df28-46e1-91eb-acea7ca2f9c8",
+  filename: "11db753b-df28-46e1-91eb-acea7ca2f9c8.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 11db753b-df28-46e1-91eb-acea7ca2f9c8
+exo__Instance_class:
+  - "[[30d63ce4-e574-456c-8de8-2bf1a53688c1|exo__StringProperty]]"
+exo__Asset_label: exo__Layout_coexistsWithDefault
+aliases:
+  - exo__Layout_coexistsWithDefault
+  - Layout Coexists With Default
+---
+`,
+};
+
+// ----------------------------------------------------------------------------
+// 3 LayoutBlock_* properties
+// ----------------------------------------------------------------------------
+
+const LAYOUT_BLOCK_TITLE: ExoLayoutOntologyFile = {
+  uid: "a3df1733-a66d-40ab-8a71-acca4886609a",
+  filename: "a3df1733-a66d-40ab-8a71-acca4886609a.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: a3df1733-a66d-40ab-8a71-acca4886609a
+exo__Instance_class:
+  - "[[30d63ce4-e574-456c-8de8-2bf1a53688c1|exo__StringProperty]]"
+exo__Asset_label: exo__LayoutBlock_title
+aliases:
+  - exo__LayoutBlock_title
+  - Layout Block Title
+---
+`,
+};
+
+const LAYOUT_BLOCK_TYPE: ExoLayoutOntologyFile = {
+  uid: "5f48b45b-fdc7-44ef-8846-f3ffd70665fc",
+  filename: "5f48b45b-fdc7-44ef-8846-f3ffd70665fc.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 5f48b45b-fdc7-44ef-8846-f3ffd70665fc
+exo__Instance_class:
+  - "[[30d63ce4-e574-456c-8de8-2bf1a53688c1|exo__StringProperty]]"
+exo__Asset_label: exo__LayoutBlock_type
+aliases:
+  - exo__LayoutBlock_type
+  - Layout Block Type
+---
+`,
+};
+
+const LAYOUT_BLOCK_COLLAPSED: ExoLayoutOntologyFile = {
+  uid: "5b52a2aa-f5ea-48bb-a1c5-728d59bb805f",
+  filename: "5b52a2aa-f5ea-48bb-a1c5-728d59bb805f.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 5b52a2aa-f5ea-48bb-a1c5-728d59bb805f
+exo__Instance_class:
+  - "[[30d63ce4-e574-456c-8de8-2bf1a53688c1|exo__StringProperty]]"
+exo__Asset_label: exo__LayoutBlock_collapsed
+aliases:
+  - exo__LayoutBlock_collapsed
+  - Layout Block Collapsed
+---
+`,
+};
+
+// ----------------------------------------------------------------------------
+// 7 BacklinksTableBlock_* properties
+// ----------------------------------------------------------------------------
+
+const BACKLINKS_ROW_CLASS: ExoLayoutOntologyFile = {
+  uid: "07bc2f29-abde-43ed-9b7a-72b67114cf54",
+  filename: "07bc2f29-abde-43ed-9b7a-72b67114cf54.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 07bc2f29-abde-43ed-9b7a-72b67114cf54
+exo__Instance_class:
+  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"
+exo__Asset_label: exo__BacklinksTableBlock_rowClass
+aliases:
+  - exo__BacklinksTableBlock_rowClass
+  - Backlinks Row Class
+---
+`,
+};
+
+const BACKLINKS_REFERENCING_PROPERTY: ExoLayoutOntologyFile = {
+  uid: "76bb0bde-d692-41c4-88ab-7637bf0c7e54",
+  filename: "76bb0bde-d692-41c4-88ab-7637bf0c7e54.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 76bb0bde-d692-41c4-88ab-7637bf0c7e54
+exo__Instance_class:
+  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"
+exo__Asset_label: exo__BacklinksTableBlock_referencingProperty
+aliases:
+  - exo__BacklinksTableBlock_referencingProperty
+  - Backlinks Referencing Property
+---
+`,
+};
+
+const BACKLINKS_COLUMNS: ExoLayoutOntologyFile = {
+  uid: "42c32853-c8e4-462d-b927-6d16d962aa3e",
+  filename: "42c32853-c8e4-462d-b927-6d16d962aa3e.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 42c32853-c8e4-462d-b927-6d16d962aa3e
+exo__Instance_class:
+  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"
+exo__Asset_label: exo__BacklinksTableBlock_columns
+aliases:
+  - exo__BacklinksTableBlock_columns
+  - Backlinks Columns
+---
+`,
+};
+
+const BACKLINKS_SORT_BY: ExoLayoutOntologyFile = {
+  uid: "05a5f768-298f-4561-aad5-31c8c326eece",
+  filename: "05a5f768-298f-4561-aad5-31c8c326eece.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 05a5f768-298f-4561-aad5-31c8c326eece
+exo__Instance_class:
+  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"
+exo__Asset_label: exo__BacklinksTableBlock_sortBy
+aliases:
+  - exo__BacklinksTableBlock_sortBy
+  - Backlinks Sort By
+---
+`,
+};
+
+const BACKLINKS_SORT_ORDER: ExoLayoutOntologyFile = {
+  uid: "cb70ba11-6e07-4fbb-a38f-afd0c6ecff02",
+  filename: "cb70ba11-6e07-4fbb-a38f-afd0c6ecff02.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: cb70ba11-6e07-4fbb-a38f-afd0c6ecff02
+exo__Instance_class:
+  - "[[30d63ce4-e574-456c-8de8-2bf1a53688c1|exo__StringProperty]]"
+exo__Asset_label: exo__BacklinksTableBlock_sortOrder
+aliases:
+  - exo__BacklinksTableBlock_sortOrder
+  - Backlinks Sort Order
+---
+`,
+};
+
+const BACKLINKS_LIMIT: ExoLayoutOntologyFile = {
+  uid: "498a804d-e925-4cec-a392-1b1a6d4bd3d1",
+  filename: "498a804d-e925-4cec-a392-1b1a6d4bd3d1.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 498a804d-e925-4cec-a392-1b1a6d4bd3d1
+exo__Instance_class:
+  - "[[81c5d3c0-e2f2-4f7d-a19d-de91f414340e|exo__NumberProperty]]"
+exo__Asset_label: exo__BacklinksTableBlock_limit
+aliases:
+  - exo__BacklinksTableBlock_limit
+  - Backlinks Limit
+---
+`,
+};
+
+const BACKLINKS_SHOW_ARCHIVED: ExoLayoutOntologyFile = {
+  uid: "3ef3ddca-560e-4b6c-9e1f-deb8a28f9438",
+  filename: "3ef3ddca-560e-4b6c-9e1f-deb8a28f9438.md",
+  content: `---
+exo__Asset_isDefinedBy: "[[ca97bb2f-99bd-4ceb-b51e-c386b9231ae3]]"
+exo__Asset_uid: 3ef3ddca-560e-4b6c-9e1f-deb8a28f9438
+exo__Instance_class:
+  - "[[30d63ce4-e574-456c-8de8-2bf1a53688c1|exo__StringProperty]]"
+exo__Asset_label: exo__BacklinksTableBlock_showArchived
+aliases:
+  - exo__BacklinksTableBlock_showArchived
+  - Backlinks Show Archived
+---
+`,
+};
+
+/**
+ * Static manifest of the 18 `exo__Layout` ontology files bundled with the
+ * plugin.
+ *
+ * Source-of-truth: `kitelev/exocortex-starter-kit` `exo/` directory
+ * (snapshot from PR #87 / commit 84101d3, 2026-04-24).
+ *
+ * Layout: 4 classes + 14 properties. Classes carry `exo__Class` instance
+ * (8619c4fc); subclasses (BacklinksTableBlock, PropertiesBlock) also carry
+ * `rdfs__subClassOf: [[6bca6f8d|exo__LayoutBlock]]`. Properties carry one
+ * of `exo__ObjectProperty` / `exo__StringProperty` / `exo__NumberProperty`
+ * via `exo__Instance_class`. All 18 reference the `!exo` ontology root
+ * `ca97bb2f-99bd-4ceb-b51e-c386b9231ae3` via `exo__Asset_isDefinedBy`.
+ */
+export const EXO_LAYOUT_ONTOLOGY_FILES: readonly ExoLayoutOntologyFile[] = [
+  // 4 classes
+  LAYOUT_CLASS,
+  LAYOUT_BLOCK_CLASS,
+  BACKLINKS_TABLE_BLOCK_CLASS,
+  PROPERTIES_BLOCK_CLASS,
+  // 4 Layout_* properties
+  LAYOUT_TARGET_CLASS,
+  LAYOUT_PRIORITY,
+  LAYOUT_BLOCKS,
+  LAYOUT_COEXISTS_WITH_DEFAULT,
+  // 3 LayoutBlock_* properties
+  LAYOUT_BLOCK_TITLE,
+  LAYOUT_BLOCK_TYPE,
+  LAYOUT_BLOCK_COLLAPSED,
+  // 7 BacklinksTableBlock_* properties
+  BACKLINKS_ROW_CLASS,
+  BACKLINKS_REFERENCING_PROPERTY,
+  BACKLINKS_COLUMNS,
+  BACKLINKS_SORT_BY,
+  BACKLINKS_SORT_ORDER,
+  BACKLINKS_LIMIT,
+  BACKLINKS_SHOW_ARCHIVED,
+];
+
+export class ExoLayoutOntologyBootstrapper {
+  private readonly targetFolder: string;
+
+  constructor(
+    private readonly vault: ExoLayoutOntologyBootstrapperVault,
+    options: ExoLayoutOntologyBootstrapperOptions = {},
+  ) {
+    this.targetFolder = options.targetFolder ?? DEFAULT_TARGET_FOLDER;
+  }
+
+  async bootstrap(): Promise<ExoLayoutOntologyBootstrapResult> {
+    const created: string[] = [];
+    const skipped: string[] = [];
+    const errors: Array<{ path: string; error: Error }> = [];
+
+    const pending: Array<{ path: string; content: string }> = [];
+    for (const file of EXO_LAYOUT_ONTOLOGY_FILES) {
+      const path = `${this.targetFolder}/${file.filename}`;
+      if (this.vault.hasAssetWithUid(file.uid) || this.vault.fileExists(path)) {
+        skipped.push(path);
+      } else {
+        pending.push({ path, content: file.content });
+      }
+    }
+
+    if (pending.length > 0) {
+      await this.vault.ensureFolder(this.targetFolder);
+    }
+
+    for (const entry of pending) {
+      try {
+        await this.vault.createFile(entry.path, entry.content);
+        created.push(entry.path);
+      } catch (error) {
+        errors.push({
+          path: entry.path,
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+      }
+    }
+
+    return { created, skipped, errors };
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/ontology/ObsidianExoLayoutOntologyBootstrapperVault.ts
+++ b/packages/obsidian-plugin/src/infrastructure/ontology/ObsidianExoLayoutOntologyBootstrapperVault.ts
@@ -1,0 +1,46 @@
+import type { MetadataCache, Vault } from "obsidian";
+import type { ExoLayoutOntologyBootstrapperVault } from "./ExoLayoutOntologyBootstrapper";
+
+/**
+ * Obsidian-concrete `ExoLayoutOntologyBootstrapperVault` adapter — translates
+ * the minimal bootstrapper API to `Vault` primitives.
+ *
+ * Mirrors `ObsidianUiOntologyBootstrapperVault` (since v15.121.1). See the
+ * memory entry `reference_obsidian_metadataCache_getFirstLinkpathDest_onload.md`
+ * for the O(1) early-onload UID lookup mechanism.
+ *
+ * `hasAssetWithUid` uses `MetadataCache.getFirstLinkpathDest`, which Obsidian
+ * indexes on basename and resolves synchronously without requiring a full
+ * `metadataCache.on("resolved")` — suitable for early `onload` invocation.
+ * This catches legacy copies of the 18 files at non-default folders (e.g.
+ * starter-kit `exo/` convention) and prevents the bootstrapper from creating
+ * duplicate `exo__Asset_uid` assets on plugin upgrade.
+ *
+ * `fileExists` remains a fast path-level fallback against
+ * `getAbstractFileByPath` — used after the UID scan as defence in depth.
+ */
+export class ObsidianExoLayoutOntologyBootstrapperVault
+  implements ExoLayoutOntologyBootstrapperVault
+{
+  constructor(
+    private readonly vault: Vault,
+    private readonly metadataCache: MetadataCache,
+  ) {}
+
+  hasAssetWithUid(uid: string): boolean {
+    return this.metadataCache.getFirstLinkpathDest(uid, "") !== null;
+  }
+
+  fileExists(path: string): boolean {
+    return this.vault.getAbstractFileByPath(path) !== null;
+  }
+
+  async createFile(path: string, content: string): Promise<void> {
+    await this.vault.create(path, content);
+  }
+
+  async ensureFolder(path: string): Promise<void> {
+    if (this.vault.getAbstractFileByPath(path) !== null) return;
+    await this.vault.createFolder(path);
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/infrastructure/ontology/ExoLayoutOntologyBootstrapper.starter-kit-drift.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/ontology/ExoLayoutOntologyBootstrapper.starter-kit-drift.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { EXO_LAYOUT_ONTOLOGY_FILES } from "../../../../src/infrastructure/ontology/ExoLayoutOntologyBootstrapper";
+
+/**
+ * Drift-guard: ensures the 18 bundled `exo__Layout` ontology literals in
+ * `ExoLayoutOntologyBootstrapper.ts` remain byte-identical to the starter-kit
+ * source-of-truth (`exocortex-starter-kit/exo/<uid>.md`, PR #87 / commit
+ * 84101d3).
+ *
+ * This test is **local-only** — CI runners do not have the starter-kit repo
+ * on disk, so the suite short-circuits cleanly when the starter-kit path is
+ * not present. Developers can run this before opening a PR (or after pulling
+ * starter-kit changes) to catch accidental drift before it ships.
+ *
+ * Why a separate test file: the main `ExoLayoutOntologyBootstrapper.test.ts`
+ * suite is pure in-memory and must stay hermetic. Mixing filesystem reads
+ * would make the primary unit tests non-portable.
+ */
+
+const STARTER_KIT_EXO_DIR = "/Users/kitelev/Developer/exocortex-development/exocortex-starter-kit/exo";
+
+const canDrive = existsSync(STARTER_KIT_EXO_DIR);
+const describeLocal = canDrive ? describe : describe.skip;
+
+describeLocal("ExoLayoutOntologyBootstrapper — starter-kit drift-guard", () => {
+  it("each bundled file matches the starter-kit source verbatim", () => {
+    const mismatches: Array<{
+      uid: string;
+      mismatch: string;
+    }> = [];
+    for (const file of EXO_LAYOUT_ONTOLOGY_FILES) {
+      const starterKitPath = resolve(
+        STARTER_KIT_EXO_DIR,
+        `${file.uid}.md`,
+      );
+      if (!existsSync(starterKitPath)) {
+        mismatches.push({ uid: file.uid, mismatch: "file missing in starter-kit" });
+        continue;
+      }
+      const starterKitContent = readFileSync(starterKitPath, "utf-8");
+      if (starterKitContent !== file.content) {
+        mismatches.push({
+          uid: file.uid,
+          mismatch: `content differs — bundle (${file.content.length} bytes) vs starter-kit (${starterKitContent.length} bytes)`,
+        });
+      }
+    }
+
+    if (mismatches.length > 0) {
+      const summary = mismatches
+        .map((m) => `  - ${m.uid}: ${m.mismatch}`)
+        .join("\n");
+      throw new Error(
+        `Drift detected between bundled exo__Layout ontology and starter-kit ` +
+          `source-of-truth (exocortex-starter-kit/exo/<uid>.md):\n${summary}\n\n` +
+          `Fix: either update the string literals in ExoLayoutOntologyBootstrapper.ts ` +
+          `to match starter-kit, OR revert the starter-kit change. Both must agree.`,
+      );
+    }
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/ontology/ExoLayoutOntologyBootstrapper.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/ontology/ExoLayoutOntologyBootstrapper.test.ts
@@ -1,0 +1,334 @@
+import {
+  EXO_LAYOUT_ONTOLOGY_FILES,
+  ExoLayoutOntologyBootstrapper,
+  type ExoLayoutOntologyBootstrapperVault,
+} from "../../../../src/infrastructure/ontology/ExoLayoutOntologyBootstrapper";
+
+interface FakeVault extends ExoLayoutOntologyBootstrapperVault {
+  files: Map<string, string>;
+  folders: Set<string>;
+  createdPaths: string[];
+  ensuredFolders: string[];
+  existingUids: Set<string>;
+}
+
+const UUID_BASENAME_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function makeVault(
+  existingPaths: Iterable<string> = [],
+  existingUids: Iterable<string> = [],
+): FakeVault {
+  const files = new Map<string, string>();
+  const folders = new Set<string>();
+  const createdPaths: string[] = [];
+  const ensuredFolders: string[] = [];
+  const uids = new Set<string>(existingUids);
+
+  for (const path of existingPaths) {
+    files.set(path, "existing-stub");
+    const basename = path.replace(/^.*\//, "").replace(/\.md$/, "");
+    if (UUID_BASENAME_RE.test(basename)) uids.add(basename);
+  }
+
+  return {
+    files,
+    folders,
+    createdPaths,
+    ensuredFolders,
+    existingUids: uids,
+    hasAssetWithUid(uid) {
+      return uids.has(uid);
+    },
+    fileExists(path) {
+      return files.has(path);
+    },
+    async createFile(path, content) {
+      if (files.has(path)) {
+        throw new Error(`duplicate create for ${path}`);
+      }
+      files.set(path, content);
+      createdPaths.push(path);
+    },
+    async ensureFolder(path) {
+      folders.add(path);
+      ensuredFolders.push(path);
+    },
+  };
+}
+
+const TARGET_FOLDER = "_exocortex-exo-layout-ontology";
+
+// 18 UIDs from starter-kit PR #87 (commit 84101d3, 2026-04-24).
+// 4 classes + 14 properties.
+const BUNDLED_UIDS = [
+  // 4 classes
+  "08d00289-a5c8-4df1-8885-40a00a014004", // exo__Layout
+  "6bca6f8d-2a2b-4f38-8e20-97727499009e", // exo__LayoutBlock
+  "2e868956-d81e-43fd-9817-1addde9cb311", // exo__BacklinksTableBlock
+  "fd039b3c-ed2b-41c2-a42e-bbfcdd074bfe", // exo__PropertiesBlock
+  // 4 Layout_* properties
+  "c062eb14-e21a-44f9-a490-6f9773e0a93d", // targetClass
+  "f39f69bb-24e4-4f21-aa4c-5fe6a69dd4e6", // priority
+  "d1d19227-937b-4761-89a6-e2f665716262", // blocks
+  "11db753b-df28-46e1-91eb-acea7ca2f9c8", // coexistsWithDefault
+  // 3 LayoutBlock_* properties
+  "a3df1733-a66d-40ab-8a71-acca4886609a", // title
+  "5f48b45b-fdc7-44ef-8846-f3ffd70665fc", // type
+  "5b52a2aa-f5ea-48bb-a1c5-728d59bb805f", // collapsed
+  // 7 BacklinksTableBlock_* properties
+  "07bc2f29-abde-43ed-9b7a-72b67114cf54", // rowClass
+  "76bb0bde-d692-41c4-88ab-7637bf0c7e54", // referencingProperty
+  "42c32853-c8e4-462d-b927-6d16d962aa3e", // columns
+  "05a5f768-298f-4561-aad5-31c8c326eece", // sortBy
+  "cb70ba11-6e07-4fbb-a38f-afd0c6ecff02", // sortOrder
+  "498a804d-e925-4cec-a392-1b1a6d4bd3d1", // limit
+  "3ef3ddca-560e-4b6c-9e1f-deb8a28f9438", // showArchived
+] as const;
+
+const EXO_ROOT_UID = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
+
+describe("ExoLayoutOntologyBootstrapper", () => {
+  describe("EXO_LAYOUT_ONTOLOGY_FILES static manifest", () => {
+    it("bundles exactly 18 ontology files (4 classes + 14 properties)", () => {
+      expect(EXO_LAYOUT_ONTOLOGY_FILES).toHaveLength(18);
+    });
+
+    it("covers all 18 canonical UUIDs", () => {
+      const uids = EXO_LAYOUT_ONTOLOGY_FILES.map((f) => f.uid).sort();
+      expect(uids).toEqual([...BUNDLED_UIDS].sort());
+    });
+
+    it("each file has a UUID basename and a non-empty markdown body", () => {
+      for (const file of EXO_LAYOUT_ONTOLOGY_FILES) {
+        expect(file.uid).toMatch(UUID_BASENAME_RE);
+        expect(file.filename).toBe(`${file.uid}.md`);
+        expect(file.content.length).toBeGreaterThan(0);
+        expect(file.content).toContain(`exo__Asset_uid: ${file.uid}`);
+      }
+    });
+
+    it("each file references the !exo ontology root via isDefinedBy", () => {
+      for (const file of EXO_LAYOUT_ONTOLOGY_FILES) {
+        expect(file.content).toContain(
+          `exo__Asset_isDefinedBy: "[[${EXO_ROOT_UID}]]"`,
+        );
+      }
+    });
+
+    it("class files use exo__Class (8619c4fc) instance", () => {
+      const classUids = new Set([
+        "08d00289-a5c8-4df1-8885-40a00a014004",
+        "6bca6f8d-2a2b-4f38-8e20-97727499009e",
+        "2e868956-d81e-43fd-9817-1addde9cb311",
+        "fd039b3c-ed2b-41c2-a42e-bbfcdd074bfe",
+      ]);
+      for (const file of EXO_LAYOUT_ONTOLOGY_FILES) {
+        if (!classUids.has(file.uid)) continue;
+        expect(file.content).toContain(
+          "exo__Instance_class:\n  - \"[[8619c4fc-64f1-4869-b17e-e34186cacca9]]\"",
+        );
+      }
+    });
+
+    it("subclass files carry rdfs__subClassOf to exo__LayoutBlock", () => {
+      const subclassUids = new Set([
+        "2e868956-d81e-43fd-9817-1addde9cb311", // BacklinksTableBlock
+        "fd039b3c-ed2b-41c2-a42e-bbfcdd074bfe", // PropertiesBlock
+      ]);
+      for (const file of EXO_LAYOUT_ONTOLOGY_FILES) {
+        if (!subclassUids.has(file.uid)) continue;
+        expect(file.content).toContain(
+          "rdfs__subClassOf: \"[[6bca6f8d-2a2b-4f38-8e20-97727499009e|exo__LayoutBlock]]\"",
+        );
+      }
+    });
+  });
+
+  describe("bootstrap() — empty vault", () => {
+    it("creates target folder + all 18 files when vault is empty", async () => {
+      const vault = makeVault();
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(18);
+      expect(result.skipped).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
+      expect(vault.ensuredFolders).toContain(TARGET_FOLDER);
+      expect(vault.createdPaths).toHaveLength(18);
+      for (const uid of BUNDLED_UIDS) {
+        expect(vault.files.has(`${TARGET_FOLDER}/${uid}.md`)).toBe(true);
+      }
+    });
+
+    it("written file content matches the bundled manifest verbatim", async () => {
+      const vault = makeVault();
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+
+      await bootstrapper.bootstrap();
+
+      for (const file of EXO_LAYOUT_ONTOLOGY_FILES) {
+        const stored = vault.files.get(`${TARGET_FOLDER}/${file.filename}`);
+        expect(stored).toBe(file.content);
+      }
+    });
+  });
+
+  describe("bootstrap() — idempotency", () => {
+    it("is a no-op when all 18 files already exist at target path", async () => {
+      const preExisting = BUNDLED_UIDS.map(
+        (uid) => `${TARGET_FOLDER}/${uid}.md`,
+      );
+      const vault = makeVault(preExisting);
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(0);
+      expect(result.skipped).toHaveLength(18);
+      expect(vault.createdPaths).toHaveLength(0);
+    });
+
+    it("second bootstrap call after first is a no-op (re-run safety)", async () => {
+      const vault = makeVault();
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+
+      const first = await bootstrapper.bootstrap();
+      expect(first.created).toHaveLength(18);
+
+      const second = await bootstrapper.bootstrap();
+      expect(second.created).toHaveLength(0);
+      expect(second.skipped).toHaveLength(18);
+      expect(vault.files.size).toBe(18);
+    });
+
+    it("is a no-op when the 18 UUIDs already exist in a legacy custom folder (e.g. starter-kit `exo/`)", async () => {
+      // Regression for RFC be70f741 Task 2 v15.121.0 defect (advisor warning=requirement):
+      // starter-kit install convention is `exo/<uid>.md`. UID-aware scan must
+      // detect these to avoid creating duplicate exo__Asset_uid in the default
+      // hidden folder.
+      const legacyPaths = BUNDLED_UIDS.map((uid) => `exo/${uid}.md`);
+      const vault = makeVault(legacyPaths);
+
+      expect(vault.hasAssetWithUid(BUNDLED_UIDS[0])).toBe(true);
+
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(0);
+      expect(result.skipped).toHaveLength(18);
+      expect(vault.createdPaths).toHaveLength(0);
+      expect(vault.ensuredFolders).toHaveLength(0);
+      for (const uid of BUNDLED_UIDS) {
+        expect(vault.files.has(`${TARGET_FOLDER}/${uid}.md`)).toBe(false);
+      }
+    });
+
+    it("creates only the missing subset when vault has partial install", async () => {
+      const preExisting = [
+        `${TARGET_FOLDER}/08d00289-a5c8-4df1-8885-40a00a014004.md`, // Layout class
+        `${TARGET_FOLDER}/6bca6f8d-2a2b-4f38-8e20-97727499009e.md`, // LayoutBlock class
+        `${TARGET_FOLDER}/c062eb14-e21a-44f9-a490-6f9773e0a93d.md`, // Layout_targetClass
+      ];
+      const vault = makeVault(preExisting);
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.skipped).toHaveLength(3);
+      expect(result.created).toHaveLength(15);
+      expect(vault.files.size).toBe(18);
+    });
+
+    it("is a no-op when UIDs exist in a non-default folder without matching path", async () => {
+      // User has manually copied exo-layout ontology to `03 Knowledge/exo/`.
+      // UID scan finds them, path check at the default folder doesn't — UID
+      // check must win and all 18 are skipped.
+      const customPaths = BUNDLED_UIDS.map(
+        (uid) => `03 Knowledge/exo/${uid}.md`,
+      );
+      const vault = makeVault(customPaths);
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(0);
+      expect(result.skipped).toHaveLength(18);
+    });
+  });
+
+  describe("bootstrap() — folder handling", () => {
+    it("ensures the target folder before any file write", async () => {
+      const vault = makeVault();
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+
+      const order: string[] = [];
+      const origEnsure = vault.ensureFolder;
+      vault.ensureFolder = async (path: string) => {
+        order.push(`folder:${path}`);
+        await origEnsure.call(vault, path);
+      };
+      const origCreate = vault.createFile;
+      vault.createFile = async (path: string, content: string) => {
+        order.push(`file:${path}`);
+        await origCreate.call(vault, path, content);
+      };
+
+      await bootstrapper.bootstrap();
+
+      expect(order[0]).toBe(`folder:${TARGET_FOLDER}`);
+      for (let i = 1; i < order.length; i++) {
+        expect(order[i]).toMatch(/^file:/);
+      }
+    });
+
+    it("does NOT call ensureFolder when all files are skipped (idempotent no-op)", async () => {
+      const preExisting = BUNDLED_UIDS.map(
+        (uid) => `exo/${uid}.md`,
+      );
+      const vault = makeVault(preExisting);
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+
+      await bootstrapper.bootstrap();
+
+      expect(vault.ensuredFolders).toHaveLength(0);
+    });
+
+    it("accepts a custom targetFolder option", async () => {
+      const vault = makeVault();
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault, {
+        targetFolder: "custom/exo-layout",
+      });
+
+      await bootstrapper.bootstrap();
+
+      expect(vault.ensuredFolders).toContain("custom/exo-layout");
+      for (const uid of BUNDLED_UIDS) {
+        expect(vault.files.has(`custom/exo-layout/${uid}.md`)).toBe(true);
+      }
+    });
+  });
+
+  describe("bootstrap() — error isolation", () => {
+    it("continues installing remaining files when a single create fails", async () => {
+      const vault = makeVault();
+      const bootstrapper = new ExoLayoutOntologyBootstrapper(vault);
+
+      const failingUid = BUNDLED_UIDS[0];
+      const failingPath = `${TARGET_FOLDER}/${failingUid}.md`;
+      const origCreate = vault.createFile;
+      vault.createFile = async (path: string, content: string) => {
+        if (path === failingPath) throw new Error("simulated write failure");
+        await origCreate.call(vault, path, content);
+      };
+
+      const result = await bootstrapper.bootstrap();
+
+      expect(result.created).toHaveLength(17);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].path).toBe(failingPath);
+      expect(result.errors[0].error.message).toBe("simulated write failure");
+    });
+  });
+});


### PR DESCRIPTION
Closes Task 3 (`07ceb846-53f0-4646-b542-10b36e85ff31`) of RFC exo__Layout — the
final Phase 4 (bootstrap + migration helper) that completes the RFC.

## Summary

- **Part A** — Plugin auto-installs the 18 `exo__Layout` ontology assets (4
  classes + 14 properties) into a hidden `_exocortex-exo-layout-ontology/`
  folder on first load. Idempotent and UID-aware (mirrors v15.121.1
  `UiOntologyBootstrapper` pattern).
- **Part B** — CLI `migrate-relcolset-to-exolayout` generates a starting-point
  `exo__Layout` + `exo__BacklinksTableBlock` pair from each existing
  `ui__RelationColumnSet` config. Dry-run by default; `--apply` to write.
- **Part C** — `EXO_LAYOUT.md` gains "Bootstrap" + "Migrating from
  ui__RelationColumnSet" sections; `RELATION_COLUMN_SET.md` links back to
  exo__Layout for users wanting full body control.

## Scope note on round-trip equivalence (AC #4)

Round-trip is **YAML-level field-preservation**, not **DOM-level
render-identity**. The two systems are semantically different:

- `ui__RelationColumnSet` is **additive** (extends hardcoded Name +
  InstanceClass columns of the Asset Relations table).
- `exo__BacklinksTableBlock` is **replacing** (renders only the declared
  columns).

Auto-generating a DOM-identical migration would require prepending Name +
InstanceClass, which defeats the purpose of `exo__Layout` (full control).
The migration instead produces a starting-point pair with:

- Generated block carrying `exo__Layout_coexistsWithDefault: true` (legacy
  table still renders below migrated block).
- `exo__Layout.targetClass` placeholder requiring user review (page-class
  vs row-class are different concepts and the CLI cannot infer the former
  from the latter).
- Runtime warnings per pair explaining both gaps.

This follows the RFC guidance «no auto-migration in MVP; user rewrites».

## Determinism fix (advisor-caught pre-PR)

Initial implementation used `crypto.randomUUID()` → two `--apply` runs
would duplicate. Switched to **SHA-256-derived UUIDs** (128 bits, v4-shape,
archgate `no-weak-hash` compliant). Re-running produces identical files.
Regression test `default UID generator is deterministic across
independent runs (idempotent --apply)` guards against regression.

## Tests

- **Plugin unit (3 suites, 34 tests):** empty vault / idempotent / partial
  install / custom folder / error-isolation; starter-kit drift-guard.
- **CLI unit + integration (2 suites, 27 tests):** frontmatter predicate,
  extractor, transform, determinism, UUID shape, round-trip YAML; tmp
  vault scan → transform → apply → reread.
- Full plugin suite (`npx jest packages/obsidian-plugin/tests/unit`): 240
  suites, 4862 tests, all green.
- `npm run check:types` green. `npm run lint` green. `npm run archgate`
  (pre-commit) green. Plugin esbuild production build green.

## Test plan

- [x] CI: `archgate · detect-changes · e2e-shard (1..6) · lint · test-bdd ·
  test-component · test-coverage · typecheck` — 13 required checks
- [x] Unit tests for both plugin ontology bootstrap and CLI migration
- [ ] Post-merge verification: fresh vault → plugin install → first
  `exo__Layout` asset renders (manual live-test after auto-release)
- [ ] CLI release: `@kitelev/exocortex-cli` auto-publishes via
  `prepublishOnly` which rebuilds `dist/` from source

## References

- RFC source: `inbox/6628d78a-78a9-473c-ace3-e9b6d28750d1` §Phase 4
- Starter-kit ontology drift-guard source: PR
  [kitelev/exocortex-starter-kit#87](https://github.com/kitelev/exocortex-starter-kit/pull/87)
  (commit 84101d3)
- Idempotency pattern precedent: PR #2945 + #2946 (v15.121.1 UI ontology)
- Project: `kitelev/9541965c-c5dc-48ff-94b2-98aad3d62b2e` — RFC exo__Layout
  (all 4 phases closed after this PR merges)