### PR TITLE
fix(commands): universal targetClass=exo__Asset bindings match subclass instances (#2958)

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -38,8 +38,62 @@ const MAX_TRANSITIVE_DEPTH = 10;
 @injectable()
 export class CommandResolver {
   private readonly cache = new Map<string, ResolvedCommand[]>();
+  private readonly multiCache = new Map<string, ResolvedCommand[]>();
 
   constructor(private readonly tripleStore: ITripleStore) {}
+
+  /**
+   * Resolve commands for an asset declaring multiple classes (RFC-009 §5.3, Issue #2958).
+   *
+   * Iterates each class in `assetClasses`, merges results, and deduplicates by `binding.id`
+   * (NOT `commandRef` — the same command may have multiple bindings, each must surface once).
+   *
+   * Caller-side multi-class dispatch enables universal bindings (`targetClass: exo__Asset`)
+   * to match subclass instances when the caller appends `exo__Asset` to the classes array.
+   *
+   * @param subjectIRI - IRI of the target asset (subject)
+   * @param assetClasses - All declared classes of the asset (typically `exo__Instance_class`
+   *                      array + universal `exo__Asset` superclass appended by caller)
+   * @param prototypeIRI - Optional prototype IRI for prototype-scoped bindings
+   * @returns Resolved commands sorted by binding priority then order; deduped by binding.id
+   */
+  async resolveForAssetMulti(
+    subjectIRI: string,
+    assetClasses: string[],
+    prototypeIRI?: string,
+  ): Promise<ResolvedCommand[]> {
+    if (assetClasses.length === 0) return [];
+
+    // Cache key uses sorted classes — stable across permutations
+    const sortedClasses = [...assetClasses].sort().join(",");
+    const cacheKey = `${subjectIRI}::${sortedClasses}::${prototypeIRI ?? ""}`;
+    const cached = this.multiCache.get(cacheKey);
+    if (cached) return cached;
+
+    const seen = new Set<string>();
+    const merged: ResolvedCommand[] = [];
+
+    for (const cls of assetClasses) {
+      const bindings = await this.resolveForAsset(subjectIRI, cls, prototypeIRI);
+      for (const rc of bindings) {
+        if (!seen.has(rc.binding.id)) {
+          seen.add(rc.binding.id);
+          merged.push(rc);
+        }
+      }
+    }
+
+    // Re-sort across merged classes: priority (asset > prototype > class) then order
+    merged.sort((a, b) => {
+      const priorityA = this.getBindingPriority(a.binding);
+      const priorityB = this.getBindingPriority(b.binding);
+      if (priorityA !== priorityB) return priorityA - priorityB;
+      return (a.binding.order ?? 100) - (b.binding.order ?? 100);
+    });
+
+    this.multiCache.set(cacheKey, merged);
+    return merged;
+  }
 
   /**
    * Resolve all available commands for a specific asset.
@@ -171,6 +225,7 @@ export class CommandResolver {
    */
   invalidateCache(): void {
     this.cache.clear();
+    this.multiCache.clear();
   }
 
   /**

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -725,6 +725,124 @@ describe("CommandResolver", () => {
     });
   });
 
+  describe("resolveForAssetMulti (Issue #2958 — Universal exo__Asset bindings)", () => {
+    it("should match binding with targetClass=exo__Asset when exo__Asset is in classes array", async () => {
+      // AC1: Universal binding visible on subclass instance via multi-class dispatch
+      await addGroundingAsset(store, { uid: "gnd-univ", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, { uid: "cmd-clean", label: "Clean Properties", groundingRef: "gnd-univ" });
+      await addBindingAsset(store, { uid: "bind-univ", label: "Universal", commandRef: "cmd-clean", targetClass: "exo__Asset" });
+
+      const resolved = await resolver.resolveForAssetMulti("asset-1", ["ems__Task", "exo__Asset"]);
+
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0].command.name).toBe("Clean Properties");
+      expect(resolved[0].binding.targetClass).toBe("exo__Asset");
+    });
+
+    it("should merge bindings from multiple classes", async () => {
+      // AC2: Multi-class asset gets bindings from each declared class
+      await addGroundingAsset(store, { uid: "gnd-1", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, { uid: "cmd-task", label: "Task cmd", groundingRef: "gnd-1" });
+      await addCommandAsset(store, { uid: "cmd-univ", label: "Universal cmd", groundingRef: "gnd-1" });
+
+      await addBindingAsset(store, { uid: "bind-task", label: "BT", commandRef: "cmd-task", targetClass: "ems__Task" });
+      await addBindingAsset(store, { uid: "bind-univ", label: "BU", commandRef: "cmd-univ", targetClass: "exo__Asset" });
+
+      const resolved = await resolver.resolveForAssetMulti("asset-1", ["ems__Task", "exo__Asset"]);
+
+      expect(resolved).toHaveLength(2);
+      const names = resolved.map((rc) => rc.command.name).sort();
+      expect(names).toEqual(["Task cmd", "Universal cmd"]);
+    });
+
+    it("should deduplicate by binding.id when same binding matches multiple classes", async () => {
+      // AC3: dedup by binding.id (NOT commandRef)
+      await addGroundingAsset(store, { uid: "gnd-1", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, { uid: "cmd-shared", label: "Shared", groundingRef: "gnd-1" });
+
+      // Two SEPARATE bindings to the same command — both should appear (dedupe by binding.id, not commandRef)
+      await addBindingAsset(store, { uid: "bind-task", label: "BT", commandRef: "cmd-shared", targetClass: "ems__Task" });
+      await addBindingAsset(store, { uid: "bind-univ", label: "BU", commandRef: "cmd-shared", targetClass: "exo__Asset" });
+
+      const resolved = await resolver.resolveForAssetMulti("asset-1", ["ems__Task", "exo__Asset"]);
+
+      // Both bindings appear because they have different binding.id
+      expect(resolved).toHaveLength(2);
+      const bindingIds = resolved.map((rc) => rc.binding.id).sort();
+      expect(bindingIds).toEqual(["bind-task", "bind-univ"]);
+    });
+
+    it("should not duplicate when same binding object is matched twice via different classes", async () => {
+      // If somehow the same binding gets returned for two classes, dedup by binding.id keeps it once
+      await addGroundingAsset(store, { uid: "gnd-1", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, { uid: "cmd-1", label: "C1", groundingRef: "gnd-1" });
+      // Single binding with targetClass=exo__Asset; both array entries trigger same binding
+      await addBindingAsset(store, { uid: "bind-1", label: "B1", commandRef: "cmd-1", targetClass: "exo__Asset" });
+
+      const resolved = await resolver.resolveForAssetMulti("asset-1", ["exo__Asset", "exo__Asset"]);
+
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0].binding.id).toBe("bind-1");
+    });
+
+    it("should return empty when classes array is empty", async () => {
+      await addGroundingAsset(store, { uid: "gnd-1", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, { uid: "cmd-1", label: "C1", groundingRef: "gnd-1" });
+      await addBindingAsset(store, { uid: "bind-1", label: "B1", commandRef: "cmd-1", targetClass: "ems__Task" });
+
+      const resolved = await resolver.resolveForAssetMulti("asset-1", []);
+
+      expect(resolved).toHaveLength(0);
+    });
+
+    it("should produce stable cache key for any permutation of class array", async () => {
+      // Cache key sorts classes — same key for ['A','B'] and ['B','A']
+      await addGroundingAsset(store, { uid: "gnd-1", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, { uid: "cmd-1", label: "C1", groundingRef: "gnd-1" });
+      await addBindingAsset(store, { uid: "bind-1", label: "B1", commandRef: "cmd-1", targetClass: "exo__Asset" });
+
+      const matchSpy = jest.spyOn(store, "match");
+
+      const first = await resolver.resolveForAssetMulti("asset-1", ["ems__Task", "exo__Asset"]);
+      const callsAfterFirst = matchSpy.mock.calls.length;
+
+      const second = await resolver.resolveForAssetMulti("asset-1", ["exo__Asset", "ems__Task"]);
+      const callsAfterSecond = matchSpy.mock.calls.length;
+
+      // Second call hits cache — no new match() calls
+      expect(callsAfterSecond).toBe(callsAfterFirst);
+      expect(second).toEqual(first);
+    });
+
+    it("should pass prototypeIRI through to inner resolution for each class", async () => {
+      await addGroundingAsset(store, { uid: "gnd-1", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, { uid: "cmd-proto", label: "Proto cmd", groundingRef: "gnd-1" });
+      await addBindingAsset(store, { uid: "bind-proto", label: "BP", commandRef: "cmd-proto", targetPrototype: "proto-1" });
+
+      const resolved = await resolver.resolveForAssetMulti("asset-1", ["ems__Task", "exo__Asset"], "proto-1");
+
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0].binding.targetPrototype).toBe("proto-1");
+    });
+
+    it("should sort by binding priority across all classes (asset > prototype > class)", async () => {
+      await addGroundingAsset(store, { uid: "gnd-1", label: "G", type: "property_delete", targetProperty: "p" });
+      await addCommandAsset(store, { uid: "cmd-class", label: "Class cmd", groundingRef: "gnd-1" });
+      await addCommandAsset(store, { uid: "cmd-univ", label: "Univ cmd", groundingRef: "gnd-1" });
+      await addCommandAsset(store, { uid: "cmd-asset", label: "Asset cmd", groundingRef: "gnd-1" });
+
+      await addBindingAsset(store, { uid: "bind-class", label: "BC", commandRef: "cmd-class", targetClass: "ems__Task" });
+      await addBindingAsset(store, { uid: "bind-univ", label: "BU", commandRef: "cmd-univ", targetClass: "exo__Asset" });
+      await addBindingAsset(store, { uid: "bind-asset", label: "BA", commandRef: "cmd-asset", targetAsset: "asset-1" });
+
+      const resolved = await resolver.resolveForAssetMulti("asset-1", ["ems__Task", "exo__Asset"]);
+
+      expect(resolved).toHaveLength(3);
+      // targetAsset (priority 0) first, then targetClass entries (priority 2)
+      expect(resolved[0].command.name).toBe("Asset cmd");
+    });
+  });
+
   describe("cache", () => {
     it("should return cached results on second call", async () => {
       await addGroundingAsset(store, { uid: "gnd-1", label: "G", type: "property_delete", targetProperty: "p" });

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -205,16 +205,16 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     // making all preconditions return false and no buttons to render.
     const subjectIRI = `obsidian://vault/${encodeURI(file.path)}`;
 
-    const assetClass = this.extractAssetClass(metadata);
-    if (!assetClass) return null;
+    const assetClasses = this.extractAssetClasses(metadata);
+    if (assetClasses.length === 0) return null;
 
     const prototypeIRI = this.extractPrototypeIRI(metadata);
 
     let resolved: ResolvedCommand[];
     try {
-      resolved = await this.config.commandResolver.resolveForAsset(
+      resolved = await this.config.commandResolver.resolveForAssetMulti(
         subjectIRI,
-        assetClass,
+        assetClasses,
         prototypeIRI,
       );
     } catch (error) {
@@ -352,20 +352,40 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     );
   }
 
-  private extractAssetClass(
+  /**
+   * Extract all declared classes from `exo__Instance_class`, plus the universal
+   * `exo__Asset` superclass appended last so that bindings with `targetClass: exo__Asset`
+   * match every asset in the vault (RFC-009 semantics, Issue #2958).
+   *
+   * Returns an empty array when no `exo__Instance_class` is declared — the builder
+   * treats this as "no asset class context" and skips command resolution. This
+   * preserves the pre-fix behavior of returning no buttons for unclassed files.
+   *
+   * If `exo__Asset` is already declared explicitly, it is not duplicated.
+   */
+  private extractAssetClasses(
     metadata: Record<string, unknown>,
-  ): string | undefined {
+  ): string[] {
     const raw = metadata["exo__Instance_class"];
+    const classes: string[] = [];
+
+    const collect = (value: unknown): void => {
+      if (typeof value !== "string") return;
+      const cleaned = value.replace(/["'[\]]/g, "").trim();
+      if (cleaned && !classes.includes(cleaned)) classes.push(cleaned);
+    };
+
     if (typeof raw === "string") {
-      return raw.replace(/["'[\]]/g, "").trim();
+      collect(raw);
+    } else if (Array.isArray(raw)) {
+      for (const item of raw) collect(item);
     }
-    if (Array.isArray(raw) && raw.length > 0) {
-      const first = raw[0];
-      if (typeof first === "string") {
-        return first.replace(/["'[\]]/g, "").trim();
-      }
-    }
-    return undefined;
+
+    if (classes.length === 0) return [];
+
+    if (!classes.includes("exo__Asset")) classes.push("exo__Asset");
+
+    return classes;
   }
 
   private extractPrototypeIRI(

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
@@ -29,7 +29,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue(null);
-    ctx.mockCommandResolver.resolveForAsset.mockResolvedValue([]);
+    ctx.mockCommandResolver.resolveForAssetMulti.mockResolvedValue([]);
 
     const groups = await ctx.builder.build(mockFile);
 
@@ -54,7 +54,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
-    ctx.mockCommandResolver.resolveForAsset.mockResolvedValue([
+    ctx.mockCommandResolver.resolveForAssetMulti.mockResolvedValue([
       {
         command: {
           id: "cmd-1",
@@ -99,7 +99,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
-    ctx.mockCommandResolver.resolveForAsset.mockResolvedValue([
+    ctx.mockCommandResolver.resolveForAssetMulti.mockResolvedValue([
       {
         command: {
           id: "cmd-visible",
@@ -174,7 +174,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
-    ctx.mockCommandResolver.resolveForAsset.mockResolvedValue([
+    ctx.mockCommandResolver.resolveForAssetMulti.mockResolvedValue([
       {
         command: {
           id: "cmd-creation",
@@ -244,7 +244,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
-    ctx.mockCommandResolver.resolveForAsset.mockRejectedValue(
+    ctx.mockCommandResolver.resolveForAssetMulti.mockRejectedValue(
       new Error("Resolver failed"),
     );
 
@@ -272,7 +272,7 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
-    ctx.mockCommandResolver.resolveForAsset.mockResolvedValue([
+    ctx.mockCommandResolver.resolveForAssetMulti.mockResolvedValue([
       {
         command: {
           id: "cmd-1",

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.dynamicCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.dynamicCommands.test.ts
@@ -59,7 +59,8 @@ describe("ButtonGroupsBuilder - dynamic commands (RFC-009)", () => {
 
   it("should include dynamic-commands builder when RFC-009 services are provided", async () => {
     const mockCommandResolver = {
-      resolveForAsset: jest.fn().mockResolvedValue([
+      resolveForAsset: jest.fn().mockResolvedValue([]),
+      resolveForAssetMulti: jest.fn().mockResolvedValue([
         {
           command: {
             id: "test-cmd",

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.fixtures.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.fixtures.ts
@@ -48,6 +48,7 @@ export function setupButtonGroupsBuilderTest(): ButtonGroupsBuilderTestContext {
 
   const mockCommandResolver = {
     resolveForAsset: jest.fn().mockResolvedValue([]),
+    resolveForAssetMulti: jest.fn().mockResolvedValue([]),
   } as any;
 
   const mockPreconditionEvaluator = {

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.handlers.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.handlers.test.ts
@@ -27,7 +27,7 @@ describe("ButtonGroupsBuilder - onClick handlers (dynamic commands)", () => {
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
-    ctx.mockCommandResolver.resolveForAsset.mockResolvedValue([
+    ctx.mockCommandResolver.resolveForAssetMulti.mockResolvedValue([
       {
         command: {
           id: "cmd-1",
@@ -75,7 +75,7 @@ describe("ButtonGroupsBuilder - onClick handlers (dynamic commands)", () => {
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
-    ctx.mockCommandResolver.resolveForAsset.mockResolvedValue([
+    ctx.mockCommandResolver.resolveForAssetMulti.mockResolvedValue([
       {
         command: {
           id: "cmd-1",
@@ -118,7 +118,7 @@ describe("ButtonGroupsBuilder - onClick handlers (dynamic commands)", () => {
     ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
     ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
     ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue("Tasks");
-    ctx.mockCommandResolver.resolveForAsset.mockResolvedValue([
+    ctx.mockCommandResolver.resolveForAssetMulti.mockResolvedValue([
       {
         command: {
           id: "cmd-1",

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -2,11 +2,13 @@ import { DynamicCommandButtonGroupBuilder } from "../../../../src/presentation/b
 import { GroundingType } from "exocortex";
 
 const mockResolveForAsset = jest.fn();
+const mockResolveForAssetMulti = jest.fn();
 const mockEvaluate = jest.fn();
 const mockExecute = jest.fn();
 
 const mockCommandResolver = {
   resolveForAsset: mockResolveForAsset,
+  resolveForAssetMulti: mockResolveForAssetMulti,
   loadCommand: jest.fn(),
   findBindings: jest.fn(),
   invalidateCache: jest.fn(),
@@ -145,14 +147,15 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
   describe("build", () => {
     it("should use file path as fallback when no Asset UID in metadata", async () => {
-      mockResolveForAsset.mockResolvedValue([]);
+      mockResolveForAssetMulti.mockResolvedValue([]);
       const context = createContext({ exo__Asset_uid: undefined });
       const result = await builder.build(context);
       expect(result).toEqual([]);
       // subjectIRI is always constructed from file.path as obsidian://vault/ IRI
-      expect(mockResolveForAsset).toHaveBeenCalledWith(
+      // Issue #2958: classes array always includes universal "exo__Asset" superclass
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
         "obsidian://vault/test/file.md",
-        "ems__Task",
+        ["ems__Task", "exo__Asset"],
         undefined,
       );
     });
@@ -164,14 +167,14 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should return empty array when no commands resolved", async () => {
-      mockResolveForAsset.mockResolvedValue([]);
+      mockResolveForAssetMulti.mockResolvedValue([]);
       const context = createContext();
       const result = await builder.build(context);
       expect(result).toEqual([]);
     });
 
     it("should return empty array when CommandResolver throws", async () => {
-      mockResolveForAsset.mockRejectedValue(new Error("resolver error"));
+      mockResolveForAssetMulti.mockRejectedValue(new Error("resolver error"));
       const context = createContext();
       const result = await builder.build(context);
       expect(result).toEqual([]);
@@ -179,7 +182,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
     it("should return buttons for commands with passing preconditions", async () => {
       const rc = createResolvedCommand({ name: "Do something" });
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
       const context = createContext();
@@ -194,7 +197,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     it("should filter out commands with failing preconditions", async () => {
       const rc1 = createResolvedCommand({ id: "cmd-pass", name: "Passing" });
       const rc2 = createResolvedCommand({ id: "cmd-fail", name: "Failing" });
-      mockResolveForAsset.mockResolvedValue([rc1, rc2]);
+      mockResolveForAssetMulti.mockResolvedValue([rc1, rc2]);
       mockEvaluate.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
       const context = createContext();
@@ -208,7 +211,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       const rc1 = createResolvedCommand({ id: "cmd-1", name: "Cmd 1" });
       const rc2 = createResolvedCommand({ id: "cmd-2", name: "Cmd 2" });
       const rc3 = createResolvedCommand({ id: "cmd-3", name: "Cmd 3" });
-      mockResolveForAsset.mockResolvedValue([rc1, rc2, rc3]);
+      mockResolveForAssetMulti.mockResolvedValue([rc1, rc2, rc3]);
       mockEvaluate.mockResolvedValue(true);
 
       const context = createContext();
@@ -219,7 +222,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
     it("should handle precondition evaluation errors gracefully", async () => {
       const rc = createResolvedCommand();
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockRejectedValue(new Error("eval error"));
 
       const context = createContext();
@@ -228,7 +231,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should pass correct arguments to CommandResolver", async () => {
-      mockResolveForAsset.mockResolvedValue([]);
+      mockResolveForAssetMulti.mockResolvedValue([]);
       const context = createContext({
         exo__Asset_uid: "obsidian://vault/test/file.md",
         exo__Instance_class: ["[[ems__Task]]"],
@@ -236,37 +239,65 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       });
       await builder.build(context);
 
-      expect(mockResolveForAsset).toHaveBeenCalledWith(
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
         "obsidian://vault/test/file.md",
-        "ems__Task",
+        ["ems__Task", "exo__Asset"],
         "proto-uid",
       );
     });
 
-    it("should handle array instance class", async () => {
-      mockResolveForAsset.mockResolvedValue([]);
+    it("should handle array instance class — pass all classes plus universal exo__Asset (Issue #2958)", async () => {
+      mockResolveForAssetMulti.mockResolvedValue([]);
       const context = createContext({
         exo__Instance_class: ["ems__Task", "ems__Meeting"],
       });
       await builder.build(context);
 
-      expect(mockResolveForAsset).toHaveBeenCalledWith(
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
         "obsidian://vault/test/file.md",
-        "ems__Task",
+        ["ems__Task", "ems__Meeting", "exo__Asset"],
         undefined,
       );
     });
 
     it("should normalize wikilink brackets from instance class", async () => {
-      mockResolveForAsset.mockResolvedValue([]);
+      mockResolveForAssetMulti.mockResolvedValue([]);
       const context = createContext({
         exo__Instance_class: ["[[ems__Task]]"],
       });
       await builder.build(context);
 
-      expect(mockResolveForAsset).toHaveBeenCalledWith(
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
         "obsidian://vault/test/file.md",
-        "ems__Task",
+        ["ems__Task", "exo__Asset"],
+        undefined,
+      );
+    });
+
+    it("should not duplicate exo__Asset when already declared in instance class (Issue #2958)", async () => {
+      mockResolveForAssetMulti.mockResolvedValue([]);
+      const context = createContext({
+        exo__Instance_class: ["[[exo__Asset]]"],
+      });
+      await builder.build(context);
+
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+        "obsidian://vault/test/file.md",
+        ["exo__Asset"],
+        undefined,
+      );
+    });
+
+    it("should preserve order — declared classes first, exo__Asset appended (Issue #2958)", async () => {
+      mockResolveForAssetMulti.mockResolvedValue([]);
+      const context = createContext({
+        exo__Instance_class: ["[[ems__Project]]", "[[custom__Class]]"],
+      });
+      await builder.build(context);
+
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+        "obsidian://vault/test/file.md",
+        ["ems__Project", "custom__Class", "exo__Asset"],
         undefined,
       );
     });
@@ -277,7 +308,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         { name: "Create action" },
         { group: "creation" },
       );
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
       const context = createContext();
@@ -291,7 +322,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         { name: "Rebuild index" },
         { group: "maintenance" },
       );
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
       const context = createContext();
@@ -305,7 +336,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         { name: "Default action" },
         { group: undefined },
       );
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
       const context = createContext();
@@ -319,7 +350,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         { name: "Future action" },
         { group: "future-uncategorized" },
       );
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
       const context = createContext();
@@ -332,7 +363,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
   describe("button onClick", () => {
     it("should execute grounding on click", async () => {
       const rc = createResolvedCommand({ name: "Execute me" });
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
       mockExecute.mockResolvedValue({ success: true } as ExecutionResult);
 
@@ -354,7 +385,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         name: "Success cmd",
         successMessage: "Done!",
       });
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
       mockExecute.mockResolvedValue({ success: true } as ExecutionResult);
 
@@ -368,7 +399,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
     it("should refresh layout after successful execution", async () => {
       const rc = createResolvedCommand();
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
       mockExecute.mockResolvedValue({ success: true } as ExecutionResult);
 
@@ -382,7 +413,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
     it("should show error notice when execution fails", async () => {
       const rc = createResolvedCommand();
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
       mockExecute.mockResolvedValue({
         success: false,
@@ -404,7 +435,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         name: "Dangerous",
         confirmMessage: "Are you sure?",
       });
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
       const originalConfirm = window.confirm;
@@ -426,7 +457,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         name: "Dangerous",
         confirmMessage: "Are you sure?",
       });
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
       const originalConfirm = window.confirm;
@@ -447,7 +478,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         name: "No message",
         successMessage: undefined,
       });
-      mockResolveForAsset.mockResolvedValue([rc]);
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
       mockExecute.mockResolvedValue({ success: true } as ExecutionResult);
 
@@ -465,7 +496,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       const rc1 = createResolvedCommand({ id: "c1", name: "Cmd A" });
       const rc2 = createResolvedCommand({ id: "c2", name: "Cmd B" });
       const rc3 = createResolvedCommand({ id: "c3", name: "Cmd C" });
-      mockResolveForAsset.mockResolvedValue([rc1, rc2, rc3]);
+      mockResolveForAssetMulti.mockResolvedValue([rc1, rc2, rc3]);
       mockEvaluate.mockResolvedValue(true);
 
       const context = createContext();
@@ -484,7 +515,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         { id: "c2", name: "Second" },
         { order: 2 },
       );
-      mockResolveForAsset.mockResolvedValue([rc1, rc2]);
+      mockResolveForAssetMulti.mockResolvedValue([rc1, rc2]);
       mockEvaluate.mockResolvedValue(true);
 
       const context = createContext();
@@ -524,7 +555,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
           category: "criticality",
         }),
       ];
-      mockResolveForAsset.mockResolvedValue(commands);
+      mockResolveForAssetMulti.mockResolvedValue(commands);
       mockEvaluate.mockResolvedValue(true);
 
       const result = await builder.buildCategoryGroups(createContext());
@@ -546,7 +577,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should mark maintenance group collapsedByDefault", async () => {
-      mockResolveForAsset.mockResolvedValue([
+      mockResolveForAssetMulti.mockResolvedValue([
         createResolvedCommand({
           id: "c1",
           name: "Create Task",
@@ -571,7 +602,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should omit categories that have zero visible commands", async () => {
-      mockResolveForAsset.mockResolvedValue([
+      mockResolveForAssetMulti.mockResolvedValue([
         createResolvedCommand({
           id: "c1",
           name: "Create Task",
@@ -597,7 +628,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should drop categories where preconditions filter out every command", async () => {
-      mockResolveForAsset.mockResolvedValue([
+      mockResolveForAssetMulti.mockResolvedValue([
         createResolvedCommand({
           id: "c1",
           name: "Create Task",
@@ -617,7 +648,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should route commands without category into Other group at the end", async () => {
-      mockResolveForAsset.mockResolvedValue([
+      mockResolveForAssetMulti.mockResolvedValue([
         createResolvedCommand({
           id: "c1",
           name: "Create Task",
@@ -638,13 +669,13 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should return [] when no commands resolved", async () => {
-      mockResolveForAsset.mockResolvedValue([]);
+      mockResolveForAssetMulti.mockResolvedValue([]);
       const result = await builder.buildCategoryGroups(createContext());
       expect(result).toEqual([]);
     });
 
     it("should return [] when resolver throws", async () => {
-      mockResolveForAsset.mockRejectedValue(new Error("boom"));
+      mockResolveForAssetMulti.mockRejectedValue(new Error("boom"));
       const result = await builder.buildCategoryGroups(createContext());
       expect(result).toEqual([]);
     });


### PR DESCRIPTION
## Summary

Universal `exocmd__CommandBinding` with `targetClass: exo__Asset` previously did not surface on `ems__Task`/`ems__Project`/`ems__Area` pages because the caller-side `extractAssetClass` returned only the first declared class and `bindingMatches` did literal-string comparison without hierarchy walking.

**Fix (Option A — caller-side multi-class dispatch):**

- `DynamicCommandButtonGroupBuilder.extractAssetClasses(metadata): string[]` replaces `extractAssetClass`. Returns the full `exo__Instance_class` array with `exo__Asset` appended as the universal superclass when not already present.
- `CommandResolver.resolveForAssetMulti(iri, classes[], prototypeIRI?)` — iterates each class, merges results, dedupes by `binding.id` (NOT `commandRef`). Cache key uses sorted classes for permutation stability. Re-sorts merged results by binding priority (asset > prototype > class) then order.
- `invalidateCache()` now clears both single-class and multi-class caches.

Net effect: 6 universal bindings (Clean Properties, Rename to UID, Fix Missing Label, Repair Folder, Copy Label to Aliases, Archive) now appear on every asset that declares any subclass of `exo__Asset`.

## Acceptance Criteria

- [x] Given `ems__Task` with `exo__Instance_class: [[ems__Task]]` AND binding with `targetClass: exo__Asset`, binding is in result
- [x] `ems__Project` / `ems__Area` / `ems__Meeting` / `ztlk__PermanentNote` instances — same universal binding visible
- [x] Asset with multiple classes `[ems__Task, custom__Class]` — bindings deduped by `binding.id`
- [x] Unit tests: `resolveForAssetMulti` covers multi-class, dedup, cache stability, prototypeIRI passthrough, priority sort
- [x] Performance: O(N bindings) × O(M classes per asset)
- [ ] **Empirical** in vault-2025 task `d18fbf07-…` — delegated to user (auto-release post-merge)

## Test plan

- [x] `CommandResolver.test.ts` — 48/48 pass (8 new for `resolveForAssetMulti`)
- [x] `DynamicCommandButtonGroupBuilder.test.ts` — 35/35 pass (3 new for class-array-with-universal)
- [x] `ButtonGroupsBuilder.{build,dynamicCommands,handlers}.test.ts` — 13/13 pass after mock migration
- [x] `npm run check:types` — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings unchanged)

Closes #2958