### PR TITLE
fix(rdf): class-named wikilink → namespace IRI normalization (#2959)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,10 +447,12 @@ jobs:
         # Additions:
         # - RFC be70f741 Phase 2: application/services/RelationColumnSetResolver(.property)?.test.ts
         #   + performance/RelationColumnSetResolverPerformance.test.ts (p95 <1ms gate).
+        # - Issue #2959: services/NoteToRDFConverter.issue-2959.test.ts (class-named
+        #   wikilink → namespace IRI normalization regression suite).
         run: |
           node ./node_modules/jest/bin/jest.js \
             --config packages/exocortex/jest.config.js \
-            --testPathPatterns='(services/(GroundingExecutor|AssetConversionService)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test)\.ts' \
+            --testPathPatterns='(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test)\.ts' \
             --forceExit
 
   test-coverage:

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -682,6 +682,25 @@ export class NoteToRDFConverter {
             return [fileIRI, uuidLiteral];
           }
 
+          // Issue #2959: When a class-named wikilink resolves to its class
+          // definition file (e.g. `ems__Effort_status: "[[ems__EffortStatusDone]]"`
+          // → `ems/ems__EffortStatusDone.md`), emit the namespace class IRI
+          // (`<https://exocortex.my/ontology/ems#EffortStatusDone>`) instead of
+          // the file IRI. SPARQL ASK preconditions of the form
+          //   ASK { ?s ems:Effort_status <ems:EffortStatusDone> }
+          // require the canonical class IRI to match. Without this, the
+          // "Archive Completed" command's "Is in Done status" precondition
+          // returned `false` on tasks that were actually Done.
+          //
+          // This mirrors the Issue #2782 fix for UUID-form wikilinks but
+          // applies when the wikilink is itself a class-prefixed name
+          // (`ems__*` / `exo__*` / etc.) and the resolved file's basename
+          // is a class reference.
+          const basenameClassIRI = this.expandClassValue(targetFile.basename);
+          if (basenameClassIRI) {
+            return [basenameClassIRI];
+          }
+
           return [fileIRI];
         }
         // If target file not found but wikilink is a class reference,

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.issue-2959.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.issue-2959.test.ts
@@ -1,0 +1,226 @@
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import { IVaultAdapter, IFile, IFrontmatter } from "../../../src/interfaces/IVaultAdapter";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+/**
+ * Regression suite for Issue #2959 — exocmd__Precondition "Is in Done status"
+ * returned `false` on tasks with `ems__Effort_status: "[[ems__EffortStatusDone]]"`.
+ *
+ * Root cause (H2): when a class-named wikilink ([[ems__EffortStatusDone]])
+ * resolved to its class-definition file (`ems/ems__EffortStatusDone.md`),
+ * `valueToRDFObject` emitted the file IRI (`obsidian://vault/...`) instead
+ * of the namespace class IRI (`<https://exocortex.my/ontology/ems#EffortStatusDone>`).
+ *
+ * SPARQL ASK preconditions like
+ *   ASK { ?s ems:Effort_status <ems:EffortStatusDone> }
+ * therefore returned false on tasks that were actually Done — the
+ * "Archive Completed" command stayed hidden.
+ *
+ * The fix mirrors Issue #2782 (UUID wikilink class normalization) and
+ * extends it to class-named wikilinks: when the resolved target file's
+ * basename expands to a class IRI (any namespace prefix), emit the
+ * namespace IRI instead of the file IRI.
+ */
+describe("NoteToRDFConverter — Issue #2959 regression", () => {
+  let converter: NoteToRDFConverter;
+  let mockVault: jest.Mocked<IVaultAdapter>;
+
+  beforeEach(() => {
+    mockVault = {
+      getFrontmatter: jest.fn(),
+      getAllFiles: jest.fn(),
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      updateLinks: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+    } as jest.Mocked<IVaultAdapter>;
+
+    converter = new NoteToRDFConverter(mockVault);
+  });
+
+  const taskFile: IFile = {
+    path: "03 Knowledge/kitelev/d18fbf07-044f-4412-86fd-d8e2e6be954b.md",
+    basename: "d18fbf07-044f-4412-86fd-d8e2e6be954b",
+    name: "d18fbf07-044f-4412-86fd-d8e2e6be954b.md",
+    parent: null,
+  };
+
+  const buildClassFile = (basename: string): IFile => ({
+    path: `03 Knowledge/ems/${basename}.md`,
+    basename,
+    name: `${basename}.md`,
+    parent: null,
+  });
+
+  describe("class-named wikilink → class IRI normalization", () => {
+    it.each([
+      ["ems__EffortStatusBacklog", "EffortStatusBacklog"],
+      ["ems__EffortStatusDoing", "EffortStatusDoing"],
+      ["ems__EffortStatusDone", "EffortStatusDone"],
+      ["ems__EffortStatusCancelled", "EffortStatusCancelled"],
+      ["ems__EffortStatusReview", "EffortStatusReview"],
+      ["ems__EffortStatusWaiting", "EffortStatusWaiting"],
+      ["ems__EffortStatusBlocked", "EffortStatusBlocked"],
+      ["ems__EffortStatusAnalysis", "EffortStatusAnalysis"],
+    ])(
+      "stores ems__Effort_status [[%s]] as class namespace IRI when target file resolves",
+      async (statusClass, localName) => {
+        const enumFile = buildClassFile(statusClass);
+
+        const taskFrontmatter: IFrontmatter = {
+          ems__Effort_status: `[[${statusClass}]]`,
+        };
+
+        mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+          if (f.path === taskFile.path) return taskFrontmatter;
+          return null;
+        });
+
+        mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+          if (linkpath === statusClass) return enumFile;
+          return null;
+        });
+
+        const triples = await converter.convertNote(taskFile);
+
+        const statusTriples = triples.filter(
+          (t) => (t.predicate as IRI).value === Namespace.EMS.term("Effort_status").value
+        );
+
+        // Replace, not additive: ASK is existential — file IRI bindings
+        // would defeat preconditions of the form
+        //   ASK { ?s ems:Effort_status <ems:EffortStatusDone> }
+        expect(statusTriples).toHaveLength(1);
+        expect(statusTriples[0].object).toBeInstanceOf(IRI);
+        expect((statusTriples[0].object as IRI).value).toBe(
+          Namespace.EMS.term(localName).value
+        );
+      }
+    );
+
+    it("empirical reproduction — vault-2025 task d18fbf07 with ems__EffortStatusDone", async () => {
+      // Mirrors the exact frontmatter from
+      //   /Users/kitelev/vault-2025/03 Knowledge/kitelev/d18fbf07-…b.md
+      // discovered live via Obsidian DevTools 2026-04-25:
+      //
+      //   const cr = app.plugins.plugins.exocortex.commandResolver;
+      //   const pe = app.plugins.plugins.exocortex.preconditionEvaluator;
+      //   const c = await cr.loadCommand('52c88678-…');
+      //   pe.evaluate(c.precondition, subjectIRI, ctx)  // → false ❌  (expected: true)
+      const enumFile = buildClassFile("ems__EffortStatusDone");
+
+      const taskFrontmatter: IFrontmatter = {
+        exo__Instance_class: ["[[ems__Task]]"],
+        ems__Effort_status: "[[ems__EffortStatusDone]]",
+        exo__Asset_label: "Заполнить таблетницу на 2026-W18",
+      };
+
+      mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+        if (f.path === taskFile.path) return taskFrontmatter;
+        return null;
+      });
+
+      mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+        if (linkpath === "ems__EffortStatusDone") return enumFile;
+        return null;
+      });
+
+      const triples = await converter.convertNote(taskFile);
+
+      const statusTriples = triples.filter(
+        (t) => (t.predicate as IRI).value === Namespace.EMS.term("Effort_status").value
+      );
+
+      // Pre-fix: returned obsidian://vault/03%20Knowledge/ems/ems__EffortStatusDone.md
+      // Post-fix: returns <https://exocortex.my/ontology/ems#EffortStatusDone>
+      expect(statusTriples).toHaveLength(1);
+      expect(statusTriples[0].object).toBeInstanceOf(IRI);
+      expect((statusTriples[0].object as IRI).value).toBe(
+        "https://exocortex.my/ontology/ems#EffortStatusDone"
+      );
+    });
+
+    it("falls back to file IRI when target basename is NOT a class reference", async () => {
+      const ordinaryFile: IFile = {
+        path: "03 Knowledge/notes/Some Note.md",
+        basename: "Some Note",
+        name: "Some Note.md",
+        parent: null,
+      };
+
+      const taskFrontmatter: IFrontmatter = {
+        exo__Asset_relates: "[[Some Note]]",
+      };
+
+      mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+        if (f.path === taskFile.path) return taskFrontmatter;
+        return null;
+      });
+
+      mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+        if (linkpath === "Some Note") return ordinaryFile;
+        return null;
+      });
+
+      const triples = await converter.convertNote(taskFile);
+
+      const relatesTriples = triples.filter(
+        (t) => (t.predicate as IRI).value === Namespace.EXO.term("Asset_relates").value
+      );
+
+      expect(relatesTriples).toHaveLength(1);
+      expect(relatesTriples[0].object).toBeInstanceOf(IRI);
+      expect((relatesTriples[0].object as IRI).value).toContain("Some%20Note.md");
+    });
+
+    it("preserves UUID dual-storage behavior (Issue #2782 regression guard)", async () => {
+      // UUID-form wikilinks pointing at non-class-like targets keep the
+      // existing dual-storage (file IRI + UUID literal) behavior.
+      const ordinaryFile: IFile = {
+        path: "03 Knowledge/inbox/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.md",
+        basename: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        name: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.md",
+        parent: null,
+      };
+
+      const taskFrontmatter: IFrontmatter = {
+        ems__Effort_parent: "[[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]]",
+      };
+
+      mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+        if (f.path === taskFile.path) return taskFrontmatter;
+        if (f.path === ordinaryFile.path) return { exo__Asset_label: "Some other task" };
+        return null;
+      });
+
+      mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+        if (linkpath === "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee") return ordinaryFile;
+        return null;
+      });
+
+      const triples = await converter.convertNote(taskFile);
+
+      const parentTriples = triples.filter(
+        (t) => (t.predicate as IRI).value === Namespace.EMS.term("Effort_parent").value
+      );
+
+      // Two triples expected: file IRI + UUID literal (no class IRI replacement).
+      expect(parentTriples).toHaveLength(2);
+      const objectValues = parentTriples.map((t) => (t.object as IRI | { value: string }).value);
+      expect(objectValues.some((v) => v.includes("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.md"))).toBe(true);
+      expect(objectValues).toContain("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+      expect(objectValues.some((v) => v.startsWith("https://exocortex.my/ontology/"))).toBe(false);
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -620,7 +620,11 @@ describe("NoteToRDFConverter", () => {
         expect(values).toContain(Namespace.EMS.term("Effort").value);
       });
 
-      it("should still use file URI when wiki-link target file exists", async () => {
+      // Issue #2959: when a class-named wikilink resolves to its class
+      // definition file, the namespace class IRI is emitted (not the file
+      // IRI). This is required for SPARQL ASK/FILTER preconditions and
+      // canonical rdfs:domain/range triples (Issue #871) to match.
+      it("should use namespace URI when wiki-link target file exists for a class reference (Issue #2959)", async () => {
         const frontmatter: IFrontmatter = {
           exo__Property_domain: "[[ems__Effort]]",
         };
@@ -643,8 +647,7 @@ describe("NoteToRDFConverter", () => {
 
         expect(domainTriple).toBeDefined();
         expect(domainTriple!.object).toBeInstanceOf(IRI);
-        expect((domainTriple!.object as IRI).value).toContain("obsidian://vault/");
-        expect((domainTriple!.object as IRI).value).toContain("ems__Effort.md");
+        expect((domainTriple!.object as IRI).value).toBe(Namespace.EMS.term("Effort").value);
       });
 
       it("should return literal for wiki-link to non-class file when not found", async () => {

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -97,8 +97,10 @@ fi
 # - RFC-028 Finding 5 (3.C.1): services/AssetConversionService.test.ts
 # - RFC be70f741 Phase 2: application/services/RelationColumnSetResolver(.property)?.test.ts
 #   + performance/RelationColumnSetResolverPerformance.test.ts (p95 <1ms gate)
+# - Issue #2959: services/NoteToRDFConverter.issue-2959.test.ts (class-named
+#   wikilink → namespace IRI normalization regression suite)
 echo "📦 Running exocortex grounding + RFC regression tests..."
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test)\.ts --forceExit"
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
Closes #2959

## Summary

`valueToRDFObject` previously stored class-named wikilinks like `ems__Effort_status: "[[ems__EffortStatusDone]]"` as the resolved file IRI (`obsidian://vault/...EffortStatusDone.md`) whenever the class-definition file existed in the vault.

SPARQL ASK preconditions of the form

```sparql
ASK { ?s ems:Effort_status <ems:EffortStatusDone> }
```

require the canonical class IRI to match. As a result, the **"Archive Completed"** command's **"Is in Done status"** precondition (UID `8762ddc2-…`) returned `false` on tasks that were actually Done — the Archive button stayed hidden in the Maintenance group.

## Diagnose evidence (Hypothesis H2 confirmed)

The four hypotheses from the Issue body were:

| # | Hypothesis | Status |
|---|------------|--------|
| H1 | Triple store stores enum values as `Literal`, not `IRI` | ❌ Disproved — `valueToRDFObject` does emit IRI |
| **H2** | **Frontmatter normalizer doesn't convert class-name strings to namespace IRIs** | ✅ **Root cause** |
| H3 | Subject IRI mismatch in canonicalization | ❌ Disproved — both sides use `obsidian://vault/...` |
| H4 | Trailing whitespace / encoding | ❌ Disproved — `expandClassValue` strips and matches by prefix |

The new failing-then-passing parametrized test in `NoteToRDFConverter.issue-2959.test.ts` mirrors the live vault-2025 task `d18fbf07-044f-4412-86fd-d8e2e6be954b` frontmatter (`ems__Effort_status: "[[ems__EffortStatusDone]]"`).

**Pre-fix object IRI:** `obsidian://vault/03%20Knowledge/ems/ems__EffortStatusDone.md`
**Post-fix object IRI:** `https://exocortex.my/ontology/ems#EffortStatusDone`

## Fix

Single insertion in `packages/exocortex/src/services/NoteToRDFConverter.ts` (`valueToRDFObject`), placed immediately after the UUID-branch (Issue #2782 fix) and before `return [fileIRI]`:

```typescript
const basenameClassIRI = this.expandClassValue(targetFile.basename);
if (basenameClassIRI) {
  return [basenameClassIRI];
}
```

This mirrors the Issue #2782 UUID-wikilink basename/label normalization and extends it: when the resolved target's basename expands to a namespace IRI via `expandClassValue` (`ems__*` / `exo__*` / `exocmd__*` / `ims__*` / `ztlk__*` / `ptms__*` / `lit__*` / `inbox__*`), emit the class IRI instead of the file IRI.

## Regression suite (Acceptance Criteria 4)

`packages/exocortex/tests/unit/services/NoteToRDFConverter.issue-2959.test.ts`:

- **8 status enums** parametrized via `it.each` (Backlog/Doing/Done/Cancelled/Review/Waiting/Blocked/Analysis) — all assert canonical class IRI ✅
- **Empirical reproduction** mirrors vault-2025 task `d18fbf07-…` frontmatter ✅
- **Negative guard**: non-class wikilink targets (`[[Some Note]]`) still produce file IRIs ✅
- **Issue #2782 guard**: UUID-form wikilinks pointing at non-class-like targets keep dual storage (file IRI + UUID literal) ✅

CI allowlist (`scripts/test-ci-batched.sh` and `.github/workflows/ci.yml` `test-coverage-exocortex`) updated to include the new regression suite.

Local results:

```
✓ 8 parametrized status tests
✓ empirical reproduction (vault-2025 d18fbf07)
✓ negative guard (non-class wikilink)
✓ Issue #2782 dual-storage regression guard

Tests:       11 passed, 11 total
```

## Acceptance Criteria

- [x] **Diagnose first** — H2 confirmed via failing-test mirror of vault-2025 frontmatter
- [x] **Given** vault fixture, **When** precondition `8762ddc2-…` evaluated against ems__Task with `ems__Effort_status: ems__EffortStatusDone`, **Then** result `true` (covered by `valueToRDFObject` returning canonical class IRI; precondition SPARQL ASK now matches)
- [x] **Fix** in indexer — `NoteToRDFConverter.ts` (preferred over precondition asset rewrite per Issue's "Implementation Steps")
- [x] **Regression suite** — all 8 status preconditions covered (parametrized)
- [ ] **Empirical verify** in vault-2025 — delegated to user (post-release Obsidian DevTools probe per Issue body's "Best Practices Checklist")

## Files Changed

- `packages/exocortex/src/services/NoteToRDFConverter.ts` — fix (8 lines + comment)
- `packages/exocortex/tests/unit/services/NoteToRDFConverter.issue-2959.test.ts` — new regression suite
- `packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts` — updated existing test that asserted the buggy behavior
- `.github/workflows/ci.yml` + `scripts/test-ci-batched.sh` — extend allowlist

## Risks (per Issue body)

| Risk | Mitigation |
|------|------------|
| Fixing IRI normalization breaks Literal-based queries | None affected — fix only changes `IRI(file)` → `IRI(class)` for class-prefixed wikilink targets, never touches Literals |
| Subject IRI mismatch (H3) | H3 disproved; subject IRI canonicalization unchanged |
| 8 status preconditions all broken | All 8 covered in parametrized regression test |
| Pre-existing CI gap for `NoteToRDFConverter.test.ts` | New regression file added to CI allowlist explicitly |