### PR TITLE
feat(rdf): register pmbok namespace in NoteToRDFConverter

### DIFF
--- a/packages/exocortex/src/domain/models/rdf/Namespace.ts
+++ b/packages/exocortex/src/domain/models/rdf/Namespace.ts
@@ -71,4 +71,6 @@ export class Namespace {
   static readonly LIT = new Namespace("lit", "https://exocortex.my/ontology/lit#");
 
   static readonly INBOX = new Namespace("inbox", "https://exocortex.my/ontology/inbox#");
+
+  static readonly PMBOK = new Namespace("pmbok", "https://exocortex.my/ontology/pmbok#");
 }

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -603,6 +603,7 @@ export class NoteToRDFConverter {
     ["ptms__", Namespace.PTMS],
     ["lit__", Namespace.LIT],
     ["inbox__", Namespace.INBOX],
+    ["pmbok__", Namespace.PMBOK],
   ];
 
   private isExocortexProperty(key: string): boolean {

--- a/packages/exocortex/src/utilities/FrontmatterService.ts
+++ b/packages/exocortex/src/utilities/FrontmatterService.ts
@@ -247,6 +247,7 @@ export class FrontmatterService {
     "https://exocortex.my/ontology/ptms#": "ptms__",
     "https://exocortex.my/ontology/lit#": "lit__",
     "https://exocortex.my/ontology/inbox#": "inbox__",
+    "https://exocortex.my/ontology/pmbok#": "pmbok__",
   };
 
   /**

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -198,6 +198,35 @@ describe("NoteToRDFConverter", () => {
       expect((statusTriple!.object as Literal).value).toBe("ToDo");
     });
 
+    it("should convert pmbok__ properties to RDF triples with pmbok namespace IRI", async () => {
+      const file: IFile = {
+        path: "test.md",
+        basename: "test",
+        name: "test.md",
+        parent: null,
+      };
+
+      const frontmatter: IFrontmatter = {
+        pmbok__ProjectStatusRecord_reportDate: "2026-04-25T02:32:28+0500",
+      };
+
+      mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+      const triples = await converter.convertNote(file);
+
+      const reportDateTriple = triples.find((t) =>
+        (t.predicate as IRI).value.includes("ProjectStatusRecord_reportDate")
+      );
+
+      expect(reportDateTriple).toBeDefined();
+      expect((reportDateTriple!.predicate as IRI).value).toBe(
+        "https://exocortex.my/ontology/pmbok#ProjectStatusRecord_reportDate"
+      );
+      expect((reportDateTriple!.object as Literal).value).toBe(
+        "2026-04-25T02:32:28+0500"
+      );
+    });
+
     it("should convert wikilinks to IRI references", async () => {
       const file: IFile = {
         path: "test.md",
@@ -276,6 +305,32 @@ describe("NoteToRDFConverter", () => {
 
       expect(typeTriple).toBeDefined();
       expect((typeTriple!.object as IRI).value).toContain("Task");
+    });
+
+    it("should resolve pmbok__ class wikilinks to pmbok namespace IRI", async () => {
+      const file: IFile = {
+        path: "test.md",
+        basename: "test",
+        name: "test.md",
+        parent: null,
+      };
+
+      const frontmatter: IFrontmatter = {
+        exo__Instance_class: ["[[pmbok__OverallStatusOnTrack]]"],
+      };
+
+      mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+      const triples = await converter.convertNote(file);
+
+      const typeTriple = triples.find((t) =>
+        (t.predicate as IRI).value === Namespace.RDF.term("type").value
+      );
+
+      expect(typeTriple).toBeDefined();
+      expect((typeTriple!.object as IRI).value).toBe(
+        "https://exocortex.my/ontology/pmbok#OverallStatusOnTrack"
+      );
     });
 
     it("should handle archived notes with exo__Asset_isArchived", async () => {


### PR DESCRIPTION
## Summary

Registers `pmbok` (`https://exocortex.my/ontology/pmbok#`) as a recognized namespace in `NoteToRDFConverter`, `Namespace`, and `FrontmatterService`. Without this, vault assets with `pmbok__*` frontmatter properties are silently dropped — graph contains 0 triples in the pmbok namespace, and SPARQL competency-question queries return empty results.

## Why

RFC pmbok-artifacts v3 (vault asset `5da902a8-4cb6-462a-b2b4-779f32711bc8`) introduces PMBOK ontology classes (`pmbok__ProjectCharter`, `pmbok__ProjectStatusRecord`, `pmbok__OverallStatus`) and 6+ properties. The RFC's M3 acceptance criteria require validating CQ1/CQ2/CQ4/CQ5 SPARQL queries against pilot data — but the converter's namespace registry currently lists only `exo`, `ems`, `exocmd`, `ims`, `ztlk`, `ptms`, `lit`, `inbox`. Pmbok is the 9th first-party namespace and parallels the others structurally.

Verified pre-existing gap: `SELECT ?p WHERE { ?s ?p ?o . FILTER(CONTAINS(STR(?p), 'pmbok')) }` against `vault-2025` returns count = 0, including for the existing `pmbok__ProjectCharter_project` (created 2026-04-26 before this PR).

## Changes

Three additive edits in three files (no behavioural changes for existing namespaces):

- `packages/exocortex/src/domain/models/rdf/Namespace.ts` — `Namespace.PMBOK` constant
- `packages/exocortex/src/services/NoteToRDFConverter.ts` — `["pmbok__", Namespace.PMBOK]` in `NAMESPACE_MAP`
- `packages/exocortex/src/utilities/FrontmatterService.ts` — `pmbok#` → `pmbok__` in `IRI_PREFIX_MAP`

## Tests

Two new unit tests in `tests/unit/services/NoteToRDFConverter.test.ts`:

- `should convert pmbok__ properties to RDF triples with pmbok namespace IRI` — round-trip property emission
- `should resolve pmbok__ class wikilinks to pmbok namespace IRI` — class resolution path (covers `exo__Instance_class: [[pmbok__OverallStatusOnTrack]]`)

## Test plan

- [x] `npx jest tests/unit/services/NoteToRDFConverter.test.ts -t "pmbok"` — both new tests pass locally
- [x] `npx jest tests/unit/services/NoteToRDFConverter.test.ts tests/unit/domain/rdf/Namespace.test.ts` — full suites green except 3 pre-existing failures present on `main` HEAD (verified by `git stash` + re-run on bare `main`)
- [x] `npm run lint` — clean (only pre-existing warnings, no errors)
- [x] `npx tsc -p packages/exocortex/tsconfig.json --noEmit` — clean
- [x] Pre-commit hooks (BDD coverage, archgate) — all 13 ADR rules pass
- [ ] CI green (will run on PR)