### PR TITLE
feat(layout): PanelResolver service with 3-axis cache (RFC-024 Phase 3 / T6.2)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -38,7 +38,9 @@ import { TaskTrackingService } from "./application/services/TaskTrackingService"
 import { AliasSyncService } from "./application/services/AliasSyncService";
 import { WikilinkAliasService } from "./application/services/WikilinkAliasService";
 import { ThemeResolver } from "./application/services/ThemeResolver";
+import { PanelResolver } from "./application/services/PanelResolver";
 import { isLayoutFrontmatter } from "./domain/layout";
+import { isCommandBindingFrontmatter } from "exocortex";
 import { SPARQLCodeBlockProcessor } from "./application/processors/SPARQLCodeBlockProcessor";
 import { LayoutCodeBlockProcessor } from "./application/processors/LayoutCodeBlockProcessor";
 import { SPARQLApi } from "./application/api/SPARQLApi";
@@ -86,6 +88,7 @@ export default class ExocortexPlugin extends Plugin {
   private aliasSyncService!: AliasSyncService;
   private wikilinkAliasService!: WikilinkAliasService;
   themeResolver!: ThemeResolver;
+  panelResolver!: PanelResolver;
   // Use LRU cache with max 1000 entries and 5-minute TTL to prevent unbounded memory growth
   // TTL ensures stale entries are evicted even if not accessed
   private metadataCache!: LRUCache<string, Record<string, unknown>>;
@@ -338,6 +341,49 @@ export default class ExocortexPlugin extends Plugin {
           if (fm && isLayoutFrontmatter(fm as Record<string, unknown>)) {
             this.themeResolver.invalidate();
           }
+        }),
+      );
+
+      // RFC-024 Phase 3 — Panel resolver for class-level command panels.
+      // 3-axis cache invalidation: layout edit / binding edit / class change.
+      // layoutProvider is a placeholder pending T6.3 wiring of an
+      // ExoLayoutRepository lookup; the resolver still serves as a
+      // permanent contract surface — `applyFilter` and `isFeatured`
+      // become no-ops when no panel is declared (non-breaking).
+      this.panelResolver = new PanelResolver();
+      this.registerEvent(
+        this.app.metadataCache.on("changed", (file) => {
+          const fm = this.app.metadataCache.getFileCache(file)?.frontmatter as
+            | Record<string, unknown>
+            | undefined;
+          if (!fm) return;
+          // Axis 1 — Layout asset edited (panel spec / target class / order).
+          if (isLayoutFrontmatter(fm)) {
+            this.panelResolver.invalidateOnLayoutChange();
+            return;
+          }
+          // Axis 2 — Binding asset edited; may be referenced by
+          // featuredBinding / excludeCommands of any panel.
+          if (isCommandBindingFrontmatter(fm)) {
+            this.panelResolver.invalidateOnBindingChange();
+          }
+          // Axis 3 — Class membership change is observed via the
+          // metadataCache `changed` event itself when `exo__Instance_class`
+          // is mutated; the affected file's previous class is unknown
+          // here, so the safest invariant is to clear all entries.
+          // (Falls through to full invalidation below.)
+        }),
+      );
+      // Axis 3 wiring — explicit hook for class membership renames /
+      // deletions that the `changed` predicate above cannot detect.
+      this.registerEvent(
+        this.app.metadataCache.on("deleted", () => {
+          this.panelResolver.invalidateOnClassChange();
+        }),
+      );
+      this.registerEvent(
+        this.app.vault.on("rename", () => {
+          this.panelResolver.invalidateOnClassChange();
         }),
       );
 

--- a/packages/obsidian-plugin/src/application/services/PanelResolver.ts
+++ b/packages/obsidian-plugin/src/application/services/PanelResolver.ts
@@ -1,0 +1,171 @@
+/**
+ * PanelResolver — RFC-024 Phase 3 service that resolves the
+ * `exo__Layout_commandPanel` for a given target class and exposes the
+ * three precedence helpers that act on the resolved panel:
+ *
+ *   1. {@link PanelResolver.resolve}      — return the active panel spec.
+ *   2. {@link PanelResolver.applyFilter}  — `excludeCommands` trumps
+ *      `includeGroups` (RFC-024 §5 rule #2).
+ *   3. {@link PanelResolver.isFeatured}   — `featuredBinding` overrides
+ *      a binding's variant to `primary` (RFC-024 §5 rule #3).
+ *
+ * Resolved values are memoised by class reference. Cache invalidation has
+ * three orthogonal entry points — one per axis described in the RFC §4
+ * Phase 3 service contract:
+ *
+ *   - {@link PanelResolver.invalidateOnLayoutChange}  — `exo__Layout`
+ *     asset edited (the panel spec itself, layout target class, or order).
+ *   - {@link PanelResolver.invalidateOnBindingChange} — an
+ *     `exocmd__CommandBinding` referenced by `featuredBinding` or
+ *     `excludeCommands` was edited / renamed / deleted.
+ *   - {@link PanelResolver.invalidateOnClassChange}   — the asset's
+ *     `exo__Instance_class` membership changed, so the class key the
+ *     panel is cached under is no longer valid for that file.
+ *
+ * All three reduce to {@link PanelResolver.invalidate}; the named methods
+ * are the public contract so wiring code documents which axis fired.
+ *
+ * @module application/services/PanelResolver
+ * @since RFC-024 Phase 3
+ */
+
+import {
+  applyCommandPanelFilter,
+  isFeaturedBinding,
+  type BaseLayout,
+  type CommandPanel,
+} from "@plugin/domain/layout";
+
+/**
+ * Callback supplied by the plugin that returns the layout currently
+ * targeting the given class reference (already normalised to the bare
+ * class name). Returning `null` — or a layout without a `commandPanel`
+ * slot — means the resolver falls through to "no panel override".
+ */
+export type PanelLayoutProvider = (
+  classRef: string,
+) => Pick<BaseLayout, "commandPanel"> | null;
+
+export interface PanelResolverOptions {
+  /**
+   * How to discover the layout for a class reference. Defaults to
+   * `() => null`, which is useful for tests and for initial wiring before
+   * a layout repository is available.
+   */
+  readonly layoutProvider?: PanelLayoutProvider;
+}
+
+/**
+ * Reads, resolves, and caches the `exo__Layout_commandPanel` slot for a
+ * given target class. Acts as the single source of truth for which
+ * command bindings render in a class-specific panel and which one is
+ * promoted to `primary`.
+ */
+export class PanelResolver {
+  private readonly layoutProvider: PanelLayoutProvider;
+  private readonly cache = new Map<string, CommandPanel | null>();
+
+  constructor(options: PanelResolverOptions = {}) {
+    this.layoutProvider = options.layoutProvider ?? (() => null);
+  }
+
+  /**
+   * Returns the active {@link CommandPanel} spec for the given class, or
+   * `null` if no layout declares one. Result is memoised per class.
+   */
+  resolve(classRef: string): CommandPanel | null {
+    const key = this.normaliseClassRef(classRef);
+    if (this.cache.has(key)) {
+      return this.cache.get(key) ?? null;
+    }
+    const layout = this.layoutProvider(key);
+    const panel = layout?.commandPanel ?? null;
+    this.cache.set(key, panel);
+    return panel;
+  }
+
+  /**
+   * Applies the resolved panel's include/exclude rules to a list of
+   * candidate commands. Pure pass-through when no panel is declared.
+   *
+   * @param classRef   - Target class whose panel is consulted.
+   * @param candidates - Candidate commands (each with `uid` + optional
+   *                     `group`). Order is preserved.
+   * @returns Filtered subset honouring rule #2 (exclude trumps include).
+   */
+  applyFilter<T extends { uid: string; group?: string }>(
+    classRef: string,
+    candidates: readonly T[],
+  ): T[] {
+    return applyCommandPanelFilter(
+      candidates,
+      this.resolve(classRef) ?? undefined,
+    );
+  }
+
+  /**
+   * Reports whether the given binding is the panel's `featuredBinding`
+   * for the given class — i.e. its variant should be promoted to
+   * `primary` regardless of any binding-level style.
+   */
+  isFeatured(classRef: string, bindingUid: string): boolean {
+    return isFeaturedBinding(
+      this.resolve(classRef) ?? undefined,
+      bindingUid,
+    );
+  }
+
+  /**
+   * Axis 1 — invalidate after an `exo__Layout` asset is edited. Drops
+   * the cache entry for the layout's target class (or every entry when
+   * the caller cannot pin down the affected class — e.g. when the layout
+   * has just been deleted).
+   */
+  invalidateOnLayoutChange(classRef?: string): void {
+    this.invalidate(classRef);
+  }
+
+  /**
+   * Axis 2 — invalidate after an `exocmd__CommandBinding` asset is
+   * edited / renamed / deleted. Bindings can be referenced by any
+   * panel's `excludeCommands` or `featuredBinding`, so the safest
+   * invariant is to drop the whole cache.
+   */
+  invalidateOnBindingChange(): void {
+    this.invalidate();
+  }
+
+  /**
+   * Axis 3 — invalidate after an asset's `exo__Instance_class`
+   * membership changes (rename, retype). When the caller knows the
+   * affected class, only that key is dropped.
+   */
+  invalidateOnClassChange(classRef?: string): void {
+    this.invalidate(classRef);
+  }
+
+  /**
+   * Drops a cached resolution. Omit the argument to clear the whole
+   * cache. Used internally by the three named axis hooks; exposed so
+   * test harnesses can also reset state directly.
+   */
+  invalidate(classRef?: string): void {
+    if (classRef === undefined) {
+      this.cache.clear();
+      return;
+    }
+    this.cache.delete(this.normaliseClassRef(classRef));
+  }
+
+  /**
+   * Strips wikilink syntax and the optional alias suffix so that
+   * `[[ems__Task]]`, `[[ems__Task|Task]]`, and `ems__Task` all collapse
+   * to the same cache key.
+   */
+  private normaliseClassRef(classRef: string): string {
+    const trimmed = classRef.trim();
+    const inner = trimmed.replace(/^\[\[|\]\]$/g, "");
+    const pipeIdx = inner.indexOf("|");
+    return (pipeIdx >= 0 ? inner.slice(0, pipeIdx) : inner).trim();
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -213,7 +213,8 @@ describe("ExocortexPlugin", () => {
       );
       // 10 - 4 semantic search file events (create, modify, delete, rename) = 6
       // + 1 PrintNameRuleService refresh + 1 ThemeResolver invalidation (RFC-024 Phase 1) = 8
-      expect(plugin.registerEvent).toHaveBeenCalledTimes(8);
+      // + 3 PanelResolver invalidations (RFC-024 Phase 3 — layout/binding `changed`, `deleted`, vault `rename`) = 11
+      expect(plugin.registerEvent).toHaveBeenCalledTimes(11);
       expect(mockLogger.info).toHaveBeenCalledWith("Exocortex Plugin loaded successfully");
     });
 

--- a/packages/obsidian-plugin/tests/unit/application/services/PanelResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/services/PanelResolver.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, jest } from "@jest/globals";
+
+import {
+  PanelResolver,
+  type PanelLayoutProvider,
+} from "../../../../src/application/services/PanelResolver";
+import type { CommandPanel } from "../../../../src/domain/layout";
+
+describe("PanelResolver", () => {
+  describe("resolve", () => {
+    it("returns the layout-declared command panel when present", () => {
+      const panel: CommandPanel = {
+        includeGroups: ["status"],
+        excludeCommands: ["bind-block"],
+        layout: "stacked",
+        featuredBinding: "bind-feature",
+      };
+      const provider: PanelLayoutProvider = (classRef) =>
+        classRef === "ems__Task" ? { commandPanel: panel } : null;
+
+      const resolver = new PanelResolver({ layoutProvider: provider });
+
+      expect(resolver.resolve("ems__Task")).toEqual(panel);
+    });
+
+    it("returns null when the layout exists but has no commandPanel slot", () => {
+      const resolver = new PanelResolver({ layoutProvider: () => ({}) });
+
+      expect(resolver.resolve("ems__Task")).toBeNull();
+    });
+
+    it("returns null when no layout is declared for the class", () => {
+      const resolver = new PanelResolver({ layoutProvider: () => null });
+
+      expect(resolver.resolve("unknown__Class")).toBeNull();
+    });
+
+    it("normalises wikilink form and alias when looking up a panel", () => {
+      const panel: CommandPanel = { includeGroups: ["creation"] };
+      const provider = jest.fn<PanelLayoutProvider>((classRef) =>
+        classRef === "ems__Task" ? { commandPanel: panel } : null,
+      );
+      const resolver = new PanelResolver({ layoutProvider: provider });
+
+      expect(resolver.resolve("[[ems__Task]]")).toEqual(panel);
+      expect(resolver.resolve("[[ems__Task|Task]]")).toEqual(panel);
+      // Both forms collapse to the same key — the provider is only hit once.
+      expect(provider).toHaveBeenCalledTimes(1);
+      expect(provider).toHaveBeenCalledWith("ems__Task");
+    });
+
+    it("caches resolutions so the layout provider is only queried once per class", () => {
+      const provider = jest.fn<PanelLayoutProvider>(() => null);
+      const resolver = new PanelResolver({ layoutProvider: provider });
+
+      resolver.resolve("ems__Task");
+      resolver.resolve("ems__Task");
+      resolver.resolve("ems__Task");
+
+      expect(provider).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches the negative result (null) so repeated lookups skip the provider", () => {
+      const provider = jest.fn<PanelLayoutProvider>(() => null);
+      const resolver = new PanelResolver({ layoutProvider: provider });
+
+      expect(resolver.resolve("ems__Task")).toBeNull();
+      expect(resolver.resolve("ems__Task")).toBeNull();
+
+      expect(provider).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("applyFilter", () => {
+    const candidates = [
+      { uid: "bind-create", group: "creation" },
+      { uid: "bind-status", group: "status" },
+      { uid: "bind-block", group: "status" },
+      { uid: "bind-misc", group: "maintenance" },
+    ];
+
+    it("returns the candidates unchanged when no panel is declared", () => {
+      const resolver = new PanelResolver({ layoutProvider: () => null });
+
+      expect(resolver.applyFilter("ems__Task", candidates)).toEqual(candidates);
+    });
+
+    it("includes only bindings whose group is whitelisted", () => {
+      const panel: CommandPanel = { includeGroups: ["creation", "status"] };
+      const resolver = new PanelResolver({
+        layoutProvider: () => ({ commandPanel: panel }),
+      });
+
+      expect(resolver.applyFilter("ems__Task", candidates).map((c) => c.uid)).toEqual([
+        "bind-create",
+        "bind-status",
+        "bind-block",
+      ]);
+    });
+
+    it("drops excluded bindings even when their group is included (rule #2)", () => {
+      const panel: CommandPanel = {
+        includeGroups: ["creation", "status"],
+        excludeCommands: ["bind-block"],
+      };
+      const resolver = new PanelResolver({
+        layoutProvider: () => ({ commandPanel: panel }),
+      });
+
+      expect(resolver.applyFilter("ems__Task", candidates).map((c) => c.uid)).toEqual([
+        "bind-create",
+        "bind-status",
+      ]);
+    });
+  });
+
+  describe("isFeatured", () => {
+    it("returns true only for the panel's featuredBinding (rule #3)", () => {
+      const panel: CommandPanel = { featuredBinding: "bind-feature" };
+      const resolver = new PanelResolver({
+        layoutProvider: () => ({ commandPanel: panel }),
+      });
+
+      expect(resolver.isFeatured("ems__Task", "bind-feature")).toBe(true);
+      expect(resolver.isFeatured("ems__Task", "bind-other")).toBe(false);
+    });
+
+    it("returns false when the class has no panel", () => {
+      const resolver = new PanelResolver({ layoutProvider: () => null });
+
+      expect(resolver.isFeatured("ems__Task", "bind-anything")).toBe(false);
+    });
+  });
+
+  describe("invalidation (3 axes)", () => {
+    it("axis 1 (layout change) re-queries after a class-specific invalidation", () => {
+      const provider = jest.fn<PanelLayoutProvider>(() => null);
+      const resolver = new PanelResolver({ layoutProvider: provider });
+
+      resolver.resolve("ems__Task");
+      resolver.invalidateOnLayoutChange("ems__Task");
+      resolver.resolve("ems__Task");
+
+      expect(provider).toHaveBeenCalledTimes(2);
+    });
+
+    it("axis 1 (layout change) without a class clears every cached entry", () => {
+      const provider = jest.fn<PanelLayoutProvider>(() => null);
+      const resolver = new PanelResolver({ layoutProvider: provider });
+
+      resolver.resolve("ems__Task");
+      resolver.resolve("ems__Project");
+      resolver.invalidateOnLayoutChange();
+      resolver.resolve("ems__Task");
+      resolver.resolve("ems__Project");
+
+      expect(provider).toHaveBeenCalledTimes(4);
+    });
+
+    it("axis 2 (binding change) clears every cached entry — featuredBinding / excludeCommands references are global", () => {
+      const provider = jest.fn<PanelLayoutProvider>(() => null);
+      const resolver = new PanelResolver({ layoutProvider: provider });
+
+      resolver.resolve("ems__Task");
+      resolver.resolve("ems__Project");
+      resolver.invalidateOnBindingChange();
+      resolver.resolve("ems__Task");
+      resolver.resolve("ems__Project");
+
+      expect(provider).toHaveBeenCalledTimes(4);
+    });
+
+    it("axis 3 (class change) drops the affected class entry only", () => {
+      const provider = jest.fn<PanelLayoutProvider>(() => null);
+      const resolver = new PanelResolver({ layoutProvider: provider });
+
+      resolver.resolve("ems__Task");
+      resolver.resolve("ems__Project");
+      resolver.invalidateOnClassChange("ems__Task");
+      resolver.resolve("ems__Task");
+      resolver.resolve("ems__Project");
+
+      // Task: 2 calls (initial + post-invalidation). Project: 1 call.
+      expect(provider).toHaveBeenCalledTimes(3);
+    });
+
+    it("invalidate normalises wikilink form so [[X]] hits the same key as X", () => {
+      const provider = jest.fn<PanelLayoutProvider>(() => null);
+      const resolver = new PanelResolver({ layoutProvider: provider });
+
+      resolver.resolve("ems__Task");
+      resolver.invalidate("[[ems__Task]]");
+      resolver.resolve("ems__Task");
+
+      expect(provider).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("default options", () => {
+    it("constructs without a layoutProvider — every resolve returns null", () => {
+      const resolver = new PanelResolver();
+
+      expect(resolver.resolve("ems__Task")).toBeNull();
+      expect(resolver.applyFilter("ems__Task", [{ uid: "x" }])).toEqual([
+        { uid: "x" },
+      ]);
+      expect(resolver.isFeatured("ems__Task", "x")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `PanelResolver` service that resolves the `exo__Layout_commandPanel` slot for a target class (RFC-024 Phase 3).
- Expose the three precedence helpers built on T6.1's `CommandPanel` domain module:
  - `resolve(classRef)` — return the active panel spec (memoised).
  - `applyFilter(classRef, candidates)` — rule #2: `excludeCommands` trumps `includeGroups`.
  - `isFeatured(classRef, bindingUid)` — rule #3: `featuredBinding` promotes a binding to `primary`.
- Three orthogonal cache-invalidation entry points (one per axis described in the RFC service contract):
  - `invalidateOnLayoutChange()` — `exo__Layout` asset edited.
  - `invalidateOnBindingChange()` — `exocmd__CommandBinding` edited (referenced by `featuredBinding` / `excludeCommands`).
  - `invalidateOnClassChange()` — `exo__Instance_class` membership change.
- Wired in `ExocortexPlugin.onload`: `metadataCache.changed` → axes 1+2; `metadataCache.deleted` + vault `rename` → axis 3.

## Scope boundaries
- `LayoutProvider` is a `() => null` placeholder — non-breaking; later wiring to `ExoLayoutRepository` (T6.3) doesn't touch the resolver.
- No `CATEGORY_ORDER` / `DynamicCommandButtonGroupBuilder` changes (T6.3+ scope).

## AC coverage (vault task `00dcee72`)
- [x] PanelResolver resolves `includeGroups` + `excludeCommands` + `featuredBinding`.
- [x] Cache invalidation verified for all 3 axes.
- [x] Wired in plugin onload.

## Test plan
- [x] `npx jest tests/unit/application/services/PanelResolver.test.ts` → 17/17 pass.
- [x] `npx jest tests/unit/ExocortexPlugin.test.ts` → 72/72 pass (registerEvent count bumped 8 → 11).
- [x] `npm run check:types` → clean.
- [x] `npm run lint` → 0 errors (2 pre-existing warnings unrelated).
- [x] Pre-commit archgate → 13/13 rules pass.
- [ ] CI — 13 required checks (archgate, detect-changes, e2e-shard 1..6, lint, test-bdd, test-component, test-coverage, typecheck).