### PR TITLE
feat(rfc-024): CommandResolver reads binding.style with fallback chain (T5.2)

### DIFF
--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -1,4 +1,9 @@
 import { GroundingType } from "../constants/GroundingType";
+import type {
+  CommandVariant,
+  LabelClass,
+  StyleSource,
+} from "../constants/CommandBindingStyleEnums";
 
 /**
  * Domain model for a dynamic command (RFC-009 Section 4.2.1).
@@ -119,6 +124,53 @@ export interface CommandBindingDefinition {
   readonly group?: string;
   /** Binding-level precondition overriding command-level precondition */
   readonly precondition?: PreconditionDefinition;
+  /**
+   * Resolved visual style (RFC-024 §4 Phase 2).
+   *
+   * Populated by CommandResolver applying the fallback chain:
+   * 1. `exocmd__CommandBinding_style` wikilink → load referenced
+   *    CommandBindingStyle asset (preferred — reusable across bindings).
+   * 2. `exocmd__CommandBinding_variant` inline literal → synthesize
+   *    minimal style with only `variant` set.
+   * 3. Neither present → `style` is `undefined`; UI applies group-based
+   *    Phase 0 default via `resolveVariant(group)`.
+   *
+   * Invalid enum values are coerced (lowercase + trim) and dropped to
+   * `undefined` after warning (RFC-024 §5 — never crash).
+   */
+  readonly style?: CommandBindingStyleDefinition;
+}
+
+/**
+ * Domain model for `exocmd__CommandBindingStyle` (RFC-024 §4 Phase 2).
+ *
+ * Resolved visual properties for a command binding. Constructed by
+ * CommandResolver from either a referenced style asset (full definition)
+ * or an inline `CommandBinding_variant` shorthand (variant only).
+ *
+ * All fields are optional — caller (UI layer) supplies its own defaults.
+ */
+export interface CommandBindingStyleDefinition {
+  /** Asset UID of the style asset (or synthetic `inline:<binding-uid>` for shorthand) */
+  readonly id: string;
+  /** Human-readable label of the style asset (empty for inline shorthand) */
+  readonly label: string;
+  /** Semantic button variant whitelist value */
+  readonly variant?: CommandVariant;
+  /** Boolean — render the existing Command_icon (default true at UI layer) */
+  readonly showIcon?: boolean;
+  /** Typographic modifier whitelist value */
+  readonly labelClass?: LabelClass;
+  /** Literal text for the aria-label attribute */
+  readonly ariaLabel?: string;
+  /** Literal text for the title attribute (Obsidian tooltip convention) */
+  readonly tooltip?: string;
+  /** Chord string (e.g. "Mod+Shift+D") — registered with `exo-cmd-` namespace */
+  readonly keyboardShortcut?: string;
+  /** Governance marker — user wins over vendor per precedence matrix */
+  readonly source?: StyleSource;
+  /** True iff this style was synthesized from inline `CommandBinding_variant` */
+  readonly inline: boolean;
 }
 
 // -- Type Guards --

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -1,9 +1,19 @@
 import { injectable } from "tsyringe";
 import type { ITripleStore } from "../interfaces/ITripleStore";
+import type { ILogger } from "../interfaces/ILogger";
+import { NullLogger } from "../infrastructure/NullLogger";
 import { IRI } from "../domain/models/rdf/IRI";
 import { Literal } from "../domain/models/rdf/Literal";
 import { Namespace } from "../domain/models/rdf/Namespace";
 import { GroundingType } from "../domain/constants/GroundingType";
+import {
+  COMMAND_VARIANT_VALUES,
+  LABEL_CLASS_VALUES,
+  STYLE_SOURCE_VALUES,
+  type CommandVariant,
+  type LabelClass,
+  type StyleSource,
+} from "../domain/constants/CommandBindingStyleEnums";
 import { ExoQLParser } from "../infrastructure/sparql/SPARQLParser";
 import { ExoQLAlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
 import { ExoQLQueryExecutor } from "../infrastructure/sparql/executors/QueryExecutor";
@@ -12,6 +22,7 @@ import type {
   PreconditionDefinition,
   GroundingDefinition,
   CommandBindingDefinition,
+  CommandBindingStyleDefinition,
 } from "../domain/models/CommandDefinition";
 
 /**
@@ -40,7 +51,16 @@ export class CommandResolver {
   private readonly cache = new Map<string, ResolvedCommand[]>();
   private readonly multiCache = new Map<string, ResolvedCommand[]>();
 
-  constructor(private readonly tripleStore: ITripleStore) {}
+  /**
+   * @param tripleStore - RDF triple store backing vault assets.
+   * @param logger - Optional structured logger; defaults to no-op.
+   *                 RFC-024 §5: invalid enum values warn (capped 200 chars)
+   *                 then fall back — never crash.
+   */
+  constructor(
+    private readonly tripleStore: ITripleStore,
+    private readonly logger: ILogger = NullLogger,
+  ) {}
 
   /**
    * Resolve commands for an asset declaring multiple classes (RFC-009 §5.3, Issue #2958).
@@ -359,6 +379,9 @@ export class CommandResolver {
       Namespace.EXOCMD.term("CommandBinding_precondition"),
     );
 
+    // RFC-024 §4 Phase 2 — resolve visual style with fallback chain
+    const style = await this.loadLinkedStyle(subject, uid);
+
     return {
       id: uid,
       label,
@@ -370,7 +393,220 @@ export class CommandResolver {
       order: orderStr ? parseInt(orderStr, 10) : undefined,
       group: group ?? undefined,
       precondition: precondition ?? undefined,
+      style: style ?? undefined,
     };
+  }
+
+  /**
+   * Resolve a binding's visual style via the RFC-024 §4 Phase 2 fallback chain.
+   *
+   * Step 1 (preferred): follow `exocmd__CommandBinding_style` wikilink to a
+   * CommandBindingStyle asset and project all 7 properties.
+   *
+   * Step 2 (shorthand): if no style asset reference, read inline literal
+   * `exocmd__CommandBinding_variant` and synthesize a minimal style with
+   * only `variant` populated. Coerce via `String(v).trim().toLowerCase()`,
+   * whitelist via `COMMAND_VARIANT_VALUES`, drop with capped warning on miss.
+   *
+   * Returns `null` when neither source is present — caller treats as
+   * "delegate to UI-level group default" (Phase 0 `categoryDefaultVariant`).
+   *
+   * Strategy: split-query (separate `match()` calls per property), **not**
+   * SPARQL OPTIONAL — see RFC-024 §3 architectural principle.
+   */
+  private async loadLinkedStyle(
+    bindingSubject: IRI,
+    bindingUid: string,
+  ): Promise<CommandBindingStyleDefinition | null> {
+    // Step 1 — explicit style asset reference (preferred)
+    const styleRefTriples = await this.tripleStore.match(
+      bindingSubject,
+      Namespace.EXOCMD.term("CommandBinding_style"),
+      undefined,
+    );
+
+    if (styleRefTriples.length > 0) {
+      const ref = styleRefTriples[0].object;
+      let styleSubject: IRI | null = null;
+
+      if (ref instanceof IRI) {
+        styleSubject = ref;
+      } else if (ref instanceof Literal) {
+        const refUid = this.normalizeWikilink(ref.value);
+        styleSubject = await this.findSubjectByUID(refUid);
+      }
+
+      if (styleSubject) {
+        const fromAsset = await this.loadStyleAsset(styleSubject);
+        if (fromAsset) return fromAsset;
+      }
+      // Reference present but didn't yield a usable style asset — log + try inline
+      this.logger.warn(
+        this.capWarning(
+          `CommandBinding ${bindingUid}: style reference unresolved, falling back to inline variant`,
+        ),
+      );
+    }
+
+    // Step 2 — inline shorthand `CommandBinding_variant` literal
+    const inlineVariantRaw = await this.getLiteralValue(
+      bindingSubject,
+      Namespace.EXOCMD.term("CommandBinding_variant"),
+    );
+
+    if (inlineVariantRaw !== null) {
+      const variant = this.coerceVariant(inlineVariantRaw, bindingUid);
+      if (variant !== undefined) {
+        return {
+          id: `inline:${bindingUid}`,
+          label: "",
+          variant,
+          inline: true,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Project a CommandBindingStyle asset to a {@link CommandBindingStyleDefinition}.
+   * Invalid enum values are coerced and dropped with warning (RFC-024 §5).
+   * Returns `null` if the asset is missing the mandatory `Asset_uid` property.
+   */
+  private async loadStyleAsset(
+    subject: IRI,
+  ): Promise<CommandBindingStyleDefinition | null> {
+    const uid = await this.getLiteralValue(subject, Namespace.EXO.term("Asset_uid"));
+    if (!uid) return null;
+
+    const label =
+      (await this.getLiteralValue(subject, Namespace.EXO.term("Asset_label"))) ?? "";
+
+    const variantRaw = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("CommandBindingStyle_variant"),
+    );
+    const variant =
+      variantRaw !== null ? this.coerceVariant(variantRaw, uid) : undefined;
+
+    const showIconRaw = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("CommandBindingStyle_showIcon"),
+    );
+    const showIcon = this.coerceBoolean(showIconRaw);
+
+    const labelClassRaw = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("CommandBindingStyle_labelClass"),
+    );
+    const labelClass =
+      labelClassRaw !== null ? this.coerceLabelClass(labelClassRaw, uid) : undefined;
+
+    const ariaLabel = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("CommandBindingStyle_ariaLabel"),
+    );
+    const tooltip = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("CommandBindingStyle_tooltip"),
+    );
+    const keyboardShortcut = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("CommandBindingStyle_keyboardShortcut"),
+    );
+
+    const sourceRaw = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("CommandBindingStyle_source"),
+    );
+    const source =
+      sourceRaw !== null ? this.coerceStyleSource(sourceRaw, uid) : undefined;
+
+    return {
+      id: uid,
+      label,
+      variant,
+      showIcon,
+      labelClass,
+      ariaLabel: ariaLabel ?? undefined,
+      tooltip: tooltip ?? undefined,
+      keyboardShortcut: keyboardShortcut ?? undefined,
+      source,
+      inline: false,
+    };
+  }
+
+  /**
+   * Coerce raw input to a {@link CommandVariant} or warn and drop.
+   * RFC-024 §5: trim + lowercase + whitelist → never crash.
+   */
+  private coerceVariant(
+    raw: unknown,
+    contextUid: string,
+  ): CommandVariant | undefined {
+    if (raw == null) return undefined;
+    const normalized = String(raw).trim().toLowerCase();
+    if (normalized === "") return undefined;
+    if ((COMMAND_VARIANT_VALUES as readonly string[]).includes(normalized)) {
+      return normalized as CommandVariant;
+    }
+    this.logger.warn(
+      this.capWarning(
+        `CommandBindingStyle variant "${normalized}" not in whitelist [${COMMAND_VARIANT_VALUES.join(",")}]; dropped (asset ${contextUid})`,
+      ),
+    );
+    return undefined;
+  }
+
+  private coerceLabelClass(
+    raw: unknown,
+    contextUid: string,
+  ): LabelClass | undefined {
+    if (raw == null) return undefined;
+    const normalized = String(raw).trim().toLowerCase();
+    if (normalized === "") return undefined;
+    if ((LABEL_CLASS_VALUES as readonly string[]).includes(normalized)) {
+      return normalized as LabelClass;
+    }
+    this.logger.warn(
+      this.capWarning(
+        `CommandBindingStyle labelClass "${normalized}" not in whitelist [${LABEL_CLASS_VALUES.join(",")}]; dropped (asset ${contextUid})`,
+      ),
+    );
+    return undefined;
+  }
+
+  private coerceStyleSource(
+    raw: unknown,
+    contextUid: string,
+  ): StyleSource | undefined {
+    if (raw == null) return undefined;
+    const normalized = String(raw).trim().toLowerCase();
+    if (normalized === "") return undefined;
+    if ((STYLE_SOURCE_VALUES as readonly string[]).includes(normalized)) {
+      return normalized as StyleSource;
+    }
+    this.logger.warn(
+      this.capWarning(
+        `CommandBindingStyle source "${normalized}" not in whitelist [${STYLE_SOURCE_VALUES.join(",")}]; dropped (asset ${contextUid})`,
+      ),
+    );
+    return undefined;
+  }
+
+  /** Returns boolean for "true"/"false" (case-insensitive); undefined otherwise. */
+  private coerceBoolean(raw: string | null): boolean | undefined {
+    if (raw === null) return undefined;
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+    return undefined;
+  }
+
+  /** Cap warning messages at 200 chars per RFC-024 §5 logging policy. */
+  private capWarning(message: string): string {
+    return message.length <= 200 ? message : message.slice(0, 197) + "...";
   }
 
   private bindingMatches(

--- a/packages/exocortex/tests/unit/services/CommandResolver.style.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.style.test.ts
@@ -1,0 +1,534 @@
+/**
+ * CommandResolver — RFC-024 §4 Phase 2 binding-style resolution (T5.2).
+ *
+ * Coverage:
+ * - Step 1: explicit `CommandBinding_style` wikilink → CommandBindingStyle asset projection
+ * - Step 2: inline `CommandBinding_variant` shorthand → synthesized minimal style
+ * - Step 3: neither present → `style` is `undefined` (UI applies group-based fallback)
+ * - Edge-case matrix (parametrized): non-string, null, empty, unicode zero-width, casing
+ * - Coerce → warn (cap 200 chars) → drop (RFC-024 §5 — never crash)
+ * - Cache coherence: concurrent edit + invalidate → re-resolve picks up change
+ *
+ * Strategy: split-query SPARQL (separate `match()` calls per property), not OPTIONAL.
+ */
+
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+
+// -- Stub logger that records warnings for assertions --
+
+interface RecordingLogger extends ILogger {
+  readonly warnings: string[];
+}
+
+function makeRecordingLogger(): RecordingLogger {
+  const warnings: string[] = [];
+  return {
+    debug() {},
+    info() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
+    error() {},
+    warnings,
+  };
+}
+
+// -- Asset builders (mirrors patterns from CommandResolver.test.ts) --
+
+async function addGrounding(store: InMemoryTripleStore, uid: string): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(`Grounding ${uid}`)),
+    new Triple(subject, Namespace.EXOCMD.term("Grounding_type"), new Literal("property_delete")),
+    new Triple(subject, Namespace.EXOCMD.term("Grounding_targetProperty"), new Literal("ems__Effort_x")),
+  ]);
+}
+
+async function addCommand(store: InMemoryTripleStore, uid: string, groundingUid: string): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(`Command ${uid}`)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Command_grounding"),
+      new IRI(`obsidian://vault/${groundingUid}.md`),
+    ),
+  ]);
+}
+
+async function addStyleAsset(
+  store: InMemoryTripleStore,
+  opts: {
+    uid: string;
+    variant?: string;
+    showIcon?: string;
+    labelClass?: string;
+    ariaLabel?: string;
+    tooltip?: string;
+    keyboardShortcut?: string;
+    source?: string;
+  },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("CommandBindingStyle")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(`Style ${opts.uid}`)),
+  ];
+  const term = (local: string) => Namespace.EXOCMD.term(local);
+  if (opts.variant !== undefined)
+    triples.push(new Triple(subject, term("CommandBindingStyle_variant"), new Literal(opts.variant)));
+  if (opts.showIcon !== undefined)
+    triples.push(new Triple(subject, term("CommandBindingStyle_showIcon"), new Literal(opts.showIcon)));
+  if (opts.labelClass !== undefined)
+    triples.push(new Triple(subject, term("CommandBindingStyle_labelClass"), new Literal(opts.labelClass)));
+  if (opts.ariaLabel !== undefined)
+    triples.push(new Triple(subject, term("CommandBindingStyle_ariaLabel"), new Literal(opts.ariaLabel)));
+  if (opts.tooltip !== undefined)
+    triples.push(new Triple(subject, term("CommandBindingStyle_tooltip"), new Literal(opts.tooltip)));
+  if (opts.keyboardShortcut !== undefined)
+    triples.push(new Triple(subject, term("CommandBindingStyle_keyboardShortcut"), new Literal(opts.keyboardShortcut)));
+  if (opts.source !== undefined)
+    triples.push(new Triple(subject, term("CommandBindingStyle_source"), new Literal(opts.source)));
+  await store.addAll(triples);
+}
+
+interface BindingOpts {
+  uid: string;
+  commandUid: string;
+  targetClass: string;
+  styleRefUid?: string;
+  inlineVariant?: string;
+}
+
+async function addBinding(store: InMemoryTripleStore, opts: BindingOpts): Promise<IRI> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("CommandBinding")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(`Binding ${opts.uid}`)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("CommandBinding_command"),
+      new IRI(`obsidian://vault/${opts.commandUid}.md`),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("CommandBinding_targetClass"),
+      new Literal(opts.targetClass),
+    ),
+  ];
+  if (opts.styleRefUid !== undefined) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("CommandBinding_style"),
+        new IRI(`obsidian://vault/${opts.styleRefUid}.md`),
+      ),
+    );
+  }
+  if (opts.inlineVariant !== undefined) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("CommandBinding_variant"),
+        new Literal(opts.inlineVariant),
+      ),
+    );
+  }
+  await store.addAll(triples);
+  return subject;
+}
+
+// -- Tests --
+
+describe("CommandResolver — RFC-024 binding style resolution", () => {
+  const TARGET_CLASS = "ems__Task";
+  let store: InMemoryTripleStore;
+  let logger: RecordingLogger;
+  let resolver: CommandResolver;
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    logger = makeRecordingLogger();
+    resolver = new CommandResolver(store, logger);
+    await addGrounding(store, "gnd-1");
+    await addCommand(store, "cmd-1", "gnd-1");
+  });
+
+  describe("Step 1 — explicit style asset reference (preferred)", () => {
+    it("projects all 7 properties from CommandBindingStyle asset", async () => {
+      await addStyleAsset(store, {
+        uid: "style-success",
+        variant: "success",
+        showIcon: "true",
+        labelClass: "bold",
+        ariaLabel: "Mark Done",
+        tooltip: "Promote to Done",
+        keyboardShortcut: "Mod+Shift+D",
+        source: "vendor",
+      });
+      await addBinding(store, {
+        uid: "bind-1",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        styleRefUid: "style-success",
+      });
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.style).toEqual({
+        id: "style-success",
+        label: "Style style-success",
+        variant: "success",
+        showIcon: true,
+        labelClass: "bold",
+        ariaLabel: "Mark Done",
+        tooltip: "Promote to Done",
+        keyboardShortcut: "Mod+Shift+D",
+        source: "vendor",
+        inline: false,
+      });
+    });
+
+    it("style reference wins over inline variant when both present", async () => {
+      await addStyleAsset(store, { uid: "style-danger", variant: "danger" });
+      await addBinding(store, {
+        uid: "bind-2",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        styleRefUid: "style-danger",
+        inlineVariant: "primary",
+      });
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.style?.variant).toBe("danger");
+      expect(resolved.binding.style?.inline).toBe(false);
+    });
+
+    it("falls through to inline variant when style asset is unresolvable", async () => {
+      await addBinding(store, {
+        uid: "bind-3",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        // styleRefUid points to a non-existent asset path resolved as IRI;
+        // adding a binding with style ref to missing UID via Literal wikilink
+      });
+      // Inject a bare wikilink-literal style ref pointing at a non-existent uid
+      await store.addAll([
+        new Triple(
+          new IRI(`obsidian://vault/bind-3.md`),
+          Namespace.EXOCMD.term("CommandBinding_style"),
+          new Literal("[[does-not-exist]]"),
+        ),
+        new Triple(
+          new IRI(`obsidian://vault/bind-3.md`),
+          Namespace.EXOCMD.term("CommandBinding_variant"),
+          new Literal("warning"),
+        ),
+      ]);
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.style?.variant).toBe("warning");
+      expect(resolved.binding.style?.inline).toBe(true);
+      expect(logger.warnings.some((w) => /style reference unresolved/.test(w))).toBe(true);
+    });
+  });
+
+  describe("Step 2 — inline `CommandBinding_variant` shorthand", () => {
+    it.each([
+      ["primary"],
+      ["secondary"],
+      ["success"],
+      ["warning"],
+      ["danger"],
+      ["muted"],
+    ])("synthesizes minimal inline style for valid variant %p", async (variant) => {
+      await addBinding(store, {
+        uid: `bind-${variant}`,
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        inlineVariant: variant,
+      });
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.style).toEqual({
+        id: `inline:bind-${variant}`,
+        label: "",
+        variant,
+        inline: true,
+      });
+    });
+
+    it("coerces casing — uppercase, mixed-case, surrounding whitespace", async () => {
+      const cases: Array<[string, string]> = [
+        ["PRIMARY", "primary"],
+        ["  Success  ", "success"],
+        ["DaNgEr", "danger"],
+        ["\tmuted\n", "muted"],
+      ];
+      for (const [raw, expected] of cases) {
+        const subStore = new InMemoryTripleStore();
+        const subResolver = new CommandResolver(subStore, logger);
+        await addGrounding(subStore, "gnd-1");
+        await addCommand(subStore, "cmd-1", "gnd-1");
+        await addBinding(subStore, {
+          uid: "bind-coerce",
+          commandUid: "cmd-1",
+          targetClass: TARGET_CLASS,
+          inlineVariant: raw,
+        });
+        const [resolved] = await subResolver.resolveForAsset(
+          "obsidian://vault/asset-1.md",
+          TARGET_CLASS,
+        );
+        expect(resolved.binding.style?.variant).toBe(expected);
+      }
+    });
+  });
+
+  describe("Step 3 — fallback (neither style ref nor inline variant)", () => {
+    it("returns binding with `style` undefined when neither source present", async () => {
+      await addBinding(store, {
+        uid: "bind-fallback",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+      });
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.style).toBeUndefined();
+      expect(logger.warnings).toHaveLength(0);
+    });
+  });
+
+  describe("Edge-case matrix — invalid values coerce → warn → drop", () => {
+    // Each row exercises the resilience contract: never crash, log capped warning,
+    // emit `style: undefined` (falls through to UI group-default).
+    // Note: empty-string variant is impossible to inject — Literal rejects "" at
+    // construction. Frontmatter parsers replace empty values with null upstream;
+    // null is exercised separately via "Step 3 — fallback".
+    const invalidVariants: Array<[string, string]> = [
+      ["whitespace only", "   "],
+      ["unicode zero-width", "​primary‌"],
+      ["typo", "primry"],
+      ["unknown enum", "info"],
+      ["numeric string", "3"],
+      ["very long string", "x".repeat(500)],
+      ["null literal text", "null"],
+      ["yaml-style array", "[primary,danger]"],
+    ];
+
+    it.each(invalidVariants)(
+      "drops invalid inline variant (%s) without crashing",
+      async (_label, raw) => {
+        const subStore = new InMemoryTripleStore();
+        const subLogger = makeRecordingLogger();
+        const subResolver = new CommandResolver(subStore, subLogger);
+        await addGrounding(subStore, "gnd-1");
+        await addCommand(subStore, "cmd-1", "gnd-1");
+        await addBinding(subStore, {
+          uid: "bind-bad",
+          commandUid: "cmd-1",
+          targetClass: TARGET_CLASS,
+          inlineVariant: raw,
+        });
+
+        const result = await subResolver.resolveForAsset(
+          "obsidian://vault/asset-1.md",
+          TARGET_CLASS,
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0].binding.style).toBeUndefined();
+        // empty/whitespace-only short-circuit before whitelist check — no warn
+        const expectsWarning = raw.trim().length > 0;
+        if (expectsWarning) {
+          expect(subLogger.warnings.length).toBeGreaterThan(0);
+          for (const w of subLogger.warnings) {
+            expect(w.length).toBeLessThanOrEqual(200);
+          }
+        }
+      },
+    );
+
+    it("drops invalid labelClass and source on style asset, keeps valid variant", async () => {
+      await addStyleAsset(store, {
+        uid: "style-mixed",
+        variant: "primary",
+        labelClass: "italic", // not in whitelist
+        source: "external", // not in whitelist
+      });
+      await addBinding(store, {
+        uid: "bind-mixed",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        styleRefUid: "style-mixed",
+      });
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.style?.variant).toBe("primary");
+      expect(resolved.binding.style?.labelClass).toBeUndefined();
+      expect(resolved.binding.style?.source).toBeUndefined();
+      expect(logger.warnings.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("coerces showIcon to boolean only for true/false (case-insensitive)", async () => {
+      await addStyleAsset(store, { uid: "style-icon-on", variant: "primary", showIcon: "TRUE" });
+      await addStyleAsset(store, { uid: "style-icon-off", variant: "primary", showIcon: "False" });
+      await addStyleAsset(store, { uid: "style-icon-bad", variant: "primary", showIcon: "yes" });
+      await addBinding(store, { uid: "bind-on", commandUid: "cmd-1", targetClass: "C-on", styleRefUid: "style-icon-on" });
+      await addBinding(store, { uid: "bind-off", commandUid: "cmd-1", targetClass: "C-off", styleRefUid: "style-icon-off" });
+      await addBinding(store, { uid: "bind-bad", commandUid: "cmd-1", targetClass: "C-bad", styleRefUid: "style-icon-bad" });
+
+      const [on] = await resolver.resolveForAsset("a", "C-on");
+      const [off] = await resolver.resolveForAsset("a", "C-off");
+      const [bad] = await resolver.resolveForAsset("a", "C-bad");
+
+      expect(on.binding.style?.showIcon).toBe(true);
+      expect(off.binding.style?.showIcon).toBe(false);
+      expect(bad.binding.style?.showIcon).toBeUndefined();
+    });
+  });
+
+  describe("Cache coherence — invalidate → re-resolve", () => {
+    it("picks up style asset edit after invalidateCache()", async () => {
+      await addStyleAsset(store, { uid: "style-mut", variant: "secondary" });
+      await addBinding(store, {
+        uid: "bind-mut",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        styleRefUid: "style-mut",
+      });
+
+      const [first] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+      expect(first.binding.style?.variant).toBe("secondary");
+
+      // Concurrent edit: replace variant on the style asset
+      const styleSubject = new IRI("obsidian://vault/style-mut.md");
+      await store.remove(
+        new Triple(
+          styleSubject,
+          Namespace.EXOCMD.term("CommandBindingStyle_variant"),
+          new Literal("secondary"),
+        ),
+      );
+      await store.add(
+        new Triple(
+          styleSubject,
+          Namespace.EXOCMD.term("CommandBindingStyle_variant"),
+          new Literal("danger"),
+        ),
+      );
+
+      // Without invalidate, cache still serves stale value
+      const [stale] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+      expect(stale.binding.style?.variant).toBe("secondary");
+
+      // After invalidate, fresh read sees the edit
+      resolver.invalidateCache();
+      const [fresh] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+      expect(fresh.binding.style?.variant).toBe("danger");
+    });
+
+    it("multi-resolve cache invalidates across class permutations", async () => {
+      await addStyleAsset(store, { uid: "style-multi", variant: "primary" });
+      await addBinding(store, {
+        uid: "bind-multi",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        styleRefUid: "style-multi",
+      });
+
+      const [first] = await resolver.resolveForAssetMulti(
+        "obsidian://vault/asset-1.md",
+        [TARGET_CLASS, "exo__Asset"],
+      );
+      expect(first.binding.style?.variant).toBe("primary");
+
+      const styleSubject = new IRI("obsidian://vault/style-multi.md");
+      await store.remove(
+        new Triple(
+          styleSubject,
+          Namespace.EXOCMD.term("CommandBindingStyle_variant"),
+          new Literal("primary"),
+        ),
+      );
+      await store.add(
+        new Triple(
+          styleSubject,
+          Namespace.EXOCMD.term("CommandBindingStyle_variant"),
+          new Literal("muted"),
+        ),
+      );
+      resolver.invalidateCache();
+
+      const [updated] = await resolver.resolveForAssetMulti(
+        "obsidian://vault/asset-1.md",
+        [TARGET_CLASS, "exo__Asset"],
+      );
+      expect(updated.binding.style?.variant).toBe("muted");
+    });
+  });
+
+  describe("Default constructor — no logger", () => {
+    it("works without explicit logger (NullLogger fallback)", async () => {
+      const silentResolver = new CommandResolver(store);
+      await addBinding(store, {
+        uid: "bind-silent",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        inlineVariant: "not-a-variant",
+      });
+
+      // Must not throw despite invalid variant
+      const result = await silentResolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].binding.style).toBeUndefined();
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -169,7 +169,7 @@ export default class ExocortexPlugin extends Plugin {
       // RFC-009: Wire Dynamic Command System services BEFORE renderer
       // Construct manually (not via tsyringe) because they need the live triple store
       const tripleStore = this.sparql.getTripleStore();
-      this.commandResolver = new CommandResolver(tripleStore);
+      this.commandResolver = new CommandResolver(tripleStore, this.logger);
       this.preconditionEvaluator = new PreconditionEvaluator(tripleStore);
       this.serviceRegistry = new ServiceRegistry();
       const obsidianFs = new ObsidianFileSystemAdapter(this.app.vault);


### PR DESCRIPTION
## Summary

Implements RFC-024 §4 Phase 2 task **T5.2** — `CommandResolver` reads `exocmd__CommandBinding_style` wikilinks (preferred) and `exocmd__CommandBinding_variant` inline shorthand (fallback) and projects a resolved `style` onto every `CommandBindingDefinition`.

Resolution fallback chain (RFC-024 §5):
1. **Style asset reference** → load `exocmd__CommandBindingStyle` and project all 7 properties (`variant`, `showIcon`, `labelClass`, `ariaLabel`, `tooltip`, `keyboardShortcut`, `source`).
2. **Inline shorthand** → synthesize minimal style with only `variant` set (`id="inline:<binding-uid>"`, `inline=true`).
3. **Neither present** → `style` stays `undefined`; UI applies group-based default (Phase 0 `categoryDefaultVariant`).

Resilience (RFC-024 §5 — never crash):
- Coerce: `String(v).trim().toLowerCase()`
- Whitelist via `COMMAND_VARIANT_VALUES` / `LABEL_CLASS_VALUES` / `STYLE_SOURCE_VALUES`
- Drop with warning capped at 200 chars on miss

Strategy: split-query (separate `match()` calls per property), **not** SPARQL OPTIONAL.

`CommandResolver` constructor now accepts an optional `ILogger` (defaults to `NullLogger`); `ExocortexPlugin` wires the existing plugin logger.

## Acceptance Criteria

- [x] CommandResolver handles style wikilink resolution (Step 1 + Step 2 + Step 3)
- [x] Parametrized edge-case matrix test (whitespace / unicode zero-width / typo / unknown enum / numeric / very-long / yaml-array / null-text / casing variants)
- [x] Cache coherence: concurrent edit → invalidate → re-resolve (single + multi cache)

## Test plan

- [x] `CommandResolver.style.test.ts` — 24 cases pass (split-query + projection + fallback + edge-case matrix + cache coherence + NullLogger fallback)
- [x] Existing `CommandResolver.test.ts` — 48 cases unchanged + green
- [x] `npm run check:types` — clean
- [x] `npm run lint` — no new warnings (2 pre-existing in unrelated files)
- [x] Full unit suite — green (4864 obsidian-plugin tests + 1696 CLI integration tests + 152 component tests)

## Linked

- RFC-024: `inbox__ExoAssistantKnowledge` `83d5a78e-8ba1-436d-b97f-6cf1cf5add74`
- Parent task UUID: `4a037cf0-0ee0-4a8c-b3c8-733c1cd13a99`
- Phase 5 parent: `5ecac473-ef58-4eba-a6db-de75304b0ad6`
- Predecessor: T5.1 `80dc32bb-ba83-4f49-ab12-cc2cca6d69eb` (Done — `CommandBindingStyleEnums`)