### PR TITLE
feat(rfc-024): ActionButton icon rendering via setIcon + useRef (T5.3)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -190,9 +190,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     { id: "maintenance", title: "Maintenance", collapsedByDefault: true },
   ];
 
-  private async resolveVisibleCommands(
-    context: ButtonBuilderContext,
-  ): Promise<{
+  private async resolveVisibleCommands(context: ButtonBuilderContext): Promise<{
     visibleCommands: ResolvedCommand[];
     subjectIRI: string;
   } | null> {
@@ -267,10 +265,22 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     const { command, binding } = rc;
     const variant = resolveVariantForGroup(binding.group);
 
+    // RFC-024 §4 Phase 2 — T5.3: render `Command_icon` by default. The
+    // resolved `binding.style.showIcon` (populated in T5.2 by CommandResolver)
+    // can opt out per-binding; absence of style or `showIcon=true` keeps the
+    // existing icon — covers the 44 starter-kit bindings that already declare
+    // `Command_icon` in RDF without any user configuration.
+    const showIcon = binding.style?.showIcon !== false;
+    const icon =
+      showIcon && command.icon && command.icon.length > 0
+        ? command.icon
+        : undefined;
+
     return {
       id: `dynamic-cmd-${command.id}`,
       label: command.name,
       variant,
+      icon,
       visible: true,
       onClick: async () => {
         await this.handleClick(rc, targetIRI, filePath, app, logger, refresh);
@@ -363,9 +373,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
    *
    * If `exo__Asset` is already declared explicitly, it is not duplicated.
    */
-  private extractAssetClasses(
-    metadata: Record<string, unknown>,
-  ): string[] {
+  private extractAssetClasses(metadata: Record<string, unknown>): string[] {
     const raw = metadata["exo__Instance_class"];
     const classes: string[] = [];
 

--- a/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { setIcon } from "obsidian";
 
 /**
  * Semantic variants for action buttons. The `muted` variant (RFC-024 Phase 0)
@@ -22,6 +23,19 @@ export interface ActionButton {
   onClick: () => void | Promise<void>;
   variant?: ActionButtonVariant;
   visible?: boolean;
+  /**
+   * Optional Lucide icon name (RFC-024 §4 Phase 2 — T5.3).
+   *
+   * When set, the button renders an SVG icon to the left of the label using
+   * Obsidian's `setIcon` helper, which writes the bundled Lucide SVG into the
+   * supplied element. The DOM-mutation bridge is implemented inside
+   * `ActionButtonsGroup` via `useRef` + `useEffect`, so callers may simply
+   * propagate `command.icon` from the resolved binding.
+   *
+   * No-op when undefined or empty — preserves the no-icon baseline established
+   * before T5.3.
+   */
+  icon?: string;
 }
 
 /**
@@ -46,6 +60,56 @@ export interface ButtonGroup {
 export interface ActionButtonsGroupProps {
   groups: ButtonGroup[];
 }
+
+/**
+ * Renders a single action button.
+ *
+ * RFC-024 §4 Phase 2 — T5.3: when `button.icon` is set, an icon container is
+ * mounted before the label and `setIcon(ref, iconName)` is invoked from a
+ * `useEffect` whose cleanup empties the container before the next icon swap
+ * (and on unmount). This keeps the React/Obsidian boundary explicit — Obsidian
+ * mutates the DOM, React owns the container reference and lifecycle.
+ *
+ * The Obsidian `setIcon` helper writes the Lucide SVG into the supplied
+ * element. We intentionally do not memoize on `button.icon`: a fresh render
+ * with the same icon name is harmless (cleanup empties the host element first)
+ * and keeps the swap path identical to the mount path.
+ */
+const ActionButtonView: React.FC<{ button: ActionButton }> = ({ button }) => {
+  const iconRef = useRef<HTMLSpanElement | null>(null);
+
+  useEffect(() => {
+    const host = iconRef.current;
+    if (host === null) return;
+    if (!button.icon) return;
+    setIcon(host, button.icon);
+    return () => {
+      // Drop the SVG before the next icon name takes effect (or on unmount)
+      // so we do not stack icons under DOM mutation in development StrictMode.
+      while (host.firstChild) host.removeChild(host.firstChild);
+    };
+  }, [button.icon]);
+
+  return (
+    <button
+      className={`exocortex-action-button exocortex-action-button--${button.variant || "secondary"}`}
+      onClick={async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        await button.onClick();
+      }}
+    >
+      {button.icon ? (
+        <span
+          ref={iconRef}
+          className="exocortex-action-button-icon"
+          aria-hidden="true"
+        />
+      ) : null}
+      <span className="exocortex-action-button-label">{button.label}</span>
+    </button>
+  );
+};
 
 /**
  * ActionButtonsGroup Component
@@ -119,17 +183,7 @@ export const ActionButtonsGroup: React.FC<ActionButtonsGroupProps> = ({
                 id={`exocortex-button-group-body-${group.id}`}
               >
                 {group.buttons.map((button) => (
-                  <button
-                    key={button.id}
-                    className={`exocortex-action-button exocortex-action-button--${button.variant || "secondary"}`}
-                    onClick={async (e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      await button.onClick();
-                    }}
-                  >
-                    {button.label}
-                  </button>
+                  <ActionButtonView key={button.id} button={button} />
                 ))}
               </div>
             )}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -1114,6 +1114,35 @@
 }
 
 /* ----------------------------------------------------------------------------
+   Action button icon (RFC-024 §4 Phase 2 — T5.3)
+   ----------------------------------------------------------------------------
+   Obsidian's `setIcon` injects an inline `<svg>` into the host element. We
+   constrain the SVG to 16px (button default) and leave a 6px gap to the label.
+   The compact label class (T5.4) overrides the icon size to 14px so the icon
+   stays proportional to the smaller label glyphs. */
+.exocortex-action-button-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 6px;
+  width: 16px;
+  height: 16px;
+  line-height: 0;
+  flex-shrink: 0;
+}
+
+.exocortex-action-button-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.exocortex-action-button--label-compact .exocortex-action-button-icon,
+.exocortex-action-button--label-compact .exocortex-action-button-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* ----------------------------------------------------------------------------
    Layer 2 intent tokens (RFC-024 Phase 1)
    ----------------------------------------------------------------------------
    Exocortex semantic tokens bridge Obsidian theme vars (Layer 1) with

--- a/packages/obsidian-plugin/tests/component/ActionButtonsGroup.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/ActionButtonsGroup.spec.tsx
@@ -404,4 +404,67 @@ test.describe("ActionButtonsGroup Component", () => {
     const buttons = component.locator("button");
     await expect(buttons).toHaveCount(3);
   });
+
+  // RFC-024 §4 Phase 2 — T5.3: ActionButton icon rendering via setIcon + useRef.
+  test("should render icon via setIcon when button.icon is set", async ({
+    mount,
+  }) => {
+    const groups: ButtonGroup[] = [
+      {
+        id: "with-icon",
+        title: "With Icon",
+        buttons: [
+          {
+            id: "btn-icon",
+            label: "Mark Done",
+            variant: "success",
+            icon: "check",
+            visible: true,
+            onClick: async () => {},
+          },
+        ],
+      },
+    ];
+
+    const component = await mount(<ActionButtonsGroup groups={groups} />);
+
+    const iconHost = component.locator(".exocortex-action-button-icon");
+    await expect(iconHost).toHaveCount(1);
+    // Mock `setIcon` writes data-* attributes on the host element.
+    await expect(iconHost).toHaveAttribute("data-icon-set", "true");
+    await expect(iconHost).toHaveAttribute("data-icon-name", "check");
+    await expect(iconHost).toHaveAttribute("aria-hidden", "true");
+
+    // Label still rendered next to the icon.
+    const label = component.locator(".exocortex-action-button-label");
+    await expect(label).toHaveText("Mark Done");
+  });
+
+  test("should not render icon container when button.icon is undefined", async ({
+    mount,
+  }) => {
+    const groups: ButtonGroup[] = [
+      {
+        id: "no-icon",
+        title: "No Icon",
+        buttons: [
+          {
+            id: "btn-no-icon",
+            label: "Plain",
+            variant: "secondary",
+            visible: true,
+            onClick: async () => {},
+          },
+        ],
+      },
+    ];
+
+    const component = await mount(<ActionButtonsGroup groups={groups} />);
+
+    const iconHost = component.locator(".exocortex-action-button-icon");
+    await expect(iconHost).toHaveCount(0);
+
+    const label = component.locator(".exocortex-action-button-label");
+    await expect(label).toHaveText("Plain");
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -360,6 +360,87 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
   });
 
+  // RFC-024 §4 Phase 2 — T5.3: Command_icon projection to ActionButton.
+  describe("icon projection (RFC-024 T5.3)", () => {
+    it("should project command.icon to button.icon when style.showIcon is unset (default)", async () => {
+      const rc = createResolvedCommand({
+        name: "Mark done",
+        icon: "check",
+      });
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].icon).toBe("check");
+    });
+
+    it("should project icon when binding.style.showIcon is explicitly true", async () => {
+      const rc = createResolvedCommand(
+        { name: "Mark done", icon: "check" },
+        {
+          style: {
+            id: "style-1",
+            label: "Default",
+            showIcon: true,
+            inline: false,
+          },
+        },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].icon).toBe("check");
+    });
+
+    it("should suppress icon when binding.style.showIcon is false", async () => {
+      const rc = createResolvedCommand(
+        { name: "Mark done", icon: "check" },
+        {
+          style: {
+            id: "style-1",
+            label: "No icon",
+            showIcon: false,
+            inline: false,
+          },
+        },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].icon).toBeUndefined();
+    });
+
+    it("should leave icon undefined when command has no icon", async () => {
+      const rc = createResolvedCommand({ name: "No-icon cmd" });
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].icon).toBeUndefined();
+    });
+
+    it("should treat empty string icon as no icon", async () => {
+      const rc = createResolvedCommand({ name: "Empty icon", icon: "" });
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].icon).toBeUndefined();
+    });
+  });
+
   describe("button onClick", () => {
     it("should execute grounding on click", async () => {
       const rc = createResolvedCommand({ name: "Execute me" });


### PR DESCRIPTION
## Summary
- Project the resolved `Command_icon` onto `ActionButton.icon`, honouring the per-binding `style.showIcon` override populated by CommandResolver in T5.2 (#2966).
- Bridge React → Obsidian `setIcon` through `useRef` + `useEffect`. Cleanup empties the host element so re-renders / icon swaps do not stack SVGs (StrictMode-safe).
- CSS sizes the icon to 16px (button default) with a compact 14px override placeholder for the upcoming T5.4 `labelClass`.
- All 44 starter-kit bindings that already declare `Command_icon` in RDF light up automatically.

## Coverage
- 5 new unit tests on the projection rules (icon present/absent, `showIcon` true/false, empty string).
- 2 new component tests asserting the DOM bridge (icon host marked by mock `setIcon`, label still renders) and the absent-icon baseline.
- Existing 16 visual-snapshot tests remain green — the `<span>` label wrapper does not perturb layout when no icon is set.

## RFC reference
- RFC-024 (`83d5a78e-8ba1-436d-b97f-6cf1cf5add74`) §4 Phase 2 — task `3fb87f1c-a8b7-4f9a-b07e-9c3f82fd2693`.
- Predecessor: PR #2966 (T5.2 — CommandResolver style fallback chain, v15.128.0).

## Test plan
- [x] `npm run check:types`
- [x] `npm run lint`
- [x] `npx jest packages/obsidian-plugin/tests/unit/presentation` — 904 tests pass
- [x] `npx playwright test ActionButtonsGroup` — 12 functional + 16 visual tests pass
- [ ] CI green (13 required checks)
- [ ] Auto-release publishes new minor