### PR TITLE
feat(rfc-024): FileExplorerIconPatch — DOM overlay for class icons (T7.1)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -63,6 +63,7 @@ import { PropertiesLinkPatch } from "./presentation/properties/PropertiesLinkPat
 import { PropertiesUidCopyPatch } from "./presentation/properties/PropertiesUidCopyPatch";
 import { PropertiesLabelPatch } from "./presentation/properties/PropertiesLabelPatch";
 import { FileExplorerLabelPatch } from "./presentation/fileexplorer/FileExplorerLabelPatch";
+import { FileExplorerIconPatch } from "./presentation/fileexplorer/FileExplorerIconPatch";
 import { ReadingModeEnforcer } from "./presentation/reading-mode/ReadingModeEnforcer";
 import { BodyLinkPatch } from "./presentation/body/BodyLinkPatch";
 import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
@@ -121,6 +122,7 @@ export default class ExocortexPlugin extends Plugin {
   private propertiesUidCopyPatch!: PropertiesUidCopyPatch;
   private propertiesLabelPatch!: PropertiesLabelPatch;
   private fileExplorerLabelPatch!: FileExplorerLabelPatch;
+  private fileExplorerIconPatch!: FileExplorerIconPatch;
   private readingModeEnforcer!: ReadingModeEnforcer;
   private graphViewPatch!: GraphViewPatch;
   private fileLogChannel!: FileLogChannel;
@@ -665,6 +667,23 @@ export default class ExocortexPlugin extends Plugin {
         500,
       );
 
+      // RFC-024 Phase 4 — File Explorer icons (DOM overlay, sibling to
+      // FileExplorerLabelPatch). Renders Lucide icons resolved via
+      // ThemeResolver from `exo__Layout_icon` for class-bearing notes.
+      this.fileExplorerIconPatch = new FileExplorerIconPatch(
+        this,
+        this.themeResolver,
+      );
+      if (this.settings.showIconsInFileExplorer) {
+        this.timerManager.setTimeout(
+          "file-explorer-icon-patch",
+          () => {
+            this.fileExplorerIconPatch.enable();
+          },
+          500,
+        );
+      }
+
       // Initialize Reading Mode enforcer.
       // Obsidian's layout rendering path is Reading Mode only; new leaves open
       // in Live Preview by default, so first-time users see "nothing happens"
@@ -834,6 +853,11 @@ export default class ExocortexPlugin extends Plugin {
     // Cleanup File Explorer readable-label patch
     if (this.fileExplorerLabelPatch) {
       this.fileExplorerLabelPatch.cleanup();
+    }
+
+    // Cleanup File Explorer icon patch (RFC-024 Phase 4)
+    if (this.fileExplorerIconPatch) {
+      this.fileExplorerIconPatch.cleanup();
     }
 
     // Cleanup Body link patch

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -115,6 +115,13 @@ export interface ExocortexSettings {
    * authors a Layout.
    */
   enableExoLayoutRenderer: boolean;
+  /**
+   * RFC-024 Phase 4 — render Lucide icons next to File Explorer rows whose
+   * frontmatter declares `exo__Instance_class` and whose resolved
+   * `exo__Layout_icon` is non-null. DOM overlay pattern (sibling to
+   * `FileExplorerLabelPatch`). Set to `false` to opt out.
+   */
+  showIconsInFileExplorer: boolean;
   [key: string]: unknown;
 }
 
@@ -137,4 +144,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   autoReadingModeForExocortexAssets: true,
   enableRelationColumnSetResolver: true,
   enableExoLayoutRenderer: true,
+  showIconsInFileExplorer: true,
 };

--- a/packages/obsidian-plugin/src/presentation/fileexplorer/FileExplorerIconPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/fileexplorer/FileExplorerIconPatch.ts
@@ -1,0 +1,212 @@
+import { Plugin, TFile, setIcon } from "obsidian";
+import type { ThemeResolver } from "../../application/services/ThemeResolver";
+
+/**
+ * FileExplorerIconPatch — RFC-024 §4 Phase 4. Renders a Lucide icon next to
+ * each Obsidian File Explorer row whose underlying note declares
+ * `exo__Instance_class`, when the resolved `exo__Layout_icon` is non-null.
+ *
+ * Strategy: DOM overlay (mirrors the proven `FileExplorerLabelPatch` pattern).
+ * A sibling `<span class="exo-file-explorer-icon">` is prepended inside the
+ * `.nav-file-title` element, before `.nav-file-title-content`. We never mutate
+ * the original DOM children — Obsidian re-renders the row on rename/refresh,
+ * and our MutationObserver re-applies the overlay on every such re-render.
+ *
+ * Trigger: frontmatter has `exo__Instance_class` AND `ThemeResolver.resolveIcon`
+ * returns a non-empty string for the first class. Without an icon resolution
+ * we leave the row alone.
+ *
+ * Co-existence with the Iconize community plugin (RFC-024 §8): if any node in
+ * the row already carries an Iconize-injected icon class, we skip — Iconize
+ * wins by default.
+ */
+
+const PATCHED_ATTR = "data-exo-fe-icon-patched";
+const OVERLAY_SPAN_CLASS = "exo-file-explorer-icon";
+const ICONIZE_MARKERS = [
+  "obsidian-icon-folder-icon",
+  "iconize-icon",
+];
+
+interface PatchRecord {
+  titleEl: HTMLElement;
+  overlay: HTMLSpanElement;
+}
+
+export class FileExplorerIconPatch {
+  private app: Plugin["app"];
+  private plugin: Plugin;
+  private themeResolver: ThemeResolver;
+  private observer: MutationObserver | null = null;
+  private enabled = false;
+  private patched: PatchRecord[] = [];
+
+  constructor(plugin: Plugin, themeResolver: ThemeResolver) {
+    this.plugin = plugin;
+    this.app = plugin.app;
+    this.themeResolver = themeResolver;
+  }
+
+  enable(): void {
+    if (this.enabled) return;
+    this.enabled = true;
+
+    this.patchAll();
+    this.setupObserver();
+
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("changed", () => {
+        this.patchAll();
+      }),
+    );
+
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("resolved", () => {
+        this.restoreAll();
+        this.patchAll();
+      }),
+    );
+
+    this.plugin.registerEvent(
+      this.app.workspace.on("layout-change", () => {
+        setTimeout(() => this.patchAll(), 100);
+      }),
+    );
+  }
+
+  disable(): void {
+    if (!this.enabled) return;
+    this.enabled = false;
+
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+
+    this.restoreAll();
+  }
+
+  cleanup(): void {
+    this.disable();
+  }
+
+  private patchAll(): void {
+    if (!this.enabled) return;
+    const titles = document.getElementsByClassName("nav-file-title");
+    for (const title of Array.from(titles)) {
+      if (title instanceof HTMLElement) this.patchTitle(title);
+    }
+  }
+
+  private patchTitle(titleEl: HTMLElement): void {
+    if (titleEl.getAttribute(PATCHED_ATTR) === "true") return;
+
+    const dataPath = titleEl.getAttribute("data-path");
+    if (!dataPath) return;
+
+    const abstractFile = this.app.vault.getAbstractFileByPath(dataPath);
+    if (!abstractFile || !(abstractFile instanceof TFile)) return;
+
+    const cache = this.app.metadataCache.getFileCache(abstractFile);
+    const fm = cache?.frontmatter;
+    if (!fm) return;
+
+    const instanceClass = fm["exo__Instance_class"];
+    const firstClass = this.firstClassRef(instanceClass);
+    if (!firstClass) return;
+
+    const iconName = this.themeResolver.resolveIcon(firstClass);
+    if (!iconName) return;
+
+    if (this.hasIconizeOverlay(titleEl)) return;
+
+    const contentEl = titleEl.querySelector<HTMLElement>(
+      ".nav-file-title-content",
+    );
+
+    const overlay = document.createElement("span");
+    overlay.className = OVERLAY_SPAN_CLASS;
+    overlay.setAttribute("data-exo-source-path", dataPath);
+    overlay.setAttribute("aria-hidden", "true");
+
+    try {
+      setIcon(overlay, iconName);
+    } catch {
+      // Unknown Lucide icon name — skip silently rather than crash the row.
+      return;
+    }
+
+    if (contentEl) {
+      titleEl.insertBefore(overlay, contentEl);
+    } else {
+      titleEl.appendChild(overlay);
+    }
+    titleEl.setAttribute(PATCHED_ATTR, "true");
+
+    this.patched.push({ titleEl, overlay });
+  }
+
+  private setupObserver(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+
+    this.observer = new MutationObserver((mutations) => {
+      if (!this.enabled) return;
+
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (!(node instanceof HTMLElement)) continue;
+
+          if (node.classList?.contains("nav-file-title")) {
+            this.patchTitle(node);
+          } else {
+            const titles = node.getElementsByClassName("nav-file-title");
+            for (const title of Array.from(titles)) {
+              if (title instanceof HTMLElement) this.patchTitle(title);
+            }
+          }
+        }
+      }
+    });
+
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  private restoreAll(): void {
+    for (const record of this.patched) {
+      try {
+        record.overlay.remove();
+        record.titleEl.removeAttribute(PATCHED_ATTR);
+      } catch {
+        // Best-effort restore.
+      }
+    }
+    this.patched = [];
+  }
+
+  private firstClassRef(value: unknown): string | null {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed ? trimmed : null;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === "string" && item.trim()) {
+          return item.trim();
+        }
+      }
+    }
+    return null;
+  }
+
+  private hasIconizeOverlay(titleEl: HTMLElement): boolean {
+    for (const marker of ICONIZE_MARKERS) {
+      if (titleEl.querySelector(`.${marker}`)) return true;
+    }
+    return false;
+  }
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6040,3 +6040,21 @@
   line-height: var(--line-height-tight);
   color: inherit;
 }
+
+/* FileExplorerIconPatch (RFC-024 Phase 4) — Lucide icon prepended to nav rows */
+.nav-file-title .exo-file-explorer-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--icon-s, 16px);
+  height: var(--icon-s, 16px);
+  margin-right: var(--size-2-2, 4px);
+  flex-shrink: 0;
+  color: var(--icon-color, currentColor);
+  vertical-align: middle;
+}
+
+.nav-file-title .exo-file-explorer-icon svg {
+  width: 100%;
+  height: 100%;
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerIconPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerIconPatch.test.ts
@@ -1,0 +1,315 @@
+jest.mock("obsidian", () => {
+  class FakeTFileCtor {
+    path: string;
+    basename: string;
+    extension: string;
+    constructor(path: string) {
+      this.path = path;
+      const name = path.split("/").pop() || path;
+      this.basename = name.replace(/\.md$/, "");
+      this.extension = "md";
+    }
+  }
+  return {
+    Plugin: class {},
+    TFile: FakeTFileCtor,
+    Notice: jest.fn(),
+    setIcon: jest.fn((el: HTMLElement, name: string) => {
+      el.setAttribute("data-lucide", name);
+    }),
+  };
+});
+
+import { FileExplorerIconPatch } from "../../../../src/presentation/fileexplorer/FileExplorerIconPatch";
+import { ThemeResolver } from "../../../../src/application/services/ThemeResolver";
+import { TFile as ObsidianTFile, setIcon as obsidianSetIcon } from "obsidian";
+
+const FakeTFileCtor = ObsidianTFile as unknown as new (path: string) => {
+  path: string;
+  basename: string;
+  extension: string;
+};
+
+describe("FileExplorerIconPatch", () => {
+  const TASK_PATH = "03 Knowledge/task-uuid.md";
+  const PROJECT_PATH = "03 Knowledge/project-uuid.md";
+  const NON_EXOCORTEX_PATH = "03 Knowledge/Random.md";
+  const NO_ICON_PATH = "03 Knowledge/no-icon.md";
+
+  let patch: FileExplorerIconPatch;
+  let mockPlugin: any;
+  let mockApp: any;
+  let navContainer: HTMLElement;
+  let frontmatters: Record<string, any>;
+  let filesByPath: Record<string, any>;
+  let themeResolver: ThemeResolver;
+
+  function createNavFileTitle(path: string): HTMLElement {
+    const titleEl = document.createElement("div");
+    titleEl.className = "nav-file-title";
+    titleEl.setAttribute("data-path", path);
+
+    const contentEl = document.createElement("div");
+    contentEl.className = "nav-file-title-content";
+    contentEl.textContent = (path.split("/").pop() || path).replace(
+      /\.md$/,
+      "",
+    );
+    titleEl.appendChild(contentEl);
+
+    return titleEl;
+  }
+
+  beforeEach(() => {
+    navContainer = document.createElement("div");
+    navContainer.className = "nav-files-container";
+    document.body.appendChild(navContainer);
+
+    frontmatters = {
+      [TASK_PATH]: {
+        exo__Instance_class: ["[[ems__Task]]"],
+        exo__Asset_label: "Task A",
+      },
+      [PROJECT_PATH]: {
+        exo__Instance_class: ["[[ems__Project]]"],
+        exo__Asset_label: "Project A",
+      },
+      [NON_EXOCORTEX_PATH]: { tags: ["misc"] },
+      [NO_ICON_PATH]: {
+        exo__Instance_class: ["[[ems__UnknownClass]]"],
+      },
+    };
+    filesByPath = {
+      [TASK_PATH]: new FakeTFileCtor(TASK_PATH),
+      [PROJECT_PATH]: new FakeTFileCtor(PROJECT_PATH),
+      [NON_EXOCORTEX_PATH]: new FakeTFileCtor(NON_EXOCORTEX_PATH),
+      [NO_ICON_PATH]: new FakeTFileCtor(NO_ICON_PATH),
+    };
+
+    mockApp = {
+      workspace: { on: jest.fn().mockReturnValue({ id: "evt" }) },
+      metadataCache: {
+        on: jest.fn().mockReturnValue({ id: "evt" }),
+        getFileCache: jest.fn().mockImplementation((file: any) => {
+          const fm = frontmatters[file.path];
+          return fm ? { frontmatter: fm } : null;
+        }),
+      },
+      vault: {
+        getAbstractFileByPath: jest
+          .fn()
+          .mockImplementation((p: string) => filesByPath[p] ?? null),
+      },
+    };
+
+    mockPlugin = { app: mockApp, registerEvent: jest.fn() };
+
+    themeResolver = new ThemeResolver({
+      layoutProvider: (cls: string) => {
+        if (cls === "ems__Task") {
+          return {
+            accentColor: null,
+            icon: "check-square",
+            labelTypography: null,
+          };
+        }
+        if (cls === "ems__Project") {
+          return {
+            accentColor: null,
+            icon: "folder-kanban",
+            labelTypography: null,
+          };
+        }
+        return null;
+      },
+    });
+
+    patch = new FileExplorerIconPatch(mockPlugin, themeResolver);
+  });
+
+  afterEach(() => {
+    patch.cleanup();
+    jest.clearAllMocks();
+    if (navContainer.parentNode) {
+      navContainer.parentNode.removeChild(navContainer);
+    }
+  });
+
+  describe("enable", () => {
+    it("registers metadataCache (changed + resolved) and layout-change handlers", () => {
+      patch.enable();
+      expect(mockApp.metadataCache.on).toHaveBeenCalledWith(
+        "changed",
+        expect.any(Function),
+      );
+      expect(mockApp.metadataCache.on).toHaveBeenCalledWith(
+        "resolved",
+        expect.any(Function),
+      );
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        "layout-change",
+        expect.any(Function),
+      );
+    });
+
+    it("is idempotent (double enable does not double-register)", () => {
+      patch.enable();
+      const calls = mockPlugin.registerEvent.mock.calls.length;
+      patch.enable();
+      expect(mockPlugin.registerEvent).toHaveBeenCalledTimes(calls);
+    });
+  });
+
+  describe("icon overlay", () => {
+    it("renders icon for class-bearing file with resolved icon", () => {
+      const titleEl = createNavFileTitle(TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      const overlay = titleEl.querySelector<HTMLSpanElement>(
+        ".exo-file-explorer-icon",
+      );
+      expect(overlay).toBeTruthy();
+      expect(obsidianSetIcon).toHaveBeenCalledWith(overlay, "check-square");
+    });
+
+    it("inserts icon BEFORE .nav-file-title-content", () => {
+      const titleEl = createNavFileTitle(TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      const children = Array.from(titleEl.children);
+      const iconIdx = children.findIndex((c) =>
+        c.classList.contains("exo-file-explorer-icon"),
+      );
+      const contentIdx = children.findIndex((c) =>
+        c.classList.contains("nav-file-title-content"),
+      );
+      expect(iconIdx).toBeGreaterThanOrEqual(0);
+      expect(iconIdx).toBeLessThan(contentIdx);
+    });
+
+    it("renders icons for multiple class-bearing files independently", () => {
+      const taskEl = createNavFileTitle(TASK_PATH);
+      const projectEl = createNavFileTitle(PROJECT_PATH);
+      navContainer.appendChild(taskEl);
+      navContainer.appendChild(projectEl);
+
+      patch.enable();
+
+      const taskOverlay = taskEl.querySelector(".exo-file-explorer-icon");
+      const projectOverlay = projectEl.querySelector(
+        ".exo-file-explorer-icon",
+      );
+      expect(taskOverlay).toBeTruthy();
+      expect(projectOverlay).toBeTruthy();
+      expect(obsidianSetIcon).toHaveBeenCalledWith(taskOverlay, "check-square");
+      expect(obsidianSetIcon).toHaveBeenCalledWith(
+        projectOverlay,
+        "folder-kanban",
+      );
+    });
+
+    it("does not double-overlay on subsequent patchAll", () => {
+      const titleEl = createNavFileTitle(TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+      const changedCb = mockApp.metadataCache.on.mock.calls.find(
+        (c: any[]) => c[0] === "changed",
+      )?.[1];
+      if (changedCb) changedCb();
+
+      const overlays = titleEl.querySelectorAll(".exo-file-explorer-icon");
+      expect(overlays.length).toBe(1);
+    });
+  });
+
+  describe("non-class / no-icon edge cases", () => {
+    it("does NOT inject overlay for file without exo__Instance_class", () => {
+      const titleEl = createNavFileTitle(NON_EXOCORTEX_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeNull();
+    });
+
+    it("does NOT inject overlay when ThemeResolver returns null icon", () => {
+      const titleEl = createNavFileTitle(NO_ICON_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeNull();
+    });
+
+    it("does nothing when metadataCache returns null", () => {
+      const orphan = "03 Knowledge/orphan.md";
+      filesByPath[orphan] = new FakeTFileCtor(orphan);
+      const titleEl = createNavFileTitle(orphan);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeNull();
+    });
+
+    it("does nothing when data-path is missing", () => {
+      const titleEl = document.createElement("div");
+      titleEl.className = "nav-file-title";
+      const contentEl = document.createElement("div");
+      contentEl.className = "nav-file-title-content";
+      titleEl.appendChild(contentEl);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeNull();
+    });
+  });
+
+  describe("Iconize co-existence", () => {
+    it("skips rows that already carry an Iconize-injected icon", () => {
+      const titleEl = createNavFileTitle(TASK_PATH);
+      const iconize = document.createElement("span");
+      iconize.className = "obsidian-icon-folder-icon";
+      titleEl.insertBefore(iconize, titleEl.firstChild);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeNull();
+    });
+  });
+
+  describe("disable / cleanup", () => {
+    it("removes overlay on disable", () => {
+      const titleEl = createNavFileTitle(TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeTruthy();
+
+      patch.disable();
+
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeNull();
+      expect(titleEl.getAttribute("data-exo-fe-icon-patched")).toBeNull();
+    });
+  });
+
+  describe("MutationObserver", () => {
+    it("patches a nav-file-title added after enable()", async () => {
+      patch.enable();
+
+      const titleEl = createNavFileTitle(TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

RFC-024 §4 Phase 4 — `FileExplorerIconPatch` service. Sibling to the proven `FileExplorerLabelPatch` DOM-overlay pattern. NOT the phantom `registerIconProvider` API.

- New service `packages/obsidian-plugin/src/presentation/fileexplorer/FileExplorerIconPatch.ts`
- `MutationObserver` on `.nav-file-title` re-applies overlay on every Obsidian re-render
- For class-bearing notes: reads first `exo__Instance_class` → `ThemeResolver.resolveIcon` → renders Lucide icon via Obsidian `setIcon` prepended inside `.nav-file-title`
- Iconize co-existence: skips rows that already carry an Iconize-injected icon (RFC-024 §8 «Co-exist, не конкурировать»)
- Wired in `ExocortexPlugin.onload` after `themeResolver` init; `cleanup` in `onunload`
- New setting `showIconsInFileExplorer` (default `true`) — opt-out per RFC §4 Phase 4
- Styles: `.exo-file-explorer-icon` overlay (16px, vertical-align middle, color `currentColor`)

Until a `LayoutProvider` is wired into `ThemeResolver`, `resolveIcon` returns `null` for every class so the overlay is a permanent contract surface but a no-op in production — matches the same wiring strategy used for `accentColor` (RFC-024 Phase 1).

## AC

- [x] Service file created
- [x] MutationObserver hooks file-explorer nav titles
- [x] Icons render для class-bearing files (when `resolveIcon` returns non-null)
- [x] Non-class files — no overlay (verified by unit test)

## Test plan

- [x] 13 unit tests in `FileExplorerIconPatch.test.ts` covering: enable idempotency, overlay placement (before `.nav-file-title-content`), multi-file independence, non-class skip, no-icon skip, missing data-path, Iconize co-existence, MutationObserver re-application, disable/cleanup
- [x] `npm run check:types` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm run build` succeeds