### PR TITLE
feat(rfc-024): ARIA labels + hover tooltips for ActionButton (T5.4 narrow)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -257,8 +257,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     // declared class — i.e. the first non-`exo__Asset` class. Universal
     // `exo__Asset` is the appended superclass and would over-broadly bind
     // to every asset's panel.
-    const panelClassRef =
-      assetClasses.find((c) => c !== "exo__Asset") ?? null;
+    const panelClassRef = assetClasses.find((c) => c !== "exo__Asset") ?? null;
 
     const prototypeIRI = this.extractPrototypeIRI(metadata);
 
@@ -358,11 +357,21 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
         ? command.icon
         : undefined;
 
+    // RFC-024 §4 Phase 2 — T5.4: propagate accessibility properties from
+    // the resolved CommandBindingStyle. `ariaLabel` overrides the
+    // screen-reader name; `tooltip` populates the `title` attribute. Both
+    // are populated by CommandResolver (T5.2) and forwarded as-is so the
+    // UI layer remains a passthrough — no defaults / coercion here.
+    const ariaLabel = binding.style?.ariaLabel;
+    const tooltip = binding.style?.tooltip;
+
     return {
       id: `dynamic-cmd-${command.id}`,
       label: command.name,
       variant,
       icon,
+      ariaLabel,
+      tooltip,
       visible: true,
       onClick: async () => {
         await this.handleClick(rc, targetIRI, filePath, app, logger, refresh);

--- a/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/ActionButtonsGroup.tsx
@@ -36,6 +36,25 @@ export interface ActionButton {
    * before T5.3.
    */
   icon?: string;
+  /**
+   * Optional accessible label (RFC-024 §4 Phase 2 — T5.4).
+   *
+   * Rendered as the `aria-label` attribute when set. Use to override the
+   * visible `label` for screen readers when the visible text is not
+   * self-explanatory (icon-only or short labels). Sourced from
+   * `binding.style.ariaLabel` resolved by CommandResolver (T5.2). When
+   * undefined the visible label remains the accessible name per the
+   * default ARIA accessible-name computation.
+   */
+  ariaLabel?: string;
+  /**
+   * Optional hover tooltip (RFC-024 §4 Phase 2 — T5.4).
+   *
+   * Rendered as the `title` attribute (Obsidian convention). Sourced from
+   * `binding.style.tooltip` resolved by CommandResolver (T5.2). When
+   * undefined no tooltip is shown.
+   */
+  tooltip?: string;
 }
 
 /**
@@ -90,9 +109,26 @@ const ActionButtonView: React.FC<{ button: ActionButton }> = ({ button }) => {
     };
   }, [button.icon]);
 
+  // RFC-024 §4 Phase 2 — T5.4 — accessibility infrastructure.
+  // `ariaLabel` overrides the screen-reader name (otherwise the visible
+  // `<span>` label is used per default ARIA name computation). `tooltip`
+  // populates the `title` attribute — Obsidian's convention for hover
+  // copy. Both are no-ops when undefined: ARIA accessible name then falls
+  // back to the visible label and no tooltip is rendered.
+  const ariaLabelProp =
+    typeof button.ariaLabel === "string" && button.ariaLabel.length > 0
+      ? { "aria-label": button.ariaLabel }
+      : {};
+  const titleProp =
+    typeof button.tooltip === "string" && button.tooltip.length > 0
+      ? { title: button.tooltip }
+      : {};
+
   return (
     <button
       className={`exocortex-action-button exocortex-action-button--${button.variant || "secondary"}`}
+      {...ariaLabelProp}
+      {...titleProp}
       onClick={async (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/packages/obsidian-plugin/tests/component/ActionButtonsGroup.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/ActionButtonsGroup.spec.tsx
@@ -440,6 +440,99 @@ test.describe("ActionButtonsGroup Component", () => {
     await expect(label).toHaveText("Mark Done");
   });
 
+  // RFC-024 §4 Phase 2 — T5.4: ARIA labels + hover tooltips propagation.
+  test("should apply aria-label and title attributes when ariaLabel and tooltip are set", async ({
+    mount,
+  }) => {
+    const groups: ButtonGroup[] = [
+      {
+        id: "a11y",
+        title: "A11y",
+        buttons: [
+          {
+            id: "btn-a11y",
+            label: "Done",
+            variant: "success",
+            ariaLabel: "Mark this task as done",
+            tooltip: "Sets ems__Effort_status to Done",
+            visible: true,
+            onClick: async () => {},
+          },
+        ],
+      },
+    ];
+
+    const component = await mount(<ActionButtonsGroup groups={groups} />);
+
+    const button = component.locator("button");
+    await expect(button).toHaveAttribute(
+      "aria-label",
+      "Mark this task as done",
+    );
+    await expect(button).toHaveAttribute(
+      "title",
+      "Sets ems__Effort_status to Done",
+    );
+  });
+
+  test("should omit aria-label and title attributes when ariaLabel and tooltip are undefined", async ({
+    mount,
+  }) => {
+    const groups: ButtonGroup[] = [
+      {
+        id: "no-a11y",
+        title: "No A11y",
+        buttons: [
+          {
+            id: "btn-no-a11y",
+            label: "Plain",
+            variant: "secondary",
+            visible: true,
+            onClick: async () => {},
+          },
+        ],
+      },
+    ];
+
+    const component = await mount(<ActionButtonsGroup groups={groups} />);
+
+    const button = component.locator("button");
+    await expect(button).not.toHaveAttribute("aria-label", /.*/);
+    await expect(button).not.toHaveAttribute("title", /.*/);
+    // The visible label remains the accessible name fallback.
+    await expect(button.locator(".exocortex-action-button-label")).toHaveText(
+      "Plain",
+    );
+  });
+
+  test("should omit aria-label and title when set to empty strings", async ({
+    mount,
+  }) => {
+    const groups: ButtonGroup[] = [
+      {
+        id: "empty-a11y",
+        title: "Empty A11y",
+        buttons: [
+          {
+            id: "btn-empty",
+            label: "Plain",
+            variant: "secondary",
+            ariaLabel: "",
+            tooltip: "",
+            visible: true,
+            onClick: async () => {},
+          },
+        ],
+      },
+    ];
+
+    const component = await mount(<ActionButtonsGroup groups={groups} />);
+
+    const button = component.locator("button");
+    await expect(button).not.toHaveAttribute("aria-label", /.*/);
+    await expect(button).not.toHaveAttribute("title", /.*/);
+  });
+
   test("should not render icon container when button.icon is undefined", async ({
     mount,
   }) => {

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -443,6 +443,84 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
   });
 
+  describe("a11y propagation (RFC-024 T5.4)", () => {
+    it("should propagate ariaLabel from binding.style to ActionButton", async () => {
+      const rc = createResolvedCommand(
+        { name: "Mark done" },
+        {
+          style: {
+            id: "style-1",
+            label: "Done style",
+            ariaLabel: "Mark this task as done",
+            inline: false,
+          },
+        },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].ariaLabel).toBe("Mark this task as done");
+    });
+
+    it("should propagate tooltip from binding.style to ActionButton", async () => {
+      const rc = createResolvedCommand(
+        { name: "Mark done" },
+        {
+          style: {
+            id: "style-1",
+            label: "Done style",
+            tooltip: "Sets ems__Effort_status to Done",
+            inline: false,
+          },
+        },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].tooltip).toBe("Sets ems__Effort_status to Done");
+    });
+
+    it("should leave ariaLabel and tooltip undefined when binding.style is absent", async () => {
+      const rc = createResolvedCommand({ name: "No style" });
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].ariaLabel).toBeUndefined();
+      expect(result[0].tooltip).toBeUndefined();
+    });
+
+    it("should leave ariaLabel and tooltip undefined when style has no a11y fields", async () => {
+      const rc = createResolvedCommand(
+        { name: "Style without a11y" },
+        {
+          style: {
+            id: "style-1",
+            label: "Variant only",
+            variant: "primary",
+            inline: false,
+          },
+        },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].ariaLabel).toBeUndefined();
+      expect(result[0].tooltip).toBeUndefined();
+    });
+  });
+
   describe("button onClick", () => {
     it("should execute grounding on click", async () => {
       const rc = createResolvedCommand({ name: "Execute me" });


### PR DESCRIPTION
## Summary

RFC-024 §4 Phase 2 — T5.4 (narrow scope): propagate `ariaLabel` + `tooltip` from the resolved `binding.style` (T5.2) to the rendered `<button>` as `aria-label` and `title` attributes.

Builds on T5.3 (PR #2968 / v15.129.0) icon rendering. Pure passthrough: CommandResolver already populates these fields — UI layer just forwards them.

## Scope decision

Per orchestrator decision (RFC-024 ems__Project `c28b28a9`): ship narrow (ARIA + tooltip only). The other AC items (hotkey registration with conflict warning, focus-visible ring, touch-target audit) are deferred to follow-up tasks T5.4a/b/c — HotkeyRegistrar in particular is a days-scale subsystem that warrants its own PR and review window.

## Changes

- `ActionButton` interface (`ActionButtonsGroup.tsx`): add optional `ariaLabel` + `tooltip` fields with rationale comments
- `ActionButtonView`: spread `aria-label` / `title` only when set and non-empty (so the visible label remains the accessible-name fallback when undefined)
- `DynamicCommandButtonGroupBuilder.createButton`: forward `binding.style?.ariaLabel` / `binding.style?.tooltip`
- Component tests: 3 new cases (set / undefined / empty-string)
- Unit tests: 4 new cases for builder propagation (ariaLabel set, tooltip set, no style, style without a11y fields)

## Test plan

- [x] `npm run check:types` — clean
- [x] `npm run lint` — 2 pre-existing warnings only (display-name PrintNameRuleService)
- [x] Unit: `DynamicCommandButtonGroupBuilder.test.ts` — 52/52 pass
- [x] Component: `ActionButtonsGroup.spec.tsx` — 15/15 pass (3 new + 12 pre-existing)
- [ ] CI: 13 required checks green
- [ ] Auto Release publishes new version

## Refs

- RFC-024 §4 Phase 2 — `83d5a78e-8ba1-436d-b97f-6cf1cf5add74`
- ems__Task — `ded40c45-3776-45c5-9ba6-c119ffc4d56e`
- ems__Project — `c28b28a9-4101-47fb-ac3b-bdd70bb8bf8b`
- Predecessor — PR #2968 (T5.3)