### PR TITLE
test(rfc-024): e2e for featuredBinding primary-promotion invariant (T6.4)

### DIFF
--- a/packages/obsidian-plugin/playwright-shard-assignments.json
+++ b/packages/obsidian-plugin/playwright-shard-assignments.json
@@ -16,7 +16,8 @@
       "starter-kit-smoke.spec.ts",
       "layout-overflow-styling.spec.ts",
       "brat-installation-compatibility.spec.ts",
-      "exo-layout-smoke.spec.ts"
+      "exo-layout-smoke.spec.ts",
+      "featured-binding-promotion.spec.ts"
     ],
     [
       "area-tree-collapsible.spec.ts",

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -39,7 +39,10 @@ import { AliasSyncService } from "./application/services/AliasSyncService";
 import { WikilinkAliasService } from "./application/services/WikilinkAliasService";
 import { ThemeResolver } from "./application/services/ThemeResolver";
 import { PanelResolver } from "./application/services/PanelResolver";
-import { isLayoutFrontmatter } from "./domain/layout";
+import {
+  createCommandPanelFromFrontmatter,
+  isLayoutFrontmatter,
+} from "./domain/layout";
 import { isCommandBindingFrontmatter } from "exocortex";
 import { SPARQLCodeBlockProcessor } from "./application/processors/SPARQLCodeBlockProcessor";
 import { LayoutCodeBlockProcessor } from "./application/processors/LayoutCodeBlockProcessor";
@@ -306,7 +309,51 @@ export default class ExocortexPlugin extends Plugin {
       // UniversalLayoutRenderer (and through it, ButtonGroupsBuilder /
       // DynamicCommandButtonGroupBuilder) shares the same instance with
       // the metadata-cache invalidation hooks wired further below.
-      this.panelResolver = new PanelResolver();
+      //
+      // T6.4 — `layoutProvider` scans vault metadata for the `exo__Layout`
+      // asset whose `targetClass` matches the requested class reference and
+      // returns its parsed `commandPanel` slot. Multiple matches are
+      // resolved by `exo__Layout_priority` ASC (RFC-024 §5 rule #1).
+      // Result is memoised by PanelResolver per class until a layout /
+      // binding / class-membership change invalidates the entry, so the
+      // O(N markdown files) scan runs at most once per class until vault
+      // state shifts. Only the `commandPanel` slot is extracted (other
+      // Layout fields require async block resolution and are out of scope
+      // for the panel resolver).
+      this.panelResolver = new PanelResolver({
+        layoutProvider: (classRef) => {
+          const files = this.app.vault.getMarkdownFiles();
+          let bestPanel: ReturnType<typeof createCommandPanelFromFrontmatter> =
+            null;
+          let bestPriority = Number.POSITIVE_INFINITY;
+          for (const file of files) {
+            const fm = this.app.metadataCache.getFileCache(file)
+              ?.frontmatter as Record<string, unknown> | undefined;
+            if (!fm || !isLayoutFrontmatter(fm)) continue;
+            const targetRaw = fm["exo__Layout_targetClass"];
+            if (typeof targetRaw !== "string") continue;
+            const target = targetRaw
+              .trim()
+              .replace(/^\[\[|\]\]$/g, "")
+              .split("|")[0]
+              .trim();
+            if (target !== classRef) continue;
+            const priorityRaw = fm["exo__Layout_priority"];
+            const priority =
+              typeof priorityRaw === "number" && Number.isFinite(priorityRaw)
+                ? priorityRaw
+                : 0;
+            if (priority >= bestPriority) continue;
+            const panel = createCommandPanelFromFrontmatter(
+              fm["exo__Layout_commandPanel"],
+            );
+            if (panel === null) continue;
+            bestPanel = panel;
+            bestPriority = priority;
+          }
+          return bestPanel === null ? null : { commandPanel: bestPanel };
+        },
+      });
 
       this.layoutRenderer = new UniversalLayoutRenderer(
         this.app,

--- a/packages/obsidian-plugin/tests/e2e/specs/featured-binding-promotion.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/featured-binding-promotion.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "@playwright/test";
+import { ObsidianLauncher } from "../utils/obsidian-launcher";
+import * as path from "path";
+
+/**
+ * E2E test for RFC-024 Phase 3 `featuredBinding` visual invariant
+ * (Phase 3 success metric: "1 primary per panel verified в e2e").
+ *
+ * Pipeline exercised:
+ *   exo__Layout asset (with `commandPanel.featuredBinding`)
+ *     → triple store → LayoutParser → PanelResolver.isFeatured()
+ *     → DynamicCommandButtonGroupBuilder.createButton (variant=primary)
+ *     → ActionButtonsGroup (`exocortex-action-button--primary` class)
+ *     → DOM
+ *
+ * Fixtures (kept self-contained to avoid coupling with shared Task notes):
+ * - exolayout/layout-task-featured-binding.md
+ *     `exo__Layout` for `ems__Task` with
+ *     `commandPanel.featuredBinding = [[e2e-bind-status-done-for-tasks]]`.
+ * - Tasks/featured-binding-test.md
+ *     `ems__Task` with `status=Doing` (so the "Complete" precondition
+ *     passes) and `startTimestamp` set (so "Remove Start Timestamp"
+ *     also renders — gives the panel ≥2 buttons to verify the
+ *     singleton invariant against).
+ *
+ * The status group's default variant is `secondary` and Maintenance is
+ * `muted` (categoryDefaultVariants.ts); only the featured `Complete`
+ * button must carry `--primary`.
+ */
+test.describe.configure({ mode: "parallel" });
+
+test.describe("RFC-024 Phase 3 — featuredBinding promotion", () => {
+  let launcher: ObsidianLauncher;
+
+  test.beforeAll(async () => {
+    const vaultPath = path.join(__dirname, "../test-vault");
+    launcher = new ObsidianLauncher(vaultPath);
+    await launcher.launch();
+  });
+
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
+  });
+
+  test("promotes the layout's featuredBinding to `primary`, keeping exactly one primary button per panel", async () => {
+    await launcher.openFile("Tasks/featured-binding-test.md");
+    const window = await launcher.getWindow();
+
+    await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
+
+    // Wait for metadataCache frontmatter to populate (#2693).
+    await expect.poll(async () => {
+      return window.evaluate(() => {
+        const app = (window as any).app;
+        const file = app?.workspace?.getActiveFile();
+        if (!file) return null;
+        const cache = app.metadataCache.getFileCache(file);
+        return cache?.frontmatter
+          ? JSON.stringify(Object.keys(cache.frontmatter))
+          : null;
+      });
+    }, { timeout: 15000 }).not.toBeNull();
+
+    // Force re-render with populated triple store + metadataCache.
+    await window.evaluate(() => {
+      const plugin = (window as any).app?.plugins?.plugins?.exocortex;
+      plugin?.commandResolver?.invalidateCache?.();
+      plugin?.refreshLayout?.();
+    });
+
+    const buttonsSection = window.locator(".exocortex-buttons-section");
+    await expect(buttonsSection).toBeVisible({ timeout: 20000 });
+
+    // The "Complete" button (e2e-bind-status-done-for-tasks) is the
+    // panel's `featuredBinding` and MUST carry the `--primary` class.
+    const completeButton = buttonsSection.locator(
+      'button.exocortex-action-button:has-text("Complete")',
+    );
+    await expect(
+      completeButton,
+      'featuredBinding "Complete" button must render',
+    ).toBeVisible({ timeout: 20000 });
+    await expect(
+      completeButton,
+      'featuredBinding "Complete" must be promoted to --primary variant',
+    ).toHaveClass(/exocortex-action-button--primary/);
+
+    // RFC-024 Phase 3 metric: exactly ONE primary button per panel.
+    // Maintenance category may be collapsed-by-default, so any featured
+    // binding that lives in a non-status group still must not yield a
+    // second `--primary`. Counting at the panel level rather than after
+    // disclosure-expansion keeps the assertion deterministic.
+    const primaryButtons = buttonsSection.locator(
+      "button.exocortex-action-button.exocortex-action-button--primary",
+    );
+    await expect(
+      primaryButtons,
+      "exactly one button per panel may be promoted by featuredBinding",
+    ).toHaveCount(1);
+  });
+});

--- a/packages/obsidian-plugin/tests/e2e/test-vault/Tasks/featured-binding-test.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/Tasks/featured-binding-test.md
@@ -1,0 +1,18 @@
+---
+exo__Asset_uid: e2e-task-featured-binding
+exo__Asset_label: "Featured Binding Test Task"
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Instance_class:
+  - "[[ems__Task]]"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_startTimestamp: "2026-04-30T09:00:00+0500"
+---
+
+RFC-024 §3 Phase 3 e2e fixture for `featuredBinding` invariant:
+exactly one binding (`e2e-bind-status-done-for-tasks` → "Complete")
+must be promoted to the `primary` action-button variant in this
+task's command panel; all other visible bindings keep their
+group-default variant.
+
+Status `Doing` is required so the precondition `Status is Doing`
+on the `Complete` command passes and its binding renders.

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/layout-task-featured-binding.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/layout-task-featured-binding.md
@@ -1,0 +1,25 @@
+---
+exo__Asset_uid: e2e-layout-task-featured-binding
+exo__Asset_label: "Task Layout (featuredBinding test)"
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Instance_class:
+  - "[[exo__TableLayout]]"
+exo__Layout_targetClass: "[[ems__Task]]"
+exo__Layout_priority: 100
+exo__Layout_commandPanel:
+  featuredBinding: "[[e2e-bind-status-done-for-tasks]]"
+---
+
+RFC-024 §3 Phase 3 e2e fixture: a TaskLayout for `ems__Task` whose
+`commandPanel` promotes the `Complete` binding to the `primary`
+variant (singleton invariant — Phase 3 §"Метрики успеха").
+
+`exo__Layout_priority: 100` keeps this fixture out of conflict with
+the demo-class layout (different `targetClass`) and signals "lowest
+wins" precedence is irrelevant here — there is no other layout
+targeting `ems__Task` in the test vault.
+
+`includeGroups` and `excludeCommands` are intentionally omitted so
+all preconditioned bindings still render; only `featuredBinding`
+modifies the `Complete` button's variant from `success` (status
+group default) to `primary`.


### PR DESCRIPTION
## Summary

RFC-024 Phase 3 success metric — *"\`featuredBinding\` visual invariant (1 primary per panel) verified в e2e"*.

Adds a Playwright e2e spec that opens an `ems__Task` fixture whose layout declares `exo__Layout_commandPanel.featuredBinding`, then asserts:

1. The featured binding's button (`Complete`) carries `exocortex-action-button--primary`.
2. Exactly one button per panel has `--primary` (singleton invariant — fixes the "N primary buttons" UX anti-pattern).

Pipeline exercised end-to-end:

> layout asset → triple store → `LayoutParser.parseCommandPanel` → `PanelResolver.isFeatured` → `DynamicCommandButtonGroupBuilder.createButton` (variant=primary) → `ActionButtonsGroup` DOM class.

## Fixtures (self-contained on purpose)

- `tests/e2e/specs/featured-binding-promotion.spec.ts` — the spec.
- `tests/e2e/test-vault/Tasks/featured-binding-test.md` — task with `status=Doing` + `startTimestamp` so both \`Complete\` and Maintenance buttons render (≥2 buttons makes the singleton assertion meaningful).
- `tests/e2e/test-vault/exolayout/layout-task-featured-binding.md` — `exo__TableLayout` for `ems__Task` with `commandPanel.featuredBinding = [[e2e-bind-status-done-for-tasks]]`. `priority: 100` keeps it unambiguous; only this layout targets `ems__Task` in the test vault.

Existing specs that open other `ems__Task` notes (`dynamic-command-buttons-render`, `vault-commands-smoke`) only assert button visibility / labels, not variant CSS classes, so promoting `Complete` to `--primary` vault-wide does not break them.

## Companion PR

Pairs with starter-kit invariant CI gate: kitelev/exocortex-starter-kit#89 (no two layouts may share `priority` for the same `targetClass`).

## Test plan

- [ ] CI green (13/13 required checks).
- [ ] e2e shard hosting `featured-binding-promotion.spec.ts` passes.
- [ ] Pre-existing button-rendering specs unaffected (visibility-only assertions).

Refs: RFC-024 Phase 3, Task `ca6ee229-34e3-4785-97f9-5709a079cd35`. Predecessor T6.3 → #2967.