### PR TITLE
feat(rfc-024): T7.2 file explorer icons opt-out toggle + Iconize startup detection

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -64,6 +64,7 @@ import { PropertiesUidCopyPatch } from "./presentation/properties/PropertiesUidC
 import { PropertiesLabelPatch } from "./presentation/properties/PropertiesLabelPatch";
 import { FileExplorerLabelPatch } from "./presentation/fileexplorer/FileExplorerLabelPatch";
 import { FileExplorerIconPatch } from "./presentation/fileexplorer/FileExplorerIconPatch";
+import { IconizeDetector } from "./presentation/fileexplorer/IconizeDetector";
 import { ReadingModeEnforcer } from "./presentation/reading-mode/ReadingModeEnforcer";
 import { BodyLinkPatch } from "./presentation/body/BodyLinkPatch";
 import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
@@ -680,6 +681,17 @@ export default class ExocortexPlugin extends Plugin {
         this,
         this.themeResolver,
       );
+      // RFC-024 §8 (T7.2) — log Iconize plugin coexistence handshake. Per-row
+      // skip happens inside FileExplorerIconPatch.hasIconizeOverlay; this
+      // startup log lets users see which plugin "wins" on iconized rows.
+      const iconize = IconizeDetector.detect(this.app);
+      if (iconize.detected) {
+        this.logger.info("FileExplorerIconPatch", {
+          message:
+            `Iconize community plugin detected (${iconize.pluginId}); ` +
+            "Exocortex will skip overlay on rows already iconized by Iconize.",
+        });
+      }
       if (this.settings.showIconsInFileExplorer) {
         this.timerManager.setTimeout(
           "file-explorer-icon-patch",
@@ -994,6 +1006,19 @@ export default class ExocortexPlugin extends Plugin {
       this.graphViewPatch.enable();
     } else {
       this.graphViewPatch.disable();
+    }
+  }
+
+  /**
+   * Toggle File Explorer class-icon overlay on/off (RFC-024 §4 Phase 4).
+   * Called from settings when the showIconsInFileExplorer toggle changes.
+   */
+  toggleFileExplorerIcons(enabled: boolean): void {
+    if (!this.fileExplorerIconPatch) return;
+    if (enabled) {
+      this.fileExplorerIconPatch.enable();
+    } else {
+      this.fileExplorerIconPatch.disable();
     }
   }
 

--- a/packages/obsidian-plugin/src/presentation/fileexplorer/IconizeDetector.ts
+++ b/packages/obsidian-plugin/src/presentation/fileexplorer/IconizeDetector.ts
@@ -1,0 +1,39 @@
+/**
+ * IconizeDetector — RFC-024 §8 (T7.2). Detects whether the Iconize community
+ * plugin (`obsidian-icon-folder`) is installed and enabled at startup, so the
+ * Exocortex File Explorer overlay can log the coexistence handshake.
+ *
+ * Per-row skip is enforced by `FileExplorerIconPatch.hasIconizeOverlay`
+ * (DOM-marker based). This detector is the startup-time discovery counterpart
+ * — it does not affect overlay behaviour, only emits a log line so users
+ * understand which plugin "wins" on iconized rows.
+ */
+
+const ICONIZE_PLUGIN_IDS = ["obsidian-icon-folder"] as const;
+
+export interface IconizeDetectionResult {
+  detected: boolean;
+  pluginId: string | null;
+}
+
+interface AppLike {
+  plugins?: {
+    plugins?: Record<string, unknown>;
+    enabledPlugins?: Set<string> | string[];
+  };
+}
+
+export class IconizeDetector {
+  static detect(app: unknown): IconizeDetectionResult {
+    const plugins = (app as AppLike | null | undefined)?.plugins?.plugins;
+    if (!plugins || typeof plugins !== "object") {
+      return { detected: false, pluginId: null };
+    }
+    for (const id of ICONIZE_PLUGIN_IDS) {
+      if (plugins[id]) {
+        return { detected: true, pluginId: id };
+      }
+    }
+    return { detected: false, pluginId: null };
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -112,6 +112,23 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Show class icons in file explorer")
+      .setDesc(
+        "Render Lucide icons next to file explorer rows for notes whose " +
+        "exo__Instance_class resolves to an exo__Layout_icon. " +
+        "Skips rows already iconized by the Iconize community plugin.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showIconsInFileExplorer)
+          .onChange(async (value) => {
+            this.plugin.settings.showIconsInFileExplorer = value;
+            await this.plugin.saveSettings();
+            this.plugin.toggleFileExplorerIcons(value);
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Auto reading mode for exocortex assets")
       .setDesc(
         "When opening a note with the `exo__Instance_class` frontmatter property, automatically switch to reading mode so the exocortex layout (create / status / planning panels) is visible. Disable to keep obsidian's default view mode.",

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -127,9 +127,9 @@ describe("ExocortexSettingTab", () => {
       settingTab.display();
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
-      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 25
+      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 26
       // Log channels section: 1 heading + 4 log level rows = 5
-      expect(MockSetting).toHaveBeenCalledTimes(25);
+      expect(MockSetting).toHaveBeenCalledTimes(26);
     });
 
     it("should render layout visibility toggle as first setting", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/fileexplorer/IconizeDetector.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/fileexplorer/IconizeDetector.test.ts
@@ -1,0 +1,53 @@
+import { IconizeDetector } from "../../../../src/presentation/fileexplorer/IconizeDetector";
+
+describe("IconizeDetector", () => {
+  it("returns detected=false when app is null", () => {
+    expect(IconizeDetector.detect(null)).toEqual({
+      detected: false,
+      pluginId: null,
+    });
+  });
+
+  it("returns detected=false when app.plugins is missing", () => {
+    expect(IconizeDetector.detect({})).toEqual({
+      detected: false,
+      pluginId: null,
+    });
+  });
+
+  it("returns detected=false when plugins map is empty", () => {
+    expect(
+      IconizeDetector.detect({ plugins: { plugins: {} } }),
+    ).toEqual({ detected: false, pluginId: null });
+  });
+
+  it("returns detected=false when plugins map lacks Iconize ids", () => {
+    expect(
+      IconizeDetector.detect({
+        plugins: { plugins: { "some-other-plugin": {} } },
+      }),
+    ).toEqual({ detected: false, pluginId: null });
+  });
+
+  it("returns detected=true with pluginId when obsidian-icon-folder is loaded", () => {
+    const result = IconizeDetector.detect({
+      plugins: {
+        plugins: {
+          "obsidian-icon-folder": { settings: {} },
+          "another-plugin": {},
+        },
+      },
+    });
+    expect(result).toEqual({
+      detected: true,
+      pluginId: "obsidian-icon-folder",
+    });
+  });
+
+  it("does not throw on malformed app shape", () => {
+    expect(() => IconizeDetector.detect({ plugins: "string" })).not.toThrow();
+    expect(() =>
+      IconizeDetector.detect({ plugins: { plugins: 42 } }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Settings UI toggle for `showIconsInFileExplorer` (default `true`; T7.1 shipped only the data field).
- Adds `IconizeDetector` startup probe of `app.plugins.plugins["obsidian-icon-folder"]`. On detection emits an info log line documenting the coexistence handshake. Per-row skip stays in `FileExplorerIconPatch.hasIconizeOverlay`.
- Public `ExocortexPlugin.toggleFileExplorerIcons(enabled)` mirrors sibling toggles (label/body/graph/tab) so settings change applies live.

## Files
- `src/presentation/fileexplorer/IconizeDetector.ts` (new)
- `src/ExocortexPlugin.ts`: detect+log on load, `toggleFileExplorerIcons` method
- `src/presentation/settings/ExocortexSettingTab.ts`: new toggle bound to setting
- `tests/unit/presentation/fileexplorer/IconizeDetector.test.ts` (new, 6 cases)
- `tests/unit/ExocortexSettingTab.test.ts`: bump expected Setting count 25→26

## Acceptance Criteria (RFC-024 Phase 4 / T7.2)
- [x] Setting exposed in plugin settings UI
- [x] Default `true`, toggle enables/disables overlay live
- [x] Iconize detection works (via `app.plugins.plugins`)
- [x] Skip pattern verified for iconized files (existing `hasIconizeOverlay` covers per-row; logged on startup)

## Test Plan
- [x] `npx jest tests/unit/presentation/fileexplorer/` — 33 passed
- [x] `npx jest tests/unit/ExocortexSettingTab.test.ts` — 5 passed
- [x] `npm run check:types` clean
- [x] `npm run lint` clean
- [ ] CI 13/13 green
- [ ] Auto-release

RFC-024 task UUID: `d617b6c4-34bd-47e1-988e-9507f8cd9977`. Predecessor: PR #2969 (v15.130.0).