### PR TITLE
feat(rfc-024): T7.3 cleanup lifecycle + E2E for FileExplorerIconPatch

### DIFF
--- a/packages/obsidian-plugin/playwright-shard-assignments.json
+++ b/packages/obsidian-plugin/playwright-shard-assignments.json
@@ -22,7 +22,8 @@
     [
       "area-tree-collapsible.spec.ts",
       "vault-commands-smoke.spec.ts",
-      "table-virtualization-large-datasets.spec.ts"
+      "table-virtualization-large-datasets.spec.ts",
+      "file-explorer-icons.spec.ts"
     ],
     [
       "daily-navigation.spec.ts",

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -388,10 +388,70 @@ export default class ExocortexPlugin extends Plugin {
       );
 
       // RFC-024 Phase 1 — Theme resolver for class-level visual accents.
-      // layoutProvider is a callback placeholder; a subsequent PR will wire a
-      // LayoutService lookup. The resolver still serves plugin-built-in
-      // defaults via CLASS_DEFAULT_ACCENT (Tasks/Projects/Areas/Knowledge).
-      this.themeResolver = new ThemeResolver();
+      // RFC-024 §4 Phase 4 (T7.3) — `layoutProvider` scans vault metadata for
+      // the `exo__Layout` asset whose `targetClass` matches the requested
+      // class reference and returns its parsed visual slots (accentColor,
+      // icon, labelTypography). Multiple matches are resolved by
+      // `exo__Layout_priority` ASC (RFC-024 §5 rule #1). Result is memoised
+      // by ThemeResolver per class until a layout edit invalidates the entry,
+      // so the O(N markdown files) scan runs at most once per class until
+      // vault state shifts. Mirrors the PanelResolver wiring above.
+      this.themeResolver = new ThemeResolver({
+        layoutProvider: (classRef) => {
+          const files = this.app.vault.getMarkdownFiles();
+          let bestSlots:
+            | {
+                accentColor?: string;
+                icon?: string;
+                labelTypography?: import("@plugin/domain/layout").LabelTypography;
+              }
+            | null = null;
+          let bestPriority = Number.POSITIVE_INFINITY;
+          for (const file of files) {
+            const fm = this.app.metadataCache.getFileCache(file)
+              ?.frontmatter as Record<string, unknown> | undefined;
+            if (!fm || !isLayoutFrontmatter(fm)) continue;
+            const targetRaw = fm["exo__Layout_targetClass"];
+            if (typeof targetRaw !== "string") continue;
+            const target = targetRaw
+              .trim()
+              .replace(/^\[\[|\]\]$/g, "")
+              .split("|")[0]
+              .trim();
+            if (target !== classRef) continue;
+            const priorityRaw = fm["exo__Layout_priority"];
+            const priority =
+              typeof priorityRaw === "number" && Number.isFinite(priorityRaw)
+                ? priorityRaw
+                : 0;
+            if (priority >= bestPriority) continue;
+            const accentRaw = fm["exo__Layout_accentColor"];
+            const iconRaw = fm["exo__Layout_icon"];
+            const typoRaw = fm["exo__Layout_labelTypography"];
+            const slots: {
+              accentColor?: string;
+              icon?: string;
+              labelTypography?: import("@plugin/domain/layout").LabelTypography;
+            } = {};
+            if (typeof accentRaw === "string" && accentRaw.trim().length > 0) {
+              slots.accentColor = accentRaw.trim();
+            }
+            if (typeof iconRaw === "string" && iconRaw.trim().length > 0) {
+              slots.icon = iconRaw.trim();
+            }
+            if (
+              typoRaw === "small" ||
+              typoRaw === "medium" ||
+              typoRaw === "large"
+            ) {
+              slots.labelTypography = typoRaw;
+            }
+            bestSlots = slots;
+            bestPriority = priority;
+          }
+          return bestSlots;
+        },
+      });
       this.registerEvent(
         this.app.metadataCache.on("changed", (file) => {
           const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;

--- a/packages/obsidian-plugin/tests/e2e/specs/file-explorer-icons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/file-explorer-icons.spec.ts
@@ -9,7 +9,7 @@ import { ObsidianLauncher } from "../utils/obsidian-launcher";
  * given the vault's `exo__Layout` for `ems__Task` declares
  * `exo__Layout_icon: check-square`. The fixture
  * `exolayout/layout-task-featured-binding.md` provides the layout, and
- * `Tasks/featured-binding-test.md` provides a class-bearing target.
+ * `e2e-icon-target-task.md` provides a class-bearing target.
  *
  * Acceptance (RFC-024 §8 Phase 4 success metric):
  *   `npm run test:e2e file-explorer-icons` — class-bearing notes show
@@ -36,11 +36,11 @@ test.describe("FileExplorerIconPatch — Phase 4 smoke", () => {
       // Open any file to ensure the workspace is initialised; the patch
       // attaches to nav-file-title elements globally and re-applies on
       // metadataCache "resolved".
-      await launcher.openFile("Tasks/featured-binding-test.md");
+      await launcher.openFile("e2e-icon-target-task.md");
       await launcher.waitForModalsToClose(10_000);
 
       const targetTitle = launcher.page!.locator(
-        '.nav-file-title[data-path="Tasks/featured-binding-test.md"]',
+        '.nav-file-title[data-path="e2e-icon-target-task.md"]',
       );
 
       // Wait for the file explorer to render the row.

--- a/packages/obsidian-plugin/tests/e2e/specs/file-explorer-icons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/file-explorer-icons.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+import { ObsidianLauncher } from "../utils/obsidian-launcher";
+
+/**
+ * RFC-024 §4 Phase 4 (T7.3) — L3 E2E smoke for FileExplorerIconPatch.
+ *
+ * Verifies the DOM-overlay icon is rendered next to a `nav-file-title`
+ * whose underlying note declares `exo__Instance_class: [[ems__Task]]`,
+ * given the vault's `exo__Layout` for `ems__Task` declares
+ * `exo__Layout_icon: check-square`. The fixture
+ * `exolayout/layout-task-featured-binding.md` provides the layout, and
+ * `Tasks/featured-binding-test.md` provides a class-bearing target.
+ *
+ * Acceptance (RFC-024 §8 Phase 4 success metric):
+ *   `npm run test:e2e file-explorer-icons` — class-bearing notes show
+ *   the resolved Lucide icon when one is declared in the layout.
+ */
+test.describe("FileExplorerIconPatch — Phase 4 smoke", () => {
+  let launcher: ObsidianLauncher;
+
+  test.beforeAll(async () => {
+    launcher = new ObsidianLauncher();
+    await launcher.launch();
+  });
+
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
+  });
+
+  test(
+    "ems__Task nav-file-title carries .exo-file-explorer-icon overlay before .nav-file-title-content",
+    { timeout: 25_000 },
+    async () => {
+      // Open any file to ensure the workspace is initialised; the patch
+      // attaches to nav-file-title elements globally and re-applies on
+      // metadataCache "resolved".
+      await launcher.openFile("Tasks/featured-binding-test.md");
+      await launcher.waitForModalsToClose(10_000);
+
+      const targetTitle = launcher.page!.locator(
+        '.nav-file-title[data-path="Tasks/featured-binding-test.md"]',
+      );
+
+      // Wait for the file explorer to render the row.
+      await expect(targetTitle).toHaveCount(1, { timeout: 15_000 });
+
+      // Wait for the patch to inject the overlay (MutationObserver +
+      // metadataCache "resolved" together cover both startup paths).
+      const overlay = targetTitle.locator(".exo-file-explorer-icon");
+      await expect(overlay).toHaveCount(1, { timeout: 15_000 });
+
+      // Overlay must precede `.nav-file-title-content` (RFC-024 §4).
+      const order = await targetTitle.evaluate((title) => {
+        const overlayEl = title.querySelector(".exo-file-explorer-icon");
+        const contentEl = title.querySelector(".nav-file-title-content");
+        if (!overlayEl || !contentEl) return null;
+        const children = Array.from(title.children);
+        return {
+          overlayIdx: children.indexOf(overlayEl),
+          contentIdx: children.indexOf(contentEl),
+        };
+      });
+      expect(order).not.toBeNull();
+      expect(order!.overlayIdx).toBeGreaterThanOrEqual(0);
+      expect(order!.overlayIdx).toBeLessThan(order!.contentIdx);
+
+      // Lucide icon name plumbed through `setIcon(overlay, "check-square")`.
+      // Obsidian's setIcon mounts an <svg> child; we assert structural
+      // presence rather than rasterised visuals so this stays robust to
+      // Lucide version bumps.
+      const svg = overlay.locator("svg");
+      await expect(svg).toHaveCount(1);
+    },
+  );
+});

--- a/packages/obsidian-plugin/tests/e2e/test-vault/e2e-icon-target-task.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/e2e-icon-target-task.md
@@ -1,0 +1,14 @@
+---
+exo__Asset_uid: e2e-icon-target-task
+exo__Asset_label: "Icon Target Task (root, T7.3 e2e fixture)"
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Instance_class:
+  - "[[ems__Task]]"
+ems__Effort_status: "[[ems__EffortStatusBacklog]]"
+---
+
+RFC-024 §4 Phase 4 (T7.3) E2E fixture. Lives at vault root so the
+`nav-file-title` is rendered without expanding any folder. The
+`exolayout/layout-task-featured-binding.md` layout declares
+`exo__Layout_icon: check-square` for `ems__Task`, so
+`FileExplorerIconPatch` must inject `.exo-file-explorer-icon` here.

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/layout-task-featured-binding.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exolayout/layout-task-featured-binding.md
@@ -6,6 +6,7 @@ exo__Instance_class:
   - "[[exo__TableLayout]]"
 exo__Layout_targetClass: "[[ems__Task]]"
 exo__Layout_priority: 100
+exo__Layout_icon: check-square
 exo__Layout_commandPanel:
   featuredBinding: "[[e2e-bind-status-done-for-tasks]]"
 ---

--- a/packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerIconPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerIconPatch.test.ts
@@ -298,6 +298,31 @@ describe("FileExplorerIconPatch", () => {
       expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeNull();
       expect(titleEl.getAttribute("data-exo-fe-icon-patched")).toBeNull();
     });
+
+    it("disconnects MutationObserver on cleanup — no overlay for rows added later", async () => {
+      patch.enable();
+      patch.cleanup();
+
+      // Row appears AFTER cleanup; the observer must not re-patch it.
+      const titleEl = createNavFileTitle(TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeNull();
+      expect(titleEl.getAttribute("data-exo-fe-icon-patched")).toBeNull();
+    });
+
+    it("cleanup is idempotent (double cleanup safe)", () => {
+      const titleEl = createNavFileTitle(TASK_PATH);
+      navContainer.appendChild(titleEl);
+
+      patch.enable();
+      patch.cleanup();
+      // Second cleanup must not throw and must keep the row free of overlay.
+      expect(() => patch.cleanup()).not.toThrow();
+      expect(titleEl.querySelector(".exo-file-explorer-icon")).toBeNull();
+    });
   });
 
   describe("MutationObserver", () => {


### PR DESCRIPTION
## Summary

RFC-024 §4 Phase 4 — final task (T7.3) wiring + tests.

- **ThemeResolver layoutProvider** wired in `ExocortexPlugin` (mirrors `PanelResolver`): scans vault for matching `exo__Layout` (priority ASC) and resolves `accentColor`/`icon`/`labelTypography`. Removes the Phase 4 placeholder so `FileExplorerIconPatch` actually receives icons.
- **E2E spec** `file-explorer-icons.spec.ts` (shard 5) — opens `Tasks/featured-binding-test.md`, asserts `.exo-file-explorer-icon` overlay rendered before `.nav-file-title-content` with embedded `<svg>`. Test-vault layout extended with `exo__Layout_icon: check-square`.
- **Unit cleanup-leak tests** — observer disconnects on `cleanup()`, double-cleanup is idempotent.

## Test plan
- [x] `npm run check:types` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] FileExplorerIconPatch.test.ts — 15 tests pass
- [x] Shard validator — 18 specs balanced across 6 shards
- [ ] CI 13/13 green
- [ ] Auto Release publishes new patch version