### PR TITLE
feat(ci): aggregate flaky-reporter artifacts (RFC Phase 3.4 / T4.1)

### DIFF
--- a/.github/workflows/flaky-dashboard.yml
+++ b/.github/workflows/flaky-dashboard.yml
@@ -1,0 +1,80 @@
+name: Flaky Dashboard Aggregator
+
+# RFC Phase 3.4 / T4.1 — aggregate flaky-reporter.json artifacts from the
+# last 30 main CI runs and publish a structured JSON for downstream
+# dashboard rendering. Read-only with respect to repository content.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC (≈11:00 Asia/Almaty, after weekend lull)
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Rolling window size (number of recent main runs)"
+        required: false
+        default: "30"
+      dry_run:
+        description: "Skip artifact downloads"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  aggregate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Install root deps (tsx)
+        run: npm ci --no-audit --no-fund
+
+      - name: Run flaky-aggregate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LIMIT="${{ inputs.limit || '30' }}"
+          DRY_RUN_FLAG=""
+          if [ "${{ inputs.dry_run || 'false' }}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          mkdir -p packages/obsidian-plugin/docs
+          npx tsx packages/obsidian-plugin/scripts/flaky-aggregate.ts \
+            --repo "${{ github.repository }}" \
+            --workflow ci.yml \
+            --branch main \
+            --limit "$LIMIT" \
+            --output packages/obsidian-plugin/docs/FLAKY_DASHBOARD.json \
+            $DRY_RUN_FLAG
+
+      - name: Show summary
+        run: |
+          if [ -f packages/obsidian-plugin/docs/FLAKY_DASHBOARD.json ]; then
+            echo "## Flaky Dashboard Summary" >> "$GITHUB_STEP_SUMMARY"
+            jq -r '
+              "- generatedAt: \(.generatedAt)",
+              "- runs analyzed: \(.summary.totalRuns)",
+              "- runs with flaky: \(.summary.runsWithFlaky)",
+              "- rerun rate: \(.summary.rerunRatePercent)%",
+              "- avg flaky/run: \(.summary.averageFlakyPerRun)"
+            ' packages/obsidian-plugin/docs/FLAKY_DASHBOARD.json >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload dashboard JSON
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: flaky-dashboard
+          path: packages/obsidian-plugin/docs/FLAKY_DASHBOARD.json
+          retention-days: 90
+          if-no-files-found: warn

--- a/packages/obsidian-plugin/scripts/flaky-aggregate.ts
+++ b/packages/obsidian-plugin/scripts/flaky-aggregate.ts
@@ -1,0 +1,513 @@
+#!/usr/bin/env tsx
+/**
+ * flaky-aggregate.ts — RFC Phase 3.4 / T4.1
+ *
+ * Aggregates flaky-reporter.json artifacts across the last N main-branch CI
+ * runs and emits a single structured JSON consumable by the upcoming
+ * FLAKY_DASHBOARD renderer (Phase 3.4 §Output).
+ *
+ * Two execution modes:
+ *  - online (default): uses `gh` CLI to list runs and download artifacts
+ *  - offline (--input): reads already-downloaded artifact tree
+ *
+ * Run from monorepo root:
+ *   npx tsx packages/obsidian-plugin/scripts/flaky-aggregate.ts --limit 30
+ *   npx tsx packages/obsidian-plugin/scripts/flaky-aggregate.ts --input ./artifacts --dry-run
+ */
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const ARTIFACT_GLOB = "flaky*";
+const FLAKY_FILE_PATTERN = /flaky-report.*\.json$/i;
+
+export interface FlakyTestEntry {
+  file: string;
+  title: string;
+  retryCount: number;
+  duration: number;
+  source: string;
+  shard?: string;
+  project?: string;
+}
+
+export interface RawFlakyReport {
+  timestamp?: string;
+  totalFlaky?: number;
+  tests?: Array<Record<string, unknown>>;
+  summary?: {
+    totalTests?: number;
+    totalSuites?: number;
+    flakyPercentage?: number;
+  };
+}
+
+export interface RunMeta {
+  runId: number;
+  createdAt: string;
+  conclusion: string;
+  headSha: string;
+}
+
+export interface AggregateInput {
+  runs: Array<{
+    meta: RunMeta;
+    reports: Array<{ source: string; report: RawFlakyReport }>;
+  }>;
+}
+
+export interface AggregateOutput {
+  generatedAt: string;
+  schemaVersion: 1;
+  rollingWindow: {
+    requestedSize: number;
+    actualSize: number;
+    runIds: number[];
+  };
+  summary: {
+    totalRuns: number;
+    runsWithFlaky: number;
+    totalFlakyOccurrences: number;
+    averageFlakyPerRun: number;
+    rerunRatePercent: number;
+  };
+  perSpec: Array<{
+    file: string;
+    title: string;
+    occurrences: number;
+    rerunRate: number;
+    sources: string[];
+  }>;
+  perShard: Record<string, { runs: number; flaky: number }>;
+  perRun: Array<{
+    runId: number;
+    createdAt: string;
+    conclusion: string;
+    headSha: string;
+    totalFlaky: number;
+    sources: string[];
+  }>;
+}
+
+export interface CliOptions {
+  repo: string;
+  workflow: string;
+  branch: string;
+  limit: number;
+  output: string;
+  input?: string;
+  dryRun: boolean;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = {
+    repo: "kitelev/exocortex",
+    workflow: "ci.yml",
+    branch: "main",
+    limit: 30,
+    output: "packages/obsidian-plugin/docs/FLAKY_DASHBOARD.json",
+    dryRun: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => argv[++i];
+    switch (arg) {
+      case "--repo":
+        opts.repo = next();
+        break;
+      case "--workflow":
+        opts.workflow = next();
+        break;
+      case "--branch":
+        opts.branch = next();
+        break;
+      case "--limit":
+        opts.limit = Number(next());
+        break;
+      case "--output":
+      case "-o":
+        opts.output = next();
+        break;
+      case "--input":
+      case "-i":
+        opts.input = next();
+        break;
+      case "--dry-run":
+        opts.dryRun = true;
+        break;
+      case "--help":
+      case "-h":
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        if (arg.startsWith("--")) {
+          throw new Error(`Unknown flag: ${arg}`);
+        }
+    }
+  }
+  if (!Number.isFinite(opts.limit) || opts.limit <= 0) {
+    throw new Error(`--limit must be a positive integer, got: ${opts.limit}`);
+  }
+  return opts;
+}
+
+function printUsage(): void {
+  console.log(`Usage: flaky-aggregate.ts [options]
+
+Options:
+  --repo <slug>        owner/repo (default: kitelev/exocortex)
+  --workflow <file>    workflow filename (default: ci.yml)
+  --branch <name>      branch to scan (default: main)
+  --limit <N>          rolling window size (default: 30)
+  --output, -o <path>  output JSON path
+  --input, -i <dir>    offline mode: read artifacts from directory
+  --dry-run            skip downloads, print plan
+  --help, -h           show this help
+`);
+}
+
+function gh(args: string[]): string {
+  const proc = spawnSync("gh", args, {
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (proc.status !== 0) {
+    throw new Error(
+      `gh ${args.join(" ")} failed (exit ${proc.status}): ${proc.stderr}`,
+    );
+  }
+  return proc.stdout;
+}
+
+export function listRuns(
+  repo: string,
+  workflow: string,
+  branch: string,
+  limit: number,
+): RunMeta[] {
+  const json = gh([
+    "run",
+    "list",
+    "--repo",
+    repo,
+    "--workflow",
+    workflow,
+    "--branch",
+    branch,
+    "--limit",
+    String(limit),
+    "--json",
+    "databaseId,createdAt,conclusion,headSha,status",
+  ]);
+  const raw = JSON.parse(json) as Array<{
+    databaseId: number;
+    createdAt: string;
+    conclusion: string | null;
+    headSha: string;
+    status: string;
+  }>;
+  return raw
+    .filter((r) => r.status === "completed")
+    .map((r) => ({
+      runId: r.databaseId,
+      createdAt: r.createdAt,
+      conclusion: r.conclusion ?? "unknown",
+      headSha: r.headSha,
+    }));
+}
+
+export function downloadFlakyArtifacts(
+  repo: string,
+  runId: number,
+  destDir: string,
+): void {
+  fs.mkdirSync(destDir, { recursive: true });
+  // -p restricts artifacts by name pattern; some runs have none — exit 1 OK.
+  const proc = spawnSync(
+    "gh",
+    [
+      "run",
+      "download",
+      String(runId),
+      "--repo",
+      repo,
+      "-p",
+      ARTIFACT_GLOB,
+      "-D",
+      destDir,
+    ],
+    { encoding: "utf-8" },
+  );
+  // gh exits non-zero when nothing matches — treat as zero-flaky run.
+  if (proc.status !== 0 && !/no artifacts/i.test(proc.stderr ?? "")) {
+    // Don't throw — best-effort; warn so caller can debug.
+    console.warn(
+      `[warn] gh run download ${runId} returned ${proc.status}: ${proc.stderr?.trim()}`,
+    );
+  }
+}
+
+export function readReportsFromDir(
+  rootDir: string,
+): Array<{ source: string; report: RawFlakyReport }> {
+  if (!fs.existsSync(rootDir)) return [];
+  const out: Array<{ source: string; report: RawFlakyReport }> = [];
+  for (const entry of walk(rootDir)) {
+    if (!FLAKY_FILE_PATTERN.test(path.basename(entry))) continue;
+    try {
+      const text = fs.readFileSync(entry, "utf-8");
+      const report = JSON.parse(text) as RawFlakyReport;
+      const source = path
+        .relative(rootDir, entry)
+        .replace(/\\/g, "/")
+        .replace(/\.json$/i, "");
+      out.push({ source, report });
+    } catch (err) {
+      console.warn(`[warn] skipping unreadable report ${entry}: ${err}`);
+    }
+  }
+  return out;
+}
+
+function* walk(dir: string): Generator<string> {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) yield* walk(full);
+    else if (ent.isFile()) yield full;
+  }
+}
+
+export function normalizeTest(
+  raw: Record<string, unknown>,
+  source: string,
+): FlakyTestEntry {
+  const file = String(raw.file ?? "");
+  const title = String(raw.title ?? raw.name ?? "");
+  const retryCount = Number(raw.retryCount ?? 0);
+  const duration = Number(raw.duration ?? 0);
+  const project = typeof raw.project === "string" ? raw.project : undefined;
+  const shard = extractShardFromSource(source);
+  return {
+    file,
+    title,
+    retryCount: Number.isFinite(retryCount) ? retryCount : 0,
+    duration: Number.isFinite(duration) ? duration : 0,
+    source,
+    shard,
+    project,
+  };
+}
+
+function extractShardFromSource(source: string): string | undefined {
+  const m = source.match(/shard[-_]?(\d+)/i);
+  return m ? `shard-${m[1]}` : undefined;
+}
+
+export function aggregate(input: AggregateInput, requestedSize: number): AggregateOutput {
+  const perSpecMap = new Map<
+    string,
+    { file: string; title: string; occurrences: number; sources: Set<string> }
+  >();
+  const perShard = new Map<string, { runs: number; flaky: number }>();
+  const perRun: AggregateOutput["perRun"] = [];
+  let runsWithFlaky = 0;
+  let totalFlakyOccurrences = 0;
+
+  for (const run of input.runs) {
+    const sources = new Set<string>();
+    let runFlaky = 0;
+    const shardsTouched = new Set<string>();
+
+    for (const { source, report } of run.reports) {
+      sources.add(source);
+      const tests = (report.tests ?? []).map((t) => normalizeTest(t, source));
+      const shard = extractShardFromSource(source);
+      if (shard) shardsTouched.add(shard);
+      for (const t of tests) {
+        const key = `${t.file}::${t.title}`;
+        const existing = perSpecMap.get(key);
+        if (existing) {
+          existing.occurrences++;
+          existing.sources.add(t.source);
+        } else {
+          perSpecMap.set(key, {
+            file: t.file,
+            title: t.title,
+            occurrences: 1,
+            sources: new Set([t.source]),
+          });
+        }
+      }
+      runFlaky += tests.length;
+    }
+
+    for (const shard of shardsTouched) {
+      const entry = perShard.get(shard) ?? { runs: 0, flaky: 0 };
+      entry.runs++;
+      perShard.set(shard, entry);
+    }
+    // Record flaky counts per shard touched in this run
+    for (const { source, report } of run.reports) {
+      const shard = extractShardFromSource(source);
+      if (!shard) continue;
+      const entry = perShard.get(shard) ?? { runs: 0, flaky: 0 };
+      entry.flaky += (report.tests ?? []).length;
+      perShard.set(shard, entry);
+    }
+
+    if (runFlaky > 0) runsWithFlaky++;
+    totalFlakyOccurrences += runFlaky;
+    perRun.push({
+      runId: run.meta.runId,
+      createdAt: run.meta.createdAt,
+      conclusion: run.meta.conclusion,
+      headSha: run.meta.headSha,
+      totalFlaky: runFlaky,
+      sources: Array.from(sources).sort(),
+    });
+  }
+
+  const totalRuns = input.runs.length;
+  const perSpec = Array.from(perSpecMap.values())
+    .map((s) => ({
+      file: s.file,
+      title: s.title,
+      occurrences: s.occurrences,
+      rerunRate:
+        totalRuns > 0 ? Number(((s.occurrences / totalRuns) * 100).toFixed(2)) : 0,
+      sources: Array.from(s.sources).sort(),
+    }))
+    .sort((a, b) => b.occurrences - a.occurrences || a.file.localeCompare(b.file));
+
+  return {
+    generatedAt: new Date().toISOString(),
+    schemaVersion: 1,
+    rollingWindow: {
+      requestedSize,
+      actualSize: totalRuns,
+      runIds: input.runs.map((r) => r.meta.runId),
+    },
+    summary: {
+      totalRuns,
+      runsWithFlaky,
+      totalFlakyOccurrences,
+      averageFlakyPerRun:
+        totalRuns > 0
+          ? Number((totalFlakyOccurrences / totalRuns).toFixed(2))
+          : 0,
+      rerunRatePercent:
+        totalRuns > 0
+          ? Number(((runsWithFlaky / totalRuns) * 100).toFixed(2))
+          : 0,
+    },
+    perSpec,
+    perShard: Object.fromEntries(
+      Array.from(perShard.entries()).sort(([a], [b]) => a.localeCompare(b)),
+    ),
+    perRun: perRun.sort((a, b) => b.runId - a.runId),
+  };
+}
+
+function collectRuns(opts: CliOptions): AggregateInput {
+  if (opts.input) {
+    return collectFromInputDir(opts.input);
+  }
+  return collectFromGitHub(opts);
+}
+
+function collectFromInputDir(rootDir: string): AggregateInput {
+  // Layout: <rootDir>/<runId>/<artifact-dir>/*.json
+  // Or:     <rootDir>/<artifact-dir>/*.json (single run)
+  const entries = fs
+    .readdirSync(rootDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory());
+  const numericChildren = entries.filter((e) => /^\d+$/.test(e.name));
+  if (numericChildren.length > 0) {
+    return {
+      runs: numericChildren.map((e) => {
+        const dir = path.join(rootDir, e.name);
+        const stat = fs.statSync(dir);
+        return {
+          meta: {
+            runId: Number(e.name),
+            createdAt: stat.mtime.toISOString(),
+            conclusion: "unknown",
+            headSha: "",
+          },
+          reports: readReportsFromDir(dir),
+        };
+      }),
+    };
+  }
+  // Treat entire rootDir as one synthetic run
+  const stat = fs.statSync(rootDir);
+  return {
+    runs: [
+      {
+        meta: {
+          runId: 0,
+          createdAt: stat.mtime.toISOString(),
+          conclusion: "unknown",
+          headSha: "",
+        },
+        reports: readReportsFromDir(rootDir),
+      },
+    ],
+  };
+}
+
+function collectFromGitHub(opts: CliOptions): AggregateInput {
+  const runs = listRuns(opts.repo, opts.workflow, opts.branch, opts.limit);
+  if (opts.dryRun) {
+    console.log(
+      `[dry-run] would download flaky artifacts for ${runs.length} runs`,
+    );
+    return { runs: runs.map((meta) => ({ meta, reports: [] })) };
+  }
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "flaky-agg-"));
+  try {
+    return {
+      runs: runs.map((meta) => {
+        const runDir = path.join(tmp, String(meta.runId));
+        downloadFlakyArtifacts(opts.repo, meta.runId, runDir);
+        return { meta, reports: readReportsFromDir(runDir) };
+      }),
+    };
+  } finally {
+    // Best-effort cleanup; skip on dry-run
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export function runCli(argv: string[]): void {
+  const opts = parseArgs(argv);
+  const input = collectRuns(opts);
+  const output = aggregate(input, opts.limit);
+  const outPath = path.resolve(opts.output);
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2) + "\n", "utf-8");
+  const { totalRuns, runsWithFlaky, rerunRatePercent } = output.summary;
+  console.log(
+    `flaky-aggregate: wrote ${outPath} (${totalRuns} runs, ${runsWithFlaky} with flaky, rerunRate=${rerunRatePercent}%)`,
+  );
+}
+
+function isInvokedAsScript(): boolean {
+  const entry = process.argv[1] ?? "";
+  return /flaky-aggregate\.[mc]?[tj]s$/.test(entry);
+}
+
+if (isInvokedAsScript()) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (err) {
+    console.error(`flaky-aggregate failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/flaky-aggregate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/flaky-aggregate.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for scripts/flaky-aggregate.ts (RFC Phase 3.4 / T4.1).
+ *
+ * The script has two surfaces: pure data functions (parseArgs, normalizeTest,
+ * aggregate, readReportsFromDir) and gh-CLI bound collectors. Tests cover the
+ * pure surface with synthetic input — no network, no gh dependency.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  aggregate,
+  normalizeTest,
+  parseArgs,
+  readReportsFromDir,
+  type AggregateInput,
+  type RawFlakyReport,
+} from "../../scripts/flaky-aggregate";
+
+describe("flaky-aggregate / parseArgs", () => {
+  it("returns defaults with empty argv", () => {
+    const opts = parseArgs([]);
+    expect(opts).toEqual({
+      repo: "kitelev/exocortex",
+      workflow: "ci.yml",
+      branch: "main",
+      limit: 30,
+      output: "packages/obsidian-plugin/docs/FLAKY_DASHBOARD.json",
+      dryRun: false,
+    });
+  });
+
+  it("overrides values from flags", () => {
+    const opts = parseArgs([
+      "--repo",
+      "foo/bar",
+      "--limit",
+      "10",
+      "--output",
+      "/tmp/out.json",
+      "--dry-run",
+    ]);
+    expect(opts.repo).toBe("foo/bar");
+    expect(opts.limit).toBe(10);
+    expect(opts.output).toBe("/tmp/out.json");
+    expect(opts.dryRun).toBe(true);
+  });
+
+  it("rejects non-positive --limit", () => {
+    expect(() => parseArgs(["--limit", "0"])).toThrow(/positive integer/);
+    expect(() => parseArgs(["--limit", "abc"])).toThrow(/positive integer/);
+  });
+
+  it("rejects unknown flags", () => {
+    expect(() => parseArgs(["--bogus"])).toThrow(/Unknown flag/);
+  });
+});
+
+describe("flaky-aggregate / normalizeTest", () => {
+  it("handles jest-style fields (name)", () => {
+    const t = normalizeTest(
+      { file: "a.test.ts", name: "should X", retryCount: 2, duration: 100 },
+      "flaky-report-shard-3/flaky-report-shard-3",
+    );
+    expect(t).toMatchObject({
+      file: "a.test.ts",
+      title: "should X",
+      retryCount: 2,
+      duration: 100,
+      shard: "shard-3",
+    });
+  });
+
+  it("handles playwright-style fields (title, project)", () => {
+    const t = normalizeTest(
+      {
+        file: "smoke.spec.ts",
+        title: "renders",
+        retryCount: 1,
+        duration: 5000,
+        project: "obsidian-electron",
+      },
+      "flaky-test-report-component/flaky-report-playwright",
+    );
+    expect(t.title).toBe("renders");
+    expect(t.project).toBe("obsidian-electron");
+    expect(t.shard).toBeUndefined();
+  });
+
+  it("coerces bad numerics to 0", () => {
+    const t = normalizeTest(
+      { file: "x", title: "y", retryCount: "nan" as unknown as number },
+      "src",
+    );
+    expect(t.retryCount).toBe(0);
+    expect(t.duration).toBe(0);
+  });
+});
+
+describe("flaky-aggregate / aggregate", () => {
+  const baseReport = (count: number, file = "spec.test.ts"): RawFlakyReport => ({
+    timestamp: "2026-04-30T00:00:00Z",
+    totalFlaky: count,
+    tests: Array.from({ length: count }, (_, i) => ({
+      file,
+      name: `case ${i}`,
+      retryCount: 1,
+      duration: 10,
+    })),
+    summary: { totalTests: 100, flakyPercentage: count },
+  });
+
+  it("returns empty-shaped output for empty input", () => {
+    const out = aggregate({ runs: [] }, 30);
+    expect(out.summary).toEqual({
+      totalRuns: 0,
+      runsWithFlaky: 0,
+      totalFlakyOccurrences: 0,
+      averageFlakyPerRun: 0,
+      rerunRatePercent: 0,
+    });
+    expect(out.perSpec).toEqual([]);
+    expect(out.perShard).toEqual({});
+    expect(out.rollingWindow.requestedSize).toBe(30);
+    expect(out.rollingWindow.actualSize).toBe(0);
+  });
+
+  it("aggregates across runs and computes rerunRate", () => {
+    const input: AggregateInput = {
+      runs: [
+        {
+          meta: {
+            runId: 100,
+            createdAt: "2026-04-30T01:00:00Z",
+            conclusion: "success",
+            headSha: "a1",
+          },
+          reports: [
+            { source: "flaky-report-shard-1/flaky-report-shard-1", report: baseReport(2) },
+          ],
+        },
+        {
+          meta: {
+            runId: 101,
+            createdAt: "2026-04-30T02:00:00Z",
+            conclusion: "success",
+            headSha: "a2",
+          },
+          reports: [
+            { source: "flaky-report-shard-1/flaky-report-shard-1", report: baseReport(1) },
+          ],
+        },
+        {
+          meta: {
+            runId: 102,
+            createdAt: "2026-04-30T03:00:00Z",
+            conclusion: "success",
+            headSha: "a3",
+          },
+          reports: [
+            { source: "flaky-report-shard-2/flaky-report-shard-2", report: baseReport(0) },
+          ],
+        },
+      ],
+    };
+
+    const out = aggregate(input, 30);
+    expect(out.summary.totalRuns).toBe(3);
+    expect(out.summary.runsWithFlaky).toBe(2);
+    expect(out.summary.totalFlakyOccurrences).toBe(3);
+    expect(out.summary.rerunRatePercent).toBeCloseTo(66.67, 1);
+    expect(out.summary.averageFlakyPerRun).toBe(1);
+
+    expect(out.perShard["shard-1"]).toEqual({ runs: 2, flaky: 3 });
+    expect(out.perShard["shard-2"]).toEqual({ runs: 1, flaky: 0 });
+
+    // run 100 contributes case 0 + case 1; run 101 contributes case 0; run 102 has no tests
+    expect(out.perSpec).toHaveLength(2);
+    expect(out.perSpec[0].occurrences).toBe(2); // "case 0" appears in 2 runs
+    expect(out.perSpec[1].occurrences).toBe(1); // "case 1" appears once
+
+    expect(out.perRun.map((r) => r.runId)).toEqual([102, 101, 100]);
+    expect(out.rollingWindow.runIds).toContain(100);
+  });
+
+  it("groups same (file,title) across runs into single perSpec entry", () => {
+    const same = {
+      file: "a.test.ts",
+      name: "shared",
+      retryCount: 1,
+      duration: 1,
+    };
+    const report: RawFlakyReport = {
+      tests: [same],
+      totalFlaky: 1,
+      summary: { totalTests: 10, flakyPercentage: 10 },
+    };
+    const input: AggregateInput = {
+      runs: [
+        {
+          meta: { runId: 1, createdAt: "x", conclusion: "success", headSha: "h" },
+          reports: [{ source: "flaky-report-shard-1/x", report }],
+        },
+        {
+          meta: { runId: 2, createdAt: "y", conclusion: "success", headSha: "h" },
+          reports: [{ source: "flaky-report-shard-1/x", report }],
+        },
+      ],
+    };
+    const out = aggregate(input, 30);
+    expect(out.perSpec).toHaveLength(1);
+    expect(out.perSpec[0]).toMatchObject({
+      file: "a.test.ts",
+      title: "shared",
+      occurrences: 2,
+      rerunRate: 100,
+    });
+  });
+});
+
+describe("flaky-aggregate / readReportsFromDir", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "flaky-agg-test-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns empty array for missing directory", () => {
+    expect(readReportsFromDir(path.join(tmp, "nope"))).toEqual([]);
+  });
+
+  it("skips non-flaky-named JSON files", () => {
+    fs.writeFileSync(path.join(tmp, "other.json"), "{}");
+    expect(readReportsFromDir(tmp)).toEqual([]);
+  });
+
+  it("loads matching report files recursively", () => {
+    const sub = path.join(tmp, "flaky-report-shard-1");
+    fs.mkdirSync(sub);
+    fs.writeFileSync(
+      path.join(sub, "flaky-report-shard-1.json"),
+      JSON.stringify({ totalFlaky: 0, tests: [] }),
+    );
+    fs.writeFileSync(
+      path.join(tmp, "flaky-report-playwright.json"),
+      JSON.stringify({ totalFlaky: 1, tests: [{ file: "x", title: "y" }] }),
+    );
+    const reports = readReportsFromDir(tmp);
+    expect(reports).toHaveLength(2);
+    const sources = reports.map((r) => r.source).sort();
+    expect(sources[0]).toMatch(/flaky-report-playwright/);
+    expect(sources[1]).toMatch(/flaky-report-shard-1/);
+  });
+
+  it("skips unreadable JSON without throwing", () => {
+    fs.writeFileSync(path.join(tmp, "flaky-report.json"), "not-json{");
+    expect(() => readReportsFromDir(tmp)).not.toThrow();
+    expect(readReportsFromDir(tmp)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

RFC Phase 3.4 / T4.1 — adds the rolling-30-runs flaky aggregator that
the upcoming `FLAKY_DASHBOARD` renderer (next subtask) consumes. The
aggregator pulls flaky-reporter artifacts off recent main runs via
`gh run list/download`, normalizes jest- and playwright-shaped entries,
and emits a single structured JSON.

- `packages/obsidian-plugin/scripts/flaky-aggregate.ts` — CLI/library:
  - online mode (default): walks last N main runs of `ci.yml`
  - offline mode (`--input <dir>`): aggregates pre-downloaded artifacts
  - normalizes jest (`name`) ↔ playwright (`title`) shapes
  - per-spec rerun rate, per-shard counts, per-run breakdown
- `packages/obsidian-plugin/tests/unit/flaky-aggregate.test.ts` —
  14 unit tests covering arg parsing, normalization, aggregation math,
  perSpec dedup, and offline-mode directory walking.
- `.github/workflows/flaky-dashboard.yml` — weekly cron (Mondays
  06:00 UTC) + workflow_dispatch; uploads JSON as 90-day artifact.

No production code touched; read-only over repo content.

Source: [Task 66e3befe](https://github.com/kitelev/exocortex/issues/2974) (issue context: RFC Phase 3 successor to RFC 3cc77ba2).

## Test plan
- [x] `npx jest …/flaky-aggregate.test.ts` — 14/14 pass
- [x] `npx tsx flaky-aggregate.ts --input … --output …` smoke (offline) — wrote dashboard.json with correct shape
- [x] `npx tsc -noEmit -skipLibCheck` clean
- [x] `npm run lint` 0 errors (2 pre-existing warnings)
- [ ] CI: 13 required checks green (auto via PR)