### PR TITLE
feat(exoql): PR2 — AST-allowlist parser + exo:eval + eval-budget at flag (RFC c78cc5c8 Phase 1a, T2)

### DIFF
--- a/packages/exocortex/src/exoql/AllowlistValidator.ts
+++ b/packages/exocortex/src/exoql/AllowlistValidator.ts
@@ -1,0 +1,122 @@
+/**
+ * AST allowlist validator for exoql__Query bodies.
+ *
+ * RFC c78cc5c8 Phase 1a — exoql__Query + exo:eval MVP.
+ *
+ * The allowlist permits SELECT and ASK queries only. Any of the following
+ * are rejected at parse-time (BEFORE any execution against the triple store)
+ * with `ExoQLForbiddenKeywordError`:
+ *
+ *  - `UPDATE` (any update operation: INSERT/DELETE DATA, INSERT/DELETE WHERE,
+ *    LOAD, CLEAR, CREATE, DROP, COPY, MOVE, ADD).
+ *  - `FROM`  / `FROM NAMED` dataset clauses (federated dataset selection).
+ *  - `SERVICE` patterns (federated query to remote endpoints).
+ *  - `LOAD` (data import — sub-case of UPDATE; flagged with its specific
+ *    keyword so the error message names it accurately).
+ *
+ * The validator is INDEPENDENT of the `exoql.eval.enabled` feature flag —
+ * it is a security guard for the parser-stage, not a feature gate. It runs
+ * regardless of B2 lock state.
+ *
+ * Walking strategy: depth-first traversal of the parsed sparqljs AST. For
+ * SERVICE patterns (which can appear anywhere in WHERE/OPTIONAL/UNION/MINUS
+ * groups), we walk the pattern tree recursively. For UPDATE / LOAD we
+ * inspect `query.type === "update"` and the per-update `type` discriminator.
+ */
+
+import type { SPARQLQuery } from "../infrastructure/sparql/SPARQLParser";
+import { ExoQLForbiddenKeywordError } from "./eval-errors";
+
+interface PatternLike {
+  type?: string;
+  patterns?: PatternLike[];
+}
+
+interface UpdateOpLike {
+  type?: string;
+  updateType?: string;
+}
+
+interface DatasetClause {
+  default?: unknown[];
+  named?: unknown[];
+}
+
+interface QueryWithDataset {
+  type?: string;
+  queryType?: string;
+  from?: DatasetClause;
+  where?: PatternLike[];
+  template?: PatternLike[];
+}
+
+/**
+ * Walk a SPARQL AST and throw `ExoQLForbiddenKeywordError` if any banned
+ * construct is present. Returns silently on success.
+ *
+ * @param query Parsed sparqljs AST (the value returned by `ExoQLParser.parse`)
+ * @throws ExoQLForbiddenKeywordError on the first banned construct encountered
+ */
+export function validateExoQLAllowlist(query: SPARQLQuery): void {
+  if (!query || typeof query !== "object") return;
+
+  const q = query as unknown as QueryWithDataset;
+
+  // 1. UPDATE is a top-level discriminator in sparqljs.
+  if (q.type === "update") {
+    const updates =
+      (query as unknown as { updates?: UpdateOpLike[] }).updates ?? [];
+    // Surface LOAD specifically when the update is exclusively a LOAD — the
+    // BDD scenario expects the error message to name the keyword the user wrote.
+    for (const op of updates) {
+      if (op?.type === "load") {
+        throw new ExoQLForbiddenKeywordError("LOAD");
+      }
+    }
+    throw new ExoQLForbiddenKeywordError("UPDATE");
+  }
+
+  if (q.type !== "query") return;
+
+  // 2. FROM / FROM NAMED dataset clauses.
+  if (q.from) {
+    const hasDefault =
+      Array.isArray(q.from.default) && q.from.default.length > 0;
+    const hasNamed = Array.isArray(q.from.named) && q.from.named.length > 0;
+    if (hasDefault || hasNamed) {
+      throw new ExoQLForbiddenKeywordError("FROM");
+    }
+  }
+
+  // 3. SERVICE inside WHERE (or any pattern subtree).
+  if (Array.isArray(q.where)) {
+    for (const p of q.where) walkPatternForBannedKeywords(p);
+  }
+
+  // 4. CONSTRUCT template body — patterns can host SERVICE in unusual cases.
+  if (Array.isArray(q.template)) {
+    for (const p of q.template) walkPatternForBannedKeywords(p);
+  }
+}
+
+function walkPatternForBannedKeywords(pattern: PatternLike | undefined): void {
+  if (!pattern || typeof pattern !== "object") return;
+
+  if (pattern.type === "service") {
+    throw new ExoQLForbiddenKeywordError("SERVICE");
+  }
+
+  // sparqljs nests subgroups under `patterns` for: group, optional, union,
+  // minus, graph, service (already handled), bind, filter, query (subquery).
+  if (Array.isArray(pattern.patterns)) {
+    for (const child of pattern.patterns) {
+      walkPatternForBannedKeywords(child);
+    }
+  }
+
+  // Subqueries hang the inner SELECT under `.query` — recurse into its WHERE.
+  const inner = (pattern as unknown as { where?: PatternLike[] }).where;
+  if (Array.isArray(inner)) {
+    for (const child of inner) walkPatternForBannedKeywords(child);
+  }
+}

--- a/packages/exocortex/src/exoql/eval-config.ts
+++ b/packages/exocortex/src/exoql/eval-config.ts
@@ -1,0 +1,43 @@
+/**
+ * Configuration for the exoql__Query + exo:eval evaluator.
+ *
+ * RFC c78cc5c8 Phase 1a — exoql__Query + exo:eval MVP.
+ *
+ * The default config keeps `enabled: false` (B2 lock — PR2 ships inert; PR3
+ * flips the flag in user-facing settings). Budget defaults are the values
+ * declared in the BDD scenarios (`packages/obsidian-plugin/specs/features/
+ * exoql/exoql-eval.feature`): ≤100 nested invocations, ≤10 000 ms aggregate
+ * wall-clock per top-level query.
+ */
+export interface ExoQLEvalConfig {
+  /**
+   * Master feature flag (`exoql.eval.enabled`). When `false`, every public
+   * entry-point throws `ExoQLEvalDisabledError` BEFORE any work happens — the
+   * only paths that remain hot are the always-on parser allowlist (which is a
+   * safety guard, not a feature) and the registry symbol lookup.
+   */
+  enabled: boolean;
+
+  /**
+   * Maximum number of nested `exo:eval` calls per top-level query.
+   * Counted across the whole call-tree, not per recursion depth.
+   * The 101st invocation raises `ExoQLBudgetExceededError`.
+   */
+  maxNestedEvalCount: number;
+
+  /**
+   * Maximum aggregate wall-clock time spent inside nested evaluations,
+   * measured in milliseconds and counted across the whole call-tree.
+   * Crossing the threshold raises `ExoQLBudgetExceededError`.
+   */
+  maxAggregateEvalMillis: number;
+}
+
+/**
+ * Default config — inert (`enabled: false`, B2 lock) with PR3 budget defaults.
+ */
+export const DEFAULT_EVAL_CONFIG: ExoQLEvalConfig = Object.freeze({
+  enabled: false,
+  maxNestedEvalCount: 100,
+  maxAggregateEvalMillis: 10_000,
+});

--- a/packages/exocortex/src/exoql/eval-errors.ts
+++ b/packages/exocortex/src/exoql/eval-errors.ts
@@ -1,0 +1,70 @@
+/**
+ * Error classes for the exoql__Query + exo:eval pipeline.
+ *
+ * RFC c78cc5c8 Phase 1a — exoql__Query + exo:eval MVP.
+ *
+ * Each error inherits from Error and sets a stable `name` so tests / callers
+ * can match by `error.name === "ExoQLForbiddenKeywordError"` or via
+ * `instanceof`. The names are also asserted against in the BDD red-anchor
+ * suite (`packages/obsidian-plugin/tests/unit/exoql/exoql-eval-stubs.test.ts`).
+ */
+
+export class ExoQLForbiddenKeywordError extends Error {
+  public readonly keyword: string;
+
+  constructor(keyword: string, message?: string) {
+    super(
+      message ??
+        `ExoQLForbiddenKeywordError: keyword "${keyword}" is not permitted by the exoql__Query AST allowlist`,
+    );
+    this.name = "ExoQLForbiddenKeywordError";
+    this.keyword = keyword;
+  }
+}
+
+export class ExoQLEvalDisabledError extends Error {
+  constructor(message?: string) {
+    super(
+      message ??
+        "ExoQLEvalDisabledError: exoql.eval.enabled is false (default). Flip the feature flag to opt in.",
+    );
+    this.name = "ExoQLEvalDisabledError";
+  }
+}
+
+export class ExoQLCycleError extends Error {
+  public readonly path: ReadonlyArray<string>;
+
+  constructor(path: ReadonlyArray<string>, message?: string) {
+    super(
+      message ??
+        `ExoQLCycleError: cycle detected in nested exo:eval invocations: ${path.join(" → ")}`,
+    );
+    this.name = "ExoQLCycleError";
+    this.path = path;
+  }
+}
+
+export type ExoQLBudgetKind = "nested-eval-count" | "aggregate-eval-millis";
+
+export class ExoQLBudgetExceededError extends Error {
+  public readonly budget: ExoQLBudgetKind;
+  public readonly limit: number;
+  public readonly observed: number;
+
+  constructor(
+    budget: ExoQLBudgetKind,
+    limit: number,
+    observed: number,
+    message?: string,
+  ) {
+    super(
+      message ??
+        `ExoQLBudgetExceededError: ${budget} budget exceeded (limit=${limit}, observed=${observed})`,
+    );
+    this.name = "ExoQLBudgetExceededError";
+    this.budget = budget;
+    this.limit = limit;
+    this.observed = observed;
+  }
+}

--- a/packages/exocortex/src/exoql/evaluateWithExoEval.ts
+++ b/packages/exocortex/src/exoql/evaluateWithExoEval.ts
@@ -1,0 +1,80 @@
+/**
+ * Public entry-point for the exoql__Query + exo:eval pipeline (PR2 inert).
+ *
+ * RFC c78cc5c8 Phase 1a — exoql__Query + exo:eval MVP.
+ *
+ *  1. **Always-on AST allowlist** — parses the input via `ExoQLParser` and
+ *     rejects SERVICE / FROM / LOAD / UPDATE on parse-stage with
+ *     `ExoQLForbiddenKeywordError`. Independent of the feature flag — this
+ *     is a safety guard, not a feature.
+ *
+ *  2. **Feature-flag gate** — when `config.enabled === false` (the default,
+ *     B2 lock for PR2), throws `ExoQLEvalDisabledError`. PR3 (T4) flips the
+ *     default to `true` once the dogfood store wiring lands.
+ *
+ *  3. **Recursive eval engine** — when the flag is `true`, walks the parsed
+ *     query for `exo:eval(<urn>)` invocations, recursively fetches the
+ *     referenced exoql__Query body from the triple store, and executes it
+ *     under a shared budget (max nested invocations / aggregate millis) and
+ *     a path-tracked cycle detector (`ExoQLCycleError`). PR3 wires the
+ *     ITripleStore consumer; PR2 ships the structural skeleton so the
+ *     symbol exists for Jest TDD red-anchors.
+ *
+ * Test contract:
+ *   • Synchronous return type (matches `it.failing` red-anchors in
+ *     `packages/obsidian-plugin/tests/unit/exoql/exoql-eval-stubs.test.ts`).
+ *   • The function symbol MUST be exported from
+ *     `packages/exocortex/src/exoql/index.ts` so
+ *     `require("…/exocortex/src/exoql").evaluateWithExoEval` returns it.
+ */
+
+import { ExoQLParser } from "../infrastructure/sparql/SPARQLParser";
+import type { ITripleStore } from "../interfaces/ITripleStore";
+import { validateExoQLAllowlist } from "./AllowlistValidator";
+import { DEFAULT_EVAL_CONFIG, type ExoQLEvalConfig } from "./eval-config";
+import { ExoQLEvalDisabledError } from "./eval-errors";
+
+export interface EvaluateWithExoEvalOptions {
+  /** Triple store the recursive engine queries against (PR3 wiring). */
+  store?: ITripleStore;
+  /** Per-invocation config override; falls back to DEFAULT_EVAL_CONFIG. */
+  config?: Partial<ExoQLEvalConfig>;
+}
+
+/**
+ * Synchronously parse, validate, and (when enabled) evaluate a SPARQL string
+ * containing `exo:eval(<urn>)` calls.
+ *
+ * On PR2 (inert): throws `ExoQLEvalDisabledError` when the flag is `false`.
+ *
+ * @param sparql  SPARQL string (SELECT or ASK; UPDATE/FROM/SERVICE/LOAD banned)
+ * @param options Triple store + config override
+ * @returns       Solution rows (PR2: empty array — never reached when inert)
+ */
+export function evaluateWithExoEval(
+  sparql: string,
+  options: EvaluateWithExoEvalOptions = {},
+): unknown[] {
+  if (typeof sparql !== "string") {
+    throw new TypeError("evaluateWithExoEval: sparql must be a string");
+  }
+
+  // 1. Parse — surfaces SPARQLParseError for malformed input.
+  const parser = new ExoQLParser();
+  const ast = parser.parse(sparql);
+
+  // 2. AST allowlist (always on — independent of flag).
+  validateExoQLAllowlist(ast);
+
+  // 3. Feature-flag gate.
+  const config: ExoQLEvalConfig = {
+    ...DEFAULT_EVAL_CONFIG,
+    ...(options.config ?? {}),
+  };
+  if (!config.enabled) {
+    throw new ExoQLEvalDisabledError();
+  }
+
+  // 4. PR3 wiring slot — recursive engine attaches here. PR2 returns [].
+  return [];
+}

--- a/packages/exocortex/src/exoql/index.ts
+++ b/packages/exocortex/src/exoql/index.ts
@@ -1,5 +1,10 @@
 import type { ITripleStore } from "../interfaces/ITripleStore";
-import type { Triple, Subject, Predicate, Object as RDFObject } from "../domain/models/rdf/Triple";
+import type {
+  Triple,
+  Subject,
+  Predicate,
+  Object as RDFObject,
+} from "../domain/models/rdf/Triple";
 import { ExoQLParser } from "../infrastructure/sparql/SPARQLParser";
 import { ExoQLAlgebraTranslator } from "../infrastructure/sparql/algebra/AlgebraTranslator";
 import {
@@ -13,6 +18,21 @@ import type {
 } from "../infrastructure/sparql/algebra/AlgebraOperation";
 import { SourceAnnotator, SOURCE_VARIABLE } from "../services/SourceAnnotator";
 import { Literal } from "../domain/models/rdf/Literal";
+
+// RFC c78cc5c8 Phase 1a — exoql__Query + exo:eval MVP (PR2 inert surface).
+export {
+  evaluateWithExoEval,
+  type EvaluateWithExoEvalOptions,
+} from "./evaluateWithExoEval";
+export { validateExoQLAllowlist } from "./AllowlistValidator";
+export { DEFAULT_EVAL_CONFIG, type ExoQLEvalConfig } from "./eval-config";
+export {
+  ExoQLForbiddenKeywordError,
+  ExoQLEvalDisabledError,
+  ExoQLCycleError,
+  ExoQLBudgetExceededError,
+  type ExoQLBudgetKind,
+} from "./eval-errors";
 
 /**
  * ExoQL  public facade for executing SPARQL queries against a triple store.

--- a/packages/exocortex/src/infrastructure/sparql/filters/FunctionRegistry.ts
+++ b/packages/exocortex/src/infrastructure/sparql/filters/FunctionRegistry.ts
@@ -27,7 +27,10 @@ export interface FunctionContext {
   /** Evaluate an expression and get the result */
   evaluateExpression: (expr: Expression, solution: SolutionMapping) => unknown;
   /** Get term from expression (for RDF term functions) */
-  getTermFromExpression: (expr: Expression, solution: SolutionMapping) => unknown;
+  getTermFromExpression: (
+    expr: Expression,
+    solution: SolutionMapping,
+  ) => unknown;
   /** Convert value to string */
   getStringValue: (value: unknown) => string;
   /** Current solution mapping */
@@ -46,7 +49,7 @@ export interface FunctionContext {
  */
 export type FunctionHandler = (
   args: Expression[],
-  ctx: FunctionContext
+  ctx: FunctionContext,
 ) => unknown;
 
 /**
@@ -60,36 +63,50 @@ export const functionHandlers: Map<string, FunctionHandler> = new Map();
 // =============================================================================
 
 functionHandlers.set("str", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.str(term);
 });
 
 functionHandlers.set("lang", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.lang(term);
 });
 
 functionHandlers.set("langmatches", (args, ctx) => {
-  const langTag = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const langRange = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const langTag = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const langRange = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   return BuiltInFunctions.langMatches(langTag, langRange);
 });
 
 functionHandlers.set("contains", (args, ctx) => {
   const str = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const substr = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const substr = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   return BuiltInFunctions.contains(str, substr);
 });
 
 functionHandlers.set("strstarts", (args, ctx) => {
   const str = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const prefix = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const prefix = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   return BuiltInFunctions.strStarts(str, prefix);
 });
 
 functionHandlers.set("strends", (args, ctx) => {
   const str = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const suffix = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const suffix = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   return BuiltInFunctions.strEnds(str, suffix);
 });
 
@@ -132,15 +149,19 @@ functionHandlers.set("strafter", (args, ctx) => {
 
 functionHandlers.set("concat", (args, ctx) => {
   const concatArgs = args.map((arg) =>
-    ctx.getStringValue(ctx.evaluateExpression(arg, ctx.solution))
+    ctx.getStringValue(ctx.evaluateExpression(arg, ctx.solution)),
   );
   return BuiltInFunctions.concat(...concatArgs);
 });
 
 functionHandlers.set("replace", (args, ctx) => {
   const str = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const pattern = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
-  const replacement = ctx.getStringValue(ctx.evaluateExpression(args[2], ctx.solution));
+  const pattern = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
+  const replacement = ctx.getStringValue(
+    ctx.evaluateExpression(args[2], ctx.solution),
+  );
   const flags = args[3]
     ? ctx.getStringValue(ctx.evaluateExpression(args[3], ctx.solution))
     : undefined;
@@ -148,8 +169,12 @@ functionHandlers.set("replace", (args, ctx) => {
 });
 
 functionHandlers.set("regex", (args, ctx) => {
-  const text = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const pattern = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const text = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const pattern = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   const flags = args[2]
     ? ctx.getStringValue(ctx.evaluateExpression(args[2], ctx.solution))
     : undefined;
@@ -166,7 +191,9 @@ functionHandlers.set("encode_for_uri", (args, ctx) => {
 // =============================================================================
 
 functionHandlers.set("datatype", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.datatype(term).value;
 });
 
@@ -181,40 +208,56 @@ functionHandlers.set("bound", (args, ctx) => {
 
 // Register both isiri and isuri (aliases)
 const isIriHandler: FunctionHandler = (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.isIRI(term);
 };
 functionHandlers.set("isiri", isIriHandler);
 functionHandlers.set("isuri", isIriHandler);
 
 functionHandlers.set("isblank", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.isBlank(term);
 });
 
 functionHandlers.set("isliteral", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.isLiteral(term);
 });
 
 functionHandlers.set("isnumeric", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.isNumeric(term);
 });
 
 functionHandlers.set("haslangdir", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.hasLangdir(term);
 });
 
 functionHandlers.set("istriple", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.isTriple(term);
 });
 
 functionHandlers.set("sameterm", (args, ctx) => {
-  const term1 = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
-  const term2 = ctx.getTermFromExpression(args[1], ctx.solution) as RDFTerm | undefined;
+  const term1 = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
+  const term2 = ctx.getTermFromExpression(args[1], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.sameTerm(term1, term2);
 });
 
@@ -223,22 +266,30 @@ functionHandlers.set("sameterm", (args, ctx) => {
 // =============================================================================
 
 functionHandlers.set("abs", (args, ctx) => {
-  const num = Number(ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution)));
+  const num = Number(
+    ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution)),
+  );
   return BuiltInFunctions.abs(num);
 });
 
 functionHandlers.set("round", (args, ctx) => {
-  const num = Number(ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution)));
+  const num = Number(
+    ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution)),
+  );
   return BuiltInFunctions.round(num);
 });
 
 functionHandlers.set("ceil", (args, ctx) => {
-  const num = Number(ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution)));
+  const num = Number(
+    ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution)),
+  );
   return BuiltInFunctions.ceil(num);
 });
 
 functionHandlers.set("floor", (args, ctx) => {
-  const num = Number(ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution)));
+  const num = Number(
+    ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution)),
+  );
   return BuiltInFunctions.floor(num);
 });
 
@@ -258,33 +309,53 @@ functionHandlers.set("parsedate", (args, ctx) => {
 });
 
 functionHandlers.set("datebefore", (args, ctx) => {
-  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const date1 = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const date2 = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   return BuiltInFunctions.dateBefore(date1, date2);
 });
 
 functionHandlers.set("dateafter", (args, ctx) => {
-  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const date1 = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const date2 = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   return BuiltInFunctions.dateAfter(date1, date2);
 });
 
 functionHandlers.set("dateinrange", (args, ctx) => {
-  const date = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const start = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const date = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const start = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   const end = ctx.getStringValue(ctx.evaluateExpression(args[2], ctx.solution));
   return BuiltInFunctions.dateInRange(date, start, end);
 });
 
 functionHandlers.set("datediffminutes", (args, ctx) => {
-  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const date1 = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const date2 = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   return BuiltInFunctions.dateDiffMinutes(date1, date2);
 });
 
 functionHandlers.set("datediffhours", (args, ctx) => {
-  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const date1 = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const date2 = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   return BuiltInFunctions.dateDiffHours(date1, date2);
 });
 
@@ -292,7 +363,7 @@ functionHandlers.set("datediffhours", (args, ctx) => {
 const createDateTimeAccessor = (
   dateTimeFn: (s: string) => number,
   yearMonthDurFn: ((v: DurationArg) => number) | null,
-  dayTimeDurFn: ((v: DurationArg) => number) | null
+  dayTimeDurFn: ((v: DurationArg) => number) | null,
 ): FunctionHandler => {
   return (args, ctx) => {
     const value = ctx.evaluateExpression(args[0], ctx.solution);
@@ -312,7 +383,7 @@ const createDateTimeAccessor = (
 const yearHandler = createDateTimeAccessor(
   BuiltInFunctions.year.bind(BuiltInFunctions),
   BuiltInFunctions.durationYears.bind(BuiltInFunctions),
-  null
+  null,
 );
 functionHandlers.set("year", yearHandler);
 functionHandlers.set("years", yearHandler);
@@ -321,7 +392,7 @@ functionHandlers.set("years", yearHandler);
 const monthHandler = createDateTimeAccessor(
   BuiltInFunctions.month.bind(BuiltInFunctions),
   BuiltInFunctions.durationMonths.bind(BuiltInFunctions),
-  null
+  null,
 );
 functionHandlers.set("month", monthHandler);
 functionHandlers.set("months", monthHandler);
@@ -330,47 +401,63 @@ functionHandlers.set("months", monthHandler);
 const dayHandler = createDateTimeAccessor(
   BuiltInFunctions.day.bind(BuiltInFunctions),
   null,
-  BuiltInFunctions.durationDays.bind(BuiltInFunctions)
+  BuiltInFunctions.durationDays.bind(BuiltInFunctions),
 );
 functionHandlers.set("day", dayHandler);
 functionHandlers.set("days", dayHandler);
 
 // hours - can work on dateTime or dayTimeDuration
-functionHandlers.set("hours", createDateTimeAccessor(
-  BuiltInFunctions.hours.bind(BuiltInFunctions),
-  null,
-  BuiltInFunctions.durationHours.bind(BuiltInFunctions)
-));
+functionHandlers.set(
+  "hours",
+  createDateTimeAccessor(
+    BuiltInFunctions.hours.bind(BuiltInFunctions),
+    null,
+    BuiltInFunctions.durationHours.bind(BuiltInFunctions),
+  ),
+);
 
 // minutes - can work on dateTime or dayTimeDuration
-functionHandlers.set("minutes", createDateTimeAccessor(
-  BuiltInFunctions.minutes.bind(BuiltInFunctions),
-  null,
-  BuiltInFunctions.durationMinutes.bind(BuiltInFunctions)
-));
+functionHandlers.set(
+  "minutes",
+  createDateTimeAccessor(
+    BuiltInFunctions.minutes.bind(BuiltInFunctions),
+    null,
+    BuiltInFunctions.durationMinutes.bind(BuiltInFunctions),
+  ),
+);
 
 // seconds - can work on dateTime or dayTimeDuration
-functionHandlers.set("seconds", createDateTimeAccessor(
-  BuiltInFunctions.seconds.bind(BuiltInFunctions),
-  null,
-  BuiltInFunctions.durationSeconds.bind(BuiltInFunctions)
-));
+functionHandlers.set(
+  "seconds",
+  createDateTimeAccessor(
+    BuiltInFunctions.seconds.bind(BuiltInFunctions),
+    null,
+    BuiltInFunctions.durationSeconds.bind(BuiltInFunctions),
+  ),
+);
 
 functionHandlers.set("timezone", (args, ctx) => {
-  const date = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const date = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
   return BuiltInFunctions.timezone(date);
 });
 
 functionHandlers.set("tz", (args, ctx) => {
-  const date = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const date = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
   return BuiltInFunctions.tz(date);
 });
 
 functionHandlers.set("adjust", (args, ctx) => {
   const dateTime = ctx.evaluateExpression(args[0], ctx.solution) as DurationArg;
-  const timezone = args.length > 1
-    ? ctx.evaluateExpression(args[1], ctx.solution) as DurationArg | undefined
-    : undefined;
+  const timezone =
+    args.length > 1
+      ? (ctx.evaluateExpression(args[1], ctx.solution) as
+          | DurationArg
+          | undefined)
+      : undefined;
   return BuiltInFunctions.adjust(dateTime, timezone);
 });
 
@@ -536,24 +623,36 @@ functionHandlers.set("sha512", (args, ctx) => {
 // =============================================================================
 
 functionHandlers.set("subject", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.subject(term);
 });
 
 functionHandlers.set("predicate", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.predicate(term);
 });
 
 functionHandlers.set("object", (args, ctx) => {
-  const term = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
+  const term = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.object(term);
 });
 
 functionHandlers.set("triple", (args, ctx) => {
-  const subject = ctx.getTermFromExpression(args[0], ctx.solution) as RDFTerm | undefined;
-  const predicate = ctx.getTermFromExpression(args[1], ctx.solution) as RDFTerm | undefined;
-  const object = ctx.getTermFromExpression(args[2], ctx.solution) as RDFTerm | undefined;
+  const subject = ctx.getTermFromExpression(args[0], ctx.solution) as
+    | RDFTerm
+    | undefined;
+  const predicate = ctx.getTermFromExpression(args[1], ctx.solution) as
+    | RDFTerm
+    | undefined;
+  const object = ctx.getTermFromExpression(args[2], ctx.solution) as
+    | RDFTerm
+    | undefined;
   return BuiltInFunctions.triple(subject, predicate, object);
 });
 
@@ -572,8 +671,12 @@ functionHandlers.set("triple", (args, ctx) => {
 
 // DAYS_BETWEEN(a, b) → integer: days between two dateTimes
 functionHandlers.set("days_between", (args, ctx) => {
-  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const date1 = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const date2 = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   const d1 = new Date(date1);
   const d2 = new Date(date2);
   return Math.floor((d2.getTime() - d1.getTime()) / (24 * 60 * 60 * 1000));
@@ -581,8 +684,12 @@ functionHandlers.set("days_between", (args, ctx) => {
 
 // MINUTES_BETWEEN(a, b) → integer: minutes between two dateTimes
 functionHandlers.set("minutes_between", (args, ctx) => {
-  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const date1 = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const date2 = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   const d1 = new Date(date1);
   const d2 = new Date(date2);
   return Math.floor((d2.getTime() - d1.getTime()) / (60 * 1000));
@@ -590,8 +697,12 @@ functionHandlers.set("minutes_between", (args, ctx) => {
 
 // HOURS_BETWEEN(a, b) → decimal: hours between two dateTimes
 functionHandlers.set("hours_between", (args, ctx) => {
-  const date1 = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const date2 = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const date1 = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const date2 = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   const d1 = new Date(date1);
   const d2 = new Date(date2);
   return (d2.getTime() - d1.getTime()) / (60 * 60 * 1000);
@@ -599,7 +710,9 @@ functionHandlers.set("hours_between", (args, ctx) => {
 
 // AGE_DAYS(dateTime) → integer: days from dateTime to NOW()
 functionHandlers.set("age_days", (args, ctx) => {
-  const dateStr = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const dateStr = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
   const d = new Date(dateStr);
   const now = new Date();
   return Math.floor((now.getTime() - d.getTime()) / (24 * 60 * 60 * 1000));
@@ -607,20 +720,28 @@ functionHandlers.set("age_days", (args, ctx) => {
 
 // WEEK_NUMBER(dateTime) → integer: ISO week number
 functionHandlers.set("week_number", (args, ctx) => {
-  const dateStr = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
+  const dateStr = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
   const d = new Date(dateStr);
   // ISO 8601 week number calculation
   const tmp = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
   tmp.setUTCDate(tmp.getUTCDate() + 4 - (tmp.getUTCDay() || 7));
   const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
-  return Math.ceil(((tmp.getTime() - yearStart.getTime()) / (24 * 60 * 60 * 1000) + 1) / 7);
+  return Math.ceil(
+    ((tmp.getTime() - yearStart.getTime()) / (24 * 60 * 60 * 1000) + 1) / 7,
+  );
 });
 
 // FORMAT_DATE(dateTime, pattern) → string: format date with pattern
 // Supported patterns: YYYY, MM, DD, HH, mm, ss
 functionHandlers.set("format_date", (args, ctx) => {
-  const dateStr = ctx.getStringValue(ctx.evaluateExpression(args[0], ctx.solution));
-  const pattern = ctx.getStringValue(ctx.evaluateExpression(args[1], ctx.solution));
+  const dateStr = ctx.getStringValue(
+    ctx.evaluateExpression(args[0], ctx.solution),
+  );
+  const pattern = ctx.getStringValue(
+    ctx.evaluateExpression(args[1], ctx.solution),
+  );
   const d = new Date(dateStr);
   return pattern
     .replace("YYYY", String(d.getFullYear()))
@@ -629,4 +750,24 @@ functionHandlers.set("format_date", (args, ctx) => {
     .replace("HH", String(d.getHours()).padStart(2, "0"))
     .replace("mm", String(d.getMinutes()).padStart(2, "0"))
     .replace("ss", String(d.getSeconds()).padStart(2, "0"));
+});
+
+// =============================================================================
+// exo:eval — RFC c78cc5c8 Phase 1a (PR2 inert)
+// =============================================================================
+//
+// Registered so the symbol exists in the SPARQL filter dispatcher (drift-guard
+// + visibility for downstream tooling), but the handler itself throws
+// `ExoQLEvalDisabledError` until PR3 (T4) flips `exoql.eval.enabled` and wires
+// the recursive engine through `evaluateWithExoEval`. Calling `exo:eval` from
+// a regular ExoQL.query path on PR2 surfaces the disabled-error so users see
+// an explicit signal instead of a silent no-op.
+functionHandlers.set("exo:eval", () => {
+  // Imported lazily to avoid a circular dependency between
+  // `infrastructure/sparql/filters` and `exoql/`.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ExoQLEvalDisabledError } = require("../../../exoql/eval-errors") as {
+    ExoQLEvalDisabledError: new () => Error;
+  };
+  throw new ExoQLEvalDisabledError();
 });

--- a/packages/exocortex/tests/unit/exoql/evaluateWithExoEval.test.ts
+++ b/packages/exocortex/tests/unit/exoql/evaluateWithExoEval.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for the PR2 inert surface of `evaluateWithExoEval`.
+ *
+ * RFC c78cc5c8 Phase 1a — exoql__Query + exo:eval MVP.
+ *
+ * Covers:
+ *  • feature-flag default (`enabled: false` → `ExoQLEvalDisabledError`)
+ *  • allowlist enforcement (FROM / SERVICE / UPDATE / LOAD on parse-stage)
+ *  • allowlist permits SELECT and ASK without dataset / SERVICE / UPDATE clauses
+ *  • flag override path returns `[]` (PR2 inert; PR3 wires the recursive engine)
+ */
+
+import {
+  evaluateWithExoEval,
+  validateExoQLAllowlist,
+  ExoQLEvalDisabledError,
+  ExoQLForbiddenKeywordError,
+  DEFAULT_EVAL_CONFIG,
+} from "../../../src/exoql";
+import { ExoQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+
+describe("evaluateWithExoEval (PR2 inert)", () => {
+  it("throws ExoQLEvalDisabledError when the feature flag is false (default)", () => {
+    expect(() => evaluateWithExoEval("SELECT ?s WHERE { ?s ?p ?o }")).toThrow(
+      ExoQLEvalDisabledError,
+    );
+  });
+
+  it("returns [] when the feature flag is overridden to true (PR2 stub)", () => {
+    const result = evaluateWithExoEval("SELECT ?s WHERE { ?s ?p ?o }", {
+      config: { enabled: true },
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("freezes DEFAULT_EVAL_CONFIG with enabled=false", () => {
+    expect(DEFAULT_EVAL_CONFIG.enabled).toBe(false);
+    expect(DEFAULT_EVAL_CONFIG.maxNestedEvalCount).toBe(100);
+    expect(DEFAULT_EVAL_CONFIG.maxAggregateEvalMillis).toBe(10_000);
+    // Frozen via Object.freeze — assignment must not mutate.
+    expect(Object.isFrozen(DEFAULT_EVAL_CONFIG)).toBe(true);
+  });
+
+  it("rejects FROM dataset clauses with ExoQLForbiddenKeywordError", () => {
+    expect(() =>
+      evaluateWithExoEval(
+        "SELECT ?s FROM <http://example.org/g> WHERE { ?s ?p ?o }",
+        { config: { enabled: true } },
+      ),
+    ).toThrow(ExoQLForbiddenKeywordError);
+  });
+
+  it("rejects FROM NAMED dataset clauses with ExoQLForbiddenKeywordError", () => {
+    expect(() =>
+      evaluateWithExoEval(
+        "SELECT ?s FROM NAMED <http://example.org/g> WHERE { ?s ?p ?o }",
+        { config: { enabled: true } },
+      ),
+    ).toThrow(ExoQLForbiddenKeywordError);
+  });
+
+  it("rejects SERVICE patterns inside WHERE with ExoQLForbiddenKeywordError", () => {
+    expect(() =>
+      evaluateWithExoEval(
+        "SELECT ?s WHERE { SERVICE <http://example.org/sparql> { ?s ?p ?o } }",
+        { config: { enabled: true } },
+      ),
+    ).toThrow(ExoQLForbiddenKeywordError);
+  });
+
+  it("rejects SERVICE nested inside OPTIONAL with ExoQLForbiddenKeywordError", () => {
+    expect(() =>
+      evaluateWithExoEval(
+        "SELECT ?s WHERE { ?s ?p ?o OPTIONAL { SERVICE <http://x/> { ?s ?p ?o } } }",
+        { config: { enabled: true } },
+      ),
+    ).toThrow(ExoQLForbiddenKeywordError);
+  });
+
+  it("rejects INSERT DATA (UPDATE) with ExoQLForbiddenKeywordError", () => {
+    expect(() =>
+      evaluateWithExoEval(
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> <http://example.org/o> }",
+        { config: { enabled: true } },
+      ),
+    ).toThrow(ExoQLForbiddenKeywordError);
+  });
+
+  it("rejects DELETE DATA (UPDATE) with ExoQLForbiddenKeywordError", () => {
+    expect(() =>
+      evaluateWithExoEval(
+        "DELETE DATA { <http://example.org/s> <http://example.org/p> <http://example.org/o> }",
+        { config: { enabled: true } },
+      ),
+    ).toThrow(ExoQLForbiddenKeywordError);
+  });
+
+  it("rejects LOAD with ExoQLForbiddenKeywordError naming the LOAD keyword", () => {
+    try {
+      evaluateWithExoEval("LOAD <http://example.org/data.ttl>", {
+        config: { enabled: true },
+      });
+      fail("expected ExoQLForbiddenKeywordError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExoQLForbiddenKeywordError);
+      expect((err as ExoQLForbiddenKeywordError).keyword).toBe("LOAD");
+    }
+  });
+
+  it("permits a vanilla SELECT (no FROM / SERVICE / UPDATE)", () => {
+    expect(() =>
+      evaluateWithExoEval("SELECT ?s WHERE { ?s ?p ?o }", {
+        config: { enabled: true },
+      }),
+    ).not.toThrow();
+  });
+
+  it("permits a vanilla ASK", () => {
+    expect(() =>
+      evaluateWithExoEval("ASK WHERE { ?s ?p ?o }", {
+        config: { enabled: true },
+      }),
+    ).not.toThrow();
+  });
+
+  it("disabled flag wins over allowlist when input is fully valid", () => {
+    // Defensive ordering check — allowlist runs BEFORE flag, so a banned
+    // construct surfaces ExoQLForbiddenKeywordError even when the flag is
+    // its default `false`. (Otherwise users would get a misleading
+    // "disabled" error for genuinely banned queries.)
+    expect(() =>
+      evaluateWithExoEval("SELECT ?s FROM <http://x/> WHERE { ?s ?p ?o }"),
+    ).toThrow(ExoQLForbiddenKeywordError);
+  });
+
+  it("rejects non-string input with TypeError", () => {
+    expect(() => evaluateWithExoEval(123 as unknown as string)).toThrow(
+      TypeError,
+    );
+  });
+});
+
+describe("validateExoQLAllowlist (direct AST entry-point)", () => {
+  const parser = new ExoQLParser();
+
+  it("returns silently for a vanilla SELECT", () => {
+    const ast = parser.parse("SELECT ?s WHERE { ?s ?p ?o }");
+    expect(() => validateExoQLAllowlist(ast)).not.toThrow();
+  });
+
+  it("returns silently for a vanilla ASK", () => {
+    const ast = parser.parse("ASK WHERE { ?s ?p ?o }");
+    expect(() => validateExoQLAllowlist(ast)).not.toThrow();
+  });
+
+  it("ignores undefined / non-object input gracefully", () => {
+    expect(() => validateExoQLAllowlist(undefined as never)).not.toThrow();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/exoql/drift-guard-function-registry.test.ts
+++ b/packages/obsidian-plugin/tests/unit/exoql/drift-guard-function-registry.test.ts
@@ -26,7 +26,7 @@
 
 import { functionHandlers } from "../../../../exocortex/src/infrastructure/sparql/filters/FunctionRegistry";
 
-const EXPECTED_FUNCTIONS_PRE_EXOQL_EVAL: ReadonlyArray<string> = [
+const EXPECTED_FUNCTIONS_INCLUDING_EXOQL_EVAL: ReadonlyArray<string> = [
   "abs",
   "adjust",
   "age_days",
@@ -60,6 +60,7 @@ const EXPECTED_FUNCTIONS_PRE_EXOQL_EVAL: ReadonlyArray<string> = [
   "durationtoseconds",
   "durationyears",
   "encode_for_uri",
+  "exo:eval",
   "floor",
   "format_date",
   "haslangdir",
@@ -121,14 +122,14 @@ const EXPECTED_FUNCTIONS_PRE_EXOQL_EVAL: ReadonlyArray<string> = [
 describe("drift-guard: SPARQL FunctionRegistry", () => {
   it("registry sorted keys match the inline manifest exactly", () => {
     const actual = Array.from(functionHandlers.keys()).sort();
-    const expected = [...EXPECTED_FUNCTIONS_PRE_EXOQL_EVAL].sort();
+    const expected = [...EXPECTED_FUNCTIONS_INCLUDING_EXOQL_EVAL].sort();
     expect(actual).toEqual(expected);
   });
 
-  // PR1 TDD red anchor — `it.failing()` inverts the expectation:
-  //   • PR1 (no impl):  body throws  → it.failing PASSES → CI green
-  //   • PR2 (impl):    body passes → it.failing FAILS  → forces flip to `it(...)` + manifest update
-  it.failing("exo:eval is registered as a SPARQL builtin (will be impl in PR2)", () => {
+  // PR2 (T2) flipped this from `it.failing` to `it(...)` once the handler
+  // landed in FunctionRegistry. The presence of `exo:eval` is now an
+  // affirmative invariant; removing the registration breaks this test.
+  it("exo:eval is registered as a SPARQL builtin (PR2 — T2)", () => {
     expect(functionHandlers.has("exo:eval")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

PR2 of RFC c78cc5c8 Phase 1a (T2) — `exoql__Query` + `exo:eval` MVP. Ships **inert** behind `exoql.eval.enabled = false` (B2 lock); PR3/T4 flips the default.

- `evaluateWithExoEval` public entry-point (sync) — parses, runs allowlist, honours flag.
- AST allowlist (always-on safety guard, independent of flag): SERVICE/FROM/UPDATE/LOAD rejected on parse-stage with `ExoQLForbiddenKeywordError`.
- `exo:eval` registered in `FunctionRegistry` (handler throws `ExoQLEvalDisabledError` on PR2; recursive engine attaches in PR3).
- Error classes (`ExoQLForbiddenKeywordError`, `ExoQLEvalDisabledError`, `ExoQLCycleError`, `ExoQLBudgetExceededError`) with stable `name` + typed metadata so PR3 cycle/budget machinery wires in without API churn.
- Drift-guard manifest extended with `exo:eval`; PR1 `it.failing` red anchor flipped to affirmative `it(...)`.

## Acceptance Criteria

- [x] AST-allowlist parser rejects 4 banned forms on parse-time
- [x] `exo:eval(?uid)` registered in SPARQL function registry
- [x] Eval-budget config plumbed (≤100 nested, ≤10 000 ms aggregate; enforcement engine — PR3)
- [x] Cycle detection error class + typed `path` field plumbed (engine — PR3)
- [x] `exoql.eval.enabled = false` default — all code paths inert
- [x] PR opened (this) — merge pending

## Out of scope (PR3 / T4)

- Recursive engine that walks `exo:eval(<urn>)`, fetches `exoql__Query` body from store, recurses with cycle/budget tracking. Skeleton + types are in place; the wiring slot in `evaluateWithExoEval.ts` is documented.
- Flipping the default flag to `true` (B2 lock).
- Cucumber step definitions for `exoql-eval.feature` (5 scenarios). `bdd:test` runs with `continue-on-error: true`; coverage already satisfied via `coverage-mapping.json` overrides PR1 added.
- Flipping the 5 BDD red-anchor stubs in `exoql-eval-stubs.test.ts`. They require store-aware fixtures (exoql__Query asset, A↔B cycle store, fan-out generator) outside PR2's B2 scope; PR3 will provide them alongside dogfood SPARQL.

## Test plan

- [x] 17/17 new unit tests in `packages/exocortex/tests/unit/exoql/evaluateWithExoEval.test.ts` (flag default/override, FROM, FROM NAMED, SERVICE in WHERE, SERVICE under OPTIONAL, INSERT/DELETE DATA, LOAD with keyword propagation, vanilla SELECT/ASK, allowlist-precedes-flag ordering, TypeError on non-string, AST-direct entry-point).
- [x] Drift-guard `it("registry sorted keys match the inline manifest exactly")` green with `exo:eval` in manifest.
- [x] Drift-guard `it("exo:eval is registered as a SPARQL builtin")` flipped from `it.failing` and green.
- [x] 5 PR1 stubs in `exoql-eval-stubs.test.ts` still pass as `it.failing` (bodies still surface non-matching errors due to flag=false / fixture absence).
- [x] `npm run check:types` green.
- [x] `npm run lint` green (only 2 pre-existing warnings unrelated to this PR).

## RFC

[RFC c78cc5c8 Phase 1a — exoql__Query + exo:eval MVP](https://github.com/kitelev/exocortex/issues?q=c78cc5c8). Predecessor: T1 PR #2975 → v15.133.1.