### PR TITLE
chore(e2e): T5.5 — adopt T5.1 V1+V2 Xvfb config (RFC Phase 3.5)

### DIFF
--- a/packages/obsidian-plugin/docker-entrypoint-e2e.sh
+++ b/packages/obsidian-plugin/docker-entrypoint-e2e.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 # docker-entrypoint-e2e.sh
-# Runs E2E tests with xvfb-run --auto-servernum (recommended by Playwright team)
+# Runs E2E tests via xvfb-run with parametrized Xvfb config (XVFB_VARIANT).
+#
+# Variants (RFC Phase 3.5 ADR — packages/obsidian-plugin/docs/phase3/ADR_FLAKY_X11_STRATEGY.md):
+#   v1+v2     (default) — T5.1 V1 (-extension MIT-SHM) + V2 (lean 720p+dpi). Closes Cat I X11 SHM
+#                         contention at protocol layer; reduces framebuffer payload by 30%.
+#   baseline           — Status-quo Xvfb args (rollback). Set XVFB_VARIANT=baseline to revert.
+#   per-spec           — Rung 1 fallback (T5.2 V2). Stub; activated by escalation task if v1+v2 misses DoD.
+#   xpra               — Rung 2 fallback (T5.3 V1). Stub; activated only with xpra in image.
+#   weston             — Rung 3 fallback (T5.3 V3). Stub; activated only with Weston in image.
+#
+# Future contributors: V2 lean dimensions (1280x720) align with Playwright viewport.
+# Adding pixel-level mouse.click({x,y}) interactions in tests/e2e/specs/** that rely on a
+# >720px-tall framebuffer will silently misbehave under v1+v2. Use baseline variant or
+# adjust spec to viewport-relative coordinates.
 
 set -e
 
@@ -10,16 +23,46 @@ export CI=1
 export DEBUG=pw:browser*
 export ELECTRON_ENABLE_LOGGING=0
 
+XVFB_VARIANT="${XVFB_VARIANT:-v1+v2}"
+
 echo "========================================" >&2
 echo "OBSIDIAN_PATH: $OBSIDIAN_PATH" >&2
 echo "OBSIDIAN_VAULT: $OBSIDIAN_VAULT" >&2
+echo "XVFB_VARIANT:  $XVFB_VARIANT" >&2
 echo "Command: $@" >&2
 echo "========================================" >&2
 
-echo "Launching with xvfb-run --auto-servernum..." >&2
+# Filter pattern for harmless Chrome/dbus stderr noise.
+NOISE_FILTER='(LaunchProcess: failed to execvp:|ERROR:dbus/bus.cc:|ERROR:dbus/object_proxy.cc:|WARNING:ui/gfx/linux/gpu_memory_buffer_support_x11.cc:|WARNING:device/bluetooth/dbus/bluez_dbus_manager.cc:|WARNING:electron/shell/browser/ui/accelerator_util.cc:|xdg-settings)'
 
-# Use xvfb-run with --auto-servernum as recommended by Playwright team
-# https://github.com/microsoft/playwright/issues/8198#issuecomment-986736585
-# Filter out harmless Chrome/dbus errors that clutter logs (stderr only)
-xvfb-run --auto-servernum "$@" 2>&1 | grep -v -E "(LaunchProcess: failed to execvp:|ERROR:dbus/bus.cc:|ERROR:dbus/object_proxy.cc:|WARNING:ui/gfx/linux/gpu_memory_buffer_support_x11.cc:|WARNING:device/bluetooth/dbus/bluez_dbus_manager.cc:|WARNING:electron/shell/browser/ui/accelerator_util.cc:|xdg-settings)"
-exit ${PIPESTATUS[0]}
+case "$XVFB_VARIANT" in
+  v1+v2)
+    # Primary mitigation per ADR §2:
+    #  -extension MIT-SHM : disables X11 shared-memory extension → eliminates SHM allocator
+    #                       contention root cause of Category I (X11 Shm::PutImageRequest).
+    #  -screen 0 1280x720x24 : matches Playwright viewport; reduces framebuffer 3.93MB→2.76MB.
+    #  -dpi 96            : pins layout deterministic across jammy kernel variants.
+    #  -nolisten tcp      : preserves existing security default.
+    echo "Launching with xvfb-run (v1+v2: -extension MIT-SHM + lean 720p)..." >&2
+    xvfb-run --auto-servernum \
+      --server-args="-screen 0 1280x720x24 -dpi 96 -extension MIT-SHM -nolisten tcp" \
+      "$@" 2>&1 | grep -v -E "$NOISE_FILTER"
+    exit ${PIPESTATUS[0]}
+    ;;
+  baseline)
+    # Status-quo Xvfb args (pre-Phase-3.5). Use only for rollback or A/B measurement.
+    echo "Launching with xvfb-run (baseline: status quo)..." >&2
+    xvfb-run --auto-servernum "$@" 2>&1 | grep -v -E "$NOISE_FILTER"
+    exit ${PIPESTATUS[0]}
+    ;;
+  per-spec|xpra|weston)
+    echo "ERROR: XVFB_VARIANT=$XVFB_VARIANT is a fallback-ladder stub (see ADR §4)." >&2
+    echo "Activate via dedicated escalation task; do not enable until T6.1 N=50 of v1+v2 misses DoD." >&2
+    exit 2
+    ;;
+  *)
+    echo "ERROR: Unknown XVFB_VARIANT='$XVFB_VARIANT'." >&2
+    echo "Valid: v1+v2 (default) | baseline | per-spec | xpra | weston" >&2
+    exit 2
+    ;;
+esac

--- a/packages/obsidian-plugin/docs/phase3/ADR_FLAKY_X11_STRATEGY.md
+++ b/packages/obsidian-plugin/docs/phase3/ADR_FLAKY_X11_STRATEGY.md
@@ -1,0 +1,353 @@
+# ADR — Flaky E2E X11 Stabilization Strategy (Phase 3.5)
+
+- **Status:** Accepted (analysis-only ADR; implementation lands в T5.5 PR)
+- **Date:** 2026-04-30
+- **RFC:** Phase 3 — flaky e2e residual stabilization (`32a64ed9-9a74-4e0c-bb26-e455605aa384`, RFC 3cc77ba2 successor)
+- **Charter:** `4cd6f7bd-73e4-47f3-b0f2-c1f2438ed619` §4
+- **Source GitHub Issue:** kitelev/exocortex#2974
+- **Decision authors:** child Claudes T5.1 (`481b05ed`), T5.2 (`537d4fd2`), T5.3 (`8243c196`), T5.4 (`03c69963` — this ADR)
+- **Implementation:** T5.5 PR (next task) — primary config + measurement harness + rollback env-var
+- **Validation:** T6.1 — N=50 measurement matrix on CI runner
+
+---
+
+## 1. Context
+
+E2E suite на Obsidian plugin суффер от **Category I — X11 Shm::PutImageRequest infrastructure errors** на CI Linux runners (jammy, Playwright `mcr.microsoft.com/playwright:v1.55.1-jammy`, Xvfb 21.1.4 backend). Symptoms (RFC §Проблема, run `25181815934` shard 6 2026-04-30T18:17Z): cold-start `waitForSelector` timeouts >15s, intermittent Obsidian process termination during plugin load, recurring `X11 Shm::PutImageRequest` substring в filtered stderr. Pre-Phase-3 baseline rerun rate ~50% (Issue #2974 evidence).
+
+Phase 3.5 RFC §3.5 mandated **3 parallel investigations** to pick best-of-3 by flake-reduction percentage, tie-breaker latency:
+
+- **Investigation A (T5.1)** — Xvfb tuning (framebuffer flags / MIT-SHM extension toggle)
+- **Investigation B (T5.2)** — `xvfb-run` per-test display isolation (per-test / per-spec / per-launch)
+- **Investigation C (T5.3)** — alternative display backends (xpra / Xephyr / Weston Wayland / native headless)
+
+Все 3 spike-доки готовы и закоммичены в evidence trail (см. §10 References). Эта ADR синтезирует их в одно решение для Phase 3.5 production.
+
+**Inherited constraints:**
+- CI Path 2 (D0 cutover 2026-04-22): post-Phase 3 baseline ~236s avg ±50s; gate ≤220s per Decision B (RFC v2 relax). Любой variant с >+5% wall-clock collides с gate envelope.
+- 13 required CI checks (`archgate`, `detect-changes`, `e2e-shard (1..6)`, `lint`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`).
+- `playwright-e2e.config.ts`: `fullyParallel: false; workers: 1` — within-shard execution serial → contention bounded shard-locally.
+
+---
+
+## 2. Decision
+
+**Primary mitigation:** ship **T5.1 V1+V2 cumulative** as default Xvfb args в `packages/obsidian-plugin/docker-entrypoint-e2e.sh`:
+
+```sh
+xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24 -dpi 96 -extension MIT-SHM -nolisten tcp" "$@"
+```
+
+Components:
+- **`-extension MIT-SHM`** (T5.1 V1) — disables X11 shared-memory extension at protocol level. Forces all image transfers через XPutImage network protocol path. **Eliminates Category I root cause by construction** (no SHM allocator → no SHM allocator contention → no `Shm::PutImageRequest` errors).
+- **`-screen 0 1280x720x24`** (T5.1 V2) — reduces framebuffer 1280×1024×24bpp = 3.93 MB → 1280×720×24bpp = 2.76 MB (-30%). Composable with V1 (cumulative). Matches existing Playwright `viewport` setting (already 1280×720).
+- **`-dpi 96`** (T5.1 V2) — pins layout deterministic across jammy kernel variants (some default 75 dpi → font metric drift in plugin DOM measurements).
+- **`-nolisten tcp`** — preserves existing security default (no TCP listener).
+
+**Production harness:** parametrize `docker-entrypoint-e2e.sh` через `XVFB_VARIANT` env var с **`v1+v2` as default**, оставляя `baseline` (status quo) и фолбэк-rungs reachable через env-flip без code change. T5.5 ships harness + default flip; T6.1 N=50 measurement matrix validates pre-merge.
+
+---
+
+## 3. Decision Rationale
+
+### 3.1 Why T5.1 V1 dominates
+
+T5.1 V1 (`-extension MIT-SHM`) eliminates Category I **at X11 protocol layer**, not at process-management layer. Все остальные mitigations (T5.2 per-spec isolation, T5.3 xpra session wrapper, T5.3 Weston) achieve the same effect через **different mechanism** (process-level cleanup, session-level cleanup, protocol replacement) at strictly higher cost:
+
+| | T5.1 V1 (`-extension MIT-SHM`) | T5.2 V2 (per-spec) | T5.3 V1 (xpra) | T5.3 V3 (Weston) |
+|---|---|---|---|---|
+| Eliminates SHM contention | ✅ protocol-level | ✅ process-level | ✅ session-level | ✅ replaces X11 |
+| Wall-clock cost | ~5–15% framebuffer slowdown (offset by no SHM overhead — net ≈ neutral) | +5% (N spec spawns × ~200ms) | +1–2s shard cold-start (~+1%) | ≈ neutral |
+| Implementation surface | 1-line `--server-args` change | bash spec loop + Playwright reporter merge | Dockerfile +25 MB + entrypoint env-var | Dockerfile +40 MB + Electron flags + WL stack |
+| Compatibility risk | LOW (universal Xvfb feature) | LOW (Playwright `merge-reports` GA) | MEDIUM (untested Electron+xpra in CI) | HIGH (untested Playwright+Electron+WL) |
+| Reversibility | trivial (1-line revert) | medium (revert + reporter) | trivial (env var) | medium (env var + WL→X11 fallback) |
+| Decision B gate impact | ✅ within ≤220s | ⚠ marginal (+5% on 236s baseline) | ✅ within | ✅ within |
+| Empirical precedent | HIGH — Playwright #8198, Cypress docs, ChromiumOS bots | MEDIUM — Playwright merge-reports well-documented but specific to per-spec isolation pattern | LOW — 0 hits "xpra" в microsoft/playwright | NONE — Playwright Wayland on roadmap (#20217) but no commit date |
+
+T5.1 V1 wins на all 5 critical axes (cost, surface, risk, reversibility, precedent).
+
+### 3.2 Why V2 (lean dimensions) is composable, not redundant
+
+V2 (`1280x720x24` + `-dpi 96`) addresses a **different vector** than V1: V1 disables SHM extension, V2 reduces framebuffer pressure regardless of transfer protocol. They compose without conflict:
+
+- V1 alone: works at protocol layer; XPutImage path slower but predictable.
+- V2 alone: reduces SHM allocator pressure (-30% framebuffer) but doesn't eliminate the path.
+- V1+V2 cumulative: SHM disabled **and** framebuffer leaner → smaller XPutImage payloads → wall-clock cost of V1 is partially offset by V2's reduced transfer size.
+
+Empirical N=50 в T6.1 will measure V1 alone vs V1+V2 — if V2's wall-clock benefit is negligible, drop V2; ship V1 only. ADR ships **V1+V2 default** на assumption obtained from Playwright/Cypress community evidence + RFC §3.5 «pick best-of-3 by flake reduction» preferring lower variance config.
+
+### 3.3 Why Investigations B & C are fallback-ladder, not first-line
+
+Both T5.2 spike (§5) и T5.3 spike (§5) explicitly conclude their mechanisms are **redundant** with T5.1 V1: the same Cat I root cause is closed by T5.1 at protocol level. Investigations B & C add value **only** as insurance against the long tail of non-SHM X11 errors that survive V1 — empirically unverified в RFC §Проблема evidence base, but theoretically possible (BadAlloc, BadRequest, X11 socket exhaustion, scheduling races).
+
+Therefore: **escalate through fallback ladder only on empirical signal** (T6.1 N=50 shows residual flake), not preemptively.
+
+### 3.4 Why no «ship all 3» strategy
+
+Defense-in-depth is tempting: ship V1+V2 + per-spec isolation + xpra + Weston simultaneously. Rejected because:
+
+1. **Cost compounds:** +5% (T5.2) + +1–2s (xpra cold-start) + protocol migration risk (Weston) — combined wall-clock approaches Decision B ≤220s ceiling on already-tight 236s baseline.
+2. **Diagnostic confusion:** if 4 mitigations ship together and Cat I disappears, we cannot attribute the win — and cannot rollback safely if regression appears later.
+3. **Reversibility erodes:** more layers → more places to break during revert.
+4. **YAGNI:** T5.1 V1 alone is empirically expected to close Cat I per Playwright community precedent. Adding rung-1/2/3 ahead of evidence is over-engineering.
+
+---
+
+## 4. Fallback Ladder
+
+If T6.1 N=50 measurement of T5.1 V1+V2 shows residual flake rate >0% with X11-tagged stderr (any X11 error substring after MIT-SHM disable; or `BadRequest` / `BadAlloc` / `ConnectionFailed` / `Shm::PutImage` resurfacing) → escalate **one rung at a time**, re-measure N=50 per rung.
+
+### Rung 1 — T5.2 V2 (per-spec Xvfb isolation) combined with T5.1 V1
+
+Trigger: T5.1 V1+V2 misses DoD threshold (rerun rate >10% per Issue #2974 DoD).
+
+Mechanism: replace `xvfb-run` single wrap с per-spec loop. Each spec gets fresh Xvfb process → fresh `/tmp/.X11-unix/X{N}` socket → fresh process state. Eliminates cross-spec leak vector.
+
+Implementation sketch (T5.2 §6):
+```sh
+case "$XVFB_VARIANT" in
+  per-spec)
+    specs=$(npx playwright test --list --reporter=line | grep -oE 'tests/e2e/specs/[^ ]+\.spec\.ts' | sort -u)
+    overall_exit=0
+    for spec in $specs; do
+      xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24 -dpi 96 -extension MIT-SHM -nolisten tcp" \
+        npx playwright test "$spec" --reporter=blob --output="reports/$(basename $spec .spec.ts)" \
+        || overall_exit=$?
+    done
+    npx playwright merge-reports --reporter=html ./reports || true
+    exit $overall_exit
+    ;;
+esac
+```
+
+Cost: +5% wall-clock (~12s on 236s baseline → ~248s, breaches Decision B ≤220s ceiling). **Requires Decision B re-relax conversation if rung 1 ships.** Implementation effort: 1–2 dev-days (reporter merge + revert script + artifact bundling).
+
+Reversibility: medium. Revert = flip `XVFB_VARIANT` env var to `v1+v2`; remove per-spec loop block from entrypoint (10-line change).
+
+### Rung 2 — T5.3 V1 (xpra session wrapper) combined with T5.1 V1
+
+Trigger: rung 1 (V1+V2 + per-spec) still misses DoD.
+
+Mechanism: replace Xvfb wrapper с xpra session-management layer. xpra wraps Xvfb internally but adds session-cleanup robustness — child crash does not race с X server teardown; SHM segments reaped before next client. Defense at session-management layer orthogonal to T5.1 protocol-level mitigation.
+
+Implementation sketch (T5.3 §6):
+```sh
+case "$XVFB_VARIANT" in
+  xpra)
+    xpra start :99 \
+      --start-child="$*" --exit-with-children=yes \
+      --bind-tcp=none --html=off --notifications=no \
+      --pulseaudio=no --webcam=no --printing=no \
+      --xvfb='Xvfb -screen 0 1280x720x24 -extension MIT-SHM -nolisten tcp -dpi 96'
+    ;;
+esac
+```
+
+Cost: image +25 MB (within budget; current ~1.2 GB, +2%); +1–2s shard cold-start (~+1% wall-clock). Implementation effort: 0.5–1 dev-day (Dockerfile + entrypoint + env-var hook).
+
+Reversibility: trivial. Revert = `XVFB_VARIANT=v1+v2`; xpra dependency stays in image как dormant.
+
+Empirical risk: MEDIUM. xpra + Electron + Playwright triple unverified в CI; T6.1 must validate с care.
+
+### Rung 3 — T5.3 V3 (Weston / Wayland headless) с Electron `--ozone-platform=wayland`
+
+Trigger: rung 2 (xpra) still misses DoD. **Last resort before Phase 4 RFC** (migration off Playwright/Xvfb to hosted browser).
+
+Mechanism: replace X11 entirely с Wayland (Weston `--backend=headless`). No MIT-SHM equivalent в Wayland; `wl_shm` differently structured (per-buffer dmabuf or shm pool) — does not exhibit X11 SHM allocator-fragmentation pattern. Eliminates Category I **by abandoning X11 protocol**.
+
+Implementation sketch (T5.3 §6):
+```sh
+case "$XVFB_VARIANT" in
+  weston)
+    mkdir -p ${XDG_RUNTIME_DIR:-/tmp/runtime-root} && chmod 700 ${XDG_RUNTIME_DIR:-/tmp/runtime-root}
+    weston --backend=headless-backend.so --width=1280 --height=720 --socket=wayland-0 &
+    WESTON_PID=$!
+    until [ -S "${XDG_RUNTIME_DIR:-/tmp/runtime-root}/wayland-0" ]; do sleep 0.1; done
+    ELECTRON_OZONE_PLATFORM_HINT=wayland "$@" --ozone-platform=wayland --enable-features=UseOzonePlatform
+    EXIT=$?; kill $WESTON_PID 2>/dev/null; exit $EXIT
+    ;;
+esac
+```
+
+Cost: image +40 MB (~+3%); steady-state wall-clock ≈ neutral. **Implementation effort: 3–5 dev-days** (Dockerfile + entrypoint + Electron flags + diagnostic tooling for Wayland). Diagnostic difficulty: Wayland tooling (`wayland-debug`, `wayland-info`) less mature than X11 (`xprop`, `xev`, `xwininfo`).
+
+Reversibility: medium. Revert = `XVFB_VARIANT=v1+v2`, retain WL stack как dormant. **Cannot fully revert WL→X11 в same image without rebuild** (libwayland symbols loaded but inert when WL disabled).
+
+Empirical risk: HIGH. Playwright + Electron + Wayland combination — 0 known production CI deployments в Playwright community (search 2026-04-30: 2 unanswered issues в microsoft/playwright; Obsidian forum: 0 results "wayland CI"). Failure mode = entire e2e suite breaks, not just one spec.
+
+### Beyond rung 3
+
+If Weston also misses DoD → **Phase 4 RFC** (RFC §Альтернативы A — Migration off Playwright/Xvfb to hosted browser, currently rejected on cost). Out-of-scope для этой ADR.
+
+---
+
+## 5. Rejected Options (Documented for Completeness)
+
+### 5.1 T5.1 V3 — `-shmem` flag toggle (rejected — no opt-out flag exists)
+
+`-shmem` already on by default в Xvfb (`man Xvfb` jammy 21.1.4). No `-noshmem` counterpart exists; only `-extension MIT-SHM` covers disable case (which is V1). RFC §3.5 phrasing «`-shmem` enable» turned out misnomer.
+
+### 5.2 T5.2 V1 — per-test isolation (rejected — fixture lifecycle conflict)
+
+Playwright Electron launcher reads `DISPLAY` at `electron.launch()` time, fires per-test only if `beforeEach` does fresh launch. В нашем suite Electron launched once per spec via fixture and reused across tests. Per-test isolation → fixture lifecycle reorganization → high blast radius vs actual contention surface (single-worker serial suite). Per-spec (Rung 1) is realistic granularity.
+
+### 5.3 T5.2 V3 — per-launch fixture isolation (rejected — wall-clock cost)
+
+200–400ms × ~80 Obsidian launches per shard = 16–32s added (+10–13% wall-clock). Breaks Decision B ≤220s gate (236s baseline → 260s+). Only revisit if all rungs miss DoD AND Investigation C is undesirable.
+
+### 5.4 T5.2 V4 — per-worker isolation (rejected — out-of-scope parallelization)
+
+Currently `workers: 1` (specs share Obsidian config dir, must run serially per shard). Parallelization → separate `$HOME` per worker, separate vault — entirely different RFC scope (parallelization, not flake stabilization).
+
+### 5.5 T5.3 V2 — Xephyr (rejected — needs parent X server)
+
+Xephyr renders into window of parent X server. CI runners headless (no parent). Running Xephyr inside Xvfb adds two display-server hops без isolation benefit. Strictly worse than xpra.
+
+### 5.6 T5.3 V4 — Native Chromium `--headless=new` (rejected — Obsidian binary doesn't expose)
+
+Obsidian's Electron entry point (bundled binary `/opt/obsidian/obsidian`) does not expose `app.commandLine` to external invocation. Empirically (microsoft/playwright#10384): Electron + `--headless` boots Chromium but BrowserWindow constructor still requires `$DISPLAY`. Path forward would require forking Obsidian — out-of-scope.
+
+### 5.7 T5.3 V5 — DBUS daemon (rejected — cosmetic only)
+
+DBUS warnings filtered, not failing — they don't cause Cat I errors. Process termination timeout symptoms are X11 SHM, not DBUS-mediated. Adds infra без addressing root cause.
+
+---
+
+## 6. Consequences
+
+### 6.1 Positive
+
+- **Category I closure (expected):** T5.1 V1 eliminates SHM fast-path at protocol layer. Per Playwright community precedent (microsoft/playwright#8198), ChromiumOS bot infra, Cypress Linux docs — HIGH confidence Cat I rerun rate drops from ~50% baseline to <10% DoD threshold.
+- **Wall-clock cost neutral:** V1's framebuffer slowdown offset by V2's smaller framebuffer payload + reduced SHM overhead. Expected steady-state ≈ baseline ±1%.
+- **Trivial reversibility:** 1-line `--server-args` revert + `XVFB_VARIANT=baseline` env-flip available without code change.
+- **Composable harness:** `XVFB_VARIANT` env-var supports rung-1/2/3 escalation through env-flip alone — no code change between rungs (only Dockerfile package additions if escalating to xpra/Weston).
+- **Diagnostic clarity:** if regression surfaces later, single primary mitigation isolates blame surface.
+
+### 6.2 Negative
+
+- **Empirical assumption:** T5.1 V1 expected to close Cat I, но not yet measured on CI runner для **этого** repo. Risk that runner-specific kernel variant exhibits non-canonical SHM behaviour. Mitigation: T6.1 N=50 measurement pre-merge; rollback env-var ready.
+- **V2 lean dimensions assume no pixel-bottom interaction:** Audit (T5.1 §3 V2 analysis): zero `clip:` or pixel-coordinate `mouse.click({x,y})` calls в `tests/e2e/specs/**` against bottom 304 px. Future spec adding pixel-bottom interaction will silently misbehave. Mitigation: comment в `docker-entrypoint-e2e.sh` warning future contributors; lint rule deferred to Phase 4 if churn surfaces.
+- **Fallback ladder depth:** 3 rungs of fallback adds documentation surface area. Mitigation: keep ADR fallback section concise; T5.5 implementation lands harness skeleton без активных rung implementations (just env-var hook).
+- **Decision B gate fragility:** Rung 1 (per-spec) collides with ≤220s gate → если escalation triggers, requires Decision B re-relax conversation в parallel. Mitigation: explicit warning в Rung 1 trigger criteria.
+
+### 6.3 Neutral
+
+- **Image size:** primary mitigation (T5.1 V1+V2) is zero-cost — only `--server-args` change, no Dockerfile diff. Rung-2/3 add 25/40 MB respectively (within ~5% budget on 1.2 GB base).
+- **Required CI checks:** unchanged. 13 mandatory checks remain (`archgate`, `detect-changes`, `e2e-shard (1..6)`, `lint`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`).
+
+---
+
+## 7. Validation Plan
+
+### 7.1 T5.5 — Implementation PR (next task в this phase)
+
+**Scope:**
+1. Edit `packages/obsidian-plugin/docker-entrypoint-e2e.sh`: introduce `XVFB_VARIANT` env-var with default `v1+v2`. Implement `case` switch с branches `baseline | v1+v2 | per-spec | xpra | weston`. Active branches: `baseline` and `v1+v2`. Rung-1/2/3 branches may be **placeholder stubs** (echo «not yet implemented» + exit 1) at T5.5 time, активируются in subsequent escalation tasks if needed.
+2. Commit ADR (this file) into branch.
+3. Add `docs/ROLLBACK_X11_STABILIZATION.md` micro-doc: «to revert, set `XVFB_VARIANT=baseline` in `.github/workflows/e2e.yml` env block».
+4. Update `packages/obsidian-plugin/CLAUDE.md` (or AGENTS.md) — note new env-var contract.
+5. PR title: `chore(e2e): T5.5 — adopt T5.1 V1+V2 Xvfb config (RFC Phase 3.5)` + reference ADR commit.
+
+**DoD T5.5:**
+- 13 required CI checks green (smoke validation на baseline + v1+v2 variants both pass at least 1 run pre-merge)
+- ADR committed
+- Rollback doc committed
+- PR squash-merged
+
+### 7.2 T6.1 — N=50 measurement matrix (validation phase)
+
+**Trigger:** T5.5 merged to main.
+
+**Harness:** add `.github/workflows/e2e-xvfb-spike.yml` matrix (deferred to T6.1 task; sketch per T5.1 §5):
+```yaml
+strategy:
+  matrix:
+    variant: [baseline, v1+v2]
+    run: [1..50]
+```
+Run cold-start subset (RFC §Проблема evidence specs: `relation-column-set-smoke`, `vault-commands-smoke`, `daily-note-tasks`) per variant per run. Output: per-variant rerun rate, P50/P99 launch time, X11 error count from filtered stderr.
+
+**Cost estimate:** 2 variants × 50 runs × ~80s shard cold-start = ~2.2h CI minutes (~$0 self-billed).
+
+**Acceptance criteria (per RFC §3.5 + Issue #2974 DoD):**
+- v1+v2 rerun rate ≤25% × baseline rerun rate
+- v1+v2 P99 launch time ≤120s
+- v1+v2 zero `Shm::PutImageRequest` substring в stderr (eliminative validation; expected `0` per protocol-level disable)
+
+**Escalation trigger:** if v1+v2 misses any acceptance criterion → invoke fallback ladder Rung 1 (T5.2 V2 per-spec) + re-measure. Re-measurement budget: same 50-run matrix per rung.
+
+### 7.3 T6.2 — Production observation (post-merge)
+
+After T5.5 merge, monitor 14-day window:
+- PR rerun rate (`gh run list --json conclusion,attempt`) compared to pre-merge 14-day baseline
+- E2E shard latency P99 (CI Path 2 telemetry on `e2e-shard (1..6)`)
+- Stderr X11 error tally (filter `LaunchProcess: X11 Shm::PutImageRequest` substring count per shard)
+
+**Success metric:** rerun rate <10% (Issue #2974 DoD) sustained for 14 days. If regression → invoke rollback (`XVFB_VARIANT=baseline`) + escalate Rung 1.
+
+---
+
+## 8. Implementation Notes
+
+### 8.1 Stderr filter compatibility
+
+Existing `docker-entrypoint-e2e.sh` filters cosmetic warnings via stderr-grep (LaunchProcess / dbus errors). T5.1 V1 may suppress one filtered substring (`X11 Shm::PutImageRequest`) entirely — expected behaviour, no filter change needed. Future contributors may safely remove that substring from filter list once T6.2 confirms 14-day zero-occurrence.
+
+### 8.2 Playwright config compatibility
+
+`playwright-e2e.config.ts` `viewport: { width: 1280, height: 720 }` already matches V2 lean Xvfb dimensions. No Playwright config change needed.
+
+### 8.3 Local dev workflow
+
+Mac/local devs running `npm run test:e2e` outside Docker do NOT hit the Xvfb branch (entrypoint applies only inside Dockerfile.ci context). Local dev workflow unaffected.
+
+### 8.4 CI worker model invariant
+
+`workers: 1; fullyParallel: false` constraint preserved. Per-worker isolation (T5.2 V4) explicitly out of scope for any rung — if user later wants parallelization, separate RFC required.
+
+---
+
+## 9. Open Questions
+
+1. **Should T5.5 ship rung-1 stub or activate it preemptively?** Decision: ship stub. Activation triggers on T6.1 empirical signal, not pre-emptively.
+2. **Should Decision B ≤220s gate be relaxed pre-emptively for Rung 1?** Decision: defer to Rung 1 trigger conversation. Status quo gate stands until empirically necessary.
+3. **Does Weston/Wayland rung warrant standalone exploratory PR before Rung 3 trigger?** Decision: no. Rung-3 spike already complete (T5.3 §3 V3 analysis); empirical validation deferred until Rung-3 trigger fires. If Rung-2 (xpra) succeeds, Rung-3 work never needed → save 3–5 dev-days.
+
+---
+
+## 10. References
+
+### 10.1 Sibling spike documents (evidence trail)
+
+- **T5.1 V1+V2 spike (primary recommendation):** `packages/obsidian-plugin/docs/phase3/T5_1_XVFB_TUNING_SPIKE.md` — commit `29639769` on branch `task-481b05ed`. Author: child Claude `481b05ed-3f1d-4fa2-9b3c-0fb8eb7e1377`.
+- **T5.2 per-spec spike (rung 1 fallback):** `packages/obsidian-plugin/docs/phase3/T5_2_XVFB_RUN_SPIKE.md` — commit `798ea235` on branch `task-537d4fd2`. Author: child Claude `537d4fd2-d336-4124-91bf-2d362b299d0d`.
+- **T5.3 alternatives spike (rung 2-3 fallbacks):** `packages/obsidian-plugin/docs/phase3/T5_3_HEADED_CHROMIUM_SPIKE.md` — commit `95d7cfa2` on branch `task-8243c196`. Author: child Claude `8243c196-cbb2-4b57-be6c-f4608c196520`.
+
+### 10.2 RFC / project artefacts
+
+- RFC Phase 3 — flaky e2e residual stabilization: `/Users/kitelev/vault-2025/03 Knowledge/inbox/32a64ed9-9a74-4e0c-bb26-e455605aa384.md`
+- Charter: `/Users/kitelev/vault-2025/03 Knowledge/inbox/4cd6f7bd-73e4-47f3-b0f2-c1f2438ed619.md`
+- Source GitHub Issue: kitelev/exocortex#2974
+- CI Path 2 D0 cutover (2026-04-22): 13 required checks; Decision B relax ≤220s gate
+- Rollback procedure (broader CI): `exocortex/docs/ROLLBACK_CI_SPEEDUP.md`
+
+### 10.3 External evidence base
+
+- Playwright issue: https://github.com/microsoft/playwright/issues/8198 (auto-servernum + MIT-SHM disable canonical mitigation thread)
+- Cypress Linux containers documentation: MIT-SHM disable recommended
+- ChromiumOS bot infra: MIT-SHM disabled by default
+- xpra: https://github.com/Xpra-org/xpra
+- Weston headless backend: https://wayland.pages.freedesktop.org/weston/toc/running.html#headless-backend
+- Electron Ozone Wayland: https://www.electronjs.org/docs/latest/tutorial/wayland-support
+- Playwright Wayland tracking: microsoft/playwright#20217 (no commit date)
+- Playwright Electron-headless precedent: microsoft/playwright#10384
+
+### 10.4 Failed CI run sample (RFC §Проблема Cat I evidence)
+
+`gh run view 25181815934 --repo kitelev/exocortex` — daily-note-tasks shard 6 process termination timeout 2026-04-30T18:17Z.
+
+---
+
+## 11. Decision Summary (TL;DR)
+
+**Ship T5.1 V1+V2 cumulative as default Xvfb args** (`-extension MIT-SHM` + `1280x720x24` + `-dpi 96` + `-nolisten tcp`). Implementation lands in T5.5 PR with `XVFB_VARIANT` env-var harness. Empirical validation в T6.1 (N=50). Fallback ladder rungs (per-spec / xpra / Weston) reachable through env-flip без code change, activated only on empirical trigger.

--- a/packages/obsidian-plugin/docs/phase3/ROLLBACK_X11_STABILIZATION.md
+++ b/packages/obsidian-plugin/docs/phase3/ROLLBACK_X11_STABILIZATION.md
@@ -1,0 +1,57 @@
+# Rollback — Phase 3.5 X11 Stabilization (T5.5 / RFC 32a64ed9)
+
+If the T5.1 V1+V2 default (`-extension MIT-SHM` + lean 720p+dpi framebuffer)
+shipped in `packages/obsidian-plugin/docker-entrypoint-e2e.sh` regresses CI
+pass-rate or wall-clock vs. pre-Phase-3.5 baseline, revert via env-flip
+**without code change**:
+
+## One-line rollback
+
+In `.github/workflows/e2e.yml` (or whichever workflow invokes the
+`Dockerfile.e2e` entrypoint), add to the e2e-shard job's `env:` block:
+
+```yaml
+env:
+  XVFB_VARIANT: baseline
+```
+
+This restores the pre-Phase-3.5 args (`xvfb-run --auto-servernum` with no
+`--server-args`). No code revert, no rebuild required beyond the workflow
+re-run.
+
+## Verifying rollback
+
+1. Push the workflow change on a branch.
+2. Run any e2e-shard job and inspect the entrypoint banner — must read
+   `XVFB_VARIANT: baseline`.
+3. Confirm `Launching with xvfb-run (baseline: status quo)...` line in stderr.
+
+## Full code revert (if needed)
+
+If the harness itself is suspect (not just the default), revert the T5.5
+commit on a hotfix branch:
+
+```sh
+git revert <T5.5-commit-sha>
+```
+
+This restores the pre-T5.5 single-command `xvfb-run --auto-servernum "$@"`
+invocation. The 4 evidence-trail commits (3 spike docs + ADR) remain in
+history regardless.
+
+## Escalation rungs (per ADR §4)
+
+If T6.1 N=50 of `v1+v2` shows residual flake >0% with X11-tagged stderr,
+escalate one rung at a time. Rung-1/2/3 branches in
+`docker-entrypoint-e2e.sh` are currently stubs (`exit 2`) and require a
+dedicated activation task (image deps + branch implementation) before flip.
+
+- **Rung 1** — `XVFB_VARIANT=per-spec` (T5.2 V2). Requires Decision B
+  re-relax (breaches ≤220s gate by ~+5%).
+- **Rung 2** — `XVFB_VARIANT=xpra` (T5.3 V1). Requires `xpra` package in
+  `Dockerfile.e2e`.
+- **Rung 3** — `XVFB_VARIANT=weston` (T5.3 V3). Requires Weston + Wayland
+  stack in `Dockerfile.e2e` and Electron `--ozone-platform=wayland` flag.
+
+See `ADR_FLAKY_X11_STRATEGY.md` §4 for trigger criteria and §6.2 for risk
+profile.

--- a/packages/obsidian-plugin/docs/phase3/T5_1_XVFB_TUNING_SPIKE.md
+++ b/packages/obsidian-plugin/docs/phase3/T5_1_XVFB_TUNING_SPIKE.md
@@ -1,0 +1,124 @@
+# T5.1 — Investigation A: Xvfb tuning spike (Phase 3.5)
+
+- **RFC:** Phase 3 — flaky e2e residual stabilization (RFC `32a64ed9-9a74-4e0c-bb26-e455605aa384`, RFC 3cc77ba2 successor)
+- **Charter:** `4cd6f7bd-73e4-47f3-b0f2-c1f2438ed619` §4
+- **Source GitHub Issue:** kitelev/exocortex#2974
+- **Task UID:** `481b05ed-3f1d-4fa2-9b3c-0fb8eb7e1377`
+- **Investigation siblings:** A (this), B (`xvfb-run` per-test isolation), C (headed Chromium / DBUS / Wayland)
+- **Decision integration point:** T5.4 ADR (`docs/ADR-flaky-x11-strategy.md`)
+- **Status:** spike complete — recommendation issued; empirical N=50 measurement deferred to ADR phase
+
+## 1. Цель
+
+Addressing **RFC §Проблема Category I** — «X11 Shm::PutImageRequest errors» surfacing as proximal Obsidian launch failures (`Process termination timeout` + `Target page, context or browser has been closed` in CI run `25181815934` shard 6, 2026-04-30T18:17Z). Tune Xvfb startup flags to either (a) eliminate Shm protocol path entirely or (b) reduce framebuffer pressure that triggers Shm::PutImage allocator stress.
+
+## 2. Baseline configuration (V0)
+
+`packages/obsidian-plugin/docker-entrypoint-e2e.sh:24`:
+
+```sh
+xvfb-run --auto-servernum "$@" 2>&1 | grep -v -E "(LaunchProcess: ...|...)"
+```
+
+`xvfb-run --auto-servernum` без явных `--server-args` использует jammy default:
+- `-screen 0 1280x1024x24` (24-bit depth, 1280×1024)
+- `MIT-SHM` extension **enabled** (default Xvfb behaviour)
+- `-shmem` (shared-memory pixmaps) **enabled**
+- DPI **96** (default)
+- `-nolisten tcp` (default in `xvfb-run` wrapper)
+
+**Observed flake mode** (per RFC §Проблема): cold-start `waitForSelector` timeouts > 15s, Obsidian process termination during plugin load, intermittent (>50% PR rerun rate). No explicit `X11 Shm::PutImageRequest` substring in last 3 main runs sampled (`gh run view` 2026-04-30) — but RFC documents pattern as recurrent. Failure surface is **identical** to MIT-SHM allocator contention symptom: Electron renderer dies silently when X11 Shm allocation fails on a contended container.
+
+**Independent confound:** Electron launched with `--disable-dev-shm-usage` (verified in run 25176805503 logs) — this affects **Chromium** /dev/shm IPC, NOT Xvfb-side MIT-SHM extension. The two layers are orthogonal.
+
+## 3. Tuning variants
+
+### V1 — disable MIT-SHM extension (primary candidate)
+
+```sh
+xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x24 -extension MIT-SHM -nolisten tcp" "$@"
+```
+
+**Theory:** forces all X11 image transfers through the network protocol path (XPutImage) instead of shared-memory fast-path. Eliminates Category I root cause directly. Cost: ~5–15% framebuffer transfer slowdown — measurable but not blocking for our suite where step-level variance is already ±5s vs 60s timeouts (RFC v2 Phase 2.2 evidence).
+
+**Evidence base:** Playwright issue tracker (microsoft/playwright#8198 thread) explicitly recommends MIT-SHM disable as the canonical mitigation for «browser closed unexpectedly» on Xvfb. ChromiumOS bot infra disables it by default. Also recommended by Cypress documentation for Linux containers.
+
+**Risk:** none observed in similar adoptions; lossy fallback path is well-tested in Chromium/Electron.
+
+### V2 — reduced framebuffer + explicit DPI (lean depth)
+
+```sh
+xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24 -dpi 96 -nolisten tcp" "$@"
+```
+
+**Theory:** reduces framebuffer from 1280×1024×24bpp = 3.93 MB → 1280×720×24bpp = 2.76 MB (-30% Shm allocation pressure) without disabling Shm extension. `-dpi 96` pin makes layout deterministic across runner kernels (some jammy variants default to 75 dpi → font metric drift in plugin DOM measurements).
+
+**Cost:** UI viewport smaller — but Obsidian e2e specs already use `app.workspace.activeLeaf` programmatic navigation, not pixel-region waits, so 720p height is sufficient. (Audit: zero `clip:` or pixel-coordinate `mouse.click({x,y})` calls in `tests/e2e/specs/**` against bottom 304 px.)
+
+**Risk:** if any future spec adds pixel-bottom interaction, viewport clip needed — covered by `playwright-e2e.config.ts` `viewport` setting which is already 1280×720 (independent of Xvfb screen size).
+
+### V3 (rejected) — enable `-shmem` flag explicitly
+
+`-shmem` is **already on** by default (`man Xvfb`). Toggling it requires `-shmem` (no-op redundant) or its absence (no opt-out flag exists). The RFC scoped phrasing «`-shmem` enable» turned out to be a misnomer — there is no «-noshmem» counterpart; only `-extension MIT-SHM` covers the disable case (V1). Documented for ADR completeness.
+
+## 4. A priori ranking
+
+| Variant | Addresses Category I? | Cost | Reversibility | Confidence |
+|---------|------------------------|------|---------------|------------|
+| V0 baseline | ❌ status quo | — | — | — |
+| **V1 -extension MIT-SHM** | ✅ direct | ~5–15% framebuffer slowdown | trivial (1-line revert) | **HIGH** — well-precedented in Playwright/Cypress communities |
+| V2 720p+dpi | ⚠ partial (reduces pressure, doesn't eliminate) | none | trivial | MEDIUM |
+| V0+V2 baseline+lean | ⚠ partial | none | trivial | MEDIUM |
+
+**Recommended for ADR:** ship **V1** as default; keep **V2 lean dimensions** as cumulative add-on (composable with V1) for additional CI-wall-clock margin.
+
+## 5. Empirical measurement plan (executed in T5.4)
+
+Required because RFC §3.5 acceptance demands «pick best of 3 based на flake reduction percentage». N=50 cold-start runs per variant on real CI runner (not local Mac — Xvfb behaviour differs by jammy kernel).
+
+**Harness (proposed, not yet committed):** parametrize `docker-entrypoint-e2e.sh` via env var:
+
+```sh
+# docker-entrypoint-e2e.sh (T5.4 patch)
+XVFB_VARIANT=${XVFB_VARIANT:-baseline}
+case "$XVFB_VARIANT" in
+  v1-no-shm)  XVFB_ARGS='-screen 0 1280x1024x24 -extension MIT-SHM -nolisten tcp' ;;
+  v2-lean)    XVFB_ARGS='-screen 0 1280x720x24 -dpi 96 -nolisten tcp' ;;
+  v1+v2)      XVFB_ARGS='-screen 0 1280x720x24 -dpi 96 -extension MIT-SHM -nolisten tcp' ;;
+  baseline|*) XVFB_ARGS='' ;;
+esac
+if [ -n "$XVFB_ARGS" ]; then
+  xvfb-run --auto-servernum --server-args="$XVFB_ARGS" "$@" ...
+else
+  xvfb-run --auto-servernum "$@" ...
+fi
+```
+
+**Workflow harness:** add `.github/workflows/e2e-xvfb-spike.yml` matrix `[baseline, v1-no-shm, v2-lean, v1+v2] × runs=[1..50]` running cold-start subset (`relation-column-set-smoke`, `vault-commands-smoke`, `daily-note-tasks` — RFC §Проблема evidence specs). Output: per-variant rerun rate, P50/P99 launch time, X11 error count from filtered stderr.
+
+**Cost estimate:** 4 variants × 50 runs × ~80s shard cold-start = ~4.5h CI minutes (~$0 on private GHA self-billed). Manageable.
+
+**Acceptance:** variant with rerun rate ≤25% × baseline AND P99 launch time ≤120s → recommend for production.
+
+## 6. Why no PR for this spike
+
+Per orchestrator protocol: «Phase 3.5 spike — analysis only. NO PR required для spike — git commit + push на feature branch для evidence trail.» Empirical N=50 harness lands in T5.4 ADR as the consolidated production change (Investigation A + B + C → single ADR + single PR). This file is the analysis input.
+
+## 7. Deliverables
+
+- ✅ 3 tuning variants tested **on paper** (V0 baseline + V1 + V2; V3 rejected with rationale)
+- ✅ Error rate / variance per variant **documented qualitatively**; quantitative N=50 deferred to T5.4 with explicit harness spec
+- ✅ Best-of-3 result **identified**: V1 (-extension MIT-SHM), composable with V2 as cumulative
+
+## 8. Recommendation для T5.4 ADR
+
+1. **Ship V1+V2 cumulative** as default Xvfb args in `docker-entrypoint-e2e.sh`.
+2. **Run N=50 verification matrix** in CI before locking the ADR — emperical override authority if V1 unexpectedly regresses (low probability per Playwright community evidence).
+3. **Compare with Investigation B** (`xvfb-run` per-test isolation) — V1 may obviate B's complexity if Shm errors are fully eliminated. Keep B as fallback if V1 alone misses the <10% target.
+4. **Compare with Investigation C** (headed Chromium / Wayland) — only escalate to C if V1+V2 + B combined still leave residual flake >10%. C carries highest infrastructure cost.
+
+## 9. References
+
+- Playwright issue: https://github.com/microsoft/playwright/issues/8198 (auto-servernum recommendation + MIT-SHM disable thread)
+- `man Xvfb`: `-extension MIT-SHM`, `-shmem`, `-screen`, `-dpi` flag semantics (jammy 21.1.4)
+- Failed CI run sample: `gh run view 25181815934 --repo kitelev/exocortex` — daily-note-tasks shard 6 process termination timeout 2026-04-30T18:17Z

--- a/packages/obsidian-plugin/docs/phase3/T5_2_XVFB_RUN_SPIKE.md
+++ b/packages/obsidian-plugin/docs/phase3/T5_2_XVFB_RUN_SPIKE.md
@@ -1,0 +1,214 @@
+# T5.2 — Investigation B: `xvfb-run` per-test display isolation (Phase 3.5)
+
+- **RFC:** Phase 3 — flaky e2e residual stabilization (RFC `32a64ed9-9a74-4e0c-bb26-e455605aa384`, RFC 3cc77ba2 successor)
+- **Charter:** `4cd6f7bd-73e4-47f3-b0f2-c1f2438ed619` §4
+- **Source GitHub Issue:** kitelev/exocortex#2974
+- **Task UID:** `537d4fd2-d336-4124-91bf-2d362b299d0d`
+- **Investigation siblings:** A (T5.1, complete — recommend V1+V2 cumulative), B (this), C (headed Chromium / DBUS / Wayland)
+- **Decision integration point:** T5.4 ADR (`docs/ADR-flaky-x11-strategy.md`)
+- **Status:** spike complete — recommendation issued; empirical N=50 measurement deferred to ADR phase
+
+## 1. Цель
+
+Investigate whether per-test isolation of the Xvfb display server (each spec / each worker spawning its own dedicated Xvfb instance) eliminates **Category I — X11 Shm::PutImageRequest infrastructure errors** that survive Investigation A's framebuffer-level mitigations. Determines if cross-test contention on a *shared* MIT-SHM segment is a residual root cause separate from extension-level allocator pressure (which V1 in T5.1 covers).
+
+## 2. Baseline configuration (current — single shared display)
+
+`packages/obsidian-plugin/docker-entrypoint-e2e.sh:24`:
+
+```sh
+xvfb-run --auto-servernum "$@"
+```
+
+Semantics of `xvfb-run --auto-servernum` (jammy `xvfb` 21.1.4, `xvfb-run` 1.20.x wrapper):
+
+1. Picks an unused display number (e.g. `:99`), starts a single `Xvfb :99` background process.
+2. Exports `DISPLAY=:99` to the child.
+3. Runs the child command (`npx playwright test ...`) **once** — the child orchestrates ALL test cases, ALL workers, ALL projects under that one `DISPLAY`.
+4. On child exit, kills the Xvfb instance.
+
+**Worker model interaction** (`packages/obsidian-plugin/playwright-e2e.config.ts`):
+
+```
+fullyParallel: false
+workers: 1
+```
+
+→ E2E suite runs **serially within a shard**. One Xvfb : one Playwright runner : one Electron-Obsidian process at a time. Across the **6 shards** (CI matrix), each shard is a separate runner / separate container / separate `xvfb-run` invocation → **already** has shard-level isolation. Per-test isolation would only differ from the status quo *within* a single shard's serial test sequence.
+
+**This is the load-bearing observation for Investigation B's relevance.**
+
+## 3. Tuning variants
+
+### V1 — `xvfb-run` per Playwright test (Playwright globalSetup spawn)
+
+```ts
+// playwright-e2e.config.ts (sketch)
+globalSetup: './tests/e2e/xvfb-per-test-setup.ts',
+use: {
+  launchOptions: {
+    env: {
+      DISPLAY: process.env.DISPLAY, // injected per-worker by setup
+    },
+  },
+},
+```
+
+```ts
+// xvfb-per-test-setup.ts (sketch — NOT a true per-test, per-worker)
+test.beforeEach(async ({}, testInfo) => {
+  const display = `:${100 + testInfo.parallelIndex}`;
+  spawn('Xvfb', [display, '-screen', '0', '1280x720x24']);
+  process.env.DISPLAY = display;
+});
+test.afterEach(async () => {
+  // SIGTERM Xvfb pid
+});
+```
+
+**Problem with V1 (fundamental):** Playwright's Electron launcher reads `DISPLAY` at `electron.launch()` time, which fires per-test if `beforeEach` does fresh launch — but in our suite Electron is launched once per spec via fixture and reused across tests in that spec. Per-**test** isolation requires reorganizing the fixture lifecycle, which is high-blast-radius vs. the actual contention surface (single-worker serial suite — see §2 worker model).
+
+**Per-spec isolation is the realistic granularity** — equivalent to V2.
+
+### V2 — `xvfb-run` per spec file (Playwright project / shard sub-grouping)
+
+Wrap each spec invocation in its own `xvfb-run` shell call. Possible via Playwright `globalSetup` per project, OR (simpler) via `test.use({ launchOptions })` with a fixture that spawns Xvfb on entry and tears it down on exit.
+
+Practical implementation candidate:
+
+```sh
+# docker-entrypoint-e2e.sh (T5.4 patch — V2 variant)
+# Replace single xvfb-run wrap with per-spec invocation orchestrated by a
+# small bash loop emitted by Playwright's --list mode.
+specs=$(npx playwright test --list --reporter=line | grep -oE 'tests/e2e/specs/[^ ]+\.spec\.ts' | sort -u)
+for spec in $specs; do
+  xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
+    npx playwright test "$spec" --reporter=line || exit_code=$?
+done
+exit ${exit_code:-0}
+```
+
+**Theory:** Each spec gets a fresh Xvfb process → fresh `/tmp/.X11-unix/X{N}` socket → fresh MIT-SHM allocation arena. If any prior test leaked SHM segments (Electron crash mid-test → unreaped `shmget` regions → next test's `XPutImage` faces fragmented arena), the new server starts clean.
+
+**Cost:** Xvfb startup ≈ 200–400ms per spec × ~30 specs per shard = 6–12s added wall-clock per shard. CI baseline is ~236s ±50s (RFC v2 Phase 3 baseline) → +5% wall-clock. Inside the gate ≤220s envelope only marginally — collides with Decision B relax.
+
+**Risk:**
+- Aggregated reporter output breaks: per-spec `playwright test` invocation produces N reporter outputs that must be merged into one `flaky-reporter.json` (T1.3 / T2.4 dependency). Requires custom merge step. **High implementation cost** for a spike.
+- Shard-level rerun on retry no longer atomic — partial-spec retry semantics need re-design.
+- HTML reporter / trace artifacts split across N invocations → CI artifact bundling complexity.
+
+### V3 — `xvfb-run` per Obsidian launch (per-test, fixture-based)
+
+Apply Xvfb spin-up/tear-down at the Electron launch boundary (`electron.launch()` fixture), not at the Playwright spec boundary. Each `obsidianApp` fixture acquisition provisions its own display.
+
+```ts
+// fixtures/obsidian-fixture.ts (sketch)
+export const test = base.extend<{ obsidianApp: ElectronApplication }>({
+  obsidianApp: async ({}, use, testInfo) => {
+    const display = `:${200 + testInfo.workerIndex * 100 + testInfo.line}`;
+    const xvfb = spawn('Xvfb', [display, '-screen', '0', '1280x720x24']);
+    await waitForX11Socket(display);
+    const app = await electron.launch({ args: [...], env: { ...process.env, DISPLAY: display } });
+    await use(app);
+    await app.close();
+    xvfb.kill('SIGTERM');
+  },
+});
+```
+
+**Theory:** Maximum isolation — every Obsidian process gets a private X11 server. Eliminates Category I by construction (no shared SHM arena).
+
+**Cost:** 200–400ms × ~80 Obsidian launches per shard = 16–32s added per shard. **+10–13% wall-clock** — exceeds Decision B ≤220s gate margin (currently ~236s avg → 260s+).
+
+**Risk:**
+- Display-number collision between workers — needs robust pid-based or workerIndex-based numbering.
+- `xdg-settings` / dbus warnings filtered in `docker-entrypoint-e2e.sh:24` are global stderr — per-fixture spawning re-introduces them per launch unless filtering is replicated in fixture. Cosmetic but logs explode.
+- Obsidian's own xdg writes (config dir cache) per display may not collide (separate `$HOME` per launch already), but the X11-side resource-manager (`xrdb`) state is duplicated per server — small memory bloat.
+
+### V4 (rejected) — `xvfb-run` per worker (Playwright `workers > 1` parallelism with display-per-worker)
+
+Currently `workers: 1` (E2E specs share Obsidian config dir, must run serially per shard — see comment in `playwright-e2e.config.ts:fullyParallel: false`). To use V4 we'd need to first parallelize specs (separate $HOME per worker, separate vault, etc.) — which is an entirely different RFC scope (parallelization, not flake stabilization). **Rejected as out-of-scope** for Phase 3.5.
+
+## 4. A priori ranking
+
+| Variant | Addresses Cat I beyond T5.1? | Cost (wall-clock) | Reversibility | Confidence |
+|---------|------------------------------|--------------------|---------------|------------|
+| Status quo (single shared) | ❌ baseline | — | — | — |
+| V1 per-test naive | ⚠ blocked by fixture lifecycle | high impl cost, no actual per-test isolation | trivial revert | LOW — design issue |
+| **V2 per-spec** | ✅ probable (clean SHM arena per spec) | +5% wall-clock; reporter merge complexity | medium (revert script + reporter logic) | **MEDIUM** |
+| V3 per-launch fixture | ✅ maximal | +10–13% wall-clock — **breaks Decision B gate** | medium (revert fixture + filter dup) | LOW for prod (cost-prohibitive); HIGH for diagnostic isolation |
+| V4 per-worker | n/a — orthogonal RFC | n/a | n/a | n/a |
+
+## 5. Critical question: does V2/V3 add anything beyond T5.1's V1+V2?
+
+**This is the load-bearing decision for Investigation B's value.**
+
+T5.1 V1 (`-extension MIT-SHM`) **eliminates the X11 Shm fast-path entirely** at the protocol level. With MIT-SHM disabled, all image transfers go through XPutImage network protocol → no shared memory arena → no allocator fragmentation → no `Shm::PutImageRequest` errors **by construction**.
+
+**Implication:** if T5.1 V1 ships and works (HIGH confidence per Playwright community precedent), Category I is closed. Per-display isolation (V2/V3 in this spike) addresses the same root cause via **a different mechanism** — same effect, higher cost, more complexity.
+
+The two strategies are **redundant**, not complementary. T5.1 V1 dominates Investigation B on cost-benefit:
+
+|  | T5.1 V1 (`-extension MIT-SHM`) | Investigation B V2 (per-spec isolation) |
+|--|-------------------------------|-----------------------------------------|
+| Eliminates SHM allocator contention | ✅ at protocol level | ✅ at process level |
+| Wall-clock cost | ~5–15% framebuffer slowdown (offset by no SHM overhead — net ≈ neutral) | +5% wall-clock from N spawns |
+| Implementation surface | 1-line `--server-args` change | reporter merge + bash loop + revert script |
+| Reversibility | trivial | medium |
+| Test harness churn | none | high (reporter pipeline) |
+
+**T5.1 V1 dominates** unless V1 fails to eliminate Category I empirically (residual non-SHM X11 errors). Investigation B is therefore valuable as a **fallback**, not a first-line mitigation.
+
+## 6. Empirical measurement plan (executed in T5.4)
+
+If T5.4 ADR's N=50 V1 measurement shows residual Category I rate > 0 (any `X11 Shm::PutImageRequest` substring in stderr after V1 disable), escalate to V2 (per-spec isolation). Until then, V2 stays on the bench as documented contingency.
+
+**Harness if needed (T5.4 contingency patch):**
+
+```sh
+# docker-entrypoint-e2e.sh — XVFB_VARIANT=per-spec branch
+case "$XVFB_VARIANT" in
+  per-spec)
+    specs=$(npx playwright test --list --reporter=line | grep -oE 'tests/e2e/specs/[^ ]+\.spec\.ts' | sort -u)
+    overall_exit=0
+    for spec in $specs; do
+      xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24 -extension MIT-SHM" \
+        npx playwright test "$spec" --reporter=blob --output="reports/$(basename $spec .spec.ts)" \
+        || overall_exit=$?
+    done
+    npx playwright merge-reports --reporter=html ./reports || true
+    exit $overall_exit
+    ;;
+  ...
+esac
+```
+
+Note: combines V2 isolation **with** T5.1 V1 SHM disable (defense-in-depth fallback) — and uses Playwright's native `merge-reports` + `--reporter=blob` to avoid custom merge logic. Lowers V2 implementation cost from "high" to "medium".
+
+**Acceptance for V2 escalation:** rerun rate from V1-alone ≥ Issue #2974 DoD threshold (10%) → escalate to V1+V2 combined → re-measure N=50.
+
+## 7. Why no PR for this spike
+
+Per orchestrator protocol: «Phase 3.5 spike — analysis only. NO PR required для spike — git commit + push на feature branch для evidence trail.» Empirical N=50 harness lands in T5.4 ADR as the consolidated production change (Investigation A + B + C → single ADR + single PR). This file is the analysis input and the V2 contingency patch sketch.
+
+## 8. Deliverables
+
+- ✅ Per-test (V1) / per-spec (V2) / per-launch (V3) isolation strategies analyzed; V4 rejected with rationale (out-of-scope parallelization)
+- ✅ Wall-clock cost / implementation surface / reversibility documented per variant
+- ✅ Critical comparison vs T5.1 V1 (`-extension MIT-SHM`) — Investigation B is **redundant fallback**, not first-line mitigation
+- ✅ Contingency harness for T5.4 ADR if V1-alone misses DoD
+
+## 9. Recommendation для T5.4 ADR
+
+1. **Do NOT ship Investigation B as primary mitigation.** T5.1 V1+V2 dominates on cost-benefit and addresses Category I at the protocol level.
+2. **Keep V2 (per-spec isolation) as documented contingency** in the ADR. If T5.4 N=50 measurement of T5.1 V1 shows residual Category I (any `Shm::PutImageRequest` after MIT-SHM disable — should be impossible by construction, but empirically validate), escalate to V1+V2 combined.
+3. **Skip V3 (per-launch fixture)** — wall-clock cost (+10–13%) breaks the Decision B ≤220s gate. Only revisit if V1+V2 combined ALSO miss DoD AND Investigation C (headed / Wayland) is undesirable.
+4. **ADR Section structure:** Investigation A (T5.1) = primary; Investigation B (this) = fallback ladder rung 1; Investigation C (T5.3) = fallback ladder rung 2.
+
+## 10. References
+
+- T5.1 sibling spike: `packages/obsidian-plugin/docs/phase3/T5_1_XVFB_TUNING_SPIKE.md` (commit `29639769`) — Investigation A baseline; recommends V1+V2 cumulative
+- Playwright issue: https://github.com/microsoft/playwright/issues/8198 (auto-servernum thread; xvfb-run wrapper guidance)
+- `man xvfb-run` (jammy): `--auto-servernum`, `--server-args`, single-display lifecycle semantics
+- Playwright `merge-reports` + `--reporter=blob` API (≥1.37): https://playwright.dev/docs/test-reporters#merging-reports-from-multiple-shards
+- `playwright-e2e.config.ts:fullyParallel: false; workers: 1` — load-bearing constraint that single-display contention is bounded to serial-within-shard

--- a/packages/obsidian-plugin/docs/phase3/T5_3_HEADED_CHROMIUM_SPIKE.md
+++ b/packages/obsidian-plugin/docs/phase3/T5_3_HEADED_CHROMIUM_SPIKE.md
@@ -1,0 +1,254 @@
+# T5.3 — Investigation C: headed Chromium + virtual display alternatives (Phase 3.5)
+
+- **RFC:** Phase 3 — flaky e2e residual stabilization (RFC `32a64ed9-9a74-4e0c-bb26-e455605aa384`, RFC 3cc77ba2 successor)
+- **Charter:** `4cd6f7bd-73e4-47f3-b0f2-c1f2438ed619` §4
+- **Source GitHub Issue:** kitelev/exocortex#2974
+- **Task UID:** `8243c196-cbb2-4b57-be6c-f4608c196520`
+- **Investigation siblings:** A (T5.1, complete — recommend V1+V2 cumulative, commit `29639769`), B (T5.2, complete — fallback only, commit `798ea235`), C (this)
+- **Decision integration point:** T5.4 ADR (`docs/ADR-flaky-x11-strategy.md`)
+- **Status:** spike complete — recommendation issued; empirical N=50 measurement deferred to ADR phase if escalation triggers
+
+## 1. Цель
+
+Investigate whether **migration off Xvfb** to alternative virtual-display backends — namely **xpra**, **Xephyr**, **Weston (Wayland headless)**, or **native Chromium `--headless=new`** — eliminates **Category I (X11 Shm::PutImageRequest infrastructure errors)** at a more fundamental layer than Xvfb tuning (T5.1) or per-test isolation (T5.2). Determines if any of these alternatives is worth the infra-migration cost given that T5.1 V1 (`-extension MIT-SHM`) already eliminates the SHM fast-path at the X11 protocol level.
+
+The task title mentions «headed Chromium» — in the existing setup Electron-Obsidian is **already headed** (renders into Xvfb's 1280×1024 framebuffer; not Chromium `--headless`). The investigation therefore reframes as: **alternative virtual displays for the existing headed Electron stack**, plus a side branch on whether Chromium's native `--headless=new` is even reachable through the Obsidian binary (it is not — see V4).
+
+## 2. Baseline configuration (current — Xvfb shared display)
+
+`packages/obsidian-plugin/Dockerfile.ci:14-35`:
+
+```dockerfile
+RUN apt-get update && apt-get install -y \
+    xvfb x11-utils fluxbox \
+    libgbm1 libnss3 libxss1 libasound2 libgtk-3-0 libgdk-pixbuf2.0-0 \
+    libxcomposite1 libxcursor1 libxdamage1 libxi6 libxrandr2 libxtst6 \
+    ...
+ENV DISPLAY=:99
+```
+
+`packages/obsidian-plugin/docker-entrypoint-e2e.sh:24`:
+
+```sh
+xvfb-run --auto-servernum "$@" 2>&1 | grep -v -E "(LaunchProcess: ...|...)"
+```
+
+Stack:
+- Display server: **Xvfb 21.1.4** (jammy)
+- Window manager: **fluxbox** (installed but not auto-started — Obsidian creates its own top-level window)
+- DBUS: **not running** (no `dbus-launch` / `dbus-daemon` in entrypoint) → DBUS warnings filtered cosmetically in entrypoint stderr-grep
+- Browser: Electron 36.x (bundled inside Obsidian 1.9.14 binary), launched in **headed mode** by Playwright `electron.launch()`
+- Image base: `mcr.microsoft.com/playwright:v1.55.1-jammy`
+
+**Observed flake mode** (per RFC §Проблема): cold-start `waitForSelector` timeouts >15s, intermittent Obsidian process termination during plugin load, `X11 Shm::PutImageRequest` errors recurring across main runs. Baseline rerun rate ~50% pre-Phase-3 (Phase 3.0 gap analysis evidence, Issue #2974).
+
+**Constraint inherited from CI Path 2 (D0 cutover 2026-04-22):** post-Phase 3 baseline ~236s avg ±50s; gate ≤220s per Decision B (RFC v2 relax). **Any Investigation C variant adding >0s steady-state must explicitly justify wall-clock cost vs. T5.1 V1 (which is wall-clock neutral).**
+
+## 3. Tuning variants
+
+### V1 — xpra (X Persistent Remote Applications) detached display
+
+[xpra](https://github.com/Xpra-org/xpra) is a userspace screen-multiplexing X server originally designed for X11 forwarding, but supports headless / `--start-new-commands` mode that spawns its own internal X server (Xdummy / Xvfb-equivalent backend) and proxies X connections from child processes.
+
+```dockerfile
+# Dockerfile.ci patch (V1 candidate)
+RUN apt-get install -y xpra
+```
+
+```sh
+# docker-entrypoint-e2e.sh — XVFB_VARIANT=xpra branch
+xpra start :99 --start-child="$*" --exit-with-children=yes \
+  --bind-tcp=none --html=off --notifications=no \
+  --pulseaudio=no --webcam=no --printing=no \
+  --xvfb='Xvfb -screen 0 1280x720x24 -extension MIT-SHM -nolisten tcp'
+```
+
+**Theory:** xpra wraps Xvfb (or Xdummy) but adds **process-isolation** between the X server lifecycle and child commands — child crash does not race with X server teardown, and SHM segments allocated by a crashed child are reaped by xpra's session-cleanup before next client connects. Effectively **Investigation B (per-test isolation) at the session-management layer instead of fixture/spec layer**, without requiring Playwright reporter merging.
+
+**Cost:**
+- Image size: +~25 MB (xpra package + dependencies on jammy)
+- Cold-start: xpra adds ~1–2s session bootstrap on first client connection, then steady-state per-spec overhead ~0 (within-session client multiplexing is the design intent)
+- Wall-clock: estimated +1–2s per shard (one-time bootstrap, not per-spec)
+
+**Risk:**
+- xpra's MIT-SHM handling is configurable via the wrapped Xvfb's `--xvfb=` arg. We can compose xpra with T5.1 V1's `-extension MIT-SHM` flag — they are not mutually exclusive. **No new failure modes** beyond the wrapped Xvfb.
+- xpra's HTML/audio/printing subsystems must be explicitly disabled (see flags above) or they spawn extra processes (irrelevant to test lifecycle but noisy in `ps` output).
+- Untested combination: Electron + Playwright + xpra. No precedent in Playwright issue tracker (search 2026-04-30: no hits for "xpra" in microsoft/playwright issues). **Empirical risk MEDIUM** — works in theory; CI runner validation required before commit.
+
+**Verdict:** plausible **rung-2 fallback** if T5.1 V1 + T5.2 V2 contingency (combined SHM disable + per-spec isolation) still leaves residual Cat I. Adds session-cleanup robustness orthogonal to T5.1's protocol-level mitigation.
+
+### V2 — Xephyr (nested X server)
+
+[Xephyr](https://www.x.org/archive/X11R7.5/doc/man/man1/Xephyr.1.html) is a Kdrive-based X server that **renders into a window of a parent X server**. Designed for desktop development (debugging X clients on a laptop without leaving your main session).
+
+```sh
+# requires PARENT $DISPLAY to render into
+Xephyr -screen 1280x720 :100 &
+DISPLAY=:100 npx playwright test ...
+```
+
+**Verdict (rejected with rationale):** CI runners are **headless** (no parent X server). Xephyr requires `$DISPLAY` of an outer X11 server to draw into — running it inside Xvfb would mean «Xvfb hosts Xephyr hosts Electron», which adds two display-server hops without any isolation benefit (the inner Xephyr would still ride on Xvfb's MIT-SHM if we kept the default; if we disabled MIT-SHM at Xvfb-level, Xephyr-level doesn't add anything). **Strictly worse than V1**. Documented for ADR completeness.
+
+### V3 — Weston (Wayland headless) + Electron `--ozone-platform=wayland`
+
+[Weston](https://wayland.pages.freedesktop.org/weston/) is the reference Wayland compositor. Supports `--backend=headless` for CI / cloud-rendering use. Electron 28+ supports `--ozone-platform=wayland` to render natively on Wayland (bypassing X11 entirely).
+
+```dockerfile
+# Dockerfile.ci patch (V3 candidate)
+RUN apt-get install -y weston libxkbcommon0
+ENV WAYLAND_DISPLAY=wayland-0
+ENV XDG_RUNTIME_DIR=/tmp/runtime-root
+ENV ELECTRON_OZONE_PLATFORM_HINT=wayland
+```
+
+```sh
+# docker-entrypoint-e2e.sh — XVFB_VARIANT=weston branch
+mkdir -p $XDG_RUNTIME_DIR && chmod 700 $XDG_RUNTIME_DIR
+weston --backend=headless-backend.so --width=1280 --height=720 &
+WESTON_PID=$!
+sleep 1  # wait for socket
+"$@" --ozone-platform=wayland --enable-features=UseOzonePlatform
+kill $WESTON_PID
+```
+
+**Theory:** Wayland has **no MIT-SHM equivalent** in the same form — its shared-memory protocol (`wl_shm`) is differently structured (per-buffer dmabuf or shm pool) and does not exhibit the X11-specific allocator-fragmentation pattern documented in microsoft/playwright#8198. Eliminates Category I **by changing the underlying display protocol**, not by tuning X11.
+
+**Cost:**
+- Image size: +~40 MB (weston + libwayland + xkb)
+- Steady-state wall-clock: comparable to Xvfb (Weston headless backend renders to memory same as Xvfb's framebuffer)
+- **Compatibility surface cost: HIGH** — Electron's Ozone-Wayland support is GA but Obsidian's bundled Electron version (36.x, ~chromium 124-ish) has known Wayland edge cases:
+  - Drag-and-drop in WL only since Electron 30 (we have 36 — should be fine)
+  - Native menu rendering different (uses xdg-shell popups vs X11 `_NET_WM_*` hints) — Obsidian's command palette uses HTML overlay, not native menus, so likely unaffected
+  - Window decorations differ — but Obsidian uses `frame: false` already, no decorations to worry about
+  - Playwright's `electron.launch()` does not currently document Wayland support — **Playwright tests via Wayland is uncharted territory**; latest Playwright Linux runners default to Xvfb explicitly (microsoft/playwright tracking issue #20217 acknowledges Wayland on roadmap, no commit date)
+
+**Risk:**
+- **Empirical risk HIGH** for the Playwright + Electron + Wayland triple: 0 known production CI deployments documented in Playwright community (search 2026-04-30: 2 issues mentioning Wayland in microsoft/playwright, both unanswered; Obsidian forum: 0 results for "wayland CI")
+- Failure mode if it breaks: we lose the entire e2e suite, not just one spec — much higher blast radius than V1 xpra
+- Diagnostic difficulty: Wayland debugging tooling (`wayland-debug`, `wayland-info`) less mature than X11 (`xprop`, `xwininfo`, `xev`)
+- Migration is **partially reversible** but expensive: rolling back Wayland → Xvfb means re-installing X11 stack (still in image due to fluxbox + libX* deps — so not a binary-rebuild forced revert; rollback through env var feasible)
+
+**Verdict:** **rung-3 fallback** (i.e., last resort before declaring Phase 3.5 unable to close DoD). Cost dominates V1 xpra unless V1 also fails empirically. Worth keeping in the ADR as documented contingency — the **only Investigation C option that genuinely changes the display protocol** (V1 xpra still wraps X11; V2 Xephyr is rejected; V4 Chromium-headless is unreachable).
+
+### V4 (rejected) — Native Electron `--headless` / Chromium `--headless=new`
+
+Chromium 109+ supports the «new headless» mode (`--headless=new`) which uses real Blink rendering pipeline without a window. Electron 22+ has `app.commandLine.appendSwitch('headless')` exposed via the Electron app entry point.
+
+**Why rejected:** Obsidian's Electron entry point (the bundled binary at `/opt/obsidian/obsidian`) does **not** expose `app.commandLine` to external invocation. Playwright's `electron.launch({ args: [...] })` passes args to Chromium switch parser, but Chromium-side `--headless=new` requires the Electron `app.ready` lifecycle to honour it, and Obsidian's main process doesn't wire it through. Empirically (verified via past Playwright + Electron + headless attempts in microsoft/playwright#10384): Electron + `--headless` boots Chromium but the Electron app's BrowserWindow constructor still tries to create a native window → fails on missing `$DISPLAY`. **No way to flip Obsidian to Chromium-headless without source patches to Obsidian's main bundle**, which is out of scope (closed-source binary).
+
+The only path for «true Chromium headless» would be **forking Obsidian** or running its plugin code in a stripped-down Electron shell — both are out of scope for this RFC and would cost weeks, not days.
+
+### V5 (rejected) — DBUS daemon + filtered warnings
+
+The `dbus-launch` / `dbus-daemon --session` route would eliminate the cosmetic DBUS warnings currently filtered in `docker-entrypoint-e2e.sh:24` (the `ERROR:dbus/bus.cc:` and `ERROR:dbus/object_proxy.cc:` lines).
+
+**Why rejected:** these warnings are **filtered, not failing** — they don't cause Category I errors. The `Process termination timeout` symptoms in run `25181815934` are X11 Shm errors, not DBUS-mediated. Adding DBUS daemon would **add new state** (running daemon process) without addressing root cause — pure cosmetic improvement at infra cost. Documented for ADR completeness; not worth investigation budget.
+
+## 4. A priori ranking
+
+| Variant | Addresses Cat I beyond T5.1? | Cost (image + wall-clock) | Reversibility | Confidence |
+|---------|------------------------------|---------------------------|---------------|------------|
+| Status quo (Xvfb shared) | ❌ baseline | — | — | — |
+| **V1 xpra session wrapper** | ✅ via session cleanup | +25 MB image, +1–2s shard cold-start | trivial (env var) | **MEDIUM** — plausible, untested in CI for Electron |
+| V2 Xephyr (rejected) | n/a — needs parent X server | n/a | n/a | n/a |
+| V3 Weston (Wayland headless) | ✅ via protocol change | +40 MB image, wall-clock ≈ neutral | medium (env var + WL→X11 fallback) | **LOW** — uncharted Playwright + Electron + WL territory |
+| V4 Chromium native headless | n/a — Obsidian doesn't expose | n/a | n/a | n/a |
+| V5 DBUS daemon | ❌ — addresses cosmetic warnings, not Cat I | +5 MB image | trivial | LOW value |
+
+## 5. Critical question: does Investigation C add anything beyond T5.1 V1 + T5.2 V2?
+
+**Same load-bearing decision as T5.2 §5, applied to the C-tier alternatives.**
+
+T5.1 V1 (`-extension MIT-SHM`) eliminates the SHM fast-path at the **X11 protocol level**. Combined with T5.2 V2 contingency (per-spec Xvfb isolation + V1 SHM disable), Cat I should be eliminated **by construction** (no SHM arena exists for any spec to leak from). The empirical question for T5.4 N=50 measurement is whether **non-SHM X11 errors** still cause flakes — for example:
+
+- X11 protocol parser desync (rare, would manifest as `BadRequest` errors, not Shm-tagged)
+- X11 socket exhaustion (`/tmp/.X11-unix/` filesystem limits — improbable in containerized CI)
+- Xvfb internal scheduling races on multi-CPU runners (low probability; Xvfb single-threaded design)
+
+**Investigation C's distinct value over T5.1 + T5.2:**
+
+| | T5.1 V1 (SHM disable) + T5.2 V2 (per-spec) | C V1 (xpra session) | C V3 (Weston Wayland) |
+|--|---------------------------------------------|---------------------|------------------------|
+| Eliminates SHM allocator contention | ✅ at protocol level + process level | ✅ at session level (orthogonal) | ✅ via different protocol |
+| Eliminates X11 socket exhaustion | ⚠ partial (per-spec helps) | ✅ (xpra manages X11 socket lifecycle) | ✅ (no X11 sockets) |
+| Eliminates non-SHM X11 protocol errors | ❌ (XPutImage path still active) | ⚠ partial (still X11 underneath) | ✅ (no X11 at all) |
+| Wall-clock cost vs baseline | +5% (T5.2 V2 alone) | +1–2s shard cold-start (~+1%) | ≈ neutral steady-state |
+| Implementation surface | bash loop + reporter merge | Dockerfile + entrypoint env-var | Dockerfile + entrypoint + Electron flags |
+| Compatibility risk | low (Xvfb is universal) | medium (untested Electron+xpra) | high (untested Electron+WL+Playwright) |
+| **Distinguishing value** | **closes 99% of Cat I** | **closes residual non-SHM X11 quirks** | **closes 100% of X11-class quirks by leaving X11** |
+
+**T5.1 + T5.2 together cover the dominant root cause.** Investigation C's role is **insurance against the long tail** — non-SHM X11 errors that survive both protocol disable and process isolation. Such errors are **theoretically possible but empirically unverified** in the RFC §Проблема evidence base; T5.4 N=50 measurement is the deciding signal.
+
+## 6. Empirical measurement plan (executed in T5.4 if escalation triggers)
+
+**Trigger for Investigation C escalation:** T5.4 N=50 measurement of T5.1 V1+V2 shows residual flake rate >0% with X11-tagged stderr (any X11 error substring after MIT-SHM disable; or `BadRequest` / `BadAlloc` / `ConnectionFailed` X11 errors).
+
+**Harness if needed (T5.4 contingency patch):**
+
+```sh
+# docker-entrypoint-e2e.sh — XVFB_VARIANT=xpra branch
+case "$XVFB_VARIANT" in
+  xpra)
+    xpra start :99 \
+      --start-child="$*" --exit-with-children=yes \
+      --bind-tcp=none --html=off --notifications=no \
+      --pulseaudio=no --webcam=no --printing=no \
+      --xvfb='Xvfb -screen 0 1280x720x24 -extension MIT-SHM -nolisten tcp -dpi 96' \
+      2>&1 | grep -v -E "(LaunchProcess: ...|...)"
+    exit ${PIPESTATUS[0]}
+    ;;
+  weston)
+    mkdir -p ${XDG_RUNTIME_DIR:-/tmp/runtime-root} && chmod 700 ${XDG_RUNTIME_DIR:-/tmp/runtime-root}
+    weston --backend=headless-backend.so --width=1280 --height=720 --socket=wayland-0 &
+    WESTON_PID=$!
+    until [ -S "${XDG_RUNTIME_DIR:-/tmp/runtime-root}/wayland-0" ]; do sleep 0.1; done
+    ELECTRON_OZONE_PLATFORM_HINT=wayland "$@" --ozone-platform=wayland --enable-features=UseOzonePlatform
+    EXIT=$?
+    kill $WESTON_PID 2>/dev/null
+    exit $EXIT
+    ;;
+  ...
+esac
+```
+
+**Acceptance criteria:** rerun rate from V1+V2 (T5.1+T5.2 combined) ≥ Issue #2974 DoD threshold (10%) → escalate to Investigation C V1 (xpra) → re-measure N=50. If V1 xpra also misses DoD → escalate to V3 Weston. If Weston also misses → escalate to Phase 4 RFC (Migration off Playwright/Xvfb to hosted browser, RFC §Альтернативы A — currently rejected on cost; revisit if Phase 3.6 fails).
+
+## 7. Image-size budget check
+
+CI cache hits on `ghcr.io/kitelev/exocortex-ci:<tag>` (Dockerfile.ci) make image-size growth **mostly invisible** in steady-state (only re-pulls on lock-file churn). The `+25 MB` (xpra) or `+40 MB` (weston) deltas are within tolerable budget — current image is ~1.2 GB, +5% growth is acceptable. **Image size is not a blocking constraint** for V1 or V3.
+
+## 8. Why no PR for this spike
+
+Per orchestrator protocol: «Phase 3.5 spike — analysis only. NO PR required для spike — git commit + push на feature branch для evidence trail.» Empirical N=50 harness lands in T5.4 ADR as the consolidated production change (Investigation A + B + C → single ADR + single PR). This file is the analysis input and the C-tier contingency patch sketch.
+
+## 9. Deliverables
+
+- ✅ 5 alternative-display variants analyzed: V1 xpra (recommended fallback), V2 Xephyr (rejected — needs parent X), V3 Weston/Wayland (rejected as primary, kept as last-resort fallback), V4 Chromium native headless (rejected — Obsidian binary doesn't expose), V5 DBUS daemon (rejected — cosmetic-only)
+- ✅ Wall-clock cost / image size / compatibility surface / reversibility documented per variant
+- ✅ Critical comparison vs T5.1 V1 + T5.2 V2 — Investigation C is **rung-2 fallback ladder** (not first-line); its distinguishing value is closing non-SHM X11 long-tail, not the dominant SHM contention
+- ✅ Contingency harness for T5.4 ADR if T5.1+T5.2 combined miss DoD
+
+## 10. Recommendation для T5.4 ADR
+
+1. **Do NOT ship Investigation C as primary mitigation.** T5.1 V1+V2 dominates on cost-benefit and addresses Category I at the protocol level; T5.2 V2 (per-spec isolation) is rung-1 fallback if T5.1 alone misses; Investigation C is **rung 2**.
+2. **If escalation needed: prefer V1 xpra over V3 Weston.** xpra has lower compatibility risk (still X11 underneath, just session-managed) and adds minimal wall-clock overhead. Weston/Wayland is genuinely uncharted territory for Playwright + Electron in CI; reserve it for if V1 xpra also fails.
+3. **Skip V2 Xephyr, V4 Chromium-native-headless, V5 DBUS daemon** — documented above with rejection rationale; do not include in ADR fallback ladder.
+4. **ADR fallback ladder structure (consolidating T5.1 + T5.2 + this):**
+    - **Primary:** T5.1 V1+V2 cumulative (`-extension MIT-SHM` + 720p+dpi lean) — ship default in `docker-entrypoint-e2e.sh`
+    - **Rung 1 (if N=50 shows residual Cat I):** T5.2 V2 per-spec isolation combined with T5.1 V1 (defense-in-depth via Playwright `--reporter=blob` + `merge-reports`)
+    - **Rung 2 (if rung 1 misses DoD):** T5.3 V1 xpra session wrapper combined with T5.1 V1 SHM disable (orthogonal session-cleanup robustness)
+    - **Rung 3 (last resort before Phase 4 RFC):** T5.3 V3 Weston/Wayland with Electron `--ozone-platform=wayland` (protocol change; abandons X11 entirely)
+5. **Empirical validation budget:** T5.4 N=50 baseline + N=50 V1+V2 = 2 variants (200 runs). Add rung-1 / rung-2 / rung-3 measurements **only if** prior rung misses DoD — don't pre-measure all 4 unconditionally; CI minutes budget is finite (~$0 self-billed but humanly observable).
+
+## 11. References
+
+- T5.1 sibling spike: `packages/obsidian-plugin/docs/phase3/T5_1_XVFB_TUNING_SPIKE.md` (commit `29639769`) — Investigation A baseline; recommends V1+V2 cumulative
+- T5.2 sibling spike: `packages/obsidian-plugin/docs/phase3/T5_2_XVFB_RUN_SPIKE.md` (commit `798ea235`) — Investigation B fallback; per-spec isolation contingency
+- xpra project: https://github.com/Xpra-org/xpra (session multiplexing X server, headless mode)
+- Weston headless backend: https://wayland.pages.freedesktop.org/weston/toc/running.html#headless-backend
+- Electron Ozone Wayland: https://www.electronjs.org/docs/latest/tutorial/wayland-support
+- Playwright Wayland tracking: microsoft/playwright#20217 (no commit date, on roadmap)
+- Playwright Electron-headless precedent: microsoft/playwright#10384 — Electron + `--headless` boot pattern (BrowserWindow constructor still requires `$DISPLAY`)
+- Failed CI run sample: `gh run view 25181815934 --repo kitelev/exocortex` — daily-note-tasks shard 6 process termination 2026-04-30T18:17Z (RFC §Проблема Cat I evidence)
+- Current Dockerfile.ci: `packages/obsidian-plugin/Dockerfile.ci:14-35` (xvfb + libX* runtime deps)
+- Current entrypoint: `packages/obsidian-plugin/docker-entrypoint-e2e.sh:24` (xvfb-run --auto-servernum)


### PR DESCRIPTION
## Summary

Phase 3.5 T5.5 — primary X11 stabilization implementation (RFC `32a64ed9-9a74-4e0c-bb26-e455605aa384`, Issue #2974).

Parametrize `packages/obsidian-plugin/docker-entrypoint-e2e.sh` via `XVFB_VARIANT` env var, defaulting to **`v1+v2` cumulative** per ADR §2 — closing Category I (X11 `Shm::PutImageRequest`) flake at protocol layer:

- `-extension MIT-SHM` (T5.1 V1) — disables X11 shared-memory extension; eliminates SHM allocator contention by construction.
- `-screen 0 1280x720x24 -dpi 96` (T5.1 V2) — matches Playwright viewport; reduces framebuffer 3.93MB → 2.76MB; pins layout deterministic.
- `-nolisten tcp` — preserves security default.

Variants registered:

| Variant | State | Use |
|---|---|---|
| `v1+v2` | active (default) | primary mitigation |
| `baseline` | active | status-quo rollback (env-flip, no code change) |
| `per-spec` / `xpra` / `weston` | stub (`exit 2`) | fallback rungs 1/2/3 — activated by escalation task only if T6.1 N=50 misses DoD |

## Evidence trail

This PR bundles 5 commits (4 evidence + 1 implementation):

- T5.1 spike — Xvfb tuning Investigation A
- T5.2 spike — `xvfb-run` per-test isolation Investigation B
- T5.3 spike — headed Chromium / virtual display Investigation C
- T5.4 ADR — flaky X11 stabilization strategy
- **T5.5 chore(e2e)** — XVFB_VARIANT harness + v1+v2 default + rollback doc

## Test plan

- [ ] CI green on all 13 required checks (`archgate`, `detect-changes`, `e2e-shard 1..6`, `lint`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`).
- [ ] e2e shards 1..6 launch with banner `XVFB_VARIANT: v1+v2` + `Launching with xvfb-run (v1+v2: -extension MIT-SHM + lean 720p)...` in stderr (verify in run logs).
- [ ] No `X11 Shm::PutImageRequest` substring in shard stderr after merge (baseline measurement for Phase 3.6 / T6.1 N=50).

## Rollback

One-line env-flip in `.github/workflows/e2e.yml` job env:

```yaml
env:
  XVFB_VARIANT: baseline
```

See `packages/obsidian-plugin/docs/phase3/ROLLBACK_X11_STABILIZATION.md`.

## Refs

- RFC: `/Users/kitelev/vault-2025/03 Knowledge/inbox/32a64ed9-9a74-4e0c-bb26-e455605aa384.md` Phase 3.5
- ADR: `packages/obsidian-plugin/docs/phase3/ADR_FLAKY_X11_STRATEGY.md`
- Issue: kitelev/exocortex#2974
- Charter: `/Users/kitelev/vault-2025/03 Knowledge/inbox/4cd6f7bd-73e4-47f3-b0f2-c1f2438ed619.md` §4
