### PR TITLE
feat(plugin): make sparql/exoql code-block auto-execute opt-in (#2992)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -109,7 +109,8 @@ export default class ExocortexPlugin extends Plugin {
   preconditionEvaluator!: PreconditionEvaluator;
   groundingExecutor!: GroundingExecutor;
   serviceRegistry!: ServiceRegistry;
-  private relationColumnSetRepository: RelationColumnSetRepository | null = null;
+  private relationColumnSetRepository: RelationColumnSetRepository | null =
+    null;
   private relationColumnSetResolver: RelationColumnSetResolver | null = null;
   private exoLayoutRepository: ExoLayoutRepository | null = null;
   private layoutSelector: LayoutSelector | null = null;
@@ -188,14 +189,10 @@ export default class ExocortexPlugin extends Plugin {
         ),
       );
       this.registerEvent(
-        this.app.vault.on("delete", () =>
-          queryBodyResolver.invalidateCache(),
-        ),
+        this.app.vault.on("delete", () => queryBodyResolver.invalidateCache()),
       );
       this.registerEvent(
-        this.app.vault.on("rename", () =>
-          queryBodyResolver.invalidateCache(),
-        ),
+        this.app.vault.on("rename", () => queryBodyResolver.invalidateCache()),
       );
       this.serviceRegistry = new ServiceRegistry();
       const obsidianFs = new ObsidianFileSystemAdapter(this.app.vault);
@@ -416,13 +413,11 @@ export default class ExocortexPlugin extends Plugin {
       this.themeResolver = new ThemeResolver({
         layoutProvider: (classRef) => {
           const files = this.app.vault.getMarkdownFiles();
-          let bestSlots:
-            | {
-                accentColor?: string;
-                icon?: string;
-                labelTypography?: import("@plugin/domain/layout").LabelTypography;
-              }
-            | null = null;
+          let bestSlots: {
+            accentColor?: string;
+            icon?: string;
+            labelTypography?: import("@plugin/domain/layout").LabelTypography;
+          } | null = null;
           let bestPriority = Number.POSITIVE_INFINITY;
           for (const file of files) {
             const fm = this.app.metadataCache.getFileCache(file)
@@ -561,12 +556,36 @@ export default class ExocortexPlugin extends Plugin {
 
       this.addSettingTab(new ExocortexSettingTab(this.app, this));
 
+      // Issue #2992: gate auto-execution behind opt-in setting. When
+      // `enableSparqlAutoExecute` is `false` (default), render the code block
+      // as plain `<pre><code>` so users can paste SPARQL snippets for
+      // documentation/reference without triggering query execution on every
+      // render. The setting is read at render time, so flipping the toggle
+      // takes effect on next render without a plugin reload.
+      const renderSparqlBlock = (
+        source: string,
+        el: HTMLElement,
+        ctx: Parameters<
+          Parameters<typeof this.registerMarkdownCodeBlockProcessor>[1]
+        >[2],
+        language: "sparql" | "exoql",
+      ): void | Promise<void> => {
+        if (this.settings.enableSparqlAutoExecute) {
+          return this.sparqlProcessor.process(source, el, ctx);
+        }
+        const pre = el.createEl("pre");
+        pre.addClass(`language-${language}`);
+        const code = pre.createEl("code");
+        code.addClass(`language-${language}`);
+        code.setText(source);
+      };
+
       this.registerMarkdownCodeBlockProcessor("sparql", (source, el, ctx) =>
-        this.sparqlProcessor.process(source, el, ctx),
+        renderSparqlBlock(source, el, ctx, "sparql"),
       );
 
       this.registerMarkdownCodeBlockProcessor("exoql", (source, el, ctx) =>
-        this.sparqlProcessor.process(source, el, ctx),
+        renderSparqlBlock(source, el, ctx, "exoql"),
       );
 
       this.registerMarkdownCodeBlockProcessor("exo-layout", (source, el, ctx) =>

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -116,6 +116,14 @@ export interface ExocortexSettings {
    * `FileExplorerLabelPatch`). Set to `false` to opt out.
    */
   showIconsInFileExplorer: boolean;
+  /**
+   * When `true`, ` ```sparql ` and ` ```exoql ` markdown code blocks are
+   * executed as queries during note rendering (legacy behaviour). When
+   * `false` (default), those code blocks render as plain code so users can
+   * paste SPARQL snippets for documentation/reference without side effects.
+   * Issue #2992.
+   */
+  enableSparqlAutoExecute: boolean;
   [key: string]: unknown;
 }
 
@@ -139,4 +147,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   enableRelationColumnSetResolver: true,
   enableExoLayoutRenderer: true,
   showIconsInFileExplorer: true,
+  enableSparqlAutoExecute: false,
 };

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
-import type ExocortexPlugin from '@plugin/ExocortexPlugin';
+import type ExocortexPlugin from "@plugin/ExocortexPlugin";
 import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
 import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
 import {
@@ -54,7 +54,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
       .setName("Auto-adjust planned end time")
       .setDesc(
         "Automatically shift plannedEndTimestamp when plannedStartTimestamp changes. " +
-        "Disable if using Obsidian Sync to prevent duplicate shifts.",
+          "Disable if using Obsidian Sync to prevent duplicate shifts.",
       )
       .addToggle((toggle) =>
         toggle
@@ -67,9 +67,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Show labels in tab titles")
-      .setDesc(
-        "Display asset labels instead of filenames in tab headers",
-      )
+      .setDesc("Display asset labels instead of filenames in tab headers")
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.showLabelsInTabTitles)
@@ -99,7 +97,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
       .setName("Enable custom layouts")
       .setDesc(
         "Render class-specific layouts defined via exo__Layout assets. " +
-        "When disabled, the plugin falls back to the default Asset Relations section.",
+          "When disabled, the plugin falls back to the default Asset Relations section.",
       )
       .addToggle((toggle) =>
         toggle
@@ -115,8 +113,8 @@ export class ExocortexSettingTab extends PluginSettingTab {
       .setName("Show class icons in file explorer")
       .setDesc(
         "Render Lucide icons next to file explorer rows for notes whose " +
-        "exo__Instance_class resolves to an exo__Layout_icon. " +
-        "Skips rows already iconized by the Iconize community plugin.",
+          "exo__Instance_class resolves to an exo__Layout_icon. " +
+          "Skips rows already iconized by the Iconize community plugin.",
       )
       .addToggle((toggle) =>
         toggle
@@ -125,6 +123,24 @@ export class ExocortexSettingTab extends PluginSettingTab {
             this.plugin.settings.showIconsInFileExplorer = value;
             await this.plugin.saveSettings();
             this.plugin.toggleFileExplorerIcons(value);
+          }),
+      );
+
+    new Setting(containerEl)
+      // eslint-disable-next-line obsidianmd/ui/sentence-case -- "SPARQL" is an established acronym
+      .setName("Auto-execute SPARQL code blocks")
+      .setDesc(
+        "When enabled, sparql and exoql code blocks are executed as queries " +
+          "during note rendering. When disabled (default), those code blocks " +
+          "render as plain code so SPARQL snippets can be pasted for " +
+          "documentation or reference without side effects. Issue #2992.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableSparqlAutoExecute)
+          .onChange(async (value) => {
+            this.plugin.settings.enableSparqlAutoExecute = value;
+            await this.plugin.saveSettings();
           }),
       );
 
@@ -176,7 +192,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
       .setName("Show labels in live preview")
       .setDesc(
         "Display asset labels instead of UUIDs for wikilinks in live preview mode (edit mode). " +
-        "When enabled, [[uuid]] will show as 'Asset Label' while editing.",
+          "When enabled, [[uuid]] will show as 'Asset Label' while editing.",
       )
       .addToggle((toggle) =>
         toggle
@@ -192,13 +208,13 @@ export class ExocortexSettingTab extends PluginSettingTab {
     this.renderLogChannelsSection(containerEl);
 
     // Display Name Template section
-    new Setting(containerEl)
-      .setName("Display name templates")
-      .setHeading();
+    new Setting(containerEl).setName("Display name templates").setHeading();
 
     // Ensure displayNameSettings is initialized
     if (!this.plugin.settings.displayNameSettings) {
-      this.plugin.settings.displayNameSettings = { ...DEFAULT_DISPLAY_NAME_SETTINGS };
+      this.plugin.settings.displayNameSettings = {
+        ...DEFAULT_DISPLAY_NAME_SETTINGS,
+      };
     }
 
     const displayNameSettings = this.plugin.settings.displayNameSettings;
@@ -227,13 +243,15 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     // Per-class templates section
-    new Setting(containerEl)
-      .setName("Per-class templates")
-      .setHeading();
+    new Setting(containerEl).setName("Per-class templates").setHeading();
 
-    const classTemplatesDesc = containerEl.createDiv({ cls: "setting-item-description" });
+    const classTemplatesDesc = containerEl.createDiv({
+      cls: "setting-item-description",
+    });
     const classTemplatesP = classTemplatesDesc.createEl("p");
-    classTemplatesP.appendText("Configure different display name templates for each asset class.");
+    classTemplatesP.appendText(
+      "Configure different display name templates for each asset class.",
+    );
 
     // Common classes to configure
     const commonClasses = [
@@ -272,14 +290,14 @@ export class ExocortexSettingTab extends PluginSettingTab {
       .setName("Reset to defaults")
       .setDesc("Reset all display name templates to default values")
       .addButton((button) =>
-        button
-          .setButtonText("Reset")
-          .onClick(async () => {
-            this.plugin.settings.displayNameSettings = { ...DEFAULT_DISPLAY_NAME_SETTINGS };
-            await this.plugin.saveSettings();
-            this.plugin.applyDisplayNameTemplate();
-            this.display(); // Refresh UI
-          }),
+        button.setButtonText("Reset").onClick(async () => {
+          this.plugin.settings.displayNameSettings = {
+            ...DEFAULT_DISPLAY_NAME_SETTINGS,
+          };
+          await this.plugin.saveSettings();
+          this.plugin.applyDisplayNameTemplate();
+          this.display(); // Refresh UI
+        }),
       );
 
     // Template syntax help
@@ -287,10 +305,15 @@ export class ExocortexSettingTab extends PluginSettingTab {
       cls: "setting-item-description",
     });
     helpEl.createEl("strong", { text: "Available placeholders:" });
-    const placeholderList = helpEl.createEl("ul", { cls: "exocortex-placeholder-list" });
+    const placeholderList = helpEl.createEl("ul", {
+      cls: "exocortex-placeholder-list",
+    });
     const placeholders = [
       { code: "{{exo__Asset_label}}", desc: "Asset label" },
-      { code: "{{exo__Instance_class}}", desc: "Asset class (Task, Project, etc.)" },
+      {
+        code: "{{exo__Instance_class}}",
+        desc: "Asset class (Task, Project, etc.)",
+      },
       { code: "{{ems__Effort_status}}", desc: "Current effort status" },
       { code: "{{_basename}}", desc: "Original filename" },
       { code: "{{_created}}", desc: "File creation date" },
@@ -308,14 +331,12 @@ export class ExocortexSettingTab extends PluginSettingTab {
    * Rows = log levels, columns = channels (Notice / Console / File).
    */
   private renderLogChannelsSection(containerEl: HTMLElement): void {
-    new Setting(containerEl)
-      .setName("Log channels")
-      .setHeading();
+    new Setting(containerEl).setName("Log channels").setHeading();
 
     const desc = containerEl.createDiv({ cls: "setting-item-description" });
     desc.appendText(
       "Choose which channels each log level should be routed to. " +
-      "File channel writes to exocortex-logs.txt in the vault root.",
+        "File channel writes to exocortex-logs.txt in the vault root.",
     );
 
     // Ensure logChannels exists
@@ -356,22 +377,35 @@ export class ExocortexSettingTab extends PluginSettingTab {
   /**
    * Update the per-class template preview
    */
-  private updatePerClassPreview(previewEl: HTMLElement, settings: DisplayNameSettings): void {
+  private updatePerClassPreview(
+    previewEl: HTMLElement,
+    settings: DisplayNameSettings,
+  ): void {
     const resolver = new DisplayNameResolver(settings);
 
     const sampleAssets = [
       {
-        metadata: { exo__Asset_label: "Fix bug", exo__Instance_class: ["[[ems__Task]]"], ems__Effort_status: "DOING" },
+        metadata: {
+          exo__Asset_label: "Fix bug",
+          exo__Instance_class: ["[[ems__Task]]"],
+          ems__Effort_status: "DOING",
+        },
         basename: "fix-bug-123",
         name: "Task",
       },
       {
-        metadata: { exo__Asset_label: "Morning routine", exo__Instance_class: ["[[ems__TaskPrototype]]"] },
+        metadata: {
+          exo__Asset_label: "Morning routine",
+          exo__Instance_class: ["[[ems__TaskPrototype]]"],
+        },
         basename: "morning-routine",
         name: "TaskPrototype",
       },
       {
-        metadata: { exo__Asset_label: "Alpha Project", exo__Instance_class: ["[[ems__Project]]"] },
+        metadata: {
+          exo__Asset_label: "Alpha Project",
+          exo__Instance_class: ["[[ems__Project]]"],
+        },
         basename: "alpha-project",
         name: "Project",
       },
@@ -381,10 +415,16 @@ export class ExocortexSettingTab extends PluginSettingTab {
     previewEl.empty();
 
     previewEl.createEl("strong", { text: "Preview:" });
-    const previewList = previewEl.createEl("ul", { cls: "exocortex-preview-list" });
+    const previewList = previewEl.createEl("ul", {
+      cls: "exocortex-preview-list",
+    });
 
     for (const { metadata, basename, name } of sampleAssets) {
-      const displayName = resolver.resolve({ metadata, basename, createdDate: new Date() });
+      const displayName = resolver.resolve({
+        metadata,
+        basename,
+        createdDate: new Date(),
+      });
       const li = previewList.createEl("li");
       li.createEl("strong", { text: `${name}: ` });
       li.appendText(displayName || "(empty)");

--- a/packages/obsidian-plugin/tests/e2e/specs/vault-commands-smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/vault-commands-smoke.spec.ts
@@ -265,6 +265,18 @@ test.describe("Vault Commands Smoke Tests", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
+    // Issue #2992: SPARQL auto-execute is opt-in (default off). Enable it
+    // for this test so the legacy SPARQLCodeBlockProcessor path runs.
+    await window.evaluate(async () => {
+      const app = (window as any).app;
+      const plugin = app.plugins?.plugins?.exocortex;
+      if (plugin) {
+        plugin.settings.enableSparqlAutoExecute = true;
+        await plugin.saveSettings?.();
+      }
+    });
+    // Re-open so the markdown post-processor re-runs with the new setting.
+    await launcher.openFile("exoql-test-page.md");
     await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     // ExoQL code blocks are processed by SPARQLCodeBlockProcessor and MUST

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -1171,7 +1171,7 @@ describe("ExocortexPlugin", () => {
       // Wait for 150ms setTimeout in handler
       await waitForCondition(
         () => mockWorkspace.getActiveViewOfType.mock.calls.length > 0,
-        { timeout: 500, message: "getActiveViewOfType not called" }
+        { timeout: 2000, message: "getActiveViewOfType not called" }
       );
 
       // Assert
@@ -1194,7 +1194,7 @@ describe("ExocortexPlugin", () => {
       // Wait for 150ms setTimeout in handler
       await waitForCondition(
         () => mockWorkspace.getActiveViewOfType.mock.calls.length > 0,
-        { timeout: 500, message: "getActiveViewOfType not called" }
+        { timeout: 2000, message: "getActiveViewOfType not called" }
       );
 
       // Assert
@@ -1217,7 +1217,7 @@ describe("ExocortexPlugin", () => {
       // Wait for 150ms setTimeout in handler
       await waitForCondition(
         () => mockWorkspace.getActiveViewOfType.mock.calls.length > 0,
-        { timeout: 500, message: "getActiveViewOfType not called" }
+        { timeout: 2000, message: "getActiveViewOfType not called" }
       );
 
       // Assert
@@ -1226,11 +1226,13 @@ describe("ExocortexPlugin", () => {
   });
 
   describe("SPARQL processor integration", () => {
-    it("should register SPARQL code block processor", async () => {
+    it("should register SPARQL code block processor (delegates to processor when toggle on)", async () => {
       // Arrange
       await plugin.onload();
+      // Issue #2992: auto-execute is opt-in (default off). Enable for legacy delegation test.
+      plugin.settings.enableSparqlAutoExecute = true;
 
-      // Assert
+      // Assert registration happened
       expect(plugin.registerMarkdownCodeBlockProcessor).toHaveBeenCalledWith(
         "sparql",
         expect.any(Function)
@@ -1252,9 +1254,10 @@ describe("ExocortexPlugin", () => {
       expect(mockSparqlProcessor.process).toHaveBeenCalledWith(source, el, ctx);
     });
 
-    it("should register exoql code block processor as alias for SPARQL", async () => {
+    it("should register exoql code block processor as alias for SPARQL (delegates when toggle on)", async () => {
       // Arrange
       await plugin.onload();
+      plugin.settings.enableSparqlAutoExecute = true;
 
       // Assert
       expect(plugin.registerMarkdownCodeBlockProcessor).toHaveBeenCalledWith(
@@ -1278,6 +1281,32 @@ describe("ExocortexPlugin", () => {
 
       // Assert
       expect(mockSparqlProcessor.process).toHaveBeenCalledWith(source, el, ctx);
+    });
+
+    it("Issue #2992: when toggle is off (default), does NOT execute SPARQL — renders plain code", async () => {
+      // Arrange
+      await plugin.onload();
+      // Default is false; assert explicitly for clarity
+      expect(plugin.settings.enableSparqlAutoExecute).toBe(false);
+
+      const calls = (plugin.registerMarkdownCodeBlockProcessor as jest.Mock).mock.calls;
+      const sparqlCall = calls.find((c: any[]) => c[0] === "sparql");
+      const processorFn = sparqlCall![1];
+
+      const source = "ASK { ?s ?p ?o }";
+      const el = document.createElement("div");
+      const ctx = {} as any;
+
+      // Act
+      processorFn(source, el, ctx);
+
+      // Assert — processor not invoked, plain <pre><code> appended
+      expect(mockSparqlProcessor.process).not.toHaveBeenCalled();
+      const pre = el.querySelector("pre.language-sparql");
+      expect(pre).not.toBeNull();
+      const code = pre!.querySelector("code.language-sparql");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe(source);
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -127,9 +127,9 @@ describe("ExocortexSettingTab", () => {
       settingTab.display();
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
-      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 26
+      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 27
       // Log channels section: 1 heading + 4 log level rows = 5
-      expect(MockSetting).toHaveBeenCalledTimes(26);
+      expect(MockSetting).toHaveBeenCalledTimes(27);
     });
 
     it("should render layout visibility toggle as first setting", () => {

--- a/packages/obsidian-plugin/tests/unit/SparqlAutoExecuteSetting.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SparqlAutoExecuteSetting.test.ts
@@ -1,0 +1,123 @@
+import { DEFAULT_SETTINGS } from "../../src/domain/settings/ExocortexSettings";
+
+describe("enableSparqlAutoExecute setting (Issue #2992)", () => {
+  it("defaults to false (opt-in auto-execute)", () => {
+    expect(DEFAULT_SETTINGS.enableSparqlAutoExecute).toBe(false);
+  });
+
+  it("is a boolean field", () => {
+    expect(typeof DEFAULT_SETTINGS.enableSparqlAutoExecute).toBe("boolean");
+  });
+});
+
+describe("SPARQL code block gating logic (Issue #2992)", () => {
+  // The actual processor registration lives in ExocortexPlugin.ts and is
+  // exercised end-to-end via E2E. Here we verify the gating predicate
+  // semantics in isolation: when the setting is true the legacy processor
+  // path runs; when false a plain <pre><code> is appended to the host
+  // element with the source verbatim (no SPARQL execution).
+  type FakeEl = {
+    children: FakeEl[];
+    classes: string[];
+    text: string;
+    tag: string;
+    addClass: (c: string) => void;
+    setText: (t: string) => void;
+    createEl: (tag: string) => FakeEl;
+  };
+  const makeEl = (tag = "div"): FakeEl => {
+    const el: FakeEl = {
+      children: [],
+      classes: [],
+      text: "",
+      tag,
+      addClass(c: string) {
+        this.classes.push(c);
+      },
+      setText(t: string) {
+        this.text = t;
+      },
+      createEl(t: string) {
+        const child = makeEl(t);
+        this.children.push(child);
+        return child;
+      },
+    };
+    return el;
+  };
+
+  // Replicates the inline `renderSparqlBlock` logic in ExocortexPlugin.ts.
+  function renderSparqlBlock(
+    enabled: boolean,
+    source: string,
+    el: FakeEl,
+    language: "sparql" | "exoql",
+    process: (s: string, e: FakeEl) => string,
+  ): string {
+    if (enabled) {
+      return process(source, el);
+    }
+    const pre = el.createEl("pre");
+    pre.addClass(`language-${language}`);
+    const code = pre.createEl("code");
+    code.addClass(`language-${language}`);
+    code.setText(source);
+    return "plain";
+  }
+
+  it("when disabled (default), renders <pre><code> with the source verbatim", () => {
+    const el = makeEl();
+    const processSpy = jest.fn(() => "executed");
+    const result = renderSparqlBlock(
+      false,
+      "ASK { ?s ?p ?o }",
+      el,
+      "sparql",
+      processSpy,
+    );
+    expect(result).toBe("plain");
+    expect(processSpy).not.toHaveBeenCalled();
+    expect(el.children).toHaveLength(1);
+    const pre = el.children[0]!;
+    expect(pre.tag).toBe("pre");
+    expect(pre.classes).toContain("language-sparql");
+    expect(pre.children).toHaveLength(1);
+    const code = pre.children[0]!;
+    expect(code.tag).toBe("code");
+    expect(code.classes).toContain("language-sparql");
+    expect(code.text).toBe("ASK { ?s ?p ?o }");
+  });
+
+  it("when disabled, exoql blocks also render plain with language-exoql class", () => {
+    const el = makeEl();
+    const processSpy = jest.fn(() => "executed");
+    renderSparqlBlock(
+      false,
+      "SELECT ?x WHERE { ?x ?p ?o }",
+      el,
+      "exoql",
+      processSpy,
+    );
+    expect(processSpy).not.toHaveBeenCalled();
+    const pre = el.children[0]!;
+    expect(pre.classes).toContain("language-exoql");
+    const code = pre.children[0]!;
+    expect(code.classes).toContain("language-exoql");
+  });
+
+  it("when enabled, delegates to the SPARQL processor (legacy behaviour)", () => {
+    const el = makeEl();
+    const processSpy = jest.fn(() => "executed");
+    const result = renderSparqlBlock(
+      true,
+      "ASK { ?s ?p ?o }",
+      el,
+      "sparql",
+      processSpy,
+    );
+    expect(result).toBe("executed");
+    expect(processSpy).toHaveBeenCalledWith("ASK { ?s ?p ?o }", el);
+    // No plain <pre> appended when delegated
+    expect(el.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2992. Adds `enableSparqlAutoExecute: boolean` setting (default `false`) that gates auto-execution of `sparql` and `exoql` markdown code blocks. When off (default) blocks render as plain `<pre><code>` — no SPARQL execution, no side effects on render. When on, the existing `SPARQLCodeBlockProcessor.process()` path runs (legacy behaviour).

The setting is read at render time, so flipping the toggle takes effect without a plugin reload.

## Changes

- `packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts` — new field + default `false`.
- `packages/obsidian-plugin/src/ExocortexPlugin.ts` — gate registered processors on the setting; when off, append plain `<pre class="language-{lang}"><code class="language-{lang}">{source}</code></pre>`.
- `packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts` — toggle UI.
- `packages/obsidian-plugin/tests/unit/SparqlAutoExecuteSetting.test.ts` — new (default value + gating logic, both branches).
- `packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts` — adapt SPARQL processor tests; add explicit default-off behaviour test.
- `packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts` — bump expected `Setting` count 26 → 27.
- Drive-by: bump three pre-existing `waitForCondition` timeouts (file-open / active-leaf-change / layout-change handlers) from 500ms → 2000ms; they intermittently flaked under jest's parallel load.

## Acceptance Criteria

- [x] Default `enableSparqlAutoExecute === false` on fresh install.
- [x] When off, ` ```sparql … ``` ` renders as plain code (no `SPARQLCodeBlockProcessor.process()` call).
- [x] When on, behaviour matches pre-PR (delegates to processor).
- [x] Same applies to `exoql`.
- [x] Toggle visible in settings tab; persists via `saveSettings()`.
- [x] Toggle changes effective on next render (no reload).

## Test Plan

- [x] `npm run check:types`
- [x] `npm run lint` (only pre-existing warnings)
- [x] `npx jest … tests/unit/SparqlAutoExecuteSetting.test.ts` — 5/5 passing
- [x] `npx jest … tests/unit/ExocortexPlugin.test.ts` — 73/73 passing
- [x] `npx jest … tests/unit/ExocortexSettingTab.test.ts` — passing (count updated)
- [ ] Full CI (13 required checks)

## Out of scope

- `exo-layout` processor — unchanged.
- Per-block override syntax (e.g. ` ```sparql:auto`).
- "Run query" button inside plain-rendered block (can be added later).