### PR TITLE
refactor(core): extract vaultPathToIRI helper (T1.1, #2996)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -235,6 +235,7 @@ export {
   type RDFDeserializeOptions,
 } from "./infrastructure/rdf/RDFSerializer";
 export { NullLogger } from "./infrastructure/NullLogger";
+export { vaultPathToIRI, OBSIDIAN_VAULT_SCHEME } from "./infrastructure/vault/iri";
 export { InMemoryTripleStore } from "./infrastructure/rdf/InMemoryTripleStore";
 export { RDFVocabularyMapper } from "./infrastructure/rdf/RDFVocabularyMapper";
 export { RDFSInferenceEngine } from "./infrastructure/rdf/RDFSInferenceEngine";

--- a/packages/exocortex/src/infrastructure/vault/iri.ts
+++ b/packages/exocortex/src/infrastructure/vault/iri.ts
@@ -1,0 +1,8 @@
+export const OBSIDIAN_VAULT_SCHEME = "obsidian://vault/";
+
+export function vaultPathToIRI(relativePath: string): string {
+  const normalized = relativePath.startsWith("./")
+    ? relativePath.slice(2)
+    : relativePath;
+  return `${OBSIDIAN_VAULT_SCHEME}${encodeURI(normalized)}`;
+}

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -9,6 +9,7 @@ import { Namespace } from "../domain/models/rdf/Namespace";
 import { DI_TOKENS } from "../interfaces/tokens";
 import { RDFVocabularyMapper } from "../infrastructure/rdf/RDFVocabularyMapper";
 import { NullLogger } from "../infrastructure/NullLogger";
+import { vaultPathToIRI, OBSIDIAN_VAULT_SCHEME } from "../infrastructure/vault/iri";
 import {
   Exo003Parser,
   Exo003MetadataType,
@@ -29,7 +30,7 @@ import {
  */
 @injectable()
 export class NoteToRDFConverter {
-  private readonly OBSIDIAN_VAULT_SCHEME = "obsidian://vault/";
+  private readonly OBSIDIAN_VAULT_SCHEME = OBSIDIAN_VAULT_SCHEME;
   private readonly vocabularyMapper: RDFVocabularyMapper;
 
   /**
@@ -555,8 +556,7 @@ export class NoteToRDFConverter {
 
     for (const file of files) {
       // Check if the file path can be converted to a valid IRI
-      const encodedPath = encodeURI(file.path);
-      const iriString = `${this.OBSIDIAN_VAULT_SCHEME}${encodedPath}`;
+      const iriString = vaultPathToIRI(file.path);
 
       if (!IRI.isValidIRI(iriString)) {
         issues.push({
@@ -586,12 +586,7 @@ export class NoteToRDFConverter {
    * ```
    */
   notePathToIRI(path: string): IRI {
-    // Use encodeURI to preserve forward slashes (/) while encoding
-    // spaces and other special characters. This fixes query mismatch
-    // issues where exact URI matches fail due to inconsistent encoding.
-    // See: https://github.com/kitelev/exocortex/issues/621
-    const encodedPath = encodeURI(path);
-    return new IRI(`${this.OBSIDIAN_VAULT_SCHEME}${encodedPath}`);
+    return new IRI(vaultPathToIRI(path));
   }
 
   private static readonly NAMESPACE_MAP: ReadonlyArray<[string, Namespace]> = [

--- a/packages/exocortex/tests/unit/infrastructure/vault/iri.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/vault/iri.test.ts
@@ -1,0 +1,72 @@
+import { vaultPathToIRI, OBSIDIAN_VAULT_SCHEME } from "../../../../src/infrastructure/vault/iri";
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../../src/services/NoteToRDFConverter";
+import { NullLogger } from "../../../../src/infrastructure/NullLogger";
+import type { IVaultAdapter } from "../../../../src/interfaces/IVaultAdapter";
+
+describe("vaultPathToIRI", () => {
+  it("uses obsidian://vault/ scheme", () => {
+    expect(OBSIDIAN_VAULT_SCHEME).toBe("obsidian://vault/");
+  });
+
+  it("encodes spaces to %20 (canonical RFC contract)", () => {
+    expect(vaultPathToIRI("03 Knowledge/kitelev/abc.md")).toBe(
+      "obsidian://vault/03%20Knowledge/kitelev/abc.md",
+    );
+  });
+
+  it("preserves forward slashes (not %2F)", () => {
+    const iri = vaultPathToIRI("a/b/c.md");
+    expect(iri).toBe("obsidian://vault/a/b/c.md");
+    expect(iri).not.toContain("%2F");
+  });
+
+  it("encodes unicode (cyrillic) characters", () => {
+    const iri = vaultPathToIRI("Заметки/Файл.md");
+    expect(iri.startsWith("obsidian://vault/")).toBe(true);
+    expect(iri).toBe(`obsidian://vault/${encodeURI("Заметки/Файл.md")}`);
+  });
+
+  it("strips leading ./ prefix", () => {
+    expect(vaultPathToIRI("./03 Knowledge/x.md")).toBe(
+      "obsidian://vault/03%20Knowledge/x.md",
+    );
+  });
+
+  it("handles deeply nested folders", () => {
+    expect(vaultPathToIRI("a/b/c/d/e/f/file.md")).toBe(
+      "obsidian://vault/a/b/c/d/e/f/file.md",
+    );
+  });
+
+  it("encodes special chars (#, ?, etc.) like encodeURI", () => {
+    expect(vaultPathToIRI("Tasks/Review PR #123.md")).toBe(
+      `obsidian://vault/${encodeURI("Tasks/Review PR #123.md")}`,
+    );
+  });
+
+  it("is idempotent on repeated invocations", () => {
+    const path = "01 Areas/02 Projects/My Project.md";
+    expect(vaultPathToIRI(path)).toBe(vaultPathToIRI(path));
+  });
+});
+
+describe("vaultPathToIRI ↔ NoteToRDFConverter.notePathToIRI round-trip", () => {
+  const fakeVault = {} as IVaultAdapter;
+  const converter = new NoteToRDFConverter(fakeVault, NullLogger);
+  const samplePaths = [
+    "simple.md",
+    "03 Knowledge/kitelev/f2dccb6a-802d-48d3-8e8a-2c4264197692.md",
+    "Tasks/Review PR #123.md",
+    "01 Areas/02 Projects/My Project.md",
+    "Заметки/Мой файл.md",
+    "Notes/My (Important) Note [v2].md",
+    "a/b/c/d/e/f/deep.md",
+    "01 Inbox/GetAreaChain (exo__Query<ems__Area>).md",
+    "Generic<Types>/SpecificType.md",
+  ];
+
+  it.each(samplePaths)("matches notePathToIRI for path: %s", (path) => {
+    expect(vaultPathToIRI(path)).toBe(converter.notePathToIRI(path).value);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the canonical vault-path → `obsidian://` IRI logic from `NoteToRDFConverter` into a shared helper `vaultPathToIRI` exported from `@exocortex/core`. Pre-requisite for T1.2 — the `/dyncommand exec $target` binding fix (which needs the same canonicalisation without depending on `NoteToRDFConverter`).

- New module: `packages/exocortex/src/infrastructure/vault/iri.ts`
- `NoteToRDFConverter.notePathToIRI` and `validateVault` delegate to the helper — bit-identical output preserved
- Helper additionally normalises a leading `./` prefix (canonical contract)

## Test plan

- [x] New unit tests `tests/unit/infrastructure/vault/iri.test.ts` — 17 cases (scheme, encoding, idempotency, `./` stripping, deeply nested, round-trip property test against `NoteToRDFConverter.notePathToIRI`)
- [x] No regression in pre-existing `NoteToRDFConverter` tests (3 unrelated failures pre-exist on main)
- [x] Typecheck (`tsc --noEmit`) clean
- [ ] CI green (13 required checks)

Refs #2996