### PR TITLE
feat(grounding): interpolate $target in service_call JSON defaults (#2999)

### DIFF
--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -96,7 +96,13 @@ const MAX_COMPOSITE_DEPTH = 20;
  * - `$today` → current date (YYYY-MM-DD)
  * - `$target` → IRI of the target asset
  *
- * Issue #2430
+ * Substitution applies to `property_set` raw values and to `service_call`
+ * JSON `targetValue` defaults (Issue #2999 / RFC 5a61a359 Phase C.0). For
+ * service_call the substitution is performed before `JSON.parse`, so any
+ * string position inside the JSON object can reference a token, e.g.
+ * `{"prototype":"$target"}` resolves to `{prototype: <targetIRI>}`.
+ *
+ * Issue #2430, #2999
  */
 @injectable()
 export class GroundingExecutor {
@@ -383,11 +389,30 @@ export class GroundingExecutor {
       };
     }
 
-    // Merge grounding.targetValue (JSON) as defaults into userInput
+    // Merge grounding.targetValue (JSON) as defaults into userInput.
+    //
+    // Issue #2999 (RFC 5a61a359 Phase C.0): apply substituteVariables BEFORE
+    // JSON.parse so vault groundings can reference $target / $now / $today /
+    // $nowLocal / $input / $value inside JSON string values. This unlocks the
+    // create-instance-from-prototype pattern: a Grounding with
+    //   targetValue: '{"prototype":"$target"}'
+    // resolves $target to the current asset IRI, which `createAsset` then
+    // writes as exo__Asset_prototype on the new instance. Substitution is
+    // identical to the property_set path (substituteVariables already escapes
+    // nothing — JSON safety relies on caller-supplied IRIs being safe; UUID
+    // and URL IRIs in the vault contain no `"` or `\\`). Backwards compatible:
+    // groundings without `$<token>` substrings are unchanged by the regex
+    // pass, so existing literal-JSON targetValues (e.g. updateProperty +
+    // {"property":"ems__Effort_parent"}) continue to parse identically.
     let mergedInput = userInput;
     if (grounding.targetValue) {
       try {
-        const defaults = JSON.parse(grounding.targetValue);
+        const substituted = this.substituteVariables(
+          grounding.targetValue,
+          targetIRI,
+          userInput,
+        );
+        const defaults = JSON.parse(substituted);
         if (typeof defaults === "object" && defaults !== null) {
           mergedInput = { ...defaults, ...(userInput ?? {}) };
         }

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -444,6 +444,87 @@ describe("GroundingExecutor", () => {
       expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, userInput);
     });
 
+    // Issue #2999 / RFC 5a61a359 Phase C.0 (AC1): create-instance-from-prototype.
+    // Grounding `service_call → createAsset` with targetValue carrying `$target`
+    // must resolve to the current target IRI before JSON.parse, so the underlying
+    // service receives `{prototype: <targetIRI>}` as a default and writes
+    // `exo__Asset_prototype: "[[<source-IRI>]]"` on the new instance.
+    it("should interpolate $target in JSON targetValue and merge as default (#2999)", async () => {
+      const mockService = {
+        execute: jest.fn().mockResolvedValue(undefined),
+      };
+      registry.register("createAsset", mockService);
+
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "createAsset",
+        targetValue: '{"prototype":"$target"}',
+      });
+
+      const userInput = { label: "New Instance" };
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        userInput,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
+        prototype: TARGET_IRI,
+        label: "New Instance",
+      });
+    });
+
+    it("should let userInput override $target-interpolated default (#2999)", async () => {
+      const mockService = {
+        execute: jest.fn().mockResolvedValue(undefined),
+      };
+      registry.register("createAsset", mockService);
+
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "createAsset",
+        targetValue: '{"prototype":"$target","folder":"03 Knowledge/inbox"}',
+      });
+
+      const userInput = { prototype: "explicit-prototype-uid", label: "Lunch 2026-05-02" };
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        userInput,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
+        prototype: "explicit-prototype-uid",
+        folder: "03 Knowledge/inbox",
+        label: "Lunch 2026-05-02",
+      });
+    });
+
+    it("should interpolate $today in JSON targetValue defaults (#2999)", async () => {
+      const mockService = {
+        execute: jest.fn().mockResolvedValue(undefined),
+      };
+      registry.register("scheduleTask", mockService);
+
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "scheduleTask",
+        targetValue: '{"plannedStartDate":"$today"}',
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const today = new Date().toISOString().slice(0, 10);
+      expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
+        plannedStartDate: today,
+      });
+    });
+
     it("should use targetValue as sole input when no userInput", async () => {
       const mockService = {
         execute: jest.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

Closes #2999. RFC `5a61a359` Phase C.0 TS prerequisite for the v15.38.0 UI Parity Restoration Phase C.1 (Create-Instance-from-prototype button).

`GroundingExecutor.executeServiceCall` already merged JSON `targetValue` as defaults into `userInput`, but parsed the raw string — `$target` and the other interpolation tokens never resolved on the `service_call` path. The vault grounding `service_call → createAsset` therefore could not write `exo__Asset_prototype` derived from the click target.

This PR applies `substituteVariables` before `JSON.parse`, mirroring `property_set` semantics. Any string position in the JSON object can now reference `$target / $now / $nowLocal / $today / $input / $value`.

### AC1 (BDD) — covered by new unit tests
**Given** a Grounding with `targetValue: '{"prototype":"$target"}'` and target IRI `[[<source>]]`
**When** `GroundingExecutor` executes the grounding
**Then** the registered `createAsset` service is invoked with `{prototype: <source-IRI>, ...userInput}` and writes `exo__Asset_prototype: "[[<source>]]"` on the new instance.

### AC2 — backwards compatibility
Substitution is a regex pass; literal-JSON `targetValue` without `$<token>` substrings is byte-identical after substitution. All existing service_call tests (Convert to Task/Project, Link-to-parent non-regression, JSON merge, override, non-JSON ignore) pass unchanged.

### AC3
Auto-release on merge to `main` will publish a new minor.

## Homoiconicity rationale (Q3.в exception)

Per `homoiconicity-exception` label and RFC `c78cc5c8` Q3.в — interpolation engine is infrastructure / executor primitives, not domain rule. No class lists or button enums introduced in TS. Diff is constrained to `GroundingExecutor.ts` + its test.

## Test plan

- [x] `npx jest --config packages/exocortex/jest.config.js packages/exocortex/tests/unit/services/GroundingExecutor.test.ts` — 74 passed (3 new for #2999)
- [x] Pre-commit `archgate` 13/13 pass, BDD coverage 100%
- [ ] CI: 13 required checks green
- [ ] Auto-release publishes new minor on merge

## References

- Issue: #2999
- RFC: `5a61a359-d76b-4f6c-9bff-624ddcec42b8` (UI Parity Phase 10+, Phase C.0)
- Homoiconicity invariant RFC: `c78cc5c8-076c-4509-9e22-6f0257c51df4`
- Tracking ems__Task: `3b038d97-b4e8-427e-b7c2-86ef495fef06` (C.0.2)