### PR TITLE
test(cli): #2997 Phase 1 — synthetic fixture + skipped reproduction test

### DIFF
--- a/packages/cli/tests/fixtures/issue-2997/README.md
+++ b/packages/cli/tests/fixtures/issue-2997/README.md
@@ -1,0 +1,34 @@
+# Issue #2997 — Synthetic fixture vault
+
+Reproduces the SPARQL algebra crash described in
+https://github.com/kitelev/exocortex/issues/2997
+(`Literals cannot appear in subject position` on
+`FILTER(CONTAINS(STR(?var), …))` queries when the vault contains
+files that fail pre-validation).
+
+Layout:
+
+- `valid-tree/` — three legacy-format files modelling the
+  Project → Phase → Task hierarchy used in the issue's reproduction
+  query. Loaded alone this set must answer the query without throwing
+  (control case).
+- `bad-files/` — 11 files mimicking each shape that produced a
+  loader skip-warning during the original incident:
+
+  | #   | File                                 | Bad shape                                                                |
+  | --- | ------------------------------------ | ------------------------------------------------------------------------ |
+  | 1   | `01-invalid-iri-class.md`            | `exo__Instance_class` wikilink with spaces/parens → `Invalid IRI format` |
+  | 2   | `02-empty-locked-by.md`              | `ems__Effort_lockedBy: ""` → empty literal                               |
+  | 3   | `03-empty-lock-expires.md`           | `ems__Effort_lockExpires: ""` → empty literal                            |
+  | 4   | `04-missing-asset-uid.md`            | no `exo__Asset_uid`                                                      |
+  | 5   | `05-missing-asset-isdefinedby.md`    | no `exo__Asset_isDefinedBy`                                              |
+  | 6   | `06-empty-asset-label.md`            | `exo__Asset_label: ""`                                                   |
+  | 7   | `07-empty-instance-class.md`         | `exo__Instance_class: ""`                                                |
+  | 8   | `08-empty-effort-status.md`          | `ems__Effort_status: ""`                                                 |
+  | 9   | `09-empty-effort-parent.md`          | `ems__Effort_parent: ""`                                                 |
+  | 10  | `10-empty-asset-updatedat.md`        | `exo__Asset_updatedAt: ""`                                               |
+  | 11  | `11-empty-effort-start-timestamp.md` | `ems__Effort_startTimestamp: ""`                                         |
+
+The Project root carries the UUID
+`5b4030aa-f0c1-43dc-996a-896b0a1a6dfb` from the issue, so the same
+`FILTER(CONTAINS(STR(?root), '5b4030aa-…'))` filter binds.

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/01-invalid-iri-class.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/01-invalid-iri-class.md
@@ -1,0 +1,10 @@
+---
+exo__Asset_isDefinedBy: "[[!exo]]"
+exo__Asset_uid: bad00001-0000-0000-0000-000000000001
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[exo__QueryPrototype (exo__Class)]]"
+exo__Asset_label: "Bad — Invalid IRI in Instance_class"
+aliases:
+  - "Bad — Invalid IRI in Instance_class"
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/02-empty-locked-by.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/02-empty-locked-by.md
@@ -1,0 +1,13 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: bad00002-0000-0000-0000-000000000002
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: "Bad — empty Effort_lockedBy"
+aliases:
+  - "Bad — empty Effort_lockedBy"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+ems__Effort_lockedBy: ""
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/03-empty-lock-expires.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/03-empty-lock-expires.md
@@ -1,0 +1,13 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: bad00003-0000-0000-0000-000000000003
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: "Bad — empty Effort_lockExpires"
+aliases:
+  - "Bad — empty Effort_lockExpires"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+ems__Effort_lockExpires: ""
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/04-missing-asset-uid.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/04-missing-asset-uid.md
@@ -1,0 +1,11 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: "Bad — missing Asset_uid"
+aliases:
+  - "Bad — missing Asset_uid"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/05-missing-asset-isdefinedby.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/05-missing-asset-isdefinedby.md
@@ -1,0 +1,11 @@
+---
+exo__Asset_uid: bad00005-0000-0000-0000-000000000005
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: "Bad — missing Asset_isDefinedBy"
+aliases:
+  - "Bad — missing Asset_isDefinedBy"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/06-empty-asset-label.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/06-empty-asset-label.md
@@ -1,0 +1,12 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: bad00006-0000-0000-0000-000000000006
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: ""
+aliases:
+  - "Bad — empty Asset_label"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/07-empty-instance-class.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/07-empty-instance-class.md
@@ -1,0 +1,11 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: bad00007-0000-0000-0000-000000000007
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class: ""
+exo__Asset_label: "Bad — empty Instance_class"
+aliases:
+  - "Bad — empty Instance_class"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/08-empty-effort-status.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/08-empty-effort-status.md
@@ -1,0 +1,12 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: bad00008-0000-0000-0000-000000000008
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: "Bad — empty Effort_status"
+aliases:
+  - "Bad — empty Effort_status"
+ems__Effort_status: ""
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/09-empty-effort-parent.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/09-empty-effort-parent.md
@@ -1,0 +1,12 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: bad00009-0000-0000-0000-000000000009
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: "Bad — empty Effort_parent"
+aliases:
+  - "Bad — empty Effort_parent"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: ""
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/10-empty-asset-updatedat.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/10-empty-asset-updatedat.md
@@ -1,0 +1,13 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: bad00010-0000-0000-0000-000000000010
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Asset_updatedAt: ""
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: "Bad — empty Asset_updatedAt"
+aliases:
+  - "Bad — empty Asset_updatedAt"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+---

--- a/packages/cli/tests/fixtures/issue-2997/bad-files/11-empty-effort-start-timestamp.md
+++ b/packages/cli/tests/fixtures/issue-2997/bad-files/11-empty-effort-start-timestamp.md
@@ -1,0 +1,13 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: bad00011-0000-0000-0000-000000000011
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: "Bad — empty Effort_startTimestamp"
+aliases:
+  - "Bad — empty Effort_startTimestamp"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+ems__Effort_startTimestamp: ""
+---

--- a/packages/cli/tests/fixtures/issue-2997/valid-tree/5b4030aa-f0c1-43dc-996a-896b0a1a6dfb.md
+++ b/packages/cli/tests/fixtures/issue-2997/valid-tree/5b4030aa-f0c1-43dc-996a-896b0a1a6dfb.md
@@ -1,0 +1,12 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: 5b4030aa-f0c1-43dc-996a-896b0a1a6dfb
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Asset_updatedAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Project]]"
+exo__Asset_label: "Repro Project — issue #2997"
+aliases:
+  - "Repro Project — issue #2997"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+---

--- a/packages/cli/tests/fixtures/issue-2997/valid-tree/c2c2c2c2-0000-0000-0000-000000000001.md
+++ b/packages/cli/tests/fixtures/issue-2997/valid-tree/c2c2c2c2-0000-0000-0000-000000000001.md
@@ -1,0 +1,13 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: c2c2c2c2-0000-0000-0000-000000000001
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Asset_updatedAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Project]]"
+exo__Asset_label: "Phase 1 — repro"
+aliases:
+  - "Phase 1 — repro"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[5b4030aa-f0c1-43dc-996a-896b0a1a6dfb|Repro Project]]"
+---

--- a/packages/cli/tests/fixtures/issue-2997/valid-tree/c3c3c3c3-0000-0000-0000-000000000001.md
+++ b/packages/cli/tests/fixtures/issue-2997/valid-tree/c3c3c3c3-0000-0000-0000-000000000001.md
@@ -1,0 +1,13 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: c3c3c3c3-0000-0000-0000-000000000001
+exo__Asset_createdAt: 2026-05-02T00:00:00+0500
+exo__Asset_updatedAt: 2026-05-02T00:00:00+0500
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: "T1 — sample task under phase"
+aliases:
+  - "T1 — sample task under phase"
+ems__Effort_status: "[[ems__EffortStatusDoing]]"
+ems__Effort_parent: "[[c2c2c2c2-0000-0000-0000-000000000001|Phase 1]]"
+---

--- a/packages/cli/tests/integration/issue-2997-repro.integration.test.ts
+++ b/packages/cli/tests/integration/issue-2997-repro.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Reproduction test for issue #2997 — Phase 1 of the fix.
+ *
+ * Issue: `npx @kitelev/exocortex-cli sparql query` crashes with
+ * `Literals cannot appear in subject position` on a SELECT that uses
+ * `FILTER(CONTAINS(STR(?var), …))` after the loader emits 11 skip-warnings
+ * for files that fail pre-validation. The hypothesis (RFC
+ * `0810aad3-90fc-46bb-a103-26ca8172970b`) is that some triples leak into
+ * the store from a side code path even though the file-level validator
+ * marks the asset as skipped, and the algebra/executor pipeline then
+ * encounters a literal where it expects a node.
+ *
+ * Phase 1 deliverables (this file):
+ *  - synthetic fixture vault under `tests/fixtures/issue-2997/`
+ *  - reproduction test (this suite) that loads the fixture and runs the
+ *    issue query, expecting the crash → marked `.skip` until Phases 2/3
+ *    land the loader + translator fixes
+ *  - control test that loads only the well-formed subtree and confirms
+ *    the same query returns the expected row
+ *
+ * Both tests are wrapped with `describe.skip(...)` so they document the
+ * regression without breaking CI. Drop the `.skip` once Phase 2 (loader
+ * all-or-nothing) and Phase 3 (translator literal-safety guard) land —
+ * the suite then becomes the regression gate for #2997.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { resolve } from "path";
+import {
+  ExoQLAlgebraTranslator,
+  ExoQLParser,
+  ExoQLQueryExecutor,
+  InMemoryTripleStore,
+  NoteToRDFConverter,
+  type Triple,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../src/adapters/FileSystemVaultAdapter.js";
+
+const FIXTURE_ROOT = resolve(__dirname, "../fixtures/issue-2997");
+
+const ISSUE_QUERY = `
+PREFIX exo: <https://exocortex.my/ontology/exo#>
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+SELECT DISTINCT ?task ?label ?status ?updated ?phase WHERE {
+  ?task ems:Effort_parent ?phase .
+  ?phase ems:Effort_parent ?root .
+  ?task exo:Instance_class ?cls .
+  ?task exo:Asset_label ?label .
+  OPTIONAL { ?task ems:Effort_status ?status }
+  OPTIONAL { ?task exo:Asset_updatedAt ?updated }
+  FILTER(STRENDS(STR(?cls), '#Task'))
+  FILTER(CONTAINS(STR(?root), '5b4030aa-f0c1-43dc-996a-896b0a1a6dfb'))
+}
+ORDER BY ?phase ?label
+`;
+
+async function loadVault(vaultPath: string): Promise<Triple[]> {
+  const adapter = new FileSystemVaultAdapter(vaultPath);
+  const converter = new NoteToRDFConverter(adapter);
+  return converter.convertVault();
+}
+
+async function runIssueQuery(vaultPath: string): Promise<unknown[]> {
+  const triples = await loadVault(vaultPath);
+  const store = new InMemoryTripleStore();
+  await store.addAll(triples);
+
+  const parser = new ExoQLParser();
+  const ast = parser.parse(ISSUE_QUERY);
+  const translator = new ExoQLAlgebraTranslator();
+  const algebra = translator.translate(ast);
+  const executor = new ExoQLQueryExecutor(store);
+
+  const rows: unknown[] = [];
+  for await (const solution of executor.execute(algebra)) {
+    rows.push(solution);
+  }
+  return rows;
+}
+
+// Suite is `.skip`'d until Phase 2 (loader all-or-nothing) + Phase 3
+// (translator literal-safety guard) land. Drop `.skip` then to convert
+// these into the regression gate for #2997.
+describe.skip("Issue #2997 reproduction (skipped until Phase 2/3 fix)", () => {
+  it("issue query on full fixture vault returns rows without throwing", async () => {
+    // Expected post-fix behaviour: query resolves and returns at least
+    // the row from the well-formed subtree (Project → Phase → Task with
+    // the Project UUID `5b4030aa-…`). Until Phases 2 (loader
+    // all-or-nothing) and 3 (translator literal-safety guard) land, this
+    // assertion is the regression target. The `.skip` is dropped once
+    // the fixes are in.
+    //
+    // Current production failure mode (CLI v15.29.0 against the user's
+    // 129K-triple vault) is:
+    //   ❌ Error: Literals cannot appear in subject position
+    // emitted from the SPARQL executor when a variable that sits in
+    // subject position elsewhere in the BGP gets bound to a literal —
+    // either because the loader leaked partial triples from an asset
+    // that pre-validation marked as skip, or because a property like
+    // `ems__Effort_parent` resolved an unresolvable wikilink to a
+    // Literal (NoteToRDFConverter#valueToRDFObject line 715).
+    const rows = await runIssueQuery(FIXTURE_ROOT);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+  }, 30_000);
+
+  it("control: same query on the well-formed subtree returns the expected row", async () => {
+    const rows = await runIssueQuery(`${FIXTURE_ROOT}/valid-tree`);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+  }, 30_000);
+});

--- a/packages/cli/tests/integration/issue-2997-repro.integration.test.ts
+++ b/packages/cli/tests/integration/issue-2997-repro.integration.test.ts
@@ -24,7 +24,8 @@
  * the suite then becomes the regression gate for #2997.
  */
 import { describe, it, expect } from "@jest/globals";
-import { resolve } from "path";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 import {
   ExoQLAlgebraTranslator,
   ExoQLParser,
@@ -35,6 +36,7 @@ import {
 } from "exocortex";
 import { FileSystemVaultAdapter } from "../../src/adapters/FileSystemVaultAdapter.js";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_ROOT = resolve(__dirname, "../fixtures/issue-2997");
 
 const ISSUE_QUERY = `


### PR DESCRIPTION
## Summary

Phase 1 of RFC `0810aad3-90fc-46bb-a103-26ca8172970b` for issue #2997
(`Literals cannot appear in subject position` SPARQL crash on the
production vault). This PR lays the test scaffolding so Phases 2 (loader
all-or-nothing) and 3 (translator literal-safety guard) have a stable
target to flip from `.skip` to active.

- New synthetic fixture vault under
  `packages/cli/tests/fixtures/issue-2997/`:
  - `valid-tree/` — Project → Phase → Task hierarchy that reuses the
    Project UUID `5b4030aa-…` from the issue. Loaded alone, the issue
    query must answer without throwing (control case).
  - `bad-files/` — 11 files mirroring each shape that produced a loader
    skip-warning during the original incident (1× `Invalid IRI` in
    `Instance_class`, 10× empty literal across `Effort_lockedBy`,
    `lockExpires`, `Asset_uid`, `Asset_isDefinedBy`, `Asset_label`,
    `Instance_class`, `Effort_status`, `Effort_parent`,
    `Asset_updatedAt`, `Effort_startTimestamp`).
- `packages/cli/tests/integration/issue-2997-repro.integration.test.ts`
  — `describe.skip` suite that loads the fixture via
  `FileSystemVaultAdapter` + `NoteToRDFConverter` + ExoQL pipeline and
  runs the exact issue query. Drop the `.skip` once Phase 2/3 land to
  convert the suite into the regression gate for #2997.

The control case (well-formed subtree only) passes today; the full
fixture variant stays skipped until the loader/translator fixes ship.

## Test plan

- [x] `cd packages/cli && npx jest tests/integration/issue-2997-repro.integration.test.ts` →
  `Tests: 2 skipped, 2 total` (suite is skipped per AC).
- [x] Temporary unskip locally confirms the control case resolves with
  the expected row.
- [x] Repo-wide `npx tsc --noEmit --skipLibCheck` passes (no new type
  errors introduced by the test file).

Refs #2997