### PR TITLE
feat(commands): per-binding variant override (RFC f1dc284a Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,19 @@ Rollback procedure: `docs/ROLLBACK_EXOQL_EVAL.md`. T7 (CI drift-guard + scoped E
 - Integration tests for full create_instance pipeline with NoteToRDFConverter validation
 - Obsidian plugin wiring for create_instance grounding with vault-relative path resolution
 
+**Per-binding button variant override (RFC `f1dc284a-eadc-4d0e-8e72-323e999ea510` command-variant-split)**: New `exocmd__CommandBinding_variant` property lets each binding override the button colour independently of its category. Variant precedence is now `binding.variant > featuredBinding > category default > "secondary"`, so an explicit `danger` override on a maintenance command wins over a panel-level `featuredBinding` nomination.
+
 ### Changed
+
+**`resolveVariantForGroup` renamed → `resolveDefaultVariantForCategory`** (`categoryDefaultVariants.ts`, RFC command-variant-split): the map keys were always category strings — the rename makes that explicit and removes the synthetic `group: rc.command.category` bridge in the panel filter (`applyCommandPanelFilter` / `PanelResolver.applyFilter` now type the candidate dimension as `category` directly).
 
 **Multi-Valued Property Merge in PrototypeChainMaterializer (RFC-016 Blocker 1)**: Properties marked with `exo__PropertyCardinalityMultiple` now APPEND inherited values from the prototype chain instead of skipping when already present. This enables RFC-014 plugin class adoption where an existing instance can adopt additional classes from a plugin prototype.
 
 **`property_set` Grounding Verified with YAML Arrays of Wikilinks (RFC-016 Blocker 3)**: Confirmed and tested that `property_set` grounding correctly handles YAML arrays of wikilinks (`[[uuid|label]]`), ensuring plugin commands can set multi-valued properties declaratively.
+
+### Deprecated
+
+**`exocmd__CommandBinding_group` property (RFC command-variant-split)**: Use `exocmd__CommandBinding_variant` instead. The parser still tolerates legacy `_group` for one release — when both `_group` and `_variant` appear on the same binding, `_variant` wins and a capped warning is logged. Starter-kit assets have been migrated to drop `_group` (kitelev/exocortex-starter-kit#94).
 
 ### Note
 

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -126,8 +126,21 @@ export interface CommandBindingDefinition {
   readonly position?: string;
   /** Sort order (default: 100) */
   readonly order?: number;
-  /** Button group name */
+  /**
+   * @deprecated Button group name (legacy). Use `variant` for explicit per-binding
+   * button variant override. Parser still reads `_group` for backward compat,
+   * but prefers `_variant` when both are present (logs warning). RFC
+   * f1dc284a-eadc-4d0e-8e72-323e999ea510 — removal scheduled for next release
+   * after starter-kit migration.
+   */
   readonly group?: string;
+  /**
+   * Per-binding button variant override (RFC command-variant-split,
+   * f1dc284a-eadc-4d0e-8e72-323e999ea510). Populated from
+   * `exocmd__CommandBinding_variant` frontmatter literal. When absent, UI
+   * falls back to category-default variant (then `secondary`).
+   */
+  readonly variant?: CommandVariant;
   /** Binding-level precondition overriding command-level precondition */
   readonly precondition?: PreconditionDefinition;
   /**

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -373,6 +373,29 @@ export class CommandResolver {
     const orderStr = await this.getLiteralValue(subject, Namespace.EXOCMD.term("CommandBinding_order"));
     const group = await this.getLiteralValue(subject, Namespace.EXOCMD.term("CommandBinding_group"));
 
+    // RFC command-variant-split (f1dc284a) — top-level variant override.
+    // Read `_variant` literal directly so callers can use `binding.variant`
+    // without having to walk the legacy RFC-024 inline-style path.
+    const variantRawForBinding = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("CommandBinding_variant"),
+    );
+    const variant =
+      variantRawForBinding !== null
+        ? this.coerceVariant(variantRawForBinding, uid)
+        : undefined;
+
+    // Coexistence guard: if binding declares both legacy `_group` and
+    // explicit `_variant`, log a (capped) warning so legacy bindings can be
+    // migrated. `_variant` always wins downstream (builder precedence).
+    if (group !== null && variantRawForBinding !== null) {
+      this.logger.warn(
+        this.capWarning(
+          `CommandBinding ${uid}: both _group and _variant present; preferring _variant (${String(variantRawForBinding)})`,
+        ),
+      );
+    }
+
     // Load binding-level precondition override
     const precondition = await this.loadLinkedPreconditionFromProperty(
       subject,
@@ -392,6 +415,7 @@ export class CommandResolver {
       position: position ?? undefined,
       order: orderStr ? parseInt(orderStr, 10) : undefined,
       group: group ?? undefined,
+      variant,
       precondition: precondition ?? undefined,
       style: style ?? undefined,
     };

--- a/packages/exocortex/tests/unit/services/CommandResolver.style.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.style.test.ts
@@ -512,6 +512,84 @@ describe("CommandResolver — RFC-024 binding style resolution", () => {
     });
   });
 
+  describe("RFC f1dc284a — top-level binding.variant", () => {
+    it("populates binding.variant from `_variant` literal", async () => {
+      await addBinding(store, {
+        uid: "bind-variant-top",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        inlineVariant: "danger",
+      });
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.variant).toBe("danger");
+    });
+
+    it("drops invalid variant (coerce → warn → undefined)", async () => {
+      await addBinding(store, {
+        uid: "bind-variant-bad",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        inlineVariant: "rainbow",
+      });
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.variant).toBeUndefined();
+    });
+
+    it("logs warning when both legacy `_group` and `_variant` are present (prefers _variant)", async () => {
+      const subject = await addBinding(store, {
+        uid: "bind-coexist",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+        inlineVariant: "primary",
+      });
+      await store.addAll([
+        new Triple(
+          subject,
+          Namespace.EXOCMD.term("CommandBinding_group"),
+          new Literal("maintenance"),
+        ),
+      ]);
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.variant).toBe("primary");
+      expect(resolved.binding.group).toBe("maintenance");
+      expect(
+        logger.warnings.some((w) =>
+          /both _group and _variant present/.test(w),
+        ),
+      ).toBe(true);
+    });
+
+    it("leaves binding.variant undefined when neither `_variant` literal nor style asset is set", async () => {
+      await addBinding(store, {
+        uid: "bind-no-variant",
+        commandUid: "cmd-1",
+        targetClass: TARGET_CLASS,
+      });
+
+      const [resolved] = await resolver.resolveForAsset(
+        "obsidian://vault/asset-1.md",
+        TARGET_CLASS,
+      );
+
+      expect(resolved.binding.variant).toBeUndefined();
+    });
+  });
+
   describe("Default constructor — no logger", () => {
     it("works without explicit logger (NullLogger fallback)", async () => {
       const silentResolver = new CommandResolver(store);

--- a/packages/obsidian-plugin/src/application/services/PanelResolver.ts
+++ b/packages/obsidian-plugin/src/application/services/PanelResolver.ts
@@ -90,10 +90,10 @@ export class PanelResolver {
    *
    * @param classRef   - Target class whose panel is consulted.
    * @param candidates - Candidate commands (each with `uid` + optional
-   *                     `group`). Order is preserved.
+   *                     `category`). Order is preserved.
    * @returns Filtered subset honouring rule #2 (exclude trumps include).
    */
-  applyFilter<T extends { uid: string; group?: string }>(
+  applyFilter<T extends { uid: string; category?: string }>(
     classRef: string,
     candidates: readonly T[],
   ): T[] {

--- a/packages/obsidian-plugin/src/domain/layout/CommandPanel.ts
+++ b/packages/obsidian-plugin/src/domain/layout/CommandPanel.ts
@@ -182,12 +182,12 @@ export function createCommandPanelFromFrontmatter(
  * Group membership is supplied by the caller since command assets live
  * outside this domain module.
  *
- * @param candidates - Candidate commands (each with uid + optional group).
+ * @param candidates - Candidate commands (each with uid + optional category).
  * @param panel - Parsed command panel spec.
- * @returns Commands that pass both include-by-group and exclude-by-uid.
+ * @returns Commands that pass both include-by-category and exclude-by-uid.
  */
 export function applyCommandPanelFilter<
-  T extends { uid: string; group?: string },
+  T extends { uid: string; category?: string },
 >(candidates: readonly T[], panel: CommandPanel | undefined): T[] {
   if (!panel) {
     return [...candidates];
@@ -201,7 +201,7 @@ export function applyCommandPanelFilter<
       return false;
     }
     if (include && include.length > 0) {
-      if (!candidate.group || !include.includes(candidate.group)) {
+      if (!candidate.category || !include.includes(candidate.category)) {
         return false;
       }
     }

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -19,7 +19,7 @@ import {
   ButtonBuilderContext,
 } from "./ButtonBuilderTypes";
 import { DynamicFormModal } from "@plugin/presentation/modals/DynamicFormModal";
-import { resolveVariantForGroup } from "./categoryDefaultVariants";
+import { resolveDefaultVariantForCategory } from "./categoryDefaultVariants";
 import {
   FALLBACK_CATEGORY_ORDER,
   resolveCategoryCollapsed,
@@ -307,8 +307,9 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
 
     // RFC-024 Phase 3 — apply class-level panel filter (excludeCommands
     // trumps includeGroups). When no panel is declared this is a pure
-    // pass-through. Group dimension uses `command.category` since the UI
-    // sections by category, not by `binding.group`.
+    // pass-through. Filter dimension uses `command.category` (post-RFC
+    // f1dc284a — sectioning axis is `Command_category`, no longer routed
+    // through the synthesised `binding.group` bridge).
     const visibleCommands =
       panelClassRef !== null
         ? this.panelResolver
@@ -316,7 +317,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
               panelClassRef,
               preconditionPassed.map((rc) => ({
                 uid: rc.binding.id,
-                group: rc.command.category,
+                category: rc.command.category,
                 rc,
               })),
             )
@@ -339,15 +340,21 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
   ): ActionButton {
     const { command, binding } = rc;
 
-    // RFC-024 §5 rule #3 — `featuredBinding` overrides binding-level
-    // style.variant → `primary` regardless of any other resolution.
+    // Variant precedence (RFC f1dc284a-eadc-4d0e-8e72-323e999ea510):
+    //   binding.variant > featuredBinding > category default > "secondary"
+    // Explicit per-binding override wins over panel-level featuredBinding so
+    // a destructive `maintenance` command can be rendered as `danger` even
+    // when nominated featured (cf. RFC §Кейс A). Featured binding still
+    // promotes to `primary` when no explicit variant is set.
     const featured =
       panelClassRef !== null &&
       this.panelResolver.isFeatured(panelClassRef, binding.id);
 
-    const variant: ActionButtonVariant = featured
-      ? "primary"
-      : resolveVariantForGroup(binding.group);
+    const variant: ActionButtonVariant =
+      binding.variant ??
+      (featured
+        ? "primary"
+        : resolveDefaultVariantForCategory(command.category));
 
     // RFC-024 §4 Phase 2 — T5.3: render `Command_icon` by default. The
     // resolved `binding.style.showIcon` (populated in T5.2 by CommandResolver)

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/categoryDefaultVariants.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/categoryDefaultVariants.ts
@@ -1,18 +1,20 @@
 import type { ActionButtonVariant } from "@plugin/presentation/components/ActionButtonsGroup";
 
 /**
- * Built-in default variant map per command-binding group (RFC-024 Phase 0).
+ * Built-in default variant map per command category (RFC-024 Phase 0,
+ * post-RFC f1dc284a-eadc-4d0e-8e72-323e999ea510 rename).
  *
- * Keys are values of `exocmd__CommandBinding_group` (or the `binding.group` field
+ * Keys are values of `exocmd__Command_category` (the `command.category` field
  * on the domain model). Forward-looking sub-category keys (`status/done`,
  * `status/blocked`, `status/cancelled`) are included per RFC-024 §4 acceptance
- * criteria — they are inert today because starter-kit bindings use flat `status`
- * category, but will activate when sub-category granularity is introduced.
+ * criteria — they are inert today because starter-kit commands use a flat
+ * `status` category, but will activate when sub-category granularity is
+ * introduced.
  *
- * Rationale: prior implementation hardcoded a 5-case switch in
- * `DynamicCommandButtonGroupBuilder.resolveVariant`; this map is
- * independently testable and removes rollout coupling to starter-kit migration
- * (every installation receives the correct default colors on plugin upgrade).
+ * Rationale: `Command_category` (UI sectioning) and per-binding
+ * `CommandBinding_variant` (button color override) are now separate axes.
+ * This map encodes the built-in fallback colour for a category when no
+ * per-binding variant is set.
  */
 export const categoryDefaultVariant: Readonly<
   Record<string, ActionButtonVariant>
@@ -26,12 +28,17 @@ export const categoryDefaultVariant: Readonly<
 });
 
 /**
- * Resolves the default button variant for a command binding's `group` string.
- * Falls back to `"secondary"` for unknown, empty, or missing groups.
+ * Resolves the default button variant for a command's `category` string.
+ * Falls back to `"secondary"` for unknown, empty, or missing categories.
+ *
+ * Note: prior to RFC f1dc284a this function was named `resolveVariantForGroup`
+ * and was keyed by the legacy `binding.group` literal. After the split of
+ * `Command_category` (UI sectioning) and `CommandBinding_variant` (button
+ * color override) it is now keyed by `command.category` directly.
  */
-export function resolveVariantForGroup(
-  group: string | undefined,
+export function resolveDefaultVariantForCategory(
+  category: string | undefined,
 ): ActionButtonVariant {
-  if (!group) return "secondary";
-  return categoryDefaultVariant[group] ?? "secondary";
+  if (!category) return "secondary";
+  return categoryDefaultVariant[category] ?? "secondary";
 }

--- a/packages/obsidian-plugin/tests/unit/application/services/PanelResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/services/PanelResolver.test.ts
@@ -73,10 +73,10 @@ describe("PanelResolver", () => {
 
   describe("applyFilter", () => {
     const candidates = [
-      { uid: "bind-create", group: "creation" },
-      { uid: "bind-status", group: "status" },
-      { uid: "bind-block", group: "status" },
-      { uid: "bind-misc", group: "maintenance" },
+      { uid: "bind-create", category: "creation" },
+      { uid: "bind-status", category: "status" },
+      { uid: "bind-block", category: "status" },
+      { uid: "bind-misc", category: "maintenance" },
     ];
 
     it("returns the candidates unchanged when no panel is declared", () => {
@@ -85,7 +85,7 @@ describe("PanelResolver", () => {
       expect(resolver.applyFilter("ems__Task", candidates)).toEqual(candidates);
     });
 
-    it("includes only bindings whose group is whitelisted", () => {
+    it("includes only bindings whose category is whitelisted", () => {
       const panel: CommandPanel = { includeGroups: ["creation", "status"] };
       const resolver = new PanelResolver({
         layoutProvider: () => ({ commandPanel: panel }),
@@ -98,7 +98,7 @@ describe("PanelResolver", () => {
       ]);
     });
 
-    it("drops excluded bindings even when their group is included (rule #2)", () => {
+    it("drops excluded bindings even when their category is included (rule #2)", () => {
       const panel: CommandPanel = {
         includeGroups: ["creation", "status"],
         excludeCommands: ["bind-block"],

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts
@@ -179,11 +179,11 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
         command: {
           id: "cmd-creation",
           name: "Create Task",
-          category: "status",
+          category: "creation",
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value" },
         },
-        binding: { order: 0, group: "creation" },
+        binding: { order: 0 },
       },
       {
         command: {
@@ -193,37 +193,43 @@ describe("ButtonGroupsBuilder - build (dynamic commands only)", () => {
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value" },
         },
-        binding: { order: 1, group: "maintenance" },
+        binding: { order: 1 },
       },
       {
         command: {
           id: "cmd-unknown",
           name: "Trash",
-          category: "maintenance",
+          category: "unknown-future-category",
           precondition: { type: "always_true" },
           grounding: { type: "set_frontmatter_value" },
         },
-        binding: { order: 2, group: "legacy-unknown" },
+        binding: { order: 2 },
       },
     ]);
     ctx.mockPreconditionEvaluator.evaluate.mockResolvedValue(true);
 
     const groups = await ctx.builder.build(mockFile);
 
-    // RFC-024 Phase 0: category-driven default variants.
-    // `creation` → primary, `maintenance` → muted, unknown group → secondary.
-    const statusGroup = groups.find((g) => g.id === "dynamic-commands-status");
+    // RFC f1dc284a: category-driven default variants.
+    // `creation` → primary, `maintenance` → muted, unknown category → secondary.
+    const creationGroup = groups.find(
+      (g) => g.id === "dynamic-commands-creation",
+    );
     const maintenanceGroup = groups.find(
       (g) => g.id === "dynamic-commands-maintenance",
     );
-    expect(statusGroup).toBeDefined();
-    expect(statusGroup!.buttons.length).toBe(1);
-    expect(statusGroup!.buttons[0].variant).toBe("primary");
+    const unknownGroup = groups.find(
+      (g) => g.id === "dynamic-commands-unknown-future-category",
+    );
+    expect(creationGroup).toBeDefined();
+    expect(creationGroup!.buttons.length).toBe(1);
+    expect(creationGroup!.buttons[0].variant).toBe("primary");
     expect(maintenanceGroup).toBeDefined();
     expect(maintenanceGroup!.collapsedByDefault).toBe(true);
-    expect(maintenanceGroup!.buttons.length).toBe(2);
+    expect(maintenanceGroup!.buttons.length).toBe(1);
     expect(maintenanceGroup!.buttons[0].variant).toBe("muted");
-    expect(maintenanceGroup!.buttons[1].variant).toBe("secondary");
+    expect(unknownGroup).toBeDefined();
+    expect(unknownGroup!.buttons[0].variant).toBe("secondary");
   });
 
   it("should handle resolver errors gracefully", async () => {

--- a/packages/obsidian-plugin/tests/unit/domain/layout/CommandPanel.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/layout/CommandPanel.test.ts
@@ -196,10 +196,10 @@ describe("CommandPanel — RFC-024 Phase 3 domain model", () => {
 
   describe("applyCommandPanelFilter — precedence rule #2", () => {
     const candidates = [
-      { uid: "a", group: "creation" },
-      { uid: "b", group: "creation" },
-      { uid: "c", group: "status" },
-      { uid: "d", group: "misc" },
+      { uid: "a", category: "creation" },
+      { uid: "b", category: "creation" },
+      { uid: "c", category: "status" },
+      { uid: "d", category: "misc" },
       { uid: "e" },
     ];
 
@@ -240,7 +240,7 @@ describe("CommandPanel — RFC-024 Phase 3 domain model", () => {
       ).toEqual(["b"]);
     });
 
-    it("drops ungrouped commands when includeGroups is active", () => {
+    it("drops uncategorized commands when includeGroups is active", () => {
       const panel: CommandPanel = { includeGroups: ["creation"] };
       expect(
         applyCommandPanelFilter(candidates, panel).map((c) => c.uid),

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -304,11 +304,10 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       );
     });
 
-    it("should resolve variant from binding group via categoryDefaultVariant map", async () => {
-      // RFC-024 Phase 0: `creation` group maps to `primary` by built-in defaults
+    it("should resolve variant from command category via categoryDefaultVariant map", async () => {
+      // RFC f1dc284a: `creation` category maps to `primary` by built-in defaults.
       const rc = createResolvedCommand(
-        { name: "Create action" },
-        { group: "creation" },
+        { name: "Create action", category: "creation" },
       );
       mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
@@ -319,10 +318,9 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       expect(result[0].variant).toBe("primary");
     });
 
-    it("should map maintenance group to muted variant (RFC-024 Phase 0)", async () => {
+    it("should map maintenance category to muted variant", async () => {
       const rc = createResolvedCommand(
-        { name: "Rebuild index" },
-        { group: "maintenance" },
+        { name: "Rebuild index", category: "maintenance" },
       );
       mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
@@ -333,10 +331,9 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       expect(result[0].variant).toBe("muted");
     });
 
-    it("should default variant to secondary when no group", async () => {
+    it("should default variant to secondary when no category", async () => {
       const rc = createResolvedCommand(
-        { name: "Default action" },
-        { group: undefined },
+        { name: "Default action", category: undefined },
       );
       mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
@@ -345,6 +342,21 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       const result = await builder.build(context);
 
       expect(result[0].variant).toBe("secondary");
+    });
+
+    it("binding.variant override wins over category default and featuredBinding (RFC f1dc284a)", async () => {
+      // Кейс A: destructive maintenance command rendered as `danger`.
+      const rc = createResolvedCommand(
+        { name: "Delete asset", category: "maintenance" },
+        { variant: "danger" },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const context = createContext();
+      const result = await builder.build(context);
+
+      expect(result[0].variant).toBe("danger");
     });
 
     it("should default variant to secondary for unknown group", async () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -1123,4 +1123,145 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       ]);
     });
   });
+
+  // -- T3 — RFC f1dc284a variant precedence chain ----------------------------
+  // Six explicit branches of:
+  //   binding.variant > featuredBinding > category default > "secondary"
+  // Each test labels its branch (a–f) so the AC checklist on
+  // task 4ed5c130-6aae-4e36-acb0-6292852be67d can be verified by name.
+  describe("variant precedence chain (RFC f1dc284a, T3)", () => {
+    function makeBuilderWithFeatured(featuredBindingId: string | undefined) {
+      const panelResolver = new PanelResolver({
+        layoutProvider: (classRef) =>
+          classRef === "ems__Task"
+            ? {
+                commandPanel: featuredBindingId
+                  ? { featuredBinding: featuredBindingId }
+                  : {},
+              }
+            : null,
+      });
+      return new DynamicCommandButtonGroupBuilder({
+        commandResolver: mockCommandResolver as unknown as any,
+        preconditionEvaluator: mockPreconditionEvaluator as unknown as any,
+        groundingExecutor: mockGroundingExecutor as unknown as any,
+        notificationService: mockNotificationService as any,
+        panelResolver,
+      });
+    }
+
+    it("(a) binding.variant=danger wins over featuredBinding and category default", async () => {
+      // featuredBinding would normally promote to `primary`; category
+      // `creation` would normally default to `primary`. Explicit
+      // `binding.variant=danger` must beat both.
+      const rc = createResolvedCommand(
+        { name: "Hard delete", category: "creation" },
+        { id: "binding-a", variant: "danger" },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const builder = makeBuilderWithFeatured("binding-a");
+      const result = await builder.build(createContext());
+
+      expect(result).toHaveLength(1);
+      expect(result[0].variant).toBe("danger");
+    });
+
+    it("(b) no variant + no group + category=creation → primary", async () => {
+      const rc = createResolvedCommand(
+        { name: "Create Task", category: "creation" },
+        { id: "binding-b" },
+      );
+      expect(rc.binding.variant).toBeUndefined();
+      expect(rc.binding.group).toBeUndefined();
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const result = await builder.build(createContext());
+
+      expect(result[0].variant).toBe("primary");
+    });
+
+    it("(c) no variant + unknown category → secondary fallback", async () => {
+      const rc = createResolvedCommand(
+        { name: "Mystery action", category: "future-uncategorized-bucket" },
+        { id: "binding-c" },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const result = await builder.build(createContext());
+
+      expect(result[0].variant).toBe("secondary");
+    });
+
+    it("(d) legacy group=maintenance + variant=danger → variant wins (group still parsed for diagnostics)", async () => {
+      // Mirrors the parser-level CommandResolver assertion that both fields
+      // coexist; here the builder consumes the resolved object and must
+      // pick `variant` regardless of legacy `group`. The CommandResolver
+      // unit suite (`CommandResolver.style.test.ts`) covers the parser
+      // warning emission for the same shape.
+      const rc = createResolvedCommand(
+        { name: "Wipe cache", category: "maintenance" },
+        { id: "binding-d", group: "maintenance", variant: "danger" },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const result = await builder.build(createContext());
+
+      expect(result[0].variant).toBe("danger");
+    });
+
+    it("(e) backward compat — binding without _variant produces stable UI snapshot", async () => {
+      // Pre-RFC fixture: explicit `_variant` absent, only category drives
+      // colour. Snapshot pins the full button shape so a future regression
+      // (e.g. accidental field reorder, default flip) flags here.
+      const rc = createResolvedCommand(
+        {
+          id: "cmd-legacy",
+          name: "Mark Done",
+          category: "status",
+          icon: "check",
+        },
+        { id: "binding-legacy" },
+      );
+      expect(rc.binding.variant).toBeUndefined();
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const result = await builder.build(createContext());
+
+      expect(result).toHaveLength(1);
+      const { onClick: _onClick, ...snapshot } = result[0];
+      expect(snapshot).toMatchInlineSnapshot(`
+{
+  "ariaLabel": undefined,
+  "icon": "check",
+  "id": "dynamic-cmd-cmd-legacy",
+  "label": "Mark Done",
+  "tooltip": undefined,
+  "variant": "secondary",
+  "visible": true,
+}
+`);
+    });
+
+    it("(f) binding.variant=warning + featuredBinding=this → explicit variant beats featured promotion", async () => {
+      const rc = createResolvedCommand(
+        { name: "Caution action", category: "creation" },
+        { id: "binding-f", variant: "warning" },
+      );
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+
+      const builder = makeBuilderWithFeatured("binding-f");
+      const result = await builder.build(createContext());
+
+      // Without binding.variant, featured would have promoted to `primary`.
+      // With explicit `warning`, that wins per RFC §Кейс A precedence.
+      expect(result[0].variant).toBe("warning");
+    });
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/categoryDefaultVariants.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/categoryDefaultVariants.test.ts
@@ -1,6 +1,6 @@
 import {
   categoryDefaultVariant,
-  resolveVariantForGroup,
+  resolveDefaultVariantForCategory,
 } from "../../../../src/presentation/builders/button-groups/categoryDefaultVariants";
 
 describe("categoryDefaultVariant map (RFC-024 Phase 0)", () => {
@@ -37,36 +37,38 @@ describe("categoryDefaultVariant map (RFC-024 Phase 0)", () => {
   });
 });
 
-describe("resolveVariantForGroup (RFC-024 Phase 0)", () => {
-  it("returns secondary for undefined group", () => {
-    expect(resolveVariantForGroup(undefined)).toBe("secondary");
+describe("resolveDefaultVariantForCategory (RFC f1dc284a rename)", () => {
+  it("returns secondary for undefined category", () => {
+    expect(resolveDefaultVariantForCategory(undefined)).toBe("secondary");
   });
 
-  it("returns secondary for empty string group", () => {
-    expect(resolveVariantForGroup("")).toBe("secondary");
+  it("returns secondary for empty string category", () => {
+    expect(resolveDefaultVariantForCategory("")).toBe("secondary");
   });
 
-  it("returns primary for creation group", () => {
-    expect(resolveVariantForGroup("creation")).toBe("primary");
+  it("returns primary for creation category", () => {
+    expect(resolveDefaultVariantForCategory("creation")).toBe("primary");
   });
 
-  it("returns warning for criticality group", () => {
-    expect(resolveVariantForGroup("criticality")).toBe("warning");
+  it("returns warning for criticality category", () => {
+    expect(resolveDefaultVariantForCategory("criticality")).toBe("warning");
   });
 
-  it("returns muted for maintenance group", () => {
-    expect(resolveVariantForGroup("maintenance")).toBe("muted");
+  it("returns muted for maintenance category", () => {
+    expect(resolveDefaultVariantForCategory("maintenance")).toBe("muted");
   });
 
-  it("returns secondary for unknown group", () => {
-    expect(resolveVariantForGroup("unknown-future-category")).toBe("secondary");
+  it("returns secondary for unknown category", () => {
+    expect(resolveDefaultVariantForCategory("unknown-future-category")).toBe(
+      "secondary",
+    );
   });
 
-  it("returns secondary for bare status group (sub-category required for color)", () => {
-    expect(resolveVariantForGroup("status")).toBe("secondary");
+  it("returns secondary for bare status category (sub-category required for color)", () => {
+    expect(resolveDefaultVariantForCategory("status")).toBe("secondary");
   });
 
-  it("returns secondary for planning group", () => {
-    expect(resolveVariantForGroup("planning")).toBe("secondary");
+  it("returns secondary for planning category", () => {
+    expect(resolveDefaultVariantForCategory("planning")).toBe("secondary");
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 of RFC `f1dc284a-eadc-4d0e-8e72-323e999ea510` (command-variant-split): separate `exocmd__Command_category` (UI sectioning) from `exocmd__CommandBinding_variant` (per-binding button colour override).

- Surface `binding.variant?: CommandVariant` on `CommandBindingDefinition`, populated by `CommandResolver` from the existing `exocmd__CommandBinding_variant` literal (T1 added the property asset, UID `61f449b2-26c3-4ca3-95dc-fe6b0d1b5f57`).
- New variant precedence in `DynamicCommandButtonGroupBuilder`:
  ```
  binding.variant > featuredBinding > category default > "secondary"
  ```
  Explicit per-binding override now wins over panel-level `featuredBinding` (RFC §Кейс A — destructive maintenance command rendered as `danger` even when nominated featured).
- Rename `resolveVariantForGroup` → `resolveDefaultVariantForCategory` (the map keys were already category strings); update JSDoc.
- Remove the synthetic `group: rc.command.category` bridge in the panel filter by typing the candidate dimension as `category` directly (`applyCommandPanelFilter`, `PanelResolver.applyFilter`).
- Resolver logs a capped warning when a binding declares both legacy `_group` and `_variant` (the latter wins downstream).
- Legacy `binding.group` is still parsed (`@deprecated` tag) so existing starter-kit / user vaults keep working until the Phase 5 starter-kit migration drops `_group`.

## Acceptance criteria (from task `f0c6da64-9ca4-4572-a143-884868ff1d1c`)

- [x] `CommandBinding` domain interface contains `variant?: ActionButtonVariant` (`CommandVariant` in `@exocortex/core`, identical union)
- [x] Parser extracts `exocmd__CommandBinding_variant` from frontmatter, validates against enum (drop unknown with capped warning via existing `coerceVariant` helper)
- [x] Builder precedence: `binding.variant > featuredBinding > category default > "secondary"`
- [x] Synthetic `group: rc.command.category` bridge removed (filter dimension renamed to `category`)
- [x] `resolveVariantForGroup` renamed to `resolveDefaultVariantForCategory`
- [x] Backward compat: bindings without `_variant` render identically to pre-RFC builds (category map unchanged; `creation` → `primary`, `maintenance` → `muted`, etc.)
- [x] Legacy `binding.group` still parsed but `_variant` wins when both are present (warning logged)
- [x] Lint + typecheck clean

## Test plan

- [x] `categoryDefaultVariants.test.ts` — renamed function, all 14 cases pass
- [x] `CommandPanel.test.ts` / `PanelResolver.test.ts` — filter generic renamed `group` → `category`, tests updated
- [x] `DynamicCommandButtonGroupBuilder.test.ts` — added test for `binding.variant` override; existing variant-from-category cases pass
- [x] `CommandResolver.style.test.ts` — added 4 tests for top-level `binding.variant` (extraction, invalid coerce-drop, `_group + _variant` warning, absent literal)
- [x] `ButtonGroupsBuilder.build.test.ts` — fixture now category-driven (was relying on legacy `binding.group` for variant)
- [x] Full unit-test runs: 4979/4982 pass in `obsidian-plugin`, 7339/7419 pass in `exocortex` (28 preexisting failures unchanged from `main`)
- [x] `npm run check:types` clean
- [x] `npm run lint` clean (2 preexisting non-null-assertion warnings, unchanged)

## Related

- RFC: `f1dc284a-eadc-4d0e-8e72-323e999ea510` (command-variant-split)
- Charter: `ec9fa94d-d647-4085-a3ad-71af30548791`
- Task: `f0c6da64-9ca4-4572-a143-884868ff1d1c` (T2 — Parser/builder)
- Depends on T1 — `exocmd__CommandBinding_variant` property asset (`61f449b2-26c3-4ca3-95dc-fe6b0d1b5f57`)

## Related PRs

- kitelev/exocortex-starter-kit#94 — Phase 5 starter-kit migration (drop `_group` from 57 bindings)