### PR TITLE
fix(loader): #2997 Phase 2 — two-phase commit (all-or-nothing) for asset loader

### DIFF
--- a/packages/cli/tests/integration/issue-2997-loader-2pc.integration.test.ts
+++ b/packages/cli/tests/integration/issue-2997-loader-2pc.integration.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Phase 2 integration tests for issue #2997 — Loader two-phase commit.
+ *
+ * RFC `0810aad3-90fc-46bb-a103-26ca8172970b` Phase 2.
+ *
+ * Walks each of the 11 bad-file fixtures in
+ * `tests/fixtures/issue-2997/bad-files/` through
+ * `NoteToRDFConverter.convertVaultWithValidation` in isolation and
+ * asserts the all-or-nothing invariant: a single malformed asset must
+ * produce zero triples in the candidate output and must be reported in
+ * `skippedFiles`.
+ *
+ * Each fixture is loaded into its own temporary vault (the file alone)
+ * so the per-file invariant is exercised without interference from
+ * neighbouring files.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import { NoteToRDFConverter } from "exocortex";
+import { FileSystemVaultAdapter } from "../../src/adapters/FileSystemVaultAdapter.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BAD_FILES_DIR = resolve(__dirname, "../fixtures/issue-2997/bad-files");
+const VALID_TREE_DIR = resolve(__dirname, "../fixtures/issue-2997/valid-tree");
+
+interface BadFixture {
+  filename: string;
+  expectedReasonContains: string;
+}
+
+const BAD_FIXTURES: BadFixture[] = [
+  { filename: "01-invalid-iri-class.md", expectedReasonContains: "Invalid Instance_class IRI" },
+  { filename: "02-empty-locked-by.md", expectedReasonContains: "ems__Effort_lockedBy" },
+  { filename: "03-empty-lock-expires.md", expectedReasonContains: "ems__Effort_lockExpires" },
+  { filename: "04-missing-asset-uid.md", expectedReasonContains: "exo__Asset_uid" },
+  { filename: "05-missing-asset-isdefinedby.md", expectedReasonContains: "exo__Asset_isDefinedBy" },
+  { filename: "06-empty-asset-label.md", expectedReasonContains: "exo__Asset_label" },
+  { filename: "07-empty-instance-class.md", expectedReasonContains: "exo__Instance_class" },
+  { filename: "08-empty-effort-status.md", expectedReasonContains: "ems__Effort_status" },
+  { filename: "09-empty-effort-parent.md", expectedReasonContains: "ems__Effort_parent" },
+  { filename: "10-empty-asset-updatedat.md", expectedReasonContains: "exo__Asset_updatedAt" },
+  { filename: "11-empty-effort-start-timestamp.md", expectedReasonContains: "ems__Effort_startTimestamp" },
+];
+
+let tempRoot: string;
+
+async function makeTempVaultWith(fixturePath: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(tempRoot, "issue-2997-2pc-"));
+  const dest = path.join(dir, path.basename(fixturePath));
+  await fs.copy(fixturePath, dest);
+  return dir;
+}
+
+describe("Issue #2997 Phase 2 — Loader two-phase commit (all-or-nothing)", () => {
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "exo-2997-phase2-"));
+  });
+
+  afterAll(async () => {
+    if (tempRoot) await fs.remove(tempRoot);
+  });
+
+  it.each(BAD_FIXTURES)(
+    "rejects $filename without leaking any triples",
+    async ({ filename, expectedReasonContains }) => {
+      const fixturePath = path.join(BAD_FILES_DIR, filename);
+      const vaultRoot = await makeTempVaultWith(fixturePath);
+
+      const adapter = new FileSystemVaultAdapter(vaultRoot);
+      const converter = new NoteToRDFConverter(adapter);
+
+      const result = await converter.convertVaultWithValidation();
+
+      expect(result.triples).toEqual([]);
+      expect(result.summary.indexed).toBe(0);
+      expect(result.summary.skipped).toBe(1);
+      expect(result.summary.total).toBe(1);
+      expect(result.skippedFiles).toHaveLength(1);
+      expect(result.skippedFiles[0].path).toBe(filename);
+      expect(result.skippedFiles[0].reason).toContain(expectedReasonContains);
+    },
+  );
+
+  it("indexes the well-formed control tree with non-empty triples and zero skips", async () => {
+    const adapter = new FileSystemVaultAdapter(VALID_TREE_DIR);
+    const converter = new NoteToRDFConverter(adapter);
+
+    const result = await converter.convertVaultWithValidation();
+
+    expect(result.summary.skipped).toBe(0);
+    expect(result.triples.length).toBeGreaterThan(0);
+    expect(result.skippedFiles).toEqual([]);
+  });
+
+  it(
+    "loads the full mixed fixture vault: only valid files contribute triples, all 11 bad files reported as skipped",
+    async () => {
+      const fixtureRoot = resolve(__dirname, "../fixtures/issue-2997");
+      const adapter = new FileSystemVaultAdapter(fixtureRoot);
+      const converter = new NoteToRDFConverter(adapter);
+
+      const result = await converter.convertVaultWithValidation();
+
+      expect(result.summary.skipped).toBe(BAD_FIXTURES.length);
+      expect(result.skippedFiles.map((f) => path.basename(f.path)).sort()).toEqual(
+        BAD_FIXTURES.map((f) => f.filename).sort(),
+      );
+      // Triples must come exclusively from the valid-tree subset.
+      for (const triple of result.triples) {
+        const subject = (triple.subject as { value: string }).value;
+        for (const bad of BAD_FIXTURES) {
+          expect(subject).not.toContain(bad.filename);
+        }
+      }
+      expect(result.triples.length).toBeGreaterThan(0);
+    },
+    30_000,
+  );
+});

--- a/packages/cli/tests/integration/issue-2997-repro.integration.test.ts
+++ b/packages/cli/tests/integration/issue-2997-repro.integration.test.ts
@@ -79,10 +79,12 @@ async function runIssueQuery(vaultPath: string): Promise<unknown[]> {
   return rows;
 }
 
-// Suite is `.skip`'d until Phase 2 (loader all-or-nothing) + Phase 3
-// (translator literal-safety guard) land. Drop `.skip` then to convert
-// these into the regression gate for #2997.
-describe.skip("Issue #2997 reproduction (skipped until Phase 2/3 fix)", () => {
+// Phase 3 (translator literal-safety guard) is now in place — the full-fixture
+// case is enabled because the executor must complete without throwing even if
+// the loader leaks partial-state literals (Phase 2 will additionally make the
+// loader all-or-nothing so 0 such literals leak; Phase 3 is the safety net).
+// Control test always passes; full-fixture case is the regression gate.
+describe("Issue #2997 reproduction (Phase 3 guard active)", () => {
   it("issue query on full fixture vault returns rows without throwing", async () => {
     // Expected post-fix behaviour: query resolves and returns at least
     // the row from the well-formed subtree (Project → Phase → Task with

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -19,6 +19,24 @@ import {
 } from "../domain/models/exo003";
 
 /**
+ * File-level invariant codes detected by `validateExocortexAsset`.
+ *
+ * Issue #2997 Phase 2: each code maps to one of the 11 bad-file shapes
+ * that previously leaked partial triples into the store.
+ */
+export type ExocortexInvariantCode =
+  | "MISSING_PROPERTY"
+  | "EMPTY_PROPERTY"
+  | "EMPTY_OPTIONAL_PROPERTY"
+  | "INVALID_INSTANCE_CLASS_IRI";
+
+export interface ExocortexInvariantViolation {
+  code: ExocortexInvariantCode;
+  property: string;
+  message: string;
+}
+
+/**
  * Service for converting Obsidian notes (frontmatter + wikilinks) to RDF triples.
  *
  * @example
@@ -497,8 +515,50 @@ export class NoteToRDFConverter {
 
     for (const file of files) {
       try {
-        const triples = await this.convertNote(file);
-        allTriples.push(...triples);
+        // Issue #2997 Phase 2 — Loader two-phase commit (all-or-nothing).
+        //
+        // Pipeline (per file):
+        //   1. Read frontmatter once.
+        //   2. Validate file-level invariants against raw frontmatter
+        //      (see `validateExocortexAsset`). Covers the 11 bad shapes
+        //      from RFC 0810aad3-…/Phase 2 fixtures (empty required
+        //      properties, empty optionals, malformed Instance_class
+        //      IRI). Validation is cheap (dictionary lookup) so we
+        //      front-load it before any triple work.
+        //   3. Build the candidate triple buffer via `convertNote`.
+        //      The buffer is local to this iteration — it never enters
+        //      `allTriples` if anything below fails.
+        //   4. Commit the buffer into `allTriples` atomically.
+        //
+        // Any violation at step 2, or any throw at step 3, discards the
+        // entire buffer and records the file as skipped — a single
+        // malformed asset can never leak partial triples into the store
+        // (which previously tripped the SPARQL executor with
+        // "Literals cannot appear in subject position").
+        const frontmatter = this.vault.getFrontmatter(file);
+        const violation = frontmatter
+          ? this.validateExocortexAsset(frontmatter)
+          : null;
+
+        if (violation) {
+          if (strict) {
+            throw new Error(
+              `Invariant violation in "${file.path}": ${violation.message}`,
+            );
+          }
+          skippedFiles.push({
+            path: file.path,
+            reason: `Invariant violation: ${violation.message}`,
+          });
+          this.logger.warn(
+            `Skipping file with invariant violation: ${file.path}`,
+            { code: violation.code, property: violation.property, reason: violation.message },
+          );
+          continue;
+        }
+
+        const candidate = await this.convertNote(file);
+        allTriples.push(...candidate);
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
 
@@ -549,6 +609,120 @@ export class NoteToRDFConverter {
    * }
    * ```
    */
+  /**
+   * Validates a single file's frontmatter against Exocortex asset
+   * invariants.
+   *
+   * Issue #2997 Phase 2 — file-level invariants, evaluated against
+   * the raw frontmatter before any triple is committed to the store.
+   * Used by `convertVaultWithValidation` as the second leg of the
+   * two-phase load (build candidate → validate → commit).
+   *
+   * Trigger: only frontmatter that looks like an Exocortex asset
+   * (declares `exo__Instance_class` or `exo__Asset_uid`) is checked.
+   * Plain markdown notes with arbitrary frontmatter pass through
+   * unchanged.
+   *
+   * Invariants:
+   *   - Required + non-empty: `exo__Asset_uid`, `exo__Asset_isDefinedBy`,
+   *     `exo__Asset_label`, `exo__Instance_class`.
+   *   - Optional but non-empty if present: `ems__Effort_status`,
+   *     `ems__Effort_parent`, `ems__Effort_lockedBy`,
+   *     `ems__Effort_lockExpires`, `exo__Asset_updatedAt`,
+   *     `ems__Effort_startTimestamp`.
+   *   - `exo__Instance_class` wikilink target must not contain
+   *     whitespace or parentheses when it carries a class-style
+   *     namespace prefix (e.g. `exo__`, `ems__`) — those expand to
+   *     namespace IRIs and would otherwise produce invalid IRIs.
+   *
+   * @param frontmatter - The note's parsed frontmatter.
+   * @returns The first detected invariant violation, or `null` if the
+   *          frontmatter passes (or is not an Exocortex asset).
+   */
+  validateExocortexAsset(
+    frontmatter: Record<string, unknown>,
+  ): ExocortexInvariantViolation | null {
+    const isEmpty = (v: unknown): boolean => {
+      if (v === null || v === undefined) return true;
+      if (typeof v === "string") return v.trim() === "";
+      if (Array.isArray(v)) return v.length === 0 || v.every(isEmpty);
+      return false;
+    };
+
+    // Trigger: skip non-Exocortex notes entirely.
+    const looksLikeAsset =
+      "exo__Instance_class" in frontmatter ||
+      "exo__Asset_uid" in frontmatter;
+    if (!looksLikeAsset) {
+      return null;
+    }
+
+    const REQUIRED_PROPERTIES = [
+      "exo__Asset_uid",
+      "exo__Asset_isDefinedBy",
+      "exo__Asset_label",
+      "exo__Instance_class",
+    ];
+    for (const key of REQUIRED_PROPERTIES) {
+      if (!(key in frontmatter)) {
+        return {
+          code: "MISSING_PROPERTY",
+          property: key,
+          message: `Required property "${key}" is missing`,
+        };
+      }
+      if (isEmpty(frontmatter[key])) {
+        return {
+          code: "EMPTY_PROPERTY",
+          property: key,
+          message: `Required property "${key}" is empty`,
+        };
+      }
+    }
+
+    const OPTIONAL_NON_EMPTY_PROPERTIES = [
+      "ems__Effort_status",
+      "ems__Effort_parent",
+      "ems__Effort_lockedBy",
+      "ems__Effort_lockExpires",
+      "exo__Asset_updatedAt",
+      "ems__Effort_startTimestamp",
+    ];
+    for (const key of OPTIONAL_NON_EMPTY_PROPERTIES) {
+      if (key in frontmatter && isEmpty(frontmatter[key])) {
+        return {
+          code: "EMPTY_OPTIONAL_PROPERTY",
+          property: key,
+          message: `Optional property "${key}" is present but empty`,
+        };
+      }
+    }
+
+    // Instance_class wikilink shape — only reject when target carries
+    // a known namespace prefix (e.g. `exo__`, `ems__`) but contains
+    // characters that would produce an invalid namespace IRI.
+    const instanceClassValue = frontmatter["exo__Instance_class"];
+    const classCandidates = Array.isArray(instanceClassValue)
+      ? instanceClassValue
+      : [instanceClassValue];
+    for (const candidate of classCandidates) {
+      if (typeof candidate !== "string") continue;
+      const cleaned = this.removeQuotes(candidate);
+      const wikilink = this.extractWikilink(cleaned);
+      const target = (wikilink ?? cleaned).trim();
+      const looksLikeNamespacedClass = /^[a-z][a-zA-Z0-9]*__/.test(target);
+      if (looksLikeNamespacedClass && /[\s()]/.test(target)) {
+        return {
+          code: "INVALID_INSTANCE_CLASS_IRI",
+          property: "exo__Instance_class",
+          message: `Invalid Instance_class IRI: "${candidate}"`,
+        };
+      }
+    }
+
+    return null;
+  }
+
   async validateVault(): Promise<Array<{ path: string; reason: string }>> {
     const files = this.vault.getAllFiles();
     const issues: Array<{ path: string; reason: string }> = [];

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.iri-validation.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.iri-validation.test.ts
@@ -53,10 +53,17 @@ describe("Issue #2205: IRI Validation and Error Handling", () => {
 
       mockVaultAdapter.getAllFiles.mockReturnValue([validFile, problematicFile]);
 
-      // Valid file returns good frontmatter
+      // Valid file returns good frontmatter (Issue #2997 Phase 2:
+      // includes all required Exocortex asset properties so the
+      // file-level invariant validator does not skip it).
       mockVaultAdapter.getFrontmatter.mockImplementation((file) => {
         if (file.path === "valid-file.md") {
-          return { exo__Instance_class: ["[[ems__Task]]"] };
+          return {
+            exo__Asset_uid: "11111111-1111-1111-1111-111111111111",
+            exo__Asset_isDefinedBy: "[[!kitelev]]",
+            exo__Asset_label: "Valid File",
+            exo__Instance_class: ["[[ems__Task]]"],
+          };
         }
         // Problematic file will throw during conversion
         throw new Error("Invalid subject: cannot parse frontmatter");
@@ -151,7 +158,12 @@ describe("Issue #2205: IRI Validation and Error Handling", () => {
         if (file.path === "will-fail.md") {
           throw new Error("Conversion error");
         }
-        return { exo__Instance_class: ["[[ems__Task]]"] };
+        return {
+          exo__Asset_uid: "22222222-2222-2222-2222-222222222222",
+          exo__Asset_isDefinedBy: "[[!kitelev]]",
+          exo__Asset_label: file.path,
+          exo__Instance_class: ["[[ems__Task]]"],
+        };
       });
       mockVaultAdapter.read.mockResolvedValue("# Content");
 
@@ -181,6 +193,9 @@ describe("Issue #2205: IRI Validation and Error Handling", () => {
 
       mockVaultAdapter.getAllFiles.mockReturnValue(validFiles);
       mockVaultAdapter.getFrontmatter.mockReturnValue({
+        exo__Asset_uid: "33333333-3333-3333-3333-333333333333",
+        exo__Asset_isDefinedBy: "[[!kitelev]]",
+        exo__Asset_label: "Valid File",
         exo__Instance_class: ["[[ems__Task]]"],
       });
       mockVaultAdapter.read.mockResolvedValue("# Content");


### PR DESCRIPTION
## Summary

- RFC `0810aad3-90fc-46bb-a103-26ca8172970b` Phase 2.
- Closes the partial-state leak that triggered the SPARQL crash *"Literals cannot appear in subject position"* reported in #2997. The loader now commits triples per file atomically (build → validate → commit), so a malformed asset can never leak orphan triples into the store.
- Un-skips the Phase 1 reproduction test as the active regression gate for #2997 — Phase 2 alone is sufficient (Phase 3 reinforces the property at the algebra layer).

## What changed

**`NoteToRDFConverter` (core)**

- New `validateExocortexAsset(frontmatter)` — file-level invariant validator covering all 11 bad-fixture shapes from the RFC §Phase 2 fixtures.
- Refactored `convertVaultWithValidation` into a buffer-validate-commit pipeline:
  1. Read frontmatter once.
  2. Validate file-level invariants against raw frontmatter (cheap, dictionary-level).
  3. Build the candidate triple buffer via `convertNote` (existing logic, unchanged).
  4. Commit the buffer into `allTriples` atomically.
- Public exports: `ExocortexInvariantCode` and `ExocortexInvariantViolation` for downstream callers that want structured skip reasons.

**Invariants**
- Required + non-empty: `exo__Asset_uid`, `exo__Asset_isDefinedBy`, `exo__Asset_label`, `exo__Instance_class`.
- Optional but non-empty if present: `ems__Effort_status`, `ems__Effort_parent`, `ems__Effort_lockedBy`, `ems__Effort_lockExpires`, `exo__Asset_updatedAt`, `ems__Effort_startTimestamp`.
- `exo__Instance_class` wikilink target: when carrying a known namespace prefix (`exo__`/`ems__`/etc.), must not contain whitespace or parentheses.

Validation only triggers when the frontmatter looks like an Exocortex asset (declares `exo__Instance_class` or `exo__Asset_uid`); plain markdown notes pass through unchanged.

**Tests**
- `issue-2997-loader-2pc.integration.test.ts` (cli, **new**) — 11 parametrized cases (one per bad-fixture shape) asserting `store.size == 0` and a specific `skippedFiles` reason; control case for the well-formed subtree; mixed-vault case asserting only valid files contribute triples.
- `issue-2997-repro.integration.test.ts` (cli) — un-skipped, comment updated to reflect the new role as the active regression gate.
- `NoteToRDFConverter.iri-validation.test.ts` (core) — extended mock frontmatter in 3 fixtures to include `Asset_uid`/`isDefinedBy`/`label` so the existing skip-tracking tests still exercise the catch-error branch.

## Test plan
- [x] `npm test -- tests/integration/issue-2997` (15/15 green — 11 bad-fixture cases + 1 control + 1 mixed-vault + 2 reproduction cases).
- [x] `npm test --workspace exocortex` shows no regression (29 pre-existing failures, identical to baseline).
- [x] `npm test --workspace @kitelev/exocortex-cli` shows no regression (7 pre-existing starter-kit failures, identical to baseline).
- [x] `npx tsc --noEmit --skipLibCheck` clean.
- [x] Pre-commit hook (BDD coverage + Archgate) green.
- [ ] CI: 13 required checks must go green before merge.

Refs #2997