### PR TITLE
test(ci): #2997 Phase 5 — explicit CI allow-list for regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,10 +449,15 @@ jobs:
         #   + performance/RelationColumnSetResolverPerformance.test.ts (p95 <1ms gate).
         # - Issue #2959: services/NoteToRDFConverter.issue-2959.test.ts (class-named
         #   wikilink → namespace IRI normalization regression suite).
+        # - Issue #2997 Phase 5 (RFC 0810aad3): infrastructure/sparql/executors/BGPExecutor.issue-2997.test.ts
+        #   (translator literal-safety guard regression gate). Phase 1+2 CLI integration
+        #   tests (issue-2997-repro / issue-2997-loader-2pc) run via test-coverage-cli;
+        #   BGP unit suite needs explicit allow-list entry here because exocortex
+        #   jest.config.js is otherwise unreachable from CI (see scripts/test-ci-batched.sh).
         run: |
           node ./node_modules/jest/bin/jest.js \
             --config packages/exocortex/jest.config.js \
-            --testPathPatterns='(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test)\.ts' \
+            --testPathPatterns='(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test)\.ts' \
             --forceExit
 
   test-coverage:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+**Issue #2997 Phase 5 — Regression test → CI gate (RFC `0810aad3-90fc-46bb-a103-26ca8172970b`)**: Closes #2997 ("Literals cannot appear in subject position" SPARQL crash). The Phase 1 reproduction suite (`packages/cli/tests/integration/issue-2997-repro.integration.test.ts`) was un-skipped by Phase 2 (#3004) and is now active under `test-coverage-cli`; the Phase 3 BGP literal-safety guard suite (`packages/exocortex/tests/unit/infrastructure/sparql/executors/BGPExecutor.issue-2997.test.ts`) is added to the explicit allow-list in `test-coverage-exocortex` (ci.yml + scripts/test-ci-batched.sh) so it runs as a named regression gate rather than relying on transitive test discovery. Together with `issue-2997-loader-2pc.integration.test.ts` (11 parametrized 2pc cases) the gate covers loader partial-state leak, translator literal-safety guard, and the original user-reported query shape end-to-end.
+
 **exoql:eval default ON + IQueryBodyResolver (RFC c78cc5c8 Phase 1a, PR3 / T4–T6)**: The `exoql__Query` + `exo:eval` MVP pipeline is now active. Preconditions can reference an `exoql__Query` asset by UID (`exocmd__Precondition_query`) instead of inlining the SPARQL string in frontmatter — preserving the M2 invariant that the query body lives only in the markdown ```sparql code-block.
 
 - `DEFAULT_EVAL_CONFIG.enabled` flipped from `false` to `true`

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -99,8 +99,10 @@ fi
 #   + performance/RelationColumnSetResolverPerformance.test.ts (p95 <1ms gate)
 # - Issue #2959: services/NoteToRDFConverter.issue-2959.test.ts (class-named
 #   wikilink → namespace IRI normalization regression suite)
+# - Issue #2997 Phase 5 (RFC 0810aad3): infrastructure/sparql/executors/BGPExecutor.issue-2997.test.ts
+#   (translator literal-safety guard regression gate)
 echo "📦 Running exocortex grounding + RFC regression tests..."
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test)\.ts --forceExit"
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
## Summary
- Closes #2997 Phase 5 (RFC `0810aad3-90fc-46bb-a103-26ca8172970b`).
- Adds `BGPExecutor.issue-2997.test.ts` (Phase 3 translator literal-safety guard regression suite) to the explicit allow-list in `test-coverage-exocortex` (`.github/workflows/ci.yml`) and `scripts/test-ci-batched.sh`. Before this change the suite was only matched transitively via `obsidian-plugin/jest.config.js`'s `<rootDir>/../exocortex/tests/...` testMatch — but jest's `roots` config doesn't actually pull external roots, so the file was silently absent from every CI run-list. Verified empirically with `--listTests`.
- CHANGELOG entry summarising the full Phase 1-5 closure of #2997.

## Why now
- AC «Тест добавлен в CI test workflow как required check» was met implicitly for the CLI integration tests (`issue-2997-repro`, `issue-2997-loader-2pc` run via `test-coverage-cli`), but the BGP unit suite — the lower-cost gate that would catch a regression even without the fixture vault — was effectively un-gated. Phase 5 names the gate explicitly so it survives any future testMatch refactor.

## Verification
- New allow-list resolves to 7 suites (was 6); local run: **162 tests passed** in 4s (+1 suite, +18 tests over the previous baseline).
- `test-coverage` is in `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks` (required on `main`), so the BGP suite is now protected by branch-protection.
- No source code changes — pure CI/test-orchestration + CHANGELOG.

## Test plan
- [x] Local: `--listTests` confirms `BGPExecutor.issue-2997.test.ts` is matched by the new pattern.
- [x] Local: full allow-list run — all 7 suites, 162 tests pass.
- [ ] CI: `test-coverage` (specifically `test-coverage-exocortex`) must remain green.
- [ ] CI: `archgate`, `lint`, `typecheck`, `test-bdd`, `test-component`, all 6 e2e shards green.
- [ ] Post-merge: Auto Release publishes new patch version.

Refs #2997
RFC `0810aad3-90fc-46bb-a103-26ca8172970b` Phase 5

Co-authored-by: Claude (Task 412b5992) <claude@anthropic.com>