### PR TITLE
feat(cli): #2997 Phase 4 — `validate frontmatter` actionable errors

### DIFF
--- a/packages/cli/src/commands/validate-frontmatter.ts
+++ b/packages/cli/src/commands/validate-frontmatter.ts
@@ -1,0 +1,222 @@
+import { Command } from "commander";
+import { existsSync } from "fs";
+import { resolve } from "path";
+import { execSync } from "child_process";
+import {
+  NoteToRDFConverter,
+  type ExocortexInvariantViolation,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+import { ResponseBuilder } from "../responses/index.js";
+
+export interface FrontmatterValidationOptions {
+  vault: string;
+  output?: OutputFormat;
+  staged?: boolean;
+}
+
+export interface FrontmatterError {
+  file: string;
+  code:
+    | "MISSING_PROPERTY"
+    | "EMPTY_PROPERTY"
+    | "EMPTY_OPTIONAL_PROPERTY"
+    | "INVALID_INSTANCE_CLASS_IRI"
+    | "INVALID_PATH_IRI";
+  property?: string;
+  reason: string;
+  hint: string;
+}
+
+export interface FrontmatterValidationResult {
+  vaultPath: string;
+  filesChecked: number;
+  errors: FrontmatterError[];
+  healthy: boolean;
+}
+
+/**
+ * Required-property hints by frontmatter key. Provides actionable templates
+ * the user can paste directly into a file's frontmatter.
+ */
+const MISSING_PROPERTY_HINTS: Record<string, string> = {
+  exo__Asset_uid: 'add `exo__Asset_uid: <uuid>` to frontmatter',
+  exo__Asset_isDefinedBy:
+    'add `exo__Asset_isDefinedBy: "[[!kitelev]]"` (or your own ontology marker) to frontmatter',
+  exo__Asset_label: 'add `exo__Asset_label: "<short label>"` to frontmatter',
+  exo__Instance_class:
+    'add `exo__Instance_class: ["[[<ClassName>]]"]` to frontmatter',
+};
+
+/**
+ * Translate a Phase-2 invariant violation into an actionable per-file
+ * frontmatter error. Each branch covers one of RFC 0810aad3 Phase 4
+ * acceptance scenarios — a missing required property, an empty literal,
+ * an empty optional, or a malformed Instance_class wikilink.
+ */
+export function violationToError(
+  filePath: string,
+  v: ExocortexInvariantViolation,
+): FrontmatterError {
+  switch (v.code) {
+    case "MISSING_PROPERTY":
+      return {
+        file: filePath,
+        code: v.code,
+        property: v.property,
+        reason: v.message,
+        hint:
+          MISSING_PROPERTY_HINTS[v.property] ??
+          `add \`${v.property}: <value>\` to frontmatter`,
+      };
+    case "EMPTY_PROPERTY":
+      return {
+        file: filePath,
+        code: v.code,
+        property: v.property,
+        reason: v.message,
+        hint: `set a non-empty value for \`${v.property}\` (or remove the asset markers if this file is not an Exocortex asset)`,
+      };
+    case "EMPTY_OPTIONAL_PROPERTY":
+      return {
+        file: filePath,
+        code: v.code,
+        property: v.property,
+        reason: v.message,
+        hint: `remove \`${v.property}\` from frontmatter or fill it with a non-empty value`,
+      };
+    case "INVALID_INSTANCE_CLASS_IRI":
+      return {
+        file: filePath,
+        code: v.code,
+        property: v.property,
+        reason: v.message,
+        hint: `fix the \`${v.property}\` wikilink target — namespaced classes (e.g. \`ems__\`, \`exo__\`) cannot contain whitespace or parentheses, otherwise they expand into invalid IRIs`,
+      };
+  }
+}
+
+export function getStagedMdFiles(vaultPath: string): string[] {
+  try {
+    const stdout = execSync("git diff --cached --name-only", {
+      cwd: vaultPath,
+      encoding: "utf-8",
+    });
+    return stdout
+      .split("\n")
+      .filter((f) => f.endsWith(".md") && f.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Issue #2997 Phase 4: Per-file actionable frontmatter validation.
+ *
+ * Walks the vault (or just git-staged .md files), parses each file's
+ * frontmatter and runs Phase-2 file-level invariants, plus a path → IRI
+ * conversion guard. Each violation is turned into an error that contains
+ * the file path, the offending property, and a concrete hint describing
+ * how to fix it.
+ *
+ * Exits non-zero when at least one error is reported, so the command
+ * can be wired into pre-commit and CI pipelines.
+ */
+export function validateFrontmatterCommand(): Command {
+  return new Command("frontmatter")
+    .description(
+      "Check vault frontmatter for missing/empty properties and malformed IRIs (Issue #2997 Phase 4)",
+    )
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option(
+      "--output <type>",
+      "Response format: text|json (for MCP tools)",
+      "text",
+    )
+    .option(
+      "--staged",
+      "Only validate git-staged .md files (for pre-commit hooks)",
+    )
+    .action(async (options: FrontmatterValidationOptions) => {
+      const outputFormat = (options.output || "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const adapter = new FileSystemVaultAdapter(vaultPath);
+        const converter = new NoteToRDFConverter(adapter);
+
+        let files = adapter.getAllFiles();
+        if (options.staged) {
+          const staged = new Set(getStagedMdFiles(vaultPath));
+          files = files.filter((f) => staged.has(f.path));
+        }
+
+        const errors: FrontmatterError[] = [];
+        for (const file of files) {
+          const fm = adapter.getFrontmatter(file);
+          if (fm) {
+            const violation = converter.validateExocortexAsset(fm);
+            if (violation) {
+              errors.push(violationToError(file.path, violation));
+            }
+          }
+          // Guard the path → IRI conversion — captures filenames that cannot
+          // be percent-encoded into a valid `obsidian://vault/...` IRI
+          // (the loader skips such files with "Invalid IRI format" today).
+          try {
+            converter.notePathToIRI(file.path);
+          } catch (e) {
+            const reason = e instanceof Error ? e.message : String(e);
+            errors.push({
+              file: file.path,
+              code: "INVALID_PATH_IRI",
+              reason: `Invalid IRI format for vault path: ${reason}`,
+              hint: `rename the file — its path \`${file.path}\` cannot be encoded into a valid \`obsidian://vault/...\` IRI (avoid raw whitespace, control characters, and angle brackets)`,
+            });
+          }
+        }
+
+        const result: FrontmatterValidationResult = {
+          vaultPath,
+          filesChecked: files.length,
+          errors,
+          healthy: errors.length === 0,
+        };
+
+        if (outputFormat === "json") {
+          console.log(
+            JSON.stringify(ResponseBuilder.success(result), null, 2),
+          );
+        } else if (errors.length === 0) {
+          console.log(
+            `✅ All ${files.length} file(s) pass frontmatter validation.`,
+          );
+        } else {
+          console.log(
+            `⚠️  Found ${errors.length} frontmatter error(s) in ${new Set(errors.map((e) => e.file)).size} file(s):\n`,
+          );
+          for (const err of errors) {
+            console.log(`   ❌ ${err.file}`);
+            console.log(`      ${err.reason}`);
+            console.log(`      💡 ${err.hint}`);
+          }
+          console.log(
+            "\n📝 These shapes prevented the file from loading into the SPARQL store (Issue #2997 Phase 2). Fix them so the asset can be indexed.",
+          );
+        }
+
+        if (errors.length > 0) {
+          process.exitCode = 1;
+        }
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -6,6 +6,7 @@ import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { ResponseBuilder } from "../responses/index.js";
 import { validateSchemaCommand } from "./validate-schema.js";
+import { validateFrontmatterCommand } from "./validate-frontmatter.js";
 
 export interface ValidateOptions {
   vault: string;
@@ -91,10 +92,13 @@ function validateIriCommand(): Command {
  */
 export function validateCommand(): Command {
   const cmd = new Command("validate")
-    .description("Validate vault files (IRI checks, schema linting)");
+    .description(
+      "Validate vault files (IRI checks, schema linting, frontmatter shapes)",
+    );
 
   cmd.addCommand(validateIriCommand());
   cmd.addCommand(validateSchemaCommand());
+  cmd.addCommand(validateFrontmatterCommand());
 
   return cmd;
 }

--- a/packages/cli/tests/unit/commands/validate-frontmatter.test.ts
+++ b/packages/cli/tests/unit/commands/validate-frontmatter.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Issue #2997 Phase 4: Unit tests for `exocortex-cli validate frontmatter`.
+ *
+ * Each scenario in the RFC's acceptance criteria gets its own test:
+ *   1. Missing `exo__Asset_uid` → actionable error with file path + hint.
+ *   2. Missing `exo__Asset_isDefinedBy` → actionable error with file path + hint.
+ *   3. Empty literal property → actionable error with file path + property + hint.
+ *   4. Invalid Instance_class IRI → actionable error with file path + IRI nature.
+ *   5. Clean vault → no errors.
+ *
+ * Plus:
+ *   - The `violationToError` mapper covers each invariant code.
+ *   - The command is registered as a `frontmatter` subcommand.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const {
+  validateFrontmatterCommand,
+  violationToError,
+} = await import("../../../src/commands/validate-frontmatter.js");
+
+const { NoteToRDFConverter } = await import("exocortex");
+const { FileSystemVaultAdapter } = await import(
+  "../../../src/adapters/FileSystemVaultAdapter.js"
+);
+
+function createTmpVault(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "exocortex-validate-fm-"));
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, "utf-8");
+}
+
+/**
+ * Helper: run the same per-file pipeline that the command's `.action`
+ * runs, but inline so we can assert on the structured error list without
+ * spinning up Commander's process-exit machinery.
+ */
+function collectErrors(vaultPath: string) {
+  const adapter = new FileSystemVaultAdapter(vaultPath);
+  const converter = new NoteToRDFConverter(adapter);
+  const errors = [];
+  for (const file of adapter.getAllFiles()) {
+    const fm = adapter.getFrontmatter(file);
+    if (fm) {
+      const violation = converter.validateExocortexAsset(fm);
+      if (violation) errors.push(violationToError(file.path, violation));
+    }
+    try {
+      converter.notePathToIRI(file.path);
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      errors.push({
+        file: file.path,
+        code: "INVALID_PATH_IRI" as const,
+        reason: `Invalid IRI format for vault path: ${reason}`,
+        hint: `rename the file — its path \`${file.path}\` cannot be encoded into a valid \`obsidian://vault/...\` IRI (avoid raw whitespace, control characters, and angle brackets)`,
+      });
+    }
+  }
+  return errors;
+}
+
+describe("Issue #2997 Phase 4: validate frontmatter command", () => {
+  let vault: string;
+
+  beforeEach(() => {
+    vault = createTmpVault();
+  });
+
+  afterEach(() => {
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("registers a 'frontmatter' subcommand with --vault, --output, --staged options", () => {
+    const cmd = validateFrontmatterCommand();
+    expect(cmd.name()).toBe("frontmatter");
+
+    const flags = (cmd as any).options.map((o: any) => o.long);
+    expect(flags).toEqual(
+      expect.arrayContaining(["--vault", "--output", "--staged"]),
+    );
+  });
+
+  describe("AC1: missing exo__Asset_uid", () => {
+    it("reports file path + hint to add `exo__Asset_uid: <uuid>` to frontmatter", () => {
+      writeFile(
+        vault,
+        "bad-uid.md",
+        `---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_label: "no uid"
+exo__Instance_class:
+  - "[[ems__Task]]"
+---
+body
+`,
+      );
+
+      const errors = collectErrors(vault);
+      const err = errors.find(
+        (e) =>
+          e.code === "MISSING_PROPERTY" &&
+          (e as any).property === "exo__Asset_uid",
+      );
+      expect(err).toBeDefined();
+      expect(err!.file).toBe("bad-uid.md");
+      expect(err!.hint).toMatch(/exo__Asset_uid/);
+      expect(err!.hint).toMatch(/<uuid>/);
+    });
+  });
+
+  describe("AC2: missing exo__Asset_isDefinedBy", () => {
+    it("reports file path + hint to add `exo__Asset_isDefinedBy`", () => {
+      writeFile(
+        vault,
+        "bad-defined-by.md",
+        `---
+exo__Asset_uid: 11111111-1111-1111-1111-111111111111
+exo__Asset_label: "no defined-by"
+exo__Instance_class:
+  - "[[ems__Task]]"
+---
+body
+`,
+      );
+
+      const errors = collectErrors(vault);
+      const err = errors.find(
+        (e) =>
+          e.code === "MISSING_PROPERTY" &&
+          (e as any).property === "exo__Asset_isDefinedBy",
+      );
+      expect(err).toBeDefined();
+      expect(err!.file).toBe("bad-defined-by.md");
+      expect(err!.hint).toMatch(/exo__Asset_isDefinedBy/);
+      expect(err!.hint).toMatch(/\[\[!kitelev\]\]/);
+    });
+  });
+
+  describe("AC3: empty literal property", () => {
+    it("reports file path + property name + hint when a required property is empty", () => {
+      writeFile(
+        vault,
+        "empty-label.md",
+        `---
+exo__Asset_uid: 22222222-2222-2222-2222-222222222222
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_label: ""
+exo__Instance_class:
+  - "[[ems__Task]]"
+---
+`,
+      );
+
+      const errors = collectErrors(vault);
+      const err = errors.find(
+        (e) =>
+          e.code === "EMPTY_PROPERTY" &&
+          (e as any).property === "exo__Asset_label",
+      );
+      expect(err).toBeDefined();
+      expect(err!.file).toBe("empty-label.md");
+      expect(err!.hint).toMatch(/exo__Asset_label/);
+      expect(err!.hint).toMatch(/non-empty value|remove/);
+    });
+
+    it("reports the property name when an optional property is present but empty", () => {
+      writeFile(
+        vault,
+        "empty-status.md",
+        `---
+exo__Asset_uid: 33333333-3333-3333-3333-333333333333
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_label: "task"
+exo__Instance_class:
+  - "[[ems__Task]]"
+ems__Effort_status: ""
+---
+`,
+      );
+
+      const errors = collectErrors(vault);
+      const err = errors.find(
+        (e) =>
+          e.code === "EMPTY_OPTIONAL_PROPERTY" &&
+          (e as any).property === "ems__Effort_status",
+      );
+      expect(err).toBeDefined();
+      expect(err!.file).toBe("empty-status.md");
+      expect(err!.hint).toMatch(/ems__Effort_status/);
+      expect(err!.hint).toMatch(/remove|non-empty/);
+    });
+  });
+
+  describe("AC4: Invalid IRI format (Instance_class wikilink)", () => {
+    it("reports file path + nature of malformed IRI when Instance_class contains spaces or parens", () => {
+      writeFile(
+        vault,
+        "bad-class.md",
+        `---
+exo__Asset_uid: 44444444-4444-4444-4444-444444444444
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_label: "bad class"
+exo__Instance_class:
+  - "[[ems__Effort (legacy)]]"
+---
+`,
+      );
+
+      const errors = collectErrors(vault);
+      const err = errors.find(
+        (e) => e.code === "INVALID_INSTANCE_CLASS_IRI",
+      );
+      expect(err).toBeDefined();
+      expect(err!.file).toBe("bad-class.md");
+      expect(err!.reason).toMatch(/Invalid Instance_class IRI/);
+      expect(err!.hint).toMatch(/whitespace|parentheses/);
+    });
+  });
+
+  describe("AC5: clean vault → no errors", () => {
+    it("returns zero errors when every asset satisfies invariants", () => {
+      writeFile(
+        vault,
+        "good.md",
+        `---
+exo__Asset_uid: 55555555-5555-5555-5555-555555555555
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_label: "good"
+exo__Instance_class:
+  - "[[ems__Task]]"
+---
+body
+`,
+      );
+      writeFile(
+        vault,
+        "plain-note.md",
+        `# heading
+
+a plain markdown note with no frontmatter
+`,
+      );
+
+      const errors = collectErrors(vault);
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe("violationToError mapper", () => {
+    it("maps MISSING_PROPERTY for exo__Asset_uid to a uid-template hint", () => {
+      const err = violationToError("a.md", {
+        code: "MISSING_PROPERTY",
+        property: "exo__Asset_uid",
+        message: 'Required property "exo__Asset_uid" is missing',
+      });
+      expect(err.code).toBe("MISSING_PROPERTY");
+      expect(err.file).toBe("a.md");
+      expect(err.hint).toContain("exo__Asset_uid");
+      expect(err.hint).toContain("<uuid>");
+    });
+
+    it("maps MISSING_PROPERTY for exo__Asset_isDefinedBy to an ontology-marker hint", () => {
+      const err = violationToError("a.md", {
+        code: "MISSING_PROPERTY",
+        property: "exo__Asset_isDefinedBy",
+        message: 'Required property "exo__Asset_isDefinedBy" is missing',
+      });
+      expect(err.hint).toContain("exo__Asset_isDefinedBy");
+      expect(err.hint).toContain("[[!kitelev]]");
+    });
+
+    it("maps EMPTY_PROPERTY to a fill-or-remove hint", () => {
+      const err = violationToError("a.md", {
+        code: "EMPTY_PROPERTY",
+        property: "exo__Asset_label",
+        message: 'Required property "exo__Asset_label" is empty',
+      });
+      expect(err.hint).toMatch(/non-empty/);
+      expect(err.hint).toContain("exo__Asset_label");
+    });
+
+    it("maps EMPTY_OPTIONAL_PROPERTY to a remove-or-fill hint", () => {
+      const err = violationToError("a.md", {
+        code: "EMPTY_OPTIONAL_PROPERTY",
+        property: "ems__Effort_status",
+        message: 'Optional property "ems__Effort_status" is present but empty',
+      });
+      expect(err.hint).toMatch(/remove|non-empty/);
+      expect(err.hint).toContain("ems__Effort_status");
+    });
+
+    it("maps INVALID_INSTANCE_CLASS_IRI to a wikilink-fix hint", () => {
+      const err = violationToError("a.md", {
+        code: "INVALID_INSTANCE_CLASS_IRI",
+        property: "exo__Instance_class",
+        message: 'Invalid Instance_class IRI: "[[ems__Foo (bar)]]"',
+      });
+      expect(err.hint).toMatch(/whitespace|parentheses/);
+    });
+  });
+});

--- a/packages/cli/tests/unit/commands/validate.test.ts
+++ b/packages/cli/tests/unit/commands/validate.test.ts
@@ -68,6 +68,12 @@ describe("Issue #2346: validate command", () => {
     expect(schemaCmd).toBeDefined();
   });
 
+  it("should have 'frontmatter' subcommand (Issue #2997 Phase 4)", () => {
+    const cmd = validateCommand();
+    const fmCmd = cmd.commands.find((c: any) => c.name() === "frontmatter");
+    expect(fmCmd).toBeDefined();
+  });
+
   it("iri subcommand should have optional --vault option with default value", () => {
     const cmd = validateCommand();
     const iriCmd = cmd.commands.find((c: any) => c.name() === "iri") as any;

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -242,7 +242,11 @@ export { NonInheritablePropertyRegistry } from "./services/NonInheritablePropert
 export { PropertyCardinalityRegistry } from "./services/PropertyCardinalityRegistry";
 export { PrototypeChainMaterializer, INFERRED_GRAPH } from "./services/PrototypeChainMaterializer";
 export { SourceAnnotator, SOURCE_VARIABLE, type TripleSource } from "./services/SourceAnnotator";
-export { NoteToRDFConverter } from "./services/NoteToRDFConverter";
+export {
+  NoteToRDFConverter,
+  type ExocortexInvariantCode,
+  type ExocortexInvariantViolation,
+} from "./services/NoteToRDFConverter";
 
 // SPARQL Engine exports
 export { ExoQLParser, SPARQLParser, SPARQLParseError, type SPARQLQuery, type SelectQuery, type ConstructQuery, type Update, type UpdateOperation, type ExtendedDescribeQuery, type ParseResult } from "./infrastructure/sparql/SPARQLParser";


### PR DESCRIPTION
## Summary

RFC `0810aad3-90fc-46bb-a103-26ca8172970b` Phase 4. Closes the Phase 4 task `dc0e772e-2679-49c6-9a99-340e0d460ba8` of issue #2997.

Adds `exocortex-cli validate frontmatter` — a per-file lint that surfaces every Phase-2 invariant violation as an actionable error with a paste-ready hint:

- missing `exo__Asset_uid` → hint to add `exo__Asset_uid: <uuid>`
- missing `exo__Asset_isDefinedBy` → hint to add the `[[!kitelev]]` (or own) ontology marker
- empty required/optional literal → hint to fill or remove the property
- malformed `exo__Instance_class` IRI → hint to drop whitespace/parentheses

The command reuses `NoteToRDFConverter.validateExocortexAsset` (Phase 2) so loader and CLI never drift, and adds a path → IRI guard for the "Invalid IRI format" shape from RFC §Phase 2 fixtures.

Exit code is `1` when at least one error is reported, `0` on a clean vault — wireable into pre-commit and CI.

## Acceptance Criteria

- [x] Missing `exo__Asset_uid` → error contains file path + actionable hint
- [x] Missing `exo__Asset_isDefinedBy` → error contains file path + actionable hint
- [x] Empty literal → error contains file path + property name + fill-or-remove hint
- [x] Invalid Instance_class IRI → error contains file path + nature of malformation
- [x] Exit code != 0 on any error; exit 0 on clean vault
- [x] Unit tests per scenario (12 tests, all passing)

## Test plan
- [x] `npm test` for `tests/unit/commands/validate*.test.ts` — 62 tests pass (10 validate + 50 schema + 12 frontmatter)
- [x] CLI smoke: `validate frontmatter --vault <fixture>` outputs actionable errors and exits 1
- [x] CLI smoke: clean vault → "✅ All N file(s) pass frontmatter validation." exits 0
- [x] CLI smoke: `--output json` returns structured `errors[]` with `code`, `file`, `property`, `reason`, `hint`
- [x] Pre-commit hook (lint, typecheck, BDD coverage 100%, archgate 13/13) green