### PR TITLE
feat(services): wire createNarrowerConcept + createSubclass to ServiceRegistry

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -13,6 +13,8 @@ import {
   FolderRepairService,
   PropertyCleanupService,
   RenameToUidService,
+  ConceptCreationService,
+  ClassCreationService,
   DateFormatter,
   type IGroundingService,
   type UserInput,
@@ -291,6 +293,8 @@ export function populateServiceRegistry(
     const fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
     const renameToUidService = new RenameToUidService(vaultAdapter);
     const folderRepairService = new FolderRepairService(vaultAdapter);
+    const conceptCreationService = new ConceptCreationService(vaultAdapter);
+    const classCreationService = new ClassCreationService(vaultAdapter);
 
     registry.register(
       "rollbackStatus",
@@ -499,6 +503,60 @@ export function populateServiceRegistry(
           return;
         }
         await folderRepairService.repairFolder(iFile, expectedFolder);
+      }),
+    );
+
+    registry.register(
+      "createNarrowerConcept",
+      wrapService(async (targetIRI: string, userInput?: UserInput) => {
+        // Create a child ims__Concept whose ims__Concept_broader points to the
+        // current target concept. Wraps existing ConceptCreationService (which
+        // was previously orphaned: no service_call wiring → no UI button could
+        // invoke it). Mirrors createRelatedTask pattern: resolve target file,
+        // call domain service, open created file. See RFC 5a61a359 Phase C.2.
+        const label = userInput?.label as string | undefined;
+        if (!label) throw new Error("createNarrowerConcept requires userInput.label");
+        const definition = (userInput?.definition as string | undefined) ?? "";
+        const aliasesInput = userInput?.aliases;
+        const aliases = Array.isArray(aliasesInput)
+          ? aliasesInput.map(String)
+          : typeof aliasesInput === "string" && aliasesInput.length > 0
+            ? [aliasesInput]
+            : [];
+        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
+        const createdFile = await conceptCreationService.createNarrowerConcept(
+          iFile,
+          label,
+          definition,
+          aliases,
+        );
+        const tfile = vaultAdapter.toTFile(createdFile);
+        const leaf = app.workspace.getLeaf("tab");
+        await leaf.openFile(tfile);
+        app.workspace.setActiveLeaf(leaf, { focus: true });
+      }),
+    );
+
+    registry.register(
+      "createSubclass",
+      wrapService(async (targetIRI: string, userInput?: UserInput) => {
+        // Create a child exo__Class whose exo__Class_superClass points to the
+        // current target class. Wraps existing ClassCreationService (previously
+        // orphaned). See RFC 5a61a359 Phase C.3.
+        const label = userInput?.label as string | undefined;
+        if (!label) throw new Error("createSubclass requires userInput.label");
+        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
+        const parentMetadata =
+          (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
+        const createdFile = await classCreationService.createSubclass(
+          iFile,
+          label,
+          parentMetadata,
+        );
+        const tfile = vaultAdapter.toTFile(createdFile);
+        const leaf = app.workspace.getLeaf("tab");
+        await leaf.openFile(tfile);
+        app.workspace.setActiveLeaf(leaf, { focus: true });
       }),
     );
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -137,6 +137,8 @@ describe("ServiceRegistryPopulator", () => {
       "fixMissingLabel",
       "renameToUid",
       "repairFolder",
+      "createNarrowerConcept",
+      "createSubclass",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -467,6 +469,8 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       "fixMissingLabel",
       "renameToUid",
       "repairFolder",
+      "createNarrowerConcept",
+      "createSubclass",
       "createTaskForDailyNote",
     ];
     for (const id of vaultDependentIds) {
@@ -712,6 +716,92 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       const service = registry.get("createRelatedProject")!;
       await expect(service.execute("test-uid-123", {})).rejects.toThrow(
         "createRelatedProject requires userInput.label",
+      );
+    });
+  });
+
+  describe("createNarrowerConcept", () => {
+    it("should create child concept with ims__Concept_broader pointing to parent", async () => {
+      const service = registry.get("createNarrowerConcept")!;
+      await service.execute("test-uid-123", { label: "Child Concept" });
+
+      expect(deps.vaultAdapter!.create).toHaveBeenCalledWith(
+        expect.stringContaining("concepts/Child Concept.md"),
+        expect.stringContaining("ims__Concept_broader: \"[[test-uid-123]]\""),
+      );
+    });
+
+    it("should accept optional definition and aliases", async () => {
+      const service = registry.get("createNarrowerConcept")!;
+      await service.execute("test-uid-123", {
+        label: "Child",
+        definition: "A narrower concept",
+        aliases: ["alt-label"],
+      });
+
+      const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
+      const content = createCall[1] as string;
+      expect(content).toContain("ims__Concept_definition: A narrower concept");
+      expect(content).toContain("alt-label");
+    });
+
+    it("should open the created concept in a new tab leaf", async () => {
+      const service = registry.get("createNarrowerConcept")!;
+      await service.execute("test-uid-123", { label: "Visible Concept" });
+
+      expect(deps.app.workspace.getLeaf).toHaveBeenCalledWith("tab");
+      expect(deps.vaultAdapter!.toTFile).toHaveBeenCalled();
+      const leafMock = (deps.app.workspace.getLeaf as jest.Mock).mock.results[0].value;
+      expect(leafMock.openFile).toHaveBeenCalled();
+      expect(deps.app.workspace.setActiveLeaf).toHaveBeenCalledWith(
+        leafMock,
+        { focus: true },
+      );
+    });
+
+    it("should throw when label is missing", async () => {
+      const service = registry.get("createNarrowerConcept")!;
+      await expect(service.execute("test-uid-123", {})).rejects.toThrow(
+        "createNarrowerConcept requires userInput.label",
+      );
+    });
+  });
+
+  describe("createSubclass", () => {
+    it("should create child class with exo__Class_superClass pointing to parent", async () => {
+      const service = registry.get("createSubclass")!;
+      await service.execute("test-uid-123", { label: "ChildClass" });
+
+      expect(deps.vaultAdapter!.create).toHaveBeenCalledWith(
+        expect.stringContaining("classes/childclass.md"),
+        expect.stringContaining("exo__Class_superClass: \"[[test-uid-123]]\""),
+      );
+    });
+
+    it("should write exo__Instance_class as exo__Class", async () => {
+      const service = registry.get("createSubclass")!;
+      await service.execute("test-uid-123", { label: "MyClass" });
+
+      const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
+      const content = createCall[1] as string;
+      expect(content).toContain("exo__Instance_class");
+      expect(content).toContain("[[exo__Class]]");
+    });
+
+    it("should open the created class in a new tab leaf", async () => {
+      const service = registry.get("createSubclass")!;
+      await service.execute("test-uid-123", { label: "VisibleClass" });
+
+      expect(deps.app.workspace.getLeaf).toHaveBeenCalledWith("tab");
+      expect(deps.vaultAdapter!.toTFile).toHaveBeenCalled();
+      const leafMock = (deps.app.workspace.getLeaf as jest.Mock).mock.results[0].value;
+      expect(leafMock.openFile).toHaveBeenCalled();
+    });
+
+    it("should throw when label is missing", async () => {
+      const service = registry.get("createSubclass")!;
+      await expect(service.execute("test-uid-123", {})).rejects.toThrow(
+        "createSubclass requires userInput.label",
       );
     });
   });


### PR DESCRIPTION
## Summary

Adds two `service_call` targets to `ServiceRegistryPopulator` (in `if (vaultAdapter)` block):

- `createNarrowerConcept` — wraps existing `ConceptCreationService.createNarrowerConcept`. Creates child `ims__Concept` with `ims__Concept_broader: [[<target>]]`. Accepts optional `definition` and `aliases`.
- `createSubclass` — wraps existing `ClassCreationService.createSubclass`. Creates child `exo__Class` with `exo__Class_superClass: [[<target>]]`.

Both services existed in `packages/exocortex/src/services/` (with `@injectable()` + DI registration in `infrastructure/container.ts`) but were **orphaned**: no `service_call` Grounding could invoke them. This unblocks vault-only Phase C.2/C.3 of RFC `5a61a359-d76b-4f6c-9bff-624ddcec42b8` (v15.38.0 UI Parity Restoration) — restores 2 of 3 v15.38.0 baseline CREATION buttons that regressed during RDF migration.

## Test plan

- [x] +8 unit tests in `ServiceRegistryPopulator.test.ts` (4 per service: linkback, optional fields, open-in-tab UX, missing-label error)
- [x] Existing 76 tests in same file still pass (84 total)
- [x] Pre-commit gates pass (lint, BDD 100%, archgate 13/13)
- [ ] CI green (13 required checks)
- [ ] Auto Release publishes new version

## After merge

PMBOK project `0991eb22` Phase C.2/C.3 vault wiring proceeds:
- Phase C.2: 1 Command + 1 Grounding (`service_call → createNarrowerConcept`) + 1 CommandBinding (`targetClass: ims__Concept`) + 1 Precondition
- Phase C.3: same shape for `createSubclass` on `exo__Class`