### PR TITLE
fix(sparql): resolve inconvertible types comparison in FilterExecutor (Fixes #2849)

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -357,7 +357,7 @@ export class FilterExecutor {
     if (value === undefined || value === null) {
       return { type: "literal", value: "" } as unknown as Expression;
     }
-    if (typeof value === "object" && value !== null && "termType" in (value as object)) {
+    if (value !== null && typeof value === "object" && "termType" in value) {
       return value as unknown as Expression;
     }
     if (value instanceof IRI || value instanceof Literal) {

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/FilterExecutor.test.ts
@@ -1052,6 +1052,44 @@ describe("FilterExecutor", () => {
     });
   });
 
+  describe("wrapAsLiteralExpression (regression #2849)", () => {
+    type WrapFn = (value: unknown) => { type: string; value: unknown; termType?: string };
+    const getWrap = (): WrapFn =>
+      (executor as unknown as { wrapAsLiteralExpression: WrapFn }).wrapAsLiteralExpression.bind(executor);
+
+    it("should return empty literal for null without throwing", () => {
+      const wrap = getWrap();
+      expect(() => wrap(null)).not.toThrow();
+      expect(wrap(null)).toEqual({ type: "literal", value: "" });
+    });
+
+    it("should return empty literal for undefined", () => {
+      const wrap = getWrap();
+      expect(wrap(undefined)).toEqual({ type: "literal", value: "" });
+    });
+
+    it("should preserve RDF term-like objects with termType", () => {
+      const wrap = getWrap();
+      const term = { termType: "Literal", value: "hello" };
+      expect(wrap(term)).toBe(term);
+    });
+
+    it("should wrap primitives as literals", () => {
+      const wrap = getWrap();
+      expect(wrap(42)).toEqual({ type: "literal", value: 42 });
+      expect(wrap(true)).toEqual({ type: "literal", value: true });
+      expect(wrap("foo")).toEqual({ type: "literal", value: "foo" });
+    });
+
+    it("should not misclassify null as a term-like object", () => {
+      // Null has typeof === "object" — verifies null-first guard prevents
+      // accidental "in" operator on null (TypeError) and CodeQL alert #303.
+      const wrap = getWrap();
+      const result = wrap(null);
+      expect(result).toEqual({ type: "literal", value: "" });
+    });
+  });
+
   describe("Streaming", () => {
     it("should support streaming iteration", async () => {
       const operation: FilterOperation = {


### PR DESCRIPTION
## Summary

Fixes #2849 — CodeQL alert `js/comparison-between-incompatible-types` (ID 303) at `packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts:360`.

## Root cause

In `wrapAsLiteralExpression`, the guard ordering was:

```ts
if (typeof value === "object" && value !== null && "termType" in (value as object)) {
```

CodeQL's flow analysis narrowed `value` to `date | object | regex` (excluding null) after the `typeof === "object"` check, then flagged `value !== null` as a comparison between inconvertible types (always-true).

## Fix

Reorder so the null guard runs first; semantically identical, but type-safe per CodeQL:

```ts
if (value !== null && typeof value === "object" && "termType" in value) {
```

The `(value as object)` cast becomes unnecessary because `typeof === "object"` already narrows.

## Tests

Added `wrapAsLiteralExpression (regression #2849)` describe block with 5 cases covering null, undefined, RDF term-like objects, primitives, and explicit null-misclassification guard.

## Verification

- `npm run check:types` — clean
- `npm run lint` — clean
- `FilterExecutor.test.ts` — 159/159 pass