### PR TITLE
feat: drop legacy `_group` parsing from CommandBinding (RFC f1dc284a Phase 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,9 @@ Rollback procedure: `docs/ROLLBACK_EXOQL_EVAL.md`. T7 (CI drift-guard + scoped E
 
 **`property_set` Grounding Verified with YAML Arrays of Wikilinks (RFC-016 Blocker 3)**: Confirmed and tested that `property_set` grounding correctly handles YAML arrays of wikilinks (`[[uuid|label]]`), ensuring plugin commands can set multi-valued properties declaratively.
 
-### Deprecated
+### Removed
 
-**`exocmd__CommandBinding_group` property (RFC command-variant-split)**: Use `exocmd__CommandBinding_variant` instead. The parser still tolerates legacy `_group` for one release — when both `_group` and `_variant` appear on the same binding, `_variant` wins and a capped warning is logged. Starter-kit assets have been migrated to drop `_group` (kitelev/exocortex-starter-kit#94).
+**`exocmd__CommandBinding_group` parsing dropped (RFC `f1dc284a-eadc-4d0e-8e72-323e999ea510` Phase 8)**: After two release windows of deprecation, `binding.group` is gone. The `CommandBindingDefinition` interface no longer exposes a `group` field, `CommandResolver.loadBindingDefinition` no longer reads `exocmd__CommandBinding_group`, the coexistence-warning log line is removed, and `CommandBindingProperty.GROUP` is deleted from the constants table. Existing user vaults that still ship the legacy `_group` frontmatter remain valid markdown — the parser silently ignores the unknown property (verified by parser unit test + retained E2E fixtures). Starter-kit assets were migrated in kitelev/exocortex-starter-kit#94. Use `exocmd__CommandBinding_variant` for per-binding button-color overrides.
 
 ### Note
 

--- a/packages/exocortex/src/domain/constants/CommandProperty.ts
+++ b/packages/exocortex/src/domain/constants/CommandProperty.ts
@@ -58,8 +58,6 @@ export const CommandBindingProperty = {
   POSITION: "exocmd__CommandBinding_position",
   /** Sort order among buttons (default: 100) */
   ORDER: "exocmd__CommandBinding_order",
-  /** Button group name for grouping related commands */
-  GROUP: "exocmd__CommandBinding_group",
   /** Override command-level precondition for this binding (wikilink) */
   PRECONDITION: "exocmd__CommandBinding_precondition",
   /** Optional reference to exocmd__CommandBindingStyle asset (wikilink, RFC-024 §4 Phase 2) */

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -127,14 +127,6 @@ export interface CommandBindingDefinition {
   /** Sort order (default: 100) */
   readonly order?: number;
   /**
-   * @deprecated Button group name (legacy). Use `variant` for explicit per-binding
-   * button variant override. Parser still reads `_group` for backward compat,
-   * but prefers `_variant` when both are present (logs warning). RFC
-   * f1dc284a-eadc-4d0e-8e72-323e999ea510 — removal scheduled for next release
-   * after starter-kit migration.
-   */
-  readonly group?: string;
-  /**
    * Per-binding button variant override (RFC command-variant-split,
    * f1dc284a-eadc-4d0e-8e72-323e999ea510). Populated from
    * `exocmd__CommandBinding_variant` frontmatter literal. When absent, UI
@@ -151,8 +143,8 @@ export interface CommandBindingDefinition {
    *    CommandBindingStyle asset (preferred — reusable across bindings).
    * 2. `exocmd__CommandBinding_variant` inline literal → synthesize
    *    minimal style with only `variant` set.
-   * 3. Neither present → `style` is `undefined`; UI applies group-based
-   *    Phase 0 default via `resolveVariant(group)`.
+   * 3. Neither present → `style` is `undefined`; UI applies category-based
+   *    default via `resolveDefaultVariantForCategory(command.category)`.
    *
    * Invalid enum values are coerced (lowercase + trim) and dropped to
    * `undefined` after warning (RFC-024 §5 — never crash).

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -371,11 +371,15 @@ export class CommandResolver {
     // Load display options
     const position = await this.getLiteralValue(subject, Namespace.EXOCMD.term("CommandBinding_position"));
     const orderStr = await this.getLiteralValue(subject, Namespace.EXOCMD.term("CommandBinding_order"));
-    const group = await this.getLiteralValue(subject, Namespace.EXOCMD.term("CommandBinding_group"));
 
     // RFC command-variant-split (f1dc284a) — top-level variant override.
     // Read `_variant` literal directly so callers can use `binding.variant`
     // without having to walk the legacy RFC-024 inline-style path.
+    //
+    // Legacy `exocmd__CommandBinding_group` was removed in RFC f1dc284a
+    // Phase 8 (`drop _group parsing`). Existing vaults with `_group`
+    // frontmatter remain valid markdown — the parser silently ignores the
+    // unknown property.
     const variantRawForBinding = await this.getLiteralValue(
       subject,
       Namespace.EXOCMD.term("CommandBinding_variant"),
@@ -384,17 +388,6 @@ export class CommandResolver {
       variantRawForBinding !== null
         ? this.coerceVariant(variantRawForBinding, uid)
         : undefined;
-
-    // Coexistence guard: if binding declares both legacy `_group` and
-    // explicit `_variant`, log a (capped) warning so legacy bindings can be
-    // migrated. `_variant` always wins downstream (builder precedence).
-    if (group !== null && variantRawForBinding !== null) {
-      this.logger.warn(
-        this.capWarning(
-          `CommandBinding ${uid}: both _group and _variant present; preferring _variant (${String(variantRawForBinding)})`,
-        ),
-      );
-    }
 
     // Load binding-level precondition override
     const precondition = await this.loadLinkedPreconditionFromProperty(
@@ -414,7 +407,6 @@ export class CommandResolver {
       targetAsset: targetAsset ?? undefined,
       position: position ?? undefined,
       order: orderStr ? parseInt(orderStr, 10) : undefined,
-      group: group ?? undefined,
       variant,
       precondition: precondition ?? undefined,
       style: style ?? undefined,
@@ -433,7 +425,7 @@ export class CommandResolver {
    * whitelist via `COMMAND_VARIANT_VALUES`, drop with capped warning on miss.
    *
    * Returns `null` when neither source is present — caller treats as
-   * "delegate to UI-level group default" (Phase 0 `categoryDefaultVariant`).
+   * "delegate to UI-level category default" (`categoryDefaultVariant`).
    *
    * Strategy: split-query (separate `match()` calls per property), **not**
    * SPARQL OPTIONAL — see RFC-024 §3 architectural principle.

--- a/packages/exocortex/tests/integration/dynamic-commands/remove-start-timestamp.test.ts
+++ b/packages/exocortex/tests/integration/dynamic-commands/remove-start-timestamp.test.ts
@@ -312,14 +312,16 @@ describe("Issue #2494: Remove Start Timestamp — dynamic command pipeline integ
       expect(grounding.targetProperty).toBe("ems__Effort_startTimestamp");
     });
 
-    it("should load binding metadata (position, order, group)", async () => {
+    it("should load binding metadata (position, order, targetClass) and silently ignore legacy `_group`", async () => {
       const commands = await resolver.resolveForAsset(ASSET_IRI, "ems__Task");
       const binding = commands[0].binding;
 
       expect(binding.position).toBe("header");
       expect(binding.order).toBe(10);
-      expect(binding.group).toBe("maintenance");
       expect(binding.targetClass).toBe("ems__Task");
+      // RFC f1dc284a Phase 8 — `_group` parsing dropped. Fixture still emits
+      // the legacy triple to verify parser silently ignores it.
+      expect((binding as { group?: string }).group).toBeUndefined();
     });
 
     it("should NOT resolve command for a non-matching class (ems__Project)", async () => {

--- a/packages/exocortex/tests/unit/domain/constants/CommandConstants.test.ts
+++ b/packages/exocortex/tests/unit/domain/constants/CommandConstants.test.ts
@@ -58,8 +58,11 @@ describe("CommandBindingProperty", () => {
     expect(CommandBindingProperty.TARGET_ASSET).toBe("exocmd__CommandBinding_targetAsset");
     expect(CommandBindingProperty.POSITION).toBe("exocmd__CommandBinding_position");
     expect(CommandBindingProperty.ORDER).toBe("exocmd__CommandBinding_order");
-    expect(CommandBindingProperty.GROUP).toBe("exocmd__CommandBinding_group");
     expect(CommandBindingProperty.PRECONDITION).toBe("exocmd__CommandBinding_precondition");
+  });
+
+  it("should not expose dropped legacy `GROUP` constant (RFC f1dc284a Phase 8)", () => {
+    expect((CommandBindingProperty as Record<string, unknown>).GROUP).toBeUndefined();
   });
 });
 

--- a/packages/exocortex/tests/unit/domain/models/CommandDefinition.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/CommandDefinition.test.ts
@@ -191,7 +191,6 @@ describe("CommandDefinition", () => {
         targetPrototype: "a717a21b-a960-4795-9caa-04aeaba730ee",
         position: "inline",
         order: 50,
-        group: "maintenance",
       };
 
       expect(binding.targetPrototype).toBe("a717a21b-a960-4795-9caa-04aeaba730ee");

--- a/packages/exocortex/tests/unit/services/CommandResolver.style.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.style.test.ts
@@ -545,9 +545,13 @@ describe("CommandResolver — RFC-024 binding style resolution", () => {
       expect(resolved.binding.variant).toBeUndefined();
     });
 
-    it("logs warning when both legacy `_group` and `_variant` are present (prefers _variant)", async () => {
+    it("silently ignores legacy `_group` frontmatter (RFC f1dc284a Phase 8 — `_group` parsing dropped)", async () => {
+      // Pre-RFC vaults can still ship `exocmd__CommandBinding_group` triples.
+      // After Phase 8 the parser must NOT surface a `binding.group` field, must
+      // NOT log a coexistence warning, and must continue to resolve the
+      // explicit `_variant` override unchanged.
       const subject = await addBinding(store, {
-        uid: "bind-coexist",
+        uid: "bind-legacy-group",
         commandUid: "cmd-1",
         targetClass: TARGET_CLASS,
         inlineVariant: "primary",
@@ -566,12 +570,10 @@ describe("CommandResolver — RFC-024 binding style resolution", () => {
       );
 
       expect(resolved.binding.variant).toBe("primary");
-      expect(resolved.binding.group).toBe("maintenance");
+      expect((resolved.binding as { group?: string }).group).toBeUndefined();
       expect(
-        logger.warnings.some((w) =>
-          /both _group and _variant present/.test(w),
-        ),
-      ).toBe(true);
+        logger.warnings.some((w) => /_group/.test(w)),
+      ).toBe(false);
     });
 
     it("leaves binding.variant undefined when neither `_variant` literal nor style asset is set", async () => {

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -127,7 +127,6 @@ async function addBindingAsset(
     targetAsset?: string;
     position?: string;
     order?: number;
-    group?: string;
   },
 ): Promise<IRI> {
   const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
@@ -153,9 +152,6 @@ async function addBindingAsset(
   }
   if (opts.order !== undefined) {
     triples.push(new Triple(subject, Namespace.EXOCMD.term("CommandBinding_order"), new Literal(String(opts.order))));
-  }
-  if (opts.group) {
-    triples.push(new Triple(subject, Namespace.EXOCMD.term("CommandBinding_group"), new Literal(opts.group)));
   }
 
   await store.addAll(triples);

--- a/packages/exocortex/tests/unit/services/DynamicCommandPipeline.test.ts
+++ b/packages/exocortex/tests/unit/services/DynamicCommandPipeline.test.ts
@@ -167,9 +167,11 @@ describe("Dynamic Command Pipeline — Remove Start Timestamp (RFC-009 §6)", ()
       expect(command.grounding.type).toBe("property_delete");
       expect(command.grounding.targetProperty).toBe("ems__Effort_startTimestamp");
 
-      // Step 4: Verify binding metadata
-      expect(binding.group).toBe("maintenance");
+      // Step 4: Verify binding metadata.
+      // Legacy `_group` triple is present in the fixture (line 77) but parser
+      // silently ignores it (RFC f1dc284a Phase 8). Assert position only.
       expect(binding.position).toBe("inline");
+      expect((binding as { group?: string }).group).toBeUndefined();
     });
 
     it("should hide command when asset has no startTimestamp", async () => {

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -307,9 +307,8 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
 
     // RFC-024 Phase 3 — apply class-level panel filter (excludeCommands
     // trumps includeGroups). When no panel is declared this is a pure
-    // pass-through. Filter dimension uses `command.category` (post-RFC
-    // f1dc284a — sectioning axis is `Command_category`, no longer routed
-    // through the synthesised `binding.group` bridge).
+    // pass-through. Filter dimension is `command.category` (RFC f1dc284a
+    // — sectioning axis is `Command_category`).
     const visibleCommands =
       panelClassRef !== null
         ? this.panelResolver

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/categoryDefaultVariants.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/categoryDefaultVariants.ts
@@ -30,11 +30,6 @@ export const categoryDefaultVariant: Readonly<
 /**
  * Resolves the default button variant for a command's `category` string.
  * Falls back to `"secondary"` for unknown, empty, or missing categories.
- *
- * Note: prior to RFC f1dc284a this function was named `resolveVariantForGroup`
- * and was keyed by the legacy `binding.group` literal. After the split of
- * `Command_category` (UI sectioning) and `CommandBinding_variant` (button
- * color override) it is now keyed by `command.category` directly.
  */
 export function resolveDefaultVariantForCategory(
   category: string | undefined,

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -359,10 +359,10 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       expect(result[0].variant).toBe("danger");
     });
 
-    it("should default variant to secondary for unknown group", async () => {
+    it("should default variant to secondary for unknown category", async () => {
       const rc = createResolvedCommand(
-        { name: "Future action" },
-        { group: "future-uncategorized" },
+        { name: "Future action", category: "future-uncategorized" },
+        { id: "binding-unknown-category" },
       );
       mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
@@ -1041,11 +1041,11 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       ]);
     });
 
-    it("featuredBinding promotes its binding to primary regardless of group default", async () => {
+    it("featuredBinding promotes its binding to primary regardless of category default", async () => {
       const featured = createResolvedCommand(
         // `maintenance` would normally resolve to `muted` per Phase 0 defaults.
         { id: "c-featured", name: "Featured", category: "maintenance" },
-        { id: "binding-featured", group: "maintenance" },
+        { id: "binding-featured" },
       );
       mockResolveForAssetMulti.mockResolvedValue([featured]);
       mockEvaluate.mockResolvedValue(true);
@@ -1059,10 +1059,10 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       expect(result[0].variant).toBe("primary");
     });
 
-    it("non-featured bindings keep their group-derived variant", async () => {
+    it("non-featured bindings keep their category-derived variant", async () => {
       const nonFeatured = createResolvedCommand(
         { id: "c-other", name: "Maintenance Op", category: "maintenance" },
-        { id: "binding-other", group: "maintenance" },
+        { id: "binding-other" },
       );
       mockResolveForAssetMulti.mockResolvedValue([nonFeatured]);
       mockEvaluate.mockResolvedValue(true);
@@ -1168,13 +1168,12 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       expect(result[0].variant).toBe("danger");
     });
 
-    it("(b) no variant + no group + category=creation → primary", async () => {
+    it("(b) no variant + category=creation → primary", async () => {
       const rc = createResolvedCommand(
         { name: "Create Task", category: "creation" },
         { id: "binding-b" },
       );
       expect(rc.binding.variant).toBeUndefined();
-      expect(rc.binding.group).toBeUndefined();
       mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
@@ -1196,15 +1195,14 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       expect(result[0].variant).toBe("secondary");
     });
 
-    it("(d) legacy group=maintenance + variant=danger → variant wins (group still parsed for diagnostics)", async () => {
-      // Mirrors the parser-level CommandResolver assertion that both fields
-      // coexist; here the builder consumes the resolved object and must
-      // pick `variant` regardless of legacy `group`. The CommandResolver
-      // unit suite (`CommandResolver.style.test.ts`) covers the parser
-      // warning emission for the same shape.
+    it("(d) variant=danger on a maintenance category → variant wins over category default `muted`", async () => {
+      // Sanity check that an explicit `_variant` override always beats the
+      // category-derived default. (Pre-RFC f1dc284a Phase 8 this branch was
+      // labelled "legacy `group` + `variant` coexistence"; with `_group`
+      // parsing dropped only the variant axis remains.)
       const rc = createResolvedCommand(
         { name: "Wipe cache", category: "maintenance" },
-        { id: "binding-d", group: "maintenance", variant: "danger" },
+        { id: "binding-d", variant: "danger" },
       );
       mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);


### PR DESCRIPTION
## Summary

Finalize RFC `f1dc284a-eadc-4d0e-8e72-323e999ea510` Phase 8 — drop the legacy `exocmd__CommandBinding_group` axis after two release windows of deprecation. The `_variant` axis introduced in earlier phases is now the sole source for per-binding button colour.

- Remove `group?` field from `CommandBindingDefinition` interface
- Remove `GROUP` constant from `CommandBindingProperty` table
- Drop `_group` parsing + coexistence-warning log from `CommandResolver.loadBindingDefinition`
- Refresh inline comments in `DynamicCommandButtonGroupBuilder` and `categoryDefaultVariants` (no more `binding.group` bridge references)
- CHANGELOG: move Deprecated entry → Removed

## Backward compatibility

Existing user vaults that still ship the legacy `_group` frontmatter remain valid markdown — the parser silently ignores the unknown property. Verified by:

- New parser unit test in `CommandResolver.style.test.ts` asserting `binding.group === undefined` and no warning emitted when `_group` triple is present.
- Updated assertions in `DynamicCommandPipeline.test.ts` and `remove-start-timestamp.test.ts` against fixtures that still emit the legacy triple.
- Retained E2E starter-kit fixtures with legacy `_group` frontmatter.

## Related

- Task: `6e8cb346-4177-4e8b-a813-acf9ea74313a` (T8 — Next-release removal)
- Blocked by: T7 release v15.142.0 — gate satisfied (latest v15.144.0, ≥2 release windows passed)
- Starter-kit migration: kitelev/exocortex-starter-kit#94

## Test plan

- [x] `npm run check:types` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] Targeted unit + integration suites green (CommandResolver, CommandResolver.style, DynamicCommandPipeline, remove-start-timestamp, smoke pipeline, CommandConstants, DCBGB, ButtonGroupsBuilder)
- [x] Full `npm run test:unit` — same pass/fail counts as `origin/main` baseline (7 pre-existing CLI failures unrelated to this change)
- [ ] CI green (13 required checks)
- [ ] Auto Release succeeds