### PR TITLE
fix(sparql): numeric ordering for xsd:dayTimeDuration in ORDER BY (Fixes #2964)

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -36,6 +36,28 @@ import { ServiceExecutor, ServiceExecutorConfig } from "./ServiceExecutor";
 import { GraphExecutor } from "./GraphExecutor";
 import { SPARQLGenerator } from "../algebra/SPARQLGenerator";
 import { IRI } from "../../../domain/models/rdf/IRI";
+import { Literal } from "../../../domain/models/rdf/Literal";
+import { DateTimeFunctions } from "../filters/functions/DateTimeFunctions";
+
+const XSD = "http://www.w3.org/2001/XMLSchema#";
+const XSD_NUMERIC_DATATYPES: ReadonlySet<string> = new Set([
+  `${XSD}integer`,
+  `${XSD}decimal`,
+  `${XSD}float`,
+  `${XSD}double`,
+  `${XSD}nonPositiveInteger`,
+  `${XSD}negativeInteger`,
+  `${XSD}long`,
+  `${XSD}int`,
+  `${XSD}short`,
+  `${XSD}byte`,
+  `${XSD}nonNegativeInteger`,
+  `${XSD}unsignedLong`,
+  `${XSD}unsignedInt`,
+  `${XSD}unsignedShort`,
+  `${XSD}unsignedByte`,
+  `${XSD}positiveInteger`,
+]);
 
 export class QueryExecutorError extends Error {
   constructor(message: string, cause?: Error) {
@@ -832,10 +854,30 @@ export class ExoQLQueryExecutor {
   private getExpressionValue(expr: import("../algebra/AlgebraOperation").Expression, solution: SolutionMapping): unknown {
     if (expr.type === "variable") {
       const term = solution.get(expr.name);
-      if (term) {
-        return (term as { value?: string; id?: string }).value ?? (term as { value?: string; id?: string }).id ?? String(term);
+      if (!term) {
+        return undefined;
       }
-      return undefined;
+      // SPARQL 1.1 §17.4.5.4 — ORDER BY uses value-based ordering.
+      // For numeric-typed and xsd:dayTimeDuration literals, return a number so
+      // the sort comparator compares values, not lexical forms.
+      if (term instanceof Literal) {
+        const dt = term.datatype?.value;
+        if (dt === `${XSD}dayTimeDuration`) {
+          try {
+            return DateTimeFunctions.parseDayTimeDuration(term.value);
+          } catch {
+            return term.value;
+          }
+        }
+        if (dt && XSD_NUMERIC_DATATYPES.has(dt)) {
+          const n = parseFloat(term.value);
+          if (!Number.isNaN(n)) {
+            return n;
+          }
+        }
+        return term.value;
+      }
+      return (term as { value?: string; id?: string }).value ?? (term as { value?: string; id?: string }).id ?? String(term);
     }
     if (expr.type === "literal") {
       return expr.value;

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/QueryExecutor.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/QueryExecutor.test.ts
@@ -413,6 +413,74 @@ describe("QueryExecutor", () => {
       const results = await executor.executeAll(orderByOp);
       expect(results).toHaveLength(2);
     });
+
+    // Regression: #2964 — ORDER BY on xsd:dayTimeDuration must sort by value,
+    // not lexically. P10D > P3D > P1D numerically, but lex-order gives P3D > P1D > P10D.
+    // Per W3C SPARQL 1.1 §17.4.5.4 ordering must be value-based.
+    it("should sort xsd:dayTimeDuration values numerically (issue #2964)", async () => {
+      const dayTimeDuration = new IRI("http://www.w3.org/2001/XMLSchema#dayTimeDuration");
+      await store.add(new Triple(ex("ms-a"), ex("slip"), new Literal("P3D", dayTimeDuration)));
+      await store.add(new Triple(ex("ms-b"), ex("slip"), new Literal("P1D", dayTimeDuration)));
+      await store.add(new Triple(ex("ms-c"), ex("slip"), new Literal("P10D", dayTimeDuration)));
+
+      const orderByOp: OrderByOperation = {
+        type: "orderby",
+        comparators: [
+          {
+            expression: { type: "variable", name: "slip" },
+            descending: true,
+          },
+        ],
+        input: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: ex("slip").value },
+              object: { type: "variable", value: "slip" },
+            },
+          ],
+        } as BGPOperation,
+      };
+
+      const results = await executor.executeAll(orderByOp);
+      const slipValues = results.map((sol) => (sol.get("slip") as Literal).value);
+      expect(slipValues).toEqual(["P10D", "P3D", "P1D"]);
+    });
+
+    // Regression: numeric typed literals (e.g. xsd:integer "10" vs "9") must
+    // sort numerically, not lexically. Same root cause as #2964 — datatype loss
+    // on extraction.
+    it("should sort xsd:integer values numerically", async () => {
+      const xsdInteger = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+      await store.add(new Triple(ex("n-a"), ex("count"), new Literal("9", xsdInteger)));
+      await store.add(new Triple(ex("n-b"), ex("count"), new Literal("10", xsdInteger)));
+      await store.add(new Triple(ex("n-c"), ex("count"), new Literal("2", xsdInteger)));
+
+      const orderByOp: OrderByOperation = {
+        type: "orderby",
+        comparators: [
+          {
+            expression: { type: "variable", name: "n" },
+            descending: false,
+          },
+        ],
+        input: {
+          type: "bgp",
+          triples: [
+            {
+              subject: { type: "variable", value: "s" },
+              predicate: { type: "iri", value: ex("count").value },
+              object: { type: "variable", value: "n" },
+            },
+          ],
+        } as BGPOperation,
+      };
+
+      const results = await executor.executeAll(orderByOp);
+      const nValues = results.map((sol) => (sol.get("n") as Literal).value);
+      expect(nValues).toEqual(["2", "9", "10"]);
+    });
   });
 
   describe("execute slice (LIMIT/OFFSET)", () => {


### PR DESCRIPTION
## Summary

Fixes #2964.

`ORDER BY` on `xsd:dayTimeDuration` values was sorted **lexically** (`P3D` > `P10D`) instead of by numeric duration. Per W3C SPARQL 1.1 §17.4.5.4 (Operator Mapping) ordering must be **value-based**.

## Root cause

`QueryExecutor.getExpressionValue` (used by `executeOrderBy`) unwrapped variable terms to their `.value` lexical form, dropping datatype information. The downstream sort comparator therefore only ever saw strings, and the `typeof === "number"` numeric branch was effectively dead for typed-literal variables.

## Fix

`packages/exocortex/src/infrastructure/sparql/executors/QueryExecutor.ts` — when extracting a variable term for ORDER BY:
- `xsd:dayTimeDuration` → `DateTimeFunctions.parseDayTimeDuration(value)` (ms → number)
- `xsd:integer/decimal/float/double` and their derived integer subtypes → `parseFloat(value)`
- Everything else → unchanged (string lexical form)

The existing comparator branches then sort numerically.

### Repro (from issue)

3 rows with `?slip` ∈ {`P3D`, `P1D`, `P10D`}, `ORDER BY DESC(?slip)`:
- **Before**: `P3D, P1D, P10D` (lex)
- **After**:  `P10D, P3D, P1D` (numeric)

## Tests

`packages/exocortex/tests/unit/infrastructure/sparql/executors/QueryExecutor.test.ts` — two regression tests:
1. `xsd:dayTimeDuration` DESC — replicates issue #2964 dataset (P3D/P1D/P10D)
2. `xsd:integer` ASC — same root cause (`9` vs `10` vs `2`)

Both pass; full `QueryExecutor.test.ts` (35 tests) green. `npm run check:types` and `npm run lint` clean.

## Out of scope

The issue also notes that `xsd:double()` cast on dayTimeDuration does not bind. That is a separate function-mapping concern (cast pipeline) and is not addressed here — current fix targets the ORDER BY comparator path that the issue's primary reproduction depends on.

## Spec reference

W3C SPARQL 1.1 Query Language §17.4.5.4 — https://www.w3.org/TR/sparql11-query/#OperatorMapping