### PR TITLE
test(sparql): regression test for #2844 (Closes #2844 — not reproducible)

### DIFF
--- a/packages/obsidian-plugin/tests/unit/infrastructure/sparql/CaseWhenTransformer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/sparql/CaseWhenTransformer.test.ts
@@ -288,5 +288,28 @@ SELECT (CASE WHEN ?x > 10 THEN "high" ELSE "low" END AS ?level) WHERE { ?s :v ?x
       const input = `# just a CASE WHEN END comment with no SPARQL content`;
       expect(() => transformer.transform(input)).not.toThrow();
     });
+
+    // Regression: #2844 — substring `case` (e.g. `worst-case`) inside a `#`
+    // comment combined with a parenthesised projection like `(CONCAT(...) AS ?x)`
+    // must not trip the CASE/END scanner. Comment-stripping (#2842) is applied
+    // before the CASE scan, so this query should round-trip unchanged.
+    it("should not trip on substring 'case' in a # header comment with CONCAT projection (#2844)", () => {
+      const input = `# Notes:  Quadratic worst-case -- benchmark before scaling past about 100 Areas.
+
+PREFIX ems: <https://exocortex.my/ontology/ems#>
+
+SELECT ?task (CONCAT("ems__Area parent cycle detected: ", STR(?task)) AS ?issue) WHERE {
+  ?task ems:Area_parent+ ?task .
+  FILTER(isIRI(?task))
+}
+GROUP BY ?task`;
+      expect(() => transformer.transform(input)).not.toThrow();
+      const result = transformer.transform(input);
+      // No CASE WHEN to transform → IF() must not appear
+      expect(result).not.toContain("IF(");
+      // Body keywords preserved, comment replaced by whitespace of equal length
+      expect(result).toContain("SELECT ?task");
+      expect(result).toContain("GROUP BY ?task");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #2844 by adding a regression test next to existing #2835 cases. **The bug as reported is not reproducible on `main` (`edc4ee2e`) nor on the published `@kitelev/exocortex-cli@15.101.0`** — fix #2842 (`d4c4e6fb`) already strips `#` comments before the CASE WHEN scan.

## Investigation

- v15.101.0 contains commit `d4c4e6fb` (`git tag --contains d4c4e6fb` returns `v15.100.1, v15.101.0, v15.102.0, …`).
- Running the exact issue query against `npx @kitelev/exocortex-cli@15.101.0 exoql query` parses successfully:

  ```
  📦 Loading vault: /tmp/test-vault-2844...
  ✅ Loaded 0 triples in 1ms
  🔍 Parsing SPARQL query...
  🔄 Translating to algebra...
  ✅ Found 0 result(s) in 3ms
  ```

- No standalone "CASE WHEN validation scanner" exists in `packages/cli/src` (`grep -rn "CASE WHEN" packages/cli/src` returns nothing). The only CASE-aware code is `CaseWhenTransformer` in `packages/exocortex`, and per `transform()` line 46 it strips `#` line comments first via `stripLineComments(query)` — exactly the pre-pass the issue calls for.
- Three unit-test variants confirm the scenario passes today: `CaseWhenTransformer` standalone, full `ExoQLParser.parse()`, and `SPARQL_PREFIXES + query` (885-char total, matching the position cited in the issue).

## What this PR does

Adds one regression test to `CaseWhenTransformer.test.ts` next to the existing #2835 (`SPARQL \`#\` line comments`) suite, pinning the exact issue scenario (`worst-case` in a `#` header + `(CONCAT(...) AS ?issue)` projection + `GROUP BY`). Any future regression of the comment-stripping pipeline that re-introduces this bug will fail CI.

## Why close instead of fix

A fake fix under an honest-looking commit message would be no-op or worse — could introduce regressions. The fix the issue requests already exists. If the reporter has a specific vault configuration that still triggers the bug, please reopen with full repro details (vault structure, exact CLI invocation).

Closes #2844

## Test plan

- [x] `npx jest packages/obsidian-plugin/tests/unit/infrastructure/sparql/CaseWhenTransformer.test.ts` — 37 tests pass
- [ ] CI: 13 required checks green