### PR TITLE
fix(e2e): deterministic clock for daily-note-tasks spec (Fixes #2986)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/daily-note-tasks.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-note-tasks.spec.ts
@@ -2,8 +2,15 @@ import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
 import * as path from "path";
 
-// RFC Phase 3.2 (T2.1): per-spec retry(1) — top T0.2 offender (rank #2, Cat I time-dependent).
-test.describe.configure({ mode: "parallel", retries: 1 });
+// RFC Phase 3.3 (T3.1 #2986): root-cause fix via deterministic clock pins virtual time
+// to the daily-note fixture date, so the spec sees a fixed wall-clock regardless of when
+// CI runs. retry(1) (T2.1) removed per Charter Risk 1 — retries papered over time
+// dependence; pinned clock removes the dependence entirely.
+test.describe.configure({ mode: "parallel" });
+
+// Pinned virtual time aligned to the fixture daily note (`Daily Notes/2025-10-16.md`)
+// so any "today" check sees the same date as the on-disk fixture.
+const PINNED_VIRTUAL_TIME = new Date("2025-10-16T12:00:00");
 
 test.describe("DailyNote Tasks Table", () => {
   let launcher: ObsidianLauncher;
@@ -12,6 +19,12 @@ test.describe("DailyNote Tasks Table", () => {
     const vaultPath = path.join(__dirname, "../test-vault");
     launcher = new ObsidianLauncher(vaultPath);
     await launcher.launch();
+
+    // Pin Date.now() / new Date() in the renderer page to the fixture date.
+    // Resolves Issue #2986: "current day" predicate was time-dependent and crossed
+    // UTC midnight intermittently, causing 2 / 41 post-cutover incidents.
+    const window = await launcher.getWindow();
+    await window.clock.install({ time: PINNED_VIRTUAL_TIME });
   });
 
   test.afterAll(async () => {


### PR DESCRIPTION
## Summary

Wires Playwright `page.clock.install({ time })` into `daily-note-tasks.spec.ts` setup with a pinned virtual time (`2025-10-16T12:00:00`, aligned to the fixture daily note `Daily Notes/2025-10-16.md`). Removes per-spec `retry(1)` (T2.1) since the pinned clock removes the underlying time dependence rather than masking it (Charter Risk 1).

## Root cause

Per T3.1 decision matrix row #2 / T0.2 §2: spec was **Category I (time-dependent)** — the "current day" predicate was evaluated against wall-clock time, so runs crossing UTC midnight saw an in-memory date that diverged from the on-disk fixture filename, producing 2 / 41 post-cutover incidents on shard 6.

## Fix

- Add `await window.clock.install({ time: PINNED_VIRTUAL_TIME })` in `beforeAll` after `launcher.launch()`.
- Pinned virtual time = `2025-10-16T12:00:00` so any `Date.now()` / `new Date()` call in the renderer page returns a stable date matching the fixture.
- Drop `retries: 1` from `test.describe.configure(...)` — retries are no longer needed and continuing to ship them would mask any future regression (Charter Risk 1).

## DoD checklist

- [x] `page.clock.install()` wired into spec setup with pinned virtual date
- [x] Spec no longer depends on wall-clock time of day
- [x] `retry(1)` removed per Charter Risk 1
- [ ] No incidents in next 30 runs after fix lands (post-merge observation)

## References

- Fixes #2986
- RFC: `32a64ed9-9a74-4e0c-bb26-e455605aa384` (Phase 3.3 — Flaky E2E Residual Stabilization)
- T3.1 matrix: `packages/obsidian-plugin/docs/phase3/T3_1_QUARANTINE_DECISION_MATRIX.md` row #2
- T0.2 §4 priority #1