### PR TITLE
fix(e2e): await featuredBinding render signal before assertions (Fixes #2985)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/featured-binding-promotion.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/featured-binding-promotion.spec.ts
@@ -66,11 +66,40 @@ test.describe("RFC-024 Phase 3 — featuredBinding promotion", () => {
     }, { timeout: 15000 }).not.toBeNull();
 
     // Force re-render with populated triple store + metadataCache.
+    // `refreshLayout()` removes the old auto-layout container and fires a
+    // fire-and-forget async render — `evaluate` resolves before the new
+    // render commits. Without an explicit re-render signal here, downstream
+    // assertions race against `featuredBinding` promotion (#2985).
+    //
+    // Capture the current `.exocortex-layout-rendered` element; the refresh
+    // will detach it and a NEW container will get the class once render() in
+    // UniversalLayoutRenderer reaches its terminal `el.addClass(...)` line.
+    // Awaiting both transitions makes the rest of the spec deterministic.
+    const oldLayoutRendered = window
+      .locator(".exocortex-auto-layout.exocortex-layout-rendered")
+      .first();
+
     await window.evaluate(() => {
       const plugin = (window as any).app?.plugins?.plugins?.exocortex;
       plugin?.commandResolver?.invalidateCache?.();
       plugin?.refreshLayout?.();
     });
+
+    // Old container is removed by `removeAutoRenderedLayouts()` at the very
+    // start of `autoRenderLayout()`. Ignore detach failures (a previous test
+    // run could have left no rendered marker — e.g. settings.layoutVisible
+    // off — and then there's nothing to wait for).
+    await oldLayoutRendered
+      .waitFor({ state: "detached", timeout: 5000 })
+      .catch(() => {});
+
+    // Wait for the freshly mounted auto-layout to reach its rendered marker
+    // before any visual assertion. This is the explicit render signal that
+    // RFC-024 Phase 3 visual invariants depend on.
+    await window
+      .locator(".exocortex-auto-layout.exocortex-layout-rendered")
+      .first()
+      .waitFor({ state: "attached", timeout: 20000 });
 
     const buttonsSection = window.locator(".exocortex-buttons-section");
     await expect(buttonsSection).toBeVisible({ timeout: 20000 });


### PR DESCRIPTION
Fixes #2985

## Root cause

`plugin.refreshLayout()` → `autoRenderLayout()` removes the existing
auto-layout container and starts a **fire-and-forget** async render via
`void (async () => render())` (`ExocortexPlugin.ts:1223`). The outer
`window.evaluate()` therefore resolves immediately — long before the
new render reaches its terminal `el.addClass("exocortex-layout-rendered")`
line in `UniversalLayoutRenderer.render()` (lines 293/308).

Downstream `expect(buttonsSection).toBeVisible()` and
`toHaveClass(/--primary/)` then race against the in-flight render and
panel-resolver work, producing the 30.6s **test-level** timeout flake
(2 incidents / 41 post-cutover runs, shard 4).

This is exactly the priority #2 hypothesis from RFC-024 T0.2 §4
(Cat H net-new spec, top T0.2 offender after #2986).

## Fix

Make the spec's render signal explicit:

1. Capture the pre-refresh `.exocortex-auto-layout.exocortex-layout-rendered`
   handle.
2. Run `refreshLayout()` (still synchronous void).
3. Await the **detach** of the captured old handle (`removeAutoRenderedLayouts()`
   removes it at the very start of `autoRenderLayout`). Best-effort
   `.catch(() => {})` so we don't break if the marker was absent (e.g.
   `settings.layoutVisible = false` in some prior state).
4. Await the **attach** of a fresh `.exocortex-auto-layout.exocortex-layout-rendered`
   element (terminal signal of `UniversalLayoutRenderer.render()` —
   guarantees `featuredBinding` promotion has been applied).

Only then proceed to visual assertions.

## Out of scope

- `retries: 1` (T2.1, commit 688d9163) is intentionally **kept** in this
  PR — separate follow-up will re-evaluate per RFC-024 Charter Risk 1
  once flake rate stabilises across a green window. Avoiding combined
  changes here so the deterministic-wait fix can be assessed in
  isolation.

## Verification

- `npm run check:types` — clean
- `npm run lint` — only 2 pre-existing warnings (unchanged)
- E2E shard 4 (the affected shard) will be the real verification in CI

## References

- RFC-024 T0.2 §4 priority #2
- Issue #2985
- Net-new from PR #2971 (RFC-024 T6.4)
- Sibling fix paradigm: PR #3015 (#2986 Playwright clock determinism)