### PR TITLE
chore(e2e): flaky-track annotation for alias-sync-on-label-change.spec.ts (Fixes #2987)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/alias-sync-on-label-change.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/alias-sync-on-label-change.spec.ts
@@ -5,7 +5,15 @@ import * as path from "path";
 
 test.describe.configure({ mode: "parallel" });
 
-test.describe("Alias Sync on Label Change", () => {
+// flaky-track #2987 — RFC 32a64ed9-9a74-4e0c-bb26-e455605aa384 §3.3.
+// Single-incident at N=41 (T3.1 row #6); insufficient evidence to discriminate
+// flake vs regression. Keep enabled, no retry (Charter Risk 1). Watch criteria:
+// incident #2 by 2026-05-31 → escalate to fix; zero further at N≥100 → close.
+// Tag enables Phase 3.4 dashboard filtering (`--grep @flaky-track`).
+test.describe(
+  "Alias Sync on Label Change",
+  { tag: ["@flaky-track", "@issue-2987"] },
+  () => {
   let launcher: ObsidianLauncher;
 
   test.beforeAll(async () => {


### PR DESCRIPTION
## Summary

Adds Playwright `tag: ["@flaky-track", "@issue-2987"]` to `alias-sync-on-label-change.spec.ts` `test.describe` block, plus a header comment recording the RFC tracking decision.

**Decision:** Option A (lightweight tracking annotation), per RFC `32a64ed9-9a74-4e0c-bb26-e455605aa384` §3.3 — *track*, not *fix*. The spec stays enabled, no retry, no behaviour change. The tag enables Phase 3.4 dashboard filtering (`--grep @flaky-track`) and makes the watch status visible in the spec source rather than only in `T3_3_TRACKING_ISSUES.md`.

**Why not retry(1):** pre-emptively masking a single-incident flake violates Charter Risk 1 — it would discard evidence needed to discriminate flake vs latent regression at N≥100.

## Watch criteria (mirrored from issue #2987)

- Incident #2 within 30 days (by **2026-05-31**) → escalate to `flaky-fix`
- Zero further incidents at N≥100 → close as resolved
- Expiry: 2026-05-31

## References

- RFC `32a64ed9-9a74-4e0c-bb26-e455605aa384` §3.3 — track-bucket policy
- T3.1 decision matrix row #6 — `packages/obsidian-plugin/docs/phase3/T3_1_QUARANTINE_DECISION_MATRIX.md`
- T3.3 tracking issues index — `packages/obsidian-plugin/docs/phase3/T3_3_TRACKING_ISSUES.md`
- Charter `4cd6f7bd-73e4-47f3-b0f2-c1f2438ed619` Risk 1 — pre-emptive retry forbidden

## Test plan

- [x] `npm run lint` passes (only pre-existing warnings)
- [x] `npx tsc --noEmit` passes — no new TS errors
- [x] No behaviour change to spec body — only annotation + comment
- [ ] 13 required CI checks green (archgate · detect-changes · e2e-shard 1..6 · lint · test-bdd · test-component · test-coverage · typecheck)

Fixes #2987