### PR TITLE
chore(e2e): flaky-track annotation for daily-archive-filter.spec.ts (Fixes #2988)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
@@ -1,10 +1,25 @@
+// flaky-track: Issue #2988 — single-incident flake (1/41) without retry(1).
+// Per RFC 32a64ed9 §3.3, bucket = track: keep enabled, no retry, rely on
+// Phase 3.4 dashboard to disambiguate at higher N.
+// Watch criteria: incident #2 within 30 days → escalate to fix; zero further
+// at N≥100 → close as resolved. Expiry: 2026-05-31.
 import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
 import * as path from "path";
 
 test.describe.configure({ mode: "parallel" });
 
-test.describe("DailyNote Archive Filter", () => {
+test.describe(
+  "DailyNote Archive Filter",
+  {
+    tag: ["@flaky-track"],
+    annotation: {
+      type: "flaky-track",
+      description:
+        "Issue #2988 — RFC 32a64ed9 §3.3 track bucket; watch criteria: incident #2 → fix, N≥100 zero-further → close; expiry 2026-05-31",
+    },
+  },
+  () => {
   let launcher: ObsidianLauncher;
 
   test.beforeAll(async () => {


### PR DESCRIPTION
## Summary

Adds a Playwright `@flaky-track` tag and structured `annotation` to the top-level `test.describe` block of `daily-archive-filter.spec.ts`. Pure metadata change — no behavioural impact on the test.

## Decision rationale

Per [RFC 32a64ed9](../tree/main/packages/obsidian-plugin/docs/phase3/T3_1_QUARANTINE_DECISION_MATRIX.md) §3.3 and the T3.1 decision matrix (row #7), this spec is in the **track** bucket:

- Single incident (1/41) without `retry(1)` coverage
- Insufficient evidence to discriminate flake vs regression
- Adding `retry(1)` pre-emptively would mask real bugs (Charter Risk 1)
- The right action is **track**: keep enabled, no further code change, rely on the Phase 3.4 dashboard to disambiguate at higher N

The annotation makes this watch state queryable from the dashboard and visible to anyone reading the spec.

## Watch criteria (from #2988 / T3.3 §2)

- **Incident #2** within 30 days → escalate to **fix**
- **Zero further incidents** at N≥100 → close as resolved
- **Expiry**: 2026-05-31

## Files changed

- `packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts` — added header comment + `tag: ["@flaky-track"]` + `annotation: { type: "flaky-track", description: ... }` on the describe block.

## References

- RFC `32a64ed9-9a74-4e0c-bb26-e455605aa384` §3.3 (track bucket)
- Charter `4cd6f7bd-73e4-47f3-b0f2-c1f2438ed619` Risk 1 (retry pre-emption)
- T3.1 decision matrix — `packages/obsidian-plugin/docs/phase3/T3_1_QUARANTINE_DECISION_MATRIX.md` row #7
- T3.3 tracking issues index — `packages/obsidian-plugin/docs/phase3/T3_3_TRACKING_ISSUES.md` row #4

Fixes #2988

## Test plan

- [x] `npm run check:types` — clean
- [x] `npm run lint` — only pre-existing warnings, none from this change
- [x] No behavioural change — annotation is metadata only, dashboard / Playwright tag filtering unaffected
- [ ] CI: 13 required checks must remain green