### PR TITLE
chore(e2e): flaky-track annotation for file-explorer-icons.spec.ts (Fixes #2989)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/file-explorer-icons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/file-explorer-icons.spec.ts
@@ -15,63 +15,82 @@ import { ObsidianLauncher } from "../utils/obsidian-launcher";
  *   `npm run test:e2e file-explorer-icons` — class-bearing notes show
  *   the resolved Lucide icon when one is declared in the layout.
  */
-test.describe("FileExplorerIconPatch — Phase 4 smoke", () => {
-  let launcher: ObsidianLauncher;
+// flaky-track #2989 — RFC 32a64ed9 Phase 3.3 (T3.1 Decision Matrix row #9).
+// Bucket: track (no behavioural change, no retry()). Single incident at N=41
+// against recently-shipped FileExplorerIconPatch. Watch criteria:
+//   - Incident #2 within 30 days → escalate to fix.
+//   - Zero further at N≥100 → close as resolved.
+// Expiry: 2026-05-31. See packages/obsidian-plugin/docs/phase3/T3_1_QUARANTINE_DECISION_MATRIX.md.
+test.describe(
+  "FileExplorerIconPatch — Phase 4 smoke",
+  {
+    annotation: [
+      {
+        type: "flaky-track",
+        description:
+          "RFC 32a64ed9 Phase 3.3 / T3.1 #9. Bucket=track, no retry(). " +
+          "Watch: incident #2 within 30d → fix; zero at N≥100 → close. Expiry 2026-05-31. Issue #2989.",
+      },
+    ],
+  },
+  () => {
+    let launcher: ObsidianLauncher;
 
-  test.beforeAll(async () => {
-    launcher = new ObsidianLauncher();
-    await launcher.launch();
-  });
+    test.beforeAll(async () => {
+      launcher = new ObsidianLauncher();
+      await launcher.launch();
+    });
 
-  test.afterAll(async () => {
-    if (launcher) {
-      await launcher.close();
-    }
-  });
+    test.afterAll(async () => {
+      if (launcher) {
+        await launcher.close();
+      }
+    });
 
-  test(
-    "ems__Task nav-file-title carries .exo-file-explorer-icon overlay before .nav-file-title-content",
-    { timeout: 25_000 },
-    async () => {
-      // Open any file to ensure the workspace is initialised; the patch
-      // attaches to nav-file-title elements globally and re-applies on
-      // metadataCache "resolved".
-      await launcher.openFile("e2e-icon-target-task.md");
-      await launcher.waitForModalsToClose(10_000);
+    test(
+      "ems__Task nav-file-title carries .exo-file-explorer-icon overlay before .nav-file-title-content",
+      { timeout: 25_000 },
+      async () => {
+        // Open any file to ensure the workspace is initialised; the patch
+        // attaches to nav-file-title elements globally and re-applies on
+        // metadataCache "resolved".
+        await launcher.openFile("e2e-icon-target-task.md");
+        await launcher.waitForModalsToClose(10_000);
 
-      const targetTitle = launcher.page!.locator(
-        '.nav-file-title[data-path="e2e-icon-target-task.md"]',
-      );
+        const targetTitle = launcher.page!.locator(
+          '.nav-file-title[data-path="e2e-icon-target-task.md"]',
+        );
 
-      // Wait for the file explorer to render the row.
-      await expect(targetTitle).toHaveCount(1, { timeout: 15_000 });
+        // Wait for the file explorer to render the row.
+        await expect(targetTitle).toHaveCount(1, { timeout: 15_000 });
 
-      // Wait for the patch to inject the overlay (MutationObserver +
-      // metadataCache "resolved" together cover both startup paths).
-      const overlay = targetTitle.locator(".exo-file-explorer-icon");
-      await expect(overlay).toHaveCount(1, { timeout: 15_000 });
+        // Wait for the patch to inject the overlay (MutationObserver +
+        // metadataCache "resolved" together cover both startup paths).
+        const overlay = targetTitle.locator(".exo-file-explorer-icon");
+        await expect(overlay).toHaveCount(1, { timeout: 15_000 });
 
-      // Overlay must precede `.nav-file-title-content` (RFC-024 §4).
-      const order = await targetTitle.evaluate((title) => {
-        const overlayEl = title.querySelector(".exo-file-explorer-icon");
-        const contentEl = title.querySelector(".nav-file-title-content");
-        if (!overlayEl || !contentEl) return null;
-        const children = Array.from(title.children);
-        return {
-          overlayIdx: children.indexOf(overlayEl),
-          contentIdx: children.indexOf(contentEl),
-        };
-      });
-      expect(order).not.toBeNull();
-      expect(order!.overlayIdx).toBeGreaterThanOrEqual(0);
-      expect(order!.overlayIdx).toBeLessThan(order!.contentIdx);
+        // Overlay must precede `.nav-file-title-content` (RFC-024 §4).
+        const order = await targetTitle.evaluate((title) => {
+          const overlayEl = title.querySelector(".exo-file-explorer-icon");
+          const contentEl = title.querySelector(".nav-file-title-content");
+          if (!overlayEl || !contentEl) return null;
+          const children = Array.from(title.children);
+          return {
+            overlayIdx: children.indexOf(overlayEl),
+            contentIdx: children.indexOf(contentEl),
+          };
+        });
+        expect(order).not.toBeNull();
+        expect(order!.overlayIdx).toBeGreaterThanOrEqual(0);
+        expect(order!.overlayIdx).toBeLessThan(order!.contentIdx);
 
-      // Lucide icon name plumbed through `setIcon(overlay, "check-square")`.
-      // Obsidian's setIcon mounts an <svg> child; we assert structural
-      // presence rather than rasterised visuals so this stays robust to
-      // Lucide version bumps.
-      const svg = overlay.locator("svg");
-      await expect(svg).toHaveCount(1);
-    },
-  );
-});
+        // Lucide icon name plumbed through `setIcon(overlay, "check-square")`.
+        // Obsidian's setIcon mounts an <svg> child; we assert structural
+        // presence rather than rasterised visuals so this stays robust to
+        // Lucide version bumps.
+        const svg = overlay.locator("svg");
+        await expect(svg).toHaveCount(1);
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Per [T3.1 Decision Matrix](https://github.com/kitelev/exocortex/blob/main/packages/obsidian-plugin/docs/phase3/T3_1_QUARANTINE_DECISION_MATRIX.md) row #9, `file-explorer-icons.spec.ts` is bucket=**track** under RFC `32a64ed9-9a74-4e0c-bb26-e455605aa384` Phase 3.3.

RFC §3.3 prescribes track (no behavioral change). This PR adds an **inert** Playwright `flaky-track` annotation + comment block so the spec is greppable as `flaky-track #2989` for the Phase 3.4 dashboard, and uses `Fixes #2989` to close the tracking issue per orchestrator batching. Watch criteria preserved in the annotation `description`. **Behavior unchanged** — no `retry()`, no `test.fixme`, no timing tweaks (Charter Risk 1: pre-emptive `retry(1)` would mask a real Phase-4 regression in net-new FileExplorerIconPatch code).

## Decision rationale

- Single incident at N=41 against recently-shipped FileExplorerIconPatch
- Could be flake or real Phase-4 regression — Phase 3.4 dashboard is the right disambiguator
- Adding `retry(1)` pre-emptively masks a regression in net-new code → forbidden

## Watch criteria (preserved in annotation)

- Incident #2 within 30 days → escalate to **fix** with FileExplorerIconPatch owner
- Zero further incidents at N≥100 → close as resolved
- Expiry: **2026-05-31**

## References

- RFC `32a64ed9-9a74-4e0c-bb26-e455605aa384` §3.3
- T3.1 matrix: `packages/obsidian-plugin/docs/phase3/T3_1_QUARANTINE_DECISION_MATRIX.md` row #9
- Charter §4 Risk 1
- Fixes #2989

## Test plan

- [x] `npm run check:types` clean
- [x] `npx prettier --check` clean on modified file
- [x] No behavioural change to spec body
- [ ] 13 required CI checks green
- [ ] Auto-merge + Auto Release succeed