### PR TITLE
T1.2: Create @kitelev/exocortex-services package с adapter injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4200,6 +4200,10 @@
       "resolved": "packages/cli",
       "link": true
     },
+    "node_modules/@kitelev/exocortex-services": {
+      "resolved": "packages/services",
+      "link": true
+    },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
@@ -17182,6 +17186,7 @@
         "exocortex-cli": "dist/index.js"
       },
       "devDependencies": {
+        "@kitelev/exocortex-services": "file:../services",
         "@types/fs-extra": "^11.0.0",
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.0",
@@ -17340,6 +17345,21 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "packages/services": {
+      "name": "@kitelev/exocortex-services",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "exocortex": "file:../exocortex"
+      },
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "@types/node": "^20.19.24",
+        "jest": "^30.0.0",
+        "ts-jest": "^29.4.6",
+        "typescript": "^5.9.3"
       }
     },
     "packages/test-utils": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "npm run dev -w @exocortex/obsidian-plugin",
-    "build": "npm run build -w exocortex && npm run build --workspaces --if-present && tsc -noEmit -skipLibCheck && node packages/obsidian-plugin/esbuild.config.mjs production",
+    "build": "npm run build -w exocortex && npm run build -w @kitelev/exocortex-services && npm run build --workspaces --if-present && tsc -noEmit -skipLibCheck && node packages/obsidian-plugin/esbuild.config.mjs production",
     "lint": "eslint packages/obsidian-plugin/src --ext .ts,.tsx",
     "lint:fix": "eslint packages/obsidian-plugin/src --ext .ts,.tsx --fix",
     "format": "prettier --write 'packages/**/*.{ts,tsx}'",

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
   moduleNameMapper: {
     "^exocortex$": "<rootDir>/../exocortex/src/index.ts",
+    "^@kitelev/exocortex-services$": "<rootDir>/../services/src/index.ts",
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
   transform: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "exocortex": "file:../exocortex",
+    "@kitelev/exocortex-services": "file:../services",
     "@types/fs-extra": "^11.0.0",
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.0",

--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -2,8 +2,6 @@ import {
   ServiceRegistry,
   type IGroundingService,
   type IVaultAdapter,
-  type IFile,
-  type UserInput,
   GenericAssetCreationService,
   ArchiveAssetService,
   FixMissingLabelService,
@@ -12,6 +10,16 @@ import {
   RenameToUidService,
   TaskStatusService,
 } from "exocortex";
+import {
+  createCreateRelatedTaskService,
+  createCreateRelatedProjectService,
+  createArchiveAssetService,
+  createCleanPropertiesService,
+  createFixMissingLabelService,
+  createRenameToUidService,
+  createRepairFolderService,
+  createPlanForEveningService,
+} from "@kitelev/exocortex-services";
 
 /**
  * The 10 well-known service IDs the plugin registers via
@@ -79,268 +87,25 @@ export interface CliServiceRegistryDeps {
   folderRepairService: FolderRepairService;
 }
 
-function resolveTargetFile(vaultAdapter: IVaultAdapter, targetIRI: string): IFile {
-  const candidate = vaultAdapter.getAbstractFileByPath(`${targetIRI}.md`);
-  if (!candidate || !("basename" in candidate)) {
-    throw new Error(`Cannot resolve target file for IRI: ${targetIRI}`);
-  }
-  return candidate as IFile;
-}
-
 /**
- * CLI-side implementation of the `createRelatedTask` service (#2865).
+ * Re-export the storage-agnostic grounding-service factories from the shared
+ * `@kitelev/exocortex-services` package (RFC 94e520da Phase 1, T1.2).
  *
- * Mirrors the plugin handler in
- * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`
- * minus workspace/leaf side-effects — the CLI just writes the new `.md` file
- * and returns. Parent-context inheritance (ems__Effort_area vs ems__Effort_parent)
- * is delegated to `GenericAssetCreationService.inheritParentContext`.
+ * Existing call sites — both internal (`populateCliServiceRegistry` below)
+ * and external test imports — continue to work via this re-export. The
+ * factory definitions themselves moved to `packages/services/src/` so the
+ * plugin can adopt the same handlers in T1.3 without code duplication.
  */
-export function createCreateRelatedTaskService(
-  vaultAdapter: IVaultAdapter,
-  genericAssetCreationService: GenericAssetCreationService,
-): IGroundingService {
-  return {
-    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
-      const label = userInput?.label as string | undefined;
-      if (!label) {
-        throw new Error("createRelatedTask requires userInput.label");
-      }
-
-      const parentFile = resolveTargetFile(vaultAdapter, targetIRI);
-      const parentMetadata =
-        (vaultAdapter.getFrontmatter(parentFile) as Record<string, unknown>) ?? {};
-      const folderPath = parentFile.parent?.path || "";
-
-      const propertyValues: Record<string, unknown> = {
-        ems__Effort_status: '"[[ems__EffortStatusDraft]]"',
-      };
-
-      const explicitParentProperty = userInput?.parentProperty as string | undefined;
-      if (explicitParentProperty && parentFile.basename) {
-        propertyValues[explicitParentProperty] = `"[[${parentFile.basename}]]"`;
-      }
-
-      await genericAssetCreationService.createAsset({
-        className: "ems__Task",
-        label,
-        folderPath,
-        propertyValues,
-        parentFile,
-        parentMetadata,
-      });
-    },
-  };
-}
-
-/**
- * CLI-side implementation of the `createRelatedProject` service (#2866).
- *
- * Mirrors the plugin handler in
- * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`
- * minus workspace/leaf side-effects. Parent-context inheritance
- * (ems__Effort_area vs ems__Effort_parent) is delegated to
- * `GenericAssetCreationService.inheritParentContext`, which covers the
- * `ems__Project` branch symmetrically with `ems__Task`.
- */
-export function createCreateRelatedProjectService(
-  vaultAdapter: IVaultAdapter,
-  genericAssetCreationService: GenericAssetCreationService,
-): IGroundingService {
-  return {
-    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
-      const label = userInput?.label as string | undefined;
-      if (!label) {
-        throw new Error("createRelatedProject requires userInput.label");
-      }
-
-      const parentFile = resolveTargetFile(vaultAdapter, targetIRI);
-      const parentMetadata =
-        (vaultAdapter.getFrontmatter(parentFile) as Record<string, unknown>) ?? {};
-      const folderPath = parentFile.parent?.path || "";
-
-      const propertyValues: Record<string, unknown> = {
-        ems__Effort_status: '"[[ems__EffortStatusDraft]]"',
-      };
-
-      const explicitParentProperty = userInput?.parentProperty as string | undefined;
-      if (explicitParentProperty && parentFile.basename) {
-        propertyValues[explicitParentProperty] = `"[[${parentFile.basename}]]"`;
-      }
-
-      await genericAssetCreationService.createAsset({
-        className: "ems__Project",
-        label,
-        folderPath,
-        propertyValues,
-        parentFile,
-        parentMetadata,
-      });
-    },
-  };
-}
-
-/**
- * CLI-side implementation of the `archiveAsset` service (#2867).
- *
- * Mirrors the plugin handler in
- * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
- * Archive semantic is in-place frontmatter mutation (`archived: true` +
- * remove `aliases`) delegated to the shared `ArchiveAssetService`. No
- * file move; batch cross-vault archival remains the domain of the
- * separate `cli archive` command (`ArchiveService`).
- */
-export function createArchiveAssetService(
-  vaultAdapter: IVaultAdapter,
-  archiveAssetService: ArchiveAssetService,
-): IGroundingService {
-  return {
-    async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
-      await archiveAssetService.archiveAsset(targetFile);
-    },
-  };
-}
-
-/**
- * CLI-side implementation of the `cleanProperties` service (#2869).
- *
- * Mirrors the plugin handler in
- * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
- * Delegates to the shared `PropertyCleanupService` which strips frontmatter
- * entries whose values are empty (`""`, `null`, `undefined`, `[]`, `{}`).
- * Storage-agnostic via `IVaultAdapter`, so the plugin and CLI paths stay
- * byte-identical for the same input.
- */
-export function createCleanPropertiesService(
-  vaultAdapter: IVaultAdapter,
-  propertyCleanupService: PropertyCleanupService,
-): IGroundingService {
-  return {
-    async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
-      await propertyCleanupService.cleanEmptyProperties(targetFile);
-    },
-  };
-}
-
-/**
- * CLI-side implementation of the `fixMissingLabel` service (#2870).
- *
- * Mirrors the plugin handler in
- * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
- * Delegates to the shared `FixMissingLabelService` which sets
- * `exo__Asset_label` to `file.basename` when the property is missing or
- * empty. Idempotent: a no-op when the label is already set. Storage-agnostic
- * via `IVaultAdapter`, so plugin and CLI stay byte-identical.
- */
-export function createFixMissingLabelService(
-  vaultAdapter: IVaultAdapter,
-  fixMissingLabelService: FixMissingLabelService,
-): IGroundingService {
-  return {
-    async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
-      await fixMissingLabelService.fixMissingLabel(targetFile);
-    },
-  };
-}
-
-/**
- * CLI-side implementation of the `renameToUid` service (#2871).
- *
- * Mirrors the plugin handler in
- * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
- * Delegates to the shared `RenameToUidService` which renames the file to
- * match its `exo__Asset_uid` property (e.g. `My Task.md` → `a1b2c3d4-….md`).
- *
- * Caveat: `FileSystemVaultAdapter.updateLinks` in the CLI is a no-op stub —
- * the file itself is renamed and a missing label is backfilled, but
- * wikilinks referencing the old basename in other vault notes are NOT
- * rewritten. Parity with the Obsidian plugin's vault-wide link update is
- * tracked separately; users relying on link rewrite should continue to use
- * Obsidian. Plugin path remains fully symmetric.
- */
-export function createRenameToUidService(
-  vaultAdapter: IVaultAdapter,
-  renameToUidService: RenameToUidService,
-): IGroundingService {
-  return {
-    async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
-      const metadata =
-        (vaultAdapter.getFrontmatter(targetFile) as Record<string, unknown>) ??
-        {};
-      await renameToUidService.renameToUid(targetFile, metadata);
-    },
-  };
-}
-
-/**
- * CLI-side implementation of the `repairFolder` service (#2872).
- *
- * Mirrors the plugin handler in
- * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
- * Delegates to the shared `FolderRepairService`: derives the expected folder
- * from `exo__Asset_isDefinedBy` and moves the target file there. Idempotent —
- * a no-op when the asset is already in the expected folder. Throws when the
- * expected folder cannot be derived (missing `exo__Asset_isDefinedBy` or the
- * referenced asset is not in the vault) so the CLI exits non-zero and dyncommand
- * groundings surface the failure instead of silently no-op'ing (#2864 pattern).
- *
- * Storage-agnostic via `IVaultAdapter`, so plugin and CLI stay byte-identical
- * for the same input. The separate hardcoded `cli command repair-folder`
- * subcommand (`FolderRepairExecutor`) remains for batch/scripting workflows
- * and is not touched by this wiring.
- */
-export function createRepairFolderService(
-  vaultAdapter: IVaultAdapter,
-  folderRepairService: FolderRepairService,
-): IGroundingService {
-  return {
-    async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
-      const metadata =
-        (vaultAdapter.getFrontmatter(targetFile) as Record<string, unknown>) ??
-        {};
-      const expectedFolder = await folderRepairService.getExpectedFolder(
-        targetFile,
-        metadata,
-      );
-      if (expectedFolder === null) {
-        throw new Error(
-          "repairFolder: cannot determine expected folder (missing exo__Asset_isDefinedBy or referenced asset not found)",
-        );
-      }
-      const currentFolder = targetFile.parent?.path ?? "";
-      if (currentFolder === expectedFolder) {
-        return;
-      }
-      await folderRepairService.repairFolder(targetFile, expectedFolder);
-    },
-  };
-}
-
-/**
- * CLI-side implementation of the `planForEvening` service (#2868).
- *
- * Mirrors the plugin handler in
- * `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`.
- * Sets `ems__Effort_plannedStartTimestamp` to today at 19:00:00 local time
- * (no ms, no tz) via the shared `TaskStatusService.planForEvening`, which
- * is already storage-agnostic via `IVaultAdapter`.
- */
-export function createPlanForEveningService(
-  vaultAdapter: IVaultAdapter,
-  taskStatusService: TaskStatusService,
-): IGroundingService {
-  return {
-    async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
-      await taskStatusService.planForEvening(targetFile);
-    },
-  };
-}
+export {
+  createCreateRelatedTaskService,
+  createCreateRelatedProjectService,
+  createArchiveAssetService,
+  createCleanPropertiesService,
+  createFixMissingLabelService,
+  createRenameToUidService,
+  createRepairFolderService,
+  createPlanForEveningService,
+};
 
 /**
  * Populate a ServiceRegistry with fail-loud stubs for all well-known services.
@@ -381,17 +146,11 @@ export function populateCliServiceRegistry(
     );
     registry.register(
       "archiveAsset",
-      createArchiveAssetService(
-        deps.vaultAdapter,
-        deps.archiveAssetService,
-      ),
+      createArchiveAssetService(deps.vaultAdapter, deps.archiveAssetService),
     );
     registry.register(
       "planForEvening",
-      createPlanForEveningService(
-        deps.vaultAdapter,
-        deps.taskStatusService,
-      ),
+      createPlanForEveningService(deps.vaultAdapter, deps.taskStatusService),
     );
     registry.register(
       "cleanProperties",
@@ -402,17 +161,11 @@ export function populateCliServiceRegistry(
     );
     registry.register(
       "renameToUid",
-      createRenameToUidService(
-        deps.vaultAdapter,
-        deps.renameToUidService,
-      ),
+      createRenameToUidService(deps.vaultAdapter, deps.renameToUidService),
     );
     registry.register(
       "repairFolder",
-      createRepairFolderService(
-        deps.vaultAdapter,
-        deps.folderRepairService,
-      ),
+      createRepairFolderService(deps.vaultAdapter, deps.folderRepairService),
     );
     registry.register(
       "fixMissingLabel",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": true,
     "resolveJsonModule": true,
     "paths": {
-      "exocortex": ["../exocortex/src"]
+      "exocortex": ["../exocortex/src"],
+      "@kitelev/exocortex-services": ["../services/src"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/services/jest.config.js
+++ b/packages/services/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  setupFiles: ['reflect-metadata'],
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/?(*.)+(spec|test).ts'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/**/index.ts',
+  ],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+  },
+  moduleNameMapper: {
+    '^exocortex$': '<rootDir>/../exocortex/src/index.ts',
+  },
+};

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@kitelev/exocortex-services",
+  "version": "0.1.0",
+  "description": "Shared grounding-service factories for Exocortex plugin and CLI (RFC 94e520da Phase 1, T1.2)",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "jest",
+    "lint": "eslint src --ext .ts",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "exocortex",
+    "grounding",
+    "service-call",
+    "shared-services"
+  ],
+  "author": "A. Kitelev",
+  "license": "MIT",
+  "dependencies": {
+    "exocortex": "file:../exocortex"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20.19.24",
+    "jest": "^30.0.0",
+    "ts-jest": "^29.4.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -1,0 +1,209 @@
+import type {
+  IGroundingService,
+  IVaultAdapter,
+  IFile,
+  UserInput,
+  GenericAssetCreationService,
+  ArchiveAssetService,
+  TaskStatusService,
+  PropertyCleanupService,
+  FixMissingLabelService,
+  RenameToUidService,
+  FolderRepairService,
+} from "exocortex";
+
+/**
+ * Shared, storage-agnostic grounding-service factories used by both the CLI
+ * (`packages/cli/src/services/CliServiceRegistryPopulator.ts`) and — once T1.3
+ * lands — the plugin (`packages/obsidian-plugin/src/infrastructure/services/`).
+ *
+ * Each factory returns an `IGroundingService` that adapts a domain service
+ * (already lives in the shared `exocortex` package) to the runtime-agnostic
+ * `service_call` contract dispatched by `GroundingExecutor`. All filesystem
+ * access goes through `IVaultAdapter`, so plugin (Obsidian) and CLI (Node fs)
+ * runtimes produce byte-identical state changes for the same input.
+ *
+ * RFC 94e520da Phase 1, T1.2 (`@kitelev/exocortex-services` package).
+ */
+
+function resolveTargetFile(
+  vaultAdapter: IVaultAdapter,
+  targetIRI: string,
+): IFile {
+  const candidate = vaultAdapter.getAbstractFileByPath(`${targetIRI}.md`);
+  if (!candidate || !("basename" in candidate)) {
+    throw new Error(`Cannot resolve target file for IRI: ${targetIRI}`);
+  }
+  return candidate as IFile;
+}
+
+export function createCreateRelatedTaskService(
+  vaultAdapter: IVaultAdapter,
+  genericAssetCreationService: GenericAssetCreationService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
+      const label = userInput?.label as string | undefined;
+      if (!label) {
+        throw new Error("createRelatedTask requires userInput.label");
+      }
+
+      const parentFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const parentMetadata =
+        (vaultAdapter.getFrontmatter(parentFile) as Record<string, unknown>) ??
+        {};
+      const folderPath = parentFile.parent?.path || "";
+
+      const propertyValues: Record<string, unknown> = {
+        ems__Effort_status: '"[[ems__EffortStatusDraft]]"',
+      };
+
+      const explicitParentProperty = userInput?.parentProperty as
+        | string
+        | undefined;
+      if (explicitParentProperty && parentFile.basename) {
+        propertyValues[explicitParentProperty] = `"[[${parentFile.basename}]]"`;
+      }
+
+      await genericAssetCreationService.createAsset({
+        className: "ems__Task",
+        label,
+        folderPath,
+        propertyValues,
+        parentFile,
+        parentMetadata,
+      });
+    },
+  };
+}
+
+export function createCreateRelatedProjectService(
+  vaultAdapter: IVaultAdapter,
+  genericAssetCreationService: GenericAssetCreationService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
+      const label = userInput?.label as string | undefined;
+      if (!label) {
+        throw new Error("createRelatedProject requires userInput.label");
+      }
+
+      const parentFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const parentMetadata =
+        (vaultAdapter.getFrontmatter(parentFile) as Record<string, unknown>) ??
+        {};
+      const folderPath = parentFile.parent?.path || "";
+
+      const propertyValues: Record<string, unknown> = {
+        ems__Effort_status: '"[[ems__EffortStatusDraft]]"',
+      };
+
+      const explicitParentProperty = userInput?.parentProperty as
+        | string
+        | undefined;
+      if (explicitParentProperty && parentFile.basename) {
+        propertyValues[explicitParentProperty] = `"[[${parentFile.basename}]]"`;
+      }
+
+      await genericAssetCreationService.createAsset({
+        className: "ems__Project",
+        label,
+        folderPath,
+        propertyValues,
+        parentFile,
+        parentMetadata,
+      });
+    },
+  };
+}
+
+export function createArchiveAssetService(
+  vaultAdapter: IVaultAdapter,
+  archiveAssetService: ArchiveAssetService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      await archiveAssetService.archiveAsset(targetFile);
+    },
+  };
+}
+
+export function createCleanPropertiesService(
+  vaultAdapter: IVaultAdapter,
+  propertyCleanupService: PropertyCleanupService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      await propertyCleanupService.cleanEmptyProperties(targetFile);
+    },
+  };
+}
+
+export function createFixMissingLabelService(
+  vaultAdapter: IVaultAdapter,
+  fixMissingLabelService: FixMissingLabelService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      await fixMissingLabelService.fixMissingLabel(targetFile);
+    },
+  };
+}
+
+export function createRenameToUidService(
+  vaultAdapter: IVaultAdapter,
+  renameToUidService: RenameToUidService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const metadata =
+        (vaultAdapter.getFrontmatter(targetFile) as Record<string, unknown>) ??
+        {};
+      await renameToUidService.renameToUid(targetFile, metadata);
+    },
+  };
+}
+
+export function createRepairFolderService(
+  vaultAdapter: IVaultAdapter,
+  folderRepairService: FolderRepairService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const metadata =
+        (vaultAdapter.getFrontmatter(targetFile) as Record<string, unknown>) ??
+        {};
+      const expectedFolder = await folderRepairService.getExpectedFolder(
+        targetFile,
+        metadata,
+      );
+      if (expectedFolder === null) {
+        throw new Error(
+          "repairFolder: cannot determine expected folder (missing exo__Asset_isDefinedBy or referenced asset not found)",
+        );
+      }
+      const currentFolder = targetFile.parent?.path ?? "";
+      if (currentFolder === expectedFolder) {
+        return;
+      }
+      await folderRepairService.repairFolder(targetFile, expectedFolder);
+    },
+  };
+}
+
+export function createPlanForEveningService(
+  vaultAdapter: IVaultAdapter,
+  taskStatusService: TaskStatusService,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      await taskStatusService.planForEvening(targetFile);
+    },
+  };
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * @kitelev/exocortex-services — shared grounding-service factories.
+ *
+ * This package hosts the runtime-agnostic factory functions that build
+ * `IGroundingService` instances dispatched by `GroundingExecutor` for
+ * `service_call` groundings (RFC 94e520da Phase 1).
+ *
+ * Both runtimes consume the same factories:
+ * - CLI (`@kitelev/exocortex-cli`) — wired via `CliServiceRegistryPopulator`,
+ *   adapter is `NodeVaultAdapter` over fs/promises.
+ * - Plugin (`@exocortex/obsidian-plugin`) — to be migrated in T1.3, adapter
+ *   will be `ObsidianVaultAdapter` over Obsidian's `app.vault` API.
+ *
+ * Domain services themselves continue to live in the shared `exocortex`
+ * package; this package only provides the thin `IVaultAdapter`-aware
+ * grounding-handler shells that bridge them to the registry contract.
+ *
+ * Scope of T1.2 (this PR): the 8 storage-agnostic CLI-side factories are
+ * moved here. Plugin-side migration of the remaining handlers (UI tab open,
+ * SPARQL invocation, status workflow, voting, etc.) is tracked under T1.3 +
+ * follow-up tickets per RFC § Phase 1 plan.
+ */
+
+export {
+  createCreateRelatedTaskService,
+  createCreateRelatedProjectService,
+  createArchiveAssetService,
+  createCleanPropertiesService,
+  createFixMissingLabelService,
+  createRenameToUidService,
+  createRepairFolderService,
+  createPlanForEveningService,
+} from "./grounding-service-factories";

--- a/packages/services/tests/grounding-service-factories.test.ts
+++ b/packages/services/tests/grounding-service-factories.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  createCreateRelatedTaskService,
+  createCreateRelatedProjectService,
+  createArchiveAssetService,
+  createCleanPropertiesService,
+  createFixMissingLabelService,
+  createRenameToUidService,
+  createRepairFolderService,
+  createPlanForEveningService,
+} from "../src/index";
+
+/**
+ * Smoke contract tests for the factories re-housed in
+ * `@kitelev/exocortex-services`. The factories are pure adapters: they do not
+ * read or write the filesystem themselves, they only call into the injected
+ * `IVaultAdapter` and the injected domain service. Behavioural parity tests
+ * (real fs, vault-shaped fixtures) continue to live in
+ * `packages/cli/tests/unit/services/*.test.ts`, since the factories were
+ * previously defined inline there. This suite exists to lock in the contract
+ * of the new public API: each factory returns an `IGroundingService` whose
+ * `execute` resolves a target file via `getAbstractFileByPath(`${IRI}.md`)`
+ * and delegates to the injected domain service.
+ */
+
+interface StubFile {
+  basename: string;
+  parent: { path: string };
+}
+
+function stubFile(basename: string, parentPath = "Tasks"): StubFile {
+  return { basename, parent: { path: parentPath } };
+}
+
+function stubVaultAdapter(file: StubFile, frontmatter: Record<string, unknown> = {}) {
+  return {
+    getAbstractFileByPath: (_path: string) => file as never,
+    getFrontmatter: (_f: unknown) => frontmatter,
+  } as never;
+}
+
+describe("@kitelev/exocortex-services — factory contract", () => {
+  it("createCreateRelatedTaskService delegates to GenericAssetCreationService.createAsset with ems__Task", async () => {
+    const calls: unknown[] = [];
+    const generic = {
+      createAsset: async (args: unknown) => {
+        calls.push(args);
+      },
+    } as never;
+    const file = stubFile("parent-uid", "Tasks/Inbox");
+    const adapter = stubVaultAdapter(file, { exo__Asset_label: "Parent" });
+    const service = createCreateRelatedTaskService(adapter, generic);
+
+    await service.execute("parent-uid", { label: "Child Task" });
+
+    expect(calls).toHaveLength(1);
+    const arg = calls[0] as { className: string; label: string; folderPath: string };
+    expect(arg.className).toBe("ems__Task");
+    expect(arg.label).toBe("Child Task");
+    expect(arg.folderPath).toBe("Tasks/Inbox");
+  });
+
+  it("createCreateRelatedTaskService throws when label is missing", async () => {
+    const generic = { createAsset: async () => {} } as never;
+    const adapter = stubVaultAdapter(stubFile("uid"));
+    const service = createCreateRelatedTaskService(adapter, generic);
+
+    await expect(service.execute("uid", {})).rejects.toThrow(
+      /createRelatedTask requires userInput.label/,
+    );
+  });
+
+  it("createCreateRelatedProjectService delegates with ems__Project class", async () => {
+    const calls: unknown[] = [];
+    const generic = {
+      createAsset: async (args: unknown) => {
+        calls.push(args);
+      },
+    } as never;
+    const adapter = stubVaultAdapter(stubFile("area-uid", "Areas"));
+    const service = createCreateRelatedProjectService(adapter, generic);
+
+    await service.execute("area-uid", { label: "New Project" });
+
+    expect((calls[0] as { className: string }).className).toBe("ems__Project");
+  });
+
+  it("createArchiveAssetService delegates to ArchiveAssetService.archiveAsset", async () => {
+    const seen: unknown[] = [];
+    const archive = {
+      archiveAsset: async (file: unknown) => {
+        seen.push(file);
+      },
+    } as never;
+    const file = stubFile("archive-me");
+    const adapter = stubVaultAdapter(file);
+    const service = createArchiveAssetService(adapter, archive);
+
+    await service.execute("archive-me");
+
+    expect(seen).toHaveLength(1);
+  });
+
+  it("createCleanPropertiesService delegates to PropertyCleanupService", async () => {
+    const seen: unknown[] = [];
+    const cleanup = {
+      cleanEmptyProperties: async (file: unknown) => {
+        seen.push(file);
+      },
+    } as never;
+    const adapter = stubVaultAdapter(stubFile("uid"));
+    const service = createCleanPropertiesService(adapter, cleanup);
+
+    await service.execute("uid");
+
+    expect(seen).toHaveLength(1);
+  });
+
+  it("createFixMissingLabelService delegates to FixMissingLabelService", async () => {
+    const seen: unknown[] = [];
+    const fix = {
+      fixMissingLabel: async (file: unknown) => {
+        seen.push(file);
+      },
+    } as never;
+    const adapter = stubVaultAdapter(stubFile("uid"));
+    const service = createFixMissingLabelService(adapter, fix);
+
+    await service.execute("uid");
+
+    expect(seen).toHaveLength(1);
+  });
+
+  it("createRenameToUidService passes resolved metadata to the domain service", async () => {
+    const calls: Array<[unknown, unknown]> = [];
+    const rename = {
+      renameToUid: async (file: unknown, meta: unknown) => {
+        calls.push([file, meta]);
+      },
+    } as never;
+    const meta = { exo__Asset_uid: "abc123" };
+    const adapter = stubVaultAdapter(stubFile("name"), meta);
+    const service = createRenameToUidService(adapter, rename);
+
+    await service.execute("name");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0][1]).toEqual(meta);
+  });
+
+  it("createRepairFolderService throws when expected folder cannot be derived", async () => {
+    const folderRepair = {
+      getExpectedFolder: async () => null,
+      repairFolder: async () => {
+        throw new Error("must not be called");
+      },
+    } as never;
+    const adapter = stubVaultAdapter(stubFile("uid", "Wherever"));
+    const service = createRepairFolderService(adapter, folderRepair);
+
+    await expect(service.execute("uid")).rejects.toThrow(/cannot determine expected folder/);
+  });
+
+  it("createRepairFolderService no-ops when current folder matches expected", async () => {
+    let repaired = false;
+    const folderRepair = {
+      getExpectedFolder: async () => "Tasks",
+      repairFolder: async () => {
+        repaired = true;
+      },
+    } as never;
+    const adapter = stubVaultAdapter(stubFile("uid", "Tasks"));
+    const service = createRepairFolderService(adapter, folderRepair);
+
+    await service.execute("uid");
+
+    expect(repaired).toBe(false);
+  });
+
+  it("createRepairFolderService delegates repair when folders differ", async () => {
+    const calls: Array<[unknown, string]> = [];
+    const folderRepair = {
+      getExpectedFolder: async () => "Tasks",
+      repairFolder: async (file: unknown, folder: string) => {
+        calls.push([file, folder]);
+      },
+    } as never;
+    const adapter = stubVaultAdapter(stubFile("uid", "Misplaced"));
+    const service = createRepairFolderService(adapter, folderRepair);
+
+    await service.execute("uid");
+
+    expect(calls).toEqual([[expect.anything(), "Tasks"]]);
+  });
+
+  it("createPlanForEveningService delegates to TaskStatusService.planForEvening", async () => {
+    const seen: unknown[] = [];
+    const taskStatus = {
+      planForEvening: async (file: unknown) => {
+        seen.push(file);
+      },
+    } as never;
+    const adapter = stubVaultAdapter(stubFile("uid"));
+    const service = createPlanForEveningService(adapter, taskStatus);
+
+    await service.execute("uid");
+
+    expect(seen).toHaveLength(1);
+  });
+
+  it("factories throw when target file cannot be resolved", async () => {
+    const generic = { createAsset: async () => {} } as never;
+    const adapter = {
+      getAbstractFileByPath: () => null,
+      getFrontmatter: () => ({}),
+    } as never;
+    const service = createCreateRelatedTaskService(adapter, generic);
+
+    await expect(service.execute("missing-uid", { label: "x" })).rejects.toThrow(
+      /Cannot resolve target file/,
+    );
+  });
+});

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/services/tsconfig.test.json
+++ b/packages/services/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "exocortex": ["../exocortex/src"]
+    }
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,18 @@
     "baseUrl": ".",
     "paths": {
       "exocortex": ["./packages/exocortex/src/index.ts"],
+      "@kitelev/exocortex-services": ["./packages/services/src/index.ts"],
       "@plugin/types": ["./packages/obsidian-plugin/src/types/index.ts"],
       "@plugin/types/*": ["./packages/obsidian-plugin/src/types/*"],
       "@plugin/adapters/*": ["./packages/obsidian-plugin/src/adapters/*"],
       "@plugin/application/*": ["./packages/obsidian-plugin/src/application/*"],
       "@plugin/domain/*": ["./packages/obsidian-plugin/src/domain/*"],
-      "@plugin/infrastructure/*": ["./packages/obsidian-plugin/src/infrastructure/*"],
-      "@plugin/presentation/*": ["./packages/obsidian-plugin/src/presentation/*"],
+      "@plugin/infrastructure/*": [
+        "./packages/obsidian-plugin/src/infrastructure/*"
+      ],
+      "@plugin/presentation/*": [
+        "./packages/obsidian-plugin/src/presentation/*"
+      ],
       "@plugin/*": ["./packages/obsidian-plugin/src/*"]
     },
     "inlineSourceMap": true,


### PR DESCRIPTION
Closes vault task `95817483-c487-495e-b2c8-b307d97b0fe9`.

RFC `94e520da` Phase 1, T1.2 — извлекаю shared grounding-service factories в новый workspace package, чтобы plugin (T1.3) и CLI (уже на main) строили один и тот же `ServiceRegistry` без code-duplication.

## Summary
- New workspace package `packages/services/` → `@kitelev/exocortex-services` (build via `tsc`, tests via `ts-jest`).
- 8 storage-agnostic factory functions переехали из `packages/cli/src/services/CliServiceRegistryPopulator.ts` в `packages/services/src/grounding-service-factories.ts`: `createCreateRelatedTask`, `createCreateRelatedProject`, `createArchiveAsset`, `createCleanProperties`, `createFixMissingLabel`, `createRenameToUid`, `createRepairFolder`, `createPlanForEvening`.
- CLI populator теперь импортирует факторы из нового package и реэкспортирует их — все 68 существующих CLI service-тестов в `packages/cli/tests/unit/services/*` остаются зелёными zero-changes.
- 12 contract tests в новом package фиксируют публичный API: каждый фактор резолвит target через `getAbstractFileByPath` и делегирует в инжектируемый domain service.

## Scope decision (autonomous)
RFC § Phase 1 R1 явно говорит: extraction всех ~26 plugin-side handlers — 4-5 weeks, нужен инкрементальный подход. Эта PR ограничена тем, что **уже** runtime-agnostic — 8 CLI factories. Plugin-side handlers (`updateProperty`/`removeProperty`/`setStatus`/`createAsset`/`rollbackStatus`/`shiftDay`/`copyLabelToAliases`/`incrementVotes`/`createNarrowerConcept`/`createSubclass`/`createTaskForDailyNote`, плюс UI-effecting `openFile`/`trashFile`/`sparqlSelect`) остаются в `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts` и мигрируют в **T1.3** (plugin transitions to shared package) с adapter abstraction для UI side-effects (workspace tab, leaf focus). Decision записан в Progress Log vault-task'а.

## Test plan
- [x] `npm run check:types` (root) — clean
- [x] `npm run lint` (root) — 2 pre-existing warnings, 0 new
- [x] `packages/services` jest — 12/12 pass
- [x] `packages/cli` jest tests/unit/services — 68/68 pass
- [x] CLI typecheck — fewer errors than baseline (29 vs 33 на main, pre-existing only)
- [ ] CI green (13 required checks: archgate, detect-changes, e2e-shard 1..6, lint, test-bdd, test-component, test-coverage, typecheck)

## Acceptance Criteria (T1.2)
- [x] Implementation complete (package skeleton + 8 factories migrated)
- [x] Tests added/updated (12 new contract tests + 68 existing CLI tests pass)
- [ ] CI green (pending)
- [x] Phase-level metric не ухудшилась (additive change, no behaviour modification)