### PR TITLE
T2.2: hasClass dual-format support (UUID + label)

### DIFF
--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -516,6 +516,70 @@ describe("dynamic-command CLI", () => {
 
       consoleSpy.mockRestore();
     });
+
+    it("should resolve UUID-wikilink with alias via reverse index (#2863 T2.2)", async () => {
+      // Real vault pattern: exo__Instance_class entries are UUID-wikilinks WITH human-readable
+      // alias suffix, e.g. "[[<class-uuid>|exocmd__Command]]". hasClass must extract the UUID
+      // (before the pipe) and resolve to label via reverse index, ignoring the alias text.
+      const classFm = [
+        "exo__Asset_uid: 790e5b16-251d-4556-96ac-e5c7f1429b2e",
+        'exo__Asset_label: "exocmd__Command"',
+      ].join("\n");
+
+      const gndClassFm = [
+        "exo__Asset_uid: 11579feb-2e42-491c-af59-b89b1129a539",
+        'exo__Asset_label: "exocmd__Grounding"',
+      ].join("\n");
+
+      const cmdAliasFm = [
+        "exo__Instance_class:",
+        // UUID-wikilink with deliberately misleading alias text — must NOT short-circuit on alias
+        '  - "[[790e5b16-251d-4556-96ac-e5c7f1429b2e|Some Display Name]]"',
+        "exo__Asset_uid: cmd-uuid-aliased",
+        "exo__Asset_label: UUID Aliased Command",
+        "exocmd__Command_grounding: [[gnd-uuid-aliased]]",
+      ].join("\n");
+
+      const gndAliasFm = [
+        "exo__Instance_class:",
+        '  - "[[11579feb-2e42-491c-af59-b89b1129a539|Grounding Instance]]"',
+        "exo__Asset_uid: gnd-uuid-aliased",
+        'exocmd__Grounding_type: "property_set"',
+      ].join("\n");
+
+      mockReaddirSync.mockImplementation((dir: string) => {
+        if (dir.endsWith("/vault")) {
+          return [
+            { name: "cmd-class.md", isDirectory: () => false },
+            { name: "gnd-class.md", isDirectory: () => false },
+            { name: "cmd.md", isDirectory: () => false },
+            { name: "gnd.md", isDirectory: () => false },
+          ];
+        }
+        return [];
+      });
+
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("/cmd-class.md")) return `---\n${classFm}\n---\n`;
+        if (path.endsWith("/gnd-class.md")) return `---\n${gndClassFm}\n---\n`;
+        if (path.endsWith("/cmd.md")) return `---\n${cmdAliasFm}\n---\n`;
+        if (path.endsWith("/gnd.md")) return `---\n${gndAliasFm}\n---\n`;
+        return "";
+      });
+
+      const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+      const cmd = dynamicCommandCommand();
+      const listCmd = cmd.commands.find((c: any) => c.name() === "list");
+      await listCmd.parseAsync(["--vault", "/vault", "--output", "json"], { from: "user" });
+
+      const output = consoleSpy.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toMatch(/"totalCommands":\s*1/);
+      expect(output).toContain("cmd-uuid-aliased");
+      expect(output).toContain("property_set");
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe("show action", () => {


### PR DESCRIPTION
Closes vault task `74c0855a-a10d-47a8-bc68-fd5a10b3d464`.
Refs RFC `94e520da-c6f7-48af-944c-51298d68da45` § Phase 2 T2.2.

## Summary

Adds explicit unit-test for the most common vault pattern — `exo__Instance_class: "[[<uuid>|<human-label>]]"`. Verifies `hasClass` extracts the UUID prefix (not the alias text) and resolves to the canonical class label via the reverse index built in T2.1 (#3022 / #2873).

## Context

Implementation of dual-format `hasClass` already shipped in #2873. T2.1 (#3022) added the mixed-vault test. This PR closes the remaining gap: previous mixed-vault test used UUID-wikilinks **without** alias (`[[uuid]]`), but real starter-kit and user vaults predominantly use the aliased form (`[[uuid|Label]]`). Confirms the regex `/\[\[([^|\]]+)/` correctly trims the alias before UUID resolution.

## Test plan

- [x] `npm test -- tests/unit/commands/dynamic-command.test.ts` — 25/25 pass (was 24, +1 new test)
- [x] `npm run check:types` — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings unchanged)
- [ ] CI: 13 required checks green