### PR TITLE
test(cli): dyncommand validate on 3 vault shapes (T2.3 #2863 / RFC Phase 2)

### DIFF
--- a/packages/cli/tests/unit/commands/dynamic-command.test.ts
+++ b/packages/cli/tests/unit/commands/dynamic-command.test.ts
@@ -787,6 +787,133 @@ describe("dynamic-command CLI", () => {
       consoleSpy.mockRestore();
     });
 
+    // RFC 94e520da § Phase 2 — T2.3 explicit per-shape coverage for `dyncommand validate`.
+    // List-side coverage shipped in T2.1 (#3022 mixed) + T2.2 (#3026 UUID+alias).
+    // Validate-side previously covered only the label-only shape — these cases lock in
+    // the dual-format `hasClass` reverse index for the `validate` codepath as well.
+    describe.each([
+      {
+        shape: "UUID-only",
+        commandClass: '"[[790e5b16-251d-4556-96ac-e5c7f1429b2e]]"',
+        groundingClass: '"[[11579feb-2e42-491c-af59-b89b1129a539]]"',
+      },
+      {
+        shape: "label-only",
+        commandClass: "exocmd__Command",
+        groundingClass: "exocmd__Grounding",
+      },
+      {
+        shape: "mixed (cmd UUID-wikilink, grounding label)",
+        commandClass: '"[[790e5b16-251d-4556-96ac-e5c7f1429b2e]]"',
+        groundingClass: "exocmd__Grounding",
+      },
+    ])(
+      "vault shape: $shape (RFC Phase 2 T2.3)",
+      ({ commandClass, groundingClass }) => {
+        const cmdClassFm = [
+          "exo__Asset_uid: 790e5b16-251d-4556-96ac-e5c7f1429b2e",
+          'exo__Asset_label: "exocmd__Command"',
+        ].join("\n");
+        const gndClassFm = [
+          "exo__Asset_uid: 11579feb-2e42-491c-af59-b89b1129a539",
+          'exo__Asset_label: "exocmd__Grounding"',
+        ].join("\n");
+
+        it("validates a well-formed command + grounding pair", async () => {
+          const commandFm = [
+            `exo__Instance_class: ${commandClass}`,
+            "exo__Asset_uid: cmd-shape",
+            "exo__Asset_label: Shape Command",
+            "exocmd__Command_grounding: [[gnd-shape]]",
+          ].join("\n");
+
+          const groundingFm = [
+            `exo__Instance_class: ${groundingClass}`,
+            "exo__Asset_uid: gnd-shape",
+            "exo__Asset_label: Shape Grounding",
+            "exocmd__Grounding_type: property_set",
+            "exocmd__Grounding_targetProperty: ems__Effort_startTimestamp",
+            "exocmd__Grounding_targetValue: $now",
+          ].join("\n");
+
+          const bindingFm = [
+            "exo__Instance_class: exocmd__CommandBinding",
+            "exo__Asset_uid: bind-shape",
+            "exocmd__CommandBinding_command: [[cmd-shape]]",
+          ].join("\n");
+
+          mockReaddirSync.mockImplementation((dir: string) => {
+            if (dir.endsWith("/vault")) {
+              return [
+                { name: "cmd-class.md", isDirectory: () => false },
+                { name: "gnd-class.md", isDirectory: () => false },
+                { name: "cmd.md", isDirectory: () => false },
+                { name: "gnd.md", isDirectory: () => false },
+                { name: "bind.md", isDirectory: () => false },
+              ];
+            }
+            return [];
+          });
+
+          mockReadFileSync.mockImplementation((path: string) => {
+            if (path.endsWith("/cmd-class.md")) return `---\n${cmdClassFm}\n---\n`;
+            if (path.endsWith("/gnd-class.md")) return `---\n${gndClassFm}\n---\n`;
+            if (path.endsWith("/cmd.md")) return `---\n${commandFm}\n---\n`;
+            if (path.endsWith("/gnd.md")) return `---\n${groundingFm}\n---\n`;
+            if (path.endsWith("/bind.md")) return `---\n${bindingFm}\n---\n`;
+            return "";
+          });
+
+          const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+          const cmd = dynamicCommandCommand();
+          const valCmd = cmd.commands.find((c: any) => c.name() === "validate");
+          await valCmd.parseAsync(["--vault", "/vault"], { from: "user" });
+
+          const output = consoleSpy.mock.calls.map((c: any) => c[0]).join("\n");
+          expect(output).toContain("valid");
+          expect(output).not.toContain("Missing");
+
+          consoleSpy.mockRestore();
+        });
+
+        it("flags a command with missing grounding link", async () => {
+          const commandFm = [
+            `exo__Instance_class: ${commandClass}`,
+            "exo__Asset_uid: cmd-broken-shape",
+            "exo__Asset_label: Broken Shape Command",
+          ].join("\n");
+
+          mockReaddirSync.mockImplementation((dir: string) => {
+            if (dir.endsWith("/vault")) {
+              return [
+                { name: "cmd-class.md", isDirectory: () => false },
+                { name: "broken.md", isDirectory: () => false },
+              ];
+            }
+            return [];
+          });
+
+          mockReadFileSync.mockImplementation((path: string) => {
+            if (path.endsWith("/cmd-class.md")) return `---\n${cmdClassFm}\n---\n`;
+            if (path.endsWith("/broken.md")) return `---\n${commandFm}\n---\n`;
+            return "";
+          });
+
+          const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+          const cmd = dynamicCommandCommand();
+          const valCmd = cmd.commands.find((c: any) => c.name() === "validate");
+          await valCmd.parseAsync(["--vault", "/vault"], { from: "user" });
+
+          const output = consoleSpy.mock.calls.map((c: any) => c[0]).join("\n");
+          expect(output).toContain("Missing exocmd__Command_grounding");
+
+          consoleSpy.mockRestore();
+        });
+      },
+    );
+
     it("should report missing serviceId in service_call grounding", async () => {
       const commandFm = [
         "exo__Instance_class: exocmd__Command",


### PR DESCRIPTION
## Summary

T2.1 (#3022) and T2.2 (#3026) shipped explicit `dyncommand list` coverage for UUID-only / label-only / mixed / UUID+alias vault shapes. The `dyncommand validate` codepath shares the same dual-format `hasClass` reverse index but had only label-only test coverage — leaving the discriminator untested for the modern starter-kit (UUID-wikilink) and mixed legacy/modern vault layouts.

Adds parametrised `describe.each` over UUID-only, label-only, and mixed shapes, asserting that `dyncommand validate`:

- reports a well-formed command + grounding + binding triple as **valid**
- flags a missing `exocmd__Command_grounding` link

regardless of which shape the class reference takes. Locks in regression-resistance of the reverse-index behaviour for the validate codepath in addition to list.

No production code changes — additive test coverage only. 31/31 unit tests pass; `check:types` clean; lint clean.

Refs RFC `94e520da-c6f7-48af-944c-51298d68da45` § Phase 2 T2.3.

Closes vault task `b5c7f979-bed9-4c32-b983-d2f5cc0a694e`.

## Test plan

- [x] `npm test -- tests/unit/commands/dynamic-command.test.ts` — 31/31 passing (3 new shape × 2 cases = 6 added)
- [x] `npm run check:types` — clean
- [x] `npm run lint` — clean (only pre-existing warnings)
- [ ] CI green on all 13 required checks