### PR TITLE
feat(cli): alias-index in FileSystemVaultAdapter (T3.1 RFC-027 Phase 3)

### DIFF
--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -10,6 +10,21 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
   /** UUID (lowercase) → relative filepath mapping for O(1) lookups */
   private uuidIndex: Map<string, string> | null = null;
 
+  /**
+   * Lower-cased basename → relative filepath. Mirrors Obsidian's
+   * metadataCache basename-aware wikilink resolution across the vault.
+   */
+  private basenameIndex: Map<string, string> | null = null;
+
+  /**
+   * Lower-cased frontmatter alias → relative filepath. Required for
+   * CLI ↔ plugin triple parity (RFC-027 Phase 3): wikilinks like
+   * `[[ems__EffortStatusBacklog]]` must resolve to the file that has
+   * `aliases: [ems__EffortStatusBacklog]`, just like Obsidian's
+   * metadataCache.getFirstLinkpathDest does.
+   */
+  private aliasIndex: Map<string, string> | null = null;
+
   constructor(private rootPath: string) {}
 
   async read(file: IFile): Promise<string> {
@@ -163,7 +178,80 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
       return this.createFileObject(relativePath);
     }
 
+    // Step 4: Fall back to basename / frontmatter-alias index lookup so
+    // wikilinks like [[ems__EffortStatusBacklog]] resolve to the file that
+    // declares it as a basename or alias, matching Obsidian's behavior.
+    if (this.basenameIndex === null || this.aliasIndex === null) {
+      this.buildLinkpathIndex();
+    }
+
+    const linkKey = cleanLinkpath.toLowerCase();
+    const basenameMatch = this.basenameIndex!.get(linkKey);
+    if (basenameMatch) {
+      return this.createFileObject(basenameMatch);
+    }
+
+    const aliasMatch = this.aliasIndex!.get(linkKey);
+    if (aliasMatch) {
+      return this.createFileObject(aliasMatch);
+    }
+
     return null;
+  }
+
+  /**
+   * Build basename- and alias-to-filepath indexes by scanning the vault
+   * once. Mirrors Obsidian's metadataCache.getFirstLinkpathDest semantics
+   * required for CLI ↔ plugin triple parity (RFC-027 Phase 3).
+   *
+   * Conflict policy: first-write-wins. Obsidian itself produces a single
+   * winner for ambiguous basenames/aliases; we choose deterministically
+   * by traversal order rather than overwriting, so repeated lookups are
+   * stable within one process.
+   */
+  private buildLinkpathIndex(): void {
+    this.basenameIndex = new Map();
+    this.aliasIndex = new Map();
+
+    this.walkDirectory(this.rootPath, (fullPath) => {
+      if (!fullPath.endsWith(".md")) {
+        return;
+      }
+
+      const relativePath = path.relative(this.rootPath, fullPath);
+      const basename = path.basename(fullPath, ".md").toLowerCase();
+      if (!this.basenameIndex!.has(basename)) {
+        this.basenameIndex!.set(basename, relativePath);
+      }
+
+      let raw: string;
+      try {
+        raw = fs.readFileSync(fullPath, "utf-8");
+      } catch {
+        return; // Permission/IO errors – skip this file.
+      }
+
+      const frontmatter = this.extractFrontmatter(raw);
+      if (!frontmatter) {
+        return;
+      }
+
+      const aliases = frontmatter.aliases;
+      const aliasList = Array.isArray(aliases)
+        ? aliases
+        : typeof aliases === "string"
+          ? [aliases]
+          : [];
+
+      for (const alias of aliasList) {
+        if (typeof alias !== "string") continue;
+        const key = alias.trim().toLowerCase();
+        if (!key) continue;
+        if (!this.aliasIndex!.has(key)) {
+          this.aliasIndex!.set(key, relativePath);
+        }
+      }
+    });
   }
 
   /**

--- a/packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts
+++ b/packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts
@@ -375,6 +375,194 @@ describe("FileSystemVaultAdapter", () => {
         expect(result2).not.toBeNull();
       });
     });
+
+    // RFC-027 Phase 3: alias-aware getFirstLinkpathDest for CLI ↔ plugin parity
+    describe("alias-index resolution (RFC-027 Phase 3)", () => {
+      let readFileSyncSpy: jest.SpiedFunction<typeof fs.readFileSync>;
+
+      beforeEach(() => {
+        readFileSyncSpy = jest.spyOn(fs, "readFileSync");
+      });
+
+      const setupVault = (
+        files: { name: string; content: string }[],
+      ): void => {
+        const filenames = files.map((f) => f.name);
+
+        readdirSyncSpy.mockImplementation((dir) => {
+          if (String(dir) === rootPath) {
+            return filenames.map((name) => ({
+              name,
+              isDirectory: () => false,
+              isFile: () => true,
+            })) as unknown as fs.Dirent[];
+          }
+          return [] as unknown as fs.Dirent[];
+        });
+
+        existsSyncSpy.mockImplementation((p) => {
+          const pathStr = String(p);
+          return filenames.some(
+            (name) => pathStr === path.join(rootPath, name),
+          );
+        });
+
+        readFileSyncSpy.mockImplementation((p) => {
+          const pathStr = String(p);
+          const match = files.find(
+            (f) => pathStr === path.join(rootPath, f.name),
+          );
+          if (match) return match.content;
+          throw new Error(`File not found: ${pathStr}`);
+        });
+      };
+
+      it("should resolve wikilink to file via frontmatter alias match", () => {
+        // [[ems__EffortStatusBacklog]] → file `753a44d5-...md` whose
+        // frontmatter declares aliases: [ems__EffortStatusBacklog].
+        const uuid = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+        setupVault([
+          {
+            name: `${uuid}.md`,
+            content: `---\nexo__Asset_uid: ${uuid}\naliases:\n  - ems__EffortStatusBacklog\n---\nbody`,
+          },
+          {
+            name: "other.md",
+            content: "---\naliases:\n  - something-else\n---\n",
+          },
+        ]);
+
+        const result = adapter.getFirstLinkpathDest(
+          "ems__EffortStatusBacklog",
+          "source.md",
+        );
+
+        expect(result).not.toBeNull();
+        expect(result?.path).toBe(`${uuid}.md`);
+      });
+
+      it("should resolve wikilink via basename when file isn't in source dir", () => {
+        // Basename match anywhere in vault, like Obsidian's
+        // metadataCache. Existing path-relative resolution returns null
+        // when the file isn't adjacent to source.
+        setupVault([
+          {
+            name: "ems__EffortStatusBacklog.md",
+            content: "---\nlabel: Backlog\n---\nbody",
+          },
+        ]);
+
+        const result = adapter.getFirstLinkpathDest(
+          "ems__EffortStatusBacklog",
+          "deep/nested/source.md",
+        );
+
+        expect(result).not.toBeNull();
+        expect(result?.path).toBe("ems__EffortStatusBacklog.md");
+      });
+
+      it("should match aliases case-insensitively", () => {
+        const uuid = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+        setupVault([
+          {
+            name: `${uuid}.md`,
+            content: `---\naliases:\n  - ems__EffortStatusDoing\n---\n`,
+          },
+        ]);
+
+        const result = adapter.getFirstLinkpathDest(
+          "EMS__effortstatusDOING",
+          "source.md",
+        );
+
+        expect(result).not.toBeNull();
+        expect(result?.path).toBe(`${uuid}.md`);
+      });
+
+      it("should accept scalar alias (single string) in frontmatter", () => {
+        setupVault([
+          {
+            name: "scalar.md",
+            content: "---\naliases: solo-alias\n---\n",
+          },
+        ]);
+
+        const result = adapter.getFirstLinkpathDest("solo-alias", "src.md");
+
+        expect(result).not.toBeNull();
+        expect(result?.path).toBe("scalar.md");
+      });
+
+      it("should return null when neither basename nor alias matches", () => {
+        setupVault([
+          {
+            name: "alpha.md",
+            content: "---\naliases:\n  - alpha-alias\n---\n",
+          },
+        ]);
+
+        const result = adapter.getFirstLinkpathDest("nope", "src.md");
+
+        expect(result).toBeNull();
+      });
+
+      it("should prefer basename over alias when both could match different files", () => {
+        // Obsidian-style precedence: a file named exactly like the
+        // linkpath wins over a different file that lists it as alias.
+        setupVault([
+          {
+            name: "Foo.md",
+            content: "---\n---\nbody",
+          },
+          {
+            name: "other.md",
+            content: "---\naliases:\n  - Foo\n---\n",
+          },
+        ]);
+
+        const result = adapter.getFirstLinkpathDest("Foo", "src.md");
+
+        expect(result).not.toBeNull();
+        expect(result?.path).toBe("Foo.md");
+      });
+
+      it("should ignore alias-stripped suffix when matching", () => {
+        // Wikilink display alias (`linkpath|label`) is stripped before
+        // alias-index lookup, just like for UUID resolution.
+        setupVault([
+          {
+            name: "target.md",
+            content: "---\naliases:\n  - my-alias\n---\n",
+          },
+        ]);
+
+        const result = adapter.getFirstLinkpathDest(
+          "my-alias|Display Label",
+          "src.md",
+        );
+
+        expect(result).not.toBeNull();
+        expect(result?.path).toBe("target.md");
+      });
+
+      it("should not crash on files with malformed frontmatter", () => {
+        setupVault([
+          {
+            name: "broken.md",
+            content: "---\naliases: [unterminated\n---\nbody",
+          },
+          {
+            name: "good.md",
+            content: "---\naliases:\n  - good-alias\n---\n",
+          },
+        ]);
+
+        const result = adapter.getFirstLinkpathDest("good-alias", "src.md");
+
+        expect(result).not.toBeNull();
+        expect(result?.path).toBe("good.md");
+      });
+    });
   });
 
   describe("getAllFiles() - directory boundary and hidden folders", () => {


### PR DESCRIPTION
## Summary
- Adds basename + frontmatter-alias fallback to `FileSystemVaultAdapter.getFirstLinkpathDest`, mirroring Obsidian's `metadataCache.getFirstLinkpathDest` semantics.
- Wikilinks like `[[ems__EffortStatusBacklog]]` now resolve to the file declaring it as basename or in `aliases:` frontmatter — not just by relative path or UUID.
- Foundation for CLI ↔ plugin triple parity (RFC-027 Phase 3 closure). Resolves the divergence documented in aiKnow `b4a956fc` where the same vault produced namespace-URI triples in CLI vs file-IRI triples in plugin.

Resolution order in `getFirstLinkpathDest`: UUID → relative path → **basename → alias** (new).

Both indexes are built lazily on first non-UUID lookup using the existing vault walk + `extractFrontmatter`. First-write-wins for ambiguous keys keeps lookups deterministic.

## Test plan
- [x] 8 new unit tests in `FileSystemVaultAdapter.test.ts`:
  - frontmatter alias match
  - basename match across vault when not in source dir
  - case-insensitive matching
  - scalar vs array alias frontmatter
  - null when no match
  - basename precedence over alias on collision
  - alias-strip suffix (`linkpath|label`) before lookup
  - resilient to malformed frontmatter
- [x] `npm test` in `packages/cli` — 1764 passed, 0 failed (6.8s)
- [x] `npm run check:types` — clean
- [x] `npm run lint` — only pre-existing warnings unrelated to this change
- [x] All 22 pre-existing `getFirstLinkpathDest` tests still pass

## RFC reference
- `94e520da-c6f7-48af-944c-51298d68da45` § Phase 3 (T3.1)
- Architectural mandate: Homoiconicity Q1 (parity prerequisite for fail-loud `service_call` audit in Phase 1, dyncommand discovery in Phase 2)

Closes vault task `e3fb7cf6-eaf6-4a82-8c31-545f33afdea1`.