### PR TITLE
T1.3: Plugin migrates to @kitelev/exocortex-services factories (6 pure handlers)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17302,6 +17302,7 @@
       "dependencies": {
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.38.1",
+        "@kitelev/exocortex-services": "*",
         "@tanstack/react-query": "^5.90.12",
         "@tanstack/react-virtual": "^3.13.13",
         "exocortex": "*",

--- a/packages/obsidian-plugin/jest.config.js
+++ b/packages/obsidian-plugin/jest.config.js
@@ -36,6 +36,7 @@ module.exports = {
   ],
   moduleNameMapper: {
     "^exocortex$": "<rootDir>/../exocortex/src/index.ts",
+    "^@kitelev/exocortex-services$": "<rootDir>/../services/src/index.ts",
     "^@plugin/types$": "<rootDir>/src/types/index.ts",
     "^@plugin/types/(.*)$": "<rootDir>/src/types/$1",
     "^@plugin/adapters/(.*)$": "<rootDir>/src/adapters/$1",
@@ -123,6 +124,7 @@ module.exports = {
           isolatedModules: true,
           paths: {
             "exocortex": ["<rootDir>/../exocortex/src/index.ts"],
+            "@kitelev/exocortex-services": ["<rootDir>/../services/src/index.ts"],
             "@plugin/types": ["<rootDir>/src/types/index.ts"],
             "@plugin/types/*": ["<rootDir>/src/types/*"],
             "@plugin/adapters/*": ["<rootDir>/src/adapters/*"],

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -21,6 +21,7 @@
     "@codemirror/view": "^6.38.1",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-virtual": "^3.13.13",
+    "@kitelev/exocortex-services": "*",
     "exocortex": "*",
     "obsidian": "latest",
     "react": "^19.2.3",

--- a/packages/obsidian-plugin/src/infrastructure/services/ObsidianTargetResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ObsidianTargetResolver.ts
@@ -1,0 +1,62 @@
+import type { App } from "obsidian";
+import type { IFile } from "exocortex";
+import type { ITargetResolver } from "@kitelev/exocortex-services";
+import type { ObsidianVaultAdapter } from "../../adapters/ObsidianVaultAdapter";
+
+/**
+ * Obsidian-aware `ITargetResolver` for the shared
+ * `@kitelev/exocortex-services` factories (RFC 94e520da Phase 1, T1.3).
+ *
+ * The plugin's `service_call` groundings receive `targetIRI` in three shapes
+ * depending on caller (button click, dyncommand exec, internal):
+ *   1. `obsidian://vault/<encoded-path>` URI — decoded and resolved as path.
+ *   2. `exo__Asset_uid` value (e.g. UUID) — looked up via metadataCache scan.
+ *   3. `@id` JSON-LD identifier — same scan, different field.
+ *
+ * The CLI runtime in contrast always passes a vault-relative path
+ * (without `.md`) — see `createPathBasedTargetResolver`. Keeping resolution
+ * pluggable lets both runtimes share the factories without hard-coding either
+ * IRI dialect.
+ *
+ * Behavior is byte-identical to the legacy private `resolveFilePath` /
+ * `resolveIFile` helpers in `ServiceRegistryPopulator` so plugin tests pass
+ * without modification.
+ */
+export function createObsidianTargetResolver(
+  app: App,
+  vaultAdapter: ObsidianVaultAdapter,
+): ITargetResolver {
+  return {
+    resolveFile(targetIRI: string): IFile {
+      const filePath = resolveFilePath(app, targetIRI);
+      const candidate = vaultAdapter.getAbstractFileByPath(filePath);
+      if (!candidate || !("basename" in candidate)) {
+        throw new Error(`Cannot resolve IFile for path: ${filePath}`);
+      }
+      return candidate as IFile;
+    },
+  };
+}
+
+function resolveFilePath(app: App, targetIRI: string): string {
+  if (targetIRI.startsWith("obsidian://vault/")) {
+    const decoded = decodeURIComponent(
+      targetIRI.replace("obsidian://vault/", ""),
+    );
+    const file = app.vault.getAbstractFileByPath(decoded);
+    if (file) return decoded;
+  }
+
+  const files = app.vault.getMarkdownFiles();
+  for (const file of files) {
+    const cache = app.metadataCache.getFileCache(file);
+    if (cache?.frontmatter?.exo__Asset_uid === targetIRI) {
+      return file.path;
+    }
+    const iri = cache?.frontmatter?.["@id"];
+    if (iri === targetIRI) {
+      return file.path;
+    }
+  }
+  throw new Error(`No file found for IRI: ${targetIRI}`);
+}

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -20,9 +20,18 @@ import {
   type UserInput,
   type IFile,
 } from "exocortex";
+import {
+  createArchiveAssetService,
+  createCleanPropertiesService,
+  createFixMissingLabelService,
+  createPlanForEveningService,
+  createRenameToUidService,
+  createRepairFolderService,
+} from "@kitelev/exocortex-services";
 import type { SPARQLApi } from "../../application/api/SPARQLApi";
 import type { ObsidianFileSystemAdapter } from "../../adapters/ObsidianFileSystemAdapter";
 import type { ObsidianVaultAdapter } from "../../adapters/ObsidianVaultAdapter";
+import { createObsidianTargetResolver } from "./ObsidianTargetResolver";
 
 export interface ServiceRegistryDeps {
   app: App;
@@ -295,6 +304,10 @@ export function populateServiceRegistry(
     const folderRepairService = new FolderRepairService(vaultAdapter);
     const conceptCreationService = new ConceptCreationService(vaultAdapter);
     const classCreationService = new ClassCreationService(vaultAdapter);
+    // Obsidian-aware resolver for shared @kitelev/exocortex-services factories
+    // (RFC 94e520da Phase 1, T1.3). Produces byte-identical IFile resolution
+    // to the legacy `resolveIFile` helper below — see ObsidianTargetResolver.
+    const targetResolver = createObsidianTargetResolver(app, vaultAdapter);
 
     registry.register(
       "rollbackStatus",
@@ -314,10 +327,7 @@ export function populateServiceRegistry(
 
     registry.register(
       "planForEvening",
-      wrapService(async (targetIRI: string) => {
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        await taskStatusService.planForEvening(iFile);
-      }),
+      createPlanForEveningService(vaultAdapter, taskStatusService, targetResolver),
     );
 
     registry.register(
@@ -451,59 +461,39 @@ export function populateServiceRegistry(
 
     registry.register(
       "archiveAsset",
-      wrapService(async (targetIRI: string) => {
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        await archiveAssetService.archiveAsset(iFile);
-      }),
+      createArchiveAssetService(vaultAdapter, archiveAssetService, targetResolver),
     );
 
     registry.register(
       "cleanProperties",
-      wrapService(async (targetIRI: string) => {
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        await propertyCleanupService.cleanEmptyProperties(iFile);
-      }),
+      createCleanPropertiesService(
+        vaultAdapter,
+        propertyCleanupService,
+        targetResolver,
+      ),
     );
 
     registry.register(
       "fixMissingLabel",
-      wrapService(async (targetIRI: string) => {
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        await fixMissingLabelService.fixMissingLabel(iFile);
-      }),
+      createFixMissingLabelService(
+        vaultAdapter,
+        fixMissingLabelService,
+        targetResolver,
+      ),
     );
 
     registry.register(
       "renameToUid",
-      wrapService(async (targetIRI: string) => {
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        const metadata =
-          (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
-        await renameToUidService.renameToUid(iFile, metadata);
-      }),
+      createRenameToUidService(vaultAdapter, renameToUidService, targetResolver),
     );
 
     registry.register(
       "repairFolder",
-      wrapService(async (targetIRI: string) => {
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        const metadata =
-          (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
-        const expectedFolder = await folderRepairService.getExpectedFolder(
-          iFile,
-          metadata,
-        );
-        if (expectedFolder === null) {
-          throw new Error(
-            "repairFolder: cannot determine expected folder (missing exo__Asset_isDefinedBy or referenced asset not found)",
-          );
-        }
-        const currentFolder = iFile.parent?.path ?? "";
-        if (currentFolder === expectedFolder) {
-          return;
-        }
-        await folderRepairService.repairFolder(iFile, expectedFolder);
-      }),
+      createRepairFolderService(
+        vaultAdapter,
+        folderRepairService,
+        targetResolver,
+      ),
     );
 
     registry.register(

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ObsidianTargetResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ObsidianTargetResolver.test.ts
@@ -1,0 +1,87 @@
+import { createObsidianTargetResolver } from "../../../../src/infrastructure/services/ObsidianTargetResolver";
+
+const fileObj = (path: string) => ({
+  path,
+  basename: path.replace(/\.md$/, "").split("/").pop()!,
+  name: path.split("/").pop()!,
+  parent: { path: path.split("/").slice(0, -1).join("/") },
+});
+
+function buildApp(files: { path: string; uid?: string; jsonId?: string }[]) {
+  const tfiles = files.map((f) => fileObj(f.path));
+  const cacheByPath = new Map(
+    files.map((f) => [
+      f.path,
+      {
+        frontmatter: {
+          ...(f.uid !== undefined ? { exo__Asset_uid: f.uid } : {}),
+          ...(f.jsonId !== undefined ? { "@id": f.jsonId } : {}),
+        },
+      },
+    ]),
+  );
+  return {
+    vault: {
+      getMarkdownFiles: jest.fn(() => tfiles),
+      getAbstractFileByPath: jest.fn((p: string) =>
+        tfiles.find((f) => f.path === p) ?? null,
+      ),
+    },
+    metadataCache: {
+      getFileCache: jest.fn((f: { path: string }) =>
+        cacheByPath.get(f.path),
+      ),
+    },
+  } as never;
+}
+
+const vaultAdapter = {
+  getAbstractFileByPath: (path: string) =>
+    path === "missing.md" ? null : fileObj(path),
+} as never;
+
+describe("ObsidianTargetResolver", () => {
+  it("resolves obsidian://vault/<path> URI by decoding", () => {
+    const app = buildApp([{ path: "Tasks/foo bar.md" }]);
+    const resolver = createObsidianTargetResolver(app, vaultAdapter);
+    const file = resolver.resolveFile(
+      "obsidian://vault/Tasks/foo%20bar.md",
+    );
+    expect(file.basename).toBe("foo bar");
+  });
+
+  it("resolves UID via metadataCache scan", () => {
+    const app = buildApp([
+      { path: "other.md" },
+      { path: "Tasks/uuid-1.md", uid: "uuid-1" },
+    ]);
+    const resolver = createObsidianTargetResolver(app, vaultAdapter);
+    const file = resolver.resolveFile("uuid-1");
+    expect(file.path).toBe("Tasks/uuid-1.md");
+  });
+
+  it("resolves @id via metadataCache scan", () => {
+    const app = buildApp([
+      { path: "Concepts/c.md", jsonId: "https://example.com/c" },
+    ]);
+    const resolver = createObsidianTargetResolver(app, vaultAdapter);
+    const file = resolver.resolveFile("https://example.com/c");
+    expect(file.path).toBe("Concepts/c.md");
+  });
+
+  it("throws when no file matches", () => {
+    const app = buildApp([{ path: "x.md", uid: "x" }]);
+    const resolver = createObsidianTargetResolver(app, vaultAdapter);
+    expect(() => resolver.resolveFile("missing-uid")).toThrow(
+      /No file found for IRI: missing-uid/,
+    );
+  });
+
+  it("throws when vaultAdapter cannot materialize the IFile", () => {
+    const app = buildApp([{ path: "missing.md", uid: "ghost" }]);
+    const resolver = createObsidianTargetResolver(app, vaultAdapter);
+    expect(() => resolver.resolveFile("ghost")).toThrow(
+      /Cannot resolve IFile for path/,
+    );
+  });
+});

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -23,23 +23,38 @@ import type {
  * access goes through `IVaultAdapter`, so plugin (Obsidian) and CLI (Node fs)
  * runtimes produce byte-identical state changes for the same input.
  *
- * RFC 94e520da Phase 1, T1.2 (`@kitelev/exocortex-services` package).
+ * Target-IRI → IFile resolution is delegated to the optional
+ * `ITargetResolver` parameter. CLI runtime keeps the historical
+ * path-based default (`getAbstractFileByPath(`${IRI}.md`)`); the Obsidian
+ * plugin (T1.3) injects an Obsidian-aware resolver that scans
+ * `metadataCache` for `exo__Asset_uid` / `@id` matches and decodes
+ * `obsidian://vault/...` URIs.
+ *
+ * RFC 94e520da Phase 1, T1.2 (factories) + T1.3 (plugin migration).
  */
 
-function resolveTargetFile(
+export interface ITargetResolver {
+  resolveFile(targetIRI: string): IFile;
+}
+
+export function createPathBasedTargetResolver(
   vaultAdapter: IVaultAdapter,
-  targetIRI: string,
-): IFile {
-  const candidate = vaultAdapter.getAbstractFileByPath(`${targetIRI}.md`);
-  if (!candidate || !("basename" in candidate)) {
-    throw new Error(`Cannot resolve target file for IRI: ${targetIRI}`);
-  }
-  return candidate as IFile;
+): ITargetResolver {
+  return {
+    resolveFile(targetIRI: string): IFile {
+      const candidate = vaultAdapter.getAbstractFileByPath(`${targetIRI}.md`);
+      if (!candidate || !("basename" in candidate)) {
+        throw new Error(`Cannot resolve target file for IRI: ${targetIRI}`);
+      }
+      return candidate as IFile;
+    },
+  };
 }
 
 export function createCreateRelatedTaskService(
   vaultAdapter: IVaultAdapter,
   genericAssetCreationService: GenericAssetCreationService,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
 ): IGroundingService {
   return {
     async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
@@ -48,7 +63,7 @@ export function createCreateRelatedTaskService(
         throw new Error("createRelatedTask requires userInput.label");
       }
 
-      const parentFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const parentFile = resolver.resolveFile(targetIRI);
       const parentMetadata =
         (vaultAdapter.getFrontmatter(parentFile) as Record<string, unknown>) ??
         {};
@@ -80,6 +95,7 @@ export function createCreateRelatedTaskService(
 export function createCreateRelatedProjectService(
   vaultAdapter: IVaultAdapter,
   genericAssetCreationService: GenericAssetCreationService,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
 ): IGroundingService {
   return {
     async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
@@ -88,7 +104,7 @@ export function createCreateRelatedProjectService(
         throw new Error("createRelatedProject requires userInput.label");
       }
 
-      const parentFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const parentFile = resolver.resolveFile(targetIRI);
       const parentMetadata =
         (vaultAdapter.getFrontmatter(parentFile) as Record<string, unknown>) ??
         {};
@@ -120,10 +136,11 @@ export function createCreateRelatedProjectService(
 export function createArchiveAssetService(
   vaultAdapter: IVaultAdapter,
   archiveAssetService: ArchiveAssetService,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
 ): IGroundingService {
   return {
     async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const targetFile = resolver.resolveFile(targetIRI);
       await archiveAssetService.archiveAsset(targetFile);
     },
   };
@@ -132,10 +149,11 @@ export function createArchiveAssetService(
 export function createCleanPropertiesService(
   vaultAdapter: IVaultAdapter,
   propertyCleanupService: PropertyCleanupService,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
 ): IGroundingService {
   return {
     async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const targetFile = resolver.resolveFile(targetIRI);
       await propertyCleanupService.cleanEmptyProperties(targetFile);
     },
   };
@@ -144,10 +162,11 @@ export function createCleanPropertiesService(
 export function createFixMissingLabelService(
   vaultAdapter: IVaultAdapter,
   fixMissingLabelService: FixMissingLabelService,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
 ): IGroundingService {
   return {
     async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const targetFile = resolver.resolveFile(targetIRI);
       await fixMissingLabelService.fixMissingLabel(targetFile);
     },
   };
@@ -156,10 +175,11 @@ export function createFixMissingLabelService(
 export function createRenameToUidService(
   vaultAdapter: IVaultAdapter,
   renameToUidService: RenameToUidService,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
 ): IGroundingService {
   return {
     async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const targetFile = resolver.resolveFile(targetIRI);
       const metadata =
         (vaultAdapter.getFrontmatter(targetFile) as Record<string, unknown>) ??
         {};
@@ -171,10 +191,11 @@ export function createRenameToUidService(
 export function createRepairFolderService(
   vaultAdapter: IVaultAdapter,
   folderRepairService: FolderRepairService,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
 ): IGroundingService {
   return {
     async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const targetFile = resolver.resolveFile(targetIRI);
       const metadata =
         (vaultAdapter.getFrontmatter(targetFile) as Record<string, unknown>) ??
         {};
@@ -199,10 +220,11 @@ export function createRepairFolderService(
 export function createPlanForEveningService(
   vaultAdapter: IVaultAdapter,
   taskStatusService: TaskStatusService,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
 ): IGroundingService {
   return {
     async execute(targetIRI: string): Promise<void> {
-      const targetFile = resolveTargetFile(vaultAdapter, targetIRI);
+      const targetFile = resolver.resolveFile(targetIRI);
       await taskStatusService.planForEvening(targetFile);
     },
   };

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -30,4 +30,6 @@ export {
   createRenameToUidService,
   createRepairFolderService,
   createPlanForEveningService,
+  createPathBasedTargetResolver,
+  type ITargetResolver,
 } from "./grounding-service-factories";


### PR DESCRIPTION
RFC `94e520da` Phase 1 (T1.3, vault task `e3150dc4-fa04-4a2f-96ef-79ccaa7e5c57`).

## What

`packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts` now imports the storage-agnostic factories from `@kitelev/exocortex-services` (T1.2 PR #3025) for the **6** handlers that have no UI side effects:

- `archiveAsset`
- `cleanProperties`
- `fixMissingLabel`
- `renameToUid`
- `repairFolder`
- `planForEvening`

These handlers were inline `wrapService(...)` lambdas duplicating the same shape that already lives in the shared package. Migration is a pure re-wiring — domain services (`ArchiveAssetService`, `PropertyCleanupService`, etc.) and their `IVaultAdapter` injection are unchanged.

## How — `ITargetResolver`

The shared factories previously hard-coded path-based IRI resolution (`getAbstractFileByPath(\`${IRI}.md\`)`) which is what the CLI uses. The plugin's `targetIRI` is a `exo__Asset_uid` / `@id` / `obsidian://vault/...` URI that requires `metadataCache` lookup.

Each factory now accepts an optional `ITargetResolver` parameter (default = `createPathBasedTargetResolver(vaultAdapter)` — preserves CLI behavior, no breaking change). The plugin injects `ObsidianTargetResolver` (new file), which wraps the legacy `resolveFilePath` / `resolveIFile` helpers byte-for-byte.

## Out of scope (deferred per RFC § Phase 1 plan)

UI-touching handlers stay as plugin-side inline lambdas: `createRelatedTask`, `createRelatedProject`, `createNarrowerConcept`, `createSubclass`, `openFile`, `trashFile`, `duplicateFile`, `createTaskForDailyNote`, `rollbackStatus`, `planOnToday`, `shiftDay`, `incrementVotes`, `copyLabelToAliases`, plus the storage-handler trio (`updateProperty`, `removeProperty`, `setStatus`, `createAsset`, `sparqlSelect`, `getActiveFile*`).

These need an additional adapter abstraction for `leaf.openFile` / `app.workspace.openLinkText` / `app.vault.adapter.trashLocal` that does not yet exist in the shared package. Adding it without a consumer would be premature; tracked under follow-up T1.4 / future Phase 1 work.

## Tests

- ✅ `ServiceRegistryPopulator.test.ts` — **84 / 84 pass without modification** (proof of zero behavior change for the 6 migrated handlers).
- ✅ New `ObsidianTargetResolver.test.ts` — 5 cases covering URI decode, UID lookup, `@id` lookup, missing-IRI throw, missing-IFile throw.
- ✅ Shared-package factory tests (`packages/services/tests/`) — 12 / 12 pass after `ITargetResolver` refactor.
- ✅ `npm run check:types` clean.
- ✅ `npm run lint` clean (only pre-existing 2 warnings unrelated to this PR).
- ✅ Plugin bundle (`esbuild production`) builds with shared factories inlined.
- ✅ Full plugin unit suite — **5029 / 5029 pass** (250 suites green) after migration.

## Closes

Closes vault task `e3150dc4-fa04-4a2f-96ef-79ccaa7e5c57`.