### PR TITLE
T1.4: port frontmatter handlers to shared services + drop CLI stubs (3/10)

### DIFF
--- a/packages/cli/src/commands/dynamic-command.ts
+++ b/packages/cli/src/commands/dynamic-command.ts
@@ -356,8 +356,10 @@ export function dynamicCommandCommand(): Command {
           new EffortStatusWorkflow(),
           new StatusTimestampService(vaultAdapter),
         );
+        const nodeFsAdapter = new NodeFsAdapter(vaultPath);
         populateCliServiceRegistry(serviceRegistry, {
           vaultAdapter,
+          fsAdapter: nodeFsAdapter,
           genericAssetCreationService,
           archiveAssetService,
           taskStatusService,
@@ -366,7 +368,6 @@ export function dynamicCommandCommand(): Command {
           renameToUidService,
           folderRepairService,
         });
-        const nodeFsAdapter = new NodeFsAdapter(vaultPath);
         const groundingExecutor = new GroundingExecutor(
           nodeFsAdapter,
           nodeFsAdapter,

--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -1,7 +1,9 @@
 import {
   ServiceRegistry,
+  FrontmatterService,
   type IGroundingService,
   type IVaultAdapter,
+  type IFileSystemAdapter,
   GenericAssetCreationService,
   ArchiveAssetService,
   FixMissingLabelService,
@@ -19,20 +21,93 @@ import {
   createRenameToUidService,
   createRepairFolderService,
   createPlanForEveningService,
+  createUpdatePropertyService,
+  createRemovePropertyService,
+  createSetStatusService,
+  type IPathResolver,
 } from "@kitelev/exocortex-services";
 
+const OBSIDIAN_VAULT_SCHEME = "obsidian://vault/";
+
 /**
- * The 10 well-known service IDs the plugin registers via
- * ServiceRegistryPopulator. CLI stubs exist so that `dyncommand validate` can
- * verify grounding service references point to a known service, and so that
- * `dyncommand exec` fails loudly instead of silently fake-succeeding.
+ * CLI implementation of `IPathResolver` used by the
+ * `updateProperty`/`removeProperty`/`setStatus` factories (RFC 94e520da
+ * Phase 1, T1.4).
+ *
+ * Resolution rules — in order:
+ * 1. `obsidian://vault/<encoded>` URIs decode to a vault-relative path,
+ *    matching the canonical `$target` IRI form built by `vaultPathToIRI`
+ *    after the #2996 fix. The decoded path is returned verbatim — typically
+ *    already includes `.md` because `dyncommand exec --target <path>` keeps
+ *    the extension.
+ * 2. UUID-shaped IRIs are resolved through
+ *    `IFileSystemMetadataProvider.findFileByUID`, supporting tests and
+ *    callers that pass a bare UUID.
+ * 3. Anything else is treated as a vault-relative path; if it lacks a `.md`
+ *    extension, it is appended (mirrors the legacy CLI behaviour for the
+ *    historical path-based factories that did `${IRI}.md`).
+ *
+ * If the resolved candidate does not exist on disk we fall through to a
+ * loud `Error` so callers see a named failure instead of a stale path.
+ */
+export function createCliPathResolver(
+  fsAdapter: IFileSystemAdapter,
+): IPathResolver {
+  const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  return {
+    async resolveTargetPath(targetIRI: string): Promise<string> {
+      if (!targetIRI) {
+        throw new Error("Cannot resolve empty targetIRI to a vault path");
+      }
+      let candidate = targetIRI;
+      if (candidate.startsWith(OBSIDIAN_VAULT_SCHEME)) {
+        candidate = decodeURI(candidate.slice(OBSIDIAN_VAULT_SCHEME.length));
+      } else if (UUID_RE.test(candidate)) {
+        const found = await fsAdapter.findFileByUID(candidate);
+        if (!found) {
+          throw new Error(`No vault file found for UID: ${candidate}`);
+        }
+        candidate = found;
+      }
+      if (!candidate.endsWith(".md")) {
+        candidate = `${candidate}.md`;
+      }
+      if (!(await fsAdapter.fileExists(candidate))) {
+        throw new Error(
+          `Cannot resolve target file for IRI "${targetIRI}" (tried "${candidate}")`,
+        );
+      }
+      return candidate;
+    },
+  };
+}
+
+/**
+ * Well-known service IDs the plugin registers via ServiceRegistryPopulator.
+ * CLI stubs exist so that `dyncommand validate` can verify grounding service
+ * references point to a known service, and so that `dyncommand exec` fails
+ * loudly instead of silently fake-succeeding.
+ *
+ * RFC 94e520da Phase 1, T1.4: `updateProperty`, `removeProperty`, `setStatus`
+ * dropped from this list — they now have real CLI implementations through
+ * the shared `@kitelev/exocortex-services` package and run end-to-end against
+ * a vault on disk via {@link CliServiceRegistryDeps.fsAdapter}.
+ *
+ * The remaining 7 services are genuinely unsupported in CLI runtime:
+ * - `openFile`, `getActiveFileIRI`, `getActiveFilePath` rely on Obsidian's
+ *   workspace/active-file concept that has no CLI analogue.
+ * - `sparqlSelect` would require porting plugin's SPARQLApi — separate issue.
+ * - `trashFile` semantics (Obsidian trash) differ from `fs.unlink`; needs an
+ *   adapter design before it can be safely shared.
+ * - `createAsset`, `duplicateFile` carry parent-context inheritance that
+ *   currently reads `app.metadataCache`; porting them awaits an Obsidian-free
+ *   metadata abstraction.
  *
  * Issue #2518, #2864
  */
 export const CLI_STUB_SERVICE_IDS = [
-  "updateProperty",
-  "removeProperty",
-  "setStatus",
   "createAsset",
   "openFile",
   "sparqlSelect",
@@ -78,6 +153,14 @@ function notImplementedService(serviceId: string): IGroundingService {
  */
 export interface CliServiceRegistryDeps {
   vaultAdapter: IVaultAdapter;
+  /**
+   * Path-based filesystem adapter (NodeFsAdapter in production) used by the
+   * frontmatter-only handlers ported in T1.4: `updateProperty`,
+   * `removeProperty`, `setStatus`. Optional so existing callers without
+   * adapter wiring degrade to the fail-loud stubs only for those three
+   * services.
+   */
+  fsAdapter?: IFileSystemAdapter;
   genericAssetCreationService: GenericAssetCreationService;
   archiveAssetService: ArchiveAssetService;
   taskStatusService: TaskStatusService;
@@ -105,6 +188,9 @@ export {
   createRenameToUidService,
   createRepairFolderService,
   createPlanForEveningService,
+  createUpdatePropertyService,
+  createRemovePropertyService,
+  createSetStatusService,
 };
 
 /**
@@ -129,7 +215,43 @@ export function populateCliServiceRegistry(
     registry.register(id, notImplementedService(id));
   }
 
+  // T1.4: frontmatter-only handlers registered as fail-loud stubs when no
+  // fsAdapter is wired (e.g. `dyncommand validate`). With fsAdapter the real
+  // shared-package factories below replace these stubs.
+  for (const id of ["updateProperty", "removeProperty", "setStatus"] as const) {
+    registry.register(id, notImplementedService(id));
+  }
+
   if (deps) {
+    if (deps.fsAdapter) {
+      const frontmatterService = new FrontmatterService();
+      const pathResolver = createCliPathResolver(deps.fsAdapter);
+      registry.register(
+        "updateProperty",
+        createUpdatePropertyService(
+          deps.fsAdapter,
+          frontmatterService,
+          pathResolver,
+        ),
+      );
+      registry.register(
+        "removeProperty",
+        createRemovePropertyService(
+          deps.fsAdapter,
+          frontmatterService,
+          pathResolver,
+        ),
+      );
+      registry.register(
+        "setStatus",
+        createSetStatusService(
+          deps.fsAdapter,
+          frontmatterService,
+          pathResolver,
+        ),
+      );
+    }
+
     registry.register(
       "createRelatedTask",
       createCreateRelatedTaskService(

--- a/packages/cli/tests/unit/services/CliServiceRegistryPopulator.test.ts
+++ b/packages/cli/tests/unit/services/CliServiceRegistryPopulator.test.ts
@@ -10,7 +10,13 @@ jest.unstable_mockModule("exocortex", () => {
     has(id: string) { return this.services.has(id); }
     getRegisteredIds() { return Array.from(this.services.keys()); }
   }
-  return { ServiceRegistry };
+  // T1.4: CliServiceRegistryPopulator imports FrontmatterService at module
+  // load time to wire the new updateProperty/removeProperty/setStatus
+  // factories. The constructor is never invoked from this suite (deps left
+  // out → stubs path), so a no-op shape is sufficient for the import to
+  // resolve under ESM mocking.
+  class FrontmatterService {}
+  return { ServiceRegistry, FrontmatterService };
 });
 
 let populateCliServiceRegistry: any;
@@ -28,15 +34,12 @@ beforeEach(async () => {
 
 describe("CliServiceRegistryPopulator", () => {
   describe("CLI_STUB_SERVICE_IDS", () => {
-    it("should export exactly 10 service IDs", () => {
-      expect(CLI_STUB_SERVICE_IDS).toHaveLength(10);
+    it("should export exactly 7 service IDs (T1.4: updateProperty/removeProperty/setStatus moved to real impls)", () => {
+      expect(CLI_STUB_SERVICE_IDS).toHaveLength(7);
     });
 
-    it("should include all well-known service IDs", () => {
+    it("should include all genuinely-unsupported well-known service IDs", () => {
       const expected = [
-        "updateProperty",
-        "removeProperty",
-        "setStatus",
         "createAsset",
         "openFile",
         "sparqlSelect",
@@ -50,9 +53,12 @@ describe("CliServiceRegistryPopulator", () => {
   });
 
   describe("populateCliServiceRegistry", () => {
-    it("should register all 10 stub services", () => {
+    it("should register the 7 fail-loud stubs + the 3 frontmatter handlers (10 total) when called without deps", () => {
       const registry = new ServiceRegistry();
       populateCliServiceRegistry(registry);
+      // Without `deps.fsAdapter`, the 3 frontmatter handlers
+      // (updateProperty/removeProperty/setStatus) fall back to fail-loud stubs
+      // so `dyncommand validate` keeps recognising them as known service IDs.
       expect(registry.getRegisteredIds()).toHaveLength(10);
     });
 

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -27,6 +27,10 @@ import {
   createPlanForEveningService,
   createRenameToUidService,
   createRepairFolderService,
+  createUpdatePropertyService,
+  createRemovePropertyService,
+  createSetStatusService,
+  type IPathResolver,
 } from "@kitelev/exocortex-services";
 import type { SPARQLApi } from "../../application/api/SPARQLApi";
 import type { ObsidianFileSystemAdapter } from "../../adapters/ObsidianFileSystemAdapter";
@@ -59,49 +63,40 @@ export function populateServiceRegistry(
   const { app, fileSystemAdapter, sparqlApi, vaultAdapter } = deps;
   const frontmatterService = new FrontmatterService();
 
+  // Plugin-side `IPathResolver` adapting the existing `resolveFilePath`
+  // (UID lookup via `app.metadataCache` + `obsidian://vault/` URI decode) to
+  // the storage-agnostic shared factories ported in T1.4.
+  const pluginPathResolver: IPathResolver = {
+    async resolveTargetPath(targetIRI: string): Promise<string> {
+      return resolveFilePath(app, targetIRI);
+    },
+  };
+
   registry.register(
     "updateProperty",
-    wrapService(async (targetIRI: string, userInput?: UserInput) => {
-      const property = userInput?.property as string | undefined;
-      const value = userInput?.value;
-      if (!property) throw new Error("updateProperty requires userInput.property");
-      if (value === undefined) throw new Error("updateProperty requires userInput.value");
-
-      const filePath = resolveFilePath(app, targetIRI);
-      const content = await fileSystemAdapter.readFile(filePath);
-      const updated = frontmatterService.updateProperty(content, property, value);
-      await fileSystemAdapter.updateFile(filePath, updated);
-    }),
+    createUpdatePropertyService(
+      fileSystemAdapter,
+      frontmatterService,
+      pluginPathResolver,
+    ),
   );
 
   registry.register(
     "removeProperty",
-    wrapService(async (targetIRI: string, userInput?: UserInput) => {
-      const property = userInput?.property as string | undefined;
-      if (!property) throw new Error("removeProperty requires userInput.property");
-
-      const filePath = resolveFilePath(app, targetIRI);
-      const content = await fileSystemAdapter.readFile(filePath);
-      const updated = frontmatterService.removeProperty(content, property);
-      await fileSystemAdapter.updateFile(filePath, updated);
-    }),
+    createRemovePropertyService(
+      fileSystemAdapter,
+      frontmatterService,
+      pluginPathResolver,
+    ),
   );
 
   registry.register(
     "setStatus",
-    wrapService(async (targetIRI: string, userInput?: UserInput) => {
-      const statusUID = userInput?.statusUID as string | undefined;
-      if (!statusUID) throw new Error("setStatus requires userInput.statusUID");
-
-      const filePath = resolveFilePath(app, targetIRI);
-      const content = await fileSystemAdapter.readFile(filePath);
-      const updated = frontmatterService.updateProperty(
-        content,
-        "ems__Effort_status",
-        `"[[${statusUID}]]"`,
-      );
-      await fileSystemAdapter.updateFile(filePath, updated);
-    }),
+    createSetStatusService(
+      fileSystemAdapter,
+      frontmatterService,
+      pluginPathResolver,
+    ),
   );
 
   registry.register(

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -2,7 +2,10 @@ import type {
   IGroundingService,
   IVaultAdapter,
   IFile,
+  IFileSystemReader,
+  IFileSystemWriter,
   UserInput,
+  FrontmatterService,
   GenericAssetCreationService,
   ArchiveAssetService,
   TaskStatusService,
@@ -226,6 +229,113 @@ export function createPlanForEveningService(
     async execute(targetIRI: string): Promise<void> {
       const targetFile = resolver.resolveFile(targetIRI);
       await taskStatusService.planForEvening(targetFile);
+    },
+  };
+}
+
+/**
+ * Resolves a `service_call` `targetIRI` to a vault-relative file path the
+ * `IFileSystemAdapter` can `readFile`/`updateFile`. The plugin scans
+ * `app.metadataCache` (UID lookup, `obsidian://vault/` decode); the CLI
+ * decodes the `obsidian://vault/<encoded-path>` scheme + falls back to
+ * `IFileSystemMetadataProvider.findFileByUID`. This indirection lets shared
+ * factories below stay storage-agnostic.
+ *
+ * RFC 94e520da Phase 1, T1.4 — added when porting the
+ * frontmatter-only handlers (`updateProperty`/`removeProperty`/`setStatus`)
+ * out of plugin-side inline lambdas into runtime-agnostic factories.
+ */
+export interface IPathResolver {
+  resolveTargetPath(targetIRI: string): Promise<string>;
+}
+
+/**
+ * Shared factory for the `updateProperty` `service_call` grounding.
+ *
+ * Reads the target file via `IFileSystemReader.readFile`, applies
+ * `FrontmatterService.updateProperty`, writes back via
+ * `IFileSystemWriter.updateFile`. Path resolution is delegated to the
+ * caller-supplied `IPathResolver` because plugin and CLI runtimes locate
+ * a file from a `targetIRI` differently (see interface doc).
+ */
+export function createUpdatePropertyService(
+  fsAdapter: IFileSystemReader & IFileSystemWriter,
+  frontmatterService: FrontmatterService,
+  pathResolver: IPathResolver,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
+      const property = userInput?.property as string | undefined;
+      const value = userInput?.value;
+      if (!property) {
+        throw new Error("updateProperty requires userInput.property");
+      }
+      if (value === undefined) {
+        throw new Error("updateProperty requires userInput.value");
+      }
+      const filePath = await pathResolver.resolveTargetPath(targetIRI);
+      const content = await fsAdapter.readFile(filePath);
+      const updated = frontmatterService.updateProperty(
+        content,
+        property,
+        value,
+      );
+      await fsAdapter.updateFile(filePath, updated);
+    },
+  };
+}
+
+/**
+ * Shared factory for the `removeProperty` `service_call` grounding.
+ *
+ * Mirrors {@link createUpdatePropertyService} but applies
+ * `FrontmatterService.removeProperty`. No-op if the property is absent.
+ */
+export function createRemovePropertyService(
+  fsAdapter: IFileSystemReader & IFileSystemWriter,
+  frontmatterService: FrontmatterService,
+  pathResolver: IPathResolver,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
+      const property = userInput?.property as string | undefined;
+      if (!property) {
+        throw new Error("removeProperty requires userInput.property");
+      }
+      const filePath = await pathResolver.resolveTargetPath(targetIRI);
+      const content = await fsAdapter.readFile(filePath);
+      const updated = frontmatterService.removeProperty(content, property);
+      await fsAdapter.updateFile(filePath, updated);
+    },
+  };
+}
+
+/**
+ * Shared factory for the `setStatus` `service_call` grounding.
+ *
+ * Sugar over {@link createUpdatePropertyService}: forces `ems__Effort_status`
+ * as the property and quotes `userInput.statusUID` into a wikilink so callers
+ * pass the bare UID (e.g. `ems__EffortStatusBacklog`).
+ */
+export function createSetStatusService(
+  fsAdapter: IFileSystemReader & IFileSystemWriter,
+  frontmatterService: FrontmatterService,
+  pathResolver: IPathResolver,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
+      const statusUID = userInput?.statusUID as string | undefined;
+      if (!statusUID) {
+        throw new Error("setStatus requires userInput.statusUID");
+      }
+      const filePath = await pathResolver.resolveTargetPath(targetIRI);
+      const content = await fsAdapter.readFile(filePath);
+      const updated = frontmatterService.updateProperty(
+        content,
+        "ems__Effort_status",
+        `"[[${statusUID}]]"`,
+      );
+      await fsAdapter.updateFile(filePath, updated);
     },
   };
 }

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -30,6 +30,10 @@ export {
   createRenameToUidService,
   createRepairFolderService,
   createPlanForEveningService,
+  createUpdatePropertyService,
+  createRemovePropertyService,
+  createSetStatusService,
   createPathBasedTargetResolver,
   type ITargetResolver,
+  type IPathResolver,
 } from "./grounding-service-factories";

--- a/packages/services/tests/grounding-service-factories.test.ts
+++ b/packages/services/tests/grounding-service-factories.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
+import { FrontmatterService } from "../../exocortex/src/utilities/FrontmatterService";
 import {
   createCreateRelatedTaskService,
   createCreateRelatedProjectService,
@@ -8,6 +9,10 @@ import {
   createRenameToUidService,
   createRepairFolderService,
   createPlanForEveningService,
+  createUpdatePropertyService,
+  createRemovePropertyService,
+  createSetStatusService,
+  type IPathResolver,
 } from "../src/index";
 
 /**
@@ -219,5 +224,126 @@ describe("@kitelev/exocortex-services — factory contract", () => {
     await expect(service.execute("missing-uid", { label: "x" })).rejects.toThrow(
       /Cannot resolve target file/,
     );
+  });
+
+  describe("frontmatter-only factories (T1.4)", () => {
+    function makeFsStub(initial: Record<string, string>): {
+      reads: string[];
+      writes: Array<{ path: string; content: string }>;
+      adapter: never;
+    } {
+      const files = new Map(Object.entries(initial));
+      const reads: string[] = [];
+      const writes: Array<{ path: string; content: string }> = [];
+      const adapter = {
+        async readFile(path: string): Promise<string> {
+          reads.push(path);
+          const content = files.get(path);
+          if (content === undefined) throw new Error(`not found: ${path}`);
+          return content;
+        },
+        async updateFile(path: string, content: string): Promise<void> {
+          if (!files.has(path)) throw new Error(`not found: ${path}`);
+          files.set(path, content);
+          writes.push({ path, content });
+        },
+      } as never;
+      return { reads, writes, adapter };
+    }
+
+    function pathResolver(returns: string): IPathResolver {
+      return {
+        async resolveTargetPath(): Promise<string> {
+          return returns;
+        },
+      };
+    }
+
+    const fmInput = `---\nfoo: bar\n---\nbody\n`;
+
+    it("createUpdatePropertyService rewrites frontmatter property via FrontmatterService", async () => {
+      const fs = makeFsStub({ "tasks/x.md": fmInput });
+      const service = createUpdatePropertyService(
+        fs.adapter,
+        new FrontmatterService(),
+        pathResolver("tasks/x.md"),
+      );
+      await service.execute("any-iri", { property: "foo", value: "baz" });
+      expect(fs.writes).toHaveLength(1);
+      expect(fs.writes[0].path).toBe("tasks/x.md");
+      expect(fs.writes[0].content).toMatch(/foo: baz/);
+    });
+
+    it("createUpdatePropertyService throws on missing userInput.property", async () => {
+      const fs = makeFsStub({});
+      const service = createUpdatePropertyService(
+        fs.adapter,
+        new FrontmatterService(),
+        pathResolver("tasks/x.md"),
+      );
+      await expect(service.execute("iri", { value: "v" })).rejects.toThrow(
+        /requires userInput.property/,
+      );
+    });
+
+    it("createUpdatePropertyService throws on missing userInput.value", async () => {
+      const fs = makeFsStub({});
+      const service = createUpdatePropertyService(
+        fs.adapter,
+        new FrontmatterService(),
+        pathResolver("tasks/x.md"),
+      );
+      await expect(service.execute("iri", { property: "foo" })).rejects.toThrow(
+        /requires userInput.value/,
+      );
+    });
+
+    it("createRemovePropertyService removes a property via FrontmatterService", async () => {
+      const fs = makeFsStub({ "tasks/x.md": fmInput });
+      const service = createRemovePropertyService(
+        fs.adapter,
+        new FrontmatterService(),
+        pathResolver("tasks/x.md"),
+      );
+      await service.execute("iri", { property: "foo" });
+      expect(fs.writes[0].content).not.toMatch(/foo:/);
+    });
+
+    it("createRemovePropertyService throws on missing userInput.property", async () => {
+      const fs = makeFsStub({});
+      const service = createRemovePropertyService(
+        fs.adapter,
+        new FrontmatterService(),
+        pathResolver("tasks/x.md"),
+      );
+      await expect(service.execute("iri", {})).rejects.toThrow(
+        /requires userInput.property/,
+      );
+    });
+
+    it("createSetStatusService writes ems__Effort_status as wikilink to statusUID", async () => {
+      const fs = makeFsStub({ "tasks/x.md": `---\nlabel: x\n---\n` });
+      const service = createSetStatusService(
+        fs.adapter,
+        new FrontmatterService(),
+        pathResolver("tasks/x.md"),
+      );
+      await service.execute("iri", { statusUID: "ems__EffortStatusDone" });
+      expect(fs.writes[0].content).toMatch(
+        /ems__Effort_status:\s*"\[\[ems__EffortStatusDone\]\]"/,
+      );
+    });
+
+    it("createSetStatusService throws on missing userInput.statusUID", async () => {
+      const fs = makeFsStub({});
+      const service = createSetStatusService(
+        fs.adapter,
+        new FrontmatterService(),
+        pathResolver("tasks/x.md"),
+      );
+      await expect(service.execute("iri", {})).rejects.toThrow(
+        /requires userInput.statusUID/,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

RFC 94e520da Phase 1, T1.4. Closes vault task `78dece4d-c980-4ba3-969c-52fc355ae2f9`.

CLI now consumes the same `service_call` factories the plugin uses for the 3 frontmatter-only handlers (`updateProperty` / `removeProperty` / `setStatus`). Pre-this PR these were no-op fail-loud stubs; they're now real implementations through `@kitelev/exocortex-services` + `IFileSystemAdapter`. The remaining 7 stubs (`createAsset`, `openFile`, `sparqlSelect`, `getActiveFileIRI`, `getActiveFilePath`, `trashFile`, `duplicateFile`) stay fail-loud — each genuinely unsupported in CLI today (UI side-effects, active-file concept, SPARQL plugin API, trash semantics, parent-context inheritance via `app.metadataCache`).

## Changes

- **services package** — 3 new factories (`createUpdatePropertyService`, `createRemovePropertyService`, `createSetStatusService`) + new `IPathResolver` interface so plugin (UID via `app.metadataCache`) and CLI (`obsidian://vault/` decode + `findFileByUID`) share one contract.
- **plugin** — `ServiceRegistryPopulator.ts` swaps 3 inline `wrapService(...)` registrations for shared-factory calls. No behavioural change; 84/84 existing tests pass.
- **CLI** — `CliServiceRegistryPopulator.ts` registers the 3 real handlers when `fsAdapter` is in `deps`; new `createCliPathResolver` resolves IRIs (URI scheme decode, UUID lookup, `${path}.md` fallback). `CLI_STUB_SERVICE_IDS` shrinks from 10 → 7. `dynamic-command.ts` wires `nodeFsAdapter` into the populator.

## Test plan

- [x] `npm run check:types` — clean.
- [x] `npm run lint` — 0 new warnings (2 pre-existing).
- [x] `packages/services` jest — 19/19 (12 pre-existing + 7 new).
- [x] `packages/cli` `CliServiceRegistryPopulator.test.ts` — 8/8.
- [x] `packages/obsidian-plugin` `ServiceRegistryPopulator.test.ts` — 84/84 (no behavioural change).
- [x] `npm run build` — production build green.
- [ ] CI — required checks green on PR.