### PR TITLE
ci: add parity-gate required check (T3.3 RFC-027 Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,36 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+  parity-gate:
+    # RFC `94e520da` Phase 3 (T3.3) — required CI gate enforcing CLI ↔ plugin
+    # triple parity (М2: diff = 0 across 5 reference vaults). Runs ONLY the
+    # parity integration test in isolation so a failure surfaces with a
+    # named, dedicated check rather than being absorbed into the broader
+    # `test-coverage-cli` job. Independently parallel; not part of the
+    # `test-coverage` aggregator chain by design.
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Node & install deps
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Run CLI ↔ plugin triple parity diff-test
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096 --experimental-vm-modules"
+          CI: "true"
+        run: |
+          node --experimental-vm-modules ./node_modules/jest/bin/jest.js \
+            --config packages/cli/jest.config.js \
+            --testPathPatterns='tests/integration/cli-plugin-triple-parity\.integration\.test\.ts' \
+            --runInBand \
+            --forceExit
+
   test-coverage-exocortex:
     # Bare ubuntu-latest — narrow node-only regression suite, no browser needed.
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds dedicated CI job `parity-gate` (`.github/workflows/ci.yml`) that runs **only** `packages/cli/tests/integration/cli-plugin-triple-parity.integration.test.ts` (5 reference vaults, M2 metric).
- Job is independently parallel — not in the `test-coverage` aggregator chain — so future CLI ↔ plugin wikilink-resolution drift surfaces with a named, dedicated, blocking status check rather than being absorbed into the broader `test-coverage-cli` jest run.
- Closes T3.3 (RFC `94e520da-c6f7-48af-944c-51298d68da45` Phase 3); completes Phase 3 → M2 satisfied.

## Branch protection follow-up

Branch protection list update (append `parity-gate` to required checks) will be done **after this PR merges** so existing in-flight PRs are not retroactively marked BEHIND. Current required: 13 checks → after: 14.

## Test plan

- [x] `node ./node_modules/jest/bin/jest.js --config packages/cli/jest.config.js --testPathPatterns='cli-plugin-triple-parity\.integration\.test\.ts' --runInBand --forceExit` — 5/5 pass locally
- [ ] Full CI green (13 existing required checks) + new `parity-gate` job green

Closes vault task `9ab10672-6152-4c8c-a89b-4adb62f267af`.