### PR TITLE
test(cli): bootstrap Cucumber.js BDD harness for Phase 6 (T6.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "test:all": "npm test && npm run test:e2e:docker",
     "bdd:test": "cd packages/obsidian-plugin && npx tsx ../../node_modules/@cucumber/cucumber/bin/cucumber.js && cd ../..",
     "bdd:test:dry": "cd packages/obsidian-plugin && npx tsx ../../node_modules/@cucumber/cucumber/bin/cucumber.js --dry-run && cd ../..",
+    "bdd:test:cli": "cd packages/cli && npx tsx ../../node_modules/@cucumber/cucumber/bin/cucumber.js && cd ../..",
+    "bdd:test:cli:dry": "cd packages/cli && npx tsx ../../node_modules/@cucumber/cucumber/bin/cucumber.js --dry-run && cd ../..",
     "bdd:coverage": "node scripts/bdd-coverage.js",
     "bdd:report": "node scripts/generate-bdd-report.js",
     "bdd:check": "node scripts/bdd-coverage.js --fail-on-uncovered",

--- a/packages/cli/cucumber.json
+++ b/packages/cli/cucumber.json
@@ -1,0 +1,11 @@
+{
+  "default": {
+    "import": ["specs/step_definitions/**/*.ts", "specs/support/**/*.ts"],
+    "format": ["progress", "html:reports/cucumber-report.html"],
+    "formatOptions": {
+      "snippetInterface": "async-await"
+    },
+    "paths": ["specs/features/**/*.feature"],
+    "publishQuiet": true
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,8 @@
     "start": "node dist/index.js",
     "clean": "rm -rf dist",
     "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js",
+    "bdd:test": "tsx ../../node_modules/@cucumber/cucumber/bin/cucumber.js",
+    "bdd:test:dry": "tsx ../../node_modules/@cucumber/cucumber/bin/cucumber.js --dry-run",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "keywords": [

--- a/packages/cli/specs/README.md
+++ b/packages/cli/specs/README.md
@@ -1,0 +1,24 @@
+# CLI BDD Suite
+
+Cucumber.js harness for `@kitelev/exocortex-cli`. Foundation only — laid down by T6.1
+(RFC `94e520da-c6f7-48af-944c-51298d68da45` § Phase 6).
+
+## Run
+
+```bash
+# from monorepo root
+npm run bdd:test:cli       # full run
+npm run bdd:test:cli:dry   # snippet check only
+```
+
+## Layout
+
+- `features/*.feature` — Gherkin scenarios
+- `step_definitions/*.steps.ts` — step bindings
+- `support/world.ts` — shared `CliBddWorld` state object
+
+## Next: T6.2
+
+Replace the placeholder `echo` helper in `support/world.ts` with a real
+`dyncommand exec` runner against fixture vaults, then author 48 starter-kit
+grounding scenarios under `features/groundings/`.

--- a/packages/cli/specs/features/smoke.feature
+++ b/packages/cli/specs/features/smoke.feature
@@ -1,0 +1,16 @@
+Feature: CLI BDD framework smoke
+  As a CLI developer
+  I want a working Cucumber.js test harness in @kitelev/exocortex-cli
+  So that Phase 6 (T6.2) can author 48 starter-kit grounding scenarios on top of it
+
+  Background:
+    Given the CLI BDD harness is initialized
+
+  Scenario: Harness boots and shares state across steps
+    When I record the value "phase-6-foundation"
+    Then the recorded value should be "phase-6-foundation"
+
+  Scenario: Harness runs a deterministic CLI-style command
+    When I exec the CLI helper "echo" with payload "hello-bdd"
+    Then the helper exit code should be 0
+    And the helper stdout should be "hello-bdd"

--- a/packages/cli/specs/step_definitions/smoke.steps.ts
+++ b/packages/cli/specs/step_definitions/smoke.steps.ts
@@ -1,0 +1,54 @@
+import { Given, When, Then } from "@cucumber/cucumber";
+import assert from "node:assert/strict";
+import { CliBddWorld } from "../support/world.js";
+
+Given("the CLI BDD harness is initialized", function (this: CliBddWorld) {
+  this.initialized = true;
+});
+
+When(
+  "I record the value {string}",
+  function (this: CliBddWorld, value: string) {
+    assert.equal(this.initialized, true, "harness must be initialized");
+    this.recordedValue = value;
+  },
+);
+
+Then(
+  "the recorded value should be {string}",
+  function (this: CliBddWorld, expected: string) {
+    assert.equal(this.recordedValue, expected);
+  },
+);
+
+When(
+  "I exec the CLI helper {string} with payload {string}",
+  function (this: CliBddWorld, helper: string, payload: string) {
+    assert.equal(this.initialized, true, "harness must be initialized");
+    if (helper === "echo") {
+      this.helperResult = { exitCode: 0, stdout: payload, stderr: "" };
+      return;
+    }
+    this.helperResult = {
+      exitCode: 1,
+      stdout: "",
+      stderr: `unknown helper: ${helper}`,
+    };
+  },
+);
+
+Then(
+  "the helper exit code should be {int}",
+  function (this: CliBddWorld, expected: number) {
+    assert.ok(this.helperResult, "helper must have run");
+    assert.equal(this.helperResult!.exitCode, expected);
+  },
+);
+
+Then(
+  "the helper stdout should be {string}",
+  function (this: CliBddWorld, expected: string) {
+    assert.ok(this.helperResult, "helper must have run");
+    assert.equal(this.helperResult!.stdout, expected);
+  },
+);

--- a/packages/cli/specs/support/world.ts
+++ b/packages/cli/specs/support/world.ts
@@ -1,0 +1,26 @@
+import { setWorldConstructor, World, IWorldOptions } from "@cucumber/cucumber";
+
+/**
+ * Result of a CLI-style helper invocation.
+ *
+ * T6.2 will replace `helperResult` with a real `dyncommand exec` runner that
+ * captures exit code, stdout, stderr and frontmatter mutations against a test
+ * vault. This minimal shape is the contract the step layer relies on.
+ */
+export interface CliHelperResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export class CliBddWorld extends World {
+  initialized = false;
+  recordedValue: string | null = null;
+  helperResult: CliHelperResult | null = null;
+
+  constructor(options: IWorldOptions) {
+    super(options);
+  }
+}
+
+setWorldConstructor(CliBddWorld);

--- a/packages/cli/specs/tsconfig.json
+++ b/packages/cli/specs/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "outDir": "./dist",
+    "rootDir": "./"
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Bootstraps a Cucumber.js BDD harness for `@kitelev/exocortex-cli` — foundation for RFC `94e520da-c6f7-48af-944c-51298d68da45` § Phase 6.
- Adds `packages/cli/cucumber.json`, `packages/cli/specs/{features,step_definitions,support}` and `bdd:test` / `bdd:test:cli` scripts (cli-local + monorepo root).
- Smoke feature exercises the `CliBddWorld` state object with 2 scenarios / 7 steps; placeholder helper runner is the seam T6.2 will replace with a real `dyncommand exec` runner against fixture vaults.

Task UID: `4fe1502a-eb69-4904-ab9e-e5df88cab3dc`
Phase: 6 — L3 BDD test suite for 48 starter-kit groundings (`5355bfb9-ec27-4a24-af50-4991fe7ba355`)
Project: `d4afbc7e-1eaf-4286-9bc8-6e9aa78c3c9d`

## Decision log
- **Chose Cucumber.js over vitest-cucumber.** Monorepo already depends on `@cucumber/cucumber@^12.3.0` (used by `packages/obsidian-plugin/specs`); reusing it avoids adding a parallel BDD stack and keeps L3 vocabulary identical between plugin and CLI.
- **No CI wiring in this PR.** Per RFC, CI integration into `test-bdd` is T6.3. T6.2 will populate the 48 grounding scenarios first.

## Test plan
- [x] `npm run bdd:test:cli:dry` — 2 scenarios skipped (snippets resolve)
- [x] `npm run bdd:test:cli` — 2 scenarios passed, 7 steps passed
- [x] Pre-commit hooks (archgate, BDD coverage) green