### PR TITLE
docs(examples): production cron deployable for dyncommand exec (T5.3)

### DIFF
--- a/examples/production-cron/README.md
+++ b/examples/production-cron/README.md
@@ -1,0 +1,104 @@
+# Production cron example — Exocortex CLI `dyncommand exec`
+
+Reference setup for running an Exocortex `exocmd:Command` on a real cron-driven
+server. Materialises a fresh `Lunch` instance from a vault prototype every day
+at 13:00, then verifies the result at 23:55. Mirrors RFC `94e520da` § Phase 5
+acceptance criterion **М5** ("production cron example на реальной машине ≥7
+дней без manual intervention").
+
+## What this directory contains
+
+| File | Purpose |
+| --- | --- |
+| `lunch-tracker.sh` | Cron-invoked script that calls `dyncommand exec` for the `Create Instance` command against today's daily note. |
+| `verify-cron.sh` | Nightly verifier that asserts today's instance exists and emits a JSON heartbeat. |
+| `crontab.example` | Drop-in crontab fragment with both jobs. |
+
+The triple is intentionally minimal: one execution path, one verification
+path, one crontab. Anything more complex is a custom deployment, not a
+reference example.
+
+## Why a separate example (and not just a README snippet)?
+
+The CLI README (`packages/cli/README.md`) shows the *idea* of a cron-driven
+`dyncommand exec`. This directory is the **soak target** — what an operator
+deploys on a real machine to accumulate the ≥7-day evidence the RFC requires.
+
+Per the RFC's "Killer feature exocortex" framing, the same `CREATE_INSTANCE_CMD`
+UID is reused by the plugin button, the Telegram bot, and this cron — one
+RDF-defined command, three runtimes, zero hardcoded TS per use case.
+
+## Setup (one-time)
+
+1. Locate the `Create Instance` command UID in your vault:
+   ```bash
+   npx @kitelev/exocortex-cli dyncommand list --vault "$VAULT" --output json \
+     | jq -r '.[] | select(.label | test("Create Instance")) | .uid'
+   ```
+   This is the value for `CREATE_INSTANCE_CMD` below. If `list` returns nothing,
+   the vault is on a UUID-wikilink-only shape; rebuild the index or pass
+   `--target` explicitly (see CLI README troubleshooting section).
+
+2. Stage the scripts on the production host:
+   ```bash
+   sudo install -Dm755 lunch-tracker.sh /opt/exocortex/lunch-tracker.sh
+   sudo install -Dm755 verify-cron.sh   /opt/exocortex/verify-cron.sh
+   sudo touch /var/log/exocortex-lunch.log /var/log/exocortex-cron-verify.log
+   sudo chown "$USER:$USER" /var/log/exocortex-*.log
+   ```
+
+3. Install the crontab:
+   ```bash
+   crontab -l > /tmp/cron.bak 2>/dev/null || true
+   cat crontab.example >> /tmp/cron.bak
+   crontab /tmp/cron.bak
+   ```
+   Edit the `VAULT=` and `CREATE_INSTANCE_CMD=` lines first — the example UID
+   is a placeholder.
+
+4. Smoke-test before waiting on cron:
+   ```bash
+   VAULT=/home/exocortex/vault \
+   CREATE_INSTANCE_CMD=<your-uid> \
+     /opt/exocortex/lunch-tracker.sh
+
+   VAULT=/home/exocortex/vault \
+     /opt/exocortex/verify-cron.sh
+   ```
+   Both should exit 0 and the verifier should print a `"status":"ok"` JSON
+   line.
+
+## Soak protocol (≥7 days)
+
+The RFC measures success by absence of operator intervention over a week. The
+recommended monitoring loop:
+
+1. After each daily 13:00 run, `tail -n 1 /var/log/exocortex-lunch.log` should
+   show a CLI JSON result with `"success": true`.
+2. After each 23:55 run, `tail -n 1 /var/log/exocortex-cron-verify.log` should
+   show `"status":"ok"`.
+3. Any `"status":"missing"` line is a soak failure — file an issue, do not
+   silently re-run the missing job.
+4. After 7 consecutive `ok` heartbeats, the soak window has closed; the cron
+   is considered production-ready and М5 is satisfied.
+
+A counter-snippet for log scrape:
+
+```bash
+grep -c '"status":"ok"' /var/log/exocortex-cron-verify.log
+```
+
+## Failure modes worth knowing
+
+| Symptom | Likely cause | Action |
+| --- | --- | --- |
+| `precondition not satisfied` | Today's daily note missing or daily note's frontmatter changed | Recreate daily note before 13:00; precondition is intentional. |
+| `Service "..." not implemented in CLI runtime` | Grounding uses a plugin-only `service_call` (Phase 1 fail-loud) | Switch to a `create_instance` / `property_set` / `composite` grounding; CLI cannot run plugin-only services. |
+| `Command with UID "..." not found` | UUID-wikilink discovery glitch (RFC § Phase 2) | Run `dyncommand list` again; if still empty, pass the explicit `--target` IRI. |
+| Verifier says `missing` but `lunch-tracker.log` says `success` | Vault drift / wrong `LABEL_PREFIX` / clock skew | Check `EXPECTED_LABEL` in verifier output vs created instance label. |
+
+## Cross-references
+
+- CLI README cron snippet: `../../packages/cli/README.md` — Example 3.
+- RFC: vault asset `94e520da-c6f7-48af-944c-51298d68da45` § Phase 5.
+- Architecture diagram: repository root `README.md`.

--- a/examples/production-cron/crontab.example
+++ b/examples/production-cron/crontab.example
@@ -1,0 +1,21 @@
+# Example crontab entry for the Exocortex daily Lunch tracker.
+#
+# Install on the production server with:
+#   crontab -e
+# and append the lines below (adjust paths to your environment).
+#
+# Layout:
+#   m  h  dom  mon  dow  command
+
+# Required environment for the wrapped script
+VAULT=/home/exocortex/vault
+CREATE_INSTANCE_CMD=00000000-0000-0000-0000-000000000000
+PATH=/usr/local/bin:/usr/bin:/bin
+
+# Daily Lunch instance at 13:00 server time.
+# Logs go to a rotated log file; verification script tails it.
+0 13 * * * /opt/exocortex/lunch-tracker.sh >> /var/log/exocortex-lunch.log 2>&1
+
+# Optional: nightly verification at 23:55 (writes a JSON heartbeat the operator
+# can monitor via Prometheus textfile collector or any log-tailer).
+55 23 * * * /opt/exocortex/verify-cron.sh >> /var/log/exocortex-cron-verify.log 2>&1

--- a/examples/production-cron/lunch-tracker.sh
+++ b/examples/production-cron/lunch-tracker.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# lunch-tracker.sh — production cron entry that materializes a fresh `Lunch`
+# instance every day at 13:00 from a vault prototype, using the generic
+# `create_instance` grounding. See README.md (this directory) for setup and
+# RFC 94e520da § Phase 5 for context.
+#
+# Cron line:
+#   0 13 * * * /opt/exocortex/lunch-tracker.sh >> /var/log/exocortex-lunch.log 2>&1
+#
+# Exit codes:
+#   0  — success (fresh Lunch instance created, or already existed and was idempotent)
+#   1  — CLI invocation failed (precondition unsatisfied, command not found, etc.)
+#   2  — environment misconfiguration (VAULT missing, daily note missing)
+
+set -euo pipefail
+
+# ---------- Required environment ----------
+: "${VAULT:?VAULT must point to the Obsidian vault root (e.g. /home/user/vault)}"
+: "${CREATE_INSTANCE_CMD:?CREATE_INSTANCE_CMD must be the UID of the Create Instance dyncommand (find via 'dyncommand list')}"
+
+# ---------- Optional knobs ----------
+CLI_PACKAGE="${CLI_PACKAGE:-@kitelev/exocortex-cli}"
+DAILY_DIR="${DAILY_DIR:-daily}"
+LABEL_PREFIX="${LABEL_PREFIX:-Lunch}"
+TODAY="$(date +%Y-%m-%d)"
+DAILY="${DAILY_DIR}/${TODAY}.md"
+
+if [[ ! -f "${VAULT}/${DAILY}" ]]; then
+  echo "[lunch-tracker] daily note ${DAILY} missing in vault ${VAULT}" >&2
+  exit 2
+fi
+
+# ---------- Invoke the dyncommand ----------
+# `--output json` makes the result machine-parsable for log greppers.
+# We intentionally do NOT use --dry-run; the cron is the production path.
+exec npx --yes "${CLI_PACKAGE}" dyncommand exec "${CREATE_INSTANCE_CMD}" \
+  --target "${DAILY}" \
+  --input "{\"label\":\"${LABEL_PREFIX} — ${TODAY}\"}" \
+  --vault "${VAULT}" \
+  --output json

--- a/examples/production-cron/verify-cron.sh
+++ b/examples/production-cron/verify-cron.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# verify-cron.sh — nightly soak verification for the Lunch cron.
+#
+# Reads VAULT and the canonical Lunch class label, then asserts that today's
+# daily note has at least one related Lunch instance whose label matches
+# "${LABEL_PREFIX} — YYYY-MM-DD". Emits a JSON heartbeat suitable for a
+# Prometheus node-exporter textfile collector or simple log scrape.
+#
+# Exit codes:
+#   0  — heartbeat ok (instance found)
+#   1  — instance NOT found for today (cron likely failed)
+#   2  — environment misconfiguration
+
+set -euo pipefail
+
+: "${VAULT:?VAULT must point to the Obsidian vault root}"
+LABEL_PREFIX="${LABEL_PREFIX:-Lunch}"
+DAILY_DIR="${DAILY_DIR:-daily}"
+TODAY="$(date +%Y-%m-%d)"
+DAILY_PATH="${VAULT}/${DAILY_DIR}/${TODAY}.md"
+EXPECTED_LABEL="${LABEL_PREFIX} — ${TODAY}"
+
+if [[ ! -d "${VAULT}" ]]; then
+  echo "[verify-cron] VAULT ${VAULT} not a directory" >&2
+  exit 2
+fi
+
+if [[ ! -f "${DAILY_PATH}" ]]; then
+  echo "[verify-cron] daily note ${DAILY_PATH} missing" >&2
+  exit 2
+fi
+
+# Search vault for a Lunch instance whose label or aliases match today's
+# expected pattern. We grep the frontmatter rather than running SPARQL to keep
+# the verifier dependency-free (no Node, no plugin, no CLI cold start).
+match_count=$(grep -lR --include="*.md" -F "${EXPECTED_LABEL}" "${VAULT}" 2>/dev/null | wc -l | tr -d ' ')
+
+status="ok"
+exit_code=0
+if [[ "${match_count}" -eq 0 ]]; then
+  status="missing"
+  exit_code=1
+fi
+
+# Single-line JSON heartbeat — easy to parse by log shippers.
+printf '{"timestamp":"%s","date":"%s","expected_label":"%s","matches":%s,"status":"%s"}\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  "${TODAY}" \
+  "${EXPECTED_LABEL}" \
+  "${match_count}" \
+  "${status}"
+
+exit "${exit_code}"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -446,6 +446,11 @@ npx @kitelev/exocortex-cli dyncommand exec "$CREATE_INSTANCE_CMD" \
 If the command, its precondition, or its grounding ever change in the vault,
 the cron job picks up the new behavior automatically — no redeploy.
 
+A drop-in deployable version of this script — with crontab fragment, nightly
+verifier, install instructions, and a 7-day soak protocol — lives in
+[`examples/production-cron/`](../../examples/production-cron/) (RFC
+`94e520da` § Phase 5).
+
 #### Troubleshooting
 
 - **`Precondition not satisfied`** — run `dyncommand show <uid>` to read the


### PR DESCRIPTION
## Summary

Materialises RFC `94e520da` § Phase 5 acceptance metric **М5** — a real-machine cron deployable an operator can install today and use to accumulate the ≥7-day soak evidence the RFC requires. Same `dyncommand exec` codepath as the plugin button and Telegram bot — one RDF-defined `Create Instance` command, three runtimes, zero hardcoded TS per use case.

Adds `examples/production-cron/` with:
- `lunch-tracker.sh` — daily 13:00 cron driver invoking `dyncommand exec` against today's daily note.
- `verify-cron.sh` — nightly heartbeat asserting today's instance exists; emits single-line JSON suitable for Prometheus textfile collector or any log shipper.
- `crontab.example` — drop-in crontab fragment with both jobs.
- `README.md` — install steps, soak protocol, failure-mode table cross-referencing the CLI README troubleshooting section.

Cross-links from `packages/cli/README.md` cron snippet (Example 3) to the deployable so users discover the soak target from the docs entry point.

## Phase 5 closure note

Per task contract Option A: 7-day soak evidence accumulates **post-merge** on the operator host. This is ops verification, not code work, and does not block М5/М7. The artefact is shippable now; CI verifies the scripts parse cleanly.

Refs RFC `94e520da-c6f7-48af-944c-51298d68da45` § Phase 5 (T5.3).
Closes Phase 5 of project `d4afbc7e-1eaf-4286-9bc8-6e9aa78c3c9d`.

## Test plan

- [x] `bash -n` on both shell scripts (syntax clean)
- [x] CLI README link to `examples/production-cron/` resolves
- [ ] CI green (13 required checks)
- [ ] Auto-merge --squash