### PR TITLE
test(cli): 48 BDD scenarios + expected.json fixtures (T6.2)

### DIFF
--- a/packages/cli/specs/features/groundings.feature
+++ b/packages/cli/specs/features/groundings.feature
@@ -1,0 +1,66 @@
+Feature: Starter-kit grounding execution (RFC 94e520da § Phase 6)
+  As an Exocortex CLI user
+  I want every starter-kit grounding to behave deterministically when invoked via dyncommand exec
+  So that any regression breaking a grounding is caught by the test-bdd CI gate
+
+  All 48 starter-kit groundings (T1.5 audit) are exercised. Per-grounding
+  expected outcomes live in packages/cli/specs/fixtures/groundings/<uid>.expected.json.
+
+  Background:
+    Given the starter-kit fixture vault is initialized
+
+  Scenario Outline: Grounding "<label>" (<uid>)
+    Given a fresh test target asset in the fixture vault
+    When I exec grounding "<uid>" via the CLI grounding executor
+    Then the result should match the expected fixture for "<uid>"
+
+    Examples:
+      | uid | type | cliStatus | label |
+      | 58714ab2-c155-47d8-a8bb-38da317817ad | property_delete | real         | Remove start timestamp |
+      | 30b9e8d8-bc55-492d-80fa-82f01ed19a45 | service_call    | real         | Link to parent |
+      | 4919afb1-fcc3-4a6e-85a0-a869e6a69774 | service_call    | real         | Create related task via service |
+      | 4d8d5055-cf83-4d12-8749-7c0f6956d9be | service_call    | unregistered | Create task for daily note via service |
+      | 8748f8b0-989b-45a0-88a9-155bc5126f3c | service_call    | real         | Create project |
+      | 95aaab51-8cd5-42db-a207-42793864d133 | service_call    | stub         | Create knowledge |
+      | a222094b-f499-4342-aec0-65c4ba99c657 | service_call    | stub         | Create task |
+      | abdbdf09-8712-4c11-8cbe-467f46091294 | service_call    | real         | Convert to task |
+      | c84e2e08-8fb9-42e7-9112-11864fb13a09 | service_call    | stub         | Create note |
+      | e72a5fa1-a902-4508-b671-bde8a1461a02 | create_instance | real         | Create Area via service |
+      | e8c1d18a-f622-41b4-89e7-9a3be33a96d7 | service_call    | real         | Convert to project |
+      | 023596ba-3ea1-4d3c-aaf5-5589c8a4f7f5 | property_set    | real         | Set zone to Today |
+      | 6d78a3a4-401a-4fb9-8b44-48c6530eef62 | property_set    | real         | Set zone to This Week |
+      | dc39bd9e-77b8-4ecf-b38f-f35795540dd9 | property_set    | real         | Set zone to Someday |
+      | bf4772d7-9f5c-401e-9ac6-8f9e240a5928 | service_call    | real         | Rename to UID via service |
+      | cd98b4de-3c04-4d05-9715-7335ffb61630 | service_call    | real         | Fix missing label via service |
+      | de7914fb-3f56-4278-81f1-6c23345553f0 | service_call    | real         | Clean properties via service |
+      | e7189a73-fa97-45ad-b9e9-bd68a0feee10 | service_call    | real         | Repair folder via service |
+      | eb3bb751-596b-48f8-b834-7a9e680dabbe | service_call    | real         | Archive asset via service |
+      | eba11892-6e8d-4e38-b5e4-d50dd006e6d8 | service_call    | unregistered | Rollback status via service |
+      | 1a14832c-f657-4816-b2aa-d06f2a80fccf | property_delete | real         | Delete start timestamp |
+      | 2c53ea68-8247-4ea8-870e-3bfbf2256b2f | property_delete | real         | Delete end timestamp |
+      | a85668fa-17b7-45d0-aa7f-935e2502dff0 | service_call    | unregistered | Copy label to aliases via service |
+      | c4616dcd-3832-4812-b289-0968510fb8be | service_call    | real         | Set result value |
+      | 0b104d75-3ed5-44c5-ab04-cffb26e2578a | service_call    | unregistered | Shift day forward via service |
+      | 22a6ba6b-030a-47e4-946e-1a30dc9450e5 | service_call    | unregistered | Plan on today via service |
+      | 4ffd02e9-f0a6-477d-846e-6364b8b4d528 | property_delete | real         | Remove scheduled date |
+      | 506f031e-007f-4c74-8257-158550c64956 | service_call    | unregistered | Increment votes via service |
+      | 6ee56341-966c-4791-8eb3-7a75104b2e5b | service_call    | unregistered | Shift day backward via service |
+      | 85687461-c2df-4d1b-819b-0c3ae0ab3741 | service_call    | real         | Set planned start timestamp |
+      | afda78d9-88e1-4590-8ce8-2c664d6359d3 | service_call    | real         | Set planned end timestamp |
+      | d222ddaf-0a56-4bac-91e3-6af02fafebc8 | service_call    | real         | Set scheduled date |
+      | f8893042-77ed-4241-959e-e360a4858759 | service_call    | real         | Plan for evening via service |
+      | 21e534ee-afe7-464f-8d96-6142660e965b | property_set    | real         | Set status to Draft |
+      | 23727560-5f6b-4c49-9b33-eea34c7eec9e | composite       | real         | Transition to Doing (status + startTimestamp) |
+      | 53c228c8-c169-4345-a893-9c4dd005949c | property_set    | real         | Set status to Review |
+      | 54bd588f-e5f2-4fbf-b6da-64b54a9a3ee4 | property_set    | real         | Set status to ToDo |
+      | 584f7e07-d485-4d85-9be6-23b2bf3f19af | property_set    | real         | Set ems__Effort_endTimestamp to $nowLocal |
+      | 735a7c95-a5ea-4870-97e5-bb13bc167fc1 | property_set    | real         | Set status to Waiting |
+      | 73ec8312-4675-41d9-9fa1-33455d983880 | property_set    | real         | Set ems__Effort_resolutionTimestamp to $nowLocal |
+      | 95dfbcad-daca-47aa-8788-74e09f6b10a1 | property_set    | real         | Set ems__Effort_startTimestamp to $nowLocal |
+      | bdf3c81f-3531-48a8-a680-eaf5543ea042 | property_set    | real         | Set status to Done |
+      | cce66b76-9ca5-4954-85b0-6d549855ed2a | property_set    | real         | Set status to Analysis |
+      | cfd2d68a-49cc-4a9f-9231-abd3dece59fb | property_set    | real         | Set status to Backlog |
+      | d5deac7a-149d-43a1-b249-875d91834b60 | property_set    | real         | Set status to Doing |
+      | ef1d12dc-6a65-4f1d-b7f5-d5c5367d9633 | property_set    | real         | Set status to Blocked |
+      | f32de9a1-f62b-4406-8610-31af5003ba29 | property_set    | real         | Set status to Cancelled |
+      | f9e23c9e-174b-456c-a2f0-c11f811a7ee6 | composite       | real         | Transition to Done (status + end + resolution) |

--- a/packages/cli/specs/fixtures/groundings/023596ba-3ea1-4d3c-aaf5-5589c8a4f7f5.expected.json
+++ b/packages/cli/specs/fixtures/groundings/023596ba-3ea1-4d3c-aaf5-5589c8a4f7f5.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "023596ba-3ea1-4d3c-aaf5-5589c8a4f7f5",
+  "label": "Set zone to Today",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/criticality/023596ba-3ea1-4d3c-aaf5-5589c8a4f7f5.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Task_zone": "[[e266a2e9-9eb0-431d-b1fe-b95b9d3e9a3f]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/0b104d75-3ed5-44c5-ab04-cffb26e2578a.expected.json
+++ b/packages/cli/specs/fixtures/groundings/0b104d75-3ed5-44c5-ab04-cffb26e2578a.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "0b104d75-3ed5-44c5-ab04-cffb26e2578a",
+  "label": "Shift day forward via service",
+  "type": "service_call",
+  "cliStatus": "unregistered",
+  "serviceId": "shiftDay",
+  "sourcePath": "exocmd/planning/0b104d75-3ed5-44c5-ab04-cffb26e2578a.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service not found: \\\"shiftDay\\\""
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/1a14832c-f657-4816-b2aa-d06f2a80fccf.expected.json
+++ b/packages/cli/specs/fixtures/groundings/1a14832c-f657-4816-b2aa-d06f2a80fccf.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "1a14832c-f657-4816-b2aa-d06f2a80fccf",
+  "label": "Delete start timestamp",
+  "type": "property_delete",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/maintenance/1a14832c-f657-4816-b2aa-d06f2a80fccf.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterRemoved": ["ems__Effort_startTimestamp"]
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/21e534ee-afe7-464f-8d96-6142660e965b.expected.json
+++ b/packages/cli/specs/fixtures/groundings/21e534ee-afe7-464f-8d96-6142660e965b.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "21e534ee-afe7-464f-8d96-6142660e965b",
+  "label": "Set status to Draft",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/21e534ee-afe7-464f-8d96-6142660e965b.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/22a6ba6b-030a-47e4-946e-1a30dc9450e5.expected.json
+++ b/packages/cli/specs/fixtures/groundings/22a6ba6b-030a-47e4-946e-1a30dc9450e5.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "22a6ba6b-030a-47e4-946e-1a30dc9450e5",
+  "label": "Plan on today via service",
+  "type": "service_call",
+  "cliStatus": "unregistered",
+  "serviceId": "planOnToday",
+  "sourcePath": "exocmd/planning/22a6ba6b-030a-47e4-946e-1a30dc9450e5.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service not found: \\\"planOnToday\\\""
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/23727560-5f6b-4c49-9b33-eea34c7eec9e.expected.json
+++ b/packages/cli/specs/fixtures/groundings/23727560-5f6b-4c49-9b33-eea34c7eec9e.expected.json
@@ -1,0 +1,16 @@
+{
+  "uid": "23727560-5f6b-4c49-9b33-eea34c7eec9e",
+  "label": "Transition to Doing (status + startTimestamp)",
+  "type": "composite",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/23727560-5f6b-4c49-9b33-eea34c7eec9e.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  },
+  "compositeStepUids": [
+    "d5deac7a-149d-43a1-b249-875d91834b60",
+    "95dfbcad-daca-47aa-8788-74e09f6b10a1"
+  ]
+}

--- a/packages/cli/specs/fixtures/groundings/2c53ea68-8247-4ea8-870e-3bfbf2256b2f.expected.json
+++ b/packages/cli/specs/fixtures/groundings/2c53ea68-8247-4ea8-870e-3bfbf2256b2f.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "2c53ea68-8247-4ea8-870e-3bfbf2256b2f",
+  "label": "Delete end timestamp",
+  "type": "property_delete",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/maintenance/2c53ea68-8247-4ea8-870e-3bfbf2256b2f.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterRemoved": ["ems__Effort_endTimestamp"]
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/30b9e8d8-bc55-492d-80fa-82f01ed19a45.expected.json
+++ b/packages/cli/specs/fixtures/groundings/30b9e8d8-bc55-492d-80fa-82f01ed19a45.expected.json
@@ -1,0 +1,14 @@
+{
+  "uid": "30b9e8d8-bc55-492d-80fa-82f01ed19a45",
+  "label": "Link to parent",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "updateProperty",
+  "sourcePath": "exocmd/creation/30b9e8d8-bc55-492d-80fa-82f01ed19a45.md",
+  "userInput": {
+    "value": "[[bdd-parent-asset]]"
+  },
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/4919afb1-fcc3-4a6e-85a0-a869e6a69774.expected.json
+++ b/packages/cli/specs/fixtures/groundings/4919afb1-fcc3-4a6e-85a0-a869e6a69774.expected.json
@@ -1,0 +1,14 @@
+{
+  "uid": "4919afb1-fcc3-4a6e-85a0-a869e6a69774",
+  "label": "Create related task via service",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "createRelatedTask",
+  "sourcePath": "exocmd/creation/4919afb1-fcc3-4a6e-85a0-a869e6a69774.md",
+  "userInput": {
+    "label": "BDD Test"
+  },
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/4d8d5055-cf83-4d12-8749-7c0f6956d9be.expected.json
+++ b/packages/cli/specs/fixtures/groundings/4d8d5055-cf83-4d12-8749-7c0f6956d9be.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "4d8d5055-cf83-4d12-8749-7c0f6956d9be",
+  "label": "Create task for daily note via service",
+  "type": "service_call",
+  "cliStatus": "unregistered",
+  "serviceId": "createTaskForDailyNote",
+  "sourcePath": "exocmd/creation/4d8d5055-cf83-4d12-8749-7c0f6956d9be.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service not found: \\\"createTaskForDailyNote\\\""
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/4ffd02e9-f0a6-477d-846e-6364b8b4d528.expected.json
+++ b/packages/cli/specs/fixtures/groundings/4ffd02e9-f0a6-477d-846e-6364b8b4d528.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "4ffd02e9-f0a6-477d-846e-6364b8b4d528",
+  "label": "Remove scheduled date",
+  "type": "property_delete",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/planning/4ffd02e9-f0a6-477d-846e-6364b8b4d528.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterRemoved": ["ems__Effort_scheduledDate"]
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/506f031e-007f-4c74-8257-158550c64956.expected.json
+++ b/packages/cli/specs/fixtures/groundings/506f031e-007f-4c74-8257-158550c64956.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "506f031e-007f-4c74-8257-158550c64956",
+  "label": "Increment votes via service",
+  "type": "service_call",
+  "cliStatus": "unregistered",
+  "serviceId": "incrementVotes",
+  "sourcePath": "exocmd/planning/506f031e-007f-4c74-8257-158550c64956.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service not found: \\\"incrementVotes\\\""
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/53c228c8-c169-4345-a893-9c4dd005949c.expected.json
+++ b/packages/cli/specs/fixtures/groundings/53c228c8-c169-4345-a893-9c4dd005949c.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "53c228c8-c169-4345-a893-9c4dd005949c",
+  "label": "Set status to Review",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/53c228c8-c169-4345-a893-9c4dd005949c.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[23117822-229d-43ab-8702-4fd72697b446]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/54bd588f-e5f2-4fbf-b6da-64b54a9a3ee4.expected.json
+++ b/packages/cli/specs/fixtures/groundings/54bd588f-e5f2-4fbf-b6da-64b54a9a3ee4.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "54bd588f-e5f2-4fbf-b6da-64b54a9a3ee4",
+  "label": "Set status to ToDo",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/54bd588f-e5f2-4fbf-b6da-64b54a9a3ee4.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[6a0e933a-6653-46f4-95ae-ed7508177c73]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/584f7e07-d485-4d85-9be6-23b2bf3f19af.expected.json
+++ b/packages/cli/specs/fixtures/groundings/584f7e07-d485-4d85-9be6-23b2bf3f19af.expected.json
@@ -1,0 +1,17 @@
+{
+  "uid": "584f7e07-d485-4d85-9be6-23b2bf3f19af",
+  "label": "Set ems__Effort_endTimestamp to $nowLocal",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/584f7e07-d485-4d85-9be6-23b2bf3f19af.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_endTimestamp": {
+        "__regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+      }
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/58714ab2-c155-47d8-a8bb-38da317817ad.expected.json
+++ b/packages/cli/specs/fixtures/groundings/58714ab2-c155-47d8-a8bb-38da317817ad.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "58714ab2-c155-47d8-a8bb-38da317817ad",
+  "label": "Remove start timestamp",
+  "type": "property_delete",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/58714ab2-c155-47d8-a8bb-38da317817ad.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterRemoved": ["ems__Effort_startTimestamp"]
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/6d78a3a4-401a-4fb9-8b44-48c6530eef62.expected.json
+++ b/packages/cli/specs/fixtures/groundings/6d78a3a4-401a-4fb9-8b44-48c6530eef62.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "6d78a3a4-401a-4fb9-8b44-48c6530eef62",
+  "label": "Set zone to This Week",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/criticality/6d78a3a4-401a-4fb9-8b44-48c6530eef62.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Task_zone": "[[c7f1a968-0959-4ac7-ac82-31b0cdc2aba7]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/6ee56341-966c-4791-8eb3-7a75104b2e5b.expected.json
+++ b/packages/cli/specs/fixtures/groundings/6ee56341-966c-4791-8eb3-7a75104b2e5b.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "6ee56341-966c-4791-8eb3-7a75104b2e5b",
+  "label": "Shift day backward via service",
+  "type": "service_call",
+  "cliStatus": "unregistered",
+  "serviceId": "shiftDay",
+  "sourcePath": "exocmd/planning/6ee56341-966c-4791-8eb3-7a75104b2e5b.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service not found: \\\"shiftDay\\\""
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/735a7c95-a5ea-4870-97e5-bb13bc167fc1.expected.json
+++ b/packages/cli/specs/fixtures/groundings/735a7c95-a5ea-4870-97e5-bb13bc167fc1.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "735a7c95-a5ea-4870-97e5-bb13bc167fc1",
+  "label": "Set status to Waiting",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/735a7c95-a5ea-4870-97e5-bb13bc167fc1.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[0610947c-6a62-41c8-9d44-7863d3ba3a8e]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/73ec8312-4675-41d9-9fa1-33455d983880.expected.json
+++ b/packages/cli/specs/fixtures/groundings/73ec8312-4675-41d9-9fa1-33455d983880.expected.json
@@ -1,0 +1,17 @@
+{
+  "uid": "73ec8312-4675-41d9-9fa1-33455d983880",
+  "label": "Set ems__Effort_resolutionTimestamp to $nowLocal",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/73ec8312-4675-41d9-9fa1-33455d983880.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_resolutionTimestamp": {
+        "__regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+      }
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/85687461-c2df-4d1b-819b-0c3ae0ab3741.expected.json
+++ b/packages/cli/specs/fixtures/groundings/85687461-c2df-4d1b-819b-0c3ae0ab3741.expected.json
@@ -1,0 +1,14 @@
+{
+  "uid": "85687461-c2df-4d1b-819b-0c3ae0ab3741",
+  "label": "Set planned start timestamp",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "updateProperty",
+  "sourcePath": "exocmd/planning/85687461-c2df-4d1b-819b-0c3ae0ab3741.md",
+  "userInput": {
+    "value": "[[bdd-parent-asset]]"
+  },
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/8748f8b0-989b-45a0-88a9-155bc5126f3c.expected.json
+++ b/packages/cli/specs/fixtures/groundings/8748f8b0-989b-45a0-88a9-155bc5126f3c.expected.json
@@ -1,0 +1,14 @@
+{
+  "uid": "8748f8b0-989b-45a0-88a9-155bc5126f3c",
+  "label": "Create project",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "createRelatedProject",
+  "sourcePath": "exocmd/creation/8748f8b0-989b-45a0-88a9-155bc5126f3c.md",
+  "userInput": {
+    "label": "BDD Test"
+  },
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/95aaab51-8cd5-42db-a207-42793864d133.expected.json
+++ b/packages/cli/specs/fixtures/groundings/95aaab51-8cd5-42db-a207-42793864d133.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "95aaab51-8cd5-42db-a207-42793864d133",
+  "label": "Create knowledge",
+  "type": "service_call",
+  "cliStatus": "stub",
+  "serviceId": "createAsset",
+  "sourcePath": "exocmd/creation/95aaab51-8cd5-42db-a207-42793864d133.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service \\\"createAsset\\\" is not implemented"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/95dfbcad-daca-47aa-8788-74e09f6b10a1.expected.json
+++ b/packages/cli/specs/fixtures/groundings/95dfbcad-daca-47aa-8788-74e09f6b10a1.expected.json
@@ -1,0 +1,17 @@
+{
+  "uid": "95dfbcad-daca-47aa-8788-74e09f6b10a1",
+  "label": "Set ems__Effort_startTimestamp to $nowLocal",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/95dfbcad-daca-47aa-8788-74e09f6b10a1.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_startTimestamp": {
+        "__regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+      }
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/a222094b-f499-4342-aec0-65c4ba99c657.expected.json
+++ b/packages/cli/specs/fixtures/groundings/a222094b-f499-4342-aec0-65c4ba99c657.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "a222094b-f499-4342-aec0-65c4ba99c657",
+  "label": "Create task",
+  "type": "service_call",
+  "cliStatus": "stub",
+  "serviceId": "createAsset",
+  "sourcePath": "exocmd/creation/a222094b-f499-4342-aec0-65c4ba99c657.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service \\\"createAsset\\\" is not implemented"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/a85668fa-17b7-45d0-aa7f-935e2502dff0.expected.json
+++ b/packages/cli/specs/fixtures/groundings/a85668fa-17b7-45d0-aa7f-935e2502dff0.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "a85668fa-17b7-45d0-aa7f-935e2502dff0",
+  "label": "Copy label to aliases via service",
+  "type": "service_call",
+  "cliStatus": "unregistered",
+  "serviceId": "copyLabelToAliases",
+  "sourcePath": "exocmd/maintenance/a85668fa-17b7-45d0-aa7f-935e2502dff0.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service not found: \\\"copyLabelToAliases\\\""
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/abdbdf09-8712-4c11-8cbe-467f46091294.expected.json
+++ b/packages/cli/specs/fixtures/groundings/abdbdf09-8712-4c11-8cbe-467f46091294.expected.json
@@ -1,0 +1,12 @@
+{
+  "uid": "abdbdf09-8712-4c11-8cbe-467f46091294",
+  "label": "Convert to task",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "updateProperty",
+  "sourcePath": "exocmd/creation/abdbdf09-8712-4c11-8cbe-467f46091294.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/afda78d9-88e1-4590-8ce8-2c664d6359d3.expected.json
+++ b/packages/cli/specs/fixtures/groundings/afda78d9-88e1-4590-8ce8-2c664d6359d3.expected.json
@@ -1,0 +1,14 @@
+{
+  "uid": "afda78d9-88e1-4590-8ce8-2c664d6359d3",
+  "label": "Set planned end timestamp",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "updateProperty",
+  "sourcePath": "exocmd/planning/afda78d9-88e1-4590-8ce8-2c664d6359d3.md",
+  "userInput": {
+    "value": "[[bdd-parent-asset]]"
+  },
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/bdf3c81f-3531-48a8-a680-eaf5543ea042.expected.json
+++ b/packages/cli/specs/fixtures/groundings/bdf3c81f-3531-48a8-a680-eaf5543ea042.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "bdf3c81f-3531-48a8-a680-eaf5543ea042",
+  "label": "Set status to Done",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/bdf3c81f-3531-48a8-a680-eaf5543ea042.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[7b9b3116-7c3c-438c-9618-94fe301320a6]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/bf4772d7-9f5c-401e-9ac6-8f9e240a5928.expected.json
+++ b/packages/cli/specs/fixtures/groundings/bf4772d7-9f5c-401e-9ac6-8f9e240a5928.expected.json
@@ -1,0 +1,12 @@
+{
+  "uid": "bf4772d7-9f5c-401e-9ac6-8f9e240a5928",
+  "label": "Rename to UID via service",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "renameToUid",
+  "sourcePath": "exocmd/maintenance-complex/bf4772d7-9f5c-401e-9ac6-8f9e240a5928.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/c4616dcd-3832-4812-b289-0968510fb8be.expected.json
+++ b/packages/cli/specs/fixtures/groundings/c4616dcd-3832-4812-b289-0968510fb8be.expected.json
@@ -1,0 +1,14 @@
+{
+  "uid": "c4616dcd-3832-4812-b289-0968510fb8be",
+  "label": "Set result value",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "updateProperty",
+  "sourcePath": "exocmd/maintenance/c4616dcd-3832-4812-b289-0968510fb8be.md",
+  "userInput": {
+    "value": "[[bdd-parent-asset]]"
+  },
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/c84e2e08-8fb9-42e7-9112-11864fb13a09.expected.json
+++ b/packages/cli/specs/fixtures/groundings/c84e2e08-8fb9-42e7-9112-11864fb13a09.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "c84e2e08-8fb9-42e7-9112-11864fb13a09",
+  "label": "Create note",
+  "type": "service_call",
+  "cliStatus": "stub",
+  "serviceId": "createAsset",
+  "sourcePath": "exocmd/creation/c84e2e08-8fb9-42e7-9112-11864fb13a09.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service \\\"createAsset\\\" is not implemented"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/cce66b76-9ca5-4954-85b0-6d549855ed2a.expected.json
+++ b/packages/cli/specs/fixtures/groundings/cce66b76-9ca5-4954-85b0-6d549855ed2a.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "cce66b76-9ca5-4954-85b0-6d549855ed2a",
+  "label": "Set status to Analysis",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/cce66b76-9ca5-4954-85b0-6d549855ed2a.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[cde3525c-57ea-4efc-b477-2e7e7ccd3a1e]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/cd98b4de-3c04-4d05-9715-7335ffb61630.expected.json
+++ b/packages/cli/specs/fixtures/groundings/cd98b4de-3c04-4d05-9715-7335ffb61630.expected.json
@@ -1,0 +1,12 @@
+{
+  "uid": "cd98b4de-3c04-4d05-9715-7335ffb61630",
+  "label": "Fix missing label via service",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "fixMissingLabel",
+  "sourcePath": "exocmd/maintenance-complex/cd98b4de-3c04-4d05-9715-7335ffb61630.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/cfd2d68a-49cc-4a9f-9231-abd3dece59fb.expected.json
+++ b/packages/cli/specs/fixtures/groundings/cfd2d68a-49cc-4a9f-9231-abd3dece59fb.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "cfd2d68a-49cc-4a9f-9231-abd3dece59fb",
+  "label": "Set status to Backlog",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/cfd2d68a-49cc-4a9f-9231-abd3dece59fb.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/d222ddaf-0a56-4bac-91e3-6af02fafebc8.expected.json
+++ b/packages/cli/specs/fixtures/groundings/d222ddaf-0a56-4bac-91e3-6af02fafebc8.expected.json
@@ -1,0 +1,14 @@
+{
+  "uid": "d222ddaf-0a56-4bac-91e3-6af02fafebc8",
+  "label": "Set scheduled date",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "updateProperty",
+  "sourcePath": "exocmd/planning/d222ddaf-0a56-4bac-91e3-6af02fafebc8.md",
+  "userInput": {
+    "value": "[[bdd-parent-asset]]"
+  },
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/d5deac7a-149d-43a1-b249-875d91834b60.expected.json
+++ b/packages/cli/specs/fixtures/groundings/d5deac7a-149d-43a1-b249-875d91834b60.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "d5deac7a-149d-43a1-b249-875d91834b60",
+  "label": "Set status to Doing",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/d5deac7a-149d-43a1-b249-875d91834b60.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/dc39bd9e-77b8-4ecf-b38f-f35795540dd9.expected.json
+++ b/packages/cli/specs/fixtures/groundings/dc39bd9e-77b8-4ecf-b38f-f35795540dd9.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "dc39bd9e-77b8-4ecf-b38f-f35795540dd9",
+  "label": "Set zone to Someday",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/criticality/dc39bd9e-77b8-4ecf-b38f-f35795540dd9.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Task_zone": "[[6968a0fc-7a41-4393-82b1-17d767c7ad7c]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/de7914fb-3f56-4278-81f1-6c23345553f0.expected.json
+++ b/packages/cli/specs/fixtures/groundings/de7914fb-3f56-4278-81f1-6c23345553f0.expected.json
@@ -1,0 +1,12 @@
+{
+  "uid": "de7914fb-3f56-4278-81f1-6c23345553f0",
+  "label": "Clean properties via service",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "cleanProperties",
+  "sourcePath": "exocmd/maintenance-complex/de7914fb-3f56-4278-81f1-6c23345553f0.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/e7189a73-fa97-45ad-b9e9-bd68a0feee10.expected.json
+++ b/packages/cli/specs/fixtures/groundings/e7189a73-fa97-45ad-b9e9-bd68a0feee10.expected.json
@@ -1,0 +1,12 @@
+{
+  "uid": "e7189a73-fa97-45ad-b9e9-bd68a0feee10",
+  "label": "Repair folder via service",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "repairFolder",
+  "sourcePath": "exocmd/maintenance-complex/e7189a73-fa97-45ad-b9e9-bd68a0feee10.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/e72a5fa1-a902-4508-b671-bde8a1461a02.expected.json
+++ b/packages/cli/specs/fixtures/groundings/e72a5fa1-a902-4508-b671-bde8a1461a02.expected.json
@@ -1,0 +1,16 @@
+{
+  "uid": "e72a5fa1-a902-4508-b671-bde8a1461a02",
+  "label": "Create Area via service",
+  "type": "create_instance",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/creation/e72a5fa1-a902-4508-b671-bde8a1461a02.md",
+  "userInput": {
+    "label": "BDD Test"
+  },
+  "expect": {
+    "outcome": "success"
+  },
+  "targetClass": "82c74542-1b14-4217-b852-d84730484b25",
+  "targetFolder": "01 Areas"
+}

--- a/packages/cli/specs/fixtures/groundings/e8c1d18a-f622-41b4-89e7-9a3be33a96d7.expected.json
+++ b/packages/cli/specs/fixtures/groundings/e8c1d18a-f622-41b4-89e7-9a3be33a96d7.expected.json
@@ -1,0 +1,12 @@
+{
+  "uid": "e8c1d18a-f622-41b4-89e7-9a3be33a96d7",
+  "label": "Convert to project",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "updateProperty",
+  "sourcePath": "exocmd/creation/e8c1d18a-f622-41b4-89e7-9a3be33a96d7.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/eb3bb751-596b-48f8-b834-7a9e680dabbe.expected.json
+++ b/packages/cli/specs/fixtures/groundings/eb3bb751-596b-48f8-b834-7a9e680dabbe.expected.json
@@ -1,0 +1,12 @@
+{
+  "uid": "eb3bb751-596b-48f8-b834-7a9e680dabbe",
+  "label": "Archive asset via service",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "archiveAsset",
+  "sourcePath": "exocmd/maintenance-complex/eb3bb751-596b-48f8-b834-7a9e680dabbe.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/eba11892-6e8d-4e38-b5e4-d50dd006e6d8.expected.json
+++ b/packages/cli/specs/fixtures/groundings/eba11892-6e8d-4e38-b5e4-d50dd006e6d8.expected.json
@@ -1,0 +1,13 @@
+{
+  "uid": "eba11892-6e8d-4e38-b5e4-d50dd006e6d8",
+  "label": "Rollback status via service",
+  "type": "service_call",
+  "cliStatus": "unregistered",
+  "serviceId": "rollbackStatus",
+  "sourcePath": "exocmd/maintenance-complex/eba11892-6e8d-4e38-b5e4-d50dd006e6d8.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "failure",
+    "errorPattern": "Service not found: \\\"rollbackStatus\\\""
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/ef1d12dc-6a65-4f1d-b7f5-d5c5367d9633.expected.json
+++ b/packages/cli/specs/fixtures/groundings/ef1d12dc-6a65-4f1d-b7f5-d5c5367d9633.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "ef1d12dc-6a65-4f1d-b7f5-d5c5367d9633",
+  "label": "Set status to Blocked",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/ef1d12dc-6a65-4f1d-b7f5-d5c5367d9633.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[8c63578b-6aef-4b49-9727-07c4407bdada]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/f32de9a1-f62b-4406-8610-31af5003ba29.expected.json
+++ b/packages/cli/specs/fixtures/groundings/f32de9a1-f62b-4406-8610-31af5003ba29.expected.json
@@ -1,0 +1,15 @@
+{
+  "uid": "f32de9a1-f62b-4406-8610-31af5003ba29",
+  "label": "Set status to Cancelled",
+  "type": "property_set",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/f32de9a1-f62b-4406-8610-31af5003ba29.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success",
+    "frontmatterAfter": {
+      "ems__Effort_status": "[[cf6269e4-6c5e-418e-b9f2-115aea5fcfb6]]"
+    }
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/f8893042-77ed-4241-959e-e360a4858759.expected.json
+++ b/packages/cli/specs/fixtures/groundings/f8893042-77ed-4241-959e-e360a4858759.expected.json
@@ -1,0 +1,12 @@
+{
+  "uid": "f8893042-77ed-4241-959e-e360a4858759",
+  "label": "Plan for evening via service",
+  "type": "service_call",
+  "cliStatus": "real",
+  "serviceId": "planForEvening",
+  "sourcePath": "exocmd/planning/f8893042-77ed-4241-959e-e360a4858759.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  }
+}

--- a/packages/cli/specs/fixtures/groundings/f9e23c9e-174b-456c-a2f0-c11f811a7ee6.expected.json
+++ b/packages/cli/specs/fixtures/groundings/f9e23c9e-174b-456c-a2f0-c11f811a7ee6.expected.json
@@ -1,0 +1,17 @@
+{
+  "uid": "f9e23c9e-174b-456c-a2f0-c11f811a7ee6",
+  "label": "Transition to Done (status + end + resolution)",
+  "type": "composite",
+  "cliStatus": "real",
+  "serviceId": null,
+  "sourcePath": "exocmd/status/f9e23c9e-174b-456c-a2f0-c11f811a7ee6.md",
+  "userInput": null,
+  "expect": {
+    "outcome": "success"
+  },
+  "compositeStepUids": [
+    "bdf3c81f-3531-48a8-a680-eaf5543ea042",
+    "584f7e07-d485-4d85-9be6-23b2bf3f19af",
+    "73ec8312-4675-41d9-9fa1-33455d983880"
+  ]
+}

--- a/packages/cli/specs/fixtures/test-target.template.md
+++ b/packages/cli/specs/fixtures/test-target.template.md
@@ -1,0 +1,26 @@
+---
+exo__Asset_uid: 11111111-2222-3333-4444-555555555555
+exo__Asset_label: "BDD Test Target"
+exo__Asset_isDefinedBy: "[[05a5f768-298f-4561-aad5-31c8c326eece]]"
+exo__Asset_createdAt: "2026-05-02T18:00:00+0500"
+exo__Instance_class:
+  - "[[ems__Effort]]"
+ems__Effort_status: "[[ems__EffortStatusBacklog]]"
+ems__Effort_startTimestamp: "2026-04-15T10:00:00"
+ems__Effort_endTimestamp: "2026-04-15T11:00:00"
+ems__Effort_resolutionTimestamp: "2026-04-15T11:00:00"
+ems__Effort_plannedStartTimestamp: "2026-04-20T09:00:00"
+ems__Effort_plannedEndTimestamp: "2026-04-20T10:00:00"
+ems__Effort_scheduledOn: "2026-04-20"
+ems__Effort_zone: "[[someday]]"
+ems__Effort_votes: 1
+ems__Effort_result: "old-result"
+aliases:
+  - "BDD Test Target"
+---
+
+# BDD Test Target
+
+Synthetic asset created by the Phase 6 BDD harness (T6.2). Covers the union of
+frontmatter properties touched by starter-kit groundings so a single template
+satisfies every scenario without per-grounding bespoke fixtures.

--- a/packages/cli/specs/step_definitions/grounding.steps.ts
+++ b/packages/cli/specs/step_definitions/grounding.steps.ts
@@ -1,0 +1,335 @@
+import {
+  Given,
+  When,
+  Then,
+  Before,
+  BeforeAll,
+  AfterAll,
+  setDefaultTimeout,
+} from "@cucumber/cucumber";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, cpSync, existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+  GroundingType,
+  type GroundingDefinition,
+  ArchiveAssetService,
+  FixMissingLabelService,
+  FolderRepairService,
+  GenericAssetCreationService,
+  PropertyCleanupService,
+  RenameToUidService,
+  TaskStatusService,
+  EffortStatusWorkflow,
+  StatusTimestampService,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../src/adapters/FileSystemVaultAdapter.js";
+import { NodeFsAdapter } from "../../src/adapters/NodeFsAdapter.js";
+import { populateCliServiceRegistry } from "../../src/services/CliServiceRegistryPopulator.js";
+import { CliBddWorld } from "../support/world.js";
+
+setDefaultTimeout(60_000);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const specsRoot = resolve(__dirname, "..");
+const repoRoot = resolve(specsRoot, "..", "..", "..");
+const fixtureDir = join(specsRoot, "fixtures", "groundings");
+const testTargetTemplate = join(specsRoot, "fixtures", "test-target.template.md");
+const TEST_TARGET_REL = "01 Inbox/bdd-test-target.md";
+
+// Shared fixture vault — populated once by BeforeAll, reused across all 48
+// scenarios. Per-scenario `Before` hook restores the test target file from
+// the template so each grounding executes against a known shape.
+let SHARED_VAULT_PATH: string | null = null;
+let UID_INDEX: Map<string, string> = new Map();
+
+function findStarterKit(): string {
+  const candidates = [
+    resolve(repoRoot, "..", "exocortex-starter-kit"),
+    resolve(repoRoot, "..", "..", "exocortex-starter-kit"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(join(c, "exocmd"))) return c;
+  }
+  throw new Error(
+    `Cannot locate exocortex-starter-kit in any of: ${candidates.join(", ")}`,
+  );
+}
+
+function buildUidIndex(rootDir: string): Map<string, string> {
+  const idx = new Map<string, string>();
+  function walk(dir: string) {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === "node_modules" || e.name.startsWith(".")) continue;
+        walk(p);
+      } else if (e.isFile() && e.name.endsWith(".md")) {
+        try {
+          const txt = readFileSync(p, "utf8");
+          const m = txt.match(/^exo__Asset_uid:\s*([0-9a-f-]+)/m);
+          if (m) idx.set(m[1], p);
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+  walk(rootDir);
+  return idx;
+}
+
+function parseFrontmatter(text: string): Record<string, unknown> {
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return {};
+  try {
+    // JSON_SCHEMA keeps ISO timestamps as strings instead of coercing them to
+    // Date objects — the grounding executor writes `$nowLocal` substitutions
+    // verbatim and assertions need to compare against the string form.
+    const parsed = yaml.load(m[1], { schema: yaml.JSON_SCHEMA });
+    return (typeof parsed === "object" && parsed !== null)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeWikilink(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const stripped = value.replace(/["'[\]]/g, "").trim();
+  const pipe = stripped.indexOf("|");
+  return pipe >= 0 ? stripped.slice(0, pipe).trim() : stripped;
+}
+
+function readGroundingDef(uid: string, depth = 0): GroundingDefinition {
+  if (depth > 20) {
+    throw new Error(`Composite recursion depth exceeded resolving ${uid}`);
+  }
+  const path = UID_INDEX.get(uid);
+  if (!path) throw new Error(`Grounding ${uid} not found in fixture vault`);
+  const fm = parseFrontmatter(readFileSync(path, "utf8"));
+  const type = fm["exocmd__Grounding_type"] as GroundingType;
+  const targetProperty =
+    type === "service_call"
+      ? (fm["exocmd__Grounding_serviceId"] as string | undefined) ??
+        (fm["exocmd__Grounding_targetProperty"] as string | undefined)
+      : (fm["exocmd__Grounding_targetProperty"] as string | undefined);
+  let steps: GroundingDefinition[] | undefined;
+  if (type === "composite") {
+    const rawSteps = fm["exocmd__Grounding_steps"];
+    if (Array.isArray(rawSteps)) {
+      steps = rawSteps.map((ref) => readGroundingDef(normalizeWikilink(ref), depth + 1));
+    }
+  }
+  return {
+    id: uid,
+    label: (fm["exo__Asset_label"] as string) ?? "",
+    type,
+    targetProperty,
+    targetValue: fm["exocmd__Grounding_targetValue"] as string | undefined,
+    targetClass: fm["exocmd__Grounding_targetClass"] as string | undefined,
+    targetPrototype: fm["exocmd__Grounding_targetPrototype"] as string | undefined,
+    targetFolder: fm["exocmd__Grounding_targetFolder"] as string | undefined,
+    steps,
+  };
+}
+
+interface ExpectedFixture {
+  uid: string;
+  type: string;
+  cliStatus: "real" | "stub" | "unregistered";
+  serviceId: string | null;
+  userInput: Record<string, unknown> | null;
+  expect:
+    | { outcome: "success"; frontmatterAfter?: Record<string, unknown>; frontmatterRemoved?: string[] }
+    | { outcome: "failure"; errorPattern: string };
+}
+
+function loadFixture(uid: string): ExpectedFixture {
+  return JSON.parse(readFileSync(join(fixtureDir, `${uid}.expected.json`), "utf8"));
+}
+
+function buildExecutor(vaultPath: string): {
+  executor: GroundingExecutor;
+  serviceRegistry: ServiceRegistry;
+} {
+  const fsAdapter = new NodeFsAdapter(vaultPath);
+  const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
+  const serviceRegistry = new ServiceRegistry();
+  populateCliServiceRegistry(serviceRegistry, {
+    vaultAdapter,
+    fsAdapter,
+    genericAssetCreationService: new GenericAssetCreationService(vaultAdapter),
+    archiveAssetService: new ArchiveAssetService(vaultAdapter),
+    propertyCleanupService: new PropertyCleanupService(vaultAdapter),
+    fixMissingLabelService: new FixMissingLabelService(vaultAdapter),
+    renameToUidService: new RenameToUidService(vaultAdapter),
+    folderRepairService: new FolderRepairService(vaultAdapter),
+    taskStatusService: new TaskStatusService(
+      vaultAdapter,
+      new EffortStatusWorkflow(),
+      new StatusTimestampService(vaultAdapter),
+    ),
+  });
+  const executor = new GroundingExecutor(fsAdapter, fsAdapter, serviceRegistry);
+  return { executor, serviceRegistry };
+}
+
+function resetTestTarget(vaultPath: string): void {
+  const targetAbs = join(vaultPath, TEST_TARGET_REL);
+  mkdirSync(dirname(targetAbs), { recursive: true });
+  const template = readFileSync(testTargetTemplate, "utf8");
+  writeFileSync(targetAbs, template, "utf8");
+}
+
+// --- hooks ---
+
+BeforeAll({ timeout: 120_000 }, async function () {
+  const starterKit = findStarterKit();
+  SHARED_VAULT_PATH = mkdtempSync(join(tmpdir(), "exocortex-bdd-vault-"));
+  cpSync(starterKit, SHARED_VAULT_PATH, {
+    recursive: true,
+    filter: (src) => !src.includes("node_modules") && !src.endsWith(".git"),
+  });
+  UID_INDEX = buildUidIndex(SHARED_VAULT_PATH);
+});
+
+AfterAll(function () {
+  if (SHARED_VAULT_PATH) {
+    try {
+      rmSync(SHARED_VAULT_PATH, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+    SHARED_VAULT_PATH = null;
+  }
+});
+
+Before(function (this: CliBddWorld) {
+  if (!SHARED_VAULT_PATH) throw new Error("Fixture vault not initialized");
+  this.fixtureVaultPath = SHARED_VAULT_PATH;
+  this.testTargetRelPath = TEST_TARGET_REL;
+  resetTestTarget(SHARED_VAULT_PATH);
+  this.groundingResult = null;
+});
+
+// --- steps ---
+
+Given("the starter-kit fixture vault is initialized", function (this: CliBddWorld) {
+  assert.ok(this.fixtureVaultPath, "fixture vault must be initialized by BeforeAll");
+  assert.ok(UID_INDEX.size > 0, "uid index must be populated");
+});
+
+Given("a fresh test target asset in the fixture vault", function (this: CliBddWorld) {
+  assert.ok(this.fixtureVaultPath, "vault path missing");
+  const targetAbs = join(this.fixtureVaultPath!, TEST_TARGET_REL);
+  assert.ok(existsSync(targetAbs), "test target file must exist after reset");
+});
+
+When(
+  "I exec grounding {string} via the CLI grounding executor",
+  async function (this: CliBddWorld, uid: string) {
+    const vault = this.fixtureVaultPath!;
+    const fixture = loadFixture(uid);
+    const grounding = readGroundingDef(uid);
+    // Some service factories (createRelatedTask, archiveAsset, …) call
+    // `vault.getAbstractFileByPath(<targetIRI>.md)` directly, expecting the
+    // IRI to be a bare vault-relative path (the convention used by the
+    // plugin's CommandManager). The path-resolver-based services (update/
+    // remove/setStatus) handle both shapes via createCliPathResolver. So we
+    // pass the bare path (sans .md) here — works for both code paths.
+    const targetIRI = TEST_TARGET_REL.replace(/\.md$/, "");
+    const targetAbs = join(vault, TEST_TARGET_REL);
+
+    const before = parseFrontmatter(readFileSync(targetAbs, "utf8"));
+    const { executor } = buildExecutor(vault);
+    const result = await executor.execute(
+      grounding,
+      targetIRI,
+      TEST_TARGET_REL,
+      fixture.userInput ?? undefined,
+    );
+
+    let after: Record<string, unknown> = {};
+    if (existsSync(targetAbs)) {
+      after = parseFrontmatter(readFileSync(targetAbs, "utf8"));
+    }
+    this.groundingResult = {
+      success: result.success,
+      error: result.error,
+      frontmatterBefore: before,
+      frontmatterAfter: after,
+    };
+  },
+);
+
+Then(
+  "the result should match the expected fixture for {string}",
+  function (this: CliBddWorld, uid: string) {
+    const fixture = loadFixture(uid);
+    const result = this.groundingResult;
+    assert.ok(result, "grounding result must be captured");
+    if (fixture.expect.outcome === "success") {
+      assert.equal(
+        result!.success,
+        true,
+        `Expected success for ${uid} (${fixture.cliStatus} ${fixture.type}), got error: ${result!.error}`,
+      );
+      // Optional state-delta assertions for property_set/property_delete.
+      if ("frontmatterAfter" in fixture.expect && fixture.expect.frontmatterAfter) {
+        for (const [key, expectedRaw] of Object.entries(fixture.expect.frontmatterAfter)) {
+          const actual = result!.frontmatterAfter?.[key];
+          if (
+            typeof expectedRaw === "object" &&
+            expectedRaw !== null &&
+            "__regex" in (expectedRaw as Record<string, unknown>)
+          ) {
+            const pattern = new RegExp((expectedRaw as { __regex: string }).__regex);
+            assert.ok(
+              typeof actual === "string" && pattern.test(actual),
+              `Property ${key} expected to match ${pattern}, got ${JSON.stringify(actual)}`,
+            );
+          } else {
+            assert.equal(
+              actual,
+              expectedRaw,
+              `Property ${key} mismatch on ${uid}`,
+            );
+          }
+        }
+      }
+      if ("frontmatterRemoved" in fixture.expect && fixture.expect.frontmatterRemoved) {
+        for (const key of fixture.expect.frontmatterRemoved) {
+          assert.equal(
+            result!.frontmatterAfter?.[key],
+            undefined,
+            `Property ${key} should be removed on ${uid}`,
+          );
+        }
+      }
+    } else {
+      assert.equal(
+        result!.success,
+        false,
+        `Expected failure for ${uid} (${fixture.cliStatus}), but grounding succeeded`,
+      );
+      const pattern = new RegExp(fixture.expect.errorPattern);
+      assert.ok(
+        result!.error && pattern.test(result!.error),
+        `Error for ${uid} expected to match /${fixture.expect.errorPattern}/, got: ${result!.error}`,
+      );
+    }
+  },
+);

--- a/packages/cli/specs/support/world.ts
+++ b/packages/cli/specs/support/world.ts
@@ -1,11 +1,7 @@
 import { setWorldConstructor, World, IWorldOptions } from "@cucumber/cucumber";
 
 /**
- * Result of a CLI-style helper invocation.
- *
- * T6.2 will replace `helperResult` with a real `dyncommand exec` runner that
- * captures exit code, stdout, stderr and frontmatter mutations against a test
- * vault. This minimal shape is the contract the step layer relies on.
+ * Result of a CLI-style helper invocation (smoke harness only).
  */
 export interface CliHelperResult {
   exitCode: number;
@@ -13,10 +9,28 @@ export interface CliHelperResult {
   stderr: string;
 }
 
+/**
+ * Result of a `dyncommand exec`-style grounding invocation captured by the
+ * T6.2 step layer. Mirrors `GroundingExecutor.execute` (RFC-009 §5.4) and is
+ * augmented with frontmatter snapshots so `Then` clauses can assert the
+ * observable state delta against per-grounding `expected.json` fixtures.
+ */
+export interface GroundingRunResult {
+  success: boolean;
+  error?: string;
+  frontmatterBefore?: Record<string, unknown>;
+  frontmatterAfter?: Record<string, unknown>;
+}
+
 export class CliBddWorld extends World {
   initialized = false;
   recordedValue: string | null = null;
   helperResult: CliHelperResult | null = null;
+
+  // T6.2 — grounding scenario state
+  fixtureVaultPath: string | null = null;
+  testTargetRelPath: string | null = null;
+  groundingResult: GroundingRunResult | null = null;
 
   constructor(options: IWorldOptions) {
     super(options);

--- a/scripts/generate-bdd-fixtures.mjs
+++ b/scripts/generate-bdd-fixtures.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+// RFC 94e520da Phase 6 / T6.2 — generate per-grounding `expected.json` fixtures
+// + a single `groundings.feature` Scenario Outline with 48 examples.
+//
+// Inputs:
+//   - docs/rfc-94e520da/starter-kit-grounding-status.json   (T1.5 audit output)
+//   - exocortex-starter-kit/exocmd/**/*.md                  (per-grounding details)
+//
+// Outputs:
+//   - packages/cli/specs/fixtures/groundings/<uid>.expected.json   (48 files)
+//   - packages/cli/specs/features/groundings.feature               (1 outline, 48 rows)
+
+import { readFile, writeFile, mkdir, readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const yaml = require("js-yaml");
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const auditPath = resolve(
+  repoRoot,
+  "docs/rfc-94e520da/starter-kit-grounding-status.json",
+);
+// Default points to the sibling starter-kit checkout used both in main repo
+// and worktrees (parent of `worktrees/`). Override with --starter-kit <path>.
+const argv = process.argv.slice(2);
+let starterKitOverride = null;
+for (let i = 0; i < argv.length; i++) {
+  if (argv[i] === "--starter-kit") starterKitOverride = argv[++i];
+}
+const starterKitRoot =
+  starterKitOverride ??
+  resolve(repoRoot, "..", "exocortex-starter-kit");
+const fallbackStarterKit = resolve(
+  repoRoot,
+  "..",
+  "..",
+  "exocortex-starter-kit",
+);
+const fixtureDir = resolve(
+  repoRoot,
+  "packages/cli/specs/fixtures/groundings",
+);
+const featurePath = resolve(
+  repoRoot,
+  "packages/cli/specs/features/groundings.feature",
+);
+
+// --- frontmatter parser (minimal — handles starter-kit shape only) ---
+
+function parseFrontmatter(text) {
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return {};
+  try {
+    const parsed = yaml.load(m[1]);
+    return typeof parsed === "object" && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function stripOuterQuotes(s) {
+  if (typeof s !== "string" || s.length < 2) return s;
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+function normalizeWikilink(value) {
+  if (typeof value !== "string") return "";
+  const stripped = value.replace(/["'[\]]/g, "").trim();
+  const pipe = stripped.indexOf("|");
+  return pipe >= 0 ? stripped.slice(0, pipe).trim() : stripped;
+}
+
+// --- locate grounding file in starter-kit by uid ---
+
+async function buildUidIndex(rootDir) {
+  const idx = new Map();
+  async function walk(dir) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === "node_modules" || e.name.startsWith(".")) continue;
+        await walk(p);
+      } else if (e.isFile() && e.name.endsWith(".md")) {
+        const txt = await readFile(p, "utf8");
+        const m = txt.match(/^exo__Asset_uid:\s*([0-9a-f-]+)/m);
+        if (m) idx.set(m[1], p);
+      }
+    }
+  }
+  await walk(join(rootDir, "exocmd"));
+  return idx;
+}
+
+// --- userInput defaults per service / per substitution token ---
+
+function inferUserInput(grounding, fm) {
+  const input = {};
+  // $input / $value substitution in targetValue
+  const targetValue = fm.exocmd__Grounding_targetValue ?? "";
+  if (/\$(input|value)\b/.test(targetValue)) {
+    input.value = "bdd-input-value";
+  }
+  // service_call services that consume `value` from inputSchema:
+  // updateProperty (link-to-parent), createRelatedTask, createRelatedProject etc.
+  const serviceId = fm.exocmd__Grounding_serviceId;
+  if (
+    serviceId === "updateProperty" &&
+    /"value"\s*:/.test(fm.exocmd__Grounding_inputSchema ?? "")
+  ) {
+    input.value = input.value ?? "[[bdd-parent-asset]]";
+  }
+  if (
+    serviceId === "createRelatedTask" ||
+    serviceId === "createRelatedProject" ||
+    grounding.type === "create_instance"
+  ) {
+    input.label = "BDD Test";
+  }
+  return Object.keys(input).length > 0 ? input : null;
+}
+
+// --- expected outcome per cliStatus + grounding type ---
+
+function buildExpect(grounding, fm) {
+  const { type, cliStatus, serviceId } = grounding;
+  // service_call stub → fail-loud CliServiceNotImplementedError
+  if (cliStatus === "stub") {
+    return {
+      outcome: "failure",
+      errorPattern: `Service \\"${serviceId}\\" is not implemented`,
+    };
+  }
+  // service_call unregistered → "Service not found: <id>"
+  if (cliStatus === "unregistered") {
+    return {
+      outcome: "failure",
+      errorPattern: `Service not found: \\"${serviceId}\\"`,
+    };
+  }
+  // Real groundings — verify success and (where cheaply possible) the
+  // observable frontmatter delta on the test target.
+  const expect = { outcome: "success" };
+  if (type === "property_set") {
+    // FrontmatterService.updateProperty writes targetValue verbatim into the
+    // YAML, so a value like '"[[uuid]]"' (literal quotes from grounding source)
+    // round-trips through js-yaml as bare `[[uuid]]`. Strip one quote layer
+    // so the fixture matches what the test reads back via yaml.load.
+    let raw = fm.exocmd__Grounding_targetValue;
+    if (typeof raw === "string") {
+      raw = stripOuterQuotes(raw);
+    }
+    expect.frontmatterAfter = {
+      [fm.exocmd__Grounding_targetProperty]: substituteTokens(raw),
+    };
+  } else if (type === "property_delete") {
+    expect.frontmatterRemoved = [fm.exocmd__Grounding_targetProperty];
+  }
+  return expect;
+}
+
+// Best-effort token substitution recorder — used only for fixture authoring,
+// step layer performs the *actual* substitution at runtime against $now.
+function substituteTokens(value) {
+  if (typeof value !== "string") return value;
+  // We assert via regex match in the step layer for $-token values.
+  if (/\$(now|nowLocal|today|target|input|value)\b/.test(value)) {
+    return { __regex: tokenRegex(value) };
+  }
+  return value;
+}
+
+function tokenRegex(raw) {
+  // Convert literal -> regex, replacing tokens with permissive patterns.
+  // `\b` (word boundary) is the regex anchor, not the two-char string `\b`.
+  let escaped = raw.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+  escaped = escaped
+    .replace(/\\\$nowLocal\b/g, "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}")
+    .replace(/\\\$now\b/g, "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*")
+    .replace(/\\\$today\b/g, "\\d{4}-\\d{2}-\\d{2}")
+    .replace(/\\\$target\b/g, ".+")
+    .replace(/\\\$input\b/g, ".+")
+    .replace(/\\\$value\b/g, ".+");
+  return `^${escaped}$`;
+}
+
+// --- main ---
+
+async function main() {
+  const audit = JSON.parse(await readFile(auditPath, "utf8"));
+  const groundings = audit.groundings;
+  if (groundings.length !== 48) {
+    console.warn(
+      `[gen-bdd] expected 48 groundings in audit, got ${groundings.length}`,
+    );
+  }
+
+  let resolvedStarterKit = starterKitRoot;
+  try {
+    await readdir(join(resolvedStarterKit, "exocmd"));
+  } catch {
+    resolvedStarterKit = fallbackStarterKit;
+  }
+  const uidIndex = await buildUidIndex(resolvedStarterKit);
+  await mkdir(fixtureDir, { recursive: true });
+
+  const examplesRows = [];
+  for (const g of groundings) {
+    const path = uidIndex.get(g.uid);
+    if (!path) {
+      throw new Error(
+        `[gen-bdd] grounding ${g.uid} listed in audit but not found in starter-kit`,
+      );
+    }
+    const text = await readFile(path, "utf8");
+    const fm = parseFrontmatter(text);
+    const fixture = {
+      uid: g.uid,
+      label: g.label,
+      type: g.type,
+      cliStatus: g.cliStatus,
+      serviceId: g.serviceId,
+      sourcePath: g.path,
+      userInput: inferUserInput(g, fm),
+      expect: buildExpect(g, fm),
+    };
+    if (g.type === "create_instance") {
+      fixture.targetClass = fm.exocmd__Grounding_targetClass;
+      fixture.targetFolder = fm.exocmd__Grounding_targetFolder;
+    }
+    if (g.type === "composite") {
+      // resolve sub-step uids via Grounding_steps wikilinks
+      const steps = fm.exocmd__Grounding_steps;
+      fixture.compositeStepUids = Array.isArray(steps)
+        ? steps.map(normalizeWikilink)
+        : [];
+    }
+    await writeFile(
+      join(fixtureDir, `${g.uid}.expected.json`),
+      JSON.stringify(fixture, null, 2) + "\n",
+      "utf8",
+    );
+    const safeLabel = (g.label ?? "").replace(/\|/g, "\\|");
+    examplesRows.push(
+      `      | ${g.uid} | ${g.type.padEnd(15)} | ${(g.cliStatus + "").padEnd(12)} | ${safeLabel} |`,
+    );
+  }
+
+  const featureBody = `Feature: Starter-kit grounding execution (RFC 94e520da § Phase 6)
+  As an Exocortex CLI user
+  I want every starter-kit grounding to behave deterministically when invoked via dyncommand exec
+  So that any regression breaking a grounding is caught by the test-bdd CI gate
+
+  All 48 starter-kit groundings (T1.5 audit) are exercised. Per-grounding
+  expected outcomes live in packages/cli/specs/fixtures/groundings/<uid>.expected.json.
+
+  Background:
+    Given the starter-kit fixture vault is initialized
+
+  Scenario Outline: Grounding "<label>" (<uid>)
+    Given a fresh test target asset in the fixture vault
+    When I exec grounding "<uid>" via the CLI grounding executor
+    Then the result should match the expected fixture for "<uid>"
+
+    Examples:
+      | uid | type | cliStatus | label |
+${examplesRows.join("\n")}
+`;
+
+  await mkdir(dirname(featurePath), { recursive: true });
+  await writeFile(featurePath, featureBody, "utf8");
+
+  console.log(
+    `[gen-bdd] wrote ${groundings.length} fixtures + ${featurePath}`,
+  );
+}
+
+await main();


### PR DESCRIPTION
## Summary

- Adds the L3 BDD suite covering all 48 starter-kit groundings inventoried in T1.5 audit (RFC 94e520da § Phase 6).
- Per-grounding `expected.json` fixtures encode the deterministic outcome — real groundings assert success (with frontmatter delta for property_set/property_delete), stubs/unregistered fail loudly with named-error patterns. Result: zero fake-succeed by construction.
- Generator script (`scripts/generate-bdd-fixtures.mjs`) regenerates fixtures + feature from the audit JSON whenever starter-kit groundings change.

Builds on T6.1 (#3039 — Cucumber.js harness).

## Test plan

- [x] `npm run bdd:test:cli` → 50/50 (48 grounding scenarios + 2 T6.1 smoke scenarios).
- [x] `npm run check:types` clean.
- [ ] CI: `test-bdd` workflow runs the new feature without regressing other shards.

Closes T6.2 (vault task `cd7e589b-ba42-4323-b6bd-270ded0d41f1`). T6.3 will wire the suite into the required `test-bdd` CI gate.