### PR TITLE
ci: wire 48 BDD scenarios into test-bdd workflow (T6.3 RFC 94e520da Phase 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,6 +625,21 @@ jobs:
         run: npm run bdd:check
         continue-on-error: false
 
+      # RFC `94e520da` Phase 6 (T6.3) — runs the L3 CLI BDD suite covering
+      # all 48 starter-kit groundings (М6: 48/48 green as release v16 gate).
+      # Suite source: packages/cli/specs/features/groundings.feature +
+      # per-grounding fixtures under specs/fixtures/groundings/. Mirrors the
+      # T3.3 parity-gate pattern by executing under the same `test-bdd`
+      # required check so a single named gate enforces both BDD coverage
+      # and grounding state-change correctness; failure surfaces by failing
+      # this step (no continue-on-error). Requires exocortex + services
+      # workspace dist (CLI imports them at runtime via tsx loader).
+      - name: Build workspace deps for CLI BDD suite
+        run: npm run build -w exocortex && npm run build -w @kitelev/exocortex-services
+
+      - name: Run CLI BDD suite (48 starter-kit groundings)
+        run: npm run bdd:test:cli
+
       - name: Generate BDD Coverage Report
         if: always()
         run: npm run bdd:report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,7 +633,18 @@ jobs:
       # required check so a single named gate enforces both BDD coverage
       # and grounding state-change correctness; failure surfaces by failing
       # this step (no continue-on-error). Requires exocortex + services
-      # workspace dist (CLI imports them at runtime via tsx loader).
+      # workspace dist (CLI imports them at runtime via tsx loader) and a
+      # sibling checkout of exocortex-starter-kit (resolved by
+      # specs/step_definitions/grounding.steps.ts via `../exocortex-starter-kit`).
+      - name: Checkout exocortex-starter-kit (sibling repo for BDD fixtures)
+        run: |
+          # findStarterKit() in grounding.steps.ts probes ../exocortex-starter-kit
+          # and ../../exocortex-starter-kit relative to repoRoot. GITHUB_WORKSPACE
+          # is /home/runner/work/exocortex/exocortex, so cloning to its parent
+          # places the kit at the first probe path.
+          git clone --depth 1 https://github.com/kitelev/exocortex-starter-kit.git \
+            "${GITHUB_WORKSPACE}/../exocortex-starter-kit"
+
       - name: Build workspace deps for CLI BDD suite
         run: npm run build -w exocortex && npm run build -w @kitelev/exocortex-services
 


### PR DESCRIPTION
## Summary

- Closes Phase 6 of RFC `94e520da-c6f7-48af-944c-51298d68da45` (production-ready CLI command execution).
- Wires the CLI BDD suite from T6.2 (50 scenarios — 48 grounding + 2 T6.1 smoke) into the existing required `test-bdd` job as a fail-fast step.
- Satisfies М6: 48/48 starter-kit groundings green in CI as the release-v16 gate.

## Decision log

- **Extended existing `test-bdd` job rather than creating a new `test-bdd-cli` job.** `test-bdd` is already in the 13-check required list (verified via `gh api .../branches/main/protection/required_status_checks`), so this satisfies the «add as required CI check» requirement without a branch-protection update — the failure surface (red `test-bdd`) blocks merge identically to a dedicated job. Mirrors T3.3 parity-gate's *reasoning* (named, dedicated assertion that fails the required check on regression) without duplicating its *job structure*.
- **Build step bootstraps `exocortex` + `@kitelev/exocortex-services` workspace dist** before the BDD run because the CLI's tsx loader resolves `@kitelev/exocortex-services/dist/index.js` at runtime. ~5–10s on cache-cold; cache-hit path on workspace `node_modules` shaves most of it.
- **No `continue-on-error`** on the new step — opposite of `bdd:test` (plugin) above which keeps that lenience until plugin BDD coverage stabilises. CLI suite is 50/50 today and the gate is meaningful only if hard-failing.

Builds on T6.1 (#3039 — Cucumber.js harness) and T6.2 (#3042 — 48 scenarios + fixtures).

Task UID: `8e54affe-2960-4cb8-87dc-5eb2bec51d18`
Phase: 6 — L3 BDD test suite (`5355bfb9-ec27-4a24-af50-4991fe7ba355`) — last task; closes M6.
Project: `d4afbc7e-1eaf-4286-9bc8-6e9aa78c3c9d`

## Test plan

- [x] `npm run bdd:test:cli` locally → 50 scenarios (50 passed) / 199 steps (199 passed) in 0.24s.
- [x] Pre-commit: archgate + bdd:check (universal-layout-rendering 8/8) green.
- [ ] CI: `test-bdd` runs the new step without regression on other shards.