### PR TITLE
feat(cli): add deprecation warning to `command start` runtime (T7.2)

### DIFF
--- a/packages/cli/src/commands/command.ts
+++ b/packages/cli/src/commands/command.ts
@@ -84,6 +84,14 @@ export function commandCommand(): Command {
       const format = (options.format || "text") as OutputFormat;
       ErrorHandler.setFormat(format);
 
+      if (commandName === "start") {
+        console.error(
+          '⚠️  DEPRECATED: `command start <path>` is deprecated. ' +
+            'Use `dyncommand exec <uid>` instead. ' +
+            '`command start <path>` will be removed in 2 minor releases (T7.3).',
+        );
+      }
+
       try {
         const vaultPath = resolve(options.vault);
         const executor = new CommandExecutor(vaultPath, options.dryRun);

--- a/packages/cli/tests/unit/commands/command.test.ts
+++ b/packages/cli/tests/unit/commands/command.test.ts
@@ -98,6 +98,31 @@ describe("commandCommand", () => {
       expect(mockExecutor.executeStart).toHaveBeenCalledWith("task.md");
     });
 
+    it("should print deprecation warning when start is invoked (T7.2)", async () => {
+      const cmd = commandCommand();
+      await cmd.parseAsync(["node", "test", "start", "task.md", "--vault", "/test/vault"]);
+
+      const deprecationCalls = consoleErrorSpy.mock.calls.filter(
+        (call) => typeof call[0] === "string" && (call[0] as string).includes("DEPRECATED"),
+      );
+      expect(deprecationCalls.length).toBeGreaterThan(0);
+      const warning = deprecationCalls[0][0] as string;
+      expect(warning).toContain("dyncommand exec");
+      expect(warning).toContain("command start");
+      // Backward-compat: executor still invoked
+      expect(mockExecutor.executeStart).toHaveBeenCalledWith("task.md");
+    });
+
+    it("should NOT print deprecation warning for non-start commands (T7.2)", async () => {
+      const cmd = commandCommand();
+      await cmd.parseAsync(["node", "test", "complete", "task.md", "--vault", "/test/vault"]);
+
+      const deprecationCalls = consoleErrorSpy.mock.calls.filter(
+        (call) => typeof call[0] === "string" && (call[0] as string).includes("DEPRECATED"),
+      );
+      expect(deprecationCalls).toHaveLength(0);
+    });
+
     it("should execute complete", async () => {
       const cmd = commandCommand();
       await cmd.parseAsync(["node", "test", "complete", "task.md", "--vault", "/test/vault"]);


### PR DESCRIPTION
## Summary
- Phase 7 of RFC `94e520da-c6f7-48af-944c-51298d68da45`. Emits a stderr deprecation warning when users invoke the legacy `exocortex command start <path>`, pointing them to `dyncommand exec <uid>`.
- Backward-compat preserved: legacy invocation still runs `executeStart`. Removal of the legacy code path is scoped to T7.3 (≥2 minor releases out).

## Changes
- `packages/cli/src/commands/command.ts`: print warning to stderr when `commandName === "start"`, before the action runs.
- `packages/cli/tests/unit/commands/command.test.ts`: 2 tests — warning fires for `start`, does NOT fire for `complete`.

## Task
- ems__Task `697402a4-7b98-4c2b-bfb5-bc7b36a0a348`
- Predecessor: T7.1 (#3045)

## Test plan
- [x] `npm test -- --testPathPatterns='commands/command.test.ts'` — 31/31 green
- [ ] CI green