### PR TITLE
chore(cli): schedule sunset of legacy `command start <path>` (T7.3)

### DIFF
--- a/packages/cli/docs/SUNSET_LEGACY_COMMAND_START.md
+++ b/packages/cli/docs/SUNSET_LEGACY_COMMAND_START.md
@@ -1,0 +1,75 @@
+# Sunset checklist — legacy `command start <path>`
+
+> **Source RFC:** `94e520da-c6f7-48af-944c-51298d68da45` § Phase 7
+> **Phase 7 task ledger:** T7.1 (#3045 — Telegram bot routing doc) → T7.2 (#3046 — runtime deprecation warning) → **T7.3 (this doc — sunset planning)**.
+> **Canonical replacement:** `exocortex dyncommand exec <uid>`.
+
+The legacy invocation
+
+```bash
+exocortex command start <path-to-asset>
+```
+
+is deprecated. It still runs `executeStart` and emits a stderr deprecation warning (T7.2), but it MUST be removed once the soak window of **≥ 2 minor releases after 15.55.5** has elapsed.
+
+## When to remove
+
+| Gate | Condition                                                                                                                                                                                                |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | CLI version on `main` is **≥ 15.57.0** (≥ 2 minor releases past the 15.55.x line where T7.2's warning shipped).                                                                                          |
+| 2    | Telegram bot Claude subprocess is verified to invoke `dyncommand exec <uid>` (T7.1 routing doc applied; no callers of `command start` remain in `examples/`, `scripts/`, ops cron, or vault automation). |
+| 3    | No internal user has reported reliance on `command start <path>` in the prior minor cycle (no inbound issue / Slack thread / Telegram report referencing the deprecation warning text).                  |
+
+If **any** gate is unmet, defer one more minor release and re-evaluate.
+
+## Removal checklist
+
+Once all three gates are green, open a single PR titled `chore(cli): remove deprecated 'command start <path>' (RFC 94e520da § Phase 7 sunset)`:
+
+- [ ] **Code — `packages/cli/src/commands/command.ts`**
+  - [ ] Delete the `if (commandName === "start") { console.error(... ) }` deprecation block (marked with `SUNSET-T7.3`).
+  - [ ] Delete the `case "start":` branch in the action switch (marked with `SUNSET-T7.3`).
+  - [ ] Verify the `<command-name>` CLI argument's help text no longer lists `start` as a supported value (line currently reads `"Command to execute (rename-to-uid, start, complete, schedule, set-deadline, etc.)"` — drop `start`).
+- [ ] **Tests — `packages/cli/tests/unit/commands/command.test.ts`**
+  - [ ] Delete the two T7.2 deprecation-warning tests (warning fires for `start`, does NOT fire for `complete`).
+  - [ ] Add a regression test: `command start <path>` now hits the `default` branch and surfaces an "unknown command" `InvalidArgumentsError`, exactly the same way any other unknown command would.
+- [ ] **Docs — `packages/cli/README.md`**
+  - [ ] Remove the `# ⚠️ LEGACY (still works until Phase 7.3 sunset...)` block (currently around line 475).
+  - [ ] Remove the `Backward compat: the legacy 'command start' path keeps working through Phase 7.2 (deprecation warning) and Phase 7.3 (sunset)` bullet.
+  - [ ] Confirm the **NEW canonical path** (`dyncommand exec <uid>`) example is the only Telegram-bot integration code path documented.
+- [ ] **Docs — `packages/cli/docs/CLI_API_REFERENCE.md`**
+  - [ ] Search for `command start` and remove or rewrite stale references.
+- [ ] **Docs — this file**
+  - [ ] After the removal PR merges, delete `packages/cli/docs/SUNSET_LEGACY_COMMAND_START.md`. Its only purpose is to schedule the removal; once removal lands it has no consumer.
+- [ ] **Vault / ops surface**
+  - [ ] Confirm `examples/production-cron/` and any other runnable script no longer reference `command start`.
+  - [ ] Re-grep across the monorepo: `grep -rn "command start " packages/ examples/ scripts/ docs/ tests/ specs/ | grep -v -E "(node_modules|coverage|dist|\\.test\\.ts:)"` — expect zero hits.
+- [ ] **Release**
+  - [ ] Removal MUST land as a `feat!:` or explicit BREAKING CHANGE-tagged commit so the auto-release flow bumps a major (or, by Decision A in the RFC, a clearly-labeled minor that is communicated as semver-breaking in the changelog).
+  - [ ] Update `packages/cli/CHANGELOG.md` (or let `release-please`/auto-release) record the removal under a `### Breaking changes` heading, citing this RFC.
+
+## Why a deferred sunset, not an immediate removal
+
+The Phase 7 task literal (`Sunset через ≥ 2 minor releases`) physically requires real soak time across at least two minor releases — not a code-day's worth of edits. T7.3 ships the **commitment** to that sunset (this doc + code FIXME markers near both the deprecation warning and the `case "start"` branch) so the next person who touches `command.ts` cannot miss the cleanup. Actual code deletion is intentionally not part of T7.3's PR; doing so would short-circuit the soak window and re-introduce risk T7.2 was designed to detect.
+
+This pattern (ship the contract now, ship the deletion later under a separate, smaller, mechanically-driven PR) is the one the RFC § Phase 7 explicitly endorses.
+
+## Verification before opening the removal PR
+
+```bash
+# 1. Confirm canonical path still works:
+exocortex dyncommand exec 1abe7877-a462-4bd5-9bd8-1f75fe7f50aa \
+  --target "03 Knowledge/daily/$(date +%Y-%m-%d).md" \
+  --dry-run --vault ~/vault --output json
+
+# 2. Confirm legacy path emits deprecation warning *and* still runs:
+exocortex command start "tasks/<some-task-uid>.md" --vault ~/vault 2>&1 \
+  | grep -E "DEPRECATED.*command start"
+
+# 3. Grep for remaining callers:
+grep -rn "command start " packages/ examples/ scripts/ docs/ tests/ specs/ \
+  | grep -v -E "(node_modules|coverage|dist|\\.test\\.ts:|SUNSET_LEGACY_COMMAND_START\\.md)"
+# Expect: only T7.2 test-file matches and this checklist's own examples.
+```
+
+If step 3 returns any non-test, non-doc match — that caller must be migrated to `dyncommand exec <uid>` _before_ removal.

--- a/packages/cli/src/commands/command.ts
+++ b/packages/cli/src/commands/command.ts
@@ -84,6 +84,11 @@ export function commandCommand(): Command {
       const format = (options.format || "text") as OutputFormat;
       ErrorHandler.setFormat(format);
 
+      // SUNSET-T7.3: legacy `command start <path>` is deprecated as of v15.55.x
+      // (RFC 94e520da § Phase 7). Remove this `if` block AND the `case "start"`
+      // branch below in v15.57.0 or later (≥2 minor releases after 15.55.5).
+      // See packages/cli/docs/SUNSET_LEGACY_COMMAND_START.md for the full removal
+      // checklist; canonical replacement is `dyncommand exec <uid>`.
       if (commandName === "start") {
         console.error(
           '⚠️  DEPRECATED: `command start <path>` is deprecated. ' +
@@ -119,6 +124,10 @@ export function commandCommand(): Command {
             break;
 
           // Status transition commands
+          // SUNSET-T7.3: remove this `case "start"` branch in v15.57.0+
+          // (RFC 94e520da § Phase 7). After removal, "start" falls through to
+          // the `default` branch and surfaces an "unknown command" error,
+          // pushing callers onto `dyncommand exec <uid>`.
           case "start":
             await executor.executeStart(filepath);
             outputResult(format, commandName, filepath, "Started task");


### PR DESCRIPTION
## Summary

Phase 7 task **T7.3** of RFC `94e520da-c6f7-48af-944c-51298d68da45`. Locks in the deletion timeline for the legacy `exocortex command start <path>` invocation without performing the deletion itself — the literal acceptance criterion (*sunset через ≥ 2 minor releases*) requires real soak time across at least two minor releases past 15.55.x.

## Phase 7 ledger

- T7.1 (#3045) — Telegram bot routing migration doc.
- T7.2 (#3046) — runtime deprecation warning when `command start` is invoked.
- **T7.3 (this PR) — sunset planning: code markers + removal checklist.**

## Changes

- `packages/cli/src/commands/command.ts` — adds two `SUNSET-T7.3` marker comments, one on the deprecation-warning block and one on the `case "start":` switch arm, so the next person who edits this file cannot miss the cleanup.
- `packages/cli/docs/SUNSET_LEGACY_COMMAND_START.md` *(new)* — full removal checklist: gating conditions (CLI ≥ 15.57.0, no remaining callers, no inbound user reports), step-by-step file edits, test/doc cleanup, semver/changelog handling, pre-removal verification commands.

No behaviour change; legacy `command start <path>` still runs `executeStart` and still emits the T7.2 deprecation warning. Equivalent canonical path remains `dyncommand exec <uid>`.

## Why deferred (not immediate) removal

> See `packages/cli/docs/SUNSET_LEGACY_COMMAND_START.md` § *Why a deferred sunset, not an immediate removal*.

Shipping the deletion in this PR would short-circuit the soak window and re-introduce the regression risk T7.2 was designed to detect. The RFC § Phase 7 explicitly endorses *ship the contract now, ship the deletion later under a separate, smaller, mechanically-driven PR*.

## Task

- ems__Task `93920d0f-017f-4530-9ab4-4374b29386a4`
- Predecessors: T7.1 (#3045), T7.2 (#3046)
- Closes Phase 7 (`e1800239-b881-43d7-846c-d22fef91d2a2`) → unblocks **M7 Final Acceptance Gate**

## Test plan

- [x] `npm test -- --testPathPatterns='unit/commands/command.test.ts'` — 31/31 green (no test changes; only comment additions on prod code).
- [x] BDD coverage 198/198 (pre-commit gate).
- [x] Archgate ADR compliance — pass.
- [ ] CI green (13 required checks).