### PR TITLE
feat(cli): add ClaimService with flock claim transaction for aiTask workers

### DIFF
--- a/packages/cli/src/services/ClaimService.ts
+++ b/packages/cli/src/services/ClaimService.ts
@@ -1,0 +1,139 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import yaml from "js-yaml";
+import {
+  atomicUpdateFrontmatter,
+  AtomicUpdateOptions,
+  AtomicUpdateResult,
+} from "./AtomicFrontmatterService.js";
+
+// Flock-based claim transaction for aiTask delegation.
+// Lock file: ~/.exocortex/locks/claim.lock (or EXO_CLAIM_LOCK_DIR override for tests).
+// Advisory exclusive lock via O_CREAT|O_EXCL atomic file creation (POSIX/APFS safe).
+
+type UpdateFn = (
+  filePath: string,
+  updates: Record<string, unknown>,
+  options?: AtomicUpdateOptions,
+) => AtomicUpdateResult;
+
+const LOCK_RETRIES = 10;
+const LOCK_RETRY_DELAY_MS = 100;
+
+// Module-level lock state — safe in single-threaded Node.js event loop.
+let _lockHeld = false;
+
+function getLockDir(): string {
+  return (
+    process.env.EXO_CLAIM_LOCK_DIR ??
+    path.join(os.homedir(), ".exocortex", "locks")
+  );
+}
+
+function getLockFile(): string {
+  return path.join(getLockDir(), "claim.lock");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function tryAcquireLockFileOnce(): boolean {
+  try {
+    const fd = fs.openSync(
+      getLockFile(),
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL,
+      0o600,
+    );
+    fs.closeSync(fd);
+    _lockHeld = true;
+    return true;
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw e;
+  }
+}
+
+async function acquireLock(): Promise<boolean> {
+  fs.mkdirSync(getLockDir(), { recursive: true });
+  for (let i = 0; i < LOCK_RETRIES; i++) {
+    if (tryAcquireLockFileOnce()) return true;
+    if (i < LOCK_RETRIES - 1) await sleep(LOCK_RETRY_DELAY_MS);
+  }
+  return false;
+}
+
+export function releaseClaimLock(): void {
+  if (_lockHeld) {
+    try {
+      fs.unlinkSync(getLockFile());
+    } catch {
+      // best-effort
+    }
+    _lockHeld = false;
+  }
+}
+
+const FRONTMATTER_RE = /^---\s*\r?\n([\s\S]*?)\r?\n---/;
+
+function readFrontmatter(filePath: string): Record<string, unknown> | null {
+  const content = fs.readFileSync(filePath, "utf8");
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return null;
+  const parsed = yaml.load(match[1]);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Claim an aiTask file for this worker.
+ *
+ * Returns true if the claim succeeded (this worker now owns the task),
+ * false if it was already claimed by another worker or the lock timed out.
+ *
+ * The optional updateFn parameter is for dependency injection in tests.
+ */
+export async function claimTask(
+  taskFilePath: string,
+  workerPid: number,
+  updateFn: UpdateFn = atomicUpdateFrontmatter,
+): Promise<boolean> {
+  const acquired = await acquireLock();
+  if (!acquired) return false;
+
+  try {
+    const fm = readFrontmatter(taskFilePath);
+    if (
+      fm !== null &&
+      fm["aiTask__Task_claimedBy"] !== undefined &&
+      fm["aiTask__Task_claimedBy"] !== null
+    ) {
+      return false;
+    }
+
+    const now = new Date().toISOString();
+    const result = updateFn(
+      taskFilePath,
+      {
+        "aiTask__Task_claimedBy": String(workerPid),
+        "aiTask__Task_claimedAt": now,
+        "ems__Effort_status": "[[ems__EffortStatusDoing]]",
+        "ems__Effort_startTimestamp": now,
+        "exo__Asset_updatedAt": now,
+      },
+      {
+        verifyKey: "aiTask__Task_claimedBy",
+        verifyValue: String(workerPid),
+      },
+    );
+
+    return result.success && result.verified;
+  } finally {
+    releaseClaimLock();
+  }
+}

--- a/packages/cli/tests/unit/services/ClaimService.test.ts
+++ b/packages/cli/tests/unit/services/ClaimService.test.ts
@@ -1,0 +1,86 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  mkdtempSync,
+  writeFileSync,
+  existsSync,
+  rmSync,
+} from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import yaml from "js-yaml";
+
+import {
+  claimTask,
+  releaseClaimLock,
+} from "../../../src/services/ClaimService.js";
+
+function buildMd(fm: Record<string, unknown>, body = ""): string {
+  return `---\n${yaml.dump(fm)}---\n${body}`;
+}
+
+describe("ClaimService", () => {
+  let tmpDir: string;
+  let tmpLockDir: string;
+  let target: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), "claim-svc-"));
+    tmpLockDir = path.join(tmpDir, "locks");
+    process.env.EXO_CLAIM_LOCK_DIR = tmpLockDir;
+    target = path.join(tmpDir, "task.md");
+    writeFileSync(
+      target,
+      buildMd({
+        exo__Asset_uid: "test-uuid",
+        ems__Effort_status: "[[ems__EffortStatusBacklog]]",
+        exo__Asset_updatedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+  });
+
+  afterEach(() => {
+    releaseClaimLock();
+    delete process.env.EXO_CLAIM_LOCK_DIR;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("5 parallel claims → exactly one returns true", async () => {
+    const results = await Promise.all(
+      [1001, 1002, 1003, 1004, 1005].map((pid) => claimTask(target, pid)),
+    );
+    const trueCount = results.filter(Boolean).length;
+    expect(trueCount).toBe(1);
+  });
+
+  it("releases lock when updateFn throws", async () => {
+    const lockFile = path.join(tmpLockDir, "claim.lock");
+
+    await expect(
+      claimTask(target, 999, () => {
+        throw new Error("simulated failure");
+      }),
+    ).rejects.toThrow("simulated failure");
+
+    expect(existsSync(lockFile)).toBe(false);
+  });
+
+  it("returns false for already-claimed task", async () => {
+    const first = await claimTask(target, 111);
+    expect(first).toBe(true);
+
+    const second = await claimTask(target, 222);
+    expect(second).toBe(false);
+  });
+
+  it("creates lock directory if it does not exist", async () => {
+    expect(existsSync(tmpLockDir)).toBe(false);
+    await claimTask(target, 333);
+    expect(existsSync(tmpLockDir)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ClaimService.ts` with `claimTask(taskFilePath, workerPid)` function
- Advisory exclusive lock via `O_CREAT|O_EXCL` on `~/.exocortex/locks/claim.lock` (POSIX/APFS atomic, no external deps)
- 10 retries × 100ms = ~1s total timeout
- `atomicUpdateFrontmatter` (Task 3.1, #3048) writes `claimedBy`, `claimedAt`, `ems__Effort_status`, `startTimestamp`, `updatedAt` with `verifyKey` post-claim validation
- `releaseClaimLock()` export for emergency cleanup (e.g. SIGTERM handler)
- `try/finally` guarantees lock release on both success and exception

## Lock strategy decision

`proper-lockfile` was not in `packages/cli` dependencies. Used `fs.openSync(O_CREAT|O_EXCL)` atomic file approach — simpler, no extra deps, safe on macOS APFS and Linux ext4.

## Test results

4 unit tests passing:
- 5 parallel `claimTask` calls → exactly 1 returns `true`
- `updateFn` throws → lock released (file deleted)
- Already-claimed task → returns `false`
- Lock directory auto-created on first run

## AC checklist

- [x] `claimTask(taskFilePath, pid) → Promise<boolean>` implemented in TypeScript
- [x] Test: 5 parallel claims → exactly one true
- [x] Lock release on exception (try/finally)
- [x] Lock dir created on first run