### PR TITLE
feat(shacl): P1.2 ShapeRegistry+ShapeLoader

### DIFF
--- a/packages/exocortex/src/services/ShapeLoader.ts
+++ b/packages/exocortex/src/services/ShapeLoader.ts
@@ -1,0 +1,357 @@
+import { ShapeRegistry, Shape } from "./ShapeRegistry";
+import type { ITripleStore } from "../interfaces/ITripleStore";
+import { IRI } from "../domain/models/rdf/IRI";
+import { Literal } from "../domain/models/rdf/Literal";
+import { Namespace } from "../domain/models/rdf/Namespace";
+
+// W3C SHACL namespace base
+const SH_NS = "http://www.w3.org/ns/shacl#";
+
+// Maps namespace prefix → Namespace (mirrors NoteToRDFConverter.NAMESPACE_MAP)
+const NAMESPACE_MAP: ReadonlyArray<[string, Namespace]> = [
+  ["exo__", Namespace.EXO],
+  ["ems__", Namespace.EMS],
+  ["exocmd__", Namespace.EXOCMD],
+  ["ims__", Namespace.IMS],
+  ["ztlk__", Namespace.ZTLK],
+  ["ptms__", Namespace.PTMS],
+  ["lit__", Namespace.LIT],
+  ["inbox__", Namespace.INBOX],
+  ["pmbok__", Namespace.PMBOK],
+];
+
+/** Cached shape format written to / read from ~/.cache/exocortex/property-shapes.json */
+export interface ShapeJSONCache {
+  version: number;
+  vaultMtime: number;
+  shapes: Record<string, Omit<Shape, "propertyIRI"> & { propertyIRI: string }>;
+}
+
+export class ShapeLoader {
+  /**
+   * Node.js only: walks vaultPath, parses all exo__Property*.md files and
+   * builds ShapeRegistry from their frontmatter.
+   */
+  static async loadFromVaultFS(vaultPath: string): Promise<ShapeRegistry> {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
+    const { readdir, readFile } = require("fs/promises") as typeof import("fs/promises");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
+    const path = require("path") as typeof import("path");
+    const registry = new ShapeRegistry();
+    await ShapeLoader.scanDir(vaultPath, registry, { readdir, readFile, path });
+    return registry;
+  }
+
+  /**
+   * Browser-safe: loads shapes from an in-memory ITripleStore
+   * (as populated by VaultRDFIndexer / NoteToRDFConverter).
+   */
+  static async loadFromRDFGraph(graph: ITripleStore): Promise<ShapeRegistry> {
+    const registry = new ShapeRegistry();
+
+    const EXO = Namespace.EXO;
+    const RDFS = Namespace.RDFS;
+    const RDF = Namespace.RDF;
+
+    // Find all property definition subjects (exo:Property or exo:ObjectProperty)
+    const [objPropTriples, basePropTriples] = await Promise.all([
+      graph.match(undefined, RDF.term("type"), EXO.term("ObjectProperty")),
+      graph.match(undefined, RDF.term("type"), EXO.term("Property")),
+    ]);
+
+    const subjects = new Set<string>();
+    for (const t of [...objPropTriples, ...basePropTriples]) {
+      if (t.subject instanceof IRI) subjects.add(t.subject.value);
+    }
+
+    for (const subjectValue of subjects) {
+      const subject = new IRI(subjectValue);
+
+      const [domainTs, rangeTs, cardTs, sevTs, labelTs] = await Promise.all([
+        graph.match(subject, RDFS.term("domain"), undefined),
+        graph.match(subject, RDFS.term("range"), undefined),
+        graph.match(subject, EXO.term("Property_cardinality"), undefined),
+        graph.match(subject, EXO.term("Property_severity"), undefined),
+        graph.match(subject, EXO.term("Asset_label"), undefined),
+      ]);
+
+      if (domainTs.length === 0) continue;
+
+      const labelObj = labelTs[0]?.object;
+      if (!(labelObj instanceof Literal)) continue;
+      const propertyIRI = ShapeLoader.labelToIRI(labelObj.value);
+      if (!propertyIRI) continue;
+
+      const domain = domainTs
+        .map((t) => (t.object instanceof IRI ? t.object.value : null))
+        .filter((v): v is string => v !== null);
+
+      const rangeValues = rangeTs
+        .map((t) => (t.object instanceof IRI ? t.object.value : null))
+        .filter((v): v is string => v !== null);
+
+      const cardinality = ShapeLoader.cardinalityFromIRI(
+        cardTs[0]?.object instanceof IRI ? cardTs[0].object.value : undefined,
+      );
+
+      const severity = ShapeLoader.severityFromValue(
+        sevTs[0]?.object instanceof Literal
+          ? sevTs[0].object.value
+          : sevTs[0]?.object instanceof IRI
+            ? sevTs[0].object.value
+            : undefined,
+      );
+
+      registry.register({
+        propertyIRI,
+        domain,
+        range: rangeValues.length > 0 ? rangeValues : undefined,
+        cardinality,
+        severity,
+      });
+    }
+
+    return registry;
+  }
+
+  /**
+   * Reads pre-baked shape cache from a JSON file.
+   * Format: ShapeJSONCache — see RFC 82a72aca §"Cached shape format".
+   */
+  static async loadFromShapeJSON(jsonPath: string): Promise<ShapeRegistry> {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
+    const { readFile } = require("fs/promises") as typeof import("fs/promises");
+    const raw = await readFile(jsonPath, "utf-8");
+    const cache: ShapeJSONCache = JSON.parse(raw) as ShapeJSONCache;
+    const registry = new ShapeRegistry();
+    for (const shape of Object.values(cache.shapes)) {
+      registry.register(shape);
+    }
+    return registry;
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  private static async scanDir(
+    dir: string,
+    registry: ShapeRegistry,
+    io: {
+      readdir: (
+        p: string,
+        opts: { withFileTypes: true },
+      ) => Promise<import("fs").Dirent[]>;
+      readFile: (p: string, enc: "utf-8") => Promise<string>;
+      path: typeof import("path");
+    },
+  ): Promise<void> {
+    let entries: import("fs").Dirent[];
+    try {
+      entries = await io.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = io.path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await ShapeLoader.scanDir(full, registry, io);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        await ShapeLoader.processFile(full, registry, io.readFile);
+      }
+    }
+  }
+
+  private static async processFile(
+    filePath: string,
+    registry: ShapeRegistry,
+    readFile: (p: string, enc: "utf-8") => Promise<string>,
+  ): Promise<void> {
+    let content: string;
+    try {
+      content = await readFile(filePath, "utf-8");
+    } catch {
+      return;
+    }
+
+    const fm = ShapeLoader.parseFrontmatter(content);
+    if (!fm) return;
+
+    // Must be a property definition
+    const classes = ShapeLoader.asArray(fm["exo__Instance_class"]);
+    const isProperty = classes.some((c) => {
+      const ref = ShapeLoader.extractWikilinkRef(c);
+      return (
+        ref === "exo__Property" ||
+        ref === "exo__ObjectProperty" ||
+        ref?.includes("|exo__Property") ||
+        ref?.includes("|exo__ObjectProperty")
+      );
+    });
+    if (!isProperty) return;
+
+    const labelRaw = fm["exo__Asset_label"];
+    if (!labelRaw || typeof labelRaw !== "string") return;
+    const label = labelRaw.trim();
+    const propertyIRI = ShapeLoader.labelToIRI(label);
+    if (!propertyIRI) return;
+
+    const domainRaw = fm["exo__Property_domain"];
+    const rangeRaw = fm["exo__Property_range"];
+    const cardRaw = fm["exo__Property_cardinality"];
+    const sevRaw = fm["exo__Property_severity"];
+
+    const domain = ShapeLoader.asArray(domainRaw)
+      .map((v) => ShapeLoader.wikilinkToIRI(v))
+      .filter((v): v is string => v !== null);
+    if (domain.length === 0) return;
+
+    const range = ShapeLoader.asArray(rangeRaw)
+      .map((v) => ShapeLoader.wikilinkToIRI(v))
+      .filter((v): v is string => v !== null);
+
+    const cardinality = ShapeLoader.cardinalityFromLabel(
+      typeof cardRaw === "string" ? cardRaw : undefined,
+    );
+
+    const severity = ShapeLoader.severityFromValue(
+      typeof sevRaw === "string" ? sevRaw : undefined,
+    );
+
+    registry.register({
+      propertyIRI,
+      domain,
+      range: range.length > 0 ? range : undefined,
+      cardinality,
+      severity,
+    });
+  }
+
+  /**
+   * Parses YAML frontmatter (between --- delimiters).
+   * Handles simple key: value and key:\n  - item arrays.
+   * Returns null if no frontmatter found.
+   */
+  private static parseFrontmatter(
+    content: string,
+  ): Record<string, string | string[]> | null {
+    const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+    if (!match) return null;
+
+    const yaml = match[1];
+    const result: Record<string, string | string[]> = {};
+    const lines = yaml.split(/\r?\n/);
+    let currentKey: string | null = null;
+    let currentArray: string[] | null = null;
+
+    for (const line of lines) {
+      const arrayItem = /^ {2}- (.*)$/.exec(line);
+      if (arrayItem) {
+        if (currentKey && currentArray) {
+          currentArray.push(arrayItem[1].trim());
+        }
+        continue;
+      }
+
+      // Save pending array
+      if (currentKey && currentArray) {
+        result[currentKey] = currentArray;
+        currentKey = null;
+        currentArray = null;
+      }
+
+      const kvMatch = /^([^:]+):\s*(.*)$/.exec(line);
+      if (!kvMatch) continue;
+      const key = kvMatch[1].trim();
+      const value = kvMatch[2].trim();
+
+      if (value === "") {
+        // Next lines may be array items
+        currentKey = key;
+        currentArray = [];
+      } else {
+        result[key] = value;
+      }
+    }
+
+    // Flush pending array
+    if (currentKey && currentArray) {
+      result[currentKey] = currentArray;
+    }
+
+    return result;
+  }
+
+  /** Converts label like "ems__Effort_parent" to full IRI, or null if unknown prefix. */
+  private static labelToIRI(label: string): string | null {
+    for (const [prefix, ns] of NAMESPACE_MAP) {
+      if (label.startsWith(prefix)) {
+        return ns.term(label.substring(prefix.length)).value;
+      }
+    }
+    return null;
+  }
+
+  /** Extracts the first part of [[ref]] or [[ref|alias]], stripping quotes. */
+  private static extractWikilinkRef(value: string): string | null {
+    const clean = value.replace(/^["']|["']$/g, "");
+    const m = /\[\[([^\]]+)\]\]/.exec(clean);
+    if (!m) return clean;
+    return m[1];
+  }
+
+  /**
+   * Converts a wikilink value to a full IRI string.
+   * Handles: "[[ems__Effort]]", "[[uuid|ems__Effort]]", "[[exo__PropertyCardinalitySingle]]"
+   */
+  private static wikilinkToIRI(value: string): string | null {
+    const ref = ShapeLoader.extractWikilinkRef(value);
+    if (!ref) return null;
+
+    // [[uuid|alias]] — take alias part
+    const parts = ref.split("|");
+    const candidates = parts.length > 1 ? [parts[1], parts[0]] : [parts[0]];
+
+    for (const candidate of candidates) {
+      const iri = ShapeLoader.labelToIRI(candidate.trim());
+      if (iri) return iri;
+    }
+
+    // Try as a full IRI
+    if (ref.startsWith("http")) return ref;
+    // Try SHACL prefix
+    if (ref.startsWith("sh:")) return SH_NS + ref.substring(3);
+
+    return null;
+  }
+
+  private static asArray(v: unknown): string[] {
+    if (Array.isArray(v)) return v.map(String);
+    if (typeof v === "string") return [v];
+    return [];
+  }
+
+  private static cardinalityFromIRI(iri: string | undefined): "Single" | "Multiple" | undefined {
+    if (!iri) return undefined;
+    if (iri.endsWith("PropertyCardinalitySingle")) return "Single";
+    if (iri.endsWith("PropertyCardinalityMultiple")) return "Multiple";
+    return undefined;
+  }
+
+  private static cardinalityFromLabel(raw: string | undefined): "Single" | "Multiple" | undefined {
+    if (!raw) return undefined;
+    const ref = ShapeLoader.extractWikilinkRef(raw) ?? raw;
+    const label = ref.split("|").pop() ?? ref;
+    if (label.includes("Single")) return "Single";
+    if (label.includes("Multiple")) return "Multiple";
+    return undefined;
+  }
+
+  private static severityFromValue(
+    raw: string | undefined,
+  ): "sh:Violation" | "sh:Warning" | "sh:Info" {
+    if (!raw) return "sh:Violation";
+    if (raw.includes("Violation") || raw === SH_NS + "Violation") return "sh:Violation";
+    if (raw.includes("Warning") || raw === SH_NS + "Warning") return "sh:Warning";
+    if (raw.includes("Info") || raw === SH_NS + "Info") return "sh:Info";
+    return "sh:Violation";
+  }
+}

--- a/packages/exocortex/src/services/ShapeRegistry.ts
+++ b/packages/exocortex/src/services/ShapeRegistry.ts
@@ -1,0 +1,36 @@
+/**
+ * Shape: a parsed SHACL-lite constraint for a single property.
+ * W3C SHACL vocabulary aligned — see RFC 82a72aca §"Engine: SHACL-lite service".
+ */
+export interface Shape {
+  propertyIRI: string;
+  domain: string[];
+  range?: string[];
+  cardinality?: "Single" | "Multiple";
+  minCount?: number;
+  severity: "sh:Violation" | "sh:Warning" | "sh:Info";
+  message?: string;
+}
+
+/**
+ * In-memory registry: propertyIRI → Shape.
+ */
+export class ShapeRegistry {
+  private readonly shapes: Map<string, Shape> = new Map();
+
+  get(propertyIRI: string): Shape | undefined {
+    return this.shapes.get(propertyIRI);
+  }
+
+  register(shape: Shape): void {
+    this.shapes.set(shape.propertyIRI, shape);
+  }
+
+  getAll(): Shape[] {
+    return Array.from(this.shapes.values());
+  }
+
+  get size(): number {
+    return this.shapes.size;
+  }
+}

--- a/packages/exocortex/tests/services/ShapeLoader.test.ts
+++ b/packages/exocortex/tests/services/ShapeLoader.test.ts
@@ -1,0 +1,618 @@
+import * as os from "os";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { ShapeLoader } from "../../src/services/ShapeLoader";
+import { ShapeRegistry } from "../../src/services/ShapeRegistry";
+import { IRI } from "../../src/domain/models/rdf/IRI";
+import { Literal } from "../../src/domain/models/rdf/Literal";
+import { Triple } from "../../src/domain/models/rdf/Triple";
+import { Namespace } from "../../src/domain/models/rdf/Namespace";
+import type { ITripleStore } from "../../src/interfaces/ITripleStore";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const EMS = "https://exocortex.my/ontology/ems#";
+const EXO = "https://exocortex.my/ontology/exo#";
+
+function makeTriple(s: string, p: string, o: string | { literal: string }): Triple {
+  const subj = new IRI(s);
+  const pred = new IRI(p);
+  const obj =
+    typeof o === "string" ? new IRI(o) : new Literal((o as { literal: string }).literal);
+  return new Triple(subj, pred, obj);
+}
+
+// Minimal mock for ITripleStore
+function makeStore(triples: Triple[]): jest.Mocked<ITripleStore> {
+  return {
+    match: jest.fn().mockImplementation(
+      async (
+        subject?: unknown,
+        predicate?: unknown,
+        object?: unknown,
+      ): Promise<Triple[]> => {
+        return triples.filter((t) => {
+          if (subject && !(t.subject instanceof IRI && t.subject.value === (subject as IRI).value))
+            return false;
+          if (
+            predicate &&
+            !(t.predicate instanceof IRI && t.predicate.value === (predicate as IRI).value)
+          )
+            return false;
+          if (object && !(t.object instanceof IRI && t.object.value === (object as IRI).value))
+            return false;
+          return true;
+        });
+      },
+    ),
+    add: jest.fn(),
+    remove: jest.fn(),
+    has: jest.fn(),
+    addAll: jest.fn(),
+    removeAll: jest.fn(),
+    clear: jest.fn(),
+    count: jest.fn(),
+    subjects: jest.fn(),
+    predicates: jest.fn(),
+    objects: jest.fn(),
+    beginTransaction: jest.fn(),
+  } as unknown as jest.Mocked<ITripleStore>;
+}
+
+// ── loadFromShapeJSON ─────────────────────────────────────────────────────────
+
+describe("ShapeLoader.loadFromShapeJSON", () => {
+  let tmpDir: string;
+  let jsonPath: string;
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "shacl-test-"));
+    jsonPath = path.join(tmpDir, "shapes.json");
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns ShapeRegistry instance", async () => {
+    await fs.writeFile(
+      jsonPath,
+      JSON.stringify({ version: 1, vaultMtime: 0, shapes: {} }),
+      "utf-8",
+    );
+    const reg = await ShapeLoader.loadFromShapeJSON(jsonPath);
+    expect(reg).toBeInstanceOf(ShapeRegistry);
+  });
+
+  it("loads shapes from RFC §Cached shape format", async () => {
+    const cache = {
+      version: 1,
+      vaultMtime: 1714398672,
+      shapes: {
+        "ems__Effort_parent": {
+          propertyIRI: `${EMS}Effort_parent`,
+          domain: [`${EMS}Effort`],
+          range: [`${EMS}ParentEffort`],
+          cardinality: "Single",
+          severity: "sh:Violation",
+          message: "ems__Effort_parent must reference ems__ParentEffort",
+        },
+      },
+    };
+    await fs.writeFile(jsonPath, JSON.stringify(cache), "utf-8");
+
+    const reg = await ShapeLoader.loadFromShapeJSON(jsonPath);
+    expect(reg.size).toBe(1);
+    const shape = reg.get(`${EMS}Effort_parent`);
+    expect(shape).toBeDefined();
+    expect(shape!.domain).toEqual([`${EMS}Effort`]);
+    expect(shape!.range).toEqual([`${EMS}ParentEffort`]);
+    expect(shape!.cardinality).toBe("Single");
+    expect(shape!.severity).toBe("sh:Violation");
+    expect(shape!.message).toBe("ems__Effort_parent must reference ems__ParentEffort");
+  });
+
+  it("loads multiple shapes", async () => {
+    const cache = {
+      version: 1,
+      vaultMtime: 0,
+      shapes: {
+        a: { propertyIRI: `${EMS}Effort_parent`, domain: [`${EMS}Effort`], severity: "sh:Violation" },
+        b: { propertyIRI: `${EMS}Effort_status`, domain: [`${EMS}Effort`], severity: "sh:Warning" },
+      },
+    };
+    await fs.writeFile(jsonPath, JSON.stringify(cache), "utf-8");
+    const reg = await ShapeLoader.loadFromShapeJSON(jsonPath);
+    expect(reg.size).toBe(2);
+  });
+});
+
+// ── loadFromRDFGraph ──────────────────────────────────────────────────────────
+
+describe("ShapeLoader.loadFromRDFGraph", () => {
+  const FILE_IRI = "obsidian://vault/ems/ems__Effort_parent.md";
+  const RDF_TYPE = Namespace.RDF.term("type").value;
+  const RDFS_DOMAIN = Namespace.RDFS.term("domain").value;
+  const RDFS_RANGE = Namespace.RDFS.term("range").value;
+  const EXO_CARD = Namespace.EXO.term("Property_cardinality").value;
+  const EXO_SEV = Namespace.EXO.term("Property_severity").value;
+  const EXO_LABEL = Namespace.EXO.term("Asset_label").value;
+  const OBJ_PROP_TYPE = `${EXO}ObjectProperty`;
+  const PROP_TYPE = `${EXO}Property`;
+
+  function makePropertyTriples(overrides?: {
+    type?: string;
+    domain?: string;
+    range?: string;
+    cardinality?: string;
+    severity?: string;
+    label?: string;
+  }): Triple[] {
+    const t = {
+      type: OBJ_PROP_TYPE,
+      domain: `${EMS}Effort`,
+      range: `${EMS}ParentEffort`,
+      cardinality: `${EXO}PropertyCardinalitySingle`,
+      severity: undefined as string | undefined,
+      label: "ems__Effort_parent",
+      ...overrides,
+    };
+
+    const triples: Triple[] = [
+      makeTriple(FILE_IRI, RDF_TYPE, t.type),
+      makeTriple(FILE_IRI, RDFS_DOMAIN, t.domain),
+      makeTriple(FILE_IRI, RDFS_RANGE, t.range),
+      makeTriple(FILE_IRI, EXO_CARD, t.cardinality),
+      makeTriple(FILE_IRI, EXO_LABEL, { literal: t.label }),
+    ];
+
+    if (t.severity) {
+      triples.push(makeTriple(FILE_IRI, EXO_SEV, { literal: t.severity }));
+    }
+
+    return triples;
+  }
+
+  it("returns ShapeRegistry instance", async () => {
+    const store = makeStore([]);
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg).toBeInstanceOf(ShapeRegistry);
+  });
+
+  it("loads shape from exo:ObjectProperty triple", async () => {
+    const store = makeStore(makePropertyTriples());
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+
+    expect(reg.size).toBe(1);
+    const shape = reg.get(`${EMS}Effort_parent`);
+    expect(shape).toBeDefined();
+    expect(shape!.domain).toContain(`${EMS}Effort`);
+    expect(shape!.range).toContain(`${EMS}ParentEffort`);
+    expect(shape!.cardinality).toBe("Single");
+  });
+
+  it("loads shape from exo:Property triple", async () => {
+    const store = makeStore(makePropertyTriples({ type: PROP_TYPE }));
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.size).toBe(1);
+  });
+
+  it("skips property without domain triples", async () => {
+    const triples = [
+      makeTriple(FILE_IRI, RDF_TYPE, OBJ_PROP_TYPE),
+      makeTriple(FILE_IRI, EXO_LABEL, { literal: "ems__Effort_parent" }),
+    ];
+    const store = makeStore(triples);
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.size).toBe(0);
+  });
+
+  it("skips property without label triple", async () => {
+    const triples = [
+      makeTriple(FILE_IRI, RDF_TYPE, OBJ_PROP_TYPE),
+      makeTriple(FILE_IRI, RDFS_DOMAIN, `${EMS}Effort`),
+    ];
+    const store = makeStore(triples);
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.size).toBe(0);
+  });
+
+  it("defaults severity to sh:Violation when not specified", async () => {
+    const store = makeStore(makePropertyTriples({ severity: undefined }));
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.get(`${EMS}Effort_parent`)!.severity).toBe("sh:Violation");
+  });
+
+  it("parses sh:Warning severity", async () => {
+    const store = makeStore(makePropertyTriples({ severity: "sh:Warning" }));
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.get(`${EMS}Effort_parent`)!.severity).toBe("sh:Warning");
+  });
+
+  it("parses sh:Info severity", async () => {
+    const store = makeStore(makePropertyTriples({ severity: "sh:Info" }));
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.get(`${EMS}Effort_parent`)!.severity).toBe("sh:Info");
+  });
+
+  it("parses Multiple cardinality", async () => {
+    const store = makeStore(
+      makePropertyTriples({ cardinality: `${EXO}PropertyCardinalityMultiple` }),
+    );
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.get(`${EMS}Effort_parent`)!.cardinality).toBe("Multiple");
+  });
+
+  it("handles property with unknown label prefix (non-namespaced) — skips", async () => {
+    const triples = [
+      makeTriple(FILE_IRI, RDF_TYPE, OBJ_PROP_TYPE),
+      makeTriple(FILE_IRI, RDFS_DOMAIN, `${EMS}Effort`),
+      makeTriple(FILE_IRI, EXO_LABEL, { literal: "unknown__something" }),
+    ];
+    const store = makeStore(triples);
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.size).toBe(0);
+  });
+
+  it("handles empty store — returns empty registry", async () => {
+    const store = makeStore([]);
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.size).toBe(0);
+  });
+});
+
+// ── loadFromVaultFS ───────────────────────────────────────────────────────────
+
+describe("ShapeLoader.loadFromVaultFS", () => {
+  let tmpDir: string;
+
+  async function writeFile(name: string, content: string): Promise<string> {
+    const filePath = path.join(tmpDir, name);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content, "utf-8");
+    return filePath;
+  }
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "shacl-vault-"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty registry for empty vault", async () => {
+    const emptyDir = await fs.mkdtemp(path.join(os.tmpdir(), "shacl-empty-"));
+    try {
+      const reg = await ShapeLoader.loadFromVaultFS(emptyDir);
+      expect(reg.size).toBe(0);
+    } finally {
+      await fs.rm(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips non-property .md files", async () => {
+    await writeFile(
+      "regular-note.md",
+      `---\nexo__Instance_class:\n  - "[[ems__Task]]"\nexo__Asset_label: some-task\n---\n`,
+    );
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    expect(reg.size).toBe(0);
+  });
+
+  it("loads property with domain, range, cardinality, severity from frontmatter", async () => {
+    await writeFile(
+      "ems__Effort_parent.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[086f71fa-dd30-4284-90cf-e609f2a6c461|ems__Effort]]"',
+        'exo__Property_range: "[[ems__ParentEffort]]"',
+        'exo__Property_cardinality: "[[exo__PropertyCardinalitySingle]]"',
+        "exo__Asset_label: ems__Effort_parent",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Effort_parent`);
+    expect(shape).toBeDefined();
+    expect(shape!.domain).toEqual([`${EMS}Effort`]);
+    expect(shape!.range).toEqual([`${EMS}ParentEffort`]);
+    expect(shape!.cardinality).toBe("Single");
+  });
+
+  it("defaults severity to sh:Violation when absent", async () => {
+    await writeFile(
+      "no-severity.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        "exo__Asset_label: ems__Effort_blocker",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Effort_blocker`);
+    expect(shape).toBeDefined();
+    expect(shape!.severity).toBe("sh:Violation");
+  });
+
+  it("parses exo__Property class (not just ObjectProperty)", async () => {
+    await writeFile(
+      "sub/base-prop.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__Property]]"',
+        'exo__Property_domain: "[[exo__Asset]]"',
+        "exo__Asset_label: exo__Asset_label",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EXO}Asset_label`);
+    expect(shape).toBeDefined();
+  });
+
+  it("skips file without exo__Property_domain", async () => {
+    const preSize = (await ShapeLoader.loadFromVaultFS(tmpDir)).size;
+    await writeFile(
+      "no-domain.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        "exo__Asset_label: ems__Effort_something",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    expect(reg.size).toBe(preSize); // unchanged
+  });
+
+  it("skips file without exo__Asset_label", async () => {
+    const preSize = (await ShapeLoader.loadFromVaultFS(tmpDir)).size;
+    await writeFile(
+      "no-label.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    expect(reg.size).toBe(preSize); // unchanged
+  });
+
+  it("handles Multiple cardinality", async () => {
+    await writeFile(
+      "multi-card.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        'exo__Property_cardinality: "[[exo__PropertyCardinalityMultiple]]"',
+        "exo__Asset_label: ems__Effort_relates",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Effort_relates`);
+    expect(shape).toBeDefined();
+    expect(shape!.cardinality).toBe("Multiple");
+  });
+
+  it("parses sh:Violation severity literal", async () => {
+    await writeFile(
+      "sev-violation.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        "exo__Property_severity: sh:Violation",
+        "exo__Asset_label: ems__Effort_jiraURL",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    expect(reg.get(`${EMS}Effort_jiraURL`)!.severity).toBe("sh:Violation");
+  });
+
+  it("walks subdirectories recursively", async () => {
+    await writeFile(
+      "deep/sub/dir/property.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[exo__Asset]]"',
+        "exo__Asset_label: exo__Asset_uid",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    expect(reg.get(`${EXO}Asset_uid`)).toBeDefined();
+  });
+
+  it("skips files without frontmatter", async () => {
+    const preSize = (await ShapeLoader.loadFromVaultFS(tmpDir)).size;
+    await writeFile("no-fm.md", "# Just a note\nNo frontmatter here.\n");
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    expect(reg.size).toBe(preSize);
+  });
+
+  it("handles range absent — shape.range is undefined", async () => {
+    await writeFile(
+      "no-range.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        "exo__Asset_label: ems__Effort_day",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Effort_day`);
+    expect(shape).toBeDefined();
+    expect(shape!.range).toBeUndefined();
+  });
+
+  it("gracefully handles non-existent vault directory (returns empty registry)", async () => {
+    const reg = await ShapeLoader.loadFromVaultFS("/non/existent/dir");
+    expect(reg.size).toBe(0);
+  });
+
+  it("flushes array at end of frontmatter (last key is array)", async () => {
+    // Frontmatter where the array is the very last key (no trailing newline before ---)
+    await writeFile(
+      "array-last.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        "exo__Asset_label: ems__Effort_area",
+        'exo__Property_range:',
+        '  - "[[ems__Area]]"',
+        "---",
+      ].join("\n"),
+    );
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Effort_area`);
+    expect(shape).toBeDefined();
+    expect(shape!.range).toEqual([`${Namespace.EMS.term("Area").value}`]);
+  });
+
+  it("handles range wikilink with full http IRI fallback", async () => {
+    await writeFile(
+      "full-iri-range.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        'exo__Property_range: "[[http://www.w3.org/ns/shacl#Severity]]"',
+        "exo__Asset_label: exo__Property_severity",
+        "---",
+      ].join("\n"),
+    );
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EXO}Property_severity`);
+    expect(shape).toBeDefined();
+    expect(shape!.range).toEqual(["http://www.w3.org/ns/shacl#Severity"]);
+  });
+
+  it("handles unrecognized cardinality label (returns undefined cardinality)", async () => {
+    await writeFile(
+      "unknown-card.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        'exo__Property_cardinality: "[[exo__UnknownCardinality]]"',
+        "exo__Asset_label: ems__Effort_notes",
+        "---",
+      ].join("\n"),
+    );
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Effort_notes`);
+    expect(shape).toBeDefined();
+    expect(shape!.cardinality).toBeUndefined();
+  });
+
+  it("ignores range wikilink with unrecognized prefix (no IRI produced)", async () => {
+    await writeFile(
+      "period-range.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        'exo__Property_range: "[[period__Day]]"',
+        "exo__Asset_label: ems__Effort_day2",
+        "---",
+      ].join("\n"),
+    );
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Effort_day2`);
+    // range value with unknown prefix → wikilinkToIRI returns null → shape.range = undefined
+    expect(shape).toBeDefined();
+    expect(shape!.range).toBeUndefined();
+  });
+
+  it("handles sh: prefix in range wikilink", async () => {
+    await writeFile(
+      "sh-range.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[exo__Property]]"',
+        'exo__Property_range: "[[sh:Severity]]"',
+        "exo__Asset_label: exo__Property_severity2",
+        "---",
+      ].join("\n"),
+    );
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EXO}Property_severity2`);
+    expect(shape).toBeDefined();
+    expect(shape!.range).toEqual(["http://www.w3.org/ns/shacl#Severity"]);
+  });
+});
+
+// ── loadFromRDFGraph: additional edge-case coverage ───────────────────────────
+
+describe("ShapeLoader.loadFromRDFGraph — additional cases", () => {
+  const FILE_IRI = "obsidian://vault/ems/test-prop.md";
+  const RDF_TYPE = Namespace.RDF.term("type").value;
+  const RDFS_DOMAIN = Namespace.RDFS.term("domain").value;
+  const EXO_CARD = Namespace.EXO.term("Property_cardinality").value;
+  const EXO_SEV = Namespace.EXO.term("Property_severity").value;
+  const EXO_LABEL = Namespace.EXO.term("Asset_label").value;
+  const EMS_NS = "https://exocortex.my/ontology/ems#";
+  const EXO_NS = "https://exocortex.my/ontology/exo#";
+  const OBJ_PROP_TYPE = `${EXO_NS}ObjectProperty`;
+
+  it("defaults to sh:Violation for unknown severity IRI", async () => {
+    const triples = [
+      makeTriple(FILE_IRI, RDF_TYPE, OBJ_PROP_TYPE),
+      makeTriple(FILE_IRI, RDFS_DOMAIN, `${EMS_NS}Effort`),
+      makeTriple(FILE_IRI, EXO_LABEL, { literal: "ems__Effort_test" }),
+      makeTriple(FILE_IRI, EXO_SEV, { literal: "totally-unknown-severity" }),
+    ];
+    const store = makeStore(triples);
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.get(`${EMS_NS}Effort_test`)!.severity).toBe("sh:Violation");
+  });
+
+  it("returns undefined cardinality for unrecognized cardinality IRI", async () => {
+    const triples = [
+      makeTriple(FILE_IRI, RDF_TYPE, OBJ_PROP_TYPE),
+      makeTriple(FILE_IRI, RDFS_DOMAIN, `${EMS_NS}Effort`),
+      makeTriple(FILE_IRI, EXO_LABEL, { literal: "ems__Effort_test2" }),
+      makeTriple(FILE_IRI, EXO_CARD, `${EXO_NS}PropertyCardinalityUnknown`),
+    ];
+    const store = makeStore(triples);
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.get(`${EMS_NS}Effort_test2`)!.cardinality).toBeUndefined();
+  });
+});

--- a/packages/exocortex/tests/services/ShapeRegistry.test.ts
+++ b/packages/exocortex/tests/services/ShapeRegistry.test.ts
@@ -1,0 +1,128 @@
+import { ShapeRegistry, Shape } from "../../src/services/ShapeRegistry";
+
+const makeShape = (propertyIRI: string, overrides?: Partial<Shape>): Shape => ({
+  propertyIRI,
+  domain: ["https://exocortex.my/ontology/ems#Effort"],
+  severity: "sh:Violation",
+  ...overrides,
+});
+
+describe("ShapeRegistry", () => {
+  let registry: ShapeRegistry;
+
+  beforeEach(() => {
+    registry = new ShapeRegistry();
+  });
+
+  describe("register / get", () => {
+    it("registers a shape and retrieves it by propertyIRI", () => {
+      const shape = makeShape("https://exocortex.my/ontology/ems#Effort_parent");
+      registry.register(shape);
+      expect(registry.get("https://exocortex.my/ontology/ems#Effort_parent")).toEqual(shape);
+    });
+
+    it("returns undefined for unknown propertyIRI", () => {
+      expect(registry.get("https://example.com/unknown")).toBeUndefined();
+    });
+
+    it("overwrites shape registered under the same propertyIRI", () => {
+      const first = makeShape("https://exocortex.my/ontology/ems#Effort_parent", {
+        severity: "sh:Warning",
+      });
+      const second = makeShape("https://exocortex.my/ontology/ems#Effort_parent", {
+        severity: "sh:Violation",
+      });
+      registry.register(first);
+      registry.register(second);
+      expect(registry.get("https://exocortex.my/ontology/ems#Effort_parent")!.severity).toBe(
+        "sh:Violation",
+      );
+    });
+  });
+
+  describe("getAll", () => {
+    it("returns empty array when no shapes registered", () => {
+      expect(registry.getAll()).toEqual([]);
+    });
+
+    it("returns all registered shapes", () => {
+      const s1 = makeShape("https://exocortex.my/ontology/ems#Effort_parent");
+      const s2 = makeShape("https://exocortex.my/ontology/ems#Effort_status");
+      registry.register(s1);
+      registry.register(s2);
+      expect(registry.getAll()).toHaveLength(2);
+      expect(registry.getAll()).toContainEqual(s1);
+      expect(registry.getAll()).toContainEqual(s2);
+    });
+  });
+
+  describe("size", () => {
+    it("reflects number of registered shapes", () => {
+      expect(registry.size).toBe(0);
+      registry.register(makeShape("https://exocortex.my/ontology/ems#Effort_parent"));
+      expect(registry.size).toBe(1);
+      registry.register(makeShape("https://exocortex.my/ontology/ems#Effort_status"));
+      expect(registry.size).toBe(2);
+    });
+
+    it("does not grow on duplicate registration", () => {
+      registry.register(makeShape("https://exocortex.my/ontology/ems#Effort_parent"));
+      registry.register(makeShape("https://exocortex.my/ontology/ems#Effort_parent"));
+      expect(registry.size).toBe(1);
+    });
+  });
+
+  describe("Shape optional fields", () => {
+    it("stores range when provided", () => {
+      const shape = makeShape("https://exocortex.my/ontology/ems#Effort_parent", {
+        range: ["https://exocortex.my/ontology/ems#ParentEffort"],
+      });
+      registry.register(shape);
+      expect(registry.get(shape.propertyIRI)!.range).toEqual([
+        "https://exocortex.my/ontology/ems#ParentEffort",
+      ]);
+    });
+
+    it("stores cardinality Single", () => {
+      const shape = makeShape("https://exocortex.my/ontology/ems#Effort_parent", {
+        cardinality: "Single",
+      });
+      registry.register(shape);
+      expect(registry.get(shape.propertyIRI)!.cardinality).toBe("Single");
+    });
+
+    it("stores cardinality Multiple", () => {
+      const shape = makeShape("https://exocortex.my/ontology/ems#Effort_parent", {
+        cardinality: "Multiple",
+      });
+      registry.register(shape);
+      expect(registry.get(shape.propertyIRI)!.cardinality).toBe("Multiple");
+    });
+
+    it("stores sh:Warning severity", () => {
+      const shape = makeShape("https://exocortex.my/ontology/ems#Effort_parent", {
+        severity: "sh:Warning",
+      });
+      registry.register(shape);
+      expect(registry.get(shape.propertyIRI)!.severity).toBe("sh:Warning");
+    });
+
+    it("stores sh:Info severity", () => {
+      const shape = makeShape("https://exocortex.my/ontology/ems#Effort_parent", {
+        severity: "sh:Info",
+      });
+      registry.register(shape);
+      expect(registry.get(shape.propertyIRI)!.severity).toBe("sh:Info");
+    });
+
+    it("stores message when provided", () => {
+      const shape = makeShape("https://exocortex.my/ontology/ems#Effort_parent", {
+        message: "must reference ems:ParentEffort",
+      });
+      registry.register(shape);
+      expect(registry.get(shape.propertyIRI)!.message).toBe(
+        "must reference ems:ParentEffort",
+      );
+    });
+  });
+});

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -101,8 +101,9 @@ fi
 #   wikilink → namespace IRI normalization regression suite)
 # - Issue #2997 Phase 5 (RFC 0810aad3): infrastructure/sparql/executors/BGPExecutor.issue-2997.test.ts
 #   (translator literal-safety guard regression gate)
+# - RFC 82a72aca P1.2 (SHACL-lite): services/ShapeRegistry.test.ts + services/ShapeLoader.test.ts
 echo "📦 Running exocortex grounding + RFC regression tests..."
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test)\.ts --forceExit"
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"

--- a/scripts/validate-docs-properties.js
+++ b/scripts/validate-docs-properties.js
@@ -34,6 +34,7 @@ const KNOWN_EXCEPTIONS = new Set([
   "exo__Task_priority", // sparql/User-Guide.md SPARQL example (simplified)
   "ems__Session_scheduled_start_time", // workflows time-specific scheduling
   "ems__Effort_status_changes", // workflows status history YAML example
+  "exo__Property_minCount", // SHACL_LITE_MAPPING.md Phase 3+ planned property (YAGNI Drop #3 in RFC 82a72aca v3)
 ]);
 
 function extractPropertiesFromDocs() {


### PR DESCRIPTION
## Summary

- Implements `ShapeRegistry` — in-memory map `propertyIRI → Shape` with `get()`, `register()`, `getAll()`, `size`
- Implements `ShapeLoader` with 3 loading strategies per RFC 82a72aca §"Engine: SHACL-lite service":
  - `loadFromVaultFS(path)` — Node.js only, parses `.md` property assets via built-in frontmatter parser; wikilinks `[[uuid|ems__Effort]]` → full namespace IRI
  - `loadFromRDFGraph(graph: ITripleStore)` — browser-safe, queries triple store for `rdf:type exo:ObjectProperty/Property` + domain/range/cardinality/severity
  - `loadFromShapeJSON(path)` — reads pre-baked cache (RFC §"Cached shape format")
- `Shape` interface aligned with W3C SHACL vocabulary (`sh:Violation` / `sh:Warning` / `sh:Info`)
- 47 tests covering all 3 loaders, edge cases (missing domain/label, unknown cardinality/severity, recursive directory scan, wikilink variants)
- Adds `ShapeRegistry` + `ShapeLoader` to CI `test-ci-batched.sh` allow-list

## Test plan

- [x] `ShapeRegistry.test.ts` — 13 tests (100% coverage)
- [x] `ShapeLoader.test.ts` — 34 tests (97%+ statements, 89%+ branches, 100% functions)
- [x] Existing regression suite: 162 tests passing (no regressions)
- [x] Typecheck: clean (`tsc --noEmit`)
- [x] ESLint: clean (pre-commit hook passed)
- [x] Archgate: all ADR checks passed