### PR TITLE
fix(ci): add exo__Property_severity to docs-property-validation exceptions

### DIFF
--- a/scripts/validate-docs-properties.js
+++ b/scripts/validate-docs-properties.js
@@ -35,6 +35,7 @@ const KNOWN_EXCEPTIONS = new Set([
   "ems__Session_scheduled_start_time", // workflows time-specific scheduling
   "ems__Effort_status_changes", // workflows status history YAML example
   "exo__Property_minCount", // SHACL_LITE_MAPPING.md Phase 3+ planned property (YAGNI Drop #3 in RFC 82a72aca v3)
+  "exo__Property_severity", // SHACL_LITE_MAPPING.md sh:severity alignment — docs-only mapping reference (aa6615f0)
 ]);
 
 function extractPropertiesFromDocs() {


### PR DESCRIPTION
## Summary

- `exo__Property_severity` was missing from KNOWN_EXCEPTIONS in `scripts/validate-docs-properties.js`
- `exo__Property_minCount` was already there
- Both properties were introduced in commit `aa6615f0` (P0.4, SHACL_LITE_MAPPING.md)
- `docs-property-validation` check was failing on every PR since that commit

## Test plan

- [x] `node scripts/validate-docs-properties.js` → `0 missing`, exit 0
- [x] No behavior change — allowlist-only addition

Closes #3058