### PR TITLE
test(cli): P1.7 — SHACL-lite integration test with golden file

### DIFF
--- a/packages/cli/tests/fixtures/shacl-integration/data/asset-a.md
+++ b/packages/cli/tests/fixtures/shacl-integration/data/asset-a.md
@@ -1,0 +1,15 @@
+---
+exo__Asset_isDefinedBy: "[[!test]]"
+exo__Asset_uid: 11111111-aaaa-1111-aaaa-111111111111
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: Asset A
+ems__Task_name:
+  - "First Name"
+  - "Second Name"
+aliases:
+  - Asset A
+---
+
+Asset A: sh:maxCount violation — ems\_\_Task_name is Single cardinality but has 2 values.

--- a/packages/cli/tests/fixtures/shacl-integration/data/asset-b.md
+++ b/packages/cli/tests/fixtures/shacl-integration/data/asset-b.md
@@ -1,0 +1,13 @@
+---
+exo__Asset_isDefinedBy: "[[!test]]"
+exo__Asset_uid: 22222222-bbbb-2222-bbbb-222222222222
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: Asset B
+ems__Task_count: "not-a-number"
+aliases:
+  - Asset B
+---
+
+Asset B: sh:datatype violation — ems\_\_Task_count expects xsd:integer but has a string literal.

--- a/packages/cli/tests/fixtures/shacl-integration/data/asset-c.md
+++ b/packages/cli/tests/fixtures/shacl-integration/data/asset-c.md
@@ -1,0 +1,16 @@
+---
+exo__Asset_isDefinedBy: "[[!test]]"
+exo__Asset_uid: 33333333-cccc-3333-cccc-333333333333
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: Asset C
+ems__Task_name:
+  - "Name One"
+  - "Name Two"
+ems__Task_count: "bad-count"
+aliases:
+  - Asset C
+---
+
+Asset C: both sh:maxCount and sh:datatype violations simultaneously.

--- a/packages/cli/tests/fixtures/shacl-integration/golden-report.json
+++ b/packages/cli/tests/fixtures/shacl-integration/golden-report.json
@@ -1,0 +1,30 @@
+[
+  {
+    "focusNode": "obsidian://vault/data/asset-a.md",
+    "propertyPath": "https://exocortex.my/ontology/ems#Task_name",
+    "severity": "sh:Violation",
+    "message": "sh:maxCount violation: expected at most 1 value for <https://exocortex.my/ontology/ems#Task_name>, got 2"
+  },
+  {
+    "focusNode": "obsidian://vault/data/asset-b.md",
+    "propertyPath": "https://exocortex.my/ontology/ems#Task_count",
+    "severity": "sh:Violation",
+    "message": "sh:datatype violation: literal \"not-a-number\" has datatype <http://www.w3.org/2001/XMLSchema#string>, expected http://www.w3.org/2001/XMLSchema#integer",
+    "actualValue": "not-a-number",
+    "expectedRange": "http://www.w3.org/2001/XMLSchema#integer"
+  },
+  {
+    "focusNode": "obsidian://vault/data/asset-c.md",
+    "propertyPath": "https://exocortex.my/ontology/ems#Task_count",
+    "severity": "sh:Violation",
+    "message": "sh:datatype violation: literal \"bad-count\" has datatype <http://www.w3.org/2001/XMLSchema#string>, expected http://www.w3.org/2001/XMLSchema#integer",
+    "actualValue": "bad-count",
+    "expectedRange": "http://www.w3.org/2001/XMLSchema#integer"
+  },
+  {
+    "focusNode": "obsidian://vault/data/asset-c.md",
+    "propertyPath": "https://exocortex.my/ontology/ems#Task_name",
+    "severity": "sh:Violation",
+    "message": "sh:maxCount violation: expected at most 1 value for <https://exocortex.my/ontology/ems#Task_name>, got 2"
+  }
+]

--- a/packages/cli/tests/fixtures/shacl-integration/shapes/ems__Task_count.md
+++ b/packages/cli/tests/fixtures/shacl-integration/shapes/ems__Task_count.md
@@ -1,0 +1,16 @@
+---
+exo__Asset_isDefinedBy: "[[!ems]]"
+exo__Asset_uid: bbb22222-2222-2222-2222-222222222222
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[exo__Property]]"
+exo__Asset_label: ems__Task_count
+exo__Property_domain:
+  - "[[ems__Task]]"
+exo__Property_range: "http://www.w3.org/2001/XMLSchema#integer"
+exo__Property_severity: sh:Violation
+aliases:
+  - ems__Task_count
+---
+
+Test shape: ems**Task_count must be an xsd:integer on ems**Task nodes.

--- a/packages/cli/tests/fixtures/shacl-integration/shapes/ems__Task_name.md
+++ b/packages/cli/tests/fixtures/shacl-integration/shapes/ems__Task_name.md
@@ -1,0 +1,16 @@
+---
+exo__Asset_isDefinedBy: "[[!ems]]"
+exo__Asset_uid: aaa11111-1111-1111-1111-111111111111
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[exo__Property]]"
+exo__Asset_label: ems__Task_name
+exo__Property_domain:
+  - "[[ems__Task]]"
+exo__Property_cardinality: "[[exo__PropertyCardinalitySingle]]"
+exo__Property_severity: sh:Violation
+aliases:
+  - ems__Task_name
+---
+
+Test shape: ems**Task_name must be a Single-cardinality property on ems**Task nodes.

--- a/packages/cli/tests/integration/validate-schema-shapes.integration.test.ts
+++ b/packages/cli/tests/integration/validate-schema-shapes.integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * P1.7 — CLI integration test: validate schema --shapes-mode
+ *
+ * Synthetic vault with known violations → expected ValidationReport (golden file diff).
+ *
+ * Scenarios:
+ * 1. Asset A — sh:maxCount violation (ems__Task_name Single cardinality, 2 values given)
+ * 2. Asset B — sh:datatype violation (ems__Task_count expects xsd:integer, got string)
+ * 3. Asset C — both violations simultaneously
+ *
+ * To regenerate the golden file:
+ *   UPDATE_GOLDEN=1 npx jest validate-schema-shapes
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+} from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as url from "url";
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const FIXTURE_DIR = path.resolve(__dirname, "../fixtures/shacl-integration");
+const GOLDEN_FILE = path.join(FIXTURE_DIR, "golden-report.json");
+
+const { runShapesValidation } = await import(
+  "../../src/commands/validate-schema.js"
+);
+
+const { NoteToRDFConverter } = await import("exocortex");
+const { FileSystemVaultAdapter } = await import(
+  "../../src/adapters/FileSystemVaultAdapter.js"
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let violations: any[];
+let conforms: boolean;
+
+beforeAll(async () => {
+  const adapter = new FileSystemVaultAdapter(FIXTURE_DIR);
+  const converter = new NoteToRDFConverter(adapter);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const triples = (await converter.convertVault()) as any[];
+  const report = await runShapesValidation(FIXTURE_DIR, triples);
+  violations = report.violations;
+  conforms = report.conforms;
+});
+
+describe("BDD: validate schema --shapes-mode (P1.7 — synthetic vault fixtures)", () => {
+  it("Scenario: synthetic vault has violations — validation finds at least one violation", () => {
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  it("Scenario: exit code behavior — conforms=false when violations found (maps to CLI exit code 1)", () => {
+    expect(conforms).toBe(false);
+  });
+
+  it("Scenario: canonical sort — violations are sorted by focusNode then propertyPath", () => {
+    for (let i = 0; i < violations.length - 1; i++) {
+      const a = violations[i];
+      const b = violations[i + 1];
+      const cmp =
+        a.focusNode !== b.focusNode
+          ? a.focusNode.localeCompare(b.focusNode)
+          : a.propertyPath.localeCompare(b.propertyPath);
+      expect(cmp).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it("Scenario: asset-a.md — sh:maxCount violation for ems__Task_name (Single cardinality, 2 values)", () => {
+    const v = violations.find(
+      (x) =>
+        x.focusNode.includes("asset-a.md") &&
+        x.propertyPath.includes("Task_name"),
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("sh:Violation");
+    expect(v?.message).toContain("sh:maxCount violation");
+  });
+
+  it("Scenario: asset-b.md — sh:datatype violation for ems__Task_count (expects xsd:integer, got string)", () => {
+    const v = violations.find(
+      (x) =>
+        x.focusNode.includes("asset-b.md") &&
+        x.propertyPath.includes("Task_count"),
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("sh:Violation");
+    expect(v?.message).toContain("sh:datatype violation");
+  });
+
+  it("Scenario: asset-c.md — has both maxCount and datatype violations (at least 2 violations)", () => {
+    const assetC = violations.filter((x) => x.focusNode.includes("asset-c.md"));
+    expect(assetC.length).toBeGreaterThanOrEqual(2);
+    expect(assetC.some((x) => x.message.includes("sh:maxCount violation"))).toBe(true);
+    expect(assetC.some((x) => x.message.includes("sh:datatype violation"))).toBe(true);
+  });
+
+  it("Scenario: golden file — violations match golden report byte-by-byte (canonical sort)", () => {
+    const actual = JSON.stringify(violations, null, 2);
+    if (process.env.UPDATE_GOLDEN === "1") {
+      fs.writeFileSync(GOLDEN_FILE, actual + "\n", "utf-8");
+    }
+    expect(fs.existsSync(GOLDEN_FILE)).toBe(true);
+    const golden = fs.readFileSync(GOLDEN_FILE, "utf-8");
+    expect(actual + "\n").toBe(golden);
+  });
+});

--- a/packages/exocortex/src/services/ShapeLoader.ts
+++ b/packages/exocortex/src/services/ShapeLoader.ts
@@ -33,10 +33,10 @@ export class ShapeLoader {
    * builds ShapeRegistry from their frontmatter.
    */
   static async loadFromVaultFS(vaultPath: string): Promise<ShapeRegistry> {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
-    const { readdir, readFile } = require("fs/promises") as typeof import("fs/promises");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
-    const path = require("path") as typeof import("path");
+    // eslint-disable-next-line import/no-nodejs-modules
+    const { readdir, readFile } = await import("fs/promises");
+    // eslint-disable-next-line import/no-nodejs-modules
+    const path = await import("path");
     const registry = new ShapeRegistry();
     await ShapeLoader.scanDir(vaultPath, registry, { readdir, readFile, path });
     return registry;
@@ -119,8 +119,8 @@ export class ShapeLoader {
    * Format: ShapeJSONCache — see RFC 82a72aca §"Cached shape format".
    */
   static async loadFromShapeJSON(jsonPath: string): Promise<ShapeRegistry> {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
-    const { readFile } = require("fs/promises") as typeof import("fs/promises");
+    // eslint-disable-next-line import/no-nodejs-modules
+    const { readFile } = await import("fs/promises");
     const raw = await readFile(jsonPath, "utf-8");
     const cache: ShapeJSONCache = JSON.parse(raw) as ShapeJSONCache;
     const registry = new ShapeRegistry();


### PR DESCRIPTION
## Summary

- Adds synthetic vault fixture (`tests/fixtures/shacl-integration/`) with 3 assets having known violations
- Adds integration test `validate-schema-shapes.integration.test.ts` (7 BDD scenarios)
- Adds golden file `golden-report.json` (canonical sort by focusNode+propertyPath)
- Fixes `ShapeLoader.loadFromVaultFS` and `loadFromShapeJSON` to use dynamic `import()` instead of `require()` for ESM test environment compatibility

## Violations in synthetic vault

| Asset | Violation type | Shape |
|-------|---------------|-------|
| `data/asset-a.md` | `sh:maxCount` — Single cardinality, 2 values | `ems__Task_name` |
| `data/asset-b.md` | `sh:datatype` — expects `xsd:integer`, got string | `ems__Task_count` |
| `data/asset-c.md` | Both `sh:maxCount` + `sh:datatype` simultaneously | Both |

## Test plan

- [x] 7 BDD scenarios pass locally
- [x] Existing validate-schema tests unaffected (62 tests pass)
- [x] Pre-commit hooks pass (lint, archgate, BDD coverage 100%)
- [x] ShapeLoader fix: `require()` → `import()` with ESLint disable comment
- [x] Golden file regenerated with `UPDATE_GOLDEN=1 npm test`