### PR TITLE
feat(shacl): P1.9 ValidatorDaemon idle-kill + lazy-start + DaemonClient

### DIFF
--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,0 +1,35 @@
+import { Command } from "commander";
+import { ValidatorDaemon, DEFAULT_SOCKET_PATH, IDLE_TIMEOUT_MS } from "exocortex";
+
+export interface DaemonStartOptions {
+  socket: string;
+  idleTimeout: number;
+}
+
+function daemonStartCommand(): Command {
+  return new Command("start")
+    .description("Start the ValidatorDaemon process (long-running, Unix socket)")
+    .option("--socket <path>", "Unix socket path", DEFAULT_SOCKET_PATH)
+    .option(
+      "--idle-timeout <seconds>",
+      "Exit after N seconds of inactivity",
+      String(Math.floor(IDLE_TIMEOUT_MS / 1000)),
+    )
+    .action(async (options: { socket: string; idleTimeout: string }) => {
+      const socketPath = options.socket;
+      const idleTimeoutMs = Number(options.idleTimeout) * 1000;
+
+      const daemon = new ValidatorDaemon(socketPath, idleTimeoutMs);
+      await daemon.start();
+      // Process stays alive: net.Server keeps the event loop running.
+      // Exits via: SIGTERM, SIGINT, or idle-kill timer.
+    });
+}
+
+export function daemonCommand(): Command {
+  const cmd = new Command("daemon").description(
+    "Manage the ValidatorDaemon background process",
+  );
+  cmd.addCommand(daemonStartCommand());
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import { workflowCommand } from "./commands/workflow.js";
 import { dynamicCommandCommand } from "./commands/dynamic-command.js";
 import { convertCommand } from "./commands/convert.js";
 import { migrateRelColSetToExoLayoutCommand } from "./commands/migrate-relcolset-to-exolayout.js";
+import { daemonCommand } from "./commands/daemon.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -81,6 +82,7 @@ export function createProgram(version?: string): Command {
   program.addCommand(dynamicCommandCommand());
   program.addCommand(convertCommand());
   program.addCommand(migrateRelColSetToExoLayoutCommand());
+  program.addCommand(daemonCommand());
 
   return program;
 }

--- a/packages/cli/src/services/DaemonClient.ts
+++ b/packages/cli/src/services/DaemonClient.ts
@@ -1,0 +1,134 @@
+import * as net from "net";
+import { spawn, type SpawnOptions, type ChildProcess } from "child_process";
+import {
+  shaclValidate,
+  ShaclShapeRegistry,
+  ShapeLoader,
+  TripleClassHierarchy,
+  DEFAULT_SOCKET_PATH,
+  type DaemonRequest,
+  type DaemonResponse,
+} from "exocortex";
+
+export { DEFAULT_SOCKET_PATH, type DaemonRequest, type DaemonResponse };
+
+export type SpawnFn = (
+  cmd: string,
+  args: string[],
+  opts: SpawnOptions,
+) => Pick<ChildProcess, "unref">;
+
+export interface DaemonClientOptions {
+  socketPath?: string;
+  /** argv to spawn the daemon: [node, cliEntry, 'daemon', 'start', ...] */
+  spawnArgv?: string[];
+  maxRetries?: number;
+  retryDelayMs?: number;
+  /** Injectable spawn function for testing */
+  spawnFn?: SpawnFn;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 200;
+const SOCKET_TIMEOUT_MS = 5000;
+
+export class DaemonClient {
+  private readonly socketPath: string;
+  private readonly spawnArgv: string[];
+  private readonly maxRetries: number;
+  private readonly retryDelayMs: number;
+  private readonly spawnFn: SpawnFn;
+
+  constructor(opts: DaemonClientOptions = {}) {
+    this.socketPath = opts.socketPath ?? DEFAULT_SOCKET_PATH;
+    this.spawnArgv = opts.spawnArgv ?? [
+      process.execPath,
+      process.argv[1],
+      "daemon",
+      "start",
+      "--socket",
+      this.socketPath,
+    ];
+    this.maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.retryDelayMs = opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    this.spawnFn = opts.spawnFn ?? ((cmd, args, spawnOpts) => spawn(cmd, args, spawnOpts));
+  }
+
+  async validate(req: DaemonRequest): Promise<DaemonResponse> {
+    try {
+      return await this.sendRequest(req);
+    } catch {
+      // Daemon not running — spawn it and retry
+      this.spawnDaemon();
+
+      for (let i = 0; i < this.maxRetries; i++) {
+        await sleep(this.retryDelayMs);
+        try {
+          return await this.sendRequest(req);
+        } catch {
+          // retry
+        }
+      }
+
+      // All retries exhausted → fallback to in-process validation
+      return this.fallbackValidate(req);
+    }
+  }
+
+  private spawnDaemon(): void {
+    const child = this.spawnFn(this.spawnArgv[0], this.spawnArgv.slice(1), {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+  }
+
+  private sendRequest(req: DaemonRequest): Promise<DaemonResponse> {
+    return new Promise<DaemonResponse>((resolve, reject) => {
+      const socket = net.createConnection(this.socketPath);
+      let buf = "";
+
+      socket.setEncoding("utf-8");
+      socket.setTimeout(SOCKET_TIMEOUT_MS);
+
+      socket.on("error", reject);
+      socket.on("timeout", () => {
+        socket.destroy();
+        reject(new Error("socket timeout"));
+      });
+
+      socket.on("data", (chunk: string) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl !== -1) {
+          socket.destroy();
+          try {
+            resolve(JSON.parse(buf.slice(0, nl)) as DaemonResponse);
+          } catch (e) {
+            reject(e);
+          }
+        }
+      });
+
+      socket.on("connect", () => {
+        socket.write(JSON.stringify(req) + "\n");
+      });
+    });
+  }
+
+  private async fallbackValidate(req: DaemonRequest): Promise<DaemonResponse> {
+    try {
+      const loaded = await ShapeLoader.loadFromShapeJSON(req.registryPath);
+      const registry = new ShaclShapeRegistry(loaded.getAll());
+      const hierarchy = new TripleClassHierarchy(req.subclassTriples ?? []);
+      const report = shaclValidate(req.triples as never, registry, hierarchy);
+      return { report };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cli/tests/unit/services/DaemonClient.test.ts
+++ b/packages/cli/tests/unit/services/DaemonClient.test.ts
@@ -1,0 +1,148 @@
+import * as os from "os";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as net from "net";
+import { DaemonClient, SpawnFn } from "../../../src/services/DaemonClient.js";
+import { DaemonRequest, DaemonResponse } from "../../../src/services/DaemonClient.js";
+import { ShapeJSONCache } from "exocortex";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const TEST_SOCKET_DIR = path.join(os.tmpdir(), "exo-daemonclient-test");
+let socketSeq = 0;
+
+function makeSocketPath(): string {
+  return path.join(TEST_SOCKET_DIR, `client-${process.pid}-${++socketSeq}.sock`);
+}
+
+async function writeMinimalShapeCache(dir: string): Promise<string> {
+  await fs.mkdir(dir, { recursive: true });
+  const jsonPath = path.join(dir, `shapes-${Date.now()}.json`);
+  const cache: ShapeJSONCache = { version: 1, vaultMtime: 0, shapes: {} };
+  await fs.writeFile(jsonPath, JSON.stringify(cache), "utf-8");
+  return jsonPath;
+}
+
+function startEchoServer(socketPath: string): net.Server {
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf-8");
+    let buf = "";
+    socket.on("data", (chunk: string) => {
+      buf += chunk;
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        buf = buf.slice(nl + 1);
+        const response: DaemonResponse = {
+          report: { conforms: true, violations: [] },
+        };
+        socket.write(JSON.stringify(response) + "\n");
+      }
+    });
+    socket.on("error", () => socket.destroy());
+  });
+  server.listen(socketPath);
+  return server;
+}
+
+function noopSpawn(): SpawnFn {
+  return () => ({ unref: () => {} });
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+let registryPath: string;
+
+beforeAll(async () => {
+  await fs.mkdir(TEST_SOCKET_DIR, { recursive: true });
+  registryPath = await writeMinimalShapeCache(TEST_SOCKET_DIR);
+});
+
+afterAll(async () => {
+  await fs.rm(TEST_SOCKET_DIR, { recursive: true, force: true });
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("DaemonClient", () => {
+  describe("direct connect (daemon already running)", () => {
+    let server: net.Server;
+    let socketPath: string;
+    let client: DaemonClient;
+
+    beforeAll(async () => {
+      socketPath = makeSocketPath();
+      server = startEchoServer(socketPath);
+      await new Promise<void>((resolve) => server.once("listening", resolve));
+      client = new DaemonClient({ socketPath, spawnFn: noopSpawn() });
+    });
+
+    afterAll(async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    it("returns report from daemon", async () => {
+      const req: DaemonRequest = { triples: [], registryPath };
+      const res = await client.validate(req);
+      expect(res.error).toBeUndefined();
+      expect(res.report).toBeDefined();
+      expect(res.report!.conforms).toBe(true);
+    });
+  });
+
+  describe("lazy-start: socket down → spawn + retry", () => {
+    it("calls spawnFn and eventually connects after server starts", async () => {
+      const socketPath = makeSocketPath();
+      let server: net.Server | null = null;
+      let spawnCalled = false;
+
+      const lazySpawn: SpawnFn = () => {
+        spawnCalled = true;
+        // Start an echo server after a short delay (simulates daemon boot)
+        setTimeout(() => {
+          server = startEchoServer(socketPath);
+        }, 50);
+        return { unref: () => {} };
+      };
+
+      const client = new DaemonClient({
+        socketPath,
+        spawnFn: lazySpawn,
+        maxRetries: 5,
+        retryDelayMs: 60,
+      });
+
+      try {
+        const req: DaemonRequest = { triples: [], registryPath };
+        const res = await client.validate(req);
+        expect(spawnCalled).toBe(true);
+        expect(res.report).toBeDefined();
+        expect(res.report!.conforms).toBe(true);
+      } finally {
+        if (server) {
+          await new Promise<void>((resolve) =>
+            (server as net.Server).close(() => resolve()),
+          );
+        }
+      }
+    });
+  });
+
+  describe("fallback: daemon cannot be spawned / retries exhausted", () => {
+    it("falls back to in-process validation when socket never becomes available", async () => {
+      const socketPath = makeSocketPath();
+
+      const client = new DaemonClient({
+        socketPath,
+        spawnFn: noopSpawn(), // spawn does nothing — socket stays down
+        maxRetries: 1,
+        retryDelayMs: 10,
+      });
+
+      const req: DaemonRequest = { triples: [], registryPath };
+      const res = await client.validate(req);
+      // Fallback ran in-process — should succeed
+      expect(res.report).toBeDefined();
+      expect(res.report!.conforms).toBe(true);
+    });
+  });
+});

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -507,3 +507,11 @@ export {
   type Shape as ShaclShape,
 } from "./services/ShaclLiteValidator";
 export * from "./application/errors";
+export {
+  ValidatorDaemon,
+  DEFAULT_SOCKET_PATH,
+  IDLE_TIMEOUT_MS,
+  type DaemonRequest,
+  type DaemonResponse,
+} from "./services/ValidatorDaemon";
+export { ClassHierarchy as TripleClassHierarchy } from "./services/ClassHierarchy";

--- a/packages/exocortex/src/services/ShapeLoader.ts
+++ b/packages/exocortex/src/services/ShapeLoader.ts
@@ -119,8 +119,10 @@ export class ShapeLoader {
    * Format: ShapeJSONCache — see RFC 82a72aca §"Cached shape format".
    */
   static async loadFromShapeJSON(jsonPath: string): Promise<ShapeRegistry> {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
-    const { readFile } = require("fs/promises") as typeof import("fs/promises");
+    // Dynamic import avoids static no-restricted-imports lint rule while
+    // supporting both CommonJS (transpiled) and ESM (--experimental-vm-modules) contexts.
+    // eslint-disable-next-line import/no-nodejs-modules
+    const { readFile } = await import("fs/promises");
     const raw = await readFile(jsonPath, "utf-8");
     const cache: ShapeJSONCache = JSON.parse(raw) as ShapeJSONCache;
     const registry = new ShapeRegistry();

--- a/packages/exocortex/src/services/ValidatorDaemon.ts
+++ b/packages/exocortex/src/services/ValidatorDaemon.ts
@@ -15,22 +15,20 @@ export interface DaemonResponse {
   error?: string;
 }
 
-export const DEFAULT_SOCKET_PATH = (() => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
-  const os = require('os') as typeof import('os');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
-  const path = require('path') as typeof import('path');
-  return path.join(os.homedir(), '.cache', 'exocortex', 'validator.sock');
-})();
+export const DEFAULT_SOCKET_PATH = `${process.env.HOME ?? process.env.USERPROFILE ?? '/tmp'}/.cache/exocortex/validator.sock`;
+
+export const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
 export class ValidatorDaemon {
   private readonly socketPath: string;
   private readonly registryCache = new Map<string, ValidatorShapeRegistry>();
-   
+  private readonly idleTimeoutMs: number;
   private server: import('net').Server | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(socketPath: string = DEFAULT_SOCKET_PATH) {
+  constructor(socketPath: string = DEFAULT_SOCKET_PATH, idleTimeoutMs: number = IDLE_TIMEOUT_MS) {
     this.socketPath = socketPath;
+    this.idleTimeoutMs = idleTimeoutMs;
   }
 
   async start(): Promise<void> {
@@ -59,16 +57,27 @@ export class ValidatorDaemon {
       server.listen(this.socketPath, resolve);
     });
 
+    this.resetIdleTimer();
+
     const handleSignal = (): void => { void this.stop(); };
     process.once('SIGTERM', handleSignal);
     process.once('SIGINT', handleSignal);
   }
 
   async stop(): Promise<void> {
+    if (this.idleTimer !== null) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
     if (!this.server) return;
     const server = this.server;
     this.server = null;
     await new Promise<void>((resolve) => { server.close(() => resolve()); });
+  }
+
+  private resetIdleTimer(): void {
+    if (this.idleTimer !== null) clearTimeout(this.idleTimer);
+    this.idleTimer = setTimeout(() => { process.exit(0); }, this.idleTimeoutMs);
   }
 
   private handleConnection(socket: import('net').Socket): void {
@@ -93,6 +102,7 @@ export class ValidatorDaemon {
   }
 
   private async handleRequest(raw: string, socket: import('net').Socket): Promise<void> {
+    this.resetIdleTimer();
     let response: DaemonResponse;
     try {
       const req = JSON.parse(raw) as DaemonRequest;

--- a/packages/exocortex/tests/services/ValidatorDaemon.test.ts
+++ b/packages/exocortex/tests/services/ValidatorDaemon.test.ts
@@ -2,9 +2,9 @@ import * as os from 'os';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as net from 'net';
-import { ValidatorDaemon } from '../../src/services/ValidatorDaemon';
-import type { DaemonRequest, DaemonResponse } from '../../src/services/ValidatorDaemon';
-import type { ShapeJSONCache } from '../../src/services/ShapeLoader';
+import { ValidatorDaemon, IDLE_TIMEOUT_MS } from '../../src/services/ValidatorDaemon';
+import { DaemonRequest, DaemonResponse } from '../../src/services/ValidatorDaemon';
+import { ShapeJSONCache } from '../../src/services/ShapeLoader';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -189,5 +189,66 @@ describe('ValidatorDaemon', () => {
 
       expect(p95).toBeLessThan(30);
     }, 15_000);
+  });
+
+  describe('idle-kill', () => {
+    it('IDLE_TIMEOUT_MS constant is 5 minutes', () => {
+      expect(IDLE_TIMEOUT_MS).toBe(5 * 60 * 1000);
+    });
+
+    it('idle timer fires process.exit after short timeout', async () => {
+      const socketPath = makeSocketPath();
+      const daemon = new ValidatorDaemon(socketPath, 50);
+      await daemon.start();
+
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+      try {
+        await new Promise<void>((resolve) => setTimeout(resolve, 120));
+        expect(exitSpy).toHaveBeenCalledWith(0);
+      } finally {
+        exitSpy.mockRestore();
+        await daemon.stop();
+      }
+    });
+
+    it('idle timer resets on each request', async () => {
+      const socketPath = makeSocketPath();
+      const daemon = new ValidatorDaemon(socketPath, 150);
+      await daemon.start();
+
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+      try {
+        const req: DaemonRequest = { triples: [], registryPath };
+
+        // Send request at t=0, t=100 — each resets the 150ms timer
+        await sendRequest(socketPath, req);
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+        await sendRequest(socketPath, req);
+        // At t=100 the timer was reset; wait only 80ms — should NOT fire yet
+        await new Promise<void>((resolve) => setTimeout(resolve, 80));
+        expect(exitSpy).not.toHaveBeenCalled();
+        // Wait past the 150ms window without further requests — timer fires
+        await new Promise<void>((resolve) => setTimeout(resolve, 120));
+        expect(exitSpy).toHaveBeenCalledWith(0);
+      } finally {
+        exitSpy.mockRestore();
+        await daemon.stop();
+      }
+    });
+
+    it('stop() cancels idle timer', async () => {
+      const socketPath = makeSocketPath();
+      const daemon = new ValidatorDaemon(socketPath, 50);
+      await daemon.start();
+
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+      try {
+        await daemon.stop();
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+        expect(exitSpy).not.toHaveBeenCalled();
+      } finally {
+        exitSpy.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Idle-kill timer**: `ValidatorDaemon` exits after 5 minutes of inactivity (`IDLE_TIMEOUT_MS=300000`). Timer resets on every request; `stop()` cancels it.
- **Lazy-start**: New `DaemonClient` service connects to the daemon socket; on failure spawns `exocortex daemon start` (detached), retries with backoff, then falls back to in-process validation.
- **`exocortex daemon start`** CLI command: long-running daemon process with `--socket` and `--idle-timeout` flags.
- **ESM compatibility**: `DEFAULT_SOCKET_PATH` uses `process.env.HOME`; `ShapeLoader.loadFromShapeJSON` switched to dynamic `import()` to work in both CJS and ESM jest contexts.
- **Public API**: `ValidatorDaemon`, `IDLE_TIMEOUT_MS`, `DaemonRequest`, `DaemonResponse`, `TripleClassHierarchy` exported from `exocortex` package.

## AC

- [x] Daemon стартует автоматически (lazy-start via DaemonClient)
- [x] After 5min idle — process exit (IDLE_TIMEOUT_MS timer in ValidatorDaemon)
- [x] Fallback subprocess работает с graceful degradation (in-process fallback in DaemonClient)

## Test plan

- [x] `ValidatorDaemon` idle-kill suite: 3 cases (timer fires, resets on request, stop cancels)
- [x] `DaemonClient` suite: 3 cases (direct connect, lazy-start spawn+retry, fallback in-process)
- [x] All pre-commit checks green (lint, typecheck, BDD coverage 100%, archgate)