### PR TITLE
feat(plugin): P1.10 metadataCache.on('changed') 50ms debounce SHACL validation (#P1.10)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -26,6 +26,12 @@ import {
   ServiceRegistry,
   RelationColumnSetResolver,
   LayoutSelector,
+  ShapeLoader,
+  ShaclShapeRegistry,
+  shaclValidate,
+  type ClassHierarchy as ShaclClassHierarchy,
+  DomainIRI,
+  DomainLiteral,
 } from "exocortex";
 import {
   RelationColumnSetRepository,
@@ -658,6 +664,7 @@ export default class ExocortexPlugin extends Plugin {
         this.app.metadataCache.on("changed", (file) => {
           this.handleMetadataChange(file);
           this.scheduleHotReindex(file);
+          this.scheduleValidation(file);
         }),
       );
 
@@ -1570,6 +1577,74 @@ export default class ExocortexPlugin extends Plugin {
         })();
       },
       150,
+    );
+  }
+
+  /**
+   * P1.10: Schedule a 50ms-debounced SHACL-lite validation run for a changed file.
+   *
+   * Frontmatter is already parsed by Obsidian's metadataCache when this fires,
+   * so there is no need to re-parse the file. The engine is strictly read-only —
+   * it never writes back to vault files (no save-loop risk).
+   *
+   * Timer key is per-file (`shacl-validate:<path>`) so burst edits collapse to
+   * one validation while concurrent file changes each get their own timer.
+   */
+  private scheduleValidation(file: TFile): void {
+    if (file.extension !== "md") return;
+
+    const timerName = `shacl-validate:${file.path}`;
+    this.timerManager.setTimeout(
+      timerName,
+      () => {
+        void (async () => {
+          try {
+            const store = this.sparql.getTripleStore();
+            const shapeRegistry = await ShapeLoader.loadFromRDFGraph(store);
+            if (shapeRegistry.size === 0) return;
+
+            const domainTriples = await store.match();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const algebraTriples: any[] = [];
+            for (const t of domainTriples) {
+              const subj = t.subject;
+              const pred = t.predicate;
+              const obj = t.object;
+              if (!(subj instanceof DomainIRI) || !(pred instanceof DomainIRI)) continue;
+              let algObj: { type: 'iri'; value: string } | { type: 'literal'; value: string; datatype?: string } | null = null;
+              if (obj instanceof DomainIRI) {
+                algObj = { type: 'iri', value: obj.value };
+              } else if (obj instanceof DomainLiteral) {
+                algObj = { type: 'literal', value: obj.value, datatype: obj.datatype?.value };
+              }
+              if (!algObj) continue;
+              algebraTriples.push({
+                subject: { type: 'iri', value: subj.value },
+                predicate: { type: 'iri', value: pred.value },
+                object: algObj,
+              });
+            }
+
+            const shaclRegistry = new ShaclShapeRegistry(shapeRegistry.getAll());
+            const hierarchy: ShaclClassHierarchy = { isSubClassOf: (c, p) => c === p };
+            const report = shaclValidate(algebraTriples, shaclRegistry, hierarchy);
+
+            if (!report.conforms) {
+              for (const v of report.violations) {
+                this.logger.warn(
+                  `SHACL ${v.severity} in ${file.path}: ${v.message}`,
+                );
+              }
+            }
+          } catch (err) {
+            this.logger.error(
+              `SHACL validation failed for ${file.path}`,
+              err as Error,
+            );
+          }
+        })();
+      },
+      50,
     );
   }
 

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -1933,4 +1933,84 @@ describe("ExocortexPlugin", () => {
       expect(reindexFileSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("scheduleValidation — P1.10 metadataCache.on('changed') 50ms debounce", () => {
+    // Pins the hot-validation contract introduced by P1.10.
+    // When metadataCache fires 'changed', SHACL validation must be scheduled
+    // with a 50ms debounce and the engine must never write to vault files.
+
+    let changedHandlers: Array<(file: TFile) => void> = [];
+    let loadFromRDFGraphSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      changedHandlers = [];
+      mockMetadataCache.on.mockImplementation(
+        (event: string, cb: (file: TFile) => void) => {
+          if (event === "changed") {
+            changedHandlers.push(cb);
+          }
+          return { unsubscribe: jest.fn() };
+        },
+      );
+
+      const exocortexModule = await import("exocortex");
+      loadFromRDFGraphSpy = jest
+        .spyOn(exocortexModule.ShapeLoader, "loadFromRDFGraph")
+        .mockResolvedValue({ size: 0, getAll: () => [] } as any);
+
+      await plugin.onload();
+      await flushPromises();
+    });
+
+    afterEach(() => {
+      loadFromRDFGraphSpy?.mockRestore();
+    });
+
+    const getLastChangedHandler = (): ((file: TFile) => void) => {
+      expect(changedHandlers.length).toBeGreaterThan(0);
+      return changedHandlers[changedHandlers.length - 1]!;
+    };
+
+    it("fires ShapeLoader.loadFromRDFGraph after the 50ms debounce", async () => {
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      const handler = getLastChangedHandler();
+
+      handler(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader.loadFromRDFGraph never called after debounce" },
+      );
+
+      expect(loadFromRDFGraphSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("never writes to vault files — engine is strictly read-only (no save-loop)", async () => {
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      mockVault.modify = jest.fn();
+      const handler = getLastChangedHandler();
+
+      handler(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader.loadFromRDFGraph never called" },
+      );
+      // Extra settling time to catch any deferred vault writes
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockVault.modify).not.toHaveBeenCalled();
+    });
+
+    it("ignores non-markdown files (extension !== 'md')", async () => {
+      const imageFile = { path: "cover.png", extension: "png" } as TFile;
+      const handler = getLastChangedHandler();
+
+      handler(imageFile);
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(loadFromRDFGraphSpy).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Subscribes to `metadataCache.on('changed')` with a **50ms debounced** per-file SHACL-lite validation run
- Frontmatter already parsed by Obsidian at event time — no re-parse needed
- Engine is **strictly read-only**: converts domain triples → algebra format, runs `shaclValidate()`, logs violations via `ILogger.warn()` — never writes to vault files
- Per-file debounce key `shacl-validate:<path>` collapses burst edits to one validation; non-md files skip early; empty shape registry short-circuits before triple conversion

## AC

- [x] Hook subscribes на metadataCache
- [x] 50ms debounce active
- [x] No save-loop (engine read-only)

## Test plan

- [x] 3 new unit tests in `ExocortexPlugin.test.ts` (76 total, all pass)
  - `fires ShapeLoader.loadFromRDFGraph after the 50ms debounce`
  - `never writes to vault files — engine is strictly read-only (no save-loop)`
  - `ignores non-markdown files (extension !== 'md')`
- [x] Pre-commit hooks: lint, BDD 100%, archgate all pass
- [ ] CI required checks (13): archgate · detect-changes · e2e-shard (1..6) · lint · test-bdd · test-component · test-coverage · typecheck