### PR TITLE
feat(plugin): P1.11 severity-based UI dispatch for SHACL violations

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -135,6 +135,7 @@ export default class ExocortexPlugin extends Plugin {
   private graphViewPatch!: GraphViewPatch;
   private fileLogChannel!: FileLogChannel;
   private notifier!: ObsidianNotificationService;
+  private shaclStatusBar: HTMLElement | null = null;
   // Issue #2780: tracked so the post-resolve reindex can await it before
   // calling refresh(), avoiding a concurrent clear()/convertVault() race.
   private eagerInitPromise: Promise<void> | null = null;
@@ -895,6 +896,8 @@ export default class ExocortexPlugin extends Plugin {
         );
       }
 
+      this.shaclStatusBar = this.addStatusBarItem();
+
       this.logger.info("Exocortex Plugin loaded successfully");
     } catch (error) {
       this.logger?.error("Failed to load Exocortex Plugin", error as Error);
@@ -1629,18 +1632,37 @@ export default class ExocortexPlugin extends Plugin {
             const hierarchy: ShaclClassHierarchy = { isSubClassOf: (c, p) => c === p };
             const report = shaclValidate(algebraTriples, shaclRegistry, hierarchy);
 
-            if (!report.conforms) {
-              for (const v of report.violations) {
-                this.logger.warn(
-                  `SHACL ${v.severity} in ${file.path}: ${v.message}`,
-                );
+            const violations = report.violations.filter(
+              (v) => v.severity === "sh:Violation",
+            );
+            const warnings = report.violations.filter(
+              (v) => v.severity === "sh:Warning",
+            );
+            const infos = report.violations.filter(
+              (v) => v.severity === "sh:Info",
+            );
+
+            for (const v of violations) {
+              this.notifier.warn(`SHACL: ${v.message}`);
+            }
+
+            if (this.shaclStatusBar) {
+              if (warnings.length > 0) {
+                this.shaclStatusBar.setText(`⚠ ${warnings.length}`);
+                this.shaclStatusBar.title = warnings
+                  .map((w) => w.message)
+                  .join("\n");
+              } else {
+                this.shaclStatusBar.setText("");
+                this.shaclStatusBar.title = "";
               }
             }
+
+            for (const v of infos) {
+              console.debug(`[Exocortex SHACL] Info in ${file.path}: ${v.message}`);
+            }
           } catch (err) {
-            this.logger.error(
-              `SHACL validation failed for ${file.path}`,
-              err as Error,
-            );
+            console.error("[Exocortex] SHACL engine error", err);
           }
         })();
       },

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -26,6 +26,12 @@ import {
   ServiceRegistry,
   RelationColumnSetResolver,
   LayoutSelector,
+  ShapeLoader,
+  ShaclShapeRegistry,
+  shaclValidate,
+  type ClassHierarchy as ShaclClassHierarchy,
+  DomainIRI,
+  DomainLiteral,
 } from "exocortex";
 import {
   RelationColumnSetRepository,
@@ -658,6 +664,7 @@ export default class ExocortexPlugin extends Plugin {
         this.app.metadataCache.on("changed", (file) => {
           this.handleMetadataChange(file);
           this.scheduleHotReindex(file);
+          this.scheduleValidation(file);
         }),
       );
 
@@ -1570,6 +1577,74 @@ export default class ExocortexPlugin extends Plugin {
         })();
       },
       150,
+    );
+  }
+
+  /**
+   * P1.10: Schedule a 50ms-debounced SHACL-lite validation run for a changed file.
+   *
+   * Frontmatter is already parsed by Obsidian's metadataCache when this fires,
+   * so there is no need to re-parse the file. The engine is strictly read-only —
+   * it never writes back to vault files (no save-loop risk).
+   *
+   * Timer key is per-file (`shacl-validate:<path>`) so burst edits collapse to
+   * one validation while concurrent file changes each get their own timer.
+   */
+  private scheduleValidation(file: TFile): void {
+    if (file.extension !== "md") return;
+
+    const timerName = `shacl-validate:${file.path}`;
+    this.timerManager.setTimeout(
+      timerName,
+      () => {
+        void (async () => {
+          try {
+            const store = this.sparql.getTripleStore();
+            const shapeRegistry = await ShapeLoader.loadFromRDFGraph(store);
+            if (shapeRegistry.size === 0) return;
+
+            const domainTriples = await store.match();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const algebraTriples: any[] = [];
+            for (const t of domainTriples) {
+              const subj = t.subject;
+              const pred = t.predicate;
+              const obj = t.object;
+              if (!(subj instanceof DomainIRI) || !(pred instanceof DomainIRI)) continue;
+              let algObj: { type: 'iri'; value: string } | { type: 'literal'; value: string; datatype?: string } | null = null;
+              if (obj instanceof DomainIRI) {
+                algObj = { type: 'iri', value: obj.value };
+              } else if (obj instanceof DomainLiteral) {
+                algObj = { type: 'literal', value: obj.value, datatype: obj.datatype?.value };
+              }
+              if (!algObj) continue;
+              algebraTriples.push({
+                subject: { type: 'iri', value: subj.value },
+                predicate: { type: 'iri', value: pred.value },
+                object: algObj,
+              });
+            }
+
+            const shaclRegistry = new ShaclShapeRegistry(shapeRegistry.getAll());
+            const hierarchy: ShaclClassHierarchy = { isSubClassOf: (c, p) => c === p };
+            const report = shaclValidate(algebraTriples, shaclRegistry, hierarchy);
+
+            if (!report.conforms) {
+              for (const v of report.violations) {
+                this.logger.warn(
+                  `SHACL ${v.severity} in ${file.path}: ${v.message}`,
+                );
+              }
+            }
+          } catch (err) {
+            this.logger.error(
+              `SHACL validation failed for ${file.path}`,
+              err as Error,
+            );
+          }
+        })();
+      },
+      50,
     );
   }
 

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -1933,4 +1933,84 @@ describe("ExocortexPlugin", () => {
       expect(reindexFileSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("scheduleValidation — P1.10 metadataCache.on('changed') 50ms debounce", () => {
+    // Pins the hot-validation contract introduced by P1.10.
+    // When metadataCache fires 'changed', SHACL validation must be scheduled
+    // with a 50ms debounce and the engine must never write to vault files.
+
+    let changedHandlers: Array<(file: TFile) => void> = [];
+    let loadFromRDFGraphSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      changedHandlers = [];
+      mockMetadataCache.on.mockImplementation(
+        (event: string, cb: (file: TFile) => void) => {
+          if (event === "changed") {
+            changedHandlers.push(cb);
+          }
+          return { unsubscribe: jest.fn() };
+        },
+      );
+
+      const exocortexModule = await import("exocortex");
+      loadFromRDFGraphSpy = jest
+        .spyOn(exocortexModule.ShapeLoader, "loadFromRDFGraph")
+        .mockResolvedValue({ size: 0, getAll: () => [] } as any);
+
+      await plugin.onload();
+      await flushPromises();
+    });
+
+    afterEach(() => {
+      loadFromRDFGraphSpy?.mockRestore();
+    });
+
+    const getLastChangedHandler = (): ((file: TFile) => void) => {
+      expect(changedHandlers.length).toBeGreaterThan(0);
+      return changedHandlers[changedHandlers.length - 1]!;
+    };
+
+    it("fires ShapeLoader.loadFromRDFGraph after the 50ms debounce", async () => {
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      const handler = getLastChangedHandler();
+
+      handler(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader.loadFromRDFGraph never called after debounce" },
+      );
+
+      expect(loadFromRDFGraphSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("never writes to vault files — engine is strictly read-only (no save-loop)", async () => {
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      mockVault.modify = jest.fn();
+      const handler = getLastChangedHandler();
+
+      handler(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader.loadFromRDFGraph never called" },
+      );
+      // Extra settling time to catch any deferred vault writes
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockVault.modify).not.toHaveBeenCalled();
+    });
+
+    it("ignores non-markdown files (extension !== 'md')", async () => {
+      const imageFile = { path: "cover.png", extension: "png" } as TFile;
+      const handler = getLastChangedHandler();
+
+      handler(imageFile);
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(loadFromRDFGraphSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -2013,4 +2013,167 @@ describe("ExocortexPlugin", () => {
       expect(loadFromRDFGraphSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("scheduleValidation — P1.11 severity-based UI dispatch", () => {
+    // Pins the severity-dispatch contract introduced by P1.11:
+    //   sh:Violation → new Notice(msg)
+    //   sh:Warning   → statusbar dot update
+    //   sh:Info      → console.log only
+    //   engine throw → caught, Obsidian does not crash
+
+    let changedHandlers: Array<(file: TFile) => void> = [];
+    let loadFromRDFGraphSpy: jest.SpyInstance;
+    let shaclValidateSpy: jest.SpyInstance;
+    let notifierWarnSpy: jest.SpyInstance;
+    let consoleDebugSpy: jest.SpyInstance;
+    let consoleErrorSpy: jest.SpyInstance;
+
+    const makeReport = (violations: Array<{ severity: string; message: string }>) => ({
+      conforms: !violations.some((v) => v.severity === "sh:Violation"),
+      violations,
+    });
+
+    beforeEach(async () => {
+      changedHandlers = [];
+      mockMetadataCache.on.mockImplementation(
+        (event: string, cb: (file: TFile) => void) => {
+          if (event === "changed") {
+            changedHandlers.push(cb);
+          }
+          return { unsubscribe: jest.fn() };
+        },
+      );
+
+      const exocortexModule = await import("exocortex");
+      loadFromRDFGraphSpy = jest
+        .spyOn(exocortexModule.ShapeLoader, "loadFromRDFGraph")
+        .mockResolvedValue({ size: 1, getAll: () => [] } as any);
+
+      shaclValidateSpy = jest
+        .spyOn(exocortexModule, "shaclValidate")
+        .mockReturnValue(makeReport([]) as any);
+
+      consoleDebugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+      consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      await plugin.onload();
+      await flushPromises();
+
+      // Spy on notifier.warn after onload so the instance exists
+      notifierWarnSpy = jest.spyOn((plugin as any).notifier, "warn");
+    });
+
+    afterEach(() => {
+      loadFromRDFGraphSpy?.mockRestore();
+      shaclValidateSpy?.mockRestore();
+      notifierWarnSpy?.mockRestore();
+      consoleDebugSpy?.mockRestore();
+      consoleErrorSpy?.mockRestore();
+    });
+
+    const getLastChangedHandler = (): ((file: TFile) => void) => {
+      expect(changedHandlers.length).toBeGreaterThan(0);
+      return changedHandlers[changedHandlers.length - 1]!;
+    };
+
+    it("AC1: calls notifier.warn for each sh:Violation", async () => {
+      shaclValidateSpy.mockReturnValue(
+        makeReport([
+          { severity: "sh:Violation", message: "minCount violation on label" },
+        ]) as any,
+      );
+
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      getLastChangedHandler()(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader never called" },
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(notifierWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("minCount violation on label"),
+      );
+    });
+
+    it("AC2: updates statusbar text when sh:Warning violations exist", async () => {
+      shaclValidateSpy.mockReturnValue(
+        makeReport([
+          { severity: "sh:Warning", message: "optional field missing" },
+        ]) as any,
+      );
+
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      getLastChangedHandler()(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader never called" },
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      const statusBarEl = (plugin as any).shaclStatusBar as HTMLElement | null;
+      expect(statusBarEl).not.toBeNull();
+      expect(statusBarEl?.textContent).toMatch(/⚠/);
+    });
+
+    it("AC2: clears statusbar text when no warnings", async () => {
+      shaclValidateSpy.mockReturnValue(makeReport([]) as any);
+
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      getLastChangedHandler()(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader never called" },
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      const statusBarEl = (plugin as any).shaclStatusBar as HTMLElement | null;
+      expect(statusBarEl).not.toBeNull();
+      expect(statusBarEl?.textContent ?? "").toBe("");
+    });
+
+    it("AC2: logs sh:Info to console.debug without notifier.warn", async () => {
+      shaclValidateSpy.mockReturnValue(
+        makeReport([{ severity: "sh:Info", message: "informational hint" }]) as any,
+      );
+
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      getLastChangedHandler()(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader never called" },
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(consoleDebugSpy).toHaveBeenCalledWith(
+        expect.stringContaining("informational hint"),
+      );
+      expect(notifierWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("AC3: engine throw is caught — plugin does not re-throw", async () => {
+      shaclValidateSpy.mockImplementation(() => {
+        throw new Error("engine exploded");
+      });
+
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      getLastChangedHandler()(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader never called" },
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("SHACL engine error"),
+        expect.any(Error),
+      );
+      expect(notifierWarnSpy).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Routes SHACL validation results by severity after the P1.10 debounce fires
- `sh:Violation` → `notifier.warn(message)` — visible ⚠ Notice in Obsidian UI
- `sh:Warning` → statusbar element updated with `⚠ N` count + tooltip
- `sh:Info` → `console.debug` only (no UI noise)
- Wraps engine call in try/catch — engine throws are caught, Obsidian never crashes

## AC

- [x] Notice появляется на violation (via notifier.warn → ObsidianNotificationService)
- [x] Statusbar dot на warning, очищается при отсутствии предупреждений
- [x] Engine throw → Obsidian не падает (try/catch)

## Test plan

- [x] 5 new unit tests in `ExocortexPlugin.test.ts` (P1.11 describe block)
- [x] All 81 ExocortexPlugin unit tests pass
- [x] Pre-commit checks: lint, BDD 100%, archgate all pass
- [ ] CI: 13 required checks (e2e-shard 1..6, archgate, lint, test-bdd, test-component, test-coverage, typecheck, detect-changes)

## Notes

- Uses `this.notifier` (INotificationService) per ESLint `no-restricted-syntax` rule — `new Notice()` not called directly
- `shaclStatusBar` field initialized via `addStatusBarItem()` in `onload()`
- `docs-property-validation` FAIL is a known non-blocker per DoD