### PR TITLE
feat(plugin): P1.12 enableShaclValidation feature flag — default false, settings UI, hot-toggle (#P1.12)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -1591,6 +1591,7 @@ export default class ExocortexPlugin extends Plugin {
    * one validation while concurrent file changes each get their own timer.
    */
   private scheduleValidation(file: TFile): void {
+    if (!this.settings.enableShaclValidation) return;
     if (file.extension !== "md") return;
 
     const timerName = `shacl-validate:${file.path}`;

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -124,6 +124,13 @@ export interface ExocortexSettings {
    * Issue #2992.
    */
   enableSparqlAutoExecute: boolean;
+  /**
+   * P1.12 — enable the metadataCache SHACL-lite validation debounce (P1.10).
+   * Default `false` in v15.x.0; will flip to `true` in v15.y.0 after soak.
+   * Hot-toggle: the `scheduleValidation` guard reads this flag on every
+   * invocation — no plugin reload required.
+   */
+  enableShaclValidation: boolean;
   [key: string]: unknown;
 }
 
@@ -148,4 +155,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   enableExoLayoutRenderer: true,
   showIconsInFileExplorer: true,
   enableSparqlAutoExecute: false,
+  enableShaclValidation: false,
 };

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -145,6 +145,23 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      // eslint-disable-next-line obsidianmd/ui/sentence-case -- "SHACL" is an established acronym
+      .setName("Enable SHACL validation (experimental)")
+      .setDesc(
+        "When enabled, validates frontmatter properties against SHACL shapes " +
+          "on every file save (50ms debounce). Violations are logged as warnings. " +
+          "Default off in v15.x.0; will be enabled by default after soak period.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableShaclValidation)
+          .onChange(async (value) => {
+            this.plugin.settings.enableShaclValidation = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Auto reading mode for exocortex assets")
       .setDesc(
         "When opening a note with the `exo__Instance_class` frontmatter property, automatically switch to reading mode so the exocortex layout (create / status / planning panels) is visible. Disable to keep obsidian's default view mode.",

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -1959,6 +1959,8 @@ describe("ExocortexPlugin", () => {
         .mockResolvedValue({ size: 0, getAll: () => [] } as any);
 
       await plugin.onload();
+      // P1.12: enable the flag so P1.10 contract tests can exercise the engine
+      plugin.settings.enableShaclValidation = true;
       await flushPromises();
     });
 
@@ -2011,6 +2013,71 @@ describe("ExocortexPlugin", () => {
       await new Promise((r) => setTimeout(r, 200));
 
       expect(loadFromRDFGraphSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enableShaclValidation feature flag — P1.12", () => {
+    // Pins the P1.12 contract: scheduleValidation must short-circuit when
+    // enableShaclValidation is false (default), and run when true.
+
+    let changedHandlers: Array<(file: TFile) => void> = [];
+    let loadFromRDFGraphSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      changedHandlers = [];
+      mockMetadataCache.on.mockImplementation(
+        (event: string, cb: (file: TFile) => void) => {
+          if (event === "changed") {
+            changedHandlers.push(cb);
+          }
+          return { unsubscribe: jest.fn() };
+        },
+      );
+
+      const exocortexModule = await import("exocortex");
+      loadFromRDFGraphSpy = jest
+        .spyOn(exocortexModule.ShapeLoader, "loadFromRDFGraph")
+        .mockResolvedValue({ size: 0, getAll: () => [] } as any);
+
+      await plugin.onload();
+      await flushPromises();
+    });
+
+    afterEach(() => {
+      loadFromRDFGraphSpy?.mockRestore();
+    });
+
+    const getLastChangedHandler = (): ((file: TFile) => void) => {
+      expect(changedHandlers.length).toBeGreaterThan(0);
+      return changedHandlers[changedHandlers.length - 1]!;
+    };
+
+    it("skips validation when enableShaclValidation is false (default)", async () => {
+      expect(plugin.settings.enableShaclValidation).toBe(false);
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      const handler = getLastChangedHandler();
+
+      handler(mockFile);
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(loadFromRDFGraphSpy).not.toHaveBeenCalled();
+    });
+
+    it("runs validation after hot-toggle to true without plugin reload", async () => {
+      plugin.settings.enableShaclValidation = true;
+
+      const mockFile = { path: "note.md", extension: "md" } as TFile;
+      const handler = getLastChangedHandler();
+
+      handler(mockFile);
+
+      await waitForCondition(
+        () => loadFromRDFGraphSpy.mock.calls.length > 0,
+        { timeout: 500, message: "ShapeLoader.loadFromRDFGraph never called after hot-toggle" },
+      );
+
+      expect(loadFromRDFGraphSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -127,9 +127,9 @@ describe("ExocortexSettingTab", () => {
       settingTab.display();
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
-      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 27
+      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 1 enableShaclValidation toggle (P1.12) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 28
       // Log channels section: 1 heading + 4 log level rows = 5
-      expect(MockSetting).toHaveBeenCalledTimes(27);
+      expect(MockSetting).toHaveBeenCalledTimes(28);
     });
 
     it("should render layout visibility toggle as first setting", () => {


### PR DESCRIPTION
## Summary

- Add `enableShaclValidation: boolean` to `ExocortexSettings` interface + `DEFAULT_SETTINGS` (default `false`)
- Add Settings UI toggle "Enable SHACL validation (experimental)" to `ExocortexSettingTab`
- Guard `scheduleValidation` (P1.10) with `if (!this.settings.enableShaclValidation) return` — hot-toggle without plugin reload
- Update P1.10 test suite `beforeEach` to opt-in via `plugin.settings.enableShaclValidation = true`
- Add 2 new P1.12 contract tests: flag-off skips validation; hot-toggle-on runs validation

## AC

- [x] Settings UI добавлен
- [x] Default false
- [x] Hot-toggle без plugin reload

## Test plan

- [x] 5 tests in P1.10/P1.12 suites pass
- [x] ExocortexSettingTab count assertion updated (27 → 28)
- [x] All 5034 plugin unit tests pass
- [x] Pre-commit hooks: lint, BDD 100%, archgate all pass
- [ ] CI required checks (13): archgate · detect-changes · e2e-shard (1..6) · lint · test-bdd · test-component · test-coverage · typecheck