### PR TITLE
test(shacl): P1.13 — cross-runtime parity test CLI vs Plugin SHACL engine

### DIFF
--- a/docs/CROSS_RUNTIME_PARITY.md
+++ b/docs/CROSS_RUNTIME_PARITY.md
@@ -1,0 +1,75 @@
+# Cross-Runtime Parity Contract (P1.13)
+
+## Overview
+
+The Exocortex SHACL-lite validator runs in two runtimes:
+
+| Runtime                                                              | Entry point                                       | Shape loading                  | Hierarchy                                           | Triple conversion                 |
+| -------------------------------------------------------------------- | ------------------------------------------------- | ------------------------------ | --------------------------------------------------- | --------------------------------- |
+| **CLI** (`npx @kitelev/exocortex-cli validate schema --shapes-mode`) | `packages/cli/src/commands/validate-schema.ts`    | `ShapeLoader.loadFromVaultFS`  | `TripleClassHierarchy` (rdfs:subClassOf BFS)        | `domainToAlgebraTriples()` helper |
+| **Plugin** (`ExocortexPlugin.scheduleValidation`)                    | `packages/obsidian-plugin/src/ExocortexPlugin.ts` | `ShapeLoader.loadFromRDFGraph` | `{ isSubClassOf: (c, p) => c === p }` (exact match) | Inline loop                       |
+
+Both paths call the **same** shared engine function `shaclValidate` from `@exocortex/core`, which guarantees a common foundation.
+
+## Parity Contract
+
+> For any vault where no `rdfs:subClassOf` hierarchy is used in shapes, both runtimes MUST produce a **byte-identical** `ValidationReport` (violations array sorted canonically by `focusNode` then `propertyPath`).
+
+This is the **R2 mitigation**: any divergence in engine behaviour (triple-conversion bugs, hierarchy discrepancies, sorting differences) is caught by the parity test before it reaches production.
+
+## Known Differences
+
+### 1. Hierarchy implementation
+
+| CLI                                                                                                                          | Plugin                                                                                         |
+| ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `TripleClassHierarchy` — reads `rdfs:subClassOf` triples from the vault and performs BFS to determine subclass relationships | `{ isSubClassOf: (c, p) => c === p }` — only matches if classes are identical (no inheritance) |
+
+**Impact**: vaults that declare class hierarchies via `exo__Class_superClass` will produce different results. The parity test uses a fixture without hierarchy — both implementations behave identically there.
+
+### 2. Shape loading
+
+| CLI                                                                                                                                                        | Plugin                                                                                                                                                                                  |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ShapeLoader.loadFromVaultFS` — reads `exo__Property*.md` files from the filesystem directly; resolves wikilinks without needing the target files to exist | `ShapeLoader.loadFromRDFGraph` — queries the in-memory RDF triple store for `rdf:type exo:Property` nodes; requires the wikilink targets (class definition files) to exist in the vault |
+
+**Impact**: in practice the production vault is complete, so both loaders produce the same shapes. The `ShapeLoader` unit tests cover both paths independently.
+
+## Parity Test
+
+**File**: `packages/cli/tests/integration/cross-runtime-parity.test.ts`
+
+**Fixture**: `packages/cli/tests/fixtures/shacl-integration/` (same as P1.7 golden file test)
+
+**Scenarios tested**:
+
+1. CLI engine produces violations from fixture
+2. Plugin-style engine produces same violations
+3. Violation counts match
+4. `violations` arrays are deep-equal after canonical sort
+5. JSON-serialized reports are byte-identical
+6. `conforms` field matches
+7. Both violation arrays are already sorted (canonical sort invariant)
+8. CLI `domainToAlgebraTriples()` and plugin inline conversion produce the same number of algebra triples
+
+**Run locally**:
+
+```bash
+NODE_OPTIONS="--experimental-vm-modules" \
+  npx jest --config packages/cli/jest.config.js \
+  tests/integration/cross-runtime-parity.test.ts
+```
+
+## CI Integration
+
+The parity test runs as part of the standard `test-coverage` CI check (all `packages/cli/tests/**/*.test.ts` are included automatically via `jest.config.js`). No additional CI configuration is required.
+
+## Regenerating the Golden File
+
+The underlying fixture golden file (`golden-report.json`) is shared with P1.7:
+
+```bash
+UPDATE_GOLDEN=1 NODE_OPTIONS="--experimental-vm-modules" \
+  npx jest --config packages/cli/jest.config.js \
+  tests/integration/validate-schema-shapes.integration.test.ts
+```

--- a/packages/cli/tests/integration/cross-runtime-parity.test.ts
+++ b/packages/cli/tests/integration/cross-runtime-parity.test.ts
@@ -1,0 +1,224 @@
+/**
+ * P1.13 — Cross-runtime parity test
+ *
+ * Verifies that the CLI SHACL engine and the plugin SHACL engine produce
+ * byte-identical ValidationReports when run against the same vault fixture.
+ *
+ * Both paths use the same underlying `shaclValidate` function.
+ * The differences being tested:
+ *
+ *   CLI path:
+ *     - ShapeLoader.loadFromVaultFS (FS-based shape loading)
+ *     - domainToAlgebraTriples() helper for triple conversion
+ *     - TripleClassHierarchy (rdfs:subClassOf-aware BFS hierarchy)
+ *
+ *   Plugin-style path:
+ *     - ShapeLoader.loadFromVaultFS (same shapes, different code path would be
+ *       loadFromRDFGraph — but that requires class-definition files in vault;
+ *       shape loading parity is covered by ShapeLoader unit tests)
+ *     - Inline triple conversion loop (mirrors ExocortexPlugin.ts scheduleValidation)
+ *     - Simple { isSubClassOf: (c, p) => c === p } hierarchy (production plugin)
+ *
+ * R2 mitigation: divergence in triple-conversion or hierarchy logic will surface here.
+ *
+ * Golden fixture: tests/fixtures/shacl-integration/
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+} from "@jest/globals";
+import * as path from "path";
+import * as url from "url";
+
+const _currentFile = url.fileURLToPath(import.meta.url);
+const _currentDir = path.dirname(_currentFile);
+
+const FIXTURE_DIR = path.resolve(_currentDir, "../fixtures/shacl-integration");
+
+const { runShapesValidation, domainToAlgebraTriples } = await import(
+  "../../src/commands/validate-schema.js"
+);
+
+const {
+  NoteToRDFConverter,
+  ShapeLoader,
+  shaclValidate,
+  ShaclShapeRegistry,
+  DomainIRI,
+  DomainLiteral,
+} = await import("exocortex");
+
+const { FileSystemVaultAdapter } = await import(
+  "../../src/adapters/FileSystemVaultAdapter.js"
+);
+
+type Violation = {
+  focusNode: string;
+  propertyPath: string;
+  severity: string;
+  message: string;
+  actualValue?: string;
+  expectedRange?: string;
+};
+
+function sortViolations(violations: Violation[]): Violation[] {
+  return [...violations].sort((a, b) => {
+    const c = a.focusNode.localeCompare(b.focusNode);
+    return c !== 0 ? c : a.propertyPath.localeCompare(b.propertyPath);
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let cliViolations: any[];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let pluginStyleViolations: any[];
+let cliConforms: boolean;
+let pluginStyleConforms: boolean;
+
+beforeAll(async () => {
+  const adapter = new FileSystemVaultAdapter(FIXTURE_DIR);
+  const converter = new NoteToRDFConverter(adapter);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const domainTriples = (await converter.convertVault()) as any[];
+
+  // ── CLI path (P1.7 golden path) ────────────────────────────────────────────
+  // Uses: ShapeLoader.loadFromVaultFS + domainToAlgebraTriples + TripleClassHierarchy
+  const cliReport = await runShapesValidation(FIXTURE_DIR, domainTriples);
+  cliViolations = cliReport.violations;
+  cliConforms = cliReport.conforms;
+
+  // ── Plugin-style path ──────────────────────────────────────────────────────
+  // Uses: same shapes (loadFromVaultFS) + inline triple conversion (mirrors plugin)
+  //       + simple { isSubClassOf: (c, p) => c === p } hierarchy (matches production plugin)
+  //
+  // This path exercises the same code branches that ExocortexPlugin.ts scheduleValidation()
+  // uses, except for shape loading (loadFromRDFGraph requires class-definition files in vault;
+  // both loaders are covered in ShapeLoader unit tests).
+
+  // 1. Load shapes using the same FS loader as CLI
+  const pluginShapeRegistry = await ShapeLoader.loadFromVaultFS(FIXTURE_DIR);
+
+  // 2. Inline triple conversion — mirrors ExocortexPlugin.ts scheduleValidation() exactly
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pluginAlgebraTriples: any[] = [];
+  for (const t of domainTriples) {
+    const subj = t.subject;
+    const pred = t.predicate;
+    const obj = t.object;
+    if (!(subj instanceof DomainIRI) || !(pred instanceof DomainIRI)) continue;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let algObj: any = null;
+    if (obj instanceof DomainIRI) {
+      algObj = { type: "iri", value: obj.value };
+    } else if (obj instanceof DomainLiteral) {
+      algObj = { type: "literal", value: obj.value, datatype: obj.datatype?.value };
+    }
+    if (!algObj) continue;
+    pluginAlgebraTriples.push({
+      subject: { type: "iri", value: subj.value },
+      predicate: { type: "iri", value: pred.value },
+      object: algObj,
+    });
+  }
+
+  // 3. CLI algebra triple conversion (for comparison)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cliAlgebraTriples = domainToAlgebraTriples(domainTriples as any);
+
+  // 4. Build SHACL registry (same shapes) + simple hierarchy (production plugin behaviour)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const shaclRegistry = new ShaclShapeRegistry(pluginShapeRegistry.getAll() as any);
+  const simpleHierarchy = { isSubClassOf: (c: string, p: string) => c === p };
+
+  // 5. Run the shared shaclValidate engine with plugin-style inputs
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pluginReport = shaclValidate(pluginAlgebraTriples as any, shaclRegistry as any, simpleHierarchy);
+  pluginStyleViolations = pluginReport.violations;
+  pluginStyleConforms = pluginReport.conforms;
+
+  // Store CLI algebra triples for structural comparison
+  (global as Record<string, unknown>)._cliAlgebraTriples = cliAlgebraTriples;
+  (global as Record<string, unknown>)._pluginAlgebraTriples = pluginAlgebraTriples;
+});
+
+describe("P1.13 — Cross-runtime parity: CLI vs Plugin SHACL engine", () => {
+  describe("CLI engine baseline", () => {
+    it("produces at least one violation from fixture", () => {
+      expect(cliViolations.length).toBeGreaterThan(0);
+    });
+
+    it("reports conforms=false for violation-containing fixture", () => {
+      expect(cliConforms).toBe(false);
+    });
+  });
+
+  describe("Plugin-style engine baseline", () => {
+    it("produces at least one violation from fixture", () => {
+      expect(pluginStyleViolations.length).toBeGreaterThan(0);
+    });
+
+    it("reports conforms=false for violation-containing fixture", () => {
+      expect(pluginStyleConforms).toBe(false);
+    });
+  });
+
+  describe("Parity: CLI vs Plugin-style", () => {
+    it("both runtimes report the same number of violations", () => {
+      expect(pluginStyleViolations.length).toBe(cliViolations.length);
+    });
+
+    it("violations are deep-equal after canonical sort by focusNode+propertyPath", () => {
+      const sortedCli = sortViolations(cliViolations as Violation[]);
+      const sortedPlugin = sortViolations(pluginStyleViolations as Violation[]);
+      expect(sortedPlugin).toEqual(sortedCli);
+    });
+
+    it("reports are bytes-identical when JSON-serialized (canonical sort)", () => {
+      const sortedCli = sortViolations(cliViolations as Violation[]);
+      const sortedPlugin = sortViolations(pluginStyleViolations as Violation[]);
+      expect(JSON.stringify(sortedPlugin, null, 2)).toBe(
+        JSON.stringify(sortedCli, null, 2),
+      );
+    });
+
+    it("conforms field matches between runtimes", () => {
+      expect(pluginStyleConforms).toBe(cliConforms);
+    });
+  });
+
+  describe("Canonical sort invariant (both runtimes)", () => {
+    it("CLI violations are already sorted by focusNode then propertyPath", () => {
+      for (let i = 0; i < cliViolations.length - 1; i++) {
+        const a = cliViolations[i] as Violation;
+        const b = cliViolations[i + 1] as Violation;
+        const cmp =
+          a.focusNode !== b.focusNode
+            ? a.focusNode.localeCompare(b.focusNode)
+            : a.propertyPath.localeCompare(b.propertyPath);
+        expect(cmp).toBeLessThanOrEqual(0);
+      }
+    });
+
+    it("plugin-style violations are already sorted by focusNode then propertyPath", () => {
+      for (let i = 0; i < pluginStyleViolations.length - 1; i++) {
+        const a = pluginStyleViolations[i] as Violation;
+        const b = pluginStyleViolations[i + 1] as Violation;
+        const cmp =
+          a.focusNode !== b.focusNode
+            ? a.focusNode.localeCompare(b.focusNode)
+            : a.propertyPath.localeCompare(b.propertyPath);
+        expect(cmp).toBeLessThanOrEqual(0);
+      }
+    });
+  });
+
+  describe("Triple conversion parity", () => {
+    it("CLI and plugin inline conversion produce same number of algebra triples", () => {
+      const cliTriples = (global as Record<string, unknown>)._cliAlgebraTriples as unknown[];
+      const pluginTriples = (global as Record<string, unknown>)._pluginAlgebraTriples as unknown[];
+      expect(pluginTriples.length).toBe(cliTriples.length);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `packages/cli/tests/integration/cross-runtime-parity.test.ts` — 11 test cases verifying CLI and plugin-style SHACL engines produce byte-identical ValidationReports from the same vault fixture
- Adds `docs/CROSS_RUNTIME_PARITY.md` — parity contract documentation (known differences, how to run, CI integration)
- R2 mitigation: any future divergence in triple-conversion or hierarchy logic will surface here

## What is tested

| Scenario | Description |
|---|---|
| CLI baseline | `runShapesValidation` produces violations + conforms=false |
| Plugin baseline | Inline conversion + simple hierarchy produces violations + conforms=false |
| Parity: count | Both runtimes report same number of violations |
| Parity: deep-equal | Violations are deep-equal after canonical sort by focusNode+propertyPath |
| Parity: bytes | JSON-serialized reports are byte-identical |
| Parity: conforms | conforms field matches |
| Sort invariant | Both violation arrays are already sorted (canonical sort) |
| Triple conversion | CLI `domainToAlgebraTriples()` and plugin inline loop produce same algebra triple count |

## Design note

The parity test uses `ShapeLoader.loadFromVaultFS` for both paths (not `loadFromRDFGraph` for the plugin path). This is because `loadFromRDFGraph` requires class-definition files in the vault to resolve wikilinks — the test fixture only contains shape and data files. Both loaders are covered by ShapeLoader unit tests. The parity test focuses on engine divergence: hierarchy implementation and triple conversion.

## Test plan

- [x] `cross-runtime-parity.test.ts` — 11 tests pass locally
- [x] P1.7 golden file test unchanged (18/18 pass)
- [x] Pre-commit hooks pass (BDD 100%, archgate pass)
- [x] No TS errors in new files