### PR TITLE
feat(shacl): P3.2 — closed-world mode for ShaclLiteValidator

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -505,6 +505,7 @@ export {
   type ClassHierarchy,
   type Severity,
   type Shape as ShaclShape,
+  type ValidatorOptions,
 } from "./services/ShaclLiteValidator";
 export * from "./application/errors";
 export {

--- a/packages/exocortex/src/services/ShaclLiteValidator.ts
+++ b/packages/exocortex/src/services/ShaclLiteValidator.ts
@@ -30,6 +30,15 @@ export interface ClassHierarchy {
   isSubClassOf(child: string, parent: string): boolean;
 }
 
+export interface ValidatorOptions {
+  /**
+   * When true, any property predicate that has no registered shape emits sh:Warning.
+   * CQ4 SPARQL shapes are the source of truth — the legacy validate-properties whitelist
+   * file is deprecated in favour of this closed-world engine mode.
+   */
+  closedWorldMode?: boolean;
+}
+
 export class ShapeRegistry {
   private readonly shapeMap: Map<string, Shape>;
   readonly typePredicateIRI: string;
@@ -59,6 +68,7 @@ export function validate(
   triples: Triple[],
   registry: ShapeRegistry,
   hierarchy: ClassHierarchy,
+  options?: ValidatorOptions,
 ): ValidationReport {
   const subjectClasses = new Map<string, string[]>();
   const subjectProps = new Map<string, Map<string, Array<IRI | Literal>>>();
@@ -180,6 +190,22 @@ export function validate(
               });
             }
           }
+        }
+      }
+    }
+  }
+
+  if (options?.closedWorldMode) {
+    for (const subjectIRI of allSubjects) {
+      const props = subjectProps.get(subjectIRI) ?? new Map<string, Array<IRI | Literal>>();
+      for (const predicateIRI of props.keys()) {
+        if (!registry.hasShape(predicateIRI)) {
+          violations.push({
+            focusNode: subjectIRI,
+            propertyPath: predicateIRI,
+            severity: 'sh:Warning',
+            message: `Unknown property: <${predicateIRI}> has no registered shape`,
+          });
         }
       }
     }

--- a/packages/exocortex/src/services/ValidatorDaemon.ts
+++ b/packages/exocortex/src/services/ValidatorDaemon.ts
@@ -8,6 +8,7 @@ export interface DaemonRequest {
   triples: Triple[];
   registryPath: string;
   subclassTriples?: Triple[];
+  closedWorldMode?: boolean;
 }
 
 export interface DaemonResponse {
@@ -108,7 +109,7 @@ export class ValidatorDaemon {
       const req = JSON.parse(raw) as DaemonRequest;
       const registry = await this.getRegistry(req.registryPath);
       const hierarchy = new ClassHierarchy(req.subclassTriples ?? []);
-      const report = validate(req.triples, registry, hierarchy);
+      const report = validate(req.triples, registry, hierarchy, { closedWorldMode: req.closedWorldMode });
       response = { report };
     } catch (err) {
       response = { error: err instanceof Error ? err.message : String(err) };

--- a/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
+++ b/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
@@ -770,3 +770,95 @@ describe('validate — edge cases', () => {
     expect(report.violations).toHaveLength(0);
   });
 });
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Suite 12: Closed-world mode
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('validate — closed-world mode', () => {
+  it('T58: closedWorldMode=false (default) — unknown property emits no violation', () => {
+    const triples = [
+      typeTriple('node:A', `${EMS}Effort`),
+      litTriple('node:A', `${EMS}Effort_unknownProp`, 'value'),
+    ];
+    const report = validate(triples, makeRegistry([]), flatHierarchy);
+    expect(report.violations).toHaveLength(0);
+    expect(report.conforms).toBe(true);
+  });
+
+  it('T59: closedWorldMode=true — unknown property emits sh:Warning', () => {
+    const triples = [
+      typeTriple('node:A', `${EMS}Effort`),
+      litTriple('node:A', `${EMS}Effort_unknownProp`, 'value'),
+    ];
+    const report = validate(triples, makeRegistry([]), flatHierarchy, { closedWorldMode: true });
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0].severity).toBe('sh:Warning');
+    expect(report.violations[0].propertyPath).toBe(`${EMS}Effort_unknownProp`);
+    expect(report.violations[0].message).toContain('Unknown property');
+  });
+
+  it('T60: closedWorldMode=true — unknown property warning does not affect conforms', () => {
+    const triples = [
+      typeTriple('node:A', `${EMS}Effort`),
+      litTriple('node:A', `${EMS}Effort_unknownProp`, 'value'),
+    ];
+    const report = validate(triples, makeRegistry([]), flatHierarchy, { closedWorldMode: true });
+    expect(report.conforms).toBe(true);
+    expect(report.violations).toHaveLength(1);
+  });
+
+  it('T61: closedWorldMode=true — known property (has shape) emits no extra warning', () => {
+    const shape = makeShape({ propertyIRI: `${EMS}Effort_status` });
+    const triples = [
+      typeTriple('node:A', `${EMS}Effort`),
+      litTriple('node:A', `${EMS}Effort_status`, 'Doing'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy, { closedWorldMode: true });
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T62: closedWorldMode=true — typePredicateIRI triple does not trigger unknown-property warning', () => {
+    const triples = [typeTriple('node:A', `${EMS}Effort`)];
+    const report = validate(triples, makeRegistry([]), flatHierarchy, { closedWorldMode: true });
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T63: closedWorldMode=true — multiple unknown properties emit one warning each', () => {
+    const triples = [
+      typeTriple('node:A', `${EMS}Effort`),
+      litTriple('node:A', `${EMS}Effort_propA`, 'val1'),
+      litTriple('node:A', `${EMS}Effort_propB`, 'val2'),
+    ];
+    const report = validate(triples, makeRegistry([]), flatHierarchy, { closedWorldMode: true });
+    expect(report.violations).toHaveLength(2);
+    expect(report.violations.every((v) => v.severity === 'sh:Warning')).toBe(true);
+  });
+
+  it('T64: closedWorldMode=true — mix of known and unknown properties', () => {
+    const shape = makeShape({ propertyIRI: `${EMS}Effort_status` });
+    const triples = [
+      typeTriple('node:A', `${EMS}Effort`),
+      litTriple('node:A', `${EMS}Effort_status`, 'Doing'),
+      litTriple('node:A', `${EMS}Effort_unknownProp`, 'value'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy, { closedWorldMode: true });
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0].propertyPath).toBe(`${EMS}Effort_unknownProp`);
+    expect(report.violations[0].severity).toBe('sh:Warning');
+  });
+
+  it('T65: closedWorldMode=true — sh:Violation from shape plus Warning from unknown prop', () => {
+    const shape = makeShape({ propertyIRI: `${EMS}Effort_status`, minCount: 1, severity: 'sh:Violation' });
+    const triples = [
+      typeTriple('node:A', `${EMS}Effort`),
+      litTriple('node:A', `${EMS}Effort_unknownProp`, 'value'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy, { closedWorldMode: true });
+    expect(report.conforms).toBe(false);
+    const violation = report.violations.find((v) => v.severity === 'sh:Violation');
+    const warning = report.violations.find((v) => v.severity === 'sh:Warning');
+    expect(violation).toBeDefined();
+    expect(warning).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ValidatorOptions.closedWorldMode` flag to `validate()` function in `ShaclLiteValidator`
- When `closedWorldMode: true`, any property predicate without a registered shape emits `sh:Warning` (not `sh:Violation`, not silent)
- `ValidatorDaemon.DaemonRequest` extended with `closedWorldMode?: boolean` to propagate the flag through the daemon protocol
- `ValidatorOptions` exported from package `index.ts`
- 8 new unit tests T58–T65 covering all closed-world scenarios

## Acceptance Criteria

- [x] Closed-world flag в engine config (`ValidatorOptions.closedWorldMode: boolean`)
- [x] Unknown property → `sh:Warning` emit (не `sh:Violation`, не silent)
- [x] Whitelist file deprecated — CQ4 SPARQL является source of truth (задокументировано в JSDoc)

## Test plan

- [x] T58: `closedWorldMode=false` (default) — unknown property emits no violation
- [x] T59: `closedWorldMode=true` — unknown property emits `sh:Warning`
- [x] T60: `closedWorldMode=true` — warning does not affect `conforms`
- [x] T61: `closedWorldMode=true` — known property (has shape) emits no extra warning
- [x] T62: `closedWorldMode=true` — `typePredicateIRI` triple does not trigger warning
- [x] T63: `closedWorldMode=true` — multiple unknown properties emit one warning each
- [x] T64: `closedWorldMode=true` — mix of known and unknown properties
- [x] T65: `closedWorldMode=true` — `sh:Violation` from shape plus Warning from unknown prop