### PR TITLE
fix(cli): fix backfill suggester NX filter and substring false positives

### DIFF
--- a/packages/cli/src/commands/backfill-suggest.ts
+++ b/packages/cli/src/commands/backfill-suggest.ts
@@ -109,8 +109,10 @@ function extractAliases(content: string): string[] {
   return aliases.filter(Boolean);
 }
 
-function isConceptFile(content: string): boolean {
-  return content.includes(IMS_CONCEPT_UUID);
+export function isConceptFile(content: string): boolean {
+  const fm = parseFrontmatterRaw(content);
+  const classVal = fm["exo__Instance_class"] ?? "";
+  return classVal.includes(IMS_CONCEPT_UUID);
 }
 
 export function walkMdFiles(dir: string): string[] {
@@ -153,13 +155,15 @@ export function loadConcepts(vaultPath: string): ConceptEntry[] {
   return concepts;
 }
 
+export const MIN_LABEL_FOR_SUBSTRING = 4;
+
 export function scoreMatch(text: string, term: string): number {
   const textLower = text.toLowerCase();
   const termLower = term.toLowerCase();
-  if (!termLower || termLower.length < 2) return 0;
+  if (!termLower) return 0;
 
   if (textLower === termLower) return 1.0;
-  if (textLower.includes(termLower)) return 0.85;
+  if (termLower.length >= MIN_LABEL_FOR_SUBSTRING && textLower.includes(termLower)) return 0.85;
   return 0;
 }
 

--- a/packages/cli/tests/unit/commands/backfill-suggest.test.ts
+++ b/packages/cli/tests/unit/commands/backfill-suggest.test.ts
@@ -4,6 +4,8 @@ import {
   scoreMatch,
   computeCandidates,
   isAutoApproved,
+  isConceptFile,
+  MIN_LABEL_FOR_SUBSTRING,
 } from "../../../src/commands/backfill-suggest.js";
 
 describe("backfill suggest — scoreMatch", () => {
@@ -26,11 +28,67 @@ describe("backfill suggest — scoreMatch", () => {
   it("returns 0 for single-char term (too short)", () => {
     expect(scoreMatch("a text", "a")).toBe(0);
   });
+
+  it("MIN_LABEL_FOR_SUBSTRING constant equals 4", () => {
+    expect(MIN_LABEL_FOR_SUBSTRING).toBe(4);
+  });
+
+  it("returns 0 for 2-char term substring (below MIN_LABEL_FOR_SUBSTRING)", () => {
+    expect(scoreMatch("a beautiful day", "be")).toBe(0);
+  });
+
+  it("returns 0 for 3-char term substring (below MIN_LABEL_FOR_SUBSTRING)", () => {
+    expect(scoreMatch("knowledge management", "man")).toBe(0);
+  });
+
+  it("still returns 1.0 exact match for short term", () => {
+    expect(scoreMatch("ai", "AI")).toBe(1.0);
+  });
+
+  it("returns 0.85 for substring with term of exactly 4 chars", () => {
+    expect(scoreMatch("knowledge management", "know")).toBe(0.85);
+  });
+});
+
+describe("backfill suggest — isConceptFile", () => {
+  const CONCEPT_UUID = "dda12c48-6886-4624-8710-ed4ba92ce2b3";
+
+  const conceptFrontmatter = `---
+exo__Asset_uid: abc-123
+exo__Asset_label: My Concept
+exo__Instance_class: "[[${CONCEPT_UUID}|ims__Concept]]"
+---
+This is the body text.`;
+
+  const nonConceptFrontmatter = `---
+exo__Asset_uid: def-456
+exo__Asset_label: My Task
+exo__Instance_class: "[[1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task]]"
+---
+This text references a concept wikilink [[${CONCEPT_UUID}|ims__Concept]] in the body.`;
+
+  const noFrontmatter = `Just plain body text mentioning ${CONCEPT_UUID} without frontmatter.`;
+
+  it("returns true when exo__Instance_class frontmatter contains concept UUID", () => {
+    expect(isConceptFile(conceptFrontmatter)).toBe(true);
+  });
+
+  it("returns false when concept UUID appears only in body, not in frontmatter class", () => {
+    expect(isConceptFile(nonConceptFrontmatter)).toBe(false);
+  });
+
+  it("returns false for file with no frontmatter", () => {
+    expect(isConceptFile(noFrontmatter)).toBe(false);
+  });
+
+  it("returns false for file with empty content", () => {
+    expect(isConceptFile("")).toBe(false);
+  });
 });
 
 describe("backfill suggest — computeCandidates", () => {
   const concepts: ConceptEntry[] = [
-    { uid: "uid-1", label: "Knowledge Management", aliases: ["KM", "PKM"], filePath: "/vault/c1.md" },
+    { uid: "uid-1", label: "Knowledge Management", aliases: ["KM", "PKMS"], filePath: "/vault/c1.md" },
     { uid: "uid-2", label: "Distributed Systems", aliases: ["DS"], filePath: "/vault/c2.md" },
     { uid: "uid-3", label: "Graph Database", aliases: ["Graph DB"], filePath: "/vault/c3.md" },
     { uid: "uid-4", label: "Totally Unrelated Topic", aliases: [], filePath: "/vault/c4.md" },
@@ -88,7 +146,7 @@ describe("backfill suggest — computeCandidates", () => {
 
   it("detects alias match with lower confidence than direct label match", () => {
     const candidates = computeCandidates(
-      "PKM notes",
+      "PKMS notes",
       "",
       "",
       concepts,
@@ -97,6 +155,13 @@ describe("backfill suggest — computeCandidates", () => {
     expect(kmCandidate).toBeDefined();
     expect(kmCandidate!.confidence).toBeLessThan(1.0);
     expect(kmCandidate!.match_type).toContain("alias");
+  });
+
+  it("does NOT match 3-char alias as substring (MIN_LABEL_FOR_SUBSTRING=4)", () => {
+    // "PKM" is 3 chars — below MIN_LABEL_FOR_SUBSTRING, so no substring match
+    const candidates = computeCandidates("PKM notes", "", "", concepts);
+    const kmCandidate = candidates.find((c) => c.concept_uid === "uid-1");
+    expect(kmCandidate).toBeUndefined();
   });
 
   it("body match has lower confidence than label match", () => {


### PR DESCRIPTION
## Problem

Two bugs in the `backfill suggest` command introduced in #3072:

1. **B1 — NX filter false positives**: `isConceptFile()` used `content.includes(UUID)` which matched the concept UUID anywhere in the file body (e.g. wikilinks in non-concept assets). This caused non-concept files to be incorrectly identified as concepts.

2. **B2 — Short label false positives**: `scoreMatch` filtered out terms shorter than 2 chars, but 2–3 char concept labels/aliases (like "AI", "KM", "PKM") still caused ~98% false positive substring matches (e.g. "ai" matches "maintaining", "daily", "trail").

## Fix

- `isConceptFile()` now checks only frontmatter: parses `exo__Instance_class` field and checks if it contains the UUID — ignoring body text
- `scoreMatch` adds `MIN_LABEL_FOR_SUBSTRING = 4`: substring matching is only allowed when `term.length >= 4`; exact matching still works for any non-empty term
- Both `isConceptFile` and `MIN_LABEL_FOR_SUBSTRING` are exported for direct testability

## Tests

Added 8 new unit tests:
- `isConceptFile`: returns true only when UUID is in frontmatter class field; returns false when UUID appears only in body, no frontmatter, or empty content
- `MIN_LABEL_FOR_SUBSTRING`: constant equals 4; 2-char and 3-char terms do NOT substring-match; exact match still works for short terms; 4-char terms DO substring-match
- Updated existing alias test to use a 4-char alias ("PKMS") and added explicit test verifying 3-char alias ("PKM") no longer produces substring matches

## Verification

```
Tests: 29 passed (backfill-suggest unit suite)
Pre-commit: all checks green (lint-staged, BDD 100%, archgate pass)
Pre-existing failures: 6 starter-kit integration tests fail on base commit too (unrelated)
```