### PR TITLE
fix(cli): use path-based concept detection in backfill suggester

### DIFF
--- a/packages/cli/src/commands/backfill-suggest.ts
+++ b/packages/cli/src/commands/backfill-suggest.ts
@@ -3,8 +3,6 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { homedir } from "os";
 import { join, resolve } from "path";
 
-// ims__Concept class UUID
-const IMS_CONCEPT_UUID = "dda12c48-6886-4624-8710-ed4ba92ce2b3";
 
 export interface ConceptEntry {
   uid: string;
@@ -109,10 +107,8 @@ function extractAliases(content: string): string[] {
   return aliases.filter(Boolean);
 }
 
-export function isConceptFile(content: string): boolean {
-  const fm = parseFrontmatterRaw(content);
-  const classVal = fm["exo__Instance_class"] ?? "";
-  return classVal.includes(IMS_CONCEPT_UUID);
+export function isConceptFile(filePath: string, _content: string): boolean {
+  return filePath.includes("/concepts/");
 }
 
 export function walkMdFiles(dir: string): string[] {
@@ -142,7 +138,7 @@ export function loadConcepts(vaultPath: string): ConceptEntry[] {
     } catch {
       continue;
     }
-    if (!isConceptFile(content)) continue;
+    if (!isConceptFile(filePath, content)) continue;
 
     const fm = parseFrontmatterRaw(content);
     const uid = fm["exo__Asset_uid"] ?? "";

--- a/packages/cli/tests/unit/commands/backfill-suggest.test.ts
+++ b/packages/cli/tests/unit/commands/backfill-suggest.test.ts
@@ -51,38 +51,24 @@ describe("backfill suggest — scoreMatch", () => {
 });
 
 describe("backfill suggest — isConceptFile", () => {
-  const CONCEPT_UUID = "dda12c48-6886-4624-8710-ed4ba92ce2b3";
-
-  const conceptFrontmatter = `---
-exo__Asset_uid: abc-123
-exo__Asset_label: My Concept
-exo__Instance_class: "[[${CONCEPT_UUID}|ims__Concept]]"
----
-This is the body text.`;
-
-  const nonConceptFrontmatter = `---
-exo__Asset_uid: def-456
-exo__Asset_label: My Task
-exo__Instance_class: "[[1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task]]"
----
-This text references a concept wikilink [[${CONCEPT_UUID}|ims__Concept]] in the body.`;
-
-  const noFrontmatter = `Just plain body text mentioning ${CONCEPT_UUID} without frontmatter.`;
-
-  it("returns true when exo__Instance_class frontmatter contains concept UUID", () => {
-    expect(isConceptFile(conceptFrontmatter)).toBe(true);
+  it("returns true for file inside /concepts/ directory", () => {
+    expect(isConceptFile("/vault/03 Knowledge/concepts/abc-123.md", "")).toBe(true);
   });
 
-  it("returns false when concept UUID appears only in body, not in frontmatter class", () => {
-    expect(isConceptFile(nonConceptFrontmatter)).toBe(false);
+  it("returns true for nested path inside /concepts/", () => {
+    expect(isConceptFile("/vault/03 Knowledge/concepts/sub/def-456.md", "")).toBe(true);
   });
 
-  it("returns false for file with no frontmatter", () => {
-    expect(isConceptFile(noFrontmatter)).toBe(false);
+  it("returns false for file outside /concepts/ directory", () => {
+    expect(isConceptFile("/vault/03 Knowledge/aiKnow/ghi-789.md", "some content")).toBe(false);
   });
 
-  it("returns false for file with empty content", () => {
-    expect(isConceptFile("")).toBe(false);
+  it("returns false for file whose name contains 'concepts' but not as directory segment", () => {
+    expect(isConceptFile("/vault/03 Knowledge/my-concepts-index.md", "")).toBe(false);
+  });
+
+  it("returns false for empty path", () => {
+    expect(isConceptFile("", "")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Bug**: `isConceptFile` in v15.161.1 checked for `ims__Concept` UUID (`dda12c48`) in `exo__Instance_class` frontmatter, but concept files use `ims__ConceptSchema` class (different UUID) → 0 concepts loaded from 2750
- **Fix**: Detect concepts by file path (`/concepts/` directory segment) instead of class UUID
- **Tests**: Updated `isConceptFile` tests to validate path-based detection (5 test cases)

## Changes

- `packages/cli/src/commands/backfill-suggest.ts`: `isConceptFile(filePath, _content)` — checks `filePath.includes("/concepts/")`, removed `IMS_CONCEPT_UUID` constant
- `packages/cli/tests/unit/commands/backfill-suggest.test.ts`: replaced UUID-based tests with path-based tests

## Regression history

- v15.161.0 (#3072): B2 self-referential bug
- v15.161.1 (#3073): fixed B2, introduced B3 (wrong UUID for concept class)
- v15.161.2 (this PR): path-based detection, no UUID dependency

## Test plan

- [x] All 30 unit tests pass (`backfill-suggest.test.ts`)
- [x] Pre-commit hooks: lint-staged + BDD coverage 100% + archgate pass
- [x] CI required checks