### PR TITLE
feat(cli): add body_word_exact match type for backfill auto-approval

### DIFF
--- a/packages/cli/src/commands/backfill-suggest.ts
+++ b/packages/cli/src/commands/backfill-suggest.ts
@@ -24,6 +24,7 @@ export type MatchType =
   | "label_substring"
   | "description_exact"
   | "description_substring"
+  | "body_word_exact"
   | "body_exact"
   | "body_substring"
   | "alias_label_exact"
@@ -153,6 +154,24 @@ export function loadConcepts(vaultPath: string): ConceptEntry[] {
 
 export const MIN_LABEL_FOR_SUBSTRING = 4;
 
+const STOP_WORDS = new Set([
+  "the", "and", "for", "but", "with", "this", "that", "from", "have",
+  "been", "are", "was", "will", "can", "not", "all", "any", "both",
+  "each", "few", "more", "most", "other", "some", "such", "than", "then",
+  "when", "where", "which", "while", "who", "how", "its", "into", "over",
+]);
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function matchesWordBoundary(text: string, term: string): boolean {
+  if (term.length < MIN_LABEL_FOR_SUBSTRING) return false;
+  if (STOP_WORDS.has(term.toLowerCase())) return false;
+  const pattern = new RegExp(`\\b${escapeRegex(term)}\\b`, "i");
+  return pattern.test(text);
+}
+
 export function scoreMatch(text: string, term: string): number {
   const textLower = text.toLowerCase();
   const termLower = term.toLowerCase();
@@ -186,6 +205,13 @@ export function computeCandidates(
     }
 
     if (bestScore < 1.0) {
+      if (matchesWordBoundary(bodyLower, concept.label) || matchesWordBoundary(descLower, concept.label)) {
+        if (0.90 > bestScore) {
+          bestScore = 0.90;
+          bestType = "body_word_exact";
+        }
+      }
+
       const descScore = scoreMatch(descLower, concept.label);
       const descAdjusted = descScore === 1.0 ? 0.75 : descScore > 0 ? 0.65 : 0;
       if (descAdjusted > bestScore) {
@@ -250,7 +276,11 @@ export function isAutoApproved(
 ): boolean {
   return (
     candidate.confidence >= threshold &&
-    (candidate.match_type === "label_exact" || candidate.match_type === "alias_label_exact")
+    (
+      candidate.match_type === "label_exact" ||
+      candidate.match_type === "alias_label_exact" ||
+      candidate.match_type === "body_word_exact"
+    )
   );
 }
 

--- a/packages/cli/tests/unit/commands/backfill-suggest.test.ts
+++ b/packages/cli/tests/unit/commands/backfill-suggest.test.ts
@@ -5,6 +5,7 @@ import {
   computeCandidates,
   isAutoApproved,
   isConceptFile,
+  matchesWordBoundary,
   MIN_LABEL_FOR_SUBSTRING,
 } from "../../../src/commands/backfill-suggest.js";
 
@@ -47,6 +48,44 @@ describe("backfill suggest — scoreMatch", () => {
 
   it("returns 0.85 for substring with term of exactly 4 chars", () => {
     expect(scoreMatch("knowledge management", "know")).toBe(0.85);
+  });
+});
+
+describe("backfill suggest — matchesWordBoundary", () => {
+  it("returns true when term appears as a standalone word", () => {
+    expect(matchesWordBoundary("used typescript interfaces to define the schema", "TypeScript")).toBe(true);
+  });
+
+  it("returns false when term is a substring of a larger word", () => {
+    expect(matchesWordBoundary("javascriptengine.run()", "Java")).toBe(false);
+  });
+
+  it("returns false for stop word terms", () => {
+    expect(matchesWordBoundary("this is the answer for all", "the")).toBe(false);
+    expect(matchesWordBoundary("made for testing", "for")).toBe(false);
+  });
+
+  it("returns false for terms shorter than MIN_LABEL_FOR_SUBSTRING", () => {
+    expect(matchesWordBoundary("go is a language", "go")).toBe(false);
+    expect(matchesWordBoundary("a ai b", "ai")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchesWordBoundary("used TYPESCRIPT daily", "typescript")).toBe(true);
+    expect(matchesWordBoundary("used typescript daily", "TypeScript")).toBe(true);
+  });
+
+  it("matches at start and end of string", () => {
+    expect(matchesWordBoundary("typescript is great", "TypeScript")).toBe(true);
+    expect(matchesWordBoundary("we use typescript", "TypeScript")).toBe(true);
+  });
+
+  it("returns false when term is not present", () => {
+    expect(matchesWordBoundary("totally different text", "TypeScript")).toBe(false);
+  });
+
+  it("returns true for multi-word concept labels when present as phrase", () => {
+    expect(matchesWordBoundary("knowledge management systems are important", "knowledge management")).toBe(true);
   });
 });
 
@@ -159,6 +198,59 @@ describe("backfill suggest — computeCandidates", () => {
       expect(labelTop.confidence).toBeGreaterThan(bodyTop.confidence);
     }
   });
+
+  it("detects body_word_exact when concept label is a standalone word in body", () => {
+    const candidates = computeCandidates(
+      "T2.1: Implement backfill-suggester",
+      "",
+      "used typescript interfaces to define the schema",
+      [{ uid: "uid-ts", label: "TypeScript", aliases: [], filePath: "/vault/c-ts.md" }],
+    );
+    const top = candidates[0];
+    expect(top).toBeDefined();
+    expect(top.match_type).toBe("body_word_exact");
+    expect(top.confidence).toBe(0.90);
+  });
+
+  it("does NOT produce body_word_exact when concept label is substring of larger word", () => {
+    const candidates = computeCandidates(
+      "Some title",
+      "",
+      "javascriptengine runs the code",
+      [{ uid: "uid-java", label: "Java", aliases: [], filePath: "/vault/c-java.md" }],
+    );
+    const javaCandidate = candidates.find((c) => c.concept_uid === "uid-java");
+    if (javaCandidate) {
+      expect(javaCandidate.match_type).not.toBe("body_word_exact");
+    }
+  });
+
+  it("detects body_word_exact in description field as well", () => {
+    const candidates = computeCandidates(
+      "Some unrelated title",
+      "This note covers TypeScript best practices",
+      "",
+      [{ uid: "uid-ts", label: "TypeScript", aliases: [], filePath: "/vault/c-ts.md" }],
+    );
+    const top = candidates[0];
+    expect(top).toBeDefined();
+    expect(top.match_type).toBe("body_word_exact");
+    expect(top.confidence).toBe(0.90);
+  });
+
+  it("body_word_exact confidence 0.90 beats description_exact 0.75", () => {
+    // If body has word-boundary match AND description has exact match, body_word_exact wins
+    const candidates = computeCandidates(
+      "Some title",
+      "blockchain",
+      "this note covers blockchain technology in detail",
+      concepts,
+    );
+    const top = candidates.find((c) => c.concept_uid === "uid-5");
+    expect(top).toBeDefined();
+    expect(top!.match_type).toBe("body_word_exact");
+    expect(top!.confidence).toBe(0.90);
+  });
 });
 
 describe("backfill suggest — isAutoApproved", () => {
@@ -201,6 +293,29 @@ describe("backfill suggest — isAutoApproved", () => {
   it("respects custom threshold", () => {
     expect(isAutoApproved(substringCandidate, 0.5)).toBe(false);
     expect(isAutoApproved(exactLabelCandidate, 1.1)).toBe(false);
+  });
+
+  it("auto-approves body_word_exact with confidence ≥ threshold", () => {
+    const wordExactCandidate: BackfillCandidate = {
+      concept_uid: "uid-ts",
+      concept_label: "TypeScript",
+      concept_file: "/vault/c-ts.md",
+      confidence: 0.90,
+      match_type: "body_word_exact",
+    };
+    expect(isAutoApproved(wordExactCandidate, 0.8)).toBe(true);
+    expect(isAutoApproved(wordExactCandidate, 0.95)).toBe(false);
+  });
+
+  it("does NOT auto-approve body_word_exact below threshold", () => {
+    const lowWordExact: BackfillCandidate = {
+      concept_uid: "uid-ts",
+      concept_label: "TypeScript",
+      concept_file: "/vault/c-ts.md",
+      confidence: 0.70,
+      match_type: "body_word_exact",
+    };
+    expect(isAutoApproved(lowWordExact, 0.8)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `body_word_exact` match type: concept label as complete word (`\b{label}\b`, case-insensitive) in aiKnow body or description
- Confidence: **0.90** (auto-approvable at ≥0.80 threshold)
- Guards: minimum 4-char label (MIN_LABEL_FOR_SUBSTRING), stop-word exclusion ("the", "and", "for", etc.)
- `isAutoApproved()` extended to include `body_word_exact` alongside existing `label_exact`/`alias_label_exact`

## Why

aiKnow labels are descriptive phrases ("T2.1: Implement backfill-suggester.ts") while concept labels are short nouns ("TypeScript"). This mismatch gave 0 auto-approvals across 659 aiKnow assets. The new match type catches "concept mentioned in content" as a strong signal.

## Test plan

- [x] `matchesWordBoundary()` — 8 tests: standalone word, substring guard, stop words, short labels, case-insensitivity, multi-word phrases
- [x] `computeCandidates()` — 4 new tests: body match, description match, non-match for substring of larger word, confidence ordering vs description_exact
- [x] `isAutoApproved()` — 2 new tests: auto-approves ≥threshold, rejects <threshold
- [x] All 44 backfill-suggest tests pass; all 96 CLI unit test suites pass (1680 tests)
- [x] BDD coverage 100%, archgate ✅, lint-staged ✅