### PR TITLE
feat(cli): add stdout DONE: fallback completion detection (T1.4)

### DIFF
--- a/packages/cli/src/services/SpawnService.ts
+++ b/packages/cli/src/services/SpawnService.ts
@@ -1,5 +1,5 @@
 import { exec } from "child_process";
-import { mkdirSync, existsSync } from "fs";
+import { mkdirSync, existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 import path from "path";
 import { atomicUpdateFrontmatter } from "./AtomicFrontmatterService.js";
@@ -17,14 +17,25 @@ export type ExecFn = (
   callback: (error: Error | null, stdout: string, stderr: string) => void,
 ) => unknown;
 
+/** Result of vault status polling: completion detected or deadline reached. */
+export type VaultPollResult = "done" | "timeout";
+
 export interface SpawnDeps {
   execFn?: ExecFn;
   atomicUpdate?: typeof atomicUpdateFrontmatter;
   /** Polling interval for tmux window monitoring (ms). Default: 5000. */
   pollIntervalMs?: number;
+  /** Custom file reader for vault status polling (injectable for tests). */
+  readFileFn?: (filePath: string) => string;
+  /** Polling interval for vault status detection (ms). Default: 10_000. */
+  vaultPollIntervalMs?: number;
+  /** Shared cancellation signal — set `cancelled: true` to stop vault polling. */
+  vaultCancelSignal?: { cancelled: boolean };
 }
 
 const LOG_DIR = path.join(homedir(), ".exocortex", "ai-task-logs");
+
+const COMPLETION_STATUS_FRAGMENTS = ["EffortStatusDone", "EffortStatusReview"];
 
 function uuid8(uuid: string): string {
   return uuid.replace(/-/g, "").slice(0, 8);
@@ -42,6 +53,59 @@ function makeExecPromise(execFn: ExecFn) {
         else resolve({ stdout, stderr });
       });
     });
+}
+
+function isCompletionStatus(content: string): boolean {
+  // Match any quoting style (single, double, or bare) since YAML serializers vary.
+  const m = content.match(/ems__Effort_status:.*\[\[([^\]]+)\]\]/);
+  if (!m) return false;
+  return COMPLETION_STATUS_FRAGMENTS.some((f) => m[1].includes(f));
+}
+
+/**
+ * Polls the vault task file until ems__Effort_status flips to Done or Review.
+ * Returns 'done' when a completion status is detected, 'timeout' if the
+ * deadline passes without a flip.
+ *
+ * The poll interval defaults to 10 s; set deps.vaultPollIntervalMs for tests.
+ * Set deps.vaultCancelSignal.cancelled = true to abort early.
+ */
+export function pollVaultStatus(
+  taskFilePath: string,
+  timeoutMs: number,
+  deps: SpawnDeps = {},
+): Promise<VaultPollResult> {
+  const readFn =
+    deps.readFileFn ?? ((p: string) => readFileSync(p, "utf8"));
+  const pollMs = deps.vaultPollIntervalMs ?? 10_000;
+  const signal = deps.vaultCancelSignal;
+
+  return new Promise((resolve) => {
+    const deadline = Date.now() + timeoutMs;
+
+    function check() {
+      if (signal?.cancelled) {
+        resolve("timeout");
+        return;
+      }
+      try {
+        const content = readFn(taskFilePath);
+        if (isCompletionStatus(content)) {
+          resolve("done");
+          return;
+        }
+      } catch {
+        // file temporarily unreadable — keep waiting
+      }
+      if (Date.now() >= deadline) {
+        resolve("timeout");
+        return;
+      }
+      setTimeout(check, pollMs);
+    }
+
+    setTimeout(check, pollMs);
+  });
 }
 
 /**
@@ -83,7 +147,17 @@ export function monitorSession(
 
 /**
  * Spawns a detached Claude session in a tmux window.
- * Returns exit code: 0 = success, 1 = failed, 124 = timeout.
+ *
+ * Primary completion detection (T1.3): polls the vault task file every
+ * vaultPollIntervalMs (default 10 s) for ems__Effort_status flipping to
+ * Done or Review.
+ *
+ * Secondary detection: monitors the tmux window via list-windows.
+ *
+ * Returns:
+ *   0   — vault status flipped OR window exited cleanly
+ *   1   — spawn failed
+ *   124 — timeout without status flip (hand off to Completion detection B / T1.4)
  */
 export async function spawnSession(
   opts: SpawnOptions,
@@ -126,17 +200,34 @@ export async function spawnSession(
   });
 
   const timeoutMs = opts.timeoutMinutes * 60 * 1000;
-  const exitCode = await monitorSession(windowName, timeoutMs, {
-    execFn,
-    pollIntervalMs: deps.pollIntervalMs,
-  });
+  const vaultCancelSignal = { cancelled: false };
 
-  if (exitCode === 124) {
-    try {
-      await execPromise(`tmux kill-window -t ${windowName}`);
-    } catch {
-      // window may already be gone
+  type RaceResult =
+    | { source: "vault"; result: VaultPollResult }
+    | { source: "tmux"; code: number };
+
+  const winner: RaceResult = await Promise.race([
+    pollVaultStatus(opts.taskFilePath, timeoutMs, {
+      readFileFn: deps.readFileFn,
+      vaultPollIntervalMs: deps.vaultPollIntervalMs,
+      vaultCancelSignal,
+    }).then((result) => ({ source: "vault" as const, result })),
+    monitorSession(windowName, timeoutMs, {
+      execFn,
+      pollIntervalMs: deps.pollIntervalMs,
+    }).then((code) => ({ source: "tmux" as const, code })),
+  ]);
+
+  vaultCancelSignal.cancelled = true;
+
+  if (winner.source === "vault") {
+    if (winner.result === "done") {
+      // Vault status flip detected — session complete; clean up the tmux window.
+      await execPromise(`tmux kill-window -t ${windowName}`).catch(() => {});
+      return 0;
     }
+    // Vault polling timed out — hand off to Completion detection B (T1.4).
+    await execPromise(`tmux kill-window -t ${windowName}`).catch(() => {});
     updateFn(opts.taskFilePath, {
       "ems__Effort_status": "[[ems__EffortStatusFailed]]",
       "aiTask__Task_lastError": "timeout exceeded",
@@ -145,5 +236,18 @@ export async function spawnSession(
     return 124;
   }
 
+  // tmux window exited first.
+  if (winner.code === 124) {
+    // tmux-side timeout — treat same as vault timeout.
+    await execPromise(`tmux kill-window -t ${windowName}`).catch(() => {});
+    updateFn(opts.taskFilePath, {
+      "ems__Effort_status": "[[ems__EffortStatusFailed]]",
+      "aiTask__Task_lastError": "timeout exceeded",
+      "exo__Asset_updatedAt": nowIso(),
+    });
+    return 124;
+  }
+
+  // Window closed naturally — success.
   return 0;
 }

--- a/packages/cli/src/services/SpawnService.ts
+++ b/packages/cli/src/services/SpawnService.ts
@@ -128,6 +128,26 @@ export async function countClaudeSessions(execFn: ExecFn = exec): Promise<number
 }
 
 /**
+ * Completion detection B (T1.4): scans the last 20 lines of the Claude stdout
+ * log for a line starting with "DONE:" (case-insensitive). Returns true if the
+ * marker is found, false otherwise (file unreadable counts as not found).
+ */
+export function checkStdoutDone(
+  logFilePath: string,
+  readFileFn?: (filePath: string) => string,
+): boolean {
+  try {
+    const read = readFileFn ?? ((p: string) => readFileSync(p, "utf8"));
+    const content = read(logFilePath);
+    const lines = content.trimEnd().split("\n");
+    const tail = lines.slice(-20);
+    return tail.some((line) => /^DONE:/i.test(line.trim()));
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Polls tmux list-windows until the named window disappears or timeout elapses.
  * Returns 0 if window exited cleanly, 124 if timed out.
  */
@@ -270,8 +290,15 @@ export async function spawnSession(
       await execPromise(`tmux kill-window -t ${windowName}`).catch(() => {});
       return 0;
     }
-    // Vault polling timed out — hand off to Completion detection B (T1.4).
+    // Vault polling timed out — Completion detection B (T1.4): check stdout log.
     await execPromise(`tmux kill-window -t ${windowName}`).catch(() => {});
+    if (checkStdoutDone(logFile, deps.readFileFn)) {
+      updateFn(opts.taskFilePath, {
+        "ems__Effort_status": "[[ems__EffortStatusReview]]",
+        "exo__Asset_updatedAt": nowIso(),
+      });
+      return 0;
+    }
     updateFn(opts.taskFilePath, {
       "ems__Effort_status": "[[ems__EffortStatusFailed]]",
       "aiTask__Task_lastError": "timeout exceeded",
@@ -282,8 +309,15 @@ export async function spawnSession(
 
   // tmux window exited first.
   if (winner.code === 124) {
-    // tmux-side timeout — treat same as vault timeout.
+    // tmux-side timeout — Completion detection B (T1.4): check stdout log.
     await execPromise(`tmux kill-window -t ${windowName}`).catch(() => {});
+    if (checkStdoutDone(logFile, deps.readFileFn)) {
+      updateFn(opts.taskFilePath, {
+        "ems__Effort_status": "[[ems__EffortStatusReview]]",
+        "exo__Asset_updatedAt": nowIso(),
+      });
+      return 0;
+    }
     updateFn(opts.taskFilePath, {
       "ems__Effort_status": "[[ems__EffortStatusFailed]]",
       "aiTask__Task_lastError": "timeout exceeded",

--- a/packages/cli/tests/unit/services/SpawnService.test.ts
+++ b/packages/cli/tests/unit/services/SpawnService.test.ts
@@ -1,5 +1,10 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
-import { spawnSession, monitorSession, type ExecFn } from "../../../src/services/SpawnService.js";
+import {
+  spawnSession,
+  monitorSession,
+  pollVaultStatus,
+  type ExecFn,
+} from "../../../src/services/SpawnService.js";
 import { type AtomicUpdateResult } from "../../../src/services/AtomicFrontmatterService.js";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
@@ -63,6 +68,109 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
   jest.useRealTimers();
+});
+
+// --- pollVaultStatus ---
+
+describe("pollVaultStatus", () => {
+  it("returns 'done' when status is EffortStatusDone", async () => {
+    jest.useFakeTimers();
+
+    const content = buildMd({
+      exo__Asset_uid: TASK_UUID,
+      "ems__Effort_status": "[[ems__EffortStatusDone]]",
+    });
+    const promise = pollVaultStatus(taskFile, 60_000, {
+      readFileFn: () => content,
+      vaultPollIntervalMs: 1_000,
+    });
+
+    await jest.advanceTimersByTimeAsync(1_100);
+    expect(await promise).toBe("done");
+  });
+
+  it("returns 'done' when status is EffortStatusReview", async () => {
+    jest.useFakeTimers();
+
+    const content = buildMd({
+      exo__Asset_uid: TASK_UUID,
+      "ems__Effort_status": "[[ems__EffortStatusReview]]",
+    });
+    const promise = pollVaultStatus(taskFile, 60_000, {
+      readFileFn: () => content,
+      vaultPollIntervalMs: 1_000,
+    });
+
+    await jest.advanceTimersByTimeAsync(1_100);
+    expect(await promise).toBe("done");
+  });
+
+  it("returns 'done' for UUID|label wikilink format", async () => {
+    jest.useFakeTimers();
+
+    const content =
+      `---\nexo__Asset_uid: ${TASK_UUID}\n` +
+      `ems__Effort_status: "[[7b9b3116-7c3c-438c-9618-94fe301320a6|ems__EffortStatusDone]]"\n---\n`;
+    const promise = pollVaultStatus(taskFile, 60_000, {
+      readFileFn: () => content,
+      vaultPollIntervalMs: 1_000,
+    });
+
+    await jest.advanceTimersByTimeAsync(1_100);
+    expect(await promise).toBe("done");
+  });
+
+  it("returns 'timeout' when status never flips before deadline", async () => {
+    jest.useFakeTimers();
+
+    const content = buildMd({ exo__Asset_uid: TASK_UUID });
+    const promise = pollVaultStatus(taskFile, 3_000, {
+      readFileFn: () => content,
+      vaultPollIntervalMs: 1_000,
+    });
+
+    await jest.advanceTimersByTimeAsync(10_000);
+    expect(await promise).toBe("timeout");
+  });
+
+  it("returns 'timeout' on next check when cancel signal is set", async () => {
+    jest.useFakeTimers();
+
+    const content = buildMd({ exo__Asset_uid: TASK_UUID });
+    const vaultCancelSignal = { cancelled: false };
+    const promise = pollVaultStatus(taskFile, 60_000, {
+      readFileFn: () => content,
+      vaultPollIntervalMs: 1_000,
+      vaultCancelSignal,
+    });
+
+    await jest.advanceTimersByTimeAsync(500);
+    vaultCancelSignal.cancelled = true;
+    await jest.advanceTimersByTimeAsync(1_100);
+    expect(await promise).toBe("timeout");
+  });
+
+  it("handles file read errors gracefully and keeps polling until status flips", async () => {
+    jest.useFakeTimers();
+
+    let callCount = 0;
+    const readFileFn = () => {
+      callCount++;
+      if (callCount < 3) throw new Error("ENOENT: no such file");
+      return buildMd({
+        exo__Asset_uid: TASK_UUID,
+        "ems__Effort_status": "[[ems__EffortStatusDone]]",
+      });
+    };
+
+    const promise = pollVaultStatus(taskFile, 60_000, {
+      readFileFn,
+      vaultPollIntervalMs: 1_000,
+    });
+
+    await jest.advanceTimersByTimeAsync(4_000);
+    expect(await promise).toBe("done");
+  });
 });
 
 // --- spawnSession ---
@@ -161,6 +269,76 @@ describe("spawnSession", () => {
     expect(spawnCalls.length).toBeGreaterThanOrEqual(2);
     expect([0, 1, 124]).toContain(code1);
     expect([0, 1, 124]).toContain(code2);
+  });
+
+  it("returns 0 when vault status flips to Done before tmux window closes", async () => {
+    jest.useFakeTimers();
+
+    let fileContent = buildMd({ exo__Asset_uid: TASK_UUID });
+
+    const execFn: ExecFn = (cmd, cb) => {
+      if (cmd.includes("list-windows")) {
+        cb(null, `${WINDOW_NAME}\n`, ""); // window stays alive
+      } else {
+        cb(null, "", "");
+      }
+      return {};
+    };
+
+    const promise = spawnSession(BASE_OPTS, {
+      execFn,
+      atomicUpdate: mockAtomicUpdate,
+      pollIntervalMs: 600_000, // tmux won't fire before vault
+      readFileFn: () => fileContent,
+      vaultPollIntervalMs: 5_000,
+    });
+
+    // Advance past first vault poll — status not yet set
+    await jest.advanceTimersByTimeAsync(5_100);
+
+    // Flip vault status to Done
+    fileContent = buildMd({
+      exo__Asset_uid: TASK_UUID,
+      "ems__Effort_status": "[[ems__EffortStatusDone]]",
+    });
+
+    // Advance past next vault poll — status detected
+    await jest.advanceTimersByTimeAsync(5_100);
+    const code = await promise;
+
+    expect(code).toBe(0);
+  });
+
+  it("returns 124 when vault times out without status flip (T1.4 handoff)", async () => {
+    jest.useFakeTimers();
+
+    const timeoutMinutes = 8 / 60; // 8_000 ms
+    const opts = { ...BASE_OPTS, timeoutMinutes };
+
+    const execFn: ExecFn = (cmd, cb) => {
+      if (cmd.includes("list-windows")) {
+        cb(null, `${WINDOW_NAME}\n`, ""); // window stays alive
+      } else {
+        cb(null, "", "");
+      }
+      return {};
+    };
+
+    const promise = spawnSession(opts, {
+      execFn,
+      atomicUpdate: mockAtomicUpdate,
+      pollIntervalMs: 600_000, // tmux won't fire before vault
+      readFileFn: () => buildMd({ exo__Asset_uid: TASK_UUID }), // never completes
+      vaultPollIntervalMs: 5_000,
+    });
+
+    await jest.advanceTimersByTimeAsync(20_000);
+    const code = await promise;
+
+    expect(code).toBe(124);
+    expect(
+      atomicCalls.some(([, u]) => u["aiTask__Task_lastError"] === "timeout exceeded"),
+    ).toBe(true);
   });
 });
 

--- a/packages/cli/tests/unit/services/SpawnService.test.ts
+++ b/packages/cli/tests/unit/services/SpawnService.test.ts
@@ -1,15 +1,16 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
-import type { ExecFn } from "../../../src/services/SpawnService.js";
 import {
   spawnSession,
   monitorSession,
   pollVaultStatus,
   countClaudeSessions,
+  checkStdoutDone,
   CLAUDE_SESSION_CAP,
+  type ExecFn,
 } from "../../../src/services/SpawnService.js";
 import type { AtomicUpdateResult } from "../../../src/services/AtomicFrontmatterService.js";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { tmpdir, homedir } from "os";
 import path from "path";
 import yaml from "js-yaml";
 
@@ -435,6 +436,46 @@ describe("spawnSession", () => {
     expect(code).toBe(0);
   });
 
+  it("returns 0 and sets Review when vault times out but stdout contains DONE: (T1.4)", async () => {
+    jest.useFakeTimers();
+
+    const timeoutMinutes = 8 / 60; // 8_000 ms
+    const opts = { ...BASE_OPTS, timeoutMinutes };
+
+    const execFn: ExecFn = (cmd, cb) => {
+      if (cmd.includes("list-windows")) {
+        cb(null, `${WINDOW_NAME}\n`, ""); // window stays alive
+      } else {
+        cb(null, "", "");
+      }
+      return {};
+    };
+
+    const logPath = path.join(homedir(), ".exocortex", "ai-task-logs", `${TASK_UUID}.log`);
+
+    const promise = spawnSession(opts, {
+      execFn,
+      atomicUpdate: mockAtomicUpdate,
+      pollIntervalMs: 600_000,
+      readFileFn: (p) => {
+        if (p === logPath) return "Claude output\nDONE: task completed successfully\n";
+        return buildMd({ exo__Asset_uid: TASK_UUID }); // vault — no status flip
+      },
+      vaultPollIntervalMs: 5_000,
+    });
+
+    await jest.advanceTimersByTimeAsync(20_000);
+    const code = await promise;
+
+    expect(code).toBe(0);
+    expect(
+      atomicCalls.some(([, u]) => u["ems__Effort_status"] === "[[ems__EffortStatusReview]]"),
+    ).toBe(true);
+    expect(
+      atomicCalls.some(([, u]) => u["aiTask__Task_lastError"] !== undefined),
+    ).toBe(false);
+  });
+
   it("returns 124 when vault times out without status flip (T1.4 handoff)", async () => {
     jest.useFakeTimers();
 
@@ -465,6 +506,45 @@ describe("spawnSession", () => {
     expect(
       atomicCalls.some(([, u]) => u["aiTask__Task_lastError"] === "timeout exceeded"),
     ).toBe(true);
+  });
+});
+
+// --- checkStdoutDone ---
+
+describe("checkStdoutDone", () => {
+  it("returns true when last lines contain 'DONE:' marker", () => {
+    const log = "some output\nprocessing...\nDONE: task completed\n";
+    expect(checkStdoutDone("/any.log", () => log)).toBe(true);
+  });
+
+  it("returns true when DONE: appears within last 20 lines", () => {
+    const body = Array.from({ length: 15 }, (_, i) => `line ${i}`).join("\n");
+    const log = `${body}\nDONE: finished\n`;
+    expect(checkStdoutDone("/any.log", () => log)).toBe(true);
+  });
+
+  it("returns false when DONE: is not in last 20 lines", () => {
+    const earlyDone = "DONE: old run\n" + Array.from({ length: 25 }, (_, i) => `line ${i}`).join("\n");
+    expect(checkStdoutDone("/any.log", () => earlyDone)).toBe(false);
+  });
+
+  it("returns false when log has no DONE: marker at all", () => {
+    const log = "Claude output...\nsome work done\nfinal line\n";
+    expect(checkStdoutDone("/any.log", () => log)).toBe(false);
+  });
+
+  it("returns false when log file is unreadable", () => {
+    expect(checkStdoutDone("/nonexistent/path.log")).toBe(false);
+  });
+
+  it("matches DONE: case-insensitively", () => {
+    const log = "work done\ndone: lowercase marker\n";
+    expect(checkStdoutDone("/any.log", () => log)).toBe(true);
+  });
+
+  it("ignores DONE: that appears mid-line (not at line start)", () => {
+    const log = "output containing DONE: in middle of line\n";
+    expect(checkStdoutDone("/any.log", () => log)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `checkStdoutDone(logFilePath, readFileFn?)` — exported, injectable function that scans the last 20 lines of the Claude session stdout log for a `DONE:` marker (case-insensitive, must be at line start)
- Integrates into both timeout paths in `spawnSession`: vault-polling timeout and tmux-side timeout
- When `DONE:` found → sets `ems__Effort_status` to `[[ems__EffortStatusReview]]` and returns `0`
- When absent → sets `Failed` with `"timeout exceeded"` error (passes to `ai-task-recover`)

## Acceptance Criteria

- [x] Срабатывает только если frontmatter polling (T1.3) не зафиксировал флип за timeout
- [x] stdout буферизируется и парсится на `DONE:` паттерн  
- [x] При наличии маркера → runner сам пишет status=Review в vault
- [x] При отсутствии маркера → task переходит в Failed

## Test plan

- 7 unit tests for `checkStdoutDone`: DONE: present/absent, case-insensitive, mid-line ignored, unreadable file
- T1.4 spawnSession integration test: vault times out, log contains `DONE:` → returns 0 + Review status
- Existing T1.3 timeout test unchanged: no DONE: in log → returns 124 + Failed
- All 30 SpawnService tests green

## Dependencies

Builds on T1.3 (`feature/t13-vault-status-poller`, PR #3079). This branch includes T1.1+T1.2+T1.3 changes.