### PR TITLE
feat(cli): add OrphanRecoveryService and recover command (T2.2)

### DIFF
--- a/packages/cli/src/commands/recover.ts
+++ b/packages/cli/src/commands/recover.ts
@@ -1,0 +1,84 @@
+import { Command } from "commander";
+import { resolve, join } from "path";
+import { existsSync } from "fs";
+import { homedir } from "os";
+import {
+  detectOrphans,
+  recoverOrphan,
+} from "../services/OrphanRecoveryService.js";
+
+export interface RecoverCommandOptions {
+  vault: string;
+  dryRun: boolean;
+  apply: boolean;
+}
+
+function defaultVault(): string {
+  return (
+    process.env.EXOCORTEX_VAULT ??
+    join(homedir(), "vault-2025")
+  );
+}
+
+export function recoverCommand(): Command {
+  return new Command("recover")
+    .description(
+      "Detect and recover orphaned claude-child tmux sessions. " +
+      "A session is orphaned when the corresponding vault task is not in Doing status. " +
+      "Default mode: dry-run (no changes). Use --apply to perform recovery.",
+    )
+    .option("--vault <path>", "Path to Obsidian vault", defaultVault())
+    .option("--dry-run", "List orphans without applying changes (default)", false)
+    .option("--apply", "Apply orphan recovery: set Failed + kill tmux session", false)
+    .action(async (options: RecoverCommandOptions) => {
+      const vaultPath = resolve(options.vault);
+      if (!existsSync(vaultPath)) {
+        console.error(`[recover] vault not found: ${vaultPath}`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const dryRun = !options.apply;
+
+      console.log(
+        `[recover] vault=${vaultPath} mode=${dryRun ? "dry-run" : "apply"}`,
+      );
+
+      const orphans = await detectOrphans(vaultPath);
+
+      if (orphans.length === 0) {
+        console.log("[recover] No orphaned claude-child sessions found.");
+        return;
+      }
+
+      console.log(`[recover] Found ${orphans.length} orphan(s):`);
+      for (const o of orphans) {
+        const fp = o.taskFilePath ?? "(not found in vault)";
+        console.log(`  session=${o.sessionName}  uuid=${o.taskUuid}  reason=${o.reason}`);
+        console.log(`    file=${fp}`);
+      }
+
+      if (dryRun) {
+        console.log(
+          "[recover] Dry-run mode: no changes applied. Use --apply to recover.",
+        );
+        return;
+      }
+
+      let recovered = 0;
+      let errors = 0;
+      for (const o of orphans) {
+        const result = await recoverOrphan(o, false);
+        if (result.ok) {
+          recovered++;
+          console.log(`[recover] RECOVERED: ${o.sessionName}`);
+        } else {
+          errors++;
+          console.error(`[recover] ERROR recovering ${o.sessionName}: ${result.error}`);
+        }
+      }
+
+      console.log(`[recover] Done: recovered=${recovered} errors=${errors}`);
+      if (errors > 0) process.exitCode = 1;
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import { convertCommand } from "./commands/convert.js";
 import { migrateRelColSetToExoLayoutCommand } from "./commands/migrate-relcolset-to-exolayout.js";
 import { daemonCommand } from "./commands/daemon.js";
 import { backfillCommand } from "./commands/backfill.js";
+import { recoverCommand } from "./commands/recover.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -85,6 +86,7 @@ export function createProgram(version?: string): Command {
   program.addCommand(migrateRelColSetToExoLayoutCommand());
   program.addCommand(daemonCommand());
   program.addCommand(backfillCommand());
+  program.addCommand(recoverCommand());
 
   return program;
 }

--- a/packages/cli/src/services/OrphanRecoveryService.ts
+++ b/packages/cli/src/services/OrphanRecoveryService.ts
@@ -1,0 +1,240 @@
+import { exec } from "child_process";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { atomicUpdateFrontmatter } from "./AtomicFrontmatterService.js";
+
+export type ExecFn = (
+  cmd: string,
+  callback: (error: Error | null, stdout: string, stderr: string) => void,
+) => unknown;
+
+export type UpdateFn = typeof atomicUpdateFrontmatter;
+
+// Session name patterns for tasks spawned by ai-task-worker / orchestrator.
+// Full UUID pattern: claude-child-<uuid> (bash worker — tmux new-session)
+const FULL_UUID_RE =
+  /^claude-child-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/;
+// Short prefix pattern: claude-child-<8chars>-<digits> (orchestrator)
+const SHORT_UUID_RE = /^claude-child-([0-9a-f]{8})-(\d+)$/;
+
+const DOING_FRAGMENT = "EffortStatusDoing";
+
+export interface ParsedSession {
+  sessionName: string;
+  /** Full UUID (full-type) or 8-char prefix (short-type). */
+  uuid: string;
+  type: "full" | "short";
+}
+
+export interface OrphanSession {
+  sessionName: string;
+  taskUuid: string;
+  taskFilePath: string | null;
+  reason: string;
+}
+
+export interface RecoveryResult {
+  orphans: number;
+  recovered: number;
+  skipped: number;
+  errors: number;
+}
+
+function makeExecPromise(execFn: ExecFn) {
+  return (cmd: string): Promise<string> =>
+    new Promise((resolve, reject) => {
+      execFn(cmd, (err, stdout, stderr) => {
+        if (err) reject(Object.assign(err, { stdout, stderr }));
+        else resolve(stdout);
+      });
+    });
+}
+
+/** List all tmux sessions whose name matches the claude-child patterns. */
+export async function listClaudeChildSessions(
+  execFn: ExecFn = exec,
+): Promise<ParsedSession[]> {
+  const run = makeExecPromise(execFn);
+  let stdout: string;
+  try {
+    stdout = await run("tmux list-sessions -F '#{session_name}' 2>/dev/null");
+  } catch {
+    return [];
+  }
+
+  const sessions: ParsedSession[] = [];
+  for (const name of stdout.split("\n").map((l) => l.trim()).filter(Boolean)) {
+    const fullMatch = FULL_UUID_RE.exec(name);
+    if (fullMatch) {
+      sessions.push({ sessionName: name, uuid: fullMatch[1], type: "full" });
+      continue;
+    }
+    const shortMatch = SHORT_UUID_RE.exec(name);
+    if (shortMatch) {
+      sessions.push({ sessionName: name, uuid: shortMatch[1], type: "short" });
+    }
+  }
+  return sessions;
+}
+
+/**
+ * Recursively search for a vault markdown file whose name (without extension)
+ * matches the given UUID or UUID prefix.
+ */
+export function findVaultFile(
+  vaultDir: string,
+  uuidOrPrefix: string,
+  type: "full" | "short",
+): string | null {
+  let result: string | null = null;
+  const prefix = uuidOrPrefix.toLowerCase();
+
+  function walk(dir: string): void {
+    if (result) return;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (result) return;
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.name.endsWith(".md")) {
+        const base = entry.name.slice(0, -3).toLowerCase();
+        if (type === "full" && base === prefix) {
+          result = fullPath;
+        } else if (type === "short" && base.startsWith(prefix)) {
+          result = fullPath;
+        }
+      }
+    }
+  }
+
+  walk(vaultDir);
+  return result;
+}
+
+/** Return true if the vault file's ems__Effort_status is Doing. */
+export function isTaskDoing(filePath: string, readFn?: (p: string) => string): boolean {
+  try {
+    const read = readFn ?? ((p: string) => readFileSync(p, "utf8"));
+    const content = read(filePath);
+    const m = content.match(/ems__Effort_status\s*:.*\[\[([^\]]+)\]\]/);
+    if (!m) return false;
+    return m[1].includes(DOING_FRAGMENT);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect orphaned claude-child tmux sessions:
+ * a session is orphaned when either the corresponding vault task is not found
+ * or its status is not Doing.
+ */
+export async function detectOrphans(
+  vaultDir: string,
+  execFn: ExecFn = exec,
+  readFn?: (p: string) => string,
+): Promise<OrphanSession[]> {
+  const sessions = await listClaudeChildSessions(execFn);
+  const orphans: OrphanSession[] = [];
+
+  for (const s of sessions) {
+    const filePath = findVaultFile(vaultDir, s.uuid, s.type);
+
+    if (!filePath) {
+      orphans.push({
+        sessionName: s.sessionName,
+        taskUuid: s.uuid,
+        taskFilePath: null,
+        reason: "vault task not found",
+      });
+      continue;
+    }
+
+    if (!isTaskDoing(filePath, readFn)) {
+      orphans.push({
+        sessionName: s.sessionName,
+        taskUuid: s.uuid,
+        taskFilePath: filePath,
+        reason: "vault task status != Doing",
+      });
+    }
+  }
+
+  return orphans;
+}
+
+/**
+ * Recover a single orphan: transition vault task to Failed and kill tmux session.
+ * In dry-run mode only logs; no mutations are made.
+ */
+export async function recoverOrphan(
+  orphan: OrphanSession,
+  dryRun: boolean,
+  execFn: ExecFn = exec,
+  updateFn: UpdateFn = atomicUpdateFrontmatter,
+): Promise<{ ok: boolean; error?: string }> {
+  const run = makeExecPromise(execFn);
+
+  if (dryRun) {
+    return { ok: true };
+  }
+
+  const now = new Date().toISOString();
+
+  if (orphan.taskFilePath) {
+    try {
+      updateFn(orphan.taskFilePath, {
+        "ems__Effort_status": "[[ems__EffortStatusFailed]]",
+        "aiTask__Task_lastError": `orphan recovery: ${orphan.reason}`,
+        "exo__Asset_updatedAt": now,
+      });
+    } catch (e) {
+      return { ok: false, error: `vault update failed: ${(e as Error).message}` };
+    }
+  }
+
+  try {
+    await run(`tmux kill-session -t ${JSON.stringify(orphan.sessionName)}`);
+  } catch {
+    // Session may have already exited — not an error.
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Full orphan recovery run. Returns a summary.
+ * Without --apply (dryRun=true) lists orphans without modifying anything.
+ */
+export async function runOrphanRecovery(
+  vaultDir: string,
+  dryRun: boolean,
+  execFn: ExecFn = exec,
+  readFn?: (p: string) => string,
+  updateFn: UpdateFn = atomicUpdateFrontmatter,
+): Promise<RecoveryResult> {
+  const orphans = await detectOrphans(vaultDir, execFn, readFn);
+  let recovered = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const orphan of orphans) {
+    const result = await recoverOrphan(orphan, dryRun, execFn, updateFn);
+    if (!result.ok) {
+      errors++;
+    } else if (dryRun) {
+      skipped++;
+    } else {
+      recovered++;
+    }
+  }
+
+  return { orphans: orphans.length, recovered, skipped, errors };
+}

--- a/packages/cli/tests/unit/services/OrphanRecoveryService.test.ts
+++ b/packages/cli/tests/unit/services/OrphanRecoveryService.test.ts
@@ -1,0 +1,402 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+} from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import yaml from "js-yaml";
+
+import {
+  listClaudeChildSessions,
+  findVaultFile,
+  isTaskDoing,
+  detectOrphans,
+  recoverOrphan,
+  runOrphanRecovery,
+  type ExecFn,
+  type OrphanSession,
+} from "../../../src/services/OrphanRecoveryService.js";
+import type { AtomicUpdateResult } from "../../../src/services/AtomicFrontmatterService.js";
+
+const FULL_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const SHORT_UUID_PREFIX = "a1b2c3d4";
+const SHORT_SESSION = `claude-child-${SHORT_UUID_PREFIX}-1777826100`;
+const FULL_SESSION = `claude-child-${FULL_UUID}`;
+
+function makeSessionExecFn(sessionNames: string[]): ExecFn {
+  return (_cmd, cb) => {
+    cb(null, sessionNames.join("\n"), "");
+    return {};
+  };
+}
+
+function failExecFn(): ExecFn {
+  return (_cmd, cb) => {
+    cb(new Error("tmux not available"), "", "");
+    return {};
+  };
+}
+
+function noopExecFn(): ExecFn {
+  return (_cmd, cb) => {
+    cb(null, "", "");
+    return {};
+  };
+}
+
+function buildMd(fm: Record<string, unknown>): string {
+  return `---\n${yaml.dump(fm)}---\n`;
+}
+
+describe("OrphanRecoveryService", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), "orphan-svc-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── listClaudeChildSessions ─────────────────────────────────────────
+
+  describe("listClaudeChildSessions", () => {
+    it("parses full-UUID session", async () => {
+      const result = await listClaudeChildSessions(
+        makeSessionExecFn([FULL_SESSION]),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        sessionName: FULL_SESSION,
+        uuid: FULL_UUID,
+        type: "full",
+      });
+    });
+
+    it("parses short-UUID session", async () => {
+      const result = await listClaudeChildSessions(
+        makeSessionExecFn([SHORT_SESSION]),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        sessionName: SHORT_SESSION,
+        uuid: SHORT_UUID_PREFIX,
+        type: "short",
+      });
+    });
+
+    it("ignores non-claude-child sessions", async () => {
+      const result = await listClaudeChildSessions(
+        makeSessionExecFn(["n8n", "claude-orch-w1-123", "main"]),
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it("returns empty array when tmux fails", async () => {
+      const result = await listClaudeChildSessions(failExecFn());
+      expect(result).toHaveLength(0);
+    });
+
+    it("handles multiple sessions of different types", async () => {
+      const result = await listClaudeChildSessions(
+        makeSessionExecFn([FULL_SESSION, SHORT_SESSION, "irrelevant"]),
+      );
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  // ── findVaultFile ───────────────────────────────────────────────────
+
+  describe("findVaultFile", () => {
+    it("finds a file by full UUID (exact match)", () => {
+      writeFileSync(path.join(tmpDir, `${FULL_UUID}.md`), "---\n---\n");
+      const result = findVaultFile(tmpDir, FULL_UUID, "full");
+      expect(result).toBe(path.join(tmpDir, `${FULL_UUID}.md`));
+    });
+
+    it("finds a file by UUID prefix (short match)", () => {
+      writeFileSync(path.join(tmpDir, `${FULL_UUID}.md`), "---\n---\n");
+      const result = findVaultFile(tmpDir, SHORT_UUID_PREFIX, "short");
+      expect(result).toBe(path.join(tmpDir, `${FULL_UUID}.md`));
+    });
+
+    it("searches recursively in subdirectories", () => {
+      const sub = path.join(tmpDir, "sub", "deep");
+      mkdirSync(sub, { recursive: true });
+      writeFileSync(path.join(sub, `${FULL_UUID}.md`), "---\n---\n");
+      const result = findVaultFile(tmpDir, FULL_UUID, "full");
+      expect(result).toBe(path.join(sub, `${FULL_UUID}.md`));
+    });
+
+    it("returns null when not found", () => {
+      const result = findVaultFile(tmpDir, "00000000-0000-0000-0000-000000000000", "full");
+      expect(result).toBeNull();
+    });
+
+    it("skips hidden directories", () => {
+      const hidden = path.join(tmpDir, ".obsidian");
+      mkdirSync(hidden, { recursive: true });
+      writeFileSync(path.join(hidden, `${FULL_UUID}.md`), "---\n---\n");
+      const result = findVaultFile(tmpDir, FULL_UUID, "full");
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── isTaskDoing ─────────────────────────────────────────────────────
+
+  describe("isTaskDoing", () => {
+    it("returns true when status is Doing", () => {
+      const filePath = path.join(tmpDir, "task.md");
+      writeFileSync(
+        filePath,
+        buildMd({ ems__Effort_status: "[[ems__EffortStatusDoing]]" }),
+      );
+      expect(isTaskDoing(filePath)).toBe(true);
+    });
+
+    it("returns false when status is Backlog", () => {
+      const filePath = path.join(tmpDir, "task.md");
+      writeFileSync(
+        filePath,
+        buildMd({ ems__Effort_status: "[[ems__EffortStatusBacklog]]" }),
+      );
+      expect(isTaskDoing(filePath)).toBe(false);
+    });
+
+    it("returns false when status is Failed", () => {
+      const filePath = path.join(tmpDir, "task.md");
+      writeFileSync(
+        filePath,
+        buildMd({ ems__Effort_status: "[[ems__EffortStatusFailed]]" }),
+      );
+      expect(isTaskDoing(filePath)).toBe(false);
+    });
+
+    it("returns false when file does not exist", () => {
+      expect(isTaskDoing(path.join(tmpDir, "nonexistent.md"))).toBe(false);
+    });
+
+    it("accepts injected readFn", () => {
+      const fakePath = "/fake/path.md";
+      const readFn = (_p: string) => "---\nems__Effort_status: \"[[ems__EffortStatusDoing]]\"\n---\n";
+      expect(isTaskDoing(fakePath, readFn)).toBe(true);
+    });
+  });
+
+  // ── detectOrphans ───────────────────────────────────────────────────
+
+  describe("detectOrphans", () => {
+    it("reports orphan when vault file not found", async () => {
+      const orphans = await detectOrphans(
+        tmpDir,
+        makeSessionExecFn([FULL_SESSION]),
+      );
+      expect(orphans).toHaveLength(1);
+      expect(orphans[0].reason).toContain("not found");
+      expect(orphans[0].taskFilePath).toBeNull();
+    });
+
+    it("reports orphan when vault task status is not Doing", async () => {
+      writeFileSync(
+        path.join(tmpDir, `${FULL_UUID}.md`),
+        buildMd({
+          exo__Asset_uid: FULL_UUID,
+          ems__Effort_status: "[[ems__EffortStatusBacklog]]",
+        }),
+      );
+      const orphans = await detectOrphans(
+        tmpDir,
+        makeSessionExecFn([FULL_SESSION]),
+      );
+      expect(orphans).toHaveLength(1);
+      expect(orphans[0].reason).toContain("status != Doing");
+    });
+
+    it("does not report orphan when task is Doing", async () => {
+      writeFileSync(
+        path.join(tmpDir, `${FULL_UUID}.md`),
+        buildMd({
+          exo__Asset_uid: FULL_UUID,
+          ems__Effort_status: "[[ems__EffortStatusDoing]]",
+        }),
+      );
+      const orphans = await detectOrphans(
+        tmpDir,
+        makeSessionExecFn([FULL_SESSION]),
+      );
+      expect(orphans).toHaveLength(0);
+    });
+
+    it("handles short-UUID session finding vault file by prefix", async () => {
+      writeFileSync(
+        path.join(tmpDir, `${FULL_UUID}.md`),
+        buildMd({
+          exo__Asset_uid: FULL_UUID,
+          ems__Effort_status: "[[ems__EffortStatusDone]]",
+        }),
+      );
+      const orphans = await detectOrphans(
+        tmpDir,
+        makeSessionExecFn([SHORT_SESSION]),
+      );
+      expect(orphans).toHaveLength(1);
+      expect(orphans[0].taskFilePath).toBeTruthy();
+    });
+
+    it("returns empty when no claude-child sessions", async () => {
+      const orphans = await detectOrphans(tmpDir, makeSessionExecFn([]));
+      expect(orphans).toHaveLength(0);
+    });
+  });
+
+  // ── recoverOrphan ───────────────────────────────────────────────────
+
+  describe("recoverOrphan", () => {
+    const killCmds: string[] = [];
+    const updateCalls: Array<[string, Record<string, unknown>]> = [];
+
+    let trackExecFn: ExecFn;
+    let mockUpdateFn: (
+      filePath: string,
+      updates: Record<string, unknown>,
+    ) => AtomicUpdateResult;
+
+    beforeEach(() => {
+      killCmds.length = 0;
+      updateCalls.length = 0;
+      trackExecFn = (cmd, cb) => {
+        killCmds.push(cmd);
+        cb(null, "", "");
+        return {};
+      };
+      mockUpdateFn = (fp, updates) => {
+        updateCalls.push([fp, updates]);
+        return { success: true, verified: true };
+      };
+    });
+
+    it("dry-run: does not kill session or update vault", async () => {
+      const orphan: OrphanSession = {
+        sessionName: FULL_SESSION,
+        taskUuid: FULL_UUID,
+        taskFilePath: path.join(tmpDir, `${FULL_UUID}.md`),
+        reason: "test",
+      };
+      const result = await recoverOrphan(orphan, true, trackExecFn, mockUpdateFn);
+      expect(result.ok).toBe(true);
+      expect(killCmds).toHaveLength(0);
+      expect(updateCalls).toHaveLength(0);
+    });
+
+    it("apply: updates vault and kills session when file exists", async () => {
+      const filePath = path.join(tmpDir, `${FULL_UUID}.md`);
+      writeFileSync(
+        filePath,
+        buildMd({ ems__Effort_status: "[[ems__EffortStatusDoing]]" }),
+      );
+      const orphan: OrphanSession = {
+        sessionName: FULL_SESSION,
+        taskUuid: FULL_UUID,
+        taskFilePath: filePath,
+        reason: "vault task status != Doing",
+      };
+      const result = await recoverOrphan(orphan, false, trackExecFn, mockUpdateFn);
+      expect(result.ok).toBe(true);
+      expect(updateCalls).toHaveLength(1);
+      expect(updateCalls[0][1]["ems__Effort_status"]).toBe("[[ems__EffortStatusFailed]]");
+      expect(String(updateCalls[0][1]["aiTask__Task_lastError"])).toContain("orphan recovery");
+      expect(killCmds.some((c) => c.includes(FULL_SESSION))).toBe(true);
+    });
+
+    it("apply: kills session even when vault file not found", async () => {
+      const orphan: OrphanSession = {
+        sessionName: FULL_SESSION,
+        taskUuid: FULL_UUID,
+        taskFilePath: null,
+        reason: "vault task not found",
+      };
+      const result = await recoverOrphan(orphan, false, trackExecFn, mockUpdateFn);
+      expect(result.ok).toBe(true);
+      expect(updateCalls).toHaveLength(0);
+      expect(killCmds.some((c) => c.includes(FULL_SESSION))).toBe(true);
+    });
+
+    it("handles tmux kill-session failure gracefully", async () => {
+      const failKillExec: ExecFn = (cmd, cb) => {
+        if (cmd.includes("kill-session")) {
+          cb(new Error("no such session"), "", "");
+        } else {
+          cb(null, "", "");
+        }
+        return {};
+      };
+      const orphan: OrphanSession = {
+        sessionName: FULL_SESSION,
+        taskUuid: FULL_UUID,
+        taskFilePath: null,
+        reason: "vault task not found",
+      };
+      const result = await recoverOrphan(
+        orphan,
+        false,
+        failKillExec,
+        mockUpdateFn,
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  // ── runOrphanRecovery ───────────────────────────────────────────────
+
+  describe("runOrphanRecovery", () => {
+    it("dry-run reports orphan count without mutations", async () => {
+      const result = await runOrphanRecovery(
+        tmpDir,
+        true,
+        makeSessionExecFn([FULL_SESSION]),
+      );
+      expect(result.orphans).toBe(1);
+      expect(result.recovered).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toBe(0);
+    });
+
+    it("apply mode increments recovered count", async () => {
+      const result = await runOrphanRecovery(
+        tmpDir,
+        false,
+        makeSessionExecFn([FULL_SESSION]),
+        undefined,
+        (fp, updates) => {
+          void fp; void updates;
+          return { success: true, verified: true };
+        },
+      );
+      expect(result.orphans).toBe(1);
+      expect(result.recovered).toBe(1);
+      expect(result.errors).toBe(0);
+    });
+
+    it("returns zeros when no sessions", async () => {
+      const result = await runOrphanRecovery(
+        tmpDir,
+        true,
+        makeSessionExecFn([]),
+      );
+      expect(result.orphans).toBe(0);
+      expect(result.recovered).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `OrphanRecoveryService` that detects orphaned `claude-child-*` tmux sessions: sessions whose corresponding vault task is not in Doing status
- Adds `recover` CLI command (`npx @kitelev/exocortex-cli recover [--dry-run|--apply]`) — dry-run by default
- Extends `~/.exocortex/bin/ai-task-recover` with Phase 2: orphan session recovery via new CLI command
- 27 unit tests covering all public API surface

Supports both session naming conventions:
- Full UUID (bash worker): `claude-child-<uuid>`  
- Short prefix (orchestrator): `claude-child-<8chars>-<digits>`

## Acceptance Criteria

- [x] ai-task-recover находит tmux сессии с паттерном claude-child-<uuid>
- [x] Для каждой: проверяет есть ли соответствующий vault task в статусе Doing
- [x] Если task не найден или статус != Doing → сессия считается orphan
- [x] Orphan сессии: vault task → Failed, tmux сессия kill-session
- [x] Dry-run режим (--dry-run) логирует без изменений

## Test plan

- [ ] Run `npx @kitelev/exocortex-cli recover --dry-run` — should list sessions without changes
- [ ] Run `npx @kitelev/exocortex-cli recover --apply` — should recover actual orphans
- [ ] Unit tests: 27/27 pass