### PR TITLE
fix(display-name): restore label-only rendering in Reading View

### DIFF
--- a/packages/obsidian-plugin/specs/features/layout/reading-view-labels.feature
+++ b/packages/obsidian-plugin/specs/features/layout/reading-view-labels.feature
@@ -1,0 +1,70 @@
+# language: en
+@reading-view @body-link-patch @critical
+Feature: Reading View Link Labels
+
+  As an Exocortex plugin user
+  I want to see human-readable labels in Reading View wikilinks
+  So that I can navigate my knowledge base without seeing raw UUIDs
+
+  Rule: Internal links in Reading View show exo__Asset_label, not UUID or class suffix
+
+    Scenario: ems__Task link shows label only
+      Given a note "source" exists with body content linking to asset "fix-bug-uuid"
+      And asset "fix-bug-uuid" exists with metadata:
+        | Property            | Value            |
+        | exo__Asset_label    | Fix the login bug |
+        | exo__Instance_class | [[ems__Task]]    |
+      When I open "source" in Reading View
+      Then the internal link to "fix-bug-uuid" displays text "Fix the login bug"
+      And the link does NOT show "Fix the login bug (ems__Task)"
+      And the link does NOT show "fix-bug-uuid"
+
+    Scenario: ims__Concept link shows label only (H1 regression)
+      Given a note "source" exists with body content linking to asset "concept-uuid"
+      And asset "concept-uuid" exists with metadata:
+        | Property            | Value           |
+        | exo__Asset_label    | Wikilink Pattern |
+        | exo__Instance_class | [[ims__Concept]] |
+      When I open "source" in Reading View
+      Then the internal link to "concept-uuid" displays text "Wikilink Pattern"
+      And the link does NOT show "Wikilink Pattern (ims__Concept)"
+      And the link does NOT show "concept-uuid"
+
+    Scenario: ems__TaskPrototype link shows label with suffix
+      Given a note "source" exists with body content linking to asset "morning-proto-uuid"
+      And asset "morning-proto-uuid" exists with metadata:
+        | Property            | Value                  |
+        | exo__Asset_label    | Morning Standup        |
+        | exo__Instance_class | [[ems__TaskPrototype]] |
+      When I open "source" in Reading View
+      Then the internal link to "morning-proto-uuid" displays text "Morning Standup (TaskPrototype)"
+
+    Scenario: Unknown class link shows label only (no class suffix)
+      Given a note "source" exists with body content linking to asset "custom-uuid"
+      And asset "custom-uuid" exists with metadata:
+        | Property            | Value                   |
+        | exo__Asset_label    | My Knowledge Note       |
+        | exo__Instance_class | [[ztlk__FleetingNote]]  |
+      When I open "source" in Reading View
+      Then the internal link to "custom-uuid" displays text "My Knowledge Note"
+      And the link does NOT show "My Knowledge Note (ztlk__FleetingNote)"
+
+    Scenario: Link without exo__Asset_label is not patched
+      Given a note "source" exists with body content linking to asset "no-label-uuid"
+      And asset "no-label-uuid" exists with metadata:
+        | Property            | Value         |
+        | exo__Instance_class | [[ems__Task]] |
+      When I open "source" in Reading View
+      Then the internal link to "no-label-uuid" shows the original file basename
+
+    Scenario: User-defined alias is preserved
+      Given a note "source" exists with body content:
+        """
+        See [[concept-uuid|My Custom Alias]] for details.
+        """
+      And asset "concept-uuid" exists with metadata:
+        | Property         | Value            |
+        | exo__Asset_label | Wikilink Pattern |
+      When I open "source" in Reading View
+      Then the internal link displays text "My Custom Alias"
+      And NOT "Wikilink Pattern"

--- a/packages/obsidian-plugin/specs/step_definitions/reading-view-labels.steps.ts
+++ b/packages/obsidian-plugin/specs/step_definitions/reading-view-labels.steps.ts
@@ -1,0 +1,154 @@
+import { Given, When, Then } from "@cucumber/cucumber";
+import { ExocortexWorld } from "../support/world.js";
+import { DisplayNameResolver } from "../../src/domain/display-name/DisplayNameResolver.js";
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from "../../src/domain/settings/ExocortexSettings.js";
+import assert from "assert";
+
+// resolved display name for the current target asset
+let resolvedDisplayName: string | null = null;
+// basename of the target asset
+let targetBasename: string = "";
+// user-defined alias extracted from body wikilink (if any)
+let userDefinedAlias: string | null = null;
+
+Given(
+  "a note {string} exists with body content linking to asset {string}",
+  function (this: ExocortexWorld, sourceName: string, targetId: string) {
+    this.createFile(`Notes/${sourceName}.md`, {
+      exo__Asset_label: `Source: ${sourceName}`,
+    });
+    targetBasename = targetId;
+    userDefinedAlias = null;
+    resolvedDisplayName = null;
+  }
+);
+
+Given(
+  "asset {string} exists with metadata:",
+  function (this: ExocortexWorld, assetId: string, dataTable: any) {
+    const frontmatter: Record<string, unknown> = {};
+    const rows: string[][] = dataTable.rows();
+    for (const [prop, value] of rows) {
+      // Handle array-like wikilink values
+      if (value.startsWith("[[") && value.endsWith("]]")) {
+        frontmatter[prop] = [value];
+      } else {
+        frontmatter[prop] = value;
+      }
+    }
+    this.createFile(`Assets/${assetId}.md`, frontmatter);
+    targetBasename = assetId;
+  }
+);
+
+Given(
+  "a note {string} exists with body content:",
+  function (this: ExocortexWorld, sourceName: string, docString: string) {
+    // Extract wikilink target and optional alias: [[target|alias]] or [[target]]
+    const match = docString.match(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/);
+    if (match) {
+      targetBasename = match[1].trim();
+      userDefinedAlias = match[2] ? match[2].trim() : null;
+    }
+    this.createFile(`Notes/${sourceName}.md`, {
+      exo__Asset_label: `Source: ${sourceName}`,
+    });
+  }
+);
+
+When(
+  "I open {string} in Reading View",
+  function (this: ExocortexWorld, _sourceName: string) {
+    const assetNote = this.notes.get(`Assets/${targetBasename}.md`);
+    if (!assetNote) {
+      resolvedDisplayName = null;
+      return;
+    }
+
+    // Simulate BodyLinkPatch alias detection: if the link has an explicit user alias,
+    // BodyLinkPatch skips patching (hasUserAlias = true → return early).
+    if (userDefinedAlias !== null) {
+      resolvedDisplayName = null; // patch is skipped — original alias is preserved
+      return;
+    }
+
+    const resolver = new DisplayNameResolver(DEFAULT_DISPLAY_NAME_SETTINGS);
+    resolvedDisplayName = resolver.resolve({
+      metadata: assetNote.frontmatter as Record<string, unknown>,
+      basename: assetNote.file.basename,
+    });
+  }
+);
+
+Then(
+  "the internal link to {string} displays text {string}",
+  function (this: ExocortexWorld, _targetId: string, expectedText: string) {
+    assert.strictEqual(
+      resolvedDisplayName,
+      expectedText,
+      `Expected display name "${expectedText}" but got "${resolvedDisplayName}"`
+    );
+  }
+);
+
+Then(
+  "the link does NOT show {string}",
+  function (this: ExocortexWorld, unexpectedText: string) {
+    assert.notStrictEqual(
+      resolvedDisplayName,
+      unexpectedText,
+      `Display name should NOT be "${unexpectedText}" but it is`
+    );
+  }
+);
+
+Then(
+  "the internal link to {string} shows the original file basename",
+  function (this: ExocortexWorld, _targetId: string) {
+    // null means BodyLinkPatch skips this link → shows original basename
+    assert.strictEqual(
+      resolvedDisplayName,
+      null,
+      `Expected null (no patching) but got "${resolvedDisplayName}"`
+    );
+  }
+);
+
+Then(
+  "the internal link displays text {string}",
+  function (this: ExocortexWorld, expectedText: string) {
+    // For alias scenario: BodyLinkPatch detected hasUserAlias=true and returned early.
+    // resolvedDisplayName = null means the link was NOT patched → original alias preserved.
+    // We verify: (a) patching was skipped, (b) the user alias matches what was written.
+    if (userDefinedAlias !== null) {
+      assert.strictEqual(
+        userDefinedAlias,
+        expectedText,
+        `User alias "${userDefinedAlias}" should match expected "${expectedText}"`
+      );
+      assert.strictEqual(
+        resolvedDisplayName,
+        null,
+        "BodyLinkPatch should have skipped alias links (no patching)"
+      );
+      return;
+    }
+    // Non-alias case: verify resolved display name
+    assert.strictEqual(
+      resolvedDisplayName,
+      expectedText,
+      `Expected display name "${expectedText}" but got "${resolvedDisplayName}"`
+    );
+  }
+);
+
+Then(
+  "NOT {string}",
+  function (this: ExocortexWorld, unexpectedText: string) {
+    assert.notStrictEqual(
+      resolvedDisplayName,
+      unexpectedText,
+      `Display name should NOT be "${unexpectedText}"`
+    );
+  }
+);

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -13,11 +13,10 @@ export interface DisplayNameSettings {
  * Default display name configuration
  *
  * The defaultTemplate applies to ALL asset types not explicitly listed in classTemplates.
- * It uses the "label (class)" format to provide consistent, readable display names
- * across all asset types in the Properties block.
+ * Shows only the label — classes that need a suffix (e.g. TaskPrototype) have explicit entries.
  */
 export const DEFAULT_DISPLAY_NAME_SETTINGS: DisplayNameSettings = {
-  defaultTemplate: "{{exo__Asset_label}} ({{exo__Instance_class}})",
+  defaultTemplate: "{{exo__Asset_label}}",
 
   classTemplates: {
     ems__TaskPrototype: "{{exo__Asset_label}} (TaskPrototype)",

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
@@ -277,11 +277,9 @@ describe("DisplayNameResolver", () => {
   });
 
   describe("DEFAULT_DISPLAY_NAME_SETTINGS", () => {
-    it("should have default template with class suffix for all asset types", () => {
-      // Default template now includes class suffix for consistent display across all asset types
-      expect(DEFAULT_DISPLAY_NAME_SETTINGS.defaultTemplate).toBe(
-        "{{exo__Asset_label}} ({{exo__Instance_class}})"
-      );
+    it("should have default template showing label only", () => {
+      // Default template shows just the label — classes needing a suffix have explicit entries in classTemplates
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.defaultTemplate).toBe("{{exo__Asset_label}}");
     });
 
     it("should have class templates for common classes", () => {
@@ -316,10 +314,10 @@ describe("DisplayNameResolver", () => {
       expect(prototypeResult).toBe("Morning routine (TaskPrototype)");
     });
 
-    it("should use default template with class suffix for unknown asset types", () => {
+    it("should use default template (label only) for unknown asset types", () => {
       const resolver = new DisplayNameResolver(DEFAULT_DISPLAY_NAME_SETTINGS);
 
-      // Custom/unknown asset class should use default template
+      // Unknown class (e.g. ims__Concept, myapp__CustomClass) shows just the label — no class suffix
       const customResult = resolver.resolve({
         metadata: {
           exo__Asset_label: "My Custom Asset",
@@ -327,7 +325,20 @@ describe("DisplayNameResolver", () => {
         },
         basename: "custom-asset",
       });
-      expect(customResult).toBe("My Custom Asset (myapp__CustomClass)");
+      expect(customResult).toBe("My Custom Asset");
+    });
+
+    it("should show label only for ims__Concept (H1 regression fix)", () => {
+      const resolver = new DisplayNameResolver(DEFAULT_DISPLAY_NAME_SETTINGS);
+
+      const result = resolver.resolve({
+        metadata: {
+          exo__Asset_label: "Wikilink in Reading View",
+          exo__Instance_class: ["[[ims__Concept]]"],
+        },
+        basename: "some-concept-uuid",
+      });
+      expect(result).toBe("Wikilink in Reading View");
     });
 
     it("should gracefully handle missing class in default template", () => {


### PR DESCRIPTION
Fixes H1 regression: defaultTemplate was appending (ClassName) suffix for classes outside classTemplates. Related RFC: b2716d50-f14e-4e48-9829-fed6e8b0d7be