### PR TITLE
fix(cli): pass ai-task prompt via stdin — fix W6 claude spawn regression

### DIFF
--- a/packages/cli/bin/ai-task-runner
+++ b/packages/cli/bin/ai-task-runner
@@ -34,6 +34,6 @@ PROMPT="$(< "$TASK_FILE")"
 
 echo "[runner] $(date '+%Y-%m-%dT%H:%M:%S%z'): spawning claude model=$TASK_MODEL timeout=${TASK_TIMEOUT}m"
 
-# Run real claude -p — exec replaces this process
-exec env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_EXECPATH \
-  claude --dangerously-skip-permissions --model "$TASK_MODEL" -p "$PROMPT"
+# Pass prompt via stdin to avoid shell parsing '---' frontmatter delimiter as a CLI option.
+printf '%s' "$PROMPT" | env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_EXECPATH \
+  claude --dangerously-skip-permissions --model "$TASK_MODEL" -p

--- a/packages/cli/bin/ai-task-worker
+++ b/packages/cli/bin/ai-task-worker
@@ -14,7 +14,7 @@ mkdir -p "$LOG_DIR"
 LOG="$LOG_DIR/aitask-worker.log"
 RUNNER="$HOME/.exocortex/bin/ai-task-runner"
 
-log() { echo "[ai-task-worker] $(date '+%Y-%m-%dT%H:%M:%S%z'): $*" | tee -a "$LOG"; }
+log() { echo "[ai-task-worker] $(date '+%Y-%m-%dT%H:%M:%S%z'): $*"; }
 
 log "Scan start (vault=$VAULT_DIR)"
 
@@ -25,9 +25,7 @@ vault, log_path, runner, parent_pid = sys.argv[1:5]
 
 def log(msg):
     ts = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S%z')
-    line = f"[ai-task-worker] {ts}: {msg}"
-    print(line)
-    open(log_path, 'a').write(line + "\n")
+    print(f"[ai-task-worker] {ts}: {msg}")
 
 def now_iso5():
     tz5 = datetime.timezone(datetime.timedelta(hours=5))

--- a/packages/cli/src/services/SpawnService.ts
+++ b/packages/cli/src/services/SpawnService.ts
@@ -45,6 +45,11 @@ export const CLAUDE_SESSION_CAP = 4;
 
 const COMPLETION_STATUS_FRAGMENTS = ["EffortStatusDone", "EffortStatusReview"];
 
+/** POSIX single-quote escaping: embeds arbitrary string safely in a shell command. */
+function shellSingleQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
 const LOG_DIR = path.join(homedir(), ".exocortex", "ai-task-logs");
 const WORKER_LOG = path.join(homedir(), ".exocortex", "logs", "aitask-worker.log");
 
@@ -221,11 +226,11 @@ export async function spawnSession(
   const logFile = path.join(LOG_DIR, `${opts.taskUuid}.log`);
   const windowName = `claude-child-${opts.taskUuid}`;
 
-  const promptFlag = opts.systemPrompt
-    ? `-p ${JSON.stringify(opts.systemPrompt)}`
-    : "";
-
-  const claudeCmd = `claude --model ${opts.model} --dangerously-skip-permissions ${promptFlag} 2>&1 | tee ${JSON.stringify(logFile)}`;
+  // Pass prompt via stdin to avoid shell parsing '---' YAML frontmatter as a CLI option flag.
+  // Single-quote escaping (POSIX) preserves newlines and special characters safely.
+  const claudeCmd = opts.systemPrompt
+    ? `printf '%s' ${shellSingleQuote(opts.systemPrompt)} | claude --model ${opts.model} --dangerously-skip-permissions -p 2>&1 | tee ${JSON.stringify(logFile)}`
+    : `claude --model ${opts.model} --dangerously-skip-permissions -p 2>&1 | tee ${JSON.stringify(logFile)}`;
   const envPrefix =
     "env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_EXECPATH";
   const tmuxCmd = `tmux new-window -d -n ${windowName} "${envPrefix} bash -c ${JSON.stringify(claudeCmd)}"`;

--- a/packages/cli/tests/unit/services/SpawnService.test.ts
+++ b/packages/cli/tests/unit/services/SpawnService.test.ts
@@ -571,6 +571,91 @@ describe("spawnSession", () => {
   });
 });
 
+// --- spawnSession: stdin prompt (regression W6) ---
+
+describe("spawnSession — systemPrompt piped via stdin", () => {
+  it("does not pass frontmatter body as -p positional arg when systemPrompt starts with '---'", async () => {
+    const capturedCmds: string[] = [];
+    const execFn: ExecFn = (cmd, cb) => {
+      capturedCmds.push(cmd);
+      cb(null, "", "");
+      return {};
+    };
+
+    const frontmatterPrompt =
+      "---\nexo__Asset_uid: test-uuid\nems__Effort_status: \"[[ems__EffortStatusBacklog]]\"\n---\n\nDo something useful.";
+
+    await spawnSession(
+      { ...BASE_OPTS, systemPrompt: frontmatterPrompt },
+      {
+        execFn,
+        atomicUpdate: mockAtomicUpdate,
+        costFn: mockCostFn,
+        pollIntervalMs: 1,
+        countClaudeSessionsFn: async () => 0,
+      },
+    );
+
+    const spawnCmd = capturedCmds.find((c) => c.includes("new-window"));
+    expect(spawnCmd).toBeDefined();
+    // Must use stdin pipe, NOT -p "<content>" as positional arg
+    expect(spawnCmd).toContain("printf '%s'");
+    expect(spawnCmd).toContain("| claude");
+    // Must NOT pass the raw --- string as a positional argument
+    expect(spawnCmd).not.toMatch(/-p\s+"---/);
+    expect(spawnCmd).not.toMatch(/-p\s+'---/);
+  });
+
+  it("properly escapes single quotes in systemPrompt", async () => {
+    const capturedCmds: string[] = [];
+    const execFn: ExecFn = (cmd, cb) => {
+      capturedCmds.push(cmd);
+      cb(null, "", "");
+      return {};
+    };
+
+    const promptWithQuotes = "Task: fix the user's issue\n---\nbody";
+
+    await spawnSession(
+      { ...BASE_OPTS, systemPrompt: promptWithQuotes },
+      {
+        execFn,
+        atomicUpdate: mockAtomicUpdate,
+        costFn: mockCostFn,
+        pollIntervalMs: 1,
+        countClaudeSessionsFn: async () => 0,
+      },
+    );
+
+    const spawnCmd = capturedCmds.find((c) => c.includes("new-window"));
+    expect(spawnCmd).toBeDefined();
+    // JSON.stringify in tmuxCmd construction doubles the backslash; the actual shell sees '\''
+    expect(spawnCmd).toContain("'\\\\''");
+    expect(spawnCmd).toContain("printf '%s'");
+  });
+
+  it("spawns without prompt prefix when systemPrompt is not provided", async () => {
+    const capturedCmds: string[] = [];
+    const execFn: ExecFn = (cmd, cb) => {
+      capturedCmds.push(cmd);
+      cb(null, "", "");
+      return {};
+    };
+
+    await spawnSession(BASE_OPTS, {
+      execFn,
+      atomicUpdate: mockAtomicUpdate,
+      costFn: mockCostFn,
+      pollIntervalMs: 1,
+      countClaudeSessionsFn: async () => 0,
+    });
+
+    const spawnCmd = capturedCmds.find((c) => c.includes("new-window"));
+    expect(spawnCmd).toBeDefined();
+    expect(spawnCmd).not.toContain("printf '%s'");
+  });
+});
+
 // --- checkStdoutDone ---
 
 describe("checkStdoutDone", () => {


### PR DESCRIPTION
## Summary

- **Bug**: `ai-task-runner` passed the full task file content (starting with YAML `---` delimiter) as a positional CLI argument to `claude`. Commander.js parsed `---` as an unknown option → process died immediately after spawn.
- **Fix**: Pipe prompt via `printf '%s' "$PROMPT" | claude ... -p` (stdin) instead.
- **Also fixed**: Duplicate log entries in `ai-task-worker` — bash `log()` used `tee -a $LOG` while LaunchAgent `StandardOutPath` also captured stdout to the same file; same double-write in Python `log()`.
- **SpawnService.ts**: Same fix for `systemPrompt` field — use `printf '%s' ${shellSingleQuote(...)} | claude -p` via POSIX single-quote helper.

## Root cause evidence

Session log `/Users/kitelev/.exocortex/logs/aitask-session-851cfd53-*.log`:
```
[runner] start task=...
error: unknown option '---
exo__Asset_isDefinedBy: "[[!kitelev]]"
...
```

## Changes

| File | Change |
|------|--------|
| `packages/cli/bin/ai-task-runner` | `printf '%s' "$PROMPT" \| claude ... -p` (stdin pipe) |
| `packages/cli/bin/ai-task-worker` | Remove duplicate log writes (tee + launchd capture = double entries) |
| `packages/cli/src/services/SpawnService.ts` | `shellSingleQuote` helper + stdin pipe for systemPrompt |
| `packages/cli/tests/unit/services/SpawnService.test.ts` | 3 regression tests for frontmatter-as-prompt case |

## Test plan

- [x] `SpawnService.test.ts` — 35/35 passing (3 new regression tests added)
- [ ] CI pipeline green
- [ ] Post-merge: bump global CLI, re-trigger task `851cfd53` with `aiTask__Task_delegated: true`

Fixes W6 functional regression (parent project `085e42ce`).