### PR TITLE
fix(rdf): emit exo:Instance_class for class-IRI subjects to satisfy sh:class

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -786,6 +786,13 @@ export class NoteToRDFConverter {
   // Fix #ff3858e5: when emitting a class IRI for an enum instance, also push an
   // rdf:type triple derived from the target file's exo__Instance_class frontmatter.
   // This satisfies sh:class constraints in the SHACL-lite engine.
+  //
+  // Also emit exo:Instance_class triple — ShaclLiteValidator.typePredicateIRI is
+  // exo#Instance_class (not rdf:type), so the rdf:type triple alone does not
+  // register the enum-instance IRI as a member of its class for sh:class checks.
+  // Without this, references like [[<uuid>|inbox__Role]] resolve to namespace IRI
+  // <inbox#Role>, but the validator finds no class declaration for that subject
+  // and reports false sh:class violations even when the class file exists.
   private emitTypeTripleForEnumInstance(classIRI: IRI, targetFile: IFile): void {
     const targetFm = this.vault.getFrontmatter(targetFile);
     if (!targetFm) return;
@@ -798,6 +805,9 @@ export class NoteToRDFConverter {
     if (parentClassIRI instanceof IRI) {
       this.pendingExtraTriples.push(
         new Triple(classIRI, Namespace.RDF.term("type"), parentClassIRI)
+      );
+      this.pendingExtraTriples.push(
+        new Triple(classIRI, Namespace.EXO.term("Instance_class"), parentClassIRI)
       );
     }
   }
@@ -867,6 +877,10 @@ export class NoteToRDFConverter {
               if (typeof label === "string") {
                 const labelClassIRI = this.expandClassValue(label);
                 if (labelClassIRI) {
+                  // Fix: emit class-registration triples for label-derived class IRI
+                  // so sh:class constraints resolve for UID-named class declarations
+                  // (e.g. `<uuid>.md` with alias `inbox__Role`).
+                  this.emitTypeTripleForEnumInstance(labelClassIRI, targetFile);
                   return [labelClassIRI];
                 }
               }

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.shacl-cardinality.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.shacl-cardinality.test.ts
@@ -238,6 +238,112 @@ describe("SHACL cardinality regression (Issue ff3858e5)", () => {
     expect(typeTriple).toBeDefined();
   });
 
+  it("Enum instance wikilink emits exo:Instance_class triple alongside rdf:type (sh:class registration)", async () => {
+    // ShaclLiteValidator uses exo#Instance_class (not rdf:type) as typePredicateIRI.
+    // Without this triple, even existing class declarations don't satisfy sh:class
+    // constraints because no asset's subject IRI maps to the namespace IRI form.
+    const taskFile: IFile = {
+      path: "03 Knowledge/kitelev/3d62b9cf-0000-0000-0000-000000000000.md",
+      basename: "3d62b9cf-0000-0000-0000-000000000000",
+      name: "3d62b9cf-0000-0000-0000-000000000000.md",
+      parent: null,
+    };
+    const doneFile: IFile = {
+      path: "03 Knowledge/ems/ems__EffortStatusDone.md",
+      basename: "ems__EffortStatusDone",
+      name: "ems__EffortStatusDone.md",
+      parent: null,
+    };
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === taskFile.path) {
+        return { ems__Effort_status: "[[ems__EffortStatusDone]]" };
+      }
+      if (f.path === doneFile.path) {
+        return { exo__Instance_class: "ems__EffortStatus" };
+      }
+      return null;
+    });
+
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === "ems__EffortStatusDone") return doneFile;
+      return null;
+    });
+
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(taskFile);
+
+    const instanceClassPred = Namespace.EXO.term("Instance_class").value;
+    const instanceClassTriple = triples.find(
+      (t) =>
+        (t.subject as IRI).value === Namespace.EMS.term("EffortStatusDone").value &&
+        (t.predicate as IRI).value === instanceClassPred &&
+        (t.object as IRI).value === Namespace.EMS.term("EffortStatus").value
+    );
+    expect(instanceClassTriple).toBeDefined();
+  });
+
+  it("UID-named class file resolved via UUID wikilink with class-prefixed label emits exo:Instance_class triple", async () => {
+    // Real-world case: vault has UID-named class declarations like
+    //   inbox/<uuid>.md  with  exo__Asset_label: inbox__Role
+    //                          exo__Instance_class: [[exo__Class]]
+    // and references like exo__Class_superClass: "[[<uuid>|inbox__Role]]".
+    // The converter resolves the wikilink to the namespace IRI <inbox#Role> via
+    // the file's exo__Asset_label (basename is the UUID, doesn't expand). For
+    // sh:class to resolve, <inbox#Role> needs an exo:Instance_class triple.
+    const sourceUUID = "11111111-1111-1111-1111-111111111111";
+    const targetUUID = "f9713a5d-88e3-40a5-b407-9dfec0d1649d";
+    const sourceFile: IFile = {
+      path: `03 Knowledge/ems/${sourceUUID}.md`,
+      basename: sourceUUID,
+      name: `${sourceUUID}.md`,
+      parent: null,
+    };
+    const targetFile: IFile = {
+      path: `03 Knowledge/inbox/${targetUUID}.md`,
+      basename: targetUUID,
+      name: `${targetUUID}.md`,
+      parent: null,
+    };
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return {
+          exo__Class_superClass: [`[[${targetUUID}|inbox__Role]]`],
+        };
+      }
+      if (f.path === targetFile.path) {
+        return {
+          exo__Asset_label: "inbox__Role",
+          exo__Instance_class: "[[exo__Class]]",
+        };
+      }
+      return null;
+    });
+
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === targetUUID) return targetFile;
+      return null;
+    });
+
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+
+    const instanceClassPred = Namespace.EXO.term("Instance_class").value;
+    const inboxRoleIRI = Namespace.INBOX.term("Role").value;
+    const exoClassIRI = Namespace.EXO.term("Class").value;
+
+    const registrationTriple = triples.find(
+      (t) =>
+        (t.subject as IRI).value === inboxRoleIRI &&
+        (t.predicate as IRI).value === instanceClassPred &&
+        (t.object as IRI).value === exoClassIRI
+    );
+    expect(registrationTriple).toBeDefined();
+  });
+
   it("Fix 3 audit: body wikilinks use exo:Asset_bodyLink — no cardinality impact on frontmatter predicates", async () => {
     // Body wikilinks are stored under the dedicated exo:Asset_bodyLink predicate,
     // so they cannot inflate cardinality counts for frontmatter predicates.


### PR DESCRIPTION
## Summary

`ShaclLiteValidator` uses `exo#Instance_class` (not `rdf:type`) as `typePredicateIRI`. `NoteToRDFConverter` previously emitted only `rdf:type` for namespace-IRI subjects derived from class-named or label-derived enum-instance wikilinks, leaving those IRIs unregistered as members of any class. Result: false `sh:class` violations on every reference to a class IRI even when a UID-named or legacy-named class declaration existed in the vault.

## Changes

Two narrow fixes in `packages/exocortex/src/services/NoteToRDFConverter.ts`:

1. **`emitTypeTripleForEnumInstance`** now also pushes a triple with predicate `exo:Instance_class` alongside the existing `rdf:type`, so the namespace IRI is registered as an instance of its declared class for SHACL.
2. **Label-resolution branch in `valueToRDFObject`** (UUID-form wikilink with class-prefixed `exo__Asset_label`, e.g. `[[<uuid>|inbox__Role]]`) now also calls `emitTypeTripleForEnumInstance`. Previously only the basename-derived path (label-named class files) emitted these triples, so UID-named class declarations did not register their namespace IRIs.

## Empirical impact

Validated against `/Users/kitelev/vault-2025` (production vault, ~160k triples):
- **Before:** 596 SHACL violations
- **After:** 116 SHACL violations
- **Drop:** 480 false-positive `sh:class` violations eliminated

The remaining 116 violations are different problem classes (broken file-IRI wikilinks, `prov:` namespace not in `NAMESPACE_MAP`, etc.) — out of scope for this fix.

## Tests

2 new regression tests in `NoteToRDFConverter.shacl-cardinality.test.ts`:
- "Enum instance wikilink emits `exo:Instance_class` triple alongside `rdf:type` (sh:class registration)" — covers basename-derived path.
- "UID-named class file resolved via UUID wikilink with class-prefixed label emits `exo:Instance_class` triple" — covers label-derived path.

All 169 `NoteToRDFConverter` tests pass. No regressions in the 5040+ exocortex package tests.

## Resolves

Task `9dd73e62-5727-4653-93bc-76709d34a680` (P2 SHACL Validation Completion) in vault-2025.

## Test plan

- [x] Unit tests: `npx jest tests/unit/services/NoteToRDFConverter` — 169 passed
- [x] Empirical: SHACL violation count on production vault dropped 596 → 116
- [ ] CI: 13 required checks pass (archgate, e2e-shard 1-6, lint, test-bdd, test-component, test-coverage, typecheck)
- [ ] Auto Release succeeds after merge → `@kitelev/exocortex-cli` new version published