### PR TITLE
fix(cli): fix TripleClassHierarchy to resolve class membership via ontology URIs

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -375,6 +375,38 @@ export function validateFile(
 }
 
 const RDFS_SUBCLASS_OF = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
+
+/**
+ * Converts a frontmatter label string (e.g. "ims__Concept") to its ontology URI
+ * (e.g. "https://exocortex.my/ontology/ims#Concept") using NAMESPACE_PREFIX_MAP.
+ * Returns null if no matching namespace prefix is found.
+ */
+export function labelToOntologyIRI(label: string): string | null {
+  const dunderIdx = label.indexOf("__");
+  if (dunderIdx === -1) return null;
+  const prefix = label.slice(0, dunderIdx + 2);
+  const local = label.slice(dunderIdx + 2);
+  const ns = NAMESPACE_PREFIX_MAP.get(prefix);
+  if (!ns || !local) return null;
+  return ns + local;
+}
+
+/**
+ * Tries to extract an ontology URI from a file IRI by examining the filename.
+ * File IRIs for label-named class files look like:
+ *   obsidian://vault/03%20Knowledge/exo/exo__Asset.md
+ * The filename stem "exo__Asset" can be converted to "https://exocortex.my/ontology/exo#Asset".
+ * Returns null for UUID-named files or unrecognised prefixes.
+ */
+function fileIriToOntologyURIFromFilename(fileIri: string): string | null {
+  const decodedIri = decodeURIComponent(fileIri);
+  const lastSlash = decodedIri.lastIndexOf("/");
+  if (lastSlash === -1) return null;
+  const filename = decodedIri.slice(lastSlash + 1);
+  const stem = filename.endsWith(".md") ? filename.slice(0, -3) : filename;
+  return labelToOntologyIRI(stem);
+}
 
 type AlgebraIRI = { type: "iri"; value: string };
 type AlgebraLiteral = { type: "literal"; value: string; datatype?: string; language?: string };
@@ -415,11 +447,26 @@ export function domainToAlgebraTriples(triples: DomainTriple[]): AlgebraStyleTri
 
 /**
  * Builds a ClassHierarchy by extracting rdfs:subClassOf triples.
+ *
+ * The hierarchy is built in two IRI spaces simultaneously:
+ *   1. File IRIs  — from rdfs:subClassOf triples as emitted by NoteToRDFConverter
+ *   2. Ontology URIs — derived via rdfs:label + NAMESPACE_PREFIX_MAP
+ *
+ * This dual mapping is necessary because exo__Instance_class values are converted
+ * to ontology URIs (e.g. "ims#Concept") while rdfs:subClassOf triples use file IRIs.
+ * Without the dual mapping, isSubClassOf("ims#Concept", "exo#Asset") always returns false.
  */
 export class TripleClassHierarchy implements ClassHierarchy {
   private readonly subClassMap: Map<string, Set<string>> = new Map();
 
   constructor(triples: DomainTriple[]) {
+    // Pass 1: build fileIRI → ontologyURI map.
+    // Primary source: rdfs:label triples (e.g. from UUID-named class files with exo__Asset_label).
+    // Fallback: filename stem (e.g. "exo__Asset.md" → exo#Asset for label-named class files).
+    const fileIriToOntologyUri = new Map<string, string>();
+
+    // Collect file IRIs that appear in rdfs:subClassOf triples (candidates for class files)
+    const classFileIris = new Set<string>();
     for (const t of triples) {
       if (
         t.predicate instanceof DomainIRI &&
@@ -427,9 +474,77 @@ export class TripleClassHierarchy implements ClassHierarchy {
         t.subject instanceof DomainIRI &&
         t.object instanceof DomainIRI
       ) {
-        const set = this.subClassMap.get(t.subject.value) ?? new Set<string>();
-        set.add(t.object.value);
-        this.subClassMap.set(t.subject.value, set);
+        classFileIris.add(t.subject.value);
+        classFileIris.add(t.object.value);
+      }
+    }
+
+    // Populate from rdfs:label triples first (preferred — explicit label)
+    for (const t of triples) {
+      if (
+        t.predicate instanceof DomainIRI &&
+        t.predicate.value === RDFS_LABEL &&
+        t.subject instanceof DomainIRI &&
+        t.object instanceof DomainLiteral
+      ) {
+        const ontologyUri = labelToOntologyIRI(t.object.value);
+        if (ontologyUri) {
+          fileIriToOntologyUri.set(t.subject.value, ontologyUri);
+        }
+      }
+    }
+
+    // Fallback: derive from filename for class-file IRIs not covered by rdfs:label
+    for (const fileIri of classFileIris) {
+      if (!fileIriToOntologyUri.has(fileIri)) {
+        const ontologyUri = fileIriToOntologyURIFromFilename(fileIri);
+        if (ontologyUri) {
+          fileIriToOntologyUri.set(fileIri, ontologyUri);
+        }
+      }
+    }
+
+    // Pass 2a: add identity entries so that fileIri is-a ontologyUri.
+    // Example: <dda12c48-file-IRI> rdfs:label "ims__Concept"
+    // → isSubClassOf("dda12c48-file-IRI", "ims#Concept") must return true.
+    // This handles the case where exo__Instance_class stores a UUID wikilink
+    // (resolves to file IRI) but the range check uses the ontology URI.
+    for (const [fileIri, ontUri] of fileIriToOntologyUri) {
+      const selfSet = this.subClassMap.get(fileIri) ?? new Set<string>();
+      selfSet.add(ontUri);
+      this.subClassMap.set(fileIri, selfSet);
+    }
+
+    // Pass 2b: build subClassMap for both file IRIs and ontology URIs
+    for (const t of triples) {
+      if (
+        t.predicate instanceof DomainIRI &&
+        t.predicate.value === RDFS_SUBCLASS_OF &&
+        t.subject instanceof DomainIRI &&
+        t.object instanceof DomainIRI
+      ) {
+        const childFileIri = t.subject.value;
+        const parentFileIri = t.object.value;
+
+        // File IRI hierarchy entry (original behaviour)
+        const fileSet = this.subClassMap.get(childFileIri) ?? new Set<string>();
+        fileSet.add(parentFileIri);
+        this.subClassMap.set(childFileIri, fileSet);
+
+        // Ontology URI hierarchy entry (enables isSubClassOf for ontology URIs).
+        // The parent object may already be an ontology URI (when [[exo__Asset]] wikilink
+        // resolves to a class-named file and NoteToRDFConverter emits the namespace IRI
+        // directly). In that case, use it as-is; otherwise look it up via fileIriToOntologyUri
+        // or fall back to the filename-derived mapping.
+        const childOntUri = fileIriToOntologyUri.get(childFileIri);
+        const parentOntUri = parentFileIri.startsWith("obsidian://")
+          ? fileIriToOntologyUri.get(parentFileIri)
+          : parentFileIri; // already an ontology URI
+        if (childOntUri && parentOntUri) {
+          const ontSet = this.subClassMap.get(childOntUri) ?? new Set<string>();
+          ontSet.add(parentOntUri);
+          this.subClassMap.set(childOntUri, ontSet);
+        }
       }
     }
   }

--- a/packages/cli/tests/unit/commands/validate-schema.test.ts
+++ b/packages/cli/tests/unit/commands/validate-schema.test.ts
@@ -54,10 +54,13 @@ const {
   validateFile,
   extractPropertyNameFromURI,
   TripleClassHierarchy,
+  labelToOntologyIRI,
   domainToAlgebraTriples,
   buildEARLReport,
   runShapesValidation,
 } = await import("../../../src/commands/validate-schema.js");
+
+const { DomainIRI, DomainLiteral } = await import("exocortex");
 
 const TMP_DIR = "/tmp/validate-schema-test-" + Date.now();
 
@@ -474,6 +477,132 @@ describe("P1.6 TripleClassHierarchy", () => {
 
   it("is instantiated without errors from an empty array", () => {
     expect(() => new TripleClassHierarchy([])).not.toThrow();
+  });
+});
+
+describe("P1.6 labelToOntologyIRI", () => {
+  it("converts ims__Concept to ontology URI", () => {
+    expect(labelToOntologyIRI("ims__Concept")).toBe("https://exocortex.my/ontology/ims#Concept");
+  });
+
+  it("converts exo__Asset to ontology URI", () => {
+    expect(labelToOntologyIRI("exo__Asset")).toBe("https://exocortex.my/ontology/exo#Asset");
+  });
+
+  it("converts ems__Task to ontology URI", () => {
+    expect(labelToOntologyIRI("ems__Task")).toBe("https://exocortex.my/ontology/ems#Task");
+  });
+
+  it("returns null for label without double-underscore", () => {
+    expect(labelToOntologyIRI("SomePlainLabel")).toBeNull();
+  });
+
+  it("returns null for label with unknown prefix", () => {
+    expect(labelToOntologyIRI("unknown__Foo")).toBeNull();
+  });
+
+  it("returns null for label with prefix only (no local name)", () => {
+    expect(labelToOntologyIRI("ims__")).toBeNull();
+  });
+});
+
+describe("P1.6 TripleClassHierarchy ontology URI resolution", () => {
+  const RDFS_SUBCLASS_OF = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+  const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
+
+  function makeIRI(value: string) { return new DomainIRI(value); }
+  function makeLiteral(value: string) { return new DomainLiteral(value); }
+  function makeTriple(s: any, p: any, o: any) { return { subject: s, predicate: p, object: o }; }
+
+  it("resolves isSubClassOf via ontology URIs when rdfs:label triples are present", () => {
+    const conceptFileIri = "obsidian://vault/ims/ims-concept.md";
+    const assetFileIri = "obsidian://vault/exo/exo-asset.md";
+
+    const triples = [
+      // rdfs:label for ims__Concept file
+      makeTriple(makeIRI(conceptFileIri), makeIRI(RDFS_LABEL), makeLiteral("ims__Concept")),
+      // rdfs:label for exo__Asset file
+      makeTriple(makeIRI(assetFileIri), makeIRI(RDFS_LABEL), makeLiteral("exo__Asset")),
+      // rdfs:subClassOf (file IRI based)
+      makeTriple(makeIRI(conceptFileIri), makeIRI(RDFS_SUBCLASS_OF), makeIRI(assetFileIri)),
+    ];
+
+    const hier = new TripleClassHierarchy(triples);
+
+    // Ontology URI-based check (the previously broken case)
+    expect(hier.isSubClassOf(
+      "https://exocortex.my/ontology/ims#Concept",
+      "https://exocortex.my/ontology/exo#Asset"
+    )).toBe(true);
+
+    // File IRI-based check still works
+    expect(hier.isSubClassOf(conceptFileIri, assetFileIri)).toBe(true);
+  });
+
+  it("returns true when checking fileIRI against its own ontology URI (identity mapping)", () => {
+    // exo__Instance_class [[UUID|ims__Concept]] → NoteToRDFConverter emits ims#Concept as class
+    // But when another file references UUID, it may produce UUID-file-IRI as the type.
+    // TripleClassHierarchy must also handle isSubClassOf("UUID-file-IRI", "ims#Concept").
+    const conceptFileIri = "obsidian://vault/ims/dda12c48-1234.md";
+
+    const triples = [
+      makeTriple(makeIRI(conceptFileIri), makeIRI(RDFS_LABEL), makeLiteral("ims__Concept")),
+    ];
+
+    const hier = new TripleClassHierarchy(triples);
+
+    // fileIRI "is" ims#Concept because it declares rdfs:label "ims__Concept"
+    expect(hier.isSubClassOf(conceptFileIri, "https://exocortex.my/ontology/ims#Concept")).toBe(true);
+  });
+
+  it("returns false for unrelated ontology URIs", () => {
+    const hier = new TripleClassHierarchy([]);
+    expect(hier.isSubClassOf(
+      "https://exocortex.my/ontology/ims#Concept",
+      "https://exocortex.my/ontology/ems#Task"
+    )).toBe(false);
+  });
+
+  it("resolves isSubClassOf via filename fallback when no rdfs:label triple exists", () => {
+    // exo__Asset.md has no exo__Asset_label, so no rdfs:label triple
+    // but filename "exo__Asset.md" can be decoded from the file IRI
+    const conceptFileIri = "obsidian://vault/03%20Knowledge/ims/dda12c48-6886-4624-8710.md";
+    const assetFileIri = "obsidian://vault/03%20Knowledge/exo/exo__Asset.md";
+
+    const triples = [
+      // UUID-named concept file has rdfs:label "ims__Concept"
+      makeTriple(makeIRI(conceptFileIri), makeIRI(RDFS_LABEL), makeLiteral("ims__Concept")),
+      // Label-named asset file has no rdfs:label — fallback to filename
+      makeTriple(makeIRI(conceptFileIri), makeIRI(RDFS_SUBCLASS_OF), makeIRI(assetFileIri)),
+    ];
+
+    const hier = new TripleClassHierarchy(triples);
+
+    expect(hier.isSubClassOf(
+      "https://exocortex.my/ontology/ims#Concept",
+      "https://exocortex.my/ontology/exo#Asset"
+    )).toBe(true);
+  });
+
+  it("resolves transitive ontology URI hierarchy", () => {
+    const conceptFileIri = "obsidian://vault/ims/concept.md";
+    const assetFileIri = "obsidian://vault/exo/asset.md";
+    const thingFileIri = "obsidian://vault/exo/thing.md";
+
+    const triples = [
+      makeTriple(makeIRI(conceptFileIri), makeIRI(RDFS_LABEL), makeLiteral("ims__Concept")),
+      makeTriple(makeIRI(assetFileIri), makeIRI(RDFS_LABEL), makeLiteral("exo__Asset")),
+      makeTriple(makeIRI(thingFileIri), makeIRI(RDFS_LABEL), makeLiteral("exo__Thing")),
+      makeTriple(makeIRI(conceptFileIri), makeIRI(RDFS_SUBCLASS_OF), makeIRI(assetFileIri)),
+      makeTriple(makeIRI(assetFileIri), makeIRI(RDFS_SUBCLASS_OF), makeIRI(thingFileIri)),
+    ];
+
+    const hier = new TripleClassHierarchy(triples);
+
+    expect(hier.isSubClassOf(
+      "https://exocortex.my/ontology/ims#Concept",
+      "https://exocortex.my/ontology/exo#Thing"
+    )).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Root cause**: `TripleClassHierarchy` stored only file IRIs from `rdfs:subClassOf` triples, but `exo__Instance_class` values are converted to ontology URIs by `NoteToRDFConverter` via `valueToClassURI` (alias extraction from `[[UUID|ims__Concept]]` wikilinks). This caused `isSubClassOf("ims#Concept", "exo#Asset")` to always return `false`, producing false `sh:class` violations for all instance types with superclass chains.
- **Fix**: Two-pass approach in `TripleClassHierarchy` constructor:
  1. Build `fileIRI → ontologyURI` map from `rdfs:label` triples (explicit) + filename fallback for label-named class files like `exo__Asset.md`
  2. Add identity entries: each class file IRI "is" its corresponding ontology URI — enables `isSubClassOf("<UUID-file-IRI>", "ims#Concept")` to return `true` when the file has `rdfs:label "ims__Concept"`
  3. Build `subClassMap` entries for both file IRIs (original behaviour) and ontology URIs (new)
- **New export**: `labelToOntologyIRI()` converts dunder-style labels (`ims__Concept`) to ontology URIs

## Test plan

- [ ] All 59 existing + new unit tests pass (`packages/cli/tests/unit/commands/validate-schema.test.ts`)
- [ ] 5 new test cases covering: rdfs:label-based resolution, identity mapping (fileIRI IS the class), filename fallback, transitive hierarchy, negative case
- [ ] Full CI suite green