### PR TITLE
fix(cli): emit single-cardinality wikilink properties as scalars (#3099)

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { resolve } from "path";
 import { existsSync } from "fs";
 import { readFileSync } from "fs";
+import { ShapeLoader, type ShapeRegistry } from "exocortex";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { ClassResolverService } from "../services/ClassResolverService.js";
 import { WikilinkValidator } from "../services/WikilinkValidator.js";
@@ -201,10 +202,22 @@ export function createCommand(): Command {
         const fsAdapter = new NodeFsAdapter(vaultPath);
         const classResolver = new ClassResolverService(fsAdapter);
         const wikilinkValidator = new WikilinkValidator(fsAdapter);
+
+        // Load SHACL-lite shape registry from vault for cardinality-aware
+        // property serialization (issue #3099). Failure here is non-fatal —
+        // proceed with default array wrapping if shapes cannot be loaded.
+        let shapeRegistry: ShapeRegistry | undefined;
+        try {
+          shapeRegistry = await ShapeLoader.loadFromVaultFS(vaultPath);
+        } catch {
+          shapeRegistry = undefined;
+        }
+
         const creationService = new AssetCreationService(
           fsAdapter,
           classResolver,
           wikilinkValidator,
+          shapeRegistry,
         );
 
         // Execute creation

--- a/packages/cli/src/services/AssetCreationService.ts
+++ b/packages/cli/src/services/AssetCreationService.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
-import { DateFormatter, MetadataHelpers } from "exocortex";
+import { DateFormatter, MetadataHelpers, Namespace } from "exocortex";
+import type { ShapeRegistry } from "exocortex";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { ClassResolverService } from "./ClassResolverService.js";
 import { WikilinkValidator } from "./WikilinkValidator.js";
@@ -74,6 +75,14 @@ export class AssetCreationService {
     private readonly fsAdapter: NodeFsAdapter,
     private readonly classResolver: ClassResolverService,
     private readonly wikilinkValidator: WikilinkValidator,
+    /**
+     * Optional SHACL-lite shape registry loaded from vault property assets.
+     * When provided, properties declared with
+     * `exo__Property_cardinality: "[[exo__PropertyCardinalitySingle]]"`
+     * are serialized as scalar YAML values instead of single-entry arrays.
+     * When omitted, all wikilink values are wrapped in arrays (legacy default).
+     */
+    private readonly shapeRegistry?: ShapeRegistry,
   ) {}
 
   /**
@@ -187,7 +196,7 @@ export class AssetCreationService {
         ) {
           continue;
         }
-        fm[key] = this.formatPropertyValue(value);
+        fm[key] = this.formatPropertyValue(key, value);
       }
     }
 
@@ -197,13 +206,18 @@ export class AssetCreationService {
   /**
    * Format a property value for frontmatter.
    *
-   * Wikilink values (containing `[[`) are quoted and wrapped in a YAML array
-   * so Obsidian can parse them correctly. Plain values are left as scalars.
+   * Wikilink values (containing `[[`) are quoted. By default they are wrapped
+   * in a single-entry YAML array so Obsidian can parse them as a list. If the
+   * shape registry declares the property's cardinality as `"Single"`, the
+   * quoted value is emitted as a scalar instead (issue #3099).
    *
+   * Plain (non-wikilink) values are always left as scalars.
+   *
+   * @param key - The property key (e.g. `ems__Effort_status`)
    * @param value - The raw property value string
-   * @returns Formatted value: `string` for plain values, `string[]` for wikilinks
+   * @returns Formatted value: `string` for plain or single-cardinality wikilinks, `string[]` for arrays
    */
-  private formatPropertyValue(value: string): string | string[] {
+  private formatPropertyValue(key: string, value: string): string | string[] {
     if (!value.includes("[[")) {
       return value;
     }
@@ -212,8 +226,28 @@ export class AssetCreationService {
     const quoted =
       value.startsWith('"') && value.endsWith('"') ? value : `"${value}"`;
 
-    // Wrap in array for YAML list format
+    if (this.isSingleValued(key)) {
+      return quoted;
+    }
+
+    // Default: wrap in array for YAML list format
     return [quoted];
+  }
+
+  /**
+   * Check whether a property is declared single-valued in the shape registry.
+   *
+   * Safe default: `false` (treat as multi-valued / wrap in array) when no
+   * registry is provided, when the property has no shape, or when its
+   * cardinality is not explicitly `"Single"`.
+   */
+  private isSingleValued(key: string): boolean {
+    if (!this.shapeRegistry) return false;
+    const parsed = Namespace.fromPropertyKey(key);
+    if (!parsed) return false;
+    const propertyIRI = parsed.namespace.term(parsed.localName).value;
+    const shape = this.shapeRegistry.get(propertyIRI);
+    return shape?.cardinality === "Single";
   }
 
   /**

--- a/packages/cli/tests/unit/commands/create.test.ts
+++ b/packages/cli/tests/unit/commands/create.test.ts
@@ -13,6 +13,28 @@ jest.unstable_mockModule("exocortex", () => ({
   IFileSystemAdapter: {},
   FileNotFoundError: class FileNotFoundError extends Error {},
   FileAlreadyExistsError: class FileAlreadyExistsError extends Error {},
+  Namespace: {
+    fromPropertyKey: (key: string) => {
+      const match = /^([a-z][a-zA-Z0-9]*)__(.+)$/.exec(key);
+      if (!match) return null;
+      return {
+        namespace: {
+          term: (localName: string) => ({
+            value: `https://exocortex.my/ontology/${match[1]}#${localName}`,
+          }),
+        },
+        localName: match[2],
+      };
+    },
+  },
+  ShapeLoader: {
+    loadFromVaultFS: jest.fn(async () => ({
+      get: () => undefined,
+      getAll: () => [],
+      register: () => undefined,
+      size: 0,
+    })),
+  },
 }));
 
 // Mock fs-extra (NodeFsAdapter dependency)

--- a/packages/cli/tests/unit/services/AssetCreationService.test.ts
+++ b/packages/cli/tests/unit/services/AssetCreationService.test.ts
@@ -36,6 +36,20 @@ jest.unstable_mockModule("exocortex", () => ({
     toLocalTimestamp: jest.fn(() => "2026-03-21T15:30:00"),
   },
   MetadataHelpers: mockMetadataHelpers,
+  Namespace: {
+    fromPropertyKey: (key: string) => {
+      const match = /^([a-z][a-zA-Z0-9]*)__(.+)$/.exec(key);
+      if (!match) return null;
+      return {
+        namespace: {
+          term: (localName: string) => ({
+            value: `https://exocortex.my/ontology/${match[1]}#${localName}`,
+          }),
+        },
+        localName: match[2],
+      };
+    },
+  },
 }));
 
 // Mock services
@@ -267,6 +281,137 @@ describe("AssetCreationService", () => {
         expect(result.frontmatter["exo__Asset_relates"]).toEqual(
           ['"[[some-uuid|Label]]"'],
         );
+      });
+    });
+
+    describe("Issue #3099: cardinality-aware wikilink serialization", () => {
+      const propertyIRI = (prefix: string, local: string) =>
+        `https://exocortex.my/ontology/${prefix}#${local}`;
+
+      const buildRegistry = (
+        entries: Array<{ key: string; cardinality: "Single" | "Multiple" }>,
+      ) => {
+        const map = new Map<string, { cardinality: "Single" | "Multiple" }>();
+        for (const { key, cardinality } of entries) {
+          const match = /^([a-z][a-zA-Z0-9]*)__(.+)$/.exec(key);
+          if (!match) continue;
+          map.set(propertyIRI(match[1], match[2]), { cardinality });
+        }
+        return {
+          get: (iri: string) => map.get(iri),
+        };
+      };
+
+      it("should emit scalar for properties declared PropertyCardinalitySingle", async () => {
+        const registry = buildRegistry([
+          { key: "ems__Effort_status", cardinality: "Single" },
+        ]);
+        const singleService = new AssetCreationService(
+          mockFsAdapter as any,
+          mockClassResolver as any,
+          mockWikilinkValidator as any,
+          registry as any,
+        );
+
+        const result = await singleService.create({
+          classShortName: "ems__Task",
+          label: "Test Task",
+          vault: "/vault",
+          properties: {
+            "ems__Effort_status": "[[ems__EffortStatusBacklog]]",
+          },
+        });
+
+        expect(result.frontmatter["ems__Effort_status"]).toBe(
+          '"[[ems__EffortStatusBacklog]]"',
+        );
+      });
+
+      it("should emit array for properties declared PropertyCardinalityMultiple", async () => {
+        const registry = buildRegistry([
+          { key: "ems__Effort_prototype", cardinality: "Multiple" },
+        ]);
+        const multiService = new AssetCreationService(
+          mockFsAdapter as any,
+          mockClassResolver as any,
+          mockWikilinkValidator as any,
+          registry as any,
+        );
+
+        const result = await multiService.create({
+          classShortName: "ems__Task",
+          label: "Test Task",
+          vault: "/vault",
+          properties: {
+            "ems__Effort_prototype": "[[some-uuid|Proto]]",
+          },
+        });
+
+        expect(result.frontmatter["ems__Effort_prototype"]).toEqual([
+          '"[[some-uuid|Proto]]"',
+        ]);
+      });
+
+      it("should emit array (legacy default) for properties not in registry", async () => {
+        const registry = buildRegistry([]);
+        const emptyService = new AssetCreationService(
+          mockFsAdapter as any,
+          mockClassResolver as any,
+          mockWikilinkValidator as any,
+          registry as any,
+        );
+
+        const result = await emptyService.create({
+          classShortName: "ems__Task",
+          label: "Test Task",
+          vault: "/vault",
+          properties: {
+            "ems__Effort_status": "[[ems__EffortStatusBacklog]]",
+          },
+        });
+
+        expect(result.frontmatter["ems__Effort_status"]).toEqual([
+          '"[[ems__EffortStatusBacklog]]"',
+        ]);
+      });
+
+      it("should emit array (legacy default) when no shape registry is provided", async () => {
+        // Service constructed without registry (existing behavior)
+        const result = await service.create({
+          classShortName: "ems__Task",
+          label: "Test Task",
+          vault: "/vault",
+          properties: {
+            "ems__Effort_status": "[[ems__EffortStatusBacklog]]",
+          },
+        });
+
+        expect(result.frontmatter["ems__Effort_status"]).toEqual([
+          '"[[ems__EffortStatusBacklog]]"',
+        ]);
+      });
+
+      it("should leave plain (non-wikilink) values as scalars regardless of cardinality", async () => {
+        const registry = buildRegistry([
+          { key: "custom_prop", cardinality: "Single" },
+        ]);
+        const singleService = new AssetCreationService(
+          mockFsAdapter as any,
+          mockClassResolver as any,
+          mockWikilinkValidator as any,
+          registry as any,
+        );
+
+        const result = await singleService.create({
+          classShortName: "ems__Task",
+          label: "Test Task",
+          vault: "/vault",
+          properties: {
+            "custom_prop": "plain value",
+          },
+        });
+
+        expect(result.frontmatter["custom_prop"]).toBe("plain value");
       });
     });
 

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -496,7 +496,8 @@ export * from "./domain/errors";
 
 // SHACL-lite validation engine (RFC 82a72aca)
 export { ShapeLoader, type ShapeJSONCache } from "./services/ShapeLoader";
-export { ShapeRegistry } from "./services/ShapeRegistry";
+export { ShapeRegistry, type Shape } from "./services/ShapeRegistry";
+export { Namespace } from "./domain/models/rdf/Namespace";
 export {
   validate as shaclValidate,
   ShapeRegistry as ShaclShapeRegistry,

--- a/packages/exocortex/src/services/ShapeLoader.ts
+++ b/packages/exocortex/src/services/ShapeLoader.ts
@@ -159,7 +159,12 @@ export class ShapeLoader {
       if (entry.isDirectory()) {
         await ShapeLoader.scanDir(full, registry, io);
       } else if (entry.isFile() && entry.name.endsWith(".md")) {
-        await ShapeLoader.processFile(full, registry, io.readFile);
+        // Fail-soft: one malformed property asset should not abort the scan.
+        try {
+          await ShapeLoader.processFile(full, registry, io.readFile, io.path);
+        } catch {
+          // Skip the offending file silently
+        }
       }
     }
   }
@@ -168,6 +173,7 @@ export class ShapeLoader {
     filePath: string,
     registry: ShapeRegistry,
     readFile: (p: string, enc: "utf-8") => Promise<string>,
+    path?: typeof import("path"),
   ): Promise<void> {
     let content: string;
     try {
@@ -192,9 +198,20 @@ export class ShapeLoader {
     });
     if (!isProperty) return;
 
+    // Resolve label: prefer explicit `exo__Asset_label`, fall back to filename
+    // basename for property assets that omit the label field (issue #3099).
+    let label: string | null = null;
     const labelRaw = fm["exo__Asset_label"];
-    if (!labelRaw || typeof labelRaw !== "string") return;
-    const label = labelRaw.trim();
+    if (typeof labelRaw === "string" && labelRaw.trim().length > 0) {
+      label = labelRaw.trim();
+    } else if (path) {
+      const basename = path.basename(filePath, ".md");
+      if (Namespace.fromPropertyKey(basename)) {
+        label = basename;
+      }
+    }
+    if (!label) return;
+
     const propertyIRI = ShapeLoader.labelToIRI(label);
     if (!propertyIRI) return;
 


### PR DESCRIPTION
## Summary

`exocortex-cli create --property X=[[uuid|Label]]` previously wrapped every wikilink value in a YAML array, ignoring the property's declared cardinality. After this fix, properties whose shape declares `exo__Property_cardinality: "[[exo__PropertyCardinalitySingle]]"` are serialized as scalar YAML; everything else keeps the legacy array-wrap (safe default).

Closes #3099.

## Changes

- **`AssetCreationService`** now accepts an optional `ShapeRegistry`. `formatPropertyValue(key, value)` looks up the property's shape; `cardinality === "Single"` → scalar, otherwise → single-entry array.
- **`create.ts`** loads the registry via `ShapeLoader.loadFromVaultFS(vaultPath)` on every invocation; any load failure falls through to the legacy array behaviour.
- **`ShapeLoader.processFile`** falls back to filename basename when a property asset omits `exo__Asset_label` (real-world property files like `ems__Effort_status.md`, `ems__Effort_prototype.md` typically don't carry the label field — their basename is the canonical label). The directory scan is now fail-soft so one malformed property asset cannot abort the entire walk.
- **`exocortex` package** now exports `Namespace` and `Shape` so the CLI can compute property IRIs without duplicating the prefix parser.

## Test plan

- [x] `AssetCreationService.test.ts` — 5 new units (Single → scalar, Multiple → array, no-registry default, missing-shape default, plain non-wikilink value)
- [x] `create.test.ts` — `Namespace` and `ShapeLoader` added to the `exocortex` mock
- [x] All 35 existing `ShapeLoader` tests stay green
- [x] Root `npm run check:types` passes
- [x] **Live smoke** against `/Users/kitelev/vault-2025` after declaring `ems__Effort_status` as `PropertyCardinalitySingle` in the property asset:
  ```
  ems__Effort_status: "[[ems__EffortStatusBacklog]]"   ← scalar (was an array before)
  ```

## Impact

Resolves the root cause of the 130 task instances that landed with array-wrapped `ems__Effort_status` during the 2026-05-11 week-planner run. Going forward, declaring `exo__Property_cardinality: "[[exo__PropertyCardinalitySingle]]"` on a property asset is enough to make `cli create` emit scalar YAML for that property — no caller changes required.