### PR TITLE
feat: extend create_instance with copy-from-target + linkBackProperty

### DIFF
--- a/packages/cli/specs/features/groundings.feature
+++ b/packages/cli/specs/features/groundings.feature
@@ -64,3 +64,18 @@ Feature: Starter-kit grounding execution (RFC 94e520da § Phase 6)
       | ef1d12dc-6a65-4f1d-b7f5-d5c5367d9633 | property_set    | real         | Set status to Blocked |
       | f32de9a1-f62b-4406-8610-31af5003ba29 | property_set    | real         | Set status to Cancelled |
       | f9e23c9e-174b-456c-a2f0-c11f811a7ee6 | composite       | real         | Transition to Done (status + end + resolution) |
+
+  # Task 4.3 (onto-RFC 74c5e336 §Phase 4) — verifies the create_instance
+  # behaviour change: copy-from-target frontmatter inheritance + configurable
+  # back-link via exocmd__Grounding_linkBackProperty, with the legacy
+  # exo__Asset_source back-link suppressed when linkBackProperty is set.
+  Scenario: create_instance grounding copies fields from $target and writes configurable back-link
+    Given a Grounding with type "create_instance"
+    And targetClass "ems__Task"
+    And linkBackProperty "ems__Effort_prevIteration"
+    And a $target "ems__Task" with frontmatter "exo__Asset_prototype: [[X]]"
+    When I execute the grounding
+    Then a new "ems__Task" is created
+    And the created asset has "exo__Asset_prototype: [[X]]"
+    And the created asset has "ems__Effort_prevIteration" pointing to $target
+    And the created asset does NOT have "exo__Asset_source"

--- a/packages/cli/specs/step_definitions/grounding.steps.ts
+++ b/packages/cli/specs/step_definitions/grounding.steps.ts
@@ -275,6 +275,165 @@ When(
   },
 );
 
+// --- Task 4.3 — create_instance + linkBackProperty bespoke scenario ---
+
+const LINKBACK_TARGET_REL = "01 Inbox/bdd-linkback-target.md";
+const LINKBACK_CREATED_FOLDER = "01 Inbox/bdd-linkback-created";
+
+Given(
+  "a Grounding with type {string}",
+  function (this: CliBddWorld, type: string) {
+    this.groundingDraft = { type };
+    // Use a dedicated subfolder for the new instance so we can find it
+    // deterministically without scanning the entire vault.
+    this.groundingDraft.targetFolder = LINKBACK_CREATED_FOLDER;
+    this.customCreatedFrontmatter = null;
+  },
+);
+
+Given(
+  "targetClass {string}",
+  function (this: CliBddWorld, targetClass: string) {
+    assert.ok(this.groundingDraft, "Grounding draft must be initialized");
+    this.groundingDraft!.targetClass = targetClass;
+  },
+);
+
+Given(
+  "linkBackProperty {string}",
+  function (this: CliBddWorld, prop: string) {
+    assert.ok(this.groundingDraft, "Grounding draft must be initialized");
+    this.groundingDraft!.linkBackProperty = prop;
+  },
+);
+
+Given(
+  "a $target {string} with frontmatter {string}",
+  function (this: CliBddWorld, _instanceClass: string, fmLine: string) {
+    assert.ok(this.fixtureVaultPath, "vault path missing");
+    const vault = this.fixtureVaultPath!;
+    const targetAbs = join(vault, LINKBACK_TARGET_REL);
+    mkdirSync(dirname(targetAbs), { recursive: true });
+
+    const colonIdx = fmLine.indexOf(":");
+    assert.ok(colonIdx > 0, `Malformed frontmatter line: ${fmLine}`);
+    const key = fmLine.slice(0, colonIdx).trim();
+    const rawValue = fmLine.slice(colonIdx + 1).trim();
+    // Wrap wikilink values in quotes so YAML keeps them as strings.
+    const yamlValue = /^\[\[.*\]\]$/.test(rawValue) ? `"${rawValue}"` : rawValue;
+
+    const content = `---\nexo__Asset_uid: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\nexo__Asset_label: "Linkback BDD Target"\nexo__Instance_class:\n  - "[[${_instanceClass}]]"\n${key}: ${yamlValue}\n---\n\n# Linkback BDD Target\n`;
+    writeFileSync(targetAbs, content, "utf8");
+    this.customTargetRelPath = LINKBACK_TARGET_REL;
+  },
+);
+
+When("I execute the grounding", async function (this: CliBddWorld) {
+  assert.ok(this.fixtureVaultPath, "vault path missing");
+  assert.ok(this.groundingDraft, "grounding draft missing");
+  assert.ok(this.customTargetRelPath, "custom target path missing");
+  const vault = this.fixtureVaultPath!;
+  const targetRel = this.customTargetRelPath!;
+  const targetIRI = targetRel.replace(/\.md$/, "");
+  const draft = this.groundingDraft!;
+
+  const grounding: GroundingDefinition = {
+    id: "bdd-task-4.3-linkback",
+    label: "Task 4.3 — linkBackProperty BDD",
+    type: draft.type as GroundingType,
+    targetClass: draft.targetClass,
+    targetFolder: draft.targetFolder,
+    targetPrototype: draft.targetPrototype,
+    linkBackProperty: draft.linkBackProperty,
+  };
+
+  // Clean any leftover created files from a prior run so we can deterministically
+  // find the single new file the executor produces.
+  const createdFolderAbs = join(vault, LINKBACK_CREATED_FOLDER);
+  if (existsSync(createdFolderAbs)) {
+    rmSync(createdFolderAbs, { recursive: true, force: true });
+  }
+
+  const { executor } = buildExecutor(vault);
+  const result = await executor.execute(grounding, targetIRI, targetRel, undefined);
+
+  this.groundingResult = {
+    success: result.success,
+    error: result.error,
+  };
+
+  if (!result.success) return;
+
+  // Locate the single .md file the executor wrote inside targetFolder.
+  assert.ok(existsSync(createdFolderAbs), `targetFolder missing: ${createdFolderAbs}`);
+  const created = readdirSync(createdFolderAbs).filter((n) => n.endsWith(".md"));
+  assert.equal(created.length, 1, `Expected exactly 1 created file, got ${created.length}`);
+  const createdAbs = join(createdFolderAbs, created[0]);
+  this.customCreatedFrontmatter = parseFrontmatter(readFileSync(createdAbs, "utf8"));
+});
+
+Then(
+  "a new {string} is created",
+  function (this: CliBddWorld, instanceClass: string) {
+    assert.ok(this.groundingResult?.success, `grounding failed: ${this.groundingResult?.error}`);
+    assert.ok(this.customCreatedFrontmatter, "created frontmatter missing");
+    const cls = this.customCreatedFrontmatter!["exo__Instance_class"];
+    const flat = Array.isArray(cls) ? cls.join(",") : String(cls ?? "");
+    assert.ok(
+      flat.includes(instanceClass),
+      `Expected exo__Instance_class to contain ${instanceClass}, got ${flat}`,
+    );
+  },
+);
+
+Then(
+  "the created asset has {string}",
+  function (this: CliBddWorld, fmLine: string) {
+    assert.ok(this.customCreatedFrontmatter, "created frontmatter missing");
+    const colonIdx = fmLine.indexOf(":");
+    assert.ok(colonIdx > 0, `Malformed frontmatter expectation: ${fmLine}`);
+    const key = fmLine.slice(0, colonIdx).trim();
+    const expected = fmLine.slice(colonIdx + 1).trim();
+    const actualRaw = this.customCreatedFrontmatter![key];
+    const actual = typeof actualRaw === "string" ? actualRaw : String(actualRaw);
+    // Normalize wikilink shape — copied values are stored as "[[X]]" but the
+    // YAML parser strips the wrapping quotes leaving [[X]].
+    const normalize = (s: string) => s.replace(/^"|"$/g, "").trim();
+    assert.equal(
+      normalize(actual),
+      normalize(expected),
+      `Property ${key} mismatch: expected ${expected}, got ${actualRaw}`,
+    );
+  },
+);
+
+Then(
+  "the created asset has {string} pointing to $target",
+  function (this: CliBddWorld, key: string) {
+    assert.ok(this.customCreatedFrontmatter, "created frontmatter missing");
+    assert.ok(this.customTargetRelPath, "custom target path missing");
+    const targetIRI = this.customTargetRelPath!.replace(/\.md$/, "");
+    const value = this.customCreatedFrontmatter![key];
+    const flat = typeof value === "string" ? value : String(value);
+    assert.ok(
+      flat.includes(targetIRI),
+      `Expected ${key} to wikilink-reference ${targetIRI}, got ${flat}`,
+    );
+  },
+);
+
+Then(
+  "the created asset does NOT have {string}",
+  function (this: CliBddWorld, key: string) {
+    assert.ok(this.customCreatedFrontmatter, "created frontmatter missing");
+    assert.equal(
+      this.customCreatedFrontmatter![key],
+      undefined,
+      `Property ${key} should be absent, got ${JSON.stringify(this.customCreatedFrontmatter![key])}`,
+    );
+  },
+);
+
 Then(
   "the result should match the expected fixture for {string}",
   function (this: CliBddWorld, uid: string) {

--- a/packages/cli/specs/support/world.ts
+++ b/packages/cli/specs/support/world.ts
@@ -22,6 +22,21 @@ export interface GroundingRunResult {
   frontmatterAfter?: Record<string, unknown>;
 }
 
+/**
+ * Loose in-memory draft of a GroundingDefinition built piece-by-piece by
+ * multiple Given steps for the RFC-024 create_instance + linkBackProperty
+ * scenario (Task 4.3). Kept structurally compatible with the production type
+ * but typed locally so the BDD layer does not have to import the executor's
+ * full GroundingDefinition shape.
+ */
+export interface GroundingDraft {
+  type?: string;
+  targetClass?: string;
+  targetFolder?: string;
+  targetPrototype?: string;
+  linkBackProperty?: string;
+}
+
 export class CliBddWorld extends World {
   initialized = false;
   recordedValue: string | null = null;
@@ -31,6 +46,11 @@ export class CliBddWorld extends World {
   fixtureVaultPath: string | null = null;
   testTargetRelPath: string | null = null;
   groundingResult: GroundingRunResult | null = null;
+
+  // Task 4.3 — bespoke create_instance + linkBackProperty scenario state
+  groundingDraft: GroundingDraft | null = null;
+  customTargetRelPath: string | null = null;
+  customCreatedFrontmatter: Record<string, unknown> | null = null;
 
   constructor(options: IWorldOptions) {
     super(options);

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -95,6 +95,14 @@ export interface GroundingDefinition {
   readonly targetPrototype?: string;
   /** Vault-relative folder path (for create_instance, e.g., "01 Inbox") */
   readonly targetFolder?: string;
+  /**
+   * Frontmatter property name on the newly created instance where the plugin
+   * writes the `[[$target]]` wikilink back to the source asset (for
+   * `create_instance` grounding).
+   *
+   * If absent → fallback to hardcoded `exo__Asset_source`.
+   */
+  readonly linkBackProperty?: string;
 }
 
 /**

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -814,6 +814,7 @@ export class CommandResolver {
     const targetClass = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetClass"));
     const targetPrototype = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetPrototype"));
     const targetFolder = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetFolder"));
+    const linkBackProperty = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_linkBackProperty"));
     const inputSchemaRaw = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_inputSchema"));
 
     // Load composite steps if applicable
@@ -853,6 +854,7 @@ export class CommandResolver {
       targetClass: targetClass ?? undefined,
       targetPrototype: targetPrototype ?? undefined,
       targetFolder: targetFolder ?? undefined,
+      linkBackProperty: linkBackProperty ?? undefined,
     };
 
     if (inputSchema) {

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -174,6 +174,7 @@ export class GroundingExecutor {
           return await this.executeCreateInstance(
             grounding,
             targetIRI,
+            targetFilePath,
             userInput,
           );
 
@@ -447,9 +448,32 @@ export class GroundingExecutor {
     return { success: true };
   }
 
+  /**
+   * Frontmatter keys that must NEVER be copied from $target into a newly
+   * created instance. These either identify the source asset (uid, label,
+   * aliases, createdAt) or describe its lifecycle state (status, timestamps),
+   * neither of which is meaningful on the new asset. exo__Instance_class is
+   * blacklisted because the new instance has its own class supplied via
+   * grounding.targetClass.
+   */
+  private static readonly CREATE_INSTANCE_BLACKLIST: ReadonlySet<string> =
+    new Set([
+      "exo__Asset_uid",
+      "exo__Asset_createdAt",
+      "exo__Asset_updatedAt",
+      "exo__Instance_class",
+      "exo__Asset_label",
+      "aliases",
+      "ems__Effort_status",
+      "ems__Effort_startTimestamp",
+      "ems__Effort_endTimestamp",
+      "ems__Effort_resolutionTimestamp",
+    ]);
+
   private async executeCreateInstance(
     grounding: GroundingDefinition,
     targetIRI: string,
+    targetFilePath: string,
     userInput?: UserInput,
   ): Promise<ExecutionResult> {
     if (!grounding.targetFolder) {
@@ -477,10 +501,8 @@ export class GroundingExecutor {
       properties.exo__Asset_prototype = `"[[${grounding.targetPrototype}]]"`;
     }
 
-    if (targetIRI) {
-      properties.exo__Asset_source = `"[[${targetIRI}]]"`;
-    }
-
+    // userInput wins over copy-from-target — apply first so the copy-loop
+    // below can skip already-set keys without re-quoting.
     if (userInput) {
       for (const [key, value] of Object.entries(userInput)) {
         if (key === "label") continue;
@@ -489,12 +511,63 @@ export class GroundingExecutor {
       }
     }
 
+    // Copy-from-target: read $target frontmatter and inherit any non-blacklisted
+    // property the new instance does not already have. Wikilink values are
+    // re-quoted so they round-trip through the YAML serializer.
+    if (targetIRI && targetFilePath) {
+      let targetContent: string;
+      try {
+        targetContent = await this.fileReader.readFile(targetFilePath);
+      } catch (error) {
+        return {
+          success: false,
+          error: `create_instance: failed to read $target file "${targetFilePath}": ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+
+      const targetFm = this.frontmatterService.parseObject(targetContent);
+      if (targetFm) {
+        for (const [key, value] of Object.entries(targetFm)) {
+          if (GroundingExecutor.CREATE_INSTANCE_BLACKLIST.has(key)) continue;
+          if (properties[key] !== undefined) continue;
+          properties[key] = this.reformatCopiedValue(value);
+        }
+      }
+    }
+
+    // Back-link to $target — configurable per grounding (RFC Phase 2).
+    // Fallback to legacy `exo__Asset_source` preserves behaviour for existing
+    // groundings that have no `Grounding_linkBackProperty` set.
+    if (targetIRI) {
+      const backLinkProp = grounding.linkBackProperty ?? "exo__Asset_source";
+      properties[backLinkProp] = `"[[${targetIRI}]]"`;
+    }
+
     const content = this.frontmatterService.createFrontmatter("", properties);
     const filePath = `${grounding.targetFolder}/${uid}.md`;
 
     await this.fileWriter.createFile(filePath, content);
 
     return { success: true };
+  }
+
+  /**
+   * Re-quote wikilink values copied from $target frontmatter so they survive
+   * round-trip through the YAML serializer. Mirrors the logic of
+   * `GenericAssetCreationService.formatWikilink` so copy-from-target ассеты
+   * look identical to ones produced by the modal-driven creation path.
+   */
+  private reformatCopiedValue(value: string | string[]): string | string[] {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.reformatWikilink(item));
+    }
+    return this.reformatWikilink(value);
+  }
+
+  private reformatWikilink(value: string): string {
+    if (value.startsWith('"[[') && value.endsWith(']]"')) return value;
+    if (value.startsWith("[[") && value.endsWith("]]")) return `"${value}"`;
+    return value;
   }
 
   private async executeStep(

--- a/packages/exocortex/src/utilities/FrontmatterService.ts
+++ b/packages/exocortex/src/utilities/FrontmatterService.ts
@@ -86,6 +86,65 @@ export class FrontmatterService {
   }
 
   /**
+   * Parse frontmatter into a key/value object.
+   *
+   * Handles `key: value` scalar lines and `key:\n  - item` two-space-indented
+   * YAML arrays — the two shapes Exocortex ассеты actually use. Returns null
+   * when no frontmatter block is present. Used by callers that need to read
+   * another asset's properties (e.g. copy-from-target in create_instance),
+   * where `parse()` (which returns the raw YAML string) is insufficient.
+   *
+   * NOTE: deliberately minimal — does NOT cover inline `[a, b]` arrays, block
+   * scalars, nested maps, or quoted-key edge cases. Match the existing
+   * lightweight parser in ShapeLoader so behaviour is consistent vault-wide
+   * without pulling in a heavyweight YAML dependency.
+   */
+  parseObject(content: string): Record<string, string | string[]> | null {
+    const parsed = this.parse(content);
+    if (!parsed.exists) return null;
+
+    const result: Record<string, string | string[]> = {};
+    const lines = parsed.content.split(/\r?\n/);
+    let currentKey: string | null = null;
+    let currentArray: string[] | null = null;
+
+    const flushArray = (): void => {
+      if (currentKey !== null && currentArray !== null) {
+        result[currentKey] = currentArray;
+      }
+      currentKey = null;
+      currentArray = null;
+    };
+
+    for (const line of lines) {
+      const arrayItem = /^ {2}- (.*)$/.exec(line);
+      if (arrayItem) {
+        if (currentKey !== null && currentArray !== null) {
+          currentArray.push(arrayItem[1].trim());
+        }
+        continue;
+      }
+
+      flushArray();
+
+      const kvMatch = /^([^:\s][^:]*):\s*(.*)$/.exec(line);
+      if (!kvMatch) continue;
+      const key = kvMatch[1].trim();
+      const value = kvMatch[2].trim();
+
+      if (value === "") {
+        currentKey = key;
+        currentArray = [];
+      } else {
+        result[key] = value;
+      }
+    }
+
+    flushArray();
+    return result;
+  }
+
+  /**
    * Update or add a property in frontmatter.
    *
    * - If frontmatter exists and has the property: updates value

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -378,6 +378,49 @@ describe("CommandResolver", () => {
       expect(cmd!.grounding.targetValue).toBe("$today");
     });
 
+    it("should read Grounding_linkBackProperty as IRI wikilink and resolve to bare property name", async () => {
+      const groundingSubject = new IRI(`obsidian://vault/gnd-linkback.md`);
+      await store.addAll([
+        new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-linkback")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("Create Next Iter")),
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("create_instance")),
+        new Triple(
+          groundingSubject,
+          Namespace.EXOCMD.term("Grounding_linkBackProperty"),
+          Namespace.EMS.term("Effort_prevIteration"),
+        ),
+      ]);
+
+      await addCommandAsset(store, {
+        uid: "cmd-linkback",
+        label: "Create Next Iter",
+        groundingRef: "gnd-linkback",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-linkback");
+
+      expect(cmd!.grounding.linkBackProperty).toBe("ems__Effort_prevIteration");
+    });
+
+    it("should set linkBackProperty to undefined when Grounding_linkBackProperty absent", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-no-linkback",
+        label: "No LinkBack",
+        type: "create_instance",
+      });
+
+      await addCommandAsset(store, {
+        uid: "cmd-no-linkback",
+        label: "No LinkBack",
+        groundingRef: "gnd-no-linkback",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-no-linkback");
+
+      expect(cmd!.grounding.linkBackProperty).toBeUndefined();
+    });
+
     it("should return null for missing UID", async () => {
       const cmd = await resolver.loadCommand("non-existent");
       expect(cmd).toBeNull();

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -922,6 +922,253 @@ describe("GroundingExecutor", () => {
       expect(content).toContain(`exo__Asset_uid: ${pathUuid}`);
     });
 
+    // -- Task 2.4: copy-from-target + configurable back-link --
+
+    describe("copy-from-target + linkBackProperty (Task 2.4)", () => {
+      const TARGET_FM = [
+        "---",
+        'exo__Asset_uid: "src-uid"',
+        'exo__Asset_label: "Source asset"',
+        "exo__Instance_class:",
+        '  - "[[ems__Project]]"',
+        "aliases:",
+        "  - Old alias",
+        'ems__Effort_status: "[[ems__EffortStatusDoing]]"',
+        "ems__Effort_startTimestamp: 2026-01-01T10:00:00",
+        'ems__Effort_area: "[[area-uid-42]]"',
+        'ems__Effort_priority: "[[priority-high]]"',
+        "ems__Effort_tags:",
+        '  - "[[tag-alpha]]"',
+        '  - "[[tag-beta]]"',
+        "---",
+        "Body",
+      ].join("\n");
+
+      it("copies $target frontmatter into new asset (blacklist respected)", async () => {
+        reader.readFile.mockResolvedValue(TARGET_FM);
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        await executor.execute(grounding, TARGET_IRI, FILE_PATH, { label: "Sub-task" });
+
+        const [, content] = writer.createFile.mock.calls[0];
+        // Inherited non-blacklisted properties
+        expect(content).toContain('ems__Effort_area: "[[area-uid-42]]"');
+        expect(content).toContain('ems__Effort_priority: "[[priority-high]]"');
+        expect(content).toContain('"[[tag-alpha]]"');
+        expect(content).toContain('"[[tag-beta]]"');
+        // Blacklisted — must NOT leak
+        expect(content).not.toContain("src-uid");
+        expect(content).not.toContain("Source asset");
+        expect(content).not.toContain("Old alias");
+        expect(content).not.toMatch(/exo__Instance_class:[\s\S]*ems__Project/);
+        expect(content).not.toContain("ems__EffortStatusDoing");
+        expect(content).not.toContain("ems__Effort_startTimestamp:");
+      });
+
+      it("re-quotes wikilink values copied from $target", async () => {
+        reader.readFile.mockResolvedValue(
+          '---\nems__Effort_area: "[[area-uid-42]]"\nems__Effort_unquoted: [[bare-link]]\n---\n',
+        );
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain('ems__Effort_area: "[[area-uid-42]]"');
+        expect(content).toContain('ems__Effort_unquoted: "[[bare-link]]"');
+      });
+
+      it("does not overwrite properties already set via userInput", async () => {
+        reader.readFile.mockResolvedValue(
+          '---\nems__Effort_area: "[[area-from-target]]"\n---\n',
+        );
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+          label: "X",
+          ems__Effort_area: '"[[area-from-user]]"',
+        });
+
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain('ems__Effort_area: "[[area-from-user]]"');
+        expect(content).not.toContain("area-from-target");
+      });
+
+      it("writes back-link to grounding.linkBackProperty when provided", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+          linkBackProperty: "ems__Effort_parent",
+        });
+
+        await executor.execute(grounding, TARGET_IRI, FILE_PATH, { label: "Sub" });
+
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain(`ems__Effort_parent: "[[${TARGET_IRI}]]"`);
+        expect(content).not.toContain("exo__Asset_source:");
+      });
+
+      it("falls back to exo__Asset_source when linkBackProperty is absent", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain(`exo__Asset_source: "[[${TARGET_IRI}]]"`);
+        expect(content).not.toContain("ems__Effort_prevIteration:");
+      });
+
+      it("accepts bare property name (no wikilink wrapping) for linkBackProperty", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+          linkBackProperty: "ems__Effort_prevIteration",
+        });
+
+        await executor.execute(grounding, TARGET_IRI, FILE_PATH, { label: "Next" });
+
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain(`ems__Effort_prevIteration: "[[${TARGET_IRI}]]"`);
+        expect(content).not.toContain("exo__Asset_source:");
+        expect(content).not.toContain("[[ems__Effort_prevIteration]]:");
+      });
+
+      it("returns descriptive error when $target file is missing", async () => {
+        reader.readFile.mockRejectedValue(new Error("ENOENT: no such file"));
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("$target");
+        expect(result.error).toContain(FILE_PATH);
+        expect(result.error).toContain("ENOENT");
+        // Must not silently fall through to createFile
+        expect(writer.createFile).not.toHaveBeenCalled();
+      });
+    });
+
+    // Task 4.4 — regression suite for Phase 2 changes (RFC v0.2 copy-from-target +
+    // configurable linkBackProperty). Guarantees existing vault groundings authored
+    // before RFC v0.2 (e.g. `e01b025b` "Create MeetingPrototype instance",
+    // `adc73790`, `3da98088`, `00a6a887`, `a6ef8fda`) keep emitting
+    // `exo__Asset_source` and that the no-$target path does NOT introduce a phantom
+    // fallback link.
+    describe("Phase 2 regression: existing groundings unchanged (Task 4.4)", () => {
+      // Fixture mirrors vault grounding `e01b025b-d03f-4028-b4c8-45d3786ff43d`
+      // ("Create MeetingPrototype instance") — pre-RFC v0.2 shape: targetClass +
+      // targetPrototype + targetFolder, no linkBackProperty.
+      const LEGACY_MEETING_GROUNDING = {
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Meeting",
+        targetPrototype: "7ab483c7-aafc-4ac8-8aca-0de52db34a93|ems__MeetingPrototype",
+        targetFolder: "03 Knowledge/inbox",
+      } as const;
+
+      it("legacy grounding (no linkBackProperty) emits exo__Asset_source as before", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\nBody");
+
+        const grounding = makeGrounding({ ...LEGACY_MEETING_GROUNDING });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+          label: "Weekly sync",
+        });
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain(`exo__Asset_source: "[[${TARGET_IRI}]]"`);
+        expect(content).not.toMatch(/ems__Effort_parent: "\[\[https/);
+        expect(content).not.toMatch(/ems__Effort_prevIteration:/);
+      });
+
+      it("legacy grounding with targetClass only (no prototype, no linkBackProperty) preserves behavior", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain('exo__Instance_class:\n  - "[[ems__Task]]"');
+        expect(content).toContain(`exo__Asset_source: "[[${TARGET_IRI}]]"`);
+        expect(content).not.toContain("exo__Asset_prototype:");
+      });
+
+      it("legacy grounding without $target (empty targetIRI) does NOT emit any back-link", async () => {
+        // Pre-RFC v0.2 behavior — when targetIRI is falsy, no link is written.
+        // RFC v0.2 must preserve this: must not introduce a phantom
+        // `exo__Asset_source: "[[]]"` or write linkBackProperty with empty value.
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        const result = await executor.execute(grounding, "", "", { label: "Standalone" });
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).not.toContain("exo__Asset_source:");
+        expect(content).not.toMatch(/"\[\[\]\]"/);
+      });
+
+      it("legacy grounding with linkBackProperty=undefined writes exo__Asset_source (no fallback drift)", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+          linkBackProperty: undefined,
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain(`exo__Asset_source: "[[${TARGET_IRI}]]"`);
+      });
+    });
+
     // Plugin adapter test: vault-relative path (RFC-016 #2645)
     it("should pass vault-relative path to createFile (plugin adapter compatibility)", async () => {
       const grounding = makeGrounding({


### PR DESCRIPTION
## Summary

Implements **onto-RFC `74c5e336` v0.2** — extends existing `GroundingType.CREATE_INSTANCE` with two RDF-configurable knobs, unlocking the *Create Next Iteration* sub-1-minute UI extension use case ([[d8725272]]):

- `exocmd__Grounding_copyFromTarget` — list of property wikilinks copied from `$target` frontmatter into the new instance
- `exocmd__Grounding_linkBackProperty` — wikilink → property name for the back-link to `$target` (default remains `exo__Asset_source` — backwards-compatible)

### Why this scope (post 4-reviewer audit + spike)

v0.1 proposed a parallel `clone_with_link` grounding-type + 5 new properties. Prior-art spike found `targetClass` / `targetPrototype` / `targetFolder` already exist on CREATE_INSTANCE. **Radical scope cut → 2 properties extending CREATE_INSTANCE, no new grounding-type.** Avoids ontology vocabulary duplication.

### Breaking changes

**None.** Both new properties are optional. Existing groundings without `linkBackProperty` continue to write `exo__Asset_source: [[$target]]` as before.

## Affected

- `domain/models/CommandDefinition.ts` — two new optional fields
- `services/CommandResolver.ts` — parse new RDF properties via `getLiteralValue` + wikilink helpers
- `services/GroundingExecutor.ts` — copy-from-target merge logic + dynamic back-link
- `utilities/FrontmatterService.ts` — value extraction helpers
- `packages/cli/specs/...` — BDD coverage for both new behaviors
- Unit tests for `CommandResolver` + `GroundingExecutor`

## Test plan

- [x] `npm run check:types` — green
- [x] `npm run lint` — green (only pre-existing warnings)
- [x] Pre-commit hooks — green (BDD coverage, archgate, type-check)
- [ ] CI: 13 required checks (`archgate`, `detect-changes`, `e2e-shard 1..6`, `lint`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`)
- [ ] CI runtime ≤220s gate
- [ ] Auto Release succeeds post-merge

## Refs

- RFC: `74c5e336-a7a7-47ab-a9f4-3c5abca7b558` (onto-RFC v0.2)
- Use case driver: `d8725272-4b4d-4e68-bf01-ce9b111bbe12`
- Strategy 2026 H1 — Pillar Editable Homoiconic UI