### PR TITLE
fix(rdf): emit synthesised IRI for unresolved wikilinks (uniform semantics)

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -959,15 +959,27 @@ export class NoteToRDFConverter {
 
           return [fileIRI];
         }
-        // If target file not found but wikilink is a class reference,
-        // expand to namespace URI (Issue #667, #668: normalize Instance_class/Property_domain)
+        // Three-step wikilink resolver (RFC 4724eb62-7396-4928-a129-1d17a0f190ee).
+        // Step 1: canonical namespace mapping for prefix__LocalName form.
+        // Issue #667, #668 — normalize Instance_class/Property_domain.
         if (this.isClassReference(wikilink)) {
           const classIRI = this.expandClassValue(wikilink);
           if (classIRI) {
             return [classIRI];
           }
         }
-        return [new Literal(cleanValue)];
+        // Step 2 (vault file lookup) reached the no-match branch above
+        // (`getFirstLinkpathDest` returned null).
+        // Step 3: synthesised vault-path IRI for unresolved wikilinks.
+        // Behavioral rule (aiKnow 64d2a7ac-cf4a-4f81-80f0-4982ae63cbf0):
+        // `[[...]]` is always an asset reference (existing or future).
+        // Never emit Literal — dangling link allowed.
+        // Strip optional `|alias` suffix before synthesising path; the alias
+        // is a display hint, not part of the identity.
+        const linkpath = wikilink.includes("|")
+          ? wikilink.split("|")[0]
+          : wikilink;
+        return [this.notePathToIRI(`${linkpath}.md`)];
       }
 
       if (this.isClassReference(cleanValue)) {

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -707,7 +707,10 @@ describe("NoteToRDFConverter", () => {
         expect((domainTriple!.object as IRI).value).toBe(Namespace.EMS.term("Effort").value);
       });
 
-      it("should return literal for wiki-link to non-class file when not found", async () => {
+      it("should synthesise vault-path IRI for wiki-link to non-class file when not found", async () => {
+        // RFC 4724eb62 P3': under uniform wikilink semantics, unresolved
+        // non-class wikilinks emit synthesised vault-path IRI (dangling link),
+        // not Literal. See aiKnow behavioral rule 64d2a7ac.
         const frontmatter: IFrontmatter = {
           ems__Effort_area: "[[Development]]",
         };
@@ -722,8 +725,10 @@ describe("NoteToRDFConverter", () => {
         );
 
         expect(areaTriple).toBeDefined();
-        expect(areaTriple!.object).toBeInstanceOf(Literal);
-        expect((areaTriple!.object as Literal).value).toBe("[[Development]]");
+        expect(areaTriple!.object).toBeInstanceOf(IRI);
+        expect((areaTriple!.object as IRI).value).toBe(
+          "obsidian://vault/Development.md"
+        );
       });
 
       it("should handle quoted wiki-link to class when file not found", async () => {
@@ -3081,7 +3086,10 @@ It can contain **markdown** formatting.
         expect(iriValues.some((v) => v.includes(uuid2))).toBe(true);
       });
 
-      it("should not create duplicate Literal when wikilink target file doesn't exist", async () => {
+      it("should emit single synthesised IRI when wikilink target file doesn't exist", async () => {
+        // RFC 4724eb62 P3': under uniform wikilink semantics, unresolved
+        // UUID-form wikilinks emit synthesised vault-path IRI (dangling link),
+        // not Literal. Dual-storage (#2102) applies only when target file resolves.
         const uuid = "e3347bcf-bb50-4fb7-9064-14266469384b";
 
         // File not found
@@ -3100,10 +3108,12 @@ It can contain **markdown** formatting.
           (t.predicate as IRI).value.includes("Asset_prototype")
         );
 
-        // When file doesn't exist, should fall back to literal (existing behavior)
-        // Should be 1 triple, not 2 (no dual storage when file doesn't exist)
+        // Single triple — no dual storage since file doesn't exist.
         expect(prototypeTriples.length).toBe(1);
-        expect(prototypeTriples[0].object).toBeInstanceOf(Literal);
+        expect(prototypeTriples[0].object).toBeInstanceOf(IRI);
+        expect((prototypeTriples[0].object as IRI).value).toBe(
+          `obsidian://vault/${uuid}.md`
+        );
       });
 
       // Issue #2489: Verify dual storage with display name wikilink syntax

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.uniform-wikilink.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.uniform-wikilink.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for three-step wikilink resolver (RFC 4724eb62-7396-4928-a129-1d17a0f190ee).
+ *
+ * Behavioral rule (aiKnow 64d2a7ac-cf4a-4f81-80f0-4982ae63cbf0):
+ * `[[...]]` is always an asset reference (existing or future).
+ * Never Literal, never context-dependent.
+ *
+ * Resolution order in NoteToRDFConverter.valueToRDFObject for unresolved wikilinks:
+ *   Step 1: canonical namespace mapping for prefix__LocalName form
+ *   Step 2: vault file lookup (handled before this branch via getFirstLinkpathDest)
+ *   Step 3: synthesised vault-path IRI (new — replaces Literal fallback)
+ *
+ * Prior attempt: Fix 3 in commit ed5be839 reverted as d9e700d8 due to E2E regression.
+ * Audit P1 (2026-05-14) identified Step 1 (canonical namespace) was already present
+ * before line 970; only Step 3 was missing. This narrow change emits IRI in place
+ * of Literal for unresolved non-class wikilinks.
+ */
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import { IVaultAdapter, IFile } from "../../../src/interfaces/IVaultAdapter";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+
+describe("NoteToRDFConverter — uniform wikilink resolver (RFC P3')", () => {
+  let mockVault: jest.Mocked<IVaultAdapter>;
+  let converter: NoteToRDFConverter;
+  let file: IFile;
+
+  beforeEach(() => {
+    mockVault = {
+      getFrontmatter: jest.fn(),
+      getAllFiles: jest.fn().mockReturnValue([]),
+      read: jest.fn().mockResolvedValue(""),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      updateLinks: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+    } as jest.Mocked<IVaultAdapter>;
+    converter = new NoteToRDFConverter(mockVault);
+    file = {
+      path: "test/source.md",
+      basename: "source",
+      extension: "md",
+      name: "source.md",
+      parent: null,
+    } as IFile;
+  });
+
+  describe("Step 1: canonical namespace mapping (existing behavior, regression guard)", () => {
+    it("resolves [[ems__EffortStatusReview]] to canonical namespace IRI even when file missing", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        ems__Effort_status: "[[ems__EffortStatusReview]]",
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const statusTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("ems#Effort_status"),
+      );
+
+      expect(statusTriple).toBeDefined();
+      expect(statusTriple!.object).toBeInstanceOf(IRI);
+      expect((statusTriple!.object as IRI).value).toBe(
+        "https://exocortex.my/ontology/ems#EffortStatusReview",
+      );
+    });
+
+    it("resolves [[exo__Theory]] to canonical namespace IRI when file missing", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_relates: "[[exo__Theory]]",
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const relatesTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_relates"),
+      );
+
+      expect(relatesTriple).toBeDefined();
+      expect(relatesTriple!.object).toBeInstanceOf(IRI);
+      expect((relatesTriple!.object as IRI).value).toBe(
+        "https://exocortex.my/ontology/exo#Theory",
+      );
+    });
+  });
+
+  describe("Step 3: synthesised vault-path IRI for unresolved non-class wikilinks (NEW)", () => {
+    it("emits IRI (not Literal) for unresolved [[Sales Platform]]", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_relates: "[[Sales Platform]]",
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const relatesTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_relates"),
+      );
+
+      expect(relatesTriple).toBeDefined();
+      expect(relatesTriple!.object).toBeInstanceOf(IRI);
+      expect(relatesTriple!.object).not.toBeInstanceOf(Literal);
+      expect((relatesTriple!.object as IRI).value).toBe(
+        "obsidian://vault/Sales%20Platform.md",
+      );
+    });
+
+    it("emits IRI for unresolved [[Some Random Name]] with spaces", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_relates: "[[Some Random Name]]",
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const relatesTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_relates"),
+      );
+
+      expect(relatesTriple).toBeDefined();
+      expect(relatesTriple!.object).toBeInstanceOf(IRI);
+      expect((relatesTriple!.object as IRI).value).toContain(
+        "obsidian://vault/Some%20Random%20Name.md",
+      );
+    });
+
+    it("strips |alias suffix before synthesising IRI", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_relates: "[[abc-uuid|Display Label]]",
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const relatesTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_relates"),
+      );
+
+      expect(relatesTriple).toBeDefined();
+      expect(relatesTriple!.object).toBeInstanceOf(IRI);
+      // Synthesised IRI should use the identifier part, not the alias.
+      expect((relatesTriple!.object as IRI).value).toBe(
+        "obsidian://vault/abc-uuid.md",
+      );
+    });
+  });
+
+  describe("Negative cases: no regression on non-wikilink values", () => {
+    it("leaves plain string values as Literal", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_label: "Plain text title",
+      });
+
+      const triples = await converter.convertNote(file);
+      const labelTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_label"),
+      );
+
+      expect(labelTriple).toBeDefined();
+      expect(labelTriple!.object).toBeInstanceOf(Literal);
+      expect((labelTriple!.object as Literal).value).toBe("Plain text title");
+    });
+
+    it("does not turn ISO 8601 dateTime into IRI", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_createdAt: "2026-05-14T10:00:00+05:00",
+      });
+
+      const triples = await converter.convertNote(file);
+      const createdTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_createdAt"),
+      );
+
+      expect(createdTriple).toBeDefined();
+      expect(createdTriple!.object).toBeInstanceOf(Literal);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements **RFC 4724eb62 P3'** — three-step wikilink resolver in `NoteToRDFConverter`
- Replaces Literal fallback (line 970) with synthesised vault-path IRI for unresolved non-class wikilinks
- Behavioral rule: `[[...]]` is **always** an asset reference (existing or future) — see aiKnow `64d2a7ac-cf4a-4f81-80f0-4982ae63cbf0`

## Resolution order

1. **Canonical namespace mapping** for `prefix__LocalName` form — existing (#667/#668), regression-guarded by new tests
2. **Vault file lookup** via `getFirstLinkpathDest` — existing
3. **Synthesised vault-path IRI** (`obsidian://vault/<linkpath>.md`) — **NEW**, replaces `new Literal(cleanValue)` at line 970

## Why this is not a repeat of Fix 3 (ed5be839 reverted as d9e700d8)

Audit P1 (2026-05-14) identified that the previous regression was caused by Fix 3 being too aggressive — it bypassed the namespace canonical step in certain cases. This PR keeps step 1 fully intact; only the terminal Literal fallback becomes IRI. The 4 previously-failing E2E specs depended on class-named wikilinks resolving to canonical namespace IRIs (handled by step 1), not on the synthesis path. CI E2E gate verifies.

## Tests

- `NoteToRDFConverter.uniform-wikilink.test.ts` — 7 new tests:
  - Step 1 canonical namespace regression guard (`[[ems__EffortStatusReview]]`, `[[exo__Theory]]`)
  - Step 3 synthesised IRI (`[[Sales Platform]]`, `[[Some Random Name]]`, `[[uuid|alias]]` strip)
  - Negative cases (plain strings stay Literal, ISO 8601 dateTime stays Literal)
- Updated 2 existing tests that asserted old Literal-fallback behavior — now assert synthesised IRI

All 186 NoteToRDFConverter tests pass. 13 pre-existing baseline test failures unchanged (not regression).

## Expected vault impact

SHACL violations: **16 212 → ≤5500** (eliminates ~5k sh:datatype on wikilink-as-literal + ~6k cascade sh:class)

## Test plan

- [ ] CI: all 13 required checks green
- [ ] CI: 4 E2E specs from prior Fix 3 revert green — `dynamic-command-buttons-render`, `exo-layout-smoke`, `featured-binding-promotion`, `vault-commands-smoke`
- [ ] Post-merge: vault re-validation shows expected violation drop
- [ ] Post-merge: 3 consecutive main pipelines green (Decision B stability gate per RFC AC2)

## Refs

- RFC: vault `[[4724eb62-7396-4928-a129-1d17a0f190ee]]`
- Behavioral rule: vault `[[64d2a7ac-cf4a-4f81-80f0-4982ae63cbf0]]`
- Prior revert: commit `d9e700d8` (branch `feature/shacl-parser-fixes`)
- Related: PR #2746 (valueToClassURI vault lookup), #3093 (rdf:type predicate), #3097 (external IRI allowlist)