### PR TITLE
fix(rdf): emit synthesised IRI for unresolved UUID wikilinks (Phase A)

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -959,13 +959,32 @@ export class NoteToRDFConverter {
 
           return [fileIRI];
         }
-        // If target file not found but wikilink is a class reference,
-        // expand to namespace URI (Issue #667, #668: normalize Instance_class/Property_domain)
+        // Three-step wikilink resolver (RFC 4724eb62, phased rollout).
+        // Step 1: canonical namespace mapping for prefix__LocalName form.
+        // Issue #667, #668 — normalize Instance_class/Property_domain.
         if (this.isClassReference(wikilink)) {
           const classIRI = this.expandClassValue(wikilink);
           if (classIRI) {
             return [classIRI];
           }
+        }
+        // Step 2 (vault file lookup) reached the no-match branch above
+        // (`getFirstLinkpathDest` returned null).
+        // Step 3 (phase A — UUID-form only): synthesised vault-path IRI
+        // when the linkpath is a UUID. Narrow scope intentionally — Fix 3
+        // attempt 1 (PR #3106) broadened this to all unresolved wikilinks
+        // and broke 4 E2E specs that depend on non-UUID identifier wikilinks
+        // (e.g. `[[e2e-bind-status-done-for-tasks]]` in test vault) flowing
+        // as Literal so downstream `CommandResolver.normalizeWikilink` can
+        // extract the bare reference. Phase B will widen to non-UUID forms
+        // once those downstream paths are migrated.
+        //
+        // Strip optional `|alias` suffix — the alias is a display hint.
+        const linkpath = wikilink.includes("|")
+          ? wikilink.split("|")[0]
+          : wikilink;
+        if (this.isUUID(linkpath)) {
+          return [this.notePathToIRI(`${linkpath}.md`)];
         }
         return [new Literal(cleanValue)];
       }

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -3081,7 +3081,11 @@ It can contain **markdown** formatting.
         expect(iriValues.some((v) => v.includes(uuid2))).toBe(true);
       });
 
-      it("should not create duplicate Literal when wikilink target file doesn't exist", async () => {
+      it("should emit single synthesised IRI for UUID wikilink when target file doesn't exist", async () => {
+        // RFC 4724eb62 Phase A: UUID-form wikilinks emit synthesised vault-path
+        // IRI (dangling link) when target file is missing, not Literal.
+        // Non-UUID wikilinks remain Literal — see Phase A scope tests in
+        // NoteToRDFConverter.uniform-wikilink.test.ts.
         const uuid = "e3347bcf-bb50-4fb7-9064-14266469384b";
 
         // File not found
@@ -3100,10 +3104,11 @@ It can contain **markdown** formatting.
           (t.predicate as IRI).value.includes("Asset_prototype")
         );
 
-        // When file doesn't exist, should fall back to literal (existing behavior)
-        // Should be 1 triple, not 2 (no dual storage when file doesn't exist)
         expect(prototypeTriples.length).toBe(1);
-        expect(prototypeTriples[0].object).toBeInstanceOf(Literal);
+        expect(prototypeTriples[0].object).toBeInstanceOf(IRI);
+        expect((prototypeTriples[0].object as IRI).value).toBe(
+          `obsidian://vault/${uuid}.md`
+        );
       });
 
       // Issue #2489: Verify dual storage with display name wikilink syntax

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.uniform-wikilink.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.uniform-wikilink.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for three-step wikilink resolver — Phase A (UUID-only Step 3).
+ *
+ * RFC 4724eb62-7396-4928-a129-1d17a0f190ee, behavioral rule
+ * aiKnow 64d2a7ac-cf4a-4f81-80f0-4982ae63cbf0: `[[...]]` should always
+ * be an asset reference. Phase A delivers this for UUID-form wikilinks
+ * (~80% of vault violations); Phase B extends to non-UUID identifier
+ * forms after migrating downstream consumers like CommandResolver.normalizeWikilink.
+ *
+ * Resolution order for unresolved wikilinks (line 962-990 in NoteToRDFConverter):
+ *   Step 1: canonical namespace (prefix__LocalName) — existing
+ *   Step 2: vault file lookup via getFirstLinkpathDest — existing
+ *   Step 3: synthesised vault-path IRI — NEW, gated on isUUID(linkpath)
+ *
+ * Prior attempt: Fix 3 in ed5be839, reverted as d9e700d8; PR #3106 retry,
+ * closed 2026-05-14 after same E2E shards (3/4/5) regressed.
+ */
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import { IVaultAdapter, IFile } from "../../../src/interfaces/IVaultAdapter";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+
+describe("NoteToRDFConverter — wikilink resolver Phase A (UUID-only Step 3)", () => {
+  let mockVault: jest.Mocked<IVaultAdapter>;
+  let converter: NoteToRDFConverter;
+  let file: IFile;
+
+  beforeEach(() => {
+    mockVault = {
+      getFrontmatter: jest.fn(),
+      getAllFiles: jest.fn().mockReturnValue([]),
+      read: jest.fn().mockResolvedValue(""),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      updateLinks: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+    } as jest.Mocked<IVaultAdapter>;
+    converter = new NoteToRDFConverter(mockVault);
+    file = {
+      path: "test/source.md",
+      basename: "source",
+      extension: "md",
+      name: "source.md",
+      parent: null,
+    } as IFile;
+  });
+
+  describe("Step 1 regression guard: canonical namespace mapping", () => {
+    it("resolves [[ems__EffortStatusReview]] to canonical namespace IRI when file missing", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        ems__Effort_status: "[[ems__EffortStatusReview]]",
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const statusTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("ems#Effort_status"),
+      );
+
+      expect(statusTriple).toBeDefined();
+      expect(statusTriple!.object).toBeInstanceOf(IRI);
+      expect((statusTriple!.object as IRI).value).toBe(
+        "https://exocortex.my/ontology/ems#EffortStatusReview",
+      );
+    });
+  });
+
+  describe("Step 3 Phase A: synthesised vault-path IRI for unresolved UUID-form wikilinks", () => {
+    it("emits IRI (not Literal) for unresolved UUID-form wikilink", async () => {
+      const uuid = "e3347bcf-bb50-4fb7-9064-14266469384b";
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_relates: `[[${uuid}]]`,
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const relatesTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_relates"),
+      );
+
+      expect(relatesTriple).toBeDefined();
+      expect(relatesTriple!.object).toBeInstanceOf(IRI);
+      expect((relatesTriple!.object as IRI).value).toBe(
+        `obsidian://vault/${uuid}.md`,
+      );
+    });
+
+    it("emits IRI for [[uuid|alias]] format, stripping alias", async () => {
+      const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_relates: `[[${uuid}|Display Label]]`,
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const relatesTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_relates"),
+      );
+
+      expect(relatesTriple).toBeDefined();
+      expect(relatesTriple!.object).toBeInstanceOf(IRI);
+      expect((relatesTriple!.object as IRI).value).toBe(
+        `obsidian://vault/${uuid}.md`,
+      );
+    });
+  });
+
+  describe("Phase A scope: non-UUID identifiers stay as Literal (defer to Phase B)", () => {
+    it("emits Literal for unresolved non-UUID wikilink [[Sales Platform]]", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_relates: "[[Sales Platform]]",
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const relatesTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_relates"),
+      );
+
+      expect(relatesTriple).toBeDefined();
+      expect(relatesTriple!.object).toBeInstanceOf(Literal);
+      // Phase B will change this to synthesised IRI; for now Literal
+      // is preserved to keep CommandResolver.normalizeWikilink working
+      // on e2e-bind-* style slugs.
+      expect((relatesTriple!.object as Literal).value).toBe(
+        "[[Sales Platform]]",
+      );
+    });
+
+    it("emits Literal for unresolved slug-form wikilink [[e2e-bind-status-done-for-tasks]]", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exocmd__CommandBinding_command: "[[e2e-bind-status-done-for-tasks|Complete]]",
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const triples = await converter.convertNote(file);
+      const triple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("CommandBinding_command"),
+      );
+
+      expect(triple).toBeDefined();
+      expect(triple!.object).toBeInstanceOf(Literal);
+    });
+  });
+
+  describe("Negative cases: no regression on non-wikilink values", () => {
+    it("leaves plain string values as Literal", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_label: "Plain text title",
+      });
+
+      const triples = await converter.convertNote(file);
+      const labelTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_label"),
+      );
+
+      expect(labelTriple).toBeDefined();
+      expect(labelTriple!.object).toBeInstanceOf(Literal);
+    });
+
+    it("preserves xsd:dateTime literal datatype", async () => {
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_createdAt: "2026-05-14T10:00:00+05:00",
+      });
+
+      const triples = await converter.convertNote(file);
+      const createdTriple = triples.find((t) =>
+        (t.predicate as IRI).value.endsWith("Asset_createdAt"),
+      );
+
+      expect(createdTriple).toBeDefined();
+      expect(createdTriple!.object).toBeInstanceOf(Literal);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements **RFC 4724eb62 Phase A** — narrowed retry of Fix 3 (`ed5be839` reverted as `d9e700d8`; PR #3106 attempt 2 also reverted)
- Synthesised vault-path IRI emitted only for **UUID-form** unresolved wikilinks; slug-form wikilinks remain as Literal (Phase B scope)
- Fixes ~15k of ~16k vault SHACL violations while staying within proven-safe wikilink semantics for test vault

## Why narrower scope vs PR #3106

PR #3106 broadened synthesis to all unresolved wikilinks. E2E shards 3/4/5 regressed because test vault uses slug-form UIDs (e.g. `[[e2e-bind-status-done-for-tasks|Complete]]`) where `file.basename != exo__Asset_uid`. `CommandResolver.normalizeWikilink` extracts slug from Literal form, then `findSubjectByUID` resolves via `exo:Asset_uid` triple. When converter emits IRI instead, the slug round-trip works in trivial cases but breaks for at least 4 specs (dynamic-command-buttons-render, exo-layout-smoke, featured-binding-promotion, vault-commands-smoke).

Phase A scope sidesteps this entirely:
- UUID-form `[[<uuid>]]` / `[[<uuid>|alias]]` → synthesised IRI **NEW**
- Non-UUID form → Literal **unchanged**

UUID-form is the bulk of vault violations (Asset_prototype, Asset_relates with UUID refs).

## Tests

- `NoteToRDFConverter.uniform-wikilink.test.ts` — 7 new tests covering:
  - Step 1 canonical namespace regression guard
  - Step 3 Phase A UUID-only synthesis (bare + with alias)
  - Phase A scope: non-UUID stays Literal (regression guard for E2E specs)
  - Negative cases: plain strings, dateTime
- Updated 1 existing test asserting old Literal-fallback for UUID — now asserts synthesised IRI

All 186 NoteToRDFConverter tests pass locally; 13 pre-existing baseline suite failures unchanged.

## Vault SHACL impact

Expected: **16 212 → ~1500-3000 violations** (eliminates UUID wikilink-as-Literal sh:datatype + cascade sh:class; slug-form violations remain for Phase B).

## Phase B (deferred)

Widen to non-UUID identifiers after auditing & migrating downstream consumers off literal-form wikilink parsing (`CommandResolver.normalizeWikilink` + companions). Requires careful audit per RFC §"Альтернативы" discussion.

## Test plan

- [ ] CI: all 13 required checks green
- [ ] CI: 4 prior-failing E2E specs green (`dynamic-command-buttons-render`, `exo-layout-smoke`, `featured-binding-promotion`, `vault-commands-smoke`)
- [ ] Post-merge: vault re-validation shows expected violation drop
- [ ] Post-merge: 3 consecutive main pipelines green

## Refs

- RFC: vault `[[4724eb62-7396-4928-a129-1d17a0f190ee]]`
- Behavioral rule: vault `[[64d2a7ac-cf4a-4f81-80f0-4982ae63cbf0]]`
- Prior closed PRs: #3106 (broadened scope, reverted)
- Prior revert commit: `d9e700d8`