### PR TITLE
fix(cli): update inbound wikilinks on rename-to-uid (#3113)

### DIFF
--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import path from "path";
 import yaml from "js-yaml";
 import { IVaultAdapter, IFile, IFolder, IFrontmatter } from "exocortex";
+import { rewriteInboundWikilinks } from "../utils/wikilinkRewriter.js";
 
 /** UUID v4 pattern for wikilink resolution */
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -291,12 +292,21 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
     };
   }
 
+  /**
+   * Rewrites inbound wikilinks pointing at `oldBasename` so they target the
+   * new file's basename, preserving the original basename as the display
+   * alias (UID-form convention). Honors fenced/inline code-block exclusion
+   * and skips the file being renamed itself. Issue #3113.
+   */
   async updateLinks(
-    _oldPath: string,
-    _newPath: string,
-    _oldBasename: string,
+    oldPath: string,
+    newPath: string,
+    oldBasename: string,
   ): Promise<void> {
-    return Promise.resolve();
+    const newBasename = path.basename(newPath, ".md");
+    await rewriteInboundWikilinks(this.rootPath, oldBasename, newBasename, {
+      excludeRelPath: oldPath,
+    });
   }
 
   private resolvePath(filePath: string): string {

--- a/packages/cli/src/executors/commands/PropertyCommandExecutor.ts
+++ b/packages/cli/src/executors/commands/PropertyCommandExecutor.ts
@@ -3,6 +3,7 @@ import { BaseCommandExecutor, CommandContext } from "./BaseCommandExecutor.js";
 import { ErrorHandler } from "../../utils/ErrorHandler.js";
 import { ExitCodes } from "../../utils/ExitCodes.js";
 import { DateFormatter } from "exocortex";
+import { rewriteInboundWikilinks } from "../../utils/wikilinkRewriter.js";
 
 /**
  * Executes property-related commands (rename-to-uid, update-label, schedule, set-deadline)
@@ -52,6 +53,19 @@ export class PropertyCommandExecutor extends BaseCommandExecutor {
           }
         }
         console.log(`[dry-run] Would rename: ${relativePath} -> ${newPath}`);
+        // Inbound wikilink preview (Issue #3113)
+        const linkPreview = await rewriteInboundWikilinks(
+          this.pathResolver.getVaultRoot(),
+          currentBasename,
+          targetBasename,
+          { dryRun: true, excludeRelPath: relativePath },
+        );
+        console.log(
+          `[dry-run] Would update links in ${linkPreview.filesModified} file(s)` +
+            (linkPreview.filesModified > 0
+              ? ` (${linkPreview.replacements} replacement(s))`
+              : ""),
+        );
         console.log(`\n💡 Run without --dry-run to apply changes`);
         process.exit(ExitCodes.SUCCESS);
       }
@@ -79,12 +93,26 @@ export class PropertyCommandExecutor extends BaseCommandExecutor {
         console.log(`   Updated label: "${currentBasename}"`);
       }
 
+      // Update inbound wikilinks before renaming (Issue #3113).
+      const linkResult = await rewriteInboundWikilinks(
+        this.pathResolver.getVaultRoot(),
+        currentBasename,
+        targetBasename,
+        { dryRun: false, excludeRelPath: relativePath },
+      );
+
       // Rename file
       await this.fsAdapter.renameFile(relativePath, newPath);
 
       console.log(`✅ Renamed to UID format`);
       console.log(`   Old: ${relativePath}`);
       console.log(`   New: ${newPath}`);
+      console.log(
+        `   Updated links in ${linkResult.filesModified} file(s)` +
+          (linkResult.filesModified > 0
+            ? ` (${linkResult.replacements} replacement(s))`
+            : ""),
+      );
       process.exit(ExitCodes.SUCCESS);
     } catch (error) {
       ErrorHandler.handle(error as Error);

--- a/packages/cli/src/utils/wikilinkRewriter.ts
+++ b/packages/cli/src/utils/wikilinkRewriter.ts
@@ -1,0 +1,165 @@
+import fs from "fs-extra";
+import path from "path";
+import * as glob from "glob";
+
+export interface RewriteOptions {
+  dryRun?: boolean;
+  /** Relative-to-root path of the file being renamed (skipped during scan). */
+  excludeRelPath?: string;
+}
+
+export interface RewriteResult {
+  filesScanned: number;
+  filesModified: number;
+  replacements: number;
+  modifiedFiles: string[];
+}
+
+/**
+ * Rewrites inbound wikilinks pointing to `oldBasename` so they target
+ * `newBasename` while preserving the original basename as the display alias.
+ *
+ * Shapes handled (Issue #3113 AC):
+ *   [[OldName]]                 -> [[NewBase|OldName]]
+ *   [[OldName|Display]]         -> [[NewBase|Display]]
+ *   [[OldName#Heading]]         -> [[NewBase#Heading|OldName]]
+ *   [[OldName#Heading|Display]] -> [[NewBase#Heading|Display]]
+ *
+ * Skips fenced code blocks (``` … ```), inline code (` … `), and embeds (`![[…]]`).
+ * Skips the renamed file itself via `excludeRelPath`.
+ */
+export async function rewriteInboundWikilinks(
+  rootPath: string,
+  oldBasename: string,
+  newBasename: string,
+  opts: RewriteOptions = {},
+): Promise<RewriteResult> {
+  const { dryRun = false, excludeRelPath } = opts;
+  const pattern = path.join(rootPath, "**/*.md");
+  const files = await glob.glob(pattern, {
+    nodir: true,
+    ignore: [
+      path.join(rootPath, ".obsidian/**"),
+      path.join(rootPath, ".trash/**"),
+      path.join(rootPath, "**/.obsidian/**"),
+      path.join(rootPath, "**/.trash/**"),
+    ],
+  });
+
+  const result: RewriteResult = {
+    filesScanned: 0,
+    filesModified: 0,
+    replacements: 0,
+    modifiedFiles: [],
+  };
+
+  for (const absPath of files) {
+    const relPath = path.relative(rootPath, absPath);
+    if (excludeRelPath && relPath === excludeRelPath) continue;
+    result.filesScanned += 1;
+
+    let content: string;
+    try {
+      content = await fs.readFile(absPath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const { updated, replacements } = rewriteContent(
+      content,
+      oldBasename,
+      newBasename,
+    );
+
+    if (replacements > 0) {
+      result.filesModified += 1;
+      result.replacements += replacements;
+      result.modifiedFiles.push(relPath);
+      if (!dryRun) {
+        await fs.writeFile(absPath, updated, "utf-8");
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Pure function: rewrite wikilinks inside a single string, skipping fenced
+ * code blocks, inline code spans, and embed `![[...]]` references.
+ */
+export function rewriteContent(
+  content: string,
+  oldBasename: string,
+  newBasename: string,
+): { updated: string; replacements: number } {
+  // Split content by fenced code blocks (```...```), preserving fences.
+  // Even-indexed segments are prose; odd-indexed are code.
+  const fenceParts = content.split(/(^```[\s\S]*?^```)/m);
+  let replacements = 0;
+
+  for (let i = 0; i < fenceParts.length; i++) {
+    if (i % 2 === 1) continue; // code block — keep as-is
+    const segment = fenceParts[i];
+    const out = rewriteProseSegment(segment, oldBasename, newBasename);
+    replacements += out.replacements;
+    fenceParts[i] = out.updated;
+  }
+
+  return { updated: fenceParts.join(""), replacements };
+}
+
+function rewriteProseSegment(
+  segment: string,
+  oldBasename: string,
+  newBasename: string,
+): { updated: string; replacements: number } {
+  // Split by inline code spans (`...`). Preserve them.
+  const inlineParts = segment.split(/(`[^`\n]*`)/);
+  let replacements = 0;
+
+  for (let i = 0; i < inlineParts.length; i++) {
+    if (i % 2 === 1) continue; // inline code — keep as-is
+    const out = replaceWikilinks(inlineParts[i], oldBasename, newBasename);
+    replacements += out.replacements;
+    inlineParts[i] = out.updated;
+  }
+
+  return { updated: inlineParts.join(""), replacements };
+}
+
+function replaceWikilinks(
+  text: string,
+  oldBasename: string,
+  newBasename: string,
+): { updated: string; replacements: number } {
+  // (?<!!) — exclude embeds ![[...]]
+  // Group 1: link target (no |, #, ], [, newline)
+  // Group 2: optional #heading (without |)
+  // Group 3: optional |display
+  const regex = /(?<!!)\[\[([^\[\]\n|#]+)(#[^\[\]\n|]*)?(\|[^\[\]\n]*)?\]\]/g;
+  let replacements = 0;
+
+  const updated = text.replace(regex, (match, target, heading, alias) => {
+    const trimmedTarget = target.trim();
+    if (trimmedTarget !== oldBasename) return match;
+    replacements += 1;
+
+    const headingPart = heading ?? "";
+    let aliasPart: string;
+    if (alias) {
+      // Preserve existing display alias.
+      aliasPart = alias;
+    } else if (headingPart) {
+      // Heading without explicit alias — preserve original basename as display.
+      aliasPart = `|${oldBasename}`;
+    } else {
+      // Bare wikilink — preserve original basename as display per UID-form convention.
+      aliasPart = `|${oldBasename}`;
+    }
+
+    return `[[${newBasename}${headingPart}${aliasPart}]]`;
+  });
+
+  return { updated, replacements };
+}

--- a/packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts
+++ b/packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Issue #3113: `command rename-to-uid` must update inbound wikilinks across
+ * the vault, matching Obsidian plugin parity.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { CommandExecutor } = await import("../../src/executors/CommandExecutor.js");
+
+const ASSET_UID = "b0afb5a7-52f8-4fa6-b0db-768957ba33e4";
+const OTHER_UID = "8279b5e7-3fe4-42b9-bc43-928d07bb7831";
+
+function targetFile(opts: { uid: string; label: string }): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${opts.uid}`,
+    `exo__Asset_label: ${opts.label}`,
+    `exo__Instance_class:`,
+    `  - "[[ems__Task]]"`,
+    "---",
+    "",
+    "# Body",
+    "",
+  ].join("\n");
+}
+
+describe("Issue #3113: rename-to-uid updates inbound wikilinks", () => {
+  let vaultRoot: string;
+  let processExitSpy: any;
+  let consoleLogSpy: any;
+  let consoleErrorSpy: any;
+
+  beforeEach(() => {
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "exo-cli-3113-"));
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__process_exit_${code ?? 0}__`);
+    }) as any);
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    fs.rmSync(vaultRoot, { recursive: true, force: true });
+  });
+
+  async function runSilently(fn: () => Promise<unknown>): Promise<void> {
+    try {
+      await fn();
+    } catch (e: any) {
+      if (!/^__process_exit_/.test(String(e?.message))) throw e;
+    }
+  }
+
+  function write(rel: string, content: string): string {
+    const full = path.join(vaultRoot, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content, "utf-8");
+    return full;
+  }
+
+  it("rewrites all wikilink shapes; skips code/embeds/already-UID-form", async () => {
+    const inbox = "01 Inbox/Choco.md";
+    write(inbox, targetFile({ uid: ASSET_UID, label: "Choco" }));
+
+    const bare = write(
+      "03 Knowledge/bare.md",
+      "Refers to [[Choco]] in body.\n",
+    );
+    const aliased = write(
+      "03 Knowledge/aliased.md",
+      "See [[Choco|Шоколад]] for details.\n",
+    );
+    const heading = write(
+      "03 Knowledge/heading.md",
+      "Check [[Choco#Ingredients]] section.\n",
+    );
+    const headingAliased = write(
+      "03 Knowledge/heading-aliased.md",
+      "Check [[Choco#Ingredients|See Ingredients]] section.\n",
+    );
+
+    // Should NOT be touched: fenced code, inline code, embed, already-UID-form, unrelated link
+    const codeBlock = write(
+      "03 Knowledge/code.md",
+      "```\nDo not rewrite [[Choco]] here\n```\n\nAfter code [[Choco]] should rewrite.\n",
+    );
+    const inlineCode = write(
+      "03 Knowledge/inline-code.md",
+      "Inline `[[Choco]]` stays. Outside [[Choco]] rewrites.\n",
+    );
+    const alreadyUid = write(
+      "03 Knowledge/already-uid.md",
+      `Already targets uid: [[${OTHER_UID}|Choco]]. Should NOT change.\n`,
+    );
+    const embed = write(
+      "03 Knowledge/embed.md",
+      "Embed ![[Choco]] should remain untouched.\n",
+    );
+    const unrelated = write(
+      "03 Knowledge/unrelated.md",
+      "Unrelated [[Banana]] link stays.\n",
+    );
+
+    const exec = new CommandExecutor(vaultRoot, /* dryRun */ false);
+    await runSilently(() => exec.executeRenameToUid(inbox));
+
+    // The target file is renamed
+    const newTargetPath = path.join(vaultRoot, "01 Inbox", `${ASSET_UID}.md`);
+    expect(fs.existsSync(newTargetPath)).toBe(true);
+    expect(fs.existsSync(path.join(vaultRoot, inbox))).toBe(false);
+
+    // Trigger files updated
+    expect(fs.readFileSync(bare, "utf-8")).toContain(`[[${ASSET_UID}|Choco]]`);
+    expect(fs.readFileSync(aliased, "utf-8")).toContain(
+      `[[${ASSET_UID}|Шоколад]]`,
+    );
+    expect(fs.readFileSync(heading, "utf-8")).toContain(
+      `[[${ASSET_UID}#Ingredients|Choco]]`,
+    );
+    expect(fs.readFileSync(headingAliased, "utf-8")).toContain(
+      `[[${ASSET_UID}#Ingredients|See Ingredients]]`,
+    );
+
+    // Code-block contents preserved verbatim
+    const codeBlockContent = fs.readFileSync(codeBlock, "utf-8");
+    expect(codeBlockContent).toContain("Do not rewrite [[Choco]] here");
+    expect(codeBlockContent).toContain(`After code [[${ASSET_UID}|Choco]]`);
+
+    // Inline code preserved
+    const inlineContent = fs.readFileSync(inlineCode, "utf-8");
+    expect(inlineContent).toContain("`[[Choco]]`");
+    expect(inlineContent).toContain(`Outside [[${ASSET_UID}|Choco]]`);
+
+    // Already-UID-form unchanged
+    expect(fs.readFileSync(alreadyUid, "utf-8")).toContain(
+      `[[${OTHER_UID}|Choco]]`,
+    );
+
+    // Embed unchanged
+    expect(fs.readFileSync(embed, "utf-8")).toContain("![[Choco]]");
+
+    // Unrelated link unchanged
+    expect(fs.readFileSync(unrelated, "utf-8")).toContain("[[Banana]]");
+  });
+
+  it("dry-run reports planned link updates without writing", async () => {
+    const inbox = "01 Inbox/Choco.md";
+    write(inbox, targetFile({ uid: ASSET_UID, label: "Choco" }));
+    const ref = write("03 Knowledge/ref.md", "Refers to [[Choco]].\n");
+    const beforeRef = fs.readFileSync(ref, "utf-8");
+    const beforeStat = fs.statSync(path.join(vaultRoot, inbox));
+
+    const exec = new CommandExecutor(vaultRoot, /* dryRun */ true);
+    await runSilently(() => exec.executeRenameToUid(inbox));
+
+    // No fs writes
+    expect(fs.readFileSync(ref, "utf-8")).toBe(beforeRef);
+    expect(fs.existsSync(path.join(vaultRoot, inbox))).toBe(true);
+    expect(fs.statSync(path.join(vaultRoot, inbox)).ino).toBe(beforeStat.ino);
+
+    const out = consoleLogSpy.mock.calls.flat().join("\n");
+    expect(out).toMatch(/\[dry-run\] Would update links in 1 file/);
+  });
+});


### PR DESCRIPTION
Fixes #3113.

## Summary

- `FileSystemVaultAdapter.updateLinks` was a no-op stub, so `exocortex command rename-to-uid` left all `[[OldName]]` references stale — diverging from the Obsidian plugin path which updates inbound links via `vault.updateLinks`.
- Adds `packages/cli/src/utils/wikilinkRewriter.ts`: vault-wide rewriter handling all four wikilink shapes from the issue AC, with code-block / inline-code / embed / already-UID-form / unrelated-link exclusions.
- `PropertyCommandExecutor.executeRenameToUid` invokes the rewriter before `renameFile` (real-run) and reports planned counts under `--dry-run` (`[dry-run] Would update links in N file(s)`).
- `FileSystemVaultAdapter.updateLinks` now delegates to the same utility (parity with plugin path through `RenameToUidService`).

## Shapes rewritten

| Before | After |
|--------|-------|
| `[[Old]]` | `[[<UID>\|Old]]` |
| `[[Old\|Display]]` | `[[<UID>\|Display]]` |
| `[[Old#Heading]]` | `[[<UID>#Heading\|Old]]` |
| `[[Old#Heading\|Display]]` | `[[<UID>#Heading\|Display]]` |

## Skipped

- Fenced code blocks (` ``` … ``` `)
- Inline code (`` ` … ` ``)
- Embeds (`![[…]]`) — out of scope per issue
- Already-UID-form (`[[<uuid>|Old]]`)
- Unrelated links
- The renamed file itself

## Test plan

- [x] New integration test `rename-to-uid-update-inbound-links.integration.test.ts` covering all four shapes, fenced/inline-code exclusion, embed exclusion, already-UID-form preservation, unrelated-link preservation, and dry-run no-write contract.
- [x] Existing `command-dry-run.integration.test.ts` still green.
- [x] Existing `FileSystemVaultAdapter.test.ts` still green.
- [x] `tsc --noEmit --skipLibCheck` clean.
- [x] Pre-commit (BDD coverage 100% + Archgate) green.