### PR TITLE
fix(shacl): exempt Literals from sh:class range checks (#3115)

### DIFF
--- a/packages/exocortex/src/services/ShaclLiteValidator.ts
+++ b/packages/exocortex/src/services/ShaclLiteValidator.ts
@@ -121,6 +121,20 @@ function isExternalOntologyIRI(iri: string): boolean {
   return EXTERNAL_ONTOLOGY_IRI_PREFIXES.some((prefix) => iri.startsWith(prefix));
 }
 
+/**
+ * XSD datatype IRI prefixes — both canonical W3C and Exocortex ad-hoc forms.
+ * Range entries with these prefixes are sh:datatype constraints (apply to Literals).
+ * All other range entries are sh:class constraints (apply to IRI nodes only).
+ */
+const XSD_DATATYPE_PREFIXES: readonly string[] = [
+  'http://www.w3.org/2001/XMLSchema#',
+  'https://exocortex.my/ontology/xsd#',
+];
+
+function isXSDDatatypeIRI(iri: string): boolean {
+  return XSD_DATATYPE_PREFIXES.some((prefix) => iri.startsWith(prefix));
+}
+
 export function validate(
   triples: Triple[],
   registry: ShapeRegistry,
@@ -238,10 +252,20 @@ export function validate(
               });
             }
           } else if (obj.type === 'literal') {
-            // Datatype range: literal datatype must match declared range IRI
+            // sh:datatype constraints apply only to range entries that are XSD datatypes.
+            // Class-IRI range entries express sh:class — by SHACL semantics they
+            // constrain non-Literal nodes only. Skip them silently for Literals.
+            //
+            // This also tolerates dual-storage predicates (Issue #2102) such as
+            // exo__Asset_prototype, where the converter intentionally emits both
+            // an IRI (for sh:class targets) and a UUID Literal (for raw-UUID SPARQL
+            // lookup). Without this distinction the Literal triggered a false
+            // sh:datatype violation against an exo:Asset class range (Issue #3115).
+            const datatypeRanges = shape.range.filter((r) => isXSDDatatypeIRI(r));
+            if (datatypeRanges.length === 0) continue;
             const literalDatatype =
               obj.datatype ?? 'http://www.w3.org/2001/XMLSchema#string';
-            const datatypeConforms = shape.range.some((r) => r === literalDatatype);
+            const datatypeConforms = datatypeRanges.some((r) => r === literalDatatype);
             if (!datatypeConforms) {
               violations.push({
                 focusNode: subjectIRI,
@@ -249,9 +273,9 @@ export function validate(
                 severity: shape.severity,
                 message:
                   shape.message ??
-                  `sh:datatype violation: literal "${obj.value}" has datatype <${literalDatatype}>, expected ${shape.range.join(' | ')}`,
+                  `sh:datatype violation: literal "${obj.value}" has datatype <${literalDatatype}>, expected ${datatypeRanges.join(' | ')}`,
                 actualValue: obj.value,
-                expectedRange: shape.range.join(' | '),
+                expectedRange: datatypeRanges.join(' | '),
               });
             }
           }

--- a/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
+++ b/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
@@ -489,6 +489,63 @@ describe('validate — range conformance (literal values)', () => {
     expect(report.violations).toHaveLength(1);
     expect(report.violations[0].expectedRange).toBe(`${XSD}integer`);
   });
+
+  // Issue #3115: dual-storage for exo__Asset_prototype emits both IRI and UUID
+  // Literal. The Literal must NOT trigger an sh:datatype violation when the
+  // shape's range is a class IRI (sh:class semantics — Literals are skipped).
+  it('T34: literal value against class-IRI range → no violation (dual-storage tolerance, Issue #3115)', () => {
+    const shape = makeShape({
+      propertyIRI: `${EXO}Asset_prototype`,
+      domain: [`${EXO}Asset`],
+      range: [`${EXO}Asset`],
+    });
+    const targetUUID = 'f2dccb6a-802d-48d3-8e8a-2c4264197692';
+    const targetIRI = `vault://kitelev/${targetUUID}.md`;
+    const triples = [
+      typeTriple('node:A', `${EXO}Asset`),
+      typeTriple(targetIRI, `${EXO}Asset`),
+      iriTriple('node:A', `${EXO}Asset_prototype`, targetIRI),
+      litTriple('node:A', `${EXO}Asset_prototype`, targetUUID),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.conforms).toBe(true);
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T35: literal-only value against class-IRI range → no violation (sh:class skips Literals)', () => {
+    const shape = makeShape({
+      propertyIRI: `${EXO}Asset_prototype`,
+      domain: [`${EXO}Asset`],
+      range: [`${EXO}Asset`],
+    });
+    const triples = [
+      typeTriple('node:A', `${EXO}Asset`),
+      litTriple('node:A', `${EXO}Asset_prototype`, 'some-uuid-string'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    // sh:class doesn't apply to Literals; range has no XSD datatype entries.
+    expect(report.violations.filter((v) => v.message.includes('sh:datatype'))).toHaveLength(0);
+  });
+
+  it('T36: mixed range (class IRI + xsd:string) — Literal validated against datatype subset', () => {
+    const shape = makeShape({
+      propertyIRI: `${EMS}Effort_mixed`,
+      range: [`${EMS}Foo`, `${XSD}string`],
+    });
+    const triplesOk = [
+      typeTriple('node:A', `${EMS}Effort`),
+      litTriple('node:A', `${EMS}Effort_mixed`, 'plain string'),
+    ];
+    expect(validate(triplesOk, makeRegistry([shape]), flatHierarchy).violations).toHaveLength(0);
+
+    const triplesBad = [
+      typeTriple('node:B', `${EMS}Effort`),
+      litTriple('node:B', `${EMS}Effort_mixed`, '42', `${XSD}integer`),
+    ];
+    const badReport = validate(triplesBad, makeRegistry([shape]), flatHierarchy);
+    expect(badReport.violations).toHaveLength(1);
+    expect(badReport.violations[0].message).toContain('sh:datatype');
+  });
 });
 
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #3115

## Problem

SHACL-lite pre-validator rejected valid `exo__Asset_prototype` wikilinks
with `sh:datatype violation: literal "<uuid>" has datatype xsd:string,
expected <https://exocortex.my/ontology/exo#Asset>`. This blocked
recurring-task instantiation flows: `/week-planner`, `/smoke-log`,
`/oshia-log`, weekly БАД pillbox-fill, etc.

## Root cause

`NoteToRDFConverter` intentionally emits **dual-storage** for
`exo__Asset_prototype` (Issue #2102): both an IRI triple (for
prototype→instance navigation) and a UUID Literal (for raw-UUID SPARQL
lookup). The shape for `exo__Asset_prototype` declares
`exo__Property_range: exo__Asset` — a class IRI, i.e. an `sh:class`
constraint, which per SHACL semantics applies to non-Literal nodes only.

The validator did not distinguish XSD datatype range entries from
class-IRI ones, so the Literal half of the dual-storage triggered a
false `sh:datatype` violation against the class IRI.

## Fix

In `ShaclLiteValidator.validate`, when iterating over a Literal value's
range conformance:

- Filter `shape.range` to entries under XSD namespaces (canonical
  `http://www.w3.org/2001/XMLSchema#` or Exocortex ad-hoc
  `https://exocortex.my/ontology/xsd#`) — those are `sh:datatype`
  constraints.
- If no XSD entries remain, skip the Literal silently. Class-IRI ranges
  (`sh:class`) don't constrain Literals.
- If XSD entries exist, compare literal datatype against them as before.

This restores SHACL standard semantics (sh:class ∝ IRI, sh:datatype ∝
Literal) and tolerates dual-storage by design.

## Tests

- `T34`: dual-storage `[IRI, UUID Literal]` for `exo__Asset_prototype`
  with class-IRI range → no violation.
- `T35`: literal-only value against class-IRI range → no `sh:datatype`
  violation.
- `T36`: mixed `[class IRI, xsd:string]` range — literals validated
  against the XSD subset only.

Existing 82 ShaclLiteValidator tests + 308 SHACL/converter tests stay
green. Pre-existing test failures elsewhere (8 suites, unrelated to
SHACL) confirmed against baseline `main`.

## Verification

- Repro snippet from issue → exit 0 (was exit 1).
- Legacy instances `1a9fe125-...` and `cdbe3394-...` validate clean.
- Other IRI-valued properties (`_relates`, `_parent`, `_area`,
  `_responsible`) unaffected.

## Test plan
- [x] Unit tests for new T34-T36
- [x] Full ShaclLiteValidator suite (82 tests)
- [x] NoteToRDFConverter dual-storage tests (#2102, #2489)
- [x] CLI smoke test against vault — repro passes, legacy clean