### PR TITLE
fix(e2e): block Obsidian auto-update endpoints to stabilize shard 1 (#3024)

### DIFF
--- a/packages/obsidian-plugin/docker-entrypoint-e2e.sh
+++ b/packages/obsidian-plugin/docker-entrypoint-e2e.sh
@@ -23,6 +23,19 @@ export CI=1
 export DEBUG=pw:browser*
 export ELECTRON_ENABLE_LOGGING=0
 
+# Issue #3024 — Block Obsidian auto-update endpoints.
+# Obsidian binary is pinned at 1.9.14 in Dockerfile.ci, but at runtime Obsidian
+# polls releases.obsidian.md on first launch and starts a background asar.gz
+# download for any newer version. That download races plugin-load assertions in
+# e2e-shard-1 (dynamic-commands.spec.ts:38) and causes intermittent timeouts.
+# Routing the update endpoints to 127.0.0.1 makes the check fail fast so the
+# plugin reaches "loaded" state deterministically. Plugin downloads still work
+# (those resolve through github.com, untouched).
+{
+  echo "127.0.0.1 releases.obsidian.md"
+  echo "127.0.0.1 publish.obsidian.md"
+} >> /etc/hosts 2>/dev/null || echo "WARN: could not pin update endpoints in /etc/hosts" >&2
+
 XVFB_VARIANT="${XVFB_VARIANT:-v1+v2}"
 
 echo "========================================" >&2


### PR DESCRIPTION
## Summary

- Stops e2e-shard-1 from racing Obsidian's first-launch auto-update download.
- Blocks `releases.obsidian.md` + `publish.obsidian.md` at `/etc/hosts` inside the e2e container; plugin downloads via `github.com` are untouched.
- Obsidian binary already pinned at 1.9.14 in `Dockerfile.ci` — this PR closes the runtime side of the race.

## Root cause

Per #3024:

1. CI runner launches Obsidian (1.9.14, pinned).
2. Obsidian polls `releases.obsidian.md` and starts a background `asar.gz` download for the latest version (e.g. 1.12.7 in PR #3019 failure logs).
3. Plugin-load assertions run before the update download settles.
4. Plugin appears "not loaded" → `dynamic-commands.spec.ts:38` times out.

`gh run rerun --failed` was the only known workaround.

## Fix

`docker-entrypoint-e2e.sh` now appends the two update endpoints to `/etc/hosts` before launching xvfb. Resolution fails fast, Obsidian skips the background download, plugin reaches the loaded state deterministically.

This corresponds to Option 1 + a runtime variant of Option 2 from the issue's "Suggested fixes" (pin + disable auto-update). Option 1 (pin) was already in place via `Dockerfile.ci`.

## Test plan

- [ ] CI: `e2e-shard (1..6)` green
- [ ] CI: rest of 13 required checks green
- [ ] No regression in `dynamic-commands.spec.ts`
- [ ] Manual: container logs no longer show `Latest version is ... Downloading update from ...`

Fixes #3024