### PR TITLE
fix(sparql): drop redundant null check flagged by CodeQL (#3010)

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -371,7 +371,7 @@ export class FilterExecutor {
     if (value === undefined || value === null) {
       return { type: "literal", value: "" } as unknown as Expression;
     }
-    if (value !== null && typeof value === "object" && "termType" in value) {
+    if (typeof value === "object" && "termType" in value) {
       return value as unknown as Expression;
     }
     if (value instanceof IRI || value instanceof Literal) {


### PR DESCRIPTION
## Summary

Closes CodeQL alert #304 (`js/comparison-between-incompatible-types`) on `FilterExecutor.ts:374`.

`wrapAsLiteralExpression` already returns early when `value` is null or undefined on line 371, so TS narrows `value` to exclude null afterwards. The follow-up `value !== null && ...` on line 374 is always true and CodeQL flags it as a comparison between inconvertible types.

## Change

```diff
-    if (value !== null && typeof value === "object" && "termType" in value) {
+    if (typeof value === "object" && "termType" in value) {
```

Behaviour identical — the `typeof === "object" && "termType" in value` guard still gates the RDF Term early return.

## Test plan

- [x] `npx jest --testPathPatterns=FilterExecutor` → 183/183 pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed file
- [ ] CI: 13 required checks green
- [ ] CodeQL alert #304 closes automatically after merge

Fixes #3010