### PR TITLE
feat(indexer): index whitelisted unprefixed frontmatter (#3043 Phase 1)

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -38,6 +38,18 @@ export interface ExocortexInvariantViolation {
 }
 
 /**
+ * Issue #3043 Phase 1 (RFC 871c1e56 A-series): whitelist of unprefixed
+ * frontmatter keys that index as `exo:Asset_<key>` triples. The whitelist is
+ * intentionally narrow — extending it requires an explicit decision because
+ * every entry trades indexer simplicity for triple-graph growth.
+ */
+const UNPREFIXED_ASSET_FIELDS: ReadonlySet<string> = new Set([
+  "archived",
+  "draft",
+  "pinned",
+]);
+
+/**
  * Service for converting Obsidian notes (frontmatter + wikilinks) to RDF triples.
  *
  * @example
@@ -116,11 +128,19 @@ export class NoteToRDFConverter {
     triples.push(new Triple(subject, fileNamePredicate, new Literal(file.basename)));
 
     for (const [key, value] of Object.entries(frontmatter)) {
-      if (!this.isExocortexProperty(key)) {
+      // Issue #3043 Phase 1: whitelisted unprefixed frontmatter keys are
+      // indexed under the `exo:Asset_<key>` predicate so SPARQL queries like
+      // `?s exo:Asset_archived true` can match assets that carry the bare
+      // Obsidian-style flag in frontmatter (`archived: true`). Keys outside
+      // the whitelist remain skipped to avoid uncontrolled triple growth.
+      const normalizedKey = UNPREFIXED_ASSET_FIELDS.has(key)
+        ? `exo__Asset_${key}`
+        : key;
+      if (!this.isExocortexProperty(normalizedKey)) {
         continue;
       }
 
-      const predicate = this.propertyKeyToIRI(key);
+      const predicate = this.propertyKeyToIRI(normalizedKey);
       const values = Array.isArray(value) ? value : [value];
 
       for (const val of values) {

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -357,6 +357,52 @@ describe("NoteToRDFConverter", () => {
       expect((archivedTriple!.object as Literal).value).toBe("true");
     });
 
+    // Issue #3043 Phase 1: unprefixed frontmatter whitelist
+    describe("unprefixed frontmatter whitelist (Issue #3043 Phase 1)", () => {
+      it.each([
+        ["archived", "exo__Asset_archived"],
+        ["draft", "exo__Asset_draft"],
+        ["pinned", "exo__Asset_pinned"],
+      ])("indexes unprefixed %s as %s", async (key, expectedPredicate) => {
+        const file: IFile = {
+          path: "test.md",
+          basename: "test",
+          name: "test.md",
+          parent: null,
+        };
+        const frontmatter: IFrontmatter = { [key]: true };
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const match = triples.find((t) =>
+          (t.predicate as IRI).value.endsWith(expectedPredicate.replace("__", "#"))
+            || (t.predicate as IRI).value.endsWith(`/${expectedPredicate.split("__")[1]}`)
+        );
+        expect(match).toBeDefined();
+        expect((match!.object as Literal).value).toBe("true");
+      });
+
+      it("does not index non-whitelisted unprefixed keys", async () => {
+        const file: IFile = {
+          path: "test.md",
+          basename: "test",
+          name: "test.md",
+          parent: null,
+        };
+        const frontmatter: IFrontmatter = { color: "blue", priority: 5 };
+        mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+        const triples = await converter.convertNote(file);
+
+        const leaked = triples.find((t) => {
+          const p = (t.predicate as IRI).value;
+          return p.includes("Asset_color") || p.includes("Asset_priority");
+        });
+        expect(leaked).toBeUndefined();
+      });
+    });
+
     // Issue #666: Add Asset_fileName predicate for all assets
     describe("Asset_fileName predicate (Issue #666)", () => {
       it("should add Asset_fileName triple with file basename (without .md)", async () => {


### PR DESCRIPTION
## Summary

First sub-PR for parent issue #3043 (RFC `871c1e56` — APPROVED v4, A-series Phase 1).

`NoteToRDFConverter` now indexes a narrow whitelist of unprefixed frontmatter keys under the corresponding `exo:Asset_<key>` predicate:

| Frontmatter key | Predicate |
|-----------------|-----------|
| `archived` | `exo:Asset_archived` |
| `draft` | `exo:Asset_draft` |
| `pinned` | `exo:Asset_pinned` |

Closes Blocker 2 of three in #3043 — SPARQL queries can now filter assets carrying bare Obsidian-style `archived: true` frontmatter without a grep-then-SPARQL workaround.

## Why narrow whitelist (not generic rule)

RFC §A4 specifies a <5% triple-graph growth decision gate. A blanket "any unprefixed key → exo:Asset_<key>" rule risks indexing Obsidian-internal keys (`cssclass`, `publish`, `created`, `modified`, `priority`, `due`) that are not Exocortex domain data. The whitelist trades simplicity for predictable growth — extending it is a follow-up sub-issue (A1, JSON Schema config) intentionally not bundled.

## Acceptance criterion satisfied

From #3043:

> **Given** asset with `archived: true` in frontmatter, **When** SPARQL `?s exo:Asset_archived true`, **Then** asset matches.

## Test plan

- [x] 4 new parametrised tests (`it.each`): each whitelisted key produces correct predicate
- [x] Negative test: non-whitelisted unprefixed keys (`color`, `priority`) still skipped
- [x] All 193 existing `NoteToRDFConverter.*.test.ts` pass
- [x] `tsc --noEmit` clean, ESLint clean, archgate 13/13, BDD 100%
- [ ] CI: 13 required checks green

## Scope (out)

- Blocker 1 (wikilink-literals → property paths) — RFC Phase 3, separate elapsed-time budget (4-8 weeks per RFC §Schedule)
- Blocker 3 (`describe-class` CLI) — follow-up PR in this issue
- A1 JSON Schema config + A3 fixture coverage + A4 dry-run bench — explicit RFC sub-issues, not bundled here

Refs #3043