### PR TITLE
feat(cli): expose describe-class alias for schema introspection (#3043 Phase B)

### DIFF
--- a/packages/cli/src/commands/classes.ts
+++ b/packages/cli/src/commands/classes.ts
@@ -41,7 +41,11 @@ interface PropertyInfo {
  */
 export function classesCommand(): Command {
   return new Command("classes")
-    .description("List RDF classes in Obsidian vault or show class details")
+    .alias("describe-class")
+    .description(
+      "List RDF classes in vault, or describe a class (predicates + counts). " +
+      "Alias `describe-class` is provided per #3043 RFC §B (schema introspection).",
+    )
     .argument("[class-name]", "Optional class name to show details (e.g., ems__Task)")
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
     .option("--format <type>", "Output format: table|json", "table")

--- a/packages/cli/tests/unit/commands/classes.test.ts
+++ b/packages/cli/tests/unit/commands/classes.test.ts
@@ -125,6 +125,12 @@ describe("classesCommand", () => {
       const cacheOption = cmd.options.find(opt => opt.flags.includes("--use-cache"));
       expect(cacheOption).toBeDefined();
     });
+
+    // Issue #3043 Phase B: schema introspection AC requires `describe-class` name.
+    it("should expose describe-class alias (#3043 RFC §B)", () => {
+      const cmd = classesCommand();
+      expect(cmd.aliases()).toContain("describe-class");
+    });
   });
 
   describe("vault validation", () => {


### PR DESCRIPTION
## Summary

Second sub-PR for parent issue #3043 (RFC `871c1e56` — APPROVED v4, B-series).

Schema introspection AC3 in #3043 requires the literal command form:

> **Given** класс `ems__Project` в графе, **When** `exocortex-cli describe-class ems:Project`, **Then** выводится список предикатов используемых на инстансах класса с counts.

After audit (RFC §"Audit-First Strategy") I found `exocortex classes <class-name>` already implements the full underlying behaviour — SPARQL aggregate `SELECT ?property (COUNT(?value) AS ?usageCount) ... GROUP BY ?property ORDER BY DESC(?usageCount)`, `--format table|json`, `--use-cache`, formatted output. Sub-issues **B1 + B2 + B3 are pre-implemented**.

This PR closes the last gap — the literal command name — by adding `describe-class` as a Commander alias for `classes`. Both forms now work identically:

```
exocortex classes ems__Project       # existing
exocortex describe-class ems__Project # NEW — same behaviour
```

## Why alias, not new command

- No code duplication
- All existing tests + options (`--vault`, `--format`, `--output`, `--use-cache`) automatically apply
- Follows the same precedent in this codebase (e.g. `sparql` aliased to `exoql`)

## Test plan

- [x] 1 new test: `cmd.aliases()` contains `describe-class`
- [x] All 9 existing `classes.test.ts` tests pass (2 pre-existing skips kept)
- [x] `tsc --noEmit` clean, archgate 13/13, BDD 100%
- [ ] CI: 13 required checks green

## Issue progress

After this PR + #3119 (Blocker 2 — frontmatter whitelist), #3043 will have:
- ✅ Blocker 2: indexer indexes `archived`/`draft`/`pinned` unprefixed
- ✅ Blocker 3: schema introspection via `describe-class` alias
- ⏳ Blocker 1: wikilink-literals → property paths — RFC Phase 3 (C-series), 4-8 weeks elapsed per RFC §Schedule

Parent issue stays open until Blocker 1 lands.

Refs #3043