### PR TITLE
fix(shacl-lite): multi-class sh:class ANY-of (#3121)

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1849,3 +1849,43 @@ observer.observe(container, {
 **Prerequisite**: The enum instance file (e.g. `pmbok__ClosureOutcomeAllAccepted.md`) must have `exo__Instance_class` in its frontmatter pointing to the parent class.
 
 **Reference**: IssueItem ff3858e5, PR #3070
+
+---
+
+## SHACL-lite false `sh:class violation` from Multi-Valued `exo__Instance_class` with One Malformed Entry
+
+**Symptom**: An asset has frontmatter like
+
+```yaml
+exo__Instance_class:
+  - "[[kf__Academic Discipline]]" # malformed (whitespace in local name)
+  - "[[ims__Concept]]" # well-formed
+```
+
+…and SHACL still reports `sh:class violation` for the asset (or for assets that reference it) even though `ims__Concept` IS expected to be in `rdf:type`.
+
+**Diagnostic procedure (IRI-normalization / triple-presence audit, ≤15 min)**
+
+1. **Probe whether the target has ANY triples in the store:**
+
+   ```bash
+   npx @kitelev/exocortex-cli exoql query \
+     "SELECT ?p ?o WHERE { <obsidian://vault/path/to/target.md> ?p ?o }"
+   ```
+
+   - `0 results` → the converter dropped the entire asset. Continue at step 2.
+   - rdf:type triples appear → the bug is not the converter. Suspect IRI normalization between `subjectClasses.set` (line 165 of `ShaclLiteValidator.ts`) and `subjectClasses.get(obj.value)` (line 235) — compare lookup-key vs subject-key encoding (percent-encoding, trailing slashes).
+
+2. **Inspect the target's `exo__Instance_class` array.** Any entry whose `[[wikilink]]` starts with a namespaced prefix (`kf__`, `ems__`, `inbox__`, …) but whose local name contains whitespace, parentheses, or other characters illegal in an IRI is malformed.
+
+3. **Pre-fix root cause (resolved by Issue #3121):** a single malformed entry threw at `Namespace.term()`, aborting the whole-asset triple build via the outer catch in `convertVaultWithValidation`. Validator-side `validateExocortexAsset` also rejected the whole asset on the first malformed entry. Net result: every reference to the asset triggered a false sh:class violation because the target had zero `rdf:type` triples in the store.
+
+**Fix (Issue #3121, v15.176.x+)**
+
+- `expandClassValue` rejects local names containing whitespace/parens — returns `null` instead of throwing.
+- `validateExocortexAsset` accepts a multi-valued array if **any** entry is well-formed; only rejects when **all** entries are malformed.
+- Net effect: malformed entries are silently dropped at conversion; valid siblings still produce `rdf:type` and `exo__Instance_class` triples, so SHACL `sh:class` ANY-of check sees the correct class set.
+
+**User action**: optionally rename malformed targets to a valid namespace form (e.g. `kf__AcademicDiscipline`). The asset is no longer invisible to SHACL in the meantime.
+
+**Reference**: Issue #3121

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -780,10 +780,20 @@ export class NoteToRDFConverter {
     // Instance_class wikilink shape — only reject when target carries
     // a known namespace prefix (e.g. `exo__`, `ems__`) but contains
     // characters that would produce an invalid namespace IRI.
+    //
+    // Issue #3121: for multi-valued exo__Instance_class, only reject if
+    // ALL entries are invalid. Mixed arrays (one bad + N valid) survive —
+    // the bad entries are dropped by `expandClassValue` returning null at
+    // triple-build time, while valid entries still produce rdf:type and
+    // exo__Instance_class triples. Previously a single malformed entry
+    // dropped the entire asset from the store, cascading false sh:class
+    // violations on referencing assets.
     const instanceClassValue = frontmatter["exo__Instance_class"];
     const classCandidates = Array.isArray(instanceClassValue)
       ? instanceClassValue
       : [instanceClassValue];
+    let firstInvalid: { candidate: string } | null = null;
+    let anyValid = false;
     for (const candidate of classCandidates) {
       if (typeof candidate !== "string") continue;
       const cleaned = this.removeQuotes(candidate);
@@ -791,12 +801,17 @@ export class NoteToRDFConverter {
       const target = (wikilink ?? cleaned).trim();
       const looksLikeNamespacedClass = /^[a-z][a-zA-Z0-9]*__/.test(target);
       if (looksLikeNamespacedClass && /[\s()]/.test(target)) {
-        return {
-          code: "INVALID_INSTANCE_CLASS_IRI",
-          property: "exo__Instance_class",
-          message: `Invalid Instance_class IRI: "${candidate}"`,
-        };
+        if (!firstInvalid) firstInvalid = { candidate };
+      } else {
+        anyValid = true;
       }
+    }
+    if (firstInvalid && !anyValid) {
+      return {
+        code: "INVALID_INSTANCE_CLASS_IRI",
+        property: "exo__Instance_class",
+        message: `Invalid Instance_class IRI: "${firstInvalid.candidate}"`,
+      };
     }
 
     return null;
@@ -1198,6 +1213,12 @@ export class NoteToRDFConverter {
     const cleanValue = this.removeQuotes(value);
     const parsed = Namespace.fromPropertyKey(cleanValue);
     if (!parsed) return null;
+    // Issue #3121: reject local names whose IRI form would be invalid
+    // (whitespace, parens). Without this gate, `Namespace.term` throws and
+    // aborts the entire vault-load iteration via the outer catch, dropping
+    // every triple for the asset — including valid sibling rdf:type triples
+    // from other entries in a multi-valued exo__Instance_class array.
+    if (/[\s()]/.test(parsed.localName)) return null;
     return parsed.namespace.term(parsed.localName);
   }
 

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.issue-3121-multi-class.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.issue-3121-multi-class.test.ts
@@ -1,0 +1,121 @@
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import { IVaultAdapter, IFile } from "../../../src/interfaces/IVaultAdapter";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+
+/**
+ * Issue #3121: an invalid entry in a multi-valued `exo__Instance_class`
+ * array (e.g. `[[kf__Academic Discipline]]` — namespaced prefix but
+ * local name with whitespace) must not drop the entire asset from the
+ * triple store. Other valid entries continue to produce class-membership
+ * triples (`rdf:type`, `exo__Instance_class`).
+ *
+ * Pre-fix behaviour: `validateExocortexAsset` returned
+ * `INVALID_INSTANCE_CLASS_IRI` and `convertVaultWithValidation` skipped
+ * the entire file. Result: cascading false sh:class violations against
+ * every asset that referenced the dropped one (e.g. Psychology, Medicine
+ * referenced by other concepts).
+ */
+describe("Issue #3121: multi-valued exo__Instance_class with one invalid entry", () => {
+  let mockVault: jest.Mocked<IVaultAdapter>;
+  let converter: NoteToRDFConverter;
+
+  beforeEach(() => {
+    mockVault = {
+      getFrontmatter: jest.fn(),
+      getAllFiles: jest.fn(),
+      read: jest.fn().mockResolvedValue(""),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      updateLinks: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+    } as jest.Mocked<IVaultAdapter>;
+
+    converter = new NoteToRDFConverter(mockVault);
+  });
+
+  it("validateExocortexAsset accepts mixed array if at least one entry is valid", () => {
+    const frontmatter = {
+      exo__Asset_uid: "fdd8969a-dc13-475a-b044-5b56c3275ee1",
+      exo__Asset_isDefinedBy: "[[!exo]]",
+      exo__Instance_class: [
+        "[[kf__Academic Discipline]]", // invalid: whitespace in local name
+        "[[ims__Concept]]",             // valid
+      ],
+    };
+    expect(converter.validateExocortexAsset(frontmatter)).toBeNull();
+  });
+
+  it("validateExocortexAsset still rejects when all entries are invalid", () => {
+    const frontmatter = {
+      exo__Asset_uid: "00000000-0000-0000-0000-000000000000",
+      exo__Asset_isDefinedBy: "[[!exo]]",
+      exo__Instance_class: ["[[kf__Academic Discipline]]"], // only invalid entry
+    };
+    expect(converter.validateExocortexAsset(frontmatter)?.code).toBe(
+      "INVALID_INSTANCE_CLASS_IRI",
+    );
+  });
+
+  it("convertNote emits rdf:type triples for valid entries and skips invalid ones", async () => {
+    const file = {
+      path: "03 Knowledge/x/fdd8969a-dc13-475a-b044-5b56c3275ee1.md",
+      basename: "fdd8969a-dc13-475a-b044-5b56c3275ee1",
+      name: "fdd8969a-dc13-475a-b044-5b56c3275ee1.md",
+      extension: "md",
+      parent: null,
+    } as unknown as IFile;
+
+    mockVault.getFrontmatter.mockReturnValue({
+      exo__Asset_uid: "fdd8969a-dc13-475a-b044-5b56c3275ee1",
+      exo__Asset_isDefinedBy: "[[!exo]]",
+      exo__Asset_label: "Psychology",
+      exo__Instance_class: [
+        "[[kf__Academic Discipline]]",
+        "[[ims__Concept]]",
+      ],
+    });
+
+    const triples = await converter.convertNote(file);
+
+    const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+    const EXO_INSTANCE_CLASS = "https://exocortex.my/ontology/exo#Instance_class";
+    const IMS_CONCEPT = "https://exocortex.my/ontology/ims#Concept";
+
+    // Valid entry produces both class-membership triples
+    const rdfTypeIRIs = triples
+      .filter(
+        (t) =>
+          t.predicate instanceof IRI &&
+          t.predicate.value === RDF_TYPE &&
+          t.object instanceof IRI,
+      )
+      .map((t) => (t.object as IRI).value);
+    expect(rdfTypeIRIs).toContain(IMS_CONCEPT);
+
+    const instanceClassValues = triples
+      .filter(
+        (t) =>
+          t.predicate instanceof IRI &&
+          t.predicate.value === EXO_INSTANCE_CLASS &&
+          t.object instanceof IRI,
+      )
+      .map((t) => (t.object as IRI).value);
+    expect(instanceClassValues).toContain(IMS_CONCEPT);
+
+    // Invalid entry MUST NOT produce an IRI with whitespace (would be unusable)
+    expect(instanceClassValues.some((v) => /\s/.test(v))).toBe(false);
+    expect(rdfTypeIRIs.some((v) => /\s/.test(v))).toBe(false);
+    // And MUST NOT produce an rdf:type triple at all — the line 186-194 loop
+    // gates on `instanceof IRI`, so a Literal-resolved bad entry is dropped.
+    expect(rdfTypeIRIs).toEqual([IMS_CONCEPT]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3121.

A single malformed entry in a multi-valued `exo__Instance_class` array (e.g. `[[kf__Academic Discipline]]` — namespaced prefix with whitespace in the local name) caused `Namespace.term()` to throw and abort the entire whole-asset triple build. The asset ended up with **zero** `rdf:type` triples in the store, which made every reference to it trigger a false `sh:class` violation in SHACL-lite validation.

## Root cause

Discovered empirically via SPARQL probe — the reproducer asset `fdd8969a-…` (Psychology) returned `0` triples from the store despite being on disk:

```bash
$ exoql query "SELECT ?p ?o WHERE { ?s exo:Asset_uid 'fdd8969a-...' . ?s ?p ?o }"
No results found.
```

The vault load iterator in `convertVaultWithValidation` catches throws and skips the file. `expandClassValue` → `Namespace.term("Academic Discipline")` → `new IRI(<space>)` → throws → file dropped. Same applies to ~6 known assets (Psychology, Medicine, Outcome, Philosophy, Biology, TOOS Chapter), producing ~56 false `ims#Concept` / `ims#ConceptSchema` violations cascaded across assets that referenced them.

## Fix

Two surgical changes in `packages/exocortex/src/services/NoteToRDFConverter.ts`:

1. **`expandClassValue`** — reject local names containing whitespace or parens (return `null` instead of letting `Namespace.term` throw).
2. **`validateExocortexAsset`** — for multi-valued `exo__Instance_class`, only reject when **all** entries are malformed. Mixed arrays survive; malformed entries are silently dropped by the now-null-returning `expandClassValue`; valid siblings still produce `rdf:type` and `exo__Instance_class` triples → SHACL ANY-of `sh:class` sees the correct class set.

The downstream `convertLegacyNote` `rdf:type` emission (line 186-194) already gates on `instanceof IRI`, so `Literal`-resolved malformed entries are naturally dropped without producing nonsense type triples.

## Acceptance criteria (from issue)

- [x] Failing test added (multi-class asset, 2nd-position class in sh:class range) → `NoteToRDFConverter.issue-3121-multi-class.test.ts` (3 scenarios: mixed-valid validation, all-invalid still rejected, triple-emission preserves valid)
- [x] Root cause fixed → test passes; all 46 services test suites green (1157 tests)
- [ ] Vault regression validation (ims#Concept 65 → ≤5) — to be verified post-release via `npx @kitelev/exocortex-cli@latest validate schema --shapes-mode` against `/Users/kitelev/vault-2025`
- [x] `TROUBLESHOOTING.md` gets IRI-presence diagnostic procedure (SPARQL probe + frontmatter audit + pre/post-fix behaviour)

## Test plan

- [x] `npm test` — services suite green (1157/1157)
- [x] CLI integration baseline failures pre-existing on `main` (5 CLI integration suites — require built CLI bundle; not affected by this change)
- [ ] CI 13 required checks
- [ ] Post-merge: re-run validate on `vault-2025`, confirm `ims#Concept` violation count drops