### PR TITLE
docs(schema): canonical Instance_class form (#3123)

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1889,3 +1889,66 @@ exo__Instance_class:
 **User action**: optionally rename malformed targets to a valid namespace form (e.g. `kf__AcademicDiscipline`). The asset is no longer invisible to SHACL in the meantime.
 
 **Reference**: Issue #3121
+
+---
+
+## exo\_\_Instance_class wikilink form mismatch — all forms RDF-equivalent
+
+**Symptom / question**: "I bulk-rewrote `exo__Instance_class` from label form `[[ems__Task]]` to bare-UUID form `[[1b20a8f0-…]]`. SHACL violation count didn't change at all. Did the rewrite do nothing? Was my hypothesis wrong?"
+
+**Short answer**: The rewrite did exactly what it should — **nothing semantically**, because all three accepted forms are RDF-equivalent. The violation count is identical _by design_. Don't burn cycles debugging this.
+
+### The three forms
+
+`exo__Instance_class` historically accepts three wikilink shapes:
+
+| Form | Example                                                 | Where used                                                                   |
+| ---- | ------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| A    | `"[[ems__Task]]"`                                       | Older `/exocortex-asset` skill template, hand-written assets                 |
+| B    | `"[[1b20a8f0-d745-4e93-91db-4531b3df120e\|ems__Task]]"` | Mixed-form skill outputs (UUID for stability, alias for humans)              |
+| C    | `"[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"`            | **Canonical** since 2026-05-16 (issue #3123). Used by recent bulk migrations |
+
+### Why all three are semantically equivalent
+
+`NoteToRDFConverter.valueToClassURI` resolves any of the three to the **same namespace IRI** (e.g. `https://exocortex.my/ontology/ems#Task`) via `Namespace.fromPropertyKey`. The converter:
+
+1. Strips wikilink brackets `[[...]]` and any alias `|...`.
+2. Tries the inner value as a property-key (`ems__Task`) — succeeds for Form A and Form B (after alias strip).
+3. If not a property-key (Form C: bare UUID), looks up the target asset and reads _its_ `exo__Instance_class` to derive the class IRI.
+
+Crucially, **file existence at the wikilink target is not consulted for the class IRI itself in Form A/B** — only the property-key registry. That means Form A (`[[ems__Task]]`) produces a valid class IRI even when no file named `ems__Task.md` exists in the vault.
+
+The SHACL-lite validator (`ShaclLiteValidator`) then sees the same `rdf:type` triple regardless of which form was emitted, so:
+
+- `sh:class` checks: identical result.
+- `sh:in` enum checks: identical result.
+- `sh:minCount` / `sh:maxCount` cardinality: identical result.
+
+### Empirical evidence (2026-05-16 SHACL deep-dive session)
+
+Migration A → C across the vault:
+
+- **n** = 305 files rewritten
+- **Total SHACL violations before**: 307
+- **Total SHACL violations after**: 307
+- **Delta**: 0
+
+This is the expected, correct outcome — not a bug, not a missed cache invalidation, not a malformed entry being silently dropped.
+
+### Obsidian navigation caveat
+
+The forms _do_ differ for **Obsidian wiki-style navigation** (Ctrl/Cmd + click on the link in the editor):
+
+- Form A `[[ems__Task]]` only navigates if a file `ems__Task.md` exists (label-named shim).
+- Form B `[[uuid|ems__Task]]` navigates to the UUID-named file (`<uuid>.md`); alias is display-only.
+- Form C `[[uuid]]` navigates to the UUID-named file with the UUID as display text.
+
+This is a UX/cosmetic concern that has **no bearing on RDF semantics or SHACL conformance**.
+
+### What to do
+
+1. **For new assets**: emit Form C only. `/exocortex-asset` skill template and `docs/PROPERTY_SCHEMA.md` § _exo\_\_Instance_class › Canonical form_ are the source of truth.
+2. **For existing assets**: Form A and Form B continue to work; migration is cosmetic and may be deferred. The pre-write hook `~/.claude/hooks/validate-wikilinks.sh` warns on non-Form-C in _new_ writes but does not block or rewrite legacy content.
+3. **If SHACL violation counts didn't change after a form-only rewrite**: that's success, not failure. Move on.
+
+**Reference**: Issue #3123. Related: `docs/PROPERTY_SCHEMA.md` § `exo__Instance_class` › _Canonical form_.

--- a/docs/PROPERTY_SCHEMA.md
+++ b/docs/PROPERTY_SCHEMA.md
@@ -202,26 +202,51 @@ exo__Asset_isDefinedBy: "[[Ontology/EMS]]"
 
 **Asset type classification (one or more types)**
 
-| Attribute        | Value                                                   |
-| ---------------- | ------------------------------------------------------- |
-| **Type**         | Array of WikiLinks                                      |
-| **Required**     | ✅ Yes (ALL assets)                                     |
-| **Format**       | `['"[[AssetClassValue]]"']` (quoted WikiLinks in array) |
-| **Purpose**      | Determine asset type for UI rendering and commands      |
-| **Generated**    | Based on creation context (see `INSTANCE_CLASS_MAP`)    |
-| **Mutable**      | Rarely (type usually fixed at creation)                 |
-| **Valid Values** | See `AssetClass` enum                                   |
+| Attribute          | Value                                                                    |
+| ------------------ | ------------------------------------------------------------------------ |
+| **Type**           | Array of WikiLinks                                                       |
+| **Required**       | ✅ Yes (ALL assets)                                                      |
+| **Canonical form** | **Form C — bare UUID** `"[[<class-uuid>]]"` (see _Canonical form_ below) |
+| **Purpose**        | Determine asset type for UI rendering and commands                       |
+| **Generated**      | Based on creation context (see `INSTANCE_CLASS_MAP`)                     |
+| **Mutable**        | Rarely (type usually fixed at creation)                                  |
+| **Valid Values**   | See `AssetClass` enum                                                    |
 
-**Example**:
+#### Canonical form (decided 2026-05-16, issue #3123)
+
+For new assets the canonical encoding of `exo__Instance_class` values is **Form C — bare UUID wikilink**:
 
 ```yaml
 exo__Instance_class:
-  - "[[ems__Task]]"
+  - "[[1b20a8f0-d745-4e93-91db-4531b3df120e]]" # ems__Task
+```
 
-# Or multiple classes
+Two non-canonical legacy forms are still accepted by the converter and are **semantically equivalent** for RDF/SHACL purposes — see `TROUBLESHOOTING.md` § _exo\_\_Instance_class wikilink form mismatch — all forms RDF-equivalent_ — but new assets must not emit them:
+
+| Form | Example                                                 | Status        |
+| ---- | ------------------------------------------------------- | ------------- |
+| A    | `"[[ems__Task]]"`                                       | Legacy (warn) |
+| B    | `"[[1b20a8f0-d745-4e93-91db-4531b3df120e\|ems__Task]]"` | Legacy (warn) |
+| C    | `"[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"`            | **Canonical** |
+
+**Why Form C:**
+
+1. **Symbolic stability** — UUID is immutable; renaming the class file (label change) never breaks the wikilink.
+2. **Storage consistency** — every class asset is already stored under its UUID filename (`<UUID>.md`); Form C navigates directly to the canonical file with no shim required.
+3. **Zero RDF semantic difference** — `NoteToRDFConverter.valueToClassURI` resolves all three forms to the same namespace IRI via `Namespace.fromPropertyKey`; file existence is _not_ consulted for class wikilinks. Empirically confirmed in the 2026-05-16 SHACL deep-dive (n=305 files migrated A → C, total SHACL violations 307 → 307).
+4. **No shim files needed** — Form A requires a label-named `<ClassName>.md` shim alongside the UUID-named original for Obsidian navigation; Form C avoids that duplication entirely.
+
+**Enforcement:**
+
+- Pre-write hook `~/.claude/hooks/validate-wikilinks.sh` emits a `warn` (not block) when an asset write contains a non-Form-C `exo__Instance_class` entry. Pre-existing files are untouched; the warning fires only on new content.
+- The `/exocortex-asset` skill template emits Form C for all `exo__Instance_class` examples and references.
+
+**Multiple classes example**:
+
+```yaml
 exo__Instance_class:
-  - "[[ems__Task]]"
-  - "[[ims__Concept]]"
+  - "[[1b20a8f0-d745-4e93-91db-4531b3df120e]]" # ems__Task
+  - "[[08691c91-3d64-4f6c-a475-ec46daa1c1fb]]" # ims__Concept
 ```
 
 **Valid Asset Classes**:


### PR DESCRIPTION
Closes #3123.

## Summary

Documents **Form C — bare UUID** `[[<uuid>]]` as the canonical form for `exo__Instance_class` wikilink values in new assets.

Forms A (label-only `[[ems__Task]]`) and B (UUID+alias `[[uuid|ems__Task]]`) remain accepted by the converter — all three resolve to the same RDF namespace IRI via `Namespace.fromPropertyKey` — but new content must not emit them.

## Why Form C

- **Symbolic stability** — UUID is immutable across class renames.
- **Storage consistency** — class assets are already UUID-named files; Form C navigates directly to the canonical file.
- **No shim files needed** — Form A requires label-named `.md` shims for Obsidian navigation; Form C avoids that.
- **Empirically validated 2026-05-16:** n=305 files migrated A → C, SHACL violations 307 → 307 (zero semantic delta).

## Changes (this PR — repo only)

- `docs/PROPERTY_SCHEMA.md` § *exo__Instance_class* — new *Canonical form* subsection with the three accepted forms table, rationale, and enforcement note.
- `TROUBLESHOOTING.md` — new section *exo__Instance_class wikilink form mismatch — all forms RDF-equivalent* explaining why a bulk A→C rewrite produces zero SHACL violation delta (expected outcome, not a bug), so future AI agents don't waste cycles re-investigating.

## Out of scope (handled separately in `~/.claude/` dotfiles)

- `~/.claude/skills/exocortex-asset/SKILL.md` — templates updated to emit Form C for `exo__Instance_class` examples; *Important UIDs Reference* table extended with Form C column and lookup UUIDs (Project / Task / Meeting / Concept / Conspect / PermanentNote / ExoAssistantKnowledge / ProjectCharter / ProjectStatusRecord).
- `~/.claude/hooks/validate-wikilinks.sh` — warn-only check for non-Form-C `exo__Instance_class` entries in new writes (stderr message + exit 0, does **NOT** block; pre-existing files untouched). Smoke-tested on Form A (warns) and Form C (silent).

## Test plan

- [x] `bash -n` syntax check + smoke test of `validate-wikilinks.sh` warn-only path (Form A → warn + exit 0; Form C → silent + exit 0; blocking path for non-existent UUIDs preserved).
- [x] `npm run test:all` in worktree — 14 pre-existing CLI convert failures from issue #2832 (verified identical on stashed main HEAD; doc-only changes cannot cause them).
- [x] Pre-commit hooks (lint, archgate, BDD coverage) green.
- [ ] CI green (13 required checks).
- [ ] Auto-release publishes patch version after merge.

## Issue conversation answers

- **Q1** canonical form → C (bare UUID).
- **Q2** validation hook → warn-only (no block).
- **Q3** update `/exocortex-asset` skill → yes (done in dotfiles).
- **Q4** TROUBLESHOOTING equivalence note → yes (in this PR).