### PR TITLE
feat(cli): multi-vault SHACL validation via --also flag (#3127)

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -12,6 +12,7 @@ import {
   Triple,
   ShapeLoader,
   ShaclShapeRegistry,
+  type Shape,
   shaclValidate,
   DomainIRI,
   DomainLiteral,
@@ -78,11 +79,136 @@ export type ShapesFormat = "text" | "json" | "earl";
 
 export interface ValidateSchemaOptions {
   vault: string;
+  also?: string[];
   output?: OutputFormat;
   staged?: boolean;
   useCache?: boolean;
   shapesMode?: boolean;
   format?: ShapesFormat;
+}
+
+/**
+ * Commander.js accumulator for repeatable --also flag.
+ * Each --also <path> adds a vault path to the array.
+ */
+function collectAlso(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}
+
+/**
+ * Loads triples from the primary vault plus any additional --also vaults
+ * and concatenates them into a single array (last-write-wins on duplicate
+ * subjects, matching `exoql query --also` semantics).
+ *
+ * If `--use-cache` and `--also` are combined, the cache is disabled and a
+ * warning is logged: the per-vault triple cache cannot represent merged
+ * multi-vault state.
+ */
+async function loadTriplesFromAllVaults(
+  vaultPath: string,
+  alsoPaths: string[],
+  useCache: boolean,
+  verbose: boolean,
+): Promise<{ triples: DomainTriple[]; cacheHit: boolean }> {
+  if (useCache && alsoPaths.length > 0) {
+    if (verbose) {
+      console.log("⚠️  --use-cache is disabled when --also is specified (per-vault cache cannot represent multi-vault state).");
+    }
+    useCache = false;
+  }
+
+  let triples: DomainTriple[];
+  let cacheHit = false;
+  if (useCache) {
+    const cacheManager = new CacheManager(vaultPath);
+    const cacheResult = await cacheManager.loadOrBuild();
+    triples = cacheResult.triples as DomainTriple[];
+    cacheHit = cacheResult.cacheHit;
+  } else {
+    const adapter = new FileSystemVaultAdapter(vaultPath);
+    const converter = new NoteToRDFConverter(adapter);
+    triples = (await converter.convertVault()) as DomainTriple[];
+  }
+
+  for (const alsoPath of alsoPaths) {
+    const resolvedAlsoPath = resolve(alsoPath);
+    if (!existsSync(resolvedAlsoPath)) {
+      throw new VaultNotFoundError(resolvedAlsoPath);
+    }
+    if (verbose) {
+      console.log(`📦 Loading additional vault: ${resolvedAlsoPath}...`);
+    }
+    const alsoAdapter = new FileSystemVaultAdapter(resolvedAlsoPath);
+    const alsoConverter = new NoteToRDFConverter(alsoAdapter);
+    const alsoTriples = (await alsoConverter.convertVault()) as DomainTriple[];
+    triples = triples.concat(alsoTriples);
+    if (verbose) {
+      console.log(`   ➕ Added ${alsoTriples.length} triples from ${resolvedAlsoPath}`);
+    }
+  }
+
+  return { triples, cacheHit };
+}
+
+/**
+ * Loads shape files from the primary vault plus all --also vaults and
+ * merges them into one ShaclShapeRegistry. First-wins on duplicate
+ * propertyIRI; conflicts are warned to stderr.
+ */
+async function loadMergedShapeRegistry(
+  vaultPath: string,
+  alsoPaths: string[],
+  verbose: boolean,
+): Promise<ShaclShapeRegistry> {
+  const seen = new Map<string, string>(); // propertyIRI → vault path that registered it
+  const merged: Shape[] = [];
+
+  const ingest = async (path: string): Promise<void> => {
+    const reg = await ShapeLoader.loadFromVaultFS(path);
+    for (const shape of reg.getAll()) {
+      const owner = seen.get(shape.propertyIRI);
+      if (owner !== undefined) {
+        if (verbose) {
+          console.log(`⚠️  Duplicate shape for ${shape.propertyIRI} in ${path} (first-wins: kept from ${owner})`);
+        }
+        continue;
+      }
+      seen.set(shape.propertyIRI, path);
+      merged.push(shape);
+    }
+  };
+
+  await ingest(vaultPath);
+  for (const alsoPath of alsoPaths) {
+    await ingest(resolve(alsoPath));
+  }
+
+  return new ShaclShapeRegistry(merged);
+}
+
+/**
+ * Resolves a focusNode IRI (obsidian://vault/<relPath>) to the absolute
+ * filesystem path inside one of the vault roots. Returns the first vault
+ * root whose <root>/<relPath> exists; falls back to primary vault otherwise.
+ */
+export function qualifyFocusNodePath(
+  focusNode: string,
+  vaultPaths: string[],
+): string {
+  const prefix = "obsidian://vault/";
+  let relPath = focusNode;
+  if (focusNode.startsWith(prefix)) {
+    relPath = decodeURIComponent(focusNode.substring(prefix.length));
+  } else {
+    return focusNode;
+  }
+  for (const root of vaultPaths) {
+    const candidate = join(root, relPath);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return join(vaultPaths[0] ?? "", relPath);
 }
 
 export interface SchemaViolation {
@@ -666,14 +792,20 @@ export function applyLegacyExceptionFilter(
 
 /**
  * Runs SHACL-lite shapes validation against vault triples.
+ *
+ * When `alsoPaths` is supplied, shape definitions are loaded from each path
+ * in addition to the primary vault and merged into a single registry
+ * (first-wins on duplicate propertyIRI). Caller is responsible for merging
+ * triples from --also vaults into `triples` before calling.
  */
 export async function runShapesValidation(
   vaultPath: string,
   triples: DomainTriple[],
+  alsoPaths: string[] = [],
 ): Promise<ValidationReport> {
-  const standaloneRegistry = await ShapeLoader.loadFromVaultFS(vaultPath);
-  const shapes = standaloneRegistry.getAll();
-  const registry = new ShaclShapeRegistry(shapes);
+  const registry = alsoPaths.length > 0
+    ? await loadMergedShapeRegistry(vaultPath, alsoPaths, false)
+    : new ShaclShapeRegistry((await ShapeLoader.loadFromVaultFS(vaultPath)).getAll());
   const hierarchy = new TripleClassHierarchy(triples);
   const algebraTriples = domainToAlgebraTriples(triples);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -689,22 +821,21 @@ async function runShapesModeAction(options: ValidateSchemaOptions): Promise<void
       throw new VaultNotFoundError(vaultPath);
     }
 
+    const alsoPaths = options.also ?? [];
+    const allVaultRoots = [vaultPath, ...alsoPaths.map((p) => resolve(p))];
+
     if (fmt === "text") {
       console.log(`📦 Loading vault (shapes-mode): ${vaultPath}...`);
     }
 
-    let triples: DomainTriple[];
-    if (options.useCache) {
-      const cacheManager = new CacheManager(vaultPath);
-      const cacheResult = await cacheManager.loadOrBuild();
-      triples = cacheResult.triples as DomainTriple[];
-      if (fmt === "text" && cacheResult.cacheHit) {
-        console.log("🚀 Cache hit! Loading from persistent cache...");
-      }
-    } else {
-      const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
-      const converter = new NoteToRDFConverter(vaultAdapter);
-      triples = await converter.convertVault() as DomainTriple[];
+    const { triples, cacheHit } = await loadTriplesFromAllVaults(
+      vaultPath,
+      alsoPaths,
+      Boolean(options.useCache),
+      fmt === "text",
+    );
+    if (fmt === "text" && cacheHit) {
+      console.log("🚀 Cache hit! Loading from persistent cache...");
     }
 
     if (fmt === "text") {
@@ -712,18 +843,26 @@ async function runShapesModeAction(options: ValidateSchemaOptions): Promise<void
       console.log(`🔍 Running SHACL-lite validation...`);
     }
 
-    const rawReport = await runShapesValidation(vaultPath, triples);
+    const rawReport = await runShapesValidation(vaultPath, triples, alsoPaths);
     const report = applyLegacyExceptionFilter(triples, rawReport);
+
+    const qualifyNode = (focusNode: string): string =>
+      allVaultRoots.length > 1 ? qualifyFocusNodePath(focusNode, allVaultRoots) : focusNode;
 
     if (fmt === "earl") {
       const earl = buildEARLReport(vaultPath, report);
       console.log(JSON.stringify(earl, null, 2));
     } else if (fmt === "json") {
+      const annotated = report.violations.map((v) => ({
+        ...v,
+        vaultQualifiedPath: qualifyNode(v.focusNode),
+      }));
       const response = ResponseBuilder.success({
         vaultPath,
+        alsoPaths: alsoPaths.map((p) => resolve(p)),
         conforms: report.conforms,
         violationCount: report.violations.length,
-        violations: report.violations,
+        violations: annotated,
       });
       console.log(JSON.stringify(response, null, 2));
     } else {
@@ -738,7 +877,8 @@ async function runShapesModeAction(options: ValidateSchemaOptions): Promise<void
         }
         console.log(`⚠️  Found ${report.violations.length} SHACL violation(s) in ${byNode.size} node(s):\n`);
         for (const [node, violations] of byNode) {
-          console.log(`   ❌ ${node}`);
+          const label = allVaultRoots.length > 1 ? qualifyNode(node) : node;
+          console.log(`   ❌ ${label}`);
           for (const v of violations) {
             const sev = v.severity.replace("sh:", "");
             console.log(`      [${sev}] ${v.message}`);
@@ -765,9 +905,10 @@ export function validateSchemaCommand(): Command {
   return new Command("schema")
     .description("Check frontmatter properties against ontology (Issue #2713)")
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--also <path>", "Additional vault to merge into validation graph (repeatable). --use-cache is disabled when --also is present.", collectAlso, [])
     .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
     .option("--staged", "Only validate git-staged .md files (for pre-commit hooks)")
-    .option("--use-cache", "Use persistent triple cache (faster vault loading)")
+    .option("--use-cache", "Use persistent triple cache (faster vault loading; disabled when --also is set)")
     .option("--shapes-mode", "Run SHACL-lite shapes validation instead of schema linting")
     .option("--format <type>", "Output format for shapes-mode: text|json|earl", "text")
     .action(async (options: ValidateSchemaOptions) => {
@@ -807,23 +948,21 @@ export function validateSchemaCommand(): Command {
           targetFiles = collectMdFiles(vaultPath);
         }
 
-        // 2. Load vault into triple store
+        // 2. Load vault (+ --also vaults) into triple store
         if (outputFormat === "text") {
           console.log(`📦 Loading vault: ${vaultPath}...`);
         }
 
-        let triples: Triple[];
-        if (options.useCache) {
-          const cacheManager = new CacheManager(vaultPath);
-          const cacheResult = await cacheManager.loadOrBuild();
-          triples = cacheResult.triples;
-          if (outputFormat === "text" && cacheResult.cacheHit) {
-            console.log("🚀 Cache hit! Loading from persistent cache...");
-          }
-        } else {
-          const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
-          const converter = new NoteToRDFConverter(vaultAdapter);
-          triples = await converter.convertVault();
+        const alsoPaths = options.also ?? [];
+        const { triples: loadedTriples, cacheHit } = await loadTriplesFromAllVaults(
+          vaultPath,
+          alsoPaths,
+          Boolean(options.useCache),
+          outputFormat === "text",
+        );
+        const triples: Triple[] = loadedTriples as Triple[];
+        if (outputFormat === "text" && cacheHit) {
+          console.log("🚀 Cache hit! Loading from persistent cache...");
         }
 
         if (outputFormat === "text") {

--- a/packages/cli/tests/integration/validate-schema-shapes-multivault.integration.test.ts
+++ b/packages/cli/tests/integration/validate-schema-shapes-multivault.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Issue #3127 — CLI integration test: validate schema --shapes-mode --also <path>
+ *
+ * Two-vault scenario:
+ *   vaultA/ → contains the ems__Task_count Property shape (range = xsd:integer)
+ *   vaultB/ → contains an instance with ems__Task_count = "not-an-integer"
+ *
+ * Without --also vaultA:
+ *   ShapeLoader sees no shape for ems__Task_count → no violation reported
+ *   (shape is invisible to the single-vault load).
+ *
+ * With --also vaultA:
+ *   Merged registry includes the shape → sh:datatype violation surfaces.
+ *
+ * This is the regression test for the false-negative case: shapes that
+ * live in a separate vault must be loadable into the validation graph.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { runShapesValidation, qualifyFocusNodePath } = await import(
+  "../../src/commands/validate-schema.js"
+);
+const { NoteToRDFConverter } = await import("exocortex");
+const { FileSystemVaultAdapter } = await import(
+  "../../src/adapters/FileSystemVaultAdapter.js"
+);
+
+let tmpRoot: string;
+let vaultA: string;
+let vaultB: string;
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "exocortex-multivault-"));
+  vaultA = path.join(tmpRoot, "vaultA");
+  vaultB = path.join(tmpRoot, "vaultB");
+  fs.mkdirSync(path.join(vaultA, "shapes"), { recursive: true });
+  fs.mkdirSync(path.join(vaultB, "data"), { recursive: true });
+
+  // Shape lives in vaultA
+  fs.writeFileSync(
+    path.join(vaultA, "shapes", "ems__Task_count.md"),
+    `---
+exo__Asset_isDefinedBy: "[[!ems]]"
+exo__Asset_uid: aaaa1111-1111-1111-1111-aaaaaaaaaaaa
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[exo__Property]]"
+exo__Asset_label: ems__Task_count
+exo__Property_domain:
+  - "[[ems__Task]]"
+exo__Property_range: "http://www.w3.org/2001/XMLSchema#integer"
+exo__Property_severity: sh:Violation
+aliases:
+  - ems__Task_count
+---
+Shape def in vaultA.
+`,
+  );
+
+  // Violating instance lives in vaultB
+  fs.writeFileSync(
+    path.join(vaultB, "data", "asset-violating.md"),
+    `---
+exo__Asset_isDefinedBy: "[[!test]]"
+exo__Asset_uid: bbbb2222-2222-2222-2222-bbbbbbbbbbbb
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: Asset Violating
+ems__Task_count: "not-an-integer"
+aliases:
+  - asset-violating
+---
+Bad integer in vaultB.
+`,
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+async function loadTriples(...vaults: string[]): Promise<unknown[]> {
+  const all: unknown[] = [];
+  for (const v of vaults) {
+    const adapter = new FileSystemVaultAdapter(v);
+    const converter = new NoteToRDFConverter(adapter);
+    const triples = await converter.convertVault();
+    for (const t of triples) all.push(t);
+  }
+  return all;
+}
+
+describe("BDD: validate schema --shapes-mode --also (Issue #3127)", () => {
+  it("Scenario: single-vault validation of vaultB alone — shape from vaultA is INVISIBLE", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const triples = (await loadTriples(vaultB)) as any[];
+    const report = await runShapesValidation(vaultB, triples);
+    // Without the shape from vaultA, no sh:datatype check is performed on ems__Task_count
+    const datatypeViolations = report.violations.filter((v) =>
+      v.message.includes("sh:datatype"),
+    );
+    expect(datatypeViolations.length).toBe(0);
+  });
+
+  it("Scenario: multi-vault validation with --also vaultA — shape is loaded and violation surfaces", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const triples = (await loadTriples(vaultB, vaultA)) as any[];
+    const report = await runShapesValidation(vaultB, triples, [vaultA]);
+    const datatypeViolations = report.violations.filter((v) =>
+      v.message.includes("sh:datatype"),
+    );
+    expect(datatypeViolations.length).toBeGreaterThan(0);
+    const v = datatypeViolations[0];
+    expect(v.focusNode).toContain("asset-violating");
+    expect(v.propertyPath).toContain("Task_count");
+  });
+
+  it("Scenario: qualifyFocusNodePath resolves focusNode to the vault root that owns the file", () => {
+    const focusNode = "obsidian://vault/data/asset-violating.md";
+    const resolved = qualifyFocusNodePath(focusNode, [vaultA, vaultB]);
+    expect(resolved).toBe(path.join(vaultB, "data", "asset-violating.md"));
+  });
+
+  it("Scenario: qualifyFocusNodePath falls back to primary vault when file not found in any root", () => {
+    const focusNode = "obsidian://vault/missing/asset.md";
+    const resolved = qualifyFocusNodePath(focusNode, [vaultA, vaultB]);
+    expect(resolved).toBe(path.join(vaultA, "missing", "asset.md"));
+  });
+});

--- a/packages/cli/tests/unit/commands/validate-schema.test.ts
+++ b/packages/cli/tests/unit/commands/validate-schema.test.ts
@@ -113,9 +113,15 @@ describe("Issue #2713: validate schema command", () => {
       expect(option).toBeDefined();
     });
 
-    it("should register exactly 6 options", () => {
+    it("should register exactly 7 options (incl. --also for multi-vault SHACL — Issue #3127)", () => {
       const cmd = validateSchemaCommand();
-      expect(cmd.options).toHaveLength(6);
+      expect(cmd.options).toHaveLength(7);
+    });
+
+    it("should register --also option (Issue #3127 — repeatable additional vaults)", () => {
+      const cmd = validateSchemaCommand();
+      const option = cmd.options.find((o: any) => o.long === "--also");
+      expect(option).toBeDefined();
     });
 
     it("should register --shapes-mode option", () => {


### PR DESCRIPTION
## Summary

Closes #3127.

- Adds repeatable `--also <path>` to `exocortex validate schema` for both `--shapes-mode` and schema-linting paths. Triples from `--vault` + each `--also` are merged into one graph before validation, so class and property declarations living in a separate vault resolve correctly (no more false-positive "unknown class" / "property not declared" violations).
- Mirrors the proven pattern from `exoql query --also`. Shapes from `--also` vaults are loaded and merged into the SHACL registry with first-wins on duplicate `propertyIRI` (warned).
- `--use-cache` is auto-disabled when `--also` is present (per-vault triple cache cannot represent merged state) with a stderr warning. Documented in `--help`.
- JSON output adds `vaultQualifiedPath` per violation; text output prepends the resolved absolute path when multiple vaults are loaded. `qualifyFocusNodePath` resolves the `obsidian://vault/<relPath>` focusNode against the actual filesystem path that owns the file.

## Test plan

- [x] New integration test `validate-schema-shapes-multivault.integration.test.ts` — 2-vault fixture (shape in vault A, instance in vault B): without `--also` no violation surfaces; with `--also` violation surfaces with correct `focusNode` + `propertyPath`.
- [x] `qualifyFocusNodePath` unit coverage for both resolved-in-vault and fallback-to-primary branches.
- [x] Existing `validate-schema.test.ts` updated (option count 6 → 7, plus explicit `--also` registration assertion).
- [x] All 85 tests in the `validate-schema*` test files pass locally.

## Acceptance criteria (from #3127)

- [x] `--vault A --also B` merges triples before SHACL run
- [x] Cross-vault class IRIs resolve (no false positive `sh:class` violations)
- [x] Cross-vault property declarations seen by `loadDeclaredProperties` (linting path also gets `--also` merging)
- [x] Violation report path qualified — JSON emits `vaultQualifiedPath`; text prepends resolved path in multi-vault mode
- [x] `--also` is repeatable (commander accumulator copied from `sparql-query`)
- [x] Shape files in any `--also` path loaded and merged (first-wins + warn on dup)
- [x] Empirical regression test: 2-vault fixture asserts the fix
- [x] `validate schema --help` documents `--also`
- [x] `--use-cache` interaction documented — auto-disabled with warning when `--also` is set