### PR TITLE
feat(cli): add top-level `query` and `index` commands (RFC 8e83442b T1.7/T1.8)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -56,6 +56,11 @@ export function createProgram(version?: string): Command {
 
   addQuerySubcommands(exoqlCommand);
 
+  // RFC 8e83442b (CLI v16) T1.7/T1.8: top-level aliases for query and index
+  // (exoql namespace is scheduled for removal in T2.5, this is the replacement surface)
+  program.addCommand(sparqlQueryCommand());
+  program.addCommand(sparqlIndexCommand());
+
   // Deprecated alias: sparql → exoql (prints deprecation warning)
   const sparqlCommand = program
     .command("sparql")

--- a/packages/cli/tests/unit/commands/cli-v16-top-level-query-index.test.ts
+++ b/packages/cli/tests/unit/commands/cli-v16-top-level-query-index.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "@jest/globals";
+import { Command } from "commander";
+
+/**
+ * RFC 8e83442b CLI v16.0 — T1.7/T1.8: top-level `query` and `index` commands
+ * registered alongside the existing `exoql` namespace.
+ *
+ * Like exoql-alias.test.ts, this replicates the structural registration
+ * pattern locally to avoid pulling in heavy ESM deps (ora, etc.) through
+ * src/index.ts. Validates the command surface contract documented in the
+ * RFC — both top-level aliases coexist with the `exoql` namespace until
+ * T2.5 removes it.
+ */
+describe("CLI v16 — top-level query/index commands", () => {
+  function makeDummyQuery(): Command {
+    return new Command("query").description("ExoQL query — dummy").action(() => {});
+  }
+  function makeDummyIndex(): Command {
+    return new Command("index").description("ExoQL index — dummy").action(() => {});
+  }
+
+  function buildProgram(): Command {
+    const program = new Command();
+    program.name("exocortex");
+
+    const exoql = program.command("exoql").description("ExoQL query execution and cache management");
+    exoql.addCommand(makeDummyQuery());
+    exoql.addCommand(makeDummyIndex());
+
+    // T1.7 / T1.8 additive top-level aliases
+    program.addCommand(makeDummyQuery());
+    program.addCommand(makeDummyIndex());
+
+    return program;
+  }
+
+  it("registers 'query' as a top-level command", () => {
+    const names = buildProgram().commands.map((c) => c.name());
+    expect(names).toContain("query");
+  });
+
+  it("registers 'index' as a top-level command", () => {
+    const names = buildProgram().commands.map((c) => c.name());
+    expect(names).toContain("index");
+  });
+
+  it("keeps the 'exoql' namespace alongside the new top-level commands", () => {
+    const program = buildProgram();
+    const names = program.commands.map((c) => c.name());
+    expect(names).toContain("exoql");
+
+    const exoql = program.commands.find((c) => c.name() === "exoql")!;
+    const subs = exoql.commands.map((c) => c.name());
+    expect(subs).toContain("query");
+    expect(subs).toContain("index");
+  });
+
+  it("top-level 'query' is structurally distinct from 'exoql query' (independent Command instance)", () => {
+    const program = buildProgram();
+    const topQuery = program.commands.find((c) => c.name() === "query")!;
+    const exoql = program.commands.find((c) => c.name() === "exoql")!;
+    const exoqlQuery = exoql.commands.find((c) => c.name() === "query")!;
+    expect(topQuery).not.toBe(exoqlQuery);
+    expect(topQuery.description()).toBe(exoqlQuery.description());
+  });
+
+  it("top-level 'index' is structurally distinct from 'exoql index'", () => {
+    const program = buildProgram();
+    const topIndex = program.commands.find((c) => c.name() === "index")!;
+    const exoql = program.commands.find((c) => c.name() === "exoql")!;
+    const exoqlIndex = exoql.commands.find((c) => c.name() === "index")!;
+    expect(topIndex).not.toBe(exoqlIndex);
+    expect(topIndex.description()).toBe(exoqlIndex.description());
+  });
+});


### PR DESCRIPTION
## Summary

RFC `8e83442b` (CLI v16.0) introduces top-level semantic verbs. T1.7 / T1.8
add `exocortex query` and `exocortex index` as additive aliases for the
existing `exoql query` / `exoql index` subcommands. The `exoql` namespace
remains in place until T2.5 removes it as part of the v16.0 cleanup phase.

- `packages/cli/src/index.ts` — register `sparqlQueryCommand()` and
  `sparqlIndexCommand()` as top-level commands. Both factories return
  fresh `Command` instances, so this does not interfere with their
  existing exoql-namespace registration.
- `packages/cli/tests/unit/commands/cli-v16-top-level-query-index.test.ts`
  — pin the new surface: query/index live both at top level and under
  exoql, the two instances are structurally distinct.

Pure additive surface change — no existing behavior is modified.

## Why

- T0.1 regression sweep (`exocortex (batch|batch-repair|dyncommand|exoql|convert)`)
  came back clean for `exoql` in private targets and in `.github/workflows/`,
  README, AGENTS.md, exocortex-public-ontologies — only doc/cli reference
  pages mention the old surface, and those are scoped to T3.1.
- This unblocks the rest of Phase 1a (find / apply UUID-only / validate
  --class) which share the additive top-level surface assumption.

## Refs

- RFC: `[[8e83442b-700c-4da4-86a2-d7edc7378b05]]`
- Onto-RFC TBox track (parallel, already merged into shared submodules):
  M1.1–M1.4 — `find__Alias`, `find__Alias_sparql`,
  `exocmd__Command_cliName`, `exocmd__Command_destructive`.

## Test plan

- [x] `npx jest tests/unit/commands/cli-v16-top-level-query-index.test.ts` — 5/5 pass locally.
- [x] Root `tsc -noEmit -skipLibCheck` clean.
- [x] Pre-commit lint-staged + BDD coverage + Archgate all green.
- [ ] CI (13 required checks) green on this PR.