### PR TITLE
feat(cli): find --class alias discovery (T1.10 / RFC 8e83442b Phase 1b)

### DIFF
--- a/packages/cli/src/commands/find.ts
+++ b/packages/cli/src/commands/find.ts
@@ -25,6 +25,7 @@ export interface FindOptions {
   vault: string;
   also?: string[];
   sparql?: string;
+  class?: string;
 }
 
 /**
@@ -32,6 +33,83 @@ export interface FindOptions {
  */
 function collectAlso(value: string, previous: string[]): string[] {
   return previous.concat([value]);
+}
+
+const FIND_ALIAS_SPARQL_PRED = "https://exocortex.my/ontology/find#Alias_sparql";
+const EXO_ASSET_LABEL_PRED = "https://exocortex.my/ontology/exo#Asset_label";
+
+function nodeValue(node: unknown): string {
+  if (node && typeof node === "object" && "value" in (node as Record<string, unknown>)) {
+    const v = (node as { value: unknown }).value;
+    return typeof v === "string" ? v : String(v);
+  }
+  return String(node);
+}
+
+/**
+ * Look up the SPARQL WHERE-fragment of a find__Alias by its exo:Asset_label.
+ *
+ * Each find__Alias instance carries:
+ *   - exo:Asset_label "<label>"        — the human-readable alias name (`class`, `folder`, ...)
+ *   - find:Alias_sparql "<fragment>"   — WHERE-fragment that binds ?path and consumes ?value
+ *
+ * Returns the fragment string, or null if no alias with that label is found.
+ * Throws if multiple aliases share the same label (ambiguous).
+ */
+async function resolveAliasFragment(
+  tripleStore: InMemoryTripleStore,
+  aliasLabel: string,
+): Promise<string | null> {
+  const labelTriples = await tripleStore.match(undefined, undefined, undefined);
+  const aliasSubjectsByLabel: string[] = [];
+  for (const t of labelTriples) {
+    const pred = nodeValue(t.predicate);
+    if (pred !== EXO_ASSET_LABEL_PRED) continue;
+    const obj = nodeValue(t.object);
+    if (obj !== aliasLabel) continue;
+    aliasSubjectsByLabel.push(nodeValue(t.subject));
+  }
+  if (aliasSubjectsByLabel.length === 0) return null;
+
+  const fragments: string[] = [];
+  for (const subj of aliasSubjectsByLabel) {
+    for (const t of labelTriples) {
+      const pred = nodeValue(t.predicate);
+      if (pred !== FIND_ALIAS_SPARQL_PRED) continue;
+      if (nodeValue(t.subject) !== subj) continue;
+      fragments.push(nodeValue(t.object));
+    }
+  }
+  if (fragments.length === 0) return null;
+  if (fragments.length > 1) {
+    throw new InvalidArgumentsError(
+      `Ambiguous find__Alias "${aliasLabel}" — ${fragments.length} instances define a sparql fragment`,
+      `Ensure exactly one find__Alias asset has exo:Asset_label "${aliasLabel}"`,
+    );
+  }
+  return fragments[0];
+}
+
+const SLUG_RE = /^([a-z][a-zA-Z0-9]*)__([A-Za-z0-9_]+)$/;
+const ONTOLOGY_BASE = "https://exocortex.my/ontology/";
+
+/**
+ * Substitute occurrences of the SPARQL variable `?value` in a fragment.
+ *
+ * If `value` matches the Exocortex slug pattern `<prefix>__<LocalName>`
+ * (e.g. `ems__Task`, `inbox__Role`), substitute as a full IRI in angle
+ * brackets — `<https://exocortex.my/ontology/ems#Task>`. Otherwise substitute
+ * as an RDF literal in double quotes. Word-boundary aware to avoid clobbering
+ * `?valueX`.
+ */
+function bindValueLiteral(fragment: string, value: string): string {
+  const slugMatch = SLUG_RE.exec(value);
+  if (slugMatch) {
+    const iri = `<${ONTOLOGY_BASE}${slugMatch[1]}#${slugMatch[2]}>`;
+    return fragment.replace(/\?value\b/g, iri);
+  }
+  const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return fragment.replace(/\?value\b/g, `"${escaped}"`);
 }
 
 /**
@@ -47,14 +125,24 @@ export function findCommand(): Command {
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
     .option("--also <path>", "Additional vault to include (repeatable)", collectAlso, [])
     .option("--sparql <query>", "SPARQL SELECT query (must bind ?path)")
+    .option(
+      "--class <value>",
+      "Filter by class label via find__Alias 'class' (e.g. ems__Task)",
+    )
     .action(async (options: FindOptions) => {
       ErrorHandler.setFormat("text" as OutputFormat);
 
       try {
-        if (!options.sparql) {
+        if (options.sparql && options.class) {
           throw new InvalidArgumentsError(
-            "--sparql <query> is required",
-            'exocortex find --sparql "SELECT ?path WHERE { ?path a <https://exocortex.my/ontology/ems#Task> }"',
+            "--sparql and --class are mutually exclusive",
+            "Pass either a raw --sparql query or a find__Alias-backed flag like --class",
+          );
+        }
+        if (!options.sparql && !options.class) {
+          throw new InvalidArgumentsError(
+            "one of --sparql <query> or --class <value> is required",
+            'exocortex find --class ems__Task   OR   exocortex find --sparql "SELECT ?path WHERE { ... }"',
           );
         }
 
@@ -82,7 +170,22 @@ export function findCommand(): Command {
         const tripleStore = new InMemoryTripleStore();
         await tripleStore.addAll(triples);
 
-        let queryString = transformShorthandNotation(options.sparql);
+        let rawQuery: string;
+        if (options.class) {
+          const fragment = await resolveAliasFragment(tripleStore, "class");
+          if (fragment === null) {
+            throw new InvalidArgumentsError(
+              'No find__Alias with exo:Asset_label "class" was found in the vault',
+              "Seed a find__Alias asset (label=class) or fall back to exocortex find --sparql",
+            );
+          }
+          const bound = bindValueLiteral(fragment, options.class);
+          rawQuery = `SELECT ?path WHERE { ${bound} }`;
+        } else {
+          rawQuery = options.sparql!;
+        }
+
+        let queryString = transformShorthandNotation(rawQuery);
         queryString = injectExocortexPrefixes(queryString);
 
         const parser = new ExoQLParser();

--- a/packages/cli/tests/fixtures/find-class-alias/aaaaaaaa-0000-0000-0000-000000000001.md
+++ b/packages/cli/tests/fixtures/find-class-alias/aaaaaaaa-0000-0000-0000-000000000001.md
@@ -1,0 +1,9 @@
+---
+exo__Asset_isDefinedBy: "[[!find]]"
+exo__Asset_uid: aaaaaaaa-0000-0000-0000-000000000001
+exo__Asset_createdAt: 2026-05-16T22:30:00+0500
+exo__Asset_label: "class"
+exo__Instance_class:
+  - "[[6b98cd5e-485b-4d53-b54e-402eb8f06fca|find__Alias]]"
+find__Alias_sparql: "?path <https://exocortex.my/ontology/exo#Instance_class> ?value"
+---

--- a/packages/cli/tests/fixtures/find-class-alias/bbbbbbbb-0000-0000-0000-000000000001.md
+++ b/packages/cli/tests/fixtures/find-class-alias/bbbbbbbb-0000-0000-0000-000000000001.md
@@ -1,0 +1,8 @@
+---
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Asset_uid: bbbbbbbb-0000-0000-0000-000000000001
+exo__Asset_createdAt: 2026-05-16T22:31:00+0500
+exo__Asset_label: "Sample task"
+exo__Instance_class:
+  - "[[ems__Task]]"
+---

--- a/packages/cli/tests/fixtures/find-class-alias/ems__Task.md
+++ b/packages/cli/tests/fixtures/find-class-alias/ems__Task.md
@@ -1,0 +1,7 @@
+---
+exo__Asset_isDefinedBy: "[[!ems]]"
+exo__Asset_uid: 1b20a8f0-d745-4e93-91db-4531b3df120e
+exo__Asset_label: "ems__Task"
+exo__Instance_class:
+  - "[[exo__Class]]"
+---

--- a/packages/cli/tests/integration/find-class-alias.integration.test.ts
+++ b/packages/cli/tests/integration/find-class-alias.integration.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Integration test for `exocortex find --class <value>` (RFC 8e83442b T1.10 / onto-RFC 245b8493).
+ *
+ * Mocks a tiny vault containing:
+ *   - a `find__Alias` instance with exo:Asset_label "class" and a sparql fragment
+ *     that resolves `?path` via `exo:Instance_class` → target class label
+ *   - the `ems__Task` class asset (exo:Asset_label "ems__Task")
+ *   - a task instance pointing at that class
+ *
+ * Verifies that running the find command with `--class ems__Task` produces
+ * the task instance's vault-relative path on stdout.
+ */
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import { findCommand } from "../../src/commands/find.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_VAULT = resolve(__dirname, "../fixtures/find-class-alias");
+
+describe("CLI v16 — find --class (T1.10, alias-driven)", () => {
+  let stdoutSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+  let captured: string;
+  let capturedErr: string;
+  let exitSpy: jest.SpiedFunction<typeof process.exit>;
+
+  beforeEach(() => {
+    captured = "";
+    capturedErr = "";
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        captured += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+        return true;
+      });
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        capturedErr +=
+          typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+        return true;
+      });
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("resolves --class via find__Alias and emits the matching path", async () => {
+    const cmd = findCommand();
+    await cmd.parseAsync(
+      ["--vault", FIXTURE_VAULT, "--class", "ems__Task"],
+      { from: "user" },
+    );
+
+    if (capturedErr.includes("Error")) {
+      throw new Error(`find command emitted error: ${capturedErr}`);
+    }
+    const lines = captured.split("\n").filter((l) => l.length > 0);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(
+      lines.some((l) => l.includes("bbbbbbbb-0000-0000-0000-000000000001")),
+    ).toBe(true);
+  }, 30_000);
+
+  it("declares the --class option", () => {
+    const cmd = findCommand();
+    const opts = cmd.options.map((o) => o.long);
+    expect(opts).toContain("--class");
+  });
+});


### PR DESCRIPTION
## Summary

CLI v16 Phase 1b — wires up the `find --class <X>` alias-driven selector on top of the `find__Alias` ABox shipped by onto-RFC 245b8493 (M1.1 / M1.2).

- New `--class <value>` option on `exocortex find`, mutually exclusive with `--sparql`
- Helper resolves the single `find__Alias` instance whose `exo:Asset_label` is `class`, reads `find:Alias_sparql`, substitutes `?value` (slug-form inputs like `ems__Task` bind as the full ontology IRI, everything else as RDF literal), wraps in `SELECT ?path WHERE { ... }`
- New integration test exercises a synthetic vault with one class alias + one task instance and asserts the matching vault-relative path lands on stdout
- Pairs with vault commits in `vault-2025/assetspaces/exo/` that seed the canonical `class`, `folder`, `status` aliases, and with `vault-2025/assetspaces/exocmd/` commits that backfill `exocmd__Command_cliName` + `exocmd__Command_destructive` on all 50 existing commands

## Test plan

- [x] `npm run test --workspace=@kitelev/exocortex-cli -- --testPathPatterns find` — 7 tests pass (5 unit + 2 integration)
- [x] `npm run build --workspace=@kitelev/exocortex-cli` — clean
- [x] Empirical: `node packages/cli/dist/index.js find --class ems__Task --vault <vault>` returns paths (no `unknown option`)

## Scope

In-scope (this PR):
- T1.10 implementation + test

Out-of-scope (companion vault commits, separate repos):
- find__Alias seed assets in `vault-2025/assetspaces/exo/`
- cliName/destructive backfill in `vault-2025/assetspaces/exocmd/`

Refs: RFC 8e83442b · onto-RFC 245b8493