### PR TITLE
feat(grounding): declarative property_append + $target.<prop> substitution (#3132)

### DIFF
--- a/docs/rfc-94e520da/T1.5-grounding-audit.md
+++ b/docs/rfc-94e520da/T1.5-grounding-audit.md
@@ -7,12 +7,12 @@
 
 ## TL;DR
 
-| Status                                       | Groundings |         % | Notes                                                                                                                                              |
-| -------------------------------------------- | ---------: | --------: | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Real CLI implementation                   |     **38** | **79.2%** | Mutate vault state through `IFileSystemAdapter` / shared services factories                                                                        |
-| 🔴 Fail-loud `CliServiceNotImplementedError` |      **3** |  **6.2%** | Stub: `createAsset` (Obsidian-specific path conventions, T1.6+)                                                                                    |
-| ⚠️ Unregistered service id                   |      **7** | **14.6%** | Plugin-only services not yet ported: `shiftDay`, `rollbackStatus`, `planOnToday`, `incrementVotes`, `createTaskForDailyNote`, `copyLabelToAliases` |
-| **Total**                                    |     **48** |  **100%** |                                                                                                                                                    |
+| Status                                       | Groundings |         % | Notes                                                                                                                                                                                                      |
+| -------------------------------------------- | ---------: | --------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ Real CLI implementation                   |     **39** | **81.3%** | Mutate vault state through `IFileSystemAdapter` / shared services factories. Includes `a85668fa-…` migrated to declarative `property_append` (Issue #3132)                                                 |
+| 🔴 Fail-loud `CliServiceNotImplementedError` |      **3** |  **6.2%** | Stub: `createAsset` (Obsidian-specific path conventions, T1.6+)                                                                                                                                            |
+| ⚠️ Unregistered service id                   |      **6** | **12.5%** | Plugin-only services not yet ported: `shiftDay`, `rollbackStatus`, `planOnToday`, `incrementVotes`, `createTaskForDailyNote` (`copyLabelToAliases` removed by Issue #3132 — migrated to `property_append`) |
+| **Total**                                    |     **48** |  **100%** |                                                                                                                                                                                                            |
 
 **Zero silent fake-succeed groundings remain** — all 10 needs-impl groundings now fail loudly when invoked via `dyncommand exec`. M1 (RFC § Метрики успеха) is met for the audit slice; M6 (48/48 green BDD) is gated on porting the 7 unregistered services + designing CLI semantics for `createAsset`.
 
@@ -20,13 +20,14 @@
 
 48 groundings split across 5 types:
 
-| Type              | Count | CLI status                                                                     |
-| ----------------- | ----: | ------------------------------------------------------------------------------ |
-| `property_set`    |    16 | ✅ Generic frontmatter handler in `GroundingExecutor.executeFrontmatterUpdate` |
-| `service_call`    |    25 | Mixed — see table below                                                        |
-| `property_delete` |     4 | ✅ Generic frontmatter handler                                                 |
-| `composite`       |     2 | ✅ Sequential dispatch to children (each child evaluated recursively)          |
-| `create_instance` |     1 | ✅ Generic handler (verified empirically in C.1.5)                             |
+| Type              | Count | CLI status                                                                         |
+| ----------------- | ----: | ---------------------------------------------------------------------------------- |
+| `property_set`    |    16 | ✅ Generic frontmatter handler in `GroundingExecutor.executeFrontmatterUpdate`     |
+| `service_call`    |    24 | Mixed — see table below (1 grounding migrated to `property_append` in Issue #3132) |
+| `property_delete` |     4 | ✅ Generic frontmatter handler                                                     |
+| `composite`       |     2 | ✅ Sequential dispatch to children (each child evaluated recursively)              |
+| `create_instance` |     1 | ✅ Generic handler (verified empirically in C.1.5)                                 |
+| `property_append` |     1 | ✅ Declarative handler (Issue #3132 — `$target.<prop>` substitution + Set dedup)   |
 
 The 23 non-`service_call` groundings (`property_set` + `property_delete` + `composite` + `create_instance`) are all served by ontology-driven generic handlers and require no per-grounding implementation. They contribute the bulk of the 79.2% real-impl share.
 
@@ -64,8 +65,8 @@ The 23 non-`service_call` groundings (`property_set` + `property_delete` + `comp
 | `rollbackStatus`         |          1 | Plugin `TaskStatusService.rollback`                                                      | Low — already partially in shared package via `taskStatusService` dep; just needs factory + registration |
 | `incrementVotes`         |          1 | Plugin command — counter bump on `ems__Effort_votes`                                     | Trivial — single property increment                                                                      |
 | `createTaskForDailyNote` |          1 | Plugin command on `period__DailyNote` host                                               | Low — mirrors `createRelatedTask` shape                                                                  |
-| `copyLabelToAliases`     |          1 | `CopyLabelToAliasesCommand.ts`                                                           | Trivial — read `exo__Asset_label`, push into `aliases` array                                             |
-| **Subtotal**             |      **7** | (6 unique service ids)                                                                   | All fit T1.6 / Phase 1 follow-up sprint                                                                  |
+| ~~`copyLabelToAliases`~~ |      ~~1~~ | Migrated to declarative `property_append` (Issue #3132 — `$target.exo__Asset_label`)     | ✅ Done                                                                                                  |
+| **Subtotal**             |      **6** | (5 unique service ids)                                                                   | All fit T1.6 / Phase 1 follow-up sprint                                                                  |
 
 None of these depend on Obsidian-specific APIs that lack `IFileSystemAdapter` analogs — every operation is frontmatter mutation against a target file resolved by IRI. They were left out of T1.2/T1.4 to keep the migration deltas small; T1.5 confirms the shape of the remaining work.
 
@@ -103,13 +104,14 @@ Full row-level inventory in `docs/rfc-94e520da/starter-kit-grounding-status.json
   "summary": {
     "totalGroundings": 48,
     "byType": {
-      "service_call": 25,
+      "service_call": 24,
       "property_set": 16,
       "property_delete": 4,
       "composite": 2,
-      "create_instance": 1
+      "create_instance": 1,
+      "property_append": 1
     },
-    "byCliStatus": { "real": 38, "stub": 3, "unregistered": 7 }
+    "byCliStatus": { "real": 39, "stub": 3, "unregistered": 6 }
   },
   "groundings": [
     /* 48 rows */

--- a/docs/rfc-94e520da/starter-kit-grounding-status.json
+++ b/docs/rfc-94e520da/starter-kit-grounding-status.json
@@ -8,14 +8,15 @@
     "totalGroundings": 48,
     "byType": {
       "property_delete": 4,
-      "service_call": 25,
+      "service_call": 24,
       "create_instance": 1,
       "property_set": 16,
-      "composite": 2
+      "composite": 2,
+      "property_append": 1
     },
     "byCliStatus": {
-      "real": 38,
-      "unregistered": 7,
+      "real": 39,
+      "unregistered": 6,
       "stub": 3
     },
     "serviceIdCounts": {
@@ -30,7 +31,6 @@
       "repairFolder": 1,
       "archiveAsset": 1,
       "rollbackStatus": 1,
-      "copyLabelToAliases": 1,
       "shiftDay": 2,
       "planOnToday": 1,
       "incrementVotes": 1,
@@ -218,9 +218,9 @@
       "uid": "a85668fa-17b7-45d0-aa7f-935e2502dff0",
       "label": "Copy label to aliases via service",
       "path": "exocmd/maintenance/a85668fa-17b7-45d0-aa7f-935e2502dff0.md",
-      "type": "service_call",
-      "serviceId": "copyLabelToAliases",
-      "cliStatus": "unregistered"
+      "type": "property_append",
+      "serviceId": null,
+      "cliStatus": "real"
     },
     {
       "uid": "c4616dcd-3832-4812-b289-0968510fb8be",

--- a/packages/cli/tests/unit/services/StarterKitGroundingAudit.test.ts
+++ b/packages/cli/tests/unit/services/StarterKitGroundingAudit.test.ts
@@ -63,17 +63,22 @@ describe("RFC 94e520da T1.5 starter-kit grounding audit fixture", () => {
   });
 
   it("matches the expected type/cliStatus distribution", () => {
+    // Issue #3132: grounding a85668fa-… migrated from service_call
+    // (copyLabelToAliases) to declarative property_append, reducing
+    // service_call count by 1, introducing property_append count = 1, and
+    // moving 1 grounding from unregistered to real.
     expect(fixture.summary.byType).toEqual({
-      service_call: 25,
+      service_call: 24,
       property_set: 16,
       property_delete: 4,
       composite: 2,
       create_instance: 1,
+      property_append: 1,
     });
     expect(fixture.summary.byCliStatus).toEqual({
-      real: 38,
+      real: 39,
       stub: 3,
-      unregistered: 7,
+      unregistered: 6,
     });
   });
 
@@ -108,7 +113,8 @@ describe("RFC 94e520da T1.5 starter-kit grounding audit fixture", () => {
       "rollbackStatus",
       "incrementVotes",
       "createTaskForDailyNote",
-      "copyLabelToAliases",
+      // copyLabelToAliases removed in Issue #3132 — grounding migrated to
+      // declarative property_append (no longer a service_call).
     ]);
 
     for (const g of fixture.groundings) {

--- a/packages/exocortex/src/domain/constants/GroundingType.ts
+++ b/packages/exocortex/src/domain/constants/GroundingType.ts
@@ -16,4 +16,14 @@ export enum GroundingType {
   SERVICE_CALL = "service_call",
   /** Create a new instance file from a prototype (RFC-016) */
   CREATE_INSTANCE = "create_instance",
+  /**
+   * Append a value to an array-typed frontmatter property with Set-based dedup.
+   * Reads `targetProperty` (array property) and `targetValue` (resolved via
+   * substituteVariables — supports `$target.<prop>` dotted-property access).
+   *
+   * Issue #3132 — Declarative replacement for `service_call` /
+   * `copyLabelToAliases` (Homoiconicity Invariant Q1: user-configurable
+   * semantics belong in RDF, not TypeScript).
+   */
+  PROPERTY_APPEND = "property_append",
 }

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -178,6 +178,14 @@ export class GroundingExecutor {
             userInput,
           );
 
+        case GroundingType.PROPERTY_APPEND:
+          return await this.executePropertyAppend(
+            grounding,
+            targetIRI,
+            targetFilePath,
+            userInput,
+          );
+
         case GroundingType.SPARQL_UPDATE:
           return {
             success: false,
@@ -627,13 +635,45 @@ export class GroundingExecutor {
     value: string,
     targetIRI: string,
     userInput?: UserInput,
+    targetFrontmatter?: Record<string, string | string[]>,
   ): string {
     const date = new Date();
     const now = date.toISOString();
     const nowLocal = DateFormatter.toLocalTimestamp(date);
     const today = now.slice(0, 10);
 
-    let result = value
+    // Issue #3132: `$target.<propertyName>` reads from target asset
+    // frontmatter. MUST run before bare `$target` substitution (more-specific
+    // first), otherwise `$target.foo` would become `<IRI>.foo`. If
+    // targetFrontmatter is not supplied (e.g. legacy property_set call sites),
+    // any `$target.<prop>` token throws — fail-loud, never silently emits a
+    // half-substituted literal.
+    let result = value.replace(/\$target\.([A-Za-z_][\w]*)/g, (_, prop) => {
+      if (!targetFrontmatter) {
+        throw new Error(
+          `$target.${prop} substitution requires target frontmatter context; ` +
+            `none was supplied (asset IRI: ${targetIRI})`,
+        );
+      }
+      const fmValue = targetFrontmatter[prop];
+      if (fmValue === undefined || fmValue === null) {
+        throw new Error(
+          `$target.${prop} is undefined on asset ${targetIRI}`,
+        );
+      }
+      if (Array.isArray(fmValue)) {
+        // Array properties cannot be substituted into a scalar position —
+        // refuse rather than emit YAML-like `[a, b]` literal.
+        throw new Error(
+          `$target.${prop} resolved to an array on asset ${targetIRI}; ` +
+            `only scalar properties are supported for substitution`,
+        );
+      }
+      // Strip surrounding YAML quotes if present (parseObject preserves them).
+      return String(fmValue).replace(/^["'](.*)["']$/, "$1");
+    });
+
+    result = result
       .replace(/\$target/g, targetIRI)
       .replace(/\$nowLocal/g, nowLocal)
       .replace(/\$now/g, now)
@@ -645,6 +685,89 @@ export class GroundingExecutor {
     }
 
     return result;
+  }
+
+  /**
+   * Append a resolved value to a frontmatter array property with Set-based
+   * dedup. Issue #3132 — declarative replacement for `service_call` /
+   * `copyLabelToAliases` (Homoiconicity Invariant Q1).
+   *
+   * Reads:
+   * - `grounding.targetProperty` — array property to append to (e.g. `aliases`).
+   * - `grounding.targetValue` — value to append, with substituteVariables
+   *   resolution (supports `$target.<prop>` dotted-property reads from target
+   *   asset frontmatter).
+   *
+   * Behavior:
+   * - Empty / missing array → write `[resolvedValue]`.
+   * - Existing array without value → append.
+   * - Existing array containing value → no-op (idempotent — Set-based dedup).
+   *
+   * Errors (plain Error with structured message — `GroundingError` class is
+   * not yet introduced in the codebase; existing executors also use Error):
+   * - Missing `targetProperty` / `targetValue` on the grounding definition.
+   * - `$target.<prop>` resolved to undefined / null / array.
+   */
+  private async executePropertyAppend(
+    grounding: GroundingDefinition,
+    targetIRI: string,
+    filePath: string,
+    userInput?: UserInput,
+  ): Promise<ExecutionResult> {
+    if (!grounding.targetProperty) {
+      return {
+        success: false,
+        error: "property_append requires targetProperty",
+      };
+    }
+    if (grounding.targetValue === undefined) {
+      return {
+        success: false,
+        error: "property_append requires targetValue",
+      };
+    }
+
+    const content = await this.fileReader.readFile(filePath);
+    const targetFrontmatter =
+      this.frontmatterService.parseObject(content) ?? {};
+
+    const resolvedValue = this.substituteVariables(
+      grounding.targetValue,
+      targetIRI,
+      userInput,
+      targetFrontmatter,
+    );
+
+    const existingRaw = targetFrontmatter[grounding.targetProperty];
+    const existing: string[] = Array.isArray(existingRaw)
+      ? existingRaw
+      : existingRaw !== undefined
+        ? [String(existingRaw)]
+        : [];
+
+    // Set-based dedup. Compare against unquoted form so a stored
+    // `"Foo"` (with YAML quotes) does not duplicate a plain `Foo`.
+    const stripQuotes = (s: string): string =>
+      s.replace(/^["'](.*)["']$/, "$1");
+    const seen = new Set(existing.map(stripQuotes));
+    let merged: string[];
+    if (seen.has(stripQuotes(resolvedValue))) {
+      merged = existing;
+    } else {
+      // Preserve YAML-quoted form for string values to round-trip safely
+      // through serializeValue (matches LabelToAliasService behavior).
+      const formatted = `"${stripQuotes(resolvedValue)}"`;
+      merged = [...existing, formatted];
+    }
+
+    const updated = this.frontmatterService.updateProperty(
+      content,
+      grounding.targetProperty,
+      merged,
+    );
+    await this.fileWriter.updateFile(filePath, updated);
+
+    return { success: true };
   }
 
   /**

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.property_append.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.property_append.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for the declarative `property_append` grounding type and the
+ * `$target.<propertyName>` substitution introduced in Issue #3132.
+ *
+ * These cases port the behavior expectations from the (still-extant) palette
+ * service `LabelToAliasService` to the new declarative executor branch.
+ * Once Path B (sparql_update) lands, the palette command itself may be
+ * deprecated; the executor-layer coverage here is the new source of truth for
+ * "copy label to aliases" semantics in the grounding pipeline.
+ *
+ * AC reference (Issue #3132):
+ * - asset with label "Foo" + no aliases     → aliases: ["Foo"]
+ * - asset with label "Foo" + aliases [Bar]  → aliases: [Bar, "Foo"]
+ * - asset with label "Foo" + aliases [Foo]  → aliases: [Foo] (no duplicate)
+ * - asset without exo__Asset_label          → executor returns success:false
+ *   with informative message
+ */
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+
+// -- Mocks --
+
+function createMockReader(content: string) {
+  return {
+    readFile: jest.fn().mockResolvedValue(content),
+    fileExists: jest.fn().mockResolvedValue(true),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+}
+
+function createMockWriter() {
+  return {
+    createFile: jest.fn().mockResolvedValue(""),
+    updateFile: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    deleteFile: jest.fn().mockResolvedValue(undefined),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeGrounding(overrides: Record<string, unknown>): GroundingDefinition {
+  return {
+    id: "gnd-property-append",
+    label: "Property Append",
+    ...overrides,
+  } as unknown as GroundingDefinition;
+}
+
+const TARGET_IRI = "https://exocortex.my/assets/test-asset-123";
+const FILE_PATH = "/vault/test-asset.md";
+
+function makeExecutor(content: string): {
+  executor: GroundingExecutor;
+  reader: ReturnType<typeof createMockReader>;
+  writer: ReturnType<typeof createMockWriter>;
+} {
+  const reader = createMockReader(content);
+  const writer = createMockWriter();
+  const registry = new ServiceRegistry();
+  const executor = new GroundingExecutor(reader, writer, registry);
+  return { executor, reader, writer };
+}
+
+describe("GroundingExecutor.property_append (Issue #3132)", () => {
+  describe("happy path", () => {
+    it("appends $target.exo__Asset_label to empty aliases", async () => {
+      const { executor, writer } = makeExecutor(
+        '---\nexo__Asset_label: "Foo"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_APPEND,
+        targetProperty: "aliases",
+        targetValue: "$target.exo__Asset_label",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toContain("aliases:");
+      expect(written).toContain('  - "Foo"');
+    });
+
+    it("appends to existing aliases array without removing prior items", async () => {
+      const { executor, writer } = makeExecutor(
+        '---\nexo__Asset_label: "Foo"\naliases:\n  - "Bar"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_APPEND,
+        targetProperty: "aliases",
+        targetValue: "$target.exo__Asset_label",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toContain('  - "Bar"');
+      expect(written).toContain('  - "Foo"');
+    });
+
+    it("is idempotent — does not duplicate value already in array", async () => {
+      const { executor, writer } = makeExecutor(
+        '---\nexo__Asset_label: "Foo"\naliases:\n  - "Foo"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_APPEND,
+        targetProperty: "aliases",
+        targetValue: "$target.exo__Asset_label",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      const fooCount = (written.match(/- "Foo"/g) ?? []).length;
+      expect(fooCount).toBe(1);
+    });
+  });
+
+  describe("$target.<prop> substitution", () => {
+    it("resolves $target.<prop> from target frontmatter scalar value", async () => {
+      const { executor, writer } = makeExecutor(
+        '---\nexo__Asset_label: "Hello"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_APPEND,
+        targetProperty: "aliases",
+        targetValue: "$target.exo__Asset_label",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toContain('  - "Hello"');
+    });
+
+    it("returns failure with informative message when $target.<prop> is undefined on target", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nfoo: bar\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_APPEND,
+        targetProperty: "aliases",
+        targetValue: "$target.exo__Asset_label",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("exo__Asset_label");
+      expect(result.error).toContain(TARGET_IRI);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error paths", () => {
+    it("returns failure when targetProperty is missing", async () => {
+      const { executor } = makeExecutor(
+        '---\nexo__Asset_label: "Foo"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_APPEND,
+        targetValue: "$target.exo__Asset_label",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/targetProperty/i);
+    });
+
+    it("returns failure when targetValue is missing", async () => {
+      const { executor } = makeExecutor(
+        '---\nexo__Asset_label: "Foo"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_APPEND,
+        targetProperty: "aliases",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/targetValue/i);
+    });
+  });
+});
+
+describe("GroundingExecutor.substituteVariables — $target.<prop> (Issue #3132)", () => {
+  function makeBareExecutor(): GroundingExecutor {
+    const reader = createMockReader("");
+    const writer = createMockWriter();
+    return new GroundingExecutor(reader, writer, new ServiceRegistry());
+  }
+
+  it("resolves dotted-property access ahead of bare $target", () => {
+    const executor = makeBareExecutor();
+    const result = executor.substituteVariables(
+      "$target.exo__Asset_label",
+      TARGET_IRI,
+      undefined,
+      { exo__Asset_label: '"Foo"' },
+    );
+    // Quotes are stripped during scalar substitution.
+    expect(result).toBe("Foo");
+  });
+
+  it("still substitutes bare $target after extraction", () => {
+    const executor = makeBareExecutor();
+    const result = executor.substituteVariables(
+      "see $target for context",
+      TARGET_IRI,
+      undefined,
+      {},
+    );
+    expect(result).toBe(`see ${TARGET_IRI} for context`);
+  });
+
+  it("throws when $target.<prop> resolves to undefined", () => {
+    const executor = makeBareExecutor();
+    expect(() =>
+      executor.substituteVariables(
+        "$target.nonexistentProp",
+        TARGET_IRI,
+        undefined,
+        { exo__Asset_label: "Foo" },
+      ),
+    ).toThrow(/nonexistentProp/);
+  });
+
+  it("throws when $target.<prop> resolves to an array", () => {
+    const executor = makeBareExecutor();
+    expect(() =>
+      executor.substituteVariables(
+        "$target.aliases",
+        TARGET_IRI,
+        undefined,
+        { aliases: ["a", "b"] },
+      ),
+    ).toThrow(/array/);
+  });
+
+  it("throws when $target.<prop> is used without frontmatter context", () => {
+    const executor = makeBareExecutor();
+    expect(() =>
+      executor.substituteVariables(
+        "$target.someProp",
+        TARGET_IRI,
+        undefined,
+      ),
+    ).toThrow(/someProp/);
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -4,7 +4,6 @@ import {
   FrontmatterService,
   TaskStatusService,
   EffortVotingService,
-  LabelToAliasService,
   EffortStatusWorkflow,
   StatusTimestampService,
   GenericAssetCreationService,
@@ -290,7 +289,11 @@ export function populateServiceRegistry(
       statusTimestampService,
     );
     const effortVotingService = new EffortVotingService(vaultAdapter);
-    const labelToAliasService = new LabelToAliasService(vaultAdapter);
+    // LabelToAliasService is no longer constructed here — Issue #3132 migrated
+    // the only `service_call` consumer (grounding a85668fa-…) to the
+    // declarative `property_append` grounding type. The palette command
+    // `CopyLabelToAliasesCommand` instantiates LabelToAliasService directly
+    // via DI, not through this registry.
     const genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
     const archiveAssetService = new ArchiveAssetService(vaultAdapter);
     const propertyCleanupService = new PropertyCleanupService(vaultAdapter);
@@ -349,13 +352,11 @@ export function populateServiceRegistry(
       }),
     );
 
-    registry.register(
-      "copyLabelToAliases",
-      wrapService(async (targetIRI: string) => {
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        await labelToAliasService.copyLabelToAliases(iFile);
-      }),
-    );
+    // `copyLabelToAliases` service registration removed in Issue #3132 —
+    // the sole grounding consumer (a85668fa-17b7-45d0-aa7f-935e2502dff0) was
+    // migrated to declarative `property_append` + `$target.exo__Asset_label`
+    // (Homoiconicity Invariant Q1 remediation). Palette command path remains
+    // via direct LabelToAliasService usage in CopyLabelToAliasesCommand.
 
     registry.register(
       "createRelatedTask",

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -129,7 +129,6 @@ describe("ServiceRegistryPopulator", () => {
       "planForEvening",
       "shiftDay",
       "incrementVotes",
-      "copyLabelToAliases",
       "createRelatedTask",
       "createRelatedProject",
       "archiveAsset",
@@ -461,7 +460,6 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       "planForEvening",
       "shiftDay",
       "incrementVotes",
-      "copyLabelToAliases",
       "createRelatedTask",
       "createRelatedProject",
       "archiveAsset",
@@ -476,6 +474,10 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
     for (const id of vaultDependentIds) {
       expect(registry.has(id)).toBe(true);
     }
+  });
+
+  it("should NOT register copyLabelToAliases (Issue #3132 — migrated to declarative property_append)", () => {
+    expect(registry.has("copyLabelToAliases")).toBe(false);
   });
 
   describe("rollbackStatus", () => {
@@ -567,18 +569,10 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
     });
   });
 
-  describe("copyLabelToAliases", () => {
-    it("should resolve file and add label to aliases", async () => {
-      const service = registry.get("copyLabelToAliases")!;
-      await service.execute("test-uid-123");
-
-      expect(deps.vaultAdapter!.read).toHaveBeenCalledWith(mockIFile);
-      expect(deps.vaultAdapter!.modify).toHaveBeenCalledWith(
-        mockIFile,
-        expect.stringContaining("aliases"),
-      );
-    });
-  });
+  // describe("copyLabelToAliases", ...) removed — Issue #3132 migrated the
+  // grounding to declarative property_append; the registry registration no
+  // longer exists. See GroundingExecutor.property_append.test.ts for new
+  // coverage at the executor layer.
 
   describe("createRelatedTask", () => {
     it("should create a related task with ems__Effort_parent link", async () => {

--- a/scripts/audit-starter-kit-groundings.mjs
+++ b/scripts/audit-starter-kit-groundings.mjs
@@ -44,7 +44,8 @@ const KNOWN_UNREGISTERED_SERVICE_IDS = new Set([
   "rollbackStatus",
   "incrementVotes",
   "createTaskForDailyNote",
-  "copyLabelToAliases",
+  // copyLabelToAliases removed in Issue #3132 — grounding a85668fa-… migrated
+  // to declarative `property_append` (Homoiconicity Q1 remediation).
 ]);
 
 function parseArgs(argv) {


### PR DESCRIPTION
## Summary
- Eliminates the `copyLabelToAliases` `service_call` Homoiconicity violation by introducing declarative `property_append` grounding type + `$target.<propertyName>` substitution in `GroundingExecutor`.
- Removes the orphan registry registration (palette command keeps `LabelToAliasService` via direct DI — class untouched).
- Updates T1.5 audit docs + drift-gate script to the new distribution.

Closes #3132.

> Vault-side asset migration is in the sibling starter-kit PR: kitelev/exocortex-starter-kit#TBD (branch `feat/3132-property-append`).

## Changes
- `packages/exocortex/src/domain/constants/GroundingType.ts` — add `PROPERTY_APPEND = "property_append"` enum member.
- `packages/exocortex/src/services/GroundingExecutor.ts`:
  - New `executePropertyAppend()` — reads array property, appends resolved value with Set-based dedup, writes back YAML-quoted form.
  - Extended `substituteVariables(value, targetIRI, userInput?, targetFrontmatter?)` — `$target.<propertyName>` runs **before** bare `$target` (more-specific first); throws on undefined / array / missing-context.
  - Dispatcher case added for `PROPERTY_APPEND`.
- `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts` — drop `copyLabelToAliases` registration + `LabelToAliasService` import + local var. Comment explains why class itself remains (palette command).
- `packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts` — remove `copyLabelToAliases` from expected sets; add explicit "is NOT registered" guard; remove orphan `describe` block.
- `packages/cli/tests/unit/services/StarterKitGroundingAudit.test.ts` — update expected `byType` / `byCliStatus` distribution + drop `copyLabelToAliases` from documented unregistered set.
- `docs/rfc-94e520da/T1.5-grounding-audit.md` — counter math: `real 38→39`, `unregistered 7→6`, new `property_append` row.
- `docs/rfc-94e520da/starter-kit-grounding-status.json` — same delta + `a85668fa-…` entry flipped to `type: "property_append"` / `cliStatus: "real"`.
- `scripts/audit-starter-kit-groundings.mjs` — drop `copyLabelToAliases` from `KNOWN_UNREGISTERED_SERVICE_IDS` so re-run does not regress.

## Testing
- New: `packages/exocortex/tests/unit/services/GroundingExecutor.property_append.test.ts` — **12 cases**, all passing:
  - `happy path`: empty array → `["Foo"]`; existing array → append; idempotent dedup.
  - `$target.<prop>`: scalar resolution; fails on undefined property; informative message includes property name + asset IRI.
  - `error paths`: missing targetProperty; missing targetValue.
  - `substituteVariables` unit cases: more-specific-first ordering, bare `$target` still works, undefined/array/missing-context all throw.
- Regression: `GroundingExecutor.test.ts` (85 cases), `ServiceRegistryPopulator.test.ts` (84 cases), `StarterKitGroundingAudit.test.ts` (5 cases) — all green.

## Verification
- `npx tsc -noEmit -skipLibCheck` — clean.
- `npm run lint` — clean (2 pre-existing warnings, unrelated).
- Audit drift-gate: `node scripts/audit-starter-kit-groundings.mjs --starter-kit <starter-kit-worktree> --out /tmp/x.json` → produces fixture byte-equivalent to committed (modulo timestamp + path).

## Acceptance Criteria (Issue #3132)
- [x] Asset `a85668fa-…` will contain no `service_call` / `serviceId: copyLabelToAliases` (sibling PR; this PR provides the executor that makes the asset's new form runnable).
- [x] AC2 (empty aliases → `[Foo]`) covered by happy-path unit test.
- [x] AC3 (existing `[Bar]` → `[Bar, Foo]`) covered.
- [x] AC4 (already `[Foo]` → no duplicate) covered.
- [x] AC5 (missing `exo__Asset_label` → fail-loud) covered.
- [x] Unit tests for new grounding type added.
- [x] `ServiceRegistryPopulator.ts:353` registration removed.
- [x] `T1.5-grounding-audit.md` and `starter-kit-grounding-status.json` updated.
- [ ] E2E test via `CommandResolver` — covered indirectly by L2 starter-kit integration suite (auto-pulled fixture). Adding a dedicated `dyncommand exec` BDD scenario explicitly is out of scope for this PR; the existing fixture-driven contract test now exercises `property_append` automatically.

## Out of Scope
- Path B (`sparql_update` grounding type) — requires separate onto-RFC per issue.
- Vault-side asset migration — sibling starter-kit PR.
- Downstream sync into vault-2025 / vault-exodev — manual `git pull` after merge.

## Risk
- Backwards-compat: extension only adds an enum member + new optional parameter to `substituteVariables` (default `undefined` — legacy call sites unchanged). No existing grounding type modified.
- 84-case `ServiceRegistryPopulator` test suite re-run confirms no regression in the remaining 15 vault-dependent service registrations.