### PR TITLE
feat(grounding): declarative property_increment + property_shift (#3134)

### DIFF
--- a/docs/rfc-94e520da/T1.5-grounding-audit.md
+++ b/docs/rfc-94e520da/T1.5-grounding-audit.md
@@ -7,29 +7,43 @@
 
 ## TL;DR
 
-| Status                                       | Groundings |         % | Notes                                                                                                                                                                                                      |
-| -------------------------------------------- | ---------: | --------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Real CLI implementation                   |     **39** | **81.3%** | Mutate vault state through `IFileSystemAdapter` / shared services factories. Includes `a85668fa-…` migrated to declarative `property_append` (Issue #3132)                                                 |
-| 🔴 Fail-loud `CliServiceNotImplementedError` |      **3** |  **6.2%** | Stub: `createAsset` (Obsidian-specific path conventions, T1.6+)                                                                                                                                            |
-| ⚠️ Unregistered service id                   |      **6** | **12.5%** | Plugin-only services not yet ported: `shiftDay`, `rollbackStatus`, `planOnToday`, `incrementVotes`, `createTaskForDailyNote` (`copyLabelToAliases` removed by Issue #3132 — migrated to `property_append`) |
-| **Total**                                    |     **48** |  **100%** |                                                                                                                                                                                                            |
+| Status                                       | Groundings |         % | Notes                                                                                                                                                                                                                                                                                                                                                                                                 |
+| -------------------------------------------- | ---------: | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ Real CLI implementation                   |     **42** | **87.5%** | Mutate vault state through `IFileSystemAdapter` / shared services factories. Includes `a85668fa-…` migrated to declarative `property_append` (Issue #3132); `0b104d75-…` + `6ee56341-…` migrated to `property_shift` and `506f031e-…` migrated to `property_increment` (Issue #3134 / RFC `18407cb2-9554-4897-9213-17321f9dd434` Path B)                                                              |
+| 🔴 Fail-loud `CliServiceNotImplementedError` |      **3** |  **6.3%** | Stub: `createAsset` (Obsidian-specific path conventions, T1.6+)                                                                                                                                                                                                                                                                                                                                       |
+| ⚠️ Unregistered service id                   |      **3** |  **6.3%** | Plugin-only services not yet ported: `rollbackStatus`, `planOnToday`, `createTaskForDailyNote` (`copyLabelToAliases` removed by Issue #3132; `shiftDay`×2 + `incrementVotes` removed by Issue #3134 — migrated to declarative `property_*` types). All three remaining are **documented Homoiconicity exceptions** — see [Documented Homoiconicity Exceptions](#documented-homoiconicity-exceptions). |
+| **Total**                                    |     **48** |  **100%** |                                                                                                                                                                                                                                                                                                                                                                                                       |
 
-**Zero silent fake-succeed groundings remain** — all 10 needs-impl groundings now fail loudly when invoked via `dyncommand exec`. M1 (RFC § Метрики успеха) is met for the audit slice; M6 (48/48 green BDD) is gated on porting the 7 unregistered services + designing CLI semantics for `createAsset`.
+**Zero silent fake-succeed groundings remain** — all 6 needs-impl groundings now fail loudly when invoked via `dyncommand exec`. M1 (RFC § Метрики успеха) is met for the audit slice; the 3 remaining unregistered service ids are now classified as **documented Homoiconicity exceptions** (RFC `18407cb2-…` Q3.a/Q3.b corollary) — they are not violations to remediate but rationale-bound legitimate platform integrations / temporal-stack operations.
+
+## Documented Homoiconicity Exceptions
+
+Per RFC `c78cc5c8-076c-4509-9e22-6f0257c51df4` (Homoiconicity Invariant v0.2) Q3 corollary applied through RFC `18407cb2-9554-4897-9213-17321f9dd434` (T1.5 closure, 2026-05-17 Path B):
+
+| Service id               | Exception clause                                     | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rollbackStatus`         | **Q3.a** — ядро обработки over **non-RDF substrate** | Temporal-stack pop over the `_history` array. Not a triple-pattern mutation; cannot be expressed as `property_*` because it requires reading and re-writing an ordered list of prior states, which is not a value the user authors directly. Stays in TS until a generic `stack_pop` grounding type is justified by ≥2 use cases.                                                                                                                                    |
+| `planOnToday`            | **Q3.b** — platform integration                      | Resolves "today's daily note" via the period-namespace plugin's `period__DailyNote` lookup and writes a wikilink to that asset. Daily-note resolution is platform-integration substrate (Obsidian metadata cache + DailyNote plugin), not user-authorable RDF logic.                                                                                                                                                                                                 |
+| `createTaskForDailyNote` | **Q3.b** — platform integration                      | Creates a task asset whose `ems__Effort_day` points at today's `period__DailyNote`. Identical platform-integration substrate to `planOnToday`; not coverable by `create_instance` because the back-link target is computed (today's daily note IRI), not configured at grounding-author time. Phase 6+ follow-up may introduce a `$today_dailyNote` substitution token to fold this back into declarative form, but that is out of scope for the T1.5 closure issue. |
+
+Each exception is bound to a verifiable property of the substrate (non-RDF history list / platform metadata cache), not to TypeScript-implementation convenience. Re-evaluating an exception requires demonstrating that the substrate property changed (e.g. daily-note resolution becomes addressable as a pure SPARQL function over the vault graph).
 
 ## Breakdown by `exocmd__Grounding_type`
 
-48 groundings split across 5 types:
+48 groundings split across 7 types:
 
-| Type              | Count | CLI status                                                                         |
-| ----------------- | ----: | ---------------------------------------------------------------------------------- |
-| `property_set`    |    16 | ✅ Generic frontmatter handler in `GroundingExecutor.executeFrontmatterUpdate`     |
-| `service_call`    |    24 | Mixed — see table below (1 grounding migrated to `property_append` in Issue #3132) |
-| `property_delete` |     4 | ✅ Generic frontmatter handler                                                     |
-| `composite`       |     2 | ✅ Sequential dispatch to children (each child evaluated recursively)              |
-| `create_instance` |     1 | ✅ Generic handler (verified empirically in C.1.5)                                 |
-| `property_append` |     1 | ✅ Declarative handler (Issue #3132 — `$target.<prop>` substitution + Set dedup)   |
+| Type                 | Count | CLI status                                                                                        |
+| -------------------- | ----: | ------------------------------------------------------------------------------------------------- |
+| `property_set`       |    16 | ✅ Generic frontmatter handler in `GroundingExecutor.executeFrontmatterUpdate`                    |
+| `service_call`       |    21 | Mixed — see table below (4 groundings migrated to declarative types in Issue #3132 + Issue #3134) |
+| `property_delete`    |     4 | ✅ Generic frontmatter handler                                                                    |
+| `composite`          |     2 | ✅ Sequential dispatch to children (each child evaluated recursively)                             |
+| `create_instance`    |     1 | ✅ Generic handler (verified empirically in C.1.5)                                                |
+| `property_append`    |     1 | ✅ Declarative handler (Issue #3132 — `$target.<prop>` substitution + Set dedup)                  |
+| `property_increment` |     1 | ✅ Declarative handler (Issue #3134 — integer counter bump, default delta 1)                      |
+| `property_shift`     |     2 | ✅ Declarative handler (Issue #3134 — ISO-8601 duration arithmetic via `DateTimeParsing`)         |
 
-The 23 non-`service_call` groundings (`property_set` + `property_delete` + `composite` + `create_instance`) are all served by ontology-driven generic handlers and require no per-grounding implementation. They contribute the bulk of the 79.2% real-impl share.
+The 27 non-`service_call` groundings (`property_set` + `property_delete` + `composite` + `create_instance` + `property_append` + `property_increment` + `property_shift`) are all served by ontology-driven generic handlers and require no per-grounding implementation. They contribute the bulk of the 87.5% real-impl share.
 
 ## `service_call` gap analysis (25 groundings → 16 unique service ids)
 
@@ -58,15 +72,15 @@ The 23 non-`service_call` groundings (`property_set` + `property_delete` + `comp
 
 ### ⚠️ Unregistered service ids (no stub, no impl — `GroundingExecutor` raises `unknown service` error)
 
-| Service id               | Groundings | Plugin source                                                                            | Effort to port                                                                                           |
-| ------------------------ | ---------: | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `shiftDay`               |          2 | `packages/obsidian-plugin/src/application/commands/ShiftDay{Forward,Backward}Command.ts` | Low — pure frontmatter shift on `ems__Effort_plannedStartTimestamp`/`plannedEndTimestamp`                |
-| `planOnToday`            |          1 | `PlanOnTodayCommand.ts`                                                                  | Low — frontmatter mutation against today's daily-note path                                               |
-| `rollbackStatus`         |          1 | Plugin `TaskStatusService.rollback`                                                      | Low — already partially in shared package via `taskStatusService` dep; just needs factory + registration |
-| `incrementVotes`         |          1 | Plugin command — counter bump on `ems__Effort_votes`                                     | Trivial — single property increment                                                                      |
-| `createTaskForDailyNote` |          1 | Plugin command on `period__DailyNote` host                                               | Low — mirrors `createRelatedTask` shape                                                                  |
-| ~~`copyLabelToAliases`~~ |      ~~1~~ | Migrated to declarative `property_append` (Issue #3132 — `$target.exo__Asset_label`)     | ✅ Done                                                                                                  |
-| **Subtotal**             |      **6** | (5 unique service ids)                                                                   | All fit T1.6 / Phase 1 follow-up sprint                                                                  |
+| Service id               | Groundings | Plugin source                                                                        | Disposition (post Issue #3134)                                                                            |
+| ------------------------ | ---------: | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `planOnToday`            |          1 | `PlanOnTodayCommand.ts`                                                              | **Documented Homoiconicity exception (Q3.b)** — daily-note platform integration; not user-RDF-authorable. |
+| `rollbackStatus`         |          1 | Plugin `TaskStatusService.rollback`                                                  | **Documented Homoiconicity exception (Q3.a)** — temporal-stack pop over non-RDF `_history` substrate.     |
+| `createTaskForDailyNote` |          1 | Plugin command on `period__DailyNote` host                                           | **Documented Homoiconicity exception (Q3.b)** — same daily-note platform integration as `planOnToday`.    |
+| ~~`shiftDay`~~           |      ~~2~~ | Migrated to declarative `property_shift` (Issue #3134 — `P1D` / `-P1D`)              | ✅ Done                                                                                                   |
+| ~~`incrementVotes`~~     |      ~~1~~ | Migrated to declarative `property_increment` (Issue #3134 — default delta 1)         | ✅ Done                                                                                                   |
+| ~~`copyLabelToAliases`~~ |      ~~1~~ | Migrated to declarative `property_append` (Issue #3132 — `$target.exo__Asset_label`) | ✅ Done                                                                                                   |
+| **Subtotal**             |      **3** | (3 unique service ids — all documented exceptions)                                   | See [Documented Homoiconicity Exceptions](#documented-homoiconicity-exceptions) above.                    |
 
 None of these depend on Obsidian-specific APIs that lack `IFileSystemAdapter` analogs — every operation is frontmatter mutation against a target file resolved by IRI. They were left out of T1.2/T1.4 to keep the migration deltas small; T1.5 confirms the shape of the remaining work.
 

--- a/docs/rfc-94e520da/starter-kit-grounding-status.json
+++ b/docs/rfc-94e520da/starter-kit-grounding-status.json
@@ -3,20 +3,22 @@
     "rfc": "94e520da",
     "phase": 1,
     "task": "T1.5",
-    "auditedAt": "2026-05-02T12:24:40.767Z",
-    "starterKitPath": "/Users/kitelev/Developer/exocortex-development/exocortex-starter-kit",
+    "auditedAt": "2026-05-17T03:52:35.692Z",
+    "starterKitPath": "/Users/kitelev/Developer/exocortex-development/worktrees/starter-kit-claude1-property-increment-shift",
     "totalGroundings": 48,
     "byType": {
       "property_delete": 4,
-      "service_call": 24,
+      "service_call": 21,
       "create_instance": 1,
       "property_set": 16,
-      "composite": 2,
-      "property_append": 1
+      "property_append": 1,
+      "property_shift": 2,
+      "property_increment": 1,
+      "composite": 2
     },
     "byCliStatus": {
-      "real": 39,
-      "unregistered": 6,
+      "real": 42,
+      "unregistered": 3,
       "stub": 3
     },
     "serviceIdCounts": {
@@ -31,9 +33,7 @@
       "repairFolder": 1,
       "archiveAsset": 1,
       "rollbackStatus": 1,
-      "shiftDay": 2,
       "planOnToday": 1,
-      "incrementVotes": 1,
       "planForEvening": 1
     }
   },
@@ -232,11 +232,11 @@
     },
     {
       "uid": "0b104d75-3ed5-44c5-ab04-cffb26e2578a",
-      "label": "Shift day forward via service",
+      "label": "Shift day forward via property_shift",
       "path": "exocmd/planning/0b104d75-3ed5-44c5-ab04-cffb26e2578a.md",
-      "type": "service_call",
-      "serviceId": "shiftDay",
-      "cliStatus": "unregistered"
+      "type": "property_shift",
+      "serviceId": null,
+      "cliStatus": "real"
     },
     {
       "uid": "22a6ba6b-030a-47e4-946e-1a30dc9450e5",
@@ -256,19 +256,19 @@
     },
     {
       "uid": "506f031e-007f-4c74-8257-158550c64956",
-      "label": "Increment votes via service",
+      "label": "Increment votes via property_increment",
       "path": "exocmd/planning/506f031e-007f-4c74-8257-158550c64956.md",
-      "type": "service_call",
-      "serviceId": "incrementVotes",
-      "cliStatus": "unregistered"
+      "type": "property_increment",
+      "serviceId": null,
+      "cliStatus": "real"
     },
     {
       "uid": "6ee56341-966c-4791-8eb3-7a75104b2e5b",
-      "label": "Shift day backward via service",
+      "label": "Shift day backward via property_shift",
       "path": "exocmd/planning/6ee56341-966c-4791-8eb3-7a75104b2e5b.md",
-      "type": "service_call",
-      "serviceId": "shiftDay",
-      "cliStatus": "unregistered"
+      "type": "property_shift",
+      "serviceId": null,
+      "cliStatus": "real"
     },
     {
       "uid": "85687461-c2df-4d1b-819b-0c3ae0ab3741",

--- a/packages/cli/tests/unit/services/StarterKitGroundingAudit.test.ts
+++ b/packages/cli/tests/unit/services/StarterKitGroundingAudit.test.ts
@@ -64,21 +64,29 @@ describe("RFC 94e520da T1.5 starter-kit grounding audit fixture", () => {
 
   it("matches the expected type/cliStatus distribution", () => {
     // Issue #3132: grounding a85668fa-… migrated from service_call
-    // (copyLabelToAliases) to declarative property_append, reducing
-    // service_call count by 1, introducing property_append count = 1, and
-    // moving 1 grounding from unregistered to real.
+    // (copyLabelToAliases) to declarative property_append (−1 service_call,
+    // +1 property_append).
+    // Issue #3134: groundings 0b104d75-… + 6ee56341-… migrated from
+    // service_call (shiftDay) to declarative property_shift (−2 service_call,
+    // +2 property_shift); grounding 506f031e-… migrated from service_call
+    // (incrementVotes) to declarative property_increment (−1 service_call,
+    // +1 property_increment). Net: 3 groundings move from
+    // unregistered → real (24 → 21 service_call, 39 → 42 real,
+    // 6 → 3 unregistered).
     expect(fixture.summary.byType).toEqual({
-      service_call: 24,
+      service_call: 21,
       property_set: 16,
       property_delete: 4,
       composite: 2,
       create_instance: 1,
       property_append: 1,
+      property_increment: 1,
+      property_shift: 2,
     });
     expect(fixture.summary.byCliStatus).toEqual({
-      real: 39,
+      real: 42,
       stub: 3,
-      unregistered: 6,
+      unregistered: 3,
     });
   });
 
@@ -108,13 +116,14 @@ describe("RFC 94e520da T1.5 starter-kit grounding audit fixture", () => {
     ]);
     const documentedStubIds = new Set(["createAsset"]);
     const documentedUnregisteredIds = new Set([
-      "shiftDay",
       "planOnToday",
       "rollbackStatus",
-      "incrementVotes",
       "createTaskForDailyNote",
       // copyLabelToAliases removed in Issue #3132 — grounding migrated to
       // declarative property_append (no longer a service_call).
+      // shiftDay (×2) + incrementVotes (×1) removed in Issue #3134 —
+      // groundings migrated to declarative property_shift /
+      // property_increment (RFC 18407cb2 Path B).
     ]);
 
     for (const g of fixture.groundings) {

--- a/packages/exocortex/src/domain/constants/GroundingType.ts
+++ b/packages/exocortex/src/domain/constants/GroundingType.ts
@@ -26,4 +26,27 @@ export enum GroundingType {
    * semantics belong in RDF, not TypeScript).
    */
   PROPERTY_APPEND = "property_append",
+  /**
+   * Increment an integer frontmatter property by `incrementBy` (default 1).
+   * Reads `targetProperty` (integer property) and `incrementBy` (xsd:integer,
+   * supports negative values). Missing property is treated as 0.
+   *
+   * Issue #3134 — Declarative replacement for `service_call` /
+   * `incrementVotes` (Homoiconicity Invariant Q1). Fails fast when target
+   * value is not parseable as an integer.
+   */
+  PROPERTY_INCREMENT = "property_increment",
+  /**
+   * Shift a datetime frontmatter property by an ISO-8601 duration literal.
+   * Reads `targetProperty` (xsd:dateTime property) and `shiftDelta` (ISO-8601
+   * duration string, e.g. "P1D", "-PT2H", "P1M"; supports both
+   * xsd:dayTimeDuration and xsd:yearMonthDuration shapes).
+   *
+   * Issue #3134 — Declarative replacement for `service_call` / `shiftDay`
+   * (Homoiconicity Invariant Q1). Fails fast on non-datetime current value
+   * or invalid duration literal. Output is formatted via
+   * DateFormatter.toLocalTimestamp (no TZ suffix, matching the
+   * BehavioralRule for ems__Effort_*Timestamp properties).
+   */
+  PROPERTY_SHIFT = "property_shift",
 }

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -103,6 +103,17 @@ export interface GroundingDefinition {
    * If absent → fallback to hardcoded `exo__Asset_source`.
    */
   readonly linkBackProperty?: string;
+  /**
+   * Integer delta for `property_increment` grounding (Issue #3134).
+   * Supports negative values. Default 1 when omitted.
+   */
+  readonly incrementBy?: number;
+  /**
+   * ISO-8601 duration literal for `property_shift` grounding (Issue #3134).
+   * Accepts xsd:dayTimeDuration (`P1D`, `-PT2H`, `P1DT12H`) and
+   * xsd:yearMonthDuration (`P1M`, `P1Y2M`) shapes.
+   */
+  readonly shiftDelta?: string;
 }
 
 /**

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -816,6 +816,16 @@ export class CommandResolver {
     const targetFolder = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetFolder"));
     const linkBackProperty = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_linkBackProperty"));
     const inputSchemaRaw = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_inputSchema"));
+    // Issue #3134: property_increment / property_shift control fields.
+    const incrementByRaw = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_incrementBy"));
+    const shiftDelta = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_shiftDelta"));
+    let incrementBy: number | undefined;
+    if (incrementByRaw !== undefined && incrementByRaw !== null && incrementByRaw !== "") {
+      const parsed = Number.parseInt(String(incrementByRaw), 10);
+      if (Number.isFinite(parsed)) {
+        incrementBy = parsed;
+      }
+    }
 
     // Load composite steps if applicable
     let steps: GroundingDefinition[] | undefined;
@@ -855,6 +865,8 @@ export class CommandResolver {
       targetPrototype: targetPrototype ?? undefined,
       targetFolder: targetFolder ?? undefined,
       linkBackProperty: linkBackProperty ?? undefined,
+      incrementBy,
+      shiftDelta: shiftDelta ?? undefined,
     };
 
     if (inputSchema) {

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -6,6 +6,7 @@ import type { GroundingDefinition } from "../domain/models/CommandDefinition";
 import { GroundingType } from "../domain/constants/GroundingType";
 import { FrontmatterService } from "../utilities/FrontmatterService";
 import { DateFormatter } from "../utilities/DateFormatter";
+import { DateTimeParsing } from "../infrastructure/sparql/filters/functions/DateTimeParsing";
 import { LoggingService } from "./LoggingService";
 
 /**
@@ -184,6 +185,18 @@ export class GroundingExecutor {
             targetIRI,
             targetFilePath,
             userInput,
+          );
+
+        case GroundingType.PROPERTY_INCREMENT:
+          return await this.executePropertyIncrement(
+            grounding,
+            targetFilePath,
+          );
+
+        case GroundingType.PROPERTY_SHIFT:
+          return await this.executePropertyShift(
+            grounding,
+            targetFilePath,
           );
 
         case GroundingType.SPARQL_UPDATE:
@@ -768,6 +781,187 @@ export class GroundingExecutor {
     await this.fileWriter.updateFile(filePath, updated);
 
     return { success: true };
+  }
+
+  /**
+   * Increment an integer frontmatter property by `incrementBy` (default 1).
+   * Issue #3134 — declarative replacement for `service_call` /
+   * `incrementVotes` (Homoiconicity Invariant Q1).
+   *
+   * Behaviour:
+   * - Missing property → write `incrementBy` (treats current as 0).
+   * - Existing int → write `current + incrementBy` (preserves YAML int).
+   * - Negative delta supported.
+   * - YAML-quoted string ("5") is also accepted and coerced to int per
+   *   ontology range — output is always emitted as bare int.
+   *
+   * Errors (returned as { success: false, error }):
+   * - Missing `targetProperty` on grounding.
+   * - Current value not parseable as integer (e.g. "abc" or "1.5").
+   */
+  private async executePropertyIncrement(
+    grounding: GroundingDefinition,
+    filePath: string,
+  ): Promise<ExecutionResult> {
+    if (!grounding.targetProperty) {
+      return {
+        success: false,
+        error: "property_increment requires targetProperty",
+      };
+    }
+
+    const delta = grounding.incrementBy ?? 1;
+    if (!Number.isFinite(delta) || !Number.isInteger(delta)) {
+      return {
+        success: false,
+        error: `property_increment: incrementBy must be an integer (got ${String(grounding.incrementBy)})`,
+      };
+    }
+
+    const content = await this.fileReader.readFile(filePath);
+    const fm = this.frontmatterService.parseObject(content) ?? {};
+    const raw = fm[grounding.targetProperty];
+
+    let current: number;
+    if (raw === undefined || raw === null || raw === "") {
+      current = 0;
+    } else if (Array.isArray(raw)) {
+      return {
+        success: false,
+        error: `property_increment: targetProperty "${grounding.targetProperty}" is an array, expected integer`,
+      };
+    } else {
+      // Strip optional YAML quotes (FrontmatterService.parseObject preserves
+      // them for string values). Then require strict integer literal.
+      const unquoted = String(raw).replace(/^["'](.*)["']$/, "$1").trim();
+      if (!/^-?\d+$/.test(unquoted)) {
+        return {
+          success: false,
+          error: `property_increment: targetProperty "${grounding.targetProperty}" current value "${String(raw)}" is not a valid integer`,
+        };
+      }
+      current = Number.parseInt(unquoted, 10);
+    }
+
+    const next = current + delta;
+    const updated = this.frontmatterService.updateProperty(
+      content,
+      grounding.targetProperty,
+      next,
+    );
+    await this.fileWriter.updateFile(filePath, updated);
+    return { success: true };
+  }
+
+  /**
+   * Shift a datetime frontmatter property by an ISO-8601 duration literal.
+   * Issue #3134 — declarative replacement for `service_call` / `shiftDay`
+   * (Homoiconicity Invariant Q1).
+   *
+   * Accepts xsd:dayTimeDuration (`P1D`, `-PT2H`, `P1DT12H`) and
+   * xsd:yearMonthDuration (`P1M`, `P1Y2M`) shapes. Day-time durations are
+   * applied via Date arithmetic (`new Date(getTime() + ms)`); year-month
+   * durations use `setMonth(getMonth() + months)`, inheriting JS Date's
+   * month-end normalization (Jan 31 + P1M → Mar 03 in non-leap years; see
+   * tests for the documented behaviour).
+   *
+   * Output is formatted via DateFormatter.toLocalTimestamp — no TZ suffix —
+   * matching the canonical effort-timestamp shape (RFC-009 +
+   * BehavioralRule [[609e78ed-56aa-4697-8d9c-af9efde32c10]]).
+   *
+   * Errors (returned as { success: false, error }):
+   * - Missing `targetProperty` or `shiftDelta` on grounding.
+   * - Current value undefined or not parseable as a datetime.
+   * - shiftDelta is not a valid ISO-8601 duration literal.
+   */
+  private async executePropertyShift(
+    grounding: GroundingDefinition,
+    filePath: string,
+  ): Promise<ExecutionResult> {
+    if (!grounding.targetProperty) {
+      return {
+        success: false,
+        error: "property_shift requires targetProperty",
+      };
+    }
+    if (!grounding.shiftDelta) {
+      return {
+        success: false,
+        error: "property_shift requires shiftDelta (ISO-8601 duration literal)",
+      };
+    }
+
+    const content = await this.fileReader.readFile(filePath);
+    const fm = this.frontmatterService.parseObject(content) ?? {};
+    const raw = fm[grounding.targetProperty];
+
+    if (raw === undefined || raw === null || raw === "") {
+      return {
+        success: false,
+        error: `property_shift: targetProperty "${grounding.targetProperty}" is not set on target asset`,
+      };
+    }
+    if (Array.isArray(raw)) {
+      return {
+        success: false,
+        error: `property_shift: targetProperty "${grounding.targetProperty}" is an array, expected single datetime`,
+      };
+    }
+
+    const currentStr = String(raw).replace(/^["'](.*)["']$/, "$1").trim();
+    const currentDate = new Date(currentStr);
+    if (Number.isNaN(currentDate.getTime())) {
+      return {
+        success: false,
+        error: `property_shift: current value "${currentStr}" is not a valid datetime`,
+      };
+    }
+
+    // Parse duration — auto-detect day-time vs year-month shape.
+    let shifted: Date;
+    try {
+      shifted = GroundingExecutor.applyIsoDuration(currentDate, grounding.shiftDelta);
+    } catch (error) {
+      return {
+        success: false,
+        error: `property_shift: invalid shiftDelta "${grounding.shiftDelta}": ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    const nextTimestamp = DateFormatter.toLocalTimestamp(shifted);
+    const updated = this.frontmatterService.updateProperty(
+      content,
+      grounding.targetProperty,
+      nextTimestamp,
+    );
+    await this.fileWriter.updateFile(filePath, updated);
+    return { success: true };
+  }
+
+  /**
+   * Apply an ISO-8601 duration to a Date. Auto-detects xsd:yearMonthDuration
+   * (PnY[mM] / Pn M — no T component, no day) vs xsd:dayTimeDuration (PnDTnH…)
+   * by checking for a `T` separator or a day/time component. Throws on
+   * unparseable literals (delegated to DateTimeParsing helpers).
+   *
+   * For year-month durations: uses JS `setMonth` semantics (Jan 31 + P1M
+   * overflows into March in non-leap years — documented behaviour, matches
+   * Date.prototype.setMonth contract; no leap-year compensation invented).
+   */
+  private static applyIsoDuration(date: Date, literal: string): Date {
+    const trimmed = literal.trim();
+    // Heuristic: a year-month duration is P[-]?nY[mM] or P[-]?nM with no T.
+    // A day-time duration has a D component or a T separator.
+    const isYearMonth = /^-?P(\d+Y)(\d+M)?$|^-?P\d+M$/.test(trimmed);
+    if (isYearMonth) {
+      const months = DateTimeParsing.parseYearMonthDuration(trimmed);
+      const result = new Date(date.getTime());
+      result.setMonth(result.getMonth() + months);
+      return result;
+    }
+    // Fallback: day-time duration (P1D, PT2H, -PT2H30M, P1DT12H, ...).
+    const ms = DateTimeParsing.parseDayTimeDuration(trimmed);
+    return new Date(date.getTime() + ms);
   }
 
   /**

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.property_increment.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.property_increment.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the declarative `property_increment` grounding type introduced
+ * in Issue #3134 (RFC `18407cb2-9554-4897-9213-17321f9dd434`, Path B).
+ *
+ * Port of `EffortVotingService.incrementEffortVotes` semantics into the
+ * declarative executor branch — counter bump on `ems__Effort_votes` and
+ * other integer properties without `service_call` dispatch.
+ *
+ * AC reference (Issue #3134):
+ * - empty (no property)                 → writes integer `delta` (default 1)
+ * - existing `votes: 5`, default delta  → writes `votes: 6`
+ * - existing `votes: 5`, delta 3        → writes `votes: 8`
+ * - existing `votes: 5`, delta -1       → writes `votes: 4`
+ * - existing `votes: "abc"`             → success:false with informative error
+ */
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+
+function createMockReader(content: string) {
+  return {
+    readFile: jest.fn().mockResolvedValue(content),
+    fileExists: jest.fn().mockResolvedValue(true),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+}
+
+function createMockWriter() {
+  return {
+    createFile: jest.fn().mockResolvedValue(""),
+    updateFile: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    deleteFile: jest.fn().mockResolvedValue(undefined),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeGrounding(overrides: Record<string, unknown>): GroundingDefinition {
+  return {
+    id: "gnd-property-increment",
+    label: "Property Increment",
+    ...overrides,
+  } as unknown as GroundingDefinition;
+}
+
+const TARGET_IRI = "https://exocortex.my/assets/test-asset-123";
+const FILE_PATH = "/vault/test-asset.md";
+
+function makeExecutor(content: string): {
+  executor: GroundingExecutor;
+  reader: ReturnType<typeof createMockReader>;
+  writer: ReturnType<typeof createMockWriter>;
+} {
+  const reader = createMockReader(content);
+  const writer = createMockWriter();
+  const registry = new ServiceRegistry();
+  const executor = new GroundingExecutor(reader, writer, registry);
+  return { executor, reader, writer };
+}
+
+describe("GroundingExecutor.property_increment (Issue #3134)", () => {
+  describe("happy path", () => {
+    it("writes default delta when property is absent", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nexo__Asset_uid: x\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_INCREMENT,
+        targetProperty: "ems__Effort_votes",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      // Default delta 1 + 0 (missing) → 1, emitted as bare YAML int.
+      expect(written).toMatch(/ems__Effort_votes:\s*1\b/);
+    });
+
+    it("increments existing int by default delta of 1", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_votes: 5\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_INCREMENT,
+        targetProperty: "ems__Effort_votes",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(/ems__Effort_votes:\s*6\b/);
+    });
+
+    it("applies explicit positive incrementBy delta", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_votes: 5\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_INCREMENT,
+        targetProperty: "ems__Effort_votes",
+        incrementBy: 3,
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(/ems__Effort_votes:\s*8\b/);
+    });
+
+    it("supports negative incrementBy delta (decrement)", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_votes: 5\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_INCREMENT,
+        targetProperty: "ems__Effort_votes",
+        incrementBy: -1,
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(/ems__Effort_votes:\s*4\b/);
+    });
+
+    it("coerces YAML-quoted int string to integer (ontology range invariant)", async () => {
+      // RFC R1 mitigation: when source quoting is ambiguous, default to int.
+      const { executor, writer } = makeExecutor(
+        '---\nems__Effort_votes: "5"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_INCREMENT,
+        targetProperty: "ems__Effort_votes",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      // Output is always bare int — no preserved quoting.
+      expect(written).toMatch(/ems__Effort_votes:\s*6\b/);
+      expect(written).not.toMatch(/ems__Effort_votes:\s*"6"/);
+    });
+  });
+
+  describe("error paths", () => {
+    it("returns failure when targetProperty is missing", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_votes: 5\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_INCREMENT,
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/targetProperty/i);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+
+    it("fails fast on non-integer current value", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_votes: abc\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_INCREMENT,
+        targetProperty: "ems__Effort_votes",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not a valid integer/i);
+      expect(result.error).toContain("ems__Effort_votes");
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+
+    it("fails fast on fractional current value (strict integer literal)", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_votes: 1.5\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_INCREMENT,
+        targetProperty: "ems__Effort_votes",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not a valid integer/i);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.property_shift.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.property_shift.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for the declarative `property_shift` grounding type introduced in
+ * Issue #3134 (RFC `18407cb2-9554-4897-9213-17321f9dd434`, Path B).
+ *
+ * Port of `TaskStatusService.shiftDay{Forward,Backward}` semantics into the
+ * declarative executor branch — date arithmetic on
+ * `ems__Effort_plannedStartTimestamp` and similar dateTime properties
+ * without `service_call` dispatch.
+ *
+ * AC reference (Issue #3134):
+ * - `P1D` forward                       → +1 day
+ * - `-PT2H` backward                    → −2 hours
+ * - `P1M` month forward                 → +1 month (JS setMonth semantics)
+ * - non-datetime current value          → success:false
+ * - invalid duration literal            → success:false
+ */
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+
+function createMockReader(content: string) {
+  return {
+    readFile: jest.fn().mockResolvedValue(content),
+    fileExists: jest.fn().mockResolvedValue(true),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+}
+
+function createMockWriter() {
+  return {
+    createFile: jest.fn().mockResolvedValue(""),
+    updateFile: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    deleteFile: jest.fn().mockResolvedValue(undefined),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeGrounding(overrides: Record<string, unknown>): GroundingDefinition {
+  return {
+    id: "gnd-property-shift",
+    label: "Property Shift",
+    ...overrides,
+  } as unknown as GroundingDefinition;
+}
+
+const TARGET_IRI = "https://exocortex.my/assets/test-asset-123";
+const FILE_PATH = "/vault/test-asset.md";
+
+function makeExecutor(content: string): {
+  executor: GroundingExecutor;
+  reader: ReturnType<typeof createMockReader>;
+  writer: ReturnType<typeof createMockWriter>;
+} {
+  const reader = createMockReader(content);
+  const writer = createMockWriter();
+  const registry = new ServiceRegistry();
+  const executor = new GroundingExecutor(reader, writer, registry);
+  return { executor, reader, writer };
+}
+
+describe("GroundingExecutor.property_shift (Issue #3134)", () => {
+  describe("happy path — day-time durations", () => {
+    it("shifts forward by P1D (one day)", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_plannedStartTimestamp: 2026-05-17T10:00:00\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        targetProperty: "ems__Effort_plannedStartTimestamp",
+        shiftDelta: "P1D",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      // Local timestamp form — no Z suffix.
+      expect(written).toMatch(
+        /ems__Effort_plannedStartTimestamp:\s*2026-05-18T10:00:00\b/,
+      );
+      expect(written).not.toContain("2026-05-18T10:00:00Z");
+    });
+
+    it("shifts backward by -PT2H (two hours)", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_plannedStartTimestamp: 2026-05-17T10:00:00\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        targetProperty: "ems__Effort_plannedStartTimestamp",
+        shiftDelta: "-PT2H",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(
+        /ems__Effort_plannedStartTimestamp:\s*2026-05-17T08:00:00\b/,
+      );
+    });
+
+    it("supports backward P1D as -P1D", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_plannedStartTimestamp: 2026-05-17T00:00:00\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        targetProperty: "ems__Effort_plannedStartTimestamp",
+        shiftDelta: "-P1D",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(
+        /ems__Effort_plannedStartTimestamp:\s*2026-05-16T00:00:00\b/,
+      );
+    });
+  });
+
+  describe("happy path — year-month durations", () => {
+    it("shifts forward by P1M (one month)", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_plannedStartTimestamp: 2026-05-15T10:00:00\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        targetProperty: "ems__Effort_plannedStartTimestamp",
+        shiftDelta: "P1M",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(
+        /ems__Effort_plannedStartTimestamp:\s*2026-06-15T10:00:00\b/,
+      );
+    });
+
+    it("Jan 31 + P1M overflows into March per JS Date.setMonth semantics", async () => {
+      // Documented behaviour (RFC R2 mitigation): we inherit JS Date contract,
+      // do not invent leap-year compensation. Jan 31 → setMonth(+1) lands on
+      // Mar 03 in non-leap years (Feb has 28 days, 31 % 28 = 3).
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_plannedStartTimestamp: 2027-01-31T00:00:00\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        targetProperty: "ems__Effort_plannedStartTimestamp",
+        shiftDelta: "P1M",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      // 2027 is not a leap year — Feb has 28 days, Jan 31 + 1 month → Mar 03.
+      expect(written).toMatch(
+        /ems__Effort_plannedStartTimestamp:\s*2027-03-03T00:00:00\b/,
+      );
+    });
+  });
+
+  describe("error paths", () => {
+    it("returns failure when targetProperty is missing", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_plannedStartTimestamp: 2026-05-17T10:00:00\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        shiftDelta: "P1D",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/targetProperty/i);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+
+    it("returns failure when shiftDelta is missing", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_plannedStartTimestamp: 2026-05-17T10:00:00\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        targetProperty: "ems__Effort_plannedStartTimestamp",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/shiftDelta/i);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+
+    it("fails fast when target property is absent on asset", async () => {
+      const { executor, writer } = makeExecutor("---\nfoo: bar\n---\nBody");
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        targetProperty: "ems__Effort_plannedStartTimestamp",
+        shiftDelta: "P1D",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not set/i);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+
+    it("fails fast on non-datetime current value", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_plannedStartTimestamp: not-a-date\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        targetProperty: "ems__Effort_plannedStartTimestamp",
+        shiftDelta: "P1D",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not a valid datetime/i);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+
+    it("fails fast on invalid ISO-8601 duration literal", async () => {
+      const { executor, writer } = makeExecutor(
+        "---\nems__Effort_plannedStartTimestamp: 2026-05-17T10:00:00\n---\nBody",
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SHIFT,
+        targetProperty: "ems__Effort_plannedStartTimestamp",
+        shiftDelta: "1day",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/invalid shiftDelta/i);
+      expect(writer.updateFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -3,7 +3,6 @@ import {
   ServiceRegistry,
   FrontmatterService,
   TaskStatusService,
-  EffortVotingService,
   EffortStatusWorkflow,
   StatusTimestampService,
   GenericAssetCreationService,
@@ -288,7 +287,12 @@ export function populateServiceRegistry(
       effortStatusWorkflow,
       statusTimestampService,
     );
-    const effortVotingService = new EffortVotingService(vaultAdapter);
+    // EffortVotingService is no longer constructed here — Issue #3134 migrated
+    // the only `service_call` consumer (grounding 506f031e-…) to the
+    // declarative `property_increment` grounding type. The palette command
+    // `VoteOnEffortCommand` instantiates EffortVotingService directly via DI,
+    // not through this registry.
+    //
     // LabelToAliasService is no longer constructed here — Issue #3132 migrated
     // the only `service_call` consumer (grounding a85668fa-…) to the
     // declarative `property_append` grounding type. The palette command
@@ -328,29 +332,18 @@ export function populateServiceRegistry(
       createPlanForEveningService(vaultAdapter, taskStatusService, targetResolver),
     );
 
-    registry.register(
-      "shiftDay",
-      wrapService(async (targetIRI: string, userInput?: UserInput) => {
-        const direction = userInput?.direction as string | undefined;
-        if (!direction) throw new Error("shiftDay requires userInput.direction");
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        if (direction === "forward") {
-          await taskStatusService.shiftDayForward(iFile);
-        } else if (direction === "backward") {
-          await taskStatusService.shiftDayBackward(iFile);
-        } else {
-          throw new Error(`shiftDay: unknown direction "${direction}". Use "forward" or "backward"`);
-        }
-      }),
-    );
-
-    registry.register(
-      "incrementVotes",
-      wrapService(async (targetIRI: string) => {
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        await effortVotingService.incrementEffortVotes(iFile);
-      }),
-    );
+    // `shiftDay` + `incrementVotes` service registrations removed in
+    // Issue #3134 — the three grounding consumers (`0b104d75-…`, `6ee56341-…`,
+    // `506f031e-…`) were migrated to declarative `property_shift` /
+    // `property_increment` (Homoiconicity Invariant Q1 remediation, RFC
+    // `18407cb2-9554-4897-9213-17321f9dd434` Path B). Palette command paths
+    // remain via direct DI:
+    //   - `ShiftDayForwardCommand` / `ShiftDayBackwardCommand` →
+    //     `taskStatusService.shiftDay{Forward,Backward}(file)`
+    //   - `VoteOnEffortCommand` → `effortVotingService.incrementEffortVotes(file)`
+    // The TS service classes are intentionally preserved (palette + hotkey
+    // surfaces); only the registry registrations are deleted to avoid
+    // duplicate dispatch paths for the now-declarative groundings.
 
     // `copyLabelToAliases` service registration removed in Issue #3132 —
     // the sole grounding consumer (a85668fa-17b7-45d0-aa7f-935e2502dff0) was

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -127,8 +127,6 @@ describe("ServiceRegistryPopulator", () => {
       "rollbackStatus",
       "planOnToday",
       "planForEvening",
-      "shiftDay",
-      "incrementVotes",
       "createRelatedTask",
       "createRelatedProject",
       "archiveAsset",
@@ -458,8 +456,6 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
       "rollbackStatus",
       "planOnToday",
       "planForEvening",
-      "shiftDay",
-      "incrementVotes",
       "createRelatedTask",
       "createRelatedProject",
       "archiveAsset",
@@ -478,6 +474,11 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
 
   it("should NOT register copyLabelToAliases (Issue #3132 — migrated to declarative property_append)", () => {
     expect(registry.has("copyLabelToAliases")).toBe(false);
+  });
+
+  it("should NOT register shiftDay or incrementVotes (Issue #3134 — migrated to declarative property_shift / property_increment)", () => {
+    expect(registry.has("shiftDay")).toBe(false);
+    expect(registry.has("incrementVotes")).toBe(false);
   });
 
   describe("rollbackStatus", () => {
@@ -524,50 +525,14 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
     });
   });
 
-  describe("shiftDay", () => {
-    it("should shift day forward when direction is 'forward'", async () => {
-      const service = registry.get("shiftDay")!;
-      await service.execute("test-uid-123", { direction: "forward" });
-
-      expect(deps.vaultAdapter!.read).toHaveBeenCalledWith(mockIFile);
-      expect(deps.vaultAdapter!.modify).toHaveBeenCalled();
-    });
-
-    it("should shift day backward when direction is 'backward'", async () => {
-      const service = registry.get("shiftDay")!;
-      await service.execute("test-uid-123", { direction: "backward" });
-
-      expect(deps.vaultAdapter!.read).toHaveBeenCalledWith(mockIFile);
-      expect(deps.vaultAdapter!.modify).toHaveBeenCalled();
-    });
-
-    it("should throw when direction is missing", async () => {
-      const service = registry.get("shiftDay")!;
-      await expect(service.execute("test-uid-123", {})).rejects.toThrow(
-        "shiftDay requires userInput.direction",
-      );
-    });
-
-    it("should throw when direction is unknown", async () => {
-      const service = registry.get("shiftDay")!;
-      await expect(
-        service.execute("test-uid-123", { direction: "sideways" }),
-      ).rejects.toThrow('unknown direction "sideways"');
-    });
-  });
-
-  describe("incrementVotes", () => {
-    it("should resolve file and increment ems__Effort_votes", async () => {
-      const service = registry.get("incrementVotes")!;
-      await service.execute("test-uid-123");
-
-      expect(deps.vaultAdapter!.read).toHaveBeenCalledWith(mockIFile);
-      expect(deps.vaultAdapter!.modify).toHaveBeenCalledWith(
-        mockIFile,
-        expect.stringContaining("ems__Effort_votes"),
-      );
-    });
-  });
+  // describe("shiftDay", ...) + describe("incrementVotes", ...) removed —
+  // Issue #3134 migrated the three groundings to declarative
+  // property_shift / property_increment; the registry registrations no
+  // longer exist. See GroundingExecutor.property_shift.test.ts and
+  // GroundingExecutor.property_increment.test.ts for new coverage at the
+  // executor layer. Palette command paths (ShiftDayForwardCommand,
+  // ShiftDayBackwardCommand, VoteOnEffortCommand) continue to call
+  // taskStatusService / effortVotingService directly via DI.
 
   // describe("copyLabelToAliases", ...) removed — Issue #3132 migrated the
   // grounding to declarative property_append; the registry registration no

--- a/scripts/audit-starter-kit-groundings.mjs
+++ b/scripts/audit-starter-kit-groundings.mjs
@@ -39,13 +39,14 @@ const KNOWN_STUB_SERVICE_IDS = new Set([
 // follow-up (T1.6). Listed explicitly so the drift gate exits zero today
 // and exits non-zero the moment a brand-new service id appears.
 const KNOWN_UNREGISTERED_SERVICE_IDS = new Set([
-  "shiftDay",
   "planOnToday",
   "rollbackStatus",
-  "incrementVotes",
   "createTaskForDailyNote",
   // copyLabelToAliases removed in Issue #3132 — grounding a85668fa-… migrated
   // to declarative `property_append` (Homoiconicity Q1 remediation).
+  // shiftDay (×2) + incrementVotes (×1) removed in Issue #3134 — migrated to
+  // declarative `property_shift` / `property_increment` (RFC
+  // 18407cb2-9554-4897-9213-17321f9dd434 Path B).
 ]);
 
 function parseArgs(argv) {


### PR DESCRIPTION
## Summary
- Adds two specialized declarative grounding types — `property_increment` (counter bump) and `property_shift` (ISO-8601 duration arithmetic) — eliminating the `shiftDay` and `incrementVotes` `service_call` Homoiconicity Invariant violations.
- Closes RFC `18407cb2-9554-4897-9213-17321f9dd434` T1.5: counter `unregistered 6 → 3 + 2 documented Homoiconicity exceptions`. The remaining three (`rollbackStatus`, `planOnToday`, `createTaskForDailyNote`) are now rationale-bound exceptions, not violations.
- Vault-side starter-kit migration in sibling PR kitelev/exocortex-starter-kit#TBD (branch `feat/property-increment-shift`).

Closes #3134.

## Changes
- `packages/exocortex/src/domain/constants/GroundingType.ts` — add `PROPERTY_INCREMENT`, `PROPERTY_SHIFT` enum members with JSDoc.
- `packages/exocortex/src/domain/models/CommandDefinition.ts` — add optional `incrementBy: number`, `shiftDelta: string` fields.
- `packages/exocortex/src/services/GroundingExecutor.ts`:
  - `executePropertyIncrement` — read int property (fallback 0), apply `incrementBy` (default 1, supports negative), write YAML int.
  - `executePropertyShift` — read datetime, apply ISO-8601 duration (auto-detect dayTime vs yearMonth shape), write via `DateFormatter.toLocalTimestamp` (no TZ suffix per BehavioralRule `[[609e78ed-…]]`).
  - `applyIsoDuration` helper — dispatches to `DateTimeParsing.parseYearMonthDuration` or `parseDayTimeDuration`.
- `packages/exocortex/src/services/CommandResolver.ts` — load `exocmd:Grounding_incrementBy` (parsed as integer) and `exocmd:Grounding_shiftDelta` from RDF triples.
- `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts` — drop `shiftDay` and `incrementVotes` registrations + `EffortVotingService` import / local var. Comment explains why TS classes remain (palette commands use them via direct DI).
- `packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts` — remove migrated ids from expected sets; add explicit "is NOT registered" guard; drop describe blocks for `shiftDay` / `incrementVotes`.
- `packages/cli/tests/unit/services/StarterKitGroundingAudit.test.ts` — distribution: `service_call 24 → 21`, `real 39 → 42`, `unregistered 6 → 3`, new types added.
- `scripts/audit-starter-kit-groundings.mjs` — `KNOWN_UNREGISTERED_SERVICE_IDS` reduced to `{planOnToday, rollbackStatus, createTaskForDailyNote}`.
- `docs/rfc-94e520da/T1.5-grounding-audit.md` — TL;DR table updated; new "Documented Homoiconicity Exceptions" section with per-service rationale (Q3.a temporal stack / Q3.b platform integration).
- `docs/rfc-94e520da/starter-kit-grounding-status.json` — regenerated by audit script against starter-kit worktree (`property_shift: 2`, `property_increment: 1`, `service_call: 21`).

## Testing
- **New unit tests (18 cases)**:
  - `packages/exocortex/tests/unit/services/GroundingExecutor.property_increment.test.ts` — 8 cases (default delta, existing int, explicit positive, negative, YAML-quoted-int coercion, missing targetProperty, non-int current, fractional current).
  - `packages/exocortex/tests/unit/services/GroundingExecutor.property_shift.test.ts` — 10 cases (P1D forward, -PT2H backward, -P1D, P1M month forward, Jan 31 + P1M JS-Date overflow, missing targetProperty, missing shiftDelta, property absent, non-datetime, invalid duration).
- **Regression**:
  - `GroundingExecutor.test.ts` + `GroundingExecutor.property_append.test.ts` — 97 cases green.
  - `ServiceRegistryPopulator.test.ts` — 80 cases green.
  - `StarterKitGroundingAudit.test.ts` — 5 cases green.
  - `CommandResolver.test.ts` + `CommandResolver.style.test.ts` — 78 cases green.

## Verification
- `npx tsc --noEmit --skipLibCheck` — clean.
- `npm run lint` — clean (2 pre-existing warnings, unrelated).
- Audit drift-gate `node scripts/audit-starter-kit-groundings.mjs --starter-kit <worktree>` — produces fixture byte-identical to committed copy (modulo timestamp + absolute path).

## Acceptance Criteria (Issue #3134)
- [x] Three vault assets contain no `service_call` / `serviceId` (sibling starter-kit PR delivers the new shape; this PR makes the shape runnable).
- [x] Increment with no existing property → writes `1` (default delta).
- [x] Existing `votes: 5` → `votes: 6` (YAML int preserved).
- [x] Explicit `incrementBy: 3` → applies delta.
- [x] Negative delta (`-1`) supported.
- [x] Shift forward `P1D` → +1 day, no TZ suffix.
- [x] Shift backward `-PT2H` → −2 hours.
- [x] Shift `P1M` → +1 month with JS-Date `setMonth` semantics (documented Jan 31 + P1M test).
- [x] Invalid duration / non-int / non-datetime → fail-fast with informative error.
- [x] `T1.5-grounding-audit.md` counter: `6 unmigrated → 0 unmigrated + 3 documented exceptions`.

## Deviation from RFC
- RFC §План миграции step says "reuse `luxon Duration.fromISO()` — battle-tested". Verified: **luxon is not in `packages/exocortex/package.json` and `node_modules/luxon` does not exist**. Avoided adding a new runtime dependency for ~30 LoC — used the existing `DateTimeParsing.parseDayTimeDuration` / `parseYearMonthDuration` helpers already in the monorepo (`packages/exocortex/src/infrastructure/sparql/filters/functions/DateTimeParsing.ts`). Auto-detection of year-month vs day-time shape is handled by a 3-line regex heuristic in the new `GroundingExecutor.applyIsoDuration` helper.

## Out of Scope
- Path B (`sparql_update` general-purpose engine) — defer indefinitely per RFC `18407cb2-…` § Альтернативы (Variant A rejected).
- `rollbackStatus` migration — Q3.a documented exception (temporal stack pop over non-RDF `_history` substrate).
- `planOnToday` / `createTaskForDailyNote` migration — Q3.b documented exceptions (platform integration with daily-note resolution). Phase 6+ may introduce `$today_dailyNote` substitution token, but that is a separate RFC.

## Risk
- Backwards-compat: extension only adds two enum members + two optional `GroundingDefinition` fields with `undefined` defaults — every existing grounding type and call site is unchanged.
- 80-case `ServiceRegistryPopulator` test suite + 78-case `CommandResolver` suite + 97-case `GroundingExecutor` baseline all re-run green.

## Predecessor refs
- #3132 / #3133 — `property_append` + `$target.<prop>`.
- RFC vault asset: `18407cb2-9554-4897-9213-17321f9dd434` (v2 Path B).
- T1.5 audit: `docs/rfc-94e520da/T1.5-grounding-audit.md`.