### PR TITLE
fix(shape-loader): recognize UID-form exo__Instance_class (post-RFC-004 regression)

### DIFF
--- a/packages/exocortex/src/services/ShapeLoader.ts
+++ b/packages/exocortex/src/services/ShapeLoader.ts
@@ -194,13 +194,23 @@ export class ShapeLoader {
     const fm = ShapeLoader.parseFrontmatter(content);
     if (!fm) return;
 
-    // Must be a property definition
+    // Must be a property definition.
+    // After RFC-004 UUID-canonicalization (2026-05-16), TBox class IRIs in
+    // exo__Instance_class are written as pure UID wikilinks (no alias suffix),
+    // so we must accept both:
+    //   - label-form `[[exo__Property]]` / `[[exo__ObjectProperty]]` (legacy)
+    //   - UID+alias form `[[<uid>|exo__Property]]` (intermediate canon)
+    //   - pure UID form `[[<uid>]]` (current strip-canon)
+    const EXO_PROPERTY_UID = "38277bfa-d7f9-4a75-b856-b23276ab0db3";
+    const EXO_OBJECT_PROPERTY_UID = "9a1cf31c-9d41-4ef3-9023-584a8d087d16";
     const classes = ShapeLoader.asArray(fm["exo__Instance_class"]);
     const isProperty = classes.some((c) => {
       const ref = ShapeLoader.extractWikilinkRef(c);
       return (
         ref === "exo__Property" ||
         ref === "exo__ObjectProperty" ||
+        ref === EXO_PROPERTY_UID ||
+        ref === EXO_OBJECT_PROPERTY_UID ||
         ref?.includes("|exo__Property") ||
         ref?.includes("|exo__ObjectProperty")
       );

--- a/packages/exocortex/tests/services/ShapeLoader.test.ts
+++ b/packages/exocortex/tests/services/ShapeLoader.test.ts
@@ -338,6 +338,51 @@ describe("ShapeLoader.loadFromVaultFS", () => {
     expect(shape!.cardinality).toBe("Single");
   });
 
+  it("loads property with pure UID-form exo__Instance_class (post UUID-canon, no alias)", async () => {
+    // After RFC-004 UUID-canonicalization + alias strip (2026-05-17),
+    // property files reference their type class by bare UID with no display alias:
+    //   exo__Instance_class:
+    //     - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16]]"  # exo__ObjectProperty UID
+    // ShapeLoader must recognise this form, otherwise validate-schema --shapes-mode
+    // silently loads zero shapes and reports `conforms: true` on every vault.
+    await writeFile(
+      "uid-form-prop.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        'exo__Property_range: "[[ems__Task]]"',
+        "exo__Asset_label: ems__Task_uidFormProp",
+        "---",
+      ].join("\n"),
+    );
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Task_uidFormProp`);
+    expect(shape).toBeDefined();
+    expect(shape!.range).toEqual([`${EMS}Task`]);
+  });
+
+  it("loads property with pure UID-form for exo__Property class UID", async () => {
+    // Same scenario for exo__Property (not ObjectProperty) by UID:
+    //   38277bfa-d7f9-4a75-b856-b23276ab0db3 = exo__Property class
+    await writeFile(
+      "uid-form-base-prop.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[38277bfa-d7f9-4a75-b856-b23276ab0db3]]"',
+        'exo__Property_domain: "[[exo__Asset]]"',
+        "exo__Asset_label: exo__Asset_uidLabel",
+        "---",
+      ].join("\n"),
+    );
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EXO}Asset_uidLabel`);
+    expect(shape).toBeDefined();
+    expect(shape!.domain).toEqual([`${EXO}Asset`]);
+  });
+
   it("defaults severity to sh:Violation when absent", async () => {
     await writeFile(
       "no-severity.md",


### PR DESCRIPTION
## Problem

After RFC-004 UUID-canonicalization (2026-05-16) plus the strip-canon decision (2026-05-17), property TBox files reference their meta-class by bare UID, no alias:

\`\`\`yaml
exo__Instance_class:
  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16]]"  # exo__ObjectProperty
\`\`\`

\`ShapeLoader.processFile\` only matched three legacy forms:
- \`[[exo__Property]]\` (label)
- \`[[exo__ObjectProperty]]\` (label)
- \`[[<uid>|exo__Property]]\` (UID+alias)

After strip-canon, none match → **`isProperty = false` → zero shapes loaded** → \`validate schema --shapes-mode\` silently reports \`conforms: true\` on every vault, regardless of actual violations.

Empirical evidence (this session): both vault-2025 and vault-exodev returned 232,687 triples / 0 violations after 11-wave UID-canon migration. Sanity tests with deliberately-violating instances (wrong class refs, wrong datatypes) also passed — confirming nothing is being checked.

## Fix

Accept the canonical class UIDs alongside legacy label-form:

- \`exo__Property\` = \`38277bfa-d7f9-4a75-b856-b23276ab0db3\`
- \`exo__ObjectProperty\` = \`9a1cf31c-9d41-4ef3-9023-584a8d087d16\`

## Test plan

- [x] Two new ShapeLoader tests cover the pure UID-only form for both class UIDs
- [x] All 43 ShapeLoader tests pass
- [x] Existing label-form and UID+alias paths preserved (backward compatible)

## Why hardcoded UIDs

Trade-off considered: read class UIDs from the graph dynamically (more flexible, no hardcoded constants). Rejected because:
1. ShapeLoader.loadFromVaultFS scans the filesystem file-by-file without building a triple graph first — no cheap way to look up class IRIs at scan time
2. Two class UIDs are stable per the exocortex-exo-ontology contract — they cannot change without breaking ABox everywhere
3. Same pattern already used for hardcoded XSD/RDFS resolution in this file