### PR TITLE
fix(shape-loader): resolve UID-form domain/range via vault UID→label map

### DIFF
--- a/packages/exocortex/src/services/ShapeLoader.ts
+++ b/packages/exocortex/src/services/ShapeLoader.ts
@@ -8,6 +8,9 @@ import { Namespace } from "../domain/models/rdf/Namespace";
 const SH_NS = "http://www.w3.org/ns/shacl#";
 // XML Schema Datatypes namespace base
 const XSD_NS = "http://www.w3.org/2001/XMLSchema#";
+// UUID v4 regex (case-insensitive)
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Legacy whitelist retained for documentation; runtime resolution now goes
 // through Namespace.fromPropertyKey, which auto-extends to any well-formed
@@ -44,8 +47,61 @@ export class ShapeLoader {
     // eslint-disable-next-line import/no-nodejs-modules
     const path = await import("path");
     const registry = new ShapeRegistry();
-    await ShapeLoader.scanDir(vaultPath, registry, { readdir, readFile, path });
+    // Pass 1: build UID → label map so wikilinkToIRI can resolve pure-UID
+    // refs `[[<uid>]]` (post RFC-004 strip-canon). Without this, shapes
+    // get range=undefined/domain=[] when their frontmatter uses UID-form,
+    // and SHACL silently passes.
+    const uidToLabel = new Map<string, string>();
+    await ShapeLoader.buildUidLabelMap(vaultPath, uidToLabel, { readdir, readFile, path });
+    await ShapeLoader.scanDir(vaultPath, registry, { readdir, readFile, path }, uidToLabel);
     return registry;
+  }
+
+  /**
+   * Pass 1 helper: walks the vault and collects exo__Asset_uid → exo__Asset_label
+   * mapping for every .md file. Used by `wikilinkToIRI` to resolve pure-UID
+   * wikilinks like `[[1b20a8f0-...]]` to their ontology IRI.
+   */
+  private static async buildUidLabelMap(
+    dir: string,
+    out: Map<string, string>,
+    io: {
+      readdir: (
+        p: string,
+        opts: { withFileTypes: true },
+      ) => Promise<import("fs").Dirent[]>;
+      readFile: (p: string, enc: "utf-8") => Promise<string>;
+      path: typeof import("path");
+    },
+  ): Promise<void> {
+    let entries: import("fs").Dirent[];
+    try {
+      entries = await io.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = io.path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await ShapeLoader.buildUidLabelMap(full, out, io);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        try {
+          const content = await io.readFile(full, "utf-8");
+          const fm = ShapeLoader.parseFrontmatter(content);
+          if (!fm) continue;
+          const uid = fm["exo__Asset_uid"];
+          const label = fm["exo__Asset_label"];
+          if (typeof uid !== "string" || typeof label !== "string") continue;
+          const uidTrim = uid.trim().replace(/^["']|["']$/g, "");
+          const labelTrim = label.trim().replace(/^["']|["']$/g, "");
+          if (uidTrim && labelTrim && !out.has(uidTrim)) {
+            out.set(uidTrim, labelTrim);
+          }
+        } catch {
+          // skip unreadable file
+        }
+      }
+    }
   }
 
   /**
@@ -156,6 +212,7 @@ export class ShapeLoader {
       readFile: (p: string, enc: "utf-8") => Promise<string>;
       path: typeof import("path");
     },
+    uidToLabel?: Map<string, string>,
   ): Promise<void> {
     let entries: import("fs").Dirent[];
     try {
@@ -166,11 +223,11 @@ export class ShapeLoader {
     for (const entry of entries) {
       const full = io.path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        await ShapeLoader.scanDir(full, registry, io);
+        await ShapeLoader.scanDir(full, registry, io, uidToLabel);
       } else if (entry.isFile() && entry.name.endsWith(".md")) {
         // Fail-soft: one malformed property asset should not abort the scan.
         try {
-          await ShapeLoader.processFile(full, registry, io.readFile, io.path);
+          await ShapeLoader.processFile(full, registry, io.readFile, io.path, uidToLabel);
         } catch {
           // Skip the offending file silently
         }
@@ -183,6 +240,7 @@ export class ShapeLoader {
     registry: ShapeRegistry,
     readFile: (p: string, enc: "utf-8") => Promise<string>,
     path?: typeof import("path"),
+    uidToLabel?: Map<string, string>,
   ): Promise<void> {
     let content: string;
     try {
@@ -241,12 +299,12 @@ export class ShapeLoader {
     const minCountRaw = fm["exo__Property_minCount"];
 
     const domain = ShapeLoader.asArray(domainRaw)
-      .map((v) => ShapeLoader.wikilinkToIRI(v))
+      .map((v) => ShapeLoader.wikilinkToIRI(v, uidToLabel))
       .filter((v): v is string => v !== null);
     if (domain.length === 0) return;
 
     const range = ShapeLoader.asArray(rangeRaw)
-      .map((v) => ShapeLoader.wikilinkToIRI(v))
+      .map((v) => ShapeLoader.wikilinkToIRI(v, uidToLabel))
       .filter((v): v is string => v !== null);
 
     const cardinality = ShapeLoader.cardinalityFromLabel(
@@ -349,19 +407,36 @@ export class ShapeLoader {
 
   /**
    * Converts a wikilink value to a full IRI string.
-   * Handles: "[[ems__Effort]]", "[[uuid|ems__Effort]]", "[[exo__PropertyCardinalitySingle]]"
+   * Handles:
+   *   - `[[ems__Effort]]`                  — label-form (legacy)
+   *   - `[[uuid|ems__Effort]]`             — UID + alias
+   *   - `[[ems__PropertyCardinalitySingle]]` — label-form
+   *   - `[[1b20a8f0-...]]`                 — pure UID (post RFC-004 strip-canon)
+   *     resolved via `uidToLabel` map → label → IRI
    */
-  private static wikilinkToIRI(value: string): string | null {
+  private static wikilinkToIRI(
+    value: string,
+    uidToLabel?: Map<string, string>,
+  ): string | null {
     const ref = ShapeLoader.extractWikilinkRef(value);
     if (!ref) return null;
 
-    // [[uuid|alias]] — take alias part
+    // [[uuid|alias]] — try alias first, then UID part
     const parts = ref.split("|");
     const candidates = parts.length > 1 ? [parts[1], parts[0]] : [parts[0]];
 
     for (const candidate of candidates) {
       const iri = ShapeLoader.labelToIRI(candidate.trim());
       if (iri) return iri;
+    }
+
+    // Pure UID form `[[<uid>]]`: resolve via uidToLabel map (Pass 1 result)
+    if (uidToLabel && UUID_RE.test(ref)) {
+      const label = uidToLabel.get(ref);
+      if (label) {
+        const iri = ShapeLoader.labelToIRI(label);
+        if (iri) return iri;
+      }
     }
 
     // Try as a full IRI

--- a/packages/exocortex/tests/services/ShapeLoader.test.ts
+++ b/packages/exocortex/tests/services/ShapeLoader.test.ts
@@ -383,6 +383,54 @@ describe("ShapeLoader.loadFromVaultFS", () => {
     expect(shape!.domain).toEqual([`${EXO}Asset`]);
   });
 
+  it("resolves pure UID-form domain/range via vault uidToLabel map (post strip-canon)", async () => {
+    // After RFC-004 + strip-canon (2026-05-17), property files reference their
+    // domain/range classes by pure UID wikilinks:
+    //   exo__Property_domain: "[[<uid>]]"
+    //   exo__Property_range:  "[[<uid>]]"
+    // ShapeLoader's Pass 1 collects UID→label across vault; Pass 2 resolves UID
+    // wikilinks through that map. Without this, range = undefined and SHACL
+    // sh:class checks silently skip.
+    const subDir = await fs.mkdtemp(path.join(os.tmpdir(), "shacl-uid-resolve-"));
+    try {
+      const classUid = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+      await fs.writeFile(
+        path.join(subDir, `${classUid}.md`),
+        [
+          "---",
+          'exo__Instance_class:',
+          '  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"',
+          `exo__Asset_uid: ${classUid}`,
+          "exo__Asset_label: ems__Task",
+          "---",
+        ].join("\n"),
+        "utf-8",
+      );
+      const propUid = "aaaa1111-bbbb-2222-cccc-333344445555";
+      await fs.writeFile(
+        path.join(subDir, `${propUid}.md`),
+        [
+          "---",
+          'exo__Instance_class:',
+          '  - "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16]]"',
+          `exo__Asset_uid: ${propUid}`,
+          `exo__Property_domain: "[[${classUid}]]"`,
+          `exo__Property_range: "[[${classUid}]]"`,
+          "exo__Asset_label: ems__Task_clones",
+          "---",
+        ].join("\n"),
+        "utf-8",
+      );
+      const reg = await ShapeLoader.loadFromVaultFS(subDir);
+      const shape = reg.get(`${EMS}Task_clones`);
+      expect(shape).toBeDefined();
+      expect(shape!.domain).toEqual([`${EMS}Task`]);
+      expect(shape!.range).toEqual([`${EMS}Task`]);
+    } finally {
+      await fs.rm(subDir, { recursive: true, force: true });
+    }
+  });
+
   it("defaults severity to sh:Violation when absent", async () => {
     await writeFile(
       "no-severity.md",


### PR DESCRIPTION
## Problem (continuation of #3137)

Even after #3137 fixed `isProperty` detection for UID-form `exo__Instance_class`, SHACL still reported \`conforms: true\` on UID-canonical vaults with deliberately violating instances.

Root cause: \`wikilinkToIRI\` could not resolve pure-UID wikilinks like \`[[1b20a8f0-...]]\` (no alias, no \`<ns>__<Local>\` shape) → shape's \`domain\`/\`range\` arrays got filtered to empty → sh:class and sh:datatype constraints silently skipped during validation.

After RFC-004 + strip-canon, property frontmatter looks like:
\`\`\`yaml
exo__Property_domain: "[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"   # ems__Task
exo__Property_range:  "[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"   # ems__Task
\`\`\`

Validator processed 232,687 triples and emitted 0 violations even with a synthetic violator pointing the range at a wrong class.

## Fix

Two-pass scan in \`loadFromVaultFS\`:

1. **Pass 1 — \`buildUidLabelMap\`**: walks the vault, collects \`exo__Asset_uid\` → \`exo__Asset_label\` for every \`.md\` file
2. **Pass 2 — \`scanDir\`/\`processFile\`**: receives the map; \`wikilinkToIRI\` resolves pure-UID wikilinks by looking up the label and converting it to an IRI

UID detection via standard UUID v4 regex. \`uidToLabel\` is optional — when absent (e.g. \`loadFromRDFGraph\` path), existing behavior preserved.

## Test plan

- [x] New test \"resolves pure UID-form domain/range via vault uidToLabel map (post strip-canon)\" — verifies both \`domain\` AND \`range\` UID-wikilinks resolve to IRIs
- [x] All 44 ShapeLoader tests pass
- [x] Existing label-form (\`[[ems__Effort]]\`) and UID+alias form (\`[[<uid>|ems__Effort]]\`) paths unchanged

## After this merge — empirical test

I will re-run \`validate schema --shapes-mode --vault /Users/kitelev/vault-2025 --also /Users/kitelev/vault-exodev\` with the new version. If non-zero violations surface, that's empirical proof the validator is now actually checking constraints (a good thing — current zero is a false positive).