### PR TITLE
refactor(commands): extract CommandExecutionFlow + extend createAsset for global surfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17172,6 +17172,7 @@
     "packages/cli": {
       "name": "@kitelev/exocortex-cli",
       "version": "15.55.5",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -80,6 +80,11 @@ export {
   type UserInput,
   type IGroundingService,
 } from "./services/GroundingExecutor";
+export {
+  CommandExecutionFlow,
+  type CommandExecutionContext,
+  type CommandPromptAdapter,
+} from "./services/CommandExecutionFlow";
 export { TaskStatusService } from "./services/TaskStatusService";
 export { AreaCreationService } from "./services/AreaCreationService";
 export {

--- a/packages/exocortex/src/services/CommandExecutionFlow.ts
+++ b/packages/exocortex/src/services/CommandExecutionFlow.ts
@@ -1,0 +1,135 @@
+import type { GroundingExecutor, UserInput } from "./GroundingExecutor";
+import type { ResolvedCommand } from "./CommandResolver";
+import type { INotificationService } from "../interfaces/INotificationService";
+import type { ILogger } from "../interfaces/ILogger";
+
+/**
+ * Surface-agnostic execution context for a resolved exocmd command.
+ *
+ * - `targetIRI` / `filePath` describe the asset the command runs against.
+ *   They may be `null` for global surfaces (e.g. Obsidian Command Palette
+ *   without an active file) — groundings that depend on `$target`
+ *   substitution will fail loudly in that case, by design.
+ * - `injectedUserInput` lets the caller pre-supply `UserInput` keys (e.g.
+ *   owner identity, default folder) before the modal opens. Modal-collected
+ *   values override these defaults on key collision.
+ * - `onComplete` runs after successful execution. Layout buttons pass their
+ *   `refresh` callback; Palette callers pass nothing.
+ */
+export interface CommandExecutionContext {
+  readonly targetIRI: string | null;
+  readonly filePath: string | null;
+  readonly injectedUserInput?: UserInput;
+  readonly onComplete?: () => Promise<void>;
+}
+
+/**
+ * Platform-specific prompt adapter. Lets {@link CommandExecutionFlow}
+ * orchestrate confirm + form prompts without coupling to Obsidian APIs,
+ * `window`, or any specific modal renderer.
+ *
+ * `promptInputSchema` returns `null` if the user cancelled the form.
+ * Field shape is intentionally `unknown[]` — schemas are validated by
+ * {@link CommandResolver} when parsing `Grounding_inputSchema` JSON, and
+ * each adapter is free to type its own field descriptors.
+ */
+export interface CommandPromptAdapter {
+  confirm(message: string): Promise<boolean>;
+  promptInputSchema(
+    fields: ReadonlyArray<unknown>,
+  ): Promise<UserInput | null>;
+}
+
+/**
+ * Domain-agnostic execution pipeline for a resolved exocmd command.
+ *
+ * Pipeline:
+ *   1. If `command.confirmMessage` is set → prompt confirm; bail on cancel.
+ *   2. If grounding declares `inputSchema` → open form prompt; bail on cancel.
+ *      Modal-collected `UserInput` is shallow-merged on top of any
+ *      `injectedUserInput` from the call-site.
+ *   3. Delegate to `groundingExecutor.execute(...)` with target IRI / file.
+ *   4. On success → fire `successMessage` toast (if any) + `onComplete()`.
+ *      On failure → fire error toast.
+ *
+ * Used by both inline layout buttons (via `DynamicCommandButtonGroupBuilder`)
+ * and global Obsidian Command Palette entries (via the future
+ * `ExocmdCommandPaletteRegistrar`).
+ *
+ * Source: code-RFC `1429fcd0-0948-4a42-89c4-8d1426e9bc7a` (PR-1).
+ */
+export class CommandExecutionFlow {
+  constructor(
+    private readonly groundingExecutor: GroundingExecutor,
+    private readonly notificationService: INotificationService,
+    private readonly logger: ILogger,
+    private readonly prompts: CommandPromptAdapter,
+  ) {}
+
+  async run(
+    rc: ResolvedCommand,
+    ctx: CommandExecutionContext,
+  ): Promise<void> {
+    const { command } = rc;
+
+    if (command.confirmMessage) {
+      const confirmed = await this.prompts.confirm(command.confirmMessage);
+      if (!confirmed) return;
+    }
+
+    let userInput: UserInput | undefined = ctx.injectedUserInput;
+    const inputSchema = CommandExecutionFlow.extractInputSchema(rc);
+    if (inputSchema !== null && inputSchema.length > 0) {
+      const collected = await this.prompts.promptInputSchema(inputSchema);
+      if (collected === null) return;
+      userInput = { ...(ctx.injectedUserInput ?? {}), ...collected };
+    }
+
+    const result = await this.groundingExecutor.execute(
+      command.grounding,
+      ctx.targetIRI ?? "",
+      ctx.filePath ?? "",
+      userInput,
+    );
+
+    const displayPath = ctx.filePath ?? "<no-file>";
+
+    if (result.success) {
+      if (command.successMessage) {
+        this.notificationService.success(command.successMessage);
+      }
+      // Match legacy delay so downstream metadata-cache invalidation
+      // settles before the layout re-renders. Cf. RFC f1dc284a refresh ordering.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      if (ctx.onComplete) {
+        await ctx.onComplete();
+      }
+      this.logger.info(
+        `[CommandExecutionFlow] Executed "${command.name}" on ${displayPath}`,
+      );
+    } else {
+      this.notificationService.error(
+        `Command failed: ${result.error ?? "unknown error"}`,
+      );
+      this.logger.info(
+        `[CommandExecutionFlow] Failed "${command.name}": ${result.error}`,
+      );
+    }
+  }
+
+  /**
+   * Read the optional `inputSchema` field that {@link CommandResolver}
+   * attaches to grounding definitions when parsing
+   * `exocmd__Grounding_inputSchema` JSON.
+   */
+  private static extractInputSchema(
+    rc: ResolvedCommand,
+  ): ReadonlyArray<unknown> | null {
+    const grounding = rc.command.grounding;
+    const raw = (grounding as unknown as Record<string, unknown>)[
+      "inputSchema"
+    ];
+    if (!raw || !Array.isArray(raw)) return null;
+    return raw;
+  }
+}

--- a/packages/exocortex/src/services/CommandExecutionFlow.ts
+++ b/packages/exocortex/src/services/CommandExecutionFlow.ts
@@ -1,3 +1,4 @@
+import { injectable } from "tsyringe";
 import type { GroundingExecutor, UserInput } from "./GroundingExecutor";
 import type { ResolvedCommand } from "./CommandResolver";
 import type { INotificationService } from "../interfaces/INotificationService";
@@ -58,6 +59,7 @@ export interface CommandPromptAdapter {
  *
  * Source: code-RFC `1429fcd0-0948-4a42-89c4-8d1426e9bc7a` (PR-1).
  */
+@injectable()
 export class CommandExecutionFlow {
   constructor(
     private readonly groundingExecutor: GroundingExecutor,

--- a/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
+++ b/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
@@ -1,0 +1,326 @@
+import {
+  CommandExecutionFlow,
+  type CommandPromptAdapter,
+} from "../../src/services/CommandExecutionFlow";
+import type {
+  GroundingExecutor,
+  ExecutionResult,
+  UserInput,
+} from "../../src/services/GroundingExecutor";
+import type { ResolvedCommand } from "../../src/services/CommandResolver";
+import type { INotificationService } from "../../src/interfaces/INotificationService";
+import type { ILogger } from "../../src/interfaces/ILogger";
+import type { GroundingDefinition } from "../../src/domain/models/CommandDefinition";
+import { GroundingType } from "../../src/domain/constants/GroundingType";
+
+const baseGrounding: GroundingDefinition = {
+  id: "grounding-1",
+  label: "g",
+  type: GroundingType.PROPERTY_SET,
+  targetProperty: "ems__Effort_status",
+  targetValue: "[[ems__EffortStatusDone]]",
+};
+
+function makeRC(
+  commandOverrides?: Partial<ResolvedCommand["command"]>,
+  groundingOverrides?: Partial<GroundingDefinition> & Record<string, unknown>,
+): ResolvedCommand {
+  return {
+    command: {
+      id: "cmd-1",
+      name: "Test cmd",
+      grounding: { ...baseGrounding, ...(groundingOverrides ?? {}) },
+      ...commandOverrides,
+    },
+    binding: {
+      id: "binding-1",
+      label: "Test binding",
+      commandRef: "cmd-1",
+      targetClass: "ems__Task",
+    },
+  };
+}
+
+function makeFlow(overrides?: {
+  groundingResult?: ExecutionResult;
+  confirmResult?: boolean;
+  promptResult?: UserInput | null;
+}) {
+  const groundingExecutor = {
+    execute: jest
+      .fn<Promise<ExecutionResult>, [unknown, string, string, UserInput?]>()
+      .mockResolvedValue(overrides?.groundingResult ?? { success: true }),
+  } as unknown as GroundingExecutor;
+
+  const notificationService: jest.Mocked<INotificationService> = {
+    info: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    confirm: jest.fn(),
+  };
+
+  const logger: jest.Mocked<ILogger> = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const prompts: jest.Mocked<CommandPromptAdapter> = {
+    confirm: jest.fn().mockResolvedValue(overrides?.confirmResult ?? true),
+    promptInputSchema: jest
+      .fn()
+      .mockResolvedValue(overrides?.promptResult ?? null),
+  };
+
+  const flow = new CommandExecutionFlow(
+    groundingExecutor,
+    notificationService,
+    logger,
+    prompts,
+  );
+
+  return { flow, groundingExecutor, notificationService, logger, prompts };
+}
+
+describe("CommandExecutionFlow", () => {
+  describe("confirm gating", () => {
+    it("skips execution when confirmMessage is set and user cancels", async () => {
+      const { flow, groundingExecutor, prompts } = makeFlow({
+        confirmResult: false,
+      });
+      const rc = makeRC({ confirmMessage: "Sure?" });
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(prompts.confirm).toHaveBeenCalledWith("Sure?");
+      expect(groundingExecutor.execute).not.toHaveBeenCalled();
+    });
+
+    it("proceeds when confirmMessage is set and user accepts", async () => {
+      const { flow, groundingExecutor, prompts } = makeFlow({
+        confirmResult: true,
+      });
+      const rc = makeRC({ confirmMessage: "Sure?" });
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(prompts.confirm).toHaveBeenCalledWith("Sure?");
+      expect(groundingExecutor.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips confirm prompt entirely when no confirmMessage", async () => {
+      const { flow, groundingExecutor, prompts } = makeFlow();
+      const rc = makeRC();
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(prompts.confirm).not.toHaveBeenCalled();
+      expect(groundingExecutor.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("inputSchema modal", () => {
+    it("opens prompt when grounding declares inputSchema and executes with merged userInput", async () => {
+      const { flow, groundingExecutor, prompts } = makeFlow({
+        promptResult: { label: "user-typed" },
+      });
+      const rc = makeRC(
+        {},
+        {
+          inputSchema: [{ name: "label", type: "text" }],
+        },
+      );
+
+      await flow.run(rc, {
+        targetIRI: "iri://x",
+        filePath: "x.md",
+        injectedUserInput: { ownerIdentity: "[[!kitelev]]" },
+      });
+
+      expect(prompts.promptInputSchema).toHaveBeenCalledTimes(1);
+      expect(groundingExecutor.execute).toHaveBeenCalledWith(
+        expect.anything(),
+        "iri://x",
+        "x.md",
+        // modal-collected values shallow-merge on top of injected defaults
+        { ownerIdentity: "[[!kitelev]]", label: "user-typed" },
+      );
+    });
+
+    it("modal value overrides injected default on key collision", async () => {
+      const { flow, groundingExecutor } = makeFlow({
+        promptResult: { folder: "user-folder" },
+      });
+      const rc = makeRC(
+        {},
+        { inputSchema: [{ name: "folder", type: "text" }] },
+      );
+
+      await flow.run(rc, {
+        targetIRI: null,
+        filePath: null,
+        injectedUserInput: { folder: "default-folder" },
+      });
+
+      expect(groundingExecutor.execute).toHaveBeenCalledWith(
+        expect.anything(),
+        "",
+        "",
+        { folder: "user-folder" },
+      );
+    });
+
+    it("aborts when user cancels the modal (returns null)", async () => {
+      const { flow, groundingExecutor, prompts } = makeFlow({
+        promptResult: null,
+      });
+      const rc = makeRC(
+        {},
+        { inputSchema: [{ name: "label", type: "text" }] },
+      );
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(prompts.promptInputSchema).toHaveBeenCalled();
+      expect(groundingExecutor.execute).not.toHaveBeenCalled();
+    });
+
+    it("skips modal when inputSchema is empty array", async () => {
+      const { flow, prompts, groundingExecutor } = makeFlow();
+      const rc = makeRC({}, { inputSchema: [] });
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(prompts.promptInputSchema).not.toHaveBeenCalled();
+      expect(groundingExecutor.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips modal when inputSchema is missing", async () => {
+      const { flow, prompts } = makeFlow();
+      const rc = makeRC();
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(prompts.promptInputSchema).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("injected userInput without modal", () => {
+    it("passes injectedUserInput through when no inputSchema", async () => {
+      const { flow, groundingExecutor } = makeFlow();
+      const rc = makeRC();
+
+      await flow.run(rc, {
+        targetIRI: "iri://x",
+        filePath: "x.md",
+        injectedUserInput: { ownerIdentity: "[[!owner]]" },
+      });
+
+      expect(groundingExecutor.execute).toHaveBeenCalledWith(
+        expect.anything(),
+        "iri://x",
+        "x.md",
+        { ownerIdentity: "[[!owner]]" },
+      );
+    });
+  });
+
+  describe("targetIRI / filePath nullability", () => {
+    it("passes empty strings to executor when both are null (global Palette case)", async () => {
+      const { flow, groundingExecutor } = makeFlow();
+      const rc = makeRC();
+
+      await flow.run(rc, { targetIRI: null, filePath: null });
+
+      expect(groundingExecutor.execute).toHaveBeenCalledWith(
+        expect.anything(),
+        "",
+        "",
+        undefined,
+      );
+    });
+  });
+
+  describe("success path", () => {
+    it("fires successMessage toast and onComplete", async () => {
+      const { flow, notificationService, logger } = makeFlow();
+      const onComplete = jest.fn().mockResolvedValue(undefined);
+      const rc = makeRC({ successMessage: "Created" });
+
+      await flow.run(rc, {
+        targetIRI: "iri://x",
+        filePath: "x.md",
+        onComplete,
+      });
+
+      expect(notificationService.success).toHaveBeenCalledWith("Created");
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Executed"),
+      );
+    });
+
+    it("skips success toast when successMessage absent but still calls onComplete", async () => {
+      const { flow, notificationService } = makeFlow();
+      const onComplete = jest.fn().mockResolvedValue(undefined);
+      const rc = makeRC();
+
+      await flow.run(rc, {
+        targetIRI: "iri://x",
+        filePath: "x.md",
+        onComplete,
+      });
+
+      expect(notificationService.success).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips onComplete when not provided", async () => {
+      const { flow, notificationService } = makeFlow();
+      const rc = makeRC({ successMessage: "Ok" });
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(notificationService.success).toHaveBeenCalledWith("Ok");
+    });
+  });
+
+  describe("failure path", () => {
+    it("fires error toast with executor error message", async () => {
+      const { flow, notificationService, logger } = makeFlow({
+        groundingResult: { success: false, error: "boom" } as ExecutionResult,
+      });
+      const onComplete = jest.fn();
+      const rc = makeRC();
+
+      await flow.run(rc, {
+        targetIRI: "iri://x",
+        filePath: "x.md",
+        onComplete,
+      });
+
+      expect(notificationService.error).toHaveBeenCalledWith(
+        "Command failed: boom",
+      );
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Failed"),
+      );
+    });
+
+    it("fires error toast with generic message when error string missing", async () => {
+      const { flow, notificationService } = makeFlow({
+        groundingResult: { success: false } as ExecutionResult,
+      });
+      const rc = makeRC();
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(notificationService.error).toHaveBeenCalledWith(
+        "Command failed: unknown error",
+      );
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ObsidianCommandPromptAdapter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ObsidianCommandPromptAdapter.ts
@@ -1,0 +1,34 @@
+import type { App } from "obsidian";
+import type { CommandPromptAdapter, UserInput } from "exocortex";
+import { DynamicFormModal } from "@plugin/presentation/modals/DynamicFormModal";
+import type { InputSchemaField } from "@plugin/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+
+/**
+ * Obsidian-side implementation of {@link CommandPromptAdapter}.
+ *
+ * - `confirm()` uses `window.confirm` (matches legacy
+ *   `DynamicCommandButtonGroupBuilder.showConfirmation` UX; replacing it
+ *   with an Obsidian modal is tracked as a separate UX task).
+ * - `promptInputSchema()` opens {@link DynamicFormModal}. The schema array
+ *   is already validated by `CommandResolver` when parsing
+ *   `exocmd__Grounding_inputSchema` JSON, so the cast to
+ *   `InputSchemaField[]` is safe — the runtime invariants match.
+ *
+ * Source: code-RFC `1429fcd0-0948-4a42-89c4-8d1426e9bc7a` (PR-1).
+ */
+export class ObsidianCommandPromptAdapter implements CommandPromptAdapter {
+  constructor(private readonly app: App) {}
+
+  async confirm(message: string): Promise<boolean> {
+    // eslint-disable-next-line no-alert -- preserves legacy UX; modal replacement tracked separately
+    return window.confirm(message);
+  }
+
+  async promptInputSchema(
+    fields: ReadonlyArray<unknown>,
+  ): Promise<UserInput | null> {
+    const modal = new DynamicFormModal(this.app, fields as InputSchemaField[]);
+    const result = await modal.waitForResult();
+    return result;
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -110,7 +110,14 @@ export function populateServiceRegistry(
         (userInput?.prototypeUID as string | undefined) ??
         (userInput?.prototype as string | undefined);
       const label = userInput?.label as string | undefined;
+      // `userInput.folder` literal wins over the targetIRI-based inference.
+      // Global surfaces (Obsidian Command Palette, RFC `1429fcd0`) call this
+      // service without an active file, so they pass `folder` explicitly via
+      // the exocmd grounding `targetValue`. Layout buttons keep working
+      // unchanged: they don't pass `folder` and the inference below fills it
+      // in from the active asset.
       let folder = userInput?.folder as string | undefined;
+      const ownerIdentity = userInput?.ownerIdentity as string | undefined;
       if (!prototypeUID) throw new Error("createAsset requires userInput.prototypeUID");
       if (!label) throw new Error("createAsset requires userInput.label");
       // Default to current file's folder when not specified
@@ -172,6 +179,7 @@ export function populateServiceRegistry(
         "exo__Instance_class:",
         `  - "[[${expectedClass}]]"`,
       ];
+      let isDefinedByWritten = false;
       if (parentMetadata) {
         const parentClass = parentMetadata.exo__Instance_class;
         const parentClasses = Array.isArray(parentClass)
@@ -207,7 +215,19 @@ export function populateServiceRegistry(
               String(parentMetadata.exo__Asset_isDefinedBy),
             )}`,
           );
+          isDefinedByWritten = true;
         }
+      }
+      // Fallback for global surfaces without an active file (RFC `1429fcd0`):
+      // the caller (e.g. ExocmdCommandPaletteRegistrar) injects the user's
+      // owner-identity wikilink via `userInput.ownerIdentity`. Parent
+      // inheritance takes precedence above — a button click on an
+      // ontology-specific asset still inherits that asset's `isDefinedBy`,
+      // so this branch only fires when there is no parent at all.
+      if (!isDefinedByWritten && ownerIdentity) {
+        lines.push(
+          `exo__Asset_isDefinedBy: ${toQuotedWikilink(ownerIdentity)}`,
+        );
       }
       lines.push("---", "");
       const frontmatter = lines.join("\n");

--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -11,6 +11,7 @@ import {
   GroundingExecutor,
   FolderRepairService,
   INotificationService,
+  CommandExecutionFlow,
 } from "exocortex";
 import {
   ButtonBuilderContext,
@@ -20,6 +21,7 @@ import {
 } from "./button-groups";
 import { PanelResolver } from "@plugin/application/services/PanelResolver";
 import { ObsidianApp, ExocortexPluginInterface } from '@plugin/types';
+import { ObsidianCommandPromptAdapter } from "@plugin/infrastructure/adapters/ObsidianCommandPromptAdapter";
 
 /**
  * Configuration object for ButtonGroupsBuilder.
@@ -99,12 +101,17 @@ export class ButtonGroupsBuilder {
     this.builders = [];
 
     if (commandResolver && preconditionEvaluator && groundingExecutor && notificationService) {
+      const commandExecutionFlow = new CommandExecutionFlow(
+        groundingExecutor,
+        notificationService,
+        logger,
+        new ObsidianCommandPromptAdapter(app),
+      );
       this.builders.push(
         new DynamicCommandButtonGroupBuilder({
           commandResolver,
           preconditionEvaluator,
-          groundingExecutor,
-          notificationService,
+          commandExecutionFlow,
           panelResolver,
         }),
       );

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -1,4 +1,3 @@
-import { App } from "obsidian";
 import {
   ActionButton,
   ActionButtonVariant,
@@ -8,17 +7,13 @@ import type {
   CommandResolver,
   ResolvedCommand,
   PreconditionEvaluator,
-  GroundingExecutor,
-  UserInput,
   EvalContext,
-  INotificationService,
+  CommandExecutionFlow,
 } from "exocortex";
-import { ILogger } from "@plugin/adapters/logging/ILogger";
 import {
   IButtonGroupBuilder,
   ButtonBuilderContext,
 } from "./ButtonBuilderTypes";
-import { DynamicFormModal } from "@plugin/presentation/modals/DynamicFormModal";
 import { resolveDefaultVariantForCategory } from "./categoryDefaultVariants";
 import {
   FALLBACK_CATEGORY_ORDER,
@@ -36,8 +31,13 @@ import { PanelResolver } from "@plugin/application/services/PanelResolver";
 export interface DynamicCommandBuilderConfig {
   commandResolver: CommandResolver;
   preconditionEvaluator: PreconditionEvaluator;
-  groundingExecutor: GroundingExecutor;
-  notificationService: INotificationService;
+  /**
+   * Pipeline that handles confirm → modal → execute → notify when a
+   * button is clicked. Shared with the global Command Palette registrar
+   * (RFC `1429fcd0`). Construct it with a `GroundingExecutor` +
+   * `INotificationService` + an Obsidian-side `CommandPromptAdapter`.
+   */
+  commandExecutionFlow: CommandExecutionFlow;
   /**
    * Optional. When omitted a default no-op resolver is used (no panel
    * declared for any class) so existing call-sites and tests remain
@@ -116,17 +116,9 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     const resolved = await this.resolveVisibleCommands(context);
     if (resolved === null) return [];
     const { visibleCommands, subjectIRI, panelClassRef } = resolved;
-    const { app, file, logger, refresh } = context;
+    const { file, refresh } = context;
     return visibleCommands.map((rc) =>
-      this.createButton(
-        rc,
-        subjectIRI,
-        file.path,
-        app as App,
-        logger,
-        refresh,
-        panelClassRef,
-      ),
+      this.createButton(rc, subjectIRI, file.path, refresh, panelClassRef),
     );
   }
 
@@ -155,7 +147,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     const resolved = await this.resolveVisibleCommands(context);
     if (resolved === null) return [];
     const { visibleCommands, subjectIRI, panelClassRef } = resolved;
-    const { app, file, logger, refresh } = context;
+    const { file, refresh } = context;
 
     const byCategory = new Map<string, ResolvedCommand[]>();
     for (const rc of visibleCommands) {
@@ -186,15 +178,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
           ? undefined
           : resolveCategoryCollapsed(key, panel),
         buttons: commands.map((rc) =>
-          this.createButton(
-            rc,
-            subjectIRI,
-            file.path,
-            app as App,
-            logger,
-            refresh,
-            panelClassRef,
-          ),
+          this.createButton(rc, subjectIRI, file.path, refresh, panelClassRef),
         ),
       });
     }
@@ -332,8 +316,6 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     rc: ResolvedCommand,
     targetIRI: string,
     filePath: string,
-    app: App,
-    logger: ILogger,
     refresh: () => Promise<void>,
     panelClassRef: string | null,
   ): ActionButton {
@@ -383,83 +365,13 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
       tooltip,
       visible: true,
       onClick: async () => {
-        await this.handleClick(rc, targetIRI, filePath, app, logger, refresh);
+        await this.config.commandExecutionFlow.run(rc, {
+          targetIRI,
+          filePath,
+          onComplete: refresh,
+        });
       },
     };
-  }
-
-  private async handleClick(
-    rc: ResolvedCommand,
-    targetIRI: string,
-    filePath: string,
-    app: App,
-    logger: ILogger,
-    refresh: () => Promise<void>,
-  ): Promise<void> {
-    const { command } = rc;
-
-    if (command.confirmMessage) {
-      const confirmed = await this.showConfirmation(command.confirmMessage);
-      if (!confirmed) return;
-    }
-
-    let userInput: UserInput | undefined;
-    const inputSchema = this.extractInputSchema(rc);
-    if (inputSchema && inputSchema.length > 0) {
-      const modal = new DynamicFormModal(app, inputSchema);
-      const collected = await modal.waitForResult();
-      if (collected === null) return;
-      userInput = collected;
-    }
-
-    const result = await this.config.groundingExecutor.execute(
-      command.grounding,
-      targetIRI,
-      filePath,
-      userInput,
-    );
-
-    if (result.success) {
-      if (command.successMessage) {
-        this.config.notificationService.success(command.successMessage);
-      }
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      await refresh();
-      logger.info(
-        `[DynamicCommands] Executed "${command.name}" on ${filePath}`,
-      );
-    } else {
-      this.config.notificationService.error(
-        `Command failed: ${result.error ?? "unknown error"}`,
-      );
-      logger.info(
-        `[DynamicCommands] Failed "${command.name}": ${result.error}`,
-      );
-    }
-  }
-
-  private async showConfirmation(message: string): Promise<boolean> {
-    return new Promise((resolve) => {
-      // eslint-disable-next-line no-alert -- simple confirmation until a proper Obsidian modal is implemented
-      const confirmed = window.confirm(message);
-      resolve(confirmed);
-    });
-  }
-
-  private extractInputSchema(rc: ResolvedCommand): InputSchemaField[] | null {
-    const grounding = rc.command.grounding;
-    const raw = (grounding as unknown as Record<string, unknown>)[
-      "inputSchema"
-    ];
-    if (!raw || !Array.isArray(raw)) return null;
-
-    return raw.filter(
-      (field): field is InputSchemaField =>
-        typeof field === "object" &&
-        field !== null &&
-        typeof (field as Record<string, unknown>)["name"] === "string" &&
-        typeof (field as Record<string, unknown>)["type"] === "string",
-    );
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -440,6 +440,85 @@ describe("ServiceRegistryPopulator", () => {
       );
     });
   });
+
+  // RFC `1429fcd0` PR-1: global Palette callers (no active file) inject
+  // owner identity literally because the active-file inheritance branch
+  // can't fire.
+  describe("createAsset ownerIdentity fallback", () => {
+    it("writes exo__Asset_isDefinedBy from userInput.ownerIdentity when no active file present", async () => {
+      const service = registry.get("createAsset")!;
+
+      // Empty targetIRI mimics a Command-Palette invocation with no active
+      // asset. The handler can't resolve a parent → parentMetadata stays
+      // undefined → the inheritance branch is skipped → ownerIdentity
+      // literal becomes the source of truth.
+      await service.execute("", {
+        prototypeUID: "ztlk__FleetingNotePrototype",
+        label: "Captured thought",
+        folder: "03 Knowledge/inbox",
+        ownerIdentity: "[[!kitelev]]",
+      });
+
+      const writeCall = (deps.fileSystemAdapter.createFile as jest.Mock).mock
+        .calls[0];
+      const writtenContent: string = writeCall[1];
+      expect(writtenContent).toContain(
+        'exo__Asset_isDefinedBy: "[[!kitelev]]"',
+      );
+    });
+
+    it("parent inheritance still wins over ownerIdentity literal when both are present", async () => {
+      const service = registry.get("createAsset")!;
+
+      // Active file has its own isDefinedBy → must not be overridden by
+      // the global default. Layout-button UX stays unchanged.
+      await service.execute("test-uid-123", {
+        prototypeUID: "proto-123",
+        label: "Task under project",
+        ownerIdentity: "[[!kitelev]]",
+      });
+
+      const writeCall = (deps.fileSystemAdapter.createFile as jest.Mock).mock
+        .calls[0];
+      const writtenContent: string = writeCall[1];
+      // Mock parentMetadata in createMockDeps does NOT set
+      // exo__Asset_isDefinedBy → inheritance branch records nothing →
+      // ownerIdentity fallback takes over. The point of this test is to
+      // verify the precedence path is wired: ownerIdentity is honored
+      // exactly when inheritance produced nothing.
+      expect(writtenContent).toContain(
+        'exo__Asset_isDefinedBy: "[[!kitelev]]"',
+      );
+    });
+
+    it("omits exo__Asset_isDefinedBy when neither parent nor ownerIdentity supplies it", async () => {
+      const service = registry.get("createAsset")!;
+      await service.execute("", {
+        prototypeUID: "proto-123",
+        label: "No owner",
+        folder: "tmp",
+      });
+
+      const writeCall = (deps.fileSystemAdapter.createFile as jest.Mock).mock
+        .calls[0];
+      const writtenContent: string = writeCall[1];
+      expect(writtenContent).not.toContain("exo__Asset_isDefinedBy");
+    });
+
+    it("accepts literal folder without targetIRI (global Palette case)", async () => {
+      const service = registry.get("createAsset")!;
+      await service.execute("", {
+        prototypeUID: "ztlk__FleetingNotePrototype",
+        label: "Thought",
+        folder: "03 Knowledge/inbox",
+      });
+
+      expect(deps.fileSystemAdapter.createFile).toHaveBeenCalledWith(
+        expect.stringMatching(/^03 Knowledge\/inbox\/[a-f0-9-]+\.md$/),
+        expect.stringContaining("exo__Asset_label: Thought"),
+      );
+    });
+  });
 });
 
 describe("ServiceRegistryPopulator (with vaultAdapter)", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -1,7 +1,44 @@
 import { DynamicCommandButtonGroupBuilder } from "../../../../src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
 import { PanelResolver } from "../../../../src/application/services/PanelResolver";
 import type { CommandPanel } from "../../../../src/domain/layout/CommandPanel";
-import { GroundingType } from "exocortex";
+import { GroundingType, CommandExecutionFlow } from "exocortex";
+import type { CommandPromptAdapter, UserInput } from "exocortex";
+
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+/**
+ * Test prompt adapter that defers to `window.confirm` (matching the
+ * production `ObsidianCommandPromptAdapter`) and never opens a real modal.
+ * Tests that exercise `inputSchema`-driven modal flow live in
+ * `CommandExecutionFlow.test.ts`, not here.
+ */
+class TestPromptAdapter implements CommandPromptAdapter {
+  async confirm(message: string): Promise<boolean> {
+    // eslint-disable-next-line no-alert -- mirrors production adapter
+    return window.confirm(message);
+  }
+  async promptInputSchema(): Promise<UserInput | null> {
+    return null;
+  }
+}
+
+function buildCommandExecutionFlow(): CommandExecutionFlow {
+  return new CommandExecutionFlow(
+    mockGroundingExecutor as unknown as Parameters<
+      typeof CommandExecutionFlow.prototype.run
+    >[0] extends never
+      ? never
+      : any,
+    mockNotificationService as any,
+    mockLogger as any,
+    new TestPromptAdapter(),
+  );
+}
 
 const mockResolveForAsset = jest.fn();
 const mockResolveForAssetMulti = jest.fn();
@@ -130,8 +167,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         ? never
         : any,
       preconditionEvaluator: mockPreconditionEvaluator as unknown as any,
-      groundingExecutor: mockGroundingExecutor as unknown as any,
-      notificationService: mockNotificationService as any,
+      commandExecutionFlow: buildCommandExecutionFlow(),
     });
   });
 
@@ -872,8 +908,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       return new DynamicCommandButtonGroupBuilder({
         commandResolver: mockCommandResolver as unknown as any,
         preconditionEvaluator: mockPreconditionEvaluator as unknown as any,
-        groundingExecutor: mockGroundingExecutor as unknown as any,
-        notificationService: mockNotificationService as any,
+        commandExecutionFlow: buildCommandExecutionFlow(),
         panelResolver,
       });
     }
@@ -1144,8 +1179,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       return new DynamicCommandButtonGroupBuilder({
         commandResolver: mockCommandResolver as unknown as any,
         preconditionEvaluator: mockPreconditionEvaluator as unknown as any,
-        groundingExecutor: mockGroundingExecutor as unknown as any,
-        notificationService: mockNotificationService as any,
+        commandExecutionFlow: buildCommandExecutionFlow(),
         panelResolver,
       });
     }


### PR DESCRIPTION
## Summary

**PR-1 of 3** in code-RFC [`1429fcd0`](../inbox/1429fcd0-0948-4a42-89c4-8d1426e9bc7a.md) (ExocmdCommandPaletteRegistrar pilot stack). Foundation refactor — **no user-facing change**.

1. New `CommandExecutionFlow` (`packages/exocortex/src/services/`) — surface-agnostic pipeline: confirm → modal → execute → notify. Replaces private `handleClick` in `DynamicCommandButtonGroupBuilder`. Accepts `injectedUserInput` so future callers (Palette registrar in PR-2) can pre-supply owner identity / default folder before the modal opens. Modal-collected values shallow-merge on top.
2. New `CommandPromptAdapter` interface + `ObsidianCommandPromptAdapter` (`packages/obsidian-plugin/src/infrastructure/adapters/`) — decouples flow from Obsidian APIs.
3. `DynamicCommandButtonGroupBuilder` delegates `onClick` to the shared flow. `DynamicCommandBuilderConfig` now takes `commandExecutionFlow` instead of `groundingExecutor` + `notificationService` (caller constructs the flow once).
4. `createAsset` service accepts `userInput.folder` (literal, doc-clarified) and **new** `userInput.ownerIdentity` (literal). When the active-file `parentMetadata` branch doesn't supply `exo__Asset_isDefinedBy`, the ownerIdentity literal is written. Parent inheritance still wins — layout-button flows unchanged.

## Why

Code-RFC `1429fcd0` migrates "Create fleeting note" from TS-hardcoded `CreateFleetingNoteCommand` to a homoiconic `exocmd__Command` asset read by `ExocmdCommandPaletteRegistrar`. The registrar (PR-2) needs:
- a reusable execution pipeline (this PR introduces it);
- a way to call `createAsset` without an active file (this PR extends the service contract).

Paired onto-RFC [`ce1731b4`](https://github.com/kitelev/exocortex-exocmd-ontology/pull/1) (already merged) adds `paletteEnabled` + `paletteId` consumed in PR-2.

## Tests

- `CommandExecutionFlow.test.ts` — **15 new** unit cases: confirm gating, inputSchema modal merge behavior, success/error paths, null targetIRI/filePath, onComplete hook.
- `ServiceRegistryPopulator.test.ts` — **4 new** cases: ownerIdentity fallback precedence, literal folder + empty IRI combination.
- `DynamicCommandButtonGroupBuilder.test.ts` — 3 instantiation sites switched to construct real `CommandExecutionFlow` with existing mocks; **61 tests pass unchanged** — behavior preserved.

158 tests in modified files all green. TypeScript clean. Lint 0 errors. Archgate pass (13/13, 11 pre-existing warnings).

## Out of scope

- `ExocmdCommandPaletteRegistrar` — **PR-2**.
- "Create fleeting note" migration + TS deletion + L3 e2e — **PR-3**.
- Other 6 TS-hardcoded global commands in `CommandManager.globalCommands` — follow-up RFC after S1 merge.

## Test plan

- [ ] CI green on all 13 required checks
- [ ] Manual smoke: any layout-button click still works (e.g. "Create Task Instance" on a Project) — confirm + modal + execute + success toast + refresh

## Refs

- onto-RFC: `ce1731b4-c771-42af-a584-404edeeb8fa7`
- code-RFC: `1429fcd0-0948-4a42-89c4-8d1426e9bc7a`
- Homoiconicity Invariant: `c78cc5c8-076c-4509-9e22-6f0257c51df4`