### PR TITLE
feat(commands): register paletteEnabled exocmd commands in Obsidian Command Palette

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -240,6 +240,87 @@ export class CommandResolver {
   }
 
   /**
+   * Find all commands that opt-in to Obsidian Command Palette registration via
+   * `exocmd__Command_paletteEnabled: true`. Used by
+   * `ExocmdCommandPaletteRegistrar` to surface global commands at plugin load.
+   *
+   * The palette id used for `plugin.addCommand({ id })` is derived per command:
+   *   1. `exocmd__Command_paletteId` literal (if present)
+   *   2. `exocmd__Command_cliName` literal (fallback — shared CLI surface)
+   *   3. `exo__Asset_uid` (last-resort, always present)
+   *
+   * Duplicate ids across the vault are dropped after the first occurrence and
+   * warned through the logger — first match wins, deterministically ordered by
+   * triple store iteration order.
+   *
+   * Source: code-RFC `1429fcd0-0948-4a42-89c4-8d1426e9bc7a` (PR-2).
+   */
+  async findPaletteEnabledCommands(): Promise<
+    Array<{ command: CommandDefinition; paletteId: string }>
+  > {
+    const typeTriples = await this.tripleStore.match(
+      undefined,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("Command"),
+    );
+
+    const results: Array<{ command: CommandDefinition; paletteId: string }> =
+      [];
+    const seenIds = new Set<string>();
+
+    for (const triple of typeTriples) {
+      const subject = triple.subject as IRI;
+
+      const enabledRaw = await this.getLiteralValue(
+        subject,
+        Namespace.EXOCMD.term("Command_paletteEnabled"),
+      );
+      if (enabledRaw?.toLowerCase() !== "true") continue;
+
+      const uid = await this.getLiteralValue(
+        subject,
+        Namespace.EXO.term("Asset_uid"),
+      );
+      if (!uid) {
+        this.logger.warn(
+          `[CommandResolver] paletteEnabled command at ${subject.value} has no exo__Asset_uid — skipped`,
+        );
+        continue;
+      }
+
+      const command = await this.loadCommand(uid);
+      if (!command) {
+        this.logger.warn(
+          `[CommandResolver] paletteEnabled command ${uid} could not be loaded (missing grounding?) — skipped`,
+        );
+        continue;
+      }
+
+      const explicitPaletteId = await this.getLiteralValue(
+        subject,
+        Namespace.EXOCMD.term("Command_paletteId"),
+      );
+      const cliName = await this.getLiteralValue(
+        subject,
+        Namespace.EXOCMD.term("Command_cliName"),
+      );
+      const paletteId = explicitPaletteId ?? cliName ?? uid;
+
+      if (seenIds.has(paletteId)) {
+        this.logger.warn(
+          `[CommandResolver] duplicate paletteId "${paletteId}" — first registration wins, dropping ${uid}`,
+        );
+        continue;
+      }
+      seenIds.add(paletteId);
+
+      results.push({ command, paletteId });
+    }
+
+    return results;
+  }
+
+  /**
    * Invalidate all cached command resolutions.
    * Call when vault files change.
    */

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -1144,4 +1144,245 @@ describe("CommandResolver", () => {
       expect(cmd!.labelTemplate).toBe("Dynamic ({SELECT ?x WHERE { ?s ?p ?o }})");
     });
   });
+
+  describe("findPaletteEnabledCommands (RFC 1429fcd0 PR-2)", () => {
+    async function setEnabled(
+      uid: string,
+      enabled: "true" | "false" | string,
+    ): Promise<void> {
+      await store.add(
+        new Triple(
+          new IRI(`obsidian://vault/${uid}.md`),
+          Namespace.EXOCMD.term("Command_paletteEnabled"),
+          new Literal(enabled),
+        ),
+      );
+    }
+    async function setLiteral(
+      uid: string,
+      predicate: IRI,
+      value: string,
+    ): Promise<void> {
+      await store.add(
+        new Triple(
+          new IRI(`obsidian://vault/${uid}.md`),
+          predicate,
+          new Literal(value),
+        ),
+      );
+    }
+
+    it("returns only commands marked paletteEnabled=true", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-p1",
+        label: "G",
+        type: "property_set",
+        targetProperty: "x",
+        targetValue: "y",
+      });
+      await addGroundingAsset(store, {
+        uid: "gnd-p2",
+        label: "G",
+        type: "property_set",
+        targetProperty: "x",
+        targetValue: "y",
+      });
+      await addGroundingAsset(store, {
+        uid: "gnd-p3",
+        label: "G",
+        type: "property_set",
+        targetProperty: "x",
+        targetValue: "y",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-enabled",
+        label: "Enabled cmd",
+        groundingRef: "gnd-p1",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-disabled",
+        label: "Disabled cmd",
+        groundingRef: "gnd-p2",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-absent",
+        label: "No flag cmd",
+        groundingRef: "gnd-p3",
+      });
+      await setEnabled("cmd-enabled", "true");
+      await setEnabled("cmd-disabled", "false");
+      // cmd-absent has no Command_paletteEnabled triple at all
+
+      const found = await resolver.findPaletteEnabledCommands();
+      expect(found).toHaveLength(1);
+      expect(found[0].command.id).toBe("cmd-enabled");
+    });
+
+    it("derives paletteId from Command_paletteId when present", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-id1",
+        label: "G",
+        type: "property_set",
+        targetProperty: "x",
+        targetValue: "y",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-id1",
+        label: "Foo",
+        groundingRef: "gnd-id1",
+      });
+      await setEnabled("cmd-id1", "true");
+      await setLiteral(
+        "cmd-id1",
+        Namespace.EXOCMD.term("Command_paletteId"),
+        "stable-id",
+      );
+
+      const found = await resolver.findPaletteEnabledCommands();
+      expect(found[0].paletteId).toBe("stable-id");
+    });
+
+    it("falls back to Command_cliName when paletteId absent", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-id2",
+        label: "G",
+        type: "property_set",
+        targetProperty: "x",
+        targetValue: "y",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-id2",
+        label: "Foo",
+        groundingRef: "gnd-id2",
+      });
+      await setEnabled("cmd-id2", "true");
+      await setLiteral(
+        "cmd-id2",
+        Namespace.EXOCMD.term("Command_cliName"),
+        "create-note",
+      );
+
+      const found = await resolver.findPaletteEnabledCommands();
+      expect(found[0].paletteId).toBe("create-note");
+    });
+
+    it("falls back to Asset_uid when neither paletteId nor cliName present", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-id3",
+        label: "G",
+        type: "property_set",
+        targetProperty: "x",
+        targetValue: "y",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-id3",
+        label: "Foo",
+        groundingRef: "gnd-id3",
+      });
+      await setEnabled("cmd-id3", "true");
+
+      const found = await resolver.findPaletteEnabledCommands();
+      expect(found[0].paletteId).toBe("cmd-id3");
+    });
+
+    it("drops duplicate paletteIds — first wins, logs warning", async () => {
+      const warn = jest.fn();
+      const debug = jest.fn();
+      const info = jest.fn();
+      const error = jest.fn();
+      resolver = new CommandResolver(store, { warn, debug, info, error });
+
+      await addGroundingAsset(store, {
+        uid: "gnd-dup1",
+        label: "G",
+        type: "property_set",
+        targetProperty: "x",
+        targetValue: "y",
+      });
+      await addGroundingAsset(store, {
+        uid: "gnd-dup2",
+        label: "G",
+        type: "property_set",
+        targetProperty: "x",
+        targetValue: "y",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-dup-a",
+        label: "A",
+        groundingRef: "gnd-dup1",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-dup-b",
+        label: "B",
+        groundingRef: "gnd-dup2",
+      });
+      await setEnabled("cmd-dup-a", "true");
+      await setEnabled("cmd-dup-b", "true");
+      await setLiteral(
+        "cmd-dup-a",
+        Namespace.EXOCMD.term("Command_paletteId"),
+        "collide",
+      );
+      await setLiteral(
+        "cmd-dup-b",
+        Namespace.EXOCMD.term("Command_paletteId"),
+        "collide",
+      );
+
+      const found = await resolver.findPaletteEnabledCommands();
+      expect(found).toHaveLength(1);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("duplicate paletteId"),
+      );
+    });
+
+    it("treats string 'True' case-insensitively (resilient to YAML quoting)", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-case",
+        label: "G",
+        type: "property_set",
+        targetProperty: "x",
+        targetValue: "y",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-case",
+        label: "Foo",
+        groundingRef: "gnd-case",
+      });
+      await setEnabled("cmd-case", "True");
+
+      const found = await resolver.findPaletteEnabledCommands();
+      expect(found).toHaveLength(1);
+    });
+
+    it("skips commands without grounding (loadCommand returns null)", async () => {
+      // Command type triple exists but no grounding link → loadCommand returns null.
+      const subject = new IRI("obsidian://vault/cmd-no-grounding.md");
+      await store.addAll([
+        new Triple(
+          subject,
+          Namespace.RDF.term("type"),
+          Namespace.EXOCMD.term("Command"),
+        ),
+        new Triple(
+          subject,
+          Namespace.EXO.term("Asset_uid"),
+          new Literal("cmd-no-grounding"),
+        ),
+        new Triple(
+          subject,
+          Namespace.EXO.term("Asset_label"),
+          new Literal("No grounding"),
+        ),
+        new Triple(
+          subject,
+          Namespace.EXOCMD.term("Command_paletteEnabled"),
+          new Literal("true"),
+        ),
+      ]);
+
+      const found = await resolver.findPaletteEnabledCommands();
+      expect(found).toHaveLength(0);
+    });
+  });
 });

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -77,6 +77,13 @@ import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
 import { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService";
 import { ObsidianFileSystemAdapter } from "./adapters/ObsidianFileSystemAdapter";
 import { populateServiceRegistry } from "./infrastructure/services/ServiceRegistryPopulator";
+import { ExocmdCommandPaletteRegistrar } from "./application/services/ExocmdCommandPaletteRegistrar";
+import { ObsidianCommandPromptAdapter } from "./infrastructure/adapters/ObsidianCommandPromptAdapter";
+import {
+  CommandExecutionFlow,
+  DI_TOKENS,
+  type IVaultSettings,
+} from "exocortex";
 
 /**
  * Exocortex Plugin - Automatic layout rendering
@@ -480,6 +487,36 @@ export default class ExocortexPlugin extends Plugin {
       this.commandManager.registerAllCommands(this, () =>
         this.autoRenderLayout(),
       );
+
+      // RFC 1429fcd0 PR-2: register vault-described palette-enabled exocmd
+      // commands as Obsidian Command Palette entries. Runs synchronously after
+      // CommandManager so it sees the same plugin command surface; SPARQL
+      // resolution + plugin.addCommand are both cheap enough for onload.
+      // Known limitation: Obsidian's public API has no `removeCommand`, so
+      // newly-added paletteEnabled assets only surface after plugin reload.
+      try {
+        const vaultSettings = container.resolve<IVaultSettings>(
+          DI_TOKENS.IVaultSettings,
+        );
+        const paletteFlow = new CommandExecutionFlow(
+          this.groundingExecutor,
+          new ObsidianNotificationService(),
+          this.logger,
+          new ObsidianCommandPromptAdapter(this.app),
+        );
+        await new ExocmdCommandPaletteRegistrar(
+          this,
+          this.commandResolver,
+          paletteFlow,
+          vaultSettings,
+          this.logger,
+        ).init();
+      } catch (error) {
+        this.logger.error(
+          "[ExocortexPlugin] ExocmdCommandPaletteRegistrar init failed",
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
 
       // GTD Capture: one-click fleeting note to inbox.
       // Delegates to the existing `create-fleeting-note` command so the

--- a/packages/obsidian-plugin/src/application/services/ExocmdCommandPaletteRegistrar.ts
+++ b/packages/obsidian-plugin/src/application/services/ExocmdCommandPaletteRegistrar.ts
@@ -1,0 +1,84 @@
+import type { CommandResolver, CommandExecutionFlow } from "exocortex";
+import type { IVaultSettings } from "exocortex";
+import type { ExocortexPluginInterface } from "@plugin/types";
+import type { ILogger } from "@plugin/adapters/logging/ILogger";
+
+/**
+ * Registers vault-described `exocmd__Command` assets that opt-in via
+ * `exocmd__Command_paletteEnabled: true` as global Obsidian Command Palette
+ * entries. Wires each command's callback to {@link CommandExecutionFlow.run}
+ * with `targetIRI`/`filePath` = null (Palette has no active file) and
+ * pre-injects the user's owner-identity wikilink so that `createAsset`-style
+ * groundings can write `exo__Asset_isDefinedBy` without parent inheritance.
+ *
+ * Source: code-RFC `1429fcd0-0948-4a42-89c4-8d1426e9bc7a` (PR-2).
+ *
+ * Known limitation: Obsidian's public API does NOT expose `removeCommand`,
+ * so newly-added (or removed) `paletteEnabled` assets only surface after a
+ * plugin reload (Ctrl-Shift-R). `init()` is therefore safe to call exactly
+ * once per plugin load.
+ */
+export class ExocmdCommandPaletteRegistrar {
+  constructor(
+    private readonly plugin: ExocortexPluginInterface,
+    private readonly commandResolver: CommandResolver,
+    private readonly commandExecutionFlow: CommandExecutionFlow,
+    private readonly vaultSettings: IVaultSettings,
+    private readonly logger: ILogger,
+  ) {}
+
+  async init(): Promise<void> {
+    let entries: Awaited<
+      ReturnType<CommandResolver["findPaletteEnabledCommands"]>
+    >;
+    try {
+      entries = await this.commandResolver.findPaletteEnabledCommands();
+    } catch (error) {
+      this.logger.error(
+        "[ExocmdCommandPaletteRegistrar] Failed to resolve palette-enabled commands",
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      return;
+    }
+
+    for (const { command, paletteId } of entries) {
+      // Capture owner identity at registration time — re-reading on every
+      // click would be an unexpected coupling. Plugin reload reflects setting
+      // changes (same window as command list refresh, see "Known limitation"
+      // above).
+      const ownerIdentity = this.vaultSettings.getOwnerIdentity();
+
+      this.plugin.addCommand({
+        id: paletteId,
+        name: command.name,
+        callback: () => {
+          void this.commandExecutionFlow.run(
+            { command, binding: SYNTHETIC_PALETTE_BINDING },
+            {
+              targetIRI: null,
+              filePath: null,
+              injectedUserInput: { ownerIdentity },
+            },
+          );
+        },
+      });
+
+      this.logger.info(
+        `[ExocmdCommandPaletteRegistrar] Registered "${command.name}" as palette command "${paletteId}"`,
+      );
+    }
+  }
+}
+
+/**
+ * Placeholder `CommandBindingDefinition` for palette-surface commands which,
+ * unlike inline-button commands, have no `CommandBinding` asset. The flow
+ * does not read `rc.binding` for the palette code path; the field is present
+ * only to satisfy the `ResolvedCommand` shape.
+ */
+const SYNTHETIC_PALETTE_BINDING = {
+  id: "synthetic:palette",
+  label: "synthetic:palette",
+  commandRef: "synthetic:palette",
+  targetClass: "synthetic:palette",
+} as const;

--- a/packages/obsidian-plugin/tests/unit/application/services/ExocmdCommandPaletteRegistrar.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/services/ExocmdCommandPaletteRegistrar.test.ts
@@ -1,0 +1,176 @@
+import { ExocmdCommandPaletteRegistrar } from "../../../../src/application/services/ExocmdCommandPaletteRegistrar";
+import type {
+  CommandResolver,
+  CommandExecutionFlow,
+  IVaultSettings,
+  CommandDefinition,
+} from "exocortex";
+import type { ExocortexPluginInterface } from "../../../../src/types";
+import type { ILogger } from "../../../../src/adapters/logging/ILogger";
+
+function makeCommand(
+  overrides?: Partial<CommandDefinition>,
+): CommandDefinition {
+  return {
+    id: "cmd-uid",
+    name: "Test command",
+    grounding: {
+      id: "g1",
+      label: "g1",
+      type: "property_set" as never,
+      targetProperty: "ems__Effort_status",
+      targetValue: "x",
+    } as never,
+    ...overrides,
+  };
+}
+
+interface Harness {
+  plugin: {
+    addCommand: jest.Mock;
+  };
+  commandResolver: {
+    findPaletteEnabledCommands: jest.Mock;
+  };
+  commandExecutionFlow: {
+    run: jest.Mock;
+  };
+  vaultSettings: { getOwnerIdentity: jest.Mock } & Partial<IVaultSettings>;
+  logger: jest.Mocked<ILogger>;
+  registrar: ExocmdCommandPaletteRegistrar;
+}
+
+function makeHarness(
+  entries: Array<{ command: CommandDefinition; paletteId: string }>,
+  ownerIdentity = '"[[!kitelev]]"',
+): Harness {
+  const plugin = { addCommand: jest.fn() };
+  const commandResolver = {
+    findPaletteEnabledCommands: jest.fn().mockResolvedValue(entries),
+  };
+  const commandExecutionFlow = { run: jest.fn().mockResolvedValue(undefined) };
+  const vaultSettings = {
+    getOwnerIdentity: jest.fn().mockReturnValue(ownerIdentity),
+  };
+  const logger: jest.Mocked<ILogger> = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const registrar = new ExocmdCommandPaletteRegistrar(
+    plugin as unknown as ExocortexPluginInterface,
+    commandResolver as unknown as CommandResolver,
+    commandExecutionFlow as unknown as CommandExecutionFlow,
+    vaultSettings as unknown as IVaultSettings,
+    logger,
+  );
+
+  return {
+    plugin,
+    commandResolver,
+    commandExecutionFlow,
+    vaultSettings,
+    logger,
+    registrar,
+  };
+}
+
+describe("ExocmdCommandPaletteRegistrar", () => {
+  describe("init()", () => {
+    it("registers nothing when no palette-enabled commands found", async () => {
+      const h = makeHarness([]);
+      await h.registrar.init();
+      expect(h.plugin.addCommand).not.toHaveBeenCalled();
+    });
+
+    it("registers one Obsidian command per resolved entry", async () => {
+      const h = makeHarness([
+        {
+          command: makeCommand({ name: "Create fleeting note" }),
+          paletteId: "create-fleeting-note",
+        },
+        {
+          command: makeCommand({ id: "cmd-2", name: "Other" }),
+          paletteId: "other-id",
+        },
+      ]);
+      await h.registrar.init();
+      expect(h.plugin.addCommand).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses paletteId from resolver as Obsidian command id", async () => {
+      const h = makeHarness([
+        {
+          command: makeCommand({ name: "Foo" }),
+          paletteId: "stable-hotkey-id",
+        },
+      ]);
+      await h.registrar.init();
+      const arg = h.plugin.addCommand.mock.calls[0][0];
+      expect(arg.id).toBe("stable-hotkey-id");
+      expect(arg.name).toBe("Foo");
+      expect(typeof arg.callback).toBe("function");
+    });
+
+    it("callback invokes commandExecutionFlow.run with null targetIRI/filePath + injected ownerIdentity", async () => {
+      const cmd = makeCommand({ name: "Create" });
+      const h = makeHarness(
+        [{ command: cmd, paletteId: "create" }],
+        '"[[!alice]]"',
+      );
+      await h.registrar.init();
+
+      const arg = h.plugin.addCommand.mock.calls[0][0];
+      await arg.callback();
+
+      expect(h.commandExecutionFlow.run).toHaveBeenCalledTimes(1);
+      const [rc, ctx] = h.commandExecutionFlow.run.mock.calls[0];
+      expect(rc.command).toBe(cmd);
+      expect(ctx.targetIRI).toBeNull();
+      expect(ctx.filePath).toBeNull();
+      expect(ctx.injectedUserInput).toEqual({ ownerIdentity: '"[[!alice]]"' });
+    });
+
+    it("captures owner identity at registration time (snapshot, not lazy)", async () => {
+      const h = makeHarness(
+        [{ command: makeCommand(), paletteId: "id" }],
+        "initial",
+      );
+      await h.registrar.init();
+
+      // Later setting change must NOT leak into the existing callback.
+      h.vaultSettings.getOwnerIdentity.mockReturnValue("changed");
+      const arg = h.plugin.addCommand.mock.calls[0][0];
+      await arg.callback();
+
+      const [, ctx] = h.commandExecutionFlow.run.mock.calls[0];
+      expect(ctx.injectedUserInput).toEqual({ ownerIdentity: "initial" });
+    });
+
+    it("does not throw or register anything when commandResolver fails — logs error", async () => {
+      const h = makeHarness([]);
+      h.commandResolver.findPaletteEnabledCommands.mockRejectedValue(
+        new Error("triple-store offline"),
+      );
+
+      await expect(h.registrar.init()).resolves.toBeUndefined();
+      expect(h.plugin.addCommand).not.toHaveBeenCalled();
+      expect(h.logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to resolve palette-enabled commands"),
+        expect.any(Error),
+      );
+    });
+
+    it("logs info per registered command", async () => {
+      const h = makeHarness([
+        { command: makeCommand({ name: "X" }), paletteId: "x" },
+      ]);
+      await h.registrar.init();
+      expect(h.logger.info).toHaveBeenCalledWith(
+        expect.stringMatching(/Registered "X" as palette command "x"/),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**PR-2 of 3** in code-RFC [`1429fcd0`](../inbox/1429fcd0-0948-4a42-89c4-8d1426e9bc7a.md). Bridges vault `exocmd__Command` assets to Obsidian's Command Palette.

1. **`CommandResolver.findPaletteEnabledCommands()`** — scans triple store for `exocmd:Command` subjects with `Command_paletteEnabled "true"`, returns `{ command, paletteId }`. Id derivation: `Command_paletteId` literal → `Command_cliName` literal → `exo__Asset_uid`. Duplicates after first warned + dropped.
2. **`ExocmdCommandPaletteRegistrar`** (plugin) — iterates resolver output, calls `plugin.addCommand({ id: paletteId, name, callback })`. Callback delegates to `CommandExecutionFlow.run(rc, { targetIRI: null, filePath: null, injectedUserInput: { ownerIdentity } })`. Owner identity captured at registration time (snapshot semantics).
3. **`ExocortexPlugin.onload()`** wires registrar synchronously after `CommandManager.registerAllCommands(...)`. Resolver failures swallowed + logged so palette init never blocks plugin load.

## Why

Without this PR, surfacing a global command in Palette requires a TS-hardcoded `ICommand` subclass — homoiconicity violation (RFC `c78cc5c8` Q1). After this PR, any vault asset with `exocmd__Command_paletteEnabled: true` becomes Palette-discoverable. PR-3 pilots the actual migration of "Create fleeting note" off its TS implementation.

## Tests

- **`CommandResolver.test.ts`** — 7 new cases for `findPaletteEnabledCommands`: filter by paletteEnabled, id derivation chain (3 branches), duplicate detection + warning, YAML-quoting case insensitivity, graceful skip of grounding-less commands.
- **`ExocmdCommandPaletteRegistrar.test.ts`** — 7 new cases: empty resolver result, registration count, paletteId pass-through, callback context (null IRI + injected ownerIdentity), snapshot ownerIdentity capture, resolver failure handling, info log per command.

144 tests in touched/new files all green. TypeScript clean. Lint 0 errors.

## Known Limitation

Obsidian's public API has no `removeCommand`. New `paletteEnabled: true` assets surface only after plugin reload (Ctrl-Shift-R). Documented in RFC, acceptable for S1 pilot scope.

## Out of scope

- "Create fleeting note" migration + TS deletion + L3 e2e — **PR-3**.
- Hot-reload mechanism — follow-up RFC.

## Test plan

- [ ] CI green on all required checks
- [ ] After merge, branch into PR-3 (pilot migration of `692aa011-...` asset)

## Refs

- onto-RFC: `ce1731b4-c771-42af-a584-404edeeb8fa7`
- code-RFC: `1429fcd0-0948-4a42-89c4-8d1426e9bc7a`
- Homoiconicity Invariant: `c78cc5c8-076c-4509-9e22-6f0257c51df4`
- Companion PR-1: #3143 (merged)