### PR TITLE
fix(commands): defer ExocmdCommandPaletteRegistrar until triple store is populated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exocortex-monorepo",
-  "version": "15.55.5",
+  "version": "15.55.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exocortex-monorepo",
-      "version": "15.55.5",
+      "version": "15.55.6",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exocortex-monorepo",
-  "version": "15.55.5",
+  "version": "16.6.2",
   "description": "Exocortex: A configurable UI system for Obsidian that transforms knowledge management through ontology-driven layouts and semantic capabilities",
   "main": "main.js",
   "workspaces": [


### PR DESCRIPTION
## Summary

User-visible regression in **v16.6.0** (RFC `1429fcd0` PR-2/PR-3): Cmd-P → "Create fleeting note" returned **"No commands found."** despite the vault asset `692aa011-...` having `Command_paletteEnabled: true` and CLI SPARQL on the same vault finding it correctly.

## Root cause

`ExocortexPlugin.onload()` initialized the registrar **synchronously**, but the triple store has zero triples at that point. The store is populated inside `onLayoutReady` → `sparql.query("ASK { ?s ?p ?o }")` which forces `VaultRDFIndexer.initialize()`. At onload-time that initializer hasn't run → `CommandResolver.findPaletteEnabledCommands()` matches zero subjects → registrar silently registers nothing.

## Fix

Move registrar init into a local async helper and call it inside the existing `eagerInitPromise.then(...)` chain, **after** the ASK query has forced the indexer to populate the store. Registrar now runs before `autoRenderLayout()` so the Command Palette is ready for the first user Cmd-P.

## Verification

- DevTools pre-fix: `app.commands.commands["exocortex:create-fleeting-note"]` → `undefined`.
- CLI on same vault: `npx @kitelev/exocortex-cli query "?cmd a exocmd:Command ; exocmd:Command_paletteEnabled ?palette"` → **1 result** (data is correct, only runtime indexing timing was wrong).
- Post-fix: 67 unit tests across registrar + CommandManager green.

## Why L1 didn't catch

L1 tests use `InMemoryTripleStore` pre-seeded with data — that mirrors the post-init state. The regression was an **ordering** bug at the integration layer (`onload` vs `onLayoutReady`), which L1 cannot catch by construction. Follow-up: add an L2 integration test that constructs the plugin against a real (initially empty) vault and asserts the command appears in `app.commands.commands` only after `onLayoutReady` fires.

## Refs

- RFC: `1429fcd0-0948-4a42-89c4-8d1426e9bc7a`
- PR-2: #3144 (introduced the regression)
- PR-3: #3145 (pilot migration depended on it)