### PR TITLE
fix(validator-daemon): guard DEFAULT_SOCKET_PATH against undefined process (iOS plugin load)

### DIFF
--- a/packages/exocortex/src/services/ValidatorDaemon.ts
+++ b/packages/exocortex/src/services/ValidatorDaemon.ts
@@ -16,7 +16,14 @@ export interface DaemonResponse {
   error?: string;
 }
 
-export const DEFAULT_SOCKET_PATH = `${process.env.HOME ?? process.env.USERPROFILE ?? '/tmp'}/.cache/exocortex/validator.sock`;
+// Guarded against `process` being undefined on platforms where this module
+// gets bundled into a non-Node runtime (e.g. Obsidian on iOS). The Daemon
+// itself is server-side only and never instantiated on mobile, but the
+// module's top-level evaluation must not throw when imported transitively.
+export const DEFAULT_SOCKET_PATH =
+  typeof process !== 'undefined' && process.env
+    ? `${process.env.HOME ?? process.env.USERPROFILE ?? '/tmp'}/.cache/exocortex/validator.sock`
+    : '/tmp/.cache/exocortex/validator.sock';
 
 export const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 


### PR DESCRIPTION
## Problem

Plugin fails to load on Obsidian iOS with **"failed to load plugin"** error since v15.156.0.

## Root Cause

`packages/exocortex/src/services/ValidatorDaemon.ts:19` evaluates `process.env.HOME ?? process.env.USERPROFILE ?? '/tmp'` at **module top-level**:

```ts
export const DEFAULT_SOCKET_PATH = `${process.env.HOME ?? process.env.USERPROFILE ?? '/tmp'}/.cache/exocortex/validator.sock`;
```

On Obsidian iOS the `process` global is **undefined** → `ReferenceError: process is not defined` at module evaluation → plugin crashes before `onload()`.

ValidatorDaemon is server-side only and never instantiated on mobile, but the module gets bundled transitively (re-exported from `packages/exocortex/src/index.ts:468+`) and its top-level constants evaluate at module load.

## Regression history

- v15.155.0 main.js: **no** `process.env.HOME` in bundle — works on iOS
- v15.156.0 main.js: introduces top-level `process.env.HOME ??...` — breaks iOS
- v15.155.0 and v15.155.2 main.js are **byte-identical** (md5 match) — the apparent v15.155.2 bisect hit was noise

Regression commit: **`cfd31118` (PR #3062)** — "feat(shacl): P1.9 ValidatorDaemon idle-kill + lazy-start + DaemonClient". Replaced the previous IIFE+`require('os')`/`require('path')` with a top-level template literal access to `process.env`, removing the implicit Node-only fence.

## Fix

Gate path computation behind `typeof process !== 'undefined' && process.env`, mirroring the existing defensive pattern in `LoggingService.ts:36`. Falls back to `/tmp/.cache/exocortex/validator.sock` when `process` is unavailable (the constant is irrelevant on mobile anyway — daemon is never started there).

## Empirical verification

- BRAT bisect across ~20 releases narrowed regression to v15.155.x → v15.156.0 boundary
- Bundle-diff confirmed v15.156.0 is the first release introducing top-level `process.env.HOME` in `main.js`
- Built `packages/obsidian-plugin/main.js` after fix contains the `typeof process<"u"&&process.env?...` guard
- All 9 existing `ValidatorDaemon.test.ts` tests pass

## Affected versions

v15.156.0 through v16.5.0 (all currently published versions fail to load on iOS).

## Reporter

@kitelev (Andrey, on iPhone) — observed as Notice flood of "Skipping file with invariant violation" + plugin disabled in Community plugins.