### PR TITLE
fix(validator): make exo__Asset_isDefinedBy optional

### DIFF
--- a/packages/cli/tests/integration/issue-2997-loader-2pc.integration.test.ts
+++ b/packages/cli/tests/integration/issue-2997-loader-2pc.integration.test.ts
@@ -37,7 +37,8 @@ const BAD_FIXTURES: BadFixture[] = [
   { filename: "02-empty-locked-by.md", expectedReasonContains: "ems__Effort_lockedBy" },
   { filename: "03-empty-lock-expires.md", expectedReasonContains: "ems__Effort_lockExpires" },
   { filename: "04-missing-asset-uid.md", expectedReasonContains: "exo__Asset_uid" },
-  { filename: "05-missing-asset-isdefinedby.md", expectedReasonContains: "exo__Asset_isDefinedBy" },
+  // 05-missing-asset-isdefinedby removed: exo__Asset_isDefinedBy is now
+  // optional — downstream consumers handle the missing case via defaults.
   // 06-empty-asset-label removed: exo__Asset_label is now optional with basename fallback.
   { filename: "07-empty-instance-class.md", expectedReasonContains: "exo__Instance_class" },
   { filename: "08-empty-effort-status.md", expectedReasonContains: "ems__Effort_status" },

--- a/packages/cli/tests/unit/commands/validate-frontmatter.test.ts
+++ b/packages/cli/tests/unit/commands/validate-frontmatter.test.ts
@@ -116,11 +116,15 @@ body
     });
   });
 
-  describe("AC2: missing exo__Asset_isDefinedBy", () => {
-    it("reports file path + hint to add `exo__Asset_isDefinedBy`", () => {
+  describe("AC2: missing exo__Asset_isDefinedBy is allowed", () => {
+    it("does not report a violation when exo__Asset_isDefinedBy is absent", () => {
+      // exo__Asset_isDefinedBy was downgraded from required to optional —
+      // downstream consumers (FolderRepairService, URIConstructionService,
+      // MetadataExtractor) handle the missing case via defaults, so the loader
+      // no longer skips assets that lack the ontology pointer.
       writeFile(
         vault,
-        "bad-defined-by.md",
+        "missing-defined-by.md",
         `---
 exo__Asset_uid: 11111111-1111-1111-1111-111111111111
 exo__Asset_label: "no defined-by"
@@ -137,10 +141,7 @@ body
           e.code === "MISSING_PROPERTY" &&
           (e as any).property === "exo__Asset_isDefinedBy",
       );
-      expect(err).toBeDefined();
-      expect(err!.file).toBe("bad-defined-by.md");
-      expect(err!.hint).toMatch(/exo__Asset_isDefinedBy/);
-      expect(err!.hint).toMatch(/\[\[!kitelev\]\]/);
+      expect(err).toBeUndefined();
     });
   });
 

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -684,8 +684,9 @@ export class NoteToRDFConverter {
    * unchanged.
    *
    * Invariants:
-   *   - Required + non-empty: `exo__Asset_uid`, `exo__Asset_isDefinedBy`,
-   *     `exo__Asset_label`, `exo__Instance_class`.
+   *   - Required + non-empty: `exo__Asset_uid`, `exo__Instance_class`.
+   *   - `exo__Asset_isDefinedBy` and `exo__Asset_label` are no longer
+   *     required — converter falls back to defaults when absent.
    *   - Optional but non-empty if present: `ems__Effort_status`,
    *     `ems__Effort_parent`, `ems__Effort_lockedBy`,
    *     `ems__Effort_lockExpires`, `exo__Asset_updatedAt`,
@@ -739,7 +740,6 @@ export class NoteToRDFConverter {
 
     const REQUIRED_PROPERTIES = [
       "exo__Asset_uid",
-      "exo__Asset_isDefinedBy",
       "exo__Instance_class",
     ];
     for (const key of REQUIRED_PROPERTIES) {

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.infer-label.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.infer-label.test.ts
@@ -102,6 +102,40 @@ describe("Issue #3101: Infer exo__Asset_label from filename", () => {
     });
   });
 
+  describe("validateExocortexAsset — exo__Asset_isDefinedBy is optional", () => {
+    it("should not require exo__Asset_isDefinedBy when missing", () => {
+      const frontmatter = {
+        exo__Asset_uid: "11111111-1111-1111-1111-111111111111",
+        exo__Instance_class: ["[[ems__Task]]"],
+      };
+
+      const result = converter.validateExocortexAsset(frontmatter, "my-note");
+      expect(result).toBeNull();
+    });
+
+    it("should not flag empty-string exo__Asset_isDefinedBy", () => {
+      const frontmatter = {
+        exo__Asset_uid: "11111111-1111-1111-1111-111111111111",
+        exo__Asset_isDefinedBy: "",
+        exo__Instance_class: ["[[ems__Task]]"],
+      };
+
+      const result = converter.validateExocortexAsset(frontmatter, "my-note");
+      expect(result).toBeNull();
+    });
+
+    it("should not flag empty-array exo__Asset_isDefinedBy", () => {
+      const frontmatter = {
+        exo__Asset_uid: "11111111-1111-1111-1111-111111111111",
+        exo__Asset_isDefinedBy: [],
+        exo__Instance_class: ["[[ems__Task]]"],
+      };
+
+      const result = converter.validateExocortexAsset(frontmatter, "my-note");
+      expect(result).toBeNull();
+    });
+  });
+
   describe("convertNote with inferred label", () => {
     it("should emit rdfs:label and exo:Asset_label triples when label inferred from basename", async () => {
       const file: IFile = {


### PR DESCRIPTION
## Summary

Drops `exo__Asset_isDefinedBy` from `REQUIRED_PROPERTIES` in `NoteToRDFConverter.validateExocortexAsset`. Downstream consumers (`FolderRepairService`, `URIConstructionService`, `MetadataExtractor`) already handle missing `isDefinedBy` gracefully — removing the hard requirement stops the loader from skipping otherwise-valid assets.

## Motivation

User vault audit found 230+ assets (primarily in `01 Inbox/` and legacy notes) emitting `Skipping file with invariant violation: MISSING_PROPERTY exo__Asset_isDefinedBy` warnings on every Obsidian startup. These assets are still semantically valid — they just lack the ontology-namespace pointer, which can be repaired post-hoc.

`exo__Asset_label` was already made optional earlier (line 735-738 comment); this PR completes the soft-validation direction for the second non-critical required property.

## Changes

- `NoteToRDFConverter.ts`: remove `"exo__Asset_isDefinedBy"` from `REQUIRED_PROPERTIES` array; update docstring.
- `NoteToRDFConverter.infer-label.test.ts`: add 3 new test cases covering missing / empty-string / empty-array `isDefinedBy`.

## Test plan

- [x] `npx jest --testPathPatterns "NoteToRDFConverter|InMemoryTripleStore"` — 330 tests pass
- [x] `npm run check:types` — clean
- [x] Pre-commit hooks (BDD coverage, archgate) — green
- [ ] CI: 13 required checks
- [ ] Auto Release publishes new plugin version
- [ ] Verify reduced warnings in Obsidian DevTools console after reload