### PR TITLE
fix(shacl): join cross-vault subject classes via UUID-keyed index

### DIFF
--- a/packages/exocortex/src/services/ShaclLiteValidator.ts
+++ b/packages/exocortex/src/services/ShaclLiteValidator.ts
@@ -135,6 +135,26 @@ function isXSDDatatypeIRI(iri: string): boolean {
   return XSD_DATATYPE_PREFIXES.some((prefix) => iri.startsWith(prefix));
 }
 
+/**
+ * Extract bare UUID from a vault subject IRI of the form
+ * `obsidian://vault/.../<uuid>.md` or `obsidian://vault/<uuid>.md`.
+ *
+ * Returns the lowercase UUID string when the IRI ends with `<uuid>.md`,
+ * otherwise null. Used to build a secondary UID-keyed index of subject
+ * classes so that cross-vault wikilink references resolve regardless of
+ * whether the producing converter saw the file at its full vault path
+ * (`obsidian://vault/assetspaces/.../<uid>.md`) or only as a synthesized
+ * UUID-only IRI (`obsidian://vault/<uid>.md`) emitted when the wikilink
+ * target lives outside the converter's own vault scope.
+ */
+const UID_SUFFIX_RE =
+  /\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/i;
+
+function extractUid(iri: string): string | null {
+  const m = UID_SUFFIX_RE.exec(iri);
+  return m ? m[1].toLowerCase() : null;
+}
+
 export function validate(
   triples: Triple[],
   registry: ShapeRegistry,
@@ -163,6 +183,17 @@ export function validate(
         const classes = subjectClasses.get(subjectIRI) ?? [];
         classes.push(obj.value);
         subjectClasses.set(subjectIRI, classes);
+        // Secondary UID-keyed index: lets cross-vault wikilink targets
+        // (synthesized as `obsidian://vault/<uid>.md` without directory)
+        // resolve to the class set indexed by the full-path subject IRI
+        // produced by the owning vault's converter.
+        const uid = extractUid(subjectIRI);
+        if (uid) {
+          const uidKey = `uid:${uid}`;
+          const uidClasses = subjectClasses.get(uidKey) ?? [];
+          uidClasses.push(obj.value);
+          subjectClasses.set(uidKey, uidClasses);
+        }
       }
     } else {
       let props = subjectProps.get(subjectIRI);
@@ -231,8 +262,19 @@ export function validate(
             // and are never registered in subjectClasses. Skip the sh:class check for
             // them — they are authoritative by definition (fix: 5 external IRI violations).
             if (isExternalOntologyIRI(obj.value)) continue;
-            // Class range: value's class(es) must satisfy range via hierarchy
-            const valueClasses = subjectClasses.get(obj.value) ?? [];
+            // Class range: value's class(es) must satisfy range via hierarchy.
+            // Direct lookup first; if it misses and the value IRI ends with a
+            // UUID-named markdown file, fall back to the UID-keyed index so
+            // cross-vault synth IRIs (`obsidian://vault/<uid>.md` without dir)
+            // join with full-path subject IRIs produced by another vault's
+            // converter for the same underlying asset.
+            let valueClasses = subjectClasses.get(obj.value) ?? [];
+            if (valueClasses.length === 0) {
+              const uid = extractUid(obj.value);
+              if (uid) {
+                valueClasses = subjectClasses.get(`uid:${uid}`) ?? [];
+              }
+            }
             // R13: ANY-of semantics — any value class matching any range class satisfies
             const rangeConforms = shape.range.some((expectedClass) =>
               valueClasses.some(

--- a/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
+++ b/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
@@ -1162,3 +1162,106 @@ describe('validate — external ontology IRI allowlist', () => {
     expect(report.violations[0].message).toContain('sh:class violation');
   });
 });
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Suite 12: Cross-vault UUID-keyed subject resolution
+//
+// In multi-vault scans (`--also <path>` repeated), each vault's
+// NoteToRDFConverter emits subject IRIs from its own root:
+//   primary vault →   obsidian://vault/assetspaces/exoass/<uid>.md
+// For wikilink targets resolving outside that vault's scope, the converter
+// synthesizes a directory-less IRI:
+//                     obsidian://vault/<uid>.md
+// These two IRIs reference the same underlying asset but never join in the
+// validator's subjectClasses map, producing spurious sh:class violations.
+//
+// Fix: maintain a secondary `uid:<uuid>` keyed index of subject classes so
+// rdf:type recorded under the full-path form resolves under the synth form
+// (and vice versa) for any subject whose IRI ends with `<uuid>.md`.
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('validate — cross-vault UUID-keyed subject resolution', () => {
+  const UID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const FULL_PATH_IRI = `obsidian://vault/assetspaces/exoass/${UID}.md`;
+  const SYNTH_IRI = `obsidian://vault/${UID}.md`;
+  const EFFORT = `${EMS}Effort`;
+  const TASK = `${EMS}Task`;
+
+  it('T-CV-01: synth IRI value joins to full-path subject classes via UID', () => {
+    const shape = makeShape({
+      propertyIRI: `${EMS}Effort_parent`,
+      range: [EFFORT],
+    });
+    const triples: Triple[] = [
+      typeTriple('node:A', EFFORT),
+      // Target subject typed under full-path IRI (other vault's converter)
+      typeTriple(FULL_PATH_IRI, EFFORT),
+      // Reference to it via synth IRI (this vault's converter)
+      iriTriple('node:A', `${EMS}Effort_parent`, SYNTH_IRI),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T-CV-02: full-path IRI value joins to synth-IRI subject classes via UID', () => {
+    const shape = makeShape({
+      propertyIRI: `${EMS}Effort_parent`,
+      range: [EFFORT],
+    });
+    const triples: Triple[] = [
+      typeTriple('node:A', EFFORT),
+      // Target subject typed under synth IRI
+      typeTriple(SYNTH_IRI, EFFORT),
+      // Reference to it via full-path IRI
+      iriTriple('node:A', `${EMS}Effort_parent`, FULL_PATH_IRI),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T-CV-03: direct match still preferred over UID fallback', () => {
+    const shape = makeShape({
+      propertyIRI: `${EMS}Effort_parent`,
+      range: [EFFORT],
+    });
+    const triples: Triple[] = [
+      typeTriple('node:A', EFFORT),
+      typeTriple(FULL_PATH_IRI, EFFORT),
+      iriTriple('node:A', `${EMS}Effort_parent`, FULL_PATH_IRI),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T-CV-04: UID fallback respects class mismatch (still produces violation)', () => {
+    const shape = makeShape({
+      propertyIRI: `${EMS}Effort_parent`,
+      range: [EFFORT],
+    });
+    const triples: Triple[] = [
+      typeTriple('node:A', EFFORT),
+      // Target typed as Task (wrong class) under full-path
+      typeTriple(FULL_PATH_IRI, TASK),
+      // Reference via synth IRI
+      iriTriple('node:A', `${EMS}Effort_parent`, SYNTH_IRI),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0].message).toContain('sh:class');
+  });
+
+  it('T-CV-05: non-UUID IRIs are not touched by UID fallback', () => {
+    const shape = makeShape({
+      propertyIRI: `${EMS}Effort_parent`,
+      range: [EFFORT],
+    });
+    const triples: Triple[] = [
+      typeTriple('node:A', EFFORT),
+      // node:B has no type triple → empty valueClasses → violation expected
+      iriTriple('node:A', `${EMS}Effort_parent`, 'node:B'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0].actualValue).toBe('node:B');
+  });
+});


### PR DESCRIPTION
## Summary

Multi-vault SHACL validation (`validate schema --shapes-mode --also <path>` …) emits sh:class violations against assets that are correctly typed but live in a different `--also` vault than their wikilink source. Root cause: each vault's converter produces subject IRIs scoped to its own root (full-path), while wikilink targets pointing outside the current vault are synthesized as directory-less `obsidian://vault/<uid>.md`. The validator's `subjectClasses` map keyed only by full IRI never joins these two views.

**Fix (minimal scope, validator only):** maintain a secondary `uid:<uuid>` index alongside the existing full-IRI index. Any subject IRI ending with `<uuid>.md` is registered under both keys; the sh:class range check falls back to the UID index when the direct lookup misses and the value IRI carries a UUID.

## Empirical impact

vault-2025 with `--also vault-exodev/assetspaces/{exoass,exodev}`: 778 → ~612 violations (-166, -21%).

The remainder are a **separate upstream bug** (literal `[[<uid>]]` values on `exo__Instance_class` for `--also` files never resolve to canonical class IRIs because per-vault class resolvers don't cross vault boundaries). Not addressed here — different fix, different PR. The validator-level fix is a strict improvement for any cross-vault pair where target IS typed.

## Tests

5 new cases in `ShaclLiteValidator.test.ts` Suite 12:
- T-CV-01: synth IRI value joins to full-path subject classes via UID
- T-CV-02: full-path IRI value joins to synth-IRI subject classes via UID (symmetric)
- T-CV-03: direct match still preferred over UID fallback
- T-CV-04: UID fallback respects class mismatch (still produces violation)
- T-CV-05: non-UUID IRIs are not touched by UID fallback

All 87 ShaclLiteValidator tests pass.

## Test plan

- [x] Unit tests pass (87/87)
- [x] BDD coverage 100%
- [x] Archgate ADR checks pass
- [x] Local validation run on vault-2025 + vault-exodev confirms -166 violations
- [ ] CI green (13 required checks)