### PR TITLE
feat(createAsset): configurable isDefinedBy via grounding targetValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exocortex-monorepo",
-  "version": "16.6.3",
+  "version": "16.7.0",
   "description": "Exocortex: A configurable UI system for Obsidian that transforms knowledge management through ontology-driven layouts and semantic capabilities",
   "main": "main.js",
   "workspaces": [

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -118,6 +118,7 @@ export function populateServiceRegistry(
       // in from the active asset.
       let folder = userInput?.folder as string | undefined;
       const ownerIdentity = userInput?.ownerIdentity as string | undefined;
+      const explicitIsDefinedBy = userInput?.isDefinedBy as string | undefined;
       if (!prototypeUID) throw new Error("createAsset requires userInput.prototypeUID");
       if (!label) throw new Error("createAsset requires userInput.label");
       // Default to current file's folder when not specified
@@ -180,6 +181,18 @@ export function populateServiceRegistry(
         `  - "[[${expectedClass}]]"`,
       ];
       let isDefinedByWritten = false;
+      // Highest precedence: explicit `isDefinedBy` from grounding `targetValue`
+      // (RFC `1429fcd0` follow-up). Lets each exocmd command pin its created
+      // assets to a specific owner without depending on vault default or parent
+      // inheritance. Example: a global Palette "Create note" command sets
+      // `targetValue.isDefinedBy = "[[<kitelev-uid>]]"` so the note is owned
+      // by the user even when fired without an active file.
+      if (explicitIsDefinedBy) {
+        lines.push(
+          `exo__Asset_isDefinedBy: ${toQuotedWikilink(explicitIsDefinedBy)}`,
+        );
+        isDefinedByWritten = true;
+      }
       if (parentMetadata) {
         const parentClass = parentMetadata.exo__Instance_class;
         const parentClasses = Array.isArray(parentClass)
@@ -209,7 +222,7 @@ export function populateServiceRegistry(
           );
         }
         lines.push('ems__Effort_status: "[[ems__EffortStatusBacklog]]"');
-        if (parentMetadata.exo__Asset_isDefinedBy) {
+        if (!isDefinedByWritten && parentMetadata.exo__Asset_isDefinedBy) {
           lines.push(
             `exo__Asset_isDefinedBy: ${toQuotedWikilink(
               String(parentMetadata.exo__Asset_isDefinedBy),
@@ -218,12 +231,11 @@ export function populateServiceRegistry(
           isDefinedByWritten = true;
         }
       }
-      // Fallback for global surfaces without an active file (RFC `1429fcd0`):
-      // the caller (e.g. ExocmdCommandPaletteRegistrar) injects the user's
-      // owner-identity wikilink via `userInput.ownerIdentity`. Parent
-      // inheritance takes precedence above — a button click on an
-      // ontology-specific asset still inherits that asset's `isDefinedBy`,
-      // so this branch only fires when there is no parent at all.
+      // Final fallback for global surfaces without an active file (RFC
+      // `1429fcd0`): ExocmdCommandPaletteRegistrar injects the vault default
+      // owner-identity wikilink via `userInput.ownerIdentity`. Precedence
+      // chain: explicit grounding `isDefinedBy` > parent inheritance >
+      // vault-default `ownerIdentity`.
       if (!isDefinedByWritten && ownerIdentity) {
         lines.push(
           `exo__Asset_isDefinedBy: ${toQuotedWikilink(ownerIdentity)}`,

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -491,6 +491,33 @@ describe("ServiceRegistryPopulator", () => {
       );
     });
 
+    it("explicit isDefinedBy from grounding targetValue wins over ownerIdentity fallback", async () => {
+      const service = registry.get("createAsset")!;
+      await service.execute("", {
+        prototypeUID: "ztlk__FleetingNotePrototype",
+        label: "Pinned-owner note",
+        folder: "03 Knowledge/inbox",
+        // GroundingExecutor merges targetValue defaults into userInput; an
+        // explicit `isDefinedBy` pin must trump the registrar-injected
+        // vault default `ownerIdentity`.
+        isDefinedBy: "[[0aa339bc-9b56-400a-8148-cbde57bbf0b6]]",
+        ownerIdentity: "[[!some-other-default]]",
+      });
+
+      const writeCall = (deps.fileSystemAdapter.createFile as jest.Mock).mock
+        .calls[0];
+      const writtenContent: string = writeCall[1];
+      expect(writtenContent).toContain(
+        'exo__Asset_isDefinedBy: "[[0aa339bc-9b56-400a-8148-cbde57bbf0b6]]"',
+      );
+      expect(writtenContent).not.toContain("[[!some-other-default]]");
+      // Guard against duplicate isDefinedBy lines (regression: parent block
+      // used to unconditionally append after explicit pin landed).
+      const occurrences = (writtenContent.match(/exo__Asset_isDefinedBy:/g) ?? [])
+        .length;
+      expect(occurrences).toBe(1);
+    });
+
     it("omits exo__Asset_isDefinedBy when neither parent nor ownerIdentity supplies it", async () => {
       const service = registry.get("createAsset")!;
       await service.execute("", {


### PR DESCRIPTION
## Summary

Allow `exocmd__Command` assets to pin the owner of created notes via `Grounding_targetValue.isDefinedBy`. Precedence chain in `createAsset` service:

1. **Explicit grounding pin** — `userInput.isDefinedBy` (merged from `targetValue`)
2. **Parent inheritance** — `parentMetadata.exo__Asset_isDefinedBy` (button surface)
3. **Vault default** — `userInput.ownerIdentity` (Palette surface registrar fallback)

## Why

After v16.6.5 the Palette command "Create fleeting note" still wrote `[[!kitelev]]` (the vault's literal default owner-identity label), not the canonical UID-named identity. The user wants per-command control without coupling to vault settings. This makes the command's identity binding part of its declarative description, consistent with the Homoiconicity Invariant (RFC `c78cc5c8`).

## Changes

- `ServiceRegistryPopulator.ts` — `createAsset` reads `userInput.isDefinedBy` first; new guard on the parent-inheritance branch prevents duplicate `exo__Asset_isDefinedBy` lines.
- `ServiceRegistryPopulator.test.ts` — new unit test covering explicit-pin precedence + duplicate-line regression.
- Companion vault edit (separate, in `/Users/kitelev/vault-2025`): grounding `c84e2e08-…` `targetValue` now includes `"isDefinedBy":"[[0aa339bc-9b56-400a-8148-cbde57bbf0b6]]"` (UID of `a.kitelev`).

## Test plan
- [x] `ServiceRegistryPopulator.test.ts` — 83 tests pass (+1 new)
- [x] `npm run lint` — clean (2 pre-existing warnings, unchanged)
- [ ] CI green (13 required checks)
- [ ] Manual: after release, Cmd+P → "Create fleeting note" produces file with `exo__Asset_isDefinedBy: "[[0aa339bc-9b56-400a-8148-cbde57bbf0b6]]"`

Refs RFC `1429fcd0`, prior PRs #3146 / #3148 / #3153.