### PR TITLE
fix(shacl): resolve cross-vault Instance_class literal wikilinks to canonical IRIs

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -173,8 +173,125 @@ async function loadTriplesFromAllVaults(
     }
   }
 
+  if (alsoPaths.length > 0) {
+    const before = triples.length;
+    triples = resolveCrossVaultInstanceClassWikilinks(triples);
+    if (verbose) {
+      const added = triples.length - before;
+      if (added > 0) {
+        console.log(
+          `   🔗 Cross-vault Instance_class resolution: emitted ${added} additional canonical-IRI triple(s)`,
+        );
+      }
+    }
+  }
+
   return { triples, cacheHit };
 }
+
+const EXO_INSTANCE_CLASS_IRI =
+  "https://exocortex.my/ontology/exo#Instance_class";
+const RDF_TYPE_IRI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const INSTANCE_CLASS_LITERAL_WIKILINK_RE =
+  /^\[\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\|[^\]]*)?\]\]$/i;
+const SUBJECT_UID_SUFFIX_RE =
+  /\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/i;
+
+/**
+ * In multi-vault scans (`--also` repeated), each per-path NoteToRDFConverter
+ * resolves `exo__Instance_class` wikilink targets only against its own vault.
+ * When a class definition file lives in vault A and a typed asset lives in
+ * vault B passed via `--also`, the converter in B cannot find the class file,
+ * leaving the value as a literal `[[<uid>]]` instead of the canonical class
+ * IRI. SHACL sh:class checks then fail for the asset, even though the asset
+ * IS correctly typed in another vault.
+ *
+ * This post-processing pass closes the gap purely in CLI scope:
+ *
+ *   1. Scan all triples once to build a `uid → canonical-class-IRI` map from
+ *      class-definition files. A file at `obsidian://…/<uid>.md` is a class
+ *      definition when it carries an `rdfs:label` or `exo:Asset_label`
+ *      literal whose value matches the `<namespacePrefix>__<LocalName>`
+ *      pattern recognised by `labelToOntologyIRI()`.
+ *
+ *   2. Walk the triple set again. For each triple with predicate
+ *      `exo:Instance_class` and a Literal object of form `[[<uid>]]` or
+ *      `[[<uid>|alias]]`, emit the missing canonical-IRI triple AND a
+ *      matching `rdf:type` triple (the SHACL validator reads either
+ *      predicate, see ShaclLiteValidator.ts L158–159).
+ *
+ * The literal triple is preserved — downstream consumers that read the raw
+ * wikilink (SPARQL queries against the literal form) keep working. Only
+ * additive emission, no replacement.
+ */
+export function resolveCrossVaultInstanceClassWikilinks(
+  triples: DomainTriple[],
+): DomainTriple[] {
+  const uidToClassIRI = new Map<string, string>();
+  for (const t of triples) {
+    if (
+      !(t.subject instanceof DomainIRI) ||
+      !(t.predicate instanceof DomainIRI) ||
+      !(t.object instanceof DomainLiteral)
+    ) {
+      continue;
+    }
+    if (t.predicate.value !== RDFS_LABEL && t.predicate.value !== EXO_ASSET_LABEL_IRI) {
+      continue;
+    }
+    const m = SUBJECT_UID_SUFFIX_RE.exec(t.subject.value);
+    if (!m) continue;
+    const uid = m[1].toLowerCase();
+    if (uidToClassIRI.has(uid)) continue;
+    const labelValue = t.object.value.trim();
+    // labelToOntologyIRI splits on first `__`; multi-word or whitespace-bearing
+    // labels (e.g. "ems__Project Special") would yield an invalid IRI. Restrict
+    // to single-token labels to keep DomainIRI construction safe.
+    if (/\s/.test(labelValue)) continue;
+    const classIRI = labelToOntologyIRI(labelValue);
+    if (classIRI) {
+      uidToClassIRI.set(uid, classIRI);
+    }
+  }
+
+  if (uidToClassIRI.size === 0) return triples;
+
+  const emitted = new Set<string>();
+  const additions: DomainTriple[] = [];
+  for (const t of triples) {
+    if (
+      !(t.subject instanceof DomainIRI) ||
+      !(t.predicate instanceof DomainIRI) ||
+      !(t.object instanceof DomainLiteral)
+    ) {
+      continue;
+    }
+    if (t.predicate.value !== EXO_INSTANCE_CLASS_IRI) continue;
+    const lit = t.object.value.trim();
+    const m = INSTANCE_CLASS_LITERAL_WIKILINK_RE.exec(lit);
+    if (!m) continue;
+    const uid = m[1].toLowerCase();
+    const classIRI = uidToClassIRI.get(uid);
+    if (!classIRI) continue;
+
+    const subjectIRI = t.subject.value;
+    const dedupKey = `${subjectIRI} ${classIRI}`;
+    if (emitted.has(dedupKey)) continue;
+    emitted.add(dedupKey);
+
+    const classNode = new DomainIRI(classIRI);
+    additions.push(
+      new DomainTriple(t.subject, new DomainIRI(EXO_INSTANCE_CLASS_IRI), classNode),
+    );
+    additions.push(
+      new DomainTriple(t.subject, new DomainIRI(RDF_TYPE_IRI), classNode),
+    );
+  }
+
+  return additions.length > 0 ? triples.concat(additions) : triples;
+}
+
+const EXO_ASSET_LABEL_IRI = "https://exocortex.my/ontology/exo#Asset_label";
 
 /**
  * Resolves a focusNode IRI (obsidian://vault/<relPath>) to the absolute

--- a/packages/cli/tests/unit/commands/validate-schema.test.ts
+++ b/packages/cli/tests/unit/commands/validate-schema.test.ts
@@ -18,7 +18,9 @@ jest.unstable_mockModule("exocortex", () => ({
   shaclValidate: jest.fn().mockReturnValue({ conforms: true, violations: [] }),
   DomainIRI: class { constructor(public value: string) {} },
   DomainLiteral: class { constructor(public value: string) {} },
-  DomainTriple: jest.fn(),
+  DomainTriple: class {
+    constructor(public subject: unknown, public predicate: unknown, public object: unknown) {}
+  },
 }));
 
 // Mock fs-extra (CacheManager dependency)
@@ -59,6 +61,7 @@ const {
   buildEARLReport,
   runShapesValidation,
   applyLegacyExceptionFilter,
+  resolveCrossVaultInstanceClassWikilinks,
 } = await import("../../../src/commands/validate-schema.js");
 
 // Import mocked DomainIRI/DomainLiteral so instanceof checks in applyLegacyExceptionFilter work
@@ -778,5 +781,129 @@ describe("P4.3 applyLegacyExceptionFilter", () => {
     const first = applyLegacyExceptionFilter(triples as any, report);
     const second = applyLegacyExceptionFilter(triples as any, first);
     expect(second).toEqual(first);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// resolveCrossVaultInstanceClassWikilinks — multi-vault literal Instance_class
+// post-processing. Confirms uid→class-IRI map construction + canonical-IRI
+// emission + rdf:type emission for cross-vault literal wikilinks.
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("resolveCrossVaultInstanceClassWikilinks", () => {
+  const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
+  const EXO_ASSET_LABEL = "https://exocortex.my/ontology/exo#Asset_label";
+  const EXO_INSTANCE_CLASS = "https://exocortex.my/ontology/exo#Instance_class";
+  const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+  const EMS_PROJECT = "https://exocortex.my/ontology/ems#Project";
+
+  // Helpers matching the mocked DomainIRI/DomainLiteral/DomainTriple shape.
+  const iri = (v: string) => new DomainIRI(v);
+  const lit = (v: string) => new DomainLiteral(v);
+  const makeTriple = (s: any, p: any, o: any): any => ({
+    subject: s,
+    predicate: p,
+    object: o,
+  });
+
+  const CLASS_FILE_IRI =
+    "obsidian://vault/assetspaces/ems/7db5eeff-718a-49b0-8d2b-39b084a356e3.md";
+  const ASSET_IRI =
+    "obsidian://vault/assetspaces/exodev/9541965c-c5dc-48ff-94b2-98aad3d62b2e.md";
+  const CLASS_UID = "7db5eeff-718a-49b0-8d2b-39b084a356e3";
+
+  it("emits canonical Instance_class IRI + rdf:type when class file is in primary vault and asset references via literal wikilink", () => {
+    const triples = [
+      makeTriple(iri(CLASS_FILE_IRI), iri(RDFS_LABEL), lit("ems__Project")),
+      makeTriple(iri(ASSET_IRI), iri(EXO_INSTANCE_CLASS), lit(`[[${CLASS_UID}]]`)),
+    ];
+    const result = resolveCrossVaultInstanceClassWikilinks(triples as any);
+    expect(result.length).toBe(triples.length + 2);
+    const added = result.slice(triples.length);
+    const canonicalInstance = added.find(
+      (t: any) =>
+        t.predicate.value === EXO_INSTANCE_CLASS &&
+        t.object instanceof DomainIRI &&
+        t.object.value === EMS_PROJECT,
+    );
+    const rdfType = added.find(
+      (t: any) =>
+        t.predicate.value === RDF_TYPE &&
+        t.object instanceof DomainIRI &&
+        t.object.value === EMS_PROJECT,
+    );
+    expect(canonicalInstance).toBeDefined();
+    expect(rdfType).toBeDefined();
+  });
+
+  it("resolves class IRI from exo:Asset_label as well as rdfs:label", () => {
+    const triples = [
+      makeTriple(iri(CLASS_FILE_IRI), iri(EXO_ASSET_LABEL), lit("ems__Project")),
+      makeTriple(iri(ASSET_IRI), iri(EXO_INSTANCE_CLASS), lit(`[[${CLASS_UID}]]`)),
+    ];
+    const result = resolveCrossVaultInstanceClassWikilinks(triples as any);
+    expect(result.length).toBe(triples.length + 2);
+  });
+
+  it("handles [[uid|alias]] wikilink form", () => {
+    const triples = [
+      makeTriple(iri(CLASS_FILE_IRI), iri(RDFS_LABEL), lit("ems__Project")),
+      makeTriple(
+        iri(ASSET_IRI),
+        iri(EXO_INSTANCE_CLASS),
+        lit(`[[${CLASS_UID}|ems__Project]]`),
+      ),
+    ];
+    const result = resolveCrossVaultInstanceClassWikilinks(triples as any);
+    expect(result.length).toBe(triples.length + 2);
+  });
+
+  it("no-op when class definition is missing (uid not in map)", () => {
+    const triples = [
+      makeTriple(iri(ASSET_IRI), iri(EXO_INSTANCE_CLASS), lit(`[[${CLASS_UID}]]`)),
+    ];
+    const result = resolveCrossVaultInstanceClassWikilinks(triples as any);
+    expect(result).toBe(triples);
+  });
+
+  it("no-op when value is already a canonical IRI (not a literal wikilink)", () => {
+    const triples = [
+      makeTriple(iri(CLASS_FILE_IRI), iri(RDFS_LABEL), lit("ems__Project")),
+      makeTriple(iri(ASSET_IRI), iri(EXO_INSTANCE_CLASS), iri(EMS_PROJECT)),
+    ];
+    const result = resolveCrossVaultInstanceClassWikilinks(triples as any);
+    expect(result.length).toBe(triples.length);
+  });
+
+  it("skips multi-word labels that would yield invalid IRIs", () => {
+    const triples = [
+      makeTriple(iri(CLASS_FILE_IRI), iri(RDFS_LABEL), lit("ems__Project Special")),
+      makeTriple(iri(ASSET_IRI), iri(EXO_INSTANCE_CLASS), lit(`[[${CLASS_UID}]]`)),
+    ];
+    const result = resolveCrossVaultInstanceClassWikilinks(triples as any);
+    expect(result.length).toBe(triples.length);
+  });
+
+  it("deduplicates emissions when one subject has multiple literal wikilinks resolving to same class", () => {
+    const triples = [
+      makeTriple(iri(CLASS_FILE_IRI), iri(RDFS_LABEL), lit("ems__Project")),
+      makeTriple(iri(ASSET_IRI), iri(EXO_INSTANCE_CLASS), lit(`[[${CLASS_UID}]]`)),
+      makeTriple(iri(ASSET_IRI), iri(EXO_INSTANCE_CLASS), lit(`[[${CLASS_UID}|alias]]`)),
+    ];
+    const result = resolveCrossVaultInstanceClassWikilinks(triples as any);
+    expect(result.length).toBe(triples.length + 2);
+  });
+
+  it("ignores non-Instance_class predicates with literal wikilink values", () => {
+    const triples = [
+      makeTriple(iri(CLASS_FILE_IRI), iri(RDFS_LABEL), lit("ems__Project")),
+      makeTriple(
+        iri(ASSET_IRI),
+        iri("https://exocortex.my/ontology/exo#Asset_relates"),
+        lit(`[[${CLASS_UID}]]`),
+      ),
+    ];
+    const result = resolveCrossVaultInstanceClassWikilinks(triples as any);
+    expect(result.length).toBe(triples.length);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #3151. When `validate schema --shapes-mode --also <path>` runs, each per-path `NoteToRDFConverter` resolves `exo__Instance_class` wikilink targets only against its own vault. When a class definition file lives in vault A and a typed asset lives in vault B (passed via `--also`), the converter in B can't find the class file via `getFirstLinkpathDest`, leaving `Instance_class` as a literal `[[<uid>]]` instead of canonical `https://exocortex.my/ontology/<ns>#<Local>`. SHACL sh:class checks then fail for the asset even though it IS correctly typed in another vault.

**Fix (CLI post-processing, plugin untouched):**

1. After all converters concat their triples, build a `uid → canonical-class-IRI` map by scanning subjects matching `…/<uid>.md` that carry `rdfs:label` or `exo:Asset_label` matching `<prefix>__<Local>`.
2. Walk triples; for each `exo:Instance_class` triple whose object is a literal wikilink `[[<uid>]]` or `[[<uid>|alias]]`, emit:
   - canonical `<subject> exo:Instance_class <ns#Local>` IRI triple
   - matching `<subject> rdf:type <ns#Local>` (ShaclLiteValidator reads either predicate)
3. Original literal triple preserved — additive only.

Multi-word labels that would yield invalid IRIs are skipped (whitespace check). Per-subject-class pairs deduplicated. Pass only runs when `alsoPaths.length > 0`.

## Empirical impact

vault-2025 + `--also vault-exodev/{exoass,exodev}`:
- 495-entry uid→class-IRI map built
- 478 additional triples emitted for 239 subjects
- Violation count: **612 → 606**

Modest delta because most remaining violations target subjects in unscanned paths (`vault-exodev/inbox/…`, not in `--also`) or legacy label-named files outside the UUID convention — separate fixes.

## Tests

8 new unit tests in `validate-schema.test.ts`:
- emits canonical IRI + rdf:type for cross-vault literal wikilink
- resolves from `exo:Asset_label` and `rdfs:label`
- handles `[[uid|alias]]` form
- no-op when class def missing
- no-op when value already canonical IRI
- skips multi-word labels (invalid IRI)
- dedups multiple references to same class
- ignores non-Instance_class predicates

75/75 validate-schema unit tests pass; 4/4 multi-vault integration tests pass; BDD 100%; Archgate green.

## Test plan

- [x] Unit tests pass (75/75)
- [x] Multi-vault integration tests pass (4/4)
- [x] BDD coverage 100%
- [x] Archgate ADR checks pass
- [x] Empirical local run confirms -6 violations (additive correctness)
- [ ] CI green (13 required checks)