### PR TITLE
feat(grounding): standalone exocmd__Grounding_isDefinedBy property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exocortex-monorepo",
-  "version": "16.6.3",
+  "version": "16.7.0",
   "description": "Exocortex: A configurable UI system for Obsidian that transforms knowledge management through ontology-driven layouts and semantic capabilities",
   "main": "main.js",
   "workspaces": [

--- a/packages/exocortex/src/domain/constants/CommandProperty.ts
+++ b/packages/exocortex/src/domain/constants/CommandProperty.ts
@@ -42,6 +42,14 @@ export const GroundingProperty = {
   TARGET_VALUE: "exocmd__Grounding_targetValue",
   /** Ordered array of Grounding asset references (for composite type) */
   STEPS: "exocmd__Grounding_steps",
+  /**
+   * Wikilink to the owner identity to write as `exo__Asset_isDefinedBy` on
+   * the newly created asset (for `service_call` createAsset). Standalone
+   * property (not embedded in `Grounding_targetValue` JSON) so the link is
+   * a real Obsidian backlink — the referenced identity asset's layout can
+   * list every Grounding that pins it.
+   */
+  IS_DEFINED_BY: "exocmd__Grounding_isDefinedBy",
 } as const;
 
 /** Properties for exocmd__CommandBinding assets */

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -128,6 +128,17 @@ export interface GroundingDefinition {
    * is unaffected by this map.
    */
   readonly propertyDefaults?: Record<string, string>;
+  /**
+   * Standalone wikilink to the owner identity asset pinned by this grounding.
+   * Injected into `userInput.isDefinedBy` for the `service_call` createAsset
+   * service, where it becomes `exo__Asset_isDefinedBy` on the new asset.
+   *
+   * Encoded as the `exocmd__Grounding_isDefinedBy` RDF triple — a real
+   * frontmatter wikilink, not a value embedded in `Grounding_targetValue`
+   * JSON. This makes the relationship discoverable in the referenced
+   * identity asset's incoming-links / layout.
+   */
+  readonly isDefinedBy?: string;
 }
 
 /**

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -891,6 +891,7 @@ export class CommandResolver {
       }
     }
     const targetValue = await this.getObsidianWikilinkValue(subject, Namespace.EXOCMD.term("Grounding_targetValue"));
+    const isDefinedBy = await this.getObsidianWikilinkValue(subject, Namespace.EXOCMD.term("Grounding_isDefinedBy"));
     const sparqlUpdate = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_sparqlUpdate"));
     const targetClass = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetClass"));
     const targetPrototype = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetPrototype"));
@@ -984,6 +985,7 @@ export class CommandResolver {
       incrementBy,
       shiftDelta: shiftDelta ?? undefined,
       propertyDefaults,
+      isDefinedBy: isDefinedBy ?? undefined,
     };
 
     if (inputSchema) {

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -427,6 +427,15 @@ export class GroundingExecutor {
     // pass, so existing literal-JSON targetValues (e.g. updateProperty +
     // {"property":"ems__Effort_parent"}) continue to parse identically.
     let mergedInput = userInput;
+    // Standalone `Grounding_isDefinedBy` wikilink (RFC follow-up): inject as a
+    // default so `createAsset` (or any service_call that consumes
+    // userInput.isDefinedBy) can pin owner identity without burying the link
+    // inside JSON `targetValue`. Authored as a real frontmatter wikilink, the
+    // identity asset's layout / backlinks list every Grounding that references
+    // it. userInput from the modal still wins over this default.
+    if (grounding.isDefinedBy) {
+      mergedInput = { isDefinedBy: grounding.isDefinedBy, ...(mergedInput ?? {}) };
+    }
     if (grounding.targetValue) {
       try {
         const substituted = this.substituteVariables(
@@ -436,7 +445,10 @@ export class GroundingExecutor {
         );
         const defaults = JSON.parse(substituted);
         if (typeof defaults === "object" && defaults !== null) {
-          mergedInput = { ...defaults, ...(userInput ?? {}) };
+          // Spread the already-merged `mergedInput` (which may carry the
+          // standalone `Grounding_isDefinedBy` default from the block above),
+          // so JSON-derived defaults stack on top without erasing it.
+          mergedInput = { ...defaults, ...(mergedInput ?? {}) };
         }
       } catch {
         // Not valid JSON — ignore (e.g. plain string targetValue)

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -425,6 +425,52 @@ describe("GroundingExecutor", () => {
       });
     });
 
+    it("should inject standalone Grounding_isDefinedBy as userInput default", async () => {
+      const mockService = {
+        execute: jest.fn().mockResolvedValue(undefined),
+      };
+      registry.register("createAsset", mockService);
+
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "createAsset",
+        targetValue: '{"prototype":"ztlk__FleetingNotePrototype"}',
+        isDefinedBy: "[[0aa339bc-9b56-400a-8148-cbde57bbf0b6]]",
+      });
+
+      const userInput = { label: "Test note" };
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, userInput);
+
+      expect(result.success).toBe(true);
+      expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
+        prototype: "ztlk__FleetingNotePrototype",
+        isDefinedBy: "[[0aa339bc-9b56-400a-8148-cbde57bbf0b6]]",
+        label: "Test note",
+      });
+    });
+
+    it("should let userInput.isDefinedBy override grounding.isDefinedBy default", async () => {
+      const mockService = {
+        execute: jest.fn().mockResolvedValue(undefined),
+      };
+      registry.register("createAsset", mockService);
+
+      const grounding = makeGrounding({
+        type: GroundingType.SERVICE_CALL,
+        targetProperty: "createAsset",
+        isDefinedBy: "[[default-owner]]",
+      });
+
+      const userInput = { label: "x", isDefinedBy: "[[runtime-pick]]" };
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, userInput);
+
+      expect(result.success).toBe(true);
+      expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
+        label: "x",
+        isDefinedBy: "[[runtime-pick]]",
+      });
+    });
+
     it("should ignore non-JSON targetValue for service_call", async () => {
       const mockService = {
         execute: jest.fn().mockResolvedValue(undefined),

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -118,6 +118,7 @@ export function populateServiceRegistry(
       // in from the active asset.
       let folder = userInput?.folder as string | undefined;
       const ownerIdentity = userInput?.ownerIdentity as string | undefined;
+      const explicitIsDefinedBy = userInput?.isDefinedBy as string | undefined;
       if (!prototypeUID) throw new Error("createAsset requires userInput.prototypeUID");
       if (!label) throw new Error("createAsset requires userInput.label");
       // Default to current file's folder when not specified
@@ -180,6 +181,18 @@ export function populateServiceRegistry(
         `  - "[[${expectedClass}]]"`,
       ];
       let isDefinedByWritten = false;
+      // Highest precedence: explicit `isDefinedBy` from grounding `targetValue`
+      // (RFC `1429fcd0` follow-up). Lets each exocmd command pin its created
+      // assets to a specific owner without depending on vault default or parent
+      // inheritance. Example: a global Palette "Create note" command sets
+      // `targetValue.isDefinedBy = "[[<kitelev-uid>]]"` so the note is owned
+      // by the user even when fired without an active file.
+      if (explicitIsDefinedBy) {
+        lines.push(
+          `exo__Asset_isDefinedBy: ${toQuotedWikilink(explicitIsDefinedBy)}`,
+        );
+        isDefinedByWritten = true;
+      }
       if (parentMetadata) {
         const parentClass = parentMetadata.exo__Instance_class;
         const parentClasses = Array.isArray(parentClass)
@@ -209,7 +222,7 @@ export function populateServiceRegistry(
           );
         }
         lines.push('ems__Effort_status: "[[ems__EffortStatusBacklog]]"');
-        if (parentMetadata.exo__Asset_isDefinedBy) {
+        if (!isDefinedByWritten && parentMetadata.exo__Asset_isDefinedBy) {
           lines.push(
             `exo__Asset_isDefinedBy: ${toQuotedWikilink(
               String(parentMetadata.exo__Asset_isDefinedBy),
@@ -218,12 +231,11 @@ export function populateServiceRegistry(
           isDefinedByWritten = true;
         }
       }
-      // Fallback for global surfaces without an active file (RFC `1429fcd0`):
-      // the caller (e.g. ExocmdCommandPaletteRegistrar) injects the user's
-      // owner-identity wikilink via `userInput.ownerIdentity`. Parent
-      // inheritance takes precedence above — a button click on an
-      // ontology-specific asset still inherits that asset's `isDefinedBy`,
-      // so this branch only fires when there is no parent at all.
+      // Final fallback for global surfaces without an active file (RFC
+      // `1429fcd0`): ExocmdCommandPaletteRegistrar injects the vault default
+      // owner-identity wikilink via `userInput.ownerIdentity`. Precedence
+      // chain: explicit grounding `isDefinedBy` > parent inheritance >
+      // vault-default `ownerIdentity`.
       if (!isDefinedByWritten && ownerIdentity) {
         lines.push(
           `exo__Asset_isDefinedBy: ${toQuotedWikilink(ownerIdentity)}`,

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -491,6 +491,33 @@ describe("ServiceRegistryPopulator", () => {
       );
     });
 
+    it("explicit isDefinedBy from grounding targetValue wins over ownerIdentity fallback", async () => {
+      const service = registry.get("createAsset")!;
+      await service.execute("", {
+        prototypeUID: "ztlk__FleetingNotePrototype",
+        label: "Pinned-owner note",
+        folder: "03 Knowledge/inbox",
+        // GroundingExecutor merges targetValue defaults into userInput; an
+        // explicit `isDefinedBy` pin must trump the registrar-injected
+        // vault default `ownerIdentity`.
+        isDefinedBy: "[[0aa339bc-9b56-400a-8148-cbde57bbf0b6]]",
+        ownerIdentity: "[[!some-other-default]]",
+      });
+
+      const writeCall = (deps.fileSystemAdapter.createFile as jest.Mock).mock
+        .calls[0];
+      const writtenContent: string = writeCall[1];
+      expect(writtenContent).toContain(
+        'exo__Asset_isDefinedBy: "[[0aa339bc-9b56-400a-8148-cbde57bbf0b6]]"',
+      );
+      expect(writtenContent).not.toContain("[[!some-other-default]]");
+      // Guard against duplicate isDefinedBy lines (regression: parent block
+      // used to unconditionally append after explicit pin landed).
+      const occurrences = (writtenContent.match(/exo__Asset_isDefinedBy:/g) ?? [])
+        .length;
+      expect(occurrences).toBe(1);
+    });
+
     it("omits exo__Asset_isDefinedBy when neither parent nor ownerIdentity supplies it", async () => {
       const service = registry.get("createAsset")!;
       await service.execute("", {


### PR DESCRIPTION
## Summary

Promote `isDefinedBy` from a buried key inside `Grounding_targetValue` JSON to a first-class frontmatter wikilink on the Grounding asset. The pinned identity asset (e.g. `0aa339bc-…` for `a.kitelev`) now lists every Grounding that references it via Obsidian's metadataCache backlinks / Asset Relations panel.

## Why

Follow-up to #3155. The user pointed out that putting an `isDefinedBy: "[[uuid]]"` inside a JSON-string `targetValue` hides the relationship from Obsidian — the wikilink isn't parsed and so the identity's layout can't surface "which commands pin me". Standalone property fixes this without losing the override semantics.

## Changes

- `CommandProperty.GroundingProperty.IS_DEFINED_BY` constant
- `GroundingDefinition.isDefinedBy?: string` field
- `CommandResolver` reads `Grounding_isDefinedBy` via `getObsidianWikilinkValue` (UUID-canon + alias resolution, identical to `targetValue` path)
- `GroundingExecutor.executeServiceCall`:
  - Injects `grounding.isDefinedBy` as a default in `mergedInput` BEFORE the JSON-targetValue merge
  - Bug fix: JSON-targetValue merge now spreads `mergedInput` (not raw `userInput`) so successive default sources stack instead of overwriting each other
- 2 new unit tests in `GroundingExecutor.test.ts` (inject default; `userInput` runtime override wins)

Companion vault edit (separate, in `/Users/kitelev/vault-2025`): grounding `c84e2e08-…` drops `isDefinedBy` from `targetValue` JSON and gains the standalone `exocmd__Grounding_isDefinedBy: "[[<a.kitelev-uid>]]"` property + updated body documentation.

## Test plan
- [x] `GroundingExecutor.test.ts` — 97 pass (+2)
- [x] `ServiceRegistryPopulator.test.ts` — 83 pass (unchanged)
- [x] `CommandResolver*.test.ts` — 87 pass (unchanged)
- [x] BDD coverage 100%, archgate green
- [ ] CI green (13 required checks)
- [ ] Post-release manual: Cmd+P → "Create fleeting note" still pins `[[a.kitelev]]` AND the layout of `a.kitelev` asset shows c84e2e08 grounding in backlinks/Asset Relations

Refs RFC `1429fcd0`, prior PR #3155.