### PR TITLE
fix(daily-tasks): recognize UUID-canon class refs in DailyNoteHelpers

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
@@ -7,6 +7,12 @@ export interface DailyNoteInfo {
   day: string | null;
 }
 
+// UUID-canon (RFC-004 follow-up, 2026-05-16): class TBox files are renamed
+// to `<uid>.md`, so `exo__Instance_class` in instances is now stored as
+// `[[<uid>]]`. The symbolic alternative is retained as a fallback for
+// vaults that have not migrated yet.
+const PN_DAILYNOTE_UID = "b04e7a3e-6b49-4984-9f8d-b74e9f36818b";
+
 export class DailyNoteHelpers {
   /**
    * Checks if a file is a daily note and extracts the day property
@@ -23,7 +29,11 @@ export class DailyNoteHelpers {
       ? instanceClass
       : [instanceClass];
     const isDailyNote = classes.some(
-      (c: string | null) => c === "[[pn__DailyNote]]" || c === "pn__DailyNote",
+      (c: string | null) =>
+        c === "[[pn__DailyNote]]" ||
+        c === "pn__DailyNote" ||
+        c === `[[${PN_DAILYNOTE_UID}]]` ||
+        c === PN_DAILYNOTE_UID,
     );
 
     if (!isDailyNote) {

--- a/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.test.ts
+++ b/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.test.ts
@@ -65,6 +65,42 @@ describe("DailyNoteHelpers", () => {
       expect(result.day).toBe("2025-10-15");
     });
 
+    it("should return isDailyNote=true for UUID-canon class ref [[<uid>]] (RFC-004)", () => {
+      const mockFile = { path: "2025-10-15.md" } as TFile;
+      mockMetadataExtractor.extractMetadata.mockReturnValue({
+        pn__DailyNote_day: "[[2025-10-15]]",
+      });
+      mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+        "[[b04e7a3e-6b49-4984-9f8d-b74e9f36818b]]",
+      );
+
+      const result = DailyNoteHelpers.extractDailyNoteInfo(
+        mockFile,
+        mockMetadataExtractor,
+      );
+
+      expect(result.isDailyNote).toBe(true);
+      expect(result.day).toBe("2025-10-15");
+    });
+
+    it("should return isDailyNote=true for bare-UUID class ref (RFC-004)", () => {
+      const mockFile = { path: "2025-10-15.md" } as TFile;
+      mockMetadataExtractor.extractMetadata.mockReturnValue({
+        pn__DailyNote_day: "2025-10-15",
+      });
+      mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+        "b04e7a3e-6b49-4984-9f8d-b74e9f36818b",
+      );
+
+      const result = DailyNoteHelpers.extractDailyNoteInfo(
+        mockFile,
+        mockMetadataExtractor,
+      );
+
+      expect(result.isDailyNote).toBe(true);
+      expect(result.day).toBe("2025-10-15");
+    });
+
     it("should return isDailyNote=true with day=null when pn__DailyNote_day is missing", () => {
       const mockFile = { path: "daily.md" } as TFile;
       mockMetadataExtractor.extractMetadata.mockReturnValue({});


### PR DESCRIPTION
## Summary

- After RFC-004 UUID-canon bulk rename of TBox files (2026-05-16), every DailyNote in a migrated vault stores `exo__Instance_class: [[b04e7a3e-6b49-4984-9f8d-b74e9f36818b]]` instead of `[[pn__DailyNote]]`.
- `DailyNoteHelpers.extractDailyNoteInfo` only matched the symbolic form → `isDailyNote=false` → `DailyTasksRenderer.render` bails before rendering anything → **Tasks section disappears from DailyNote layout** (reported on mobile after plugin upgrade).
- Parallel to #3141 (which fixed the same UUID→symbolic gap in `DynamicCommandButtonGroupBuilder`), but that change did not extend to this helper.

## Fix

Hotfix-narrow: extend the class match in `DailyNoteHelpers.ts` to also accept `[[<uid>]]` and bare `<uid>` for the pinned `pn__DailyNote` UID (`b04e7a3e-6b49-4984-9f8d-b74e9f36818b`). Symbolic form is retained as fallback for pre-migration vaults and existing fixtures. No new dependencies, no API change — single static helper, zero regression surface.

## Test plan

- [x] Added 2 unit tests covering `[[<uid>]]` and bare-`<uid>` cases in `DailyNoteHelpers.test.ts`
- [x] `npx jest packages/obsidian-plugin/tests/unit/DailyNoteHelpers.test.ts` → 27/27 passing locally
- [ ] CI: 13 required checks
- [ ] Manual verification on phone after release: open today's DailyNote, confirm Tasks section renders

## Follow-up (separate PR)

Audit other sites doing direct symbolic-only class matches after UUID-canon migration:
```
grep -rn '=== "\[\[\(pn\|ems\|ims\|aiknow\|pmbok\)__\|=== "\(pn\|ems\|ims\|aiknow\|pmbok\)__' packages/obsidian-plugin/src packages/exocortex/src
```
Likely candidates: Layout matching, Project filter, other class-targeted renderers. Consider extracting `isClassMatch(value, symbolicName, uid)` helper.