### PR TITLE
fix(daily-tasks): derive day from YYYY-MM-DD basename when frontmatter lacks pn__DailyNote_day

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
@@ -42,7 +42,18 @@ export class DailyNoteHelpers {
 
     const dayProperty = metadata.pn__DailyNote_day;
     if (!dayProperty) {
-      logger?.debug("No pn__DailyNote_day found for daily note");
+      // Fallback: derive day from basename when frontmatter lacks the
+      // explicit property. obsidian-calendar-plugin and most daily-note
+      // templates name files `YYYY-MM-DD*` (e.g. "2026-05-17 Note.md"),
+      // so the basename prefix is a reliable source of truth. This keeps
+      // the Tasks section rendering for daily notes created by templates
+      // that don't populate `pn__DailyNote_day` (regression seen on
+      // vault-2025 daily notes from 2025-11 onward).
+      const basenameDay = DailyNoteHelpers.extractDayFromBasename(file);
+      if (basenameDay) {
+        return { isDailyNote: true, day: basenameDay };
+      }
+      logger?.debug("No pn__DailyNote_day or YYYY-MM-DD basename for daily note");
       return { isDailyNote: true, day: null };
     }
 
@@ -55,6 +66,18 @@ export class DailyNoteHelpers {
       : String(dayProperty).replace(/^\[\[|\]\]$/g, "");
 
     return { isDailyNote: true, day };
+  }
+
+  /**
+   * Extract a `YYYY-MM-DD` day from a filename basename like
+   * `2026-05-17 Note.md`. Returns null if the basename does not begin
+   * with that pattern.
+   */
+  private static extractDayFromBasename(file: TFile | IFile): string | null {
+    const basename = file.basename;
+    if (!basename) return null;
+    const match = basename.match(/^(\d{4}-\d{2}-\d{2})/);
+    return match ? match[1] : null;
   }
 
   static findDailyNoteByDate(

--- a/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.test.ts
+++ b/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.test.ts
@@ -101,8 +101,40 @@ describe("DailyNoteHelpers", () => {
       expect(result.day).toBe("2025-10-15");
     });
 
-    it("should return isDailyNote=true with day=null when pn__DailyNote_day is missing", () => {
-      const mockFile = { path: "daily.md" } as TFile;
+    it("should derive day from basename when pn__DailyNote_day is missing (YYYY-MM-DD prefix)", () => {
+      const mockFile = { path: "2026-05-17 Note.md", basename: "2026-05-17 Note" } as TFile;
+      mockMetadataExtractor.extractMetadata.mockReturnValue({});
+      mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+        "[[pn__DailyNote]]",
+      );
+
+      const result = DailyNoteHelpers.extractDailyNoteInfo(
+        mockFile,
+        mockMetadataExtractor,
+      );
+
+      expect(result.isDailyNote).toBe(true);
+      expect(result.day).toBe("2026-05-17");
+    });
+
+    it("should derive day from basename also for UUID-canon class refs", () => {
+      const mockFile = { path: "2026-05-17.md", basename: "2026-05-17" } as TFile;
+      mockMetadataExtractor.extractMetadata.mockReturnValue({});
+      mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+        "[[b04e7a3e-6b49-4984-9f8d-b74e9f36818b]]",
+      );
+
+      const result = DailyNoteHelpers.extractDailyNoteInfo(
+        mockFile,
+        mockMetadataExtractor,
+      );
+
+      expect(result.isDailyNote).toBe(true);
+      expect(result.day).toBe("2026-05-17");
+    });
+
+    it("should return day=null when pn__DailyNote_day missing AND basename does not match YYYY-MM-DD", () => {
+      const mockFile = { path: "daily.md", basename: "daily" } as TFile;
       mockMetadataExtractor.extractMetadata.mockReturnValue({});
       mockMetadataExtractor.extractInstanceClass.mockReturnValue(
         "[[pn__DailyNote]]",
@@ -115,6 +147,24 @@ describe("DailyNoteHelpers", () => {
 
       expect(result.isDailyNote).toBe(true);
       expect(result.day).toBeNull();
+    });
+
+    it("should prefer pn__DailyNote_day over basename when both present", () => {
+      const mockFile = { path: "2026-05-17 Note.md", basename: "2026-05-17 Note" } as TFile;
+      mockMetadataExtractor.extractMetadata.mockReturnValue({
+        pn__DailyNote_day: "[[2025-12-25]]",
+      });
+      mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+        "[[pn__DailyNote]]",
+      );
+
+      const result = DailyNoteHelpers.extractDailyNoteInfo(
+        mockFile,
+        mockMetadataExtractor,
+      );
+
+      expect(result.isDailyNote).toBe(true);
+      expect(result.day).toBe("2025-12-25");
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.core.test.ts
+++ b/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.core.test.ts
@@ -42,11 +42,14 @@ describe("DailyTasksRenderer - render", () => {
     expect(ctx.mockReactRenderer.render).not.toHaveBeenCalled();
   });
 
-  it("should not render when pn__DailyNote_day is missing", async () => {
+  it("should not render when pn__DailyNote_day is missing AND basename has no YYYY-MM-DD prefix", async () => {
+    // Both `pn__DailyNote_day` and the basename-fallback (YYYY-MM-DD
+    // prefix) are absent, so `extractDailyNoteInfo` returns day=null
+    // and the renderer must bail.
     const mockFile = {
-      path: "test.md",
+      path: "daily.md",
       parent: { path: "DailyNotes" },
-      basename: "2025-10-20",
+      basename: "daily",
     } as TFile;
     const metadata = { exo__Instance_class: ["[[pn__DailyNote]]"] };
 
@@ -59,7 +62,7 @@ describe("DailyTasksRenderer - render", () => {
     await ctx.renderer.render(mockEl, mockFile);
 
     expect(ctx.mockLogger.debug).toHaveBeenCalledWith(
-      "No pn__DailyNote_day found for daily note",
+      "No pn__DailyNote_day or YYYY-MM-DD basename for daily note",
     );
     expect(ctx.mockReactRenderer.render).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Daily notes created by templates (or by obsidian-calendar-plugin) often do not populate the explicit `pn__DailyNote_day` frontmatter property. `DailyNoteHelpers.extractDailyNoteInfo` returned `day=null` for those, which caused `DailyTasksRenderer.render` to bail and the **Tasks section to disappear from the layout** — even with #3158 already in place.

Empirical: 217 of 283 daily-note files in vault-2025 lacked the property (everything from 2025-11 onward, after a template change). Verified end-to-end on macOS Obsidian via computer-control after backfilling vault frontmatter + this fix.

## Fix

When `pn__DailyNote_day` is absent, fall back to parsing the basename for a `YYYY-MM-DD` prefix (e.g. `"2026-05-17 Note"` → day `"2026-05-17"`). This matches the daily-note basename convention required by [obsidian-calendar-plugin](https://github.com/liamcain/obsidian-calendar-plugin) — already whitelisted in CLAUDE.md UUID-CANON rule for `pn__DailyNote`.

Explicit property still takes precedence when both are present, so users can override the day inferred from the filename if needed.

## Test plan

- [x] 4 new unit cases in `DailyNoteHelpers.test.ts` (basename derivation with symbolic + UUID class refs, no-match fallback to null, property-precedence) — 30/30 pass
- [x] Updated `DailyTasksRenderer.core.test.ts` "should not render" case to use a basename without `YYYY-MM-DD` prefix (otherwise fallback now legitimately succeeds and renderer proceeds further) — 200/200 related tests pass
- [x] Manual E2E on macOS Obsidian after vault backfill + v16.7.2 plugin: Tasks section renders 6 tasks for today's `2026-05-17 Note.md` (UUID-canon class ref + missing `pn__DailyNote_day` + basename matches `YYYY-MM-DD`)
- [ ] CI: 13 required checks