### PR TITLE
fix(grounding): restore label+date prefill for create_instance (regression from v15.38)

### DIFF
--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -139,6 +139,30 @@ export interface GroundingDefinition {
    * identity asset's incoming-links / layout.
    */
   readonly isDefinedBy?: string;
+  /**
+   * Opt-in flag for `create_instance` groundings: when `true`, the modal
+   * pre-fills the `label` input with `${prototype.exo__Asset_label} YYYY-MM-DD`
+   * (e.g. `Morning Wim Hof 2026-05-17`).
+   *
+   * Restores the legacy v15.38 `CreateInstanceCommand` behaviour that was lost
+   * when commands migrated to the vault-driven exocmd pipeline (commit
+   * abdb19a3 / PR #2733 stripped `default` from the inputSchema mapping).
+   *
+   * Authored as the `exocmd__Grounding_prefillLabelWithDate` RDF triple
+   * (`xsd:boolean`). Default `false` keeps existing groundings unchanged.
+   */
+  readonly prefillLabelWithDate?: boolean;
+  /**
+   * Resolved `exo__Asset_label` of the prototype referenced by
+   * `targetPrototype`. Populated by `CommandResolver` only when
+   * `prefillLabelWithDate === true` (otherwise omitted to keep grounding
+   * definitions lean).
+   *
+   * `CommandExecutionFlow` reads this together with the current date to build
+   * the prefill string at the moment the user clicks the button — so the date
+   * portion stays fresh even though the grounding definition is cached.
+   */
+  readonly prototypeLabel?: string;
 }
 
 /**

--- a/packages/exocortex/src/services/CommandExecutionFlow.ts
+++ b/packages/exocortex/src/services/CommandExecutionFlow.ts
@@ -3,6 +3,9 @@ import type { GroundingExecutor, UserInput } from "./GroundingExecutor";
 import type { ResolvedCommand } from "./CommandResolver";
 import type { INotificationService } from "../interfaces/INotificationService";
 import type { ILogger } from "../interfaces/ILogger";
+import type { GroundingDefinition } from "../domain/models/CommandDefinition";
+import { GroundingType } from "../domain/constants/GroundingType";
+import { DateFormatter } from "../utilities/DateFormatter";
 
 /**
  * Surface-agnostic execution context for a resolved exocmd command.
@@ -82,7 +85,11 @@ export class CommandExecutionFlow {
     let userInput: UserInput | undefined = ctx.injectedUserInput;
     const inputSchema = CommandExecutionFlow.extractInputSchema(rc);
     if (inputSchema !== null && inputSchema.length > 0) {
-      const collected = await this.prompts.promptInputSchema(inputSchema);
+      const effectiveSchema = CommandExecutionFlow.applyLabelDatePrefill(
+        inputSchema,
+        command.grounding,
+      );
+      const collected = await this.prompts.promptInputSchema(effectiveSchema);
       if (collected === null) return;
       userInput = { ...(ctx.injectedUserInput ?? {}), ...collected };
     }
@@ -133,5 +140,43 @@ export class CommandExecutionFlow {
     ];
     if (!raw || !Array.isArray(raw)) return null;
     return raw;
+  }
+
+  /**
+   * Opt-in pre-fill of the `label` modal field for `create_instance` groundings
+   * — restores the v15.38 behaviour stripped by PR #2733. Active only when:
+   *   - grounding type is `create_instance`,
+   *   - `prefillLabelWithDate` is true on the grounding (RDF opt-in),
+   *   - the resolver populated `prototypeLabel`,
+   *   - the schema has a field named `label` without an existing defaultValue.
+   *
+   * The current date is computed here (not in the resolver) so it stays fresh
+   * regardless of grounding caching. Defaults already supplied by the schema
+   * author win — user-explicit configuration takes precedence over the prefill.
+   *
+   * Date formatter matches the legacy `CreateInstanceCommand.showModal()` —
+   * `DateFormatter.toDateString` uses local-tz calendar parts so the prefill
+   * stays "today" in the user's timezone (Almaty UTC+5, etc.) even between
+   * 00:00–04:59 local when UTC would still report yesterday.
+   */
+  static applyLabelDatePrefill(
+    schema: ReadonlyArray<unknown>,
+    grounding: GroundingDefinition,
+  ): ReadonlyArray<unknown> {
+    if (grounding.type !== GroundingType.CREATE_INSTANCE) return schema;
+    if (!grounding.prefillLabelWithDate) return schema;
+    if (!grounding.prototypeLabel) return schema;
+
+    const today = DateFormatter.toDateString(new Date());
+    const prefill = `${grounding.prototypeLabel} ${today}`;
+
+    return schema.map((field) => {
+      if (typeof field !== "object" || field === null) return field;
+      const f = field as Record<string, unknown>;
+      if (f.name !== "label") return field;
+      const existing = f.defaultValue;
+      if (typeof existing === "string" && existing.length > 0) return field;
+      return { ...f, defaultValue: prefill };
+    });
   }
 }

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -950,24 +950,55 @@ export class CommandResolver {
       steps = await this.loadCompositeSteps(subject, depth + 1);
     }
 
-    // Parse inputSchema JSON into array of field descriptors for form modals
+    // Parse inputSchema JSON into array of field descriptors for form modals.
+    // `default` / `defaultValue` are propagated so static prefills authored in
+    // the JSON Schema survive the projection (restoration of v15.38 behaviour
+    // — pre-PR #2733 this field was silently dropped).
     let inputSchema: unknown[] | undefined;
     if (inputSchemaRaw) {
       try {
         const parsed = JSON.parse(inputSchemaRaw);
         if (parsed?.properties) {
-          inputSchema = Object.entries(parsed.properties as Record<string, Record<string, string>>).map(
-            ([name, prop]) => ({
-              name,
-              type: prop.type === "string" ? "text" : prop.type,
-              label: prop.title ?? name,
-              required: Array.isArray(parsed.required) && parsed.required.includes(name),
-            }),
+          inputSchema = Object.entries(parsed.properties as Record<string, Record<string, unknown>>).map(
+            ([name, prop]) => {
+              const rawType = prop.type;
+              const fieldType = rawType === "string" ? "text" : rawType;
+              const rawDefault =
+                prop.defaultValue !== undefined ? prop.defaultValue : prop.default;
+              const field: Record<string, unknown> = {
+                name,
+                type: fieldType,
+                label: prop.title ?? name,
+                required: Array.isArray(parsed.required) && parsed.required.includes(name),
+              };
+              if (rawDefault !== undefined && rawDefault !== null) {
+                field.defaultValue = String(rawDefault);
+              }
+              return field;
+            },
           );
         }
       } catch {
         // Invalid JSON — skip inputSchema
       }
+    }
+
+    // Restoration regression v15.38: opt-in pre-fill of the `label` modal field
+    // with `${prototype.exo__Asset_label} YYYY-MM-DD`. The boolean flag lives
+    // on the grounding; the prototype label is resolved here (one triple-store
+    // lookup, cached with the grounding) so that `CommandExecutionFlow` can
+    // build the final string at click-time without acquiring a triple-store
+    // dependency.
+    const prefillRaw = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("Grounding_prefillLabelWithDate"),
+    );
+    const prefillLabelWithDate =
+      prefillRaw !== null && String(prefillRaw).trim().toLowerCase() === "true";
+
+    let prototypeLabel: string | undefined;
+    if (prefillLabelWithDate && type === GroundingType.CREATE_INSTANCE) {
+      prototypeLabel = await this.resolvePrototypeLabel(subject);
     }
 
     const grounding: GroundingDefinition = {
@@ -986,6 +1017,8 @@ export class CommandResolver {
       shiftDelta: shiftDelta ?? undefined,
       propertyDefaults,
       isDefinedBy: isDefinedBy ?? undefined,
+      prefillLabelWithDate: prefillLabelWithDate || undefined,
+      prototypeLabel,
     };
 
     if (inputSchema) {
@@ -993,6 +1026,43 @@ export class CommandResolver {
     }
 
     return grounding;
+  }
+
+  /**
+   * Read the `exo__Asset_label` of the prototype referenced by
+   * `exocmd__Grounding_targetPrototype`. Resolves alias-form
+   * `[[<UID>|<symbolic>]]` to the UID (NOT the symbolic tail) so the lookup
+   * works against UUID-canonicalised vaults (CLAUDE.md §UUID-canon).
+   * Returns `undefined` when the prototype is missing, unresolved, or has no
+   * label — callers must handle the absence gracefully (no prefill).
+   */
+  private async resolvePrototypeLabel(
+    groundingSubject: IRI,
+  ): Promise<string | undefined> {
+    const refTriples = await this.tripleStore.match(
+      groundingSubject,
+      Namespace.EXOCMD.term("Grounding_targetPrototype"),
+      undefined,
+    );
+    if (refTriples.length === 0) return undefined;
+
+    const ref = refTriples[0].object;
+    let prototypeSubject: IRI | null = null;
+    if (ref instanceof IRI) {
+      prototypeSubject = ref;
+    } else if (ref instanceof Literal) {
+      const uid = this.normalizeWikilink(ref.value);
+      if (uid) {
+        prototypeSubject = await this.findSubjectByUID(uid);
+      }
+    }
+    if (!prototypeSubject) return undefined;
+
+    const label = await this.getLiteralValue(
+      prototypeSubject,
+      Namespace.EXO.term("Asset_label"),
+    );
+    return label ?? undefined;
   }
 
   private async loadCompositeSteps(

--- a/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
+++ b/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
@@ -12,6 +12,7 @@ import type { INotificationService } from "../../src/interfaces/INotificationSer
 import type { ILogger } from "../../src/interfaces/ILogger";
 import type { GroundingDefinition } from "../../src/domain/models/CommandDefinition";
 import { GroundingType } from "../../src/domain/constants/GroundingType";
+import { DateFormatter } from "../../src/utilities/DateFormatter";
 
 const baseGrounding: GroundingDefinition = {
   id: "grounding-1",
@@ -204,6 +205,172 @@ describe("CommandExecutionFlow", () => {
       await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
 
       expect(prompts.promptInputSchema).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("applyLabelDatePrefill (v15.38 regression restoration)", () => {
+    // Patch the date helper directly — keeps the test deterministic regardless
+    // of the runner's timezone (DateFormatter.toDateString uses local-tz
+    // calendar parts, so fake-system-time + UTC instants drift between TZs).
+    let toDateStringSpy: jest.SpyInstance<string, [Date]>;
+
+    beforeEach(() => {
+      toDateStringSpy = jest
+        .spyOn(DateFormatter, "toDateString")
+        .mockReturnValue("2026-05-17");
+    });
+
+    afterEach(() => {
+      toDateStringSpy.mockRestore();
+    });
+
+    it("prefills label field with `${prototypeLabel} YYYY-MM-DD` when flag is on", () => {
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.CREATE_INSTANCE,
+        targetPrototype: "proto-uid",
+        targetFolder: "01 Inbox",
+        prefillLabelWithDate: true,
+        prototypeLabel: "Morning Wim Hof",
+      };
+      const schema = [{ name: "label", type: "text", required: true }];
+
+      const result = CommandExecutionFlow.applyLabelDatePrefill(
+        schema,
+        grounding,
+      );
+
+      expect(result).toEqual([
+        {
+          name: "label",
+          type: "text",
+          required: true,
+          defaultValue: "Morning Wim Hof 2026-05-17",
+        },
+      ]);
+    });
+
+    it("is no-op when prefillLabelWithDate is false / missing", () => {
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.CREATE_INSTANCE,
+        targetFolder: "01 Inbox",
+        prototypeLabel: "Whatever",
+      };
+      const schema = [{ name: "label", type: "text" }];
+
+      expect(
+        CommandExecutionFlow.applyLabelDatePrefill(schema, grounding),
+      ).toBe(schema);
+    });
+
+    it("is no-op when grounding type is not create_instance", () => {
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.PROPERTY_SET,
+        prefillLabelWithDate: true,
+        prototypeLabel: "Morning Wim Hof",
+      };
+      const schema = [{ name: "label", type: "text" }];
+
+      expect(
+        CommandExecutionFlow.applyLabelDatePrefill(schema, grounding),
+      ).toBe(schema);
+    });
+
+    it("is no-op when prototypeLabel is missing (graceful fallback)", () => {
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.CREATE_INSTANCE,
+        targetFolder: "01 Inbox",
+        prefillLabelWithDate: true,
+      };
+      const schema = [{ name: "label", type: "text" }];
+
+      const result = CommandExecutionFlow.applyLabelDatePrefill(
+        schema,
+        grounding,
+      );
+      expect(result).toBe(schema);
+    });
+
+    it("does not overwrite an existing non-empty defaultValue (user-explicit wins)", () => {
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.CREATE_INSTANCE,
+        targetFolder: "01 Inbox",
+        prefillLabelWithDate: true,
+        prototypeLabel: "Morning Wim Hof",
+      };
+      const schema = [
+        {
+          name: "label",
+          type: "text",
+          defaultValue: "Author Explicit Default",
+        },
+      ];
+
+      const result = CommandExecutionFlow.applyLabelDatePrefill(
+        schema,
+        grounding,
+      );
+      expect(result[0]).toEqual({
+        name: "label",
+        type: "text",
+        defaultValue: "Author Explicit Default",
+      });
+    });
+
+    it("leaves non-label fields untouched even when prefill is active", () => {
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.CREATE_INSTANCE,
+        targetFolder: "01 Inbox",
+        prefillLabelWithDate: true,
+        prototypeLabel: "Morning Wim Hof",
+      };
+      const schema = [
+        { name: "label", type: "text" },
+        { name: "note", type: "multiline" },
+      ];
+
+      const result = CommandExecutionFlow.applyLabelDatePrefill(
+        schema,
+        grounding,
+      );
+      expect(result).toEqual([
+        {
+          name: "label",
+          type: "text",
+          defaultValue: "Morning Wim Hof 2026-05-17",
+        },
+        { name: "note", type: "multiline" },
+      ]);
+    });
+
+    it("flow.run passes prefilled schema into promptInputSchema", async () => {
+      const { flow, prompts } = makeFlow({
+        promptResult: { label: "user-typed" },
+      });
+      const rc = makeRC(
+        {},
+        {
+          type: GroundingType.CREATE_INSTANCE,
+          targetPrototype: "proto-uid",
+          targetFolder: "01 Inbox",
+          prefillLabelWithDate: true,
+          prototypeLabel: "Morning Wim Hof",
+          inputSchema: [{ name: "label", type: "text", required: true }],
+        },
+      );
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(prompts.promptInputSchema).toHaveBeenCalledTimes(1);
+      const passedSchema = prompts.promptInputSchema.mock.calls[0][0] as Array<
+        Record<string, unknown>
+      >;
+      expect(passedSchema[0].defaultValue).toBe("Morning Wim Hof 2026-05-17");
     });
   });
 

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -449,6 +449,173 @@ describe("CommandResolver", () => {
       });
     });
 
+    it("should parse exocmd__Grounding_prefillLabelWithDate and resolve prototypeLabel from triple store", async () => {
+      const prototypeSubject = new IRI("obsidian://vault/proto-1.md");
+      await store.addAll([
+        new Triple(prototypeSubject, Namespace.RDF.term("type"), Namespace.EXO.term("Asset")),
+        new Triple(prototypeSubject, Namespace.EXO.term("Asset_uid"), new Literal("proto-1")),
+        new Triple(prototypeSubject, Namespace.EXO.term("Asset_label"), new Literal("Morning Wim Hof")),
+      ]);
+      const groundingSubject = new IRI("obsidian://vault/gnd-prefill.md");
+      await store.addAll([
+        new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-prefill")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("Create Wim Hof session")),
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("create_instance")),
+        new Triple(
+          groundingSubject,
+          Namespace.EXOCMD.term("Grounding_targetPrototype"),
+          new Literal("[[proto-1|Morning Wim Hof]]"),
+        ),
+        new Triple(
+          groundingSubject,
+          Namespace.EXOCMD.term("Grounding_prefillLabelWithDate"),
+          new Literal("true"),
+        ),
+      ]);
+      await addCommandAsset(store, {
+        uid: "cmd-prefill",
+        label: "Create Wim Hof Session",
+        groundingRef: "gnd-prefill",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-prefill");
+
+      expect(cmd!.grounding.prefillLabelWithDate).toBe(true);
+      expect(cmd!.grounding.prototypeLabel).toBe("Morning Wim Hof");
+    });
+
+    it("should leave prefillLabelWithDate undefined when triple is absent (backward-compat)", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-no-prefill",
+        label: "Plain create_instance",
+        type: "create_instance",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-no-prefill",
+        label: "Plain",
+        groundingRef: "gnd-no-prefill",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-no-prefill");
+
+      expect(cmd!.grounding.prefillLabelWithDate).toBeUndefined();
+      expect(cmd!.grounding.prototypeLabel).toBeUndefined();
+    });
+
+    it("should leave prefillLabelWithDate undefined for non-true literals (only 'true' opts in)", async () => {
+      const groundingSubject = new IRI("obsidian://vault/gnd-not-true.md");
+      await store.addAll([
+        new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-not-true")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("Disabled prefill")),
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("create_instance")),
+        new Triple(
+          groundingSubject,
+          Namespace.EXOCMD.term("Grounding_prefillLabelWithDate"),
+          new Literal("false"),
+        ),
+      ]);
+      await addCommandAsset(store, {
+        uid: "cmd-not-true",
+        label: "Disabled",
+        groundingRef: "gnd-not-true",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-not-true");
+
+      expect(cmd!.grounding.prefillLabelWithDate).toBeUndefined();
+      expect(cmd!.grounding.prototypeLabel).toBeUndefined();
+    });
+
+    it("should leave prototypeLabel undefined when prototype asset is missing (graceful fallback)", async () => {
+      const groundingSubject = new IRI("obsidian://vault/gnd-orphan.md");
+      await store.addAll([
+        new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-orphan")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("Orphan proto")),
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("create_instance")),
+        new Triple(
+          groundingSubject,
+          Namespace.EXOCMD.term("Grounding_targetPrototype"),
+          new Literal("[[missing-proto]]"),
+        ),
+        new Triple(
+          groundingSubject,
+          Namespace.EXOCMD.term("Grounding_prefillLabelWithDate"),
+          new Literal("true"),
+        ),
+      ]);
+      await addCommandAsset(store, {
+        uid: "cmd-orphan",
+        label: "Orphan",
+        groundingRef: "gnd-orphan",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-orphan");
+
+      expect(cmd!.grounding.prefillLabelWithDate).toBe(true);
+      expect(cmd!.grounding.prototypeLabel).toBeUndefined();
+    });
+
+    it("should pass through `default` and `defaultValue` from inputSchema JSON Schema properties", async () => {
+      const groundingSubject = new IRI("obsidian://vault/gnd-defaults-input.md");
+      await store.addAll([
+        new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-defaults-input")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("With input defaults")),
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("create_instance")),
+        new Triple(
+          groundingSubject,
+          Namespace.EXOCMD.term("Grounding_inputSchema"),
+          new Literal(
+            JSON.stringify({
+              type: "object",
+              properties: {
+                label: { type: "string", title: "Label", default: "Static default" },
+                note: { type: "string", title: "Note", defaultValue: "from defaultValue" },
+                empty: { type: "string", title: "Empty" },
+              },
+              required: ["label"],
+            }),
+          ),
+        ),
+      ]);
+      await addCommandAsset(store, {
+        uid: "cmd-defaults-input",
+        label: "With input defaults",
+        groundingRef: "gnd-defaults-input",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-defaults-input");
+      const inputSchema = (cmd!.grounding as unknown as Record<string, unknown>)[
+        "inputSchema"
+      ] as Array<Record<string, unknown>>;
+
+      expect(inputSchema).toEqual([
+        {
+          name: "label",
+          type: "text",
+          label: "Label",
+          required: true,
+          defaultValue: "Static default",
+        },
+        {
+          name: "note",
+          type: "text",
+          label: "Note",
+          required: false,
+          defaultValue: "from defaultValue",
+        },
+        {
+          name: "empty",
+          type: "text",
+          label: "Empty",
+          required: false,
+        },
+      ]);
+    });
+
     it("should fail-loud when exocmd__Grounding_propertyDefaults is invalid JSON", async () => {
       const groundingSubject = new IRI(`obsidian://vault/gnd-bad-defaults.md`);
       await store.addAll([


### PR DESCRIPTION
## Summary
Restores plugin v15.38 behaviour: clicking «create instance prototype» now pre-fills the modal `label` field with `${prototype.exo__Asset_label} YYYY-MM-DD` (e.g. `Morning Wim Hof 2026-05-17`).

Regression was introduced in PR #2733 (commit abdb19a3, 2026-04-11) when commands migrated to the vault-driven exocmd pipeline — the new `CommandResolver` stripped `default`/`defaultValue` from `Grounding_inputSchema` projection, and JSON Schema cannot express a `{prototype.label} {today}` template natively.

## Change
- **New opt-in property `exocmd__Grounding_prefillLabelWithDate: boolean`** (default `false`) on `exocmd__Grounding` — companion ontology PR: kitelev/exocortex-exocmd-ontology#3.
- `CommandResolver.loadGroundingDefinition`:
  - parses the new flag;
  - when `true` on a `create_instance` grounding, resolves the referenced prototype's `exo__Asset_label` via one extra triple-store lookup (cached alongside the grounding, so this is a one-off cost per command load);
  - additionally **propagates `default` / `defaultValue` from inputSchema property descriptors** — closes the related dropped-field hole so any static JSON Schema default works again, not only label+date.
- `CommandExecutionFlow`:
  - new pure helper `applyLabelDatePrefill(schema, grounding)` patches the `label` field's `defaultValue` at click-time when all opt-in conditions are met;
  - date is computed via `DateFormatter.toDateString(new Date())` (local-tz, byte-identical to legacy `CreateInstanceCommand`) so prefill stays «today» in the user's TZ even between 00:00–04:59 local when UTC would still report yesterday;
  - call-site wires it in before `promptInputSchema`.

## Edge cases (covered by tests)
- Flag missing / `false` / type ≠ `create_instance` → no-op (`schema` returned unchanged by identity).
- `prototypeLabel` unresolved (prototype missing or no `Asset_label`) → graceful fallback, no prefill, no error.
- Pre-existing `defaultValue` on the `label` field → not overwritten (user-explicit wins).
- Non-label fields → untouched.

## Backward compat
Default `false` keeps existing groundings opening the modal with an empty field. The vault maintainer will opt-in the relevant groundings (Wim Hof, project prototype, etc.) in a follow-up vault pass.

## Test plan
- [x] `CommandResolver.test.ts`: new property parsed, backward-compat for absent / non-`true` literals, prototypeLabel resolved through UUID-canonical wikilink form, `default` / `defaultValue` propagated, graceful fallback when prototype missing.
- [x] `CommandExecutionFlow.test.ts`: prefill applied when all conditions met; no-op for each opt-out branch; doesn't overwrite existing defaults; flow.run pipes the patched schema into `promptInputSchema`.
- [x] `npm run check:types` clean.
- [x] `npm run lint` clean (2 pre-existing warnings unrelated).
- [ ] Manual smoke: after release, vault maintainer marks `exocmd__Grounding_prefillLabelWithDate: true` on test grounding → clicks button → label pre-filled with today's date.

## Note re: onto-RFC
Skipped formal onto-RFC per CLAUDE.md exemption: bug-fix / regression restoration. The new property is a mechanical opt-in flag — it doesn't introduce a new class of artifacts.

## Note re: pre-existing baseline failures
Verified via round-trip `git checkout origin/main`: the repository currently has 8 failing test suites on main that are unrelated to this change (`CommandConstants.test.ts` counts 6 enum values vs. actual 9; `create-instance-grounding.test.ts` has 12 InMemoryVaultAdapter wiring errors; etc.). CI may surface these as flakes; they predate this PR and should be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)