### PR TITLE
fix(grounding): resolve prefill label from current asset, not grounding.targetPrototype (v16.7.4 follow-up)

### DIFF
--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -152,17 +152,6 @@ export interface GroundingDefinition {
    * (`xsd:boolean`). Default `false` keeps existing groundings unchanged.
    */
   readonly prefillLabelWithDate?: boolean;
-  /**
-   * Resolved `exo__Asset_label` of the prototype referenced by
-   * `targetPrototype`. Populated by `CommandResolver` only when
-   * `prefillLabelWithDate === true` (otherwise omitted to keep grounding
-   * definitions lean).
-   *
-   * `CommandExecutionFlow` reads this together with the current date to build
-   * the prefill string at the moment the user clicks the button — so the date
-   * portion stays fresh even though the grounding definition is cached.
-   */
-  readonly prototypeLabel?: string;
 }
 
 /**

--- a/packages/exocortex/src/services/CommandExecutionFlow.ts
+++ b/packages/exocortex/src/services/CommandExecutionFlow.ts
@@ -3,8 +3,12 @@ import type { GroundingExecutor, UserInput } from "./GroundingExecutor";
 import type { ResolvedCommand } from "./CommandResolver";
 import type { INotificationService } from "../interfaces/INotificationService";
 import type { ILogger } from "../interfaces/ILogger";
+import type { ITripleStore } from "../interfaces/ITripleStore";
 import type { GroundingDefinition } from "../domain/models/CommandDefinition";
 import { GroundingType } from "../domain/constants/GroundingType";
+import { IRI } from "../domain/models/rdf/IRI";
+import { Literal } from "../domain/models/rdf/Literal";
+import { Namespace } from "../domain/models/rdf/Namespace";
 import { DateFormatter } from "../utilities/DateFormatter";
 
 /**
@@ -69,6 +73,7 @@ export class CommandExecutionFlow {
     private readonly notificationService: INotificationService,
     private readonly logger: ILogger,
     private readonly prompts: CommandPromptAdapter,
+    private readonly tripleStore?: ITripleStore,
   ) {}
 
   async run(
@@ -85,9 +90,10 @@ export class CommandExecutionFlow {
     let userInput: UserInput | undefined = ctx.injectedUserInput;
     const inputSchema = CommandExecutionFlow.extractInputSchema(rc);
     if (inputSchema !== null && inputSchema.length > 0) {
-      const effectiveSchema = CommandExecutionFlow.applyLabelDatePrefill(
+      const effectiveSchema = await this.applyLabelDatePrefill(
         inputSchema,
         command.grounding,
+        ctx.targetIRI,
       );
       const collected = await this.prompts.promptInputSchema(effectiveSchema);
       if (collected === null) return;
@@ -147,28 +153,43 @@ export class CommandExecutionFlow {
    * — restores the v15.38 behaviour stripped by PR #2733. Active only when:
    *   - grounding type is `create_instance`,
    *   - `prefillLabelWithDate` is true on the grounding (RDF opt-in),
-   *   - the resolver populated `prototypeLabel`,
+   *   - a `targetIRI` is available (the asset the user clicked the button on),
+   *   - that asset has a non-empty `exo__Asset_label`,
    *   - the schema has a field named `label` without an existing defaultValue.
    *
-   * The current date is computed here (not in the resolver) so it stays fresh
-   * regardless of grounding caching. Defaults already supplied by the schema
-   * author win — user-explicit configuration takes precedence over the prefill.
+   * The label source is the CURRENT asset (where the user clicked), not the
+   * grounding's `targetPrototype` — that matches the legacy v15.38
+   * `CreateInstanceCommand.showModal()` which builds `defaultLabel` from
+   * `metadata.exo__Asset_label || file.basename` of the active file.
+   *
+   * Runtime lookup (not resolver-time) keeps both the source label and the
+   * date portion fresh regardless of grounding caching. Defaults already
+   * supplied by the schema author win — user-explicit configuration takes
+   * precedence over the prefill.
    *
    * Date formatter matches the legacy `CreateInstanceCommand.showModal()` —
    * `DateFormatter.toDateString` uses local-tz calendar parts so the prefill
    * stays "today" in the user's timezone (Almaty UTC+5, etc.) even between
    * 00:00–04:59 local when UTC would still report yesterday.
+   *
+   * Graceful fallback: missing `tripleStore`, missing `targetIRI`, asset not
+   * found, or empty label → returns the schema unchanged (no-op).
    */
-  static applyLabelDatePrefill(
+  async applyLabelDatePrefill(
     schema: ReadonlyArray<unknown>,
     grounding: GroundingDefinition,
-  ): ReadonlyArray<unknown> {
+    targetIRI: string | null,
+  ): Promise<ReadonlyArray<unknown>> {
     if (grounding.type !== GroundingType.CREATE_INSTANCE) return schema;
     if (!grounding.prefillLabelWithDate) return schema;
-    if (!grounding.prototypeLabel) return schema;
+    if (!targetIRI) return schema;
+    if (!this.tripleStore) return schema;
+
+    const label = await this.resolveAssetLabel(targetIRI);
+    if (!label) return schema;
 
     const today = DateFormatter.toDateString(new Date());
-    const prefill = `${grounding.prototypeLabel} ${today}`;
+    const prefill = `${label} ${today}`;
 
     return schema.map((field) => {
       if (typeof field !== "object" || field === null) return field;
@@ -178,5 +199,28 @@ export class CommandExecutionFlow {
       if (typeof existing === "string" && existing.length > 0) return field;
       return { ...f, defaultValue: prefill };
     });
+  }
+
+  /**
+   * Read `exo__Asset_label` literal of the asset identified by `targetIRI`.
+   * Returns `undefined` when the triple is missing or non-literal — callers
+   * must handle the absence gracefully.
+   */
+  private async resolveAssetLabel(
+    targetIRI: string,
+  ): Promise<string | undefined> {
+    if (!this.tripleStore) return undefined;
+    const subject = new IRI(targetIRI);
+    const triples = await this.tripleStore.match(
+      subject,
+      Namespace.EXO.term("Asset_label"),
+      undefined,
+    );
+    if (triples.length === 0) return undefined;
+    const obj = triples[0].object;
+    if (obj instanceof Literal) {
+      return obj.value.length > 0 ? obj.value : undefined;
+    }
+    return undefined;
   }
 }

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -984,22 +984,16 @@ export class CommandResolver {
     }
 
     // Restoration regression v15.38: opt-in pre-fill of the `label` modal field
-    // with `${prototype.exo__Asset_label} YYYY-MM-DD`. The boolean flag lives
-    // on the grounding; the prototype label is resolved here (one triple-store
-    // lookup, cached with the grounding) so that `CommandExecutionFlow` can
-    // build the final string at click-time without acquiring a triple-store
-    // dependency.
+    // with `${currentAsset.exo__Asset_label} YYYY-MM-DD`. Only the boolean flag
+    // is parsed here. The label source (= the current asset the user clicked
+    // the button on) is resolved at click-time in `CommandExecutionFlow`, since
+    // the grounding definition is cached and the click target varies per-call.
     const prefillRaw = await this.getLiteralValue(
       subject,
       Namespace.EXOCMD.term("Grounding_prefillLabelWithDate"),
     );
     const prefillLabelWithDate =
       prefillRaw !== null && String(prefillRaw).trim().toLowerCase() === "true";
-
-    let prototypeLabel: string | undefined;
-    if (prefillLabelWithDate && type === GroundingType.CREATE_INSTANCE) {
-      prototypeLabel = await this.resolvePrototypeLabel(subject);
-    }
 
     const grounding: GroundingDefinition = {
       id: uid,
@@ -1018,7 +1012,6 @@ export class CommandResolver {
       propertyDefaults,
       isDefinedBy: isDefinedBy ?? undefined,
       prefillLabelWithDate: prefillLabelWithDate || undefined,
-      prototypeLabel,
     };
 
     if (inputSchema) {
@@ -1026,43 +1019,6 @@ export class CommandResolver {
     }
 
     return grounding;
-  }
-
-  /**
-   * Read the `exo__Asset_label` of the prototype referenced by
-   * `exocmd__Grounding_targetPrototype`. Resolves alias-form
-   * `[[<UID>|<symbolic>]]` to the UID (NOT the symbolic tail) so the lookup
-   * works against UUID-canonicalised vaults (CLAUDE.md §UUID-canon).
-   * Returns `undefined` when the prototype is missing, unresolved, or has no
-   * label — callers must handle the absence gracefully (no prefill).
-   */
-  private async resolvePrototypeLabel(
-    groundingSubject: IRI,
-  ): Promise<string | undefined> {
-    const refTriples = await this.tripleStore.match(
-      groundingSubject,
-      Namespace.EXOCMD.term("Grounding_targetPrototype"),
-      undefined,
-    );
-    if (refTriples.length === 0) return undefined;
-
-    const ref = refTriples[0].object;
-    let prototypeSubject: IRI | null = null;
-    if (ref instanceof IRI) {
-      prototypeSubject = ref;
-    } else if (ref instanceof Literal) {
-      const uid = this.normalizeWikilink(ref.value);
-      if (uid) {
-        prototypeSubject = await this.findSubjectByUID(uid);
-      }
-    }
-    if (!prototypeSubject) return undefined;
-
-    const label = await this.getLiteralValue(
-      prototypeSubject,
-      Namespace.EXO.term("Asset_label"),
-    );
-    return label ?? undefined;
   }
 
   private async loadCompositeSteps(

--- a/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
+++ b/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
@@ -13,6 +13,11 @@ import type { ILogger } from "../../src/interfaces/ILogger";
 import type { GroundingDefinition } from "../../src/domain/models/CommandDefinition";
 import { GroundingType } from "../../src/domain/constants/GroundingType";
 import { DateFormatter } from "../../src/utilities/DateFormatter";
+import { InMemoryTripleStore } from "../../src/infrastructure/rdf/InMemoryTripleStore";
+import { IRI } from "../../src/domain/models/rdf/IRI";
+import { Literal } from "../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../src/domain/models/rdf/Namespace";
+import { Triple } from "../../src/domain/models/rdf/Triple";
 
 const baseGrounding: GroundingDefinition = {
   id: "grounding-1",
@@ -46,6 +51,7 @@ function makeFlow(overrides?: {
   groundingResult?: ExecutionResult;
   confirmResult?: boolean;
   promptResult?: UserInput | null;
+  tripleStore?: InMemoryTripleStore;
 }) {
   const groundingExecutor = {
     execute: jest
@@ -75,14 +81,44 @@ function makeFlow(overrides?: {
       .mockResolvedValue(overrides?.promptResult ?? null),
   };
 
+  const tripleStore = overrides?.tripleStore;
+
   const flow = new CommandExecutionFlow(
     groundingExecutor,
     notificationService,
     logger,
     prompts,
+    tripleStore,
   );
 
-  return { flow, groundingExecutor, notificationService, logger, prompts };
+  return {
+    flow,
+    groundingExecutor,
+    notificationService,
+    logger,
+    prompts,
+    tripleStore,
+  };
+}
+
+/**
+ * Seed an InMemoryTripleStore with an asset whose `exo__Asset_label` is the
+ * provided literal. Returns the store ready for use as `tripleStore` in
+ * `makeFlow({ tripleStore })`.
+ */
+async function makeStoreWithAssetLabel(
+  targetIRI: string,
+  label: string,
+): Promise<InMemoryTripleStore> {
+  const store = new InMemoryTripleStore();
+  await store.add(
+    new Triple(
+      new IRI(targetIRI),
+      Namespace.EXO.term("Asset_label"),
+      new Literal(label),
+    ),
+  );
+  return store;
 }
 
 describe("CommandExecutionFlow", () => {
@@ -208,11 +244,12 @@ describe("CommandExecutionFlow", () => {
     });
   });
 
-  describe("applyLabelDatePrefill (v15.38 regression restoration)", () => {
+  describe("applyLabelDatePrefill (v15.38 regression restoration, v16.7.5 runtime fix)", () => {
     // Patch the date helper directly — keeps the test deterministic regardless
     // of the runner's timezone (DateFormatter.toDateString uses local-tz
     // calendar parts, so fake-system-time + UTC instants drift between TZs).
     let toDateStringSpy: jest.SpyInstance<string, [Date]>;
+    const TARGET_IRI = "obsidian://vault/asset-1.md";
 
     beforeEach(() => {
       toDateStringSpy = jest
@@ -224,20 +261,25 @@ describe("CommandExecutionFlow", () => {
       toDateStringSpy.mockRestore();
     });
 
-    it("prefills label field with `${prototypeLabel} YYYY-MM-DD` when flag is on", () => {
+    it("prefills label field with `${currentAsset.exo__Asset_label} YYYY-MM-DD` when flag is on", async () => {
+      const store = await makeStoreWithAssetLabel(
+        TARGET_IRI,
+        "EMS Weekly Review Light",
+      );
+      const { flow } = makeFlow({ tripleStore: store });
       const grounding: GroundingDefinition = {
         ...baseGrounding,
         type: GroundingType.CREATE_INSTANCE,
         targetPrototype: "proto-uid",
         targetFolder: "01 Inbox",
         prefillLabelWithDate: true,
-        prototypeLabel: "Morning Wim Hof",
       };
       const schema = [{ name: "label", type: "text", required: true }];
 
-      const result = CommandExecutionFlow.applyLabelDatePrefill(
+      const result = await flow.applyLabelDatePrefill(
         schema,
         grounding,
+        TARGET_IRI,
       );
 
       expect(result).toEqual([
@@ -245,62 +287,116 @@ describe("CommandExecutionFlow", () => {
           name: "label",
           type: "text",
           required: true,
-          defaultValue: "Morning Wim Hof 2026-05-17",
+          defaultValue: "EMS Weekly Review Light 2026-05-17",
         },
       ]);
     });
 
-    it("is no-op when prefillLabelWithDate is false / missing", () => {
+    it("is no-op when prefillLabelWithDate is false / missing", async () => {
+      const store = await makeStoreWithAssetLabel(TARGET_IRI, "Whatever");
+      const { flow } = makeFlow({ tripleStore: store });
       const grounding: GroundingDefinition = {
         ...baseGrounding,
         type: GroundingType.CREATE_INSTANCE,
         targetFolder: "01 Inbox",
-        prototypeLabel: "Whatever",
       };
       const schema = [{ name: "label", type: "text" }];
 
-      expect(
-        CommandExecutionFlow.applyLabelDatePrefill(schema, grounding),
-      ).toBe(schema);
-    });
-
-    it("is no-op when grounding type is not create_instance", () => {
-      const grounding: GroundingDefinition = {
-        ...baseGrounding,
-        type: GroundingType.PROPERTY_SET,
-        prefillLabelWithDate: true,
-        prototypeLabel: "Morning Wim Hof",
-      };
-      const schema = [{ name: "label", type: "text" }];
-
-      expect(
-        CommandExecutionFlow.applyLabelDatePrefill(schema, grounding),
-      ).toBe(schema);
-    });
-
-    it("is no-op when prototypeLabel is missing (graceful fallback)", () => {
-      const grounding: GroundingDefinition = {
-        ...baseGrounding,
-        type: GroundingType.CREATE_INSTANCE,
-        targetFolder: "01 Inbox",
-        prefillLabelWithDate: true,
-      };
-      const schema = [{ name: "label", type: "text" }];
-
-      const result = CommandExecutionFlow.applyLabelDatePrefill(
+      const result = await flow.applyLabelDatePrefill(
         schema,
         grounding,
+        TARGET_IRI,
       );
       expect(result).toBe(schema);
     });
 
-    it("does not overwrite an existing non-empty defaultValue (user-explicit wins)", () => {
+    it("is no-op when grounding type is not create_instance", async () => {
+      const store = await makeStoreWithAssetLabel(
+        TARGET_IRI,
+        "Morning Wim Hof",
+      );
+      const { flow } = makeFlow({ tripleStore: store });
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.PROPERTY_SET,
+        prefillLabelWithDate: true,
+      };
+      const schema = [{ name: "label", type: "text" }];
+
+      const result = await flow.applyLabelDatePrefill(
+        schema,
+        grounding,
+        TARGET_IRI,
+      );
+      expect(result).toBe(schema);
+    });
+
+    it("is no-op when targetIRI is null (global Palette surface without active file)", async () => {
+      const store = await makeStoreWithAssetLabel(
+        TARGET_IRI,
+        "Morning Wim Hof",
+      );
+      const { flow } = makeFlow({ tripleStore: store });
       const grounding: GroundingDefinition = {
         ...baseGrounding,
         type: GroundingType.CREATE_INSTANCE,
         targetFolder: "01 Inbox",
         prefillLabelWithDate: true,
-        prototypeLabel: "Morning Wim Hof",
+      };
+      const schema = [{ name: "label", type: "text" }];
+
+      const result = await flow.applyLabelDatePrefill(schema, grounding, null);
+      expect(result).toBe(schema);
+    });
+
+    it("is no-op when tripleStore is not wired (back-compat for callers without DI)", async () => {
+      const { flow } = makeFlow();
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.CREATE_INSTANCE,
+        targetFolder: "01 Inbox",
+        prefillLabelWithDate: true,
+      };
+      const schema = [{ name: "label", type: "text" }];
+
+      const result = await flow.applyLabelDatePrefill(
+        schema,
+        grounding,
+        TARGET_IRI,
+      );
+      expect(result).toBe(schema);
+    });
+
+    it("is no-op when current asset has no exo__Asset_label (graceful fallback)", async () => {
+      const store = new InMemoryTripleStore();
+      const { flow } = makeFlow({ tripleStore: store });
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.CREATE_INSTANCE,
+        targetFolder: "01 Inbox",
+        prefillLabelWithDate: true,
+      };
+      const schema = [{ name: "label", type: "text" }];
+
+      const result = await flow.applyLabelDatePrefill(
+        schema,
+        grounding,
+        TARGET_IRI,
+      );
+      expect(result).toBe(schema);
+    });
+
+    it("does not overwrite an existing non-empty defaultValue (user-explicit wins)", async () => {
+      const store = await makeStoreWithAssetLabel(
+        TARGET_IRI,
+        "Morning Wim Hof",
+      );
+      const { flow } = makeFlow({ tripleStore: store });
+      const grounding: GroundingDefinition = {
+        ...baseGrounding,
+        type: GroundingType.CREATE_INSTANCE,
+        targetFolder: "01 Inbox",
+        prefillLabelWithDate: true,
       };
       const schema = [
         {
@@ -310,9 +406,10 @@ describe("CommandExecutionFlow", () => {
         },
       ];
 
-      const result = CommandExecutionFlow.applyLabelDatePrefill(
+      const result = await flow.applyLabelDatePrefill(
         schema,
         grounding,
+        TARGET_IRI,
       );
       expect(result[0]).toEqual({
         name: "label",
@@ -321,22 +418,27 @@ describe("CommandExecutionFlow", () => {
       });
     });
 
-    it("leaves non-label fields untouched even when prefill is active", () => {
+    it("leaves non-label fields untouched even when prefill is active", async () => {
+      const store = await makeStoreWithAssetLabel(
+        TARGET_IRI,
+        "Morning Wim Hof",
+      );
+      const { flow } = makeFlow({ tripleStore: store });
       const grounding: GroundingDefinition = {
         ...baseGrounding,
         type: GroundingType.CREATE_INSTANCE,
         targetFolder: "01 Inbox",
         prefillLabelWithDate: true,
-        prototypeLabel: "Morning Wim Hof",
       };
       const schema = [
         { name: "label", type: "text" },
         { name: "note", type: "multiline" },
       ];
 
-      const result = CommandExecutionFlow.applyLabelDatePrefill(
+      const result = await flow.applyLabelDatePrefill(
         schema,
         grounding,
+        TARGET_IRI,
       );
       expect(result).toEqual([
         {
@@ -348,9 +450,14 @@ describe("CommandExecutionFlow", () => {
       ]);
     });
 
-    it("flow.run passes prefilled schema into promptInputSchema", async () => {
+    it("flow.run passes prefilled schema into promptInputSchema using current asset label", async () => {
+      const store = await makeStoreWithAssetLabel(
+        TARGET_IRI,
+        "EMS Weekly Review Light",
+      );
       const { flow, prompts } = makeFlow({
         promptResult: { label: "user-typed" },
+        tripleStore: store,
       });
       const rc = makeRC(
         {},
@@ -359,18 +466,19 @@ describe("CommandExecutionFlow", () => {
           targetPrototype: "proto-uid",
           targetFolder: "01 Inbox",
           prefillLabelWithDate: true,
-          prototypeLabel: "Morning Wim Hof",
           inputSchema: [{ name: "label", type: "text", required: true }],
         },
       );
 
-      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+      await flow.run(rc, { targetIRI: TARGET_IRI, filePath: "x.md" });
 
       expect(prompts.promptInputSchema).toHaveBeenCalledTimes(1);
       const passedSchema = prompts.promptInputSchema.mock.calls[0][0] as Array<
         Record<string, unknown>
       >;
-      expect(passedSchema[0].defaultValue).toBe("Morning Wim Hof 2026-05-17");
+      expect(passedSchema[0].defaultValue).toBe(
+        "EMS Weekly Review Light 2026-05-17",
+      );
     });
   });
 

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -449,24 +449,13 @@ describe("CommandResolver", () => {
       });
     });
 
-    it("should parse exocmd__Grounding_prefillLabelWithDate and resolve prototypeLabel from triple store", async () => {
-      const prototypeSubject = new IRI("obsidian://vault/proto-1.md");
-      await store.addAll([
-        new Triple(prototypeSubject, Namespace.RDF.term("type"), Namespace.EXO.term("Asset")),
-        new Triple(prototypeSubject, Namespace.EXO.term("Asset_uid"), new Literal("proto-1")),
-        new Triple(prototypeSubject, Namespace.EXO.term("Asset_label"), new Literal("Morning Wim Hof")),
-      ]);
+    it("should parse exocmd__Grounding_prefillLabelWithDate true literal as boolean flag", async () => {
       const groundingSubject = new IRI("obsidian://vault/gnd-prefill.md");
       await store.addAll([
         new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
         new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-prefill")),
         new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("Create Wim Hof session")),
         new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("create_instance")),
-        new Triple(
-          groundingSubject,
-          Namespace.EXOCMD.term("Grounding_targetPrototype"),
-          new Literal("[[proto-1|Morning Wim Hof]]"),
-        ),
         new Triple(
           groundingSubject,
           Namespace.EXOCMD.term("Grounding_prefillLabelWithDate"),
@@ -482,7 +471,6 @@ describe("CommandResolver", () => {
       const cmd = await resolver.loadCommand("cmd-prefill");
 
       expect(cmd!.grounding.prefillLabelWithDate).toBe(true);
-      expect(cmd!.grounding.prototypeLabel).toBe("Morning Wim Hof");
     });
 
     it("should leave prefillLabelWithDate undefined when triple is absent (backward-compat)", async () => {
@@ -500,7 +488,6 @@ describe("CommandResolver", () => {
       const cmd = await resolver.loadCommand("cmd-no-prefill");
 
       expect(cmd!.grounding.prefillLabelWithDate).toBeUndefined();
-      expect(cmd!.grounding.prototypeLabel).toBeUndefined();
     });
 
     it("should leave prefillLabelWithDate undefined for non-true literals (only 'true' opts in)", async () => {
@@ -525,37 +512,6 @@ describe("CommandResolver", () => {
       const cmd = await resolver.loadCommand("cmd-not-true");
 
       expect(cmd!.grounding.prefillLabelWithDate).toBeUndefined();
-      expect(cmd!.grounding.prototypeLabel).toBeUndefined();
-    });
-
-    it("should leave prototypeLabel undefined when prototype asset is missing (graceful fallback)", async () => {
-      const groundingSubject = new IRI("obsidian://vault/gnd-orphan.md");
-      await store.addAll([
-        new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
-        new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-orphan")),
-        new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("Orphan proto")),
-        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("create_instance")),
-        new Triple(
-          groundingSubject,
-          Namespace.EXOCMD.term("Grounding_targetPrototype"),
-          new Literal("[[missing-proto]]"),
-        ),
-        new Triple(
-          groundingSubject,
-          Namespace.EXOCMD.term("Grounding_prefillLabelWithDate"),
-          new Literal("true"),
-        ),
-      ]);
-      await addCommandAsset(store, {
-        uid: "cmd-orphan",
-        label: "Orphan",
-        groundingRef: "gnd-orphan",
-      });
-
-      const cmd = await resolver.loadCommand("cmd-orphan");
-
-      expect(cmd!.grounding.prefillLabelWithDate).toBe(true);
-      expect(cmd!.grounding.prototypeLabel).toBeUndefined();
     });
 
     it("should pass through `default` and `defaultValue` from inputSchema JSON Schema properties", async () => {

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -321,6 +321,7 @@ export default class ExocortexPlugin extends Plugin {
           preconditionEvaluator: this.preconditionEvaluator,
           groundingExecutor: this.groundingExecutor,
           notificationService: notifier,
+          tripleStore,
           relationColumnSetResolver: this.relationColumnSetResolver,
           exoLayoutRepository: this.exoLayoutRepository,
           layoutSelector: this.layoutSelector,
@@ -511,6 +512,7 @@ export default class ExocortexPlugin extends Plugin {
             new ObsidianNotificationService(),
             this.logger,
             new ObsidianCommandPromptAdapter(this.app),
+            tripleStore,
           );
           await new ExocmdCommandPaletteRegistrar(
             this,

--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -12,6 +12,7 @@ import {
   FolderRepairService,
   INotificationService,
   CommandExecutionFlow,
+  ITripleStore,
 } from "exocortex";
 import {
   ButtonBuilderContext,
@@ -40,6 +41,12 @@ export interface ButtonGroupsBuilderConfig {
   preconditionEvaluator?: PreconditionEvaluator;
   /** Executor for grounding actions */
   groundingExecutor?: GroundingExecutor;
+  /**
+   * Live triple store backing vault assets. Used by
+   * `CommandExecutionFlow.applyLabelDatePrefill` to read the current asset's
+   * `exo__Asset_label` for the v15.38 prefill restoration (v16.7.5 fix).
+   */
+  tripleStore?: ITripleStore;
   /** Service for repairing folder locations (used for visibility context) */
   folderRepairService: FolderRepairService;
   /** Extractor for file metadata */
@@ -82,6 +89,7 @@ export class ButtonGroupsBuilder {
       commandResolver,
       preconditionEvaluator,
       groundingExecutor,
+      tripleStore,
       folderRepairService,
       metadataExtractor,
       logger,
@@ -106,6 +114,7 @@ export class ButtonGroupsBuilder {
         notificationService,
         logger,
         new ObsidianCommandPromptAdapter(app),
+        tripleStore,
       );
       this.builders.push(
         new DynamicCommandButtonGroupBuilder({

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -9,7 +9,7 @@ import { ActionButtonsGroup } from '@plugin/presentation/components/ActionButton
 import { IVaultAdapter, MetadataExtractor, INotificationService } from "exocortex";
 import { FolderRepairService } from "exocortex";
 import { CommandResolver, PreconditionEvaluator, GroundingExecutor } from "exocortex";
-import type { LayoutSelector, RelationColumnSetResolver } from "exocortex";
+import type { LayoutSelector, RelationColumnSetResolver, ITripleStore } from "exocortex";
 import type { ExoLayoutRepository } from "@plugin/infrastructure/repositories";
 import { ExoLayoutRenderer } from "./ExoLayoutRenderer";
 import { BacklinksCacheManager } from '@plugin/adapters/caching/BacklinksCacheManager';
@@ -64,6 +64,7 @@ export class UniversalLayoutRenderer {
   private preconditionEvaluator?: PreconditionEvaluator;
   private groundingExecutor?: GroundingExecutor;
   private notificationService?: INotificationService;
+  private tripleStore?: ITripleStore;
   private relationColumnSetResolver: RelationColumnSetResolver | null = null;
   private exoLayoutRepository: ExoLayoutRepository | null = null;
   private layoutSelector: LayoutSelector | null = null;
@@ -92,6 +93,7 @@ export class UniversalLayoutRenderer {
       preconditionEvaluator?: PreconditionEvaluator;
       groundingExecutor?: GroundingExecutor;
       notificationService?: INotificationService;
+      tripleStore?: ITripleStore;
       relationColumnSetResolver?: RelationColumnSetResolver | null;
       exoLayoutRepository?: ExoLayoutRepository | null;
       layoutSelector?: LayoutSelector | null;
@@ -106,6 +108,7 @@ export class UniversalLayoutRenderer {
     this.preconditionEvaluator = rfc009Services?.preconditionEvaluator;
     this.groundingExecutor = rfc009Services?.groundingExecutor;
     this.notificationService = rfc009Services?.notificationService;
+    this.tripleStore = rfc009Services?.tripleStore;
     this.relationColumnSetResolver =
       rfc009Services?.relationColumnSetResolver ?? null;
     this.exoLayoutRepository = rfc009Services?.exoLayoutRepository ?? null;
@@ -174,6 +177,7 @@ export class UniversalLayoutRenderer {
       commandResolver: this.commandResolver,
       preconditionEvaluator: this.preconditionEvaluator,
       groundingExecutor: this.groundingExecutor,
+      tripleStore: this.tripleStore,
       folderRepairService: services.folderRepair,
       metadataExtractor: this.metadataExtractor,
       logger: this.logger,


### PR DESCRIPTION
## Summary
Bug fix to v16.7.4 (#3172). The prefill `label` modal value was being resolved from the wrong asset: `CommandResolver.resolvePrototypeLabel` read `Grounding_targetPrototype` from the grounding — which in our groundings is a wikilink to the **prototype's class** (e.g. `ems__TaskPrototype` UID `df7e579d`), not the user's specific prototype instance.

Per the v15.38 spec the prefill should use `exo__Asset_label` of the **current open asset** (the asset the user clicked the button on), exactly like legacy `CreateInstanceCommand.showModal()`:

```ts
const baseLabel = String(metadata.exo__Asset_label || file.basename);
const defaultLabel = `${baseLabel} ${DateFormatter.toDateString(new Date())}`;
```

## Empirical bug reproduction (manual smoke test 2026-05-17 21:25)

| Step | Result |
|---|---|
| Install v16.7.4 in `~/vault-2025/.obsidian/plugins/exocortex/` | manifest 16.7.4 |
| Add `exocmd__Grounding_prefillLabelWithDate: true` on grounding `a6ef8fda` (Create TaskPrototype instance) | ok |
| Open `5fd622db` ("EMS Weekly Review Light", TaskPrototype) | ok |
| Click `Create Task Instance` button | modal opens |
| **Expected prefill** | `EMS Weekly Review Light 2026-05-17` |
| **Actual prefill (v16.7.4)** | `https://exocortex.my/ontology/ems#TaskPrototype 2026-05-17` |

## Change

- Dropped build-time `resolvePrototypeLabel` lookup in `CommandResolver`.
- `CommandExecutionFlow.applyLabelDatePrefill` is now an `async` **instance method** that reads `exo__Asset_label` from `ctx.targetIRI` at click time via the live triple store. Both the source label AND the date stay fresh regardless of grounding caching.
- `tripleStore` threaded into `CommandExecutionFlow` constructor via:
  - `ButtonGroupsBuilder` (layout-button surface)
  - `ExocortexPlugin.initExocmdPalette` (Obsidian Command Palette surface)
- `GroundingDefinition.prototypeLabel` field removed (misleading artefact from the original v16.7.4 patch).
- `prefillLabelWithDate` boolean flag and `default` / `defaultValue` propagation unchanged.

## Tests

- `packages/exocortex/tests/unit/services/CommandResolver.test.ts` — `prototypeLabel` assertions removed; flag-parsing tests retained.
- `packages/exocortex/tests/services/CommandExecutionFlow.test.ts` — prefill block rewritten with `InMemoryTripleStore` seeded with `exo__Asset_label` on `ctx.targetIRI`. New graceful-fallback cases:
  - `targetIRI === null` (Palette surface without active file) → no-op
  - `tripleStore` not wired (back-compat for constructor-only callers) → no-op
  - asset has no `exo__Asset_label` triple → no-op
  - existing non-empty `defaultValue` is preserved (user-explicit wins)
  - non-label fields untouched
- 24 / 24 tests pass on the rewritten suite.

## Pre-existing baseline failures (unrelated)

Two CLI integration suites are red on this branch and on `origin/main` HEAD (verified by stashing the diff and re-running) — pre-existing baseline noise:
- `packages/cli/tests/integration/starter-kit/command-pilot.integration.test.ts`
- `packages/cli/tests/integration/sparql-exo003.integration.test.ts`

Neither test references `prototypeLabel`, `prefillLabelWithDate`, or `applyLabelDatePrefill`.

## Backward compatibility

Opt-in flag semantics unchanged: `true` → prefill, `false` / absent → empty field. No vault-side changes required.

## Test plan

- [x] Unit tests for `applyLabelDatePrefill` (runtime tripleStore lookup, all edge cases)
- [x] Typecheck (`npm run check:types`) green
- [x] Lint clean (2 unrelated pre-existing warnings)
- [x] No remaining `prototypeLabel` references in codebase
- [x] Both `CommandExecutionFlow` call sites pass `tripleStore`
- [ ] CI green (13 required checks)
- [ ] Empirical re-verification after release: install v16.7.5 in vault-2025, re-flip flag on grounding `a6ef8fda`, click button on `5fd622db`, expect `EMS Weekly Review Light 2026-05-17`

🤖 Generated with [Claude Code](https://claude.com/claude-code)