### PR TITLE
chore(observability): performance.mark вместо console.time для exocmd метрик

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -794,24 +794,25 @@ export default class ExocortexPlugin extends Plugin {
       // visible buttons within ~tens of ms instead of ~40s on mobile.
       // The post-init re-render below upgrades the open file to the
       // full-resolver path once `convertVault()` finishes.
-      // `console.time` instrumentation lets us measure cold-start
-      // latency against the issue's AC #1 / AC #2 targets in real
-      // sessions (developer DevTools / mobile dev tools).
+      // `performance.mark` / `performance.measure` instrumentation lets
+      // us read cold-start latency against the issue's AC #1 / AC #2
+      // targets via `performance.getEntriesByName(...)` — works on
+      // desktop and mobile without Verbose log level (Issue #3175).
       this.eagerInitPromise = new Promise<void>((resolve) => {
         this.app.workspace.onLayoutReady(() => {
-          // Issue #3171 perf instrumentation. Two distinct markers so the
+          // Issue #3171 perf instrumentation (Issue #3175 migrated from
+          // `console.time` to Web Performance API). Two distinct
+          // start-marks paired with `performance.measure` calls so the
           // developer can read the cold-start UX *and* the full-path
-          // completion separately in DevTools — fusing them under one
-          // label would falsely suggest the fast path takes ~10–40 s.
-          //   `exocmd-fastpath-ready`  — onload → first `autoRenderLayout()`
-          //                              that takes the ExocmdFastResolver
-          //                              branch (AC #1 / AC #2 metric).
-          //   `exocmd-fullpath-ready`  — onload → background `convertVault()`
-          //                              completion + post-init re-render.
-          // eslint-disable-next-line no-console -- intentional perf benchmark for Issue #3171
-          console.time("exocmd-fastpath-ready");
-          // eslint-disable-next-line no-console -- intentional perf benchmark for Issue #3171
-          console.time("exocmd-fullpath-ready");
+          // completion separately — fusing them under one label would
+          // falsely suggest the fast path takes ~10–40 s.
+          //   `exocmd-fastpath`  — onload → first `autoRenderLayout()`
+          //                        that takes the ExocmdFastResolver
+          //                        branch (AC #1 / AC #2 metric).
+          //   `exocmd-fullpath`  — onload → background `convertVault()`
+          //                        completion + post-init re-render.
+          performance.mark("exocmd-fastpath-start");
+          performance.mark("exocmd-fullpath-start");
           setTimeout(() => {
             void this.sparql
               .query("ASK { ?s ?p ?o }")
@@ -827,8 +828,12 @@ export default class ExocortexPlugin extends Plugin {
                 // switch in `DynamicCommandButtonGroupBuilder` is per-call,
                 // so this single `autoRenderLayout()` is enough.
                 this.autoRenderLayout();
-                // eslint-disable-next-line no-console -- intentional perf benchmark for Issue #3171
-                console.timeEnd("exocmd-fullpath-ready");
+                performance.mark("exocmd-fullpath-ready");
+                performance.measure(
+                  "exocmd-fullpath",
+                  "exocmd-fullpath-start",
+                  "exocmd-fullpath-ready",
+                );
               })
               .catch((err) => {
                 this.logger.error(

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -408,15 +408,20 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
       const visible = await fastResolver.resolveVisibleCommands(file);
       // Issue #3171 perf benchmark — emit the cold-start UX marker the
       // first time a fast-path render produces visible commands. Paired
-      // with `console.time("exocmd-fastpath-ready")` in `ExocortexPlugin`.
+      // with `performance.mark("exocmd-fastpath-start")` in
+      // `ExocortexPlugin` (Issue #3175 migrated from `console.time`).
       // Guarded by `!this.fastpathReadyMarked` so we only emit once per
       // plugin session (subsequent file switches still take the fast
       // path until `isFullPathReady` flips, but the metric we care about
       // is "first-render cold-start latency").
       if (!this.fastpathReadyMarked && visible.length > 0) {
         this.fastpathReadyMarked = true;
-        // eslint-disable-next-line no-console -- intentional perf benchmark for Issue #3171
-        console.timeEnd("exocmd-fastpath-ready");
+        performance.mark("exocmd-fastpath-ready");
+        performance.measure(
+          "exocmd-fastpath",
+          "exocmd-fastpath-start",
+          "exocmd-fastpath-ready",
+        );
       }
       return visible;
     } catch (error) {

--- a/packages/obsidian-plugin/tests/setup-reflect-metadata.ts
+++ b/packages/obsidian-plugin/tests/setup-reflect-metadata.ts
@@ -1,2 +1,15 @@
 // Global setup for TSyringe dependency injection in tests
 import "reflect-metadata";
+
+// jsdom does not implement the Web Performance API marks/measures used
+// by the exocmd cold-start observability instrumentation (Issue #3175).
+// Stub no-op implementations so production code that calls
+// `performance.mark` / `performance.measure` does not throw in unit
+// tests; tests that assert on these calls override with `jest.fn()`.
+const perf = performance as unknown as Record<string, unknown>;
+if (typeof perf["mark"] !== "function") {
+  perf["mark"] = () => undefined;
+}
+if (typeof perf["measure"] !== "function") {
+  perf["measure"] = () => undefined;
+}

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -2247,4 +2247,71 @@ describe("ExocortexPlugin", () => {
       expect(loadFromRDFGraphSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("Issue #3175: performance.mark cold-start observability", () => {
+    // Issue #3175 replaces the PR #3173 `console.time` markers with Web
+    // Performance API so the cold-start latency is programmatic-queryable
+    // (`performance.getEntriesByName('exocmd-fullpath')[0].duration`) and
+    // visible without Verbose log level in DevTools. These tests pin the
+    // start-marks emitted on `onLayoutReady` and the final
+    // `exocmd-fullpath` measure emitted after eager-init completes.
+    // jsdom does not implement Web Performance API marks — install jest
+    // mocks directly on the global performance object and restore the
+    // originals after each test.
+    let markSpy: jest.Mock;
+    let measureSpy: jest.Mock;
+    let originalMark: unknown;
+    let originalMeasure: unknown;
+    let querySpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      originalMark = (performance as unknown as Record<string, unknown>)["mark"];
+      originalMeasure = (performance as unknown as Record<string, unknown>)["measure"];
+      markSpy = jest.fn();
+      measureSpy = jest.fn();
+      (performance as unknown as Record<string, unknown>)["mark"] = markSpy;
+      (performance as unknown as Record<string, unknown>)["measure"] = measureSpy;
+
+      const sparqlApiModule = await import("../../src/application/api/SPARQLApi");
+      querySpy = jest
+        .spyOn(sparqlApiModule.SPARQLApi.prototype, "query")
+        .mockResolvedValue({ bindings: [], count: 0 } as any);
+      jest
+        .spyOn(sparqlApiModule.SPARQLApi.prototype, "refresh")
+        .mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      (performance as unknown as Record<string, unknown>)["mark"] = originalMark;
+      (performance as unknown as Record<string, unknown>)["measure"] =
+        originalMeasure;
+      querySpy?.mockRestore();
+    });
+
+    it("emits 'exocmd-fastpath-start' and 'exocmd-fullpath-start' marks on onLayoutReady", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      expect(markSpy).toHaveBeenCalledWith("exocmd-fastpath-start");
+      expect(markSpy).toHaveBeenCalledWith("exocmd-fullpath-start");
+    });
+
+    it("emits 'exocmd-fullpath-ready' mark + 'exocmd-fullpath' measure after eager-init completes", async () => {
+      await plugin.onload();
+      // Run flushPromises twice — onload schedules setTimeout(0) which
+      // queues the query.then() chain; one flush executes the timer, a
+      // second flush drains the resolved-query continuation that finally
+      // emits the ready-mark + measure.
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
+
+      expect(markSpy).toHaveBeenCalledWith("exocmd-fullpath-ready");
+      expect(measureSpy).toHaveBeenCalledWith(
+        "exocmd-fullpath",
+        "exocmd-fullpath-start",
+        "exocmd-fullpath-ready",
+      );
+    });
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -1344,4 +1344,124 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       expect(result[0].variant).toBe("warning");
     });
   });
+
+  // -- Issue #3175 — performance.mark cold-start observability ----------------
+  // Replaces console.time markers from PR #3173 with Web Performance API so
+  // the cold-start cold-start latency is programmatic-queryable
+  // (`performance.getEntriesByName('exocmd-fastpath')[0].duration`) and visible
+  // without Verbose log level in DevTools.
+  describe("Issue #3175: performance.mark on fast-path first render", () => {
+    // jsdom does not implement Web Performance API marks — install jest
+    // mocks directly on the global performance object and restore the
+    // originals after each test.
+    let markSpy: jest.Mock;
+    let measureSpy: jest.Mock;
+    let originalMark: unknown;
+    let originalMeasure: unknown;
+
+    beforeEach(() => {
+      originalMark = (performance as unknown as Record<string, unknown>)["mark"];
+      originalMeasure = (performance as unknown as Record<string, unknown>)["measure"];
+      markSpy = jest.fn();
+      measureSpy = jest.fn();
+      (performance as unknown as Record<string, unknown>)["mark"] = markSpy;
+      (performance as unknown as Record<string, unknown>)["measure"] = measureSpy;
+    });
+
+    afterEach(() => {
+      (performance as unknown as Record<string, unknown>)["mark"] = originalMark;
+      (performance as unknown as Record<string, unknown>)["measure"] =
+        originalMeasure;
+    });
+
+    function makeBuilderWithFastPath(opts: {
+      visibleCommands: ResolvedCommand[];
+      fullPathReady: boolean;
+    }) {
+      const fastResolver = {
+        resolveVisibleCommands: jest
+          .fn()
+          .mockResolvedValue(opts.visibleCommands),
+        invalidateCache: jest.fn(),
+      };
+      return {
+        builder: new DynamicCommandButtonGroupBuilder({
+          commandResolver: mockCommandResolver as unknown as any,
+          preconditionEvaluator: mockPreconditionEvaluator as unknown as any,
+          commandExecutionFlow: buildCommandExecutionFlow(),
+          fastResolver: fastResolver as unknown as any,
+          isFullPathReady: () => opts.fullPathReady,
+        }),
+        fastResolver,
+      };
+    }
+
+    it("emits performance.mark('exocmd-fastpath-ready') + measure on first fast-path render with visible commands", async () => {
+      const rc = createResolvedCommand();
+      const { builder } = makeBuilderWithFastPath({
+        visibleCommands: [rc],
+        fullPathReady: false,
+      });
+
+      await builder.build(createContext());
+
+      expect(markSpy).toHaveBeenCalledWith("exocmd-fastpath-ready");
+      expect(measureSpy).toHaveBeenCalledWith(
+        "exocmd-fastpath",
+        "exocmd-fastpath-start",
+        "exocmd-fastpath-ready",
+      );
+    });
+
+    it("emits the fastpath marker exactly once across multiple build() calls (guarded by fastpathReadyMarked)", async () => {
+      const rc = createResolvedCommand();
+      const { builder } = makeBuilderWithFastPath({
+        visibleCommands: [rc],
+        fullPathReady: false,
+      });
+
+      await builder.build(createContext());
+      await builder.build(createContext());
+      await builder.build(createContext());
+
+      const readyMarkCalls = markSpy.mock.calls.filter(
+        ([label]) => label === "exocmd-fastpath-ready",
+      );
+      expect(readyMarkCalls).toHaveLength(1);
+      const fastpathMeasureCalls = measureSpy.mock.calls.filter(
+        ([label]) => label === "exocmd-fastpath",
+      );
+      expect(fastpathMeasureCalls).toHaveLength(1);
+    });
+
+    it("does NOT emit the fastpath marker when fast-path returns zero visible commands", async () => {
+      const { builder } = makeBuilderWithFastPath({
+        visibleCommands: [],
+        fullPathReady: false,
+      });
+
+      await builder.build(createContext());
+
+      expect(markSpy).not.toHaveBeenCalledWith("exocmd-fastpath-ready");
+      expect(measureSpy).not.toHaveBeenCalledWith(
+        "exocmd-fastpath",
+        expect.any(String),
+        expect.any(String),
+      );
+    });
+
+    it("does NOT emit the fastpath marker when full path is ready (fast-path branch skipped)", async () => {
+      const rc = createResolvedCommand();
+      mockResolveForAssetMulti.mockResolvedValue([rc]);
+      mockEvaluate.mockResolvedValue(true);
+      const { builder } = makeBuilderWithFastPath({
+        visibleCommands: [rc],
+        fullPathReady: true,
+      });
+
+      await builder.build(createContext());
+
+      expect(markSpy).not.toHaveBeenCalledWith("exocmd-fastpath-ready");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
PR #3173 (релиз v16.8.0) добавил `console.time/timeEnd("exocmd-fastpath-ready")` и `console.time/timeEnd("exocmd-fullpath-ready")` маркеры для cold-start latency. Они непригодны: `console.time` выводит только при Verbose log level в DevTools (по умолчанию выключен), `performance.getEntriesByType` их не видит, и iPhone Safari Web Inspector тоже режет verbose-логи. Эмпирическая проверка автора issue (2026-05-17, vault-2025, v16.8.0 desktop) подтвердила что маркеры невидимы даже с Verbose+Info+Timestamps.

Этот PR заменяет их на `performance.mark` + `performance.measure`, которые доступны через `performance.getEntriesByName(...)` без verbose-режима, работают одинаково на desktop и mobile, и видны в DevTools Performance panel при записи trace.

Closes #3175.

## Changes
- `ExocortexPlugin.onLayoutReady` — `console.time("exocmd-*-ready")` → `performance.mark("exocmd-fastpath-start")` + `performance.mark("exocmd-fullpath-start")`.
- `ExocortexPlugin` eager-init `.then` callback — `console.timeEnd("exocmd-fullpath-ready")` → `performance.mark("exocmd-fullpath-ready")` + `performance.measure("exocmd-fullpath", "exocmd-fullpath-start", "exocmd-fullpath-ready")`.
- `DynamicCommandButtonGroupBuilder.resolveViaFastPath` — `console.timeEnd("exocmd-fastpath-ready")` → `performance.mark("exocmd-fastpath-ready")` + `performance.measure("exocmd-fastpath", "exocmd-fastpath-start", "exocmd-fastpath-ready")`. Однократный emit guard `fastpathReadyMarked` сохранён.
- Удалены `eslint-disable no-console` директивы для этих маркеров.
- Тесты: `DynamicCommandButtonGroupBuilder.test.ts` (4 новых теста — happy path, single-emit guard, zero visible commands, full-path-ready branch skip). `ExocortexPlugin.test.ts` (2 новых теста — start-marks on onLayoutReady, fullpath ready-mark + measure после eager-init).
- `tests/setup-reflect-metadata.ts` — jsdom не реализует Web Performance marks, поэтому global setup устанавливает no-op stubs для `performance.mark`/`measure`. Тесты, проверяющие вызовы, переопределяют их через `jest.fn()`.

## Test plan
- [x] `npm run lint` — 0 errors (2 pre-existing warnings unrelated)
- [x] `npm run check:types` — clean
- [x] `npx jest --config packages/obsidian-plugin/jest.config.js` — 5023 passed (включая 4 новых fastpath теста и 2 новых fullpath теста); 248 test suites green
- [x] `npm run build` — production bundle 701ms
- [x] DoD grep: 0 `console.time` for `exocmd` calls в исходниках; `performance.mark` для `exocmd-fastpath` — 2 (start+ready); `performance.measure` для `exocmd-fastpath`/`exocmd-fullpath` оба присутствуют
- [ ] CI: 13 required checks (archgate, detect-changes, e2e-shard 1..6, lint, test-bdd, test-component, test-coverage, typecheck) — ожидание зелёного gate

## Verification command после установки
```js
// В DevTools console (любая платформа) после открытия Obsidian с плагином и любого файла:
performance.getEntriesByName("exocmd-fastpath")[0]?.duration   // → number (ms) или undefined если fast-path не сработал
performance.getEntriesByName("exocmd-fullpath")[0]?.duration   // → number (ms) после завершения convertVault
performance.getEntriesByName("exocmd-fastpath-start")          // → [PerformanceMark]
performance.getEntriesByName("exocmd-fastpath-ready")          // → [PerformanceMark] (только при visible commands > 0)
```

## Out of scope
- Telemetry / reporting / push наружу самих измерений (отдельная feature если потребуется)
- Performance optimizations самого fast-path (PR #3173 / Issue #3171)