### PR TITLE
fix(logging): scope log file to plugin data dir, rotate at 1 MB (#3186)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -161,7 +161,7 @@ export default class ExocortexPlugin extends Plugin {
 
       // Initialize notification service and log channel routing
       this.notifier = new ObsidianNotificationService();
-      this.fileLogChannel = new FileLogChannel(this.app.vault.adapter);
+      this.fileLogChannel = new FileLogChannel(this.app.vault.adapter, this.manifest.dir ?? `${this.app.vault.configDir}/plugins/${this.manifest.id}`);
       await this.fileLogChannel.ensureFileExists();
       this.configureLogChannels();
 

--- a/packages/obsidian-plugin/src/adapters/logging/FileLogChannel.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/FileLogChannel.ts
@@ -1,31 +1,64 @@
 import type { DataAdapter } from "obsidian";
 
-const LOG_FILE_NAME = "exocortex-logs.txt";
+const LOG_FILE_BASENAME = "exocortex-logs.txt";
+
+// Rotate when current file exceeds this size on next flush.
+// Keeps disk usage bounded to ~2 MB worst case (active + rotated).
+const MAX_FILE_SIZE_BYTES = 1_000_000;
 
 /**
- * Appends log lines to a file in the vault root.
+ * Appends log lines to a file in the plugin data directory.
  * Uses Obsidian's DataAdapter (vault.adapter) for mobile compatibility.
+ *
+ * The log directory is the plugin's own data folder (Plugin.manifest.dir,
+ * usually `<vault>/.obsidian/plugins/exocortex`), so the file is not part
+ * of the user's notes, not picked up by Obsidian Sync as content, and not
+ * indexed by SPARQL/file scanners that walk the vault root. The exact
+ * config-dir prefix (`.obsidian` vs user-customised) follows whatever
+ * Obsidian reports for this plugin.
+ *
+ * Size-based single-generation rotation: when the active file exceeds
+ * MAX_FILE_SIZE_BYTES, it is renamed to `*.1` (overwriting any previous `.1`)
+ * and a fresh file is started on the next write.
  */
 export class FileLogChannel {
+  private readonly logDir: string;
+  private readonly logFilePath: string;
+  private readonly rotatedFilePath: string;
   private buffer: string[] = [];
   private flushScheduled = false;
   private fileReady = false;
 
-  constructor(private readonly adapter: DataAdapter) {}
+  /**
+   * @param adapter - Obsidian DataAdapter (vault.adapter).
+   * @param pluginDir - Plugin's data directory (`Plugin.manifest.dir`).
+   *   Required: hardcoding `.obsidian` breaks for users with a customised
+   *   `configDir` (e.g. `.obsidian-mobile`).
+   */
+  constructor(private readonly adapter: DataAdapter, pluginDir: string) {
+    this.logDir = pluginDir;
+    this.logFilePath = `${pluginDir}/${LOG_FILE_BASENAME}`;
+    this.rotatedFilePath = `${this.logFilePath}.1`;
+  }
 
   /**
-   * Ensure the log file exists on disk. Must be called once at startup
-   * before any log lines are flushed.
+   * Ensure the log directory and log file exist on disk. Must be called once
+   * at startup before any log lines are flushed.
    *
    * Obsidian's DataAdapter.append() silently no-ops when the target file
    * does not exist (resolves without error), so we cannot rely on a
-   * catch-and-create fallback inside flush().
+   * catch-and-create fallback inside flush(). The directory is created
+   * explicitly because adapter.write() does not auto-create parents.
    */
   async ensureFileExists(): Promise<void> {
     try {
-      const exists = await this.adapter.exists(LOG_FILE_NAME);
+      const dirExists = await this.adapter.exists(this.logDir);
+      if (!dirExists) {
+        await this.adapter.mkdir(this.logDir);
+      }
+      const exists = await this.adapter.exists(this.logFilePath);
       if (!exists) {
-        await this.adapter.write(LOG_FILE_NAME, "");
+        await this.adapter.write(this.logFilePath, "");
       }
       this.fileReady = true;
     } catch {
@@ -44,25 +77,54 @@ export class FileLogChannel {
     if (this.flushScheduled) return;
     this.flushScheduled = true;
     // Microtask batching — collects multiple log calls in the same tick
-    queueMicrotask(() => this.flush());
+    queueMicrotask(() => {
+      void this.flush();
+    });
   }
 
-  private flush(): void {
+  private async flush(): Promise<void> {
     const lines = this.buffer.join("");
     this.buffer = [];
     this.flushScheduled = false;
     if (!lines) return;
 
+    await this.rotateIfNeeded();
+
     if (this.fileReady) {
-      void this.adapter.append(LOG_FILE_NAME, lines).catch(() => {
+      try {
+        await this.adapter.append(this.logFilePath, lines);
+      } catch {
         // Silently fail — file may have been deleted mid-session
-      });
+      }
     } else {
-      // File was not pre-created (ensureFileExists failed or was not called).
-      // Write creates the file; subsequent flushes will use append.
-      void this.adapter.write(LOG_FILE_NAME, lines)
-        .then(() => { this.fileReady = true; })
-        .catch(() => { /* Silently fail */ });
+      try {
+        await this.adapter.write(this.logFilePath, lines);
+        this.fileReady = true;
+      } catch {
+        // Silently fail
+      }
+    }
+  }
+
+  /**
+   * Rotate the log file when it exceeds MAX_FILE_SIZE_BYTES. Single-generation:
+   * the previous `.1` (if any) is removed before rename. Resets fileReady so
+   * the next flush re-creates a fresh active file via write().
+   */
+  private async rotateIfNeeded(): Promise<void> {
+    if (!this.fileReady) return;
+    try {
+      const stat = await this.adapter.stat(this.logFilePath);
+      if (!stat || stat.size <= MAX_FILE_SIZE_BYTES) return;
+
+      const rotatedExists = await this.adapter.exists(this.rotatedFilePath);
+      if (rotatedExists) {
+        await this.adapter.remove(this.rotatedFilePath);
+      }
+      await this.adapter.rename(this.logFilePath, this.rotatedFilePath);
+      this.fileReady = false;
+    } catch {
+      // Best-effort — if stat/rename fails, continue with append
     }
   }
 }

--- a/packages/obsidian-plugin/src/adapters/logging/Logger.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/Logger.ts
@@ -15,7 +15,7 @@ export type NoticeCallback = (message: string) => void;
  * Each log level can independently route to three channels:
  * - Console (developer tools)
  * - Notice (Obsidian UI notification)
- * - File (exocortex-logs.txt in vault root)
+ * - File (exocortex-logs.txt inside the plugin's data folder, rotated at 1 MB)
  */
 export class Logger implements ILogger {
   private static isDevelopment: boolean | undefined = undefined;

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -47,8 +47,11 @@ export type LogLevel = "debug" | "info" | "warn" | "error";
 export type LogChannelsSettings = Record<LogLevel, LogChannelConfig>;
 
 export const DEFAULT_LOG_CHANNELS: LogChannelsSettings = {
-  debug: { notice: false, console: true, file: true },
-  info: { notice: false, console: true, file: true },
+  // Diagnostic levels: console only by default. Persisting every INFO/DEBUG
+  // line to disk produced ~6 MB / 54k lines per 2 days from renderer traces
+  // alone (#3186). Users can re-enable file routing per-level in settings.
+  debug: { notice: false, console: true, file: false },
+  info: { notice: false, console: true, file: false },
   warn: { notice: true, console: true, file: true },
   error: { notice: true, console: true, file: true },
 };

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -321,7 +321,7 @@ export class UniversalLayoutRenderer {
       this.metadataCache.set(currentFile.path, this.metadataExtractor.extractMetadata(currentFile));
 
       el.addClass("exocortex-layout-rendered");
-      this.logger.info(`Rendered UniversalLayout with ${relations.length} asset relations`);
+      this.logger.debug(`Rendered UniversalLayout with ${relations.length} asset relations`);
     } catch (error) {
       this.logger.error("Failed to render UniversalLayout", { error });
       el.createDiv({ text: `Error: ${error instanceof Error ? error.message : String(error)}`, cls: "exocortex-error-message" });

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -353,7 +353,8 @@ export class ExocortexSettingTab extends PluginSettingTab {
     const desc = containerEl.createDiv({ cls: "setting-item-description" });
     desc.appendText(
       "Choose which channels each log level should be routed to. " +
-        "File channel writes to exocortex-logs.txt in the vault root.",
+        "File channel writes to exocortex-logs.txt inside the plugin's data " +
+        "folder (rotated at 1 MB). Defaults: warn/error only.",
     );
 
     // Ensure logChannels exists

--- a/packages/obsidian-plugin/tests/e2e/specs/README.md
+++ b/packages/obsidian-plugin/tests/e2e/specs/README.md
@@ -10,7 +10,7 @@ Specs in this directory execute against a **shared** vault under `tests/e2e/test
 Consequences:
 
 - A test that mutates a fixture file (via `fs.writeFileSync`, `app.fileManager.processFrontMatter`, or plugin-triggered writes) leaves the fixture in a drifted state for every subsequent test in the same shard.
-- Plugin logging emits to `test-vault/exocortex-logs.txt`. That file is almost always in the modified set of `fixture-drift.json`; it is ambient output and can be ignored for isolation purposes.
+- Plugin logging emits to `test-vault/.obsidian/plugins/exocortex/exocortex-logs.txt` (since #3186). The drift detector should not see it because `.obsidian/` is outside the vault content tree, but any future log writes that escape the plugin data directory would resurface here as ambient noise.
 - Specs do **not** declare or rely on a cross-spec ordering contract. Parallel/shuffled execution must still pass. Any spec that requires a specific neighbour state must set that state itself in `beforeAll`/`beforeEach` rather than depend on the order Playwright happens to choose.
 
 ## Fixture drift detector

--- a/packages/obsidian-plugin/tests/unit/FileLogChannel.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FileLogChannel.test.ts
@@ -1,39 +1,87 @@
 import { FileLogChannel } from "../../src/adapters/logging/FileLogChannel";
 
+// Tests pass an explicit plugin dir so the channel does not assume a fixed
+// config-dir name (users can customise `.obsidian` to e.g. `.obsidian-mobile`).
+const PLUGIN_DIR = ".obsidian/plugins/exocortex";
+const LOG_FILE = `${PLUGIN_DIR}/exocortex-logs.txt`;
+const ROTATED_FILE = `${LOG_FILE}.1`;
+
+interface MockAdapter {
+  append: jest.Mock;
+  write: jest.Mock;
+  exists: jest.Mock;
+  mkdir: jest.Mock;
+  stat: jest.Mock;
+  rename: jest.Mock;
+  remove: jest.Mock;
+}
+
 describe("FileLogChannel", () => {
   let channel: FileLogChannel;
-  let mockAdapter: { append: jest.Mock; write: jest.Mock; exists: jest.Mock };
+  let mockAdapter: MockAdapter;
 
   beforeEach(() => {
     mockAdapter = {
       append: jest.fn().mockResolvedValue(undefined),
       write: jest.fn().mockResolvedValue(undefined),
       exists: jest.fn().mockResolvedValue(false),
+      mkdir: jest.fn().mockResolvedValue(undefined),
+      stat: jest.fn().mockResolvedValue({ size: 0, type: "file", ctime: 0, mtime: 0 }),
+      rename: jest.fn().mockResolvedValue(undefined),
+      remove: jest.fn().mockResolvedValue(undefined),
     };
-    channel = new FileLogChannel(mockAdapter as any);
+    channel = new FileLogChannel(mockAdapter as any, PLUGIN_DIR);
   });
 
   describe("ensureFileExists", () => {
-    it("should create the log file when it does not exist", async () => {
+    it("creates the plugin log directory when it does not exist", async () => {
       mockAdapter.exists.mockResolvedValue(false);
 
       await channel.ensureFileExists();
 
-      expect(mockAdapter.exists).toHaveBeenCalledWith("exocortex-logs.txt");
-      expect(mockAdapter.write).toHaveBeenCalledWith("exocortex-logs.txt", "");
+      expect(mockAdapter.exists).toHaveBeenCalledWith(PLUGIN_DIR);
+      expect(mockAdapter.mkdir).toHaveBeenCalledWith(PLUGIN_DIR);
     });
 
-    it("should not overwrite the log file when it already exists", async () => {
-      mockAdapter.exists.mockResolvedValue(true);
+    it("skips mkdir when the plugin log directory already exists", async () => {
+      // First exists() call (for dir) → true; second (for file) → true
+      mockAdapter.exists.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
 
       await channel.ensureFileExists();
 
-      expect(mockAdapter.exists).toHaveBeenCalledWith("exocortex-logs.txt");
+      expect(mockAdapter.exists).toHaveBeenNthCalledWith(1, PLUGIN_DIR);
+      expect(mockAdapter.mkdir).not.toHaveBeenCalled();
+    });
+
+    it("creates the log file when it does not exist (inside plugin data dir)", async () => {
+      // dir does not exist → mkdir; file does not exist → write
+      mockAdapter.exists.mockResolvedValueOnce(false).mockResolvedValueOnce(false);
+
+      await channel.ensureFileExists();
+
+      expect(mockAdapter.exists).toHaveBeenCalledWith(LOG_FILE);
+      expect(mockAdapter.write).toHaveBeenCalledWith(LOG_FILE, "");
+    });
+
+    it("does not overwrite the log file when it already exists", async () => {
+      // dir exists, file exists
+      mockAdapter.exists.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+
+      await channel.ensureFileExists();
+
+      expect(mockAdapter.exists).toHaveBeenCalledWith(LOG_FILE);
       expect(mockAdapter.write).not.toHaveBeenCalled();
     });
 
-    it("should not throw when exists check fails", async () => {
+    it("does not throw when exists check fails", async () => {
       mockAdapter.exists.mockRejectedValue(new Error("EPERM"));
+
+      await expect(channel.ensureFileExists()).resolves.toBeUndefined();
+    });
+
+    it("does not throw when mkdir fails", async () => {
+      mockAdapter.exists.mockResolvedValue(false);
+      mockAdapter.mkdir.mockRejectedValue(new Error("EPERM"));
 
       await expect(channel.ensureFileExists()).resolves.toBeUndefined();
     });
@@ -41,31 +89,36 @@ describe("FileLogChannel", () => {
 
   describe("flush after ensureFileExists", () => {
     beforeEach(async () => {
-      mockAdapter.exists.mockResolvedValue(false);
+      // dir exists, file exists → no setup writes
+      mockAdapter.exists.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
       await channel.ensureFileExists();
       mockAdapter.write.mockClear();
+      mockAdapter.exists.mockReset();
+      mockAdapter.exists.mockResolvedValue(false);
     });
 
-    it("should append log lines via adapter.append", async () => {
+    it("appends log lines to the plugin-data log path via adapter.append", async () => {
       channel.append("info", "TestCtx", "Hello world");
 
       await flushMicrotasks();
+      await flushMicrotasks(); // flush is async — await rotation+append chain
 
       expect(mockAdapter.append).toHaveBeenCalledTimes(1);
-      const writtenLine = mockAdapter.append.mock.calls[0][1] as string;
-      expect(writtenLine).toContain("[INFO]");
-      expect(writtenLine).toContain("[TestCtx]");
-      expect(writtenLine).toContain("Hello world");
-      expect(writtenLine).toMatch(/^\[\d{4}-\d{2}-\d{2}T/);
-      expect(writtenLine).toEndWith("\n");
-      expect(mockAdapter.append.mock.calls[0][0]).toBe("exocortex-logs.txt");
+      const [path, line] = mockAdapter.append.mock.calls[0];
+      expect(path).toBe(LOG_FILE);
+      expect(line).toContain("[INFO]");
+      expect(line).toContain("[TestCtx]");
+      expect(line).toContain("Hello world");
+      expect(line).toMatch(/^\[\d{4}-\d{2}-\d{2}T/);
+      expect(line).toEndWith("\n");
     });
 
-    it("should batch multiple appends in the same tick", async () => {
+    it("batches multiple appends in the same tick", async () => {
       channel.append("debug", "A", "Line 1");
       channel.append("warn", "B", "Line 2");
       channel.append("error", "C", "Line 3");
 
+      await flushMicrotasks();
       await flushMicrotasks();
 
       expect(mockAdapter.append).toHaveBeenCalledTimes(1);
@@ -76,9 +129,10 @@ describe("FileLogChannel", () => {
       expect(combined.split("\n").filter(Boolean)).toHaveLength(3);
     });
 
-    it("should format log lines with ISO timestamp", async () => {
+    it("formats log lines with ISO timestamp", async () => {
       channel.append("warn", "MyService", "Something happened");
 
+      await flushMicrotasks();
       await flushMicrotasks();
 
       const line = mockAdapter.append.mock.calls[0][1] as string;
@@ -88,31 +142,33 @@ describe("FileLogChannel", () => {
   });
 
   describe("flush without ensureFileExists (fallback path)", () => {
-    it("should use write to create the file on first flush", async () => {
+    it("uses write to create the file on first flush", async () => {
       channel.append("info", "Ctx", "First write");
 
       await flushMicrotasks();
+      await flushMicrotasks();
 
       expect(mockAdapter.write).toHaveBeenCalledTimes(1);
-      const writtenLine = mockAdapter.write.mock.calls[0][1] as string;
-      expect(writtenLine).toContain("First write");
+      const [path, line] = mockAdapter.write.mock.calls[0];
+      expect(path).toBe(LOG_FILE);
+      expect(line).toContain("First write");
     });
 
-    it("should switch to append after successful write", async () => {
+    it("switches to append after successful write", async () => {
       channel.append("info", "Ctx", "First");
       await flushMicrotasks();
-      // Let the write promise resolve and set fileReady
       await flushMicrotasks();
 
       mockAdapter.write.mockClear();
       channel.append("info", "Ctx", "Second");
+      await flushMicrotasks();
       await flushMicrotasks();
 
       expect(mockAdapter.append).toHaveBeenCalledTimes(1);
       expect(mockAdapter.write).not.toHaveBeenCalled();
     });
 
-    it("should silently handle write failure", async () => {
+    it("silently handles write failure", async () => {
       mockAdapter.write.mockRejectedValueOnce(new Error("EPERM"));
 
       channel.append("error", "Ctx", "Fail silently");
@@ -121,6 +177,83 @@ describe("FileLogChannel", () => {
       await flushMicrotasks();
 
       expect(mockAdapter.write).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("rotation", () => {
+    beforeEach(async () => {
+      mockAdapter.exists.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+      await channel.ensureFileExists();
+      mockAdapter.write.mockClear();
+      mockAdapter.exists.mockReset();
+    });
+
+    it("does not rotate when file is under the size threshold", async () => {
+      mockAdapter.stat.mockResolvedValue({ size: 500_000, type: "file", ctime: 0, mtime: 0 });
+
+      channel.append("info", "Ctx", "Below threshold");
+
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(mockAdapter.rename).not.toHaveBeenCalled();
+      expect(mockAdapter.remove).not.toHaveBeenCalled();
+      expect(mockAdapter.append).toHaveBeenCalledWith(LOG_FILE, expect.stringContaining("Below threshold"));
+    });
+
+    it("rotates the file when it exceeds 1 MB", async () => {
+      mockAdapter.stat.mockResolvedValue({ size: 1_500_000, type: "file", ctime: 0, mtime: 0 });
+      mockAdapter.exists.mockResolvedValue(false); // .1 does not exist yet
+
+      channel.append("info", "Ctx", "After rotation");
+
+      await flushMicrotasks();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(mockAdapter.rename).toHaveBeenCalledWith(LOG_FILE, ROTATED_FILE);
+      // After rotation, fileReady is reset → fresh write() recreates active file
+      expect(mockAdapter.write).toHaveBeenCalledWith(LOG_FILE, expect.stringContaining("After rotation"));
+    });
+
+    it("removes previous .1 before renaming when it already exists", async () => {
+      mockAdapter.stat.mockResolvedValue({ size: 1_500_000, type: "file", ctime: 0, mtime: 0 });
+      mockAdapter.exists.mockResolvedValue(true); // .1 already exists
+
+      channel.append("info", "Ctx", "Rotate again");
+
+      await flushMicrotasks();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(mockAdapter.remove).toHaveBeenCalledWith(ROTATED_FILE);
+      expect(mockAdapter.rename).toHaveBeenCalledWith(LOG_FILE, ROTATED_FILE);
+    });
+
+    it("falls through to append when stat fails (best-effort rotation)", async () => {
+      mockAdapter.stat.mockRejectedValue(new Error("ENOENT"));
+
+      channel.append("info", "Ctx", "Stat failed");
+
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(mockAdapter.rename).not.toHaveBeenCalled();
+      expect(mockAdapter.append).toHaveBeenCalledWith(LOG_FILE, expect.stringContaining("Stat failed"));
+    });
+
+    it("skips rotation when file is not yet ready (first write path)", async () => {
+      // Fresh channel without ensureFileExists → fileReady=false
+      const freshChannel = new FileLogChannel(mockAdapter as any, PLUGIN_DIR);
+
+      freshChannel.append("info", "Ctx", "First line ever");
+
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(mockAdapter.stat).not.toHaveBeenCalled();
+      expect(mockAdapter.rename).not.toHaveBeenCalled();
+      expect(mockAdapter.write).toHaveBeenCalledWith(LOG_FILE, expect.stringContaining("First line ever"));
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/LogChannelSettings.test.ts
+++ b/packages/obsidian-plugin/tests/unit/LogChannelSettings.test.ts
@@ -13,12 +13,12 @@ describe("LogChannelSettings", () => {
       expect(DEFAULT_LOG_CHANNELS).toHaveProperty("error");
     });
 
-    it("should default debug to console + file", () => {
-      expect(DEFAULT_LOG_CHANNELS.debug).toEqual({ notice: false, console: true, file: true });
+    it("should default debug to console only (no file persistence)", () => {
+      expect(DEFAULT_LOG_CHANNELS.debug).toEqual({ notice: false, console: true, file: false });
     });
 
-    it("should default info to console + file", () => {
-      expect(DEFAULT_LOG_CHANNELS.info).toEqual({ notice: false, console: true, file: true });
+    it("should default info to console only (no file persistence)", () => {
+      expect(DEFAULT_LOG_CHANNELS.info).toEqual({ notice: false, console: true, file: false });
     });
 
     it("should default warn to notice + console + file", () => {
@@ -29,9 +29,16 @@ describe("LogChannelSettings", () => {
       expect(DEFAULT_LOG_CHANNELS.error).toEqual({ notice: true, console: true, file: true });
     });
 
-    it("should enable file channel by default for all levels", () => {
-      const levels = Object.keys(DEFAULT_LOG_CHANNELS) as (keyof LogChannelsSettings)[];
-      for (const level of levels) {
+    it("should disable file channel by default for diagnostic levels (debug, info)", () => {
+      const diagnosticLevels: (keyof LogChannelsSettings)[] = ["debug", "info"];
+      for (const level of diagnosticLevels) {
+        expect(DEFAULT_LOG_CHANNELS[level].file).toBe(false);
+      }
+    });
+
+    it("should enable file channel by default for actionable levels (warn, error)", () => {
+      const actionableLevels: (keyof LogChannelsSettings)[] = ["warn", "error"];
+      for (const level of actionableLevels) {
         expect(DEFAULT_LOG_CHANNELS[level].file).toBe(true);
       }
     });


### PR DESCRIPTION
## Summary

Three-layered fix for #3186 — `exocortex-logs.txt` grew to **6.1 MB / 54 931 lines in 2 days** at the user's vault root, ~95% from `UniversalLayoutRenderer` info traces.

1. **Move log file out of vault root** — now lives at `Plugin.manifest.dir/exocortex-logs.txt` (typically `.obsidian/plugins/exocortex/`). Path is derived from Obsidian's manifest, not hardcoded, so users with customised `configDir` (e.g. `.obsidian-mobile`) are honoured. This satisfies the `obsidianmd/hardcoded-config-path` lint rule.
2. **Add size-based rotation** — when the active file exceeds 1 MB, it is renamed to `*.1` (single-generation, prior `.1` is replaced). Disk usage bounded to ~2 MB.
3. **Quiet diagnostic logs by default** — `DEFAULT_LOG_CHANNELS.debug.file` and `info.file` flipped to `false`. Only `warn` and `error` persist to disk by default; users can re-enable in Log channels settings. `UniversalLayoutRenderer`'s render-trace demoted from `info` → `debug` (it's diagnostic noise, fires 3× within ~100 ms on DOM updates).

Closes #3186.

## Files changed

| File | Change |
|---|---|
| `FileLogChannel.ts` | constructor takes `pluginDir`, paths now instance fields, `rotateIfNeeded()` + `mkdir` parent dir, JSDoc |
| `ExocortexPlugin.ts` | passes `this.manifest.dir` (fallback to `configDir/plugins/<id>`) |
| `ExocortexSettings.ts` | `DEFAULT_LOG_CHANNELS` — `debug.file=false`, `info.file=false` |
| `UniversalLayoutRenderer.ts` | `logger.info` → `logger.debug` for render trace |
| `Logger.ts`, `ExocortexSettingTab.ts` | JSDoc + UI text reflect new location & rotation |
| `tests/unit/FileLogChannel.test.ts` | rewrite for new constructor + 5 rotation cases (17 total, all green) |
| `tests/unit/LogChannelSettings.test.ts` | split defaults assertion into diagnostic vs actionable groups |
| `tests/e2e/specs/README.md` | note that the file moved out of the drift-scanned content tree |

## Test plan

- [x] `npx jest FileLogChannel.test.ts Logger.test.ts LogChannelSettings.test.ts ExocortexPlugin.test.ts` — 178 passed
- [x] `npm run check:types` — green
- [x] `npm run lint` — green (only 2 unrelated pre-existing warnings)
- [x] Pre-commit hooks: lint-staged + BDD coverage (100%) + Archgate ADR — all green
- [ ] CI 13 required checks (`archgate`, `detect-changes`, `e2e-shard 1..6`, `lint`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`)

## Out of scope

- Auto-cleanup of orphaned legacy `<vault>/exocortex-logs.txt` from prior versions (left in place; user data).
- Multi-generation rotation (`.1`, `.2`, …) — single generation is sufficient for the reported usage pattern.
- Async-aware rotation locking — single-writer assumption holds for plugin context; worst case is a duplicate rotation or one lost line per concurrent flush race, acceptable for log code.

## Rollout note

Users running the previous version still have `<vault>/exocortex-logs.txt` lying around — they can delete it manually once the released version is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)