### PR TITLE
fix(grounding): correct create_instance frontmatter + open new file (#3184)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -84,6 +84,7 @@ export {
   CommandExecutionFlow,
   type CommandExecutionContext,
   type CommandPromptAdapter,
+  type IFileOpener,
 } from "./services/CommandExecutionFlow";
 export { TaskStatusService } from "./services/TaskStatusService";
 export { AreaCreationService } from "./services/AreaCreationService";

--- a/packages/exocortex/src/services/CommandExecutionFlow.ts
+++ b/packages/exocortex/src/services/CommandExecutionFlow.ts
@@ -49,6 +49,21 @@ export interface CommandPromptAdapter {
 }
 
 /**
+ * Surface-agnostic file-opening hook (Issue #3184 B5). When
+ * {@link GroundingExecutor.executeCreateInstance} writes a new asset it
+ * returns the vault-relative path via {@link ExecutionResult.openPath};
+ * {@link CommandExecutionFlow} forwards that path here so the platform
+ * adapter (Obsidian plugin / future CLI) can decide where the file appears
+ * — in Obsidian, `app.workspace.getLeaf("tab").openFile(...)` + focus.
+ *
+ * Tests and headless runners may omit the dependency: when undefined the
+ * core run pipeline is unchanged (creation succeeds without auto-opening).
+ */
+export interface IFileOpener {
+  open(path: string): Promise<void>;
+}
+
+/**
  * Domain-agnostic execution pipeline for a resolved exocmd command.
  *
  * Pipeline:
@@ -74,6 +89,7 @@ export class CommandExecutionFlow {
     private readonly logger: ILogger,
     private readonly prompts: CommandPromptAdapter,
     private readonly tripleStore?: ITripleStore,
+    private readonly fileOpener?: IFileOpener,
   ) {}
 
   async run(
@@ -118,6 +134,19 @@ export class CommandExecutionFlow {
       await new Promise((resolve) => setTimeout(resolve, 100));
       if (ctx.onComplete) {
         await ctx.onComplete();
+      }
+      // Issue #3184 B5: open the newly created file when create_instance
+      // reports a path. Best-effort — failure to open is logged but does
+      // not flip the run result (the file was created; the UI may simply
+      // remain on the source asset).
+      if (result.openPath && this.fileOpener) {
+        try {
+          await this.fileOpener.open(result.openPath);
+        } catch (error) {
+          this.logger.info(
+            `[CommandExecutionFlow] Failed to open created file "${result.openPath}": ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
       }
       this.logger.info(
         `[CommandExecutionFlow] Executed "${command.name}" on ${displayPath}`,

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -11,10 +11,17 @@ import { LoggingService } from "./LoggingService";
 
 /**
  * Result of executing a grounding action.
+ *
+ * `openPath` is set by `create_instance` to the vault-relative path of the
+ * newly written asset; presentation layers use it to open the file in a new
+ * tab after a successful run (Issue #3184 B5). Surface-agnostic — the core
+ * executor only reports the path; opening is wired by the platform adapter
+ * (Obsidian plugin / CLI / test harness).
  */
 export interface ExecutionResult {
   readonly success: boolean;
   readonly error?: string;
+  readonly openPath?: string;
 }
 
 /**
@@ -488,6 +495,12 @@ export class GroundingExecutor {
    * neither of which is meaningful on the new asset. exo__Instance_class is
    * blacklisted because the new instance has its own class supplied via
    * grounding.targetClass.
+   *
+   * Issue #3184 B3+B4: `ems__Effort_area` and `exo__Asset_relates` are also
+   * blacklisted. Both belong on the prototype-instance (the asset the user
+   * clicked); inheriting them into a created instance double-materialises the
+   * link that `exo__Asset_prototype` (back-link, see executeCreateInstance)
+   * already implies through the RDF graph.
    */
   private static readonly CREATE_INSTANCE_BLACKLIST: ReadonlySet<string> =
     new Set([
@@ -501,6 +514,8 @@ export class GroundingExecutor {
       "ems__Effort_startTimestamp",
       "ems__Effort_endTimestamp",
       "ems__Effort_resolutionTimestamp",
+      "ems__Effort_area",
+      "exo__Asset_relates",
     ]);
 
   private async executeCreateInstance(
@@ -518,7 +533,14 @@ export class GroundingExecutor {
 
     const properties: Record<string, unknown> = {
       exo__Asset_uid: uid,
-      exo__Asset_createdAt: new Date().toISOString(),
+      // Issue #3188: emit `exo__Asset_createdAt` as a local timestamp without
+      // the trailing `Z` / TZ offset, matching every other creation service
+      // in the codebase (Generic/Area/Class/Concept/Supervision asset
+      // creation, TaskStatusService start/end timestamps). The legacy
+      // `new Date().toISOString()` produced UTC-suffixed values which then
+      // disagreed with the rest of the vault when rendered in the user's
+      // local timezone; this one-liner aligns the format.
+      exo__Asset_createdAt: DateFormatter.toLocalTimestamp(new Date()),
       exo__Asset_label: label,
     };
 
@@ -530,9 +552,14 @@ export class GroundingExecutor {
       properties.exo__Instance_class = [`"[[${grounding.targetClass}]]"`];
     }
 
-    if (grounding.targetPrototype) {
-      properties.exo__Asset_prototype = `"[[${grounding.targetPrototype}]]"`;
-    }
+    // Issue #3184 B1: do NOT materialise `grounding.targetPrototype` (which is
+    // the UID of the prototype CLASS, e.g. `ems__TaskPrototype`) into the new
+    // instance's `exo__Asset_prototype`. The semantically correct value is the
+    // wikilink to the prototype-INSTANCE the user clicked on ($target), and
+    // that link is written below by the back-link block whose default for
+    // create_instance is now `exo__Asset_prototype` (B2). Keeping a literal
+    // class-UID write here would either overwrite the correct back-link value
+    // or be silently overwritten — both confusing.
 
     // Issue #3136 (Q3.b closure): apply propertyDefaults BEFORE userInput so
     // user input wins. Values are passed through substituteVariables, enabling
@@ -586,10 +613,18 @@ export class GroundingExecutor {
     }
 
     // Back-link to $target — configurable per grounding (RFC Phase 2).
-    // Fallback to legacy `exo__Asset_source` preserves behaviour for existing
-    // groundings that have no `Grounding_linkBackProperty` set.
+    //
+    // Issue #3184 B1+B2: default for `create_instance` is `exo__Asset_prototype`,
+    // not `exo__Asset_source`. The prototype-driven creation flow always links
+    // the new instance back to the prototype-instance via `exo__Asset_prototype`,
+    // and the separate `exo__Asset_source` field added nothing but duplication
+    // (and a confusing extra wikilink in the resulting frontmatter). Groundings
+    // that genuinely want a different back-link target (e.g. `ems__Effort_parent`
+    // for fork-style "Create related task") still set `linkBackProperty`
+    // explicitly and bypass the default.
     if (targetIRI) {
-      const backLinkProp = grounding.linkBackProperty ?? "exo__Asset_source";
+      const backLinkProp =
+        grounding.linkBackProperty ?? "exo__Asset_prototype";
       const backLinkTarget = GroundingExecutor.extractBacklinkTarget(targetIRI, targetFilePath);
       properties[backLinkProp] = `"[[${backLinkTarget}]]"`;
     }
@@ -609,7 +644,11 @@ export class GroundingExecutor {
 
     await this.fileWriter.createFile(filePath, content);
 
-    return { success: true };
+    // Issue #3184 B5: surface the created file's vault-relative path so the
+    // presentation layer can open it in a new tab. Core stays surface-agnostic
+    // — actually opening the file is wired by the platform adapter through
+    // CommandExecutionFlow's optional IFileOpener dependency.
+    return { success: true, openPath: filePath };
   }
 
   /**

--- a/packages/exocortex/tests/integration/asset-creation/create-instance-grounding.test.ts
+++ b/packages/exocortex/tests/integration/asset-creation/create-instance-grounding.test.ts
@@ -276,13 +276,51 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
   let groundingExecutor: GroundingExecutor;
   let converter: NoteToRDFConverter;
 
-  beforeEach(() => {
+  // copy-from-target (RFC v0.2) reads the parent file's frontmatter via
+  // `fs.readFile(targetFilePath)`; the integration test previously omitted
+  // this seeding, causing every test to fail at the read with "File not
+  // found" before this suite was wired into a green required check. Seed a
+  // minimal parent.md so the executor's copy-loop sees real frontmatter and
+  // proceeds to write the new instance.
+  const PARENT_FILE_PATH = "/vault/parent.md";
+  const PARENT_FILE_CONTENT = [
+    "---",
+    'exo__Asset_uid: "parent-uid"',
+    'exo__Asset_label: "Parent prototype"',
+    "exo__Instance_class:",
+    '  - "[[ems__TaskPrototype]]"',
+    "---",
+    "Body",
+  ].join("\n");
+
+  beforeEach(async () => {
     fs = new InMemoryFileSystem();
+    await fs.createFile(PARENT_FILE_PATH, PARENT_FILE_CONTENT);
     vaultAdapter = new InMemoryVaultAdapter(fs);
     const serviceRegistry = new ServiceRegistry();
     groundingExecutor = new GroundingExecutor(fs, fs, serviceRegistry);
     converter = new NoteToRDFConverter(vaultAdapter);
   });
+
+  /**
+   * Return the single newly-created `IFile` (the parent.md seed file is
+   * excluded). Tests that expect exactly one created file get a friendlier
+   * failure message via the length assertion than a silent `files[0]` that
+   * picks parent.md when nothing was created.
+   */
+  function getCreatedFile(): IFile {
+    const created = vaultAdapter
+      .getAllFiles()
+      .filter((f) => f.path !== PARENT_FILE_PATH);
+    if (created.length !== 1) {
+      throw new Error(
+        `Expected exactly 1 created file, got ${created.length}: ${created
+          .map((f) => f.path)
+          .join(", ")}`,
+      );
+    }
+    return created[0];
+  }
 
   // -----------------------------------------------------------------------
   // Full pipeline: with prototype
@@ -308,8 +346,11 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
 
       expect(result.success).toBe(true);
 
-      const allPaths = fs.getAllPaths();
-      expect(allPaths).toHaveLength(1);
+      const createdPaths = fs
+        .getAllPaths()
+        .filter((p) => p !== PARENT_FILE_PATH);
+      expect(createdPaths).toHaveLength(1);
+      const allPaths = createdPaths;
       expect(allPaths[0]).toMatch(/^01 Inbox\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\.md$/);
     });
 
@@ -321,10 +362,8 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "Test Task" },
       );
 
-      const files = vaultAdapter.getAllFiles();
-      expect(files).toHaveLength(1);
-
-      const triples = await converter.convertNote(files[0]);
+      const file = getCreatedFile();
+      const triples = await converter.convertNote(file);
       expect(triples.length).toBeGreaterThan(0);
     });
 
@@ -336,8 +375,8 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "Test Task" },
       );
 
-      const files = vaultAdapter.getAllFiles();
-      const triples = await converter.convertNote(files[0]);
+      const file = getCreatedFile();
+      const triples = await converter.convertNote(file);
 
       const rdfType = Namespace.RDF.term("type");
       const emsTask = Namespace.EMS.term("Task");
@@ -359,8 +398,8 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "Test Task" },
       );
 
-      const files = vaultAdapter.getAllFiles();
-      const triples = await converter.convertNote(files[0]);
+      const file = getCreatedFile();
+      const triples = await converter.convertNote(file);
 
       const labelPredicate = Namespace.EXO.term("Asset_label");
       expect(hasTripleWithObject(triples, labelPredicate, "Test Task")).toBe(true);
@@ -374,8 +413,8 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "Test Task" },
       );
 
-      const files = vaultAdapter.getAllFiles();
-      const triples = await converter.convertNote(files[0]);
+      const file = getCreatedFile();
+      const triples = await converter.convertNote(file);
 
       const uidPredicate = Namespace.EXO.term("Asset_uid");
       const uidTriples = findTriples(triples, uidPredicate);
@@ -394,8 +433,8 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "Test Task" },
       );
 
-      const files = vaultAdapter.getAllFiles();
-      const triples = await converter.convertNote(files[0]);
+      const file = getCreatedFile();
+      const triples = await converter.convertNote(file);
 
       const instanceClassPredicate = Namespace.EXO.term("Instance_class");
       const classTriples = findTriples(triples, instanceClassPredicate);
@@ -409,7 +448,7 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
       expect(hasEmsTask).toBe(true);
     });
 
-    it("should produce exo:Asset_prototype triple linking to prototype", async () => {
+    it("should produce exo:Asset_prototype triple linking to the prototype-instance ($target, Issue #3184 B1)", async () => {
       await groundingExecutor.execute(
         GROUNDING,
         "https://exocortex.my/assets/parent",
@@ -417,15 +456,30 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "Test Task" },
       );
 
-      const files = vaultAdapter.getAllFiles();
-      const triples = await converter.convertNote(files[0]);
+      const file = getCreatedFile();
+      const triples = await converter.convertNote(file);
 
       const prototypePredicate = Namespace.EXO.term("Asset_prototype");
       const protoTriples = findTriples(triples, prototypePredicate);
       expect(protoTriples.length).toBeGreaterThanOrEqual(1);
 
-      // Prototype value should contain the UUID string
-      const hasProtoRef = protoTriples.some((t) => {
+      // After Issue #3184 the prototype back-link points at the
+      // prototype-INSTANCE (the file the user clicked on, i.e. parent.md),
+      // not the class UID declared in `grounding.targetPrototype`. The
+      // converter resolves wikilink targets to the linked asset's basename
+      // (`parent`) — strip the path and `.md` extension before matching.
+      const hasParentRef = protoTriples.some((t) => {
+        if (t.object instanceof Literal) {
+          return t.object.value.includes("parent");
+        }
+        if (t.object instanceof IRI) {
+          return t.object.value.includes("parent");
+        }
+        return false;
+      });
+      expect(hasParentRef).toBe(true);
+      // Class UID is NOT materialised as the prototype reference.
+      const leaksClassUID = protoTriples.some((t) => {
         if (t.object instanceof Literal) {
           return t.object.value.includes("proto-task-template-001");
         }
@@ -434,7 +488,7 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         }
         return false;
       });
-      expect(hasProtoRef).toBe(true);
+      expect(leaksClassUID).toBe(false);
     });
 
     it("should produce exo:Asset_fileName triple with basename", async () => {
@@ -445,8 +499,8 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "Test Task" },
       );
 
-      const files = vaultAdapter.getAllFiles();
-      const triples = await converter.convertNote(files[0]);
+      const file = getCreatedFile();
+      const triples = await converter.convertNote(file);
 
       const fileNamePredicate = Namespace.EXO.term("Asset_fileName");
       const fileNameTriples = findTriples(triples, fileNamePredicate);
@@ -472,7 +526,12 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
       targetFolder: "01 Inbox",
     };
 
-    it("should create file without exo__Asset_prototype in frontmatter", async () => {
+    it("should still write exo__Asset_prototype linked to $target (Issue #3184 B2 default)", async () => {
+      // Before Issue #3184 a grounding lacking `targetPrototype` produced
+      // no `exo__Asset_prototype` line. After Issue #3184 the back-link
+      // default is `exo__Asset_prototype`, so the field is always present
+      // when targetIRI is non-empty — it just points to the parent file
+      // (the asset the user clicked on) instead of a synthetic class UID.
       await groundingExecutor.execute(
         GROUNDING,
         "https://exocortex.my/assets/parent",
@@ -480,14 +539,20 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "No Proto Task" },
       );
 
-      const allPaths = fs.getAllPaths();
-      expect(allPaths).toHaveLength(1);
+      const createdPaths = fs
+        .getAllPaths()
+        .filter((p) => p !== PARENT_FILE_PATH);
+      expect(createdPaths).toHaveLength(1);
+      const allPaths = createdPaths;
 
       const content = fs.getContent(allPaths[0])!;
-      expect(content).not.toContain("exo__Asset_prototype");
+      expect(content).toContain('exo__Asset_prototype: "[[vault/parent]]"');
+      // Issue #3184 B2: legacy `exo__Asset_source` default no longer
+      // applied for create_instance.
+      expect(content).not.toContain("exo__Asset_source:");
     });
 
-    it("should NOT produce exo:Asset_prototype triple", async () => {
+    it("should produce exo:Asset_prototype triple linking to $target", async () => {
       await groundingExecutor.execute(
         GROUNDING,
         "https://exocortex.my/assets/parent",
@@ -495,12 +560,24 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "No Proto Task" },
       );
 
-      const files = vaultAdapter.getAllFiles();
-      const triples = await converter.convertNote(files[0]);
+      const file = getCreatedFile();
+      const triples = await converter.convertNote(file);
 
       const prototypePredicate = Namespace.EXO.term("Asset_prototype");
       const protoTriples = findTriples(triples, prototypePredicate);
-      expect(protoTriples).toHaveLength(0);
+      expect(protoTriples.length).toBeGreaterThanOrEqual(1);
+      // Same expectation as the "with prototype" case — the prototype
+      // back-link always references the parent file's basename.
+      const hasParentRef = protoTriples.some((t) => {
+        if (t.object instanceof Literal) {
+          return t.object.value.includes("parent");
+        }
+        if (t.object instanceof IRI) {
+          return t.object.value.includes("parent");
+        }
+        return false;
+      });
+      expect(hasParentRef).toBe(true);
     });
 
     it("should still produce rdf:type, label, uid, and Instance_class triples", async () => {
@@ -511,8 +588,8 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "No Proto Task" },
       );
 
-      const files = vaultAdapter.getAllFiles();
-      const triples = await converter.convertNote(files[0]);
+      const file = getCreatedFile();
+      const triples = await converter.convertNote(file);
 
       // rdf:type
       const rdfType = Namespace.RDF.term("type");
@@ -564,11 +641,13 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
         { label: "Task B" },
       );
 
-      const allPaths = fs.getAllPaths();
-      expect(allPaths).toHaveLength(2);
+      const createdPaths = fs
+        .getAllPaths()
+        .filter((p) => p !== PARENT_FILE_PATH);
+      expect(createdPaths).toHaveLength(2);
 
       // Extract UUIDs from paths
-      const uuids = allPaths.map((p) =>
+      const uuids = createdPaths.map((p) =>
         p.replace("01 Inbox/", "").replace(".md", ""),
       );
       expect(uuids[0]).not.toBe(uuids[1]);

--- a/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
+++ b/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
@@ -109,6 +109,11 @@ const SOURCE_CONTENT = [
   'ems__Effort_parent: "[[parent-project-uid]]"',
   'ems__Effort_area: "[[area-uid]]"',
   'ems__Effort_responsible: "[[user-uid]]"',
+  // Issue #3184 B3 added `ems__Effort_area` to the blacklist; without
+  // another non-blacklisted ems__Effort_* property the fixture would only
+  // cover 2 inherited keys instead of the documented "≥3" contract. Pick
+  // `ems__Effort_priority` — already used in vault, still copyable.
+  'ems__Effort_priority: "[[priority-high]]"',
   "---",
   "",
   "# Source Task",
@@ -326,13 +331,23 @@ describe("RFC da3a7555 — RDF → Resolver → Executor pipeline (create_instan
     const content = fs.getContent(createdPath!)!;
 
     // ≥3 copy-from-target fields must be present.
-    const copiedKeys = ["ems__Effort_parent", "ems__Effort_area", "ems__Effort_responsible"];
+    // Issue #3184 B3: `ems__Effort_area` is now blacklisted — replace with
+    // `ems__Effort_priority` which still inherits through copy-from-target.
+    const copiedKeys = [
+      "ems__Effort_parent",
+      "ems__Effort_priority",
+      "ems__Effort_responsible",
+    ];
     const copiedCount = copiedKeys.filter((k) => content.includes(`${k}:`)).length;
     expect(copiedCount).toBeGreaterThanOrEqual(3);
 
     // Blacklist enforcement: must NOT copy uid, label, status, instance_class.
     expect(content).not.toMatch(/\nexo__Asset_uid: 36e54b4c/);
     expect(content).not.toMatch(/^aliases:\n.*- "Source Task"/m);
+    // Issue #3184 B3+B4: `ems__Effort_area` and `exo__Asset_relates` are
+    // blacklisted; verify they don't bleed into the new instance.
+    expect(content).not.toContain("ems__Effort_area:");
+    expect(content).not.toContain("exo__Asset_relates:");
     // Back-link present.
     expect(content).toContain(`ems__Effort_prevIteration: "[[${SOURCE_FILE_PATH.replace(/\.md$/, "")}]]"`);
   });

--- a/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
+++ b/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
@@ -1,6 +1,7 @@
 import {
   CommandExecutionFlow,
   type CommandPromptAdapter,
+  type IFileOpener,
 } from "../../src/services/CommandExecutionFlow";
 import type {
   GroundingExecutor,
@@ -52,6 +53,7 @@ function makeFlow(overrides?: {
   confirmResult?: boolean;
   promptResult?: UserInput | null;
   tripleStore?: InMemoryTripleStore;
+  fileOpener?: IFileOpener;
 }) {
   const groundingExecutor = {
     execute: jest
@@ -82,6 +84,7 @@ function makeFlow(overrides?: {
   };
 
   const tripleStore = overrides?.tripleStore;
+  const fileOpener = overrides?.fileOpener;
 
   const flow = new CommandExecutionFlow(
     groundingExecutor,
@@ -89,6 +92,7 @@ function makeFlow(overrides?: {
     logger,
     prompts,
     tripleStore,
+    fileOpener,
   );
 
   return {
@@ -98,6 +102,7 @@ function makeFlow(overrides?: {
     logger,
     prompts,
     tripleStore,
+    fileOpener,
   };
 }
 
@@ -596,6 +601,96 @@ describe("CommandExecutionFlow", () => {
       expect(notificationService.error).toHaveBeenCalledWith(
         "Command failed: unknown error",
       );
+    });
+  });
+
+  // Issue #3184 B5 — open-in-tab plumbing across IFileOpener.
+  describe("openPath / IFileOpener (Issue #3184 B5)", () => {
+    it("forwards openPath to fileOpener.open on success", async () => {
+      const openFn = jest.fn().mockResolvedValue(undefined);
+      const fileOpener: IFileOpener = { open: openFn };
+      const { flow } = makeFlow({
+        groundingResult: {
+          success: true,
+          openPath: "01 Inbox/abc-uuid.md",
+        } as ExecutionResult,
+        fileOpener,
+      });
+      const rc = makeRC();
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(openFn).toHaveBeenCalledTimes(1);
+      expect(openFn).toHaveBeenCalledWith("01 Inbox/abc-uuid.md");
+    });
+
+    it("does nothing when fileOpener is omitted (CLI/headless surface)", async () => {
+      const { flow } = makeFlow({
+        groundingResult: {
+          success: true,
+          openPath: "01 Inbox/abc-uuid.md",
+        } as ExecutionResult,
+        // fileOpener intentionally omitted
+      });
+      const rc = makeRC();
+
+      // No-throw is the spec for surfaces that don't supply IFileOpener.
+      await expect(
+        flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("does not call fileOpener when grounding did not surface openPath", async () => {
+      const openFn = jest.fn().mockResolvedValue(undefined);
+      const { flow } = makeFlow({
+        groundingResult: { success: true } as ExecutionResult, // no openPath
+        fileOpener: { open: openFn },
+      });
+      const rc = makeRC();
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(openFn).not.toHaveBeenCalled();
+    });
+
+    it("does not call fileOpener when grounding failed", async () => {
+      const openFn = jest.fn().mockResolvedValue(undefined);
+      const { flow } = makeFlow({
+        groundingResult: {
+          success: false,
+          error: "boom",
+          openPath: "should-not-open.md",
+        } as ExecutionResult,
+        fileOpener: { open: openFn },
+      });
+      const rc = makeRC();
+
+      await flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" });
+
+      expect(openFn).not.toHaveBeenCalled();
+    });
+
+    it("logs but does not propagate fileOpener errors", async () => {
+      const openErr = new Error("workspace busy");
+      const openFn = jest.fn().mockRejectedValue(openErr);
+      const { flow, logger, notificationService } = makeFlow({
+        groundingResult: {
+          success: true,
+          openPath: "01 Inbox/abc-uuid.md",
+        } as ExecutionResult,
+        fileOpener: { open: openFn },
+      });
+      const rc = makeRC();
+
+      await expect(
+        flow.run(rc, { targetIRI: "iri://x", filePath: "x.md" }),
+      ).resolves.toBeUndefined();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to open created file"),
+      );
+      // Success path side-effects should still have fired (no error toast).
+      expect(notificationService.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -822,7 +822,12 @@ describe("GroundingExecutor", () => {
       expect(content).toContain("exo__Asset_uid:");
       expect(content).toContain("exo__Asset_label: Buy milk");
       expect(content).toContain("gtd__InboxItem");
-      expect(content).toContain("proto-uuid-123");
+      // Issue #3184 B1: exo__Asset_prototype links to the $target file
+      // (the prototype-instance the user clicked on), not the class UID
+      // declared in `grounding.targetPrototype`. The class UID is only
+      // used for binding resolution, never materialised into frontmatter.
+      expect(content).toContain('exo__Asset_prototype: "[[vault/test-asset]]"');
+      expect(content).not.toContain("proto-uuid-123");
     });
 
     it("should generate valid UUID in filename", async () => {
@@ -851,7 +856,7 @@ describe("GroundingExecutor", () => {
       expect(result.error).toContain("targetFolder");
     });
 
-    it("should work without targetPrototype", async () => {
+    it("should work without grounding.targetPrototype (prototype back-link still applied)", async () => {
       const grounding = makeGrounding({
         type: GroundingType.CREATE_INSTANCE,
         targetClass: "ems__Task",
@@ -863,7 +868,11 @@ describe("GroundingExecutor", () => {
       expect(result.success).toBe(true);
       const [, content] = writer.createFile.mock.calls[0];
       expect(content).toContain("exo__Asset_label: No proto");
-      expect(content).not.toContain("exo__Asset_prototype");
+      // Issue #3184 B2: with a non-empty targetIRI, exo__Asset_prototype is
+      // always written by the default back-link — even if grounding.targetPrototype
+      // (the class UID) is absent. The link references $target (the parent
+      // file the user clicked on), not the class UID.
+      expect(content).toContain('exo__Asset_prototype: "[[vault/test-asset]]"');
     });
 
     it("should use 'Untitled' as default label when no user input", async () => {
@@ -892,6 +901,29 @@ describe("GroundingExecutor", () => {
       expect(result.success).toBe(true);
       const [, content] = writer.createFile.mock.calls[0];
       expect(content).toMatch(/exo__Asset_createdAt: \d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("should emit exo__Asset_createdAt as a local timestamp (no Z / TZ suffix) — Issue #3188", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // Match the exact line carrying the timestamp.
+      const match = content.match(/^exo__Asset_createdAt:\s*(.+)$/m);
+      expect(match).not.toBeNull();
+      const ts = match![1].trim();
+      // Local timestamp shape: YYYY-MM-DDTHH:mm:ss (no fractional seconds,
+      // no timezone designator) — matches DateFormatter.toLocalTimestamp.
+      expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+      // Issue #3188: must NOT carry the UTC `Z` or any `±HH:MM` offset.
+      expect(ts).not.toMatch(/Z$/);
+      expect(ts).not.toMatch(/[+-]\d{2}:?\d{2}$/);
     });
 
     // Issue #3136 — Q3.b closure: propertyDefaults + $targetFolder
@@ -1007,7 +1039,7 @@ describe("GroundingExecutor", () => {
       expect(content).toContain('exo__Instance_class:\n  - "[[ems__Task]]"');
     });
 
-    it("should include exo__Asset_source linking to target asset", async () => {
+    it("should default the back-link to exo__Asset_prototype for create_instance (Issue #3184 B2)", async () => {
       const grounding = makeGrounding({
         type: GroundingType.CREATE_INSTANCE,
         targetClass: "ems__Task",
@@ -1018,7 +1050,13 @@ describe("GroundingExecutor", () => {
 
       expect(result.success).toBe(true);
       const [, content] = writer.createFile.mock.calls[0];
-      expect(content).toContain(`"[[vault/test-asset]]"`);
+      expect(content).toContain(
+        'exo__Asset_prototype: "[[vault/test-asset]]"',
+      );
+      // Issue #3184 B2: no automatic exo__Asset_source for create_instance.
+      // The prototype back-link already conveys the same semantic edge in
+      // the RDF graph; doubling it up bloats frontmatter and confuses users.
+      expect(content).not.toContain("exo__Asset_source:");
     });
 
     it("should add aliases when label is provided", async () => {
@@ -1120,8 +1158,10 @@ describe("GroundingExecutor", () => {
       expect(content).toContain("exo__Asset_createdAt:");
       expect(content).toContain("exo__Asset_label: Купить молоко");
       expect(content).toContain("gtd__InboxItem");
-      expect(content).toContain("proto-daily-review-uuid");
-      expect(content).toContain(`"[[vault/test-asset]]"`);
+      // Issue #3184 B1: prototype-class UID is NOT materialised; the
+      // back-link references the prototype-INSTANCE the user clicked.
+      expect(content).not.toContain("proto-daily-review-uuid");
+      expect(content).toContain('exo__Asset_prototype: "[[vault/test-asset]]"');
 
       // Verify UUID in path matches UUID in frontmatter
       const pathUuid = path.split("/").pop()?.replace(".md", "");
@@ -1163,7 +1203,6 @@ describe("GroundingExecutor", () => {
 
         const [, content] = writer.createFile.mock.calls[0];
         // Inherited non-blacklisted properties
-        expect(content).toContain('ems__Effort_area: "[[area-uid-42]]"');
         expect(content).toContain('ems__Effort_priority: "[[priority-high]]"');
         expect(content).toContain('"[[tag-alpha]]"');
         expect(content).toContain('"[[tag-beta]]"');
@@ -1174,11 +1213,19 @@ describe("GroundingExecutor", () => {
         expect(content).not.toMatch(/exo__Instance_class:[\s\S]*ems__Project/);
         expect(content).not.toContain("ems__EffortStatusDoing");
         expect(content).not.toContain("ems__Effort_startTimestamp:");
+        // Issue #3184 B3: ems__Effort_area belongs on the prototype-instance
+        // and is reachable through the prototype-chain in the RDF graph;
+        // copying the wikilink into the new instance double-materialises it.
+        expect(content).not.toContain("ems__Effort_area:");
+        expect(content).not.toContain("area-uid-42");
       });
 
       it("re-quotes wikilink values copied from $target", async () => {
+        // Use ems__Effort_priority (NOT blacklisted) instead of
+        // ems__Effort_area (blacklisted per Issue #3184 B3) so the test
+        // exercises the wikilink-re-quoting path rather than the blacklist.
         reader.readFile.mockResolvedValue(
-          '---\nems__Effort_area: "[[area-uid-42]]"\nems__Effort_unquoted: [[bare-link]]\n---\n',
+          '---\nems__Effort_priority: "[[priority-high]]"\nems__Effort_unquoted: [[bare-link]]\n---\n',
         );
 
         const grounding = makeGrounding({
@@ -1190,13 +1237,15 @@ describe("GroundingExecutor", () => {
         await executor.execute(grounding, TARGET_IRI, FILE_PATH);
 
         const [, content] = writer.createFile.mock.calls[0];
-        expect(content).toContain('ems__Effort_area: "[[area-uid-42]]"');
+        expect(content).toContain('ems__Effort_priority: "[[priority-high]]"');
         expect(content).toContain('ems__Effort_unquoted: "[[bare-link]]"');
       });
 
       it("does not overwrite properties already set via userInput", async () => {
+        // Use ems__Effort_priority (NOT blacklisted by Issue #3184 B3) so the
+        // assertion focuses on userInput-vs-copy-from-target precedence.
         reader.readFile.mockResolvedValue(
-          '---\nems__Effort_area: "[[area-from-target]]"\n---\n',
+          '---\nems__Effort_priority: "[[priority-from-target]]"\n---\n',
         );
 
         const grounding = makeGrounding({
@@ -1207,12 +1256,14 @@ describe("GroundingExecutor", () => {
 
         await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
           label: "X",
-          ems__Effort_area: '"[[area-from-user]]"',
+          ems__Effort_priority: '"[[priority-from-user]]"',
         });
 
         const [, content] = writer.createFile.mock.calls[0];
-        expect(content).toContain('ems__Effort_area: "[[area-from-user]]"');
-        expect(content).not.toContain("area-from-target");
+        expect(content).toContain(
+          'ems__Effort_priority: "[[priority-from-user]]"',
+        );
+        expect(content).not.toContain("priority-from-target");
       });
 
       it("writes back-link to grounding.linkBackProperty when provided", async () => {
@@ -1232,7 +1283,7 @@ describe("GroundingExecutor", () => {
         expect(content).not.toContain("exo__Asset_source:");
       });
 
-      it("falls back to exo__Asset_source when linkBackProperty is absent", async () => {
+      it("falls back to exo__Asset_prototype when linkBackProperty is absent (Issue #3184 B2)", async () => {
         reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
 
         const grounding = makeGrounding({
@@ -1244,7 +1295,10 @@ describe("GroundingExecutor", () => {
         await executor.execute(grounding, TARGET_IRI, FILE_PATH);
 
         const [, content] = writer.createFile.mock.calls[0];
-        expect(content).toContain(`exo__Asset_source: "[[vault/test-asset]]"`);
+        expect(content).toContain(
+          'exo__Asset_prototype: "[[vault/test-asset]]"',
+        );
+        expect(content).not.toContain("exo__Asset_source:");
         expect(content).not.toContain("ems__Effort_prevIteration:");
       });
 
@@ -1286,16 +1340,19 @@ describe("GroundingExecutor", () => {
       });
     });
 
-    // Task 4.4 — regression suite for Phase 2 changes (RFC v0.2 copy-from-target +
-    // configurable linkBackProperty). Guarantees existing vault groundings authored
-    // before RFC v0.2 (e.g. `e01b025b` "Create MeetingPrototype instance",
-    // `adc73790`, `3da98088`, `00a6a887`, `a6ef8fda`) keep emitting
-    // `exo__Asset_source` and that the no-$target path does NOT introduce a phantom
-    // fallback link.
-    describe("Phase 2 regression: existing groundings unchanged (Task 4.4)", () => {
+    // Issue #3184 (B1+B2) replaces the legacy default `exo__Asset_source` with
+    // `exo__Asset_prototype` for create_instance — the prior assumption was
+    // that vault groundings (e.g. `e01b025b` "Create MeetingPrototype instance",
+    // `adc73790`, `3da98088`, `00a6a887`, `a6ef8fda`) wanted `exo__Asset_source`
+    // back-links, but user-facing inspection of created assets showed the
+    // source link duplicated semantics already conveyed by the prototype edge.
+    // The suite below was originally Task 4.4 (Phase 2 backwards compat); it
+    // has been re-pointed at the new default to keep coverage on the no-
+    // `linkBackProperty` path without losing the empty-targetIRI guard.
+    describe("default back-link path (Issue #3184 B2)", () => {
       // Fixture mirrors vault grounding `e01b025b-d03f-4028-b4c8-45d3786ff43d`
-      // ("Create MeetingPrototype instance") — pre-RFC v0.2 shape: targetClass +
-      // targetPrototype + targetFolder, no linkBackProperty.
+      // ("Create MeetingPrototype instance") — targetClass + targetPrototype +
+      // targetFolder, no explicit linkBackProperty.
       const LEGACY_MEETING_GROUNDING = {
         type: GroundingType.CREATE_INSTANCE,
         targetClass: "ems__Meeting",
@@ -1303,7 +1360,7 @@ describe("GroundingExecutor", () => {
         targetFolder: "03 Knowledge/inbox",
       } as const;
 
-      it("legacy grounding (no linkBackProperty) emits exo__Asset_source as before", async () => {
+      it("vault grounding without linkBackProperty defaults to exo__Asset_prototype", async () => {
         reader.readFile.mockResolvedValue("---\nfoo: bar\n---\nBody");
 
         const grounding = makeGrounding({ ...LEGACY_MEETING_GROUNDING });
@@ -1314,12 +1371,15 @@ describe("GroundingExecutor", () => {
 
         expect(result.success).toBe(true);
         const [, content] = writer.createFile.mock.calls[0];
-        expect(content).toContain(`exo__Asset_source: "[[vault/test-asset]]"`);
+        expect(content).toContain(
+          'exo__Asset_prototype: "[[vault/test-asset]]"',
+        );
+        expect(content).not.toContain("exo__Asset_source:");
         expect(content).not.toMatch(/ems__Effort_parent: "\[\[https/);
         expect(content).not.toMatch(/ems__Effort_prevIteration:/);
       });
 
-      it("legacy grounding with targetClass only (no prototype, no linkBackProperty) preserves behavior", async () => {
+      it("grounding with targetClass only (no prototype, no linkBackProperty) defaults to exo__Asset_prototype", async () => {
         reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
 
         const grounding = makeGrounding({
@@ -1333,14 +1393,16 @@ describe("GroundingExecutor", () => {
         expect(result.success).toBe(true);
         const [, content] = writer.createFile.mock.calls[0];
         expect(content).toContain('exo__Instance_class:\n  - "[[ems__Task]]"');
-        expect(content).toContain(`exo__Asset_source: "[[vault/test-asset]]"`);
-        expect(content).not.toContain("exo__Asset_prototype:");
+        expect(content).toContain(
+          'exo__Asset_prototype: "[[vault/test-asset]]"',
+        );
+        expect(content).not.toContain("exo__Asset_source:");
       });
 
-      it("legacy grounding without $target (empty targetIRI) does NOT emit any back-link", async () => {
-        // Pre-RFC v0.2 behavior — when targetIRI is falsy, no link is written.
-        // RFC v0.2 must preserve this: must not introduce a phantom
-        // `exo__Asset_source: "[[]]"` or write linkBackProperty with empty value.
+      it("grounding without $target (empty targetIRI) does NOT emit any back-link", async () => {
+        // When targetIRI is falsy, no link is written — neither the legacy
+        // `exo__Asset_source: "[[]]"` nor the new
+        // `exo__Asset_prototype: "[[]]"` phantom value.
         reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
 
         const grounding = makeGrounding({
@@ -1354,10 +1416,11 @@ describe("GroundingExecutor", () => {
         expect(result.success).toBe(true);
         const [, content] = writer.createFile.mock.calls[0];
         expect(content).not.toContain("exo__Asset_source:");
+        expect(content).not.toContain("exo__Asset_prototype:");
         expect(content).not.toMatch(/"\[\[\]\]"/);
       });
 
-      it("legacy grounding with linkBackProperty=undefined writes exo__Asset_source (no fallback drift)", async () => {
+      it("grounding with linkBackProperty=undefined still uses the new default (no fallback drift)", async () => {
         reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
 
         const grounding = makeGrounding({
@@ -1371,7 +1434,176 @@ describe("GroundingExecutor", () => {
 
         expect(result.success).toBe(true);
         const [, content] = writer.createFile.mock.calls[0];
-        expect(content).toContain(`exo__Asset_source: "[[vault/test-asset]]"`);
+        expect(content).toContain(
+          'exo__Asset_prototype: "[[vault/test-asset]]"',
+        );
+        expect(content).not.toContain("exo__Asset_source:");
+      });
+    });
+
+    // =========================================================================
+    // Issue #3184 — bug fixes: prototype reference, source removal, blacklist,
+    // open-in-tab plumbing. Each bug gets a dedicated test so a future
+    // regression points at the exact AC that broke.
+    // =========================================================================
+    describe("Issue #3184 — grounding bug fixes", () => {
+      // Fixture mirrors the "Lunch" prototype-instance from the issue:
+      //   ems__Effort_area: "[[5dd75bb5-...]]" (B3)
+      //   exo__Asset_relates: "[[some-X]]"    (B4)
+      const PROTOTYPE_INSTANCE_FM = [
+        "---",
+        'exo__Asset_uid: "4b571141-5fc3-4ddd-8f07-ca681fc8410a"',
+        'exo__Asset_label: "Lunch"',
+        "exo__Instance_class:",
+        '  - "[[df7e579d-classid-emsTaskPrototype]]"',
+        'ems__Effort_area: "[[5dd75bb5-areauid]]"',
+        'exo__Asset_relates: "[[some-related-asset]]"',
+        'ems__Effort_priority: "[[priority-mid]]"',
+        "---",
+        "Body",
+      ].join("\n");
+
+      it("B1: exo__Asset_prototype references the prototype-INSTANCE ($target), not the class UID", async () => {
+        reader.readFile.mockResolvedValue(PROTOTYPE_INSTANCE_FM);
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          // `targetPrototype` is the CLASS UID (`ems__TaskPrototype`) — must
+          // NOT bleed into the created asset's frontmatter.
+          targetPrototype: "df7e579d-classid-emsTaskPrototype",
+          targetFolder: "01 Inbox",
+        });
+
+        const result = await executor.execute(
+          grounding,
+          TARGET_IRI,
+          FILE_PATH,
+          { label: "Lunch instance" },
+        );
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain(
+          'exo__Asset_prototype: "[[vault/test-asset]]"',
+        );
+        expect(content).not.toContain("df7e579d-classid-emsTaskPrototype");
+      });
+
+      it("B2: exo__Asset_source is not written by default for create_instance", async () => {
+        reader.readFile.mockResolvedValue(PROTOTYPE_INSTANCE_FM);
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).not.toContain("exo__Asset_source:");
+      });
+
+      it("B3: ems__Effort_area is not inherited from the prototype-instance", async () => {
+        reader.readFile.mockResolvedValue(PROTOTYPE_INSTANCE_FM);
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        const result = await executor.execute(
+          grounding,
+          TARGET_IRI,
+          FILE_PATH,
+          { label: "task" },
+        );
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).not.toContain("ems__Effort_area:");
+        expect(content).not.toContain("5dd75bb5-areauid");
+      });
+
+      it("B4: exo__Asset_relates is not inherited from the prototype-instance", async () => {
+        reader.readFile.mockResolvedValue(PROTOTYPE_INSTANCE_FM);
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        const result = await executor.execute(
+          grounding,
+          TARGET_IRI,
+          FILE_PATH,
+          { label: "task" },
+        );
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).not.toContain("exo__Asset_relates:");
+        expect(content).not.toContain("some-related-asset");
+      });
+
+      it("B3+B4: non-blacklisted properties (e.g. ems__Effort_priority) are still inherited", async () => {
+        reader.readFile.mockResolvedValue(PROTOTYPE_INSTANCE_FM);
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+          label: "task",
+        });
+
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain('ems__Effort_priority: "[[priority-mid]]"');
+      });
+
+      it("B5: ExecutionResult.openPath equals the created file path", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        const result = await executor.execute(
+          grounding,
+          TARGET_IRI,
+          FILE_PATH,
+          { label: "lunch" },
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.openPath).toBeDefined();
+        expect(result.openPath).toMatch(/^01 Inbox\/[a-f0-9-]+\.md$/);
+        // openPath equals the path actually passed to createFile.
+        const [createdPath] = writer.createFile.mock.calls[0];
+        expect(result.openPath).toBe(createdPath);
+      });
+
+      it("B5: other grounding types do not surface openPath", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\nBody");
+
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_SET,
+          targetProperty: "ems__status",
+          targetValue: "Done",
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        expect(result.openPath).toBeUndefined();
       });
     });
 

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -78,6 +78,7 @@ import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
 import { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService";
 import { ObsidianFileSystemAdapter } from "./adapters/ObsidianFileSystemAdapter";
 import { populateServiceRegistry } from "./infrastructure/services/ServiceRegistryPopulator";
+import { ObsidianFileOpener } from "./infrastructure/services/ObsidianFileOpener";
 import { ExocmdCommandPaletteRegistrar } from "./application/services/ExocmdCommandPaletteRegistrar";
 import { ObsidianCommandPromptAdapter } from "./infrastructure/adapters/ObsidianCommandPromptAdapter";
 import {
@@ -569,6 +570,7 @@ export default class ExocortexPlugin extends Plugin {
             this.logger,
             new ObsidianCommandPromptAdapter(this.app),
             tripleStore,
+            new ObsidianFileOpener(this.app),
           );
           await new ExocmdCommandPaletteRegistrar(
             this,

--- a/packages/obsidian-plugin/src/infrastructure/services/ObsidianFileOpener.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ObsidianFileOpener.ts
@@ -1,0 +1,60 @@
+import { TFile } from "obsidian";
+import type { App } from "obsidian";
+import type { IFileOpener } from "exocortex";
+
+/**
+ * Obsidian-side adapter for {@link IFileOpener} (Issue #3184 B5).
+ *
+ * Opens a vault-relative path in a new tab and focuses it. Mirrors the
+ * established `getLeaf("tab").openFile(tfile)` + `setActiveLeaf(...,
+ * {focus: true})` pattern used by `createRelatedTask` / `createNarrowerConcept`
+ * / `createSubclass` in `ServiceRegistryPopulator.ts` so create_instance and
+ * service_call-driven creation flows feel identical to the user.
+ *
+ * Robust to a brief race between `createFile` resolving and Obsidian's vault
+ * cache surfacing the new file: we poll the abstract-file lookup a few times
+ * before falling back to the legacy `openLinkText` API, which performs its
+ * own resolution against the metadataCache.
+ */
+export class ObsidianFileOpener implements IFileOpener {
+  private readonly app: App;
+
+  constructor(app: App) {
+    this.app = app;
+  }
+
+  async open(path: string): Promise<void> {
+    if (!path) return;
+
+    const tfile = await this.resolveTFile(path);
+    if (tfile) {
+      const leaf = this.app.workspace.getLeaf("tab");
+      await leaf.openFile(tfile);
+      this.app.workspace.setActiveLeaf(leaf, { focus: true });
+      return;
+    }
+
+    // Fallback: lookup miss (vault cache lag, unusual path encoding) —
+    // delegate to `openLinkText` which resolves via metadataCache. The
+    // second arg is the source path; empty string means "from vault root".
+    await this.app.workspace.openLinkText(path, "");
+  }
+
+  /**
+   * Poll the vault for the freshly-written file. Obsidian's `createFile`
+   * resolves before the vault index sees the new file in some cases, so
+   * a short poll is more reliable than a single synchronous lookup.
+   */
+  private async resolveTFile(path: string): Promise<TFile | null> {
+    const MAX_ATTEMPTS = 5;
+    const DELAY_MS = 20;
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      const af = this.app.vault.getAbstractFileByPath(path);
+      if (af instanceof TFile) return af;
+      if (i < MAX_ATTEMPTS - 1) {
+        await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+      }
+    }
+    return null;
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -24,6 +24,7 @@ import type { ExocmdFastResolver } from "./button-groups/ExocmdFastResolver";
 import { PanelResolver } from "@plugin/application/services/PanelResolver";
 import { ObsidianApp, ExocortexPluginInterface } from '@plugin/types';
 import { ObsidianCommandPromptAdapter } from "@plugin/infrastructure/adapters/ObsidianCommandPromptAdapter";
+import { ObsidianFileOpener } from "@plugin/infrastructure/services/ObsidianFileOpener";
 
 /**
  * Configuration object for ButtonGroupsBuilder.
@@ -129,6 +130,7 @@ export class ButtonGroupsBuilder {
         logger,
         new ObsidianCommandPromptAdapter(app),
         tripleStore,
+        new ObsidianFileOpener(app),
       );
       this.builders.push(
         new DynamicCommandButtonGroupBuilder({


### PR DESCRIPTION
## Summary

Fixes Issue #3184 (`create_instance` grounding produces wrong prototype/source/area properties + doesn't open new file) and bundles the small Issue #3188 (`exo__Asset_createdAt` in UTC `Z` form instead of project-standard local timestamp).

Five semantic glitches in `GroundingExecutor.executeCreateInstance` plus a one-line consistency fix:

- **B1** — `exo__Asset_prototype` now references the prototype-INSTANCE the user clicked on (back-link target), not the static class UID declared in `grounding.targetPrototype`. The literal class-UID write at lines 533-535 is dropped; the back-link block does the right thing on its own.
- **B2** — default `linkBackProperty` for `create_instance` flips from `exo__Asset_source` to `exo__Asset_prototype`. The source field was redundant (prototype edge already conveys the same RDF semantic) and confused inspecting users.
- **B3** — `ems__Effort_area` added to `CREATE_INSTANCE_BLACKLIST`. Inheriting it from the prototype-instance double-materialised the area through both prototype and explicit triple.
- **B4** — `exo__Asset_relates` added to `CREATE_INSTANCE_BLACKLIST` for the same reason.
- **B5** — `ExecutionResult` gains an optional `openPath`; `executeCreateInstance` returns the vault-relative path. `CommandExecutionFlow` picks it up via a new optional `IFileOpener` dependency, which the plugin satisfies through `ObsidianFileOpener` (uses `app.workspace.getLeaf("tab").openFile(...)` + focus). CLI / tests omit the dep and see no behavioural change.
- **#3188** — `exo__Asset_createdAt` now uses `DateFormatter.toLocalTimestamp(...)` matching every other creation service in the codebase. The legacy `new Date().toISOString()` produced UTC-suffixed timestamps that disagreed with the rest of the vault's local-tz convention.

The vault-side data-fix (UID-only `targetClass`/`targetPrototype` on the 5 creation grounding-ассеты) was already applied out-of-band before this PR.

## Test plan

- [x] `npm run check:types` clean
- [x] `npm run lint` clean (pre-existing warnings only, no new errors)
- [x] `packages/exocortex/tests/unit/services/GroundingExecutor.test.ts` — 105 cases pass; updated default-link tests + dedicated `Issue #3184 — grounding bug fixes` describe block.
- [x] `packages/exocortex/tests/services/CommandExecutionFlow.test.ts` — adds 5 IFileOpener cases (invoked / omitted / no-openPath / failed-grounding / open-throws).
- [x] `packages/exocortex/tests/integration/asset-creation/create-instance-grounding.test.ts` — seeds parent.md so copy-from-target read succeeds (this file was silently red on `main`; not in any required CI check).
- [x] `packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts` — CI-gated regression updated: fixture uses `ems__Effort_priority` (non-blacklisted) for the ≥3-inherited-fields contract; new assertions confirm `ems__Effort_area` / `exo__Asset_relates` don't leak.
- [x] `packages/obsidian-plugin/tests/**` — 5023/5023 pass.
- [x] CI-gated exocortex allowlist (per `scripts/test-ci-batched.sh`) — 255/255 pass.

Regression cover for the four sibling groundings (Project, Meeting, FleetingNote, Event): they share the same `executeCreateInstance` code path; the new tests run with `targetClass: ems__Task` and the blacklist additions apply uniformly.

Closes #3184
Closes #3188