### PR TITLE
fix(exocmd-cache): apply cached bindings + emit cache-applied mark on cold start

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -370,6 +370,11 @@ export default class ExocortexPlugin extends Plugin {
         this.logger.warn(
           `[ExocortexPlugin] cache load failed (non-fatal): ${String(err)}`,
         );
+        // Issue #3190 — surface every cache-pipeline failure to the DevTools
+        // console as well, since `logger.warn` may be silenced by the user's
+        // log-channel settings. `console.error` is the diagnostic channel of
+        // last resort for cache regressions.
+        console.error("[exocortex] cache load failed:", err);
       });
 
       this.layoutRenderer = new UniversalLayoutRenderer(
@@ -406,9 +411,32 @@ export default class ExocortexPlugin extends Plugin {
       // `commandResolver.invalidateCache()` plumbing below or by the
       // next plugin reload) overwrites it atomically. Until then, lookups
       // fall through to fast-path with the freshly invalidated mini-store.
+      //
+      // Issue #3190 — `metadataCache.on("changed")` fires for every
+      // `assetspaces/exocmd/*.md` file as Obsidian parses it during the
+      // initial vault scan, BEFORE `on("resolved")` fires. Without a
+      // bootstrap guard those bootstrap-time fires call `bindingsCache.clear()`
+      // and wipe the snapshot loaded fire-and-forget at line ~370 — by the
+      // time `autoRenderLayout()` runs the snapshot is null and the cache
+      // strategy degrades to a permanent miss (cache-applied mark never
+      // fires, full-path button set arrives at ~10 s like pre-PR #3185).
+      // The flag below is flipped by the `on("resolved")` listener below
+      // and gates invalidation so bootstrap-time `changed` events become
+      // no-ops; post-bootstrap edits invalidate as before.
+      let bootstrapResolved = false;
       const invalidateExocmdCaches = (): void => {
+        if (!bootstrapResolved) return;
         exocmdFastResolver.invalidateCommandCache();
         bindingsCache.clear();
+      };
+      // Issue #3190 — flag set in the existing `metadataCache.on("resolved")`
+      // handler further down in onload (search for `postResolveReindexDone`).
+      // The handler runs idempotently every time Obsidian fires `resolved`;
+      // we set the flag there rather than registering a second listener so
+      // the existing "first registered resolved handler" test contract is
+      // preserved (tests look up the handler by index).
+      const flipBootstrapResolved = (): void => {
+        bootstrapResolved = true;
       };
       this.registerEvent(
         this.app.metadataCache.on("changed", (changedFile) => {
@@ -729,6 +757,13 @@ export default class ExocortexPlugin extends Plugin {
       let postResolveReindexDone = false;
       this.registerEvent(
         this.app.metadataCache.on("resolved", () => {
+          // Issue #3190 — flip the bootstrap gate so post-bootstrap
+          // exocmd asset edits invalidate the bindings cache. Bootstrap
+          // `changed` events fired while parsing `assetspaces/exocmd/*.md`
+          // during the initial vault scan become no-ops, preserving the
+          // disk-cache snapshot just loaded fire-and-forget at onload.
+          flipBootstrapResolved();
+
           this.layoutRenderer.invalidateBacklinksCache();
 
           if (postResolveReindexDone) return;

--- a/packages/obsidian-plugin/src/cache/ExocmdBindingsCache.ts
+++ b/packages/obsidian-plugin/src/cache/ExocmdBindingsCache.ts
@@ -131,6 +131,10 @@ export class ExocmdBindingsCache {
       this.logger.warn(
         `[ExocmdBindingsCache] failed to read ${this.cacheFilePath}: ${String(err)}`,
       );
+      // Issue #3190 — `logger.warn` may be silenced by log-channel settings;
+      // surface every cache-pipeline failure to DevTools console as well so
+      // future regressions are visible without re-enabling Verbose logging.
+      console.error("[exocortex] cache read failed:", err);
       this.snapshot = null;
       return null;
     }
@@ -142,6 +146,7 @@ export class ExocmdBindingsCache {
       this.logger.warn(
         `[ExocmdBindingsCache] cache file is not valid JSON, discarding: ${String(err)}`,
       );
+      console.error("[exocortex] cache parse failed:", err);
       this.snapshot = null;
       return null;
     }
@@ -149,6 +154,10 @@ export class ExocmdBindingsCache {
     if (!this.isValidFileShape(parsed)) {
       this.logger.warn(
         `[ExocmdBindingsCache] cache file has unexpected shape, discarding`,
+      );
+      console.error(
+        "[exocortex] cache shape-validation failed:",
+        "cache file has unexpected shape",
       );
       this.snapshot = null;
       return null;
@@ -221,6 +230,7 @@ export class ExocmdBindingsCache {
       this.logger.warn(
         `[ExocmdBindingsCache] failed to ensure parent dir: ${String(err)}`,
       );
+      console.error("[exocortex] cache mkdir failed:", err);
       // Try the write anyway — adapter may auto-create.
     }
 
@@ -231,6 +241,7 @@ export class ExocmdBindingsCache {
       this.logger.warn(
         `[ExocmdBindingsCache] failed to write tmp cache file: ${String(err)}`,
       );
+      console.error("[exocortex] cache write-tmp failed:", err);
       throw err;
     }
 
@@ -246,6 +257,7 @@ export class ExocmdBindingsCache {
       this.logger.warn(
         `[ExocmdBindingsCache] failed to rename tmp file into place: ${String(err)}`,
       );
+      console.error("[exocortex] cache rename failed:", err);
       // Best-effort cleanup of orphaned tmp.
       try {
         if (await this.fs.exists(tmpPath)) {

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -469,27 +469,45 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     try {
       const visible = await fastResolver.resolveVisibleCommands(file);
       // Issue #3171 perf benchmark — emit the cold-start UX marker the
-      // first time a fast-path render produces visible commands. Paired
+      // first time the fast-path branch executes to completion. Paired
       // with `performance.mark("exocmd-fastpath-start")` in
       // `ExocortexPlugin` (Issue #3175 migrated from `console.time`).
       // Guarded by `!this.fastpathReadyMarked` so we only emit once per
-      // plugin session (subsequent file switches still take the fast
-      // path until `isFullPathReady` flips, but the metric we care about
-      // is "first-render cold-start latency").
-      if (!this.fastpathReadyMarked && visible.length > 0) {
+      // plugin session.
+      //
+      // Issue #3190 — the previous `visible.length > 0` guard meant
+      // cold-start sessions where the first fast-path render produced no
+      // visible commands (e.g. open file's metadata cache not yet warm,
+      // so `getFrontmatter()` returned null) never wrote the mark, and
+      // the empirical evidence for #3190 showed the mark perpetually
+      // missing. The mark documents "fast-path completed" — independent
+      // of whether anything matched — so we drop the `length > 0` guard.
+      if (!this.fastpathReadyMarked) {
         this.fastpathReadyMarked = true;
-        performance.mark("exocmd-fastpath-ready");
-        performance.measure(
-          "exocmd-fastpath",
-          "exocmd-fastpath-start",
-          "exocmd-fastpath-ready",
-        );
+        try {
+          performance.mark("exocmd-fastpath-ready");
+          performance.measure(
+            "exocmd-fastpath",
+            "exocmd-fastpath-start",
+            "exocmd-fastpath-ready",
+          );
+        } catch (markErr) {
+          // Performance API may throw if `exocmd-fastpath-start` is
+          // missing (hot reload, embedded jest env). Never let it break
+          // button rendering. Issue #3190 — surface via console.error too.
+          console.error("[exocortex] cache fastpath-mark failed:", markErr);
+        }
       }
       return visible;
     } catch (error) {
       logger.info(
         `[DynamicCommands] Fast-path resolver failed: ${String(error)}`,
       );
+      // Issue #3190 — surface fast-path failures to DevTools console so
+      // a silent fallthrough does not look identical to a successful
+      // empty result. `logger.info` is channel-gated; `console.error`
+      // is unconditional.
+      console.error("[exocortex] cache fast-path failed:", error);
       return null;
     }
   }
@@ -550,9 +568,15 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
                 "exocmd-cache-applied",
               );
             }
-          } catch {
+          } catch (markErr) {
             // Performance API edge cases (missing start mark, browser
             // throwing on unknown name) must never break button rendering.
+            // Issue #3190 — log to console.error so we can spot a future
+            // regression where the mark silently fails instead of fires.
+            console.error(
+              "[exocortex] cache cache-applied-mark failed:",
+              markErr,
+            );
           }
         }
         return [...entry.commands];

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -216,6 +216,8 @@ describe("ExocortexPlugin", () => {
       // + 3 PanelResolver invalidations (RFC-024 Phase 3 — layout/binding `changed`, `deleted`, vault `rename`) = 11
       // + 3 ObsidianQueryBodyResolver cache invalidations (RFC c78cc5c8 Phase 1a — metadata `changed`, vault `delete`, vault `rename`) = 14
       // + 3 ExocmdFastResolver cache invalidations (Issue #3171 — metadata `changed`, vault `delete`, vault `rename`) = 17
+      // Issue #3190 — bootstrap-resolved gate is folded into the existing
+      // `metadataCache.on("resolved")` handler (no additional registerEvent).
       expect(plugin.registerEvent).toHaveBeenCalledTimes(17);
       expect(mockLogger.info).toHaveBeenCalledWith("Exocortex Plugin loaded successfully");
     });
@@ -270,6 +272,118 @@ describe("ExocortexPlugin", () => {
       expect(mockWorkspace.getActiveFile).toHaveBeenCalled();
       // Layout should not be rendered
       expect(mockLayoutRenderer.render).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Issue #3190 — bootstrap-resolved gate around exocmd cache invalidation", () => {
+    // Empirical evidence in #3190 showed `exocmd-cache-applied` mark
+    // permanently missing on cold start in v16.8.5 even with a healthy
+    // 1.1 MB cache on disk. Root cause: Obsidian fires
+    // `metadataCache.on("changed")` for every `assetspaces/exocmd/*.md`
+    // file as it parses them during the initial vault scan — BEFORE
+    // `on("resolved")` fires. The pre-#3190 invalidation handler
+    // unconditionally called `bindingsCache.clear()`, wiping the
+    // snapshot loaded fire-and-forget at onload long before
+    // `autoRenderLayout()` could read it.
+    //
+    // Fix: gate `bindingsCache.clear()` (and the fast-resolver cache wipe)
+    // behind a `bootstrapResolved` flag set by `on("resolved")`. Bootstrap
+    // `changed` events become no-ops; post-bootstrap edits invalidate as
+    // before. These tests pin the contract so the race cannot return.
+
+    let changedHandlers: Array<(file: TFile) => void> = [];
+    let resolvedHandlers: Array<() => void> = [];
+
+    beforeEach(() => {
+      changedHandlers = [];
+      resolvedHandlers = [];
+      mockMetadataCache.on.mockImplementation(
+        (event: string, cb: (...args: any[]) => void) => {
+          if (event === "changed") changedHandlers.push(cb);
+          if (event === "resolved") resolvedHandlers.push(cb);
+          return { unsubscribe: jest.fn() };
+        },
+      );
+    });
+
+    /** The earliest-registered changed handler is the exocmd invalidator
+     *  (registered before the hot-mutation reindex handler in onload). */
+    const fireExocmdChanged = (): void => {
+      // The first `changed` listener registered in onload is the
+      // exocmd-invalidator (the one we care about); subsequent listeners
+      // handle hot-mutation reindex etc.
+      const exocmdFile = { path: "assetspaces/exocmd/some-cmd.md" } as TFile;
+      for (const handler of changedHandlers) {
+        handler(exocmdFile);
+      }
+    };
+
+    it("does NOT clear bindingsCache when metadataCache.changed fires before resolved", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      const cache = plugin.exocmdBindingsCache;
+      const fastResolver = plugin.exocmdFastResolver;
+      expect(cache).toBeDefined();
+      expect(fastResolver).toBeDefined();
+      const clearSpy = jest.spyOn(cache!, "clear");
+      const invalidateFastSpy = jest.spyOn(
+        fastResolver!,
+        "invalidateCommandCache",
+      );
+
+      // Simulate Obsidian parsing an exocmd asset during the initial
+      // vault scan — BEFORE the resolved handler has had a chance to
+      // fire. With the bootstrap gate in place, no invalidation should
+      // happen yet.
+      fireExocmdChanged();
+      fireExocmdChanged();
+      fireExocmdChanged();
+
+      expect(clearSpy).not.toHaveBeenCalled();
+      expect(invalidateFastSpy).not.toHaveBeenCalled();
+    });
+
+    it("clears bindingsCache when metadataCache.changed fires AFTER resolved", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      const cache = plugin.exocmdBindingsCache;
+      const fastResolver = plugin.exocmdFastResolver;
+      expect(cache).toBeDefined();
+      expect(fastResolver).toBeDefined();
+      const clearSpy = jest.spyOn(cache!, "clear");
+      const invalidateFastSpy = jest.spyOn(
+        fastResolver!,
+        "invalidateCommandCache",
+      );
+
+      // Fire `resolved` to flip the bootstrap flag.
+      expect(resolvedHandlers.length).toBeGreaterThan(0);
+      for (const handler of resolvedHandlers) handler();
+
+      fireExocmdChanged();
+
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect(invalidateFastSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores changed events for non-exocmd files at any time", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      const cache = plugin.exocmdBindingsCache;
+      expect(cache).toBeDefined();
+      const clearSpy = jest.spyOn(cache!, "clear");
+
+      // After resolved
+      for (const handler of resolvedHandlers) handler();
+
+      // Random non-exocmd file change — must NOT touch the cache.
+      const randomFile = { path: "03 Knowledge/something.md" } as TFile;
+      for (const handler of changedHandlers) handler(randomFile);
+
+      expect(clearSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/cache/ExocmdBindingsCache.test.ts
+++ b/packages/obsidian-plugin/tests/unit/cache/ExocmdBindingsCache.test.ts
@@ -241,6 +241,77 @@ describe("ExocmdBindingsCache", () => {
     });
   });
 
+  describe("Issue #3190 — diagnostic console.error on cache load failures", () => {
+    // The original PR #3185 routed every cache failure through
+    // `ILogger.warn`, which `Logger` only emits when the user has the
+    // `warn` console channel enabled. In production with the default
+    // settings the channel is on, but `logger.warn` calls were invisible
+    // when the user had silenced their log channels for noise reasons.
+    // Issue #3190 surfaces these failures unconditionally via
+    // `console.error` so future regressions stay observable.
+
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("logs to console.error when the cache file cannot be read", async () => {
+      const fs = createInMemoryFs();
+      // exists() returns true but read() throws — simulate a permission
+      // / corruption I/O failure.
+      jest.spyOn(fs, "exists").mockResolvedValue(true);
+      jest.spyOn(fs, "read").mockRejectedValue(new Error("EACCES"));
+      const cache = new ExocmdBindingsCache(
+        fs,
+        CACHE_PATH,
+        PLUGIN_VERSION,
+        mockLogger,
+      );
+      await cache.load();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[exocortex] cache read failed:",
+        expect.any(Error),
+      );
+    });
+
+    it("logs to console.error when the JSON payload cannot be parsed", async () => {
+      const fs = createInMemoryFs();
+      fs.__files.set(CACHE_PATH, "{ not json");
+      const cache = new ExocmdBindingsCache(
+        fs,
+        CACHE_PATH,
+        PLUGIN_VERSION,
+        mockLogger,
+      );
+      await cache.load();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[exocortex] cache parse failed:",
+        expect.any(Error),
+      );
+    });
+
+    it("logs to console.error when the file shape is invalid", async () => {
+      const fs = createInMemoryFs();
+      fs.__files.set(CACHE_PATH, JSON.stringify({ wrong: "shape" }));
+      const cache = new ExocmdBindingsCache(
+        fs,
+        CACHE_PATH,
+        PLUGIN_VERSION,
+        mockLogger,
+      );
+      await cache.load();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[exocortex] cache shape-validation failed:",
+        expect.any(String),
+      );
+    });
+  });
+
   describe("save", () => {
     it("writes a valid snapshot that round-trips via load", async () => {
       const fs = createInMemoryFs();

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.cache.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.cache.test.ts
@@ -454,4 +454,105 @@ describe("DynamicCommandButtonGroupBuilder — Issue #3183 cache strategy", () =
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("dynamic-cmd-legacy-cmd");
   });
+
+  describe("Issue #3190 — fastpath-ready mark fires even when fast-path yields no visible commands", () => {
+    // The original `visible.length > 0` guard meant a cold-start session
+    // whose first fast-path call returned [] (e.g. metadata cache not yet
+    // warm for the open file → `getFrontmatter()` returned null) never
+    // wrote the mark. Empirical evidence in #3190 showed the mark
+    // permanently missing in that case, conflating "fast-path ran but
+    // empty" with "fast-path never ran". The mark documents the path
+    // execution itself, independent of whether anything matched.
+
+    afterEach(() => {
+      // Reset jsdom perf stubs between tests so spies do not leak.
+      const perfRecord = performance as unknown as Record<string, unknown>;
+      delete perfRecord["mark"];
+      delete perfRecord["measure"];
+    });
+
+    it("emits exocmd-fastpath-ready on first fast-path call even when visible is empty", async () => {
+      const perfRecord = performance as unknown as Record<string, unknown>;
+      const markSpy = jest.fn();
+      perfRecord["mark"] = markSpy;
+      perfRecord["measure"] = jest.fn();
+
+      const emptyFastResolver = {
+        resolveVisibleCommands: jest.fn().mockResolvedValue([]),
+      };
+      const builder = new DynamicCommandButtonGroupBuilder({
+        commandResolver: mockCommandResolver as any,
+        preconditionEvaluator: mockPreconditionEvaluator as any,
+        commandExecutionFlow: buildCommandExecutionFlow(),
+        fastResolver: emptyFastResolver as any,
+        isFullPathReady: () => false,
+      });
+      mockResolveForAssetMulti.mockResolvedValue([]);
+
+      await builder.build(buildContext());
+
+      const fastpathReadyCalls = markSpy.mock.calls.filter(
+        ([label]) => label === "exocmd-fastpath-ready",
+      );
+      expect(fastpathReadyCalls).toHaveLength(1);
+    });
+
+    it("emits exocmd-fastpath-ready only once across multiple build() calls", async () => {
+      const perfRecord = performance as unknown as Record<string, unknown>;
+      const markSpy = jest.fn();
+      perfRecord["mark"] = markSpy;
+      perfRecord["measure"] = jest.fn();
+
+      const fastResolver = {
+        resolveVisibleCommands: jest.fn().mockResolvedValue([]),
+      };
+      const builder = new DynamicCommandButtonGroupBuilder({
+        commandResolver: mockCommandResolver as any,
+        preconditionEvaluator: mockPreconditionEvaluator as any,
+        commandExecutionFlow: buildCommandExecutionFlow(),
+        fastResolver: fastResolver as any,
+        isFullPathReady: () => false,
+      });
+
+      await builder.build(buildContext());
+      await builder.build(buildContext());
+      await builder.build(buildContext());
+
+      const fastpathReadyCalls = markSpy.mock.calls.filter(
+        ([label]) => label === "exocmd-fastpath-ready",
+      );
+      expect(fastpathReadyCalls).toHaveLength(1);
+    });
+
+    it("logs to console.error when the fast-path resolver throws", async () => {
+      const perfRecord = performance as unknown as Record<string, unknown>;
+      perfRecord["mark"] = jest.fn();
+      perfRecord["measure"] = jest.fn();
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const failingFastResolver = {
+        resolveVisibleCommands: jest
+          .fn()
+          .mockRejectedValue(new Error("triple store boom")),
+      };
+      const builder = new DynamicCommandButtonGroupBuilder({
+        commandResolver: mockCommandResolver as any,
+        preconditionEvaluator: mockPreconditionEvaluator as any,
+        commandExecutionFlow: buildCommandExecutionFlow(),
+        fastResolver: failingFastResolver as any,
+        isFullPathReady: () => false,
+      });
+
+      await builder.build(buildContext());
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[exocortex] cache fast-path failed:",
+        expect.any(Error),
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -1434,7 +1434,14 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       expect(fastpathMeasureCalls).toHaveLength(1);
     });
 
-    it("does NOT emit the fastpath marker when fast-path returns zero visible commands", async () => {
+    it("emits the fastpath marker even when fast-path returns zero visible commands (Issue #3190)", async () => {
+      // Issue #3190 contract amendment: the mark documents "fast-path
+      // branch executed to completion" — independent of whether anything
+      // matched. Pre-#3190 the mark was guarded by `visible.length > 0`,
+      // which conflated "fast-path never ran" (no mark) with "fast-path
+      // ran but the open file's metadata cache was not yet warm so it
+      // returned []" (also no mark) — empirical evidence for #3190 showed
+      // the mark perpetually missing in the latter case.
       const { builder } = makeBuilderWithFastPath({
         visibleCommands: [],
         fullPathReady: false,
@@ -1442,11 +1449,11 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
       await builder.build(createContext());
 
-      expect(markSpy).not.toHaveBeenCalledWith("exocmd-fastpath-ready");
-      expect(measureSpy).not.toHaveBeenCalledWith(
+      expect(markSpy).toHaveBeenCalledWith("exocmd-fastpath-ready");
+      expect(measureSpy).toHaveBeenCalledWith(
         "exocmd-fastpath",
-        expect.any(String),
-        expect.any(String),
+        "exocmd-fastpath-start",
+        "exocmd-fastpath-ready",
       );
     });
 


### PR DESCRIPTION
## Summary

- `metadataCache.on(\"changed\")` fires for every `assetspaces/exocmd/*.md` file during the initial vault scan (BEFORE `on(\"resolved\")`), and the pre-#3190 invalidation handler unconditionally called `bindingsCache.clear()`, wiping the snapshot loaded fire-and-forget at onload long before `autoRenderLayout()` could read it — so the disk cache (1.1 MB, 161 classes, version-matching plugin) never apply'ed.
- Gate `invalidateExocmdCaches` behind a `bootstrapResolved` flag flipped by the existing `metadataCache.on(\"resolved\")` handler; bootstrap `changed` events become no-ops, post-bootstrap edits invalidate as before.
- Drop the `visible.length > 0` guard on the `exocmd-fastpath-ready` mark and add `console.error(\"[exocortex] cache <stage> failed:\", err)` on every catch in the cache pipeline so future regressions are visible without re-enabling Verbose logging.

## Root cause

Disk cache (1.1 MB, 161 classes, plugin_version matching v16.8.5) was healthy on disk but **never apply'ed** because Obsidian's `metadataCache.on(\"changed\")` event fires for each `assetspaces/exocmd/*.md` file as it's parsed during the initial vault scan. PR #3185 wired `bindingsCache.clear()` into the same change-listener used by the pre-existing fast-resolver invalidator — every bootstrap-time exocmd parse wiped the freshly loaded snapshot before `autoRenderLayout()` could read it. Result: cache strategy permanently returned `null` (snapshot was null at lookup time), fell through to fast-path, then to full-path at T+10.5 s — identical to pre-PR #3185 behaviour.

Empirical evidence in the issue showed only four marks: `cache-read-start` (493 ms), `fastpath-start` (2942 ms), `fullpath-start` (2942 ms), `fullpath-ready` (10523 ms) — `cache-applied` and `fastpath-ready` permanently missing.

## Fix

1. **Bootstrap-resolved gate** (`ExocortexPlugin.ts`) — `let bootstrapResolved = false` declared next to `invalidateExocmdCaches`. Set inside the existing `metadataCache.on(\"resolved\")` handler (one-listener, idempotent); guards `cache.clear() + fastResolver.invalidateCommandCache()` so bootstrap-time `changed` events become no-ops.
2. **Unconditional `exocmd-fastpath-ready` mark** (`DynamicCommandButtonGroupBuilder.ts`) — drop the `visible.length > 0` guard; mark fires once per session whenever the fast-path branch runs to completion, including on empty results (e.g. open file's metadata cache not yet warm).
3. **Diagnostic `console.error`** on every catch in the cache pipeline (`ExocmdBindingsCache.load/save`, `ExocortexPlugin.onload`, `DynamicCommandButtonGroupBuilder.resolveViaCache/resolveViaFastPath`) so future regressions are observable without `Verbose` logging.

## Test plan

- [x] `npm run lint` — 0 errors, 2 pre-existing warnings.
- [x] `npm run check:types` — clean.
- [x] `npm test` (`packages/obsidian-plugin/jest.config.js`) — 251 suites, 5073 passed, 3 skipped.
- [x] `npm run build` — production build OK.
- [x] `npm run bdd:check` — 204/204 (100%).
- [x] `npx archgate check` — 13/13 pass.
- [x] AC #1 — `exocmd-cache-applied` mark fires on cache hit (covered by existing builder cache test \"emits a one-shot performance.mark on cache hit\").
- [x] AC #2 — `exocmd-cache-read-to-applied` duration measured (paired mark, existing test).
- [x] AC #4 — `console.error(\"[exocortex] cache read failed: …\", err)` on read/parse/shape-validation failures (3 new tests in `ExocmdBindingsCache.test.ts`).
- [x] AC #5 — `exocmd-fastpath-ready` mark fires when fast-path branch executes regardless of visible count (test updated in `DynamicCommandButtonGroupBuilder.test.ts` + 3 new tests in `DynamicCommandButtonGroupBuilder.cache.test.ts`).
- [x] AC #6 — all 14 required CI checks (post-Phase 4 13 + detect-changes) — pending CI.
- [ ] Manual verify after release — cold-start vault-2025 with warm cache; expect `performance.getEntriesByName('exocmd-cache-applied')[0].startTime` returning a number ≤200 ms and CREATE buttons visible alongside MISC without 10 s delay.

Closes #3190