### PR TITLE
docs: post-mortem patterns from #3184 (Optional Cross-Layer DI + Test Suite Awareness)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,18 @@ infrastructure/  → Obsidian API adapters, file system
 - **Required CI checks (13, post CI Path 2 D0 2026-04-22)**: archgate · detect-changes · e2e-shard (1..6) · lint · test-bdd · test-component · test-coverage · typecheck. Source of truth: `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`.
 - **CI pipeline target**: post-Phase 3 baseline is ~236s avg ±50s (N=3 on main). Gate relaxed to **≤220s** per Decision B (RFC v2 relax, 2026-04-22); original ≤135s target was infeasible given setup-floor dominance. See `docs/ROLLBACK_CI_SPEEDUP.md` for per-phase revert procedure.
 
+## Test Suite Awareness
+
+The exocortex-package jest config has `roots: ['<rootDir>/tests']`, but CI's `test-coverage` step uses an allowlist regex in `scripts/test-ci-batched.sh` (see `EXOCORTEX_JEST_ARGS`). New integration suites under `packages/exocortex/tests/integration/**` are NOT picked up automatically — either add them to the allowlist or accept they can rot silently.
+
+When fixing a bug, run the directly-affected suite locally even if it isn't gated by CI:
+
+```bash
+npm test -- packages/exocortex/tests/integration/<affected-suite>.test.ts
+```
+
+**Reference**: PR #3189 — `create-instance-grounding.test.ts` was silently red on `main` (12/12 fail, missing parent.md fixture) because the allowlist never included it. Coverage gates measure file/line %, not "did this suite pass"; orphan integration suites can rot indefinitely.
+
 ## TypeScript Tooling
 
 - `ts-jest` cannot transpile class-level `async *` generator methods — use `AsyncIterableIterator` from a helper/closure instead.

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -496,6 +496,52 @@ These invariants protect existing callers and avoid mass vault rewrites when new
 
 ---
 
+## Optional Cross-Layer Dependencies Pattern
+
+**When to use**: A core service needs to trigger a surface-specific side-effect (open file, show notification, refresh layout) but the side-effect doesn't belong in the core's responsibility.
+
+**Pattern**: Don't bake the side-effect into the core. Define a small interface (`IFileOpener`, `IRefreshAfter…`), accept it as an *optional* constructor argument, and `await it?.(args)` at the call site. Tests and CLI surfaces omit the dep; the platform layer wires its implementation.
+
+```ts
+// Core service — no opener dependency baked in
+class CommandExecutionFlow {
+  constructor(
+    private deps: CoreDeps,
+    private opener?: IFileOpener,  // optional
+  ) {}
+
+  async execute(cmd: Command): Promise<ExecutionResult> {
+    const result = await this.run(cmd);
+    if (result.openPath) {
+      await this.opener?.(result.openPath);  // no-op if absent
+    }
+    return result;
+  }
+}
+
+// Obsidian wiring layer — provides the platform-specific opener
+const opener: IFileOpener = async (path) => {
+  const af = app.vault.getAbstractFileByPath(path);
+  if (af instanceof TFile) {
+    await app.workspace.getLeaf("tab").openFile(af);
+  }
+};
+new CommandExecutionFlow(deps, opener);
+
+// CLI / tests — no opener arg, side-effect simply doesn't fire
+new CommandExecutionFlow(deps);
+```
+
+**Key properties**:
+- Core test fixtures stay unchanged (they pass 3 args)
+- Headless CLI path stays unchanged (no opener)
+- One-line surface added on the Obsidian wiring side
+- Side-effect is platform-conditional without conditionals scattered through the core
+
+**Reference**: PR #3189 — `GroundingExecutor` returns `ExecutionResult.openPath`; `CommandExecutionFlow` consumes via optional `IFileOpener`; `ObsidianFileOpener` opens the file in a new tab (B5 fix for #3184).
+
+---
+
 ## Sequential Related Tasks Pattern
 
 **When to use**: Implementing multiple related features in same subsystem


### PR DESCRIPTION
## Summary

Documentation improvements proposed by the child Claude session that fixed #3184 (PR #3189). User-approved via interactive prompt per Rule #2 (post-mortem improvements require explicit approval before editing instruction files).

- **PATTERNS.md** — new section: `Optional Cross-Layer Dependencies Pattern`. Reference: `IFileOpener` introduced in PR #3189 for B5 open-in-tab. Pattern: define a small interface, accept it as optional ctor arg, `await it?.(args)` at call site. Keeps core test fixtures and CLI path unchanged while adding platform-specific side-effect.

- **CLAUDE.md** — new section: `Test Suite Awareness`. Reference: `create-instance-grounding.test.ts` was silently red on `main` (12/12 fail, missing `parent.md` fixture) because `test-ci-batched.sh` allowlist excluded it. Coverage gates measure file/line %, not "did this suite pass". Orphan integration suites under `packages/exocortex/tests/integration/**` need explicit allowlisting or they rot indefinitely.

## Test plan
- [x] Both files render cleanly (markdown, no broken refs)
- [x] No code paths affected — pure documentation
- [x] Required CI checks (lint, typecheck, archgate, detect-changes) should pass — no source files touched

## References
- Baseline issue: #3184 (B1-B5 grounding fixes)
- Closure PR: #3189 (merged 2026-05-17)
- Post-mortem: backup'd to `~/Developer/post-mortems/3184.md` (not in repo by user choice)
- Follow-up regression: #3195 (path-form leakage in `exo__Asset_prototype`)