### PR TITLE
feat: parser update for RFC 31c1a0be typed predicates (Phase 3, #3194)

### DIFF
--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -81,10 +81,25 @@ export interface GroundingDefinition {
   readonly label: string;
   /** Type of grounding action */
   readonly type: GroundingType;
-  /** Frontmatter property name (for property_delete / property_set) */
+  /** Frontmatter property name (for property_delete / property_set). Resolved
+   *  from `exocmd__Grounding_targetProperty` — symbolic-string form
+   *  (`"ems__Effort_status"`) OR UUID-wikilink form (`"[[<UID>]]"`) which is
+   *  resolved by CommandResolver to the property's `exo__Asset_label` before
+   *  reaching here. RFC 31c1a0be Phase 3: never bare UUID. */
   readonly targetProperty?: string;
-  /** Value to set (for property_set) */
+  /** Legacy single-value for property_set. RFC 31c1a0be Phase 3: still read
+   *  for backward-compat (warn-log fires); new groundings use one of
+   *  `targetValueRef` / `targetValueLiteral` / `targetValueSubstitution`. */
   readonly targetValue?: string;
+  /** RFC 31c1a0be Phase 1: typed RDF reference to the value asset. When set,
+   *  emits `"[[<UID>]]"` wikilink as the property_set value. Mutually exclusive
+   *  with `targetValueLiteral` / `targetValueSubstitution`. */
+  readonly targetValueRef?: string;
+  /** RFC 31c1a0be Phase 1: literal string value for property_set. */
+  readonly targetValueLiteral?: string;
+  /** RFC 31c1a0be Phase 1: UUID of SubstitutionToken instance whose label
+   *  (e.g. `$nowLocal`) becomes the substituted value. */
+  readonly targetValueSubstitution?: string;
   /** SPARQL UPDATE query (for sparql_update) */
   readonly sparqlUpdate?: string;
   /** Ordered sub-steps (for composite type) */

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -883,6 +883,14 @@ export class CommandResolver {
     if (!type) return null;
 
     let targetProperty = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetProperty"));
+    // RFC 31c1a0be Phase 3: resolve UUID-form (`"[[<UID>]]"`) targetProperty
+    // to the property asset's exo__Asset_label. Otherwise GroundingExecutor
+    // would write the bare UUID as a frontmatter key (data corruption per
+    // HIGH-4 in self-review). Symbolic-string form passes through unchanged.
+    if (targetProperty && this.looksLikeUUID(targetProperty)) {
+      const resolved = await this.resolveLabelByUID(targetProperty);
+      if (resolved) targetProperty = resolved;
+    }
     // For service_call groundings, serviceId takes priority over targetProperty
     if (type === GroundingType.SERVICE_CALL) {
       const serviceId = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_serviceId"));
@@ -891,6 +899,24 @@ export class CommandResolver {
       }
     }
     const targetValue = await this.getObsidianWikilinkValue(subject, Namespace.EXOCMD.term("Grounding_targetValue"));
+    // RFC 31c1a0be Phase 1 typed predicates — emit wikilink/literal/token-label
+    // for property_set dispatch in GroundingExecutor.
+    // targetValueRef: use getObsidianName so the value is unwrapped to the
+    // bare UID (executor re-wraps to `"[[<UID>]]"`). Avoids
+    // getObsidianWikilinkValue's `"[[...]]"`-with-alias output that would
+    // double-wrap the wikilink at dispatch time.
+    const targetValueRef = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetValueRef"));
+    const targetValueLiteral = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetValueLiteral"));
+    // SubstitutionToken reference — read the token's exo__Asset_label
+    // (e.g. "$nowLocal") so executePropertySet's substituteVariables can
+    // resolve it via the existing regex paths.
+    const substitutionRefRaw = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetValueSubstitution"));
+    let targetValueSubstitution: string | null = null;
+    if (substitutionRefRaw && this.looksLikeUUID(substitutionRefRaw)) {
+      targetValueSubstitution = await this.resolveLabelByUID(substitutionRefRaw);
+    } else if (substitutionRefRaw) {
+      targetValueSubstitution = substitutionRefRaw;
+    }
     const isDefinedBy = await this.getObsidianWikilinkValue(subject, Namespace.EXOCMD.term("Grounding_isDefinedBy"));
     const sparqlUpdate = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_sparqlUpdate"));
     const targetClass = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetClass"));
@@ -1001,6 +1027,9 @@ export class CommandResolver {
       type,
       targetProperty: targetProperty ?? undefined,
       targetValue: targetValue ?? undefined,
+      targetValueRef: targetValueRef ?? undefined,
+      targetValueLiteral: targetValueLiteral ?? undefined,
+      targetValueSubstitution: targetValueSubstitution ?? undefined,
       sparqlUpdate: sparqlUpdate ?? undefined,
       steps,
       targetClass: targetClass ?? undefined,
@@ -1095,6 +1124,25 @@ export class CommandResolver {
     if (obj instanceof Literal) return obj.value;
     if (obj instanceof IRI) return obj.value;
     return null;
+  }
+
+  /**
+   * RFC 31c1a0be Phase 3 helper. UUID v4 detection — used to decide whether a
+   * resolved name from `getObsidianName` is actually a bare UUID basename
+   * (from UUID-named asset file) vs an already-symbolic identifier.
+   */
+  private looksLikeUUID(value: string): boolean {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+  }
+
+  /**
+   * RFC 31c1a0be Phase 3 helper. Resolve a UID to the linked asset's
+   * `exo__Asset_label`. Returns null if asset not found or has no label.
+   */
+  private async resolveLabelByUID(uid: string): Promise<string | null> {
+    const subject = await this.findSubjectByUID(uid);
+    if (!subject) return null;
+    return this.getLiteralValue(subject, Namespace.EXO.term("Asset_label"));
   }
 
   private async getLinkedUID(subject: IRI, predicate: IRI): Promise<string | null> {

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -238,14 +238,47 @@ export class GroundingExecutor {
     if (!grounding.targetProperty) {
       return { success: false, error: "property_set requires targetProperty" };
     }
-    if (grounding.targetValue === undefined) {
-      return { success: false, error: "property_set requires targetValue" };
+
+    // RFC 31c1a0be Phase 3 dispatch — typed predicates take priority over
+    // legacy `targetValue`. Priority: Ref > Literal > Substitution > legacy.
+    // Multiple typed predicates simultaneously = fail-loud (RFC §4 cardinality).
+    let effectiveValue: string | undefined;
+    const typedFieldsSet = [
+      grounding.targetValueRef !== undefined,
+      grounding.targetValueLiteral !== undefined,
+      grounding.targetValueSubstitution !== undefined,
+    ].filter(Boolean).length;
+    if (typedFieldsSet > 1) {
+      return {
+        success: false,
+        error:
+          "property_set: more than one of targetValueRef/targetValueLiteral/targetValueSubstitution set (cardinality 0..1 each, mutually exclusive)",
+      };
+    }
+    if (grounding.targetValueRef !== undefined) {
+      effectiveValue = `"[[${grounding.targetValueRef}]]"`;
+    } else if (grounding.targetValueLiteral !== undefined) {
+      effectiveValue = grounding.targetValueLiteral;
+    } else if (grounding.targetValueSubstitution !== undefined) {
+      effectiveValue = grounding.targetValueSubstitution;
+    } else if (grounding.targetValue !== undefined) {
+      // RFC 31c1a0be Phase 3 backward-compat fallback. Phase 5 removes this branch.
+      effectiveValue = grounding.targetValue;
+      LoggingService.warn(
+        `[legacy] Grounding ${grounding.id ?? "(unknown)"} uses deprecated exocmd__Grounding_targetValue — migrate to typed predicate (Ref/Literal/Substitution) per RFC 31c1a0be`,
+      );
+    } else {
+      return {
+        success: false,
+        error:
+          "property_set requires one of targetValueRef/targetValueLiteral/targetValueSubstitution (or legacy targetValue)",
+      };
     }
 
     // RFC-028 Findings 3+4: fail loudly if $input/$value placeholder is present
     // but no userInput.value is provided. Prevents silently writing the literal
     // string ("$input"/"$value") into frontmatter as a value.
-    const needsUserInput = /\$(input|value)\b/.test(grounding.targetValue);
+    const needsUserInput = /\$(input|value)\b/.test(effectiveValue);
     if (
       needsUserInput &&
       (userInput === undefined ||
@@ -260,7 +293,7 @@ export class GroundingExecutor {
     }
 
     const substitutedValue = this.substituteVariables(
-      grounding.targetValue,
+      effectiveValue,
       targetIRI,
       userInput,
     );

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -1509,3 +1509,178 @@ describe("CommandResolver", () => {
     });
   });
 });
+
+// -- RFC 31c1a0be Phase 3 — wikilink-form targetProperty resolution --
+//
+// The corruption fix (HIGH-4 from self-review): when a grounding has
+// `targetProperty: "[[<UID>]]"` referencing a property asset, CommandResolver
+// must resolve the UUID to the property's exo__Asset_label
+// (e.g. "ems__Effort_status"). Otherwise GroundingExecutor would write a
+// UUID-named frontmatter key — data corruption.
+//
+// New typed predicate dispatch (targetValueRef / Literal / Substitution) is
+// also exercised here at the resolver level — executor-level tests live in
+// GroundingExecutor.test.ts.
+describe("CommandResolver — RFC 31c1a0be Phase 3", () => {
+  let store: InMemoryTripleStore;
+  let resolver: CommandResolver;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    resolver = new CommandResolver(store);
+  });
+
+  async function addPropertyAsset(uid: string, label: string): Promise<void> {
+    const subject = new IRI(`obsidian://vault/${uid}.md`);
+    await store.addAll([
+      new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+      new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(label)),
+    ]);
+  }
+
+  async function addSubstitutionToken(uid: string, label: string): Promise<void> {
+    const subject = new IRI(`obsidian://vault/${uid}.md`);
+    await store.addAll([
+      new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+      new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(label)),
+    ]);
+  }
+
+  it("resolves wikilink-form targetProperty UUID to exo__Asset_label (corruption fix)", async () => {
+    const propUID = "44c6e9e3-955f-4afc-9ca5-b4bd70667051";
+    await addPropertyAsset(propUID, "ems__Effort_status");
+
+    await addGroundingAsset(store, {
+      uid: "gnd-1",
+      label: "Set status to Done",
+      type: "property_set",
+      targetProperty: `[[${propUID}]]`,
+      targetValue: '"[[ems__EffortStatusDone]]"',
+    });
+    await addBindingAsset(store, {
+      uid: "bind-1",
+      label: "Set status to Done → Task binding",
+      commandRef: "cmd-1",
+      targetClass: "ems__Task",
+    });
+    await addCommandAsset(store, {
+      uid: "cmd-1",
+      label: "Mark Done",
+      groundingRef: "gnd-1",
+    });
+
+    const resolved = await resolver.resolveForAsset(
+      "obsidian://vault/test.md",
+      "ems__Task",
+    );
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].command.grounding.targetProperty).toBe("ems__Effort_status");
+    // Bare UUID never reaches the executor — corruption signature absent.
+    expect(resolved[0].command.grounding.targetProperty).not.toBe(propUID);
+  });
+
+  it("passes symbolic-string targetProperty through unchanged", async () => {
+    await addGroundingAsset(store, {
+      uid: "gnd-1",
+      label: "Set status to Doing",
+      type: "property_set",
+      targetProperty: "ems__Effort_status",
+      targetValue: '"[[ems__EffortStatusDoing]]"',
+    });
+    await addBindingAsset(store, {
+      uid: "bind-1",
+      label: "Start Effort → Task binding",
+      commandRef: "cmd-1",
+      targetClass: "ems__Task",
+    });
+    await addCommandAsset(store, {
+      uid: "cmd-1",
+      label: "Start Effort",
+      groundingRef: "gnd-1",
+    });
+
+    const resolved = await resolver.resolveForAsset(
+      "obsidian://vault/test.md",
+      "ems__Task",
+    );
+    expect(resolved[0].command.grounding.targetProperty).toBe("ems__Effort_status");
+  });
+
+  it("reads targetValueRef typed predicate as raw UID string", async () => {
+    const gndSubject = new IRI("obsidian://vault/gnd-typed.md");
+    await store.addAll([
+      new Triple(gndSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+      new Triple(gndSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-typed")),
+      new Triple(gndSubject, Namespace.EXO.term("Asset_label"), new Literal("Set status Ref-form")),
+      new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("property_set")),
+      new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_targetProperty"), new Literal("ems__Effort_status")),
+      new Triple(
+        gndSubject,
+        Namespace.EXOCMD.term("Grounding_targetValueRef"),
+        new Literal("[[7b9b3116-7c3c-438c-9618-94fe301320a6]]"),
+      ),
+    ]);
+    await addBindingAsset(store, {
+      uid: "bind-typed",
+      label: "Mark Done → Task (typed)",
+      commandRef: "cmd-typed",
+      targetClass: "ems__Task",
+    });
+    await addCommandAsset(store, {
+      uid: "cmd-typed",
+      label: "Mark Done (typed)",
+      groundingRef: "gnd-typed",
+    });
+
+    const resolved = await resolver.resolveForAsset(
+      "obsidian://vault/test.md",
+      "ems__Task",
+    );
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].command.grounding.targetValueRef).toBe(
+      "7b9b3116-7c3c-438c-9618-94fe301320a6",
+    );
+  });
+
+  it("resolves targetValueSubstitution wikilink to SubstitutionToken label", async () => {
+    const tokenUID = "8bc0c038-1fd1-4ad3-a4a4-178a64b492b8";
+    await addSubstitutionToken(tokenUID, "$nowLocal");
+
+    const gndSubject = new IRI("obsidian://vault/gnd-subst.md");
+    await store.addAll([
+      new Triple(gndSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+      new Triple(gndSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-subst")),
+      new Triple(gndSubject, Namespace.EXO.term("Asset_label"), new Literal("Set ts to now (subst)")),
+      new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("property_set")),
+      new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_targetProperty"), new Literal("ems__Effort_reviewTimestamp")),
+      new Triple(
+        gndSubject,
+        Namespace.EXOCMD.term("Grounding_targetValueSubstitution"),
+        new Literal(`[[${tokenUID}]]`),
+      ),
+    ]);
+    await addBindingAsset(store, {
+      uid: "bind-subst",
+      label: "Mark Reviewed → Task binding",
+      commandRef: "cmd-subst",
+      targetClass: "ems__Task",
+    });
+    await addCommandAsset(store, {
+      uid: "cmd-subst",
+      label: "Mark Reviewed",
+      groundingRef: "gnd-subst",
+    });
+
+    const resolved = await resolver.resolveForAsset(
+      "obsidian://vault/test.md",
+      "ems__Task",
+    );
+
+    expect(resolved).toHaveLength(1);
+    // CommandResolver injects the token's exo__Asset_label so the executor's
+    // existing substituteVariables regex paths handle it transparently.
+    expect(resolved[0].command.grounding.targetValueSubstitution).toBe("$nowLocal");
+  });
+});

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -145,6 +145,93 @@ describe("GroundingExecutor", () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain("targetValue");
     });
+
+    // RFC 31c1a0be Phase 3 — typed predicate dispatch
+    describe("RFC 31c1a0be typed predicates", () => {
+      it("targetValueRef emits wikilink-form value", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_SET,
+          targetProperty: "ems__Effort_status",
+          targetValueRef: "7b9b3116-7c3c-438c-9618-94fe301320a6",
+        });
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+        expect(result.success).toBe(true);
+        const written = writer.updateFile.mock.calls[0][1];
+        expect(written).toContain(
+          'ems__Effort_status: "[[7b9b3116-7c3c-438c-9618-94fe301320a6]]"',
+        );
+      });
+
+      it("targetValueLiteral emits literal value as-is", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_SET,
+          targetProperty: "ems__Effort_notes",
+          targetValueLiteral: "some plain literal",
+        });
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+        expect(result.success).toBe(true);
+        const written = writer.updateFile.mock.calls[0][1];
+        expect(written).toContain("ems__Effort_notes: some plain literal");
+      });
+
+      it("targetValueSubstitution resolves token label like legacy targetValue", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_SET,
+          targetProperty: "ems__Effort_reviewTimestamp",
+          // Already-resolved SubstitutionToken.label injected by CommandResolver
+          targetValueSubstitution: "$nowLocal",
+        });
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+        expect(result.success).toBe(true);
+        const written = writer.updateFile.mock.calls[0][1];
+        expect(written).toMatch(
+          /ems__Effort_reviewTimestamp: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+        );
+      });
+
+      it("rejects more than one typed predicate (cardinality 0..1 each)", async () => {
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_SET,
+          targetProperty: "ems__foo",
+          targetValueRef: "uid-a",
+          targetValueLiteral: "literal-b",
+        });
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("more than one");
+      });
+
+      it("legacy targetValue still works (backward-compat fallback)", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_SET,
+          targetProperty: "ems__legacy_status",
+          targetValue: '"[[ems__EffortStatusDone]]"',
+        });
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+        expect(result.success).toBe(true);
+        const written = writer.updateFile.mock.calls[0][1];
+        expect(written).toContain('ems__legacy_status:');
+      });
+
+      it("typed predicate wins over legacy targetValue (priority)", async () => {
+        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_SET,
+          targetProperty: "ems__foo",
+          targetValueLiteral: "from-typed",
+          targetValue: "from-legacy",
+        });
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+        expect(result.success).toBe(true);
+        const written = writer.updateFile.mock.calls[0][1];
+        expect(written).toContain("ems__foo: from-typed");
+        expect(written).not.toContain("from-legacy");
+      });
+    });
   });
 
   // -- property_delete --


### PR DESCRIPTION
## Summary

RFC `31c1a0be-bc72-4a1e-8426-75e7b0ddedd2` Phase 3 — parser update.

Three layered changes for vault-driven UI commands to operate on the new typed RDF predicates landed in Phase 1 (`kitelev/exocortex-exocmd-ontology#6`).

## Changes

### 1. `GroundingDefinition` — 3 new typed-predicate fields

| Field | Purpose |
|---|---|
| `targetValueRef` | RDF reference to a value asset; emits `\"[[<UID>]]\"` wikilink |
| `targetValueLiteral` | Plain string literal |
| `targetValueSubstitution` | SubstitutionToken instance label (e.g. `\$nowLocal`) |

### 2. `CommandResolver.loadGroundingDefinition` — critical corruption-fix + new-field reads

When `targetProperty` is a UUID-wikilink (`\"[[<UID>]]\"`), the parser now resolves the UID to the target asset's `exo__Asset_label` (e.g. `\"ems__Effort_status\"`). **Without this fix, executor would write a UUID-named frontmatter key — data corruption per HIGH-4 in the Phase 1 self-review.**

Symbolic-string `targetProperty` passes through unchanged.

New helper methods `looksLikeUUID()` + `resolveLabelByUID()` are scoped to this resolver.

### 3. `GroundingExecutor.executePropertySet` — typed-predicate dispatch + BC

Priority: `targetValueRef` > `targetValueLiteral` > `targetValueSubstitution` > legacy `targetValue`.

- Cardinality guard: multiple typed predicates set simultaneously → fail-loud (RFC §4).
- Legacy `targetValue` still works — fires `[legacy]` warn-log via `LoggingService.warn`. Phase 5 removes this branch.

## Tests

- **6 new `GroundingExecutor` tests** cover all 4 dispatch branches, cardinality guard, priority (typed wins over legacy), legacy BC.
- **4 new `CommandResolver` tests** cover:
  - wikilink-form `targetProperty` UUID → `exo__Asset_label` resolution (corruption fix)
  - symbolic-string `targetProperty` pass-through
  - `targetValueRef` raw UID read
  - `targetValueSubstitution` UUID → SubstitutionToken label resolution

**178/178** tests pass on both touched suites. No regression in existing property_set / composite / create_instance / SPARQL paths.

## Pre-existing test failures NOT in scope

7 test suites fail on `origin/main` before this PR (TypeScript strict-narrowing on object literals in `CommandDefinition.test.ts`, etc.). Verified by stashing changes + running against pristine main. Unrelated to RFC 31c1a0be.

## Closes / Blocks

- Closes (partial) `kitelev/exocortex#3194` — finalized by Phase 4 (delete legacy TS commands).
- Unblocks Phase 2 (migration script in `kitelev/exocortex-exocmd-ontology`) — vault may now be migrated to new format because parser handles both.

## Verification — Phase 1 lessons applied

- Round-2 review practice from `postmortem-rfc-31c1a0be-phase-1-2026-05-19.md` → `advisor()` call planned after `code-reviewer` agent on this PR before declaring done.
- Round-1 review still pending — will run on this PR before requesting merge.

## Test plan

- [ ] Unit tests (touched suites: 178/178 pass — verified)
- [ ] CI: 13 required checks green
- [ ] Manual smoke: build plugin, install in Obsidian, click Mark Done on a Task — verify UUID-form `ems__Effort_status` written