### PR TITLE
fix: fail-loud on unresolvable UUID refs in CommandResolver (#3194 hotfix)

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -887,9 +887,21 @@ export class CommandResolver {
     // to the property asset's exo__Asset_label. Otherwise GroundingExecutor
     // would write the bare UUID as a frontmatter key (data corruption per
     // HIGH-4 in self-review). Symbolic-string form passes through unchanged.
+    //
+    // Fail-loud: a UUID that resolves to nothing (asset missing or has no
+    // exo__Asset_label) MUST skip this grounding entirely. Returning the bare
+    // UUID would defeat the corruption fix (post-merge adversarial review of
+    // PR #3197 caught this fail-open). Caller already treats `null` as
+    // "grounding inert" — UI silently omits its button instead of corrupting.
     if (targetProperty && this.looksLikeUUID(targetProperty)) {
       const resolved = await this.resolveLabelByUID(targetProperty);
-      if (resolved) targetProperty = resolved;
+      if (!resolved) {
+        this.logger.warn(
+          `Grounding ${uid}: targetProperty wikilink UID '${targetProperty}' is not resolvable to exo__Asset_label — grounding skipped (would otherwise write a UUID-named frontmatter key).`,
+        );
+        return null;
+      }
+      targetProperty = resolved;
     }
     // For service_call groundings, serviceId takes priority over targetProperty
     if (type === GroundingType.SERVICE_CALL) {
@@ -913,7 +925,17 @@ export class CommandResolver {
     const substitutionRefRaw = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetValueSubstitution"));
     let targetValueSubstitution: string | null = null;
     if (substitutionRefRaw && this.looksLikeUUID(substitutionRefRaw)) {
-      targetValueSubstitution = await this.resolveLabelByUID(substitutionRefRaw);
+      // Fail-loud: same pattern as targetProperty above. Missing/labelless
+      // SubstitutionToken instance → skip grounding rather than silently
+      // dropping the substitution and falling through to legacy targetValue.
+      const resolved = await this.resolveLabelByUID(substitutionRefRaw);
+      if (!resolved) {
+        this.logger.warn(
+          `Grounding ${uid}: targetValueSubstitution UID '${substitutionRefRaw}' is not resolvable to exo__Asset_label (SubstitutionToken instance missing or unlabelled) — grounding skipped.`,
+        );
+        return null;
+      }
+      targetValueSubstitution = resolved;
     } else if (substitutionRefRaw) {
       targetValueSubstitution = substitutionRefRaw;
     }

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -1644,6 +1644,71 @@ describe("CommandResolver — RFC 31c1a0be Phase 3", () => {
     );
   });
 
+  it("returns null grounding when targetProperty UID resolves to nothing (fail-loud)", async () => {
+    // No property asset registered for this UID — resolveLabelByUID returns null.
+    const missingPropUID = "00000000-0000-0000-0000-000000000bad";
+    await addGroundingAsset(store, {
+      uid: "gnd-bad-prop",
+      label: "Bad targetProperty grounding",
+      type: "property_set",
+      targetProperty: `[[${missingPropUID}]]`,
+      targetValue: '"[[some-uid]]"',
+    });
+    await addBindingAsset(store, {
+      uid: "bind-bad-prop",
+      label: "Bad → Task binding",
+      commandRef: "cmd-bad-prop",
+      targetClass: "ems__Task",
+    });
+    await addCommandAsset(store, {
+      uid: "cmd-bad-prop",
+      label: "Bad Mark Done",
+      groundingRef: "gnd-bad-prop",
+    });
+
+    const resolved = await resolver.resolveForAsset(
+      "obsidian://vault/test.md",
+      "ems__Task",
+    );
+    // Grounding is inert because we cannot safely resolve targetProperty.
+    // CommandResolver skips the entire command (binding has no grounding to attach to).
+    expect(resolved).toHaveLength(0);
+  });
+
+  it("returns null grounding when targetValueSubstitution UID resolves to nothing (fail-loud)", async () => {
+    const missingTokenUID = "00000000-0000-0000-0000-000000000fed";
+    const gndSubject = new IRI("obsidian://vault/gnd-bad-subst.md");
+    await store.addAll([
+      new Triple(gndSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+      new Triple(gndSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-bad-subst")),
+      new Triple(gndSubject, Namespace.EXO.term("Asset_label"), new Literal("Bad subst grounding")),
+      new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("property_set")),
+      new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_targetProperty"), new Literal("ems__Effort_reviewTimestamp")),
+      new Triple(
+        gndSubject,
+        Namespace.EXOCMD.term("Grounding_targetValueSubstitution"),
+        new Literal(`[[${missingTokenUID}]]`),
+      ),
+    ]);
+    await addBindingAsset(store, {
+      uid: "bind-bad-subst",
+      label: "Bad subst → Task binding",
+      commandRef: "cmd-bad-subst",
+      targetClass: "ems__Task",
+    });
+    await addCommandAsset(store, {
+      uid: "cmd-bad-subst",
+      label: "Bad Mark Reviewed",
+      groundingRef: "gnd-bad-subst",
+    });
+
+    const resolved = await resolver.resolveForAsset(
+      "obsidian://vault/test.md",
+      "ems__Task",
+    );
+    expect(resolved).toHaveLength(0);
+  });
+
   it("resolves targetValueSubstitution wikilink to SubstitutionToken label", async () => {
     const tokenUID = "8bc0c038-1fd1-4ad3-a4a4-178a64b492b8";
     await addSubstitutionToken(tokenUID, "$nowLocal");


### PR DESCRIPTION
## Summary

Post-merge adversarial review of #3197 caught **two fail-open paths** that defeated the data-corruption fix the original PR claimed to close.

## Cross-finding (per Phase 1 post-mortem lesson)

The reviewer's finding mirrors HIGH-4 from Phase 1: when fix-for-X is shipped, latent risk-Y may activate. Here, the corruption-fix call site itself had a fail-open guard.

## Failing scenarios fixed

### HIGH-1: targetProperty UID resolution fail-open
\`packages/exocortex/src/services/CommandResolver.ts:890-893\` (original PR).

When grounding has \`targetProperty: \"[[<UID>]]\"\` (wikilink-form) and the referenced property asset is missing or has no \`exo__Asset_label\`:
- **Before:** \`if (resolved) targetProperty = resolved\` left the bare UUID flowing through. \`GroundingExecutor.frontmatterService.updateProperty(content, \"<UUID>\", value)\` wrote a UUID-named frontmatter key — data corruption (exact HIGH-4 hazard).
- **After:** \`if (!resolved) { logger.warn(...); return null; }\` — grounding becomes inert. CommandResolver binding-resolution already treats null grounding as \"skip this binding\". UI silently omits the button.

### HIGH-2: targetValueSubstitution UID resolution fail-open
\`packages/exocortex/src/services/CommandResolver.ts:914-919\` (original PR).

Same fail-open pattern. Missing/labelless SubstitutionToken UID → null assignment → executor fell through to legacy \`targetValue\` (potentially wrong value), or returned a generic error not surfacing the broken token reference.

**After:** mirrored fix — fail-loud with logger.warn + return null.

## Tests

2 new negative tests in \`CommandResolver.test.ts\`:
- \`returns null grounding when targetProperty UID resolves to nothing (fail-loud)\`
- \`returns null grounding when targetValueSubstitution UID resolves to nothing (fail-loud)\`

Both tests verify that \`resolveForAsset\` returns an empty array (no command surfaced) when the UID points to nothing in the triple store.

**69/69** CommandResolver tests pass. No regression on existing happy paths.

## Why this matters

Reviewer's verdict on the original PR was **WARNING** with these two HIGH items as merge-blockers. PR auto-merged because CI was green and review ran in parallel (background agent). This hotfix closes the gap before any user clicks Mark Done on an asset with a misconfigured grounding.

## Test plan

- [x] 69/69 CommandResolver unit tests pass
- [ ] CI: 13 required checks green
- [ ] No regression in production Mark Done / Trash / Mark Reviewed paths