### PR TITLE
docs: deprecate EffortStatus symbolic constants (RFC 31c1a0be Phase 4 PR-B, #3194)

### DIFF
--- a/packages/exocortex/src/domain/constants/EffortStatus.ts
+++ b/packages/exocortex/src/domain/constants/EffortStatus.ts
@@ -12,7 +12,10 @@
  *   - `NoteToRDFConverter.expandClassValue` symbolic class-IRI emission
  *     (Issues #2782/#2959 — SPARQL `ASK` preconditions match the symbolic
  *     namespace IRI, not file UUIDs)
- *   - 27+ call sites comparing against the symbolic form
+ *   - 25+ direct call sites comparing against the symbolic form
+ *     (broader grep including companion `EFFORT_STATUSES` and
+ *     `EffortStatusConfig` symbols reaches ~29 files; all are well above
+ *     the Phase 4 PR-B 20-file WAITING_DECISION threshold)
  *
  * Removal requires a coordinated migration of (a) the SPARQL templates,
  * (b) the converter's class-IRI substitution branch, and (c) all callers

--- a/packages/exocortex/src/domain/constants/EffortStatus.ts
+++ b/packages/exocortex/src/domain/constants/EffortStatus.ts
@@ -1,3 +1,26 @@
+/**
+ * Symbolic class-prefixed identifiers for effort status values.
+ *
+ * **Direction note (RFC 31c1a0be Phase 4 PR-B, #3194).** String values such
+ * as `"ems__EffortStatusDoing"` are the pre-UUID-canon symbolic form. The
+ * long-term direction is to identify status targets by their TBox UUIDs
+ * (e.g. `027e78f4-6e16-4b36-b8fb-5510507d5745` for Doing) so the parser
+ * resolves targets uniformly with the rest of the graph.
+ *
+ * **Not yet removable.** The enum values are coupled to:
+ *   - `SPARQLTemplateLibrary.EFFORT_STATUSES` (symbolic PREFIX-form in queries)
+ *   - `NoteToRDFConverter.expandClassValue` symbolic class-IRI emission
+ *     (Issues #2782/#2959 — SPARQL `ASK` preconditions match the symbolic
+ *     namespace IRI, not file UUIDs)
+ *   - 27+ call sites comparing against the symbolic form
+ *
+ * Removal requires a coordinated migration of (a) the SPARQL templates,
+ * (b) the converter's class-IRI substitution branch, and (c) all callers
+ * — deferred to RFC 31c1a0be Phase 5.
+ *
+ * New code should not introduce additional dependencies on this enum.
+ * Resolve UUIDs at runtime via the TBox lookup instead.
+ */
 export enum EffortStatus {
   DRAFT = "ems__EffortStatusDraft",
   BACKLOG = "ems__EffortStatusBacklog",

--- a/packages/exocortex/src/domain/constants/EffortStatusConfig.ts
+++ b/packages/exocortex/src/domain/constants/EffortStatusConfig.ts
@@ -1,6 +1,19 @@
 import { EffortStatus } from "./EffortStatus";
 
 /**
+ * **Direction note (RFC 31c1a0be Phase 4 PR-B, #3194).** This file maps
+ * human-readable status names to the symbolic class-prefixed wikilink
+ * form (e.g. `"[[ems__EffortStatusDoing]]"`). Symbolic wikilinks are the
+ * pre-UUID-canon form; new code should emit UUID-canon wikilinks
+ * `[[<UUID>]]` produced from a TBox lookup.
+ *
+ * **Not yet removable.** See {@link EffortStatus} for the coupling to
+ * SPARQL templates and `NoteToRDFConverter` class-IRI emission. Wholesale
+ * deletion is deferred to RFC 31c1a0be Phase 5 once the coordinated
+ * SPARQL+RDF migration is in place.
+ */
+
+/**
  * Human-readable status name type.
  */
 export type EffortStatusName =

--- a/packages/exocortex/src/domain/constants/EffortStatusConfig.ts
+++ b/packages/exocortex/src/domain/constants/EffortStatusConfig.ts
@@ -1,17 +1,21 @@
-import { EffortStatus } from "./EffortStatus";
-
 /**
+ * @file Symbolic status-name → wikilink mapping helpers.
+ *
  * **Direction note (RFC 31c1a0be Phase 4 PR-B, #3194).** This file maps
  * human-readable status names to the symbolic class-prefixed wikilink
  * form (e.g. `"[[ems__EffortStatusDoing]]"`). Symbolic wikilinks are the
  * pre-UUID-canon form; new code should emit UUID-canon wikilinks
  * `[[<UUID>]]` produced from a TBox lookup.
  *
- * **Not yet removable.** See {@link EffortStatus} for the coupling to
- * SPARQL templates and `NoteToRDFConverter` class-IRI emission. Wholesale
- * deletion is deferred to RFC 31c1a0be Phase 5 once the coordinated
- * SPARQL+RDF migration is in place.
+ * **Not yet removable.** See {@link EffortStatus} for the full coupling
+ * rationale: `SPARQLTemplateLibrary.EFFORT_STATUSES` PREFIX-form strings
+ * + `NoteToRDFConverter.expandClassValue` class-IRI emission +
+ * starter-kit `ASK` preconditions (Issues #2782/#2959, hotfix b79c7ae4).
+ * Wholesale deletion is deferred to RFC 31c1a0be Phase 5 once the
+ * coordinated SPARQL+RDF migration is in place.
  */
+
+import { EffortStatus } from "./EffortStatus";
 
 /**
  * Human-readable status name type.

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -971,6 +971,11 @@ export class NoteToRDFConverter {
             // Class-like enum targets are never queried by raw UUID literal
             // (#2102 dual storage exists for exo__Asset_prototype only) so the
             // replace is safe. Mirrors valueToClassURI's Issue #2745 lookup.
+            //
+            // RFC 31c1a0be Phase 4 PR-B (#3194) invariant: the class IRI
+            // emitted here is coupled to `SPARQLTemplateLibrary.EFFORT_STATUSES`
+            // and starter-kit ASK preconditions. Migrating to UUID-form
+            // requires changing all three together; see Phase 5 follow-up.
             const basenameClassIRI = this.expandClassValue(targetFile.basename);
             if (basenameClassIRI) {
               // Fix #ff3858e5: emit rdf:type triple so sh:class constraints resolve

--- a/packages/exocortex/src/services/SPARQLTemplateLibrary.ts
+++ b/packages/exocortex/src/services/SPARQLTemplateLibrary.ts
@@ -61,7 +61,21 @@ export const ASSET_CLASSES = {
 } as const;
 
 /**
- * Effort status values
+ * Effort status values, in symbolic PREFIX-form (`ems:` shorthand).
+ *
+ * @remarks
+ * RFC 31c1a0be Phase 4 PR-B (#3194) invariant: these PREFIX-form strings
+ * are coupled to {@link NoteToRDFConverter} `expandClassValue`. The
+ * converter emits the same canonical class IRI (e.g.
+ * `<https://exocortex.my/ontology/ems#EffortStatusDoing>`) for wikilinks
+ * whose target file basename is a class-prefixed name (Issues #2782/#2959).
+ * Templates that query `?s ems:Effort_status <ems:EffortStatusDoing>` rely
+ * on the emitted IRI matching the templated literal.
+ *
+ * Migration to UUID-form (e.g. `<obsidian://vault/<UUID>.md>`) requires a
+ * coordinated change in this table, the converter's class-IRI branch, the
+ * starter-kit SPARQL ASK preconditions, and all callers — deferred to RFC
+ * 31c1a0be Phase 5.
  */
 export const EFFORT_STATUSES = {
   DOING: "ems:EffortStatusDoing",


### PR DESCRIPTION
## Summary

Ships **PR-B as a doc-only descope** after pre-implementation audit surfaced
two `WAITING_DECISION` triggers from the session prompt that make the
originally-scoped deletion unsafe in isolation.

- No runtime/behavior changes.
- 4 files touched, all within the prompt-named scope.
- 386 targeted-suite tests pass; lint + typecheck clean.

## Why descoped (was: delete enum + config, modify converter + library)

### Trigger 1 — cascade > 20 files

Direct enum usage spans 27 source/test files across `packages/exocortex/`,
`packages/obsidian-plugin/`, `packages/cli/`, and test fixtures. The prompt
states:

> If cascade > 20 files, ask orchestrator: bulk-switch OR keep wrapper helper.

Orchestrator unreachable overnight — defaulting to the safer wrapper-helper
branch.

### Trigger 2 — v16.9.2 hotfix regression risk

The prompt-cited modify-scope lines in \`NoteToRDFConverter\` (947, 987-991)
are largely comments; the actual symbolic IRI emission lives in
\`expandClassValue\` calls at lines 974 and 1021. Those branches exist
explicitly to fix Issues #2782/#2959 (SPARQL \`ASK\` preconditions match the
symbolic namespace IRI). Removing them without a coordinated update of the
starter-kit ASK preconditions regresses those bugs. The prompt states:

> If NoteToRDFConverter modification risks regression in v16.9.2 fix
> territory — ask orchestrator before commit.

### Hidden coupling

\`SPARQLTemplateLibrary.EFFORT_STATUSES\` and
\`NoteToRDFConverter.expandClassValue\` co-emit the same canonical class IRI
(\`<https://exocortex.my/ontology/ems#EffortStatusDoing>\`). Changing one
without the other silently breaks query templates (Archive Completed,
Doing Tasks). Status predicates have **no** dual-storage fallback —
\`isProtoPredicate\` (NoteToRDFConverter:998-1004) restricts dual-storage to
\`exo__Asset_prototype\` only.

## What this PR does

| File | LOC | Change |
|---|---|---|
| \`packages/exocortex/src/domain/constants/EffortStatus.ts\` | +23 -0 | Add directional doc note: pre-UUID-canon symbolic form; new code should resolve UUIDs at runtime |
| \`packages/exocortex/src/domain/constants/EffortStatusConfig.ts\` | +13 -0 | Add directional doc note: deferred deletion |
| \`packages/exocortex/src/services/SPARQLTemplateLibrary.ts\` | +16 -1 | Document \`EFFORT_STATUSES\` coupling invariant with the converter |
| \`packages/exocortex/src/services/NoteToRDFConverter.ts\` | +5 -0 | Document the inverse coupling at \`expandClassValue\` (line 974) |

JSDoc uses prose (\"Direction note\") instead of \`@deprecated\` tag because
\`@typescript-eslint/no-deprecated\` would error on the 27 existing callers —
weaponizing the lint rule on the cascade belongs to the Phase 5 coordinated
migration, not this PR.

## Audit findings

Run from the worktree:

\`\`\`bash
grep -lE 'EffortStatus\\.\\b(DRAFT|BACKLOG|ANALYSIS|TODO|DOING|DONE|TRASHED)\\b|from .*EffortStatus[\"\\']' packages/*/src/ packages/*/tests/ -r | grep -v node_modules
\`\`\`

Returns **27 files**. Sample call sites:

- Production code: \`WorkflowResolver\`, \`WorkflowEngine\`, \`WorkflowCommandAdapter\`, \`KanbanColumnProvider\`, \`VisibilityGenerator\`, \`EffortStatusWorkflow\`, \`EffortVisibilityRules\`, \`ProjectVisibilityRules\`, \`DefaultWorkflows\`, \`WorkflowDefinition\`, \`DailyTasksRenderer\`, \`BlockerHelpers\`, \`workflow.ts\` (cli).
- Test fixtures / suites: 11 test files including \`WorkflowResolver.test\`, \`VisibilityGenerator.test\`, etc.
- Wikilink helpers: \`StatusSelectPropertyField\`, \`status.helpers\`, \`task.factory\`, \`meeting.factory\`.

Existing regression coverage of the v16.9.2 hotfix is already in
\`tests/unit/services/NoteToRDFConverter.rfc-31c1a0be-grounding-ref.test.ts\`
(8 cases) — preserved by this PR.

## Test plan

- [x] \`npm run check:types\` — clean
- [x] \`npm run lint\` — clean (2 pre-existing warnings unrelated:
      \`DisplayNameResolver:77\`, \`PrintNameRuleService:167\`)
- [x] Targeted suites — 386/386 pass:
  - \`SPARQLTemplateLibrary.test.ts\`
  - \`EffortStatus.test.ts\`
  - \`EffortStatusConfig.test.ts\`
  - \`NoteToRDFConverter.test.ts\`
  - \`NoteToRDFConverter.rfc-31c1a0be-grounding-ref.test.ts\`
  - \`CommandResolver.test.ts\`
  - \`GroundingExecutor.test.ts\`
- [x] Full \`npm run test:unit\` — 1746/1763 pass. The 17 failures
      are in \`packages/cli/tests/integration/sparql-exo003.integration.test.ts\`
      and \`packages/cli/tests/integration/starter-kit/command-pilot.integration.test.ts\`,
      verified pre-existing on \`origin/main\` baseline by stashing this PR's
      changes and re-running.

## Follow-up (Phase 5)

1. Migrate \`EFFORT_STATUSES\` PREFIX-form to UUID URIs **together with**
   the \`expandClassValue\` symbolic-IRI branch in \`NoteToRDFConverter\`
   AND the matching starter-kit ASK preconditions. Otherwise queries break.
2. Cascade enum → UUID-string callers across the 27 files (incremental
   per-package PRs recommended).
3. After cascade complete, delete \`EffortStatus.ts\` and
   \`EffortStatusConfig.ts\` and remove \`status.helpers.ts\` shims.

## Cross-references

- RFC tracker: #3194 (RFC 31c1a0be)
- Stage 2 PR-A merged earlier this overnight run: #3201
- Phase 3 hotfix preserved verbatim: b79c7ae4 (v16.9.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)