### PR TITLE
feat: migrate consumer surfaces to UUID-form (RFC 31c1a0be Phase 4 PR-C, #3194)

### DIFF
--- a/packages/cli/tests/unit/services/createRelatedProject.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedProject.test.ts
@@ -99,7 +99,10 @@ describe("createRelatedProject (CLI)", () => {
     expect(fm.exo__Asset_label).toBe("New Project from Area");
     expect(fm.ems__Effort_area).toBe("[[Area1]]");
     expect(fm.ems__Effort_parent).toBeUndefined();
-    expect(fm.ems__Effort_status).toBe("[[ems__EffortStatusDraft]]");
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194).
+    expect(fm.ems__Effort_status).toBe(
+      "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]",
+    );
   });
 
   it("inherits ems__Effort_parent when parent is ems__Project", async () => {

--- a/packages/cli/tests/unit/services/createRelatedTask.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedTask.test.ts
@@ -99,7 +99,10 @@ describe("createRelatedTask (CLI)", () => {
     expect(fm.exo__Asset_label).toBe("New Task from Area");
     expect(fm.ems__Effort_area).toBe("[[Area1]]");
     expect(fm.ems__Effort_parent).toBeUndefined();
-    expect(fm.ems__Effort_status).toBe("[[ems__EffortStatusDraft]]");
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194).
+    expect(fm.ems__Effort_status).toBe(
+      "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]",
+    );
   });
 
   it("inherits ems__Effort_parent when parent is ems__Project", async () => {

--- a/packages/exocortex/src/services/KanbanColumnProvider.ts
+++ b/packages/exocortex/src/services/KanbanColumnProvider.ts
@@ -19,6 +19,14 @@ export interface KanbanColumn {
  * preserving badge colors and display order.
  *
  * Issue #2367
+ *
+ * **RFC 31c1a0be Phase 4 PR-C (#3194) descope note.** `statusToLabel` derives
+ * the column display name by stripping the `"ems__EffortStatus"` prefix from
+ * the `EffortStatus` enum value. This is structurally tied to the symbolic
+ * form of the enum, which is Phase 5 deletion territory. Migrating to
+ * UUID-form requires a UUID→label map plus updates to the WorkflowDefinition
+ * / WorkflowEngine / consumer pipeline — above the cascade-cap. Deferred to
+ * Phase 5.
  */
 @injectable()
 export class KanbanColumnProvider {

--- a/packages/exocortex/src/services/WorkflowCommandAdapter.ts
+++ b/packages/exocortex/src/services/WorkflowCommandAdapter.ts
@@ -20,6 +20,17 @@ import { WorkflowEngine } from "./WorkflowEngine";
  * Wraps WorkflowEngine for transition queries and adds command semantics.
  *
  * Issue #2431
+ *
+ * **RFC 31c1a0be Phase 4 PR-C (#3194) descope note.** This adapter depends
+ * on the `EffortStatus` enum (symbolic-form values such as
+ * `"ems__EffortStatusDoing"`) for its `shortStatus` label derivation and for
+ * the SPARQL `ASK` precondition string built in `buildPrecondition`. The
+ * `EffortStatus` enum is on the Phase 5 deletion list (see
+ * `EffortStatus.ts`); migrating this adapter to UUID-form requires a
+ * coordinated change of the enum, `WorkflowDefinition`, `WorkflowEngine`,
+ * `WorkflowResolver`, `DefaultWorkflows`, `VisibilityGenerator`,
+ * `EffortVisibilityRules`, `ProjectVisibilityRules`, plus all consumer tests
+ * — comfortably above the 15-caller cascade-cap. Deferred to Phase 5.
  */
 @injectable()
 export class WorkflowCommandAdapter {

--- a/packages/obsidian-plugin/src/application/services/TaskTrackingService.ts
+++ b/packages/obsidian-plugin/src/application/services/TaskTrackingService.ts
@@ -90,17 +90,23 @@ export class TaskTrackingService {
   }
 
   /**
-   * Check if status is "DOING"
-   * Handles both formats: [[ems__EffortStatusDoing]] and ems__EffortStatusDoing
+   * Check if status is "DOING".
+   * Accepts both the UUID-form (UUID-canon, RFC 31c1a0be Phase 4 PR-C) and
+   * the legacy symbolic form. Both wikilinked and plain variants are matched.
+   * The Doing UUID is the TBox identifier at
+   * `assetspaces/ems/027e78f4-6e16-4b36-b8fb-5510507d5745.md`.
    */
   private isDoingStatus(status: unknown): boolean {
     if (!status || typeof status !== "string") {
       return false;
     }
 
-    // Remove wiki link brackets if present
-    const normalized = status.replace(/\[\[|\]\]/g, "").trim();
-    return normalized === "ems__EffortStatusDoing";
+    // Remove wiki link brackets if present, drop optional `|label` alias.
+    const normalized = status.replace(/\[\[|\]\]/g, "").split("|")[0].trim();
+    return (
+      normalized === "027e78f4-6e16-4b36-b8fb-5510507d5745" ||
+      normalized === "ems__EffortStatusDoing"
+    );
   }
 
   /**
@@ -237,15 +243,17 @@ export class TaskTrackingService {
     const encodedPath = encodeURIComponent(filePath);
     const encodedVault = encodeURIComponent(vaultName);
 
-    // Advanced URI format for updating frontmatter
-    // Requires "Advanced URI" community plugin to be installed
+    // Advanced URI format for updating frontmatter.
+    // Requires "Advanced URI" community plugin to be installed.
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). The Done UUID is the
+    // TBox identifier at `assetspaces/ems/7b9b3116-7c3c-438c-9618-94fe301320a6.md`.
     const callbackURL =
       `obsidian://advanced-uri?` +
       `vault=${encodedVault}&` +
       `filepath=${encodedPath}&` +
       `updatefrontmatter=true&` +
       `frontmatterkey=Status&` +
-      `frontmattervalue=[[ems__EffortStatusDone]]`;
+      `frontmattervalue=[[7b9b3116-7c3c-438c-9618-94fe301320a6]]`;
 
     return callbackURL;
   }

--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
@@ -34,14 +34,20 @@ export interface SizeEnumValue {
   label: string;
 }
 
+// UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). UUID-canon mapping for
+// ems__EffortStatus instances in the vault TBox (assetspaces/ems/<UUID>.md).
+// Fallback path: used when EnumValueResolver is unavailable (pre-triple-store
+// load). Resolved path (EnumValueResolver) still emits symbolic-form short
+// names — Stage 5 will migrate that. UUID-form `value` ensures property
+// writes from this fallback are UUID-canon even when the resolver fails.
 const FALLBACK_EFFORT_STATUS_VALUES: StatusEnumValue[] = [
-  { value: "[[ems__EffortStatusBacklog]]", wikilink: "[[ems__EffortStatusBacklog|Backlog]]", label: "Backlog" },
-  { value: "[[ems__EffortStatusAnalysis]]", wikilink: "[[ems__EffortStatusAnalysis|Analysis]]", label: "Analysis" },
-  { value: "[[ems__EffortStatusToDo]]", wikilink: "[[ems__EffortStatusToDo|To Do]]", label: "To Do" },
-  { value: "[[ems__EffortStatusDoing]]", wikilink: "[[ems__EffortStatusDoing|Doing]]", label: "Doing" },
-  { value: "[[ems__EffortStatusDone]]", wikilink: "[[ems__EffortStatusDone|Done]]", label: "Done" },
-  { value: "[[ems__EffortStatusTrashed]]", wikilink: "[[ems__EffortStatusTrashed|Trashed]]", label: "Trashed" },
-  { value: "[[ems__EffortStatusDraft]]", wikilink: "[[ems__EffortStatusDraft|Draft]]", label: "Draft" },
+  { value: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]", wikilink: "[[753a44d5-846c-4b82-9196-4fd9a4d48777|Backlog]]", label: "Backlog" },
+  { value: "[[cde3525c-57ea-4efc-b477-2e7e7ccd3a1e]]", wikilink: "[[cde3525c-57ea-4efc-b477-2e7e7ccd3a1e|Analysis]]", label: "Analysis" },
+  { value: "[[6a0e933a-6653-46f4-95ae-ed7508177c73]]", wikilink: "[[6a0e933a-6653-46f4-95ae-ed7508177c73|To Do]]", label: "To Do" },
+  { value: "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]", wikilink: "[[027e78f4-6e16-4b36-b8fb-5510507d5745|Doing]]", label: "Doing" },
+  { value: "[[7b9b3116-7c3c-438c-9618-94fe301320a6]]", wikilink: "[[7b9b3116-7c3c-438c-9618-94fe301320a6|Done]]", label: "Done" },
+  { value: "[[5d14f18d-db2b-4847-9ac1-144cb93b2541]]", wikilink: "[[5d14f18d-db2b-4847-9ac1-144cb93b2541|Trashed]]", label: "Trashed" },
+  { value: "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]", wikilink: "[[c42245d0-01de-4c35-bfcf-d910445ea28e|Draft]]", label: "Draft" },
 ];
 
 const FALLBACK_TASK_SIZE_VALUES: SizeEnumValue[] = [
@@ -204,18 +210,52 @@ export function getPropertyByName(
   return schema.find((prop) => prop.name === propertyName);
 }
 
+// RFC 31c1a0be Phase 4 PR-C (#3194). Legacy symbolic-form short-name to label
+// map. UI surfaces (table renderers, kanban) may receive stale symbolic
+// values written before the UUID-canon migration; this preserves the
+// human-readable label for both forms. Stage 5 will remove this map alongside
+// the `EffortStatus` enum deletion.
+const SYMBOLIC_STATUS_LABEL_FALLBACK: Record<string, string> = {
+  emseffortstatusdraft: "Draft",
+  emseffortstatusbacklog: "Backlog",
+  emseffortstatusanalysis: "Analysis",
+  emseffortstatustodo: "To Do",
+  emseffortstatusdoing: "Doing",
+  emseffortstatusdone: "Done",
+  emseffortstatustrashed: "Trashed",
+};
+
 export function getStatusLabel(statusUri: string | null | undefined): string {
   if (!statusUri || statusUri.trim() === "") return "-";
-  // Strip wikilink brackets, then remove a trailing UUID if present.
-  // Frontmatter may store "[[ems__EffortStatusDoing 027e78f4-...]]" (class + UUID)
-  // after certain status transitions; the UUID is stripped so the class name matches.
-  const normalized = statusUri.replace(/[[\]"']/g, "").trim()
-    .replace(/\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, "")
+  // Strip wikilink brackets and optional `|alias` suffix.
+  // Frontmatter may store "[[ems__EffortStatusDoing 027e78f4-...]]" (class
+  // name + UUID) after certain status transitions, or "[[<UUID>|Doing]]"
+  // (UUID + alias). The space-separated trailing UUID is stripped so the
+  // class-name lookup still matches.
+  const normalized = statusUri
+    .replace(/[[\]"']/g, "")
+    .split("|")[0]
+    .trim()
+    .replace(
+      /\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      "",
+    )
     .toLowerCase();
+
+  // UUID-form lookup against the canonical EFFORT_STATUS_VALUES table.
   const match = EFFORT_STATUS_VALUES.find(
     (v) =>
       v.value.replace(/[[\]]/g, "").toLowerCase() === normalized ||
       v.label.toLowerCase() === normalized,
   );
-  return match?.label ?? statusUri;
+  if (match) return match.label;
+
+  // Backward-compatibility lookup against the legacy symbolic form. The
+  // double-underscore is stripped during normalization (the `[[`/`]]` regex
+  // does not strip underscores, so we collapse them here).
+  const symbolicKey = normalized.replace(/_/g, "");
+  const symbolicLabel = SYMBOLIC_STATUS_LABEL_FALLBACK[symbolicKey];
+  if (symbolicLabel) return symbolicLabel;
+
+  return statusUri;
 }

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -248,7 +248,11 @@ export function populateServiceRegistry(
             )}`,
           );
         }
-        lines.push('ems__Effort_status: "[[ems__EffortStatusBacklog]]"');
+        // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Resolves the
+        // 42-asset symbolic-form trace back to this default-write site.
+        lines.push(
+          'ems__Effort_status: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"',
+        );
         if (!isDefinedByWritten && parentMetadata.exo__Asset_isDefinedBy) {
           lines.push(
             `exo__Asset_isDefinedBy: ${toQuotedWikilink(
@@ -417,8 +421,12 @@ export function populateServiceRegistry(
         const parentMetadata = (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
         const folderPath = iFile.parent?.path || "";
 
+        // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Draft status UUID
+        // is the canonical TBox identifier; vault file at
+        // assetspaces/ems/c42245d0-01de-4c35-bfcf-d910445ea28e.md.
         const propertyValues: Record<string, unknown> = {
-          "ems__Effort_status": '"[[ems__EffortStatusDraft]]"',
+          "ems__Effort_status":
+            '"[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"',
         };
 
         // Optional declarative override: starter-kit bindings may pass
@@ -465,8 +473,10 @@ export function populateServiceRegistry(
         // auto-inherits for ems__Task, so this handler does the area vs parent
         // detection explicitly via userInput.parentProperty and falls back to
         // the auto-detected form.
+        // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194).
         const propertyValues: Record<string, unknown> = {
-          "ems__Effort_status": '"[[ems__EffortStatusDraft]]"',
+          "ems__Effort_status":
+            '"[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"',
         };
 
         if (iFile.basename) {

--- a/packages/obsidian-plugin/src/presentation/modals/DynamicAssetCreationModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/DynamicAssetCreationModal.ts
@@ -364,12 +364,17 @@ export class DynamicAssetCreationModal extends Modal {
       cls: "dropdown",
     });
 
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). The legacy values used
+    // `ems__EffortStatus_Draft` (with underscore) which never matched any
+    // vault asset (canonical TBox uses `ems__EffortStatusDraft` without the
+    // underscore). UUIDs reference the canonical TBox files at
+    // `assetspaces/ems/<UUID>.md`. "Active" maps to Doing (027e78f4-…).
     const statusOptions = [
       { value: "", label: "Not specified" },
-      { value: '"[[ems__EffortStatus_Draft]]"', label: "Draft" },
-      { value: '"[[ems__EffortStatus_Active]]"', label: "Active" },
-      { value: '"[[ems__EffortStatus_Done]]"', label: "Done" },
-      { value: '"[[ems__EffortStatus_Cancelled]]"', label: "Cancelled" },
+      { value: '"[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"', label: "Draft" },
+      { value: '"[[027e78f4-6e16-4b36-b8fb-5510507d5745]]"', label: "Active" },
+      { value: '"[[7b9b3116-7c3c-438c-9618-94fe301320a6]]"', label: "Done" },
+      { value: '"[[cf6269e4-6c5e-418e-b9f2-115aea5fcfb6]]"', label: "Cancelled" },
     ];
 
     statusOptions.forEach((option) => {

--- a/packages/obsidian-plugin/tests/component/property-editor/fields/SelectField.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/property-editor/fields/SelectField.spec.tsx
@@ -90,16 +90,18 @@ test.describe("SelectField Component", () => {
 
   test("should display selected value correctly", async ({ mount }) => {
     const property = createStatusProperty();
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Doing UUID
+    // 027e78f4-6e16-4b36-b8fb-5510507d5745.
     const component = await mount(
       <SelectField
         property={property}
-        value="[[ems__EffortStatusDoing]]"
+        value="[[027e78f4-6e16-4b36-b8fb-5510507d5745]]"
         onChange={() => {}}
       />,
     );
 
     const select = component.locator("select");
-    await expect(select).toHaveValue("[[ems__EffortStatusDoing]]");
+    await expect(select).toHaveValue("[[027e78f4-6e16-4b36-b8fb-5510507d5745]]");
   });
 
   test("should call onChange when selection changes", async ({ mount }) => {
@@ -109,18 +111,22 @@ test.describe("SelectField Component", () => {
     };
     const property = createStatusProperty();
 
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194).
+    // Backlog → Done transition.
     const component = await mount(
       <SelectField
         property={property}
-        value="[[ems__EffortStatusBacklog]]"
+        value="[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"
         onChange={onChange}
       />,
     );
 
     const select = component.locator("select");
-    await select.selectOption("[[ems__EffortStatusDone]]");
+    await select.selectOption("[[7b9b3116-7c3c-438c-9618-94fe301320a6]]");
 
-    await expect.poll(() => changedValue).toBe("[[ems__EffortStatusDone]]");
+    await expect
+      .poll(() => changedValue)
+      .toBe("[[7b9b3116-7c3c-438c-9618-94fe301320a6]]");
   });
 
   test("should have 'Not specified' option when property is not required", async ({ mount }) => {
@@ -141,10 +147,12 @@ test.describe("SelectField Component", () => {
 
   test("should NOT have 'Not specified' option when property is required", async ({ mount }) => {
     const property = createStatusProperty({ required: true });
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Draft UUID
+    // c42245d0-01de-4c35-bfcf-d910445ea28e.
     const component = await mount(
       <SelectField
         property={property}
-        value="[[ems__EffortStatusDraft]]"
+        value="[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"
         onChange={() => {}}
       />,
     );
@@ -245,10 +253,12 @@ test.describe("SelectField Component", () => {
 
   test("should disable select when property is readOnly", async ({ mount }) => {
     const property = createStatusProperty({ readOnly: true });
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Doing UUID
+    // 027e78f4-6e16-4b36-b8fb-5510507d5745.
     const component = await mount(
       <SelectField
         property={property}
-        value="[[ems__EffortStatusDoing]]"
+        value="[[027e78f4-6e16-4b36-b8fb-5510507d5745]]"
         onChange={() => {}}
       />,
     );
@@ -273,17 +283,20 @@ test.describe("SelectField Component", () => {
 
   test("should normalize value by removing quotes", async ({ mount }) => {
     const property = createStatusProperty();
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Doing UUID
+    // 027e78f4-6e16-4b36-b8fb-5510507d5745, double-quoted as it appears
+    // in raw YAML frontmatter.
     const component = await mount(
       <SelectField
         property={property}
-        value='"[[ems__EffortStatusDoing]]"'
+        value='"[[027e78f4-6e16-4b36-b8fb-5510507d5745]]"'
         onChange={() => {}}
       />,
     );
 
     const select = component.locator("select");
     // The normalized value should match the option without quotes
-    await expect(select).toHaveValue("[[ems__EffortStatusDoing]]");
+    await expect(select).toHaveValue("[[027e78f4-6e16-4b36-b8fb-5510507d5745]]");
   });
 
   test("should have dropdown class for styling", async ({ mount }) => {

--- a/packages/obsidian-plugin/tests/unit/TaskTrackingService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/TaskTrackingService.test.ts
@@ -154,6 +154,36 @@ describe("TaskTrackingService", () => {
       expect(windowOpenSpy).toHaveBeenCalled();
     });
 
+    it("should handle file with DOING status (UUID-form, RFC 31c1a0be PR-C)", async () => {
+      (mockMetadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: {
+          Status: "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]",
+          TaskId: "existing-task-id",
+          Title: "Test Task"
+        }
+      });
+
+      await service.handleFileChange(mockFile);
+
+      expect(mockMetadataCache.getFileCache).toHaveBeenCalledWith(mockFile);
+      expect(windowOpenSpy).toHaveBeenCalled();
+    });
+
+    it("should handle file with DOING status (UUID-form with alias)", async () => {
+      (mockMetadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: {
+          Status: "[[027e78f4-6e16-4b36-b8fb-5510507d5745|Doing]]",
+          TaskId: "existing-task-id",
+          Title: "Test Task"
+        }
+      });
+
+      await service.handleFileChange(mockFile);
+
+      expect(mockMetadataCache.getFileCache).toHaveBeenCalledWith(mockFile);
+      expect(windowOpenSpy).toHaveBeenCalled();
+    });
+
     it("should handle file with DOING status but no TaskId", async () => {
       (mockMetadataCache.getFileCache as jest.Mock).mockReturnValue({
         frontmatter: {

--- a/packages/obsidian-plugin/tests/unit/TaskTrackingService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/TaskTrackingService.test.ts
@@ -184,6 +184,25 @@ describe("TaskTrackingService", () => {
       expect(windowOpenSpy).toHaveBeenCalled();
     });
 
+    it("should embed UUID-form Done in Advanced URI callback (RFC 31c1a0be PR-C)", async () => {
+      (mockMetadataCache.getFileCache as jest.Mock).mockReturnValue({
+        frontmatter: {
+          Status: "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]",
+          TaskId: "existing-task-id",
+          Title: "Test Task"
+        }
+      });
+
+      await service.handleFileChange(mockFile);
+
+      expect(windowOpenSpy).toHaveBeenCalled();
+      const launchedUrl = windowOpenSpy.mock.calls[0][0] as string;
+      // The Advanced URI callback is x-success-encoded inside the launched URL.
+      // It must carry the Done UUID, not the symbolic-form `ems__EffortStatusDone`.
+      expect(launchedUrl).toContain("7b9b3116-7c3c-438c-9618-94fe301320a6");
+      expect(launchedUrl).not.toContain("ems__EffortStatusDone");
+    });
+
     it("should handle file with DOING status but no TaskId", async () => {
       (mockMetadataCache.getFileCache as jest.Mock).mockReturnValue({
         frontmatter: {

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -664,7 +664,9 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
 
       const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
       const content = createCall[1] as string;
-      expect(content).toContain('ems__Effort_status: "[[ems__EffortStatusDraft]]"');
+      expect(content).toContain(
+        'ems__Effort_status: "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"',
+      );
     });
 
     it("should open the created task in a new tab leaf", async () => {
@@ -718,7 +720,9 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
 
       const createCall = (deps.vaultAdapter!.create as jest.Mock).mock.calls[0];
       const content = createCall[1] as string;
-      expect(content).toContain('ems__Effort_status: "[[ems__EffortStatusDraft]]"');
+      expect(content).toContain(
+        'ems__Effort_status: "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"',
+      );
     });
 
     it("should write ems__Effort_area when parent is an Area", async () => {
@@ -1213,9 +1217,12 @@ describe("createAsset — orphan prevention regression (Finding 2)", () => {
       new RegExp(`ems__Effort_area:\\s*"\\[\\[${PARENT_AREA_UID}`),
     );
 
-    // 4. Effort_status must default (Backlog or Draft) so task is queryable
+    // 4. Effort_status must default (Backlog or Draft UUID) so task is queryable.
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194).
+    // Backlog: 753a44d5-846c-4b82-9196-4fd9a4d48777
+    // Draft:   c42245d0-01de-4c35-bfcf-d910445ea28e
     expect(frontmatter).toMatch(
-      /ems__Effort_status:\s*"\[\[ems__EffortStatus(Backlog|Draft)\]\]"/,
+      /ems__Effort_status:\s*"\[\[(753a44d5-846c-4b82-9196-4fd9a4d48777|c42245d0-01de-4c35-bfcf-d910445ea28e)\]\]"/,
     );
 
     // 5. Asset_isDefinedBy must inherit from parent

--- a/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
@@ -144,9 +144,14 @@ describe("PropertySchemas", () => {
       expect(labels).toContain("Trashed");
     });
 
-    it("should have wikilink format values", () => {
+    it("should have UUID-form wikilink values (RFC 31c1a0be Phase 4 PR-C)", () => {
       for (const status of FALLBACK_EFFORT_STATUS_VALUES) {
-        expect(status.value).toMatch(/^\[\[ems__EffortStatus\w+\]\]$/);
+        expect(status.value).toMatch(
+          /^\[\[[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\]\]$/,
+        );
+        expect(status.wikilink).toMatch(
+          /^\[\[[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\|.+\]\]$/,
+        );
       }
     });
   });

--- a/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
@@ -625,5 +625,17 @@ describe("PropertySchemas", () => {
       expect(getStatusLabel("[[ems__EffortStatusDone 7b9b3116-7c3c-438c-9618-94fe301320a6]]")).toBe("Done");
       expect(getStatusLabel("ems__EffortStatusBacklog 753a44d5-846c-4b82-9196-4fd9a4d48777")).toBe("Backlog");
     });
+
+    it("should return human-readable label for UUID-form wikilink (RFC 31c1a0be PR-C)", () => {
+      expect(getStatusLabel("[[027e78f4-6e16-4b36-b8fb-5510507d5745]]")).toBe("Doing");
+      expect(getStatusLabel("[[7b9b3116-7c3c-438c-9618-94fe301320a6]]")).toBe("Done");
+      expect(getStatusLabel("[[753a44d5-846c-4b82-9196-4fd9a4d48777]]")).toBe("Backlog");
+      expect(getStatusLabel("[[c42245d0-01de-4c35-bfcf-d910445ea28e]]")).toBe("Draft");
+    });
+
+    it("should return human-readable label for UUID-form wikilink with alias", () => {
+      expect(getStatusLabel("[[027e78f4-6e16-4b36-b8fb-5510507d5745|Doing]]")).toBe("Doing");
+      expect(getStatusLabel("[[7b9b3116-7c3c-438c-9618-94fe301320a6|Done]]")).toBe("Done");
+    });
   });
 });

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -72,8 +72,13 @@ export function createCreateRelatedTaskService(
         {};
       const folderPath = parentFile.parent?.path || "";
 
+      // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Draft UUID is the
+      // canonical TBox identifier at
+      // assetspaces/ems/c42245d0-01de-4c35-bfcf-d910445ea28e.md. Mirrors the
+      // obsidian-plugin ServiceRegistryPopulator default-write migration.
       const propertyValues: Record<string, unknown> = {
-        ems__Effort_status: '"[[ems__EffortStatusDraft]]"',
+        ems__Effort_status:
+          '"[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"',
       };
 
       const explicitParentProperty = userInput?.parentProperty as
@@ -113,8 +118,13 @@ export function createCreateRelatedProjectService(
         {};
       const folderPath = parentFile.parent?.path || "";
 
+      // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Draft UUID is the
+      // canonical TBox identifier at
+      // assetspaces/ems/c42245d0-01de-4c35-bfcf-d910445ea28e.md. Mirrors the
+      // obsidian-plugin ServiceRegistryPopulator default-write migration.
       const propertyValues: Record<string, unknown> = {
-        ems__Effort_status: '"[[ems__EffortStatusDraft]]"',
+        ems__Effort_status:
+          '"[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"',
       };
 
       const explicitParentProperty = userInput?.parentProperty as


### PR DESCRIPTION
## Summary

Phase 4 PR-C of RFC 31c1a0be (issue #3194). Migrate non-parser consumer
surfaces that emit/check symbolic `ems__EffortStatus*` strings to
UUID-canon form. Stage 5 (parser/RDF infrastructure: `EffortStatus.ts`,
`EffortStatusConfig.ts`, `SPARQLTemplateLibrary.ts`,
`NoteToRDFConverter.ts`, `GroundingExecutor.ts` BC fallback) is
explicitly left untouched.

### Migrated (4 files)

- **`PropertySchemas.ts`** — `FALLBACK_EFFORT_STATUS_VALUES` now
  UUID-form; `getStatusLabel` accepts both UUID-form (via
  `EFFORT_STATUS_VALUES`) and the legacy symbolic-form (via a small
  fallback map) so stale vault values still render the human label.
- **`ServiceRegistryPopulator.ts`** — three default `ems__Effort_status`
  writes (`createPrototypeInstance`, `createRelatedTask`,
  `createRelatedProject`) now emit `[[<UUID>]]`. Closes the 42-asset
  symbolic-form trace called out in the original Phase 4 plan §"active-bug fix".
- **`TaskTrackingService.ts`** — iOS Live Activities `isDoingStatus`
  check now accepts UUID-form (keeps symbolic as transitional fallback so
  existing tasker workflows still trigger); Advanced URI callback URL now
  writes UUID-form Done so iOS completion writes UUID-canon.
- **`DynamicAssetCreationModal.ts`** — `statusOptions` UUID-form. The
  legacy literals used `ems__EffortStatus_Draft` (with underscore) which
  never matched any vault asset — incidental fix-forward.

### Descoped (cascade-cap, per Stage 3 lesson)

- **`WorkflowCommandAdapter.ts`** — depends on the `EffortStatus` enum
  (Phase 5 territory) for `shortStatus`, ID generation, and SPARQL ASK
  precondition string. Migration would cascade through the enum,
  `WorkflowDefinition`, `WorkflowEngine`, `WorkflowResolver`,
  `DefaultWorkflows`, `VisibilityGenerator`, `EffortVisibilityRules`,
  `ProjectVisibilityRules`, plus tests — well above the 15-caller cap.
  JSDoc note added.
- **`KanbanColumnProvider.ts`** — `statusToLabel` structurally tied to
  the symbolic `EffortStatus` enum. JSDoc note added.

### Tests

- `packages/obsidian-plugin/tests/unit` — 238/238 suites pass
  (4909/4912 tests, 3 pre-existing skips).
- `packages/exocortex` targeted suites — `WorkflowCommandAdapter` and
  `KanbanColumnProvider` 41/41 pass.
- 7 exocortex suite failures observed on this branch are pre-existing
  on `origin/main` (verified by stash-pop test); unrelated to PR-C scope.

## Test plan

- [x] `npx jest --config packages/obsidian-plugin/jest.config.js packages/obsidian-plugin/tests/unit --runInBand` → 238/238 pass
- [x] `npx jest --config packages/exocortex/jest.config.js packages/exocortex/tests/unit/services/WorkflowCommandAdapter.test.ts packages/exocortex/tests/unit/services/KanbanColumnProvider.test.ts --runInBand` → 41/41 pass
- [x] `npm run check:types` → clean
- [x] `npm run lint` → 2 pre-existing warnings, 0 errors
- [x] Pre-commit archgate + BDD coverage gates → pass

Closes #3194 — Phase 4 PR-C scope only. Stage 5 follow-up tracks parser/RDF infrastructure removal.