### PR TITLE
feat: Phase 5a remove BC fallback in GroundingExecutor.executePropertySet (RFC 31c1a0be #3194)

### DIFF
--- a/packages/cli/specs/step_definitions/grounding.steps.ts
+++ b/packages/cli/specs/step_definitions/grounding.steps.ts
@@ -151,12 +151,20 @@ function readGroundingDef(uid: string, depth = 0): GroundingDefinition {
       // fail loud at executor layer if needed
     }
   }
+  // RFC 31c1a0be Phase 5a — typed predicates required for property_set.
+  // targetValueRef stored as wikilink-form `"[[uuid]]"` in frontmatter;
+  // unwrap to bare UID so executor re-wraps for emission.
+  const rawTargetValueRef = fm["exocmd__Grounding_targetValueRef"] as string | undefined;
+  const targetValueRef = rawTargetValueRef ? normalizeWikilink(rawTargetValueRef) : undefined;
   return {
     id: uid,
     label: (fm["exo__Asset_label"] as string) ?? "",
     type,
     targetProperty,
     targetValue: fm["exocmd__Grounding_targetValue"] as string | undefined,
+    targetValueRef,
+    targetValueLiteral: fm["exocmd__Grounding_targetValueLiteral"] as string | undefined,
+    targetValueSubstitution: fm["exocmd__Grounding_targetValueSubstitution"] as string | undefined,
     targetClass: fm["exocmd__Grounding_targetClass"] as string | undefined,
     targetPrototype: fm["exocmd__Grounding_targetPrototype"] as string | undefined,
     targetFolder: fm["exocmd__Grounding_targetFolder"] as string | undefined,

--- a/packages/cli/tests/integration/starter-kit/test-helpers/execute-command.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/execute-command.ts
@@ -127,6 +127,9 @@ export function toGroundingDefinition(
     type,
     targetProperty,
     targetValue: data.targetValue,
+    targetValueRef: data.targetValueRef,
+    targetValueLiteral: data.targetValueLiteral,
+    targetValueSubstitution: data.targetValueSubstitution,
     targetClass: data.targetClass,
     steps,
   };

--- a/packages/cli/tests/integration/starter-kit/test-helpers/extract-target-class.ts
+++ b/packages/cli/tests/integration/starter-kit/test-helpers/extract-target-class.ts
@@ -63,6 +63,10 @@ export interface GroundingData {
   readonly type?: string;
   readonly targetProperty?: string;
   readonly targetValue?: string;
+  /** RFC 31c1a0be: typed predicates for property_set (replace legacy `targetValue`). */
+  readonly targetValueRef?: string;
+  readonly targetValueLiteral?: string;
+  readonly targetValueSubstitution?: string;
   readonly serviceId?: string;
   readonly inputSchema?: string;
   readonly targetClass?: string;
@@ -235,12 +239,18 @@ function buildGroundingData(
     const stepFm = fmMap.get(stepUid);
     if (stepFm) steps.push(buildGroundingData(stepUid, stepFm, fmMap));
   }
+  // RFC 31c1a0be: targetValueRef is stored wikilink-form "[[uuid]]" → unwrap
+  const rawRef = asString(fm["exocmd__Grounding_targetValueRef"]);
+  const targetValueRef = rawRef ? unwrapWikilink(rawRef) : undefined;
   return {
     uid,
     label,
     type: asString(fm["exocmd__Grounding_type"]),
     targetProperty: asString(fm["exocmd__Grounding_targetProperty"]),
     targetValue: asString(fm["exocmd__Grounding_targetValue"]),
+    targetValueRef,
+    targetValueLiteral: asString(fm["exocmd__Grounding_targetValueLiteral"]),
+    targetValueSubstitution: asString(fm["exocmd__Grounding_targetValueSubstitution"]),
     serviceId: asString(fm["exocmd__Grounding_serviceId"]),
     inputSchema: asString(fm["exocmd__Grounding_inputSchema"]),
     targetClass: asString(fm["exocmd__Grounding_targetClass"]),

--- a/packages/cli/tests/unit/test-helpers/execute-command.test.ts
+++ b/packages/cli/tests/unit/test-helpers/execute-command.test.ts
@@ -233,7 +233,7 @@ describe("executeCommandHarness (real GroundingExecutor end-to-end)", () => {
           label: "Set Status",
           type: "property_set",
           targetProperty: "ems__Effort_status",
-          targetValue: `"[[ems__EffortStatusDoing]]"`,
+          targetValueRef: "ems__EffortStatusDoing",
           raw: {},
         },
         filePath,

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -87,9 +87,11 @@ export interface GroundingDefinition {
    *  resolved by CommandResolver to the property's `exo__Asset_label` before
    *  reaching here. RFC 31c1a0be Phase 3: never bare UUID. */
   readonly targetProperty?: string;
-  /** Legacy single-value for property_set. RFC 31c1a0be Phase 3: still read
-   *  for backward-compat (warn-log fires); new groundings use one of
-   *  `targetValueRef` / `targetValueLiteral` / `targetValueSubstitution`. */
+  /** Single-value payload for service_call (createAsset/updateProperty JSON
+   *  config, class-flip dispatch) and property_append (value to append).
+   *  RFC 31c1a0be Phase 5a removed the BC fallback in property_set — for
+   *  property_set use `targetValueRef` / `targetValueLiteral` /
+   *  `targetValueSubstitution`. */
   readonly targetValue?: string;
   /** RFC 31c1a0be Phase 1: typed RDF reference to the value asset. When set,
    *  emits `"[[<UID>]]"` wikilink as the property_set value. Mutually exclusive

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -927,7 +927,7 @@ export class CommandResolver {
     if (substitutionRefRaw && this.looksLikeUUID(substitutionRefRaw)) {
       // Fail-loud: same pattern as targetProperty above. Missing/labelless
       // SubstitutionToken instance → skip grounding rather than silently
-      // dropping the substitution and falling through to legacy targetValue.
+      // dropping the substitution.
       const resolved = await this.resolveLabelByUID(substitutionRefRaw);
       if (!resolved) {
         this.logger.warn(

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -281,7 +281,7 @@ export class GroundingExecutor {
       return {
         success: false,
         error:
-          "property_set: targetValue contains $input/$value placeholder but no userInput.value provided",
+          "property_set: substituted value contains $input/$value placeholder but no userInput.value provided",
       };
     }
 

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -239,8 +239,7 @@ export class GroundingExecutor {
       return { success: false, error: "property_set requires targetProperty" };
     }
 
-    // RFC 31c1a0be Phase 3 dispatch — typed predicates take priority over
-    // legacy `targetValue`. Priority: Ref > Literal > Substitution > legacy.
+    // RFC 31c1a0be Phase 5a — typed predicates only.
     // Multiple typed predicates simultaneously = fail-loud (RFC §4 cardinality).
     let effectiveValue: string | undefined;
     const typedFieldsSet = [
@@ -261,17 +260,11 @@ export class GroundingExecutor {
       effectiveValue = grounding.targetValueLiteral;
     } else if (grounding.targetValueSubstitution !== undefined) {
       effectiveValue = grounding.targetValueSubstitution;
-    } else if (grounding.targetValue !== undefined) {
-      // RFC 31c1a0be Phase 3 backward-compat fallback. Phase 5 removes this branch.
-      effectiveValue = grounding.targetValue;
-      LoggingService.warn(
-        `[legacy] Grounding ${grounding.id ?? "(unknown)"} uses deprecated exocmd__Grounding_targetValue — migrate to typed predicate (Ref/Literal/Substitution) per RFC 31c1a0be`,
-      );
     } else {
       return {
         success: false,
         error:
-          "property_set requires one of targetValueRef/targetValueLiteral/targetValueSubstitution (or legacy targetValue)",
+          "property_set requires one of targetValueRef/targetValueLiteral/targetValueSubstitution",
       };
     }
 

--- a/packages/exocortex/tests/integration/smoke/vault-commands-pipeline.test.ts
+++ b/packages/exocortex/tests/integration/smoke/vault-commands-pipeline.test.ts
@@ -124,6 +124,9 @@ async function seedCommand(
     gndType: string;
     gndTargetProperty?: string;
     gndTargetValue?: string;
+    gndTargetValueRef?: string;
+    gndTargetValueLiteral?: string;
+    gndTargetValueSubstitution?: string;
     bindUid: string;
     bindTargetClass: string;
     bindPosition?: string;
@@ -159,6 +162,21 @@ async function seedCommand(
   if (opts.gndTargetValue) {
     gndTriples.push(
       new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_targetValue"), new Literal(opts.gndTargetValue)),
+    );
+  }
+  if (opts.gndTargetValueRef) {
+    gndTriples.push(
+      new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_targetValueRef"), new Literal(opts.gndTargetValueRef)),
+    );
+  }
+  if (opts.gndTargetValueLiteral) {
+    gndTriples.push(
+      new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_targetValueLiteral"), new Literal(opts.gndTargetValueLiteral)),
+    );
+  }
+  if (opts.gndTargetValueSubstitution) {
+    gndTriples.push(
+      new Triple(gndSubject, Namespace.EXOCMD.term("Grounding_targetValueSubstitution"), new Literal(opts.gndTargetValueSubstitution)),
     );
   }
   await store.addAll(gndTriples);
@@ -266,7 +284,7 @@ describe("Smoke: Vault Commands Pipeline (all categories)", () => {
           gndUid: `gnd-${cmd.uid}`,
           gndType: "property_set",
           gndTargetProperty: "ems__Effort_status",
-          gndTargetValue: `'[[${cmd.to}]]'`,
+          gndTargetValueRef: cmd.to,
           bindUid: `bind-${cmd.uid}`,
           bindTargetClass: "ems__Task",
           bindPosition: "header",
@@ -335,7 +353,7 @@ describe("Smoke: Vault Commands Pipeline (all categories)", () => {
           gndUid: `gnd-${z.uid}`,
           gndType: "property_set",
           gndTargetProperty: "ems__Effort_zone",
-          gndTargetValue: z.zone,
+          gndTargetValueLiteral: z.zone,
           bindUid: `bind-${z.uid}`,
           bindTargetClass: "ems__Task",
           bindPosition: "header",
@@ -377,7 +395,7 @@ describe("Smoke: Vault Commands Pipeline (all categories)", () => {
         gndUid: "gnd-set-deadline",
         gndType: "property_set",
         gndTargetProperty: "ems__Effort_plannedEndTimestamp",
-        gndTargetValue: "$now",
+        gndTargetValueSubstitution: "$now",
         bindUid: "bind-set-deadline",
         bindTargetClass: "ems__Task",
         bindGroup: "planning",
@@ -567,7 +585,7 @@ describe("Smoke: Vault Commands Pipeline (all categories)", () => {
         gndUid: "gnd-status-x",
         gndType: "property_set",
         gndTargetProperty: "ems__Effort_status",
-        gndTargetValue: "done",
+        gndTargetValueLiteral: "done",
         bindUid: "bind-status-x",
         bindTargetClass: "ems__Task",
         bindOrder: "10",

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -61,7 +61,7 @@ describe("GroundingExecutor", () => {
       const grounding = makeGrounding({
         type: GroundingType.PROPERTY_SET,
         targetProperty: "ems__status",
-        targetValue: "Done",
+        targetValueLiteral: "Done",
       });
 
       const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
@@ -78,7 +78,7 @@ describe("GroundingExecutor", () => {
       const grounding = makeGrounding({
         type: GroundingType.PROPERTY_SET,
         targetProperty: "ems__Effort_startTimestamp",
-        targetValue: "$now",
+        targetValueSubstitution: "$now",
       });
 
       const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
@@ -96,7 +96,7 @@ describe("GroundingExecutor", () => {
       const grounding = makeGrounding({
         type: GroundingType.PROPERTY_SET,
         targetProperty: "due_date",
-        targetValue: "$today",
+        targetValueSubstitution: "$today",
       });
 
       const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
@@ -112,7 +112,7 @@ describe("GroundingExecutor", () => {
       const grounding = makeGrounding({
         type: GroundingType.PROPERTY_SET,
         targetProperty: "linked_from",
-        targetValue: "$target",
+        targetValueSubstitution: "$target",
       });
 
       const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
@@ -125,7 +125,7 @@ describe("GroundingExecutor", () => {
     it("should fail when targetProperty is missing", async () => {
       const grounding = makeGrounding({
         type: GroundingType.PROPERTY_SET,
-        targetValue: "value",
+        targetValueLiteral: "value",
       });
 
       const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
@@ -134,7 +134,7 @@ describe("GroundingExecutor", () => {
       expect(result.error).toContain("targetProperty");
     });
 
-    it("should fail when targetValue is undefined", async () => {
+    it("should fail when no typed predicate is provided", async () => {
       const grounding = makeGrounding({
         type: GroundingType.PROPERTY_SET,
         targetProperty: "prop",
@@ -143,7 +143,9 @@ describe("GroundingExecutor", () => {
       const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain("targetValue");
+      expect(result.error).toContain(
+        "targetValueRef/targetValueLiteral/targetValueSubstitution",
+      );
     });
 
     // RFC 31c1a0be Phase 3 — typed predicate dispatch
@@ -204,7 +206,7 @@ describe("GroundingExecutor", () => {
         expect(result.error).toContain("more than one");
       });
 
-      it("legacy targetValue still works (backward-compat fallback)", async () => {
+      it("rejects property_set with only legacy targetValue (no typed predicate) — RFC 31c1a0be Phase 5a", async () => {
         reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
         const grounding = makeGrounding({
           type: GroundingType.PROPERTY_SET,
@@ -212,24 +214,10 @@ describe("GroundingExecutor", () => {
           targetValue: '"[[ems__EffortStatusDone]]"',
         });
         const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
-        expect(result.success).toBe(true);
-        const written = writer.updateFile.mock.calls[0][1];
-        expect(written).toContain('ems__legacy_status:');
-      });
-
-      it("typed predicate wins over legacy targetValue (priority)", async () => {
-        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
-        const grounding = makeGrounding({
-          type: GroundingType.PROPERTY_SET,
-          targetProperty: "ems__foo",
-          targetValueLiteral: "from-typed",
-          targetValue: "from-legacy",
-        });
-        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
-        expect(result.success).toBe(true);
-        const written = writer.updateFile.mock.calls[0][1];
-        expect(written).toContain("ems__foo: from-typed");
-        expect(written).not.toContain("from-legacy");
+        expect(result.success).toBe(false);
+        expect(result.error).toContain(
+          "property_set requires one of targetValueRef/targetValueLiteral/targetValueSubstitution",
+        );
       });
     });
   });
@@ -292,12 +280,12 @@ describe("GroundingExecutor", () => {
           makeGrounding({
             type: GroundingType.PROPERTY_SET,
             targetProperty: "status",
-            targetValue: "Doing",
+            targetValueLiteral: "Doing",
           }),
           makeGrounding({
             type: GroundingType.PROPERTY_SET,
             targetProperty: "ems__Effort_startTimestamp",
-            targetValue: "$now",
+            targetValueSubstitution: "$now",
           }),
         ],
       });
@@ -320,12 +308,12 @@ describe("GroundingExecutor", () => {
           makeGrounding({
             type: GroundingType.PROPERTY_SET,
             targetProperty: "status",
-            targetValue: "Doing",
+            targetValueLiteral: "Doing",
           }),
           makeGrounding({
             type: GroundingType.PROPERTY_SET,
             // Missing targetProperty → will fail
-            targetValue: "broken",
+            targetValueLiteral: "broken",
           }),
         ],
       });
@@ -367,7 +355,7 @@ describe("GroundingExecutor", () => {
       let innermost = makeGrounding({
         type: GroundingType.PROPERTY_SET,
         targetProperty: "foo",
-        targetValue: "bar",
+        targetValueLiteral: "bar",
       });
 
       for (let i = 0; i < 25; i++) {
@@ -1684,7 +1672,7 @@ describe("GroundingExecutor", () => {
         const grounding = makeGrounding({
           type: GroundingType.PROPERTY_SET,
           targetProperty: "ems__status",
-          targetValue: "Done",
+          targetValueLiteral: "Done",
         });
 
         const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
@@ -1785,7 +1773,7 @@ describe("substituteVariables — $input/$value user-input resolution (Findings 
     // Mirrors vault grounding 85687461-* (Set Planned Start)
     const grounding = makeGrounding({
       targetProperty: "ems__Effort_plannedStartTimestamp",
-      targetValue: "$input",
+      targetValueSubstitution: "$input",
     });
     const userInput = { value: "2026-04-19T10:00:00+0500" };
 
@@ -1809,7 +1797,7 @@ describe("substituteVariables — $input/$value user-input resolution (Findings 
     // Mirrors vault grounding c4616dcd-* (Set Result)
     const grounding = makeGrounding({
       targetProperty: "ems__Effort_result",
-      targetValue: "$value",
+      targetValueSubstitution: "$value",
     });
     const userInput = { value: "Completed successfully" };
 
@@ -1829,7 +1817,7 @@ describe("substituteVariables — $input/$value user-input resolution (Findings 
   it("fails loudly (does NOT silently write literal) when $input placeholder present but no userInput provided", async () => {
     const grounding = makeGrounding({
       targetProperty: "ems__Effort_plannedStartTimestamp",
-      targetValue: "$input",
+      targetValueSubstitution: "$input",
     });
 
     const result = await executor.execute(
@@ -1884,7 +1872,7 @@ describe("substituteVariables — $input/$value user-input resolution (Findings 
     async (_label, property, placeholder, sampleValue) => {
       const grounding = makeGrounding({
         targetProperty: property,
-        targetValue: placeholder,
+        targetValueSubstitution: placeholder,
       });
       const userInput = { value: sampleValue };
 

--- a/packages/obsidian-plugin/tests/e2e/test-vault/03 Knowledge/commands/gnd-set-status-doing.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/03 Knowledge/commands/gnd-set-status-doing.md
@@ -6,5 +6,5 @@ exo__Instance_class:
   - "[[exocmd__Grounding]]"
 exocmd__Grounding_type: "property_set"
 exocmd__Grounding_targetProperty: "ems__Effort_status"
-exocmd__Grounding_targetValue: '"[[ems__EffortStatusDoing]]"'
+exocmd__Grounding_targetValueRef: "[[ems__EffortStatusDoing]]"
 ---

--- a/packages/obsidian-plugin/tests/e2e/test-vault/03 Knowledge/commands/gnd-set-status-done.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/03 Knowledge/commands/gnd-set-status-done.md
@@ -6,5 +6,5 @@ exo__Instance_class:
   - "[[exocmd__Grounding]]"
 exocmd__Grounding_type: "property_set"
 exocmd__Grounding_targetProperty: "ems__Effort_status"
-exocmd__Grounding_targetValue: '"[[ems__EffortStatusDone]]"'
+exocmd__Grounding_targetValueRef: "[[ems__EffortStatusDone]]"
 ---

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/planning/22a6ba6b-030a-47e4-946e-1a30dc9450e5.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/planning/22a6ba6b-030a-47e4-946e-1a30dc9450e5.md
@@ -6,7 +6,7 @@ exo__Instance_class:
   - "[[exocmd__Grounding]]"
 exocmd__Grounding_type: "property_set"
 exocmd__Grounding_targetProperty: "ems__Effort_plannedStartTimestamp"
-exocmd__Grounding_targetValue: "$todayStart"
+exocmd__Grounding_targetValueSubstitution: "$todayStart"
 aliases:
   - "Plan on today (declarative)"
 ---

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/95dfbcad-daca-47aa-8788-74e09f6b10a1.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/95dfbcad-daca-47aa-8788-74e09f6b10a1.md
@@ -6,7 +6,7 @@ exo__Instance_class:
   - "[[exocmd__Grounding]]"
 exocmd__Grounding_type: "property_set"
 exocmd__Grounding_targetProperty: "ems__Effort_startTimestamp"
-exocmd__Grounding_targetValue: "$nowLocal"
+exocmd__Grounding_targetValueSubstitution: "$nowLocal"
 aliases:
   - "Set ems__Effort_startTimestamp to $nowLocal"
 ---

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/d5deac7a-149d-43a1-b249-875d91834b60.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/d5deac7a-149d-43a1-b249-875d91834b60.md
@@ -6,7 +6,7 @@ exo__Instance_class:
   - "[[exocmd__Grounding]]"
 exocmd__Grounding_type: "property_set"
 exocmd__Grounding_targetProperty: "ems__Effort_status"
-exocmd__Grounding_targetValue: '"[[ems__EffortStatusDoing]]"'
+exocmd__Grounding_targetValueRef: "[[ems__EffortStatusDoing]]"
 aliases:
   - "Set status to Doing"
 ---


### PR DESCRIPTION
## Summary

RFC 31c1a0be Phase 5a: removes the legacy `targetValue` backward-compat fallback in `GroundingExecutor.executePropertySet`. After Phase 2 migration (PR #7 in `exocortex-exocmd-ontology`) and Phase 4 PR-A/B/C consumer migrations, no `property_set` grounding still depends on legacy `targetValue` — verified by Stage 1 6/6 PASS + Stage 4 orchestrator UI smoke on v16.11.0 (Mark Done writes UUID-form Done + endTimestamp + resolutionTimestamp).

## Changes

- **`GroundingExecutor.executePropertySet`**: delete `else if (grounding.targetValue !== undefined)` branch + `[legacy]` warn-log. Update final `else` error message — no `(or legacy targetValue)` suffix.
- **`GroundingExecutor.test.ts`**: replace 2 BC tests ("legacy targetValue still works", "typed predicate wins over legacy targetValue") with 1 fail-loud test verifying property_set rejects groundings with only legacy `targetValue`. Migrate property_set / composite / \$input / \$value test fixtures (~15 callsites) from `targetValue` to typed predicates (`targetValueLiteral` / `targetValueSubstitution`).
- **`vault-commands-pipeline.test.ts`** (integration smoke): extend `seedCommand` helper to accept `gndTargetValueRef/Literal/Substitution`. Migrate 4 `property_set` callsites (status / criticality / planning / cross-category) from legacy `gndTargetValue` to typed predicates.
- **`CommandResolver.ts`**: update stale comment about "falling through to legacy targetValue" (the fallback no longer exists).

## Out of scope (deferred to follow-up sessions)

⚠️ **Property asset delete is NOT in this PR** (originally Stage 5a Step B). Audit revealed 16 vault groundings still actively use `exocmd__Grounding_targetValue` for non-property_set purposes:

- **15 `service_call` groundings** (createAsset/updateProperty) — `targetValue` carries JSON config payload (`{"property":"..."}`, `{"prototype":"$target","instanceClass":"...","folder":"..."}`)
- **1 `property_append` grounding** — `targetValue` carries the value to append (`$target.exo__Asset_label`)

These usages are **outside RFC 31c1a0be Phase 2 migration scope** (which targeted only `property_set` semantic via `targetValueRef/Literal/Substitution`). Deleting the property asset now would break the service_call/property_append code paths in `GroundingExecutor` (lines 437, 479-494, 874-887). Requires separate RFC scoping the non-property_set `targetValue` uses.

Other Stage 5b items also deferred: EffortStatusConfig.ts / EffortStatus.ts / SPARQLTemplateLibrary EFFORT_STATUSES cleanup, NoteToRDFConverter expandClassValue migration, 25-29 caller cascade, historical 4989 ABox migration.

## Test plan

- [x] `npx jest packages/exocortex/tests/unit/services/GroundingExecutor.test.ts` — 110/110 PASS
- [x] `npx jest packages/exocortex/tests/unit/services/CommandResolver.test.ts` — PASS
- [x] `npx jest packages/exocortex/tests/integration/smoke/vault-commands-pipeline.test.ts` — 14/14 PASS
- [x] `npx jest --config packages/obsidian-plugin/jest.config.js` — 4912/4912 PASS
- [x] `npm run check:types` — clean
- [x] `npm run lint` — only 2 pre-existing warnings
- [x] Full `packages/exocortex` suite: 7521 passed, 8 pre-existing failures unrelated to BC removal (verified by `git stash` baseline check)
- [ ] CI required checks green (gate)
- [ ] Post-merge: UI smoke (Start Effort / Mark Done) on new release — happens after merge

## Acceptance

- No production behavior change for property_set groundings (no remaining legacy users)
- Fail-loud regression test guarantees property_set without typed predicate is rejected
- Reduces 6 lines of dispatch + warn-log + LoggingService noise from hot path