### PR TITLE
docs(CLAUDE.md): add Auto-merge discipline + Cross-repo migration RFC checklist (post-mortem RFC 31c1a0be)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,55 @@ gh pr merge --auto --squash                         # Wait for 14 required CI ch
 
 **Task is NOT complete until**: CI green + PR merged + Auto Release succeeds + post-mortem written.
 
+## Auto-merge discipline (CRITICAL)
+
+For PRs touching parser / TBox / schema / migration paths
+(`packages/exocortex/src/services/{CommandResolver,GroundingExecutor,NoteToRDFConverter}.ts`,
+`assetspaces/*/*.md` in any cloned ontology repo):
+
+⛔ **Do NOT use `gh pr merge --auto`.**
+
+Required workflow:
+
+1. Push PR
+2. Wait for CI green AND code-reviewer agent complete (run via Agent tool, `subagent_type=code-reviewer`)
+3. Apply CRITICAL / HIGH fixes
+4. Call `advisor()` AFTER applying fixes — round-2 catches cross-finding
+   interactions that the reviewer documented as «deferred / low risk»
+5. Apply advisor catches
+6. THEN `gh pr merge --squash --delete-branch` (manual, no `--auto`)
+
+**Empirical reference (RFC 31c1a0be Phase 3):** PR #3197 auto-merged before
+code-reviewer finished → 2 HIGH fail-open paths shipped → required hotfix
+PR #3198 (fail-loud guards) + root-cause PR #3199 (predicate-scoped bypass
+in `NoteToRDFConverter.valueToRDFObject:953-983`). Two-iteration discipline
+on subsequent PRs (#3201, #3203, #3204) caught issues pre-merge — zero
+follow-up hotfixes needed.
+
+## Cross-repo migration RFC checklist
+
+For RFCs migrating vault data (typed predicates, property renames,
+value-format shifts) — pre-flight audit MUST enumerate ALL repos with
+affected assets:
+
+```bash
+for repo in exocortex exocortex-starter-kit exocortex-public-ontologies; do
+  echo "=== $repo ==="
+  cd ~/Developer/exocortex-development/$repo 2>/dev/null || continue
+  grep -rln '<deprecated-predicate>:' . 2>/dev/null | head -20
+done
+```
+
+If any repo has matches → its migration is in scope. **Don't assume
+«pilot/sample/getting-started repo isn't real production data»** — empirical
+signal: RFC 31c1a0be Phase 2 missed starter-kit; surface bug appeared during
+Phase 5a BC removal as CI red (`test-bdd` 19 fail + `test-coverage-cli`),
+required fix-forward cascade (PR #98 starter-kit Phase 2 + PR #99 dangling
+binding + CLI helpers + 5 e2e fixture migrations + 2 submodule bumps).
+
+Add cross-repo audit results to the RFC body BEFORE Phase 1 starts. Saves a
+fix-forward session 3 phases later.
+
 ## RFC Execution: Audit-First Strategy
 
 Before starting any RFC Phase, audit existing codebase for pre-implemented features:


### PR DESCRIPTION
## Summary

Two new sections in `exocortex/CLAUDE.md` codifying empirical lessons from RFC 31c1a0be Phase 3-5a overnight run.

User approved 2026-05-20 morning. Source: `/Users/kitelev/Developer/postmortem-rfc-31c1a0be-phase-3-to-5a-2026-05-20.md` §Documentation Improvements Proposed.

## Additions

### 1. Auto-merge discipline (CRITICAL)

Disables `gh pr merge --auto` for PRs touching parser / TBox / schema / migration paths. Required: code-reviewer agent + advisor() round AFTER fixes, manual merge.

**Empirical reference:** PR #3197 auto-merged before code-reviewer finished → 2 HIGH fail-open paths shipped → required hotfix PR #3198 + root-cause PR #3199. Subsequent PRs #3201/#3203/#3204 applying two-iteration discipline shipped clean.

### 2. Cross-repo migration RFC checklist

Pre-flight grep across all `exocortex*` repos for deprecated predicates BEFORE Phase 1.

**Empirical reference:** RFC 31c1a0be Phase 2 missed starter-kit → surfaced as Phase 5a CI red → required fix-forward cascade (PR #98 starter-kit Phase 2 + PR #99 dangling binding + CLI helpers + 5 e2e fixture migrations + 2 submodule bumps).

## Test plan

- [x] Markdown valid
- [ ] CI green
- [ ] Manual review (no functional change — docs only)