### PR TITLE
feat(rename-to-uid): collapse wikilinks to [[uid]] + always append alias

### DIFF
--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -293,10 +293,10 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
   }
 
   /**
-   * Rewrites inbound wikilinks pointing at `oldBasename` so they target the
-   * new file's basename, preserving the original basename as the display
-   * alias (UID-form convention). Honors fenced/inline code-block exclusion
-   * and skips the file being renamed itself. Issue #3113.
+   * Rewrites inbound wikilinks pointing at `oldBasename` so they collapse to a
+   * bare `[[newBasename]]` — display label is resolved at render time from the
+   * target's `exo__Asset_label`. Honors fenced/inline code-block exclusion and
+   * skips the file being renamed itself. Issue #3113.
    */
   async updateLinks(
     oldPath: string,

--- a/packages/cli/src/utils/wikilinkRewriter.ts
+++ b/packages/cli/src/utils/wikilinkRewriter.ts
@@ -16,14 +16,18 @@ export interface RewriteResult {
 }
 
 /**
- * Rewrites inbound wikilinks pointing to `oldBasename` so they target
- * `newBasename` while preserving the original basename as the display alias.
+ * Rewrites inbound wikilinks pointing to `oldBasename` so they collapse to a
+ * bare `[[newBasename]]`. Display label is resolved at render time from the
+ * target's `exo__Asset_label`; the old basename is preserved in the target's
+ * frontmatter `aliases:` array by RenameToUidService.
  *
- * Shapes handled (Issue #3113 AC):
- *   [[OldName]]                 -> [[NewBase|OldName]]
- *   [[OldName|Display]]         -> [[NewBase|Display]]
- *   [[OldName#Heading]]         -> [[NewBase#Heading|OldName]]
- *   [[OldName#Heading|Display]] -> [[NewBase#Heading|Display]]
+ * Shapes handled (all collapse to [[NewBase]]):
+ *   [[OldName]]                 -> [[NewBase]]
+ *   [[OldName|Display]]         -> [[NewBase]]
+ *   [[OldName#Heading]]         -> [[NewBase]]
+ *   [[OldName#Heading|Display]] -> [[NewBase]]
+ *   [[OldName^block]]           -> [[NewBase]]
+ *   [[OldName^block|Display]]   -> [[NewBase]]
  *
  * Skips fenced code blocks (``` … ```), inline code (` … `), and embeds (`![[…]]`).
  * Skips the renamed file itself via `excludeRelPath`.
@@ -134,31 +138,19 @@ function replaceWikilinks(
   newBasename: string,
 ): { updated: string; replacements: number } {
   // (?<!!) — exclude embeds ![[...]]
-  // Group 1: link target (no |, #, ], [, newline)
-  // Group 2: optional #heading (without |)
-  // Group 3: optional |display
-  const regex = /(?<!!)\[\[([^\[\]\n|#]+)(#[^\[\]\n|]*)?(\|[^\[\]\n]*)?\]\]/g;
+  // Group 1: link target (no |, #, ^, ], [, newline)
+  // Optional non-capturing groups for heading / block / alias — all dropped.
+  // All shapes collapse to bare [[newBasename]]; display alias is resolved
+  // at render time from the target's exo__Asset_label.
+  const regex =
+    /(?<!!)\[\[([^\[\]\n|#^]+)(?:[#^][^\[\]\n|]*)?(?:\|[^\[\]\n]*)?\]\]/g;
   let replacements = 0;
 
-  const updated = text.replace(regex, (match, target, heading, alias) => {
+  const updated = text.replace(regex, (match, target) => {
     const trimmedTarget = target.trim();
     if (trimmedTarget !== oldBasename) return match;
     replacements += 1;
-
-    const headingPart = heading ?? "";
-    let aliasPart: string;
-    if (alias) {
-      // Preserve existing display alias.
-      aliasPart = alias;
-    } else if (headingPart) {
-      // Heading without explicit alias — preserve original basename as display.
-      aliasPart = `|${oldBasename}`;
-    } else {
-      // Bare wikilink — preserve original basename as display per UID-form convention.
-      aliasPart = `|${oldBasename}`;
-    }
-
-    return `[[${newBasename}${headingPart}${aliasPart}]]`;
+    return `[[${newBasename}]]`;
   });
 
   return { updated, replacements };

--- a/packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts
+++ b/packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts
@@ -63,7 +63,7 @@ describe("Issue #3113: rename-to-uid updates inbound wikilinks", () => {
     return full;
   }
 
-  it("rewrites all wikilink shapes; skips code/embeds/already-UID-form", async () => {
+  it("collapses all wikilink shapes to bare [[uid]]; skips code/embeds/already-UID-form", async () => {
     const inbox = "01 Inbox/Choco.md";
     write(inbox, targetFile({ uid: ASSET_UID, label: "Choco" }));
 
@@ -114,27 +114,23 @@ describe("Issue #3113: rename-to-uid updates inbound wikilinks", () => {
     expect(fs.existsSync(newTargetPath)).toBe(true);
     expect(fs.existsSync(path.join(vaultRoot, inbox))).toBe(false);
 
-    // Trigger files updated
-    expect(fs.readFileSync(bare, "utf-8")).toContain(`[[${ASSET_UID}|Choco]]`);
-    expect(fs.readFileSync(aliased, "utf-8")).toContain(
-      `[[${ASSET_UID}|Шоколад]]`,
-    );
-    expect(fs.readFileSync(heading, "utf-8")).toContain(
-      `[[${ASSET_UID}#Ingredients|Choco]]`,
-    );
+    // Trigger files updated — all shapes collapse to bare [[uid]]
+    expect(fs.readFileSync(bare, "utf-8")).toContain(`[[${ASSET_UID}]]`);
+    expect(fs.readFileSync(aliased, "utf-8")).toContain(`[[${ASSET_UID}]]`);
+    expect(fs.readFileSync(heading, "utf-8")).toContain(`[[${ASSET_UID}]]`);
     expect(fs.readFileSync(headingAliased, "utf-8")).toContain(
-      `[[${ASSET_UID}#Ingredients|See Ingredients]]`,
+      `[[${ASSET_UID}]]`,
     );
 
     // Code-block contents preserved verbatim
     const codeBlockContent = fs.readFileSync(codeBlock, "utf-8");
     expect(codeBlockContent).toContain("Do not rewrite [[Choco]] here");
-    expect(codeBlockContent).toContain(`After code [[${ASSET_UID}|Choco]]`);
+    expect(codeBlockContent).toContain(`After code [[${ASSET_UID}]]`);
 
     // Inline code preserved
     const inlineContent = fs.readFileSync(inlineCode, "utf-8");
     expect(inlineContent).toContain("`[[Choco]]`");
-    expect(inlineContent).toContain(`Outside [[${ASSET_UID}|Choco]]`);
+    expect(inlineContent).toContain(`Outside [[${ASSET_UID}]]`);
 
     // Already-UID-form unchanged
     expect(fs.readFileSync(alreadyUid, "utf-8")).toContain(

--- a/packages/cli/tests/unit/services/renameToUid.test.ts
+++ b/packages/cli/tests/unit/services/renameToUid.test.ts
@@ -98,6 +98,34 @@ describe("renameToUid (CLI)", () => {
     expect(fm.exo__Asset_label).toBe("Original");
   });
 
+  it("appends old basename to aliases even when label is preset (decoupled from label-gate)", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Preset Label.md",
+      "---\nexo__Asset_uid: alias-only-uid\nexo__Asset_label: Custom Label\n---\nBody\n",
+    );
+
+    await service.execute("tasks/Preset Label");
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/alias-only-uid.md"));
+    expect(fm.exo__Asset_label).toBe("Custom Label");
+    expect(fm.aliases).toEqual(expect.arrayContaining(["Preset Label"]));
+  });
+
+  it("does NOT append alias for archived asset", async () => {
+    writeRaw(
+      vaultRoot,
+      "tasks/Archived Task.md",
+      "---\nexo__Asset_uid: arch-uid\nexo__Asset_label: Archived\nexo__Asset_isArchived: true\n---\nBody\n",
+    );
+
+    await service.execute("tasks/Archived Task");
+
+    const fm = readFrontmatter(path.join(vaultRoot, "tasks/arch-uid.md"));
+    expect(fm.exo__Asset_label).toBe("Archived");
+    expect(fm.aliases).toBeUndefined();
+  });
+
   it("adds exo__Asset_label = original basename when label is missing before rename", async () => {
     writeRaw(
       vaultRoot,

--- a/packages/exocortex/src/services/RenameToUidService.ts
+++ b/packages/exocortex/src/services/RenameToUidService.ts
@@ -11,12 +11,12 @@ export class RenameToUidService {
   async renameToUid(file: IFile, metadata: Record<string, unknown>): Promise<void> {
     const uid = metadata.exo__Asset_uid;
 
-    if (!uid) {
+    if (!uid || typeof uid !== "string") {
       throw new Error("Asset has no exo__Asset_uid property");
     }
 
     const currentBasename = file.basename;
-    const targetBasename = uid;
+    const targetBasename: string = uid;
 
     if (currentBasename === targetBasename) {
       throw new Error("File is already named according to UID");
@@ -24,10 +24,13 @@ export class RenameToUidService {
 
     const currentLabel = metadata.exo__Asset_label as string | undefined;
     const needsLabelUpdate = !currentLabel || currentLabel.trim() === "";
+    const needsAliasUpdate = !this.isAssetArchived(metadata);
 
-    if (needsLabelUpdate) {
-      const isArchived = this.isAssetArchived(metadata);
-      await this.updateLabel(file, currentBasename, isArchived);
+    if (needsLabelUpdate || needsAliasUpdate) {
+      await this.updateFrontmatter(file, currentBasename, {
+        setLabel: needsLabelUpdate,
+        appendAlias: needsAliasUpdate,
+      });
     }
 
     const folderPath = file.parent?.path || "";
@@ -40,10 +43,10 @@ export class RenameToUidService {
     await this.vault.rename(file, newPath);
   }
 
-  private async updateLabel(
+  private async updateFrontmatter(
     file: IFile,
-    label: string,
-    isArchived: boolean,
+    basename: string,
+    opts: { setLabel: boolean; appendAlias: boolean },
   ): Promise<void> {
     await this.vault.process(file, (content) => {
       const frontmatterRegex = /^---\n([\s\S]*?)\n---/;
@@ -55,12 +58,12 @@ export class RenameToUidService {
 
       let frontmatterContent = match[1];
 
-      // Add label
-      frontmatterContent = `${frontmatterContent}\nexo__Asset_label: ${label}`;
+      if (opts.setLabel) {
+        frontmatterContent = `${frontmatterContent}\nexo__Asset_label: ${basename}`;
+      }
 
-      // Add aliases if not archived
-      if (!isArchived) {
-        frontmatterContent = this.updateAliases(frontmatterContent, label);
+      if (opts.appendAlias) {
+        frontmatterContent = this.updateAliases(frontmatterContent, basename);
       }
 
       return content.replace(frontmatterRegex, `---\n${frontmatterContent}\n---`);

--- a/packages/exocortex/tests/services/RenameToUidService.test.ts
+++ b/packages/exocortex/tests/services/RenameToUidService.test.ts
@@ -30,7 +30,7 @@ describe("RenameToUidService", () => {
   });
 
   describe("renameToUid", () => {
-    it("should rename file to UID", async () => {
+    it("should rename file to UID and process frontmatter for alias append", async () => {
       const metadata = {
         exo__Asset_uid: "asset-123",
         exo__Asset_label: "Existing Label",
@@ -39,7 +39,8 @@ describe("RenameToUidService", () => {
       await service.renameToUid(mockFile, metadata);
 
       expect(mockVault.rename).toHaveBeenCalledWith(mockFile, "/folder/asset-123.md");
-      expect(mockVault.process).not.toHaveBeenCalled();
+      // Even with existing label, process is invoked to append old basename to aliases.
+      expect(mockVault.process).toHaveBeenCalled();
     });
 
     it("should throw error when no UID property", async () => {
@@ -113,15 +114,28 @@ describe("RenameToUidService", () => {
       expect(mockVault.rename).toHaveBeenCalled();
     });
 
-    it("should not update label when valid label exists", async () => {
+    it("should not overwrite label but still append alias when valid label exists", async () => {
       const metadata = {
         exo__Asset_uid: "asset-123",
         exo__Asset_label: "Valid Label",
       };
 
+      mockVault.process.mockImplementation(async (file, fn) => {
+        const content = "---\nexo__Asset_label: Valid Label\n---\nContent";
+        const result = fn(content);
+        // Existing label preserved verbatim — no second `exo__Asset_label:` added.
+        const labelMatches = result.match(/^exo__Asset_label\s*:/gm);
+        expect(labelMatches?.length).toBe(1);
+        expect(result).toContain("exo__Asset_label: Valid Label");
+        // Old basename appended to aliases.
+        expect(result).toContain("aliases:");
+        expect(result).toContain("- old-name");
+        return result;
+      });
+
       await service.renameToUid(mockFile, metadata);
 
-      expect(mockVault.process).not.toHaveBeenCalled();
+      expect(mockVault.process).toHaveBeenCalled();
       expect(mockVault.rename).toHaveBeenCalledWith(mockFile, "/folder/asset-123.md");
     });
 

--- a/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
+++ b/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
@@ -245,48 +245,15 @@ export class ObsidianVaultAdapter implements IVaultAdapter {
         "\\$&",
       );
 
-      const patterns = [
-        {
-          regex: new RegExp(
-            `\\[\\[${escapedOldBasename}(#[^\\]|]+)\\|([^\\]]+)\\]\\]`,
-            "g",
-          ),
-          replacement: `[[${newBasename}$1|$2]]`,
-        },
-        {
-          regex: new RegExp(
-            `\\[\\[${escapedOldBasename}(\\^[^\\]|]+)\\|([^\\]]+)\\]\\]`,
-            "g",
-          ),
-          replacement: `[[${newBasename}$1|$2]]`,
-        },
-        {
-          regex: new RegExp(
-            `\\[\\[${escapedOldBasename}\\|([^\\]]+)\\]\\]`,
-            "g",
-          ),
-          replacement: `[[${newBasename}|$1]]`,
-        },
-        {
-          regex: new RegExp(`\\[\\[${escapedOldBasename}(#[^\\]|]+)\\]\\]`, "g"),
-          replacement: `[[${newBasename}$1|${oldBasename}]]`,
-        },
-        {
-          regex: new RegExp(
-            `\\[\\[${escapedOldBasename}(\\^[^\\]|]+)\\]\\]`,
-            "g",
-          ),
-          replacement: `[[${newBasename}$1|${oldBasename}]]`,
-        },
-        {
-          regex: new RegExp(`\\[\\[${escapedOldBasename}\\]\\]`, "g"),
-          replacement: `[[${newBasename}|${oldBasename}]]`,
-        },
-      ];
-
-      for (const { regex, replacement } of patterns) {
-        content = content.replace(regex, replacement);
-      }
+      // Collapse all wikilink shapes to bare [[newBasename]]:
+      //   [[Old]] / [[Old|*]] / [[Old#h]] / [[Old#h|*]] / [[Old^b]] / [[Old^b|*]]
+      // Display label resolved at render time from target's exo__Asset_label;
+      // old basename preserved in target frontmatter `aliases:` by service.
+      const collapseRegex = new RegExp(
+        `\\[\\[${escapedOldBasename}(?:[#^][^\\]|]*)?(?:\\|[^\\]]*)?\\]\\]`,
+        "g",
+      );
+      content = content.replace(collapseRegex, `[[${newBasename}]]`);
 
       await this.vault.modify(sourceFile, content);
     }

--- a/packages/obsidian-plugin/tests/unit/ObsidianVaultAdapter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ObsidianVaultAdapter.test.ts
@@ -963,7 +963,7 @@ nested:
       } as any;
     });
 
-    it("should update simple wikilinks with alias", async () => {
+    it("should collapse simple wikilinks to [[uid]]", async () => {
       const sourceFile = Object.create(TFile.prototype);
       Object.assign(sourceFile, {
         path: "source.md",
@@ -985,11 +985,11 @@ nested:
 
       expect(mockVault.modify).toHaveBeenCalledWith(
         sourceFile,
-        "Content with [[uid-123|asset1]] link"
+        "Content with [[uid-123]] link"
       );
     });
 
-    it("should update heading links with alias", async () => {
+    it("should collapse heading links to [[uid]]", async () => {
       const sourceFile = Object.create(TFile.prototype);
       Object.assign(sourceFile, {
         path: "source.md",
@@ -1011,11 +1011,11 @@ nested:
 
       expect(mockVault.modify).toHaveBeenCalledWith(
         sourceFile,
-        "Link to [[uid-123#section|asset1]]"
+        "Link to [[uid-123]]"
       );
     });
 
-    it("should update block links with alias", async () => {
+    it("should collapse block links to [[uid]]", async () => {
       const sourceFile = Object.create(TFile.prototype);
       Object.assign(sourceFile, {
         path: "source.md",
@@ -1037,11 +1037,11 @@ nested:
 
       expect(mockVault.modify).toHaveBeenCalledWith(
         sourceFile,
-        "Link to [[uid-123^block-id|asset1]]"
+        "Link to [[uid-123]]"
       );
     });
 
-    it("should preserve custom aliases", async () => {
+    it("should drop custom aliases (collapse to [[uid]])", async () => {
       const sourceFile = Object.create(TFile.prototype);
       Object.assign(sourceFile, {
         path: "source.md",
@@ -1065,7 +1065,7 @@ nested:
 
       expect(mockVault.modify).toHaveBeenCalledWith(
         sourceFile,
-        "Links: [[uid-123|Custom Alias]] and [[uid-123#section|Another Alias]]"
+        "Links: [[uid-123]] and [[uid-123]]"
       );
     });
 
@@ -1107,11 +1107,11 @@ nested:
       expect(mockVault.modify).toHaveBeenCalledTimes(2);
       expect(mockVault.modify).toHaveBeenCalledWith(
         source1,
-        "Link in file 1: [[uid-123|asset1]]"
+        "Link in file 1: [[uid-123]]"
       );
       expect(mockVault.modify).toHaveBeenCalledWith(
         source2,
-        "Link in file 2: [[uid-123|asset1]]"
+        "Link in file 2: [[uid-123]]"
       );
     });
 
@@ -1168,7 +1168,7 @@ nested:
 
       expect(mockVault.modify).toHaveBeenCalledWith(
         sourceFile,
-        "Link to [[uid-123|asset (with) [special]]]"
+        "Link to [[uid-123]]"
       );
     });
 
@@ -1196,7 +1196,7 @@ nested:
 
       expect(mockVault.modify).toHaveBeenCalledWith(
         sourceFile,
-        "Links: [[uid-123|asset1]], [[uid-123#heading|asset1]], [[uid-123|Custom]]"
+        "Links: [[uid-123]], [[uid-123]], [[uid-123]]"
       );
     });
   });

--- a/packages/obsidian-plugin/tests/unit/RenameToUidService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RenameToUidService.test.ts
@@ -82,7 +82,7 @@ Test content`;
       );
     });
 
-    it("should rename file but not add label when label already exists", async () => {
+    it("should rename file and process frontmatter to append alias when label already exists", async () => {
       const mockFile = {
         basename: "Old Task Name",
         parent: { path: "03 Knowledge/user" },
@@ -95,7 +95,8 @@ Test content`;
 
       await service.renameToUid(mockFile, metadata);
 
-      expect(mockVaultAdapter.process).not.toHaveBeenCalled();
+      // process is still invoked — label preserved, but old basename appended to aliases.
+      expect(mockVaultAdapter.process).toHaveBeenCalledTimes(1);
       expect(mockVaultAdapter.rename).toHaveBeenCalledWith(
         mockFile,
         "03 Knowledge/user/abc-123-def.md",


### PR DESCRIPTION
## Summary

- Collapse all wikilink shapes to bare `[[uid]]` on rename-to-uid:
  `[[Old]]`, `[[Old|*]]`, `[[Old#h]]`, `[[Old#h|*]]`, `[[Old^b]]`, `[[Old^b|*]]` → `[[uid]]`
- Display label resolved at render time from target's `exo__Asset_label`
- `RenameToUidService` now appends old basename to target's `aliases:` array regardless of label state (decouples from previous label-gating); archived assets still skip alias append
- Simplifies adapter regex from 6 patterns to 1 in both CLI (`wikilinkRewriter`) and Obsidian-plugin (`ObsidianVaultAdapter`)

## Rationale

User asked for uniform link shape across vault. Heading/block-refs intentionally dropped for simplicity — they aren't reliably useful when the target has been renamed, and Obsidian autocomplete can navigate to specific headers via the `aliases:` lookup.

Existing aliased wikilinks (`[[uid|customDisplay]]`) in vault are NOT migrated by this PR — only new renames produce the collapsed form. A follow-up migration may be considered later, but lossy grammatical inflections (e.g. `[[uid|Омеги]]`) make it a non-trivial decision.

## Test plan

- [x] `packages/exocortex/tests/services/RenameToUidService.test.ts` — 41/41 pass (incl. existing archived & duplicate-detection cases)
- [x] `packages/obsidian-plugin/tests/unit/ObsidianVaultAdapter.test.ts` — 60/60 pass (collapsed-shape assertions updated)
- [x] `packages/obsidian-plugin/tests/unit/RenameToUidService.test.ts` — pass
- [x] `packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts` — 2/2 pass
- [x] `packages/cli/tests/unit/services/renameToUid.test.ts` — 11/11 pass (added 2 new cases for alias-when-label-preset + archived-skip)
- [x] CI required checks: archgate · detect-changes · e2e-shard (1..6) · lint · parity-gate · test-bdd · test-component · test-coverage · typecheck

## Files changed

- `packages/cli/src/utils/wikilinkRewriter.ts` — `replaceWikilinks` simplified
- `packages/cli/src/adapters/FileSystemVaultAdapter.ts` — JSDoc only
- `packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts` — `updateLinks`: 6 patterns → 1
- `packages/exocortex/src/services/RenameToUidService.ts` — decouple aliases from label-gating; type-narrow `uid`
- 5 test files updated