### PR TITLE
ci(npm-publish): add workflow_dispatch trigger to npm-publish-cli

### DIFF
--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -3,6 +3,12 @@ name: Publish CLI to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v16.12.2). If empty, uses latest release."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -24,14 +30,22 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
-      - name: Get version from release tag
+      - name: Get version from release tag or input
         id: version
         run: |
-          # Extract version from tag (remove 'v' prefix if present)
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
+          # Source: release event tag_name OR workflow_dispatch input.tag OR latest release tag
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            RAW="${{ github.event.release.tag_name }}"
+          elif [ -n "${{ inputs.tag }}" ]; then
+            RAW="${{ inputs.tag }}"
+          else
+            RAW=$(gh release view --json tagName --jq .tagName --repo "${{ github.repository }}")
+          fi
+          VERSION="${RAW#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Publishing version: $VERSION"
+          echo "Publishing version: $VERSION (source tag: $RAW)"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Problem

GitHub default behaviour: releases created via GITHUB_TOKEN (e.g. by `auto-release.yml` workflow) do **NOT** fire `release: published` downstream events. Prevents workflow loops, but silently breaks npm CLI publishing.

**Symptom:** `npm-publish-cli.yml` last successful run 2026-02-08. Today's 5 releases (v16.10.0 → v16.12.2) shipped to GitHub Releases but NPM `@kitelev/exocortex-cli` is stuck at **16.10.0** (from Feb).

## Fix

Adds `workflow_dispatch` trigger with optional `tag` input:
- Empty input → publishes latest release tag (via `gh release view`)
- Explicit input (e.g. `v16.12.2`) → publishes that tag

Restores manual publish capability. Long-term fix (PAT in auto-release) is a separate auth concern.

## Backfill plan post-merge

```bash
gh workflow run npm-publish-cli.yml --repo kitelev/exocortex -f tag=v16.12.2
```

Brings npm CLI from 16.10.0 → 16.12.2.

## Test plan

- [x] YAML valid (gh actions linter would check on push)
- [ ] CI green
- [ ] Manual workflow_dispatch run for tag=v16.12.2 → npm @kitelev/exocortex-cli@16.12.2 published