### PR TITLE
ci(npm-publish): build services workspace before CLI bundle (follow-up to PR #3209)

### DIFF
--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -53,6 +53,13 @@ jobs:
       - name: Build core package
         run: npm run build -w exocortex
 
+      - name: Build services workspace
+        # CLI bundle imports @kitelev/exocortex-services (file:../services workspace).
+        # esbuild requires dist/ to exist before bundling — without this step, build
+        # fails «could not be resolved». Symptom seen after a Feb-Mar refactor moved
+        # CLI's runtime imports through services.
+        run: npm run build -w @kitelev/exocortex-services
+
       - name: Update CLI version
         working-directory: packages/cli
         run: |


### PR DESCRIPTION
Follow-up to PR #3209. After enabling workflow_dispatch, manual trigger revealed CLI bundle fails because @kitelev/exocortex-services workspace dist/ doesn't exist. Adds explicit `npm run build -w @kitelev/exocortex-services` step.