### PR TITLE
fix(button-groups): triple-store fallback for UUID class-label resolution (#3141 follow-up)

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -1158,10 +1158,18 @@ export class CommandResolver {
   }
 
   /**
-   * RFC 31c1a0be Phase 3 helper. Resolve a UID to the linked asset's
-   * `exo__Asset_label`. Returns null if asset not found or has no label.
+   * Resolve a UID to the linked asset's `exo__Asset_label` via the triple
+   * store. Returns null if no asset with that UID exists in the store or
+   * if the asset has no `exo__Asset_label` literal.
+   *
+   * Originally an RFC 31c1a0be Phase 3 helper (private). Promoted to
+   * public as a triple-store fallback for the UI builder's UUID→symbolic
+   * class-label expansion (#3141 follow-up, 2026-05-21): when
+   * `app.metadataCache.getFirstLinkpathDest()` cannot find the class file
+   * during cold-start / post-reload race windows, the builder falls back
+   * here so class-targeted CommandBindings do not silently fail to match.
    */
-  private async resolveLabelByUID(uid: string): Promise<string | null> {
+  async resolveLabelByUID(uid: string): Promise<string | null> {
     const subject = await this.findSubjectByUID(uid);
     if (!subject) return null;
     return this.getLiteralValue(subject, Namespace.EXO.term("Asset_label"));

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -1168,6 +1168,12 @@ export class CommandResolver {
    * `app.metadataCache.getFirstLinkpathDest()` cannot find the class file
    * during cold-start / post-reload race windows, the builder falls back
    * here so class-targeted CommandBindings do not silently fail to match.
+   *
+   * The helper does NOT type-check the resolved asset — it returns the
+   * label of whatever asset bears the given UID. Callers are responsible
+   * for ensuring the UID refers to an asset whose label is meaningful in
+   * their context (e.g., a class file when expanding `exo__Instance_class`
+   * UUID refs).
    */
   async resolveLabelByUID(uid: string): Promise<string | null> {
     const subject = await this.findSubjectByUID(uid);

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -274,7 +274,11 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     // making all preconditions return false and no buttons to render.
     const subjectIRI = `obsidian://vault/${encodeURI(file.path)}`;
 
-    const assetClasses = this.extractAssetClasses(metadata, context.app as App);
+    const assetClasses = await this.extractAssetClasses(
+      metadata,
+      context.app as App,
+      logger,
+    );
     if (assetClasses.length === 0) return null;
 
     // RFC-024 Phase 3: panels are resolved against the most-specific
@@ -284,9 +288,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     // preferred over UUID-form refs for panel lookup since panel configs
     // are authored against symbolic class names.
     const panelClassRef =
-      assetClasses.find(
-        (c) => c !== "exo__Asset" && !this.isUuidRef(c),
-      ) ??
+      assetClasses.find((c) => c !== "exo__Asset" && !this.isUuidRef(c)) ??
       assetClasses.find((c) => c !== "exo__Asset") ??
       null;
 
@@ -554,13 +556,12 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
             // "start marker unknown" and skip the measure — the mark
             // alone is enough for the AC #1 visibility target.
             const hasGet =
-              typeof (
-                performance as unknown as Record<string, unknown>
-              )["getEntriesByName"] === "function";
+              typeof (performance as unknown as Record<string, unknown>)[
+                "getEntriesByName"
+              ] === "function";
             if (
               hasGet &&
-              performance.getEntriesByName("exocmd-cache-read-start")
-                .length > 0
+              performance.getEntriesByName("exocmd-cache-read-start").length > 0
             ) {
               performance.measure(
                 "exocmd-cache-read-to-applied",
@@ -672,10 +673,11 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
    *
    * Returns an empty array when no `exo__Instance_class` is declared.
    */
-  private extractAssetClasses(
+  private async extractAssetClasses(
     metadata: Record<string, unknown>,
     app?: App,
-  ): string[] {
+    logger?: ButtonBuilderContext["logger"],
+  ): Promise<string[]> {
     const raw = metadata["exo__Instance_class"];
     const classes: string[] = [];
 
@@ -696,21 +698,54 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
     // Issue #3141 — expand UUID class refs to also include their symbolic
     // `exo__Asset_label` so CommandBindings with `targetClass: "ems__Task"`
     // match instances whose `exo__Instance_class` is UUID-canonicalised.
-    if (app?.metadataCache?.getFirstLinkpathDest) {
-      const symbolicAliases: string[] = [];
-      for (const cls of classes) {
-        if (!this.isUuidRef(cls)) continue;
-        const classFile = app.metadataCache.getFirstLinkpathDest(cls, "");
-        if (!classFile) continue;
-        const cache = app.metadataCache.getFileCache?.(classFile);
-        const label = cache?.frontmatter?.["exo__Asset_label"];
-        if (typeof label === "string" && label.length > 0 && !classes.includes(label)) {
-          symbolicAliases.push(label);
+    //
+    // Two-tier resolution (#3141 follow-up, 2026-05-21):
+    //   1. `app.metadataCache.getFirstLinkpathDest()` — fast, in-process.
+    //   2. `commandResolver.resolveLabelByUID()` — triple-store fallback
+    //      when Obsidian's metadata cache has not yet indexed the class
+    //      file (cold-start, post-reload, or class file lives under
+    //      `assetspaces/` that the cache hasn't visited yet).
+    // Without (2), class-targeted bindings silently fail to match in the
+    // race window — empirically observed on `1-2-1 a.kayukova`
+    // (ems__MeetingPrototype instance) where buttons disappeared until
+    // a forced re-open warmed the metadata cache.
+    const symbolicAliases: string[] = [];
+    for (const cls of classes) {
+      if (!this.isUuidRef(cls)) continue;
+
+      let label: string | null = null;
+
+      const classFile = app?.metadataCache?.getFirstLinkpathDest?.(cls, "");
+      if (classFile) {
+        const cache = app?.metadataCache?.getFileCache?.(classFile);
+        const cachedLabel = cache?.frontmatter?.["exo__Asset_label"];
+        if (typeof cachedLabel === "string" && cachedLabel.length > 0) {
+          label = cachedLabel;
         }
       }
-      for (const alias of symbolicAliases) {
-        if (!classes.includes(alias)) classes.push(alias);
+
+      if (!label) {
+        try {
+          label = await this.config.commandResolver.resolveLabelByUID(cls);
+        } catch (error) {
+          logger?.info(
+            `[DynamicCommands] resolveLabelByUID(${cls}) threw: ${String(error)}`,
+          );
+        }
       }
+
+      if (label && label.length > 0) {
+        if (!classes.includes(label) && !symbolicAliases.includes(label)) {
+          symbolicAliases.push(label);
+        }
+      } else {
+        logger?.info(
+          `[DynamicCommands] no symbolic exo__Asset_label resolved for UUID class ref ${cls} (metadata cache + triple store both empty); class-targeted bindings may silently fail to match.`,
+        );
+      }
+    }
+    for (const alias of symbolicAliases) {
+      if (!classes.includes(alias)) classes.push(alias);
     }
 
     if (!classes.includes("exo__Asset")) classes.push("exo__Asset");

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -42,12 +42,14 @@ function buildCommandExecutionFlow(): CommandExecutionFlow {
 
 const mockResolveForAsset = jest.fn();
 const mockResolveForAssetMulti = jest.fn();
+const mockResolveLabelByUID = jest.fn();
 const mockEvaluate = jest.fn();
 const mockExecute = jest.fn();
 
 const mockCommandResolver = {
   resolveForAsset: mockResolveForAsset,
   resolveForAssetMulti: mockResolveForAssetMulti,
+  resolveLabelByUID: mockResolveLabelByUID,
   loadCommand: jest.fn(),
   findBindings: jest.fn(),
   invalidateCache: jest.fn(),
@@ -364,6 +366,8 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       });
       // No metadataCache wired — must not throw, just pass UUID through.
       (context.app as any) = {};
+      // Triple-store fallback also empty in this scenario (asset graph cold).
+      mockResolveLabelByUID.mockResolvedValue(null);
 
       await builder.build(context);
 
@@ -372,6 +376,87 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         [classUid, "exo__Asset"],
         undefined,
       );
+    });
+
+    it("Issue #3141 follow-up — should fall back to commandResolver.resolveLabelByUID when metadataCache cannot find the class file (cold-start race)", async () => {
+      mockResolveForAssetMulti.mockResolvedValue([]);
+      const classUid = "7ab483c7-aafc-4ac8-8aca-0de52db34a93";
+      const context = createContext({
+        exo__Instance_class: ["[[" + classUid + "]]"],
+      });
+      // metadataCache wired but returns null — simulates cold-start window
+      // where Obsidian hasn't yet indexed `assetspaces/ems/<uid>.md`.
+      (context.app as any).metadataCache = {
+        getFirstLinkpathDest: jest.fn().mockReturnValue(null),
+        getFileCache: jest.fn(),
+      };
+      // Triple store has the class indexed (NoteToRDFConverter runs first).
+      mockResolveLabelByUID.mockResolvedValue("ems__MeetingPrototype");
+
+      await builder.build(context);
+
+      expect(mockResolveLabelByUID).toHaveBeenCalledWith(classUid);
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+        "obsidian://vault/test/file.md",
+        [classUid, "ems__MeetingPrototype", "exo__Asset"],
+        undefined,
+      );
+    });
+
+    it("Issue #3141 follow-up — should prefer metadataCache hit over triple-store fallback (fast path stays fast)", async () => {
+      mockResolveForAssetMulti.mockResolvedValue([]);
+      const classUid = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+      const mockClassFile = { path: "assetspaces/ems/" + classUid + ".md" };
+      const context = createContext({
+        exo__Instance_class: ["[[" + classUid + "]]"],
+      });
+      (context.app as any).metadataCache = {
+        getFirstLinkpathDest: jest.fn((link: string) =>
+          link === classUid ? mockClassFile : null,
+        ),
+        getFileCache: jest.fn((file: any) =>
+          file === mockClassFile
+            ? { frontmatter: { exo__Asset_label: "ems__Task" } }
+            : null,
+        ),
+      };
+      // resolveLabelByUID must NOT be called when metadataCache already
+      // produced the symbolic label — avoids an unnecessary triple-store
+      // round-trip in the warm path.
+      mockResolveLabelByUID.mockResolvedValue("SHOULD_NOT_BE_USED");
+
+      await builder.build(context);
+
+      expect(mockResolveLabelByUID).not.toHaveBeenCalled();
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+        "obsidian://vault/test/file.md",
+        [classUid, "ems__Task", "exo__Asset"],
+        undefined,
+      );
+    });
+
+    it("Issue #3141 follow-up — should log a warning when both metadataCache and triple-store fail to resolve a UUID class ref", async () => {
+      mockResolveForAssetMulti.mockResolvedValue([]);
+      const classUid = "deadbeef-0000-4000-8000-000000000000";
+      const context = createContext({
+        exo__Instance_class: ["[[" + classUid + "]]"],
+      });
+      (context.app as any).metadataCache = {
+        getFirstLinkpathDest: jest.fn().mockReturnValue(null),
+        getFileCache: jest.fn(),
+      };
+      mockResolveLabelByUID.mockResolvedValue(null);
+
+      await builder.build(context);
+
+      const infoLogs = (context.logger.info as jest.Mock).mock.calls;
+      const matched = infoLogs.find(
+        ([msg]: [string]) =>
+          typeof msg === "string" &&
+          msg.includes(classUid) &&
+          msg.includes("no symbolic"),
+      );
+      expect(matched).toBeDefined();
     });
 
     it("should preserve order — declared classes first, exo__Asset appended (Issue #2958)", async () => {
@@ -390,9 +475,10 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
     it("should resolve variant from command category via categoryDefaultVariant map", async () => {
       // RFC f1dc284a: `creation` category maps to `primary` by built-in defaults.
-      const rc = createResolvedCommand(
-        { name: "Create action", category: "creation" },
-      );
+      const rc = createResolvedCommand({
+        name: "Create action",
+        category: "creation",
+      });
       mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
@@ -403,9 +489,10 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should map maintenance category to muted variant", async () => {
-      const rc = createResolvedCommand(
-        { name: "Rebuild index", category: "maintenance" },
-      );
+      const rc = createResolvedCommand({
+        name: "Rebuild index",
+        category: "maintenance",
+      });
       mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
@@ -416,9 +503,10 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     });
 
     it("should default variant to secondary when no category", async () => {
-      const rc = createResolvedCommand(
-        { name: "Default action", category: undefined },
-      );
+      const rc = createResolvedCommand({
+        name: "Default action",
+        category: undefined,
+      });
       mockResolveForAssetMulti.mockResolvedValue([rc]);
       mockEvaluate.mockResolvedValue(true);
 
@@ -1360,16 +1448,22 @@ describe("DynamicCommandButtonGroupBuilder", () => {
     let originalMeasure: unknown;
 
     beforeEach(() => {
-      originalMark = (performance as unknown as Record<string, unknown>)["mark"];
-      originalMeasure = (performance as unknown as Record<string, unknown>)["measure"];
+      originalMark = (performance as unknown as Record<string, unknown>)[
+        "mark"
+      ];
+      originalMeasure = (performance as unknown as Record<string, unknown>)[
+        "measure"
+      ];
       markSpy = jest.fn();
       measureSpy = jest.fn();
       (performance as unknown as Record<string, unknown>)["mark"] = markSpy;
-      (performance as unknown as Record<string, unknown>)["measure"] = measureSpy;
+      (performance as unknown as Record<string, unknown>)["measure"] =
+        measureSpy;
     });
 
     afterEach(() => {
-      (performance as unknown as Record<string, unknown>)["mark"] = originalMark;
+      (performance as unknown as Record<string, unknown>)["mark"] =
+        originalMark;
       (performance as unknown as Record<string, unknown>)["measure"] =
         originalMeasure;
     });

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -358,7 +358,7 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       );
     });
 
-    it("Issue #3141 — should gracefully no-op symbolic expansion when metadataCache is unavailable", async () => {
+    it("Issue #3141 — should gracefully no-op symbolic expansion when both metadataCache and triple-store have no label", async () => {
       mockResolveForAssetMulti.mockResolvedValue([]);
       const classUid = "1b20a8f0-d745-4e93-91db-4531b3df120e";
       const context = createContext({
@@ -457,6 +457,37 @@ describe("DynamicCommandButtonGroupBuilder", () => {
           msg.includes("no symbolic"),
       );
       expect(matched).toBeDefined();
+    });
+
+    it("Issue #3141 follow-up — should log a warning and continue when triple-store fallback throws", async () => {
+      mockResolveForAssetMulti.mockResolvedValue([]);
+      const classUid = "cafebabe-0000-4000-8000-000000000000";
+      const context = createContext({
+        exo__Instance_class: ["[[" + classUid + "]]"],
+      });
+      (context.app as any).metadataCache = {
+        getFirstLinkpathDest: jest.fn().mockReturnValue(null),
+        getFileCache: jest.fn(),
+      };
+      mockResolveLabelByUID.mockRejectedValue(new Error("triple-store-down"));
+
+      await builder.build(context);
+
+      const infoLogs = (context.logger.info as jest.Mock).mock.calls;
+      const threwLog = infoLogs.find(
+        ([msg]: [string]) =>
+          typeof msg === "string" &&
+          msg.includes(classUid) &&
+          msg.includes("threw"),
+      );
+      expect(threwLog).toBeDefined();
+      // Builder still calls into the resolver with UUID alone (and exo__Asset),
+      // i.e. throw does not abort the whole render pipeline.
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+        "obsidian://vault/test/file.md",
+        [classUid, "exo__Asset"],
+        undefined,
+      );
     });
 
     it("should preserve order — declared classes first, exo__Asset appended (Issue #2958)", async () => {


### PR DESCRIPTION
## Summary

After UUID-canon TBox migration (CLAUDE.md §UUID-canon, 2026-05-16), `exo__Instance_class` references classes by UUID wikilink. The button-group builder needs the symbolic `exo__Asset_label` (e.g. `ems__MeetingPrototype`) so `CommandBinding.targetClass: "ems__MeetingPrototype"` matches. Today it uses `app.metadataCache.getFirstLinkpathDest()` (PR #3141). During cold-start / post-reload race windows, the metadata cache may not yet have indexed the class file under `assetspaces/<ontology>/<uid>.md` → `getFirstLinkpathDest` returns null → symbolic alias silently skipped → **button group is omitted entirely, no log, no signal**.

Empirically observed today on `1-2-1 a.kayukova` (ems__MeetingPrototype instance): buttons missing on Desktop, present on iPhone (cache warm). Forced re-open on Desktop = buttons appear → race confirmed.

## Fix

1. **Promote `CommandResolver.resolveLabelByUID` from private to public.** The triple store is populated by `NoteToRDFConverter` independently of Obsidian's per-file resolve queue, so it's a reliable source of truth at the point the builder runs.
2. **`DynamicCommandButtonGroupBuilder.extractAssetClasses` becomes async** and consults `commandResolver.resolveLabelByUID(uid)` whenever the metadata cache does not yield a label. Metadata cache wins when warm (fast path stays fast); fallback fires only when needed.
3. **Emit `logger.info` warning** when both sources fail — converts the previous silent skip into an observable signal.

## Out of scope (intentional)

- `ExocmdFastResolver.extractAssetClasses` — documented to accept the precision loss; background full-resolver re-render covers it.
- `ExocmdBindingsIndexer.extractAssetClasses` — same rationale; disk cache mirrors fast-path semantics.

## Test plan

- [x] 3 new unit cases in `DynamicCommandButtonGroupBuilder.test.ts`:
  - Cold-start fallback: metadataCache empty, triple store provides label → binding matches.
  - Warm-path precedence: metadataCache hit ⇒ `resolveLabelByUID` not called.
  - Dual-empty warning path: both sources fail ⇒ `logger.info` emitted with UUID + diagnostic message.
- [x] Pre-existing #3141 cases updated to wire the new mock and assert backwards-compatible behaviour when the triple store is also empty.
- [x] `npx jest packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts` — 70/70 pass
- [x] `npx jest packages/exocortex/tests/unit/services/CommandResolver.test.ts` — 69/69 pass
- [x] `npx jest packages/obsidian-plugin/tests/unit/cache/ packages/obsidian-plugin/tests/unit/presentation/builders/` — 159/159 pass
- [x] `npm run check:types` — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings unrelated to this PR)
- [ ] Manual verify in vault-2025 after install: open `1-2-1 a.kayukova` cold → buttons should appear without forced re-open

## Files

- `packages/exocortex/src/services/CommandResolver.ts` — `resolveLabelByUID` private→public + docstring.
- `packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts` — async `extractAssetClasses` with triple-store fallback + warning log.
- `packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts` — 3 new cases + 1 updated.

## Notes

Touches `CommandResolver.ts` (parser/TBox path). Following CLAUDE.md "Auto-merge discipline (CRITICAL)" — will NOT use `--auto`; will request code-reviewer + advisor round before manual squash-merge.