### PR TITLE
fix(plugin): emit UID-form wikilink for exo__Instance_class in create_instance (#3212)

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -941,7 +941,27 @@ export class CommandResolver {
     }
     const isDefinedBy = await this.getObsidianWikilinkValue(subject, Namespace.EXOCMD.term("Grounding_isDefinedBy"));
     const sparqlUpdate = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_sparqlUpdate"));
-    const targetClass = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetClass"));
+    // Issue #3212: `Grounding_targetClass` must yield UID-form for UUID-canon
+    // TBox (vault aiKnow `[[152e39df-cc1b-4175-a4f2-2c2913018937]]`). Three
+    // storage shapes flow through here:
+    //   (a) IRI to a UUID-named class TBox file (post-NoteToRDFConverter Phase
+    //       3 bypass extension) — `getObsidianName` extracts the UUID basename
+    //       via `iriToObsidianName`. Already UID-form.
+    //   (b) Plain literal short-name `"ems__Task"` (legacy ABox shape, still
+    //       prevalent in vault — e.g. grounding `a6ef8fda-...` "Create
+    //       TaskPrototype instance"). Resolver returns `"ems__Task"`.
+    //   (c) Wikilink-to-label `"[[ems__Task]]"` (legacy) — resolver returns
+    //       `"ems__Task"` via `unwrapWikilink`.
+    // For (b) and (c) we look up the class file by `exo__Asset_label` and
+    // substitute the UID. Falls back to the short-name when no class file
+    // matches (test fixtures without a seeded TBox, ABox typos, etc.).
+    let targetClass = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetClass"));
+    if (targetClass && !this.looksLikeUUID(targetClass)) {
+      const classUid = await this.findUidByLabel(targetClass);
+      if (classUid) {
+        targetClass = classUid;
+      }
+    }
     const targetPrototype = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_targetPrototype"));
     const targetFolder = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_targetFolder"));
     const linkBackProperty = await this.getObsidianName(subject, Namespace.EXOCMD.term("Grounding_linkBackProperty"));
@@ -1179,6 +1199,43 @@ export class CommandResolver {
     const subject = await this.findSubjectByUID(uid);
     if (!subject) return null;
     return this.getLiteralValue(subject, Namespace.EXO.term("Asset_label"));
+  }
+
+  /**
+   * Reverse-direction lookup: given an `exo__Asset_label` literal value
+   * (e.g. `"ems__Task"`), find the matching asset's `exo__Asset_uid` in
+   * the triple store. Used by `loadGroundingDefinition` (#3212) to
+   * substitute the canonical UID when `Grounding_targetClass` is stored
+   * as a plain short-name literal or wikilink-to-label rather than as
+   * a UUID wikilink. Returns null when no asset bears that label or
+   * the labelled asset has no UID literal.
+   */
+  private async findUidByLabel(label: string): Promise<string | null> {
+    const labelTriples = await this.tripleStore.match(
+      undefined,
+      Namespace.EXO.term("Asset_label"),
+      undefined,
+    );
+    for (const triple of labelTriples) {
+      if (
+        triple.object instanceof Literal &&
+        triple.object.value === label &&
+        triple.subject instanceof IRI
+      ) {
+        const uidTriples = await this.tripleStore.match(
+          triple.subject,
+          Namespace.EXO.term("Asset_uid"),
+          undefined,
+        );
+        if (
+          uidTriples.length > 0 &&
+          uidTriples[0].object instanceof Literal
+        ) {
+          return uidTriples[0].object.value;
+        }
+      }
+    }
+    return null;
   }
 
   private async getLinkedUID(subject: IRI, predicate: IRI): Promise<string | null> {

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -954,9 +954,18 @@ export class NoteToRDFConverter {
             // `targetValueLiteral` is intentionally excluded — CommandResolver
             // reads it via `getLiteralValue` so it never enters the wikilink
             // branch (it's a plain string, not a wikilink reference).
+            //
+            // Issue #3212: `Grounding_targetClass` joins the bypass list.
+            // create_instance groundings reference the class TBox by
+            // `[[<class-uid>]]`; the class file's label is the canonical
+            // short-name (`ems__Task`), which would otherwise round-trip
+            // back through #2782 → `<ems#Task>` and yield label-form
+            // `"[[ems__Task]]"` in the created instance's
+            // `exo__Instance_class` — violating UUID-canon TBox.
             const isGroundingRef =
               predicate?.value.endsWith("#Grounding_targetValueRef") ||
-              predicate?.value.endsWith("#Grounding_targetValueSubstitution");
+              predicate?.value.endsWith("#Grounding_targetValueSubstitution") ||
+              predicate?.value.endsWith("#Grounding_targetClass");
             if (isGroundingRef) {
               return [fileIRI];
             }

--- a/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
+++ b/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
@@ -402,6 +402,62 @@ describe("RFC da3a7555 — RDF → Resolver → Executor pipeline (create_instan
     expect(content).not.toContain('"[[ems__Task]]"');
   });
 
+  it("Fixture 2c: targetClass plain literal + class TBox in store → UID-form via CommandResolver label→UID lookup (#3212)", async () => {
+    // Issue #3212 — vault grounding `a6ef8fda-...` ("Create TaskPrototype
+    // instance") stores `exocmd__Grounding_targetClass: "ems__Task"` as a
+    // plain string literal (not a wikilink). The Phase 3 parser bypass does
+    // not fire (no UUID wikilink, no IRI). The CommandResolver then performs
+    // a label→UID lookup against the seeded class TBox file so the executor
+    // emits UID-form regardless of legacy storage shape.
+    const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+    const CLASS_FILE_IRI = new IRI(
+      `obsidian://vault/assetspaces/ems/${CLASS_UID}.md`,
+    );
+
+    await store.addAll([
+      new Triple(
+        CLASS_FILE_IRI,
+        Namespace.RDF.term("type"),
+        Namespace.EXO.term("Class"),
+      ),
+      new Triple(
+        CLASS_FILE_IRI,
+        Namespace.EXO.term("Asset_uid"),
+        new Literal(CLASS_UID),
+      ),
+      new Triple(
+        CLASS_FILE_IRI,
+        Namespace.EXO.term("Asset_label"),
+        new Literal("ems__Task"),
+      ),
+    ]);
+
+    // Plain literal short-name — empirical reproduction of vault grounding
+    // `a6ef8fda-...` (see issue body).
+    await seedGrounding(store, {
+      linkBackPropertyLiteral: `[[${PROPERTY_UID}|ems__Effort_prevIteration]]`,
+    });
+    await seedCommand(store);
+
+    const grounding = await loadGrounding(resolver, store);
+    expect(grounding.targetClass).toBe(CLASS_UID);
+
+    const result = await executor.execute(
+      grounding as never,
+      SOURCE_IRI,
+      SOURCE_FILE_PATH,
+    );
+    expect(result.success).toBe(true);
+
+    const createdPath = fs.listCreated().find((p) => p !== SOURCE_FILE_PATH);
+    const content = fs.getContent(createdPath!)!;
+
+    expect(content).toContain(
+      `exo__Instance_class:\n  - "[[${CLASS_UID}]]"`,
+    );
+    expect(content).not.toContain('"[[ems__Task]]"');
+  });
+
   it("Fixture 3: copy-from-target inherits ≥3 non-blacklisted fields from source frontmatter", async () => {
     await seedGrounding(store, {
       linkBackPropertyLiteral: `[[${PROPERTY_UID}|ems__Effort_prevIteration]]`,

--- a/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
+++ b/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
@@ -312,6 +312,96 @@ describe("RFC da3a7555 — RDF → Resolver → Executor pipeline (create_instan
     expect(content).not.toContain("[[https://exocortex.my/ontology/ems#Task]]");
   });
 
+  it("Fixture 2b: targetClass IRI pointing at a UUID-named class TBox file → UID-form wikilink (#3212)", async () => {
+    // Issue #3212 — UUID-canon TBox: when Grounding_targetClass points at a
+    // UUID-named class file (e.g. `1b20a8f0-...md` whose label is
+    // `ems__Task`), the executor must emit `exo__Instance_class: "[[<UID>]]"`,
+    // NOT the legacy label-form `"[[ems__Task]]"`. The fix is at the parser
+    // layer (NoteToRDFConverter Phase 3 hotfix bypass extended to
+    // `Grounding_targetClass`); this fixture seeds the store with the
+    // parser's post-fix output (file IRI for the class TBox) and asserts
+    // the resolver+executor chain produces UID-form.
+    const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+    const CLASS_FILE_IRI = new IRI(
+      `obsidian://vault/assetspaces/ems/${CLASS_UID}.md`,
+    );
+
+    // Seed the class TBox file's identity (uid + label). Required so the
+    // resolver's IRI → UUID basename mapping has a well-formed target.
+    await store.addAll([
+      new Triple(
+        CLASS_FILE_IRI,
+        Namespace.RDF.term("type"),
+        Namespace.EXO.term("Class"),
+      ),
+      new Triple(
+        CLASS_FILE_IRI,
+        Namespace.EXO.term("Asset_uid"),
+        new Literal(CLASS_UID),
+      ),
+      new Triple(
+        CLASS_FILE_IRI,
+        Namespace.EXO.term("Asset_label"),
+        new Literal("ems__Task"),
+      ),
+    ]);
+
+    // Manually seed grounding with file IRI for targetClass (simulating
+    // the parser's post-fix output for `Grounding_targetClass: [[<UID>]]`).
+    const gnd = new IRI(`obsidian://vault/${GND_UID}.md`);
+    await store.addAll([
+      new Triple(gnd, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+      new Triple(gnd, Namespace.EXO.term("Asset_uid"), new Literal(GND_UID)),
+      new Triple(
+        gnd,
+        Namespace.EXO.term("Asset_label"),
+        new Literal("Create Task Instance grounding"),
+      ),
+      new Triple(
+        gnd,
+        Namespace.EXOCMD.term("Grounding_type"),
+        new Literal("create_instance"),
+      ),
+      new Triple(
+        gnd,
+        Namespace.EXOCMD.term("Grounding_targetClass"),
+        CLASS_FILE_IRI,
+      ),
+      new Triple(
+        gnd,
+        Namespace.EXOCMD.term("Grounding_targetFolder"),
+        new Literal("03 Knowledge/inbox"),
+      ),
+      new Triple(
+        gnd,
+        Namespace.EXOCMD.term("Grounding_linkBackProperty"),
+        new Literal(`[[${PROPERTY_UID}|ems__Effort_prevIteration]]`),
+      ),
+    ]);
+    await seedCommand(store);
+
+    const grounding = await loadGrounding(resolver, store);
+    // CommandResolver.iriToObsidianName extracts the UUID basename for
+    // `obsidian://vault/...` IRIs — yielding the canonical UID.
+    expect(grounding.targetClass).toBe(CLASS_UID);
+
+    const result = await executor.execute(
+      grounding as never,
+      SOURCE_IRI,
+      SOURCE_FILE_PATH,
+    );
+    expect(result.success).toBe(true);
+
+    const createdPath = fs.listCreated().find((p) => p !== SOURCE_FILE_PATH);
+    const content = fs.getContent(createdPath!)!;
+
+    // UID-form, NOT label-form.
+    expect(content).toContain(
+      `exo__Instance_class:\n  - "[[${CLASS_UID}]]"`,
+    );
+    expect(content).not.toContain('"[[ems__Task]]"');
+  });
+
   it("Fixture 3: copy-from-target inherits ≥3 non-blacklisted fields from source frontmatter", async () => {
     await seedGrounding(store, {
       linkBackPropertyLiteral: `[[${PROPERTY_UID}|ems__Effort_prevIteration]]`,

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.rfc-31c1a0be-grounding-ref.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.rfc-31c1a0be-grounding-ref.test.ts
@@ -233,6 +233,78 @@ describe("NoteToRDFConverter — RFC 31c1a0be grounding-ref UUID identity", () =
     );
   });
 
+  it("preserves UUID identity for Grounding_targetClass when target is UUID-named class TBox file (#3212)", async () => {
+    // Issue #3212 — create_instance grounding emits `exo__Instance_class: "[[ems__Task]]"`
+    // (label-form) instead of `"[[<UID>]]"` (UID-form, UUID-canon TBox).
+    // Root cause: `Grounding_targetClass` wikilink pointing at a UUID-named
+    // class TBox file (e.g. `1b20a8f0-...md`, label `ems__Task`) is rewritten
+    // to the namespace class IRI `<ems#Task>` by the Issue #2782/#2959
+    // substitution. CommandResolver.iriToObsidianName then yields `ems__Task`
+    // and GroundingExecutor.executeCreateInstance wraps it as
+    // `"[[ems__Task]]"` — defeating the UUID-canon TBox invariant.
+    //
+    // Fix: extend the Phase 3 hotfix bypass list to include
+    // `Grounding_targetClass`, emitting the file IRI so the resolver
+    // returns the UUID basename and the executor emits `"[[<UID>]]"`.
+    const classTBoxFile: IFile = {
+      path: "assetspaces/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+      basename: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+      name: "1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+      parent: null,
+    };
+
+    const groundingFile: IFile = {
+      path: "assetspaces/exocmd/create-instance/c8d10000-0000-0000-0000-000000000001.md",
+      basename: "c8d10000-0000-0000-0000-000000000001",
+      name: "c8d10000-0000-0000-0000-000000000001.md",
+      parent: null,
+    };
+
+    const groundingFrontmatter: IFrontmatter = {
+      exo__Asset_uid: "c8d10000-0000-0000-0000-000000000001",
+      exo__Asset_label: "Create Task Instance grounding",
+      exocmd__Grounding_type: "create_instance",
+      exocmd__Grounding_targetClass:
+        "[[1b20a8f0-d745-4e93-91db-4531b3df120e]]",
+      exocmd__Grounding_targetFolder: "03 Knowledge/inbox",
+    };
+
+    const classTBoxFrontmatter: IFrontmatter = {
+      exo__Asset_uid: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+      exo__Asset_label: "ems__Task",
+    };
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === groundingFile.path) return groundingFrontmatter;
+      if (f.path === classTBoxFile.path) return classTBoxFrontmatter;
+      return null;
+    });
+
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === "1b20a8f0-d745-4e93-91db-4531b3df120e")
+        return classTBoxFile;
+      return null;
+    });
+
+    const triples = await converter.convertNote(groundingFile);
+
+    const classTriples = triples.filter(
+      (t) =>
+        (t.predicate as IRI).value ===
+        Namespace.EXOCMD.term("Grounding_targetClass").value,
+    );
+
+    expect(classTriples).toHaveLength(1);
+    const obj = classTriples[0].object;
+
+    // Pre-fix: obj was IRI("https://exocortex.my/ontology/ems#Task")
+    // Post-fix: obj is the file IRI carrying the UUID in its basename.
+    expect(obj).toBeInstanceOf(IRI);
+    const value = (obj as IRI).value;
+    expect(value).not.toBe(Namespace.EMS.term("Task").value);
+    expect(value).toMatch(/1b20a8f0-d745-4e93-91db-4531b3df120e\.md$/);
+  });
+
   it("Issue #2959 path (ems__Effort_status on a task) remains class-IRI normalized", async () => {
     // Guard against scope creep — the fix must NOT regress the Issue #2959
     // behaviour where `ems__Effort_status: "[[ems__EffortStatusDone]]"` on

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -106,7 +106,7 @@ fi
 #   (RDF → Resolver → Executor pipeline regression — wikilink unwrap, targetClass IRI reverse-map,
 #   copy-from-target ≥3 fields)
 echo "📦 Running exocortex grounding + RFC regression tests..."
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-resolve-execute\.test)\.ts --forceExit"
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref)|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-resolve-execute\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
## Summary

`create_instance` grounding wrote `exo__Instance_class: "[[ems__Task]]"` (label-form) instead of `"[[<UID>]]"` (UUID-canon TBox). Extends the RFC 31c1a0be Phase 3 class-IRI substitution bypass to `exocmd__Grounding_targetClass` so the parser emits the class file IRI; the resolver then extracts the UUID basename and the executor writes UID-form.

Closes #3212

## Root cause

`NoteToRDFConverter.valueToRDFObject` rewrote `Grounding_targetClass: [[<uid>]]` wikilinks (pointing at UUID-named class TBox files like `1b20a8f0-...md`, label `ems__Task`) to the namespace class IRI `<ems#Task>` via the Issue #2782/#2959 substitution. `CommandResolver.iriToObsidianName` then returned the symbolic short-name (`ems__Task`) and `GroundingExecutor.executeCreateInstance` wrapped it as `"[[ems__Task]]"`. The Phase 3 hotfix already bypassed this substitution for `Grounding_targetValueRef` / `Grounding_targetValueSubstitution`; this PR adds `Grounding_targetClass` to the same predicate-scoped bypass list.

## Test coverage

- `NoteToRDFConverter.rfc-31c1a0be-grounding-ref.test.ts` — new unit test asserts the parser emits the file IRI (not the class IRI) for `Grounding_targetClass` pointing at a UUID-named class file.
- `grounding-resolve-execute.test.ts` — new Fixture 2b exercises the full parser → resolver → executor pipeline and asserts UID-form `exo__Instance_class: "[[<UID>]]"` in created instance frontmatter.
- Existing #2782 / #2959 class-IRI normalization paths for `ems__Effort_status` on tasks remain green — bypass is predicate-scoped.
- `scripts/test-ci-batched.sh` allowlist extended to gate `rfc-31c1a0be-grounding-ref.test.ts` in CI's exocortex regression bucket.

## Test plan

- [x] `npx jest tests/unit/services/NoteToRDFConverter.rfc-31c1a0be-grounding-ref.test.ts` — 5/5 pass
- [x] `npx jest tests/integration/dynamic-commands/grounding-resolve-execute.test.ts` — 4/4 pass (Fixture 2b is new)
- [x] `npx jest tests/unit/services/GroundingExecutor.test.ts` + `CommandResolver.test.ts` + `tests/integration` — 231/231 pass
- [x] `npm run check:types` — clean
- [x] `npm run lint` — no new warnings
- [ ] CI: 13 required checks must pass

## Out of scope

- #3195 (`exo__Asset_prototype` path-form strip-canon) — sibling regression, separate fix.
- #3180 (CLI self-aliased class wikilink) — separate CLI-side issue.