### PR TITLE
fix(e2e): stabilize DailyNote layout flaky tests

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
@@ -1,8 +1,10 @@
-// flaky-track: Issue #2988 — single-incident flake (1/41) without retry(1).
-// Per RFC 32a64ed9 §3.3, bucket = track: keep enabled, no retry, rely on
-// Phase 3.4 dashboard to disambiguate at higher N.
-// Watch criteria: incident #2 within 30 days → escalate to fix; zero further
-// at N≥100 → close as resolved. Expiry: 2026-05-31.
+// flaky-track: Issue #2988 — incident #2 logged 2026-05-21 on PR #3211.
+// RCA: positive test missed `.exocortex-layout-rendered` wait that 6 other
+// specs use; render race under Xvfb load → "Target page closed" (60s test
+// timeout). Fix: add `waitForElement(".exocortex-layout-rendered", 30000)`
+// after every `waitForModalsToClose` in this spec.
+// Per RFC 32a64ed9 §3.3 escalation: incident #2 triggered fix; watch shifts
+// to "N≥100 zero-further on main → close `@flaky-track` tag". Expiry: 2026-05-31.
 import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
 import * as path from "path";
@@ -40,6 +42,7 @@ test.describe(
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     const toggleButton = window.locator(
       ".exocortex-daily-tasks-section .exocortex-toggle-archived",
@@ -98,6 +101,7 @@ test.describe(
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     const toggleButton = window.locator(
       ".exocortex-daily-tasks-section .exocortex-toggle-archived",
@@ -114,9 +118,11 @@ test.describe(
 
     await launcher.openFile("Daily Notes/2025-10-17.md");
     await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     await launcher.openFile("Daily Notes/2025-10-18.md");
     await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     const toggleButtonAfterRefresh = window.locator(
       ".exocortex-daily-tasks-section .exocortex-toggle-archived",

--- a/packages/obsidian-plugin/tests/e2e/specs/daily-navigation.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-navigation.spec.ts
@@ -26,6 +26,7 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
     await expect(navContainer.locator(".exocortex-nav-prev a")).toContainText(
@@ -50,6 +51,7 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
     await expect(navContainer.locator(".exocortex-nav-prev a")).toContainText(
@@ -98,6 +100,7 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
     await expect(navContainer.locator(".exocortex-nav-prev a")).toContainText(
@@ -126,6 +129,7 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
     await expect(navContainer.locator(".exocortex-nav-prev a")).toContainText(
@@ -152,6 +156,7 @@ test.describe("Daily Note Navigation", () => {
     const window = await launcher.getWindow();
 
     await launcher.waitForModalsToClose(10000);
+    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
     const navContainer = window.locator(".exocortex-daily-navigation");
     await expect(


### PR DESCRIPTION
## Summary

Stabilizes the two DailyNote e2e specs that have produced repeat flaky failures on `main` and PRs:
- `daily-navigation.spec.ts:23` — "element(s) not found" on shard-6
- `daily-archive-filter.spec.ts:37` — "Target page closed" on shard-2 (RFC 32a64ed9 incident #2)

The fix adds the canonical `waitForElement(".exocortex-layout-rendered", 30000)` after every `waitForModalsToClose(10000)` in positive tests — the exact pattern already used by 6 other specs (`vault-commands-smoke`, `table-virtualization-large-datasets`, `starter-kit-smoke`, `featured-binding-promotion`, `layout-overflow-styling`, and the existing negative test on `daily-navigation.spec.ts:83`).

## Root cause

`UniversalLayoutRenderer.render()` adds the `.exocortex-layout-rendered` class only after **all** async render passes complete (`packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts:315,330`). Positive daily-* tests bypassed this marker and relied solely on the implicit 30s poll inside `expect(locator).toContainText(...)`. Under Xvfb load (especially during shard parallel contention or cold triple-store warmup), the renderer routinely needs 5–30s; if it slips past 30s the assertion times out, then the outer 60s test budget fires and Playwright force-closes the browser — surfacing as the "Target page closed" error.

## Flaky baseline (last 30d main)

| Spec | first-attempt fails / 100 | rerun count |
|------|---------------------------|-------------|
| `daily-archive-filter` | 1 / 100 | 1 (incident #1: 2026-05-17 sha 25a3fdc; incident #2: PR #3211 2026-05-21) |
| `daily-navigation`     | 0 / 100 on main | retry(1) masks; PR #3211 attempt-1 + retry both failed → not truly hidden |

Other unrelated e2e flakies in the same window: `create-fleeting-note-palette` (2), `relation-column-set-smoke` (1), `area-tree-collapsible` (1) — out of scope; tracked separately.

## Why no local 10/10 proof

`packages/obsidian-plugin/CLAUDE.md` mandates **"E2E tests run ONLY in Docker, never run locally"**. The task DoD bullet "10/10 local greens" is therefore unsatisfiable. Substitute proof per task spec STEP H: 5 consecutive `main` CI runs green post-merge.

## Test plan

- [ ] CI green on this PR (full 14 required checks including `e2e-shard (1..6)`)
- [ ] Auto-merge to main on green
- [ ] STEP H — watch 5 consecutive main CI runs after merge; all daily-* specs pass without retry
- [ ] If any daily-* spec fails first-attempt within 5 runs → revert + reinvestigate

## Notes

- `@flaky-track` tag on `daily-archive-filter` is **retained**. RFC 32a64ed9 §3.3 closure rule = "N≥100 zero-further on main → close tag"; we are at incident #2 → fix shipped, watch resets.
- Comment header at `daily-archive-filter.spec.ts:1-7` updated with incident #2 RCA reference.
- No production code changed; touch surface = 2 test files only. Auto-merge OK per worktree CLAUDE.md (doesn't intersect parser/TBox/migration paths).