### PR TITLE
fix(plugin): resolve create_instance class label→UID at execution time (#3220)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -73,6 +73,7 @@ export {
   type ExecutionResult,
   type UserInput,
   type IGroundingService,
+  type ClassLabelToUidResolver,
 } from "./services/GroundingExecutor";
 export {
   CommandExecutionFlow,

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -51,6 +51,37 @@ function extractClassFromTargetValue(
 export type UserInput = Record<string, unknown>;
 
 /**
+ * Issue #3220 — execution-time class-label → canonical-UID resolver.
+ *
+ * `create_instance` writes `exo__Instance_class` from `grounding.targetClass`.
+ * That value may arrive in label-form (e.g. `"ems__Task"`) instead of the
+ * UUID-canon form (`"1b20a8f0-..."`) whenever the command was resolved against
+ * a store that does NOT contain the class TBox file — which is exactly what
+ * the cold-start resolution paths use:
+ *
+ *   - `ExocmdFastResolver` (#3171) builds a mini-store from the open asset
+ *     plus `assetspaces/exocmd/*.md` only — never `assetspaces/ems` where the
+ *     UUID-named class TBox files live.
+ *   - the persisted binding cache (#3183) yields `ResolvedCommand`s whose
+ *     `grounding.targetClass` was baked at write time and survives an Obsidian
+ *     restart on disk.
+ *
+ * In both cases `CommandResolver.findUidByLabel` (#3212) returns null for lack
+ * of the TBox label triple, so the grounding bakes the bare label. Re-resolving
+ * here, at execution time, against an always-warm source (the Obsidian metadata
+ * cache, injected by the plugin) guarantees UID-form regardless of which path
+ * produced the grounding. A `null` return (no resolver wired, test/CLI harness,
+ * unknown label) leaves the ref untouched — backward-compatible label-form.
+ */
+export type ClassLabelToUidResolver = (
+  label: string,
+) => string | null | Promise<string | null>;
+
+/** UUID-v4 sniff used to skip resolution for already-canonical class refs. */
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
  * A named service that can be invoked by service_call groundings.
  */
 export interface IGroundingService {
@@ -118,16 +149,23 @@ export class GroundingExecutor {
   private readonly fileReader: IFileSystemReader;
   private readonly fileWriter: IFileSystemWriter;
   private readonly serviceRegistry: ServiceRegistry;
+  private readonly classLabelToUid?: ClassLabelToUidResolver;
 
   constructor(
     fileReader: IFileSystemReader,
     fileWriter: IFileSystemWriter,
     serviceRegistry: ServiceRegistry,
+    // Issue #3220 — optional. When omitted (tests, CLI, headless runners) the
+    // executor preserves its prior label-form behaviour for class refs that
+    // arrived non-canonical. The Obsidian plugin injects a metadata-cache-
+    // backed implementation so production create_instance always emits UID-form.
+    classLabelToUid?: ClassLabelToUidResolver,
   ) {
     this.frontmatterService = new FrontmatterService();
     this.fileReader = fileReader;
     this.fileWriter = fileWriter;
     this.serviceRegistry = serviceRegistry;
+    this.classLabelToUid = classLabelToUid;
   }
 
   /**
@@ -576,7 +614,12 @@ export class GroundingExecutor {
     }
 
     if (grounding.targetClass) {
-      properties.exo__Instance_class = [`"[[${grounding.targetClass}]]"`];
+      // Issue #3220: re-resolve label-form refs to UID at execution time. See
+      // {@link ClassLabelToUidResolver} for why resolver-time resolution
+      // (CommandResolver.findUidByLabel, #3212) is insufficient in production
+      // cold-start paths. Already-UUID refs and unresolvable labels pass through.
+      const classRef = await this.resolveClassRefToUid(grounding.targetClass);
+      properties.exo__Instance_class = [`"[[${classRef}]]"`];
     }
 
     // Issue #3184 B1: do NOT materialise `grounding.targetPrototype` (which is
@@ -676,6 +719,27 @@ export class GroundingExecutor {
     // — actually opening the file is wired by the platform adapter through
     // CommandExecutionFlow's optional IFileOpener dependency.
     return { success: true, openPath: filePath };
+  }
+
+  /**
+   * Issue #3220 — resolve a class reference to its canonical UUID at execution
+   * time, falling back to the original ref when resolution is unavailable.
+   *
+   * Skips already-UUID refs (full-path resolution + the parser-layer bypass
+   * #3212/#3214 already produce these). For label-form refs (the cold-start
+   * gap), delegates to the injected {@link ClassLabelToUidResolver}; a missing
+   * resolver, a `null`/empty result, or a thrown error all preserve the prior
+   * label-form behaviour rather than failing the creation.
+   */
+  private async resolveClassRefToUid(classRef: string): Promise<string> {
+    if (UUID_V4_RE.test(classRef)) return classRef;
+    if (!this.classLabelToUid) return classRef;
+    try {
+      const uid = await this.classLabelToUid(classRef);
+      return uid && uid.length > 0 ? uid : classRef;
+    } catch {
+      return classRef;
+    }
   }
 
   /**

--- a/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
+++ b/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
@@ -458,6 +458,138 @@ describe("RFC da3a7555 — RDF → Resolver → Executor pipeline (create_instan
     expect(content).not.toContain('"[[ems__Task]]"');
   });
 
+  it("Fixture 2d: PRODUCTION-SHAPE — class TBox absent from store (cold-start) → resolver-time findUidByLabel returns null → execution-time ClassLabelToUidResolver yields UID-form (#3220)", async () => {
+    // Issue #3220 — the #3212 resolver-layer fix (CommandResolver.findUidByLabel,
+    // exercised by Fixture 2c) works ONLY when the class TBox label triple is in
+    // the SAME store the resolver queries. Production cold-start paths violate
+    // that precondition:
+    //   - ExocmdFastResolver (#3171) builds a mini-store from the open asset +
+    //     `assetspaces/exocmd` only — NEVER `assetspaces/ems` where the class
+    //     TBox lives.
+    //   - the persisted binding cache (#3183) bakes the resolved grounding and
+    //     survives an Obsidian restart.
+    // This fixture reproduces that shape: the grounding stores the plain literal
+    // `"ems__Task"` (vault grounding `a6ef8fda-...`) but — UNLIKE Fixture 2c —
+    // the class TBox file is DELIBERATELY NOT seeded into the store. So
+    // findUidByLabel returns null and the grounding bakes the bare label.
+    const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+
+    await seedGrounding(store, {
+      linkBackPropertyLiteral: `[[${PROPERTY_UID}|ems__Effort_prevIteration]]`,
+    });
+    await seedCommand(store);
+
+    const grounding = await loadGrounding(resolver, store);
+    // The production gap: with no class TBox in the store, the resolver-layer
+    // fix degrades to the bare label. This is the value baked into the disk
+    // cache / fast-path ResolvedCommand that production executes.
+    expect(grounding.targetClass).toBe("ems__Task");
+
+    // --- Execution WITHOUT a resolver (tests/CLI/headless) → label-form. ---
+    // Backward-compatibility guard: the prior behaviour is preserved when no
+    // ClassLabelToUidResolver is injected.
+    const fsNoResolver = new InMemoryFileSystem({
+      [SOURCE_FILE_PATH]: SOURCE_CONTENT,
+    });
+    const executorNoResolver = new GroundingExecutor(
+      fsNoResolver,
+      fsNoResolver,
+      new ServiceRegistry(),
+    );
+    const resNoResolver = await executorNoResolver.execute(
+      grounding as never,
+      SOURCE_IRI,
+      SOURCE_FILE_PATH,
+    );
+    expect(resNoResolver.success).toBe(true);
+    const pathNoResolver = fsNoResolver
+      .listCreated()
+      .find((p) => p !== SOURCE_FILE_PATH)!;
+    expect(fsNoResolver.getContent(pathNoResolver)!).toContain(
+      'exo__Instance_class:\n  - "[[ems__Task]]"',
+    );
+
+    // --- Execution WITH the metadata-cache-backed resolver → UID-form. ---
+    // Simulates the always-warm Obsidian metadata cache that DOES know the
+    // class (the plugin wires `createObsidianClassLabelResolver`). This is the
+    // assertion that FAILS before the #3220 fix — executeCreateInstance ignored
+    // the label and wrote `"[[ems__Task]]"` regardless.
+    const fsWithResolver = new InMemoryFileSystem({
+      [SOURCE_FILE_PATH]: SOURCE_CONTENT,
+    });
+    const calls: string[] = [];
+    const executorWithResolver = new GroundingExecutor(
+      fsWithResolver,
+      fsWithResolver,
+      new ServiceRegistry(),
+      (label: string) => {
+        calls.push(label);
+        return label === "ems__Task" ? CLASS_UID : null;
+      },
+    );
+    const resWithResolver = await executorWithResolver.execute(
+      grounding as never,
+      SOURCE_IRI,
+      SOURCE_FILE_PATH,
+    );
+    expect(resWithResolver.success).toBe(true);
+    const pathWithResolver = fsWithResolver
+      .listCreated()
+      .find((p) => p !== SOURCE_FILE_PATH)!;
+    const contentWithResolver = fsWithResolver.getContent(pathWithResolver)!;
+
+    expect(calls).toContain("ems__Task");
+    expect(contentWithResolver).toContain(
+      `exo__Instance_class:\n  - "[[${CLASS_UID}]]"`,
+    );
+    expect(contentWithResolver).not.toContain('"[[ems__Task]]"');
+  });
+
+  it("Fixture 2e: resolver is NOT invoked for already-UUID targetClass — and never overrides it (#3220)", async () => {
+    // Guards against a resolver that mis-resolves a UUID back to something else:
+    // when grounding.targetClass is already UUID-canon (full-path resolution /
+    // parser-layer bypass #3212), executeCreateInstance must short-circuit and
+    // emit it verbatim without calling the resolver.
+    const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+
+    // Seed the class TBox so the resolver-layer fix produces UID-form, mirroring
+    // a warm full-path resolution.
+    const CLASS_FILE_IRI = new IRI(
+      `obsidian://vault/assetspaces/ems/${CLASS_UID}.md`,
+    );
+    await store.addAll([
+      new Triple(CLASS_FILE_IRI, Namespace.RDF.term("type"), Namespace.EXO.term("Class")),
+      new Triple(CLASS_FILE_IRI, Namespace.EXO.term("Asset_uid"), new Literal(CLASS_UID)),
+      new Triple(CLASS_FILE_IRI, Namespace.EXO.term("Asset_label"), new Literal("ems__Task")),
+    ]);
+    await seedGrounding(store, {
+      linkBackPropertyLiteral: `[[${PROPERTY_UID}|ems__Effort_prevIteration]]`,
+    });
+    await seedCommand(store);
+
+    const grounding = await loadGrounding(resolver, store);
+    expect(grounding.targetClass).toBe(CLASS_UID);
+
+    const calls: string[] = [];
+    const executorWithResolver = new GroundingExecutor(fs, fs, new ServiceRegistry(), (label: string) => {
+      calls.push(label);
+      return "SHOULD-NOT-BE-USED";
+    });
+    const result = await executorWithResolver.execute(
+      grounding as never,
+      SOURCE_IRI,
+      SOURCE_FILE_PATH,
+    );
+    expect(result.success).toBe(true);
+    // Resolver MUST be skipped for UUID refs.
+    expect(calls).toHaveLength(0);
+    const createdPath = fs.listCreated().find((p) => p !== SOURCE_FILE_PATH)!;
+    expect(fs.getContent(createdPath)!).toContain(
+      `exo__Instance_class:\n  - "[[${CLASS_UID}]]"`,
+    );
+    expect(fs.getContent(createdPath)!).not.toContain("SHOULD-NOT-BE-USED");
+  });
+
   it("Fixture 3: copy-from-target inherits ≥3 non-blacklisted fields from source frontmatter", async () => {
     await seedGrounding(store, {
       linkBackPropertyLiteral: `[[${PROPERTY_UID}|ems__Effort_prevIteration]]`,

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -89,6 +89,7 @@ import { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService
 import { ObsidianFileSystemAdapter } from "./adapters/ObsidianFileSystemAdapter";
 import { populateServiceRegistry } from "./infrastructure/services/ServiceRegistryPopulator";
 import { ObsidianFileOpener } from "./infrastructure/services/ObsidianFileOpener";
+import { createObsidianClassLabelResolver } from "./infrastructure/services/ObsidianClassLabelResolver";
 import { ExocmdCommandPaletteRegistrar } from "./application/services/ExocmdCommandPaletteRegistrar";
 import { ObsidianCommandPromptAdapter } from "./infrastructure/adapters/ObsidianCommandPromptAdapter";
 import {
@@ -227,6 +228,11 @@ export default class ExocortexPlugin extends Plugin {
         obsidianFs,
         obsidianFs,
         this.serviceRegistry,
+        // Issue #3220: execution-time label→UID class resolution via the
+        // always-warm Obsidian metadata cache. Closes the cold-start gap where
+        // create_instance baked label-form `exo__Instance_class` because the
+        // fast resolver / disk cache store lacked the `assetspaces/ems` TBox.
+        createObsidianClassLabelResolver(this.app),
       );
 
       populateServiceRegistry(this.serviceRegistry, {

--- a/packages/obsidian-plugin/src/infrastructure/services/ObsidianClassLabelResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ObsidianClassLabelResolver.ts
@@ -1,0 +1,44 @@
+import type { App } from "obsidian";
+import type { ClassLabelToUidResolver } from "exocortex";
+
+/**
+ * Issue #3220 — build a metadata-cache-backed {@link ClassLabelToUidResolver}.
+ *
+ * # Why this lives in the plugin layer
+ *
+ * `GroundingExecutor.executeCreateInstance` writes `exo__Instance_class` from
+ * `grounding.targetClass`. In production cold-start, that value is label-form
+ * (`"ems__Task"`) rather than UUID-canon (`"1b20a8f0-..."`) because the command
+ * was resolved against a store lacking the class TBox file:
+ *
+ *   - `ExocmdFastResolver` (#3171) mini-store = open asset + `assetspaces/exocmd`
+ *     only; the class TBox lives in `assetspaces/ems`.
+ *   - the persisted binding cache (#3183) bakes the label and survives restart.
+ *
+ * `CommandResolver.findUidByLabel` (#3212) therefore returns null and the
+ * grounding keeps the bare label — the production gap reproduced in the
+ * 2026-05-22 UI smoke that motivated #3220.
+ *
+ * Obsidian's metadata cache, by contrast, is fully warm well before the user
+ * can click a button — it is the always-available source for the reverse
+ * label → UID lookup. `getFirstLinkpathDest` resolves the linkpath against both
+ * filenames AND `aliases`, so the UUID-named class file (`1b20a8f0-...md` with
+ * `aliases: [ems__Task]`) is found by its symbolic label. This mirrors the
+ * forward UUID → label expansion already in `DynamicCommandButtonGroupBuilder.
+ * extractAssetClasses` (#3141), only in the opposite direction.
+ *
+ * Returns `null` when the label resolves to no file, the file has no
+ * `exo__Asset_uid`, or the metadata-cache API surface is unavailable —
+ * `GroundingExecutor` then preserves its prior label-form output.
+ */
+export function createObsidianClassLabelResolver(
+  app: App,
+): ClassLabelToUidResolver {
+  return (label: string): string | null => {
+    const dest = app.metadataCache?.getFirstLinkpathDest?.(label, "");
+    if (!dest) return null;
+    const frontmatter = app.metadataCache?.getFileCache?.(dest)?.frontmatter;
+    const uid = frontmatter?.["exo__Asset_uid"];
+    return typeof uid === "string" && uid.length > 0 ? uid : null;
+  };
+}

--- a/packages/obsidian-plugin/tests/unit/services/ObsidianClassLabelResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/services/ObsidianClassLabelResolver.test.ts
@@ -1,0 +1,77 @@
+import type { App } from "obsidian";
+import { createObsidianClassLabelResolver } from "../../../src/infrastructure/services/ObsidianClassLabelResolver";
+
+/**
+ * Issue #3220 — unit coverage for the metadata-cache-backed class-label → UID
+ * resolver wired into GroundingExecutor by ExocortexPlugin.
+ */
+describe("createObsidianClassLabelResolver (#3220)", () => {
+  const CLASS_FILE = { path: "assetspaces/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md" };
+  const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+
+  function makeApp(opts: {
+    dest?: unknown;
+    frontmatter?: Record<string, unknown> | undefined;
+    getFirstLinkpathDest?: unknown;
+    getFileCache?: unknown;
+  }): App {
+    return {
+      metadataCache: {
+        getFirstLinkpathDest:
+          opts.getFirstLinkpathDest ??
+          jest.fn().mockReturnValue(opts.dest ?? null),
+        getFileCache:
+          opts.getFileCache ??
+          jest.fn().mockReturnValue(
+            opts.frontmatter !== undefined
+              ? { frontmatter: opts.frontmatter }
+              : {},
+          ),
+      },
+    } as unknown as App;
+  }
+
+  it("resolves a label to the class file's exo__Asset_uid (alias-matched UUID-named TBox)", () => {
+    const app = makeApp({
+      dest: CLASS_FILE,
+      frontmatter: { exo__Asset_uid: CLASS_UID, exo__Asset_label: "ems__Task" },
+    });
+    const resolve = createObsidianClassLabelResolver(app);
+    expect(resolve("ems__Task")).toBe(CLASS_UID);
+  });
+
+  it("passes the requested label and empty source path to getFirstLinkpathDest", () => {
+    const getFirstLinkpathDest = jest.fn().mockReturnValue(CLASS_FILE);
+    const app = makeApp({
+      getFirstLinkpathDest,
+      frontmatter: { exo__Asset_uid: CLASS_UID },
+    });
+    createObsidianClassLabelResolver(app)("ems__Task");
+    expect(getFirstLinkpathDest).toHaveBeenCalledWith("ems__Task", "");
+  });
+
+  it("returns null when the label resolves to no file", () => {
+    const app = makeApp({ dest: null });
+    expect(createObsidianClassLabelResolver(app)("ems__Unknown")).toBeNull();
+  });
+
+  it("returns null when the resolved file has no exo__Asset_uid", () => {
+    const app = makeApp({ dest: CLASS_FILE, frontmatter: { exo__Asset_label: "ems__Task" } });
+    expect(createObsidianClassLabelResolver(app)("ems__Task")).toBeNull();
+  });
+
+  it("returns null when the resolved file has no frontmatter at all", () => {
+    const app = makeApp({ dest: CLASS_FILE, frontmatter: undefined });
+    expect(createObsidianClassLabelResolver(app)("ems__Task")).toBeNull();
+  });
+
+  it("returns null when exo__Asset_uid is a non-string / empty value", () => {
+    const app = makeApp({ dest: CLASS_FILE, frontmatter: { exo__Asset_uid: "" } });
+    expect(createObsidianClassLabelResolver(app)("ems__Task")).toBeNull();
+  });
+
+  it("returns null gracefully when the metadata-cache API surface is unavailable", () => {
+    const app = { metadataCache: {} } as unknown as App;
+    expect(createObsidianClassLabelResolver(app)("ems__Task")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Issue #3212's fix (`CommandResolver.findUidByLabel`, PR #3214, v16.12.6→v16.13.2) landed but production still emits label-form `exo__Instance_class: ["[[ems__Task]]"]` (UI smoke 2026-05-22, vault-2025). Root cause is a **store-completeness gap** in the cold-start resolution paths.

## Root cause (hypotheses #1 + #4 confirmed)

`findUidByLabel` resolves `Grounding_targetClass` label→UID against **the triple store the resolver was built with**. The production cold-start paths use stores that do NOT contain the class TBox file:

- **`ExocmdFastResolver` (#3171)** builds a mini-store from the open asset + `assetspaces/exocmd/*.md` only — never `assetspaces/ems` where the UUID-named class TBox (`1b20a8f0-…md`, label `ems__Task`) lives.
- **Persisted binding cache (#3183)** bakes the resolved `grounding.targetClass` at write time and **survives an Obsidian restart** on disk — explaining why the smoke still failed after a full restart.

In both, `findUidByLabel("ems__Task")` returns null → the grounding keeps the bare label. The **full path** (`convertVault` over `getAllFiles`) *does* include `assetspaces/ems`, so it resolves correctly — but the user clicks within the cold-start window before `isFullPathReady()` flips.

**Why CI missed it:** Fixture 2c seeds the class TBox directly into the test store, masking the async vault-load shape.

## Fix

Re-resolve `grounding.targetClass` to UID **at execution time** in `GroundingExecutor.executeCreateInstance`, via an optional injected `ClassLabelToUidResolver`. The plugin wires a metadata-cache-backed implementation (`createObsidianClassLabelResolver`): Obsidian's metadata cache is fully warm by button-click time and resolves the symbolic label to the UUID-named TBox file through its alias index (`getFirstLinkpathDest`, verified against the CLI parity-mirror + #3141).

Path-independent — corrects label-form regardless of source (fast resolver / disk cache incl. **stale restart-surviving entries** / full path). Already-UUID refs short-circuit (resolver never invoked); a missing resolver or unresolvable label preserves prior label-form output (backward-compatible: tests, CLI, headless runners unaffected).

## Test coverage (production-shape, per #3212 retro)

- **`grounding-resolve-execute.test.ts` Fixture 2d (PRODUCTION-SHAPE):** class TBox **absent** from store (cold-start) → `grounding.targetClass` stays `"ems__Task"` → execution-time resolver yields UID-form; without resolver → label-form (backward-compat guard). Directly contrasts the seeded-store Fixture 2c. **Verified to FAIL before the executeCreateInstance change.** Gated via the test-coverage allowlist.
- **Fixture 2e:** resolver skipped for already-UUID refs (never overrides).
- **`ObsidianClassLabelResolver.test.ts`:** 7 unit cases (alias-matched lookup + every null-degradation path).

## Manual UI smoke verified

End-to-end smoke against **real vault-2025 data** (grounding `a6ef8fda` + TBox `1b20a8f0`): `create_instance` with cold-start-baked `targetClass="ems__Task"` → resolver maps to `1b20a8f0-…` → created file frontmatter is `exo__Instance_class: ["[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"]` (not label-form). Output:
```
[1] real grounding targetClass literal = "ems__Task"
[2] resolver("ems__Task") => 1b20a8f0-d745-4e93-91db-4531b3df120e
[4] exo__Instance_class => [[1b20a8f0-d745-4e93-91db-4531b3df120e]]
✅ SMOKE PASS
```

## Out of scope

- #3195 (`exo__Asset_prototype` path-form) — orthogonal.

Closes #3220