### PR TITLE
feat(engine): Phase 3a — CommandResolver parser for ref-form propertyDefault + inheritanceRule + SubstitutionToken (#3162)

### DIFF
--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -146,6 +146,30 @@ export interface GroundingDefinition {
    */
   readonly propertyDefaults?: Record<string, string>;
   /**
+   * RFC v2 Phase 1+2: declarative ref-form replacement for the legacy JSON
+   * `propertyDefaults`. Multi-valued list of `exocmd__PropertyDefault`
+   * instances attached via `Grounding_propertyDefault` predicate.
+   *
+   * Each PropertyDefault asset declares (property, value) pair. Values that
+   * point to a `SubstitutionToken` instance are resolved at parse time via
+   * the SubstitutionToken resolver registry (today / todayStart) when the
+   * resolver is context-independent. Context-dependent resolvers
+   * (targetFolder / target) are encoded as marker string
+   * `__SUBSTITUTE__<resolver-id>__<token-uid>__` for the Phase 3b executor.
+   *
+   * Coexistence rule: when present alongside legacy `propertyDefaults` JSON
+   * on the same Grounding, ref-form wins; legacy is ignored with a
+   * `logger.warn` once per session per Grounding-uid.
+   */
+  readonly propertyDefault?: ReadonlyArray<PropertyDefaultResolved>;
+  /**
+   * RFC v2 Phase 1+2: declarative ref-form mapping rules. Multi-valued list of
+   * `exocmd__InheritanceRule` instances attached via `Grounding_inheritanceRule`
+   * predicate. Engine (Phase 3b) applies them in priority-descending order
+   * with class condition / exclusion filters relative to the target IRI.
+   */
+  readonly inheritanceRule?: ReadonlyArray<InheritanceRuleResolved>;
+  /**
    * Standalone wikilink to the owner identity asset pinned by this grounding.
    * Injected into `userInput.isDefinedBy` for the `service_call` createAsset
    * service, where it becomes `exo__Asset_isDefinedBy` on the new asset.
@@ -169,6 +193,47 @@ export interface GroundingDefinition {
    * (`xsd:boolean`). Default `false` keeps existing groundings unchanged.
    */
   readonly prefillLabelWithDate?: boolean;
+}
+
+/**
+ * Domain model for a resolved `exocmd__PropertyDefault` instance
+ * (RFC v2 Phase 1+2 — ref-form replacement for legacy `propertyDefaults` JSON).
+ *
+ * Each instance binds one property (resolved to its `exo__Asset_label`) to a
+ * value. Values may be:
+ *   - wikilink-form `"[[<UID>]]"` when the value asset is a regular asset;
+ *   - already-resolved string for context-independent SubstitutionToken
+ *     resolvers (e.g. `today` → `"2026-05-21"`);
+ *   - marker `__SUBSTITUTE__<resolver-id>__<token-uid>__` for
+ *     context-dependent SubstitutionToken resolvers (Phase 3b executor
+ *     replaces the marker at execution time).
+ */
+export interface PropertyDefaultResolved {
+  /** Resolved `exo__Asset_label` of the target `exo__Property` asset. */
+  readonly propertyName: string;
+  /** Resolved value string (see interface docstring for shapes). */
+  readonly value: string;
+}
+
+/**
+ * Domain model for a resolved `exocmd__InheritanceRule` instance
+ * (RFC v2 Phase 1+2 — ref-form mapping rule attached to a Grounding).
+ *
+ * `targetClassCondition` absent → rule applies unconditionally.
+ * `targetClassExclusion` empty → no class is excluded.
+ * `priority` default 50 — higher first when Phase 3b engine sorts rules.
+ */
+export interface InheritanceRuleResolved {
+  /** Resolved `exo__Asset_label` of the source `exo__Property`. */
+  readonly sourcePropertyName: string;
+  /** Resolved `exo__Asset_label` of the target `exo__Property`. */
+  readonly targetPropertyName: string;
+  /** Resolved `exo__Asset_label` of the class condition; absent = unconditional. */
+  readonly targetClassCondition?: string;
+  /** Resolved labels of excluded classes; empty = no exclusion. */
+  readonly targetClassExclusion: readonly string[];
+  /** Priority for ordering when Phase 3b engine applies multiple rules. */
+  readonly priority: number;
 }
 
 /**

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -26,6 +26,8 @@ export type {
   PreconditionDefinition,
   GroundingDefinition,
   CommandBindingDefinition,
+  PropertyDefaultResolved,
+  InheritanceRuleResolved,
 } from "./domain/models/CommandDefinition";
 export {
   isCommandFrontmatter,

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -1336,15 +1336,65 @@ export class CommandResolver {
         continue;
       }
 
-      const targetClassCondition = await this.resolveLabelRef(
+      // HIGH fix (PR #3224 review, 2026-05-22): distinguish "no triple authored"
+      // from "broken ref" for optional class predicates. If the triple exists
+      // but resolution fails, scope of the rule changes — for exclusion in
+      // particular, dropping a broken excluded class makes the rule apply to
+      // MORE classes than authored (asymmetric failure direction). Safer:
+      // skip the entire rule on data-integrity issues.
+      const conditionTriples = await this.tripleStore.match(
         refSubject,
         Namespace.EXOCMD.term("InheritanceRule_targetClassCondition"),
+        undefined,
       );
+      let targetClassCondition: string | undefined = undefined;
+      if (conditionTriples.length > 0) {
+        const resolved = await this.resolveLabelRef(
+          refSubject,
+          Namespace.EXOCMD.term("InheritanceRule_targetClassCondition"),
+        );
+        if (!resolved) {
+          this.logger.warn(
+            `Grounding ${groundingUid}: InheritanceRule has exocmd__InheritanceRule_targetClassCondition triple but ref is unresolvable — entire rule skipped (would otherwise apply unconditionally, broadening scope).`,
+          );
+          continue;
+        }
+        targetClassCondition = resolved;
+      }
 
-      const targetClassExclusion = await this.resolveLabelRefMulti(
+      const exclusionTriples = await this.tripleStore.match(
         refSubject,
         Namespace.EXOCMD.term("InheritanceRule_targetClassExclusion"),
+        undefined,
       );
+      const targetClassExclusion: string[] = [];
+      let exclusionBroken = false;
+      for (const triple of exclusionTriples) {
+        let name: string | null = null;
+        if (triple.object instanceof IRI) {
+          name = this.iriToObsidianName(triple.object.value) ?? triple.object.value;
+        } else if (triple.object instanceof Literal) {
+          name = this.unwrapWikilink(triple.object.value);
+        }
+        if (!name) {
+          exclusionBroken = true;
+          continue;
+        }
+        const resolved = this.looksLikeUUID(name)
+          ? await this.resolveLabelByUID(name)
+          : name;
+        if (!resolved) {
+          exclusionBroken = true;
+          continue;
+        }
+        targetClassExclusion.push(resolved);
+      }
+      if (exclusionBroken) {
+        this.logger.warn(
+          `Grounding ${groundingUid}: InheritanceRule has unresolvable exocmd__InheritanceRule_targetClassExclusion entry — entire rule skipped (would otherwise expand scope by silently dropping the excluded class).`,
+        );
+        continue;
+      }
 
       const priorityRaw = await this.getLiteralValue(
         refSubject,
@@ -1361,7 +1411,7 @@ export class CommandResolver {
       resolved.push({
         sourcePropertyName,
         targetPropertyName,
-        targetClassCondition: targetClassCondition ?? undefined,
+        targetClassCondition,
         targetClassExclusion,
         priority,
       });

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -23,6 +23,8 @@ import type {
   GroundingDefinition,
   CommandBindingDefinition,
   CommandBindingStyleDefinition,
+  PropertyDefaultResolved,
+  InheritanceRuleResolved,
 } from "../domain/models/CommandDefinition";
 
 /**
@@ -35,6 +37,50 @@ export interface ResolvedCommand {
 
 /** Maximum depth for transitive loading to prevent infinite loops */
 const MAX_TRANSITIVE_DEPTH = 10;
+
+/**
+ * RFC v2 Phase 3a — UID of the canonical `exocmd__SubstitutionToken` class
+ * file (UUID-named TBox per RFC-004). Used to detect whether the value asset
+ * of a `PropertyDefault_value` reference is a SubstitutionToken instance, in
+ * which case the parser invokes a resolver from the registry below.
+ */
+const SUBSTITUTION_TOKEN_CLASS_UID = "08cec529-90eb-4d43-88de-ceecccea12b0";
+
+/**
+ * RFC v2 Phase 3a — IRI form of `exocmd__SubstitutionToken`. NoteToRDFConverter
+ * normalises every `exo__Instance_class` triple to namespace IRI form via
+ * `valueToClassURI` regardless of whether the authoring shape is symbolic
+ * (`[[exocmd__SubstitutionToken]]`) or UUID-canon (`[[<UID>]]`). Comparing
+ * class IRIs against this constant is the cheapest detection path; UID
+ * fallback exists for the unlikely case where label expansion failed.
+ */
+const SUBSTITUTION_TOKEN_CLASS_IRI = Namespace.EXOCMD.term("SubstitutionToken").value;
+
+/**
+ * RFC v2 Phase 3a — known SubstitutionToken resolver-ids. RDF vocabulary
+ * (the token assets themselves) lives in vault; this Set is the TS-side
+ * validation surface so the parser can warn loudly on unknown resolver-ids
+ * instead of silently emitting a marker the executor can't honour.
+ */
+const KNOWN_SUBSTITUTION_RESOLVER_IDS: ReadonlySet<string> = new Set([
+  "today",
+  "todayStart",
+  "targetFolder",
+  "target",
+]);
+
+/**
+ * Marker for context-dependent SubstitutionToken resolvers (targetFolder /
+ * target). The Phase 3b GroundingExecutor recognises this exact shape and
+ * substitutes the resolver's value at execution time, when the click target
+ * IRI / UID is known. Context-independent resolvers (today / todayStart) are
+ * resolved at parse time and never produce this marker.
+ *
+ * Shape: `__SUBSTITUTE__<resolver-id>__<token-uid>__`
+ */
+function buildSubstitutionMarker(resolverId: string, tokenUid: string): string {
+  return `__SUBSTITUTE__${resolverId}__${tokenUid}__`;
+}
 
 /**
  * Resolves dynamic commands from vault assets stored in an ITripleStore (RFC-009 §5.3).
@@ -50,6 +96,15 @@ const MAX_TRANSITIVE_DEPTH = 10;
 export class CommandResolver {
   private readonly cache = new Map<string, ResolvedCommand[]>();
   private readonly multiCache = new Map<string, ResolvedCommand[]>();
+
+  /**
+   * RFC v2 Phase 3a — once-per-session-per-Grounding warning suppression set
+   * for the coexistence rule (ref-form `propertyDefault` wins over legacy
+   * `propertyDefaults` JSON). `readonly` refers to the binding; the Set is
+   * mutable. CommandResolver is a `@injectable` singleton via tsyringe, so
+   * "session" == "container lifetime" which matches the brief's contract.
+   */
+  private readonly _coexistenceWarnedGroundings = new Set<string>();
 
   /**
    * @param tripleStore - RDF triple store backing vault assets.
@@ -1012,6 +1067,27 @@ export class CommandResolver {
       propertyDefaults = map;
     }
 
+    // RFC v2 Phase 3a — declarative ref-form replacement for the legacy
+    // `Grounding_propertyDefaults` JSON. Multi-valued list of
+    // `exocmd__PropertyDefault` assets attached via `Grounding_propertyDefault`.
+    const propertyDefault = await this.resolvePropertyDefaults(subject, uid);
+    // RFC v2 Phase 3a — multi-valued list of `exocmd__InheritanceRule` assets
+    // attached via `Grounding_inheritanceRule`. Phase 3b executor applies them.
+    const inheritanceRule = await this.resolveInheritanceRules(subject, uid);
+
+    // RFC v2 Phase 3a coexistence rule — both legacy JSON `propertyDefaults`
+    // and ref-form `propertyDefault` present on the same Grounding? Ref-form
+    // wins; legacy is dropped with a one-shot warn per Grounding-uid.
+    if (propertyDefaults !== undefined && propertyDefault.length > 0) {
+      if (!this._coexistenceWarnedGroundings.has(uid)) {
+        this.logger.warn(
+          `Grounding ${uid}: legacy exocmd__Grounding_propertyDefaults JSON ignored — ref-form exocmd__Grounding_propertyDefault takes precedence. Remove legacy property to silence this warning.`,
+        );
+        this._coexistenceWarnedGroundings.add(uid);
+      }
+      propertyDefaults = undefined;
+    }
+
     // Load composite steps if applicable
     let steps: GroundingDefinition[] | undefined;
     if (type === GroundingType.COMPOSITE) {
@@ -1081,6 +1157,8 @@ export class CommandResolver {
       incrementBy,
       shiftDelta: shiftDelta ?? undefined,
       propertyDefaults,
+      propertyDefault: propertyDefault.length > 0 ? propertyDefault : undefined,
+      inheritanceRule: inheritanceRule.length > 0 ? inheritanceRule : undefined,
       isDefinedBy: isDefinedBy ?? undefined,
       prefillLabelWithDate: prefillLabelWithDate || undefined,
     };
@@ -1122,6 +1200,333 @@ export class CommandResolver {
     }
 
     return steps;
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // RFC v2 Phase 3a — ref-form Grounding extensions (Phase 3b executor wires)
+  // ────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Resolve the multi-valued `exocmd__Grounding_propertyDefault` predicate
+   * into a list of {@link PropertyDefaultResolved} entries.
+   *
+   * Each referenced `exocmd__PropertyDefault` asset must carry:
+   *   - `exocmd__PropertyDefault_property` → wikilink to an `exo__Property`
+   *     asset; resolved to that property's `exo__Asset_label`.
+   *   - `exocmd__PropertyDefault_value` → wikilink to the value asset; if the
+   *     value asset is a SubstitutionToken instance, its
+   *     `exocmd__SubstitutionToken_resolver` is invoked (today / todayStart
+   *     resolve at parse time; targetFolder / target emit a marker for the
+   *     Phase 3b executor). Otherwise the value is emitted as
+   *     wikilink-form `"[[<UID>]]"`.
+   *
+   * Refs that cannot be resolved (target asset missing, property has no
+   * label) are skipped with a `logger.warn` — never silently dropped, never
+   * fail-loud (would mask other valid PropertyDefault entries on the same
+   * Grounding).
+   */
+  private async resolvePropertyDefaults(
+    grounding: IRI,
+    groundingUid: string,
+  ): Promise<PropertyDefaultResolved[]> {
+    const refTriples = await this.tripleStore.match(
+      grounding,
+      Namespace.EXOCMD.term("Grounding_propertyDefault"),
+      undefined,
+    );
+
+    const resolved: PropertyDefaultResolved[] = [];
+    for (const triple of refTriples) {
+      const refSubject = await this.resolveRefTripleObject(triple.object);
+      if (!refSubject) continue;
+
+      // -- property → exo__Asset_label of the referenced exo__Property
+      const propertyRefUid = await this.getObsidianName(
+        refSubject,
+        Namespace.EXOCMD.term("PropertyDefault_property"),
+      );
+      if (!propertyRefUid) {
+        this.logger.warn(
+          `Grounding ${groundingUid}: PropertyDefault asset missing exocmd__PropertyDefault_property — entry skipped.`,
+        );
+        continue;
+      }
+      const propertyName = this.looksLikeUUID(propertyRefUid)
+        ? await this.resolveLabelByUID(propertyRefUid)
+        : propertyRefUid;
+      if (!propertyName) {
+        this.logger.warn(
+          `Grounding ${groundingUid}: PropertyDefault property UID '${propertyRefUid}' is not resolvable to exo__Asset_label — entry skipped.`,
+        );
+        continue;
+      }
+
+      // -- value → either SubstitutionToken-resolved string, or wikilink form
+      const valueRefUid = await this.getObsidianName(
+        refSubject,
+        Namespace.EXOCMD.term("PropertyDefault_value"),
+      );
+      if (!valueRefUid) {
+        this.logger.warn(
+          `Grounding ${groundingUid}: PropertyDefault '${propertyName}' missing exocmd__PropertyDefault_value — entry skipped.`,
+        );
+        continue;
+      }
+
+      const value = await this.resolvePropertyDefaultValue(
+        valueRefUid,
+        groundingUid,
+        propertyName,
+      );
+      if (value === null) continue;
+
+      resolved.push({ propertyName, value });
+    }
+    return resolved;
+  }
+
+  /**
+   * Resolve the multi-valued `exocmd__Grounding_inheritanceRule` predicate
+   * into a list of {@link InheritanceRuleResolved} entries.
+   *
+   * Each `exocmd__InheritanceRule` asset declares 5 properties:
+   *   - `InheritanceRule_sourceProperty`  (REQUIRED — UID → label)
+   *   - `InheritanceRule_targetProperty`  (REQUIRED — UID → label)
+   *   - `InheritanceRule_targetClassCondition` (optional — UID → label)
+   *   - `InheritanceRule_targetClassExclusion` (optional, multi-valued — list of UIDs → labels)
+   *   - `InheritanceRule_priority`  (xsd:integer literal; defaults to 50)
+   *
+   * Missing REQUIRED fields cause the entry to be skipped with a warn;
+   * optional fields default to absent/empty/50.
+   */
+  private async resolveInheritanceRules(
+    grounding: IRI,
+    groundingUid: string,
+  ): Promise<InheritanceRuleResolved[]> {
+    const refTriples = await this.tripleStore.match(
+      grounding,
+      Namespace.EXOCMD.term("Grounding_inheritanceRule"),
+      undefined,
+    );
+
+    const resolved: InheritanceRuleResolved[] = [];
+    for (const triple of refTriples) {
+      const refSubject = await this.resolveRefTripleObject(triple.object);
+      if (!refSubject) continue;
+
+      const sourcePropertyName = await this.resolveLabelRef(
+        refSubject,
+        Namespace.EXOCMD.term("InheritanceRule_sourceProperty"),
+      );
+      if (!sourcePropertyName) {
+        this.logger.warn(
+          `Grounding ${groundingUid}: InheritanceRule missing/unresolvable exocmd__InheritanceRule_sourceProperty — entry skipped.`,
+        );
+        continue;
+      }
+
+      const targetPropertyName = await this.resolveLabelRef(
+        refSubject,
+        Namespace.EXOCMD.term("InheritanceRule_targetProperty"),
+      );
+      if (!targetPropertyName) {
+        this.logger.warn(
+          `Grounding ${groundingUid}: InheritanceRule missing/unresolvable exocmd__InheritanceRule_targetProperty — entry skipped.`,
+        );
+        continue;
+      }
+
+      const targetClassCondition = await this.resolveLabelRef(
+        refSubject,
+        Namespace.EXOCMD.term("InheritanceRule_targetClassCondition"),
+      );
+
+      const targetClassExclusion = await this.resolveLabelRefMulti(
+        refSubject,
+        Namespace.EXOCMD.term("InheritanceRule_targetClassExclusion"),
+      );
+
+      const priorityRaw = await this.getLiteralValue(
+        refSubject,
+        Namespace.EXOCMD.term("InheritanceRule_priority"),
+      );
+      let priority = 50;
+      if (priorityRaw !== null && priorityRaw !== "") {
+        const parsed = Number.parseInt(String(priorityRaw), 10);
+        if (Number.isFinite(parsed)) {
+          priority = parsed;
+        }
+      }
+
+      resolved.push({
+        sourcePropertyName,
+        targetPropertyName,
+        targetClassCondition: targetClassCondition ?? undefined,
+        targetClassExclusion,
+        priority,
+      });
+    }
+    return resolved;
+  }
+
+  /**
+   * Helper: given a triple object that points to another asset (IRI or
+   * literal wikilink), resolve it to the asset's subject IRI in the store.
+   *
+   * Mirrors `loadCompositeSteps`' pattern: accept either IRI (direct) or
+   * Literal (UUID wikilink → `findSubjectByUID`).
+   */
+  private async resolveRefTripleObject(object: unknown): Promise<IRI | null> {
+    if (object instanceof IRI) return object;
+    if (object instanceof Literal) {
+      const uid = this.normalizeWikilink(object.value);
+      if (!uid) return null;
+      return this.findSubjectByUID(uid);
+    }
+    return null;
+  }
+
+  /**
+   * Helper: read a single wikilink predicate, resolve it to the referenced
+   * asset's `exo__Asset_label`. UUID short-name path returns the asset label
+   * via `resolveLabelByUID`; non-UUID short-name is treated as already-symbolic
+   * (legacy authoring) and returned unchanged.
+   */
+  private async resolveLabelRef(
+    subject: IRI,
+    predicate: IRI,
+  ): Promise<string | null> {
+    const refUid = await this.getObsidianName(subject, predicate);
+    if (!refUid) return null;
+    if (!this.looksLikeUUID(refUid)) return refUid;
+    return this.resolveLabelByUID(refUid);
+  }
+
+  /**
+   * Helper: read a multi-valued wikilink predicate, resolve each referenced
+   * UID to its asset's `exo__Asset_label`. Refs that fail to resolve are
+   * dropped silently (the parent caller already controls aggregate semantics
+   * — e.g. an empty exclusion list means "no exclusion", which is a valid
+   * default; warning per-entry would spam).
+   */
+  private async resolveLabelRefMulti(
+    subject: IRI,
+    predicate: IRI,
+  ): Promise<string[]> {
+    const triples = await this.tripleStore.match(subject, predicate, undefined);
+    const labels: string[] = [];
+    for (const triple of triples) {
+      let name: string | null = null;
+      if (triple.object instanceof IRI) {
+        name = this.iriToObsidianName(triple.object.value) ?? triple.object.value;
+      } else if (triple.object instanceof Literal) {
+        name = this.unwrapWikilink(triple.object.value);
+      }
+      if (!name) continue;
+      const resolved = this.looksLikeUUID(name)
+        ? await this.resolveLabelByUID(name)
+        : name;
+      if (resolved) labels.push(resolved);
+    }
+    return labels;
+  }
+
+  /**
+   * Resolve the value side of a PropertyDefault entry. If the value asset is
+   * a SubstitutionToken instance, dispatch via the resolver registry; else
+   * emit wikilink-form `"[[<UID>]]"`.
+   *
+   * Returns `null` to signal "skip this entry" (e.g. value asset has no
+   * SubstitutionToken_resolver despite being typed as one — fail-loud per
+   * the brief).
+   */
+  private async resolvePropertyDefaultValue(
+    valueRefUid: string,
+    groundingUid: string,
+    propertyName: string,
+  ): Promise<string | null> {
+    // Non-UUID-form values (legacy symbolic shape) pass through as wikilinks.
+    if (!this.looksLikeUUID(valueRefUid)) {
+      return `"[[${valueRefUid}]]"`;
+    }
+
+    const valueSubject = await this.findSubjectByUID(valueRefUid);
+    if (!valueSubject) {
+      // Asset not in store yet (cold-start race / pruned vault) — emit
+      // wikilink anyway; downstream UI / executor renders it as a dead link.
+      return `"[[${valueRefUid}]]"`;
+    }
+
+    const isSubstitutionToken = await this.assetIsSubstitutionToken(valueSubject);
+    if (!isSubstitutionToken) {
+      return `"[[${valueRefUid}]]"`;
+    }
+
+    const resolverId = await this.getLiteralValue(
+      valueSubject,
+      Namespace.EXOCMD.term("SubstitutionToken_resolver"),
+    );
+    if (!resolverId || !resolverId.trim()) {
+      this.logger.warn(
+        `Grounding ${groundingUid}: PropertyDefault '${propertyName}' references SubstitutionToken '${valueRefUid}' with no exocmd__SubstitutionToken_resolver — falling back to wikilink form.`,
+      );
+      return `"[[${valueRefUid}]]"`;
+    }
+    const trimmedResolverId = resolverId.trim();
+
+    if (!KNOWN_SUBSTITUTION_RESOLVER_IDS.has(trimmedResolverId)) {
+      this.logger.warn(
+        `Grounding ${groundingUid}: PropertyDefault '${propertyName}' SubstitutionToken '${valueRefUid}' declares unknown resolver-id '${trimmedResolverId}' — falling back to wikilink form. Known ids: ${Array.from(KNOWN_SUBSTITUTION_RESOLVER_IDS).join(", ")}.`,
+      );
+      return `"[[${valueRefUid}]]"`;
+    }
+
+    // Context-independent resolvers — invoke at parse time.
+    if (trimmedResolverId === "today") {
+      return new Date().toISOString().slice(0, 10);
+    }
+    if (trimmedResolverId === "todayStart") {
+      return new Date(new Date().setHours(0, 0, 0, 0)).toISOString();
+    }
+
+    // Context-dependent resolvers (targetFolder / target) — emit a marker so
+    // the Phase 3b GroundingExecutor substitutes at runtime when the click
+    // target IRI/UID is known.
+    return buildSubstitutionMarker(trimmedResolverId, valueRefUid);
+  }
+
+  /**
+   * Detect whether `subject` is an instance of `exocmd__SubstitutionToken`.
+   *
+   * Primary path: iterate the asset's `exo__Instance_class` triples and
+   * compare each to `SUBSTITUTION_TOKEN_CLASS_IRI` (NoteToRDFConverter
+   * normalises every Instance_class triple to the namespace IRI regardless
+   * of authoring shape — symbolic, UUID-canon, or full IRI — via
+   * `valueToClassURI`).
+   *
+   * Fallback: when the class triple's object is a Literal wikilink (e.g.
+   * `[[<UID>|exocmd__SubstitutionToken]]` shape that didn't fully expand),
+   * unwrap to short-name and compare; or when the value is a bare UUID,
+   * compare to `SUBSTITUTION_TOKEN_CLASS_UID`.
+   */
+  private async assetIsSubstitutionToken(subject: IRI): Promise<boolean> {
+    const classTriples = await this.tripleStore.match(
+      subject,
+      Namespace.EXO.term("Instance_class"),
+      undefined,
+    );
+    for (const triple of classTriples) {
+      if (triple.object instanceof IRI) {
+        if (triple.object.value === SUBSTITUTION_TOKEN_CLASS_IRI) return true;
+        // Edge case: class IRI is the UUID-named TBox file URL itself.
+        if (triple.object.value.includes(SUBSTITUTION_TOKEN_CLASS_UID)) return true;
+      } else if (triple.object instanceof Literal) {
+        const unwrapped = this.unwrapWikilink(triple.object.value);
+        if (unwrapped === "exocmd__SubstitutionToken") return true;
+        if (unwrapped === SUBSTITUTION_TOKEN_CLASS_UID) return true;
+      }
+    }
+    return false;
   }
 
   private resolveGroundingType(value: string): GroundingType | null {

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -1453,35 +1453,6 @@ export class CommandResolver {
   }
 
   /**
-   * Helper: read a multi-valued wikilink predicate, resolve each referenced
-   * UID to its asset's `exo__Asset_label`. Refs that fail to resolve are
-   * dropped silently (the parent caller already controls aggregate semantics
-   * — e.g. an empty exclusion list means "no exclusion", which is a valid
-   * default; warning per-entry would spam).
-   */
-  private async resolveLabelRefMulti(
-    subject: IRI,
-    predicate: IRI,
-  ): Promise<string[]> {
-    const triples = await this.tripleStore.match(subject, predicate, undefined);
-    const labels: string[] = [];
-    for (const triple of triples) {
-      let name: string | null = null;
-      if (triple.object instanceof IRI) {
-        name = this.iriToObsidianName(triple.object.value) ?? triple.object.value;
-      } else if (triple.object instanceof Literal) {
-        name = this.unwrapWikilink(triple.object.value);
-      }
-      if (!name) continue;
-      const resolved = this.looksLikeUUID(name)
-        ? await this.resolveLabelByUID(name)
-        : name;
-      if (resolved) labels.push(resolved);
-    }
-    return labels;
-  }
-
-  /**
    * Resolve the value side of a PropertyDefault entry. If the value asset is
    * a SubstitutionToken instance, dispatch via the resolver registry; else
    * emit wikilink-form `"[[<UID>]]"`.

--- a/packages/exocortex/tests/unit/services/CommandResolver.coexistence.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.coexistence.test.ts
@@ -1,0 +1,231 @@
+/**
+ * CommandResolver — RFC v2 Phase 3a coexistence rule
+ * (Issue kitelev/exocortex#3162).
+ *
+ * Coverage:
+ * - Grounding with BOTH legacy `Grounding_propertyDefaults` JSON literal
+ *   AND ref-form `Grounding_propertyDefault` refs → ref-form wins,
+ *   legacy is dropped (`propertyDefaults` undefined), one warning logged.
+ * - Same Grounding parsed twice (via two distinct commands sharing it) →
+ *   warn is emitted **once** total per resolver instance / Grounding-uid.
+ *   `loadCommand` does not memoise, so the second call does re-enter the
+ *   coexistence branch — the warn-suppression Set must engage.
+ */
+
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+
+interface RecordingLogger extends ILogger {
+  readonly warnings: string[];
+}
+
+function makeRecordingLogger(): RecordingLogger {
+  const warnings: string[] = [];
+  return {
+    debug() {},
+    info() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
+    error() {},
+    warnings,
+  };
+}
+
+async function addLabelledAsset(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+}
+
+async function addPropertyDefaultAsset(
+  store: InMemoryTripleStore,
+  opts: { uid: string; propertyRefUid: string; valueRefUid: string },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(
+      subject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("PropertyDefault"),
+    ),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("PropertyDefault_property"),
+      new IRI(`obsidian://vault/${opts.propertyRefUid}.md`),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("PropertyDefault_value"),
+      new IRI(`obsidian://vault/${opts.valueRefUid}.md`),
+    ),
+  ]);
+}
+
+/**
+ * Grounding with BOTH legacy JSON `propertyDefaults` AND ref-form
+ * `Grounding_propertyDefault` (coexistence scenario).
+ */
+async function addGroundingWithBothShapes(
+  store: InMemoryTripleStore,
+  opts: {
+    uid: string;
+    label: string;
+    legacyJson: string;
+    refUids: string[];
+  },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(opts.label)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal("create_instance"),
+    ),
+    // Legacy JSON literal — must remain valid JSON object so the parser does
+    // not throw before reaching the coexistence branch.
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Grounding_propertyDefaults"),
+      new Literal(opts.legacyJson),
+    ),
+  ];
+  for (const ref of opts.refUids) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("Grounding_propertyDefault"),
+        new IRI(`obsidian://vault/${ref}.md`),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+async function addCommand(
+  store: InMemoryTripleStore,
+  commandUid: string,
+  groundingUid: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${commandUid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(commandUid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(commandUid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Command_grounding"),
+      new IRI(`obsidian://vault/${groundingUid}.md`),
+    ),
+  ]);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// UUID v4 fixtures
+// ────────────────────────────────────────────────────────────────────────────
+
+const PROP_UID  = "11111111-1111-4111-8111-111111111111";
+const VALUE_UID = "22222222-2222-4222-8222-222222222222";
+const PD_UID    = "33333333-3333-4333-8333-333333333333";
+
+const GROUNDING_UID = "44444444-4444-4444-8444-444444444444";
+const COMMAND_A     = "55555555-5555-4555-8555-555555555555";
+const COMMAND_B     = "66666666-6666-4666-8666-666666666666";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CommandResolver — RFC v2 Phase 3a coexistence (ref-form vs legacy JSON)", () => {
+  let store: InMemoryTripleStore;
+  let logger: RecordingLogger;
+  let resolver: CommandResolver;
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    logger = makeRecordingLogger();
+    resolver = new CommandResolver(store, logger);
+
+    // Seed property + value + PropertyDefault assets common to both tests.
+    await addLabelledAsset(store, PROP_UID, "ems__Effort_plannedStartTimestamp");
+    await addLabelledAsset(store, VALUE_UID, "ems__EffortStatusBacklog");
+    await addPropertyDefaultAsset(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: VALUE_UID,
+    });
+  });
+
+  it("drops legacy propertyDefaults JSON when ref-form propertyDefault is present (one warn)", async () => {
+    await addGroundingWithBothShapes(store, {
+      uid: GROUNDING_UID,
+      label: "Coexistence grounding",
+      legacyJson: '{"ems__Effort_status":"[[legacy-default]]"}',
+      refUids: [PD_UID],
+    });
+    await addCommand(store, COMMAND_A, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_A);
+
+    expect(cmd).not.toBeNull();
+    // Ref-form wins → legacy JSON dropped → propertyDefaults undefined.
+    expect(cmd!.grounding.propertyDefaults).toBeUndefined();
+    // Ref-form entry survives.
+    expect(cmd!.grounding.propertyDefault).toBeDefined();
+    expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+    expect(cmd!.grounding.propertyDefault![0].propertyName).toBe(
+      "ems__Effort_plannedStartTimestamp",
+    );
+
+    // Exactly one deprecation warning, mentioning both the Grounding-uid and
+    // the precedence direction.
+    const coexistenceWarns = logger.warnings.filter((w) =>
+      /legacy exocmd__Grounding_propertyDefaults JSON ignored/.test(w),
+    );
+    expect(coexistenceWarns).toHaveLength(1);
+    expect(coexistenceWarns[0]).toContain(GROUNDING_UID);
+    expect(coexistenceWarns[0]).toContain("ref-form");
+  });
+
+  it("warns once per Grounding-uid across multiple loadCommand calls on the same resolver", async () => {
+    await addGroundingWithBothShapes(store, {
+      uid: GROUNDING_UID,
+      label: "Coexistence grounding (shared)",
+      legacyJson: '{"ems__Effort_status":"[[legacy-default]]"}',
+      refUids: [PD_UID],
+    });
+    // Two distinct Commands sharing the SAME Grounding — guarantees two
+    // re-entries into loadGroundingDefinition (loadCommand has no result
+    // cache; resolveForAsset's cache is irrelevant here).
+    await addCommand(store, COMMAND_A, GROUNDING_UID);
+    await addCommand(store, COMMAND_B, GROUNDING_UID);
+
+    const cmdA = await resolver.loadCommand(COMMAND_A);
+    const cmdB = await resolver.loadCommand(COMMAND_B);
+
+    expect(cmdA).not.toBeNull();
+    expect(cmdB).not.toBeNull();
+
+    const coexistenceWarns = logger.warnings.filter((w) =>
+      /legacy exocmd__Grounding_propertyDefaults JSON ignored/.test(w),
+    );
+    // Once-per-session-per-Grounding-uid suppression: even though the
+    // Grounding was parsed twice, only one coexistence warn was emitted.
+    expect(coexistenceWarns).toHaveLength(1);
+  });
+});

--- a/packages/exocortex/tests/unit/services/CommandResolver.inheritanceRule.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.inheritanceRule.test.ts
@@ -1,0 +1,328 @@
+/**
+ * CommandResolver — RFC v2 Phase 3a ref-form `Grounding_inheritanceRule`
+ * resolution (Issue kitelev/exocortex#3162).
+ *
+ * Coverage:
+ * - Empty refs → no `inheritanceRule` field (optional).
+ * - Three rules covering all branches: targetClassCondition,
+ *   targetClassExclusion multi, unconditional — priorities + props parsed.
+ * - Missing `InheritanceRule_priority` literal → default 50.
+ * - Multi-valued `InheritanceRule_targetClassExclusion` → array of labels.
+ *
+ * Mirrors fixture patterns from CommandResolver.test.ts /
+ * CommandResolver.style.test.ts.
+ */
+
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+import type { InheritanceRuleResolved } from "../../../src/domain/models/CommandDefinition";
+
+interface RecordingLogger extends ILogger {
+  readonly warnings: string[];
+}
+
+function makeRecordingLogger(): RecordingLogger {
+  const warnings: string[] = [];
+  return {
+    debug() {},
+    info() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
+    error() {},
+    warnings,
+  };
+}
+
+async function addLabelledAsset(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+}
+
+interface InheritanceRuleOpts {
+  uid: string;
+  sourcePropertyRefUid: string;
+  targetPropertyRefUid: string;
+  targetClassConditionRefUid?: string;
+  targetClassExclusionRefUids?: string[];
+  priority?: number; // numeric → emitted as Literal(string); omit → no triple
+}
+
+async function addInheritanceRuleAsset(
+  store: InMemoryTripleStore,
+  opts: InheritanceRuleOpts,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(
+      subject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("InheritanceRule"),
+    ),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("InheritanceRule_sourceProperty"),
+      new IRI(`obsidian://vault/${opts.sourcePropertyRefUid}.md`),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("InheritanceRule_targetProperty"),
+      new IRI(`obsidian://vault/${opts.targetPropertyRefUid}.md`),
+    ),
+  ];
+  if (opts.targetClassConditionRefUid) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("InheritanceRule_targetClassCondition"),
+        new IRI(`obsidian://vault/${opts.targetClassConditionRefUid}.md`),
+      ),
+    );
+  }
+  for (const exclUid of opts.targetClassExclusionRefUids ?? []) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("InheritanceRule_targetClassExclusion"),
+        new IRI(`obsidian://vault/${exclUid}.md`),
+      ),
+    );
+  }
+  if (opts.priority !== undefined) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("InheritanceRule_priority"),
+        new Literal(String(opts.priority)),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+async function addGroundingWithInheritanceRules(
+  store: InMemoryTripleStore,
+  opts: { uid: string; label: string; ruleRefUids: string[] },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(opts.label)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal("create_instance"),
+    ),
+  ];
+  for (const ref of opts.ruleRefUids) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("Grounding_inheritanceRule"),
+        new IRI(`obsidian://vault/${ref}.md`),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+async function addCommandForGrounding(
+  store: InMemoryTripleStore,
+  commandUid: string,
+  groundingUid: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${commandUid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(commandUid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(commandUid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Command_grounding"),
+      new IRI(`obsidian://vault/${groundingUid}.md`),
+    ),
+  ]);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// UUID v4 fixtures
+// ────────────────────────────────────────────────────────────────────────────
+
+const SRC_PROP_UID = "11111111-1111-4111-8111-111111111111";
+const TGT_PROP_UID = "22222222-2222-4222-8222-222222222222";
+
+const COND_CLASS_AREA   = "33333333-3333-4333-8333-333333333333";
+const EXCL_CLASS_TASK   = "44444444-4444-4444-8444-444444444444";
+const EXCL_CLASS_PROJ   = "55555555-5555-4555-8555-555555555555";
+
+const RULE_UID_COND      = "66666666-6666-4666-8666-666666666666";
+const RULE_UID_EXCL      = "77777777-7777-4777-8777-777777777777";
+const RULE_UID_UNCOND    = "88888888-8888-4888-8888-888888888888";
+
+const GROUNDING_UID = "99999999-9999-4999-8999-999999999999";
+const COMMAND_UID   = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CommandResolver — RFC v2 Phase 3a resolveInheritanceRules", () => {
+  let store: InMemoryTripleStore;
+  let logger: RecordingLogger;
+  let resolver: CommandResolver;
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    logger = makeRecordingLogger();
+    resolver = new CommandResolver(store, logger);
+
+    // Seed common labelled assets — properties + classes used by most cases.
+    await addLabelledAsset(store, SRC_PROP_UID, "ems__Effort_area");
+    await addLabelledAsset(store, TGT_PROP_UID, "ems__Effort_areaInherited");
+    await addLabelledAsset(store, COND_CLASS_AREA, "ems__Area");
+    await addLabelledAsset(store, EXCL_CLASS_TASK, "ems__Task");
+    await addLabelledAsset(store, EXCL_CLASS_PROJ, "ems__Project");
+  });
+
+  it("returns no inheritanceRule field when Grounding has zero ref-form refs", async () => {
+    await addGroundingWithInheritanceRules(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding without IR refs",
+      ruleRefUids: [],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.grounding.inheritanceRule).toBeUndefined();
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it("parses 3 rules (condition / exclusion / unconditional) with all 5 properties each", async () => {
+    // Rule A — condition only, priority 100.
+    await addInheritanceRuleAsset(store, {
+      uid: RULE_UID_COND,
+      sourcePropertyRefUid: SRC_PROP_UID,
+      targetPropertyRefUid: TGT_PROP_UID,
+      targetClassConditionRefUid: COND_CLASS_AREA,
+      priority: 100,
+    });
+    // Rule B — exclusion of two classes, priority 50.
+    await addInheritanceRuleAsset(store, {
+      uid: RULE_UID_EXCL,
+      sourcePropertyRefUid: SRC_PROP_UID,
+      targetPropertyRefUid: TGT_PROP_UID,
+      targetClassExclusionRefUids: [EXCL_CLASS_TASK, EXCL_CLASS_PROJ],
+      priority: 50,
+    });
+    // Rule C — unconditional, priority 10.
+    await addInheritanceRuleAsset(store, {
+      uid: RULE_UID_UNCOND,
+      sourcePropertyRefUid: SRC_PROP_UID,
+      targetPropertyRefUid: TGT_PROP_UID,
+      priority: 10,
+    });
+
+    await addGroundingWithInheritanceRules(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with 3 IRs",
+      ruleRefUids: [RULE_UID_COND, RULE_UID_EXCL, RULE_UID_UNCOND],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.inheritanceRule).toBeDefined();
+    expect(cmd!.grounding.inheritanceRule).toHaveLength(3);
+
+    // Find each rule by priority — order is store-iteration-dependent, but
+    // priorities are unique per fixture, so a priority-keyed lookup is stable.
+    const byPriority = new Map<number, InheritanceRuleResolved>();
+    for (const rule of cmd!.grounding.inheritanceRule!) {
+      byPriority.set(rule.priority, rule);
+    }
+
+    const cond = byPriority.get(100);
+    expect(cond).toBeDefined();
+    expect(cond!.sourcePropertyName).toBe("ems__Effort_area");
+    expect(cond!.targetPropertyName).toBe("ems__Effort_areaInherited");
+    expect(cond!.targetClassCondition).toBe("ems__Area");
+    expect(cond!.targetClassExclusion).toEqual([]);
+
+    const excl = byPriority.get(50);
+    expect(excl).toBeDefined();
+    expect(excl!.targetClassCondition).toBeUndefined();
+    // Both excluded classes must be present.
+    expect(excl!.targetClassExclusion).toEqual(
+      expect.arrayContaining(["ems__Task", "ems__Project"]),
+    );
+    expect(excl!.targetClassExclusion).toHaveLength(2);
+
+    const uncond = byPriority.get(10);
+    expect(uncond).toBeDefined();
+    expect(uncond!.targetClassCondition).toBeUndefined();
+    expect(uncond!.targetClassExclusion).toEqual([]);
+  });
+
+  it("defaults priority to 50 when InheritanceRule_priority literal is absent", async () => {
+    await addInheritanceRuleAsset(store, {
+      uid: RULE_UID_UNCOND,
+      sourcePropertyRefUid: SRC_PROP_UID,
+      targetPropertyRefUid: TGT_PROP_UID,
+      // priority omitted → no Literal triple → resolver default 50
+    });
+    await addGroundingWithInheritanceRules(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with default-prio rule",
+      ruleRefUids: [RULE_UID_UNCOND],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.inheritanceRule).toHaveLength(1);
+    expect(cmd!.grounding.inheritanceRule![0].priority).toBe(50);
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it("resolves multi-valued targetClassExclusion to a labelled array", async () => {
+    await addInheritanceRuleAsset(store, {
+      uid: RULE_UID_EXCL,
+      sourcePropertyRefUid: SRC_PROP_UID,
+      targetPropertyRefUid: TGT_PROP_UID,
+      targetClassExclusionRefUids: [EXCL_CLASS_TASK, EXCL_CLASS_PROJ],
+      priority: 25,
+    });
+    await addGroundingWithInheritanceRules(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with multi-excl rule",
+      ruleRefUids: [RULE_UID_EXCL],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.inheritanceRule).toHaveLength(1);
+    const rule = cmd!.grounding.inheritanceRule![0];
+    expect(rule.targetClassExclusion).toHaveLength(2);
+    expect(rule.targetClassExclusion).toEqual(
+      expect.arrayContaining(["ems__Task", "ems__Project"]),
+    );
+    expect(rule.priority).toBe(25);
+  });
+});

--- a/packages/exocortex/tests/unit/services/CommandResolver.inheritanceRule.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.inheritanceRule.test.ts
@@ -325,4 +325,64 @@ describe("CommandResolver — RFC v2 Phase 3a resolveInheritanceRules", () => {
     );
     expect(rule.priority).toBe(25);
   });
+
+  // HIGH fix (PR #3224 code-review, 2026-05-22): broken condition/exclusion
+  // refs must skip the ENTIRE rule, not silently expand scope.
+  it("skips entire rule when targetClassCondition triple exists but ref unresolvable", async () => {
+    const BROKEN_CLASS_UID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+    // Add InheritanceRule that references a class UID that has no asset (no Asset_label triple).
+    await addInheritanceRuleAsset(store, {
+      uid: RULE_UID_COND,
+      sourcePropertyRefUid: SRC_PROP_UID,
+      targetPropertyRefUid: TGT_PROP_UID,
+      targetClassConditionRefUid: BROKEN_CLASS_UID, // exists in triple but never labelled
+      priority: 100,
+    });
+    await addGroundingWithInheritanceRules(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with broken condition ref",
+      ruleRefUids: [RULE_UID_COND],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    // Entire rule dropped — would-be unconditional rule is not silently applied.
+    expect(cmd!.grounding.inheritanceRule).toBeUndefined();
+    // Warn surfaces the scope-broadening risk.
+    expect(
+      logger.warnings.some((w) =>
+        w.includes("targetClassCondition triple but ref is unresolvable") &&
+        w.includes("entire rule skipped"),
+      ),
+    ).toBe(true);
+  });
+
+  it("skips entire rule when one targetClassExclusion entry is unresolvable (asymmetric scope expansion)", async () => {
+    const BROKEN_EXCL_UID = "ffffffff-ffff-4fff-8fff-fffffffffff0";
+    // Two exclusion refs — one valid, one broken (no asset_label triple).
+    await addInheritanceRuleAsset(store, {
+      uid: RULE_UID_EXCL,
+      sourcePropertyRefUid: SRC_PROP_UID,
+      targetPropertyRefUid: TGT_PROP_UID,
+      targetClassExclusionRefUids: [EXCL_CLASS_TASK, BROKEN_EXCL_UID],
+      priority: 50,
+    });
+    await addGroundingWithInheritanceRules(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with broken exclusion entry",
+      ruleRefUids: [RULE_UID_EXCL],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.inheritanceRule).toBeUndefined();
+    expect(
+      logger.warnings.some((w) =>
+        w.includes("targetClassExclusion entry") &&
+        w.includes("entire rule skipped"),
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/exocortex/tests/unit/services/CommandResolver.propertyDefault.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.propertyDefault.test.ts
@@ -1,0 +1,315 @@
+/**
+ * CommandResolver — RFC v2 Phase 3a ref-form `Grounding_propertyDefault`
+ * resolution (Issue kitelev/exocortex#3162).
+ *
+ * Coverage:
+ * - Empty refs → empty array (no triples; `propertyDefault` omitted).
+ * - Single PropertyDefault with regular wikilink value → resolved entry
+ *   with `propertyName` = property asset's `exo__Asset_label` and
+ *   `value` = `"[[<UID>]]"` wikilink form.
+ * - Two PropertyDefaults in stable triple-store-iteration order.
+ * - PropertyDefault whose property UID is unresolvable to a label → entry
+ *   skipped + `logger.warn` called.
+ *
+ * Mirrors the asset/store setup pattern from CommandResolver.test.ts and
+ * the `RecordingLogger` from CommandResolver.style.test.ts.
+ */
+
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Recording logger — captures warnings for assertion
+// ────────────────────────────────────────────────────────────────────────────
+
+interface RecordingLogger extends ILogger {
+  readonly warnings: string[];
+}
+
+function makeRecordingLogger(): RecordingLogger {
+  const warnings: string[] = [];
+  return {
+    debug() {},
+    info() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
+    error() {},
+    warnings,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fixture helpers — TBox assets needed for ref-form PropertyDefault parsing
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Property asset (an `exo__Property` instance, identified by UUID-named file). */
+async function addPropertyAsset(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<IRI> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+  return subject;
+}
+
+/** Generic value asset (regular asset, NOT a SubstitutionToken). */
+async function addValueAsset(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<IRI> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+  return subject;
+}
+
+/**
+ * `exocmd__PropertyDefault` instance. `Grounding_propertyDefault` will
+ * reference this via an IRI-form triple.
+ */
+async function addPropertyDefaultAsset(
+  store: InMemoryTripleStore,
+  opts: {
+    uid: string;
+    propertyRefUid: string; // UID of the exo__Property asset
+    valueRefUid: string; // UID of the value asset (regular or SubstitutionToken)
+  },
+): Promise<IRI> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(
+      subject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("PropertyDefault"),
+    ),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("PropertyDefault_property"),
+      new IRI(`obsidian://vault/${opts.propertyRefUid}.md`),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("PropertyDefault_value"),
+      new IRI(`obsidian://vault/${opts.valueRefUid}.md`),
+    ),
+  ]);
+  return subject;
+}
+
+/**
+ * `exocmd__Grounding` asset that points at zero or more PropertyDefault
+ * assets via multi-valued `Grounding_propertyDefault`.
+ */
+async function addGroundingWithPropertyDefaults(
+  store: InMemoryTripleStore,
+  opts: {
+    uid: string;
+    label: string;
+    type?: string;
+    propertyDefaultRefs?: string[];
+  },
+): Promise<IRI> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(opts.label)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal(opts.type ?? "create_instance"),
+    ),
+  ];
+  for (const ref of opts.propertyDefaultRefs ?? []) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("Grounding_propertyDefault"),
+        new IRI(`obsidian://vault/${ref}.md`),
+      ),
+    );
+  }
+  await store.addAll(triples);
+  return subject;
+}
+
+async function addCommandForGrounding(
+  store: InMemoryTripleStore,
+  commandUid: string,
+  groundingUid: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${commandUid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(commandUid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(commandUid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Command_grounding"),
+      new IRI(`obsidian://vault/${groundingUid}.md`),
+    ),
+  ]);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// UUID v4 fixtures — must satisfy CommandResolver.looksLikeUUID regex
+// ────────────────────────────────────────────────────────────────────────────
+
+const PROPERTY_UID_PLANNED = "11111111-1111-4111-8111-111111111111";
+const PROPERTY_UID_STATUS  = "22222222-2222-4222-8222-222222222222";
+const PROPERTY_UID_MISSING = "99999999-9999-4999-8999-999999999999";
+
+const VALUE_UID_TODAY   = "33333333-3333-4333-8333-333333333333";
+const VALUE_UID_BACKLOG = "44444444-4444-4444-8444-444444444444";
+
+const PD_UID_1 = "55555555-5555-4555-8555-555555555555";
+const PD_UID_2 = "66666666-6666-4666-8666-666666666666";
+const PD_UID_BAD = "77777777-7777-4777-8777-777777777777";
+
+const GROUNDING_UID = "88888888-8888-4888-8888-888888888888";
+const COMMAND_UID   = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CommandResolver — RFC v2 Phase 3a resolvePropertyDefaults", () => {
+  let store: InMemoryTripleStore;
+  let logger: RecordingLogger;
+  let resolver: CommandResolver;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    logger = makeRecordingLogger();
+    resolver = new CommandResolver(store, logger);
+  });
+
+  it("returns no propertyDefault array when Grounding has zero ref-form refs", async () => {
+    await addGroundingWithPropertyDefaults(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding without PD refs",
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd).not.toBeNull();
+    // resolvePropertyDefaults returns []; loadGroundingDefinition omits the
+    // field from the projection (length > 0 ? array : undefined).
+    expect(cmd!.grounding.propertyDefault).toBeUndefined();
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it("resolves one PropertyDefault whose value points to a regular asset → wikilink form", async () => {
+    await addPropertyAsset(store, PROPERTY_UID_PLANNED, "ems__Effort_plannedStartTimestamp");
+    await addValueAsset(store, VALUE_UID_BACKLOG, "ems__EffortStatusBacklog");
+    await addPropertyDefaultAsset(store, {
+      uid: PD_UID_1,
+      propertyRefUid: PROPERTY_UID_PLANNED,
+      valueRefUid: VALUE_UID_BACKLOG,
+    });
+    await addGroundingWithPropertyDefaults(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with one PD",
+      propertyDefaultRefs: [PD_UID_1],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault).toBeDefined();
+    expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+    expect(cmd!.grounding.propertyDefault![0]).toEqual({
+      propertyName: "ems__Effort_plannedStartTimestamp",
+      value: `"[[${VALUE_UID_BACKLOG}]]"`,
+    });
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it("resolves two PropertyDefaults in stable iteration order", async () => {
+    await addPropertyAsset(store, PROPERTY_UID_PLANNED, "ems__Effort_plannedStartTimestamp");
+    await addPropertyAsset(store, PROPERTY_UID_STATUS, "ems__Effort_status");
+    await addValueAsset(store, VALUE_UID_TODAY, "today-value");
+    await addValueAsset(store, VALUE_UID_BACKLOG, "ems__EffortStatusBacklog");
+    await addPropertyDefaultAsset(store, {
+      uid: PD_UID_1,
+      propertyRefUid: PROPERTY_UID_PLANNED,
+      valueRefUid: VALUE_UID_TODAY,
+    });
+    await addPropertyDefaultAsset(store, {
+      uid: PD_UID_2,
+      propertyRefUid: PROPERTY_UID_STATUS,
+      valueRefUid: VALUE_UID_BACKLOG,
+    });
+    await addGroundingWithPropertyDefaults(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with two PDs",
+      propertyDefaultRefs: [PD_UID_1, PD_UID_2],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault).toHaveLength(2);
+    const propertyNames = cmd!.grounding.propertyDefault!.map((p) => p.propertyName);
+    // Both expected entries must be present; insertion order is preserved by
+    // the triple-store's deterministic SPO iteration.
+    expect(propertyNames).toContain("ems__Effort_plannedStartTimestamp");
+    expect(propertyNames).toContain("ems__Effort_status");
+
+    const planned = cmd!.grounding.propertyDefault!.find(
+      (p) => p.propertyName === "ems__Effort_plannedStartTimestamp",
+    );
+    expect(planned?.value).toBe(`"[[${VALUE_UID_TODAY}]]"`);
+    const status = cmd!.grounding.propertyDefault!.find(
+      (p) => p.propertyName === "ems__Effort_status",
+    );
+    expect(status?.value).toBe(`"[[${VALUE_UID_BACKLOG}]]"`);
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it("skips PropertyDefault whose property UID is unresolvable and logs a warning", async () => {
+    // Seed value asset only — the property UID is missing, simulating a
+    // dangling wikilink (asset deleted, vault not yet re-indexed).
+    await addValueAsset(store, VALUE_UID_BACKLOG, "ems__EffortStatusBacklog");
+    await addPropertyDefaultAsset(store, {
+      uid: PD_UID_BAD,
+      propertyRefUid: PROPERTY_UID_MISSING,
+      valueRefUid: VALUE_UID_BACKLOG,
+    });
+    await addGroundingWithPropertyDefaults(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with bad PD",
+      propertyDefaultRefs: [PD_UID_BAD],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    // Bad PropertyDefault skipped → propertyDefault array empty → omitted.
+    expect(cmd!.grounding.propertyDefault).toBeUndefined();
+    expect(logger.warnings.length).toBeGreaterThan(0);
+    // Warning must mention the unresolvable UID for actionable diagnostics.
+    expect(
+      logger.warnings.some(
+        (w) =>
+          w.includes(PROPERTY_UID_MISSING) &&
+          /not resolvable to exo__Asset_label/.test(w),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/exocortex/tests/unit/services/CommandResolver.refForm.bdd.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.refForm.bdd.test.ts
@@ -1,0 +1,440 @@
+/**
+ * CommandResolver — RFC v2 Phase 3a ref-form Grounding BDD scenarios
+ * (Issue kitelev/exocortex#3162).
+ *
+ * Feature: CommandResolver — ref-form PropertyDefault and InheritanceRule
+ *
+ * Why BDD-style here, not Cucumber: `packages/exocortex` has no
+ * `@cucumber/cucumber` / `jest-cucumber` dependency. The package's `tests/`
+ * tree is jest-only. Existing BDD feature files live under
+ * `packages/cli/specs/features/` and `packages/obsidian-plugin/specs/features/`,
+ * each driven by package-local step definitions whose imports cannot reach
+ * the exocortex package internals (CommandResolver) without significant
+ * wiring. To keep the BDD-style verification close to the unit being tested
+ * — and to land within scope — these 4 scenarios are expressed as
+ * Given/When/Then-shaped jest `describe`/`it` blocks. Naming convention
+ * `.bdd.test.ts` flags the intent; each `it` block names its scenario
+ * verbatim.
+ */
+
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+
+// ────────────────────────────────────────────────────────────────────────────
+// BDD scaffolding — recording logger, asset builders. Kept self-contained so
+// the file is readable as a feature spec in isolation.
+// ────────────────────────────────────────────────────────────────────────────
+
+interface RecordingLogger extends ILogger {
+  readonly warnings: string[];
+}
+
+function makeRecordingLogger(): RecordingLogger {
+  const warnings: string[] = [];
+  return {
+    debug() {},
+    info() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
+    error() {},
+    warnings,
+  };
+}
+
+async function givenLabelledAsset(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+}
+
+async function givenSubstitutionToken(
+  store: InMemoryTripleStore,
+  opts: { uid: string; label: string; resolverId: string },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(opts.label)),
+    new Triple(
+      subject,
+      Namespace.EXO.term("Instance_class"),
+      Namespace.EXOCMD.term("SubstitutionToken"),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("SubstitutionToken_resolver"),
+      new Literal(opts.resolverId),
+    ),
+  ]);
+}
+
+async function givenPropertyDefault(
+  store: InMemoryTripleStore,
+  opts: { uid: string; propertyRefUid: string; valueRefUid: string },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(
+      subject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("PropertyDefault"),
+    ),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("PropertyDefault_property"),
+      new IRI(`obsidian://vault/${opts.propertyRefUid}.md`),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("PropertyDefault_value"),
+      new IRI(`obsidian://vault/${opts.valueRefUid}.md`),
+    ),
+  ]);
+}
+
+interface InheritanceRuleSpec {
+  uid: string;
+  sourcePropertyRefUid: string;
+  targetPropertyRefUid: string;
+  targetClassConditionRefUid?: string;
+  targetClassExclusionRefUids?: string[];
+  priority?: number;
+}
+
+async function givenInheritanceRule(
+  store: InMemoryTripleStore,
+  opts: InheritanceRuleSpec,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(
+      subject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("InheritanceRule"),
+    ),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("InheritanceRule_sourceProperty"),
+      new IRI(`obsidian://vault/${opts.sourcePropertyRefUid}.md`),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("InheritanceRule_targetProperty"),
+      new IRI(`obsidian://vault/${opts.targetPropertyRefUid}.md`),
+    ),
+  ];
+  if (opts.targetClassConditionRefUid) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("InheritanceRule_targetClassCondition"),
+        new IRI(`obsidian://vault/${opts.targetClassConditionRefUid}.md`),
+      ),
+    );
+  }
+  for (const excl of opts.targetClassExclusionRefUids ?? []) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("InheritanceRule_targetClassExclusion"),
+        new IRI(`obsidian://vault/${excl}.md`),
+      ),
+    );
+  }
+  if (opts.priority !== undefined) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("InheritanceRule_priority"),
+        new Literal(String(opts.priority)),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+interface GroundingSpec {
+  uid: string;
+  label?: string;
+  legacyJson?: string;
+  propertyDefaultRefs?: string[];
+  inheritanceRuleRefs?: string[];
+}
+
+async function givenGrounding(
+  store: InMemoryTripleStore,
+  opts: GroundingSpec,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      subject,
+      Namespace.EXO.term("Asset_label"),
+      new Literal(opts.label ?? opts.uid),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal("create_instance"),
+    ),
+  ];
+  if (opts.legacyJson !== undefined) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("Grounding_propertyDefaults"),
+        new Literal(opts.legacyJson),
+      ),
+    );
+  }
+  for (const ref of opts.propertyDefaultRefs ?? []) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("Grounding_propertyDefault"),
+        new IRI(`obsidian://vault/${ref}.md`),
+      ),
+    );
+  }
+  for (const ref of opts.inheritanceRuleRefs ?? []) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("Grounding_inheritanceRule"),
+        new IRI(`obsidian://vault/${ref}.md`),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+async function givenCommand(
+  store: InMemoryTripleStore,
+  commandUid: string,
+  groundingUid: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${commandUid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(commandUid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(commandUid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Command_grounding"),
+      new IRI(`obsidian://vault/${groundingUid}.md`),
+    ),
+  ]);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// UUID v4 fixtures (per-scenario UIDs declared inside their describe blocks).
+// ────────────────────────────────────────────────────────────────────────────
+
+const PROP_UID_PRIMARY  = "11111111-1111-4111-8111-111111111111";
+const VALUE_UID_BACKLOG = "22222222-2222-4222-8222-222222222222";
+const TOKEN_UID_TODAY   = "33333333-3333-4333-8333-333333333333";
+
+const PROP_UID_TARGET_INHERITED = "44444444-4444-4444-8444-444444444444";
+
+const COND_CLASS_AREA = "55555555-5555-4555-8555-555555555555";
+const EXCL_CLASS_TASK = "66666666-6666-4666-8666-666666666666";
+
+const PD_UID_1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+const RULE_UID_COND   = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const RULE_UID_EXCL   = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const RULE_UID_UNCOND = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+const GROUNDING_UID = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+const COMMAND_UID   = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Feature: CommandResolver — ref-form PropertyDefault and InheritanceRule
+// (RFC v2 Phase 3a)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("Feature: CommandResolver — ref-form PropertyDefault and InheritanceRule (RFC v2 Phase 3a)", () => {
+  let store: InMemoryTripleStore;
+  let logger: RecordingLogger;
+  let resolver: CommandResolver;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    logger = makeRecordingLogger();
+    resolver = new CommandResolver(store, logger);
+  });
+
+  it(
+    "Scenario: PropertyDefault refs resolve to array — " +
+      "Given a Grounding asset with ref-form Grounding_propertyDefault pointing to 1 PropertyDefault instance " +
+      "When the grounding is loaded by CommandResolver " +
+      "Then the returned GroundingDefinition.propertyDefault has length 1 " +
+      "And the entry's propertyName matches the resolved exo__Asset_label",
+    async () => {
+      // Given
+      await givenLabelledAsset(store, PROP_UID_PRIMARY, "ems__Effort_plannedStartTimestamp");
+      await givenLabelledAsset(store, VALUE_UID_BACKLOG, "ems__EffortStatusBacklog");
+      await givenPropertyDefault(store, {
+        uid: PD_UID_1,
+        propertyRefUid: PROP_UID_PRIMARY,
+        valueRefUid: VALUE_UID_BACKLOG,
+      });
+      await givenGrounding(store, {
+        uid: GROUNDING_UID,
+        label: "Grounding-1 PD ref",
+        propertyDefaultRefs: [PD_UID_1],
+      });
+      await givenCommand(store, COMMAND_UID, GROUNDING_UID);
+
+      // When
+      const cmd = await resolver.loadCommand(COMMAND_UID);
+
+      // Then
+      expect(cmd).not.toBeNull();
+      expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+      expect(cmd!.grounding.propertyDefault![0].propertyName).toBe(
+        "ems__Effort_plannedStartTimestamp",
+      );
+    },
+  );
+
+  it(
+    "Scenario: InheritanceRule mutual exclusion (3 rules) — " +
+      "Given a Grounding asset with 3 InheritanceRule refs (Area condition prio 100, non-Area exclusion prio 50, unconditional prio 10) " +
+      "When the grounding is loaded " +
+      "Then the returned GroundingDefinition.inheritanceRule has length 3 " +
+      "And priorities [100, 50, 10] are all present",
+    async () => {
+      // Given
+      await givenLabelledAsset(store, PROP_UID_PRIMARY, "ems__Effort_area");
+      await givenLabelledAsset(store, PROP_UID_TARGET_INHERITED, "ems__Effort_areaInherited");
+      await givenLabelledAsset(store, COND_CLASS_AREA, "ems__Area");
+      await givenLabelledAsset(store, EXCL_CLASS_TASK, "ems__Task");
+
+      await givenInheritanceRule(store, {
+        uid: RULE_UID_COND,
+        sourcePropertyRefUid: PROP_UID_PRIMARY,
+        targetPropertyRefUid: PROP_UID_TARGET_INHERITED,
+        targetClassConditionRefUid: COND_CLASS_AREA,
+        priority: 100,
+      });
+      await givenInheritanceRule(store, {
+        uid: RULE_UID_EXCL,
+        sourcePropertyRefUid: PROP_UID_PRIMARY,
+        targetPropertyRefUid: PROP_UID_TARGET_INHERITED,
+        targetClassExclusionRefUids: [EXCL_CLASS_TASK],
+        priority: 50,
+      });
+      await givenInheritanceRule(store, {
+        uid: RULE_UID_UNCOND,
+        sourcePropertyRefUid: PROP_UID_PRIMARY,
+        targetPropertyRefUid: PROP_UID_TARGET_INHERITED,
+        priority: 10,
+      });
+      await givenGrounding(store, {
+        uid: GROUNDING_UID,
+        label: "Grounding-3 IRs",
+        inheritanceRuleRefs: [RULE_UID_COND, RULE_UID_EXCL, RULE_UID_UNCOND],
+      });
+      await givenCommand(store, COMMAND_UID, GROUNDING_UID);
+
+      // When
+      const cmd = await resolver.loadCommand(COMMAND_UID);
+
+      // Then
+      expect(cmd!.grounding.inheritanceRule).toHaveLength(3);
+      const priorities = cmd!.grounding.inheritanceRule!.map((r) => r.priority);
+      // Iteration order is store-dependent but unique priorities allow a
+      // set-equality check that is robust against re-ordering.
+      expect(new Set(priorities)).toEqual(new Set([100, 50, 10]));
+    },
+  );
+
+  it(
+    "Scenario: Coexistence — ref-form wins over legacy JSON — " +
+      "Given a Grounding with both legacy _propertyDefaults JSON literal AND ref-form _propertyDefault " +
+      "When the grounding is loaded " +
+      "Then the returned GroundingDefinition.propertyDefaults is undefined " +
+      "And propertyDefault is the resolved array " +
+      "And a deprecation warning is logged once",
+    async () => {
+      // Given
+      await givenLabelledAsset(store, PROP_UID_PRIMARY, "ems__Effort_plannedStartTimestamp");
+      await givenLabelledAsset(store, VALUE_UID_BACKLOG, "ems__EffortStatusBacklog");
+      await givenPropertyDefault(store, {
+        uid: PD_UID_1,
+        propertyRefUid: PROP_UID_PRIMARY,
+        valueRefUid: VALUE_UID_BACKLOG,
+      });
+      await givenGrounding(store, {
+        uid: GROUNDING_UID,
+        label: "Grounding-coexistence",
+        legacyJson: '{"ems__Effort_status":"[[legacy-default]]"}',
+        propertyDefaultRefs: [PD_UID_1],
+      });
+      await givenCommand(store, COMMAND_UID, GROUNDING_UID);
+
+      // When
+      const cmd = await resolver.loadCommand(COMMAND_UID);
+
+      // Then
+      expect(cmd!.grounding.propertyDefaults).toBeUndefined();
+      expect(cmd!.grounding.propertyDefault).toBeDefined();
+      expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+      const coexistenceWarns = logger.warnings.filter((w) =>
+        /legacy exocmd__Grounding_propertyDefaults JSON ignored/.test(w),
+      );
+      expect(coexistenceWarns).toHaveLength(1);
+    },
+  );
+
+  it(
+    "Scenario: SubstitutionToken parse-time resolution — " +
+      "Given a PropertyDefault with value pointing to SubstitutionToken (resolver `today`) " +
+      "When the grounding is loaded " +
+      "Then the returned value matches the pattern YYYY-MM-DD",
+    async () => {
+      // Given
+      await givenLabelledAsset(store, PROP_UID_PRIMARY, "ems__Effort_plannedStartTimestamp");
+      await givenSubstitutionToken(store, {
+        uid: TOKEN_UID_TODAY,
+        label: "$today",
+        resolverId: "today",
+      });
+      await givenPropertyDefault(store, {
+        uid: PD_UID_1,
+        propertyRefUid: PROP_UID_PRIMARY,
+        valueRefUid: TOKEN_UID_TODAY,
+      });
+      await givenGrounding(store, {
+        uid: GROUNDING_UID,
+        label: "Grounding-$today",
+        propertyDefaultRefs: [PD_UID_1],
+      });
+      await givenCommand(store, COMMAND_UID, GROUNDING_UID);
+
+      // When
+      const cmd = await resolver.loadCommand(COMMAND_UID);
+
+      // Then
+      expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+      expect(cmd!.grounding.propertyDefault![0].value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    },
+  );
+});

--- a/packages/exocortex/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -1,0 +1,275 @@
+/**
+ * CommandResolver — RFC v2 Phase 3a SubstitutionToken resolver registry
+ * dispatched from PropertyDefault values (Issue kitelev/exocortex#3162).
+ *
+ * Coverage:
+ * - Context-independent `today` resolver → resolved AT PARSE TIME to
+ *   YYYY-MM-DD ISO date string. Asserted by regex (clock-flake safe).
+ * - Context-dependent `targetFolder` resolver → emits marker
+ *   `__SUBSTITUTE__targetFolder__<uid>__` (Phase 3b executor wires this).
+ * - Unknown resolver-id → fallback to `"[[<UID>]]"` wikilink form + warn.
+ *
+ * Strategy: assetIsSubstitutionToken detects a value asset by inspecting
+ * `exo__Instance_class` triples. NoteToRDFConverter normalises every
+ * Instance_class triple's object to the canonical namespace IRI
+ * (`https://exocortex.my/ontology/exocmd#SubstitutionToken`) regardless of
+ * authoring shape, so tests emit IRI-form `Instance_class` triples to
+ * mirror production-grade RDF storage shape.
+ */
+
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+
+interface RecordingLogger extends ILogger {
+  readonly warnings: string[];
+}
+
+function makeRecordingLogger(): RecordingLogger {
+  const warnings: string[] = [];
+  return {
+    debug() {},
+    info() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
+    error() {},
+    warnings,
+  };
+}
+
+async function addLabelledAsset(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+}
+
+/**
+ * `exocmd__SubstitutionToken` instance.
+ *
+ * Stored shape mirrors NoteToRDFConverter output:
+ *   - `exo__Instance_class` → IRI of `exocmd:SubstitutionToken` (normalised).
+ *   - `exocmd__SubstitutionToken_resolver` → literal resolver-id.
+ */
+async function addSubstitutionToken(
+  store: InMemoryTripleStore,
+  opts: { uid: string; label: string; resolverId: string },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(opts.label)),
+    new Triple(
+      subject,
+      Namespace.EXO.term("Instance_class"),
+      Namespace.EXOCMD.term("SubstitutionToken"),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("SubstitutionToken_resolver"),
+      new Literal(opts.resolverId),
+    ),
+  ]);
+}
+
+async function addPropertyDefault(
+  store: InMemoryTripleStore,
+  opts: { uid: string; propertyRefUid: string; valueRefUid: string },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(
+      subject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("PropertyDefault"),
+    ),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("PropertyDefault_property"),
+      new IRI(`obsidian://vault/${opts.propertyRefUid}.md`),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("PropertyDefault_value"),
+      new IRI(`obsidian://vault/${opts.valueRefUid}.md`),
+    ),
+  ]);
+}
+
+async function addGrounding(
+  store: InMemoryTripleStore,
+  opts: { uid: string; label: string; propertyDefaultRefs: string[] },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(opts.label)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal("create_instance"),
+    ),
+  ];
+  for (const ref of opts.propertyDefaultRefs) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("Grounding_propertyDefault"),
+        new IRI(`obsidian://vault/${ref}.md`),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+async function addCommand(
+  store: InMemoryTripleStore,
+  commandUid: string,
+  groundingUid: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${commandUid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(commandUid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(commandUid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Command_grounding"),
+      new IRI(`obsidian://vault/${groundingUid}.md`),
+    ),
+  ]);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// UUID v4 fixtures
+// ────────────────────────────────────────────────────────────────────────────
+
+const PROP_UID = "11111111-1111-4111-8111-111111111111";
+
+const TOKEN_TODAY_UID         = "22222222-2222-4222-8222-222222222222";
+const TOKEN_TARGET_FOLDER_UID = "33333333-3333-4333-8333-333333333333";
+const TOKEN_UNKNOWN_UID       = "44444444-4444-4444-8444-444444444444";
+
+const PD_UID  = "55555555-5555-4555-8555-555555555555";
+
+const GROUNDING_UID = "88888888-8888-4888-8888-888888888888";
+const COMMAND_UID   = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () => {
+  let store: InMemoryTripleStore;
+  let logger: RecordingLogger;
+  let resolver: CommandResolver;
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    logger = makeRecordingLogger();
+    resolver = new CommandResolver(store, logger);
+    await addLabelledAsset(store, PROP_UID, "ems__Effort_plannedStartTimestamp");
+  });
+
+  it("resolves a `today` SubstitutionToken at parse time to a YYYY-MM-DD literal", async () => {
+    await addSubstitutionToken(store, {
+      uid: TOKEN_TODAY_UID,
+      label: "$today",
+      resolverId: "today",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: TOKEN_TODAY_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with $today PD",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+    const value = cmd!.grounding.propertyDefault![0].value;
+    // Clock-flake safe assertion — regex, not literal.
+    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it("encodes a `targetFolder` SubstitutionToken as a marker for the Phase 3b executor", async () => {
+    await addSubstitutionToken(store, {
+      uid: TOKEN_TARGET_FOLDER_UID,
+      label: "$targetFolder",
+      resolverId: "targetFolder",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: TOKEN_TARGET_FOLDER_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with $targetFolder PD",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+    // Marker format from buildSubstitutionMarker: __SUBSTITUTE__<id>__<uid>__
+    expect(cmd!.grounding.propertyDefault![0].value).toBe(
+      `__SUBSTITUTE__targetFolder__${TOKEN_TARGET_FOLDER_UID}__`,
+    );
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it("falls back to wikilink form and warns when SubstitutionToken declares an unknown resolver-id", async () => {
+    await addSubstitutionToken(store, {
+      uid: TOKEN_UNKNOWN_UID,
+      label: "$bogusResolver",
+      resolverId: "definitelyNotAKnownResolver",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: TOKEN_UNKNOWN_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with unknown resolver",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+    // Fallback to wikilink form with the token's own UID.
+    expect(cmd!.grounding.propertyDefault![0].value).toBe(
+      `"[[${TOKEN_UNKNOWN_UID}]]"`,
+    );
+    // Warning must surface the unknown resolver-id for actionable debugging.
+    expect(
+      logger.warnings.some(
+        (w) =>
+          w.includes("definitelyNotAKnownResolver") &&
+          /unknown resolver-id/.test(w),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

RFC v2 Phase 3a — implements the **parser half** of engine integration. Extends `CommandResolver.loadGroundingDefinition` to read two new ref-form multi-valued Grounding predicates and resolve them into structured arrays for `GroundingExecutor` (Phase 3b, #3163) to consume.

Phase 1 (#3160) shipped the TBox classes. Phase 2 (#3161) attached instances to Grounding \`a6ef8fda-…\`. This phase makes the parser **aware** of those refs. **No behavior change to existing groundings** — `executeCreateInstance` (Phase 3b) does not yet read the new fields.

## What changes

### Type additions

- `PropertyDefaultResolved { propertyName, value }`
- `InheritanceRuleResolved { sourcePropertyName, targetPropertyName, targetClassCondition?, targetClassExclusion[], priority }`
- `GroundingDefinition.propertyDefault?: ReadonlyArray<PropertyDefaultResolved>` (optional, ref-form)
- `GroundingDefinition.inheritanceRule?: ReadonlyArray<InheritanceRuleResolved>` (optional)
- Both re-exported from `@exocortex/core` public surface

### CommandResolver.ts — 7 new private parser methods

| Method | Purpose |
|---|---|
| `resolvePropertyDefaults(grounding, uid)` | Entry for \`Grounding_propertyDefault\` multi-ref |
| `resolveInheritanceRules(grounding, uid)` | Entry for \`Grounding_inheritanceRule\` multi-ref |
| `resolveRefTripleObject(object)` | IRI/Literal wikilink → subject IRI |
| `resolveLabelRef(subject, predicate)` | UID single → exo__Asset_label |
| `resolveLabelRefMulti(subject, predicate)` | UIDs multi → label list |
| `resolvePropertyDefaultValue(uid, gUid, propName)` | SubstitutionToken dispatch |
| `assetIsSubstitutionToken(subject)` | Type detection (3 IRI shapes) |

### SubstitutionToken resolver registry

Context-**independent** resolvers invoke at parse time:
- \`today\` → \`new Date().toISOString().slice(0, 10)\`
- \`todayStart\` → ISO start-of-day

Context-**dependent** resolvers emit marker for executor to invoke at runtime (Phase 3b):
- \`targetFolder\`, \`target\` → \`__SUBSTITUTE__<resolverId>__<tokenUid>__\`

Unknown resolver-id → \`logger.warn\` + fallback to wikilink \`[[<UID>]]\`.

### Coexistence rule

When a Grounding has **both** legacy \`Grounding_propertyDefaults\` (JSON literal) AND new ref-form \`Grounding_propertyDefault\`:
- ref-form wins; legacy field returned \`undefined\`
- \`logger.warn\` once per session per Grounding-uid (internal Set tracks)
- Deprecation message guides authors to remove legacy property

## Scope fence respected

- ⛔ \`GroundingExecutor.ts\` UNTOUCHED — that's Phase 3b (#3163, blockedBy this PR)
- ⛔ No vault assets touched — pure code change
- ⛔ Legacy JSON parser preserved unchanged for coexistence window (Phase 5 cleanup)

## Tests added (17 new, 0 regression)

| File | Tests |
|---|---|
| \`CommandResolver.propertyDefault.test.ts\` | 4 |
| \`CommandResolver.inheritanceRule.test.ts\` | 4 |
| \`CommandResolver.coexistence.test.ts\` | 2 |
| \`CommandResolver.substitutionToken.test.ts\` | 3 |
| \`CommandResolver.refForm.bdd.test.ts\` | 4 BDD scenarios |

**Note on BDD location:** \`packages/exocortex/tests/bdd/features/\` doesn't exist (BDD lives in cli + obsidian-plugin packages with Cucumber harness). 4 Gherkin scenarios from the spec are expressed as \`describe\`/\`it\` blocks with Given/When/Then comments in \`.bdd.test.ts\` file, preserving readability without adding Cucumber dep to exocortex package.

### Local verification

- All 17 new CommandResolver tests pass
- 114/114 total CommandResolver suite green (97 baseline + 17 new) — zero regression
- \`tsc --noEmit\` on packages/exocortex — 0 errors
- Pre-commit ADR rules — 13/13 pass (11 warnings, all pre-existing)

### Known pre-existing failures (unrelated)

17 failures in \`packages/cli/tests/integration/sparql-exo003.integration.test.ts\` — pre-existing rot. This PR doesn't touch CLI; per CLAUDE.md Test Suite Awareness, integration tests under \`tests/integration/\` are not CI-gated and can rot silently (see PR #3189 reference).

## Auto-merge discipline

⛔ \`gh pr merge --auto\` not used. This PR touches CommandResolver (parser path) per project CLAUDE.md «Auto-merge discipline» rule:

1. Push PR ✅
2. Wait CI green AND code-reviewer agent complete
3. Apply CRITICAL/HIGH/MEDIUM fixes
4. \`advisor()\` round-2 after fixes
5. Apply advisor catches
6. \`gh pr merge --squash --delete-branch\` (manual)

## Downstream

- Phase 3b (\`GroundingExecutor.ts\` precedence pipeline) → #3163 unblocked
- Phase 3.5 (CLI parity) → #3164 (after 3b)
- Phase 4a/4b (vault migration + legacy handler removal) → #3165/#3166
- Phase 5/6/6.5 → #3167/#3168/#3169

## RFC reference

\`vault-exodev/inbox/2f3f640b-c5e0-4873-8c56-c390b8402cfa.md\`

Closes #3162