### PR TITLE
fix(plugin): resolve exo__Instance_class to UID in convert paths (#3222)

### DIFF
--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -532,10 +532,15 @@ export class GroundingExecutor {
 
   private async executeConvertToTask(filePath: string): Promise<ExecutionResult> {
     const content = await this.fileReader.readFile(filePath);
+    // Issue #3222: route the hardcoded class label through the same
+    // execution-time resolver as create_instance (#3220) so the written
+    // exo__Instance_class is UUID-canon when a resolver is wired; falls back
+    // to label-form for tests/CLI/headless. See resolveClassRefToUid.
+    const classRef = await this.resolveClassRefToUid("ems__Task");
     const updated = this.frontmatterService.updateProperty(
       content,
       "exo__Instance_class",
-      `["[[ems__Task]]"]`,
+      `["[[${classRef}]]"]`,
     );
     await this.fileWriter.updateFile(filePath, updated);
     return { success: true };
@@ -543,10 +548,12 @@ export class GroundingExecutor {
 
   private async executeConvertToProject(filePath: string): Promise<ExecutionResult> {
     const content = await this.fileReader.readFile(filePath);
+    // Issue #3222: see executeConvertToTask — same UID-canon resolution.
+    const classRef = await this.resolveClassRefToUid("ems__Project");
     const updated = this.frontmatterService.updateProperty(
       content,
       "exo__Instance_class",
-      `["[[ems__Project]]"]`,
+      `["[[${classRef}]]"]`,
     );
     await this.fileWriter.updateFile(filePath, updated);
     return { success: true };

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -2392,4 +2392,172 @@ describe("Convert commands — production-shape dispatch (Finding 5 completion)"
       expect(writer.updateFile).not.toHaveBeenCalled();
     });
   });
+
+  // ===========================================================================
+  // Issue #3222: the convert paths (executeConvertToTask / executeConvertToProject)
+  // wrote a hardcoded label-form `["[[ems__Task]]"]` / `["[[ems__Project]]"]`,
+  // bypassing the execution-time class label→UID resolution added in #3220.
+  // When an ObsidianClassLabelResolver is injected (production plugin), the
+  // written `exo__Instance_class` must be UUID-canon. With no resolver
+  // (tests/CLI/headless), the label-form fallback is preserved.
+  // ===========================================================================
+  describe("Convert paths — UID-canon resolution (#3222)", () => {
+    const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+    const PROJECT_UID = "7db5eeff-718a-49b0-8d2b-39b084a356e3";
+
+    function makeResolver(map: Record<string, string>) {
+      const calls: string[] = [];
+      const fn = (label: string): string | null => {
+        calls.push(label);
+        return map[label] ?? null;
+      };
+      return { fn, calls };
+    }
+
+    it("Convert to Task emits UID-form exo__Instance_class when a resolver is wired", async () => {
+      const reader = createConvertReader("ems__Project");
+      const writer = createWriter();
+      const { fn, calls } = makeResolver({ ems__Task: TASK_UID });
+      const executor = new GroundingExecutor(
+        reader,
+        writer,
+        new ServiceRegistry(),
+        fn,
+      );
+
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "ems__Task",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      expect(calls).toContain("ems__Task");
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(
+        new RegExp(`exo__Instance_class:\\s*\\[?\\s*"\\[\\[${TASK_UID}\\]\\]"`),
+      );
+      // label-form was replaced by UID (regression criterion: pre-fix wrote
+      // "[[ems__Task]]") and the source class was overwritten.
+      expect(written).not.toMatch(/"\[\[ems__Task\]\]"/);
+      expect(written).not.toMatch(/"\[\[ems__Project\]\]"/);
+    });
+
+    it("Convert to Project emits UID-form exo__Instance_class when a resolver is wired", async () => {
+      const reader = createConvertReader("ems__Task");
+      const writer = createWriter();
+      const { fn, calls } = makeResolver({ ems__Project: PROJECT_UID });
+      const executor = new GroundingExecutor(
+        reader,
+        writer,
+        new ServiceRegistry(),
+        fn,
+      );
+
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "ems__Project",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      expect(calls).toContain("ems__Project");
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(
+        new RegExp(
+          `exo__Instance_class:\\s*\\[?\\s*"\\[\\[${PROJECT_UID}\\]\\]"`,
+        ),
+      );
+      // label-form was replaced by UID (regression criterion: pre-fix wrote
+      // "[[ems__Project]]") and the source class was overwritten.
+      expect(written).not.toMatch(/"\[\[ems__Project\]\]"/);
+      expect(written).not.toMatch(/"\[\[ems__Task\]\]"/);
+    });
+
+    it("Convert to Task falls back to label-form when no resolver is injected", async () => {
+      const reader = createConvertReader("ems__Project");
+      const writer = createWriter();
+      const executor = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "ems__Task",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(/exo__Instance_class:\s*\[?\s*"\[\[ems__Task\]\]"/);
+    });
+
+    it("Convert to Project falls back to label-form when no resolver is injected", async () => {
+      const reader = createConvertReader("ems__Task");
+      const writer = createWriter();
+      const executor = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "ems__Project",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(
+        /exo__Instance_class:\s*\[?\s*"\[\[ems__Project\]\]"/,
+      );
+    });
+
+    it("Convert to Task preserves label-form when resolver returns null (unresolvable)", async () => {
+      const reader = createConvertReader("ems__Project");
+      const writer = createWriter();
+      const { fn } = makeResolver({}); // resolves nothing
+      const executor = new GroundingExecutor(
+        reader,
+        writer,
+        new ServiceRegistry(),
+        fn,
+      );
+
+      const grounding = makeSvcCall({
+        targetProperty: "updateProperty",
+        targetValue: "ems__Task",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        FILE_PATH,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1] as string;
+      expect(written).toMatch(/exo__Instance_class:\s*\[?\s*"\[\[ems__Task\]\]"/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`GroundingExecutor.executeConvertToTask` / `executeConvertToProject` wrote a hardcoded label-form `exo__Instance_class` (`["[[ems__Task]]"]` / `["[[ems__Project]]"]`), bypassing the execution-time class label→UID resolution added in #3220 (PR #3221) and refined in #3223 (PR #3225). Same UUID-canon TBox violation as #3220 on the convert (`serviceId === "updateProperty"` short-circuit) path.

This routes both convert methods through the existing private `resolveClassRefToUid(...)` — no new resolver infrastructure. When the plugin wires `createObsidianClassLabelResolver(this.app)` (ExocortexPlugin.ts:235), the written class is UUID-canon; tests/CLI/headless (no resolver) preserve the label-form fallback.

`Closes #3222`

## Change
- `executeConvertToTask`: `resolveClassRefToUid("ems__Task")` → `["[[<UID>]]"]`
- `executeConvertToProject`: `resolveClassRefToUid("ems__Project")` → `["[[<UID>]]"]`

`resolveClassRefToUid` already handles: UUID short-circuit, null resolver → label-form fallback, resolver throw → label-form fallback.

## Test coverage
New `describe("Convert paths — UID-canon resolution (#3222)")` in `GroundingExecutor.test.ts` (5 cases):
- Convert to Task / Project emit UID-form when a resolver is wired (red→green regression criterion)
- Convert to Task / Project fall back to label-form with no resolver injected
- Convert to Task preserves label-form when resolver returns null
All 115 GroundingExecutor tests pass; related grounding/conversion/create-instance suites (30) pass; typecheck + lint clean.

Verified production class assets exist: `assetspaces/ems/1b20a8f0-...` (ems__Task), `7db5eeff-...` (ems__Project) — resolver will produce UID-form in prod.

## Out of scope
- #3195 (orthogonal sibling fix)

## Pending
- **Manual UI smoke after release** (per #3220/#3223 lesson: production-shape unit tests ≠ real Obsidian API contract).