### PR TITLE
fix(plugin): strip-canon exo__Asset_prototype to bare UID (#3195)

### DIFF
--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -1167,13 +1167,47 @@ export class GroundingExecutor {
   }
 
   /**
+   * Matches a bare UUID v4-shaped basename (the UID-canon filename convention,
+   * 2026-05-17). Anchored — must be the *entire* basename, so a folder named
+   * `<uuid>` embedded mid-path does not trip it.
+   */
+  private static readonly UUID_BASENAME_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  /**
    * Derive a stable wikilink target (vault-relative path, no `.md` suffix) for
    * the back-link property write. Falls back to decoding the `obsidian://` URL
    * when no fs path is provided. Without this normalization the executor would
-   * emit `[[obsidian://vault/.../<uid>.md]]` instead of the desired
-   * `[[<folder>/<basename>]]` form that Obsidian resolves directly.
+   * emit `[[obsidian://vault/.../<uid>.md]]` instead of an Obsidian-resolvable
+   * link.
+   *
+   * Issue #3195 — strip-canon: when the target is a UUID-named file (the
+   * UID-canon TBox/ABox convention, 2026-05-17), the link must be the BARE UID
+   * (`[[<uid>]]`), not the full vault-relative path
+   * (`[[assetspaces/shared-identities/<uid>]]`). Both forms resolve to the same
+   * file at runtime, but the path-form violates the convention and leaks a
+   * folder prefix into `exo__Asset_prototype` (and any other back-link this
+   * helper feeds). Non-UUID basenames (e.g. whitelisted `pn__DailyNote`
+   * `YYYY-MM-DD`, `period__Week` `YYYY-Www`) keep their path-form so Obsidian
+   * still resolves them.
    */
   private static extractBacklinkTarget(targetIRI: string, targetFilePath: string): string {
+    const path = GroundingExecutor.resolveTargetPath(targetIRI, targetFilePath);
+    const basename = path.split("/").pop() ?? path;
+    if (GroundingExecutor.UUID_BASENAME_RE.test(basename)) {
+      return basename;
+    }
+    return path;
+  }
+
+  /**
+   * Resolve the raw vault-relative path (no `.md` suffix, no leading slash) of
+   * the back-link target, from either the fs path or the `obsidian://` IRI.
+   * Split out from {@link extractBacklinkTarget} so the strip-canon gate has a
+   * single exit point covering both the fs-path and IRI-fallback branches
+   * (Issue #3195).
+   */
+  private static resolveTargetPath(targetIRI: string, targetFilePath: string): string {
     if (targetFilePath) {
       return targetFilePath.replace(/\.md$/i, "").replace(/^\/+/, "");
     }

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -950,6 +950,90 @@ describe("GroundingExecutor", () => {
       expect(content).toContain('exo__Asset_prototype: "[[vault/test-asset]]"');
     });
 
+    // Issue #3195: strip-canon. For UUID-named prototype-instance targets
+    // (UID-canon TBox/ABox convention, 2026-05-17), the `exo__Asset_prototype`
+    // back-link must be the BARE UID — `[[<uid>]]` — not the full vault-relative
+    // path `[[assetspaces/shared-identities/<uid>]]`. Both resolve to the same
+    // file in Obsidian runtime, but the path-form violates the convention.
+    //
+    // Production shape (from the issue's empirical evidence): the user clicks
+    // the Lunch prototype-instance whose file is
+    // `assetspaces/shared-identities/4b571141-…fc8410a.md`; `executeCreateInstance`
+    // receives that vault-relative path as `targetFilePath`. The fix lives in
+    // `extractBacklinkTarget` (a pure string transform — no Obsidian API to
+    // mock), so the realism that matters here is the path SHAPE, not a faked
+    // API return value.
+    describe("strip-canon back-link for UUID-named targets (Issue #3195)", () => {
+      const PROTO_UID = "4b571141-5fc3-4ddd-8f07-ca681fc8410a";
+      const PROTO_PATH = `assetspaces/shared-identities/${PROTO_UID}.md`;
+      const PROTO_IRI = `obsidian://vault/vault-2025/assetspaces/shared-identities/${PROTO_UID}.md`;
+
+      it("writes exo__Asset_prototype as bare UID, not path-form (targetFilePath branch)", async () => {
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetPrototype: "df7e579d-02d4-4f3a-971f-3d1d785b689b|ems__TaskPrototype",
+          targetFolder: "03 Knowledge/inbox",
+        });
+
+        const result = await executor.execute(
+          grounding,
+          PROTO_IRI,
+          PROTO_PATH,
+          { label: "Lunch 2026-05-19" },
+        );
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        // Bare strip-canon UID — the actual fix assertion.
+        expect(content).toContain(`exo__Asset_prototype: "[[${PROTO_UID}]]"`);
+        // Must NOT leak the path prefix.
+        expect(content).not.toContain("assetspaces/shared-identities");
+      });
+
+      it("strips path-form to bare UID via the obsidian:// IRI fallback branch too", async () => {
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "03 Knowledge/inbox",
+        });
+
+        // Empty targetFilePath forces the obsidian:// IRI decoding branch.
+        const result = await executor.execute(
+          grounding,
+          PROTO_IRI,
+          "",
+          { label: "Lunch" },
+        );
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain(`exo__Asset_prototype: "[[${PROTO_UID}]]"`);
+        expect(content).not.toContain("assetspaces/shared-identities");
+      });
+
+      it("leaves non-UUID-named targets in path-form (whitelist: DailyNote etc.)", async () => {
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "03 Knowledge/inbox",
+        });
+
+        // A DailyNote-style basename is NOT a UUID → path-form preserved so
+        // Obsidian still resolves it (basename is unique by calendar convention).
+        const result = await executor.execute(
+          grounding,
+          "obsidian://vault/vault-2025/01 Daily/2026-05-19.md",
+          "01 Daily/2026-05-19.md",
+          { label: "From daily" },
+        );
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain('exo__Asset_prototype: "[[01 Daily/2026-05-19]]"');
+      });
+    });
+
     it("should use 'Untitled' as default label when no user input", async () => {
       const grounding = makeGrounding({
         type: GroundingType.CREATE_INSTANCE,


### PR DESCRIPTION
## Summary

Follow-up to #3184 / #3189. `executeCreateInstance` correctly links `exo__Asset_prototype` to the prototype-**instance** UID (B1 fix in #3189), but composed the wikilink in **path-form** — `extractBacklinkTarget` returned the full vault-relative path (`assetspaces/shared-identities/<uid>`), violating the UID-canon **strip-canon** convention (2026-05-17, aiKnow `152e39df-cc1b-4175-a4f2-2c2913018937`).

### Before
```yaml
exo__Asset_prototype: "[[assetspaces/shared-identities/4b571141-5fc3-4ddd-8f07-ca681fc8410a]]"
```
### After
```yaml
exo__Asset_prototype: "[[4b571141-5fc3-4ddd-8f07-ca681fc8410a]]"
```

## Fix

Added a strip-canon gate in `GroundingExecutor.extractBacklinkTarget`: when the resolved target's **basename is a UUID**, emit the bare UID; otherwise keep path-form. The path resolution was split into `resolveTargetPath` so the strip-canon gate has a **single exit point** covering both the fs-path branch and the `obsidian://` IRI fallback branch.

Non-UUID basenames (whitelisted `pn__DailyNote` `YYYY-MM-DD`, `period__Week` `YYYY-Www` calendar notes) keep their path-form so Obsidian still resolves them — no regression to the existing `[[vault/test-asset]]` assertions in the 115 GroundingExecutor tests.

## Test coverage

New production-shape suite `strip-canon back-link for UUID-named targets (Issue #3195)` in `GroundingExecutor.test.ts`:
- fs-path branch: UUID-named target → bare `[[<uid>]]`, asserts **no** `assetspaces/shared-identities` path leak (issue's empirical shape).
- `obsidian://` IRI fallback branch: same strip-canon result.
- non-UUID (DailyNote) target → path-form preserved.

The fix is a pure string transform (no Obsidian API to mock). Logic was additionally validated via a standalone reproduction (OLD → path-form leak, NEW → bare UID for all UUID cases, path-form unchanged for non-UUID and existing `vault/test-asset`).

> Note on local jest: the exocortex package's `GroundingExecutor.test.ts` cannot be run fresh in a git worktree locally due to the known uuid ESM/CJS babel-root transform issue (uuid resolves outside the worktree's babel root). CI runs this suite via the `services/GroundingExecutor.test` allowlist in `scripts/test-ci-batched.sh`.

## Out of scope
None — last in the #3184 follow-up chain. Orthogonal to #3220/#3222/#3223 (class-IRI resolution side).

Closes #3195
