### PR TITLE
feat(engine): Phase 3b — GroundingExecutor 5-step pipeline (#3163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,7 +487,7 @@ jobs:
         run: |
           node ./node_modules/jest/bin/jest.js \
             --config packages/exocortex/jest.config.js \
-            --testPathPatterns='(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test)\.ts' \
+            --testPathPatterns='(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-phase3b-pipeline\.test)\.ts' \
             --forceExit
 
   test-coverage:

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -2,7 +2,11 @@ import { injectable } from "tsyringe";
 import { v4 as uuidv4 } from "uuid";
 import type { IFileSystemReader } from "../interfaces/IFileSystemAdapter";
 import type { IFileSystemWriter } from "../interfaces/IFileSystemAdapter";
-import type { GroundingDefinition } from "../domain/models/CommandDefinition";
+import type {
+  GroundingDefinition,
+  InheritanceRuleResolved,
+  PropertyDefaultResolved,
+} from "../domain/models/CommandDefinition";
 import { GroundingType } from "../domain/constants/GroundingType";
 import { FrontmatterService } from "../utilities/FrontmatterService";
 import { DateFormatter } from "../utilities/DateFormatter";
@@ -80,6 +84,18 @@ export type ClassLabelToUidResolver = (
 /** UUID-v4 sniff used to skip resolution for already-canonical class refs. */
 const UUID_V4_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * RFC v2 Phase 3a marker emitted by CommandResolver for context-dependent
+ * SubstitutionToken resolvers (`target`, `targetFolder`). Context-independent
+ * resolvers (`today`, `todayStart`) are resolved at parse time and never reach
+ * the executor in marker form. Shape: `__SUBSTITUTE__<resolver-id>__<token-uid>__`.
+ *
+ * Phase 3b executor recognises this exact shape and substitutes the resolved
+ * value at execution time when the click-target IRI / file path is known.
+ */
+const SUBSTITUTION_MARKER_RE =
+  /^__SUBSTITUTE__(target|targetFolder)__[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}__$/;
 
 /**
  * A named service that can be invoked by service_call groundings.
@@ -638,11 +654,37 @@ export class GroundingExecutor {
     // class-UID write here would either overwrite the correct back-link value
     // or be silently overwritten — both confusing.
 
-    // Issue #3136 (Q3.b closure): apply propertyDefaults BEFORE userInput so
-    // user input wins. Values are passed through substituteVariables, enabling
-    // declarative use of `$today` / `$todayStart` / `$targetFolder` / `$target`
-    // (replacing the legacy `createTaskForDailyNote` service_call).
-    if (grounding.propertyDefaults) {
+    // RFC v2 Phase 3b — Step 2 (PropertyDefault, declarative ref-form).
+    // Apply ref-form PropertyDefaults from `grounding.propertyDefault` (parser
+    // emits resolved-or-marker values per Phase 3a contract). The CommandResolver
+    // coexistence rule guarantees that legacy `propertyDefaults` JSON is
+    // `undefined` whenever ref-form is set, so both blocks below cannot
+    // double-write the same key (legacy block is skipped). Phase 3b values are
+    // emitted by the parser already resolved (today / todayStart) or as
+    // `__SUBSTITUTE__<resolver>__<token-uid>__` markers (target / targetFolder);
+    // executor substitutes the markers at runtime when click-target context is
+    // known. PropertyDefault explicitly bypasses CREATE_INSTANCE_BLACKLIST per
+    // RFC v2 §Precedence — blacklist applies ONLY to copy-from-target step 4.
+    if (grounding.propertyDefault && grounding.propertyDefault.length > 0) {
+      this.applyPropertyDefaultStep(
+        properties,
+        grounding.propertyDefault,
+        targetIRI,
+        targetFilePath,
+      );
+    }
+
+    // Issue #3136 (Q3.b closure): legacy JSON-literal propertyDefaults path.
+    // RFC v2 Phase 3a coexistence rule: ref-form `propertyDefault` takes
+    // precedence. The parser already returns legacy `propertyDefaults` as
+    // `undefined` when ref-form is set; this explicit guard provides
+    // defense-in-depth so a future parser regression OR a hand-edited Grounding
+    // with both shapes cannot silently overwrite ref-form values via the
+    // legacy block. Apply legacy BEFORE userInput so user input still wins.
+    if (
+      grounding.propertyDefaults &&
+      !(grounding.propertyDefault && grounding.propertyDefault.length > 0)
+    ) {
       for (const [key, rawValue] of Object.entries(grounding.propertyDefaults)) {
         if (typeof rawValue !== "string") continue;
         properties[key] = this.substituteVariables(
@@ -665,9 +707,9 @@ export class GroundingExecutor {
       }
     }
 
-    // Copy-from-target: read $target frontmatter and inherit any non-blacklisted
-    // property the new instance does not already have. Wikilink values are
-    // re-quoted so they round-trip through the YAML serializer.
+    // Parse $target frontmatter once — shared by Step 3 (InheritanceRule, reads
+    // source-property values) and Step 4 (copy-from-target, fills gaps).
+    let targetFm: Record<string, string | string[]> | null = null;
     if (targetIRI && targetFilePath) {
       let targetContent: string;
       try {
@@ -678,14 +720,36 @@ export class GroundingExecutor {
           error: `create_instance: failed to read $target file "${targetFilePath}": ${error instanceof Error ? error.message : String(error)}`,
         };
       }
+      targetFm = this.frontmatterService.parseObject(targetContent) ?? null;
+    }
 
-      const targetFm = this.frontmatterService.parseObject(targetContent);
-      if (targetFm) {
-        for (const [key, value] of Object.entries(targetFm)) {
-          if (GroundingExecutor.CREATE_INSTANCE_BLACKLIST.has(key)) continue;
-          if (properties[key] !== undefined) continue;
-          properties[key] = this.reformatCopiedValue(value);
-        }
+    // RFC v2 Phase 3b — Step 3 (InheritanceRule, declarative ref-form).
+    // Apply each applicable rule (condition match, exclusion non-match) in
+    // priority-descending order. Like Step 2, this bypasses CREATE_INSTANCE_BLACKLIST
+    // — `ems__Effort_area` and `ems__Effort_parent` are in the BLACKLIST but
+    // are LEGITIMATE inheritance targets per RFC. Step 3 only writes keys not
+    // already set by Steps 1 (userInput) or 2 (PropertyDefault).
+    if (
+      grounding.inheritanceRule &&
+      grounding.inheritanceRule.length > 0 &&
+      targetFm
+    ) {
+      await this.applyInheritanceRuleStep(
+        properties,
+        grounding.inheritanceRule,
+        targetFm,
+      );
+    }
+
+    // Step 4: Copy-from-target — read $target frontmatter and inherit any
+    // non-blacklisted property the new instance does not already have.
+    // Wikilink values are re-quoted so they round-trip through the YAML
+    // serializer. BLACKLIST applies ONLY here per RFC v2 §Precedence.
+    if (targetFm) {
+      for (const [key, value] of Object.entries(targetFm)) {
+        if (GroundingExecutor.CREATE_INSTANCE_BLACKLIST.has(key)) continue;
+        if (properties[key] !== undefined) continue;
+        properties[key] = this.reformatCopiedValue(value);
       }
     }
 
@@ -747,6 +811,232 @@ export class GroundingExecutor {
     } catch {
       return classRef;
     }
+  }
+
+  /**
+   * RFC v2 Phase 3b — Step 2 implementation. Apply ref-form PropertyDefaults
+   * declared by the Grounding via `exocmd__Grounding_propertyDefault`.
+   *
+   * Higher-priority steps (userInput) already populated `properties`; this
+   * step only writes keys not already set. Values flow from CommandResolver
+   * (Phase 3a) either fully-resolved (e.g. `today` → `2026-05-23`) or as
+   * `__SUBSTITUTE__<resolver-id>__<token-uid>__` markers for context-dependent
+   * resolvers (`target`, `targetFolder`) that the executor swaps in at runtime.
+   *
+   * Bypasses `CREATE_INSTANCE_BLACKLIST` by design — `ems__Effort_status` is
+   * blacklisted (to prevent literal copy-from-target) but PropertyDefault MUST
+   * be able to set it. RFC v2 §Precedence: BLACKLIST scopes only Step 4.
+   */
+  private applyPropertyDefaultStep(
+    properties: Record<string, unknown>,
+    propertyDefault: ReadonlyArray<PropertyDefaultResolved>,
+    targetIRI: string,
+    targetFilePath: string,
+  ): void {
+    for (const { propertyName, value } of propertyDefault) {
+      if (properties[propertyName] !== undefined) continue;
+      properties[propertyName] = this.resolveSubstitutionMarker(
+        value,
+        targetIRI,
+        targetFilePath,
+      );
+    }
+  }
+
+  /**
+   * Swap context-dependent SubstitutionToken markers for runtime-resolved
+   * values. Non-marker strings pass through unchanged.
+   *
+   * - `__SUBSTITUTE__target__<uid>__` → `"[[<target-uid>]]"` where target-uid is
+   *   the canonical UID-or-path emitted by {@link extractBacklinkTarget}.
+   * - `__SUBSTITUTE__targetFolder__<uid>__` → vault-relative folder portion of
+   *   `targetFilePath`. Empty string when target is at vault root.
+   *
+   * Unknown markers (defensive — parser whitelists resolver-ids upstream) and
+   * non-marker strings are returned unchanged so production callers keep
+   * receiving the parser's literal output.
+   */
+  private resolveSubstitutionMarker(
+    value: string,
+    targetIRI: string,
+    targetFilePath: string,
+  ): string {
+    const match = value.match(SUBSTITUTION_MARKER_RE);
+    if (!match) return value;
+    const resolverId = match[1];
+    if (resolverId === "target") {
+      const bare = GroundingExecutor.extractBacklinkTarget(
+        targetIRI,
+        targetFilePath,
+      );
+      return `"[[${bare}]]"`;
+    }
+    if (resolverId === "targetFolder") {
+      if (!targetFilePath) return "";
+      const normalized = targetFilePath.replace(/^\/+/, "");
+      const slashIdx = normalized.lastIndexOf("/");
+      return slashIdx >= 0 ? normalized.slice(0, slashIdx) : "";
+    }
+    return value;
+  }
+
+  /**
+   * RFC v2 Phase 3b — Step 3 implementation. Apply ref-form InheritanceRules
+   * declared by the Grounding via `exocmd__Grounding_inheritanceRule`.
+   *
+   * Resolution per RFC v2 §Precedence:
+   *   1. Filter rules where `targetClassCondition` is absent OR matches one of
+   *      the target's classes (`exo__Instance_class` is multi-valued).
+   *   2. Filter out rules where ANY `targetClassExclusion` matches a target class.
+   *   3. Sort by `priority` desc (stable — JS Array.sort is stable since ES2019).
+   *   4. Apply: for each rule, read `sourcePropertyName` from target frontmatter,
+   *      write it to `targetPropertyName` on the new instance — only if no
+   *      higher-priority step (userInput / PropertyDefault) already set it.
+   *      Higher-priority rules within Step 3 also win because the
+   *      `properties[key] !== undefined` guard fires once any rule has written.
+   *
+   * Like Step 2, this bypasses CREATE_INSTANCE_BLACKLIST (`ems__Effort_area`
+   * / `ems__Effort_parent` are intentional inheritance targets — BLACKLIST
+   * scopes only Step 4 copy-from-target).
+   *
+   * Source-value formatting handles two common shapes:
+   * - Bare UUID (e.g. target's `exo__Asset_uid`) → wrapped as `"[[<uid>]]"`
+   *   so the new asset's frontmatter receives a valid wikilink.
+   * - Already wikilink-form (e.g. target's `exo__Asset_isDefinedBy`) → passed
+   *   through `reformatWikilink` for YAML round-trip safety.
+   */
+  private async applyInheritanceRuleStep(
+    properties: Record<string, unknown>,
+    inheritanceRule: ReadonlyArray<InheritanceRuleResolved>,
+    targetFm: Record<string, string | string[]>,
+  ): Promise<void> {
+    const targetClassNames = this.extractTargetClassNames(targetFm);
+
+    const applicable: InheritanceRuleResolved[] = [];
+    for (const rule of inheritanceRule) {
+      const conditionOk = await this.inheritanceConditionMatches(
+        rule.targetClassCondition,
+        targetClassNames,
+      );
+      if (!conditionOk) continue;
+      const excluded = await this.inheritanceExclusionMatches(
+        rule.targetClassExclusion,
+        targetClassNames,
+      );
+      if (excluded) continue;
+      applicable.push(rule);
+    }
+
+    // Sort by priority descending; JS Array.sort is stable (ES2019+), so equal
+    // priorities preserve the authoring/triple-store order — deterministic.
+    applicable.sort((a, b) => b.priority - a.priority);
+
+    for (const rule of applicable) {
+      if (properties[rule.targetPropertyName] !== undefined) continue;
+      const sourceValue = targetFm[rule.sourcePropertyName];
+      if (sourceValue === undefined || sourceValue === null) continue;
+      properties[rule.targetPropertyName] = this.formatInheritedValue(
+        sourceValue,
+      );
+    }
+  }
+
+  /**
+   * Check if a class condition matches any of the target's classes. Absent
+   * condition = unconditional rule (always matches).
+   *
+   * Matching is dual-form: direct symbolic equality (target authored with
+   * `[[ems__Area]]` style) OR via the injected ClassLabelToUidResolver
+   * (target authored with UID-canon `[[82c74542-...]]`). Resolver absence /
+   * failure falls back to direct-only — backward-compatible with test/CLI
+   * harnesses that don't wire the Obsidian metadata-cache adapter.
+   */
+  private async inheritanceConditionMatches(
+    condition: string | undefined,
+    targetClassNames: string[],
+  ): Promise<boolean> {
+    if (!condition) return true;
+    return this.classMatchesAny(condition, targetClassNames);
+  }
+
+  private async inheritanceExclusionMatches(
+    exclusions: readonly string[],
+    targetClassNames: string[],
+  ): Promise<boolean> {
+    for (const ex of exclusions) {
+      if (await this.classMatchesAny(ex, targetClassNames)) return true;
+    }
+    return false;
+  }
+
+  private async classMatchesAny(
+    label: string,
+    targetClassNames: string[],
+  ): Promise<boolean> {
+    if (targetClassNames.includes(label)) return true;
+    if (!this.classLabelToUid) return false;
+    try {
+      const uid = await this.classLabelToUid(label);
+      if (uid && uid.length > 0 && targetClassNames.includes(uid)) return true;
+    } catch {
+      // Resolver failures degrade gracefully — direct-only match still applied.
+    }
+    return false;
+  }
+
+  /**
+   * Extract bare class refs from target's `exo__Instance_class` frontmatter
+   * entry. Handles both string and array forms; unwraps `[[<inner>]]` and
+   * `[[<inner>|<alias>]]` wikilink shapes; strips surrounding YAML quotes.
+   */
+  private extractTargetClassNames(
+    targetFm: Record<string, string | string[]>,
+  ): string[] {
+    const raw = targetFm["exo__Instance_class"];
+    if (raw === undefined || raw === null) return [];
+    const arr = Array.isArray(raw) ? raw : [raw];
+    const out: string[] = [];
+    for (const item of arr) {
+      const inner = this.extractWikilinkInner(String(item));
+      if (inner) out.push(inner);
+    }
+    return out;
+  }
+
+  private extractWikilinkInner(s: string): string {
+    const m = s.match(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/);
+    if (m) return m[1].trim();
+    return s.replace(/^["']|["']$/g, "").trim();
+  }
+
+  /**
+   * Format an inherited source value for the new instance's frontmatter.
+   *
+   * - Already wikilink-form (`"[[...]]"` / `[[...]]`) → `reformatWikilink`
+   *   ensures YAML-quoted round-trip.
+   * - Bare UUID v4 (e.g. target's `exo__Asset_uid`) → wrap as `"[[<uid>]]"`
+   *   so the new asset receives a valid wikilink (per RFC v2 InheritanceRule
+   *   asset description for `ems__Effort_area` / `ems__Effort_parent`).
+   * - Anything else (literal scalar) → pass-through.
+   * - Array source → element-wise scalar formatting.
+   */
+  private formatInheritedValue(
+    value: string | string[],
+  ): string | string[] {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.formatInheritedScalar(String(item)));
+    }
+    return this.formatInheritedScalar(String(value));
+  }
+
+  private formatInheritedScalar(value: string): string {
+    if (/^"?\[\[.+\]\]"?$/.test(value)) {
+      return this.reformatWikilink(value);
+    }
+    if (UUID_V4_RE.test(value)) {
+      return `"[[${value}]]"`;
+    }
+    return value;
   }
 
   /**

--- a/packages/exocortex/tests/integration/dynamic-commands/grounding-phase3b-pipeline.test.ts
+++ b/packages/exocortex/tests/integration/dynamic-commands/grounding-phase3b-pipeline.test.ts
@@ -1,0 +1,569 @@
+/**
+ * Integration test: RFC v2 Phase 3b — CommandResolver → GroundingExecutor pipeline.
+ *
+ * Verifies the end-to-end handoff between Phase 3a parser output (`propertyDefault`
+ * + `inheritanceRule` arrays on GroundingDefinition) and the Phase 3b executor's
+ * 5-step precedence pipeline. Mirrors the Grounding `a6ef8fda-…` topology used
+ * in production (Create Task under Area):
+ *
+ *   - PropertyDefault: `ems__Effort_status = "[[<EffortStatusDraft-UID>]]"`
+ *   - InheritanceRule #1: `exo__Asset_uid → ems__Effort_area`,
+ *       condition `ems__Area`, priority 100
+ *   - InheritanceRule #2: `exo__Asset_uid → ems__Effort_parent`,
+ *       exclusion `ems__Area`, priority 50
+ *   - InheritanceRule #3: `exo__Asset_isDefinedBy → exo__Asset_isDefinedBy`,
+ *       unconditional, priority 10
+ *
+ * Two scenarios:
+ *   1. Target IS an `ems__Area` → resolved frontmatter has `ems__Effort_area`
+ *      set to the target's UID, NO `ems__Effort_parent`.
+ *   2. Target is a Project (NOT Area) → frontmatter has `ems__Effort_parent`,
+ *      NO `ems__Effort_area`.
+ *
+ * Both scenarios MUST emit `ems__Effort_status = "[[<EffortStatusDraft-UID>]]"`
+ * — the BLACKLIST-bypassing PropertyDefault path — and inherit `isDefinedBy`
+ * unconditionally.
+ */
+
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type {
+  IFileSystemReader,
+  IFileSystemWriter,
+} from "../../../src/interfaces/IFileSystemAdapter";
+
+// ───────────────────────────────────────────────────────────────────────────
+// In-memory fs adapter (mirrors grounding-resolve-execute.test.ts)
+// ───────────────────────────────────────────────────────────────────────────
+
+class InMemoryFileSystem implements IFileSystemReader, IFileSystemWriter {
+  private files = new Map<string, string>();
+
+  constructor(initial?: Record<string, string>) {
+    if (initial) {
+      for (const [p, c] of Object.entries(initial)) this.files.set(p, c);
+    }
+  }
+
+  async readFile(p: string): Promise<string> {
+    const c = this.files.get(p);
+    if (c === undefined) throw new Error(`File not found: ${p}`);
+    return c;
+  }
+  async fileExists(p: string): Promise<boolean> {
+    return this.files.has(p);
+  }
+  async getMarkdownFiles(): Promise<string[]> {
+    return Array.from(this.files.keys()).filter((p) => p.endsWith(".md"));
+  }
+  async createFile(p: string, c: string): Promise<string> {
+    this.files.set(p, c);
+    return p;
+  }
+  async updateFile(p: string, c: string): Promise<void> {
+    this.files.set(p, c);
+  }
+  async writeFile(p: string, c: string): Promise<void> {
+    this.files.set(p, c);
+  }
+  async deleteFile(p: string): Promise<void> {
+    this.files.delete(p);
+  }
+  async renameFile(o: string, n: string): Promise<void> {
+    const c = this.files.get(o);
+    if (c !== undefined) {
+      this.files.set(n, c);
+      this.files.delete(o);
+    }
+  }
+  listCreated(): string[] {
+    return Array.from(this.files.keys());
+  }
+  getContent(p: string): string | undefined {
+    return this.files.get(p);
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixture UIDs — match production Grounding a6ef8fda's topology shape
+// ───────────────────────────────────────────────────────────────────────────
+
+// Classes (TBox)
+const CLASS_AREA_UID = "82c74542-1b14-4217-b852-d84730484b25";
+const CLASS_PROJECT_UID = "bbbbbbbb-1111-4111-8111-bbbbbbbbbbbb";
+const CLASS_TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+
+// Properties (TBox)
+const PROP_ASSET_UID = "fada7446-b0a4-4100-88f4-6d4421c175fb"; // exo__Asset_uid
+const PROP_EFFORT_AREA = "9be36e9d-de67-4ed2-90b0-99cdf103e9bf"; // ems__Effort_area
+const PROP_EFFORT_PARENT = "6528ecfa-a03d-47f1-a819-9ba5fea8fc28"; // ems__Effort_parent
+const PROP_EFFORT_STATUS = "44c6e9e3-955f-4afc-9ca5-b4bd70667051"; // ems__Effort_status
+const PROP_ISDEFINEDBY = "179d6b59-c7fc-4bdf-a32f-ace630884a8c"; // exo__Asset_isDefinedBy
+
+// Value assets
+const STATUS_DRAFT_UID = "c42245d0-01de-4c35-bfcf-d910445ea28e";
+const ONTOLOGY_KITELEV_UID = "60967c6a-4e8a-4ee3-8922-db98b981e4f4";
+
+// Grounding + DeclarativeRule assets
+const GROUNDING_UID = "a6ef8fda-addb-40c3-940c-fe55fd7e8500";
+const COMMAND_UID = "cmd-create-task-instance-test";
+const BINDING_UID_AREA = "bind-create-task-area";
+const BINDING_UID_PROJECT = "bind-create-task-project";
+
+const PD_STATUS_UID = "d9aa9bb8-5676-4ba2-ba5e-fc8d9df02250";
+const IR_AREA_UID = "3f08f5a8-df11-47e7-8519-7d8d84175951";
+const IR_PARENT_UID = "43731bae-78cb-4ffe-9eaa-4c258cb1c493";
+const IR_ISDEFINEDBY_UID = "cbe000c4-b29a-4405-876d-790fb2296121";
+
+// Targets (ABox)
+const TARGET_AREA_UID = "905cc587-0000-0000-0000-000000000aaa";
+const TARGET_AREA_PATH = `03 Knowledge/areas/${TARGET_AREA_UID}.md`;
+const TARGET_AREA_IRI = `obsidian://vault/${encodeURI(TARGET_AREA_PATH)}`;
+
+const TARGET_PROJECT_UID = "4ef4acc6-0000-0000-0000-000000000bbb";
+const TARGET_PROJECT_PATH = `03 Knowledge/projects/${TARGET_PROJECT_UID}.md`;
+const TARGET_PROJECT_IRI = `obsidian://vault/${encodeURI(TARGET_PROJECT_PATH)}`;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers: seed TBox + ABox into triple store
+// ───────────────────────────────────────────────────────────────────────────
+
+async function seedClass(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<void> {
+  const iri = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(iri, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(iri, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+}
+
+async function seedProperty(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<void> {
+  const iri = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(iri, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(iri, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+}
+
+async function seedValueAsset(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<void> {
+  const iri = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(iri, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(iri, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+}
+
+async function seedPropertyDefault(
+  store: InMemoryTripleStore,
+  opts: { uid: string; propertyRefUid: string; valueRefUid: string },
+): Promise<void> {
+  const iri = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(
+      iri,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("PropertyDefault"),
+    ),
+    new Triple(iri, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      iri,
+      Namespace.EXOCMD.term("PropertyDefault_property"),
+      new IRI(`obsidian://vault/${opts.propertyRefUid}.md`),
+    ),
+    new Triple(
+      iri,
+      Namespace.EXOCMD.term("PropertyDefault_value"),
+      new IRI(`obsidian://vault/${opts.valueRefUid}.md`),
+    ),
+  ]);
+}
+
+async function seedInheritanceRule(
+  store: InMemoryTripleStore,
+  opts: {
+    uid: string;
+    sourcePropUid: string;
+    targetPropUid: string;
+    conditionClassUid?: string;
+    exclusionClassUids?: string[];
+    priority: number;
+  },
+): Promise<void> {
+  const iri = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(
+      iri,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("InheritanceRule"),
+    ),
+    new Triple(iri, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      iri,
+      Namespace.EXOCMD.term("InheritanceRule_sourceProperty"),
+      new IRI(`obsidian://vault/${opts.sourcePropUid}.md`),
+    ),
+    new Triple(
+      iri,
+      Namespace.EXOCMD.term("InheritanceRule_targetProperty"),
+      new IRI(`obsidian://vault/${opts.targetPropUid}.md`),
+    ),
+    new Triple(
+      iri,
+      Namespace.EXOCMD.term("InheritanceRule_priority"),
+      new Literal(String(opts.priority)),
+    ),
+  ];
+  if (opts.conditionClassUid) {
+    triples.push(
+      new Triple(
+        iri,
+        Namespace.EXOCMD.term("InheritanceRule_targetClassCondition"),
+        new IRI(`obsidian://vault/${opts.conditionClassUid}.md`),
+      ),
+    );
+  }
+  for (const exUid of opts.exclusionClassUids ?? []) {
+    triples.push(
+      new Triple(
+        iri,
+        Namespace.EXOCMD.term("InheritanceRule_targetClassExclusion"),
+        new IRI(`obsidian://vault/${exUid}.md`),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+async function seedGrounding(
+  store: InMemoryTripleStore,
+  opts: {
+    uid: string;
+    propertyDefaultRefs: string[];
+    inheritanceRuleRefs: string[];
+  },
+): Promise<void> {
+  const iri = new IRI(`obsidian://vault/${opts.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(iri, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+    new Triple(iri, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      iri,
+      Namespace.EXO.term("Asset_label"),
+      new Literal("Create TaskPrototype instance"),
+    ),
+    new Triple(
+      iri,
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal("create_instance"),
+    ),
+    new Triple(
+      iri,
+      Namespace.EXOCMD.term("Grounding_targetClass"),
+      new Literal("ems__Task"),
+    ),
+    new Triple(
+      iri,
+      Namespace.EXOCMD.term("Grounding_targetFolder"),
+      new Literal("03 Knowledge/inbox"),
+    ),
+  ];
+  for (const ref of opts.propertyDefaultRefs) {
+    triples.push(
+      new Triple(
+        iri,
+        Namespace.EXOCMD.term("Grounding_propertyDefault"),
+        new IRI(`obsidian://vault/${ref}.md`),
+      ),
+    );
+  }
+  for (const ref of opts.inheritanceRuleRefs) {
+    triples.push(
+      new Triple(
+        iri,
+        Namespace.EXOCMD.term("Grounding_inheritanceRule"),
+        new IRI(`obsidian://vault/${ref}.md`),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+async function seedCommandAndBindings(
+  store: InMemoryTripleStore,
+): Promise<void> {
+  const cmd = new IRI(`obsidian://vault/${COMMAND_UID}.md`);
+  const gnd = new IRI(`obsidian://vault/${GROUNDING_UID}.md`);
+  await store.addAll([
+    new Triple(cmd, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+    new Triple(cmd, Namespace.EXO.term("Asset_uid"), new Literal(COMMAND_UID)),
+    new Triple(
+      cmd,
+      Namespace.EXO.term("Asset_label"),
+      new Literal("Create Task"),
+    ),
+    new Triple(cmd, Namespace.EXOCMD.term("Command_grounding"), gnd),
+  ]);
+
+  for (const [bindUid, targetClassLabel] of [
+    [BINDING_UID_AREA, "ems__Area"],
+    [BINDING_UID_PROJECT, "ems__Project"],
+  ] as const) {
+    const bind = new IRI(`obsidian://vault/${bindUid}.md`);
+    await store.addAll([
+      new Triple(
+        bind,
+        Namespace.RDF.term("type"),
+        Namespace.EXOCMD.term("CommandBinding"),
+      ),
+      new Triple(bind, Namespace.EXO.term("Asset_uid"), new Literal(bindUid)),
+      new Triple(bind, Namespace.EXOCMD.term("CommandBinding_command"), cmd),
+      new Triple(
+        bind,
+        Namespace.EXOCMD.term("CommandBinding_targetClass"),
+        new Literal(targetClassLabel),
+      ),
+    ]);
+  }
+}
+
+function buildTargetMd(
+  uid: string,
+  classRefs: string[],
+  extras: Record<string, string> = {},
+): string {
+  const classLines = classRefs.map((c) => `  - "[[${c}]]"`).join("\n");
+  const extraLines = Object.entries(extras)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n");
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    "exo__Instance_class:",
+    classLines,
+    extraLines,
+    "---",
+    "Body",
+  ].join("\n");
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Suite
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("RFC v2 Phase 3b — CommandResolver → GroundingExecutor pipeline integration", () => {
+  let store: InMemoryTripleStore;
+  let resolver: CommandResolver;
+  let fs: InMemoryFileSystem;
+  let executor: GroundingExecutor;
+
+  /**
+   * ClassLabelToUidResolver stub: maps the three class labels used in tests
+   * to their UIDs so the executor's InheritanceRule class-match supports
+   * UID-canon target wikilinks (matches production vault shape).
+   */
+  const classLabelToUid = (label: string): string | null => {
+    if (label === "ems__Area") return CLASS_AREA_UID;
+    if (label === "ems__Project") return CLASS_PROJECT_UID;
+    if (label === "ems__Task") return CLASS_TASK_UID;
+    return null;
+  };
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    resolver = new CommandResolver(store);
+    fs = new InMemoryFileSystem();
+    executor = new GroundingExecutor(fs, fs, new ServiceRegistry(), classLabelToUid);
+
+    // Seed TBox
+    await seedClass(store, CLASS_AREA_UID, "ems__Area");
+    await seedClass(store, CLASS_PROJECT_UID, "ems__Project");
+    await seedClass(store, CLASS_TASK_UID, "ems__Task");
+    await seedProperty(store, PROP_ASSET_UID, "exo__Asset_uid");
+    await seedProperty(store, PROP_EFFORT_AREA, "ems__Effort_area");
+    await seedProperty(store, PROP_EFFORT_PARENT, "ems__Effort_parent");
+    await seedProperty(store, PROP_EFFORT_STATUS, "ems__Effort_status");
+    await seedProperty(store, PROP_ISDEFINEDBY, "exo__Asset_isDefinedBy");
+    await seedValueAsset(store, STATUS_DRAFT_UID, "ems__EffortStatusDraft");
+    await seedValueAsset(store, ONTOLOGY_KITELEV_UID, "kitelev");
+
+    // Seed DeclarativeRule assets
+    await seedPropertyDefault(store, {
+      uid: PD_STATUS_UID,
+      propertyRefUid: PROP_EFFORT_STATUS,
+      valueRefUid: STATUS_DRAFT_UID,
+    });
+    await seedInheritanceRule(store, {
+      uid: IR_AREA_UID,
+      sourcePropUid: PROP_ASSET_UID,
+      targetPropUid: PROP_EFFORT_AREA,
+      conditionClassUid: CLASS_AREA_UID,
+      priority: 100,
+    });
+    await seedInheritanceRule(store, {
+      uid: IR_PARENT_UID,
+      sourcePropUid: PROP_ASSET_UID,
+      targetPropUid: PROP_EFFORT_PARENT,
+      exclusionClassUids: [CLASS_AREA_UID],
+      priority: 50,
+    });
+    await seedInheritanceRule(store, {
+      uid: IR_ISDEFINEDBY_UID,
+      sourcePropUid: PROP_ISDEFINEDBY,
+      targetPropUid: PROP_ISDEFINEDBY,
+      priority: 10,
+    });
+
+    // Seed Grounding + Command + Bindings
+    await seedGrounding(store, {
+      uid: GROUNDING_UID,
+      propertyDefaultRefs: [PD_STATUS_UID],
+      inheritanceRuleRefs: [IR_AREA_UID, IR_PARENT_UID, IR_ISDEFINEDBY_UID],
+    });
+    await seedCommandAndBindings(store);
+  });
+
+  it("Area target: produces Task with Draft status + Effort_area set + no Effort_parent + isDefinedBy inherited", async () => {
+    // Seed target Area asset (file + triples for resolver class-lookup).
+    fs = new InMemoryFileSystem({
+      [TARGET_AREA_PATH]: buildTargetMd(TARGET_AREA_UID, [CLASS_AREA_UID], {
+        exo__Asset_isDefinedBy: `"[[${ONTOLOGY_KITELEV_UID}]]"`,
+      }),
+    });
+    executor = new GroundingExecutor(fs, fs, new ServiceRegistry(), classLabelToUid);
+    const targetIRI = new IRI(TARGET_AREA_IRI);
+    await store.addAll([
+      new Triple(
+        targetIRI,
+        Namespace.EXO.term("Asset_uid"),
+        new Literal(TARGET_AREA_UID),
+      ),
+      new Triple(
+        targetIRI,
+        Namespace.EXO.term("Instance_class"),
+        new Literal(`[[${CLASS_AREA_UID}]]`),
+      ),
+    ]);
+
+    // Resolve grounding through the Command → CommandBinding path.
+    const resolved = await resolver.resolveForAssetMulti(
+      TARGET_AREA_IRI,
+      ["ems__Area"],
+      undefined,
+    );
+    expect(resolved.length).toBeGreaterThan(0);
+    const grounding = resolved[0]!.command.grounding;
+    // Parser produced typed ref-form outputs.
+    expect(grounding.propertyDefault?.length).toBe(1);
+    expect(grounding.propertyDefault?.[0]?.propertyName).toBe("ems__Effort_status");
+    expect(grounding.inheritanceRule?.length).toBe(3);
+
+    // Execute end-to-end.
+    const result = await executor.execute(
+      grounding,
+      TARGET_AREA_IRI,
+      TARGET_AREA_PATH,
+      { label: "Buy groceries" },
+    );
+    expect(result.success).toBe(true);
+
+    const createdPath = fs
+      .listCreated()
+      .find((p) => p !== TARGET_AREA_PATH && p.endsWith(".md"));
+    expect(createdPath).toBeDefined();
+    const content = fs.getContent(createdPath!)!;
+
+    // PropertyDefault: status (BLACKLIST-bypassing).
+    expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
+    // InheritanceRule #1 (Area condition, prio 100): area = target UID.
+    expect(content).toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
+    // InheritanceRule #2 (Area exclusion, prio 50): NOT applied.
+    expect(content).not.toContain("ems__Effort_parent:");
+    // InheritanceRule #3 (unconditional, prio 10): isDefinedBy inherited.
+    expect(content).toContain(
+      `exo__Asset_isDefinedBy: "[[${ONTOLOGY_KITELEV_UID}]]"`,
+    );
+    // Class is ems__Task (UID-canon when ClassLabelToUidResolver is wired).
+    expect(content).toContain(`exo__Instance_class:`);
+    expect(content).toMatch(
+      new RegExp(`\\[\\[(ems__Task|${CLASS_TASK_UID})\\]\\]`),
+    );
+  });
+
+  it("Project target: produces Task with Draft status + Effort_parent set + no Effort_area + isDefinedBy inherited", async () => {
+    fs = new InMemoryFileSystem({
+      [TARGET_PROJECT_PATH]: buildTargetMd(
+        TARGET_PROJECT_UID,
+        [CLASS_PROJECT_UID],
+        {
+          exo__Asset_isDefinedBy: `"[[${ONTOLOGY_KITELEV_UID}]]"`,
+        },
+      ),
+    });
+    executor = new GroundingExecutor(fs, fs, new ServiceRegistry(), classLabelToUid);
+    const targetIRI = new IRI(TARGET_PROJECT_IRI);
+    await store.addAll([
+      new Triple(
+        targetIRI,
+        Namespace.EXO.term("Asset_uid"),
+        new Literal(TARGET_PROJECT_UID),
+      ),
+      new Triple(
+        targetIRI,
+        Namespace.EXO.term("Instance_class"),
+        new Literal(`[[${CLASS_PROJECT_UID}]]`),
+      ),
+    ]);
+
+    const resolved = await resolver.resolveForAssetMulti(
+      TARGET_PROJECT_IRI,
+      ["ems__Project"],
+      undefined,
+    );
+    expect(resolved.length).toBeGreaterThan(0);
+    const grounding = resolved[0]!.command.grounding;
+
+    const result = await executor.execute(
+      grounding,
+      TARGET_PROJECT_IRI,
+      TARGET_PROJECT_PATH,
+      { label: "Sub-task" },
+    );
+    expect(result.success).toBe(true);
+
+    const createdPath = fs
+      .listCreated()
+      .find((p) => p !== TARGET_PROJECT_PATH && p.endsWith(".md"));
+    expect(createdPath).toBeDefined();
+    const content = fs.getContent(createdPath!)!;
+
+    // PropertyDefault: status.
+    expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
+    // InheritanceRule #1 (Area condition NOT matched): NO area.
+    expect(content).not.toContain("ems__Effort_area:");
+    // InheritanceRule #2 (Area exclusion not matched): parent = target UID.
+    expect(content).toContain(`ems__Effort_parent: "[[${TARGET_PROJECT_UID}]]"`);
+    // InheritanceRule #3 (unconditional): isDefinedBy.
+    expect(content).toContain(
+      `exo__Asset_isDefinedBy: "[[${ONTOLOGY_KITELEV_UID}]]"`,
+    );
+  });
+});

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -2645,3 +2645,790 @@ describe("Convert commands — production-shape dispatch (Finding 5 completion)"
     });
   });
 });
+
+// -- RFC v2 Phase 3b — 5-step pipeline (Issue #3163) --
+//
+// Stand-alone top-level suite (NOT inside "Convert commands" describe) so the
+// outer-most `executor` instance (no ClassLabelToUidResolver) is the default,
+// matching the production GroundingExecutor wiring for headless/CLI contexts.
+describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
+  const TARGET_IRI = "https://exocortex.my/assets/test-asset-123";
+  const FILE_PATH = "/vault/test-asset.md";
+
+  let reader: ReturnType<typeof createMockReader>;
+  let writer: ReturnType<typeof createMockWriter>;
+  let registry: ServiceRegistry;
+  let executor: GroundingExecutor;
+
+  beforeEach(() => {
+    reader = createMockReader();
+    writer = createMockWriter();
+    registry = new ServiceRegistry();
+    executor = new GroundingExecutor(reader, writer, registry);
+  });
+
+  // -- Test fixtures --
+  //
+  // Tests the executor half of `exocmd__Grounding_propertyDefault` (ref-form)
+  // and `exocmd__Grounding_inheritanceRule` wiring. Parser side lives in
+  // CommandResolver.ts (Phase 3a, merged via PR #3224).
+  //
+  // Precedence per RFC v2 §Precedence (high → low):
+  //   1. userInput (modal form fields)
+  //   2. PropertyDefault (declarative ref-form, bypasses BLACKLIST)
+  //   3. InheritanceRule (filter + sort + apply, bypasses BLACKLIST)
+  //   4. copy-from-target (BLACKLIST-constrained)
+  //   5. [implicit] gaps remain empty
+  const TARGET_AREA_UID = "905cc587-0000-0000-0000-000000000001";
+  const TARGET_AREA_PATH = "03 Knowledge/areas/host.md";
+  const TARGET_AREA_IRI =
+    "obsidian://vault/vault-2025/03 Knowledge/areas/host.md";
+  const STATUS_DRAFT_UID = "c42245d0-01de-4c35-bfcf-d910445ea28e";
+  const STATUS_BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+  const OWNER_ONTOLOGY_UID = "60967c6a-4e8a-4ee3-8922-db98b981e4f4";
+
+  /**
+   * Build a target frontmatter string with `exo__Instance_class` plus any
+   * extra properties. Authored in symbolic form (`[[ems__Area]]`) so unit
+   * tests don't need a wired ClassLabelToUidResolver.
+   */
+  function buildTargetFm(
+      classNames: string[],
+      extraProps: Record<string, string> = {},
+    ): string {
+      const classLines = classNames.map((c) => `  - "[[${c}]]"`).join("\n");
+      const extraLines = Object.entries(extraProps)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join("\n");
+      return `---\nexo__Asset_uid: ${TARGET_AREA_UID}\nexo__Instance_class:\n${classLines}\n${extraLines}\n---\nBody`;
+    }
+
+    // -- Step 1 vs Step 2: userInput overrides PropertyDefault --
+
+    it("userInput overrides PropertyDefault for the same property name (Step 1 > Step 2)", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_status",
+            value: `"[[${STATUS_DRAFT_UID}]]"`,
+          },
+        ],
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+        label: "Override test",
+        ems__Effort_status: `"[[${STATUS_BACKLOG_UID}]]"`,
+      });
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // userInput value wins.
+      expect(content).toContain(`ems__Effort_status: "[[${STATUS_BACKLOG_UID}]]"`);
+      // PropertyDefault value is NOT present.
+      expect(content).not.toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
+    });
+
+    // -- Step 2 — PropertyDefault applies new declarative defaults --
+
+    it("PropertyDefault sets a declarative wikilink value when userInput omits it", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_status",
+            value: `"[[${STATUS_DRAFT_UID}]]"`,
+          },
+        ],
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+        label: "PD test",
+      });
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
+    });
+
+    // -- CRITICAL invariant: PropertyDefault bypasses CREATE_INSTANCE_BLACKLIST --
+    //
+    // `ems__Effort_status` is in CREATE_INSTANCE_BLACKLIST (line ~538) to
+    // prevent literal copy-from-target. RFC v2 §Precedence: BLACKLIST scopes
+    // ONLY Step 4 (copy-from-target). PropertyDefault (Step 2) MUST be able
+    // to set blacklisted properties — that's the entire point of replacing
+    // the hardcoded `ems__Effort_status: Backlog` write at
+    // ServiceRegistryPopulator.ts:211.
+    it("PropertyDefault overrides BLACKLIST: writes ems__Effort_status (Step 2 ignores BLACKLIST)", async () => {
+      // Target has its own status field — BLACKLIST blocks copy-from-target,
+      // PropertyDefault still writes the new value.
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_status",
+            value: `"[[${STATUS_DRAFT_UID}]]"`,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(
+        buildTargetFm(["ems__Area"], {
+          ems__Effort_status: `"[[${STATUS_BACKLOG_UID}]]"`,
+        }),
+      );
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "BLACKLIST bypass test" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // PropertyDefault value wins; copy-from-target was blocked by BLACKLIST.
+      expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
+      expect(content).not.toContain(`ems__Effort_status: "[[${STATUS_BACKLOG_UID}]]"`);
+    });
+
+    // -- Step 2 — SubstitutionToken marker resolution --
+
+    it("PropertyDefault marker __SUBSTITUTE__target__<uid>__ → [[<target-uid>]] wikilink at runtime", async () => {
+      const TOKEN_UID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_parent",
+            value: `__SUBSTITUTE__target__${TOKEN_UID}__`,
+          },
+        ],
+      });
+      const PROTO_UID = "4b571141-5fc3-4ddd-8f07-ca681fc8410a";
+      const PROTO_PATH = `assetspaces/shared-identities/${PROTO_UID}.md`;
+      const PROTO_IRI = `obsidian://vault/vault-2025/${PROTO_PATH}`;
+
+      const result = await executor.execute(grounding, PROTO_IRI, PROTO_PATH, {
+        label: "marker target",
+      });
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(`ems__Effort_parent: "[[${PROTO_UID}]]"`);
+    });
+
+    it("PropertyDefault marker __SUBSTITUTE__targetFolder__<uid>__ → vault-relative folder", async () => {
+      const TOKEN_UID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_sourceFolder",
+            value: `__SUBSTITUTE__targetFolder__${TOKEN_UID}__`,
+          },
+        ],
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        "03 Knowledge/areas/host.md",
+        { label: "folder marker" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain("ems__Effort_sourceFolder: 03 Knowledge/areas");
+    });
+
+    it("PropertyDefault literal `today` resolved at parse time passes through unchanged", async () => {
+      // CommandResolver Phase 3a invokes `today` resolver at parse time, so
+      // the executor receives an already-resolved string like "2026-05-23".
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_plannedStartTimestamp",
+            value: "2026-05-23",
+          },
+        ],
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+        label: "today literal",
+      });
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(
+        "ems__Effort_plannedStartTimestamp: 2026-05-23",
+      );
+    });
+
+    // -- Step 3 — InheritanceRule applies with class condition --
+
+    it("InheritanceRule applies when target instanceof condition class (uid→area for ems__Area target)", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_area",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(buildTargetFm(["ems__Area"]));
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "area test" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // Source `exo__Asset_uid` is a bare UUID → wrapped as wikilink.
+      expect(content).toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
+    });
+
+    it("InheritanceRule skipped when target is NOT instanceof condition class", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_area",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+      // Target is a Project, not an Area — condition does NOT match.
+      reader.readFile.mockResolvedValue(buildTargetFm(["ems__Project"]));
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "non-area test" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).not.toContain("ems__Effort_area:");
+    });
+
+    // -- Step 3 — InheritanceRule exclusion semantics --
+
+    it("InheritanceRule skipped when target instanceof exclusion class (uid→parent excluded for Area)", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_parent",
+            targetClassExclusion: ["ems__Area"],
+            priority: 50,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(buildTargetFm(["ems__Area"]));
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "exclude area" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).not.toContain("ems__Effort_parent:");
+    });
+
+    it("InheritanceRule applies when target NOT in exclusion list", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_parent",
+            targetClassExclusion: ["ems__Area"],
+            priority: 50,
+          },
+        ],
+      });
+      // Target is a Project — NOT excluded.
+      reader.readFile.mockResolvedValue(buildTargetFm(["ems__Project"]));
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "parent test" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(`ems__Effort_parent: "[[${TARGET_AREA_UID}]]"`);
+    });
+
+    it("InheritanceRule exclusion is multi-valued: ANY excluded class skips rule", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_parent",
+            targetClassExclusion: ["ems__Area", "ems__Quarter"],
+            priority: 50,
+          },
+        ],
+      });
+      // Target has both Project and Quarter — Quarter is in exclusion.
+      reader.readFile.mockResolvedValue(
+        buildTargetFm(["ems__Project", "ems__Quarter"]),
+      );
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "multi exclude" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).not.toContain("ems__Effort_parent:");
+    });
+
+    // -- Step 3 — Priority sort and override semantics --
+
+    it("Higher-priority InheritanceRule wins; lower priority does not override same targetProperty", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          // Authored in low-then-high order to verify sort actually runs.
+          {
+            sourcePropertyName: "exo__Asset_isDefinedBy",
+            targetPropertyName: "exo__Asset_isDefinedBy",
+            targetClassExclusion: [],
+            priority: 10,
+          },
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "exo__Asset_isDefinedBy", // intentionally same key
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(
+        buildTargetFm(["ems__Area"], {
+          exo__Asset_isDefinedBy: `"[[${OWNER_ONTOLOGY_UID}]]"`,
+        }),
+      );
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "priority test" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // Priority-100 rule wins: source = exo__Asset_uid (bare UUID → wrapped).
+      expect(content).toContain(
+        `exo__Asset_isDefinedBy: "[[${TARGET_AREA_UID}]]"`,
+      );
+      // Priority-10 rule did NOT override (would have written OWNER_ONTOLOGY_UID).
+      expect(content).not.toContain(
+        `exo__Asset_isDefinedBy: "[[${OWNER_ONTOLOGY_UID}]]"`,
+      );
+    });
+
+    it("Equal-priority InheritanceRules preserve authoring order (stable sort)", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_parent",
+            targetClassExclusion: [],
+            priority: 50,
+          },
+          {
+            // Same priority, same target — first one (above) should win.
+            sourcePropertyName: "exo__Asset_isDefinedBy",
+            targetPropertyName: "ems__Effort_parent",
+            targetClassExclusion: [],
+            priority: 50,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(
+        buildTargetFm(["ems__Project"], {
+          exo__Asset_isDefinedBy: `"[[${OWNER_ONTOLOGY_UID}]]"`,
+        }),
+      );
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "stable" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // First-authored equal-priority rule wins.
+      expect(content).toContain(`ems__Effort_parent: "[[${TARGET_AREA_UID}]]"`);
+      expect(content).not.toContain(
+        `ems__Effort_parent: "[[${OWNER_ONTOLOGY_UID}]]"`,
+      );
+    });
+
+    // -- Step 3 bypasses BLACKLIST (ems__Effort_area is blacklisted) --
+
+    it("InheritanceRule overrides BLACKLIST: writes ems__Effort_area (Step 3 ignores BLACKLIST)", async () => {
+      // `ems__Effort_area` is in CREATE_INSTANCE_BLACKLIST. Target's own
+      // `ems__Effort_area` value (if any) would be blocked from copy-from-target,
+      // but InheritanceRule explicitly writes a transformed value (target uid
+      // wrapped as wikilink) to it.
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_area",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(
+        buildTargetFm(["ems__Area"], {
+          ems__Effort_area: '"[[outer-area-uid]]"',
+        }),
+      );
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "BLACKLIST bypass IR" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // InheritanceRule wrote target's UID, copy-from-target was blocked.
+      expect(content).toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
+      expect(content).not.toContain('ems__Effort_area: "[[outer-area-uid]]"');
+    });
+
+    // -- Step 2 > Step 3: PropertyDefault wins over InheritanceRule --
+
+    it("Step 2 (PropertyDefault) takes precedence over Step 3 (InheritanceRule) for same property", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_parent",
+            value: '"[[hardcoded-parent-uid]]"',
+          },
+        ],
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_parent",
+            targetClassExclusion: ["ems__Area"],
+            priority: 50,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(buildTargetFm(["ems__Project"]));
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "PD wins over IR" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain('ems__Effort_parent: "[[hardcoded-parent-uid]]"');
+      expect(content).not.toContain(`ems__Effort_parent: "[[${TARGET_AREA_UID}]]"`);
+    });
+
+    // -- Step 3 — Source value already wikilink (isDefinedBy pass-through) --
+
+    it("InheritanceRule passes through already-wikilink source values (exo__Asset_isDefinedBy)", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_isDefinedBy",
+            targetPropertyName: "exo__Asset_isDefinedBy",
+            targetClassExclusion: [],
+            priority: 10,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(
+        buildTargetFm(["ems__Area"], {
+          exo__Asset_isDefinedBy: `"[[${OWNER_ONTOLOGY_UID}]]"`,
+        }),
+      );
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "isDefinedBy pass-through" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(
+        `exo__Asset_isDefinedBy: "[[${OWNER_ONTOLOGY_UID}]]"`,
+      );
+    });
+
+    // -- Step 3 — Multi-class target (exo__Instance_class is multi-valued) --
+
+    it("InheritanceRule condition matches when target has multiple classes and ANY is the condition", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_area",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+      // Target has both ems__Area and a marker class; condition matches via
+      // either class entry in the multi-valued list.
+      reader.readFile.mockResolvedValue(
+        buildTargetFm(["ems__FocusZone", "ems__Area"]),
+      );
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "multi-class" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
+    });
+
+    // -- ClassLabelToUidResolver path: UID-canon target classes match label-form conditions --
+
+    it("Class condition matches UID-canon target classes via ClassLabelToUidResolver", async () => {
+      const AREA_UID = "82c74542-1b14-4217-b852-d84730484b25";
+      const labelToUid = jest
+        .fn()
+        .mockImplementation((label: string) =>
+          label === "ems__Area" ? AREA_UID : null,
+        );
+      const executorWithResolver = new GroundingExecutor(
+        reader,
+        writer,
+        registry,
+        labelToUid,
+      );
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_area",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+      // Target authored with UID-canon class wikilink.
+      reader.readFile.mockResolvedValue(buildTargetFm([AREA_UID]));
+
+      const result = await executorWithResolver.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "UID-canon class match" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
+      expect(labelToUid).toHaveBeenCalledWith("ems__Area");
+    });
+
+    // -- End-to-end Grounding `a6ef8fda` semantics — golden scenario --
+
+    it("End-to-end (Grounding a6ef8fda semantics): Area target → Task with Draft status + area + isDefinedBy", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_status",
+            value: `"[[${STATUS_DRAFT_UID}]]"`,
+          },
+        ],
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_area",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_parent",
+            targetClassExclusion: ["ems__Area"],
+            priority: 50,
+          },
+          {
+            sourcePropertyName: "exo__Asset_isDefinedBy",
+            targetPropertyName: "exo__Asset_isDefinedBy",
+            targetClassExclusion: [],
+            priority: 10,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(
+        buildTargetFm(["ems__Area"], {
+          exo__Asset_isDefinedBy: `"[[${OWNER_ONTOLOGY_UID}]]"`,
+        }),
+      );
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "Buy groceries" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // PropertyDefault: status = Draft (UID-canon)
+      expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
+      // InheritanceRule#1 (prio 100, condition Area): area = target uid
+      expect(content).toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
+      // InheritanceRule#2 (exclusion Area): SHOULD NOT have parent
+      expect(content).not.toContain("ems__Effort_parent:");
+      // InheritanceRule#3 (unconditional): isDefinedBy passes through
+      expect(content).toContain(
+        `exo__Asset_isDefinedBy: "[[${OWNER_ONTOLOGY_UID}]]"`,
+      );
+    });
+
+    // -- Coexistence: legacy + ref-form (parser hands ref-form precedence) --
+
+    it("Coexistence: ref-form propertyDefault wins when both ref-form and legacy JSON leak through (executor-side defense-in-depth)", async () => {
+      // RFC v2 §Precedence: ref-form is canonical. Parser already returns
+      // legacy `propertyDefaults` as `undefined` when ref-form is set, but the
+      // executor MUST also gate the legacy block so a parser regression or
+      // hand-edited Grounding with both shapes cannot silently downgrade to
+      // the legacy value. This test feeds both directly to the executor
+      // (bypassing the parser) and asserts ref-form wins definitively.
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_status",
+            value: `"[[${STATUS_DRAFT_UID}]]"`,
+          },
+        ],
+        propertyDefaults: {
+          ems__Effort_status: `"[[${STATUS_BACKLOG_UID}]]"`,
+        },
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+        label: "coexistence",
+      });
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // Ref-form value wins exactly. Legacy value MUST NOT appear.
+      expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
+      expect(content).not.toContain(
+        `ems__Effort_status: "[[${STATUS_BACKLOG_UID}]]"`,
+      );
+    });
+
+    // -- Backward compatibility: Groundings without propertyDefault / inheritanceRule --
+
+    it("Backward compat: Grounding without propertyDefault / inheritanceRule still creates instance correctly", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, {
+        label: "backward compat",
+      });
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain("exo__Asset_label: backward compat");
+      expect(content).toContain("ems__Task");
+    });
+});

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -3413,6 +3413,110 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       );
     });
 
+    // -- Step 1 > Step 3 (review MED-1): userInput overrides InheritanceRule --
+
+    it("userInput overrides InheritanceRule for the same target property (Step 1 > Step 3)", async () => {
+      // Mirrors the Step 1 > Step 2 invariant test, but with InheritanceRule
+      // instead of PropertyDefault on the same target property. Guards against
+      // a future refactor that re-orders Steps 1 and 3 silently breaking the
+      // userInput-wins contract documented in RFC v2 §Precedence.
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_area",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(buildTargetFm(["ems__Area"]));
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        {
+          label: "userInput wins over IR",
+          ems__Effort_area: '"[[user-supplied-area-uid]]"',
+        },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // userInput value wins.
+      expect(content).toContain('ems__Effort_area: "[[user-supplied-area-uid]]"');
+      // InheritanceRule value is NOT present.
+      expect(content).not.toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
+    });
+
+    // -- Three-layer interaction (review MED-2):
+    //    Step 1 (userInput) + Step 2 (PropertyDefault) + Step 3 (InheritanceRule)
+    //    + Step 4 (copy-from-target) all contribute to distinct property slots --
+
+    it("Three-layer + copy-from-target: each step contributes to its own slot without cross-talk", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "03 Knowledge/inbox",
+        propertyDefault: [
+          {
+            propertyName: "ems__Effort_status",
+            value: `"[[${STATUS_DRAFT_UID}]]"`,
+          },
+        ],
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_area",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+      // Target has a non-blacklisted property (`ems__Effort_priority`) that
+      // Steps 2/3 don't touch — Step 4 copy-from-target must fill it.
+      reader.readFile.mockResolvedValue(
+        buildTargetFm(["ems__Area"], {
+          exo__Asset_isDefinedBy: `"[[${OWNER_ONTOLOGY_UID}]]"`,
+          ems__Effort_priority: '"[[priority-high]]"',
+        }),
+      );
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        {
+          label: "Three-layer test",
+          ems__Effort_responsible: '"[[user-uid]]"', // Step 1: userInput
+        },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // Step 1 (userInput) contributes ems__Effort_responsible.
+      expect(content).toContain('ems__Effort_responsible: "[[user-uid]]"');
+      // Step 2 (PropertyDefault) contributes ems__Effort_status (BLACKLISTed
+      // but PD bypasses BLACKLIST).
+      expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
+      // Step 3 (InheritanceRule) contributes ems__Effort_area (BLACKLISTed
+      // but IR bypasses BLACKLIST).
+      expect(content).toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
+      // Step 4 (copy-from-target) fills ems__Effort_priority — not touched
+      // by Steps 2/3, not in BLACKLIST.
+      expect(content).toContain('ems__Effort_priority: "[[priority-high]]"');
+      // Step 4 also copies non-blacklisted exo__Asset_isDefinedBy from target.
+      expect(content).toContain(
+        `exo__Asset_isDefinedBy: "[[${OWNER_ONTOLOGY_UID}]]"`,
+      );
+    });
+
     // -- Backward compatibility: Groundings without propertyDefault / inheritanceRule --
 
     it("Backward compat: Grounding without propertyDefault / inheritanceRule still creates instance correctly", async () => {

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -105,8 +105,10 @@ fi
 # - RFC da3a7555 (v15.173.1 fix): integration/dynamic-commands/grounding-resolve-execute.test.ts
 #   (RDF → Resolver → Executor pipeline regression — wikilink unwrap, targetClass IRI reverse-map,
 #   copy-from-target ≥3 fields)
+# - RFC v2 Phase 3b (Issue #3163): integration/dynamic-commands/grounding-phase3b-pipeline.test.ts
+#   (CommandResolver → GroundingExecutor 5-step precedence pipeline end-to-end)
 echo "📦 Running exocortex grounding + RFC regression tests..."
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref)|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-resolve-execute\.test)\.ts --forceExit"
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref)|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/(grounding-resolve-execute|grounding-phase3b-pipeline)\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
## Summary

Closes #3163. RFC v2 Phase 3b — wires `propertyDefault` and `inheritanceRule` ref-form arrays from the Phase 3a CommandResolver parser (PR #3224) into `executeCreateInstance`. Implements the 5-step precedence pipeline declared by RFC v2 §Precedence.

RFC v2 source: `2f3f640b-c5e0-4873-8c56-c390b8402cfa`

## 5-step precedence pipeline

1. **userInput** (modal form fields) — highest priority
2. **PropertyDefault** (declarative ref-form, includes SubstitutionToken marker resolution) — **bypasses BLACKLIST**
3. **InheritanceRule** (condition + exclusion filter, priority-desc stable sort) — **bypasses BLACKLIST**
4. **copy-from-target** (BLACKLIST-constrained) — unchanged
5. *(implicit)* gaps remain empty

## Critical invariants honoured

- `CREATE_INSTANCE_BLACKLIST` scopes ONLY Step 4. PropertyDefault MUST be able to set `ems__Effort_status` (in BLACKLIST) — replaces hardcoded `ServiceRegistryPopulator.ts:211` literal. InheritanceRule MUST be able to set `ems__Effort_area`/`ems__Effort_parent` (in BLACKLIST) — replaces hardcoded `ts:199-201` Area-vs-non-Area dispatch.
- `exo__Instance_class` multi-valued handling — match if ANY target class equals condition (and same for exclusion); supports both symbolic-form (test) and UID-canon (production via `ClassLabelToUidResolver`).
- Priority sort descending and **stable** (JS `Array.sort` since ES2019); equal-priority rules preserve authoring order.
- SubstitutionToken markers: `today`/`todayStart` resolved at parse time (literal pass-through), `target`/`targetFolder` resolved at executor time via `__SUBSTITUTE__<resolver>__<token-uid>__` marker.
- **Coexistence guard** (defense-in-depth): legacy `propertyDefaults` JSON block now skipped whenever ref-form `propertyDefault` is set, so a parser regression or hand-edited Grounding carrying both shapes cannot silently downgrade to legacy. Parser-side `undefined` invariant remains the primary contract; this is a second barrier.

## Files changed

- `packages/exocortex/src/services/GroundingExecutor.ts` (+204/-3) — pipeline wiring + helpers, `SUBSTITUTION_MARKER_RE` const, `PropertyDefaultResolved`/`InheritanceRuleResolved` imports.
- `packages/exocortex/tests/unit/services/GroundingExecutor.test.ts` (+894) — 22 new unit tests covering precedence (Step 1 > Step 2 > Step 3 > Step 4), BLACKLIST-bypass for both Steps 2 & 3, marker resolution, condition/exclusion semantics (single + multi-valued), priority sort + stability, isDefinedBy pass-through, multi-class target, UID-canon class match via resolver, end-to-end Grounding a6ef8fda semantics, coexistence (ref-form wins definitively), backward compatibility, three-layer interaction with Step 4 (per code-review MED-1/MED-2).
- `packages/exocortex/tests/integration/dynamic-commands/grounding-phase3b-pipeline.test.ts` (NEW, +570) — full CommandResolver → GroundingExecutor handoff with real triple-store fixtures (Area target → area; Project target → parent).
- `.github/workflows/ci.yml` (+1) — added new integration test to test-coverage-exocortex allowlist (avoids orphan-rot trap per worktree CLAUDE.md).
- `scripts/test-ci-batched.sh` (+3) — parallel allowlist mirror.

## Code-review summary (round 1)

Verdict: **Approve** (3 MED + 3 LOW). Addressed:
- ✅ MED-1: Added Step 1 > Step 3 invariant test.
- ✅ MED-2: Added three-layer + copy-from-target interaction test.
- ✅ MED-3 (`$input`/`$value` scope reduction): **Non-issue by design**. Ref-form `exocmd__PropertyDefault_value` is `range: exo__Asset` (wikilink to an asset), never a literal-with-tokens string. The parser at `CommandResolver.ts:1464` only emits wikilinks, parse-time-resolved strings (`today`/`todayStart`), or `__SUBSTITUTE__` markers for the 4 whitelisted resolver-ids. `$input`/`$value` semantics live on the legacy JSON `propertyDefaults` path which the coexistence guard preserves. Future $input-like behavior in ref-form would be a new `SubstitutionToken` instance + matching executor resolver, NOT a parser change.
- LOW-1/2/3 deferred — filed as follow-up issues post-merge (see PR description in comments).

## Test plan

- [x] 22 new unit tests in `GroundingExecutor.test.ts` (total 141 in file) — all green locally.
- [x] 2 integration tests in `grounding-phase3b-pipeline.test.ts` — all green locally.
- [x] Local `npx tsc --noEmit -p packages/exocortex/tsconfig.json` clean.
- [x] Local `npm run lint` 0 errors.
- [x] BDD coverage at 100% — `npm run bdd:check` ✅ (no new orphan `.feature` files).
- [x] `cli-plugin-triple-parity` integration test green locally — `parity-gate` (NoteToRDF parity) unaffected by executor-only changes.
- [ ] CI 14 required checks green (first push had 4 infrastructure checkout flakes — re-running on `515b2cdb`).

## Vault state context

- 7 `create_instance` Groundings authored (Phase 2). Only `a6ef8fda` (Create Task from prototype) uses new ref-form; `4d8d5055` (daily-note) uses legacy JSON; 5 plain backward-compat. Issue body said "9" — loose, actual count from `vault-2025/assetspaces/exocmd/creation/` is 7.

## Auto-merge discipline

Per worktree `CLAUDE.md` — `GroundingExecutor.ts` is on the manual-merge list. **NOT using `--auto`.** Workflow: push → CI green + code-reviewer agent → fixes → advisor round-2 → manual `gh pr merge --squash --delete-branch`.