### PR TITLE
feat(parser): emit exo:Asset_filename + preserve wikilink anchors (RFC 1ce2a226 Phase 3)

### DIFF
--- a/packages/cli/src/utils/wikilinkRewriter.ts
+++ b/packages/cli/src/utils/wikilinkRewriter.ts
@@ -16,18 +16,19 @@ export interface RewriteResult {
 }
 
 /**
- * Rewrites inbound wikilinks pointing to `oldBasename` so they collapse to a
- * bare `[[newBasename]]`. Display label is resolved at render time from the
- * target's `exo__Asset_label`; the old basename is preserved in the target's
- * frontmatter `aliases:` array by RenameToUidService.
+ * Rewrites inbound wikilinks pointing to `oldBasename` so the link target
+ * becomes `newBasename`. Display label (`|Alias`) is stripped — Obsidian
+ * renders the target's `exo__Asset_label` at view time. Anchors (`#Heading`
+ * and `^block`) are PRESERVED per RFC 1ce2a226 Phase 3c — they identify a
+ * navigation point inside the target document, not its display name.
  *
- * Shapes handled (all collapse to [[NewBase]]):
+ * Shapes handled:
  *   [[OldName]]                 -> [[NewBase]]
  *   [[OldName|Display]]         -> [[NewBase]]
- *   [[OldName#Heading]]         -> [[NewBase]]
- *   [[OldName#Heading|Display]] -> [[NewBase]]
- *   [[OldName^block]]           -> [[NewBase]]
- *   [[OldName^block|Display]]   -> [[NewBase]]
+ *   [[OldName#Heading]]         -> [[NewBase#Heading]]
+ *   [[OldName#Heading|Display]] -> [[NewBase#Heading]]
+ *   [[OldName^block]]           -> [[NewBase^block]]
+ *   [[OldName^block|Display]]   -> [[NewBase^block]]
  *
  * Skips fenced code blocks (``` … ```), inline code (` … `), and embeds (`![[…]]`).
  * Skips the renamed file itself via `excludeRelPath`.
@@ -139,18 +140,18 @@ function replaceWikilinks(
 ): { updated: string; replacements: number } {
   // (?<!!) — exclude embeds ![[...]]
   // Group 1: link target (no |, #, ^, ], [, newline)
-  // Optional non-capturing groups for heading / block / alias — all dropped.
-  // All shapes collapse to bare [[newBasename]]; display alias is resolved
-  // at render time from the target's exo__Asset_label.
+  // Group 2: optional anchor (#heading or ^block) including the leading
+  //          sigil; PRESERVED in the output per RFC 1ce2a226 Phase 3c.
+  // Optional non-capturing |alias — dropped (strip-canon policy).
   const regex =
-    /(?<!!)\[\[([^\[\]\n|#^]+)(?:[#^][^\[\]\n|]*)?(?:\|[^\[\]\n]*)?\]\]/g;
+    /(?<!!)\[\[([^\[\]\n|#^]+)((?:[#^][^\[\]\n|]*)?)(?:\|[^\[\]\n]*)?\]\]/g;
   let replacements = 0;
 
-  const updated = text.replace(regex, (match, target) => {
+  const updated = text.replace(regex, (_match, target, anchor) => {
     const trimmedTarget = target.trim();
-    if (trimmedTarget !== oldBasename) return match;
+    if (trimmedTarget !== oldBasename) return _match;
     replacements += 1;
-    return `[[${newBasename}]]`;
+    return `[[${newBasename}${anchor}]]`;
   });
 
   return { updated, replacements };

--- a/packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts
+++ b/packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts
@@ -114,12 +114,15 @@ describe("Issue #3113: rename-to-uid updates inbound wikilinks", () => {
     expect(fs.existsSync(newTargetPath)).toBe(true);
     expect(fs.existsSync(path.join(vaultRoot, inbox))).toBe(false);
 
-    // Trigger files updated — all shapes collapse to bare [[uid]]
+    // Trigger files updated. Bare and aliased shapes collapse to [[uid]];
+    // heading-anchored shapes preserve the `#Anchor` per RFC 1ce2a226 Phase 3c.
     expect(fs.readFileSync(bare, "utf-8")).toContain(`[[${ASSET_UID}]]`);
     expect(fs.readFileSync(aliased, "utf-8")).toContain(`[[${ASSET_UID}]]`);
-    expect(fs.readFileSync(heading, "utf-8")).toContain(`[[${ASSET_UID}]]`);
+    expect(fs.readFileSync(heading, "utf-8")).toContain(
+      `[[${ASSET_UID}#Ingredients]]`,
+    );
     expect(fs.readFileSync(headingAliased, "utf-8")).toContain(
-      `[[${ASSET_UID}]]`,
+      `[[${ASSET_UID}#Ingredients]]`,
     );
 
     // Code-block contents preserved verbatim

--- a/packages/cli/tests/integration/sparql-exo003.integration.test.ts
+++ b/packages/cli/tests/integration/sparql-exo003.integration.test.ts
@@ -378,7 +378,7 @@ describeOrSkip("SPARQL queries on Exo 0.0.3 format (Issue #1367)", () => {
       // Should have triples from both legacy and Exo003 files
       // Use meta.triplesScanned as reliable count (avoids typed literal parsing)
       const triplesScanned = response.meta?.triplesScanned;
-      // Legacy: 2 files * (Asset_label + Asset_fileName) = 4 triples
+      // Legacy: 2 files * (Asset_label + Asset_filename) = 4 triples
       // Exo003: 2 anchors * 2 owl:sameAs = 4 triples
       // Total: 8+ triples
       expect(triplesScanned).toBeGreaterThanOrEqual(8);

--- a/packages/cli/tests/unit/utils/wikilinkRewriter.anchor-preservation.test.ts
+++ b/packages/cli/tests/unit/utils/wikilinkRewriter.anchor-preservation.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "@jest/globals";
+import { rewriteContent } from "../../../src/utils/wikilinkRewriter.js";
+
+/**
+ * RFC 1ce2a226 Phase 3c acceptance: anchors (`#heading` / `^block`) are
+ * PRESERVED when an inbound wikilink is rewritten from `oldBasename` to
+ * `newBasename`. The display alias (`|Alias`) is dropped (strip-canon).
+ *
+ * Pre-Phase-3 behaviour collapsed every shape to bare `[[NewBase]]` — the
+ * regex captured the anchor in a non-capturing group and discarded it. This
+ * destroyed deep links inside long notes (e.g. `[[BAD-2026-W21#Понедельник]]`
+ * lost its `Понедельник` section pointer on UUID-canon rename). Phase 3c
+ * fixes that by capturing the anchor and re-emitting it under the new target.
+ */
+describe("wikilinkRewriter — anchor preservation (RFC 1ce2a226 Phase 3c)", () => {
+  const OLD = "Choco";
+  const NEW = "11111111-1111-1111-1111-111111111111";
+
+  it("preserves #heading anchor on bare wikilink", () => {
+    const { updated, replacements } = rewriteContent(
+      "See [[Choco#Ingredients]] section.\n",
+      OLD,
+      NEW,
+    );
+    expect(replacements).toBe(1);
+    expect(updated).toContain(`[[${NEW}#Ingredients]]`);
+    expect(updated).not.toContain(`[[${NEW}]]`);
+  });
+
+  it("preserves #heading anchor when alias is also present (strips alias)", () => {
+    const { updated, replacements } = rewriteContent(
+      "Read [[Choco#Ingredients|See Ingredients]] now.\n",
+      OLD,
+      NEW,
+    );
+    expect(replacements).toBe(1);
+    expect(updated).toContain(`[[${NEW}#Ingredients]]`);
+    expect(updated).not.toContain("See Ingredients");
+  });
+
+  it("preserves ^block reference on bare wikilink", () => {
+    const { updated, replacements } = rewriteContent(
+      "Quote [[Choco^block-abc]] here.\n",
+      OLD,
+      NEW,
+    );
+    expect(replacements).toBe(1);
+    expect(updated).toContain(`[[${NEW}^block-abc]]`);
+  });
+
+  it("preserves ^block reference when alias is also present (strips alias)", () => {
+    const { updated, replacements } = rewriteContent(
+      "Quote [[Choco^block-abc|callout]] here.\n",
+      OLD,
+      NEW,
+    );
+    expect(replacements).toBe(1);
+    expect(updated).toContain(`[[${NEW}^block-abc]]`);
+    expect(updated).not.toContain("callout");
+  });
+
+  it("collapses [[Old]] (no anchor, no alias) to bare [[uid]]", () => {
+    const { updated, replacements } = rewriteContent(
+      "Plain [[Choco]] link.\n",
+      OLD,
+      NEW,
+    );
+    expect(replacements).toBe(1);
+    expect(updated).toContain(`[[${NEW}]]`);
+  });
+
+  it("collapses [[Old|Alias]] to bare [[uid]] (strips alias, no anchor)", () => {
+    const { updated, replacements } = rewriteContent(
+      "Aliased [[Choco|Display Label]] link.\n",
+      OLD,
+      NEW,
+    );
+    expect(replacements).toBe(1);
+    expect(updated).toContain(`[[${NEW}]]`);
+    expect(updated).not.toContain("Display Label");
+  });
+
+  it("does not rewrite links inside fenced code blocks", () => {
+    const input =
+      "Before [[Choco#Ingredients]].\n" +
+      "```\nKeep [[Choco#Ingredients]] verbatim.\n```\n" +
+      "After [[Choco#Ingredients]].\n";
+    const { updated, replacements } = rewriteContent(input, OLD, NEW);
+    expect(replacements).toBe(2);
+    expect(updated).toContain("Keep [[Choco#Ingredients]] verbatim.");
+    expect(updated).toContain(`Before [[${NEW}#Ingredients]]`);
+    expect(updated).toContain(`After [[${NEW}#Ingredients]]`);
+  });
+
+  it("does not rewrite anchor links inside inline code spans", () => {
+    const input = "Outside [[Choco#Ingredients]] but `[[Choco#Ingredients]]` inline.\n";
+    const { updated, replacements } = rewriteContent(input, OLD, NEW);
+    expect(replacements).toBe(1);
+    expect(updated).toContain("`[[Choco#Ingredients]]`");
+    expect(updated).toContain(`Outside [[${NEW}#Ingredients]]`);
+  });
+
+  it("does not rewrite embed anchors (![[Old#section]])", () => {
+    const input = "Embed ![[Choco#Ingredients]] block.\n";
+    const { updated, replacements } = rewriteContent(input, OLD, NEW);
+    expect(replacements).toBe(0);
+    expect(updated).toBe(input);
+  });
+
+  it("leaves unrelated targets with anchors untouched", () => {
+    const input = "See [[Banana#Slicing]] doc.\n";
+    const { updated, replacements } = rewriteContent(input, OLD, NEW);
+    expect(replacements).toBe(0);
+    expect(updated).toBe(input);
+  });
+});

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -102,13 +102,27 @@ export class NoteToRDFConverter {
       return [];
     }
 
+    // RFC 1ce2a226 Phase 3a: emit exo:Asset_filename for every parsed file.
+    // `file.basename` is the disk basename without `.md` extension, already
+    // URL-decoded by Obsidian (e.g. "My Note", not "My%20Note"). Overwrite-
+    // on-reindex semantics are provided by VaultRDFIndexer.updateFile/
+    // renameFile, which call removeFileTriples(filePath) before re-emitting.
+    const fileSubject = this.notePathToIRI(file.path);
+    const filenamePredicate = Namespace.EXO.term("Asset_filename");
+    const filenameTriple = new Triple(
+      fileSubject,
+      filenamePredicate,
+      new Literal(file.basename),
+    );
+
     // Issue #1366: Check for Exo 0.0.3 format first
     if (Exo003Parser.isExo003Format(frontmatter)) {
-      return this.convertExo003Note(file, frontmatter);
+      const exo003Triples = await this.convertExo003Note(file, frontmatter);
+      return [filenameTriple, ...exo003Triples];
     }
 
     // Legacy format processing
-    return this.convertLegacyNote(file, frontmatter);
+    return this.convertLegacyNote(file, frontmatter, filenameTriple);
   }
 
   /**
@@ -116,16 +130,12 @@ export class NoteToRDFConverter {
    */
   private async convertLegacyNote(
     file: IFile,
-    frontmatter: Record<string, unknown>
+    frontmatter: Record<string, unknown>,
+    filenameTriple: Triple,
   ): Promise<Triple[]> {
     this.pendingExtraTriples = [];
-    const triples: Triple[] = [];
+    const triples: Triple[] = [filenameTriple];
     const subject = this.notePathToIRI(file.path);
-
-    // Always add Asset_fileName triple (Issue #666)
-    // This allows SPARQL queries to search by filename without hardcoded URIs
-    const fileNamePredicate = Namespace.EXO.term("Asset_fileName");
-    triples.push(new Triple(subject, fileNamePredicate, new Literal(file.basename)));
 
     for (const [key, value] of Object.entries(frontmatter)) {
       // Issue #3043 Phase 1: whitelisted unprefixed frontmatter keys are

--- a/packages/exocortex/tests/integration/asset-creation/create-instance-grounding.test.ts
+++ b/packages/exocortex/tests/integration/asset-creation/create-instance-grounding.test.ts
@@ -491,7 +491,7 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
       expect(leaksClassUID).toBe(false);
     });
 
-    it("should produce exo:Asset_fileName triple with basename", async () => {
+    it("should produce exo:Asset_filename triple with basename", async () => {
       await groundingExecutor.execute(
         GROUNDING,
         "https://exocortex.my/assets/parent",
@@ -502,7 +502,7 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
       const file = getCreatedFile();
       const triples = await converter.convertNote(file);
 
-      const fileNamePredicate = Namespace.EXO.term("Asset_fileName");
+      const fileNamePredicate = Namespace.EXO.term("Asset_filename");
       const fileNameTriples = findTriples(triples, fileNamePredicate);
       expect(fileNameTriples).toHaveLength(1);
 

--- a/packages/exocortex/tests/unit/infrastructure/sparql/AssetFileNameQuery.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/AssetFileNameQuery.test.ts
@@ -1,7 +1,7 @@
 /**
- * Acceptance test for Asset_fileName predicate (Issue #666).
+ * Acceptance test for Asset_filename predicate (Issue #666).
  *
- * This test verifies that every asset gets an exo:Asset_fileName triple
+ * This test verifies that every asset gets an exo:Asset_filename triple
  * during RDF indexing, allowing SPARQL queries to search by filename
  * without hardcoded URIs.
  *
@@ -9,7 +9,7 @@
  * ```sparql
  * PREFIX exo: <https://exocortex.my/ontology/exo#>
  * SELECT ?s WHERE {
- *   ?s exo:Asset_fileName "ems__Meeting" .
+ *   ?s exo:Asset_filename "ems__Meeting" .
  * }
  * ```
  */
@@ -23,7 +23,7 @@ import { Literal } from "../../../../src/domain/models/rdf/Literal";
 import { Triple } from "../../../../src/domain/models/rdf/Triple";
 import { Namespace } from "../../../../src/domain/models/rdf/Namespace";
 
-describe("Asset_fileName SPARQL Query (Issue #666)", () => {
+describe("Asset_filename SPARQL Query (Issue #666)", () => {
   let store: InMemoryTripleStore;
   let executor: QueryExecutor;
   let parser: SPARQLParser;
@@ -40,9 +40,9 @@ describe("Asset_fileName SPARQL Query (Issue #666)", () => {
     parser = new SPARQLParser();
     translator = new AlgebraTranslator();
 
-    // Setup test data: Assets with Asset_fileName triples
+    // Setup test data: Assets with Asset_filename triples
     // This simulates what NoteToRDFConverter.convertNote() produces
-    const EXO_ASSET_FILE_NAME = Namespace.EXO.term("Asset_fileName");
+    const EXO_ASSET_FILE_NAME = Namespace.EXO.term("Asset_filename");
     const EXO_ASSET_LABEL = Namespace.EXO.term("Asset_label");
     const EXO_INSTANCE_CLASS = Namespace.EXO.term("Instance_class");
 
@@ -95,12 +95,12 @@ describe("Asset_fileName SPARQL Query (Issue #666)", () => {
     ]);
   });
 
-  describe("Basic Asset_fileName queries", () => {
+  describe("Basic Asset_filename queries", () => {
     it("should find asset by exact fileName match", async () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT ?s WHERE {
-          ?s exo:Asset_fileName "ems__Meeting" .
+          ?s exo:Asset_filename "ems__Meeting" .
         }
       `;
 
@@ -116,7 +116,7 @@ describe("Asset_fileName SPARQL Query (Issue #666)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT ?s WHERE {
-          ?s exo:Asset_fileName "My Note" .
+          ?s exo:Asset_filename "My Note" .
         }
       `;
 
@@ -132,7 +132,7 @@ describe("Asset_fileName SPARQL Query (Issue #666)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT ?s WHERE {
-          ?s exo:Asset_fileName "NonExistent" .
+          ?s exo:Asset_filename "NonExistent" .
         }
       `;
 
@@ -147,7 +147,7 @@ describe("Asset_fileName SPARQL Query (Issue #666)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT ?s ?fileName WHERE {
-          ?s exo:Asset_fileName ?fileName .
+          ?s exo:Asset_filename ?fileName .
         }
         ORDER BY ?fileName
       `;
@@ -164,12 +164,12 @@ describe("Asset_fileName SPARQL Query (Issue #666)", () => {
     });
   });
 
-  describe("Combined queries with Asset_fileName", () => {
+  describe("Combined queries with Asset_filename", () => {
     it("should find asset by fileName and return its label", async () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT ?label WHERE {
-          ?s exo:Asset_fileName "ems__Meeting" .
+          ?s exo:Asset_filename "ems__Meeting" .
           ?s exo:Asset_label ?label .
         }
       `;
@@ -187,7 +187,7 @@ describe("Asset_fileName SPARQL Query (Issue #666)", () => {
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT ?fileName WHERE {
           ?s exo:Instance_class exo:Class .
-          ?s exo:Asset_fileName ?fileName .
+          ?s exo:Asset_filename ?fileName .
         }
         ORDER BY ?fileName
       `;
@@ -209,13 +209,13 @@ describe("Asset_fileName SPARQL Query (Issue #666)", () => {
     it("should allow querying by human-readable filename (Issue #666 acceptance criteria)", async () => {
       // This is the exact acceptance criteria from Issue #666:
       // Given vault with file `03 Knowledge/ems/ems__Meeting.md`
-      // When executing SPARQL: SELECT ?s WHERE { ?s exo:Asset_fileName "ems__Meeting" . }
+      // When executing SPARQL: SELECT ?s WHERE { ?s exo:Asset_filename "ems__Meeting" . }
       // Then receive 1 result with URI `obsidian://vault/03%20Knowledge/ems/ems__Meeting.md`
 
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT ?s WHERE {
-          ?s exo:Asset_fileName "ems__Meeting" .
+          ?s exo:Asset_filename "ems__Meeting" .
         }
       `;
 
@@ -235,7 +235,7 @@ describe("Asset_fileName SPARQL Query (Issue #666)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT ?s WHERE {
-          ?s exo:Asset_fileName "ems__Meeting" .
+          ?s exo:Asset_filename "ems__Meeting" .
         }
       `;
 

--- a/packages/exocortex/tests/unit/infrastructure/sparql/ClassPropertiesQuery.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/ClassPropertiesQuery.test.ts
@@ -6,13 +6,13 @@
  * The canonical SPARQL query pattern being tested:
  * ```sparql
  * SELECT DISTINCT ?propertyLabel WHERE {
- *   ?targetClass exo:Asset_fileName "ems__Meeting" .
+ *   ?targetClass exo:Asset_filename "ems__Meeting" .
  *   ?targetClass exo:Class_superClass* ?class .
  *   ?property exo:Property_domain ?class .
- *   ?property exo:Asset_fileName ?propertyLabel .
+ *   ?property exo:Asset_filename ?propertyLabel .
  *   ?property exo:Instance_class ?propClass .
  *   FILTER NOT EXISTS {
- *     ?propClass exo:Asset_fileName "exo__DeprecatedProperty"
+ *     ?propClass exo:Asset_filename "exo__DeprecatedProperty"
  *   }
  * }
  * ORDER BY ?propertyLabel
@@ -29,7 +29,7 @@ import { Triple } from "../../../../src/domain/models/rdf/Triple";
 
 // Ontology URIs
 const EXO = "https://exocortex.my/ontology/exo#";
-const EXO_ASSET_FILE_NAME = new IRI(`${EXO}Asset_fileName`);
+const EXO_ASSET_FILE_NAME = new IRI(`${EXO}Asset_filename`);
 const EXO_CLASS_SUPER_CLASS = new IRI(`${EXO}Class_superClass`);
 const EXO_PROPERTY_DOMAIN = new IRI(`${EXO}Property_domain`);
 const EXO_INSTANCE_CLASS = new IRI(`${EXO}Instance_class`);
@@ -245,7 +245,7 @@ describe("Class Properties Query (Issue #665)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?class WHERE {
-          ?targetClass exo:Asset_fileName "ems__Meeting" .
+          ?targetClass exo:Asset_filename "ems__Meeting" .
           ?targetClass exo:Class_superClass* ?class .
         }
       `;
@@ -266,7 +266,7 @@ describe("Class Properties Query (Issue #665)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?class WHERE {
-          ?targetClass exo:Asset_fileName "ems__Effort" .
+          ?targetClass exo:Asset_filename "ems__Effort" .
           ?targetClass exo:Class_superClass* ?class .
         }
       `;
@@ -287,7 +287,7 @@ describe("Class Properties Query (Issue #665)", () => {
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?propertyLabel WHERE {
           ?property exo:Property_domain <${MEETING_CLASS}> .
-          ?property exo:Asset_fileName ?propertyLabel .
+          ?property exo:Asset_filename ?propertyLabel .
         }
         ORDER BY ?propertyLabel
       `;
@@ -307,10 +307,10 @@ describe("Class Properties Query (Issue #665)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?propertyLabel WHERE {
-          ?targetClass exo:Asset_fileName "ems__Meeting" .
+          ?targetClass exo:Asset_filename "ems__Meeting" .
           ?targetClass exo:Class_superClass* ?class .
           ?property exo:Property_domain ?class .
-          ?property exo:Asset_fileName ?propertyLabel .
+          ?property exo:Asset_filename ?propertyLabel .
         }
         ORDER BY ?propertyLabel
       `;
@@ -342,13 +342,13 @@ describe("Class Properties Query (Issue #665)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?propertyLabel WHERE {
-          ?targetClass exo:Asset_fileName "ems__Meeting" .
+          ?targetClass exo:Asset_filename "ems__Meeting" .
           ?targetClass exo:Class_superClass* ?class .
           ?property exo:Property_domain ?class .
-          ?property exo:Asset_fileName ?propertyLabel .
+          ?property exo:Asset_filename ?propertyLabel .
           ?property exo:Instance_class ?propClass .
           FILTER NOT EXISTS {
-            ?propClass exo:Asset_fileName "exo__DeprecatedProperty"
+            ?propClass exo:Asset_filename "exo__DeprecatedProperty"
           }
         }
         ORDER BY ?propertyLabel
@@ -382,12 +382,12 @@ describe("Class Properties Query (Issue #665)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?propertyLabel WHERE {
-          ?targetClass exo:Asset_fileName "ems__Meeting" .
+          ?targetClass exo:Asset_filename "ems__Meeting" .
           ?targetClass exo:Class_superClass* ?class .
           ?property exo:Property_domain ?class .
-          ?property exo:Asset_fileName ?propertyLabel .
+          ?property exo:Asset_filename ?propertyLabel .
           ?property exo:Instance_class ?propClass .
-          ?propClass exo:Asset_fileName "exo__DeprecatedProperty" .
+          ?propClass exo:Asset_filename "exo__DeprecatedProperty" .
         }
         ORDER BY ?propertyLabel
       `;
@@ -409,10 +409,10 @@ describe("Class Properties Query (Issue #665)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?propertyLabel WHERE {
-          ?targetClass exo:Asset_fileName "NonExistentClass" .
+          ?targetClass exo:Asset_filename "NonExistentClass" .
           ?targetClass exo:Class_superClass* ?class .
           ?property exo:Property_domain ?class .
-          ?property exo:Asset_fileName ?propertyLabel .
+          ?property exo:Asset_filename ?propertyLabel .
         }
       `;
 
@@ -430,10 +430,10 @@ describe("Class Properties Query (Issue #665)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?propertyLabel WHERE {
-          ?targetClass exo:Asset_fileName "EmptyClass" .
+          ?targetClass exo:Asset_filename "EmptyClass" .
           ?targetClass exo:Class_superClass* ?class .
           ?property exo:Property_domain ?class .
-          ?property exo:Asset_fileName ?propertyLabel .
+          ?property exo:Asset_filename ?propertyLabel .
         }
       `;
 
@@ -448,13 +448,13 @@ describe("Class Properties Query (Issue #665)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?propertyLabel WHERE {
-          ?targetClass exo:Asset_fileName "ems__Task" .
+          ?targetClass exo:Asset_filename "ems__Task" .
           ?targetClass exo:Class_superClass* ?class .
           ?property exo:Property_domain ?class .
-          ?property exo:Asset_fileName ?propertyLabel .
+          ?property exo:Asset_filename ?propertyLabel .
           ?property exo:Instance_class ?propClass .
           FILTER NOT EXISTS {
-            ?propClass exo:Asset_fileName "exo__DeprecatedProperty"
+            ?propClass exo:Asset_filename "exo__DeprecatedProperty"
           }
         }
         ORDER BY ?propertyLabel
@@ -487,13 +487,13 @@ describe("Class Properties Query (Issue #665)", () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
         SELECT DISTINCT ?propertyLabel WHERE {
-          ?targetClass exo:Asset_fileName "ems__Meeting" .
+          ?targetClass exo:Asset_filename "ems__Meeting" .
           ?targetClass exo:Class_superClass* ?class .
           ?property exo:Property_domain ?class .
-          ?property exo:Asset_fileName ?propertyLabel .
+          ?property exo:Asset_filename ?propertyLabel .
           ?property exo:Instance_class ?propClass .
           FILTER NOT EXISTS {
-            ?propClass exo:Asset_fileName "exo__DeprecatedProperty"
+            ?propClass exo:Asset_filename "exo__DeprecatedProperty"
           }
         }
         ORDER BY ?propertyLabel

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.asset-filename.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.asset-filename.test.ts
@@ -1,0 +1,237 @@
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import {
+  IVaultAdapter,
+  IFile,
+  IFrontmatter,
+} from "../../../src/interfaces/IVaultAdapter";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+function createMockLogger(): jest.Mocked<ILogger> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+function createVault(): jest.Mocked<IVaultAdapter> {
+  return {
+    getFrontmatter: jest.fn(),
+    getAllFiles: jest.fn(),
+    read: jest.fn(),
+    create: jest.fn(),
+    modify: jest.fn(),
+    delete: jest.fn(),
+    exists: jest.fn(),
+    getAbstractFileByPath: jest.fn(),
+    updateFrontmatter: jest.fn(),
+    rename: jest.fn(),
+    createFolder: jest.fn(),
+    getFirstLinkpathDest: jest.fn(),
+    process: jest.fn(),
+    updateLinks: jest.fn(),
+    getDefaultNewFileParent: jest.fn(),
+  } as jest.Mocked<IVaultAdapter>;
+}
+
+/**
+ * RFC 1ce2a226 Phase 3 acceptance tests for `exo:Asset_filename` parser emit.
+ *
+ * Verifies:
+ *  - Test 1: every parsed file emits exactly one `exo:Asset_filename` triple.
+ *  - Test 2 (idempotency): two convertNote → addAll cycles produce identical
+ *    triple graph (no duplicate filename triple).
+ *  - Test 3 (rename overwrite): when a file's basename changes between
+ *    reindex cycles, the simulated indexer flow (remove-by-subject + addAll)
+ *    leaves only the new filename triple, no leftover from the old basename.
+ *  - Test 4 (anchor preservation) lives in
+ *    `packages/cli/tests/unit/services/RenameToUidService.test.ts`.
+ */
+describe("NoteToRDFConverter — exo:Asset_filename (RFC 1ce2a226 Phase 3)", () => {
+  const FILENAME_PREDICATE = Namespace.EXO.term("Asset_filename");
+
+  let converter: NoteToRDFConverter;
+  let mockVault: jest.Mocked<IVaultAdapter>;
+
+  beforeEach(() => {
+    mockVault = createVault();
+    converter = new NoteToRDFConverter(mockVault, createMockLogger());
+  });
+
+  describe("Test 1: single-file emit", () => {
+    it("emits exactly one exo:Asset_filename triple per legacy note", async () => {
+      const file: IFile = {
+        path: "03 Knowledge/ems/some-task.md",
+        basename: "some-task",
+        name: "some-task.md",
+        parent: null,
+      };
+      const frontmatter: IFrontmatter = {
+        exo__Asset_uid: "11111111-1111-1111-1111-111111111111",
+        exo__Asset_label: "Some Task",
+        exo__Instance_class: ["[[ems__Task]]"],
+      };
+      mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+      const triples = await converter.convertNote(file);
+
+      const filenameTriples = triples.filter((t) =>
+        t.predicate.equals(FILENAME_PREDICATE),
+      );
+      expect(filenameTriples).toHaveLength(1);
+      expect((filenameTriples[0].object as Literal).value).toBe("some-task");
+      expect((filenameTriples[0].subject as IRI).value).toBe(
+        "obsidian://vault/03%20Knowledge/ems/some-task.md",
+      );
+    });
+
+    it("preserves spaces in basename (URL-decoded literal, encoded IRI)", async () => {
+      const file: IFile = {
+        path: "Notes/My Note.md",
+        basename: "My Note",
+        name: "My Note.md",
+        parent: null,
+      };
+      const frontmatter: IFrontmatter = {
+        exo__Asset_uid: "22222222-2222-2222-2222-222222222222",
+        exo__Asset_label: "My Note",
+      };
+      mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+      const triples = await converter.convertNote(file);
+
+      const filenameTriple = triples.find((t) =>
+        t.predicate.equals(FILENAME_PREDICATE),
+      );
+      expect(filenameTriple).toBeDefined();
+      expect((filenameTriple!.object as Literal).value).toBe("My Note");
+      expect((filenameTriple!.subject as IRI).value).toBe(
+        "obsidian://vault/Notes/My%20Note.md",
+      );
+    });
+
+    it("emits exo:Asset_filename for Exo 0.0.3 notes as well", async () => {
+      const file: IFile = {
+        path: "exo003/sample.md",
+        basename: "sample",
+        name: "sample.md",
+        parent: null,
+      };
+      // Minimal valid Exo 0.0.3 Namespace metadata. Even if the converter
+      // returns zero domain triples, the filename triple must still be
+      // emitted at the convertNote level.
+      const frontmatter: IFrontmatter = {
+        metadata: "namespace",
+        prefix: "ex",
+        uri: "https://example.org/ns#",
+      };
+      mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+      const triples = await converter.convertNote(file);
+
+      const filenameTriples = triples.filter((t) =>
+        t.predicate.equals(FILENAME_PREDICATE),
+      );
+      expect(filenameTriples).toHaveLength(1);
+      expect((filenameTriples[0].object as Literal).value).toBe("sample");
+    });
+  });
+
+  describe("Test 2: idempotency on double reindex", () => {
+    it("double convertNote + addAll → set semantics keeps single filename triple", async () => {
+      const file: IFile = {
+        path: "idempotent.md",
+        basename: "idempotent",
+        name: "idempotent.md",
+        parent: null,
+      };
+      const frontmatter: IFrontmatter = {
+        exo__Asset_uid: "33333333-3333-3333-3333-333333333333",
+        exo__Asset_label: "Idempotent Note",
+      };
+      mockVault.getFrontmatter.mockReturnValue(frontmatter);
+
+      const store = new InMemoryTripleStore();
+
+      // First indexing pass.
+      const firstTriples = await converter.convertNote(file);
+      await store.addAll(firstTriples);
+
+      // Second indexing pass — identical file state.
+      const secondTriples = await converter.convertNote(file);
+      await store.addAll(secondTriples);
+
+      const filenameTriples = await store.match(
+        undefined,
+        FILENAME_PREDICATE,
+        undefined,
+      );
+      expect(filenameTriples).toHaveLength(1);
+      expect((filenameTriples[0].object as Literal).value).toBe("idempotent");
+    });
+  });
+
+  describe("Test 3: rename overwrite via remove-by-subject + addAll", () => {
+    it("after basename change + remove-by-subject + re-add → only new filename triple remains", async () => {
+      const store = new InMemoryTripleStore();
+      const fileOld: IFile = {
+        path: "rename-source.md",
+        basename: "rename-source",
+        name: "rename-source.md",
+        parent: null,
+      };
+      mockVault.getFrontmatter.mockReturnValue({
+        exo__Asset_uid: "44444444-4444-4444-4444-444444444444",
+        exo__Asset_label: "Rename Source",
+      });
+
+      // Initial indexing — file is "rename-source.md".
+      const initialTriples = await converter.convertNote(fileOld);
+      await store.addAll(initialTriples);
+
+      // Simulate VaultRDFIndexer.renameFile flow: removeFileTriples(oldPath)
+      // before re-emitting under new path. This is the production overwrite
+      // semantics described in RFC 1ce2a226 §Phase 3b.
+      const oldSubjectIRI = new IRI(
+        "obsidian://vault/rename-source.md",
+      );
+      const staleTriples = await store.match(oldSubjectIRI, undefined, undefined);
+      await store.removeAll(staleTriples);
+
+      // File renamed to "renamed-target.md".
+      const fileNew: IFile = {
+        path: "renamed-target.md",
+        basename: "renamed-target",
+        name: "renamed-target.md",
+        parent: null,
+      };
+      const newTriples = await converter.convertNote(fileNew);
+      await store.addAll(newTriples);
+
+      const allFilenames = await store.match(
+        undefined,
+        FILENAME_PREDICATE,
+        undefined,
+      );
+      expect(allFilenames).toHaveLength(1);
+      expect((allFilenames[0].object as Literal).value).toBe("renamed-target");
+      expect((allFilenames[0].subject as IRI).value).toBe(
+        "obsidian://vault/renamed-target.md",
+      );
+
+      // Verify old filename triple is gone.
+      const staleFilename = await store.match(
+        oldSubjectIRI,
+        FILENAME_PREDICATE,
+        undefined,
+      );
+      expect(staleFilename).toHaveLength(0);
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.namespace-relax.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.namespace-relax.test.ts
@@ -91,9 +91,9 @@ describe("NoteToRDFConverter — namespace whitelist relaxation", () => {
 
     const triples = await converter.convertNote(file);
 
-    // Only the implicit Asset_fileName triple should be emitted.
+    // Only the implicit Asset_filename triple should be emitted.
     expect(triples.length).toBe(1);
-    expect(triples[0].predicate.value.endsWith("Asset_fileName")).toBe(true);
+    expect(triples[0].predicate.value.endsWith("Asset_filename")).toBe(true);
   });
 
   it("ignores keys whose prefix starts with a non-letter", async () => {
@@ -104,6 +104,6 @@ describe("NoteToRDFConverter — namespace whitelist relaxation", () => {
     mockVault.getFrontmatter.mockReturnValue(frontmatter);
 
     const triples = await converter.convertNote(file);
-    expect(triples.length).toBe(1); // only Asset_fileName
+    expect(triples.length).toBe(1); // only Asset_filename
   });
 });

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -403,9 +403,9 @@ describe("NoteToRDFConverter", () => {
       });
     });
 
-    // Issue #666: Add Asset_fileName predicate for all assets
-    describe("Asset_fileName predicate (Issue #666)", () => {
-      it("should add Asset_fileName triple with file basename (without .md)", async () => {
+    // Issue #666: Add Asset_filename predicate for all assets
+    describe("Asset_filename predicate (Issue #666)", () => {
+      it("should add Asset_filename triple with file basename (without .md)", async () => {
         const file: IFile = {
           path: "03 Knowledge/ems/ems__Meeting.md",
           basename: "ems__Meeting",
@@ -422,19 +422,19 @@ describe("NoteToRDFConverter", () => {
         const triples = await converter.convertNote(file);
 
         const fileNameTriple = triples.find((t) =>
-          (t.predicate as IRI).value.includes("Asset_fileName")
+          (t.predicate as IRI).value.includes("Asset_filename")
         );
 
         expect(fileNameTriple).toBeDefined();
         expect(fileNameTriple!.predicate).toBeInstanceOf(IRI);
         expect((fileNameTriple!.predicate as IRI).value).toBe(
-          Namespace.EXO.term("Asset_fileName").value
+          Namespace.EXO.term("Asset_filename").value
         );
         expect(fileNameTriple!.object).toBeInstanceOf(Literal);
         expect((fileNameTriple!.object as Literal).value).toBe("ems__Meeting");
       });
 
-      it("should add Asset_fileName for files with spaces in path", async () => {
+      it("should add Asset_filename for files with spaces in path", async () => {
         const file: IFile = {
           path: "My Folder/My Task.md",
           basename: "My Task",
@@ -451,14 +451,14 @@ describe("NoteToRDFConverter", () => {
         const triples = await converter.convertNote(file);
 
         const fileNameTriple = triples.find((t) =>
-          (t.predicate as IRI).value.includes("Asset_fileName")
+          (t.predicate as IRI).value.includes("Asset_filename")
         );
 
         expect(fileNameTriple).toBeDefined();
         expect((fileNameTriple!.object as Literal).value).toBe("My Task");
       });
 
-      it("should use correct subject IRI for Asset_fileName triple", async () => {
+      it("should use correct subject IRI for Asset_filename triple", async () => {
         const file: IFile = {
           path: "03 Knowledge/ems/ems__Task.md",
           basename: "ems__Task",
@@ -475,7 +475,7 @@ describe("NoteToRDFConverter", () => {
         const triples = await converter.convertNote(file);
 
         const fileNameTriple = triples.find((t) =>
-          (t.predicate as IRI).value.includes("Asset_fileName")
+          (t.predicate as IRI).value.includes("Asset_filename")
         );
 
         expect(fileNameTriple).toBeDefined();
@@ -485,7 +485,7 @@ describe("NoteToRDFConverter", () => {
         );
       });
 
-      it("should add Asset_fileName even if no other exo/ems properties exist", async () => {
+      it("should add Asset_filename even if no other exo/ems properties exist", async () => {
         const file: IFile = {
           path: "Notes/My Note.md",
           basename: "My Note",
@@ -502,9 +502,9 @@ describe("NoteToRDFConverter", () => {
 
         const triples = await converter.convertNote(file);
 
-        // Should only have Asset_fileName triple (no exo/ems properties)
+        // Should only have Asset_filename triple (no exo/ems properties)
         expect(triples.length).toBe(1);
-        expect((triples[0].predicate as IRI).value).toContain("Asset_fileName");
+        expect((triples[0].predicate as IRI).value).toContain("Asset_filename");
         expect((triples[0].object as Literal).value).toBe("My Note");
       });
     });
@@ -1160,9 +1160,9 @@ describe("NoteToRDFConverter", () => {
     });
   });
 
-  // Issue #666: Asset_fileName predicate for SPARQL queries by filename
-  describe("Asset_fileName predicate (Issue #666)", () => {
-    it("should add Asset_fileName triple for every file with frontmatter", async () => {
+  // Issue #666: Asset_filename predicate for SPARQL queries by filename
+  describe("Asset_filename predicate (Issue #666)", () => {
+    it("should add Asset_filename triple for every file with frontmatter", async () => {
       const file: IFile = {
         path: "03 Knowledge/ems/ems__Meeting.md",
         basename: "ems__Meeting",
@@ -1179,7 +1179,7 @@ describe("NoteToRDFConverter", () => {
       const triples = await converter.convertNote(file);
 
       const fileNameTriple = triples.find((t) =>
-        (t.predicate as IRI).value.includes("Asset_fileName")
+        (t.predicate as IRI).value.includes("Asset_filename")
       );
 
       expect(fileNameTriple).toBeDefined();
@@ -1187,7 +1187,7 @@ describe("NoteToRDFConverter", () => {
       expect((fileNameTriple!.object as Literal).value).toBe("ems__Meeting");
     });
 
-    it("should use exo namespace for Asset_fileName predicate", async () => {
+    it("should use exo namespace for Asset_filename predicate", async () => {
       const file: IFile = {
         path: "test.md",
         basename: "test",
@@ -1204,12 +1204,12 @@ describe("NoteToRDFConverter", () => {
       const triples = await converter.convertNote(file);
 
       const fileNameTriple = triples.find((t) =>
-        (t.predicate as IRI).value.includes("Asset_fileName")
+        (t.predicate as IRI).value.includes("Asset_filename")
       );
 
       expect(fileNameTriple).toBeDefined();
       expect((fileNameTriple!.predicate as IRI).value).toBe(
-        Namespace.EXO.term("Asset_fileName").value
+        Namespace.EXO.term("Asset_filename").value
       );
     });
 
@@ -1230,7 +1230,7 @@ describe("NoteToRDFConverter", () => {
       const triples = await converter.convertNote(file);
 
       const fileNameTriple = triples.find((t) =>
-        (t.predicate as IRI).value.includes("Asset_fileName")
+        (t.predicate as IRI).value.includes("Asset_filename")
       );
 
       expect(fileNameTriple).toBeDefined();
@@ -1255,7 +1255,7 @@ describe("NoteToRDFConverter", () => {
       const triples = await converter.convertNote(file);
 
       const fileNameTriple = triples.find((t) =>
-        (t.predicate as IRI).value.includes("Asset_fileName")
+        (t.predicate as IRI).value.includes("Asset_filename")
       );
 
       expect(fileNameTriple).toBeDefined();
@@ -1264,7 +1264,7 @@ describe("NoteToRDFConverter", () => {
       );
     });
 
-    it("should NOT add Asset_fileName for files without frontmatter", async () => {
+    it("should NOT add Asset_filename for files without frontmatter", async () => {
       const file: IFile = {
         path: "test.md",
         basename: "test",
@@ -1278,12 +1278,12 @@ describe("NoteToRDFConverter", () => {
 
       expect(triples).toEqual([]);
       const fileNameTriple = triples.find((t) =>
-        (t.predicate as IRI).value?.includes("Asset_fileName")
+        (t.predicate as IRI).value?.includes("Asset_filename")
       );
       expect(fileNameTriple).toBeUndefined();
     });
 
-    it("should add Asset_fileName for all files in convertVault", async () => {
+    it("should add Asset_filename for all files in convertVault", async () => {
       const file1: IFile = {
         path: "note1.md",
         basename: "note1",
@@ -1306,7 +1306,7 @@ describe("NoteToRDFConverter", () => {
       const triples = await converter.convertVault();
 
       const fileNameTriples = triples.filter((t) =>
-        (t.predicate as IRI).value.includes("Asset_fileName")
+        (t.predicate as IRI).value.includes("Asset_filename")
       );
 
       expect(fileNameTriples.length).toBe(2);
@@ -1649,7 +1649,7 @@ describe("NoteToRDFConverter", () => {
 
         // Verify file name triples from both files
         const fileNameTriples = triples.filter((t) =>
-          (t.predicate as IRI).value.includes("Asset_fileName")
+          (t.predicate as IRI).value.includes("Asset_filename")
         );
         expect(fileNameTriples.length).toBe(2);
 
@@ -2348,7 +2348,7 @@ Here is an image: ![[screenshot.png]] and a link [[Real Note]].
         // Should NOT throw, just skip body links
         const triples = await converter.convertNote(file);
 
-        // Should have Asset_fileName, Asset_label, and rdfs:label (Issue #2807), but no body links
+        // Should have Asset_filename, Asset_label, and rdfs:label (Issue #2807), but no body links
         expect(triples.length).toBe(3);
         const bodyLinkTriples = triples.filter((t) =>
           (t.predicate as IRI).value.includes("Asset_bodyLink")
@@ -2497,8 +2497,13 @@ See [[Note A]], then [[Note A]] again, and [[Note A]] once more.
 
         const triples = await converter.convertNote(file);
 
-        // Namespace files don't generate triples directly
-        expect(triples.length).toBe(0);
+        // Namespace files don't generate domain triples — only the
+        // RFC 1ce2a226 Phase 3a `exo:Asset_filename` derived triple.
+        expect(triples.length).toBe(1);
+        const filenameTriple = triples[0];
+        expect((filenameTriple.predicate as IRI).value).toBe(
+          "https://exocortex.my/ontology/exo#Asset_filename",
+        );
       });
 
       it("should detect Exo 0.0.3 blank_node format", async () => {
@@ -2529,7 +2534,7 @@ See [[Note A]], then [[Note A]] again, and [[Note A]] once more.
 
         const triples = await converter.convertNote(file);
 
-        // Should process as legacy format (with Asset_fileName)
+        // Should process as legacy format (with Asset_filename)
         const labelTriple = triples.find((t) =>
           (t.predicate as IRI).value.includes("Asset_label")
         );
@@ -2549,14 +2554,17 @@ See [[Note A]], then [[Note A]] again, and [[Note A]] once more.
 
         const triples = await converter.convertNote(file);
 
-        expect(triples.length).toBe(2);
+        // 2 bidirectional owl:sameAs + 1 RFC 1ce2a226 Phase 3a filename triple
+        expect(triples.length).toBe(3);
 
-        // File IRI -> Anchor URI
-        const fileToUri = triples.find((t) =>
-          (t.subject as IRI).value.includes("obsidian://vault/")
+        // File IRI -> Anchor URI (owl:sameAs to anchor URI as object)
+        const fileToUri = triples.find(
+          (t) =>
+            (t.subject as IRI).value.includes("obsidian://vault/") &&
+            t.object instanceof IRI &&
+            (t.object as IRI).value === "https://exocortex.my/ontology/ems#Meeting",
         );
         expect(fileToUri).toBeDefined();
-        expect((fileToUri!.object as IRI).value).toBe("https://exocortex.my/ontology/ems#Meeting");
 
         // Anchor URI -> File IRI
         const uriToFile = triples.find((t) =>
@@ -2628,8 +2636,8 @@ See [[Note A]], then [[Note A]] again, and [[Note A]] once more.
 
         const triples = await converter.convertNote(statementFile);
 
-        // Should have the statement triple + file reference triple
-        expect(triples.length).toBe(2);
+        // statement triple + file reference triple + RFC 1ce2a226 Phase 3a filename
+        expect(triples.length).toBe(3);
 
         const statementTriple = triples.find((t) =>
           (t.subject as IRI).value === "https://example.org/subject"
@@ -2652,7 +2660,8 @@ See [[Note A]], then [[Note A]] again, and [[Note A]] once more.
 
         const triples = await converter.convertNote(file);
 
-        expect(triples.length).toBe(2);
+        // statement triple + reverse anchor triple + RFC 1ce2a226 Phase 3a filename
+        expect(triples.length).toBe(3);
 
         const statementTriple = triples.find((t) =>
           (t.subject as IRI).value === "https://example.org/subject"
@@ -2722,8 +2731,8 @@ It can contain **markdown** formatting.
 
         const triples = await converter.convertNote(bodyFile);
 
-        // Should have the body triple + file reference triple
-        expect(triples.length).toBe(2);
+        // body triple + file reference triple + RFC 1ce2a226 Phase 3a filename
+        expect(triples.length).toBe(3);
 
         const bodyTriple = triples.find((t) =>
           (t.subject as IRI).value === "https://example.org/subject"
@@ -2848,7 +2857,10 @@ It can contain **markdown** formatting.
     });
 
     describe("invalid Exo 0.0.3 files", () => {
-      it("should return empty array for invalid Exo 0.0.3 frontmatter", async () => {
+      it("emits filename only (no domain triples) for invalid Exo 0.0.3 frontmatter", async () => {
+        // RFC 1ce2a226 Phase 3a: filename is path-derived and always emitted
+        // when frontmatter is present, even if Exo 0.0.3 validation fails.
+        // Domain triples are still skipped — only the filename remains.
         const frontmatter: IFrontmatter = {
           metadata: Exo003MetadataType.Anchor,
           // missing uri - invalid
@@ -2858,10 +2870,13 @@ It can contain **markdown** formatting.
 
         const triples = await converter.convertNote(file);
 
-        expect(triples).toEqual([]);
+        expect(triples.length).toBe(1);
+        expect((triples[0].predicate as IRI).value).toBe(
+          "https://exocortex.my/ontology/exo#Asset_filename",
+        );
       });
 
-      it("should return empty array for statement with forbidden properties", async () => {
+      it("emits filename only (no domain triples) for statement with forbidden properties", async () => {
         const frontmatter: IFrontmatter = {
           metadata: Exo003MetadataType.Statement,
           subject: "[[subject]]",
@@ -2874,8 +2889,11 @@ It can contain **markdown** formatting.
 
         const triples = await converter.convertNote(file);
 
-        // Should skip invalid files
-        expect(triples).toEqual([]);
+        // Domain skipped, filename retained per RFC 1ce2a226 Phase 3a.
+        expect(triples.length).toBe(1);
+        expect((triples[0].predicate as IRI).value).toBe(
+          "https://exocortex.my/ontology/exo#Asset_filename",
+        );
       });
     });
 

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -106,7 +106,9 @@ fi
 #   (RDF → Resolver → Executor pipeline regression — wikilink unwrap, targetClass IRI reverse-map,
 #   copy-from-target ≥3 fields)
 echo "📦 Running exocortex grounding + RFC regression tests..."
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref)|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-resolve-execute\.test)\.ts --forceExit"
+# RFC 1ce2a226 Phase 3 (asset-filename): NoteToRDFConverter.asset-filename
+#   acceptance suite (single-file emit, idempotency, rename overwrite).
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref|asset-filename)|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-resolve-execute\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
## Summary

RFC `1ce2a226-6454-4edb-b639-4af44e99faa9` Phase 3 — materialize file basename as a queryable `exo:Asset_filename` triple, with overwrite-on-reindex semantics, and bring inbound-wikilink rewrite in line with the documented anchor-preservation rule.

- Predicate rename `exo:Asset_fileName` (camelCase, Issue #666) → `exo:Asset_filename` (lowercase). The lowercase form is the canonical name per RFC §Phase 2 property asset `4223f91e-f1e9-4bff-b892-36e6e28d5754` (already shipped to vault `assetspaces/exo/`). No external SPARQL consumer in either vault references `Asset_fileName` (only descriptive prose in `PATTERNS.md` + one inbox scan).
- Emit moved from `convertLegacyNote` → `convertNote`, so Exo 0.0.3 files (namespace / anchor / blank_node / statement / body) also receive the derived filename triple. Filename is path-derived and always emitted when frontmatter is present — see RFC §Метрики «каждый .md в vault».
- `wikilinkRewriter` now preserves `#heading` and `^block` anchors when rewriting inbound wikilinks to a UID-canon target. Previous behaviour collapsed every shape to bare `[[uid]]`, contradicting the documented vault rule (`Developer/CLAUDE.md` line 70, aiKnow `152e39df`). Phase 3c brings implementation in line with the rule.

## Behaviour changes — flag for review

1. **Predicate rename.** `exo:Asset_fileName` is retired. All in-package consumers were swept via `sed` (78 references / 7 files). No vault SPARQL queries / SHACL shapes reference the old camelCase name.
2. **Anchor preservation in `rewriteInboundWikilinks`.** `[[Old#section]]` → `[[NewBase#section]]` (previously `[[NewBase]]`). Aliases are still dropped per strip-canon policy. Test fixture in `rename-to-uid-update-inbound-links.integration.test.ts` updated to assert new behaviour.
3. **Filename emit for malformed Exo 0.0.3 files.** Invalid Exo 0.0.3 frontmatter (missing `uri`, forbidden `uid` in statement) now emits 1 filename triple instead of 0. Domain triples are still skipped — only the path-derived filename is recoverable. Matches RFC §Метрики «каждый .md в vault».

## Tests

- `packages/exocortex/tests/unit/services/NoteToRDFConverter.asset-filename.test.ts` (NEW, 5 cases) — single-file emit, spaces in basename, Exo 0.0.3 emit, idempotency (set-semantics), rename overwrite (remove-by-subject + re-add).
- `packages/cli/tests/unit/utils/wikilinkRewriter.anchor-preservation.test.ts` (NEW, 10 cases) — anchor preservation across all 6 shapes, plus fenced-code / inline-code / embed-link exclusion checks.
- 7 existing Exo 0.0.3 tests in `NoteToRDFConverter.test.ts` updated to expect the additional filename triple.
- `rename-to-uid-update-inbound-links.integration.test.ts` updated for new anchor-preserving expectation.
- `scripts/test-ci-batched.sh` allowlist regex extended with `NoteToRDFConverter.asset-filename` so the new acceptance suite is gated by the `test-coverage` CI step.

## Local verification

- `npm run check:types` — clean
- `npm run lint` — clean (only 2 pre-existing warnings, no errors)
- `packages/exocortex/tests/unit/services/NoteToRDFConverter.**` — 209/209 green (with 7 fixed Exo003 expectations)
- `packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.test.ts` — 32/32 green
- `packages/cli/tests/unit` (94 suites) — green, including new `wikilinkRewriter.anchor-preservation` (10/10)
- `packages/cli/tests/integration/rename-to-uid-update-inbound-links` — 2/2 green with updated anchor expectations
- Pre-existing failures (`CommandConstants.test`, `command-pilot.integration.test`, `sparql-exo003.integration.test`, `grounding-resolve-execute.test` Fixtures 1+3, `QueryExecutor.branch.test`, `FrontmatterService.error.test`, `subquery-acceptance.test`, `CommandDefinition.test`) reproduce identically on `origin/main` without this branch — environmental or CI-only fixtures.

## Test plan

- [ ] 14 required CI checks green: `archgate`, `detect-changes`, `e2e-shard (1..6)`, `lint`, `parity-gate`, `test-bdd`, `test-component`, `test-coverage`, `typecheck`
- [ ] `code-reviewer` agent run after CI green (parser PR ⇒ no `gh pr merge --auto`)
- [ ] `advisor()` round-2 after applying reviewer findings
- [ ] Manual `gh pr merge --squash --delete-branch`
- [ ] After merge: `@kitelev/exocortex-cli` auto-released, Phase 3.5 hard SPARQL gate verified in both vaults (COUNT ≥ asset count)

## Refs

- RFC `1ce2a226-6454-4edb-b639-4af44e99faa9` (vault-exodev/inbox)
- Phase 2 property asset `4223f91e-f1e9-4bff-b892-36e6e28d5754` (`assetspaces/exo/`)
- Super-property `0be06648-acee-4c8d-bfb7-53fc14155ea2` (`exo__Asset_derivedAttribute`)