### PR TITLE
feat(shacl): add sh:pattern constraint via exo__Property_pattern

### DIFF
--- a/packages/exocortex/src/services/ShaclLiteValidator.ts
+++ b/packages/exocortex/src/services/ShaclLiteValidator.ts
@@ -8,6 +8,12 @@ export interface Shape {
   range?: string[];
   cardinality?: 'Single' | 'Multiple';
   minCount?: number;
+  /**
+   * ECMAScript regex string. Maps to W3C SHACL `sh:pattern`.
+   * Applied to literal values only; compiled once per validation run.
+   * Invalid pattern strings are silently ignored (TBox config error).
+   */
+  pattern?: string;
   severity: Severity;
   message?: string;
 }
@@ -252,6 +258,35 @@ export function validate(
             `sh:maxCount violation: expected at most 1 value for <${shape.propertyIRI}>, got ${values.length}`,
         });
         continue;
+      }
+
+      // sh:pattern check — regex match on literal values.
+      // Independent of range/class constraints: a property may have a pattern
+      // without declaring a range (e.g. constraining lexical form of any string).
+      // Compile once outside the value loop; invalid patterns are skipped silently
+      // (TBox config error, not data error).
+      if (shape.pattern !== undefined && shape.pattern.length > 0) {
+        let compiledPattern: RegExp | null = null;
+        try {
+          compiledPattern = new RegExp(shape.pattern);
+        } catch {
+          compiledPattern = null;
+        }
+        if (compiledPattern) {
+          for (const obj of values) {
+            if (obj.type === 'literal' && !compiledPattern.test(obj.value)) {
+              violations.push({
+                focusNode: subjectIRI,
+                propertyPath: shape.propertyIRI,
+                severity: shape.severity,
+                message:
+                  shape.message ??
+                  `sh:pattern violation: literal "${obj.value}" does not match pattern ${shape.pattern}`,
+                actualValue: obj.value,
+              });
+            }
+          }
+        }
       }
 
       // sh:class / sh:datatype range check

--- a/packages/exocortex/src/services/ShaclLiteValidator.ts
+++ b/packages/exocortex/src/services/ShaclLiteValidator.ts
@@ -10,8 +10,13 @@ export interface Shape {
   minCount?: number;
   /**
    * ECMAScript regex string. Maps to W3C SHACL `sh:pattern`.
-   * Applied to literal values only; compiled once per validation run.
-   * Invalid pattern strings are silently ignored (TBox config error).
+   * Applied to literal values only. Pattern is compiled into a `RegExp`
+   * once at the start of `validate()` (cached in a per-call `Map<Shape, RegExp>`),
+   * so the cost is one-shot per validation run regardless of subject count.
+   * Invalid pattern strings are silently ignored (TBox config error, not data
+   * error). Pattern strings are assumed to come from a trusted single-tenant
+   * TBox (vault owner); a per-value length cap protects against ReDoS via
+   * long input literals — see `MAX_PATTERN_INPUT_LENGTH`.
    */
   pattern?: string;
   severity: Severity;
@@ -216,6 +221,28 @@ export function validate(
   const violations: Violation[] = [];
   const allSubjects = new Set([...subjectClasses.keys(), ...subjectProps.keys()]);
 
+  // Precompile sh:pattern regexes once per validation run (not per subject×shape).
+  // Invalid patterns map to null and are skipped silently at use site
+  // (TBox config error, not data error). See Shape.pattern JSDoc.
+  const patternCache = new Map<Shape, RegExp | null>();
+  for (const shape of registry.getAllShapes()) {
+    if (shape.pattern !== undefined && shape.pattern.length > 0) {
+      try {
+        patternCache.set(shape, new RegExp(shape.pattern));
+      } catch {
+        patternCache.set(shape, null);
+      }
+    }
+  }
+
+  // ReDoS guard: cap input length passed to RegExp.test().
+  // Pattern strings come from a trusted single-tenant TBox (vault owner),
+  // but values can be arbitrarily long literals (URLs in vault metadata,
+  // descriptions, etc.). A catastrophic-backtracking pattern combined with
+  // a long input value would block the validator thread. Skip the check
+  // (with a sh:Warning, NOT a violation) when value exceeds the cap.
+  const MAX_PATTERN_INPUT_LENGTH = 4096;
+
   for (const subjectIRI of allSubjects) {
     const classes = subjectClasses.get(subjectIRI) ?? [];
     const props = subjectProps.get(subjectIRI) ?? new Map<string, Array<IRI | Literal>>();
@@ -263,28 +290,33 @@ export function validate(
       // sh:pattern check — regex match on literal values.
       // Independent of range/class constraints: a property may have a pattern
       // without declaring a range (e.g. constraining lexical form of any string).
-      // Compile once outside the value loop; invalid patterns are skipped silently
-      // (TBox config error, not data error).
-      if (shape.pattern !== undefined && shape.pattern.length > 0) {
-        let compiledPattern: RegExp | null = null;
-        try {
-          compiledPattern = new RegExp(shape.pattern);
-        } catch {
-          compiledPattern = null;
-        }
-        if (compiledPattern) {
-          for (const obj of values) {
-            if (obj.type === 'literal' && !compiledPattern.test(obj.value)) {
-              violations.push({
-                focusNode: subjectIRI,
-                propertyPath: shape.propertyIRI,
-                severity: shape.severity,
-                message:
-                  shape.message ??
-                  `sh:pattern violation: literal "${obj.value}" does not match pattern ${shape.pattern}`,
-                actualValue: obj.value,
-              });
-            }
+      // Regex is precompiled in `patternCache` outside the subject loop above;
+      // null entries indicate invalid pattern strings (silently skipped).
+      const compiledPattern = patternCache.get(shape);
+      if (compiledPattern) {
+        for (const obj of values) {
+          if (obj.type !== 'literal') continue;
+          // ReDoS guard — see MAX_PATTERN_INPUT_LENGTH comment near declaration.
+          if (obj.value.length > MAX_PATTERN_INPUT_LENGTH) {
+            violations.push({
+              focusNode: subjectIRI,
+              propertyPath: shape.propertyIRI,
+              severity: 'sh:Warning',
+              message: `sh:pattern check skipped: literal exceeds ${MAX_PATTERN_INPUT_LENGTH} chars (ReDoS guard)`,
+              actualValue: obj.value.substring(0, 64) + '…',
+            });
+            continue;
+          }
+          if (!compiledPattern.test(obj.value)) {
+            violations.push({
+              focusNode: subjectIRI,
+              propertyPath: shape.propertyIRI,
+              severity: shape.severity,
+              message:
+                shape.message ??
+                `sh:pattern violation: literal "${obj.value}" does not match pattern ${shape.pattern}`,
+              actualValue: obj.value,
+            });
           }
         }
       }

--- a/packages/exocortex/src/services/ShapeLoader.ts
+++ b/packages/exocortex/src/services/ShapeLoader.ts
@@ -88,6 +88,7 @@ export class ShapeLoader {
         exoLabelTs,
         rdfsLabelTs,
         minCountTs,
+        patternTs,
       ] = await Promise.all([
         graph.match(subject, RDFS.term("domain"), undefined),
         graph.match(subject, EXO.term("Property_domain"), undefined),
@@ -102,6 +103,7 @@ export class ShapeLoader {
         // rdfs:label Literal twin that Exocortex always emits alongside.
         graph.match(subject, RDFS.term("label"), undefined),
         graph.match(subject, EXO.term("Property_minCount"), undefined),
+        graph.match(subject, EXO.term("Property_pattern"), undefined),
       ]);
       const labelTs = [...exoLabelTs, ...rdfsLabelTs];
       // NoteToRDFConverter emits the RDFS-mapped twin triple only when the
@@ -182,6 +184,12 @@ export class ShapeLoader {
         minCountLiteral instanceof Literal ? parseInt(minCountLiteral.value, 10) : NaN;
       const minCount = !isNaN(minCountParsed) ? minCountParsed : undefined;
 
+      const patternLiteral = patternTs[0]?.object;
+      const pattern =
+        patternLiteral instanceof Literal && patternLiteral.value.length > 0
+          ? patternLiteral.value
+          : undefined;
+
       registry.register({
         propertyIRI,
         domain,
@@ -189,6 +197,7 @@ export class ShapeLoader {
         cardinality,
         severity,
         minCount,
+        pattern,
       });
     }
 
@@ -370,6 +379,7 @@ export class ShapeLoader {
     const cardRaw = fm["exo__Property_cardinality"];
     const sevRaw = fm["exo__Property_severity"];
     const minCountRaw = fm["exo__Property_minCount"];
+    const patternRaw = fm["exo__Property_pattern"];
 
     const domain = ShapeLoader.asArray(domainRaw)
       .map((v) => ShapeLoader.wikilinkToIRI(v))
@@ -393,6 +403,18 @@ export class ShapeLoader {
     const minCount =
       minCountParsed !== undefined && !isNaN(minCountParsed) ? minCountParsed : undefined;
 
+    // Strip surrounding YAML quotes that the simple regex-based parseFrontmatter
+    // leaves in place. Pattern values typically need quoting due to regex special
+    // characters, so this case is common in practice.
+    const patternStripped =
+      typeof patternRaw === "string"
+        ? patternRaw.replace(/^["']|["']$/g, "")
+        : undefined;
+    const pattern =
+      patternStripped !== undefined && patternStripped.length > 0
+        ? patternStripped
+        : undefined;
+
     registry.register({
       propertyIRI,
       domain,
@@ -400,6 +422,7 @@ export class ShapeLoader {
       cardinality,
       severity,
       minCount,
+      pattern,
     });
   }
 

--- a/packages/exocortex/src/services/ShapeRegistry.ts
+++ b/packages/exocortex/src/services/ShapeRegistry.ts
@@ -10,9 +10,9 @@ export interface Shape {
   minCount?: number;
   /**
    * ECMAScript-compatible regex string applied to literal values.
-   * Maps to W3C SHACL `sh:pattern`. Compiled once per validation run;
-   * invalid patterns are silently ignored (TBox config error, not data error).
-   * Anchors `^`/`$` recommended for exact-match semantics.
+   * Maps to W3C SHACL `sh:pattern`. Cached as a compiled `RegExp` once per
+   * `validate()` call (not per subject) — invalid patterns are silently
+   * ignored (TBox config error). Anchors `^`/`$` recommended for exact-match.
    */
   pattern?: string;
   severity: "sh:Violation" | "sh:Warning" | "sh:Info";

--- a/packages/exocortex/src/services/ShapeRegistry.ts
+++ b/packages/exocortex/src/services/ShapeRegistry.ts
@@ -8,6 +8,13 @@ export interface Shape {
   range?: string[];
   cardinality?: "Single" | "Multiple";
   minCount?: number;
+  /**
+   * ECMAScript-compatible regex string applied to literal values.
+   * Maps to W3C SHACL `sh:pattern`. Compiled once per validation run;
+   * invalid patterns are silently ignored (TBox config error, not data error).
+   * Anchors `^`/`$` recommended for exact-match semantics.
+   */
+  pattern?: string;
   severity: "sh:Violation" | "sh:Warning" | "sh:Info";
   message?: string;
 }

--- a/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
+++ b/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
@@ -1265,3 +1265,154 @@ describe('validate — cross-vault UUID-keyed subject resolution', () => {
     expect(report.violations[0].actualValue).toBe('node:B');
   });
 });
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Suite: sh:pattern (regex on literal lexical form)
+// Added 2026-05-23 — RFC 75b50f51 SHACL constraint follow-up.
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('validate — pattern', () => {
+  const ASSETSPACE = `${EXO}AssetSpace`;
+  const GIT_PROP = `${EXO}AssetSpace_git`;
+  const EXOAS_PATTERN = '^https://github\\.com/kitelev/exoas-[a-z0-9-]+$';
+
+  // Local shape builder pinned to AssetSpace domain (makeShape default is ems:Effort).
+  function makePatternShape(overrides: Partial<Shape> & Pick<Shape, 'propertyIRI'>): Shape {
+    return makeShape({ domain: [ASSETSPACE], ...overrides });
+  }
+
+  it('T-PAT-01: literal matching pattern passes', () => {
+    const shape = makePatternShape({ propertyIRI: GIT_PROP, pattern: EXOAS_PATTERN });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      litTriple('node:A', GIT_PROP, 'https://github.com/kitelev/exoas-ems'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.conforms).toBe(true);
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T-PAT-02: literal not matching pattern emits violation', () => {
+    const shape = makePatternShape({ propertyIRI: GIT_PROP, pattern: EXOAS_PATTERN });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      litTriple('node:A', GIT_PROP, 'https://github.com/kitelev/exocortex-ems-ontology'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.conforms).toBe(false);
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0].propertyPath).toBe(GIT_PROP);
+    expect(report.violations[0].actualValue).toBe(
+      'https://github.com/kitelev/exocortex-ems-ontology',
+    );
+    expect(report.violations[0].message).toContain('sh:pattern');
+  });
+
+  it('T-PAT-03: default message mentions the pattern string', () => {
+    const shape = makePatternShape({ propertyIRI: GIT_PROP, pattern: EXOAS_PATTERN });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      litTriple('node:A', GIT_PROP, 'invalid'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations[0].message).toContain(EXOAS_PATTERN);
+  });
+
+  it('T-PAT-04: custom message overrides default', () => {
+    const shape = makePatternShape({
+      propertyIRI: GIT_PROP,
+      pattern: EXOAS_PATTERN,
+      message: 'AssetSpace git URL must follow exoas-<namespace> convention',
+    });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      litTriple('node:A', GIT_PROP, 'invalid'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations[0].message).toBe(
+      'AssetSpace git URL must follow exoas-<namespace> convention',
+    );
+  });
+
+  it('T-PAT-05: pattern check skipped for IRI values (sh:pattern is for literals)', () => {
+    const shape = makePatternShape({ propertyIRI: GIT_PROP, pattern: EXOAS_PATTERN });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      iriTriple('node:A', GIT_PROP, 'https://github.com/kitelev/exocortex-ems-ontology'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    // IRI values don't match the canonical sh:pattern semantics — skip silently
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T-PAT-06: invalid regex pattern is silently ignored (TBox config error)', () => {
+    const shape = makePatternShape({
+      propertyIRI: GIT_PROP,
+      pattern: '[invalid(regex',
+    });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      litTriple('node:A', GIT_PROP, 'any value'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.conforms).toBe(true);
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T-PAT-07: empty pattern string is treated as no constraint', () => {
+    const shape = makePatternShape({ propertyIRI: GIT_PROP, pattern: '' });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      litTriple('node:A', GIT_PROP, 'anything'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations).toHaveLength(0);
+  });
+
+  it('T-PAT-08: pattern and range coexist — both fire independently', () => {
+    const shape = makePatternShape({
+      propertyIRI: GIT_PROP,
+      range: [`${XSD}string`],
+      pattern: EXOAS_PATTERN,
+    });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      // Literal with non-string datatype + non-matching pattern → 2 violations
+      litTriple('node:A', GIT_PROP, '123', `${XSD}integer`),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations.length).toBeGreaterThanOrEqual(2);
+    expect(report.violations.some((v) => v.message.includes('sh:pattern'))).toBe(true);
+    expect(report.violations.some((v) => v.message.includes('sh:datatype'))).toBe(true);
+  });
+
+  it('T-PAT-09: pattern severity respects shape.severity', () => {
+    const shape = makePatternShape({
+      propertyIRI: GIT_PROP,
+      pattern: EXOAS_PATTERN,
+      severity: 'sh:Warning',
+    });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      litTriple('node:A', GIT_PROP, 'invalid'),
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0].severity).toBe('sh:Warning');
+    // Warning does not break conforms
+    expect(report.conforms).toBe(true);
+  });
+
+  it('T-PAT-10: pattern with anchored ^...$ exactly matches full string', () => {
+    const shape = makePatternShape({ propertyIRI: GIT_PROP, pattern: '^abc$' });
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      litTriple('node:A', GIT_PROP, 'abc'),
+      typeTriple('node:B', ASSETSPACE),
+      litTriple('node:B', GIT_PROP, 'abcdef'), // contains "abc" but not anchored match
+    ];
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0].focusNode).toBe('node:B');
+  });
+});

--- a/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
+++ b/packages/exocortex/tests/services/ShaclLiteValidator.test.ts
@@ -1377,11 +1377,11 @@ describe('validate — pattern', () => {
     });
     const triples = [
       typeTriple('node:A', ASSETSPACE),
-      // Literal with non-string datatype + non-matching pattern → 2 violations
+      // Literal with non-string datatype + non-matching pattern → exactly 2 violations
       litTriple('node:A', GIT_PROP, '123', `${XSD}integer`),
     ];
     const report = validate(triples, makeRegistry([shape]), flatHierarchy);
-    expect(report.violations.length).toBeGreaterThanOrEqual(2);
+    expect(report.violations).toHaveLength(2);
     expect(report.violations.some((v) => v.message.includes('sh:pattern'))).toBe(true);
     expect(report.violations.some((v) => v.message.includes('sh:datatype'))).toBe(true);
   });
@@ -1414,5 +1414,53 @@ describe('validate — pattern', () => {
     const report = validate(triples, makeRegistry([shape]), flatHierarchy);
     expect(report.violations).toHaveLength(1);
     expect(report.violations[0].focusNode).toBe('node:B');
+  });
+
+  it('T-PAT-11: ReDoS guard — values over 4096 chars skipped with sh:Warning', () => {
+    // ReDoS-prone pattern + long input: without the length cap this would
+    // catastrophically backtrack. With the cap, the engine emits a Warning
+    // and continues (conforms stays true since no sh:Violation raised).
+    const shape = makePatternShape({
+      propertyIRI: GIT_PROP,
+      pattern: '^(a+)+b$', // classic catastrophic-backtracking pattern
+    });
+    const longValue = 'a'.repeat(5000); // exceeds MAX_PATTERN_INPUT_LENGTH = 4096
+    const triples = [
+      typeTriple('node:A', ASSETSPACE),
+      litTriple('node:A', GIT_PROP, longValue),
+    ];
+    const start = Date.now();
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    const elapsed = Date.now() - start;
+    // Must complete instantly — cap kicked in before .test()
+    expect(elapsed).toBeLessThan(100);
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0].severity).toBe('sh:Warning');
+    expect(report.violations[0].message).toContain('ReDoS');
+    expect(report.conforms).toBe(true);
+  });
+
+  it('T-PAT-12: regex compiled once per validation run — many subjects share cache', () => {
+    // Smoke test for HIGH finding fix: verify validate() completes quickly
+    // even with many subjects against the same pattern (would have been
+    // N×compile under previous per-subject compilation).
+    const shape = makePatternShape({
+      propertyIRI: GIT_PROP,
+      pattern: EXOAS_PATTERN,
+    });
+    const triples: Triple[] = [];
+    for (let i = 0; i < 500; i++) {
+      triples.push(typeTriple(`node:${i}`, ASSETSPACE));
+      triples.push(
+        litTriple(`node:${i}`, GIT_PROP, `https://github.com/kitelev/exoas-ns${i}`),
+      );
+    }
+    const start = Date.now();
+    const report = validate(triples, makeRegistry([shape]), flatHierarchy);
+    const elapsed = Date.now() - start;
+    expect(report.conforms).toBe(true);
+    expect(report.violations).toHaveLength(0);
+    // 500 subjects, single shape with pattern — should be fast
+    expect(elapsed).toBeLessThan(500);
   });
 });

--- a/packages/exocortex/tests/services/ShapeLoader.test.ts
+++ b/packages/exocortex/tests/services/ShapeLoader.test.ts
@@ -858,4 +858,62 @@ describe("ShapeLoader.loadFromVaultFS — minCount and xsd: range", () => {
     expect(shape!.severity).toBe("sh:Warning");
     expect(shape!.domain).toEqual([`${EXO_NS}Asset`]);
   });
+
+  // Added 2026-05-23 — RFC 75b50f51 SHACL pattern constraint follow-up.
+  // Uses String.raw to keep backslashes literal (simple regex parseFrontmatter
+  // does not process YAML escape sequences — value passes through verbatim).
+  it("parses exo__Property_pattern from frontmatter (with quote stripping)", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "shacl-pattern-"));
+    try {
+      const filePath = path.join(dir, "exo__AssetSpace_git.md");
+      await fs.writeFile(
+        filePath,
+        [
+          "---",
+          'exo__Instance_class:',
+          '  - "[[30d63ce4-e574-456c-8de8-2bf1a53688c1|exo__Property]]"',
+          'exo__Property_domain: "[[73bd00e4-ccc0-4f3f-b20d-c4388c4588fb|exo__AssetSpace]]"',
+          String.raw`exo__Property_pattern: "^https://github\.com/kitelev/exoas-[a-z0-9-]+$"`,
+          "exo__Asset_label: exo__AssetSpace_git",
+          "---",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const reg = await ShapeLoader.loadFromVaultFS(dir);
+      const shape = reg.get(`${EXO_NS}AssetSpace_git`);
+      expect(shape).toBeDefined();
+      expect(shape!.pattern).toBe(
+        String.raw`^https://github\.com/kitelev/exoas-[a-z0-9-]+$`,
+      );
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves pattern undefined when frontmatter omits it", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "shacl-nopattern-"));
+    try {
+      const filePath = path.join(dir, "exo__AssetSpace_version.md");
+      await fs.writeFile(
+        filePath,
+        [
+          "---",
+          'exo__Instance_class:',
+          '  - "[[30d63ce4-e574-456c-8de8-2bf1a53688c1|exo__Property]]"',
+          'exo__Property_domain: "[[73bd00e4-ccc0-4f3f-b20d-c4388c4588fb|exo__AssetSpace]]"',
+          "exo__Asset_label: exo__AssetSpace_version",
+          "---",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const reg = await ShapeLoader.loadFromVaultFS(dir);
+      const shape = reg.get(`${EXO_NS}AssetSpace_version`);
+      expect(shape).toBeDefined();
+      expect(shape!.pattern).toBeUndefined();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Adds W3C SHACL `sh:pattern` support to the SHACL-lite engine via the new `exo__Property_pattern` meta-property. Regex constraint applied to literal lexical form, declared in RDF (vault property shape ABox), evaluated at validation time.

## Motivation

RFC `75b50f51-512e-473c-a253-77a7ad96eaa5` (AssetSpace Naming Convention `exoas-<namespace>`) — enables enforcement of repo-name ↔ namespace bijection convention. After this PR lands + new version published, `exo__AssetSpace_git` property shape can declare:

```yaml
exo__Property_pattern: "^https://github\.com/kitelev/exoas-[a-z0-9-]+$"
```

…and any AssetSpace ABox with non-conforming `_git` URL gets flagged at SHACL validation.

## Companion TBox

New property def asset already merged in vault (independent of this PR):
- UUID: `66c01ef5-2238-4586-ace7-85298ee97630`
- Location: `kitelev/exoas-exo` submodule, commit `404df16`
- Declares `exo__Property_pattern` (domain `exo__Property`, cardinality Single, range string)
- **Dormant until this PR + npm publish** — engine doesn't read `Property_pattern` predicate without the code support.

## Changes

| File | What |
|---|---|
| `ShapeRegistry.ts` + `ShaclLiteValidator.ts` | `Shape` interface: add `pattern?: string` |
| `ShapeLoader.ts` `loadFromRDFGraph` | Read `Property_pattern` triples (Promise.all extension) |
| `ShapeLoader.ts` `processFile` | Parse `exo__Property_pattern` from frontmatter с YAML quote stripping |
| `ShaclLiteValidator.ts` `validate` | Regex check on literal values, independent of range/class |

Implementation follows existing `minCount` precedent — one new field, no architectural shift.

## Semantics

- **Applies to literal values only** (canonical SHACL spec — sh:pattern is for lexical form)
- IRI values silently skipped (would be semantic mismatch)
- Invalid regex strings silently ignored (TBox config error, not data error — graceful degradation)
- Empty pattern treated as no constraint
- Independent of range/class checks — both can fire on same literal
- Compiled once outside value loop (efficient when shape applies to many subjects)

## Test plan

- [x] 10 new `sh:pattern` tests в `ShaclLiteValidator.test.ts` (T-PAT-01..10)
  - Positive/negative match, default/custom message, IRI skip, invalid regex graceful, empty pattern, pattern+range coexistence, severity, anchored matching
- [x] 2 new `ShapeLoader.test.ts` tests (frontmatter parse + undefined when omitted)
- [x] 158/158 pass в 3 affected test suites (87+10 ShaclLite + 48+2 ShapeLoader + 11 ShapeRegistry)
- [x] 570/570 pass full services tier — zero regressions
- [x] typecheck clean
- [ ] CI: 14 required checks (waiting)

## Verification post-release

Once merged + new version published, can declare pattern constraint in vault и validate:

```bash
cd /Users/kitelev/vault-2025 && npx @kitelev/exocortex-cli validate schema --shapes-mode
# Expected: any AssetSpace ABox с non-conforming _git URL emits sh:pattern violation
```

## RFC reference

[RFC 75b50f51](https://github.com/kitelev/vault-exodev/blob/main/inbox/75b50f51-512e-473c-a253-77a7ad96eaa5.md) §Follow-up RFCs (item «SHACL constraint»).