### PR TITLE
feat(cli): Phase 3.5 — CLI parity for createAsset via shared factory (#3164)

### DIFF
--- a/docs/rfc-94e520da/starter-kit-grounding-status.json
+++ b/docs/rfc-94e520da/starter-kit-grounding-status.json
@@ -3,8 +3,8 @@
     "rfc": "94e520da",
     "phase": 1,
     "task": "T1.5",
-    "auditedAt": "2026-05-17T06:43:06.521Z",
-    "starterKitPath": "../starter-kit-claude2-feat-q3b-migration",
+    "auditedAt": "2026-05-23T08:32:27.143Z",
+    "starterKitPath": "/Users/kitelev/Developer/exocortex-development/exocortex-starter-kit",
     "totalGroundings": 48,
     "byType": {
       "property_delete": 4,
@@ -17,8 +17,7 @@
       "composite": 2
     },
     "byCliStatus": {
-      "real": 44,
-      "stub": 3,
+      "real": 47,
       "unregistered": 1
     },
     "serviceIdCounts": {
@@ -82,7 +81,7 @@
       "path": "exocmd/creation/95aaab51-8cd5-42db-a207-42793864d133.md",
       "type": "service_call",
       "serviceId": "createAsset",
-      "cliStatus": "stub"
+      "cliStatus": "real"
     },
     {
       "uid": "a222094b-f499-4342-aec0-65c4ba99c657",
@@ -90,7 +89,7 @@
       "path": "exocmd/creation/a222094b-f499-4342-aec0-65c4ba99c657.md",
       "type": "service_call",
       "serviceId": "createAsset",
-      "cliStatus": "stub"
+      "cliStatus": "real"
     },
     {
       "uid": "abdbdf09-8712-4c11-8cbe-467f46091294",
@@ -106,7 +105,7 @@
       "path": "exocmd/creation/c84e2e08-8fb9-42e7-9112-11864fb13a09.md",
       "type": "service_call",
       "serviceId": "createAsset",
-      "cliStatus": "stub"
+      "cliStatus": "real"
     },
     {
       "uid": "e72a5fa1-a902-4508-b671-bde8a1461a02",

--- a/packages/cli/specs/fixtures/groundings/95aaab51-8cd5-42db-a207-42793864d133.expected.json
+++ b/packages/cli/specs/fixtures/groundings/95aaab51-8cd5-42db-a207-42793864d133.expected.json
@@ -2,12 +2,13 @@
   "uid": "95aaab51-8cd5-42db-a207-42793864d133",
   "label": "Create knowledge",
   "type": "service_call",
-  "cliStatus": "stub",
+  "cliStatus": "real",
   "serviceId": "createAsset",
   "sourcePath": "exocmd/creation/95aaab51-8cd5-42db-a207-42793864d133.md",
-  "userInput": null,
+  "userInput": {
+    "label": "BDD Knowledge"
+  },
   "expect": {
-    "outcome": "failure",
-    "errorPattern": "Service \\\"createAsset\\\" is not implemented"
+    "outcome": "success"
   }
 }

--- a/packages/cli/specs/fixtures/groundings/a222094b-f499-4342-aec0-65c4ba99c657.expected.json
+++ b/packages/cli/specs/fixtures/groundings/a222094b-f499-4342-aec0-65c4ba99c657.expected.json
@@ -2,12 +2,13 @@
   "uid": "a222094b-f499-4342-aec0-65c4ba99c657",
   "label": "Create task",
   "type": "service_call",
-  "cliStatus": "stub",
+  "cliStatus": "real",
   "serviceId": "createAsset",
   "sourcePath": "exocmd/creation/a222094b-f499-4342-aec0-65c4ba99c657.md",
-  "userInput": null,
+  "userInput": {
+    "label": "BDD Task"
+  },
   "expect": {
-    "outcome": "failure",
-    "errorPattern": "Service \\\"createAsset\\\" is not implemented"
+    "outcome": "success"
   }
 }

--- a/packages/cli/specs/fixtures/groundings/c84e2e08-8fb9-42e7-9112-11864fb13a09.expected.json
+++ b/packages/cli/specs/fixtures/groundings/c84e2e08-8fb9-42e7-9112-11864fb13a09.expected.json
@@ -2,12 +2,13 @@
   "uid": "c84e2e08-8fb9-42e7-9112-11864fb13a09",
   "label": "Create note",
   "type": "service_call",
-  "cliStatus": "stub",
+  "cliStatus": "real",
   "serviceId": "createAsset",
   "sourcePath": "exocmd/creation/c84e2e08-8fb9-42e7-9112-11864fb13a09.md",
-  "userInput": null,
+  "userInput": {
+    "label": "BDD Note"
+  },
   "expect": {
-    "outcome": "failure",
-    "errorPattern": "Service \\\"createAsset\\\" is not implemented"
+    "outcome": "success"
   }
 }

--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -1,6 +1,8 @@
 import {
   ServiceRegistry,
   FrontmatterService,
+  type ClassRefResolver,
+  type IFile,
   type IGroundingService,
   type IVaultAdapter,
   type IFileSystemAdapter,
@@ -13,6 +15,7 @@ import {
   TaskStatusService,
 } from "exocortex";
 import {
+  createCreateAssetService,
   createCreateRelatedTaskService,
   createCreateRelatedProjectService,
   createArchiveAssetService,
@@ -95,20 +98,27 @@ export function createCliPathResolver(
  * the shared `@kitelev/exocortex-services` package and run end-to-end against
  * a vault on disk via {@link CliServiceRegistryDeps.fsAdapter}.
  *
- * The remaining 7 services are genuinely unsupported in CLI runtime:
+ * The remaining 6 services are genuinely unsupported in CLI runtime:
  * - `openFile`, `getActiveFileIRI`, `getActiveFilePath` rely on Obsidian's
  *   workspace/active-file concept that has no CLI analogue.
  * - `sparqlSelect` would require porting plugin's SPARQLApi — separate issue.
  * - `trashFile` semantics (Obsidian trash) differ from `fs.unlink`; needs an
  *   adapter design before it can be safely shared.
- * - `createAsset`, `duplicateFile` carry parent-context inheritance that
- *   currently reads `app.metadataCache`; porting them awaits an Obsidian-free
- *   metadata abstraction.
+ * - `duplicateFile` carries parent-context inheritance that currently reads
+ *   `app.metadataCache`; porting awaits an Obsidian-free metadata abstraction.
  *
- * Issue #2518, #2864
+ * RFC v2 Phase 3.5 (Issue #3164, 2026-05-23): `createAsset` dropped from this
+ * list — now has a real CLI implementation through the shared
+ * `createCreateAssetService` factory (`@kitelev/exocortex-services`) that
+ * mirrors the plugin's `ServiceRegistryPopulator.createAsset` handler
+ * one-for-one (parent inheritance, area/parent detection, isDefinedBy
+ * precedence). Phase 4b will remove both this CLI registration and the
+ * plugin's parallel inlined handler once vault Groundings migrate from
+ * `service_call createAsset` to declarative `create_instance` type.
+ *
+ * Issue #2518, #2864, #3164
  */
 export const CLI_STUB_SERVICE_IDS = [
-  "createAsset",
   "openFile",
   "sparqlSelect",
   "getActiveFileIRI",
@@ -180,6 +190,7 @@ export interface CliServiceRegistryDeps {
  * plugin can adopt the same handlers in T1.3 without code duplication.
  */
 export {
+  createCreateAssetService,
   createCreateRelatedTaskService,
   createCreateRelatedProjectService,
   createArchiveAssetService,
@@ -192,6 +203,32 @@ export {
   createRemovePropertyService,
   createSetStatusService,
 };
+
+/**
+ * Build a `ClassRefResolver` (UUID → symbolic class label) backed by
+ * `IVaultAdapter.getFirstLinkpathDest` + `getFrontmatter` (both sync, so the
+ * resolver matches `WikiLinkHelpers.resolveSymbolic`'s sync contract).
+ *
+ * Mirrors the plugin's `createMetadataClassResolver`
+ * (`ServiceRegistryPopulator.ts`) which reads Obsidian's `metadataCache`.
+ * `FileSystemVaultAdapter` builds a UUID index lazily on first lookup, so
+ * subsequent calls within one CLI session are O(1).
+ *
+ * Used by `createAsset` (Phase 3.5) to detect Area parents when
+ * `exo__Instance_class` stores UID-canon refs (`[[<uuid>]]`). Symbolic refs
+ * (`[[ems__Area]]`) bypass the resolver via `WikiLinkHelpers.resolveSymbolic`.
+ */
+export function createCliClassResolver(
+  vaultAdapter: IVaultAdapter,
+): ClassRefResolver {
+  return (uuid: string): string | null => {
+    const target = vaultAdapter.getFirstLinkpathDest(uuid, "");
+    if (!target || !("basename" in target)) return null;
+    const meta = vaultAdapter.getFrontmatter(target as IFile);
+    const label = meta?.exo__Asset_label;
+    return typeof label === "string" && label.length > 0 ? label : null;
+  };
+}
 
 /**
  * Populate a ServiceRegistry with fail-loud stubs for all well-known services.
@@ -215,10 +252,15 @@ export function populateCliServiceRegistry(
     registry.register(id, notImplementedService(id));
   }
 
-  // T1.4: frontmatter-only handlers registered as fail-loud stubs when no
-  // fsAdapter is wired (e.g. `dyncommand validate`). With fsAdapter the real
-  // shared-package factories below replace these stubs.
-  for (const id of ["updateProperty", "removeProperty", "setStatus"] as const) {
+  // T1.4 + Phase 3.5: handlers requiring fsAdapter registered as fail-loud
+  // stubs when no fsAdapter is wired (e.g. `dyncommand validate`). With
+  // fsAdapter the real shared-package factories below replace these stubs.
+  for (const id of [
+    "updateProperty",
+    "removeProperty",
+    "setStatus",
+    "createAsset",
+  ] as const) {
     registry.register(id, notImplementedService(id));
   }
 
@@ -248,6 +290,22 @@ export function populateCliServiceRegistry(
           deps.fsAdapter,
           frontmatterService,
           pathResolver,
+        ),
+      );
+
+      // RFC v2 Phase 3.5 (Issue #3164): real `createAsset` handler replaces
+      // the legacy CliServiceNotImplementedError stub. Mirrors the plugin's
+      // inlined handler in `ServiceRegistryPopulator.createAsset`
+      // (parent-context inheritance, area-vs-parent detection via class
+      // resolver, isDefinedBy precedence chain). Requires both fsAdapter
+      // (for `createFile`) and vaultAdapter (for parent metadata + UID-canon
+      // class resolution); when fsAdapter is absent the stub remains.
+      registry.register(
+        "createAsset",
+        createCreateAssetService(
+          deps.vaultAdapter,
+          deps.fsAdapter,
+          createCliClassResolver(deps.vaultAdapter),
         ),
       );
     }

--- a/packages/cli/tests/unit/services/CliServiceRegistryPopulator.test.ts
+++ b/packages/cli/tests/unit/services/CliServiceRegistryPopulator.test.ts
@@ -16,7 +16,30 @@ jest.unstable_mockModule("exocortex", () => {
   // out → stubs path), so a no-op shape is sufficient for the import to
   // resolve under ESM mocking.
   class FrontmatterService {}
-  return { ServiceRegistry, FrontmatterService };
+  // Phase 3.5 (#3164): the shared `@kitelev/exocortex-services` factory used
+  // by the new createAsset registration imports `WikiLinkHelpers` and
+  // `DateFormatter` from the `exocortex` package at module-evaluation time.
+  // The deps-omitted code path tested here never invokes the factory body, so
+  // shape stubs are sufficient — the imports just need to resolve.
+  class WikiLinkHelpers {
+    static resolveSymbolic(value: string): string {
+      return value;
+    }
+    static normalize(value: string): string {
+      return value;
+    }
+  }
+  class DateFormatter {
+    static toISOTimestamp(date: Date): string {
+      return date.toISOString();
+    }
+  }
+  return {
+    ServiceRegistry,
+    FrontmatterService,
+    WikiLinkHelpers,
+    DateFormatter,
+  };
 });
 
 let populateCliServiceRegistry: any;
@@ -34,13 +57,12 @@ beforeEach(async () => {
 
 describe("CliServiceRegistryPopulator", () => {
   describe("CLI_STUB_SERVICE_IDS", () => {
-    it("should export exactly 7 service IDs (T1.4: updateProperty/removeProperty/setStatus moved to real impls)", () => {
-      expect(CLI_STUB_SERVICE_IDS).toHaveLength(7);
+    it("should export exactly 6 service IDs (T1.4 + Phase 3.5: updateProperty/removeProperty/setStatus + createAsset moved to real impls)", () => {
+      expect(CLI_STUB_SERVICE_IDS).toHaveLength(6);
     });
 
     it("should include all genuinely-unsupported well-known service IDs", () => {
       const expected = [
-        "createAsset",
         "openFile",
         "sparqlSelect",
         "getActiveFileIRI",
@@ -53,12 +75,13 @@ describe("CliServiceRegistryPopulator", () => {
   });
 
   describe("populateCliServiceRegistry", () => {
-    it("should register the 7 fail-loud stubs + the 3 frontmatter handlers (10 total) when called without deps", () => {
+    it("should register the 6 fail-loud stubs + the 4 fsAdapter-gated handlers (10 total) when called without deps", () => {
       const registry = new ServiceRegistry();
       populateCliServiceRegistry(registry);
-      // Without `deps.fsAdapter`, the 3 frontmatter handlers
-      // (updateProperty/removeProperty/setStatus) fall back to fail-loud stubs
-      // so `dyncommand validate` keeps recognising them as known service IDs.
+      // Without `deps.fsAdapter`, the 4 fsAdapter-gated handlers
+      // (updateProperty/removeProperty/setStatus/createAsset) fall back to
+      // fail-loud stubs so `dyncommand validate` keeps recognising them as
+      // known service IDs.
       expect(registry.getRegisteredIds()).toHaveLength(10);
     });
 

--- a/packages/cli/tests/unit/services/StarterKitGroundingAudit.test.ts
+++ b/packages/cli/tests/unit/services/StarterKitGroundingAudit.test.ts
@@ -91,9 +91,11 @@ describe("RFC 94e520da T1.5 starter-kit grounding audit fixture", () => {
       property_increment: 1,
       property_shift: 2,
     });
+    // Phase 3.5 (Issue #3164): `createAsset` ported from CLI stub → real
+    // via shared `createCreateAssetService` factory. The 3 starter-kit
+    // groundings previously classified as `stub` are now `real`.
     expect(fixture.summary.byCliStatus).toEqual({
-      real: 44,
-      stub: 3,
+      real: 47,
       unregistered: 1,
     });
   });
@@ -121,8 +123,11 @@ describe("RFC 94e520da T1.5 starter-kit grounding audit fixture", () => {
       "repairFolder",
       "fixMissingLabel",
       "updateProperty",
+      // Phase 3.5 (Issue #3164, 2026-05-23): createAsset moved from stub →
+      // real (shared `createCreateAssetService` factory).
+      "createAsset",
     ]);
-    const documentedStubIds = new Set(["createAsset"]);
+    const documentedStubIds = new Set<string>();
     const documentedUnregisteredIds = new Set([
       "rollbackStatus",
       // copyLabelToAliases removed in Issue #3132 — grounding migrated to

--- a/packages/cli/tests/unit/services/createAsset.test.ts
+++ b/packages/cli/tests/unit/services/createAsset.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import yaml from "js-yaml";
+import {
+  ArchiveAssetService,
+  EffortStatusWorkflow,
+  FixMissingLabelService,
+  FolderRepairService,
+  GenericAssetCreationService,
+  PropertyCleanupService,
+  RenameToUidService,
+  ServiceRegistry,
+  StatusTimestampService,
+  TaskStatusService,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../../src/adapters/FileSystemVaultAdapter.js";
+import { NodeFsAdapter } from "../../../src/adapters/NodeFsAdapter.js";
+import {
+  populateCliServiceRegistry,
+  CliServiceNotImplementedError,
+} from "../../../src/services/CliServiceRegistryPopulator.js";
+
+/**
+ * Phase 3.5 (Issue #3164) — registry-level integration tests for the new
+ * `createAsset` handler. Mirrors the registry tests for `createRelatedTask`
+ * /`createRelatedProject` so the three handlers share the same regression
+ * surface: invoke through the same `populateCliServiceRegistry` entry point,
+ * assert byte-level frontmatter on disk.
+ *
+ * Direct factory tests (parameter validation, branch coverage on parent
+ * inheritance + isDefinedBy precedence) live in
+ * `packages/services/tests/grounding-service-factories.test.ts` to keep the
+ * CLI suite focused on the wiring contract.
+ */
+
+type Frontmatter = Record<string, unknown>;
+
+function readFrontmatter(filePath: string): Frontmatter {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter in ${filePath}`);
+  return yaml.load(match[1]) as Frontmatter;
+}
+
+function writeAsset(
+  vaultRoot: string,
+  relPath: string,
+  frontmatter: Frontmatter,
+): string {
+  const fullPath = path.join(vaultRoot, relPath);
+  fs.ensureDirSync(path.dirname(fullPath));
+  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n`, "utf-8");
+  return fullPath;
+}
+
+function newCreatedFile(
+  vaultRoot: string,
+  folder: string,
+  excludeBasenames: Set<string>,
+): string {
+  const dir = path.join(vaultRoot, folder);
+  const entries = fs.readdirSync(dir).filter((e) => e.endsWith(".md"));
+  const created = entries.find(
+    (e) => !excludeBasenames.has(path.basename(e, ".md")),
+  );
+  if (!created) {
+    throw new Error(
+      `No new .md file found in ${dir}. Existing: ${entries.join(", ")}`,
+    );
+  }
+  return path.join(dir, created);
+}
+
+describe("createAsset (CLI registry integration, Phase 3.5)", () => {
+  let vaultRoot: string;
+  let vaultAdapter: FileSystemVaultAdapter;
+  let fsAdapter: NodeFsAdapter;
+  let genericAssetCreationService: GenericAssetCreationService;
+  let archiveAssetService: ArchiveAssetService;
+  let propertyCleanupService: PropertyCleanupService;
+  let taskStatusService: TaskStatusService;
+  let fixMissingLabelService: FixMissingLabelService;
+  let renameToUidService: RenameToUidService;
+  let folderRepairService: FolderRepairService;
+
+  beforeEach(() => {
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-createasset-"));
+    vaultAdapter = new FileSystemVaultAdapter(vaultRoot);
+    fsAdapter = new NodeFsAdapter(vaultRoot);
+    genericAssetCreationService = new GenericAssetCreationService(vaultAdapter);
+    archiveAssetService = new ArchiveAssetService(vaultAdapter);
+    propertyCleanupService = new PropertyCleanupService(vaultAdapter);
+    fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
+    renameToUidService = new RenameToUidService(vaultAdapter);
+    folderRepairService = new FolderRepairService(vaultAdapter);
+    taskStatusService = new TaskStatusService(
+      vaultAdapter,
+      new EffortStatusWorkflow(),
+      new StatusTimestampService(vaultAdapter),
+    );
+  });
+
+  afterEach(() => {
+    fs.removeSync(vaultRoot);
+  });
+
+  function fullDeps() {
+    return {
+      vaultAdapter,
+      fsAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+      taskStatusService,
+      propertyCleanupService,
+      fixMissingLabelService,
+      renameToUidService,
+      folderRepairService,
+    };
+  }
+
+  it("registry without fsAdapter keeps createAsset as a fail-loud stub", async () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, {
+      vaultAdapter,
+      genericAssetCreationService,
+      archiveAssetService,
+      taskStatusService,
+      propertyCleanupService,
+      fixMissingLabelService,
+      renameToUidService,
+      folderRepairService,
+    });
+
+    const registered = registry.get("createAsset");
+    expect(registered).toBeDefined();
+
+    await expect(
+      registered!.execute("any-iri", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Stub Task",
+      }),
+    ).rejects.toBeInstanceOf(CliServiceNotImplementedError);
+  });
+
+  it("registry with fsAdapter registers the real createAsset handler", async () => {
+    writeAsset(vaultRoot, "areas/Area1.md", {
+      exo__Asset_uid: "area-uid-1",
+      exo__Asset_label: "Area 1",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+    const before = new Set(["Area1"]);
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, fullDeps());
+
+    const registered = registry.get("createAsset");
+    expect(registered).toBeDefined();
+
+    await registered!.execute("areas/Area1", {
+      prototypeUID: "ems__TaskPrototype",
+      label: "Registered CreateAsset",
+    });
+
+    const createdPath = newCreatedFile(vaultRoot, "areas", before);
+    const fm = readFrontmatter(createdPath);
+    expect(fm.exo__Asset_label).toBe("Registered CreateAsset");
+    expect(fm.exo__Asset_prototype).toBe("[[ems__TaskPrototype]]");
+    expect(fm.exo__Instance_class).toEqual(["[[ems__Task]]"]);
+    expect(fm.ems__Effort_area).toBe("[[Area1]]");
+    expect(fm.ems__Effort_status).toBe("[[ems__EffortStatusBacklog]]");
+  });
+
+  it("registry with fsAdapter: createAsset is NOT a CliServiceNotImplementedError stub", async () => {
+    writeAsset(vaultRoot, "areas/Area2.md", {
+      exo__Asset_uid: "area-uid-2",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, fullDeps());
+    const registered = registry.get("createAsset");
+    expect(registered).toBeDefined();
+
+    try {
+      await registered!.execute("areas/Area2", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Guard Task",
+      });
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(CliServiceNotImplementedError);
+    }
+  });
+
+  it("createAsset inherits ems__Effort_parent (not _area) from non-Area parent", async () => {
+    writeAsset(vaultRoot, "projects/Project1.md", {
+      exo__Asset_uid: "proj-uid-1",
+      exo__Asset_label: "Project 1",
+      exo__Instance_class: ["[[ems__Project]]"],
+    });
+    const before = new Set(["Project1"]);
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, fullDeps());
+
+    await registry.get("createAsset")!.execute("projects/Project1", {
+      prototypeUID: "ems__TaskPrototype",
+      label: "Subtask from Project",
+    });
+
+    const createdPath = newCreatedFile(vaultRoot, "projects", before);
+    const fm = readFrontmatter(createdPath);
+    expect(fm.ems__Effort_parent).toBe("[[Project1]]");
+    expect(fm.ems__Effort_area).toBeUndefined();
+  });
+
+  it("createAsset inherits exo__Asset_isDefinedBy from parent when not explicitly overridden", async () => {
+    writeAsset(vaultRoot, "areas/Area3.md", {
+      exo__Asset_uid: "area-uid-3",
+      exo__Asset_label: "Area 3",
+      exo__Instance_class: ["[[ems__Area]]"],
+      exo__Asset_isDefinedBy: "[[OwnerA]]",
+    });
+    const before = new Set(["Area3"]);
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, fullDeps());
+
+    await registry.get("createAsset")!.execute("areas/Area3", {
+      prototypeUID: "ems__TaskPrototype",
+      label: "Inherits owner",
+    });
+
+    const createdPath = newCreatedFile(vaultRoot, "areas", before);
+    const fm = readFrontmatter(createdPath);
+    expect(fm.exo__Asset_isDefinedBy).toBe("[[OwnerA]]");
+  });
+
+  it("createAsset accepts explicit userInput.folder overriding parent-inferred folder", async () => {
+    writeAsset(vaultRoot, "areas/Area4.md", {
+      exo__Asset_uid: "area-uid-4",
+      exo__Instance_class: ["[[ems__Area]]"],
+    });
+
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, fullDeps());
+
+    await registry.get("createAsset")!.execute("areas/Area4", {
+      prototypeUID: "ems__TaskPrototype",
+      label: "Custom folder",
+      folder: "inbox",
+    });
+
+    expect(fs.existsSync(path.join(vaultRoot, "inbox"))).toBe(true);
+    const inboxFiles = fs
+      .readdirSync(path.join(vaultRoot, "inbox"))
+      .filter((e) => e.endsWith(".md"));
+    expect(inboxFiles).toHaveLength(1);
+  });
+
+  it("createAsset throws when prototypeUID is missing", async () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, fullDeps());
+    await expect(
+      registry.get("createAsset")!.execute("any", { label: "x", folder: "x" }),
+    ).rejects.toThrow(/createAsset requires userInput.prototypeUID/);
+  });
+
+  it("createAsset throws when label is missing", async () => {
+    const registry = new ServiceRegistry();
+    populateCliServiceRegistry(registry, fullDeps());
+    await expect(
+      registry
+        .get("createAsset")!
+        .execute("any", { prototypeUID: "ems__TaskPrototype", folder: "x" }),
+    ).rejects.toThrow(/createAsset requires userInput.label/);
+  });
+});

--- a/packages/cli/tests/unit/services/createAsset.test.ts
+++ b/packages/cli/tests/unit/services/createAsset.test.ts
@@ -170,7 +170,10 @@ describe("createAsset (CLI registry integration, Phase 3.5)", () => {
     expect(fm.exo__Asset_prototype).toBe("[[ems__TaskPrototype]]");
     expect(fm.exo__Instance_class).toEqual(["[[ems__Task]]"]);
     expect(fm.ems__Effort_area).toBe("[[Area1]]");
-    expect(fm.ems__Effort_status).toBe("[[ems__EffortStatusBacklog]]");
+    // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194) — Backlog UID.
+    expect(fm.ems__Effort_status).toBe(
+      "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]",
+    );
   });
 
   it("registry with fsAdapter: createAsset is NOT a CliServiceNotImplementedError stub", async () => {

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -307,7 +307,13 @@ export function createCreateAssetService(
             )}`,
           );
         }
-        lines.push('ems__Effort_status: "[[ems__EffortStatusBacklog]]"');
+        // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Mirrors plugin's
+        // `ServiceRegistryPopulator.createAsset` line 253-255; CLI must emit
+        // the same UID so backlinks resolve uniformly with the rest of the
+        // graph (avoid the 42-asset symbolic-form trace the prior RFC closed).
+        lines.push(
+          'ems__Effort_status: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"',
+        );
         if (!isDefinedByWritten && parentMetadata.exo__Asset_isDefinedBy) {
           lines.push(
             `exo__Asset_isDefinedBy: ${toQuotedWikilink(

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -1,4 +1,6 @@
+import { WikiLinkHelpers, DateFormatter } from "exocortex";
 import type {
+  ClassRefResolver,
   IGroundingService,
   IVaultAdapter,
   IFile,
@@ -142,6 +144,189 @@ export function createCreateRelatedProjectService(
         parentFile,
         parentMetadata,
       });
+    },
+  };
+}
+
+/**
+ * Format a wikilink value as the quoted YAML form (`"[[X]]"`) consistently with
+ * the plugin's hand-rolled `createAsset` frontmatter writer
+ * (`ServiceRegistryPopulator.toQuotedWikilink`). Idempotent — already-quoted
+ * inputs round-trip unchanged; bare/unwrapped values are re-wrapped.
+ */
+function toQuotedWikilink(value: string): string {
+  if (value.startsWith('"[[') && value.endsWith(']]"')) return value;
+  if (value.startsWith("[[") && value.endsWith("]]")) return `"${value}"`;
+  return `"[[${value}]]"`;
+}
+
+/**
+ * Default `ClassRefResolver` used when CLI callers don't supply one. The
+ * legacy plugin path resolved UID-canon `[[<uuid>]]` references through
+ * Obsidian's `metadataCache`; in CLI runtime there is no resolver, so this
+ * fallback returns `null` for every UUID. Symbolic refs (`[[ems__Area]]`)
+ * continue to round-trip through `WikiLinkHelpers.resolveSymbolic` without
+ * resolver assistance.
+ *
+ * Production CLI usage that needs UID-canon resolution should inject a real
+ * resolver (e.g. one that scans the vault for `<uuid>.md` and reads
+ * `exo__Asset_label`). Phase 3.5 keeps parity with plugin's `createAsset` on
+ * vaults that still use symbolic refs for `exo__Instance_class`; the UID-canon
+ * variant is a follow-up tracked in #3164's review checklist.
+ */
+const NULL_CLASS_RESOLVER: ClassRefResolver = () => null;
+
+/**
+ * Shared factory for the `createAsset` `service_call` grounding — ports the
+ * inlined plugin handler (`ServiceRegistryPopulator.ts:126-275`) onto the
+ * storage-agnostic `IVaultAdapter` + `IFileSystemWriter` contract so the CLI
+ * registry can reuse the same logic via `populateCliServiceRegistry`.
+ *
+ * Behaviour mirrors the plugin handler one-for-one:
+ *
+ * 1. Accepts `prototypeUID` (or legacy `prototype`) + `label`; folder defaults
+ *    to the parent file's folder when omitted.
+ * 2. Reads parent metadata via `vaultAdapter.getFrontmatter` to inherit
+ *    `ems__Effort_area`/`ems__Effort_parent` (auto-detected from parent class),
+ *    `ems__Effort_status: "[[ems__EffortStatusBacklog]]"`, and
+ *    `exo__Asset_isDefinedBy` when not explicitly overridden by the caller.
+ * 3. Writes the new asset as `<folder>/<uid>.md` via `fsAdapter.createFile`.
+ *
+ * Precedence chain for `exo__Asset_isDefinedBy` (highest first), preserved
+ * from the plugin:
+ * - `userInput.isDefinedBy` (explicit grounding override).
+ * - Parent's `exo__Asset_isDefinedBy` (inherited).
+ * - `userInput.ownerIdentity` (vault-default owner fallback, see RFC `1429fcd0`).
+ *
+ * Phase 3.5 (RFC v2, Issue #3164) — CLI parity port. Phase 4b will remove
+ * both this factory and the plugin's parallel handler once vault Groundings
+ * migrate from `service_call createAsset` to declarative `create_instance`.
+ */
+export function createCreateAssetService(
+  vaultAdapter: IVaultAdapter,
+  fsAdapter: IFileSystemWriter,
+  classResolver: ClassRefResolver = NULL_CLASS_RESOLVER,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
+): IGroundingService {
+  return {
+    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
+      const prototypeUID =
+        (userInput?.prototypeUID as string | undefined) ??
+        (userInput?.prototype as string | undefined);
+      const label = userInput?.label as string | undefined;
+      let folder = userInput?.folder as string | undefined;
+      const ownerIdentity = userInput?.ownerIdentity as string | undefined;
+      const explicitIsDefinedBy = userInput?.isDefinedBy as string | undefined;
+
+      if (!prototypeUID) {
+        throw new Error("createAsset requires userInput.prototypeUID");
+      }
+      if (!label) {
+        throw new Error("createAsset requires userInput.label");
+      }
+
+      let parentPath: string | undefined;
+      let parentMetadata: Record<string, unknown> | undefined;
+      if (targetIRI) {
+        try {
+          const parentFile = resolver.resolveFile(targetIRI);
+          parentPath = parentFile.path;
+          parentMetadata =
+            (vaultAdapter.getFrontmatter(parentFile) as
+              | Record<string, unknown>
+              | null) ?? undefined;
+        } catch {
+          // Mirrors plugin: IRI resolution failure is non-fatal — folder
+          // resolution falls back to `userInput.folder` and parent inheritance
+          // is skipped entirely.
+        }
+      }
+
+      if (!folder && parentPath) {
+        const lastSlash = parentPath.lastIndexOf("/");
+        folder = lastSlash >= 0 ? parentPath.substring(0, lastSlash) : "";
+      }
+      if (folder === undefined) {
+        throw new Error("createAsset requires userInput.folder");
+      }
+
+      const expectedClass = prototypeUID.endsWith("Prototype")
+        ? prototypeUID.slice(0, -"Prototype".length)
+        : prototypeUID;
+
+      const uid = crypto.randomUUID();
+      const createdAt = DateFormatter.toISOTimestamp(new Date());
+      const fileName = `${uid}.md`;
+      const filePath = folder ? `${folder}/${fileName}` : fileName;
+
+      const lines: string[] = [
+        "---",
+        `exo__Asset_uid: ${uid}`,
+        `exo__Asset_createdAt: ${createdAt}`,
+        `exo__Asset_label: ${label}`,
+        `exo__Asset_prototype: "[[${prototypeUID}]]"`,
+        "exo__Instance_class:",
+        `  - "[[${expectedClass}]]"`,
+      ];
+
+      let isDefinedByWritten = false;
+      if (explicitIsDefinedBy) {
+        lines.push(
+          `exo__Asset_isDefinedBy: ${toQuotedWikilink(explicitIsDefinedBy)}`,
+        );
+        isDefinedByWritten = true;
+      }
+
+      if (parentMetadata) {
+        const parentClass = parentMetadata.exo__Instance_class;
+        const parentClasses = Array.isArray(parentClass)
+          ? parentClass
+          : parentClass != null
+            ? [parentClass]
+            : [];
+        const isAreaParent = parentClasses.some((cls) =>
+          WikiLinkHelpers.resolveSymbolic(String(cls), classResolver).includes(
+            "Area",
+          ),
+        );
+        const parentBasename = parentPath
+          ? parentPath
+              .substring(parentPath.lastIndexOf("/") + 1)
+              .replace(/\.md$/, "")
+          : undefined;
+        if (parentBasename) {
+          const parentProperty = isAreaParent
+            ? "ems__Effort_area"
+            : "ems__Effort_parent";
+          lines.push(`${parentProperty}: "[[${parentBasename}]]"`);
+        }
+        if (!isAreaParent && parentMetadata.ems__Effort_area) {
+          lines.push(
+            `ems__Effort_area: ${toQuotedWikilink(
+              String(parentMetadata.ems__Effort_area),
+            )}`,
+          );
+        }
+        lines.push('ems__Effort_status: "[[ems__EffortStatusBacklog]]"');
+        if (!isDefinedByWritten && parentMetadata.exo__Asset_isDefinedBy) {
+          lines.push(
+            `exo__Asset_isDefinedBy: ${toQuotedWikilink(
+              String(parentMetadata.exo__Asset_isDefinedBy),
+            )}`,
+          );
+          isDefinedByWritten = true;
+        }
+      }
+
+      if (!isDefinedByWritten && ownerIdentity) {
+        lines.push(
+          `exo__Asset_isDefinedBy: ${toQuotedWikilink(ownerIdentity)}`,
+        );
+      }
+
+      lines.push("---", "");
+      const frontmatter = lines.join("\n");
+      await fsAdapter.createFile(filePath, frontmatter);
     },
   };
 }

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -22,6 +22,7 @@
  */
 
 export {
+  createCreateAssetService,
   createCreateRelatedTaskService,
   createCreateRelatedProjectService,
   createArchiveAssetService,

--- a/packages/services/tests/grounding-service-factories.test.ts
+++ b/packages/services/tests/grounding-service-factories.test.ts
@@ -504,7 +504,10 @@ describe("@kitelev/exocortex-services — factory contract", () => {
       const content = fs.writes[0].content;
       expect(content).toMatch(/ems__Effort_area: "\[\[Area1\]\]"/);
       expect(content).not.toMatch(/ems__Effort_parent:/);
-      expect(content).toMatch(/ems__Effort_status: "\[\[ems__EffortStatusBacklog\]\]"/);
+      // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194) — Backlog UID.
+      expect(content).toMatch(
+        /ems__Effort_status: "\[\[753a44d5-846c-4b82-9196-4fd9a4d48777\]\]"/,
+      );
     });
 
     it("inherits ems__Effort_parent when parent is not ems__Area", async () => {

--- a/packages/services/tests/grounding-service-factories.test.ts
+++ b/packages/services/tests/grounding-service-factories.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "@jest/globals";
 import { FrontmatterService } from "../../exocortex/src/utilities/FrontmatterService";
 import {
+  createCreateAssetService,
   createCreateRelatedTaskService,
   createCreateRelatedProjectService,
   createArchiveAssetService,
@@ -344,6 +345,381 @@ describe("@kitelev/exocortex-services — factory contract", () => {
       await expect(service.execute("iri", {})).rejects.toThrow(
         /requires userInput.statusUID/,
       );
+    });
+  });
+
+  describe("createCreateAssetService (Phase 3.5, #3164)", () => {
+    /**
+     * Parity tests for the shared `createAsset` factory. The plugin's inlined
+     * handler (`ServiceRegistryPopulator.ts:126-275`) writes frontmatter as an
+     * ordered string array; this factory mirrors that format one-for-one so
+     * CLI invocations of `service_call createAsset` produce byte-identical
+     * frontmatter to plugin invocations of the same grounding.
+     *
+     * Assertions hit each branch that previously diverged between CLI (no-op
+     * stub) and plugin (inlined logic): label/prototype validation, folder
+     * inference from parent path, prototype-suffix stripping, area-vs-parent
+     * detection via classResolver, `exo__Asset_isDefinedBy` precedence chain
+     * (explicit > inherited > ownerIdentity).
+     */
+
+    interface RecordedWrite {
+      path: string;
+      content: string;
+    }
+
+    function makeFsWriter(): {
+      writes: RecordedWrite[];
+      adapter: never;
+    } {
+      const writes: RecordedWrite[] = [];
+      const adapter = {
+        async createFile(path: string, content: string): Promise<string> {
+          writes.push({ path, content });
+          return path;
+        },
+        async updateFile(): Promise<void> {},
+        async writeFile(): Promise<void> {},
+        async deleteFile(): Promise<void> {},
+        async renameFile(): Promise<void> {},
+      } as never;
+      return { writes, adapter };
+    }
+
+    interface ParentFixture {
+      path: string;
+      basename: string;
+      frontmatter: Record<string, unknown>;
+    }
+
+    function makeVaultAdapter(
+      parent: ParentFixture | null,
+    ): { calls: { iri?: string }; adapter: never } {
+      const calls: { iri?: string } = {};
+      const adapter = {
+        getAbstractFileByPath: (path: string) => {
+          calls.iri = path;
+          if (!parent) return null;
+          // Mimic `IFile` shape — basename/path/parent fields are read by the
+          // plugin-parity logic below.
+          return {
+            path: parent.path,
+            basename: parent.basename,
+            name: `${parent.basename}.md`,
+            parent: { path: parent.path.includes("/") ? parent.path.substring(0, parent.path.lastIndexOf("/")) : "" },
+          } as never;
+        },
+        getFrontmatter: () => (parent ? parent.frontmatter : null),
+      } as never;
+      return { calls, adapter };
+    }
+
+    function extractFrontmatter(content: string): Record<string, string> {
+      // Naive parse — only used inside tests against output we control.
+      const out: Record<string, string> = {};
+      const fm = content.match(/^---\n([\s\S]*?)\n---/);
+      if (!fm) return out;
+      for (const line of fm[1].split("\n")) {
+        const idx = line.indexOf(":");
+        if (idx < 0) continue;
+        const key = line.substring(0, idx).trim();
+        const val = line.substring(idx + 1).trim();
+        if (key && val) out[key] = val;
+      }
+      return out;
+    }
+
+    it("rejects when prototypeUID is missing", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter(null);
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await expect(
+        service.execute("any-iri", { label: "x" }),
+      ).rejects.toThrow(/createAsset requires userInput.prototypeUID/);
+    });
+
+    it("rejects when label is missing", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter(null);
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await expect(
+        service.execute("any-iri", { prototypeUID: "ems__TaskPrototype" }),
+      ).rejects.toThrow(/createAsset requires userInput.label/);
+    });
+
+    it("strips `Prototype` suffix to derive exo__Instance_class", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter(null);
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Strip Test",
+        folder: "Inbox",
+      });
+      expect(fs.writes).toHaveLength(1);
+      expect(fs.writes[0].content).toMatch(/exo__Instance_class:\n {2}- "\[\[ems__Task\]\]"/);
+      expect(fs.writes[0].content).toMatch(/exo__Asset_prototype: "\[\[ems__TaskPrototype\]\]"/);
+    });
+
+    it("keeps prototypeUID verbatim when no Prototype suffix", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter(null);
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("", {
+        prototypeUID: "ems__Task",
+        label: "Verbatim",
+        folder: "Inbox",
+      });
+      expect(fs.writes[0].content).toMatch(/exo__Asset_prototype: "\[\[ems__Task\]\]"/);
+      expect(fs.writes[0].content).toMatch(/- "\[\[ems__Task\]\]"/);
+    });
+
+    it("accepts legacy `prototype` key as alias for prototypeUID", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter(null);
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("", {
+        prototype: "ems__TaskPrototype",
+        label: "Legacy alias",
+        folder: "Inbox",
+      });
+      expect(fs.writes[0].content).toMatch(/exo__Asset_prototype: "\[\[ems__TaskPrototype\]\]"/);
+    });
+
+    it("inherits ems__Effort_area from ems__Area parent (symbolic refs)", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter({
+        path: "Areas/Area1.md",
+        basename: "Area1",
+        frontmatter: {
+          exo__Instance_class: ["[[ems__Area]]"],
+        },
+      });
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("Areas/Area1", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Task from Area",
+      });
+      expect(fs.writes).toHaveLength(1);
+      const content = fs.writes[0].content;
+      expect(content).toMatch(/ems__Effort_area: "\[\[Area1\]\]"/);
+      expect(content).not.toMatch(/ems__Effort_parent:/);
+      expect(content).toMatch(/ems__Effort_status: "\[\[ems__EffortStatusBacklog\]\]"/);
+    });
+
+    it("inherits ems__Effort_parent when parent is not ems__Area", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter({
+        path: "Projects/Project1.md",
+        basename: "Project1",
+        frontmatter: {
+          exo__Instance_class: ["[[ems__Project]]"],
+        },
+      });
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("Projects/Project1", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Subtask",
+      });
+      const content = fs.writes[0].content;
+      expect(content).toMatch(/ems__Effort_parent: "\[\[Project1\]\]"/);
+      expect(content).not.toMatch(/ems__Effort_area: "\[\[Project1\]\]"/);
+    });
+
+    it("forwards ems__Effort_area from non-Area parent (e.g. Project under Area)", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter({
+        path: "Projects/Project1.md",
+        basename: "Project1",
+        frontmatter: {
+          exo__Instance_class: ["[[ems__Project]]"],
+          ems__Effort_area: "[[Area1]]",
+        },
+      });
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("Projects/Project1", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Sub",
+      });
+      const content = fs.writes[0].content;
+      expect(content).toMatch(/ems__Effort_parent: "\[\[Project1\]\]"/);
+      expect(content).toMatch(/ems__Effort_area: "\[\[Area1\]\]"/);
+    });
+
+    it("defaults folder from parent path when userInput.folder absent", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter({
+        path: "Areas/Sub/Area1.md",
+        basename: "Area1",
+        frontmatter: { exo__Instance_class: ["[[ems__Area]]"] },
+      });
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("Areas/Sub/Area1", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Inherits folder",
+      });
+      expect(fs.writes[0].path.startsWith("Areas/Sub/")).toBe(true);
+      expect(fs.writes[0].path.endsWith(".md")).toBe(true);
+    });
+
+    it("respects explicit userInput.folder over inferred folder", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter({
+        path: "Areas/Area1.md",
+        basename: "Area1",
+        frontmatter: { exo__Instance_class: ["[[ems__Area]]"] },
+      });
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("Areas/Area1", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Override",
+        folder: "CustomFolder",
+      });
+      expect(fs.writes[0].path.startsWith("CustomFolder/")).toBe(true);
+    });
+
+    it("isDefinedBy precedence: explicit > inherited > ownerIdentity", async () => {
+      // Case 1: explicit wins (parent inherited + ownerIdentity present)
+      {
+        const fs = makeFsWriter();
+        const vault = makeVaultAdapter({
+          path: "Areas/A.md",
+          basename: "A",
+          frontmatter: {
+            exo__Instance_class: ["[[ems__Area]]"],
+            exo__Asset_isDefinedBy: "[[InheritedOwner]]",
+          },
+        });
+        const service = createCreateAssetService(vault.adapter, fs.adapter);
+        await service.execute("Areas/A", {
+          prototypeUID: "ems__TaskPrototype",
+          label: "Case1",
+          isDefinedBy: "[[ExplicitOwner]]",
+          ownerIdentity: "[[FallbackOwner]]",
+        });
+        const fm = extractFrontmatter(fs.writes[0].content);
+        expect(fm.exo__Asset_isDefinedBy).toBe('"[[ExplicitOwner]]"');
+      }
+
+      // Case 2: parent-inherited wins over ownerIdentity (no explicit)
+      {
+        const fs = makeFsWriter();
+        const vault = makeVaultAdapter({
+          path: "Areas/A.md",
+          basename: "A",
+          frontmatter: {
+            exo__Instance_class: ["[[ems__Area]]"],
+            exo__Asset_isDefinedBy: "[[InheritedOwner]]",
+          },
+        });
+        const service = createCreateAssetService(vault.adapter, fs.adapter);
+        await service.execute("Areas/A", {
+          prototypeUID: "ems__TaskPrototype",
+          label: "Case2",
+          ownerIdentity: "[[FallbackOwner]]",
+        });
+        const fm = extractFrontmatter(fs.writes[0].content);
+        expect(fm.exo__Asset_isDefinedBy).toBe('"[[InheritedOwner]]"');
+      }
+
+      // Case 3: ownerIdentity wins when no explicit and no parent-inherited
+      {
+        const fs = makeFsWriter();
+        const vault = makeVaultAdapter(null);
+        const service = createCreateAssetService(vault.adapter, fs.adapter);
+        await service.execute("", {
+          prototypeUID: "ems__TaskPrototype",
+          label: "Case3",
+          folder: "Inbox",
+          ownerIdentity: "[[FallbackOwner]]",
+        });
+        const fm = extractFrontmatter(fs.writes[0].content);
+        expect(fm.exo__Asset_isDefinedBy).toBe('"[[FallbackOwner]]"');
+      }
+    });
+
+    it("writes exo__Asset_uid, createdAt, label, prototype, instance_class always", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter(null);
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Required Fields",
+        folder: "Inbox",
+      });
+      const content = fs.writes[0].content;
+      expect(content).toMatch(
+        /^---\nexo__Asset_uid: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\n/,
+      );
+      expect(content).toMatch(/exo__Asset_createdAt: \d{4}-\d{2}-\d{2}T/);
+      expect(content).toMatch(/exo__Asset_label: Required Fields/);
+    });
+
+    it("filename uses generated UUID with .md suffix", async () => {
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter(null);
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Filename Test",
+        folder: "Inbox",
+      });
+      expect(fs.writes[0].path).toMatch(
+        /^Inbox\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.md$/,
+      );
+    });
+
+    it("Area detection works through UID-canon refs via classResolver", async () => {
+      // Vault state post UID-canon: `exo__Instance_class: ["[[<uuid>]]"]`. The
+      // resolver maps that UUID to symbolic label `ems__Area`, allowing the
+      // factory to detect the Area parent even though the literal frontmatter
+      // value is a UUID. Mirrors plugin's `createMetadataClassResolver`
+      // (Obsidian metadataCache).
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter({
+        path: "Areas/Area1.md",
+        basename: "Area1",
+        frontmatter: {
+          exo__Instance_class: ["[[82c74542-1b14-4217-b852-d84730484b25]]"],
+        },
+      });
+      const resolver = (uuid: string) =>
+        uuid === "82c74542-1b14-4217-b852-d84730484b25"
+          ? "ems__Area"
+          : null;
+      const service = createCreateAssetService(
+        vault.adapter,
+        fs.adapter,
+        resolver,
+      );
+      await service.execute("Areas/Area1", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "UID-canon Task",
+      });
+      const content = fs.writes[0].content;
+      expect(content).toMatch(/ems__Effort_area: "\[\[Area1\]\]"/);
+    });
+
+    it("falls back to ems__Effort_parent when classResolver returns null", async () => {
+      // Same shape as the UID-canon test above, but the resolver returns null
+      // (resource not in cache). The factory should NOT detect Area, falling
+      // back to the generic parent-relation property.
+      const fs = makeFsWriter();
+      const vault = makeVaultAdapter({
+        path: "Anywhere/Foo.md",
+        basename: "Foo",
+        frontmatter: {
+          exo__Instance_class: ["[[unknown-uuid-1234-5678-90ab-cdef12345678]]"],
+        },
+      });
+      const service = createCreateAssetService(vault.adapter, fs.adapter);
+      await service.execute("Anywhere/Foo", {
+        prototypeUID: "ems__TaskPrototype",
+        label: "Unknown parent class",
+      });
+      const content = fs.writes[0].content;
+      expect(content).toMatch(/ems__Effort_parent: "\[\[Foo\]\]"/);
+      expect(content).not.toMatch(/ems__Effort_area: "\[\[Foo\]\]"/);
     });
   });
 });

--- a/packages/services/tsconfig.test.json
+++ b/packages/services/tsconfig.test.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "baseUrl": ".",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "paths": {
       "exocortex": ["../exocortex/src"]
     }

--- a/scripts/audit-starter-kit-groundings.mjs
+++ b/scripts/audit-starter-kit-groundings.mjs
@@ -23,10 +23,15 @@ const KNOWN_REAL_SERVICE_IDS = new Set([
   "updateProperty",
   "removeProperty",
   "setStatus",
+  // Phase 3.5 (Issue #3164, 2026-05-23): createAsset ported from CLI stub to
+  // real handler via shared `createCreateAssetService` factory
+  // (@kitelev/exocortex-services). Mirrors the plugin's inlined handler
+  // one-for-one; Phase 4b will remove both implementations once vault
+  // Groundings migrate from service_call to create_instance type.
+  "createAsset",
 ]);
 
 const KNOWN_STUB_SERVICE_IDS = new Set([
-  "createAsset",
   "openFile",
   "sparqlSelect",
   "getActiveFileIRI",


### PR DESCRIPTION
Closes #3164. RFC v2 Phase 3.5 (asset `2f3f640b-c5e0-4873-8c56-c390b8402cfa`).

## Summary

- Port CLI `createAsset` handler from a `CliServiceNotImplementedError` no-op stub to a real implementation backed by a new `createCreateAssetService` factory in `@kitelev/exocortex-services`. Mirrors plugin's inlined handler (`ServiceRegistryPopulator.ts:126-275`) one-for-one.
- All 3 starter-kit `createAsset` invocations now `cliStatus: "real"` (audit fixture: was `real:44, stub:3`, now `real:47, unregistered:1`).
- Unblocks Phase 4a (#3165) vault Grounding migration — CLI parity now matches plugin so `create_instance` migration can be smoke-tested through CLI fixtures.

## Scope correction vs original prompt

Re-reading code surfaced that the prompt's premise (port CLI through `CommandResolver.resolvePropertyDefaults` + `GroundingExecutor.executeCreateInstance`) was incorrect:

1. `CommandResolver.resolvePropertyDefaults` does not exist; only legacy JSON-literal `propertyDefaults` parser is shipped post-Phase-3b.
2. `executeCreateInstance` is private and dispatches only for `GroundingType.CREATE_INSTANCE`, not for `service_call createAsset`.
3. Plugin's `createAsset` registry handler is ~150 LOC of inlined logic, not a thin wrapper over the new pipeline.
4. `createRelatedTask`/`createRelatedProject` shared factories already mirror plugin handlers (RFC 94e520da T1.2, PR #3025).

The real Phase 3.5 gap was only `createAsset`. Phase 4b will remove both this factory and the plugin's parallel inline handler once vault Groundings migrate from `service_call` to declarative `create_instance`.

## On the parity-regression-test AC wording

#3164 §AC says *"Parity regression test passes (CLI frontmatter == plugin frontmatter for `a6ef8fda-…`)"*. We do not have a literal byte-diff test that runs plugin handler against CLI handler with the same input. Instead, parity is achieved **by construction**: the shared factory now contains the canonical implementation; CLI registers it directly. The plugin still has its parallel inlined handler (~150 LOC) because Phase 4b is the dedicated PR for that refactor — it will delete both implementations together when vault Groundings migrate to declarative `create_instance`. Adding a snapshot test against the plugin's pre-deletion output would introduce a fixture that is itself slated for removal in 1-2 releases; the unit + integration tests on the shared factory (15 + 8 = 23 new assertions) lock in the canonical behaviour CLI ships today.

## Audit findings (per #3164 task list)

- **20 vault Groundings** in `assetspaces/exocmd/` reference legacy `createAsset`/`createRelatedTask`/`createRelatedProject` serviceIds — Phase 4a migration scope.
- **0 external callers**: n8n workflows and Telegram bot scripts do NOT invoke CLI handlers directly; both go through assistant chat + SPARQL queries. All references inside `packages/cli/` (handlers + tests) or vault Groundings.

## Test plan

- [x] `packages/services/tests/grounding-service-factories.test.ts` — 15 new unit tests on `createCreateAssetService` (34/34 total green)
- [x] `packages/cli/tests/unit/services/createAsset.test.ts` — 8 new registry-integration tests (8/8 green)
- [x] `packages/cli/tests/unit/services/CliServiceRegistryPopulator.test.ts` — updated for reduced stub set (8/8 green)
- [x] `packages/cli/tests/unit/services/StarterKitGroundingAudit.test.ts` — fixture + expectations updated (5/5 green)
- [x] `packages/cli/specs/fixtures/groundings/{95aaab51,a222094b,c84e2e08}.expected.json` — updated `cliStatus` stub→real, `outcome` failure→success, supplied minimal `userInput` (commit `2d583e73`). Local `bdd:test:cli` 51/51 green.
- [x] Pre-commit archgate, lint, BDD coverage 100% green
- [ ] 14 required CI checks green (in-progress after fixture commit)

## Files

- `packages/services/src/grounding-service-factories.ts` — new factory + helpers (`toQuotedWikilink`, `NULL_CLASS_RESOLVER`)
- `packages/services/src/index.ts` — export factory
- `packages/services/tsconfig.test.json` — enable `experimentalDecorators` (value imports of `WikiLinkHelpers`/`DateFormatter` from moduleNameMapper-resolved source pull in `TaskStatusService.ts` decorators at compile time)
- `packages/cli/src/services/CliServiceRegistryPopulator.ts` — register real factory when `deps.fsAdapter` present, sync UID-canon class resolver via `IVaultAdapter.getFirstLinkpathDest`; `createAsset` moved from `CLI_STUB_SERVICE_IDS` to fsAdapter-gated stub loop (no-deps behaviour unchanged)
- `scripts/audit-starter-kit-groundings.mjs` — promote `createAsset` from `KNOWN_STUB_SERVICE_IDS` to `KNOWN_REAL_SERVICE_IDS`
- `docs/rfc-94e520da/starter-kit-grounding-status.json` — regenerated
- `packages/cli/specs/fixtures/groundings/*.expected.json` — 3 BDD fixtures updated (commit `2d583e73`)