### PR TITLE
feat(services): IClock + IUidGenerator DI interfaces (Phase 0 Task 0.1)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -340,6 +340,16 @@ export {
 } from "./interfaces/ITripleStore";
 
 // DI Interfaces exports
+export {
+  liveClock,
+  frozenClock,
+  type IClock,
+} from "./services/IClock";
+export {
+  liveUidGenerator,
+  seededUidGenerator,
+  type IUidGenerator,
+} from "./services/IUidGenerator";
 export type { ILogger } from "./interfaces/ILogger";
 export type { IQueryBodyResolver } from "./interfaces/IQueryBodyResolver";
 export type { IEventBus } from "./interfaces/IEventBus";

--- a/packages/exocortex/src/services/IClock.ts
+++ b/packages/exocortex/src/services/IClock.ts
@@ -1,0 +1,16 @@
+export interface IClock {
+  now(): Date;
+}
+
+export function liveClock(): IClock {
+  return {
+    now: () => new Date(),
+  };
+}
+
+export function frozenClock(iso: string): IClock {
+  const fixed = new Date(iso);
+  return {
+    now: () => new Date(fixed.getTime()),
+  };
+}

--- a/packages/exocortex/src/services/IUidGenerator.ts
+++ b/packages/exocortex/src/services/IUidGenerator.ts
@@ -1,0 +1,25 @@
+import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
+
+export interface IUidGenerator {
+  next(): string;
+}
+
+export function liveUidGenerator(): IUidGenerator {
+  return {
+    next: () => uuidv4(),
+  };
+}
+
+const SEED_NAMESPACE = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+export function seededUidGenerator(seed: string): IUidGenerator {
+  let counter = 0;
+  const seedNamespace = uuidv5(seed, SEED_NAMESPACE);
+  return {
+    next: () => {
+      const name = `${seed}#${counter}`;
+      counter += 1;
+      return uuidv5(name, seedNamespace);
+    },
+  };
+}

--- a/packages/exocortex/tests/services/IClock.test.ts
+++ b/packages/exocortex/tests/services/IClock.test.ts
@@ -1,0 +1,43 @@
+import { liveClock, frozenClock } from "../../src/services/IClock";
+
+describe("IClock", () => {
+  describe("liveClock", () => {
+    it("returns a Date instance", () => {
+      const c = liveClock();
+      expect(c.now()).toBeInstanceOf(Date);
+    });
+
+    it("returns timestamps close to system time", () => {
+      const c = liveClock();
+      const before = Date.now();
+      const t = c.now().getTime();
+      const after = Date.now();
+      expect(t).toBeGreaterThanOrEqual(before);
+      expect(t).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("frozenClock", () => {
+    it("returns stable timestamp across calls", () => {
+      const iso = "2026-05-23T09:00:00Z";
+      const c = frozenClock(iso);
+      const t1 = c.now().getTime();
+      const t2 = c.now().getTime();
+      expect(t1).toBe(t2);
+      expect(t1).toBe(new Date(iso).getTime());
+    });
+
+    it("returns Date instances that are independent (mutation safety)", () => {
+      const c = frozenClock("2026-01-01T00:00:00Z");
+      const d = c.now();
+      d.setFullYear(2030);
+      expect(c.now().getFullYear()).toBe(2026);
+    });
+
+    it("two frozenClock instances with different ISO values are independent", () => {
+      const a = frozenClock("2026-01-01T00:00:00Z");
+      const b = frozenClock("2030-06-15T12:34:56Z");
+      expect(a.now().getTime()).not.toBe(b.now().getTime());
+    });
+  });
+});

--- a/packages/exocortex/tests/services/IUidGenerator.test.ts
+++ b/packages/exocortex/tests/services/IUidGenerator.test.ts
@@ -1,0 +1,45 @@
+import { liveUidGenerator, seededUidGenerator } from "../../src/services/IUidGenerator";
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe("IUidGenerator", () => {
+  describe("liveUidGenerator", () => {
+    it("returns valid UUIDs", () => {
+      const g = liveUidGenerator();
+      expect(g.next()).toMatch(UUID_REGEX);
+    });
+
+    it("returns unique UUIDs across calls", () => {
+      const g = liveUidGenerator();
+      const a = g.next();
+      const b = g.next();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("seededUidGenerator", () => {
+    it("with same seed yields identical sequence", () => {
+      const seed = "test-seed-001";
+      const a = seededUidGenerator(seed);
+      const b = seededUidGenerator(seed);
+      const aSeq = [a.next(), a.next(), a.next()];
+      const bSeq = [b.next(), b.next(), b.next()];
+      expect(aSeq).toEqual(bSeq);
+      aSeq.forEach((u) => expect(u).toMatch(UUID_REGEX));
+    });
+
+    it("with different seeds yields different sequences", () => {
+      const a = seededUidGenerator("seed-A");
+      const b = seededUidGenerator("seed-B");
+      expect(a.next()).not.toBe(b.next());
+    });
+
+    it("monotonic counter produces distinct UUIDs within one generator", () => {
+      const g = seededUidGenerator("monotonic-test");
+      const ids = [g.next(), g.next(), g.next(), g.next()];
+      const unique = new Set(ids);
+      expect(unique.size).toBe(ids.length);
+      ids.forEach((u) => expect(u).toMatch(UUID_REGEX));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `IClock` interface + `liveClock()` / `frozenClock(iso)` factories
- Add `IUidGenerator` interface + `liveUidGenerator()` (uuid v4) / `seededUidGenerator(seed)` (deterministic uuid v5)
- Backwards-compat: interface-only PR, no callsite changes

## Test plan
- [x] `IClock` unit tests (live + frozen + immutability + independence)
- [x] `IUidGenerator` unit tests (live + seeded determinism + seed independence + monotonic)
- [x] Lint + check:types + jest green locally (10/10 tests pass)
- [ ] CI green (waiting)

## Refs
- vault RFC: aaaa2dea-abf3-4601-b800-286111b15ec2 (RFC v2: Гомоиконичное тестирование плагинов)
- vault Task: bbf45a72-136f-43a2-ba45-f5af252957c7
- vault Phase: 7bc159d8-3319-4652-ab88-c02efd97306c (Phase 0 — CLI determinism)