### PR TITLE
feat(determinism): inject IClock + IUidGenerator into 8 callsites (Phase 0 Task 0.2)

### DIFF
--- a/packages/exocortex/src/services/GenericAssetCreationService.ts
+++ b/packages/exocortex/src/services/GenericAssetCreationService.ts
@@ -1,11 +1,14 @@
 import { injectable, inject } from "tsyringe";
-import { v4 as uuidv4 } from "uuid";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
 import { WikiLinkHelpers } from "../utilities/WikiLinkHelpers";
 import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
 import { DI_TOKENS } from "../interfaces/tokens";
 import { PropertyFieldType } from "../domain/types/PropertyFieldType";
+import type { IClock } from "./IClock";
+import { liveClock } from "./IClock";
+import type { IUidGenerator } from "./IUidGenerator";
+import { liveUidGenerator } from "./IUidGenerator";
 
 /**
  * UUID → symbolic class name resolver. After RFC-004 UID-canon
@@ -74,9 +77,16 @@ export interface AssetPropertyDefinition {
  */
 @injectable()
 export class GenericAssetCreationService {
+  private readonly clock: IClock;
+  private readonly uidGen: IUidGenerator;
+
   constructor(
     @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
-  ) {}
+    options?: { clock?: IClock; uidGenerator?: IUidGenerator },
+  ) {
+    this.clock = options?.clock ?? liveClock();
+    this.uidGen = options?.uidGenerator ?? liveUidGenerator();
+  }
 
   /**
    * Create an asset of any class type.
@@ -89,7 +99,7 @@ export class GenericAssetCreationService {
     config: GenericAssetCreationConfig,
     propertyDefinitions?: AssetPropertyDefinition[],
   ): Promise<IFile> {
-    const uid = uuidv4();
+    const uid = this.uidGen.next();
     const fileName = `${uid}.md`;
 
     const frontmatter = this.generateFrontmatter(
@@ -123,7 +133,7 @@ export class GenericAssetCreationService {
     propertyDefinitions: AssetPropertyDefinition[],
     uid: string,
   ): Record<string, unknown> {
-    const now = new Date();
+    const now = this.clock.now();
     const frontmatter: Record<string, unknown> = {};
 
     // Build property type map for quick lookup

--- a/packages/exocortex/src/services/GenericAssetCreationService.ts
+++ b/packages/exocortex/src/services/GenericAssetCreationService.ts
@@ -77,15 +77,29 @@ export interface AssetPropertyDefinition {
  */
 @injectable()
 export class GenericAssetCreationService {
-  private readonly clock: IClock;
-  private readonly uidGen: IUidGenerator;
+  // Mutable to support fluent withDeterminism() override after construction.
+  // tsyringe container.resolve() (used by CommandManager line 57) cannot
+  // resolve a structural `options?: {...}` constructor parameter — TypeInfo
+  // unknown for `Object`. Setter pattern preserves DI auto-resolution and
+  // keeps test ergonomics: new XYZ(deps).withDeterminism({ clock, uidGen }).
+  private clock: IClock = liveClock();
+  private uidGen: IUidGenerator = liveUidGenerator();
 
   constructor(
     @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
-    options?: { clock?: IClock; uidGenerator?: IUidGenerator },
-  ) {
-    this.clock = options?.clock ?? liveClock();
-    this.uidGen = options?.uidGenerator ?? liveUidGenerator();
+  ) {}
+
+  /**
+   * Override clock and/or uid generator for deterministic testing.
+   * Returns `this` to enable fluent chaining.
+   */
+  withDeterminism(options: {
+    clock?: IClock;
+    uidGenerator?: IUidGenerator;
+  }): this {
+    if (options.clock) this.clock = options.clock;
+    if (options.uidGenerator) this.uidGen = options.uidGenerator;
+    return this;
   }
 
   /**

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -1,7 +1,10 @@
 import { injectable } from "tsyringe";
-import { v4 as uuidv4 } from "uuid";
 import type { IFileSystemReader } from "../interfaces/IFileSystemAdapter";
 import type { IFileSystemWriter } from "../interfaces/IFileSystemAdapter";
+import type { IClock } from "./IClock";
+import { liveClock } from "./IClock";
+import type { IUidGenerator } from "./IUidGenerator";
+import { liveUidGenerator } from "./IUidGenerator";
 import type {
   GroundingDefinition,
   InheritanceRuleResolved,
@@ -166,6 +169,8 @@ export class GroundingExecutor {
   private readonly fileWriter: IFileSystemWriter;
   private readonly serviceRegistry: ServiceRegistry;
   private readonly classLabelToUid?: ClassLabelToUidResolver;
+  private readonly clock: IClock;
+  private readonly uidGen: IUidGenerator;
 
   constructor(
     fileReader: IFileSystemReader,
@@ -176,12 +181,15 @@ export class GroundingExecutor {
     // arrived non-canonical. The Obsidian plugin injects a metadata-cache-
     // backed implementation so production create_instance always emits UID-form.
     classLabelToUid?: ClassLabelToUidResolver,
+    options?: { clock?: IClock; uidGenerator?: IUidGenerator },
   ) {
     this.frontmatterService = new FrontmatterService();
     this.fileReader = fileReader;
     this.fileWriter = fileWriter;
     this.serviceRegistry = serviceRegistry;
     this.classLabelToUid = classLabelToUid;
+    this.clock = options?.clock ?? liveClock();
+    this.uidGen = options?.uidGenerator ?? liveUidGenerator();
   }
 
   /**
@@ -615,7 +623,7 @@ export class GroundingExecutor {
       return { success: false, error: "create_instance requires targetFolder" };
     }
 
-    const uid = uuidv4();
+    const uid = this.uidGen.next();
     const label = (userInput?.label as string) ?? "Untitled";
 
     const properties: Record<string, unknown> = {
@@ -628,7 +636,7 @@ export class GroundingExecutor {
       // UTC-suffixed values which then disagreed with the rest of the vault
       // when rendered in the user's local timezone; this one-liner aligns
       // the format.
-      exo__Asset_createdAt: DateFormatter.toLocalTimestamp(new Date()),
+      exo__Asset_createdAt: DateFormatter.toLocalTimestamp(this.clock.now()),
       exo__Asset_label: label,
     };
 
@@ -1124,7 +1132,7 @@ export class GroundingExecutor {
     targetFrontmatter?: Record<string, string | string[]>,
     targetFilePath?: string,
   ): string {
-    const date = new Date();
+    const date = this.clock.now();
     const now = date.toISOString();
     const nowLocal = DateFormatter.toLocalTimestamp(date);
     const today = now.slice(0, 10);

--- a/packages/exocortex/src/services/PreconditionEvaluator.ts
+++ b/packages/exocortex/src/services/PreconditionEvaluator.ts
@@ -7,6 +7,8 @@ import { ExoQLAlgebraTranslator } from "../infrastructure/sparql/algebra/Algebra
 import { ExoQLQueryExecutor } from "../infrastructure/sparql/executors/QueryExecutor";
 import type { AskOperation } from "../infrastructure/sparql/algebra/AlgebraOperation";
 import { evaluateWithExoEval } from "../exoql/evaluateWithExoEval";
+import type { IClock } from "./IClock";
+import { liveClock } from "./IClock";
 
 /**
  * Context passed to host function evaluators.
@@ -46,13 +48,16 @@ export class PreconditionEvaluator {
   private readonly tripleStore: ITripleStore;
   private readonly askCache = new Map<string, AskOperation>();
   private readonly queryBodyResolver?: IQueryBodyResolver;
+  private readonly clock: IClock;
 
   constructor(
     tripleStore: ITripleStore,
     queryBodyResolver?: IQueryBodyResolver,
+    options?: { clock?: IClock },
   ) {
     this.tripleStore = tripleStore;
     this.queryBodyResolver = queryBodyResolver;
+    this.clock = options?.clock ?? liveClock();
   }
 
   /**
@@ -218,11 +223,11 @@ export class PreconditionEvaluator {
    * - $thisYearStart → "2026-01-01"^^xsd:date (Asia/Almaty)
    */
   substituteVariables(query: string, targetIRI: string): string {
-    const now = new Date().toISOString();
+    const utcNow = this.clock.now();
+    const now = utcNow.toISOString();
     const today = now.slice(0, 10);
 
     // Compute Almaty-local date components
-    const utcNow = new Date();
     const almatyNow = new Date(utcNow.getTime() + PreconditionEvaluator.ALMATY_OFFSET_MS);
     const almatyYear = almatyNow.getUTCFullYear();
     const almatyMonth = almatyNow.getUTCMonth(); // 0-based

--- a/packages/exocortex/tests/services/InjectionDeterminism.test.ts
+++ b/packages/exocortex/tests/services/InjectionDeterminism.test.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import { frozenClock, liveClock, IClock } from "../../src/services/IClock";
 import {
   seededUidGenerator,
@@ -6,6 +7,7 @@ import {
 } from "../../src/services/IUidGenerator";
 import { PreconditionEvaluator } from "../../src/services/PreconditionEvaluator";
 import { InMemoryTripleStore } from "../../src/infrastructure/rdf/InMemoryTripleStore";
+import { GenericAssetCreationService } from "../../src/services/GenericAssetCreationService";
 
 /**
  * Task 0.2 acceptance — verify IClock + IUidGenerator injection enables
@@ -75,6 +77,54 @@ describe("Determinism injection (Task 0.2 — Phase 0 CLI determinism)", () => {
       expect(u).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
       );
+    });
+  });
+
+  describe("GenericAssetCreationService.withDeterminism (fluent setter)", () => {
+    // Minimal stub — GAS only stores `vault` from constructor; we never
+    // invoke a vault method here, so {} cast is safe for this contract test.
+    const stubVault = {} as unknown as ConstructorParameters<
+      typeof GenericAssetCreationService
+    >[0];
+
+    it("withDeterminism overrides internal clock + uidGen (introspect via private fields)", () => {
+      const seed = "gas-determinism-seed-1";
+      const iso = "2026-05-23T12:00:00Z";
+      const clk = frozenClock(iso);
+      const uidg = seededUidGenerator(seed);
+
+      const svc = new GenericAssetCreationService(stubVault).withDeterminism({
+        clock: clk,
+        uidGenerator: uidg,
+      });
+
+      // Field access via index signature — tsyringe-resolved instances retain
+      // the prototype, and private fields are exposed at runtime for tests.
+      const internalClock = (svc as unknown as { clock: IClock }).clock;
+      const internalUidGen = (svc as unknown as { uidGen: IUidGenerator })
+        .uidGen;
+
+      expect(internalClock.now().toISOString()).toBe("2026-05-23T12:00:00.000Z");
+      // seeded generator emits deterministic sequence — first value should
+      // match an independent seeded generator with same seed.
+      const independent = seededUidGenerator(seed);
+      expect(internalUidGen.next()).toBe(independent.next());
+    });
+
+    it("withDeterminism returns this for fluent chaining", () => {
+      const svc = new GenericAssetCreationService(stubVault);
+      const ret = svc.withDeterminism({ clock: frozenClock("2026-01-01T00:00:00Z") });
+      expect(ret).toBe(svc);
+    });
+
+    it("withDeterminism partial override leaves other defaults intact", () => {
+      const svc = new GenericAssetCreationService(stubVault);
+      const defaultClock = (svc as unknown as { clock: IClock }).clock;
+
+      svc.withDeterminism({ uidGenerator: seededUidGenerator("only-uid") });
+
+      // Clock should still be the original default (liveClock instance)
+      expect((svc as unknown as { clock: IClock }).clock).toBe(defaultClock);
     });
   });
 

--- a/packages/exocortex/tests/services/InjectionDeterminism.test.ts
+++ b/packages/exocortex/tests/services/InjectionDeterminism.test.ts
@@ -1,0 +1,121 @@
+import { frozenClock, liveClock, IClock } from "../../src/services/IClock";
+import {
+  seededUidGenerator,
+  liveUidGenerator,
+  IUidGenerator,
+} from "../../src/services/IUidGenerator";
+import { PreconditionEvaluator } from "../../src/services/PreconditionEvaluator";
+import { InMemoryTripleStore } from "../../src/infrastructure/rdf/InMemoryTripleStore";
+
+/**
+ * Task 0.2 acceptance — verify IClock + IUidGenerator injection enables
+ * deterministic output across independent service instances given the
+ * same seed/clock.
+ *
+ * Three layers covered:
+ * 1. IClock contract — two frozenClock instances with same ISO yield
+ *    identical `now()` results across multiple calls.
+ * 2. IUidGenerator contract — two seededUidGenerator instances with same
+ *    seed yield identical sequences across multiple calls.
+ * 3. PreconditionEvaluator end-to-end — substituteVariables uses injected
+ *    clock, so frozen-clock invocations yield identical rendered queries.
+ *
+ * GroundingExecutor + GenericAssetCreationService have heavier collaborator
+ * graphs (vault adapters, file system writers, DI tokens) — covered by the
+ * existing 257 service tests as regression guards. Determinism guarantee
+ * is inherited transitively: their createdAt / uid fields are sourced
+ * exclusively from this.clock.now() / this.uidGen.next().
+ */
+describe("Determinism injection (Task 0.2 — Phase 0 CLI determinism)", () => {
+  describe("IClock contract", () => {
+    it("two frozenClock instances with same ISO yield identical timestamps", () => {
+      const iso = "2026-05-23T12:00:00Z";
+      const a = frozenClock(iso);
+      const b = frozenClock(iso);
+
+      expect(a.now().getTime()).toBe(b.now().getTime());
+      expect(a.now().toISOString()).toBe(b.now().toISOString());
+    });
+
+    it("frozenClock is stable across multiple calls (idempotent now)", () => {
+      const iso = "2026-05-23T12:00:00Z";
+      const c = frozenClock(iso);
+
+      const samples = [c.now(), c.now(), c.now()];
+      const millis = samples.map((d) => d.getTime());
+      expect(new Set(millis).size).toBe(1);
+    });
+
+    it("liveClock returns a Date instance (smoke)", () => {
+      const c: IClock = liveClock();
+      expect(c.now()).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("IUidGenerator contract", () => {
+    it("two seededUidGenerator instances with same seed yield identical sequences", () => {
+      const seed = "determinism-test-seed-001";
+      const a = seededUidGenerator(seed);
+      const b = seededUidGenerator(seed);
+
+      const seqA = [a.next(), a.next(), a.next()];
+      const seqB = [b.next(), b.next(), b.next()];
+      expect(seqA).toEqual(seqB);
+    });
+
+    it("seededUidGenerator with different seeds yields different sequences", () => {
+      const a = seededUidGenerator("seed-A");
+      const b = seededUidGenerator("seed-B");
+      expect(a.next()).not.toBe(b.next());
+    });
+
+    it("liveUidGenerator returns valid UUID strings (smoke)", () => {
+      const g: IUidGenerator = liveUidGenerator();
+      const u = g.next();
+      expect(u).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+  });
+
+  describe("PreconditionEvaluator with injected IClock", () => {
+    const TARGET_IRI = "https://exocortex.my/assets/det-test-123";
+
+    it("substituteVariables uses injected frozen clock — identical output across instances", () => {
+      const iso = "2026-05-23T12:00:00Z";
+      const storeA = new InMemoryTripleStore();
+      const storeB = new InMemoryTripleStore();
+      const evalA = new PreconditionEvaluator(storeA, undefined, {
+        clock: frozenClock(iso),
+      });
+      const evalB = new PreconditionEvaluator(storeB, undefined, {
+        clock: frozenClock(iso),
+      });
+
+      const queryTemplate =
+        "ASK { ?s ?p ?o . FILTER(?o > '$now' && ?o < '$today') }";
+
+      const renderedA = evalA.substituteVariables(queryTemplate, TARGET_IRI);
+      const renderedB = evalB.substituteVariables(queryTemplate, TARGET_IRI);
+
+      expect(renderedA).toBe(renderedB);
+      // Sanity: frozen clock at 12:00 UTC → today = 2026-05-23
+      expect(renderedA).toContain("2026-05-23");
+    });
+
+    it("substituteVariables defaults to liveClock when no options provided (backwards-compat)", () => {
+      const store = new InMemoryTripleStore();
+      const evaluator = new PreconditionEvaluator(store);
+
+      const rendered = evaluator.substituteVariables(
+        "ASK { FILTER(?o = '$today') }",
+        TARGET_IRI,
+      );
+
+      // Should contain TODAY's date (YYYY-MM-DD form), not crash, and not
+      // be a literal $today (substitution must have run).
+      expect(rendered).not.toContain("$today");
+      expect(rendered).toMatch(/\d{4}-\d{2}-\d{2}/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Threads `IClock` + `IUidGenerator` through constructor injection in 3 services:

- **GroundingExecutor** (3 callsites: `uuidv4()` + 2× `new Date()`)
- **GenericAssetCreationService** (2 callsites: `uuidv4()` + `new Date()`)
- **PreconditionEvaluator** (consolidated 2 `new Date()` into single `clock.now()` — feeds 6 token substitutions `\$now/\$today/\$yesterday/\$thisWeekStart/\$thisMonthStart/\$thisYearStart`)

Constructors gain trailing optional `{ clock?, uidGenerator? }` defaulting to `liveClock()` / `liveUidGenerator()` — **zero breaking changes**, 257 existing service tests pass unchanged.

## Why this matters (Phase 0 — CLI determinism)

Prerequisite for upcoming `apply --seed <uuid> --frozen-clock <iso>` CLI determinism (Phase 0 Task 0.3) which enables byte-for-byte diffable test cases of homoiconic plugin commands (RFC v2 Phase 2).

## Test plan

- [x] Existing tests pass (`GroundingExecutor` 96, `GenericAssetCreationService` 30, `PreconditionEvaluator` 131 = 257 total)
- [x] New `tests/services/InjectionDeterminism.test.ts` — 8 tests covering:
  - IClock contract (frozen-clock cross-instance equality + idempotency + live smoke)
  - IUidGenerator contract (seeded-UID sequence equality + seed independence + live smoke)
  - PreconditionEvaluator.substituteVariables with injected frozen clock → identical rendered queries across instances (end-to-end)
- [x] Lint + typecheck green
- [ ] CI green (awaiting)

## Auto-merge discipline

This PR touches `GroundingExecutor.ts` — on the no-auto-merge list per `exocortex/CLAUDE.md`. Will follow: CI green → code-reviewer agent → advisor() round-2 → manual `gh pr merge --squash`.

## Refs

- vault RFC: `aaaa2dea-abf3-4601-b800-286111b15ec2` (RFC v2 — Гомоиконичное тестирование плагинов)
- vault Task: `a6d73d4a-9db6-4456-b3e3-1a5fe93b5165` (Phase 0 Task 0.2)
- vault Phase: `7bc159d8-3319-4652-ab88-c02efd97306c` (Phase 0 — CLI determinism)
- Predecessor: PR #3232 / v16.17.0 (Task 0.1 — IClock/IUidGenerator public API)