### PR TITLE
refactor: Phase 4b — thin-wrap legacy createAsset handlers (#3166)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -13,8 +13,6 @@ import {
   RenameToUidService,
   ConceptCreationService,
   ClassCreationService,
-  DateFormatter,
-  WikiLinkHelpers,
   type ClassRefResolver,
   type IGroundingService,
   type UserInput,
@@ -42,6 +40,9 @@ function createMetadataClassResolver(app: App): ClassRefResolver {
 import {
   createArchiveAssetService,
   createCleanPropertiesService,
+  createCreateAssetService,
+  createCreateRelatedProjectService,
+  createCreateRelatedTaskService,
   createFixMissingLabelService,
   createPlanForEveningService,
   createRenameToUidService,
@@ -67,12 +68,6 @@ function wrapService(
   fn: (targetIRI: string, userInput?: UserInput) => Promise<void>,
 ): IGroundingService {
   return { execute: fn };
-}
-
-function toQuotedWikilink(value: string): string {
-  if (value.startsWith('"[[') && value.endsWith(']]"')) return value;
-  if (value.startsWith("[[") && value.endsWith("]]")) return `"${value}"`;
-  return `"[[${value}]]"`;
 }
 
 export function populateServiceRegistry(
@@ -120,162 +115,6 @@ export function populateServiceRegistry(
       frontmatterService,
       pluginPathResolver,
     ),
-  );
-
-  registry.register(
-    "createAsset",
-    wrapService(async (targetIRI: string, userInput?: UserInput) => {
-      // Accept both `prototypeUID` and `prototype` — starter-kit groundings
-      // prior to 2026-04-13 wired "Create Project" with `{"prototype":"..."}`
-      // (natural JSON key), which diverged from the service contract. The UI
-      // click-through silently failed because the 4 s red Notice fades fast
-      // while the direct console call suggested the plugin was correct. See
-      // #2850 Bug 3.
-      const prototypeUID =
-        (userInput?.prototypeUID as string | undefined) ??
-        (userInput?.prototype as string | undefined);
-      const label = userInput?.label as string | undefined;
-      // `userInput.folder` literal wins over the targetIRI-based inference.
-      // Global surfaces (Obsidian Command Palette, RFC `1429fcd0`) call this
-      // service without an active file, so they pass `folder` explicitly via
-      // the exocmd grounding `targetValue`. Layout buttons keep working
-      // unchanged: they don't pass `folder` and the inference below fills it
-      // in from the active asset.
-      let folder = userInput?.folder as string | undefined;
-      const ownerIdentity = userInput?.ownerIdentity as string | undefined;
-      const explicitIsDefinedBy = userInput?.isDefinedBy as string | undefined;
-      if (!prototypeUID) throw new Error("createAsset requires userInput.prototypeUID");
-      if (!label) throw new Error("createAsset requires userInput.label");
-      // Default to current file's folder when not specified
-      if (!folder && targetIRI) {
-        try {
-          const currentPath = resolveFilePath(app, targetIRI);
-          const lastSlash = currentPath.lastIndexOf("/");
-          folder = lastSlash >= 0 ? currentPath.substring(0, lastSlash) : "";
-        } catch {
-          // IRI resolution failed — folder stays undefined
-        }
-      }
-      if (!folder && folder !== "") throw new Error("createAsset requires userInput.folder");
-
-      // Resolve parent file and metadata from targetIRI so prototype-based
-      // creation inherits context (Instance_class, Effort_parent/area, status,
-      // isDefinedBy) — mirrors createRelatedTask's inheritParentContext but
-      // operates through fileSystemAdapter.createFile because this handler is
-      // used from bindings that only have app+fileSystemAdapter wired.
-      // RFC-028 Finding 2: without this inheritance, prototype-button created
-      // Tasks render as orphans in Project layouts.
-      let parentPath: string | undefined;
-      let parentMetadata: Record<string, unknown> | undefined;
-      if (targetIRI) {
-        try {
-          parentPath = resolveFilePath(app, targetIRI);
-          const parentFile = app.vault.getAbstractFileByPath(parentPath);
-          if (parentFile) {
-            const cache = app.metadataCache.getFileCache(parentFile as never);
-            parentMetadata = cache?.frontmatter as
-              | Record<string, unknown>
-              | undefined;
-          }
-        } catch {
-          // IRI resolution failed — no parent inheritance
-        }
-      }
-      // Default folder from current file's parent folder (re-use parentPath)
-      if (!folder && parentPath) {
-        const lastSlash = parentPath.lastIndexOf("/");
-        folder = lastSlash >= 0 ? parentPath.substring(0, lastSlash) : "";
-      }
-      if (!folder && folder !== "") throw new Error("createAsset requires userInput.folder");
-
-      const expectedClass = prototypeUID.endsWith("Prototype")
-        ? prototypeUID.slice(0, -"Prototype".length)
-        : prototypeUID;
-
-      const uid = crypto.randomUUID();
-      const createdAt = DateFormatter.toISOTimestamp(new Date());
-      const fileName = `${uid}.md`;
-      const filePath = `${folder}/${fileName}`;
-      const lines: string[] = [
-        "---",
-        `exo__Asset_uid: ${uid}`,
-        `exo__Asset_createdAt: ${createdAt}`,
-        `exo__Asset_label: ${label}`,
-        `exo__Asset_prototype: "[[${prototypeUID}]]"`,
-        "exo__Instance_class:",
-        `  - "[[${expectedClass}]]"`,
-      ];
-      let isDefinedByWritten = false;
-      // Highest precedence: explicit `isDefinedBy` from grounding `targetValue`
-      // (RFC `1429fcd0` follow-up). Lets each exocmd command pin its created
-      // assets to a specific owner without depending on vault default or parent
-      // inheritance. Example: a global Palette "Create note" command sets
-      // `targetValue.isDefinedBy = "[[<kitelev-uid>]]"` so the note is owned
-      // by the user even when fired without an active file.
-      if (explicitIsDefinedBy) {
-        lines.push(
-          `exo__Asset_isDefinedBy: ${toQuotedWikilink(explicitIsDefinedBy)}`,
-        );
-        isDefinedByWritten = true;
-      }
-      if (parentMetadata) {
-        const parentClass = parentMetadata.exo__Instance_class;
-        const parentClasses = Array.isArray(parentClass)
-          ? parentClass
-          : parentClass != null
-            ? [parentClass]
-            : [];
-        const isAreaParent = parentClasses.some((cls) =>
-          WikiLinkHelpers.resolveSymbolic(String(cls), classResolver).includes(
-            "Area",
-          ),
-        );
-        const parentBasename = parentPath
-          ? parentPath
-              .substring(parentPath.lastIndexOf("/") + 1)
-              .replace(/\.md$/, "")
-          : undefined;
-        if (parentBasename) {
-          const parentProperty = isAreaParent
-            ? "ems__Effort_area"
-            : "ems__Effort_parent";
-          lines.push(`${parentProperty}: "[[${parentBasename}]]"`);
-        }
-        if (!isAreaParent && parentMetadata.ems__Effort_area) {
-          lines.push(
-            `ems__Effort_area: ${toQuotedWikilink(
-              String(parentMetadata.ems__Effort_area),
-            )}`,
-          );
-        }
-        // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Resolves the
-        // 42-asset symbolic-form trace back to this default-write site.
-        lines.push(
-          'ems__Effort_status: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"',
-        );
-        if (!isDefinedByWritten && parentMetadata.exo__Asset_isDefinedBy) {
-          lines.push(
-            `exo__Asset_isDefinedBy: ${toQuotedWikilink(
-              String(parentMetadata.exo__Asset_isDefinedBy),
-            )}`,
-          );
-          isDefinedByWritten = true;
-        }
-      }
-      // Final fallback for global surfaces without an active file (RFC
-      // `1429fcd0`): ExocmdCommandPaletteRegistrar injects the vault default
-      // owner-identity wikilink via `userInput.ownerIdentity`. Precedence
-      // chain: explicit grounding `isDefinedBy` > parent inheritance >
-      // vault-default `ownerIdentity`.
-      if (!isDefinedByWritten && ownerIdentity) {
-        lines.push(
-          `exo__Asset_isDefinedBy: ${toQuotedWikilink(ownerIdentity)}`,
-        );
-      }
-      lines.push("---", "");
-      const frontmatter = lines.join("\n");
-      await fileSystemAdapter.createFile(filePath, frontmatter);
-    }),
   );
 
   registry.register(
@@ -412,111 +251,49 @@ export function populateServiceRegistry(
     // (Homoiconicity Invariant Q1 remediation). Palette command path remains
     // via direct LabelToAliasService usage in CopyLabelToAliasesCommand.
 
+    // Phase 4b (#3166) — thin wrappers delegate the createAsset family to the
+    // storage-agnostic shared factories from `@kitelev/exocortex-services`
+    // (Phase 3.5 ship). Removes ~250 LOC of inlined logic previously duplicated
+    // between plugin and CLI. The `openCreatedFileInTab` callback wires the
+    // Obsidian-specific post-create UX (focus the new asset in a new workspace
+    // tab) without leaking Obsidian dependencies into the shared package.
+    const openCreatedFileInTab = async (createdFile: IFile): Promise<void> => {
+      const tfile = vaultAdapter.toTFile(createdFile);
+      const leaf = app.workspace.getLeaf("tab");
+      await leaf.openFile(tfile);
+      app.workspace.setActiveLeaf(leaf, { focus: true });
+    };
+
+    registry.register(
+      "createAsset",
+      createCreateAssetService(
+        vaultAdapter,
+        fileSystemAdapter,
+        classResolver,
+        targetResolver,
+      ),
+    );
+
     registry.register(
       "createRelatedTask",
-      wrapService(async (targetIRI: string, userInput?: UserInput) => {
-        const label = userInput?.label as string | undefined;
-        if (!label) throw new Error("createRelatedTask requires userInput.label");
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        const parentMetadata = (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
-        const folderPath = iFile.parent?.path || "";
-
-        // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194). Draft status UUID
-        // is the canonical TBox identifier; vault file at
-        // assetspaces/ems/c42245d0-01de-4c35-bfcf-d910445ea28e.md.
-        const propertyValues: Record<string, unknown> = {
-          "ems__Effort_status":
-            '"[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"',
-        };
-
-        // Optional declarative override: starter-kit bindings may pass
-        // `parentProperty` via Grounding_targetValue to force a specific parent
-        // link. When absent, GenericAssetCreationService auto-detects
-        // ems__Effort_area vs ems__Effort_parent from the parent's Instance_class.
-        const explicitParentProperty = userInput?.parentProperty as string | undefined;
-        if (explicitParentProperty && iFile.basename) {
-          propertyValues[explicitParentProperty] = `"[[${iFile.basename}]]"`;
-        }
-
-        const createdFile = await genericAssetCreationService.createAsset({
-          className: "ems__Task",
-          label,
-          folderPath,
-          propertyValues,
-          parentFile: iFile,
-          parentMetadata,
-          classResolver,
-        });
-
-        const tfile = vaultAdapter.toTFile(createdFile);
-        const leaf = app.workspace.getLeaf("tab");
-        await leaf.openFile(tfile);
-        app.workspace.setActiveLeaf(leaf, { focus: true });
-      }),
+      createCreateRelatedTaskService(
+        vaultAdapter,
+        genericAssetCreationService,
+        targetResolver,
+        openCreatedFileInTab,
+        classResolver,
+      ),
     );
 
     registry.register(
       "createRelatedProject",
-      wrapService(async (targetIRI: string, userInput?: UserInput) => {
-        const label = userInput?.label as string | undefined;
-        if (!label) throw new Error("createRelatedProject requires userInput.label");
-        const iFile = resolveIFile(app, targetIRI, vaultAdapter);
-        const parentMetadata = (vaultAdapter.getFrontmatter(iFile) as Record<string, unknown>) ?? {};
-        const folderPath = iFile.parent?.path || "";
-
-        // Mirror createRelatedTask but scoped to ems__Project. Uses the same
-        // ems__Effort_* parent-property convention so AssetRelations rendering
-        // works uniformly with sibling Task/Meeting efforts. When the parent
-        // is an ems__Area, write ems__Effort_area; when the parent is another
-        // Project or Task, write ems__Effort_parent. The core
-        // GenericAssetCreationService.inheritParentContext currently only
-        // auto-inherits for ems__Task, so this handler does the area vs parent
-        // detection explicitly via userInput.parentProperty and falls back to
-        // the auto-detected form.
-        // UUID-form per RFC 31c1a0be Phase 4 PR-C (#3194).
-        const propertyValues: Record<string, unknown> = {
-          "ems__Effort_status":
-            '"[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"',
-        };
-
-        if (iFile.basename) {
-          const explicitParentProperty = userInput?.parentProperty as string | undefined;
-          if (explicitParentProperty) {
-            propertyValues[explicitParentProperty] = `"[[${iFile.basename}]]"`;
-          } else {
-            const parentClass = parentMetadata["exo__Instance_class"];
-            const parentClasses = Array.isArray(parentClass)
-              ? parentClass
-              : parentClass != null
-                ? [parentClass]
-                : [];
-            const isAreaParent = parentClasses.some((cls) =>
-              WikiLinkHelpers.resolveSymbolic(String(cls), classResolver).includes(
-                "Area",
-              ),
-            );
-            const parentPropertyName = isAreaParent
-              ? "ems__Effort_area"
-              : "ems__Effort_parent";
-            propertyValues[parentPropertyName] = `"[[${iFile.basename}]]"`;
-          }
-        }
-
-        const createdFile = await genericAssetCreationService.createAsset({
-          className: "ems__Project",
-          label,
-          folderPath,
-          propertyValues,
-          parentFile: iFile,
-          parentMetadata,
-          classResolver,
-        });
-
-        const tfile = vaultAdapter.toTFile(createdFile);
-        const leaf = app.workspace.getLeaf("tab");
-        await leaf.openFile(tfile);
-        app.workspace.setActiveLeaf(leaf, { focus: true });
-      }),
+      createCreateRelatedProjectService(
+        vaultAdapter,
+        genericAssetCreationService,
+        targetResolver,
+        openCreatedFileInTab,
+        classResolver,
+      ),
     );
 
     registry.register(

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -99,17 +99,20 @@ describe("ServiceRegistryPopulator", () => {
     populateServiceRegistry(registry, deps);
   });
 
-  it("should register 10 services", () => {
+  it("should register 9 services", () => {
     const ids = registry.getRegisteredIds();
-    expect(ids.length).toBeGreaterThanOrEqual(10);
+    // `createAsset` moved into the vaultAdapter-gated block in Phase 4b (#3166)
+    // — the shared-factory delegation requires `vaultAdapter.getFrontmatter`
+    // for parent inheritance, so the registration is now vault-dependent.
+    expect(ids.length).toBeGreaterThanOrEqual(9);
   });
 
   it("should register all expected service IDs", () => {
+    // `createAsset` moved to the vault-dependent block in Phase 4b (#3166).
     const expectedIds = [
       "updateProperty",
       "removeProperty",
       "setStatus",
-      "createAsset",
       "openFile",
       "sparqlSelect",
       "getActiveFileIRI",
@@ -126,9 +129,12 @@ describe("ServiceRegistryPopulator", () => {
     // `planOnToday` + `createTaskForDailyNote` removed in Issue #3136 (Q3.b
     // closure — migrated to declarative groundings via $todayStart /
     // $targetFolder + propertyDefaults).
+    // `createAsset` moved into vault-dependent block in Phase 4b (#3166) —
+    // shared-factory delegation needs `vaultAdapter.getFrontmatter`.
     const vaultDependentIds = [
       "rollbackStatus",
       "planForEvening",
+      "createAsset",
       "createRelatedTask",
       "createRelatedProject",
       "archiveAsset",
@@ -221,6 +227,14 @@ describe("ServiceRegistryPopulator", () => {
   });
 
   describe("createAsset", () => {
+    // Phase 4b (#3166): createAsset is now registered inside the vault-adapter
+    // gated block (delegates to shared `createCreateAssetService` factory).
+    beforeEach(() => {
+      registry = new ServiceRegistry();
+      deps = createMockDeps(true);
+      populateServiceRegistry(registry, deps);
+    });
+
     it("should create file with frontmatter", async () => {
       const service = registry.get("createAsset")!;
       await service.execute("", {
@@ -413,6 +427,12 @@ describe("ServiceRegistryPopulator", () => {
   });
 
   describe("createAsset default folder", () => {
+    beforeEach(() => {
+      registry = new ServiceRegistry();
+      deps = createMockDeps(true);
+      populateServiceRegistry(registry, deps);
+    });
+
     it("should use current file folder when folder not specified", async () => {
       const service = registry.get("createAsset")!;
       await service.execute("test-uid-123", {
@@ -445,6 +465,12 @@ describe("ServiceRegistryPopulator", () => {
   // owner identity literally because the active-file inheritance branch
   // can't fire.
   describe("createAsset ownerIdentity fallback", () => {
+    beforeEach(() => {
+      registry = new ServiceRegistry();
+      deps = createMockDeps(true);
+      populateServiceRegistry(registry, deps);
+    });
+
     it("writes exo__Asset_isDefinedBy from userInput.ownerIdentity when no active file present", async () => {
       const service = registry.get("createAsset")!;
 
@@ -1170,10 +1196,21 @@ describe("createAsset — orphan prevention regression (Finding 2)", () => {
 
   beforeEach(() => {
     registry = new ServiceRegistry();
-    deps = createMockDeps();
+    // Phase 4b (#3166): createAsset is now registered inside the vault-adapter
+    // gated block (delegates to shared `createCreateAssetService` factory).
+    // Both the targetResolver (`createObsidianTargetResolver`) and the
+    // parent-metadata lookup go through `vaultAdapter`, so the mocks below
+    // need to mirror what `metadataCache` previously provided.
+    deps = createMockDeps(true);
 
     // Override mocks so the parent IRI resolves to a Project file with
     // rich inheritable context (area, isDefinedBy, Project class).
+    const parentIFile = {
+      path: PARENT_PATH,
+      basename: "parent-project-uid-001",
+      name: "parent-project-uid-001.md",
+      parent: { path: "01 Areas", name: "01 Areas" },
+    };
     (deps.app.vault.getMarkdownFiles as jest.Mock).mockReturnValue([
       { path: PARENT_PATH },
     ]);
@@ -1188,6 +1225,17 @@ describe("createAsset — orphan prevention regression (Finding 2)", () => {
         ems__Effort_area: `[[${PARENT_AREA_UID}]]`,
         exo__Asset_isDefinedBy: "[[!toos_areas]]",
       },
+    });
+    // Mirror metadataCache content via vaultAdapter for shared factory path.
+    (deps.vaultAdapter!.getAbstractFileByPath as jest.Mock).mockImplementation(
+      (path: string) => (path === PARENT_PATH ? parentIFile : null),
+    );
+    (deps.vaultAdapter!.getFrontmatter as jest.Mock).mockReturnValue({
+      exo__Asset_uid: PARENT_PROJECT_UID,
+      exo__Asset_label: "Audit Project",
+      exo__Instance_class: ["[[ems__Project]]"],
+      ems__Effort_area: `[[${PARENT_AREA_UID}]]`,
+      exo__Asset_isDefinedBy: "[[!toos_areas]]",
     });
 
     populateServiceRegistry(registry, deps);

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -56,10 +56,41 @@ export function createPathBasedTargetResolver(
   };
 }
 
+/**
+ * Optional post-create hook used by the obsidian-plugin thin wrapper
+ * (Phase 4b) to focus the new asset in a workspace tab. CLI runtimes
+ * omit this parameter; behavior is unchanged for those callers.
+ */
+export type OnCreatedCallback = (file: IFile) => Promise<void>;
+
+/**
+ * Default `ClassRefResolver` used when CLI callers don't supply one. The
+ * legacy plugin path resolved UID-canon `[[<uuid>]]` references through
+ * Obsidian's `metadataCache`; in CLI runtime there is no resolver, so this
+ * fallback returns `null` for every UUID. Symbolic refs (`[[ems__Area]]`)
+ * continue to round-trip through `WikiLinkHelpers.resolveSymbolic` without
+ * resolver assistance.
+ */
+const NULL_CLASS_RESOLVER: ClassRefResolver = () => null;
+
+/**
+ * Format a wikilink value as the quoted YAML form (`"[[X]]"`) consistently with
+ * the plugin's hand-rolled `createAsset` frontmatter writer
+ * (`ServiceRegistryPopulator.toQuotedWikilink`). Idempotent — already-quoted
+ * inputs round-trip unchanged; bare/unwrapped values are re-wrapped.
+ */
+function toQuotedWikilink(value: string): string {
+  if (value.startsWith('"[[') && value.endsWith(']]"')) return value;
+  if (value.startsWith("[[") && value.endsWith("]]")) return `"${value}"`;
+  return `"[[${value}]]"`;
+}
+
 export function createCreateRelatedTaskService(
   vaultAdapter: IVaultAdapter,
   genericAssetCreationService: GenericAssetCreationService,
   resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
+  onCreated?: OnCreatedCallback,
+  classResolver: ClassRefResolver = NULL_CLASS_RESOLVER,
 ): IGroundingService {
   return {
     async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
@@ -90,14 +121,19 @@ export function createCreateRelatedTaskService(
         propertyValues[explicitParentProperty] = `"[[${parentFile.basename}]]"`;
       }
 
-      await genericAssetCreationService.createAsset({
+      const createdFile = await genericAssetCreationService.createAsset({
         className: "ems__Task",
         label,
         folderPath,
         propertyValues,
         parentFile,
         parentMetadata,
+        classResolver,
       });
+
+      if (onCreated) {
+        await onCreated(createdFile);
+      }
     },
   };
 }
@@ -106,6 +142,8 @@ export function createCreateRelatedProjectService(
   vaultAdapter: IVaultAdapter,
   genericAssetCreationService: GenericAssetCreationService,
   resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
+  onCreated?: OnCreatedCallback,
+  classResolver: ClassRefResolver = NULL_CLASS_RESOLVER,
 ): IGroundingService {
   return {
     async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
@@ -136,45 +174,22 @@ export function createCreateRelatedProjectService(
         propertyValues[explicitParentProperty] = `"[[${parentFile.basename}]]"`;
       }
 
-      await genericAssetCreationService.createAsset({
+      const createdFile = await genericAssetCreationService.createAsset({
         className: "ems__Project",
         label,
         folderPath,
         propertyValues,
         parentFile,
         parentMetadata,
+        classResolver,
       });
+
+      if (onCreated) {
+        await onCreated(createdFile);
+      }
     },
   };
 }
-
-/**
- * Format a wikilink value as the quoted YAML form (`"[[X]]"`) consistently with
- * the plugin's hand-rolled `createAsset` frontmatter writer
- * (`ServiceRegistryPopulator.toQuotedWikilink`). Idempotent — already-quoted
- * inputs round-trip unchanged; bare/unwrapped values are re-wrapped.
- */
-function toQuotedWikilink(value: string): string {
-  if (value.startsWith('"[[') && value.endsWith(']]"')) return value;
-  if (value.startsWith("[[") && value.endsWith("]]")) return `"${value}"`;
-  return `"[[${value}]]"`;
-}
-
-/**
- * Default `ClassRefResolver` used when CLI callers don't supply one. The
- * legacy plugin path resolved UID-canon `[[<uuid>]]` references through
- * Obsidian's `metadataCache`; in CLI runtime there is no resolver, so this
- * fallback returns `null` for every UUID. Symbolic refs (`[[ems__Area]]`)
- * continue to round-trip through `WikiLinkHelpers.resolveSymbolic` without
- * resolver assistance.
- *
- * Production CLI usage that needs UID-canon resolution should inject a real
- * resolver (e.g. one that scans the vault for `<uuid>.md` and reads
- * `exo__Asset_label`). Phase 3.5 keeps parity with plugin's `createAsset` on
- * vaults that still use symbolic refs for `exo__Instance_class`; the UID-canon
- * variant is a follow-up tracked in #3164's review checklist.
- */
-const NULL_CLASS_RESOLVER: ClassRefResolver = () => null;
 
 /**
  * Shared factory for the `createAsset` `service_call` grounding — ports the


### PR DESCRIPTION
Closes #3166.

## Summary

Replaces ~290 LOC of inlined `service_call` handler logic in `ServiceRegistryPopulator.ts` (`createAsset`, `createRelatedTask`, `createRelatedProject`) with thin wrappers delegating to the storage-agnostic shared factories from `@kitelev/exocortex-services` (Phase 3.5 ship).

**Net: -160 LOC** (137 insertions, 297 deletions). ≥50 LOC issue requirement met **3x**.

## Scope deviation from issue body — IMPORTANT

Issue body literal wording reads:

> No longer registered — handled by `create_instance` Grounding type via GroundingExecutor

**Reinterpreted in this PR as:** *"no longer registered as inline 290 LOC; now thin wrappers delegating to shared factory"*.

### Why deviate

Pre-flight caller audit found:

- **Phase 4a (#3165, PR #3233) migrated *only* `vault-2025` Groundings** to `create_instance` form.
- **`exocortex-starter-kit/exocmd/creation/`** (5 Groundings — distributed to new users)
- **`packages/starter-kit-fixtures/exocmd/creation/`** (5 mirror files)
- **`packages/obsidian-plugin/tests/e2e/test-vault/exocmd/creation/`** (2 fixtures)

…all still reference `exocmd__Grounding_serviceId: createAsset|createRelatedTask|createRelatedProject`. Removing the registrations outright would break the e2e suite + starter-kit for any new user clone — exactly the failure mode the original `≥1 release soak` requirement was designed to surface.

**User explicitly overrode the soak gate** and confirmed **Option A** (thin-wrapper delegation) after a BLOCKED ping documented the consumer audit. starter-kit / fixtures / e2e migration is deferred to a future PR (per cascade-cap ≤15 rule).

Consumer outcome: **zero breakage** — existing Groundings continue working via the wrappers; LOC reduction goal achieved through inline-logic removal in the plugin.

## What changed

### `packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts`

- `createAsset` registration **moved into the `if (vaultAdapter)` block** — delegates to `createCreateAssetService(vaultAdapter, fileSystemAdapter, classResolver, targetResolver)`.
- `createRelatedTask` + `createRelatedProject` replaced with delegation to `createCreateRelatedTaskService` / `createCreateRelatedProjectService` plus the new `onCreated` callback (opens the freshly-created asset in a workspace tab, preserves the existing UX without leaking Obsidian dependencies into the shared package).
- Removed dead helpers: `toQuotedWikilink`, unused imports (`WikiLinkHelpers`, `DateFormatter`). `wrapService` + `FrontmatterService` retained — still used by other handlers.

### `packages/services/src/grounding-service-factories.ts`

- Added `OnCreatedCallback` type + optional `onCreated` parameter to `createCreateRelatedTaskService` / `createCreateRelatedProjectService` (additive; CLI callers pass nothing, behaviour unchanged).
- Added optional `classResolver` parameter to both factories so the plugin can inject its `metadataCache`-backed resolver for UID-canon class refs.
- Hoisted `NULL_CLASS_RESOLVER` + `toQuotedWikilink` to the top of the file so all factories can reference them.

### `ServiceRegistryPopulator.test.ts`

- `createAsset` now vault-dependent — `should register 9 services` + `should register all expected service IDs` + `should not register vault-dependent services when vaultAdapter is absent` updated.
- Three `createAsset` describe blocks + the orphan-prevention regression block get their own `beforeEach` using `createMockDeps(true)` + matching `vaultAdapter.getFrontmatter` mock so the shared-factory path receives the same parent metadata that the legacy inline path read from `app.metadataCache`.

## Caller audit (soak replacement)

| Source | Result |
|---|---|
| `packages/{obsidian-plugin,cli,services}/src` | 0 production callers outside the three handler files |
| `~/.n8n` workflows | 0 callers |
| `~/IdeaProjects/exocortex/telegram-bot` | 0 callers |
| `vault-2025` user Groundings | only via shared `exocmd` submodule (`assetspaces/exocmd/creation/c84e2e08-…`), continues working via thin wrapper |

## Tests

- `ServiceRegistryPopulator.test.ts` — **83/83 pass** (test setup updated for new vault-dependent createAsset).
- `createRelatedTask.test.ts` + `createRelatedProject.test.ts` + `CliServiceRegistryPopulator.test.ts` — **25/25 pass** (no changes needed; `onCreated` is optional and backwards-compatible).
- Workspace `npm run check:types` + `npm run lint` — green.
- BDD coverage 204/204 (100%). Archgate 13/13 pass.

## Test plan

- [x] Plugin `ServiceRegistryPopulator.test.ts` green (83/83)
- [x] CLI grounding factory tests green (25/25)
- [x] `check:types` clean
- [x] `lint` clean (2 pre-existing warnings unrelated)
- [x] BDD coverage 100%
- [x] Archgate ADR pass
- [ ] CI 13/13 required checks green (awaiting)

## Related

- Issue: #3166
- RFC v2 asset: `2f3f640b-c5e0-4873-8c56-c390b8402cfa`
- Prerequisite: #3165 (Phase 4a, PR #3233 merged 2026-05-23)
- Unblocks: #3167 (Phase 5 — cleanup legacy JSON parser)