### PR TITLE
feat(parser): RFC 918a2b65 Phase 2 — typed predicates for service_call + property_append

### DIFF
--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -102,6 +102,18 @@ export interface GroundingDefinition {
   /** RFC 31c1a0be Phase 1: UUID of SubstitutionToken instance whose label
    *  (e.g. `$nowLocal`) becomes the substituted value. */
   readonly targetValueSubstitution?: string;
+  /** RFC 918a2b65 Phase 1: Opaque JSON config payload for `service_call`
+   *  groundings. Resolved through `substituteVariables` before `JSON.parse`;
+   *  merged into `userInput` defaults at `GroundingExecutor.executeServiceCall`.
+   *  Replaces legacy `targetValue` for service_call semantics. Disjoint with
+   *  `appendExpression`. */
+  readonly serviceCallPayload?: string;
+  /** RFC 918a2b65 Phase 1: Substitution expression for `property_append`
+   *  groundings. Resolved by `substituteVariables` (supports standard tokens +
+   *  property-accessor postfix like `$target.<property>`). Replaces legacy
+   *  `targetValue` for property_append semantics. Disjoint with
+   *  `serviceCallPayload`. */
+  readonly appendExpression?: string;
   /** SPARQL UPDATE query (for sparql_update) */
   readonly sparqlUpdate?: string;
   /** Ordered sub-steps (for composite type) */

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -107,6 +107,12 @@ export class CommandResolver {
    * remove after one minor release window.
    */
   private readonly _legacyPropertyDefaultsWarnedGroundings = new Set<string>();
+  /** RFC 918a2b65 Phase 2: per-Grounding-uid suppression for the transitional
+   *  legacy-targetValue warn (mirrors `_legacyPropertyDefaultsWarnedGroundings`
+   *  pattern). Surface change audibly once per Grounding to avoid log noise on
+   *  re-parses. Remove together with the deprecation warn after vault migration
+   *  completes and the property asset 321b5623 is deleted. */
+  private readonly _legacyTargetValueWarnedGroundings = new Set<string>();
 
   /**
    * @param tripleStore - RDF triple store backing vault assets.
@@ -996,6 +1002,34 @@ export class CommandResolver {
     } else if (substitutionRefRaw) {
       targetValueSubstitution = substitutionRefRaw;
     }
+    // RFC 918a2b65 Phase 1 typed predicates for service_call + property_append.
+    // Replace legacy `Grounding_targetValue` for those two grounding types.
+    // Both are plain string literals (JSON config or substitution expression);
+    // resolution is identical to `targetValueLiteral`. Parser piles them onto
+    // `GroundingDefinition`; executor dispatches in priority chain (new
+    // predicates first, legacy fallback with console.warn).
+    const serviceCallPayload = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("Grounding_serviceCallPayload"),
+    );
+    const appendExpression = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("Grounding_appendExpression"),
+    );
+    // RFC 918a2b65 Phase 2 — transitional deprecation warn when legacy
+    // `Grounding_targetValue` is paired with a grounding_type that has a
+    // dedicated typed predicate. Mirrors the RFC v2 Phase 5 warn pattern
+    // (one-shot per Grounding-uid).
+    if (
+      targetValue &&
+      (type === GroundingType.SERVICE_CALL || type === GroundingType.PROPERTY_APPEND) &&
+      !this._legacyTargetValueWarnedGroundings.has(uid)
+    ) {
+      this.logger.warn(
+        `Grounding ${uid}: deprecated exocmd__Grounding_targetValue used for ${typeStr} — migrate to exocmd__Grounding_${type === GroundingType.SERVICE_CALL ? "serviceCallPayload" : "appendExpression"} per RFC 918a2b65 (the legacy predicate will be removed after vault migration).`,
+      );
+      this._legacyTargetValueWarnedGroundings.add(uid);
+    }
     const isDefinedBy = await this.getObsidianWikilinkValue(subject, Namespace.EXOCMD.term("Grounding_isDefinedBy"));
     const sparqlUpdate = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Grounding_sparqlUpdate"));
     // Issue #3212: `Grounding_targetClass` must yield UID-form for UUID-canon
@@ -1124,6 +1158,8 @@ export class CommandResolver {
       targetValueRef: targetValueRef ?? undefined,
       targetValueLiteral: targetValueLiteral ?? undefined,
       targetValueSubstitution: targetValueSubstitution ?? undefined,
+      serviceCallPayload: serviceCallPayload ?? undefined,
+      appendExpression: appendExpression ?? undefined,
       sparqlUpdate: sparqlUpdate ?? undefined,
       steps,
       targetClass: targetClass ?? undefined,

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -52,6 +52,32 @@ function extractClassFromTargetValue(
 }
 
 /**
+ * RFC 918a2b65 Phase 2 — translate a `Grounding_targetValueRef` value into a
+ * class label for the `service_call/updateProperty` class-flip dispatch
+ * (Convert to Task / Convert to Project). The ref arrives as one of:
+ *   - bare label `"ems__Task"` (older vault clones, test fixtures, CLI usage
+ *     without TBox warm-up);
+ *   - bare UUID `"1b20a8f0-..."` (post-#3165 migration, UUID-canon TBox).
+ *
+ * Returns the class label (`"ems__Task"` or `"ems__Project"`) if recognised;
+ * undefined otherwise. Coupled to the same two classes the legacy
+ * `extractClassFromTargetValue` recognises — extending this requires a
+ * separate RFC for class-flip generalisation (`class_convert` grounding type).
+ */
+function resolveClassFlipTarget(
+  ref: string | undefined,
+): string | undefined {
+  if (!ref) return undefined;
+  // UUID-canon match — the only two class-flip targets in scope today.
+  if (ref === "1b20a8f0-d745-4e93-91db-4531b3df120e") return "ems__Task";
+  if (ref === "7db5eeff-718a-49b0-8d2b-39b084a356e3") return "ems__Project";
+  // Bare label match (CommandResolver may have downgraded to label-form when
+  // the class TBox file was absent from the resolution store, see #3220).
+  if (ref === "ems__Task" || ref === "ems__Project") return ref;
+  return undefined;
+}
+
+/**
  * Input parameters collected from the user (for service_call groundings).
  * UI layer collects these via modals; CLI via interactive prompts or --arg flags.
  */
@@ -489,11 +515,23 @@ export class GroundingExecutor {
     // targetValue (driven via inputSchema+userInput) and so flows past this
     // short-circuit into the registered updateProperty service below.
     if (serviceId === "updateProperty") {
-      const targetClass = extractClassFromTargetValue(grounding.targetValue);
-      if (targetClass === "ems__Task") {
+      // RFC 918a2b65 Phase 2 — priority chain: targetValueRef (typed) wins,
+      // legacy targetValue (string/wikilink) is the deprecated fallback.
+      // targetValueRef is the canonical class-flip predicate after Phase 5b;
+      // it can be either UUID-canon (post-#3165 migration) or bare label
+      // (older stores without TBox lookup). Both shapes are accepted.
+      const refClass = resolveClassFlipTarget(grounding.targetValueRef);
+      if (refClass === "ems__Task") {
         return await this.executeConvertToTask(filePath);
       }
-      if (targetClass === "ems__Project") {
+      if (refClass === "ems__Project") {
+        return await this.executeConvertToProject(filePath);
+      }
+      const legacyClass = extractClassFromTargetValue(grounding.targetValue);
+      if (legacyClass === "ems__Task") {
+        return await this.executeConvertToTask(filePath);
+      }
+      if (legacyClass === "ems__Project") {
         return await this.executeConvertToProject(filePath);
       }
     }
@@ -531,10 +569,16 @@ export class GroundingExecutor {
     if (grounding.isDefinedBy) {
       mergedInput = { isDefinedBy: grounding.isDefinedBy, ...(mergedInput ?? {}) };
     }
-    if (grounding.targetValue) {
+    // RFC 918a2b65 Phase 2 — priority chain: serviceCallPayload (typed) first,
+    // legacy targetValue is the deprecated fallback. CommandResolver emits a
+    // one-shot deprecation warn at parse time when targetValue is used for
+    // service_call/property_append, so this dispatch stays silent. Both fields
+    // may briefly coexist mid-migration — the typed predicate wins definitively.
+    const payloadSource = grounding.serviceCallPayload ?? grounding.targetValue;
+    if (payloadSource) {
       try {
         const substituted = this.substituteVariables(
-          grounding.targetValue,
+          payloadSource,
           targetIRI,
           userInput,
         );
@@ -546,7 +590,8 @@ export class GroundingExecutor {
           mergedInput = { ...defaults, ...(mergedInput ?? {}) };
         }
       } catch {
-        // Not valid JSON — ignore (e.g. plain string targetValue)
+        // Not valid JSON — ignore (e.g. plain string targetValue used as class
+        // ref for `updateProperty` class-flip dispatch handled above).
       }
     }
 
@@ -1209,10 +1254,14 @@ export class GroundingExecutor {
         error: "property_append requires targetProperty",
       };
     }
-    if (grounding.targetValue === undefined) {
+    // RFC 918a2b65 Phase 2 — priority chain: appendExpression (typed) first,
+    // legacy targetValue is the deprecated fallback. CommandResolver emits the
+    // one-shot deprecation warn at parse time for legacy use.
+    const exprSource = grounding.appendExpression ?? grounding.targetValue;
+    if (exprSource === undefined) {
       return {
         success: false,
-        error: "property_append requires targetValue",
+        error: "property_append requires appendExpression",
       };
     }
 
@@ -1221,7 +1270,7 @@ export class GroundingExecutor {
       this.frontmatterService.parseObject(content) ?? {};
 
     const resolvedValue = this.substituteVariables(
-      grounding.targetValue,
+      exprSource,
       targetIRI,
       userInput,
       targetFrontmatter,

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -1239,7 +1239,10 @@ export class GroundingExecutor {
    *
    * Errors (plain Error with structured message — `GroundingError` class is
    * not yet introduced in the codebase; existing executors also use Error):
-   * - Missing `targetProperty` / `targetValue` on the grounding definition.
+   * - Missing `targetProperty` / `appendExpression` (or legacy `targetValue`)
+   *   on the grounding definition. RFC 918a2b65 Phase 2: `appendExpression`
+   *   is the canonical predicate; legacy `targetValue` is the deprecated
+   *   transitional fallback.
    * - `$target.<prop>` resolved to undefined / null / array.
    */
   private async executePropertyAppend(

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.property_append.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.property_append.test.ts
@@ -194,7 +194,9 @@ describe("GroundingExecutor.property_append (Issue #3132)", () => {
       const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
 
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/targetValue/i);
+      // RFC 918a2b65 Phase 2 — error message now references appendExpression
+      // (the new canonical predicate) instead of legacy targetValue.
+      expect(result.error).toMatch(/appendExpression/i);
     });
   });
 });

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -3430,4 +3430,277 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       expect(content).toContain("exo__Asset_label: backward compat");
       expect(content).toContain("ems__Task");
     });
+
+  // -- RFC 918a2b65 Phase 2 — typed predicates for service_call + property_append --
+  describe("RFC 918a2b65 typed predicates", () => {
+    describe("service_call: serviceCallPayload (JSON merge)", () => {
+      it("merges serviceCallPayload JSON as defaults into userInput", async () => {
+        const mockService = {
+          execute: jest.fn().mockResolvedValue(undefined),
+        };
+        registry.register("updateProperty", mockService);
+
+        const grounding = makeGrounding({
+          type: GroundingType.SERVICE_CALL,
+          targetProperty: "updateProperty",
+          serviceCallPayload: '{"property":"ems__Effort_parent"}',
+        });
+
+        const userInput = { value: "[[some-asset]]" };
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH, userInput);
+
+        expect(result.success).toBe(true);
+        expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
+          property: "ems__Effort_parent",
+          value: "[[some-asset]]",
+        });
+      });
+
+      it("serviceCallPayload wins over legacy targetValue when both present", async () => {
+        const mockService = {
+          execute: jest.fn().mockResolvedValue(undefined),
+        };
+        registry.register("updateProperty", mockService);
+
+        const grounding = makeGrounding({
+          type: GroundingType.SERVICE_CALL,
+          targetProperty: "updateProperty",
+          serviceCallPayload: '{"property":"new_predicate"}',
+          targetValue: '{"property":"old_predicate"}',
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
+          property: "new_predicate",
+        });
+      });
+
+      it("falls back to legacy targetValue when serviceCallPayload absent (transitional)", async () => {
+        const mockService = {
+          execute: jest.fn().mockResolvedValue(undefined),
+        };
+        registry.register("updateProperty", mockService);
+
+        const grounding = makeGrounding({
+          type: GroundingType.SERVICE_CALL,
+          targetProperty: "updateProperty",
+          targetValue: '{"property":"ems__Effort_status"}',
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
+          property: "ems__Effort_status",
+        });
+      });
+
+      it("substitutes $target inside serviceCallPayload before JSON.parse", async () => {
+        const mockService = {
+          execute: jest.fn().mockResolvedValue(undefined),
+        };
+        registry.register("createAsset", mockService);
+
+        const grounding = makeGrounding({
+          type: GroundingType.SERVICE_CALL,
+          targetProperty: "createAsset",
+          serviceCallPayload:
+            '{"prototype":"$target","instanceClass":"ems__Task","folder":"03 Knowledge/inbox"}',
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
+          prototype: TARGET_IRI,
+          instanceClass: "ems__Task",
+          folder: "03 Knowledge/inbox",
+        });
+      });
+    });
+
+    describe("service_call: class-flip via targetValueRef (Convert to Task / Project)", () => {
+      it("dispatches Convert to Task when targetValueRef is the ems__Task UUID", async () => {
+        const reader2 = createMockReader(
+          "---\nexo__Instance_class: '[[ems__Project]]'\n---",
+        );
+        const writer2 = createMockWriter();
+        const executor2 = new GroundingExecutor(reader2, writer2, registry);
+
+        const grounding = makeGrounding({
+          type: GroundingType.SERVICE_CALL,
+          targetProperty: "updateProperty",
+          targetValueRef: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+        });
+
+        const result = await executor2.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer2.updateFile.mock.calls[0];
+        expect(content).toContain("ems__Task");
+      });
+
+      it("dispatches Convert to Project when targetValueRef is the ems__Project UUID", async () => {
+        const reader2 = createMockReader(
+          "---\nexo__Instance_class: '[[ems__Task]]'\n---",
+        );
+        const writer2 = createMockWriter();
+        const executor2 = new GroundingExecutor(reader2, writer2, registry);
+
+        const grounding = makeGrounding({
+          type: GroundingType.SERVICE_CALL,
+          targetProperty: "updateProperty",
+          targetValueRef: "7db5eeff-718a-49b0-8d2b-39b084a356e3",
+        });
+
+        const result = await executor2.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer2.updateFile.mock.calls[0];
+        expect(content).toContain("ems__Project");
+      });
+
+      it("accepts targetValueRef in bare-label form (#3220 downgrade path)", async () => {
+        const reader2 = createMockReader(
+          "---\nexo__Instance_class: '[[ems__Project]]'\n---",
+        );
+        const writer2 = createMockWriter();
+        const executor2 = new GroundingExecutor(reader2, writer2, registry);
+
+        const grounding = makeGrounding({
+          type: GroundingType.SERVICE_CALL,
+          targetProperty: "updateProperty",
+          targetValueRef: "ems__Task",
+        });
+
+        const result = await executor2.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer2.updateFile.mock.calls[0];
+        expect(content).toContain("ems__Task");
+      });
+
+      it("targetValueRef wins over legacy targetValue when both present (precedence)", async () => {
+        const reader2 = createMockReader(
+          "---\nexo__Instance_class: '[[ems__Project]]'\n---",
+        );
+        const writer2 = createMockWriter();
+        const executor2 = new GroundingExecutor(reader2, writer2, registry);
+
+        const grounding = makeGrounding({
+          type: GroundingType.SERVICE_CALL,
+          targetProperty: "updateProperty",
+          targetValueRef: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+          targetValue: "ems__Project",
+        });
+
+        const result = await executor2.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer2.updateFile.mock.calls[0];
+        expect(content).toContain("ems__Task");
+      });
+
+      it("falls back to legacy targetValue class-flip when targetValueRef absent (regression)", async () => {
+        const reader2 = createMockReader(
+          "---\nexo__Instance_class: '[[ems__Project]]'\n---",
+        );
+        const writer2 = createMockWriter();
+        const executor2 = new GroundingExecutor(reader2, writer2, registry);
+
+        const grounding = makeGrounding({
+          type: GroundingType.SERVICE_CALL,
+          targetProperty: "updateProperty",
+          targetValue: "ems__Task",
+        });
+
+        const result = await executor2.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer2.updateFile.mock.calls[0];
+        expect(content).toContain("ems__Task");
+      });
+    });
+
+    describe("property_append: appendExpression", () => {
+      it("resolves appendExpression via substituteVariables", async () => {
+        const reader2 = createMockReader(
+          "---\nexo__Asset_label: My Asset\naliases:\n  - existing\n---",
+        );
+        const writer2 = createMockWriter();
+        const executor2 = new GroundingExecutor(reader2, writer2, registry);
+
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_APPEND,
+          targetProperty: "aliases",
+          appendExpression: "$target.exo__Asset_label",
+        });
+
+        const result = await executor2.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer2.updateFile.mock.calls[0];
+        expect(content).toContain("My Asset");
+        expect(content).toContain("existing");
+      });
+
+      it("appendExpression wins over legacy targetValue when both present", async () => {
+        const reader2 = createMockReader(
+          "---\nexo__Asset_label: Winner\nfallbackField: Loser\naliases: []\n---",
+        );
+        const writer2 = createMockWriter();
+        const executor2 = new GroundingExecutor(reader2, writer2, registry);
+
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_APPEND,
+          targetProperty: "aliases",
+          appendExpression: "$target.exo__Asset_label",
+          targetValue: "$target.fallbackField",
+        });
+
+        const result = await executor2.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer2.updateFile.mock.calls[0];
+        const aliasesMatch = content.match(/aliases:[\s\S]*?(?=\n[^\s-]|$)/);
+        expect(aliasesMatch).not.toBeNull();
+        expect(aliasesMatch![0]).toContain("Winner");
+        expect(aliasesMatch![0]).not.toContain("Loser");
+      });
+
+      it("falls back to legacy targetValue when appendExpression absent (regression)", async () => {
+        const reader2 = createMockReader(
+          "---\nexo__Asset_label: Legacy Label\naliases: []\n---",
+        );
+        const writer2 = createMockWriter();
+        const executor2 = new GroundingExecutor(reader2, writer2, registry);
+
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_APPEND,
+          targetProperty: "aliases",
+          targetValue: "$target.exo__Asset_label",
+        });
+
+        const result = await executor2.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer2.updateFile.mock.calls[0];
+        expect(content).toContain("Legacy Label");
+      });
+
+      it("fails-loud when neither appendExpression nor targetValue is set", async () => {
+        const grounding = makeGrounding({
+          type: GroundingType.PROPERTY_APPEND,
+          targetProperty: "aliases",
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("appendExpression");
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes RFC 918a2b65-a19f-4c38-bbce-86d3e58400bb Phase 2 (successor to RFC 31c1a0be). Adds 2 typed predicates on `GroundingDefinition` + dispatch logic in `GroundingExecutor`, replacing legacy `exocmd__Grounding_targetValue` for `service_call` and `property_append` grounding types.

**RFC source:** `vault-exodev/inbox/918a2b65-a19f-4c38-bbce-86d3e58400bb.md`
**Parent RFC:** 31c1a0be-bc72-4a1e-8426-75e7b0ddedd2 (Grounding as first-class RDF)

## TBox prerequisites (already merged)

- `kitelev/exoas-exocmd@33e9b26`: 2 new `exo__StringProperty` assets
  - `exocmd__Grounding_serviceCallPayload` → `aaca11ba-48ab-4f22-bf64-7cb0f136b69d`
  - `exocmd__Grounding_appendExpression` → `b6f51a69-8310-48db-aedc-63865e2a8c66`
- vault-2025 submodule pointer bump: commit `0740b1e4e`
- vault-exodev submodule pointer bump: commit `aa3e4a3`

## Code changes (3 files)

### `CommandDefinition.ts` — 2 new optional fields on `GroundingDefinition`

### `CommandResolver.ts`
- 2 new literal loaders for the typed predicates
- Pipe into `GroundingDefinition` construction
- One-shot per-Grounding-uid transitional deprecation warn when legacy `targetValue` paired with `service_call` / `property_append` (mirrors the RFC v2 Phase 5 warn pattern at L1056-1064)

### `GroundingExecutor.ts`
- **Class-flip dispatch** (`executeServiceCall` L491+): priority chain `targetValueRef` (typed, UUID-canon or label) > legacy `targetValue` via `extractClassFromTargetValue`. New helper `resolveClassFlipTarget` accepts both ems__Task / ems__Project UUIDs (`1b20a8f0`, `7db5eeff`) and bare labels (the #3220 downgrade path).
- **JSON merge** (`executeServiceCall` L509+): priority chain `serviceCallPayload` > legacy `targetValue`. Both feed the same `substituteVariables` → `JSON.parse` pipeline; `serviceCallPayload` wins definitively when both present.
- **Property append** (`executePropertyAppend` L1200+): priority chain `appendExpression` > legacy `targetValue`. Error message updated. Property-accessor postfix semantics unchanged (delegated to `substituteVariables`).

## Test coverage

- `GroundingExecutor.test.ts`: **+13 cases** in new "RFC 918a2b65 typed predicates" describe block.
- `GroundingExecutor.property_append.test.ts`: 1 assertion updated to match new error message text.

## Test results (local)

| Suite | Pass | Total |
|---|---|---|
| `packages/exocortex/tests/unit/services/` | 1190 | 1190 |
| `GroundingExecutor.test.ts` | 150 | 150 (137 baseline + 13 new) |
| `CommandResolver.test.ts` | 69 | 69 (unchanged) |
| `tsc --noEmit` | ✅ clean | — |
| Pre-commit hooks (BDD + ArchGate) | ✅ 13/13 ADR | — |

## Backward compatibility

Legacy `targetValue` paths preserved with priority-chain fallback + one-shot per-Grounding deprecation warn. Vault migration (Phase 3) will strip `targetValue` from active groundings; legacy code path remains reachable for third-party vaults that haven't migrated yet. Phase 4 (legacy code removal) deferred to follow-up RFC after 1-2 week observation window.

## Cross-repo coordination

- TBox pushed in advance (above).
- Starter-kit migration: deferred to separate PR per RFC §Q5 decision.
- Property asset deletion (`321b5623`): Phase 5b, after vault migration verifies CQ4 `legacyCount=0`.

## Auto-merge discipline (CRITICAL)

Per `exocortex/CLAUDE.md` §"Auto-merge discipline" — touches `GroundingExecutor.ts` + `CommandResolver.ts` → **manual merge only**. NO `gh pr merge --auto`. Workflow: CI green → code-reviewer agent → fix HIGH/CRITICAL → advisor() round-2 → fix catches → manual `gh pr merge --squash --delete-branch`.

## Test plan

- [x] Local typecheck + unit tests green (1190 pass)
- [ ] 14/14 required CI checks green (archgate · detect-changes · e2e-shard 1-6 · lint · parity-gate · test-bdd · test-component · test-coverage · typecheck)
- [ ] code-reviewer agent — apply HIGH/CRITICAL
- [ ] advisor() round-2 — apply catches
- [ ] Manual `gh pr merge --squash --delete-branch`
- [ ] Auto-release succeeds + post-merge UI smoke (Convert to Task + Copy Label to Aliases + Mark Done regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)