### PR TITLE
test(e2e): migrate 3 e2e fixtures to RFC 918a2b65 typed predicates

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/creation/c84e2e08-8fb9-42e7-9112-11864fb13a09.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/creation/c84e2e08-8fb9-42e7-9112-11864fb13a09.md
@@ -7,7 +7,7 @@ exo__Instance_class:
 exocmd__Grounding_type: "service_call"
 exocmd__Grounding_serviceId: "createAsset"
 exocmd__Grounding_inputSchema: '{"type":"object","properties":{"label":{"type":"string","title":"Note title"}},"required":["label"]}'
-exocmd__Grounding_targetValue: '{"prototype":"ztlk__FleetingNotePrototype","folder":"03 Knowledge/inbox"}'
+exocmd__Grounding_serviceCallPayload: '{"prototype":"ztlk__FleetingNotePrototype","folder":"03 Knowledge/inbox"}'
 aliases:
   - "Create note grounding"
 ---

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/maintenance/c4616dcd-3832-4812-b289-0968510fb8be.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/maintenance/c4616dcd-3832-4812-b289-0968510fb8be.md
@@ -6,7 +6,7 @@ exo__Instance_class:
   - "[[exocmd__Grounding]]"
 exocmd__Grounding_type: "service_call"
 exocmd__Grounding_serviceId: "updateProperty"
-exocmd__Grounding_targetValue: '{"property":"ems__Effort_result"}'
+exocmd__Grounding_serviceCallPayload: '{"property":"ems__Effort_result"}'
 exocmd__Grounding_inputSchema: '{"type":"object","properties":{"value":{"type":"string","title":"Result"}},"required":["value"]}'
 aliases:
   - "Set result value"

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/planning/85687461-c2df-4d1b-819b-0c3ae0ab3741.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/planning/85687461-c2df-4d1b-819b-0c3ae0ab3741.md
@@ -6,7 +6,7 @@ exo__Instance_class:
   - "[[exocmd__Grounding]]"
 exocmd__Grounding_type: "service_call"
 exocmd__Grounding_serviceId: "updateProperty"
-exocmd__Grounding_targetValue: '{"property":"ems__Effort_plannedStartTimestamp"}'
+exocmd__Grounding_serviceCallPayload: '{"property":"ems__Effort_plannedStartTimestamp"}'
 exocmd__Grounding_inputSchema: '{"type":"object","properties":{"value":{"type":"string","title":"Planned start (date)"}},"required":["value"]}'
 aliases:
   - "Set planned start timestamp"


### PR DESCRIPTION
## Summary

Closes the e2e test-vault mirror of [RFC 918a2b65](https://github.com/kitelev/vault-exodev/blob/main/inbox/918a2b65-a19f-4c38-bbce-86d3e58400bb.md) Phase 3. Migrates 3 legacy `exocmd__Grounding_targetValue` fixtures aligned with the production vault migration in [kitelev/exoas-exocmd@1f8d889](https://github.com/kitelev/exoas-exocmd/commit/1f8d889) and the starter-kit mirror in [kitelev/exocortex-starter-kit#101](https://github.com/kitelev/exocortex-starter-kit/pull/101).

## Migration (all → `serviceCallPayload`)

- `planning/85687461` (Set planned start timestamp)
- `creation/c84e2e08` ([Grounding] Create FleetingNote — typo `Prototyrpe` preserved)
- `maintenance/c4616dcd` (Set result value)

## Gate

CQ4 `legacyCount=0` precondition for property asset `321b5623` deletion (RFC §Phase 5b):

| Location | Status |
|---|---|
| `kitelev/exoas-exocmd` (vault TBox submodule) | ✅ migrated |
| `kitelev/exocortex` e2e test-vault | this PR |
| `kitelev/exocortex-starter-kit` | PR #101 |

Once all three merge, the property asset can be removed in a follow-up `exoas-exocmd` commit.

## Test plan

- [x] Local migration script applied to test-vault fixtures
- [ ] 14/14 required CI checks green
- [ ] Auto-merge OK (no source code changes — fixtures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)