### PR TITLE
feat(properties): exo__Property_displayName resolver (RFC-030)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
@@ -66,10 +66,15 @@ interface PatchRecord {
 
 /**
  * Unwrap an Obsidian-style wikilink to a canonical UID.
- *   "[[uuid]]"        → "uuid"
- *   "[[uuid|alias]]"  → "uuid"
- *   "uuid"            → "uuid" (when shape matches UUID v4 layout)
- *   anything else     → null
+ *   "[[uuid]]"              → "uuid"
+ *   "[[uuid|alias]]"        → "uuid"
+ *   "[[path/to/uuid]]"      → "uuid"  (strips path prefix; UID-canon TBox
+ *                                       does not emit path-qualified links,
+ *                                       but legacy authoring tools may —
+ *                                       defensive parsing avoids silent
+ *                                       BFS-closure miss for class refs)
+ *   "uuid"                  → "uuid"  (when shape matches UUID v4 layout)
+ *   anything else           → null
  *
  * Exported for unit testing.
  */
@@ -78,7 +83,17 @@ export function unwrapWikilinkUid(value: unknown): string | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
   const wlMatch = trimmed.match(/^\[\[([^\]|]+)(?:\|[^\]]*)?\]\]$/);
-  if (wlMatch) return wlMatch[1].trim();
+  if (wlMatch) {
+    // Strip any path prefix: "some/path/uuid" → "uuid". Mirrors the leniency
+    // pattern from PrintNameRuleService.cleanClassValue for cross-resolver
+    // consistency.
+    const inner = wlMatch[1].trim();
+    const lastSegment = inner.split("/").pop()?.trim() ?? "";
+    if (UUID_REGEX.test(lastSegment)) return lastSegment;
+    // Path-stripped form isn't a UUID — return null so the caller can skip
+    // (consistent with non-UUID symbolic wikilink behavior).
+    return null;
+  }
   if (UUID_REGEX.test(trimmed)) return trimmed;
   return null;
 }

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
@@ -2,26 +2,52 @@ import { Plugin, TFile } from "obsidian";
 
 /**
  * PropertiesLabelPatch - Patches Obsidian's Properties block to show human-readable
- * predicate labels (e.g. "Effort Area" instead of `ems__Effort_area`) and makes
- * them clickable to open the predicate definition asset.
+ * predicate labels and makes them clickable to open the predicate definition asset.
  *
- * Resolution strategy (resolvePredicate):
- *  1. Filename match — a file whose basename equals the raw predicate name
- *  2. Aliases match — a file whose frontmatter `aliases` contains the raw predicate
+ * Resolution strategy (RFC-030 — exo__Property_displayName, 2026-05-23):
+ *  1. At init time walk the class hierarchy in metadataCache, computing the set
+ *     of UIDs that descend from exo__Property via exo__Class_superClass triples
+ *     (subClass closure). Cache as `propertyClassUids`.
+ *  2. Index only assets whose `exo__Instance_class` intersects propertyClassUids
+ *     (rdf:type filter). All non-property assets are skipped — this protects
+ *     against label-collision shadowing from ABox concepts.
+ *  3. Matching key for cache: `exo__Asset_label` (TBox convention: label of a
+ *     property asset equals the raw predicate name, e.g. "ems__Effort_area").
+ *  4. Display text: `exo__Property_displayName` if present (non-empty), else
+ *     fallback to `exo__Asset_label` (i.e. the raw predicate name itself, which
+ *     keeps the patch a no-op visually until a displayName is authored).
+ *  5. Collision handling: first-write-wins + `console.warn` (deterministic by
+ *     `vault.getMarkdownFiles()` enumeration order). Data-side collisions are
+ *     surfaced but not auto-resolved.
  *
- * Both paths require the matched file to have a non-empty `exo__Asset_label` that
- * differs from the raw predicate; that label is what replaces the key text. If no
- * definition asset is found, the predicate row is left untouched (Scenario C fallback).
+ * Behavior changes from pre-RFC-030 mechanic:
+ *  - aliases-array matching removed (was secondary fallback). For property
+ *    assets following TBox convention (label == raw predicate == aliases[0])
+ *    the aliases loop was always a no-op after self-match skip.
+ *  - line "if (key === label) continue" skip removed. With the new matching
+ *    semantics (key == label by definition), the skip would always fire and
+ *    block every property asset.
+ *  - rdf:type filter is hard, not optional. Legacy ims__Concept assets that
+ *    used to resolve via aliases-match no longer participate. Intentional —
+ *    UI resolver must operate only on canonical TBox property definitions.
  *
- * Reading Mode only. Live Preview is explicitly out of scope for first iteration.
- * Follows the MutationObserver + layout-change re-patch pattern established by
- * PropertiesLinkPatch / PropertiesUidCopyPatch.
+ * Reading Mode only. Live Preview is explicitly out of scope for first
+ * iteration. Follows the MutationObserver + layout-change re-patch pattern
+ * established by PropertiesLinkPatch / PropertiesUidCopyPatch.
  */
 
 const PATCHED_ATTR = "data-exo-label-patched";
 const DISPLAY_SPAN_CLASS = "exo-label-display";
 const HIDDEN_INPUT_CLASS = "exo-label-hidden-input";
 const CLICKABLE_CLASS = "exo-label-clickable";
+
+// Root UID of exo__Property class (TBox-stable). All assets whose
+// exo__Instance_class transitively descends from this UID via
+// exo__Class_superClass qualify as "property assets" for indexing.
+const EXO_PROPERTY_ROOT_UID = "38277bfa-d7f9-4a75-b856-b23276ab0db3";
+
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
 interface ResolvedPredicate {
   label: string;
@@ -38,12 +64,53 @@ interface PatchRecord {
   clickHandler: (e: MouseEvent) => void;
 }
 
+/**
+ * Unwrap an Obsidian-style wikilink to a canonical UID.
+ *   "[[uuid]]"        → "uuid"
+ *   "[[uuid|alias]]"  → "uuid"
+ *   "uuid"            → "uuid" (when shape matches UUID v4 layout)
+ *   anything else     → null
+ *
+ * Exported for unit testing.
+ */
+export function unwrapWikilinkUid(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const wlMatch = trimmed.match(/^\[\[([^\]|]+)(?:\|[^\]]*)?\]\]$/);
+  if (wlMatch) return wlMatch[1].trim();
+  if (UUID_REGEX.test(trimmed)) return trimmed;
+  return null;
+}
+
+/**
+ * Normalize Obsidian YAML class-list value (scalar or array) into a sanitized
+ * array of UIDs. Each element is unwrapped via `unwrapWikilinkUid` so we hold
+ * canonical UIDs only.
+ *
+ * Exported for unit testing.
+ */
+export function normalizeClassList(value: unknown): string[] {
+  let raw: unknown[];
+  if (Array.isArray(value)) raw = value;
+  else if (typeof value === "string") raw = [value];
+  else return [];
+
+  const out: string[] = [];
+  for (const v of raw) {
+    const uid = unwrapWikilinkUid(v);
+    if (uid) out.push(uid);
+  }
+  return out;
+}
+
 export class PropertiesLabelPatch {
   private app: Plugin["app"];
   private plugin: Plugin;
   private observer: MutationObserver | null = null;
   private enabled = false;
-  private resolveCache: Map<string, ResolvedPredicate | null> = new Map();
+  private resolveCache: Map<string, ResolvedPredicate> = new Map();
+  private propertyClassUids: Set<string> = new Set();
   private indexBuilt = false;
   private patched: PatchRecord[] = [];
 
@@ -113,11 +180,81 @@ export class PropertiesLabelPatch {
   private invalidateIndex(): void {
     this.indexBuilt = false;
     this.resolveCache.clear();
+    this.propertyClassUids.clear();
+  }
+
+  /**
+   * Build the Set of UIDs for `exo__Property` and all its (transitive) subclasses
+   * by walking the class-hierarchy graph defined by `exo__Class_superClass`
+   * triples in the metadataCache. Pure metadata-cache approach — no SPARQL
+   * engine dependency. Synchronous; runs once per `buildIndex` invocation.
+   *
+   * BFS fixpoint: starting from `EXO_PROPERTY_ROOT_UID`, repeatedly include any
+   * class whose `exo__Class_superClass` contains an already-included UID, until
+   * no additions in a pass.
+   */
+  private resolvePropertyClassUids(files: TFile[]): Set<string> {
+    // childUid → Set<parentUid> from frontmatter exo__Class_superClass
+    const superClassMap: Map<string, Set<string>> = new Map();
+
+    for (const file of files) {
+      const cache = this.app.metadataCache.getFileCache(file);
+      const fm = cache?.frontmatter;
+      if (!fm) continue;
+
+      const uidRaw = fm["exo__Asset_uid"];
+      if (typeof uidRaw !== "string") continue;
+      const uid = uidRaw.trim();
+      if (!uid) continue;
+
+      const supers = normalizeClassList(fm["exo__Class_superClass"]);
+      // Include root with empty parents too so a vault containing
+      // exo__Property itself but no subclasses still seeds the Set.
+      superClassMap.set(uid, new Set(supers));
+    }
+
+    const result = new Set<string>([EXO_PROPERTY_ROOT_UID]);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const [childUid, parentUids] of superClassMap) {
+        if (result.has(childUid)) continue;
+        for (const parentUid of parentUids) {
+          if (result.has(parentUid)) {
+            result.add(childUid);
+            changed = true;
+            break;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Insert a cache entry, but if `key` already maps to a *different* file,
+   * keep the first write and log a collision warning. Deterministic by
+   * `vault.getMarkdownFiles()` enumeration order.
+   */
+  private setWithCollisionGuard(
+    key: string,
+    value: ResolvedPredicate
+  ): void {
+    const existing = this.resolveCache.get(key);
+    if (existing && existing.file.path !== value.file.path) {
+      console.warn(
+        `[PropertiesLabelPatch] Label collision for key "${key}": ` +
+          `keeping ${existing.file.path}, ignoring ${value.file.path}`
+      );
+      return;
+    }
+    this.resolveCache.set(key, value);
   }
 
   private buildIndex(): void {
     if (this.indexBuilt) return;
     this.resolveCache.clear();
+    this.propertyClassUids.clear();
 
     let files: TFile[] = [];
     if (typeof this.app.vault.getMarkdownFiles === "function") {
@@ -127,6 +264,12 @@ export class PropertiesLabelPatch {
       }
     }
 
+    // Step 1: resolve subClass closure for exo__Property.
+    // Done once per index build; ~138 known property assets and ~30 class
+    // assets in current TBox, BFS converges in 2-3 passes.
+    this.propertyClassUids = this.resolvePropertyClassUids(files);
+
+    // Step 2: index property-class ассеты only.
     for (const file of files) {
       const cache = this.app.metadataCache.getFileCache(file);
       const fm = cache?.frontmatter;
@@ -137,23 +280,21 @@ export class PropertiesLabelPatch {
       const label = rawLabel.trim();
       if (!label) continue;
 
-      const keys = new Set<string>();
-      keys.add(file.basename);
-      const aliases = fm["aliases"];
-      if (Array.isArray(aliases)) {
-        for (const a of aliases) {
-          if (typeof a === "string" && a.trim().length > 0) {
-            keys.add(a.trim());
-          }
-        }
-      }
+      // rdf:type filter — assets whose exo__Instance_class contains at least
+      // one UID from the property-class closure.
+      const classUids = normalizeClassList(fm["exo__Instance_class"]);
+      if (classUids.length === 0) continue;
+      if (!classUids.some((uid) => this.propertyClassUids.has(uid))) continue;
 
-      for (const key of keys) {
-        if (key === label) continue;
-        if (!this.resolveCache.has(key)) {
-          this.resolveCache.set(key, { label, file });
-        }
-      }
+      // Display source: displayName > label fallback. Empty/whitespace-only
+      // displayName triggers fallback (same as missing displayName).
+      const displayNameRaw = fm["exo__Property_displayName"];
+      const displayText =
+        typeof displayNameRaw === "string" && displayNameRaw.trim().length > 0
+          ? displayNameRaw.trim()
+          : label;
+
+      this.setWithCollisionGuard(label, { label: displayText, file });
     }
 
     this.indexBuilt = true;

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
@@ -1,4 +1,8 @@
-import { PropertiesLabelPatch } from "../../../../src/presentation/properties/PropertiesLabelPatch";
+import {
+  PropertiesLabelPatch,
+  unwrapWikilinkUid,
+  normalizeClassList,
+} from "../../../../src/presentation/properties/PropertiesLabelPatch";
 
 jest.mock("obsidian", () => ({
   Plugin: class {},
@@ -16,6 +20,10 @@ interface FakeLeaf {
   openFile: jest.Mock;
 }
 
+const EXO_PROPERTY_UID = "38277bfa-d7f9-4a75-b856-b23276ab0db3";
+const EXO_OBJECT_PROPERTY_UID = "9a1cf31c-9d41-4ef3-9023-584a8d087d16";
+const IMS_CONCEPT_UID = "dda12c48-6886-4624-8710-ed4ba92ce2b3";
+
 describe("PropertiesLabelPatch", () => {
   let patch: PropertiesLabelPatch;
   let mockPlugin: any;
@@ -26,6 +34,18 @@ describe("PropertiesLabelPatch", () => {
   let openedFiles: FakeFile[];
   let openFileMock: jest.Mock;
 
+  // ----- property-class definition assets (TBox class hierarchy) -----
+  // Without these, resolvePropertyClassUids only knows the root UID.
+  // With FILE_CLASS_OBJECTPROPERTY (superClass=[exo__Property]) the BFS
+  // closure adds the ObjectProperty UID — required for the subClass-closure
+  // tests to succeed.
+  const FILE_CLASS_OBJECTPROPERTY: FakeFile = {
+    path: "exo/9a1cf31c.md",
+    basename: "9a1cf31c-9d41-4ef3-9023-584a8d087d16",
+    extension: "md",
+  };
+
+  // ----- property assets (instance_class is exo__Property direct) -----
   const FILE_EFFORT_AREA: FakeFile = {
     path: "ems/ab1b5cc2.md",
     basename: "ab1b5cc2",
@@ -41,27 +61,100 @@ describe("PropertiesLabelPatch", () => {
     basename: "3d1e4212",
     extension: "md",
   };
-  const FILE_EFFORT_AREA_FALLBACK: FakeFile = {
-    path: "exo/properties/ems__Effort_area.md",
-    basename: "ems__Effort_area",
+  // Property asset WITHOUT displayName — exercises label-fallback path.
+  const FILE_NO_DISPLAYNAME: FakeFile = {
+    path: "ems/no-dn.md",
+    basename: "no-dn",
+    extension: "md",
+  };
+  // Property asset with class=ObjectProperty (subClass of Property) — exercises
+  // the subClass-closure filter path.
+  const FILE_CONCEPT_BROADER: FakeFile = {
+    path: "ims/4b67640a.md",
+    basename: "4b67640a",
+    extension: "md",
+  };
+
+  // ----- non-property asset — must be filtered out (regression: 8400800f) -----
+  const FILE_NON_PROPERTY: FakeFile = {
+    path: "concepts/aliases-concept.md",
+    basename: "8400800f",
+    extension: "md",
+  };
+
+  // ----- collision pair — two property assets sharing the same label -----
+  const FILE_COLLISION_A: FakeFile = {
+    path: "exo/collision-a.md",
+    basename: "collision-a",
+    extension: "md",
+  };
+  const FILE_COLLISION_B: FakeFile = {
+    path: "exo/collision-b.md",
+    basename: "collision-b",
     extension: "md",
   };
 
   const FRONTMATTERS: Record<string, any> = {
+    [FILE_CLASS_OBJECTPROPERTY.path]: {
+      exo__Asset_uid: EXO_OBJECT_PROPERTY_UID,
+      exo__Asset_label: "exo__ObjectProperty",
+      exo__Class_superClass: [`[[${EXO_PROPERTY_UID}]]`],
+    },
     [FILE_EFFORT_AREA.path]: {
-      exo__Asset_label: "Effort Area",
+      exo__Asset_uid: "ab1b5cc2-0000-0000-0000-000000000000",
+      exo__Asset_label: "ems__Effort_area",
+      exo__Property_displayName: "Effort Area",
+      exo__Instance_class: [`[[${EXO_PROPERTY_UID}]]`],
       aliases: ["ems__Effort_area"],
     },
     [FILE_EFFORT_STATUS.path]: {
-      exo__Asset_label: "Effort Status",
+      exo__Asset_uid: "64594641-0000-0000-0000-000000000000",
+      exo__Asset_label: "ems__Effort_status",
+      exo__Property_displayName: "Effort Status",
+      exo__Instance_class: [`[[${EXO_PROPERTY_UID}]]`],
       aliases: ["ems__Effort_status"],
     },
     [FILE_ASSET_LABEL.path]: {
-      exo__Asset_label: "Label",
+      exo__Asset_uid: "3d1e4212-0000-0000-0000-000000000000",
+      exo__Asset_label: "exo__Asset_label",
+      exo__Property_displayName: "Label",
+      exo__Instance_class: [`[[${EXO_PROPERTY_UID}]]`],
       aliases: ["exo__Asset_label"],
     },
-    [FILE_EFFORT_AREA_FALLBACK.path]: {
-      exo__Asset_label: "Effort Area Fallback",
+    [FILE_NO_DISPLAYNAME.path]: {
+      exo__Asset_uid: "deadbeef-0000-0000-0000-000000000000",
+      exo__Asset_label: "ems__Tag_field",
+      // intentionally no exo__Property_displayName — fallback case
+      exo__Instance_class: [`[[${EXO_PROPERTY_UID}]]`],
+    },
+    [FILE_CONCEPT_BROADER.path]: {
+      exo__Asset_uid: "4b67640a-71b5-4fbb-83bd-82342eed479b",
+      exo__Asset_label: "ims__Concept_broader",
+      exo__Property_displayName: "broader",
+      // class = ObjectProperty, which itself is a subClass of exo__Property.
+      // This forces resolvePropertyClassUids to do the BFS expansion.
+      exo__Instance_class: [`[[${EXO_OBJECT_PROPERTY_UID}]]`],
+    },
+    [FILE_NON_PROPERTY.path]: {
+      exo__Asset_uid: "8400800f-71c5-48a6-b68d-fd640771ce3e",
+      exo__Asset_label: "aliases",
+      // class = ims__Concept (not exo__Property and not a subClass) — must
+      // be skipped by the filter. Regression guard: 8400800f-... case from
+      // RFC-030 §1.1 / §8 intentional behavior change.
+      exo__Instance_class: [`[[${IMS_CONCEPT_UID}]]`],
+      aliases: ["aliases"],
+    },
+    [FILE_COLLISION_A.path]: {
+      exo__Asset_uid: "aaaa1111-0000-0000-0000-000000000000",
+      exo__Asset_label: "exo__Asset_updatedAt",
+      exo__Property_displayName: "Updated At (A)",
+      exo__Instance_class: [`[[${EXO_PROPERTY_UID}]]`],
+    },
+    [FILE_COLLISION_B.path]: {
+      exo__Asset_uid: "bbbb2222-0000-0000-0000-000000000000",
+      exo__Asset_label: "exo__Asset_updatedAt",
+      exo__Property_displayName: "Updated At (B)",
+      exo__Instance_class: [`[[${EXO_PROPERTY_UID}]]`],
     },
   };
 
@@ -143,10 +236,15 @@ describe("PropertiesLabelPatch", () => {
         getMarkdownFiles: jest
           .fn()
           .mockReturnValue([
+            FILE_CLASS_OBJECTPROPERTY,
             FILE_EFFORT_AREA,
             FILE_EFFORT_STATUS,
             FILE_ASSET_LABEL,
-            FILE_EFFORT_AREA_FALLBACK,
+            FILE_NO_DISPLAYNAME,
+            FILE_CONCEPT_BROADER,
+            FILE_NON_PROPERTY,
+            // Collision pair NOT included by default — opt-in per test
+            // via mockReturnValueOnce.
           ]),
       },
     };
@@ -167,6 +265,85 @@ describe("PropertiesLabelPatch", () => {
     }
   });
 
+  // ============================================================
+  // Pure-function helpers
+  // ============================================================
+  describe("unwrapWikilinkUid", () => {
+    it('returns inner uid for "[[uuid]]" form', () => {
+      expect(unwrapWikilinkUid("[[38277bfa-d7f9-4a75-b856-b23276ab0db3]]")).toBe(
+        "38277bfa-d7f9-4a75-b856-b23276ab0db3"
+      );
+    });
+
+    it('returns inner uid for "[[uuid|alias]]" form (strips alias)', () => {
+      expect(
+        unwrapWikilinkUid("[[38277bfa-d7f9-4a75-b856-b23276ab0db3|Property]]")
+      ).toBe("38277bfa-d7f9-4a75-b856-b23276ab0db3");
+    });
+
+    it("returns bare uuid string as-is when shape matches UUID layout", () => {
+      expect(unwrapWikilinkUid("38277bfa-d7f9-4a75-b856-b23276ab0db3")).toBe(
+        "38277bfa-d7f9-4a75-b856-b23276ab0db3"
+      );
+    });
+
+    it("returns null for non-UUID strings and non-strings", () => {
+      expect(unwrapWikilinkUid("not-a-uuid")).toBeNull();
+      expect(unwrapWikilinkUid("")).toBeNull();
+      expect(unwrapWikilinkUid("   ")).toBeNull();
+      expect(unwrapWikilinkUid(null)).toBeNull();
+      expect(unwrapWikilinkUid(undefined)).toBeNull();
+      expect(unwrapWikilinkUid(42)).toBeNull();
+      expect(unwrapWikilinkUid({})).toBeNull();
+    });
+
+    it("trims whitespace before parsing", () => {
+      expect(
+        unwrapWikilinkUid("  [[38277bfa-d7f9-4a75-b856-b23276ab0db3]]  ")
+      ).toBe("38277bfa-d7f9-4a75-b856-b23276ab0db3");
+    });
+  });
+
+  describe("normalizeClassList", () => {
+    it("returns empty array for missing or invalid input", () => {
+      expect(normalizeClassList(undefined)).toEqual([]);
+      expect(normalizeClassList(null)).toEqual([]);
+      expect(normalizeClassList(42)).toEqual([]);
+      expect(normalizeClassList({})).toEqual([]);
+    });
+
+    it("handles scalar wikilink string (YAML inline form)", () => {
+      // Obsidian YAML can emit `exo__Instance_class: "[[uuid]]"` as scalar.
+      expect(normalizeClassList(`[[${EXO_PROPERTY_UID}]]`)).toEqual([
+        EXO_PROPERTY_UID,
+      ]);
+    });
+
+    it("handles array of wikilinks (YAML list form)", () => {
+      expect(
+        normalizeClassList([
+          `[[${EXO_PROPERTY_UID}]]`,
+          `[[${EXO_OBJECT_PROPERTY_UID}]]`,
+        ])
+      ).toEqual([EXO_PROPERTY_UID, EXO_OBJECT_PROPERTY_UID]);
+    });
+
+    it("filters out non-string and non-UUID array entries", () => {
+      expect(
+        normalizeClassList([
+          `[[${EXO_PROPERTY_UID}]]`,
+          "garbage",
+          null,
+          42,
+          `[[${EXO_OBJECT_PROPERTY_UID}]]`,
+        ])
+      ).toEqual([EXO_PROPERTY_UID, EXO_OBJECT_PROPERTY_UID]);
+    });
+  });
+
+  // ============================================================
+  // Lifecycle
+  // ============================================================
   describe("enable", () => {
     it("registers layout-change, active-leaf-change, metadataCache changed events", () => {
       patch.enable();
@@ -193,8 +370,11 @@ describe("PropertiesLabelPatch", () => {
     });
   });
 
+  // ============================================================
+  // Scenario A — readable labels (displayName path)
+  // ============================================================
   describe("Scenario A: known predicates get readable labels via span overlay", () => {
-    it("inserts a display span with the readable label while leaving input.value UNCHANGED", () => {
+    it("inserts a display span with the displayName while leaving input.value UNCHANGED", () => {
       const row = createPropertyRow({ inputValue: "ems__Effort_area" });
       mockMetadataContainer.appendChild(row);
 
@@ -292,6 +472,9 @@ describe("PropertiesLabelPatch", () => {
     });
   });
 
+  // ============================================================
+  // Scenario B — click navigates to definition
+  // ============================================================
   describe("Scenario B: clicking readable label opens definition", () => {
     it("click on display span calls openFile for the definition asset", () => {
       const row = createPropertyRow({ inputValue: "ems__Effort_status" });
@@ -328,6 +511,9 @@ describe("PropertiesLabelPatch", () => {
     });
   });
 
+  // ============================================================
+  // Scenario C — unknown predicate fallback
+  // ============================================================
   describe("Scenario C: unknown predicate fallback", () => {
     it("does NOT create a display span for unknown predicate", () => {
       const row = createPropertyRow({ inputValue: "vendor__Custom_field" });
@@ -363,6 +549,327 @@ describe("PropertiesLabelPatch", () => {
     });
   });
 
+  // ============================================================
+  // RFC-030 §3.2 — displayName → label fallback
+  // ============================================================
+  describe("RFC-030 displayName fallback", () => {
+    it("falls back to exo__Asset_label when displayName is missing", () => {
+      const row = createPropertyRow({ inputValue: "ems__Tag_field" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      expect(span).toBeTruthy();
+      // FILE_NO_DISPLAYNAME has label "ems__Tag_field" and no
+      // exo__Property_displayName, so display falls back to the label itself.
+      expect(span.textContent).toBe("ems__Tag_field");
+    });
+
+    it("falls back when displayName is empty string", () => {
+      // Patch a property asset to have an empty-string displayName
+      const tempFile: FakeFile = {
+        path: "tmp/empty-dn.md",
+        basename: "empty-dn",
+        extension: "md",
+      };
+      const tempFrontmatter = {
+        exo__Asset_uid: "11111111-0000-0000-0000-000000000000",
+        exo__Asset_label: "ems__Empty_dn",
+        exo__Property_displayName: "",
+        exo__Instance_class: [`[[${EXO_PROPERTY_UID}]]`],
+      };
+      mockApp.vault.getMarkdownFiles = jest
+        .fn()
+        .mockReturnValue([FILE_CLASS_OBJECTPROPERTY, tempFile]);
+      mockApp.metadataCache.getFileCache = jest
+        .fn()
+        .mockImplementation((file: FakeFile) => {
+          if (file.path === FILE_CLASS_OBJECTPROPERTY.path) {
+            return { frontmatter: FRONTMATTERS[FILE_CLASS_OBJECTPROPERTY.path] };
+          }
+          if (file.path === tempFile.path) {
+            return { frontmatter: tempFrontmatter };
+          }
+          return null;
+        });
+
+      const row = createPropertyRow({ inputValue: "ems__Empty_dn" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      expect(span.textContent).toBe("ems__Empty_dn");
+    });
+
+    it("falls back when displayName is whitespace-only", () => {
+      const tempFile: FakeFile = {
+        path: "tmp/ws-dn.md",
+        basename: "ws-dn",
+        extension: "md",
+      };
+      mockApp.vault.getMarkdownFiles = jest
+        .fn()
+        .mockReturnValue([FILE_CLASS_OBJECTPROPERTY, tempFile]);
+      mockApp.metadataCache.getFileCache = jest
+        .fn()
+        .mockImplementation((file: FakeFile) => {
+          if (file.path === FILE_CLASS_OBJECTPROPERTY.path) {
+            return { frontmatter: FRONTMATTERS[FILE_CLASS_OBJECTPROPERTY.path] };
+          }
+          if (file.path === tempFile.path) {
+            return {
+              frontmatter: {
+                exo__Asset_uid: "22222222-0000-0000-0000-000000000000",
+                exo__Asset_label: "ems__Ws_dn",
+                exo__Property_displayName: "   ",
+                exo__Instance_class: [`[[${EXO_PROPERTY_UID}]]`],
+              },
+            };
+          }
+          return null;
+        });
+
+      const row = createPropertyRow({ inputValue: "ems__Ws_dn" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      expect(span.textContent).toBe("ems__Ws_dn");
+    });
+
+    it("skips assets entirely when exo__Asset_label is missing", () => {
+      const tempFile: FakeFile = {
+        path: "tmp/no-label.md",
+        basename: "no-label",
+        extension: "md",
+      };
+      mockApp.vault.getMarkdownFiles = jest
+        .fn()
+        .mockReturnValue([FILE_CLASS_OBJECTPROPERTY, tempFile]);
+      mockApp.metadataCache.getFileCache = jest
+        .fn()
+        .mockImplementation((file: FakeFile) => {
+          if (file.path === FILE_CLASS_OBJECTPROPERTY.path) {
+            return { frontmatter: FRONTMATTERS[FILE_CLASS_OBJECTPROPERTY.path] };
+          }
+          if (file.path === tempFile.path) {
+            return {
+              frontmatter: {
+                exo__Asset_uid: "33333333-0000-0000-0000-000000000000",
+                // intentionally NO exo__Asset_label
+                exo__Property_displayName: "Whatever",
+                exo__Instance_class: [`[[${EXO_PROPERTY_UID}]]`],
+              },
+            };
+          }
+          return null;
+        });
+
+      const row = createPropertyRow({ inputValue: "Whatever" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      // Asset lacking label is skipped entirely.
+      expect(
+        row.querySelector<HTMLSpanElement>(".exo-label-display")
+      ).toBeNull();
+    });
+  });
+
+  // ============================================================
+  // RFC-030 §3.2 — rdf:type filter (positive + negative)
+  // ============================================================
+  describe("RFC-030 rdf:type filter", () => {
+    it("indexes asset with direct exo__Property class (positive direct)", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_area" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      expect(
+        row.querySelector<HTMLSpanElement>(".exo-label-display")?.textContent
+      ).toBe("Effort Area");
+    });
+
+    it("indexes asset with subClass-of-Property class via BFS closure (positive subClass)", () => {
+      // FILE_CONCEPT_BROADER has class=exo__ObjectProperty; its class asset
+      // declares exo__Class_superClass=[exo__Property]. resolvePropertyClassUids
+      // must add ObjectProperty UID to the closure set so this asset indexes.
+      const row = createPropertyRow({ inputValue: "ims__Concept_broader" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display");
+      expect(span?.textContent).toBe("broader");
+    });
+
+    it("skips non-property asset (FILE_NON_PROPERTY ims__Concept describing aliases)", () => {
+      // FILE_NON_PROPERTY has class=ims__Concept (not a subClass of Property).
+      // RFC-030 intentional behavior change: 8400800f-... no longer resolves.
+      // The frontmatter key "aliases" must NOT be patched by the resolver
+      // (Obsidian native "System Reserved" indicator continues to operate
+      // independently).
+      const row = createPropertyRow({ inputValue: "aliases" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      expect(
+        row.querySelector<HTMLSpanElement>(".exo-label-display")
+      ).toBeNull();
+    });
+
+    it("skips asset with no exo__Instance_class at all", () => {
+      const tempFile: FakeFile = {
+        path: "tmp/no-class.md",
+        basename: "no-class",
+        extension: "md",
+      };
+      mockApp.vault.getMarkdownFiles = jest
+        .fn()
+        .mockReturnValue([FILE_CLASS_OBJECTPROPERTY, tempFile]);
+      mockApp.metadataCache.getFileCache = jest
+        .fn()
+        .mockImplementation((file: FakeFile) => {
+          if (file.path === FILE_CLASS_OBJECTPROPERTY.path) {
+            return { frontmatter: FRONTMATTERS[FILE_CLASS_OBJECTPROPERTY.path] };
+          }
+          if (file.path === tempFile.path) {
+            return {
+              frontmatter: {
+                exo__Asset_uid: "44444444-0000-0000-0000-000000000000",
+                exo__Asset_label: "ems__Orphan",
+                exo__Property_displayName: "Orphan",
+                // intentionally NO exo__Instance_class
+              },
+            };
+          }
+          return null;
+        });
+
+      const row = createPropertyRow({ inputValue: "ems__Orphan" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      expect(
+        row.querySelector<HTMLSpanElement>(".exo-label-display")
+      ).toBeNull();
+    });
+
+    it("accepts scalar exo__Instance_class (YAML inline form, not array)", () => {
+      const tempFile: FakeFile = {
+        path: "tmp/scalar-class.md",
+        basename: "scalar-class",
+        extension: "md",
+      };
+      mockApp.vault.getMarkdownFiles = jest
+        .fn()
+        .mockReturnValue([FILE_CLASS_OBJECTPROPERTY, tempFile]);
+      mockApp.metadataCache.getFileCache = jest
+        .fn()
+        .mockImplementation((file: FakeFile) => {
+          if (file.path === FILE_CLASS_OBJECTPROPERTY.path) {
+            return { frontmatter: FRONTMATTERS[FILE_CLASS_OBJECTPROPERTY.path] };
+          }
+          if (file.path === tempFile.path) {
+            return {
+              frontmatter: {
+                exo__Asset_uid: "55555555-0000-0000-0000-000000000000",
+                exo__Asset_label: "ems__Scalar_class",
+                exo__Property_displayName: "Scalar Class",
+                // SCALAR (string, not array) — YAML accepts both forms
+                exo__Instance_class: `[[${EXO_PROPERTY_UID}]]`,
+              },
+            };
+          }
+          return null;
+        });
+
+      const row = createPropertyRow({ inputValue: "ems__Scalar_class" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display");
+      expect(span?.textContent).toBe("Scalar Class");
+    });
+  });
+
+  // ============================================================
+  // RFC-030 §3.2 — collision guard
+  // ============================================================
+  describe("RFC-030 collision guard", () => {
+    it("first-write-wins on label collision; warns about the second asset", () => {
+      // Include both collision-pair fixtures
+      mockApp.vault.getMarkdownFiles = jest
+        .fn()
+        .mockReturnValue([
+          FILE_CLASS_OBJECTPROPERTY,
+          FILE_COLLISION_A,
+          FILE_COLLISION_B,
+        ]);
+
+      const warnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      const row = createPropertyRow({ inputValue: "exo__Asset_updatedAt" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      // FILE_COLLISION_A enumerated first → wins.
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      expect(span.textContent).toBe("Updated At (A)");
+
+      // Click on the span should open the winning file (A), not the loser.
+      span.click();
+      expect(openedFiles[0]).toBe(FILE_COLLISION_A);
+
+      // Collision warning fired with both paths in the message.
+      expect(warnSpy).toHaveBeenCalled();
+      const warnMsg = warnSpy.mock.calls[0][0] as string;
+      expect(warnMsg).toContain("exo__Asset_updatedAt");
+      expect(warnMsg).toContain(FILE_COLLISION_A.path);
+      expect(warnMsg).toContain(FILE_COLLISION_B.path);
+
+      warnSpy.mockRestore();
+    });
+
+    it("does NOT warn when the same asset is encountered twice (same file.path)", () => {
+      // If buildIndex sees same file twice (theoretical, but defensive)
+      // we should not log a spurious collision.
+      mockApp.vault.getMarkdownFiles = jest
+        .fn()
+        .mockReturnValue([
+          FILE_CLASS_OBJECTPROPERTY,
+          FILE_EFFORT_AREA,
+          FILE_EFFORT_AREA, // intentional duplicate
+        ]);
+
+      const warnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      patch.enable();
+
+      // The duplicate file.path is the same — collision-guard treats it as
+      // re-write of the same value, not as a real collision.
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ============================================================
+  // disable / cleanup
+  // ============================================================
   describe("disable / cleanup", () => {
     it("removes display span on disable and restores input visibility", () => {
       const row = createPropertyRow({ inputValue: "ems__Effort_area" });
@@ -407,6 +914,9 @@ describe("PropertiesLabelPatch", () => {
     });
   });
 
+  // ============================================================
+  // Dynamic DOM
+  // ============================================================
   describe("dynamic DOM (MutationObserver)", () => {
     it("patches a property row that is added after enable()", async () => {
       patch.enable();
@@ -421,6 +931,9 @@ describe("PropertiesLabelPatch", () => {
     });
   });
 
+  // ============================================================
+  // Index invalidation + Finding-4 recovery
+  // ============================================================
   describe("index invalidation", () => {
     it("re-patches on metadataCache changed event", () => {
       const row = createPropertyRow({ inputValue: "ems__Effort_area" });
@@ -499,6 +1012,9 @@ describe("PropertiesLabelPatch", () => {
     });
   });
 
+  // ============================================================
+  // Stylesheet guard
+  // ============================================================
   describe("stylesheet: .exo-label-display matches native input metrics", () => {
     it("occupies the same geometric box as native .metadata-property-key input", () => {
       const fs = require("fs");

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
@@ -302,6 +302,29 @@ describe("PropertiesLabelPatch", () => {
         unwrapWikilinkUid("  [[38277bfa-d7f9-4a75-b856-b23276ab0db3]]  ")
       ).toBe("38277bfa-d7f9-4a75-b856-b23276ab0db3");
     });
+
+    it("strips path prefix from path-qualified wikilink (defensive)", () => {
+      // UID-canon TBox doesn't emit path-qualified links, but legacy
+      // authoring tools may. Defensive parsing prevents silent BFS-closure
+      // miss on class refs like [[03 Knowledge/exo/38277bfa-...]].
+      expect(
+        unwrapWikilinkUid(
+          "[[assetspaces/exo/38277bfa-d7f9-4a75-b856-b23276ab0db3]]"
+        )
+      ).toBe("38277bfa-d7f9-4a75-b856-b23276ab0db3");
+      expect(
+        unwrapWikilinkUid(
+          "[[some/path/38277bfa-d7f9-4a75-b856-b23276ab0db3|alias]]"
+        )
+      ).toBe("38277bfa-d7f9-4a75-b856-b23276ab0db3");
+    });
+
+    it("returns null when path-stripped form is not a UUID", () => {
+      // Symbolic path-qualified wikilink — neither UID-canon nor UUID shape.
+      expect(
+        unwrapWikilinkUid("[[some/path/symbolic-label]]")
+      ).toBeNull();
+    });
   });
 
   describe("normalizeClassList", () => {


### PR DESCRIPTION
## Summary

PropertiesLabelPatch теперь индексирует исключительно `exo__Property` и его subClass-closure ассеты, использует `exo__Asset_label` как matching key (совпадает с raw predicate name per TBox convention), и берёт display-текст из нового optional property `exo__Property_displayName` с fallback на label.

**Поведенческие изменения от прежней механики:**
- Удалён aliases-array matching (был secondary fallback)
- Удалена строка skip `if (key === label) continue` (всегда срабатывала для exo__Property ассетов с label==raw_predicate convention — это был bug отсекающий 99% TBox)
- Добавлен hard `rdf:type` filter с **subClass-closure** (resolved at init через BFS по `exo__Class_superClass` triples в metadataCache; sync, no SPARQL dependency)
- Добавлен collision guard (first-write-wins + `console.warn`)
- Добавлен `exo__Property_displayName` lookup с fallback на label

**Intentional regression:** `ims__Concept` ассеты больше не резолвят patch (в частности `8400800f-...md` который описывал Obsidian-system "aliases" predicate). Obsidian native "System Reserved" indicator продолжает работать independently. Решение per user интервью.

## Why

Современный resolver работал только для ~5-10% predicate-определений в TBox — fixture artifact текущего dataset (label "случайно" длиннее raw predicate). Большинство `exo__Property` ассетов следуют convention `label == raw predicate name`, и существующий skip-condition `key === label` отсекал их все.

После RFC-030 filter expectation: ≥80% TBox-предикатов становятся clickable label-references после первой инсталляции (без data migration). Post-merge добавление `exo__Property_displayName` per asset — incremental Phase 2 work.

## Test plan

- [x] Unit tests: 43 cases, 0 failures (`PropertiesLabelPatch.test.ts`)
  - `unwrapWikilinkUid` (7 cases): wikilink form, alias-stripped, bare UUID, invalid input, whitespace, **path-qualified strip (LOW1 defensive)**, path-strip non-UUID null
  - `normalizeClassList` (4 cases): missing, scalar, array, filtered non-UUID entries
  - `displayName` fallback (3 cases): missing, empty string, whitespace-only
  - `rdf:type` filter: positive direct + positive subClass via BFS closure + negative non-property + negative missing class + scalar YAML form
  - Collision detection: first-write-wins + console.warn raised + same-file no spurious warn
  - Existing Scenario A/B/C tests updated to new label-matching convention
  - Finding-4 cache-resolved recovery preserved
- [x] Full obsidian-plugin unit suite: 4935 / 4935 passing
- [x] `npm run typecheck`: clean
- [x] `npm run lint`: 0 errors (3 pre-existing warnings in unrelated files)
- [x] Code-reviewer agent: **APPROVE** (0 CRITICAL, 0 HIGH, 1 MEDIUM non-blocking perf opt, 2 LOW)
- [x] LOW1 applied: defensive path-strip в `unwrapWikilinkUid`
- [ ] CI: pending (14 required checks)
- [ ] Visual smoke в Obsidian: открыть ноту с `ims__Concept_broader` frontmatter, проверить clickable span "ims__Concept_broader" → клик открывает `4b67640a-...md`
- [ ] Visual smoke negative: ноту с `aliases` frontmatter key — patch NOT applied (regression intentional)

## Follow-ups (non-blocking)

- **MEDIUM:** `metadataCache.on("changed")` rebuilds full index on every file edit. For 10K+ file vaults this is O(N) per keystroke flush. Established mitigation pattern в `ExocortexPlugin.ts:441-446` (Issue #3190 bootstrap guard) — file-scoped invalidation. File as separate issue post-merge.

## Related

- RFC: `vault-exodev/inbox/e0ff64cd-0c38-410a-b154-f7b17ca888a6.md` (RFC-030, v3 after 3 review iterations)
- TBox sync: `kitelev/exoas-exo` commit `e718782` (new property asset `29eaa6f0-...md`), submodule pointer bumped in both `vault-2025` (c34b3146d) и `vault-exodev` (350251f)