### PR TITLE
feat(settings): toggle для PropertiesLabelPatch + docs (RFC-030 follow-up)

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -500,20 +500,20 @@ These invariants protect existing callers and avoid mass vault rewrites when new
 
 **When to use**: A core service needs to trigger a surface-specific side-effect (open file, show notification, refresh layout) but the side-effect doesn't belong in the core's responsibility.
 
-**Pattern**: Don't bake the side-effect into the core. Define a small interface (`IFileOpener`, `IRefreshAfter…`), accept it as an *optional* constructor argument, and `await it?.(args)` at the call site. Tests and CLI surfaces omit the dep; the platform layer wires its implementation.
+**Pattern**: Don't bake the side-effect into the core. Define a small interface (`IFileOpener`, `IRefreshAfter…`), accept it as an _optional_ constructor argument, and `await it?.(args)` at the call site. Tests and CLI surfaces omit the dep; the platform layer wires its implementation.
 
 ```ts
 // Core service — no opener dependency baked in
 class CommandExecutionFlow {
   constructor(
     private deps: CoreDeps,
-    private opener?: IFileOpener,  // optional
+    private opener?: IFileOpener, // optional
   ) {}
 
   async execute(cmd: Command): Promise<ExecutionResult> {
     const result = await this.run(cmd);
     if (result.openPath) {
-      await this.opener?.(result.openPath);  // no-op if absent
+      await this.opener?.(result.openPath); // no-op if absent
     }
     return result;
   }
@@ -533,6 +533,7 @@ new CommandExecutionFlow(deps);
 ```
 
 **Key properties**:
+
 - Core test fixtures stay unchanged (they pass 3 args)
 - Headless CLI path stays unchanged (no opener)
 - One-line surface added on the Obsidian wiring side
@@ -8841,3 +8842,97 @@ export default class MyPlugin extends Plugin {
 - Run `npm run test:e2e` locally before push when modifying plugin startup sequence — the in-repo `npm run test:all` does NOT include Docker E2E, so flaky-modal races only surface in CI
 
 **Reference**: RFC-024 Phase 0 (#2833) / PR #2838 — E2E flaky `daily-archive-filter.spec.ts` was caused by `ChangelogModal` intercepting archive-toggle clicks on fresh test vault; fixed by `isFreshInstall` gate.
+
+## BFS subClass Closure via metadataCache
+
+For plugin code that needs "all assets of class X or any subclass thereof" — synchronous BFS over `exo__Class_superClass` triples in the metadataCache. No SPARQL engine dependency, no async lifecycle complexity.
+
+**Reference implementation**: `PropertiesLabelPatch.resolvePropertyClassUids` (RFC-030, PR #3246).
+
+**Pattern**:
+
+1. Iterate `app.vault.getMarkdownFiles()` and build a child→parents map from frontmatter:
+
+   ```ts
+   const superClassMap: Map<string, Set<string>> = new Map();
+   for (const file of files) {
+     const fm = app.metadataCache.getFileCache(file)?.frontmatter;
+     if (!fm) continue;
+     const uid = fm["exo__Asset_uid"];
+     if (typeof uid !== "string") continue;
+     const supers = normalizeClassList(fm["exo__Class_superClass"]); // unwrap wikilinks
+     superClassMap.set(uid.trim(), new Set(supers));
+   }
+   ```
+
+2. BFS fixpoint from a known root UID (hardcoded constant, e.g. `EXO_PROPERTY_ROOT_UID = "38277bfa-..."`):
+
+   ```ts
+   const result = new Set<string>([ROOT_UID]);
+   let changed = true;
+   while (changed) {
+     changed = false;
+     for (const [childUid, parentUids] of superClassMap) {
+       if (result.has(childUid)) continue;
+       for (const parentUid of parentUids) {
+         if (result.has(parentUid)) {
+           result.add(childUid);
+           changed = true;
+           break;
+         }
+       }
+     }
+   }
+   ```
+
+3. Use the resulting Set as a class-filter predicate in a downstream pass:
+   ```ts
+   const classUids = normalizeClassList(fm["exo__Instance_class"]);
+   if (!classUids.some((uid) => result.has(uid))) continue; // skip — not a subclass
+   ```
+
+**Performance**: For ~30 class assets + 138 property-class subclasses in current TBox, BFS converges in 2-3 iterations, ~5-10 ms total at index build time.
+
+**Why not SPARQL `rdfs:subClassOf*`**: Plugin code runs before the SPARQL engine may be ready (metadataCache.resolved fires before any user query). BFS over metadataCache is sync and dependency-free.
+
+**Cycle safety**: The `result.has(childUid)` guard prevents infinite loops if `exo__Class_superClass` contains a cycle (A→B, B→A). Cycles not connected to the root are silently excluded.
+
+**Reference**: RFC-030 §3.2 + PR #3246 (`PropertiesLabelPatch.ts:194-232`).
+
+**Pitfall — single-UID root is not enough**: Three independent reviewers (RFC-030 review iterations) all missed that a filter checking only direct `exo__Property` UID excluded `exo__ObjectProperty` instances (87/138 property assets). Always verify empirically: `grep -rln '"\[\[<root-uid>\]\]"' assetspaces/ | wc -l` shows direct count; if substantially smaller than expected total, you need closure.
+
+## Collision Guard Pattern for Cache Deduplication
+
+When a cache key can be populated from multiple sources (e.g. different files with the same `exo__Asset_label`), default `cache.set(key, value)` silently overwrites. For diagnostic purposes you want **first-write-wins + console.warn**.
+
+```ts
+function setWithCollisionGuard<K, V extends { file: { path: string } }>(
+  cache: Map<K, V>,
+  key: K,
+  value: V,
+): void {
+  const existing = cache.get(key);
+  if (existing && existing.file.path !== value.file.path) {
+    console.warn(
+      `[CacheCollision] Key "${String(key)}": ` +
+        `keeping ${existing.file.path}, ignoring ${value.file.path}`,
+    );
+    return; // first-write-wins
+  }
+  cache.set(key, value);
+}
+```
+
+**Properties**:
+
+- Deterministic by source enumeration order (e.g. `vault.getMarkdownFiles()`)
+- Same-file rewrite (same `file.path`) is silent — no spurious warnings on idempotent re-indexing
+- Cross-file collision logs both paths so the user can manually pick the winner (rename / archive / merge)
+- Audit query for systematic detection (SPARQL or shell):
+  ```bash
+  grep -rh 'exo__Asset_label:' assetspaces/ | sort | uniq -d
+  ```
+
+**When to use**: cache builders that consume frontmatter values which are conventionally-but-not-formally unique (label, alias, displayName). Pure-UID keys (which are guaranteed unique by definition) don't need this.
+
+**Reference**: `PropertiesLabelPatch.setWithCollisionGuard` (RFC-030, PR #3246). Empirical collisions found pre-merge: `exo__Asset_label: exo__Asset_updatedAt` ×2, `exo__Asset_label: ems__Initiative` ×2 — surfaced via console.warn after deployment, not blocked.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1952,3 +1952,42 @@ This is a UX/cosmetic concern that has **no bearing on RDF semantics or SHACL co
 3. **If SHACL violation counts didn't change after a form-only rewrite**: that's success, not failure. Move on.
 
 **Reference**: Issue #3123. Related: `docs/PROPERTY_SCHEMA.md` § `exo__Instance_class` › _Canonical form_.
+
+## Plugin Patch Behavior Not Visible After Code Change
+
+**Symptom**: Plugin code change is merged and built, but the expected UI behavior (e.g. patched DOM elements, new render, settings effect) is not observable in Obsidian. May appear as "only some elements affected" — partial-application state.
+
+### Diagnostic ladder
+
+1. **Plugin actually reloaded?**
+   - `Cmd+R` reloads the renderer process **only**. Plugin lifecycle (onload / enable) runs in the main process — Electron split. Cmd+R will not re-run `onload`, will not re-init patches, will not pick up new code paths.
+   - **Correct**: `Cmd+P` → `Reload app without saving` — full lifecycle restart. Or use BRAT update (which triggers reinstall + restart automatically).
+   - See aiKnow `2d7dd8c1-...` (vault-exodev/assetspaces/exoass).
+
+2. **Manifest version matches main.js?**
+   - If you copied `main.js` manually (not via BRAT), manifest.json may be stale → version mismatch → BRAT thinks no update needed → partial reload state.
+   - **Check via DevTools console**: `app.plugins.plugins['exocortex'].manifest.version`
+   - **Correct**: never manual-copy `main.js`. Go through the release pipeline → BRAT update.
+
+3. **Index built against new code path?**
+   - Many plugin features (PropertiesLabelPatch, FileExplorerLabelPatch, etc.) lazily build index at first invocation, then cache. If first invocation happened against OLD code, cache holds stale results.
+   - **Check**: spawn `metadataCache.trigger('resolved')` from console to force re-index, then observe.
+   - **Reference**: PropertiesLabelPatch caches both `propertyClassUids: Set<string>` AND `resolveCache: Map<key, ResolvedPredicate>`. Both invalidated on `metadataCache.changed` and `resolved` events.
+
+4. **Setting toggle disabled the feature?**
+   - Many patches are gated by user-toggleable settings (RFC-030's `enablePropertiesLabelPatch`, etc.). Check `Cmd+,` → Exocortex → setting state.
+   - In DevTools: `app.plugins.plugins['exocortex'].settings.enablePropertiesLabelPatch`
+
+### How to verify correctness
+
+```js
+// From DevTools console — count active patched elements:
+document.querySelectorAll(".exo-label-clickable").length;
+// Compare against expected (e.g. open known note with 5 predicate keys → expect 5)
+```
+
+### Anti-pattern
+
+Don't iterate `cp main.js → vault/.obsidian/plugins/ + Cmd+R` for debugging — this builds up cache-drift between renderer state and plugin state, and obscures the actual symptom. Either fully reload the app or go through BRAT.
+
+**Reference**: RFC-030 implementation (PR #3246) — manual main.js copy + Cmd+R produced "patch applied only to aliases" partial state. Root cause: renderer-only reload kept old DOM hooks; new main.js bytes loaded but old patch handlers still attached. Restoration via backup + merge + BRAT update + Cmd+P Reload resolved cleanly. See `~/.claude/rules/obsidian-plugin-update-via-brat.md`.

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -1083,14 +1083,19 @@ export default class ExocortexPlugin extends Plugin {
         500,
       );
 
-      // Initialize Properties readable-label patch (always enabled)
+      // Initialize Properties readable-label patch (RFC-030).
       // Replaces raw predicate names (e.g. ems__Effort_area) with human-readable
-      // labels resolved from property definition assets' exo__Asset_label.
+      // labels resolved from property definition assets' exo__Property_displayName
+      // (fallback exo__Asset_label). Gated by settings.enablePropertiesLabelPatch
+      // (default true; user-toggleable for users who prefer native predicate
+      // rendering or who hit edge cases with custom TBox conventions).
       this.propertiesLabelPatch = new PropertiesLabelPatch(this);
       this.timerManager.setTimeout(
         "properties-label-patch",
         () => {
-          this.propertiesLabelPatch.enable();
+          if (this.settings.enablePropertiesLabelPatch) {
+            this.propertiesLabelPatch.enable();
+          }
         },
         500,
       );
@@ -1377,6 +1382,20 @@ export default class ExocortexPlugin extends Plugin {
       this.propertiesLinkPatch.enable();
     } else {
       this.propertiesLinkPatch.disable();
+    }
+  }
+
+  /**
+   * Toggle PropertiesLabelPatch (RFC-030 predicate-key resolver) on/off.
+   * Called from settings when `enablePropertiesLabelPatch` changes. Hot-toggle:
+   * `enable()` rebuilds the property-class subClass closure + cache from
+   * scratch; `disable()` restores any patched DOM and disconnects observers.
+   */
+  togglePropertiesLabelPatch(enabled: boolean): void {
+    if (enabled) {
+      this.propertiesLabelPatch.enable();
+    } else {
+      this.propertiesLabelPatch.disable();
     }
   }
 

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -133,6 +133,18 @@ export interface ExocortexSettings {
    * invocation — no plugin reload required.
    */
   enableShaclValidation: boolean;
+  /**
+   * RFC-030 — enable the `PropertiesLabelPatch` which patches predicate keys
+   * in Obsidian's Properties block (Reading Mode) to:
+   * - Replace raw predicate name (e.g. `ems__Effort_area`) with clickable span
+   *   whose text is `exo__Property_displayName` (fallback to `exo__Asset_label`)
+   * - Open the property-definition asset on click
+   *
+   * Default `true`. When `false`, the Properties block renders native Obsidian
+   * (raw predicate names, no click-to-definition). Hot-toggleable — change
+   * takes effect immediately, no plugin reload required.
+   */
+  enablePropertiesLabelPatch: boolean;
   [key: string]: unknown;
 }
 
@@ -158,4 +170,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   showIconsInFileExplorer: true,
   enableSparqlAutoExecute: false,
   enableShaclValidation: false,
+  enablePropertiesLabelPatch: true,
 };

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -94,6 +94,25 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Replace predicate names with display labels")
+      .setDesc(
+        "In the Properties block, replace raw predicate keys " +
+          "(e.g. ems__Effort_area) with a clickable label resolved from the " +
+          "property's exo__Property_displayName (fallback exo__Asset_label). " +
+          "Clicking the label opens the property-definition asset. When " +
+          "disabled, predicate keys render as raw frontmatter names.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enablePropertiesLabelPatch)
+          .onChange(async (value) => {
+            this.plugin.settings.enablePropertiesLabelPatch = value;
+            await this.plugin.saveSettings();
+            this.plugin.togglePropertiesLabelPatch(value);
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Enable custom layouts")
       .setDesc(
         "Render class-specific layouts defined via exo__Layout assets. " +

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -127,9 +127,9 @@ describe("ExocortexSettingTab", () => {
       settingTab.display();
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
-      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 1 enableShaclValidation toggle (P1.12) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 28
+      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 1 enableShaclValidation toggle (P1.12) + 1 enablePropertiesLabelPatch toggle (RFC-030) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 29
       // Log channels section: 1 heading + 4 log level rows = 5
-      expect(MockSetting).toHaveBeenCalledTimes(28);
+      expect(MockSetting).toHaveBeenCalledTimes(29);
     });
 
     it("should render layout visibility toggle as first setting", () => {


### PR DESCRIPTION
## Summary

Follow-up к RFC-030 (PR #3246) — три independent items в одном PR (общая тема: post-merge polish + docs):

1. **User toggle для PropertiesLabelPatch** — new setting `enablePropertiesLabelPatch` (default `true`), hot-toggleable через Settings → Exocortex. Дает safe fallback к native Obsidian rendering Properties block для users prefer raw predicate names или encounter edge cases с custom TBox conventions.

2. **PATTERNS.md** — 2 new sections documenting RFC-030 patterns как canonical examples:
   - "BFS subClass closure via metadataCache" (synchronous, no SPARQL engine dependency)
   - "Collision guard pattern for cache deduplication" (first-write-wins + console.warn)

3. **TROUBLESHOOTING.md** — "Plugin patch behavior not visible after code change" diagnostic ladder (Cmd+R vs Reload app vs BRAT). Empirical incident reference from RFC-030 implementation session.

## Why each

- **Toggle**: RFC-030 ввел intentional behavior change (8400800f-... ims__Concept больше не резолвит patch). Toggle дает user explicit control over feature без отката версии плагина. Hot-toggleable design — runtime enable/disable, без plugin reload.
- **PATTERNS.md**: RFC-030 introduced два re-usable patterns. Documented для future plugin code which needs similar class-hierarchy traversal или cache deduplication.
- **TROUBLESHOOTING.md**: visual smoke session yielded a recoverable but lossy debug experience (manual main.js copy + Cmd+R → partial reload state masking как "patch broken"). Diagnostic ladder prevents re-discovery.

## Test plan

- [x] Unit tests: 48/48 pass (`PropertiesLabelPatch.test.ts` + `ExocortexSettingTab.test.ts`)
- [x] Setting count assertion updated (28 → 29 toggles)
- [x] Full obsidian-plugin suite: 4937/4937 pass
- [x] `npm run check:types`: clean
- [x] `npm run lint`: 0 errors (2 pre-existing warnings unrelated)
- [ ] CI: pending
- [ ] Visual confirmation: toggle off → PropertiesLabelPatch disable() restores native rendering; toggle on → patch re-applies

## Related

- RFC-030: `vault-exodev/inbox/e0ff64cd-...md`
- PR #3246: RFC-030 implementation (merged 697e269)
- aiKnow `2d7dd8c1`: Cmd+P "Reload app" (vault-exodev/assetspaces/exoass)
- Rule: `~/.claude/rules/obsidian-plugin-update-via-brat.md` (dotfiles 366477d)