### PR TITLE
fix(plugin): skip exocmd-bindings indexer on mobile by default (#3250)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -988,10 +988,16 @@ export default class ExocortexPlugin extends Plugin {
                 //
                 // Issue #3250 — gated behind a mobile-aware predicate. On
                 // iOS the indexer's full vault walk + per-class resolve
-                // tipped the plugin process over the jetsam memory budget
-                // (15-30 s restart loop). Mobile users skip the indexer by
-                // default; the toggle re-enables it for power users (iPad
-                // Pro etc). Desktop ignores the toggle — indexer always runs.
+                // caused a 15-30 s restart loop. Root kill mechanism not
+                // isolated from JetsamEvent logs (Obsidian absent from the
+                // sample crash reports) — most likely candidates are
+                // memory-pressure-driven per-process-limit kills or
+                // main-thread-block watchdog kills, since both are
+                // consistent with a synchronous full-vault scan on a
+                // memory-constrained device. Mobile users skip the indexer
+                // by default; the toggle re-enables it for power users
+                // (iPad Pro etc). Desktop ignores the toggle — indexer
+                // always runs there.
                 if (
                   !shouldRunExocmdIndexer(
                     Platform.isMobile,

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import {
   MarkdownPostProcessorContext,
   MarkdownView,
+  Platform,
   Plugin,
   TFile,
 } from "obsidian";
@@ -68,6 +69,7 @@ import {
   DEFAULT_CACHE_FILE_PATH,
   type CacheFileSystem,
 } from "./cache/ExocmdBindingsCache";
+import { shouldRunExocmdIndexer } from "./cache/shouldRunExocmdIndexer";
 import {
   ExocmdBindingsIndexer,
   type FrontmatterRecord,
@@ -983,42 +985,61 @@ export default class ExocortexPlugin extends Plugin {
                 // immediately. Errors are swallowed: a failed indexer
                 // run only means the next cold start falls back to the
                 // existing fast-path behaviour — never a regression.
-                try {
-                  const indexer = new ExocmdBindingsIndexer({
-                    cache: bindingsCache,
-                    vaultSource: {
-                      listAllAssets: (): Iterable<FrontmatterRecord> => {
-                        const files = this.app.vault.getMarkdownFiles();
-                        const records: FrontmatterRecord[] = [];
-                        for (const f of files) {
-                          const fm = this.app.metadataCache.getFileCache(f)
-                            ?.frontmatter as Record<string, unknown> | undefined;
-                          records.push({
-                            path: f.path,
-                            frontmatter: fm ?? null,
-                          });
-                        }
-                        return records;
-                      },
-                    },
-                    commandResolver: this.commandResolver,
-                    preconditionEvaluator: this.preconditionEvaluator,
-                    logger: this.logger,
-                  });
-                  const summary = await indexer.runFullScan();
+                //
+                // Issue #3250 — gated behind a mobile-aware predicate. On
+                // iOS the indexer's full vault walk + per-class resolve
+                // tipped the plugin process over the jetsam memory budget
+                // (15-30 s restart loop). Mobile users skip the indexer by
+                // default; the toggle re-enables it for power users (iPad
+                // Pro etc). Desktop ignores the toggle — indexer always runs.
+                if (
+                  !shouldRunExocmdIndexer(
+                    Platform.isMobile,
+                    this.settings.exocmdBindingsCacheEnabledOnMobile,
+                  )
+                ) {
                   this.logger.info(
-                    `[ExocortexPlugin] exocmd-bindings cache populated`,
-                    {
-                      classesScanned: summary.classesScanned,
-                      classesWritten: summary.classesWritten,
-                      assetsConsidered: summary.assetsConsidered,
-                      errors: summary.errors,
-                    },
+                    "[ExocortexPlugin] exocmd-bindings indexer skipped " +
+                      "(mobile platform, opt-in toggle disabled; see #3250)",
                   );
-                } catch (err) {
-                  this.logger.warn(
-                    `[ExocortexPlugin] exocmd-bindings indexer failed (non-fatal): ${String(err)}`,
-                  );
+                } else {
+                  try {
+                    const indexer = new ExocmdBindingsIndexer({
+                      cache: bindingsCache,
+                      vaultSource: {
+                        listAllAssets: (): Iterable<FrontmatterRecord> => {
+                          const files = this.app.vault.getMarkdownFiles();
+                          const records: FrontmatterRecord[] = [];
+                          for (const f of files) {
+                            const fm = this.app.metadataCache.getFileCache(f)
+                              ?.frontmatter as Record<string, unknown> | undefined;
+                            records.push({
+                              path: f.path,
+                              frontmatter: fm ?? null,
+                            });
+                          }
+                          return records;
+                        },
+                      },
+                      commandResolver: this.commandResolver,
+                      preconditionEvaluator: this.preconditionEvaluator,
+                      logger: this.logger,
+                    });
+                    const summary = await indexer.runFullScan();
+                    this.logger.info(
+                      `[ExocortexPlugin] exocmd-bindings cache populated`,
+                      {
+                        classesScanned: summary.classesScanned,
+                        classesWritten: summary.classesWritten,
+                        assetsConsidered: summary.assetsConsidered,
+                        errors: summary.errors,
+                      },
+                    );
+                  } catch (err) {
+                    this.logger.warn(
+                      `[ExocortexPlugin] exocmd-bindings indexer failed (non-fatal): ${String(err)}`,
+                    );
+                  }
                 }
               })
               .catch((err) => {

--- a/packages/obsidian-plugin/src/cache/shouldRunExocmdIndexer.ts
+++ b/packages/obsidian-plugin/src/cache/shouldRunExocmdIndexer.ts
@@ -1,0 +1,27 @@
+/**
+ * Decide whether to run `ExocmdBindingsIndexer.runFullScan()` on cold start.
+ *
+ * # Why this is a separate function
+ *
+ * Issue #3250 — on iOS the indexer's per-startup full vault scan tipped the
+ * plugin process over the jetsam memory budget, causing Obsidian to restart
+ * every 15-30 seconds. The fix gates the indexer behind a mobile-aware
+ * predicate so mobile users get a stable plugin by default and can opt in
+ * if they have headroom (iPad Pro, etc).
+ *
+ * The predicate is extracted as a pure function so the four-branch decision
+ * table (mobile × toggle) can be unit-tested without instantiating the
+ * plugin or mocking the Obsidian `Platform` module.
+ *
+ * @param isMobile      Value of `Platform.isMobile` at call site.
+ * @param enabledOnMobile  User setting `exocmdBindingsCacheEnabledOnMobile`.
+ *                      Ignored when `isMobile === false` (desktop always runs).
+ * @returns `true` if `runFullScan()` should execute, `false` if it should skip.
+ */
+export function shouldRunExocmdIndexer(
+  isMobile: boolean,
+  enabledOnMobile: boolean,
+): boolean {
+  if (!isMobile) return true;
+  return enabledOnMobile;
+}

--- a/packages/obsidian-plugin/src/cache/shouldRunExocmdIndexer.ts
+++ b/packages/obsidian-plugin/src/cache/shouldRunExocmdIndexer.ts
@@ -3,11 +3,15 @@
  *
  * # Why this is a separate function
  *
- * Issue #3250 — on iOS the indexer's per-startup full vault scan tipped the
- * plugin process over the jetsam memory budget, causing Obsidian to restart
- * every 15-30 seconds. The fix gates the indexer behind a mobile-aware
- * predicate so mobile users get a stable plugin by default and can opt in
- * if they have headroom (iPad Pro, etc).
+ * Issue #3250 — on iOS the indexer's per-startup full vault walk + per-class
+ * `CommandResolver` pass caused Obsidian to restart every 15-30 seconds. The
+ * exact kernel kill mechanism was not isolated from JetsamEvent logs (Obsidian
+ * did not appear in the user's three sample events as a killed process); the
+ * most likely candidates are memory-pressure-driven per-process-limit kills
+ * and main-thread-block-driven watchdog kills, since both are consistent with
+ * a synchronous full-vault scan on a memory-constrained device. The fix gates
+ * the indexer behind a mobile-aware predicate so mobile users get a stable
+ * plugin by default and can opt in if they have headroom (iPad Pro, etc).
  *
  * The predicate is extracted as a pure function so the four-branch decision
  * table (mobile × toggle) can be unit-tested without instantiating the

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -145,6 +145,15 @@ export interface ExocortexSettings {
    * takes effect immediately, no plugin reload required.
    */
   enablePropertiesLabelPatch: boolean;
+  /**
+   * Issue #3250 — on iOS the exocmd-bindings indexer's per-startup full
+   * vault scan tipped the plugin process over the jetsam memory budget,
+   * causing Obsidian to restart every 15-30 seconds. The indexer is now
+   * skipped on mobile by default. Power-users (iPad Pro with headroom)
+   * can flip this toggle to re-enable it. Desktop ignores the toggle —
+   * indexer always runs there.
+   */
+  exocmdBindingsCacheEnabledOnMobile: boolean;
   [key: string]: unknown;
 }
 
@@ -171,4 +180,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   enableSparqlAutoExecute: false,
   enableShaclValidation: false,
   enablePropertiesLabelPatch: true,
+  exocmdBindingsCacheEnabledOnMobile: false,
 };

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -147,11 +147,13 @@ export interface ExocortexSettings {
   enablePropertiesLabelPatch: boolean;
   /**
    * Issue #3250 — on iOS the exocmd-bindings indexer's per-startup full
-   * vault scan tipped the plugin process over the jetsam memory budget,
-   * causing Obsidian to restart every 15-30 seconds. The indexer is now
-   * skipped on mobile by default. Power-users (iPad Pro with headroom)
-   * can flip this toggle to re-enable it. Desktop ignores the toggle —
-   * indexer always runs there.
+   * vault scan caused Obsidian to restart every 15-30 seconds. Root
+   * kill mechanism not isolated from JetsamEvent logs (Obsidian absent
+   * from sample crash reports); most likely candidates are memory-
+   * pressure-driven per-process-limit kills or main-thread-block
+   * watchdog kills. The indexer is now skipped on mobile by default.
+   * Power-users (iPad Pro with headroom) can flip this toggle to
+   * re-enable it. Desktop ignores the toggle — indexer always runs there.
    */
   exocmdBindingsCacheEnabledOnMobile: boolean;
   [key: string]: unknown;

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -113,6 +113,25 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Enable exocmd bindings cache indexer on mobile")
+      .setDesc(
+        "Build the exocmd-bindings disk cache on mobile (iOS/Android). " +
+          "Off by default because the full-vault scan caused iOS to " +
+          "OOM-kill Obsidian every 15-30 seconds (issue #3250). " +
+          "Enable only if you have a high-memory device (e.g. iPad Pro) " +
+          "and want faster cold-start buttons. Desktop ignores this " +
+          "toggle — the indexer always runs there.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.exocmdBindingsCacheEnabledOnMobile)
+          .onChange(async (value) => {
+            this.plugin.settings.exocmdBindingsCacheEnabledOnMobile = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Enable custom layouts")
       .setDesc(
         "Render class-specific layouts defined via exo__Layout assets. " +

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -116,12 +116,13 @@ export class ExocortexSettingTab extends PluginSettingTab {
       .setName("Enable exocmd bindings cache indexer on mobile")
       .setDesc(
         "Build the exocmd-bindings disk cache on mobile (iOS/Android). " +
-          "Off by default because the full-vault scan caused iOS to " +
-          "OOM-kill Obsidian every 15-30 seconds (issue #3250). " +
-          "Enable only if you have a high-memory device (e.g. iPad Pro) " +
-          "and want faster cold-start buttons. Desktop ignores this " +
-          "toggle — the indexer always runs there. " +
-          "Changes take effect on the next Obsidian restart.",
+          "Off by default because the full-vault scan caused Obsidian " +
+          "to restart every 15-30 seconds on iOS (issue #3250 — root " +
+          "kill mechanism not isolated from system logs, likely memory " +
+          "pressure or main-thread block). Enable only if you have a " +
+          "high-memory device (e.g. iPad Pro) and want faster cold-start " +
+          "buttons. Desktop ignores this toggle — the indexer always " +
+          "runs there. Changes take effect on the next Obsidian restart.",
       )
       .addToggle((toggle) =>
         toggle

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -120,7 +120,8 @@ export class ExocortexSettingTab extends PluginSettingTab {
           "OOM-kill Obsidian every 15-30 seconds (issue #3250). " +
           "Enable only if you have a high-memory device (e.g. iPad Pro) " +
           "and want faster cold-start buttons. Desktop ignores this " +
-          "toggle — the indexer always runs there.",
+          "toggle — the indexer always runs there. " +
+          "Changes take effect on the next Obsidian restart.",
       )
       .addToggle((toggle) =>
         toggle

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -127,9 +127,9 @@ describe("ExocortexSettingTab", () => {
       settingTab.display();
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
-      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 1 enableShaclValidation toggle (P1.12) + 1 enablePropertiesLabelPatch toggle (RFC-030) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 29
+      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 1 enableShaclValidation toggle (P1.12) + 1 enablePropertiesLabelPatch toggle (RFC-030) + 1 exocmdBindingsCacheEnabledOnMobile toggle (#3250) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 30
       // Log channels section: 1 heading + 4 log level rows = 5
-      expect(MockSetting).toHaveBeenCalledTimes(29);
+      expect(MockSetting).toHaveBeenCalledTimes(30);
     });
 
     it("should render layout visibility toggle as first setting", () => {

--- a/packages/obsidian-plugin/tests/unit/cache/shouldRunExocmdIndexer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/cache/shouldRunExocmdIndexer.test.ts
@@ -1,0 +1,23 @@
+import { shouldRunExocmdIndexer } from "@plugin/cache/shouldRunExocmdIndexer";
+
+describe("shouldRunExocmdIndexer (issue #3250)", () => {
+  describe("desktop branch — toggle is ignored", () => {
+    it("runs on desktop when mobile-toggle is off", () => {
+      expect(shouldRunExocmdIndexer(false, false)).toBe(true);
+    });
+
+    it("runs on desktop when mobile-toggle is on", () => {
+      expect(shouldRunExocmdIndexer(false, true)).toBe(true);
+    });
+  });
+
+  describe("mobile branch — toggle is honoured", () => {
+    it("skips on mobile when mobile-toggle is off (default behaviour)", () => {
+      expect(shouldRunExocmdIndexer(true, false)).toBe(false);
+    });
+
+    it("runs on mobile when mobile-toggle is on (opt-in)", () => {
+      expect(shouldRunExocmdIndexer(true, true)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 fix for #3250 — Obsidian on iOS was restarting every 15-30 s after the v16.7.x exocmd-bindings disk-cache feature shipped. The user empirically confirmed (2026-05-24) that disabling the exocortex plugin stops the restart loop, so `ExocmdBindingsIndexer.runFullScan()` (which performs a full vault walk + per-class `CommandResolver.resolveForAssetMulti()` on every cold start) is conclusively the trigger.

**Root kernel-kill mechanism not isolated.** The user pulled three `JetsamEvent-*.ips` reports from iPhone Analytics Data (2026-05-23 01:05, 2026-05-24 03:12, 2026-05-24 10:09) — Obsidian is absent from all three (`grep -c obsidian` = 0). Likely candidates that remain consistent with the empirical "disable plugin → loop stops" finding:

- **Memory pressure** tipping Obsidian past a per-process limit (`per-process-limit` / `highwater` jetsam reasons appeared in the sample logs for other processes — YouTube, WebKit.WebContent — under tight memory at the time, but Obsidian itself was not in the lists).
- **Main-thread block** from the synchronous full-vault scan triggering a watchdog kill that produces a different crash-report family (not `JetsamEvent-*.ips`).

Phase 2 mitigation works for either mechanism because it short-circuits the entire `runFullScan()` block on mobile.

Gate the indexer behind a mobile-aware predicate:

- **Desktop (`!Platform.isMobile`):** behaviour unchanged — indexer runs on every cold start, ignores the toggle
- **Mobile (`Platform.isMobile`):** indexer skipped by default, runs only when the new opt-in toggle `exocmdBindingsCacheEnabledOnMobile` is true (off by default)

Predicate extracted as a 4-line pure function `shouldRunExocmdIndexer(isMobile, enabledOnMobile)` so the decision table can be unit-tested without mocking the Obsidian `Platform` module.

Closes #3250.

## What changed

| File | Change |
|---|---|
| `packages/obsidian-plugin/src/cache/shouldRunExocmdIndexer.ts` | **new** — pure predicate |
| `packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts` | new field `exocmdBindingsCacheEnabledOnMobile: boolean` (default `false`) |
| `packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts` | new toggle UI |
| `packages/obsidian-plugin/src/ExocortexPlugin.ts` | import `Platform`, wrap indexer block in `if (shouldRunExocmdIndexer(...))` |
| `packages/obsidian-plugin/tests/unit/cache/shouldRunExocmdIndexer.test.ts` | **new** — 4-branch decision table |
| `packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts` | bump toggle count 29 → 30 |

## Out of scope (follow-up PRs per RFC `d4c9c992`)

- **Phase 1 — cache freshness short-circuit:** skip `runFullScan()` on desktop too when loaded snapshot is within TTL and matches `plugin_version`. Orthogonal desktop optimization.
- **Phase 3 — relocate cache out of vault root:** move from `.exocortex/cache/exocmd-bindings.json` to `<manifest.dir>/cache/exocmd-bindings.json` to eliminate Obsidian Sync / iCloud churn.

RFC source (vault-exodev): `d4c9c992-e26b-4ef7-b63c-94db2006e632`.

## Test plan

- [x] `npm run check:types` clean
- [x] `npm run lint` clean (2 pre-existing warnings unrelated)
- [x] `npm run test:unit` — 4940/4944 pass (3 pre-existing skipped, 0 fails after my SettingsTab count bump)
- [x] New `shouldRunExocmdIndexer.test.ts` — 4/4 pass covering full decision table
- [x] CI green on `a8a38e45` — 35/35 (initial flaky `e2e-shard (4)` cleared on rerun)
- [x] code-reviewer agent — APPROVE, 0 CRITICAL/HIGH/MEDIUM, 3 LOW (1 applied, 2 advised-skip)
- [x] advisor round-2 — no blockers
- [x] JetsamEvent verification gate — outcome: framing softened (Obsidian absent from sample logs) but mitigation still defensible per empirical "disable plugin → loop stops"
- [ ] Post-merge: user updates plugin via BRAT on iPhone → no restart loop within ≥5 min uptime