### PR TITLE
fix(properties): match Obsidian link semantics for label click (RFC-030 follow-up)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts
@@ -1,4 +1,5 @@
-import { Plugin, TFile } from "obsidian";
+import { Keymap, Plugin, TFile } from "obsidian";
+import type { PaneType } from "obsidian";
 
 /**
  * PropertiesLabelPatch - Patches Obsidian's Properties block to show human-readable
@@ -62,6 +63,7 @@ interface PatchRecord {
   textNode: Text | null;
   originalTextContent: string | null;
   clickHandler: (e: MouseEvent) => void;
+  auxClickHandler: (e: MouseEvent) => void;
 }
 
 /**
@@ -398,9 +400,20 @@ export class PropertiesLabelPatch {
     const clickHandler = (e: MouseEvent): void => {
       e.preventDefault();
       e.stopPropagation();
-      this.openDefinition(resolved.file);
+      this.openDefinition(resolved.file, e);
+    };
+    // auxclick: middle-mouse-button (button === 1) opens in a new tab, matching
+    // Obsidian's native internal-link behavior. Other auxclick buttons (e.g. 2
+    // = right click) are ignored — they should fall through to native context
+    // menu handling.
+    const auxClickHandler = (e: MouseEvent): void => {
+      if (e.button !== 1) return;
+      e.preventDefault();
+      e.stopPropagation();
+      this.openDefinition(resolved.file, e);
     };
     displaySpan.addEventListener("click", clickHandler);
+    displaySpan.addEventListener("auxclick", auxClickHandler);
 
     keyEl.classList.add(CLICKABLE_CLASS);
     propertyEl.setAttribute(PATCHED_ATTR, "true");
@@ -412,6 +425,7 @@ export class PropertiesLabelPatch {
       textNode,
       originalTextContent,
       clickHandler,
+      auxClickHandler,
     });
   }
 
@@ -447,8 +461,25 @@ export class PropertiesLabelPatch {
     return null;
   }
 
-  private openDefinition(file: TFile): void {
-    const leaf = this.app.workspace.getLeaf("tab");
+  private openDefinition(file: TFile, event?: MouseEvent): void {
+    // Match Obsidian's native link behavior:
+    //   plain click           → same tab (getLeaf(false) reuses current leaf)
+    //   Cmd/Ctrl click        → new tab        ('tab')
+    //   Cmd/Ctrl+Alt click    → split pane     ('split')
+    //   Cmd/Ctrl+Alt+Shift    → new window     ('window')
+    //   middle-mouse click    → new tab        (resolved via auxclick handler
+    //                                           that delegates here with e.button=1)
+    // `Keymap.isModEvent` returns the correct PaneType (or false) for the
+    // platform-default modifier (Cmd on mac, Ctrl elsewhere).
+    let leafArg: PaneType | boolean = false;
+    if (event) {
+      if (event.type === "auxclick" && event.button === 1) {
+        leafArg = "tab";
+      } else {
+        leafArg = Keymap.isModEvent(event);
+      }
+    }
+    const leaf = this.app.workspace.getLeaf(leafArg as PaneType | boolean);
     if (leaf && typeof (leaf as { openFile?: (f: TFile) => Promise<void> }).openFile === "function") {
       void (leaf as { openFile: (f: TFile) => Promise<void> }).openFile(file);
     }
@@ -495,6 +526,7 @@ export class PropertiesLabelPatch {
     for (const record of this.patched) {
       try {
         record.displaySpan.removeEventListener("click", record.clickHandler);
+        record.displaySpan.removeEventListener("auxclick", record.auxClickHandler);
         record.displaySpan.remove();
 
         if (record.input) {

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts
@@ -8,6 +8,20 @@ jest.mock("obsidian", () => ({
   Plugin: class {},
   TFile: class {},
   Notice: jest.fn(),
+  Keymap: {
+    // Minimal stub that mirrors Obsidian's behavior for the modifier
+    // combinations we care about in tests. The real implementation also
+    // distinguishes split/window via Alt/Shift but tests below exercise only
+    // the plain-click and Mod+click cases.
+    isModEvent: (evt?: MouseEvent | KeyboardEvent): "tab" | "split" | "window" | false => {
+      if (!evt) return false;
+      const mod = (evt as MouseEvent).metaKey || (evt as MouseEvent).ctrlKey;
+      if (!mod) return false;
+      if ((evt as MouseEvent).altKey && (evt as MouseEvent).shiftKey) return "window";
+      if ((evt as MouseEvent).altKey) return "split";
+      return "tab";
+    },
+  },
 }));
 
 interface FakeFile {
@@ -499,18 +513,96 @@ describe("PropertiesLabelPatch", () => {
   // Scenario B — click navigates to definition
   // ============================================================
   describe("Scenario B: clicking readable label opens definition", () => {
-    it("click on display span calls openFile for the definition asset", () => {
+    it("plain click opens definition in the SAME tab (getLeaf(false))", () => {
       const row = createPropertyRow({ inputValue: "ems__Effort_status" });
       mockMetadataContainer.appendChild(row);
 
       patch.enable();
 
       const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
-      span.click();
+      span.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+
+      expect(mockApp.workspace.getLeaf).toHaveBeenCalledWith(false);
+      expect(openFileMock).toHaveBeenCalledTimes(1);
+      expect(openedFiles[0]).toBe(FILE_EFFORT_STATUS);
+    });
+
+    it("Cmd-click (metaKey) opens definition in a NEW tab (getLeaf('tab'))", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_status" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      span.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          metaKey: true,
+        })
+      );
 
       expect(mockApp.workspace.getLeaf).toHaveBeenCalledWith("tab");
       expect(openFileMock).toHaveBeenCalledTimes(1);
       expect(openedFiles[0]).toBe(FILE_EFFORT_STATUS);
+    });
+
+    it("Ctrl-click (ctrlKey) opens definition in a NEW tab — non-mac fallback", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_status" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      span.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          ctrlKey: true,
+        })
+      );
+
+      expect(mockApp.workspace.getLeaf).toHaveBeenCalledWith("tab");
+      expect(openFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("middle-mouse auxclick (button=1) opens definition in a NEW tab", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_status" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      span.dispatchEvent(
+        new MouseEvent("auxclick", {
+          bubbles: true,
+          cancelable: true,
+          button: 1,
+        })
+      );
+
+      expect(mockApp.workspace.getLeaf).toHaveBeenCalledWith("tab");
+      expect(openFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("right-mouse auxclick (button=2) does NOT open the definition", () => {
+      const row = createPropertyRow({ inputValue: "ems__Effort_status" });
+      mockMetadataContainer.appendChild(row);
+
+      patch.enable();
+
+      const span = row.querySelector<HTMLSpanElement>(".exo-label-display")!;
+      span.dispatchEvent(
+        new MouseEvent("auxclick", {
+          bubbles: true,
+          cancelable: true,
+          button: 2,
+        })
+      );
+
+      expect(openFileMock).not.toHaveBeenCalled();
     });
 
     it("click event does NOT propagate to the input (no frontmatter corruption)", () => {


### PR DESCRIPTION
## Summary

`PropertiesLabelPatch` (RFC-030, PR #3246) made predicate labels in the Obsidian Properties block clickable, but the click handler always called `getLeaf("tab")`, so **every click opened the predicate definition in a new tab** — inconsistent with every other Obsidian link, which opens in the current tab on plain click and only opens a new tab with the platform modifier (Cmd on macOS, Ctrl elsewhere) or middle-mouse.

User report (2026-05-24): «если нажать на ссылку, то она всегда открывается в новой вкладке. Хочу, чтобы поведение было такое же, как у других ссылок».

## Fix

- `openDefinition` now takes the `MouseEvent` and computes the leaf mode via `Keymap.isModEvent(evt)` — same canonical pattern as `LinkHandlers.ts:17`, `DailyTasksRenderer.ts:144`, `AreaTreeRenderer.ts:81`. Returns `false` (current tab), `"tab"`, `"split"`, or `"window"` based on modifier keys.
- Separate `auxclick` listener so middle-mouse-button (`button === 1`) also opens in a new tab, matching native internal-link behavior. Other auxclick buttons (e.g. `button === 2` right-click) fall through untouched so context menu still works.
- `PatchRecord` tracks `auxClickHandler` so `disable()` removes both listeners on cleanup.

Mapping (matches native internal-link):

| Input | Result |
|---|---|
| Plain click | Same tab (`getLeaf(false)`) |
| Cmd/Ctrl + click | New tab (`getLeaf("tab")`) |
| Cmd/Ctrl + Alt + click | Split (`getLeaf("split")`) |
| Cmd/Ctrl + Alt + Shift + click | New window (`getLeaf("window")`) |
| Middle-mouse | New tab (auxclick handler) |
| Right-mouse | Untouched (native context menu) |

## Test plan

Unit suite: **43 → 47 passing** (`PropertiesLabelPatch.test.ts`).

- [x] Plain click → `getLeaf(false)` + `openFile` called once (replaces old assertion that expected `"tab"`)
- [x] Cmd-click (metaKey) → `getLeaf("tab")`
- [x] Ctrl-click (ctrlKey) → `getLeaf("tab")` — non-mac fallback
- [x] Middle auxclick (button=1) → `getLeaf("tab")`
- [x] Right auxclick (button=2) → no `openFile` call
- [x] Existing «click does not propagate to input» test still passes (preserves no-corruption invariant)
- [x] `npm run check:types` clean
- [x] `npm run lint` clean (2 pre-existing warnings in unrelated files)
- [x] BDD coverage 100% (204/204), Archgate 13/13

**Manual UI verification path (post-merge):**

Per `~/.claude/rules/obsidian-plugin-update-via-brat.md` — verify through real upgrade path, not manual file copy:

1. Merge → Auto Release publishes new version
2. In Obsidian: `Cmd+P` → `BRAT: Check for updates to all beta plugins`
3. `Cmd+P` → `Reload app without saving`
4. Open any asset with property labels → click a label → opens in **current tab** ✓
5. Cmd-click a label → opens in **new tab** ✓

## Files

- `packages/obsidian-plugin/src/presentation/properties/PropertiesLabelPatch.ts` (+24 / -3)
- `packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts` (+106 / -3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)