### PR TITLE
feat(exocortex): LazyAssetGraphLoader (RFC c7da0bca Phase 2)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -217,6 +217,12 @@ export { RDFSInferenceEngine } from "./infrastructure/rdf/RDFSInferenceEngine";
 export { NonInheritablePropertyRegistry } from "./services/NonInheritablePropertyRegistry";
 export { PropertyCardinalityRegistry } from "./services/PropertyCardinalityRegistry";
 export { PrototypeChainMaterializer, INFERRED_GRAPH } from "./services/PrototypeChainMaterializer";
+export {
+  LazyAssetGraphLoader,
+  MAX_LAZY_DEPTH,
+  type INoteConverter,
+} from "./services/LazyAssetGraphLoader";
+export type { IFileResolver } from "./interfaces/IFileResolver";
 export { SourceAnnotator, SOURCE_VARIABLE, type TripleSource } from "./services/SourceAnnotator";
 export {
   NoteToRDFConverter,

--- a/packages/exocortex/src/interfaces/IFileResolver.ts
+++ b/packages/exocortex/src/interfaces/IFileResolver.ts
@@ -1,0 +1,26 @@
+import type { IRI } from "../domain/models/rdf/IRI";
+import type { IFile } from "./IVaultAdapter";
+
+/**
+ * Resolves vault asset IRIs to concrete `IFile` handles.
+ *
+ * Decouples `LazyAssetGraphLoader` (and any future on-demand loader) from
+ * the IRI→path encoding. Production wires a wrapper that strips the
+ * `obsidian://vault/` prefix and URL-decodes the remainder, then delegates
+ * to `IVaultFileReader.getAbstractFileByPath`. Tests inject in-memory fakes.
+ *
+ * Returning `null` for an unresolvable IRI is normal — the caller must
+ * treat the absence gracefully (e.g. emit a warn-level diagnostic and
+ * continue). Throwing from this method is reserved for genuine I/O errors.
+ *
+ * @see RFC c7da0bca Phase 2 — Lazy precondition evaluation
+ */
+export interface IFileResolver {
+  /**
+   * @param iri - The IRI of a vault asset (typically `obsidian://vault/...`).
+   * @returns The corresponding `IFile`, or `null` when no file exists for
+   *          this IRI (e.g. broken wikilink, IRI built from a value that
+   *          doesn't correspond to a real vault asset).
+   */
+  resolveByIRI(iri: IRI): IFile | null;
+}

--- a/packages/exocortex/src/services/LazyAssetGraphLoader.ts
+++ b/packages/exocortex/src/services/LazyAssetGraphLoader.ts
@@ -1,0 +1,191 @@
+import { injectable } from "tsyringe";
+import type { ITripleStore } from "../interfaces/ITripleStore";
+import type { IFileResolver } from "../interfaces/IFileResolver";
+import type { IFile } from "../interfaces/IVaultAdapter";
+import type { Triple } from "../domain/models/rdf/Triple";
+import { IRI } from "../domain/models/rdf/IRI";
+import { Namespace } from "../domain/models/rdf/Namespace";
+
+/**
+ * Maximum recursion depth for class + prototype chain traversal.
+ *
+ * Matches `MAX_PROTOTYPE_DEPTH` in `PrototypeChainMaterializer` for
+ * consistency: 10 levels is generous for any real ontology and bounded
+ * enough to protect against pathological cycles that slip past the
+ * loaded-set guard (e.g. an asset that references itself via a
+ * non-canonical IRI variant).
+ */
+export const MAX_LAZY_DEPTH = 10;
+
+/**
+ * Narrow interface over `NoteToRDFConverter` that the loader depends on.
+ * Lets tests pass a structural fake without instantiating the full
+ * converter or its `IVaultAdapter` dependency tree.
+ */
+export interface INoteConverter {
+  convertNote(file: IFile): Promise<Triple[]>;
+  notePathToIRI(path: string): IRI;
+}
+
+/**
+ * On-demand asset-graph expansion (RFC `c7da0bca` Phase 2).
+ *
+ * Replaces the cold-start `convertVault()` full-walk with a per-render
+ * lazy strategy: when a layout renders asset N, the loader ensures that
+ * N + its class chain + its prototype chain are materialised in the
+ * triple store, then the existing `PreconditionEvaluator` runs against
+ * the now-up-to-date store.
+ *
+ * # Loading algorithm
+ *
+ * For each new file:
+ * 1. Call `INoteConverter.convertNote(file)` to obtain the file's
+ *    triples; add them to the store.
+ * 2. Inspect the loaded triples for `exo:Instance_class`,
+ *    `exo:Class_superClass`, and `exo:Asset_prototype` objects.
+ * 3. For each IRI object referenced via those predicates, resolve it
+ *    to an `IFile` via `IFileResolver.resolveByIRI`, then recursively
+ *    ensure-load it.
+ *
+ * Recursion through `ensureLoadedByIRI` naturally produces the
+ * transitive closure: a class's `exo:Class_superClass` triples become
+ * visible only after the class file is loaded, so super-classes are
+ * walked one BFS level at a time.
+ *
+ * # Idempotency + cycle safety
+ *
+ * - `loadedIRIs` Set tracks every IRI ever loaded in this session;
+ *   `ensureFileLoaded` and `ensureLoadedByIRI` early-return when their
+ *   target is already in the set.
+ * - A self-cycle (`A → A`), mutual cycle (`A → B → A`), or longer
+ *   cycle is broken at the second visit because the set already
+ *   contains the IRI.
+ * - `MAX_LAZY_DEPTH` is a defence-in-depth bound: if a pathological
+ *   non-canonical IRI variant defeats the set (e.g. case difference,
+ *   URL-encoding difference), the depth check still terminates the
+ *   recursion.
+ *
+ * # Out of scope for Phase 2
+ *
+ * - **No edit invalidation.** When an asset is edited mid-session,
+ *   stale triples remain in the store. Phase 3's plugin wiring will
+ *   call a `forget` API or re-build the working store on file events.
+ * - **No TBox preload.** Phase 3 wires startup bootstrap of
+ *   `assetspaces/{exo,ems,ims,exocmd}` by calling `ensureFileLoaded`
+ *   on each ontology asset upfront.
+ * - **No SPARQL-AST inspection for data-driven preconditions.** Phase 1
+ *   audit (`9271ef44`) found zero data-driven preconditions in the
+ *   in-scope vaults, so AST-walk-then-retry is deferred per RFC
+ *   `c7da0bca` Q4 decision.
+ *
+ * @see RFC c7da0bca, Phase 1 audit 9271ef44
+ */
+@injectable()
+export class LazyAssetGraphLoader {
+  private readonly loadedIRIs = new Set<string>();
+  private readonly instanceClassPredicate: IRI;
+  private readonly superClassPredicate: IRI;
+  private readonly prototypePredicate: IRI;
+
+  constructor(
+    private readonly converter: INoteConverter,
+    private readonly fileResolver: IFileResolver,
+    private readonly store: ITripleStore,
+  ) {
+    // Pre-compute the three predicate IRIs we filter triples by.
+    this.instanceClassPredicate = Namespace.EXO.term("Instance_class");
+    this.superClassPredicate = Namespace.EXO.term("Class_superClass");
+    this.prototypePredicate = Namespace.EXO.term("Asset_prototype");
+  }
+
+  /**
+   * Idempotently ensure that the given file's triples + its class chain
+   * + its prototype chain are present in the triple store.
+   *
+   * @param file - The file whose graph slice to load.
+   * @param depth - Internal recursion-depth counter (callers should
+   *                omit; defaults to 0).
+   */
+  async ensureFileLoaded(file: IFile, depth = 0): Promise<void> {
+    if (depth >= MAX_LAZY_DEPTH) return;
+    const iri = this.converter.notePathToIRI(file.path).value;
+    if (this.loadedIRIs.has(iri)) return;
+    this.loadedIRIs.add(iri);
+
+    const triples = await this.converter.convertNote(file);
+    for (const t of triples) {
+      await this.store.add(t);
+    }
+
+    await this.walkClassAndPrototypeRelations(triples, depth + 1);
+  }
+
+  /**
+   * Resolve an IRI to a file via the injected resolver, then ensure
+   * it's loaded. Returns silently if the resolver returns `null`
+   * (broken wikilink, IRI built from a string that doesn't correspond
+   * to a real vault asset).
+   *
+   * @param iri - The IRI of an asset to ensure-load.
+   * @param depth - Internal recursion-depth counter.
+   */
+  async ensureLoadedByIRI(iri: IRI, depth = 0): Promise<void> {
+    if (depth >= MAX_LAZY_DEPTH) return;
+    if (this.loadedIRIs.has(iri.value)) return;
+    const file = this.fileResolver.resolveByIRI(iri);
+    if (file === null) return;
+    await this.ensureFileLoaded(file, depth);
+  }
+
+  /**
+   * Has the given IRI been loaded? Exposed for tests + future hot-path
+   * optimisations (e.g. Phase 3 can short-circuit redundant
+   * `ensureLoadedByIRI` calls).
+   */
+  isLoaded(iri: IRI): boolean {
+    return this.loadedIRIs.has(iri.value);
+  }
+
+  /**
+   * Count of distinct IRIs loaded so far. Useful for observability +
+   * test assertions ("did the chain walk reach all 3 expected files?").
+   */
+  get loadedCount(): number {
+    return this.loadedIRIs.size;
+  }
+
+  /**
+   * Test-only hook to reset the loaded set. Production callers must
+   * never call this — the set is intentionally append-only for the
+   * session.
+   */
+  clearForTests(): void {
+    this.loadedIRIs.clear();
+  }
+
+  /**
+   * Scan the newly-loaded triples for class + prototype links and
+   * recursively ensure each referenced asset is loaded.
+   */
+  private async walkClassAndPrototypeRelations(
+    triples: ReadonlyArray<Triple>,
+    depth: number,
+  ): Promise<void> {
+    const targets: IRI[] = [];
+    for (const t of triples) {
+      if (!(t.object instanceof IRI)) continue;
+      const predicateValue = t.predicate.value;
+      if (
+        predicateValue === this.instanceClassPredicate.value ||
+        predicateValue === this.superClassPredicate.value ||
+        predicateValue === this.prototypePredicate.value
+      ) {
+        targets.push(t.object);
+      }
+    }
+
+    for (const target of targets) {
+      await this.ensureLoadedByIRI(target, depth);
+    }
+  }
+}

--- a/packages/exocortex/src/services/LazyAssetGraphLoader.ts
+++ b/packages/exocortex/src/services/LazyAssetGraphLoader.ts
@@ -110,14 +110,24 @@ export class LazyAssetGraphLoader {
     if (depth >= MAX_LAZY_DEPTH) return;
     const iri = this.converter.notePathToIRI(file.path).value;
     if (this.loadedIRIs.has(iri)) return;
+
+    // Coalesce concurrent renders: setting the loaded mark BEFORE the
+    // `await` means a second `ensureFileLoaded(file)` fired in the same
+    // tick short-circuits via `loadedIRIs.has`. This avoids racing two
+    // `convertNote` calls for the same asset.
     this.loadedIRIs.add(iri);
-
-    const triples = await this.converter.convertNote(file);
-    for (const t of triples) {
-      await this.store.add(t);
+    try {
+      const triples = await this.converter.convertNote(file);
+      await this.store.addAll(triples);
+      await this.walkClassAndPrototypeRelations(triples, depth + 1);
+    } catch (err) {
+      // Rollback the loaded mark so the caller can retry. Without this
+      // a thrown `convertNote` would poison the IRI for the session —
+      // the next ensure-call would short-circuit on the loaded mark
+      // while the store has zero triples for the asset.
+      this.loadedIRIs.delete(iri);
+      throw err;
     }
-
-    await this.walkClassAndPrototypeRelations(triples, depth + 1);
   }
 
   /**

--- a/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
+++ b/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
@@ -1,0 +1,421 @@
+import {
+  LazyAssetGraphLoader,
+  MAX_LAZY_DEPTH,
+  type INoteConverter,
+} from "../../../src/services/LazyAssetGraphLoader";
+import type { IFileResolver } from "../../../src/interfaces/IFileResolver";
+import type { IFile } from "../../../src/interfaces/IVaultAdapter";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+describe("LazyAssetGraphLoader", () => {
+  // Predicates
+  const instanceClassPred = Namespace.EXO.term("Instance_class");
+  const superClassPred = Namespace.EXO.term("Class_superClass");
+  const prototypePred = Namespace.EXO.term("Asset_prototype");
+  const labelPred = Namespace.EXO.term("Asset_label");
+
+  /** Build the obsidian://vault/ IRI for a relative path. */
+  const pathToIRI = (path: string): IRI =>
+    new IRI(`obsidian://vault/${encodeURI(path)}`);
+
+  /** Build a minimal IFile for tests. */
+  const makeFile = (path: string): IFile => ({
+    path,
+    basename: path.split("/").pop()!.replace(/\.md$/, ""),
+    name: path.split("/").pop()!,
+    parent: null,
+  });
+
+  /**
+   * Test-only converter: maps path → triples. Tracks call counts so
+   * tests can assert idempotency.
+   */
+  class FakeConverter implements INoteConverter {
+    private readonly triplesByPath = new Map<string, Triple[]>();
+    public callCounts = new Map<string, number>();
+
+    registerFile(file: IFile, triples: Triple[]): void {
+      this.triplesByPath.set(file.path, triples);
+    }
+
+    async convertNote(file: IFile): Promise<Triple[]> {
+      const count = this.callCounts.get(file.path) ?? 0;
+      this.callCounts.set(file.path, count + 1);
+      return this.triplesByPath.get(file.path) ?? [];
+    }
+
+    notePathToIRI(path: string): IRI {
+      return pathToIRI(path);
+    }
+  }
+
+  /**
+   * Test-only resolver: maps IRI string → IFile. Returns null for
+   * unregistered IRIs (simulates broken wikilinks).
+   */
+  class FakeFileResolver implements IFileResolver {
+    private readonly filesByIRI = new Map<string, IFile>();
+
+    register(file: IFile): void {
+      this.filesByIRI.set(pathToIRI(file.path).value, file);
+    }
+
+    resolveByIRI(iri: IRI): IFile | null {
+      return this.filesByIRI.get(iri.value) ?? null;
+    }
+  }
+
+  let converter: FakeConverter;
+  let resolver: FakeFileResolver;
+  let store: InMemoryTripleStore;
+  let loader: LazyAssetGraphLoader;
+
+  beforeEach(() => {
+    converter = new FakeConverter();
+    resolver = new FakeFileResolver();
+    store = new InMemoryTripleStore();
+    loader = new LazyAssetGraphLoader(converter, resolver, store);
+  });
+
+  describe("ensureFileLoaded — base cases", () => {
+    it("loads a single file's triples into the store", async () => {
+      const file = makeFile("task.md");
+      const subject = pathToIRI("task.md");
+      converter.registerFile(file, [
+        new Triple(subject, labelPred, new Literal("Task")),
+      ]);
+
+      await loader.ensureFileLoaded(file);
+
+      expect(loader.loadedCount).toBe(1);
+      expect(loader.isLoaded(subject)).toBe(true);
+      const match = await store.match(subject, undefined, undefined);
+      expect(match).toHaveLength(1);
+    });
+
+    it("is idempotent — second call does not re-invoke convertNote", async () => {
+      const file = makeFile("task.md");
+      converter.registerFile(file, []);
+
+      await loader.ensureFileLoaded(file);
+      await loader.ensureFileLoaded(file);
+      await loader.ensureFileLoaded(file);
+
+      expect(converter.callCounts.get("task.md")).toBe(1);
+      expect(loader.loadedCount).toBe(1);
+    });
+
+    it("handles a file whose convertNote returns zero triples (empty asset)", async () => {
+      const file = makeFile("empty.md");
+      converter.registerFile(file, []);
+
+      await loader.ensureFileLoaded(file);
+
+      expect(loader.loadedCount).toBe(1);
+      expect(loader.isLoaded(pathToIRI("empty.md"))).toBe(true);
+    });
+  });
+
+  describe("class chain walk", () => {
+    it("loads the asset's declared classes via exo:Instance_class", async () => {
+      const taskFile = makeFile("my-task.md");
+      const classFile = makeFile("ems__Task.md");
+
+      converter.registerFile(taskFile, [
+        new Triple(
+          pathToIRI("my-task.md"),
+          instanceClassPred,
+          pathToIRI("ems__Task.md"),
+        ),
+      ]);
+      converter.registerFile(classFile, [
+        new Triple(
+          pathToIRI("ems__Task.md"),
+          labelPred,
+          new Literal("ems__Task"),
+        ),
+      ]);
+      resolver.register(classFile);
+
+      await loader.ensureFileLoaded(taskFile);
+
+      expect(loader.isLoaded(pathToIRI("my-task.md"))).toBe(true);
+      expect(loader.isLoaded(pathToIRI("ems__Task.md"))).toBe(true);
+      expect(loader.loadedCount).toBe(2);
+    });
+
+    it("iterates ALL Instance_class values (multi-class)", async () => {
+      const assetFile = makeFile("multi.md");
+      const classAFile = makeFile("ClassA.md");
+      const classBFile = makeFile("ClassB.md");
+
+      converter.registerFile(assetFile, [
+        new Triple(
+          pathToIRI("multi.md"),
+          instanceClassPred,
+          pathToIRI("ClassA.md"),
+        ),
+        new Triple(
+          pathToIRI("multi.md"),
+          instanceClassPred,
+          pathToIRI("ClassB.md"),
+        ),
+      ]);
+      converter.registerFile(classAFile, []);
+      converter.registerFile(classBFile, []);
+      resolver.register(classAFile);
+      resolver.register(classBFile);
+
+      await loader.ensureFileLoaded(assetFile);
+
+      expect(loader.isLoaded(pathToIRI("ClassA.md"))).toBe(true);
+      expect(loader.isLoaded(pathToIRI("ClassB.md"))).toBe(true);
+      expect(loader.loadedCount).toBe(3);
+    });
+
+    it("walks the superclass chain transitively (Class → superClass → superSuperClass)", async () => {
+      const taskFile = makeFile("my-task.md");
+      const taskClass = makeFile("ems__Task.md");
+      const effortClass = makeFile("ems__Effort.md");
+      const assetClass = makeFile("exo__Asset.md");
+
+      converter.registerFile(taskFile, [
+        new Triple(
+          pathToIRI("my-task.md"),
+          instanceClassPred,
+          pathToIRI("ems__Task.md"),
+        ),
+      ]);
+      converter.registerFile(taskClass, [
+        new Triple(
+          pathToIRI("ems__Task.md"),
+          superClassPred,
+          pathToIRI("ems__Effort.md"),
+        ),
+      ]);
+      converter.registerFile(effortClass, [
+        new Triple(
+          pathToIRI("ems__Effort.md"),
+          superClassPred,
+          pathToIRI("exo__Asset.md"),
+        ),
+      ]);
+      converter.registerFile(assetClass, []);
+      resolver.register(taskClass);
+      resolver.register(effortClass);
+      resolver.register(assetClass);
+
+      await loader.ensureFileLoaded(taskFile);
+
+      expect(loader.isLoaded(pathToIRI("ems__Task.md"))).toBe(true);
+      expect(loader.isLoaded(pathToIRI("ems__Effort.md"))).toBe(true);
+      expect(loader.isLoaded(pathToIRI("exo__Asset.md"))).toBe(true);
+      expect(loader.loadedCount).toBe(4);
+    });
+
+    it("returns silently when a referenced class IRI has no resolver entry (broken wikilink)", async () => {
+      const taskFile = makeFile("my-task.md");
+
+      converter.registerFile(taskFile, [
+        new Triple(
+          pathToIRI("my-task.md"),
+          instanceClassPred,
+          pathToIRI("MissingClass.md"),
+        ),
+      ]);
+      // Do NOT register MissingClass with resolver.
+
+      await loader.ensureFileLoaded(taskFile);
+
+      expect(loader.isLoaded(pathToIRI("my-task.md"))).toBe(true);
+      expect(loader.isLoaded(pathToIRI("MissingClass.md"))).toBe(false);
+      expect(loader.loadedCount).toBe(1);
+    });
+  });
+
+  describe("prototype chain walk", () => {
+    it("loads the asset's prototype via exo:Asset_prototype", async () => {
+      const instance = makeFile("instance.md");
+      const proto = makeFile("Prototype.md");
+
+      converter.registerFile(instance, [
+        new Triple(
+          pathToIRI("instance.md"),
+          prototypePred,
+          pathToIRI("Prototype.md"),
+        ),
+      ]);
+      converter.registerFile(proto, []);
+      resolver.register(proto);
+
+      await loader.ensureFileLoaded(instance);
+
+      expect(loader.isLoaded(pathToIRI("Prototype.md"))).toBe(true);
+      expect(loader.loadedCount).toBe(2);
+    });
+
+    it("walks the prototype chain transitively (A → B → C)", async () => {
+      const a = makeFile("A.md");
+      const b = makeFile("B.md");
+      const c = makeFile("C.md");
+
+      converter.registerFile(a, [
+        new Triple(pathToIRI("A.md"), prototypePred, pathToIRI("B.md")),
+      ]);
+      converter.registerFile(b, [
+        new Triple(pathToIRI("B.md"), prototypePred, pathToIRI("C.md")),
+      ]);
+      converter.registerFile(c, []);
+      resolver.register(b);
+      resolver.register(c);
+
+      await loader.ensureFileLoaded(a);
+
+      expect(loader.isLoaded(pathToIRI("A.md"))).toBe(true);
+      expect(loader.isLoaded(pathToIRI("B.md"))).toBe(true);
+      expect(loader.isLoaded(pathToIRI("C.md"))).toBe(true);
+      expect(loader.loadedCount).toBe(3);
+    });
+  });
+
+  describe("cycle safety", () => {
+    it("does not loop on a 2-asset class cycle (A.class=B, B.superClass=A)", async () => {
+      const a = makeFile("A.md");
+      const b = makeFile("B.md");
+
+      converter.registerFile(a, [
+        new Triple(pathToIRI("A.md"), instanceClassPred, pathToIRI("B.md")),
+      ]);
+      converter.registerFile(b, [
+        new Triple(pathToIRI("B.md"), superClassPred, pathToIRI("A.md")),
+      ]);
+      resolver.register(a);
+      resolver.register(b);
+
+      // Should complete without throwing or hanging
+      await loader.ensureFileLoaded(a);
+
+      expect(loader.loadedCount).toBe(2);
+      expect(converter.callCounts.get("A.md")).toBe(1);
+      expect(converter.callCounts.get("B.md")).toBe(1);
+    });
+
+    it("does not loop on a 3-asset prototype cycle (A → B → C → A)", async () => {
+      const a = makeFile("A.md");
+      const b = makeFile("B.md");
+      const c = makeFile("C.md");
+
+      converter.registerFile(a, [
+        new Triple(pathToIRI("A.md"), prototypePred, pathToIRI("B.md")),
+      ]);
+      converter.registerFile(b, [
+        new Triple(pathToIRI("B.md"), prototypePred, pathToIRI("C.md")),
+      ]);
+      converter.registerFile(c, [
+        new Triple(pathToIRI("C.md"), prototypePred, pathToIRI("A.md")),
+      ]);
+      resolver.register(a);
+      resolver.register(b);
+      resolver.register(c);
+
+      await loader.ensureFileLoaded(a);
+
+      expect(loader.loadedCount).toBe(3);
+      expect(converter.callCounts.get("A.md")).toBe(1);
+    });
+
+    it("does not loop on a self-prototype (A.prototype=A)", async () => {
+      const a = makeFile("A.md");
+      converter.registerFile(a, [
+        new Triple(pathToIRI("A.md"), prototypePred, pathToIRI("A.md")),
+      ]);
+      resolver.register(a);
+
+      await loader.ensureFileLoaded(a);
+
+      expect(loader.loadedCount).toBe(1);
+      expect(converter.callCounts.get("A.md")).toBe(1);
+    });
+  });
+
+  describe("bounded depth", () => {
+    it("terminates a pathological chain at MAX_LAZY_DEPTH", async () => {
+      // Build a linear chain A0 → A1 → A2 → ... → A20 via prototype
+      const chainLength = MAX_LAZY_DEPTH + 10; // 20 levels
+      const files: IFile[] = [];
+      for (let i = 0; i < chainLength; i++) {
+        files.push(makeFile(`A${i}.md`));
+      }
+      for (let i = 0; i < chainLength - 1; i++) {
+        converter.registerFile(files[i], [
+          new Triple(
+            pathToIRI(`A${i}.md`),
+            prototypePred,
+            pathToIRI(`A${i + 1}.md`),
+          ),
+        ]);
+        resolver.register(files[i]);
+      }
+      converter.registerFile(files[chainLength - 1], []);
+      resolver.register(files[chainLength - 1]);
+
+      await loader.ensureFileLoaded(files[0]);
+
+      // The depth bound caps the chain — exact reachable depth depends on
+      // how depth is incremented; the contract is "≤ MAX_LAZY_DEPTH + 1
+      // distinct files for a starting file at depth 0".
+      expect(loader.loadedCount).toBeLessThanOrEqual(MAX_LAZY_DEPTH + 1);
+      expect(loader.loadedCount).toBeGreaterThanOrEqual(MAX_LAZY_DEPTH - 1);
+    });
+  });
+
+  describe("ensureLoadedByIRI", () => {
+    it("loads via IRI when resolver knows the file", async () => {
+      const file = makeFile("task.md");
+      converter.registerFile(file, []);
+      resolver.register(file);
+
+      await loader.ensureLoadedByIRI(pathToIRI("task.md"));
+
+      expect(loader.isLoaded(pathToIRI("task.md"))).toBe(true);
+    });
+
+    it("returns silently when resolver returns null", async () => {
+      // No registration of any file
+      await loader.ensureLoadedByIRI(pathToIRI("nonexistent.md"));
+
+      expect(loader.loadedCount).toBe(0);
+    });
+
+    it("is idempotent — second call is no-op", async () => {
+      const file = makeFile("task.md");
+      converter.registerFile(file, []);
+      resolver.register(file);
+
+      await loader.ensureLoadedByIRI(pathToIRI("task.md"));
+      await loader.ensureLoadedByIRI(pathToIRI("task.md"));
+
+      expect(converter.callCounts.get("task.md")).toBe(1);
+    });
+  });
+
+  describe("clearForTests", () => {
+    it("resets the loaded set so subsequent loads re-fetch", async () => {
+      const file = makeFile("task.md");
+      converter.registerFile(file, []);
+
+      await loader.ensureFileLoaded(file);
+      expect(converter.callCounts.get("task.md")).toBe(1);
+
+      loader.clearForTests();
+      expect(loader.loadedCount).toBe(0);
+
+      await loader.ensureFileLoaded(file);
+      expect(converter.callCounts.get("task.md")).toBe(2);
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
+++ b/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
@@ -368,8 +368,10 @@ describe("LazyAssetGraphLoader", () => {
       // The depth bound caps the chain — exact reachable depth depends on
       // how depth is incremented; the contract is "≤ MAX_LAZY_DEPTH + 1
       // distinct files for a starting file at depth 0".
-      expect(loader.loadedCount).toBeLessThanOrEqual(MAX_LAZY_DEPTH + 1);
-      expect(loader.loadedCount).toBeGreaterThanOrEqual(MAX_LAZY_DEPTH - 1);
+      // Entry at depth 0 increments to depth 1 → 2 → ... up to MAX_LAZY_DEPTH.
+      // At depth === MAX_LAZY_DEPTH, ensureFileLoaded returns before adding,
+      // so exactly MAX_LAZY_DEPTH distinct files end up loaded.
+      expect(loader.loadedCount).toBe(MAX_LAZY_DEPTH);
     });
   });
 
@@ -400,6 +402,46 @@ describe("LazyAssetGraphLoader", () => {
       await loader.ensureLoadedByIRI(pathToIRI("task.md"));
 
       expect(converter.callCounts.get("task.md")).toBe(1);
+    });
+  });
+
+  describe("throw recovery", () => {
+    it("rolls back loadedIRIs on convertNote throw, allowing successful retry", async () => {
+      const file = makeFile("flaky.md");
+      const subject = pathToIRI("flaky.md");
+      let callCount = 0;
+
+      // Custom converter: throws on first call, succeeds on second.
+      const flakyConverter: INoteConverter = {
+        convertNote: async (_f: IFile): Promise<Triple[]> => {
+          callCount += 1;
+          if (callCount === 1) {
+            throw new Error("simulated transient parse error");
+          }
+          return [new Triple(subject, labelPred, new Literal("Flaky"))];
+        },
+        notePathToIRI: pathToIRI,
+      };
+      const flakyLoader = new LazyAssetGraphLoader(
+        flakyConverter,
+        resolver,
+        store,
+      );
+
+      // First call: throws; loadedIRIs must NOT retain the IRI.
+      await expect(flakyLoader.ensureFileLoaded(file)).rejects.toThrow(
+        "simulated transient parse error",
+      );
+      expect(flakyLoader.isLoaded(subject)).toBe(false);
+      expect(flakyLoader.loadedCount).toBe(0);
+
+      // Second call: succeeds; store now has the triples.
+      await flakyLoader.ensureFileLoaded(file);
+      expect(flakyLoader.isLoaded(subject)).toBe(true);
+      expect(flakyLoader.loadedCount).toBe(1);
+      const match = await store.match(subject, undefined, undefined);
+      expect(match).toHaveLength(1);
+      expect(callCount).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 2 of [RFC c7da0bca](https://github.com/kitelev/exocortex/issues?q=is%3Aissue%20%22RFC%20c7da0bca%22) — on-demand asset-graph expansion service. Lays the groundwork for eliminating the cold-start `convertVault()` full-walk on mobile in Phase 3.

**Behaviour-neutral against today's production code.** This PR is additive-only — new class + interface + tests + exports. No call sites yet (Phase 3 wires it in). Mobile users still get the band-aid from PR #3251 / v16.22.1 until Phase 3 lands.

## RFC + Phase 1 audit references

- **RFC** (vault-exodev): `c7da0bca-a728-4d1f-97c8-a3193a61a519`
- **Phase 1 audit findings** (vault-exodev): `9271ef44-5483-4c46-8403-18c40842206b` — empirically confirmed **27/27 preconditions in scope are class-stable**, so AST-walk extension is deferred (per RFC §Q4 decision).
- **Supersedes**: RFC `d4c9c992-e26b-4ef7-b63c-94db2006e632` Phases 1+3 (band-aid Phase 2 already shipped in v16.22.1).

## What changed

| File | Change |
|---|---|
| `packages/exocortex/src/interfaces/IFileResolver.ts` | **new** — single-method `resolveByIRI(iri): IFile \| null` interface so the loader stays decoupled from Obsidian |
| `packages/exocortex/src/services/LazyAssetGraphLoader.ts` | **new** — `@injectable()` service. Public surface: `ensureFileLoaded`, `ensureLoadedByIRI`, `isLoaded`, `loadedCount`, `clearForTests`. Bounded by `MAX_LAZY_DEPTH = 10`. Cycle-safe via internal `Set<string>`. |
| `packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts` | **new** — 17 unit cases |
| `packages/exocortex/src/index.ts` | export the new symbols |

## Test coverage (17 cases)

- **Base** (3): single-file load adds triples to store; idempotent (calling twice does not re-invoke `convertNote`); empty-frontmatter asset loads gracefully
- **Class chain walk** (4): single class loaded via `exo:Instance_class`; ALL `Instance_class` values iterated (multi-class); transitive superClass walk (Class → superClass → superSuperClass); broken wikilink (resolver returns null) handled silently
- **Prototype chain walk** (2): single prototype via `exo:Asset_prototype`; transitive walk A → B → C
- **Cycle safety** (3): 2-asset class cycle (A.class=B, B.superClass=A); 3-asset prototype cycle (A→B→C→A); self-prototype (A.prototype=A)
- **Bounded depth** (1): pathological 20-level chain terminates at MAX_LAZY_DEPTH
- **`ensureLoadedByIRI`** (3): load via IRI; null-resolver silent; idempotent
- **`clearForTests`** (1): hook resets loaded set

## Test plan

- [x] 17/17 unit tests green locally (`npx jest LazyAssetGraphLoader.test.ts`)
- [x] `npm run check:types` clean (no errors)
- [x] `npm run lint` — only 2 pre-existing warnings (DisplayNameResolver, PrintNameRuleService), no new
- [x] `npm run test:unit` — 1 pre-existing failure in `packages/cli/tests/integration/sparql-exo003.integration.test.ts` (verified failing on main HEAD too via stash-pop). 1782 other tests pass. Not introduced by this PR.
- [ ] CI green (awaiting)
- [ ] code-reviewer agent
- [ ] advisor round-2
- [ ] Manual merge — Phase 3 follow-up depends on this being on `main`

## Auto-merge

⛔ **Do NOT enable auto-merge.** This PR is the first of 4 staged Phase PRs for RFC c7da0bca. Each is reviewed individually for revert-blast-radius minimisation per the user-approved staging decision (RFC §Decisions Q2).