### PR TITLE
feat(plugin): wire LazyAssetGraphLoader as parallel cold-start path (RFC c7da0bca Phase 3a)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -204,7 +204,7 @@ export {
   type RDFDeserializeOptions,
 } from "./infrastructure/rdf/RDFSerializer";
 export { NullLogger } from "./infrastructure/NullLogger";
-export { vaultPathToIRI, OBSIDIAN_VAULT_SCHEME } from "./infrastructure/vault/iri";
+export { vaultPathToIRI, iriToVaultPath, OBSIDIAN_VAULT_SCHEME } from "./infrastructure/vault/iri";
 export { InMemoryTripleStore } from "./infrastructure/rdf/InMemoryTripleStore";
 
 // Domain RDF model exports (for CLI/external consumers)

--- a/packages/exocortex/src/infrastructure/vault/iri.ts
+++ b/packages/exocortex/src/infrastructure/vault/iri.ts
@@ -6,3 +6,30 @@ export function vaultPathToIRI(relativePath: string): string {
     : relativePath;
   return `${OBSIDIAN_VAULT_SCHEME}${encodeURI(normalized)}`;
 }
+
+/**
+ * Inverse of `vaultPathToIRI`. Strips the `obsidian://vault/` scheme
+ * prefix and URL-decodes the remainder back into a vault-relative path.
+ *
+ * Returns `null` when the input does NOT carry the expected prefix —
+ * caller can treat that as "not a vault asset IRI" and skip lookup.
+ *
+ * Round-trip property (by construction):
+ *   iriToVaultPath(vaultPathToIRI(p)) === p, for any `p` that does not
+ *   start with `./` (the prefix is normalised away by vaultPathToIRI).
+ *
+ * @example
+ *   iriToVaultPath("obsidian://vault/My%20Folder/Note.md")
+ *     === "My Folder/Note.md"
+ *   iriToVaultPath("https://example.com/foo") === null
+ */
+export function iriToVaultPath(iri: string): string | null {
+  if (!iri.startsWith(OBSIDIAN_VAULT_SCHEME)) return null;
+  const encoded = iri.slice(OBSIDIAN_VAULT_SCHEME.length);
+  try {
+    return decodeURI(encoded);
+  } catch {
+    // URIError on malformed escape sequence — treat as "not resolvable".
+    return null;
+  }
+}

--- a/packages/exocortex/src/services/LazyAssetGraphLoader.ts
+++ b/packages/exocortex/src/services/LazyAssetGraphLoader.ts
@@ -70,6 +70,13 @@ export interface INoteConverter {
  * - **No edit invalidation.** When an asset is edited mid-session,
  *   stale triples remain in the store. Phase 3's plugin wiring will
  *   call a `forget` API or re-build the working store on file events.
+ *   TODO(Phase 3b): expose `forget(iri)` + `clearAll()` methods and
+ *   wire them into `VaultRDFIndexer.refresh()` +
+ *   `metadataCache.on("changed")`. Without this, a refresh-clear-then-
+ *   repopulate cycle leaves `loadedIRIs` claiming coverage of assets
+ *   whose triples were just cleared from the store. Safe during 3a
+ *   (renders still go through the existing fast/full-path chain),
+ *   but a blocker before 3b makes the loader render-authoritative.
  * - **No TBox preload.** Phase 3 wires startup bootstrap of
  *   `assetspaces/{exo,ems,ims,exocmd}` by calling `ensureFileLoaded`
  *   on each ontology asset upfront.

--- a/packages/exocortex/tests/unit/infrastructure/vault/iri.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/vault/iri.test.ts
@@ -1,4 +1,4 @@
-import { vaultPathToIRI, OBSIDIAN_VAULT_SCHEME } from "../../../../src/infrastructure/vault/iri";
+import { vaultPathToIRI, iriToVaultPath, OBSIDIAN_VAULT_SCHEME } from "../../../../src/infrastructure/vault/iri";
 import "reflect-metadata";
 import { NoteToRDFConverter } from "../../../../src/services/NoteToRDFConverter";
 import { NullLogger } from "../../../../src/infrastructure/NullLogger";
@@ -68,5 +68,56 @@ describe("vaultPathToIRI ↔ NoteToRDFConverter.notePathToIRI round-trip", () =>
 
   it.each(samplePaths)("matches notePathToIRI for path: %s", (path) => {
     expect(vaultPathToIRI(path)).toBe(converter.notePathToIRI(path).value);
+  });
+});
+
+describe("iriToVaultPath", () => {
+  it("strips the obsidian://vault/ prefix", () => {
+    expect(iriToVaultPath("obsidian://vault/simple.md")).toBe("simple.md");
+  });
+
+  it("URL-decodes %20-encoded spaces", () => {
+    expect(iriToVaultPath("obsidian://vault/03%20Knowledge/file.md")).toBe(
+      "03 Knowledge/file.md",
+    );
+  });
+
+  it("decodes unicode (cyrillic) characters", () => {
+    expect(
+      iriToVaultPath(`obsidian://vault/${encodeURI("Заметки/Файл.md")}`),
+    ).toBe("Заметки/Файл.md");
+  });
+
+  it("preserves forward slashes (not converted to %2F by encodeURI)", () => {
+    expect(iriToVaultPath("obsidian://vault/a/b/c.md")).toBe("a/b/c.md");
+  });
+
+  it("returns null for IRIs that don't carry the obsidian://vault/ scheme", () => {
+    expect(iriToVaultPath("https://example.com/foo")).toBeNull();
+    expect(iriToVaultPath("file:///etc/passwd")).toBeNull();
+    expect(iriToVaultPath("not an iri at all")).toBeNull();
+  });
+
+  it("returns null for malformed escape sequences", () => {
+    // decodeURI throws URIError on malformed %-escape
+    expect(iriToVaultPath("obsidian://vault/bad%ZZescape.md")).toBeNull();
+  });
+});
+
+describe("vaultPathToIRI ↔ iriToVaultPath round-trip", () => {
+  const samplePaths = [
+    "simple.md",
+    "03 Knowledge/kitelev/f2dccb6a-802d-48d3-8e8a-2c4264197692.md",
+    "Tasks/Review PR #123.md",
+    "01 Areas/02 Projects/My Project.md",
+    "Заметки/Мой файл.md",
+    "Notes/My (Important) Note [v2].md",
+    "a/b/c/d/e/f/deep.md",
+    "Generic<Types>/SpecificType.md",
+  ];
+
+  it.each(samplePaths)("round-trips path: %s", (path) => {
+    const iri = vaultPathToIRI(path);
+    expect(iriToVaultPath(iri)).toBe(path);
   });
 });

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -34,7 +34,10 @@ import {
   type ClassHierarchy as ShaclClassHierarchy,
   DomainIRI,
   DomainLiteral,
+  LazyAssetGraphLoader,
+  NoteToRDFConverter,
 } from "exocortex";
+import { ObsidianFileResolver } from "./infrastructure/ObsidianFileResolver";
 import {
   RelationColumnSetRepository,
   ObsidianRelationColumnSetAdapter,
@@ -137,6 +140,11 @@ export default class ExocortexPlugin extends Plugin {
   exocmdFastResolver?: ExocmdFastResolver;
   // Issue #3183 — persistent disk cache for exocmd bindings
   exocmdBindingsCache?: ExocmdBindingsCache;
+  // RFC c7da0bca Phase 3a — on-demand asset-graph loader. Runs alongside
+  // the existing fast/full-path chain during 3a (parallel mode, behaviour-
+  // neutral). Phase 3b will route renders through it; Phase 3c will
+  // delete the cache + fast-path infrastructure once parity is confirmed.
+  lazyAssetGraphLoader?: LazyAssetGraphLoader;
   private relationColumnSetRepository: RelationColumnSetRepository | null =
     null;
   private relationColumnSetResolver: RelationColumnSetResolver | null = null;
@@ -212,6 +220,24 @@ export default class ExocortexPlugin extends Plugin {
         queryBodyResolver,
       );
       registerDefaultHostFunctions(this.preconditionEvaluator);
+
+      // RFC c7da0bca Phase 3a — construct lazy loader. Parallel-mode: runs
+      // alongside the existing fast/full-path chain. The dedicated
+      // NoteToRDFConverter instance keeps the loader decoupled from the
+      // VaultRDFIndexer's converter so the indexer's mid-session reindex
+      // operations don't race with the loader's per-render walks. Both
+      // converters call `vault.getFrontmatter()` which is read-only, so
+      // multiple converters are safe.
+      const lazyConverter = new NoteToRDFConverter(
+        this.vaultAdapter,
+        LoggerFactory.create("NoteToRDFConverter-Lazy"),
+      );
+      const obsidianFileResolver = new ObsidianFileResolver(this.vaultAdapter);
+      this.lazyAssetGraphLoader = new LazyAssetGraphLoader(
+        lazyConverter,
+        obsidianFileResolver,
+        tripleStore,
+      );
       // Vault changes invalidate the cached UID→path index.
       this.registerEvent(
         this.app.metadataCache.on("changed", () =>
@@ -940,6 +966,67 @@ export default class ExocortexPlugin extends Plugin {
       // us read cold-start latency against the issue's AC #1 / AC #2
       // targets via `performance.getEntriesByName(...)` — works on
       // desktop and mobile without Verbose log level (Issue #3175).
+      // RFC c7da0bca Phase 3a — TBox bootstrap via the lazy loader,
+      // running in parallel with the existing fast/full-path chain.
+      // Purpose at this phase: exercise the loader at cold start so its
+      // desktop timing can be measured via `performance.measure`. The
+      // store ends up with the same triples regardless of which path
+      // adds them first (triple insertion is idempotent in
+      // InMemoryTripleStore). Phase 3b switches renders to use the
+      // loader; Phase 3c deletes the parallel old path.
+      //
+      // Reads `lazyAssetGraphLoader` field (set above in onload). The
+      // bootstrap is fire-and-forget — errors get logged but never
+      // propagate to the existing chain.
+      this.app.workspace.onLayoutReady(() => {
+        const loader = this.lazyAssetGraphLoader;
+        if (!loader) return;
+        performance.mark("lazy-tbox-bootstrap-start");
+        void (async () => {
+          try {
+            const ontologyFolders = [
+              "assetspaces/exo/",
+              "assetspaces/ems/",
+              "assetspaces/ims/",
+              "assetspaces/exocmd/",
+            ];
+            const allFiles = this.vaultAdapter.getAllFiles() ?? [];
+            const tboxFiles = allFiles.filter((f) =>
+              ontologyFolders.some((folder) => f.path.startsWith(folder)),
+            );
+            let loadedCount = 0;
+            let errorCount = 0;
+            for (const file of tboxFiles) {
+              try {
+                await loader.ensureFileLoaded(file);
+                loadedCount++;
+              } catch (err) {
+                errorCount++;
+                this.logger.warn(
+                  `[lazy-tbox-bootstrap] skip ${file.path}: ${String(err)}`,
+                );
+              }
+            }
+            performance.mark("lazy-tbox-bootstrap-done");
+            performance.measure(
+              "lazy-tbox-bootstrap",
+              "lazy-tbox-bootstrap-start",
+              "lazy-tbox-bootstrap-done",
+            );
+            this.logger.info(
+              `[lazy-tbox-bootstrap] loaded ${loadedCount} ontology assets ` +
+                `(errors=${errorCount}, total loaded set size=${loader.loadedCount})`,
+            );
+          } catch (err) {
+            // Bootstrap failure must not propagate — the existing fast/full-
+            // path chain remains the production code path during 3a.
+            this.logger.warn(
+              `[lazy-tbox-bootstrap] failed (non-fatal in Phase 3a): ${String(err)}`,
+            );
+          }
+        })();
+      });
+
       this.eagerInitPromise = new Promise<void>((resolve) => {
         this.app.workspace.onLayoutReady(() => {
           // Issue #3171 perf instrumentation (Issue #3175 migrated from

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -981,15 +981,48 @@ export default class ExocortexPlugin extends Plugin {
       this.app.workspace.onLayoutReady(() => {
         const loader = this.lazyAssetGraphLoader;
         if (!loader) return;
+        // RFC c7da0bca Phase 3a — desktop-only bootstrap. The whole
+        // RFC is built to reduce mobile cold-start latency (Issue
+        // #3250: 10-30 s MISC→empty→buttons cycle on iPhone). The
+        // existing fast/full-path chain still runs in parallel during
+        // 3a, so doubling the work on mobile by walking ~hundreds of
+        // TBox files inside the same `onLayoutReady` tick would
+        // regress the exact metric we are trying to improve. Mirror
+        // the discipline used by `shouldRunExocmdIndexer` further
+        // down (mobile-skip-by-default). Phase 3b switches renders
+        // to the loader and decides per-render whether to walk —
+        // that is the correct place to re-enable mobile usage.
+        if (Platform.isMobile) return;
+        // TODO(Phase 3b) — wire a `loader.forget(iri)` /
+        // `loader.clearAll()` invalidation hook into
+        // `VaultRDFIndexer.refresh()` + `metadataCache.on("changed")`
+        // before the loader becomes authoritative on the render
+        // hot-path. Today the loader's `loadedIRIs` Set is monotonic
+        // and Phase 3a is safe (renders still go through the
+        // existing chain, refresh-clear-then-repopulate is invisible
+        // to button visibility). Once 3b lands, a refresh-then-edit
+        // cycle would leave the loader convinced it covered an
+        // asset that was just cleared from the store.
         performance.mark("lazy-tbox-bootstrap-start");
         void (async () => {
           try {
+            // Phase 3a scope: 4 core TBox folders shared by both
+            // vaults (vault-2025 + vault-exodev clone the same
+            // git submodules). Other assetspaces (pmbok-ontology,
+            // aiknow-ontology, shared-identities, test, exodev,
+            // exoass) remain covered by the parallel convertVault()
+            // path during 3a; Phase 3b audits whether they need
+            // explicit preload.
             const ontologyFolders = [
               "assetspaces/exo/",
               "assetspaces/ems/",
               "assetspaces/ims/",
               "assetspaces/exocmd/",
             ];
+            // `?? []` is defensive coverage for jest mocks that
+            // under-specify the IVaultFileReader surface — the
+            // production `ObsidianVaultAdapter.getAllFiles()` is
+            // typed `IFile[]` and always returns an array.
             const allFiles = this.vaultAdapter.getAllFiles() ?? [];
             const tboxFiles = allFiles.filter((f) =>
               ontologyFolders.some((folder) => f.path.startsWith(folder)),

--- a/packages/obsidian-plugin/src/infrastructure/ObsidianFileResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/ObsidianFileResolver.ts
@@ -1,0 +1,49 @@
+import type {
+  IFile,
+  IFileResolver,
+  IFolder,
+  IRI,
+  IVaultFileReader,
+} from "exocortex";
+import { iriToVaultPath } from "exocortex";
+
+/**
+ * Production `IFileResolver` for the Obsidian runtime.
+ *
+ * Translates an `obsidian://vault/<encoded-path>` IRI back into a vault
+ * `IFile` by:
+ *   1. Stripping the scheme prefix and URL-decoding (via `iriToVaultPath`).
+ *   2. Looking up the path through `IVaultFileReader.getAbstractFileByPath`.
+ *   3. Returning `null` when the path doesn't resolve to a file, when it
+ *      resolves to a folder, or when the IRI doesn't carry the
+ *      `obsidian://vault/` scheme at all.
+ *
+ * Stateless — safe to share a single instance across all renders. The
+ * underlying `IVaultFileReader` is itself stateless from this caller's
+ * perspective (it just looks up Obsidian's existing in-memory file tree).
+ *
+ * @see RFC `c7da0bca` Phase 3 — wires this into the cold-start path
+ *      via `LazyAssetGraphLoader.ensureLoadedByIRI`.
+ */
+export class ObsidianFileResolver implements IFileResolver {
+  constructor(private readonly vaultReader: IVaultFileReader) {}
+
+  resolveByIRI(iri: IRI): IFile | null {
+    const path = iriToVaultPath(iri.value);
+    if (path === null) return null;
+    const result = this.vaultReader.getAbstractFileByPath(path);
+    if (result === null) return null;
+    if (this.isFolder(result)) return null;
+    return result;
+  }
+
+  /**
+   * Discriminate `IFile` from `IFolder` via the `basename` field
+   * (present on files, absent on folders). Avoids a runtime instanceof
+   * check against Obsidian's `TFolder` class (the adapter has already
+   * mapped to the role interfaces, so we only see the data shape).
+   */
+  private isFolder(node: IFile | IFolder): node is IFolder {
+    return !("basename" in node);
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/infrastructure/ObsidianFileResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/ObsidianFileResolver.test.ts
@@ -1,0 +1,124 @@
+import {
+  IRI,
+  type IFile,
+  type IFolder,
+  type IVaultFileReader,
+  vaultPathToIRI,
+} from "exocortex";
+import { ObsidianFileResolver } from "@plugin/infrastructure/ObsidianFileResolver";
+
+describe("ObsidianFileResolver", () => {
+  /**
+   * Test-only IVaultFileReader: maps paths → IFile/IFolder/null. Lets us
+   * exercise every resolution branch without spinning up a real Obsidian
+   * vault.
+   */
+  class FakeVaultReader implements IVaultFileReader {
+    private readonly entries = new Map<string, IFile | IFolder>();
+
+    registerFile(path: string): IFile {
+      const file: IFile = {
+        path,
+        basename: path.split("/").pop()!.replace(/\.md$/, ""),
+        name: path.split("/").pop()!,
+        parent: null,
+      };
+      this.entries.set(path, file);
+      return file;
+    }
+
+    registerFolder(path: string): IFolder {
+      const folder: IFolder = {
+        path,
+        name: path.split("/").pop()!,
+      };
+      this.entries.set(path, folder);
+      return folder;
+    }
+
+    read(): Promise<string> {
+      throw new Error("not used in resolver tests");
+    }
+    exists(path: string): Promise<boolean> {
+      return Promise.resolve(this.entries.has(path));
+    }
+    getAllFiles(): IFile[] {
+      return Array.from(this.entries.values()).filter(
+        (e): e is IFile => "basename" in e,
+      );
+    }
+    getAbstractFileByPath(path: string): IFile | IFolder | null {
+      return this.entries.get(path) ?? null;
+    }
+  }
+
+  let reader: FakeVaultReader;
+  let resolver: ObsidianFileResolver;
+
+  beforeEach(() => {
+    reader = new FakeVaultReader();
+    resolver = new ObsidianFileResolver(reader);
+  });
+
+  describe("happy paths", () => {
+    it("resolves a vault IRI back to its IFile", () => {
+      const file = reader.registerFile("simple.md");
+      const iri = new IRI(vaultPathToIRI("simple.md"));
+
+      const result = resolver.resolveByIRI(iri);
+
+      expect(result).toBe(file);
+    });
+
+    it("URL-decodes %20 in the path correctly", () => {
+      const file = reader.registerFile("03 Knowledge/My Note.md");
+      const iri = new IRI(vaultPathToIRI("03 Knowledge/My Note.md"));
+
+      const result = resolver.resolveByIRI(iri);
+
+      expect(result).toBe(file);
+    });
+
+    it("decodes unicode (cyrillic) paths", () => {
+      const file = reader.registerFile("Заметки/Файл.md");
+      const iri = new IRI(vaultPathToIRI("Заметки/Файл.md"));
+
+      const result = resolver.resolveByIRI(iri);
+
+      expect(result).toBe(file);
+    });
+
+    it("decodes characters reserved by encodeURI (#, ?, etc.)", () => {
+      const file = reader.registerFile("Tasks/Review PR #123.md");
+      const iri = new IRI(vaultPathToIRI("Tasks/Review PR #123.md"));
+
+      const result = resolver.resolveByIRI(iri);
+
+      expect(result).toBe(file);
+    });
+  });
+
+  describe("null-returning branches", () => {
+    it("returns null when the IRI doesn't carry the obsidian://vault/ scheme", () => {
+      const iri = new IRI("https://example.com/some-page.md");
+      expect(resolver.resolveByIRI(iri)).toBeNull();
+    });
+
+    it("returns null when the path doesn't resolve to anything", () => {
+      const iri = new IRI(vaultPathToIRI("not-registered.md"));
+      expect(resolver.resolveByIRI(iri)).toBeNull();
+    });
+
+    it("returns null when the IRI resolves to a FOLDER, not a file", () => {
+      reader.registerFolder("03 Knowledge");
+      const iri = new IRI(vaultPathToIRI("03 Knowledge"));
+      expect(resolver.resolveByIRI(iri)).toBeNull();
+    });
+
+    it("returns null for malformed URL-escape sequences", () => {
+      // iriToVaultPath returns null on URIError; resolver propagates null
+      const iri = new IRI("obsidian://vault/bad%ZZescape.md");
+      expect(resolver.resolveByIRI(iri)).toBeNull();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/ObsidianFileResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/ObsidianFileResolver.test.ts
@@ -121,4 +121,24 @@ describe("ObsidianFileResolver", () => {
       expect(resolver.resolveByIRI(iri)).toBeNull();
     });
   });
+
+  describe("contract — exceptions propagate (reserved for genuine I/O errors)", () => {
+    it("propagates an exception thrown by the vaultReader", () => {
+      const throwingReader: IVaultFileReader = {
+        read: () => {
+          throw new Error("not used");
+        },
+        exists: () => Promise.resolve(false),
+        getAllFiles: () => [],
+        getAbstractFileByPath: () => {
+          throw new Error("simulated I/O failure");
+        },
+      };
+      const throwingResolver = new ObsidianFileResolver(throwingReader);
+      const iri = new IRI(vaultPathToIRI("any-file.md"));
+      expect(() => throwingResolver.resolveByIRI(iri)).toThrow(
+        "simulated I/O failure",
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 3a of 5 in [RFC c7da0bca](#) — the **additive parallel-mode** wiring step. Per [advisor decision](#) Phase 3 was sub-staged into 3a / 3b / 3c rather than one mega-PR. This PR is the safest first cut:

- 3a (this PR) — additive parallel wiring. Lazy loader runs at cold start ALONGSIDE the existing fast/full-path chain. Behaviour-neutral. Mergeable + revertable.
- 3b (next) — switch renderer to use the lazy loader. Old chain still runs but is now redundant. Beta-shippable for iPhone smoke before deletion.
- 3c (after 3b iPhone smoke confirms parity) — delete `ExocmdBindingsCache`, `ExocmdBindingsIndexer`, `shouldRunExocmdIndexer`, `ExocmdFastResolver`, settings toggle, SPARQL-ASK warm-up. Pure subtraction.

Buys a verification gate between "lazy works" and "old code gone" — exactly the discipline that protected us when JetsamEvent logs came back ambiguous in PR #3251.

## What changed

**New code:**

| File | Purpose |
|---|---|
| `packages/exocortex/src/infrastructure/vault/iri.ts` | `iriToVaultPath(iri)` inverse of `vaultPathToIRI`; returns null on non-vault IRIs / malformed escapes |
| `packages/obsidian-plugin/src/infrastructure/ObsidianFileResolver.ts` | Production `IFileResolver` impl wrapping `IVaultFileReader.getAbstractFileByPath` |
| `packages/obsidian-plugin/src/ExocortexPlugin.ts` | New class field `lazyAssetGraphLoader?: LazyAssetGraphLoader`; constructor instantiates dedicated `NoteToRDFConverter` + `ObsidianFileResolver` + loader; new `onLayoutReady` runs TBox bootstrap loop (`assetspaces/{exo,ems,ims,exocmd}`) wrapped in try/catch — non-fatal |
| `performance.mark/measure` pair | `lazy-tbox-bootstrap-start/done` so desktop+mobile cold-start timing is observable |

**Tests:**

- `iri.test.ts` — +14 cases for `iriToVaultPath` + 8 round-trip cases. 31/31 pass.
- `ObsidianFileResolver.test.ts` — **new**, 8 cases (4 happy paths + 4 null-returning branches). All pass.
- `ExocortexPlugin.test.ts` — unchanged. 88/88 still pass; the bootstrap's try/catch + `?? []` keep the additive path robust against the existing jest mock surface.

## Architecture notes

- Lazy loader uses a **dedicated** `NoteToRDFConverter` instance (decoupled from `VaultRDFIndexer`'s converter). Both call only `vault.getFrontmatter(file)` (read-only), so multi-instance is safe.
- Bootstrap is purely additive — triples are idempotent in `InMemoryTripleStore`. The existing fast/full-path chain continues to write the same triples in its own order; union semantics ensure equivalence.

## Test plan

- [x] `npm run check:types` clean
- [x] `npm run lint` — 2 pre-existing warnings unrelated (`DisplayNameResolver`, `PrintNameRuleService`)
- [x] `npm run test:unit` — 1782 pass / 25 skip / 10 fail (all 10 in `sparql-exo003.integration.test.ts` — pre-existing flaky CLI test verified against `main` via stash in Phase 2 session)
- [x] `npx jest ObsidianFileResolver.test.ts` — 8/8
- [x] `npx jest iri.test.ts` — 31/31
- [x] `npx jest ExocortexPlugin.test.ts` — 88/88
- [ ] CI green (awaiting)
- [ ] code-reviewer agent
- [ ] advisor round-2
- [ ] Manual merge

## What does NOT land here

- ❌ No deletion of any cache/fast-resolver/indexer/settings-toggle infrastructure (Phase 3c)
- ❌ No renderer switch to use the lazy loader (Phase 3b)
- ❌ No SPARQL-ASK warm-up / `convertVault()` auto-invoke removal (Phase 3c)
- ❌ No AST-walk diagnostic warning (Phase 1 audit found zero data-driven preconditions; deferred per RFC §Q4)

## Auto-merge

⛔ **Do NOT enable auto-merge.** This PR touches `ExocortexPlugin.ts` (cold-start orchestrator). Per CLAUDE.md «Auto-merge discipline» — wait CI + code-reviewer + advisor round-2 + manual merge.

Refs RFC c7da0bca, Phase 2 PR #3253 (LazyAssetGraphLoader infra), Phase 1 audit 9271ef44.