### PR TITLE
fix: PropertyDefault_value UUID identity + Create Task Instance prototype semantics

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -972,10 +972,21 @@ export class NoteToRDFConverter {
             // back through #2782 → `<ems#Task>` and yield label-form
             // `"[[ems__Task]]"` in the created instance's
             // `exo__Instance_class` — violating UUID-canon TBox.
+            //
+            // `PropertyDefault_value` joins the bypass list for the same
+            // reason: PropertyDefault assets store the default value as a
+            // wikilink (e.g. `[[c42245d0-...]]` pointing to
+            // `ems__EffortStatusDraft`). Without this bypass the #2782
+            // substitution rewrites the triple object to
+            // `<ems#EffortStatusDraft>`, CommandResolver.resolvePropertyDefaultValue
+            // then writes label-form `"[[ems__EffortStatusDraft]]"` into the
+            // created instance — violating UUID-canon for `ems__Effort_status`
+            // and the wider PropertyDefault story.
             const isGroundingRef =
               predicate?.value.endsWith("#Grounding_targetValueRef") ||
               predicate?.value.endsWith("#Grounding_targetValueSubstitution") ||
-              predicate?.value.endsWith("#Grounding_targetClass");
+              predicate?.value.endsWith("#Grounding_targetClass") ||
+              predicate?.value.endsWith("#PropertyDefault_value");
             if (isGroundingRef) {
               return [fileIRI];
             }

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.property-default-value-uuid-canon.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.property-default-value-uuid-canon.test.ts
@@ -1,0 +1,175 @@
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import { IVaultAdapter, IFile, IFrontmatter } from "../../../src/interfaces/IVaultAdapter";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+/**
+ * Regression: `exocmd__PropertyDefault_value` UUID identity preservation.
+ *
+ * Bug observed 2026-05-24 with prototype `f2dccb6a` ("Заполнить таблетницу"):
+ * clicking "Create Task Instance" produced a new task whose
+ * `ems__Effort_status` was written as `"[[ems__EffortStatusDraft]]"`
+ * (symbolic, label-form) instead of the UID-form
+ * `"[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"` that the
+ * `PropertyDefault` asset actually declares.
+ *
+ * Root cause: `valueToRDFObject`'s class-IRI substitution branch
+ * (Issue #2782/#2959) rewrites the triple object for any wikilink whose
+ * target carries a class-prefixed `exo__Asset_label`. The
+ * `PropertyDefault_value` predicate was not in the bypass list, so the
+ * declared `[[c42245d0-...]]` ref got rewritten to
+ * `<ems#EffortStatusDraft>` (because target's label is
+ * `ems__EffortStatusDraft`). `CommandResolver.resolvePropertyDefaultValue`
+ * then read that as `"ems__EffortStatusDraft"`, failed `looksLikeUUID`,
+ * and returned label-form — defeating UID-canon for the entire
+ * PropertyDefault story.
+ *
+ * Fix: add `#PropertyDefault_value` to the `isGroundingRef` bypass list
+ * in `NoteToRDFConverter.valueToRDFObject`. The triple object stays as
+ * the file IRI; `iriToObsidianName` extracts the UUID basename; the
+ * resolver writes UID-form.
+ */
+describe("NoteToRDFConverter — PropertyDefault_value UUID identity", () => {
+  let converter: NoteToRDFConverter;
+  let mockVault: jest.Mocked<IVaultAdapter>;
+
+  beforeEach(() => {
+    mockVault = {
+      getFrontmatter: jest.fn(),
+      getAllFiles: jest.fn(),
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      updateLinks: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+    } as jest.Mocked<IVaultAdapter>;
+
+    converter = new NoteToRDFConverter(mockVault);
+  });
+
+  const propertyDefaultFile: IFile = {
+    path: "assetspaces/exocmd/d9aa9bb8-5676-4ba2-ba5e-fc8d9df02250.md",
+    basename: "d9aa9bb8-5676-4ba2-ba5e-fc8d9df02250",
+    name: "d9aa9bb8-5676-4ba2-ba5e-fc8d9df02250.md",
+    parent: null,
+  };
+
+  const draftStatusFile: IFile = {
+    path: "assetspaces/ems/c42245d0-01de-4c35-bfcf-d910445ea28e.md",
+    basename: "c42245d0-01de-4c35-bfcf-d910445ea28e",
+    name: "c42245d0-01de-4c35-bfcf-d910445ea28e.md",
+    parent: null,
+  };
+
+  it("preserves UUID identity for PropertyDefault_value when target label is a class-prefixed string", async () => {
+    // Empirical reproduction — production PropertyDefault asset `d9aa9bb8`
+    // declares `exocmd__PropertyDefault_value: "[[c42245d0-...]]"` pointing
+    // at UUID-named EffortStatusDraft. Pre-fix: triple object becomes class
+    // IRI <ems#EffortStatusDraft>. Post-fix: triple object is the file IRI
+    // (UUID intact).
+    const propertyDefaultFrontmatter: IFrontmatter = {
+      exo__Asset_uid: "d9aa9bb8-5676-4ba2-ba5e-fc8d9df02250",
+      exo__Asset_label: "PropertyDefault: ems__Effort_status = EffortStatusDraft",
+      exo__Instance_class: ["[[74d6d2d3-c435-4fd0-9c4b-d9dc9f0bb088]]"],
+      exocmd__PropertyDefault_property: "[[44c6e9e3-955f-4afc-9ca5-b4bd70667051]]",
+      exocmd__PropertyDefault_value: "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]",
+    };
+
+    // Target EffortStatusDraft asset — its label is class-prefixed, which
+    // is exactly what triggers the #2782 substitution branch.
+    const draftStatusFrontmatter: IFrontmatter = {
+      exo__Asset_uid: "c42245d0-01de-4c35-bfcf-d910445ea28e",
+      exo__Asset_label: "ems__EffortStatusDraft",
+    };
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === propertyDefaultFile.path) return propertyDefaultFrontmatter;
+      if (f.path === draftStatusFile.path) return draftStatusFrontmatter;
+      return null;
+    });
+
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === "c42245d0-01de-4c35-bfcf-d910445ea28e") return draftStatusFile;
+      return null;
+    });
+
+    const triples = await converter.convertNote(propertyDefaultFile);
+
+    const valueTriples = triples.filter(
+      (t) => (t.predicate as IRI).value === Namespace.EXOCMD.term("PropertyDefault_value").value,
+    );
+
+    expect(valueTriples).toHaveLength(1);
+    const obj = valueTriples[0].object;
+
+    // Pre-fix: obj was IRI("https://exocortex.my/ontology/ems#EffortStatusDraft")
+    // Post-fix: obj is the file IRI carrying the UUID basename.
+    expect(obj).toBeInstanceOf(IRI);
+    const value = (obj as IRI).value;
+    expect(value).not.toBe(Namespace.EMS.term("EffortStatusDraft").value);
+    expect(value).toMatch(/c42245d0-01de-4c35-bfcf-d910445ea28e\.md$/);
+  });
+
+  it("preserves UUID identity for PropertyDefault_value even with EffortStatusBacklog (different enum, same bypass)", async () => {
+    // Cross-check: bypass must apply uniformly regardless of which enum
+    // member is referenced. Guards against ad-hoc per-value patches.
+    const backlogFile: IFile = {
+      path: "assetspaces/ems/753a44d5-846c-4b82-9196-4fd9a4d48777.md",
+      basename: "753a44d5-846c-4b82-9196-4fd9a4d48777",
+      name: "753a44d5-846c-4b82-9196-4fd9a4d48777.md",
+      parent: null,
+    };
+
+    const propertyDefaultBacklog: IFile = {
+      path: "assetspaces/exocmd/aaaa1111-aaaa-1111-aaaa-111111111111.md",
+      basename: "aaaa1111-aaaa-1111-aaaa-111111111111",
+      name: "aaaa1111-aaaa-1111-aaaa-111111111111.md",
+      parent: null,
+    };
+
+    const propertyDefaultFm: IFrontmatter = {
+      exo__Asset_uid: "aaaa1111-aaaa-1111-aaaa-111111111111",
+      exo__Asset_label: "PropertyDefault: ems__Effort_status = EffortStatusBacklog",
+      exo__Instance_class: ["[[74d6d2d3-c435-4fd0-9c4b-d9dc9f0bb088]]"],
+      exocmd__PropertyDefault_property: "[[44c6e9e3-955f-4afc-9ca5-b4bd70667051]]",
+      exocmd__PropertyDefault_value: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]",
+    };
+
+    const backlogFm: IFrontmatter = {
+      exo__Asset_uid: "753a44d5-846c-4b82-9196-4fd9a4d48777",
+      exo__Asset_label: "ems__EffortStatusBacklog",
+    };
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === propertyDefaultBacklog.path) return propertyDefaultFm;
+      if (f.path === backlogFile.path) return backlogFm;
+      return null;
+    });
+
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === "753a44d5-846c-4b82-9196-4fd9a4d48777") return backlogFile;
+      return null;
+    });
+
+    const triples = await converter.convertNote(propertyDefaultBacklog);
+
+    const valueTriples = triples.filter(
+      (t) => (t.predicate as IRI).value === Namespace.EXOCMD.term("PropertyDefault_value").value,
+    );
+
+    expect(valueTriples).toHaveLength(1);
+    const obj = valueTriples[0].object;
+    expect(obj).toBeInstanceOf(IRI);
+    expect((obj as IRI).value).not.toBe(Namespace.EMS.term("EffortStatusBacklog").value);
+    expect((obj as IRI).value).toMatch(/753a44d5-846c-4b82-9196-4fd9a4d48777\.md$/);
+  });
+});


### PR DESCRIPTION
## Summary

User-visible bug (2026-05-24): clicking **Create Task Instance** on prototype `f2dccb6a` ("Заполнить таблетницу") produced a new task with three issues:

1. ❌ `ems__Effort_status: "[[ems__EffortStatusDraft]]"` — label-form instead of UID-form `"[[c42245d0-…]]"`
2. ❌ `ems__Effort_parent: "[[f2dccb6a-…]]"` — spurious parent pointing at the prototype
3. ❌ `ems__Recurring_rule` copied wholesale from prototype (should be inherited via `exo__Asset_prototype`)

This PR ships fixes for **#1 (code) and #2 (data, separately, already merged in exocmd submodule)**. **#3 is deferred to an upcoming RFC** at user request — see «Out of scope» below.

## Issue #1 — PropertyDefault_value UUID identity (this PR)

**Root cause**: `valueToRDFObject`'s class-IRI substitution branch (Issue #2782/#2959) rewrites wikilink-object triples whose target carries a class-prefixed `exo__Asset_label`. The `isGroundingRef` bypass list covered `Grounding_targetValueRef` / `_targetValueSubstitution` / `_targetClass` but **not** `PropertyDefault_value`. The declared `[[c42245d0-…]]` got rewritten to `<ems#EffortStatusDraft>`; `CommandResolver.resolvePropertyDefaultValue` early-returned label-form on the non-UUID input.

**Fix**: one line — add `#PropertyDefault_value` to the bypass list (`NoteToRDFConverter.ts:975-982`). Mirrors the pattern documented for the three sibling predicates. Comment block above the change explains the production reproduction and the bypass semantics.

## Issue #2 — InheritanceRule semantics (companion commit chain, separate from this PR)

Already shipped in `kitelev/exoas-exocmd` commit `680478c` + vault-2025 pointer bump `745f41625` + vault-exodev pointer bump `604809d`.

`InheritanceRule 43731bae` was authored as «exclusion: ems__Area, prio 50» — meaning «fire for any target that is NOT Area». This was overly permissive: prototypes (TaskPrototype, ProjectPrototype, …) are not Areas, so the rule fired for them too. Flipped to **«condition: ems__Project, prio 50»** — explicit homoiconic semantics matching user intent: `ems__Effort_parent` is set only when creating a task under a real Project. Prototype/instance relation lives in `exo__Asset_prototype`, not in the parent slot. No code change — engine's `classMatchesAny` already supports direct UUID match.

## Tests

New unit suite `NoteToRDFConverter.property-default-value-uuid-canon.test.ts` (2 cases):
- Empirical reproduction with EffortStatusDraft (production scenario)
- Cross-check with EffortStatusBacklog (different enum, same bypass — guards against per-value patches)

**Empirically verified** FAILS pre-fix (2/2) and PASSES post-fix (2/2) via revert→fail→restore→pass cycle in worktree (per `integration-test-revert-verify.md` discipline).

All 12 `NoteToRDFConverter*.test.ts` suites (214 tests total) pass. Full unit suite green; 1 unrelated CLI integration suite (`sparql-exo003.integration.test.ts`) was already failing locally on main (not gated by CI's allowlist regex, per CLAUDE.md test-suite-awareness section).

## Out of scope (deferred to RFC)

Issue #3 — `ems__Recurring_rule` and similar implicit copy from prototype — stems from `executeCreateInstance` Step 4 (copy-from-target with hardcoded `CREATE_INSTANCE_BLACKLIST` in `GroundingExecutor.ts`).

User explicitly rejected the blacklist-extension workaround:
> «blacklist это костыль. Лучше использовать конкретные инструкции по наполнению созданного ассета»

The proper homoiconic fix is to remove Step 4 entirely and materialise all property inheritance through declarative `exocmd__PropertyDefault` / `exocmd__InheritanceRule` assets. Audit data ready (20 create_instance Groundings analysed: 4 fully covered, 1 partial, 15 rely on Step 4). RFC drafting starts in a separate session.

## Test plan

- [ ] After merge — Auto Release publishes new version
- [ ] In Obsidian: `Cmd+P` → `BRAT: Check for updates to all beta plugins`
- [ ] `Cmd+P` → `Reload app without saving`
- [ ] Open prototype `f2dccb6a-802d-48d3-8e8a-2c4264197692` ("Заполнить таблетницу")
- [ ] Click **Create Task Instance**
- [ ] Verify created asset frontmatter:
  - ✅ `ems__Effort_status: "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]"` (UID-form)
  - ✅ no `ems__Effort_parent` field (prototype not a Project)
  - ❌ `ems__Recurring_rule` still copied (deferred to RFC — known)
- [ ] Regression — open a real `ems__Project` asset, click **Create Task Instance**
  - ✅ created task has `ems__Effort_parent: "[[<project-uid>]]"`

## Auto-merge discipline

This PR touches `NoteToRDFConverter.ts` (parser). Per `exocortex/CLAUDE.md` auto-merge discipline section, manual workflow required:
1. ⏳ CI green
2. ⏳ code-reviewer agent (subagent_type=code-reviewer)
3. ⏳ apply CRITICAL/HIGH fixes
4. ⏳ advisor() round-2
5. ⏳ apply advisor catches
6. ⏳ manual `gh pr merge --squash --delete-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)