### PR TITLE
feat(lazy-loader): forget(iri) + clearAll() invalidation API (RFC c7da0bca Phase 3b-prep)

### DIFF
--- a/packages/exocortex/src/services/LazyAssetGraphLoader.ts
+++ b/packages/exocortex/src/services/LazyAssetGraphLoader.ts
@@ -67,16 +67,13 @@ export interface INoteConverter {
  *
  * # Out of scope for Phase 2
  *
- * - **No edit invalidation.** When an asset is edited mid-session,
- *   stale triples remain in the store. Phase 3's plugin wiring will
- *   call a `forget` API or re-build the working store on file events.
- *   TODO(Phase 3b): expose `forget(iri)` + `clearAll()` methods and
- *   wire them into `VaultRDFIndexer.refresh()` +
- *   `metadataCache.on("changed")`. Without this, a refresh-clear-then-
- *   repopulate cycle leaves `loadedIRIs` claiming coverage of assets
- *   whose triples were just cleared from the store. Safe during 3a
- *   (renders still go through the existing fast/full-path chain),
- *   but a blocker before 3b makes the loader render-authoritative.
+ * - **`forget(iri)` + `clearAll()` exist but are not yet wired.**
+ *   Phase 3b-prep (this PR) ships the API; Phase 3b-main wires
+ *   `forget` to `metadataCache.on("changed")` and `clearAll` next
+ *   to every `VaultRDFIndexer.refresh()` call site. Until 3b-main
+ *   lands, the loader is still write-only at startup (Phase 3a
+ *   bootstrap) and renders bypass it — so invalidation is moot
+ *   on production at the moment.
  * - **No TBox preload.** Phase 3 wires startup bootstrap of
  *   `assetspaces/{exo,ems,ims,exocmd}` by calling `ensureFileLoaded`
  *   on each ontology asset upfront.
@@ -161,6 +158,50 @@ export class LazyAssetGraphLoader {
    */
   isLoaded(iri: IRI): boolean {
     return this.loadedIRIs.has(iri.value);
+  }
+
+  /**
+   * Mark a single IRI as no-longer-loaded so the next ensure-call for
+   * this asset re-walks frontmatter + chains afresh.
+   *
+   * # When to call
+   *
+   * Wire this to `metadataCache.on("changed")` so an asset edit
+   * invalidates the loader's monotonic load-mark. The underlying
+   * triple-store cleanup is already handled by
+   * `VaultRDFIndexer.updateFile()` (which does
+   * `removeFileTriples` + re-convert + re-add), so this method ONLY
+   * manages the `loadedIRIs` set — it does NOT touch the store, and
+   * it does NOT cascade to the asset's downstream class / prototype
+   * chain (those entries are still valid until they too are edited).
+   *
+   * No-op when the IRI was never loaded.
+   *
+   * @param iri - The IRI to drop from the loaded-set.
+   */
+  forget(iri: IRI): void {
+    this.loadedIRIs.delete(iri.value);
+  }
+
+  /**
+   * Wipe the entire loaded-set.
+   *
+   * # When to call
+   *
+   * Wire this alongside any `tripleStore.clear()` call — most
+   * importantly `VaultRDFIndexer.refresh()`, which clears the store
+   * and re-runs `convertVault()`. After such a refresh the store is
+   * re-populated by the existing chain, but the loader still believes
+   * every IRI in `loadedIRIs` is covered. The next render's
+   * `ensureFileLoaded` would short-circuit on the stale mark while
+   * the lazy walker has lost its incremental coverage. `clearAll()`
+   * resets that invariant.
+   *
+   * Like `forget`, this method does NOT touch the triple store —
+   * store-side cleanup is the caller's responsibility.
+   */
+  clearAll(): void {
+    this.loadedIRIs.clear();
   }
 
   /**

--- a/packages/exocortex/src/services/LazyAssetGraphLoader.ts
+++ b/packages/exocortex/src/services/LazyAssetGraphLoader.ts
@@ -177,7 +177,34 @@ export class LazyAssetGraphLoader {
    *
    * No-op when the IRI was never loaded.
    *
-   * @param iri - The IRI to drop from the loaded-set.
+   * # IRI canonical form (REQUIRED)
+   *
+   * The IRI MUST be in the canonical form returned by
+   * `INoteConverter.notePathToIRI(file.path)` — callers wiring this
+   * to file events should construct the IRI via the same converter
+   * the loader was instantiated with. A non-canonical IRI (e.g.
+   * `new IRI("obsidian://vault/" + file.path)` without `encodeURI`
+   * for spaces/unicode) silently no-ops on a mismatch.
+   *
+   * # Race with in-flight `ensureFileLoaded` (Phase 3b-main concern)
+   *
+   * `ensureFileLoaded` sets the load-mark BEFORE its
+   * `await convertNote()`, which acts as a concurrent-render
+   * coalesce-guard. If `forget(iri)` fires during that await window,
+   * the mark is removed but the success branch does NOT re-add it.
+   * The subsequent ensure-call then re-invokes `convertNote` — which
+   * races with `VaultRDFIndexer.updateFile()` (which fires for the
+   * same `metadataCache.on("changed")` event). Result: store may
+   * contain pre- and post-edit triples briefly, both written by
+   * different code paths. This is acceptable in the additive-Phase
+   * 3a state (the loader is not render-authoritative) but Phase
+   * 3b-main wire-up MUST coordinate the ordering. The right fix is
+   * generation-counter detection in `ensureFileLoaded` (option a in
+   * the PR #3256 reviewer report) — deferred until 3b-main reveals
+   * concrete ordering requirements.
+   *
+   * @param iri - Canonical-form IRI of the asset to drop from the
+   *              loaded-set. See "IRI canonical form" above.
    */
   forget(iri: IRI): void {
     this.loadedIRIs.delete(iri.value);
@@ -199,6 +226,20 @@ export class LazyAssetGraphLoader {
    *
    * Like `forget`, this method does NOT touch the triple store —
    * store-side cleanup is the caller's responsibility.
+   *
+   * # Ordering requirement
+   *
+   * Call `clearAll()` AFTER the synchronous portion of any store-
+   * rebuilding operation has resolved — most importantly, AFTER
+   * `VaultRDFIndexer.refresh()`'s entire await chain (`clear()` →
+   * `convertVault()` → `addAll()` → `runInference()`) has completed.
+   * Calling clearAll before the rebuild completes opens a window
+   * where concurrent renders can re-populate `loadedIRIs` for assets
+   * whose triples are about to be re-added by the bulk rebuild,
+   * leading to stale marks. Sequence as:
+   *
+   *     await sparqlApi.refresh();   // store-side rebuild
+   *     lazyLoader.clearAll();       // then reset loader state
    */
   clearAll(): void {
     this.loadedIRIs.clear();

--- a/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
+++ b/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
@@ -445,6 +445,96 @@ describe("LazyAssetGraphLoader", () => {
     });
   });
 
+  describe("forget", () => {
+    it("drops the IRI from the loaded set so the next ensure re-walks", async () => {
+      const file = makeFile("task.md");
+      const subject = pathToIRI("task.md");
+      converter.registerFile(file, []);
+
+      await loader.ensureFileLoaded(file);
+      expect(loader.isLoaded(subject)).toBe(true);
+      expect(converter.callCounts.get("task.md")).toBe(1);
+
+      loader.forget(subject);
+      expect(loader.isLoaded(subject)).toBe(false);
+      expect(loader.loadedCount).toBe(0);
+
+      // Re-ensure: convertNote is invoked again, IRI is back in the set.
+      await loader.ensureFileLoaded(file);
+      expect(loader.isLoaded(subject)).toBe(true);
+      expect(converter.callCounts.get("task.md")).toBe(2);
+    });
+
+    it("is a no-op for an IRI that was never loaded", () => {
+      const subject = pathToIRI("never-loaded.md");
+      loader.forget(subject);
+      expect(loader.loadedCount).toBe(0);
+      expect(loader.isLoaded(subject)).toBe(false);
+    });
+
+    it("does NOT cascade to class/prototype chain entries", async () => {
+      const instance = makeFile("instance.md");
+      const proto = makeFile("Prototype.md");
+
+      converter.registerFile(instance, [
+        new Triple(
+          pathToIRI("instance.md"),
+          prototypePred,
+          pathToIRI("Prototype.md"),
+        ),
+      ]);
+      converter.registerFile(proto, []);
+      resolver.register(proto);
+
+      await loader.ensureFileLoaded(instance);
+      expect(loader.loadedCount).toBe(2);
+      expect(loader.isLoaded(pathToIRI("Prototype.md"))).toBe(true);
+
+      // Forget only the instance; the prototype's mark must survive.
+      loader.forget(pathToIRI("instance.md"));
+      expect(loader.isLoaded(pathToIRI("instance.md"))).toBe(false);
+      expect(loader.isLoaded(pathToIRI("Prototype.md"))).toBe(true);
+      expect(loader.loadedCount).toBe(1);
+    });
+  });
+
+  describe("clearAll", () => {
+    it("wipes every IRI from the loaded set", async () => {
+      const a = makeFile("A.md");
+      const b = makeFile("B.md");
+      converter.registerFile(a, []);
+      converter.registerFile(b, []);
+
+      await loader.ensureFileLoaded(a);
+      await loader.ensureFileLoaded(b);
+      expect(loader.loadedCount).toBe(2);
+
+      loader.clearAll();
+      expect(loader.loadedCount).toBe(0);
+      expect(loader.isLoaded(pathToIRI("A.md"))).toBe(false);
+      expect(loader.isLoaded(pathToIRI("B.md"))).toBe(false);
+    });
+
+    it("permits a fresh ensure cycle after clearing", async () => {
+      const file = makeFile("task.md");
+      converter.registerFile(file, []);
+
+      await loader.ensureFileLoaded(file);
+      expect(converter.callCounts.get("task.md")).toBe(1);
+
+      loader.clearAll();
+      await loader.ensureFileLoaded(file);
+      expect(converter.callCounts.get("task.md")).toBe(2);
+      expect(loader.loadedCount).toBe(1);
+    });
+
+    it("is a no-op when the set is already empty", () => {
+      expect(loader.loadedCount).toBe(0);
+      loader.clearAll();
+      expect(loader.loadedCount).toBe(0);
+    });
+  });
+
   describe("clearForTests", () => {
     it("resets the loaded set so subsequent loads re-fetch", async () => {
       const file = makeFile("task.md");

--- a/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
+++ b/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
@@ -472,7 +472,7 @@ describe("LazyAssetGraphLoader", () => {
       expect(loader.isLoaded(subject)).toBe(false);
     });
 
-    it("does NOT cascade to class/prototype chain entries", async () => {
+    it("does NOT cascade to prototype chain entries", async () => {
       const instance = makeFile("instance.md");
       const proto = makeFile("Prototype.md");
 
@@ -494,6 +494,31 @@ describe("LazyAssetGraphLoader", () => {
       loader.forget(pathToIRI("instance.md"));
       expect(loader.isLoaded(pathToIRI("instance.md"))).toBe(false);
       expect(loader.isLoaded(pathToIRI("Prototype.md"))).toBe(true);
+      expect(loader.loadedCount).toBe(1);
+    });
+
+    it("does NOT cascade to class chain entries", async () => {
+      const taskFile = makeFile("my-task.md");
+      const classFile = makeFile("ems__Task.md");
+
+      converter.registerFile(taskFile, [
+        new Triple(
+          pathToIRI("my-task.md"),
+          instanceClassPred,
+          pathToIRI("ems__Task.md"),
+        ),
+      ]);
+      converter.registerFile(classFile, []);
+      resolver.register(classFile);
+
+      await loader.ensureFileLoaded(taskFile);
+      expect(loader.loadedCount).toBe(2);
+      expect(loader.isLoaded(pathToIRI("ems__Task.md"))).toBe(true);
+
+      // Forget only the task instance; the class file's mark must survive.
+      loader.forget(pathToIRI("my-task.md"));
+      expect(loader.isLoaded(pathToIRI("my-task.md"))).toBe(false);
+      expect(loader.isLoaded(pathToIRI("ems__Task.md"))).toBe(true);
       expect(loader.loadedCount).toBe(1);
     });
   });


### PR DESCRIPTION
## Summary

Phase 3b is being shipped as **3b-prep** (this PR — additive API + tests, behaviour-neutral) and **3b-main** (separate PR — plugin wire-up of these methods + renderer switch). Same staging discipline as Phase 3a's sub-split: ship the loader-only surface first so the API can be tested in isolation before plugin integration risk.

Addresses the **MEDIUM** finding from PR #3254 code-reviewer — Phase 3b invalidation gap.

## What ships

| Method | Purpose |
|---|---|
| `LazyAssetGraphLoader.forget(iri)` | Drops one IRI from `loadedIRIs`. Wire-point: `metadataCache.on("changed")`. Does NOT touch the triple store — `VaultRDFIndexer.updateFile()` handles that already. |
| `LazyAssetGraphLoader.clearAll()` | Wipes the entire `loadedIRIs` set. Wire-point: alongside `VaultRDFIndexer.refresh()` call sites (3 verified via grep). Same store-side contract. |

Plus 6 new unit tests covering both methods — including the no-cascade-to-chain contract for `forget`.

## Architecture notes

Both methods are deliberately narrow: they manage the load-mark only. Single-responsibility split (loader owns its set; indexer owns the store) prevents double-deletes and lets the two subsystems evolve independently.

Wire-up for 3b-main (not in this PR):
- `metadataCache.on("changed", file => loader.forget(iriForPath(file.path)))`
- After each of the 3 `refresh()` call sites: `loader.clearAll()`
- `UniversalLayoutRenderer.render()` — call `loader.ensureFileLoaded(currentFile)` before `buttonGroupsBuilder.build()`

## Test plan

- [x] 24/24 LazyAssetGraphLoader tests pass (was 18; +6 new)
- [x] `npm run check:types` clean
- [x] `npm run lint` — 2 pre-existing warnings unrelated
- [x] `npm run test:unit` — 1782 pass / 25 skip / 10 fail (all 10 in `sparql-exo003.integration.test.ts` — pre-existing flaky CLI, verified failing on `main` via stash in Phase 2 session)
- [ ] CI green (awaiting)
- [ ] code-reviewer agent
- [ ] advisor round-2
- [ ] Manual squash-merge

## Out of scope

- ❌ Plugin wire-up of `forget` / `clearAll` (Phase 3b-main)
- ❌ Renderer switch to use `ensureFileLoaded` (Phase 3b-main)
- ❌ Deletion of `ExocmdBindingsCache` / `ExocmdBindingsIndexer` / `shouldRunExocmdIndexer` / `ExocmdFastResolver` / settings toggle (Phase 3c)

## Auto-merge

⛔ **Do NOT enable auto-merge.** Per CLAUDE.md «Auto-merge discipline» — wait CI + code-reviewer + advisor + manual merge.

Refs RFC c7da0bca-a728-4d1f-97c8-a3193a61a519 Phase 3b-prep, Phase 3a PR #3254 reviewer MEDIUM finding.