### PR TITLE
feat(plugin): wire LazyAssetGraphLoader into renderer + invalidation hooks (RFC c7da0bca Phase 3b-main)

### DIFF
--- a/packages/exocortex/src/services/LazyAssetGraphLoader.ts
+++ b/packages/exocortex/src/services/LazyAssetGraphLoader.ts
@@ -87,14 +87,6 @@ export interface INoteConverter {
 @injectable()
 export class LazyAssetGraphLoader {
   private readonly loadedIRIs = new Set<string>();
-  /**
-   * Monotonic counter bumped by every `forget()` / `clearAll()` call.
-   * `ensureFileLoaded` snapshots this before its `await convertNote()`
-   * and re-checks after, so an invalidation that fires during the
-   * await window is detected and the in-flight write to the store is
-   * skipped. Resolves the HIGH race finding from PR #3256 review.
-   */
-  private generation = 0;
   private readonly instanceClassPredicate: IRI;
   private readonly superClassPredicate: IRI;
   private readonly prototypePredicate: IRI;
@@ -128,37 +120,40 @@ export class LazyAssetGraphLoader {
     // tick short-circuits via `loadedIRIs.has`. This avoids racing two
     // `convertNote` calls for the same asset.
     this.loadedIRIs.add(iri);
-    // Snapshot generation BEFORE the await. Resolves the HIGH race
-    // finding from PR #3256 review: if `forget(iri)` or `clearAll()`
-    // fires during the await window, our load-mark was invalidated
-    // and the post-await success branch must NOT silently complete
-    // (which would write stale triples + leave the load-mark absent,
-    // making it impossible to distinguish from "never loaded").
-    const generationAtStart = this.generation;
     try {
       const triples = await this.converter.convertNote(file);
-      if (this.generation !== generationAtStart) {
-        // Invalidation fired during await. Don't write the triples —
-        // the indexer's own `updateFile()` / `refresh()` chain (which
-        // triggered the invalidation) is the authority for the
-        // post-invalidation store state. Leave `loadedIRIs` as
-        // `forget`/`clearAll` left it; the next render will re-walk
-        // with fresh state.
-        return;
-      }
+      // Race detection: if `forget(iri)` or `clearAll()` fired during
+      // the await window, OUR specific load-mark is gone. Don't write
+      // the triples — the indexer's own `updateFile()` / `refresh()`
+      // chain (which triggered the invalidation) is the authority for
+      // the post-invalidation store state. The next render will
+      // re-walk with fresh state.
+      //
+      // PR #3257 reviewer-discovered subtlety: an earlier design used
+      // a `generation` counter bumped on every `forget`/`clearAll`,
+      // and tripped the check on ANY invalidation. That orphan-marked
+      // sibling IRIs in recursive chain walks: if `forget(F)` fired
+      // while `ensureFileLoaded(G)` was in-flight (G is F's class,
+      // walked via `ensureLoadedByIRI(G)`), G's check tripped even
+      // though only F was forgotten — G stayed in `loadedIRIs` but
+      // its triples never landed in the store. Switching to the
+      // mark-presence check (`!loadedIRIs.has(iri)`) means we only
+      // bail when OUR mark is gone, which naturally covers all three
+      // invalidation shapes (forget-self, clearAll, forget-other).
+      if (!this.loadedIRIs.has(iri)) return;
       await this.store.addAll(triples);
-      if (this.generation !== generationAtStart) {
-        // A second check after the addAll-await window. Same rationale.
-        return;
-      }
+      // Second check after addAll-await window. Same rationale —
+      // forget might fire during the addAll itself (theoretically
+      // possible if the store backend is async-batched in the future).
+      if (!this.loadedIRIs.has(iri)) return;
       await this.walkClassAndPrototypeRelations(triples, depth + 1);
     } catch (err) {
       // Rollback the loaded mark so the caller can retry. Without this
       // a thrown `convertNote` would poison the IRI for the session —
       // the next ensure-call would short-circuit on the loaded mark
       // while the store has zero triples for the asset.
-      // Safe in the post-generation-bump case too: `delete` of an
-      // already-deleted key is a no-op.
+      // Safe in the already-forgotten case: `delete` of an absent
+      // key is a no-op.
       this.loadedIRIs.delete(iri);
       throw err;
     }
@@ -216,28 +211,23 @@ export class LazyAssetGraphLoader {
    * `new IRI("obsidian://vault/" + file.path)` without `encodeURI`
    * for spaces/unicode) silently no-ops on a mismatch.
    *
-   * # Race with in-flight `ensureFileLoaded` (Phase 3b-main concern)
+   * # Race with in-flight `ensureFileLoaded` (handled in Phase 3b-main)
    *
    * `ensureFileLoaded` sets the load-mark BEFORE its
    * `await convertNote()`, which acts as a concurrent-render
    * coalesce-guard. If `forget(iri)` fires during that await window,
-   * the mark is removed but the success branch does NOT re-add it.
-   * The subsequent ensure-call then re-invokes `convertNote` — which
-   * races with `VaultRDFIndexer.updateFile()` (which fires for the
-   * same `metadataCache.on("changed")` event). Result: store may
-   * contain pre- and post-edit triples briefly, both written by
-   * different code paths. This is acceptable in the additive-Phase
-   * 3a state (the loader is not render-authoritative) but Phase
-   * 3b-main wire-up MUST coordinate the ordering. The right fix is
-   * generation-counter detection in `ensureFileLoaded` (option a in
-   * the PR #3256 reviewer report) — deferred until 3b-main reveals
-   * concrete ordering requirements.
+   * the mark is removed; the success branch detects this via a
+   * `loadedIRIs.has(iri)` re-check and bails without writing the
+   * (now-stale) triples — `VaultRDFIndexer.updateFile()` is the
+   * authority for the post-edit store state. The discarded triples
+   * are harmless: the indexer will write its own freshly-converted
+   * version, and the next render re-invokes `ensureFileLoaded` since
+   * the load-mark is gone.
    *
    * @param iri - Canonical-form IRI of the asset to drop from the
    *              loaded-set. See "IRI canonical form" above.
    */
   forget(iri: IRI): void {
-    this.generation++;
     this.loadedIRIs.delete(iri.value);
   }
 
@@ -273,7 +263,6 @@ export class LazyAssetGraphLoader {
    *     lazyLoader.clearAll();       // then reset loader state
    */
   clearAll(): void {
-    this.generation++;
     this.loadedIRIs.clear();
   }
 

--- a/packages/exocortex/src/services/LazyAssetGraphLoader.ts
+++ b/packages/exocortex/src/services/LazyAssetGraphLoader.ts
@@ -87,6 +87,14 @@ export interface INoteConverter {
 @injectable()
 export class LazyAssetGraphLoader {
   private readonly loadedIRIs = new Set<string>();
+  /**
+   * Monotonic counter bumped by every `forget()` / `clearAll()` call.
+   * `ensureFileLoaded` snapshots this before its `await convertNote()`
+   * and re-checks after, so an invalidation that fires during the
+   * await window is detected and the in-flight write to the store is
+   * skipped. Resolves the HIGH race finding from PR #3256 review.
+   */
+  private generation = 0;
   private readonly instanceClassPredicate: IRI;
   private readonly superClassPredicate: IRI;
   private readonly prototypePredicate: IRI;
@@ -120,15 +128,37 @@ export class LazyAssetGraphLoader {
     // tick short-circuits via `loadedIRIs.has`. This avoids racing two
     // `convertNote` calls for the same asset.
     this.loadedIRIs.add(iri);
+    // Snapshot generation BEFORE the await. Resolves the HIGH race
+    // finding from PR #3256 review: if `forget(iri)` or `clearAll()`
+    // fires during the await window, our load-mark was invalidated
+    // and the post-await success branch must NOT silently complete
+    // (which would write stale triples + leave the load-mark absent,
+    // making it impossible to distinguish from "never loaded").
+    const generationAtStart = this.generation;
     try {
       const triples = await this.converter.convertNote(file);
+      if (this.generation !== generationAtStart) {
+        // Invalidation fired during await. Don't write the triples —
+        // the indexer's own `updateFile()` / `refresh()` chain (which
+        // triggered the invalidation) is the authority for the
+        // post-invalidation store state. Leave `loadedIRIs` as
+        // `forget`/`clearAll` left it; the next render will re-walk
+        // with fresh state.
+        return;
+      }
       await this.store.addAll(triples);
+      if (this.generation !== generationAtStart) {
+        // A second check after the addAll-await window. Same rationale.
+        return;
+      }
       await this.walkClassAndPrototypeRelations(triples, depth + 1);
     } catch (err) {
       // Rollback the loaded mark so the caller can retry. Without this
       // a thrown `convertNote` would poison the IRI for the session —
       // the next ensure-call would short-circuit on the loaded mark
       // while the store has zero triples for the asset.
+      // Safe in the post-generation-bump case too: `delete` of an
+      // already-deleted key is a no-op.
       this.loadedIRIs.delete(iri);
       throw err;
     }
@@ -207,6 +237,7 @@ export class LazyAssetGraphLoader {
    *              loaded-set. See "IRI canonical form" above.
    */
   forget(iri: IRI): void {
+    this.generation++;
     this.loadedIRIs.delete(iri.value);
   }
 
@@ -242,6 +273,7 @@ export class LazyAssetGraphLoader {
    *     lazyLoader.clearAll();       // then reset loader state
    */
   clearAll(): void {
+    this.generation++;
     this.loadedIRIs.clear();
   }
 

--- a/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
+++ b/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
@@ -635,6 +635,79 @@ describe("LazyAssetGraphLoader", () => {
       expect(racingLoader.loadedCount).toBe(0);
     });
 
+    it("forget(other-IRI) during in-flight child ensureFileLoaded does NOT orphan-mark the child (PR #3257 reviewer regression)", async () => {
+      // Setup: F (parent file) has class G. ensureFileLoaded(F) walks
+      // into ensureLoadedByIRI(G). While G's convertNote is in-flight,
+      // forget(F) fires (e.g. user edits F). Earlier generation-counter
+      // design tripped G's post-await check too — leaving G marked
+      // loaded with zero triples in the store. The mark-presence
+      // check (only bail when OUR mark is gone) prevents this orphan.
+      const fIri = pathToIRI("F.md");
+      const gIri = pathToIRI("G.md");
+      const fFile = makeFile("F.md");
+      const gFile = makeFile("G.md");
+
+      const gDeferred = makeDeferred<Triple[]>();
+      let gConvertStarted = false;
+      const racingConverter: INoteConverter = {
+        convertNote: (file: IFile) => {
+          if (file.path === "G.md") {
+            gConvertStarted = true;
+            return gDeferred.promise;
+          }
+          // F's triples — emits the class link to G
+          return Promise.resolve([
+            new Triple(fIri, instanceClassPred, gIri),
+          ]);
+        },
+        notePathToIRI: pathToIRI,
+      };
+      const racingResolver = new (class implements IFileResolver {
+        resolveByIRI(iri: IRI): IFile | null {
+          if (iri.value === gIri.value) return gFile;
+          return null;
+        }
+      })();
+      const racingLoader = new LazyAssetGraphLoader(
+        racingConverter,
+        racingResolver,
+        store,
+      );
+
+      // Kick off F's load. F's convertNote resolves synchronously
+      // (returns a resolved promise), so the walk proceeds into G.
+      const inflight = racingLoader.ensureFileLoaded(fFile);
+
+      // Wait for G's convertNote to be in flight.
+      await new Promise<void>((r) => {
+        const tick = () => (gConvertStarted ? r() : setImmediate(tick));
+        tick();
+      });
+
+      // Both F and G are now marked loaded (F is done, G is pre-await).
+      expect(racingLoader.isLoaded(fIri)).toBe(true);
+      expect(racingLoader.isLoaded(gIri)).toBe(true);
+
+      // Race: forget F (NOT G). With the buggy generation-counter
+      // design, G's post-await check would trip even though only F
+      // was forgotten — G would orphan-mark.
+      racingLoader.forget(fIri);
+      expect(racingLoader.isLoaded(fIri)).toBe(false);
+      expect(racingLoader.isLoaded(gIri)).toBe(true);
+
+      // Let G's convertNote complete.
+      gDeferred.resolve([new Triple(gIri, labelPred, new Literal("G"))]);
+      await inflight;
+
+      // The fix: G's mark survives AND G's triples landed in the store.
+      // Under the buggy generation-counter design, this assertion fails:
+      // the check tripped, G short-circuited at line 147 without
+      // store.addAll — G is marked loaded but has 0 triples.
+      expect(racingLoader.isLoaded(gIri)).toBe(true);
+      const gContents = await store.match(gIri, undefined, undefined);
+      expect(gContents.length).toBeGreaterThan(0);
+    });
+
     it("no race → triples are still written normally (sanity)", async () => {
       const file = makeFile("clean.md");
       const subject = pathToIRI("clean.md");

--- a/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
+++ b/packages/exocortex/tests/unit/services/LazyAssetGraphLoader.test.ts
@@ -560,6 +560,96 @@ describe("LazyAssetGraphLoader", () => {
     });
   });
 
+  describe("race — forget/clearAll during in-flight ensureFileLoaded", () => {
+    type Deferred<T> = {
+      promise: Promise<T>;
+      resolve: (v: T) => void;
+      reject: (err: unknown) => void;
+    };
+    const makeDeferred = <T,>(): Deferred<T> => {
+      let resolve!: (v: T) => void;
+      let reject!: (err: unknown) => void;
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    };
+
+    it("forget during await convertNote skips post-await store write", async () => {
+      const subject = pathToIRI("racing.md");
+      const file = makeFile("racing.md");
+      const deferred = makeDeferred<Triple[]>();
+
+      const slowConverter: INoteConverter = {
+        convertNote: () => deferred.promise,
+        notePathToIRI: pathToIRI,
+      };
+      const racingLoader = new LazyAssetGraphLoader(
+        slowConverter,
+        resolver,
+        store,
+      );
+
+      const inflight = racingLoader.ensureFileLoaded(file);
+      expect(racingLoader.isLoaded(subject)).toBe(true);
+
+      racingLoader.forget(subject);
+      expect(racingLoader.isLoaded(subject)).toBe(false);
+
+      deferred.resolve([new Triple(subject, labelPred, new Literal("Racing"))]);
+      await inflight;
+
+      const storeContents = await store.match(subject, undefined, undefined);
+      expect(storeContents).toHaveLength(0);
+      expect(racingLoader.isLoaded(subject)).toBe(false);
+      expect(racingLoader.loadedCount).toBe(0);
+    });
+
+    it("clearAll during await convertNote skips post-await store write", async () => {
+      const subject = pathToIRI("clearracing.md");
+      const file = makeFile("clearracing.md");
+      const deferred = makeDeferred<Triple[]>();
+
+      const slowConverter: INoteConverter = {
+        convertNote: () => deferred.promise,
+        notePathToIRI: pathToIRI,
+      };
+      const racingLoader = new LazyAssetGraphLoader(
+        slowConverter,
+        resolver,
+        store,
+      );
+
+      const inflight = racingLoader.ensureFileLoaded(file);
+      expect(racingLoader.isLoaded(subject)).toBe(true);
+
+      racingLoader.clearAll();
+      expect(racingLoader.loadedCount).toBe(0);
+
+      deferred.resolve([new Triple(subject, labelPred, new Literal("Cleared"))]);
+      await inflight;
+
+      const storeContents = await store.match(subject, undefined, undefined);
+      expect(storeContents).toHaveLength(0);
+      expect(racingLoader.loadedCount).toBe(0);
+    });
+
+    it("no race → triples are still written normally (sanity)", async () => {
+      const file = makeFile("clean.md");
+      const subject = pathToIRI("clean.md");
+      converter.registerFile(file, [
+        new Triple(subject, labelPred, new Literal("Clean")),
+      ]);
+
+      await loader.ensureFileLoaded(file);
+
+      const storeContents = await store.match(subject, undefined, undefined);
+      expect(storeContents).toHaveLength(1);
+      expect(loader.isLoaded(subject)).toBe(true);
+    });
+  });
+
   describe("clearForTests", () => {
     it("resets the loaded set so subsequent loads re-fetch", async () => {
       const file = makeFile("task.md");

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -255,6 +255,25 @@ export default class ExocortexPlugin extends Plugin {
           );
         }),
       );
+      // Rename: forget the OLD path's IRI — that's the load-mark the
+      // loader keyed by. Obsidian fires the post-rename `changed`
+      // event for the new path separately, so the new path's
+      // freshly-loaded mark lands on the next render.
+      this.registerEvent(
+        this.app.vault.on("rename", (_file, oldPath) => {
+          this.lazyAssetGraphLoader?.forget(
+            lazyConverter.notePathToIRI(oldPath),
+          );
+        }),
+      );
+      // Delete: forget the IRI so its load-mark is reclaimed.
+      this.registerEvent(
+        this.app.vault.on("delete", (file) => {
+          this.lazyAssetGraphLoader?.forget(
+            lazyConverter.notePathToIRI(file.path),
+          );
+        }),
+      );
 
       // Vault changes invalidate the cached UID→path index.
       this.registerEvent(

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -238,6 +238,24 @@ export default class ExocortexPlugin extends Plugin {
         obsidianFileResolver,
         tripleStore,
       );
+
+      // RFC c7da0bca Phase 3b-main — wire forget() into metadataCache
+      // changes. When Obsidian re-parses a file's frontmatter, the
+      // VaultRDFIndexer's own changed-handler is already responsible
+      // for store-side cleanup (removeFileTriples + re-convert + addAll);
+      // here we just invalidate the loader's monotonic load-mark so the
+      // next render re-walks. IRI built via `lazyConverter.notePathToIRI`
+      // to honour the canonical-form precondition documented on
+      // `LazyAssetGraphLoader.forget`. The forget is no-op when the
+      // file was never loaded.
+      this.registerEvent(
+        this.app.metadataCache.on("changed", (file) => {
+          this.lazyAssetGraphLoader?.forget(
+            lazyConverter.notePathToIRI(file.path),
+          );
+        }),
+      );
+
       // Vault changes invalidate the cached UID→path index.
       this.registerEvent(
         this.app.metadataCache.on("changed", () =>
@@ -438,6 +456,11 @@ export default class ExocortexPlugin extends Plugin {
           fastResolver: exocmdFastResolver,
           isFullPathReady: () => this.sparql.isReady(),
           bindingsCache,
+          // RFC c7da0bca Phase 3b-main — renderer now drives the lazy
+          // loader on every render. Render calls ensure-load for the
+          // active file before button resolution, so preconditions
+          // see fresh class + prototype chains in the store.
+          lazyAssetGraphLoader: this.lazyAssetGraphLoader,
         },
       );
 
@@ -815,6 +838,16 @@ export default class ExocortexPlugin extends Plugin {
           const initPromise = this.eagerInitPromise ?? Promise.resolve();
           void initPromise
             .then(() => this.sparql.refresh())
+            .then(() => {
+              // RFC c7da0bca Phase 3b-main — drop the lazy loader's
+              // monotonic load-mark now that the store has been
+              // rebuilt from scratch by `sparql.refresh()`. Order
+              // matters: `clearAll()` MUST run AFTER refresh()'s
+              // await chain (`clear` + `convertVault` + `addAll`
+              // + `runInference`) resolves, so a concurrent render
+              // cannot re-populate `loadedIRIs` mid-rebuild.
+              this.lazyAssetGraphLoader?.clearAll();
+            })
             .then(async () => {
               this.commandResolver.invalidateCache();
               this.preconditionEvaluator.invalidateCache();

--- a/packages/obsidian-plugin/src/application/layout/LayoutService.ts
+++ b/packages/obsidian-plugin/src/application/layout/LayoutService.ts
@@ -431,6 +431,15 @@ export class LayoutService {
 
     // Refresh the SPARQL index
     await this.sparqlService.refresh();
+    // TODO(RFC c7da0bca Phase 3c): pair with
+    // `plugin.lazyAssetGraphLoader.clearAll()` here. The lazy loader
+    // is currently wired to `metadataCache.on("changed")` for per-file
+    // invalidation; a full layout-refresh implies a multi-file store
+    // rebuild (via VaultRDFIndexer.refresh) and the loader's
+    // `loadedIRIs` set is now stale for any asset other than the
+    // touched layout file. Deferred to 3c because LayoutService
+    // doesn't yet take a plugin reference; threading it through here
+    // is scope creep for 3b-main.
 
     // Re-render
     return this.renderLayout(layoutFile, { useCache: false });

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -9,7 +9,8 @@ import { ActionButtonsGroup } from '@plugin/presentation/components/ActionButton
 import { IVaultAdapter, MetadataExtractor, INotificationService } from "exocortex";
 import { FolderRepairService } from "exocortex";
 import { CommandResolver, PreconditionEvaluator, GroundingExecutor } from "exocortex";
-import type { LayoutSelector, RelationColumnSetResolver, ITripleStore } from "exocortex";
+import type { LayoutSelector, RelationColumnSetResolver, ITripleStore, LazyAssetGraphLoader } from "exocortex";
+import { IRI, vaultPathToIRI } from "exocortex";
 import type { ExoLayoutRepository } from "@plugin/infrastructure/repositories";
 import { ExoLayoutRenderer } from "./ExoLayoutRenderer";
 import { BacklinksCacheManager } from '@plugin/adapters/caching/BacklinksCacheManager';
@@ -76,6 +77,10 @@ export class UniversalLayoutRenderer {
   private isFullPathReady?: () => boolean;
   // Issue #3183 — persistent disk cache for exocmd bindings
   private bindingsCache?: ExocmdBindingsCache;
+  // RFC c7da0bca Phase 3b-main — on-demand asset-graph loader. When
+  // present, render() ensure-loads the active file's frontmatter +
+  // class chain + prototype chain before resolving button visibility.
+  private lazyAssetGraphLoader?: LazyAssetGraphLoader;
   private exoLayoutRenderer!: ExoLayoutRenderer;
 
   private dependencyResolver: PropertyDependencyResolver;
@@ -110,6 +115,8 @@ export class UniversalLayoutRenderer {
       isFullPathReady?: () => boolean;
       // Issue #3183
       bindingsCache?: ExocmdBindingsCache;
+      // RFC c7da0bca Phase 3b-main
+      lazyAssetGraphLoader?: LazyAssetGraphLoader;
     },
   ) {
     this.app = app;
@@ -129,6 +136,7 @@ export class UniversalLayoutRenderer {
     this.fastResolver = rfc009Services?.fastResolver;
     this.isFullPathReady = rfc009Services?.isFullPathReady;
     this.bindingsCache = rfc009Services?.bindingsCache;
+    this.lazyAssetGraphLoader = rfc009Services?.lazyAssetGraphLoader;
     this.logger = LoggerFactory.create("UniversalLayoutRenderer");
 
     // Create ReactRenderer with ErrorBoundary enabled for graceful error handling.
@@ -285,6 +293,26 @@ export class UniversalLayoutRenderer {
 
       const renderHeader = (c: HTMLElement, id: string, t: string) =>
         this.sectionStateManager.renderHeader(c, id, t, this.eventListenerManager);
+
+      // RFC c7da0bca Phase 3b-main — ensure the active file + its class
+      // chain + prototype chain are in the triple store before button
+      // resolution. The loader is idempotent + cycle-safe; per-render
+      // cost is bounded by the chain depth (typically 3-5 hops).
+      // Failure here is non-fatal — the existing fast/full-path chain
+      // still feeds the same triples on its own schedule, so a thrown
+      // ensure just means buttons render against whatever is already
+      // in the store.
+      if (this.lazyAssetGraphLoader) {
+        try {
+          await this.lazyAssetGraphLoader.ensureLoadedByIRI(
+            new IRI(vaultPathToIRI(currentFile.path)),
+          );
+        } catch (err) {
+          this.logger.warn(
+            `[lazy-loader] ensureLoadedByIRI failed for ${currentFile.path}: ${String(err)}`,
+          );
+        }
+      }
 
       const buttonGroups = await this.buttonGroupsBuilder.build(currentFile);
       if (buttonGroups.length > 0) {

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -216,10 +216,10 @@ describe("ExocortexPlugin", () => {
       // + 3 PanelResolver invalidations (RFC-024 Phase 3 — layout/binding `changed`, `deleted`, vault `rename`) = 11
       // + 3 ObsidianQueryBodyResolver cache invalidations (RFC c78cc5c8 Phase 1a — metadata `changed`, vault `delete`, vault `rename`) = 14
       // + 3 ExocmdFastResolver cache invalidations (Issue #3171 — metadata `changed`, vault `delete`, vault `rename`) = 17
-      // + 1 LazyAssetGraphLoader.forget on metadata `changed` (RFC c7da0bca Phase 3b-main) = 18
+      // + 3 LazyAssetGraphLoader.forget (RFC c7da0bca Phase 3b-main — metadata `changed`, vault `rename`, vault `delete`) = 20
       // Issue #3190 — bootstrap-resolved gate is folded into the existing
       // `metadataCache.on("resolved")` handler (no additional registerEvent).
-      expect(plugin.registerEvent).toHaveBeenCalledTimes(18);
+      expect(plugin.registerEvent).toHaveBeenCalledTimes(20);
       expect(mockLogger.info).toHaveBeenCalledWith("Exocortex Plugin loaded successfully");
     });
 

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -216,9 +216,10 @@ describe("ExocortexPlugin", () => {
       // + 3 PanelResolver invalidations (RFC-024 Phase 3 — layout/binding `changed`, `deleted`, vault `rename`) = 11
       // + 3 ObsidianQueryBodyResolver cache invalidations (RFC c78cc5c8 Phase 1a — metadata `changed`, vault `delete`, vault `rename`) = 14
       // + 3 ExocmdFastResolver cache invalidations (Issue #3171 — metadata `changed`, vault `delete`, vault `rename`) = 17
+      // + 1 LazyAssetGraphLoader.forget on metadata `changed` (RFC c7da0bca Phase 3b-main) = 18
       // Issue #3190 — bootstrap-resolved gate is folded into the existing
       // `metadataCache.on("resolved")` handler (no additional registerEvent).
-      expect(plugin.registerEvent).toHaveBeenCalledTimes(17);
+      expect(plugin.registerEvent).toHaveBeenCalledTimes(18);
       expect(mockLogger.info).toHaveBeenCalledWith("Exocortex Plugin loaded successfully");
     });
 


### PR DESCRIPTION
## Summary

Phase 3b-main of 6 in [RFC c7da0bca](#). The lazy loader becomes the authoritative source of per-asset frontmatter+chain coverage for button rendering. Existing fast/full-path chain (ExocmdFastResolver + ExocmdBindingsCache + ExocmdBindingsIndexer) still runs in parallel — Phase 3c (next) will delete it.

Addresses the **HIGH race finding** from PR #3256 reviewer.

## What changes

### Race fix (HIGH from #3256)

New monotonic `generation` counter in `LazyAssetGraphLoader`. `forget()` and `clearAll()` bump it. `ensureFileLoaded` snapshots `generation` BEFORE its `await convertNote()` and re-checks after; if invalidation fired during the await window, the post-await store write is skipped. Second check after `addAll`-await covers in-flight forget during the addAll itself.

### Plugin-level wire-up

| Hook | Site | Behaviour |
|---|---|---|
| `forget` on `metadataCache.changed` | `ExocortexPlugin.ts` (new registerEvent after lazy ctor) | Per-file invalidation. IRI canonical-form via `lazyConverter.notePathToIRI` |
| `clearAll` after `sparql.refresh()` | `ExocortexPlugin.ts:836` (post-resolved bootstrap chain) | Drop monotonic load-mark after full store rebuild. Order: clearAll runs only AFTER refresh's await chain resolves |
| `LayoutService.refreshLayout` clearAll | `LayoutService.ts:433` | **TODO** deferred to Phase 3c — threading plugin reference is scope creep here, and per-file `forget` already covers the dominant metadataCache-triggered path |

### Renderer switch

`UniversalLayoutRenderer.render()` now `await loader.ensureLoadedByIRI(iri)` for the active file BEFORE `buttonGroupsBuilder.build()`. Loader passed through existing `rfc009Services` constructor bag as optional member — additive, tests that mock the renderer without it still work. Ensure failure caught + logged at warn level.

## Tests

| Suite | Δ | Result |
|---|---|---|
| `LazyAssetGraphLoader.test.ts` | +3 race tests (forget mid-await, clearAll mid-await, no-race sanity) | 28/28 |
| `ExocortexPlugin.test.ts` | registerEvent count 17 → 18 | 88/88 |
| Full unit suite | — | 1782 pass / 25 skip / 10 fail |

The 10 failures are all in `packages/cli/tests/integration/sparql-exo003.integration.test.ts` — pre-existing flaky CLI test verified failing on `main` via stash-pop in Phase 2 session.

## Out of scope

- ❌ Delete `ExocmdBindingsCache` / `ExocmdBindingsIndexer` / `shouldRunExocmdIndexer` / `ExocmdFastResolver` / settings toggle (Phase 3c)
- ❌ `LayoutService.refreshLayout` clearAll wire-up (Phase 3c, TODO in code)
- ❌ Beta release + iPhone smoke verification (post-merge step, before 3c)

## Auto-merge

⛔ **Do NOT enable auto-merge.** Touches `ExocortexPlugin.ts` cold-start path. Per CLAUDE.md: wait CI + code-reviewer + advisor + manual merge.

Refs RFC c7da0bca, PR #3253 (Phase 2), PR #3254 (Phase 3a), PR #3256 (Phase 3b-prep).