### PR TITLE
fix(cli): wire ClassLabelToUidResolver into apply (UID-form parity with UI) #3258

### DIFF
--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -17,6 +17,7 @@ import {
   EffortStatusWorkflow,
   StatusTimestampService,
   TaskStatusService,
+  createVaultFrontmatterClassLabelResolver,
   vaultPathToIRI,
   IRI,
   liveClock,
@@ -201,11 +202,20 @@ async function executeOnTarget(
     renameToUidService,
     folderRepairService,
   });
+  // Issue #3258: wire a vault-frontmatter-backed ClassLabelToUidResolver so
+  // CLI `apply` emits UID-form `exo__Instance_class` (parity with UI button
+  // path, which wires `createObsidianClassLabelResolver(app)`). Without this,
+  // label-form `grounding.targetClass` (e.g. `"ems__Task"`) passed through
+  // untouched, producing `"[[ems__Task]]"` instead of `"[[1b20a8f0-...]]"` in
+  // created frontmatter. Triple-store lookup is insufficient here because
+  // NoteToRDFConverter substitutes class-shaped string literals with class
+  // IRIs at predicate `exo:Asset_label` (Issue #2782/#2959), so a vault scan
+  // by frontmatter is required.
   const groundingExecutor = new GroundingExecutor(
     nodeFsAdapter,
     nodeFsAdapter,
     serviceRegistry,
-    undefined,
+    createVaultFrontmatterClassLabelResolver(nodeFsAdapter),
     { clock, uidGenerator: uidGen },
   );
 

--- a/packages/cli/tests/integration/apply-class-resolver.integration.test.ts
+++ b/packages/cli/tests/integration/apply-class-resolver.integration.test.ts
@@ -2,14 +2,14 @@
  * Issue #3258 — CLI `apply` must emit UID-form `exo__Instance_class` for the
  * created instance, matching the UI button path's output.
  *
- * Bug reproduction: prior to wiring `createTripleStoreClassLabelResolver`,
+ * Bug reproduction: prior to wiring `createVaultFrontmatterClassLabelResolver`,
  * `apply` passed `grounding.targetClass = "ems__Task"` (label-form) through
  * to `GroundingExecutor.executeCreateInstance` unchanged, producing
  * `exo__Instance_class: "[[ems__Task]]"`. The plugin's UI button path
  * (wires `createObsidianClassLabelResolver(app)`) emits canonical UID-form
  * `exo__Instance_class: "[[1b20a8f0-...]]"`.
  *
- * After fix: CLI `apply` wires `createTripleStoreClassLabelResolver(tripleStore)`
+ * After fix: CLI `apply` wires `createVaultFrontmatterClassLabelResolver(nodeFsAdapter)`
  * and emits the same UID-form.
  *
  * Integration test exercises real `applyCommand().parseAsync(...)` against a

--- a/packages/cli/tests/integration/apply-class-resolver.integration.test.ts
+++ b/packages/cli/tests/integration/apply-class-resolver.integration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Issue #3258 — CLI `apply` must emit UID-form `exo__Instance_class` for the
+ * created instance, matching the UI button path's output.
+ *
+ * Bug reproduction: prior to wiring `createTripleStoreClassLabelResolver`,
+ * `apply` passed `grounding.targetClass = "ems__Task"` (label-form) through
+ * to `GroundingExecutor.executeCreateInstance` unchanged, producing
+ * `exo__Instance_class: "[[ems__Task]]"`. The plugin's UI button path
+ * (wires `createObsidianClassLabelResolver(app)`) emits canonical UID-form
+ * `exo__Instance_class: "[[1b20a8f0-...]]"`.
+ *
+ * After fix: CLI `apply` wires `createTripleStoreClassLabelResolver(tripleStore)`
+ * and emits the same UID-form.
+ *
+ * Integration test exercises real `applyCommand().parseAsync(...)` against a
+ * temp vault containing:
+ *   - command + create_instance grounding (label-form targetClass)
+ *   - parent prototype asset to click on
+ *   - class TBox file declaring `ems__Task` with canonical UID
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { applyCommand } = await import("../../src/commands/apply.js");
+
+const COMMAND_UID = "dddddddd-0000-0000-0000-000000000001";
+const GROUNDING_UID = "dddddddd-0000-0000-0000-000000000002";
+const PARENT_UID = "dddddddd-0000-0000-0000-000000000003";
+const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e"; // canonical ems__Task UID
+const SEED = "99999999-8888-7777-6666-555555555555";
+const FROZEN_CLOCK = "2026-01-01T00:00:00Z";
+
+const COMMAND_MD = [
+  "---",
+  `exo__Asset_uid: ${COMMAND_UID}`,
+  `exo__Asset_label: "Create child task (cli-class-resolver)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Command]]"`,
+  `exocmd__Command_grounding: "[[${GROUNDING_UID}|Create child task grounding]]"`,
+  `exocmd__Command_successMessage: "Child task created"`,
+  "---",
+  "",
+].join("\n");
+
+const GROUNDING_MD = [
+  "---",
+  `exo__Asset_uid: ${GROUNDING_UID}`,
+  `exo__Asset_label: "Create child task grounding"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "create_instance"`,
+  // Label-form targetClass — the exact shape that triggered the regression.
+  `exocmd__Grounding_targetClass: "ems__Task"`,
+  `exocmd__Grounding_targetFolder: "Inbox"`,
+  "---",
+  "",
+].join("\n");
+
+const PARENT_MD = [
+  "---",
+  `exo__Asset_uid: ${PARENT_UID}`,
+  `exo__Asset_label: "Parent prototype asset"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[ems__TaskPrototype]]"`,
+  "---",
+  "",
+].join("\n");
+
+// Class TBox file — UUID-named per UID-canon discipline. Carries the canonical
+// UID and the label "ems__Task" the grounding references.
+const CLASS_TBOX_MD = [
+  "---",
+  `exo__Asset_uid: ${CLASS_UID}`,
+  `exo__Asset_label: "ems__Task"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exo__Class]]"`,
+  "---",
+  "",
+].join("\n");
+
+interface VaultLayout {
+  root: string;
+  parentRelPath: string;
+  inboxDir: string;
+}
+
+function buildVault(opts: { withClassTBox: boolean } = { withClassTBox: true }): VaultLayout {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "exo-apply-clsres-"));
+  fs.writeFileSync(path.join(root, `${COMMAND_UID}.md`), COMMAND_MD, "utf-8");
+  fs.writeFileSync(path.join(root, `${GROUNDING_UID}.md`), GROUNDING_MD, "utf-8");
+  fs.writeFileSync(path.join(root, `${PARENT_UID}.md`), PARENT_MD, "utf-8");
+  if (opts.withClassTBox) {
+    fs.writeFileSync(path.join(root, `${CLASS_UID}.md`), CLASS_TBOX_MD, "utf-8");
+  }
+  const inboxDir = path.join(root, "Inbox");
+  fs.mkdirSync(inboxDir, { recursive: true });
+  return { root, parentRelPath: `${PARENT_UID}.md`, inboxDir };
+}
+
+function listCreatedFiles(inboxDir: string): string[] {
+  if (!fs.existsSync(inboxDir)) return [];
+  return fs.readdirSync(inboxDir).filter((f) => f.endsWith(".md"));
+}
+
+describe("Issue #3258: CLI `apply` emits UID-form exo__Instance_class", () => {
+  let vault: VaultLayout;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__process_exit_${code ?? 0}__`);
+    }) as never);
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (vault) fs.rmSync(vault.root, { recursive: true, force: true });
+  });
+
+  async function runApply(vaultRoot: string): Promise<void> {
+    const cmd = applyCommand();
+    const args = [
+      "node",
+      "apply",
+      COMMAND_UID,
+      `${PARENT_UID}.md`,
+      "--vault",
+      vaultRoot,
+      "--input",
+      JSON.stringify({ label: "Child instance" }),
+      "--seed",
+      SEED,
+      "--frozen-clock",
+      FROZEN_CLOCK,
+    ];
+    try {
+      await cmd.parseAsync(args);
+    } catch (err) {
+      if (!/^__process_exit_/.test(String((err as Error)?.message))) throw err;
+    }
+  }
+
+  it("emits exo__Instance_class as UID-form wikilink when class TBox is present", async () => {
+    vault = buildVault({ withClassTBox: true });
+
+    await runApply(vault.root);
+
+    const created = listCreatedFiles(vault.inboxDir);
+    expect(created).toHaveLength(1);
+    const content = fs.readFileSync(path.join(vault.inboxDir, created[0]), "utf-8");
+
+    // Primary acceptance criterion: UID-form, not label-form.
+    expect(content).toContain(`exo__Instance_class:\n  - "[[${CLASS_UID}]]"`);
+    // Negative — must NOT have label-form anywhere.
+    expect(content).not.toContain(`"[[ems__Task]]"`);
+  });
+
+  it("falls back to label-form when class TBox is missing (resolver returns null)", async () => {
+    vault = buildVault({ withClassTBox: false });
+
+    await runApply(vault.root);
+
+    const created = listCreatedFiles(vault.inboxDir);
+    expect(created).toHaveLength(1);
+    const content = fs.readFileSync(path.join(vault.inboxDir, created[0]), "utf-8");
+
+    // Without TBox declaration, resolver returns null and GroundingExecutor
+    // preserves the original label-form ref. Backward-compatible behaviour.
+    expect(content).toContain(`exo__Instance_class:\n  - "[[ems__Task]]"`);
+  });
+});

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -77,6 +77,7 @@ export {
   type IGroundingService,
   type ClassLabelToUidResolver,
 } from "./services/GroundingExecutor";
+export { createVaultFrontmatterClassLabelResolver } from "./services/VaultFrontmatterClassLabelResolver";
 export {
   CommandExecutionFlow,
   type CommandExecutionContext,

--- a/packages/exocortex/src/services/VaultFrontmatterClassLabelResolver.ts
+++ b/packages/exocortex/src/services/VaultFrontmatterClassLabelResolver.ts
@@ -1,0 +1,70 @@
+import type { IFileSystemMetadataProvider } from "../interfaces/IFileSystemAdapter";
+import type { ClassLabelToUidResolver } from "./GroundingExecutor";
+
+/**
+ * Issue #3258 — filesystem-frontmatter-backed {@link ClassLabelToUidResolver}.
+ *
+ * # Why a filesystem-frontmatter resolver, not a triple-store resolver
+ *
+ * `GroundingExecutor.executeCreateInstance` writes `exo__Instance_class` from
+ * `grounding.targetClass`. The Obsidian plugin wires
+ * {@link ../../obsidian-plugin/src/infrastructure/services/ObsidianClassLabelResolver
+ * createObsidianClassLabelResolver}, which reads frontmatter via the metadata
+ * cache rather than via the triple store — and that distinction is **load-
+ * bearing**:
+ *
+ *   `NoteToRDFConverter.valueToRDFObject` (lines 1095-1100) substitutes
+ *   class-shaped string literals like `"ems__Task"` with the canonical
+ *   class IRI (`<https://exocortex.my/ontology/ems#Task>`) when emitting
+ *   triples (Issue #2782/#2959). That substitution applies to predicate
+ *   `exo:Asset_label` too, so a class TBox file's own label triple has an
+ *   IRI object, not a Literal — meaning `CommandResolver.findUidByLabel`
+ *   (#3212) and any other triple-store label lookup returns null for
+ *   class-shaped labels. This is the same production gap the plugin's
+ *   alias-index resolver was created (#3223) to bridge.
+ *
+ * The CLI must do equivalent work: scan vault frontmatter, find the asset
+ * whose `exo__Asset_label` or `aliases` matches the requested label, return
+ * its `exo__Asset_uid`. The shape mirrors the plugin resolver one-for-one
+ * but reads from the filesystem rather than `app.metadataCache`.
+ *
+ * # Cost characteristics
+ *
+ * `findFilesByMetadata` walks every markdown file under the vault root once
+ * per call, reading frontmatter via `js-yaml`. For typical vaults (<10k
+ * files) this completes in well under a second; the resolver is invoked
+ * once per `create_instance` execution (rare). If profiling later flags
+ * this as hot, the obvious next step is to wrap with an aliasing index
+ * built from the same triple store the CLI already maintains.
+ */
+export function createVaultFrontmatterClassLabelResolver(
+  metadataProvider: IFileSystemMetadataProvider,
+): ClassLabelToUidResolver {
+  return async (label: string): Promise<string | null> => {
+    if (!label) return null;
+
+    // Primary: match by exo__Asset_label.
+    const byLabel = await metadataProvider.findFilesByMetadata({
+      exo__Asset_label: label,
+    });
+    if (byLabel.length > 0) {
+      const fm = await metadataProvider.getFileMetadata(byLabel[0]);
+      const uid = fm["exo__Asset_uid"];
+      if (typeof uid === "string" && uid.length > 0) return uid;
+    }
+
+    // Secondary: match by aliases. `findFilesByMetadata` treats array values
+    // by "any element equals", which matches the plugin resolver's aliases
+    // array semantics. String-valued `aliases` are matched literally.
+    const byAlias = await metadataProvider.findFilesByMetadata({
+      aliases: label,
+    });
+    if (byAlias.length > 0) {
+      const fm = await metadataProvider.getFileMetadata(byAlias[0]);
+      const uid = fm["exo__Asset_uid"];
+      if (typeof uid === "string" && uid.length > 0) return uid;
+    }
+
+    return null;
+  };
+}

--- a/packages/exocortex/src/services/VaultFrontmatterClassLabelResolver.ts
+++ b/packages/exocortex/src/services/VaultFrontmatterClassLabelResolver.ts
@@ -54,8 +54,16 @@ export function createVaultFrontmatterClassLabelResolver(
     }
 
     // Secondary: match by aliases. `findFilesByMetadata` treats array values
-    // by "any element equals", which matches the plugin resolver's aliases
-    // array semantics. String-valued `aliases` are matched literally.
+    // by "any element equals". Note: the underlying `IFileSystemMetadataProvider`
+    // implementation may normalise alias values before comparison (NodeFsAdapter
+    // strips brackets/quotes/whitespace via `normalizeValue`), so a stored alias
+    // like `"[[ems__Task]]"` would match label `"ems__Task"` in CLI. The plugin
+    // counterpart (`ObsidianClassLabelResolver`) uses strict `===`. For typical
+    // production data — class TBox files store plain shortnames like
+    // `"ems__Task"`, not wikilink-form strings — both resolvers yield identical
+    // results. The looser CLI semantics is forgiveness-only (matches a superset
+    // of cases the plugin accepts); it never returns a wrong UID, only an extra
+    // legitimate match. Documented for parity transparency.
     const byAlias = await metadataProvider.findFilesByMetadata({
       aliases: label,
     });

--- a/packages/exocortex/tests/unit/services/VaultFrontmatterClassLabelResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/VaultFrontmatterClassLabelResolver.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Issue #3258 — unit tests for the vault-frontmatter-backed
+ * {@link createVaultFrontmatterClassLabelResolver}.
+ *
+ * Why a fake `IFileSystemMetadataProvider` rather than a temp-fs adapter:
+ * the resolver is a pure delegation over `findFilesByMetadata` +
+ * `getFileMetadata`. Exercising the integration with the real
+ * `NodeFsAdapter` happens in the CLI integration test
+ * (`packages/cli/tests/integration/apply-class-resolver.integration.test.ts`)
+ * which builds a real temp vault. These unit tests stay focused on the
+ * branch matrix.
+ */
+import { createVaultFrontmatterClassLabelResolver } from "../../../src/services/VaultFrontmatterClassLabelResolver";
+import type { IFileSystemMetadataProvider } from "../../../src/interfaces/IFileSystemAdapter";
+
+function makeProvider(opts: {
+  labelMatches?: Record<string, string[]>;
+  aliasMatches?: Record<string, string[]>;
+  frontmatters?: Record<string, Record<string, unknown>>;
+}): IFileSystemMetadataProvider & {
+  byLabelCalls: number;
+  byAliasCalls: number;
+} {
+  const labelMatches = opts.labelMatches ?? {};
+  const aliasMatches = opts.aliasMatches ?? {};
+  const fms = opts.frontmatters ?? {};
+  const tracker = { byLabelCalls: 0, byAliasCalls: 0 };
+
+  return {
+    ...tracker,
+    async findFilesByMetadata(query: Record<string, unknown>): Promise<string[]> {
+      if ("exo__Asset_label" in query) {
+        tracker.byLabelCalls++;
+        return labelMatches[String(query.exo__Asset_label)] ?? [];
+      }
+      if ("aliases" in query) {
+        tracker.byAliasCalls++;
+        return aliasMatches[String(query.aliases)] ?? [];
+      }
+      return [];
+    },
+    async getFileMetadata(path: string): Promise<Record<string, unknown>> {
+      return fms[path] ?? {};
+    },
+    async findFileByUID(_uid: string): Promise<string | null> {
+      return null;
+    },
+    get byLabelCalls() {
+      return tracker.byLabelCalls;
+    },
+    get byAliasCalls() {
+      return tracker.byAliasCalls;
+    },
+  } as IFileSystemMetadataProvider & {
+    byLabelCalls: number;
+    byAliasCalls: number;
+  };
+}
+
+describe("createVaultFrontmatterClassLabelResolver (#3258)", () => {
+  it("resolves a label-form ref by exo__Asset_label", async () => {
+    const provider = makeProvider({
+      labelMatches: { "ems__Task": ["1b20a8f0.md"] },
+      frontmatters: {
+        "1b20a8f0.md": {
+          exo__Asset_label: "ems__Task",
+          exo__Asset_uid: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+        },
+      },
+    });
+    const resolver = createVaultFrontmatterClassLabelResolver(provider);
+    expect(await resolver("ems__Task")).toBe(
+      "1b20a8f0-d745-4e93-91db-4531b3df120e",
+    );
+  });
+
+  it("falls back to aliases when exo__Asset_label has no match", async () => {
+    const provider = makeProvider({
+      labelMatches: {},
+      aliasMatches: { "ems__Task": ["1b20a8f0.md"] },
+      frontmatters: {
+        "1b20a8f0.md": {
+          aliases: ["ems__Task"],
+          exo__Asset_uid: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+        },
+      },
+    });
+    const resolver = createVaultFrontmatterClassLabelResolver(provider);
+    expect(await resolver("ems__Task")).toBe(
+      "1b20a8f0-d745-4e93-91db-4531b3df120e",
+    );
+  });
+
+  it("prefers exo__Asset_label match over aliases match (label is primary)", async () => {
+    // Two different files: one wins by label, the other by alias.
+    const provider = makeProvider({
+      labelMatches: { foo: ["primary.md"] },
+      aliasMatches: { foo: ["secondary.md"] },
+      frontmatters: {
+        "primary.md": { exo__Asset_uid: "primary-uid" },
+        "secondary.md": { exo__Asset_uid: "secondary-uid" },
+      },
+    });
+    const resolver = createVaultFrontmatterClassLabelResolver(provider);
+    expect(await resolver("foo")).toBe("primary-uid");
+    expect(provider.byAliasCalls).toBe(0); // short-circuited on label hit
+  });
+
+  it("returns null when neither label nor alias match", async () => {
+    const provider = makeProvider({});
+    const resolver = createVaultFrontmatterClassLabelResolver(provider);
+    expect(await resolver("nonexistent")).toBeNull();
+    expect(provider.byLabelCalls).toBe(1);
+    expect(provider.byAliasCalls).toBe(1);
+  });
+
+  it("returns null for empty input without touching the filesystem", async () => {
+    const provider = makeProvider({});
+    const resolver = createVaultFrontmatterClassLabelResolver(provider);
+    expect(await resolver("")).toBeNull();
+    expect(provider.byLabelCalls).toBe(0);
+    expect(provider.byAliasCalls).toBe(0);
+  });
+
+  it("returns null when matched file has no exo__Asset_uid", async () => {
+    const provider = makeProvider({
+      labelMatches: { orphan: ["orphan.md"] },
+      frontmatters: {
+        "orphan.md": { exo__Asset_label: "orphan" /* no uid */ },
+      },
+    });
+    const resolver = createVaultFrontmatterClassLabelResolver(provider);
+    // Falls through to alias lookup, which also misses → null.
+    expect(await resolver("orphan")).toBeNull();
+  });
+
+  it("returns null when exo__Asset_uid is empty string", async () => {
+    const provider = makeProvider({
+      labelMatches: { foo: ["foo.md"] },
+      frontmatters: { "foo.md": { exo__Asset_uid: "" } },
+    });
+    const resolver = createVaultFrontmatterClassLabelResolver(provider);
+    expect(await resolver("foo")).toBeNull();
+  });
+
+  it("returns null when exo__Asset_uid is not a string", async () => {
+    const provider = makeProvider({
+      labelMatches: { foo: ["foo.md"] },
+      frontmatters: { "foo.md": { exo__Asset_uid: 12345 } },
+    });
+    const resolver = createVaultFrontmatterClassLabelResolver(provider);
+    expect(await resolver("foo")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

CLI \`apply\` produced label-form \`exo__Instance_class: \"[[ems__Task]]\"\` whereas UI button path produced canonical UID-form \`\"[[1b20a8f0-...]]\"\`. Same grounding, divergent output shape — visual unification + UID-canon discipline both broken in CLI path.

Root cause: \`apply.ts\` constructed \`GroundingExecutor\` with \`classLabelToUid: undefined\`, so label-form \`grounding.targetClass\` passed through \`resolveClassRefToUid\` untouched. The Obsidian plugin wires \`createObsidianClassLabelResolver(app)\` (alias-index over metadataCache, Issue #3223); the CLI had no equivalent.

## Fix

1. New shared factory \`createVaultFrontmatterClassLabelResolver(IFileSystemMetadataProvider)\` in core package. Algorithm identical to plugin's alias-index resolver — scans frontmatter, matches by \`exo__Asset_label\` (primary) or \`aliases\` (fallback), returns \`exo__Asset_uid\`.
2. \`apply.ts\` wires the factory against \`NodeFsAdapter\` (which already implements \`IFileSystemMetadataProvider\`).

**Why filesystem-frontmatter, not triple-store:** \`NoteToRDFConverter.valueToRDFObject\` substitutes class-shaped string literals (\`\"ems__Task\"\`) with class IRIs at predicate \`exo:Asset_label\` (Issue #2782/#2959). Consequence: a class TBox file's own label triple has an IRI object, not a Literal — \`CommandResolver.findUidByLabel\` (#3212) and any other triple-store label lookup returns null for class-labelled assets. Filesystem scan reads raw YAML and is the only reliable label→UID path for class TBox assets. This is the same gap the plugin resolver bridges.

## Test plan

- [x] L1 unit (8/8): \`packages/exocortex/tests/unit/services/VaultFrontmatterClassLabelResolver.test.ts\` — label-primary, alias-fallback, both-miss, empty input, missing/non-string UID, label-vs-alias precedence.
- [x] L2 integration (2/2): \`packages/cli/tests/integration/apply-class-resolver.integration.test.ts\` — real \`applyCommand().parseAsync(...)\` against temp vault; (a) class TBox present → UID-form, (b) class TBox missing → label-form fallback (backward-compatible).
- [x] **Empirical revert→fail / restore→pass** verified for both unit (2 positive cases fail when resolver body returns null) and integration (positive case fails when 4th arg flipped back to \`undefined\`). Per \`~/.claude/rules/integration-test-revert-verify.md\`.
- [x] Sibling \`apply-determinism.integration.test.ts\` still passes (no regression).
- [x] \`GroundingExecutor.test.ts\` 138/138 passes (no regression).

## Files

- \`packages/exocortex/src/services/VaultFrontmatterClassLabelResolver.ts\` — new factory
- \`packages/exocortex/src/index.ts\` — export factory
- \`packages/cli/src/commands/apply.ts\` — wire resolver into GroundingExecutor
- \`packages/exocortex/tests/unit/services/VaultFrontmatterClassLabelResolver.test.ts\` — L1
- \`packages/cli/tests/integration/apply-class-resolver.integration.test.ts\` — L2

## Post-merge verification plan

1. Auto Release publishes new \`@kitelev/exocortex-cli\` version.
2. \`npx @kitelev/exocortex-cli@latest apply bb00efed-7b17-42f5-a2c4-7cadf3e0ab36 <prototype-path> --vault /Users/kitelev/vault-2025\` → assert created file's \`exo__Instance_class\` is \`\"[[1b20a8f0-...]]\"\` (UID-form), matching UI button output.

Closes #3258.