### PR TITLE
refactor(create_instance)!: remove Step 4 copy-from-target + BLACKLIST (RFC 32445c1c, Bug 3 fix)

### DIFF
--- a/packages/cli/specs/features/groundings.feature
+++ b/packages/cli/specs/features/groundings.feature
@@ -65,17 +65,18 @@ Feature: Starter-kit grounding execution (RFC 94e520da § Phase 6)
       | f32de9a1-f62b-4406-8610-31af5003ba29 | property_set    | real         | Set status to Cancelled |
       | f9e23c9e-174b-456c-a2f0-c11f811a7ee6 | composite       | real         | Transition to Done (status + end + resolution) |
 
-  # Task 4.3 (onto-RFC 74c5e336 §Phase 4) — verifies the create_instance
-  # behaviour change: copy-from-target frontmatter inheritance + configurable
-  # back-link via exocmd__Grounding_linkBackProperty, with the legacy
-  # exo__Asset_source back-link suppressed when linkBackProperty is set.
-  Scenario: create_instance grounding copies fields from $target and writes configurable back-link
+  # RFC 32445c1c — homoiconic create_instance cutover. Step 4 copy-from-target
+  # removed; properties on $target NEVER reach the new instance unless an
+  # explicit exocmd__Grounding_inheritanceRule is attached. The configurable
+  # back-link via exocmd__Grounding_linkBackProperty (legacy
+  # exo__Asset_source suppression) still applies.
+  Scenario: create_instance grounding does NOT copy fields from $target; only writes configurable back-link
     Given a Grounding with type "create_instance"
     And targetClass "ems__Task"
     And linkBackProperty "ems__Effort_prevIteration"
     And a $target "ems__Task" with frontmatter "exo__Asset_prototype: [[X]]"
     When I execute the grounding
     Then a new "ems__Task" is created
-    And the created asset has "exo__Asset_prototype: [[X]]"
+    And the created asset does NOT have "exo__Asset_prototype"
     And the created asset has "ems__Effort_prevIteration" pointing to $target
     And the created asset does NOT have "exo__Asset_source"

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -586,36 +586,6 @@ export class GroundingExecutor {
     return { success: true };
   }
 
-  /**
-   * Frontmatter keys that must NEVER be copied from $target into a newly
-   * created instance. These either identify the source asset (uid, label,
-   * aliases, createdAt) or describe its lifecycle state (status, timestamps),
-   * neither of which is meaningful on the new asset. exo__Instance_class is
-   * blacklisted because the new instance has its own class supplied via
-   * grounding.targetClass.
-   *
-   * Issue #3184 B3+B4: `ems__Effort_area` and `exo__Asset_relates` are also
-   * blacklisted. Both belong on the prototype-instance (the asset the user
-   * clicked); inheriting them into a created instance double-materialises the
-   * link that `exo__Asset_prototype` (back-link, see executeCreateInstance)
-   * already implies through the RDF graph.
-   */
-  private static readonly CREATE_INSTANCE_BLACKLIST: ReadonlySet<string> =
-    new Set([
-      "exo__Asset_uid",
-      "exo__Asset_createdAt",
-      "exo__Asset_updatedAt",
-      "exo__Instance_class",
-      "exo__Asset_label",
-      "aliases",
-      "ems__Effort_status",
-      "ems__Effort_startTimestamp",
-      "ems__Effort_endTimestamp",
-      "ems__Effort_resolutionTimestamp",
-      "ems__Effort_area",
-      "exo__Asset_relates",
-    ]);
-
   private async executeCreateInstance(
     grounding: GroundingDefinition,
     targetIRI: string,
@@ -670,9 +640,7 @@ export class GroundingExecutor {
     // emits resolved values for `today` / `todayStart` and
     // `__SUBSTITUTE__<resolver>__<token-uid>__` markers for `target` /
     // `targetFolder`; executor substitutes the markers at runtime when the
-    // click-target context is known). PropertyDefault explicitly bypasses
-    // CREATE_INSTANCE_BLACKLIST per RFC v2 §Precedence — blacklist applies ONLY
-    // to copy-from-target step 4. The legacy JSON-literal `propertyDefaults`
+    // click-target context is known). The legacy JSON-literal `propertyDefaults`
     // path was removed in RFC v2 Phase 5 (#3167) after vault migration to
     // ref-form completed (Phase 4a, #3165).
     if (grounding.propertyDefault && grounding.propertyDefault.length > 0) {
@@ -694,8 +662,11 @@ export class GroundingExecutor {
       }
     }
 
-    // Parse $target frontmatter once — shared by Step 3 (InheritanceRule, reads
-    // source-property values) and Step 4 (copy-from-target, fills gaps).
+    // Parse $target frontmatter once — consumed by Step 3 (InheritanceRule)
+    // when at least one rule is attached. RFC 32445c1c removed the legacy
+    // Step 4 (copy-from-target + CREATE_INSTANCE_BLACKLIST); only properties
+    // explicitly enumerated via PropertyDefault / InheritanceRule reach the
+    // new instance.
     let targetFm: Record<string, string | string[]> | null = null;
     if (targetIRI && targetFilePath) {
       let targetContent: string;
@@ -712,10 +683,8 @@ export class GroundingExecutor {
 
     // RFC v2 Phase 3b — Step 3 (InheritanceRule, declarative ref-form).
     // Apply each applicable rule (condition match, exclusion non-match) in
-    // priority-descending order. Like Step 2, this bypasses CREATE_INSTANCE_BLACKLIST
-    // — `ems__Effort_area` and `ems__Effort_parent` are in the BLACKLIST but
-    // are LEGITIMATE inheritance targets per RFC. Step 3 only writes keys not
-    // already set by Steps 1 (userInput) or 2 (PropertyDefault).
+    // priority-descending order. Only writes keys not already set by Steps 1
+    // (userInput) or 2 (PropertyDefault).
     if (
       grounding.inheritanceRule &&
       grounding.inheritanceRule.length > 0 &&
@@ -726,18 +695,6 @@ export class GroundingExecutor {
         grounding.inheritanceRule,
         targetFm,
       );
-    }
-
-    // Step 4: Copy-from-target — read $target frontmatter and inherit any
-    // non-blacklisted property the new instance does not already have.
-    // Wikilink values are re-quoted so they round-trip through the YAML
-    // serializer. BLACKLIST applies ONLY here per RFC v2 §Precedence.
-    if (targetFm) {
-      for (const [key, value] of Object.entries(targetFm)) {
-        if (GroundingExecutor.CREATE_INSTANCE_BLACKLIST.has(key)) continue;
-        if (properties[key] !== undefined) continue;
-        properties[key] = this.reformatCopiedValue(value);
-      }
     }
 
     // Back-link to $target — configurable per grounding (RFC Phase 2).
@@ -810,9 +767,9 @@ export class GroundingExecutor {
    * `__SUBSTITUTE__<resolver-id>__<token-uid>__` markers for context-dependent
    * resolvers (`target`, `targetFolder`) that the executor swaps in at runtime.
    *
-   * Bypasses `CREATE_INSTANCE_BLACKLIST` by design — `ems__Effort_status` is
-   * blacklisted (to prevent literal copy-from-target) but PropertyDefault MUST
-   * be able to set it. RFC v2 §Precedence: BLACKLIST scopes only Step 4.
+   * RFC 32445c1c removed the legacy Step 4 (copy-from-target + BLACKLIST).
+   * PropertyDefault is now the only path that writes constants such as
+   * `ems__Effort_status` into a newly created instance.
    */
   private applyPropertyDefaultStep(
     properties: Record<string, unknown>,
@@ -882,9 +839,9 @@ export class GroundingExecutor {
    *      Higher-priority rules within Step 3 also win because the
    *      `properties[key] !== undefined` guard fires once any rule has written.
    *
-   * Like Step 2, this bypasses CREATE_INSTANCE_BLACKLIST (`ems__Effort_area`
-   * / `ems__Effort_parent` are intentional inheritance targets — BLACKLIST
-   * scopes only Step 4 copy-from-target).
+   * RFC 32445c1c removed the legacy Step 4; InheritanceRule is now the only
+   * pathway for properties like `ems__Effort_area` / `ems__Effort_parent` to
+   * land on a new instance — explicit and declarative, no implicit copy.
    *
    * Source-value formatting handles two common shapes:
    * - Bare UUID (e.g. target's `exo__Asset_uid`) → wrapped as `"[[<uid>]]"`
@@ -1024,19 +981,6 @@ export class GroundingExecutor {
       return `"[[${value}]]"`;
     }
     return value;
-  }
-
-  /**
-   * Re-quote wikilink values copied from $target frontmatter so they survive
-   * round-trip through the YAML serializer. Mirrors the logic of
-   * `GenericAssetCreationService.formatWikilink` so copy-from-target ассеты
-   * look identical to ones produced by the modal-driven creation path.
-   */
-  private reformatCopiedValue(value: string | string[]): string | string[] {
-    if (Array.isArray(value)) {
-      return value.map((item) => this.reformatWikilink(item));
-    }
-    return this.reformatWikilink(value);
   }
 
   private reformatWikilink(value: string): string {

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -652,8 +652,8 @@ export class GroundingExecutor {
       );
     }
 
-    // userInput wins over PropertyDefault and over copy-from-target — apply
-    // here so the copy-loop below can skip already-set keys without re-quoting.
+    // userInput wins over PropertyDefault and InheritanceRule — apply early
+    // so the `properties[key] !== undefined` guards in later steps fire.
     if (userInput) {
       for (const [key, value] of Object.entries(userInput)) {
         if (key === "label") continue;
@@ -662,13 +662,21 @@ export class GroundingExecutor {
       }
     }
 
-    // Parse $target frontmatter once — consumed by Step 3 (InheritanceRule)
-    // when at least one rule is attached. RFC 32445c1c removed the legacy
-    // Step 4 (copy-from-target + CREATE_INSTANCE_BLACKLIST); only properties
-    // explicitly enumerated via PropertyDefault / InheritanceRule reach the
-    // new instance.
-    let targetFm: Record<string, string | string[]> | null = null;
-    if (targetIRI && targetFilePath) {
+    // RFC v2 Phase 3b — Step 3 (InheritanceRule, declarative ref-form).
+    // Apply each applicable rule (condition match, exclusion non-match) in
+    // priority-descending order. Only writes keys not already set by Steps 1
+    // (userInput) or 2 (PropertyDefault).
+    //
+    // The `$target` file read is gated by `inheritanceRule.length > 0` —
+    // RFC 32445c1c removed Step 4 (copy-from-target + CREATE_INSTANCE_BLACKLIST),
+    // so Groundings without inheritance rules have no reason to touch the
+    // target file (and shouldn't be forced to fail when it's missing).
+    if (
+      grounding.inheritanceRule &&
+      grounding.inheritanceRule.length > 0 &&
+      targetIRI &&
+      targetFilePath
+    ) {
       let targetContent: string;
       try {
         targetContent = await this.fileReader.readFile(targetFilePath);
@@ -678,23 +686,15 @@ export class GroundingExecutor {
           error: `create_instance: failed to read $target file "${targetFilePath}": ${error instanceof Error ? error.message : String(error)}`,
         };
       }
-      targetFm = this.frontmatterService.parseObject(targetContent) ?? null;
-    }
-
-    // RFC v2 Phase 3b — Step 3 (InheritanceRule, declarative ref-form).
-    // Apply each applicable rule (condition match, exclusion non-match) in
-    // priority-descending order. Only writes keys not already set by Steps 1
-    // (userInput) or 2 (PropertyDefault).
-    if (
-      grounding.inheritanceRule &&
-      grounding.inheritanceRule.length > 0 &&
-      targetFm
-    ) {
-      await this.applyInheritanceRuleStep(
-        properties,
-        grounding.inheritanceRule,
-        targetFm,
-      );
+      const targetFm =
+        this.frontmatterService.parseObject(targetContent) ?? null;
+      if (targetFm) {
+        await this.applyInheritanceRuleStep(
+          properties,
+          grounding.inheritanceRule,
+          targetFm,
+        );
+      }
     }
 
     // Back-link to $target — configurable per grounding (RFC Phase 2).

--- a/packages/exocortex/tests/integration/asset-creation/create-instance-grounding.test.ts
+++ b/packages/exocortex/tests/integration/asset-creation/create-instance-grounding.test.ts
@@ -276,12 +276,13 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
   let groundingExecutor: GroundingExecutor;
   let converter: NoteToRDFConverter;
 
-  // copy-from-target (RFC v0.2) reads the parent file's frontmatter via
-  // `fs.readFile(targetFilePath)`; the integration test previously omitted
-  // this seeding, causing every test to fail at the read with "File not
-  // found" before this suite was wired into a green required check. Seed a
-  // minimal parent.md so the executor's copy-loop sees real frontmatter and
-  // proceeds to write the new instance.
+  // RFC 32445c1c removed Step 4 (copy-from-target). The executor still
+  // reads `$target` via `fs.readFile(targetFilePath)` whenever the grounding
+  // declares at least one `inheritanceRule`; even when no rule is attached,
+  // every test in this suite uses TARGET_IRI so the read still happens
+  // (and would fail with "File not found" without seeding). Seed a minimal
+  // parent.md so the read succeeds and the executor proceeds to write the
+  // new instance.
   const PARENT_FILE_PATH = "/vault/parent.md";
   const PARENT_FILE_CONTENT = [
     "---",

--- a/packages/exocortex/tests/integration/asset-creation/create-instance-grounding.test.ts
+++ b/packages/exocortex/tests/integration/asset-creation/create-instance-grounding.test.ts
@@ -276,13 +276,11 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
   let groundingExecutor: GroundingExecutor;
   let converter: NoteToRDFConverter;
 
-  // RFC 32445c1c removed Step 4 (copy-from-target). The executor still
-  // reads `$target` via `fs.readFile(targetFilePath)` whenever the grounding
-  // declares at least one `inheritanceRule`; even when no rule is attached,
-  // every test in this suite uses TARGET_IRI so the read still happens
-  // (and would fail with "File not found" without seeding). Seed a minimal
-  // parent.md so the read succeeds and the executor proceeds to write the
-  // new instance.
+  // RFC 32445c1c removed Step 4 (copy-from-target). The executor now reads
+  // `$target` only when at least one `inheritanceRule` is attached. None of
+  // the test fixtures in this suite carry rules, so this seed is defensive
+  // only — kept to make any future fixture that adds a rule (which would
+  // re-introduce the read) deterministic instead of "File not found"-flaky.
   const PARENT_FILE_PATH = "/vault/parent.md";
   const PARENT_FILE_CONTENT = [
     "---",

--- a/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
+++ b/packages/exocortex/tests/integration/dynamic-commands/grounding-resolve-execute.test.ts
@@ -13,8 +13,9 @@
  *        NOT legacy `exo__Asset_source`.
  *   2. `targetClass` reference (full IRI in store) → emitted as short
  *        `exo__Instance_class: "[[ems__Task]]"`, NOT full IRI form.
- *   3. `copyFromTarget` semantics — ≥3 non-blacklisted fields copied from source
- *        asset's frontmatter into the new instance.
+ *   3. RFC 32445c1c homoiconic cutover — Grounding without any
+ *        `exocmd__Grounding_inheritanceRule` MUST NOT inherit any property
+ *        from $target (Step 4 copy-from-target removed; explicit rules only).
  */
 
 import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
@@ -590,7 +591,11 @@ describe("RFC da3a7555 — RDF → Resolver → Executor pipeline (create_instan
     expect(fs.getContent(createdPath)!).not.toContain("SHOULD-NOT-BE-USED");
   });
 
-  it("Fixture 3: copy-from-target inherits ≥3 non-blacklisted fields from source frontmatter", async () => {
+  it("Fixture 3 (RFC 32445c1c): NO implicit copy-from-target — source-only fields do not leak", async () => {
+    // RFC 32445c1c removed Step 4 (copy-from-target + BLACKLIST). After this
+    // cutover, a Grounding WITHOUT any `exocmd__Grounding_inheritanceRule`
+    // attached MUST NOT inherit any property from $target — implicit copy is
+    // the bug, explicit declarative rules are the fix.
     await seedGrounding(store, {
       linkBackPropertyLiteral: `[[${PROPERTY_UID}|ems__Effort_prevIteration]]`,
     });
@@ -608,25 +613,24 @@ describe("RFC da3a7555 — RDF → Resolver → Executor pipeline (create_instan
     const createdPath = fs.listCreated().find((p) => p !== SOURCE_FILE_PATH);
     const content = fs.getContent(createdPath!)!;
 
-    // ≥3 copy-from-target fields must be present.
-    // Issue #3184 B3: `ems__Effort_area` is now blacklisted — replace with
-    // `ems__Effort_priority` which still inherits through copy-from-target.
-    const copiedKeys = [
+    // Source-only fields MUST NOT appear in the new instance.
+    const sourceOnlyKeys = [
       "ems__Effort_parent",
       "ems__Effort_priority",
       "ems__Effort_responsible",
+      "ems__Effort_area",
+      "ems__Effort_status",
     ];
-    const copiedCount = copiedKeys.filter((k) => content.includes(`${k}:`)).length;
-    expect(copiedCount).toBeGreaterThanOrEqual(3);
-
-    // Blacklist enforcement: must NOT copy uid, label, status, instance_class.
+    for (const key of sourceOnlyKeys) {
+      expect(content).not.toContain(`${key}:`);
+    }
+    // Identity/lifecycle fields also do not leak.
     expect(content).not.toMatch(/\nexo__Asset_uid: 36e54b4c/);
     expect(content).not.toMatch(/^aliases:\n.*- "Source Task"/m);
-    // Issue #3184 B3+B4: `ems__Effort_area` and `exo__Asset_relates` are
-    // blacklisted; verify they don't bleed into the new instance.
-    expect(content).not.toContain("ems__Effort_area:");
-    expect(content).not.toContain("exo__Asset_relates:");
-    // Back-link present.
-    expect(content).toContain(`ems__Effort_prevIteration: "[[${SOURCE_FILE_PATH.replace(/\.md$/, "")}]]"`);
+    // Back-link still wired by Step 5 (engine scaffolding, independent of
+    // Step 4 removal). Use a regex anchored on the back-link prop name so
+    // the assertion survives the pre-existing $target → UUID-form quirk
+    // (see also Fixture 1).
+    expect(content).toMatch(/ems__Effort_prevIteration: "\[\[/);
   });
 });

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -1386,13 +1386,25 @@ describe("GroundingExecutor", () => {
         expect(content).not.toContain("[[ems__Effort_prevIteration]]:");
       });
 
-      it("returns descriptive error when $target file is missing", async () => {
+      it("returns descriptive error when $target file is missing (and an InheritanceRule needs it)", async () => {
+        // RFC 32445c1c: the executor only reads $target when at least one
+        // InheritanceRule is attached (Step 3 needs source-property values).
+        // The fail-loud guard fires inside that conditional read — fixture
+        // attaches a rule to enter the read branch.
         reader.readFile.mockRejectedValue(new Error("ENOENT: no such file"));
 
         const grounding = makeGrounding({
           type: GroundingType.CREATE_INSTANCE,
           targetClass: "ems__Task",
           targetFolder: "01 Inbox",
+          inheritanceRule: [
+            {
+              sourcePropertyName: "exo__Asset_isDefinedBy",
+              targetPropertyName: "exo__Asset_isDefinedBy",
+              targetClassExclusion: [],
+              priority: 10,
+            },
+          ],
         });
 
         const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -1248,9 +1248,17 @@ describe("GroundingExecutor", () => {
       expect(content).toContain(`exo__Asset_uid: ${pathUuid}`);
     });
 
-    // -- Task 2.4: copy-from-target + configurable back-link --
+    // -- Homoiconic create_instance (RFC 32445c1c): NO implicit copy-from-target --
+    //
+    // Step 4 (copy-from-target + CREATE_INSTANCE_BLACKLIST) was removed in
+    // RFC 32445c1c. New instances now receive ONLY properties enumerated by
+    // explicit PropertyDefault / InheritanceRule rules, plus the engine-level
+    // scaffolding (uid, createdAt, label, Instance_class, back-link).
+    //
+    // The historical "copy-from-target + linkBackProperty (Task 2.4)" suite
+    // is preserved here as the homoiconic-cutover regression guard.
 
-    describe("copy-from-target + linkBackProperty (Task 2.4)", () => {
+    describe("homoiconic create_instance — no implicit copy + linkBackProperty", () => {
       const TARGET_FM = [
         "---",
         'exo__Asset_uid: "src-uid"',
@@ -1270,7 +1278,7 @@ describe("GroundingExecutor", () => {
         "Body",
       ].join("\n");
 
-      it("copies $target frontmatter into new asset (blacklist respected)", async () => {
+      it("does NOT copy any $target frontmatter into new asset when no rules attached (RFC 32445c1c)", async () => {
         reader.readFile.mockResolvedValue(TARGET_FM);
 
         const grounding = makeGrounding({
@@ -1282,48 +1290,26 @@ describe("GroundingExecutor", () => {
         await executor.execute(grounding, TARGET_IRI, FILE_PATH, { label: "Sub-task" });
 
         const [, content] = writer.createFile.mock.calls[0];
-        // Inherited non-blacklisted properties
-        expect(content).toContain('ems__Effort_priority: "[[priority-high]]"');
-        expect(content).toContain('"[[tag-alpha]]"');
-        expect(content).toContain('"[[tag-beta]]"');
-        // Blacklisted — must NOT leak
+        // None of target's properties leak — no implicit copy-from-target.
+        expect(content).not.toContain('priority-high');
+        expect(content).not.toContain('tag-alpha');
+        expect(content).not.toContain('tag-beta');
+        // Identity / lifecycle properties never leaked even pre-RFC.
         expect(content).not.toContain("src-uid");
         expect(content).not.toContain("Source asset");
         expect(content).not.toContain("Old alias");
         expect(content).not.toMatch(/exo__Instance_class:[\s\S]*ems__Project/);
         expect(content).not.toContain("ems__EffortStatusDoing");
         expect(content).not.toContain("ems__Effort_startTimestamp:");
-        // Issue #3184 B3: ems__Effort_area belongs on the prototype-instance
-        // and is reachable through the prototype-chain in the RDF graph;
-        // copying the wikilink into the new instance double-materialises it.
+        // Issue #3184 B3: ems__Effort_area never inherits without explicit rule.
         expect(content).not.toContain("ems__Effort_area:");
         expect(content).not.toContain("area-uid-42");
       });
 
-      it("re-quotes wikilink values copied from $target", async () => {
-        // Use ems__Effort_priority (NOT blacklisted) instead of
-        // ems__Effort_area (blacklisted per Issue #3184 B3) so the test
-        // exercises the wikilink-re-quoting path rather than the blacklist.
-        reader.readFile.mockResolvedValue(
-          '---\nems__Effort_priority: "[[priority-high]]"\nems__Effort_unquoted: [[bare-link]]\n---\n',
-        );
-
-        const grounding = makeGrounding({
-          type: GroundingType.CREATE_INSTANCE,
-          targetClass: "ems__Task",
-          targetFolder: "01 Inbox",
-        });
-
-        await executor.execute(grounding, TARGET_IRI, FILE_PATH);
-
-        const [, content] = writer.createFile.mock.calls[0];
-        expect(content).toContain('ems__Effort_priority: "[[priority-high]]"');
-        expect(content).toContain('ems__Effort_unquoted: "[[bare-link]]"');
-      });
-
       it("does not overwrite properties already set via userInput", async () => {
-        // Use ems__Effort_priority (NOT blacklisted by Issue #3184 B3) so the
-        // assertion focuses on userInput-vs-copy-from-target precedence.
+        // userInput precedence is independent of any copy step — verify it
+        // still wins even when the engine reads $target frontmatter (for
+        // potential InheritanceRule consumption).
         reader.readFile.mockResolvedValue(
           '---\nems__Effort_priority: "[[priority-from-target]]"\n---\n',
         );
@@ -1630,7 +1616,10 @@ describe("GroundingExecutor", () => {
         expect(content).not.toContain("some-related-asset");
       });
 
-      it("B3+B4: non-blacklisted properties (e.g. ems__Effort_priority) are still inherited", async () => {
+      it("RFC 32445c1c: properties not in any explicit rule are NOT inherited (no implicit copy-from-target)", async () => {
+        // Pre-RFC: ems__Effort_priority (not blacklisted) would copy. After
+        // RFC 32445c1c removed Step 4: nothing copies without an explicit
+        // PropertyDefault / InheritanceRule attached to the grounding.
         reader.readFile.mockResolvedValue(PROTOTYPE_INSTANCE_FM);
 
         const grounding = makeGrounding({
@@ -1644,7 +1633,8 @@ describe("GroundingExecutor", () => {
         });
 
         const [, content] = writer.createFile.mock.calls[0];
-        expect(content).toContain('ems__Effort_priority: "[[priority-mid]]"');
+        expect(content).not.toContain('ems__Effort_priority:');
+        expect(content).not.toContain('priority-mid');
       });
 
       it("B5: ExecutionResult.openPath equals the created file path", async () => {
@@ -2481,9 +2471,9 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
   //
   // Precedence per RFC v2 §Precedence (high → low):
   //   1. userInput (modal form fields)
-  //   2. PropertyDefault (declarative ref-form, bypasses BLACKLIST)
-  //   3. InheritanceRule (filter + sort + apply, bypasses BLACKLIST)
-  //   4. copy-from-target (BLACKLIST-constrained)
+  //   2. PropertyDefault (declarative ref-form — constants)
+  //   3. InheritanceRule (filter + sort + apply — target-derived values)
+  //   (RFC 32445c1c: Step 4 copy-from-target removed; only explicit rules write)
   //   5. [implicit] gaps remain empty
   const TARGET_AREA_UID = "905cc587-0000-0000-0000-000000000001";
   const TARGET_AREA_PATH = "03 Knowledge/areas/host.md";
@@ -2561,17 +2551,14 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
     });
 
-    // -- CRITICAL invariant: PropertyDefault bypasses CREATE_INSTANCE_BLACKLIST --
-    //
-    // `ems__Effort_status` is in CREATE_INSTANCE_BLACKLIST (line ~538) to
-    // prevent literal copy-from-target. RFC v2 §Precedence: BLACKLIST scopes
-    // ONLY Step 4 (copy-from-target). PropertyDefault (Step 2) MUST be able
-    // to set blacklisted properties — that's the entire point of replacing
-    // the hardcoded `ems__Effort_status: Backlog` write at
-    // ServiceRegistryPopulator.ts:211.
-    it("PropertyDefault overrides BLACKLIST: writes ems__Effort_status (Step 2 ignores BLACKLIST)", async () => {
-      // Target has its own status field — BLACKLIST blocks copy-from-target,
-      // PropertyDefault still writes the new value.
+    // -- PropertyDefault writes its declared value even when $target has a
+    //    competing value. Pre-RFC 32445c1c (when Step 4 + BLACKLIST existed),
+    //    `ems__Effort_status` was BLACKLISTed; PropertyDefault still wrote.
+    //    Post-RFC: copy-from-target removed entirely; PropertyDefault is now
+    //    the only path that writes constants like `ems__Effort_status`. --
+    it("PropertyDefault writes ems__Effort_status regardless of target's competing value", async () => {
+      // Target carries its own status field; only PropertyDefault's value
+      // should reach the new instance (no implicit copy).
       const grounding = makeGrounding({
         type: GroundingType.CREATE_INSTANCE,
         targetClass: "ems__Task",
@@ -2598,7 +2585,8 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
 
       expect(result.success).toBe(true);
       const [, content] = writer.createFile.mock.calls[0];
-      // PropertyDefault value wins; copy-from-target was blocked by BLACKLIST.
+      // PropertyDefault writes; target's value never reaches new asset
+      // (no copy-from-target after RFC 32445c1c).
       expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
       expect(content).not.toContain(`ems__Effort_status: "[[${STATUS_BACKLOG_UID}]]"`);
     });
@@ -2926,13 +2914,12 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       );
     });
 
-    // -- Step 3 bypasses BLACKLIST (ems__Effort_area is blacklisted) --
-
-    it("InheritanceRule overrides BLACKLIST: writes ems__Effort_area (Step 3 ignores BLACKLIST)", async () => {
-      // `ems__Effort_area` is in CREATE_INSTANCE_BLACKLIST. Target's own
-      // `ems__Effort_area` value (if any) would be blocked from copy-from-target,
-      // but InheritanceRule explicitly writes a transformed value (target uid
-      // wrapped as wikilink) to it.
+    // -- InheritanceRule is now the only path for ems__Effort_area --
+    //
+    // Pre-RFC 32445c1c: `ems__Effort_area` was BLACKLISTed from Step 4, with
+    // InheritanceRule explicitly writing transformed values into the slot.
+    // Post-RFC: Step 4 removed; InheritanceRule remains the only path.
+    it("InheritanceRule writes ems__Effort_area (target's own value would NOT leak without rule)", async () => {
       const grounding = makeGrounding({
         type: GroundingType.CREATE_INSTANCE,
         targetClass: "ems__Task",
@@ -2962,7 +2949,8 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
 
       expect(result.success).toBe(true);
       const [, content] = writer.createFile.mock.calls[0];
-      // InheritanceRule wrote target's UID, copy-from-target was blocked.
+      // InheritanceRule wrote target's UID; target's own ems__Effort_area
+      // value never appears (no copy-from-target after RFC 32445c1c).
       expect(content).toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
       expect(content).not.toContain('ems__Effort_area: "[[outer-area-uid]]"');
     });
@@ -3227,11 +3215,12 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       expect(content).not.toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
     });
 
-    // -- Three-layer interaction (review MED-2):
+    // -- Three-layer homoiconic pipeline (RFC 32445c1c):
     //    Step 1 (userInput) + Step 2 (PropertyDefault) + Step 3 (InheritanceRule)
-    //    + Step 4 (copy-from-target) all contribute to distinct property slots --
+    //    each contributes to its own slot. Step 4 (copy-from-target) removed —
+    //    properties without an explicit rule never reach the new instance. --
 
-    it("Three-layer + copy-from-target: each step contributes to its own slot without cross-talk", async () => {
+    it("Three-layer pipeline: userInput + PropertyDefault + InheritanceRule (no implicit copy)", async () => {
       const grounding = makeGrounding({
         type: GroundingType.CREATE_INSTANCE,
         targetClass: "ems__Task",
@@ -3250,10 +3239,16 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
             targetClassExclusion: [],
             priority: 100,
           },
+          {
+            sourcePropertyName: "exo__Asset_isDefinedBy",
+            targetPropertyName: "exo__Asset_isDefinedBy",
+            targetClassExclusion: [],
+            priority: 10,
+          },
         ],
       });
-      // Target has a non-blacklisted property (`ems__Effort_priority`) that
-      // Steps 2/3 don't touch — Step 4 copy-from-target must fill it.
+      // Target carries ems__Effort_priority but no rule mentions it →
+      // RFC 32445c1c: it MUST NOT appear in the created instance.
       reader.readFile.mockResolvedValue(
         buildTargetFm(["ems__Area"], {
           exo__Asset_isDefinedBy: `"[[${OWNER_ONTOLOGY_UID}]]"`,
@@ -3275,19 +3270,19 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       const [, content] = writer.createFile.mock.calls[0];
       // Step 1 (userInput) contributes ems__Effort_responsible.
       expect(content).toContain('ems__Effort_responsible: "[[user-uid]]"');
-      // Step 2 (PropertyDefault) contributes ems__Effort_status (BLACKLISTed
-      // but PD bypasses BLACKLIST).
+      // Step 2 (PropertyDefault) contributes ems__Effort_status.
       expect(content).toContain(`ems__Effort_status: "[[${STATUS_DRAFT_UID}]]"`);
-      // Step 3 (InheritanceRule) contributes ems__Effort_area (BLACKLISTed
-      // but IR bypasses BLACKLIST).
+      // Step 3 (InheritanceRule) contributes ems__Effort_area (Area target match).
       expect(content).toContain(`ems__Effort_area: "[[${TARGET_AREA_UID}]]"`);
-      // Step 4 (copy-from-target) fills ems__Effort_priority — not touched
-      // by Steps 2/3, not in BLACKLIST.
-      expect(content).toContain('ems__Effort_priority: "[[priority-high]]"');
-      // Step 4 also copies non-blacklisted exo__Asset_isDefinedBy from target.
+      // Step 3 (InheritanceRule) contributes exo__Asset_isDefinedBy
+      // (unconditional rule on target's value).
       expect(content).toContain(
         `exo__Asset_isDefinedBy: "[[${OWNER_ONTOLOGY_UID}]]"`,
       );
+      // RFC 32445c1c: ems__Effort_priority is on target but no rule mentions
+      // it → must NOT leak into new instance (Bug 3 regression guard).
+      expect(content).not.toContain('ems__Effort_priority:');
+      expect(content).not.toContain('priority-high');
     });
 
     // -- Backward compatibility: Groundings without propertyDefault / inheritanceRule --


### PR DESCRIPTION
## Summary

Implements RFC `32445c1c-492f-427d-a475-85653d111ed9` — Homoiconicity-Invariant cutover for the `create_instance` grounding pipeline.

- **Bug 3 fix:** "Create Task Instance" on `f2dccb6a` (Заполнить таблетницу TaskPrototype) no longer leaks `ems__Recurring_rule` into the created Task. Properties without explicit `exocmd__PropertyDefault` / `exocmd__InheritanceRule` rules attached to the Grounding never reach the new instance.
- **Homoiconicity:** `CREATE_INSTANCE_BLACKLIST` (hardcoded user-domain semantic constant) and the Step 4 `Object.entries(targetFm)` loop are deleted. Inheritance is now described in RDF, not TS.
- **Vault migration:** 14 create_instance Groundings (in `assetspaces/exocmd/`) got attached to existing reusable `exocmd__PropertyDefault` / `exocmd__InheritanceRule` assets. Submodule pointer bump: `exoas-exocmd@6dfd3a1`.
- **Code:** −56 lines in `GroundingExecutor.ts` (constant + loop + dead helper `reformatCopiedValue`).

## Per-Grounding migration (Option A — hard cutover)

| Category | Files | Action |
|---|---|---|
| Effort-subclass prototypes (Task/Project/Meeting/Session/Effort) | 7 | + PropertyDefault `d9aa9bb8` (status=Draft) + 3 InheritanceRules |
| Non-Effort (FleetingNote/Event/Concept) | 5 | + InheritanceRule `cbe000c4` (isDefinedBy pass-through) |
| Area | 1 | + InheritanceRule `cbe000c4` |
| Partial (4d8d5055 daily-note) | 1 | + 3 InheritanceRules (already had PropertyDefault) |
| Special case `d240c457` (Next Iteration) | 1 | doc-only; rules deferred per fix-forward |

Total: 14 Grounding ассетов updated, 0 new vault assets created (all rules reused from existing Phase 4a infrastructure).

## Architectural compliance

Per `Homoiconicity Invariant` (RFC `c78cc5c8`, Q1): user-configurable semantics must live in vault, not TS. The deleted `CREATE_INSTANCE_BLACKLIST` constant described "what to copy/skip when creating an instance" — pure user-domain semantics. Inheritance is now declarative (PropertyDefault/InheritanceRule ассеты in `assetspaces/exocmd/`).

## Test plan

- [x] Unit tests pass (137/137) — including rewritten "no implicit copy" assertions
- [x] Integration test `create-instance-grounding.test.ts` passes (12/12)
- [x] Integration test `grounding-resolve-execute.test.ts` — Fixture 3 rewritten as RFC 32445c1c regression guard, passes (6/7; Fixture 1 pre-existing failure on main, unrelated)
- [x] Empirically verified per `~/.claude/rules/integration-test-revert-verify.md`: pre-fix 3/3 new tests FAIL, post-fix 8/8 PASS
- [x] Typecheck passes
- [x] Lint clean (2 pre-existing warnings, no new)
- [x] Submodule sync: `exoas-exocmd` commit `6dfd3a1` pushed; `vault-2025` + `vault-exodev` pointer bumps pushed (`6b1699a0` + `d5c635a`); `packages/exoas-exocmd` pointer bumped in this PR
- [ ] Code-reviewer agent (subagent) — pending
- [ ] Advisor round-2 review — pending
- [ ] UI smoke after Auto Release — orchestrator (parent) responsibility per `~/.claude/rules/ui-smoke-transitive-proof.md`

## Breaking change

Groundings of type `create_instance` no longer implicitly copy non-blacklisted properties from `$target`. Any user-extended Grounding wanting to inherit specific properties must now attach explicit `exocmd__InheritanceRule` refs (canonical patterns: `3f08f5a8` area, `43731bae` parent, `cbe000c4` isDefinedBy).

## RFC

`vault-exodev/inbox/32445c1c-492f-427d-a475-85653d111ed9.md`

🤖 Generated with [Claude Code](https://claude.ai/code) (child1 session, orchestrated by parent)