### PR TITLE
refactor(plugin): disconnect renderer from legacy fast-path + cache wires (RFC c7da0bca Phase 3c-1)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -472,13 +472,21 @@ export default class ExocortexPlugin extends Plugin {
           exoLayoutRepository: this.exoLayoutRepository,
           layoutSelector: this.layoutSelector,
           panelResolver: this.panelResolver,
-          fastResolver: exocmdFastResolver,
-          isFullPathReady: () => this.sparql.isReady(),
-          bindingsCache,
-          // RFC c7da0bca Phase 3b-main — renderer now drives the lazy
-          // loader on every render. Render calls ensure-load for the
-          // active file before button resolution, so preconditions
-          // see fresh class + prototype chains in the store.
+          // RFC c7da0bca Phase 3c-1 — stop wiring the legacy
+          // cold-start optimisation paths (fast-resolver + bindings-
+          // cache + isFullPathReady) into the renderer. The lazy
+          // loader populates the triple store before every render,
+          // so the builder's `useFastPath` / `cachedBindings`
+          // branches in `DynamicCommandButtonGroupBuilder`
+          // naturally degrade to the full path
+          // (`resolveForAssetMulti` against the lazy-fed store)
+          // when these are undefined. The legacy objects are still
+          // constructed above for now — Phase 3c-2 will delete
+          // the construction once parity is confirmed in production.
+          //
+          // RFC c7da0bca Phase 3b-main — renderer drives the lazy
+          // loader on every render. `ensureLoadedByIRI` primes the
+          // store for the active file before button resolution.
           lazyAssetGraphLoader: this.lazyAssetGraphLoader,
         },
       );


### PR DESCRIPTION
## Summary

Phase 3c-1 of the deletion sweep. **Smallest possible revertable delta** — 3 lines removed from the `rfc009Services` bag passed to `UniversalLayoutRenderer`:

```diff
-          fastResolver: exocmdFastResolver,
-          isFullPathReady: () => this.sparql.isReady(),
-          bindingsCache,
```

These wired the legacy cold-start optimisation paths into the renderer. After Phase 3b-main (#3257) made the lazy loader render-authoritative — populating the triple store before every render — those branches became redundant: the production `resolveForAssetMulti` against the lazy-fed store IS the right answer.

The builder's `useFastPath` and `cachedBindings === null` gates already correctly fall through to the full path when their inputs are undefined. This PR just stops feeding them.

## Why this split

Phase 3c was originally "pure deletion sweep" but inventory revealed deep integration of fastResolver + bindingsCache across 4 renderer/builder files. Splitting into staged sub-PRs:

- **3c-1 (this PR)**: disconnect — plugin stops passing the legacy wires. Behaviour-neutral. ~15 lines diff. Trivial revert.
- **3c-2 (next)**: delete construction — plugin stops *constructing* fastResolver / bindingsCache / indexer. Removes the 3 metadataCache.changed handlers that invalidate them.
- **3c-3 (next)**: delete files — remove the 4 source files + their tests + drop dead optional ctor params from renderer/builder.

Each sub-PR is small + revertable; the deletion can pause at any step if production parity proves insufficient.

## What does NOT change in this PR

- All 4 legacy files still exist on disk
- Plugin still constructs `ExocmdFastResolver`, `ExocmdBindingsCache`, `ExocmdBindingsIndexer` (wasted work, but no behavioural change)
- Renderer + Builder constructor signatures still accept the optional fields
- Settings toggle `exocmdBindingsCacheEnabledOnMobile` still exists

## Test plan

- [x] `npm run check:types` clean
- [x] Impacted suites (`ExocortexPlugin.test.ts` + 2 builder suites): 170/170 pass
- [x] Full unit suite: 1782 pass / 25 skip / 10 fail (10 pre-existing CLI flaky verified against `main`)
- [ ] CI green (awaiting)
- [ ] code-reviewer agent
- [ ] advisor round-2
- [ ] Manual squash-merge

## Auto-merge

⛔ **Do NOT enable auto-merge.** Touches `ExocortexPlugin.ts` cold-start path. Per CLAUDE.md.

Refs RFC c7da0bca Phase 3c-1, Phase 3b-main PR #3257 (`cc2a58b2`).