### PR TITLE
fix(plugin): unguard lazy TBox bootstrap on mobile (RFC c7da0bca Phase 4)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2,7 +2,6 @@ import "reflect-metadata";
 import {
   MarkdownPostProcessorContext,
   MarkdownView,
-  Platform,
   Plugin,
   TFile,
 } from "obsidian";
@@ -908,26 +907,27 @@ export default class ExocortexPlugin extends Plugin {
       this.app.workspace.onLayoutReady(() => {
         const loader = this.lazyAssetGraphLoader;
         if (!loader) return;
-        // RFC c7da0bca Phase 3a — desktop-only bootstrap. The whole
-        // RFC is built to reduce mobile cold-start latency (Issue
-        // #3250: 10-30 s MISC→empty→buttons cycle on iPhone).
-        // Walking ~hundreds of TBox files inside the same
-        // `onLayoutReady` tick on mobile would regress the exact
-        // metric we are trying to improve, so skip mobile by default.
-        // Phase 3b switches renders to the loader and decides per-
-        // render whether to walk — that is the correct place to re-
-        // enable mobile usage.
-        if (Platform.isMobile) return;
-        // TODO(Phase 3b) — wire a `loader.forget(iri)` /
-        // `loader.clearAll()` invalidation hook into
-        // `VaultRDFIndexer.refresh()` + `metadataCache.on("changed")`
-        // before the loader becomes authoritative on the render
-        // hot-path. Today the loader's `loadedIRIs` Set is monotonic
-        // and Phase 3a is safe (renders still go through the
-        // existing chain, refresh-clear-then-repopulate is invisible
-        // to button visibility). Once 3b lands, a refresh-then-edit
-        // cycle would leave the loader convinced it covered an
-        // asset that was just cleared from the store.
+        // RFC c7da0bca Phase 4 — bootstrap runs on both desktop AND
+        // mobile. The original Phase 3a mobile-skip guard was
+        // motivated by the concern that walking the TBox folders
+        // alongside the legacy fast-resolver + convertVault chain
+        // would *double* the cold-start work on iPhone — the exact
+        // metric we were trying to improve (Issue #3250: 10-30 s
+        // MISC→empty→buttons cycle).
+        //
+        // After Phase 3c-2/3c-3 deleted the parallel fast-resolver
+        // + bindings-cache + ExocmdBindingsIndexer chain, the
+        // bootstrap is the *only* startup walk. On mobile the
+        // lazy loader is the sole code path that places
+        // `exocmd__CommandBinding` triples into the store before
+        // first render — without bootstrap those bindings are not
+        // reachable from the current asset via class/prototype
+        // walks, so the renderer surfaces zero MISC buttons until
+        // the unrelated SPARQL ASK warm-up eventually triggers
+        // convertVault() (~20-30 s on iPhone). Loading the TBox
+        // folders at onLayoutReady restores parity with desktop
+        // and eliminates the "buttons appear with the second
+        // Notice" UX regression observed on v16.26.5.
         performance.mark("lazy-tbox-bootstrap-start");
         void (async () => {
           try {
@@ -976,10 +976,13 @@ export default class ExocortexPlugin extends Plugin {
                 `(errors=${errorCount}, total loaded set size=${loader.loadedCount})`,
             );
           } catch (err) {
-            // Bootstrap failure must not propagate — the existing fast/full-
-            // path chain remains the production code path during 3a.
+            // Bootstrap failure must not propagate — convertVault() still
+            // runs as part of the SPARQL ASK warm-up downstream and will
+            // eventually populate the store, so buttons still appear
+            // (with the legacy 20-30 s mobile latency). Keep the warn
+            // logged so users can attach it to bug reports.
             this.logger.warn(
-              `[lazy-tbox-bootstrap] failed (non-fatal in Phase 3a): ${String(err)}`,
+              `[lazy-tbox-bootstrap] failed (non-fatal — buttons will still appear via convertVault warm-up): ${String(err)}`,
             );
           }
         })();

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -928,6 +928,15 @@ export default class ExocortexPlugin extends Plugin {
         // folders at onLayoutReady restores parity with desktop
         // and eliminates the "buttons appear with the second
         // Notice" UX regression observed on v16.26.5.
+        //
+        // Phase 3b loader-invalidation hooks (`forget` on
+        // metadataCache `changed` + vault `rename` + vault
+        // `delete`) live at the eager-init block above (~line 237)
+        // so the loader stays coherent across edits. If
+        // `metadataCache` is not yet fully resolved at
+        // `onLayoutReady`, `ensureFileLoaded` may insert empty
+        // frontmatter triples; the `metadataCache.on("resolved")`
+        // re-index handler downstream covers that race.
         performance.mark("lazy-tbox-bootstrap-start");
         void (async () => {
           try {

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -984,6 +984,31 @@ export default class ExocortexPlugin extends Plugin {
               `[lazy-tbox-bootstrap] loaded ${loadedCount} ontology assets ` +
                 `(errors=${errorCount}, total loaded set size=${loader.loadedCount})`,
             );
+            // RFC c7da0bca Phase 4 — drop the precondition/command
+            // resolver caches and re-trigger autoRenderLayout once the
+            // bootstrap is done. Without this, the first render
+            // (`file-open + 150 ms` or `onLayoutReady`) wins the race
+            // against the IIFE — the active asset renders with an
+            // empty bindings store, both caches lock in a "0
+            // buttons" decision, and there is no later trigger until
+            // `metadataCache.on("resolved")` chain finally finishes
+            // `sparql.refresh()` (~20-30 s on iPhone). Mirrors the
+            // post-`sparql.refresh()` invalidate-and-re-render
+            // triplet at line ~759 so the bootstrap-completion path
+            // and the refresh-completion path produce the same
+            // observable behaviour. Both invalidate/render calls are
+            // cheap idempotent re-runs when there is nothing to
+            // re-render (no active markdown view, etc.). The
+            // active-file guard mirrors the renderInitial gate
+            // above (line ~862) — if no file is open at
+            // bootstrap-done, there is nothing to re-render and the
+            // workspace file-open event will trigger autoRenderLayout
+            // when a file is later opened.
+            this.commandResolver.invalidateCache();
+            this.preconditionEvaluator.invalidateCache();
+            if (this.app.workspace.getActiveFile()) {
+              this.autoRenderLayout();
+            }
           } catch (err) {
             // Bootstrap failure must not propagate — convertVault() still
             // runs as part of the SPARQL ASK warm-up downstream and will

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -2325,13 +2325,27 @@ describe("ExocortexPlugin", () => {
     });
 
     // RFC c7da0bca Phase 4 — the lazy-tbox-bootstrap previously skipped
-    // mobile via `if (Platform.isMobile) return;`. After Phase 3c
-    // deleted the parallel fast-resolver chain, the bootstrap is the
-    // sole code path that places `exocmd__CommandBinding` triples in
-    // the store before first render. Skipping it on mobile produced a
-    // 20-30 s "buttons appear with the second Notice" UX regression
-    // (observed on v16.26.5, iPhone). The guard was removed; this
-    // test pins that the bootstrap fires on mobile.
+    // mobile via `if (Platform.isMobile) return;` placed BEFORE the
+    // `performance.mark("lazy-tbox-bootstrap-start")` call. This test
+    // mutates the Obsidian `Platform` mock to mobile and pins that
+    // the start-mark fires — pre-guard-removal it would not. After
+    // Phase 3c deleted the parallel fast-resolver chain, the
+    // bootstrap is the sole code path that places
+    // `exocmd__CommandBinding` triples into the store before first
+    // render, so skipping it on mobile produced the 20-30 s
+    // "buttons appear with the second Notice" UX regression
+    // (observed on v16.26.5, iPhone).
+    //
+    // Note: this test pins only the start-mark fire, not the
+    // file-iteration loop reach. Pinning the loop would require
+    // either undoing the file-level `jest.mock` of
+    // `ObsidianVaultAdapter` (auto-mocked at module scope, line ~19)
+    // or `jest.requireActual`-substituting the real adapter built
+    // on top of `mockVault` — both are non-trivial under the
+    // current test scaffolding. The end-to-end loader walk on
+    // mobile is independently exercised by
+    // `LazyAssetGraphLoader.test.ts` and the iPhone smoke step in
+    // the PR's verification plan.
     it("emits 'lazy-tbox-bootstrap-start' on mobile (Phase 4 unguard regression)", async () => {
       const obsidianMock = await import("obsidian");
       const platform = (obsidianMock as unknown as { Platform: { isMobile: boolean; isDesktop: boolean } }).Platform;

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -2323,5 +2323,31 @@ describe("ExocortexPlugin", () => {
         "exocmd-fullpath-ready",
       );
     });
+
+    // RFC c7da0bca Phase 4 — the lazy-tbox-bootstrap previously skipped
+    // mobile via `if (Platform.isMobile) return;`. After Phase 3c
+    // deleted the parallel fast-resolver chain, the bootstrap is the
+    // sole code path that places `exocmd__CommandBinding` triples in
+    // the store before first render. Skipping it on mobile produced a
+    // 20-30 s "buttons appear with the second Notice" UX regression
+    // (observed on v16.26.5, iPhone). The guard was removed; this
+    // test pins that the bootstrap fires on mobile.
+    it("emits 'lazy-tbox-bootstrap-start' on mobile (Phase 4 unguard regression)", async () => {
+      const obsidianMock = await import("obsidian");
+      const platform = (obsidianMock as unknown as { Platform: { isMobile: boolean; isDesktop: boolean } }).Platform;
+      const originalIsMobile = platform.isMobile;
+      const originalIsDesktop = platform.isDesktop;
+      platform.isMobile = true;
+      platform.isDesktop = false;
+      try {
+        await plugin.onload();
+        await flushPromises();
+
+        expect(markSpy).toHaveBeenCalledWith("lazy-tbox-bootstrap-start");
+      } finally {
+        platform.isMobile = originalIsMobile;
+        platform.isDesktop = originalIsDesktop;
+      }
+    });
   });
 });


### PR DESCRIPTION
## Context

Empirical regression report from user on v16.26.5 iPhone:

> «Кнопки появляются так же — через 20-30 секунд. Но MISC теперь не появляется сразу же, а вместе со всеми, через 2 Notice с skipping invariant violation»

Before RFC c7da0bca:
- Cold-start on iPhone: MISC buttons via FastResolver mini-store in <100 ms → all buttons at ~20-30 s after convertVault.
- Visual signal that something is happening within ~1 s.

After RFC c7da0bca Phase 3c-3 (v16.26.5):
- Cold-start on iPhone: zero buttons for ~20-30 s → all buttons appear together with two "skipping invariant violation" Notices.
- Lost the "fast feedback" UX property.

## Root cause

The Phase 3a `lazy-tbox-bootstrap` walks `assetspaces/{exo,ems,ims,exocmd}/*.md` and places their triples into the store via the lazy loader. It was gated `if (Platform.isMobile) return` because — at the time of Phase 3a — it ran *in parallel* with the existing fast-resolver + convertVault chain, and doubling that work on iPhone would regress the very metric we were fixing (Issue #3250: 10-30 s MISC→empty→buttons cycle).

After Phase 3c-2/3c-3 deleted the fast-resolver + bindings-cache + ExocmdBindingsIndexer chain, **the bootstrap is the only path that places `exocmd__CommandBinding` triples into the store before the SPARQL ASK warm-up triggers convertVault**. Skipping the walk leaves the renderer with zero matching command bindings until convertVault completes.

But **unguard alone is not enough** — caught by advisor self-review:

> The first render (`file-open + 150ms` or `onLayoutReady`) wins the race against the IIFE — the active asset renders with an empty bindings store, both caches (`commandResolver` + `preconditionEvaluator`) lock in a "0 buttons" decision, and there is no later trigger until `metadataCache.on("resolved")` chain finally finishes `sparql.refresh()` (~20-30 s on iPhone).

## Fix

Two commits in this PR:

1. **Remove `Platform.isMobile` guard** from the lazy-tbox-bootstrap. Doubling-work justification no longer applies (parallel chain deleted in Phase 3c-3).

2. **Mirror the post-`sparql.refresh()` invalidate-and-re-render triplet** at the bootstrap-done point. Drops `commandResolver` and `preconditionEvaluator` caches, then re-triggers `autoRenderLayout()` (gated on `getActiveFile()` to match the renderInitial gate). The bootstrap finishes in ~few hundred ms on iPhone (in-memory frontmatter reads from metadataCache, sequential `ensureFileLoaded` across ~hundreds of ontology files) — at that point the user sees buttons render with bindings present, instead of waiting 20-30 s for convertVault.

## Diff

- `packages/obsidian-plugin/src/ExocortexPlugin.ts`:
  - Remove `if (Platform.isMobile) return` from lazy-tbox-bootstrap.
  - Remove unused `Platform` import.
  - Update inline comment block to document Phase 4 reasoning.
  - Soften non-fatal failure log (Phase 3a wording no longer accurate after Phase 3c).
  - Add `commandResolver.invalidateCache() + preconditionEvaluator.invalidateCache() + autoRenderLayout()` after `lazy-tbox-bootstrap-done` mark, gated on active file. Mirrors post-refresh path at line ~759-773.
- `packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts`:
  - Add regression test that mutates the Obsidian `Platform` mock to mobile and pins that `lazy-tbox-bootstrap-start` performance mark fires (proves the guard was removed since the mark sits below the original guard).

## Test plan

- [x] `npx jest ExocortexPlugin.test.ts` — 86/86 pass (1 new test)
- [x] Full `obsidian-plugin` unit sweep — 4898/4898 pass
- [x] `npm run build` — production build clean
- [x] `npm run check:types` — typecheck clean
- [x] `npm run lint` — 2 pre-existing warnings only
- [x] code-reviewer round-1 — APPROVE (1 MEDIUM strengthened test scope deferred + 2 LOW notes addressed in commit `2792c692`)
- [x] advisor round-2 — caught critical missing re-render hook, fixed in commit `240a3e49`
- [ ] iPhone smoke after BRAT update — buttons appear in <2-3 s on cold-start, no 20-30 s delay

## RFC

`c7da0bca-a728-4d1f-97c8-a3193a61a519` (vault-exodev) — final follow-up Phase 4 to address the mobile UX regression introduced by Phase 3c-3 cache deletion.