### PR TITLE
fix(grounding): pick multi-grounding by Grounding_targetPrototype, not refTriples[0]

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -286,7 +286,13 @@ export class CommandResolver {
 
     const resolved: ResolvedCommand[] = [];
     for (const binding of bindings) {
-      const command = await this.loadCommand(binding.commandRef);
+      // Pass binding.targetClass so loadLinkedGrounding can pick the
+      // prototype-matching grounding when a command exposes N groundings
+      // (one per targetPrototype). Without context the loader falls back
+      // to first-by-iteration-order — see fix(grounding) below.
+      const command = await this.loadCommand(binding.commandRef, {
+        targetClass: binding.targetClass,
+      });
       if (!command) continue;
 
       // Apply binding-level precondition override
@@ -313,8 +319,19 @@ export class CommandResolver {
   /**
    * Load a single command definition by UID, including linked Precondition and Grounding.
    * Returns null if the command is not found.
+   *
+   * @param commandUID — UID of the command asset.
+   * @param context — optional dispatch context. When `targetClass` is set and the
+   *   command exposes multiple `Command_grounding` refs (e.g. universal Create
+   *   Instance pattern), the matching grounding is picked by
+   *   `Grounding_targetPrototype === context.targetClass`. Single-grounding
+   *   commands and palette/no-context callers preserve legacy first-wins
+   *   behaviour.
    */
-  async loadCommand(commandUID: string): Promise<CommandDefinition | null> {
+  async loadCommand(
+    commandUID: string,
+    context?: { targetClass?: string },
+  ): Promise<CommandDefinition | null> {
     // Find the command subject by UID
     const subject = await this.findSubjectByUID(commandUID);
     if (!subject) return null;
@@ -339,7 +356,7 @@ export class CommandResolver {
     const precondition = await this.loadLinkedPrecondition(subject);
 
     // Transitively load linked Grounding
-    const grounding = await this.loadLinkedGrounding(subject, 0);
+    const grounding = await this.loadLinkedGrounding(subject, 0, context);
     if (!grounding) return null; // Grounding is required
 
     return {
@@ -994,6 +1011,7 @@ export class CommandResolver {
   private async loadLinkedGrounding(
     parentSubject: IRI,
     depth: number,
+    context?: { targetClass?: string },
   ): Promise<GroundingDefinition | null> {
     if (depth >= MAX_TRANSITIVE_DEPTH) return null;
 
@@ -1004,18 +1022,64 @@ export class CommandResolver {
     );
     if (refTriples.length === 0) return null;
 
-    const ref = refTriples[0].object;
-    let groundingSubject: IRI | null = null;
-
-    if (ref instanceof IRI) {
-      groundingSubject = ref;
-    } else if (ref instanceof Literal) {
-      const uid = this.normalizeWikilink(ref.value);
-      groundingSubject = await this.findSubjectByUID(uid);
+    // Fast path: single grounding OR no targetClass context — preserve
+    // legacy first-by-iteration-order behaviour. Palette commands and
+    // single-grounding bindings land here.
+    if (refTriples.length === 1 || !context?.targetClass) {
+      const groundingSubject = await this.resolveGroundingRef(refTriples[0].object);
+      if (!groundingSubject) return null;
+      return this.loadGroundingDefinition(groundingSubject, depth);
     }
 
-    if (!groundingSubject) return null;
-    return this.loadGroundingDefinition(groundingSubject, depth);
+    // Multi-grounding dispatch: pick the grounding whose
+    // `Grounding_targetPrototype` matches the binding's `targetClass`.
+    // Enables the "1 Command + N Grounding (per prototype) + N Binding
+    // (per targetClass)" universal pattern (e.g. bb00efed Create Task
+    // Instance with TaskPrototype/ProjectPrototype/MeetingPrototype/…
+    // variant groundings). Before this fix, `refTriples[0]` was picked
+    // unconditionally — MeetingPrototype binding could end up creating
+    // an `ems__Task` if the TaskPrototype grounding happened to be first
+    // in iteration order.
+    for (const triple of refTriples) {
+      const groundingSubject = await this.resolveGroundingRef(triple.object);
+      if (!groundingSubject) continue;
+      const targetPrototype = await this.getObsidianName(
+        groundingSubject,
+        Namespace.EXOCMD.term("Grounding_targetPrototype"),
+      );
+      if (
+        targetPrototype &&
+        this.matchesReference(targetPrototype, context.targetClass)
+      ) {
+        return this.loadGroundingDefinition(groundingSubject, depth);
+      }
+    }
+
+    // Fallback: no grounding declared targetPrototype matching the
+    // binding's targetClass. Preserve legacy behaviour (first wins) so
+    // existing single-purpose commands attached via multi-grounding
+    // pattern by mistake still surface a button rather than disappear
+    // silently. The empirical case that motivated this picker (issue
+    // surfaced 2026-05-25) is now covered by the loop above.
+    const fallback = await this.resolveGroundingRef(refTriples[0].object);
+    if (!fallback) return null;
+    return this.loadGroundingDefinition(fallback, depth);
+  }
+
+  /**
+   * Resolve a `Command_grounding` object reference (IRI or Literal wikilink)
+   * to the grounding asset's IRI subject. Returns null when the reference
+   * cannot be resolved (UID not indexed).
+   */
+  private async resolveGroundingRef(
+    ref: IRI | Literal | unknown,
+  ): Promise<IRI | null> {
+    if (ref instanceof IRI) return ref;
+    if (ref instanceof Literal) {
+      const uid = this.normalizeWikilink(ref.value);
+      return await this.findSubjectByUID(uid);
+    }
+    return null;
   }
 
   private async loadGroundingDefinition(

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -327,6 +327,16 @@ export class CommandResolver {
    *   `Grounding_targetPrototype === context.targetClass`. Single-grounding
    *   commands and palette/no-context callers preserve legacy first-wins
    *   behaviour.
+   *
+   * **Scope limit:** the picker is wired off the binding's `targetClass`. A
+   *   binding that declares only `targetPrototype` or `targetAsset` (per
+   *   `loadBindingDefinition`: «at least one target is required») will pass
+   *   `context.targetClass = undefined`, hit the fast path, and resolve to
+   *   the first grounding by iteration order. This matches the empirically-
+   *   observed bug scope (2026-05-25: MeetingPrototype binding via
+   *   `targetClass`). If a future universal-N-grounding command is bound via
+   *   `targetPrototype`/`targetAsset`, extend `context` to cover those keys
+   *   and update the loop to try each.
    */
   async loadCommand(
     commandUID: string,
@@ -1061,6 +1071,18 @@ export class CommandResolver {
     // pattern by mistake still surface a button rather than disappear
     // silently. The empirical case that motivated this picker (issue
     // surfaced 2026-05-25) is now covered by the loop above.
+    //
+    // Defensive logging: silent fallback masks future misconfiguration
+    // (typo in `Grounding_targetPrototype`, missing variant for a new
+    // prototype, etc.) — same failure shape as the original bug this
+    // fix addresses. Warn so misconfig is visible in plugin logs.
+    this.logger.warn(
+      `Command ${parentSubject.value}: ${refTriples.length} groundings declared, ` +
+        `none matched context.targetClass='${context.targetClass}' via ` +
+        `Grounding_targetPrototype — falling back to first grounding by ` +
+        `iteration order (legacy behaviour). Check that one grounding's ` +
+        `Grounding_targetPrototype references this targetClass.`,
+    );
     const fallback = await this.resolveGroundingRef(refTriples[0].object);
     if (!fallback) return null;
     return this.loadGroundingDefinition(fallback, depth);

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -700,15 +700,54 @@ describe("CommandResolver", () => {
         expect(cmd!.grounding.id).toBe("gnd-meeting");
       });
 
-      it("picks Task grounding when binding targetClass=ems__TaskPrototype", async () => {
-        await setupUniversalCmdWithTwoGroundings();
+      it("picks Task grounding when binding targetClass=ems__TaskPrototype, even when Task grounding declared SECOND in iteration order", async () => {
+        // Inverse of the Meeting test: insert Meeting grounding FIRST, Task
+        // SECOND, then ask the picker for Task. If picker were still first-
+        // wins, this would return gnd-meeting. Discriminates fix-vs-revert
+        // because order is reversed from setupUniversalCmdWithTwoGroundings.
 
-        const cmd = await resolver.loadCommand("cmd-universal", {
+        await addGroundingAsset(store, {
+          uid: "gnd-meeting-2",
+          label: "Create Meeting instance",
+          type: "create_instance",
+        });
+        const gMeeting = new IRI("obsidian://vault/gnd-meeting-2.md");
+        await store.addAll([
+          new Triple(
+            gMeeting,
+            Namespace.EXOCMD.term("Grounding_targetPrototype"),
+            new Literal("uid-meeting-proto|ems__MeetingPrototype"),
+          ),
+        ]);
+        await addGroundingAsset(store, {
+          uid: "gnd-task-2",
+          label: "Create Task instance",
+          type: "create_instance",
+        });
+        const gTask = new IRI("obsidian://vault/gnd-task-2.md");
+        await store.addAll([
+          new Triple(
+            gTask,
+            Namespace.EXOCMD.term("Grounding_targetPrototype"),
+            new Literal("uid-task-proto|ems__TaskPrototype"),
+          ),
+        ]);
+        const cmdSubject = new IRI("obsidian://vault/cmd-universal-2.md");
+        await store.addAll([
+          new Triple(cmdSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+          new Triple(cmdSubject, Namespace.EXO.term("Asset_uid"), new Literal("cmd-universal-2")),
+          new Triple(cmdSubject, Namespace.EXO.term("Asset_label"), new Literal("Create Instance v2")),
+          // Meeting FIRST, Task SECOND — opposite of the other test
+          new Triple(cmdSubject, Namespace.EXOCMD.term("Command_grounding"), gMeeting),
+          new Triple(cmdSubject, Namespace.EXOCMD.term("Command_grounding"), gTask),
+        ]);
+
+        const cmd = await resolver.loadCommand("cmd-universal-2", {
           targetClass: "ems__TaskPrototype",
         });
 
         expect(cmd).not.toBeNull();
-        expect(cmd!.grounding.id).toBe("gnd-task");
+        expect(cmd!.grounding.id).toBe("gnd-task-2");
       });
 
       it("falls back to first grounding when no grounding declares matching targetPrototype (legacy behaviour preserved)", async () => {
@@ -730,6 +769,47 @@ describe("CommandResolver", () => {
 
         expect(cmd).not.toBeNull();
         expect(cmd!.grounding.id).toBe("gnd-task");
+      });
+
+      it("skips groundings without Grounding_targetPrototype triple in the loop, finds the one that has matching prototype", async () => {
+        // Grounding A: no targetPrototype at all
+        await addGroundingAsset(store, {
+          uid: "gnd-no-proto",
+          label: "Grounding without targetPrototype",
+          type: "create_instance",
+        });
+        // Grounding B: has matching targetPrototype
+        await addGroundingAsset(store, {
+          uid: "gnd-with-proto",
+          label: "Grounding with Meeting prototype",
+          type: "create_instance",
+        });
+        const gWithProto = new IRI("obsidian://vault/gnd-with-proto.md");
+        await store.addAll([
+          new Triple(
+            gWithProto,
+            Namespace.EXOCMD.term("Grounding_targetPrototype"),
+            new Literal("uid-meeting-proto|ems__MeetingPrototype"),
+          ),
+        ]);
+
+        const cmdSubject = new IRI("obsidian://vault/cmd-mixed.md");
+        await store.addAll([
+          new Triple(cmdSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+          new Triple(cmdSubject, Namespace.EXO.term("Asset_uid"), new Literal("cmd-mixed")),
+          new Triple(cmdSubject, Namespace.EXO.term("Asset_label"), new Literal("Mixed command")),
+          // No-proto grounding FIRST — picker must skip it (getObsidianName
+          // returns null → continue) and proceed to gnd-with-proto.
+          new Triple(cmdSubject, Namespace.EXOCMD.term("Command_grounding"), new IRI("obsidian://vault/gnd-no-proto.md")),
+          new Triple(cmdSubject, Namespace.EXOCMD.term("Command_grounding"), gWithProto),
+        ]);
+
+        const cmd = await resolver.loadCommand("cmd-mixed", {
+          targetClass: "ems__MeetingPrototype",
+        });
+
+        expect(cmd).not.toBeNull();
+        expect(cmd!.grounding.id).toBe("gnd-with-proto");
       });
 
       it("single-grounding commands ignore context and load that grounding (fast path)", async () => {

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -639,6 +639,120 @@ describe("CommandResolver", () => {
       expect(cmd!.grounding.steps![0].type).toBe("property_set");
       expect(cmd!.grounding.steps![1].targetProperty).toBe("ems__Effort_startTimestamp");
     });
+
+    // Multi-grounding picker (issue surfaced 2026-05-25): a command with N
+    // `Command_grounding` refs (universal Create Instance pattern) must pick
+    // the grounding whose `Grounding_targetPrototype` matches the binding's
+    // `targetClass`. Before the fix, `refTriples[0]` was returned silently,
+    // so e.g. MeetingPrototype binding could land on the TaskPrototype
+    // grounding and create the wrong instance class.
+    describe("multi-grounding picker (Command_grounding × N)", () => {
+      async function setupUniversalCmdWithTwoGroundings() {
+        // Task variant
+        await addGroundingAsset(store, {
+          uid: "gnd-task",
+          label: "Create Task instance",
+          type: "create_instance",
+        });
+        const gTask = new IRI("obsidian://vault/gnd-task.md");
+        await store.addAll([
+          new Triple(
+            gTask,
+            Namespace.EXOCMD.term("Grounding_targetPrototype"),
+            new Literal("uid-task-proto|ems__TaskPrototype"),
+          ),
+        ]);
+        // Meeting variant
+        await addGroundingAsset(store, {
+          uid: "gnd-meeting",
+          label: "Create Meeting instance",
+          type: "create_instance",
+        });
+        const gMeeting = new IRI("obsidian://vault/gnd-meeting.md");
+        await store.addAll([
+          new Triple(
+            gMeeting,
+            Namespace.EXOCMD.term("Grounding_targetPrototype"),
+            new Literal("uid-meeting-proto|ems__MeetingPrototype"),
+          ),
+        ]);
+
+        // Universal command — Task grounding declared FIRST (preserves the
+        // original bb00efed iteration-order trap).
+        const cmdSubject = new IRI("obsidian://vault/cmd-universal.md");
+        await store.addAll([
+          new Triple(cmdSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+          new Triple(cmdSubject, Namespace.EXO.term("Asset_uid"), new Literal("cmd-universal")),
+          new Triple(cmdSubject, Namespace.EXO.term("Asset_label"), new Literal("Create Instance")),
+          new Triple(cmdSubject, Namespace.EXOCMD.term("Command_grounding"), gTask),
+          new Triple(cmdSubject, Namespace.EXOCMD.term("Command_grounding"), gMeeting),
+        ]);
+      }
+
+      it("picks Meeting grounding when binding targetClass=ems__MeetingPrototype, even though Task grounding declared first", async () => {
+        await setupUniversalCmdWithTwoGroundings();
+
+        const cmd = await resolver.loadCommand("cmd-universal", {
+          targetClass: "ems__MeetingPrototype",
+        });
+
+        expect(cmd).not.toBeNull();
+        expect(cmd!.grounding.id).toBe("gnd-meeting");
+      });
+
+      it("picks Task grounding when binding targetClass=ems__TaskPrototype", async () => {
+        await setupUniversalCmdWithTwoGroundings();
+
+        const cmd = await resolver.loadCommand("cmd-universal", {
+          targetClass: "ems__TaskPrototype",
+        });
+
+        expect(cmd).not.toBeNull();
+        expect(cmd!.grounding.id).toBe("gnd-task");
+      });
+
+      it("falls back to first grounding when no grounding declares matching targetPrototype (legacy behaviour preserved)", async () => {
+        await setupUniversalCmdWithTwoGroundings();
+
+        const cmd = await resolver.loadCommand("cmd-universal", {
+          targetClass: "ems__UnknownPrototype",
+        });
+
+        expect(cmd).not.toBeNull();
+        // First in iteration order = gnd-task per setup ordering
+        expect(cmd!.grounding.id).toBe("gnd-task");
+      });
+
+      it("falls back to first grounding when called WITHOUT context (palette / direct loadCommand callers preserve legacy behaviour)", async () => {
+        await setupUniversalCmdWithTwoGroundings();
+
+        const cmd = await resolver.loadCommand("cmd-universal");
+
+        expect(cmd).not.toBeNull();
+        expect(cmd!.grounding.id).toBe("gnd-task");
+      });
+
+      it("single-grounding commands ignore context and load that grounding (fast path)", async () => {
+        await addGroundingAsset(store, {
+          uid: "gnd-solo",
+          label: "Solo grounding",
+          type: "property_set",
+          targetProperty: "ems__Effort_status",
+        });
+        await addCommandAsset(store, {
+          uid: "cmd-solo",
+          label: "Solo command",
+          groundingRef: "gnd-solo",
+        });
+
+        const cmd = await resolver.loadCommand("cmd-solo", {
+          targetClass: "ems__TaskPrototype",
+        });
+
+        expect(cmd).not.toBeNull();
+        expect(cmd!.grounding.id).toBe("gnd-solo");
+      });
+    });
   });
 
   describe("findBindings", () => {


### PR DESCRIPTION
## Summary

`CommandResolver.loadLinkedGrounding` returned `refTriples[0].object` unconditionally → universal "Create Instance" pattern (1 Command + N Grounding per targetPrototype + N Binding per targetClass) silently picked first-by-iteration-order grounding, regardless of which prototype the binding targeted.

## Empirical repro (2026-05-25)

Command `bb00efed` has 5 groundings (Task/Project/Meeting/FleetingNote/Event variants). Binding `22093ca1` (targetClass=`ems__MeetingPrototype`) → `bb00efed`.

Click on a MeetingPrototype asset (e.g. `1-2-1 n.burkov`, UID `d179e666`):
- **Expected:** `ems__Meeting` in prototype's folder (via `e01b025b` MeetingPrototype-variant grounding)
- **Actual:** `ems__Task` in `03 Knowledge/inbox/` — `a6ef8fda` (TaskPrototype variant) happened to be iteration-first

Created file `52a48948-…` had `exo__Instance_class: [[1b20a8f0|ems__Task]]` instead of `[[1b0a5e34|ems__Meeting]]`.

## Fix

- `loadCommand(uid, context?)` threads optional `{ targetClass }` dispatch context
- Binding callsite passes `{ targetClass: binding.targetClass }`
- Multi-grounding picker: iterate, read each grounding's `Grounding_targetPrototype` via `getObsidianName`, match via `matchesReference` against `context.targetClass`. First match wins.
- Fallback to `refTriples[0]` when no grounding declares matching `targetPrototype` (preserves legacy first-wins for commands accidentally wired through multi-grounding pattern)
- Palette / no-context callers + single-grounding commands take fast path (preserves legacy behaviour)

## Test plan

- [x] 5 new unit tests in `CommandResolver.test.ts` "multi-grounding picker" describe — covers Meeting picker, Task picker, no-match fallback, no-context legacy path, single-grounding fast path
- [x] 117/117 existing CommandResolver-family unit tests pass
- [x] Integration `create-instance-grounding.test.ts` passes
- [x] `npm run lint` clean (warnings pre-existing)
- [x] Typecheck clean for `packages/exocortex/src`
- [ ] CI 14 required checks
- [ ] Code-reviewer agent (per CLAUDE.md auto-merge discipline for CommandResolver)
- [ ] Advisor round-2 after fixes (if any)
- [ ] Manual `gh pr merge --squash --delete-branch` (no `--auto`)

## Vault follow-up (deferred)

After this fix lands, vault RDF can be simplified — the dedicated `2f25fcac` Create Meeting Instance + `9466c784` binding + `b87330e0` grounding workaround (added 2026-05-25 as fix-forward for the same symptom) can be replaced with universal `bb00efed` + N groundings + N bindings. Vault cleanup to be done in a separate vault commit after this PR ships.

## Files changed

```
packages/exocortex/src/services/CommandResolver.ts        +88 / -12
packages/exocortex/tests/unit/services/CommandResolver.test.ts  +114 / -0
```