### PR TITLE
feat(grounding-type): RFC 9d20c91f Phase 3 — ABox migration (75 files)

### DIFF
--- a/docs/examples/rfc-009/58714ab2-c155-47d8-a8bb-38da317817ad.md
+++ b/docs/examples/rfc-009/58714ab2-c155-47d8-a8bb-38da317817ad.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Remove start timestamp"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "property_delete"
+exocmd__Grounding_type: "[[4bdf1d0b-e9da-4d96-bafe-c5aaef8c2bd5]]"
 exocmd__Grounding_targetProperty: "ems__Effort_startTimestamp"
 ---
 

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/creation/4919afb1-fcc3-4a6e-85a0-a869e6a69774.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/creation/4919afb1-fcc3-4a6e-85a0-a869e6a69774.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Create related task via service"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "service_call"
+exocmd__Grounding_type: "[[9bf9fc99-ac37-4e51-b9f5-bd920099947c]]"
 exocmd__Grounding_serviceId: "createRelatedTask"
 exocmd__Grounding_inputSchema: '{"type":"object","properties":{"label":{"type":"string","title":"Task name"}},"required":["label"]}'
 aliases:

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/creation/c84e2e08-8fb9-42e7-9112-11864fb13a09.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/creation/c84e2e08-8fb9-42e7-9112-11864fb13a09.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Create note grounding"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "service_call"
+exocmd__Grounding_type: "[[9bf9fc99-ac37-4e51-b9f5-bd920099947c]]"
 exocmd__Grounding_serviceId: "createAsset"
 exocmd__Grounding_inputSchema: '{"type":"object","properties":{"label":{"type":"string","title":"Note title"}},"required":["label"]}'
 exocmd__Grounding_serviceCallPayload: '{"prototype":"ztlk__FleetingNotePrototype","folder":"03 Knowledge/inbox"}'

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/maintenance-complex/eb3bb751-596b-48f8-b834-7a9e680dabbe.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/maintenance-complex/eb3bb751-596b-48f8-b834-7a9e680dabbe.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Archive asset via service"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "service_call"
+exocmd__Grounding_type: "[[9bf9fc99-ac37-4e51-b9f5-bd920099947c]]"
 exocmd__Grounding_serviceId: "archiveAsset"
 aliases:
   - "Archive asset via service"

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/maintenance/c4616dcd-3832-4812-b289-0968510fb8be.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/maintenance/c4616dcd-3832-4812-b289-0968510fb8be.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Set result value"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "service_call"
+exocmd__Grounding_type: "[[9bf9fc99-ac37-4e51-b9f5-bd920099947c]]"
 exocmd__Grounding_serviceId: "updateProperty"
 exocmd__Grounding_serviceCallPayload: '{"property":"ems__Effort_result"}'
 exocmd__Grounding_inputSchema: '{"type":"object","properties":{"value":{"type":"string","title":"Result"}},"required":["value"]}'

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/planning/22a6ba6b-030a-47e4-946e-1a30dc9450e5.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/planning/22a6ba6b-030a-47e4-946e-1a30dc9450e5.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Plan on today (declarative)"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "property_set"
+exocmd__Grounding_type: "[[cf3bb923-f1f1-40be-b728-782844402426]]"
 exocmd__Grounding_targetProperty: "ems__Effort_plannedStartTimestamp"
 exocmd__Grounding_targetValueSubstitution: "$todayStart"
 aliases:

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/planning/85687461-c2df-4d1b-819b-0c3ae0ab3741.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/planning/85687461-c2df-4d1b-819b-0c3ae0ab3741.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Set planned start timestamp"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "service_call"
+exocmd__Grounding_type: "[[9bf9fc99-ac37-4e51-b9f5-bd920099947c]]"
 exocmd__Grounding_serviceId: "updateProperty"
 exocmd__Grounding_serviceCallPayload: '{"property":"ems__Effort_plannedStartTimestamp"}'
 exocmd__Grounding_inputSchema: '{"type":"object","properties":{"value":{"type":"string","title":"Planned start (date)"}},"required":["value"]}'

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/23727560-5f6b-4c49-9b33-eea34c7eec9e.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/23727560-5f6b-4c49-9b33-eea34c7eec9e.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Transition to Doing (status + startTimestamp)"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "composite"
+exocmd__Grounding_type: "[[8f9a57db-3865-4886-92fb-c5ab7f3c3fa3]]"
 exocmd__Grounding_steps:
   - "[[d5deac7a-149d-43a1-b249-875d91834b60|Set status to Doing]]"
   - "[[95dfbcad-daca-47aa-8788-74e09f6b10a1|Set ems__Effort_startTimestamp to $nowLocal]]"

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/95dfbcad-daca-47aa-8788-74e09f6b10a1.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/95dfbcad-daca-47aa-8788-74e09f6b10a1.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Set ems__Effort_startTimestamp to $nowLocal"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "property_set"
+exocmd__Grounding_type: "[[cf3bb923-f1f1-40be-b728-782844402426]]"
 exocmd__Grounding_targetProperty: "ems__Effort_startTimestamp"
 exocmd__Grounding_targetValueSubstitution: "$nowLocal"
 aliases:

--- a/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/d5deac7a-149d-43a1-b249-875d91834b60.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/exocmd/status/d5deac7a-149d-43a1-b249-875d91834b60.md
@@ -4,7 +4,7 @@ exo__Asset_label: "Set status to Doing"
 exo__Asset_isDefinedBy: "[[!kitelev]]"
 exo__Instance_class:
   - "[[exocmd__Grounding]]"
-exocmd__Grounding_type: "property_set"
+exocmd__Grounding_type: "[[cf3bb923-f1f1-40be-b728-782844402426]]"
 exocmd__Grounding_targetProperty: "ems__Effort_status"
 exocmd__Grounding_targetValueRef: "[[ems__EffortStatusDoing]]"
 aliases:


### PR DESCRIPTION
## Summary

Phase 3 ABox migration in exocortex repo для RFC 9d20c91f Variant C catalog homoiconization. Combines:

- **Submodule pointer bump** (`packages/exoas-exocmd: 4f49881 → eadfbb3`) — pulls 65 ABox migrations from `kitelev/exoas-exocmd`
- **Tree 4: 9 files** in `packages/obsidian-plugin/tests/e2e/test-vault/exocmd/`
- **Tree 5: 1 file** in `docs/examples/rfc-009/58714ab2.md`

All rewrite `exocmd__Grounding_type: "<bare-string>"` → `"[[<uid>]]"` per Phase 1 catalog UIDs.

## Audit correction (Phase 0.1 drift)

Phase 0.1 audit enumerated 5 trees totaling 172 files. **Tree 3** (`packages/starter-kit-fixtures/`) was retired in commit `0d1e0785` (PR #3239). Real Phase 3 scope:
- Tree 1: `exoas-exocmd` submodule (65)
- Tree 2: `kitelev/exocortex-starter-kit` standalone (48) — **separate PR**
- Tree 4: `e2e test-vault/exocmd/` (9)
- Tree 5: `docs/examples/rfc-009` (1)

Total: **123 files** across **3 distinct repos**. Tree 2 in separate PR.

## Context

- **RFC:** `[[9d20c91f-242c-4df0-9c3a-2f580ebde017]]` v2 в vault-exodev/inbox/
- **Phase 2 (PR #3268, merged):** dual-read parsers handle both wikilink-form (primary) and legacy bare-string (BC + `[exocmd-grounding-type-bc]` dedup warn)
- **Phase 4 (1 release post-merge):** property `6fa4f178` reshape Datatype→Object + dual-read removal env-flag
- **Phase 4+1:** CLI audit tool `audit grounding-type-literal-form`
- **CLAUDE.md «Auto-merge discipline»:** parser/TBox path — **no `--auto`**. Manual squash after code-reviewer + advisor round-2.

## Cross-vault sync chain

Per `~/.claude/rules/cross-repo-submodule-sync.md` 4-step pattern:
1. `kitelev/exoas-exocmd@eadfbb3` (pushed)
2. `vault-exodev` pointer bump: `844d90e..2dcc059`
3. `vault-2025` pointer bump: `bfbd6d2b9..c0bfd024b`
4. **THIS PR** — `kitelev/exocortex/packages/exoas-exocmd` pointer bump

vault-2025 pre-existing WIP stashed as `pre-RFC-9d20c91f-Phase-3-sync` per `pre-migration-submodule-stash.md`.

## Migration script

`~/Developer/migrate-grounding-type-to-wikilink.py` — Python, idempotent (regex anchors on bare-string only). UID map hardcoded, mirrors `packages/exocortex/src/domain/constants/GroundingTypeUIDs.ts`.

## Test plan

- [ ] CI green (33+ checks; expect parity-gate, all tests, e2e to pass — Phase 2 dual-read covers wikilink form)
- [ ] vault-fixture parity integration test still passes (Phase 2 PR #3268 added it; consumes new wikilink form correctly through CommandResolver)
- [ ] `StarterKitGroundingAudit.test.ts`: pinned fixture (48 groundings) — will regenerate via `node scripts/audit-starter-kit-groundings.mjs` after starter-kit PR (Tree 2)

## Out of scope

- Tree 2 (`kitelev/exocortex-starter-kit` standalone) — separate PR
- Audit fixture regeneration — after Tree 2 PR
- Property reshape (Phase 4)
- CLI audit tool (Phase 4+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)