### PR TITLE
chore(docs): regenerate audit fixture post-Phase 3 (RFC 9d20c91f)

### DIFF
--- a/docs/rfc-94e520da/starter-kit-grounding-status.json
+++ b/docs/rfc-94e520da/starter-kit-grounding-status.json
@@ -3,7 +3,7 @@
     "rfc": "94e520da",
     "phase": 1,
     "task": "T1.5",
-    "auditedAt": "2026-05-23T08:32:27.143Z",
+    "auditedAt": "2026-05-26T04:02:24.027Z",
     "starterKitPath": "/Users/kitelev/Developer/exocortex-development/exocortex-starter-kit",
     "totalGroundings": 48,
     "byType": {


### PR DESCRIPTION
## Summary

Regenerated pinned `docs/rfc-94e520da/starter-kit-grounding-status.json` audit fixture after RFC 9d20c91f Phase 3 ABox migration merged (PRs #3269 + starter-kit #102).

**Diff is only the `auditedAt` timestamp.** Type strings + cliStatus + byType counts are invariant under the migration — Phase 2 dual-read in the audit script correctly resolves wikilink form `"[[<uid>]]"` to canonical enum string before classification.

## Test plan

- [x] `StarterKitGroundingAudit.test.ts` pins 48 groundings — passes against new fixture
- [x] Type counts: 4 property_delete + 19 service_call + 2 create_instance + 17 property_set + 1 property_append + 2 property_shift + 1 property_increment + 2 composite = 48 ✓
- [x] cliStatus: 47 real + 1 unregistered ✓ (unchanged)

## Out of scope

- Phase 4 reshape (deferred)
- CLI audit tool (Phase 4+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)