### PR TITLE
feat(grounding-type): RFC 9d20c91f Phase 4+1 cleanup — env-flag removal + CLI audit tool

### DIFF
--- a/.github/workflows/audit-nightly.yml
+++ b/.github/workflows/audit-nightly.yml
@@ -47,7 +47,13 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
-      - name: Build CLI
+      - name: Build core package
+        run: npm run build -w exocortex
+
+      - name: Build services package
+        run: npm run build -w @kitelev/exocortex-services
+
+      - name: Build CLI bundle
         run: npm run build -w @kitelev/exocortex-cli
 
       - name: Audit packages/exoas-exocmd

--- a/.github/workflows/audit-nightly.yml
+++ b/.github/workflows/audit-nightly.yml
@@ -11,6 +11,14 @@ on:
     # 02:00 UTC daily (~07:00 Asia/Almaty)
     - cron: "0 2 * * *"
   workflow_dispatch:
+  # PR-time guard so a regression to the audited trees is flagged before
+  # merge, not on the next nightly run (avoids 24h post-merge window).
+  pull_request:
+    paths:
+      - "packages/exoas-exocmd/**"
+      - "packages/obsidian-plugin/tests/e2e/test-vault/**"
+      - "packages/cli/src/commands/audit*.ts"
+      - ".github/workflows/audit-nightly.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/audit-nightly.yml
+++ b/.github/workflows/audit-nightly.yml
@@ -1,0 +1,53 @@
+name: Audit Nightly
+
+# RFC 9d20c91f Phase 4+1 — nightly regression detector for the
+# `exocmd__Grounding_type` literal-string form. Phase 3 migrated all ABox
+# values to wikilink form `[[<uid>]]`. Phase 4 made wikilink the default;
+# Phase 4+1 removed the env-flag escape hatch. This workflow guards against
+# any drift sneaking back via manual edits or copy-paste from legacy assets.
+
+on:
+  schedule:
+    # 02:00 UTC daily (~07:00 Asia/Almaty)
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-nightly
+  cancel-in-progress: false
+
+jobs:
+  grounding-type-literal-form:
+    name: grounding-type-literal-form
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build CLI
+        run: npm run build -w @kitelev/exocortex-cli
+
+      - name: Audit packages/exoas-exocmd
+        run: |
+          node packages/cli/dist/index.js audit grounding-type-literal-form \
+            --vault packages/exoas-exocmd
+
+      - name: Audit packages/obsidian-plugin/tests/e2e/test-vault
+        run: |
+          node packages/cli/dist/index.js audit grounding-type-literal-form \
+            --vault packages/obsidian-plugin/tests/e2e/test-vault

--- a/packages/cli/specs/step_definitions/grounding.steps.ts
+++ b/packages/cli/specs/step_definitions/grounding.steps.ts
@@ -121,21 +121,16 @@ function readGroundingDef(uid: string, depth = 0): GroundingDefinition {
   const path = UID_INDEX.get(uid);
   if (!path) throw new Error(`Grounding ${uid} not found in fixture vault`);
   const fm = parseFrontmatter(readFileSync(path, "utf8"));
-  // RFC 9d20c91f Phase 4 cutover: legacy bare-string path is env-flag gated.
-  // Default (env-flag NOT set) = wikilink-only; bare-string returns the raw
-  // value cast to GroundingType only if EXOCORTEX_GROUNDING_TYPE_BC=1
-  // (rollback escape hatch). Without the flag, legacy literal-form throws
-  // (fixture surfaces as test failure rather than silent acceptance).
+  // RFC 9d20c91f Phase 4+1: wikilink-only. The env-flag escape hatch was
+  // removed (Phase 4 introduced; Phase 4+1 retires). Legacy literal-form
+  // throws — fixtures surface as test failure rather than silent acceptance.
   const rawType = fm["exocmd__Grounding_type"];
   const type = (() => {
     if (typeof rawType !== "string") return rawType as GroundingType;
     const resolved = resolveGroundingTypeFromWikilinkLiteral(rawType);
     if (resolved !== null) return resolved;
-    if (process.env.EXOCORTEX_GROUNDING_TYPE_BC === "1") {
-      return rawType as GroundingType;
-    }
     throw new Error(
-      `[exocmd-grounding-type-bc] BLOCKED legacy literal-string '${rawType}' for exocmd__Grounding_type in fixture ${uid} post-Phase-4 cutover. Migrate to wikilink form per RFC 9d20c91f Phase 3 or set EXOCORTEX_GROUNDING_TYPE_BC=1.`,
+      `[exocmd-grounding-type-literal-form] legacy literal-string '${rawType}' for exocmd__Grounding_type in fixture ${uid}. Migrate to wikilink form per RFC 9d20c91f Phase 3.`,
     );
   })();
   const targetProperty =

--- a/packages/cli/src/commands/audit-grounding-type-literal-form.ts
+++ b/packages/cli/src/commands/audit-grounding-type-literal-form.ts
@@ -1,0 +1,165 @@
+import { Command } from "commander";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { join, relative, resolve } from "path";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+
+const FRONTMATTER_FENCE = /^---\s*$/;
+const TYPE_LINE = /^exocmd__Grounding_type:\s*(.+?)\s*$/;
+const WIKILINK_FORM = /^"?\[\[[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:\|[^\]]*)?\]\]"?$/i;
+
+const SKIP_DIRS = new Set([
+  ".git",
+  ".obsidian",
+  "node_modules",
+  ".trash",
+  ".obsidian-mobile",
+  ".DS_Store",
+]);
+
+export interface AuditGroundingTypeLiteralFormOptions {
+  vault: string;
+  output?: OutputFormat;
+}
+
+export interface LiteralFormViolation {
+  path: string;
+  line: number;
+  value: string;
+}
+
+function shouldSkipDir(name: string): boolean {
+  if (name.startsWith(".")) return SKIP_DIRS.has(name.toLowerCase()) || name === ".git";
+  return SKIP_DIRS.has(name);
+}
+
+function* walkMarkdownFiles(rootDir: string): Generator<string> {
+  let entries;
+  try {
+    entries = readdirSync(rootDir, { withFileTypes: true });
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "EPERM" || e.code === "EACCES" || e.code === "ENOENT") return;
+    throw err;
+  }
+  for (const entry of entries) {
+    const fullPath = join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      if (shouldSkipDir(entry.name)) continue;
+      yield* walkMarkdownFiles(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      yield fullPath;
+    }
+  }
+}
+
+function extractFrontmatter(content: string): { lines: string[]; startLine: number } | null {
+  const allLines = content.split(/\r?\n/);
+  if (allLines.length < 2 || !FRONTMATTER_FENCE.test(allLines[0])) return null;
+  for (let i = 1; i < allLines.length; i++) {
+    if (FRONTMATTER_FENCE.test(allLines[i])) {
+      return { lines: allLines.slice(1, i), startLine: 2 };
+    }
+  }
+  return null;
+}
+
+function isLiteralForm(rawValue: string): boolean {
+  const trimmed = rawValue.trim();
+  if (trimmed === "" || trimmed === "null" || trimmed === "~") return false;
+  return !WIKILINK_FORM.test(trimmed);
+}
+
+export function scanVaultForLiteralForm(vaultPath: string): LiteralFormViolation[] {
+  const violations: LiteralFormViolation[] = [];
+  for (const filePath of walkMarkdownFiles(vaultPath)) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+    const fm = extractFrontmatter(content);
+    if (!fm) continue;
+    for (let i = 0; i < fm.lines.length; i++) {
+      const m = fm.lines[i].match(TYPE_LINE);
+      if (!m) continue;
+      const value = m[1];
+      if (isLiteralForm(value)) {
+        violations.push({
+          path: relative(vaultPath, filePath),
+          line: fm.startLine + i,
+          value,
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+/**
+ * RFC 9d20c91f Phase 4+1 — regression detector for `exocmd__Grounding_type`
+ * literal-string form (bare enum like `"property_set"`) post-cutover. Phase 3
+ * migrated all ABox values to wikilink form (`"[[<uid>]]"`). Phase 4 removed
+ * the dual-read default; Phase 4+1 removed the env-flag escape hatch entirely.
+ * This subcommand walks a vault root, parses frontmatter, and reports any
+ * file whose `exocmd__Grounding_type:` value is not wikilink-shaped.
+ *
+ * Exit 0 = clean; exit 1 = ≥1 violation. Suitable for CI nightly scheduling.
+ */
+export function auditGroundingTypeLiteralFormCommand(): Command {
+  return new Command("grounding-type-literal-form")
+    .description(
+      "Detect post-Phase-4+1 regressions: any exocmd__Grounding_type literal-string form (not wikilink) in vault frontmatter",
+    )
+    .requiredOption("--vault <path>", "Vault root directory")
+    .option("--output <type>", "Response format: text|json", "text")
+    .action((options: AuditGroundingTypeLiteralFormOptions) => {
+      const outputFormat = (options.output ?? "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath) || !statSync(vaultPath).isDirectory()) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const violations = scanVaultForLiteralForm(vaultPath);
+
+        if (outputFormat === "json") {
+          console.log(
+            JSON.stringify(
+              {
+                vaultPath,
+                violationCount: violations.length,
+                violations,
+                clean: violations.length === 0,
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          if (violations.length === 0) {
+            console.log(
+              `OK ${vaultPath}: 0 exocmd__Grounding_type literal-form violations`,
+            );
+          } else {
+            console.error(
+              `FAIL ${vaultPath}: ${violations.length} exocmd__Grounding_type literal-form violation(s):`,
+            );
+            for (const v of violations) {
+              console.error(`  ${v.path}:${v.line} — value: ${v.value}`);
+            }
+            console.error(
+              "\nRFC 9d20c91f Phase 3 migrated all values to wikilink form `[[<uid>]]`. Re-run the Phase 3 migration script or hand-edit offending files.",
+            );
+          }
+        }
+
+        if (violations.length > 0) process.exitCode = 1;
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/commands/audit-grounding-type-literal-form.ts
+++ b/packages/cli/src/commands/audit-grounding-type-literal-form.ts
@@ -8,14 +8,11 @@ const FRONTMATTER_FENCE = /^---\s*$/;
 const TYPE_LINE = /^exocmd__Grounding_type:\s*(.+?)\s*$/;
 const WIKILINK_FORM = /^"?\[\[[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:\|[^\]]*)?\]\]"?$/i;
 
-const SKIP_DIRS = new Set([
-  ".git",
-  ".obsidian",
-  "node_modules",
-  ".trash",
-  ".obsidian-mobile",
-  ".DS_Store",
-]);
+/**
+ * Matches FileSystemVaultAdapter.shouldSkipDirectory convention — any dotfile
+ * dir (.git, .obsidian, .cache, .vscode, etc.) plus node_modules.
+ */
+const NON_DOT_SKIP_DIRS = new Set(["node_modules"]);
 
 export interface AuditGroundingTypeLiteralFormOptions {
   vault: string;
@@ -29,8 +26,7 @@ export interface LiteralFormViolation {
 }
 
 function shouldSkipDir(name: string): boolean {
-  if (name.startsWith(".")) return SKIP_DIRS.has(name.toLowerCase()) || name === ".git";
-  return SKIP_DIRS.has(name);
+  return name.startsWith(".") || NON_DOT_SKIP_DIRS.has(name);
 }
 
 function* walkMarkdownFiles(rootDir: string): Generator<string> {

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,0 +1,20 @@
+import { Command } from "commander";
+import { auditGroundingTypeLiteralFormCommand } from "./audit-grounding-type-literal-form.js";
+
+/**
+ * Creates the 'audit' parent command with regression-detection subcommands:
+ * - audit grounding-type-literal-form — RFC 9d20c91f Phase 4+1 regression
+ *   detector for `exocmd__Grounding_type` literal-string form.
+ *
+ * @example
+ * exocortex audit grounding-type-literal-form --vault /path/to/vault
+ */
+export function auditCommand(): Command {
+  const cmd = new Command("audit").description(
+    "Audit vault for regression patterns (RFC cutover detectors)",
+  );
+
+  cmd.addCommand(auditGroundingTypeLiteralFormCommand());
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import { backfillCommand } from "./commands/backfill.js";
 import { recoverCommand } from "./commands/recover.js";
 import { findCommand } from "./commands/find.js";
 import { applyCommand } from "./commands/apply.js";
+import { auditCommand } from "./commands/audit.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -59,6 +60,9 @@ export function createProgram(version?: string): Command {
   program.addCommand(daemonCommand());
   program.addCommand(backfillCommand());
   program.addCommand(recoverCommand());
+
+  // RFC 9d20c91f Phase 4+1 — regression-detection audits
+  program.addCommand(auditCommand());
 
   return program;
 }

--- a/packages/cli/tests/integration/commands/test-helpers/extract-target-class.ts
+++ b/packages/cli/tests/integration/commands/test-helpers/extract-target-class.ts
@@ -246,15 +246,13 @@ function buildGroundingData(
   return {
     uid,
     label,
-    // RFC 9d20c91f Phase 4 cutover: legacy bare-string path env-flag gated.
-    // Default (env-flag NOT set) = wikilink-only; bare-string returns empty
-    // string (test-helper consumers treat empty type as missing). Setting
-    // EXOCORTEX_GROUNDING_TYPE_BC=1 retains Phase 2 raw pass-through.
+    // RFC 9d20c91f Phase 4+1: wikilink-only. Bare-string returns empty
+    // string (test-helper consumers treat empty type as missing). The
+    // env-flag escape hatch was removed alongside the dual-read path.
     type: (() => {
       const raw = asString(fm["exocmd__Grounding_type"]);
       const resolved = resolveGroundingTypeFromWikilinkLiteral(raw);
       if (resolved !== null) return resolved;
-      if (process.env.EXOCORTEX_GROUNDING_TYPE_BC === "1") return raw;
       return "";
     })(),
     targetProperty: asString(fm["exocmd__Grounding_targetProperty"]),

--- a/packages/cli/tests/unit/commands/audit-grounding-type-literal-form.test.ts
+++ b/packages/cli/tests/unit/commands/audit-grounding-type-literal-form.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  scanVaultForLiteralForm,
+  auditGroundingTypeLiteralFormCommand,
+} from "../../../src/commands/audit-grounding-type-literal-form.js";
+import { auditCommand } from "../../../src/commands/audit.js";
+
+const WL_PROPERTY_SET = "[[cf3bb923-f1f1-40be-b728-782844402426]]";
+
+function writeGrounding(dir: string, uid: string, typeLine: string): void {
+  const content = `---
+exo__Asset_uid: ${uid}
+exo__Asset_label: Test Grounding ${uid}
+exo__Instance_class: "[[abc12345-0000-0000-0000-000000000001]]"
+exocmd__Grounding_type: ${typeLine}
+exocmd__Grounding_targetProperty: "[[some-prop]]"
+---
+
+Body.
+`;
+  writeFileSync(join(dir, `${uid}.md`), content, "utf-8");
+}
+
+describe("audit grounding-type-literal-form — Commander wiring", () => {
+  it("registers under 'audit' parent command", () => {
+    const parent = auditCommand();
+    expect(parent.name()).toBe("audit");
+    const sub = parent.commands.find((c) => c.name() === "grounding-type-literal-form");
+    expect(sub).toBeDefined();
+  });
+
+  it("subcommand declares --vault required + --output options", () => {
+    const sub = auditGroundingTypeLiteralFormCommand();
+    expect(sub.name()).toBe("grounding-type-literal-form");
+    const opts = sub.options.map((o) => o.long);
+    expect(opts).toContain("--vault");
+    expect(opts).toContain("--output");
+  });
+
+  it("--help text references RFC 9d20c91f cutover semantics", () => {
+    const sub = auditGroundingTypeLiteralFormCommand();
+    const help = sub.helpInformation();
+    expect(help).toMatch(/literal-string\s+form/);
+  });
+});
+
+describe("audit grounding-type-literal-form — scanVaultForLiteralForm", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `audit-grounding-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty when all groundings use wikilink form", () => {
+    writeGrounding(tmpDir, "uid-001", `"${WL_PROPERTY_SET}"`);
+    writeGrounding(tmpDir, "uid-002", `"${WL_PROPERTY_SET}"`);
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("detects bare-string literal form (quoted)", () => {
+    writeGrounding(tmpDir, "uid-003", `"property_set"`);
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].value).toBe(`"property_set"`);
+    expect(violations[0].path).toBe("uid-003.md");
+  });
+
+  it("detects bare-string literal form (unquoted)", () => {
+    writeGrounding(tmpDir, "uid-004", `property_delete`);
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].value).toBe("property_delete");
+  });
+
+  it("recurses into nested directories", () => {
+    const sub = join(tmpDir, "subdir", "nested");
+    mkdirSync(sub, { recursive: true });
+    writeGrounding(sub, "uid-005", `"composite"`);
+    writeGrounding(tmpDir, "uid-006", `"${WL_PROPERTY_SET}"`);
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].path.endsWith("uid-005.md")).toBe(true);
+  });
+
+  it("skips .git, .obsidian, node_modules", () => {
+    for (const skip of [".git", ".obsidian", "node_modules"]) {
+      const skipDir = join(tmpDir, skip);
+      mkdirSync(skipDir, { recursive: true });
+      writeGrounding(skipDir, `uid-skip-${skip}`, `"property_set"`);
+    }
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("ignores files without Grounding_type predicate", () => {
+    const noGrounding = `---
+exo__Asset_uid: uid-007
+exo__Asset_label: Plain
+---
+Body.
+`;
+    writeFileSync(join(tmpDir, "uid-007.md"), noGrounding, "utf-8");
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("ignores files without frontmatter", () => {
+    writeFileSync(join(tmpDir, "no-fm.md"), "Just body text.\n", "utf-8");
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("returns multiple violations across files with correct line numbers", () => {
+    writeGrounding(tmpDir, "uid-008", `"property_set"`);
+    writeGrounding(tmpDir, "uid-009", `service_call`);
+    writeGrounding(tmpDir, "uid-010", `"${WL_PROPERTY_SET}"`);
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(2);
+    const paths = violations.map((v) => v.path).sort();
+    expect(paths).toEqual(["uid-008.md", "uid-009.md"]);
+    for (const v of violations) {
+      expect(v.line).toBeGreaterThan(0);
+    }
+  });
+
+  it("treats wikilink with alias as valid (e.g. `[[uid|label]]`)", () => {
+    writeGrounding(
+      tmpDir,
+      "uid-011",
+      `"[[cf3bb923-f1f1-40be-b728-782844402426|property_set]]"`,
+    );
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/packages/cli/tests/unit/commands/audit-grounding-type-literal-form.test.ts
+++ b/packages/cli/tests/unit/commands/audit-grounding-type-literal-form.test.ts
@@ -101,6 +101,16 @@ describe("audit grounding-type-literal-form — scanVaultForLiteralForm", () => 
     expect(violations).toHaveLength(0);
   });
 
+  it("skips any dotfile directory (.cache, .vscode, .idea, .tmp) to match FileSystemVaultAdapter convention", () => {
+    for (const dot of [".cache", ".vscode", ".idea", ".tmp"]) {
+      const dotDir = join(tmpDir, dot);
+      mkdirSync(dotDir, { recursive: true });
+      writeGrounding(dotDir, `uid-dot-${dot}`, `"property_set"`);
+    }
+    const violations = scanVaultForLiteralForm(tmpDir);
+    expect(violations).toHaveLength(0);
+  });
+
   it("ignores files without Grounding_type predicate", () => {
     const noGrounding = `---
 exo__Asset_uid: uid-007

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -180,16 +180,6 @@ export class CommandResolver {
   private readonly _legacyPropertyDefaultsWarnedGroundings = new Set<string>();
 
   /**
-   * RFC 9d20c91f Phase 2 — per-subject dedup for the
-   * `[exocmd-grounding-type-bc]` legacy-form warn. With ~172 ABox values
-   * still on bare-string form pre-Phase-3, every cold-start /
-   * `sparql.refresh()` traversal would otherwise emit N duplicate warns
-   * per subject. Same pattern as `_legacyPropertyDefaultsWarnedGroundings`
-   * above. Removed in Phase 4 cutover alongside dual-read.
-   */
-  private readonly _legacyGroundingTypeWarnedSubjects = new Set<string>();
-
-  /**
    * RFC 727572d2 — Universal Default Template singleton cache. Loaded once
    * per CommandResolver instance via {@link getUniversalCache}. Vault file
    * change adapters may externally call
@@ -2006,28 +1996,24 @@ export class CommandResolver {
     return false;
   }
 
-  private resolveGroundingType(value: string): GroundingType | null {
-    const normalized = value.toLowerCase().trim();
-    const values = Object.values(GroundingType) as string[];
-    return values.includes(normalized) ? (normalized as GroundingType) : null;
-  }
-
   /**
-   * RFC 9d20c91f Phase 2: dual-read for `exocmd__Grounding_type`.
+   * RFC 9d20c91f Phase 4+1: wikilink-only resolution for `exocmd__Grounding_type`.
    *
    * Phase 1 added the `exocmd__GroundingType` catalog + 9 instances in the
-   * shared `exoas-exocmd` submodule. Phase 3 will migrate ~172 ABox values
-   * from literal-string form (`"property_set"`) to wikilink form
-   * (`"[[<uid>]]"`). During the BC window, parsers accept both shapes.
+   * shared `exoas-exocmd` submodule. Phase 3 migrated all ABox values from
+   * literal-string form (`"property_set"`) to wikilink form (`"[[<uid>]]"`).
+   * Phase 4 made wikilink the default; Phase 4+1 (this revision) removed the
+   * `EXOCORTEX_GROUNDING_TYPE_BC` env-flag escape hatch entirely.
    *
    * Resolution priority:
    * 1. Triple object is IRI (post-Phase-3 ABox after vault sync) — map via
    *    `resolveGroundingTypeFromIRI` (symbolic class IRI OR file IRI fallback).
-   * 2. Triple object is Literal — try wikilink-literal first (defensive in
-   *    case NoteToRDFConverter didn't substitute the wikilink to an IRI),
-   *    then legacy bare-string match. Bare-string path emits a deprecation
-   *    warning tagged `[exocmd-grounding-type-bc]` for Phase 4 cutover
-   *    monitoring.
+   * 2. Triple object is Literal in wikilink form `"[[<uid>]]"` — resolve via
+   *    file-IRI form (defensive: NoteToRDFConverter may not substitute the
+   *    wikilink to an IRI for non-class-keyed predicates).
+   * 3. Any other Literal (bare-string legacy) — return null + emit a single
+   *    warn (grounding inert, caller skips). The CLI audit subcommand
+   *    `exocortex-cli audit grounding-type-literal-form` detects regressions.
    *
    * Returns `null` for unknown values (caller treats grounding as inert).
    */
@@ -2052,27 +2038,9 @@ export class CommandResolver {
         return resolveGroundingTypeFromIRI(`obsidian://vault/${wikilinkMatch[1].toLowerCase()}.md`);
       }
 
-      // RFC 9d20c91f Phase 4 cutover: legacy bare-string path is env-flag
-      // gated. Default (env-flag NOT set) = wikilink-only; bare-string returns
-      // null (grounding inert — fails loud at dispatch). Setting
-      // EXOCORTEX_GROUNDING_TYPE_BC=1 retains Phase 2 dual-read as a one-release
-      // rollback escape hatch. Phase 4+1 removes the env-flag entirely.
-      if (process.env.EXOCORTEX_GROUNDING_TYPE_BC === "1") {
-        if (!this._legacyGroundingTypeWarnedSubjects.has(subject.value)) {
-          this._legacyGroundingTypeWarnedSubjects.add(subject.value);
-          this.logger.warn(
-            `[exocmd-grounding-type-bc] legacy literal-string form '${raw}' for exocmd__Grounding_type on <${subject.value}> (BC env-flag enabled). Migrate to wikilink form per RFC 9d20c91f Phase 3.`,
-          );
-        }
-        return this.resolveGroundingType(raw);
-      }
-
-      if (!this._legacyGroundingTypeWarnedSubjects.has(subject.value)) {
-        this._legacyGroundingTypeWarnedSubjects.add(subject.value);
-        this.logger.warn(
-          `[exocmd-grounding-type-bc] BLOCKED legacy literal-string form '${raw}' for exocmd__Grounding_type on <${subject.value}> post-Phase-4 cutover. Migrate to wikilink form or set EXOCORTEX_GROUNDING_TYPE_BC=1 to re-enable (rollback escape hatch, removed Phase 4+1).`,
-        );
-      }
+      this.logger.warn(
+        `[exocmd-grounding-type-literal-form] legacy literal-string form '${raw}' for exocmd__Grounding_type on <${subject.value}>. Migrate to wikilink form per RFC 9d20c91f Phase 3.`,
+      );
       return null;
     }
 

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -106,10 +106,10 @@ async function addGroundingAsset(
 ): Promise<IRI> {
   const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
 
-  // RFC 9d20c91f Phase 4 cutover: emit Grounding_type as wikilink-form Literal
+  // RFC 9d20c91f Phase 4+1: emit Grounding_type as wikilink-form Literal
   // (canonical post-Phase-3 ABox shape). Fallback to bare-string for unknown
-  // type values (e.g. typo-form `"unknown_type"` test fixtures) so the legacy
-  // dispatch-null path remains testable when EXOCORTEX_GROUNDING_TYPE_BC=1.
+  // type values (e.g. typo-form `"unknown_type"` test fixtures) — the legacy
+  // dispatch-null path remains testable via direct bare-string Literal seed.
   const groundingTypeUid = TEST_GROUNDING_TYPE_UIDS[opts.type];
   const groundingTypeValue = groundingTypeUid
     ? new Literal(`[[${groundingTypeUid}]]`)
@@ -1987,79 +1987,25 @@ describe("CommandResolver — RFC 9d20c91f Phase 2 grounding type dispatch", () 
     expect(grounding.type).toBe("property_set");
   });
 
-  // RFC 9d20c91f Phase 4 cutover: legacy bare-string path env-flag-gated.
-  // Default (EXOCORTEX_GROUNDING_TYPE_BC unset) = wikilink-only — bare-string
-  // returns null (grounding inert). Setting BC=1 retains Phase 2 dual-read.
-  describe("legacy bare-string post-Phase-4 cutover", () => {
-    const ORIG_BC = process.env.EXOCORTEX_GROUNDING_TYPE_BC;
-    afterEach(() => {
-      if (ORIG_BC === undefined) delete process.env.EXOCORTEX_GROUNDING_TYPE_BC;
-      else process.env.EXOCORTEX_GROUNDING_TYPE_BC = ORIG_BC;
+  // RFC 9d20c91f Phase 4+1: env-flag escape hatch removed. Legacy bare-string
+  // always returns null grounding (inert) and emits a literal-form warn.
+  it("legacy bare-string `\"property_set\"` returns null grounding AND emits literal-form warn (Phase 4+1 — no env-flag escape)", async () => {
+    const store = new InMemoryTripleStore();
+    const warnSpy = jest.fn();
+    const resolver = new CommandResolver(store, {
+      info: jest.fn(),
+      warn: warnSpy,
+      error: jest.fn(),
+      debug: jest.fn(),
     });
+    const subject = await seedMinimalGrounding(store, new Literal("property_set"));
 
-    it("DEFAULT (no env-flag) → bare-string `\"property_set\"` returns null grounding AND emits BLOCKED warn once per subject", async () => {
-      delete process.env.EXOCORTEX_GROUNDING_TYPE_BC;
-      const store = new InMemoryTripleStore();
-      const warnSpy = jest.fn();
-      const resolver = new CommandResolver(store, {
-        info: jest.fn(),
-        warn: warnSpy,
-        error: jest.fn(),
-        debug: jest.fn(),
-      });
-      const subject = await seedMinimalGrounding(store, new Literal("property_set"));
-
-      const g1 = await loadGroundingForFixture(store, subject, resolver);
-      expect(g1.type).toBeUndefined();
-      const blockedCalls = warnSpy.mock.calls.filter((call) =>
-        String(call[0]).includes("[exocmd-grounding-type-bc] BLOCKED"),
-      );
-      expect(blockedCalls).toHaveLength(1);
-
-      // 2nd resolve same subject → dedup, no additional warn
-      await resolver.loadCommand("cmd-rfc-9d20c91f");
-      const blockedCallsAfter = warnSpy.mock.calls.filter((call) =>
-        String(call[0]).includes("[exocmd-grounding-type-bc] BLOCKED"),
-      );
-      expect(blockedCallsAfter).toHaveLength(1);
-    });
-
-    it("env-flag EXOCORTEX_GROUNDING_TYPE_BC=1 → bare-string resolves AND emits dedup BC-enabled warn (rollback escape hatch)", async () => {
-      process.env.EXOCORTEX_GROUNDING_TYPE_BC = "1";
-      const store = new InMemoryTripleStore();
-      const warnSpy = jest.fn();
-      const resolver = new CommandResolver(store, {
-        info: jest.fn(),
-        warn: warnSpy,
-        error: jest.fn(),
-        debug: jest.fn(),
-      });
-      const subject = await seedMinimalGrounding(store, new Literal("property_set"));
-
-      const g1 = await loadGroundingForFixture(store, subject, resolver);
-      expect(g1.type).toBe("property_set");
-      const bcCalls = warnSpy.mock.calls.filter((call) =>
-        String(call[0]).includes("[exocmd-grounding-type-bc]"),
-      );
-      expect(bcCalls).toHaveLength(1);
-      expect(String(bcCalls[0][0])).toContain("BC env-flag enabled");
-
-      // 2nd resolve same subject → dedup, no additional warn
-      await resolver.loadCommand("cmd-rfc-9d20c91f");
-      const bcCallsAfter = warnSpy.mock.calls.filter((call) =>
-        String(call[0]).includes("[exocmd-grounding-type-bc]"),
-      );
-      expect(bcCallsAfter).toHaveLength(1);
-    });
-
-    it("env-flag value `\"0\"` or empty string → wikilink-only (only `\"1\"` enables rollback)", async () => {
-      process.env.EXOCORTEX_GROUNDING_TYPE_BC = "0";
-      const store = new InMemoryTripleStore();
-      const resolver = new CommandResolver(store);
-      const subject = await seedMinimalGrounding(store, new Literal("property_set"));
-      const g1 = await loadGroundingForFixture(store, subject, resolver);
-      expect(g1.type).toBeUndefined();
-    });
+    const g1 = await loadGroundingForFixture(store, subject, resolver);
+    expect(g1.type).toBeUndefined();
+    const literalFormCalls = warnSpy.mock.calls.filter((call) =>
+      String(call[0]).includes("[exocmd-grounding-type-literal-form]"),
+    );
+    expect(literalFormCalls.length).toBeGreaterThanOrEqual(1);
   });
 
   it("returns null grounding when Grounding_type IRI is unknown", async () => {

--- a/scripts/audit-starter-kit-groundings.mjs
+++ b/scripts/audit-starter-kit-groundings.mjs
@@ -119,21 +119,18 @@ const GROUNDING_TYPE_UID_TO_ENUM = Object.freeze({
 });
 const WIKILINK_TYPE_RE = /^\[\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\|[^\]]*)?\]\]$/i;
 
-// RFC 9d20c91f Phase 4 cutover: legacy bare-string path is env-flag gated.
-// Default (env-flag NOT set) = wikilink-only; bare-string emits a deprecation
-// warn (audit script is read-only, can't return null without breaking
-// classification — so still returns raw with louder signal). Setting
-// EXOCORTEX_GROUNDING_TYPE_BC=1 retains silent Phase 2 behavior.
-const _legacyAuditWarnedRaw = new Set();
+// RFC 9d20c91f Phase 4+1: wikilink-only — env-flag escape hatch removed.
+// Legacy literal-string encountered post-cutover emits stderr error and
+// flags the audit run as failure (exit non-zero). Audit script is the
+// regression detector for any post-Phase-3 ABox drift.
+const _legacyAuditSawLiteralForm = { value: false };
 function resolveGroundingType(raw) {
   const m = raw.match(WIKILINK_TYPE_RE);
   if (m) return GROUNDING_TYPE_UID_TO_ENUM[m[1].toLowerCase()] ?? raw;
-  if (process.env.EXOCORTEX_GROUNDING_TYPE_BC !== "1" && !_legacyAuditWarnedRaw.has(raw)) {
-    _legacyAuditWarnedRaw.add(raw);
-    process.stderr.write(
-      `[exocmd-grounding-type-bc] WARN audit encountered legacy literal-string '${raw}' for exocmd__Grounding_type post-Phase-4 cutover. Migrate to wikilink form per RFC 9d20c91f Phase 3.\n`,
-    );
-  }
+  _legacyAuditSawLiteralForm.value = true;
+  process.stderr.write(
+    `[exocmd-grounding-type-literal-form] ERROR audit encountered legacy literal-string '${raw}' for exocmd__Grounding_type post-cutover. Migrate to wikilink form per RFC 9d20c91f Phase 3.\n`,
+  );
   return raw;
 }
 
@@ -180,6 +177,13 @@ async function main() {
     for (const g of drift) {
       console.error(`  - ${g.path} → serviceId="${g.serviceId}"`);
     }
+    process.exitCode = 1;
+  }
+
+  if (_legacyAuditSawLiteralForm.value) {
+    console.error(
+      `[audit] LITERAL-FORM: at least one exocmd__Grounding_type literal-string form encountered (see stderr above). RFC 9d20c91f Phase 4+1 cutover violated.`,
+    );
     process.exitCode = 1;
   }
 


### PR DESCRIPTION
## Summary

Closes RFC 9d20c91f Phase 4+1 — removes the `EXOCORTEX_GROUNDING_TYPE_BC` env-flag escape hatch shipped in Phase 4 (PR #3271, v16.29.0) and adds a CLI regression detector + CI nightly workflow for the `exocmd__Grounding_type` literal-string form.

### Background

- **Phase 4** (commit `5b43a4c4`) shipped wikilink-only default with env-flag escape hatch for 1-release rollback window.
- User explicitly waived the BC observation window on 2026-05-26 — empirical signal: 0 literal-form survivors verified pre-cutover across all vault assetspaces + e2e fixtures + starter-kit.
- This PR retires the env-flag entirely + bolts on long-term regression guard (CLI audit + CI nightly).

## Changes

### Env-flag removal (4 parsers)

- `packages/exocortex/src/services/CommandResolver.ts` — removes `_legacyGroundingTypeWarnedSubjects` dedup `Set<string>` field, removes legacy private `resolveGroundingType(value)` method, removes env-flag conditional block in `resolveGroundingTypeReference` Literal branch. Bare-string legacy form now returns `null` + emits single literal-form warn per call (caller already treats `null` as inert grounding — `CommandResolver.ts:1128`).
- `packages/cli/specs/step_definitions/grounding.steps.ts` — env-flag removed, legacy literal-form throws clear error.
- `packages/cli/tests/integration/commands/test-helpers/extract-target-class.ts` — env-flag removed, bare-string returns empty string.
- `scripts/audit-starter-kit-groundings.mjs` — env-flag removed, audit now exits non-zero on any literal-form encountered (was warn-only).

### Test cleanup

Drops 3 env-flag-gated tests from `CommandResolver.test.ts`. Single post-cutover assertion kept: bare-string seed → null grounding + literal-form warn. No dedup state to verify (field removed).

### New CLI audit tool

```
npx exocortex audit grounding-type-literal-form --vault <path> [--output text|json]
```

- New `audit` parent command + `grounding-type-literal-form` subcommand.
- Walks vault recursively (skips `.git`, `.obsidian`, `node_modules`), parses frontmatter, detects any `exocmd__Grounding_type:` value not matching wikilink-UID form.
- Exit 0 = clean; exit 1 = ≥1 violation. Suitable for CI scheduling.
- 12 unit tests cover: wikilink-only baseline, bare-string detection (quoted + unquoted), recursion, skip-dirs, missing FM, multi-violation line numbers, wikilink alias form.

### CI nightly workflow

`.github/workflows/audit-nightly.yml` — `cron: \"0 2 * * *\"` daily, audits `packages/exoas-exocmd` + `packages/obsidian-plugin/tests/e2e/test-vault`.

## Empirical verification (integration-test-revert-verify)

- `audit grounding-type-literal-form --vault packages/exoas-exocmd` → `exit=0, 0 violations`
- `audit grounding-type-literal-form --vault packages/obsidian-plugin/tests/e2e/test-vault` → `exit=0, 0 violations`
- Synthetic fixture (`exocmd__Grounding_type: \"property_set\"`) → `exit=1, FAIL ... 1 violation(s)` with line number + diagnostic
- `packages/exocortex/tests/unit/services/CommandResolver.test.ts` — 75/75 pass (incl. updated Phase 4+1 assertion)
- `packages/cli/tests/unit/commands/audit-grounding-type-literal-form.test.ts` — 12/12 pass
- `npx tsc --noEmit --skipLibCheck` — green
- Pre-commit lint-staged + BDD coverage 204/204 (100%) + archgate 13/13 pass

## Test plan

- [x] Local typecheck + targeted jest
- [x] Local empirical revert→fail / restore→pass on synthetic fixture
- [ ] CI: 14 required checks green
- [ ] code-reviewer agent: 0 CRIT/HIGH
- [ ] advisor round-2 sign-off
- [ ] Manual squash merge (per CLAUDE.md auto-merge discipline — parser path)

## Definition of Done

- [x] `grep -rn "EXOCORTEX_GROUNDING_TYPE_BC" packages/ scripts/` returns 0 hits (excluding historical JSDoc reference)
- [x] `_legacyGroundingTypeWarnedSubjects` field + dedup logic deleted
- [x] 4 parsers: direct wikilink-only path, no env-flag conditional
- [x] CLI: `npx exocortex audit grounding-type-literal-form` exists, exit=0 on clean / exit=1 on synthetic violation
- [x] CI nightly workflow shipped
- [ ] CI green
- [ ] code-reviewer APPROVE + advisor round-2
- [ ] Manual squash merge
- [ ] Auto Release published (v16.30.x)
- [ ] RFC closure asset `fa2fc7ad` updated