### PR TITLE
fix(plugin): lazy-bootstrap folders configurable in settings (Phase 5, fixes mobile 10-20s regression)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -946,19 +946,30 @@ export default class ExocortexPlugin extends Plugin {
         performance.mark("lazy-tbox-bootstrap-start");
         void (async () => {
           try {
-            // Phase 3a scope: 4 core TBox folders shared by both
-            // vaults (vault-2025 + vault-exodev clone the same
-            // git submodules). Other assetspaces (pmbok-ontology,
-            // aiknow-ontology, shared-identities, test, exodev,
-            // exoass) remain covered by the parallel convertVault()
-            // path during 3a; Phase 3b audits whether they need
-            // explicit preload.
-            const ontologyFolders = [
-              "assetspaces/exo/",
-              "assetspaces/ems/",
-              "assetspaces/ims/",
-              "assetspaces/exocmd/",
-            ];
+            // RFC c7da0bca Phase 5 — folder list moved to user
+            // settings (`lazyBootstrapFolders`). Phase 3a hardcoded
+            // 4 folders, but RFC aaaa2dea Phase 2 Task 2.2
+            // (2026-05-23) migrated bb00efed Command + a6ef8fda
+            // Grounding из `exocmd/creation/` в новый submodule
+            // `ems-commands/` — а hardcoded list никто не обновил.
+            // На mobile это означало Bindings (в `exocmd/creation/`,
+            // indexed) ссылались на Commands (в `ems-commands/`,
+            // NOT indexed) → unresolved refs → 0 buttons → wait для
+            // convertVault (~10-20 s на iPhone). Phase 4 autoRender
+            // hook re-renders после bootstrap, но bootstrap который
+            // не загрузил Commands — no-op для visible outcome.
+            //
+            // Per Homoiconicity Invariant: список path prefixes —
+            // user-configurable семантика (где у пользователя живут
+            // ontology submodules), не hardcoded. Default settings
+            // покрывает 5 production submodules; users с extra
+            // submodules (kitelev/, pmbok-ontology/, aiknow-ontology/,
+            // shared-identities/, ...) могут append через Settings tab.
+            //
+            // `?? []` fallback: defensive coverage for jest mocks +
+            // legacy user settings без этого поля (Object.assign
+            // в loadSettings заполнит default).
+            const ontologyFolders = this.settings.lazyBootstrapFolders ?? [];
             // `?? []` is defensive coverage for jest mocks that
             // under-specify the IVaultFileReader surface — the
             // production `ObsidianVaultAdapter.getAllFiles()` is

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -98,6 +98,32 @@ import {
  * Provides Command Palette integration for all asset commands
  */
 export default class ExocortexPlugin extends Plugin {
+  /**
+   * RFC c7da0bca Phase 5 — pure filter used by lazy-tbox-bootstrap to
+   * select TBox files from the full vault file list. Extracted as static
+   * for direct unit testing without standing up the whole plugin
+   * scaffold (code-reviewer HIGH catch — settings → bootstrap wiring
+   * was previously empirically untested, which is exactly how the
+   * `bb00efed → ems-commands/` migration silently stayed unindexed).
+   *
+   * Match is `String.startsWith` against vault-relative path. Caller is
+   * responsible for ensuring each prefix in `folderPrefixes` ends with
+   * `/` so `assetspaces/ems/` does not over-match `assetspaces/ems-commands/`
+   * (Settings UI auto-appends — see ExocortexSettingTab).
+   *
+   * Returns empty array if `folderPrefixes` is empty (degraded mode —
+   * bootstrap walks nothing; buttons appear later via convertVault).
+   */
+  static filterTBoxFiles<T extends { path: string }>(
+    files: T[],
+    folderPrefixes: string[],
+  ): T[] {
+    if (folderPrefixes.length === 0) return [];
+    return files.filter((f) =>
+      folderPrefixes.some((folder) => f.path.startsWith(folder)),
+    );
+  }
+
   private logger!: ILogger;
   private layoutRenderer!: UniversalLayoutRenderer;
   private commandManager!: CommandManager;
@@ -969,14 +995,20 @@ export default class ExocortexPlugin extends Plugin {
             // `?? []` fallback: defensive coverage for jest mocks +
             // legacy user settings без этого поля (Object.assign
             // в loadSettings заполнит default).
+            // Defensive `?? []` for jest mocks that omit
+            // `lazyBootstrapFolders` from the synthetic settings
+            // object. Production users always have the field
+            // populated by `Object.assign({}, DEFAULT_SETTINGS,
+            // rawData)` in `loadSettings`.
             const ontologyFolders = this.settings.lazyBootstrapFolders ?? [];
             // `?? []` is defensive coverage for jest mocks that
             // under-specify the IVaultFileReader surface — the
             // production `ObsidianVaultAdapter.getAllFiles()` is
             // typed `IFile[]` and always returns an array.
             const allFiles = this.vaultAdapter.getAllFiles() ?? [];
-            const tboxFiles = allFiles.filter((f) =>
-              ontologyFolders.some((folder) => f.path.startsWith(folder)),
+            const tboxFiles = ExocortexPlugin.filterTBoxFiles(
+              allFiles,
+              ontologyFolders,
             );
             let loadedCount = 0;
             let errorCount = 0;

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -150,6 +150,27 @@ export interface ExocortexSettings {
   // toggle had no remaining effect. Existing user settings JSON
   // containing this key will be silently ignored by Object.assign
   // merge in `loadSettings` — no migration needed.
+  /**
+   * RFC c7da0bca Phase 5 — folder prefixes loaded eagerly by
+   * `lazy-tbox-bootstrap` at `onLayoutReady`. The bootstrap walks
+   * these folders so that `exocmd__CommandBinding`, `exocmd__Command`,
+   * `exocmd__Grounding`, `exo__Class` and `exo__Property` triples are
+   * present in the store before the first asset render — eliminating
+   * the «buttons appear after 10-20 s» mobile cold-start regression
+   * caused by deferred convertVault.
+   *
+   * Each entry is a path prefix matched via `String.startsWith` against
+   * vault-relative file paths. Trailing slash required to prevent
+   * `assetspaces/ems/` matching `assetspaces/ems-commands/...`.
+   *
+   * Default covers the 5 production submodules. Users with extra
+   * submodules (e.g. `assetspaces/kitelev/`, `assetspaces/pmbok-ontology/`)
+   * should append to this list — change applies on next plugin reload.
+   *
+   * Empty / undefined → bootstrap walks zero files (degraded mode,
+   * buttons appear via convertVault path eventually).
+   */
+  lazyBootstrapFolders: string[];
   [key: string]: unknown;
 }
 
@@ -176,4 +197,11 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   enableSparqlAutoExecute: false,
   enableShaclValidation: false,
   enablePropertiesLabelPatch: true,
+  lazyBootstrapFolders: [
+    "assetspaces/exo/",
+    "assetspaces/ems/",
+    "assetspaces/ems-commands/",
+    "assetspaces/ims/",
+    "assetspaces/exocmd/",
+  ],
 };

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -168,6 +168,31 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Lazy bootstrap folders")
+      .setDesc(
+        "Path prefixes (one per line, trailing slash required) walked eagerly " +
+          "at plugin load so exocmd Commands/Bindings/Groundings and exo Classes/Properties " +
+          "are indexed before first render. Add extra submodules here " +
+          "(e.g. assetspaces/kitelev/, assetspaces/pmbok-ontology/) — change applies on next plugin reload. " +
+          "Empty list = bootstrap skips all folders (buttons may take 10-20s to appear on mobile).",
+      )
+      .addTextArea((textarea) => {
+        textarea
+          // eslint-disable-next-line obsidianmd/ui/sentence-case -- example shows literal vault-relative folder paths, not prose UI text
+          .setPlaceholder("assetspaces/exo/\nassetspaces/ems/")
+          .setValue((this.plugin.settings.lazyBootstrapFolders ?? []).join("\n"))
+          .onChange(async (value) => {
+            this.plugin.settings.lazyBootstrapFolders = value
+              .split("\n")
+              .map((line) => line.trim())
+              .filter((line) => line.length > 0);
+            await this.plugin.saveSettings();
+          });
+        textarea.inputEl.rows = 6;
+        textarea.inputEl.cols = 50;
+      });
+
+    new Setting(containerEl)
       // eslint-disable-next-line obsidianmd/ui/sentence-case -- "SHACL" is an established acronym
       .setName("Enable SHACL validation (experimental)")
       .setDesc(

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -182,10 +182,15 @@ export class ExocortexSettingTab extends PluginSettingTab {
           .setPlaceholder("assetspaces/exo/\nassetspaces/ems/")
           .setValue((this.plugin.settings.lazyBootstrapFolders ?? []).join("\n"))
           .onChange(async (value) => {
+            // Auto-append trailing slash to prevent `assetspaces/ems`
+            // over-matching `assetspaces/ems-commands/...` (the exact
+            // failure mode this PR fixes — see ExocortexPlugin Phase 5
+            // comment block). Code-reviewer MED catch.
             this.plugin.settings.lazyBootstrapFolders = value
               .split("\n")
               .map((line) => line.trim())
-              .filter((line) => line.length > 0);
+              .filter((line) => line.length > 0)
+              .map((line) => (line.endsWith("/") ? line : line + "/"));
             await this.plugin.saveSettings();
           });
         textarea.inputEl.rows = 6;

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.filterTBoxFiles.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.filterTBoxFiles.test.ts
@@ -1,0 +1,99 @@
+/**
+ * RFC c7da0bca Phase 5 — unit tests for `ExocortexPlugin.filterTBoxFiles`
+ * pure helper. Code-reviewer HIGH catch on PR #3277 — settings →
+ * bootstrap wiring was previously empirically untested. Empirical
+ * regression class: `bb00efed → ems-commands/` migration silently
+ * stayed unindexed because no test pinned which folders the bootstrap
+ * walks.
+ *
+ * Filter contract:
+ *  - matches vault-relative path via `String.startsWith` against each prefix
+ *  - returns empty array on empty prefix list (degraded mode)
+ *  - trailing-slash on prefix prevents over-match
+ *    (`assetspaces/ems/` vs `assetspaces/ems-commands/`)
+ *  - no path traversal sanitisation needed — input intersects with
+ *    `vault.getMarkdownFiles()` which is vault-scoped
+ */
+import ExocortexPlugin from "../../src/ExocortexPlugin";
+
+describe("ExocortexPlugin.filterTBoxFiles (RFC c7da0bca Phase 5)", () => {
+  it("returns matching files when prefix matches path start", () => {
+    const files = [
+      { path: "assetspaces/exo/Class.md" },
+      { path: "assetspaces/ems/Task.md" },
+      { path: "03 Knowledge/foo.md" },
+    ];
+    const result = ExocortexPlugin.filterTBoxFiles(files, [
+      "assetspaces/exo/",
+      "assetspaces/ems/",
+    ]);
+    expect(result.map((f) => f.path)).toEqual([
+      "assetspaces/exo/Class.md",
+      "assetspaces/ems/Task.md",
+    ]);
+  });
+
+  it("includes files in ems-commands/ when prefix listed (regression: RFC aaaa2dea Phase 2 migration of bb00efed)", () => {
+    const files = [
+      { path: "assetspaces/ems-commands/bb00efed-7b17-42f5-a2c4-7cadf3e0ab36.md" },
+      { path: "assetspaces/ems-commands/a6ef8fda-addb-40c3-940c-fe55fd7e8500.md" },
+    ];
+    const result = ExocortexPlugin.filterTBoxFiles(files, [
+      "assetspaces/exo/",
+      "assetspaces/ems/",
+      "assetspaces/ems-commands/",
+      "assetspaces/ims/",
+      "assetspaces/exocmd/",
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("does NOT over-match assetspaces/ems-commands/ when only assetspaces/ems/ is configured (trailing-slash safety)", () => {
+    const files = [
+      { path: "assetspaces/ems/Effort.md" },
+      { path: "assetspaces/ems-commands/bb00efed-7b17-42f5-a2c4-7cadf3e0ab36.md" },
+    ];
+    const result = ExocortexPlugin.filterTBoxFiles(files, ["assetspaces/ems/"]);
+    expect(result.map((f) => f.path)).toEqual(["assetspaces/ems/Effort.md"]);
+  });
+
+  it("returns empty array when prefix list is empty (degraded mode)", () => {
+    const files = [
+      { path: "assetspaces/exo/x.md" },
+      { path: "assetspaces/ems/y.md" },
+    ];
+    expect(ExocortexPlugin.filterTBoxFiles(files, [])).toEqual([]);
+  });
+
+  it("returns empty array when no path matches any prefix", () => {
+    const files = [
+      { path: "03 Knowledge/note.md" },
+      { path: "01 Inbox/scratch.md" },
+    ];
+    const result = ExocortexPlugin.filterTBoxFiles(files, [
+      "assetspaces/exo/",
+      "assetspaces/ems/",
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("supports user-added submodule prefixes (e.g. kitelev/) without code change", () => {
+    const files = [
+      { path: "assetspaces/kitelev/c862dfda-85d2-4dc0-892e-f0efdcd054f4.md" },
+      { path: "assetspaces/pmbok-ontology/Risk.md" },
+      { path: "assetspaces/ems/Task.md" },
+    ];
+    const result = ExocortexPlugin.filterTBoxFiles(files, [
+      "assetspaces/ems/",
+      "assetspaces/kitelev/",
+      "assetspaces/pmbok-ontology/",
+    ]);
+    expect(result).toHaveLength(3);
+  });
+
+  it("handles empty file list without error", () => {
+    expect(
+      ExocortexPlugin.filterTBoxFiles([], ["assetspaces/exo/"]),
+    ).toEqual([]);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -114,6 +114,16 @@ describe("ExocortexSettingTab", () => {
           callback(button);
           return setting;
         }),
+        addTextArea: jest.fn().mockImplementation((callback) => {
+          const textarea = {
+            setPlaceholder: jest.fn().mockReturnThis(),
+            setValue: jest.fn().mockReturnThis(),
+            onChange: jest.fn().mockReturnThis(),
+            inputEl: { rows: 0, cols: 0 },
+          };
+          callback(textarea);
+          return setting;
+        }),
       };
       return setting;
     });
@@ -127,10 +137,11 @@ describe("ExocortexSettingTab", () => {
       settingTab.display();
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
-      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 1 enableShaclValidation toggle (P1.12) + 1 enablePropertiesLabelPatch toggle (RFC-030) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 29
+      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 1 lazyBootstrapFolders TextArea (RFC c7da0bca Phase 5) + 1 enableShaclValidation toggle (P1.12) + 1 enablePropertiesLabelPatch toggle (RFC-030) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 30
       // RFC c7da0bca Phase 3c-3 — deleted `exocmdBindingsCacheEnabledOnMobile` toggle (-1) once its indexer was deleted in 3c-2.
+      // RFC c7da0bca Phase 5 — added `lazyBootstrapFolders` TextArea (+1).
       // Log channels section: 1 heading + 4 log level rows = 5
-      expect(MockSetting).toHaveBeenCalledTimes(29);
+      expect(MockSetting).toHaveBeenCalledTimes(30);
     });
 
     it("should render layout visibility toggle as first setting", () => {
@@ -181,6 +192,16 @@ describe("ExocortexSettingTab", () => {
               setCta: jest.fn().mockReturnThis(),
             };
             callback(button);
+            return setting;
+          }),
+          addTextArea: jest.fn().mockImplementation((callback) => {
+            const textarea = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+              inputEl: { rows: 0, cols: 0 },
+            };
+            callback(textarea);
             return setting;
           }),
         };
@@ -251,6 +272,16 @@ describe("ExocortexSettingTab", () => {
               setCta: jest.fn().mockReturnThis(),
             };
             callback(button);
+            return setting;
+          }),
+          addTextArea: jest.fn().mockImplementation((callback) => {
+            const textarea = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+              inputEl: { rows: 0, cols: 0 },
+            };
+            callback(textarea);
             return setting;
           }),
         };


### PR DESCRIPTION
## Summary

User-reported regression: on iPhone, buttons appear через 10-20s after Obsidian launch (was «pару секунд» when Phase 4 [lazy mobile bootstrap](https://github.com/kitelev/exocortex/pull/3264) first shipped).

**Root cause**: Phase 3a hardcoded `ontologyFolders` list of 4 folders (`exo`/`ems`/`ims`/`exocmd`). RFC aaaa2dea Phase 2 Task 2.2 (2026-05-23) migrated `bb00efed` Create Task Instance Command + `a6ef8fda` TaskPrototype Grounding из `exocmd/creation/` → новый submodule `assetspaces/ems-commands/`. Hardcoded list никто не обновил, поэтому на mobile:

- Bindings (in indexed `exocmd/creation/`, e.g. `2d157dc1` TaskPrototype binding) — ✓ loaded
- Commands (in non-indexed `ems-commands/`, e.g. `bb00efed`) — ✗ NOT loaded
- → unresolved Command refs → 0 buttons → wait for `convertVault` (~10-20 s on iPhone)

Phase 4 `autoRenderLayout()` hook re-renders after bootstrap, but a bootstrap that didn't load the Commands is a no-op for visible outcome.

## Fix

**Replace hardcoded list with `ExocortexSettings.lazyBootstrapFolders` (string[]) + TextArea UI in Settings tab.**

Per Homoiconicity Invariant (CLAUDE.md): list of path prefixes is user-configurable semantic (где у пользователя живут ontology submodules), not hardcoded TypeScript constant.

**Default**: 5 production submodules — `exo/`, `ems/`, **`ems-commands/` (new)**, `ims/`, `exocmd/`.

**Extensibility**: users с extra submodules (e.g. `assetspaces/kitelev/`, `assetspaces/pmbok-ontology/`, `assetspaces/aiknow-ontology/`, `assetspaces/shared-identities/`) могут append через Settings — change applies on next plugin reload.

## Diff

- `packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts` — add `lazyBootstrapFolders: string[]` field + default value (5 folders)
- `packages/obsidian-plugin/src/ExocortexPlugin.ts` — replace `ontologyFolders` array literal с `this.settings.lazyBootstrapFolders ?? []`
- `packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts` — TextArea (6 rows × 50 cols), one-prefix-per-line splitter, autosave on change
- `packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts` — extended mock с `addTextArea`; count bumped 29 → 30

## Test plan

- [x] Unit tests pass: 4909/4909 (3 pre-existing skips)
  - `ExocortexPlugin.test.ts`: 86/86 pass (start-mark regression test unchanged)
  - `ExocortexSettingTab.test.ts`: 5/5 pass (extended mock + count adjustment)
- [x] `npm run check:types` (tsc --noEmit --skipLibCheck) clean
- [x] BDD coverage gate: 204/204 scenarios
- [x] Archgate: 13/13 ADR rules pass
- [ ] CI green (post-push verification)
- [ ] Code-reviewer agent verdict (per CLAUDE.md Auto-merge discipline — this PR touches plugin bootstrap path which is parser-adjacent)
- [ ] advisor() round-2 after applying any catches
- [ ] **Manual mobile smoke**: after BRAT update on iPhone — Cmd+P → Reload app → open TaskPrototype prototype-instance → expect Create Task Instance button via ~2-3s (instead of 10-20s waiting for convertVault)

## Empirical baselines

| Version | Bootstrap behaviour on iPhone | Buttons appear |
|---|---|---|
| v16.26.5 | Phase 3c-2/3 deleted legacy fast-resolver; Phase 3a guard skipped bootstrap on mobile | Never (until convertVault, 20-30s) |
| v16.27.1 (PR #3264) | Phase 4 unguard mobile + autoRender hook | «pару секунд» — user reported initial UX |
| v16.27.1 + bb00efed migration (#3266) | bb00efed moved to ems-commands/ but hardcoded list unchanged | Regression: 10-20s (Commands not in indexed folders) |
| **This PR (Phase 5)** | Default list includes `ems-commands/` + user-configurable | Expected: 2-3s (Phase 4 UX restored) |

## Auto-merge discipline

Per [CLAUDE.md](https://github.com/kitelev/exocortex/blob/main/CLAUDE.md) Auto-merge rule: this PR touches plugin bootstrap (CommandResolver/PreconditionEvaluator invalidation timing). Workflow:

1. Push → wait CI green
2. Code-reviewer agent (manual)
3. advisor() round-2 if catches applied
4. Manual `gh pr merge --squash --delete-branch`

Closes user-reported mobile regression (no GitHub issue opened — diagnosed inline this session).