### PR TITLE
feat(settings): excluded folders skip RDF indexing and SHACL validation

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -242,6 +242,8 @@ export type { IFileResolver } from "./interfaces/IFileResolver";
 export { SourceAnnotator, SOURCE_VARIABLE, type TripleSource } from "./services/SourceAnnotator";
 export {
   NoteToRDFConverter,
+  normaliseExcludedFolders,
+  isPathExcluded,
   type ExocortexInvariantCode,
   type ExocortexInvariantViolation,
 } from "./services/NoteToRDFConverter";

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -50,6 +50,57 @@ const UNPREFIXED_ASSET_FIELDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Normalise a user-supplied list of folder-exclusion prefixes:
+ *   - Treat `undefined` / non-array as empty.
+ *   - Coerce each entry through `String(...)` defensively in case JSON
+ *     persistence smuggled in a non-string (legacy settings files).
+ *   - Replace backslashes with forward slashes so Windows-style paths from
+ *     hand-edited settings still match the vault's `file.path` shape.
+ *   - Trim surrounding whitespace.
+ *   - Drop empty entries — an empty prefix matches every path, which would
+ *     silently exclude the entire vault.
+ *   - Auto-append a trailing slash when missing. A user typing `"09 Templates"`
+ *     without a slash overwhelmingly means "the folder", not "any path
+ *     starting with that string"; without the slash a literal prefix match
+ *     would also catch sibling folders like `"09 Templates Archive/"`. We
+ *     close the footgun in normalisation so neither the UI hint text nor
+ *     manual JSON edits can produce silent over-matching.
+ */
+export function normaliseExcludedFolders(
+  excludedFolders: string[] | undefined,
+): string[] {
+  if (!Array.isArray(excludedFolders)) {
+    return [];
+  }
+  return excludedFolders
+    .map((entry) => String(entry).replace(/\\/g, "/").trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => (entry.endsWith("/") ? entry : `${entry}/`));
+}
+
+/**
+ * Path-prefix match against a normalised list of excluded folders.
+ * Case-sensitive (mirrors Obsidian's case-sensitive vault paths on macOS/Linux
+ * with case-sensitive filesystems; users on case-insensitive filesystems can
+ * extend the list with both casings if needed).
+ */
+export function isPathExcluded(
+  filePath: string,
+  normalisedPrefixes: string[],
+): boolean {
+  if (normalisedPrefixes.length === 0) {
+    return false;
+  }
+  const normalisedPath = filePath.replace(/\\/g, "/");
+  for (const prefix of normalisedPrefixes) {
+    if (normalisedPath.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Service for converting Obsidian notes (frontmatter + wikilinks) to RDF triples.
  *
  * @example
@@ -499,16 +550,28 @@ export class NoteToRDFConverter {
   /**
    * Converts all notes in the vault to RDF triples.
    *
+   * @param options.excludedFolders - Optional list of vault-relative path
+   *   prefixes; any file whose path starts with one of these prefixes is
+   *   skipped without validation and without producing a warn-log entry. See
+   *   {@link convertVaultWithValidation} for full semantics.
    * @returns Array of all RDF triples from the vault
    *
    * @example
    * ```typescript
    * const allTriples = await converter.convertVault();
    * console.log(`Converted ${allTriples.length} triples`);
+   *
+   * // Skip the user-managed templates folder:
+   * await converter.convertVault({ excludedFolders: ["09 Templates/"] });
    * ```
    */
-  async convertVault(): Promise<Triple[]> {
-    const result = await this.convertVaultWithValidation({ strict: false });
+  async convertVault(
+    options: { excludedFolders?: string[] } = {},
+  ): Promise<Triple[]> {
+    const result = await this.convertVaultWithValidation({
+      strict: false,
+      excludedFolders: options.excludedFolders,
+    });
     return result.triples;
   }
 
@@ -557,6 +620,15 @@ export class NoteToRDFConverter {
    *
    * @param options - Validation options
    * @param options.strict - If true, throws on first invalid IRI instead of skipping
+   * @param options.excludedFolders - Vault-relative path prefixes whose files
+   *   are silently dropped before validation (no warn-log entry, no
+   *   `skippedFiles` record, no presence in the `summary.total` count). Used
+   *   by the Obsidian plugin to keep user-managed templates folders out of the
+   *   RDF index. Matching is case-sensitive path-prefix on the forward-slash
+   *   form of `file.path`; entries should typically end with a trailing slash
+   *   (`"09 Templates/"`) to avoid matching sibling folders sharing a name
+   *   prefix (e.g. `"09 Templates Archive/..."`). An empty / whitespace-only
+   *   prefix is ignored to prevent the entire vault from being excluded.
    * @returns Result containing triples, skipped files, and summary statistics
    *
    * @example
@@ -567,21 +639,39 @@ export class NoteToRDFConverter {
    *
    * // Strict mode: fail fast on first invalid IRI
    * await converter.convertVaultWithValidation({ strict: true });
+   *
+   * // Skip a templates folder from validation entirely
+   * await converter.convertVaultWithValidation({
+   *   excludedFolders: ["09 Templates/", "10 Drafts/"],
+   * });
    * ```
    *
    * @throws Error if strict mode is enabled and an invalid IRI is encountered
    */
   async convertVaultWithValidation(
-    options: { strict?: boolean } = {}
+    options: { strict?: boolean; excludedFolders?: string[] } = {}
   ): Promise<{
     triples: Triple[];
     skippedFiles: Array<{ path: string; reason: string }>;
     summary: { total: number; indexed: number; skipped: number };
   }> {
-    const files = this.vault.getAllFiles();
+    const allFiles = this.vault.getAllFiles();
     const allTriples: Triple[] = [];
     const skippedFiles: Array<{ path: string; reason: string }> = [];
     const strict = options.strict ?? false;
+    const excludedPrefixes = normaliseExcludedFolders(options.excludedFolders);
+
+    // Folder-level exclusion: drop files whose vault path starts with any
+    // configured prefix BEFORE validation. Excluded files are intentionally
+    // invisible to the rest of the pipeline (no warn-log, no skippedFiles
+    // record, no `summary.total` contribution) — they are treated as if they
+    // never existed in the vault. This is the user-facing escape hatch for
+    // template folders whose contents violate Exocortex invariants by design.
+    const files = excludedPrefixes.length === 0
+      ? allFiles
+      : allFiles.filter(
+          (file) => !isPathExcluded(file.path, excludedPrefixes),
+        );
 
     for (const file of files) {
       try {

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.excluded-folders.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.excluded-folders.test.ts
@@ -1,0 +1,325 @@
+import "reflect-metadata";
+import {
+  NoteToRDFConverter,
+  normaliseExcludedFolders,
+  isPathExcluded,
+} from "../../../src/services/NoteToRDFConverter";
+import {
+  IVaultAdapter,
+  IFile,
+  IFrontmatter,
+} from "../../../src/interfaces/IVaultAdapter";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+
+function createMockLogger(): jest.Mocked<ILogger> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+function file(path: string): IFile {
+  const parts = path.split("/");
+  const name = parts[parts.length - 1];
+  return {
+    path,
+    basename: name.replace(/\.md$/, ""),
+    name,
+    parent: null,
+  };
+}
+
+describe("NoteToRDFConverter — excludedFolders", () => {
+  let converter: NoteToRDFConverter;
+  let logger: jest.Mocked<ILogger>;
+  let mockVault: jest.Mocked<IVaultAdapter>;
+
+  // A frontmatter shape that would normally trigger an invariant violation:
+  // exo__Instance_class is present but empty. The converter's
+  // `validateExocortexAsset` flags this as `EMPTY_PROPERTY` and emits a
+  // "Skipping file with invariant violation" warn-log entry.
+  const invariantViolatingFrontmatter: IFrontmatter = {
+    exo__Asset_uid: "11111111-2222-3333-4444-555555555555",
+    exo__Asset_label: "Template",
+    exo__Instance_class: "",
+  };
+
+  // A well-formed frontmatter that passes validation.
+  const validFrontmatter: IFrontmatter = {
+    exo__Asset_uid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    exo__Asset_label: "Real Task",
+    exo__Instance_class: ["[[ems__Task]]"],
+  };
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    mockVault = {
+      getFrontmatter: jest.fn(),
+      getAllFiles: jest.fn(),
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      updateLinks: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+    } as jest.Mocked<IVaultAdapter>;
+    converter = new NoteToRDFConverter(mockVault, logger);
+  });
+
+  describe("normaliseExcludedFolders", () => {
+    it("returns empty array for undefined", () => {
+      expect(normaliseExcludedFolders(undefined)).toEqual([]);
+    });
+
+    it("returns empty array for non-array input", () => {
+      // Cast through `unknown` because the JSON-persisted settings file can
+      // legitimately contain non-array shapes after manual edits — the
+      // production helper must defend against this.
+      expect(
+        normaliseExcludedFolders("not-an-array" as unknown as string[]),
+      ).toEqual([]);
+    });
+
+    it("drops empty and whitespace-only entries", () => {
+      expect(
+        normaliseExcludedFolders(["09 Templates/", "", "   ", "10 Drafts/"]),
+      ).toEqual(["09 Templates/", "10 Drafts/"]);
+    });
+
+    it("trims surrounding whitespace from entries", () => {
+      expect(normaliseExcludedFolders(["  09 Templates/  "])).toEqual([
+        "09 Templates/",
+      ]);
+    });
+
+    it("converts backslashes to forward slashes", () => {
+      expect(normaliseExcludedFolders(["09 Templates\\sub\\"])).toEqual([
+        "09 Templates/sub/",
+      ]);
+    });
+
+    it("coerces non-string entries via String()", () => {
+      // Defensive: a corrupted settings JSON could carry a number where a
+      // string is expected. The helper must not crash, and the resulting
+      // prefix should be the numeric stringification — with the auto-
+      // appended trailing slash applied to the coerced form too.
+      expect(
+        normaliseExcludedFolders([123 as unknown as string, "ok/"]),
+      ).toEqual(["123/", "ok/"]);
+    });
+
+    it("auto-appends a trailing slash when missing (closes sibling-folder footgun)", () => {
+      // A user typing "09 Templates" (no slash) overwhelmingly means
+      // "the 09 Templates folder", not "any path starting with that
+      // string". Without normalisation a bare-string prefix would also
+      // match sibling folders like "09 Templates Archive/".
+      expect(
+        normaliseExcludedFolders(["09 Templates", "10 Drafts/"]),
+      ).toEqual(["09 Templates/", "10 Drafts/"]);
+    });
+
+    it("auto-append prevents sibling-folder over-match end-to-end", () => {
+      // Demonstrates the user-visible benefit of auto-append: a user entry
+      // without trailing slash MUST NOT silently exclude a sibling that
+      // shares a name prefix.
+      const prefixes = normaliseExcludedFolders(["09 Templates"]);
+      expect(isPathExcluded("09 Templates Archive/foo.md", prefixes)).toBe(
+        false,
+      );
+      expect(isPathExcluded("09 Templates/foo.md", prefixes)).toBe(true);
+    });
+  });
+
+  describe("isPathExcluded", () => {
+    it("returns false when prefix list is empty", () => {
+      expect(isPathExcluded("09 Templates/foo.md", [])).toBe(false);
+    });
+
+    it("returns true when path starts with a prefix", () => {
+      expect(
+        isPathExcluded("09 Templates/foo.md", ["09 Templates/"]),
+      ).toBe(true);
+    });
+
+    it("returns false when path only shares a name prefix without trailing slash boundary", () => {
+      // With a trailing-slash prefix this sibling MUST NOT match.
+      expect(
+        isPathExcluded("09 Templates Archive/foo.md", ["09 Templates/"]),
+      ).toBe(false);
+    });
+
+    it("is case-sensitive (mirrors Obsidian vault paths on case-sensitive FS)", () => {
+      expect(
+        isPathExcluded("09 templates/foo.md", ["09 Templates/"]),
+      ).toBe(false);
+    });
+
+    it("normalises backslashes in file paths before matching", () => {
+      // The plugin's `file.path` is forward-slash on every platform we
+      // support, but defending against a stray backslash is cheap.
+      expect(
+        isPathExcluded("09 Templates\\foo.md", ["09 Templates/"]),
+      ).toBe(true);
+    });
+
+    it("returns true if ANY prefix matches", () => {
+      expect(
+        isPathExcluded("10 Drafts/x.md", ["09 Templates/", "10 Drafts/"]),
+      ).toBe(true);
+    });
+  });
+
+  describe("convertVaultWithValidation — folder exclusion", () => {
+    it("skips files in excluded folders WITHOUT emitting an invariant-violation warn-log", async () => {
+      const templatesFile = file("09 Templates/broken.md");
+      const realFile = file("03 Knowledge/valid.md");
+
+      mockVault.getAllFiles.mockReturnValue([templatesFile, realFile]);
+      mockVault.getFrontmatter.mockImplementation((f) => {
+        if (f.path === templatesFile.path) return invariantViolatingFrontmatter;
+        if (f.path === realFile.path) return validFrontmatter;
+        return null;
+      });
+
+      const result = await converter.convertVaultWithValidation({
+        excludedFolders: ["09 Templates/"],
+      });
+
+      // 1. summary.total counts ONLY the non-excluded files: excluded files
+      //    are invisible to the validation pipeline (per the user-facing
+      //    contract — they should not appear in any "skipped X files"
+      //    diagnostic either).
+      expect(result.summary.total).toBe(1);
+      expect(result.summary.indexed).toBe(1);
+      expect(result.summary.skipped).toBe(0);
+
+      // 2. skippedFiles must not mention the templates file.
+      expect(
+        result.skippedFiles.find((s) => s.path === templatesFile.path),
+      ).toBeUndefined();
+
+      // 3. Most importantly: no "Skipping file with invariant violation"
+      //    warn-log entry — that warn drives the user-visible Notice the
+      //    feature is supposed to silence.
+      const warnCalls = logger.warn.mock.calls;
+      const invariantWarn = warnCalls.find(
+        (call) =>
+          typeof call[0] === "string" &&
+          call[0].includes("Skipping file with invariant violation") &&
+          call[0].includes(templatesFile.path),
+      );
+      expect(invariantWarn).toBeUndefined();
+    });
+
+    it("keeps validating files OUTSIDE excluded folders (no false-positive suppression)", async () => {
+      const templatesFile = file("09 Templates/broken.md");
+      // This non-excluded file ALSO has the invariant violation. We need
+      // the warn-log + skippedFiles record to still fire for it, otherwise
+      // the feature would silently swallow ALL validation errors.
+      const brokenRealFile = file("03 Knowledge/broken.md");
+
+      mockVault.getAllFiles.mockReturnValue([templatesFile, brokenRealFile]);
+      mockVault.getFrontmatter.mockImplementation((f) => {
+        if (f.path === templatesFile.path) return invariantViolatingFrontmatter;
+        if (f.path === brokenRealFile.path)
+          return invariantViolatingFrontmatter;
+        return null;
+      });
+
+      const result = await converter.convertVaultWithValidation({
+        excludedFolders: ["09 Templates/"],
+      });
+
+      expect(result.summary.total).toBe(1);
+      expect(result.summary.skipped).toBe(1);
+      expect(result.skippedFiles[0].path).toBe(brokenRealFile.path);
+
+      const warnCalls = logger.warn.mock.calls;
+      const invariantWarn = warnCalls.find(
+        (call) =>
+          typeof call[0] === "string" &&
+          call[0].includes("Skipping file with invariant violation") &&
+          call[0].includes(brokenRealFile.path),
+      );
+      expect(invariantWarn).toBeDefined();
+    });
+
+    it("treats an empty excludedFolders list as a no-op (legacy behaviour preserved)", async () => {
+      const templatesFile = file("09 Templates/broken.md");
+      mockVault.getAllFiles.mockReturnValue([templatesFile]);
+      mockVault.getFrontmatter.mockReturnValue(invariantViolatingFrontmatter);
+
+      const result = await converter.convertVaultWithValidation({});
+
+      expect(result.summary.total).toBe(1);
+      expect(result.summary.skipped).toBe(1);
+      expect(result.skippedFiles[0].path).toBe(templatesFile.path);
+    });
+
+    it("supports multiple excluded prefixes", async () => {
+      const a = file("09 Templates/x.md");
+      const b = file("10 Drafts/y.md");
+      const c = file("03 Knowledge/z.md");
+      mockVault.getAllFiles.mockReturnValue([a, b, c]);
+      mockVault.getFrontmatter.mockImplementation((f) => {
+        if (f.path === c.path) return validFrontmatter;
+        return invariantViolatingFrontmatter;
+      });
+
+      const result = await converter.convertVaultWithValidation({
+        excludedFolders: ["09 Templates/", "10 Drafts/"],
+      });
+
+      expect(result.summary.total).toBe(1);
+      expect(result.summary.indexed).toBe(1);
+      expect(result.summary.skipped).toBe(0);
+    });
+
+    it("ignores empty/whitespace prefixes to prevent excluding the entire vault", async () => {
+      const realFile = file("03 Knowledge/valid.md");
+      mockVault.getAllFiles.mockReturnValue([realFile]);
+      mockVault.getFrontmatter.mockReturnValue(validFrontmatter);
+
+      // An empty string would prefix-match every path. The normalisation
+      // helper drops it; the result here proves the converter still sees
+      // the real file and indexes it.
+      const result = await converter.convertVaultWithValidation({
+        excludedFolders: ["", "   "],
+      });
+
+      expect(result.summary.total).toBe(1);
+      expect(result.summary.indexed).toBe(1);
+    });
+  });
+
+  describe("convertVault — folder exclusion plumbing", () => {
+    it("forwards excludedFolders to convertVaultWithValidation", async () => {
+      const templatesFile = file("09 Templates/broken.md");
+      const realFile = file("03 Knowledge/valid.md");
+      mockVault.getAllFiles.mockReturnValue([templatesFile, realFile]);
+      mockVault.getFrontmatter.mockImplementation((f) => {
+        if (f.path === templatesFile.path) return invariantViolatingFrontmatter;
+        return validFrontmatter;
+      });
+
+      const triples = await converter.convertVault({
+        excludedFolders: ["09 Templates/"],
+      });
+
+      // Only the valid file contributed triples; the templates file was
+      // pre-filtered and never reached convertNote.
+      const subjects = new Set(triples.map((t) => t.subject.toString()));
+      const templatesSubject = `obsidian://vault/${encodeURI(templatesFile.path)}`;
+      expect(subjects.has(templatesSubject)).toBe(false);
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -1363,6 +1363,16 @@ export default class ExocortexPlugin extends Plugin {
     if (!this.settings.logChannels) {
       this.settings.logChannels = DEFAULT_LOG_CHANNELS;
     }
+    // Repair a corrupted `excludedFolders` shape (e.g. a hand-edited
+    // settings JSON that stored a comma-joined string instead of an
+    // array). `Object.assign` overlays default-on-missing, but a
+    // *present* non-array value would otherwise survive into the UI
+    // and break the textarea's `.join("\n")`.
+    if (!Array.isArray(this.settings.excludedFolders)) {
+      this.settings.excludedFolders = [
+        ...(DEFAULT_SETTINGS.excludedFolders ?? []),
+      ];
+    }
   }
 
   /**

--- a/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
+++ b/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
@@ -120,7 +120,12 @@ export class SPARQLApi {
    * ```
    */
   constructor(plugin: ExocortexPlugin) {
-    this.queryService = new SPARQLQueryService(plugin.app);
+    this.queryService = new SPARQLQueryService(
+      plugin.app,
+      undefined,
+      undefined,
+      plugin.settings?.excludedFolders ?? [],
+    );
   }
 
   /**

--- a/packages/obsidian-plugin/src/application/layout/LayoutService.ts
+++ b/packages/obsidian-plugin/src/application/layout/LayoutService.ts
@@ -111,7 +111,8 @@ export class LayoutService {
     app: App,
     vaultAdapter: IVaultAdapter,
     logger?: ILogger,
-    notifier?: INotificationService
+    notifier?: INotificationService,
+    excludedFolders: string[] = [],
   ) {
     this.app = app;
     this.vaultAdapter = vaultAdapter;
@@ -126,7 +127,12 @@ export class LayoutService {
 
     this.parser = new LayoutParser(vaultAdapter);
     this.queryBuilder = new LayoutQueryBuilder();
-    this.sparqlService = new SPARQLQueryService(app, this.logger, notifier);
+    this.sparqlService = new SPARQLQueryService(
+      app,
+      this.logger,
+      notifier,
+      excludedFolders,
+    );
   }
 
   /**

--- a/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
@@ -170,7 +170,10 @@ export class LayoutCodeBlockProcessor {
     if (this.layoutService === null) {
       this.layoutService = new LayoutService(
         this.plugin.app,
-        this.plugin.vaultAdapter
+        this.plugin.vaultAdapter,
+        undefined,
+        undefined,
+        this.plugin.settings?.excludedFolders ?? [],
       );
       await this.layoutService.initialize();
     }

--- a/packages/obsidian-plugin/src/application/processors/SPARQLCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/SPARQLCodeBlockProcessor.ts
@@ -384,7 +384,9 @@ export class SPARQLCodeBlockProcessor {
         this.plugin.app
       );
       const converter = new NoteToRDFConverter(vaultAdapter, LoggerFactory.create("NoteToRDFConverter"));
-      const triples = await converter.convertVault();
+      const triples = await converter.convertVault({
+        excludedFolders: this.plugin.settings?.excludedFolders ?? [],
+      });
 
       this.tripleStore = new InMemoryTripleStore();
 

--- a/packages/obsidian-plugin/src/application/services/CommandManager.ts
+++ b/packages/obsidian-plugin/src/application/services/CommandManager.ts
@@ -55,7 +55,12 @@ export class CommandManager {
     const notifier: INotificationService = new ObsidianNotificationService();
 
     const genericAssetCreationService = container.resolve(GenericAssetCreationService);
-    const sparqlQueryService = new SPARQLQueryService(this.app, logger);
+    const sparqlQueryService = new SPARQLQueryService(
+      this.app,
+      logger,
+      undefined,
+      plugin.settings?.excludedFolders ?? [],
+    );
     const ontologySchemaService = new OntologySchemaService(sparqlQueryService);
     const classDiscoveryService = new ClassDiscoveryService(sparqlQueryService);
 

--- a/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
+++ b/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
@@ -29,7 +29,8 @@ export class SPARQLQueryService {
   constructor(
     app: App,
     logger?: ILogger,
-    notifier?: INotificationService
+    notifier?: INotificationService,
+    excludedFolders: string[] = [],
   ) {
     const defaultLogger = LoggerFactory.create("SPARQLQueryService");
     this.logger = logger || {
@@ -53,7 +54,7 @@ export class SPARQLQueryService {
       notifier || defaultNotifier
     );
 
-    this.indexer = new VaultRDFIndexer(app, this.logger, notifier);
+    this.indexer = new VaultRDFIndexer(app, this.logger, notifier, excludedFolders);
     this.parser = new ExoQLParser();
     this.translator = new ExoQLAlgebraTranslator();
     this.optimizer = new AlgebraOptimizer();

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -146,17 +146,33 @@ export interface ExocortexSettings {
    */
   enablePropertiesLabelPatch: boolean;
   /**
-   * Folders whose markdown files are excluded from RDF indexing and SHACL-lite
-   * validation. Matching is path-prefix: a file is excluded when its vault path
-   * starts with any of the listed prefixes (case-sensitive, normalised to use
-   * forward slashes; a trailing slash is recommended to avoid matching sibling
-   * folders that share a name prefix). Excluded files never enter
-   * `NoteToRDFConverter.convertVaultWithValidation`, so they produce no
-   * "Skipping file with invariant violation" Notices and no warn-log entries.
+   * Folders whose markdown files are excluded from the cold-start RDF
+   * indexing walk and the per-file live-edit indexing path, and therefore
+   * from the SHACL-lite validation that runs as part of that walk.
+   * Matching is path-prefix on the forward-slash form of `file.path`,
+   * case-sensitive. Entries are auto-normalised to end with a trailing
+   * slash so a user-typed `"09 Templates"` cannot silently exclude
+   * sibling folders like `"09 Templates Archive/"`. Excluded files never
+   * enter `NoteToRDFConverter.convertVaultWithValidation`, so they
+   * produce no "Skipping file with invariant violation" Notices and no
+   * warn-log entries.
    *
-   * Default: `["09 Templates/"]` — Obsidian's conventional templates folder,
-   * whose files are known to violate Exocortex invariants by design (template
-   * placeholders, missing required properties).
+   * Default: `["09 Templates/"]` — Obsidian's conventional templates
+   * folder, whose files are known to violate Exocortex invariants by
+   * design (template placeholders, missing required properties).
+   *
+   * Scope caveats (called out so future contributors do not over-promise
+   * to users in UI copy):
+   *   - The list is snapshotted by every component that builds its own
+   *     indexer (`SPARQLApi`, `CommandManager`, `LayoutService`). Editing
+   *     the list in Settings only takes effect after reloading Obsidian.
+   *     `SPARQLCodeBlockProcessor` re-reads the current setting on each
+   *     render and is therefore self-healing.
+   *   - `LazyAssetGraphLoader` (the per-render lazy walker) is NOT gated
+   *     on this list. Opening an excluded-folder file directly may push
+   *     its triples into the in-memory store, but `convertNote` does not
+   *     emit the "invariant violation" warn-log, so the user-facing
+   *     Notice stays silenced.
    */
   excludedFolders: string[];
   // RFC c7da0bca Phase 3c-3 — dropped `exocmdBindingsCacheEnabledOnMobile`

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -145,6 +145,20 @@ export interface ExocortexSettings {
    * takes effect immediately, no plugin reload required.
    */
   enablePropertiesLabelPatch: boolean;
+  /**
+   * Folders whose markdown files are excluded from RDF indexing and SHACL-lite
+   * validation. Matching is path-prefix: a file is excluded when its vault path
+   * starts with any of the listed prefixes (case-sensitive, normalised to use
+   * forward slashes; a trailing slash is recommended to avoid matching sibling
+   * folders that share a name prefix). Excluded files never enter
+   * `NoteToRDFConverter.convertVaultWithValidation`, so they produce no
+   * "Skipping file with invariant violation" Notices and no warn-log entries.
+   *
+   * Default: `["09 Templates/"]` — Obsidian's conventional templates folder,
+   * whose files are known to violate Exocortex invariants by design (template
+   * placeholders, missing required properties).
+   */
+  excludedFolders: string[];
   // RFC c7da0bca Phase 3c-3 — dropped `exocmdBindingsCacheEnabledOnMobile`
   // setting. The indexer it gated has been deleted (Phase 3c-2); the
   // toggle had no remaining effect. Existing user settings JSON
@@ -176,4 +190,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   enableSparqlAutoExecute: false,
   enableShaclValidation: false,
   enablePropertiesLabelPatch: true,
+  excludedFolders: ["09 Templates/"],
 };

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -11,6 +11,8 @@ import {
   Namespace,
   NetworkError,
   ServiceError,
+  isPathExcluded,
+  normaliseExcludedFolders,
   type ILogger,
   type INotificationService,
   type IFile,
@@ -27,11 +29,19 @@ export class VaultRDFIndexer {
   private eventRefs: EventRef[] = [];
   private errorHandler: ApplicationErrorHandler;
   private logger: ILogger;
+  /**
+   * Snapshot of vault-relative folder prefixes whose files must not be
+   * indexed. The plugin's settings tab passes the current list through the
+   * constructor; this instance keeps a frozen copy so per-event handlers
+   * (modify/rename/create) honour the same set as the initial walk.
+   */
+  private readonly excludedFolders: string[];
 
   constructor(
     private app: App,
     logger?: ILogger,
-    notifier?: INotificationService
+    notifier?: INotificationService,
+    excludedFolders: string[] = [],
   ) {
     this.tripleStore = new InMemoryTripleStore();
     this.vaultAdapter = new ObsidianVaultAdapter(
@@ -40,6 +50,7 @@ export class VaultRDFIndexer {
       app
     );
     this.converter = new NoteToRDFConverter(this.vaultAdapter, logger || LoggerFactory.create("NoteToRDFConverter"));
+    this.excludedFolders = normaliseExcludedFolders(excludedFolders);
 
     const defaultLogger = LoggerFactory.create("VaultRDFIndexer");
     this.logger = logger || {
@@ -71,7 +82,9 @@ export class VaultRDFIndexer {
 
     try {
       const triples = await this.errorHandler.executeWithRetry(
-        async () => this.converter.convertVault(),
+        async () => this.converter.convertVault({
+          excludedFolders: this.excludedFolders,
+        }),
         { context: "VaultRDFIndexer.initialize", operation: "convertVault" }
       );
       await this.tripleStore.addAll(triples);
@@ -171,6 +184,18 @@ export class VaultRDFIndexer {
       return;
     }
 
+    // Honour folder-exclusion settings for live-edit events too. Without
+    // this guard a file inside an excluded folder would still be indexed
+    // when the user edited it (the initial walk in `initialize()` excludes
+    // it, but `vault.on("modify")` would re-introduce it). To keep the
+    // store consistent with the configured exclusion set we also remove
+    // any stale triples that may exist for the path (e.g. files that were
+    // indexed before the user added their folder to the exclusion list).
+    if (isPathExcluded(file.path, this.excludedFolders)) {
+      await this.removeFileTriples(file.path);
+      return;
+    }
+
     await this.errorHandler.executeWithRetry(
       async () => {
         const fileIRI = new IRI(`obsidian://vault/${encodeURI(file.path)}`);
@@ -221,7 +246,9 @@ export class VaultRDFIndexer {
     await this.errorHandler.executeWithRetry(
       async () => {
         await this.tripleStore.clear();
-        const triples = await this.converter.convertVault();
+        const triples = await this.converter.convertVault({
+          excludedFolders: this.excludedFolders,
+        });
         await this.tripleStore.addAll(triples);
         await this.runInference();
       },

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -244,6 +244,10 @@ export class ExocortexSettingTab extends PluginSettingTab {
           }),
       );
 
+    // Excluded folders section — files inside these folders are skipped
+    // entirely by the RDF indexer and SHACL-lite validation.
+    this.renderExcludedFoldersSection(containerEl);
+
     // Logging section
     this.renderLogChannelsSection(containerEl);
 
@@ -364,6 +368,69 @@ export class ExocortexSettingTab extends PluginSettingTab {
       li.createEl("code", { text: code });
       li.appendText(` - ${desc}`);
     }
+  }
+
+  /**
+   * Render the "Excluded folders" section.
+   *
+   * Each non-empty line in the textarea is treated as a vault-relative
+   * path-prefix. Files whose path starts with any of these prefixes are
+   * excluded from RDF indexing AND SHACL-lite validation, so they never
+   * produce the "Skipping file with invariant violation" Notice.
+   *
+   * The default `"09 Templates/"` matches Obsidian's conventional templates
+   * folder, whose contents typically violate Exocortex invariants by design.
+   * Users can add, edit, or remove entries; an empty textarea clears all
+   * exclusions.
+   *
+   * Changes take effect on the next vault re-index (full Obsidian reload or
+   * manual cache refresh). A reload Notice could be added later, but is not
+   * required for correctness — live edits to files outside excluded folders
+   * keep working immediately because `VaultRDFIndexer.updateFile` consults
+   * the prefix list it captured at construction time.
+   */
+  private renderExcludedFoldersSection(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("Excluded folders").setHeading();
+
+    const desc = containerEl.createDiv({ cls: "setting-item-description" });
+    desc.appendText(
+      "Vault-relative folder prefixes whose files are excluded from RDF " +
+        "indexing and SHACL-lite validation. Files inside these folders do " +
+        "NOT trigger the \"Skipping file with invariant violation\" Notice, " +
+        "even when their frontmatter is incomplete by design (for example, " +
+        "Obsidian template files). One prefix per line. Path-prefix match " +
+        "is case-sensitive — use a trailing slash (\"09 Templates/\") to " +
+        "avoid matching sibling folders that share a name prefix. Changes " +
+        "take effect on next vault reload.",
+    );
+
+    // Ensure excludedFolders exists (older settings JSON may not have the key)
+    if (!Array.isArray(this.plugin.settings.excludedFolders)) {
+      this.plugin.settings.excludedFolders = [];
+    }
+
+    new Setting(containerEl)
+      .setName("Folder prefixes")
+      .setDesc("One folder prefix per line (e.g. \"09 Templates/\")")
+      .addTextArea((textArea) => {
+        textArea
+          .setPlaceholder("09 templates/\n10 drafts/")
+          .setValue(this.plugin.settings.excludedFolders.join("\n"))
+          .onChange(async (value) => {
+            // Split on any line break, trim each entry, drop empties so a
+            // trailing newline or accidental blank line does not register
+            // as "exclude everything". Persisted form is the cleaned array.
+            const folders = value
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter((line) => line.length > 0);
+            this.plugin.settings.excludedFolders = folders;
+            await this.plugin.saveSettings();
+          });
+        // A slightly taller textarea reads better for a list of paths.
+        textArea.inputEl.rows = 4;
+        textArea.inputEl.cols = 40;
+      });
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -394,14 +394,17 @@ export class ExocortexSettingTab extends PluginSettingTab {
 
     const desc = containerEl.createDiv({ cls: "setting-item-description" });
     desc.appendText(
-      "Vault-relative folder prefixes whose files are excluded from RDF " +
-        "indexing and SHACL-lite validation. Files inside these folders do " +
-        "NOT trigger the \"Skipping file with invariant violation\" Notice, " +
-        "even when their frontmatter is incomplete by design (for example, " +
-        "Obsidian template files). One prefix per line. Path-prefix match " +
-        "is case-sensitive — use a trailing slash (\"09 Templates/\") to " +
-        "avoid matching sibling folders that share a name prefix. Changes " +
-        "take effect on next vault reload.",
+      "Vault-relative folder prefixes whose files are excluded from the " +
+        "cold-start RDF indexing walk and live-edit indexing. Files inside " +
+        "these folders do NOT trigger the \"Skipping file with invariant " +
+        "violation\" Notice, even when their frontmatter is incomplete by " +
+        "design (for example, Obsidian template files). One prefix per " +
+        "line; case-sensitive path-prefix match. A trailing slash is " +
+        "auto-appended on save so a sibling folder sharing a name prefix " +
+        "is not silently excluded. Reload Obsidian after editing the list — " +
+        "indexer, command manager, and layout service each snapshot this " +
+        "list at startup. SPARQL code-blocks honour the current setting on " +
+        "next render.",
     );
 
     // Ensure excludedFolders exists (older settings JSON may not have the key)

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -1,4 +1,5 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
+import { normaliseExcludedFolders } from "exocortex";
 import type ExocortexPlugin from "@plugin/ExocortexPlugin";
 import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
 import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
@@ -420,14 +421,17 @@ export class ExocortexSettingTab extends PluginSettingTab {
           .setPlaceholder("09 templates/\n10 drafts/")
           .setValue(this.plugin.settings.excludedFolders.join("\n"))
           .onChange(async (value) => {
-            // Split on any line break, trim each entry, drop empties so a
-            // trailing newline or accidental blank line does not register
-            // as "exclude everything". Persisted form is the cleaned array.
-            const folders = value
-              .split(/\r?\n/)
-              .map((line) => line.trim())
-              .filter((line) => line.length > 0);
-            this.plugin.settings.excludedFolders = folders;
+            // Persist the FULLY-NORMALISED list so storage matches what the
+            // runtime actually uses (trailing slashes auto-appended,
+            // whitespace stripped, empties dropped). Without this round-trip
+            // the user could type `"09 Templates"` and on reopen still see
+            // `"09 Templates"` while the converter is silently treating it
+            // as `"09 Templates/"` — confusing if the user later tries to
+            // exclude a `"09 Templates2/"`-style sibling and wonders why
+            // their entry "looks different" than what is being matched.
+            const parsed = value.split(/\r?\n/);
+            this.plugin.settings.excludedFolders =
+              normaliseExcludedFolders(parsed);
             await this.plugin.saveSettings();
           });
         // A slightly taller textarea reads better for a list of paths.

--- a/packages/obsidian-plugin/src/types/index.ts
+++ b/packages/obsidian-plugin/src/types/index.ts
@@ -63,6 +63,7 @@ export interface ExocortexPluginInterface extends Plugin {
     showArchivedAssets?: boolean;
     showEffortArea?: boolean;
     showEffortVotes?: boolean;
+    excludedFolders?: string[];
   };
   vaultAdapter: IVaultAdapter;
   themeResolver?: ThemeResolver;

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -105,6 +105,18 @@ describe("ExocortexSettingTab", () => {
           callback(text);
           return setting;
         }),
+        addTextArea: jest.fn().mockImplementation((callback) => {
+          const textArea = {
+            setPlaceholder: jest.fn().mockReturnThis(),
+            setValue: jest.fn().mockReturnThis(),
+            onChange: jest.fn().mockReturnThis(),
+            // `inputEl` is mutated by the production code (rows/cols).
+            // A plain object is enough — production code only sets properties.
+            inputEl: {} as Record<string, unknown>,
+          };
+          callback(textArea);
+          return setting;
+        }),
         addButton: jest.fn().mockImplementation((callback) => {
           const button = {
             setButtonText: jest.fn().mockReturnThis(),
@@ -130,7 +142,8 @@ describe("ExocortexSettingTab", () => {
       // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 1 enableShaclValidation toggle (P1.12) + 1 enablePropertiesLabelPatch toggle (RFC-030) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 29
       // RFC c7da0bca Phase 3c-3 — deleted `exocmdBindingsCacheEnabledOnMobile` toggle (-1) once its indexer was deleted in 3c-2.
       // Log channels section: 1 heading + 4 log level rows = 5
-      expect(MockSetting).toHaveBeenCalledTimes(29);
+      // Excluded folders section (this feature): 1 heading + 1 textarea row = +2 → 31
+      expect(MockSetting).toHaveBeenCalledTimes(31);
     });
 
     it("should render layout visibility toggle as first setting", () => {
@@ -172,6 +185,16 @@ describe("ExocortexSettingTab", () => {
               onChange: jest.fn().mockReturnThis(),
             };
             callback(text);
+            return setting;
+          }),
+          addTextArea: jest.fn().mockImplementation((callback) => {
+            const textArea = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+              inputEl: {} as Record<string, unknown>,
+            };
+            callback(textArea);
             return setting;
           }),
           addButton: jest.fn().mockImplementation((callback) => {
@@ -242,6 +265,16 @@ describe("ExocortexSettingTab", () => {
               onChange: jest.fn().mockReturnThis(),
             };
             callback(text);
+            return setting;
+          }),
+          addTextArea: jest.fn().mockImplementation((callback) => {
+            const textArea = {
+              setPlaceholder: jest.fn().mockReturnThis(),
+              setValue: jest.fn().mockReturnThis(),
+              onChange: jest.fn().mockReturnThis(),
+              inputEl: {} as Record<string, unknown>,
+            };
+            callback(textArea);
             return setting;
           }),
           addButton: jest.fn().mockImplementation((callback) => {

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.excluded-folders.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.excluded-folders.test.ts
@@ -9,45 +9,42 @@ import {
 import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
 
 // Mock `exocortex` wholesale (matches the sibling VaultRDFIndexer.test.ts
-// strategy), then re-export the real `isPathExcluded` / `normaliseExcludedFolders`
-// helpers so the indexer's `updateFile` guard exercises production behaviour
-// rather than a mock identity. Replicating the real helpers inline is short
-// enough that we avoid a `requireActual` import (which destabilised the rest
-// of the mock surface).
-jest.mock("exocortex", () => ({
-  InMemoryTripleStore: jest.fn(),
-  NoteToRDFConverter: jest.fn(),
-  ApplicationErrorHandler: jest.fn(),
-  RDFSInferenceEngine: jest.fn(),
-  NonInheritablePropertyRegistry: jest.fn(),
-  PropertyCardinalityRegistry: jest.fn(),
-  PrototypeChainMaterializer: jest.fn(),
-  INFERRED_GRAPH: "https://exocortex.my/graph/inferred",
-  Namespace: { EXO: { term: jest.fn() } },
-  NetworkError: class NetworkError extends Error {},
-  ServiceError: class ServiceError extends Error {
-    constructor(msg: string, public meta?: unknown) {
-      super(msg);
-    }
-  },
-  IRI: class IRI {
-    constructor(public value: string) {}
-    toString() {
-      return this.value;
-    }
-  },
-  isPathExcluded: (filePath: string, prefixes: string[]): boolean => {
-    if (prefixes.length === 0) return false;
-    const norm = filePath.replace(/\\/g, "/");
-    return prefixes.some((p) => norm.startsWith(p));
-  },
-  normaliseExcludedFolders: (entries: string[] | undefined): string[] => {
-    if (!Array.isArray(entries)) return [];
-    return entries
-      .map((e) => String(e).replace(/\\/g, "/").trim())
-      .filter((e) => e.length > 0);
-  },
-}));
+// strategy) but pin `isPathExcluded` / `normaliseExcludedFolders` to the
+// PRODUCTION implementations via `jest.requireActual`. Replicating helpers
+// inline drifts from production semantics over time — e.g. the trailing-
+// slash auto-append landed in `normaliseExcludedFolders` after this suite
+// was written, and an inline copy without it would let sibling-folder
+// over-match silently slip back in (see ~/.claude/rules/test-fixture-
+// realism.md). The other exports are stubs because the indexer pulls them
+// in for types or unrelated subsystems we don't exercise here.
+jest.mock("exocortex", () => {
+  const actual = jest.requireActual("exocortex");
+  return {
+    InMemoryTripleStore: jest.fn(),
+    NoteToRDFConverter: jest.fn(),
+    ApplicationErrorHandler: jest.fn(),
+    RDFSInferenceEngine: jest.fn(),
+    NonInheritablePropertyRegistry: jest.fn(),
+    PropertyCardinalityRegistry: jest.fn(),
+    PrototypeChainMaterializer: jest.fn(),
+    INFERRED_GRAPH: "https://exocortex.my/graph/inferred",
+    Namespace: { EXO: { term: jest.fn() } },
+    NetworkError: class NetworkError extends Error {},
+    ServiceError: class ServiceError extends Error {
+      constructor(msg: string, public meta?: unknown) {
+        super(msg);
+      }
+    },
+    IRI: class IRI {
+      constructor(public value: string) {}
+      toString() {
+        return this.value;
+      }
+    },
+    isPathExcluded: actual.isPathExcluded,
+    normaliseExcludedFolders: actual.normaliseExcludedFolders,
+  };
+});
 jest.mock("../../../src/adapters/ObsidianVaultAdapter");
 
 describe("VaultRDFIndexer — excludedFolders plumbing", () => {
@@ -174,6 +171,24 @@ describe("VaultRDFIndexer — excludedFolders plumbing", () => {
         "  09 Templates/  ",
         "",
         "   ",
+        "10 Drafts/",
+      ]);
+
+      await indexer.initialize();
+
+      expect(mockConverter.convertVault).toHaveBeenCalledWith({
+        excludedFolders: ["09 Templates/", "10 Drafts/"],
+      });
+    });
+
+    it("auto-appends a trailing slash to user-typed entries without one", async () => {
+      // Regression guard — exercises that `requireActual` for
+      // `normaliseExcludedFolders` brings the production auto-append rule
+      // into this suite. A unit-of-production-truth test: if the helper
+      // ever loses auto-append, this fails here (sibling-folder over-match
+      // would slip back in silently otherwise).
+      const indexer = new VaultRDFIndexer(mockApp, undefined, undefined, [
+        "09 Templates",
         "10 Drafts/",
       ]);
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.excluded-folders.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.excluded-folders.test.ts
@@ -1,0 +1,283 @@
+import { VaultRDFIndexer } from "../../../src/infrastructure/VaultRDFIndexer";
+import type { App, TFile, EventRef } from "obsidian";
+import {
+  InMemoryTripleStore,
+  NoteToRDFConverter,
+  ApplicationErrorHandler,
+  Namespace,
+} from "exocortex";
+import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
+
+// Mock `exocortex` wholesale (matches the sibling VaultRDFIndexer.test.ts
+// strategy), then re-export the real `isPathExcluded` / `normaliseExcludedFolders`
+// helpers so the indexer's `updateFile` guard exercises production behaviour
+// rather than a mock identity. Replicating the real helpers inline is short
+// enough that we avoid a `requireActual` import (which destabilised the rest
+// of the mock surface).
+jest.mock("exocortex", () => ({
+  InMemoryTripleStore: jest.fn(),
+  NoteToRDFConverter: jest.fn(),
+  ApplicationErrorHandler: jest.fn(),
+  RDFSInferenceEngine: jest.fn(),
+  NonInheritablePropertyRegistry: jest.fn(),
+  PropertyCardinalityRegistry: jest.fn(),
+  PrototypeChainMaterializer: jest.fn(),
+  INFERRED_GRAPH: "https://exocortex.my/graph/inferred",
+  Namespace: { EXO: { term: jest.fn() } },
+  NetworkError: class NetworkError extends Error {},
+  ServiceError: class ServiceError extends Error {
+    constructor(msg: string, public meta?: unknown) {
+      super(msg);
+    }
+  },
+  IRI: class IRI {
+    constructor(public value: string) {}
+    toString() {
+      return this.value;
+    }
+  },
+  isPathExcluded: (filePath: string, prefixes: string[]): boolean => {
+    if (prefixes.length === 0) return false;
+    const norm = filePath.replace(/\\/g, "/");
+    return prefixes.some((p) => norm.startsWith(p));
+  },
+  normaliseExcludedFolders: (entries: string[] | undefined): string[] => {
+    if (!Array.isArray(entries)) return [];
+    return entries
+      .map((e) => String(e).replace(/\\/g, "/").trim())
+      .filter((e) => e.length > 0);
+  },
+}));
+jest.mock("../../../src/adapters/ObsidianVaultAdapter");
+
+describe("VaultRDFIndexer — excludedFolders plumbing", () => {
+  let mockApp: App;
+  let mockTripleStore: jest.Mocked<InMemoryTripleStore>;
+  let mockConverter: jest.Mocked<NoteToRDFConverter>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (
+      ApplicationErrorHandler as jest.MockedClass<
+        typeof ApplicationErrorHandler
+      >
+    ).mockImplementation(
+      () =>
+        ({
+          executeWithRetry: jest
+            .fn()
+            .mockImplementation(async (operation: () => Promise<unknown>) => {
+              return await operation();
+            }),
+          handle: jest.fn(),
+        }) as any,
+    );
+
+    mockApp = {
+      vault: {
+        on: jest.fn(),
+        off: jest.fn(),
+        offref: jest.fn(),
+        getAllFiles: jest.fn().mockReturnValue([]),
+      },
+      metadataCache: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
+    } as unknown as App;
+
+    mockTripleStore = {
+      addAll: jest.fn().mockResolvedValue(undefined),
+      clear: jest.fn().mockResolvedValue(undefined),
+      clearGraph: jest.fn().mockResolvedValue(undefined),
+      match: jest.fn().mockResolvedValue([]),
+      removeAll: jest.fn().mockResolvedValue(0),
+    } as any;
+
+    mockConverter = {
+      convertVault: jest.fn().mockResolvedValue([]),
+      convertNote: jest.fn().mockResolvedValue([]),
+    } as any;
+
+    (
+      InMemoryTripleStore as jest.MockedClass<typeof InMemoryTripleStore>
+    ).mockImplementation(() => mockTripleStore);
+    (
+      NoteToRDFConverter as jest.MockedClass<typeof NoteToRDFConverter>
+    ).mockImplementation(() => mockConverter);
+    (
+      ObsidianVaultAdapter as jest.MockedClass<typeof ObsidianVaultAdapter>
+    ).mockImplementation(() => ({}) as any);
+
+    // RDFS inference scaffolding — VaultRDFIndexer always runs an inference
+    // pass after a full vault walk; these mocks just need to expose the
+    // method names so the await-chain resolves.
+    const {
+      RDFSInferenceEngine,
+      NonInheritablePropertyRegistry,
+      PropertyCardinalityRegistry,
+      PrototypeChainMaterializer,
+    } = jest.requireMock("exocortex") as {
+      RDFSInferenceEngine: jest.Mock;
+      NonInheritablePropertyRegistry: jest.Mock;
+      PropertyCardinalityRegistry: jest.Mock;
+      PrototypeChainMaterializer: jest.Mock;
+    };
+    RDFSInferenceEngine.mockImplementation(() => ({
+      materialize: jest.fn().mockResolvedValue(undefined),
+    }));
+    NonInheritablePropertyRegistry.mockImplementation(() => ({
+      initialize: jest.fn().mockResolvedValue(undefined),
+    }));
+    PropertyCardinalityRegistry.mockImplementation(() => ({
+      initialize: jest.fn().mockResolvedValue(undefined),
+    }));
+    PrototypeChainMaterializer.mockImplementation(() => ({
+      materialize: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    const mockPrototypePredicate = {
+      value: "https://exocortex.my/ontology/exo#Asset_prototype",
+    };
+    (Namespace as any).EXO = {
+      term: jest.fn().mockReturnValue(mockPrototypePredicate),
+    };
+  });
+
+  describe("initialize", () => {
+    it("forwards configured excludedFolders to converter.convertVault", async () => {
+      const indexer = new VaultRDFIndexer(mockApp, undefined, undefined, [
+        "09 Templates/",
+        "10 Drafts/",
+      ]);
+
+      await indexer.initialize();
+
+      expect(mockConverter.convertVault).toHaveBeenCalledWith({
+        excludedFolders: ["09 Templates/", "10 Drafts/"],
+      });
+    });
+
+    it("defaults to an empty list when no excludedFolders argument is passed", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+
+      await indexer.initialize();
+
+      expect(mockConverter.convertVault).toHaveBeenCalledWith({
+        excludedFolders: [],
+      });
+    });
+
+    it("normalises the constructor argument (drops empty entries, trims whitespace)", async () => {
+      const indexer = new VaultRDFIndexer(mockApp, undefined, undefined, [
+        "  09 Templates/  ",
+        "",
+        "   ",
+        "10 Drafts/",
+      ]);
+
+      await indexer.initialize();
+
+      expect(mockConverter.convertVault).toHaveBeenCalledWith({
+        excludedFolders: ["09 Templates/", "10 Drafts/"],
+      });
+    });
+  });
+
+  describe("refresh", () => {
+    it("forwards configured excludedFolders to converter.convertVault", async () => {
+      const indexer = new VaultRDFIndexer(mockApp, undefined, undefined, [
+        "09 Templates/",
+      ]);
+
+      await indexer.refresh();
+
+      expect(mockConverter.convertVault).toHaveBeenCalledWith({
+        excludedFolders: ["09 Templates/"],
+      });
+    });
+  });
+
+  describe("updateFile", () => {
+    function makeFile(path: string): TFile {
+      return {
+        path,
+        extension: "md",
+        basename: path.split("/").pop()!.replace(/\.md$/, ""),
+        name: path.split("/").pop()!,
+      } as unknown as TFile;
+    }
+
+    it("skips convertNote for files inside an excluded folder", async () => {
+      const indexer = new VaultRDFIndexer(mockApp, undefined, undefined, [
+        "09 Templates/",
+      ]);
+
+      const templatesFile = makeFile("09 Templates/some-template.md");
+
+      await indexer.updateFile(templatesFile);
+
+      // The whole point of the feature: a per-file event for an excluded
+      // folder must NOT push the file through the converter (which is what
+      // emits the "Skipping file with invariant violation" warn-log).
+      expect(mockConverter.convertNote).not.toHaveBeenCalled();
+    });
+
+    it("still calls convertNote for files OUTSIDE excluded folders", async () => {
+      const indexer = new VaultRDFIndexer(mockApp, undefined, undefined, [
+        "09 Templates/",
+      ]);
+
+      const realFile = makeFile("03 Knowledge/real-task.md");
+
+      await indexer.updateFile(realFile);
+
+      expect(mockConverter.convertNote).toHaveBeenCalledTimes(1);
+      // Match by `.path` rather than reference equality — the indexer
+      // currently passes `file as IFile` directly, but a defensive
+      // path-based check tolerates future wrapping (e.g. an adapter that
+      // produces a fresh IFile object).
+      const passed = mockConverter.convertNote.mock.calls[0][0] as {
+        path: string;
+      };
+      expect(passed.path).toBe(realFile.path);
+    });
+
+    it("removes stale triples when an excluded-folder file is edited", async () => {
+      // Scenario: a file was indexed earlier (before the user added its
+      // folder to the exclusion list). When the user next edits the file,
+      // the indexer should evict its stale triples so SPARQL queries no
+      // longer see them — even though we no longer re-convert.
+      const indexer = new VaultRDFIndexer(mockApp, undefined, undefined, [
+        "09 Templates/",
+      ]);
+
+      const templatesFile = makeFile("09 Templates/old-asset.md");
+
+      await indexer.updateFile(templatesFile);
+
+      expect(mockTripleStore.match).toHaveBeenCalled();
+      // removeAll is invoked even with an empty `match` result; the
+      // important contract is that the indexer DID attempt to evict.
+      expect(mockTripleStore.removeAll).toHaveBeenCalled();
+    });
+
+    it("ignores non-markdown files regardless of folder exclusion", async () => {
+      const indexer = new VaultRDFIndexer(mockApp, undefined, undefined, [
+        "09 Templates/",
+      ]);
+      const pngFile = {
+        path: "03 Knowledge/picture.png",
+        extension: "png",
+      } as unknown as TFile;
+
+      await indexer.updateFile(pngFile);
+
+      expect(mockConverter.convertNote).not.toHaveBeenCalled();
+      // Also the eviction path must not fire for non-md files — they were
+      // never indexed in the first place.
+      expect(mockTripleStore.removeAll).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/services/SPARQLQueryService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/services/SPARQLQueryService.test.ts
@@ -81,7 +81,8 @@ describe("SPARQLQueryService", () => {
       expect(VaultRDFIndexer).toHaveBeenCalledWith(
         mockApp,
         expect.any(Object), // logger (default or provided)
-        undefined           // notifier (undefined when not provided to SPARQLQueryService)
+        undefined,          // notifier (undefined when not provided to SPARQLQueryService)
+        []                  // excludedFolders (defaults to [] when no setting is passed)
       );
     });
   });


### PR DESCRIPTION
## Summary

- New per-vault setting **Excluded folders** (Settings → Exocortex). Files inside any listed folder prefix are skipped before SHACL-lite validation, so the *Skipping file with invariant violation* Notice no longer fires on every Obsidian reload for templates / drafts / scratch folders.
- Default `excludedFolders: [\"09 Templates/\"]` covers Obsidian's conventional templates folder out of the box. Empty list = legacy behaviour preserved.
- Match is path-prefix on the forward-slash form of \`file.path\`, case-sensitive. **Auto-appends a trailing slash** so a user-typed \`\"09 Templates\"\` cannot silently exclude \`\"09 Templates Archive/\"\`. Empty entries are dropped to prevent excluding the entire vault.

## Why

\`NoteToRDFConverter.convertVaultWithValidation\` flags files with missing / malformed required properties as \"Invariant violation\" and routes the warn through \`logger.warn\` → Notice channel (per \`logChannels\` settings). For folders whose files violate invariants **by design** (Obsidian templates with placeholder frontmatter), this produces a wall of red Notices on every reload. The user explicitly asked for a settings-driven escape hatch.

## Plumbing

- \`NoteToRDFConverter\`: \`convertVault(options?)\` and \`convertVaultWithValidation(options)\` accept \`excludedFolders\`. Excluded files are filtered *before* validation — they're invisible to \`summary.total\`, \`skippedFiles\`, and the warn-log.
- \`VaultRDFIndexer\`: new optional constructor arg, snapshotted (frozen on construction). Passes to \`convertVault\` on \`initialize()\`/\`refresh()\`. \`updateFile\` adds a guard: live-edit events for excluded files don't re-introduce them; any stale triples are evicted.
- \`SPARQLQueryService\`, \`LayoutService\`, \`LayoutCodeBlockProcessor\`, \`SPARQLCodeBlockProcessor\`, \`SPARQLApi\`, \`CommandManager\`: all pass \`plugin.settings.excludedFolders\` through.
- \`ExocortexSettingTab\`: new \"Excluded folders\" section with a textarea (one prefix per line) and an explanatory description.

## Test plan

- [x] 20 new unit tests in \`NoteToRDFConverter.excluded-folders.test.ts\` (helpers + end-to-end pipeline)
- [x] 8 new unit tests in \`VaultRDFIndexer.excluded-folders.test.ts\` (constructor forwarding + updateFile guard + stale eviction)
- [x] Revert→fail / restore→pass discipline verified on the production filter (3 critical suppression tests fail without the fix) and on the \`updateFile\` guard (the no-convertNote assertion fails without it)
- [x] Sibling-folder over-match guard test (\`isPathExcluded(\"09 Templates Archive/foo.md\", normalise([\"09 Templates\"]))\` → \`false\`)
- [x] \`npm run typecheck\` green, \`npm run lint\` green
- [x] Full plugin unit suite (237 suites, 4917 passed)
- [x] Pre-existing failures in \`grounding-type-vault-fixture-parity\` confirmed independently of this PR (reproduced on \`origin/main\` HEAD via \`git stash\`) — unrelated

UI smoke not performed automatically — manually verify by reloading Obsidian with a \`09 Templates/\` folder containing intentionally-broken assets and confirming the Notice does not fire.

## Known scope limitations (called out for reviewer)

1. **Settings hot-reload:** \`VaultRDFIndexer\` captures the prefix list at construction. Changing the list in Settings takes effect on the next vault reload. Live edits to non-excluded files keep working immediately. UI description states this.
2. **LazyAssetGraphLoader gap:** the per-render lazy walker (\`convertNote(file)\`) is not gated on the exclusion list. \`convertNote\` does not emit the \"invariant violation\" warn-log, so the user-facing Notice is already silenced. Triples for an excluded-folder file may still appear in the store if a user opens it directly. Not blocking the original ask — tracked as follow-up.

## Auto-merge discipline

\`NoteToRDFConverter.ts\` is on the critical-path file list per \`CLAUDE.md\` (\"Auto-merge discipline\"). I will **NOT** use \`gh pr merge --auto\`. Workflow per repo guidelines:
1. Wait for CI green
2. Run code-reviewer agent
3. Apply CRITICAL / HIGH fixes
4. \`advisor()\` round-2
5. Manual \`gh pr merge --squash --delete-branch\`