### PR TITLE
feat(create_instance): one-click flow — openInSameTab + labelTemplate + $nowCompact (RFC ce27e55d)

### DIFF
--- a/packages/exocortex/src/domain/constants/CommandProperty.ts
+++ b/packages/exocortex/src/domain/constants/CommandProperty.ts
@@ -20,6 +20,11 @@ export const CommandProperty = {
   SUCCESS_MESSAGE: "exocmd__Command_successMessage",
   /** Category for grouping: "maintenance", "status", "planning" */
   CATEGORY: "exocmd__Command_category",
+  /**
+   * RFC ce27e55d: when true (`xsd:boolean`), instance opener uses
+   * `getLeaf(false)` (current leaf) instead of `getLeaf("tab")` (new tab).
+   */
+  OPEN_IN_SAME_TAB: "exocmd__Command_openInSameTab",
 } as const;
 
 /** Properties for exocmd__Precondition assets */
@@ -48,6 +53,12 @@ export const GroundingProperty = {
    * layout can list every Grounding that pins it.
    */
   IS_DEFINED_BY: "exocmd__Grounding_isDefinedBy",
+  /**
+   * RFC ce27e55d: substitution-token string for the new instance's
+   * `exo__Asset_label` when no modal collects userInput.label
+   * (one-click flow). Resolved by `GroundingExecutor.substituteVariables`.
+   */
+  LABEL_TEMPLATE: "exocmd__Grounding_labelTemplate",
 } as const;
 
 /** Properties for exocmd__CommandBinding assets */

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -39,6 +39,14 @@ export interface CommandDefinition {
   readonly successMessage?: string;
   /** Category for grouping (e.g., "maintenance", "status") */
   readonly category?: string;
+  /**
+   * RFC ce27e55d: when true, the platform file opener navigates to the
+   * newly-created instance in the CURRENT active leaf (Obsidian
+   * `getLeaf(false)`) instead of opening a new tab (`getLeaf("tab")`).
+   * Authored as the `exocmd__Command_openInSameTab` RDF triple
+   * (`xsd:boolean`). Default `false` keeps existing commands unchanged.
+   */
+  readonly openInSameTab?: boolean;
 }
 
 /**
@@ -185,6 +193,20 @@ export interface GroundingDefinition {
    * (`xsd:boolean`). Default `false` keeps existing groundings unchanged.
    */
   readonly prefillLabelWithDate?: boolean;
+  /**
+   * RFC ce27e55d: substitution-token string used by `executeCreateInstance`
+   * to derive `exo__Asset_label` on the newly created asset when the user
+   * supplied no `userInput.label` (i.e. no input modal). Supports the same
+   * tokens as `substituteVariables` — `$target`, `$target.<prop>`, `$today`,
+   * `$nowLocal`, `$nowCompact`, `$todayStart`. Typical value:
+   * `"$target.exo__Asset_label $nowCompact"` → `"Осознал, что делаю шелуху 2026-05-28-22-51"`.
+   *
+   * Authored as the `exocmd__Grounding_labelTemplate` RDF triple. Disjoint
+   * from `prefillLabelWithDate` — labelTemplate is consulted only when no
+   * modal collects user input (one-click flow), whereas prefillLabelWithDate
+   * pre-fills the modal's default value.
+   */
+  readonly labelTemplate?: string;
 }
 
 /**

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -17,7 +17,7 @@ export interface CommandDefinition {
   /** Human-readable label (e.g., "Remove start timestamp") */
   readonly name: string;
   /**
-   * SPARQL-based label template with `{sparql}` placeholders.
+   * SPARQL-based template for the BUTTON label with `{sparql}` placeholders.
    * Each `{...}` block is executed as a SPARQL SELECT query;
    * the first binding of the first result row replaces the placeholder.
    *
@@ -25,6 +25,11 @@ export interface CommandDefinition {
    *
    * Variable substitution (same as PreconditionEvaluator):
    * - `$target` → `<targetIRI>`
+   *
+   * NOTE — distinct from {@link GroundingDefinition.labelTemplate}. That
+   * sibling is a substitution-token template for the NEW INSTANCE's
+   * `exo__Asset_label` consulted by `executeCreateInstance` during one-click
+   * flows. Two distinct concepts, two distinct interfaces, same English word.
    */
   readonly labelTemplate?: string;
   /** Lucide icon name (e.g., "clock-x") */
@@ -205,6 +210,12 @@ export interface GroundingDefinition {
    * from `prefillLabelWithDate` — labelTemplate is consulted only when no
    * modal collects user input (one-click flow), whereas prefillLabelWithDate
    * pre-fills the modal's default value.
+   *
+   * NOTE — distinct from {@link CommandDefinition.labelTemplate}. That sibling
+   * is a SPARQL-placeholder template for the BUTTON label (e.g.
+   * `"Vote ({SELECT (COUNT(?v) AS ?n) WHERE { $target exo:vote ?v }})"`).
+   * This field is the template for the NEW ASSET's `exo__Asset_label`.
+   * Two distinct concepts, two distinct interfaces, same English word.
    */
   readonly labelTemplate?: string;
 }

--- a/packages/exocortex/src/services/CommandExecutionFlow.ts
+++ b/packages/exocortex/src/services/CommandExecutionFlow.ts
@@ -53,14 +53,19 @@ export interface CommandPromptAdapter {
  * {@link GroundingExecutor.executeCreateInstance} writes a new asset it
  * returns the vault-relative path via {@link ExecutionResult.openPath};
  * {@link CommandExecutionFlow} forwards that path here so the platform
- * adapter (Obsidian plugin / future CLI) can decide where the file appears
- * — in Obsidian, `app.workspace.getLeaf("tab").openFile(...)` + focus.
+ * adapter (Obsidian plugin / future CLI) can decide where the file appears.
+ *
+ * RFC ce27e55d: `opts.sameTab` (when true) requests navigation in the
+ * current active leaf (Obsidian `getLeaf(false)`) instead of opening a new
+ * tab (`getLeaf("tab")`) — implements `exocmd__Command_openInSameTab`
+ * semantics. Adapters that have no notion of tabs (CLI, headless) ignore
+ * the second argument.
  *
  * Tests and headless runners may omit the dependency: when undefined the
  * core run pipeline is unchanged (creation succeeds without auto-opening).
  */
 export interface IFileOpener {
-  open(path: string): Promise<void>;
+  open(path: string, opts?: { readonly sameTab?: boolean }): Promise<void>;
 }
 
 /**
@@ -141,7 +146,11 @@ export class CommandExecutionFlow {
       // remain on the source asset).
       if (result.openPath && this.fileOpener) {
         try {
-          await this.fileOpener.open(result.openPath);
+          // RFC ce27e55d: forward `openInSameTab` to the platform adapter.
+          // Obsidian opener branches on the flag; CLI/headless ignores it.
+          await this.fileOpener.open(result.openPath, {
+            sameTab: command.openInSameTab,
+          });
         } catch (error) {
           this.logger.info(
             `[CommandExecutionFlow] Failed to open created file "${result.openPath}": ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -362,6 +362,15 @@ export class CommandResolver {
     const confirmMessage = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Command_confirmMessage"));
     const successMessage = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Command_successMessage"));
     const category = await this.getLiteralValue(subject, Namespace.EXOCMD.term("Command_category"));
+    // RFC ce27e55d: parse boolean openInSameTab — when true, platform opener
+    // navigates to the new instance in the current leaf instead of a new tab.
+    const openInSameTabRaw = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("Command_openInSameTab"),
+    );
+    const openInSameTab =
+      openInSameTabRaw !== null &&
+      String(openInSameTabRaw).trim().toLowerCase() === "true";
 
     // Transitively load linked Precondition
     const precondition = await this.loadLinkedPrecondition(subject);
@@ -380,6 +389,7 @@ export class CommandResolver {
       confirmMessage: confirmMessage ?? undefined,
       successMessage: successMessage ?? undefined,
       category: category ?? undefined,
+      openInSameTab: openInSameTab || undefined,
     };
   }
 
@@ -1305,6 +1315,15 @@ export class CommandResolver {
     const prefillLabelWithDate =
       prefillRaw !== null && String(prefillRaw).trim().toLowerCase() === "true";
 
+    // RFC ce27e55d: substitution-token template для auto-label при one-click
+    // (когда нет inputSchema modal). Resolved at execution time by
+    // `GroundingExecutor.substituteVariables` — supports `$target`,
+    // `$target.<prop>`, `$nowCompact`, etc.
+    const labelTemplate = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("Grounding_labelTemplate"),
+    );
+
     const grounding: GroundingDefinition = {
       id: uid,
       label,
@@ -1327,6 +1346,7 @@ export class CommandResolver {
       inheritanceRule: inheritanceRule.length > 0 ? inheritanceRule : undefined,
       isDefinedBy: isDefinedBy ?? undefined,
       prefillLabelWithDate: prefillLabelWithDate || undefined,
+      labelTemplate: labelTemplate ?? undefined,
     };
 
     if (inputSchema) {

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -628,7 +628,12 @@ export class GroundingExecutor {
         grounding.propertyDefault.some(
           (pd) =>
             typeof pd.value === "string" && pd.value.includes("__SUBSTITUTE"),
-        ));
+        )) ||
+      // RFC ce27e55d: labelTemplate с токеном `$target.<prop>` нуждается
+      // в frontmatter target'а для substituteVariables. Чисто `$nowCompact`
+      // или `$today` не требуют target read, поэтому проверяем dotted-form.
+      (grounding.labelTemplate !== undefined &&
+        /\$target\./.test(grounding.labelTemplate));
     if (needsTargetRead && targetIRI && targetFilePath) {
       let targetContent: string;
       try {
@@ -689,6 +694,10 @@ export class GroundingExecutor {
       properties,
       userInput,
       groundingTargetClassUid,
+      grounding,
+      targetIRI,
+      targetFm,
+      targetFilePath,
     );
 
     // userInput wins over PropertyDefault and InheritanceRule — apply after
@@ -842,6 +851,10 @@ export class GroundingExecutor {
     properties: Record<string, unknown>,
     userInput: UserInput | undefined,
     groundingTargetClassUid: string | undefined,
+    grounding?: GroundingDefinition,
+    targetIRI?: string,
+    targetFm?: Record<string, string | string[]> | null,
+    targetFilePath?: string,
   ): void {
     const missing: string[] = [];
 
@@ -858,10 +871,36 @@ export class GroundingExecutor {
     }
 
     if (properties.exo__Asset_label === undefined) {
-      const label = (userInput?.label as string) ?? "Untitled";
-      properties.exo__Asset_label = label;
-      if (label !== "Untitled" && properties.aliases === undefined) {
-        properties.aliases = [label];
+      // RFC ce27e55d: labelTemplate fallback before the "Untitled" hardcoded.
+      // Active when:
+      //   - userInput has no `label` field (one-click flow, no input modal);
+      //   - grounding declares `exocmd__Grounding_labelTemplate`;
+      //   - substituteVariables succeeds (else fall through to "Untitled").
+      //
+      // Single source of truth for label decision (advisor adjustment): the
+      // executor already owns the property-write at this point. Adding the
+      // resolution in CommandExecutionFlow would split logic across two layers.
+      let label: string | undefined = userInput?.label as string | undefined;
+      if (label === undefined && grounding?.labelTemplate) {
+        try {
+          label = this.substituteVariables(
+            grounding.labelTemplate,
+            targetIRI ?? "",
+            userInput,
+            targetFm ?? undefined,
+            targetFilePath,
+          );
+        } catch (error) {
+          LoggingService.error(
+            `[GroundingExecutor] labelTemplate substitution failed: ${error instanceof Error ? error.message : String(error)}. Falling back to "Untitled".`,
+          );
+          label = undefined;
+        }
+      }
+      const finalLabel = label ?? "Untitled";
+      properties.exo__Asset_label = finalLabel;
+      if (finalLabel !== "Untitled" && properties.aliases === undefined) {
+        properties.aliases = [finalLabel];
       }
       missing.push("exo__Asset_label");
     }
@@ -1208,6 +1247,10 @@ export class GroundingExecutor {
    *   composite groundings (Mark Done, Start Effort, etc.) write the same
    *   shape as every other effort/asset timestamp in the codebase.
    * - $today → current date (YYYY-MM-DD)
+   * - $nowCompact → current local timestamp with minute precision in
+   *   filename-safe dash-form (YYYY-MM-DD-HH-mm). Powers RFC ce27e55d
+   *   one-click labelTemplate use-case
+   *   (`$target.exo__Asset_label $nowCompact`).
    * - $todayStart → today at local midnight (YYYY-MM-DDT00:00:00, no TZ) —
    *   matches `DateFormatter.getTodayStartTimestamp()`. A declarative
    *   `property_set` with `$todayStart` is byte-identical to the legacy
@@ -1232,6 +1275,10 @@ export class GroundingExecutor {
     const nowLocal = DateFormatter.toLocalTimestamp(date);
     const today = now.slice(0, 10);
     const todayStart = `${today}T00:00:00`;
+    // RFC ce27e55d $nowCompact: filename-safe minute-precision form derived
+    // from nowLocal slices. nowLocal = "YYYY-MM-DDTHH:mm:ss" → indices 0..10
+    // = date, 11..13 = hour, 14..16 = minute.
+    const nowCompact = `${nowLocal.slice(0, 10)}-${nowLocal.slice(11, 13)}-${nowLocal.slice(14, 16)}`;
 
     // Issue #3132: `$target.<propertyName>` reads from target asset
     // frontmatter. MUST run before bare `$target` substitution (more-specific
@@ -1282,6 +1329,10 @@ export class GroundingExecutor {
 
     result = result
       .replace(/\$target/g, targetIRI)
+      // $nowCompact MUST run before $nowLocal/$now (more-specific first) —
+      // otherwise the $now prefix would be consumed and leave the "Compact"
+      // tail in the output. RFC ce27e55d.
+      .replace(/\$nowCompact\b/g, nowCompact)
       .replace(/\$nowLocal/g, nowLocal)
       .replace(/\$now/g, now)
       .replace(/\$todayStart\b/g, todayStart)

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -883,18 +883,26 @@ export class GroundingExecutor {
       let label: string | undefined = userInput?.label as string | undefined;
       if (label === undefined && grounding?.labelTemplate) {
         try {
-          label = this.substituteVariables(
+          const substituted = this.substituteVariables(
             grounding.labelTemplate,
             targetIRI ?? "",
             userInput,
             targetFm ?? undefined,
             targetFilePath,
           );
+          // Reviewer MEDIUM: empty / whitespace-only substitution result
+          // would otherwise leak into `exo__Asset_label:` as a literally
+          // empty value (worse than "Untitled"). Treat blank substituted
+          // result as "no label" per RFC ce27e55d contract. Scoped only to
+          // labelTemplate path — userInput.label `??` semantics preserved
+          // (advisor round-2 — keep RFC diff minimal).
+          if (substituted.trim().length > 0) {
+            label = substituted;
+          }
         } catch (error) {
           LoggingService.error(
             `[GroundingExecutor] labelTemplate substitution failed: ${error instanceof Error ? error.message : String(error)}. Falling back to "Untitled".`,
           );
-          label = undefined;
         }
       }
       const finalLabel = label ?? "Untitled";

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -445,6 +445,115 @@ describe("CommandResolver", () => {
       expect(cmd!.grounding.prefillLabelWithDate).toBeUndefined();
     });
 
+    // RFC ce27e55d (One-click create_instance) parsing tests
+    it("should parse exocmd__Command_openInSameTab true literal as boolean flag", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-same-tab",
+        label: "Trivial grounding",
+        type: "create_instance",
+      });
+      const commandSubject = new IRI("obsidian://vault/cmd-same-tab.md");
+      await store.addAll([
+        new Triple(commandSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+        new Triple(commandSubject, Namespace.EXO.term("Asset_uid"), new Literal("cmd-same-tab")),
+        new Triple(commandSubject, Namespace.EXO.term("Asset_label"), new Literal("Log Supervision")),
+        new Triple(commandSubject, Namespace.EXOCMD.term("Command_grounding"), new IRI("obsidian://vault/gnd-same-tab.md")),
+        new Triple(
+          commandSubject,
+          Namespace.EXOCMD.term("Command_openInSameTab"),
+          new Literal("true"),
+        ),
+      ]);
+
+      const cmd = await resolver.loadCommand("cmd-same-tab");
+
+      expect(cmd!.openInSameTab).toBe(true);
+    });
+
+    it("should leave openInSameTab undefined when triple is absent (backward-compat)", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-default-tab",
+        label: "Default tab grounding",
+        type: "create_instance",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-default-tab",
+        label: "Default",
+        groundingRef: "gnd-default-tab",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-default-tab");
+
+      expect(cmd!.openInSameTab).toBeUndefined();
+    });
+
+    it("should leave openInSameTab undefined for non-true literals (only 'true' opts in)", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-not-same-tab",
+        label: "Explicit false",
+        type: "create_instance",
+      });
+      const commandSubject = new IRI("obsidian://vault/cmd-not-same-tab.md");
+      await store.addAll([
+        new Triple(commandSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+        new Triple(commandSubject, Namespace.EXO.term("Asset_uid"), new Literal("cmd-not-same-tab")),
+        new Triple(commandSubject, Namespace.EXO.term("Asset_label"), new Literal("Explicit false")),
+        new Triple(commandSubject, Namespace.EXOCMD.term("Command_grounding"), new IRI("obsidian://vault/gnd-not-same-tab.md")),
+        new Triple(
+          commandSubject,
+          Namespace.EXOCMD.term("Command_openInSameTab"),
+          new Literal("false"),
+        ),
+      ]);
+
+      const cmd = await resolver.loadCommand("cmd-not-same-tab");
+
+      expect(cmd!.openInSameTab).toBeUndefined();
+    });
+
+    it("should parse exocmd__Grounding_labelTemplate literal verbatim", async () => {
+      const groundingSubject = new IRI("obsidian://vault/gnd-label-tmpl.md");
+      await store.addAll([
+        new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-label-tmpl")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("Auto label")),
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("[[4367e2d6-6c92-450a-becb-abce1fb07682]]")),
+        new Triple(
+          groundingSubject,
+          Namespace.EXOCMD.term("Grounding_labelTemplate"),
+          new Literal("$target.exo__Asset_label $nowCompact"),
+        ),
+      ]);
+      await addCommandAsset(store, {
+        uid: "cmd-label-tmpl",
+        label: "Auto label",
+        groundingRef: "gnd-label-tmpl",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-label-tmpl");
+
+      expect(cmd!.grounding.labelTemplate).toBe(
+        "$target.exo__Asset_label $nowCompact",
+      );
+    });
+
+    it("should leave labelTemplate undefined when triple is absent (backward-compat)", async () => {
+      await addGroundingAsset(store, {
+        uid: "gnd-no-tmpl",
+        label: "No template",
+        type: "create_instance",
+      });
+      await addCommandAsset(store, {
+        uid: "cmd-no-tmpl",
+        label: "No template",
+        groundingRef: "gnd-no-tmpl",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-no-tmpl");
+
+      expect(cmd!.grounding.labelTemplate).toBeUndefined();
+    });
+
     it("should pass through `default` and `defaultValue` from inputSchema JSON Schema properties", async () => {
       const groundingSubject = new IRI("obsidian://vault/gnd-defaults-input.md");
       await store.addAll([

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -825,6 +825,32 @@ describe("GroundingExecutor", () => {
       expect(result).not.toContain("$today");
     });
 
+    // RFC ce27e55d $nowCompact substitution token tests
+    it("should replace $nowCompact with YYYY-MM-DD-HH-mm (filename-safe minute precision)", () => {
+      const result = executor.substituteVariables(
+        "supervision $nowCompact",
+        TARGET_IRI,
+      );
+      expect(result).toMatch(/^supervision \d{4}-\d{2}-\d{2}-\d{2}-\d{2}$/);
+    });
+
+    it("should replace $nowCompact before $nowLocal/$now to avoid prefix collision", () => {
+      const result = executor.substituteVariables(
+        "$nowCompact then $nowLocal then $now",
+        TARGET_IRI,
+      );
+      // $nowCompact = YYYY-MM-DD-HH-mm; $nowLocal = YYYY-MM-DDTHH:mm:ss;
+      // $now = ISO-UTC with milliseconds Z. Three distinct shapes prove
+      // each replacement consumed its own token without prefix collision.
+      expect(result).toMatch(
+        /^\d{4}-\d{2}-\d{2}-\d{2}-\d{2} then \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} then \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$/,
+      );
+      expect(result).not.toContain("Compact");
+      expect(result).not.toContain("Local");
+      expect(result).not.toContain("$now");
+    });
+
+
     it("should replace $targetFolder with parent dir of targetFilePath", () => {
       const result = executor.substituteVariables(
         "place under $targetFolder",
@@ -941,6 +967,114 @@ describe("GroundingExecutor", () => {
       // (the class UID) is absent. The link references $target (the parent
       // file the user clicked on), not the class UID.
       expect(content).toContain('exo__Asset_prototype: "[[vault/test-asset]]"');
+    });
+
+    // RFC ce27e55d: labelTemplate fallback for one-click create_instance
+    // (no input modal). Verifies the executor resolves the new instance's
+    // label from `grounding.labelTemplate` when no userInput.label is supplied.
+    // Revert-verify discipline: each test must FAIL if the labelTemplate path
+    // is removed (advisor's catch — confirm test exercises the new code).
+    describe("RFC ce27e55d labelTemplate fallback", () => {
+      it("uses labelTemplate when userInput is undefined (one-click flow)", async () => {
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+          labelTemplate: "Auto label",
+        });
+
+        // Note: no `userInput` arg → triggers labelTemplate fallback.
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain("exo__Asset_label: Auto label");
+        // Aliases auto-populated because label is non-"Untitled".
+        expect(content).toContain("aliases:");
+      });
+
+      it("userInput.label wins over labelTemplate (explicit user input takes precedence)", async () => {
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+          labelTemplate: "Template label",
+        });
+
+        const result = await executor.execute(
+          grounding,
+          TARGET_IRI,
+          FILE_PATH,
+          { label: "User explicit" },
+        );
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain("exo__Asset_label: User explicit");
+        expect(content).not.toContain("Template label");
+      });
+
+      it("falls back to Untitled when neither userInput.label nor labelTemplate is set (BC)", async () => {
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain("exo__Asset_label: Untitled");
+      });
+
+      it("substitutes $nowCompact within labelTemplate", async () => {
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "kitelev__Supervision",
+          targetFolder: "03 Knowledge/kitelev",
+          labelTemplate: "Осознал, что делаю шелуху $nowCompact",
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toMatch(
+          /exo__Asset_label: Осознал, что делаю шелуху \d{4}-\d{2}-\d{2}-\d{2}-\d{2}/,
+        );
+      });
+
+      it("substitutes $target.exo__Asset_label by reading target frontmatter (production shape)", async () => {
+        // Production shape: user clicks the prototype-instance whose file
+        // contains `exo__Asset_label: «Осознал, что делаю шелуху»`. The
+        // executor reads target frontmatter (triggered by `$target.` in
+        // labelTemplate) and substitutes the value.
+        reader.readFile.mockResolvedValue(
+          [
+            "---",
+            'exo__Asset_uid: "deaa0051-0236-4cae-b2a5-2b156c3c127a"',
+            'exo__Asset_label: "Осознал, что делаю шелуху"',
+            "---",
+            "Body",
+          ].join("\n"),
+        );
+
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "kitelev__Supervision",
+          targetFolder: "03 Knowledge/kitelev",
+          labelTemplate: "$target.exo__Asset_label $nowCompact",
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toMatch(
+          /exo__Asset_label: Осознал, что делаю шелуху \d{4}-\d{2}-\d{2}-\d{2}-\d{2}/,
+        );
+      });
     });
 
     // Issue #3195: strip-canon. For UUID-named prototype-instance targets

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -1045,6 +1045,27 @@ describe("GroundingExecutor", () => {
         );
       });
 
+      it("falls back to Untitled when labelTemplate substitution result is empty string (reviewer MEDIUM)", async () => {
+        // Reviewer MEDIUM: empty-string or whitespace-only substitution
+        // result must NOT leak into `exo__Asset_label` as a literally empty
+        // value. RFC ce27e55d contract: blank result → fallback to "Untitled".
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "ems__Task",
+          targetFolder: "01 Inbox",
+          labelTemplate: "   ", // whitespace-only template — substitutes to whitespace-only string
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toContain("exo__Asset_label: Untitled");
+        // No aliases block for Untitled (preserves BC with pre-RFC behavior).
+        // Convention match with existing aliases assertion in test suite.
+        expect(content).not.toContain("aliases:");
+      });
+
       it("substitutes $target.exo__Asset_label by reading target frontmatter (production shape)", async () => {
         // Production shape: user clicks the prototype-instance whose file
         // contains `exo__Asset_label: «Осознал, что делаю шелуху»`. The

--- a/packages/obsidian-plugin/src/infrastructure/services/ObsidianFileOpener.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ObsidianFileOpener.ts
@@ -5,11 +5,15 @@ import type { IFileOpener } from "exocortex";
 /**
  * Obsidian-side adapter for {@link IFileOpener} (Issue #3184 B5).
  *
- * Opens a vault-relative path in a new tab and focuses it. Mirrors the
- * established `getLeaf("tab").openFile(tfile)` + `setActiveLeaf(...,
- * {focus: true})` pattern used by `createRelatedTask` / `createNarrowerConcept`
- * / `createSubclass` in `ServiceRegistryPopulator.ts` so create_instance and
- * service_call-driven creation flows feel identical to the user.
+ * Opens a vault-relative path and focuses it. Default mode is "new tab"
+ * (`getLeaf("tab")`) — mirrors the legacy `createRelatedTask` /
+ * `createNarrowerConcept` / `createSubclass` pattern from `ServiceRegistryPopulator`.
+ *
+ * RFC ce27e55d: when `opts.sameTab` is true the opener calls
+ * `getLeaf(false)` instead — navigates the CURRENT active leaf to the new
+ * file. Implements `exocmd__Command_openInSameTab` semantics for one-click
+ * supervision-style flows where the user expects the prototype tab to
+ * become the new instance immediately.
  *
  * Robust to a brief race between `createFile` resolving and Obsidian's vault
  * cache surfacing the new file: we poll the abstract-file lookup a few times
@@ -23,12 +27,19 @@ export class ObsidianFileOpener implements IFileOpener {
     this.app = app;
   }
 
-  async open(path: string): Promise<void> {
+  async open(
+    path: string,
+    opts?: { readonly sameTab?: boolean },
+  ): Promise<void> {
     if (!path) return;
 
     const tfile = await this.resolveTFile(path);
     if (tfile) {
-      const leaf = this.app.workspace.getLeaf("tab");
+      // RFC ce27e55d: branch on `opts.sameTab` — `false` argument to
+      // `getLeaf` requests the CURRENT active leaf (Obsidian API contract),
+      // `"tab"` requests a fresh tab.
+      const leafArg: false | "tab" = opts?.sameTab ? false : "tab";
+      const leaf = this.app.workspace.getLeaf(leafArg);
       await leaf.openFile(tfile);
       this.app.workspace.setActiveLeaf(leaf, { focus: true });
       return;
@@ -37,6 +48,8 @@ export class ObsidianFileOpener implements IFileOpener {
     // Fallback: lookup miss (vault cache lag, unusual path encoding) —
     // delegate to `openLinkText` which resolves via metadataCache. The
     // second arg is the source path; empty string means "from vault root".
+    // `openLinkText` does not expose a tab/leaf preference; same-tab callers
+    // accept fallback to default behaviour when the polled-file path failed.
     await this.app.workspace.openLinkText(path, "");
   }
 

--- a/packages/obsidian-plugin/tests/unit/ObsidianFileOpener.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ObsidianFileOpener.test.ts
@@ -1,0 +1,98 @@
+import { ObsidianFileOpener } from "../../src/infrastructure/services/ObsidianFileOpener";
+import { TFile } from "obsidian";
+
+describe("ObsidianFileOpener — RFC ce27e55d openInSameTab plumbing", () => {
+  let mockApp: any;
+  let mockLeaf: any;
+  let mockTFile: TFile;
+  let getLeafCalls: Array<false | "tab" | "split" | "window" | undefined>;
+
+  beforeEach(() => {
+    mockTFile = new TFile("01 Inbox/instance-uuid.md");
+
+    mockLeaf = {
+      openFile: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // Track-by-call: per `test-fixture-realism.md`, the fake MUST distinguish
+    // sameTab=true vs absent by recording the actual argument used.
+    getLeafCalls = [];
+
+    mockApp = {
+      vault: {
+        getAbstractFileByPath: jest.fn().mockReturnValue(mockTFile),
+      },
+      workspace: {
+        getLeaf: jest.fn((arg?: false | "tab" | "split" | "window") => {
+          getLeafCalls.push(arg);
+          return mockLeaf;
+        }),
+        setActiveLeaf: jest.fn(),
+        openLinkText: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  it("default (no opts) uses getLeaf(\"tab\") — new tab", async () => {
+    const opener = new ObsidianFileOpener(mockApp);
+
+    await opener.open("01 Inbox/instance-uuid.md");
+
+    expect(getLeafCalls).toEqual(["tab"]);
+    expect(mockLeaf.openFile).toHaveBeenCalledWith(mockTFile);
+    expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, {
+      focus: true,
+    });
+  });
+
+  it("opts.sameTab=false uses getLeaf(\"tab\") — explicit default", async () => {
+    const opener = new ObsidianFileOpener(mockApp);
+
+    await opener.open("01 Inbox/instance-uuid.md", { sameTab: false });
+
+    expect(getLeafCalls).toEqual(["tab"]);
+  });
+
+  it("opts.sameTab=true uses getLeaf(false) — current active leaf", async () => {
+    const opener = new ObsidianFileOpener(mockApp);
+
+    await opener.open("01 Inbox/instance-uuid.md", { sameTab: true });
+
+    // Obsidian getLeaf(false) requests the CURRENT active leaf.
+    expect(getLeafCalls).toEqual([false]);
+    expect(mockLeaf.openFile).toHaveBeenCalledWith(mockTFile);
+    expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, {
+      focus: true,
+    });
+  });
+
+  it("opts.sameTab=undefined uses getLeaf(\"tab\") — same as no opts", async () => {
+    const opener = new ObsidianFileOpener(mockApp);
+
+    await opener.open("01 Inbox/instance-uuid.md", { sameTab: undefined });
+
+    expect(getLeafCalls).toEqual(["tab"]);
+  });
+
+  it("returns early on empty path without calling getLeaf", async () => {
+    const opener = new ObsidianFileOpener(mockApp);
+
+    await opener.open("");
+
+    expect(getLeafCalls).toEqual([]);
+    expect(mockApp.vault.getAbstractFileByPath).not.toHaveBeenCalled();
+  });
+
+  it("falls back to openLinkText when TFile lookup misses (vault cache lag)", async () => {
+    mockApp.vault.getAbstractFileByPath = jest.fn().mockReturnValue(null);
+    const opener = new ObsidianFileOpener(mockApp);
+
+    await opener.open("unresolved.md", { sameTab: true });
+
+    expect(getLeafCalls).toEqual([]);
+    expect(mockApp.workspace.openLinkText).toHaveBeenCalledWith(
+      "unresolved.md",
+      "",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements RFC ce27e55d: extends `exocmd__Command` / `exocmd__Grounding` TBox with 2 properties + 1 substitution token, enabling zero-friction one-click create_instance buttons via **pure RDF configuration** going forward.

- **`exocmd__Command_openInSameTab`** (xsd:boolean) — opens new instance in current active leaf (`getLeaf(false)`) instead of new tab.
- **`exocmd__Grounding_labelTemplate`** (xsd:string) — auto-label template resolved by executor when no `userInput.label` (no input modal). Supports all existing substitution tokens + new `$nowCompact`.
- **`$nowCompact`** token → `YYYY-MM-DD-HH-mm` (filename-safe, minute precision).

**Catalyst:** Supervision logging button «Осознал, что делаю шелуху» — клик создаёт `kitelev__Supervision` instance с label «Осознал, что делаю шелуху 2026-05-28-22-51» и сразу открывает в текущей вкладке.

**Per Homoiconicity Invariant Q3:** One-time code change extends TBox interpretation infrastructure (exception (в) — guard rail extension). After merge, all future similar buttons declare behavior purely via RDF — no plugin changes.

## Files

- `packages/exocortex/src/domain/models/CommandDefinition.ts` — 2 new optional fields (`openInSameTab`, `labelTemplate` on Grounding).
- `packages/exocortex/src/domain/constants/CommandProperty.ts` — TBox property names.
- `packages/exocortex/src/services/CommandResolver.ts` — parse both new properties (xsd:boolean / xsd:string).
- `packages/exocortex/src/services/GroundingExecutor.ts` — `$nowCompact` substitution + `labelTemplate` fallback in `applyMissingScalarPrimitives` (single source of truth per advisor adjustment) + `needsTargetRead` extension for `$target.<prop>` templates.
- `packages/exocortex/src/services/CommandExecutionFlow.ts` — `IFileOpener.open(path, opts?)` signature + forward `command.openInSameTab`.
- `packages/obsidian-plugin/src/infrastructure/services/ObsidianFileOpener.ts` — branch on `opts.sameTab` to choose `getLeaf(false)` vs `getLeaf("tab")`.

## Tests (18 new)

| File | Tests | Coverage |
|---|---|---|
| `CommandResolver.test.ts` | 5 | openInSameTab parse (true/false/absent), labelTemplate parse + BC |
| `GroundingExecutor.test.ts` | 7 | `$nowCompact` substitution (basic + collision order), labelTemplate fallback (userInput wins, BC Untitled, `$nowCompact`, `$target.<prop>` production shape) |
| `ObsidianFileOpener.test.ts` (NEW) | 6 | sameTab=true/false/undefined/absent + early-return + openLinkText fallback. Fake `App` tracks each `getLeaf` argument (per `test-fixture-realism.md`) |

**Revert-verify discipline:** confirmed 3/5 labelTemplate executor tests + 3/3 `$nowCompact` tests FAIL when fix removed, all PASS after restore.

## Backward compatibility

- All new properties are optional with sensible defaults.
- Commands/groundings without them produce identical pre-RFC behavior (open in new tab, "Untitled" fallback when no userInput.label).
- `CommandResolver` gracefully ignores unknown frontmatter keys (verified pre-existing behavior).

## Multi-parser audit (per RFC 918a2b65 retro)

CLI BDD `step_definitions/grounding.steps.ts` and integration `test-helpers/extract-target-class.ts` read raw frontmatter via `fm["exocmd__Grounding_<X>"]` for specific keys only — new properties gracefully ignored. No existing fixture uses the new properties, so no regression risk for BDD pipeline. If future fixtures declare `labelTemplate`, parallel BDD plumbing will be needed.

## Test plan

- [x] `npm run check:types` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] All 18 new tests pass locally
- [x] Existing tests in `GroundingExecutor.test.ts` + `CommandResolver.test.ts` pass (226 total)
- [x] Revert-verify confirms tests exercise the new code path
- [ ] CI 14 required checks pass
- [ ] Code-reviewer agent review (manual merge per Auto-merge discipline — touches `CommandResolver`/`GroundingExecutor` parser paths)
- [ ] Advisor round-2 after fixes

## Post-merge follow-ups (separate session)

1. TBox property assets in `assetspaces/exocmd/` (kitelev/exoas-exocmd repo) declaring `exocmd__Command_openInSameTab` + `exocmd__Grounding_labelTemplate` as `exo__Property` instances with domain/range/cardinality.
2. Update Supervision Command `[[115271f5-87ac-4866-9695-1295d2403bdf]]` — remove `confirmMessage`, add `openInSameTab: true`.
3. Update Supervision Grounding `[[314d02f0-3029-4de2-9f58-9dff2e0dcfea]]` — remove `inputSchema` + `prefillLabelWithDate`, add `labelTemplate: "\$target.exo__Asset_label \$nowCompact"`.
4. UI smoke: click button on «Осознал, что делаю шелуху» prototype → verify label format + same-tab + no friction.

## RFC reference

- Vault: `[[ce27e55d-e5e6-4b52-86ba-3ac9b30de38a|RFC One-click create_instance]]` (vault-exodev/inbox/)
- Catalyst Supervision Grounding: `[[314d02f0-3029-4de2-9f58-9dff2e0dcfea]]`
- Catalyst Supervision prototype-instance: `[[deaa0051-0236-4cae-b2a5-2b156c3c127a]]`