### PR TITLE
fix(create_instance): labelTemplate fires when upstream PD writes empty label

### DIFF
--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -870,7 +870,17 @@ export class GroundingExecutor {
       missing.push("exo__Asset_createdAt");
     }
 
-    if (properties.exo__Asset_label === undefined) {
+    // RFC ce27e55d: also treat an empty / whitespace-only `exo__Asset_label`
+    // written by an upstream PropertyDefault as "missing". Discovered during
+    // UI smoke 2026-05-29 — Universal Default Template's PD #3
+    // (`exo__Asset_label = $userInputLabel`) writes an empty literal when
+    // userInput.label is undefined (one-click flow). That left labels blank
+    // on disk because the `=== undefined` guard skipped my labelTemplate
+    // fallback. Treat blank PropertyDefault result identically to absent.
+    const labelIsBlank =
+      typeof properties.exo__Asset_label === "string" &&
+      properties.exo__Asset_label.trim().length === 0;
+    if (properties.exo__Asset_label === undefined || labelIsBlank) {
       // RFC ce27e55d: labelTemplate fallback before the "Untitled" hardcoded.
       // Active when:
       //   - userInput has no `label` field (one-click flow, no input modal);

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -1045,6 +1045,40 @@ describe("GroundingExecutor", () => {
         );
       });
 
+      it("uses labelTemplate when upstream PropertyDefault wrote empty exo__Asset_label (UI smoke fix 2026-05-29)", async () => {
+        // Production interaction discovered during UI smoke 2026-05-29:
+        // Universal Default Template PD #3 (exo__Asset_label = $userInputLabel)
+        // writes an empty literal when userInput.label is undefined. Without
+        // this guard, the `=== undefined` check skipped labelTemplate fallback
+        // and the empty PD result reached the file on disk.
+        reader.readFile.mockResolvedValue(
+          [
+            "---",
+            'exo__Asset_uid: "deaa0051-0236-4cae-b2a5-2b156c3c127a"',
+            'exo__Asset_label: "Осознал, что делаю шелуху"',
+            "---",
+            "Body",
+          ].join("\n"),
+        );
+        const grounding = makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "kitelev__Supervision",
+          targetFolder: "03 Knowledge/kitelev",
+          labelTemplate: "$target.exo__Asset_label $nowCompact",
+          // Simulate Universal Default Template PD writing empty exo__Asset_label.
+          propertyDefault: [{ propertyName: "exo__Asset_label", value: "" }],
+        });
+
+        const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+        expect(result.success).toBe(true);
+        const [, content] = writer.createFile.mock.calls[0];
+        expect(content).toMatch(
+          /exo__Asset_label: Осознал, что делаю шелуху \d{4}-\d{2}-\d{2}-\d{2}-\d{2}/,
+        );
+        expect(content).not.toMatch(/exo__Asset_label:\s*$/m);
+      });
+
       it("falls back to Untitled when labelTemplate substitution result is empty string (reviewer MEDIUM)", async () => {
         // Reviewer MEDIUM: empty-string or whitespace-only substitution
         // result must NOT leak into `exo__Asset_label` as a literally empty


### PR DESCRIPTION
## Summary

Hotfix discovered during UI smoke 2026-05-29 verifying RFC ce27e55d (PR #3287, merged as v16.31.1).

**Root cause:** Universal Default Template's PropertyDefault #3
(`exo__Asset_label = $userInputLabel`, UID bb2b0443) runs BEFORE
`applyMissingScalarPrimitives` in `executeCreateInstance`. When
`userInput.label` is undefined (one-click flow, no input modal), the
$userInputLabel substitution resolves to empty string `""`. My
labelTemplate fallback check (`properties.exo__Asset_label === undefined`)
skipped this case because the value was `""`, not undefined → labelTemplate
fallback didn't fire → empty label hit disk.

**Symptom:** Clicking the "Log Supervision" button on the «Осознал, что делаю шелуху» prototype created a Supervision instance with literal empty `exo__Asset_label:` in frontmatter (shown as "Empty" in Obsidian Properties panel) instead of the expected "Осознал, что делаю шелуху 2026-05-29-10-14".

## Fix

Extend the guard in `applyMissingScalarPrimitives` to also treat empty / whitespace-only string values as "missing":

```ts
const labelIsBlank =
  typeof properties.exo__Asset_label === "string" &&
  properties.exo__Asset_label.trim().length === 0;
if (properties.exo__Asset_label === undefined || labelIsBlank) {
  // labelTemplate fallback now fires whether PD wrote nothing OR wrote blank.
}
```

### Side-effect (stealth bugfix beyond RFC ce27e55d scope, per code-reviewer flag)

Groundings WITHOUT `labelTemplate` that previously persisted empty `exo__Asset_label` (because Universal PD #3 wrote `""` and nothing overrode it) will now persist `"Untitled"` instead. Empty-label assets were never useful state; this is a desirable stealth fix. No backward-compatibility concerns.

## Tests

- 1 new unit test: "uses labelTemplate when upstream PropertyDefault wrote empty exo__Asset_label (UI smoke fix 2026-05-29)" — simulates the production shape with PD writing `""` alongside labelTemplate.
- Existing 6 labelTemplate tests still pass (no regression).

## Why unit tests didn't catch this

The original RFC ce27e55d tests were structurally scoped — they tested label-decision logic with `userInput.label` undefined AND no PD. They never seeded a PD writing empty label, because that interaction surfaces only when the Universal Default Template singleton runs against a labelTemplate-bearing grounding. The catalyst Supervision Command/Grounding (created in vault BUT not in PR fixtures) exercised this in production-shape vault.

Layer-3 functional smoke (per `test-fixture-realism.md` empirical reference) caught what unit tests structurally couldn't.

## Test plan

- [x] `npm run check:types` clean
- [x] Pre-commit checks pass (BDD 100%, archgate, etc.)
- [x] 7 labelTemplate executor tests pass
- [x] CI 14 required checks pass (33 SUCCESS / 0 FAILURE)
- [x] Code-reviewer APPROVE (0 CRIT/HIGH; 2 MEDIUM advisory addressed)
- [ ] UI smoke re-run after v16.31.2 BRAT update — click button → verify label format