### PR TITLE
fix(layout): refresh BUTTONS section + triple store after frontmatter mutation

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -463,6 +463,17 @@ export default class ExocortexPlugin extends Plugin {
           // loader on every render. `ensureLoadedByIRI` primes the
           // store for the active file before button resolution.
           lazyAssetGraphLoader: this.lazyAssetGraphLoader,
+          // Issue followup to #3279 — re-index per-file triples + drop
+          // command/precondition caches BEFORE the incremental section
+          // refresh runs. The BUTTONS section's precondition ASKs query
+          // the triple store; without this, a click that mutates the
+          // frontmatter (e.g. `ems__Task_zone`) would refresh the section
+          // against pre-mutation triples and the buttons would not flip.
+          prepareForRefresh: async (file) => {
+            await this.sparql.reindexFile(file);
+            this.commandResolver.invalidateCache();
+            this.preconditionEvaluator.invalidateCache();
+          },
         },
       );
 

--- a/packages/obsidian-plugin/src/application/services/PropertyDependencyResolver.ts
+++ b/packages/obsidian-plugin/src/application/services/PropertyDependencyResolver.ts
@@ -50,6 +50,12 @@ export class PropertyDependencyResolver {
     "ems__Task_blocks": [
       LayoutSection.RELATIONS,
     ],
+    // ems__Task_zone gates criticality buttons (Set Criticality Low/Med/High).
+    // Their preconditions check the current zone — without re-render after a
+    // click that mutates zone, all three remain visible until reload.
+    "ems__Task_zone": [
+      LayoutSection.BUTTONS,
+    ],
 
     "ems__Project_blockedBy": [
       LayoutSection.RELATIONS,

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -77,6 +77,7 @@ export class UniversalLayoutRenderer {
   // present, render() ensure-loads the active file's frontmatter +
   // class chain + prototype chain before resolving button visibility.
   private lazyAssetGraphLoader?: LazyAssetGraphLoader;
+  private prepareForRefresh?: (file: TFile) => Promise<void>;
   private exoLayoutRenderer!: ExoLayoutRenderer;
 
   private dependencyResolver: PropertyDependencyResolver;
@@ -110,6 +111,17 @@ export class UniversalLayoutRenderer {
       // `isFullPathReady`, `bindingsCache` ctor params.
       // RFC c7da0bca Phase 3b-main
       lazyAssetGraphLoader?: LazyAssetGraphLoader;
+      /**
+       * Called by `handleMetadataChange` BEFORE building the section delta
+       * + running `IncrementalUpdateHandler.updateSections`. The BUTTONS
+       * section's preconditions query the triple store via SPARQL ASK; if
+       * the store still holds pre-mutation triples at that moment, the
+       * preconditions silently return their old result and the buttons
+       * don't refresh. This hook lets the wiring code refresh per-file
+       * triples + invalidate command/precondition caches before the
+       * sections-update pass starts.
+       */
+      prepareForRefresh?: (file: TFile) => Promise<void>;
     },
   ) {
     this.app = app;
@@ -127,6 +139,7 @@ export class UniversalLayoutRenderer {
     this.layoutSelector = rfc009Services?.layoutSelector ?? null;
     this.panelResolver = rfc009Services?.panelResolver ?? null;
     this.lazyAssetGraphLoader = rfc009Services?.lazyAssetGraphLoader;
+    this.prepareForRefresh = rfc009Services?.prepareForRefresh;
     this.logger = LoggerFactory.create("UniversalLayoutRenderer");
 
     // Create ReactRenderer with ErrorBoundary enabled for graceful error handling.
@@ -250,6 +263,23 @@ export class UniversalLayoutRenderer {
       const abstractFile = this.app.vault.getAbstractFileByPath(filePath);
       if (!abstractFile || !(abstractFile instanceof TFile)) return;
       const currentFile = abstractFile;
+
+      // Refresh per-file triples + drop cached precondition results BEFORE
+      // re-rendering any section. The BUTTONS section's preconditions read
+      // from the triple store; without this, `updateButtons` would call
+      // `buildCategoryGroups` against pre-mutation triples and reach the
+      // same precondition decision as the previous render — the user-
+      // visible "click does nothing" symptom on `ems__Task_zone`-gated
+      // criticality buttons (Issue followup to #3279 button restore).
+      if (this.prepareForRefresh) {
+        try {
+          await this.prepareForRefresh(currentFile);
+        } catch (err) {
+          this.logger.warn(
+            `[handleMetadataChange] prepareForRefresh failed for ${filePath}: ${String(err)}`,
+          );
+        }
+      }
 
       const oldMetadata = this.metadataCache.get(filePath) || {};
       const newMetadata = this.metadataExtractor.extractMetadata(currentFile);

--- a/packages/obsidian-plugin/tests/unit/PropertyDependencyResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PropertyDependencyResolver.test.ts
@@ -106,6 +106,13 @@ describe("PropertyDependencyResolver", () => {
       expect(sections).toContain(LayoutSection.RELATIONS);
       expect(sections).toHaveLength(1);
     });
+
+    it("should map ems__Task_zone to Buttons (criticality buttons reactivity)", () => {
+      const sections = resolver.getAffectedSections(["ems__Task_zone"]);
+
+      expect(sections).toContain(LayoutSection.BUTTONS);
+      expect(sections).toHaveLength(1);
+    });
   });
 
   describe("Project properties (ems__Project_)", () => {

--- a/packages/obsidian-plugin/tests/unit/UniversalLayoutRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/UniversalLayoutRenderer.test.ts
@@ -225,6 +225,118 @@ describe("UniversalLayoutRenderer", () => {
       // Verify metadata was extracted
       expect(renderer_any.metadataExtractor.extractMetadata).toHaveBeenCalledWith(mockFile);
     });
+
+    it("should await prepareForRefresh BEFORE extracting metadata + updating sections", async () => {
+      const callOrder: string[] = [];
+      const prepareForRefresh = jest.fn().mockImplementation(async () => {
+        callOrder.push("prepareForRefresh");
+      });
+
+      const renderer = new UniversalLayoutRenderer(
+        mockApp,
+        mockSettings,
+        mockPlugin,
+        mockVaultAdapter,
+        { prepareForRefresh },
+      );
+
+      const mockFile = Object.create(TFile.prototype);
+      Object.assign(mockFile, {
+        path: "test.md",
+        extension: "md",
+        basename: "test",
+      });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      const renderer_any = renderer as any;
+      renderer_any.currentFilePath = "test.md";
+      renderer_any.rootContainer = document.createElement("div");
+      renderer_any.metadataExtractor = {
+        extractMetadata: jest.fn().mockImplementation(() => {
+          callOrder.push("extractMetadata");
+          return {};
+        }),
+      };
+
+      await renderer.handleMetadataChange("test.md");
+      jest.advanceTimersByTime(100);
+      // Flush the awaited promise inside the setTimeout body.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(prepareForRefresh).toHaveBeenCalledWith(mockFile);
+      expect(callOrder[0]).toBe("prepareForRefresh");
+      expect(callOrder.indexOf("extractMetadata")).toBeGreaterThan(
+        callOrder.indexOf("prepareForRefresh"),
+      );
+    });
+
+    it("should not error when prepareForRefresh is not provided", async () => {
+      const renderer = new UniversalLayoutRenderer(
+        mockApp,
+        mockSettings,
+        mockPlugin,
+        mockVaultAdapter,
+      );
+
+      const mockFile = Object.create(TFile.prototype);
+      Object.assign(mockFile, {
+        path: "test.md",
+        extension: "md",
+        basename: "test",
+      });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      const renderer_any = renderer as any;
+      renderer_any.currentFilePath = "test.md";
+      renderer_any.rootContainer = document.createElement("div");
+      renderer_any.metadataExtractor = {
+        extractMetadata: jest.fn().mockReturnValue({}),
+      };
+
+      await renderer.handleMetadataChange("test.md");
+      jest.advanceTimersByTime(100);
+
+      expect(renderer_any.metadataExtractor.extractMetadata).toHaveBeenCalledWith(mockFile);
+    });
+
+    it("should swallow prepareForRefresh errors and still update sections", async () => {
+      const prepareForRefresh = jest
+        .fn()
+        .mockRejectedValue(new Error("reindex blew up"));
+
+      const renderer = new UniversalLayoutRenderer(
+        mockApp,
+        mockSettings,
+        mockPlugin,
+        mockVaultAdapter,
+        { prepareForRefresh },
+      );
+
+      const mockFile = Object.create(TFile.prototype);
+      Object.assign(mockFile, {
+        path: "test.md",
+        extension: "md",
+        basename: "test",
+      });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      const renderer_any = renderer as any;
+      renderer_any.currentFilePath = "test.md";
+      renderer_any.rootContainer = document.createElement("div");
+      renderer_any.metadataExtractor = {
+        extractMetadata: jest.fn().mockReturnValue({}),
+      };
+
+      await renderer.handleMetadataChange("test.md");
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(prepareForRefresh).toHaveBeenCalled();
+      // Sections-update pass still ran even though the prep step threw.
+      expect(renderer_any.metadataExtractor.extractMetadata).toHaveBeenCalledWith(mockFile);
+    });
   });
 
   describe("incremental updates via IncrementalUpdateHandler", () => {


### PR DESCRIPTION
## Summary
- Map `ems__Task_zone` → `LayoutSection.BUTTONS` in `PropertyDependencyResolver` so the incremental update path actually targets the BUTTONS section when a click mutates the task zone (the criticality buttons are gated by exactly this property).
- Add an optional `prepareForRefresh(file)` hook on `UniversalLayoutRenderer`. The `handleMetadataChange` setTimeout body awaits it BEFORE `extractMetadata` / `IncrementalUpdateHandler.updateSections`. `ExocortexPlugin` wires it to `sparql.reindexFile(file)` + `commandResolver.invalidateCache()` + `preconditionEvaluator.invalidateCache()` so the BUTTONS section's preconditions evaluate against fresh triples + caches, not the pre-mutation snapshot.

## Why
After v16.31.x restored the 3 «Set Criticality Low/Med/High» bindings (#3279 followup), an end-to-end UI smoke uncovered a second bug: clicking the buttons mutated the frontmatter (`ems__Task_zone` was written), but the buttons stayed visible until plugin reload.

Two compounding root causes:

1. `PropertyDependencyResolver.PROPERTY_DEPENDENCIES` had no entry for `ems__Task_zone`. `FrontmatterDeltaDetector` correctly reported the property as modified, but `getAffectedSections([...])` returned `[]` — `IncrementalUpdateHandler.updateSections(... [], ...)` is a no-op. Buttons section was never asked to refresh.

2. Even with the mapping added, `IncrementalUpdateHandler.updateButtons` calls `buttonGroupsBuilder.build`, whose preconditions run SPARQL ASK against the triple store. The 50 ms incremental-update timer (`handleMetadataChange`) fires BEFORE the 150 ms `scheduleHotReindex` timer that actually re-converts the file's frontmatter into triples. Without sequencing reindex before update, the rebuilt section evaluates preconditions against the pre-mutation triple state and reaches the same decision.

`autoRenderLayout` at 150 ms is Reading-Mode-only (early returns in Live Preview), so before this PR the bug was permanent in Live Preview until plugin reload.

## How
- `PropertyDependencyResolver.ts`: add `ems__Task_zone: [LayoutSection.BUTTONS]`.
- `UniversalLayoutRenderer.ts`:
  - extend the `rfc009Services` ctor option bag with `prepareForRefresh?: (file: TFile) => Promise<void>`,
  - store the hook on a private field,
  - in `handleMetadataChange` setTimeout, await the hook (if provided) BEFORE extracting metadata + computing delta + calling `updateSections`. Errors are swallowed and warn-logged so the UI update pass still runs.
- `ExocortexPlugin.ts`: pass `prepareForRefresh: async (file) => { await sparql.reindexFile(file); commandResolver.invalidateCache(); preconditionEvaluator.invalidateCache(); }`.

The hook is optional everywhere so existing renderer instantiations (tests, downstream consumers) keep compiling and behave as before.

## Tests
- `PropertyDependencyResolver.test.ts`: new case asserts `ems__Task_zone → [BUTTONS]`.
- `UniversalLayoutRenderer.test.ts`: 3 new cases —
  - `prepareForRefresh` is awaited BEFORE `extractMetadata`,
  - missing `prepareForRefresh` is a no-op (back-compat),
  - `prepareForRefresh` errors are swallowed and the sections-update pass still runs.
- `npm run check:types`: clean.
- `npm run lint`: clean (2 pre-existing warnings unrelated).
- `packages/obsidian-plugin/tests/unit`: 239 suites / 4935 tests pass locally.

## Test plan
- [x] Unit tests for new mapping + new hook ordering / fallback / error-swallow
- [x] `npm run check:types` + `npm run lint`
- [x] `packages/obsidian-plugin/tests/unit` full suite
- [ ] BRAT update → reload → click `Set Criticality High` on a fresh `ems__Task` → button hides, the other two remain (UI smoke after Auto Release)
- [ ] On a `ems__Task` with `ems__Effort_status = Done`, the criticality category is hidden (this part comes from the companion vault-side PR — terminal-status guards in 3 preconditions, already merged into `exoas-exocmd@1877276`)

## Vault tracking
- vault-exodev/inbox/`e511a0af-3219-4698-85b7-31845680a07c` (parent, criticality button restore)
- vault-exodev/inbox/`6afb3f0d-cb85-438d-8f9e-cb7afdd7100e` (this minor)