### PR TITLE
fix(layout): gate prepareForRefresh on BUTTONS to avoid global cache wipe

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -22,7 +22,7 @@ import { DailyTasksRenderer } from "./DailyTasksRenderer";
 import { AreaTreeRenderer } from "./layout/AreaTreeRenderer";
 import { RelationsRenderer, UniversalLayoutConfig } from "./layout/RelationsRenderer";
 import { AssetMetadataService } from "./layout/helpers/AssetMetadataService";
-import { PropertyDependencyResolver } from '@plugin/application/services/PropertyDependencyResolver';
+import { LayoutSection, PropertyDependencyResolver } from '@plugin/application/services/PropertyDependencyResolver';
 import { FrontmatterDeltaDetector } from '@plugin/application/services/FrontmatterDeltaDetector';
 import {
   SectionStateManager,
@@ -264,23 +264,6 @@ export class UniversalLayoutRenderer {
       if (!abstractFile || !(abstractFile instanceof TFile)) return;
       const currentFile = abstractFile;
 
-      // Refresh per-file triples + drop cached precondition results BEFORE
-      // re-rendering any section. The BUTTONS section's preconditions read
-      // from the triple store; without this, `updateButtons` would call
-      // `buildCategoryGroups` against pre-mutation triples and reach the
-      // same precondition decision as the previous render — the user-
-      // visible "click does nothing" symptom on `ems__Task_zone`-gated
-      // criticality buttons (Issue followup to #3279 button restore).
-      if (this.prepareForRefresh) {
-        try {
-          await this.prepareForRefresh(currentFile);
-        } catch (err) {
-          this.logger.warn(
-            `[handleMetadataChange] prepareForRefresh failed for ${filePath}: ${String(err)}`,
-          );
-        }
-      }
-
       const oldMetadata = this.metadataCache.get(filePath) || {};
       const newMetadata = this.metadataExtractor.extractMetadata(currentFile);
       const delta = this.deltaDetector.detectChanges(oldMetadata, newMetadata);
@@ -290,6 +273,34 @@ export class UniversalLayoutRenderer {
 
       this.metadataCache.set(filePath, newMetadata);
       const affectedSections = this.dependencyResolver.getAffectedSections(changedProps);
+
+      // Refresh per-file triples + drop cached precondition results BEFORE
+      // re-rendering the BUTTONS section. The BUTTONS section's preconditions
+      // read from the triple store; without this, `updateButtons` would call
+      // `buildCategoryGroups` against pre-mutation triples and reach the
+      // same precondition decision as the previous render — the user-
+      // visible "click does nothing" symptom on `ems__Task_zone`-gated
+      // criticality buttons (Issue followup to #3279 button restore).
+      //
+      // Gated on `BUTTONS in affectedSections` so non-tracked frontmatter
+      // changes (timestamp bumps from ai-task workflows, claimedAt/claimedBy
+      // writes) continue to early-return at `changedProps.length === 0` /
+      // pay no triple-store + global-cache-wipe cost. The companion +150ms
+      // `scheduleHotReindex` in ExocortexPlugin still runs for the full
+      // cache-invalidation path on every "changed" event.
+      if (
+        affectedSections.includes(LayoutSection.BUTTONS) &&
+        this.prepareForRefresh
+      ) {
+        try {
+          await this.prepareForRefresh(currentFile);
+        } catch (err) {
+          this.logger.warn(
+            `[handleMetadataChange] prepareForRefresh failed for ${filePath}: ${String(err)}`,
+          );
+        }
+      }
+
       await this.incrementalUpdateHandler.updateSections(
         this.rootContainer, currentFile, affectedSections, this.currentConfig);
     }, 50);

--- a/packages/obsidian-plugin/tests/unit/UniversalLayoutRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/UniversalLayoutRenderer.test.ts
@@ -226,7 +226,7 @@ describe("UniversalLayoutRenderer", () => {
       expect(renderer_any.metadataExtractor.extractMetadata).toHaveBeenCalledWith(mockFile);
     });
 
-    it("should await prepareForRefresh BEFORE extracting metadata + updating sections", async () => {
+    it("should await prepareForRefresh BEFORE updating sections when BUTTONS is affected", async () => {
       const callOrder: string[] = [];
       const prepareForRefresh = jest.fn().mockImplementation(async () => {
         callOrder.push("prepareForRefresh");
@@ -251,11 +251,18 @@ describe("UniversalLayoutRenderer", () => {
       const renderer_any = renderer as any;
       renderer_any.currentFilePath = "test.md";
       renderer_any.rootContainer = document.createElement("div");
+      // `ems__Task_zone` maps to BUTTONS in PropertyDependencyResolver — the
+      // delta below trips the gate that runs prepareForRefresh.
       renderer_any.metadataExtractor = {
-        extractMetadata: jest.fn().mockImplementation(() => {
-          callOrder.push("extractMetadata");
-          return {};
+        extractMetadata: jest.fn().mockReturnValue({
+          ems__Task_zone: "[[e266a2e9-9eb0-431d-b1fe-b95b9d3e9a3f]]",
         }),
+      };
+      const updateSectionsSpy = jest.fn().mockImplementation(async () => {
+        callOrder.push("updateSections");
+      });
+      renderer_any.incrementalUpdateHandler = {
+        updateSections: updateSectionsSpy,
       };
 
       await renderer.handleMetadataChange("test.md");
@@ -265,10 +272,90 @@ describe("UniversalLayoutRenderer", () => {
       await Promise.resolve();
 
       expect(prepareForRefresh).toHaveBeenCalledWith(mockFile);
-      expect(callOrder[0]).toBe("prepareForRefresh");
-      expect(callOrder.indexOf("extractMetadata")).toBeGreaterThan(
+      expect(updateSectionsSpy).toHaveBeenCalled();
+      expect(callOrder.indexOf("updateSections")).toBeGreaterThan(
         callOrder.indexOf("prepareForRefresh"),
       );
+    });
+
+    it("should NOT call prepareForRefresh when no tracked property changed", async () => {
+      const prepareForRefresh = jest.fn();
+
+      const renderer = new UniversalLayoutRenderer(
+        mockApp,
+        mockSettings,
+        mockPlugin,
+        mockVaultAdapter,
+        { prepareForRefresh },
+      );
+
+      const mockFile = Object.create(TFile.prototype);
+      Object.assign(mockFile, {
+        path: "test.md",
+        extension: "md",
+        basename: "test",
+      });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      const renderer_any = renderer as any;
+      renderer_any.currentFilePath = "test.md";
+      renderer_any.rootContainer = document.createElement("div");
+      // Identical old/new metadata → empty delta → early-return before
+      // reaching the prepareForRefresh gate.
+      const sameMeta = { exo__Asset_label: "x" };
+      renderer_any.metadataCache.set("test.md", sameMeta);
+      renderer_any.metadataExtractor = {
+        extractMetadata: jest.fn().mockReturnValue(sameMeta),
+      };
+
+      await renderer.handleMetadataChange("test.md");
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+
+      expect(prepareForRefresh).not.toHaveBeenCalled();
+    });
+
+    it("should NOT call prepareForRefresh when only non-BUTTONS sections are affected", async () => {
+      const prepareForRefresh = jest.fn();
+
+      const renderer = new UniversalLayoutRenderer(
+        mockApp,
+        mockSettings,
+        mockPlugin,
+        mockVaultAdapter,
+        { prepareForRefresh },
+      );
+
+      const mockFile = Object.create(TFile.prototype);
+      Object.assign(mockFile, {
+        path: "test.md",
+        extension: "md",
+        basename: "test",
+      });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+
+      const renderer_any = renderer as any;
+      renderer_any.currentFilePath = "test.md";
+      renderer_any.rootContainer = document.createElement("div");
+      // `ems__Effort_votes` maps to DAILY_TASKS only — BUTTONS not in the
+      // affected set, so the gate should keep prepareForRefresh dormant.
+      renderer_any.metadataExtractor = {
+        extractMetadata: jest.fn().mockReturnValue({
+          ems__Effort_votes: 3,
+        }),
+      };
+      renderer_any.incrementalUpdateHandler = {
+        updateSections: jest.fn().mockResolvedValue(undefined),
+      };
+
+      await renderer.handleMetadataChange("test.md");
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(prepareForRefresh).not.toHaveBeenCalled();
+      // The sections-update pass still ran for the DAILY_TASKS section.
+      expect(renderer_any.incrementalUpdateHandler.updateSections).toHaveBeenCalled();
     });
 
     it("should not error when prepareForRefresh is not provided", async () => {
@@ -291,13 +378,21 @@ describe("UniversalLayoutRenderer", () => {
       renderer_any.currentFilePath = "test.md";
       renderer_any.rootContainer = document.createElement("div");
       renderer_any.metadataExtractor = {
-        extractMetadata: jest.fn().mockReturnValue({}),
+        extractMetadata: jest.fn().mockReturnValue({
+          ems__Task_zone: "[[e266a2e9-9eb0-431d-b1fe-b95b9d3e9a3f]]",
+        }),
+      };
+      renderer_any.incrementalUpdateHandler = {
+        updateSections: jest.fn().mockResolvedValue(undefined),
       };
 
       await renderer.handleMetadataChange("test.md");
       jest.advanceTimersByTime(100);
+      await Promise.resolve();
 
       expect(renderer_any.metadataExtractor.extractMetadata).toHaveBeenCalledWith(mockFile);
+      // No callback wired — sections still update normally.
+      expect(renderer_any.incrementalUpdateHandler.updateSections).toHaveBeenCalled();
     });
 
     it("should swallow prepareForRefresh errors and still update sections", async () => {
@@ -325,7 +420,13 @@ describe("UniversalLayoutRenderer", () => {
       renderer_any.currentFilePath = "test.md";
       renderer_any.rootContainer = document.createElement("div");
       renderer_any.metadataExtractor = {
-        extractMetadata: jest.fn().mockReturnValue({}),
+        extractMetadata: jest.fn().mockReturnValue({
+          ems__Task_zone: "[[e266a2e9-9eb0-431d-b1fe-b95b9d3e9a3f]]",
+        }),
+      };
+      const updateSectionsSpy = jest.fn().mockResolvedValue(undefined);
+      renderer_any.incrementalUpdateHandler = {
+        updateSections: updateSectionsSpy,
       };
 
       await renderer.handleMetadataChange("test.md");
@@ -335,7 +436,7 @@ describe("UniversalLayoutRenderer", () => {
 
       expect(prepareForRefresh).toHaveBeenCalled();
       // Sections-update pass still ran even though the prep step threw.
-      expect(renderer_any.metadataExtractor.extractMetadata).toHaveBeenCalledWith(mockFile);
+      expect(updateSectionsSpy).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
Hotfix for PR #3290 — code-reviewer round-1 HIGH-1 caught after auto-merge fired. Moves `prepareForRefresh` AFTER the existing delta detection / early-return + gates it on `affectedSections.includes(LayoutSection.BUTTONS)` so non-tracked frontmatter changes (timestamp bumps, ai-task worker writes) no longer pay a per-file reindex + two GLOBAL cache wipes for no UI-visible reason.

## Why
PR #3290 placed `prepareForRefresh` BEFORE `if (changedProps.length === 0) return;`. That early-return is the architecture's guarantee that non-tracked frontmatter mutations are free — bypassing it makes every `metadataCache.on("changed")` event do:
- `sparql.reindexFile(file)` — fine, per-file
- `commandResolver.invalidateCache()` — **GLOBAL `this.cache.clear()`** wipe
- `preconditionEvaluator.invalidateCache()` — **GLOBAL `this.askCache.clear()`** wipe

On hot paths (ai-task worker writing `claimedAt`/`claimedBy`/`exo__Asset_updatedAt` every 30s, "Mark Reviewed" cascades, etc.) this churns the caches for every other open leaf in every other workspace.

The user-visible fix preserved: BUTTONS is exactly the section whose preconditions need fresh triples, so gating on `affectedSections.includes(BUTTONS)` is semantically correct — narrows the new cost to zone/status mutations that actually flip buttons.

## How
- Move `prepareForRefresh` block from BEFORE delta detection to AFTER it.
- Wrap in `if (affectedSections.includes(LayoutSection.BUTTONS) && this.prepareForRefresh)`.
- Import `LayoutSection` in `UniversalLayoutRenderer.ts`.

## Tests
- Updated `should await prepareForRefresh BEFORE updating sections when BUTTONS is affected` — now uses delta-bearing metadata so the gate fires.
- Added `should NOT call prepareForRefresh when no tracked property changed` — early-return path.
- Added `should NOT call prepareForRefresh when only non-BUTTONS sections are affected` — `ems__Effort_votes` (DAILY_TASKS only) verifies the gate.
- Updated back-compat + error-swallow tests to use delta-bearing metadata.
- 43 tests pass locally (`UniversalLayoutRenderer.test.ts` + `PropertyDependencyResolver.test.ts`).

## Test plan
- [x] Unit tests for gating + early-return + non-BUTTONS path
- [x] `npm run check:types` clean
- [ ] BRAT update → click `Set Criticality High` on zone-less task → button hides, Medium/Low remain (UI smoke after Auto Release)

## Vault tracking
- `[[e511a0af-3219-4698-85b7-31845680a07c]]` parent (criticality buttons restore)
- `[[6afb3f0d-cb85-438d-8f9e-cb7afdd7100e]]` this minor