### PR TITLE
feat(palette): Duplicate current asset (homoiconic, #3292)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -74,6 +74,7 @@ export {
 } from "./services/PreconditionEvaluator";
 export {
   hasNonUidFilename,
+  hasUidFilename,
   registerDefaultHostFunctions,
 } from "./services/preconditionHostFunctions";
 export {

--- a/packages/exocortex/src/services/PreconditionEvaluator.ts
+++ b/packages/exocortex/src/services/PreconditionEvaluator.ts
@@ -134,6 +134,29 @@ export class PreconditionEvaluator {
     return this.hostFunctions.has(name);
   }
 
+  /**
+   * Synchronously evaluate a host-function precondition (Issue #3292).
+   *
+   * Returns `null` when the named host function is not registered — the
+   * caller decides whether absence means "deny" or "allow" (palette
+   * registrar treats `null` as "fail closed = false" to surface
+   * misconfiguration loudly).
+   *
+   * Used by surfaces that cannot await an async precondition — notably
+   * Obsidian's `addCommand({ checkCallback })`, which is synchronous and
+   * runs on every Command Palette open. The async {@link evaluate} method
+   * remains the canonical path for inline buttons, layouts, CLI, and any
+   * other surface that can wait for SPARQL ASK / `exoql__Query`.
+   */
+  evaluateHostFunctionSync(
+    name: string,
+    targetIRI: string,
+    context?: EvalContext,
+  ): boolean | null {
+    if (!this.hostFunctions.has(name)) return null;
+    return this.evaluateHostFunction(name, targetIRI, context);
+  }
+
   invalidateCache(): void {
     this.askCache.clear();
   }

--- a/packages/exocortex/src/services/preconditionHostFunctions.ts
+++ b/packages/exocortex/src/services/preconditionHostFunctions.ts
@@ -23,6 +23,27 @@ export const hasNonUidFilename: HostFunction = (ctx: EvalContext): boolean => {
 };
 
 /**
+ * Host function: returns `true` when the target asset's filename equals
+ * its `exo__Asset_uid` (UUID-canon, per CLAUDE.md TBox rule). Inverse of
+ * `hasNonUidFilename`. Used by palette commands that operate on
+ * UUID-canon assets only (e.g. "Duplicate current asset", Issue #3292) —
+ * automatically hides on label-named whitelist (`pn__DailyNote`,
+ * `period__Week`) and freeform `.md` files without disturbing the
+ * existing whitelist vocabulary.
+ *
+ * Returns `false` when:
+ *  - the context has no `assetUid` (file has no `exo__Asset_uid`)
+ *  - the file basename does not equal the asset's UID (label-named)
+ */
+export const hasUidFilename: HostFunction = (ctx: EvalContext): boolean => {
+  const uid = ctx.assetUid;
+  if (typeof uid !== "string" || uid.trim() === "") return false;
+  const basename = ctx.fileBasename;
+  if (typeof basename !== "string") return false;
+  return basename === uid;
+};
+
+/**
  * Register all built-in host functions on a `PreconditionEvaluator`. Call
  * this once per evaluator instance so the same well-known functions are
  * available from every code path (plugin runtime, cold-start fast resolver,
@@ -32,4 +53,5 @@ export function registerDefaultHostFunctions(
   evaluator: PreconditionEvaluator,
 ): void {
   evaluator.registerHostFunction("hasNonUidFilename", hasNonUidFilename);
+  evaluator.registerHostFunction("hasUidFilename", hasUidFilename);
 }

--- a/packages/exocortex/tests/unit/services/preconditionHostFunctions.test.ts
+++ b/packages/exocortex/tests/unit/services/preconditionHostFunctions.test.ts
@@ -2,6 +2,7 @@ import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTri
 import { PreconditionEvaluator } from "../../../src/services/PreconditionEvaluator";
 import {
   hasNonUidFilename,
+  hasUidFilename,
   registerDefaultHostFunctions,
 } from "../../../src/services/preconditionHostFunctions";
 
@@ -68,6 +69,102 @@ describe("hasNonUidFilename host function", () => {
   });
 });
 
+describe("hasUidFilename host function", () => {
+  it("returns true when basename equals assetUid", () => {
+    expect(
+      hasUidFilename({
+        targetIRI: TARGET_IRI,
+        fileBasename: UID,
+        assetUid: UID,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when basename differs from assetUid (label-named)", () => {
+    expect(
+      hasUidFilename({
+        targetIRI: TARGET_IRI,
+        fileBasename: "Human Readable Name",
+        assetUid: UID,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when assetUid is missing (no exo__Asset_uid in frontmatter)", () => {
+    expect(
+      hasUidFilename({
+        targetIRI: TARGET_IRI,
+        fileBasename: "Some Name",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when assetUid is empty string", () => {
+    expect(
+      hasUidFilename({
+        targetIRI: TARGET_IRI,
+        fileBasename: "",
+        assetUid: "",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when assetUid is whitespace-only", () => {
+    expect(
+      hasUidFilename({
+        targetIRI: TARGET_IRI,
+        fileBasename: "   ",
+        assetUid: "   ",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when fileBasename is missing", () => {
+    expect(
+      hasUidFilename({
+        targetIRI: TARGET_IRI,
+        assetUid: UID,
+      }),
+    ).toBe(false);
+  });
+
+  it("daily-note shape (basename=YYYY-MM-DD, uid=UUID): returns false (palette hidden)", () => {
+    expect(
+      hasUidFilename({
+        targetIRI: "obsidian://vault/Daily/2026-05-29.md",
+        fileBasename: "2026-05-29",
+        assetUid: UID,
+      }),
+    ).toBe(false);
+  });
+
+  it("weekly-note shape (basename=YYYY-Www, uid=UUID): returns false (palette hidden)", () => {
+    expect(
+      hasUidFilename({
+        targetIRI: "obsidian://vault/Weekly/2026-W22.md",
+        fileBasename: "2026-W22",
+        assetUid: UID,
+      }),
+    ).toBe(false);
+  });
+
+  it("is the strict logical inverse of hasNonUidFilename for valid uid+basename pairs", () => {
+    const ctx = {
+      targetIRI: TARGET_IRI,
+      fileBasename: UID,
+      assetUid: UID,
+    };
+    expect(hasUidFilename(ctx)).toBe(!hasNonUidFilename(ctx));
+
+    const ctx2 = {
+      targetIRI: TARGET_IRI,
+      fileBasename: "Some Label",
+      assetUid: UID,
+    };
+    expect(hasUidFilename(ctx2)).toBe(!hasNonUidFilename(ctx2));
+  });
+});
+
 describe("registerDefaultHostFunctions", () => {
   it("registers hasNonUidFilename on the evaluator", () => {
     const evaluator = new PreconditionEvaluator(new InMemoryTripleStore());
@@ -77,6 +174,85 @@ describe("registerDefaultHostFunctions", () => {
     registerDefaultHostFunctions(evaluator);
 
     expect(evaluator.hasHostFunction("hasNonUidFilename")).toBe(true);
+  });
+
+  it("registers hasUidFilename on the evaluator", () => {
+    const evaluator = new PreconditionEvaluator(new InMemoryTripleStore());
+
+    expect(evaluator.hasHostFunction("hasUidFilename")).toBe(false);
+
+    registerDefaultHostFunctions(evaluator);
+
+    expect(evaluator.hasHostFunction("hasUidFilename")).toBe(true);
+  });
+
+  it("evaluator routes hasUidFilename precondition through the registered fn", async () => {
+    const evaluator = new PreconditionEvaluator(new InMemoryTripleStore());
+    registerDefaultHostFunctions(evaluator);
+
+    const precondition = {
+      id: "pre-duplicate-asset",
+      label: "Has UID filename",
+      hostFunction: "hasUidFilename",
+    };
+
+    const visibleWhenUidNamed = await evaluator.evaluate(
+      precondition,
+      TARGET_IRI,
+      {
+        targetIRI: TARGET_IRI,
+        fileBasename: UID,
+        assetUid: UID,
+      },
+    );
+    expect(visibleWhenUidNamed).toBe(true);
+
+    const hiddenWhenLabelNamed = await evaluator.evaluate(
+      precondition,
+      TARGET_IRI,
+      {
+        targetIRI: TARGET_IRI,
+        fileBasename: "Human Readable Name",
+        assetUid: UID,
+      },
+    );
+    expect(hiddenWhenLabelNamed).toBe(false);
+  });
+
+  it("evaluateHostFunctionSync returns true for registered fn with passing context", () => {
+    const evaluator = new PreconditionEvaluator(new InMemoryTripleStore());
+    registerDefaultHostFunctions(evaluator);
+
+    const result = evaluator.evaluateHostFunctionSync(
+      "hasUidFilename",
+      TARGET_IRI,
+      { targetIRI: TARGET_IRI, fileBasename: UID, assetUid: UID },
+    );
+    expect(result).toBe(true);
+  });
+
+  it("evaluateHostFunctionSync returns false for registered fn with failing context", () => {
+    const evaluator = new PreconditionEvaluator(new InMemoryTripleStore());
+    registerDefaultHostFunctions(evaluator);
+
+    const result = evaluator.evaluateHostFunctionSync(
+      "hasUidFilename",
+      TARGET_IRI,
+      { targetIRI: TARGET_IRI, fileBasename: "Label", assetUid: UID },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("evaluateHostFunctionSync returns null for unregistered host function (fail-closed signal)", () => {
+    const evaluator = new PreconditionEvaluator(new InMemoryTripleStore());
+    // Do NOT register defaults — simulate misconfiguration.
+
+    const result = evaluator.evaluateHostFunctionSync(
+      "hasUidFilename",
+      TARGET_IRI,
+      { targetIRI: TARGET_IRI, fileBasename: UID, assetUid: UID },
+    );
+    expect(result).toBeNull();
   });
 
   it("evaluator routes hasNonUidFilename precondition through the registered fn", async () => {

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -681,6 +681,8 @@ export default class ExocortexPlugin extends Plugin {
             paletteFlow,
             vaultSettings,
             this.logger,
+            this.app,
+            this.preconditionEvaluator,
           ).init();
         } catch (error) {
           this.logger.error(

--- a/packages/obsidian-plugin/src/application/services/ExocmdCommandPaletteRegistrar.ts
+++ b/packages/obsidian-plugin/src/application/services/ExocmdCommandPaletteRegistrar.ts
@@ -1,4 +1,11 @@
-import type { CommandResolver, CommandExecutionFlow } from "exocortex";
+import type { App } from "obsidian";
+import type {
+  CommandResolver,
+  CommandExecutionFlow,
+  CommandDefinition,
+  PreconditionEvaluator,
+  EvalContext,
+} from "exocortex";
 import type { IVaultSettings } from "exocortex";
 import type { ExocortexPluginInterface } from "@plugin/types";
 import type { ILogger } from "@plugin/adapters/logging/ILogger";
@@ -6,12 +13,33 @@ import type { ILogger } from "@plugin/adapters/logging/ILogger";
 /**
  * Registers vault-described `exocmd__Command` assets that opt-in via
  * `exocmd__Command_paletteEnabled: true` as global Obsidian Command Palette
- * entries. Wires each command's callback to {@link CommandExecutionFlow.run}
- * with `targetIRI`/`filePath` = null (Palette has no active file) and
- * pre-injects the user's owner-identity wikilink so that `createAsset`-style
- * groundings can write `exo__Asset_isDefinedBy` without parent inheritance.
+ * entries.
  *
- * Source: code-RFC `1429fcd0-0948-4a42-89c4-8d1426e9bc7a` (PR-2).
+ * Two execution shapes are supported:
+ *
+ * 1. **No-target palette commands** (the original RFC 1429fcd0 PR-2 shape):
+ *    commands with no `precondition` and groundings whose semantics do not
+ *    require an active file (e.g. `createAsset` writing to a literal default
+ *    folder). Wired as `addCommand({ callback })` — always visible.
+ *
+ * 2. **Active-target palette commands** (Issue #3292): commands with a
+ *    host-function `precondition` (e.g. `hasUidFilename`). Wired as
+ *    `addCommand({ checkCallback })`; visibility is gated by synchronously
+ *    evaluating the host function against the active file's metadata, and
+ *    the active file's `obsidian://vault/<encoded-path>` IRI is forwarded as
+ *    `targetIRI` at execution time so service-call groundings (e.g.
+ *    `duplicateAsset`) can resolve the source file.
+ *
+ *    SPARQL ASK and `exoql__Query` preconditions are intentionally NOT
+ *    supported on the palette code path — Obsidian's `checkCallback` is
+ *    synchronous, and pre-caching SPARQL evaluations across active-leaf
+ *    changes would be invisible scope growth beyond this issue. A precondition
+ *    asset with `sparqlAsk` / `query` but no `hostFunction` causes the command
+ *    to be skipped at registration with a warning, so misconfiguration fails
+ *    loudly instead of silently surfacing an always-visible button.
+ *
+ * Source: code-RFC `1429fcd0-0948-4a42-89c4-8d1426e9bc7a` (PR-2) +
+ *         Issue #3292 (precondition + active-target extension).
  *
  * Known limitation: Obsidian's public API does NOT expose `removeCommand`,
  * so newly-added (or removed) `paletteEnabled` assets only surface after a
@@ -25,6 +53,8 @@ export class ExocmdCommandPaletteRegistrar {
     private readonly commandExecutionFlow: CommandExecutionFlow,
     private readonly vaultSettings: IVaultSettings,
     private readonly logger: ILogger,
+    private readonly app?: App,
+    private readonly preconditionEvaluator?: PreconditionEvaluator,
   ) {}
 
   async init(): Promise<void> {
@@ -48,26 +78,164 @@ export class ExocmdCommandPaletteRegistrar {
       // above).
       const ownerIdentity = this.vaultSettings.getOwnerIdentity();
 
-      this.plugin.addCommand({
-        id: paletteId,
-        name: command.name,
-        callback: () => {
+      if (this.isActiveTargetCommand(command)) {
+        this.registerActiveTargetCommand(
+          command,
+          paletteId,
+          ownerIdentity,
+        );
+      } else {
+        this.registerNoTargetCommand(command, paletteId, ownerIdentity);
+      }
+    }
+  }
+
+  /**
+   * Active-target commands have a precondition with a `hostFunction` — they
+   * operate on the currently open file and use the precondition to gate
+   * Command Palette visibility against it. Falls back to no-target shape
+   * (with a warning) if `app` or `preconditionEvaluator` were not injected
+   * — preserves backward compatibility with any caller that still uses the
+   * 5-argument constructor.
+   */
+  private isActiveTargetCommand(command: CommandDefinition): boolean {
+    const pre = command.precondition;
+    if (!pre) return false;
+
+    // SPARQL-only preconditions cannot be evaluated synchronously — skip.
+    // Logged at registration so misconfiguration is visible.
+    if (!pre.hostFunction) {
+      this.logger.warn(
+        `[ExocmdCommandPaletteRegistrar] paletteEnabled command "${command.name}" has a non-host-function precondition (sparqlAsk/exoql query) — palette path supports host-function preconditions only; command skipped`,
+      );
+      return false;
+    }
+
+    if (!this.app || !this.preconditionEvaluator) {
+      this.logger.warn(
+        `[ExocmdCommandPaletteRegistrar] paletteEnabled command "${command.name}" has a host-function precondition but registrar was constructed without app/preconditionEvaluator dependencies — falling back to always-visible no-target registration`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  private registerNoTargetCommand(
+    command: CommandDefinition,
+    paletteId: string,
+    ownerIdentity: string | null,
+  ): void {
+    this.plugin.addCommand({
+      id: paletteId,
+      name: command.name,
+      callback: () => {
+        void this.commandExecutionFlow.run(
+          { command, binding: SYNTHETIC_PALETTE_BINDING },
+          {
+            targetIRI: null,
+            filePath: null,
+            injectedUserInput: { ownerIdentity },
+          },
+        );
+      },
+    });
+
+    this.logger.info(
+      `[ExocmdCommandPaletteRegistrar] Registered "${command.name}" as palette command "${paletteId}"`,
+    );
+  }
+
+  private registerActiveTargetCommand(
+    command: CommandDefinition,
+    paletteId: string,
+    ownerIdentity: string | null,
+  ): void {
+    // `isActiveTargetCommand` already enforced all three of these to be
+    // present — narrow once here so the closure body stays clean.
+    const { app, preconditionEvaluator: evaluator } = this;
+    const hostFunctionName = command.precondition?.hostFunction;
+    if (!app || !evaluator || !hostFunctionName) {
+      // Defensive — should never fire given `isActiveTargetCommand` returned
+      // true. Keeps the type narrowing local without `!` assertions.
+      this.logger.warn(
+        `[ExocmdCommandPaletteRegistrar] Unexpected: active-target registration called without complete deps for "${command.name}"`,
+      );
+      this.registerNoTargetCommand(command, paletteId, ownerIdentity);
+      return;
+    }
+
+    this.plugin.addCommand({
+      id: paletteId,
+      name: command.name,
+      checkCallback: (checking: boolean): boolean => {
+        const ctx = readActiveFileContext(app);
+        if (ctx === null) return false;
+
+        // Synchronously evaluate the host-function precondition.
+        // `evaluateHostFunctionSync` returns null only when the host
+        // function is not registered — treat as fail-closed.
+        const visible = evaluator.evaluateHostFunctionSync(
+          hostFunctionName,
+          ctx.targetIRI,
+          ctx.evalContext,
+        );
+        if (visible !== true) return false;
+
+        if (!checking) {
           void this.commandExecutionFlow.run(
             { command, binding: SYNTHETIC_PALETTE_BINDING },
             {
-              targetIRI: null,
-              filePath: null,
+              targetIRI: ctx.targetIRI,
+              filePath: ctx.filePath,
               injectedUserInput: { ownerIdentity },
             },
           );
-        },
-      });
+        }
+        return true;
+      },
+    });
 
-      this.logger.info(
-        `[ExocmdCommandPaletteRegistrar] Registered "${command.name}" as palette command "${paletteId}"`,
-      );
-    }
+    this.logger.info(
+      `[ExocmdCommandPaletteRegistrar] Registered active-target palette command "${command.name}" (id=${paletteId}, precondition=${hostFunctionName})`,
+    );
   }
+}
+
+/**
+ * Extracts the precondition `EvalContext` + targetIRI/filePath payload from
+ * the currently active markdown file. Returns `null` when there is no
+ * active file — the precondition is treated as "fail closed" upstream, so
+ * the command stays hidden.
+ *
+ * The shape mirrors `DynamicCommandButtonGroupBuilder` (`evalContext` with
+ * `targetIRI`, `fileBasename`, `currentFolder`, `assetUid`) so existing
+ * host functions (e.g. `hasNonUidFilename` / `hasUidFilename`) work on the
+ * palette code path without modification.
+ */
+function readActiveFileContext(app: App): {
+  targetIRI: string;
+  filePath: string;
+  evalContext: EvalContext;
+} | null {
+  const file = app.workspace.getActiveFile();
+  if (!file) return null;
+
+  const targetIRI = `obsidian://vault/${encodeURI(file.path)}`;
+  const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+  const rawUid = frontmatter?.exo__Asset_uid;
+  const assetUid = typeof rawUid === "string" ? rawUid : undefined;
+
+  return {
+    targetIRI,
+    filePath: file.path,
+    evalContext: {
+      targetIRI,
+      fileBasename: file.basename,
+      currentFolder: file.parent?.path,
+      assetUid,
+    },
+  };
 }
 
 /**

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -50,6 +50,7 @@ import {
   createUpdatePropertyService,
   createRemovePropertyService,
   createSetStatusService,
+  createDuplicateAssetService,
   type IPathResolver,
 } from "@kitelev/exocortex-services";
 import type { SPARQLApi } from "../../application/api/SPARQLApi";
@@ -322,6 +323,19 @@ export function populateServiceRegistry(
     registry.register(
       "renameToUid",
       createRenameToUidService(vaultAdapter, renameToUidService, targetResolver),
+    );
+
+    // Issue #3292 — homoiconic palette command "Duplicate current asset"
+    // (vault asset describes id/icon/label/precondition; this TS hook owns
+    // the per-platform file-ops integration). Reuses `openCreatedFileInTab`
+    // to focus the new asset in a workspace tab, mirroring createRelatedTask.
+    registry.register(
+      "duplicateAsset",
+      createDuplicateAssetService(
+        vaultAdapter,
+        targetResolver,
+        openCreatedFileInTab,
+      ),
     );
 
     registry.register(

--- a/packages/obsidian-plugin/tests/unit/application/services/ExocmdCommandPaletteRegistrar.activeTarget.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/services/ExocmdCommandPaletteRegistrar.activeTarget.test.ts
@@ -1,0 +1,376 @@
+import { ExocmdCommandPaletteRegistrar } from "../../../../src/application/services/ExocmdCommandPaletteRegistrar";
+import { InMemoryTripleStore } from "exocortex";
+import { PreconditionEvaluator } from "exocortex";
+import { registerDefaultHostFunctions } from "exocortex";
+
+/**
+ * Unit tests for `ExocmdCommandPaletteRegistrar` covering both code paths:
+ *
+ *  - **No-target shape** (RFC 1429fcd0 PR-2): commands without a precondition
+ *    are wired as `addCommand({ callback })` — always visible in the Palette,
+ *    invoked with `targetIRI: null, filePath: null`.
+ *
+ *  - **Active-target shape** (Issue #3292): commands with a `hostFunction`
+ *    precondition are wired as `addCommand({ checkCallback })` — visibility
+ *    is gated by synchronously evaluating the host function against the
+ *    active file's metadata, and the active file's IRI is passed at exec
+ *    time so service-call groundings (e.g. `duplicateAsset`) can resolve
+ *    the source.
+ *
+ * The fakes mirror the real Obsidian + exocortex API contract per
+ * `~/.claude/rules/test-fixture-realism.md` — `getFirstLinkpathDest`
+ * semantics, frontmatter shape, and the `EvalContext` keys
+ * (`fileBasename`, `currentFolder`, `assetUid`) that real host functions
+ * use are all reproduced as they appear in production.
+ */
+
+type CommandShape = {
+  id: string;
+  name: string;
+  callback?: () => void;
+  checkCallback?: (checking: boolean) => boolean;
+};
+
+function makePlugin(): {
+  addCommand: jest.Mock;
+  registered: CommandShape[];
+} {
+  const registered: CommandShape[] = [];
+  const addCommand = jest.fn((c: CommandShape) => {
+    registered.push(c);
+  });
+  return { addCommand, registered };
+}
+
+function makeCommandResolver(
+  entries: Array<{
+    command: unknown;
+    paletteId: string;
+  }>,
+): unknown {
+  return {
+    findPaletteEnabledCommands: async () => entries,
+  };
+}
+
+function makeFlow(): {
+  run: jest.Mock;
+} {
+  return { run: jest.fn(async () => {}) };
+}
+
+function makeVaultSettings(owner: string | null): unknown {
+  return { getOwnerIdentity: () => owner };
+}
+
+function makeLogger(): {
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+} {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+function makeApp(active: {
+  path: string;
+  basename: string;
+  parentPath: string;
+  frontmatter: Record<string, unknown> | undefined;
+} | null): unknown {
+  const file = active
+    ? {
+        path: active.path,
+        basename: active.basename,
+        parent: { path: active.parentPath },
+      }
+    : null;
+  return {
+    workspace: { getActiveFile: () => file },
+    metadataCache: {
+      getFileCache: (f: unknown) => {
+        if (!file || f !== file) return undefined;
+        return { frontmatter: active!.frontmatter };
+      },
+    },
+  };
+}
+
+function makeEvaluator(): PreconditionEvaluator {
+  const evaluator = new PreconditionEvaluator(new InMemoryTripleStore());
+  registerDefaultHostFunctions(evaluator);
+  return evaluator;
+}
+
+describe("ExocmdCommandPaletteRegistrar — no-target commands (RFC 1429fcd0)", () => {
+  it("registers always-visible callback command when command has no precondition", async () => {
+    const plugin = makePlugin();
+    const flow = makeFlow();
+    const command = {
+      id: "uid-1",
+      name: "Create Note",
+      grounding: {
+        id: "g1",
+        label: "g",
+        type: "service_call",
+      },
+    };
+    const resolver = makeCommandResolver([
+      { command, paletteId: "create-note" },
+    ]);
+
+    await new ExocmdCommandPaletteRegistrar(
+      plugin as never,
+      resolver as never,
+      flow as never,
+      makeVaultSettings("[[!kitelev]]") as never,
+      makeLogger() as never,
+    ).init();
+
+    expect(plugin.addCommand).toHaveBeenCalledTimes(1);
+    const registered = plugin.registered[0];
+    expect(registered.id).toBe("create-note");
+    expect(registered.name).toBe("Create Note");
+    expect(registered.callback).toBeDefined();
+    expect(registered.checkCallback).toBeUndefined();
+
+    // Invoking callback dispatches the flow with null target — matches
+    // the RFC 1429fcd0 "no active file" contract.
+    registered.callback!();
+    expect(flow.run).toHaveBeenCalledWith(
+      expect.objectContaining({ command }),
+      expect.objectContaining({
+        targetIRI: null,
+        filePath: null,
+        injectedUserInput: { ownerIdentity: "[[!kitelev]]" },
+      }),
+    );
+  });
+});
+
+describe("ExocmdCommandPaletteRegistrar — active-target commands (Issue #3292)", () => {
+  const HOST_FUNCTION_COMMAND = {
+    id: "dup-1",
+    name: "Duplicate current asset",
+    grounding: { id: "g-dup", label: "Dup", type: "service_call" },
+    precondition: {
+      id: "pre-1",
+      label: "Has UID filename",
+      hostFunction: "hasUidFilename",
+    },
+  };
+
+  it("uses checkCallback and gates visibility on the host-function precondition", async () => {
+    const uid = "11111111-1111-4111-8111-111111111111";
+    const plugin = makePlugin();
+    const flow = makeFlow();
+    const resolver = makeCommandResolver([
+      { command: HOST_FUNCTION_COMMAND, paletteId: "duplicate-current-asset" },
+    ]);
+
+    await new ExocmdCommandPaletteRegistrar(
+      plugin as never,
+      resolver as never,
+      flow as never,
+      makeVaultSettings(null) as never,
+      makeLogger() as never,
+      makeApp({
+        path: `inbox/${uid}.md`,
+        basename: uid,
+        parentPath: "inbox",
+        frontmatter: { exo__Asset_uid: uid },
+      }) as never,
+      makeEvaluator(),
+    ).init();
+
+    const registered = plugin.registered[0];
+    expect(registered.checkCallback).toBeDefined();
+    expect(registered.callback).toBeUndefined();
+
+    // checking=true on a UID-named asset with matching uid → visible
+    expect(registered.checkCallback!(true)).toBe(true);
+    // Flow not invoked during visibility check
+    expect(flow.run).not.toHaveBeenCalled();
+
+    // checking=false: invoke the flow with the active file's IRI + path
+    registered.checkCallback!(false);
+    expect(flow.run).toHaveBeenCalledWith(
+      expect.objectContaining({ command: HOST_FUNCTION_COMMAND }),
+      expect.objectContaining({
+        targetIRI: `obsidian://vault/inbox/${uid}.md`,
+        filePath: `inbox/${uid}.md`,
+      }),
+    );
+  });
+
+  it("hides the command when active file is a daily note (basename != uid)", async () => {
+    const uid = "22222222-2222-4222-8222-222222222222";
+    const plugin = makePlugin();
+    const flow = makeFlow();
+    const resolver = makeCommandResolver([
+      { command: HOST_FUNCTION_COMMAND, paletteId: "duplicate-current-asset" },
+    ]);
+
+    await new ExocmdCommandPaletteRegistrar(
+      plugin as never,
+      resolver as never,
+      flow as never,
+      makeVaultSettings(null) as never,
+      makeLogger() as never,
+      makeApp({
+        path: "Daily/2026-05-29.md",
+        basename: "2026-05-29",
+        parentPath: "Daily",
+        frontmatter: { exo__Asset_uid: uid },
+      }) as never,
+      makeEvaluator(),
+    ).init();
+
+    const registered = plugin.registered[0];
+    expect(registered.checkCallback!(true)).toBe(false);
+    expect(flow.run).not.toHaveBeenCalled();
+  });
+
+  it("hides the command when active file has no exo__Asset_uid (freeform .md)", async () => {
+    const plugin = makePlugin();
+    const flow = makeFlow();
+    const resolver = makeCommandResolver([
+      { command: HOST_FUNCTION_COMMAND, paletteId: "duplicate-current-asset" },
+    ]);
+
+    await new ExocmdCommandPaletteRegistrar(
+      plugin as never,
+      resolver as never,
+      flow as never,
+      makeVaultSettings(null) as never,
+      makeLogger() as never,
+      makeApp({
+        path: "Notes/Freeform.md",
+        basename: "Freeform",
+        parentPath: "Notes",
+        frontmatter: undefined,
+      }) as never,
+      makeEvaluator(),
+    ).init();
+
+    expect(plugin.registered[0].checkCallback!(true)).toBe(false);
+  });
+
+  it("hides the command when there is no active file (Cmd-P opened with no open file)", async () => {
+    const plugin = makePlugin();
+    const flow = makeFlow();
+    const resolver = makeCommandResolver([
+      { command: HOST_FUNCTION_COMMAND, paletteId: "duplicate-current-asset" },
+    ]);
+
+    await new ExocmdCommandPaletteRegistrar(
+      plugin as never,
+      resolver as never,
+      flow as never,
+      makeVaultSettings(null) as never,
+      makeLogger() as never,
+      makeApp(null) as never,
+      makeEvaluator(),
+    ).init();
+
+    expect(plugin.registered[0].checkCallback!(true)).toBe(false);
+  });
+
+  it("hides the command when the host function is not registered (fail-closed signal)", async () => {
+    const plugin = makePlugin();
+    const flow = makeFlow();
+    const command = {
+      ...HOST_FUNCTION_COMMAND,
+      precondition: {
+        id: "pre-x",
+        label: "x",
+        hostFunction: "neverRegistered",
+      },
+    };
+    const resolver = makeCommandResolver([
+      { command, paletteId: "duplicate-current-asset" },
+    ]);
+
+    const uid = "33333333-3333-4333-8333-333333333333";
+    await new ExocmdCommandPaletteRegistrar(
+      plugin as never,
+      resolver as never,
+      flow as never,
+      makeVaultSettings(null) as never,
+      makeLogger() as never,
+      makeApp({
+        path: `f/${uid}.md`,
+        basename: uid,
+        parentPath: "f",
+        frontmatter: { exo__Asset_uid: uid },
+      }) as never,
+      makeEvaluator(),
+    ).init();
+
+    expect(plugin.registered[0].checkCallback!(true)).toBe(false);
+  });
+
+  it("skips and warns for commands with non-host-function preconditions (SPARQL ASK)", async () => {
+    const plugin = makePlugin();
+    const flow = makeFlow();
+    const command = {
+      ...HOST_FUNCTION_COMMAND,
+      precondition: {
+        id: "pre-sparql",
+        label: "sparql-only",
+        sparqlAsk: "ASK { ?s ?p ?o }",
+      },
+    };
+    const resolver = makeCommandResolver([
+      { command, paletteId: "x" },
+    ]);
+    const logger = makeLogger();
+
+    await new ExocmdCommandPaletteRegistrar(
+      plugin as never,
+      resolver as never,
+      flow as never,
+      makeVaultSettings(null) as never,
+      logger as never,
+      makeApp(null) as never,
+      makeEvaluator(),
+    ).init();
+
+    // SPARQL-only precondition: falls back to no-target callback (always visible),
+    // logged at warn level so misconfiguration is observable.
+    expect(plugin.registered[0].callback).toBeDefined();
+    expect(plugin.registered[0].checkCallback).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "non-host-function precondition (sparqlAsk/exoql query)",
+      ),
+    );
+  });
+
+  it("falls back to no-target when app/preconditionEvaluator are not injected (backward compat)", async () => {
+    const plugin = makePlugin();
+    const flow = makeFlow();
+    const resolver = makeCommandResolver([
+      { command: HOST_FUNCTION_COMMAND, paletteId: "duplicate-current-asset" },
+    ]);
+    const logger = makeLogger();
+
+    // Five-argument constructor — pre-#3292 caller shape.
+    await new ExocmdCommandPaletteRegistrar(
+      plugin as never,
+      resolver as never,
+      flow as never,
+      makeVaultSettings(null) as never,
+      logger as never,
+    ).init();
+
+    expect(plugin.registered[0].callback).toBeDefined();
+    expect(plugin.registered[0].checkCallback).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("falling back to always-visible no-target"),
+    );
+  });
+});

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -555,3 +555,117 @@ export function createSetStatusService(
     },
   };
 }
+
+/**
+ * Shared factory for the `duplicateAsset` `service_call` grounding (Issue
+ * #3292). Creates a byte-verbatim copy of the target asset's file in the same
+ * folder with two surgical frontmatter substitutions:
+ *
+ *  - `exo__Asset_uid`   →   freshly-generated UUID v4
+ *  - `exo__Asset_createdAt` → local ISO timestamp (now)
+ *
+ * Everything else (label, modifiedAt, instance class, relations, prototype,
+ * parent, all class-specific properties, the markdown body) is preserved
+ * unchanged — including filled checklist items, SPARQL blocks, and trailing
+ * whitespace. The new file is named `<new-uid>.md` per the UUID-canon rule.
+ *
+ * Visibility (when surfaced through `exocmd__Command_paletteEnabled`) is
+ * gated by the `hasUidFilename` host-function precondition — palette entry
+ * is hidden when the active file isn't itself a UUID-canon Exocortex asset
+ * (freeform notes, daily/weekly notes via the `pn__DailyNote` /
+ * `period__Week` whitelist, ontology TBox label-named files). See
+ * `preconditionHostFunctions.ts:hasUidFilename`.
+ *
+ * The `onCreated` callback is the Obsidian-specific tab-opening hook
+ * (mirrors `createRelatedTask` etc); CLI runtimes can omit it.
+ */
+export function createDuplicateAssetService(
+  vaultAdapter: IVaultAdapter,
+  resolver: ITargetResolver = createPathBasedTargetResolver(vaultAdapter),
+  onCreated?: OnCreatedCallback,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string): Promise<void> {
+      if (!targetIRI) {
+        throw new Error(
+          "duplicateAsset requires an active target — open an Exocortex asset before invoking",
+        );
+      }
+
+      const sourceFile = resolver.resolveFile(targetIRI);
+      const sourceContent = await vaultAdapter.read(sourceFile);
+
+      const newUid = crypto.randomUUID();
+      const newCreatedAt = DateFormatter.toLocalTimestamp(new Date());
+
+      const duplicatedContent = rewriteFrontmatterScalars(sourceContent, {
+        exo__Asset_uid: newUid,
+        exo__Asset_createdAt: newCreatedAt,
+      });
+
+      const folderPath = sourceFile.parent?.path ?? "";
+      const newPath = folderPath
+        ? `${folderPath}/${newUid}.md`
+        : `${newUid}.md`;
+
+      const createdFile = await vaultAdapter.create(newPath, duplicatedContent);
+
+      if (onCreated) {
+        await onCreated(createdFile);
+      }
+    },
+  };
+}
+
+/**
+ * Replace top-level scalar values in a markdown file's leading YAML
+ * frontmatter block. Preserves the document byte-for-byte except for the
+ * specific keys whose values are rewritten; if a key exists, its line is
+ * rewritten in place (preserving leading whitespace) — if absent, a new
+ * line is appended just before the closing `---` fence.
+ *
+ * Pure text manipulation (no YAML parse → serialize) so it does not
+ * re-order keys, re-indent lists, collapse comments, or change quoting
+ * style anywhere else. Out of scope: nested keys, block scalars, or
+ * documents without a leading frontmatter block (caller's responsibility
+ * to ensure the input has one).
+ *
+ * @internal — exported for unit testing only.
+ */
+export function rewriteFrontmatterScalars(
+  content: string,
+  replacements: Record<string, string>,
+): string {
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch) {
+    throw new Error(
+      "duplicateAsset: source file has no YAML frontmatter block",
+    );
+  }
+
+  const frontmatterBody = fmMatch[1];
+  const remaining = new Map(Object.entries(replacements));
+
+  const rewrittenLines = frontmatterBody.split("\n").map((line) => {
+    // Top-level key: optional indent then `key:` then anything after.
+    // Skip indented lines (list items, nested mappings) by matching only
+    // at column 0.
+    const keyMatch = line.match(/^([A-Za-z_][A-Za-z0-9_]*):/);
+    if (!keyMatch) return line;
+    const key = keyMatch[1];
+    const newValue = remaining.get(key);
+    if (newValue === undefined) return line;
+    remaining.delete(key);
+    return `${key}: ${newValue}`;
+  });
+
+  // Append keys that were not present in the source frontmatter.
+  for (const [key, value] of remaining) {
+    rewrittenLines.push(`${key}: ${value}`);
+  }
+
+  const rewrittenBody = rewrittenLines.join("\n");
+  const eol = fmMatch[0].includes("\r\n") ? "\r\n" : "\n";
+  const head = `---${eol}${rewrittenBody}${eol}---`;
+  return head + content.slice(fmMatch[0].length);
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -34,6 +34,8 @@ export {
   createUpdatePropertyService,
   createRemovePropertyService,
   createSetStatusService,
+  createDuplicateAssetService,
+  rewriteFrontmatterScalars,
   createPathBasedTargetResolver,
   type ITargetResolver,
   type IPathResolver,

--- a/packages/services/tests/grounding-service-factories.test.ts
+++ b/packages/services/tests/grounding-service-factories.test.ts
@@ -13,6 +13,8 @@ import {
   createUpdatePropertyService,
   createRemovePropertyService,
   createSetStatusService,
+  createDuplicateAssetService,
+  rewriteFrontmatterScalars,
   type IPathResolver,
 } from "../src/index";
 
@@ -723,6 +725,358 @@ describe("@kitelev/exocortex-services — factory contract", () => {
       const content = fs.writes[0].content;
       expect(content).toMatch(/ems__Effort_parent: "\[\[Foo\]\]"/);
       expect(content).not.toMatch(/ems__Effort_area: "\[\[Foo\]\]"/);
+    });
+  });
+
+  describe("rewriteFrontmatterScalars (Issue #3292 helper)", () => {
+    it("replaces existing top-level scalar in place, preserving all other lines verbatim", () => {
+      const input = [
+        "---",
+        "exo__Asset_uid: old-uid-abc",
+        "exo__Asset_label: My Task",
+        "exo__Asset_createdAt: 2026-01-01T10:00:00",
+        "exo__Instance_class:",
+        '  - "[[ems__Task]]"',
+        "---",
+        "",
+        "# Body title",
+        "- [x] step one",
+        "- [ ] step two",
+      ].join("\n");
+
+      const out = rewriteFrontmatterScalars(input, {
+        exo__Asset_uid: "new-uid-xyz",
+        exo__Asset_createdAt: "2026-05-29T17:30:00",
+      });
+
+      expect(out).toContain("exo__Asset_uid: new-uid-xyz");
+      expect(out).toContain("exo__Asset_createdAt: 2026-05-29T17:30:00");
+      // Untouched lines stay verbatim
+      expect(out).toContain("exo__Asset_label: My Task");
+      expect(out).toContain('  - "[[ems__Task]]"');
+      // Body preserved including filled checklist (vebatim copy guarantee)
+      expect(out).toContain("# Body title");
+      expect(out).toContain("- [x] step one");
+      expect(out).toContain("- [ ] step two");
+      // Old UID is gone — surgical replacement, not append
+      expect(out).not.toContain("old-uid-abc");
+      expect(out).not.toContain("2026-01-01T10:00:00");
+    });
+
+    it("appends keys that were absent from source frontmatter, before the closing fence", () => {
+      const input = "---\nexo__Asset_uid: u1\n---\n\nbody";
+      const out = rewriteFrontmatterScalars(input, {
+        exo__Asset_uid: "u2",
+        exo__Asset_createdAt: "2026-05-29T17:30:00",
+      });
+      expect(out).toMatch(/exo__Asset_uid: u2/);
+      expect(out).toMatch(/exo__Asset_createdAt: 2026-05-29T17:30:00\n---/);
+      expect(out).toMatch(/---\n\nbody$/);
+    });
+
+    it("preserves CRLF line endings if source has them", () => {
+      const input = "---\r\nexo__Asset_uid: u1\r\n---\r\n\r\nbody";
+      const out = rewriteFrontmatterScalars(input, { exo__Asset_uid: "u2" });
+      expect(out).toContain("exo__Asset_uid: u2");
+      expect(out).toContain("\r\n---");
+    });
+
+    it("does not touch indented (nested) lines with the same key suffix", () => {
+      // Nested key with leading whitespace must NOT be matched (top-level only).
+      const input = [
+        "---",
+        "exo__Asset_uid: outer",
+        "nested:",
+        "  exo__Asset_uid: inner",
+        "---",
+        "",
+        "body",
+      ].join("\n");
+      const out = rewriteFrontmatterScalars(input, { exo__Asset_uid: "NEW" });
+      expect(out).toContain("exo__Asset_uid: NEW");
+      // The indented inner value stays
+      expect(out).toContain("  exo__Asset_uid: inner");
+    });
+
+    it("preserves array lists, wikilinks, quoted values, and comments byte-for-byte", () => {
+      const input = [
+        "---",
+        "exo__Asset_uid: old",
+        "exo__Asset_label: 'My Task'",
+        '# This comment must survive verbatim',
+        "exo__Instance_class:",
+        '  - "[[ems__Task]]"',
+        '  - "[[anotherClass]]"',
+        'aliases: ["A", "B"]',
+        "---",
+        "",
+        "Body with [[wikilinks]] and ```sparql blocks```",
+      ].join("\n");
+      const out = rewriteFrontmatterScalars(input, {
+        exo__Asset_uid: "new",
+      });
+      // The only intended change
+      expect(out).toContain("exo__Asset_uid: new");
+      expect(out).not.toContain("exo__Asset_uid: old");
+      // Everything else verbatim
+      expect(out).toContain("exo__Asset_label: 'My Task'");
+      expect(out).toContain("# This comment must survive verbatim");
+      expect(out).toContain('  - "[[ems__Task]]"');
+      expect(out).toContain('  - "[[anotherClass]]"');
+      expect(out).toContain('aliases: ["A", "B"]');
+      expect(out).toContain("Body with [[wikilinks]] and ```sparql blocks```");
+    });
+
+    it("throws when source has no YAML frontmatter (freeform markdown)", () => {
+      expect(() => rewriteFrontmatterScalars("# Just a heading\nbody", {})).toThrow(
+        /no YAML frontmatter block/,
+      );
+    });
+  });
+
+  describe("createDuplicateAssetService (Issue #3292)", () => {
+    interface DupeFile {
+      path: string;
+      basename: string;
+      parent: { path: string };
+    }
+
+    function makeDupeAdapter(opts: {
+      sourcePath: string;
+      sourceBasename: string;
+      sourceFolder: string;
+      sourceContent: string;
+    }): {
+      adapter: never;
+      created: { path: string; content: string }[];
+    } {
+      const sourceFile: DupeFile = {
+        path: opts.sourcePath,
+        basename: opts.sourceBasename,
+        parent: { path: opts.sourceFolder },
+      };
+      const created: { path: string; content: string }[] = [];
+      const adapter = {
+        getAbstractFileByPath: (path: string): DupeFile | null => {
+          if (path === `${opts.sourcePath}` || path === `${opts.sourcePath}.md`) {
+            return sourceFile;
+          }
+          return null;
+        },
+        read: async (_f: DupeFile): Promise<string> => opts.sourceContent,
+        create: async (path: string, content: string): Promise<DupeFile> => {
+          created.push({ path, content });
+          return {
+            path,
+            basename: path.replace(/\.md$/, "").split("/").pop()!,
+            parent: { path: path.split("/").slice(0, -1).join("/") },
+          };
+        },
+      } as never;
+      return { adapter, created };
+    }
+
+    it("creates a new file with new UID + new createdAt, body verbatim, in the same folder", async () => {
+      const originalUid = "11111111-1111-4111-8111-111111111111";
+      const sourceContent = [
+        "---",
+        `exo__Asset_uid: ${originalUid}`,
+        "exo__Asset_label: Weekly Review",
+        "exo__Asset_createdAt: 2026-01-01T10:00:00",
+        "exo__Instance_class:",
+        '  - "[[ems__Task]]"',
+        "---",
+        "",
+        "# Review",
+        "- [x] last week wrap-up",
+        "- [ ] this week plan",
+      ].join("\n");
+
+      const { adapter, created } = makeDupeAdapter({
+        sourcePath: `03 Knowledge/inbox/${originalUid}`,
+        sourceBasename: originalUid,
+        sourceFolder: "03 Knowledge/inbox",
+        sourceContent,
+      });
+
+      const resolver = {
+        resolveFile: (iri: string) => {
+          const a = adapter as unknown as {
+            getAbstractFileByPath: (p: string) => DupeFile;
+          };
+          return a.getAbstractFileByPath(iri) as never;
+        },
+      };
+
+      const onCreatedSeen: string[] = [];
+      const service = createDuplicateAssetService(
+        adapter,
+        resolver,
+        async (file) => {
+          onCreatedSeen.push((file as DupeFile).path);
+        },
+      );
+
+      await service.execute(`03 Knowledge/inbox/${originalUid}`);
+
+      expect(created).toHaveLength(1);
+      const written = created[0];
+
+      // Filename = <new-uid>.md in source folder
+      expect(written.path).toMatch(
+        /^03 Knowledge\/inbox\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.md$/,
+      );
+      const newUid = written.path.replace(/^.*\/(.+)\.md$/, "$1");
+      expect(newUid).not.toBe(originalUid);
+
+      // Frontmatter — new UID substituted, original gone
+      expect(written.content).toContain(`exo__Asset_uid: ${newUid}`);
+      expect(written.content).not.toContain(`exo__Asset_uid: ${originalUid}`);
+
+      // createdAt is new, ISO local format (no Z suffix per DateFormatter.toLocalTimestamp)
+      expect(written.content).toMatch(
+        /exo__Asset_createdAt: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?!Z)/,
+      );
+      expect(written.content).not.toContain("2026-01-01T10:00:00");
+
+      // Other fields preserved (label, instance class)
+      expect(written.content).toContain("exo__Asset_label: Weekly Review");
+      expect(written.content).toContain('  - "[[ems__Task]]"');
+
+      // Body verbatim, including filled checklist
+      expect(written.content).toContain("# Review");
+      expect(written.content).toContain("- [x] last week wrap-up");
+      expect(written.content).toContain("- [ ] this week plan");
+
+      // onCreated callback fired with the new file
+      expect(onCreatedSeen).toEqual([written.path]);
+    });
+
+    it("two duplications of the same source produce two different new UIDs (freshness check)", async () => {
+      const originalUid = "22222222-2222-4222-8222-222222222222";
+      const sourceContent = [
+        "---",
+        `exo__Asset_uid: ${originalUid}`,
+        "exo__Asset_createdAt: 2026-01-01T10:00:00",
+        "---",
+        "",
+        "body",
+      ].join("\n");
+
+      const { adapter, created } = makeDupeAdapter({
+        sourcePath: `inbox/${originalUid}`,
+        sourceBasename: originalUid,
+        sourceFolder: "inbox",
+        sourceContent,
+      });
+      const resolver = {
+        resolveFile: (iri: string) =>
+          (adapter as unknown as {
+            getAbstractFileByPath: (p: string) => DupeFile;
+          }).getAbstractFileByPath(iri) as never,
+      };
+      const service = createDuplicateAssetService(adapter, resolver);
+
+      await service.execute(`inbox/${originalUid}`);
+      await service.execute(`inbox/${originalUid}`);
+
+      expect(created).toHaveLength(2);
+      expect(created[0].path).not.toBe(created[1].path);
+    });
+
+    it("preserves modifiedAt unchanged (rule: only uid + createdAt differ)", async () => {
+      const originalUid = "33333333-3333-4333-8333-333333333333";
+      const sourceContent = [
+        "---",
+        `exo__Asset_uid: ${originalUid}`,
+        "exo__Asset_createdAt: 2026-01-01T10:00:00",
+        "exo__Asset_modifiedAt: 2026-02-15T14:30:00",
+        "---",
+        "",
+        "body",
+      ].join("\n");
+
+      const { adapter, created } = makeDupeAdapter({
+        sourcePath: `n/${originalUid}`,
+        sourceBasename: originalUid,
+        sourceFolder: "n",
+        sourceContent,
+      });
+      const resolver = {
+        resolveFile: (iri: string) =>
+          (adapter as unknown as {
+            getAbstractFileByPath: (p: string) => DupeFile;
+          }).getAbstractFileByPath(iri) as never,
+      };
+      const service = createDuplicateAssetService(adapter, resolver);
+
+      await service.execute(`n/${originalUid}`);
+
+      expect(created).toHaveLength(1);
+      expect(created[0].content).toContain(
+        "exo__Asset_modifiedAt: 2026-02-15T14:30:00",
+      );
+    });
+
+    it("throws when targetIRI is empty (Command Palette without active asset)", async () => {
+      const { adapter } = makeDupeAdapter({
+        sourcePath: "x",
+        sourceBasename: "x",
+        sourceFolder: "",
+        sourceContent: "---\nexo__Asset_uid: u\n---\n",
+      });
+      const resolver = {
+        resolveFile: () => {
+          throw new Error("should not be called for empty IRI");
+        },
+      };
+      const service = createDuplicateAssetService(adapter, resolver);
+
+      await expect(service.execute("")).rejects.toThrow(
+        /requires an active target/,
+      );
+    });
+
+    it("works without onCreated callback (CLI / headless shape)", async () => {
+      const originalUid = "44444444-4444-4444-8444-444444444444";
+      const { adapter, created } = makeDupeAdapter({
+        sourcePath: `f/${originalUid}`,
+        sourceBasename: originalUid,
+        sourceFolder: "f",
+        sourceContent: `---\nexo__Asset_uid: ${originalUid}\n---\nbody`,
+      });
+      const resolver = {
+        resolveFile: (iri: string) =>
+          (adapter as unknown as {
+            getAbstractFileByPath: (p: string) => DupeFile;
+          }).getAbstractFileByPath(iri) as never,
+      };
+      const service = createDuplicateAssetService(adapter, resolver);
+      // No 3rd arg
+      await service.execute(`f/${originalUid}`);
+      expect(created).toHaveLength(1);
+    });
+
+    it("places new file at vault root when source has no parent folder", async () => {
+      const originalUid = "55555555-5555-4555-8555-555555555555";
+      const { adapter, created } = makeDupeAdapter({
+        sourcePath: originalUid,
+        sourceBasename: originalUid,
+        sourceFolder: "",
+        sourceContent: `---\nexo__Asset_uid: ${originalUid}\n---\n`,
+      });
+      const resolver = {
+        resolveFile: (iri: string) =>
+          (adapter as unknown as {
+            getAbstractFileByPath: (p: string) => DupeFile;
+          }).getAbstractFileByPath(iri) as never,
+      };
+      const service = createDuplicateAssetService(adapter, resolver);
+      await service.execute(originalUid);
+      // Path is bare <uid>.md, no leading slash
+      expect(created[0].path).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.md$/,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Single-click Command Palette entry that duplicates the active Exocortex asset into a byte-verbatim copy in the same folder with two surgical frontmatter substitutions: `exo__Asset_uid` → new UUID v4, `exo__Asset_createdAt` → now (Asia/Almaty local ISO). Everything else (label, modifiedAt, instance class, relations, prototype, parent, all class-specific properties, markdown body incl. filled checklist items + SPARQL blocks) preserved byte-for-byte. New file named `<new-uid>.md` per UUID-canon, opened in a new workspace tab with focus.

Closes #3292.

## Scope diverged from Issue — homoiconic re-architecture

The Issue described a `DuplicateAssetCommand.ts` class in `packages/obsidian-plugin/src/application/commands/`. **Actual implementation is homoiconic** per CLAUDE.md Homoiconicity Invariant — the command, its visibility predicate, and its action live as vault assets, not a hardcoded TS class:

| Layer | Vault asset (post-PR submodule chain) | TS implementation |
|---|---|---|
| Command | `exocmd__Command` "Duplicate current asset" (paletteEnabled) — UID `5a3ebc9b-...` | — |
| Action | `exocmd__Grounding` "Duplicate asset via service" (`serviceId: duplicateAsset`) — UID `1c49a105-...` | `createDuplicateAssetService` in `@kitelev/exocortex-services` |
| Visibility | `exocmd__Precondition` "Has UID filename" (`hostFunction: hasUidFilename`) — UID `4cffa221-...` | `hasUidFilename` in `preconditionHostFunctions` |

TS additions are scoped to "core infra integration" per the invariant (point 2 — Obsidian platform API):

- **`hasUidFilename` host function** — inverse of existing `hasNonUidFilename`. Returns true when file basename equals `exo__Asset_uid`. Hides palette entry on label-named whitelist (`pn__DailyNote`, `period__Week`) and freeform `.md` files **without** an explicit class list — basename-vs-uid is the whitelist's empirical signal.

- **`PreconditionEvaluator.evaluateHostFunctionSync`** — synchronous host-function evaluation needed by Obsidian's `addCommand({ checkCallback })` (Obsidian's checkCallback is sync; async `evaluate()` remains canonical for inline buttons, layouts, CLI). Returns null for unknown function name → palette treats as fail-closed.

- **`createDuplicateAssetService`** factory — storage-agnostic `IGroundingService`. Internal helper `rewriteFrontmatterScalars` is pure text manipulation (no YAML parse → serialize), so key order, indent style, comments, list quoting, and CRLF endings round-trip byte-for-byte.

- **`ExocmdCommandPaletteRegistrar`** extended with active-target shape: commands with host-function precondition are wired as `checkCallback`, visibility gated synchronously, active-file `obsidian://vault/<encoded-path>` IRI forwarded as `targetIRI` at execution time. SPARQL-only preconditions intentionally skipped on palette path (would need active-leaf-change cache — invisible scope growth); fall back to no-target callback with warn log. Five-arg constructor preserved (backward-compat).

- **`ServiceRegistryPopulator`** registers `duplicateAsset` reusing the shared `openCreatedFileInTab` Obsidian hook.

## Out of scope

- **CLI parity** in `CliServiceRegistryPopulator` — palette command is Obsidian-specific (no "active file context" in CLI). Future ask if needed.
- **E2E test-vault palette fixtures** — no spec currently exercises Command Palette discovery against test-vault assets.
- **Vault submodule commit chain** — follows this PR's release. Plugin must register `serviceId: duplicateAsset` before the vault asset references it; reverse order would fail the grounding on dispatch.

## Test plan

- [x] `hasUidFilename` host fn — 9 cases (incl. daily/weekly note shapes, inverse parity with `hasNonUidFilename`)
- [x] `PreconditionEvaluator.evaluateHostFunctionSync` — 3 cases (pass / fail / fail-closed on unknown)
- [x] `rewriteFrontmatterScalars` — 6 cases (replace-in-place, append-if-absent, CRLF, indented-key isolation, comments/arrays/quotes, throw on freeform .md)
- [x] `createDuplicateAssetService` — 6 cases (full contract, UID freshness, modifiedAt preservation, empty-IRI guard, no-callback CLI shape, vault-root placement)
- [x] `ExocmdCommandPaletteRegistrar.activeTarget` — 8 cases (UID-named visible, daily-note hidden, no-frontmatter hidden, no-active-file hidden, unknown-fn fail-closed, SPARQL-only skipped+warned, 5-arg backward-compat fallback)
- [x] **Revert→fail / restore→pass verified** per `~/.claude/rules/integration-test-revert-verify.md`: sabotaged `rewriteFrontmatterScalars` call in `createDuplicateAssetService` to skip both substitutions → 1/46 services tests FAIL on main contract assertion (new UID in written content); restored → 46/46 pass.
- [ ] BRAT verify post-release: command visible on UUID-named asset, hidden on daily note `2026-05-29.md`, hidden on freeform `.md` without frontmatter; clicking the entry creates `<new-uid>.md` in same folder, opens in new tab, frontmatter has exactly two field deltas vs original.