### PR TITLE
fix(folder-repair): strip alias suffix from wikilink isDefinedBy

### DIFF
--- a/packages/cli/src/executors/BatchExecutor.ts
+++ b/packages/cli/src/executors/BatchExecutor.ts
@@ -746,6 +746,7 @@ export class BatchExecutor {
   /**
    * Extract reference from various formats:
    * - [[Reference]] -> Reference
+   * - [[uid|alias]] -> uid (alias suffix stripped — getFirstLinkpathDest rejects pipe-aliased linkpath)
    * - "[[Reference]]" -> Reference
    * - Reference -> Reference
    */
@@ -759,6 +760,13 @@ export class BatchExecutor {
 
     // Remove wiki-link brackets if present
     cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
+
+    // Strip alias suffix (everything after first `|`) — getFirstLinkpathDest
+    // returns null for pipe-aliased linkpaths, breaking alias-form refs.
+    const pipeIdx = cleaned.indexOf("|");
+    if (pipeIdx !== -1) {
+      cleaned = cleaned.slice(0, pipeIdx).trim();
+    }
 
     return cleaned || null;
   }

--- a/packages/cli/src/executors/commands/FolderRepairExecutor.ts
+++ b/packages/cli/src/executors/commands/FolderRepairExecutor.ts
@@ -139,6 +139,7 @@ export class FolderRepairExecutor extends BaseCommandExecutor {
   /**
    * Extract reference from various formats:
    * - [[Reference]] -> Reference
+   * - [[uid|alias]] -> uid (alias suffix stripped — getFirstLinkpathDest rejects pipe-aliased linkpath)
    * - "[[Reference]]" -> Reference
    * - Reference -> Reference
    */
@@ -152,6 +153,13 @@ export class FolderRepairExecutor extends BaseCommandExecutor {
 
     // Remove wiki-link brackets if present
     cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
+
+    // Strip alias suffix (everything after first `|`) — getFirstLinkpathDest
+    // returns null for pipe-aliased linkpaths, breaking alias-form refs.
+    const pipeIdx = cleaned.indexOf("|");
+    if (pipeIdx !== -1) {
+      cleaned = cleaned.slice(0, pipeIdx).trim();
+    }
 
     return cleaned || null;
   }

--- a/packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts
+++ b/packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts
@@ -284,6 +284,32 @@ describe("BatchExecutor - repair-folder command", () => {
       expect(mockFsAdapterInstance.findFileByUID).toHaveBeenCalledWith("abc123-def456");
     });
 
+    it("should strip alias suffix from UUID-aliased wiki-link: [[uuid|$label]]", async () => {
+      mockFsAdapterInstance.getFileMetadata.mockResolvedValue({
+        exo__Asset_isDefinedBy:
+          "[[e4bc670e-2618-41fc-87f8-9e3422f91514|$tbank-areas]]",
+      });
+
+      mockFsAdapterInstance.fileExists.mockResolvedValue(false);
+      mockFsAdapterInstance.findFileByUID.mockResolvedValue(
+        "assetspaces/tbank-areas/e4bc670e-2618-41fc-87f8-9e3422f91514.md",
+      );
+      mockFsAdapterInstance.getMarkdownFiles.mockResolvedValue([]);
+
+      const result = await executor.executeBatch([
+        { command: "repair-folder", filepath: "wrong/task.md" },
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(result.results[0].success).toBe(true);
+      expect(result.results[0].changes?.newPath).toBe(
+        "assetspaces/tbank-areas/task.md",
+      );
+      expect(mockFsAdapterInstance.findFileByUID).toHaveBeenCalledWith(
+        "e4bc670e-2618-41fc-87f8-9e3422f91514",
+      );
+    });
+
     it("should process multiple files in batch", async () => {
       mockFsAdapterInstance.getFileMetadata
         .mockResolvedValueOnce({ exo__Asset_isDefinedBy: "[[def1]]" })

--- a/packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts
+++ b/packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts
@@ -348,6 +348,32 @@ describe("FolderRepairExecutor", () => {
         );
       });
 
+      it("should strip alias suffix from UUID-aliased wiki-link: [[uuid|$label]]", async () => {
+        mockPathResolverInstance.resolve.mockReturnValue(
+          "/test/vault/tasks/task.md",
+        );
+        mockFsAdapterInstance.getFileMetadata.mockResolvedValue({
+          exo__Asset_isDefinedBy:
+            "[[e4bc670e-2618-41fc-87f8-9e3422f91514|$tbank-areas]]",
+        });
+        mockFsAdapterInstance.fileExists.mockResolvedValue(false);
+        mockFsAdapterInstance.findFileByUID.mockResolvedValue(
+          "assetspaces/tbank-areas/e4bc670e-2618-41fc-87f8-9e3422f91514.md",
+        );
+        mockFsAdapterInstance.directoryExists.mockResolvedValue(true);
+
+        await executor.executeRepairFolder("tasks/task.md");
+
+        expect(processExitSpy).toHaveBeenCalledWith(ExitCodes.SUCCESS);
+        expect(mockFsAdapterInstance.findFileByUID).toHaveBeenCalledWith(
+          "e4bc670e-2618-41fc-87f8-9e3422f91514",
+        );
+        expect(mockFsAdapterInstance.renameFile).toHaveBeenCalledWith(
+          "tasks/task.md",
+          "assetspaces/tbank-areas/task.md",
+        );
+      });
+
       it("should find referenced file by filename search", async () => {
         mockPathResolverInstance.resolve.mockReturnValue(
           "/test/vault/tasks/task.md",

--- a/packages/exocortex/src/services/FolderRepairService.ts
+++ b/packages/exocortex/src/services/FolderRepairService.ts
@@ -76,6 +76,7 @@ export class FolderRepairService {
   /**
    * Extract reference from various formats:
    * - [[Reference]] -> Reference
+   * - [[uid|alias]] -> uid (alias suffix stripped — getFirstLinkpathDest rejects pipe-aliased linkpath)
    * - "[[Reference]]" -> Reference
    * - Reference -> Reference
    */
@@ -89,6 +90,13 @@ export class FolderRepairService {
 
     // Remove wiki-link brackets if present
     cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
+
+    // Strip alias suffix (everything after first `|`) — getFirstLinkpathDest
+    // returns null for pipe-aliased linkpaths, breaking alias-form refs.
+    const pipeIdx = cleaned.indexOf("|");
+    if (pipeIdx !== -1) {
+      cleaned = cleaned.slice(0, pipeIdx).trim();
+    }
 
     return cleaned || null;
   }

--- a/packages/exocortex/tests/unit/services/FolderRepairService.test.ts
+++ b/packages/exocortex/tests/unit/services/FolderRepairService.test.ts
@@ -157,6 +157,45 @@ describe("FolderRepairService", () => {
 
       expect(result).toBe("target");
     });
+
+    it("should strip alias suffix from UUID-aliased wiki-link: [[uuid|$label]]", async () => {
+      const file = createMockFile();
+      const referencedFile = createMockFile({
+        path: "assetspaces/tbank-areas/e4bc670e-2618-41fc-87f8-9e3422f91514.md",
+        parent: { path: "assetspaces/tbank-areas", name: "tbank-areas" },
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(referencedFile);
+
+      const result = await service.getExpectedFolder(file, {
+        exo__Asset_isDefinedBy:
+          "[[e4bc670e-2618-41fc-87f8-9e3422f91514|$tbank-areas]]",
+      });
+
+      expect(result).toBe("assetspaces/tbank-areas");
+      expect(mockVault.getFirstLinkpathDest).toHaveBeenCalledWith(
+        "e4bc670e-2618-41fc-87f8-9e3422f91514",
+        file.path,
+      );
+    });
+
+    it("should strip alias suffix from label-aliased wiki-link: [[Target|Alias]]", async () => {
+      const file = createMockFile();
+      const referencedFile = createMockFile({
+        path: "folder/target.md",
+        parent: { path: "folder", name: "folder" },
+      });
+      mockVault.getFirstLinkpathDest.mockReturnValue(referencedFile);
+
+      const result = await service.getExpectedFolder(file, {
+        exo__Asset_isDefinedBy: "[[Target|Display Label]]",
+      });
+
+      expect(result).toBe("folder");
+      expect(mockVault.getFirstLinkpathDest).toHaveBeenCalledWith(
+        "Target",
+        file.path,
+      );
+    });
   });
 
   describe("repairFolder", () => {


### PR DESCRIPTION
## Summary

Repair Folder бросал `cannot determine expected folder` для ассетов, у которых `exo__Asset_isDefinedBy` записан в alias-form (`[[<uid>|$label]]`). `extractReference()` снимал `[[`/`]]`, но не `|$alias` suffix → Obsidian's `getFirstLinkpathDest()` rejects pipe-aliased linkpaths → null → throw.

## Reproducer (UI smoke 2026-05-30)

- File: `vault-2025/assetspaces/tbank-areas/f742403d-fcad-4434-ac43-1f898fa1d213.md`
- `isDefinedBy: "[[e4bc670e-2618-41fc-87f8-9e3422f91514|\$tbank-areas]]"`
- Click Repair Folder → toast `Command failed: repairFolder: cannot determine expected folder (missing exo__Asset_isDefinedBy or referenced asset not found)`

DevTools eval:

\`\`\`js
app.metadataCache.getFirstLinkpathDest("e4bc670e-...|\$tbank-areas", path) // → null
app.metadataCache.getFirstLinkpathDest("e4bc670e-...", path)              // → resolves OK
\`\`\`

## Scale

DevTools-scan 11 377 markdown files in vault-2025 → **301 failures** (2.6%). Все — alias-form `isDefinedBy`. Affected namespaces: `assetspaces/tbank-areas/`, `assetspaces/tbank-private/`, и др.

## Fix

\`FolderRepairService.ts:91\` after strip brackets:

\`\`\`ts
const pipeIdx = cleaned.indexOf("|");
if (pipeIdx !== -1) {
  cleaned = cleaned.slice(0, pipeIdx).trim();
}
\`\`\`

## Test plan

- [x] 2 new unit tests cover UUID-aliased (\`[[uid|\$label]]\`) и label-aliased (\`[[Target|Display Label]]\`) forms. Both assert \`getFirstLinkpathDest\` is called with clean linkpath (without \`|\`).
- [x] Backward-compat: all 10 existing tests still pass (\`[[plain]]\`, quoted, single-quoted, no brackets, root file, missing, non-string).
- [x] Empirical revert-fail/restore-pass per \`integration-test-revert-verify.md\`:
  - Pre-fix: **2/2 alias tests FAIL** (\`Received: "Target|Display Label"\`)
  - Post-fix: **20/20 PASS**
- [ ] UI smoke post-merge on \`f742403d-...\` asset via BRAT update → expect toast \`Asset moved to correct folder\`.

## Vault task

\`ab56028f-3dd4-43cd-b93b-648352fe93cd\` (Backlog, area ExoPlugin EMS).