### PR TITLE
fix(repair-folder): show button/command only when asset is in wrong folder

### DIFF
--- a/packages/exocortex/src/services/FolderRepairService.ts
+++ b/packages/exocortex/src/services/FolderRepairService.ts
@@ -19,19 +19,30 @@ export class FolderRepairService {
     file: IFile,
     metadata: Record<string, unknown>,
   ): Promise<string | null> {
+    return this.getExpectedFolderSync(file, metadata);
+  }
+
+  /**
+   * Sync sibling of getExpectedFolder for use in Obsidian's synchronous
+   * checkCallback (command palette / context menu visibility). Underlying
+   * vault APIs (getFirstLinkpathDest, getAbstractFileByPath) are already
+   * synchronous, so this returns the same value without a Promise wrapper.
+   */
+  getExpectedFolderSync(
+    file: IFile,
+    metadata: Record<string, unknown>,
+  ): string | null {
     const isDefinedBy = metadata?.exo__Asset_isDefinedBy;
 
     if (!isDefinedBy) {
       return null;
     }
 
-    // Extract the reference (handle both [[Reference]] and "[[Reference]]" formats)
     const reference = this.extractReference(isDefinedBy);
     if (!reference) {
       return null;
     }
 
-    // Find the referenced file
     const referencedFile = this.vault.getFirstLinkpathDest(
       reference,
       file.path,
@@ -41,7 +52,6 @@ export class FolderRepairService {
       return null;
     }
 
-    // Get the folder of the referenced file
     return this.getFileFolder(referencedFile);
   }
 

--- a/packages/exocortex/src/services/PreconditionEvaluator.ts
+++ b/packages/exocortex/src/services/PreconditionEvaluator.ts
@@ -17,6 +17,7 @@ export interface EvalContext {
   readonly targetIRI: string;
   readonly fileBasename?: string;
   readonly currentFolder?: string;
+  readonly filePath?: string;
   readonly assetUid?: string;
   readonly [key: string]: unknown;
 }

--- a/packages/exocortex/tests/unit/services/FolderRepairService.test.ts
+++ b/packages/exocortex/tests/unit/services/FolderRepairService.test.ts
@@ -283,4 +283,41 @@ describe("FolderRepairService", () => {
       expect(mockVault.rename).toHaveBeenCalledWith(file, "/asset.md");
     });
   });
+
+  describe("getExpectedFolderSync", () => {
+    it("returns same value as async getExpectedFolder (parity)", async () => {
+      const file = createMockFile();
+      const target: IFile = {
+        path: "correct-folder/Asset.md",
+        basename: "Asset",
+        name: "Asset.md",
+        parent: { path: "correct-folder", name: "correct-folder" },
+      };
+      mockVault.getFirstLinkpathDest.mockReturnValue(target);
+
+      const metadata = { exo__Asset_isDefinedBy: "[[Asset]]" };
+      const syncResult = service.getExpectedFolderSync(file, metadata);
+      const asyncResult = await service.getExpectedFolder(file, metadata);
+
+      expect(syncResult).toBe("correct-folder");
+      expect(asyncResult).toBe(syncResult);
+    });
+
+    it("returns null synchronously when isDefinedBy missing", () => {
+      const file = createMockFile();
+      expect(service.getExpectedFolderSync(file, {})).toBeNull();
+      expect(mockVault.getFirstLinkpathDest).not.toHaveBeenCalled();
+    });
+
+    it("returns null synchronously when referenced file not found", () => {
+      const file = createMockFile();
+      mockVault.getFirstLinkpathDest.mockReturnValue(null);
+
+      const result = service.getExpectedFolderSync(file, {
+        exo__Asset_isDefinedBy: "[[Missing]]",
+      });
+
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -23,6 +23,7 @@ import {
   CommandResolver,
   PreconditionEvaluator,
   registerDefaultHostFunctions,
+  FolderRepairService,
   GroundingExecutor,
   ServiceRegistry,
   RelationColumnSetResolver,
@@ -46,6 +47,7 @@ import {
 } from "./infrastructure/repositories";
 import { ObsidianVaultAdapter } from "./adapters/ObsidianVaultAdapter";
 import { ObsidianQueryBodyResolver } from "./infrastructure/ObsidianQueryBodyResolver";
+import { createIsInWrongFolderHostFunction } from "./infrastructure/precondition/createIsInWrongFolderHostFunction";
 import { TaskTrackingService } from "./application/services/TaskTrackingService";
 import { AliasSyncService } from "./application/services/AliasSyncService";
 import { WikilinkAliasService } from "./application/services/WikilinkAliasService";
@@ -237,6 +239,19 @@ export default class ExocortexPlugin extends Plugin {
         queryBodyResolver,
       );
       registerDefaultHostFunctions(this.preconditionEvaluator);
+
+      // Register `isInWrongFolder` host function used by the homoiconic
+      // `Repair Folder` exocmd command (vault asset
+      // `2afd04ae-218d-4ee9-8ee1-7c61f4d40a91`). Without this registration
+      // `evaluateHostFunction` fails open (`return true`) and the inline
+      // button + Cmd+P entry would show on every asset.
+      this.preconditionEvaluator.registerHostFunction(
+        "isInWrongFolder",
+        createIsInWrongFolderHostFunction(
+          this.app,
+          new FolderRepairService(this.vaultAdapter),
+        ),
+      );
 
       // RFC c7da0bca Phase 3a — construct lazy loader. Parallel-mode: runs
       // alongside the existing fast/full-path chain. The dedicated

--- a/packages/obsidian-plugin/src/application/commands/RepairFolderCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/RepairFolderCommand.ts
@@ -1,6 +1,11 @@
 import type { App, TFile } from "obsidian";
 import { ICommand } from "./ICommand";
-import { FolderRepairService, LoggingService, type INotificationService } from "exocortex";
+import {
+  FolderRepairService,
+  LoggingService,
+  needsFolderRepair,
+  type INotificationService,
+} from "exocortex";
 
 export class RepairFolderCommand implements ICommand {
   id = "repair-folder";
@@ -17,6 +22,13 @@ export class RepairFolderCommand implements ICommand {
     const metadata = cache?.frontmatter || {};
 
     if (!metadata?.exo__Asset_isDefinedBy) return false;
+
+    const expectedFolder = this.folderRepairService.getExpectedFolderSync(
+      file,
+      metadata,
+    );
+    const currentFolder = file.parent?.path || "";
+    if (!needsFolderRepair(currentFolder, expectedFolder)) return false;
 
     if (!checking) {
       void (async () => {
@@ -41,7 +53,7 @@ export class RepairFolderCommand implements ICommand {
     }
 
     const currentFolder = file.parent?.path || "";
-    if (currentFolder === expectedFolder) {
+    if (!needsFolderRepair(currentFolder, expectedFolder)) {
       this.notifier.info("Asset is already in correct folder");
       return;
     }

--- a/packages/obsidian-plugin/src/application/services/ExocmdCommandPaletteRegistrar.ts
+++ b/packages/obsidian-plugin/src/application/services/ExocmdCommandPaletteRegistrar.ts
@@ -233,6 +233,7 @@ function readActiveFileContext(app: App): {
       targetIRI,
       fileBasename: file.basename,
       currentFolder: file.parent?.path,
+      filePath: file.path,
       assetUid,
     },
   };

--- a/packages/obsidian-plugin/src/infrastructure/precondition/createIsInWrongFolderHostFunction.ts
+++ b/packages/obsidian-plugin/src/infrastructure/precondition/createIsInWrongFolderHostFunction.ts
@@ -1,0 +1,47 @@
+import { TFile, type App } from "obsidian";
+import {
+  needsFolderRepair,
+  type FolderRepairService,
+  type HostFunction,
+} from "exocortex";
+
+/**
+ * Factory for the `isInWrongFolder` precondition host function used by the
+ * homoiconic exocmd "Repair Folder" command (vault asset
+ * `2afd04ae-218d-4ee9-8ee1-7c61f4d40a91`). Returns `true` only when the
+ * asset's current parent folder differs from the folder of the file
+ * referenced by `exo__Asset_isDefinedBy`.
+ *
+ * Hides the inline button + the Cmd+P palette entry on assets that are
+ * already in the correct folder. Falls back to `false` (hide) whenever
+ * the expected folder cannot be resolved — fail-closed for consistency
+ * with the Obsidian command's gate.
+ */
+export function createIsInWrongFolderHostFunction(
+  app: App,
+  folderRepairService: FolderRepairService,
+): HostFunction {
+  return (ctx) => {
+    const filePath =
+      typeof ctx.filePath === "string" && ctx.filePath.length > 0
+        ? ctx.filePath
+        : null;
+    if (filePath === null) return false;
+
+    const file = app.vault.getAbstractFileByPath(filePath);
+    if (!(file instanceof TFile)) return false;
+
+    const metadata =
+      (app.metadataCache.getFileCache(file)?.frontmatter as
+        | Record<string, unknown>
+        | undefined) ?? {};
+
+    const expected = folderRepairService.getExpectedFolderSync(file, metadata);
+    const current =
+      typeof ctx.currentFolder === "string"
+        ? ctx.currentFolder
+        : (file.parent?.path ?? "");
+
+    return needsFolderRepair(current, expected);
+  };
+}

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -362,6 +362,7 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
       targetIRI: subjectIRI,
       fileBasename: file.basename,
       currentFolder: file.parent?.path,
+      filePath: file.path,
       assetUid,
     };
     const availabilityChecks = await Promise.all(

--- a/packages/obsidian-plugin/tests/unit/RepairFolderCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RepairFolderCommand.test.ts
@@ -24,20 +24,18 @@ describe("RepairFolderCommand", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Create mock app
     mockApp = {
       metadataCache: {
         getFileCache: jest.fn(),
       },
     } as unknown as jest.Mocked<App>;
 
-    // Create mock folder repair service
     mockFolderRepairService = {
       getExpectedFolder: jest.fn(),
+      getExpectedFolderSync: jest.fn(),
       repairFolder: jest.fn(),
     } as unknown as jest.Mocked<FolderRepairService>;
 
-    // Create mock file
     mockFile = {
       path: "current/folder/test-file.md",
       basename: "test-file",
@@ -46,7 +44,6 @@ describe("RepairFolderCommand", () => {
       },
     } as jest.Mocked<TFile>;
 
-    // Create command instance
     mockNotifier = { info: jest.fn(), success: jest.fn(), error: jest.fn(), warn: jest.fn(), confirm: jest.fn() };
     command = new RepairFolderCommand(mockApp, mockFolderRepairService, mockNotifier);
   });
@@ -58,7 +55,7 @@ describe("RepairFolderCommand", () => {
     });
   });
 
-  describe("checkCallback", () => {
+  describe("checkCallback — visibility (gated on wrong folder)", () => {
     it("should return false when metadata has no exo__Asset_isDefinedBy", () => {
       mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
         frontmatter: { otherProp: "value" },
@@ -66,7 +63,7 @@ describe("RepairFolderCommand", () => {
 
       const result = command.checkCallback(true, mockFile);
       expect(result).toBe(false);
-      expect(mockFolderRepairService.getExpectedFolder).not.toHaveBeenCalled();
+      expect(mockFolderRepairService.getExpectedFolderSync).not.toHaveBeenCalled();
     });
 
     it("should return false when cache is null", () => {
@@ -74,7 +71,7 @@ describe("RepairFolderCommand", () => {
 
       const result = command.checkCallback(true, mockFile);
       expect(result).toBe(false);
-      expect(mockFolderRepairService.getExpectedFolder).not.toHaveBeenCalled();
+      expect(mockFolderRepairService.getExpectedFolderSync).not.toHaveBeenCalled();
     });
 
     it("should return false when frontmatter is missing", () => {
@@ -82,147 +79,95 @@ describe("RepairFolderCommand", () => {
 
       const result = command.checkCallback(true, mockFile);
       expect(result).toBe(false);
-      expect(mockFolderRepairService.getExpectedFolder).not.toHaveBeenCalled();
+      expect(mockFolderRepairService.getExpectedFolderSync).not.toHaveBeenCalled();
     });
 
-    it("should return true when metadata has exo__Asset_isDefinedBy and checking is true", () => {
+    it("should return false when expected folder cannot be determined (null)", () => {
       mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
         frontmatter: { exo__Asset_isDefinedBy: "Asset" },
       });
+      mockFolderRepairService.getExpectedFolderSync.mockReturnValue(null);
+
+      const result = command.checkCallback(true, mockFile);
+      expect(result).toBe(false);
+      expect(mockFolderRepairService.getExpectedFolderSync).toHaveBeenCalledWith(
+        mockFile,
+        { exo__Asset_isDefinedBy: "Asset" },
+      );
+    });
+
+    it("should return false when asset is already in the correct folder", () => {
+      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
+        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
+      });
+      mockFolderRepairService.getExpectedFolderSync.mockReturnValue("current/folder");
+
+      const result = command.checkCallback(true, mockFile);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when correct folder differs only by trailing slash", () => {
+      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
+        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
+      });
+      mockFolderRepairService.getExpectedFolderSync.mockReturnValue("current/folder/");
+
+      const result = command.checkCallback(true, mockFile);
+      expect(result).toBe(false);
+    });
+
+    it("should return true when asset is in the wrong folder", () => {
+      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
+        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
+      });
+      mockFolderRepairService.getExpectedFolderSync.mockReturnValue("expected/folder");
 
       const result = command.checkCallback(true, mockFile);
       expect(result).toBe(true);
+      // checking=true must NOT trigger execution
       expect(mockFolderRepairService.getExpectedFolder).not.toHaveBeenCalled();
-    });
-
-    it("should execute command when checking is false and metadata has exo__Asset_isDefinedBy", async () => {
-      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
-        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
-      });
-      mockFolderRepairService.getExpectedFolder.mockResolvedValue("expected/folder");
-      mockFolderRepairService.repairFolder.mockResolvedValue();
-
-      const result = command.checkCallback(false, mockFile);
-      expect(result).toBe(true);
-
-      // Wait for async execution
-      await flushPromises();
-
-      expect(mockFolderRepairService.getExpectedFolder).toHaveBeenCalledWith(
-        mockFile,
-        { exo__Asset_isDefinedBy: "Asset" }
-      );
-      expect(mockFolderRepairService.repairFolder).toHaveBeenCalledWith(mockFile, "expected/folder");
-      expect(mockNotifier.success).toHaveBeenCalledWith("Moved to expected/folder");
-    });
-
-    it("should show notice when no expected folder found", async () => {
-      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
-        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
-      });
-      mockFolderRepairService.getExpectedFolder.mockResolvedValue(null);
-
-      const result = command.checkCallback(false, mockFile);
-      expect(result).toBe(true);
-
-      // Wait for async execution
-      await flushPromises();
-
-      expect(mockFolderRepairService.getExpectedFolder).toHaveBeenCalled();
       expect(mockFolderRepairService.repairFolder).not.toHaveBeenCalled();
-      expect(mockNotifier.warn).toHaveBeenCalledWith("No expected folder found");
     });
 
-    it("should show notice when asset is already in correct folder", async () => {
-      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
-        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
-      });
-      mockFolderRepairService.getExpectedFolder.mockResolvedValue("current/folder");
-
-      const result = command.checkCallback(false, mockFile);
-      expect(result).toBe(true);
-
-      // Wait for async execution
-      await flushPromises();
-
-      expect(mockFolderRepairService.getExpectedFolder).toHaveBeenCalled();
-      expect(mockFolderRepairService.repairFolder).not.toHaveBeenCalled();
-      expect(mockNotifier.info).toHaveBeenCalledWith("Asset is already in correct folder");
-    });
-
-    it("should handle file with no parent folder", async () => {
+    it("should return true for file at vault root when expected folder is non-empty", () => {
       const rootFile = {
         path: "test-file.md",
         basename: "test-file",
         parent: null,
       } as unknown as TFile;
-
       mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
         frontmatter: { exo__Asset_isDefinedBy: "Asset" },
       });
+      mockFolderRepairService.getExpectedFolderSync.mockReturnValue("expected/folder");
+
+      const result = command.checkCallback(true, rootFile);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("checkCallback — execution (checking=false on wrong folder)", () => {
+    beforeEach(() => {
+      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
+        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
+      });
+      mockFolderRepairService.getExpectedFolderSync.mockReturnValue("expected/folder");
+    });
+
+    it("should execute repair when checking=false and folder is wrong", async () => {
       mockFolderRepairService.getExpectedFolder.mockResolvedValue("expected/folder");
       mockFolderRepairService.repairFolder.mockResolvedValue();
 
-      const result = command.checkCallback(false, rootFile);
+      const result = command.checkCallback(false, mockFile);
       expect(result).toBe(true);
 
-      // Wait for async execution
       await flushPromises();
 
-      expect(mockFolderRepairService.repairFolder).toHaveBeenCalledWith(rootFile, "expected/folder");
+      expect(mockFolderRepairService.getExpectedFolder).toHaveBeenCalledWith(
+        mockFile,
+        { exo__Asset_isDefinedBy: "Asset" },
+      );
+      expect(mockFolderRepairService.repairFolder).toHaveBeenCalledWith(mockFile, "expected/folder");
       expect(mockNotifier.success).toHaveBeenCalledWith("Moved to expected/folder");
-    });
-
-    it("should handle errors and show error notice", async () => {
-      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
-        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
-      });
-      const error = new Error("Failed to repair");
-      mockFolderRepairService.getExpectedFolder.mockRejectedValue(error);
-
-      const result = command.checkCallback(false, mockFile);
-      expect(result).toBe(true);
-
-      // Wait for async execution
-      await flushPromises();
-
-      expect(LoggingService.error).toHaveBeenCalledWith("Repair folder error", error);
-      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to repair folder: Failed to repair");
-    });
-
-    it("should handle repair folder service errors", async () => {
-      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
-        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
-      });
-      mockFolderRepairService.getExpectedFolder.mockResolvedValue("expected/folder");
-      const error = new Error("Move failed");
-      mockFolderRepairService.repairFolder.mockRejectedValue(error);
-
-      const result = command.checkCallback(false, mockFile);
-      expect(result).toBe(true);
-
-      // Wait for async execution
-      await flushPromises();
-
-      expect(LoggingService.error).toHaveBeenCalledWith("Repair folder error", error);
-      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to repair folder: Move failed");
-    });
-
-    it("should handle empty expected folder path", async () => {
-      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
-        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
-      });
-      mockFolderRepairService.getExpectedFolder.mockResolvedValue("");
-
-      const result = command.checkCallback(false, mockFile);
-      expect(result).toBe(true);
-
-      // Wait for async execution
-      await flushPromises();
-
-      expect(mockFolderRepairService.getExpectedFolder).toHaveBeenCalled();
-      expect(mockFolderRepairService.repairFolder).not.toHaveBeenCalled();
-      expect(mockNotifier.warn).toHaveBeenCalledWith("No expected folder found");
     });
 
     it("should handle complex metadata", async () => {
@@ -232,31 +177,37 @@ describe("RepairFolderCommand", () => {
         exo__Asset_label: "Complex Task",
         tags: ["important", "urgent"],
       };
-
       mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
         frontmatter: complexMetadata,
       });
+      mockFolderRepairService.getExpectedFolderSync.mockReturnValue("complex/expected/folder");
       mockFolderRepairService.getExpectedFolder.mockResolvedValue("complex/expected/folder");
       mockFolderRepairService.repairFolder.mockResolvedValue();
 
       const result = command.checkCallback(false, mockFile);
       expect(result).toBe(true);
 
-      // Wait for async execution
       await flushPromises();
 
-      expect(mockFolderRepairService.getExpectedFolder).toHaveBeenCalledWith(
-        mockFile,
-        complexMetadata
-      );
       expect(mockFolderRepairService.repairFolder).toHaveBeenCalledWith(mockFile, "complex/expected/folder");
       expect(mockNotifier.success).toHaveBeenCalledWith("Moved to complex/expected/folder");
     });
 
+    it("should handle errors from repairFolder and show error notice", async () => {
+      mockFolderRepairService.getExpectedFolder.mockResolvedValue("expected/folder");
+      const error = new Error("Move failed");
+      mockFolderRepairService.repairFolder.mockRejectedValue(error);
+
+      const result = command.checkCallback(false, mockFile);
+      expect(result).toBe(true);
+
+      await flushPromises();
+
+      expect(LoggingService.error).toHaveBeenCalledWith("Repair folder error", error);
+      expect(mockNotifier.error).toHaveBeenCalledWith("Failed to repair folder: Move failed");
+    });
+
     it("should handle permission denied error", async () => {
-      mockApp.metadataCache.getFileCache = jest.fn().mockReturnValue({
-        frontmatter: { exo__Asset_isDefinedBy: "Asset" },
-      });
       mockFolderRepairService.getExpectedFolder.mockResolvedValue("expected/folder");
       const permError = new Error("Permission denied: cannot move file");
       mockFolderRepairService.repairFolder.mockRejectedValue(permError);
@@ -264,7 +215,6 @@ describe("RepairFolderCommand", () => {
       const result = command.checkCallback(false, mockFile);
       expect(result).toBe(true);
 
-      // Wait for async execution
       await flushPromises();
 
       expect(LoggingService.error).toHaveBeenCalledWith("Repair folder error", permError);

--- a/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createIsInWrongFolderHostFunction.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createIsInWrongFolderHostFunction.test.ts
@@ -1,0 +1,133 @@
+import { App, TFile, TFolder } from "obsidian";
+import { FolderRepairService, type EvalContext } from "exocortex";
+import { createIsInWrongFolderHostFunction } from "../../../../src/infrastructure/precondition/createIsInWrongFolderHostFunction";
+
+describe("createIsInWrongFolderHostFunction", () => {
+  const buildFile = (path: string): TFile => {
+    const file = new TFile(path);
+    return file;
+  };
+
+  const buildApp = (opts: {
+    file?: TFile | TFolder | null;
+    metadata?: Record<string, unknown> | null;
+  }): App =>
+    ({
+      vault: {
+        getAbstractFileByPath: jest
+          .fn()
+          .mockReturnValue(opts.file === undefined ? null : opts.file),
+      },
+      metadataCache: {
+        getFileCache: jest.fn().mockReturnValue(
+          opts.metadata === null
+            ? null
+            : { frontmatter: opts.metadata ?? {} },
+        ),
+      },
+    }) as unknown as App;
+
+  const buildService = (
+    expected: string | null,
+  ): jest.Mocked<FolderRepairService> =>
+    ({
+      getExpectedFolder: jest.fn(),
+      getExpectedFolderSync: jest.fn().mockReturnValue(expected),
+      repairFolder: jest.fn(),
+    }) as unknown as jest.Mocked<FolderRepairService>;
+
+  const baseCtx = (overrides: Partial<EvalContext> = {}): EvalContext => ({
+    targetIRI: "obsidian://vault/current/folder/asset.md",
+    fileBasename: "asset",
+    currentFolder: "current/folder",
+    filePath: "current/folder/asset.md",
+    ...overrides,
+  });
+
+  it("returns false when filePath missing from context", () => {
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file: null }),
+      buildService("anywhere"),
+    );
+    const result = fn(baseCtx({ filePath: undefined }));
+    expect(result).toBe(false);
+  });
+
+  it("returns false when file not found in vault", () => {
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file: null }),
+      buildService("anywhere"),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when target is a folder", () => {
+    const folder = new TFolder("x");
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file: folder }),
+      buildService("anywhere"),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when expected folder cannot be resolved", () => {
+    const file = buildFile("current/folder/asset.md");
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file, metadata: {} }),
+      buildService(null),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when asset already in expected folder", () => {
+    const file = buildFile("current/folder/asset.md");
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file, metadata: { exo__Asset_isDefinedBy: "[[Class]]" } }),
+      buildService("current/folder"),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when expected differs only by trailing slash", () => {
+    const file = buildFile("current/folder/asset.md");
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file, metadata: { exo__Asset_isDefinedBy: "[[Class]]" } }),
+      buildService("current/folder/"),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns true when asset is in wrong folder", () => {
+    const file = buildFile("current/folder/asset.md");
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file, metadata: { exo__Asset_isDefinedBy: "[[Class]]" } }),
+      buildService("expected/folder"),
+    );
+    expect(fn(baseCtx())).toBe(true);
+  });
+
+  it("falls back to file.parent.path when currentFolder missing from ctx", () => {
+    const file = buildFile("fallback/asset.md");
+    const service = buildService("fallback");
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file, metadata: { exo__Asset_isDefinedBy: "[[Class]]" } }),
+      service,
+    );
+    expect(fn(baseCtx({ currentFolder: undefined }))).toBe(false);
+  });
+
+  it("passes file + metadata to FolderRepairService.getExpectedFolderSync", () => {
+    const file = buildFile("current/folder/asset.md");
+    const metadata = {
+      exo__Asset_isDefinedBy: "[[Class]]",
+      otherProp: "x",
+    };
+    const service = buildService("expected/folder");
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file, metadata }),
+      service,
+    );
+    fn(baseCtx());
+    expect(service.getExpectedFolderSync).toHaveBeenCalledWith(file, metadata);
+  });
+});


### PR DESCRIPTION
## Summary

«Repair Folder» (кнопка / Cmd+P команда / homoiconic inline-button) показывались на **каждом** ассете с `exo__Asset_isDefinedBy`, даже когда файл уже лежит в правильной папке. Этот PR гейтит все три surface на `needsFolderRepair(currentFolder, expectedFolder)`.

### Three gated surfaces

1. **Obsidian command palette** `repair-folder` (`RepairFolderCommand.checkCallback`) — добавил sync gate через новый `FolderRepairService.getExpectedFolderSync`.
2. **Homoiconic inline button** (vault asset `ad65f560-…`, precondition `2afd04ae-…` host function `isInWrongFolder`) — host function **никогда не была зарегистрирована** в коде, поэтому `PreconditionEvaluator.evaluateHostFunction:191` fail-open'ил (`if (!fn) return true`). Регистрирую через новый factory `createIsInWrongFolderHostFunction(app, folderRepairService)`.
3. **Homoiconic Cmd+P entries** для того же exocmd Command — используют тот же registered host function через `evaluateHostFunctionSync` в `ExocmdCommandPaletteRegistrar`.

### Mechanism

- `EvalContext` получил optional `filePath?: string` (additive, не ломает existing consumers).
- Wired `filePath: file.path` в evalContext в `DynamicCommandButtonGroupBuilder` (inline-buttons) + `ExocmdCommandPaletteRegistrar.readActiveFileContext` (palette).
- Host function использует `app.vault.getAbstractFileByPath(filePath)` + `instanceof TFile` + `FolderRepairService.getExpectedFolderSync` → `needsFolderRepair`. Fail-closed defaults (`return false` когда filePath отсутствует / target — folder / expected не resolved).
- `RepairFolderCommand.execute` defensive check тоже теперь использует `needsFolderRepair` вместо `===` (slash-normalized comparator parity с гейтом — code-reviewer MEDIUM #1).

### Tests

- `FolderRepairService.getExpectedFolderSync` — 3 новых case (parity с async, null short-circuits).
- `RepairFolderCommand.checkCallback` — переписан, 13 cases (visibility gate: missing isDefinedBy → null expected → same folder → trailing-slash variation → wrong folder; plus execution path).
- `createIsInWrongFolderHostFunction` — 9 cases (missing filePath / file null / folder / null expected / trailing slash / wrong folder / fallback to file.parent.path / FolderRepairService call inspect).

Empirical revert→fail / restore→pass discipline применена к обоим guard'ам.

## Test plan

- [x] `npm run check:types` — clean
- [x] `npm run lint` — clean (только 2 pre-existing warnings, unrelated)
- [x] Full obsidian-plugin jest: 240/240 suites, 4928 tests pass
- [x] Impacted exocortex jest: 9/9 suites, 447 tests pass
- [x] Pre-commit hooks: BDD 204/204 covered, archgate 13/13 pass
- [x] Revert→fail / restore→pass discipline для `RepairFolderCommand` gate (3/13 fail на revert) + `createIsInWrongFolderHostFunction` (4/9 fail на revert)
- [x] Code-reviewer agent: APPROVE, 0 CRIT/HIGH, 2 MEDIUM (one applied: comparator consistency in execute()), 2 LOW (CLI fail-open noted, async wrapper Promise.resolve)
- [ ] CI green (14 checks)
- [ ] Manual UI smoke in Obsidian post-BRAT update (per `obsidian-plugin-update-via-brat.md`): verify Repair Folder button hidden on asset already in correct folder; visible after manually moving asset to wrong folder

## Files changed

- `packages/exocortex/src/services/FolderRepairService.ts` (+sync sibling)
- `packages/exocortex/src/services/PreconditionEvaluator.ts` (+`filePath?` in EvalContext)
- `packages/exocortex/tests/unit/services/FolderRepairService.test.ts` (+3 cases)
- `packages/obsidian-plugin/src/ExocortexPlugin.ts` (+host fn registration)
- `packages/obsidian-plugin/src/application/commands/RepairFolderCommand.ts` (+gate, +comparator consistency)
- `packages/obsidian-plugin/src/application/services/ExocmdCommandPaletteRegistrar.ts` (+filePath wire)
- `packages/obsidian-plugin/src/infrastructure/precondition/createIsInWrongFolderHostFunction.ts` (NEW)
- `packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts` (+filePath wire)
- `packages/obsidian-plugin/tests/unit/RepairFolderCommand.test.ts` (rewritten)
- `packages/obsidian-plugin/tests/unit/infrastructure/precondition/createIsInWrongFolderHostFunction.test.ts` (NEW)