### PR TITLE
feat(cli): wire workflow_transition dispatcher in apply (RFC 36347daf Phase 3)

### DIFF
--- a/packages/cli/specs/features/groundings.feature
+++ b/packages/cli/specs/features/groundings.feature
@@ -79,3 +79,30 @@ Feature: Starter-kit grounding execution (RFC 94e520da § Phase 6)
     And the created asset does NOT have "exo__Asset_prototype"
     And the created asset has "ems__Effort_prevIteration" pointing to $target
     And the created asset does NOT have "exo__Asset_source"
+
+  # RFC 36347daf Phase 3 — workflow_transition apply via the CLI. The shared
+  # @exocortex/core dispatcher (`GroundingExecutor.executeWorkflowTransition`)
+  # is exercised through the actual `applyCommand().parseAsync(...)` entry
+  # point against a temp vault hydrated with Workflow ABox (Workflow +
+  # WorkflowTransition + Task target). The full integration coverage lives
+  # in `tests/integration/apply-workflow-transition.integration.test.ts` —
+  # this scenario is a high-signal smoke that protects against silent
+  # regressions in BDD-layer wiring (vault triple-store hydration,
+  # WorkflowResolver DI, GroundingLoader DI).
+
+  Scenario: CLI apply workflow_transition forward Backlog→Doing
+    Given the CLI apply workflow_transition fixture vault
+    When I run apply with the forward workflow_transition command on the Backlog task
+    Then the target task status becomes "ems__EffortStatusDoing"
+    And the postAction sentinel marker is present
+
+  Scenario: CLI apply workflow_transition rollback Done→Doing
+    Given the CLI apply workflow_transition fixture vault
+    When I run apply with the rollback workflow_transition command on the Done task
+    Then the target task status becomes "ems__EffortStatusDoing"
+
+  Scenario: CLI apply workflow_transition forward from terminal status fails loud
+    Given the CLI apply workflow_transition fixture vault
+    When I run apply with the forward-from-done workflow_transition command on the Done task
+    Then the CLI reports the missing forward transition for "ems__EffortStatusDone"
+    And the target task status remains "ems__EffortStatusDone"

--- a/packages/cli/specs/step_definitions/workflow_transition.steps.ts
+++ b/packages/cli/specs/step_definitions/workflow_transition.steps.ts
@@ -1,0 +1,372 @@
+/**
+ * RFC 36347daf Phase 3 — BDD scenarios exercising `applyCommand().parseAsync(...)`
+ * end-to-end against an isolated temp vault hydrated with a Workflow ABox
+ * (Workflow + WorkflowTransition + Task target + ems__EffortStatus stubs).
+ *
+ * The high-coverage integration tests for the same wiring live in
+ * `packages/cli/tests/integration/apply-workflow-transition.integration.test.ts`.
+ * The BDD layer protects the test-bdd CI gate against silent regressions in
+ * vault triple-store hydration, WorkflowResolver DI, and GroundingLoader DI.
+ */
+import { Given, When, Then, After } from "@cucumber/cucumber";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CliBddWorld } from "../support/world.js";
+
+// `applyCommand` is loaded lazily inside the step handler so this module stays
+// CommonJS-compatible — tsx compiles step definitions to CJS, which forbids
+// top-level await. `applyCommand()` returns a fresh commander program per call,
+// so caching the symbol is safe across scenarios.
+type ApplyCommandFactory = typeof import("../../src/commands/apply.js")["applyCommand"];
+let cachedApplyCommand: ApplyCommandFactory | null = null;
+async function getApplyCommand(): Promise<ApplyCommandFactory> {
+  if (cachedApplyCommand) return cachedApplyCommand;
+  const mod = await import("../../src/commands/apply.js");
+  cachedApplyCommand = mod.applyCommand;
+  return cachedApplyCommand;
+}
+
+// ─── Stable fixture UIDs (shared scenarios) ─────────────────────────────────
+const COMMAND_FWD_UID = "ccccdddd-0001-0000-0000-000000000001";
+const COMMAND_ROLLBACK_UID = "ccccdddd-0001-0000-0000-000000000002";
+const COMMAND_FWD_FROM_DONE_UID = "ccccdddd-0001-0000-0000-000000000003";
+
+const GROUNDING_FWD_UID = "ccccdddd-0002-0000-0000-000000000001";
+const GROUNDING_ROLLBACK_UID = "ccccdddd-0002-0000-0000-000000000002";
+const GROUNDING_FWD_FROM_DONE_UID = "ccccdddd-0002-0000-0000-000000000003";
+
+const WORKFLOW_UID = "ccccdddd-0003-0000-0000-000000000001";
+const TRANSITION_FWD_UID = "ccccdddd-0003-0000-0000-000000000002";
+const TRANSITION_ROLLBACK_UID = "ccccdddd-0003-0000-0000-000000000003";
+const POST_ACTION_UID = "ccccdddd-0003-0000-0000-000000000004";
+
+const TASK_BACKLOG_UID = "ccccdddd-0004-0000-0000-000000000001";
+const TASK_DONE_UID = "ccccdddd-0004-0000-0000-000000000002";
+
+const CLASS_TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const CLASS_WORKFLOW_UID = "ccccdddd-0005-0000-0000-000000000001";
+const CLASS_WORKFLOW_TRANSITION_UID = "8eef26d7-4692-4b84-8835-8a0277828b8c";
+
+const STATUS_BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const STATUS_DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+const STATUS_DONE_UID = "7b9b3116-7c3c-438c-9618-94fe301320a6";
+
+const TYPE_WORKFLOW_TRANSITION_UID = "5c1a2552-d576-496d-8823-563573dd1e2f";
+const TYPE_PROPERTY_SET_UID = "cf3bb923-f1f1-40be-b728-782844402426";
+
+const SEED = "99999999-7777-8888-6666-555555555555";
+const FROZEN_CLOCK = "2026-02-01T12:00:00Z";
+
+// ─── Asset templates ────────────────────────────────────────────────────────
+
+function classTBox(uid: string, label: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exo__Class]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function task(uid: string, label: string, statusUid: string, statusLabel: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[${CLASS_TASK_UID}|ems__Task]]"`,
+    `ems__Effort_status: "[[${statusUid}|${statusLabel}]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function command(uid: string, label: string, groundingUid: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Command]]"`,
+    `exocmd__Command_grounding: "[[${groundingUid}|grounding]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function workflowTransitionGrounding(uid: string, label: string, direction: "forward" | "rollback"): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Grounding]]"`,
+    `exocmd__Grounding_type: "[[${TYPE_WORKFLOW_TRANSITION_UID}]]"`,
+    `exocmd__Grounding_direction: ${direction}`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function workflowAsset(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${WORKFLOW_UID}`,
+    `exo__Asset_label: "BDD default task workflow"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[${CLASS_WORKFLOW_UID}]]"`,
+    `ems__Workflow_targetClass: "[[${CLASS_TASK_UID}|ems__Task]]"`,
+    `ems__Workflow_isDefault: true`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function transitionAsset(uid: string, label: string, fromUid: string, fromLabel: string, toUid: string, toLabel: string, isRollback: boolean, postActions: string[] = []): string {
+  const lines = [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[${CLASS_WORKFLOW_TRANSITION_UID}]]"`,
+    `ems__WorkflowTransition_workflow: "[[${WORKFLOW_UID}]]"`,
+    `ems__WorkflowTransition_from: "[[${fromUid}|${fromLabel}]]"`,
+    `ems__WorkflowTransition_to: "[[${toUid}|${toLabel}]]"`,
+    `ems__WorkflowTransition_label: "${label}"`,
+    `ems__WorkflowTransition_isRollback: ${isRollback}`,
+  ];
+  if (postActions.length > 0) {
+    lines.push(`ems__WorkflowTransition_postActions:`);
+    for (const pa of postActions) {
+      lines.push(`  - "[[${pa}]]"`);
+    }
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+function postActionGrounding(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${POST_ACTION_UID}`,
+    `exo__Asset_label: "bdd post-action sentinel"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Grounding]]"`,
+    `exocmd__Grounding_type: "[[${TYPE_PROPERTY_SET_UID}]]"`,
+    `exocmd__Grounding_targetProperty: "ems__Effort_postActionMarker"`,
+    `exocmd__Grounding_targetValueLiteral: "ran"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+// ─── Vault builder ──────────────────────────────────────────────────────────
+
+function buildWfVault(): string {
+  const root = mkdtempSync(join(tmpdir(), "exo-bdd-wf-"));
+
+  // Class TBox + status TBox.
+  writeFileSync(join(root, `${CLASS_TASK_UID}.md`), classTBox(CLASS_TASK_UID, "ems__Task"));
+  writeFileSync(join(root, `${CLASS_WORKFLOW_UID}.md`), classTBox(CLASS_WORKFLOW_UID, "ems__Workflow"));
+  writeFileSync(join(root, `${CLASS_WORKFLOW_TRANSITION_UID}.md`), classTBox(CLASS_WORKFLOW_TRANSITION_UID, "ems__WorkflowTransition"));
+  writeFileSync(join(root, `${STATUS_BACKLOG_UID}.md`), classTBox(STATUS_BACKLOG_UID, "ems__EffortStatusBacklog"));
+  writeFileSync(join(root, `${STATUS_DOING_UID}.md`), classTBox(STATUS_DOING_UID, "ems__EffortStatusDoing"));
+  writeFileSync(join(root, `${STATUS_DONE_UID}.md`), classTBox(STATUS_DONE_UID, "ems__EffortStatusDone"));
+
+  // Workflow ABox.
+  writeFileSync(join(root, `${WORKFLOW_UID}.md`), workflowAsset());
+  writeFileSync(
+    join(root, `${TRANSITION_FWD_UID}.md`),
+    transitionAsset(TRANSITION_FWD_UID, "Backlog → Doing", STATUS_BACKLOG_UID, "ems__EffortStatusBacklog", STATUS_DOING_UID, "ems__EffortStatusDoing", false, [POST_ACTION_UID]),
+  );
+  writeFileSync(
+    join(root, `${TRANSITION_ROLLBACK_UID}.md`),
+    transitionAsset(TRANSITION_ROLLBACK_UID, "Done → Doing (rollback)", STATUS_DONE_UID, "ems__EffortStatusDone", STATUS_DOING_UID, "ems__EffortStatusDoing", true),
+  );
+
+  // postAction Grounding.
+  writeFileSync(join(root, `${POST_ACTION_UID}.md`), postActionGrounding());
+
+  // Commands + groundings.
+  writeFileSync(join(root, `${COMMAND_FWD_UID}.md`), command(COMMAND_FWD_UID, "Forward transition", GROUNDING_FWD_UID));
+  writeFileSync(join(root, `${COMMAND_ROLLBACK_UID}.md`), command(COMMAND_ROLLBACK_UID, "Rollback transition", GROUNDING_ROLLBACK_UID));
+  writeFileSync(join(root, `${COMMAND_FWD_FROM_DONE_UID}.md`), command(COMMAND_FWD_FROM_DONE_UID, "Forward from Done", GROUNDING_FWD_FROM_DONE_UID));
+  writeFileSync(join(root, `${GROUNDING_FWD_UID}.md`), workflowTransitionGrounding(GROUNDING_FWD_UID, "forward grounding", "forward"));
+  writeFileSync(join(root, `${GROUNDING_ROLLBACK_UID}.md`), workflowTransitionGrounding(GROUNDING_ROLLBACK_UID, "rollback grounding", "rollback"));
+  writeFileSync(join(root, `${GROUNDING_FWD_FROM_DONE_UID}.md`), workflowTransitionGrounding(GROUNDING_FWD_FROM_DONE_UID, "forward from Done", "forward"));
+
+  // Targets.
+  writeFileSync(join(root, `${TASK_BACKLOG_UID}.md`), task(TASK_BACKLOG_UID, "Backlog task", STATUS_BACKLOG_UID, "ems__EffortStatusBacklog"));
+  writeFileSync(join(root, `${TASK_DONE_UID}.md`), task(TASK_DONE_UID, "Done task", STATUS_DONE_UID, "ems__EffortStatusDone"));
+
+  return root;
+}
+
+async function runApplyInVault(vaultRoot: string, commandUid: string, targetRel: string, errBuffer: string[]): Promise<void> {
+  const originalExit = process.exit;
+  const originalLog = console.log;
+  const originalError = console.error;
+  // Intercept process.exit so a non-zero CLI exit (terminal-status case) does
+  // not abort the cucumber runner. The buffer captures any error messages
+  // emitted along the failure path.
+  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number) => {
+    throw new Error(`__process_exit_${code ?? 0}__`);
+  }) as never;
+  console.log = () => {};
+  console.error = (msg?: unknown) => {
+    if (typeof msg === "string") errBuffer.push(msg);
+  };
+  try {
+    const applyCommand = await getApplyCommand();
+    await applyCommand().parseAsync([
+      "node",
+      "apply",
+      commandUid,
+      targetRel,
+      "--vault",
+      vaultRoot,
+      "--seed",
+      SEED,
+      "--frozen-clock",
+      FROZEN_CLOCK,
+    ]);
+  } catch (err) {
+    if (!/^__process_exit_/.test(String((err as Error)?.message))) throw err;
+  } finally {
+    process.exit = originalExit;
+    console.log = originalLog;
+    console.error = originalError;
+  }
+}
+
+// ─── Step definitions ───────────────────────────────────────────────────────
+
+Given("the CLI apply workflow_transition fixture vault", function (this: CliBddWorld) {
+  this.wfVaultPath = buildWfVault();
+  this.wfErrors = [];
+});
+
+When(
+  "I run apply with the forward workflow_transition command on the Backlog task",
+  async function (this: CliBddWorld) {
+    assert.ok(this.wfVaultPath, "wf vault not initialized");
+    await runApplyInVault(this.wfVaultPath!, COMMAND_FWD_UID, `${TASK_BACKLOG_UID}.md`, this.wfErrors);
+  },
+);
+
+When(
+  "I run apply with the rollback workflow_transition command on the Done task",
+  async function (this: CliBddWorld) {
+    assert.ok(this.wfVaultPath, "wf vault not initialized");
+    await runApplyInVault(this.wfVaultPath!, COMMAND_ROLLBACK_UID, `${TASK_DONE_UID}.md`, this.wfErrors);
+  },
+);
+
+When(
+  "I run apply with the forward-from-done workflow_transition command on the Done task",
+  async function (this: CliBddWorld) {
+    assert.ok(this.wfVaultPath, "wf vault not initialized");
+    await runApplyInVault(this.wfVaultPath!, COMMAND_FWD_FROM_DONE_UID, `${TASK_DONE_UID}.md`, this.wfErrors);
+  },
+);
+
+Then(
+  "the target task status becomes {string}",
+  function (this: CliBddWorld, expectedStatusLabel: string) {
+    assert.ok(this.wfVaultPath, "wf vault missing");
+    // Pick whichever target was used in this scenario by looking at the
+    // command emitted; both task files exist but only one gets mutated, so
+    // we accept either file showing the expected status.
+    const candidates = [
+      join(this.wfVaultPath!, `${TASK_BACKLOG_UID}.md`),
+      join(this.wfVaultPath!, `${TASK_DONE_UID}.md`),
+    ];
+    const expectedUid =
+      expectedStatusLabel === "ems__EffortStatusDoing"
+        ? STATUS_DOING_UID
+        : expectedStatusLabel === "ems__EffortStatusDone"
+          ? STATUS_DONE_UID
+          : null;
+    assert.ok(expectedUid, `unknown expected status label: ${expectedStatusLabel}`);
+    const found = candidates.some((p) => {
+      const c = readFileSync(p, "utf-8");
+      return c.includes(`ems__Effort_status: "[[${expectedUid}]]"`) ||
+        c.includes(`ems__Effort_status: "[[${expectedUid}|`);
+    });
+    assert.ok(
+      found,
+      `Expected ems__Effort_status with UID ${expectedUid} (${expectedStatusLabel}) on at least one BDD target task`,
+    );
+  },
+);
+
+Then("the postAction sentinel marker is present", function (this: CliBddWorld) {
+  assert.ok(this.wfVaultPath, "wf vault missing");
+  const content = readFileSync(join(this.wfVaultPath!, `${TASK_BACKLOG_UID}.md`), "utf-8");
+  assert.ok(
+    content.includes("ems__Effort_postActionMarker: ran"),
+    `Expected postAction marker. Task content:\n${content}`,
+  );
+});
+
+Then(
+  "the CLI reports the missing forward transition for {string}",
+  function (this: CliBddWorld, statusEnum: string) {
+    const combined = this.wfErrors.join("\n");
+    const pattern = new RegExp(`no forward transition from "${statusEnum}"`);
+    assert.ok(
+      pattern.test(combined),
+      `Expected fail-loud "no forward transition from ${statusEnum}" in errors. Got:\n${combined}`,
+    );
+  },
+);
+
+Then(
+  "the target task status remains {string}",
+  function (this: CliBddWorld, statusEnum: string) {
+    assert.ok(this.wfVaultPath, "wf vault missing");
+    const statusUid =
+      statusEnum === "ems__EffortStatusDone"
+        ? STATUS_DONE_UID
+        : statusEnum === "ems__EffortStatusBacklog"
+          ? STATUS_BACKLOG_UID
+          : null;
+    assert.ok(statusUid, `unknown status enum: ${statusEnum}`);
+    // The target for the fail-loud scenario is the Done task.
+    const content = readFileSync(join(this.wfVaultPath!, `${TASK_DONE_UID}.md`), "utf-8");
+    assert.ok(
+      content.includes(`ems__Effort_status: "[[${statusUid}`),
+      `Expected ems__Effort_status to still reference ${statusEnum} (${statusUid}); got:\n${content}`,
+    );
+  },
+);
+
+After(function (this: CliBddWorld) {
+  if (this.wfVaultPath && existsSync(this.wfVaultPath)) {
+    try {
+      rmSync(this.wfVaultPath, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+    this.wfVaultPath = null;
+  }
+});

--- a/packages/cli/specs/support/world.ts
+++ b/packages/cli/specs/support/world.ts
@@ -52,6 +52,14 @@ export class CliBddWorld extends World {
   customTargetRelPath: string | null = null;
   customCreatedFrontmatter: Record<string, unknown> | null = null;
 
+  // RFC 36347daf Phase 3 — CLI apply workflow_transition scenario state.
+  // Each scenario gets its own isolated temp vault (the helper is cheap),
+  // so `wfVaultPath` is a per-scenario root distinct from the shared
+  // starter-kit `fixtureVaultPath`. The `wfErrors` buffer captures
+  // `console.error` output so terminal-status fail-loud is assertable.
+  wfVaultPath: string | null = null;
+  wfErrors: string[] = [];
+
   constructor(options: IWorldOptions) {
     super(options);
   }

--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -17,6 +17,7 @@ import {
   EffortStatusWorkflow,
   StatusTimestampService,
   TaskStatusService,
+  WorkflowResolver,
   createVaultFrontmatterClassLabelResolver,
   vaultPathToIRI,
   IRI,
@@ -127,6 +128,7 @@ async function isDestructive(
 async function executeOnTarget(
   vaultPath: string,
   tripleStore: InMemoryTripleStore,
+  workflowResolver: WorkflowResolver,
   commandUid: string,
   targetRelative: string,
   options: ApplyOptions,
@@ -212,12 +214,26 @@ async function executeOnTarget(
   // NoteToRDFConverter substitutes class-shaped string literals with class
   // IRIs at predicate `exo:Asset_label` (Issue #2782/#2959), so a vault scan
   // by frontmatter is required.
+  // RFC 36347daf Phase 3 — wire WorkflowResolver + GroundingLoader so the
+  // workflow_transition grounding type resolves the active Workflow from
+  // vault ABox (hydrated above into `tripleStore`) and dispatches
+  // postActions through CommandResolver.loadGroundingByUid. Mirrors the
+  // plugin's `ExocortexPlugin.ts` wiring (`WorkflowResolver(tripleStore)`
+  // + `groundingLoader: (uid) => commandResolver.loadGroundingByUid(uid)`).
+  // Without these the executor returns the fail-loud "workflow_transition
+  // requires WorkflowResolver injection" error from
+  // `GroundingExecutor.executeWorkflowTransition`.
   const groundingExecutor = new GroundingExecutor(
     nodeFsAdapter,
     nodeFsAdapter,
     serviceRegistry,
     createVaultFrontmatterClassLabelResolver(nodeFsAdapter),
-    { clock, uidGenerator: uidGen },
+    {
+      clock,
+      uidGenerator: uidGen,
+      workflowResolver,
+      groundingLoader: (uid) => resolver.loadGroundingByUid(uid),
+    },
   );
 
   let userInput: Record<string, unknown> | undefined;
@@ -307,6 +323,11 @@ export function applyCommand(): Command {
         const tripleStore = new InMemoryTripleStore();
         await tripleStore.addAll(triples);
 
+        // RFC 36347daf Phase 3 — construct WorkflowResolver once for the whole
+        // batch so its per-class cache survives across stdin-piped targets
+        // (mirrors the rationale documented for `clock` / `uidGen` threading).
+        const workflowResolver = new WorkflowResolver(tripleStore);
+
         // Resolve cmdArg → UUID
         let commandUid: string;
         if (UUID_RE.test(cmdArg)) {
@@ -343,6 +364,7 @@ export function applyCommand(): Command {
           const ok = await executeOnTarget(
             vaultPath,
             tripleStore,
+            workflowResolver,
             commandUid,
             target,
             options,

--- a/packages/cli/tests/integration/apply-workflow-transition.integration.test.ts
+++ b/packages/cli/tests/integration/apply-workflow-transition.integration.test.ts
@@ -1,0 +1,433 @@
+/**
+ * RFC 36347daf Phase 3 — CLI `apply` integration tests for the
+ * `workflow_transition` grounding type.
+ *
+ * Phase 2 shipped the executor implementation
+ * (`GroundingExecutor.executeWorkflowTransition`) + plugin wiring only. Phase 3
+ * wires the same dependencies (`WorkflowResolver` + `GroundingLoader`) into the
+ * CLI `apply` command so a CLI invocation against a real vault can resolve the
+ * active Workflow ABox and dispatch postActions.
+ *
+ * Verification strategy: run the actual `applyCommand().parseAsync(...)` entry
+ * point against a temp vault — mirrors `apply-class-resolver.integration.test.ts`
+ * (Issue #3258). Without the Phase 3 DI wiring this test fails with the
+ * fail-loud message `"workflow_transition requires WorkflowResolver injection"`
+ * from `GroundingExecutor.ts:1740`.
+ *
+ * Scenarios:
+ *   1. Forward Backlog → Doing — status mutated, postAction executed.
+ *   2. Rollback Done → Doing — direction respected, status moved backward.
+ *   3. Terminal-status error — no forward transition exists, executor returns
+ *      `{success:false}` with explanatory message.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { applyCommand } = await import("../../src/commands/apply.js");
+
+// ─── Stable fixture UIDs ────────────────────────────────────────────────────
+const COMMAND_UID = "ddddeeee-0001-0000-0000-000000000001";
+const GROUNDING_FWD_UID = "ddddeeee-0001-0000-0000-000000000002";
+const GROUNDING_ROLLBACK_UID = "ddddeeee-0001-0000-0000-000000000003";
+const COMMAND_TERMINAL_UID = "ddddeeee-0001-0000-0000-000000000004";
+const GROUNDING_FWD_FROM_DONE_UID = "ddddeeee-0001-0000-0000-000000000005";
+const COMMAND_ROLLBACK_UID = "ddddeeee-0001-0000-0000-000000000006";
+
+const WORKFLOW_UID = "ddddeeee-0002-0000-0000-000000000001";
+const TRANSITION_FWD_BACKLOG_DOING_UID = "ddddeeee-0002-0000-0000-000000000002";
+const TRANSITION_ROLLBACK_DONE_DOING_UID = "ddddeeee-0002-0000-0000-000000000003";
+const POST_ACTION_UID = "ddddeeee-0002-0000-0000-000000000004";
+
+const TASK_UID = "ddddeeee-0003-0000-0000-000000000001";
+const TASK_DONE_UID = "ddddeeee-0003-0000-0000-000000000002";
+const TASK_TERMINAL_UID = "ddddeeee-0003-0000-0000-000000000003";
+
+// ─── Canonical class + status UIDs (production constants) ──────────────────
+const CLASS_TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const CLASS_WORKFLOW_UID = "f4bf6c5a-d39c-4f72-9d2f-1c1b1fa2cd95"; // ems__Workflow (any UUID — only label matters for converter)
+const CLASS_WORKFLOW_TRANSITION_UID = "8eef26d7-4692-4b84-8835-8a0277828b8c"; // ems__WorkflowTransition (actual vault UID)
+const STATUS_BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const STATUS_DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+const STATUS_DONE_UID = "7b9b3116-7c3c-438c-9618-94fe301320a6";
+
+// ─── Grounding type UIDs — must match `GROUNDING_TYPE_UIDS` reverse map.
+const TYPE_WORKFLOW_TRANSITION_UID = "5c1a2552-d576-496d-8823-563573dd1e2f";
+const TYPE_PROPERTY_SET_UID = "cf3bb923-f1f1-40be-b728-782844402426";
+const PROP_END_TS_UID = "ddddeeee-0004-0000-0000-000000000001"; // any UID — only label matters
+
+const SEED = "99999999-7777-8888-6666-444444444444";
+const FROZEN_CLOCK = "2026-02-01T12:00:00Z";
+
+// ─── Asset content templates ────────────────────────────────────────────────
+
+function buildClassTBox(uid: string, label: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exo__Class]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildGroundingTypeTBox(uid: string, label: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__GroundingType]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildPropertyTBox(uid: string, label: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exo__DatatypeProperty]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildWorkflowAsset(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${WORKFLOW_UID}`,
+    `exo__Asset_label: "Task default workflow"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[${CLASS_WORKFLOW_UID}]]"`,
+    `ems__Workflow_targetClass: "[[${CLASS_TASK_UID}|ems__Task]]"`,
+    `ems__Workflow_isDefault: true`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildForwardTransitionAsset(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${TRANSITION_FWD_BACKLOG_DOING_UID}`,
+    `exo__Asset_label: "Backlog → Doing"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[${CLASS_WORKFLOW_TRANSITION_UID}]]"`,
+    `ems__WorkflowTransition_workflow: "[[${WORKFLOW_UID}]]"`,
+    `ems__WorkflowTransition_from: "[[${STATUS_BACKLOG_UID}|ems__EffortStatusBacklog]]"`,
+    `ems__WorkflowTransition_to: "[[${STATUS_DOING_UID}|ems__EffortStatusDoing]]"`,
+    `ems__WorkflowTransition_label: "Start work"`,
+    `ems__WorkflowTransition_isRollback: false`,
+    `ems__WorkflowTransition_postActions:`,
+    `  - "[[${POST_ACTION_UID}]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildRollbackTransitionAsset(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${TRANSITION_ROLLBACK_DONE_DOING_UID}`,
+    `exo__Asset_label: "Done → Doing (rollback)"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[${CLASS_WORKFLOW_TRANSITION_UID}]]"`,
+    `ems__WorkflowTransition_workflow: "[[${WORKFLOW_UID}]]"`,
+    `ems__WorkflowTransition_from: "[[${STATUS_DONE_UID}|ems__EffortStatusDone]]"`,
+    `ems__WorkflowTransition_to: "[[${STATUS_DOING_UID}|ems__EffortStatusDoing]]"`,
+    `ems__WorkflowTransition_label: "Reopen"`,
+    `ems__WorkflowTransition_isRollback: true`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildPostActionGrounding(): string {
+  // A simple property_set grounding that writes a sentinel marker so we can
+  // assert the postAction actually ran. We use property_set with a literal
+  // value (avoids inheriting more wiring complexity than needed).
+  return [
+    "---",
+    `exo__Asset_uid: ${POST_ACTION_UID}`,
+    `exo__Asset_label: "post-action sentinel"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Grounding]]"`,
+    `exocmd__Grounding_type: "[[${TYPE_PROPERTY_SET_UID}]]"`,
+    `exocmd__Grounding_targetProperty: "ems__Effort_postActionMarker"`,
+    `exocmd__Grounding_targetValueLiteral: "ran"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildForwardCommand(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${COMMAND_UID}`,
+    `exo__Asset_label: "Forward transition"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Command]]"`,
+    `exocmd__Command_grounding: "[[${GROUNDING_FWD_UID}|forward grounding]]"`,
+    `exocmd__Command_successMessage: "Workflow advanced"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildRollbackCommand(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${COMMAND_ROLLBACK_UID}`,
+    `exo__Asset_label: "Rollback transition"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Command]]"`,
+    `exocmd__Command_grounding: "[[${GROUNDING_ROLLBACK_UID}|rollback grounding]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildTerminalCommand(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${COMMAND_TERMINAL_UID}`,
+    `exo__Asset_label: "Forward transition from terminal"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Command]]"`,
+    `exocmd__Command_grounding: "[[${GROUNDING_FWD_FROM_DONE_UID}|forward grounding from done]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildForwardGrounding(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${GROUNDING_FWD_UID}`,
+    `exo__Asset_label: "forward grounding"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Grounding]]"`,
+    `exocmd__Grounding_type: "[[${TYPE_WORKFLOW_TRANSITION_UID}]]"`,
+    `exocmd__Grounding_direction: forward`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildRollbackGrounding(): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${GROUNDING_ROLLBACK_UID}`,
+    `exo__Asset_label: "rollback grounding"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Grounding]]"`,
+    `exocmd__Grounding_type: "[[${TYPE_WORKFLOW_TRANSITION_UID}]]"`,
+    `exocmd__Grounding_direction: rollback`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildForwardFromDoneGrounding(): string {
+  // direction=forward — but vault has no forward transition out of Done so
+  // the executor reports "no forward transition from Done".
+  return [
+    "---",
+    `exo__Asset_uid: ${GROUNDING_FWD_FROM_DONE_UID}`,
+    `exo__Asset_label: "forward grounding from done"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exocmd__Grounding]]"`,
+    `exocmd__Grounding_type: "[[${TYPE_WORKFLOW_TRANSITION_UID}]]"`,
+    `exocmd__Grounding_direction: forward`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function buildTaskAsset(uid: string, label: string, statusUid: string, statusLabel: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[${CLASS_TASK_UID}|ems__Task]]"`,
+    `ems__Effort_status: "[[${statusUid}|${statusLabel}]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+// ─── Status TBox files needed for property_set to resolve the destination
+//     status wikilink correctly. Each one is a stub matching real UIDs.
+function buildStatusTBox(uid: string, label: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class:`,
+    `  - "[[exo__Class]]"`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+// ─── Vault layout ───────────────────────────────────────────────────────────
+
+interface VaultLayout {
+  root: string;
+}
+
+function buildVault(): VaultLayout {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "exo-apply-wftrans-"));
+
+  // Class TBox
+  fs.writeFileSync(path.join(root, `${CLASS_TASK_UID}.md`), buildClassTBox(CLASS_TASK_UID, "ems__Task"));
+  fs.writeFileSync(path.join(root, `${CLASS_WORKFLOW_UID}.md`), buildClassTBox(CLASS_WORKFLOW_UID, "ems__Workflow"));
+  fs.writeFileSync(path.join(root, `${CLASS_WORKFLOW_TRANSITION_UID}.md`), buildClassTBox(CLASS_WORKFLOW_TRANSITION_UID, "ems__WorkflowTransition"));
+
+  // Status TBox stubs
+  fs.writeFileSync(path.join(root, `${STATUS_BACKLOG_UID}.md`), buildStatusTBox(STATUS_BACKLOG_UID, "ems__EffortStatusBacklog"));
+  fs.writeFileSync(path.join(root, `${STATUS_DOING_UID}.md`), buildStatusTBox(STATUS_DOING_UID, "ems__EffortStatusDoing"));
+  fs.writeFileSync(path.join(root, `${STATUS_DONE_UID}.md`), buildStatusTBox(STATUS_DONE_UID, "ems__EffortStatusDone"));
+
+  // GroundingType + property TBox
+  fs.writeFileSync(
+    path.join(root, `${TYPE_WORKFLOW_TRANSITION_UID}.md`),
+    buildGroundingTypeTBox(TYPE_WORKFLOW_TRANSITION_UID, "workflow_transition"),
+  );
+  fs.writeFileSync(
+    path.join(root, `${TYPE_PROPERTY_SET_UID}.md`),
+    buildGroundingTypeTBox(TYPE_PROPERTY_SET_UID, "property_set"),
+  );
+  fs.writeFileSync(path.join(root, `${PROP_END_TS_UID}.md`), buildPropertyTBox(PROP_END_TS_UID, "ems__Effort_postActionMarker"));
+
+  // Workflow ABox
+  fs.writeFileSync(path.join(root, `${WORKFLOW_UID}.md`), buildWorkflowAsset());
+  fs.writeFileSync(path.join(root, `${TRANSITION_FWD_BACKLOG_DOING_UID}.md`), buildForwardTransitionAsset());
+  fs.writeFileSync(path.join(root, `${TRANSITION_ROLLBACK_DONE_DOING_UID}.md`), buildRollbackTransitionAsset());
+  fs.writeFileSync(path.join(root, `${POST_ACTION_UID}.md`), buildPostActionGrounding());
+
+  // Commands + groundings
+  fs.writeFileSync(path.join(root, `${COMMAND_UID}.md`), buildForwardCommand());
+  fs.writeFileSync(path.join(root, `${COMMAND_ROLLBACK_UID}.md`), buildRollbackCommand());
+  fs.writeFileSync(path.join(root, `${COMMAND_TERMINAL_UID}.md`), buildTerminalCommand());
+  fs.writeFileSync(path.join(root, `${GROUNDING_FWD_UID}.md`), buildForwardGrounding());
+  fs.writeFileSync(path.join(root, `${GROUNDING_ROLLBACK_UID}.md`), buildRollbackGrounding());
+  fs.writeFileSync(path.join(root, `${GROUNDING_FWD_FROM_DONE_UID}.md`), buildForwardFromDoneGrounding());
+
+  // Targets
+  fs.writeFileSync(path.join(root, `${TASK_UID}.md`), buildTaskAsset(TASK_UID, "BDD target task", STATUS_BACKLOG_UID, "ems__EffortStatusBacklog"));
+  fs.writeFileSync(path.join(root, `${TASK_DONE_UID}.md`), buildTaskAsset(TASK_DONE_UID, "Done target task", STATUS_DONE_UID, "ems__EffortStatusDone"));
+  fs.writeFileSync(path.join(root, `${TASK_TERMINAL_UID}.md`), buildTaskAsset(TASK_TERMINAL_UID, "Terminal target task", STATUS_DONE_UID, "ems__EffortStatusDone"));
+
+  return { root };
+}
+
+// ─── Test runner ────────────────────────────────────────────────────────────
+
+describe("RFC 36347daf Phase 3: CLI apply workflow_transition", () => {
+  let vault: VaultLayout;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+  let consoleErrorBuffer: string[];
+
+  beforeEach(() => {
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__process_exit_${code ?? 0}__`);
+    }) as never);
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorBuffer = [];
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      if (typeof msg === "string") consoleErrorBuffer.push(msg);
+    });
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (vault) fs.rmSync(vault.root, { recursive: true, force: true });
+  });
+
+  async function runApply(vaultRoot: string, commandUid: string, taskRelPath: string): Promise<void> {
+    const cmd = applyCommand();
+    const args = [
+      "node",
+      "apply",
+      commandUid,
+      taskRelPath,
+      "--vault",
+      vaultRoot,
+      "--seed",
+      SEED,
+      "--frozen-clock",
+      FROZEN_CLOCK,
+    ];
+    try {
+      await cmd.parseAsync(args);
+    } catch (err) {
+      if (!/^__process_exit_/.test(String((err as Error)?.message))) throw err;
+    }
+  }
+
+  it("forward Backlog → Doing — status mutated, postAction marker written", async () => {
+    vault = buildVault();
+
+    await runApply(vault.root, COMMAND_UID, `${TASK_UID}.md`);
+
+    const content = fs.readFileSync(path.join(vault.root, `${TASK_UID}.md`), "utf-8");
+
+    // Status mutated to Doing (UID-form).
+    expect(content).toContain(`ems__Effort_status: "[[${STATUS_DOING_UID}]]"`);
+    expect(content).not.toContain(`ems__Effort_status: "[[${STATUS_BACKLOG_UID}`);
+    // postAction sentinel applied — proves GroundingLoader DI works.
+    expect(content).toContain(`ems__Effort_postActionMarker: ran`);
+  });
+
+  it("rollback Done → Doing — direction respected, status moved backward", async () => {
+    vault = buildVault();
+
+    await runApply(vault.root, COMMAND_ROLLBACK_UID, `${TASK_DONE_UID}.md`);
+
+    const content = fs.readFileSync(path.join(vault.root, `${TASK_DONE_UID}.md`), "utf-8");
+
+    expect(content).toContain(`ems__Effort_status: "[[${STATUS_DOING_UID}]]"`);
+    expect(content).not.toContain(`ems__Effort_status: "[[${STATUS_DONE_UID}`);
+  });
+
+  it("forward from Done — no forward transition exists → fail-loud", async () => {
+    vault = buildVault();
+
+    await runApply(vault.root, COMMAND_TERMINAL_UID, `${TASK_TERMINAL_UID}.md`);
+
+    // Task untouched (still Done).
+    const content = fs.readFileSync(path.join(vault.root, `${TASK_TERMINAL_UID}.md`), "utf-8");
+    expect(content).toContain(`ems__Effort_status: "[[${STATUS_DONE_UID}`);
+
+    // Executor reported the no-transition error path.
+    const combinedErr = consoleErrorBuffer.join("\n");
+    expect(combinedErr).toMatch(/no forward transition from "ems__EffortStatusDone"/);
+  });
+});


### PR DESCRIPTION
## Summary

- CLI `apply` was missing DI for `workflow_transition` grounding type — `GroundingExecutor` constructed without `workflowResolver` + `groundingLoader`, so any CLI invocation against a vault `workflow_transition` Grounding failed with the fail-loud `"workflow_transition requires WorkflowResolver injection"` from `GroundingExecutor.ts:1740`.
- Phase 2 (PR #3299 / v16.33.0) shipped the executor implementation + plugin wiring; this PR closes the CLI gap, mirroring `ExocortexPlugin.ts:337-350`.
- Vault triple-store hydration is already done in `apply.ts:306` (`convertVault()` runs once per batch) — the only gap was DI plumbing.

## Implementation

- `apply.ts`:
  - Import `WorkflowResolver` from `@exocortex/core`.
  - Construct `new WorkflowResolver(tripleStore)` **once outer-scope** after store hydration so its per-class cache survives stdin-piped batches. Thread through `executeOnTarget`, mirroring `clock` / `uidGen` threading.
  - Pass `{ workflowResolver, groundingLoader: (uid) => resolver.loadGroundingByUid(uid) }` in the `GroundingExecutor` options. Matches plugin wiring 1:1.

## Tests

- **Integration** (`packages/cli/tests/integration/apply-workflow-transition.integration.test.ts`) — 3 scenarios exercising the actual `applyCommand().parseAsync(...)` entry point against a temp vault containing Workflow ABox + class TBox + target Task asset:
  1. Forward Backlog → Doing — status mutated to Doing UID, postAction sentinel marker written (proves WorkflowResolver + GroundingLoader DI works).
  2. Rollback Done → Doing — direction respected, status moved backward.
  3. Forward from terminal Done — no forward transition exists → fail-loud `"no forward transition from ems__EffortStatusDone"`.
- **BDD** (`packages/cli/specs/features/groundings.feature` + new `workflow_transition.steps.ts`) — 3 mirror scenarios protecting the test-bdd CI gate.
- Empirically verified per `integration-test-revert-verify` rule: tests FAIL pre-fix (3/3 with the `workflow_transition requires WorkflowResolver injection` message), PASS post-fix (3/3). Documented in commit body.

## Out of scope (Phase 3 deferred items per RFC 36347daf impl log)

- Phase 1 → workflow_transition migration (highest architectural value, separate scope)
- SHACL shapes for Workflow ontology
- `EffortStatusWorkflow` async migration
- `kitelev/exoas-ems` as submodule of `exocortex` (vault-fixture parity)

## Test plan

- [x] Local `npm run check:types` — green
- [x] Local `npm run lint` — 0 errors
- [x] Local CLI test suite — 120/120 suites pass (excl pre-existing baseline-broken `sparql-exo003.integration.test.ts`)
- [x] Local BDD `npm run bdd:test` — 53/53 scenarios pass (50 prior + 3 new)
- [x] Revert/restore empirical verification (3/3 fail revert, 3/3 pass restore)
- [ ] CI green (all 14 required checks)
- [ ] code-reviewer agent APPROVE
- [ ] advisor round-2 sign-off
- [ ] Manual squash merge (no auto-merge per parser-path discipline)
- [ ] Verify against real vault Grounding asset via `npx @kitelev/exocortex-cli@latest apply <uid> <task-path> --vault /Users/kitelev/vault-2025` post-release

## RFC link

Phase 3 task #3 from RFC `36347daf` (vault-exodev/inbox/36347daf-cb98-40d4-980b-0ea1cae5ae65.md) impl log.