### PR TITLE
test(e2e): tag BacklinksTableBlock smoke @flaky-track per #3308

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/exo-layout-smoke.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/exo-layout-smoke.spec.ts
@@ -1,3 +1,10 @@
+// flaky-track: Issue #3308 — observed 2026-05-31 on PR #3307 (B.1 GitHubRestClient).
+// Symptom: `e2e-shard(4)` ExoLayout BacklinksTableBlock smoke — Obsidian Electron
+// process termination timeout. Sibling shard(2) flake (daily-archive-filter @flaky-track)
+// observed same calendar day on PR #3305 — shared root-cause hypothesis: Playwright
+// Electron driver process management in headless macOS CI runner. Both retried green.
+// Per RFC 32a64ed9 §3.3 escalation: tag surfaces frequency in telemetry; promote to
+// `@flaky-fix` on incident #2 with root-cause PR, close on N≥100 zero-further runs.
 import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
 
@@ -15,7 +22,17 @@ import { ObsidianLauncher } from "../utils/obsidian-launcher";
  * alongside the RelationColumnSet smoke because both drive the same
  * UniversalLayout pipeline with minimal interaction (no modals, no input).
  */
-test.describe("ExoLayout — Phase 3 smoke", () => {
+test.describe(
+  "ExoLayout — Phase 3 smoke",
+  {
+    tag: ["@flaky-track"],
+    annotation: {
+      type: "flaky-track",
+      description:
+        "Issue #3308 — Electron termination timeout observed PR #3307 2026-05-31; RFC 32a64ed9 §3.3 track bucket; watch criteria: incident #2 → fix, N≥100 zero-further → close",
+    },
+  },
+  () => {
   let launcher: ObsidianLauncher;
 
   test.beforeAll(async () => {


### PR DESCRIPTION
## Summary

- Add `@flaky-track` tag + structured annotation to `test.describe("ExoLayout — Phase 3 smoke", ...)` in `exo-layout-smoke.spec.ts` so flake frequency surfaces in the flaky-dashboard telemetry per RFC 32a64ed9 §3.3.
- Scope **S** (Issue #3308 size matrix): observation-period tagging, no root-cause fix in this PR.
- Pattern mirrors existing precedent in `daily-archive-filter.spec.ts` (same `tag: ["@flaky-track"]` + annotation shape). Pure additive — no behaviour, assertions, or timeouts modified.

## Why this issue

Two Obsidian Electron lifecycle flakes on **2026-05-31** across unrelated PRs:

| # | PR | Shard | Spec | Symptom | Outcome |
|---|----|-------|------|---------|---------|
| 1 | #3307 | `e2e-shard(4)` | ExoLayout BacklinksTableBlock smoke | Electron termination timeout | Retry green |
| 2 | #3305 | `e2e-shard(2)` | daily-archive-filter (already `@flaky-track`) | "Obsidian not launched" | Retry green |

Both unrelated to TS code under test — shared root-cause hypothesis: Playwright Electron driver process management in headless macOS CI runner. Tagging surfaces frequency so we can decide between (a) wait for it to be self-resolving from upstream Playwright/Electron updates vs (b) invest in root-cause fix once Issue #3308 has incident #2 (then promote to `@flaky-fix`).

## Decision tree (per Issue body)

- ✅ Scope **S** chosen: spec exists, `@flaky-track` precedent visible in sibling spec → add tag, ship.
- ❌ Scope **M** deferred: no clear evidence Electron timeout config is the actual root cause; pure timeout bump risks masking different underlying issues. Wait for incident #2 before committing engineering effort.
- ❌ Scope **L** deferred per session prompt directive ("Scope L investigation requires Playwright+Obsidian process expert").

## Observation period

Per Issue #3308 BDD acceptance criteria: 5 PR runs; flake rate target <5%. Will be re-evaluated when telemetry accumulates.

## Test plan

- Tag is metadata-only — Playwright will continue to execute the test identically; only the test reporter / flaky-dashboard sees the tag.
- Closing parenthesis structure verified against sibling pattern in `daily-archive-filter.spec.ts` lines 14-23.
- Diff is 18 insertions / 1 deletion — change is structurally minimal.

Closes #3308