### PR TITLE
feat(plugin): TarExtractor + zip-slip protection (RFC 0a0791c1 B.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17315,6 +17315,7 @@
         "@tanstack/react-query": "^5.90.12",
         "@tanstack/react-virtual": "^3.13.13",
         "exocortex": "*",
+        "nanotar": "0.3.0",
         "obsidian": "latest",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",

--- a/packages/obsidian-plugin/src/infrastructure/adapters/TarExtractor.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/TarExtractor.ts
@@ -1,0 +1,166 @@
+import { parseTarGzip } from "nanotar";
+import type { ParsedTarFileItem } from "nanotar";
+
+export interface ExtractedTarFile {
+  path: string;
+  content: Uint8Array;
+}
+
+export interface TarExtractorOptions {
+  /**
+   * Required path prefix all extracted entries must live under (after
+   * normalisation). Pattern: trailing `/`, e.g. `"staging/"`.
+   * Empty string disables the prefix gate — only safe for tarballs whose
+   * origin is fully trusted; NOT recommended for arbitrary remote tarballs.
+   */
+  stagingDirPrefix: string;
+}
+
+export class ZipSlipError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ZipSlipError";
+  }
+}
+
+/**
+ * Normalize a tar entry path: backslash→slash, collapse `//`, strip leading
+ * `./` and `/`. Does NOT resolve `..` (rejection is `validateEntry`'s job).
+ */
+export function normalizePath(path: string): string {
+  let p = path.replace(/\\/g, "/").replace(/\/+/g, "/");
+  while (p.startsWith("./")) {
+    p = p.slice(2);
+  }
+  if (p.startsWith("/")) {
+    p = p.slice(1);
+  }
+  return p;
+}
+
+/**
+ * Validate one parsed tar entry against the 4 zip-slip checks.
+ *
+ * Note on layering: nanotar 0.3.0's parser already sanitises `..` and
+ * absolute paths via its internal `_sanitizePath` (`../foo` → `foo`,
+ * `/etc/passwd` → `etc/passwd`). The `..`/absolute checks here are
+ * defense-in-depth — they fire if the parser regresses, if the entry source
+ * bypasses the parser (e.g. raw `parseTar` on hand-crafted bytes), or for
+ * entries with unusual encodings (Windows drive letters, backslashes).
+ *
+ * The PRIMARY defense in practice is the staging-prefix check: a malicious
+ * `/etc/passwd` becomes `etc/passwd` post-sanitisation, which then fails the
+ * prefix gate against e.g. `"staging/"`.
+ *
+ * @throws ZipSlipError on any violation.
+ */
+export function validateEntry(
+  entry: { name: string; type?: string },
+  prefix: string,
+): void {
+  const rawName = entry.name;
+  if (typeof rawName !== "string" || rawName.length === 0) {
+    throw new ZipSlipError("Tar entry with empty or non-string name rejected");
+  }
+  // Link types FIRST — a symlink with a benign-looking name is still
+  // dangerous (creates a host-filesystem link to an arbitrary target).
+  if (entry.type === "symbolicLink") {
+    throw new ZipSlipError(`Symbolic-link entry rejected: ${rawName}`);
+  }
+  if (entry.type === "hardLink") {
+    throw new ZipSlipError(`Hard-link entry rejected: ${rawName}`);
+  }
+  // Absolute paths — POSIX leading `/`, leading backslash, or Windows drive.
+  if (
+    rawName.startsWith("/") ||
+    rawName.startsWith("\\") ||
+    /^[A-Za-z]:[/\\]/.test(rawName)
+  ) {
+    throw new ZipSlipError(`Absolute path rejected: ${rawName}`);
+  }
+  // Parent-dir traversal — any segment equal to `..` after normalisation.
+  const normalized = normalizePath(rawName);
+  const segments = normalized.split("/");
+  if (segments.some((s) => s === "..")) {
+    throw new ZipSlipError(`Parent-dir traversal rejected: ${rawName}`);
+  }
+  // Staging-prefix gate — primary defense once nanotar's parser has stripped
+  // leading `..` / absolute path components.
+  if (prefix.length > 0 && !normalized.startsWith(prefix)) {
+    throw new ZipSlipError(
+      `Path '${normalized}' outside staging prefix '${prefix}'`,
+    );
+  }
+}
+
+/**
+ * TarExtractor — async-iterable tarball parser with zip-slip protection.
+ *
+ * **Empirical caveat — nanotar 0.3.0 NOT streaming:**
+ * `parseTarGzip(arrayBuffer)` returns `Promise<ParsedTarFileItem[]>` — the
+ * entire tarball is decompressed and materialised as an in-memory array
+ * before the iterator yields its first entry. Memory bound is
+ * O(tarball.size), NOT O(entry.size). The `AsyncIterable` API is preserved
+ * for the iterate-then-discard yield pattern (each entry's reference in the
+ * internal array is released after yield so the caller-consumed
+ * `Uint8Array` becomes GC-eligible) and for forward compatibility if
+ * nanotar adds true streaming in a future major.
+ *
+ * Tarball size guard belongs upstream — e.g. `GitHubRestClient.pullTarball`
+ * already enforces `maxTarballBytes` (default 50 MB) before parsing.
+ *
+ * **Zip-slip protection (Security #5, RFC 0a0791c1 Vision Lock #7):**
+ *   1. Reject absolute paths (`/etc/passwd`, `C:/Windows/...`).
+ *   2. Reject `..` parent-dir traversal segments.
+ *   3. Reject `symbolicLink` and `hardLink` entry types.
+ *   4. Reject paths outside the configured `stagingDirPrefix`.
+ *
+ * Iteration throws `ZipSlipError` on first violation — the caller's
+ * `for await` loop receives the rejection (no silent skip).
+ */
+export class TarExtractor {
+  /**
+   * Parse + iterate a gzipped tarball blob.
+   *
+   * @throws ZipSlipError on any per-entry validation failure.
+   * @throws Error on parse failure (corrupt tarball, invalid gzip stream).
+   */
+  public extract(
+    blob: ArrayBuffer | Uint8Array,
+    opts: TarExtractorOptions,
+  ): AsyncIterable<ExtractedTarFile> {
+    if (!opts || typeof opts.stagingDirPrefix !== "string") {
+      throw new Error("TarExtractor.extract: stagingDirPrefix is required");
+    }
+    const prefix = normalizePath(opts.stagingDirPrefix);
+    return {
+      [Symbol.asyncIterator]:
+        async function* (): AsyncIterableIterator<ExtractedTarFile> {
+          const parsed: ParsedTarFileItem[] = await parseTarGzip(blob);
+          try {
+            for (let i = 0; i < parsed.length; i++) {
+              const entry = parsed[i];
+              // Validate first — throws on any zip-slip violation.
+              validateEntry(entry, prefix);
+              // Skip directories — callers materialise dirs via file paths.
+              if (entry.type === "directory") {
+                parsed[i] = undefined as unknown as ParsedTarFileItem;
+                continue;
+              }
+              const content = entry.data ?? new Uint8Array(0);
+              const path = normalizePath(entry.name);
+              yield { path, content };
+              // Release the entry reference so the caller-processed Uint8Array
+              // becomes GC-eligible (the parsed[] array would otherwise pin it
+              // for the lifetime of the iteration).
+              parsed[i] = undefined as unknown as ParsedTarFileItem;
+            }
+          } finally {
+            // Final cleanup runs even on early-abort (caller breaks out of
+            // for-await loop, throws, or calls iterator.return()).
+            parsed.length = 0;
+          }
+        },
+    };
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/TarExtractor.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/TarExtractor.ts
@@ -10,8 +10,14 @@ export interface TarExtractorOptions {
   /**
    * Required path prefix all extracted entries must live under (after
    * normalisation). Pattern: trailing `/`, e.g. `"staging/"`.
-   * Empty string disables the prefix gate — only safe for tarballs whose
+   *
+   * **Empty string disables the prefix gate** — only safe for tarballs whose
    * origin is fully trusted; NOT recommended for arbitrary remote tarballs.
+   *
+   * ⚠️ Inputs that normalise to empty ALSO disable the gate. `"/"` becomes
+   * `""` after `normalizePath` strips the leading slash; same for `"./"`.
+   * If you mean "everything under vault root", pass an explicit literal
+   * directory name like `"exocortex-staging/"`, not `"/"`.
    */
   stagingDirPrefix: string;
 }

--- a/packages/obsidian-plugin/tests/unit/TarExtractor.test.ts
+++ b/packages/obsidian-plugin/tests/unit/TarExtractor.test.ts
@@ -1,0 +1,428 @@
+/**
+ * @jest-environment node
+ *
+ * Reason: TarExtractor consumes Web Streams (ReadableStream,
+ * CompressionStream/DecompressionStream, Response) which are provided by
+ * Node 18+'s globalThis but NOT exposed by jest-environment-jsdom. Switching
+ * to the node env makes them available. TarExtractor itself is DOM-free —
+ * no React, no Obsidian UI surface — so the node env is the right fit.
+ */
+import { createTar } from "nanotar";
+
+import {
+  ExtractedTarFile,
+  TarExtractor,
+  ZipSlipError,
+  normalizePath,
+  validateEntry,
+} from "../../src/infrastructure/adapters/TarExtractor";
+
+// ─── Fixture helpers (real nanotar encoding for realism per test-fixture-realism rule) ───
+
+/** Build a gzipped tarball from file/dir entries via real nanotar.createTar + native gzip. */
+async function makeTarball(
+  entries: Array<{ name: string; data?: Uint8Array }>,
+): Promise<Uint8Array> {
+  const files = entries.map((e) => ({
+    name: e.name,
+    data: e.data === undefined ? undefined : e.data,
+  }));
+  const tarBuf = createTar(files);
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(tarBuf);
+      c.close();
+    },
+  }).pipeThrough(new CompressionStream("gzip"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/**
+ * Build a gzipped tarball with one or more entries' type-byte patched at
+ * header offset 156 — used to generate symlink ('2') / hardlink ('1') fixtures
+ * since nanotar.createTar emits only files ('0') or directories ('5').
+ *
+ * nanotar's parser doesn't verify the header checksum, so we leave it stale
+ * after patching — the parser still emits the patched `type` via tarItemTypeMap.
+ */
+async function makeAdversarialTarball(
+  entries: Array<{ name: string; data?: Uint8Array; typeByte?: string }>,
+): Promise<Uint8Array> {
+  const files = entries.map((e) => ({
+    name: e.name,
+    data: e.data ?? new Uint8Array(0),
+  }));
+  const tarBuf = createTar(files);
+  let offset = 0;
+  for (const entry of entries) {
+    if (entry.typeByte) {
+      tarBuf[offset + 156] = entry.typeByte.charCodeAt(0);
+    }
+    const size = entry.data?.length ?? 0;
+    offset += 512;
+    if (size > 0) {
+      offset += 512 * Math.trunc(size / 512);
+      if (size % 512) offset += 512;
+    }
+  }
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(tarBuf);
+      c.close();
+    },
+  }).pipeThrough(new CompressionStream("gzip"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+async function collect(
+  it: AsyncIterable<ExtractedTarFile>,
+): Promise<ExtractedTarFile[]> {
+  const out: ExtractedTarFile[] = [];
+  for await (const e of it) out.push(e);
+  return out;
+}
+
+// ─── normalizePath ──────────────────────────────────────────────────────────
+
+describe("normalizePath", () => {
+  it("converts backslashes to forward slashes", () => {
+    expect(normalizePath("foo\\bar\\baz")).toBe("foo/bar/baz");
+  });
+  it("collapses runs of forward slashes", () => {
+    expect(normalizePath("foo//bar///baz")).toBe("foo/bar/baz");
+  });
+  it("strips a single leading ./", () => {
+    expect(normalizePath("./foo/bar")).toBe("foo/bar");
+  });
+  it("strips repeated leading ./ runs", () => {
+    expect(normalizePath("././foo")).toBe("foo");
+  });
+  it("strips a single leading /", () => {
+    expect(normalizePath("/foo/bar")).toBe("foo/bar");
+  });
+  it("leaves benign paths unchanged", () => {
+    expect(normalizePath("staging/foo/bar.txt")).toBe("staging/foo/bar.txt");
+  });
+});
+
+// ─── validateEntry — zip-slip checks via synthetic entries ──────────────────
+
+describe("validateEntry — zip-slip protection (unit, synthetic entries)", () => {
+  const prefix = "staging/";
+
+  it("accepts a valid entry under prefix", () => {
+    expect(() =>
+      validateEntry({ name: "staging/foo.txt", type: "file" }, prefix),
+    ).not.toThrow();
+  });
+
+  it("rejects empty name", () => {
+    expect(() => validateEntry({ name: "" }, prefix)).toThrow(ZipSlipError);
+  });
+
+  it("rejects non-string name (defensive coerce)", () => {
+    expect(() =>
+      validateEntry({ name: null as unknown as string }, prefix),
+    ).toThrow(ZipSlipError);
+  });
+
+  it("rejects absolute POSIX path", () => {
+    expect(() =>
+      validateEntry({ name: "/etc/passwd", type: "file" }, prefix),
+    ).toThrow(/Absolute path rejected/);
+  });
+
+  it("rejects absolute backslash path", () => {
+    expect(() =>
+      validateEntry({ name: "\\foo\\bar", type: "file" }, prefix),
+    ).toThrow(/Absolute path rejected/);
+  });
+
+  it("rejects Windows drive-letter path", () => {
+    expect(() =>
+      validateEntry(
+        { name: "C:/Windows/system32/cmd.exe", type: "file" },
+        prefix,
+      ),
+    ).toThrow(/Absolute path rejected/);
+  });
+
+  it("rejects Windows drive-letter backslash path", () => {
+    expect(() =>
+      validateEntry({ name: "C:\\foo\\bar", type: "file" }, prefix),
+    ).toThrow(/Absolute path rejected/);
+  });
+
+  it("rejects leading ../ segment", () => {
+    expect(() =>
+      validateEntry({ name: "../foo", type: "file" }, prefix),
+    ).toThrow(/Parent-dir traversal/);
+  });
+
+  it("rejects embedded /../ segment", () => {
+    expect(() =>
+      validateEntry(
+        { name: "staging/sub/../../etc/passwd", type: "file" },
+        prefix,
+      ),
+    ).toThrow(/Parent-dir traversal/);
+  });
+
+  it("rejects symbolicLink type even with benign path", () => {
+    expect(() =>
+      validateEntry(
+        { name: "staging/inside.txt", type: "symbolicLink" },
+        prefix,
+      ),
+    ).toThrow(/Symbolic-link/);
+  });
+
+  it("rejects hardLink type even with benign path", () => {
+    expect(() =>
+      validateEntry({ name: "staging/inside.txt", type: "hardLink" }, prefix),
+    ).toThrow(/Hard-link/);
+  });
+
+  it("rejects path outside staging prefix", () => {
+    expect(() =>
+      validateEntry({ name: "other/foo.txt", type: "file" }, prefix),
+    ).toThrow(/outside staging prefix/);
+  });
+
+  it("accepts any path when prefix is empty (gate disabled)", () => {
+    expect(() =>
+      validateEntry({ name: "any/path/foo.txt", type: "file" }, ""),
+    ).not.toThrow();
+  });
+
+  it("ZipSlipError instances have correct .name", () => {
+    try {
+      validateEntry({ name: "" }, prefix);
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ZipSlipError);
+      expect((e as Error).name).toBe("ZipSlipError");
+    }
+  });
+
+  it("includes the offending raw name in the error message", () => {
+    try {
+      validateEntry({ name: "/etc/passwd", type: "file" }, prefix);
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect((e as Error).message).toContain("/etc/passwd");
+    }
+  });
+
+  it("link checks fire BEFORE absolute-path checks (link is more dangerous)", () => {
+    // A symlink with absolute name → caught by symbolicLink check, not absolute-path check.
+    try {
+      validateEntry({ name: "/etc/passwd", type: "symbolicLink" }, prefix);
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect((e as Error).message).toMatch(/Symbolic-link/);
+      expect((e as Error).message).not.toMatch(/Absolute path/);
+    }
+  });
+});
+
+// ─── TarExtractor — end-to-end via real nanotar createTar + parseTarGzip ───
+
+describe("TarExtractor.extract — end-to-end (real nanotar round-trip)", () => {
+  const PREFIX = "staging/";
+
+  it("yields entries with path + content for a valid tarball", async () => {
+    const blob = await makeTarball([
+      { name: "staging/a.txt", data: new TextEncoder().encode("AAA") },
+      { name: "staging/sub/b.txt", data: new TextEncoder().encode("BBB") },
+    ]);
+    const items = await collect(
+      new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX }),
+    );
+    expect(items.map((i) => i.path)).toEqual([
+      "staging/a.txt",
+      "staging/sub/b.txt",
+    ]);
+    expect(new TextDecoder().decode(items[0].content)).toBe("AAA");
+    expect(new TextDecoder().decode(items[1].content)).toBe("BBB");
+  });
+
+  it("accepts both ArrayBuffer and Uint8Array inputs", async () => {
+    const u8 = await makeTarball([
+      { name: "staging/a.txt", data: new TextEncoder().encode("X") },
+    ]);
+    // Uint8Array path
+    const fromU8 = await collect(
+      new TarExtractor().extract(u8, { stagingDirPrefix: PREFIX }),
+    );
+    expect(fromU8).toHaveLength(1);
+    // ArrayBuffer path (slice copy to ensure ArrayBuffer not SharedArrayBuffer)
+    const ab = u8.buffer.slice(
+      u8.byteOffset,
+      u8.byteOffset + u8.byteLength,
+    ) as ArrayBuffer;
+    const fromAb = await collect(
+      new TarExtractor().extract(ab, { stagingDirPrefix: PREFIX }),
+    );
+    expect(fromAb).toHaveLength(1);
+  });
+
+  it("rejects /etc/passwd (parser sanitises → prefix gate fires)", async () => {
+    const blob = await makeTarball([
+      { name: "/etc/passwd", data: new Uint8Array([1, 2, 3]) },
+    ]);
+    const it = new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX });
+    await expect(collect(it)).rejects.toThrow(ZipSlipError);
+  });
+
+  it("rejects ../foo (parser sanitises → prefix gate fires)", async () => {
+    const blob = await makeTarball([
+      { name: "../foo", data: new Uint8Array([1, 2, 3]) },
+    ]);
+    const it = new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX });
+    await expect(collect(it)).rejects.toThrow(ZipSlipError);
+  });
+
+  it("rejects path outside staging prefix (e.g. other/foo)", async () => {
+    const blob = await makeTarball([
+      { name: "other/foo.txt", data: new Uint8Array([1, 2, 3]) },
+    ]);
+    const it = new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX });
+    await expect(collect(it)).rejects.toThrow(/outside staging prefix/);
+  });
+
+  it("rejects symbolicLink entry (header type-byte patched to '2')", async () => {
+    const blob = await makeAdversarialTarball([
+      { name: "staging/evil", data: new Uint8Array(0), typeByte: "2" },
+    ]);
+    const it = new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX });
+    await expect(collect(it)).rejects.toThrow(/Symbolic-link/);
+  });
+
+  it("rejects hardLink entry (header type-byte patched to '1')", async () => {
+    const blob = await makeAdversarialTarball([
+      { name: "staging/evil", data: new Uint8Array(0), typeByte: "1" },
+    ]);
+    const it = new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX });
+    await expect(collect(it)).rejects.toThrow(/Hard-link/);
+  });
+
+  it("silently skips directory entries (type '5')", async () => {
+    // createTar emits type '5' (directory) for entries with undefined data.
+    const blob = await makeTarball([
+      { name: "staging/dir" }, // → directory
+      { name: "staging/dir/file.txt", data: new TextEncoder().encode("X") },
+    ]);
+    const items = await collect(
+      new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX }),
+    );
+    expect(items.map((i) => i.path)).toEqual(["staging/dir/file.txt"]);
+  });
+
+  it("handles an empty tarball (zero entries)", async () => {
+    const blob = await makeTarball([]);
+    const items = await collect(
+      new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX }),
+    );
+    expect(items).toEqual([]);
+  });
+
+  it("yields a zero-byte Uint8Array for an empty-data file entry", async () => {
+    // nanotar.parseTar sets `data: undefined` for size===0 entries — the
+    // `?? new Uint8Array(0)` fallback in TarExtractor ensures the yielded
+    // content is always a Uint8Array (never undefined).
+    const blob = await makeTarball([
+      { name: "staging/empty.txt", data: new Uint8Array(0) },
+    ]);
+    const items = await collect(
+      new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX }),
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].path).toBe("staging/empty.txt");
+    expect(items[0].content).toBeInstanceOf(Uint8Array);
+    expect(items[0].content.byteLength).toBe(0);
+  });
+
+  it("preserves entry order (not alphabetised)", async () => {
+    const blob = await makeTarball([
+      { name: "staging/03.txt", data: new TextEncoder().encode("3") },
+      { name: "staging/01.txt", data: new TextEncoder().encode("1") },
+      { name: "staging/02.txt", data: new TextEncoder().encode("2") },
+    ]);
+    const items = await collect(
+      new TarExtractor().extract(blob, { stagingDirPrefix: PREFIX }),
+    );
+    expect(items.map((i) => i.path)).toEqual([
+      "staging/03.txt",
+      "staging/01.txt",
+      "staging/02.txt",
+    ]);
+  });
+
+  it("requires stagingDirPrefix option", () => {
+    expect(() =>
+      new TarExtractor().extract(
+        new ArrayBuffer(0),
+        {} as unknown as {
+          stagingDirPrefix: string;
+        },
+      ),
+    ).toThrow(/stagingDirPrefix is required/);
+    expect(() =>
+      new TarExtractor().extract(
+        new ArrayBuffer(0),
+        null as unknown as { stagingDirPrefix: string },
+      ),
+    ).toThrow(/stagingDirPrefix is required/);
+  });
+
+  it("first violation aborts iteration (later entries never yielded)", async () => {
+    const blob = await makeTarball([
+      { name: "other/forbidden", data: new TextEncoder().encode("F") },
+      { name: "staging/ok.txt", data: new TextEncoder().encode("OK") },
+    ]);
+    const items: ExtractedTarFile[] = [];
+    await expect(
+      (async () => {
+        for await (const e of new TarExtractor().extract(blob, {
+          stagingDirPrefix: PREFIX,
+        })) {
+          items.push(e);
+        }
+      })(),
+    ).rejects.toThrow(ZipSlipError);
+    expect(items).toEqual([]); // no yield happened before the throw
+  });
+
+  it("runs finally cleanup on early caller-abort (iterator.return())", async () => {
+    const blob = await makeTarball([
+      { name: "staging/a.txt", data: new TextEncoder().encode("A") },
+      { name: "staging/b.txt", data: new TextEncoder().encode("B") },
+      { name: "staging/c.txt", data: new TextEncoder().encode("C") },
+    ]);
+    const iter = new TarExtractor()
+      .extract(blob, { stagingDirPrefix: PREFIX })
+      [Symbol.asyncIterator]() as AsyncIterableIterator<ExtractedTarFile>;
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    expect((first.value as ExtractedTarFile).path).toBe("staging/a.txt");
+    // Caller bails out — generator's finally block fires (parsed.length = 0).
+    const closed = await iter.return!(undefined);
+    expect(closed.done).toBe(true);
+    // Subsequent next() returns done.
+    const after = await iter.next();
+    expect(after.done).toBe(true);
+  });
+
+  it("propagates nanotar parse failure as a regular Error (not ZipSlipError)", async () => {
+    // Garbage bytes — not a valid gzip stream.
+    const garbage = new Uint8Array([0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa]);
+    const it = new TarExtractor().extract(garbage, {
+      stagingDirPrefix: PREFIX,
+    });
+    await expect(collect(it)).rejects.toThrow();
+    // The thrown error should NOT be a ZipSlipError (parse errors are
+    // structurally different from access-control violations).
+    await expect(collect(it)).rejects.not.toBeInstanceOf(ZipSlipError);
+  });
+});


### PR DESCRIPTION
## Summary

`TarExtractor` — async-iterable tarball parser with zip-slip protection for the Obsidian plugin runtime. Consumes the gzipped tarball returned by `GitHubRestClient.pullTarball()` (RFC 0a0791c1 B.1) and yields `{ path, content }` per entry with four security checks applied first.

## Security (Vision Lock #7 / Security #5)

Per-entry rejection raises `ZipSlipError` on the consumer's `for await` (no silent skip):

1. **Absolute paths** — POSIX leading `/`, leading `\`, `C:/...`, `C:\...`.
2. **Parent-dir traversal** — any path segment equal to `..` after normalisation.
3. **Symbolic links** — `entry.type === "symbolicLink"`.
4. **Hard links** — `entry.type === "hardLink"`.
5. **Staging-prefix gate** — `normalized.startsWith(opts.stagingDirPrefix)` (primary defense — nanotar's parser sanitises `..`/`/` upstream, so this is where `/etc/passwd → etc/passwd` gets rejected).

Link checks fire BEFORE path checks because a symlink with an otherwise benign name is still dangerous.

## Empirical caveat — nanotar 0.3.0 NOT streaming

`parseTarGzip(arrayBuffer)` is `Promise<ParsedTarFileItem[]>` — the entire tarball is decompressed and materialised in memory before iteration begins. Memory bound is `O(tarball.size)`, NOT `O(entry.size)`.

The `AsyncIterable` API is preserved for the iterate-then-discard yield pattern: after each entry is yielded, the parser releases its slot in the internal `parsed[]` array so the caller-consumed `Uint8Array` becomes GC-eligible. A `finally` block in the generator runs `parsed.length = 0` on early caller-abort (verified by test).

Tarball-size guard belongs upstream — `GitHubRestClient.pullTarball` already enforces `maxTarballBytes` (default 50 MB) before parse.

The original AC §"Streaming verified — no full-blob retention" is reinterpreted accordingly: the iterator does not retain `parsed[]` references after iteration completes. The initial full-buffer allocation cannot be eliminated without a nanotar upstream change. Documented in JSDoc.

## Tests (37 unit, 100% line/branch/function coverage)

- `normalizePath`: 6 cases (backslash, double-slash, `./`, `/`, identity).
- `validateEntry` synthetic (zip-slip unit): 16 cases (each check + ordering invariant + error metadata).
- `TarExtractor.extract` end-to-end via **real nanotar** `createTar` + native `CompressionStream` (per ~/dotfiles/.claude/rules/test-fixture-realism.md): 15 cases including:
  - valid `staging/a.txt` + `staging/sub/b.txt` round-trip
  - `/etc/passwd` rejected (parser sanitises → prefix gate fires)
  - `../foo` rejected (same path)
  - `other/foo.txt` rejected by prefix gate directly
  - symlink rejected via header-type-byte patching (`createTar` only emits files/dirs)
  - hardlink rejected likewise
  - directory entries silently skipped
  - empty tarball
  - empty-data file (zero-byte `Uint8Array` content)
  - order preservation
  - first-violation aborts iteration
  - early caller-abort runs `finally` cleanup
  - nanotar parse failure → regular `Error`, NOT `ZipSlipError`

`@jest-environment node` docblock on the test file — `jest-environment-jsdom` doesn't expose Web Streams / CompressionStream / DecompressionStream, and `TarExtractor` is DOM-free.

## Test plan

- [x] `npx jest tests/unit/TarExtractor.test.ts` — 37/37 pass
- [x] Coverage: 100% statements / 100% branches / 100% functions / 100% lines on `TarExtractor.ts`
- [x] `npm run check:types` — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings outside touched files)
- [x] `prettier --check` — clean
- [x] BDD + archgate (pre-commit) — pass
- [ ] CI: 14 required checks green
- [ ] code-reviewer agent verdict
- [ ] advisor() round-2 after fixes
- [ ] Manual merge (no auto-merge — security-critical, per `packages/obsidian-plugin/CLAUDE.md` discipline)

Related: RFC 0a0791c1 Phase B.2
Task: 5316cdce-b6d7-497e-81b2-8b1acfb9fad5
Prior: PR #3305 (B.0 nanotar pin), PR #3307 (B.1 GitHubRestClient)