### PR TITLE
feat(plugin): AssetSpaceManager (RFC 0a0791c1 B.3)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -1,0 +1,404 @@
+import type { App, TFile } from "obsidian";
+import type { INotificationService } from "exocortex";
+import { GitHubRestClient } from "./GitHubRestClient";
+
+/**
+ * Class UID of `exo__AssetSpace` (TBox root). Used to discriminate AssetSpace
+ * ABox instances from other assets when scanning the vault. Hardcoded by RFC
+ * 0a0791c1 (UID frozen by RFC v2 `2a98f345`, implemented 2026-05-17).
+ */
+export const ASSET_SPACE_CLASS_UID = "73bd00e4-ccc0-4f3f-b20d-c4388c4588fb";
+
+/**
+ * Resolved AssetSpace metadata extracted from vault frontmatter.
+ */
+export interface AssetSpaceInfo {
+  uid: string;
+  /** Repo URL — value of `exo__AssetSpace_git`. */
+  git: string;
+  /** Short name — value of `exo__AssetSpace_namespace`. */
+  namespace: string;
+  /**
+   * Vault-relative folder path where AssetSpace files live, e.g.
+   * `"assetspaces/ems"`. Derived from the path of the AssetSpace ABox
+   * asset file (its parent directory).
+   */
+  folderName: string;
+  /** Last-sync SHA — value of `exo__AssetSpace_lastPulledSha`, if recorded. */
+  lastPulledSha?: string;
+}
+
+export interface AssetSpaceManagerOptions {
+  app: App;
+  client: GitHubRestClient;
+  /**
+   * User-notification surface. Required — push outcomes (success / no-op)
+   * surface through `info()`. Inject `ObsidianNotificationService` in
+   * production wiring; tests pass a fake to capture calls.
+   */
+  notifications: INotificationService;
+  /** Git branch to push to. Default: `"main"`. */
+  branch?: string;
+}
+
+/**
+ * Operational manager for vault-cloned AssetSpaces (RFC 0a0791c1 Phase B.3).
+ *
+ * **v3 (backward-compat scope) — only push + lookup are operational.**
+ * Pull / destroy / restore methods are kept on the surface for Phase C+D
+ * stubs but throw `Phase C+D not implemented` so callers fail loudly rather
+ * than silently no-op.
+ *
+ * ## Responsibilities
+ *
+ * 1. **Dirty-file tracking** — a plugin-managed `Set<vaultPath>` updated by
+ *    the caller from a `vault.on("modify")` handler via {@link markDirty}.
+ *    The manager itself does NOT subscribe to vault events (lifecycle is
+ *    the plugin's concern). Single Set across all AssetSpaces; filtering
+ *    by `folderName` happens at push time.
+ * 2. **Push** — batch read every dirty file inside the AssetSpace's
+ *    `folderName/` prefix, strip that prefix to obtain repo-relative
+ *    paths, then call `GitHubRestClient.createCommit` (a 4-call REST
+ *    chain). Update `exo__AssetSpace_lastPulledSha` post-commit.
+ * 3. **Lookup** — given a folder name, return the AssetSpace UID that
+ *    owns that folder (used by future UI surfaces to map open file →
+ *    AssetSpace context).
+ *
+ * ## v3 Decisions (documented for handoff)
+ *
+ * - **lastPulledSha after push**: semantically `lastPulledSha` is "last
+ *   pull SHA"; we also write it after push because pushing advances the
+ *   local notion of "what remote contains". This is intentional drift
+ *   from the property's literal name; renaming → see Phase D backlog.
+ * - **Dirty Set lost on reload**: dirty state lives in memory only — closing
+ *   Obsidian forgets which files are unpushed. Acceptable for v3 (manual
+ *   push command, user-triggered). Future: persist in plugin `data.json`
+ *   or compute from a real filesystem mtime / git working-tree diff.
+ * - **Concurrent push race**: in-flight pushes are deduped via a
+ *   `Map<asUid, Promise<string>>` — a second `pushAssetSpace(asUid)`
+ *   while the first is still running reuses the same Promise. No
+ *   cross-AssetSpace lock; simultaneous push of `ems` and `kpc` is fine.
+ * - **Multi-vault (Vision Lock #11)**: this manager works on the active
+ *   vault only. The plugin instantiates one manager per `App`. Pushing
+ *   from one vault won't sync to the other — sibling vault must pull
+ *   the same submodule commit through the standard 4-step chain.
+ */
+export class AssetSpaceManager {
+  private readonly app: App;
+  private readonly client: GitHubRestClient;
+  private readonly notifications: INotificationService;
+  private readonly branch: string;
+
+  /**
+   * Vault-relative paths of files modified since the last push. Plugin
+   * populates via `markDirty` from a `vault.on("modify")` listener;
+   * `pushAssetSpace` drains the subset matching the target AssetSpace's
+   * `folderName/` prefix.
+   */
+  private readonly dirty = new Set<string>();
+
+  /**
+   * In-flight push dedup. Concurrent invocations for the same AssetSpace
+   * UID return the same Promise so we don't fire two REST 4-call chains
+   * over identical (and potentially racing) dirty snapshots.
+   */
+  private readonly inFlight = new Map<string, Promise<string | null>>();
+
+  constructor(opts: AssetSpaceManagerOptions) {
+    if (!opts || !opts.app) {
+      throw new Error("AssetSpaceManager: app is required");
+    }
+    if (!opts.client) {
+      throw new Error("AssetSpaceManager: client is required");
+    }
+    if (!opts.notifications) {
+      throw new Error("AssetSpaceManager: notifications is required");
+    }
+    this.app = opts.app;
+    this.client = opts.client;
+    this.notifications = opts.notifications;
+    this.branch = opts.branch ?? "main";
+  }
+
+  // ─────────────────────────── public — operational ───────────────────────────
+
+  /**
+   * Mark a vault path as dirty (modified since last push). Idempotent:
+   * adding the same path twice has no effect. Path stays dirty until
+   * `pushAssetSpace` succeeds for the AssetSpace owning that path.
+   *
+   * Intended caller: plugin's `vault.on("modify")` handler, e.g.
+   *   `this.app.vault.on("modify", (file) => { if (file instanceof TFile)
+   *      assetSpaceManager.markDirty(file.path); })`
+   */
+  public markDirty(vaultPath: string): void {
+    if (typeof vaultPath !== "string" || vaultPath.length === 0) return;
+    this.dirty.add(vaultPath);
+  }
+
+  /** Test/debug helper — current dirty-set snapshot. */
+  public getDirtySnapshot(): ReadonlySet<string> {
+    return new Set(this.dirty);
+  }
+
+  /**
+   * Folder-name → AssetSpace UID lookup. Returns `null` if no AssetSpace
+   * ABox asset owns this folder.
+   *
+   * The scan resolves AssetSpace assets by `exo__Instance_class` containing
+   * the AssetSpace class UID. Folder ownership is derived from the parent
+   * directory of the ABox asset's path — e.g. an asset at
+   * `assetspaces/ems/f0f674da-....md` owns folder `"assetspaces/ems"`.
+   */
+  public lookupAssetSpaceForPath(folderName: string): string | null {
+    if (typeof folderName !== "string" || folderName.length === 0) {
+      return null;
+    }
+    const normalized = stripTrailingSlash(folderName);
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const fm = this.readFrontmatter(file);
+      if (!fm) continue;
+      if (!isAssetSpaceFrontmatter(fm)) continue;
+      const parent = parentFolder(file.path);
+      if (parent === normalized) {
+        const uid = fm["exo__Asset_uid"];
+        if (typeof uid === "string" && uid.length > 0) return uid;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Push all dirty files inside an AssetSpace's folder to the AssetSpace's
+   * remote in a single commit.
+   *
+   * Steps (4 REST calls — see `GitHubRestClient.createCommit`):
+   *   1. Resolve `AssetSpaceInfo` from vault frontmatter (UID, git, namespace, folder)
+   *   2. Validate repo URL via the GitHub allowlist
+   *   3. Pre-flight rate-limit gate (≥14 remaining = 4 push calls + 10 buffer)
+   *   4. Collect dirty files in `folderName/` → repo-relative `Map<path,content>`
+   *   5. `createCommit(owner, repo, branch, files, message)` → commit SHA
+   *   6. Clear pushed paths from dirty set; write `exo__AssetSpace_lastPulledSha`
+   *
+   * Returns the commit SHA on success, or `null` if there is nothing to
+   * push (no dirty files matched). Throws on validation / network /
+   * lookup failures.
+   *
+   * Concurrent invocations for the same `asUid` reuse the in-flight Promise.
+   */
+  public pushAssetSpace(asUid: string): Promise<string | null> {
+    if (typeof asUid !== "string" || asUid.length === 0) {
+      // Reject via Promise.reject so the method stays non-async and
+      // concurrent callers receive the literally-same Promise (===).
+      return Promise.reject(new Error("pushAssetSpace: asUid is required"));
+    }
+    const existing = this.inFlight.get(asUid);
+    if (existing) return existing;
+    const promise = this.pushAssetSpaceInner(asUid).finally(() => {
+      this.inFlight.delete(asUid);
+    });
+    this.inFlight.set(asUid, promise);
+    return promise;
+  }
+
+  // ─────────────────────────── public — stubs (Phase C+D) ─────────────────────
+
+  /** STUB — pull live-load deferred to Phase C+D per RFC 0a0791c1 §Scope. */
+  public async pullAssetSpace(_asUid: string, _stagingDir: string): Promise<void> {
+    throw new Error(
+      "AssetSpaceManager.pullAssetSpace: Phase C+D not implemented (v3 scope = push + lookup only)",
+    );
+  }
+
+  /** STUB — destroy deferred to Phase C+D. */
+  public async destroyAssetSpace(_asUid: string): Promise<void> {
+    throw new Error(
+      "AssetSpaceManager.destroyAssetSpace: Phase C+D not implemented (v3 scope = push + lookup only)",
+    );
+  }
+
+  /** STUB — restore-from-cache deferred to Phase C+D. */
+  public async restoreFromCache(_asUid: string): Promise<boolean> {
+    throw new Error(
+      "AssetSpaceManager.restoreFromCache: Phase C+D not implemented (v3 scope = push + lookup only)",
+    );
+  }
+
+  // ─────────────────────────── internal ───────────────────────────
+
+  private async pushAssetSpaceInner(asUid: string): Promise<string | null> {
+    const info = this.lookupAssetSpaceInfo(asUid);
+    if (!info) {
+      throw new Error(
+        `pushAssetSpace: AssetSpace ${asUid} not found in vault TBox`,
+      );
+    }
+
+    // Allowlist validation — throws on path-traversal / non-github / etc.
+    GitHubRestClient.validateRepoURL(info.git);
+    const { owner, repo } = parseGitHubURL(info.git);
+
+    // Pre-flight rate-limit gate — createCommit makes 4 REST calls.
+    await this.client.ensureRateLimit(4);
+
+    const dirtyForAS = this.collectDirtyForAssetSpace(info);
+    if (dirtyForAS.length === 0) {
+      this.notifications.info(
+        `AssetSpace ${info.namespace}: no dirty files to push`,
+      );
+      return null;
+    }
+
+    const files = new Map<string, string>();
+    for (const vaultPath of dirtyForAS) {
+      const content = await this.app.vault.adapter.read(vaultPath);
+      const repoPath = stripFolderPrefix(vaultPath, info.folderName);
+      files.set(repoPath, content);
+    }
+
+    const message = `chore(assetspace): push ${files.size} dirty file(s) via plugin push`;
+    const sha = await this.client.createCommit(
+      owner,
+      repo,
+      this.branch,
+      files,
+      message,
+    );
+
+    // Commit succeeded — clear pushed paths from dirty set, persist sha.
+    for (const vaultPath of dirtyForAS) this.dirty.delete(vaultPath);
+    await this.updateLastPulledSha(asUid, sha);
+
+    this.notifications.success(
+      `AssetSpace ${info.namespace}: pushed ${files.size} file(s) → ${sha.slice(0, 7)}`,
+    );
+    return sha;
+  }
+
+  /**
+   * Public for testability + future use by Cmd+P / settings UI surfaces.
+   * Scans the entire vault — not the assumed `assetspaces/<ns>/` folder —
+   * so a folder convention violation doesn't silently miss the asset.
+   */
+  public lookupAssetSpaceInfo(asUid: string): AssetSpaceInfo | null {
+    if (typeof asUid !== "string" || asUid.length === 0) return null;
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const fm = this.readFrontmatter(file);
+      if (!fm) continue;
+      if (fm["exo__Asset_uid"] !== asUid) continue;
+      if (!isAssetSpaceFrontmatter(fm)) continue;
+      const git = typeof fm["exo__AssetSpace_git"] === "string"
+        ? (fm["exo__AssetSpace_git"] as string)
+        : "";
+      const namespace = typeof fm["exo__AssetSpace_namespace"] === "string"
+        ? (fm["exo__AssetSpace_namespace"] as string)
+        : "";
+      if (!git || !namespace) return null;
+      const folderName = parentFolder(file.path);
+      const lastPulledSha = typeof fm["exo__AssetSpace_lastPulledSha"] === "string"
+        ? (fm["exo__AssetSpace_lastPulledSha"] as string)
+        : undefined;
+      return { uid: asUid, git, namespace, folderName, lastPulledSha };
+    }
+    return null;
+  }
+
+  private collectDirtyForAssetSpace(info: AssetSpaceInfo): string[] {
+    const prefix = info.folderName.endsWith("/")
+      ? info.folderName
+      : info.folderName + "/";
+    const out: string[] = [];
+    for (const path of this.dirty) {
+      if (path.startsWith(prefix)) out.push(path);
+    }
+    return out;
+  }
+
+  private async updateLastPulledSha(asUid: string, sha: string): Promise<void> {
+    const file = this.findAssetSpaceFile(asUid);
+    if (!file) {
+      throw new Error(
+        `updateLastPulledSha: AssetSpace ${asUid} file vanished mid-push`,
+      );
+    }
+    await this.app.fileManager.processFrontMatter(file, (fm) => {
+      fm["exo__AssetSpace_lastPulledSha"] = sha;
+      fm["exo__Asset_updatedAt"] = nowIsoSeconds();
+    });
+  }
+
+  private findAssetSpaceFile(asUid: string): TFile | null {
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const fm = this.readFrontmatter(file);
+      if (!fm) continue;
+      if (fm["exo__Asset_uid"] === asUid && isAssetSpaceFrontmatter(fm)) {
+        return file;
+      }
+    }
+    return null;
+  }
+
+  private readFrontmatter(file: TFile): Record<string, unknown> | null {
+    const cache = this.app.metadataCache.getFileCache(file);
+    if (!cache || !cache.frontmatter) return null;
+    return cache.frontmatter as Record<string, unknown>;
+  }
+}
+
+// ────────────────────────── module-private helpers ──────────────────────────
+
+/**
+ * Predicate — does this frontmatter declare `exo__Instance_class` containing
+ * the AssetSpace class UID? Handles both wikilink-string and array-of-string
+ * shapes that Obsidian's parser may produce.
+ */
+function isAssetSpaceFrontmatter(fm: Record<string, unknown>): boolean {
+  const classes = fm["exo__Instance_class"];
+  const candidates: unknown[] = Array.isArray(classes) ? classes : [classes];
+  for (const c of candidates) {
+    if (typeof c !== "string") continue;
+    if (c.includes(ASSET_SPACE_CLASS_UID)) return true;
+  }
+  return false;
+}
+
+function parentFolder(filePath: string): string {
+  const idx = filePath.lastIndexOf("/");
+  return idx < 0 ? "" : filePath.slice(0, idx);
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.endsWith("/") ? s.slice(0, -1) : s;
+}
+
+function stripFolderPrefix(vaultPath: string, folderName: string): string {
+  const prefix = folderName.endsWith("/") ? folderName : folderName + "/";
+  if (!vaultPath.startsWith(prefix)) {
+    throw new Error(
+      `stripFolderPrefix: path "${vaultPath}" not under folder "${folderName}"`,
+    );
+  }
+  return vaultPath.slice(prefix.length);
+}
+
+/**
+ * Parse a vault-declared GitHub repo URL into `owner/repo` segments. The URL
+ * has already been validated by `GitHubRestClient.validateRepoURL`, so this
+ * function only does the structural split. Throws if shape unexpectedly
+ * differs (defensive — should be unreachable post-validation).
+ *
+ * Exported for unit test only.
+ */
+export function parseGitHubURL(url: string): { owner: string; repo: string } {
+  const m = url.match(
+    /^https:\/\/github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+?)(?:\.git)?$/,
+  );
+  if (!m) {
+    throw new Error(`parseGitHubURL: invalid URL shape: ${url}`);
+  }
+  return { owner: m[1], repo: m[2] };
+}
+
+function nowIsoSeconds(): string {
+  return new Date().toISOString().slice(0, 19);
+}

--- a/packages/obsidian-plugin/tests/unit/AssetSpaceManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AssetSpaceManager.test.ts
@@ -1,0 +1,633 @@
+import type { App, TFile } from "obsidian";
+import type { INotificationService } from "exocortex";
+
+import {
+  AssetSpaceManager,
+  ASSET_SPACE_CLASS_UID,
+  parseGitHubURL,
+} from "../../src/infrastructure/adapters/AssetSpaceManager";
+
+// ─── Fake GitHubRestClient ──────────────────────────────────────────────
+// Per advisor — inject via constructor, NOT jest.mock module-level. This
+// keeps full control over call-arg verification.
+
+interface FakeGitHubClient {
+  ensureRateLimit: jest.Mock<Promise<void>, [number]>;
+  createCommit: jest.Mock<Promise<string>, [string, string, string, Map<string, string>, string]>;
+}
+
+function makeFakeClient(overrides: Partial<FakeGitHubClient> = {}): FakeGitHubClient {
+  return {
+    ensureRateLimit: jest.fn().mockResolvedValue(undefined),
+    createCommit: jest.fn().mockResolvedValue("a".repeat(40)),
+    ...overrides,
+  };
+}
+
+// ─── Fake INotificationService ──────────────────────────────────────────
+
+interface FakeNotifier extends INotificationService {
+  infoCalls: string[];
+  successCalls: string[];
+  errorCalls: string[];
+  warnCalls: string[];
+}
+
+function makeFakeNotifier(): FakeNotifier {
+  const infoCalls: string[] = [];
+  const successCalls: string[] = [];
+  const errorCalls: string[] = [];
+  const warnCalls: string[] = [];
+  return {
+    infoCalls,
+    successCalls,
+    errorCalls,
+    warnCalls,
+    info: (m: string) => {
+      infoCalls.push(m);
+    },
+    success: (m: string) => {
+      successCalls.push(m);
+    },
+    error: (m: string) => {
+      errorCalls.push(m);
+    },
+    warn: (m: string) => {
+      warnCalls.push(m);
+    },
+    confirm: async () => true,
+  };
+}
+
+// ─── Fake App / vault / metadataCache / fileManager ─────────────────────
+// Per test-fixture-realism — mirror real Obsidian semantics:
+//   - getFileCache returns null when the file isn't seeded
+//   - vault.adapter.read rejects unknown paths
+//   - processFrontMatter mutates the seeded frontmatter and we observe
+
+interface SeedFile {
+  path: string;
+  frontmatter: Record<string, unknown>;
+  content?: string;
+}
+
+interface FakeApp {
+  app: App;
+  files: Map<string, SeedFile>;
+  processedFrontmatter: Map<string, Record<string, unknown>>;
+}
+
+function makeFakeApp(seeds: SeedFile[]): FakeApp {
+  const files = new Map<string, SeedFile>();
+  const processedFrontmatter = new Map<string, Record<string, unknown>>();
+  for (const s of seeds) files.set(s.path, s);
+
+  const tfileFor = (path: string): TFile => {
+    return { path } as unknown as TFile;
+  };
+
+  const app = {
+    vault: {
+      getMarkdownFiles: () => Array.from(files.keys()).map(tfileFor),
+      adapter: {
+        read: async (path: string) => {
+          const f = files.get(path);
+          if (!f) throw new Error(`fake vault.adapter.read: not found: ${path}`);
+          if (typeof f.content !== "string") {
+            throw new Error(`fake vault.adapter.read: no content seeded for ${path}`);
+          }
+          return f.content;
+        },
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const seed = files.get(file.path);
+        if (!seed) return null;
+        return { frontmatter: seed.frontmatter };
+      },
+    },
+    fileManager: {
+      processFrontMatter: async (
+        file: TFile,
+        fn: (fm: Record<string, unknown>) => void,
+      ) => {
+        const seed = files.get(file.path);
+        if (!seed) {
+          throw new Error(`fake processFrontMatter: not found: ${file.path}`);
+        }
+        // Mirror Obsidian: pass a mutable handle. Apply mutations directly
+        // to the seed so subsequent reads observe them.
+        fn(seed.frontmatter);
+        processedFrontmatter.set(file.path, { ...seed.frontmatter });
+      },
+    },
+  } as unknown as App;
+
+  return {
+    app,
+    files,
+    processedFrontmatter,
+  };
+}
+
+// ─── Test helpers ────────────────────────────────────────────────────────
+
+interface Harness {
+  fake: FakeApp;
+  client: FakeGitHubClient;
+  notifier: FakeNotifier;
+  mgr: AssetSpaceManager;
+}
+
+function makeHarness(
+  seeds: SeedFile[],
+  opts: {
+    clientOverrides?: Partial<FakeGitHubClient>;
+    branch?: string;
+  } = {},
+): Harness {
+  const fake = makeFakeApp(seeds);
+  const client = makeFakeClient(opts.clientOverrides);
+  const notifier = makeFakeNotifier();
+  const mgr = new AssetSpaceManager({
+    app: fake.app,
+    client: client as never,
+    notifications: notifier,
+    branch: opts.branch,
+  });
+  return { fake, client, notifier, mgr };
+}
+
+// ─── AssetSpace fixture frontmatter ──────────────────────────────────────
+
+function assetSpaceFrontmatter(opts: {
+  uid: string;
+  git: string;
+  namespace: string;
+  lastPulledSha?: string;
+}): Record<string, unknown> {
+  return {
+    "exo__Asset_uid": opts.uid,
+    "exo__Asset_label": `kitelev/exoas-${opts.namespace}`,
+    "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+    "exo__AssetSpace_git": opts.git,
+    "exo__AssetSpace_namespace": opts.namespace,
+    ...(opts.lastPulledSha
+      ? { "exo__AssetSpace_lastPulledSha": opts.lastPulledSha }
+      : {}),
+  };
+}
+
+const EMS_UID = "f0f674da-a31b-47e1-b0e8-f984b018bf75";
+
+function seedSingleAssetSpace(
+  opts: { withSha?: string } = {},
+): SeedFile[] {
+  return [
+    {
+      path: "assetspaces/ems/f0f674da.md",
+      frontmatter: assetSpaceFrontmatter({
+        uid: EMS_UID,
+        git: "https://github.com/kitelev/exoas-ems",
+        namespace: "ems",
+        lastPulledSha: opts.withSha,
+      }),
+    },
+  ];
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe("AssetSpaceManager", () => {
+  // --- constructor ------------------------------------------------------
+  describe("constructor", () => {
+    it("requires app", () => {
+      expect(
+        () =>
+          new AssetSpaceManager({
+            app: undefined as unknown as App,
+            client: makeFakeClient() as never,
+            notifications: makeFakeNotifier(),
+          }),
+      ).toThrow(/app is required/);
+    });
+
+    it("requires client", () => {
+      const fake = makeFakeApp([]);
+      expect(
+        () =>
+          new AssetSpaceManager({
+            app: fake.app,
+            client: undefined as never,
+            notifications: makeFakeNotifier(),
+          }),
+      ).toThrow(/client is required/);
+    });
+
+    it("requires notifications", () => {
+      const fake = makeFakeApp([]);
+      expect(
+        () =>
+          new AssetSpaceManager({
+            app: fake.app,
+            client: makeFakeClient() as never,
+            notifications: undefined as unknown as INotificationService,
+          }),
+      ).toThrow(/notifications is required/);
+    });
+
+    it("defaults branch to 'main'", async () => {
+      const h = makeHarness([
+        ...seedSingleAssetSpace(),
+        {
+          path: "assetspaces/ems/changed.md",
+          frontmatter: {},
+          content: "x",
+        },
+      ]);
+      h.mgr.markDirty("assetspaces/ems/changed.md");
+      await h.mgr.pushAssetSpace(EMS_UID);
+      expect(h.client.createCommit).toHaveBeenCalledWith(
+        "kitelev",
+        "exoas-ems",
+        "main",
+        expect.any(Map),
+        expect.any(String),
+      );
+    });
+
+    it("accepts custom branch", async () => {
+      const h = makeHarness(
+        [
+          ...seedSingleAssetSpace(),
+          {
+            path: "assetspaces/ems/changed.md",
+            frontmatter: {},
+            content: "x",
+          },
+        ],
+        { branch: "develop" },
+      );
+      h.mgr.markDirty("assetspaces/ems/changed.md");
+      await h.mgr.pushAssetSpace(EMS_UID);
+      expect(h.client.createCommit).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        "develop",
+        expect.any(Map),
+        expect.any(String),
+      );
+    });
+  });
+
+  // --- markDirty --------------------------------------------------------
+  describe("markDirty", () => {
+    it("adds path to dirty set", () => {
+      const h = makeHarness([]);
+      h.mgr.markDirty("foo/bar.md");
+      expect(h.mgr.getDirtySnapshot().has("foo/bar.md")).toBe(true);
+    });
+
+    it("is idempotent — duplicate add stays single entry", () => {
+      const h = makeHarness([]);
+      h.mgr.markDirty("foo.md");
+      h.mgr.markDirty("foo.md");
+      expect(h.mgr.getDirtySnapshot().size).toBe(1);
+    });
+
+    it("ignores empty / non-string paths", () => {
+      const h = makeHarness([]);
+      h.mgr.markDirty("");
+      h.mgr.markDirty(undefined as unknown as string);
+      h.mgr.markDirty(null as unknown as string);
+      expect(h.mgr.getDirtySnapshot().size).toBe(0);
+    });
+  });
+
+  // --- lookupAssetSpaceForPath -----------------------------------------
+  describe("lookupAssetSpaceForPath", () => {
+    it("returns AssetSpace UID for owned folder", () => {
+      const h = makeHarness(seedSingleAssetSpace());
+      expect(h.mgr.lookupAssetSpaceForPath("assetspaces/ems")).toBe(EMS_UID);
+    });
+
+    it("handles trailing slash", () => {
+      const h = makeHarness(seedSingleAssetSpace());
+      expect(h.mgr.lookupAssetSpaceForPath("assetspaces/ems/")).toBe(EMS_UID);
+    });
+
+    it("returns null for unknown folder", () => {
+      const h = makeHarness(seedSingleAssetSpace());
+      expect(h.mgr.lookupAssetSpaceForPath("assetspaces/nonexistent")).toBeNull();
+    });
+
+    it("returns null for empty input", () => {
+      const h = makeHarness(seedSingleAssetSpace());
+      expect(h.mgr.lookupAssetSpaceForPath("")).toBeNull();
+      expect(h.mgr.lookupAssetSpaceForPath(undefined as unknown as string)).toBeNull();
+    });
+
+    it("ignores non-AssetSpace assets at sibling paths", () => {
+      const h = makeHarness([
+        {
+          path: "assetspaces/ems/f0f674da-a31b-47e1-b0e8-f984b018bf75.md",
+          frontmatter: assetSpaceFrontmatter({
+            uid: EMS_UID,
+            git: "https://github.com/kitelev/exoas-ems",
+            namespace: "ems",
+          }),
+        },
+        {
+          path: "assetspaces/ems/some-other-asset.md",
+          // not an AssetSpace — different class
+          frontmatter: {
+            "exo__Asset_uid": "other-uid",
+            "exo__Instance_class": ["[[some-other-class]]"],
+          },
+        },
+      ]);
+      expect(h.mgr.lookupAssetSpaceForPath("assetspaces/ems")).toBe(EMS_UID);
+    });
+  });
+
+  // --- lookupAssetSpaceInfo --------------------------------------------
+  describe("lookupAssetSpaceInfo", () => {
+    it("extracts full info from frontmatter", () => {
+      const h = makeHarness(seedSingleAssetSpace({ withSha: "deadbeef" }));
+      const info = h.mgr.lookupAssetSpaceInfo(EMS_UID);
+      expect(info).toEqual({
+        uid: EMS_UID,
+        git: "https://github.com/kitelev/exoas-ems",
+        namespace: "ems",
+        folderName: "assetspaces/ems",
+        lastPulledSha: "deadbeef",
+      });
+    });
+
+    it("returns null when AssetSpace UID not found", () => {
+      const h = makeHarness(seedSingleAssetSpace());
+      expect(h.mgr.lookupAssetSpaceInfo("nonexistent")).toBeNull();
+    });
+
+    it("returns null when frontmatter missing git URL", () => {
+      const h = makeHarness([
+        {
+          path: "assetspaces/ems/f0f674da.md",
+          frontmatter: {
+            "exo__Asset_uid": EMS_UID,
+            "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+            // no exo__AssetSpace_git
+            "exo__AssetSpace_namespace": "ems",
+          },
+        },
+      ]);
+      expect(h.mgr.lookupAssetSpaceInfo(EMS_UID)).toBeNull();
+    });
+
+    it("returns null when frontmatter missing namespace", () => {
+      const h = makeHarness([
+        {
+          path: "assetspaces/ems/f0f674da.md",
+          frontmatter: {
+            "exo__Asset_uid": EMS_UID,
+            "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+            "exo__AssetSpace_git": "https://github.com/kitelev/exoas-ems",
+            // no exo__AssetSpace_namespace
+          },
+        },
+      ]);
+      expect(h.mgr.lookupAssetSpaceInfo(EMS_UID)).toBeNull();
+    });
+
+    it("returns null for empty input", () => {
+      const h = makeHarness(seedSingleAssetSpace());
+      expect(h.mgr.lookupAssetSpaceInfo("")).toBeNull();
+    });
+  });
+
+  // --- pushAssetSpace --------------------------------------------------
+  describe("pushAssetSpace", () => {
+    it("happy path — collects dirty, strips folder prefix, calls createCommit, updates lastPulledSha", async () => {
+      const h = makeHarness(
+        [
+          {
+            path: "assetspaces/ems/f0f674da.md",
+            frontmatter: assetSpaceFrontmatter({
+              uid: EMS_UID,
+              git: "https://github.com/kitelev/exoas-ems",
+              namespace: "ems",
+            }),
+          },
+          {
+            path: "assetspaces/ems/instance-1.md",
+            frontmatter: { "exo__Asset_uid": "inst-1" },
+            content: "# Instance 1\n",
+          },
+          {
+            path: "assetspaces/ems/nested/instance-2.md",
+            frontmatter: { "exo__Asset_uid": "inst-2" },
+            content: "# Instance 2\n",
+          },
+        ],
+        {
+          clientOverrides: {
+            createCommit: jest
+              .fn()
+              .mockResolvedValue("abc1234567890" + "0".repeat(27)),
+          },
+        },
+      );
+      h.mgr.markDirty("assetspaces/ems/instance-1.md");
+      h.mgr.markDirty("assetspaces/ems/nested/instance-2.md");
+      // Plus a dirty file outside the AS — must NOT be pushed.
+      h.mgr.markDirty("other/area/unrelated.md");
+
+      const sha = await h.mgr.pushAssetSpace(EMS_UID);
+      expect(sha).toBe("abc1234567890" + "0".repeat(27));
+      expect(h.client.ensureRateLimit).toHaveBeenCalledWith(4);
+      expect(h.client.createCommit).toHaveBeenCalledTimes(1);
+      const [owner, repo, branch, files, message] = h.client.createCommit.mock.calls[0];
+      expect(owner).toBe("kitelev");
+      expect(repo).toBe("exoas-ems");
+      expect(branch).toBe("main");
+      expect(files).toBeInstanceOf(Map);
+      // Repo-relative paths — folder prefix stripped
+      expect(Array.from((files as Map<string, string>).keys()).sort()).toEqual([
+        "instance-1.md",
+        "nested/instance-2.md",
+      ]);
+      expect((files as Map<string, string>).get("instance-1.md")).toBe("# Instance 1\n");
+      expect(message).toMatch(/push 2 dirty file/);
+
+      // Pushed paths cleared from dirty set; unrelated path remains
+      expect(h.mgr.getDirtySnapshot().has("assetspaces/ems/instance-1.md")).toBe(false);
+      expect(h.mgr.getDirtySnapshot().has("assetspaces/ems/nested/instance-2.md")).toBe(false);
+      expect(h.mgr.getDirtySnapshot().has("other/area/unrelated.md")).toBe(true);
+
+      // lastPulledSha written via processFrontMatter
+      const updated = h.fake.processedFrontmatter.get("assetspaces/ems/f0f674da.md");
+      expect(updated).toBeDefined();
+      expect(updated!["exo__AssetSpace_lastPulledSha"]).toBe(
+        "abc1234567890" + "0".repeat(27),
+      );
+      expect(typeof updated!["exo__Asset_updatedAt"]).toBe("string");
+
+      // Success notification surfaced
+      expect(h.notifier.successCalls.some((m) => /ems/.test(m) && /abc1234/.test(m))).toBe(true);
+    });
+
+    it("returns null when no dirty files match the AssetSpace folder", async () => {
+      const h = makeHarness(seedSingleAssetSpace());
+      h.mgr.markDirty("other/area/foo.md"); // outside ems
+      const sha = await h.mgr.pushAssetSpace(EMS_UID);
+      expect(sha).toBeNull();
+      expect(h.client.createCommit).not.toHaveBeenCalled();
+      expect(h.notifier.infoCalls.some((m) => /no dirty files/i.test(m))).toBe(true);
+    });
+
+    it("throws when asUid is empty", async () => {
+      const h = makeHarness(seedSingleAssetSpace());
+      await expect(h.mgr.pushAssetSpace("")).rejects.toThrow(/asUid is required/);
+    });
+
+    it("throws when AssetSpace UID not found in vault", async () => {
+      const h = makeHarness([]);
+      h.mgr.markDirty("assetspaces/ems/foo.md");
+      await expect(h.mgr.pushAssetSpace("nonexistent-uid")).rejects.toThrow(
+        /not found in vault/,
+      );
+    });
+
+    it("throws when AssetSpace git URL fails allowlist", async () => {
+      const h = makeHarness([
+        {
+          path: "assetspaces/evil/f0f674da.md",
+          frontmatter: assetSpaceFrontmatter({
+            uid: EMS_UID,
+            git: "https://evil.com/kitelev/exoas-ems", // not github.com
+            namespace: "evil",
+          }),
+        },
+      ]);
+      h.mgr.markDirty("assetspaces/evil/foo.md");
+      await expect(h.mgr.pushAssetSpace(EMS_UID)).rejects.toThrow(/Invalid GitHub repo URL/);
+    });
+
+    it("propagates rate-limit gate failure (does NOT call createCommit)", async () => {
+      const h = makeHarness(seedSingleAssetSpace(), {
+        clientOverrides: {
+          ensureRateLimit: jest
+            .fn()
+            .mockRejectedValue(new Error("Rate limit guard: 3 remaining < 14 needed")),
+        },
+      });
+      h.mgr.markDirty("assetspaces/ems/foo.md");
+      await expect(h.mgr.pushAssetSpace(EMS_UID)).rejects.toThrow(/Rate limit guard/);
+      expect(h.client.createCommit).not.toHaveBeenCalled();
+    });
+
+    it("dedups concurrent pushes for the same AssetSpace UID", async () => {
+      let resolveCommit: (v: string) => void = () => undefined;
+      const commitPromise = new Promise<string>((res) => {
+        resolveCommit = res;
+      });
+      const h = makeHarness(
+        [
+          ...seedSingleAssetSpace(),
+          {
+            path: "assetspaces/ems/dirty.md",
+            frontmatter: { "exo__Asset_uid": "x" },
+            content: "x",
+          },
+        ],
+        {
+          clientOverrides: {
+            createCommit: jest.fn().mockReturnValue(commitPromise),
+          },
+        },
+      );
+      h.mgr.markDirty("assetspaces/ems/dirty.md");
+      const p1 = h.mgr.pushAssetSpace(EMS_UID);
+      const p2 = h.mgr.pushAssetSpace(EMS_UID);
+      // Both should be the SAME promise (in-flight dedup)
+      expect(p1).toBe(p2);
+      resolveCommit("a".repeat(40));
+      await Promise.all([p1, p2]);
+      // createCommit must have been invoked exactly once
+      expect(h.client.createCommit).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows new push after in-flight resolves", async () => {
+      const h = makeHarness([
+        ...seedSingleAssetSpace(),
+        {
+          path: "assetspaces/ems/dirty.md",
+          frontmatter: { "exo__Asset_uid": "x" },
+          content: "x",
+        },
+      ]);
+      h.mgr.markDirty("assetspaces/ems/dirty.md");
+      await h.mgr.pushAssetSpace(EMS_UID);
+
+      // Second push — must NOT be deduped (in-flight cleared post-resolve)
+      h.mgr.markDirty("assetspaces/ems/dirty.md");
+      await h.mgr.pushAssetSpace(EMS_UID);
+      expect(h.client.createCommit).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // --- Phase C+D stubs -------------------------------------------------
+  describe("Phase C+D stubs", () => {
+    it("pullAssetSpace throws 'Phase C+D not implemented'", async () => {
+      const h = makeHarness([]);
+      await expect(h.mgr.pullAssetSpace("x", "staging")).rejects.toThrow(
+        /Phase C\+D not implemented/,
+      );
+    });
+
+    it("destroyAssetSpace throws 'Phase C+D not implemented'", async () => {
+      const h = makeHarness([]);
+      await expect(h.mgr.destroyAssetSpace("x")).rejects.toThrow(
+        /Phase C\+D not implemented/,
+      );
+    });
+
+    it("restoreFromCache throws 'Phase C+D not implemented'", async () => {
+      const h = makeHarness([]);
+      await expect(h.mgr.restoreFromCache("x")).rejects.toThrow(
+        /Phase C\+D not implemented/,
+      );
+    });
+  });
+});
+
+// ─── parseGitHubURL (exported helper) ────────────────────────────────────
+
+describe("parseGitHubURL", () => {
+  it("parses standard github URL", () => {
+    expect(parseGitHubURL("https://github.com/kitelev/exoas-ems")).toEqual({
+      owner: "kitelev",
+      repo: "exoas-ems",
+    });
+  });
+
+  it("strips trailing .git", () => {
+    expect(parseGitHubURL("https://github.com/kitelev/exoas-ems.git")).toEqual({
+      owner: "kitelev",
+      repo: "exoas-ems",
+    });
+  });
+
+  it("supports owner/repo with dashes and underscores", () => {
+    expect(parseGitHubURL("https://github.com/some-org/some_repo.foo")).toEqual({
+      owner: "some-org",
+      repo: "some_repo.foo",
+    });
+  });
+
+  it("throws on malformed URL", () => {
+    expect(() => parseGitHubURL("not-a-url")).toThrow(/invalid URL shape/);
+    expect(() => parseGitHubURL("https://gitlab.com/foo/bar")).toThrow(/invalid URL shape/);
+  });
+});


### PR DESCRIPTION
## Summary

`AssetSpaceManager` class (~390 LOC, 33 tests) — push + lookup operational; pull / destroy / restore stubbed (Phase C+D deferred per RFC 0a0791c1 §Scope split). Closes Phase B.3 of [RFC 0a0791c1](https://github.com/kitelev/exocortex/issues?q=0a0791c1) FocusProfile Phase 4 plugin runtime.

## Methods (Vision Locks #3, #4, #11)

- **`pushAssetSpace(asUid)` — OPERATIONAL.** Pre-flight rate-limit gate (4 REST calls), collect dirty files under the AssetSpace's `folderName/` prefix via `vault.adapter.read`, strip folder prefix to repo-relative paths, `GitHubRestClient.createCommit`, then clear pushed paths from the dirty set and write `exo__AssetSpace_lastPulledSha` (uses A.1 property `b08db57e`). Returns commit SHA or `null` if no dirty files.
- **`lookupAssetSpaceForPath(folderName)` — OPERATIONAL.** Vault scan (`metadataCache.getFileCache` against AssetSpace class UID `73bd00e4-...`) resolving folder → AssetSpace UID. Handles trailing slash; returns `null` for unknown.
- **`lookupAssetSpaceInfo(asUid)` — OPERATIONAL.** Returns `{ uid, git, namespace, folderName, lastPulledSha? }` extracted from frontmatter. Vault-wide scan per advisor (don't assume folder convention).
- **`markDirty(vaultPath)` — OPERATIONAL.** Plugin-managed `Set<vaultPath>` populated by the caller's `vault.on("modify")` handler. Idempotent.
- **`pullAssetSpace` / `destroyAssetSpace` / `restoreFromCache` — STUBS.** Throw `Phase C+D not implemented` so callers fail loud.

## v3 Decisions (documented in JSDoc)

1. **`lastPulledSha` post-push** — semantically tracks "last successful sync"; push advances the local notion of "what remote contains". Drift from literal name accepted; renaming → Phase D backlog.
2. **Dirty set lost on Obsidian reload** — in-memory only. Acceptable for v3 (manual command, user-triggered). Future: persist in `data.json` or compute from filesystem mtime / git working tree.
3. **Concurrent-push race** — deduped via in-flight `Map<asUid, Promise<string|null>>`. Second `pushAssetSpace(asUid)` while first is in flight returns the SAME Promise (`===`). No cross-AssetSpace lock; concurrent `ems` + `kpc` is fine.
4. **Multi-vault scope (Vision Lock #11)** — manager works on active vault only. Sibling vault must pull the same submodule commit through the standard 4-step chain.
5. **Notification surface** — `INotificationService` (DI) instead of direct `new Notice()` per the `no-restricted-syntax` lint rule.

## Tests (33 cases, 91.5% stmt / 82.2% branch / 100% func / 96.5% line coverage on `AssetSpaceManager.ts`)

- Constructor guards (app / client / notifications required; branch default + override)
- `markDirty` idempotency + empty/non-string guards
- `lookupAssetSpaceForPath`: hit / trailing-slash / unknown / empty / sibling non-AssetSpace ignored
- `lookupAssetSpaceInfo`: full extraction with sha / unknown UID / missing git / missing namespace / empty input
- `pushAssetSpace`:
  - **Happy path** — folder-prefix strip verified (`assetspaces/ems/foo.md` → repo-relative `foo.md`); `createCommit` called with correct owner/repo/branch/files; `lastPulledSha` written via `processFrontMatter`; dirty entries inside folder cleared, unrelated kept; success Notice surfaced.
  - **No dirty files** → `null` + info Notice; `createCommit` NOT called.
  - **Empty UID** → throws.
  - **Unknown AssetSpace UID** → throws.
  - **Bad git URL** (non-`github.com`) → allowlist throws (`GitHubRestClient.validateRepoURL`).
  - **Rate-limit gate failure** → propagates; `createCommit` NOT called.
  - **Concurrent dedup** — `p1 === p2` AND `createCommit` invoked exactly once.
  - **Post-resolve** — second push after the first resolves invokes `createCommit` again (in-flight Map cleared).
- Phase C+D stubs all throw `Phase C+D not implemented`.
- `parseGitHubURL` helper: standard / `.git` suffix / dashes+underscores / malformed → throws.

Per `test-fixture-realism.md`: fake `App` mirrors real Obsidian semantics — `getFileCache` returns `null` for unseeded files, `vault.adapter.read` rejects unknown paths, `processFrontMatter` mutates the seeded frontmatter for observation. `GitHubRestClient` injected via constructor (no `jest.mock` module-level), so `createCommit.mock.calls` provides exact call-arg verification.

## Test plan

- [x] `npx jest AssetSpaceManager.test.ts` — 33/33 PASS
- [x] Regression — `GitHubRestClient.test.ts` (95 tests) + `TarExtractor.test.ts` (existing) PASS unchanged
- [x] `npm run check:types` — clean
- [x] `npm run lint` — clean (only pre-existing warnings in other files)
- [x] Pre-commit Archgate ADR checks — 13/13 pass
- [ ] CI green
- [ ] code-reviewer agent verdict (security-adjacent code per auto-merge discipline)

## Related

- RFC `0a0791c1-3808-42fd-bc7f-bdd127ac7b24` Phase B.3
- Depends on: B.1 `GitHubRestClient` (#3307), B.2 `TarExtractor` (#3310), A.1 `exo__AssetSpace_lastPulledSha`