### PR TITLE
feat(plugin): FocusProfileSwitchManager + TS-floor + journal (RFC 0a0791c1 B.4)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -1,0 +1,334 @@
+import type { App } from "obsidian";
+
+import { PluginLockManager } from "./PluginLockManager";
+
+/**
+ * FocusProfileSwitchManager — coordinates profile switching:
+ *   1. acquire persistent lock (B.6)
+ *   2. write journal entry «starting»
+ *   3. compute effective ontology set (с TS-floor per Vision Lock #17)
+ *   4. persist `settings.activeProfileUid` BEFORE filesystem changes (Architect #2)
+ *   5. trigger RDF re-index with new filter
+ *   6. clear in-progress flag
+ *   7. write journal entry «completed»
+ *
+ * v3 backward-compat scope: NO destroy/pull (Phase C+D deferred). Only RDF
+ * graph filter update via re-index. Filesystem state untouched.
+ *
+ * Recovery: at plugin load, call `recoverIfNeeded()`. If last journal entry
+ * shows incomplete switch + `_switchInProgress=true`, idempotently re-trigger
+ * the re-index (no destructive rollback needed in v3 — re-index is pure).
+ *
+ * Per RFC 0a0791c1 §B.4 + Vision Lock #17 + Architect #2.
+ */
+
+export const FOCUS_PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
+
+/**
+ * TS-floor (Vision Lock #17): ontology URIs that are ALWAYS in the effective
+ * set, regardless of profile config. Hardcoded — never destroyable.
+ * Prevents plugin self-brick если user accidentally removes $exo from a profile.
+ */
+export const TS_FLOOR_ONTOLOGY_URIS: ReadonlySet<string> = new Set([
+  "https://exocortex.my/ontology/exo",
+  "https://exocortex.my/ontology/exocmd",
+]);
+
+/**
+ * Pattern для detecting "shared identities"-style ontologies. Ontology URIs
+ * containing `shared-identities` или `shared-` prefix are auto-included
+ * in the floor (R15 mitigation — `discoverSharedOntologies`).
+ */
+export const TS_FLOOR_SHARED_PATTERN = /(?:^|\/)shared-/;
+
+export interface ProfileResolution {
+  /** Profile UID. */
+  uid: string;
+  /** Directly declared `_includes` (ontology URIs). */
+  includes: string[];
+  /** Parent profile UID (resolves transitive). May be null/undefined. */
+  extends?: string | null;
+  /** Directly declared `_alwaysOnOverlay` (ontology URIs). */
+  alwaysOnOverlay: string[];
+  /** Display label (used in user-facing Notice). */
+  label?: string;
+}
+
+/**
+ * Resolves a FocusProfile asset by UID. Production implementation reads via
+ * Obsidian metadataCache + vault.adapter; tests provide an in-memory map.
+ */
+export interface IProfileResolver {
+  resolve(profileUid: string): Promise<ProfileResolution | null>;
+  /**
+   * Optional discovery hook — returns ALL ontology URIs matching the shared
+   * identities pattern. Production scans vault triples; tests can return [].
+   */
+  discoverSharedOntologies(): Promise<string[]>;
+}
+
+export interface IRdfIndexer {
+  /**
+   * Re-index the RDF graph filtering by the given effective ontology set.
+   * Implementations (NoteToRDFConverter) skip files whose AssetSpace's
+   * ontology is not in `effectiveOntologies`.
+   */
+  refresh(effectiveOntologies: ReadonlySet<string>): Promise<void>;
+}
+
+export interface SwitchSettings {
+  activeProfileUid: string | null;
+  _switchInProgress: boolean;
+}
+
+export interface ISettingsStore {
+  load(): Promise<SwitchSettings>;
+  save(s: SwitchSettings): Promise<void>;
+}
+
+export interface SwitchJournalEntry {
+  phase: "starting" | "completed" | "failed";
+  targetUid: string;
+  ts: string; // ISO
+  elapsedMs?: number;
+  error?: string;
+}
+
+export interface FocusProfileSwitchManagerOptions {
+  app: App;
+  lockMgr: PluginLockManager;
+  resolver: IProfileResolver;
+  rdfIndexer: IRdfIndexer;
+  settingsStore: ISettingsStore;
+  /** Journal path relative to vault root. Default `.exocortex/switch-journal.jsonl`. */
+  journalPath?: string;
+  /** Max `_extends` depth — guards against cycles. Default 5 (per RFC b6ba5595 validation). */
+  maxExtendsDepth?: number;
+  /** Injectable Date.now для deterministic tests. */
+  now?: () => Date;
+  /** User-facing notifier (typically `new Notice()`). */
+  notify?: (message: string) => void;
+}
+
+const DEFAULT_JOURNAL_PATH = ".exocortex/switch-journal.jsonl";
+const DEFAULT_MAX_EXTENDS_DEPTH = 5;
+
+export class FocusProfileSwitchManager {
+  private readonly app: App;
+  private readonly lockMgr: PluginLockManager;
+  private readonly resolver: IProfileResolver;
+  private readonly rdfIndexer: IRdfIndexer;
+  private readonly settingsStore: ISettingsStore;
+  private readonly journalPath: string;
+  private readonly maxExtendsDepth: number;
+  private readonly now: () => Date;
+  private readonly notify: (message: string) => void;
+
+  constructor(options: FocusProfileSwitchManagerOptions) {
+    this.app = options.app;
+    this.lockMgr = options.lockMgr;
+    this.resolver = options.resolver;
+    this.rdfIndexer = options.rdfIndexer;
+    this.settingsStore = options.settingsStore;
+    this.journalPath = options.journalPath ?? DEFAULT_JOURNAL_PATH;
+    this.maxExtendsDepth = options.maxExtendsDepth ?? DEFAULT_MAX_EXTENDS_DEPTH;
+    this.now = options.now ?? (() => new Date());
+    this.notify = options.notify ?? (() => undefined);
+  }
+
+  /**
+   * Switch active focus profile. Lock-guarded, journaled. Idempotent re-index
+   * on failure (no destructive rollback in v3).
+   */
+  async switchProfile(targetProfileUid: string): Promise<void> {
+    const acquired = await this.lockMgr.acquireLock(`switch-profile-${targetProfileUid}`);
+    if (!acquired) {
+      throw new Error(`Another switch is in progress (lock held). Try again shortly.`);
+    }
+
+    const startedAt = this.now().getTime();
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+    try {
+      await this.appendJournal({
+        phase: "starting",
+        targetUid: targetProfileUid,
+        ts: new Date(startedAt).toISOString(),
+      });
+
+      heartbeatTimer = setInterval(() => {
+        // Best-effort heartbeat — swallow errors, lock manager logs them.
+        void this.lockMgr.heartbeat();
+      }, 30_000);
+
+      // Resolve effective set ONCE before any settings mutation
+      const effective = await this.resolveEffectiveSet(targetProfileUid);
+
+      // Persist BEFORE filesystem changes (Architect #2 — atomicity invariant)
+      const settings = await this.settingsStore.load();
+      settings.activeProfileUid = targetProfileUid;
+      settings._switchInProgress = true;
+      await this.settingsStore.save(settings);
+
+      // Trigger RDF re-index
+      await this.rdfIndexer.refresh(effective);
+
+      // Clear in-progress flag
+      settings._switchInProgress = false;
+      await this.settingsStore.save(settings);
+
+      const elapsedMs = this.now().getTime() - startedAt;
+      await this.appendJournal({
+        phase: "completed",
+        targetUid: targetProfileUid,
+        ts: this.now().toISOString(),
+        elapsedMs,
+      });
+
+      const profileLabel = await this.profileLabel(targetProfileUid);
+      this.notify(`Switched to ${profileLabel} (${elapsedMs}ms)`);
+    } catch (e) {
+      await this.appendJournal({
+        phase: "failed",
+        targetUid: targetProfileUid,
+        ts: this.now().toISOString(),
+        error: this.redactError(String(e)),
+      });
+      throw e;
+    } finally {
+      if (heartbeatTimer !== null) clearInterval(heartbeatTimer);
+      await this.lockMgr.releaseLock();
+    }
+  }
+
+  /**
+   * Plugin-load recovery: if last journal entry shows an incomplete switch
+   * AND settings._switchInProgress=true, re-trigger the re-index идempotently.
+   *
+   * In v3 backward-compat mode: re-index is pure (no filesystem state to roll
+   * back), so we simply call switchProfile again — it's safe.
+   *
+   * In Phase C+D future: this would need full two-phase rollback (restore
+   * staging dir, undo destroy). Deferred.
+   */
+  async recoverIfNeeded(): Promise<{ recovered: boolean; targetUid: string | null }> {
+    const lastEntry = await this.readLastJournalEntry();
+    const settings = await this.settingsStore.load();
+
+    if (!lastEntry) return { recovered: false, targetUid: null };
+    if (lastEntry.phase === "completed") return { recovered: false, targetUid: null };
+    if (!settings._switchInProgress) return { recovered: false, targetUid: null };
+
+    // Incomplete: re-trigger
+    this.notify(`Recovering incomplete switch to ${lastEntry.targetUid}...`);
+    await this.switchProfile(lastEntry.targetUid);
+    return { recovered: true, targetUid: lastEntry.targetUid };
+  }
+
+  /**
+   * Compute the effective ontology URI set for a given profile.
+   *
+   * = derived(profile) ∪ TS_FLOOR ∪ discoveredSharedOntologies
+   *
+   * Where derived = includes ∪ extends*[alwaysOnOverlay] ∪ includes (transitive).
+   *
+   * TS-floor (Vision Lock #17) — hardcoded `[$exo, $exocmd]` + pattern match
+   * для shared-identities — guarantees the plugin keeps functioning regardless
+   * of profile config.
+   */
+  async resolveEffectiveSet(profileUid: string): Promise<Set<string>> {
+    const derived = await this.computeDerivedSet(profileUid);
+    const sharedDiscovered = await this.resolver.discoverSharedOntologies();
+    const result = new Set<string>();
+    for (const u of derived) result.add(u);
+    for (const u of TS_FLOOR_ONTOLOGY_URIS) result.add(u);
+    for (const u of sharedDiscovered) {
+      if (TS_FLOOR_SHARED_PATTERN.test(u)) result.add(u);
+    }
+    return result;
+  }
+
+  /**
+   * Compute derived ontology set without TS-floor — useful для tests verifying
+   * inheritance walk separately from floor enforcement.
+   */
+  async computeDerivedSet(profileUid: string): Promise<Set<string>> {
+    const visited = new Set<string>();
+    const result = new Set<string>();
+    await this.walkProfileChain(profileUid, visited, result, 0);
+    return result;
+  }
+
+  // === Helpers ===
+
+  private async walkProfileChain(
+    uid: string,
+    visited: Set<string>,
+    result: Set<string>,
+    depth: number,
+  ): Promise<void> {
+    if (depth > this.maxExtendsDepth) {
+      throw new Error(
+        `FocusProfile chain exceeds max depth ${this.maxExtendsDepth} at ${uid} — possible cycle`,
+      );
+    }
+    if (visited.has(uid)) return; // cycle guard
+    visited.add(uid);
+
+    const profile = await this.resolver.resolve(uid);
+    if (profile === null) return; // tolerate missing parent — leaf
+
+    for (const u of profile.includes) result.add(u);
+    for (const u of profile.alwaysOnOverlay) result.add(u);
+
+    if (typeof profile.extends === "string" && profile.extends.length > 0) {
+      await this.walkProfileChain(profile.extends, visited, result, depth + 1);
+    }
+  }
+
+  private async appendJournal(entry: SwitchJournalEntry): Promise<void> {
+    const line = JSON.stringify(entry) + "\n";
+    let existing = "";
+    try {
+      const exists = await this.app.vault.adapter.exists(this.journalPath);
+      if (exists) existing = await this.app.vault.adapter.read(this.journalPath);
+    } catch {
+      existing = "";
+    }
+    await this.app.vault.adapter.write(this.journalPath, existing + line);
+  }
+
+  private async readLastJournalEntry(): Promise<SwitchJournalEntry | null> {
+    try {
+      const exists = await this.app.vault.adapter.exists(this.journalPath);
+      if (!exists) return null;
+      const text = await this.app.vault.adapter.read(this.journalPath);
+      const lines = text.split("\n").filter((l) => l.trim().length > 0);
+      if (lines.length === 0) return null;
+      return JSON.parse(lines[lines.length - 1]) as SwitchJournalEntry;
+    } catch {
+      return null;
+    }
+  }
+
+  private async profileLabel(uid: string): Promise<string> {
+    try {
+      const p = await this.resolver.resolve(uid);
+      return p?.label ?? uid.slice(0, 8);
+    } catch {
+      return uid.slice(0, 8);
+    }
+  }
+
+  /**
+   * Redact GitHub PAT shapes from error messages — defensive depth (same regex
+   * as B.1 GitHubRestClient). Even though this class doesn't directly handle
+   * PATs, downstream errors могут carry them through stacktrace.
+   */
+  private redactError(msg: string): string {
+    return msg.replace(
+      /(?:gh[pousr]_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{22,}_[A-Za-z0-9_]{59,})/g,
+      "***REDACTED***",
+    );
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.test.ts
@@ -1,0 +1,528 @@
+import type { App } from "obsidian";
+
+import {
+  FocusProfileSwitchManager,
+  TS_FLOOR_ONTOLOGY_URIS,
+  type IProfileResolver,
+  type IRdfIndexer,
+  type ISettingsStore,
+  type ProfileResolution,
+  type SwitchJournalEntry,
+  type SwitchSettings,
+} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
+
+// ─── Fake App / vault.adapter ────────────────────────────────────────────
+
+interface FakeStore {
+  files: Map<string, string>;
+}
+
+function makeFakeApp(): { app: App; store: FakeStore } {
+  const files = new Map<string, string>();
+  const app = {
+    vault: {
+      adapter: {
+        exists: async (path: string) => files.has(path),
+        read: async (path: string) => {
+          const v = files.get(path);
+          if (v === undefined) throw new Error(`ENOENT: ${path}`);
+          return v;
+        },
+        write: async (path: string, data: string) => {
+          files.set(path, data);
+        },
+        remove: async (path: string) => {
+          files.delete(path);
+        },
+      },
+    },
+  } as unknown as App;
+  return { app, store: { files } };
+}
+
+// ─── Fake IProfileResolver ───────────────────────────────────────────────
+
+class FakeProfileResolver implements IProfileResolver {
+  constructor(
+    private readonly profiles: Map<string, ProfileResolution>,
+    private readonly sharedOntologies: string[] = [],
+  ) {}
+
+  async resolve(uid: string): Promise<ProfileResolution | null> {
+    return this.profiles.get(uid) ?? null;
+  }
+
+  async discoverSharedOntologies(): Promise<string[]> {
+    return this.sharedOntologies;
+  }
+}
+
+// ─── Fake IRdfIndexer ────────────────────────────────────────────────────
+
+class FakeRdfIndexer implements IRdfIndexer {
+  refreshCalls: ReadonlySet<string>[] = [];
+  failOnce = false;
+
+  async refresh(effectiveOntologies: ReadonlySet<string>): Promise<void> {
+    this.refreshCalls.push(new Set(effectiveOntologies));
+    if (this.failOnce) {
+      this.failOnce = false;
+      throw new Error("Simulated re-index failure");
+    }
+  }
+}
+
+// ─── Fake ISettingsStore ─────────────────────────────────────────────────
+
+class FakeSettingsStore implements ISettingsStore {
+  state: SwitchSettings = { activeProfileUid: null, _switchInProgress: false };
+  saveCalls: SwitchSettings[] = [];
+
+  async load(): Promise<SwitchSettings> {
+    return { ...this.state };
+  }
+  async save(s: SwitchSettings): Promise<void> {
+    this.state = { ...s };
+    this.saveCalls.push({ ...s });
+  }
+}
+
+// ─── Test harness ────────────────────────────────────────────────────────
+
+interface Harness {
+  app: App;
+  store: FakeStore;
+  resolver: FakeProfileResolver;
+  rdf: FakeRdfIndexer;
+  settings: FakeSettingsStore;
+  lockMgr: PluginLockManager;
+  mgr: FocusProfileSwitchManager;
+  notifyCalls: string[];
+  clock: { current: Date; advance: (ms: number) => void };
+}
+
+function makeHarness(opts: {
+  profiles: Array<[string, ProfileResolution]>;
+  sharedOntologies?: string[];
+}): Harness {
+  const { app, store } = makeFakeApp();
+  const profilesMap = new Map<string, ProfileResolution>(opts.profiles);
+  const resolver = new FakeProfileResolver(profilesMap, opts.sharedOntologies);
+  const rdf = new FakeRdfIndexer();
+  const settings = new FakeSettingsStore();
+  let current = new Date("2026-06-01T00:00:00.000Z");
+  const clock = {
+    get current(): Date {
+      return current;
+    },
+    advance: (ms: number) => {
+      current = new Date(current.getTime() + ms);
+    },
+  };
+  const lockMgr = new PluginLockManager({ app, pid: "fixed-pid", now: () => current });
+  const notifyCalls: string[] = [];
+  const mgr = new FocusProfileSwitchManager({
+    app,
+    lockMgr,
+    resolver,
+    rdfIndexer: rdf,
+    settingsStore: settings,
+    now: () => current,
+    notify: (m) => notifyCalls.push(m),
+  });
+  return { app, store, resolver, rdf, settings, lockMgr, mgr, notifyCalls, clock };
+}
+
+const UID_BASE = "ae00f219-base";
+const UID_PERSONAL = "0a0791c1-personal";
+const UID_READING = "8169cc07-reading";
+
+const ONTO_EXO = "https://exocortex.my/ontology/exo";
+const ONTO_EXOCMD = "https://exocortex.my/ontology/exocmd";
+const ONTO_KITELEV = "https://exocortex.my/ontology/kitelev";
+const ONTO_TBANK = "https://exocortex.my/ontology/tbank";
+
+// ─── resolveEffectiveSet + TS-floor ──────────────────────────────────────
+
+describe("FocusProfileSwitchManager.resolveEffectiveSet — TS-floor (Vision Lock #17)", () => {
+  it("includes TS-floor URIs even when profile has empty includes/overlay", async () => {
+    const { mgr } = makeHarness({
+      profiles: [
+        [
+          UID_BASE,
+          {
+            uid: UID_BASE,
+            includes: [],
+            alwaysOnOverlay: [],
+            extends: null,
+            label: "profile-empty",
+          },
+        ],
+      ],
+    });
+    const effective = await mgr.resolveEffectiveSet(UID_BASE);
+    expect(effective.has(ONTO_EXO)).toBe(true);
+    expect(effective.has(ONTO_EXOCMD)).toBe(true);
+  });
+
+  it("includes shared-identities pattern matches via discoverSharedOntologies", async () => {
+    const { mgr } = makeHarness({
+      profiles: [
+        [
+          UID_BASE,
+          {
+            uid: UID_BASE,
+            includes: [],
+            alwaysOnOverlay: [],
+            extends: null,
+            label: "profile-empty",
+          },
+        ],
+      ],
+      sharedOntologies: [
+        "https://exocortex.my/ontology/shared-identities",
+        "https://exocortex.my/ontology/random-not-shared",
+      ],
+    });
+    const effective = await mgr.resolveEffectiveSet(UID_BASE);
+    expect(effective.has("https://exocortex.my/ontology/shared-identities")).toBe(true);
+    expect(effective.has("https://exocortex.my/ontology/random-not-shared")).toBe(false);
+  });
+
+  it("preserves TS-floor URIs even if user tries to declare profile without them", async () => {
+    // Pathological case: profile-empty has no overlay
+    const { mgr } = makeHarness({
+      profiles: [
+        [
+          UID_BASE,
+          { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null },
+        ],
+      ],
+    });
+    const effective = await mgr.resolveEffectiveSet(UID_BASE);
+    for (const floorUri of TS_FLOOR_ONTOLOGY_URIS) {
+      expect(effective.has(floorUri)).toBe(true);
+    }
+  });
+});
+
+// ─── computeDerivedSet — inheritance ─────────────────────────────────────
+
+describe("FocusProfileSwitchManager.computeDerivedSet — _extends chain", () => {
+  it("walks _extends transitively and accumulates _alwaysOnOverlay", async () => {
+    const { mgr } = makeHarness({
+      profiles: [
+        [UID_BASE, {
+          uid: UID_BASE,
+          includes: [],
+          alwaysOnOverlay: [ONTO_EXO, ONTO_EXOCMD],
+          extends: null,
+          label: "profile-base",
+        }],
+        [UID_PERSONAL, {
+          uid: UID_PERSONAL,
+          includes: [ONTO_KITELEV],
+          alwaysOnOverlay: [],
+          extends: UID_BASE,
+          label: "profile-personal",
+        }],
+      ],
+    });
+    const derived = await mgr.computeDerivedSet(UID_PERSONAL);
+    expect(derived.has(ONTO_KITELEV)).toBe(true);
+    expect(derived.has(ONTO_EXO)).toBe(true);
+    expect(derived.has(ONTO_EXOCMD)).toBe(true);
+  });
+
+  it("handles profile with no parent (extends=null)", async () => {
+    const { mgr } = makeHarness({
+      profiles: [
+        [UID_BASE, {
+          uid: UID_BASE,
+          includes: [ONTO_KITELEV],
+          alwaysOnOverlay: [],
+          extends: null,
+        }],
+      ],
+    });
+    const derived = await mgr.computeDerivedSet(UID_BASE);
+    expect(derived.has(ONTO_KITELEV)).toBe(true);
+    expect(derived.size).toBe(1);
+  });
+
+  it("handles missing parent (resolver returns null) without throw", async () => {
+    const { mgr } = makeHarness({
+      profiles: [
+        [UID_PERSONAL, {
+          uid: UID_PERSONAL,
+          includes: [ONTO_KITELEV],
+          alwaysOnOverlay: [],
+          extends: "no-such-uid",
+        }],
+      ],
+    });
+    const derived = await mgr.computeDerivedSet(UID_PERSONAL);
+    expect(derived.has(ONTO_KITELEV)).toBe(true);
+  });
+
+  it("throws on _extends cycle (depth exceeds maxExtendsDepth)", async () => {
+    // Each profile extends the next; with maxDepth=5 a chain of 7+ throws
+    const profiles: Array<[string, ProfileResolution]> = [];
+    for (let i = 0; i < 8; i++) {
+      profiles.push([`p${i}`, {
+        uid: `p${i}`,
+        includes: [],
+        alwaysOnOverlay: [],
+        extends: `p${i + 1}`,
+      }]);
+    }
+    profiles.push([`p8`, {
+      uid: "p8",
+      includes: [],
+      alwaysOnOverlay: [],
+      extends: "p0", // cycle back
+    }]);
+    const { mgr } = makeHarness({ profiles });
+    await expect(mgr.computeDerivedSet("p0")).rejects.toThrow(/exceeds max depth/);
+  });
+
+  it("self-referencing _extends does not infinite-loop (cycle guard via visited)", async () => {
+    const { mgr } = makeHarness({
+      profiles: [
+        [UID_BASE, {
+          uid: UID_BASE,
+          includes: [ONTO_KITELEV],
+          alwaysOnOverlay: [],
+          extends: UID_BASE, // self
+        }],
+      ],
+    });
+    const derived = await mgr.computeDerivedSet(UID_BASE);
+    expect(derived.has(ONTO_KITELEV)).toBe(true);
+  });
+});
+
+// ─── switchProfile happy path ────────────────────────────────────────────
+
+describe("FocusProfileSwitchManager.switchProfile — happy path", () => {
+  it("persists settings BEFORE re-index (Architect #2 atomicity)", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [ONTO_KITELEV], alwaysOnOverlay: [], extends: null, label: "profile-base" }],
+      ],
+    });
+
+    // Track order: save calls vs rdf.refresh calls
+    const events: string[] = [];
+    const origSave = h.settings.save.bind(h.settings);
+    h.settings.save = async (s: SwitchSettings) => {
+      events.push("save");
+      await origSave(s);
+    };
+    const origRefresh = h.rdf.refresh.bind(h.rdf);
+    h.rdf.refresh = async (set) => {
+      events.push("refresh");
+      await origRefresh(set);
+    };
+
+    await h.mgr.switchProfile(UID_BASE);
+
+    // Expect: save (activeProfileUid + _switchInProgress=true), refresh, save (_switchInProgress=false)
+    expect(events).toEqual(["save", "refresh", "save"]);
+    expect(h.settings.state.activeProfileUid).toBe(UID_BASE);
+    expect(h.settings.state._switchInProgress).toBe(false);
+  });
+
+  it("writes starting + completed journal entries", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null, label: "profile-base" }],
+      ],
+    });
+    h.clock.advance(1000); // shift base
+    await h.mgr.switchProfile(UID_BASE);
+
+    const journalText = h.store.files.get(".exocortex/switch-journal.jsonl");
+    expect(journalText).toBeDefined();
+    const lines = journalText!.trim().split("\n").map((l) => JSON.parse(l) as SwitchJournalEntry);
+    expect(lines).toHaveLength(2);
+    expect(lines[0].phase).toBe("starting");
+    expect(lines[1].phase).toBe("completed");
+    expect(lines[1].elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("notifies user with profile label + elapsed ms", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null, label: "my-cool-profile" }],
+      ],
+    });
+    await h.mgr.switchProfile(UID_BASE);
+    expect(h.notifyCalls.length).toBe(1);
+    expect(h.notifyCalls[0]).toContain("my-cool-profile");
+    expect(h.notifyCalls[0]).toMatch(/\d+ms/);
+  });
+
+  it("invokes rdf.refresh with effective set including TS-floor", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [ONTO_TBANK], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    await h.mgr.switchProfile(UID_BASE);
+    expect(h.rdf.refreshCalls.length).toBe(1);
+    const set = h.rdf.refreshCalls[0];
+    expect(set.has(ONTO_TBANK)).toBe(true);
+    expect(set.has(ONTO_EXO)).toBe(true); // TS-floor
+    expect(set.has(ONTO_EXOCMD)).toBe(true); // TS-floor
+  });
+});
+
+// ─── switchProfile lock concurrency ──────────────────────────────────────
+
+describe("FocusProfileSwitchManager.switchProfile — lock contention", () => {
+  it("throws when lock already held by foreign holder", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    // Acquire lock under a different pid
+    const foreignLock = new PluginLockManager({ app: h.app, pid: "foreign-pid", now: () => h.clock.current });
+    expect(await foreignLock.acquireLock("foreign-op")).toBe(true);
+
+    await expect(h.mgr.switchProfile(UID_BASE)).rejects.toThrow(/lock held/);
+  });
+
+  it("releases lock on success", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    await h.mgr.switchProfile(UID_BASE);
+    // Lock file should be removed
+    expect(h.store.files.has(".exocortex/switch-lock.json")).toBe(false);
+  });
+
+  it("releases lock on failure (re-index throws)", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    h.rdf.failOnce = true;
+    await expect(h.mgr.switchProfile(UID_BASE)).rejects.toThrow(/Simulated/);
+    expect(h.store.files.has(".exocortex/switch-lock.json")).toBe(false);
+  });
+});
+
+// ─── switchProfile failure journal ────────────────────────────────────────
+
+describe("FocusProfileSwitchManager.switchProfile — failure path", () => {
+  it("writes failed journal entry when re-index throws", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    h.rdf.failOnce = true;
+    await expect(h.mgr.switchProfile(UID_BASE)).rejects.toThrow();
+
+    const journalText = h.store.files.get(".exocortex/switch-journal.jsonl");
+    const lines = journalText!.trim().split("\n").map((l) => JSON.parse(l) as SwitchJournalEntry);
+    // Expect: starting, failed (NOT completed)
+    expect(lines.map((l) => l.phase)).toEqual(["starting", "failed"]);
+  });
+
+  it("leaves _switchInProgress=true when re-index throws (recoverable)", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    h.rdf.failOnce = true;
+    await expect(h.mgr.switchProfile(UID_BASE)).rejects.toThrow();
+    expect(h.settings.state._switchInProgress).toBe(true);
+  });
+
+  it("redacts PAT-shaped tokens from error messages in journal", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    h.rdf.refresh = async () => {
+      throw new Error(`Auth failed: ghp_${"A".repeat(40)}`);
+    };
+    await expect(h.mgr.switchProfile(UID_BASE)).rejects.toThrow();
+
+    const journalText = h.store.files.get(".exocortex/switch-journal.jsonl");
+    const lines = journalText!.trim().split("\n").map((l) => JSON.parse(l) as SwitchJournalEntry);
+    const failed = lines.find((l) => l.phase === "failed")!;
+    expect(failed.error).toContain("***REDACTED***");
+    expect(failed.error).not.toContain("ghp_AAAAAAAAA");
+  });
+});
+
+// ─── recoverIfNeeded ──────────────────────────────────────────────────────
+
+describe("FocusProfileSwitchManager.recoverIfNeeded", () => {
+  it("returns {recovered:false} when no journal exists", async () => {
+    const h = makeHarness({ profiles: [] });
+    const res = await h.mgr.recoverIfNeeded();
+    expect(res.recovered).toBe(false);
+    expect(res.targetUid).toBeNull();
+  });
+
+  it("returns {recovered:false} when last journal entry is completed", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    await h.mgr.switchProfile(UID_BASE);
+    const res = await h.mgr.recoverIfNeeded();
+    expect(res.recovered).toBe(false);
+  });
+
+  it("re-triggers switchProfile when last entry incomplete + _switchInProgress=true", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    // Simulate crashed mid-switch: write only «starting» entry + set in-progress flag
+    await h.app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      JSON.stringify({
+        phase: "starting",
+        targetUid: UID_BASE,
+        ts: "2026-06-01T00:00:00.000Z",
+      }) + "\n",
+    );
+    h.settings.state = { activeProfileUid: UID_BASE, _switchInProgress: true };
+
+    const res = await h.mgr.recoverIfNeeded();
+    expect(res.recovered).toBe(true);
+    expect(res.targetUid).toBe(UID_BASE);
+    expect(h.rdf.refreshCalls.length).toBe(1);
+    expect(h.settings.state._switchInProgress).toBe(false);
+  });
+
+  it("does NOT recover when _switchInProgress=false even with incomplete journal", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], alwaysOnOverlay: [], extends: null }],
+      ],
+    });
+    await h.app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      JSON.stringify({ phase: "starting", targetUid: UID_BASE, ts: "..." }) + "\n",
+    );
+    // settings._switchInProgress is false (default)
+    const res = await h.mgr.recoverIfNeeded();
+    expect(res.recovered).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`FocusProfileSwitchManager` — orchestrates atomic profile switching:
1. Acquire B.6 PluginLockManager lock (с 30s heartbeat)
2. Journal entry «starting»
3. Compute effective ontology set (`includes ∪ extends*[overlay] ∪ TS_FLOOR`)
4. Persist `settings.activeProfileUid` + `_switchInProgress=true` BEFORE filesystem changes (Architect #2)
5. Trigger `rdfIndexer.refresh(effective)` — NoteToRDFConverter filters by ontology
6. Clear `_switchInProgress` flag
7. Journal entry «completed»

## v3 backward-compat scope
- NO destroy/pull (Phase C+D deferred per RFC scope split)
- RDF graph filter only — filesystem state untouched
- Recovery on failure: idempotent re-index (no destructive rollback needed)

## TS-floor (Vision Lock #17)
Hardcoded `[$exo, $exocmd]` + `shared-identities` pattern — NEVER destroyable, regardless of profile config. Prevents plugin self-brick.

## Recovery
`recoverIfNeeded()` at plugin-load: detects incomplete switch via journal + `_switchInProgress=true` flag → re-triggers switchProfile (idempotent в v3).

## DI-friendly interfaces
`IProfileResolver` / `IRdfIndexer` / `ISettingsStore` accepted via constructor. Production wiring (Obsidian metadataCache, NoteToRDFConverter, plugin settings) lives in B.11 release integration.

## Tests
22 unit tests:
- TS-floor invariance (3 scenarios)
- _extends inheritance walk (5: transitive, no-parent, missing-parent, cycle-depth-exceed, self-cycle-guard)
- switchProfile happy path (4: order check, journal entries, notify, refresh set content)
- Lock contention (3: foreign held throws, success releases, failure releases)
- Failure path (3: journal failed entry, _switchInProgress remains for recovery, PAT redaction)
- recoverIfNeeded (4: empty / completed-noop / re-trigger / flag-false-noop)

## Orchestration context
Done orchestrator-direct после 1st B.4 child died on Anthropic API rate-limit. B.6 PluginLockManager integration in place — no inline mutex compromise needed.

Related: RFC 0a0791c1 Phase B.4