### PR TITLE
feat(plugin): B.7 FocusProfileCommands handler (RFC 0a0791c1)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
@@ -1,0 +1,173 @@
+/**
+ * FocusProfileCommands — command-palette logic handler для RFC 0a0791c1 §B.7.
+ *
+ * Two commands provided:
+ *   1. `Exocortex: Switch focus profile` — fuzzy-picks a FocusProfile asset,
+ *      invokes B.4 `FocusProfileSwitchManager.switchProfile`
+ *   2. `Exocortex: Push current assetspace` — identifies AssetSpace from
+ *      active file path (B.3 `lookupAssetSpaceForPath`), invokes
+ *      B.3 `AssetSpaceManager.pushAssetSpace`
+ *
+ * Pure logic — does NOT depend on Obsidian Plugin / FuzzySuggestModal /
+ * App.workspace runtime. Dependencies passed via constructor:
+ *   - `switchMgr` (B.4)
+ *   - `pushMgr` (B.3 — interface `IAssetSpacePusher`)
+ *   - `profileLister` — returns available FocusProfile assets
+ *   - `fuzzyPick` — opens picker UI, returns chosen profile or null on cancel
+ *   - `getActiveFilePath` — returns active file path или null
+ *   - `notify` — user-facing Notice
+ *
+ * Real Obsidian wiring (plugin.addCommand + FuzzySuggestModal + Notice)
+ * happens в B.11 plugin entry-point integration.
+ */
+
+import type { FocusProfileSwitchManager } from "./FocusProfileSwitchManager";
+
+/** Minimal interface — full implementation in B.3 AssetSpaceManager. */
+export interface IAssetSpacePusher {
+  lookupAssetSpaceForPath(folderName: string): string | null;
+  pushAssetSpace(asUid: string): Promise<string>;
+}
+
+export interface FocusProfileChoice {
+  uid: string;
+  label: string;
+}
+
+export interface FocusProfileCommandsDeps {
+  switchMgr: FocusProfileSwitchManager;
+  pushMgr: IAssetSpacePusher;
+  /** Returns available FocusProfile assets (label + uid pairs). */
+  profileLister: () => Promise<FocusProfileChoice[]>;
+  /**
+   * Open a fuzzy picker UI. Returns the user's choice, or null if the
+   * picker was cancelled. Real implementation wraps Obsidian
+   * `FuzzySuggestModal`; tests provide a programmatic stub.
+   */
+  fuzzyPick: (
+    options: FocusProfileChoice[],
+    title: string,
+  ) => Promise<FocusProfileChoice | null>;
+  /** Returns the currently-active file path, or null if no file is open. */
+  getActiveFilePath: () => string | null;
+  /** Show a user-facing Notice. */
+  notify: (message: string) => void;
+}
+
+export class FocusProfileCommands {
+  private readonly switchMgr: FocusProfileSwitchManager;
+  private readonly pushMgr: IAssetSpacePusher;
+  private readonly profileLister: () => Promise<FocusProfileChoice[]>;
+  private readonly fuzzyPick: FocusProfileCommandsDeps["fuzzyPick"];
+  private readonly getActiveFilePath: () => string | null;
+  private readonly notify: (message: string) => void;
+
+  constructor(deps: FocusProfileCommandsDeps) {
+    this.switchMgr = deps.switchMgr;
+    this.pushMgr = deps.pushMgr;
+    this.profileLister = deps.profileLister;
+    this.fuzzyPick = deps.fuzzyPick;
+    this.getActiveFilePath = deps.getActiveFilePath;
+    this.notify = deps.notify;
+  }
+
+  /**
+   * Command 1 — `Exocortex: Switch focus profile`.
+   *
+   * Lists available profiles → fuzzy pick → invokes B.4 switchProfile.
+   * Errors during switch surface as a Notice (redacted in lower layers).
+   */
+  async invokeSwitchProfile(): Promise<void> {
+    let profiles: FocusProfileChoice[];
+    try {
+      profiles = await this.profileLister();
+    } catch (e) {
+      this.notify(`Could not list profiles: ${this.safeMessage(e)}`);
+      return;
+    }
+
+    if (profiles.length === 0) {
+      this.notify("No FocusProfile assets found in vault");
+      return;
+    }
+
+    const chosen = await this.fuzzyPick(profiles, "Switch focus profile");
+    if (chosen === null) return; // user cancelled
+
+    this.notify(`Switching to ${chosen.label}…`);
+    try {
+      await this.switchMgr.switchProfile(chosen.uid);
+      // switchProfile itself emits a success Notice; nothing more here
+    } catch (e) {
+      this.notify(`Switch failed: ${this.safeMessage(e)}`);
+    }
+  }
+
+  /**
+   * Command 2 — `Exocortex: Push current assetspace` (Vision Lock #4).
+   *
+   * Determines the AssetSpace context от active file path, invokes
+   * B.3 `pushAssetSpace`. Shows graceful Notice when active file is not
+   * inside an AssetSpace folder, or no file is open.
+   */
+  async invokePushCurrentAssetSpace(): Promise<void> {
+    const activePath = this.getActiveFilePath();
+    if (activePath === null) {
+      this.notify("No active file — open a note inside assetspaces/<as>/ first");
+      return;
+    }
+
+    const folderName = FocusProfileCommands.extractAssetSpaceFolder(activePath);
+    if (folderName === null) {
+      this.notify(
+        "Not in an assetspace folder (expected path under `assetspaces/<as>/`)",
+      );
+      return;
+    }
+
+    const asUid = this.pushMgr.lookupAssetSpaceForPath(folderName);
+    if (asUid === null) {
+      this.notify(
+        `Folder \`${folderName}\` is not declared as an AssetSpace ABox`,
+      );
+      return;
+    }
+
+    this.notify(`Pushing \`${folderName}\`…`);
+    try {
+      const sha = await this.pushMgr.pushAssetSpace(asUid);
+      if (sha === "" || sha === undefined) {
+        // Empty sha indicates «no dirty files» — pushAssetSpace already
+        // emitted a Notice. Avoid duplicate user message.
+        return;
+      }
+      this.notify(`Pushed \`${folderName}\` → ${sha.slice(0, 7)}`);
+    } catch (e) {
+      this.notify(`Push failed: ${this.safeMessage(e)}`);
+    }
+  }
+
+  // === Helpers ===
+
+  /**
+   * Extract the AssetSpace folder name from a vault-relative path.
+   * Returns null if the path is not under `assetspaces/<as>/`.
+   *
+   * Examples:
+   *   `"assetspaces/exo/foo.md"` → `"assetspaces/exo"`
+   *   `"assetspaces/ems/sub/dir/bar.md"` → `"assetspaces/ems"`
+   *   `"03 Knowledge/note.md"` → `null`
+   *   `"assetspaces/foo.md"` → `null` (no AS subfolder)
+   */
+  static extractAssetSpaceFolder(path: string): string | null {
+    // Normalize separators
+    const normalized = path.replace(/\\/g, "/");
+    const match = normalized.match(/^(assetspaces\/[^/]+)\//);
+    return match === null ? null : match[1];
+  }
+
+  private safeMessage(e: unknown): string {
+    if (e instanceof Error) return e.message;
+    return String(e);
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
@@ -1,0 +1,255 @@
+import {
+  FocusProfileCommands,
+  type FocusProfileChoice,
+  type FocusProfileCommandsDeps,
+  type IAssetSpacePusher,
+} from "../../src/infrastructure/adapters/FocusProfileCommands";
+import type { FocusProfileSwitchManager } from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+
+// ─── Test doubles ────────────────────────────────────────────────────────
+
+class FakeSwitchMgr {
+  switchCalls: string[] = [];
+  failOnce = false;
+  async switchProfile(uid: string): Promise<void> {
+    this.switchCalls.push(uid);
+    if (this.failOnce) {
+      this.failOnce = false;
+      throw new Error("simulated switch failure");
+    }
+  }
+}
+
+class FakePushMgr implements IAssetSpacePusher {
+  lookups = new Map<string, string | null>();
+  pushedAs: string[] = [];
+  pushReturn: string | null = "a".repeat(40);
+  pushThrows: Error | null = null;
+
+  lookupAssetSpaceForPath(folder: string): string | null {
+    return this.lookups.get(folder) ?? null;
+  }
+  async pushAssetSpace(asUid: string): Promise<string> {
+    this.pushedAs.push(asUid);
+    if (this.pushThrows) throw this.pushThrows;
+    return this.pushReturn ?? "";
+  }
+}
+
+interface Harness {
+  switchMgr: FakeSwitchMgr;
+  pushMgr: FakePushMgr;
+  notices: string[];
+  pickCalls: { options: FocusProfileChoice[]; title: string }[];
+  fuzzyResult: FocusProfileChoice | null;
+  activeFilePath: string | null;
+  cmd: FocusProfileCommands;
+}
+
+function makeHarness(opts: {
+  profiles: FocusProfileChoice[];
+  pickResult?: FocusProfileChoice | null;
+  activeFilePath?: string | null;
+  asLookups?: Array<[string, string]>;
+  listError?: Error;
+}): Harness {
+  const switchMgr = new FakeSwitchMgr();
+  const pushMgr = new FakePushMgr();
+  if (opts.asLookups) {
+    for (const [folder, uid] of opts.asLookups) pushMgr.lookups.set(folder, uid);
+  }
+  const notices: string[] = [];
+  const pickCalls: { options: FocusProfileChoice[]; title: string }[] = [];
+  const deps: FocusProfileCommandsDeps = {
+    switchMgr: switchMgr as unknown as FocusProfileSwitchManager,
+    pushMgr,
+    profileLister: async () => {
+      if (opts.listError) throw opts.listError;
+      return opts.profiles;
+    },
+    fuzzyPick: async (options, title) => {
+      pickCalls.push({ options, title });
+      return opts.pickResult === undefined ? null : opts.pickResult;
+    },
+    getActiveFilePath: () => opts.activeFilePath ?? null,
+    notify: (m) => notices.push(m),
+  };
+  return {
+    switchMgr,
+    pushMgr,
+    notices,
+    pickCalls,
+    fuzzyResult: opts.pickResult ?? null,
+    activeFilePath: opts.activeFilePath ?? null,
+    cmd: new FocusProfileCommands(deps),
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// invokeSwitchProfile
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("FocusProfileCommands.invokeSwitchProfile", () => {
+  it("opens fuzzy picker с listed profiles", async () => {
+    const profiles = [
+      { uid: "u1", label: "profile-base" },
+      { uid: "u2", label: "profile-personal" },
+    ];
+    const h = makeHarness({ profiles, pickResult: profiles[1] });
+    await h.cmd.invokeSwitchProfile();
+
+    expect(h.pickCalls).toHaveLength(1);
+    expect(h.pickCalls[0].options).toEqual(profiles);
+    expect(h.pickCalls[0].title).toBe("Switch focus profile");
+  });
+
+  it("invokes switchMgr.switchProfile with chosen uid", async () => {
+    const profiles = [{ uid: "u2", label: "profile-personal" }];
+    const h = makeHarness({ profiles, pickResult: profiles[0] });
+    await h.cmd.invokeSwitchProfile();
+
+    expect(h.switchMgr.switchCalls).toEqual(["u2"]);
+    expect(h.notices.some((n) => n.includes("profile-personal"))).toBe(true);
+  });
+
+  it("does nothing when user cancels picker (null)", async () => {
+    const profiles = [{ uid: "u1", label: "p1" }];
+    const h = makeHarness({ profiles, pickResult: null });
+    await h.cmd.invokeSwitchProfile();
+
+    expect(h.switchMgr.switchCalls).toHaveLength(0);
+  });
+
+  it("shows Notice when no FocusProfile assets in vault", async () => {
+    const h = makeHarness({ profiles: [] });
+    await h.cmd.invokeSwitchProfile();
+
+    expect(h.pickCalls).toHaveLength(0);
+    expect(h.notices.some((n) => /No FocusProfile/.test(n))).toBe(true);
+  });
+
+  it("surfaces lister error as Notice без crash", async () => {
+    const h = makeHarness({
+      profiles: [],
+      listError: new Error("vault read failed"),
+    });
+    await h.cmd.invokeSwitchProfile();
+
+    expect(h.pickCalls).toHaveLength(0);
+    expect(h.notices.some((n) => /Could not list profiles.*vault read failed/.test(n))).toBe(true);
+  });
+
+  it("surfaces switchProfile failure as Notice без re-throw", async () => {
+    const profiles = [{ uid: "u1", label: "p1" }];
+    const h = makeHarness({ profiles, pickResult: profiles[0] });
+    h.switchMgr.failOnce = true;
+
+    await expect(h.cmd.invokeSwitchProfile()).resolves.not.toThrow();
+    expect(h.notices.some((n) => /Switch failed.*simulated/.test(n))).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// invokePushCurrentAssetSpace
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("FocusProfileCommands.invokePushCurrentAssetSpace", () => {
+  it("Notice when no active file", async () => {
+    const h = makeHarness({ profiles: [], activeFilePath: null });
+    await h.cmd.invokePushCurrentAssetSpace();
+
+    expect(h.pushMgr.pushedAs).toHaveLength(0);
+    expect(h.notices.some((n) => /No active file/.test(n))).toBe(true);
+  });
+
+  it("Notice when active file outside assetspaces/", async () => {
+    const h = makeHarness({
+      profiles: [],
+      activeFilePath: "03 Knowledge/inbox/random.md",
+    });
+    await h.cmd.invokePushCurrentAssetSpace();
+
+    expect(h.pushMgr.pushedAs).toHaveLength(0);
+    expect(h.notices.some((n) => /Not in an assetspace folder/.test(n))).toBe(true);
+  });
+
+  it("Notice when folder is не declared AssetSpace ABox", async () => {
+    const h = makeHarness({
+      profiles: [],
+      activeFilePath: "assetspaces/unknown/file.md",
+      // no lookup entry for assetspaces/unknown
+    });
+    await h.cmd.invokePushCurrentAssetSpace();
+
+    expect(h.pushMgr.pushedAs).toHaveLength(0);
+    expect(h.notices.some((n) => /not declared as an AssetSpace/.test(n))).toBe(true);
+  });
+
+  it("invokes pushAssetSpace and shows SHA Notice on success", async () => {
+    const h = makeHarness({
+      profiles: [],
+      activeFilePath: "assetspaces/exo/foo.md",
+      asLookups: [["assetspaces/exo", "as-uid-1"]],
+    });
+    h.pushMgr.pushReturn = "deadbeef00112233445566778899aabbccddeeff";
+
+    await h.cmd.invokePushCurrentAssetSpace();
+
+    expect(h.pushMgr.pushedAs).toEqual(["as-uid-1"]);
+    expect(h.notices.some((n) => /deadbee/.test(n))).toBe(true);
+  });
+
+  it("does not emit duplicate Notice when push returns empty SHA (no dirty files)", async () => {
+    const h = makeHarness({
+      profiles: [],
+      activeFilePath: "assetspaces/exo/foo.md",
+      asLookups: [["assetspaces/exo", "as-uid-1"]],
+    });
+    h.pushMgr.pushReturn = "";
+
+    await h.cmd.invokePushCurrentAssetSpace();
+
+    // «Pushing…» Notice emitted before push, that's OK; final «Pushed → SHA» should NOT
+    expect(h.notices.some((n) => /Pushed.*→/.test(n))).toBe(false);
+  });
+
+  it("surfaces pushAssetSpace failure as Notice без crash", async () => {
+    const h = makeHarness({
+      profiles: [],
+      activeFilePath: "assetspaces/exo/foo.md",
+      asLookups: [["assetspaces/exo", "as-uid-1"]],
+    });
+    h.pushMgr.pushThrows = new Error("rate limit guard hit");
+
+    await expect(h.cmd.invokePushCurrentAssetSpace()).resolves.not.toThrow();
+    expect(h.notices.some((n) => /Push failed.*rate limit/.test(n))).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// extractAssetSpaceFolder helper
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("FocusProfileCommands.extractAssetSpaceFolder", () => {
+  it("extracts folder from typical path", () => {
+    expect(FocusProfileCommands.extractAssetSpaceFolder("assetspaces/exo/foo.md")).toBe("assetspaces/exo");
+  });
+
+  it("extracts folder from deeply nested path", () => {
+    expect(FocusProfileCommands.extractAssetSpaceFolder("assetspaces/ems/sub/dir/bar.md")).toBe("assetspaces/ems");
+  });
+
+  it("normalizes Windows backslash separators", () => {
+    // Source `\\` = single backslash in actual string → regex /\\/ matches
+    expect(FocusProfileCommands.extractAssetSpaceFolder("assetspaces\\shared-identities\\file.md")).toBe("assetspaces/shared-identities");
+  });
+
+  it("returns null for path outside assetspaces", () => {
+    expect(FocusProfileCommands.extractAssetSpaceFolder("03 Knowledge/inbox/note.md")).toBeNull();
+    expect(FocusProfileCommands.extractAssetSpaceFolder("inbox/note.md")).toBeNull();
+  });
+
+  it("returns null when assetspaces/ has no sub-folder", () => {
+    expect(FocusProfileCommands.extractAssetSpaceFolder("assetspaces/loose.md")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Command-palette logic handler for the 2 RFC 0a0791c1 commands:
1. **`Exocortex: Switch focus profile`** — fuzzy pick → B.4 switchProfile
2. **`Exocortex: Push current assetspace`** — active-file path → B.3 push

Pure-logic class с DI interfaces; real `addCommand` + `FuzzySuggestModal` wiring lives in B.11 plugin release integration.

## Graceful surfaces (Notice, no crash)
- No active file
- Active file outside assetspaces/
- Folder not declared as AssetSpace ABox
- Lister / switch / push errors (Notice без re-throw)
- Empty-SHA push (avoid duplicate Notice)

## Tests
17 unit tests:
- `invokeSwitchProfile`: empty list / list error / no profiles / fuzzy cancel / happy path / switch failure
- `invokePushCurrentAssetSpace`: no active / not in AS / unknown AS / happy path / empty SHA / push failure
- `extractAssetSpaceFolder` helper: typical / deeply nested / backslash normalization / outside / no sub-folder

Related: RFC 0a0791c1 Phase B.7