### PR TITLE
feat(plugin): B.8 Settings helpers — LocalSecrets + OperationsLog (RFC 0a0791c1)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/LocalSecretsStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/LocalSecretsStore.ts
@@ -1,0 +1,120 @@
+import type { App } from "obsidian";
+
+/**
+ * LocalSecretsStore — device-local secrets persistence layer для RFC 0a0791c1
+ * §B.8 + Vision Lock #1 + Security #1.
+ *
+ * Why a separate file (not Obsidian Plugin's standard \`data.json\`):
+ *
+ * Obsidian Sync replicates plugin \`data.json\` across devices. Storing a
+ * GitHub PAT там means the PAT travels through Sync's network + storage
+ * — violation of Vision Lock #1 «PAT в data.local.json only».
+ *
+ * \`data.local.json\` lives at \`.obsidian/plugins/exocortex/data.local.json\`,
+ * which Obsidian Sync EXCLUDES by convention (любые \`.local.json\` files).
+ * Verified empirically: Obsidian Sync's exclude rules treat \`.local.\` infix
+ * as device-only.
+ *
+ * Reads tolerate missing file (returns empty record). Writes create the file
+ * с pretty-printed JSON. Path resolves relative to vault root through
+ * \`app.vault.adapter\`, identical к how Plugin manages \`data.json\`.
+ */
+
+export interface LocalSecretsStoreOptions {
+  app: App;
+  /**
+   * Path relative to vault root. Default uses Obsidian's runtime
+   * `vault.configDir` (typically `.obsidian/`) joined с
+   * `plugins/exocortex/data.local.json`.
+   *
+   * Override only для tests или per-plugin-id customization.
+   */
+  path?: string;
+  /**
+   * Plugin id used to build the default sub-path under \`configDir/plugins/\`.
+   * Default `"exocortex"`.
+   */
+  pluginId?: string;
+}
+
+export class LocalSecretsStore {
+  private readonly app: App;
+  private readonly path: string;
+
+  constructor(options: LocalSecretsStoreOptions) {
+    this.app = options.app;
+    if (options.path !== undefined) {
+      this.path = options.path;
+    } else {
+      // Obsidian config dir is user-configurable; use the runtime value
+      // (per `obsidianmd/hardcoded-config-path` eslint guidance).
+      const configDir = options.app.vault.configDir;
+      const pluginId = options.pluginId ?? "exocortex";
+      this.path = `${configDir}/plugins/${pluginId}/data.local.json`;
+    }
+  }
+
+  /**
+   * Read the secrets file. Returns \`{}\` when the file is absent или
+   * unparseable — callers should not surface this as an error, since a
+   * fresh install legitimately has no secrets yet.
+   */
+  async readAll(): Promise<Record<string, string>> {
+    try {
+      const exists = await this.app.vault.adapter.exists(this.path);
+      if (!exists) return {};
+      const raw = await this.app.vault.adapter.read(this.path);
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed === null || typeof parsed !== "object") return {};
+      const result: Record<string, string> = {};
+      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v === "string") result[k] = v;
+      }
+      return result;
+    } catch {
+      return {};
+    }
+  }
+
+  /** Get a single secret by key. Returns null if missing or non-string. */
+  async getSecret(key: string): Promise<string | null> {
+    const all = await this.readAll();
+    return key in all ? all[key] : null;
+  }
+
+  /**
+   * Set or clear a single secret. Passing an empty string или null deletes
+   * the entry (avoid trailing empty-PAT junk in the file).
+   */
+  async setSecret(key: string, value: string | null): Promise<void> {
+    const all = await this.readAll();
+    if (value === null || value === "") {
+      delete all[key];
+    } else {
+      all[key] = value;
+    }
+    await this.persist(all);
+  }
+
+  /** Remove all stored secrets. Used by «Clear secrets» action в UI. */
+  async clearAll(): Promise<void> {
+    await this.persist({});
+  }
+
+  /**
+   * Render a masked view of the secret value — used for «PAT field shows
+   * `********`-style placeholder» в UI без leaking length precisely.
+   */
+  static mask(value: string | null): string {
+    if (!value) return "";
+    if (value.length <= 8) return "*".repeat(value.length);
+    // Show last 4 chars (e.g. `***********xyz1`) so user can identify
+    // which PAT is stored without revealing the body.
+    return "*".repeat(Math.max(8, value.length - 4)) + value.slice(-4);
+  }
+
+  private async persist(all: Record<string, string>): Promise<void> {
+    const json = JSON.stringify(all, null, 2);
+    await this.app.vault.adapter.write(this.path, json);
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/OperationsLogReader.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/OperationsLogReader.ts
@@ -1,0 +1,124 @@
+import type { App } from "obsidian";
+
+import type { SwitchJournalEntry } from "./FocusProfileSwitchManager";
+
+/**
+ * OperationsLogReader — formats the B.4 switch journal для UI display
+ * (RFC 0a0791c1 §B.8 Section 4 «Operations log»).
+ *
+ * Source data: \`.exocortex/switch-journal.jsonl\` (one JSON entry per line)
+ * written by \`FocusProfileSwitchManager\` (B.4).
+ *
+ * UI requirement (Architect #11 / RFC §B.8 Section 4):
+ *   «Last 10 switches displayed as `<timestamp> | <profile-label> | <elapsedMs>ms | <status>`»
+ *
+ * Profile labels are not in the journal (only UIDs are). The reader accepts
+ * a \`labelLookup\` callback that resolves UID → label, with а fallback к
+ * UID's first 8 chars when the asset is missing.
+ */
+
+export interface OperationsLogEntry {
+  /** ISO timestamp of the entry — для UI sort + display. */
+  ts: string;
+  /** Profile UID. */
+  targetUid: string;
+  /** Resolved label (falls back to UID prefix). */
+  profileLabel: string;
+  /** «starting» / «completed» / «failed». */
+  status: SwitchJournalEntry["phase"];
+  /** ms duration; null если status≠completed (no elapsedMs recorded). */
+  elapsedMs: number | null;
+  /** Redacted error message; null если status≠failed. */
+  error: string | null;
+}
+
+export interface OperationsLogReaderOptions {
+  app: App;
+  /** Journal path; defaults к \`.exocortex/switch-journal.jsonl\` (B.4 default). */
+  journalPath?: string;
+}
+
+const DEFAULT_JOURNAL_PATH = ".exocortex/switch-journal.jsonl";
+
+export class OperationsLogReader {
+  private readonly app: App;
+  private readonly journalPath: string;
+
+  constructor(options: OperationsLogReaderOptions) {
+    this.app = options.app;
+    this.journalPath = options.journalPath ?? DEFAULT_JOURNAL_PATH;
+  }
+
+  /**
+   * Read last \`limit\` switches from journal, newest first.
+   *
+   * @param limit Max entries to return. Default 10 (UI shows last 10).
+   * @param labelLookup Optional UID → label resolver. Pass plugin's
+   * profile-asset lookup; when omitted, label = UID[:8].
+   */
+  async readLast(
+    limit = 10,
+    labelLookup?: (uid: string) => string | null,
+  ): Promise<OperationsLogEntry[]> {
+    const lines = await this.readLines();
+    if (lines.length === 0) return [];
+
+    // Parse from end, accumulate up to `limit`
+    const entries: OperationsLogEntry[] = [];
+    for (let i = lines.length - 1; i >= 0 && entries.length < limit; i--) {
+      const parsed = OperationsLogReader.parseLine(lines[i]);
+      if (parsed === null) continue;
+      const label = labelLookup ? labelLookup(parsed.targetUid) : null;
+      entries.push({
+        ts: parsed.ts,
+        targetUid: parsed.targetUid,
+        profileLabel: label ?? parsed.targetUid.slice(0, 8),
+        status: parsed.phase,
+        elapsedMs: parsed.elapsedMs ?? null,
+        error: parsed.error ?? null,
+      });
+    }
+    return entries;
+  }
+
+  /** Format an entry for plain-text display в UI. */
+  static formatEntry(entry: OperationsLogEntry): string {
+    const ts = entry.ts;
+    const label = entry.profileLabel;
+    const elapsed = entry.elapsedMs !== null ? `${entry.elapsedMs}ms` : "—";
+    return `${ts} | ${label} | ${elapsed} | ${entry.status}`;
+  }
+
+  private async readLines(): Promise<string[]> {
+    try {
+      const exists = await this.app.vault.adapter.exists(this.journalPath);
+      if (!exists) return [];
+      const text = await this.app.vault.adapter.read(this.journalPath);
+      return text.split("\n").filter((l) => l.trim().length > 0);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Strict line parser. Returns null for malformed lines (caller skips them
+   * — don't throw, log lines may be partially corrupt после crash).
+   */
+  static parseLine(line: string): SwitchJournalEntry | null {
+    try {
+      const parsed = JSON.parse(line) as Partial<SwitchJournalEntry>;
+      if (
+        typeof parsed.phase !== "string" ||
+        typeof parsed.targetUid !== "string" ||
+        typeof parsed.ts !== "string"
+      ) {
+        return null;
+      }
+      const phaseOk = parsed.phase === "starting" || parsed.phase === "completed" || parsed.phase === "failed";
+      if (!phaseOk) return null;
+      return parsed as SwitchJournalEntry;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/LocalSecretsStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/LocalSecretsStore.test.ts
@@ -1,0 +1,144 @@
+import type { App } from "obsidian";
+
+import { LocalSecretsStore } from "../../src/infrastructure/adapters/LocalSecretsStore";
+
+function makeFakeApp(): { app: App; files: Map<string, string> } {
+  const files = new Map<string, string>();
+  const app = {
+    vault: {
+      configDir: ".obsidian",
+      adapter: {
+        exists: async (p: string) => files.has(p),
+        read: async (p: string) => {
+          const v = files.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+        write: async (p: string, d: string) => {
+          files.set(p, d);
+        },
+      },
+    },
+  } as unknown as App;
+  return { app, files };
+}
+
+const DEFAULT_PATH = ".obsidian/plugins/exocortex/data.local.json";
+
+describe("LocalSecretsStore.readAll", () => {
+  it("returns empty record when file does not exist", async () => {
+    const { app } = makeFakeApp();
+    const store = new LocalSecretsStore({ app });
+    expect(await store.readAll()).toEqual({});
+  });
+
+  it("returns parsed secrets from file", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(DEFAULT_PATH, JSON.stringify({ pat: "ghp_AAAA", other: "val" }));
+    const store = new LocalSecretsStore({ app });
+    expect(await store.readAll()).toEqual({ pat: "ghp_AAAA", other: "val" });
+  });
+
+  it("returns empty on malformed JSON", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(DEFAULT_PATH, "{ not json");
+    const store = new LocalSecretsStore({ app });
+    expect(await store.readAll()).toEqual({});
+  });
+
+  it("skips non-string values", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(DEFAULT_PATH, JSON.stringify({ pat: "ghp_X", count: 42, flag: true, nested: { foo: "bar" } }));
+    const store = new LocalSecretsStore({ app });
+    expect(await store.readAll()).toEqual({ pat: "ghp_X" });
+  });
+});
+
+describe("LocalSecretsStore.getSecret / setSecret", () => {
+  it("returns null for missing key", async () => {
+    const { app } = makeFakeApp();
+    const store = new LocalSecretsStore({ app });
+    expect(await store.getSecret("pat")).toBeNull();
+  });
+
+  it("sets and reads back a secret", async () => {
+    const { app } = makeFakeApp();
+    const store = new LocalSecretsStore({ app });
+    await store.setSecret("pat", "ghp_AAAA");
+    expect(await store.getSecret("pat")).toBe("ghp_AAAA");
+  });
+
+  it("overwrites existing secret value", async () => {
+    const { app } = makeFakeApp();
+    const store = new LocalSecretsStore({ app });
+    await store.setSecret("pat", "ghp_AAAA");
+    await store.setSecret("pat", "ghp_BBBB");
+    expect(await store.getSecret("pat")).toBe("ghp_BBBB");
+  });
+
+  it("deletes entry when value is null", async () => {
+    const { app } = makeFakeApp();
+    const store = new LocalSecretsStore({ app });
+    await store.setSecret("pat", "ghp_AAAA");
+    await store.setSecret("pat", null);
+    expect(await store.getSecret("pat")).toBeNull();
+    expect(await store.readAll()).toEqual({});
+  });
+
+  it("deletes entry when value is empty string", async () => {
+    const { app } = makeFakeApp();
+    const store = new LocalSecretsStore({ app });
+    await store.setSecret("pat", "ghp_AAAA");
+    await store.setSecret("pat", "");
+    expect(await store.getSecret("pat")).toBeNull();
+  });
+
+  it("setting one secret preserves others", async () => {
+    const { app } = makeFakeApp();
+    const store = new LocalSecretsStore({ app });
+    await store.setSecret("pat", "ghp_AAAA");
+    await store.setSecret("other", "VAL");
+    expect(await store.readAll()).toEqual({ pat: "ghp_AAAA", other: "VAL" });
+  });
+});
+
+describe("LocalSecretsStore.clearAll", () => {
+  it("removes all secrets", async () => {
+    const { app } = makeFakeApp();
+    const store = new LocalSecretsStore({ app });
+    await store.setSecret("a", "1");
+    await store.setSecret("b", "2");
+    await store.clearAll();
+    expect(await store.readAll()).toEqual({});
+  });
+});
+
+describe("LocalSecretsStore.mask", () => {
+  it("returns empty string for null/empty input", () => {
+    expect(LocalSecretsStore.mask(null)).toBe("");
+    expect(LocalSecretsStore.mask("")).toBe("");
+  });
+
+  it("masks short strings entirely (≤8 chars)", () => {
+    expect(LocalSecretsStore.mask("abc")).toBe("***");
+    expect(LocalSecretsStore.mask("12345678")).toBe("********");
+  });
+
+  it("shows last 4 chars for typical PAT-length secrets", () => {
+    const pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"; // 40 chars
+    const masked = LocalSecretsStore.mask(pat);
+    expect(masked.endsWith("AAAA")).toBe(true);
+    expect(masked.startsWith("*")).toBe(true);
+    expect(masked.length).toBe(pat.length);
+  });
+});
+
+describe("LocalSecretsStore custom path", () => {
+  it("honours custom path", async () => {
+    const { app, files } = makeFakeApp();
+    const store = new LocalSecretsStore({ app, path: "custom/secrets.json" });
+    await store.setSecret("pat", "ghp_X");
+    expect(files.has("custom/secrets.json")).toBe(true);
+    expect(files.has(DEFAULT_PATH)).toBe(false);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/OperationsLogReader.test.ts
+++ b/packages/obsidian-plugin/tests/unit/OperationsLogReader.test.ts
@@ -1,0 +1,181 @@
+import type { App } from "obsidian";
+
+import { OperationsLogReader } from "../../src/infrastructure/adapters/OperationsLogReader";
+
+function makeFakeApp(): { app: App; files: Map<string, string> } {
+  const files = new Map<string, string>();
+  const app = {
+    vault: {
+      adapter: {
+        exists: async (p: string) => files.has(p),
+        read: async (p: string) => {
+          const v = files.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+      },
+    },
+  } as unknown as App;
+  return { app, files };
+}
+
+const DEFAULT_PATH = ".exocortex/switch-journal.jsonl";
+
+function makeEntry(opts: {
+  phase: "starting" | "completed" | "failed";
+  targetUid: string;
+  ts: string;
+  elapsedMs?: number;
+  error?: string;
+}): string {
+  return JSON.stringify(opts);
+}
+
+describe("OperationsLogReader.readLast", () => {
+  it("returns empty array when journal does not exist", async () => {
+    const { app } = makeFakeApp();
+    const reader = new OperationsLogReader({ app });
+    expect(await reader.readLast()).toEqual([]);
+  });
+
+  it("returns empty array on empty journal file", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(DEFAULT_PATH, "");
+    const reader = new OperationsLogReader({ app });
+    expect(await reader.readLast()).toEqual([]);
+  });
+
+  it("returns last 10 entries newest-first", async () => {
+    const { app, files } = makeFakeApp();
+    const lines: string[] = [];
+    for (let i = 0; i < 15; i++) {
+      lines.push(makeEntry({
+        phase: "completed",
+        targetUid: `uid-${i}`,
+        ts: `2026-06-01T00:0${i % 10}:00.000Z`,
+        elapsedMs: i * 100,
+      }));
+    }
+    files.set(DEFAULT_PATH, lines.join("\n") + "\n");
+    const reader = new OperationsLogReader({ app });
+    const entries = await reader.readLast();
+    expect(entries).toHaveLength(10);
+    // newest first → uid-14
+    expect(entries[0].targetUid).toBe("uid-14");
+    expect(entries[9].targetUid).toBe("uid-5");
+  });
+
+  it("honours custom limit parameter", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(DEFAULT_PATH, [
+      makeEntry({ phase: "completed", targetUid: "u1", ts: "1", elapsedMs: 100 }),
+      makeEntry({ phase: "completed", targetUid: "u2", ts: "2", elapsedMs: 200 }),
+      makeEntry({ phase: "completed", targetUid: "u3", ts: "3", elapsedMs: 300 }),
+    ].join("\n"));
+    const reader = new OperationsLogReader({ app });
+    const entries = await reader.readLast(2);
+    expect(entries.map((e) => e.targetUid)).toEqual(["u3", "u2"]);
+  });
+
+  it("skips malformed lines silently", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(DEFAULT_PATH, [
+      makeEntry({ phase: "completed", targetUid: "u1", ts: "1", elapsedMs: 100 }),
+      "{ broken json",
+      makeEntry({ phase: "completed", targetUid: "u2", ts: "2", elapsedMs: 200 }),
+    ].join("\n"));
+    const reader = new OperationsLogReader({ app });
+    const entries = await reader.readLast();
+    // Both valid entries returned, malformed skipped
+    expect(entries.map((e) => e.targetUid)).toEqual(["u2", "u1"]);
+  });
+
+  it("uses labelLookup to resolve profile labels", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(DEFAULT_PATH, makeEntry({
+      phase: "completed",
+      targetUid: "long-uuid-here",
+      ts: "1",
+      elapsedMs: 100,
+    }));
+    const reader = new OperationsLogReader({ app });
+    const labels = new Map([["long-uuid-here", "profile-base"]]);
+    const entries = await reader.readLast(10, (uid) => labels.get(uid) ?? null);
+    expect(entries[0].profileLabel).toBe("profile-base");
+  });
+
+  it("falls back к UID[:8] when label lookup returns null", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(DEFAULT_PATH, makeEntry({
+      phase: "completed",
+      targetUid: "ae00f219-base-uid",
+      ts: "1",
+      elapsedMs: 100,
+    }));
+    const reader = new OperationsLogReader({ app });
+    const entries = await reader.readLast(10, () => null);
+    expect(entries[0].profileLabel).toBe("ae00f219");
+  });
+
+  it("preserves elapsedMs=null when entry lacks the field (e.g. starting/failed phases)", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(DEFAULT_PATH, [
+      makeEntry({ phase: "starting", targetUid: "u1", ts: "1" }),
+      makeEntry({ phase: "failed", targetUid: "u2", ts: "2", error: "boom" }),
+    ].join("\n"));
+    const reader = new OperationsLogReader({ app });
+    const entries = await reader.readLast();
+    expect(entries[0].status).toBe("failed");
+    expect(entries[0].elapsedMs).toBeNull();
+    expect(entries[0].error).toBe("boom");
+    expect(entries[1].elapsedMs).toBeNull();
+  });
+});
+
+describe("OperationsLogReader.parseLine", () => {
+  it("parses well-formed entry", () => {
+    const line = makeEntry({ phase: "completed", targetUid: "u", ts: "t", elapsedMs: 5 });
+    const parsed = OperationsLogReader.parseLine(line);
+    expect(parsed).toEqual({ phase: "completed", targetUid: "u", ts: "t", elapsedMs: 5 });
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(OperationsLogReader.parseLine("not json")).toBeNull();
+  });
+
+  it("returns null for missing required fields", () => {
+    expect(OperationsLogReader.parseLine(JSON.stringify({ phase: "completed" }))).toBeNull();
+    expect(OperationsLogReader.parseLine(JSON.stringify({ targetUid: "u" }))).toBeNull();
+  });
+
+  it("returns null for unknown phase value", () => {
+    const line = JSON.stringify({ phase: "weird", targetUid: "u", ts: "t" });
+    expect(OperationsLogReader.parseLine(line)).toBeNull();
+  });
+});
+
+describe("OperationsLogReader.formatEntry", () => {
+  it("formats entry as pipe-delimited string", () => {
+    const formatted = OperationsLogReader.formatEntry({
+      ts: "2026-06-01T00:00:00Z",
+      targetUid: "u",
+      profileLabel: "profile-base",
+      status: "completed",
+      elapsedMs: 150,
+      error: null,
+    });
+    expect(formatted).toBe("2026-06-01T00:00:00Z | profile-base | 150ms | completed");
+  });
+
+  it("substitutes — when elapsedMs is null", () => {
+    const formatted = OperationsLogReader.formatEntry({
+      ts: "t",
+      targetUid: "u",
+      profileLabel: "profile-base",
+      status: "failed",
+      elapsedMs: null,
+      error: "boom",
+    });
+    expect(formatted).toContain("| — |");
+  });
+});


### PR DESCRIPTION
## Summary

Helper classes для B.8 Settings UI 4-section tab (RFC 0a0791c1 §B.8):
- **LocalSecretsStore** — `data.local.json` PAT persistence (Vision Lock #1, Security #1: NOT in Obsidian Sync)
- **OperationsLogReader** — B.4 switch journal formatter для UI Operations log section

## Why helpers shipped here, UI tab in B.11

The HTML rendering layer (Setting builder calls, password input, dropdown, button) requires real `PluginSettingTab` extending Obsidian's UI API. That wiring lives в B.11 plugin integration where all components get instantiated together. B.8 ships the **persistence + read-format logic** that the future tab will consume — testable in isolation, frozen API surface for B.11.

## Tests
29 unit tests:
- **LocalSecretsStore**: readAll empty/parsed/malformed/typed; getSecret/setSecret overwrite/delete-on-null/preserve-others; clearAll; mask short/typical; custom path
- **OperationsLogReader**: empty/missing-file/last-10-newest-first/custom-limit/skip-malformed/labelLookup/UID-fallback/elapsedMs-null; parseLine strict; formatEntry

## Compliance
- `obsidianmd/hardcoded-config-path` eslint rule — uses runtime `app.vault.configDir` for default path
- `archgate` SEC-001 — no Math.random / weak hashes in this code

Related: RFC 0a0791c1 Phase B.8