### PR TITLE
feat(plugin): wire effective ontology filter through NoteToRDFConverter (#3321)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -245,6 +245,7 @@ export {
   NoteToRDFConverter,
   normaliseExcludedFolders,
   isPathExcluded,
+  shouldSkipFileForEffectiveSet,
   type ExocortexInvariantCode,
   type ExocortexInvariantViolation,
 } from "./services/NoteToRDFConverter";

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -101,6 +101,60 @@ export function isPathExcluded(
 }
 
 /**
+ * Vault-relative path prefix under which AssetSpace folders live. Files whose
+ * vault path starts with this prefix are subject to the effective-ontology
+ * filter (Issue #3321 — RFC 0a0791c1). Files outside this prefix
+ * (`03 Knowledge/`, `01 Inbox/`, etc.) are always emitted regardless of the
+ * active profile.
+ */
+const ASSET_SPACES_PATH_PREFIX = "assetspaces/";
+
+/**
+ * Decide whether a vault file should be skipped given the active effective
+ * ontology / AssetSpace set and a precomputed folder→UID lookup map.
+ *
+ * Rules (Issue #3321 / RFC 0a0791c1 §Backward-compat strategy):
+ *   - Files outside `assetspaces/` → always include (never filtered).
+ *   - Files inside `assetspaces/<folder>/` whose folder maps to an AssetSpace
+ *     UID NOT in `effective` → skip (no triples emitted).
+ *   - Files inside `assetspaces/<folder>/` whose folder is unrecognised
+ *     (absent from `assetSpaceFolderToUid`) → include (treat unknown folder
+ *     as a regular path; defensive — caller may have an out-of-date map).
+ *
+ * Caller-side responsibilities:
+ *   - The `effective` set must already include any required floor (e.g.
+ *     `$exo`, `$exocmd`, `$shared-identities`) per Vision Lock #17. The
+ *     converter does NOT re-inject the floor.
+ *   - The map must be precomputed once per indexing pass; per-file scanning
+ *     of the vault would be O(N²).
+ */
+export function shouldSkipFileForEffectiveSet(
+  filePath: string,
+  effective: ReadonlySet<string>,
+  assetSpaceFolderToUid: ReadonlyMap<string, string>,
+): boolean {
+  const normalised = filePath.replace(/\\/g, "/");
+  if (!normalised.startsWith(ASSET_SPACES_PATH_PREFIX)) {
+    return false;
+  }
+  // Extract `assetspaces/<folder>` — everything up to (but not including) the
+  // second slash. A file directly under `assetspaces/` (no nested folder) has
+  // no AssetSpace owner and is not filtered.
+  const rest = normalised.slice(ASSET_SPACES_PATH_PREFIX.length);
+  const slashIdx = rest.indexOf("/");
+  if (slashIdx < 0) {
+    return false;
+  }
+  const folder = `${ASSET_SPACES_PATH_PREFIX}${rest.slice(0, slashIdx)}`;
+  const asUid = assetSpaceFolderToUid.get(folder);
+  if (asUid === undefined) {
+    // Folder not recognised as AssetSpace — emit (defensive).
+    return false;
+  }
+  return !effective.has(asUid);
+}
+
+/**
  * Service for converting Obsidian notes (frontmatter + wikilinks) to RDF triples.
  *
  * @example
@@ -554,6 +608,21 @@ export class NoteToRDFConverter {
    *   prefixes; any file whose path starts with one of these prefixes is
    *   skipped without validation and without producing a warn-log entry. See
    *   {@link convertVaultWithValidation} for full semantics.
+   * @param options.effectiveOntologies - Issue #3321 / RFC 0a0791c1.
+   *   Optional AssetSpace UID allow-set: when defined, files under
+   *   `assetspaces/<folder>/` whose AssetSpace UID is NOT in this set are
+   *   skipped. `undefined` → no filter (backward-compatible behaviour).
+   *   An empty set is treated as a catastrophic profile configuration and
+   *   triggers a fall-back to the no-filter path with a warn-log entry
+   *   (R15 plugin self-brick mitigation).
+   *   Despite the name, comparison is performed against AssetSpace UIDs
+   *   (not ontology URIs). See follow-up Issue #3324 for the URI/UID
+   *   reconciliation question on `FocusProfileSwitchManager.TS_FLOOR_*`.
+   * @param options.assetSpaceFolderToUid - Issue #3321. Precomputed
+   *   mapping `assetspaces/<folder>` → AssetSpace UID, used by the filter
+   *   to resolve each file's owning AssetSpace in O(1). Only consulted
+   *   when `effectiveOntologies` is defined; absent map degrades to the
+   *   no-filter path (caller bug — logged at warn level).
    * @returns Array of all RDF triples from the vault
    *
    * @example
@@ -563,14 +632,26 @@ export class NoteToRDFConverter {
    *
    * // Skip the user-managed templates folder:
    * await converter.convertVault({ excludedFolders: ["09 Templates/"] });
+   *
+   * // Apply an active focus profile's effective AssetSpace set:
+   * await converter.convertVault({
+   *   effectiveOntologies: new Set([emsUid, exoUid, exocmdUid]),
+   *   assetSpaceFolderToUid: folderMap,
+   * });
    * ```
    */
   async convertVault(
-    options: { excludedFolders?: string[] } = {},
+    options: {
+      excludedFolders?: string[];
+      effectiveOntologies?: ReadonlySet<string>;
+      assetSpaceFolderToUid?: ReadonlyMap<string, string>;
+    } = {},
   ): Promise<Triple[]> {
     const result = await this.convertVaultWithValidation({
       strict: false,
       excludedFolders: options.excludedFolders,
+      effectiveOntologies: options.effectiveOntologies,
+      assetSpaceFolderToUid: options.assetSpaceFolderToUid,
     });
     return result.triples;
   }
@@ -649,7 +730,12 @@ export class NoteToRDFConverter {
    * @throws Error if strict mode is enabled and an invalid IRI is encountered
    */
   async convertVaultWithValidation(
-    options: { strict?: boolean; excludedFolders?: string[] } = {}
+    options: {
+      strict?: boolean;
+      excludedFolders?: string[];
+      effectiveOntologies?: ReadonlySet<string>;
+      assetSpaceFolderToUid?: ReadonlyMap<string, string>;
+    } = {}
   ): Promise<{
     triples: Triple[];
     skippedFiles: Array<{ path: string; reason: string }>;
@@ -661,17 +747,64 @@ export class NoteToRDFConverter {
     const strict = options.strict ?? false;
     const excludedPrefixes = normaliseExcludedFolders(options.excludedFolders);
 
+    // Issue #3321 / RFC 0a0791c1 — resolve the AssetSpace filter once before
+    // the loop. The filter is engaged only when:
+    //   * `effectiveOntologies` is defined (caller opted in), AND
+    //   * the set is non-empty (empty set ⇒ catastrophic profile config —
+    //     R15 self-brick mitigation: warn + fall back to no-filter), AND
+    //   * a folder→UID map is available (without it the filter cannot
+    //     resolve which AssetSpace owns a given file).
+    const effective = options.effectiveOntologies;
+    const folderMap = options.assetSpaceFolderToUid;
+    // `engagedFilter` is non-null IFF the effective-set filter is in play
+    // for this conversion pass. Bundling the set + map together avoids the
+    // two non-null assertions that would otherwise appear at each filter
+    // call site, and makes the engagement contract explicit at the type
+    // level (`filter is null` ⇒ "no filter active").
+    let engagedFilter: {
+      effective: ReadonlySet<string>;
+      folderMap: ReadonlyMap<string, string>;
+    } | null = null;
+    if (effective !== undefined) {
+      if (effective.size === 0) {
+        this.logger.warn(
+          "[NoteToRDFConverter] effectiveOntologies is empty — falling back to no-filter path to avoid plugin self-brick. " +
+          "Verify the active focus profile's _includes / _extends / _alwaysOnOverlay properties.",
+        );
+      } else if (folderMap === undefined) {
+        this.logger.warn(
+          "[NoteToRDFConverter] effectiveOntologies provided without assetSpaceFolderToUid map — falling back to no-filter. " +
+          "Caller must precompute the folder→UID map (see AssetSpaceManager).",
+        );
+      } else {
+        engagedFilter = { effective, folderMap };
+      }
+    }
+
     // Folder-level exclusion: drop files whose vault path starts with any
     // configured prefix BEFORE validation. Excluded files are intentionally
     // invisible to the rest of the pipeline (no warn-log, no skippedFiles
     // record, no `summary.total` contribution) — they are treated as if they
     // never existed in the vault. This is the user-facing escape hatch for
     // template folders whose contents violate Exocortex invariants by design.
-    const files = excludedPrefixes.length === 0
+    //
+    // The effective-set filter (Issue #3321) layers on top: files surviving
+    // the exclude-folders pass are then checked against the active profile.
+    // Filtered-out AssetSpace files are also invisible (no warn, no skipped
+    // record) — the active profile semantically declares them "not in scope",
+    // not "broken".
+    let files = excludedPrefixes.length === 0
       ? allFiles
       : allFiles.filter(
           (file) => !isPathExcluded(file.path, excludedPrefixes),
         );
+
+    if (engagedFilter !== null) {
+      const { effective: eff, folderMap: fm } = engagedFilter;
+      files = files.filter(
+        (file) => !shouldSkipFileForEffectiveSet(file.path, eff, fm),
+      );
+    }
 
     for (const file of files) {
       try {

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.effective-ontologies.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.effective-ontologies.test.ts
@@ -1,0 +1,380 @@
+import "reflect-metadata";
+import {
+  NoteToRDFConverter,
+  shouldSkipFileForEffectiveSet,
+} from "../../../src/services/NoteToRDFConverter";
+import {
+  IVaultAdapter,
+  IFile,
+  IFrontmatter,
+} from "../../../src/interfaces/IVaultAdapter";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+
+/**
+ * Issue #3321 / RFC 0a0791c1 — NoteToRDFConverter must honour an optional
+ * effective-ontology filter that mirrors the active FocusProfile's allow-set.
+ * Files under `assetspaces/<folder>/` whose owning AssetSpace UID is NOT in
+ * the set are skipped silently; files outside `assetspaces/` are always
+ * emitted.
+ *
+ * These tests intentionally drive `convertVault` (not just the pure helper)
+ * so we exercise the filter through the public API surface the plugin wires
+ * via `VaultRDFIndexer`.
+ */
+
+function createMockLogger(): jest.Mocked<ILogger> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+function file(path: string): IFile {
+  const parts = path.split("/");
+  const name = parts[parts.length - 1];
+  return {
+    path,
+    basename: name.replace(/\.md$/, ""),
+    name,
+    parent: null,
+  };
+}
+
+// AssetSpace UIDs lifted from real vault data (profile-base
+// `_alwaysOnOverlay` in `assetspaces/shared-identities/ae00f219-...md`).
+const EXO_AS_UID = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
+const EXOCMD_AS_UID = "60967c6a-4e8a-4ee3-8922-db98b981e4f4";
+const SHARED_AS_UID = "d1195402-73a5-45ed-965f-3a435a553e6a";
+const EMS_AS_UID = "11111111-2222-3333-4444-555555555555"; // synthetic — not in test set
+
+const validFrontmatter: IFrontmatter = {
+  exo__Asset_uid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  exo__Asset_label: "Real Task",
+  exo__Instance_class: ["[[ems__Task]]"],
+};
+
+describe("NoteToRDFConverter — effectiveOntologies (Issue #3321)", () => {
+  let converter: NoteToRDFConverter;
+  let logger: jest.Mocked<ILogger>;
+  let mockVault: jest.Mocked<IVaultAdapter>;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    mockVault = {
+      getFrontmatter: jest.fn(),
+      getAllFiles: jest.fn(),
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      updateLinks: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+    } as jest.Mocked<IVaultAdapter>;
+    converter = new NoteToRDFConverter(mockVault, logger);
+  });
+
+  describe("shouldSkipFileForEffectiveSet (pure helper)", () => {
+    const folderMap = new Map<string, string>([
+      ["assetspaces/exo", EXO_AS_UID],
+      ["assetspaces/exocmd", EXOCMD_AS_UID],
+      ["assetspaces/ems", EMS_AS_UID],
+      ["assetspaces/shared-identities", SHARED_AS_UID],
+    ]);
+
+    it("returns false for files outside `assetspaces/` regardless of the set", () => {
+      const empty = new Set<string>();
+      expect(
+        shouldSkipFileForEffectiveSet(
+          "03 Knowledge/inbox/note.md",
+          empty,
+          folderMap,
+        ),
+      ).toBe(false);
+      expect(
+        shouldSkipFileForEffectiveSet(
+          "01 Inbox/quick.md",
+          new Set([EXO_AS_UID]),
+          folderMap,
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false for files directly under `assetspaces/` with no nested folder", () => {
+      // No AssetSpace folder → no owner → emit (defensive).
+      expect(
+        shouldSkipFileForEffectiveSet(
+          "assetspaces/loose-file.md",
+          new Set([EXO_AS_UID]),
+          folderMap,
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when the AssetSpace UID IS in the effective set", () => {
+      const eff = new Set([EXO_AS_UID, EXOCMD_AS_UID, SHARED_AS_UID]);
+      expect(
+        shouldSkipFileForEffectiveSet(
+          "assetspaces/exo/Class.md",
+          eff,
+          folderMap,
+        ),
+      ).toBe(false);
+    });
+
+    it("returns true when the AssetSpace UID is NOT in the effective set", () => {
+      const eff = new Set([EXO_AS_UID, EXOCMD_AS_UID, SHARED_AS_UID]);
+      // ems is mapped but not in the active set → skip.
+      expect(
+        shouldSkipFileForEffectiveSet(
+          "assetspaces/ems/Task.md",
+          eff,
+          folderMap,
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false when the folder is NOT in the map (unknown AssetSpace — defensive emit)", () => {
+      const eff = new Set([EXO_AS_UID]);
+      // `assetspaces/strange-folder` is not mapped → treat as unknown, emit.
+      expect(
+        shouldSkipFileForEffectiveSet(
+          "assetspaces/strange-folder/x.md",
+          eff,
+          folderMap,
+        ),
+      ).toBe(false);
+    });
+
+    it("normalises backslashes before matching", () => {
+      const eff = new Set([EXO_AS_UID]);
+      // Defensive: stray backslash in a synthetic path → still routes to ems.
+      expect(
+        shouldSkipFileForEffectiveSet(
+          "assetspaces\\ems\\Task.md",
+          eff,
+          folderMap,
+        ),
+      ).toBe(true);
+    });
+
+    it("is case-sensitive on AssetSpace UIDs (Set comparison is exact)", () => {
+      const eff = new Set([EXO_AS_UID.toUpperCase()]);
+      // Map stores the lowercase form; uppercase in set → no match → skip.
+      expect(
+        shouldSkipFileForEffectiveSet(
+          "assetspaces/exo/Class.md",
+          eff,
+          folderMap,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("convertVault — filter engagement contract", () => {
+    it("indexes the full vault when `effectiveOntologies` is undefined (backward-compat)", async () => {
+      const exoFile = file("assetspaces/exo/Class.md");
+      const emsFile = file("assetspaces/ems/Task.md");
+      const knowFile = file("03 Knowledge/note.md");
+      mockVault.getAllFiles.mockReturnValue([exoFile, emsFile, knowFile]);
+      mockVault.getFrontmatter.mockReturnValue(validFrontmatter);
+
+      // Use `convertVaultWithValidation` to get a deterministic
+      // summary.total — the convertVault wrapper discards it. Counting
+      // raw `getFrontmatter` calls is fragile because `convertNote`
+      // re-reads frontmatter internally (validate + convert).
+      const result = await converter.convertVaultWithValidation({});
+
+      expect(result.summary.total).toBe(3);
+      expect(result.summary.indexed).toBe(3);
+      expect(result.summary.skipped).toBe(0);
+    });
+
+    it("indexes the full vault when called with no options (legacy call shape)", async () => {
+      const exoFile = file("assetspaces/exo/Class.md");
+      const emsFile = file("assetspaces/ems/Task.md");
+      mockVault.getAllFiles.mockReturnValue([exoFile, emsFile]);
+      mockVault.getFrontmatter.mockReturnValue(validFrontmatter);
+
+      // Call without ANY options — pre-#3321 call shape.
+      const triples = await converter.convertVault();
+
+      // Both files contributed triples; backward-compat preserved.
+      expect(triples.length).toBeGreaterThan(0);
+      expect(mockVault.getAllFiles).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips files inside an AssetSpace folder absent from the effective set", async () => {
+      const exoFile = file("assetspaces/exo/Class.md");
+      const emsFile = file("assetspaces/ems/Task.md");
+      const knowFile = file("03 Knowledge/note.md");
+      mockVault.getAllFiles.mockReturnValue([exoFile, emsFile, knowFile]);
+      mockVault.getFrontmatter.mockReturnValue(validFrontmatter);
+
+      const folderMap = new Map<string, string>([
+        ["assetspaces/exo", EXO_AS_UID],
+        ["assetspaces/ems", EMS_AS_UID],
+      ]);
+      const effective = new Set<string>([EXO_AS_UID]);
+
+      const result = await converter.convertVaultWithValidation({
+        effectiveOntologies: effective,
+        assetSpaceFolderToUid: folderMap,
+      });
+
+      // exo (in set) + knowFile (non-assetspaces) survive; ems is
+      // pre-filtered (silently — not in skippedFiles).
+      expect(result.summary.total).toBe(2);
+      expect(result.summary.indexed).toBe(2);
+      expect(result.summary.skipped).toBe(0);
+      expect(result.skippedFiles).toEqual([]);
+
+      // Verify the ems file path never reached convertNote — using a
+      // set of unique paths the mock saw (deduped because convertNote
+      // reads frontmatter twice per file).
+      const visitedPaths = new Set(
+        mockVault.getFrontmatter.mock.calls.map(
+          (c) => (c[0] as IFile).path,
+        ),
+      );
+      expect(visitedPaths.has(exoFile.path)).toBe(true);
+      expect(visitedPaths.has(knowFile.path)).toBe(true);
+      expect(visitedPaths.has(emsFile.path)).toBe(false);
+    });
+
+    it("always emits files outside `assetspaces/` regardless of the filter", async () => {
+      const knowFile = file("03 Knowledge/note.md");
+      const inboxFile = file("01 Inbox/quick.md");
+      mockVault.getAllFiles.mockReturnValue([knowFile, inboxFile]);
+      mockVault.getFrontmatter.mockReturnValue(validFrontmatter);
+
+      // Filter active but only `assetspaces/exo` is in the map; the two
+      // non-assetspaces files bypass the filter entirely.
+      const folderMap = new Map<string, string>([
+        ["assetspaces/exo", EXO_AS_UID],
+      ]);
+      const result = await converter.convertVaultWithValidation({
+        effectiveOntologies: new Set<string>([EXO_AS_UID]),
+        assetSpaceFolderToUid: folderMap,
+      });
+
+      expect(result.summary.total).toBe(2);
+      expect(result.summary.indexed).toBe(2);
+    });
+
+    it("falls back to no-filter (warn-logged) when the effective set is empty (R15 self-brick guard)", async () => {
+      const exoFile = file("assetspaces/exo/Class.md");
+      const emsFile = file("assetspaces/ems/Task.md");
+      const knowFile = file("03 Knowledge/note.md");
+      mockVault.getAllFiles.mockReturnValue([exoFile, emsFile, knowFile]);
+      mockVault.getFrontmatter.mockReturnValue(validFrontmatter);
+
+      const folderMap = new Map<string, string>([
+        ["assetspaces/exo", EXO_AS_UID],
+        ["assetspaces/ems", EMS_AS_UID],
+      ]);
+      const empty = new Set<string>();
+
+      const result = await converter.convertVaultWithValidation({
+        effectiveOntologies: empty,
+        assetSpaceFolderToUid: folderMap,
+      });
+
+      // Filter NOT engaged → every file is indexed (full vault).
+      expect(result.summary.total).toBe(3);
+      // Warn-log entry surfaced explaining the fall-back.
+      const warned = logger.warn.mock.calls.some((c) =>
+        typeof c[0] === "string"
+          ? c[0].includes("effectiveOntologies is empty")
+          : false,
+      );
+      expect(warned).toBe(true);
+    });
+
+    it("falls back to no-filter (warn-logged) when the folder map is missing (caller bug)", async () => {
+      const exoFile = file("assetspaces/exo/Class.md");
+      const emsFile = file("assetspaces/ems/Task.md");
+      mockVault.getAllFiles.mockReturnValue([exoFile, emsFile]);
+      mockVault.getFrontmatter.mockReturnValue(validFrontmatter);
+
+      // effectiveOntologies non-empty but no folder map → cannot resolve
+      // ownership → fall back rather than skip everything.
+      const result = await converter.convertVaultWithValidation({
+        effectiveOntologies: new Set<string>([EXO_AS_UID]),
+      });
+
+      expect(result.summary.total).toBe(2);
+      const warned = logger.warn.mock.calls.some((c) =>
+        typeof c[0] === "string"
+          ? c[0].includes("without assetSpaceFolderToUid")
+          : false,
+      );
+      expect(warned).toBe(true);
+    });
+
+    it("composes with `excludedFolders` (exclusion first, then effective-set filter)", async () => {
+      const templatesFile = file("09 Templates/broken.md");
+      const exoFile = file("assetspaces/exo/Class.md");
+      const emsFile = file("assetspaces/ems/Task.md");
+      mockVault.getAllFiles.mockReturnValue([templatesFile, exoFile, emsFile]);
+      mockVault.getFrontmatter.mockReturnValue(validFrontmatter);
+
+      const folderMap = new Map<string, string>([
+        ["assetspaces/exo", EXO_AS_UID],
+        ["assetspaces/ems", EMS_AS_UID],
+      ]);
+      const result = await converter.convertVaultWithValidation({
+        excludedFolders: ["09 Templates/"],
+        effectiveOntologies: new Set<string>([EXO_AS_UID]),
+        assetSpaceFolderToUid: folderMap,
+      });
+
+      // templates excluded by prefix; ems filtered by effective-set;
+      // only exo file reaches convertNote.
+      expect(result.summary.total).toBe(1);
+      const visitedPaths = new Set(
+        mockVault.getFrontmatter.mock.calls.map(
+          (c) => (c[0] as IFile).path,
+        ),
+      );
+      expect(visitedPaths.has(exoFile.path)).toBe(true);
+      expect(visitedPaths.has(templatesFile.path)).toBe(false);
+      expect(visitedPaths.has(emsFile.path)).toBe(false);
+    });
+  });
+
+  describe("convertVaultWithValidation — summary accounting under filter", () => {
+    it("excludes filtered-out files from summary.total (silent skip, like excludedFolders)", async () => {
+      const exoFile = file("assetspaces/exo/Class.md");
+      const emsFile = file("assetspaces/ems/Task.md");
+      mockVault.getAllFiles.mockReturnValue([exoFile, emsFile]);
+      mockVault.getFrontmatter.mockReturnValue(validFrontmatter);
+
+      const folderMap = new Map<string, string>([
+        ["assetspaces/exo", EXO_AS_UID],
+        ["assetspaces/ems", EMS_AS_UID],
+      ]);
+      const result = await converter.convertVaultWithValidation({
+        effectiveOntologies: new Set<string>([EXO_AS_UID]),
+        assetSpaceFolderToUid: folderMap,
+      });
+
+      // exo IS in set + knowFile would be (none here) → total = 1.
+      // ems is silently skipped (semantically out-of-scope, not "broken").
+      expect(result.summary.total).toBe(1);
+      expect(result.summary.indexed).toBe(1);
+      expect(result.summary.skipped).toBe(0);
+      // Filtered files MUST NOT appear in skippedFiles diagnostic —
+      // they are not "failed validation", they are "out of scope".
+      expect(result.skippedFiles).toEqual([]);
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -107,6 +107,15 @@ export class VaultRDFIndexer {
    * Does NOT trigger reindexing — callers control ordering. Typical flow:
    *   `indexer.setEffectiveOntologies(set)` then `indexer.refresh()`.
    * Or use {@link refresh}'s single-arg form which combines both.
+   *
+   * **Ordering invariant** (Issue #3321): the filter engages only when
+   * BOTH this set is non-empty AND {@link setAssetSpaceFolderToUid} has
+   * been called with a non-null map. A `setEffectiveOntologies(set)`
+   * before the folder map is wired triggers the R15 fall-back at the
+   * next `initialize()` / `refresh()` — the converter logs a warn and
+   * indexes the full vault. This is intentional graceful degradation;
+   * production wiring should call both setters at onload before the
+   * first walk.
    */
   setEffectiveOntologies(set: ReadonlySet<string> | null): void {
     this.effectiveOntologies = set;
@@ -121,7 +130,8 @@ export class VaultRDFIndexer {
    * they change at different cadences and originate from different
    * subsystems (vault topology vs active FocusProfile). The
    * {@link NoteToRDFConverter} requires BOTH to engage the filter;
-   * absence of either degrades to the no-filter fall-back.
+   * absence of either degrades to the no-filter fall-back via the
+   * converter's R15 warn-log.
    */
   setAssetSpaceFolderToUid(map: ReadonlyMap<string, string> | null): void {
     this.assetSpaceFolderToUid = map;

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -13,6 +13,7 @@ import {
   ServiceError,
   isPathExcluded,
   normaliseExcludedFolders,
+  shouldSkipFileForEffectiveSet,
   type ILogger,
   type INotificationService,
   type IFile,
@@ -20,21 +21,6 @@ import {
 } from "exocortex";
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
 import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
-
-/**
- * Effective ontology filter context (Issue #3321 / RFC 0a0791c1). Captures the
- * `effectiveOntologies` allow-set AND the `folder → AssetSpace UID` map that
- * the converter needs to resolve which AssetSpace owns a given file. The two
- * fields travel together because the filter is meaningless without the map.
- *
- * Stored as a snapshot inside the indexer so that mid-session reindexing
- * (`refresh()` re-runs after a profile switch OR per-file `updateFile` events)
- * applies the active filter consistently.
- */
-export interface EffectiveOntologyFilter {
-  effectiveOntologies: ReadonlySet<string>;
-  assetSpaceFolderToUid: ReadonlyMap<string, string>;
-}
 
 export class VaultRDFIndexer {
   private tripleStore: InMemoryTripleStore;
@@ -52,18 +38,29 @@ export class VaultRDFIndexer {
    */
   private readonly excludedFolders: string[];
   /**
-   * Active effective-ontology filter snapshot (Issue #3321). `null` means
-   * no filter is in effect — index the full vault (backward-compatible
-   * pre-#3321 behaviour). Updated by `setFilter()` and consumed by
-   * `initialize()` / `refresh()` / per-file `updateFile()`.
+   * Active effective-ontology allow-set (Issue #3321). `null` means no
+   * filter is in effect — index the full vault (pre-#3321 behaviour).
    *
-   * Per-file updateFile events do NOT currently re-filter against this
-   * snapshot — files surviving the initial walk are assumed to stay in
-   * scope until the next full reindex. This matches the pre-#3321
-   * `excludedFolders` event semantics. A profile switch triggers a full
-   * `refresh()` which re-runs the walk with the current filter.
+   * Stored separately from {@link assetSpaceFolderToUid} because the two
+   * arrive from different sources at different cadences:
+   *   - `effectiveOntologies` is driven by the active FocusProfile (changes
+   *     when the user switches profiles).
+   *   - `assetSpaceFolderToUid` is vault topology (changes when an
+   *     AssetSpace is added/removed — rare).
+   *
+   * Splitting the two also allows the indexer to satisfy the
+   * `IRdfIndexer.refresh(effectiveOntologies)` contract from B.4 without
+   * forcing FocusProfileSwitchManager to know about the folder map.
    */
-  private filter: EffectiveOntologyFilter | null = null;
+  private effectiveOntologies: ReadonlySet<string> | null = null;
+  /**
+   * Precomputed mapping `assetspaces/<folder>` → AssetSpace UID. Populated
+   * by the plugin from {@link AssetSpaceManager.lookupAssetSpaceForPath}
+   * once at onload and on AssetSpace topology changes. `null` means the
+   * map has not been wired yet — the filter (if any) degrades to the
+   * no-filter fall-back path with a warn-log (per converter R15 guard).
+   */
+  private assetSpaceFolderToUid: ReadonlyMap<string, string> | null = null;
 
   constructor(
     private app: App,
@@ -104,20 +101,40 @@ export class VaultRDFIndexer {
   }
 
   /**
-   * Update the active effective-ontology filter snapshot (Issue #3321).
-   * Pass `null` to clear the filter (revert to indexing the full vault).
+   * Set the active effective-ontology allow-set. Pass `null` to clear the
+   * filter (revert to indexing the full vault).
    *
-   * Does NOT trigger reindexing — callers (typically
-   * {@link FocusProfileSwitchManager.switchProfile}) call `setFilter(...)`
-   * then `refresh()` so the two operations happen in a controlled order.
+   * Does NOT trigger reindexing — callers control ordering. Typical flow:
+   *   `indexer.setEffectiveOntologies(set)` then `indexer.refresh()`.
+   * Or use {@link refresh}'s single-arg form which combines both.
    */
-  setFilter(filter: EffectiveOntologyFilter | null): void {
-    this.filter = filter;
+  setEffectiveOntologies(set: ReadonlySet<string> | null): void {
+    this.effectiveOntologies = set;
   }
 
-  /** Test helper — current filter snapshot. */
-  getFilter(): EffectiveOntologyFilter | null {
-    return this.filter;
+  /**
+   * Set the precomputed `assetspaces/<folder>` → AssetSpace UID map. The
+   * plugin updates this when the vault's AssetSpace topology changes
+   * (rarely) and at onload. Pass `null` to clear.
+   *
+   * The folder map and the effective-ontology set are decoupled because
+   * they change at different cadences and originate from different
+   * subsystems (vault topology vs active FocusProfile). The
+   * {@link NoteToRDFConverter} requires BOTH to engage the filter;
+   * absence of either degrades to the no-filter fall-back.
+   */
+  setAssetSpaceFolderToUid(map: ReadonlyMap<string, string> | null): void {
+    this.assetSpaceFolderToUid = map;
+  }
+
+  /** Test/debug helper — current effective set snapshot. */
+  getEffectiveOntologies(): ReadonlySet<string> | null {
+    return this.effectiveOntologies;
+  }
+
+  /** Test/debug helper — current folder→UID map snapshot. */
+  getAssetSpaceFolderToUid(): ReadonlyMap<string, string> | null {
+    return this.assetSpaceFolderToUid;
   }
 
   async initialize(): Promise<void> {
@@ -129,8 +146,8 @@ export class VaultRDFIndexer {
       const triples = await this.errorHandler.executeWithRetry(
         async () => this.converter.convertVault({
           excludedFolders: this.excludedFolders,
-          effectiveOntologies: this.filter?.effectiveOntologies,
-          assetSpaceFolderToUid: this.filter?.assetSpaceFolderToUid,
+          effectiveOntologies: this.effectiveOntologies ?? undefined,
+          assetSpaceFolderToUid: this.assetSpaceFolderToUid ?? undefined,
         }),
         { context: "VaultRDFIndexer.initialize", operation: "convertVault" }
       );
@@ -243,6 +260,30 @@ export class VaultRDFIndexer {
       return;
     }
 
+    // Issue #3321 — same guard for the effective-ontology filter. Without
+    // this, an edit to a file in a filtered-OUT AssetSpace would index
+    // its triples and gradually drift away from the snapshot the most
+    // recent `refresh(effectiveOntologies)` walked. We also remove any
+    // stale triples for the path defensively (covers the case where the
+    // file was indexed BEFORE the user activated a profile that excludes
+    // it). The filter engages only when BOTH the effective set is non-
+    // empty AND the folder map is wired — mirroring the converter's
+    // engagement contract (`shouldSkipFileForEffectiveSet` is a no-op
+    // unless the file lives under `assetspaces/<folder>/`).
+    if (
+      this.effectiveOntologies !== null &&
+      this.effectiveOntologies.size > 0 &&
+      this.assetSpaceFolderToUid !== null &&
+      shouldSkipFileForEffectiveSet(
+        file.path,
+        this.effectiveOntologies,
+        this.assetSpaceFolderToUid,
+      )
+    ) {
+      await this.removeFileTriples(file.path);
+      return;
+    }
+
     await this.errorHandler.executeWithRetry(
       async () => {
         const fileIRI = new IRI(`obsidian://vault/${encodeURI(file.path)}`);
@@ -292,30 +333,34 @@ export class VaultRDFIndexer {
   /**
    * Clear the triple store and rebuild from the current vault state.
    *
-   * Issue #3321 / RFC 0a0791c1 — accepts an optional `filter` argument so a
-   * profile switch (via {@link FocusProfileSwitchManager.switchProfile})
-   * can atomically update the snapshot and reindex in one call. Pattern:
-   *   - `refresh()` — reindex with the previously-stored filter (or none).
-   *   - `refresh(filter)` — update the stored filter, then reindex. Pass
-   *      a `null`-like sentinel via `setFilter(null)` if you want to clear
-   *      the filter; `refresh()` without args does NOT clear the snapshot.
+   * Issue #3321 / RFC 0a0791c1 — signature matches
+   * {@link IRdfIndexer.refresh} from B.4 so a `FocusProfileSwitchManager`
+   * instance can drive a profile-switch reindex by calling
+   * `await rdfIndexer.refresh(effectiveSet)` directly.
    *
-   * The two-step `setFilter` + `refresh` pattern matches the
-   * {@link FocusProfileSwitchManager} contract which expects `refresh` to
-   * take an `effectiveOntologies` set; the filter object bundles the
-   * companion folder→UID map so the two arrive atomically.
+   * Semantics:
+   *   - `refresh()` — reindex with the previously stored effective set
+   *     (or no filter if none stored). Does NOT clear the stored set.
+   *   - `refresh(set)` — replace the stored effective set with `set`,
+   *     then reindex. To clear, call `setEffectiveOntologies(null)`
+   *     followed by `refresh()` — `refresh(...)` itself only sets
+   *     non-undefined values.
+   *
+   * The companion `assetSpaceFolderToUid` map is managed independently
+   * via {@link setAssetSpaceFolderToUid} because it changes on vault
+   * topology (rare) rather than profile switches (per-session).
    */
-  async refresh(filter?: EffectiveOntologyFilter): Promise<void> {
-    if (filter !== undefined) {
-      this.filter = filter;
+  async refresh(effectiveOntologies?: ReadonlySet<string>): Promise<void> {
+    if (effectiveOntologies !== undefined) {
+      this.effectiveOntologies = effectiveOntologies;
     }
     await this.errorHandler.executeWithRetry(
       async () => {
         await this.tripleStore.clear();
         const triples = await this.converter.convertVault({
           excludedFolders: this.excludedFolders,
-          effectiveOntologies: this.filter?.effectiveOntologies,
-          assetSpaceFolderToUid: this.filter?.assetSpaceFolderToUid,
+          effectiveOntologies: this.effectiveOntologies ?? undefined,
+          assetSpaceFolderToUid: this.assetSpaceFolderToUid ?? undefined,
         });
         await this.tripleStore.addAll(triples);
         await this.runInference();

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -21,6 +21,21 @@ import {
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
 import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
 
+/**
+ * Effective ontology filter context (Issue #3321 / RFC 0a0791c1). Captures the
+ * `effectiveOntologies` allow-set AND the `folder → AssetSpace UID` map that
+ * the converter needs to resolve which AssetSpace owns a given file. The two
+ * fields travel together because the filter is meaningless without the map.
+ *
+ * Stored as a snapshot inside the indexer so that mid-session reindexing
+ * (`refresh()` re-runs after a profile switch OR per-file `updateFile` events)
+ * applies the active filter consistently.
+ */
+export interface EffectiveOntologyFilter {
+  effectiveOntologies: ReadonlySet<string>;
+  assetSpaceFolderToUid: ReadonlyMap<string, string>;
+}
+
 export class VaultRDFIndexer {
   private tripleStore: InMemoryTripleStore;
   private converter: NoteToRDFConverter;
@@ -36,6 +51,19 @@ export class VaultRDFIndexer {
    * (modify/rename/create) honour the same set as the initial walk.
    */
   private readonly excludedFolders: string[];
+  /**
+   * Active effective-ontology filter snapshot (Issue #3321). `null` means
+   * no filter is in effect — index the full vault (backward-compatible
+   * pre-#3321 behaviour). Updated by `setFilter()` and consumed by
+   * `initialize()` / `refresh()` / per-file `updateFile()`.
+   *
+   * Per-file updateFile events do NOT currently re-filter against this
+   * snapshot — files surviving the initial walk are assumed to stay in
+   * scope until the next full reindex. This matches the pre-#3321
+   * `excludedFolders` event semantics. A profile switch triggers a full
+   * `refresh()` which re-runs the walk with the current filter.
+   */
+  private filter: EffectiveOntologyFilter | null = null;
 
   constructor(
     private app: App,
@@ -75,6 +103,23 @@ export class VaultRDFIndexer {
     );
   }
 
+  /**
+   * Update the active effective-ontology filter snapshot (Issue #3321).
+   * Pass `null` to clear the filter (revert to indexing the full vault).
+   *
+   * Does NOT trigger reindexing — callers (typically
+   * {@link FocusProfileSwitchManager.switchProfile}) call `setFilter(...)`
+   * then `refresh()` so the two operations happen in a controlled order.
+   */
+  setFilter(filter: EffectiveOntologyFilter | null): void {
+    this.filter = filter;
+  }
+
+  /** Test helper — current filter snapshot. */
+  getFilter(): EffectiveOntologyFilter | null {
+    return this.filter;
+  }
+
   async initialize(): Promise<void> {
     if (this.isInitialized) {
       return;
@@ -84,6 +129,8 @@ export class VaultRDFIndexer {
       const triples = await this.errorHandler.executeWithRetry(
         async () => this.converter.convertVault({
           excludedFolders: this.excludedFolders,
+          effectiveOntologies: this.filter?.effectiveOntologies,
+          assetSpaceFolderToUid: this.filter?.assetSpaceFolderToUid,
         }),
         { context: "VaultRDFIndexer.initialize", operation: "convertVault" }
       );
@@ -242,12 +289,33 @@ export class VaultRDFIndexer {
     await this.tripleStore.removeAll(triples);
   }
 
-  async refresh(): Promise<void> {
+  /**
+   * Clear the triple store and rebuild from the current vault state.
+   *
+   * Issue #3321 / RFC 0a0791c1 — accepts an optional `filter` argument so a
+   * profile switch (via {@link FocusProfileSwitchManager.switchProfile})
+   * can atomically update the snapshot and reindex in one call. Pattern:
+   *   - `refresh()` — reindex with the previously-stored filter (or none).
+   *   - `refresh(filter)` — update the stored filter, then reindex. Pass
+   *      a `null`-like sentinel via `setFilter(null)` if you want to clear
+   *      the filter; `refresh()` without args does NOT clear the snapshot.
+   *
+   * The two-step `setFilter` + `refresh` pattern matches the
+   * {@link FocusProfileSwitchManager} contract which expects `refresh` to
+   * take an `effectiveOntologies` set; the filter object bundles the
+   * companion folder→UID map so the two arrive atomically.
+   */
+  async refresh(filter?: EffectiveOntologyFilter): Promise<void> {
+    if (filter !== undefined) {
+      this.filter = filter;
+    }
     await this.errorHandler.executeWithRetry(
       async () => {
         await this.tripleStore.clear();
         const triples = await this.converter.convertVault({
           excludedFolders: this.excludedFolders,
+          effectiveOntologies: this.filter?.effectiveOntologies,
+          assetSpaceFolderToUid: this.filter?.assetSpaceFolderToUid,
         });
         await this.tripleStore.addAll(triples);
         await this.runInference();

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.effective-ontologies.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.effective-ontologies.test.ts
@@ -1,5 +1,5 @@
-import { VaultRDFIndexer, type EffectiveOntologyFilter } from "../../../src/infrastructure/VaultRDFIndexer";
-import type { App } from "obsidian";
+import { VaultRDFIndexer } from "../../../src/infrastructure/VaultRDFIndexer";
+import type { App, TFile } from "obsidian";
 import {
   InMemoryTripleStore,
   NoteToRDFConverter,
@@ -13,12 +13,16 @@ import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter
  * effective-ontology filter snapshot to `NoteToRDFConverter.convertVault`
  * on both initial walk (`initialize`) and refresh (`refresh`).
  *
+ * `refresh(effectiveOntologies?)` matches the `IRdfIndexer` contract from
+ * B.4 so a `FocusProfileSwitchManager` instance can drive a profile-switch
+ * reindex without knowing about the AssetSpace folder map. The folder map
+ * is managed independently via `setAssetSpaceFolderToUid` (plugin-driven
+ * at onload / on AssetSpace topology change).
+ *
  * Following sibling `VaultRDFIndexer.excluded-folders.test.ts`: we mock
  * `exocortex` exports wholesale but keep the indexer's actual code under
- * test, then assert on the `convertVault` arguments. This is the right
- * granularity for "does the indexer plumb the filter end-to-end" — the
- * converter's own filter semantics are covered by the package-level
- * `NoteToRDFConverter.effective-ontologies.test.ts`.
+ * test, then assert on the `convertVault` arguments AND on the new
+ * `updateFile` filter guard.
  */
 
 jest.mock("exocortex", () => {
@@ -47,6 +51,7 @@ jest.mock("exocortex", () => {
     },
     isPathExcluded: actual.isPathExcluded,
     normaliseExcludedFolders: actual.normaliseExcludedFolders,
+    shouldSkipFileForEffectiveSet: actual.shouldSkipFileForEffectiveSet,
   };
 });
 jest.mock("../../../src/adapters/ObsidianVaultAdapter");
@@ -60,14 +65,14 @@ describe("VaultRDFIndexer — effectiveOntologies plumbing (Issue #3321)", () =>
   // `_alwaysOnOverlay`, see assetspaces/shared-identities/ae00f219-...md).
   const EXO_AS_UID = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
   const EXOCMD_AS_UID = "60967c6a-4e8a-4ee3-8922-db98b981e4f4";
+  const EMS_AS_UID = "11111111-2222-3333-4444-555555555555"; // synthetic
 
-  const makeFilter = (): EffectiveOntologyFilter => ({
-    effectiveOntologies: new Set<string>([EXO_AS_UID, EXOCMD_AS_UID]),
-    assetSpaceFolderToUid: new Map<string, string>([
+  const makeFolderMap = (): ReadonlyMap<string, string> =>
+    new Map<string, string>([
       ["assetspaces/exo", EXO_AS_UID],
       ["assetspaces/exocmd", EXOCMD_AS_UID],
-    ]),
-  });
+      ["assetspaces/ems", EMS_AS_UID],
+    ]);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -156,49 +161,62 @@ describe("VaultRDFIndexer — effectiveOntologies plumbing (Issue #3321)", () =>
     };
   });
 
-  describe("filter snapshot lifecycle", () => {
-    it("defaults to no filter (backward-compat)", () => {
+  describe("snapshot lifecycle", () => {
+    it("defaults to no filter and no folder map (backward-compat)", () => {
       const indexer = new VaultRDFIndexer(mockApp);
-      expect(indexer.getFilter()).toBeNull();
+      expect(indexer.getEffectiveOntologies()).toBeNull();
+      expect(indexer.getAssetSpaceFolderToUid()).toBeNull();
     });
 
-    it("stores the filter via setFilter without triggering reindex", () => {
+    it("setEffectiveOntologies stores the snapshot without triggering reindex", () => {
       const indexer = new VaultRDFIndexer(mockApp);
-      const filter = makeFilter();
+      const set = new Set<string>([EXO_AS_UID]);
 
-      indexer.setFilter(filter);
+      indexer.setEffectiveOntologies(set);
 
-      expect(indexer.getFilter()).toBe(filter);
-      // setFilter must NOT call convertVault — order is caller's concern.
+      expect(indexer.getEffectiveOntologies()).toBe(set);
       expect(mockConverter.convertVault).not.toHaveBeenCalled();
     });
 
-    it("clears the filter when null is passed", () => {
+    it("setAssetSpaceFolderToUid stores the map without triggering reindex", () => {
       const indexer = new VaultRDFIndexer(mockApp);
-      indexer.setFilter(makeFilter());
-      indexer.setFilter(null);
+      const map = makeFolderMap();
 
-      expect(indexer.getFilter()).toBeNull();
+      indexer.setAssetSpaceFolderToUid(map);
+
+      expect(indexer.getAssetSpaceFolderToUid()).toBe(map);
+      expect(mockConverter.convertVault).not.toHaveBeenCalled();
+    });
+
+    it("clears each snapshot independently when null is passed", () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      indexer.setEffectiveOntologies(new Set([EXO_AS_UID]));
+      indexer.setAssetSpaceFolderToUid(makeFolderMap());
+      indexer.setEffectiveOntologies(null);
+      indexer.setAssetSpaceFolderToUid(null);
+      expect(indexer.getEffectiveOntologies()).toBeNull();
+      expect(indexer.getAssetSpaceFolderToUid()).toBeNull();
     });
   });
 
   describe("initialize", () => {
-    it("forwards the stored filter snapshot to convertVault", async () => {
+    it("forwards both stored snapshots to convertVault", async () => {
       const indexer = new VaultRDFIndexer(mockApp);
-      const filter = makeFilter();
-      indexer.setFilter(filter);
+      const eff = new Set<string>([EXO_AS_UID, EXOCMD_AS_UID]);
+      const map = makeFolderMap();
+      indexer.setEffectiveOntologies(eff);
+      indexer.setAssetSpaceFolderToUid(map);
 
       await indexer.initialize();
 
       expect(mockConverter.convertVault).toHaveBeenCalledTimes(1);
       const callArg = mockConverter.convertVault.mock.calls[0]![0]!;
-      expect(callArg.effectiveOntologies).toBe(filter.effectiveOntologies);
-      expect(callArg.assetSpaceFolderToUid).toBe(filter.assetSpaceFolderToUid);
-      // excludedFolders still forwarded (backward-compat)
+      expect(callArg.effectiveOntologies).toBe(eff);
+      expect(callArg.assetSpaceFolderToUid).toBe(map);
       expect(callArg.excludedFolders).toEqual([]);
     });
 
-    it("forwards undefined filter fields when no filter is set", async () => {
+    it("forwards undefined when no filter is set (backward-compat)", async () => {
       const indexer = new VaultRDFIndexer(mockApp);
 
       await indexer.initialize();
@@ -209,52 +227,48 @@ describe("VaultRDFIndexer — effectiveOntologies plumbing (Issue #3321)", () =>
     });
   });
 
-  describe("refresh", () => {
-    it("forwards the stored filter snapshot to convertVault (no argument)", async () => {
+  describe("refresh — IRdfIndexer contract", () => {
+    it("forwards both stored snapshots when called with no argument", async () => {
       const indexer = new VaultRDFIndexer(mockApp);
-      const filter = makeFilter();
-      indexer.setFilter(filter);
+      const eff = new Set<string>([EXO_AS_UID]);
+      const map = makeFolderMap();
+      indexer.setEffectiveOntologies(eff);
+      indexer.setAssetSpaceFolderToUid(map);
 
       await indexer.refresh();
 
-      expect(mockConverter.convertVault).toHaveBeenCalledTimes(1);
       const callArg = mockConverter.convertVault.mock.calls[0]![0]!;
-      expect(callArg.effectiveOntologies).toBe(filter.effectiveOntologies);
-      expect(callArg.assetSpaceFolderToUid).toBe(filter.assetSpaceFolderToUid);
+      expect(callArg.effectiveOntologies).toBe(eff);
+      expect(callArg.assetSpaceFolderToUid).toBe(map);
     });
 
-    it("updates and applies the filter snapshot atomically when passed", async () => {
+    it("updates the effective set when called with a new Set (matches IRdfIndexer)", async () => {
       const indexer = new VaultRDFIndexer(mockApp);
-      const firstFilter = makeFilter();
-      const secondFilter: EffectiveOntologyFilter = {
-        effectiveOntologies: new Set<string>([EXO_AS_UID]),
-        assetSpaceFolderToUid: new Map<string, string>([
-          ["assetspaces/exo", EXO_AS_UID],
-        ]),
-      };
-      indexer.setFilter(firstFilter);
+      const original = new Set<string>([EXO_AS_UID]);
+      const replacement = new Set<string>([EXO_AS_UID, EXOCMD_AS_UID]);
+      indexer.setEffectiveOntologies(original);
+      indexer.setAssetSpaceFolderToUid(makeFolderMap());
 
-      // refresh(secondFilter) replaces the stored snapshot AND runs the walk
-      await indexer.refresh(secondFilter);
+      // Single-arg refresh — exactly what FocusProfileSwitchManager calls:
+      //   await this.rdfIndexer.refresh(effective);
+      await indexer.refresh(replacement);
 
-      expect(indexer.getFilter()).toBe(secondFilter);
+      expect(indexer.getEffectiveOntologies()).toBe(replacement);
       const callArg = mockConverter.convertVault.mock.calls[0]![0]!;
-      expect(callArg.effectiveOntologies).toBe(secondFilter.effectiveOntologies);
-      expect(callArg.assetSpaceFolderToUid).toBe(secondFilter.assetSpaceFolderToUid);
+      expect(callArg.effectiveOntologies).toBe(replacement);
     });
 
-    it("preserves the stored snapshot when refresh() is called with no argument", async () => {
+    it("preserves the stored effective set when refresh() is called without args", async () => {
       const indexer = new VaultRDFIndexer(mockApp);
-      const filter = makeFilter();
-      indexer.setFilter(filter);
+      const eff = new Set<string>([EXO_AS_UID]);
+      indexer.setEffectiveOntologies(eff);
 
       await indexer.refresh();
 
-      // No mutation — the snapshot is still the one we set.
-      expect(indexer.getFilter()).toBe(filter);
+      expect(indexer.getEffectiveOntologies()).toBe(eff);
     });
 
-    it("forwards undefined filter fields when no filter is set", async () => {
+    it("forwards undefined when nothing is set", async () => {
       const indexer = new VaultRDFIndexer(mockApp);
 
       await indexer.refresh();
@@ -266,16 +280,92 @@ describe("VaultRDFIndexer — effectiveOntologies plumbing (Issue #3321)", () =>
 
     it("clears the triple store before re-walking with the filter", async () => {
       const indexer = new VaultRDFIndexer(mockApp);
-      indexer.setFilter(makeFilter());
+      indexer.setEffectiveOntologies(new Set<string>([EXO_AS_UID]));
+      indexer.setAssetSpaceFolderToUid(makeFolderMap());
 
       await indexer.refresh();
 
-      // clear() must come BEFORE convertVault() — otherwise stale triples
-      // from the previous filter would remain. The mocks track call order
-      // via invocationCallOrder.
       const clearOrder = mockTripleStore.clear.mock.invocationCallOrder[0];
       const convertOrder = mockConverter.convertVault.mock.invocationCallOrder[0];
       expect(clearOrder).toBeLessThan(convertOrder!);
+    });
+  });
+
+  describe("updateFile — mid-session filter guard (Issue #3321 R15)", () => {
+    /**
+     * Constructs a minimal TFile-shaped mock. The real `TFile` is an
+     * Obsidian class we can't import in unit tests; the indexer only
+     * touches `path`, `extension`, and `basename`.
+     */
+    const tfile = (path: string): TFile =>
+      ({
+        path,
+        extension: "md",
+        basename: path.split("/").pop()!.replace(/\.md$/, ""),
+      }) as unknown as TFile;
+
+    it("removes stale triples for a filtered-out AssetSpace file and skips re-indexing", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      indexer.setEffectiveOntologies(new Set<string>([EXO_AS_UID]));
+      indexer.setAssetSpaceFolderToUid(makeFolderMap());
+
+      // ems is mapped to EMS_AS_UID; NOT in the active set → filtered.
+      // Edit-event for `assetspaces/ems/Task.md` must not produce triples.
+      const file = tfile("assetspaces/ems/Task.md");
+      await indexer.updateFile(file);
+
+      // Defensive cleanup: `match` was called to find stale triples.
+      expect(mockTripleStore.match).toHaveBeenCalled();
+      // No `convertNote` invocation — the file was rejected before
+      // reaching the converter.
+      expect(mockConverter.convertNote).not.toHaveBeenCalled();
+    });
+
+    it("indexes files inside an in-scope AssetSpace folder normally", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      indexer.setEffectiveOntologies(new Set<string>([EXO_AS_UID]));
+      indexer.setAssetSpaceFolderToUid(makeFolderMap());
+
+      const file = tfile("assetspaces/exo/Class.md");
+      await indexer.updateFile(file);
+
+      // exo IS in the active set → file flows through the normal path.
+      expect(mockConverter.convertNote).toHaveBeenCalledTimes(1);
+    });
+
+    it("indexes files outside `assetspaces/` regardless of the filter", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      indexer.setEffectiveOntologies(new Set<string>([EXO_AS_UID]));
+      indexer.setAssetSpaceFolderToUid(makeFolderMap());
+
+      const file = tfile("03 Knowledge/note.md");
+      await indexer.updateFile(file);
+
+      expect(mockConverter.convertNote).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT guard when no filter is active (backward-compat)", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      // No setEffectiveOntologies call — filter disengaged.
+
+      const file = tfile("assetspaces/ems/Task.md");
+      await indexer.updateFile(file);
+
+      // The legacy unfiltered path indexes normally.
+      expect(mockConverter.convertNote).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT guard when the folder map is missing (caller bug; degrade gracefully)", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      indexer.setEffectiveOntologies(new Set<string>([EXO_AS_UID]));
+      // No setAssetSpaceFolderToUid call.
+
+      const file = tfile("assetspaces/ems/Task.md");
+      await indexer.updateFile(file);
+
+      // Without the folder map the guard cannot resolve ownership →
+      // indexes normally. Consistent with the converter's R15 fall-back.
+      expect(mockConverter.convertNote).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.effective-ontologies.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.effective-ontologies.test.ts
@@ -1,0 +1,281 @@
+import { VaultRDFIndexer, type EffectiveOntologyFilter } from "../../../src/infrastructure/VaultRDFIndexer";
+import type { App } from "obsidian";
+import {
+  InMemoryTripleStore,
+  NoteToRDFConverter,
+  ApplicationErrorHandler,
+  Namespace,
+} from "exocortex";
+import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
+
+/**
+ * Issue #3321 / RFC 0a0791c1 — VaultRDFIndexer must forward the active
+ * effective-ontology filter snapshot to `NoteToRDFConverter.convertVault`
+ * on both initial walk (`initialize`) and refresh (`refresh`).
+ *
+ * Following sibling `VaultRDFIndexer.excluded-folders.test.ts`: we mock
+ * `exocortex` exports wholesale but keep the indexer's actual code under
+ * test, then assert on the `convertVault` arguments. This is the right
+ * granularity for "does the indexer plumb the filter end-to-end" — the
+ * converter's own filter semantics are covered by the package-level
+ * `NoteToRDFConverter.effective-ontologies.test.ts`.
+ */
+
+jest.mock("exocortex", () => {
+  const actual = jest.requireActual("exocortex");
+  return {
+    InMemoryTripleStore: jest.fn(),
+    NoteToRDFConverter: jest.fn(),
+    ApplicationErrorHandler: jest.fn(),
+    RDFSInferenceEngine: jest.fn(),
+    NonInheritablePropertyRegistry: jest.fn(),
+    PropertyCardinalityRegistry: jest.fn(),
+    PrototypeChainMaterializer: jest.fn(),
+    INFERRED_GRAPH: "https://exocortex.my/graph/inferred",
+    Namespace: { EXO: { term: jest.fn() } },
+    NetworkError: class NetworkError extends Error {},
+    ServiceError: class ServiceError extends Error {
+      constructor(msg: string, public meta?: unknown) {
+        super(msg);
+      }
+    },
+    IRI: class IRI {
+      constructor(public value: string) {}
+      toString() {
+        return this.value;
+      }
+    },
+    isPathExcluded: actual.isPathExcluded,
+    normaliseExcludedFolders: actual.normaliseExcludedFolders,
+  };
+});
+jest.mock("../../../src/adapters/ObsidianVaultAdapter");
+
+describe("VaultRDFIndexer — effectiveOntologies plumbing (Issue #3321)", () => {
+  let mockApp: App;
+  let mockTripleStore: jest.Mocked<InMemoryTripleStore>;
+  let mockConverter: jest.Mocked<NoteToRDFConverter>;
+
+  // AssetSpace UID samples lifted from real vault data (profile-base
+  // `_alwaysOnOverlay`, see assetspaces/shared-identities/ae00f219-...md).
+  const EXO_AS_UID = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
+  const EXOCMD_AS_UID = "60967c6a-4e8a-4ee3-8922-db98b981e4f4";
+
+  const makeFilter = (): EffectiveOntologyFilter => ({
+    effectiveOntologies: new Set<string>([EXO_AS_UID, EXOCMD_AS_UID]),
+    assetSpaceFolderToUid: new Map<string, string>([
+      ["assetspaces/exo", EXO_AS_UID],
+      ["assetspaces/exocmd", EXOCMD_AS_UID],
+    ]),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (
+      ApplicationErrorHandler as jest.MockedClass<
+        typeof ApplicationErrorHandler
+      >
+    ).mockImplementation(
+      () =>
+        ({
+          executeWithRetry: jest
+            .fn()
+            .mockImplementation(async (operation: () => Promise<unknown>) => {
+              return await operation();
+            }),
+          handle: jest.fn(),
+        }) as any,
+    );
+
+    mockApp = {
+      vault: {
+        on: jest.fn(),
+        off: jest.fn(),
+        offref: jest.fn(),
+        getAllFiles: jest.fn().mockReturnValue([]),
+      },
+      metadataCache: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
+    } as unknown as App;
+
+    mockTripleStore = {
+      addAll: jest.fn().mockResolvedValue(undefined),
+      clear: jest.fn().mockResolvedValue(undefined),
+      clearGraph: jest.fn().mockResolvedValue(undefined),
+      match: jest.fn().mockResolvedValue([]),
+      removeAll: jest.fn().mockResolvedValue(0),
+    } as any;
+
+    mockConverter = {
+      convertVault: jest.fn().mockResolvedValue([]),
+      convertNote: jest.fn().mockResolvedValue([]),
+    } as any;
+
+    (
+      InMemoryTripleStore as jest.MockedClass<typeof InMemoryTripleStore>
+    ).mockImplementation(() => mockTripleStore);
+    (
+      NoteToRDFConverter as jest.MockedClass<typeof NoteToRDFConverter>
+    ).mockImplementation(() => mockConverter);
+    (
+      ObsidianVaultAdapter as jest.MockedClass<typeof ObsidianVaultAdapter>
+    ).mockImplementation(() => ({}) as any);
+
+    const {
+      RDFSInferenceEngine,
+      NonInheritablePropertyRegistry,
+      PropertyCardinalityRegistry,
+      PrototypeChainMaterializer,
+    } = jest.requireMock("exocortex") as {
+      RDFSInferenceEngine: jest.Mock;
+      NonInheritablePropertyRegistry: jest.Mock;
+      PropertyCardinalityRegistry: jest.Mock;
+      PrototypeChainMaterializer: jest.Mock;
+    };
+    RDFSInferenceEngine.mockImplementation(() => ({
+      materialize: jest.fn().mockResolvedValue(undefined),
+    }));
+    NonInheritablePropertyRegistry.mockImplementation(() => ({
+      initialize: jest.fn().mockResolvedValue(undefined),
+    }));
+    PropertyCardinalityRegistry.mockImplementation(() => ({
+      initialize: jest.fn().mockResolvedValue(undefined),
+    }));
+    PrototypeChainMaterializer.mockImplementation(() => ({
+      materialize: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    const mockPrototypePredicate = {
+      value: "https://exocortex.my/ontology/exo#Asset_prototype",
+    };
+    (Namespace as any).EXO = {
+      term: jest.fn().mockReturnValue(mockPrototypePredicate),
+    };
+  });
+
+  describe("filter snapshot lifecycle", () => {
+    it("defaults to no filter (backward-compat)", () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      expect(indexer.getFilter()).toBeNull();
+    });
+
+    it("stores the filter via setFilter without triggering reindex", () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      const filter = makeFilter();
+
+      indexer.setFilter(filter);
+
+      expect(indexer.getFilter()).toBe(filter);
+      // setFilter must NOT call convertVault — order is caller's concern.
+      expect(mockConverter.convertVault).not.toHaveBeenCalled();
+    });
+
+    it("clears the filter when null is passed", () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      indexer.setFilter(makeFilter());
+      indexer.setFilter(null);
+
+      expect(indexer.getFilter()).toBeNull();
+    });
+  });
+
+  describe("initialize", () => {
+    it("forwards the stored filter snapshot to convertVault", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      const filter = makeFilter();
+      indexer.setFilter(filter);
+
+      await indexer.initialize();
+
+      expect(mockConverter.convertVault).toHaveBeenCalledTimes(1);
+      const callArg = mockConverter.convertVault.mock.calls[0]![0]!;
+      expect(callArg.effectiveOntologies).toBe(filter.effectiveOntologies);
+      expect(callArg.assetSpaceFolderToUid).toBe(filter.assetSpaceFolderToUid);
+      // excludedFolders still forwarded (backward-compat)
+      expect(callArg.excludedFolders).toEqual([]);
+    });
+
+    it("forwards undefined filter fields when no filter is set", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+
+      await indexer.initialize();
+
+      const callArg = mockConverter.convertVault.mock.calls[0]![0]!;
+      expect(callArg.effectiveOntologies).toBeUndefined();
+      expect(callArg.assetSpaceFolderToUid).toBeUndefined();
+    });
+  });
+
+  describe("refresh", () => {
+    it("forwards the stored filter snapshot to convertVault (no argument)", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      const filter = makeFilter();
+      indexer.setFilter(filter);
+
+      await indexer.refresh();
+
+      expect(mockConverter.convertVault).toHaveBeenCalledTimes(1);
+      const callArg = mockConverter.convertVault.mock.calls[0]![0]!;
+      expect(callArg.effectiveOntologies).toBe(filter.effectiveOntologies);
+      expect(callArg.assetSpaceFolderToUid).toBe(filter.assetSpaceFolderToUid);
+    });
+
+    it("updates and applies the filter snapshot atomically when passed", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      const firstFilter = makeFilter();
+      const secondFilter: EffectiveOntologyFilter = {
+        effectiveOntologies: new Set<string>([EXO_AS_UID]),
+        assetSpaceFolderToUid: new Map<string, string>([
+          ["assetspaces/exo", EXO_AS_UID],
+        ]),
+      };
+      indexer.setFilter(firstFilter);
+
+      // refresh(secondFilter) replaces the stored snapshot AND runs the walk
+      await indexer.refresh(secondFilter);
+
+      expect(indexer.getFilter()).toBe(secondFilter);
+      const callArg = mockConverter.convertVault.mock.calls[0]![0]!;
+      expect(callArg.effectiveOntologies).toBe(secondFilter.effectiveOntologies);
+      expect(callArg.assetSpaceFolderToUid).toBe(secondFilter.assetSpaceFolderToUid);
+    });
+
+    it("preserves the stored snapshot when refresh() is called with no argument", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      const filter = makeFilter();
+      indexer.setFilter(filter);
+
+      await indexer.refresh();
+
+      // No mutation — the snapshot is still the one we set.
+      expect(indexer.getFilter()).toBe(filter);
+    });
+
+    it("forwards undefined filter fields when no filter is set", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+
+      await indexer.refresh();
+
+      const callArg = mockConverter.convertVault.mock.calls[0]![0]!;
+      expect(callArg.effectiveOntologies).toBeUndefined();
+      expect(callArg.assetSpaceFolderToUid).toBeUndefined();
+    });
+
+    it("clears the triple store before re-walking with the filter", async () => {
+      const indexer = new VaultRDFIndexer(mockApp);
+      indexer.setFilter(makeFilter());
+
+      await indexer.refresh();
+
+      // clear() must come BEFORE convertVault() — otherwise stale triples
+      // from the previous filter would remain. The mocks track call order
+      // via invocationCallOrder.
+      const clearOrder = mockTripleStore.clear.mock.invocationCallOrder[0];
+      const convertOrder = mockConverter.convertVault.mock.invocationCallOrder[0];
+      expect(clearOrder).toBeLessThan(convertOrder!);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.effective-ontologies.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.effective-ontologies.test.ts
@@ -304,21 +304,29 @@ describe("VaultRDFIndexer — effectiveOntologies plumbing (Issue #3321)", () =>
         basename: path.split("/").pop()!.replace(/\.md$/, ""),
       }) as unknown as TFile;
 
-    it("removes stale triples for a filtered-out AssetSpace file and skips re-indexing", async () => {
+    it("skips re-indexing AND defensively removes stale triples for a filtered-out AssetSpace file", async () => {
       const indexer = new VaultRDFIndexer(mockApp);
       indexer.setEffectiveOntologies(new Set<string>([EXO_AS_UID]));
       indexer.setAssetSpaceFolderToUid(makeFolderMap());
 
+      // Simulate stale triples in the store from a pre-filter indexing run.
+      // `removeFileTriples` calls `match(fileIRI)` then `removeAll(triples)`;
+      // we satisfy both by returning one mock triple from `match`.
+      mockTripleStore.match.mockResolvedValueOnce([{ id: "stale" } as any]);
+
       // ems is mapped to EMS_AS_UID; NOT in the active set → filtered.
-      // Edit-event for `assetspaces/ems/Task.md` must not produce triples.
+      // Edit-event for `assetspaces/ems/Task.md` must not produce new triples.
       const file = tfile("assetspaces/ems/Task.md");
       await indexer.updateFile(file);
 
-      // Defensive cleanup: `match` was called to find stale triples.
-      expect(mockTripleStore.match).toHaveBeenCalled();
-      // No `convertNote` invocation — the file was rejected before
-      // reaching the converter.
+      // Primary assertion — the file was rejected BEFORE reaching the
+      // converter (the discriminating signal between "filter active" and
+      // "filter disabled" paths).
       expect(mockConverter.convertNote).not.toHaveBeenCalled();
+      // Defensive cleanup assertion — stale triples are explicitly removed,
+      // not just left in place. `removeAll` is the real discriminator (the
+      // `match` call alone is consistent with several other paths).
+      expect(mockTripleStore.removeAll).toHaveBeenCalled();
     });
 
     it("indexes files inside an in-scope AssetSpace folder normally", async () => {


### PR DESCRIPTION
## Summary

`NoteToRDFConverter.convertVault` + `convertVaultWithValidation` now accept an optional `effectiveOntologies` allow-set + a precomputed `assetSpaceFolderToUid` map. When provided, files under `assetspaces/<folder>/` whose owning AssetSpace UID is NOT in the active set are silently skipped (treated as out-of-scope, not invalid). Files outside `assetspaces/` are always emitted regardless of the filter.

`VaultRDFIndexer.refresh(effectiveOntologies?: ReadonlySet<string>)` matches the `IRdfIndexer` contract from B.4 (#3315) **structurally** — verified via tsc probe. Two independent setters (`setEffectiveOntologies`, `setAssetSpaceFolderToUid`) keep the two fields decoupled because they change at different cadences (profile switch vs vault topology).

**Refs #3321** (does not auto-close — full AC including "Plugin entry wires FocusProfileSwitchManager → NoteToRDFConverter" + UI smoke depends on follow-up **#3324**). This PR ships the API plumbing prerequisite.

## Why scope was bounded to API only

`NoteToRDFConverter` is in the auto-merge no-`--auto` list (CLAUDE.md "Auto-merge discipline"). Shipping the API + tests in a tight, reviewable PR keeps the central-class blast radius minimal. The smoke and onload wiring land together when the resolver + setting + commands are ready in #3324 — that is the natural seam.

Advisor consultation explicitly confirmed: Issue body literally recommends option (a), and "Option (b) means doubling the central-class surface in one PR". Recorded scope decision in the parent orchestrator transcript.

## R15 self-brick guards

Per Vision Lock #17 the converter cannot silently empty the triple store on a catastrophic profile config. Two fall-back paths into the no-filter walk, both warn-logged:

1. `effectiveOntologies.size === 0` → "effective set empty; profile probably misconfigured"
2. `effectiveOntologies` provided without `assetSpaceFolderToUid` → "caller didn't precompute the folder map"

`updateFile` mirrors the same engagement contract: when both are present, runs `shouldSkipFileForEffectiveSet` on the path; on hit, defensively `removeFileTriples` + skip. When either is absent, the legacy unfiltered path runs (same R15 fall-back as the converter).

The `[$exo, $exocmd, $shared-*]` floor enforcement remains the caller's responsibility (the existing B.4 `FocusProfileSwitchManager.resolveEffectiveSet` already injects it). The B.4 `TS_FLOOR_ONTOLOGY_URIS` (ontology URIs) ↔ filter (AssetSpace UIDs) unit mismatch is **documented in JSDoc** + tracked in #3324; this PR does not paper over it.

## Code-reviewer round-1 findings → fixes

Mandatory `code-reviewer` agent run per CLAUDE.md auto-merge discipline returned 0 CRITICAL, **1 HIGH** + **1 MEDIUM** + 3 LOW. Both HIGH and MEDIUM fixed in commit `9df2541a`:

**HIGH** — `VaultRDFIndexer.refresh(filter?: EffectiveOntologyFilter)` was structurally incompatible with `IRdfIndexer.refresh(effectiveOntologies: ReadonlySet<string>)`. Empirically reproduced via a 3-line tsc probe (`Type 'VaultRDFIndexer' is not assignable to type 'IRdfIndexer'. Types of property 'refresh' are incompatible.`). **Fixed** by dropping the combined `EffectiveOntologyFilter` bundle type and refactoring to two independent setters + an IRdfIndexer-compatible `refresh(effectiveOntologies?: ReadonlySet<string>)`. Re-probed → tsc accepts the assignment.

**MEDIUM** — `updateFile` indexed triples for files inside a filtered-out AssetSpace, drifting the store away from the most recent `refresh(effective)` snapshot. The pre-#3321 `excludedFolders` guard at line 241 had no effective-ontology equivalent. **Fixed** by adding a symmetric guard: `shouldSkipFileForEffectiveSet` check after the `isPathExcluded` check; on hit, defensively `removeFileTriples` and return. 5 new tests cover the guard.

3 LOW notes deferred (cosmetic; reviewer agreed).

## Test plan

`packages/exocortex/tests/unit/services/NoteToRDFConverter.effective-ontologies.test.ts` (15 tests):
- [x] Pure helper `shouldSkipFileForEffectiveSet` — non-`assetspaces/` paths, unknown folder, backslash normalization, case sensitivity
- [x] `convertVault({})` → backward-compat full-vault walk
- [x] `convertVault()` (no options) → legacy call-shape preserved
- [x] Filter engagement skips ems but keeps exo + non-assetspaces files
- [x] R15 empty-set guard → warn + fall back full vault
- [x] R15 missing-map guard → warn + fall back full vault
- [x] Composition with `excludedFolders` (exclusion first, then effective-set filter)
- [x] `convertVaultWithValidation.summary.total` excludes filter-rejected files (silent skip semantics)

`packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.effective-ontologies.test.ts` (16 tests):
- [x] Defaults: both snapshots `null`
- [x] Independent setters store without triggering reindex
- [x] Independent clear via `null`
- [x] `initialize()` forwards both stored snapshots (and `undefined` defaults)
- [x] `refresh()` forwards stored snapshots (IRdfIndexer contract)
- [x] `refresh(set)` replaces stored effective set + walks
- [x] `refresh()` preserves stored set
- [x] `clear()` precedes `convertVault()` (call-order assertion)
- [x] **New: `updateFile` guard** — removes stale + skips re-index for filtered-out AssetSpace files
- [x] **New: `updateFile`** indexes in-scope AssetSpace files normally
- [x] **New: `updateFile`** indexes files outside `assetspaces/` regardless
- [x] **New: `updateFile`** preserves backward-compat (no guard without filter)
- [x] **New: `updateFile`** degrades gracefully when folder map missing

**Revert→fail / restore→pass verified** — reverting filter engagement in `convertVaultWithValidation` causes 3 active-filter tests to FAIL; restoring passes all 15.

**Regression scan:** 250 `NoteToRDFConverter` tests + 57 `VaultRDFIndexer` tests (41 pre-existing + 16 new) + 33 `FocusProfileSwitch` regression tests all green.

## Out of scope (will ship with #3324)

- `ExocortexSettings.activeProfileUid` field
- `ObsidianProfileResolver` (production `IProfileResolver` reading vault frontmatter)
- `ExocortexPlugin.onload` reading `activeProfileUid` → resolving effective set → passing to `VaultRDFIndexer`
- `SPARQLCodeBlockProcessor.ts:387` — constructs its own converter without filter; currently uses default no-filter path which is correct for backward-compat. If/when SPARQL code blocks should honor the active profile, file a follow-up.
- UI smoke (depends on the onload wiring landing first)

## Refs

- Issue #3321 (this PR ships the prerequisite API)
- Follow-up #3324
- RFC `0a0791c1-3808-42fd-bc7f-bdd127ac7b24`
- B.4 PR #3315 (`FocusProfileSwitchManager` + `IRdfIndexer` interface)
- B.3 `AssetSpaceManager.lookupAssetSpaceForPath` — folder→UID source

## Merge protocol

Per CLAUDE.md "Auto-merge discipline" for `NoteToRDFConverter` modifications:
1. Push PR ✅
2. Wait for CI green AND `code-reviewer` agent complete ✅ (round-1 done)
3. Apply CRITICAL / HIGH fixes ✅ (commit 9df2541a)
4. Call `advisor()` AFTER fixes (round-2)
5. Apply advisor catches
6. THEN `gh pr merge --squash --delete-branch` (manual, no `--auto`)