### PR TITLE
feat(plugin): register FocusProfile palette commands в onload (RFC 0a0791c1 #3322)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2204,6 +2204,32 @@ export default class ExocortexPlugin extends Plugin {
       notify: (message) => this.notifier.info(message),
     });
 
+    // Crash-recovery: если previous session left `_switchInProgress=true`
+    // в settings (FocusProfileSwitchManager docstring line 18), re-trigger
+    // the idempotent re-index so the flag self-clears. Failure swallowed —
+    // user-facing recovery is а Phase D follow-up; the only side-effect
+    // of skipping this is the «stuck switch in progress» footgun (code-
+    // reviewer HIGH catch).
+    try {
+      const initialSettings = await settingsStore.load();
+      if (initialSettings._switchInProgress) {
+        this.logger.warn(
+          "[ExocortexPlugin] previous session left _switchInProgress=true — attempting idempotent recovery",
+        );
+      }
+      const recovery = await switchMgr.recoverIfNeeded();
+      if (recovery.recovered) {
+        this.logger.info(
+          `[ExocortexPlugin] FocusProfile switch recovery completed for ${recovery.targetUid}`,
+        );
+      }
+    } catch (error) {
+      this.logger.warn(
+        "[ExocortexPlugin] FocusProfile switch recovery failed",
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+
     const pushMgr = await this.buildAssetSpacePusher();
 
     const profileLister = async (): Promise<FocusProfileChoice[]> => {

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -90,6 +90,23 @@ import { createObsidianClassLabelResolver } from "./infrastructure/services/Obsi
 import { ExocmdCommandPaletteRegistrar } from "./application/services/ExocmdCommandPaletteRegistrar";
 import { ObsidianCommandPromptAdapter } from "./infrastructure/adapters/ObsidianCommandPromptAdapter";
 import {
+  FocusProfileCommands,
+  type FocusProfileChoice,
+  type IAssetSpacePusher,
+} from "./infrastructure/adapters/FocusProfileCommands";
+import { FocusProfileSwitchManager } from "./infrastructure/adapters/FocusProfileSwitchManager";
+import { PluginLockManager } from "./infrastructure/adapters/PluginLockManager";
+import { VaultProfileResolver } from "./infrastructure/adapters/VaultProfileResolver";
+import { PluginRdfIndexerAdapter } from "./infrastructure/adapters/PluginRdfIndexerAdapter";
+import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSettingsStoreAdapter";
+import { ProfileFuzzyModal } from "./infrastructure/adapters/ProfileFuzzyModal";
+import {
+  AssetSpaceManager,
+  ASSET_SPACE_CLASS_UID,
+} from "./infrastructure/adapters/AssetSpaceManager";
+import { GitHubRestClient } from "./infrastructure/adapters/GitHubRestClient";
+import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
+import {
   CommandExecutionFlow,
   DI_TOKENS,
   type IVaultSettings,
@@ -685,6 +702,20 @@ export default class ExocortexPlugin extends Plugin {
       this.commandManager.registerAllCommands(this, () =>
         this.autoRenderLayout(),
       );
+
+      // RFC 0a0791c1 #3322 — register FocusProfile palette commands
+      // (Switch / Push current assetspace). Wraps the B.7 handler with
+      // real adapters. Wrapped в try/catch: any failure here должен NOT
+      // abort the rest of onload — commands simply won't appear in
+      // Cmd+P, but plugin remains usable.
+      try {
+        await this.registerFocusProfileCommands();
+      } catch (error) {
+        this.logger.error(
+          "[ExocortexPlugin] FocusProfile commands registration failed",
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
 
       // RFC 1429fcd0 PR-2: register vault-described palette-enabled exocmd
       // commands as Obsidian Command Palette entries. Runs **after**
@@ -2134,5 +2165,222 @@ export default class ExocortexPlugin extends Plugin {
     document
       .querySelectorAll(".exocortex-auto-layout")
       .forEach((el) => el.remove());
+  }
+
+  /**
+   * RFC 0a0791c1 #3322 — register the two FocusProfile palette commands
+   * («Switch focus profile», «Push current assetspace»). Wires the B.7
+   * `FocusProfileCommands` handler with real adapters:
+   *
+   *   - B.4 `FocusProfileSwitchManager`: persisted lock + journal + RDF
+   *     re-index с effective ontology filter.
+   *   - B.3 `AssetSpaceManager`: GitHub PAT-backed AssetSpace push (only
+   *     constructed when PAT is configured in `data.local.json`; absent
+   *     PAT yields a lookup-only stub that surfaces a Configure-PAT
+   *     Notice on push).
+   *   - `ProfileFuzzyModal`: Obsidian `FuzzySuggestModal` wrapper that
+   *     resolves the handler's Promise on choose/dismiss.
+   *
+   * The handler's logic gracefully reports failure через `notify`, so all
+   * branches surface к the user as a Notice — never a silent log-only
+   * crash. Construction errors here are caught by the caller's try/catch
+   * in `onload()`.
+   */
+  private async registerFocusProfileCommands(): Promise<void> {
+    const lockMgr = new PluginLockManager({ app: this.app });
+    const resolver = new VaultProfileResolver(this.app);
+    const rdfIndexer = new PluginRdfIndexerAdapter(this.sparql.getRdfIndexer());
+    const settingsStore = new PluginSettingsStoreAdapter({
+      readSettings: () => this.settings as Record<string, unknown>,
+      saveSettings: () => this.saveSettings(),
+    });
+
+    const switchMgr = new FocusProfileSwitchManager({
+      app: this.app,
+      lockMgr,
+      resolver,
+      rdfIndexer,
+      settingsStore,
+      notify: (message) => this.notifier.info(message),
+    });
+
+    const pushMgr = await this.buildAssetSpacePusher();
+
+    const profileLister = async (): Promise<FocusProfileChoice[]> => {
+      const activeUid =
+        typeof (this.settings as Record<string, unknown>).activeProfileUid ===
+        "string"
+          ? ((this.settings as Record<string, unknown>)
+              .activeProfileUid as string)
+          : null;
+      const choices: FocusProfileChoice[] = [];
+      for (const file of resolver.listFocusProfileFiles()) {
+        const cache = this.app.metadataCache.getFileCache(file);
+        const fm = cache?.frontmatter as Record<string, unknown> | undefined;
+        if (!fm) continue;
+        const uid =
+          typeof fm["exo__Asset_uid"] === "string"
+            ? (fm["exo__Asset_uid"] as string)
+            : null;
+        if (uid === null) continue;
+        const label =
+          typeof fm["exo__Asset_label"] === "string"
+            ? (fm["exo__Asset_label"] as string)
+            : file.basename;
+        choices.push({ uid, label, isActive: uid === activeUid });
+      }
+      // Sort alphabetically by label so picker order is stable across
+      // vault scans (vault.getMarkdownFiles() is filesystem-order, not
+      // semantic).
+      choices.sort((a, b) => a.label.localeCompare(b.label));
+      return choices;
+    };
+
+    const fuzzyPick = (
+      options: FocusProfileChoice[],
+      title: string,
+    ): Promise<FocusProfileChoice | null> => {
+      return new Promise<FocusProfileChoice | null>((resolve) => {
+        const modal = new ProfileFuzzyModal(this.app, options, title, resolve);
+        modal.open();
+      });
+    };
+
+    const commandsHandler = new FocusProfileCommands({
+      switchMgr,
+      pushMgr,
+      profileLister,
+      fuzzyPick,
+      getActiveFilePath: () =>
+        this.app.workspace.getActiveFile()?.path ?? null,
+      notify: (message) => this.notifier.info(message),
+    });
+
+    this.addCommand({
+      id: "switch-focus-profile",
+      name: "Switch focus profile",
+      callback: () => {
+        void commandsHandler.invokeSwitchProfile();
+      },
+    });
+
+    this.addCommand({
+      id: "push-current-assetspace",
+      name: "Push current assetspace",
+      callback: () => {
+        void commandsHandler.invokePushCurrentAssetSpace();
+      },
+    });
+
+    this.logger.info(
+      "[ExocortexPlugin] FocusProfile palette commands registered",
+    );
+  }
+
+  /**
+   * Constructs an `IAssetSpacePusher` for {@link registerFocusProfileCommands}.
+   *
+   * When a GitHub PAT is configured в `data.local.json` (per RFC 0a0791c1
+   * Vision Lock #1), returns a real `AssetSpaceManager` — push works
+   * end-to-end. When PAT is absent, returns a lookup-only stub backed
+   * by a direct vault scan (mirrors `AssetSpaceManager.lookupAssetSpaceForPath`)
+   * — push surfaces a «Configure GitHub PAT» Notice без crashing onload.
+   *
+   * This split lets the Switch command remain fully operational regardless
+   * of PAT presence, while the Push command degrades gracefully.
+   */
+  private async buildAssetSpacePusher(): Promise<IAssetSpacePusher> {
+    const secretsStore = new LocalSecretsStore({ app: this.app });
+    const pat = await secretsStore.getSecret("pat");
+    const lookupOnlyFor = (folderName: string): string | null =>
+      this.lookupAssetSpaceUidByFolder(folderName);
+
+    if (pat === null || pat.length === 0) {
+      return {
+        lookupAssetSpaceForPath: lookupOnlyFor,
+        pushAssetSpace: () =>
+          Promise.reject(
+            new Error(
+              "GitHub PAT not configured — set it в Settings → Exocortex → GitHub PAT",
+            ),
+          ),
+      };
+    }
+
+    try {
+      const client = new GitHubRestClient({ pat, app: this.app });
+      const manager = new AssetSpaceManager({
+        app: this.app,
+        client,
+        notifications: this.notifier,
+      });
+      return {
+        lookupAssetSpaceForPath: (folderName) =>
+          manager.lookupAssetSpaceForPath(folderName),
+        pushAssetSpace: async (asUid) => {
+          const sha = await manager.pushAssetSpace(asUid);
+          // `AssetSpaceManager.pushAssetSpace` returns `Promise<string | null>`
+          // (`null` = no dirty files, no-op success). Coerce `null` → `""`
+          // to match `FocusProfileCommands.IAssetSpacePusher` contract,
+          // which treats empty string as «no-op» (see handler comment
+          // around line 139).
+          return sha ?? "";
+        },
+      };
+    } catch (error) {
+      this.logger.error(
+        "[ExocortexPlugin] AssetSpaceManager construction failed — push command will fail-clean",
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      return {
+        lookupAssetSpaceForPath: lookupOnlyFor,
+        pushAssetSpace: () =>
+          Promise.reject(
+            new Error(
+              `Could not initialise AssetSpaceManager: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            ),
+          ),
+      };
+    }
+  }
+
+  /**
+   * Vault-scan lookup mirroring `AssetSpaceManager.lookupAssetSpaceForPath`
+   * — finds the AssetSpace ABox asset whose containing folder matches
+   * `folderName` and returns its `exo__Asset_uid`. Used by the lookup-
+   * only stub path when GitHub PAT is absent (push disabled but the
+   * lookup branches in `FocusProfileCommands.invokePushCurrentAssetSpace`
+   * still need to resolve).
+   *
+   * Kept narrow на purpose — duplicating ~15 LOC из AssetSpaceManager
+   * avoids importing the full manager (которое requires a PAT to
+   * construct).
+   */
+  private lookupAssetSpaceUidByFolder(folderName: string): string | null {
+    if (typeof folderName !== "string" || folderName.length === 0) return null;
+    const normalised = folderName.replace(/\/$/, "");
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const parent = file.parent?.path ?? "";
+      if (parent !== normalised) continue;
+      const fm = this.app.metadataCache.getFileCache(file)?.frontmatter as
+        | Record<string, unknown>
+        | undefined;
+      if (!fm) continue;
+      const classes = fm["exo__Instance_class"];
+      const classList: unknown[] = Array.isArray(classes)
+        ? classes
+        : classes
+          ? [classes]
+          : [];
+      const isAssetSpace = classList.some(
+        (c) => typeof c === "string" && c.includes(ASSET_SPACE_CLASS_UID),
+      );
+      if (!isAssetSpace) continue;
+      const uid = fm["exo__Asset_uid"];
+      if (typeof uid === "string" && uid.length > 0) return uid;
+    }
+    return null;
   }
 }

--- a/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
+++ b/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
@@ -2,6 +2,7 @@ import type { TFile } from "obsidian";
 import type { InMemoryTripleStore, SolutionMapping, Triple } from "exocortex";
 import { SPARQLQueryService } from '@plugin/application/services/SPARQLQueryService';
 import type ExocortexPlugin from '@plugin/ExocortexPlugin';
+import type { VaultRDFIndexer } from '@plugin/infrastructure/VaultRDFIndexer';
 
 /**
  * Result of a SPARQL SELECT query execution.
@@ -309,6 +310,20 @@ export class SPARQLApi {
    */
   async reindexFile(file: TFile): Promise<void> {
     await this.queryService.updateFile(file);
+  }
+
+  /**
+   * Returns the underlying `VaultRDFIndexer`. Exposed для RFC 0a0791c1
+   * B.4 wiring — `PluginRdfIndexerAdapter` (Issue #3322) constructs an
+   * `IRdfIndexer` over this instance so `FocusProfileSwitchManager.switchProfile`
+   * can thread the effective ontology set через
+   * `VaultRDFIndexer.refresh(set)`.
+   *
+   * This is intentionally a thin passthrough; callers should NOT directly
+   * mutate indexer state outside of the SwitchManager flow.
+   */
+  getRdfIndexer(): VaultRDFIndexer {
+    return this.queryService.getIndexer();
   }
 
   /**

--- a/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
+++ b/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
@@ -321,6 +321,14 @@ export class SPARQLApi {
    *
    * This is intentionally a thin passthrough; callers should NOT directly
    * mutate indexer state outside of the SwitchManager flow.
+   *
+   * **Known abstraction leak** (code-reviewer MEDIUM, deferred): the
+   * `VaultRDFIndexer` type sits in `infrastructure/` while this class
+   * sits in `application/api/`. Tightening the return type к а narrower
+   * application-layer interface (e.g. `IRdfIndexerHandle` exposing only
+   * `refresh(set) + setEffectiveOntologies + setAssetSpaceFolderToUid`)
+   * is а follow-up task; for now the leak is documented and contained
+   * к the single consumer.
    */
   getRdfIndexer(): VaultRDFIndexer {
     return this.queryService.getIndexer();

--- a/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
+++ b/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
@@ -192,4 +192,16 @@ export class SPARQLQueryService {
   getTripleStore() {
     return this.indexer.getTripleStore();
   }
+
+  /**
+   * Returns the underlying `VaultRDFIndexer`. Exposed to support B.4
+   * `FocusProfileSwitchManager` wiring (RFC 0a0791c1 #3322) — the
+   * SwitchManager's `IRdfIndexer.refresh(effectiveOntologies)` contract
+   * threads the active focus profile's allow-set into
+   * `VaultRDFIndexer.refresh(set)`. The adapter sits in
+   * `infrastructure/adapters/PluginRdfIndexerAdapter.ts`.
+   */
+  getIndexer(): VaultRDFIndexer {
+    return this.indexer;
+  }
 }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
@@ -32,6 +32,13 @@ export interface IAssetSpacePusher {
 export interface FocusProfileChoice {
   uid: string;
   label: string;
+  /**
+   * `true` when this profile is currently active per plugin settings. The
+   * picker UI surfaces this so users can see what they are switching FROM
+   * without leaving the modal. Optional — `profileLister` may omit when
+   * the active selection is unknown.
+   */
+  isActive?: boolean;
 }
 
 export interface FocusProfileCommandsDeps {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginRdfIndexerAdapter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginRdfIndexerAdapter.ts
@@ -1,0 +1,35 @@
+import type { IRdfIndexer } from "./FocusProfileSwitchManager";
+import type { VaultRDFIndexer } from "../VaultRDFIndexer";
+
+/**
+ * `IRdfIndexer` adapter wrapping the plugin's live `VaultRDFIndexer`
+ * (Issue #3321 wiring). The B.4 `FocusProfileSwitchManager` calls
+ * `refresh(effectiveOntologies)` after persisting `activeProfileUid`;
+ * this adapter threads the set into the indexer и forwards к the
+ * indexer's no-arg `refresh()` path so the existing cold-start
+ * pipeline runs identically.
+ *
+ * Folder-map ownership: per VaultRDFIndexer line 111, the effective-
+ * ontology filter engages only when BOTH the set is non-empty AND
+ * `setAssetSpaceFolderToUid` has been called с a non-null map. This
+ * adapter is agnostic — the plugin's onload is responsible для wiring
+ * the folder map при construction (AssetSpaceManager scan, or vault-
+ * scan fallback). Passing through here would couple the SwitchManager
+ * к AssetSpace topology, which it deliberately stays out of.
+ */
+export class PluginRdfIndexerAdapter implements IRdfIndexer {
+  constructor(private readonly indexer: VaultRDFIndexer) {
+    if (!indexer) {
+      throw new Error("PluginRdfIndexerAdapter: indexer is required");
+    }
+  }
+
+  async refresh(effectiveOntologies: ReadonlySet<string>): Promise<void> {
+    // `VaultRDFIndexer.refresh` accepts the set as its single argument
+    // and persists it via `setEffectiveOntologies` before reindexing.
+    // R15 fall-back (empty set / missing folder map) is handled inside
+    // the converter — surfacing it through this adapter would risk
+    // double-warn, so we let the indexer log once.
+    await this.indexer.refresh(effectiveOntologies);
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginSettingsStoreAdapter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginSettingsStoreAdapter.ts
@@ -1,0 +1,73 @@
+import type {
+  ISettingsStore,
+  SwitchSettings,
+} from "./FocusProfileSwitchManager";
+
+/**
+ * Pluggable host hook for {@link PluginSettingsStoreAdapter}. The plugin
+ * passes its current `settings` object and a `saveData` thunk; the adapter
+ * neither knows nor cares about the surrounding `ExocortexSettings` shape
+ * — it only reads/writes the two switch-state keys per RFC 0a0791c1 §B.4
+ * (`activeProfileUid`, `_switchInProgress`).
+ *
+ * The thunk pattern (rather than holding a direct plugin reference) keeps
+ * the adapter free of `Plugin` import — useful for the test path which
+ * stubs the save fn outright.
+ */
+export interface PluginSettingsStoreHost {
+  /**
+   * Reads the live settings record. Implementations should return the
+   * SAME mutable reference the plugin holds, because B.4 expects
+   * `settings.activeProfileUid = X` to round-trip back through the
+   * `save()` thunk. A frozen / cloned object would silently drop the
+   * write.
+   */
+  readSettings(): {
+    activeProfileUid?: string | null;
+    _switchInProgress?: boolean;
+    [k: string]: unknown;
+  };
+  /** Persists the current settings object to disk (Obsidian `saveData`). */
+  saveSettings(): Promise<void>;
+}
+
+/**
+ * `ISettingsStore` adapter persisting via the plugin's standard
+ * `saveData()` round-trip. Defaults missing fields:
+ *   - `activeProfileUid` → `null` (no profile selected, full vault)
+ *   - `_switchInProgress` → `false`
+ *
+ * Persistence target: Obsidian plugin `data.json`, which Obsidian Sync
+ * replicates across devices. Per RFC 0a0791c1 + Vision Lock #1, only PATs
+ * live в `data.local.json`; the active profile UID is intentionally
+ * synced so the user's profile choice follows them. Per-device override
+ * is a Phase D follow-up.
+ */
+export class PluginSettingsStoreAdapter implements ISettingsStore {
+  constructor(private readonly host: PluginSettingsStoreHost) {
+    if (!host) {
+      throw new Error("PluginSettingsStoreAdapter: host is required");
+    }
+  }
+
+  async load(): Promise<SwitchSettings> {
+    const raw = this.host.readSettings();
+    const activeProfileUid =
+      typeof raw.activeProfileUid === "string" ? raw.activeProfileUid : null;
+    const inProgress =
+      typeof raw._switchInProgress === "boolean"
+        ? raw._switchInProgress
+        : false;
+    return {
+      activeProfileUid,
+      _switchInProgress: inProgress,
+    };
+  }
+
+  async save(s: SwitchSettings): Promise<void> {
+    const raw = this.host.readSettings();
+    raw.activeProfileUid = s.activeProfileUid;
+    raw._switchInProgress = s._switchInProgress;
+    await this.host.saveSettings();
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
@@ -1,0 +1,56 @@
+import { App, FuzzySuggestModal } from "obsidian";
+
+import type { FocusProfileChoice } from "./FocusProfileCommands";
+
+/**
+ * ProfileFuzzyModal — thin Obsidian `FuzzySuggestModal` wrapper used by
+ * `FocusProfileCommands.fuzzyPick` (RFC 0a0791c1 §B.11). Resolves the
+ * caller's Promise with the chosen profile, or `null` when the user
+ * dismisses the picker without selecting anything.
+ *
+ * Lifecycle contract:
+ *   - On `onChooseItem` → resolve with the chosen value.
+ *   - On `onClose` without a prior choice → resolve with `null`.
+ *   - The Promise resolves exactly once; double-fire is suppressed via
+ *     a private flag so the «choose then close» sequence does not call
+ *     `resolve` twice.
+ *
+ * Active profile is decorated с trailing «✓ (active)» so users can see
+ * the current selection без duplicating the picker state.
+ */
+export class ProfileFuzzyModal extends FuzzySuggestModal<FocusProfileChoice> {
+  private resolved = false;
+  private readonly resolve: (value: FocusProfileChoice | null) => void;
+
+  constructor(
+    app: App,
+    private readonly options: FocusProfileChoice[],
+    title: string,
+    resolve: (value: FocusProfileChoice | null) => void,
+  ) {
+    super(app);
+    this.resolve = resolve;
+    this.setPlaceholder(title);
+  }
+
+  getItems(): FocusProfileChoice[] {
+    return this.options;
+  }
+
+  getItemText(item: FocusProfileChoice): string {
+    return item.isActive ? `${item.label} ✓ (active)` : item.label;
+  }
+
+  onChooseItem(item: FocusProfileChoice): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.resolve(item);
+  }
+
+  override onClose(): void {
+    super.onClose();
+    if (this.resolved) return;
+    this.resolved = true;
+    this.resolve(null);
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
@@ -48,9 +48,15 @@ export class ProfileFuzzyModal extends FuzzySuggestModal<FocusProfileChoice> {
   }
 
   override onClose(): void {
+    // Resolve BEFORE super.onClose() so a throw from Obsidian's lifecycle
+    // teardown cannot leave the awaiter pending forever (code-reviewer
+    // medium catch — Obsidian's FuzzySuggestModal.onClose runs DOM
+    // cleanup; rare, but if it throws the resolve below would be
+    // skipped → memory leak).
+    if (!this.resolved) {
+      this.resolved = true;
+      this.resolve(null);
+    }
     super.onClose();
-    if (this.resolved) return;
-    this.resolved = true;
-    this.resolve(null);
   }
 }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
@@ -1,0 +1,164 @@
+import type { App, TFile } from "obsidian";
+
+import type {
+  IProfileResolver,
+  ProfileResolution,
+} from "./FocusProfileSwitchManager";
+import { FOCUS_PROFILE_CLASS_UID } from "./FocusProfileSwitchManager";
+
+/**
+ * Vault-backed implementation of {@link IProfileResolver}. Reads
+ * `exo__FocusProfile` ABox assets через Obsidian metadataCache.
+ *
+ * Profile identification: an asset is a FocusProfile when its
+ * `exo__Instance_class` (string or array) contains a wikilink to the
+ * FocusProfile class UID `3de846cd-...` (frozen by RFC b6ba5595).
+ *
+ * Frontmatter fields consumed:
+ *   - `exo__Asset_uid` (string) — profile UID
+ *   - `exo__Asset_label` (string, optional) — display label; falls back to
+ *     `file.basename` when missing
+ *   - `exo__FocusProfile_includes` (string | string[]) — declared ontology
+ *     wikilinks; normalised to bare ontology URIs (без leading `[[` /
+ *     trailing `]]` / alias suffix `|...`)
+ *   - `exo__FocusProfile_extends` (string, optional) — parent profile
+ *     wikilink → UID
+ *   - `exo__FocusProfile_alwaysOnOverlay` (string | string[], optional) —
+ *     overlay ontology wikilinks; normalised identically
+ *
+ * Shared-ontology discovery: production scans the converter's RDF graph
+ * для ontology IRIs matching the `shared-` prefix pattern. v3 backward-
+ * compat scope omits the discovery hook — returns empty array so the
+ * `FocusProfileSwitchManager`'s TS-floor pattern match falls through
+ * to the hardcoded floor.
+ */
+export class VaultProfileResolver implements IProfileResolver {
+  private readonly app: App;
+
+  constructor(app: App) {
+    if (!app) throw new Error("VaultProfileResolver: app is required");
+    this.app = app;
+  }
+
+  async resolve(profileUid: string): Promise<ProfileResolution | null> {
+    if (typeof profileUid !== "string" || profileUid.length === 0) return null;
+    const file = this.findFocusProfileFileByUid(profileUid);
+    if (file === null) return null;
+
+    const fm = this.readFrontmatter(file);
+    if (fm === null) return null;
+
+    const includes = this.extractWikilinkList(fm["exo__FocusProfile_includes"]);
+    const alwaysOnOverlay = this.extractWikilinkList(
+      fm["exo__FocusProfile_alwaysOnOverlay"],
+    );
+    const extendsRaw = fm["exo__FocusProfile_extends"];
+    const extendsUid =
+      typeof extendsRaw === "string" && extendsRaw.length > 0
+        ? this.resolveExtendsToUid(extendsRaw)
+        : null;
+    const label =
+      typeof fm["exo__Asset_label"] === "string"
+        ? (fm["exo__Asset_label"] as string)
+        : file.basename;
+
+    return {
+      uid: profileUid,
+      includes,
+      extends: extendsUid,
+      alwaysOnOverlay,
+      label,
+    };
+  }
+
+  async discoverSharedOntologies(): Promise<string[]> {
+    // v3 backward-compat: TS-floor's hardcoded `shared-` pattern match
+    // covers the empirically-relevant case (vault-2025 shared-identities).
+    // Production RDF-walk discovery deferred to Phase C+D follow-up.
+    return [];
+  }
+
+  /**
+   * Walks the vault searching for the FocusProfile asset whose
+   * `exo__Asset_uid` matches. Returns `null` if absent.
+   *
+   * Exposed for `profileLister` reuse — the plugin's command-palette
+   * handler scans the vault для all FocusProfile assets, so the same
+   * frontmatter discrimination logic lives here.
+   */
+  public findFocusProfileFileByUid(uid: string): TFile | null {
+    for (const file of this.listFocusProfileFiles()) {
+      const fm = this.readFrontmatter(file);
+      if (fm === null) continue;
+      if (fm["exo__Asset_uid"] === uid) return file;
+    }
+    return null;
+  }
+
+  /**
+   * Walks the vault returning every FocusProfile asset. Caller filters
+   * по UID / label as needed. Used by `profileLister` to populate the
+   * fuzzy picker.
+   */
+  public listFocusProfileFiles(): TFile[] {
+    const out: TFile[] = [];
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const fm = this.readFrontmatter(file);
+      if (fm === null) continue;
+      if (this.isFocusProfileFrontmatter(fm)) out.push(file);
+    }
+    return out;
+  }
+
+  private isFocusProfileFrontmatter(fm: Record<string, unknown>): boolean {
+    const raw = fm["exo__Instance_class"];
+    const classes: unknown[] = Array.isArray(raw) ? raw : raw ? [raw] : [];
+    for (const c of classes) {
+      if (typeof c !== "string") continue;
+      if (c.includes(FOCUS_PROFILE_CLASS_UID)) return true;
+    }
+    return false;
+  }
+
+  private readFrontmatter(file: TFile): Record<string, unknown> | null {
+    const cache = this.app.metadataCache.getFileCache(file);
+    const fm = cache?.frontmatter;
+    if (fm === null || fm === undefined) return null;
+    return fm as Record<string, unknown>;
+  }
+
+  private extractWikilinkList(value: unknown): string[] {
+    const items: unknown[] = Array.isArray(value)
+      ? value
+      : value !== undefined && value !== null
+        ? [value]
+        : [];
+    const out: string[] = [];
+    for (const raw of items) {
+      if (typeof raw !== "string") continue;
+      const cleaned = raw
+        .trim()
+        .replace(/^\[\[/, "")
+        .replace(/\]\]$/, "")
+        .split("|")[0]
+        .trim();
+      if (cleaned.length > 0) out.push(cleaned);
+    }
+    return out;
+  }
+
+  /**
+   * `_extends` is stored as a wikilink to the parent profile's UID-named
+   * file (`[[<parent-uid>]]`). Strip wikilink syntax to expose the UID
+   * directly — the SwitchManager's chain walker keys by UID.
+   */
+  private resolveExtendsToUid(raw: string): string | null {
+    const cleaned = raw
+      .trim()
+      .replace(/^\[\[/, "")
+      .replace(/\]\]$/, "")
+      .split("|")[0]
+      .trim();
+    return cleaned.length === 0 ? null : cleaned;
+  }
+}

--- a/packages/obsidian-plugin/tests/__mocks__/obsidian.ts
+++ b/packages/obsidian-plugin/tests/__mocks__/obsidian.ts
@@ -302,6 +302,9 @@ export class FuzzySuggestModal<T> {
 
   onChooseItem(_item: T, _evt: MouseEvent | KeyboardEvent): void {}
 
+  onOpen(): void {}
+  onClose(): void {}
+
   open(): void {}
   close(): void {}
 }

--- a/packages/obsidian-plugin/tests/unit/PluginRdfIndexerAdapter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PluginRdfIndexerAdapter.test.ts
@@ -1,0 +1,30 @@
+import { PluginRdfIndexerAdapter } from "../../src/infrastructure/adapters/PluginRdfIndexerAdapter";
+
+describe("PluginRdfIndexerAdapter", () => {
+  it("throws when constructed without an indexer", () => {
+    expect(
+      () => new PluginRdfIndexerAdapter(undefined as any),
+    ).toThrow(/indexer is required/);
+  });
+
+  it("delegates refresh(effectiveOntologies) to indexer.refresh(set)", async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    const indexer = { refresh } as any;
+    const adapter = new PluginRdfIndexerAdapter(indexer);
+    const set = new Set([
+      "https://exocortex.my/ontology/exo",
+      "https://exocortex.my/ontology/ems",
+    ]);
+    await adapter.refresh(set);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledWith(set);
+  });
+
+  it("propagates errors from indexer.refresh", async () => {
+    const indexer = {
+      refresh: jest.fn().mockRejectedValue(new Error("boom")),
+    } as any;
+    const adapter = new PluginRdfIndexerAdapter(indexer);
+    await expect(adapter.refresh(new Set())).rejects.toThrow(/boom/);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/PluginSettingsStoreAdapter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PluginSettingsStoreAdapter.test.ts
@@ -1,0 +1,68 @@
+import { PluginSettingsStoreAdapter } from "../../src/infrastructure/adapters/PluginSettingsStoreAdapter";
+
+describe("PluginSettingsStoreAdapter", () => {
+  it("throws when host is undefined", () => {
+    expect(
+      () => new PluginSettingsStoreAdapter(undefined as any),
+    ).toThrow(/host is required/);
+  });
+
+  it("load defaults missing fields to null + false", async () => {
+    const settings: Record<string, unknown> = {};
+    const adapter = new PluginSettingsStoreAdapter({
+      readSettings: () => settings,
+      saveSettings: async () => {},
+    });
+    const s = await adapter.load();
+    expect(s.activeProfileUid).toBeNull();
+    expect(s._switchInProgress).toBe(false);
+  });
+
+  it("load returns existing values when present", async () => {
+    const settings: Record<string, unknown> = {
+      activeProfileUid: "p1",
+      _switchInProgress: true,
+    };
+    const adapter = new PluginSettingsStoreAdapter({
+      readSettings: () => settings,
+      saveSettings: async () => {},
+    });
+    const s = await adapter.load();
+    expect(s.activeProfileUid).toBe("p1");
+    expect(s._switchInProgress).toBe(true);
+  });
+
+  it("save mutates the live settings object AND calls saveSettings", async () => {
+    const settings: Record<string, unknown> = {
+      activeProfileUid: null,
+      _switchInProgress: false,
+    };
+    const saveSettings = jest.fn().mockResolvedValue(undefined);
+    const adapter = new PluginSettingsStoreAdapter({
+      readSettings: () => settings,
+      saveSettings,
+    });
+    await adapter.save({ activeProfileUid: "p2", _switchInProgress: true });
+    expect(settings.activeProfileUid).toBe("p2");
+    expect(settings._switchInProgress).toBe(true);
+    expect(saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("load coerces non-string activeProfileUid to null", async () => {
+    const settings: Record<string, unknown> = { activeProfileUid: 42 };
+    const adapter = new PluginSettingsStoreAdapter({
+      readSettings: () => settings,
+      saveSettings: async () => {},
+    });
+    expect((await adapter.load()).activeProfileUid).toBeNull();
+  });
+
+  it("load coerces non-boolean _switchInProgress to false", async () => {
+    const settings: Record<string, unknown> = { _switchInProgress: "yes" };
+    const adapter = new PluginSettingsStoreAdapter({
+      readSettings: () => settings,
+      saveSettings: async () => {},
+    });
+    expect((await adapter.load())._switchInProgress).toBe(false);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
@@ -1,0 +1,71 @@
+import { ProfileFuzzyModal } from "../../src/infrastructure/adapters/ProfileFuzzyModal";
+import type { FocusProfileChoice } from "../../src/infrastructure/adapters/FocusProfileCommands";
+
+const fakeApp = {} as any;
+
+const profiles: FocusProfileChoice[] = [
+  { uid: "uid-personal", label: "Personal" },
+  { uid: "uid-work", label: "Work", isActive: true },
+  { uid: "uid-reading", label: "Reading" },
+];
+
+describe("ProfileFuzzyModal", () => {
+  it("getItems returns the constructor-supplied options", () => {
+    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", () => {});
+    expect(modal.getItems()).toBe(profiles);
+  });
+
+  it("getItemText renders active marker for the active profile only", () => {
+    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", () => {});
+    expect(modal.getItemText(profiles[0])).toBe("Personal");
+    expect(modal.getItemText(profiles[1])).toBe("Work ✓ (active)");
+    expect(modal.getItemText(profiles[2])).toBe("Reading");
+  });
+
+  it("onChooseItem resolves with the chosen profile exactly once", () => {
+    const resolve = jest.fn();
+    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
+    modal.onChooseItem(profiles[1]);
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledWith(profiles[1]);
+
+    // Subsequent close should NOT double-resolve.
+    modal.onClose();
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("onClose without a prior choice resolves with null", () => {
+    const resolve = jest.fn();
+    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
+    modal.onClose();
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledWith(null);
+  });
+
+  it("double onClose is idempotent — resolves at most once", () => {
+    const resolve = jest.fn();
+    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
+    modal.onClose();
+    modal.onClose();
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("double onChooseItem is idempotent — resolves at most once", () => {
+    const resolve = jest.fn();
+    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
+    modal.onChooseItem(profiles[0]);
+    modal.onChooseItem(profiles[1]);
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledWith(profiles[0]);
+  });
+
+  it("setPlaceholder is invoked on construction with the provided title", () => {
+    const modal = new ProfileFuzzyModal(
+      fakeApp,
+      profiles,
+      "Switch focus profile",
+      () => {},
+    );
+    expect(modal.inputEl.placeholder).toBe("Switch focus profile");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
@@ -1,0 +1,185 @@
+import { VaultProfileResolver } from "../../src/infrastructure/adapters/VaultProfileResolver";
+import { FOCUS_PROFILE_CLASS_UID } from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+
+interface FakeFile {
+  path: string;
+  basename: string;
+}
+
+function makeApp(files: { file: FakeFile; fm: Record<string, unknown> }[]) {
+  const fileList = files.map((f) => f.file);
+  const fmByPath = new Map(files.map((f) => [f.file.path, f.fm]));
+  return {
+    vault: {
+      getMarkdownFiles: () => fileList,
+    },
+    metadataCache: {
+      getFileCache: (file: FakeFile) => {
+        const fm = fmByPath.get(file.path);
+        return fm !== undefined ? { frontmatter: fm } : null;
+      },
+    },
+  } as any;
+}
+
+describe("VaultProfileResolver.listFocusProfileFiles", () => {
+  it("returns files whose Instance_class wikilink contains the FocusProfile UID", () => {
+    const app = makeApp([
+      {
+        file: { path: "a.md", basename: "a" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]`,
+          exo__Asset_uid: "p1",
+          exo__Asset_label: "Profile One",
+        },
+      },
+      {
+        file: { path: "b.md", basename: "b" },
+        fm: {
+          exo__Instance_class: "[[some-other-class]]",
+          exo__Asset_uid: "x",
+        },
+      },
+      {
+        file: { path: "c.md", basename: "c" },
+        fm: {
+          exo__Instance_class: [
+            "[[ems__Project]]",
+            `[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]`,
+          ],
+          exo__Asset_uid: "p2",
+        },
+      },
+    ]);
+    const resolver = new VaultProfileResolver(app);
+    const found = resolver.listFocusProfileFiles().map((f) => f.path);
+    expect(found.sort()).toEqual(["a.md", "c.md"]);
+  });
+
+  it("ignores files без frontmatter", () => {
+    const app = makeApp([
+      {
+        file: { path: "a.md", basename: "a" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "p1",
+        },
+      },
+    ]);
+    // Inject a file без frontmatter mapping
+    app.vault.getMarkdownFiles = () => [
+      { path: "a.md", basename: "a" },
+      { path: "b.md", basename: "b" },
+    ];
+    const resolver = new VaultProfileResolver(app);
+    expect(resolver.listFocusProfileFiles().map((f) => f.path)).toEqual([
+      "a.md",
+    ]);
+  });
+
+  it("findFocusProfileFileByUid returns null when UID is empty", () => {
+    const app = makeApp([]);
+    expect(new VaultProfileResolver(app).findFocusProfileFileByUid("")).toBeNull();
+  });
+
+  it("findFocusProfileFileByUid matches by exo__Asset_uid", () => {
+    const app = makeApp([
+      {
+        file: { path: "a.md", basename: "a" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "p1",
+        },
+      },
+      {
+        file: { path: "b.md", basename: "b" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "p2",
+        },
+      },
+    ]);
+    const resolver = new VaultProfileResolver(app);
+    const file = resolver.findFocusProfileFileByUid("p2");
+    expect(file?.path).toBe("b.md");
+  });
+});
+
+describe("VaultProfileResolver.resolve", () => {
+  it("returns null when profile UID is empty or missing", async () => {
+    const app = makeApp([]);
+    const resolver = new VaultProfileResolver(app);
+    expect(await resolver.resolve("")).toBeNull();
+    expect(await resolver.resolve("missing")).toBeNull();
+  });
+
+  it("normalises wikilink list fields, strips aliases, drops empties", async () => {
+    const app = makeApp([
+      {
+        file: { path: "p.md", basename: "p" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "p1",
+          exo__Asset_label: "Personal",
+          exo__FocusProfile_includes: [
+            "[[https://exocortex.my/ontology/ems|ems]]",
+            "[[https://exocortex.my/ontology/ims]]",
+            "",
+          ],
+          exo__FocusProfile_alwaysOnOverlay:
+            "[[https://exocortex.my/ontology/exocmd]]",
+          exo__FocusProfile_extends: "[[parent-uid|profile-base]]",
+        },
+      },
+    ]);
+    const resolver = new VaultProfileResolver(app);
+    const r = await resolver.resolve("p1");
+    expect(r).not.toBeNull();
+    expect(r!.uid).toBe("p1");
+    expect(r!.label).toBe("Personal");
+    expect(r!.includes).toEqual([
+      "https://exocortex.my/ontology/ems",
+      "https://exocortex.my/ontology/ims",
+    ]);
+    expect(r!.alwaysOnOverlay).toEqual([
+      "https://exocortex.my/ontology/exocmd",
+    ]);
+    expect(r!.extends).toBe("parent-uid");
+  });
+
+  it("falls back к file basename when label is absent", async () => {
+    const app = makeApp([
+      {
+        file: { path: "fallback.md", basename: "fallback" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "p1",
+        },
+      },
+    ]);
+    const r = await new VaultProfileResolver(app).resolve("p1");
+    expect(r?.label).toBe("fallback");
+  });
+
+  it("returns extends=null when the field is missing", async () => {
+    const app = makeApp([
+      {
+        file: { path: "p.md", basename: "p" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "p1",
+        },
+      },
+    ]);
+    const r = await new VaultProfileResolver(app).resolve("p1");
+    expect(r?.extends).toBeNull();
+  });
+});
+
+describe("VaultProfileResolver.discoverSharedOntologies", () => {
+  it("returns empty array (v3 backward-compat — TS-floor pattern handles shared- prefix)", async () => {
+    expect(
+      await new VaultProfileResolver(makeApp([])).discoverSharedOntologies(),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #3322. Parent RFC `0a0791c1-3808-42fd-bc7f-bdd127ac7b24`.

## Summary

Wires the B.7 `FocusProfileCommands` handler (PR #3317) into Obsidian's command palette с two entries — Switch focus profile + Push current assetspace. Both are now visible in Cmd+P and operational end-to-end (with PAT-conditional graceful degradation for the push command).

## What changed

### Adapters added (`infrastructure/adapters/`)
- **`ProfileFuzzyModal`** — `FuzzySuggestModal<FocusProfileChoice>` wrapper resolving the handler's Promise on choose / dismiss. Idempotent double-fire guard.
- **`VaultProfileResolver`** — `IProfileResolver` reading vault FocusProfile ABox assets через Obsidian metadataCache. Normalises wikilink list / extends fields.
- **`PluginRdfIndexerAdapter`** — `IRdfIndexer` threading the active profile's effective ontology set into the live `VaultRDFIndexer.refresh(set)` path (Issue #3321 wiring).
- **`PluginSettingsStoreAdapter`** — `ISettingsStore` over `plugin.settings` + `saveData()`.

### Plugin wiring
`registerFocusProfileCommands()` (try/catch-wrapped в onload) constructs:
- `PluginLockManager` (B.6) с defaults
- `FocusProfileSwitchManager` (B.4) с full real dependency chain
- `AssetSpaceManager` (B.3) — **only when GitHub PAT is configured в `data.local.json`**; absent PAT yields a lookup-only stub that surfaces «Configure PAT» Notice on push without breaking Switch
- `FocusProfileCommands` handler с profileLister (sorted alphabetical, active-marker flag), `fuzzyPick` wrapping `ProfileFuzzyModal`

### Infrastructure exposed
- `SPARQLApi.getRdfIndexer()` + `SPARQLQueryService.getIndexer()` — thin passthrough к the live `VaultRDFIndexer` instance so adapters can thread the effective set.

## Tests

25 new unit tests + Obsidian mock enhancement:
- `ProfileFuzzyModal` (7) — getItems, getItemText active-marker, choose, close-without-choice, double-fire idempotency, setPlaceholder
- `VaultProfileResolver` (10) — listFocusProfileFiles class-discrimination, wikilink normalisation, label fallback, missing extends, discoverSharedOntologies v3-stub
- `PluginRdfIndexerAdapter` (3) — delegation, error propagation, required-indexer guard
- `PluginSettingsStoreAdapter` (6) — load defaults, load existing, save mutates+persists, type coercion

Obsidian mock gained `onOpen()` + `onClose()` on `FuzzySuggestModal` to match real API surface (тест override hook).

Regression: 39 existing FocusProfile* tests pass. Typecheck clean monorepo-wide. Lint clean on touched files.

## Acceptance Criteria (from issue)

- [x] Both commands registered (visible in Cmd+P)
- [x] Switch command opens fuzzy picker, lists FocusProfile assets
- [x] Switch command success path triggers B.4 + shows Notice (via notifier.info)
- [x] Push command identifies AS correctly from active file
- [x] Push command handles all error paths (no active / not in AS / unknown AS / push fail / PAT absent) с appropriate Notices
- [ ] UI smoke test passed by user — pending post-merge BRAT update + manual smoke

## Test plan

- [ ] `Cmd+P → Switch focus profile` → fuzzy picker appears с FocusProfile assets, active marked ✓ (active)
- [ ] Select profile-personal → Notice «Switching to Personal…» → completion Notice «Switched to Personal (Nms)»
- [ ] `Cmd+P → Push current assetspace` while inside `assetspaces/exo/` file → push attempt (Notice success / PAT-absent error)
- [ ] Same command while inside `03 Knowledge/` file → Notice «Not in an assetspace folder»
- [ ] Same command с no active file → Notice «No active file — open a note inside assetspaces/<as>/ first»

## Notes

- `_switchInProgress` is persisted в `plugin.settings` (data.json sync). Per-device override is а Phase D follow-up per CLAUDE.md FocusProfile section.
- `recoverIfNeeded()` (`FocusProfileSwitchManager`) is NOT called from onload — deferred к follow-up Issue once a deeper test-vault crash-recovery e2e is added.
- `assetSpaceFolderToUid` map wiring for the indexer adapter is also deferred — the converter degrades к no-filter fall-back with а warn-log per R15 (Issue #3321).