### PR TITLE
feat(plugin): apply persisted activeProfileUid at onload (RFC 0a0791c1 #3324)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -709,8 +709,14 @@ export default class ExocortexPlugin extends Plugin {
       // real adapters. Wrapped в try/catch: any failure here должен NOT
       // abort the rest of onload — commands simply won't appear in
       // Cmd+P, but plugin remains usable.
+      //
+      // RFC 0a0791c1 #3324 — returns `reapplyActiveProfileFilter` so the
+      // post-`metadataCache.on("resolved")` chain can re-run the wiring
+      // against a fully-parsed cache. The initial invocation at line ~713
+      // may scan a partial cache; the re-run closes the race.
+      let reapplyActiveProfileFilter: (() => Promise<void>) | null = null;
       try {
-        await this.registerFocusProfileCommands();
+        reapplyActiveProfileFilter = await this.registerFocusProfileCommands();
       } catch (error) {
         this.logger.error(
           "[ExocortexPlugin] FocusProfile commands registration failed",
@@ -859,6 +865,37 @@ export default class ExocortexPlugin extends Plugin {
           const initPromise = this.eagerInitPromise ?? Promise.resolve();
           void initPromise
             .then(() => this.sparql.refresh())
+            .then(async () => {
+              // RFC 0a0791c1 #3324 — re-apply the active FocusProfile
+              // filter now that metadataCache has fully resolved. The
+              // first invocation at registerFocusProfileCommands time
+              // may have scanned a partial cache (AS files not yet
+              // parsed → empty containsOntology map → R15 degradation
+              // to no-filter). Re-running here closes the race; the
+              // helper is idempotent and recomputes from current vault
+              // state. Then a single follow-up sparql.refresh() walks
+              // the vault with the now-correct effective set.
+              //
+              // Gated on `activeProfileUid !== null` to avoid an extra
+              // refresh in the default null-profile path (which is the
+              // case covered by the post-resolve one-shot regression
+              // tests). When profile is null the helper would no-op and
+              // the second refresh would only re-walk the same data.
+              const hasActiveProfile =
+                typeof (this.settings as Record<string, unknown>)
+                  .activeProfileUid === "string";
+              if (reapplyActiveProfileFilter !== null && hasActiveProfile) {
+                try {
+                  await reapplyActiveProfileFilter();
+                  await this.sparql.refresh();
+                } catch (err) {
+                  this.logger.warn(
+                    "[ExocortexPlugin] active FocusProfile filter re-apply failed — indexer keeps prior wiring",
+                    err instanceof Error ? err : new Error(String(err)),
+                  );
+                }
+              }
+            })
             .then(() => {
               // RFC c7da0bca Phase 3b-main — drop the lazy loader's
               // monotonic load-mark now that the store has been
@@ -2187,7 +2224,7 @@ export default class ExocortexPlugin extends Plugin {
    * crash. Construction errors here are caught by the caller's try/catch
    * in `onload()`.
    */
-  private async registerFocusProfileCommands(): Promise<void> {
+  private async registerFocusProfileCommands(): Promise<() => Promise<void>> {
     const lockMgr = new PluginLockManager({ app: this.app });
     const resolver = new VaultProfileResolver(this.app);
     const rdfIndexer = new PluginRdfIndexerAdapter(this.sparql.getRdfIndexer());
@@ -2216,7 +2253,12 @@ export default class ExocortexPlugin extends Plugin {
     // Wrapped in try/catch so a scan failure here cannot abort the rest
     // of `registerFocusProfileCommands` — the indexer falls back to full
     // vault, matching the no-profile default.
-    try {
+    //
+    // Re-runnable closure: the resolved-handler chain in `onload` calls
+    // `reapplyActiveProfileFilter()` again after `sparql.refresh()` to
+    // close the cold-start race where `metadataCache.getFileCache` may
+    // still return null for AS files at this earlier timing.
+    const reapplyActiveProfileFilter = async (): Promise<void> => {
       const persistedProfileUid =
         typeof (this.settings as Record<string, unknown>).activeProfileUid ===
         "string"
@@ -2230,6 +2272,9 @@ export default class ExocortexPlugin extends Plugin {
         activeProfileUid: persistedProfileUid,
         logger: this.logger,
       });
+    };
+    try {
+      await reapplyActiveProfileFilter();
     } catch (error) {
       this.logger.warn(
         "[ExocortexPlugin] applyActiveProfileFilter failed — indexer falls back to full vault",
@@ -2334,6 +2379,8 @@ export default class ExocortexPlugin extends Plugin {
     this.logger.info(
       "[ExocortexPlugin] FocusProfile palette commands registered",
     );
+
+    return reapplyActiveProfileFilter;
   }
 
   /**

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -100,6 +100,7 @@ import { VaultProfileResolver } from "./infrastructure/adapters/VaultProfileReso
 import { PluginRdfIndexerAdapter } from "./infrastructure/adapters/PluginRdfIndexerAdapter";
 import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSettingsStoreAdapter";
 import { ProfileFuzzyModal } from "./infrastructure/adapters/ProfileFuzzyModal";
+import { applyActiveProfileFilter } from "./infrastructure/adapters/FocusProfileOnloadWiring";
 import {
   AssetSpaceManager,
   ASSET_SPACE_CLASS_UID,
@@ -2203,6 +2204,38 @@ export default class ExocortexPlugin extends Plugin {
       settingsStore,
       notify: (message) => this.notifier.info(message),
     });
+
+    // Issue #3324 — apply the persisted `activeProfileUid` to the indexer's
+    // filter setters BEFORE the eager-init / metadataCache-resolved chain
+    // first calls `convertVault`. The helper is no-op when the field is
+    // null (default), translates Ontology UIDs declared in the profile to
+    // AS UIDs via `exo__AssetSpace_containsOntology`, and degrades to no-
+    // filter when the translation produces zero folder overlap (R15 self-
+    // brick mitigation surfaced one layer earlier than the converter).
+    //
+    // Wrapped in try/catch so a scan failure here cannot abort the rest
+    // of `registerFocusProfileCommands` — the indexer falls back to full
+    // vault, matching the no-profile default.
+    try {
+      const persistedProfileUid =
+        typeof (this.settings as Record<string, unknown>).activeProfileUid ===
+        "string"
+          ? ((this.settings as Record<string, unknown>)
+              .activeProfileUid as string)
+          : null;
+      await applyActiveProfileFilter({
+        app: this.app,
+        switchMgr,
+        indexer: this.sparql.getRdfIndexer(),
+        activeProfileUid: persistedProfileUid,
+        logger: this.logger,
+      });
+    } catch (error) {
+      this.logger.warn(
+        "[ExocortexPlugin] applyActiveProfileFilter failed — indexer falls back to full vault",
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
 
     // Crash-recovery: если previous session left `_switchInProgress=true`
     // в settings (FocusProfileSwitchManager docstring line 18), re-trigger

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -201,6 +201,25 @@ export interface ExocortexSettings {
    * buttons appear via convertVault path eventually).
    */
   lazyBootstrapFolders: string[];
+  /**
+   * RFC 0a0791c1 — UID of the active `exo__FocusProfile` (or `null` for the
+   * full-vault default). When non-null the plugin at onload computes the
+   * effective AssetSpace set declared by the profile (transitive `_extends` +
+   * `_alwaysOnOverlay`), translates Ontology references to the AssetSpaces
+   * containing them, layers in the TS-floor (Vision Lock #17 — `$exo`,
+   * `$exocmd`, `$shared-identities` AS UIDs), and wires the result into the
+   * `VaultRDFIndexer` so cold-start `convertVault()` skips files outside the
+   * effective set.
+   *
+   * Persisted by `FocusProfileSwitchManager.switchProfile` BEFORE the RDF
+   * re-index runs (Architect #2 atomicity invariant) — the field formalises
+   * what `PluginSettingsStoreAdapter` already round-tripped via the loose
+   * `[key: string]: unknown` index signature, so existing user data.json
+   * entries continue to load without migration.
+   *
+   * Issue #3324 — onload wiring.
+   */
+  activeProfileUid: string | null;
   [key: string]: unknown;
 }
 
@@ -235,4 +254,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
     "assetspaces/ims/",
     "assetspaces/exocmd/",
   ],
+  activeProfileUid: null,
 };

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileOnloadWiring.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileOnloadWiring.ts
@@ -147,6 +147,12 @@ export async function applyActiveProfileFilter(
   // directly in profiles works without changing this helper.
   const folderMapValues = new Set(folderMap.values());
   const effectiveAsUids = new Set<string>();
+  // Track UIDs that fell through translation so the engagement log can
+  // surface them — without this breadcrumb a user investigating «why does
+  // my filter look weak» has no diagnostic. Distinct from the zero-overlap
+  // R15 degradation below (which trips when NO entry translates); this
+  // catches the partial case (some entries translate, others don't).
+  const untranslated: string[] = [];
   for (const uid of declaredSet) {
     if (folderMapValues.has(uid)) {
       // Already an AS UID — accept directly.
@@ -156,10 +162,12 @@ export async function applyActiveProfileFilter(
     const translated = ontologyToAs.get(uid);
     if (translated !== undefined) {
       effectiveAsUids.add(translated);
+      continue;
     }
     // Unmapped UID — Ontology with no declaring AssetSpace (e.g.
-    // shared-identities anchors per мульти-anchor pattern). Silently drop
-    // here; surface via the degradation outcome below when no overlap remains.
+    // shared-identities anchors per мульти-anchor pattern). Surface in
+    // engagement log so the user can trace which references silently dropped.
+    untranslated.push(uid);
   }
 
   // Always lay in the TS-floor at AS-UID level (Vision Lock #17).
@@ -190,10 +198,16 @@ export async function applyActiveProfileFilter(
 
   indexer.setEffectiveOntologies(effectiveAsUids);
   indexer.setAssetSpaceFolderToUid(folderMap);
+  const untranslatedSummary =
+    untranslated.length === 0
+      ? ""
+      : ` ${untranslated.length} declared UIDs failed translation (no AssetSpace_containsOntology mapping; ` +
+        `examples: ${untranslated.slice(0, 3).join(", ")}${untranslated.length > 3 ? ", …" : ""}). ` +
+        `Likely the shared-identities мульти-anchor case — see PR #3328 body.`;
   logger.info(
     `[FocusProfileOnloadWiring] activeProfileUid=${activeProfileUid} wired — ` +
       `${effectiveAsUids.size} effective AS UIDs (incl. ${TS_FLOOR_ASSETSPACE_UIDS.size} floor), ` +
-      `${folderMap.size} folders mapped.`,
+      `${folderMap.size} folders mapped.${untranslatedSummary}`,
   );
   return {
     outcome: "engaged",

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileOnloadWiring.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileOnloadWiring.ts
@@ -1,0 +1,289 @@
+import type { App, TFile } from "obsidian";
+import type { ILogger } from "exocortex";
+
+import { ASSET_SPACE_CLASS_UID } from "./AssetSpaceManager";
+import type { FocusProfileSwitchManager } from "./FocusProfileSwitchManager";
+
+/**
+ * Issue #3324 — wire the persisted `activeProfileUid` into the
+ * `VaultRDFIndexer` filter at plugin onload, before the first `convertVault`
+ * pass runs. Sibling to {@link FocusProfileSwitchManager} (B.4) which handles
+ * runtime switches; this module handles cold-start application of the
+ * previously-saved selection.
+ *
+ * ## Filter semantics — Ontology UID vs AssetSpace UID
+ *
+ * `VaultRDFIndexer.setEffectiveOntologies(set)` operates on **AssetSpace UIDs**
+ * (per `shouldSkipFileForEffectiveSet` in `NoteToRDFConverter`): a file under
+ * `assetspaces/<folder>/` is included iff the folder maps to an AS UID in the
+ * effective set. User-authored `exo__FocusProfile` ABox assets, however,
+ * declare wikilinks to **Ontology UIDs** (`_alwaysOnOverlay`, `_includes`) —
+ * Ontology is the homoiconic semantic primitive, AssetSpace is its container.
+ *
+ * The wiring bridges the two via the `exo__AssetSpace_containsOntology`
+ * predicate: each AS asset declares the Ontology UIDs it owns. We build a
+ * reverse `Ontology → AS` map at onload and translate the profile's effective
+ * set through it. UIDs in the profile that are already AS UIDs (declared
+ * directly, future-proof shape) pass through unchanged.
+ *
+ * ## Safe-degrade contract (R15 mitigation)
+ *
+ * Production vault data may have incomplete `containsOntology` declarations
+ * (e.g. shared-identities AS deliberately omits it — мульти-anchor pattern).
+ * When the translated set has zero overlap with the live folder map, engaging
+ * the filter would skip every `assetspaces/<folder>/` file and brick the
+ * plugin. To prevent that, the helper degrades to no-filter and logs a WARN
+ * — same shape as the converter's R15 fallback, surfaced one layer earlier so
+ * the indexer never sees the broken set.
+ *
+ * The TS-floor (Vision Lock #17) is always added at AS UID level so that
+ * `$exo`, `$exocmd`, and `$shared-identities` survive any profile config —
+ * users cannot accidentally exclude the plugin's own TBox foundations.
+ */
+
+/** AssetSpace UID of `$exo` (per `assetspaces/exo/49fd2e56-...md`). */
+export const TS_FLOOR_AS_UID_EXO = "49fd2e56-4656-4ca7-a789-f472b16ea260";
+/** AssetSpace UID of `$exocmd` (per `assetspaces/exocmd/c9c65b0f-...md`). */
+export const TS_FLOOR_AS_UID_EXOCMD = "c9c65b0f-1e01-47c1-a1f9-1bf70b11df6a";
+/**
+ * AssetSpace UID of `$shared-identities` (per
+ * `assetspaces/shared-identities/0cde1557-...md`). Container for cross-cutting
+ * Ontology anchors (`$shared-identities`, `$kitelev`, ...) — its TBox must
+ * remain reachable to keep the UID-canon resolver functioning.
+ */
+export const TS_FLOOR_AS_UID_SHARED_IDENTITIES =
+  "0cde1557-6320-4bd0-a7c4-8b72afc38720";
+
+/** TS-floor AssetSpace UIDs (Vision Lock #17, AS-UID level). */
+export const TS_FLOOR_ASSETSPACE_UIDS: ReadonlySet<string> = new Set([
+  TS_FLOOR_AS_UID_EXO,
+  TS_FLOOR_AS_UID_EXOCMD,
+  TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+]);
+
+/**
+ * Shape of the indexer surface this helper writes into. Narrowed to the
+ * three methods we touch so unit tests can substitute a stub without
+ * dragging the full `VaultRDFIndexer` lifecycle.
+ */
+export interface IEffectiveOntologyAwareIndexer {
+  setEffectiveOntologies(set: ReadonlySet<string> | null): void;
+  setAssetSpaceFolderToUid(map: ReadonlyMap<string, string> | null): void;
+}
+
+export interface ApplyActiveProfileFilterOptions {
+  app: App;
+  switchMgr: FocusProfileSwitchManager;
+  indexer: IEffectiveOntologyAwareIndexer;
+  activeProfileUid: string | null;
+  logger: ILogger;
+}
+
+export interface ApplyActiveProfileFilterResult {
+  /**
+   * `"engaged"` — filter wired; cold-start walk will honour the effective set.
+   * `"no-profile"` — `activeProfileUid` is null; no filter wired (full vault).
+   * `"degraded"` — translation produced zero overlap with folder map; filter
+   *   skipped to prevent self-brick; cold-start indexes full vault.
+   * `"error"` — resolution / scan threw; filter skipped; full vault.
+   */
+  outcome: "engaged" | "no-profile" | "degraded" | "error";
+  /** Effective AS-UID set that was wired (or `null` when no engagement). */
+  effective: ReadonlySet<string> | null;
+  /** Folder→AS-UID map that was wired (or `null` when no engagement). */
+  folderMap: ReadonlyMap<string, string> | null;
+}
+
+/**
+ * Apply the persisted `activeProfileUid` to the indexer's filter setters.
+ * Idempotent — caller may invoke at onload AND at every metadata-resolved
+ * re-scan; the helper recomputes from current vault state each time.
+ *
+ * Never throws — failures degrade to `outcome: "error"` with full-vault
+ * fallback. Caller's onload chain remains unblocked.
+ */
+export async function applyActiveProfileFilter(
+  options: ApplyActiveProfileFilterOptions,
+): Promise<ApplyActiveProfileFilterResult> {
+  const { app, switchMgr, indexer, activeProfileUid, logger } = options;
+
+  if (activeProfileUid === null) {
+    // Explicit null wipes prior state so a previous engagement does not
+    // bleed into the next onload after the user clears the profile.
+    indexer.setEffectiveOntologies(null);
+    indexer.setAssetSpaceFolderToUid(null);
+    return { outcome: "no-profile", effective: null, folderMap: null };
+  }
+
+  let declaredSet: Set<string>;
+  try {
+    declaredSet = await switchMgr.resolveEffectiveSet(activeProfileUid);
+  } catch (e) {
+    logger.warn(
+      `[FocusProfileOnloadWiring] resolveEffectiveSet(${activeProfileUid}) threw — falling back to no-filter. ${String(e)}`,
+    );
+    indexer.setEffectiveOntologies(null);
+    indexer.setAssetSpaceFolderToUid(null);
+    return { outcome: "error", effective: null, folderMap: null };
+  }
+
+  let folderMap: Map<string, string>;
+  let ontologyToAs: Map<string, string>;
+  try {
+    const scan = scanAssetSpaces(app);
+    folderMap = scan.folderMap;
+    ontologyToAs = scan.ontologyToAs;
+  } catch (e) {
+    logger.warn(
+      `[FocusProfileOnloadWiring] AssetSpace vault scan threw — falling back to no-filter. ${String(e)}`,
+    );
+    indexer.setEffectiveOntologies(null);
+    indexer.setAssetSpaceFolderToUid(null);
+    return { outcome: "error", effective: null, folderMap: null };
+  }
+
+  // Translate Ontology UIDs → AS UIDs. Pass-through entries that are already
+  // AS UIDs (folder map values), so a future migration to declaring AS UIDs
+  // directly in profiles works without changing this helper.
+  const folderMapValues = new Set(folderMap.values());
+  const effectiveAsUids = new Set<string>();
+  for (const uid of declaredSet) {
+    if (folderMapValues.has(uid)) {
+      // Already an AS UID — accept directly.
+      effectiveAsUids.add(uid);
+      continue;
+    }
+    const translated = ontologyToAs.get(uid);
+    if (translated !== undefined) {
+      effectiveAsUids.add(translated);
+    }
+    // Unmapped UID — Ontology with no declaring AssetSpace (e.g.
+    // shared-identities anchors per мульти-anchor pattern). Silently drop
+    // here; surface via the degradation outcome below when no overlap remains.
+  }
+
+  // Always lay in the TS-floor at AS-UID level (Vision Lock #17).
+  for (const floorUid of TS_FLOOR_ASSETSPACE_UIDS) {
+    effectiveAsUids.add(floorUid);
+  }
+
+  // Safety: if the effective set has zero overlap with known folders, the
+  // filter would skip every `assetspaces/` file. Degrade to no-filter so the
+  // plugin remains usable — the user's intent ("show only profile-X scope")
+  // cannot be honoured with the current vault data, and silently bricking
+  // is worse than indexing everything with a warn-log breadcrumb.
+  const hasFolderMatch = Array.from(effectiveAsUids).some((uid) =>
+    folderMapValues.has(uid),
+  );
+  if (!hasFolderMatch) {
+    logger.warn(
+      `[FocusProfileOnloadWiring] activeProfileUid=${activeProfileUid} produced an effective set with zero AssetSpace folder overlap ` +
+        `(${effectiveAsUids.size} UIDs after translation + TS-floor; ${folderMap.size} folders known). ` +
+        `Likely cause: profile declares Ontology UIDs not covered by any AssetSpace_containsOntology declaration ` +
+        `(e.g. shared-identities мульти-anchor pattern). Degrading to no-filter — full vault will be indexed. ` +
+        `Resolve by either declaring AS UIDs directly in the profile or adding containsOntology to the relevant AssetSpaces.`,
+    );
+    indexer.setEffectiveOntologies(null);
+    indexer.setAssetSpaceFolderToUid(null);
+    return { outcome: "degraded", effective: null, folderMap: null };
+  }
+
+  indexer.setEffectiveOntologies(effectiveAsUids);
+  indexer.setAssetSpaceFolderToUid(folderMap);
+  logger.info(
+    `[FocusProfileOnloadWiring] activeProfileUid=${activeProfileUid} wired — ` +
+      `${effectiveAsUids.size} effective AS UIDs (incl. ${TS_FLOOR_ASSETSPACE_UIDS.size} floor), ` +
+      `${folderMap.size} folders mapped.`,
+  );
+  return {
+    outcome: "engaged",
+    effective: effectiveAsUids,
+    folderMap,
+  };
+}
+
+/**
+ * Single vault walk producing both data products the wiring needs.
+ * - `folderMap`: `assetspaces/<ns>` → AS UID, used by `shouldSkipFileForEffectiveSet`.
+ * - `ontologyToAs`: each declared `exo__AssetSpace_containsOntology` Ontology
+ *   UID → owning AS UID, used to translate profile-declared Ontology
+ *   references to AS UIDs the filter understands.
+ *
+ * Walking once is intentional — `vault.getMarkdownFiles()` is the hot loop
+ * and the AssetSpace count is small (~10), so the cost is dominated by the
+ * `metadataCache.getFileCache` lookup per file regardless of how the data is
+ * carved.
+ */
+function scanAssetSpaces(app: App): {
+  folderMap: Map<string, string>;
+  ontologyToAs: Map<string, string>;
+} {
+  const folderMap = new Map<string, string>();
+  const ontologyToAs = new Map<string, string>();
+
+  for (const file of app.vault.getMarkdownFiles()) {
+    const fm = readFrontmatter(app, file);
+    if (!fm) continue;
+    if (!isAssetSpaceFrontmatter(fm)) continue;
+
+    const uid = fm["exo__Asset_uid"];
+    if (typeof uid !== "string" || uid.length === 0) continue;
+
+    const folder = parentFolder(file.path);
+    if (folder.length > 0) {
+      folderMap.set(folder, uid);
+    }
+
+    const rawContains = fm["exo__AssetSpace_containsOntology"];
+    const declared: unknown[] = Array.isArray(rawContains)
+      ? rawContains
+      : rawContains !== undefined && rawContains !== null
+        ? [rawContains]
+        : [];
+    for (const raw of declared) {
+      if (typeof raw !== "string") continue;
+      const ontologyUid = extractUidFromWikilink(raw);
+      if (ontologyUid === null) continue;
+      // Last-writer wins on duplicate Ontology declarations (semantically
+      // illegal — an Ontology lives in exactly one AS). The warn is left
+      // off the hot path; SHACL-lite already catches multi-AS Ontology shapes.
+      ontologyToAs.set(ontologyUid, uid);
+    }
+  }
+
+  return { folderMap, ontologyToAs };
+}
+
+function readFrontmatter(
+  app: App,
+  file: TFile,
+): Record<string, unknown> | null {
+  const cache = app.metadataCache.getFileCache(file);
+  if (!cache || !cache.frontmatter) return null;
+  return cache.frontmatter as Record<string, unknown>;
+}
+
+function isAssetSpaceFrontmatter(fm: Record<string, unknown>): boolean {
+  const raw = fm["exo__Instance_class"];
+  const classes: unknown[] = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  for (const c of classes) {
+    if (typeof c !== "string") continue;
+    if (c.includes(ASSET_SPACE_CLASS_UID)) return true;
+  }
+  return false;
+}
+
+function parentFolder(filePath: string): string {
+  const idx = filePath.lastIndexOf("/");
+  return idx < 0 ? "" : filePath.slice(0, idx);
+}
+
+function extractUidFromWikilink(raw: string): string | null {
+  const cleaned = raw
+    .trim()
+    .replace(/^\[\[/, "")
+    .replace(/\]\]$/, "")
+    .split("|")[0]
+    .trim();
+  return cleaned.length === 0 ? null : cleaned;
+}

--- a/packages/obsidian-plugin/tests/unit/FocusProfileOnloadWiring.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileOnloadWiring.test.ts
@@ -382,6 +382,38 @@ describe("applyActiveProfileFilter", () => {
     expect(indexer.effective!.has(asEms)).toBe(true);
   });
 
+  it("degrades gracefully when activeProfileUid is empty string (defensive)", async () => {
+    // VaultProfileResolver.resolve short-circuits on empty UID → resolveEffectiveSet
+    // returns just TS-floor URIs (no profile-derived entries). Translation would
+    // pass-through-translate any AS UIDs (URIs don't match folder values), then
+    // TS-floor injection adds the floor AS UIDs. Empty-string activeProfileUid
+    // (legacy data.json shape) must not throw and must engage iff floor overlaps.
+    const ontologyExo = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
+    const app = makeApp([
+      {
+        file: { path: "assetspaces/exo/exo.md", basename: "exo" },
+        fm: asFrontmatter(TS_FLOOR_AS_UID_EXO, [ontologyExo]),
+      },
+    ]);
+    const indexer = makeIndexerStub();
+    const logger = makeLogger();
+    // Empty set models VaultProfileResolver.resolve("") returning null →
+    // FocusProfileSwitchManager.resolveEffectiveSet emits empty + TS-floor URIs.
+    const switchMgr = makeSwitchMgrStub(new Set());
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: "",
+      logger,
+    });
+
+    // Engages on TS-floor alone (overlap satisfied by the exo AS file present).
+    expect(result.outcome).toBe("engaged");
+    expect(indexer.effective!.has(TS_FLOOR_AS_UID_EXO)).toBe(true);
+  });
+
   it("surfaces untranslated UIDs in the engagement info log", async () => {
     // Mix: ontologyEms translates → asEms; unknownOntology fails translation.
     // TS-floor AS files present so engagement succeeds and we land in the

--- a/packages/obsidian-plugin/tests/unit/FocusProfileOnloadWiring.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileOnloadWiring.test.ts
@@ -213,17 +213,28 @@ describe("applyActiveProfileFilter", () => {
   });
 
   it("passes through entries that are already AS UIDs without translation", async () => {
-    const asExo = TS_FLOOR_AS_UID_EXO;
+    // Use a NON-TS-floor AS UID so the assertion exercises the pass-through
+    // branch genuinely — if we asserted on a TS-floor UID, the floor injection
+    // would mask removal of the pass-through logic (revert-fail/restore-pass
+    // discipline per `~/.claude/rules/integration-test-revert-verify.md`).
+    const asEms = "f0f674da-a31b-47e1-b0e8-f984b018bf75";
     const app = makeApp([
       {
+        file: { path: "assetspaces/ems/ems.md", basename: "ems" },
+        // Note: empty containsOntology — so translation cannot inject asEms.
+        // The only way asEms lands in `effectiveAsUids` is via pass-through.
+        fm: asFrontmatter(asEms, []),
+      },
+      // TS-floor exo AS provides folder-map overlap so engagement succeeds.
+      {
         file: { path: "assetspaces/exo/exo.md", basename: "exo" },
-        fm: asFrontmatter(asExo, []),
+        fm: asFrontmatter(TS_FLOOR_AS_UID_EXO, []),
       },
     ]);
     const indexer = makeIndexerStub();
     const logger = makeLogger();
     // Profile declares the AS UID directly (future-proof shape).
-    const switchMgr = makeSwitchMgrStub(new Set([asExo]));
+    const switchMgr = makeSwitchMgrStub(new Set([asEms]));
 
     const result = await applyActiveProfileFilter({
       app,
@@ -234,7 +245,7 @@ describe("applyActiveProfileFilter", () => {
     });
 
     expect(result.outcome).toBe("engaged");
-    expect(indexer.effective!.has(asExo)).toBe(true);
+    expect(indexer.effective!.has(asEms)).toBe(true);
   });
 
   it("degrades to no-filter and logs WARN when zero folder overlap", async () => {
@@ -333,22 +344,31 @@ describe("applyActiveProfileFilter", () => {
   });
 
   it("handles single-string containsOntology (not just array form)", async () => {
-    const ontologyExo = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
-    const asExo = TS_FLOOR_AS_UID_EXO;
+    // Asserts on a non-TS-floor AS UID so the assertion genuinely exercises
+    // the array/string normalisation path (per the revert-fail discipline —
+    // a TS-floor AS UID would land via floor injection regardless of whether
+    // the string-shape was parsed correctly).
+    const ontologyEms = "d9bd496e-86cf-496d-b2da-e5f68cc3e7bc";
+    const asEms = "f0f674da-a31b-47e1-b0e8-f984b018bf75";
     const app = makeApp([
       {
-        file: { path: "assetspaces/exo/exo.md", basename: "exo" },
+        file: { path: "assetspaces/ems/ems.md", basename: "ems" },
         fm: {
-          exo__Asset_uid: asExo,
+          exo__Asset_uid: asEms,
           exo__Instance_class: [`[[${ASSET_SPACE_CLASS_UID}]]`],
           // String, not array — Obsidian parser may produce either shape.
-          exo__AssetSpace_containsOntology: `[[${ontologyExo}]]`,
+          exo__AssetSpace_containsOntology: `[[${ontologyEms}]]`,
         },
+      },
+      // TS-floor exo AS for folder-map overlap (engagement gate).
+      {
+        file: { path: "assetspaces/exo/exo.md", basename: "exo" },
+        fm: asFrontmatter(TS_FLOOR_AS_UID_EXO, []),
       },
     ]);
     const indexer = makeIndexerStub();
     const logger = makeLogger();
-    const switchMgr = makeSwitchMgrStub(new Set([ontologyExo]));
+    const switchMgr = makeSwitchMgrStub(new Set([ontologyEms]));
 
     const result = await applyActiveProfileFilter({
       app,
@@ -359,6 +379,45 @@ describe("applyActiveProfileFilter", () => {
     });
 
     expect(result.outcome).toBe("engaged");
-    expect(indexer.effective!.has(asExo)).toBe(true);
+    expect(indexer.effective!.has(asEms)).toBe(true);
+  });
+
+  it("surfaces untranslated UIDs in the engagement info log", async () => {
+    // Mix: ontologyEms translates → asEms; unknownOntology fails translation.
+    // TS-floor AS files present so engagement succeeds and we land in the
+    // info log path that reports the partial breakdown.
+    const ontologyEms = "d9bd496e-86cf-496d-b2da-e5f68cc3e7bc";
+    const asEms = "f0f674da-a31b-47e1-b0e8-f984b018bf75";
+    const unknownOntology = "deadbeef-dead-beef-dead-beefdeadbeef";
+
+    const app = makeApp([
+      {
+        file: { path: "assetspaces/ems/ems.md", basename: "ems" },
+        fm: asFrontmatter(asEms, [ontologyEms]),
+      },
+      {
+        file: { path: "assetspaces/exo/exo.md", basename: "exo" },
+        fm: asFrontmatter(TS_FLOOR_AS_UID_EXO, []),
+      },
+    ]);
+    const indexer = makeIndexerStub();
+    const logger = makeLogger();
+    const switchMgr = makeSwitchMgrStub(
+      new Set([ontologyEms, unknownOntology]),
+    );
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: "profile-test",
+      logger,
+    });
+
+    expect(result.outcome).toBe("engaged");
+    expect(logger.infos.length).toBeGreaterThan(0);
+    expect(logger.infos[0]).toMatch(/wired/);
+    expect(logger.infos[0]).toMatch(/declared UIDs failed translation/);
+    expect(logger.infos[0]).toContain(unknownOntology);
   });
 });

--- a/packages/obsidian-plugin/tests/unit/FocusProfileOnloadWiring.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileOnloadWiring.test.ts
@@ -1,0 +1,364 @@
+import type { App } from "obsidian";
+
+import {
+  applyActiveProfileFilter,
+  TS_FLOOR_AS_UID_EXO,
+  TS_FLOOR_AS_UID_EXOCMD,
+  TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+  TS_FLOOR_ASSETSPACE_UIDS,
+  type IEffectiveOntologyAwareIndexer,
+} from "../../src/infrastructure/adapters/FocusProfileOnloadWiring";
+import {
+  ASSET_SPACE_CLASS_UID,
+} from "../../src/infrastructure/adapters/AssetSpaceManager";
+import {
+  FocusProfileSwitchManager,
+} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import type { ILogger } from "exocortex";
+
+// ─── Fakes ────────────────────────────────────────────────────────────────
+
+interface FakeFile {
+  path: string;
+  basename: string;
+}
+
+function makeApp(
+  files: { file: FakeFile; fm: Record<string, unknown> | null }[],
+): App {
+  const fileList = files.map((f) => f.file);
+  const fmByPath = new Map(files.map((f) => [f.file.path, f.fm]));
+  return {
+    vault: {
+      getMarkdownFiles: () => fileList,
+      adapter: {
+        exists: async () => false,
+        read: async () => "",
+        write: async () => undefined,
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: FakeFile) => {
+        const fm = fmByPath.get(file.path);
+        return fm !== undefined && fm !== null ? { frontmatter: fm } : null;
+      },
+    },
+  } as unknown as App;
+}
+
+function makeIndexerStub(): IEffectiveOntologyAwareIndexer & {
+  effective: ReadonlySet<string> | null;
+  folderMap: ReadonlyMap<string, string> | null;
+} {
+  const stub = {
+    effective: null as ReadonlySet<string> | null,
+    folderMap: null as ReadonlyMap<string, string> | null,
+    setEffectiveOntologies(set: ReadonlySet<string> | null): void {
+      stub.effective = set;
+    },
+    setAssetSpaceFolderToUid(map: ReadonlyMap<string, string> | null): void {
+      stub.folderMap = map;
+    },
+  };
+  return stub;
+}
+
+function makeLogger(): ILogger & {
+  warns: string[];
+  infos: string[];
+} {
+  const warns: string[] = [];
+  const infos: string[] = [];
+  return {
+    warns,
+    infos,
+    debug: () => undefined,
+    info: (msg: string) => {
+      infos.push(msg);
+    },
+    warn: (msg: string) => {
+      warns.push(msg);
+    },
+    error: () => undefined,
+  } as unknown as ILogger & { warns: string[]; infos: string[] };
+}
+
+function makeSwitchMgrStub(
+  effectiveSet: Set<string> | Error,
+): FocusProfileSwitchManager {
+  return {
+    resolveEffectiveSet: async (_uid: string) => {
+      if (effectiveSet instanceof Error) throw effectiveSet;
+      return effectiveSet;
+    },
+  } as unknown as FocusProfileSwitchManager;
+}
+
+// Helper: standard AssetSpace frontmatter shape — uid + containsOntology[]
+function asFrontmatter(uid: string, containsOntology: string[]): Record<string, unknown> {
+  return {
+    exo__Asset_uid: uid,
+    exo__Instance_class: [`[[${ASSET_SPACE_CLASS_UID}|exo__AssetSpace]]`],
+    exo__AssetSpace_containsOntology: containsOntology.map((o) => `[[${o}]]`),
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe("applyActiveProfileFilter", () => {
+  it("returns no-profile and wipes prior state when activeProfileUid=null", async () => {
+    const app = makeApp([]);
+    const indexer = makeIndexerStub();
+    indexer.setEffectiveOntologies(new Set(["stale"]));
+    indexer.setAssetSpaceFolderToUid(new Map([["stale-folder", "stale-uid"]]));
+    const logger = makeLogger();
+    const switchMgr = makeSwitchMgrStub(new Set());
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: null,
+      logger,
+    });
+
+    expect(result.outcome).toBe("no-profile");
+    expect(result.effective).toBeNull();
+    expect(result.folderMap).toBeNull();
+    expect(indexer.effective).toBeNull();
+    expect(indexer.folderMap).toBeNull();
+  });
+
+  it("translates Ontology UIDs to AS UIDs via containsOntology and wires filter", async () => {
+    const ontologyExo = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
+    const ontologyEms = "d9bd496e-86cf-496d-b2da-e5f68cc3e7bc";
+    const asExo = TS_FLOOR_AS_UID_EXO;
+    const asEms = "f0f674da-a31b-47e1-b0e8-f984b018bf75";
+
+    const app = makeApp([
+      {
+        file: { path: "assetspaces/exo/49fd2e56.md", basename: "exo" },
+        fm: asFrontmatter(asExo, [ontologyExo]),
+      },
+      {
+        file: { path: "assetspaces/ems/f0f674da.md", basename: "ems" },
+        fm: asFrontmatter(asEms, [ontologyEms]),
+      },
+    ]);
+    const indexer = makeIndexerStub();
+    const logger = makeLogger();
+    const switchMgr = makeSwitchMgrStub(new Set([ontologyExo, ontologyEms]));
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: "profile-test",
+      logger,
+    });
+
+    expect(result.outcome).toBe("engaged");
+    expect(indexer.effective).not.toBeNull();
+    expect(indexer.effective!.has(asExo)).toBe(true);
+    expect(indexer.effective!.has(asEms)).toBe(true);
+    // Ontology UIDs themselves should NOT leak into the effective set.
+    expect(indexer.effective!.has(ontologyExo)).toBe(false);
+    expect(indexer.folderMap!.get("assetspaces/exo")).toBe(asExo);
+    expect(indexer.folderMap!.get("assetspaces/ems")).toBe(asEms);
+  });
+
+  it("layers TS-floor AS UIDs into the effective set on engagement", async () => {
+    const ontologyExo = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
+    const ontologyEms = "d9bd496e-86cf-496d-b2da-e5f68cc3e7bc";
+    const asEms = "f0f674da-a31b-47e1-b0e8-f984b018bf75";
+
+    // Vault has ALL three AS so the TS-floor UIDs land in folderMap and
+    // engagement can verify overlap. Profile declares only EMS Ontology —
+    // floor adds $exo/$exocmd/$shared-identities anyway.
+    const app = makeApp([
+      {
+        file: { path: "assetspaces/exo/exo.md", basename: "exo" },
+        fm: asFrontmatter(TS_FLOOR_AS_UID_EXO, [ontologyExo]),
+      },
+      {
+        file: { path: "assetspaces/exocmd/exocmd.md", basename: "exocmd" },
+        fm: asFrontmatter(TS_FLOOR_AS_UID_EXOCMD, []),
+      },
+      {
+        file: { path: "assetspaces/shared-identities/si.md", basename: "si" },
+        fm: asFrontmatter(TS_FLOOR_AS_UID_SHARED_IDENTITIES, []),
+      },
+      {
+        file: { path: "assetspaces/ems/ems.md", basename: "ems" },
+        fm: asFrontmatter(asEms, [ontologyEms]),
+      },
+    ]);
+    const indexer = makeIndexerStub();
+    const logger = makeLogger();
+    const switchMgr = makeSwitchMgrStub(new Set([ontologyEms]));
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: "profile-test",
+      logger,
+    });
+
+    expect(result.outcome).toBe("engaged");
+    expect(indexer.effective!.has(asEms)).toBe(true);
+    for (const floor of TS_FLOOR_ASSETSPACE_UIDS) {
+      expect(indexer.effective!.has(floor)).toBe(true);
+    }
+  });
+
+  it("passes through entries that are already AS UIDs without translation", async () => {
+    const asExo = TS_FLOOR_AS_UID_EXO;
+    const app = makeApp([
+      {
+        file: { path: "assetspaces/exo/exo.md", basename: "exo" },
+        fm: asFrontmatter(asExo, []),
+      },
+    ]);
+    const indexer = makeIndexerStub();
+    const logger = makeLogger();
+    // Profile declares the AS UID directly (future-proof shape).
+    const switchMgr = makeSwitchMgrStub(new Set([asExo]));
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: "profile-test",
+      logger,
+    });
+
+    expect(result.outcome).toBe("engaged");
+    expect(indexer.effective!.has(asExo)).toBe(true);
+  });
+
+  it("degrades to no-filter and logs WARN when zero folder overlap", async () => {
+    // Profile declares an Ontology UID with no `containsOntology` declaration
+    // anywhere — translation fails for every entry, TS-floor УIDs land but the
+    // vault has none of the TS-floor AssetSpaces, so overlap is empty.
+    const unknownOntology = "d1195402-73a5-45ed-965f-3a435a553e6a";
+    const someOtherAs = "feedface-feed-face-feed-facefeedface";
+
+    const app = makeApp([
+      {
+        file: { path: "assetspaces/other/other.md", basename: "other" },
+        // AS frontmatter but does NOT declare unknownOntology in containsOntology.
+        fm: asFrontmatter(someOtherAs, []),
+      },
+    ]);
+    const indexer = makeIndexerStub();
+    const logger = makeLogger();
+    const switchMgr = makeSwitchMgrStub(new Set([unknownOntology]));
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: "profile-test",
+      logger,
+    });
+
+    expect(result.outcome).toBe("degraded");
+    expect(indexer.effective).toBeNull();
+    expect(indexer.folderMap).toBeNull();
+    expect(logger.warns.length).toBeGreaterThan(0);
+    expect(logger.warns[0]).toMatch(/zero AssetSpace folder overlap/);
+  });
+
+  it("degrades when switchMgr.resolveEffectiveSet throws", async () => {
+    const app = makeApp([]);
+    const indexer = makeIndexerStub();
+    const logger = makeLogger();
+    const switchMgr = makeSwitchMgrStub(new Error("boom"));
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: "profile-test",
+      logger,
+    });
+
+    expect(result.outcome).toBe("error");
+    expect(indexer.effective).toBeNull();
+    expect(indexer.folderMap).toBeNull();
+    expect(logger.warns[0]).toMatch(/resolveEffectiveSet/);
+  });
+
+  it("skips files lacking AssetSpace Instance_class in folderMap scan", async () => {
+    const asExo = TS_FLOOR_AS_UID_EXO;
+    const ontologyExo = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
+
+    const app = makeApp([
+      // Genuine AssetSpace declaration.
+      {
+        file: { path: "assetspaces/exo/exo.md", basename: "exo" },
+        fm: asFrontmatter(asExo, [ontologyExo]),
+      },
+      // Unrelated asset in the same folder (e.g. an ABox node) — should NOT
+      // overwrite the folder map entry from the AssetSpace declaration.
+      {
+        file: { path: "assetspaces/exo/random.md", basename: "random" },
+        fm: {
+          exo__Asset_uid: "deadbeef",
+          exo__Instance_class: ["[[other-class]]"],
+        },
+      },
+      // File outside assetspaces — irrelevant.
+      {
+        file: { path: "Notes/foo.md", basename: "foo" },
+        fm: { exo__Asset_uid: "note-uid" },
+      },
+    ]);
+    const indexer = makeIndexerStub();
+    const logger = makeLogger();
+    const switchMgr = makeSwitchMgrStub(new Set([ontologyExo]));
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: "profile-test",
+      logger,
+    });
+
+    expect(result.outcome).toBe("engaged");
+    expect(indexer.folderMap!.size).toBe(1);
+    expect(indexer.folderMap!.get("assetspaces/exo")).toBe(asExo);
+  });
+
+  it("handles single-string containsOntology (not just array form)", async () => {
+    const ontologyExo = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
+    const asExo = TS_FLOOR_AS_UID_EXO;
+    const app = makeApp([
+      {
+        file: { path: "assetspaces/exo/exo.md", basename: "exo" },
+        fm: {
+          exo__Asset_uid: asExo,
+          exo__Instance_class: [`[[${ASSET_SPACE_CLASS_UID}]]`],
+          // String, not array — Obsidian parser may produce either shape.
+          exo__AssetSpace_containsOntology: `[[${ontologyExo}]]`,
+        },
+      },
+    ]);
+    const indexer = makeIndexerStub();
+    const logger = makeLogger();
+    const switchMgr = makeSwitchMgrStub(new Set([ontologyExo]));
+
+    const result = await applyActiveProfileFilter({
+      app,
+      switchMgr,
+      indexer,
+      activeProfileUid: "profile-test",
+      logger,
+    });
+
+    expect(result.outcome).toBe("engaged");
+    expect(indexer.effective!.has(asExo)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3324. Wires the persisted `activeProfileUid` setting into `VaultRDFIndexer`'s filter setters BEFORE the eager-init / `metadataCache.on("resolved")` chain first calls `convertVault`. Closes the Issue #3321 follow-up gap — API plumbing shipped в v16.43.0 / v16.44.0 but no code applied a saved profile at cold-start.

## What this PR ships

1. **`ExocortexSettings.activeProfileUid: string \| null`** — formal field + `DEFAULT_SETTINGS = null`. Field was previously round-tripped only через `[key: string]: unknown` index signature in `PluginSettingsStoreAdapter`.
2. **`FocusProfileOnloadWiring.applyActiveProfileFilter`** — new helper that:
   - Reads `activeProfileUid`; no-op when null (full-vault default)
   - Calls existing `switchMgr.resolveEffectiveSet(uid)`
   - **Translates** Ontology UIDs → AS UIDs via `exo__AssetSpace_containsOntology` reverse map
   - AS UIDs already in shape pass through unchanged (future-proof)
   - Layers `TS_FLOOR_ASSETSPACE_UIDS` (`$exo` `49fd2e56`, `$exocmd` `c9c65b0f`, `$shared-identities` `0cde1557`) per Vision Lock #17
   - Degrades to no-filter + WARN log if translation produces zero folder overlap (R15 mitigation surfaced one layer earlier)
   - Single vault walk produces both `folderMap` AND `ontologyToAs` (advisor #5 — avoid double scan)
3. **`registerFocusProfileCommands` wires it** — called after `switchMgr` construction, before recovery flow + command registration. Wrapped in `try/catch` so scan failure cannot abort onload.

## TS-floor URI/UID mismatch decision (per Issue body)

Chose **Option A** — three AS UIDs as `TS_FLOOR_ASSETSPACE_UIDS`. Single-source-of-truth, avoids dual-floor sync complexity. Old `TS_FLOOR_ONTOLOGY_URIS` left in place (consumed by SwitchManager's shared-pattern auto-include logic — separate concern).

## ⚠️ Empirically-discovered architectural gap (documented honestly)

Vault `profile-base` (UID `ae00f219-...`) declares 8 wikilinks in `_alwaysOnOverlay`, **ALL pointing to Ontology UIDs** (`ca97bb2f` = exo Ontology, `d1195402` = shared-identities Ontology, etc.) — NOT AssetSpace UIDs.

The filter at `shouldSkipFileForEffectiveSet:149` operates on AS UIDs (per `assetSpaceFolderToUid.get(folder)`). Naïve wiring would compare AS UIDs against Ontology UIDs → 0 matches → every `assetspaces/<folder>/` file skipped → catastrophic plugin self-brick.

The Issue body's claim «profile-base happens to also include AS UUIDs so it works by accident» is empirically false against current vault state.

**Translation layer (this PR)** bridges Ontology UIDs → AS UIDs via `containsOntology`. But:
- `assetspaces/exo/` AS declares `containsOntology: [[ca97bb2f]]` ✓
- `assetspaces/exocmd/` AS declares `containsOntology: [[60967c6a]]` ✓
- `assetspaces/shared-identities/` AS deliberately omits `containsOntology` (мульти-anchor pattern; body text says «No single primaryOntology»). UIDs like `d1195402` → no AS owner → silently dropped.

**Degradation path is currently the production code path** when user sets `activeProfileUid = profile-base` UID: translation succeeds for most ontologies, TS-floor adds floor, overlap with folder map ≥ 1 → engagement succeeds, but shared-identities references get dropped silently.

**Follow-up Issue to file:** add `exo__AssetSpace_containsOntology` to shared-identities AS (or each shared- subspace), OR migrate profiles to declare AS UIDs directly. Either path is data-only, no code change.

## UI smoke verification — DEFERRED

Per `~/.claude/rules/ui-smoke-transitive-proof.md`: this is new wiring on the cold-start path, not identical to any UI-smoke-verified prior release. Transitive proof not acceptable; physical UI smoke required (manually set `activeProfileUid` in `data.json`, reload, SPARQL distinct-predicates query before/after).

User to verify post-merge per Issue body's UI smoke recipe.

## Tests

8 new unit tests cover (all PASS):
- `outcome: "no-profile"` when `activeProfileUid = null` (wipes prior state)
- Ontology→AS translation engages filter correctly
- TS-floor AS UIDs added to effective set on engagement
- AS UIDs in profile pass through unchanged
- `outcome: "degraded"` on zero folder overlap + WARN logged
- `outcome: "error"` on `resolveEffectiveSet` throw
- Folder map scan skips non-AssetSpace files in `assetspaces/`
- Single-string `containsOntology` shape (not just array)

Sibling regression: 58/58 `FocusProfile*` tests + 32/32 `VaultProfileResolver`/`ProfileFuzzyModal`/`VaultRDFIndexer.effective-ontologies` + 93/93 `ExocortexPlugin*` — all green locally.

## Definition of Done

- [x] Issue #3324 closed via `Closes #3324`
- [x] Unit tests cover resolver + onload wiring + degradation paths
- [x] TS-floor decision (Option A) documented в PR body
- [x] Translation layer documented + degradation contract explicit
- [x] Empirically-discovered profile-base Ontology↔AS gap surfaced (not papered over)
- [x] UI smoke deferred с rationale per rule
- [ ] CI green (pending)
- [ ] Auto Release published (pending)

## Test plan

- [x] `npm test -- packages/obsidian-plugin/tests/unit/FocusProfile*` — 58/58 + 8/8 new
- [x] `npm test -- packages/obsidian-plugin/tests/unit/ExocortexPlugin*` — 93/93
- [x] `npm test -- packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.effective-ontologies.test.ts` — green
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npm run lint` — clean (only 2 pre-existing warnings in unrelated files)
- [x] BDD coverage 100% maintained
- [x] Archgate 13/13 pass
- [ ] CI 14 required checks
- [ ] Manual UI smoke (deferred to user post-merge)