### PR TITLE
feat(cli): FocusProfile parity --profile flag (RFC 0a0791c1 #3323)

### DIFF
--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -18,6 +18,7 @@ import { JsonFormatter } from "../formatters/JsonFormatter.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { ResponseBuilder } from "../responses/index.js";
+import { resolveProfileFilter } from "../utils/resolveProfileFilter.js";
 
 export interface AskOptions {
   vault: string;
@@ -25,6 +26,11 @@ export interface AskOptions {
   output?: OutputFormat;
   showQuery?: boolean;
   explain?: boolean;
+  /**
+   * FocusProfile UID — restricts the RDF graph to the effective AssetSpace
+   * set declared by the profile chain (RFC 0a0791c1 Issue #3323).
+   */
+  profile?: string;
 }
 
 /**
@@ -72,6 +78,10 @@ export function askCommand(): Command {
     .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
     .option("--show-query", "Show the generated SPARQL query")
     .option("--explain", "Show explanation of the query conversion")
+    .option(
+      "--profile <uid>",
+      "FocusProfile UID — restrict graph to effective AssetSpace set (RFC 0a0791c1)",
+    )
     .action(async (question: string, options: AskOptions) => {
       const outputFormat = (options.output || "text") as OutputFormat;
       ErrorHandler.setFormat(outputFormat);
@@ -122,9 +132,22 @@ export function askCommand(): Command {
         }
         const loadStartTime = Date.now();
 
+        const profileFilter = await resolveProfileFilter({
+          profileUid: options.profile,
+          primaryVaultPath: vaultPath,
+          outputFormat,
+        });
+
         const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
         const converter = new NoteToRDFConverter(vaultAdapter);
-        const triples = await converter.convertVault();
+        const triples = await converter.convertVault(
+          profileFilter !== null
+            ? {
+                effectiveOntologies: profileFilter.effective,
+                assetSpaceFolderToUid: profileFilter.folderMap,
+              }
+            : {},
+        );
 
         const tripleStore = new InMemoryTripleStore();
         await tripleStore.addAll(triples);

--- a/packages/cli/src/commands/classes.ts
+++ b/packages/cli/src/commands/classes.ts
@@ -17,12 +17,18 @@ import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { ResponseBuilder } from "../responses/index.js";
 import { CacheManager } from "../cache/CacheManager.js";
+import { resolveProfileFilter } from "../utils/resolveProfileFilter.js";
 
 export interface ClassesCommandOptions {
   vault: string;
   format: "table" | "json";
   output?: OutputFormat;
   useCache?: boolean;
+  /**
+   * FocusProfile UID — restricts the RDF graph to the effective AssetSpace
+   * set declared by the profile chain (RFC 0a0791c1 Issue #3323).
+   */
+  profile?: string;
 }
 
 interface ClassInfo {
@@ -51,6 +57,10 @@ export function classesCommand(): Command {
     .option("--format <type>", "Output format: table|json", "table")
     .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
     .option("--use-cache", "Use persistent cache (faster for repeated queries)")
+    .option(
+      "--profile <uid>",
+      "FocusProfile UID — restrict graph to effective AssetSpace set (RFC 0a0791c1)",
+    )
     .action(async (className: string | undefined, options: ClassesCommandOptions) => {
       const outputFormat = (options.output || "text") as OutputFormat;
       ErrorHandler.setFormat(outputFormat);
@@ -67,10 +77,27 @@ export function classesCommand(): Command {
           console.log(`📦 Loading vault: ${vaultPath}...`);
         }
 
+        const profileFilter = await resolveProfileFilter({
+          profileUid: options.profile,
+          primaryVaultPath: vaultPath,
+          outputFormat,
+        });
+
+        // --profile disables --use-cache (cache is not profile-aware).
+        let useCacheEffective = options.useCache ?? false;
+        if (useCacheEffective && profileFilter !== null) {
+          if (outputFormat === "text") {
+            console.log(
+              "⚠️  --use-cache disabled because --profile is active (cache is not profile-aware).",
+            );
+          }
+          useCacheEffective = false;
+        }
+
         let triples: Triple[];
         let cacheHit = false;
 
-        if (options.useCache) {
+        if (useCacheEffective) {
           const cacheManager = new CacheManager(vaultPath);
           const cacheResult = await cacheManager.loadOrBuild();
           triples = cacheResult.triples;
@@ -82,7 +109,14 @@ export function classesCommand(): Command {
         } else {
           const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
           const converter = new NoteToRDFConverter(vaultAdapter);
-          triples = await converter.convertVault();
+          triples = await converter.convertVault(
+            profileFilter !== null
+              ? {
+                  effectiveOntologies: profileFilter.effective,
+                  assetSpaceFolderToUid: profileFilter.folderMap,
+                }
+              : {},
+          );
         }
 
         const tripleStore = new InMemoryTripleStore();

--- a/packages/cli/src/commands/find.ts
+++ b/packages/cli/src/commands/find.ts
@@ -20,12 +20,18 @@ import {
   transformShorthandNotation,
   filterOntologyPrefixes,
 } from "../utils/QueryPrefixInjector.js";
+import { resolveProfileFilter } from "../utils/resolveProfileFilter.js";
 
 export interface FindOptions {
   vault: string;
   also?: string[];
   sparql?: string;
   class?: string;
+  /**
+   * FocusProfile UID — restricts the RDF graph to the effective AssetSpace
+   * set declared by the profile chain (RFC 0a0791c1 Issue #3323).
+   */
+  profile?: string;
 }
 
 /**
@@ -129,6 +135,10 @@ export function findCommand(): Command {
       "--class <value>",
       "Filter by class label via find__Alias 'class' (e.g. ems__Task)",
     )
+    .option(
+      "--profile <uid>",
+      "FocusProfile UID — restrict graph to effective AssetSpace set (RFC 0a0791c1)",
+    )
     .action(async (options: FindOptions) => {
       ErrorHandler.setFormat("text" as OutputFormat);
 
@@ -151,11 +161,24 @@ export function findCommand(): Command {
           throw new VaultNotFoundError(vaultPath);
         }
 
+        const alsoVaults = options.also || [];
+        const profileFilter = await resolveProfileFilter({
+          profileUid: options.profile,
+          primaryVaultPath: vaultPath,
+          alsoVaultPaths: alsoVaults.map((p) => resolve(p)),
+          outputFormat: "text" as OutputFormat,
+        });
+        const converterOpts = profileFilter !== null
+          ? {
+              effectiveOntologies: profileFilter.effective,
+              assetSpaceFolderToUid: profileFilter.folderMap,
+            }
+          : {};
+
         const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
         const converter = new NoteToRDFConverter(vaultAdapter);
-        let triples: Triple[] = await converter.convertVault();
+        let triples: Triple[] = await converter.convertVault(converterOpts);
 
-        const alsoVaults = options.also || [];
         for (const alsoPath of alsoVaults) {
           const resolvedAlsoPath = resolve(alsoPath);
           if (!existsSync(resolvedAlsoPath)) {
@@ -163,7 +186,7 @@ export function findCommand(): Command {
           }
           const alsoAdapter = new FileSystemVaultAdapter(resolvedAlsoPath);
           const alsoConverter = new NoteToRDFConverter(alsoAdapter);
-          const alsoTriples = await alsoConverter.convertVault();
+          const alsoTriples = await alsoConverter.convertVault(converterOpts);
           triples = triples.concat(alsoTriples);
         }
 

--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -35,6 +35,7 @@ import { SPARQLErrorEnhancer } from "../utils/SPARQLErrorEnhancer.js";
 import { NTriplesFormatter } from "../utils/NTriplesFormatter.js";
 import { scanVaultNamespaces } from "../utils/VaultNamespaceScanner.js";
 import { injectExocortexPrefixes, transformShorthandNotation, filterOntologyPrefixes } from "../utils/QueryPrefixInjector.js";
+import { resolveProfileFilter } from "../utils/resolveProfileFilter.js";
 
 export interface SparqlQueryOptions {
   vault: string;
@@ -51,6 +52,13 @@ export interface SparqlQueryOptions {
   timeout?: string;
   template?: string;
   param?: string;
+  /**
+   * FocusProfile UID — restricts the RDF graph to the effective AssetSpace
+   * set declared by the profile chain (RFC 0a0791c1 Issue #3323). When set,
+   * incompatible with `--use-cache` (cache is not profile-aware) — the cache
+   * path is silently disabled with a warn so the filter takes effect.
+   */
+  profile?: string;
 }
 
 /** Default TTL for query result cache in seconds */
@@ -248,6 +256,10 @@ export function sparqlQueryCommand(): Command {
     .option("--no-cache", "Bypass query result cache")
     .option("--template <name>", "Use a predefined query template")
     .option("--param <params>", "Template parameters (format: key=value,key2=value2)")
+    .option(
+      "--profile <uid>",
+      "FocusProfile UID — restrict graph to effective AssetSpace set (RFC 0a0791c1)",
+    )
     .action(async (queryArg: string | undefined, options: SparqlQueryOptions) => {
       const outputFormat = (options.output || "text") as OutputFormat;
       ErrorHandler.setFormat(outputFormat);
@@ -339,10 +351,37 @@ export function sparqlQueryCommand(): Command {
         }
         const loadStartTime = Date.now();
 
+        // Resolve --profile filter once, before vault loading. The filter
+        // applies to primary + --also vaults uniformly (profile semantics:
+        // the effective set spans every loaded vault that declares matching
+        // AssetSpaces).
+        const alsoVaults = options.also || [];
+        const profileFilter = await resolveProfileFilter({
+          profileUid: options.profile,
+          primaryVaultPath: vaultPath,
+          alsoVaultPaths: alsoVaults.map((p) => resolve(p)),
+          outputFormat,
+        });
+
+        // When --profile is engaged, bypass --use-cache: the persistent
+        // cache key is per-vault (no profile dimension), so reusing a
+        // full-vault cache under a profile would defeat the filter.
+        // Documented as MVP limitation in PR #3323; profile-aware caching
+        // is Variant C follow-up scope.
+        let useCacheEffective = options.useCache ?? false;
+        if (useCacheEffective && profileFilter !== null) {
+          if (outputFormat === "text") {
+            console.log(
+              "⚠️  --use-cache disabled because --profile is active (cache is not profile-aware; MVP limitation).",
+            );
+          }
+          useCacheEffective = false;
+        }
+
         let triples: Triple[];
         let cacheHit = false;
 
-        if (options.useCache) {
+        if (useCacheEffective) {
           // Use cached triples for faster loading
           const cacheManager = new CacheManager(vaultPath);
           const cacheResult = await cacheManager.loadOrBuild();
@@ -356,11 +395,17 @@ export function sparqlQueryCommand(): Command {
           // Traditional vault loading
           const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
           const converter = new NoteToRDFConverter(vaultAdapter);
-          triples = await converter.convertVault();
+          triples = await converter.convertVault(
+            profileFilter !== null
+              ? {
+                  effectiveOntologies: profileFilter.effective,
+                  assetSpaceFolderToUid: profileFilter.folderMap,
+                }
+              : {},
+          );
         }
 
         // Load additional vaults if --also specified
-        const alsoVaults = options.also || [];
         for (const alsoPath of alsoVaults) {
           const resolvedAlsoPath = resolve(alsoPath);
           if (!existsSync(resolvedAlsoPath)) {
@@ -371,7 +416,14 @@ export function sparqlQueryCommand(): Command {
           }
           const alsoAdapter = new FileSystemVaultAdapter(resolvedAlsoPath);
           const alsoConverter = new NoteToRDFConverter(alsoAdapter);
-          const alsoTriples = await alsoConverter.convertVault();
+          const alsoTriples = await alsoConverter.convertVault(
+            profileFilter !== null
+              ? {
+                  effectiveOntologies: profileFilter.effective,
+                  assetSpaceFolderToUid: profileFilter.folderMap,
+                }
+              : {},
+          );
           triples = triples.concat(alsoTriples);
           if (outputFormat === "text") {
             console.log(`   ➕ Added ${alsoTriples.length} triples from ${resolvedAlsoPath}`);

--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -278,7 +278,25 @@ export function sparqlQueryCommand(): Command {
 
         // Parse cache TTL
         const cacheTtlSeconds = parseCacheTtl(options.cacheTtl);
-        const useQueryResultCache = options.cache !== false; // --no-cache sets this to false
+        // QueryResultCache's cache key is the SPARQL string hash — no profile
+        // dimension. If --profile is active, both reading and writing the
+        // result cache could leak data across profile scopes (cache hit from
+        // a prior profileless / different-profile run returns wrong rows).
+        // Disable the result cache when --profile is set; profile-aware
+        // caching is Variant C follow-up scope.
+        const profileFlagActive =
+          options.profile !== undefined && options.profile !== "";
+        const useQueryResultCache =
+          options.cache !== false && !profileFlagActive;
+        if (
+          profileFlagActive &&
+          options.cache !== false &&
+          outputFormat === "text"
+        ) {
+          console.log(
+            "⚠️  Query result cache bypassed because --profile is active (cache is not profile-aware; MVP limitation).",
+          );
+        }
         if (options.template) {
           const registry = new TemplateRegistry();
           const params = options.param ? registry.parseParamString(options.param) : {};
@@ -363,9 +381,11 @@ export function sparqlQueryCommand(): Command {
           outputFormat,
         });
 
-        // When --profile is engaged, bypass --use-cache: the persistent
-        // cache key is per-vault (no profile dimension), so reusing a
-        // full-vault cache under a profile would defeat the filter.
+        // When --profile is engaged, bypass --use-cache (triple cache via
+        // CacheManager): the persistent cache key is per-vault, no profile
+        // dimension. Reusing a full-vault cache under a profile would
+        // defeat the filter. The query-result cache (QueryResultCache) is
+        // separately gated above via `profileFlagActive`.
         // Documented as MVP limitation in PR #3323; profile-aware caching
         // is Variant C follow-up scope.
         let useCacheEffective = options.useCache ?? false;

--- a/packages/cli/src/services/CliFocusProfileResolver.ts
+++ b/packages/cli/src/services/CliFocusProfileResolver.ts
@@ -1,0 +1,420 @@
+/**
+ * CLI-side FocusProfile resolver — parity with plugin's
+ * `FocusProfileSwitchManager.resolveEffectiveSet` + `FocusProfileOnloadWiring`
+ * (Issue #3323, RFC 0a0791c1 Variant A MVP).
+ *
+ * Walks the vault filesystem to:
+ *   1. Build folderMap: `assetspaces/<folder>` → AssetSpace UID
+ *   2. Build ontologyToAs: Ontology UID → owning AssetSpace UID (via
+ *      `exo__AssetSpace_containsOntology` declarations)
+ *   3. Resolve FocusProfile chain (`_extends*` + `_includes` + `_alwaysOnOverlay`)
+ *      to a declared Ontology UID set
+ *   4. Translate declared Ontology UIDs → AssetSpace UIDs through ontologyToAs
+ *   5. Apply TS-floor AssetSpace UIDs (Vision Lock #17): $exo, $exocmd,
+ *      $shared-identities — guarantees plugin/CLI keeps functioning regardless
+ *      of profile config
+ *   6. Safe-degrade: if effective set has zero AS-folder overlap, return null
+ *      (caller falls back to no-filter / full vault) to prevent self-brick
+ *
+ * **Phase 6 follow-up** (deferred): extract the shared resolver / translation
+ * logic to `packages/exocortex/` so plugin and CLI consume one implementation.
+ * For the spike P0 we duplicate the plugin's logic verbatim — drift surface
+ * tracked by `multi-parser-predicate-migration.md` rule + this comment.
+ */
+
+import fs from "fs-extra";
+import path from "path";
+import yaml from "js-yaml";
+
+/**
+ * AssetSpace UID of `$exo` — TS-floor anchor (Vision Lock #17).
+ * Mirrors `packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileOnloadWiring.ts:45`.
+ */
+export const TS_FLOOR_AS_UID_EXO = "49fd2e56-4656-4ca7-a789-f472b16ea260";
+/**
+ * AssetSpace UID of `$exocmd` — TS-floor anchor (Vision Lock #17).
+ * Mirrors plugin constant.
+ */
+export const TS_FLOOR_AS_UID_EXOCMD = "c9c65b0f-1e01-47c1-a1f9-1bf70b11df6a";
+/**
+ * AssetSpace UID of `$shared-identities` — TS-floor anchor (Vision Lock #17).
+ * Mirrors plugin constant.
+ */
+export const TS_FLOOR_AS_UID_SHARED_IDENTITIES =
+  "0cde1557-6320-4bd0-a7c4-8b72afc38720";
+
+/** TS-floor AssetSpace UIDs — always added to the effective set. */
+export const TS_FLOOR_ASSETSPACE_UIDS: ReadonlySet<string> = new Set([
+  TS_FLOOR_AS_UID_EXO,
+  TS_FLOOR_AS_UID_EXOCMD,
+  TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+]);
+
+/** Class UID of `exo__AssetSpace` (TBox). Mirrors plugin's `AssetSpaceManager.ASSET_SPACE_CLASS_UID`. */
+export const ASSET_SPACE_CLASS_UID = "73bd00e4-ccc0-4f3f-b20d-c4388c4588fb";
+/** Class UID of `exo__FocusProfile` (TBox). Mirrors plugin's `FocusProfileSwitchManager.FOCUS_PROFILE_CLASS_UID`. */
+export const FOCUS_PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
+
+/** Max `_extends` chain depth (matches plugin default). */
+const DEFAULT_MAX_EXTENDS_DEPTH = 5;
+
+export interface ResolveFilterResult {
+  /** AssetSpace UID set the converter should retain (incl. TS-floor). */
+  effective: ReadonlySet<string>;
+  /** `assetspaces/<folder>` → AS UID map the converter uses to look up file owners. */
+  folderMap: ReadonlyMap<string, string>;
+  /** Diagnostic — declared Ontology UIDs the profile chain produced (pre-translation). */
+  declaredOntologies: ReadonlySet<string>;
+  /** Diagnostic — Ontology UIDs that had no AS owner in `containsOntology` (translation miss). */
+  untranslated: ReadonlyArray<string>;
+}
+
+export type ResolveFilterOutcome =
+  | { outcome: "engaged"; result: ResolveFilterResult }
+  | { outcome: "no-profile" }
+  | { outcome: "missing-profile"; profileUid: string }
+  | { outcome: "degraded"; reason: string }
+  | { outcome: "error"; reason: string };
+
+export interface CliFocusProfileResolverOptions {
+  /** Primary vault path. */
+  vaultPath: string;
+  /** Additional vault paths (mirrors CLI `--also`). */
+  alsoVaultPaths?: ReadonlyArray<string>;
+  /** Override max `_extends` chain depth (default 5). */
+  maxExtendsDepth?: number;
+  /** Injectable logger for warn-level diagnostics (defaults to no-op). */
+  warn?: (msg: string) => void;
+}
+
+interface AssetMeta {
+  uid: string;
+  filePath: string;
+  vaultRoot: string;
+  frontmatter: Record<string, unknown>;
+}
+
+interface ProfileFrontmatter {
+  uid: string;
+  label?: string;
+  includes: string[];
+  extends: string | null;
+  alwaysOnOverlay: string[];
+}
+
+/**
+ * CLI-side FocusProfile resolver. Single-shot — instantiate, call
+ * `resolveFilter(profileUid)`, discard. No internal mutable state to keep
+ * concurrent CLI invocations safe.
+ */
+export class CliFocusProfileResolver {
+  private readonly vaultPaths: ReadonlyArray<string>;
+  private readonly maxExtendsDepth: number;
+  private readonly warn: (msg: string) => void;
+
+  constructor(options: CliFocusProfileResolverOptions) {
+    const also = options.alsoVaultPaths ?? [];
+    this.vaultPaths = [options.vaultPath, ...also].map((p) => path.resolve(p));
+    this.maxExtendsDepth = options.maxExtendsDepth ?? DEFAULT_MAX_EXTENDS_DEPTH;
+    this.warn = options.warn ?? (() => undefined);
+  }
+
+  /**
+   * Resolve `--profile <uid>` to the converter filter pair.
+   *
+   * Outcomes:
+   * - `engaged` — filter computed; pass `result.effective` + `result.folderMap`
+   *   to `NoteToRDFConverter.convertVault({ effectiveOntologies, assetSpaceFolderToUid })`
+   * - `no-profile` — `profileUid` was null/undefined; caller indexes full vault
+   * - `missing-profile` — UID provided but no asset with that UID found; caller
+   *   indexes full vault (defensive; surface warn)
+   * - `degraded` — translated effective set has zero AS-folder overlap; caller
+   *   indexes full vault (R15 self-brick mitigation)
+   * - `error` — vault walk / yaml parse threw; caller indexes full vault
+   */
+  async resolveFilter(
+    profileUid: string | null | undefined,
+  ): Promise<ResolveFilterOutcome> {
+    if (profileUid === null || profileUid === undefined || profileUid === "") {
+      return { outcome: "no-profile" };
+    }
+
+    let scan: {
+      folderMap: Map<string, string>;
+      ontologyToAs: Map<string, string>;
+      profiles: Map<string, ProfileFrontmatter>;
+    };
+    try {
+      scan = await this.scanAllVaults();
+    } catch (e) {
+      const reason = `[CliFocusProfileResolver] vault scan threw — ${String(e)}`;
+      this.warn(reason);
+      return { outcome: "error", reason };
+    }
+
+    const profile = scan.profiles.get(profileUid);
+    if (profile === undefined) {
+      this.warn(
+        `[CliFocusProfileResolver] profileUid=${profileUid} not found in any scanned vault — falling back to no-filter (full vault).`,
+      );
+      return { outcome: "missing-profile", profileUid };
+    }
+
+    // Walk chain → declared Ontology UID set
+    const declared = new Set<string>();
+    try {
+      this.walkProfileChain(profileUid, scan.profiles, declared, new Set(), 0);
+    } catch (e) {
+      const reason = `[CliFocusProfileResolver] profile chain walk threw — ${String(e)}`;
+      this.warn(reason);
+      return { outcome: "error", reason };
+    }
+
+    // Translate Ontology UIDs → AS UIDs
+    const folderMapValues = new Set(scan.folderMap.values());
+    const effectiveAs = new Set<string>();
+    const untranslated: string[] = [];
+    for (const uid of declared) {
+      if (folderMapValues.has(uid)) {
+        effectiveAs.add(uid);
+        continue;
+      }
+      const translated = scan.ontologyToAs.get(uid);
+      if (translated !== undefined) {
+        effectiveAs.add(translated);
+        continue;
+      }
+      untranslated.push(uid);
+    }
+
+    // Always lay TS-floor at AS UID level
+    for (const floor of TS_FLOOR_ASSETSPACE_UIDS) {
+      effectiveAs.add(floor);
+    }
+
+    // R15 zero-overlap degrade
+    const hasOverlap = Array.from(effectiveAs).some((uid) =>
+      folderMapValues.has(uid),
+    );
+    if (!hasOverlap) {
+      const reason =
+        `[CliFocusProfileResolver] profileUid=${profileUid} produced effective set with zero AssetSpace folder overlap ` +
+        `(${effectiveAs.size} AS UIDs after translation+floor; ${scan.folderMap.size} folders known). ` +
+        `Likely cause: profile declares Ontology UIDs not covered by containsOntology, or vault has no scanned AssetSpaces. ` +
+        `Falling back to no-filter (full vault indexed).`;
+      this.warn(reason);
+      return { outcome: "degraded", reason };
+    }
+
+    return {
+      outcome: "engaged",
+      result: {
+        effective: effectiveAs,
+        folderMap: scan.folderMap,
+        declaredOntologies: declared,
+        untranslated,
+      },
+    };
+  }
+
+  // ===== Internal helpers =====
+
+  private walkProfileChain(
+    uid: string,
+    profiles: Map<string, ProfileFrontmatter>,
+    out: Set<string>,
+    visited: Set<string>,
+    depth: number,
+  ): void {
+    if (depth > this.maxExtendsDepth) {
+      throw new Error(
+        `FocusProfile chain exceeds max depth ${this.maxExtendsDepth} at ${uid} — possible cycle`,
+      );
+    }
+    if (visited.has(uid)) return; // cycle guard
+    visited.add(uid);
+
+    const profile = profiles.get(uid);
+    if (profile === undefined) return; // tolerate missing parent — leaf
+
+    for (const ont of profile.includes) out.add(ont);
+    for (const ont of profile.alwaysOnOverlay) out.add(ont);
+
+    if (
+      typeof profile.extends === "string" &&
+      profile.extends.length > 0
+    ) {
+      this.walkProfileChain(profile.extends, profiles, out, visited, depth + 1);
+    }
+  }
+
+  private async scanAllVaults(): Promise<{
+    folderMap: Map<string, string>;
+    ontologyToAs: Map<string, string>;
+    profiles: Map<string, ProfileFrontmatter>;
+  }> {
+    const folderMap = new Map<string, string>();
+    const ontologyToAs = new Map<string, string>();
+    const profiles = new Map<string, ProfileFrontmatter>();
+
+    for (const vaultRoot of this.vaultPaths) {
+      if (!(await fs.pathExists(vaultRoot))) {
+        this.warn(
+          `[CliFocusProfileResolver] vault path does not exist: ${vaultRoot} — skipping.`,
+        );
+        continue;
+      }
+      const assets = await this.walkVault(vaultRoot);
+      for (const asset of assets) {
+        const classes = parseWikilinkArray(
+          asset.frontmatter["exo__Instance_class"],
+        );
+
+        if (classes.some((c) => c === ASSET_SPACE_CLASS_UID)) {
+          // AssetSpace asset — register folderMap + containsOntology
+          const folder = parentFolderRelative(asset.filePath, asset.vaultRoot);
+          if (folder.length > 0) {
+            folderMap.set(folder, asset.uid);
+          }
+          const declared = parseWikilinkArray(
+            asset.frontmatter["exo__AssetSpace_containsOntology"],
+          );
+          for (const ont of declared) {
+            ontologyToAs.set(ont, asset.uid);
+          }
+        }
+
+        if (classes.some((c) => c === FOCUS_PROFILE_CLASS_UID)) {
+          const profile: ProfileFrontmatter = {
+            uid: asset.uid,
+            label: typeof asset.frontmatter["exo__Asset_label"] === "string"
+              ? (asset.frontmatter["exo__Asset_label"] as string)
+              : undefined,
+            includes: parseWikilinkArray(
+              asset.frontmatter["exo__FocusProfile_includes"],
+            ),
+            extends:
+              parseWikilinkArray(
+                asset.frontmatter["exo__FocusProfile_extends"],
+              )[0] ?? null,
+            alwaysOnOverlay: parseWikilinkArray(
+              asset.frontmatter["exo__FocusProfile_alwaysOnOverlay"],
+            ),
+          };
+          profiles.set(asset.uid, profile);
+        }
+      }
+    }
+
+    return { folderMap, ontologyToAs, profiles };
+  }
+
+  private async walkVault(vaultRoot: string): Promise<AssetMeta[]> {
+    const out: AssetMeta[] = [];
+    const stack: string[] = [vaultRoot];
+    while (stack.length > 0) {
+      const dir = stack.pop()!;
+      let entries: fs.Dirent[];
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (
+            entry.name.startsWith(".") ||
+            entry.name === "node_modules" ||
+            entry.name === ".obsidian" ||
+            entry.name === ".exocortex"
+          ) {
+            continue;
+          }
+          stack.push(fullPath);
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+        const fm = await this.tryReadFrontmatter(fullPath);
+        if (fm === null) continue;
+        const uid = fm["exo__Asset_uid"];
+        if (typeof uid !== "string" || uid.length === 0) continue;
+        out.push({
+          uid,
+          filePath: fullPath,
+          vaultRoot,
+          frontmatter: fm,
+        });
+      }
+    }
+    return out;
+  }
+
+  private async tryReadFrontmatter(
+    filePath: string,
+  ): Promise<Record<string, unknown> | null> {
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, "utf-8");
+    } catch {
+      return null;
+    }
+    // Fast bail-out — files without --- on first line can't be frontmatter
+    if (!content.startsWith("---")) return null;
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (match === null) return null;
+    try {
+      const parsed = yaml.load(match[1]);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Parse a frontmatter value that may be a single wikilink string, an array
+ * of wikilinks, or undefined/null. Returns the bare UID portion of each
+ * wikilink (`[[UID|alias]]` → `UID`, `[[UID]]` → `UID`, `UID` → `UID`).
+ *
+ * Non-string entries are dropped. Empty / unparseable entries are dropped.
+ */
+export function parseWikilinkArray(value: unknown): string[] {
+  if (value === null || value === undefined) return [];
+  const arr: unknown[] = Array.isArray(value) ? value : [value];
+  const out: string[] = [];
+  for (const raw of arr) {
+    if (typeof raw !== "string") continue;
+    const uid = extractUidFromWikilink(raw);
+    if (uid !== null) out.push(uid);
+  }
+  return out;
+}
+
+/** Strip `[[` / `]]` / `|alias` wrappers and return the inner identifier. */
+export function extractUidFromWikilink(raw: string): string | null {
+  const cleaned = raw
+    .trim()
+    .replace(/^\[\[/, "")
+    .replace(/\]\]$/, "")
+    .split("|")[0]
+    .trim();
+  return cleaned.length === 0 ? null : cleaned;
+}
+
+/**
+ * Compute the `assetspaces/<folder>` portion of an absolute file path
+ * relative to its vault root. Returns "" when the file is not inside an
+ * `assetspaces/<folder>/` namespace.
+ */
+function parentFolderRelative(absPath: string, vaultRoot: string): string {
+  const rel = path.relative(vaultRoot, absPath).replace(/\\/g, "/");
+  if (!rel.startsWith("assetspaces/")) return "";
+  const rest = rel.slice("assetspaces/".length);
+  const slashIdx = rest.indexOf("/");
+  if (slashIdx < 0) return "";
+  return `assetspaces/${rest.slice(0, slashIdx)}`;
+}

--- a/packages/cli/src/utils/resolveProfileFilter.ts
+++ b/packages/cli/src/utils/resolveProfileFilter.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared `--profile <uid>` resolution + text-mode banner emission, consumed
+ * by `sparql-query`, `classes`, `find`, `ask`, etc. RFC 0a0791c1 Issue #3323.
+ *
+ * The helper wraps `CliFocusProfileResolver` with CLI-presentation glue:
+ * uniform engagement banners (text mode), uniform fallback warnings, and a
+ * single return shape — `{ effective, folderMap } | null` — that every
+ * `NoteToRDFConverter.convertVault({ effectiveOntologies, assetSpaceFolderToUid })`
+ * callsite can spread into the options object directly.
+ */
+
+import { CliFocusProfileResolver } from "../services/CliFocusProfileResolver.js";
+import type { OutputFormat } from "./ErrorHandler.js";
+
+export interface ResolvedProfileFilter {
+  effective: ReadonlySet<string>;
+  folderMap: ReadonlyMap<string, string>;
+}
+
+export interface ResolveProfileFilterOptions {
+  /** Raw `--profile <uid>` value (may be undefined / empty when flag absent). */
+  profileUid: string | undefined;
+  /** Primary vault root (absolute). */
+  primaryVaultPath: string;
+  /** Optional additional vault roots (already resolved to absolute paths). */
+  alsoVaultPaths?: ReadonlyArray<string>;
+  /** Current CLI output format — controls whether banner text is emitted. */
+  outputFormat: OutputFormat;
+}
+
+/**
+ * Resolve `--profile <uid>` to converter filter input. Returns `null` when
+ * the filter should NOT be engaged:
+ * - flag absent or empty (no profile);
+ * - profile UID not found in any scanned vault (missing-profile);
+ * - effective set has zero AssetSpace-folder overlap (degraded — R15);
+ * - vault scan / yaml parse errored (error).
+ *
+ * In text-mode emits a single-line banner describing the outcome so users
+ * can see why the filter did/didn't engage. JSON-mode stays quiet to keep
+ * stdout structured.
+ */
+export async function resolveProfileFilter(
+  options: ResolveProfileFilterOptions,
+): Promise<ResolvedProfileFilter | null> {
+  const { profileUid, primaryVaultPath, alsoVaultPaths, outputFormat } = options;
+  if (profileUid === undefined || profileUid === "") return null;
+
+  const resolver = new CliFocusProfileResolver({
+    vaultPath: primaryVaultPath,
+    alsoVaultPaths,
+    warn: outputFormat === "text" ? (m) => console.warn(m) : undefined,
+  });
+  const outcome = await resolver.resolveFilter(profileUid);
+
+  switch (outcome.outcome) {
+    case "engaged": {
+      if (outputFormat === "text") {
+        const floorHits = countTsFloor(outcome.result.effective);
+        console.log(
+          `🎯 Profile ${profileUid.slice(0, 8)} engaged — ` +
+            `${outcome.result.effective.size} AS UIDs in scope ` +
+            `(incl. ${floorHits} TS-floor), ` +
+            `${outcome.result.folderMap.size} folders mapped.`,
+        );
+        if (outcome.result.untranslated.length > 0) {
+          console.log(
+            `   ℹ️  ${outcome.result.untranslated.length} declared Ontology UID(s) ` +
+              `had no AssetSpace_containsOntology mapping; passed through unfiltered.`,
+          );
+        }
+      }
+      return {
+        effective: outcome.result.effective,
+        folderMap: outcome.result.folderMap,
+      };
+    }
+    case "no-profile":
+      return null;
+    case "missing-profile":
+      if (outputFormat === "text") {
+        console.log(
+          `⚠️  --profile ${outcome.profileUid} not found in vault(s) — indexing full vault.`,
+        );
+      }
+      return null;
+    case "degraded":
+      if (outputFormat === "text") {
+        console.log(`⚠️  ${outcome.reason}`);
+      }
+      return null;
+    case "error":
+      if (outputFormat === "text") {
+        console.log(`⚠️  ${outcome.reason}`);
+      }
+      return null;
+  }
+}
+
+/** TS-floor AS UID set (mirrors `CliFocusProfileResolver` constants). */
+const TS_FLOOR = new Set([
+  "49fd2e56-4656-4ca7-a789-f472b16ea260",
+  "c9c65b0f-1e01-47c1-a1f9-1bf70b11df6a",
+  "0cde1557-6320-4bd0-a7c4-8b72afc38720",
+]);
+
+function countTsFloor(effective: ReadonlySet<string>): number {
+  let n = 0;
+  for (const uid of effective) {
+    if (TS_FLOOR.has(uid)) n++;
+  }
+  return n;
+}

--- a/packages/cli/tests/unit/commands/sparql-query-profile.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-profile.test.ts
@@ -212,6 +212,28 @@ describe("sparqlQueryCommand --profile / cache interaction", () => {
       expect(mockTripleCacheLoadOrBuild).not.toHaveBeenCalled();
     });
 
+    it("STILL bypasses QueryResultCache when --profile is set but resolveProfileFilter returns null (missing-profile / degraded)", async () => {
+      // Simulate `--profile <unknown-uid>` → resolver returns null. Cache
+      // bypass MUST stay engaged based on flag presence, NOT on filter
+      // outcome — otherwise a missing-profile run would poison the
+      // shared profileless cache key.
+      const { resolveProfileFilter } = await import(
+        "../../../src/utils/resolveProfileFilter.js"
+      );
+      (resolveProfileFilter as jest.MockedFunction<typeof resolveProfileFilter>)
+        .mockResolvedValueOnce(null);
+
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", vaultDir,
+        "--profile", PROFILE_UID,
+      ]);
+      expect(mockResultCacheGet).not.toHaveBeenCalled();
+      expect(mockResultCacheSet).not.toHaveBeenCalled();
+    });
+
     it("passes effectiveOntologies+assetSpaceFolderToUid to convertVault when --profile is set", async () => {
       const cmd = sparqlQueryCommand();
       await cmd.parseAsync([

--- a/packages/cli/tests/unit/commands/sparql-query-profile.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-profile.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Regression coverage for `--profile` ↔ cache interaction в `sparql query`
+ * (RFC 0a0791c1 Issue #3323).
+ *
+ * Two caches live in the query path:
+ *   1. CacheManager — persistent triple cache (gated by --use-cache).
+ *   2. QueryResultCache — SPARQL-result cache (default ON, gated by
+ *      --no-cache).
+ * Both cache keys lack a profile dimension. When `--profile` is active
+ * either cache could return stale / wrong-scope rows. The fix bypasses
+ * BOTH caches when `--profile` is set; this test locks that contract in.
+ */
+
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const mockAddAll = jest.fn();
+const mockConvertVault = jest.fn().mockResolvedValue([]);
+const mockResultCacheGet = jest.fn().mockResolvedValue(null);
+const mockResultCacheSet = jest.fn().mockResolvedValue(undefined);
+const mockTripleCacheLoadOrBuild = jest
+  .fn()
+  .mockResolvedValue({ triples: [], cacheHit: false });
+
+jest.unstable_mockModule("../../../src/formatters/TableFormatter.js", () => ({
+  TableFormatter: jest.fn(() => ({ format: jest.fn().mockReturnValue("") })),
+}));
+jest.unstable_mockModule("../../../src/formatters/JsonFormatter.js", () => ({
+  JsonFormatter: jest.fn(() => ({ format: jest.fn().mockReturnValue("{}") })),
+}));
+jest.unstable_mockModule("../../../src/formatters/CsvFormatter.js", () => ({
+  CsvFormatter: jest.fn(() => ({ format: jest.fn().mockReturnValue("") })),
+}));
+jest.unstable_mockModule("../../../src/formatters/TriplesFormatter.js", () => ({
+  TriplesFormatter: jest.fn(() => ({
+    formatTable: jest.fn().mockReturnValue(""),
+    formatJson: jest.fn().mockReturnValue("[]"),
+    formatNTriples: jest.fn().mockReturnValue(""),
+  })),
+}));
+
+jest.unstable_mockModule("exocortex", () => ({
+  InMemoryTripleStore: jest.fn(() => ({ addAll: mockAddAll })),
+  ExoQLParser: jest.fn(() => ({
+    parse: jest.fn().mockReturnValue({ type: "query", queryType: "SELECT" }),
+  })),
+  SPARQLParser: jest.fn(() => ({
+    parse: jest.fn().mockReturnValue({ type: "query" }),
+    setVaultPrefixes: jest.fn(),
+  })),
+  SPARQLParseError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = "SPARQLParseError";
+    }
+  },
+  ExoQLAlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+  AlgebraTranslator: jest.fn(() => ({
+    translate: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+  AlgebraOptimizer: jest.fn(() => ({
+    optimize: jest.fn().mockReturnValue({ type: "bgp", patterns: [] }),
+  })),
+  AlgebraSerializer: jest.fn(() => ({
+    toString: jest.fn().mockReturnValue("BGP()"),
+  })),
+  ExoQLQueryExecutor: jest.fn(() => ({
+    executeAll: jest.fn().mockResolvedValue([]),
+  })),
+  QueryExecutor: jest.fn(() => ({
+    executeAll: jest.fn().mockResolvedValue([]),
+    isConstructQuery: jest.fn().mockReturnValue(false),
+    setTimeout: jest.fn(),
+  })),
+  NoteToRDFConverter: jest.fn(() => ({ convertVault: mockConvertVault })),
+  SolutionMapping: class extends Map {},
+  UpdateExecutor: jest.fn(() => ({
+    execute: jest.fn().mockResolvedValue([]),
+  })),
+  UpdateExecutorError: class extends Error {},
+  IRI: jest.fn(),
+  Literal: jest.fn(),
+  BlankNode: jest.fn(),
+  Triple: jest.fn(),
+  SPARQL_PREFIXES: "PREFIX exo: <https://exocortex.my/ontology/exo#>",
+}));
+
+jest.unstable_mockModule("../../../src/adapters/FileSystemVaultAdapter.js", () => ({
+  FileSystemVaultAdapter: jest.fn(),
+}));
+jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
+  CacheManager: jest.fn(() => ({
+    loadOrBuild: mockTripleCacheLoadOrBuild,
+  })),
+}));
+jest.unstable_mockModule("../../../src/cache/QueryResultCache.js", () => ({
+  QueryResultCache: jest.fn(() => ({
+    get: mockResultCacheGet,
+    set: mockResultCacheSet,
+  })),
+}));
+jest.unstable_mockModule("../../../src/utils/VaultNamespaceScanner.js", () => ({
+  scanVaultNamespaces: jest.fn().mockReturnValue(new Map()),
+}));
+jest.unstable_mockModule("../../../src/utils/QueryPrefixInjector.js", () => ({
+  injectExocortexPrefixes: jest.fn((q: string) => q),
+  transformShorthandNotation: jest.fn((q: string) => q),
+  filterOntologyPrefixes: jest.fn((m: Map<string, string>) => m),
+}));
+
+// Stub out the heavy real resolver — its correctness is covered by
+// `CliFocusProfileResolver.test.ts`. Here we only need to confirm
+// the gate logic in sparql-query.ts wires `--profile` to the cache bypass.
+jest.unstable_mockModule(
+  "../../../src/utils/resolveProfileFilter.js",
+  () => ({
+    resolveProfileFilter: jest.fn(
+      async (opts: { profileUid?: string }) => {
+        if (!opts.profileUid) return null;
+        // Return a real-shape result so the spread into convertVault works.
+        return {
+          effective: new Set(["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]),
+          folderMap: new Map([["assetspaces/ems", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]),
+        };
+      },
+    ),
+  }),
+);
+
+const { sparqlQueryCommand } = await import("../../../src/commands/sparql-query.js");
+
+const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "exo-sparql-profile-"));
+const vaultDir = path.join(tmpBase, "vault");
+fs.mkdirSync(vaultDir);
+
+const PROFILE_UID = "11111111-1111-1111-1111-111111111111";
+
+describe("sparqlQueryCommand --profile / cache interaction", () => {
+  beforeEach(() => {
+    mockAddAll.mockClear();
+    mockConvertVault.mockClear();
+    mockConvertVault.mockResolvedValue([]);
+    mockResultCacheGet.mockClear();
+    mockResultCacheGet.mockResolvedValue(null);
+    mockResultCacheSet.mockClear();
+    mockTripleCacheLoadOrBuild.mockClear();
+    mockTripleCacheLoadOrBuild.mockResolvedValue({
+      triples: [],
+      cacheHit: false,
+    });
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(process, "exit").mockImplementation((() => {}) as never);
+  });
+
+  it("should register --profile option", () => {
+    const cmd = sparqlQueryCommand();
+    const opt = cmd.options.find((o: { long?: string }) => o.long === "--profile");
+    expect(opt).toBeDefined();
+  });
+
+  describe("backward-compat: without --profile, query-result cache is consulted", () => {
+    it("calls QueryResultCache.get() when no --profile flag", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", vaultDir,
+      ]);
+      expect(mockResultCacheGet).toHaveBeenCalled();
+    });
+  });
+
+  describe("regression: with --profile, both caches are bypassed", () => {
+    it("does NOT call QueryResultCache.get() when --profile is set", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", vaultDir,
+        "--profile", PROFILE_UID,
+      ]);
+      expect(mockResultCacheGet).not.toHaveBeenCalled();
+    });
+
+    it("does NOT call QueryResultCache.set() when --profile is set (result not cached back)", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", vaultDir,
+        "--profile", PROFILE_UID,
+      ]);
+      expect(mockResultCacheSet).not.toHaveBeenCalled();
+    });
+
+    it("does NOT call CacheManager.loadOrBuild() when --profile is set with --use-cache", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", vaultDir,
+        "--profile", PROFILE_UID,
+        "--use-cache",
+      ]);
+      expect(mockTripleCacheLoadOrBuild).not.toHaveBeenCalled();
+    });
+
+    it("passes effectiveOntologies+assetSpaceFolderToUid to convertVault when --profile is set", async () => {
+      const cmd = sparqlQueryCommand();
+      await cmd.parseAsync([
+        "node", "test",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "--vault", vaultDir,
+        "--profile", PROFILE_UID,
+      ]);
+      expect(mockConvertVault).toHaveBeenCalled();
+      const callArgs = mockConvertVault.mock.calls[0][0];
+      expect(callArgs).toBeDefined();
+      expect((callArgs as { effectiveOntologies?: Set<string> }).effectiveOntologies).toBeDefined();
+      expect((callArgs as { assetSpaceFolderToUid?: Map<string, string> }).assetSpaceFolderToUid).toBeDefined();
+    });
+  });
+});

--- a/packages/cli/tests/unit/services/CliFocusProfileResolver.test.ts
+++ b/packages/cli/tests/unit/services/CliFocusProfileResolver.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Unit tests for `CliFocusProfileResolver` (RFC 0a0791c1 Issue #3323).
+ *
+ * Uses an on-disk temp vault for each test — exercises the real file walk,
+ * yaml parse, and translation chain that production CLI hits. Faster and
+ * more realistic than mocking `fs-extra` (the adapter surface area is large
+ * and stubs would diverge from real semantics, the exact failure mode
+ * `test-fixture-realism.md` warns against).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+
+import {
+  CliFocusProfileResolver,
+  TS_FLOOR_AS_UID_EXO,
+  TS_FLOOR_AS_UID_EXOCMD,
+  TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+  ASSET_SPACE_CLASS_UID,
+  FOCUS_PROFILE_CLASS_UID,
+  parseWikilinkArray,
+  extractUidFromWikilink,
+} from "../../../src/services/CliFocusProfileResolver.js";
+
+/** Fixed UIDs the fixtures reuse — readable in test names. */
+const PROFILE_PERSONAL_UID = "11111111-1111-1111-1111-111111111111";
+const PROFILE_WORK_UID = "22222222-2222-2222-2222-222222222222";
+const PROFILE_BASE_UID = "33333333-3333-3333-3333-333333333333";
+const PROFILE_CYCLE_A_UID = "44444444-4444-4444-4444-444444444444";
+const PROFILE_CYCLE_B_UID = "55555555-5555-5555-5555-555555555555";
+
+const AS_EXO_UID = TS_FLOOR_AS_UID_EXO;
+const AS_EXOCMD_UID = TS_FLOOR_AS_UID_EXOCMD;
+const AS_SHARED_UID = TS_FLOOR_AS_UID_SHARED_IDENTITIES;
+const AS_EMS_UID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const AS_KITELEV_UID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+const ONTOLOGY_EMS_UID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const ONTOLOGY_KITELEV_UID = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+
+interface AssetSpec {
+  /** Path relative to vault root (e.g. `assetspaces/ems/<uid>.md`). */
+  relPath: string;
+  frontmatter: Record<string, unknown>;
+}
+
+async function makeVault(vaultRoot: string, assets: AssetSpec[]): Promise<void> {
+  await fs.ensureDir(vaultRoot);
+  for (const asset of assets) {
+    const full = path.join(vaultRoot, asset.relPath);
+    await fs.ensureDir(path.dirname(full));
+    const yamlLines = Object.entries(asset.frontmatter).map(([k, v]) => {
+      if (Array.isArray(v)) {
+        return `${k}:\n${v.map((x) => `  - "${String(x).replace(/"/g, '\\"')}"`).join("\n")}`;
+      }
+      if (typeof v === "string") {
+        return `${k}: "${v.replace(/"/g, '\\"')}"`;
+      }
+      return `${k}: ${v}`;
+    });
+    const body = `---\n${yamlLines.join("\n")}\n---\n\n# ${asset.frontmatter["exo__Asset_uid"] ?? ""}\n`;
+    await fs.writeFile(full, body, "utf-8");
+  }
+}
+
+function asAssetSpace(uid: string, folder: string, containsOntologies: string[] = []): AssetSpec {
+  return {
+    relPath: `assetspaces/${folder}/${uid}.md`,
+    frontmatter: {
+      "exo__Asset_uid": uid,
+      "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}|exo__AssetSpace]]`],
+      ...(containsOntologies.length > 0
+        ? {
+            "exo__AssetSpace_containsOntology": containsOntologies.map(
+              (o) => `[[${o}]]`,
+            ),
+          }
+        : {}),
+    },
+  };
+}
+
+function asProfile(
+  uid: string,
+  opts: {
+    label?: string;
+    includes?: string[];
+    extends_?: string;
+    overlay?: string[];
+  } = {},
+): AssetSpec {
+  const fm: Record<string, unknown> = {
+    "exo__Asset_uid": uid,
+    "exo__Instance_class": [`[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]`],
+  };
+  if (opts.label !== undefined) fm["exo__Asset_label"] = opts.label;
+  if (opts.includes !== undefined) {
+    fm["exo__FocusProfile_includes"] = opts.includes.map((u) => `[[${u}]]`);
+  }
+  if (opts.extends_ !== undefined) {
+    fm["exo__FocusProfile_extends"] = [`[[${opts.extends_}]]`];
+  }
+  if (opts.overlay !== undefined) {
+    fm["exo__FocusProfile_alwaysOnOverlay"] = opts.overlay.map((u) => `[[${u}]]`);
+  }
+  return {
+    relPath: `profiles/${uid}.md`,
+    frontmatter: fm,
+  };
+}
+
+describe("CliFocusProfileResolver", () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "exocortex-cli-profile-test-"),
+    );
+  });
+
+  afterEach(async () => {
+    if (tmpRoot && (await fs.pathExists(tmpRoot))) {
+      await fs.remove(tmpRoot);
+    }
+  });
+
+  describe("resolveFilter — outcome shapes", () => {
+    it("returns no-profile when profileUid is null", async () => {
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(null);
+      expect(out.outcome).toBe("no-profile");
+    });
+
+    it("returns no-profile when profileUid is undefined", async () => {
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(undefined);
+      expect(out.outcome).toBe("no-profile");
+    });
+
+    it("returns no-profile when profileUid is empty string", async () => {
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter("");
+      expect(out.outcome).toBe("no-profile");
+    });
+
+    it("returns missing-profile when UID is not found in vault", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter("nonexistent-uid");
+      expect(out.outcome).toBe("missing-profile");
+      if (out.outcome === "missing-profile") {
+        expect(out.profileUid).toBe("nonexistent-uid");
+      }
+    });
+  });
+
+  describe("resolveFilter — engaged paths", () => {
+    it("engages with TS-floor only when profile has empty includes (and at least one folder overlaps via floor)", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asProfile(PROFILE_BASE_UID, { label: "base" }),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_BASE_UID);
+      expect(out.outcome).toBe("engaged");
+      if (out.outcome === "engaged") {
+        expect(out.result.effective.has(AS_EXO_UID)).toBe(true);
+        expect(out.result.effective.has(AS_EXOCMD_UID)).toBe(true);
+        expect(out.result.effective.has(AS_SHARED_UID)).toBe(true);
+        expect(out.result.effective.size).toBe(3); // floor only
+      }
+    });
+
+    it("translates declared Ontology UIDs to AS UIDs via containsOntology", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asAssetSpace(AS_EMS_UID, "ems", [ONTOLOGY_EMS_UID]),
+        asProfile(PROFILE_PERSONAL_UID, {
+          includes: [ONTOLOGY_EMS_UID],
+        }),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
+      expect(out.outcome).toBe("engaged");
+      if (out.outcome === "engaged") {
+        // Ontology UID got translated to its owning AS UID
+        expect(out.result.effective.has(AS_EMS_UID)).toBe(true);
+        // TS-floor present
+        expect(out.result.effective.has(AS_EXO_UID)).toBe(true);
+        expect(out.result.effective.has(AS_EXOCMD_UID)).toBe(true);
+        expect(out.result.effective.has(AS_SHARED_UID)).toBe(true);
+        // declared set surfaced for diagnostics
+        expect(out.result.declaredOntologies.has(ONTOLOGY_EMS_UID)).toBe(true);
+        // No untranslated entries
+        expect(out.result.untranslated.length).toBe(0);
+      }
+    });
+
+    it("passes through declared UIDs that are already AS UIDs (future-proof: profile may declare AS directly)", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asAssetSpace(AS_EMS_UID, "ems"), // No containsOntology declared
+        asProfile(PROFILE_PERSONAL_UID, {
+          includes: [AS_EMS_UID], // Profile points directly at AS UID
+        }),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
+      expect(out.outcome).toBe("engaged");
+      if (out.outcome === "engaged") {
+        expect(out.result.effective.has(AS_EMS_UID)).toBe(true);
+      }
+    });
+
+    it("records untranslated UIDs when Ontology has no AssetSpace owner", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asAssetSpace(AS_EMS_UID, "ems", [ONTOLOGY_EMS_UID]),
+        asProfile(PROFILE_PERSONAL_UID, {
+          // ONTOLOGY_EMS resolves; ONTOLOGY_KITELEV has no AS owner
+          includes: [ONTOLOGY_EMS_UID, ONTOLOGY_KITELEV_UID],
+        }),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
+      expect(out.outcome).toBe("engaged");
+      if (out.outcome === "engaged") {
+        expect(out.result.untranslated).toContain(ONTOLOGY_KITELEV_UID);
+        expect(out.result.untranslated).not.toContain(ONTOLOGY_EMS_UID);
+        expect(out.result.effective.has(AS_EMS_UID)).toBe(true);
+      }
+    });
+
+    it("walks _extends chain recursively, merging includes and overlays", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asAssetSpace(AS_EMS_UID, "ems"),
+        asAssetSpace(AS_KITELEV_UID, "kitelev"),
+        asProfile(PROFILE_BASE_UID, {
+          overlay: [AS_KITELEV_UID], // base provides kitelev via overlay
+        }),
+        asProfile(PROFILE_PERSONAL_UID, {
+          includes: [AS_EMS_UID],
+          extends_: PROFILE_BASE_UID,
+        }),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
+      expect(out.outcome).toBe("engaged");
+      if (out.outcome === "engaged") {
+        expect(out.result.effective.has(AS_EMS_UID)).toBe(true); // from includes
+        expect(out.result.effective.has(AS_KITELEV_UID)).toBe(true); // from parent overlay
+        expect(out.result.declaredOntologies.has(AS_KITELEV_UID)).toBe(true);
+      }
+    });
+
+    it("merges _alwaysOnOverlay into effective set even on the leaf profile", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asAssetSpace(AS_KITELEV_UID, "kitelev"),
+        asProfile(PROFILE_PERSONAL_UID, {
+          overlay: [AS_KITELEV_UID],
+        }),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
+      expect(out.outcome).toBe("engaged");
+      if (out.outcome === "engaged") {
+        expect(out.result.effective.has(AS_KITELEV_UID)).toBe(true);
+      }
+    });
+  });
+
+  describe("resolveFilter — cycle and depth guards", () => {
+    it("tolerates cycles via visited-set guard", async () => {
+      // A → B → A — must not infinite-loop, must complete
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asProfile(PROFILE_CYCLE_A_UID, {
+          extends_: PROFILE_CYCLE_B_UID,
+        }),
+        asProfile(PROFILE_CYCLE_B_UID, {
+          extends_: PROFILE_CYCLE_A_UID,
+        }),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_CYCLE_A_UID);
+      // Either engaged with TS-floor only, or degraded — but must NOT hang and
+      // must NOT throw.
+      expect(["engaged", "degraded"]).toContain(out.outcome);
+    });
+
+    it("throws on chain longer than maxExtendsDepth — surfaced via error outcome", async () => {
+      // Build a 7-deep chain (max default is 5)
+      const chain: string[] = [];
+      for (let i = 0; i < 7; i++) {
+        chain.push(`9${i}9${i}9${i}9${i}-9${i}9${i}-9${i}9${i}-9${i}9${i}-9${i}9${i}9${i}9${i}9${i}9${i}`);
+      }
+      const assets: AssetSpec[] = [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+      ];
+      for (let i = 0; i < chain.length; i++) {
+        assets.push(
+          asProfile(chain[i], {
+            extends_: i < chain.length - 1 ? chain[i + 1] : undefined,
+          }),
+        );
+      }
+      await makeVault(tmpRoot, assets);
+      const resolver = new CliFocusProfileResolver({
+        vaultPath: tmpRoot,
+        maxExtendsDepth: 5,
+      });
+      const out = await resolver.resolveFilter(chain[0]);
+      expect(out.outcome).toBe("error");
+      if (out.outcome === "error") {
+        expect(out.reason).toMatch(/max depth/i);
+      }
+    });
+  });
+
+  describe("resolveFilter — degraded path", () => {
+    it("returns degraded when effective set has zero AS-folder overlap (R15 self-brick mitigation)", async () => {
+      // No AssetSpace files exist at all in this vault, but a profile does
+      await makeVault(tmpRoot, [
+        asProfile(PROFILE_PERSONAL_UID, {
+          includes: ["some-random-ontology-uid"],
+        }),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
+      expect(out.outcome).toBe("degraded");
+      if (out.outcome === "degraded") {
+        expect(out.reason).toMatch(/zero AssetSpace folder overlap/i);
+      }
+    });
+  });
+
+  describe("resolveFilter — folderMap construction", () => {
+    it("builds folderMap with correct vault-relative folder keys", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asAssetSpace(AS_EMS_UID, "ems"),
+        asProfile(PROFILE_PERSONAL_UID, {
+          includes: [AS_EMS_UID],
+        }),
+      ]);
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
+      expect(out.outcome).toBe("engaged");
+      if (out.outcome === "engaged") {
+        expect(out.result.folderMap.get("assetspaces/exo")).toBe(AS_EXO_UID);
+        expect(out.result.folderMap.get("assetspaces/ems")).toBe(AS_EMS_UID);
+        expect(out.result.folderMap.get("assetspaces/exocmd")).toBe(
+          AS_EXOCMD_UID,
+        );
+        expect(out.result.folderMap.get("assetspaces/shared-identities")).toBe(
+          AS_SHARED_UID,
+        );
+      }
+    });
+  });
+
+  describe("resolveFilter — multi-vault (--also)", () => {
+    it("scans primary + alsoVaultPaths to build folderMap and find profiles", async () => {
+      const secondaryRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), "exocortex-cli-profile-secondary-"),
+      );
+      try {
+        await makeVault(tmpRoot, [
+          asAssetSpace(AS_EXO_UID, "exo"),
+          asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        ]);
+        await makeVault(secondaryRoot, [
+          asAssetSpace(AS_SHARED_UID, "shared-identities"),
+          asAssetSpace(AS_EMS_UID, "ems"),
+          asProfile(PROFILE_PERSONAL_UID, {
+            includes: [AS_EMS_UID],
+          }),
+        ]);
+        const resolver = new CliFocusProfileResolver({
+          vaultPath: tmpRoot,
+          alsoVaultPaths: [secondaryRoot],
+        });
+        const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
+        expect(out.outcome).toBe("engaged");
+        if (out.outcome === "engaged") {
+          expect(out.result.effective.has(AS_EMS_UID)).toBe(true);
+          expect(out.result.folderMap.size).toBeGreaterThanOrEqual(4);
+        }
+      } finally {
+        await fs.remove(secondaryRoot);
+      }
+    });
+
+    it("tolerates non-existent --also vault paths with warn", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asProfile(PROFILE_BASE_UID),
+      ]);
+      const warnings: string[] = [];
+      const resolver = new CliFocusProfileResolver({
+        vaultPath: tmpRoot,
+        alsoVaultPaths: ["/tmp/this-path-definitely-does-not-exist-test"],
+        warn: (m) => warnings.push(m),
+      });
+      const out = await resolver.resolveFilter(PROFILE_BASE_UID);
+      expect(out.outcome).toBe("engaged");
+      expect(warnings.some((w) => w.includes("does not exist"))).toBe(true);
+    });
+  });
+
+  describe("malformed input tolerance", () => {
+    it("skips files without frontmatter without throwing", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asProfile(PROFILE_BASE_UID),
+      ]);
+      // Drop a plain markdown file (no frontmatter)
+      await fs.ensureDir(path.join(tmpRoot, "03 Knowledge"));
+      await fs.writeFile(
+        path.join(tmpRoot, "03 Knowledge", "scratch.md"),
+        "# scratch\n\nnothing structured here\n",
+        "utf-8",
+      );
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_BASE_UID);
+      expect(out.outcome).toBe("engaged");
+    });
+
+    it("skips files with broken yaml without throwing", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asProfile(PROFILE_BASE_UID),
+      ]);
+      // Drop a file with malformed YAML frontmatter
+      await fs.ensureDir(path.join(tmpRoot, "junk"));
+      await fs.writeFile(
+        path.join(tmpRoot, "junk", "broken.md"),
+        "---\nthis is: \"not: valid:\n  yaml here\n---\n",
+        "utf-8",
+      );
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_BASE_UID);
+      expect(out.outcome).toBe("engaged");
+    });
+
+    it("skips hidden directories (.obsidian, .exocortex, .git)", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asAssetSpace(AS_EXOCMD_UID, "exocmd"),
+        asAssetSpace(AS_SHARED_UID, "shared-identities"),
+        asProfile(PROFILE_BASE_UID),
+      ]);
+      // Add a profile-shaped file inside .obsidian — it must NOT be discovered
+      const stowawayUid = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+      await fs.ensureDir(path.join(tmpRoot, ".obsidian"));
+      await fs.writeFile(
+        path.join(tmpRoot, ".obsidian", `${stowawayUid}.md`),
+        `---\nexo__Asset_uid: "${stowawayUid}"\nexo__Instance_class:\n  - "[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]"\n---\n`,
+        "utf-8",
+      );
+      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(stowawayUid);
+      expect(out.outcome).toBe("missing-profile");
+    });
+  });
+});
+
+describe("parseWikilinkArray", () => {
+  it("returns [] for null/undefined/empty inputs", () => {
+    expect(parseWikilinkArray(null)).toEqual([]);
+    expect(parseWikilinkArray(undefined)).toEqual([]);
+    expect(parseWikilinkArray([])).toEqual([]);
+  });
+
+  it("wraps a single string into an array", () => {
+    expect(parseWikilinkArray("[[abc]]")).toEqual(["abc"]);
+  });
+
+  it("strips wikilink brackets and aliases", () => {
+    expect(
+      parseWikilinkArray(["[[uid-1|alias]]", "[[uid-2]]", "raw-uid"]),
+    ).toEqual(["uid-1", "uid-2", "raw-uid"]);
+  });
+
+  it("drops non-string entries", () => {
+    expect(parseWikilinkArray(["[[ok]]", 42, null, undefined, "[[also-ok]]"])).toEqual([
+      "ok",
+      "also-ok",
+    ]);
+  });
+
+  it("drops empty entries after trimming", () => {
+    expect(parseWikilinkArray(["[[]]", "  ", "[[real]]"])).toEqual(["real"]);
+  });
+});
+
+describe("extractUidFromWikilink", () => {
+  it("returns null for empty string after stripping", () => {
+    expect(extractUidFromWikilink("[[]]")).toBeNull();
+    expect(extractUidFromWikilink("  ")).toBeNull();
+    expect(extractUidFromWikilink("|")).toBeNull();
+  });
+
+  it("strips alias", () => {
+    expect(extractUidFromWikilink("[[uid|alias]]")).toBe("uid");
+  });
+
+  it("returns trimmed inner string when not wrapped in brackets", () => {
+    expect(extractUidFromWikilink(" raw-uid ")).toBe("raw-uid");
+  });
+});

--- a/packages/cli/tests/unit/utils/resolveProfileFilter.test.ts
+++ b/packages/cli/tests/unit/utils/resolveProfileFilter.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for the shared `resolveProfileFilter` CLI helper
+ * (RFC 0a0791c1 Issue #3323).
+ *
+ * Focus: outcome → return-shape contract + text-mode banner emission.
+ * The underlying resolver is exercised via real fs in
+ * `CliFocusProfileResolver.test.ts` — here we verify the presentation glue
+ * is wired correctly across each outcome branch.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+
+import { resolveProfileFilter } from "../../../src/utils/resolveProfileFilter.js";
+import {
+  ASSET_SPACE_CLASS_UID,
+  FOCUS_PROFILE_CLASS_UID,
+  TS_FLOOR_AS_UID_EXO,
+  TS_FLOOR_AS_UID_EXOCMD,
+  TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+} from "../../../src/services/CliFocusProfileResolver.js";
+
+const PROFILE_UID = "11111111-1111-1111-1111-111111111111";
+const AS_EMS_UID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+async function makeMinimalVault(root: string, withProfile: boolean): Promise<void> {
+  await fs.ensureDir(path.join(root, "assetspaces", "exo"));
+  await fs.ensureDir(path.join(root, "assetspaces", "exocmd"));
+  await fs.ensureDir(path.join(root, "assetspaces", "shared-identities"));
+  await fs.ensureDir(path.join(root, "assetspaces", "ems"));
+  await fs.ensureDir(path.join(root, "profiles"));
+
+  const write = (rel: string, fm: Record<string, unknown>) => {
+    const yamlLines = Object.entries(fm).map(([k, v]) => {
+      if (Array.isArray(v)) {
+        return `${k}:\n${v.map((x) => `  - "${String(x).replace(/"/g, '\\"')}"`).join("\n")}`;
+      }
+      if (typeof v === "string") {
+        return `${k}: "${v.replace(/"/g, '\\"')}"`;
+      }
+      return `${k}: ${v}`;
+    });
+    return fs.writeFile(
+      path.join(root, rel),
+      `---\n${yamlLines.join("\n")}\n---\n`,
+      "utf-8",
+    );
+  };
+
+  await write(`assetspaces/exo/${TS_FLOOR_AS_UID_EXO}.md`, {
+    "exo__Asset_uid": TS_FLOOR_AS_UID_EXO,
+    "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+  });
+  await write(`assetspaces/exocmd/${TS_FLOOR_AS_UID_EXOCMD}.md`, {
+    "exo__Asset_uid": TS_FLOOR_AS_UID_EXOCMD,
+    "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+  });
+  await write(
+    `assetspaces/shared-identities/${TS_FLOOR_AS_UID_SHARED_IDENTITIES}.md`,
+    {
+      "exo__Asset_uid": TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+    },
+  );
+  await write(`assetspaces/ems/${AS_EMS_UID}.md`, {
+    "exo__Asset_uid": AS_EMS_UID,
+    "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+  });
+
+  if (withProfile) {
+    await write(`profiles/${PROFILE_UID}.md`, {
+      "exo__Asset_uid": PROFILE_UID,
+      "exo__Instance_class": [`[[${FOCUS_PROFILE_CLASS_UID}]]`],
+      "exo__FocusProfile_includes": [`[[${AS_EMS_UID}]]`],
+    });
+  }
+}
+
+describe("resolveProfileFilter", () => {
+  let tmpRoot: string;
+  let logs: string[];
+  let originalLog: typeof console.log;
+  let originalWarn: typeof console.warn;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "exocortex-cli-resolve-filter-test-"),
+    );
+    logs = [];
+    originalLog = console.log;
+    originalWarn = console.warn;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+    console.warn = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+  });
+
+  afterEach(async () => {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    if (tmpRoot && (await fs.pathExists(tmpRoot))) {
+      await fs.remove(tmpRoot);
+    }
+  });
+
+  it("returns null when profileUid is undefined", async () => {
+    await makeMinimalVault(tmpRoot, true);
+    const result = await resolveProfileFilter({
+      profileUid: undefined,
+      primaryVaultPath: tmpRoot,
+      outputFormat: "text",
+    });
+    expect(result).toBeNull();
+    expect(logs).toEqual([]); // no banner when no profile
+  });
+
+  it("returns null when profileUid is empty string", async () => {
+    await makeMinimalVault(tmpRoot, true);
+    const result = await resolveProfileFilter({
+      profileUid: "",
+      primaryVaultPath: tmpRoot,
+      outputFormat: "text",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns filter and prints engagement banner in text mode", async () => {
+    await makeMinimalVault(tmpRoot, true);
+    const result = await resolveProfileFilter({
+      profileUid: PROFILE_UID,
+      primaryVaultPath: tmpRoot,
+      outputFormat: "text",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.effective.has(AS_EMS_UID)).toBe(true);
+    expect(result!.effective.has(TS_FLOOR_AS_UID_EXO)).toBe(true);
+    expect(logs.some((l) => l.includes("engaged"))).toBe(true);
+  });
+
+  it("stays quiet in json mode even on engaged outcome", async () => {
+    await makeMinimalVault(tmpRoot, true);
+    const result = await resolveProfileFilter({
+      profileUid: PROFILE_UID,
+      primaryVaultPath: tmpRoot,
+      outputFormat: "json",
+    });
+    expect(result).not.toBeNull();
+    expect(logs).toEqual([]); // banner suppressed in json mode
+  });
+
+  it("returns null and prints missing-profile banner when UID is unknown", async () => {
+    await makeMinimalVault(tmpRoot, false);
+    const result = await resolveProfileFilter({
+      profileUid: "definitely-not-here",
+      primaryVaultPath: tmpRoot,
+      outputFormat: "text",
+    });
+    expect(result).toBeNull();
+    expect(logs.some((l) => l.includes("not found"))).toBe(true);
+  });
+
+  it("returns null and prints degraded banner when effective set has zero overlap", async () => {
+    // Vault has no AssetSpaces — TS-floor is set but has no matching folders
+    await fs.ensureDir(path.join(tmpRoot, "profiles"));
+    await fs.writeFile(
+      path.join(tmpRoot, "profiles", `${PROFILE_UID}.md`),
+      `---\nexo__Asset_uid: "${PROFILE_UID}"\nexo__Instance_class:\n  - "[[${FOCUS_PROFILE_CLASS_UID}]]"\n---\n`,
+      "utf-8",
+    );
+    const result = await resolveProfileFilter({
+      profileUid: PROFILE_UID,
+      primaryVaultPath: tmpRoot,
+      outputFormat: "text",
+    });
+    expect(result).toBeNull();
+    expect(logs.some((l) => l.includes("zero AssetSpace folder overlap"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

CLI counterpart to plugin's runtime FocusProfile filter (Issue #3324).
Adds `--profile <uid>` flag to `query`, `classes`, `find`, `ask` commands,
restricting the RDF graph to the effective AssetSpace set declared by the
profile chain. Variant A MVP scope — manual flag, no plugin sync, no
persistence. **P0 для Phase 5 E2E spike enablement.**

Closes #3323.

## Architecture

`CliFocusProfileResolver` mirrors plugin's `FocusProfileSwitchManager.resolveEffectiveSet`
+ `FocusProfileOnloadWiring.applyActiveProfileFilter` translation:

1. Walk vault filesystem → build `folderMap` (`assetspaces/<folder>` → AS UID)
   + `ontologyToAs` (Ontology UID → owning AS UID, via `containsOntology`)
   + `profiles` map.
2. Walk `_extends*` chain → declared Ontology UID set (`includes` + `alwaysOnOverlay`,
   cycle-guarded, depth-capped at 5).
3. Translate Ontology UIDs → AS UIDs via `ontologyToAs` (pass-through если
   already AS UID, track untranslated).
4. Apply TS-floor literal AS UIDs:
   - `49fd2e56` ($exo)
   - `c9c65b0f` ($exocmd)
   - `0cde1557` ($shared-identities)
5. R15 self-brick mitigation: zero AS-folder overlap → return `{ outcome: "degraded" }`,
   caller falls back to no-filter (full vault indexed).

Wired through 4 commands via shared `resolveProfileFilter` helper which emits
text-mode engagement banners uniformly and stays quiet in JSON mode.

### Cache interaction

`--profile` disables `--use-cache` (the persistent cache key is per-vault,
no profile dimension). Emits a one-line warn explaining the downgrade.
Profile-aware caching is Variant C follow-up scope.

## Verification

- ✅ 33 new unit tests (27 resolver + 6 helper)
- ✅ Full CLI suite 1859 pass (1 pre-existing failure: `npm-publish-verify.test.ts`
  import.meta issue, unrelated)
- ✅ Build green
- ✅ TypeScript: 0 new errors (21 pre-existing untouched)
- ✅ CLI smoke pending — STEP G на disposable vault (see comment after merge)

## Phase 6 follow-up (deferred)

Extract resolver + translation logic to `packages/exocortex/` so plugin and
CLI consume one implementation. For this P0 spike-enabler the logic is
duplicated verbatim — drift surface tracked by `multi-parser-predicate-
migration.md` rule + module docstring.

## Scope guarantees

- ❌ Variant B (`--use-plugin-active-profile` reading `data.json`) — deferred
- ❌ Variant C (CLI defaultProfile persistence) — deferred
- ❌ Profile-aware cache — deferred (Variant C)

## Test plan

- [x] Unit tests passing locally
- [x] Build green locally
- [ ] CI 14 required checks green
- [ ] Code-reviewer agent: 0 CRITICAL/HIGH findings
- [ ] CLI smoke on disposable vault (STEP G post-merge)

🤖 Generated with Claude Code