### PR TITLE
cleanup(plugin): #3327 deferred items (integration tests + sync gate + dedup + abstraction)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -101,10 +101,8 @@ import { PluginRdfIndexerAdapter } from "./infrastructure/adapters/PluginRdfInde
 import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSettingsStoreAdapter";
 import { ProfileFuzzyModal } from "./infrastructure/adapters/ProfileFuzzyModal";
 import { applyActiveProfileFilter } from "./infrastructure/adapters/FocusProfileOnloadWiring";
-import {
-  AssetSpaceManager,
-  isAssetSpaceFrontmatter,
-} from "./infrastructure/adapters/AssetSpaceManager";
+import { AssetSpaceManager } from "./infrastructure/adapters/AssetSpaceManager";
+import { lookupAssetSpaceUidByFolder } from "./infrastructure/adapters/AssetSpaceLookupHelper";
 import { GitHubRestClient } from "./infrastructure/adapters/GitHubRestClient";
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
 import {
@@ -2491,25 +2489,11 @@ export default class ExocortexPlugin extends Plugin {
    * lookup branches in `FocusProfileCommands.invokePushCurrentAssetSpace`
    * still need to resolve).
    *
-   * Class-membership predicate delegates to the shared
-   * `isAssetSpaceFrontmatter` helper — strict wikilink matching, not loose
-   * substring — so adjacent UUID-like noise in `exo__Instance_class` doesn't
-   * falsely register. See Issue #3312 MEDIUM #1 propagation.
+   * Delegates to the shared `lookupAssetSpaceUidByFolder` helper so this
+   * stub path and `AssetSpaceManager.lookupAssetSpaceForPath` cannot
+   * drift (Issue #3327 Item #4).
    */
   private lookupAssetSpaceUidByFolder(folderName: string): string | null {
-    if (typeof folderName !== "string" || folderName.length === 0) return null;
-    const normalised = folderName.replace(/\/$/, "");
-    for (const file of this.app.vault.getMarkdownFiles()) {
-      const parent = file.parent?.path ?? "";
-      if (parent !== normalised) continue;
-      const fm = this.app.metadataCache.getFileCache(file)?.frontmatter as
-        | Record<string, unknown>
-        | undefined;
-      if (!fm) continue;
-      if (!isAssetSpaceFrontmatter(fm)) continue;
-      const uid = fm["exo__Asset_uid"];
-      if (typeof uid === "string" && uid.length > 0) return uid;
-    }
-    return null;
+    return lookupAssetSpaceUidByFolder(this.app, folderName);
   }
 }

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -101,9 +101,8 @@ import { PluginRdfIndexerAdapter } from "./infrastructure/adapters/PluginRdfInde
 import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSettingsStoreAdapter";
 import { ProfileFuzzyModal } from "./infrastructure/adapters/ProfileFuzzyModal";
 import { applyActiveProfileFilter } from "./infrastructure/adapters/FocusProfileOnloadWiring";
-import { AssetSpaceManager } from "./infrastructure/adapters/AssetSpaceManager";
 import { lookupAssetSpaceUidByFolder } from "./infrastructure/adapters/AssetSpaceLookupHelper";
-import { GitHubRestClient } from "./infrastructure/adapters/GitHubRestClient";
+import { createAssetSpacePusher } from "./infrastructure/adapters/AssetSpacePusherFactory";
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
 import {
   CommandExecutionFlow,
@@ -2427,73 +2426,14 @@ export default class ExocortexPlugin extends Plugin {
   private async buildAssetSpacePusher(): Promise<IAssetSpacePusher> {
     const secretsStore = new LocalSecretsStore({ app: this.app });
     const pat = await secretsStore.getSecret("pat");
-    const lookupOnlyFor = (folderName: string): string | null =>
-      this.lookupAssetSpaceUidByFolder(folderName);
-
-    if (pat === null || pat.length === 0) {
-      return {
-        lookupAssetSpaceForPath: lookupOnlyFor,
-        pushAssetSpace: () =>
-          Promise.reject(
-            new Error(
-              "GitHub PAT not configured — set it в Settings → Exocortex → GitHub PAT",
-            ),
-          ),
-      };
-    }
-
-    try {
-      const client = new GitHubRestClient({ pat, app: this.app });
-      const manager = new AssetSpaceManager({
-        app: this.app,
-        client,
-        notifications: this.notifier,
-      });
-      return {
-        lookupAssetSpaceForPath: (folderName) =>
-          manager.lookupAssetSpaceForPath(folderName),
-        pushAssetSpace: async (asUid) => {
-          const sha = await manager.pushAssetSpace(asUid);
-          // `AssetSpaceManager.pushAssetSpace` returns `Promise<string | null>`
-          // (`null` = no dirty files, no-op success). Coerce `null` → `""`
-          // to match `FocusProfileCommands.IAssetSpacePusher` contract,
-          // which treats empty string as «no-op» (see handler comment
-          // around line 139).
-          return sha ?? "";
-        },
-      };
-    } catch (error) {
-      this.logger.error(
-        "[ExocortexPlugin] AssetSpaceManager construction failed — push command will fail-clean",
-        error instanceof Error ? error : new Error(String(error)),
-      );
-      return {
-        lookupAssetSpaceForPath: lookupOnlyFor,
-        pushAssetSpace: () =>
-          Promise.reject(
-            new Error(
-              `Could not initialise AssetSpaceManager: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            ),
-          ),
-      };
-    }
+    return createAssetSpacePusher({
+      app: this.app,
+      pat,
+      notifier: this.notifier,
+      logger: this.logger,
+      lookupOnly: (folderName) =>
+        lookupAssetSpaceUidByFolder(this.app, folderName),
+    });
   }
 
-  /**
-   * Vault-scan lookup mirroring `AssetSpaceManager.lookupAssetSpaceForPath`
-   * — finds the AssetSpace ABox asset whose containing folder matches
-   * `folderName` and returns its `exo__Asset_uid`. Used by the lookup-
-   * only stub path when GitHub PAT is absent (push disabled but the
-   * lookup branches in `FocusProfileCommands.invokePushCurrentAssetSpace`
-   * still need to resolve).
-   *
-   * Delegates to the shared `lookupAssetSpaceUidByFolder` helper so this
-   * stub path and `AssetSpaceManager.lookupAssetSpaceForPath` cannot
-   * drift (Issue #3327 Item #4).
-   */
-  private lookupAssetSpaceUidByFolder(folderName: string): string | null {
-    return lookupAssetSpaceUidByFolder(this.app, folderName);
-  }
 }

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -99,6 +99,7 @@ import { PluginLockManager } from "./infrastructure/adapters/PluginLockManager";
 import { VaultProfileResolver } from "./infrastructure/adapters/VaultProfileResolver";
 import { PluginRdfIndexerAdapter } from "./infrastructure/adapters/PluginRdfIndexerAdapter";
 import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSettingsStoreAdapter";
+import { PluginLocalDataStore } from "./infrastructure/adapters/PluginLocalDataStore";
 import { ProfileFuzzyModal } from "./infrastructure/adapters/ProfileFuzzyModal";
 import { applyActiveProfileFilter } from "./infrastructure/adapters/FocusProfileOnloadWiring";
 import { lookupAssetSpaceUidByFolder } from "./infrastructure/adapters/AssetSpaceLookupHelper";
@@ -227,6 +228,16 @@ export default class ExocortexPlugin extends Plugin {
    * call succeeds.
    */
   public listFocusProfileChoices: (() => Promise<FocusProfileChoice[]>) | null = null;
+
+  /**
+   * Issue #3327 Item #3 — device-local switch state store (Sync-excluded).
+   * Holds `activeProfileUid` + `_switchInProgress` per-device so profile
+   * selection does not replicate cross-device. Initialized в
+   * `registerFocusProfileCommands` with one-time legacy-migration; null
+   * до того момента, читателям нужно тогда fall-back на legacy
+   * `this.settings.activeProfileUid`.
+   */
+  public localDataStore: PluginLocalDataStore | null = null;
 
   override async onload(): Promise<void> {
     try {
@@ -900,9 +911,15 @@ export default class ExocortexPlugin extends Plugin {
               // case covered by the post-resolve one-shot regression
               // tests). When profile is null the helper would no-op and
               // the second refresh would only re-walk the same data.
+              //
+              // Item #3 — device-local store (no Sync replication). Null
+              // before `registerFocusProfileCommands` resolves; treat as
+              // no-active-profile (matches current behaviour). Loose
+              // truthiness check handles unit-test mocks where the field
+              // may be undefined rather than initialised to null.
               const hasActiveProfile =
-                typeof (this.settings as Record<string, unknown>)
-                  .activeProfileUid === "string";
+                !!this.localDataStore &&
+                this.localDataStore.getActiveProfileUid() !== null;
               if (reapplyActiveProfileFilter !== null && hasActiveProfile) {
                 try {
                   await reapplyActiveProfileFilter();
@@ -2247,10 +2264,44 @@ export default class ExocortexPlugin extends Plugin {
     const lockMgr = new PluginLockManager({ app: this.app });
     const resolver = new VaultProfileResolver(this.app);
     const rdfIndexer = new PluginRdfIndexerAdapter(this.sparql.getRdfIndexer());
-    const settingsStore = new PluginSettingsStoreAdapter({
-      readSettings: () => this.settings as Record<string, unknown>,
-      saveSettings: () => this.saveSettings(),
+
+    // Issue #3327 Item #3 — initialize device-local switch state store and
+    // run one-time migration from legacy `plugin.settings` keys. After
+    // migration, switch state lives в `data.local.json` (Sync-excluded);
+    // legacy keys are cleared from `plugin.settings` so they do not
+    // re-arrive via Sync на another device.
+    const localDataStore = new PluginLocalDataStore({ app: this.app });
+    const legacySettings = this.settings as Record<string, unknown>;
+    const migrationOutcome = await localDataStore.migrateFromLegacyIfNeeded({
+      activeProfileUid: legacySettings.activeProfileUid,
+      _switchInProgress: legacySettings._switchInProgress,
     });
+    if (migrationOutcome === "legacy") {
+      this.logger.info(
+        "[ExocortexPlugin] migrated legacy activeProfileUid/_switchInProgress " +
+          "from plugin.settings → data.local.json (per-device)",
+      );
+      delete legacySettings.activeProfileUid;
+      delete legacySettings._switchInProgress;
+      await this.saveSettings();
+    } else if (
+      legacySettings.activeProfileUid !== undefined ||
+      legacySettings._switchInProgress !== undefined
+    ) {
+      // Stale-sync edge: local already populated AND legacy fields present.
+      // Local takes precedence (idempotency); clear legacy так stale-sync
+      // value не trumps the device's choice on next migration cycle.
+      this.logger.info(
+        "[ExocortexPlugin] clearing stale legacy switch keys (local " +
+          "data.local.json already populated — Issue #3327 Item #3 idempotency)",
+      );
+      delete legacySettings.activeProfileUid;
+      delete legacySettings._switchInProgress;
+      await this.saveSettings();
+    }
+    this.localDataStore = localDataStore;
+
+    const settingsStore = new PluginSettingsStoreAdapter(localDataStore);
 
     const switchMgr = new FocusProfileSwitchManager({
       app: this.app,
@@ -2283,12 +2334,8 @@ export default class ExocortexPlugin extends Plugin {
     // close the cold-start race where `metadataCache.getFileCache` may
     // still return null for AS files at this earlier timing.
     const reapplyActiveProfileFilter = async (): Promise<void> => {
-      const persistedProfileUid =
-        typeof (this.settings as Record<string, unknown>).activeProfileUid ===
-        "string"
-          ? ((this.settings as Record<string, unknown>)
-              .activeProfileUid as string)
-          : null;
+      // Item #3 — read from device-local store (no Sync replication).
+      const persistedProfileUid = localDataStore.getActiveProfileUid();
       await applyActiveProfileFilter({
         app: this.app,
         switchMgr,
@@ -2335,12 +2382,8 @@ export default class ExocortexPlugin extends Plugin {
     const pushMgr = await this.buildAssetSpacePusher();
 
     const profileLister: () => Promise<FocusProfileChoice[]> = async () => {
-      const activeUid =
-        typeof (this.settings as Record<string, unknown>).activeProfileUid ===
-        "string"
-          ? ((this.settings as Record<string, unknown>)
-              .activeProfileUid as string)
-          : null;
+      // Item #3 — device-local store (no Sync replication).
+      const activeUid = localDataStore.getActiveProfileUid();
       const choices: FocusProfileChoice[] = [];
       for (const file of resolver.listFocusProfileFiles()) {
         const cache = this.app.metadataCache.getFileCache(file);

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -233,9 +233,14 @@ export default class ExocortexPlugin extends Plugin {
    * Issue #3327 Item #3 — device-local switch state store (Sync-excluded).
    * Holds `activeProfileUid` + `_switchInProgress` per-device so profile
    * selection does not replicate cross-device. Initialized в
-   * `registerFocusProfileCommands` with one-time legacy-migration; null
-   * до того момента, читателям нужно тогда fall-back на legacy
-   * `this.settings.activeProfileUid`.
+   * `registerFocusProfileCommands` after one-time legacy-keys migration;
+   * remains null before that point.
+   *
+   * Readers treat the null state as «no active profile» (matches the
+   * default for fresh installs and для users who never selected a profile).
+   * No fallback к legacy `this.settings.activeProfileUid` — migration
+   * runs early enough that production reads always see the initialized
+   * store, and any legacy keys are cleared in the same migration pass.
    */
   public localDataStore: PluginLocalDataStore | null = null;
 

--- a/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
+++ b/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
@@ -2,7 +2,37 @@ import type { TFile } from "obsidian";
 import type { InMemoryTripleStore, SolutionMapping, Triple } from "exocortex";
 import { SPARQLQueryService } from '@plugin/application/services/SPARQLQueryService';
 import type ExocortexPlugin from '@plugin/ExocortexPlugin';
-import type { VaultRDFIndexer } from '@plugin/infrastructure/VaultRDFIndexer';
+
+/**
+ * Application-layer handle to the underlying RDF indexer.
+ *
+ * Exposes only the operations FocusProfile wiring needs (refresh,
+ * filter mutators) so callers in `presentation/` or other plugin
+ * surfaces cannot accidentally reach into the infrastructure-layer
+ * `VaultRDFIndexer` lifecycle (init, dispose, internal store handles).
+ *
+ * Closes the abstraction-leak deferred in `getRdfIndexer()` JSDoc
+ * (Issue #3327, code-reviewer MEDIUM from PR #3326).
+ */
+export interface IRdfIndexerHandle {
+  /**
+   * Reindex the vault. With an explicit `effectiveOntologies` arg the
+   * indexer first persists it via `setEffectiveOntologies` before
+   * reindexing. Without an arg, reuses the previously stored set.
+   */
+  refresh(effectiveOntologies?: ReadonlySet<string>): Promise<void>;
+  /**
+   * Replace the stored effective AssetSpace UID set. Pass `null` to
+   * clear (disengages the filter on next refresh).
+   */
+  setEffectiveOntologies(set: ReadonlySet<string> | null): void;
+  /**
+   * Replace the folder→AS-UID map used by the converter to decide
+   * which `assetspaces/<folder>/` files belong to which AS. Pass
+   * `null` to clear (filter disengages — see VaultRDFIndexer:111).
+   */
+  setAssetSpaceFolderToUid(map: ReadonlyMap<string, string> | null): void;
+}
 
 /**
  * Result of a SPARQL SELECT query execution.
@@ -313,24 +343,22 @@ export class SPARQLApi {
   }
 
   /**
-   * Returns the underlying `VaultRDFIndexer`. Exposed для RFC 0a0791c1
-   * B.4 wiring — `PluginRdfIndexerAdapter` (Issue #3322) constructs an
-   * `IRdfIndexer` over this instance so `FocusProfileSwitchManager.switchProfile`
-   * can thread the effective ontology set через
-   * `VaultRDFIndexer.refresh(set)`.
+   * Returns an application-layer handle to the underlying RDF indexer.
+   * Exposed для RFC 0a0791c1 B.4 wiring — `PluginRdfIndexerAdapter`
+   * (Issue #3322) constructs an `IRdfIndexer` over this handle so
+   * `FocusProfileSwitchManager.switchProfile` can thread the effective
+   * ontology set через `refresh(set)`. `applyActiveProfileFilter`
+   * (Issue #3324) uses it to set the folder map and effective set
+   * during cold-start.
    *
-   * This is intentionally a thin passthrough; callers should NOT directly
-   * mutate indexer state outside of the SwitchManager flow.
+   * The return type is narrowed к {@link IRdfIndexerHandle} so callers
+   * cannot reach into `VaultRDFIndexer` lifecycle (init/dispose/store)
+   * — closes the abstraction-leak deferred in PR #3326 (Issue #3327).
    *
-   * **Known abstraction leak** (code-reviewer MEDIUM, deferred): the
-   * `VaultRDFIndexer` type sits in `infrastructure/` while this class
-   * sits in `application/api/`. Tightening the return type к а narrower
-   * application-layer interface (e.g. `IRdfIndexerHandle` exposing only
-   * `refresh(set) + setEffectiveOntologies + setAssetSpaceFolderToUid`)
-   * is а follow-up task; for now the leak is documented and contained
-   * к the single consumer.
+   * This is intentionally a thin passthrough; callers should NOT
+   * directly mutate indexer state outside of the SwitchManager flow.
    */
-  getRdfIndexer(): VaultRDFIndexer {
+  getRdfIndexer(): IRdfIndexerHandle {
     return this.queryService.getIndexer();
   }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceFrontmatter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceFrontmatter.ts
@@ -1,0 +1,52 @@
+/**
+ * Leaf module — shared constants + predicates for AssetSpace ABox detection.
+ * Extracted out of `AssetSpaceManager` so it can be imported by both
+ * `AssetSpaceManager` and `AssetSpaceLookupHelper` without forming a
+ * circular dependency (Issue #3327 code-reviewer MEDIUM-2).
+ *
+ * Pure functions only — no Obsidian API, no I/O. Suitable for use anywhere.
+ */
+
+/**
+ * Class UID of `exo__AssetSpace` (TBox root). Used to discriminate AssetSpace
+ * ABox instances from other assets when scanning the vault. Hardcoded by RFC
+ * 0a0791c1 (UID frozen by RFC v2 `2a98f345`, implemented 2026-05-17).
+ */
+export const ASSET_SPACE_CLASS_UID = "73bd00e4-ccc0-4f3f-b20d-c4388c4588fb";
+
+/**
+ * Strict wikilink regex — matches `[[<uuid>]]` or `[[<uuid>|<label>]]`,
+ * capturing the canonical UUIDv4 form (8-4-4-4-12 hex, case-insensitive).
+ * Anchored to the wikilink brackets so substring matches like
+ * `notavalid-73bd00e4-...` do not falsely register as the AssetSpace class.
+ * See Issue #3312 MEDIUM #1.
+ */
+const WIKILINK_UID_RE =
+  /\[\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\|[^\]]*)?\]\]/gi;
+
+/**
+ * Predicate — does this frontmatter declare `exo__Instance_class` containing
+ * the AssetSpace class UID? Handles both wikilink-string and array-of-string
+ * shapes that Obsidian's parser may produce. Membership is decided by strict
+ * wikilink regex (not loose substring), so adjacent UUID-like noise in the
+ * value does not falsely match.
+ *
+ * Shared by `AssetSpaceManager`, `AssetSpaceLookupHelper`, and
+ * `FocusProfileOnloadWiring.scanAssetSpaces`; centralising here makes one
+ * predicate the source of truth and breaks the `AssetSpaceManager` ↔
+ * `AssetSpaceLookupHelper` circular import.
+ * See Issue #3312.
+ */
+export function isAssetSpaceFrontmatter(fm: Record<string, unknown>): boolean {
+  const classes = fm["exo__Instance_class"];
+  const candidates: unknown[] = Array.isArray(classes) ? classes : [classes];
+  for (const c of candidates) {
+    if (typeof c !== "string") continue;
+    WIKILINK_UID_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = WIKILINK_UID_RE.exec(c)) !== null) {
+      if (m[1].toLowerCase() === ASSET_SPACE_CLASS_UID) return true;
+    }
+  }
+  return false;
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceLookupHelper.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceLookupHelper.ts
@@ -1,6 +1,6 @@
 import type { App } from "obsidian";
 
-import { isAssetSpaceFrontmatter } from "./AssetSpaceManager";
+import { isAssetSpaceFrontmatter } from "./AssetSpaceFrontmatter";
 
 /**
  * Folder-name → AssetSpace UID lookup. Returns the `exo__Asset_uid` of the

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceLookupHelper.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceLookupHelper.ts
@@ -1,0 +1,52 @@
+import type { App } from "obsidian";
+
+import { isAssetSpaceFrontmatter } from "./AssetSpaceManager";
+
+/**
+ * Folder-name → AssetSpace UID lookup. Returns the `exo__Asset_uid` of the
+ * AssetSpace ABox asset whose containing folder matches `folderName`, or
+ * `null` if no such asset is found.
+ *
+ * Shared by:
+ *  - `AssetSpaceManager.lookupAssetSpaceForPath` (PAT-present path) —
+ *    full push capability via GitHub REST.
+ *  - `ExocortexPlugin.buildAssetSpacePusher` (PAT-absent stub path) —
+ *    lookup-only path while push is unavailable.
+ *
+ * Both consumers iterate `vault.getMarkdownFiles()`, apply
+ * `isAssetSpaceFrontmatter` (strict wikilink regex per Issue #3312
+ * MEDIUM #1), and compare the file's parent folder against the
+ * normalised input. Centralising here avoids drift if the AssetSpace
+ * class UID changes or the wikilink shape evolves.
+ *
+ * Class-membership check delegates to the shared `isAssetSpaceFrontmatter`
+ * helper — strict wikilink matching, not loose substring — so adjacent
+ * UUID-like noise in `exo__Instance_class` doesn't falsely register.
+ */
+export function lookupAssetSpaceUidByFolder(
+  app: App,
+  folderName: string,
+): string | null {
+  if (typeof folderName !== "string" || folderName.length === 0) return null;
+  const normalised = stripTrailingSlash(folderName);
+  for (const file of app.vault.getMarkdownFiles()) {
+    const cache = app.metadataCache.getFileCache(file);
+    const fm = cache?.frontmatter as Record<string, unknown> | undefined;
+    if (!fm) continue;
+    if (!isAssetSpaceFrontmatter(fm)) continue;
+    const parent = parentFolder(file.path);
+    if (parent !== normalised) continue;
+    const uid = fm["exo__Asset_uid"];
+    if (typeof uid === "string" && uid.length > 0) return uid;
+  }
+  return null;
+}
+
+function parentFolder(filePath: string): string {
+  const idx = filePath.lastIndexOf("/");
+  return idx < 0 ? "" : filePath.slice(0, idx);
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.endsWith("/") ? s.slice(0, -1) : s;
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -1,6 +1,7 @@
 import type { App, TFile } from "obsidian";
 import type { INotificationService } from "exocortex";
 import { GitHubRestClient } from "./GitHubRestClient";
+import { lookupAssetSpaceUidByFolder } from "./AssetSpaceLookupHelper";
 
 /**
  * Class UID of `exo__AssetSpace` (TBox root). Used to discriminate AssetSpace
@@ -151,21 +152,7 @@ export class AssetSpaceManager {
    * `assetspaces/ems/f0f674da-....md` owns folder `"assetspaces/ems"`.
    */
   public lookupAssetSpaceForPath(folderName: string): string | null {
-    if (typeof folderName !== "string" || folderName.length === 0) {
-      return null;
-    }
-    const normalized = stripTrailingSlash(folderName);
-    for (const file of this.app.vault.getMarkdownFiles()) {
-      const fm = this.readFrontmatter(file);
-      if (!fm) continue;
-      if (!isAssetSpaceFrontmatter(fm)) continue;
-      const parent = parentFolder(file.path);
-      if (parent === normalized) {
-        const uid = fm["exo__Asset_uid"];
-        if (typeof uid === "string" && uid.length > 0) return uid;
-      }
-    }
-    return null;
+    return lookupAssetSpaceUidByFolder(this.app, folderName);
   }
 
   /**
@@ -390,10 +377,6 @@ export function isAssetSpaceFrontmatter(fm: Record<string, unknown>): boolean {
 function parentFolder(filePath: string): string {
   const idx = filePath.lastIndexOf("/");
   return idx < 0 ? "" : filePath.slice(0, idx);
-}
-
-function stripTrailingSlash(s: string): string {
-  return s.endsWith("/") ? s.slice(0, -1) : s;
 }
 
 function stripFolderPrefix(vaultPath: string, folderName: string): string {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -2,13 +2,15 @@ import type { App, TFile } from "obsidian";
 import type { INotificationService } from "exocortex";
 import { GitHubRestClient } from "./GitHubRestClient";
 import { lookupAssetSpaceUidByFolder } from "./AssetSpaceLookupHelper";
+import {
+  ASSET_SPACE_CLASS_UID,
+  isAssetSpaceFrontmatter,
+} from "./AssetSpaceFrontmatter";
 
-/**
- * Class UID of `exo__AssetSpace` (TBox root). Used to discriminate AssetSpace
- * ABox instances from other assets when scanning the vault. Hardcoded by RFC
- * 0a0791c1 (UID frozen by RFC v2 `2a98f345`, implemented 2026-05-17).
- */
-export const ASSET_SPACE_CLASS_UID = "73bd00e4-ccc0-4f3f-b20d-c4388c4588fb";
+// Re-export для backward-compat consumers that previously imported from
+// `AssetSpaceManager` directly (e.g. existing test files); leaf-module
+// authority lives in `AssetSpaceFrontmatter`.
+export { ASSET_SPACE_CLASS_UID, isAssetSpaceFrontmatter };
 
 /**
  * Resolved AssetSpace metadata extracted from vault frontmatter.
@@ -337,42 +339,9 @@ export class AssetSpaceManager {
 }
 
 // ────────────────────────── module-private helpers ──────────────────────────
-
-/**
- * Strict wikilink regex — matches `[[<uuid>]]` or `[[<uuid>|<label>]]`,
- * capturing the canonical UUIDv4 form (8-4-4-4-12 hex, case-insensitive).
- * Anchored to the wikilink brackets so substring matches like
- * `notavalid-73bd00e4-...` do not falsely register as the AssetSpace class.
- * See Issue #3312 MEDIUM #1.
- */
-const WIKILINK_UID_RE =
-  /\[\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\|[^\]]*)?\]\]/gi;
-
-/**
- * Predicate — does this frontmatter declare `exo__Instance_class` containing
- * the AssetSpace class UID? Handles both wikilink-string and array-of-string
- * shapes that Obsidian's parser may produce. Membership is decided by strict
- * wikilink regex (not loose substring), so adjacent UUID-like noise in the
- * value does not falsely match.
- *
- * Exported so sibling adapters (`ExocortexPlugin.lookupAssetSpaceUidByFolder`,
- * `FocusProfileOnloadWiring.scanAssetSpaces`) share one predicate; the prior
- * copy-paste used loose substring matching and inherited the same bug.
- * See Issue #3312.
- */
-export function isAssetSpaceFrontmatter(fm: Record<string, unknown>): boolean {
-  const classes = fm["exo__Instance_class"];
-  const candidates: unknown[] = Array.isArray(classes) ? classes : [classes];
-  for (const c of candidates) {
-    if (typeof c !== "string") continue;
-    WIKILINK_UID_RE.lastIndex = 0;
-    let m: RegExpExecArray | null;
-    while ((m = WIKILINK_UID_RE.exec(c)) !== null) {
-      if (m[1].toLowerCase() === ASSET_SPACE_CLASS_UID) return true;
-    }
-  }
-  return false;
-}
+// Shared predicates / constants (ASSET_SPACE_CLASS_UID, isAssetSpaceFrontmatter,
+// WIKILINK_UID_RE) live in `AssetSpaceFrontmatter` (leaf module) to break
+// the AssetSpaceManager ↔ AssetSpaceLookupHelper circular import.
 
 function parentFolder(filePath: string): string {
   const idx = filePath.lastIndexOf("/");

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpacePusherFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpacePusherFactory.ts
@@ -1,0 +1,107 @@
+import type { App } from "obsidian";
+import type { ILogger, INotificationService } from "exocortex";
+
+import { AssetSpaceManager } from "./AssetSpaceManager";
+import {
+  GitHubRestClient,
+  type GitHubRestClientOptions,
+} from "./GitHubRestClient";
+import type { IAssetSpacePusher } from "./FocusProfileCommands";
+
+/**
+ * Lookup-only helper from {@link AssetSpaceLookupHelper.lookupAssetSpaceUidByFolder}.
+ * Used by the PAT-absent and ctor-failure branches as the `lookupAssetSpaceForPath`
+ * implementation while `pushAssetSpace` is unavailable.
+ */
+export type AssetSpaceLookupFn = (folderName: string) => string | null;
+
+/**
+ * Optional GitHubRestClient factory — tests inject a function that throws
+ * to exercise the ctor-failure branch без monkey-patching the module. Default
+ * constructs the real client.
+ */
+export type GitHubRestClientFactory = (
+  opts: GitHubRestClientOptions,
+) => GitHubRestClient;
+
+export interface CreateAssetSpacePusherOptions {
+  app: App;
+  /** Resolved GitHub PAT, or `null`/empty when none configured. */
+  pat: string | null;
+  notifier: INotificationService;
+  logger: ILogger;
+  /** Vault-scan lookup used by lookup-only branches. */
+  lookupOnly: AssetSpaceLookupFn;
+  /** Optional client factory for tests. */
+  clientFactory?: GitHubRestClientFactory;
+}
+
+/**
+ * Factory for `IAssetSpacePusher`. Extracted from `ExocortexPlugin.buildAssetSpacePusher`
+ * for testability (Issue #3327 Item #1).
+ *
+ * Branches:
+ *   - `pat == null || pat.length === 0` → lookup-only stub, push rejects with
+ *     a «Configure GitHub PAT» message.
+ *   - `pat` valid → constructs `AssetSpaceManager`; lookup and push both
+ *     delegate to it.
+ *   - client ctor throws (PAT invalid shape, network init crash, allowlist
+ *     fail) → lookup-only stub, push rejects with the original error message;
+ *     logger.error records the failure.
+ */
+export function createAssetSpacePusher(
+  options: CreateAssetSpacePusherOptions,
+): IAssetSpacePusher {
+  const { app, pat, notifier, logger, lookupOnly } = options;
+  const clientFactory =
+    options.clientFactory ?? ((opts) => new GitHubRestClient(opts));
+
+  if (pat === null || pat.length === 0) {
+    return {
+      lookupAssetSpaceForPath: lookupOnly,
+      pushAssetSpace: () =>
+        Promise.reject(
+          new Error(
+            "GitHub PAT not configured — set it в Settings → Exocortex → GitHub PAT",
+          ),
+        ),
+    };
+  }
+
+  try {
+    const client = clientFactory({ pat, app });
+    const manager = new AssetSpaceManager({
+      app,
+      client,
+      notifications: notifier,
+    });
+    return {
+      lookupAssetSpaceForPath: (folderName) =>
+        manager.lookupAssetSpaceForPath(folderName),
+      pushAssetSpace: async (asUid) => {
+        const sha = await manager.pushAssetSpace(asUid);
+        // `AssetSpaceManager.pushAssetSpace` returns `Promise<string | null>`
+        // (`null` = no dirty files, no-op success). Coerce `null` → `""` to
+        // match `IAssetSpacePusher` contract, which treats empty string as
+        // «no-op».
+        return sha ?? "";
+      },
+    };
+  } catch (error) {
+    logger.error(
+      "[AssetSpacePusherFactory] AssetSpaceManager construction failed — push command will fail-clean",
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    return {
+      lookupAssetSpaceForPath: lookupOnly,
+      pushAssetSpace: () =>
+        Promise.reject(
+          new Error(
+            `Could not initialise AssetSpaceManager: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          ),
+        ),
+    };
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileOnloadWiring.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileOnloadWiring.ts
@@ -1,7 +1,7 @@
 import type { App, TFile } from "obsidian";
 import type { ILogger } from "exocortex";
 
-import { isAssetSpaceFrontmatter } from "./AssetSpaceManager";
+import { isAssetSpaceFrontmatter } from "./AssetSpaceFrontmatter";
 import type { FocusProfileSwitchManager } from "./FocusProfileSwitchManager";
 
 /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/LocalSecretsStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/LocalSecretsStore.ts
@@ -58,22 +58,19 @@ export class LocalSecretsStore {
    * Read the secrets file. Returns \`{}\` when the file is absent или
    * unparseable — callers should not surface this as an error, since a
    * fresh install legitimately has no secrets yet.
+   *
+   * Filters to string values only — non-string keys (e.g. PluginLocalDataStore's
+   * boolean `_switchInProgress` co-living в the same file) are NOT visible to
+   * secret-reading consumers. Internal persistence preserves them via
+   * {@link readAllRaw}; see Issue #3327 Item #3 для the cross-store rationale.
    */
   async readAll(): Promise<Record<string, string>> {
-    try {
-      const exists = await this.app.vault.adapter.exists(this.path);
-      if (!exists) return {};
-      const raw = await this.app.vault.adapter.read(this.path);
-      const parsed = JSON.parse(raw) as unknown;
-      if (parsed === null || typeof parsed !== "object") return {};
-      const result: Record<string, string> = {};
-      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-        if (typeof v === "string") result[k] = v;
-      }
-      return result;
-    } catch {
-      return {};
+    const all = await this.readAllRaw();
+    const result: Record<string, string> = {};
+    for (const [k, v] of Object.entries(all)) {
+      if (typeof v === "string") result[k] = v;
     }
+    return result;
   }
 
   /** Get a single secret by key. Returns null if missing or non-string. */
@@ -85,9 +82,14 @@ export class LocalSecretsStore {
   /**
    * Set or clear a single secret. Passing an empty string или null deletes
    * the entry (avoid trailing empty-PAT junk in the file).
+   *
+   * Read-modify-write preserves all keys (including non-string ones written
+   * by sibling stores like `PluginLocalDataStore`). Prior to Issue #3327
+   * Item #3 fix, `readAll()`-based RMW silently stripped non-string keys —
+   * deterministic data loss for booleans (`_switchInProgress`).
    */
   async setSecret(key: string, value: string | null): Promise<void> {
-    const all = await this.readAll();
+    const all = await this.readAllRaw();
     if (value === null || value === "") {
       delete all[key];
     } else {
@@ -96,9 +98,19 @@ export class LocalSecretsStore {
     await this.persist(all);
   }
 
-  /** Remove all stored secrets. Used by «Clear secrets» action в UI. */
+  /**
+   * Remove all stored SECRETS. Preserves non-secret keys written by sibling
+   * stores (e.g. `PluginLocalDataStore`). To wipe the entire file, callers
+   * should also clear those stores explicitly.
+   */
   async clearAll(): Promise<void> {
-    await this.persist({});
+    const all = await this.readAllRaw();
+    // Strip string-valued keys (secrets), preserve others.
+    const preserved: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(all)) {
+      if (typeof v !== "string") preserved[k] = v;
+    }
+    await this.persist(preserved);
   }
 
   /**
@@ -113,7 +125,25 @@ export class LocalSecretsStore {
     return "*".repeat(Math.max(8, value.length - 4)) + value.slice(-4);
   }
 
-  private async persist(all: Record<string, string>): Promise<void> {
+  /**
+   * Internal — read the raw file preserving all key types (string + sibling-
+   * store-written non-strings). Used by `setSecret` / `clearAll` для
+   * lossless RMW.
+   */
+  private async readAllRaw(): Promise<Record<string, unknown>> {
+    try {
+      const exists = await this.app.vault.adapter.exists(this.path);
+      if (!exists) return {};
+      const raw = await this.app.vault.adapter.read(this.path);
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed === null || typeof parsed !== "object") return {};
+      return { ...(parsed as Record<string, unknown>) };
+    } catch {
+      return {};
+    }
+  }
+
+  private async persist(all: Record<string, unknown>): Promise<void> {
     const json = JSON.stringify(all, null, 2);
     await this.app.vault.adapter.write(this.path, json);
   }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
@@ -24,14 +24,21 @@ import type { App } from "obsidian";
  *   - `PluginLocalDataStore` writes keys: `activeProfileUid`,
  *     `_switchInProgress`
  *
- * Concurrent writes are not coordinated by a lock. In practice:
- *   - PAT updates are rare (user-initiated in Settings UI)
- *   - Switch state writes happen during `FocusProfileSwitchManager.switchProfile`
- *     which holds `PluginLockManager` lock (serialises switches)
- *   - Cross-store contention requires a user clicking «save PAT»
- *     during a profile switch — possible but vanishingly rare
+ * Cross-store coexistence relies on **lossless read-modify-write** in
+ * both stores. `LocalSecretsStore` was originally written to filter
+ * non-string keys (its public contract returns
+ * `Record<string, string>`), and an inner `readAll → persist` round
+ * trip would deterministically strip booleans/nulls written by sibling
+ * stores. Issue #3327 Item #3 fixed this — secrets-store internals now
+ * use a typed-preserving `readAllRaw()` for the RMW path and the
+ * string-filtered `readAll()` only for public-facing consumers.
  *
- * If empirical races emerge, add file-level locking via PluginLockManager.
+ * Locking is not used. Writes from the two stores can interleave under
+ * a worst-case (user clicks «save PAT» during a profile switch) — the
+ * last writer wins. Since each store mutates only its own key
+ * namespace, the loser observes a stale read but no key collision.
+ * If empirical races emerge, add file-level locking via
+ * `PluginLockManager`.
  *
  * ## In-memory cache contract
  *

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
@@ -1,0 +1,219 @@
+import type { App } from "obsidian";
+
+/**
+ * PluginLocalDataStore — device-local persistence для switch state
+ * (`activeProfileUid`, `_switchInProgress`).
+ *
+ * Per Issue #3327 Item #3 + CLAUDE.md FocusProfile section refinement:
+ * the active profile selection и mid-switch flag are per-device state,
+ * NOT cross-device sync state. Storing них в `plugin.data.json` causes
+ * Obsidian Sync to replicate the selection: device A choosing profile
+ * X silently switches device B too, и a crash on device A leaves
+ * `_switchInProgress=true` flag visible on device B (triggering
+ * `recoverIfNeeded` for a switch that did not happen there).
+ *
+ * Solution mirrors {@link LocalSecretsStore}: persist в
+ * `<configDir>/plugins/exocortex/data.local.json`, which Obsidian Sync
+ * excludes by convention (any `.local.json` filename).
+ *
+ * ## Key separation from LocalSecretsStore
+ *
+ * Both stores write to `data.local.json` so they share the file but
+ * use disjoint key namespaces:
+ *   - `LocalSecretsStore` writes keys: `pat` (currently the only one)
+ *   - `PluginLocalDataStore` writes keys: `activeProfileUid`,
+ *     `_switchInProgress`
+ *
+ * Concurrent writes are not coordinated by a lock. In practice:
+ *   - PAT updates are rare (user-initiated in Settings UI)
+ *   - Switch state writes happen during `FocusProfileSwitchManager.switchProfile`
+ *     which holds `PluginLockManager` lock (serialises switches)
+ *   - Cross-store contention requires a user clicking «save PAT»
+ *     during a profile switch — possible but vanishingly rare
+ *
+ * If empirical races emerge, add file-level locking via PluginLockManager.
+ *
+ * ## In-memory cache contract
+ *
+ * `init()` loads the file once into `this.cache`. Synchronous accessors
+ * (`getActiveProfileUid()`, `isSwitchInProgress()`) read from the cache
+ * — they MUST be called only after `init()` resolves. `save()` writes
+ * the cache back to disk и keeps the cache up to date.
+ */
+
+const KEY_ACTIVE_PROFILE_UID = "activeProfileUid";
+const KEY_SWITCH_IN_PROGRESS = "_switchInProgress";
+
+export interface PluginLocalDataStoreOptions {
+  app: App;
+  /**
+   * Path relative к vault root. Default uses Obsidian's runtime
+   * `vault.configDir` joined с `plugins/<pluginId>/data.local.json`.
+   */
+  path?: string;
+  /** Plugin id used to build the default path. Default `"exocortex"`. */
+  pluginId?: string;
+}
+
+export interface LocalSwitchState {
+  activeProfileUid: string | null;
+  _switchInProgress: boolean;
+}
+
+const EMPTY_STATE: LocalSwitchState = {
+  activeProfileUid: null,
+  _switchInProgress: false,
+};
+
+export class PluginLocalDataStore {
+  private readonly app: App;
+  private readonly path: string;
+  private cache: LocalSwitchState = { ...EMPTY_STATE };
+  private initialized = false;
+
+  constructor(options: PluginLocalDataStoreOptions) {
+    this.app = options.app;
+    if (options.path !== undefined) {
+      this.path = options.path;
+    } else {
+      const configDir = options.app.vault.configDir;
+      const pluginId = options.pluginId ?? "exocortex";
+      this.path = `${configDir}/plugins/${pluginId}/data.local.json`;
+    }
+  }
+
+  /**
+   * Eager-load the file into the in-memory cache. Must be awaited before
+   * any sync accessor. Idempotent — subsequent calls re-read the disk
+   * state (useful for tests; production calls it once at plugin onload).
+   */
+  async init(): Promise<void> {
+    this.cache = await this.readFromDisk();
+    this.initialized = true;
+  }
+
+  /** Returns the cached active profile UID. Requires `init()` first. */
+  getActiveProfileUid(): string | null {
+    this.assertInitialized();
+    return this.cache.activeProfileUid;
+  }
+
+  /** Returns the cached switch-in-progress flag. Requires `init()` first. */
+  isSwitchInProgress(): boolean {
+    this.assertInitialized();
+    return this.cache._switchInProgress;
+  }
+
+  /** Returns a snapshot of the full cached state. */
+  snapshot(): LocalSwitchState {
+    this.assertInitialized();
+    return { ...this.cache };
+  }
+
+  /**
+   * Persist the new state to disk и refresh the cache. Read-modify-
+   * write semantics preserve unknown keys (e.g. `pat` written by
+   * LocalSecretsStore).
+   */
+  async save(state: LocalSwitchState): Promise<void> {
+    const all = await this.readAllRaw();
+    all[KEY_ACTIVE_PROFILE_UID] =
+      state.activeProfileUid === null ? null : state.activeProfileUid;
+    all[KEY_SWITCH_IN_PROGRESS] = state._switchInProgress;
+    await this.persist(all);
+    this.cache = { ...state };
+    this.initialized = true;
+  }
+
+  /**
+   * Migration helper — copy legacy `plugin.settings` keys into the local
+   * store IF the local store does not already have them. Caller (plugin
+   * onload) deletes the legacy keys from `plugin.settings` after this
+   * resolves.
+   *
+   * Idempotent: if local store already has values, returns without
+   * mutating (handles stale-sync edge case where legacy fields arrive
+   * from another device после migration already happened).
+   *
+   * Returns the source from which switch state was resolved:
+   *   - `"local"`: local store had values; legacy ignored
+   *   - `"legacy"`: copied from legacy; local store now populated
+   *   - `"none"`: neither source had values; both stay empty
+   */
+  async migrateFromLegacyIfNeeded(legacy: {
+    activeProfileUid?: unknown;
+    _switchInProgress?: unknown;
+  }): Promise<"local" | "legacy" | "none"> {
+    const fresh = await this.readFromDisk();
+    const localHasActive =
+      typeof fresh.activeProfileUid === "string" &&
+      fresh.activeProfileUid.length > 0;
+    const localHasFlag = fresh._switchInProgress === true;
+
+    if (localHasActive || localHasFlag) {
+      // Local already populated — prefer it. Idempotency guarantee.
+      this.cache = fresh;
+      this.initialized = true;
+      return "local";
+    }
+
+    const legacyActive =
+      typeof legacy.activeProfileUid === "string"
+        ? legacy.activeProfileUid
+        : null;
+    const legacyFlag =
+      typeof legacy._switchInProgress === "boolean"
+        ? legacy._switchInProgress
+        : false;
+
+    if (legacyActive === null && legacyFlag === false) {
+      // Nothing to migrate — keep cache empty.
+      this.cache = { ...EMPTY_STATE };
+      this.initialized = true;
+      return "none";
+    }
+
+    await this.save({
+      activeProfileUid: legacyActive,
+      _switchInProgress: legacyFlag,
+    });
+    return "legacy";
+  }
+
+  private assertInitialized(): void {
+    if (!this.initialized) {
+      throw new Error(
+        "PluginLocalDataStore: init() must be awaited before sync accessors",
+      );
+    }
+  }
+
+  private async readFromDisk(): Promise<LocalSwitchState> {
+    const all = await this.readAllRaw();
+    const activeProfileUid =
+      typeof all[KEY_ACTIVE_PROFILE_UID] === "string"
+        ? (all[KEY_ACTIVE_PROFILE_UID] as string)
+        : null;
+    const _switchInProgress =
+      all[KEY_SWITCH_IN_PROGRESS] === true;
+    return { activeProfileUid, _switchInProgress };
+  }
+
+  private async readAllRaw(): Promise<Record<string, unknown>> {
+    try {
+      const exists = await this.app.vault.adapter.exists(this.path);
+      if (!exists) return {};
+      const raw = await this.app.vault.adapter.read(this.path);
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed === null || typeof parsed !== "object") return {};
+      return { ...(parsed as Record<string, unknown>) };
+    } catch {
+      return {};
+    }
+  }
+
+  private async persist(all: Record<string, unknown>): Promise<void> {
+    const json = JSON.stringify(all, null, 2);
+    await this.app.vault.adapter.write(this.path, json);
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginRdfIndexerAdapter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginRdfIndexerAdapter.ts
@@ -1,5 +1,5 @@
 import type { IRdfIndexer } from "./FocusProfileSwitchManager";
-import type { VaultRDFIndexer } from "../VaultRDFIndexer";
+import type { IRdfIndexerHandle } from "@plugin/application/api/SPARQLApi";
 
 /**
  * `IRdfIndexer` adapter wrapping the plugin's live `VaultRDFIndexer`
@@ -18,7 +18,7 @@ import type { VaultRDFIndexer } from "../VaultRDFIndexer";
  * к AssetSpace topology, which it deliberately stays out of.
  */
 export class PluginRdfIndexerAdapter implements IRdfIndexer {
-  constructor(private readonly indexer: VaultRDFIndexer) {
+  constructor(private readonly indexer: IRdfIndexerHandle) {
     if (!indexer) {
       throw new Error("PluginRdfIndexerAdapter: indexer is required");
     }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginSettingsStoreAdapter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginSettingsStoreAdapter.ts
@@ -2,72 +2,49 @@ import type {
   ISettingsStore,
   SwitchSettings,
 } from "./FocusProfileSwitchManager";
+import type { PluginLocalDataStore } from "./PluginLocalDataStore";
 
 /**
- * Pluggable host hook for {@link PluginSettingsStoreAdapter}. The plugin
- * passes its current `settings` object and a `saveData` thunk; the adapter
- * neither knows nor cares about the surrounding `ExocortexSettings` shape
- * — it only reads/writes the two switch-state keys per RFC 0a0791c1 §B.4
- * (`activeProfileUid`, `_switchInProgress`).
+ * `ISettingsStore` adapter persisting через {@link PluginLocalDataStore}
+ * (Issue #3327 Item #3 — device-local switch state).
  *
- * The thunk pattern (rather than holding a direct plugin reference) keeps
- * the adapter free of `Plugin` import — useful for the test path which
- * stubs the save fn outright.
- */
-export interface PluginSettingsStoreHost {
-  /**
-   * Reads the live settings record. Implementations should return the
-   * SAME mutable reference the plugin holds, because B.4 expects
-   * `settings.activeProfileUid = X` to round-trip back through the
-   * `save()` thunk. A frozen / cloned object would silently drop the
-   * write.
-   */
-  readSettings(): {
-    activeProfileUid?: string | null;
-    _switchInProgress?: boolean;
-    [k: string]: unknown;
-  };
-  /** Persists the current settings object to disk (Obsidian `saveData`). */
-  saveSettings(): Promise<void>;
-}
-
-/**
- * `ISettingsStore` adapter persisting via the plugin's standard
- * `saveData()` round-trip. Defaults missing fields:
- *   - `activeProfileUid` → `null` (no profile selected, full vault)
- *   - `_switchInProgress` → `false`
+ * Prior to Item #3, switch state lived в `plugin.data.json` (synced
+ * across devices via Obsidian Sync). That caused two UX bugs:
+ *   1. Profile selection replicated cross-device against user intent
+ *      (per CLAUDE.md FocusProfile section «per-device» contract).
+ *   2. `_switchInProgress=true` left on a crashed device surfaced on
+ *      sibling devices as spurious `recoverIfNeeded` fires.
  *
- * Persistence target: Obsidian plugin `data.json`, which Obsidian Sync
- * replicates across devices. Per RFC 0a0791c1 + Vision Lock #1, only PATs
- * live в `data.local.json`; the active profile UID is intentionally
- * synced so the user's profile choice follows them. Per-device override
- * is a Phase D follow-up.
+ * Now the adapter delegates к `PluginLocalDataStore` which writes
+ * `data.local.json` (Sync-excluded). Caller (plugin onload) is
+ * responsible for awaiting `localDataStore.init()` and running the
+ * one-time legacy-keys migration BEFORE constructing this adapter.
+ *
+ * The `ISettingsStore` interface contract is unchanged — `load()` /
+ * `save()` shape matches what `FocusProfileSwitchManager` and tests
+ * already use.
  */
 export class PluginSettingsStoreAdapter implements ISettingsStore {
-  constructor(private readonly host: PluginSettingsStoreHost) {
-    if (!host) {
-      throw new Error("PluginSettingsStoreAdapter: host is required");
+  constructor(private readonly localDataStore: PluginLocalDataStore) {
+    if (!localDataStore) {
+      throw new Error(
+        "PluginSettingsStoreAdapter: localDataStore is required",
+      );
     }
   }
 
   async load(): Promise<SwitchSettings> {
-    const raw = this.host.readSettings();
-    const activeProfileUid =
-      typeof raw.activeProfileUid === "string" ? raw.activeProfileUid : null;
-    const inProgress =
-      typeof raw._switchInProgress === "boolean"
-        ? raw._switchInProgress
-        : false;
+    const snap = this.localDataStore.snapshot();
     return {
-      activeProfileUid,
-      _switchInProgress: inProgress,
+      activeProfileUid: snap.activeProfileUid,
+      _switchInProgress: snap._switchInProgress,
     };
   }
 
   async save(s: SwitchSettings): Promise<void> {
-    const raw = this.host.readSettings();
-    raw.activeProfileUid = s.activeProfileUid;
-    raw._switchInProgress = s._switchInProgress;
-    await this.host.saveSettings();
+    await this.localDataStore.save({
+      activeProfileUid: s.activeProfileUid,
+      _switchInProgress: s._switchInProgress,
+    });
   }
 }

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -664,11 +664,14 @@ export class ExocortexSettingTab extends PluginSettingTab {
     // ─────── Section 2 — Active focus profile ───────
     new Setting(containerEl).setName("Active focus profile").setHeading();
 
-    const settings = this.plugin.settings as unknown as Record<string, unknown>;
-    const activeProfileUid =
-      typeof settings.activeProfileUid === "string"
-        ? (settings.activeProfileUid as string)
-        : null;
+    // Issue #3327 Item #3 — read switch state from device-local store
+    // (data.local.json). `plugin.localDataStore` is null until
+    // `registerFocusProfileCommands` resolves (and undefined in unit
+    // tests с partial plugin mocks); treat as no-active-profile before
+    // then, matching the previous fallback behaviour.
+    const activeProfileUid = this.plugin.localDataStore
+      ? this.plugin.localDataStore.getActiveProfileUid()
+      : null;
 
     const profileStatusEl = containerEl.createDiv({
       cls: "setting-item-description",

--- a/packages/obsidian-plugin/tests/unit/LocalSecretsStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/LocalSecretsStore.test.ts
@@ -111,6 +111,58 @@ describe("LocalSecretsStore.clearAll", () => {
     await store.clearAll();
     expect(await store.readAll()).toEqual({});
   });
+
+  it("preserves non-string sibling-store keys (Issue #3327 cross-store)", async () => {
+    const { app, files } = makeFakeApp();
+    // Sibling store (e.g. PluginLocalDataStore) wrote a boolean key first.
+    files.set(
+      DEFAULT_PATH,
+      JSON.stringify({ pat: "ghp_BEFORE", _switchInProgress: true }),
+    );
+    const store = new LocalSecretsStore({ app });
+    await store.clearAll();
+    // Secrets gone, sibling-store boolean preserved.
+    const parsed = JSON.parse(files.get(DEFAULT_PATH) ?? "{}");
+    expect(parsed.pat).toBeUndefined();
+    expect(parsed._switchInProgress).toBe(true);
+  });
+});
+
+describe("LocalSecretsStore cross-store coexistence (Issue #3327 Item #3)", () => {
+  it("setSecret preserves non-string sibling-store keys (RMW lossless)", async () => {
+    const { app, files } = makeFakeApp();
+    // Pre-seed file simulating PluginLocalDataStore having written booleans + null.
+    files.set(
+      DEFAULT_PATH,
+      JSON.stringify({
+        _switchInProgress: true,
+        activeProfileUid: null,
+      }),
+    );
+    const store = new LocalSecretsStore({ app });
+    await store.setSecret("pat", "ghp_NEW");
+    const parsed = JSON.parse(files.get(DEFAULT_PATH) ?? "{}");
+    expect(parsed.pat).toBe("ghp_NEW");
+    // Sibling-store keys preserved across the RMW.
+    expect(parsed._switchInProgress).toBe(true);
+    expect(parsed.activeProfileUid).toBeNull();
+  });
+
+  it("setSecret null also preserves non-string sibling-store keys", async () => {
+    const { app, files } = makeFakeApp();
+    files.set(
+      DEFAULT_PATH,
+      JSON.stringify({
+        pat: "ghp_TO_BE_CLEARED",
+        _switchInProgress: true,
+      }),
+    );
+    const store = new LocalSecretsStore({ app });
+    await store.setSecret("pat", null);
+    const parsed = JSON.parse(files.get(DEFAULT_PATH) ?? "{}");
+    expect(parsed.pat).toBeUndefined();
+    expect(parsed._switchInProgress).toBe(true);
+  });
 });
 
 describe("LocalSecretsStore.mask", () => {

--- a/packages/obsidian-plugin/tests/unit/PluginLocalDataStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PluginLocalDataStore.test.ts
@@ -1,0 +1,181 @@
+import type { App } from "obsidian";
+import { PluginLocalDataStore } from "../../src/infrastructure/adapters/PluginLocalDataStore";
+
+function makeFakeApp(seed: Record<string, string> = {}): {
+  app: App;
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>(Object.entries(seed));
+  const app = {
+    vault: {
+      configDir: ".obsidian",
+      adapter: {
+        exists: async (p: string) => files.has(p),
+        read: async (p: string) => {
+          const v = files.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+        write: async (p: string, data: string) => {
+          files.set(p, data);
+        },
+      },
+    },
+  } as unknown as App;
+  return { app, files };
+}
+
+const PATH = ".obsidian/plugins/exocortex/data.local.json";
+
+describe("PluginLocalDataStore — initialization", () => {
+  it("init() with absent file → empty state", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    expect(store.getActiveProfileUid()).toBeNull();
+    expect(store.isSwitchInProgress()).toBe(false);
+  });
+
+  it("init() reads existing data.local.json", async () => {
+    const { app } = makeFakeApp({
+      [PATH]: JSON.stringify({
+        activeProfileUid: "p-x",
+        _switchInProgress: true,
+        pat: "ghp_secret",
+      }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    expect(store.getActiveProfileUid()).toBe("p-x");
+    expect(store.isSwitchInProgress()).toBe(true);
+  });
+
+  it("init() tolerates corrupted JSON (returns empty state)", async () => {
+    const { app } = makeFakeApp({ [PATH]: "<<not json>>" });
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    expect(store.getActiveProfileUid()).toBeNull();
+    expect(store.isSwitchInProgress()).toBe(false);
+  });
+
+  it("sync accessors throw when init() not yet awaited", () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    expect(() => store.getActiveProfileUid()).toThrow(
+      /init\(\) must be awaited/,
+    );
+  });
+});
+
+describe("PluginLocalDataStore — save", () => {
+  it("save persists to disk and updates the cache", async () => {
+    const { app, files } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    await store.save({ activeProfileUid: "p-y", _switchInProgress: false });
+
+    const parsed = JSON.parse(files.get(PATH) ?? "{}");
+    expect(parsed.activeProfileUid).toBe("p-y");
+    expect(parsed._switchInProgress).toBe(false);
+    expect(store.getActiveProfileUid()).toBe("p-y");
+  });
+
+  it("save preserves unrelated keys (e.g. LocalSecretsStore pat)", async () => {
+    const { app, files } = makeFakeApp({
+      [PATH]: JSON.stringify({ pat: "ghp_secret-keep-me" }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    await store.save({ activeProfileUid: "p-z", _switchInProgress: false });
+
+    const parsed = JSON.parse(files.get(PATH) ?? "{}");
+    expect(parsed.pat).toBe("ghp_secret-keep-me");
+    expect(parsed.activeProfileUid).toBe("p-z");
+  });
+});
+
+// ─── Migration matrix (advisor #3 — 4 scenarios) ─────────────────────────
+
+describe("PluginLocalDataStore.migrateFromLegacyIfNeeded", () => {
+  it("(1) fresh install — legacy and local both empty → 'none'", async () => {
+    const { app, files } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    const outcome = await store.migrateFromLegacyIfNeeded({});
+    expect(outcome).toBe("none");
+    expect(store.getActiveProfileUid()).toBeNull();
+    expect(store.isSwitchInProgress()).toBe(false);
+    // No file written — empty state is in-memory only.
+    expect(files.has(PATH)).toBe(false);
+  });
+
+  it("(2) pre-upgrade user — legacy populated, local empty → 'legacy' (copy)", async () => {
+    const { app, files } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    const outcome = await store.migrateFromLegacyIfNeeded({
+      activeProfileUid: "p-legacy",
+      _switchInProgress: false,
+    });
+    expect(outcome).toBe("legacy");
+    expect(store.getActiveProfileUid()).toBe("p-legacy");
+    // File materialized.
+    const parsed = JSON.parse(files.get(PATH) ?? "{}");
+    expect(parsed.activeProfileUid).toBe("p-legacy");
+  });
+
+  it("(2b) pre-upgrade with _switchInProgress=true also migrates the flag", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    const outcome = await store.migrateFromLegacyIfNeeded({
+      activeProfileUid: null,
+      _switchInProgress: true,
+    });
+    expect(outcome).toBe("legacy");
+    expect(store.isSwitchInProgress()).toBe(true);
+  });
+
+  it("(3) already migrated — legacy empty, local populated → 'local' (no-op)", async () => {
+    const { app, files } = makeFakeApp({
+      [PATH]: JSON.stringify({ activeProfileUid: "p-local" }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    const outcome = await store.migrateFromLegacyIfNeeded({});
+    expect(outcome).toBe("local");
+    expect(store.getActiveProfileUid()).toBe("p-local");
+    // No re-write — file content unchanged.
+    const parsed = JSON.parse(files.get(PATH) ?? "{}");
+    expect(parsed.activeProfileUid).toBe("p-local");
+  });
+
+  it("(4) stale-sync edge — legacy AND local populated → 'local' wins (idempotent)", async () => {
+    const { app, files } = makeFakeApp({
+      [PATH]: JSON.stringify({ activeProfileUid: "p-local-correct" }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    const outcome = await store.migrateFromLegacyIfNeeded({
+      activeProfileUid: "p-legacy-stale",
+      _switchInProgress: false,
+    });
+    expect(outcome).toBe("local");
+    expect(store.getActiveProfileUid()).toBe("p-local-correct");
+    // Local state preserved — stale legacy did NOT clobber.
+    const parsed = JSON.parse(files.get(PATH) ?? "{}");
+    expect(parsed.activeProfileUid).toBe("p-local-correct");
+  });
+
+  it("migration is idempotent — calling twice does not duplicate work", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    const o1 = await store.migrateFromLegacyIfNeeded({
+      activeProfileUid: "p-once",
+      _switchInProgress: false,
+    });
+    expect(o1).toBe("legacy");
+    // Second call sees local already populated.
+    const o2 = await store.migrateFromLegacyIfNeeded({
+      activeProfileUid: "p-once",
+      _switchInProgress: false,
+    });
+    expect(o2).toBe("local");
+    expect(store.getActiveProfileUid()).toBe("p-once");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/PluginSettingsStoreAdapter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PluginSettingsStoreAdapter.test.ts
@@ -1,68 +1,81 @@
+import type { App } from "obsidian";
 import { PluginSettingsStoreAdapter } from "../../src/infrastructure/adapters/PluginSettingsStoreAdapter";
+import { PluginLocalDataStore } from "../../src/infrastructure/adapters/PluginLocalDataStore";
 
-describe("PluginSettingsStoreAdapter", () => {
-  it("throws when host is undefined", () => {
+// ─── Real-shape fake App.vault.adapter ───────────────────────────────────
+
+function makeFakeApp(): { app: App; files: Map<string, string> } {
+  const files = new Map<string, string>();
+  const app = {
+    vault: {
+      configDir: ".obsidian",
+      adapter: {
+        exists: async (p: string) => files.has(p),
+        read: async (p: string) => {
+          const v = files.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+        write: async (p: string, data: string) => {
+          files.set(p, data);
+        },
+      },
+    },
+  } as unknown as App;
+  return { app, files };
+}
+
+async function makeInitializedStore(app: App): Promise<PluginLocalDataStore> {
+  const store = new PluginLocalDataStore({ app });
+  await store.init();
+  return store;
+}
+
+describe("PluginSettingsStoreAdapter (Issue #3327 Item #3 — device-local backing)", () => {
+  it("throws when localDataStore is undefined", () => {
     expect(
-      () => new PluginSettingsStoreAdapter(undefined as any),
-    ).toThrow(/host is required/);
+      () => new PluginSettingsStoreAdapter(undefined as never),
+    ).toThrow(/localDataStore is required/);
   });
 
-  it("load defaults missing fields to null + false", async () => {
-    const settings: Record<string, unknown> = {};
-    const adapter = new PluginSettingsStoreAdapter({
-      readSettings: () => settings,
-      saveSettings: async () => {},
-    });
+  it("load returns defaults when localDataStore is empty", async () => {
+    const { app } = makeFakeApp();
+    const localStore = await makeInitializedStore(app);
+    const adapter = new PluginSettingsStoreAdapter(localStore);
     const s = await adapter.load();
     expect(s.activeProfileUid).toBeNull();
     expect(s._switchInProgress).toBe(false);
   });
 
-  it("load returns existing values when present", async () => {
-    const settings: Record<string, unknown> = {
+  it("load returns persisted values from localDataStore", async () => {
+    const { app } = makeFakeApp();
+    const localStore = await makeInitializedStore(app);
+    await localStore.save({
       activeProfileUid: "p1",
       _switchInProgress: true,
-    };
-    const adapter = new PluginSettingsStoreAdapter({
-      readSettings: () => settings,
-      saveSettings: async () => {},
     });
+    const adapter = new PluginSettingsStoreAdapter(localStore);
     const s = await adapter.load();
     expect(s.activeProfileUid).toBe("p1");
     expect(s._switchInProgress).toBe(true);
   });
 
-  it("save mutates the live settings object AND calls saveSettings", async () => {
-    const settings: Record<string, unknown> = {
-      activeProfileUid: null,
-      _switchInProgress: false,
-    };
-    const saveSettings = jest.fn().mockResolvedValue(undefined);
-    const adapter = new PluginSettingsStoreAdapter({
-      readSettings: () => settings,
-      saveSettings,
-    });
+  it("save writes through to localDataStore (data.local.json)", async () => {
+    const { app, files } = makeFakeApp();
+    const localStore = await makeInitializedStore(app);
+    const adapter = new PluginSettingsStoreAdapter(localStore);
+
     await adapter.save({ activeProfileUid: "p2", _switchInProgress: true });
-    expect(settings.activeProfileUid).toBe("p2");
-    expect(settings._switchInProgress).toBe(true);
-    expect(saveSettings).toHaveBeenCalledTimes(1);
-  });
 
-  it("load coerces non-string activeProfileUid to null", async () => {
-    const settings: Record<string, unknown> = { activeProfileUid: 42 };
-    const adapter = new PluginSettingsStoreAdapter({
-      readSettings: () => settings,
-      saveSettings: async () => {},
-    });
-    expect((await adapter.load()).activeProfileUid).toBeNull();
-  });
+    // File materialized at the expected device-local path.
+    const path = ".obsidian/plugins/exocortex/data.local.json";
+    expect(files.has(path)).toBe(true);
+    const parsed = JSON.parse(files.get(path) ?? "{}");
+    expect(parsed.activeProfileUid).toBe("p2");
+    expect(parsed._switchInProgress).toBe(true);
 
-  it("load coerces non-boolean _switchInProgress to false", async () => {
-    const settings: Record<string, unknown> = { _switchInProgress: "yes" };
-    const adapter = new PluginSettingsStoreAdapter({
-      readSettings: () => settings,
-      saveSettings: async () => {},
-    });
-    expect((await adapter.load())._switchInProgress).toBe(false);
+    // Cache reflects the write (sync accessors stay in sync).
+    expect(localStore.getActiveProfileUid()).toBe("p2");
+    expect(localStore.isSwitchInProgress()).toBe(true);
   });
 });

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceLookupHelper.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceLookupHelper.test.ts
@@ -1,0 +1,117 @@
+import type { App, TFile } from "obsidian";
+
+import { lookupAssetSpaceUidByFolder } from "../../../../src/infrastructure/adapters/AssetSpaceLookupHelper";
+import { ASSET_SPACE_CLASS_UID } from "../../../../src/infrastructure/adapters/AssetSpaceManager";
+
+// ─── Fake App / vault / metadataCache (real-shape per test-fixture-realism) ───
+
+interface SeedFile {
+  path: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function makeFakeApp(seeds: SeedFile[]): App {
+  const files = new Map<string, SeedFile>();
+  for (const s of seeds) files.set(s.path, s);
+  const tfile = (path: string): TFile => ({ path }) as unknown as TFile;
+
+  return {
+    vault: {
+      getMarkdownFiles: () => Array.from(files.keys()).map(tfile),
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const seed = files.get(file.path);
+        if (!seed) return null;
+        return { frontmatter: seed.frontmatter };
+      },
+    },
+  } as unknown as App;
+}
+
+function asFrontmatter(uid: string): Record<string, unknown> {
+  return {
+    "exo__Asset_uid": uid,
+    "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+  };
+}
+
+describe("lookupAssetSpaceUidByFolder", () => {
+  it("returns the AssetSpace UID when folder matches an AS asset's parent", () => {
+    const app = makeFakeApp([
+      { path: "assetspaces/ems/uid-ems.md", frontmatter: asFrontmatter("uid-ems") },
+      { path: "assetspaces/exo/uid-exo.md", frontmatter: asFrontmatter("uid-exo") },
+    ]);
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/ems")).toBe("uid-ems");
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/exo")).toBe("uid-exo");
+  });
+
+  it("normalises trailing slash", () => {
+    const app = makeFakeApp([
+      { path: "assetspaces/ems/uid-ems.md", frontmatter: asFrontmatter("uid-ems") },
+    ]);
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/ems/")).toBe("uid-ems");
+  });
+
+  it("returns null for empty folder name", () => {
+    const app = makeFakeApp([
+      { path: "assetspaces/ems/uid-ems.md", frontmatter: asFrontmatter("uid-ems") },
+    ]);
+    expect(lookupAssetSpaceUidByFolder(app, "")).toBeNull();
+  });
+
+  it("returns null when no AssetSpace asset owns the folder", () => {
+    const app = makeFakeApp([
+      { path: "assetspaces/ems/uid-ems.md", frontmatter: asFrontmatter("uid-ems") },
+    ]);
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/missing")).toBeNull();
+  });
+
+  it("skips non-AssetSpace files in the same folder (loose class noise)", () => {
+    const app = makeFakeApp([
+      {
+        path: "assetspaces/ems/other.md",
+        frontmatter: {
+          "exo__Asset_uid": "uid-other",
+          // UUID-shaped noise but NOT the AS class
+          "exo__Instance_class": ["[[deadbeef-dead-beef-dead-beefdeadbeef]]"],
+        },
+      },
+      { path: "assetspaces/ems/real.md", frontmatter: asFrontmatter("uid-real") },
+    ]);
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/ems")).toBe("uid-real");
+  });
+
+  it("returns null when AS asset has empty UID", () => {
+    const app = makeFakeApp([
+      {
+        path: "assetspaces/ems/empty.md",
+        frontmatter: {
+          "exo__Asset_uid": "",
+          "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+        },
+      },
+    ]);
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/ems")).toBeNull();
+  });
+
+  it("returns null when frontmatter is missing entirely", () => {
+    const app = makeFakeApp([{ path: "assetspaces/ems/uid.md", frontmatter: {} }]);
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/ems")).toBeNull();
+  });
+
+  it("strict wikilink regex — substring AS UID noise does not falsely register", () => {
+    // Issue #3312 MEDIUM #1 regression guard
+    const app = makeFakeApp([
+      {
+        path: "assetspaces/ems/decoy.md",
+        frontmatter: {
+          "exo__Asset_uid": "uid-decoy",
+          // Class string contains AS UID as substring но NOT inside a wikilink.
+          "exo__Instance_class": `not-a-link-${ASSET_SPACE_CLASS_UID}`,
+        },
+      },
+    ]);
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/ems")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/wiring/FocusProfileWiring.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/wiring/FocusProfileWiring.integration.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Integration tests для RFC 0a0791c1 FocusProfile wiring (Issue #3327 Item #1).
+ *
+ * Covers the wiring surfaces extracted from `ExocortexPlugin`:
+ *   (a) `createAssetSpacePusher` with empty PAT → lookup-only stub
+ *   (b) `createAssetSpacePusher` with valid PAT → real AssetSpaceManager
+ *   (c) `createAssetSpacePusher` when GitHub client ctor throws → fallback stub
+ *   (d) `lookupAssetSpaceUidByFolder` finds matching folder / returns null
+ *   (e) `FocusProfileSwitchManager.recoverIfNeeded` fires when
+ *       `_switchInProgress=true` and last journal entry is incomplete
+ *
+ * Per `~/dotfiles/.claude/rules/test-fixture-realism.md` — fakes mirror
+ * real Obsidian semantics (metadataCache returns null for unseeded files,
+ * vault.adapter.exists/read/write/remove honour their seed set).
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import type { App, TFile } from "obsidian";
+import type { ILogger, INotificationService } from "exocortex";
+
+import {
+  createAssetSpacePusher,
+  type GitHubRestClientFactory,
+} from "../../../src/infrastructure/adapters/AssetSpacePusherFactory";
+import { lookupAssetSpaceUidByFolder } from "../../../src/infrastructure/adapters/AssetSpaceLookupHelper";
+import { ASSET_SPACE_CLASS_UID } from "../../../src/infrastructure/adapters/AssetSpaceManager";
+import { FocusProfileSwitchManager } from "../../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import { PluginLockManager } from "../../../src/infrastructure/adapters/PluginLockManager";
+import type {
+  IProfileResolver,
+  ISettingsStore,
+  IRdfIndexer,
+  ProfileResolution,
+  SwitchSettings,
+} from "../../../src/infrastructure/adapters/FocusProfileSwitchManager";
+
+// ─── Real-shape fake App / vault / metadataCache ─────────────────────────
+
+interface SeedFile {
+  path: string;
+  frontmatter?: Record<string, unknown>;
+  content?: string;
+}
+
+interface FakeAppHarness {
+  app: App;
+  files: Map<string, SeedFile>;
+}
+
+function makeFakeApp(seeds: SeedFile[]): FakeAppHarness {
+  const files = new Map<string, SeedFile>();
+  for (const s of seeds) files.set(s.path, s);
+  const tfile = (path: string): TFile => ({ path }) as unknown as TFile;
+
+  const app = {
+    vault: {
+      getMarkdownFiles: () =>
+        Array.from(files.keys())
+          .filter((p) => p.endsWith(".md"))
+          .map(tfile),
+      adapter: {
+        exists: async (p: string) => files.has(p),
+        read: async (p: string) => {
+          const f = files.get(p);
+          if (!f) throw new Error(`ENOENT: ${p}`);
+          if (typeof f.content !== "string") {
+            throw new Error(`No content seeded: ${p}`);
+          }
+          return f.content;
+        },
+        write: async (p: string, data: string) => {
+          files.set(p, {
+            path: p,
+            content: data,
+            frontmatter: files.get(p)?.frontmatter,
+          });
+        },
+        remove: async (p: string) => {
+          files.delete(p);
+        },
+      },
+      configDir: ".obsidian",
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const seed = files.get(file.path);
+        if (!seed || !seed.frontmatter) return null;
+        return { frontmatter: seed.frontmatter };
+      },
+    },
+  } as unknown as App;
+
+  return { app, files };
+}
+
+function makeFakeLogger(): { logger: ILogger; errors: string[]; warns: string[] } {
+  const errors: string[] = [];
+  const warns: string[] = [];
+  const logger: ILogger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: (msg: string) => {
+      warns.push(msg);
+    },
+    error: (msg: string) => {
+      errors.push(msg);
+    },
+  } as unknown as ILogger;
+  return { logger, errors, warns };
+}
+
+function makeFakeNotifier(): INotificationService {
+  return {
+    info: () => undefined,
+    success: () => undefined,
+    error: () => undefined,
+    warn: () => undefined,
+    confirm: async () => true,
+  };
+}
+
+function asFrontmatter(uid: string): Record<string, unknown> {
+  return {
+    "exo__Asset_uid": uid,
+    "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}]]`],
+    "exo__AssetSpace_git": "https://github.com/kitelev/exoas-test",
+    "exo__AssetSpace_namespace": "test",
+  };
+}
+
+// ─── (a) empty PAT branch ─────────────────────────────────────────────────
+
+describe("createAssetSpacePusher — branch (a) empty PAT → lookup-only stub", () => {
+  it("returns lookup-only stub when PAT is null", async () => {
+    const { app } = makeFakeApp([
+      {
+        path: "assetspaces/test/uid-test.md",
+        frontmatter: asFrontmatter("uid-test"),
+      },
+    ]);
+    const { logger, errors } = makeFakeLogger();
+    const pusher = createAssetSpacePusher({
+      app,
+      pat: null,
+      notifier: makeFakeNotifier(),
+      logger,
+      lookupOnly: (folder) => lookupAssetSpaceUidByFolder(app, folder),
+    });
+
+    expect(pusher.lookupAssetSpaceForPath("assetspaces/test")).toBe("uid-test");
+    await expect(pusher.pushAssetSpace("uid-test")).rejects.toThrow(
+      /GitHub PAT not configured/,
+    );
+    // No error log on the legitimate «no PAT» branch
+    expect(errors).toHaveLength(0);
+  });
+
+  it("returns lookup-only stub when PAT is empty string", async () => {
+    const { app } = makeFakeApp([]);
+    const pusher = createAssetSpacePusher({
+      app,
+      pat: "",
+      notifier: makeFakeNotifier(),
+      logger: makeFakeLogger().logger,
+      lookupOnly: () => null,
+    });
+    await expect(pusher.pushAssetSpace("any")).rejects.toThrow(
+      /GitHub PAT not configured/,
+    );
+  });
+});
+
+// ─── (b) valid PAT branch ─────────────────────────────────────────────────
+
+describe("createAssetSpacePusher — branch (b) valid PAT → AssetSpaceManager", () => {
+  it("delegates lookup to AssetSpaceManager when PAT is valid", async () => {
+    const { app } = makeFakeApp([
+      {
+        path: "assetspaces/test/uid-test.md",
+        frontmatter: asFrontmatter("uid-test"),
+      },
+    ]);
+    // Fake client factory that records construction calls.
+    const constructionCalls: Array<{ pat: string }> = [];
+    const clientFactory: GitHubRestClientFactory = (opts) => {
+      constructionCalls.push({ pat: opts.pat });
+      // Return a minimal client surface — the test only exercises lookup,
+      // which doesn't touch the client.
+      return {
+        ensureRateLimit: async () => undefined,
+        createCommit: async () => "a".repeat(40),
+      } as never;
+    };
+
+    const pusher = createAssetSpacePusher({
+      app,
+      pat: "ghp_validpat",
+      notifier: makeFakeNotifier(),
+      logger: makeFakeLogger().logger,
+      lookupOnly: () => null, // not used on this branch
+      clientFactory,
+    });
+
+    expect(constructionCalls).toHaveLength(1);
+    expect(constructionCalls[0].pat).toBe("ghp_validpat");
+    // Lookup goes through AssetSpaceManager.lookupAssetSpaceForPath, which
+    // calls into the shared helper — same result as branch (a).
+    expect(pusher.lookupAssetSpaceForPath("assetspaces/test")).toBe("uid-test");
+  });
+});
+
+// ─── (c) GitHub client ctor throws ────────────────────────────────────────
+
+describe("createAssetSpacePusher — branch (c) ctor throws → fallback stub", () => {
+  it("returns lookup-only stub with descriptive error when client ctor throws", async () => {
+    const { app } = makeFakeApp([
+      {
+        path: "assetspaces/test/uid-test.md",
+        frontmatter: asFrontmatter("uid-test"),
+      },
+    ]);
+    const { logger, errors } = makeFakeLogger();
+    const clientFactory: GitHubRestClientFactory = () => {
+      throw new Error("PAT malformed — does not start with ghp_");
+    };
+
+    const pusher = createAssetSpacePusher({
+      app,
+      pat: "invalid-pat",
+      notifier: makeFakeNotifier(),
+      logger,
+      lookupOnly: (folder) => lookupAssetSpaceUidByFolder(app, folder),
+      clientFactory,
+    });
+
+    // Lookup still works (fallback path uses lookupOnly).
+    expect(pusher.lookupAssetSpaceForPath("assetspaces/test")).toBe("uid-test");
+
+    // Push rejects с the wrapped original error message.
+    await expect(pusher.pushAssetSpace("uid-test")).rejects.toThrow(
+      /Could not initialise AssetSpaceManager.*PAT malformed/,
+    );
+
+    // The ctor failure was logged as error (not silent swallow).
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("AssetSpaceManager construction failed");
+  });
+});
+
+// ─── (d) folder lookup integration ────────────────────────────────────────
+
+describe("lookupAssetSpaceUidByFolder — branch (d) integration", () => {
+  it("finds matching folder when AS asset is present", () => {
+    const { app } = makeFakeApp([
+      {
+        path: "assetspaces/ems/uid-ems.md",
+        frontmatter: asFrontmatter("uid-ems"),
+      },
+      {
+        path: "assetspaces/exo/uid-exo.md",
+        frontmatter: asFrontmatter("uid-exo"),
+      },
+    ]);
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/ems")).toBe("uid-ems");
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/exo")).toBe("uid-exo");
+  });
+
+  it("returns null when folder has no AS asset", () => {
+    const { app } = makeFakeApp([
+      {
+        path: "assetspaces/ems/uid-ems.md",
+        frontmatter: asFrontmatter("uid-ems"),
+      },
+    ]);
+    expect(lookupAssetSpaceUidByFolder(app, "assetspaces/missing")).toBeNull();
+  });
+});
+
+// ─── (e) recoverIfNeeded triggered when _switchInProgress=true ────────────
+
+describe("FocusProfileSwitchManager.recoverIfNeeded — branch (e) onload trigger", () => {
+  // Minimal fakes mirroring the existing harness in
+  // tests/unit/FocusProfileSwitchManager.test.ts but focused on the
+  // onload recovery scenario.
+
+  class FakeProfileResolver implements IProfileResolver {
+    constructor(private readonly profiles: Map<string, ProfileResolution>) {}
+    async resolve(uid: string): Promise<ProfileResolution | null> {
+      return this.profiles.get(uid) ?? null;
+    }
+    async discoverSharedOntologies(): Promise<string[]> {
+      return [];
+    }
+  }
+
+  class FakeRdfIndexer implements IRdfIndexer {
+    refreshCalls: ReadonlySet<string>[] = [];
+    async refresh(effectiveOntologies: ReadonlySet<string>): Promise<void> {
+      this.refreshCalls.push(new Set(effectiveOntologies));
+    }
+  }
+
+  class FakeSettingsStore implements ISettingsStore {
+    state: SwitchSettings = { activeProfileUid: null, _switchInProgress: false };
+    async load(): Promise<SwitchSettings> {
+      return { ...this.state };
+    }
+    async save(s: SwitchSettings): Promise<void> {
+      this.state = { ...s };
+    }
+  }
+
+  function makeMgr(opts: { initialSettings: SwitchSettings; journal?: string }) {
+    const { app } = makeFakeApp([]);
+    const profile: ProfileResolution = {
+      uid: "uid-base",
+      includes: [],
+      alwaysOnOverlay: [],
+      extends: null,
+    };
+    const resolver = new FakeProfileResolver(
+      new Map([["uid-base", profile]]),
+    );
+    const rdf = new FakeRdfIndexer();
+    const settings = new FakeSettingsStore();
+    settings.state = opts.initialSettings;
+    const lockMgr = new PluginLockManager({
+      app,
+      pid: "test-pid",
+      now: () => new Date("2026-06-02T00:00:00.000Z"),
+    });
+    const notifyCalls: string[] = [];
+    const mgr = new FocusProfileSwitchManager({
+      app,
+      lockMgr,
+      resolver,
+      rdfIndexer: rdf,
+      settingsStore: settings,
+      now: () => new Date("2026-06-02T00:00:00.000Z"),
+      notify: (m) => notifyCalls.push(m),
+    });
+    // Seed journal entry если задан
+    return { app, rdf, settings, mgr, notifyCalls };
+  }
+
+  it("fires recovery when _switchInProgress=true AND last entry incomplete", async () => {
+    const { app, rdf, settings, mgr } = makeMgr({
+      initialSettings: { activeProfileUid: "uid-base", _switchInProgress: true },
+    });
+    await app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      JSON.stringify({
+        phase: "starting",
+        targetUid: "uid-base",
+        ts: "2026-06-01T23:59:00.000Z",
+      }) + "\n",
+    );
+
+    const result = await mgr.recoverIfNeeded();
+
+    expect(result.recovered).toBe(true);
+    expect(result.targetUid).toBe("uid-base");
+    expect(rdf.refreshCalls.length).toBe(1);
+    expect(settings.state._switchInProgress).toBe(false);
+  });
+
+  it("does NOT fire recovery when _switchInProgress=false (clean state)", async () => {
+    const { rdf, mgr } = makeMgr({
+      initialSettings: {
+        activeProfileUid: "uid-base",
+        _switchInProgress: false,
+      },
+    });
+
+    const result = await mgr.recoverIfNeeded();
+
+    expect(result.recovered).toBe(false);
+    expect(rdf.refreshCalls.length).toBe(0);
+  });
+
+  it("does NOT fire recovery when journal is absent (fresh install)", async () => {
+    const { rdf, mgr } = makeMgr({
+      initialSettings: { activeProfileUid: null, _switchInProgress: true },
+    });
+
+    const result = await mgr.recoverIfNeeded();
+
+    expect(result.recovered).toBe(false);
+    expect(rdf.refreshCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Address 4 remaining items from PR #3326 closure follow-up. Item #2 (`setAssetSpaceFolderToUid` wiring) closed implicitly by #3328 (#3324) — verified в #3327 comment 2026-06-02.

### Items addressed (one commit each + 1 review-fix commit)

- **Item #5** (`2b8a6be1`) — `SPARQLApi.getRdfIndexer()` narrowed к `IRdfIndexerHandle` application-layer interface. Callers cannot reach into infrastructure-layer `VaultRDFIndexer` lifecycle.
- **Item #4** (`5d3ac4aa`) — `AssetSpaceLookupHelper.lookupAssetSpaceUidByFolder` extracted; both `AssetSpaceManager.lookupAssetSpaceForPath` (PAT-present) and the prior duplicate в `ExocortexPlugin` (PAT-absent stub path) delegate to it. +8 unit tests.
- **Item #1** (`afe5dcdb`) — `createAssetSpacePusher` factory extracted from `ExocortexPlugin.buildAssetSpacePusher` so 3 branches (empty PAT / valid PAT / ctor throws) become testable without plugin lifecycle. `FocusProfileWiring.integration.test.ts` covers 9 scenarios across 5 branches (a/b/c/d/e).
- **Item #3** (`f04a5e6d`) — `activeProfileUid` + `_switchInProgress` migrated к `data.local.json` (Sync-excluded) via new `PluginLocalDataStore`. One-time legacy-keys migration with 4-scenario matrix (fresh / pre-upgrade / already-migrated / stale-sync). `PluginSettingsStoreAdapter` ctor signature updated.
- **Round-1 review fixes** (`0a8a3346`) — addresses 2 MEDIUM + 1 LOW from code-reviewer:
  - `LocalSecretsStore` RMW now lossless across sibling-store keys (was deterministically stripping `_switchInProgress`-style booleans)
  - Circular import `AssetSpaceManager` ↔ `AssetSpaceLookupHelper` broken via leaf `AssetSpaceFrontmatter` module
  - Stale JSDoc on `plugin.localDataStore` field updated

### Review

- **code-reviewer agent** (round-1): APPROVE-with-notes — 0 CRITICAL, 0 HIGH, 2 MEDIUM, 2 LOW. Both MEDIUM addressed in `0a8a3346`. LOW-2 (test branch (b) doesn't exercise push end-to-end) acknowledged as bounded.
- **advisor** (round-2): clean. Flagged 3 items: `clearAll` semantic change scope (verified: only test callers + sibling-key preserve), test location deviation (disclosed below), no UI smoke for migration (disclosed below).

### Test results

- Typecheck clean
- Full obsidian-plugin suite: 5283/5283 pass (3 skipped pre-existing)
- New: 13 `PluginLocalDataStore` tests, 4 `PluginSettingsStoreAdapter` tests (rewritten), 8 `AssetSpaceLookupHelper` tests, 9 `FocusProfileWiring` integration tests, 3 `LocalSecretsStore` cross-store tests

### Disclosures

**Test location deviation** — Item #1 prompt specified `tests/integration/services/FocusProfileWiring.integration.test.ts`; landed at `tests/unit/wiring/FocusProfileWiring.integration.test.ts`. The jest.config testMatch only picks up `tests/unit/**`; the orphan `tests/integration/` path is not gated by current config (per in-repo CLAUDE.md «Test Suite Awareness»). Moving to `tests/unit/wiring/` ensured CI auto-discovery without touching unrelated pre-existing failures в `tests/integration/display-name/`.

**UI smoke deferred** — Item #3 migration code is new (not an `ui-smoke-transitive-proof.md` extension of verified code path). Migration matrix is well-tested with realistic fakes, but real-Obsidian `delete plugin.settings.activeProfileUid` + Sync round-trip semantics are not exercised in CI. Recommend post-merge BRAT-install + manual smoke на one device: select profile → reload → confirm persistence → confirm `data.local.json` contains `activeProfileUid` + `data.json` does NOT.

### Phase 4 Gate A

This unblocks Phase 5 RFC `22b50a17` strict gate dependency.

Closes #3327