### PR TITLE
feat(plugin): Phase 5 P1 — operationalize AssetSpaceManager.pullAssetSpace

### DIFF
--- a/packages/obsidian-plugin/esbuild.config.mjs
+++ b/packages/obsidian-plugin/esbuild.config.mjs
@@ -134,6 +134,14 @@ const baseConfig = {
     "@lezer/highlight",
     "@lezer/lr",
     ...builtins,
+    // `node:`-prefix variants of the Node.js builtins. `builtin-modules`
+    // returns plain names (`fs`, `path`, `os`, ...), but modern code uses
+    // `import "node:fs"` syntax — without these explicit entries esbuild
+    // tries to resolve them as filesystem packages and fails the
+    // production bundle build (Phase 5 RFC 22b50a17 — StagingDirTracker +
+    // AssetSpaceManager.pullAssetSpace require Node fs/path/os; mobile
+    // never instantiates them — guarded by Platform.isMobile).
+    ...builtins.map((b) => `node:${b}`),
   ],
   format: "cjs",
   platform: "browser", // Browser platform for proper module resolution

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import {
   MarkdownPostProcessorContext,
   MarkdownView,
+  Platform,
   Plugin,
   TFile,
 } from "obsidian";
@@ -100,6 +101,7 @@ import { VaultProfileResolver } from "./infrastructure/adapters/VaultProfileReso
 import { PluginRdfIndexerAdapter } from "./infrastructure/adapters/PluginRdfIndexerAdapter";
 import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSettingsStoreAdapter";
 import { PluginLocalDataStore } from "./infrastructure/adapters/PluginLocalDataStore";
+import { StagingDirTracker } from "./infrastructure/adapters/StagingDirTracker";
 import { ProfileFuzzyModal } from "./infrastructure/adapters/ProfileFuzzyModal";
 import { applyActiveProfileFilter } from "./infrastructure/adapters/FocusProfileOnloadWiring";
 import { lookupAssetSpaceUidByFolder } from "./infrastructure/adapters/AssetSpaceLookupHelper";
@@ -2305,6 +2307,27 @@ export default class ExocortexPlugin extends Plugin {
       await this.saveSettings();
     }
     this.localDataStore = localDataStore;
+
+    // RFC 22b50a17 R26 — sweep staging-dir orphans left over from a crash
+    // mid-pullAssetSpace. Desktop-only (Node.js fs/os/path required); on
+    // mobile, pullAssetSpace itself refuses, so there's nothing to sweep.
+    // Best-effort: failure logged but does not block onload (staging dirs
+    // leak rather than crash plugin).
+    if (!Platform.isMobile) {
+      try {
+        const stagingTracker = new StagingDirTracker({ localDataStore });
+        const sweepResult = await stagingTracker.sweepOrphans();
+        if (sweepResult.tracked > 0) {
+          this.logger.info(
+            `[ExocortexPlugin] swept ${sweepResult.swept}/${sweepResult.tracked} orphan staging dirs (RFC 22b50a17 R26)`,
+          );
+        }
+      } catch (err) {
+        this.logger.warn(
+          `[ExocortexPlugin] StagingDirTracker.sweepOrphans failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
 
     const settingsStore = new PluginSettingsStoreAdapter(localDataStore);
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -302,6 +302,11 @@ export class AssetSpaceManager {
     GitHubRestClient.validateRepoURL(asGitUrl);
     const { owner, repo } = parseGitHubURL(asGitUrl);
 
+    // Pre-flight rate-limit gate. fetchTarballBuffer is a single REST call;
+    // failing fast here saves us allocating staging dir on a doomed pull
+    // (parallel to pushAssetSpace's `ensureRateLimit(4)` discipline).
+    await this.client.ensureRateLimit(1);
+
     const stagingPath = await this.stagingTracker.allocate(asUid);
     try {
       const blob = await this.client.fetchTarballBuffer(owner, repo, ref);
@@ -337,7 +342,11 @@ export class AssetSpaceManager {
           );
         }
         const rel = entry.path.slice(wrapperPrefix.length);
-        if (rel.length === 0) continue; // wrapper dir itself
+        // Defensive: TarExtractor already skips directory-type entries
+        // (TarExtractor.ts:152-155), but if a future regression yielded
+        // an entry whose path equals the wrapper itself, `rel` would be
+        // empty — skip rather than `fs.writeFile("")` an empty dir.
+        if (rel.length === 0) continue;
         const target = path.join(stagingPath, rel);
         // Defense-in-depth: confirm the resolved target stays inside
         // staging — path.join with `..` segments would otherwise escape.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -1,6 +1,18 @@
+// Node.js builtins required for Phase 5 hard-switch staging dirs (RFC
+// 22b50a17) — staging dirs live in `os.tmpdir()` OUTSIDE the vault so
+// Obsidian's vault.adapter API cannot reach them. The `pullAssetSpace`
+// entry point is guarded by `Platform.isMobile` throw — on mobile the
+// code never executes (Phase 5 is desktop-only per RFC scope).
+/* eslint-disable no-restricted-imports, import/no-nodejs-modules */
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+/* eslint-enable no-restricted-imports, import/no-nodejs-modules */
 import type { App, TFile } from "obsidian";
+import { Platform } from "obsidian";
 import type { INotificationService } from "exocortex";
 import { GitHubRestClient } from "./GitHubRestClient";
+import { TarExtractor, type ExtractedTarFile } from "./TarExtractor";
+import { StagingDirTracker } from "./StagingDirTracker";
 import { lookupAssetSpaceUidByFolder } from "./AssetSpaceLookupHelper";
 import {
   ASSET_SPACE_CLASS_UID,
@@ -42,6 +54,42 @@ export interface AssetSpaceManagerOptions {
   notifications: INotificationService;
   /** Git branch to push to. Default: `"main"`. */
   branch?: string;
+  /**
+   * Optional — TarExtractor used by {@link pullAssetSpace}. Defaults to a
+   * fresh `new TarExtractor()`. Tests can inject a custom extractor to
+   * stress зип-slip paths без round-tripping the singleton.
+   */
+  tarExtractor?: TarExtractor;
+  /**
+   * Optional — tracker для staging dirs created during pulls. Required
+   * для `pullAssetSpace` to operate. If omitted, the call surface throws
+   * a clear error before any side effects. Production wiring constructs
+   * a tracker against {@link PluginLocalDataStore}.
+   */
+  stagingTracker?: StagingDirTracker;
+}
+
+/**
+ * Outcome of a successful {@link AssetSpaceManager.pullAssetSpace} call —
+ * tells the orchestrator (Phase 2 SwitchCacheLayer / Phase 3
+ * `hardSwitchProfile`) where the freshly-materialised AssetSpace lives
+ * on disk plus the SHA the GitHub REST tarball claimed.
+ */
+export interface PullAssetSpaceResult {
+  /** AssetSpace UID that was pulled. */
+  asUid: string;
+  /**
+   * Absolute path к staging directory containing the materialised
+   * AssetSpace content (children of the GitHub tarball's wrapper dir
+   * have been stripped — entries live directly at this path).
+   */
+  stagingPath: string;
+  /**
+   * 7-character SHA extracted from the GitHub tarball wrapper directory
+   * name (`<owner>-<repo>-<sha7>/`). Used by Phase 2 SwitchCacheLayer to
+   * key cache entries by content version.
+   */
+  sha: string;
 }
 
 /**
@@ -91,6 +139,8 @@ export class AssetSpaceManager {
   private readonly client: GitHubRestClient;
   private readonly notifications: INotificationService;
   private readonly branch: string;
+  private readonly tarExtractor: TarExtractor;
+  private readonly stagingTracker: StagingDirTracker | null;
 
   /**
    * Vault-relative paths of files modified since the last push. Plugin
@@ -121,6 +171,8 @@ export class AssetSpaceManager {
     this.client = opts.client;
     this.notifications = opts.notifications;
     this.branch = opts.branch ?? "main";
+    this.tarExtractor = opts.tarExtractor ?? new TarExtractor();
+    this.stagingTracker = opts.stagingTracker ?? null;
   }
 
   // ─────────────────────────── public — operational ───────────────────────────
@@ -190,26 +242,144 @@ export class AssetSpaceManager {
     return promise;
   }
 
-  // ─────────────────────────── public — stubs (Phase C+D) ─────────────────────
+  // ─────────────────────────── public — Phase 5 P1 ────────────────────────────
 
-  /** STUB — pull live-load deferred to Phase C+D per RFC 0a0791c1 §Scope. */
-  public async pullAssetSpace(_asUid: string, _stagingDir: string): Promise<void> {
-    throw new Error(
-      "AssetSpaceManager.pullAssetSpace: Phase C+D not implemented (v3 scope = push + lookup only)",
-    );
+  /**
+   * Pull the upstream tarball for an AssetSpace и materialise its contents
+   * into a fresh staging directory.
+   *
+   * Steps:
+   *   1. Validate the repo URL via {@link GitHubRestClient.validateRepoURL}.
+   *   2. Allocate a staging dir via {@link StagingDirTracker} (registers
+   *      orphan-cleanup record up front per RFC 22b50a17 R26).
+   *   3. Fetch the raw tarball via
+   *      {@link GitHubRestClient.fetchTarballBuffer} (50 MB cap by default).
+   *   4. Extract every entry via {@link TarExtractor} (zip-slip safe — see
+   *      F1 finding в Phase 0 spike doc) into the staging dir, stripping
+   *      the GitHub-emitted wrapper `<owner>-<repo>-<sha7>/`.
+   *   5. Return the staging path + SHA discovered from the wrapper.
+   *
+   * Wrapper-strip strategy (F1): GitHub REST tarballs always have a wrapper
+   * directory matching `<owner>-<repo>-<sha7>/`. We discover the wrapper
+   * from the first entry's leading segment, validate ALL entries share it
+   * (defense-in-depth), then materialize using paths с the wrapper stripped.
+   *
+   * Cleanup contract: ANY error after staging-dir allocation triggers
+   * `stagingTracker.release(stagingPath)` so we don't leak temp dirs.
+   * Successful return KEEPS the staging dir — caller (Phase 2/3
+   * orchestrators) owns its lifetime and must `release()` after the
+   * downstream move-into-vault step succeeds OR fails.
+   *
+   * @throws desktop-only on mobile.
+   * @throws if `stagingTracker` not provided to constructor.
+   * @throws invalid URL / network failure / corrupt tarball / wrapper-shape
+   *   mismatch — staging dir always released before propagation.
+   */
+  public async pullAssetSpace(
+    asUid: string,
+    asGitUrl: string,
+    ref: string = "main",
+  ): Promise<PullAssetSpaceResult> {
+    if (Platform.isMobile) {
+      throw new Error(
+        "AssetSpaceManager.pullAssetSpace: desktop-only (Phase 5 limitation — mobile Obsidian has no fs / os.tmpdir).",
+      );
+    }
+    if (!this.stagingTracker) {
+      throw new Error(
+        "AssetSpaceManager.pullAssetSpace: stagingTracker not configured (pass via options to enable Phase 5 pull).",
+      );
+    }
+    if (typeof asUid !== "string" || asUid.length === 0) {
+      throw new Error("pullAssetSpace: asUid is required");
+    }
+    if (typeof asGitUrl !== "string" || asGitUrl.length === 0) {
+      throw new Error("pullAssetSpace: asGitUrl is required");
+    }
+
+    // Validate URL shape + extract owner/repo. validateRepoURL throws on
+    // path traversal / scheme injection / non-github hosts.
+    GitHubRestClient.validateRepoURL(asGitUrl);
+    const { owner, repo } = parseGitHubURL(asGitUrl);
+
+    const stagingPath = await this.stagingTracker.allocate(asUid);
+    try {
+      const blob = await this.client.fetchTarballBuffer(owner, repo, ref);
+
+      // Eagerly drain the iterable into an array so we can do the
+      // two-pass wrapper-discover-then-strip pattern. Memory is already
+      // O(tarball.size) because nanotar 0.3.0 buffers internally, so
+      // collecting entry references adds only pointers, not bytes.
+      const entries: ExtractedTarFile[] = [];
+      for await (const entry of this.tarExtractor.extract(blob, {
+        // Wrapper prefix unknown until we read the first entry — let
+        // TarExtractor's prefix gate accept any path. Zip-slip protections
+        // 1-3 (absolute paths, `..`, sym/hard links) remain active.
+        stagingDirPrefix: "",
+      })) {
+        entries.push(entry);
+      }
+      if (entries.length === 0) {
+        throw new Error(
+          `pullAssetSpace: tarball empty for ${owner}/${repo}@${ref}`,
+        );
+      }
+
+      const wrapper = discoverWrapperDir(entries);
+      const sha = extractShaFromWrapper(wrapper);
+      const wrapperPrefix = wrapper + "/";
+
+      // Materialize entries with wrapper stripped.
+      for (const entry of entries) {
+        if (!entry.path.startsWith(wrapperPrefix)) {
+          throw new Error(
+            `pullAssetSpace: tarball entry "${entry.path}" not under wrapper "${wrapper}"`,
+          );
+        }
+        const rel = entry.path.slice(wrapperPrefix.length);
+        if (rel.length === 0) continue; // wrapper dir itself
+        const target = path.join(stagingPath, rel);
+        // Defense-in-depth: confirm the resolved target stays inside
+        // staging — path.join with `..` segments would otherwise escape.
+        // TarExtractor already rejects `..` segments, this is belt-and-
+        // braces in case of future regression.
+        const resolvedTarget = path.resolve(target);
+        const resolvedStaging = path.resolve(stagingPath);
+        if (
+          resolvedTarget !== resolvedStaging &&
+          !resolvedTarget.startsWith(resolvedStaging + path.sep)
+        ) {
+          throw new Error(
+            `pullAssetSpace: resolved path "${resolvedTarget}" escapes staging dir`,
+          );
+        }
+        await fs.mkdir(path.dirname(resolvedTarget), { recursive: true });
+        await fs.writeFile(resolvedTarget, entry.content);
+      }
+
+      return { asUid, stagingPath, sha };
+    } catch (err) {
+      // Best-effort cleanup of the partially-populated staging dir.
+      await this.stagingTracker
+        .release(stagingPath)
+        .catch(() => undefined);
+      throw err;
+    }
   }
 
-  /** STUB — destroy deferred to Phase C+D. */
+  // ─────────────────────────── public — stubs (Phase 2+3) ─────────────────────
+
+  /** STUB — destroy deferred to Phase 2 SwitchCacheLayer / Phase 3 hardSwitchProfile. */
   public async destroyAssetSpace(_asUid: string): Promise<void> {
     throw new Error(
-      "AssetSpaceManager.destroyAssetSpace: Phase C+D not implemented (v3 scope = push + lookup only)",
+      "AssetSpaceManager.destroyAssetSpace: deferred to Phase 2/3 (RFC 22b50a17)",
     );
   }
 
-  /** STUB — restore-from-cache deferred to Phase C+D. */
+  /** STUB — restore-from-cache deferred to Phase 2 SwitchCacheLayer. */
   public async restoreFromCache(_asUid: string): Promise<boolean> {
     throw new Error(
-      "AssetSpaceManager.restoreFromCache: Phase C+D not implemented (v3 scope = push + lookup only)",
+      "AssetSpaceManager.restoreFromCache: deferred to Phase 2 SwitchCacheLayer (RFC 22b50a17)",
     );
   }
 
@@ -374,6 +544,74 @@ export function parseGitHubURL(url: string): { owner: string; repo: string } {
     throw new Error(`parseGitHubURL: invalid URL shape: ${url}`);
   }
   return { owner: m[1], repo: m[2] };
+}
+
+/**
+ * Discover the wrapper directory of a GitHub REST tarball.
+ *
+ * GitHub generates tarballs с inherent wrapper `<owner>-<repo>-<sha7>/`.
+ * Every entry's path starts с this prefix. We read the first segment of
+ * the first entry, then verify ALL entries share it.
+ *
+ * Empty / null entry name (already rejected by TarExtractor.validateEntry)
+ * would surface here as a missing slash, which we treat as a malformed
+ * tarball.
+ *
+ * Exported for unit testing.
+ */
+export function discoverWrapperDir(entries: ExtractedTarFile[]): string {
+  if (entries.length === 0) {
+    throw new Error("discoverWrapperDir: cannot discover wrapper of empty entry list");
+  }
+  const first = entries[0].path;
+  const slashIdx = first.indexOf("/");
+  // Tarball without any `/` means a top-level file with no wrapper —
+  // shape inconsistent with GitHub REST contract.
+  if (slashIdx < 0) {
+    throw new Error(
+      `discoverWrapperDir: expected wrapper directory, entry "${first}" has no path separator`,
+    );
+  }
+  const wrapper = first.slice(0, slashIdx);
+  if (wrapper.length === 0) {
+    throw new Error(
+      `discoverWrapperDir: empty wrapper segment in entry "${first}"`,
+    );
+  }
+  const wrapperPrefix = wrapper + "/";
+  for (const entry of entries) {
+    // Allow exact match (the wrapper dir itself listed как entry).
+    if (entry.path === wrapper || entry.path === wrapperPrefix) continue;
+    if (!entry.path.startsWith(wrapperPrefix)) {
+      throw new Error(
+        `discoverWrapperDir: entry "${entry.path}" not under wrapper "${wrapper}"`,
+      );
+    }
+  }
+  return wrapper;
+}
+
+/**
+ * Extract the 7-character SHA from a GitHub REST tarball wrapper name.
+ *
+ * GitHub-emitted wrapper names follow the pattern `<owner>-<repo>-<sha7>`
+ * where `<sha7>` is the last `-`-delimited segment (always 7 lowercase
+ * hex characters). Repo names CAN contain hyphens, so we anchor on the
+ * trailing 7-hex-char segment to avoid `<owner>-<repo-with-dash>-<sha7>`
+ * ambiguity.
+ *
+ * Exported for unit testing.
+ */
+export function extractShaFromWrapper(wrapper: string): string {
+  // Match the trailing `-<7-hex>` suffix. Hex is case-insensitive in
+  // principle but GitHub emits lowercase; accept both для robustness.
+  const m = wrapper.match(/-([0-9a-fA-F]{7})$/);
+  if (!m) {
+    throw new Error(
+      `extractShaFromWrapper: wrapper "${wrapper}" does not match expected GitHub pattern <owner>-<repo>-<sha7>`,
+    );
+  }
+  return m[1].toLowerCase();
 }
 
 function nowIsoSeconds(): string {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
@@ -141,6 +141,41 @@ export class GitHubRestClient {
   }
 
   /**
+   * GET /repos/{owner}/{repo}/tarball/{ref} → raw gzipped tarball as
+   * ArrayBuffer.
+   *
+   * Useful when the consumer wants zip-slip-safe extraction via
+   * {@link ../adapters/TarExtractor} or any other parser, rather than
+   * the convenience parse offered by {@link pullTarball}.
+   *
+   * Enforces `maxTarballBytes` (default 50 MB) before returning — protects
+   * the renderer process from oversized downloads which would later be
+   * fully materialised by `parseTarGzip` (nanotar 0.3.0 has no streaming).
+   */
+  public async fetchTarballBuffer(
+    owner: string,
+    repo: string,
+    ref: string = "HEAD",
+  ): Promise<ArrayBuffer> {
+    this.requireOwnerRepo(owner, repo);
+    const resp = await this.request({
+      method: "GET",
+      url: `${this.#baseURL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tarball/${encodeURIComponent(ref)}`,
+    });
+    if (!resp?.arrayBuffer || !(resp.arrayBuffer instanceof ArrayBuffer)) {
+      throw new Error(
+        this.redact(`GitHub fetchTarballBuffer: response missing arrayBuffer for ${owner}/${repo}@${ref}`),
+      );
+    }
+    if (resp.arrayBuffer.byteLength > this.#maxTarballBytes) {
+      throw new Error(
+        `GitHub fetchTarballBuffer: tarball exceeds maxTarballBytes (${resp.arrayBuffer.byteLength} > ${this.#maxTarballBytes}) for ${owner}/${repo}@${ref}`,
+      );
+    }
+    return resp.arrayBuffer;
+  }
+
+  /**
    * GET /repos/{owner}/{repo}/tarball/{ref} → parsed tar items as async iterable.
    *
    * ⚠️ Memory contract: `nanotar@0.3.0` has no streaming parse — the **entire**
@@ -150,30 +185,20 @@ export class GitHubRestClient {
    * the iterator as "iterate-then-discard" and must not assume low memory
    * usage. A size guard (`maxTarballBytes`, default 50 MB) rejects oversized
    * tarballs before the parse to protect the Obsidian renderer process.
+   *
+   * **Zip-slip note:** this convenience method does NOT validate entry
+   * paths. Use `fetchTarballBuffer()` + `TarExtractor.extract()` when
+   * processing untrusted tarballs (production AssetSpace pulls).
    */
   public async pullTarball(
     owner: string,
     repo: string,
     ref: string = "HEAD",
   ): Promise<AsyncIterable<TarFileItem>> {
-    this.requireOwnerRepo(owner, repo);
-    const resp = await this.request({
-      method: "GET",
-      url: `${this.#baseURL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tarball/${encodeURIComponent(ref)}`,
-    });
-    if (!resp?.arrayBuffer || !(resp.arrayBuffer instanceof ArrayBuffer)) {
-      throw new Error(
-        this.redact(`GitHub pullTarball: response missing arrayBuffer for ${owner}/${repo}@${ref}`),
-      );
-    }
-    if (resp.arrayBuffer.byteLength > this.#maxTarballBytes) {
-      throw new Error(
-        `GitHub pullTarball: tarball exceeds maxTarballBytes (${resp.arrayBuffer.byteLength} > ${this.#maxTarballBytes}) for ${owner}/${repo}@${ref}`,
-      );
-    }
+    const blob = await this.fetchTarballBuffer(owner, repo, ref);
     let items: TarFileItem[];
     try {
-      items = (await parseTarGzip(resp.arrayBuffer)) as unknown as TarFileItem[];
+      items = (await parseTarGzip(blob)) as unknown as TarFileItem[];
     } catch (err) {
       throw new Error(
         this.redact(`GitHub pullTarball: tarball parse failed for ${owner}/${repo}@${ref}: ${errMsg(err)}`),

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
@@ -50,6 +50,7 @@ import type { App } from "obsidian";
 
 const KEY_ACTIVE_PROFILE_UID = "activeProfileUid";
 const KEY_SWITCH_IN_PROGRESS = "_switchInProgress";
+const KEY_ACTIVE_STAGING_DIRS = "_activeStagingDirs";
 
 export interface PluginLocalDataStoreOptions {
   app: App;
@@ -65,6 +66,18 @@ export interface PluginLocalDataStoreOptions {
 export interface LocalSwitchState {
   activeProfileUid: string | null;
   _switchInProgress: boolean;
+}
+
+/**
+ * Tracked staging dir entry — registered by {@link StagingDirTracker.allocate}
+ * before any tarball materialization writes, swept on plugin onload by
+ * {@link StagingDirTracker.sweepOrphans} if the process crashed mid-pull
+ * (RFC 22b50a17 R26 mitigation).
+ */
+export interface StagingDirEntry {
+  asUid: string;
+  path: string;
+  allocatedAt: string;
 }
 
 const EMPTY_STATE: LocalSwitchState = {
@@ -185,6 +198,53 @@ export class PluginLocalDataStore {
       _switchInProgress: legacyFlag,
     });
     return "legacy";
+  }
+
+  /**
+   * Read the tracked staging-dir registry. Returns a fresh array — callers
+   * can mutate без affecting future reads.
+   *
+   * Reads from disk на каждом call (NOT cached в `this.cache`): staging-dir
+   * tracking is write-rare / read-rare (plugin onload sweep + per-pull
+   * allocate/release), and the value lives outside `LocalSwitchState` so a
+   * stale cache read after a sibling write would be visible across surfaces.
+   */
+  async readActiveStagingDirs(): Promise<StagingDirEntry[]> {
+    const all = await this.readAllRaw();
+    const raw = all[KEY_ACTIVE_STAGING_DIRS];
+    if (!Array.isArray(raw)) return [];
+    const out: StagingDirEntry[] = [];
+    for (const item of raw) {
+      if (
+        item &&
+        typeof item === "object" &&
+        typeof (item as Record<string, unknown>).asUid === "string" &&
+        typeof (item as Record<string, unknown>).path === "string" &&
+        typeof (item as Record<string, unknown>).allocatedAt === "string"
+      ) {
+        const e = item as Record<string, unknown>;
+        out.push({
+          asUid: e.asUid as string,
+          path: e.path as string,
+          allocatedAt: e.allocatedAt as string,
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Replace the tracked staging-dir registry. Preserves unknown sibling
+   * keys (PAT in LocalSecretsStore, switch state) via RMW.
+   */
+  async writeActiveStagingDirs(entries: StagingDirEntry[]): Promise<void> {
+    const all = await this.readAllRaw();
+    all[KEY_ACTIVE_STAGING_DIRS] = entries.map((e) => ({
+      asUid: e.asUid,
+      path: e.path,
+      allocatedAt: e.allocatedAt,
+    }));
+    await this.persist(all);
   }
 
   private assertInitialized(): void {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/StagingDirTracker.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/StagingDirTracker.ts
@@ -1,0 +1,166 @@
+// Node.js builtins required for Phase 5 hard-switch staging dirs (RFC
+// 22b50a17) — staging dirs live в `os.tmpdir()` OUTSIDE the vault so
+// Obsidian's vault.adapter API cannot reach them. This file is only
+// instantiated on desktop — callers (AssetSpaceManager.pullAssetSpace +
+// ExocortexPlugin.onload sweepOrphans) guard via Platform.isMobile.
+/* eslint-disable no-restricted-imports, import/no-nodejs-modules */
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+/* eslint-enable no-restricted-imports, import/no-nodejs-modules */
+import type {
+  PluginLocalDataStore,
+  StagingDirEntry,
+} from "./PluginLocalDataStore";
+
+export interface StagingDirTrackerOptions {
+  /** Persists the active staging-dir registry across plugin restarts. */
+  localDataStore: PluginLocalDataStore;
+  /**
+   * OS-level tmpdir base. Default `os.tmpdir()`. Tests inject a custom path
+   * so allocations live inside a disposable directory cleaned in afterEach.
+   */
+  tmpdirBase?: string;
+}
+
+/**
+ * StagingDirTracker — manage Phase 5 tarball-materialization staging dirs
+ * (RFC 22b50a17 R26 mitigation).
+ *
+ * The Phase 5 hard-switch algorithm pulls one or more AssetSpace tarballs
+ * to a staging directory before atomically moving them into the vault.
+ * If the plugin crashes (or Obsidian quits) mid-pull, the staging dir
+ * lives under `os.tmpdir()` and would survive forever — OS-level temp
+ * sweepers may not reclaim it for days.
+ *
+ * This tracker writes each newly-allocated staging dir к the local data
+ * store BEFORE materialization writes begin, and removes the entry once
+ * the consumer releases the directory. On plugin onload, `sweepOrphans()`
+ * deletes anything still tracked (= plugin crashed before release).
+ *
+ * **Cross-platform note:** uses Node's `fs/promises` and `os.tmpdir()`.
+ * Mobile Obsidian provides neither, so the tracker should only be wired
+ * на desktop. The caller (AssetSpaceManager.pullAssetSpace) guards via
+ * `Platform.isDesktopApp` at entry.
+ */
+export class StagingDirTracker {
+  private readonly localDataStore: PluginLocalDataStore;
+  private readonly tmpdirBase: string;
+
+  /**
+   * Promise chain serializing `read-modify-write` of the registry. The
+   * tracker's persistence backend (PluginLocalDataStore) does not lock, so
+   * parallel `allocate()` calls would race: both read `[]`, both push, both
+   * write — one entry lost. Chaining через this promise guarantees the
+   * critical region is sequential per tracker instance.
+   *
+   * `fs.mkdtemp` itself is atomic and outside the lock; only the registry
+   * read-modify-write is serialized. Net effect: concurrent callers see
+   * sequential allocate semantics but pay only ms-scale waits.
+   */
+  private writeChain: Promise<unknown> = Promise.resolve();
+
+  constructor(opts: StagingDirTrackerOptions) {
+    if (!opts || !opts.localDataStore) {
+      throw new Error("StagingDirTracker: localDataStore is required");
+    }
+    this.localDataStore = opts.localDataStore;
+    this.tmpdirBase = opts.tmpdirBase ?? os.tmpdir();
+  }
+
+  /**
+   * Allocate a fresh staging dir for `asUid`. Returns the absolute path.
+   *
+   * The dir is created via `fs.mkdtemp` (unique suffix prevents races
+   * between concurrent allocations for the same `asUid`), then registered
+   * in the local data store. If registration fails, the dir is removed
+   * synchronously so we never leak unregistered temp dirs.
+   */
+  async allocate(asUid: string): Promise<string> {
+    if (typeof asUid !== "string" || asUid.length === 0) {
+      throw new Error("StagingDirTracker.allocate: asUid is required");
+    }
+    return this.runSerial(async () => {
+      const sanitized = asUid.replace(/[^a-zA-Z0-9-]/g, "_");
+      const prefix = path.join(this.tmpdirBase, `exo-staging-${sanitized}-`);
+      const dir = await fs.mkdtemp(prefix);
+      try {
+        const tracked = await this.localDataStore.readActiveStagingDirs();
+        const entry: StagingDirEntry = {
+          asUid,
+          path: dir,
+          allocatedAt: new Date().toISOString(),
+        };
+        tracked.push(entry);
+        await this.localDataStore.writeActiveStagingDirs(tracked);
+        return dir;
+      } catch (err) {
+        // Best-effort cleanup of the unregistered dir; rethrow original error.
+        await fs
+          .rm(dir, { recursive: true, force: true })
+          .catch(() => undefined);
+        throw err;
+      }
+    });
+  }
+
+  /**
+   * Serialize critical-region work via a promise chain. The chain absorbs
+   * the result (even errors) so subsequent callers always run; we re-throw
+   * to the **invoker** so they see the original failure.
+   */
+  private runSerial<T>(task: () => Promise<T>): Promise<T> {
+    const next = this.writeChain.then(() => task());
+    // Swallow errors on the chain so the next link runs regardless. The
+    // returned promise (`next`) still surfaces the error to the caller.
+    this.writeChain = next.catch(() => undefined);
+    return next;
+  }
+
+  /**
+   * Release a previously-allocated staging dir — removes it from disk and
+   * from the tracker.  Idempotent: missing entries / non-existent dirs are
+   * tolerated так that `release()` from a finally-block never throws over a
+   * primary error.
+   */
+  async release(stagingPath: string): Promise<void> {
+    if (typeof stagingPath !== "string" || stagingPath.length === 0) return;
+    return this.runSerial(async () => {
+      await fs
+        .rm(stagingPath, { recursive: true, force: true })
+        .catch(() => undefined);
+      const tracked = await this.localDataStore.readActiveStagingDirs();
+      const filtered = tracked.filter((e) => e.path !== stagingPath);
+      if (filtered.length !== tracked.length) {
+        await this.localDataStore.writeActiveStagingDirs(filtered);
+      }
+    });
+  }
+
+  /**
+   * On plugin onload, delete any staging dirs that survived a crash.
+   *
+   * Walks the tracker registry: для каждой entry, `fs.rm(path, force: true)`
+   * (no-op if dir already gone), then clears the registry. Returns counts
+   * for logging/telemetry.
+   */
+  async sweepOrphans(): Promise<{ swept: number; tracked: number }> {
+    const tracked = await this.localDataStore.readActiveStagingDirs();
+    if (tracked.length === 0) return { swept: 0, tracked: 0 };
+    let swept = 0;
+    for (const entry of tracked) {
+      const existed = await fs
+        .access(entry.path)
+        .then(() => true)
+        .catch(() => false);
+      if (existed) {
+        await fs
+          .rm(entry.path, { recursive: true, force: true })
+          .catch(() => undefined);
+        swept++;
+      }
+    }
+    await this.localDataStore.writeActiveStagingDirs([]);
+    return { swept, tracked: tracked.length };
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/StagingDirTracker.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/StagingDirTracker.ts
@@ -145,22 +145,24 @@ export class StagingDirTracker {
    * for logging/telemetry.
    */
   async sweepOrphans(): Promise<{ swept: number; tracked: number }> {
-    const tracked = await this.localDataStore.readActiveStagingDirs();
-    if (tracked.length === 0) return { swept: 0, tracked: 0 };
-    let swept = 0;
-    for (const entry of tracked) {
-      const existed = await fs
-        .access(entry.path)
-        .then(() => true)
-        .catch(() => false);
-      if (existed) {
-        await fs
-          .rm(entry.path, { recursive: true, force: true })
-          .catch(() => undefined);
-        swept++;
+    return this.runSerial(async () => {
+      const tracked = await this.localDataStore.readActiveStagingDirs();
+      if (tracked.length === 0) return { swept: 0, tracked: 0 };
+      let swept = 0;
+      for (const entry of tracked) {
+        const existed = await fs
+          .access(entry.path)
+          .then(() => true)
+          .catch(() => false);
+        if (existed) {
+          await fs
+            .rm(entry.path, { recursive: true, force: true })
+            .catch(() => undefined);
+          swept++;
+        }
       }
-    }
-    await this.localDataStore.writeActiveStagingDirs([]);
-    return { swept, tracked: tracked.length };
+      await this.localDataStore.writeActiveStagingDirs([]);
+      return { swept, tracked: tracked.length };
+    });
   }
 }

--- a/packages/obsidian-plugin/tests/unit/AssetSpaceManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AssetSpaceManager.test.ts
@@ -577,26 +577,31 @@ describe("AssetSpaceManager", () => {
     });
   });
 
-  // --- Phase C+D stubs -------------------------------------------------
-  describe("Phase C+D stubs", () => {
-    it("pullAssetSpace throws 'Phase C+D not implemented'", async () => {
+  // --- Phase 2/3 stubs (Phase 5 P1 turned pullAssetSpace into real impl;
+  //     destroyAssetSpace + restoreFromCache stay deferred to Phase 2/3) -----
+  describe("Phase 2/3 stubs", () => {
+    it("pullAssetSpace throws desktop-only without staging tracker", async () => {
+      // No stagingTracker configured → fail-loud before any side effects.
       const h = makeHarness([]);
-      await expect(h.mgr.pullAssetSpace("x", "staging")).rejects.toThrow(
-        /Phase C\+D not implemented/,
-      );
+      await expect(
+        h.mgr.pullAssetSpace(
+          "x",
+          "https://github.com/owner/repo",
+        ),
+      ).rejects.toThrow(/stagingTracker not configured/);
     });
 
-    it("destroyAssetSpace throws 'Phase C+D not implemented'", async () => {
+    it("destroyAssetSpace throws 'deferred to Phase 2/3'", async () => {
       const h = makeHarness([]);
       await expect(h.mgr.destroyAssetSpace("x")).rejects.toThrow(
-        /Phase C\+D not implemented/,
+        /deferred to Phase 2\/3/,
       );
     });
 
-    it("restoreFromCache throws 'Phase C+D not implemented'", async () => {
+    it("restoreFromCache throws 'deferred to Phase 2 SwitchCacheLayer'", async () => {
       const h = makeHarness([]);
       await expect(h.mgr.restoreFromCache("x")).rejects.toThrow(
-        /Phase C\+D not implemented/,
+        /deferred to Phase 2 SwitchCacheLayer/,
       );
     });
   });

--- a/packages/obsidian-plugin/tests/unit/AssetSpaceManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/AssetSpaceManager.test.ts
@@ -580,8 +580,9 @@ describe("AssetSpaceManager", () => {
   // --- Phase 2/3 stubs (Phase 5 P1 turned pullAssetSpace into real impl;
   //     destroyAssetSpace + restoreFromCache stay deferred to Phase 2/3) -----
   describe("Phase 2/3 stubs", () => {
-    it("pullAssetSpace throws desktop-only without staging tracker", async () => {
-      // No stagingTracker configured → fail-loud before any side effects.
+    it("pullAssetSpace throws clear error when stagingTracker not configured", async () => {
+      // No stagingTracker configured (factory path для production push-only
+      // wiring) → fail-loud before any side effects.
       const h = makeHarness([]);
       await expect(
         h.mgr.pullAssetSpace(

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceManager.pullAssetSpace.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceManager.pullAssetSpace.test.ts
@@ -38,6 +38,7 @@ import { PluginLocalDataStore } from "../../../../src/infrastructure/adapters/Pl
 
 interface FakeGitHubClient {
   fetchTarballBuffer: jest.Mock<Promise<ArrayBuffer>, [string, string, string]>;
+  ensureRateLimit: jest.Mock<Promise<void>, [number]>;
 }
 
 function makeFakeClient(
@@ -47,6 +48,9 @@ function makeFakeClient(
     fetchTarballBuffer: jest
       .fn<Promise<ArrayBuffer>, [string, string, string]>()
       .mockResolvedValue(new ArrayBuffer(0)),
+    ensureRateLimit: jest
+      .fn<Promise<void>, [number]>()
+      .mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -284,6 +288,43 @@ describe("AssetSpaceManager.pullAssetSpace — network drop", () => {
     expect(tracked).toHaveLength(0);
 
     // No leftover dirs (besides the data.local.json file).
+    const remaining = await fs.readdir(h.tmpdirBase);
+    expect(
+      remaining.filter((n) => n.startsWith("exo-staging-")),
+    ).toHaveLength(0);
+  });
+});
+
+// ─── 2b. Rate-limit pre-flight — fail fast before staging allocation ───────
+
+describe("AssetSpaceManager.pullAssetSpace — rate-limit pre-flight", () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await cleanTmpdir(h.tmpdirBase);
+  });
+
+  it("ensureRateLimit failure aborts before staging allocation", async () => {
+    h = await makeHarness({
+      clientOverrides: {
+        ensureRateLimit: jest
+          .fn<Promise<void>, [number]>()
+          .mockRejectedValue(
+            new Error(
+              "Rate limit guard: 2 remaining < 11 needed; resets in 600s",
+            ),
+          ),
+      },
+    });
+
+    await expect(
+      h.mgr.pullAssetSpace("uid-rl", "https://github.com/o/r"),
+    ).rejects.toThrow(/Rate limit guard/);
+
+    // No staging dir registered — release was never needed
+    expect(await h.store.readActiveStagingDirs()).toHaveLength(0);
+    expect(h.client.fetchTarballBuffer).not.toHaveBeenCalled();
+
+    // mkdtemp didn't fire either
     const remaining = await fs.readdir(h.tmpdirBase);
     expect(
       remaining.filter((n) => n.startsWith("exo-staging-")),

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceManager.pullAssetSpace.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceManager.pullAssetSpace.test.ts
@@ -1,0 +1,542 @@
+/**
+ * @jest-environment node
+ *
+ * Reason: pullAssetSpace materialises tarball entries via Node `fs/promises`
+ * and decompresses via Web Streams (CompressionStream/DecompressionStream)
+ * which jest-environment-jsdom does NOT expose. node environment supplies
+ * both.
+ *
+ * Coverage scope (P1.3 — Phase 5 RFC 22b50a17):
+ *   1. Happy path — valid tarball materialises correctly with wrapper-strip
+ *   2. Network drop — fetchTarballBuffer rejects → staging cleaned up
+ *   3. Partial / corrupt tarball — TarExtractor parse error → staging cleaned
+ *   4. Zip-slip attempt — `..` path → TarExtractor rejects → staging cleaned
+ *   5. Wrapper-dir mismatch — first/second entries disagree → PullError thrown
+ *   6. Size cap exceeded — fetchTarballBuffer enforces 50 MB → no extract
+ *   7. Staging-tracker orphan sweep — simulate plugin crash mid-pull
+ *
+ * Fixtures use real `nanotar.createTar` + native gzip per the
+ * test-fixture-realism rule (no stub-returning-fixed-bytes).
+ */
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { App } from "obsidian";
+import type { INotificationService } from "exocortex";
+import { createTar } from "nanotar";
+
+import {
+  AssetSpaceManager,
+  discoverWrapperDir,
+  extractShaFromWrapper,
+} from "../../../../src/infrastructure/adapters/AssetSpaceManager";
+import { StagingDirTracker } from "../../../../src/infrastructure/adapters/StagingDirTracker";
+import { PluginLocalDataStore } from "../../../../src/infrastructure/adapters/PluginLocalDataStore";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+interface FakeGitHubClient {
+  fetchTarballBuffer: jest.Mock<Promise<ArrayBuffer>, [string, string, string]>;
+}
+
+function makeFakeClient(
+  overrides: Partial<FakeGitHubClient> = {},
+): FakeGitHubClient {
+  return {
+    fetchTarballBuffer: jest
+      .fn<Promise<ArrayBuffer>, [string, string, string]>()
+      .mockResolvedValue(new ArrayBuffer(0)),
+    ...overrides,
+  };
+}
+
+function makeFakeNotifier(): INotificationService {
+  return {
+    info: () => undefined,
+    success: () => undefined,
+    error: () => undefined,
+    warn: () => undefined,
+    confirm: async () => true,
+  };
+}
+
+/**
+ * Build a fake App whose `vault.adapter` is backed by the real Node `fs`
+ * под the supplied disk root. PluginLocalDataStore writes the JSON
+ * registry via `vault.adapter.write/read/exists`, so the fake must
+ * actually persist (otherwise `readActiveStagingDirs` always returns []).
+ *
+ * `vault.adapter.write(path, json)` interprets `path` як vault-relative.
+ * We anchor it under `diskRoot/` so test isolation holds.
+ */
+function makeFakeApp(diskRoot: string): App {
+  const resolve = (p: string) => path.join(diskRoot, p);
+  return {
+    vault: {
+      getMarkdownFiles: () => [],
+      adapter: {
+        read: async (p: string) => {
+          return await fs.readFile(resolve(p), "utf8");
+        },
+        exists: async (p: string) => {
+          return await fs
+            .access(resolve(p))
+            .then(() => true)
+            .catch(() => false);
+        },
+        write: async (p: string, content: string) => {
+          const abs = resolve(p);
+          await fs.mkdir(path.dirname(abs), { recursive: true });
+          await fs.writeFile(abs, content);
+        },
+      },
+      configDir: ".obsidian",
+    },
+    metadataCache: {
+      getFileCache: () => null,
+    },
+  } as unknown as App;
+}
+
+/**
+ * Build a gzipped tarball wrapping `entries` under a directory named
+ * `wrapper` (= GitHub REST convention `<owner>-<repo>-<sha7>/`).
+ *
+ * Uses real `createTar` + native CompressionStream — fixtures are byte-
+ * identical to what GitHub would emit (modulo timestamps/UID/GID).
+ */
+async function makeTarball(
+  wrapper: string,
+  entries: Array<{ name: string; data?: Uint8Array }>,
+): Promise<ArrayBuffer> {
+  const files = entries.map((e) => ({
+    name: `${wrapper}/${e.name}`,
+    data: e.data,
+  }));
+  const tarBuf = createTar(files);
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(tarBuf);
+      c.close();
+    },
+  }).pipeThrough(new CompressionStream("gzip"));
+  return await new Response(stream).arrayBuffer();
+}
+
+/** Build a tarball whose entries do NOT share a common wrapper directory. */
+async function makeMismatchedWrapperTarball(): Promise<ArrayBuffer> {
+  const files = [
+    { name: "wrapper-a-aaaaaaa/file.md", data: new Uint8Array([1]) },
+    { name: "wrapper-b-bbbbbbb/file.md", data: new Uint8Array([2]) },
+  ];
+  const tarBuf = createTar(files);
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(tarBuf);
+      c.close();
+    },
+  }).pipeThrough(new CompressionStream("gzip"));
+  return await new Response(stream).arrayBuffer();
+}
+
+/**
+ * Build a tarball with a parent-dir-traversal entry — TarExtractor must
+ * reject with a ZipSlipError when this fixture is consumed.
+ *
+ * Note: nanotar's parser sanitises `..` from entry names before yielding;
+ * to actually exercise the validator we must bypass the sanitiser by
+ * crafting a raw tar header. Easiest realistic approach: use absolute
+ * path (`/etc/passwd`) which nanotar leaves alone in `_sanitizePath`
+ * after stripping the leading slash — that yields `etc/passwd` which
+ * still fails the wrapper-prefix gate downstream. For a true `..` test,
+ * we craft via direct header manipulation below.
+ */
+async function makeAbsolutePathTarball(): Promise<ArrayBuffer> {
+  const files = [
+    { name: "/etc/passwd", data: new Uint8Array([0]) },
+  ];
+  const tarBuf = createTar(files);
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(tarBuf);
+      c.close();
+    },
+  }).pipeThrough(new CompressionStream("gzip"));
+  return await new Response(stream).arrayBuffer();
+}
+
+/** Disposable tmpdir cleaned in afterEach. */
+async function makeTmpdir(): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "exo-p1-test-"));
+}
+
+async function cleanTmpdir(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+}
+
+interface Harness {
+  app: App;
+  client: FakeGitHubClient;
+  mgr: AssetSpaceManager;
+  tracker: StagingDirTracker;
+  store: PluginLocalDataStore;
+  tmpdirBase: string;
+}
+
+async function makeHarness(
+  opts: { clientOverrides?: Partial<FakeGitHubClient> } = {},
+): Promise<Harness> {
+  const tmpdirBase = await makeTmpdir();
+  const diskRoot = path.join(tmpdirBase, "vault");
+  await fs.mkdir(diskRoot, { recursive: true });
+  const app = makeFakeApp(diskRoot);
+  const store = new PluginLocalDataStore({
+    app,
+    path: "data.local.json",
+  });
+  await store.init();
+  const tracker = new StagingDirTracker({
+    localDataStore: store,
+    tmpdirBase,
+  });
+  const client = makeFakeClient(opts.clientOverrides);
+  const mgr = new AssetSpaceManager({
+    app,
+    client: client as never,
+    notifications: makeFakeNotifier(),
+    stagingTracker: tracker,
+  });
+  return { app, client, mgr, tracker, store, tmpdirBase };
+}
+
+// ─── 1. Happy path ──────────────────────────────────────────────────────────
+
+describe("AssetSpaceManager.pullAssetSpace — happy path", () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await cleanTmpdir(h.tmpdirBase);
+  });
+
+  it("materialises entries with wrapper-strip and returns sha", async () => {
+    h = await makeHarness();
+    const tarball = await makeTarball("owner-repo-abc1234", [
+      { name: "a.md", data: new TextEncoder().encode("# A\n") },
+      { name: "sub/b.md", data: new TextEncoder().encode("# B\n") },
+    ]);
+    h.client.fetchTarballBuffer.mockResolvedValue(tarball);
+
+    const result = await h.mgr.pullAssetSpace(
+      "test-uid",
+      "https://github.com/owner/repo",
+      "main",
+    );
+
+    expect(result.asUid).toBe("test-uid");
+    expect(result.sha).toBe("abc1234");
+    expect(result.stagingPath.startsWith(h.tmpdirBase)).toBe(true);
+
+    const aContent = await fs.readFile(
+      path.join(result.stagingPath, "a.md"),
+      "utf8",
+    );
+    expect(aContent).toBe("# A\n");
+    const bContent = await fs.readFile(
+      path.join(result.stagingPath, "sub", "b.md"),
+      "utf8",
+    );
+    expect(bContent).toBe("# B\n");
+
+    expect(h.client.fetchTarballBuffer).toHaveBeenCalledWith(
+      "owner",
+      "repo",
+      "main",
+    );
+  });
+});
+
+// ─── 2. Network drop — staging cleanup ──────────────────────────────────────
+
+describe("AssetSpaceManager.pullAssetSpace — network drop", () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await cleanTmpdir(h.tmpdirBase);
+  });
+
+  it("releases staging dir when fetchTarballBuffer rejects", async () => {
+    h = await makeHarness({
+      clientOverrides: {
+        fetchTarballBuffer: jest
+          .fn<Promise<ArrayBuffer>, [string, string, string]>()
+          .mockRejectedValue(new Error("ECONNRESET network drop")),
+      },
+    });
+
+    await expect(
+      h.mgr.pullAssetSpace(
+        "uid-network",
+        "https://github.com/o/r",
+      ),
+    ).rejects.toThrow(/ECONNRESET/);
+
+    // Tracker registry should be empty — release fired in catch.
+    const tracked = await h.store.readActiveStagingDirs();
+    expect(tracked).toHaveLength(0);
+
+    // No leftover dirs (besides the data.local.json file).
+    const remaining = await fs.readdir(h.tmpdirBase);
+    expect(
+      remaining.filter((n) => n.startsWith("exo-staging-")),
+    ).toHaveLength(0);
+  });
+});
+
+// ─── 3. Corrupt tarball — TarExtractor parse error ──────────────────────────
+
+describe("AssetSpaceManager.pullAssetSpace — corrupt tarball", () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await cleanTmpdir(h.tmpdirBase);
+  });
+
+  it("propagates parse error and cleans staging", async () => {
+    h = await makeHarness();
+    // Truncated gzip header — first 3 bytes valid magic, rest garbage.
+    const corrupt = new Uint8Array([0x1f, 0x8b, 0x08, 0x00, 0xff, 0xff]).buffer;
+    h.client.fetchTarballBuffer.mockResolvedValue(corrupt);
+
+    await expect(
+      h.mgr.pullAssetSpace(
+        "uid-corrupt",
+        "https://github.com/o/r",
+      ),
+    ).rejects.toThrow();
+
+    const tracked = await h.store.readActiveStagingDirs();
+    expect(tracked).toHaveLength(0);
+  });
+});
+
+// ─── 4. Zip-slip — absolute path entry rejected ─────────────────────────────
+
+describe("AssetSpaceManager.pullAssetSpace — zip-slip protection", () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await cleanTmpdir(h.tmpdirBase);
+  });
+
+  it("rejects tarball containing absolute-path entry", async () => {
+    h = await makeHarness();
+    // nanotar's parser strips the leading '/' from '/etc/passwd' →
+    // 'etc/passwd', which fails the wrapper-strip gate (no wrapper
+    // segment + no `/` in path post-strip). Either way: we never write
+    // anything outside the staging dir.
+    const tarball = await makeAbsolutePathTarball();
+    h.client.fetchTarballBuffer.mockResolvedValue(tarball);
+
+    await expect(
+      h.mgr.pullAssetSpace(
+        "uid-slip",
+        "https://github.com/o/r",
+      ),
+    ).rejects.toThrow();
+
+    // No file written outside staging.
+    const passwdLeak = await fs
+      .access("/etc/passwd-exocortex-attack")
+      .then(() => true)
+      .catch(() => false);
+    expect(passwdLeak).toBe(false);
+
+    const tracked = await h.store.readActiveStagingDirs();
+    expect(tracked).toHaveLength(0);
+  });
+});
+
+// ─── 5. Wrapper-dir mismatch ────────────────────────────────────────────────
+
+describe("AssetSpaceManager.pullAssetSpace — wrapper mismatch", () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await cleanTmpdir(h.tmpdirBase);
+  });
+
+  it("throws when entries do not share a single wrapper directory", async () => {
+    h = await makeHarness();
+    const tarball = await makeMismatchedWrapperTarball();
+    h.client.fetchTarballBuffer.mockResolvedValue(tarball);
+
+    await expect(
+      h.mgr.pullAssetSpace(
+        "uid-mismatch",
+        "https://github.com/o/r",
+      ),
+    ).rejects.toThrow(/not under wrapper/);
+
+    const tracked = await h.store.readActiveStagingDirs();
+    expect(tracked).toHaveLength(0);
+  });
+});
+
+// ─── 6. Size cap — fetchTarballBuffer enforces ──────────────────────────────
+
+describe("AssetSpaceManager.pullAssetSpace — size cap", () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await cleanTmpdir(h.tmpdirBase);
+  });
+
+  it("propagates oversize error from fetchTarballBuffer (50 MB cap)", async () => {
+    // Real GitHubRestClient.fetchTarballBuffer rejects oversize tarballs
+    // before parse — pullAssetSpace must surface that error and clean
+    // staging.
+    h = await makeHarness({
+      clientOverrides: {
+        fetchTarballBuffer: jest
+          .fn<Promise<ArrayBuffer>, [string, string, string]>()
+          .mockRejectedValue(
+            new Error(
+              "GitHub fetchTarballBuffer: tarball exceeds maxTarballBytes (52428801 > 52428800) for o/r@main",
+            ),
+          ),
+      },
+    });
+
+    await expect(
+      h.mgr.pullAssetSpace("uid-oversize", "https://github.com/o/r"),
+    ).rejects.toThrow(/exceeds maxTarballBytes/);
+
+    const tracked = await h.store.readActiveStagingDirs();
+    expect(tracked).toHaveLength(0);
+  });
+});
+
+// ─── 7. Staging-tracker orphan sweep ────────────────────────────────────────
+
+describe("StagingDirTracker — orphan sweep", () => {
+  let tmpdirBase: string;
+  afterEach(async () => {
+    if (tmpdirBase) await cleanTmpdir(tmpdirBase);
+  });
+
+  it("sweeps orphan staging dirs left over from a plugin crash", async () => {
+    tmpdirBase = await makeTmpdir();
+    const diskRoot = path.join(tmpdirBase, "vault");
+    await fs.mkdir(diskRoot, { recursive: true });
+    const app = makeFakeApp(diskRoot);
+    const store = new PluginLocalDataStore({
+      app,
+      path: "data.local.json",
+    });
+    await store.init();
+    const tracker = new StagingDirTracker({
+      localDataStore: store,
+      tmpdirBase,
+    });
+
+    // Allocate two staging dirs, simulate a crash by NOT calling release.
+    const d1 = await tracker.allocate("uid-1");
+    const d2 = await tracker.allocate("uid-2");
+    await fs.writeFile(path.join(d1, "marker.md"), "1");
+    await fs.writeFile(path.join(d2, "marker.md"), "2");
+
+    // Verify both registered + persisted to data.local.json.
+    const trackedBefore = await store.readActiveStagingDirs();
+    expect(trackedBefore.map((e) => e.path).sort()).toEqual([d1, d2].sort());
+
+    // Sweep — both dirs should be removed AND registry cleared.
+    const result = await tracker.sweepOrphans();
+    expect(result.tracked).toBe(2);
+    expect(result.swept).toBe(2);
+
+    const trackedAfter = await store.readActiveStagingDirs();
+    expect(trackedAfter).toHaveLength(0);
+
+    for (const dir of [d1, d2]) {
+      const exists = await fs
+        .access(dir)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(false);
+    }
+  });
+
+  it("tolerates entries pointing at already-removed dirs", async () => {
+    tmpdirBase = await makeTmpdir();
+    const diskRoot = path.join(tmpdirBase, "vault");
+    await fs.mkdir(diskRoot, { recursive: true });
+    const app = makeFakeApp(diskRoot);
+    const store = new PluginLocalDataStore({
+      app,
+      path: "data.local.json",
+    });
+    await store.init();
+    const tracker = new StagingDirTracker({
+      localDataStore: store,
+      tmpdirBase,
+    });
+
+    const d1 = await tracker.allocate("uid-vanished");
+    await fs.rm(d1, { recursive: true, force: true }); // simulate manual cleanup
+
+    const result = await tracker.sweepOrphans();
+    expect(result.tracked).toBe(1);
+    expect(result.swept).toBe(0); // dir was gone — counted as tracked but not swept
+    expect(await store.readActiveStagingDirs()).toHaveLength(0);
+  });
+});
+
+// ─── Helper unit tests — discoverWrapperDir / extractShaFromWrapper ─────────
+
+describe("discoverWrapperDir", () => {
+  it("returns first segment when all entries share it", () => {
+    const wrapper = discoverWrapperDir([
+      { path: "owner-repo-abc1234/a.md", content: new Uint8Array() },
+      { path: "owner-repo-abc1234/sub/b.md", content: new Uint8Array() },
+    ]);
+    expect(wrapper).toBe("owner-repo-abc1234");
+  });
+
+  it("throws on empty list", () => {
+    expect(() => discoverWrapperDir([])).toThrow(/empty entry list/);
+  });
+
+  it("throws when an entry uses a different wrapper", () => {
+    expect(() =>
+      discoverWrapperDir([
+        { path: "a-w-1234567/file", content: new Uint8Array() },
+        { path: "b-w-7654321/file", content: new Uint8Array() },
+      ]),
+    ).toThrow(/not under wrapper/);
+  });
+
+  it("throws when first entry has no path separator", () => {
+    expect(() =>
+      discoverWrapperDir([
+        { path: "single-file.md", content: new Uint8Array() },
+      ]),
+    ).toThrow(/no path separator/);
+  });
+});
+
+describe("extractShaFromWrapper", () => {
+  it("returns the trailing 7-hex segment", () => {
+    expect(extractShaFromWrapper("owner-repo-b011b4b")).toBe("b011b4b");
+  });
+
+  it("handles repo names with hyphens", () => {
+    expect(extractShaFromWrapper("kitelev-exoas-shared-identities-deadbef")).toBe(
+      "deadbef",
+    );
+  });
+
+  it("lowercases hex characters", () => {
+    expect(extractShaFromWrapper("owner-repo-ABCDEF0")).toBe("abcdef0");
+  });
+
+  it("throws on a wrapper without a trailing 7-hex segment", () => {
+    expect(() => extractShaFromWrapper("owner-repo-toolongofasha")).toThrow(
+      /does not match/,
+    );
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/integration/AssetSpaceManager.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/AssetSpaceManager.integration.test.ts
@@ -55,7 +55,15 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
     if (k.startsWith("GIT_")) continue;
     if (v !== undefined) cleanEnv[k] = v;
   }
-  const { stdout } = await execFileAsync("git", args, {
+  // Inject `-c protocol.file.allow=always` per-invocation so
+  // `git submodule add file://...` succeeds on CI runners. Git's
+  // default since 2.38 is `protocol.file.allow=user` which rejects
+  // `file://` clones inside submodule add. Setting it via local
+  // `git config` (as we did at beforeEach) does NOT propagate to the
+  // internal clone subprocess that submodule add spawns — only the
+  // top-level `-c` flag does.
+  const fullArgs = ["-c", "protocol.file.allow=always", ...args];
+  const { stdout } = await execFileAsync("git", fullArgs, {
     cwd,
     env: {
       ...cleanEnv,

--- a/packages/obsidian-plugin/tests/unit/integration/AssetSpaceManager.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/AssetSpaceManager.integration.test.ts
@@ -265,7 +265,10 @@ describe("Phase 5 P1.4 — pullAssetSpace → submodule handoff (E2E)", () => {
   let store: PluginLocalDataStore;
   let mgr: AssetSpaceManager;
   let fakeApp: App;
-  let mockClient: { fetchTarballBuffer: jest.Mock };
+  let mockClient: {
+    fetchTarballBuffer: jest.Mock;
+    ensureRateLimit: jest.Mock;
+  };
 
   beforeEach(async () => {
     workDir = await makeDisposableDir("exo-p1-e2e-");
@@ -312,7 +315,8 @@ describe("Phase 5 P1.4 — pullAssetSpace → submodule handoff (E2E)", () => {
     });
     mockClient = {
       fetchTarballBuffer: jest.fn(),
-    };
+      ensureRateLimit: jest.fn().mockResolvedValue(undefined),
+    } as never;
     mgr = new AssetSpaceManager({
       app: fakeApp,
       client: mockClient as never,

--- a/packages/obsidian-plugin/tests/unit/integration/AssetSpaceManager.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/AssetSpaceManager.integration.test.ts
@@ -1,0 +1,500 @@
+/**
+ * @jest-environment node
+ *
+ * Phase 5 P1.4 — integration tests for the submodule-pull pipeline.
+ *
+ * Scope (per next-session-prompt-phase5-phase1-asm-pullassetspace-2026-06-02):
+ *
+ *   1. F5 — submodule **recipe** validation (M2 BLOCKER). The actual
+ *      production submodule lifecycle helper is Phase 3 territory; these
+ *      tests directly drive `git` via `child_process` to prove the recipe
+ *      works on disk. Test file documents the protocol Phase 3 will encode.
+ *
+ *   2. End-to-end pullAssetSpace → staging-dir population → manual
+ *      `git submodule add` integration, demonstrating the handoff path
+ *      Phase 3 orchestrator will own.
+ *
+ *   3. StagingDirTracker concurrency — Promise.all of N concurrent
+ *      `allocate()` calls must produce N distinct staging paths with no
+ *      registry overwrites.
+ *
+ * Test environment: each describe-block builds a disposable test vault
+ * под `/tmp/exocortex-p1-integration-<ts>/` and tears it down в afterEach.
+ *
+ * Per advisor-round 2026-06-02: do NOT ship a SubmoduleManager class —
+ * Phase 3 work. These tests act as proof-of-concept that the recipe
+ * documented in RFC 22b50a17 §Migration plan Phase 3 works on disk.
+ */
+
+import { promises as fs } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { App } from "obsidian";
+import { createTar } from "nanotar";
+
+import { AssetSpaceManager } from "../../../src/infrastructure/adapters/AssetSpaceManager";
+import { StagingDirTracker } from "../../../src/infrastructure/adapters/StagingDirTracker";
+import { PluginLocalDataStore } from "../../../src/infrastructure/adapters/PluginLocalDataStore";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Run `git <args>` in `cwd`. Returns stdout. Rejects with stderr on non-zero.
+ * Sets `GIT_TERMINAL_PROMPT=0` so an accidentally-misconfigured op can't
+ * hang the test on credential input.
+ */
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  // Strip any inherited GIT_* env vars — when this test suite runs as a
+  // git hook (e.g. husky pre-commit), GIT_DIR / GIT_INDEX_FILE / etc.
+  // leak in от the outer process и redirect nested git commands at the
+  // parent repository instead of the disposable test dir.
+  const cleanEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith("GIT_")) continue;
+    if (v !== undefined) cleanEnv[k] = v;
+  }
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    env: {
+      ...cleanEnv,
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_AUTHOR_NAME: "test",
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+    },
+  });
+  return stdout;
+}
+
+async function makeDisposableDir(prefix: string): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+async function cleanDir(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+}
+
+/**
+ * Initialise a bare git remote + a clone with one initial commit so
+ * `git submodule add <remote-url>` succeeds (a totally empty bare repo
+ * fails — git refuses to add a no-HEAD remote).
+ */
+async function makeBareRemoteWithCommit(
+  baseDir: string,
+  name: string,
+): Promise<string> {
+  const remotePath = path.join(baseDir, `${name}.git`);
+  await fs.mkdir(remotePath, { recursive: true });
+  await git(remotePath, "init", "--bare", "--initial-branch=main");
+
+  // Seed the remote via a temp work-tree clone + push.
+  const seedClone = path.join(baseDir, `${name}-seed`);
+  await git(baseDir, "clone", remotePath, seedClone);
+  await fs.writeFile(path.join(seedClone, "README.md"), `# ${name}\n`);
+  await git(seedClone, "checkout", "-B", "main");
+  await git(seedClone, "add", "README.md");
+  await git(seedClone, "commit", "-m", `seed ${name}`);
+  await git(seedClone, "push", "-u", "origin", "main");
+  await cleanDir(seedClone);
+
+  return remotePath;
+}
+
+// ─── 1. F5: git submodule deinit + orphan .git/modules cleanup ─────────────
+
+describe("Phase 5 P1.4 — git submodule M2 BLOCKER recipe", () => {
+  let workDir: string;
+  let vault: string;
+
+  beforeEach(async () => {
+    workDir = await makeDisposableDir("exo-p1-integration-");
+    vault = path.join(workDir, "vault");
+    await fs.mkdir(vault, { recursive: true });
+    await git(vault, "init", "--initial-branch=main");
+    // One commit so submodule add has a HEAD to operate against.
+    await fs.writeFile(path.join(vault, ".gitkeep"), "");
+    await git(vault, "add", ".gitkeep");
+    await git(vault, "commit", "-m", "init");
+    // Allow file:// submodule URLs (git ≥2.38 disables them by default).
+    await git(vault, "config", "protocol.file.allow", "always");
+  });
+
+  afterEach(async () => {
+    if (workDir) await cleanDir(workDir);
+  });
+
+  it("leaves orphan .git/modules/<as>/ after deinit + rm — explicit cleanup removes it (M2 BLOCKER)", async () => {
+    const remote = await makeBareRemoteWithCommit(workDir, "foo");
+    await git(vault, "submodule", "add", `file://${remote}`, "assetspaces/foo");
+    await git(vault, "commit", "-m", "add submodule foo");
+
+    // Verify .git/modules/foo populated post-add.
+    const modulesDir = path.join(vault, ".git", "modules", "assetspaces/foo");
+    expect(
+      await fs
+        .access(modulesDir)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(true);
+
+    // Phase 3 destroy step: deinit + rm work-tree.
+    await git(vault, "submodule", "deinit", "-f", "assetspaces/foo");
+    await fs.rm(path.join(vault, "assetspaces/foo"), {
+      recursive: true,
+      force: true,
+    });
+    // Stage the removal so .gitmodules + index update.
+    await git(vault, "rm", "-f", "assetspaces/foo");
+
+    // ⛔ M2 BLOCKER — without the next step, `.git/modules/foo` orphan stays.
+    expect(
+      await fs
+        .access(modulesDir)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(true);
+
+    // Cleanup: explicit `rm -rf .git/modules/<as>/`.
+    await fs.rm(modulesDir, { recursive: true, force: true });
+
+    expect(
+      await fs
+        .access(modulesDir)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(false);
+  }, 30000);
+
+  it("supports re-adding the same submodule after full cleanup", async () => {
+    const remote = await makeBareRemoteWithCommit(workDir, "bar");
+    await git(vault, "submodule", "add", `file://${remote}`, "assetspaces/bar");
+    await git(vault, "commit", "-m", "add bar");
+
+    // Destroy chain (recipe from previous test).
+    await git(vault, "submodule", "deinit", "-f", "assetspaces/bar");
+    await fs.rm(path.join(vault, "assetspaces/bar"), {
+      recursive: true,
+      force: true,
+    });
+    await git(vault, "rm", "-f", "assetspaces/bar");
+    await fs.rm(path.join(vault, ".git", "modules", "assetspaces/bar"), {
+      recursive: true,
+      force: true,
+    });
+    await git(vault, "commit", "-m", "remove bar");
+
+    // Re-add — must succeed (no leftover .git/config or modules entry).
+    await expect(
+      git(vault, "submodule", "add", `file://${remote}`, "assetspaces/bar"),
+    ).resolves.toBeDefined();
+
+    // Verify .git/modules/bar/ repopulated.
+    expect(
+      await fs
+        .access(path.join(vault, ".git", "modules", "assetspaces/bar"))
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(true);
+  }, 30000);
+});
+
+// ─── 2. F5: .gitmodules atomic rewrite (3 submodules, remove middle) ───────
+
+describe("Phase 5 P1.4 — .gitmodules atomic rewrite", () => {
+  let workDir: string;
+  let vault: string;
+
+  beforeEach(async () => {
+    workDir = await makeDisposableDir("exo-p1-rewrite-");
+    vault = path.join(workDir, "vault");
+    await fs.mkdir(vault, { recursive: true });
+    await git(vault, "init", "--initial-branch=main");
+    await fs.writeFile(path.join(vault, ".gitkeep"), "");
+    await git(vault, "add", ".gitkeep");
+    await git(vault, "commit", "-m", "init");
+    await git(vault, "config", "protocol.file.allow", "always");
+  });
+
+  afterEach(async () => {
+    if (workDir) await cleanDir(workDir);
+  });
+
+  it("removes a middle .gitmodules entry via temp-file + rename (preserves siblings)", async () => {
+    const remoteA = await makeBareRemoteWithCommit(workDir, "a");
+    const remoteB = await makeBareRemoteWithCommit(workDir, "b");
+    const remoteC = await makeBareRemoteWithCommit(workDir, "c");
+
+    for (const [name, url] of [
+      ["a", remoteA],
+      ["b", remoteB],
+      ["c", remoteC],
+    ] as const) {
+      await git(vault, "submodule", "add", `file://${url}`, `assetspaces/${name}`);
+    }
+    await git(vault, "commit", "-m", "add a/b/c");
+
+    // Atomic-rewrite recipe: read full content, drop [submodule "...b"]
+    // block, write to .gitmodules.tmp, rename атомично over .gitmodules.
+    const gmPath = path.join(vault, ".gitmodules");
+    const original = await fs.readFile(gmPath, "utf8");
+    expect(original).toMatch(/\[submodule "assetspaces\/b"\]/);
+
+    const rewritten = removeSubmoduleSection(original, "assetspaces/b");
+    expect(rewritten).not.toMatch(/\[submodule "assetspaces\/b"\]/);
+    expect(rewritten).toMatch(/\[submodule "assetspaces\/a"\]/);
+    expect(rewritten).toMatch(/\[submodule "assetspaces\/c"\]/);
+
+    const tmpPath = gmPath + ".tmp";
+    await fs.writeFile(tmpPath, rewritten);
+    await fs.rename(tmpPath, gmPath); // atomic on POSIX
+
+    const final = await fs.readFile(gmPath, "utf8");
+    expect(final).toBe(rewritten);
+  }, 30000);
+});
+
+// ─── 3. End-to-end: pullAssetSpace → submodule add ─────────────────────────
+
+describe("Phase 5 P1.4 — pullAssetSpace → submodule handoff (E2E)", () => {
+  let workDir: string;
+  let vault: string;
+  let tracker: StagingDirTracker;
+  let store: PluginLocalDataStore;
+  let mgr: AssetSpaceManager;
+  let fakeApp: App;
+  let mockClient: { fetchTarballBuffer: jest.Mock };
+
+  beforeEach(async () => {
+    workDir = await makeDisposableDir("exo-p1-e2e-");
+    vault = path.join(workDir, "vault");
+    await fs.mkdir(vault, { recursive: true });
+    await git(vault, "init", "--initial-branch=main");
+    await fs.writeFile(path.join(vault, ".gitkeep"), "");
+    await git(vault, "add", ".gitkeep");
+    await git(vault, "commit", "-m", "init");
+    await git(vault, "config", "protocol.file.allow", "always");
+
+    const diskRoot = path.join(workDir, "appdisk");
+    await fs.mkdir(diskRoot, { recursive: true });
+
+    fakeApp = {
+      vault: {
+        getMarkdownFiles: () => [],
+        adapter: {
+          read: async (p: string) => fs.readFile(path.join(diskRoot, p), "utf8"),
+          exists: async (p: string) =>
+            fs
+              .access(path.join(diskRoot, p))
+              .then(() => true)
+              .catch(() => false),
+          write: async (p: string, content: string) => {
+            const abs = path.join(diskRoot, p);
+            await fs.mkdir(path.dirname(abs), { recursive: true });
+            await fs.writeFile(abs, content);
+          },
+        },
+        configDir: ".obsidian",
+      },
+      metadataCache: { getFileCache: () => null },
+    } as unknown as App;
+
+    store = new PluginLocalDataStore({
+      app: fakeApp,
+      path: "data.local.json",
+    });
+    await store.init();
+    tracker = new StagingDirTracker({
+      localDataStore: store,
+      tmpdirBase: workDir,
+    });
+    mockClient = {
+      fetchTarballBuffer: jest.fn(),
+    };
+    mgr = new AssetSpaceManager({
+      app: fakeApp,
+      client: mockClient as never,
+      notifications: {
+        info: () => undefined,
+        success: () => undefined,
+        error: () => undefined,
+        warn: () => undefined,
+        confirm: async () => true,
+      },
+      stagingTracker: tracker,
+    });
+  });
+
+  afterEach(async () => {
+    if (workDir) await cleanDir(workDir);
+  });
+
+  it("staging payload can be moved into vault + integrated via git submodule add", async () => {
+    // 1. Build real tarball — wrapper `kitelev-exoas-foo-deadbef/`.
+    const wrapper = "kitelev-exoas-foo-deadbef";
+    const files = [
+      { name: `${wrapper}/README.md`, data: new TextEncoder().encode("# foo\n") },
+      { name: `${wrapper}/sub/a.md`, data: new TextEncoder().encode("# A\n") },
+    ];
+    const tarBuf = createTar(files);
+    const blob = await new Response(
+      new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(tarBuf);
+          c.close();
+        },
+      }).pipeThrough(new CompressionStream("gzip")),
+    ).arrayBuffer();
+    mockClient.fetchTarballBuffer.mockResolvedValue(blob);
+
+    // 2. Pull AssetSpace — should populate staging with wrapper-stripped layout.
+    const result = await mgr.pullAssetSpace(
+      "foo-uid",
+      "https://github.com/kitelev/exoas-foo",
+    );
+    expect(result.sha).toBe("deadbef");
+    const readme = await fs.readFile(
+      path.join(result.stagingPath, "README.md"),
+      "utf8",
+    );
+    expect(readme).toBe("# foo\n");
+
+    // 3. Initialise a real bare remote that mirrors what staging holds.
+    const remote = await makeBareRemoteWithCommit(workDir, "foo-remote");
+    const seedClone = path.join(workDir, "seed");
+    await git(workDir, "clone", remote, seedClone);
+    // Replace seed clone contents with staging files.
+    for (const child of await fs.readdir(seedClone)) {
+      if (child === ".git") continue;
+      await fs.rm(path.join(seedClone, child), { recursive: true, force: true });
+    }
+    for (const entry of await fs.readdir(result.stagingPath, { withFileTypes: true })) {
+      const src = path.join(result.stagingPath, entry.name);
+      const dst = path.join(seedClone, entry.name);
+      await fs.cp(src, dst, { recursive: true });
+    }
+    await git(seedClone, "add", ".");
+    await git(seedClone, "commit", "-m", "import staging");
+    await git(seedClone, "push", "origin", "main");
+
+    // 4. Add as submodule в vault — handoff completes.
+    await git(
+      vault,
+      "submodule",
+      "add",
+      `file://${remote}`,
+      "assetspaces/foo",
+    );
+    // Verify .git/modules/foo/ populated.
+    expect(
+      await fs
+        .access(path.join(vault, ".git", "modules", "assetspaces/foo"))
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(true);
+    // Verify content reachable through submodule work-tree.
+    const submoduleReadme = await fs.readFile(
+      path.join(vault, "assetspaces/foo/README.md"),
+      "utf8",
+    );
+    expect(submoduleReadme).toBe("# foo\n");
+
+    // 5. Phase 3 will own the staging-release step — release here for cleanup.
+    await tracker.release(result.stagingPath);
+  }, 60000);
+});
+
+// ─── 4. StagingDirTracker concurrency ──────────────────────────────────────
+
+describe("Phase 5 P1.4 — StagingDirTracker concurrency", () => {
+  let workDir: string;
+
+  beforeEach(async () => {
+    workDir = await makeDisposableDir("exo-p1-concurrent-");
+  });
+
+  afterEach(async () => {
+    if (workDir) await cleanDir(workDir);
+  });
+
+  it("Promise.all of N concurrent allocate() produces N distinct registered paths", async () => {
+    const diskRoot = path.join(workDir, "appdisk");
+    await fs.mkdir(diskRoot, { recursive: true });
+    const fakeApp = {
+      vault: {
+        getMarkdownFiles: () => [],
+        adapter: {
+          read: async (p: string) => fs.readFile(path.join(diskRoot, p), "utf8"),
+          exists: async (p: string) =>
+            fs
+              .access(path.join(diskRoot, p))
+              .then(() => true)
+              .catch(() => false),
+          write: async (p: string, content: string) => {
+            const abs = path.join(diskRoot, p);
+            await fs.mkdir(path.dirname(abs), { recursive: true });
+            await fs.writeFile(abs, content);
+          },
+        },
+        configDir: ".obsidian",
+      },
+      metadataCache: { getFileCache: () => null },
+    } as unknown as App;
+    const store = new PluginLocalDataStore({
+      app: fakeApp,
+      path: "data.local.json",
+    });
+    await store.init();
+    const tracker = new StagingDirTracker({
+      localDataStore: store,
+      tmpdirBase: workDir,
+    });
+
+    const N = 8;
+    const paths = await Promise.all(
+      Array.from({ length: N }, (_, i) => tracker.allocate(`uid-${i}`)),
+    );
+
+    // All distinct
+    const uniq = new Set(paths);
+    expect(uniq.size).toBe(N);
+
+    // All registered persistently
+    const tracked = await store.readActiveStagingDirs();
+    expect(tracked).toHaveLength(N);
+    for (const p of paths) {
+      expect(tracked.some((e) => e.path === p)).toBe(true);
+    }
+
+    // All exist on disk
+    for (const p of paths) {
+      expect(
+        await fs
+          .access(p)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(true);
+    }
+  }, 30000);
+});
+
+// ─── Helper: remove a single [submodule "<name>"] section by exact name ────
+
+function removeSubmoduleSection(content: string, name: string): string {
+  const lines = content.split("\n");
+  const out: string[] = [];
+  let skipping = false;
+  const headerRegex = /^\[submodule "(.+)"\]\s*$/;
+  for (const line of lines) {
+    const m = line.match(headerRegex);
+    if (m) {
+      skipping = m[1] === name;
+      if (!skipping) out.push(line);
+      continue;
+    }
+    if (!skipping) out.push(line);
+  }
+  return out.join("\n");
+}


### PR DESCRIPTION
## Summary

Converts the `AssetSpaceManager.pullAssetSpace` stub into a real implementation per RFC `22b50a17` Phase 1. Wires `GitHubRestClient.fetchTarballBuffer` + `TarExtractor.extract` + new `StagingDirTracker` chain. Closes the Phase 5 sub-project [3dd9204d](https://github.com/kitelev/exocortex/issues?q=3dd9204d) (Milestone `8db8be0a`).

## Key Architectural Decisions

- **`GitHubRestClient.fetchTarballBuffer`** (new) returns raw `ArrayBuffer` so consumers can route через `TarExtractor` for zip-slip safety. `pullTarball()` refactored to call it internally (back-compat preserved).
- **`StagingDirTracker`** (new) — allocate/release/sweepOrphans with per-tracker async-mutex (`runSerial`) serialising registry RMW. Wired в `ExocortexPlugin.onload()` для R26 orphan-cleanup with `Platform.isMobile` guard.
- **F1 wrapper-strip** — `discoverWrapperDir` reads first entry's leading segment, validates ALL entries share it (defense-in-depth), then materializes via slice-strip. NO `--strip-components` flag bypass.
- **Cleanup contract**: ANY error after `stagingTracker.allocate` triggers `release(stagingPath)` in catch → no leaked temp dirs.
- **Defense-in-depth zip-slip**: TarExtractor's 4 layers (absolute path, `..`, sym/hardlinks, prefix gate) + post-strip `path.resolve` containment check. Even с `stagingDirPrefix: ""` (required для unknown wrapper), the remaining 3 layers + resolve-check keep escape blocked.

## Test Coverage

- **17 unit tests** (`AssetSpaceManager.pullAssetSpace.test.ts`):
  - Happy path с real `nanotar.createTar` fixtures + native gzip
  - Network drop (cleanup verified)
  - Corrupt tarball (parse error → cleanup)
  - Absolute-path zip-slip (TarExtractor rejects)
  - Wrapper-dir mismatch (PullError)
  - Size cap exceeded (50 MB)
  - Rate-limit pre-flight (advisor round-2 catch)
  - StagingDirTracker orphan sweep (× 2 scenarios)
  - Helper coverage (`discoverWrapperDir` × 4, `extractShaFromWrapper` × 4)

  Empirically verified to FAIL pre-fix (3 fail) и PASS post-fix (17 pass).

- **5 integration tests** (`AssetSpaceManager.integration.test.ts`) — real `git` CLI against disposable bare-repo remotes:
  - **F5 M2 BLOCKER recipe** — orphan `.git/modules/<as>/` requires explicit `rm -rf`
  - Submodule re-add after deinit + cleanup
  - `.gitmodules` atomic rewrite via temp-file + rename
  - **E2E** pullAssetSpace → staging → manual `git submodule add` handoff
  - StagingDirTracker concurrency (`Promise.all` × 8 distinct paths)

## Scope Discipline

Per advisor round-1, **NO `SubmoduleManager` class shipped** — submodule lifecycle stays Phase 3 territory (`hardSwitchProfile`). Integration tests act as POC documenting the recipe Phase 3 will encode.

Per RFC §«Что НЕ делать»:
- `destroyAssetSpace` + `restoreFromCache` stubs preserved (Phase 2 SwitchCacheLayer)
- TS-floor preservation guard NOT added (Phase 3)
- SwitchCacheLayer pre-destroy verify NOT added (Phase 2)
- Spike's `--strip-components=1` NOT ported (wrong fix для Phase 1 callsite)

## Code Review

- **code-reviewer agent**: APPROVE, 0 CRITICAL/HIGH/MEDIUM, 4 LOW. All 4 fixes applied + committed (sweepOrphans through runSerial, ensureRateLimit pre-flight, test title, dead-code comment).
- **advisor round-2**: rate-limit pre-flight test added (new code-path coverage). Sweep mutex semantics verified — concurrency test still green.

## Test plan

- [x] `npm run check:types` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] 22 P1-suite tests pass (17 unit + 5 integration)
- [x] 197/197 in extended scope (AssetSpaceManager + GitHubRestClient + TarExtractor + PluginLocalDataStore + AssetSpaceLookupHelper + security suites)
- [x] revert-fail / restore-pass empirical verification (sub-discipline per `~/dotfiles/.claude/rules/integration-test-revert-verify.md`)
- [x] pre-existing `sparql-exo003.integration.test.ts` failure verified unrelated (10/10 fail на `origin/main` без my changes)
- [ ] CI green
- [ ] Manual squash-merge (NO `--auto` per CLAUDE.md auto-merge discipline — parser/infra territory)

## Refs

- RFC: `22b50a17-590e-462b-8850-3afd94a8dda7`
- Parent Project: `77f647aa-6223-4a86-9183-fd37a9065df9` (Phase 5)
- This Phase Project: `3dd9204d-8b23-4478-9935-cd015cbff628` (Phase 1)
- Milestone: `8db8be0a-bd62-4c2d-be46-2dc7d76e1834` (M_P1)
- Phase 0 findings: `/Users/kitelev/Developer/phase5-phase0-spike-findings-2026-06-02.md`