### PR TITLE
feat(focus-profile): Phase 5 P2 — operationalize SwitchCacheLayer (RFC 22b50a17)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -107,6 +107,8 @@ import { applyActiveProfileFilter } from "./infrastructure/adapters/FocusProfile
 import { lookupAssetSpaceUidByFolder } from "./infrastructure/adapters/AssetSpaceLookupHelper";
 import { createAssetSpacePusher } from "./infrastructure/adapters/AssetSpacePusherFactory";
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
+import { SwitchCacheLayer } from "./infrastructure/adapters/SwitchCacheLayer";
+import { ClearSwitchCacheConfirmModal } from "./infrastructure/adapters/ClearSwitchCacheConfirmModal";
 import {
   CommandExecutionFlow,
   DI_TOKENS,
@@ -2475,11 +2477,64 @@ export default class ExocortexPlugin extends Plugin {
       },
     });
 
+    // RFC 22b50a17 Decision #6 — wipe-all switch cache clearing.
+    this.addCommand({
+      id: "clear-switch-cache",
+      name: "Clear switch cache (wipe-all)",
+      callback: () => {
+        void this.invokeClearSwitchCache();
+      },
+    });
+
     this.logger.info(
       "[ExocortexPlugin] FocusProfile palette commands registered",
     );
 
     return reapplyActiveProfileFilter;
+  }
+
+  /**
+   * Handler for the «Exocortex: Clear switch cache» palette command
+   * (RFC 22b50a17 Decision #6 — wipe-all semantics).
+   *
+   * Flow:
+   *   1. Read current cache stats synchronously (count + totalSize).
+   *   2. If empty → surface a Notice and return.
+   *   3. Otherwise open `ClearSwitchCacheConfirmModal` — user must explicitly
+   *      click «Clear» to commit.
+   *   4. On commit, invoke `SwitchCacheLayer.clear()` and surface result.
+   *
+   * Errors from `clear()` surface as a user-facing error Notice — the
+   * cache directory is best-effort writable; partial clear is acceptable.
+   */
+  private async invokeClearSwitchCache(): Promise<void> {
+    const cache = new SwitchCacheLayer();
+    const stats = cache.getCacheStats();
+
+    if (stats.count === 0) {
+      this.notifier.info("Switch cache is already empty.");
+      return;
+    }
+
+    const confirmed = await new Promise<boolean>((resolve) => {
+      const modal = new ClearSwitchCacheConfirmModal(
+        this.app,
+        { entryCount: stats.count, totalSize: stats.totalSize },
+        resolve,
+      );
+      modal.open();
+    });
+    if (!confirmed) return;
+
+    try {
+      const result = await cache.clear();
+      this.notifier.info(
+        `Cleared ${result.entriesRemoved} cache entries.`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.notifier.error(`Clear switch cache failed: ${msg}`);
+    }
   }
 
   /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ClearSwitchCacheConfirmModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ClearSwitchCacheConfirmModal.ts
@@ -1,0 +1,89 @@
+import { App, Modal } from "obsidian";
+
+/**
+ * ClearSwitchCacheConfirmModal — destructive-op confirm gate for the
+ * `Exocortex: Clear switch cache` palette command (RFC 22b50a17 Decision #6).
+ *
+ * Wipe-all semantics: removes ALL cached AssetSpace tarballs across all
+ * profiles. Operation cannot be undone — modal surfaces summary stats
+ * (count + total size) before user commits.
+ *
+ * Resolves `true` only when the user clicks the explicit «Clear» button
+ * (`mod-warning` class). Esc / Cancel / any close path resolves `false`
+ * to abort. Promise resolves exactly once even if user clicks before
+ * Obsidian's teardown lifecycle.
+ */
+export class ClearSwitchCacheConfirmModal extends Modal {
+  private resolved = false;
+  private readonly entryCount: number;
+  private readonly totalSize: number;
+  private readonly resolveFn: (approved: boolean) => void;
+
+  constructor(
+    app: App,
+    summary: { entryCount: number; totalSize: number },
+    resolve: (approved: boolean) => void,
+  ) {
+    super(app);
+    this.entryCount = summary.entryCount;
+    this.totalSize = summary.totalSize;
+    this.resolveFn = resolve;
+  }
+
+  private settle(value: boolean): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.resolveFn(value);
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.createEl("h2", {
+      cls: "clear-switch-cache-title",
+      text: "Clear switch cache?",
+    });
+    contentEl.createEl("p", {
+      text:
+        `${this.entryCount} cached AssetSpace ${this.entryCount === 1 ? "entry" : "entries"} ` +
+        `will be removed (${formatBytes(this.totalSize)}). This cannot be undone.`,
+    });
+    contentEl.createEl("p", {
+      cls: "clear-switch-cache-detail",
+      text:
+        "Wipe-all semantics per RFC 22b50a17 Decision #6 — no per-profile " +
+        "selection. Cached profiles will require fresh pulls on next switch.",
+    });
+
+    const actions = contentEl.createEl("div", {
+      cls: "modal-button-container clear-switch-cache-actions",
+    });
+
+    const cancelBtn = actions.createEl("button", { text: "Cancel" });
+    cancelBtn.addEventListener("click", () => {
+      this.settle(false);
+      this.close();
+    });
+
+    const confirmBtn = actions.createEl("button", {
+      cls: "mod-warning",
+      text: "Clear",
+    });
+    confirmBtn.addEventListener("click", () => {
+      this.settle(true);
+      this.close();
+    });
+  }
+
+  override onClose(): void {
+    // If user dismissed without explicit Clear, treat as Cancel.
+    this.settle(false);
+    this.contentEl.empty();
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
@@ -1,171 +1,560 @@
-/**
- * SwitchCacheLayer — infrastructure scaffold для FocusProfile switch cache
- * (RFC 0a0791c1 §B.5). In v3 backward-compat mode: API surface complete,
- * storage is **in-memory only**. Real filesystem cache I/O deferred to
- * Phase C+D when B.3's pull/restore stubs activate.
- *
- * Why in-memory only (v3):
- * - B.3's `pullAssetSpace` + `restoreFromCache` throw «Phase C+D not implemented»;
- *   nothing populates the cache at runtime.
- * - Settings UI (B.8) wires `getCacheStats()` and shows zeros — acceptable
- *   user-visible behavior since profile switching in v3 only re-indexes RDF
- *   (no filesystem snapshot needed).
- * - Real fs storage location is platform-specific (macOS Library/Caches vs iOS
- *   app data dir) and adaptive-cap requires disk-space probing — both deferred
- *   с Vision Lock #C+D scope split.
- *
- * Activation path (Phase C+D):
- * 1. Replace `Map<string, CacheEntry>` storage with `vault.adapter`/`fs/promises`
- *    filesystem adapter (platform-detected location)
- * 2. Implement `computeAdaptiveCap` to read free disk (statvfs / fs.statfsSync)
- * 3. Wire B.3 `pullAssetSpace` to call `cacheAssetSpace` post-pull
- * 4. Wire B.3 `restoreFromCache` to call `restoreCachedAssetSpace`
- *
- * API surface (frozen в B.5, callers can rely on it):
- * - `cacheAssetSpace(asUid, files)`
- * - `restoreCachedAssetSpace(asUid): Map | null`
- * - `evictOldest(targetSize)` — LRU eviction
- * - `getCacheStats()` — `{count, totalSize, oldestEntry}`
- */
+// Node.js builtins required for switch-cache directory ops outside the
+// Obsidian vault — RFC 22b50a17 §Key sub-systems B.5. Default cache root
+// is `~/Library/Caches/exocortex/switch-cache/` (macOS desktop). Obsidian's
+// `vault.adapter` API only addresses vault-relative paths, so OS-level
+// caches must use Node directly. Mobile is guarded by `Platform.isMobile`
+// throw at every public entry point — Phase 5 hard switch is desktop-only.
+/* eslint-disable no-restricted-imports, import/no-nodejs-modules */
+import { promises as fsPromises } from "node:fs";
+import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+/* eslint-enable no-restricted-imports, import/no-nodejs-modules */
+import { Platform } from "obsidian";
+import { createTarGzip, parseTarGzip, type TarFileInput } from "nanotar";
 
-export type FileBlob = Uint8Array;
+/**
+ * SwitchCacheLayer — filesystem-backed AssetSpace snapshot cache for
+ * FocusProfile hard switch (RFC 22b50a17 §Key sub-systems B.5).
+ *
+ * Layout (Decision #6 — wipe-all retention model):
+ *   <cacheDir>/<asUid>/<sha>.tar.gz   — gzip tarball (F1 content-root convention)
+ *   <cacheDir>/<asUid>/<sha>.meta.json — sidecar { asUid, sha, cachedAt, sizeBytes }
+ *
+ * Default cacheDir = `~/Library/Caches/exocortex/switch-cache/` (macOS desktop).
+ * Constructor accepts a `cacheDir` override for test injection.
+ *
+ * Three invariants:
+ *   F1  — Cache-side content-root: tarball entries are `a.md`, `subdir/b.md`
+ *         (no wrapper directory). Restore writes them directly under the
+ *         target dir — NO path-stripping needed (would yield empty target).
+ *   F6  — verify-before-return: after archive write, `cache()` checks file
+ *         exists + non-empty + parseable + non-zero entries. Failure throws
+ *         CacheWriteError BEFORE caller proceeds to destroy uncached data.
+ *   R28 — SHA-aware: sidecar stores SHA + cachedAt. `has(uid, sha)` answers
+ *         "is THIS revision cached" so caller can fall back к fresh pull if
+ *         upstream HEAD moved.
+ *
+ * Mobile: every public entry point throws via `Platform.isMobile` — Phase 5
+ * hard switch is desktop-only (depends on git submodule ops + Node fs).
+ *
+ * Sync `getCacheStats()` is preserved for the v3 Settings UI render-path
+ * (`ExocortexSettingTab.renderFocusProfileSections`). Reads cache dir
+ * synchronously — fast enough for the small entry counts expected.
+ */
 
 export interface CacheEntry {
   asUid: string;
-  files: Map<string, FileBlob>;
-  /** Bytes total (sum of all blobs in this entry). */
-  size: number;
-  /** Epoch ms when entry was first cached. */
-  cachedAt: number;
-  /** Epoch ms last touched (read or write) — used by LRU eviction. */
-  lastTouched: number;
+  sha: string;
+  /** ISO-8601 timestamp when archive was written. */
+  cachedAt: string;
+  sizeBytes: number;
 }
 
 export interface CacheStats {
-  /** Number of AssetSpace entries currently cached. */
+  /** Number of cached tarballs across all AssetSpace dirs. */
   count: number;
-  /** Aggregate byte size across all entries. */
+  /** Aggregate byte size of all cached tarballs. */
   totalSize: number;
   /** ISO timestamp of the oldest entry's `cachedAt`, or null if empty. */
   oldestEntry: string | null;
 }
 
-export interface SwitchCacheLayerOptions {
-  /**
-   * Maximum cache size in bytes. Defaults to `50 MB` (50 * 1024 * 1024).
-   * In Phase C+D будет computed adaptively as `max(50MB, 5% free disk)`
-   * per Architect #9; in v3 this is a fixed cap.
-   */
-  maxBytes?: number;
-  /** Injectable `Date.now` для deterministic tests. */
-  now?: () => number;
+export interface ICacheLayer {
+  cache(asUid: string, sourceDir: string, sha: string): Promise<CacheEntry>;
+  has(asUid: string, expectedSha?: string): Promise<boolean>;
+  restore(asUid: string, targetDir: string): Promise<{ sha: string }>;
+  clear(): Promise<{ entriesRemoved: number }>;
+  listEntries(): Promise<ReadonlyArray<CacheEntry>>;
+  getCacheDir(): string;
+  getCacheStats(): CacheStats;
 }
 
-const DEFAULT_MAX_BYTES = 50 * 1024 * 1024;
+export interface SwitchCacheLayerOptions {
+  /** Override cache root directory (test injection). */
+  cacheDir?: string;
+}
 
-export class SwitchCacheLayer {
-  private readonly entries = new Map<string, CacheEntry>();
-  private readonly maxBytes: number;
-  private readonly now: () => number;
+export class CacheWriteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CacheWriteError";
+  }
+}
+
+export class CacheMissError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CacheMissError";
+  }
+}
+
+export class SwitchCacheLayer implements ICacheLayer {
+  private readonly cacheDir: string;
 
   constructor(options: SwitchCacheLayerOptions = {}) {
-    this.maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
-    this.now = options.now ?? (() => Date.now());
+    this.cacheDir =
+      options.cacheDir ??
+      path.join(os.homedir(), "Library", "Caches", "exocortex", "switch-cache");
+  }
+
+  getCacheDir(): string {
+    return this.cacheDir;
   }
 
   /**
-   * Cache a snapshot of an AssetSpace's files. Overwrites any existing entry
-   * for the same `asUid`. Triggers LRU eviction if total size would exceed cap.
+   * Archive `sourceDir` content into `<cacheDir>/<asUid>/<sha>.tar.gz` plus
+   * sidecar meta. Verifies the archive parses + is non-empty BEFORE returning
+   * — caller depends on this contract (F6).
    *
-   * @param asUid AssetSpace UID (vault frontmatter `exo__Asset_uid`)
-   * @param files Map of `vault-relative-path → file content bytes`
+   * @throws CacheWriteError if archive write failed in any verifiable way.
    */
-  async cacheAssetSpace(asUid: string, files: Map<string, FileBlob>): Promise<void> {
-    const t = this.now();
-    const size = SwitchCacheLayer.sumBlobBytes(files);
+  async cache(
+    asUid: string,
+    sourceDir: string,
+    sha: string,
+  ): Promise<CacheEntry> {
+    this.assertDesktop("cache");
+    if (!existsSync(sourceDir)) {
+      throw new CacheWriteError(`Source directory does not exist: ${sourceDir}`);
+    }
+    const cachePath = this.getCachePath(asUid, sha);
+    const metaPath = this.getMetaPath(asUid, sha);
+    await fsPromises.mkdir(path.dirname(cachePath), { recursive: true });
+
+    // Build tar input list with content-root convention (entries like
+    // "a.md", "subdir/b.md" — no wrapper directory).
+    let inputs: TarFileInput[];
+    try {
+      inputs = await this.collectTarInputs(sourceDir);
+    } catch (err) {
+      throw new CacheWriteError(
+        `Failed to enumerate source ${sourceDir}: ${errorMessage(err)}`,
+      );
+    }
+
+    let archive: Uint8Array;
+    try {
+      archive = await createTarGzip(inputs);
+    } catch (err) {
+      throw new CacheWriteError(
+        `tar create failed for ${asUid}@${sha}: ${errorMessage(err)}`,
+      );
+    }
+
+    try {
+      await fsPromises.writeFile(cachePath, archive);
+    } catch (err) {
+      await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+      throw new CacheWriteError(
+        `Cache file write failed for ${cachePath}: ${errorMessage(err)}`,
+      );
+    }
+
+    // F6: verify-before-return.
+    if (!existsSync(cachePath)) {
+      throw new CacheWriteError(`Cache file not written: ${cachePath}`);
+    }
+    let sizeBytes: number;
+    try {
+      const stat = await fsPromises.stat(cachePath);
+      sizeBytes = stat.size;
+    } catch (err) {
+      throw new CacheWriteError(
+        `Cannot stat cache file ${cachePath}: ${errorMessage(err)}`,
+      );
+    }
+    if (sizeBytes === 0) {
+      await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+      throw new CacheWriteError(`Cache file empty: ${cachePath}`);
+    }
+    // Verify archive parses + has non-zero entries.
+    try {
+      const buf = await fsPromises.readFile(cachePath);
+      const parsed = await parseTarGzip(buf);
+      if (!Array.isArray(parsed) || parsed.length === 0) {
+        await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+        throw new CacheWriteError(
+          `Cache archive has no entries: ${cachePath}`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof CacheWriteError) throw err;
+      await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+      throw new CacheWriteError(
+        `Cache archive corrupted: ${errorMessage(err)}`,
+      );
+    }
+
     const entry: CacheEntry = {
       asUid,
-      files: new Map(files),
-      size,
-      cachedAt: t,
-      lastTouched: t,
+      sha,
+      cachedAt: new Date().toISOString(),
+      sizeBytes,
     };
-
-    // Free space first if the new entry alone would exceed cap.
-    if (size > this.maxBytes) {
-      // Entry too large to ever fit — refuse silently (per Phase C+D safety: do not throw).
-      return;
+    try {
+      await fsPromises.writeFile(
+        metaPath,
+        JSON.stringify(entry, null, 2),
+        "utf8",
+      );
+    } catch (err) {
+      // Sidecar meta is required for restore() to pick newest entry.
+      await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+      throw new CacheWriteError(
+        `Sidecar meta write failed for ${metaPath}: ${errorMessage(err)}`,
+      );
     }
-
-    this.entries.set(asUid, entry);
-    await this.evictOldest(this.maxBytes);
+    return entry;
   }
 
   /**
-   * Retrieve a cached AssetSpace snapshot. Returns `null` if not cached.
-   * Touches `lastTouched` for LRU bookkeeping.
+   * Check whether `asUid` has any cached entry. If `expectedSha` is given,
+   * answers only for that specific revision (R28 — SHA-aware).
    */
-  async restoreCachedAssetSpace(asUid: string): Promise<Map<string, FileBlob> | null> {
-    const entry = this.entries.get(asUid);
-    if (!entry) return null;
-    entry.lastTouched = this.now();
-    // Return a copy to avoid caller mutating cached state.
-    return new Map(entry.files);
+  async has(asUid: string, expectedSha?: string): Promise<boolean> {
+    this.assertDesktop("has");
+    if (expectedSha !== undefined) {
+      return existsSync(this.getCachePath(asUid, expectedSha));
+    }
+    const dir = path.join(this.cacheDir, asUid);
+    if (!existsSync(dir)) return false;
+    try {
+      const entries = await fsPromises.readdir(dir);
+      return entries.some((e) => e.endsWith(".tar.gz"));
+    } catch {
+      return false;
+    }
   }
 
   /**
-   * Evict least-recently-touched entries until aggregate size ≤ `targetSize`.
-   * No-op if already under target.
+   * Extract the newest-by-cachedAt cached tarball for `asUid` to `targetDir`.
+   * Files land directly under `targetDir/<file>` (F1 — no wrapper directory
+   * to strip).
+   *
+   * @throws CacheMissError if no cached entries exist.
    */
-  async evictOldest(targetSize: number): Promise<void> {
-    while (this.totalSize() > targetSize && this.entries.size > 0) {
-      const oldestUid = this.findOldestUid();
-      if (oldestUid === null) break;
-      this.entries.delete(oldestUid);
+  async restore(
+    asUid: string,
+    targetDir: string,
+  ): Promise<{ sha: string }> {
+    this.assertDesktop("restore");
+    const dir = path.join(this.cacheDir, asUid);
+    if (!existsSync(dir)) {
+      throw new CacheMissError(`No cache entries для ${asUid}`);
     }
-  }
-
-  /** Synchronous stats snapshot — wired into Settings UI display (B.8). */
-  getCacheStats(): CacheStats {
-    if (this.entries.size === 0) {
-      return { count: 0, totalSize: 0, oldestEntry: null };
+    let files: string[];
+    try {
+      files = await fsPromises.readdir(dir);
+    } catch (err) {
+      throw new CacheMissError(
+        `Cannot read cache dir ${dir}: ${errorMessage(err)}`,
+      );
     }
-    let oldest = Infinity;
-    let totalSize = 0;
-    for (const entry of this.entries.values()) {
-      totalSize += entry.size;
-      if (entry.cachedAt < oldest) oldest = entry.cachedAt;
+    const metaFiles = files.filter((f) => f.endsWith(".meta.json"));
+    if (metaFiles.length === 0) {
+      throw new CacheMissError(`No cache entries для ${asUid}`);
     }
-    return {
-      count: this.entries.size,
-      totalSize,
-      oldestEntry: new Date(oldest).toISOString(),
-    };
-  }
-
-  // === Helpers ===
-
-  private totalSize(): number {
-    let sum = 0;
-    for (const entry of this.entries.values()) sum += entry.size;
-    return sum;
-  }
-
-  private findOldestUid(): string | null {
-    let oldestUid: string | null = null;
-    let oldestTouched = Infinity;
-    for (const [uid, entry] of this.entries) {
-      if (entry.lastTouched < oldestTouched) {
-        oldestTouched = entry.lastTouched;
-        oldestUid = uid;
+    const entries: CacheEntry[] = [];
+    for (const metaFile of metaFiles) {
+      const metaPath = path.join(dir, metaFile);
+      try {
+        const raw = await fsPromises.readFile(metaPath, "utf8");
+        const parsed = JSON.parse(raw) as CacheEntry;
+        if (
+          typeof parsed?.asUid === "string" &&
+          typeof parsed?.sha === "string" &&
+          typeof parsed?.cachedAt === "string"
+        ) {
+          // Sanity check: tarball must still exist next to the sidecar.
+          if (existsSync(this.getCachePath(parsed.asUid, parsed.sha))) {
+            entries.push(parsed);
+          }
+        }
+      } catch {
+        // Skip unreadable / malformed sidecars; keep scanning.
       }
     }
-    return oldestUid;
+    if (entries.length === 0) {
+      throw new CacheMissError(
+        `No valid cache entries found для ${asUid} (sidecars unreadable or orphaned)`,
+      );
+    }
+    entries.sort((a, b) => b.cachedAt.localeCompare(a.cachedAt));
+    const newest = entries[0];
+
+    await fsPromises.mkdir(targetDir, { recursive: true });
+    const archive = await fsPromises.readFile(
+      this.getCachePath(newest.asUid, newest.sha),
+    );
+    let parsed;
+    try {
+      parsed = await parseTarGzip(archive);
+    } catch (err) {
+      throw new CacheMissError(
+        `Failed to parse cached archive для ${asUid}@${newest.sha}: ${errorMessage(err)}`,
+      );
+    }
+    // F1: write entries directly under targetDir — no strip required.
+    for (const item of parsed) {
+      if (!item.name) continue;
+      // Reject absolute paths / `..` traversal — nanotar already normalises
+      // but defense-in-depth is cheap (mirrors TarExtractor's zip-slip guard).
+      if (
+        item.name.startsWith("/") ||
+        item.name.includes("..") ||
+        item.name.includes("\\")
+      ) {
+        throw new CacheMissError(
+          `Unsafe entry path в cached archive: ${item.name}`,
+        );
+      }
+      const destPath = path.join(targetDir, item.name);
+      const normalisedDest = path.resolve(destPath);
+      const normalisedTarget = path.resolve(targetDir);
+      if (!normalisedDest.startsWith(normalisedTarget + path.sep) && normalisedDest !== normalisedTarget) {
+        throw new CacheMissError(
+          `Cache restore would escape target dir: ${item.name}`,
+        );
+      }
+      if (item.type === "directory") {
+        await fsPromises.mkdir(destPath, { recursive: true });
+        continue;
+      }
+      await fsPromises.mkdir(path.dirname(destPath), { recursive: true });
+      if (item.data) {
+        await fsPromises.writeFile(destPath, item.data);
+      } else {
+        // File entry с no data — write empty file (rare, but safe).
+        await fsPromises.writeFile(destPath, new Uint8Array(0));
+      }
+    }
+    return { sha: newest.sha };
   }
 
-  private static sumBlobBytes(files: Map<string, FileBlob>): number {
-    let sum = 0;
-    for (const blob of files.values()) sum += blob.byteLength;
-    return sum;
+  /**
+   * Remove ALL cached entries across ALL AssetSpace dirs (Decision #6
+   * wipe-all semantics). Returns count of removed `.tar.gz` files.
+   */
+  async clear(): Promise<{ entriesRemoved: number }> {
+    this.assertDesktop("clear");
+    if (!existsSync(this.cacheDir)) return { entriesRemoved: 0 };
+    let removed = 0;
+    let asUidDirs: string[];
+    try {
+      asUidDirs = await fsPromises.readdir(this.cacheDir);
+    } catch {
+      return { entriesRemoved: 0 };
+    }
+    for (const name of asUidDirs) {
+      const fullDir = path.join(this.cacheDir, name);
+      let isDir: boolean;
+      try {
+        const stat = await fsPromises.stat(fullDir);
+        isDir = stat.isDirectory();
+      } catch {
+        continue;
+      }
+      if (!isDir) continue;
+      try {
+        const entries = await fsPromises.readdir(fullDir);
+        const tarballs = entries.filter((f) => f.endsWith(".tar.gz"));
+        removed += tarballs.length;
+        await fsPromises.rm(fullDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort: skip dirs we cannot remove (permissions, etc.).
+      }
+    }
+    return { entriesRemoved: removed };
+  }
+
+  /**
+   * List all cache entries across all AssetSpace dirs. Useful для UI
+   * confirm dialogs (preview before clear) and tests.
+   */
+  async listEntries(): Promise<ReadonlyArray<CacheEntry>> {
+    this.assertDesktop("listEntries");
+    if (!existsSync(this.cacheDir)) return [];
+    let asUidDirs: string[];
+    try {
+      asUidDirs = await fsPromises.readdir(this.cacheDir);
+    } catch {
+      return [];
+    }
+    const all: CacheEntry[] = [];
+    for (const name of asUidDirs) {
+      const fullDir = path.join(this.cacheDir, name);
+      let isDir: boolean;
+      try {
+        const stat = await fsPromises.stat(fullDir);
+        isDir = stat.isDirectory();
+      } catch {
+        continue;
+      }
+      if (!isDir) continue;
+      let files: string[];
+      try {
+        files = await fsPromises.readdir(fullDir);
+      } catch {
+        continue;
+      }
+      for (const f of files) {
+        if (!f.endsWith(".meta.json")) continue;
+        try {
+          const raw = await fsPromises.readFile(path.join(fullDir, f), "utf8");
+          const parsed = JSON.parse(raw) as CacheEntry;
+          if (
+            typeof parsed?.asUid === "string" &&
+            typeof parsed?.sha === "string" &&
+            typeof parsed?.cachedAt === "string" &&
+            typeof parsed?.sizeBytes === "number"
+          ) {
+            all.push(parsed);
+          }
+        } catch {
+          // Skip malformed sidecar.
+        }
+      }
+    }
+    return all;
+  }
+
+  /**
+   * Synchronous stats snapshot for the v3 Settings UI display path
+   * (`ExocortexSettingTab.renderFocusProfileSections` builds its widget
+   * synchronously per Obsidian's `PluginSettingTab` contract).
+   *
+   * On mobile: returns zeros without touching Node fs. The Settings UI
+   * section is rendered desktop-side anyway, но this defends against any
+   * unexpected mobile invocation.
+   *
+   * Reads sidecar metas synchronously — fast enough for the small entry
+   * counts expected (one tarball per AssetSpace per cached revision).
+   * On any other error: returns zeros (display gracefully degrades).
+   */
+  getCacheStats(): CacheStats {
+    // Defensive: some test environments mock `obsidian` without exporting
+    // Platform. Treat undefined as desktop (current behaviour pre-mobile
+    // guard). Settings UI must not crash on stats render.
+    if (isPlatformMobile()) {
+      return { count: 0, totalSize: 0, oldestEntry: null };
+    }
+    if (!existsSync(this.cacheDir)) {
+      return { count: 0, totalSize: 0, oldestEntry: null };
+    }
+    let asUidDirs: string[];
+    try {
+      asUidDirs = readdirSync(this.cacheDir);
+    } catch {
+      return { count: 0, totalSize: 0, oldestEntry: null };
+    }
+    let count = 0;
+    let totalSize = 0;
+    let oldest: string | null = null;
+    for (const name of asUidDirs) {
+      const fullDir = path.join(this.cacheDir, name);
+      let isDir: boolean;
+      try {
+        isDir = statSync(fullDir).isDirectory();
+      } catch {
+        continue;
+      }
+      if (!isDir) continue;
+      let files: string[];
+      try {
+        files = readdirSync(fullDir);
+      } catch {
+        continue;
+      }
+      for (const f of files) {
+        if (!f.endsWith(".meta.json")) continue;
+        try {
+          const raw = readFileSync(path.join(fullDir, f), "utf8");
+          const parsed = JSON.parse(raw) as CacheEntry;
+          if (
+            typeof parsed?.cachedAt === "string" &&
+            typeof parsed?.sizeBytes === "number"
+          ) {
+            count += 1;
+            totalSize += parsed.sizeBytes;
+            if (oldest === null || parsed.cachedAt < oldest) {
+              oldest = parsed.cachedAt;
+            }
+          }
+        } catch {
+          // Skip malformed sidecar.
+        }
+      }
+    }
+    return { count, totalSize, oldestEntry: oldest };
+  }
+
+  // ─────────────────────────── internals ──────────────────────────────────
+
+  private getCachePath(asUid: string, sha: string): string {
+    return path.join(this.cacheDir, asUid, `${sha}.tar.gz`);
+  }
+
+  private getMetaPath(asUid: string, sha: string): string {
+    return path.join(this.cacheDir, asUid, `${sha}.meta.json`);
+  }
+
+  private assertDesktop(op: string): void {
+    if (isPlatformMobile()) {
+      throw new Error(
+        `SwitchCacheLayer.${op}: mobile not supported (RFC 22b50a17 is desktop-only)`,
+      );
+    }
+  }
+
+  /**
+   * Recursively walk `sourceDir`, building the list of TarFileInput entries
+   * with content-root convention (paths relative to `sourceDir`). Includes
+   * directories so empty subdirs are preserved on restore.
+   */
+  private async collectTarInputs(sourceDir: string): Promise<TarFileInput[]> {
+    const out: TarFileInput[] = [];
+    const stack: Array<{ abs: string; rel: string }> = [
+      { abs: sourceDir, rel: "" },
+    ];
+    for (;;) {
+      const next = stack.pop();
+      if (next === undefined) break;
+      const { abs, rel } = next;
+      const dirEntries = await fsPromises.readdir(abs, { withFileTypes: true });
+      for (const entry of dirEntries) {
+        const childAbs = path.join(abs, entry.name);
+        const childRel = rel === "" ? entry.name : `${rel}/${entry.name}`;
+        if (entry.isDirectory()) {
+          out.push({ name: `${childRel}/`, attrs: { mode: "755" } });
+          stack.push({ abs: childAbs, rel: childRel });
+        } else if (entry.isFile()) {
+          const data = await fsPromises.readFile(childAbs);
+          out.push({ name: childRel, data: new Uint8Array(data) });
+        }
+        // Skip symlinks / special files — same conservative stance as
+        // TarExtractor's zip-slip checks rejecting non-regular entries.
+      }
+    }
+    return out;
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/**
+ * Defensive `Platform.isMobile` reader — some test environments mock the
+ * `obsidian` module without exporting Platform. Treat `undefined` as
+ * desktop (the historic behaviour before this guard was added). Real
+ * Obsidian (desktop OR mobile) always exports Platform.
+ */
+function isPlatformMobile(): boolean {
+  try {
+    return Boolean(Platform?.isMobile);
+  } catch {
+    return false;
   }
 }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
@@ -9,6 +9,7 @@ import { promises as fsPromises } from "node:fs";
 import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { randomBytes } from "node:crypto";
 /* eslint-enable no-restricted-imports, import/no-nodejs-modules */
 import { Platform } from "obsidian";
 import { createTarGzip, parseTarGzip, type TarFileInput } from "nanotar";
@@ -142,45 +143,54 @@ export class SwitchCacheLayer implements ICacheLayer {
       );
     }
 
+    // Atomic write: tmp + rename. POSIX rename is atomic — eliminates
+    // partial-cache-on-crash class (MEDIUM-2 from code-review). Tmp paths
+    // use random suffix so concurrent cache() calls on the same uid+sha
+    // don't clobber each other's in-flight writes.
+    const tmpSuffix = `.tmp-${Date.now()}-${randomBytes(6).toString("hex")}`;
+    const cacheTmpPath = `${cachePath}${tmpSuffix}`;
+    const metaTmpPath = `${metaPath}${tmpSuffix}`;
+
     try {
-      await fsPromises.writeFile(cachePath, archive);
+      await fsPromises.writeFile(cacheTmpPath, archive);
     } catch (err) {
-      await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+      await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
       throw new CacheWriteError(
-        `Cache file write failed for ${cachePath}: ${errorMessage(err)}`,
+        `Cache file write failed for ${cacheTmpPath}: ${errorMessage(err)}`,
       );
     }
 
-    // F6: verify-before-return.
-    if (!existsSync(cachePath)) {
-      throw new CacheWriteError(`Cache file not written: ${cachePath}`);
-    }
+    // F6: verify-before-return on tmp file.
     let sizeBytes: number;
     try {
-      const stat = await fsPromises.stat(cachePath);
+      const stat = await fsPromises.stat(cacheTmpPath);
       sizeBytes = stat.size;
     } catch (err) {
+      await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
       throw new CacheWriteError(
-        `Cannot stat cache file ${cachePath}: ${errorMessage(err)}`,
+        `Cannot stat cache tmp ${cacheTmpPath}: ${errorMessage(err)}`,
       );
     }
     if (sizeBytes === 0) {
-      await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
-      throw new CacheWriteError(`Cache file empty: ${cachePath}`);
+      await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
+      throw new CacheWriteError(`Cache file empty: ${cacheTmpPath}`);
     }
-    // Verify archive parses + has non-zero entries.
+    // Verify archive parses + has non-zero entries — re-read from disk so
+    // F6 catches post-write filesystem corruption (write returned success
+    // but file truncated). Buffer (`archive`) is also in memory but reading
+    // back is the actual integrity check the F6 contract describes.
     try {
-      const buf = await fsPromises.readFile(cachePath);
+      const buf = await fsPromises.readFile(cacheTmpPath);
       const parsed = await parseTarGzip(buf);
       if (!Array.isArray(parsed) || parsed.length === 0) {
-        await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+        await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
         throw new CacheWriteError(
-          `Cache archive has no entries: ${cachePath}`,
+          `Cache archive has no entries: ${cacheTmpPath}`,
         );
       }
     } catch (err) {
       if (err instanceof CacheWriteError) throw err;
-      await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+      await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
       throw new CacheWriteError(
         `Cache archive corrupted: ${errorMessage(err)}`,
       );
@@ -192,17 +202,43 @@ export class SwitchCacheLayer implements ICacheLayer {
       cachedAt: new Date().toISOString(),
       sizeBytes,
     };
+    // Write sidecar tmp file FIRST — fails fast if filesystem is broken
+    // before we touch the cache final path.
     try {
       await fsPromises.writeFile(
-        metaPath,
+        metaTmpPath,
         JSON.stringify(entry, null, 2),
         "utf8",
       );
     } catch (err) {
-      // Sidecar meta is required for restore() to pick newest entry.
-      await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+      await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
       throw new CacheWriteError(
-        `Sidecar meta write failed for ${metaPath}: ${errorMessage(err)}`,
+        `Sidecar meta write failed for ${metaTmpPath}: ${errorMessage(err)}`,
+      );
+    }
+    // Atomic-rename phase: tar first, then sidecar. has(uid, sha) is
+    // sidecar-gated (see has() impl), so until the sidecar rename lands
+    // the entry is invisible to consumers — preserves has()↔restore()
+    // consistency invariant (MEDIUM-1 from code-review).
+    try {
+      await fsPromises.rename(cacheTmpPath, cachePath);
+    } catch (err) {
+      await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
+      await fsPromises.rm(metaTmpPath, { force: true }).catch(() => undefined);
+      throw new CacheWriteError(
+        `Atomic rename cache tmp→final failed: ${errorMessage(err)}`,
+      );
+    }
+    try {
+      await fsPromises.rename(metaTmpPath, metaPath);
+    } catch (err) {
+      // Sidecar rename failed — tar already at final path. Best-effort
+      // rollback: remove tar + meta tmp. has() will report false (sidecar
+      // missing); next cache() call overwrites cleanly.
+      await fsPromises.rm(cachePath, { force: true }).catch(() => undefined);
+      await fsPromises.rm(metaTmpPath, { force: true }).catch(() => undefined);
+      throw new CacheWriteError(
+        `Atomic rename sidecar tmp→final failed: ${errorMessage(err)}`,
       );
     }
     return entry;
@@ -211,17 +247,38 @@ export class SwitchCacheLayer implements ICacheLayer {
   /**
    * Check whether `asUid` has any cached entry. If `expectedSha` is given,
    * answers only for that specific revision (R28 — SHA-aware).
+   *
+   * Sidecar-gated: a cached entry is considered present ONLY when BOTH
+   * tarball and sidecar meta exist. This keeps `has()` and `restore()`
+   * truth-aligned — restore() skips entries without valid sidecars
+   * (line 270 sibling check), so has() must agree to avoid surprising the
+   * caller с a true→CacheMissError flip.
    */
   async has(asUid: string, expectedSha?: string): Promise<boolean> {
     this.assertDesktop("has");
     if (expectedSha !== undefined) {
-      return existsSync(this.getCachePath(asUid, expectedSha));
+      return (
+        existsSync(this.getCachePath(asUid, expectedSha)) &&
+        existsSync(this.getMetaPath(asUid, expectedSha))
+      );
     }
     const dir = path.join(this.cacheDir, asUid);
     if (!existsSync(dir)) return false;
     try {
       const entries = await fsPromises.readdir(dir);
-      return entries.some((e) => e.endsWith(".tar.gz"));
+      // An asUid has a valid cache entry iff at least one `<sha>.tar.gz`
+      // has a matching `<sha>.meta.json` sibling.
+      const tarballShas = new Set<string>();
+      const metaShas = new Set<string>();
+      for (const e of entries) {
+        if (e.endsWith(".tar.gz")) tarballShas.add(e.slice(0, -".tar.gz".length));
+        else if (e.endsWith(".meta.json"))
+          metaShas.add(e.slice(0, -".meta.json".length));
+      }
+      for (const sha of tarballShas) {
+        if (metaShas.has(sha)) return true;
+      }
+      return false;
     } catch {
       return false;
     }
@@ -298,11 +355,14 @@ export class SwitchCacheLayer implements ICacheLayer {
     // F1: write entries directly under targetDir — no strip required.
     for (const item of parsed) {
       if (!item.name) continue;
-      // Reject absolute paths / `..` traversal — nanotar already normalises
-      // but defense-in-depth is cheap (mirrors TarExtractor's zip-slip guard).
+      // Reject absolute paths / `..` traversal / backslashes — nanotar
+      // already normalises but defense-in-depth is cheap (mirrors
+      // TarExtractor's zip-slip guard). Check `..` as a path SEGMENT, not
+      // substring — `foo..bar.md` is a legitimate filename.
+      const segments = item.name.split("/");
       if (
         item.name.startsWith("/") ||
-        item.name.includes("..") ||
+        segments.includes("..") ||
         item.name.includes("\\")
       ) {
         throw new CacheMissError(

--- a/packages/obsidian-plugin/tests/unit/SwitchCacheLayer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SwitchCacheLayer.test.ts
@@ -266,7 +266,142 @@ describe("SwitchCacheLayer", () => {
     expect(fs.existsSync(path.join(path.dirname(targetDir), "escape.md"))).toBe(
       false,
     );
-    expect(fs.existsSync("/etc/passwd-attacker-marker")).toBe(false);
+    // Sanitised entries land at `escape.md` / `etc/passwd` UNDER targetDir.
+    expect(fs.existsSync(path.join(targetDir, "escape.md"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "etc", "passwd"))).toBe(true);
+  });
+
+  // ─── 13. has() requires sidecar (orphan tarball ignored) ─────────────
+  it("has(uid, sha) — returns false for orphan tarball without sidecar", async () => {
+    // Synthesize an orphan tarball at the canonical path (no sidecar).
+    const orphanDir = path.join(cacheDir, "uid-orphan");
+    fs.mkdirSync(orphanDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(orphanDir, "sha-orphan.tar.gz"),
+      new Uint8Array([0x1f, 0x8b, 0x08]), // gzip magic, doesn't matter
+    );
+    expect(await layer.has("uid-orphan", "sha-orphan")).toBe(false);
+    expect(await layer.has("uid-orphan")).toBe(false);
+  });
+
+  // ─── 14. restore() ignores orphan tarballs, picks newest valid ───────
+  it("restore() — ignores orphan tarballs, prefers entries with valid sidecars", async () => {
+    writeFile(sourceDir, "real.md", "real");
+    await layer.cache("uid-mix", sourceDir, "sha-good");
+
+    // Plant an orphan tarball with a newer ISO timestamp encoded in path
+    // (won't matter — orphan ignored by restore).
+    const dir = path.join(cacheDir, "uid-mix");
+    fs.writeFileSync(
+      path.join(dir, "sha-orphan.tar.gz"),
+      new Uint8Array([0x1f, 0x8b]),
+    );
+
+    const result = await layer.restore("uid-mix", targetDir);
+    expect(result.sha).toBe("sha-good");
+    expect(fs.existsSync(path.join(targetDir, "real.md"))).toBe(true);
+  });
+
+  // ─── 15. restore() skips malformed sidecar, errors if all malformed ──
+  it("restore() — skips malformed sidecar JSON, throws CacheMissError if no valid entries", async () => {
+    // Write a malformed sidecar + dangling tarball.
+    const dir = path.join(cacheDir, "uid-bad-meta");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "sha-x.tar.gz"),
+      new Uint8Array([0x1f, 0x8b]),
+    );
+    fs.writeFileSync(
+      path.join(dir, "sha-x.meta.json"),
+      "not-valid-json-{{{",
+      "utf8",
+    );
+    await expect(layer.restore("uid-bad-meta", targetDir)).rejects.toBeInstanceOf(
+      CacheMissError,
+    );
+  });
+
+  // ─── 16. restore() skips sidecar pointing to missing tarball ─────────
+  it("restore() — sidecar pointing to missing tarball is skipped", async () => {
+    const dir = path.join(cacheDir, "uid-orphan-meta");
+    fs.mkdirSync(dir, { recursive: true });
+    // Sidecar references sha-gone but no tarball file exists.
+    fs.writeFileSync(
+      path.join(dir, "sha-gone.meta.json"),
+      JSON.stringify({
+        asUid: "uid-orphan-meta",
+        sha: "sha-gone",
+        cachedAt: new Date().toISOString(),
+        sizeBytes: 100,
+      }),
+      "utf8",
+    );
+    await expect(
+      layer.restore("uid-orphan-meta", targetDir),
+    ).rejects.toBeInstanceOf(CacheMissError);
+  });
+});
+
+// ─── Mobile guard — every public entry throws on Platform.isMobile ──────
+describe("SwitchCacheLayer — mobile guard", () => {
+  let cacheDir: string;
+  let sourceDir: string;
+  let originalEnv: string | undefined;
+
+  beforeAll(() => {
+    originalEnv = process.env.TEST_PLATFORM;
+    process.env.TEST_PLATFORM = "mobile";
+    // Reset module cache so the obsidian mock re-evaluates Platform.isMobile.
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) delete process.env.TEST_PLATFORM;
+    else process.env.TEST_PLATFORM = originalEnv;
+    jest.resetModules();
+  });
+
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "switch-cache-mobile-"));
+    sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "switch-source-mobile-"));
+  });
+
+  afterEach(() => {
+    for (const d of [cacheDir, sourceDir]) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  });
+
+  it("all public async entry points throw 'mobile not supported' on isMobile=true", async () => {
+    // Re-import SwitchCacheLayer post-module-reset so it picks up the new
+    // Platform.isMobile=true value.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require("../../src/infrastructure/adapters/SwitchCacheLayer");
+    const Layer = mod.SwitchCacheLayer as typeof SwitchCacheLayer;
+    const layer = new Layer({ cacheDir });
+
+    await expect(layer.cache("uid", sourceDir, "sha")).rejects.toThrow(
+      /mobile not supported/,
+    );
+    await expect(layer.has("uid")).rejects.toThrow(/mobile not supported/);
+    await expect(layer.restore("uid", cacheDir)).rejects.toThrow(
+      /mobile not supported/,
+    );
+    await expect(layer.clear()).rejects.toThrow(/mobile not supported/);
+    await expect(layer.listEntries()).rejects.toThrow(/mobile not supported/);
+  });
+
+  it("getCacheStats() returns zeros on mobile (sync, no fs touch)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require("../../src/infrastructure/adapters/SwitchCacheLayer");
+    const Layer = mod.SwitchCacheLayer as typeof SwitchCacheLayer;
+    const layer = new Layer({ cacheDir });
+    const stats = layer.getCacheStats();
+    expect(stats).toEqual({ count: 0, totalSize: 0, oldestEntry: null });
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/SwitchCacheLayer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SwitchCacheLayer.test.ts
@@ -1,170 +1,316 @@
+/**
+ * @jest-environment node
+ *
+ * SwitchCacheLayer unit tests — adversarial cache/restore/has/clear flows.
+ *
+ * Uses real filesystem via `fs.mkdtempSync` for isolation per test.
+ * tar archive emit/parse is handled by nanotar (pure JS) — no `child_process`
+ * dependency in the production code, so tests don't need to inject binaries.
+ * Node environment is required because nanotar relies on Web APIs
+ * (CompressionStream/DecompressionStream, Response, TextEncoder) that
+ * jsdom does not provide.
+ *
+ * Per `test-fixture-realism.md`: production-shape fixtures only. Tests
+ * exercise the real archive lifecycle (collectTarInputs → createTarGzip →
+ * write → parseTarGzip → readback) — no API stubs that would hide
+ * regressions like the wrapper-dir convention break that was the spike's
+ * primary finding.
+ */
+
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+
 import {
   SwitchCacheLayer,
-  type FileBlob,
+  CacheWriteError,
+  CacheMissError,
+  type CacheEntry,
 } from "../../src/infrastructure/adapters/SwitchCacheLayer";
 
-const KB = 1024;
-
-function blob(size: number, fill: number = 0): FileBlob {
-  return new Uint8Array(size).fill(fill);
+function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
 }
 
-function makeFiles(spec: Array<[string, number]>): Map<string, FileBlob> {
-  const out = new Map<string, FileBlob>();
-  for (const [path, size] of spec) out.set(path, blob(size));
-  return out;
+function writeFile(targetDir: string, relative: string, content: string): void {
+  const fullPath = path.join(targetDir, relative);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, "utf8");
 }
 
-interface Clock {
-  current: number;
-  advance: (ms: number) => void;
-}
+describe("SwitchCacheLayer", () => {
+  let cacheDir: string;
+  let sourceDir: string;
+  let targetDir: string;
+  let layer: SwitchCacheLayer;
 
-function makeClock(start = 1_000_000): Clock {
-  let current = start;
-  return {
-    get current() {
-      return current;
-    },
-    advance: (ms: number) => {
-      current += ms;
-    },
-  };
-}
-
-// ─── cacheAssetSpace / restoreCachedAssetSpace ───────────────────────────
-
-describe("SwitchCacheLayer.cacheAssetSpace / restoreCachedAssetSpace", () => {
-  it("stores files и retrieves them as a copy", async () => {
-    const cache = new SwitchCacheLayer();
-    const files = makeFiles([["assetspaces/exo/a.md", 100], ["assetspaces/exo/b.md", 200]]);
-    await cache.cacheAssetSpace("uid-1", files);
-
-    const restored = await cache.restoreCachedAssetSpace("uid-1");
-    expect(restored).not.toBeNull();
-    expect(restored!.size).toBe(2);
-    expect(restored!.get("assetspaces/exo/a.md")!.byteLength).toBe(100);
+  beforeEach(() => {
+    cacheDir = makeTempDir("switch-cache-test");
+    sourceDir = makeTempDir("switch-source");
+    targetDir = makeTempDir("switch-target");
+    layer = new SwitchCacheLayer({ cacheDir });
   });
 
-  it("returned files map is decoupled (mutation does not affect cache)", async () => {
-    const cache = new SwitchCacheLayer();
-    await cache.cacheAssetSpace("uid-1", makeFiles([["x", 10]]));
-    const first = await cache.restoreCachedAssetSpace("uid-1");
-    first!.delete("x");
-
-    const second = await cache.restoreCachedAssetSpace("uid-1");
-    expect(second!.has("x")).toBe(true);
+  afterEach(() => {
+    for (const d of [cacheDir, sourceDir, targetDir]) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
   });
 
-  it("returns null for unknown asUid", async () => {
-    const cache = new SwitchCacheLayer();
-    expect(await cache.restoreCachedAssetSpace("nope")).toBeNull();
+  // ─── 1. cache() happy path ────────────────────────────────────────────
+  it("cache() — writes tarball + sidecar meta, returns CacheEntry", async () => {
+    writeFile(sourceDir, "a.md", "alpha");
+    writeFile(sourceDir, "b.md", "beta");
+
+    const entry = await layer.cache("uid-1", sourceDir, "sha-abc123");
+
+    expect(entry.asUid).toBe("uid-1");
+    expect(entry.sha).toBe("sha-abc123");
+    expect(entry.sizeBytes).toBeGreaterThan(0);
+    expect(entry.cachedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/); // ISO-8601
+
+    const tarballPath = path.join(cacheDir, "uid-1", "sha-abc123.tar.gz");
+    const metaPath = path.join(cacheDir, "uid-1", "sha-abc123.meta.json");
+    expect(fs.existsSync(tarballPath)).toBe(true);
+    expect(fs.existsSync(metaPath)).toBe(true);
+
+    const meta = JSON.parse(fs.readFileSync(metaPath, "utf8")) as CacheEntry;
+    expect(meta.sha).toBe("sha-abc123");
+    expect(meta.sizeBytes).toBe(entry.sizeBytes);
   });
 
-  it("overwrites existing entry for same asUid", async () => {
-    const cache = new SwitchCacheLayer();
-    await cache.cacheAssetSpace("uid-1", makeFiles([["a", 100]]));
-    await cache.cacheAssetSpace("uid-1", makeFiles([["b", 200], ["c", 300]]));
-    const restored = await cache.restoreCachedAssetSpace("uid-1");
-    expect(restored!.has("a")).toBe(false);
-    expect(restored!.size).toBe(2);
+  // ─── 2. cache() F6 — non-existent source rejected ────────────────────
+  it("cache() — throws CacheWriteError if sourceDir does not exist", async () => {
+    const missing = path.join(sourceDir, "does-not-exist");
+    await expect(
+      layer.cache("uid-x", missing, "sha-zz"),
+    ).rejects.toBeInstanceOf(CacheWriteError);
+
+    // No partial cache file should remain.
+    const tarballPath = path.join(cacheDir, "uid-x", "sha-zz.tar.gz");
+    expect(fs.existsSync(tarballPath)).toBe(false);
   });
 
-  it("refuses entry larger than maxBytes без adding to cache", async () => {
-    const cache = new SwitchCacheLayer({ maxBytes: 1 * KB });
-    await cache.cacheAssetSpace("huge", makeFiles([["x", 2 * KB]]));
-    expect(await cache.restoreCachedAssetSpace("huge")).toBeNull();
-    expect(cache.getCacheStats().count).toBe(0);
+  // ─── 3. cache() F6 — empty source rejected (no entries) ──────────────
+  it("cache() — throws CacheWriteError if sourceDir has no files (empty archive)", async () => {
+    // sourceDir exists but empty. Archive would have zero entries.
+    await expect(
+      layer.cache("uid-empty", sourceDir, "sha-empty"),
+    ).rejects.toBeInstanceOf(CacheWriteError);
+    const tarballPath = path.join(cacheDir, "uid-empty", "sha-empty.tar.gz");
+    expect(fs.existsSync(tarballPath)).toBe(false);
+  });
+
+  // ─── 4. cache() F6 — corrupted pre-existing archive cleanup ──────────
+  it("cache() — overwrites pre-existing corrupted archive cleanly", async () => {
+    // Pre-write a corrupted file at the target path. cache() must overwrite,
+    // and the F6 verify on the new write must succeed.
+    writeFile(sourceDir, "a.md", "real");
+    const cachePath = path.join(cacheDir, "uid-overwrite", "sha-v.tar.gz");
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(cachePath, "garbage-not-tar");
+
+    const entry = await layer.cache("uid-overwrite", sourceDir, "sha-v");
+    expect(entry.sizeBytes).toBeGreaterThan(0);
+
+    // Now the file should be a valid archive — restore should succeed.
+    const result = await layer.restore("uid-overwrite", targetDir);
+    expect(result.sha).toBe("sha-v");
+    expect(fs.existsSync(path.join(targetDir, "a.md"))).toBe(true);
+  });
+
+  // ─── 5. restore() F1 — plain extract (no wrapper, no strip) ──────────
+  it("restore() — content lands directly under targetDir (no double-nesting)", async () => {
+    writeFile(sourceDir, "a.md", "alpha");
+    writeFile(sourceDir, "subdir/b.md", "beta");
+
+    await layer.cache("uid-r", sourceDir, "sha-r1");
+
+    const result = await layer.restore("uid-r", targetDir);
+    expect(result.sha).toBe("sha-r1");
+
+    expect(fs.existsSync(path.join(targetDir, "a.md"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "subdir", "b.md"))).toBe(true);
+    expect(fs.readFileSync(path.join(targetDir, "a.md"), "utf8")).toBe("alpha");
+    expect(fs.readFileSync(path.join(targetDir, "subdir", "b.md"), "utf8")).toBe(
+      "beta",
+    );
+
+    // F1 anti-pattern check: must NOT have wrapper directory с asUid (would
+    // indicate cache-side wrapper convention with sibling --strip-components
+    // expected on restore — the rejected anti-pattern).
+    expect(fs.existsSync(path.join(targetDir, "uid-r"))).toBe(false);
+  });
+
+  // ─── 6. restore() picks newest by cachedAt ────────────────────────────
+  it("restore() — picks newest cachedAt entry when multiple SHAs exist", async () => {
+    writeFile(sourceDir, "v1.md", "v1");
+    await layer.cache("uid-multi", sourceDir, "sha-old");
+
+    // Wait briefly so ISO timestamps differ (millisecond resolution).
+    await new Promise((r) => setTimeout(r, 20));
+
+    fs.rmSync(path.join(sourceDir, "v1.md"));
+    writeFile(sourceDir, "v2.md", "v2");
+    await layer.cache("uid-multi", sourceDir, "sha-new");
+
+    const result = await layer.restore("uid-multi", targetDir);
+    expect(result.sha).toBe("sha-new");
+
+    expect(fs.existsSync(path.join(targetDir, "v2.md"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "v1.md"))).toBe(false);
+  });
+
+  // ─── 7. restore() cache miss ─────────────────────────────────────────
+  it("restore() — throws CacheMissError for unknown asUid", async () => {
+    await expect(layer.restore("uid-nope", targetDir)).rejects.toBeInstanceOf(
+      CacheMissError,
+    );
+  });
+
+  // ─── 8. has() с SHA (R28) ─────────────────────────────────────────────
+  it("has(uid, sha) — returns true only for matching cached sha (R28)", async () => {
+    writeFile(sourceDir, "a.md", "x");
+    await layer.cache("uid-has", sourceDir, "sha-real");
+
+    expect(await layer.has("uid-has", "sha-real")).toBe(true);
+    expect(await layer.has("uid-has", "sha-other")).toBe(false);
+    expect(await layer.has("uid-unknown", "sha-real")).toBe(false);
+  });
+
+  // ─── 9. has() без SHA ─────────────────────────────────────────────────
+  it("has(uid) — returns true if any cache entry exists для asUid", async () => {
+    writeFile(sourceDir, "a.md", "x");
+    await layer.cache("uid-any", sourceDir, "sha-any-1");
+
+    expect(await layer.has("uid-any")).toBe(true);
+    expect(await layer.has("uid-empty")).toBe(false);
+  });
+
+  // ─── 10. clear() wipe-all (Decision #6) ──────────────────────────────
+  it("clear() — removes ALL cache entries across all AssetSpace dirs", async () => {
+    writeFile(sourceDir, "a.md", "x");
+    await layer.cache("uid-A", sourceDir, "sha-A1");
+    await layer.cache("uid-A", sourceDir, "sha-A2");
+    await layer.cache("uid-B", sourceDir, "sha-B1");
+
+    const before = await layer.listEntries();
+    expect(before.length).toBe(3);
+
+    const result = await layer.clear();
+    expect(result.entriesRemoved).toBe(3);
+
+    const after = await layer.listEntries();
+    expect(after.length).toBe(0);
+    expect(fs.existsSync(path.join(cacheDir, "uid-A"))).toBe(false);
+    expect(fs.existsSync(path.join(cacheDir, "uid-B"))).toBe(false);
+  });
+
+  // ─── 11. clear() on empty cache ──────────────────────────────────────
+  it("clear() — entriesRemoved=0 when cache dir does not exist", async () => {
+    const layer2 = new SwitchCacheLayer({
+      cacheDir: path.join(cacheDir, "non-existent-subdir"),
+    });
+    const result = await layer2.clear();
+    expect(result.entriesRemoved).toBe(0);
+  });
+
+  // ─── 12. listEntries() ───────────────────────────────────────────────
+  it("listEntries() — returns all cache entries across all AssetSpace dirs", async () => {
+    writeFile(sourceDir, "a.md", "x");
+    await layer.cache("uid-X", sourceDir, "sha-X");
+    await layer.cache("uid-Y", sourceDir, "sha-Y");
+
+    const entries = await layer.listEntries();
+    expect(entries.length).toBe(2);
+
+    const uids = new Set(entries.map((e) => e.asUid));
+    expect(uids.has("uid-X")).toBe(true);
+    expect(uids.has("uid-Y")).toBe(true);
+  });
+
+  // ─── Bonus: zip-slip defense (nanotar normalisation + source guard) ──
+  it("restore() — `..` / absolute entry paths are sanitised, files stay under targetDir", async () => {
+    // Build an archive с `..` / absolute paths directly via nanotar to
+    // bypass our own source walker (which would never produce traversal).
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { createTarGzip } = require("nanotar");
+    const archive: Uint8Array = await createTarGzip([
+      { name: "../escape.md", data: new TextEncoder().encode("evil") },
+      { name: "/etc/passwd", data: new TextEncoder().encode("evil2") },
+    ]);
+    const cachePath = path.join(cacheDir, "uid-evil", "sha-evil.tar.gz");
+    const metaPath = path.join(cacheDir, "uid-evil", "sha-evil.meta.json");
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(cachePath, archive);
+    fs.writeFileSync(
+      metaPath,
+      JSON.stringify({
+        asUid: "uid-evil",
+        sha: "sha-evil",
+        cachedAt: new Date().toISOString(),
+        sizeBytes: archive.byteLength,
+      }),
+      "utf8",
+    );
+
+    // nanotar normalises traversal — entries land as `escape.md` /
+    // `etc/passwd` under targetDir. Our defense-in-depth check passes
+    // because the resolved paths stay within targetDir. The critical
+    // contract is: NO write outside targetDir.
+    await layer.restore("uid-evil", targetDir);
+    expect(fs.existsSync(path.join(path.dirname(targetDir), "escape.md"))).toBe(
+      false,
+    );
+    expect(fs.existsSync("/etc/passwd-attacker-marker")).toBe(false);
   });
 });
 
-// ─── LRU eviction ─────────────────────────────────────────────────────────
+// ─── Sync getCacheStats() — Settings UI compat ─────────────────────────
+describe("SwitchCacheLayer.getCacheStats() — sync", () => {
+  let cacheDir: string;
+  let sourceDir: string;
 
-describe("SwitchCacheLayer LRU eviction", () => {
-  it("evicts oldest entry when new entry exceeds cap", async () => {
-    const clock = makeClock();
-    const cache = new SwitchCacheLayer({ maxBytes: 500, now: () => clock.current });
-
-    await cache.cacheAssetSpace("old", makeFiles([["x", 300]]));
-    clock.advance(1000);
-    await cache.cacheAssetSpace("mid", makeFiles([["y", 100]]));
-    clock.advance(1000);
-    // total = 400, adding 300 → would be 700 → evict 'old' (oldest touched)
-    await cache.cacheAssetSpace("new", makeFiles([["z", 300]]));
-
-    expect(await cache.restoreCachedAssetSpace("old")).toBeNull();
-    expect(await cache.restoreCachedAssetSpace("mid")).not.toBeNull();
-    expect(await cache.restoreCachedAssetSpace("new")).not.toBeNull();
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "switch-cache-stats-test-"));
+    sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "switch-source-stats-"));
   });
 
-  it("restore touches lastTouched (resets LRU position)", async () => {
-    const clock = makeClock();
-    const cache = new SwitchCacheLayer({ maxBytes: 500, now: () => clock.current });
-
-    await cache.cacheAssetSpace("a", makeFiles([["x", 200]]));
-    clock.advance(1000);
-    await cache.cacheAssetSpace("b", makeFiles([["y", 200]]));
-    clock.advance(1000);
-
-    // Touch 'a' so 'b' becomes oldest
-    await cache.restoreCachedAssetSpace("a");
-    clock.advance(1000);
-
-    // Adding 'c' (200B) brings total to 600 → must evict the oldest-touched: 'b'
-    await cache.cacheAssetSpace("c", makeFiles([["z", 200]]));
-
-    expect(await cache.restoreCachedAssetSpace("a")).not.toBeNull();
-    expect(await cache.restoreCachedAssetSpace("b")).toBeNull();
-    expect(await cache.restoreCachedAssetSpace("c")).not.toBeNull();
+  afterEach(() => {
+    for (const d of [cacheDir, sourceDir]) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
   });
 
-  it("explicit evictOldest reduces cache to target size", async () => {
-    const clock = makeClock();
-    const cache = new SwitchCacheLayer({ maxBytes: 1 * KB, now: () => clock.current });
-
-    await cache.cacheAssetSpace("a", makeFiles([["1", 300]]));
-    clock.advance(100);
-    await cache.cacheAssetSpace("b", makeFiles([["2", 300]]));
-    clock.advance(100);
-    await cache.cacheAssetSpace("c", makeFiles([["3", 300]]));
-
-    // Force evict to 400 bytes — should drop 'a' and 'b'
-    await cache.evictOldest(400);
-    expect(cache.getCacheStats().count).toBe(1);
-    expect(await cache.restoreCachedAssetSpace("c")).not.toBeNull();
-  });
-
-  it("evictOldest is no-op when already under target", async () => {
-    const cache = new SwitchCacheLayer({ maxBytes: 1 * KB });
-    await cache.cacheAssetSpace("a", makeFiles([["x", 100]]));
-    await cache.evictOldest(500);
-    expect(cache.getCacheStats().count).toBe(1);
-  });
-});
-
-// ─── getCacheStats ────────────────────────────────────────────────────────
-
-describe("SwitchCacheLayer.getCacheStats", () => {
-  it("returns zero stats on empty cache", () => {
-    const cache = new SwitchCacheLayer();
-    expect(cache.getCacheStats()).toEqual({
+  it("returns zeros when cache dir empty / nonexistent", () => {
+    const layer = new SwitchCacheLayer({
+      cacheDir: path.join(cacheDir, "nope"),
+    });
+    expect(layer.getCacheStats()).toEqual({
       count: 0,
       totalSize: 0,
       oldestEntry: null,
     });
   });
 
-  it("aggregates count and totalSize across entries", async () => {
-    const clock = makeClock(0);
-    const cache = new SwitchCacheLayer({ now: () => clock.current });
-    await cache.cacheAssetSpace("a", makeFiles([["x", 100]]));
-    clock.advance(5000);
-    await cache.cacheAssetSpace("b", makeFiles([["y", 200], ["z", 50]]));
+  it("aggregates count + totalSize + oldestEntry from sidecar metas", async () => {
+    const layer = new SwitchCacheLayer({ cacheDir });
+    fs.writeFileSync(path.join(sourceDir, "a.md"), "x", "utf8");
+    await layer.cache("uid-stats", sourceDir, "sha-1");
+    await new Promise((r) => setTimeout(r, 10));
+    await layer.cache("uid-stats", sourceDir, "sha-2");
 
-    const stats = cache.getCacheStats();
+    const stats = layer.getCacheStats();
     expect(stats.count).toBe(2);
-    expect(stats.totalSize).toBe(350);
-    // oldestEntry from 'a' (cachedAt=0)
-    expect(stats.oldestEntry).toBe(new Date(0).toISOString());
+    expect(stats.totalSize).toBeGreaterThan(0);
+    expect(stats.oldestEntry).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Phase 5 Phase 2 of RFC 22b50a17 (FocusProfile hard switch). Converts the
in-memory `SwitchCacheLayer` stub (originally shipped per RFC 0a0791c1
§B.5 v3 backward-compat) into the filesystem-backed cache that hard
switch needs for atomic destroy-and-rebuild cycles (Decision #7).

- Cache layout: `~/Library/Caches/exocortex/switch-cache/<asUid>/<sha>.tar.gz`
  plus sidecar `<sha>.meta.json` (`{ asUid, sha, cachedAt, sizeBytes }`)
- nanotar (pure JS) — no `child_process` dependency
- New palette command **Exocortex: Clear switch cache (wipe-all)** with
  destructive-op confirm modal
- 15 adversarial unit tests, real filesystem fixtures (production-shape
  per `test-fixture-realism.md`)

## Phase 0 findings applied

- **F1** — Cache-side content-root convention. Tarball entries are `a.md`,
  `subdir/b.md` (no wrapper directory). Restore writes directly under
  target — NO `--strip-components` (spike's rejected anti-pattern).
- **F6** — verify-before-return. After archive write, `cache()` checks
  file exists + non-empty + parseable + non-zero entries. Failure throws
  `CacheWriteError` BEFORE caller proceeds to destroy uncached data
  (Decision #7 atomicity).
- **R28** — SHA-aware. Sidecar stores SHA; `has(uid, sha)` answers "is
  this revision cached" so caller falls back to fresh pull if upstream
  HEAD moved.
- **Decision #6** — wipe-all `clear()` semantics. No LRU/TTL automation.

## Architecture notes

- `infrastructure/adapters/SwitchCacheLayer.ts` (not `services/` as the
  prompt suggested — `services/` doesn't exist; existing convention is
  `infrastructure/adapters/` where AssetSpaceManager / GitHubRestClient /
  TarExtractor / FocusProfileSwitchManager live).
- Replaces the previous in-memory stub at the same path. No production
  callers used the old in-memory API (it never persisted state); Settings
  UI's `new SwitchCacheLayer()` + `getCacheStats()` works unchanged with
  the new sync stats shim that reads sidecar metas synchronously.
- Node.js builtins (`fs`, `path`, `os`) needed for OS-level cache
  directory ops — vault.adapter can't reach `~/Library/Caches/`.
  `eslint-disable` block per existing `AssetSpaceManager.ts` /
  `StagingDirTracker.ts` pattern. `Platform.isMobile` guard at every
  public entry point — Phase 5 hard switch is desktop-only.

## Test plan

- [x] 15/15 SwitchCacheLayer unit tests pass (happy path, F6 verify-empty
      / non-existent / corrupt-overwrite, F1 plain-extract, newest-by-cachedAt
      restore, cache-miss, R28 has(uid,sha), wipe-all clear, listEntries,
      zip-slip defense, sync stats)
- [x] ExocortexSettingTab.test + ExocortexSettingTab.focusProfile.test +
      AssetSpaceManager.test continue to pass
- [x] `npm run lint` — clean (0 errors, 0 warnings on new code)
- [x] `npm run check:types` — clean

## Phase 2 DoD

- [x] All 4 P2 tasks (P2.1 layout, P2.2 methods, P2.3 palette command,
      P2.4 adversarial tests)
- [x] SwitchCacheLayer real implementation shipped
- [x] Clear switch cache palette command registered with confirm gate
- [x] 15 unit tests pass (12 prompt-spec + 3 additions: corrupt-overwrite,
      sync stats, zip-slip)
- [ ] code-reviewer round APPROVE (pending — opening PR before review)
- [ ] advisor round-2 APPROVE (pending)
- [ ] CI green
- [ ] Merged + release