### PR TITLE
fix(cli): emit bare [[uid]] for self-aliased class wikilink (#3180)

### DIFF
--- a/packages/cli/src/services/AssetCreationService.ts
+++ b/packages/cli/src/services/AssetCreationService.ts
@@ -12,6 +12,25 @@ const EXO_ASSISTANT_UUID = "de20a3f1-7483-4714-ab28-b45f5cf02c76";
 const DEFAULT_TIMEZONE = "Asia/Almaty";
 
 /**
+ * Build a class wikilink for `exo__Instance_class` frontmatter.
+ *
+ * Per UID-canon rule (CLAUDE.md 2026-05-17): wikilinks where alias equals
+ * the target are degenerate — alias provides no display value. When a user
+ * passes `--class <UUID>` directly, `classShortName === classUuid` and the
+ * naive `[[uid|uid]]` form duplicates the UID as both target and alias.
+ * Emit bare `[[uid]]` form instead (Issue #3180).
+ */
+function buildClassWikilink(
+  classUuid: string,
+  classShortName: string,
+): string {
+  if (!classShortName || classShortName === classUuid) {
+    return `"[[${classUuid}]]"`;
+  }
+  return `"[[${classUuid}|${classShortName}]]"`;
+}
+
+/**
  * Options for creating a new asset.
  */
 export interface CreateAssetOptions {
@@ -169,7 +188,7 @@ export class AssetCreationService {
     fm["exo__Asset_label"] = params.label;
     fm["exo__Asset_createdAt"] = params.timestamp;
     fm["exo__Asset_createdBy"] = `"[[${params.createdBy}]]"`;
-    fm["exo__Instance_class"] = [`"[[${params.classUuid}|${params.classShortName}]]"`];
+    fm["exo__Instance_class"] = [buildClassWikilink(params.classUuid, params.classShortName)];
 
     // Aliases
     const allAliases = [params.label];

--- a/packages/cli/tests/unit/services/AssetCreationService.test.ts
+++ b/packages/cli/tests/unit/services/AssetCreationService.test.ts
@@ -530,6 +530,55 @@ describe("AssetCreationService", () => {
       ]);
     });
 
+    // Regression: Issue #3180 — CLI emitted self-aliased [[uid|uid]] when
+    // --class <UUID> was passed directly (classShortName === classUuid).
+    // Per UID-canon rule (CLAUDE.md 2026-05-17): alias=UID is degenerate;
+    // emit bare [[uid]] form.
+    describe("Issue #3180: self-aliased class wikilink", () => {
+      const CLASS_UUID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+
+      it("should emit bare [[uid]] when classShortName equals classUuid (UUID passed as --class)", async () => {
+        mockClassResolver.resolve.mockResolvedValue(CLASS_UUID);
+
+        const result = await service.create({
+          classShortName: CLASS_UUID,
+          label: "TEST",
+          vault: "/vault",
+        });
+
+        expect(result.frontmatter.exo__Instance_class).toEqual([
+          `"[[${CLASS_UUID}]]"`,
+        ]);
+      });
+
+      it("should NOT emit self-aliased [[uid|uid]] form", async () => {
+        mockClassResolver.resolve.mockResolvedValue(CLASS_UUID);
+
+        const result = await service.create({
+          classShortName: CLASS_UUID,
+          label: "TEST",
+          vault: "/vault",
+        });
+
+        const classRef = (result.frontmatter.exo__Instance_class as string[])[0];
+        expect(classRef).not.toContain(`${CLASS_UUID}|${CLASS_UUID}`);
+      });
+
+      it("should still emit [[uid|shortName]] when classShortName is human-readable", async () => {
+        mockClassResolver.resolve.mockResolvedValue(CLASS_UUID);
+
+        const result = await service.create({
+          classShortName: "ems__Task",
+          label: "Task label",
+          vault: "/vault",
+        });
+
+        expect(result.frontmatter.exo__Instance_class).toEqual([
+          `"[[${CLASS_UUID}|ems__Task]]"`,
+        ]);
+      });
+    });
+
     it("should throw error for empty label", async () => {
       await expect(
         service.create({


### PR DESCRIPTION
## Summary

CLI `create` command was emitting self-aliased wikilink form `[[uuid|uuid]]` instead of bare `[[uuid]]` form when user passed UUID directly as `--class` argument. Per UID-canon rule (CLAUDE.md 2026-05-17): alias=UID provides no display value → strip-canon.

## Root cause

`packages/cli/src/services/AssetCreationService.ts:172` (now :191) always synthesized `[[${classUuid}|${classShortName}]]`. When user passes UUID:
- `ClassResolverService.resolve` UUID pass-through returns input unchanged
- `classShortName === classUuid` → naive interpolation produces `[[<uid>|<uid>]]`

## Fix

Extracted helper `buildClassWikilink(classUuid, classShortName)` that:
- Emits bare `"[[<uid>]]"` when `classShortName` is empty OR equals `classUuid`
- Preserves `"[[<uid>|<shortName>]]"` for human-readable class names (unchanged path)

## Verification

**Empirical revert-verify discipline (per `~/.claude/rules/integration-test-revert-verify.md`):**
- With fix: 36/36 AssetCreationService tests pass
- Revert line :191 to original: 2/36 fail (new regression tests catch the bug), 34/36 unaffected
- Restore fix: 36/36 pass

**Live integration smoke:**
```
$ node packages/cli/dist/index.js create --class 1b20a8f0-d745-4e93-91db-4531b3df120e --label "TEST" --vault /tmp/vault-3180-smoke --skip-wikilink-validation
$ cat /tmp/vault-3180-smoke/01\ Inbox/*.md | grep Instance_class
exo__Instance_class:
  - "[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"
```

Bare UID-canon form, no self-alias.

## Tests

3 new regression tests under `describe("Issue #3180: self-aliased class wikilink")`:
1. Emits bare `[[uid]]` when classShortName === classUuid
2. Does NOT contain self-aliased substring `<uid>|<uid>`
3. Still emits `[[uid|shortName]]` for human-name case (backward compat)

## Other emission-sites audited (clean)

- `GenericAssetCreationService.formatWikilink` — single-arg wrap, no synthesis
- `CreateInstanceCommand` (plugin) — already emits bare UID form
- `AssetCreationService.formatPropertyValue` — quotes user-supplied verbatim, no synthesis
- Grep `\[\[\${...}\|\${...}\]\]` across `packages/cli/src/` + `packages/exocortex/src/services/` → 0 hits outside test files

## Review chain

- `code-reviewer` agent round-1: **APPROVE** (0 CRIT/HIGH/MED, 1 LOW resolved by dropping `export` keyword on helper)
- `advisor()` round-2: not blocking, proceed (verified dist commit convention via PR history — recent CLI PRs do not commit dist; auto-rebuilt by CI)

Closes #3180