### PR TITLE
fix(services): strip obsidian://vault/ prefix in createPathBasedTargetResolver (#3301)

### DIFF
--- a/packages/cli/tests/unit/services/CliServiceRegistryPopulator.test.ts
+++ b/packages/cli/tests/unit/services/CliServiceRegistryPopulator.test.ts
@@ -34,11 +34,18 @@ jest.unstable_mockModule("exocortex", () => {
       return date.toISOString();
     }
   }
+  // Issue #3301: the path-based target resolver factory now imports
+  // `iriToVaultPath` from `exocortex` at module-evaluation time. The
+  // deps-omitted code path tested here never invokes the resolver, so a
+  // shape stub returning null (treated as "not a vault scheme IRI", caller
+  // falls back to the raw IRI) is sufficient for the import to resolve.
+  const iriToVaultPath = (_iri: string): string | null => null;
   return {
     ServiceRegistry,
     FrontmatterService,
     WikiLinkHelpers,
     DateFormatter,
+    iriToVaultPath,
   };
 });
 

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -1,4 +1,4 @@
-import { WikiLinkHelpers, DateFormatter } from "exocortex";
+import { WikiLinkHelpers, DateFormatter, iriToVaultPath } from "exocortex";
 import type {
   ClassRefResolver,
   IGroundingService,
@@ -29,11 +29,12 @@ import type {
  * runtimes produce byte-identical state changes for the same input.
  *
  * Target-IRI → IFile resolution is delegated to the optional
- * `ITargetResolver` parameter. CLI runtime keeps the historical
- * path-based default (`getAbstractFileByPath(`${IRI}.md`)`); the Obsidian
- * plugin (T1.3) injects an Obsidian-aware resolver that scans
- * `metadataCache` for `exo__Asset_uid` / `@id` matches and decodes
- * `obsidian://vault/...` URIs.
+ * `ITargetResolver` parameter. The CLI default path-based resolver strips
+ * the `obsidian://vault/<encoded-path>` URI scheme via the canonical
+ * `iriToVaultPath` helper (Issue #3301) and appends `.md` only when not
+ * already present; the Obsidian plugin (T1.3) injects an Obsidian-aware
+ * resolver that additionally scans `metadataCache` for `exo__Asset_uid` /
+ * `@id` matches.
  *
  * RFC 94e520da Phase 1, T1.2 (factories) + T1.3 (plugin migration).
  */
@@ -47,7 +48,18 @@ export function createPathBasedTargetResolver(
 ): ITargetResolver {
   return {
     resolveFile(targetIRI: string): IFile {
-      const candidate = vaultAdapter.getAbstractFileByPath(`${targetIRI}.md`);
+      // `iriToVaultPath` returns null when the input either lacks the
+      // `obsidian://vault/` prefix (a plain vault-relative path) OR carries
+      // a malformed percent-escape sequence (URIError → null). In both
+      // cases we fall back to the raw IRI: a plain path is what the
+      // resolver always accepted, and a malformed-URI lookup will miss
+      // disk and surface as the consistent "Cannot resolve target file"
+      // error below rather than a raw URIError stack trace.
+      const stripped = iriToVaultPath(targetIRI) ?? targetIRI;
+      const candidatePath = stripped.endsWith(".md")
+        ? stripped
+        : `${stripped}.md`;
+      const candidate = vaultAdapter.getAbstractFileByPath(candidatePath);
       if (!candidate || !("basename" in candidate)) {
         throw new Error(`Cannot resolve target file for IRI: ${targetIRI}`);
       }

--- a/packages/services/tests/grounding-service-factories.test.ts
+++ b/packages/services/tests/grounding-service-factories.test.ts
@@ -14,6 +14,7 @@ import {
   createRemovePropertyService,
   createSetStatusService,
   createDuplicateAssetService,
+  createPathBasedTargetResolver,
   rewriteFrontmatterScalars,
   type IPathResolver,
 } from "../src/index";
@@ -227,6 +228,123 @@ describe("@kitelev/exocortex-services — factory contract", () => {
     await expect(service.execute("missing-uid", { label: "x" })).rejects.toThrow(
       /Cannot resolve target file/,
     );
+  });
+
+  describe("createPathBasedTargetResolver — IRI form handling (#3301)", () => {
+    /**
+     * Regression guard for Issue #3301: `service_call` groundings whose
+     * targetIRI is the canonical `obsidian://vault/<encoded-path>` form
+     * (produced by `vaultPathToIRI` after #2996) must resolve to the same
+     * file as the equivalent vault-relative path. Without scheme stripping
+     * the resolver passes the raw URI to `getAbstractFileByPath`, which
+     * yields null and the surface-level error «Cannot resolve target file
+     * for IRI» on every `exocortex-cli apply` of assets outside `assetspaces/`.
+     *
+     * The fix mirrors `CliServiceRegistryPopulator.createCliPathResolver`
+     * (frontmatter-only resolver path) — same scheme prefix + decodeURI +
+     * idempotent `.md` append.
+     */
+
+    function pathAwareAdapter(
+      expectedPath: string,
+      file: { basename: string; parent: { path: string } },
+    ): { lookedUp: string[]; adapter: never } {
+      const lookedUp: string[] = [];
+      const adapter = {
+        getAbstractFileByPath(path: string) {
+          lookedUp.push(path);
+          return path === expectedPath ? (file as never) : null;
+        },
+        getFrontmatter: () => ({}),
+      } as never;
+      return { lookedUp, adapter };
+    }
+
+    it("strips obsidian://vault/ scheme prefix before lookup", () => {
+      const { lookedUp, adapter } = pathAwareAdapter("Notes/foo.md", {
+        basename: "foo",
+        parent: { path: "Notes" },
+      });
+      const resolver = createPathBasedTargetResolver(adapter);
+
+      const file = resolver.resolveFile("obsidian://vault/Notes/foo.md");
+
+      expect(file.basename).toBe("foo");
+      expect(lookedUp).toEqual(["Notes/foo.md"]);
+    });
+
+    it("decodes percent-escapes in obsidian://vault/ URI", () => {
+      const { lookedUp, adapter } = pathAwareAdapter("03 Knowledge/foo.md", {
+        basename: "foo",
+        parent: { path: "03 Knowledge" },
+      });
+      const resolver = createPathBasedTargetResolver(adapter);
+
+      // %20 → space, matching decodeURI semantics
+      resolver.resolveFile("obsidian://vault/03%20Knowledge/foo.md");
+
+      expect(lookedUp).toEqual(["03 Knowledge/foo.md"]);
+    });
+
+    it("appends .md to plain paths missing the extension (legacy behaviour)", () => {
+      const { lookedUp, adapter } = pathAwareAdapter("Tasks/uid.md", {
+        basename: "uid",
+        parent: { path: "Tasks" },
+      });
+      const resolver = createPathBasedTargetResolver(adapter);
+
+      resolver.resolveFile("Tasks/uid");
+
+      expect(lookedUp).toEqual(["Tasks/uid.md"]);
+    });
+
+    it("is idempotent when the stripped path already ends with .md", () => {
+      const { lookedUp, adapter } = pathAwareAdapter("Notes/foo.md", {
+        basename: "foo",
+        parent: { path: "Notes" },
+      });
+      const resolver = createPathBasedTargetResolver(adapter);
+
+      // obsidian:// IRIs almost always include the .md suffix because
+      // `dyncommand exec --target <path>` preserves the extension when
+      // building the canonical IRI form. Resolver must not append a
+      // second `.md`, otherwise lookup is `foo.md.md` (silent null).
+      resolver.resolveFile("obsidian://vault/Notes/foo.md");
+
+      expect(lookedUp).toEqual(["Notes/foo.md"]);
+      expect(lookedUp[0]).not.toMatch(/\.md\.md$/);
+    });
+
+    it("preserves the original IRI in the error message when lookup fails", () => {
+      const { adapter } = pathAwareAdapter("Notes/exists.md", {
+        basename: "exists",
+        parent: { path: "Notes" },
+      });
+      const resolver = createPathBasedTargetResolver(adapter);
+
+      expect(() =>
+        resolver.resolveFile("obsidian://vault/Notes/missing.md"),
+      ).toThrow(
+        "Cannot resolve target file for IRI: obsidian://vault/Notes/missing.md",
+      );
+    });
+
+    it("surfaces malformed percent-escapes as the consistent resolver error", () => {
+      // `iriToVaultPath` swallows URIError and returns null on malformed
+      // sequences — the resolver then falls back to the raw IRI, the
+      // subsequent lookup misses, and the user sees the canonical
+      // "Cannot resolve target file" message instead of a raw URIError
+      // stack trace bubbling up from Node's URI parser.
+      const { adapter } = pathAwareAdapter("Notes/exists.md", {
+        basename: "exists",
+        parent: { path: "Notes" },
+      });
+      const resolver = createPathBasedTargetResolver(adapter);
+
+      expect(() =>
+        resolver.resolveFile("obsidian://vault/bad%XXescape.md"),
+      ).toThrow(/Cannot resolve target file for IRI/);
+    });
   });
 
   describe("frontmatter-only factories (T1.4)", () => {


### PR DESCRIPTION
## Summary

`exocortex-cli apply <cmd> <path>` was failing с `Cannot resolve target file for IRI: obsidian://vault/...` when invoked against assets whose canonical IRI is the `obsidian://vault/<encoded-path>` form (produced by `vaultPathToIRI` per #2996).

Root cause: `createPathBasedTargetResolver` in `packages/services/src/grounding-service-factories.ts:50` passed raw `targetIRI` directly to `vaultAdapter.getAbstractFileByPath(\`${targetIRI}.md\`)` — no scheme strip. The parallel `IPathResolver` path (`createCliPathResolver` in `packages/cli/src/services/CliServiceRegistryPopulator.ts:67-69`) already handled this correctly for `updateProperty`/`removeProperty`/`setStatus`, so the bug was confined to the 10 services that resolve targets via `ITargetResolver`.

## Fix

Adopts the canonical `iriToVaultPath` helper from `packages/exocortex/src/infrastructure/vault/iri.ts` (already exported, already a transitive dep of `@kitelev/exocortex-services`):

```ts
const stripped = iriToVaultPath(targetIRI) ?? targetIRI;
const candidatePath = stripped.endsWith(".md") ? stripped : `${stripped}.md`;
```

Code-reviewer round-1 caught that creating a new local helper would have introduced a **third** copy of the scheme-strip constant (alongside `iri.ts` and `CliServiceRegistryPopulator`) — multi-parser-predicate-migration drift risk. Refactor to canonical helper:
- Eliminates the drift risk
- Picks up URIError safety for free (malformed `%XX` escapes return null → fallback to raw IRI → consistent `Cannot resolve target file` error instead of raw URIError stack trace)
- Adds idempotent `.md` append (`obsidian://vault/foo.md` → `foo.md`, not `foo.md.md`)

## Affected services (path-based resolver)

- `createRelatedTask`
- `createRelatedProject`
- `archiveAsset`
- `cleanProperties`
- `fixMissingLabel`
- `renameToUid`
- `repairFolder`
- `planForEvening`
- `duplicateAsset`
- `createAsset` (when its IRI resolution branch fires)

Unaffected (parallel `IPathResolver` path, already correct): `updateProperty`, `removeProperty`, `setStatus`.

## Verification

### Regression tests (`tests/grounding-service-factories.test.ts`)

New `describe` block `createPathBasedTargetResolver — IRI form handling (#3301)` with 6 assertions:

1. strips `obsidian://vault/` scheme prefix before lookup
2. decodes percent-escapes (`%20` → space)
3. appends `.md` to plain paths missing the extension (legacy behaviour)
4. idempotent when stripped path already ends with `.md` (no `.md.md`)
5. preserves the original IRI in the error message when lookup fails
6. surfaces malformed percent-escapes as the consistent resolver error (not raw URIError)

Each test uses a path-aware `getAbstractFileByPath` stub that returns the file ONLY when called with the exact expected path — assertions empirically exercise the resolver's transformation.

### Empirical revert-verify (per `~/.claude/rules/integration-test-revert-verify.md`)

Stashed `packages/services/src/grounding-service-factories.ts` (production fix only) и re-ran subset:

- **Pre-fix (stashed):** 3/6 discriminative tests FAIL (scheme strip, decode, idempotent).
- **Post-fix (restored):** 6/6 PASS.

The 3 non-discriminative tests guard adjacent contract (`.md` append, error-message format, malformed-URI surface) — passing in both states is correct: they protect the contract, not the new behaviour.

### Suite + typecheck

- `packages/services` jest: **52/52 PASS** post-fix.
- `npm run check:types` (= `tsc --noEmit --skipLibCheck`): exit 0.
- `npm run lint`: 0 errors (2 pre-existing warnings in obsidian-plugin/display-name, unrelated).
- CLI suite has 10 pre-existing failures в `tests/integration/sparql-exo003.integration.test.ts` (verified unrelated to this change by stash test on main HEAD).

### Live integration smoke

Skipped per audit's «cannot empirically test without producing fixture files» note — unit regression covers the resolver contract; the apply.ts call chain is unchanged.

## Out of scope (deferred)

- **Empty-IRI early throw.** `createCliPathResolver` throws on empty `targetIRI`; this resolver still accepts it permissively (pre-existing contract). Mirroring the throw would change behaviour for other callers (e.g. `createDuplicateAsset` already throws its own specific empty-IRI error) — surgical-fix scope per next-session-prompt.
- **Migrate `CliServiceRegistryPopulator.createCliPathResolver` + `VaultNamespaceScanner` to adopt `iriToVaultPath`.** Those still hold their own `OBSIDIAN_VAULT_SCHEME` copies. Worth a follow-up tracker so the drift doesn't re-accumulate; not blocking this PR.

## Audit references

- **Code-reviewer round-1 verdict:** WARN (1 HIGH — drift risk from new helper duplicating canonical; 2 MEDIUM — URIError propagation, empty-IRI guard; 1 LOW — stale doc comment). HIGH + MEDIUM #1 + LOW addressed in same PR; MEDIUM #2 deferred as documented above.
- **advisor round-2:** approve; flagged stale commit/PR template (addressed here), lint-before-push (run, clean), and dist-build verification (CI builds exocortex before services per root build chain).

Closes #3301