### PR TITLE
fix(cli): respect --staged in validate schema --shapes-mode (#3245)

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -1037,8 +1037,82 @@ export async function runShapesValidation(
   return shaclValidate(algebraTriples as any, registry, hierarchy);
 }
 
-async function runShapesModeAction(options: ValidateSchemaOptions): Promise<void> {
+/**
+ * Issue #3245: Filter a SHACL ValidationReport to only those violations whose
+ * focusNode resolves to a path in the staged-files set. focusNode IRIs emitted
+ * by NoteToRDFConverter use the `obsidian://vault/<encoded-relPath>` form, so
+ * decode the suffix and intersect with the staged relPath set.
+ *
+ * Violations whose focusNode does NOT use the obsidian://vault/ scheme (e.g.
+ * synthetic IRIs or shape-level diagnostics) are dropped — staged-mode is
+ * scoped to per-file ABox violations by definition.
+ */
+export function filterReportToStagedFocusNodes(
+  report: ValidationReport,
+  stagedRelPaths: ReadonlySet<string>,
+): ValidationReport {
+  const prefix = "obsidian://vault/";
+  const violations = report.violations.filter((v) => {
+    if (!v.focusNode.startsWith(prefix)) return false;
+    let relPath: string;
+    try {
+      relPath = decodeURIComponent(v.focusNode.substring(prefix.length));
+    } catch {
+      relPath = v.focusNode.substring(prefix.length);
+    }
+    return stagedRelPaths.has(relPath);
+  });
+  return {
+    conforms: violations.every((v) => v.severity !== "sh:Violation"),
+    violations,
+  };
+}
+
+/**
+ * Issue #3245: Emit the "no staged files" success response in the same shape
+ * runShapesModeAction would normally produce, so pre-commit hooks see a
+ * consistent contract (conforms=true, violationCount=0, exit 0).
+ */
+function emitEmptyStagedShapesResult(
+  vaultPath: string,
+  alsoPaths: string[],
+  fmt: ShapesFormat,
+): void {
+  if (fmt === "earl") {
+    const earl = buildEARLReport(vaultPath, { conforms: true, violations: [] });
+    console.log(JSON.stringify(earl, null, 2));
+  } else if (fmt === "json") {
+    const response = ResponseBuilder.success({
+      vaultPath,
+      alsoPaths: alsoPaths.map((p) => resolve(p)),
+      conforms: true,
+      violationCount: 0,
+      violations: [],
+    });
+    console.log(JSON.stringify(response, null, 2));
+  } else {
+    console.log("✅ No staged .md files to validate.");
+  }
+}
+
+/**
+ * Issue #3245: Dependency-injection seam for tests. Production callers omit
+ * `deps` and the action uses {@link getStagedMdFiles}. Tests can pass a
+ * pre-computed staged list and avoid relying on a real git repository in the
+ * test fixture, which keeps the suite robust against environments (such as a
+ * husky pre-commit hook) that leak GIT_INDEX_FILE / GIT_DIR into child
+ * processes.
+ */
+export interface RunShapesModeActionDeps {
+  getStagedMdFiles?: (vaultPath: string) => string[];
+}
+
+export async function runShapesModeAction(
+  options: ValidateSchemaOptions,
+  deps: RunShapesModeActionDeps = {},
+): Promise<void> {
   const fmt = (options.format || "text") as ShapesFormat;
+  const stagedResolver = deps.getStagedMdFiles ?? getStagedMdFiles;
 
   try {
     const vaultPath = resolve(options.vault);
@@ -1048,6 +1122,35 @@ async function runShapesModeAction(options: ValidateSchemaOptions): Promise<void
 
     const alsoPaths = options.also ?? [];
     const allVaultRoots = [vaultPath, ...alsoPaths.map((p) => resolve(p))];
+
+    // Issue #3245: when --staged is set, scope SHACL violations to git-staged
+    // files. Short-circuit on the zero-staged case to mirror frontmatter-mode
+    // behaviour (line ~1157-1172 below) and avoid a full-vault parse on every
+    // pre-commit invocation with nothing to check.
+    //
+    // Cross-vault note: `getStagedMdFiles` runs `git diff --cached` from the
+    // primary vault, so when --also is also supplied the staged set covers
+    // only the primary vault. focusNode IRIs from --also vaults use the same
+    // `obsidian://vault/<relPath>` shape (no vault discriminator), so a
+    // violation whose relPath happens to also exist in the staged set would
+    // be retained. In the canonical Exocortex setup --also vaults mount the
+    // same shared submodules as the primary vault, so file content is
+    // identical and the collision is benign; we surface a text-mode warning
+    // for any other layout.
+    let stagedFilter: ReadonlySet<string> | null = null;
+    if (options.staged) {
+      const stagedFiles = stagedResolver(vaultPath);
+      if (stagedFiles.length === 0) {
+        emitEmptyStagedShapesResult(vaultPath, alsoPaths, fmt);
+        return;
+      }
+      if (fmt === "text" && alsoPaths.length > 0) {
+        console.log(
+          "⚠️  --staged scopes git diff --cached to the primary vault; focusNode IRIs from --also vaults that match a staged relPath will also pass the filter.",
+        );
+      }
+      stagedFilter = new Set(stagedFiles);
+    }
 
     if (fmt === "text") {
       console.log(`📦 Loading vault (shapes-mode): ${vaultPath}...`);
@@ -1069,7 +1172,10 @@ async function runShapesModeAction(options: ValidateSchemaOptions): Promise<void
     }
 
     const rawReport = await runShapesValidation(vaultPath, triples, alsoPaths);
-    const report = applyLegacyExceptionFilter(triples, rawReport);
+    let report = applyLegacyExceptionFilter(triples, rawReport);
+    if (stagedFilter) {
+      report = filterReportToStagedFocusNodes(report, stagedFilter);
+    }
 
     const qualifyNode = (focusNode: string): string =>
       allVaultRoots.length > 1 ? qualifyFocusNodePath(focusNode, allVaultRoots) : focusNode;

--- a/packages/cli/tests/integration/validate-schema-shapes-staged.integration.test.ts
+++ b/packages/cli/tests/integration/validate-schema-shapes-staged.integration.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Issue #3245: --staged is respected by --shapes-mode.
+ *
+ * Prior to this fix, `validate schema --shapes-mode --staged` ignored the
+ * staged scope filter — it always loaded the full vault and reported every
+ * SHACL violation, which made the flag unusable from pre-commit hooks.
+ *
+ * Scenarios:
+ *   1. --staged with zero staged .md files → conforms=true, violationCount=0
+ *      (short-circuit; no full-vault parse needed)
+ *   2. --staged with one staged file that has a SHACL violation → that single
+ *      violation is reported
+ *   3. --staged with one staged clean file and one unstaged file that has a
+ *      violation → violationCount=0 (the unstaged violation is filtered out)
+ *   4. Without --staged → full-vault behaviour preserved (every violation
+ *      reported), so the fix doesn't regress existing behaviour
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  afterAll,
+  jest,
+} from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { runShapesModeAction, filterReportToStagedFocusNodes } = await import(
+  "../../src/commands/validate-schema.js"
+);
+
+interface JsonResponse {
+  status: string;
+  data: {
+    vaultPath: string;
+    conforms: boolean;
+    violationCount: number;
+    violations: Array<{ focusNode: string; propertyPath: string; severity: string; message: string }>;
+  };
+}
+
+function writeFixtureShapes(vaultDir: string): void {
+  const shapesDir = path.join(vaultDir, "shapes");
+  fs.mkdirSync(shapesDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(shapesDir, "ems__Task_name.md"),
+    `---
+exo__Asset_isDefinedBy: "[[!ems]]"
+exo__Asset_uid: aaa11111-1111-1111-1111-111111111111
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[exo__Property]]"
+exo__Asset_label: ems__Task_name
+exo__Property_domain:
+  - "[[ems__Task]]"
+exo__Property_cardinality: "[[exo__PropertyCardinalitySingle]]"
+exo__Property_severity: sh:Violation
+aliases:
+  - ems__Task_name
+---
+
+Test shape: Single-cardinality ems__Task_name.
+`,
+  );
+}
+
+function writeViolatingAsset(vaultDir: string, name: string, uid: string): string {
+  const dir = path.join(vaultDir, "data");
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  // maxCount violation: Single cardinality but 2 values
+  fs.writeFileSync(
+    file,
+    `---
+exo__Asset_isDefinedBy: "[[!test]]"
+exo__Asset_uid: ${uid}
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: ${name.replace(/\.md$/, "")}
+ems__Task_name:
+  - "First Name"
+  - "Second Name"
+aliases:
+  - ${name.replace(/\.md$/, "")}
+---
+
+Violating asset.
+`,
+  );
+  return path.relative(vaultDir, file);
+}
+
+function writeCleanAsset(vaultDir: string, name: string, uid: string): string {
+  const dir = path.join(vaultDir, "data");
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  fs.writeFileSync(
+    file,
+    `---
+exo__Asset_isDefinedBy: "[[!test]]"
+exo__Asset_uid: ${uid}
+exo__Asset_createdAt: 2025-01-01T00:00:00
+exo__Instance_class:
+  - "[[ems__Task]]"
+exo__Asset_label: ${name.replace(/\.md$/, "")}
+ems__Task_name: "Single Valid Name"
+aliases:
+  - ${name.replace(/\.md$/, "")}
+---
+
+Clean asset.
+`,
+  );
+  return path.relative(vaultDir, file);
+}
+
+function lastJsonFromCalls(spy: jest.SpiedFunction<typeof console.log>): JsonResponse {
+  for (let i = spy.mock.calls.length - 1; i >= 0; i--) {
+    const arg = spy.mock.calls[i]?.[0];
+    if (typeof arg === "string" && arg.trim().startsWith("{")) {
+      return JSON.parse(arg) as JsonResponse;
+    }
+  }
+  throw new Error("no JSON in console.log calls");
+}
+
+describe("Issue #3245 — validate schema --shapes-mode --staged respects staged scope", () => {
+  describe("filterReportToStagedFocusNodes (pure helper)", () => {
+    it("returns empty violations when staged set is empty", () => {
+      const result = filterReportToStagedFocusNodes(
+        {
+          conforms: false,
+          violations: [
+            {
+              focusNode: "obsidian://vault/data/a.md",
+              propertyPath: "x",
+              severity: "sh:Violation",
+              message: "boom",
+            },
+          ],
+        },
+        new Set<string>(),
+      );
+      expect(result.violations).toHaveLength(0);
+      expect(result.conforms).toBe(true);
+    });
+
+    it("retains violations whose focusNode matches a staged path", () => {
+      const result = filterReportToStagedFocusNodes(
+        {
+          conforms: false,
+          violations: [
+            {
+              focusNode: "obsidian://vault/data/staged.md",
+              propertyPath: "p1",
+              severity: "sh:Violation",
+              message: "v1",
+            },
+            {
+              focusNode: "obsidian://vault/data/unstaged.md",
+              propertyPath: "p2",
+              severity: "sh:Violation",
+              message: "v2",
+            },
+          ],
+        },
+        new Set(["data/staged.md"]),
+      );
+      expect(result.violations).toHaveLength(1);
+      expect(result.violations[0].focusNode).toContain("staged.md");
+      expect(result.conforms).toBe(false);
+    });
+
+    it("decodes URL-encoded focusNode segments before matching", () => {
+      const stagedRel = "data/with space.md";
+      const encoded = "obsidian://vault/data/with%20space.md";
+      const result = filterReportToStagedFocusNodes(
+        {
+          conforms: false,
+          violations: [
+            {
+              focusNode: encoded,
+              propertyPath: "p",
+              severity: "sh:Violation",
+              message: "m",
+            },
+          ],
+        },
+        new Set([stagedRel]),
+      );
+      expect(result.violations).toHaveLength(1);
+    });
+
+    it("drops violations whose focusNode does not use the obsidian://vault/ scheme", () => {
+      const result = filterReportToStagedFocusNodes(
+        {
+          conforms: false,
+          violations: [
+            {
+              focusNode: "https://exocortex.my/ontology/ems#SyntheticIRI",
+              propertyPath: "p",
+              severity: "sh:Violation",
+              message: "m",
+            },
+          ],
+        },
+        new Set(["data/a.md"]),
+      );
+      expect(result.violations).toHaveLength(0);
+      expect(result.conforms).toBe(true);
+    });
+  });
+
+  describe("runShapesModeAction with --staged (end-to-end with DI-injected staged list)", () => {
+    let tmpDir: string;
+    let logSpy: jest.SpiedFunction<typeof console.log>;
+    let errSpy: jest.SpiedFunction<typeof console.error>;
+    let originalExitCode: number | undefined;
+
+    beforeAll(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "shacl-staged-3245-"));
+      writeFixtureShapes(tmpDir);
+    });
+
+    afterAll(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    beforeEach(() => {
+      logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+      errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      originalExitCode = process.exitCode;
+      process.exitCode = undefined;
+      // Clean any leftover data files from prior scenario
+      const dataDir = path.join(tmpDir, "data");
+      if (fs.existsSync(dataDir)) {
+        fs.rmSync(dataDir, { recursive: true, force: true });
+      }
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    });
+
+    it("Scenario 1: --staged with zero staged .md files → conforms=true, violationCount=0 (short-circuit)", async () => {
+      // Write a violating asset but DON'T add it to the staged list — should
+      // be ignored even though it exists on disk, because nothing is staged.
+      writeViolatingAsset(tmpDir, "ignored.md", "00000000-0000-4000-8000-000000000001");
+
+      await runShapesModeAction(
+        { vault: tmpDir, format: "json", staged: true },
+        { getStagedMdFiles: () => [] },
+      );
+
+      const json = lastJsonFromCalls(logSpy);
+      expect(json.data.conforms).toBe(true);
+      expect(json.data.violationCount).toBe(0);
+      expect(json.data.violations).toEqual([]);
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it("Scenario 2: --staged with one staged violating file → reports only that file's violations, ignoring an unstaged sibling violator", async () => {
+      const stagedRel = writeViolatingAsset(tmpDir, "violating.md", "00000000-0000-4000-8000-000000000002");
+      // Also drop an unrelated unstaged violator on disk — pre-fix, the full
+      // vault scan would report both. Post-fix, only the staged one survives.
+      writeViolatingAsset(tmpDir, "other-unstaged.md", "00000000-0000-4000-8000-00000000000a");
+
+      await runShapesModeAction(
+        { vault: tmpDir, format: "json", staged: true },
+        { getStagedMdFiles: () => [stagedRel] },
+      );
+
+      const json = lastJsonFromCalls(logSpy);
+      expect(json.data.violationCount).toBeGreaterThanOrEqual(1);
+      // All reported violations must come from the staged file — the
+      // unstaged sibling violator must NOT leak into the report.
+      for (const v of json.data.violations) {
+        expect(v.focusNode).toContain("violating.md");
+        expect(v.focusNode).not.toContain("other-unstaged.md");
+      }
+      expect(json.data.conforms).toBe(false);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("Scenario 3: --staged with one staged clean file + one unstaged violating file → violationCount=0", async () => {
+      const cleanRel = writeCleanAsset(tmpDir, "clean.md", "00000000-0000-4000-8000-000000000003");
+      writeViolatingAsset(tmpDir, "unstaged-violator.md", "00000000-0000-4000-8000-000000000004");
+
+      await runShapesModeAction(
+        { vault: tmpDir, format: "json", staged: true },
+        { getStagedMdFiles: () => [cleanRel] },
+      );
+
+      const json = lastJsonFromCalls(logSpy);
+      expect(json.data.violationCount).toBe(0);
+      expect(json.data.conforms).toBe(true);
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it("Scenario 4: without --staged, full vault is validated and unstaged violations ARE reported", async () => {
+      writeViolatingAsset(tmpDir, "unstaged.md", "00000000-0000-4000-8000-000000000005");
+      // intentionally NOT staged
+      await runShapesModeAction({
+        vault: tmpDir,
+        format: "json",
+        staged: false,
+      });
+
+      const json = lastJsonFromCalls(logSpy);
+      expect(json.data.violationCount).toBeGreaterThanOrEqual(1);
+      expect(json.data.conforms).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3245.

`npx @kitelev/exocortex-cli validate schema --shapes-mode --staged` was ignoring the git-staged scope filter — it loaded the full vault and reported every SHACL violation regardless of which files were staged, which made the flag unusable from pre-commit hooks. The legacy frontmatter mode already respected `--staged`; only the shapes-mode dispatch was buggy.

## Changes

`packages/cli/src/commands/validate-schema.ts`:
- New exported pure helper `filterReportToStagedFocusNodes(report, stagedSet)` decodes `obsidian://vault/<encoded-relPath>` focusNode IRIs, intersects with the staged set, and re-computes `conforms` severity-aware.
- New private helper `emitEmptyStagedShapesResult` covers the zero-staged short-circuit in all three output formats (text / json / earl), matching the regular shapes-mode output contract.
- `runShapesModeAction` is now `export`ed and accepts an optional `RunShapesModeActionDeps.getStagedMdFiles` seam so tests can inject the staged list without depending on a real git repository (which proved hostile to husky pre-commit + lint-staged + jest parallelism). Production callers omit `deps` and the function falls back to the existing `getStagedMdFiles` implementation.
- When both `--staged` and `--also` are set, a text-mode warning surfaces the known cross-vault focusNode IRI ambiguity (no vault discriminator in `obsidian://vault/<relPath>`).

`packages/cli/tests/integration/validate-schema-shapes-staged.integration.test.ts` (new):
- 4 pure unit tests on the filter helper — empty set, match, URL-decoded match, non-`obsidian://` scheme drop.
- 4 end-to-end tests driving `runShapesModeAction` against an on-disk fixture vault with a DI-injected staged list:
  1. zero staged + on-disk violator → `conforms=true`, `violationCount=0`
  2. one staged violator + unstaged sibling violator → only the staged violation is reported, sibling does not leak
  3. one staged clean file + unstaged violator → `conforms=true`
  4. no `--staged` → full vault reported (regression check)

## Test plan

- [x] 8/8 new tests pass post-fix
- [x] Empirically verified revert-fail / restore-pass: surgically removed only the staged-filter wiring inside `runShapesModeAction` (kept exports + helper functions) → 3 of 4 end-to-end scenarios FAIL pre-fix (the bug-demonstrating ones); Scenario 4 remains PASS (regression-prevention sanity check, correctly insensitive to the staged-filter). 4 unit tests pass either way because they exercise the helper directly.
- [x] `npx tsc -noEmit -skipLibCheck` (root) — 0 errors
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in `obsidian-plugin/src`, untouched)
- [x] 30 existing validate-schema integration tests + 110 validate unit tests pass
- [x] code-reviewer subagent: APPROVE — 0 CRITICAL, 0 HIGH, 1 MEDIUM (cross-vault `--also`+`--staged` IRI ambiguity, addressed with text-mode warning), 4 LOW
- [x] advisor round-2 sign-off