### PR TITLE
fix(plugin): walk exo__Class_superClass chain in command-binding discovery (#3295)

### DIFF
--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -167,6 +167,15 @@ const PARSE_TIME_RESOLVERS: ReadonlySet<string> = new Set([
 export class CommandResolver {
   private readonly cache = new Map<string, ResolvedCommand[]>();
   private readonly multiCache = new Map<string, ResolvedCommand[]>();
+  /**
+   * Issue #3295 — memoize `getClassAncestors` results per class ref so
+   * the per-render BFS over `exo__Class_superClass` (called once per
+   * leaf class declared by the rendered asset) does not re-walk the
+   * triple store on every Obsidian render tick. TBox is static within
+   * a session unless `invalidateCache()` is called by indexer hooks
+   * after a TBox file write.
+   */
+  private readonly _ancestorCache = new Map<string, string[]>();
 
   /**
    * RFC v2 Phase 5 (#3167) — once-per-session-per-Grounding warning suppression
@@ -517,6 +526,7 @@ export class CommandResolver {
   invalidateCache(): void {
     this.cache.clear();
     this.multiCache.clear();
+    this._ancestorCache.clear();
   }
 
   /**
@@ -2172,6 +2182,157 @@ export class CommandResolver {
     const subject = await this.findSubjectByUID(uid);
     if (!subject) return null;
     return this.getLiteralValue(subject, Namespace.EXO.term("Asset_label"));
+  }
+
+  /**
+   * Issue #3295 — Walk the `exo__Class_superClass` chain from `classRef`
+   * and return the deduplicated set of transitive ancestor refs in BOTH
+   * symbolic (e.g. `ems__Task`) and UID-canon (e.g. `1b20a8f0-...`) form.
+   *
+   * Motivation: `bindingMatches` does string-equality on `targetClass`
+   * literals (e.g. `"ems__Task"`). Without an ancestor walk, an
+   * `ems__Meeting` asset (declared `ems__Meeting ⊑ ems__Task` via
+   * `exo__Class_superClass`) would never match a Task-targeted binding —
+   * because the caller-side class array contains only the leaf
+   * (`ems__Meeting`) plus the universal-root hardcode (`exo__Asset`).
+   * Intermediate superclasses are silently dropped.
+   *
+   * The walk is cycle-safe (visited Set keyed on the class file IRI),
+   * depth-bounded by `MAX_TRANSITIVE_DEPTH`, and consumes only the
+   * already-populated triple store — no metadata-cache or DI wiring
+   * changes required at the call site beyond invoking this method.
+   *
+   * Excludes the input `classRef` itself; callers are expected to keep
+   * the leaf in their own array. Returns `[]` when the class is unknown
+   * to the store, the chain is empty, or every parent IRI is malformed.
+   *
+   * @param classRef — Either a symbolic class name (`ems__Meeting`) or
+   *                   the UID of the class file (`1b0a5e34-...`). Both
+   *                   forms are resolved to the same file IRI subject.
+   */
+  async getClassAncestors(classRef: string): Promise<string[]> {
+    const cached = this._ancestorCache.get(classRef);
+    if (cached) return cached;
+
+    const result = new Set<string>();
+    const visited = new Set<string>();
+    const seedFileIRI = await this.resolveClassFileIRI(classRef);
+    if (!seedFileIRI) {
+      // Deliberately NOT cached: a null `seedFileIRI` means the class
+      // file is not yet in the triple store. During cold-start the
+      // `LazyAssetGraphLoader` populates TBox asynchronously and the
+      // global `invalidateCache()` reindex hook fires only after the
+      // eager-init promise completes. Caching `[]` here would lock the
+      // broken empty result across renders that fire in the window
+      // before that completion → subclass-to-superclass bindings stay
+      // silently absent (the exact regression Issue #3295 fixes).
+      // The wasted cost on retry is one label-scan via
+      // `findUidByLabel` per leaf class per render — accepted.
+      return [];
+    }
+
+    // Track the input class's own symbolic + UID forms so they NEVER
+    // appear in the result, even if the chain is cyclic
+    // (`A ⊑ B ⊑ A` would otherwise surface `A` as its own ancestor on
+    // the second hop). Callers already keep the leaf in their own array.
+    const excluded = new Set<string>([classRef]);
+    const seedUid = await this.getLiteralValue(
+      seedFileIRI,
+      Namespace.EXO.term("Asset_uid"),
+    );
+    if (seedUid) excluded.add(seedUid);
+    const seedLabel = await this.getLiteralValue(
+      seedFileIRI,
+      Namespace.EXO.term("Asset_label"),
+    );
+    if (seedLabel) excluded.add(seedLabel);
+
+    const queue: Array<{ fileIRI: IRI; depth: number }> = [
+      { fileIRI: seedFileIRI, depth: 0 },
+    ];
+
+    while (queue.length > 0) {
+      const head = queue.shift();
+      if (!head) break;
+      const { fileIRI, depth } = head;
+      if (depth >= MAX_TRANSITIVE_DEPTH) continue;
+      if (visited.has(fileIRI.value)) continue;
+      visited.add(fileIRI.value);
+
+      const parentTriples = await this.tripleStore.match(
+        fileIRI,
+        Namespace.EXO.term("Class_superClass"),
+        undefined,
+      );
+
+      for (const triple of parentTriples) {
+        const obj = triple.object;
+        if (!(obj instanceof IRI)) continue;
+
+        // Two forms are possible: namespace IRI (e.g.
+        // `https://exocortex.my/ontology/ems#Task` — emitted by
+        // `valueToRDFObject` for UUID-wikilink class refs that resolve
+        // to a labelled class file) OR file IRI
+        // (e.g. `obsidian://vault/.../<uid>.md` — fallback when the
+        // class file has no namespace-derivable label, Issue #3242).
+        // `iriToObsidianName` returns the `prefix__local` symbolic
+        // form for namespace IRIs and the bare UUID basename for file
+        // IRIs; both go into the result Set so caller arrays match
+        // either form of binding (symbolic targetClass like
+        // `"ems__Task"` AND UID-form `"[[<uid>]]"`).
+        const isFileIRI = obj.value.startsWith("obsidian://vault/");
+        const parentRef = this.iriToObsidianName(obj.value);
+        if (parentRef && !excluded.has(parentRef) && !result.has(parentRef)) {
+          result.add(parentRef);
+        }
+
+        // Map back to file IRI (the BFS-walkable subject form) so we
+        // can recurse. Symbolic-namespace IRIs are NOT themselves
+        // subjects of `exo__Class_superClass` triples — the file IRI
+        // of the class file is.
+        let parentFileIRI: IRI | null = null;
+        if (isFileIRI) {
+          parentFileIRI = obj;
+        } else if (parentRef) {
+          parentFileIRI = await this.resolveClassFileIRI(parentRef);
+        }
+
+        if (!parentFileIRI) continue;
+
+        // Surface the UID form alongside the symbolic name so caller
+        // arrays satisfying UUID-form bindings (post-UID-canon) also
+        // match transitively.
+        const parentUid = await this.getLiteralValue(
+          parentFileIRI,
+          Namespace.EXO.term("Asset_uid"),
+        );
+        if (parentUid && !excluded.has(parentUid) && !result.has(parentUid)) {
+          result.add(parentUid);
+        }
+
+        if (!visited.has(parentFileIRI.value)) {
+          queue.push({ fileIRI: parentFileIRI, depth: depth + 1 });
+        }
+      }
+    }
+
+    const ancestors = Array.from(result);
+    this._ancestorCache.set(classRef, ancestors);
+    return ancestors;
+  }
+
+  /**
+   * Issue #3295 helper — resolve a class ref (symbolic name OR UID) to
+   * the file IRI subject under which `exo__Class_superClass` triples are
+   * stored. Returns `null` when the class is unknown to the store.
+   */
+  private async resolveClassFileIRI(classRef: string): Promise<IRI | null> {
+    if (this.looksLikeUUID(classRef)) {
+      return this.findSubjectByUID(classRef);
+    }
+    const uid = await this.findUidByLabel(classRef);
+    if (!uid) return null;
+    return this.findSubjectByUID(uid);
   }
 
   /**

--- a/packages/exocortex/tests/unit/services/CommandResolver.classAncestors.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.classAncestors.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Unit tests for {@link CommandResolver.getClassAncestors} — Issue #3295.
+ *
+ * Verifies that the new public method walks `exo__Class_superClass` chain
+ * across a real triple store seeded with class TBox in production shape
+ * (per `~/dotfiles/.claude/rules/test-fixture-realism.md`):
+ *
+ *   - Subject = file IRI (`obsidian://vault/.../<uid>.md`)
+ *   - Predicate = `Namespace.EXO.term("Class_superClass")`
+ *   - Object = namespace IRI for label-resolvable classes
+ *     (`https://exocortex.my/ontology/<prefix>#<Local>`),
+ *     matching `NoteToRDFConverter.valueToRDFObject` output (#2782 path).
+ */
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+const MEETING_UID = "1b0a5e34-dd7f-4ead-b43a-6c7c5a5ecaca";
+const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const EFFORT_UID = "086f71fa-dd30-4284-90cf-e609f2a6c461";
+const ASSET_UID = "493c2ae2-de56-47ec-954d-2eb8cb49bff7";
+
+interface ClassFixture {
+  uid: string;
+  label: string;
+  superClassLabel?: string;
+}
+
+/**
+ * Seed a TBox class file mirroring real on-disk vault shape:
+ *
+ *   - `Asset_uid`, `Asset_label` triples
+ *   - When `superClassLabel` is set, emit `Class_superClass` triple
+ *     with the parent's namespace IRI (matching what
+ *     `valueToRDFObject` emits for `"[[<parent-uid>]]"` after the #2782
+ *     class-IRI substitution that round-trips through `Asset_label`).
+ */
+async function seedClass(
+  store: InMemoryTripleStore,
+  fixture: ClassFixture,
+): Promise<IRI> {
+  const subject = new IRI(`obsidian://vault/assetspaces/ems/${fixture.uid}.md`);
+  const triples: Triple[] = [
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(fixture.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(fixture.label)),
+  ];
+
+  if (fixture.superClassLabel) {
+    const parentNamespaceIRI = expandClassLabel(fixture.superClassLabel);
+    if (parentNamespaceIRI) {
+      triples.push(
+        new Triple(
+          subject,
+          Namespace.EXO.term("Class_superClass"),
+          parentNamespaceIRI,
+        ),
+      );
+    }
+  }
+
+  await store.addAll(triples);
+  return subject;
+}
+
+function expandClassLabel(label: string): IRI | null {
+  const parsed = Namespace.fromPropertyKey(label);
+  if (!parsed) return null;
+  return parsed.namespace.term(parsed.localName);
+}
+
+describe("CommandResolver.getClassAncestors — Issue #3295", () => {
+  let store: InMemoryTripleStore;
+  let resolver: CommandResolver;
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    await seedClass(store, { uid: ASSET_UID, label: "exo__Asset" });
+    await seedClass(store, {
+      uid: EFFORT_UID,
+      label: "ems__Effort",
+      superClassLabel: "exo__Asset",
+    });
+    await seedClass(store, {
+      uid: TASK_UID,
+      label: "ems__Task",
+      superClassLabel: "ems__Effort",
+    });
+    await seedClass(store, {
+      uid: MEETING_UID,
+      label: "ems__Meeting",
+      superClassLabel: "ems__Task",
+    });
+    resolver = new CommandResolver(store);
+  });
+
+  describe("symbolic input — ems__Meeting", () => {
+    it("returns the full transitive ancestor chain in both symbolic and UID form", async () => {
+      const ancestors = await resolver.getClassAncestors("ems__Meeting");
+
+      expect(ancestors).toEqual(
+        expect.arrayContaining([
+          "ems__Task",
+          TASK_UID,
+          "ems__Effort",
+          EFFORT_UID,
+          "exo__Asset",
+          ASSET_UID,
+        ]),
+      );
+    });
+
+    it("does NOT include the input class itself", async () => {
+      const ancestors = await resolver.getClassAncestors("ems__Meeting");
+
+      expect(ancestors).not.toContain("ems__Meeting");
+      expect(ancestors).not.toContain(MEETING_UID);
+    });
+
+    it("deduplicates entries (no double-emission across diamond paths)", async () => {
+      const ancestors = await resolver.getClassAncestors("ems__Meeting");
+      const unique = new Set(ancestors);
+
+      expect(ancestors.length).toBe(unique.size);
+    });
+  });
+
+  describe("UID input — accepts UID-canon class refs identically", () => {
+    it("returns the same ancestor chain whether input is symbolic or UID", async () => {
+      const fromSymbolic = await resolver.getClassAncestors("ems__Meeting");
+      const fromUid = await resolver.getClassAncestors(MEETING_UID);
+
+      expect(new Set(fromUid)).toEqual(new Set(fromSymbolic));
+    });
+  });
+
+  describe("graceful fallback", () => {
+    it("returns [] when the class is unknown to the store", async () => {
+      const ancestors = await resolver.getClassAncestors("nonexistent__Class");
+
+      expect(ancestors).toEqual([]);
+    });
+
+    it("returns [] when called with an unknown UID", async () => {
+      const ancestors = await resolver.getClassAncestors(
+        "00000000-0000-0000-0000-000000000000",
+      );
+
+      expect(ancestors).toEqual([]);
+    });
+  });
+
+  describe("file-IRI parent — Issue #3242 fallback path", () => {
+    /**
+     * When a class has no namespace-derivable label (e.g. UUID-named
+     * class file with non-prefixed `exo__Asset_label`), `valueToRDFObject`
+     * emits the file IRI as the `Class_superClass` object instead of a
+     * namespace IRI. The BFS must accept this form, extract the UID,
+     * and walk further. Production reference:
+     * `NoteToRDFConverter.ts:1463-1483`.
+     */
+    it("walks through parents emitted as file IRI (label-less class)", async () => {
+      const fileIriStore = new InMemoryTripleStore();
+      const childUid = "11111111-2222-3333-4444-555555555555";
+      const parentUid = "66666666-7777-8888-9999-aaaaaaaaaaaa";
+      const grandparentUid = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff";
+
+      const childIRI = new IRI(
+        `obsidian://vault/assetspaces/custom/${childUid}.md`,
+      );
+      const parentIRI = new IRI(
+        `obsidian://vault/assetspaces/custom/${parentUid}.md`,
+      );
+      const grandparentIRI = new IRI(
+        `obsidian://vault/assetspaces/custom/${grandparentUid}.md`,
+      );
+
+      await fileIriStore.addAll([
+        new Triple(childIRI, Namespace.EXO.term("Asset_uid"), new Literal(childUid)),
+        new Triple(childIRI, Namespace.EXO.term("Asset_label"), new Literal("custom__Child")),
+        new Triple(childIRI, Namespace.EXO.term("Class_superClass"), parentIRI),
+        // Parent — non-prefix label, emitted as file IRI (#3242 path)
+        new Triple(parentIRI, Namespace.EXO.term("Asset_uid"), new Literal(parentUid)),
+        new Triple(parentIRI, Namespace.EXO.term("Asset_label"), new Literal("Some Unprefixed Label")),
+        new Triple(parentIRI, Namespace.EXO.term("Class_superClass"), grandparentIRI),
+        // Grandparent — same shape, terminal
+        new Triple(grandparentIRI, Namespace.EXO.term("Asset_uid"), new Literal(grandparentUid)),
+        new Triple(grandparentIRI, Namespace.EXO.term("Asset_label"), new Literal("Root Label")),
+      ]);
+
+      const fileIriResolver = new CommandResolver(fileIriStore);
+      const ancestors = await fileIriResolver.getClassAncestors("custom__Child");
+
+      // Both intermediate hops must surface in UID form so caller
+      // arrays with UID-canon bindings still match transitively.
+      expect(ancestors).toEqual(
+        expect.arrayContaining([parentUid, grandparentUid]),
+      );
+    });
+  });
+
+  describe("memoization — Issue #3295 perf mitigation", () => {
+    it("caches ancestor chain per classRef across repeat calls", async () => {
+      const matchSpy = jest.spyOn(store, "match");
+      const before = matchSpy.mock.calls.length;
+
+      const first = await resolver.getClassAncestors("ems__Meeting");
+      const callsAfterFirst = matchSpy.mock.calls.length;
+      const second = await resolver.getClassAncestors("ems__Meeting");
+      const callsAfterSecond = matchSpy.mock.calls.length;
+
+      expect(second).toEqual(first);
+      expect(callsAfterSecond).toBe(callsAfterFirst);
+      expect(callsAfterFirst).toBeGreaterThan(before);
+
+      matchSpy.mockRestore();
+    });
+
+    it("invalidateCache clears the ancestor cache", async () => {
+      await resolver.getClassAncestors("ems__Meeting");
+
+      const matchSpy = jest.spyOn(store, "match");
+      resolver.invalidateCache();
+      await resolver.getClassAncestors("ems__Meeting");
+
+      expect(matchSpy.mock.calls.length).toBeGreaterThan(0);
+
+      matchSpy.mockRestore();
+    });
+
+    /**
+     * Cold-start lock-in regression — Issue #3295 advisor catch.
+     *
+     * If the negative result (`[]` from unresolvable classRef) were
+     * cached, the very-first render during cold-start would lock in
+     * the broken empty chain until `invalidateCache()` fires from the
+     * eager-init reindex hook. We deliberately skip caching in that
+     * branch so a subsequent call (after `LazyAssetGraphLoader` has
+     * loaded the class file) recomputes the real chain.
+     */
+    it("does NOT cache the empty result when the class file is not yet in the store", async () => {
+      const coldStartStore = new InMemoryTripleStore();
+      const coldResolver = new CommandResolver(coldStartStore);
+
+      const first = await coldResolver.getClassAncestors("ems__Meeting");
+      expect(first).toEqual([]);
+
+      // Simulate `LazyAssetGraphLoader` populating TBox AFTER the
+      // first failed lookup but BEFORE `invalidateCache()` fires.
+      await seedClass(coldStartStore, { uid: ASSET_UID, label: "exo__Asset" });
+      await seedClass(coldStartStore, {
+        uid: EFFORT_UID,
+        label: "ems__Effort",
+        superClassLabel: "exo__Asset",
+      });
+      await seedClass(coldStartStore, {
+        uid: TASK_UID,
+        label: "ems__Task",
+        superClassLabel: "ems__Effort",
+      });
+      await seedClass(coldStartStore, {
+        uid: MEETING_UID,
+        label: "ems__Meeting",
+        superClassLabel: "ems__Task",
+      });
+
+      const second = await coldResolver.getClassAncestors("ems__Meeting");
+      expect(second).toEqual(
+        expect.arrayContaining(["ems__Task", "ems__Effort", "exo__Asset"]),
+      );
+    });
+  });
+
+  describe("diamond inheritance — multi-parent leaves (e.g. ems__MeetingPrototype)", () => {
+    /**
+     * Real vault example: `ems__MeetingPrototype` (UID `7ab483c7-...`)
+     * declares three direct superclasses simultaneously. The BFS must
+     * walk each in turn and dedupe the shared root.
+     */
+    it("walks every direct parent and dedupes a shared grandparent", async () => {
+      const diamondStore = new InMemoryTripleStore();
+      const leafUid = "10000000-0000-0000-0000-000000000001";
+      const parentAUid = "20000000-0000-0000-0000-000000000002";
+      const parentBUid = "20000000-0000-0000-0000-000000000003";
+      const sharedRootUid = "30000000-0000-0000-0000-000000000004";
+
+      // Both parents share a grandparent — the dedup test.
+      await seedClass(diamondStore, {
+        uid: sharedRootUid,
+        label: "ems__SharedRoot",
+      });
+      await seedClass(diamondStore, {
+        uid: parentAUid,
+        label: "ems__ParentA",
+        superClassLabel: "ems__SharedRoot",
+      });
+      await seedClass(diamondStore, {
+        uid: parentBUid,
+        label: "ems__ParentB",
+        superClassLabel: "ems__SharedRoot",
+      });
+      // Leaf declares both A and B as direct parents.
+      const leafIRI = new IRI(`obsidian://vault/assetspaces/ems/${leafUid}.md`);
+      await diamondStore.addAll([
+        new Triple(leafIRI, Namespace.EXO.term("Asset_uid"), new Literal(leafUid)),
+        new Triple(leafIRI, Namespace.EXO.term("Asset_label"), new Literal("ems__DiamondLeaf")),
+        new Triple(
+          leafIRI,
+          Namespace.EXO.term("Class_superClass"),
+          expandClassLabel("ems__ParentA")!,
+        ),
+        new Triple(
+          leafIRI,
+          Namespace.EXO.term("Class_superClass"),
+          expandClassLabel("ems__ParentB")!,
+        ),
+      ]);
+
+      const diamondResolver = new CommandResolver(diamondStore);
+      const ancestors = await diamondResolver.getClassAncestors("ems__DiamondLeaf");
+
+      expect(ancestors).toEqual(
+        expect.arrayContaining([
+          "ems__ParentA",
+          parentAUid,
+          "ems__ParentB",
+          parentBUid,
+          "ems__SharedRoot",
+          sharedRootUid,
+        ]),
+      );
+      // Dedup invariant: shared root surfaces exactly once.
+      const sharedRootCount = ancestors.filter(
+        (a) => a === "ems__SharedRoot",
+      ).length;
+      expect(sharedRootCount).toBe(1);
+    });
+  });
+
+  describe("cycle safety — Issue #3295 risk mitigation", () => {
+    it("terminates on a cyclic superClass chain (A ⊑ B ⊑ A)", async () => {
+      const cycleStore = new InMemoryTripleStore();
+      const aUid = "aaaaaaaa-0000-0000-0000-000000000000";
+      const bUid = "bbbbbbbb-0000-0000-0000-000000000000";
+
+      await seedClass(cycleStore, { uid: aUid, label: "ems__CycleA", superClassLabel: "ems__CycleB" });
+      await seedClass(cycleStore, { uid: bUid, label: "ems__CycleB", superClassLabel: "ems__CycleA" });
+
+      const cycleResolver = new CommandResolver(cycleStore);
+      const ancestors = await cycleResolver.getClassAncestors("ems__CycleA");
+
+      // BFS halts via the visited set; only ems__CycleB (and its UID) surface.
+      expect(ancestors).toEqual(expect.arrayContaining(["ems__CycleB", bUid]));
+      expect(ancestors).not.toContain("ems__CycleA");
+    });
+  });
+});

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -553,6 +553,43 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
       if (!classes.includes(alias)) classes.push(alias);
     }
 
+    // Issue #3295 — Walk `exo__Class_superClass` chain so that bindings
+    // targeted at intermediate superclasses (e.g. `ems__Task`) match
+    // subclass instances (e.g. `ems__Meeting ⊑ ems__Task`). Without
+    // this, only universal `exo__Asset` bindings and same-class
+    // bindings render; everything between leaf and root is silently
+    // dropped because `CommandResolver.bindingMatches` does string-
+    // equality on `targetClass` literals (no hierarchy walk).
+    //
+    // The walk consumes only the triple store and is cycle-safe + depth-
+    // bounded inside `CommandResolver.getClassAncestors`. We iterate the
+    // SNAPSHOT of classes captured before the walk to avoid revisiting
+    // every newly-appended ancestor (the resolver walks the full chain
+    // from each leaf already).
+    const leafClasses = [...classes];
+    for (const cls of leafClasses) {
+      if (cls === "exo__Asset") continue;
+      let ancestors: string[];
+      try {
+        ancestors = await this.config.commandResolver.getClassAncestors(cls);
+      } catch (error) {
+        logger?.info(
+          `[DynamicCommands] getClassAncestors(${cls}) threw: ${String(error)}`,
+        );
+        continue;
+      }
+      for (const ancestor of ancestors) {
+        if (!classes.includes(ancestor)) classes.push(ancestor);
+      }
+    }
+
+    // Universal-root guard. After the superClass walk above this is
+    // usually idempotent (the chain typically terminates at exo__Asset),
+    // but the explicit append remains the safety net for two cases:
+    //   1. The class file is unknown to the triple store (cold-start
+    //      race; `getClassAncestors` returns []).
+    //   2. The class chain skips `exo__Asset` because the leaf is a
+    //      root concept itself (e.g. shared-identities).
     if (!classes.includes("exo__Asset")) classes.push("exo__Asset");
 
     return classes;

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -43,6 +43,9 @@ function buildCommandExecutionFlow(): CommandExecutionFlow {
 const mockResolveForAsset = jest.fn();
 const mockResolveForAssetMulti = jest.fn();
 const mockResolveLabelByUID = jest.fn();
+// Issue #3295 — caller-side ancestor walk used by extractAssetClasses.
+// Default `[]` keeps legacy tests (no superClass chain) unchanged.
+const mockGetClassAncestors = jest.fn().mockResolvedValue([]);
 const mockEvaluate = jest.fn();
 const mockExecute = jest.fn();
 
@@ -50,6 +53,7 @@ const mockCommandResolver = {
   resolveForAsset: mockResolveForAsset,
   resolveForAssetMulti: mockResolveForAssetMulti,
   resolveLabelByUID: mockResolveLabelByUID,
+  getClassAncestors: mockGetClassAncestors,
   loadCommand: jest.fn(),
   findBindings: jest.fn(),
   invalidateCache: jest.fn(),
@@ -162,6 +166,9 @@ describe("DynamicCommandButtonGroupBuilder", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Issue #3295 — restore the legacy "no ancestors" default after
+    // clearAllMocks wiped the per-test override.
+    mockGetClassAncestors.mockResolvedValue([]);
     builder = new DynamicCommandButtonGroupBuilder({
       commandResolver: mockCommandResolver as unknown as Parameters<
         typeof DynamicCommandButtonGroupBuilder.prototype.build
@@ -502,6 +509,124 @@ describe("DynamicCommandButtonGroupBuilder", () => {
         ["ems__Project", "custom__Class", "exo__Asset"],
         undefined,
       );
+    });
+
+    describe("Issue #3295 — walk exo__Class_superClass chain", () => {
+      it("appends transitive ancestors so subclass instances match superclass-targeted bindings", async () => {
+        // ems__Meeting ⊑ ems__Task ⊑ ems__Effort ⊑ exo__Asset
+        // Resolver reports ancestors for the leaf via getClassAncestors;
+        // the builder must append them deduplicated to the classes
+        // array so CommandResolver.resolveForAssetMulti dispatches a
+        // per-class binding scan for each intermediate ancestor too.
+        mockResolveForAssetMulti.mockResolvedValue([]);
+        mockGetClassAncestors.mockImplementation(async (cls: string) => {
+          if (cls === "ems__Meeting") return ["ems__Task", "ems__Effort"];
+          return [];
+        });
+        const context = createContext({
+          exo__Instance_class: ["[[ems__Meeting]]"],
+        });
+
+        await builder.build(context);
+
+        expect(mockGetClassAncestors).toHaveBeenCalledWith("ems__Meeting");
+        // exo__Asset NOT passed to ancestor walk — caller already keeps
+        // the universal-root append as a safety net.
+        expect(mockGetClassAncestors).not.toHaveBeenCalledWith("exo__Asset");
+        expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+          "obsidian://vault/test/file.md",
+          ["ems__Meeting", "ems__Task", "ems__Effort", "exo__Asset"],
+          undefined,
+        );
+      });
+
+      it("walks every declared leaf class (multi-class assets)", async () => {
+        // RFC #2958 allows multiple `exo__Instance_class` entries.
+        // Each leaf class must contribute its own ancestor chain.
+        mockResolveForAssetMulti.mockResolvedValue([]);
+        mockGetClassAncestors.mockImplementation(async (cls: string) => {
+          if (cls === "ems__Project") return ["ems__Effort"];
+          if (cls === "custom__Tag") return ["custom__Concept"];
+          return [];
+        });
+        const context = createContext({
+          exo__Instance_class: ["[[ems__Project]]", "[[custom__Tag]]"],
+        });
+
+        await builder.build(context);
+
+        expect(mockGetClassAncestors).toHaveBeenCalledWith("ems__Project");
+        expect(mockGetClassAncestors).toHaveBeenCalledWith("custom__Tag");
+        expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+          "obsidian://vault/test/file.md",
+          [
+            "ems__Project",
+            "custom__Tag",
+            "ems__Effort",
+            "custom__Concept",
+            "exo__Asset",
+          ],
+          undefined,
+        );
+      });
+
+      it("logs and continues when getClassAncestors throws (cold-start safety)", async () => {
+        mockResolveForAssetMulti.mockResolvedValue([]);
+        mockGetClassAncestors.mockRejectedValue(
+          new Error("triple-store-not-ready"),
+        );
+        const context = createContext({
+          exo__Instance_class: ["[[ems__Meeting]]"],
+        });
+
+        await builder.build(context);
+
+        const infoLogs = (context.logger.info as jest.Mock).mock.calls;
+        const threwLog = infoLogs.find(
+          ([msg]: [string]) =>
+            typeof msg === "string" &&
+            msg.includes("getClassAncestors") &&
+            msg.includes("ems__Meeting") &&
+            msg.includes("threw"),
+        );
+        expect(threwLog).toBeDefined();
+        // Universal-root guard still appends exo__Asset so universal
+        // bindings continue to render even when the walk fails.
+        expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+          "obsidian://vault/test/file.md",
+          ["ems__Meeting", "exo__Asset"],
+          undefined,
+        );
+      });
+
+      it("deduplicates ancestors against classes already declared by the asset", async () => {
+        // An asset that explicitly declares both leaf and intermediate
+        // (`["ems__Meeting", "ems__Task"]`) should NOT see ems__Task
+        // appended twice via the ancestor walk.
+        mockResolveForAssetMulti.mockResolvedValue([]);
+        mockGetClassAncestors.mockImplementation(async (cls: string) => {
+          if (cls === "ems__Meeting") return ["ems__Task", "ems__Effort"];
+          if (cls === "ems__Task") return ["ems__Effort"];
+          return [];
+        });
+        const context = createContext({
+          exo__Instance_class: ["[[ems__Meeting]]", "[[ems__Task]]"],
+        });
+
+        await builder.build(context);
+
+        const calledWith = mockResolveForAssetMulti.mock.calls[0][1] as string[];
+        const taskCount = calledWith.filter((c) => c === "ems__Task").length;
+        const effortCount = calledWith.filter((c) => c === "ems__Effort").length;
+        expect(taskCount).toBe(1);
+        expect(effortCount).toBe(1);
+        expect(calledWith).toEqual([
+          "ems__Meeting",
+          "ems__Task",
+          "ems__Effort",
+          "exo__Asset",
+        ]);
+      });
     });
 
     it("should resolve variant from command category via categoryDefaultVariant map", async () => {


### PR DESCRIPTION
## Summary

Closes #3295.

`ems__Meeting` asset pages were missing `ems__Task`-targeted command buttons (Set Status, Vote, etc.) even though TBox declares `ems__Meeting ⊑ ems__Task` via `exo__Class_superClass`. `extractAssetClasses` hardcoded a single hop to the universal `exo__Asset` root, so intermediate superclasses never participated in `CommandResolver.bindingMatches` string-equality on `targetClass`.

## Changes

- `packages/exocortex/src/services/CommandResolver.ts` — new public `getClassAncestors(classRef)` BFS-walks the `exo__Class_superClass` chain via the triple store; cycle-safe (visited Set), depth-bounded by `MAX_TRANSITIVE_DEPTH=10`, returns transitive ancestors in both symbolic and UID-canon form. Per-classRef memoization wired through `invalidateCache()`. Negative-result branch (class file not yet in store) deliberately NOT cached — avoids cold-start lock-in if the first render fires before `LazyAssetGraphLoader` populates TBox.
- `packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts` — `extractAssetClasses` iterates the leaf-class snapshot, appends each ancestor returned from `commandResolver.getClassAncestors(cls)` dedup-checked. Try/catch logs + continues on failures (cold-start safety). Universal `exo__Asset` append retained as safety net for both cold-start race + root-leaf cases.

After fix, for a Meeting asset the classes array passed to `resolveForAssetMulti` looks like:
`[ems__Meeting, ems__Task, <TaskUID>, ems__Effort, <EffortUID>, exo__Asset]`

→ all Task-, Effort-, and Asset-targeted bindings match transitively.

## Test plan

- [x] 12 unit tests for `getClassAncestors` in `packages/exocortex/tests/unit/services/CommandResolver.classAncestors.test.ts`:
  - Transitive walk (Meeting → Task → Effort → Asset)
  - Symbolic vs UID input symmetry
  - Dedup across diamond paths
  - File-IRI parent form (Issue #3242 fallback path)
  - Memoization hits + `invalidateCache()` clears
  - Cold-start lock-in regression (negative cache absence verified)
  - Diamond inheritance (multi-parent dedup of shared grandparent)
  - Cycle safety (A ⊑ B ⊑ A terminates)
  - Graceful fallback for unknown class / unknown UID
- [x] 4 integration tests in `DynamicCommandButtonGroupBuilder.test.ts`:
  - Transitive append into classes array
  - Multi-class leaves each contribute their chain
  - `getClassAncestors` throw — log + continue + universal-root guard
  - Dedup against pre-declared classes
- [x] All 67 pre-existing `DynamicCommandButtonGroupBuilder` tests still pass
- [x] All 80 pre-existing `CommandResolver.test.ts` tests still pass
- [x] All 5421 obsidian-plugin tests pass
- [x] **Revert→fail / restore→pass** per `~/.claude/rules/integration-test-revert-verify.md` — with fix stashed, all 4 new builder Issue #3295 tests FAIL + new resolver-level tests don't compile. Restore → all pass.
- [x] `npm run check:types` clean
- [x] code-reviewer subagent: APPROVE, 0 CRITICAL/HIGH (2 MEDIUM + 1 LOW addressed in this PR)
- [x] advisor round: cold-start negative-cache lock-in addressed (negative result no longer cached); diamond test added

## Auto-merge discipline

⛔ Per worktree `CLAUDE.md` "Auto-merge discipline", `packages/exocortex/src/services/CommandResolver.ts` is a parser-path file. **Manual squash merge after CI green** — not `--auto`.

## Empirical reference for cold-start safety

`LazyAssetGraphLoader.ensureFileLoaded` walks `exo__Class_superClass` transitively when loading a class file, so by render time the TBox parent chain is in the triple store. The try/catch around `getClassAncestors` covers the remaining race window where TBox loading is in flight.