### PR TITLE
fix(plugin-settings): union-merge lazyBootstrapFolders to prevent default-shadow

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -1649,6 +1649,42 @@ export default class ExocortexPlugin extends Plugin {
         ...(DEFAULT_SETTINGS.excludedFolders ?? []),
       ];
     }
+    // Issue #3279 — union-merge `lazyBootstrapFolders` to prevent
+    // saved user JSON from silently shadowing newly-added defaults.
+    // `Object.assign` replaces array fields wholesale; if a future
+    // release adds e.g. `assetspaces/aiknow-ontology/` to the default
+    // list, an existing user's persisted (older) array would override
+    // it and the new submodule would stay un-indexed, bringing back
+    // the 10-20s mobile cold-start regression that PR #3277 fixed for
+    // the current entry set.
+    //
+    // Strategy: union of defaults + saved entries, preserving order
+    // (defaults first, user extras appended) and de-duplicated via
+    // `Set`. Non-array saved values are discarded as corrupted shape;
+    // non-string entries are filtered out to keep the textarea binding
+    // robust against hand-edited garbage.
+    //
+    // Trade-off (issue body AC #2): if a user explicitly removed a
+    // default folder, it will re-appear after reload. This is the
+    // conscious cost of the failure-class fix — `excludedFolders`
+    // gates the per-file RDF index pipeline (`VaultRDFIndexer`) but
+    // does NOT short-circuit the lazy-bootstrap walk
+    // (`filterTBoxFiles` reads `lazyBootstrapFolders` only), so it
+    // is not a true workaround. A future enhancement could honour
+    // `excludedFolders` in `filterTBoxFiles` to give users an escape
+    // hatch (issue #3279 follow-up candidate).
+    const rawLazyBootstrap = rawData?.lazyBootstrapFolders;
+    const savedLazyBootstrap: string[] = Array.isArray(rawLazyBootstrap)
+      ? rawLazyBootstrap.filter(
+          (entry: unknown): entry is string => typeof entry === "string",
+        )
+      : [];
+    this.settings.lazyBootstrapFolders = Array.from(
+      new Set([
+        ...(DEFAULT_SETTINGS.lazyBootstrapFolders ?? []),
+        ...savedLazyBootstrap,
+      ]),
+    );
   }
 
   /**

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -199,6 +199,19 @@ export interface ExocortexSettings {
    *
    * Empty / undefined → bootstrap walks zero files (degraded mode,
    * buttons appear via convertVault path eventually).
+   *
+   * Issue #3279 — `loadSettings` **union-merges** this list with the
+   * current `DEFAULT_SETTINGS.lazyBootstrapFolders` on every load:
+   * defaults first, then any user-added extras, de-duplicated. This
+   * guarantees that adding a new submodule to the defaults in a future
+   * release reaches existing users automatically and prevents the 10-20 s
+   * mobile cold-start regression from returning silently.
+   *
+   * Trade-off: if a user explicitly removed a default folder, it will
+   * re-appear after reload. `excludedFolders` gates the per-file RDF
+   * index pipeline but does NOT short-circuit the lazy-bootstrap walk,
+   * so it is not a workaround. A future enhancement could honour
+   * `excludedFolders` in `filterTBoxFiles` (issue #3279 follow-up).
    */
   lazyBootstrapFolders: string[];
   /**

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -363,6 +363,142 @@ describe("ExocortexPlugin", () => {
       expect(plugin.settings.autoAdjustPlannedEndTimestamp).toBe(true);
     });
 
+    /**
+     * Issue #3279 — `lazyBootstrapFolders` is union-merged with the
+     * current `DEFAULT_SETTINGS.lazyBootstrapFolders` on every load.
+     * Each test simulates a saved user JSON predating a hypothetical
+     * future migration that adds a new entry to the defaults, and
+     * asserts the new default reaches the loaded settings without
+     * losing user-added extras.
+     */
+    describe("Issue #3279 — lazyBootstrapFolders union-merge", () => {
+      it("auto-adds new default entry when user JSON is stale (missing it)", async () => {
+        // Arrange — simulate saved JSON predating a default-list extension.
+        const savedSettings = {
+          lazyBootstrapFolders: [
+            "assetspaces/exo/",
+            "assetspaces/ems/",
+            "assetspaces/ems-commands/",
+            "assetspaces/ims/",
+            // `assetspaces/exocmd/` deliberately missing — simulates a
+            // user upgrading from a version whose defaults did not yet
+            // include it.
+          ],
+        };
+        plugin.loadData = jest.fn().mockResolvedValue(savedSettings);
+
+        // Act
+        await plugin.loadSettings();
+
+        // Assert — every current default must be present.
+        for (const folder of DEFAULT_SETTINGS.lazyBootstrapFolders) {
+          expect(plugin.settings.lazyBootstrapFolders).toContain(folder);
+        }
+      });
+
+      it("preserves user-added custom entries alongside defaults", async () => {
+        // Arrange
+        const customFolder = "assetspaces/kitelev/";
+        const savedSettings = {
+          lazyBootstrapFolders: [
+            ...DEFAULT_SETTINGS.lazyBootstrapFolders,
+            customFolder,
+          ],
+        };
+        plugin.loadData = jest.fn().mockResolvedValue(savedSettings);
+
+        // Act
+        await plugin.loadSettings();
+
+        // Assert
+        expect(plugin.settings.lazyBootstrapFolders).toContain(customFolder);
+        for (const folder of DEFAULT_SETTINGS.lazyBootstrapFolders) {
+          expect(plugin.settings.lazyBootstrapFolders).toContain(folder);
+        }
+      });
+
+      it("emits deterministic order: defaults first, then user extras, deduped", async () => {
+        // Arrange — saved JSON has a custom extra plus duplicate of a default.
+        const customFolder = "assetspaces/kitelev/";
+        const duplicateOfDefault = DEFAULT_SETTINGS.lazyBootstrapFolders[0];
+        const savedSettings = {
+          lazyBootstrapFolders: [
+            customFolder,
+            duplicateOfDefault, // already present in defaults
+          ],
+        };
+        plugin.loadData = jest.fn().mockResolvedValue(savedSettings);
+
+        // Act
+        await plugin.loadSettings();
+
+        // Assert — defaults come first in their original order, then
+        // user extras appended once, no duplicates.
+        const expected = [
+          ...DEFAULT_SETTINGS.lazyBootstrapFolders,
+          customFolder,
+        ];
+        expect(plugin.settings.lazyBootstrapFolders).toEqual(expected);
+      });
+
+      it("falls back to defaults when saved user array is empty", async () => {
+        // Arrange — user explicitly cleared the list (or it never had
+        // entries). Union semantics treat that as «no extras», so the
+        // result is exactly the current defaults.
+        const savedSettings = {
+          lazyBootstrapFolders: [] as string[],
+        };
+        plugin.loadData = jest.fn().mockResolvedValue(savedSettings);
+
+        // Act
+        await plugin.loadSettings();
+
+        // Assert
+        expect(plugin.settings.lazyBootstrapFolders).toEqual(
+          DEFAULT_SETTINGS.lazyBootstrapFolders,
+        );
+      });
+
+      it("falls back to defaults when saved JSON predates the property", async () => {
+        // Arrange — settings JSON from an older release that didn't have
+        // the `lazyBootstrapFolders` field at all.
+        const savedSettings = {
+          layoutVisible: true,
+          // No `lazyBootstrapFolders` key.
+        };
+        plugin.loadData = jest.fn().mockResolvedValue(savedSettings);
+
+        // Act
+        await plugin.loadSettings();
+
+        // Assert
+        expect(plugin.settings.lazyBootstrapFolders).toEqual(
+          DEFAULT_SETTINGS.lazyBootstrapFolders,
+        );
+      });
+
+      it("ignores non-string entries in saved JSON (corrupted shape)", async () => {
+        // Arrange — hand-edited JSON contains garbage entries.
+        const savedSettings = {
+          lazyBootstrapFolders: [
+            42,
+            null,
+            "assetspaces/kitelev/",
+            { not: "a string" },
+          ] as unknown as string[],
+        };
+        plugin.loadData = jest.fn().mockResolvedValue(savedSettings);
+
+        // Act
+        await plugin.loadSettings();
+
+        // Assert — non-strings discarded; defaults + valid user extra retained.
+        expect(plugin.settings.lazyBootstrapFolders).toEqual([
+          ...DEFAULT_SETTINGS.lazyBootstrapFolders,
+          "assetspaces/kitelev/",
+        ]);
+      });
+    });
   });
 
   describe("saveSettings", () => {


### PR DESCRIPTION
## Summary

`loadSettings` used `Object.assign({}, DEFAULT_SETTINGS, rawData)` — shallow merge. When `DEFAULT_SETTINGS.lazyBootstrapFolders` gains a new entry in a future release, the existing user's saved JSON silently shadows the new default, the new submodule stays un-indexed, and the 10–20 s mobile cold-start regression that PR #3277 fixed for the current entry set returns — invisible, no log warning, no symptom traceable to settings drift.

This PR closes the failure class for `lazyBootstrapFolders` by union-merging the saved array with the current defaults on every load (defaults first, user extras appended, deduped via `Set`, non-string entries filtered out).

## Changes

- `packages/obsidian-plugin/src/ExocortexPlugin.ts:loadSettings` — append union-merge for `lazyBootstrapFolders` after the existing `Object.assign` + `excludedFolders` shape repair. Non-array saved values are discarded; non-string entries are filtered out; defaults preserved in original order; user extras appended once.
- `packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts` — JSDoc on `lazyBootstrapFolders` documents union-merge semantics and the AC #2 trade-off.
- `packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts` — 6 new unit tests under `describe("Issue #3279 — lazyBootstrapFolders union-merge")`.

## Trade-off (issue AC #2)

The issue body lists AC #2 «if a user explicitly removed a default folder, removal preserved» but the recommended Option 1 (chosen here, per session prompt) explicitly accepts the trade-off — the removed default re-appears after reload. The JSDoc previously suggested `excludedFolders` as a workaround; that suggestion was empirically wrong — `excludedFolders` gates the per-file `VaultRDFIndexer` pipeline (line 268 of `VaultRDFIndexer.ts`) but the lazy-bootstrap path calls `ExocortexPlugin.filterTBoxFiles` which reads `lazyBootstrapFolders` only. The JSDoc now says so honestly and flags «honour `excludedFolders` in `filterTBoxFiles`» as a follow-up enhancement candidate. Option 2 (UI banner) and Option 3 (schema version migration) deferred per session prompt.

## Test plan

- [x] 6 unit tests added covering: stale JSON adds new default, user-added custom preserved, deterministic order + dedup, empty user array → defaults, predates property → defaults, corrupted (non-string) entries filtered
- [x] Empirically verified revert→fail / restore→pass: temporarily stashing `loadSettings` → 4/6 new tests FAIL (the 2 that pass pre-fix are positive-only assertions: «user has all defaults» and «predates property»); restoring → 6/6 PASS
- [x] Full `ExocortexPlugin.test.ts` (92 tests) passes
- [x] Adjacent settings tests (`LogChannelSettings.test.ts`, `SparqlAutoExecuteSetting.test.ts`) pass — no regression
- [x] `npm run check:types` — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings on unrelated files)
- [x] `code-reviewer` subagent APPROVE — 0 CRITICAL / 0 HIGH / 0 MEDIUM (2 LOW notes, the actionable one — misleading `excludedFolders` workaround — addressed before push)
- [x] `advisor()` round — flagged uncommitted JSDoc fix from code-reviewer round-1, amended into the same commit before push

Closes #3279