### PR TITLE
fix(cli): respect exo__Property_cardinality in create command frontmatter emission

### DIFF
--- a/docs/PROPERTY_SCHEMA.md
+++ b/docs/PROPERTY_SCHEMA.md
@@ -1033,7 +1033,7 @@ ims__Concept_definition: A typed superset of JavaScript that compiles to plain J
 
 ## 🔢 Property Cardinality Declarations
 
-Property-definition assets may declare their cardinality via `exo__Property_cardinality`. This drives SHACL-lite validation and cardinality-aware serialization in `exocortex-cli create` (see issue #3099).
+Property-definition assets may declare their cardinality via `exo__Property_cardinality`. This drives SHACL-lite validation and cardinality-aware serialization in `exocortex-cli create` (see issues #3099, #3179).
 
 ### exo\_\_Property_cardinality
 
@@ -1042,7 +1042,7 @@ Property-definition assets may declare their cardinality via `exo__Property_card
 | Attribute    | Value                                                                                |
 | ------------ | ------------------------------------------------------------------------------------ |
 | **Type**     | WikiLink                                                                             |
-| **Required** | No (omission ≡ `PropertyCardinalityMultiple` — legacy safe default)                  |
+| **Required** | No (omission ≡ scalar — vault convention default per issue #3179)                    |
 | **Domain**   | Asset of class `exo__Property` or `exo__ObjectProperty`                              |
 | **Range**    | `exo__PropertyCardinalitySingle` or `exo__PropertyCardinalityMultiple`               |
 | **Purpose**  | SHACL-lite cardinality validation; CLI scalar-vs-array YAML serialization            |
@@ -1062,20 +1062,24 @@ exo__Property_cardinality: "[[exo__PropertyCardinalitySingle]]"
 ---
 ```
 
-With this declaration, `exocortex-cli create --property ems__Effort_status=[[…]]` emits the value as a scalar:
+With this declaration (or when the property has no cardinality declaration at all), `exocortex-cli create --property ems__Effort_status=[[…]]` emits the value as a scalar:
 
 ```yaml
-ems__Effort_status: "[[ems__EffortStatusBacklog]]" # ✅ scalar
+ems__Effort_status: "[[ems__EffortStatusBacklog]]" # ✅ scalar (vault convention default)
 ```
 
-Without the declaration (or with `PropertyCardinalityMultiple`), the value is wrapped in a single-entry YAML array — the legacy default preserved for backward compatibility:
+Only properties explicitly declared with `PropertyCardinalityMultiple` are wrapped in a YAML array:
 
 ```yaml
-ems__Effort_status:
-  - "[[ems__EffortStatusBacklog]]" # legacy default
+# When the property's TBox file declares exo__Property_cardinality: "[[exo__PropertyCardinalityMultiple]]"
+some__Multi_field:
+  - "[[uuid-a]]"
+  - "[[uuid-b]]"
 ```
 
-**Migration guidance**: declare `PropertyCardinalitySingle` on properties that are semantically single-valued (status, parent, area, prototype-target, plannedStartTimestamp, etc.). The declaration is opt-in — unmarked properties retain the existing array-form serialization.
+**Migration guidance**: declare `PropertyCardinalityMultiple` on properties that genuinely accept multiple values (e.g., bag-style relations, tag lists). Omission and `PropertyCardinalitySingle` both produce scalar emission per the prevailing vault convention (4000+ instances of `exo__Asset_isDefinedBy`, `exo__Asset_prototype`, `ems__Effort_status`, `ems__Effort_area`). System-property arrays — `exo__Instance_class`, `aliases` — are emitted via dedicated code paths in `AssetCreationService.buildFrontmatter` and are not affected by this rule.
+
+> **Behavior change (issue #3179, June 2026)**: prior to this fix, undeclared cardinality silently fell back to single-entry array form, contradicting the vault convention and forcing post-processing (e.g., the `week-planner` skill's `flatten_singles_in_file()` helper). Existing vault content using array form for single-cardinality predicates continues to be read correctly by Obsidian — only newly-created assets follow the new default.
 
 ---
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -206,8 +206,9 @@ export function createCommand(): Command {
         const wikilinkValidator = new WikilinkValidator(fsAdapter);
 
         // Load SHACL-lite shape registry from vault for cardinality-aware
-        // property serialization (issue #3099). Failure here is non-fatal —
-        // proceed with default array wrapping if shapes cannot be loaded.
+        // property serialization (issues #3099, #3179). Failure here is
+        // non-fatal — proceed with default scalar emission if shapes cannot
+        // be loaded (vault convention default per #3179).
         let shapeRegistry: ShapeRegistry | undefined;
         try {
           shapeRegistry = await ShapeLoader.loadFromVaultFS(vaultPath);

--- a/packages/cli/src/services/AssetCreationService.ts
+++ b/packages/cli/src/services/AssetCreationService.ts
@@ -96,10 +96,16 @@ export class AssetCreationService {
     private readonly wikilinkValidator: WikilinkValidator,
     /**
      * Optional SHACL-lite shape registry loaded from vault property assets.
-     * When provided, properties declared with
-     * `exo__Property_cardinality: "[[exo__PropertyCardinalitySingle]]"`
-     * are serialized as scalar YAML values instead of single-entry arrays.
-     * When omitted, all wikilink values are wrapped in arrays (legacy default).
+     *
+     * Issue #3179: vault convention is **scalar** form for single-cardinality
+     * wikilink properties. Default emission (no shape registry, or property
+     * with no shape, or shape declared `PropertyCardinalitySingle`) is now
+     * scalar. Only properties explicitly declared
+     * `exo__Property_cardinality: "[[exo__PropertyCardinalityMultiple]]"`
+     * are wrapped in YAML arrays. Multi-cardinality system fields like
+     * `exo__Instance_class` and `aliases` continue to be emitted as arrays
+     * via dedicated code paths in `buildFrontmatter` and are not subject to
+     * this rule.
      */
     private readonly shapeRegistry?: ShapeRegistry,
   ) {}
@@ -225,16 +231,17 @@ export class AssetCreationService {
   /**
    * Format a property value for frontmatter.
    *
-   * Wikilink values (containing `[[`) are quoted. By default they are wrapped
-   * in a single-entry YAML array so Obsidian can parse them as a list. If the
-   * shape registry declares the property's cardinality as `"Single"`, the
-   * quoted value is emitted as a scalar instead (issue #3099).
+   * Wikilink values (containing `[[`) are quoted. Issue #3179: the default is
+   * **scalar** form (vault convention — 4000+ instances of
+   * `exo__Asset_isDefinedBy`, `exo__Asset_prototype`, `ems__Effort_status`
+   * etc. are scalar). Only properties whose shape declares cardinality
+   * `"Multiple"` are emitted as YAML arrays.
    *
    * Plain (non-wikilink) values are always left as scalars.
    *
    * @param key - The property key (e.g. `ems__Effort_status`)
    * @param value - The raw property value string
-   * @returns Formatted value: `string` for plain or single-cardinality wikilinks, `string[]` for arrays
+   * @returns Formatted value: `string` for scalars, `string[]` for multi-cardinality wikilinks
    */
   private formatPropertyValue(key: string, value: string): string | string[] {
     if (!value.includes("[[")) {
@@ -245,28 +252,28 @@ export class AssetCreationService {
     const quoted =
       value.startsWith('"') && value.endsWith('"') ? value : `"${value}"`;
 
-    if (this.isSingleValued(key)) {
-      return quoted;
+    if (this.shouldEmitAsArray(key)) {
+      return [quoted];
     }
 
-    // Default: wrap in array for YAML list format
-    return [quoted];
+    return quoted;
   }
 
   /**
-   * Check whether a property is declared single-valued in the shape registry.
+   * Decide whether a property should be wrapped in a YAML array.
    *
-   * Safe default: `false` (treat as multi-valued / wrap in array) when no
-   * registry is provided, when the property has no shape, or when its
-   * cardinality is not explicitly `"Single"`.
+   * Returns `true` only when the shape registry exists, the property has a
+   * declared shape, and its cardinality is explicitly `"Multiple"`. Every
+   * other case (no registry, no shape, or cardinality `"Single"`/undefined)
+   * falls back to scalar emission per vault convention (issue #3179).
    */
-  private isSingleValued(key: string): boolean {
+  private shouldEmitAsArray(key: string): boolean {
     if (!this.shapeRegistry) return false;
     const parsed = Namespace.fromPropertyKey(key);
     if (!parsed) return false;
     const propertyIRI = parsed.namespace.term(parsed.localName).value;
     const shape = this.shapeRegistry.get(propertyIRI);
-    return shape?.cardinality === "Single";
+    return shape?.cardinality === "Multiple";
   }
 
   /**

--- a/packages/cli/tests/integration/create-cardinality.integration.test.ts
+++ b/packages/cli/tests/integration/create-cardinality.integration.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Issue #3179 — integration test for `create` command cardinality emission.
+ *
+ * Builds a fixture vault with:
+ *   - cardinality enum assets (Single, Multiple) at their canonical UIDs
+ *   - a single-cardinality property (`ems__Effort_status`) referencing the
+ *     Single enum via pure-UID wikilink (post-UID-canon vault shape)
+ *   - a multi-cardinality property (`ems__Effort_relatesTo`) referencing the
+ *     Multiple enum via pure-UID wikilink
+ *   - a property with NO cardinality declared (`ems__Effort_unknown`)
+ *
+ * Then invokes the real `AssetCreationService` wired with a real
+ * `ShapeLoader.loadFromVaultFS` registry, and asserts the produced
+ * frontmatter emission matches acceptance criteria #1, #2 and #3 of the
+ * issue:
+ *   - Single → scalar
+ *   - No cardinality declared → scalar (vault convention default)
+ *   - Multiple → array
+ *
+ * Mirrors real production code path; verifies that the fix in `ShapeLoader`
+ * (UID-form parsing) and `AssetCreationService` (default flip) work
+ * together — neither alone is sufficient.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { ShapeLoader } = await import("exocortex");
+const { AssetCreationService } = await import(
+  "../../src/services/AssetCreationService.js"
+);
+const { NodeFsAdapter } = await import(
+  "../../src/adapters/NodeFsAdapter.js"
+);
+const { ClassResolverService } = await import(
+  "../../src/services/ClassResolverService.js"
+);
+const { WikilinkValidator } = await import(
+  "../../src/services/WikilinkValidator.js"
+);
+
+const CARDINALITY_SINGLE_UID = "c93c4b2f-b43d-4cc9-8dd0-31514d608da2";
+const CARDINALITY_MULTIPLE_UID = "59a37aa7-ffbe-4e0d-ba60-06ae370d880f";
+const STATUS_BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const TASK_CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+
+function md(frontmatter: Record<string, string | string[]>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}:`);
+      for (const item of v) {
+        lines.push(`  - ${item}`);
+      }
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+  lines.push("---");
+  lines.push("");
+  return lines.join("\n");
+}
+
+describe("Issue #3179: create command respects exo__Property_cardinality (integration)", () => {
+  let vault: string;
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3179-"));
+
+    const exoDir = path.join(vault, "assetspaces", "exo");
+    const emsDir = path.join(vault, "assetspaces", "ems");
+    fs.mkdirSync(exoDir, { recursive: true });
+    fs.mkdirSync(emsDir, { recursive: true });
+    fs.mkdirSync(path.join(vault, "01 Inbox"), { recursive: true });
+
+    // Cardinality enum assets — real vault shape.
+    fs.writeFileSync(
+      path.join(exoDir, `${CARDINALITY_SINGLE_UID}.md`),
+      md({
+        exo__Asset_uid: CARDINALITY_SINGLE_UID,
+        exo__Asset_label: "exo__PropertyCardinalitySingle",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(exoDir, `${CARDINALITY_MULTIPLE_UID}.md`),
+      md({
+        exo__Asset_uid: CARDINALITY_MULTIPLE_UID,
+        exo__Asset_label: "exo__PropertyCardinalityMultiple",
+      }),
+    );
+
+    // ems__Effort_status — Single cardinality via pure-UID wikilink.
+    fs.writeFileSync(
+      path.join(emsDir, "44c6e9e3-955f-4afc-9ca5-b4bd70667051.md"),
+      md({
+        exo__Asset_uid: "44c6e9e3-955f-4afc-9ca5-b4bd70667051",
+        exo__Instance_class: ['"[[exo__ObjectProperty]]"'],
+        exo__Property_domain: '"[[ems__Effort]]"',
+        exo__Property_range: '"[[ems__EffortStatus]]"',
+        exo__Property_cardinality: `"[[${CARDINALITY_SINGLE_UID}]]"`,
+        exo__Asset_label: "ems__Effort_status",
+      }),
+    );
+
+    // ems__Effort_relatesTo — Multiple cardinality via pure-UID wikilink.
+    fs.writeFileSync(
+      path.join(emsDir, "abababab-1234-5678-9999-aaaaaaaaaaaa.md"),
+      md({
+        exo__Asset_uid: "abababab-1234-5678-9999-aaaaaaaaaaaa",
+        exo__Instance_class: ['"[[exo__ObjectProperty]]"'],
+        exo__Property_domain: '"[[ems__Effort]]"',
+        exo__Property_cardinality: `"[[${CARDINALITY_MULTIPLE_UID}]]"`,
+        exo__Asset_label: "ems__Effort_relatesTo",
+      }),
+    );
+
+    // ems__Task class file (target for --class lookup)
+    fs.writeFileSync(
+      path.join(emsDir, `${TASK_CLASS_UID}.md`),
+      md({
+        exo__Asset_uid: TASK_CLASS_UID,
+        exo__Asset_label: "ems__Task",
+      }),
+    );
+
+    // Backlog status target (for property value wikilink validation)
+    fs.writeFileSync(
+      path.join(emsDir, `${STATUS_BACKLOG_UID}.md`),
+      md({
+        exo__Asset_uid: STATUS_BACKLOG_UID,
+        exo__Asset_label: "ems__EffortStatusBacklog",
+      }),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  const buildService = async () => {
+    const fsAdapter = new NodeFsAdapter(vault);
+    const classResolver = new ClassResolverService(fsAdapter);
+    const wikilinkValidator = new WikilinkValidator(fsAdapter);
+    const shapeRegistry = await ShapeLoader.loadFromVaultFS(vault);
+    return new AssetCreationService(
+      fsAdapter,
+      classResolver,
+      wikilinkValidator,
+      shapeRegistry,
+    );
+  };
+
+  it("ShapeLoader resolves Single cardinality from UID-form wikilink", async () => {
+    // Pre-condition for the rest of the suite: without UID resolution,
+    // the registry would silently fall back to undefined cardinality and
+    // all property emissions would degrade to the default path.
+    const registry = await ShapeLoader.loadFromVaultFS(vault);
+    const shape = registry.get(
+      "https://exocortex.my/ontology/ems#Effort_status",
+    );
+    expect(shape).toBeDefined();
+    expect(shape!.cardinality).toBe("Single");
+  });
+
+  it("AC#1: ems__Effort_status (Single cardinality) → scalar form", async () => {
+    const service = await buildService();
+    const result = await service.create({
+      classShortName: TASK_CLASS_UID,
+      label: "TEST-3179-single",
+      vault,
+      properties: {
+        ems__Effort_status: `[[${STATUS_BACKLOG_UID}]]`,
+      },
+      skipWikilinkValidation: true,
+    });
+
+    expect(result.frontmatter["ems__Effort_status"]).toBe(
+      `"[[${STATUS_BACKLOG_UID}]]"`,
+    );
+
+    const content = fs.readFileSync(
+      path.join(vault, result.path),
+      "utf-8",
+    );
+    expect(content).toContain(
+      `ems__Effort_status: "[[${STATUS_BACKLOG_UID}]]"`,
+    );
+    expect(content).not.toMatch(
+      /ems__Effort_status:\s*\n\s*-\s+"\[\[/,
+    );
+  });
+
+  it("AC#2: undeclared property → scalar (vault convention default)", async () => {
+    const service = await buildService();
+    const result = await service.create({
+      classShortName: TASK_CLASS_UID,
+      label: "TEST-3179-default",
+      vault,
+      properties: {
+        ems__Effort_unknown: `[[${STATUS_BACKLOG_UID}]]`,
+      },
+      skipWikilinkValidation: true,
+    });
+
+    expect(result.frontmatter["ems__Effort_unknown"]).toBe(
+      `"[[${STATUS_BACKLOG_UID}]]"`,
+    );
+  });
+
+  it("AC#1: ems__Effort_relatesTo (Multiple cardinality) → array form", async () => {
+    const service = await buildService();
+    const result = await service.create({
+      classShortName: TASK_CLASS_UID,
+      label: "TEST-3179-multi",
+      vault,
+      properties: {
+        ems__Effort_relatesTo: `[[${STATUS_BACKLOG_UID}]]`,
+      },
+      skipWikilinkValidation: true,
+    });
+
+    expect(result.frontmatter["ems__Effort_relatesTo"]).toEqual([
+      `"[[${STATUS_BACKLOG_UID}]]"`,
+    ]);
+
+    const content = fs.readFileSync(
+      path.join(vault, result.path),
+      "utf-8",
+    );
+    expect(content).toMatch(
+      /ems__Effort_relatesTo:\s*\n\s*-\s+"\[\[753a44d5/,
+    );
+  });
+
+  it("AC#3 regression: exo__Instance_class + aliases stay as arrays", async () => {
+    const service = await buildService();
+    const result = await service.create({
+      classShortName: TASK_CLASS_UID,
+      label: "TEST-3179-regression",
+      vault,
+      aliases: ["alt-label"],
+      skipWikilinkValidation: true,
+    });
+
+    expect(Array.isArray(result.frontmatter["exo__Instance_class"])).toBe(
+      true,
+    );
+    expect(Array.isArray(result.frontmatter["aliases"])).toBe(true);
+  });
+});

--- a/packages/cli/tests/unit/services/AssetCreationService.test.ts
+++ b/packages/cli/tests/unit/services/AssetCreationService.test.ts
@@ -216,16 +216,16 @@ describe("AssetCreationService", () => {
         },
       });
 
-      // Wikilink values should be quoted and wrapped in array
-      expect(result.frontmatter["ztlk__Note_developedFrom"]).toEqual(
-        ['"[[some-uuid|Label]]"'],
+      // Issue #3179: scalar is the default for wikilink wikilink values.
+      expect(result.frontmatter["ztlk__Note_developedFrom"]).toBe(
+        '"[[some-uuid|Label]]"',
       );
       // Plain values remain as scalar
       expect(result.frontmatter["custom_prop"]).toBe("custom_value");
     });
 
     describe("Issue #2293: wikilink property quoting", () => {
-      it("should quote wikilink values and wrap in array", async () => {
+      it("should quote wikilink values (scalar by default per #3179)", async () => {
         const result = await service.create({
           classShortName: "ztlk__PermanentNote",
           label: "Test Note",
@@ -235,8 +235,8 @@ describe("AssetCreationService", () => {
           },
         });
 
-        expect(result.frontmatter["exo__Asset_relates"]).toEqual(
-          ['"[[some-uuid|My Asset]]"'],
+        expect(result.frontmatter["exo__Asset_relates"]).toBe(
+          '"[[some-uuid|My Asset]]"',
         );
       });
 
@@ -263,8 +263,8 @@ describe("AssetCreationService", () => {
           },
         });
 
-        expect(result.frontmatter["exo__Asset_relates"]).toEqual(
-          ['"[[some-uuid]]"'],
+        expect(result.frontmatter["exo__Asset_relates"]).toBe(
+          '"[[some-uuid]]"',
         );
       });
 
@@ -278,8 +278,8 @@ describe("AssetCreationService", () => {
           },
         });
 
-        expect(result.frontmatter["exo__Asset_relates"]).toEqual(
-          ['"[[some-uuid|Label]]"'],
+        expect(result.frontmatter["exo__Asset_relates"]).toBe(
+          '"[[some-uuid|Label]]"',
         );
       });
     });
@@ -352,7 +352,7 @@ describe("AssetCreationService", () => {
         ]);
       });
 
-      it("should emit array (legacy default) for properties not in registry", async () => {
+      it("should emit scalar (Issue #3179 default) for properties not in registry", async () => {
         const registry = buildRegistry([]);
         const emptyService = new AssetCreationService(
           mockFsAdapter as any,
@@ -370,12 +370,12 @@ describe("AssetCreationService", () => {
           },
         });
 
-        expect(result.frontmatter["ems__Effort_status"]).toEqual([
+        expect(result.frontmatter["ems__Effort_status"]).toBe(
           '"[[ems__EffortStatusBacklog]]"',
-        ]);
+        );
       });
 
-      it("should emit array (legacy default) when no shape registry is provided", async () => {
+      it("should emit scalar (Issue #3179 default) when no shape registry is provided", async () => {
         // Service constructed without registry (existing behavior)
         const result = await service.create({
           classShortName: "ems__Task",
@@ -386,9 +386,9 @@ describe("AssetCreationService", () => {
           },
         });
 
-        expect(result.frontmatter["ems__Effort_status"]).toEqual([
+        expect(result.frontmatter["ems__Effort_status"]).toBe(
           '"[[ems__EffortStatusBacklog]]"',
-        ]);
+        );
       });
 
       it("should leave plain (non-wikilink) values as scalars regardless of cardinality", async () => {
@@ -412,6 +412,138 @@ describe("AssetCreationService", () => {
         });
 
         expect(result.frontmatter["custom_prop"]).toBe("plain value");
+      });
+    });
+
+    describe("Issue #3179: scalar by default + Multiple → array", () => {
+      const propertyIRI = (prefix: string, local: string) =>
+        `https://exocortex.my/ontology/${prefix}#${local}`;
+
+      const buildRegistry = (
+        entries: Array<{ key: string; cardinality: "Single" | "Multiple" }>,
+      ) => {
+        const map = new Map<string, { cardinality: "Single" | "Multiple" }>();
+        for (const { key, cardinality } of entries) {
+          const match = /^([a-z][a-zA-Z0-9]*)__(.+)$/.exec(key);
+          if (!match) continue;
+          map.set(propertyIRI(match[1], match[2]), { cardinality });
+        }
+        return {
+          get: (iri: string) => map.get(iri),
+        };
+      };
+
+      it("AC#1: single-cardinality + single value → scalar", async () => {
+        const registry = buildRegistry([
+          { key: "ems__Effort_status", cardinality: "Single" },
+        ]);
+        const svc = new AssetCreationService(
+          mockFsAdapter as any,
+          mockClassResolver as any,
+          mockWikilinkValidator as any,
+          registry as any,
+        );
+        const result = await svc.create({
+          classShortName: "ems__Task",
+          label: "T",
+          vault: "/v",
+          properties: {
+            "ems__Effort_status":
+              "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]",
+          },
+        });
+        expect(result.frontmatter["ems__Effort_status"]).toBe(
+          '"[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"',
+        );
+      });
+
+      it("AC#2: no cardinality declared → scalar (vault convention default)", async () => {
+        const registry = buildRegistry([]);
+        const svc = new AssetCreationService(
+          mockFsAdapter as any,
+          mockClassResolver as any,
+          mockWikilinkValidator as any,
+          registry as any,
+        );
+        const result = await svc.create({
+          classShortName: "ems__Task",
+          label: "T",
+          vault: "/v",
+          properties: {
+            // Imaginary property with no shape declared
+            "ems__Unknown_field": "[[some-uuid]]",
+          },
+        });
+        expect(result.frontmatter["ems__Unknown_field"]).toBe(
+          '"[[some-uuid]]"',
+        );
+      });
+
+      it("AC#2: no shape registry → scalar default", async () => {
+        // No registry passed to constructor at all
+        const result = await service.create({
+          classShortName: "ems__Task",
+          label: "T",
+          vault: "/v",
+          properties: {
+            "exo__Asset_isDefinedBy":
+              "[[c07593d9-d50b-46a1-aeab-aee7f2660c2c]]",
+          },
+        });
+        expect(result.frontmatter["exo__Asset_isDefinedBy"]).toBe(
+          '"[[c07593d9-d50b-46a1-aeab-aee7f2660c2c]]"',
+        );
+      });
+
+      it("AC#1: multi-cardinality + single value → array", async () => {
+        const registry = buildRegistry([
+          { key: "ems__Effort_relatesTo", cardinality: "Multiple" },
+        ]);
+        const svc = new AssetCreationService(
+          mockFsAdapter as any,
+          mockClassResolver as any,
+          mockWikilinkValidator as any,
+          registry as any,
+        );
+        const result = await svc.create({
+          classShortName: "ems__Task",
+          label: "T",
+          vault: "/v",
+          properties: {
+            "ems__Effort_relatesTo": "[[some-uuid|Other]]",
+          },
+        });
+        expect(result.frontmatter["ems__Effort_relatesTo"]).toEqual([
+          '"[[some-uuid|Other]]"',
+        ]);
+      });
+
+      it("AC#3 regression: exo__Instance_class always remains an array", async () => {
+        // Even after default flip, the hardcoded system property must stay array.
+        const result = await service.create({
+          classShortName: "ems__Task",
+          label: "T",
+          vault: "/v",
+        });
+        expect(Array.isArray(result.frontmatter["exo__Instance_class"])).toBe(
+          true,
+        );
+        expect(
+          (result.frontmatter["exo__Instance_class"] as string[]).length,
+        ).toBe(1);
+      });
+
+      it("AC#3 regression: aliases always remains an array", async () => {
+        const result = await service.create({
+          classShortName: "ems__Task",
+          label: "T",
+          vault: "/v",
+          aliases: ["one", "two"],
+        });
+        expect(Array.isArray(result.frontmatter["aliases"])).toBe(true);
+        expect(
+          (result.frontmatter["aliases"] as string[]).length,
+        ).toBeGreaterThanOrEqual(2);
       });
     });
 

--- a/packages/exocortex/src/services/ShapeLoader.ts
+++ b/packages/exocortex/src/services/ShapeLoader.ts
@@ -517,19 +517,37 @@ export class ShapeLoader {
     return [];
   }
 
+  // Known cardinality enum UIDs. Property files post-UID-canon (RFC-004)
+  // reference these via pure-UID wikilinks like
+  // `exo__Property_cardinality: "[[c93c4b2f-...]]"`, so suffix-matching on
+  // the `PropertyCardinalitySingle` label alone misses them (issue #3179).
+  private static readonly CARDINALITY_SINGLE_UID =
+    "c93c4b2f-b43d-4cc9-8dd0-31514d608da2";
+  private static readonly CARDINALITY_MULTIPLE_UID =
+    "59a37aa7-ffbe-4e0d-ba60-06ae370d880f";
+
   private static cardinalityFromIRI(iri: string | undefined): "Single" | "Multiple" | undefined {
     if (!iri) return undefined;
     if (iri.endsWith("PropertyCardinalitySingle")) return "Single";
     if (iri.endsWith("PropertyCardinalityMultiple")) return "Multiple";
+    if (iri.includes(ShapeLoader.CARDINALITY_SINGLE_UID)) return "Single";
+    if (iri.includes(ShapeLoader.CARDINALITY_MULTIPLE_UID)) return "Multiple";
     return undefined;
   }
 
   private static cardinalityFromLabel(raw: string | undefined): "Single" | "Multiple" | undefined {
     if (!raw) return undefined;
     const ref = ShapeLoader.extractWikilinkRef(raw) ?? raw;
+    // ref may be either a label like `exo__PropertyCardinalitySingle`
+    // or an alias form `<uid>|exo__PropertyCardinalitySingle`
+    // or a pure UID `c93c4b2f-...` (post-UID-canon, RFC-004).
     const label = ref.split("|").pop() ?? ref;
     if (label.includes("Single")) return "Single";
     if (label.includes("Multiple")) return "Multiple";
+    // Pure UID form: also check both halves of `ref` (covers `<uid>` alone
+    // and `<uid>|<alias>` where the alias didn't match the suffix above).
+    if (ref.includes(ShapeLoader.CARDINALITY_SINGLE_UID)) return "Single";
+    if (ref.includes(ShapeLoader.CARDINALITY_MULTIPLE_UID)) return "Multiple";
     return undefined;
   }
 

--- a/packages/exocortex/tests/services/ShapeLoader.test.ts
+++ b/packages/exocortex/tests/services/ShapeLoader.test.ts
@@ -243,6 +243,28 @@ describe("ShapeLoader.loadFromRDFGraph", () => {
     expect(reg.get(`${EMS}Effort_parent`)!.cardinality).toBe("Multiple");
   });
 
+  it("Issue #3179: parses Single cardinality from UID-form IRI", async () => {
+    // Post-UID-canon (RFC-004) Property_cardinality wikilinks resolve to
+    // file IRIs containing the enum UID rather than the symbolic label.
+    const SINGLE_UID = "c93c4b2f-b43d-4cc9-8dd0-31514d608da2";
+    const UID_FILE_IRI = `obsidian://vault/assetspaces/exo/${SINGLE_UID}.md`;
+    const store = makeStore(
+      makePropertyTriples({ cardinality: UID_FILE_IRI }),
+    );
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.get(`${EMS}Effort_parent`)!.cardinality).toBe("Single");
+  });
+
+  it("Issue #3179: parses Multiple cardinality from UID-form IRI", async () => {
+    const MULTI_UID = "59a37aa7-ffbe-4e0d-ba60-06ae370d880f";
+    const UID_FILE_IRI = `obsidian://vault/assetspaces/exo/${MULTI_UID}.md`;
+    const store = makeStore(
+      makePropertyTriples({ cardinality: UID_FILE_IRI }),
+    );
+    const reg = await ShapeLoader.loadFromRDFGraph(store);
+    expect(reg.get(`${EMS}Effort_parent`)!.cardinality).toBe("Multiple");
+  });
+
   it("auto-extends ad-hoc namespaces for non-whitelisted label prefixes", async () => {
     // RFC: SHACL namespace whitelist relaxation — `unknown__something`
     // resolves to `https://exocortex.my/ontology/unknown#something` instead of
@@ -525,6 +547,51 @@ describe("ShapeLoader.loadFromVaultFS", () => {
 
     const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
     const shape = reg.get(`${EMS}Effort_relates`);
+    expect(shape).toBeDefined();
+    expect(shape!.cardinality).toBe("Multiple");
+  });
+
+  it("Issue #3179: handles Single cardinality declared as UID wikilink", async () => {
+    // Post-UID-canon vault property files use bare UID wikilinks for the
+    // cardinality enum: `[[c93c4b2f-...]]` is the UID of
+    // exo__PropertyCardinalitySingle. cardinalityFromLabel previously only
+    // checked label suffixes and silently returned undefined → CLI fell
+    // back to array emission for single-cardinality predicates.
+    await writeFile(
+      "uid-card-single.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        'exo__Property_cardinality: "[[c93c4b2f-b43d-4cc9-8dd0-31514d608da2]]"',
+        "exo__Asset_label: ems__Effort_status",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Effort_status`);
+    expect(shape).toBeDefined();
+    expect(shape!.cardinality).toBe("Single");
+  });
+
+  it("Issue #3179: handles Multiple cardinality declared as UID wikilink", async () => {
+    await writeFile(
+      "uid-card-multi.md",
+      [
+        "---",
+        'exo__Instance_class:',
+        '  - "[[exo__ObjectProperty]]"',
+        'exo__Property_domain: "[[ems__Effort]]"',
+        'exo__Property_cardinality: "[[59a37aa7-ffbe-4e0d-ba60-06ae370d880f]]"',
+        "exo__Asset_label: ems__Effort_relatesUid",
+        "---",
+      ].join("\n"),
+    );
+
+    const reg = await ShapeLoader.loadFromVaultFS(tmpDir);
+    const shape = reg.get(`${EMS}Effort_relatesUid`);
     expect(shape).toBeDefined();
     expect(shape!.cardinality).toBe("Multiple");
   });


### PR DESCRIPTION
## Summary

`exocortex-cli create --property foo=[[uuid]]` always emitted YAML array form regardless of property cardinality. Two cooperating defects:

1. **`ShapeLoader.cardinalityFromLabel` / `cardinalityFromIRI`** could not resolve UID-form cardinality wikilinks. Post-UID-canon vault property files declare `exo__Property_cardinality: \"[[c93c4b2f-...]]\"` — a bare UUID — but the loader only checked for the literal `PropertyCardinalitySingle` / `PropertyCardinalityMultiple` suffix.
2. **`AssetCreationService.formatPropertyValue`** wrapped every wikilink in a single-entry array when no shape was found — the opposite of the vault convention (4000+ instances of `exo__Asset_isDefinedBy`, `ems__Effort_status`, `exo__Asset_prototype` etc. are scalar).

## Changes

### Production code

- **`packages/exocortex/src/services/ShapeLoader.ts`** — added explicit UID-form recognition for cardinality enums (`c93c4b2f-...` = Single, `59a37aa7-...` = Multiple) in both `cardinalityFromLabel` (vault-FS path) and `cardinalityFromIRI` (RDF-graph path). Constants declared `private static readonly` with comments referencing RFC-004 UID-canon.
- **`packages/cli/src/services/AssetCreationService.ts`** — renamed `isSingleValued` → `shouldEmitAsArray` and inverted the default: only properties whose shape declares cardinality `\"Multiple\"` are wrapped in YAML arrays. Everything else (no registry, no shape, `Single` cardinality) → scalar.
- **`packages/cli/src/commands/create.ts:210`** — comment updated to reflect new scalar default.

### Docs

- **`docs/PROPERTY_SCHEMA.md` §exo__Property_cardinality** — \"Required\" row, examples and migration guidance rewritten for the new contract. Behavior-change callout linked to #3179.

### Tests

- **`packages/exocortex/tests/services/ShapeLoader.test.ts`** — 4 new tests for UID-form Single/Multiple in both `loadFromVaultFS` and `loadFromRDFGraph` paths.
- **`packages/cli/tests/unit/services/AssetCreationService.test.ts`** — 6 new AC tests + 2 regression guards for `exo__Instance_class` / `aliases` staying as arrays. 4 legacy expectations flipped (Issue #2293, #3099 \"legacy default\" cases now assert scalar).
- **`packages/cli/tests/integration/create-cardinality.integration.test.ts`** *(new)* — 5 integration tests using real `ShapeLoader.loadFromVaultFS` + real `AssetCreationService` against fixture vault with UID-form cardinality. Asserts both `result.frontmatter` and on-disk YAML byte content. Neither the ShapeLoader nor the AssetCreationService fix alone is sufficient; this suite exercises both together — production-shape verification per `test-fixture-realism.md`.

## Empirical verification

**Pre-fix repro** (`/tmp/test-vault-3179`, UID-form `Property_cardinality` enum):
\`\`\`yaml
ems__Effort_status:
  - \"[[753a44d5-846c-4b82-9196-4fd9a4d48777]]\"
\`\`\`

**Post-fix repro** (same vault):
\`\`\`yaml
ems__Effort_status: \"[[753a44d5-846c-4b82-9196-4fd9a4d48777]]\"
exo__Asset_isDefinedBy: \"[[c07593d9-d50b-46a1-aeab-aee7f2660c2c]]\"
\`\`\`
Matches the issue's stated Expected verbatim.

**Revert-fail / restore-pass** (per `integration-test-revert-verify.md`):
- Stashed `ShapeLoader.ts` + `AssetCreationService.ts`, rebuilt → 11 CLI unit/integration tests + 4 ShapeLoader UID-form tests **FAIL**.
- Restored → 47 CLI + 50 ShapeLoader **PASS**.

## Scope

- **In scope:** `create` command only (`AssetCreationService.formatPropertyValue`).
- **Out of scope** (per next-session prompt):
  - `apply` (`GenericAssetCreationService.formatWikilink` — already emits scalar; not affected).
  - `create-task` / `create-project` / etc. (`AssetCreationExecutor` — separate code path, already emits scalar for known single-cardinality predicates).

Verified during code review: no other serializer paths bypass the new cardinality logic.

## Test plan

- [x] Unit tests pass (47 in CLI, 50 in exocortex ShapeLoader)
- [x] Integration test pass (5 in `create-cardinality.integration.test.ts`)
- [x] Revert-fail / restore-pass verified
- [x] Empirical CLI repro before/after fix
- [x] Archgate pre-commit green
- [x] Root `npm run check:types` green
- [x] code-reviewer agent APPROVE (0 CRITICAL, 0 HIGH; 1 MEDIUM addressed in `ce083b25`, 1 LOW addressed in `ce083b25`)
- [x] advisor round-1 + round-2 sign-off

Closes #3179.