### PR TITLE
fix(cli): register isInWrongFolder + default host functions in apply

### DIFF
--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -19,20 +19,27 @@ import {
   TaskStatusService,
   WorkflowResolver,
   createVaultFrontmatterClassLabelResolver,
+  registerDefaultHostFunctions,
   vaultPathToIRI,
   IRI,
   liveClock,
   frozenClock,
   liveUidGenerator,
   seededUidGenerator,
+  type EvalContext,
   type IClock,
+  type IFile,
   type IUidGenerator,
 } from "exocortex";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
-import { VaultNotFoundError, InvalidArgumentsError } from "../utils/errors/index.js";
+import {
+  VaultNotFoundError,
+  InvalidArgumentsError,
+} from "../utils/errors/index.js";
 import { ExitCodes } from "../utils/ExitCodes.js";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+import { createIsInWrongFolderHostFunction } from "../precondition/createIsInWrongFolderHostFunction.js";
 import { populateCliServiceRegistry } from "../services/CliServiceRegistryPopulator.js";
 import { registerOrderSpecFromVault } from "../services/registerOrderSpec.js";
 
@@ -46,7 +53,8 @@ export interface ApplyOptions {
   frozenClock?: string;
 }
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 async function readStdinLines(): Promise<string[]> {
   if (process.stdin.isTTY) return [];
@@ -66,7 +74,11 @@ async function readStdinLines(): Promise<string[]> {
  * Returns null if not found, throws on ambiguity.
  */
 function nodeValue(node: { value: string } | unknown): string {
-  if (node && typeof node === "object" && "value" in (node as Record<string, unknown>)) {
+  if (
+    node &&
+    typeof node === "object" &&
+    "value" in (node as Record<string, unknown>)
+  ) {
     const v = (node as { value: unknown }).value;
     return typeof v === "string" ? v : String(v);
   }
@@ -77,14 +89,18 @@ async function resolveSlugToUuid(
   tripleStore: InMemoryTripleStore,
   slug: string,
 ): Promise<string | null> {
-  const cliNameURI = new IRI("https://exocortex.my/ontology/exocmd#Command_cliName");
+  const cliNameURI = new IRI(
+    "https://exocortex.my/ontology/exocmd#Command_cliName",
+  );
   const triples = await tripleStore.match(undefined, cliNameURI, undefined);
   const matches: string[] = [];
   for (const t of triples) {
     const objStr = nodeValue(t.object);
     if (objStr === slug) {
       const subjStr = nodeValue(t.subject);
-      const match = subjStr.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/i);
+      const match = subjStr.match(
+        /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/i,
+      );
       if (match) matches.push(match[1]);
     }
   }
@@ -105,7 +121,9 @@ async function isDestructive(
   tripleStore: InMemoryTripleStore,
   commandUid: string,
 ): Promise<boolean> {
-  const destructiveURI = new IRI("https://exocortex.my/ontology/exocmd#Command_destructive");
+  const destructiveURI = new IRI(
+    "https://exocortex.my/ontology/exocmd#Command_destructive",
+  );
   const triples = await tripleStore.match(undefined, destructiveURI, undefined);
   for (const t of triples) {
     const subjStr = nodeValue(t.subject);
@@ -161,9 +179,53 @@ async function executeOnTarget(
 
   const targetIRI = vaultPathToIRI(targetRelative);
 
-  // Precondition
-  const evaluator = new PreconditionEvaluator(tripleStore, undefined, { clock });
-  const preconditionPassed = await evaluator.evaluate(command.precondition, targetIRI);
+  // Shared adapter + services used by both precondition host functions
+  // and grounding execution. Built once per target — these services are
+  // stateless so a single instance covers both phases.
+  const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
+  const folderRepairService = new FolderRepairService(vaultAdapter);
+
+  // Precondition (Issue #3302 — register host functions so that
+  // vault-declared `exocmd__Precondition_hostFunction` references resolve
+  // instead of falling open via `evaluateHostFunction`'s `return true`
+  // default. Mirrors plugin wiring in `ExocortexPlugin.ts`).
+  const evaluator = new PreconditionEvaluator(tripleStore, undefined, {
+    clock,
+  });
+  registerDefaultHostFunctions(evaluator);
+  evaluator.registerHostFunction(
+    "isInWrongFolder",
+    createIsInWrongFolderHostFunction(vaultAdapter, folderRepairService),
+  );
+
+  // EvalContext populated with the fields the registered host functions
+  // read — `filePath` for `isInWrongFolder`, `fileBasename` + `assetUid`
+  // for `hasUidFilename` / `hasNonUidFilename`. Without these fields the
+  // functions would fall closed on registered names, hiding commands the
+  // CLI is otherwise meant to run.
+  const targetNode = vaultAdapter.getAbstractFileByPath(targetRelative);
+  const targetFile =
+    targetNode !== null && "basename" in targetNode
+      ? (targetNode as IFile)
+      : null;
+  const targetFrontmatter = targetFile
+    ? vaultAdapter.getFrontmatter(targetFile)
+    : null;
+  const assetUidRaw =
+    targetFrontmatter && typeof targetFrontmatter === "object"
+      ? (targetFrontmatter as Record<string, unknown>).exo__Asset_uid
+      : undefined;
+  const evalContext: EvalContext = {
+    targetIRI,
+    filePath: targetRelative,
+    fileBasename: targetFile?.basename,
+    assetUid: typeof assetUidRaw === "string" ? assetUidRaw : undefined,
+  };
+  const preconditionPassed = await evaluator.evaluate(
+    command.precondition,
+    targetIRI,
+    evalContext,
+  );
   if (!preconditionPassed) {
     console.error(
       `❌ Precondition not satisfied for "${command.name}" on "${targetRelative}".`,
@@ -173,13 +235,14 @@ async function executeOnTarget(
 
   // Dry-run
   if (options.dryRun) {
-    console.log(`🔍 Dry-run: would apply "${command.name}" to "${targetRelative}" (precondition passed).`);
+    console.log(
+      `🔍 Dry-run: would apply "${command.name}" to "${targetRelative}" (precondition passed).`,
+    );
     return true;
   }
 
   // Execute grounding
   const serviceRegistry = new ServiceRegistry();
-  const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
   const genericAssetCreationService = new GenericAssetCreationService(
     vaultAdapter,
   ).withDeterminism({ clock, uidGenerator: uidGen });
@@ -187,7 +250,6 @@ async function executeOnTarget(
   const propertyCleanupService = new PropertyCleanupService(vaultAdapter);
   const fixMissingLabelService = new FixMissingLabelService(vaultAdapter);
   const renameToUidService = new RenameToUidService(vaultAdapter);
-  const folderRepairService = new FolderRepairService(vaultAdapter);
   const taskStatusService = new TaskStatusService(
     vaultAdapter,
     new EffortStatusWorkflow(),
@@ -240,7 +302,11 @@ async function executeOnTarget(
   if (options.input) {
     try {
       const parsed = JSON.parse(options.input);
-      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
         throw new Error("must be a JSON object");
       }
       userInput = parsed as Record<string, unknown>;
@@ -259,11 +325,15 @@ async function executeOnTarget(
   );
 
   if (result.success) {
-    const msg = command.successMessage ?? `Applied "${command.name}" to "${targetRelative}".`;
+    const msg =
+      command.successMessage ??
+      `Applied "${command.name}" to "${targetRelative}".`;
     console.log(`✅ ${msg}`);
     return true;
   } else {
-    console.error(`❌ "${command.name}" failed on "${targetRelative}": ${result.error}`);
+    console.error(
+      `❌ "${command.name}" failed on "${targetRelative}": ${result.error}`,
+    );
     return false;
   }
 }
@@ -282,7 +352,10 @@ export function applyCommand(): Command {
         "Pass a path arg or pipe paths via stdin.",
     )
     .argument("<cmd>", "Command UUID or cliName slug")
-    .argument("[path]", "Vault-relative path to target asset (omit to read paths from stdin)")
+    .argument(
+      "[path]",
+      "Vault-relative path to target asset (omit to read paths from stdin)",
+    )
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
     .option("--dry-run", "Preview without writing")
     .option("--yes", "Skip destructive-command confirmation")
@@ -295,96 +368,104 @@ export function applyCommand(): Command {
       "--frozen-clock <iso>",
       "Freeze clock to ISO timestamp for test/replay (uses frozenClock)",
     )
-    .action(async (cmdArg: string, pathArg: string | undefined, options: ApplyOptions) => {
-      ErrorHandler.setFormat("text" as OutputFormat);
+    .action(
+      async (
+        cmdArg: string,
+        pathArg: string | undefined,
+        options: ApplyOptions,
+      ) => {
+        ErrorHandler.setFormat("text" as OutputFormat);
 
-      try {
-        const vaultPath = resolve(options.vault);
-        if (!existsSync(vaultPath)) {
-          throw new VaultNotFoundError(vaultPath);
-        }
-        registerOrderSpecFromVault(vaultPath);
-
-        // Derive clock + UID generator ONCE for the whole apply invocation.
-        // Multi-target stdin pipelines reuse the same generator so that
-        // `seededUidGenerator`'s internal counter increments across targets
-        // instead of restarting at 0 per file.
-        const clock: IClock = options.frozenClock
-          ? frozenClock(options.frozenClock)
-          : liveClock();
-        const uidGen: IUidGenerator = options.seed
-          ? seededUidGenerator(options.seed)
-          : liveUidGenerator();
-
-        // Build triple store once for the whole batch
-        const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
-        const converter = new NoteToRDFConverter(vaultAdapter);
-        const triples = await converter.convertVault();
-        const tripleStore = new InMemoryTripleStore();
-        await tripleStore.addAll(triples);
-
-        // RFC 36347daf Phase 3 — construct WorkflowResolver once for the whole
-        // batch so its per-class cache survives across stdin-piped targets
-        // (mirrors the rationale documented for `clock` / `uidGen` threading).
-        const workflowResolver = new WorkflowResolver(tripleStore);
-
-        // Resolve cmdArg → UUID
-        let commandUid: string;
-        if (UUID_RE.test(cmdArg)) {
-          commandUid = cmdArg;
-        } else {
-          const resolved = await resolveSlugToUuid(tripleStore, cmdArg);
-          if (!resolved) {
-            console.error(
-              `❌ No command found with UUID or cliName "${cmdArg}".`,
-            );
-            process.exit(ExitCodes.FILE_NOT_FOUND);
+        try {
+          const vaultPath = resolve(options.vault);
+          if (!existsSync(vaultPath)) {
+            throw new VaultNotFoundError(vaultPath);
           }
-          commandUid = resolved;
-        }
+          registerOrderSpecFromVault(vaultPath);
 
-        // Build target list
-        let targets: string[];
-        if (pathArg) {
-          targets = [pathArg];
-        } else {
-          targets = await readStdinLines();
-          if (targets.length === 0) {
-            throw new InvalidArgumentsError(
-              "No target path provided and stdin is empty.",
-              "exocortex apply <uuid> <path>  OR  exocortex find ... | exocortex apply <uuid>",
+          // Derive clock + UID generator ONCE for the whole apply invocation.
+          // Multi-target stdin pipelines reuse the same generator so that
+          // `seededUidGenerator`'s internal counter increments across targets
+          // instead of restarting at 0 per file.
+          const clock: IClock = options.frozenClock
+            ? frozenClock(options.frozenClock)
+            : liveClock();
+          const uidGen: IUidGenerator = options.seed
+            ? seededUidGenerator(options.seed)
+            : liveUidGenerator();
+
+          // Build triple store once for the whole batch
+          const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
+          const converter = new NoteToRDFConverter(vaultAdapter);
+          const triples = await converter.convertVault();
+          const tripleStore = new InMemoryTripleStore();
+          await tripleStore.addAll(triples);
+
+          // RFC 36347daf Phase 3 — construct WorkflowResolver once for the whole
+          // batch so its per-class cache survives across stdin-piped targets
+          // (mirrors the rationale documented for `clock` / `uidGen` threading).
+          const workflowResolver = new WorkflowResolver(tripleStore);
+
+          // Resolve cmdArg → UUID
+          let commandUid: string;
+          if (UUID_RE.test(cmdArg)) {
+            commandUid = cmdArg;
+          } else {
+            const resolved = await resolveSlugToUuid(tripleStore, cmdArg);
+            if (!resolved) {
+              console.error(
+                `❌ No command found with UUID or cliName "${cmdArg}".`,
+              );
+              process.exit(ExitCodes.FILE_NOT_FOUND);
+            }
+            commandUid = resolved;
+          }
+
+          // Build target list
+          let targets: string[];
+          if (pathArg) {
+            targets = [pathArg];
+          } else {
+            targets = await readStdinLines();
+            if (targets.length === 0) {
+              throw new InvalidArgumentsError(
+                "No target path provided and stdin is empty.",
+                "exocortex apply <uuid> <path>  OR  exocortex find ... | exocortex apply <uuid>",
+              );
+            }
+          }
+
+          // Continue-on-error semantics
+          let successCount = 0;
+          let failCount = 0;
+          for (const target of targets) {
+            const ok = await executeOnTarget(
+              vaultPath,
+              tripleStore,
+              workflowResolver,
+              commandUid,
+              target,
+              options,
+              clock,
+              uidGen,
+            );
+            if (ok) successCount++;
+            else failCount++;
+          }
+
+          if (targets.length > 1) {
+            console.log(
+              `\n📊 Applied to ${successCount}/${targets.length} target(s) (${failCount} failed).`,
             );
           }
-        }
 
-        // Continue-on-error semantics
-        let successCount = 0;
-        let failCount = 0;
-        for (const target of targets) {
-          const ok = await executeOnTarget(
-            vaultPath,
-            tripleStore,
-            workflowResolver,
-            commandUid,
-            target,
-            options,
-            clock,
-            uidGen,
-          );
-          if (ok) successCount++;
-          else failCount++;
-        }
-
-        if (targets.length > 1) {
-          console.log(`\n📊 Applied to ${successCount}/${targets.length} target(s) (${failCount} failed).`);
-        }
-
-        if (failCount > 0) {
+          if (failCount > 0) {
+            process.exit(ExitCodes.OPERATION_FAILED);
+          }
+        } catch (error) {
+          ErrorHandler.handle(error as Error);
           process.exit(ExitCodes.OPERATION_FAILED);
         }
-      } catch (error) {
-        ErrorHandler.handle(error as Error);
-        process.exit(ExitCodes.OPERATION_FAILED);
-      }
-    });
+      },
+    );
 }

--- a/packages/cli/src/precondition/createIsInWrongFolderHostFunction.ts
+++ b/packages/cli/src/precondition/createIsInWrongFolderHostFunction.ts
@@ -1,0 +1,51 @@
+import {
+  needsFolderRepair,
+  type FolderRepairService,
+  type HostFunction,
+  type IFile,
+  type IVaultAdapter,
+} from "exocortex";
+
+/**
+ * CLI counterpart of the plugin's
+ * `obsidian-plugin/src/infrastructure/precondition/createIsInWrongFolderHostFunction.ts`.
+ *
+ * Returns `true` only when the asset referenced by `ctx.filePath` lives in a
+ * folder that differs from the folder of the file it points to via
+ * `exo__Asset_isDefinedBy`. Used by the homoiconic "Repair Folder" exocmd
+ * command (vault asset `2afd04ae-218d-4ee9-8ee1-7c61f4d40a91`) to keep
+ * `npx exocortex-cli apply <repair-folder-uid> <path>` from succeeding on
+ * assets that are already in the correct folder (Issue #3302).
+ *
+ * Fail-closed on missing context, missing file, or unresolvable expected
+ * folder — mirrors the plugin factory's contract so visible/invocable
+ * gating is symmetric between surfaces.
+ */
+export function createIsInWrongFolderHostFunction(
+  vaultAdapter: IVaultAdapter,
+  folderRepairService: FolderRepairService,
+): HostFunction {
+  return (ctx) => {
+    const filePath =
+      typeof ctx.filePath === "string" && ctx.filePath.length > 0
+        ? ctx.filePath
+        : null;
+    if (filePath === null) return false;
+
+    const node = vaultAdapter.getAbstractFileByPath(filePath);
+    if (node === null || !("basename" in node)) return false;
+    const file = node as IFile;
+
+    const metadata =
+      (vaultAdapter.getFrontmatter(file) as Record<string, unknown> | null) ??
+      {};
+
+    const expected = folderRepairService.getExpectedFolderSync(file, metadata);
+    const current =
+      typeof ctx.currentFolder === "string"
+        ? ctx.currentFolder
+        : (file.parent?.path ?? "");
+
+    return needsFolderRepair(current, expected);
+  };
+}

--- a/packages/cli/tests/unit/precondition/createIsInWrongFolderHostFunction.test.ts
+++ b/packages/cli/tests/unit/precondition/createIsInWrongFolderHostFunction.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import {
+  FolderRepairService,
+  type EvalContext,
+  type IFile,
+  type IFolder,
+  type IFrontmatter,
+  type IVaultAdapter,
+} from "exocortex";
+import { createIsInWrongFolderHostFunction } from "../../../src/precondition/createIsInWrongFolderHostFunction.js";
+
+describe("createIsInWrongFolderHostFunction (CLI parity)", () => {
+  const buildFile = (
+    path: string,
+    basename: string,
+    parentPath: string,
+  ): IFile =>
+    ({
+      path,
+      basename,
+      name: `${basename}.md`,
+      parent: {
+        path: parentPath,
+        name: parentPath.split("/").pop() ?? "",
+      } as IFolder,
+    }) as IFile;
+
+  const buildAdapter = (opts: {
+    node?: IFile | IFolder | null;
+    frontmatter?: IFrontmatter | null;
+  }): IVaultAdapter =>
+    ({
+      getAbstractFileByPath: jest
+        .fn()
+        .mockReturnValue(opts.node === undefined ? null : opts.node),
+      getFrontmatter: jest
+        .fn()
+        .mockReturnValue(
+          opts.frontmatter === undefined ? null : opts.frontmatter,
+        ),
+    }) as unknown as IVaultAdapter;
+
+  const buildService = (
+    expected: string | null,
+  ): jest.Mocked<FolderRepairService> =>
+    ({
+      getExpectedFolder: jest.fn(),
+      getExpectedFolderSync: jest.fn().mockReturnValue(expected),
+      repairFolder: jest.fn(),
+    }) as unknown as jest.Mocked<FolderRepairService>;
+
+  const baseCtx = (overrides: Partial<EvalContext> = {}): EvalContext => ({
+    targetIRI: "obsidian://vault/current/folder/asset.md",
+    fileBasename: "asset",
+    currentFolder: "current/folder",
+    filePath: "current/folder/asset.md",
+    ...overrides,
+  });
+
+  it("returns false when filePath missing from context", () => {
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({ node: null }),
+      buildService("anywhere"),
+    );
+    expect(fn(baseCtx({ filePath: undefined }))).toBe(false);
+  });
+
+  it("returns false when file not found in vault", () => {
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({ node: null }),
+      buildService("anywhere"),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when target is a folder (no basename)", () => {
+    const folder: IFolder = { path: "current/folder", name: "folder" };
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({ node: folder }),
+      buildService("anywhere"),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when expected folder cannot be resolved", () => {
+    const file = buildFile(
+      "current/folder/asset.md",
+      "asset",
+      "current/folder",
+    );
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({ node: file, frontmatter: {} }),
+      buildService(null),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when asset already in expected folder", () => {
+    const file = buildFile(
+      "current/folder/asset.md",
+      "asset",
+      "current/folder",
+    );
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({
+        node: file,
+        frontmatter: { exo__Asset_isDefinedBy: "[[Class]]" },
+      }),
+      buildService("current/folder"),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when expected differs only by trailing slash", () => {
+    const file = buildFile(
+      "current/folder/asset.md",
+      "asset",
+      "current/folder",
+    );
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({
+        node: file,
+        frontmatter: { exo__Asset_isDefinedBy: "[[Class]]" },
+      }),
+      buildService("current/folder/"),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns true when asset is in wrong folder", () => {
+    const file = buildFile(
+      "current/folder/asset.md",
+      "asset",
+      "current/folder",
+    );
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({
+        node: file,
+        frontmatter: { exo__Asset_isDefinedBy: "[[Class]]" },
+      }),
+      buildService("expected/folder"),
+    );
+    expect(fn(baseCtx())).toBe(true);
+  });
+
+  it("falls back to file.parent.path when currentFolder missing from ctx", () => {
+    const file = buildFile("fallback/asset.md", "asset", "fallback");
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({
+        node: file,
+        frontmatter: { exo__Asset_isDefinedBy: "[[Class]]" },
+      }),
+      buildService("fallback"),
+    );
+    expect(fn(baseCtx({ currentFolder: undefined }))).toBe(false);
+  });
+
+  it("returns true when fallback parent path differs from expected", () => {
+    const file = buildFile("wrong/asset.md", "asset", "wrong");
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({
+        node: file,
+        frontmatter: { exo__Asset_isDefinedBy: "[[Class]]" },
+      }),
+      buildService("expected/folder"),
+    );
+    expect(fn(baseCtx({ currentFolder: undefined }))).toBe(true);
+  });
+
+  it("passes file + metadata to FolderRepairService.getExpectedFolderSync", () => {
+    const file = buildFile(
+      "current/folder/asset.md",
+      "asset",
+      "current/folder",
+    );
+    const metadata = {
+      exo__Asset_isDefinedBy: "[[Class]]",
+      otherProp: "x",
+    };
+    const service = buildService("expected/folder");
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({ node: file, frontmatter: metadata }),
+      service,
+    );
+    fn(baseCtx());
+    expect(service.getExpectedFolderSync).toHaveBeenCalledWith(file, metadata);
+  });
+
+  it("treats null frontmatter as empty metadata object", () => {
+    const file = buildFile(
+      "current/folder/asset.md",
+      "asset",
+      "current/folder",
+    );
+    const service = buildService(null);
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({ node: file, frontmatter: null }),
+      service,
+    );
+    fn(baseCtx());
+    expect(service.getExpectedFolderSync).toHaveBeenCalledWith(file, {});
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3302. CLI parity for `exocmd__Precondition_hostFunction` evaluation.

`packages/cli/src/commands/apply.ts` constructed `PreconditionEvaluator` without registering any host functions, so vault-declared `exocmd__Precondition_hostFunction` references silently fell open via `evaluateHostFunction`'s `return true` default. For the "Repair Folder" exocmd command (precondition asset `2afd04ae`, host function `isInWrongFolder`) this meant `npx exocortex-cli apply <repair-folder-uid> <path>` always evaluated the precondition as satisfied — masked only by service-level idempotency in `FolderRepairService.repairFolder`.

## Changes

Mirrors the plugin wiring at `packages/obsidian-plugin/src/ExocortexPlugin.ts`:

- Register defaults (`hasNonUidFilename` / `hasUidFilename`) via `registerDefaultHostFunctions(evaluator)`.
- Register `isInWrongFolder` via a new CLI-flavoured factory `packages/cli/src/precondition/createIsInWrongFolderHostFunction.ts` that takes `IVaultAdapter` + `FolderRepairService` instead of obsidian's `App` (which the CLI doesn't have). Same fail-closed contract as the plugin factory: missing context → `false`, missing file → `false`, unresolvable expected folder → `false`.
- Build the `EvalContext` per target — `filePath`, `fileBasename`, `assetUid` — so the registered functions can do their job. Without these fields the registered functions would fall closed on missing context.

## Test plan

- [x] New unit tests `packages/cli/tests/unit/precondition/createIsInWrongFolderHostFunction.test.ts` — 11/11 PASS, mirror plugin spec
- [x] Revert-verify discipline per `~/dotfiles/.claude/rules/integration-test-revert-verify.md`: stub factory `() => true` → 9/11 tests FAIL (the 2 remaining trivially pass because they expect the true branch). Restore → 11/11 PASS
- [x] Regression: `packages/cli/tests/unit/commands/apply.test.ts` 6/6 PASS
- [x] Upstream: `packages/exocortex/tests/unit/services/PreconditionEvaluator.test.ts` 37/37 PASS
- [x] Sibling: `packages/obsidian-plugin/tests/unit/infrastructure/precondition/createIsInWrongFolderHostFunction.test.ts` 9/9 PASS
- [x] Pre-commit hook (lint-staged + Archgate + BDD coverage) PASS
- [x] Full workspace `npm run build` succeeds

## Multi-parser parity note

Per `~/dotfiles/.claude/rules/multi-parser-predicate-migration.md` "Host function vault↔code parity" — vault precondition asset `2afd04ae` declares `exocmd__Precondition_hostFunction: "isInWrongFolder"`; plugin registers it; CLI now also registers it. Vault↔code mapping for this surface is in sync.