### PR TITLE
fix(e2e): stabilize create-fleeting-note-palette flake on shard-4

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/create-fleeting-note-palette.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/create-fleeting-note-palette.spec.ts
@@ -55,12 +55,24 @@ test.describe("Create fleeting note — Palette registration smoke", () => {
     // here can follow as a separate PR with a UUID-canon fixture or an
     // explicit `expandClassValue` warm-up.
     const window = await launcher.getWindow();
+    // Issue #3216: flake mitigation — drain any leftover startup notices
+    // (e.g. "failed to wire hard-switch debounce" warnings seen in shard-2
+    // logs) before probing the plugins map. Mirrors the sibling pattern
+    // used in `vault-commands-smoke.spec.ts` / `daily-navigation.spec.ts`
+    // so the test does not race the Obsidian boot pipeline.
+    await launcher.waitForModalsToClose(10000);
 
     const result = await window.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const app = (window as any).app;
 
-      for (let i = 0; i < 30; i++) {
+      // Issue #3216: doubled poll budget (was 30 × 500ms = 15s, now
+      // 60 × 500ms = 30s) to absorb slow plugin-load runners. Three
+      // documented incidents on shard-4 (`8b01b3b`, `5e1673c`, `3ad3c6f`)
+      // all failed with `pluginLoaded=false` after the prior 15s window,
+      // and the test passed on rerun without code changes — consistent
+      // with a slow-runner timing issue rather than a real regression.
+      for (let i = 0; i < 60; i++) {
         if (app?.plugins?.plugins?.exocortex) break;
         await new Promise((r) => setTimeout(r, 500));
       }


### PR DESCRIPTION
## Summary

Closes #3216. Stabilize the `create-fleeting-note-palette.spec.ts` flake (3 documented first-attempt failures on shard-4 over 30 days — `8b01b3b`, `5e1673c`, `3ad3c6f`, all failed with `pluginLoaded=false` after the prior 15s polling window).

## Changes

Two narrow edits to the spec file, no production code touched:

- Add `await launcher.waitForModalsToClose(10000)` before `window.evaluate`. Mirrors the sibling pattern used in `vault-commands-smoke.spec.ts` and `daily-navigation.spec.ts`. Drains any leftover startup notices (notably the "failed to wire hard-switch debounce" warnings observed in shard-2 logs) that race the boot pipeline.
- Double the in-test polling budget from `30 × 500ms = 15s` to `60 × 500ms = 30s`. The historical timeout was exactly the window inside which all three incidents fell short, consistent with slow-runner timing rather than a real regression.

## Verification

- Pre-merge: format check passes (`prettier --check`).
- Post-merge: empirical observation gate per AC ("Spec passes first-attempt on 10 consecutive main runs after fix"). Cannot pre-merge prove flake elimination — only the symptom-level mitigations are applied.

## Risk

Minimal: spec-only change. No production code affected. Worst-case fallout = test still flaky → reverts to pre-PR behaviour with extended polling budget (strictly better than 15s).